### PR TITLE
oneshot timeout would only timeout after an event.

### DIFF
--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -49,6 +49,13 @@ void action_exec(keyevent_t event)
 
     keyrecord_t record = { .event = event };
 
+#if (defined(ONESHOT_TIMEOUT) && (ONESHOT_TIMEOUT > 0))
+    if (has_oneshot_layer_timed_out()) {
+        dprintf("Oneshot layer: timeout\n");
+        clear_oneshot_layer_state(ONESHOT_OTHER_KEY_PRESSED);
+    }
+#endif
+
 #ifndef NO_ACTION_TAPPING
     action_tapping_process(record);
 #else
@@ -100,15 +107,8 @@ bool process_record_quantum(keyrecord_t *record) {
     return true;
 }
 
-void process_record(keyrecord_t *record) 
+void process_record(keyrecord_t *record)
 {
-#if (defined(ONESHOT_TIMEOUT) && (ONESHOT_TIMEOUT > 0))
-    if (has_oneshot_layer_timed_out()) {
-        dprintf("Oneshot layer: timeout\n");
-        clear_oneshot_layer_state(ONESHOT_OTHER_KEY_PRESSED);
-    }
-#endif
-
     if (IS_NOEVENT(record->event)) { return; }
 
     if(!process_record_quantum(record))

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -102,6 +102,13 @@ bool process_record_quantum(keyrecord_t *record) {
 
 void process_record(keyrecord_t *record) 
 {
+#if (defined(ONESHOT_TIMEOUT) && (ONESHOT_TIMEOUT > 0))
+    if (has_oneshot_layer_timed_out()) {
+        dprintf("Oneshot layer: timeout\n");
+        clear_oneshot_layer_state(ONESHOT_OTHER_KEY_PRESSED);
+    }
+#endif
+
     if (IS_NOEVENT(record->event)) { return; }
 
     if(!process_record_quantum(record))
@@ -124,13 +131,6 @@ void process_action(keyrecord_t *record, action_t action)
     keyevent_t event = record->event;
 #ifndef NO_ACTION_TAPPING
     uint8_t tap_count = record->tap.count;
-#endif
-
-#if (defined(ONESHOT_TIMEOUT) && (ONESHOT_TIMEOUT > 0))
-    if (has_oneshot_layer_timed_out()) {
-        dprintf("Oneshot layer: timeout\n");
-        clear_oneshot_layer_state(ONESHOT_OTHER_KEY_PRESSED);
-    }
 #endif
 
     if (event.pressed) {


### PR DESCRIPTION
After setting a ONESHOT_TIMEOUT value, the oneshot layer state would
not expire without an event being triggered (key pressed). The reason
was that in the process_record function we would return priort to
execute the process_action function if it detected a NOEVENT cycle. The
process_action contained the codes to timeout the oneshot layer state.
The codes to clear the oneshot layer state have been move just in
front of where we check for the NOEVENT cycle in the process_record
function.