### PR TITLE
Lets Split flashing improvements

### DIFF
--- a/keyboards/lets_split/readme.md
+++ b/keyboards/lets_split/readme.md
@@ -74,6 +74,10 @@ not be very difficult to adapt it to support more if required.
 Flashing
 --------
 
+From the keymap directory run `make SUBPROJECT-KEYMAP-avrdude` for automatic serial port resolution and flashing.
+
+Example: `make rev2-serial-avrdude`
+
 If you define `EE_HANDS` in your `config.h`, you will need to set the
 EEPROM for the left and right halves. The EEPROM is used to store whether the
 half is left handed or right handed. This makes it so that the same firmware

--- a/keyboards/lets_split/rules.mk
+++ b/keyboards/lets_split/rules.mk
@@ -73,3 +73,13 @@ USE_I2C ?= yes
 SLEEP_LED_ENABLE ?= no    # Breathing sleep LED during USB suspend
 
 CUSTOM_MATRIX = yes
+
+avrdude: build
+	ls /dev/tty* > /tmp/1; \
+	echo "Reset your Pro Micro then hit any key to continue..."; \
+	read -n 1 -s; \
+	ls /dev/tty* > /tmp/2; \
+	USB=`diff /tmp/1 /tmp/2 | grep '>' | sed -e 's/> //'`; \
+	avrdude -p $(MCU) -c avr109 -P $$USB -U flash:w:$(BUILD_DIR)/$(TARGET).hex
+
+.PHONY: avrdude


### PR DESCRIPTION
Originally I did this as a standalone shell script but thought it could benefit more people by being integrated with make. I've seen a lot of folks having trouble with the Pro Micro bootloader and the race to find the serial port and run avrdude can be pretty frustrating.

I'd love some feedback on this implementation. The following commands work as expected from the keyboard directory:

```
$ make rev2-serial-avrdude
$ make avrdude SUBPROJECT=rev2 KEYMAP=serial
```

From a keymap directory without a Makefile I get this (which may be expected?): 

```
$ make avrdude
make: *** No rule to make target `avrdude'.  Stop.
```
 
Output:

```
$ make avrdude SUBPROJECT=rev2
Making lets_split/rev2 with keymap nic and target avrdude

avr-gcc (GCC) 4.9.3
Copyright (C) 2015 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Size before:
   text    data     bss     dec     hex filename
      0   22286       0   22286    570e lets_split_rev2_nic.hex

Compiling: ./tmk_core/common/command.c                                                              [OK]
Linking: .build/lets_split_rev2_nic.elf                                                             [OK]
Creating load file for Flash: .build/lets_split_rev2_nic.hex                                        [OK]
Reset your Pro Micro then hit any key to continue...

Connecting to programmer: .
Found programmer: Id = "CATERIN"; type = S
    Software Version = 1.0; No Hardware Version given.
Programmer supports auto addr increment.
Programmer supports buffered memory access with buffersize=128 bytes.

Programmer supports the following devices:
    Device code: 0x44

avrdude: AVR device initialized and ready to accept instructions

Reading | ################################################## | 100% 0.00s

avrdude: Device signature = 0x1e9587 (probably m32u4)
avrdude: NOTE: "flash" memory has been specified, an erase cycle will be performed
         To disable this feature, specify the -D option.
avrdude: erasing chip
avrdude: reading input file "./.build/lets_split_rev2_nic.hex"
avrdude: input file ./.build/lets_split_rev2_nic.hex auto detected as Intel Hex
avrdude: writing flash (22286 bytes):

Writing | ################################################## | 100% 1.71s

avrdude: 22286 bytes of flash written
avrdude: verifying flash memory against ./.build/lets_split_rev2_nic.hex:
avrdude: load data flash data from input file ./.build/lets_split_rev2_nic.hex:
avrdude: input file ./.build/lets_split_rev2_nic.hex auto detected as Intel Hex
avrdude: input file ./.build/lets_split_rev2_nic.hex contains 22286 bytes
avrdude: reading on-chip flash data:

Reading | ################################################## | 100% 0.24s

avrdude: verifying ...
avrdude: 22286 bytes of flash verified

avrdude: safemode: Fuses OK (E:CB, H:D8, L:FF)

avrdude done.  Thank you.
```