### PR TITLE
Reverted Dockerfile to put the CMD back

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,3 +26,4 @@ ENV keymap=default
 
 VOLUME /qmk
 WORKDIR /qmk
+CMD make clean ; make keyboard=${keyboard} subproject=${subproject} keymap=${keymap}


### PR DESCRIPTION
The last line of the Dockerfile didn't include a default CMD which most people would rely on when building the image and running it. It had been removed prior, adding it back. An edit to the wiki will follow to include the subproject env variable that was added.

```CMD make clean ; make keyboard=${keyboard} subproject=${subproject} keymap=${keymap}%```