### PR TITLE
Use `type cmp` to test for cmp in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -487,7 +487,7 @@ $(SUBPROJECTS): %: %-allkm
 .PHONY: %
 %: 
 	# Check if we have the CMP tool installed
-	cmp --version >/dev/null 2>&1; if [ $$? -gt 0 ]; then printf "$(MSG_NO_CMP)"; exit 1; fi;
+	cmp $(ROOT_DIR)/Makefile $(ROOT_DIR)/Makefile >/dev/null 2>&1; if [ $$? -gt 0 ]; then printf "$(MSG_NO_CMP)"; exit 1; fi;
 	# Check if the submodules are dirty, and display a warning if they are
 	git submodule status --recursive 2>/dev/null | \
 	while IFS= read -r x; do \


### PR DESCRIPTION
This PR will allow building on BSD based systems.

The `--version` option to `cmp` doesn't exist in BSD so `cmp --version` always returns non-zero status on BSD systems, causing `make` to fail.

Using `type cmp` instead of `cmp --version` will work on both GNU and BSD systems.