### PR TITLE
speeding up (un)register_code16

### DIFF
--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -33,22 +33,42 @@ static void do_code16 (uint16_t code, void (*f) (uint8_t)) {
     f(KC_RGUI);
 }
 
+static inline void qk_register_weak_mods(uint8_t kc) {
+    add_weak_mods(MOD_BIT(kc));
+    send_keyboard_report();
+}
+
+static inline void qk_unregister_weak_mods(uint8_t kc) {
+    del_weak_mods(MOD_BIT(kc));
+    send_keyboard_report();
+}
+
 static inline void qk_register_mods(uint8_t kc) {
-  register_mods(MOD_BIT(kc));
+    add_weak_mods(MOD_BIT(kc));
+    send_keyboard_report();
 }
 
 static inline void qk_unregister_mods(uint8_t kc) {
-  unregister_mods(MOD_BIT(kc));
+    del_weak_mods(MOD_BIT(kc));
+    send_keyboard_report();
 }
 
 void register_code16 (uint16_t code) {
-  do_code16 (code, qk_register_mods);
+  if (IS_MOD(code) || code == KC_NO) {
+      do_code16 (code, qk_register_mods);
+  } else {
+      do_code16 (code, qk_register_weak_mods);
+  }
   register_code (code);
 }
 
 void unregister_code16 (uint16_t code) {
   unregister_code (code);
-  do_code16 (code, qk_unregister_mods);
+  if (IS_MOD(code) || code == KC_NO) {
+      do_code16 (code, qk_unregister_mods);
+  } else {
+      do_code16 (code, qk_unregister_weak_mods);
+  }
 }
 
 __attribute__ ((weak))

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -33,14 +33,22 @@ static void do_code16 (uint16_t code, void (*f) (uint8_t)) {
     f(KC_RGUI);
 }
 
+static inline void qk_register_mods(uint8_t kc) {
+  register_mods(MOD_BIT(kc));
+}
+
+static inline void qk_unregister_mods(uint8_t kc) {
+  unregister_mods(MOD_BIT(kc));
+}
+
 void register_code16 (uint16_t code) {
-  do_code16 (code, register_code);
+  do_code16 (code, qk_register_mods);
   register_code (code);
 }
 
 void unregister_code16 (uint16_t code) {
   unregister_code (code);
-  do_code16 (code, unregister_code);
+  do_code16 (code, qk_unregister_mods);
 }
 
 __attribute__ ((weak))


### PR DESCRIPTION
In register_code16 and unregister_code16 we call register_code and
unregister_code twice, once for the mods and once for the keycode.
The (un)register_code have many check to see that keycode we have sent
however because we know that we are sending it a mods key, why not
just skip all of it and call (un)register_mods instead. This will skip
alot of checks and should speedup the loop a little.