### PR TITLE
fix: infinity60 keyboard was not using quantum features.

### DIFF
--- a/keyboards/infinity60/infinity60.c
+++ b/keyboards/infinity60/infinity60.c
@@ -15,3 +15,18 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "infinity60.h"
+
+void matrix_init_kb(void) {
+	// put your keyboard start-up code here
+	// runs once when the firmware starts up
+
+	matrix_init_user();
+}
+
+void matrix_scan_kb(void) {
+	// put your looping keyboard code here
+	// runs every cycle (a lot)
+
+	matrix_scan_user();
+}
+

--- a/keyboards/infinity60/keymaps/default/keymap.c
+++ b/keyboards/infinity60/keymaps/default/keymap.c
@@ -46,3 +46,12 @@ const uint16_t fn_actions[] = {
     
 };
 
+// Runs just one time when the keyboard initializes.
+void matrix_init_user(void) {
+
+};
+
+// Runs constantly in the background, in a loop.
+void matrix_scan_user(void) {
+
+};

--- a/keyboards/infinity60/keymaps/depariel/keymap.c
+++ b/keyboards/infinity60/keymaps/depariel/keymap.c
@@ -80,3 +80,12 @@ const uint16_t PROGMEM fn_actions[] = {
 
 };
 
+// Runs just one time when the keyboard initializes.
+void matrix_init_user(void) {
+
+};
+
+// Runs constantly in the background, in a loop.
+void matrix_scan_user(void) {
+
+};

--- a/keyboards/infinity60/keymaps/hasu/keymap.c
+++ b/keyboards/infinity60/keymaps/hasu/keymap.c
@@ -111,3 +111,13 @@ const uint16_t keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 const uint16_t fn_actions[] = {
 
 };
+
+// Runs just one time when the keyboard initializes.
+void matrix_init_user(void) {
+
+};
+
+// Runs constantly in the background, in a loop.
+void matrix_scan_user(void) {
+
+};

--- a/keyboards/infinity60/matrix.c
+++ b/keyboards/infinity60/matrix.c
@@ -62,6 +62,8 @@ void matrix_init(void)
 #endif
     memset(matrix, 0, MATRIX_ROWS);
     memset(matrix_debouncing, 0, MATRIX_ROWS);
+
+    matrix_init_quantum();
 }
 
 uint8_t matrix_scan(void)
@@ -146,6 +148,7 @@ uint8_t matrix_scan(void)
         }
         debouncing = false;
     }
+    matrix_scan_quantum();
     return 1;
 }
 


### PR DESCRIPTION
the quantum matrix codes where not being initialized or/and called
so no feature of the quantum firmware could be used. These codes have
been added and now we can enjoy the quantum firmware goodness.