### PR TITLE
Fix V-USB bug on Windows 10

### DIFF
--- a/tmk_core/protocol/vusb/vusb.c
+++ b/tmk_core/protocol/vusb/vusb.c
@@ -280,7 +280,7 @@ const PROGMEM uchar keyboard_hid_report[] = {
     0x95, 0x06,          //   Report Count (6),
     0x75, 0x08,          //   Report Size (8),
     0x15, 0x00,          //   Logical Minimum (0),
-    0x25, 0xFF, 0x00,    //   Logical Maximum(255),
+    0x26, 0xFF, 0x00,    //   Logical Maximum(255),
     0x05, 0x07,          //   Usage Page (Key Codes),
     0x19, 0x00,          //   Usage Minimum (0),
     0x29, 0xFF,          //   Usage Maximum (255),
@@ -350,7 +350,7 @@ const PROGMEM uchar mouse_hid_report[] = {
     0xa1, 0x01,                    // COLLECTION (Application)
     0x85, REPORT_ID_SYSTEM,        //   REPORT_ID (2)
     0x15, 0x01,                    //   LOGICAL_MINIMUM (0x1)
-    0x25, 0xb7, 0x00,              //   LOGICAL_MAXIMUM (0xb7)
+    0x26, 0xb7, 0x00,              //   LOGICAL_MAXIMUM (0xb7)
     0x19, 0x01,                    //   USAGE_MINIMUM (0x1)
     0x29, 0xb7,                    //   USAGE_MAXIMUM (0xb7)
     0x75, 0x10,                    //   REPORT_SIZE (16)


### PR DESCRIPTION
When we originally imported tmk/tmk_keyboard@7ce326dee5f5ae6dc558356a79c58f8d4c150fe0 as 649b33d7783cf3021928534b7ae127e0a89e8807, we had a typo in the `tmk_core/protocol/vusb/vusb.c` file, where some of the bytes in the HID reports were wrong. This was causing my B.mini X2 to not work with the V-USB protocol on Windows 10. The same problem didn't happen on OS X.

Tested this on both Windows 10 and OS X.