### PR TITLE
Add support for Unicode supplementary planes on OS X

### DIFF
--- a/quantum/process_keycode/process_unicode.c
+++ b/quantum/process_keycode/process_unicode.c
@@ -116,7 +116,16 @@ bool process_unicode_map(uint16_t keycode, keyrecord_t *record) {
     const uint32_t* map = unicode_map;
     uint16_t index = keycode & 0x7FF;
     uint32_t code = pgm_read_dword_far(&map[index]);
-    if ((code > 0xFFFF && input_mode == UC_OSX) || (code > 0xFFFFF && input_mode == UC_LNX)) {
+    if (code > 0xFFFF && code <= 0x10ffff && input_mode == UC_OSX) {
+      // Convert to UTF-16 surrogate pair
+      code -= 0x10000;
+      uint32_t lo = code & 0x3ff;
+      uint32_t hi = (code & 0xffc00) >> 10;
+      unicode_input_start();
+      register_hex32(hi + 0xd800);
+      register_hex32(lo + 0xdc00);
+      unicode_input_finish();
+    } else if ((code > 0x10ffff && input_mode == UC_OSX) || (code > 0xFFFFF && input_mode == UC_LNX)) {
       // when character is out of range supported by the OS
       unicode_map_input_error();
     } else {


### PR DESCRIPTION
According to [this StackOverflow post](http://apple.stackexchange.com/questions/183045/how-can-i-type-unicode-characters-without-using-the-mouse), Unicode characters larger than 0xFFFF can be entered as UTF-16 surrogate pairs in OS X's Unicode Hex Input mode. This patch adds supports for converting Unicode characters larger than 0xFFFF to their corresponding UTF-16 surrogate pairs when using `UC_OSX`. I have very little experience with the qmk codebase, so I'm not entirely sure whether this is the correct place for the code. I have successfully tested it using the 👍  emoji (0x1f4a9).