### PR TITLE
Check for Pro Micro serial port automatically

### DIFF
--- a/keyboards/lets_split/rules.mk
+++ b/keyboards/lets_split/rules.mk
@@ -76,10 +76,12 @@ CUSTOM_MATRIX = yes
 
 avrdude: build
 	ls /dev/tty* > /tmp/1; \
-	echo "Reset your Pro Micro then hit any key to continue..."; \
-	read -n 1 -s; \
-	ls /dev/tty* > /tmp/2; \
-	USB=`diff /tmp/1 /tmp/2 | grep '>' | sed -e 's/> //'`; \
+	echo "Reset your Pro Micro now"; \
+	while [[ -z $$USB ]]; do \
+	  sleep 1; \
+	  ls /dev/tty* > /tmp/2; \
+	  USB=`diff /tmp/1 /tmp/2 | grep -o '/dev/tty.*'`; \
+	done; \
 	avrdude -p $(MCU) -c avr109 -P $$USB -U flash:w:$(BUILD_DIR)/$(TARGET).hex
 
 .PHONY: avrdude


### PR DESCRIPTION
A small improvement to #1036 that checks for the new serial port automatically instead of having the user manually continue.