### PR TITLE
Implement tap mod dual role for right side mods.

### DIFF
--- a/quantum/keymap_common.c
+++ b/quantum/keymap_common.c
@@ -120,7 +120,7 @@ action_t action_for_key(uint8_t layer, keypos_t key)
             action.code = ACTION_MODS_ONESHOT(mod);
             break;
         case QK_MOD_TAP ... QK_MOD_TAP_MAX:
-            action.code = ACTION_MODS_TAP_KEY((keycode >> 0x8) & 0xF, keycode & 0xFF);
+            action.code = ACTION_MODS_TAP_KEY((keycode >> 0x8) & 0x1F, keycode & 0xFF);
             break;
     #ifdef BACKLIGHT_ENABLE
         case BL_0 ... BL_15:

--- a/quantum/process_keycode/process_unicode.c
+++ b/quantum/process_keycode/process_unicode.c
@@ -139,7 +139,7 @@ void unicode_map_input_error() {}
 bool process_unicode_map(uint16_t keycode, keyrecord_t *record) {
   if ((keycode & QK_UNICODE_MAP) == QK_UNICODE_MAP && record->event.pressed) {
     const uint32_t* map = unicode_map;
-    uint16_t index = keycode & 0x7FF;
+    uint16_t index = keycode - QK_UNICODE_MAP;
     uint32_t code = pgm_read_dword_far(&map[index]);
     if (code > 0xFFFF && code <= 0x10ffff && input_mode == UC_OSX) {
       // Convert to UTF-16 surrogate pair

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -43,7 +43,7 @@ enum quantum_keycodes {
     QK_TAP_DANCE_MAX      = 0x57FF,
 #ifdef UNICODEMAP_ENABLE
     QK_UNICODE_MAP        = 0x5800,
-    QK_UNICODE_MAP_MAX    = 0x5FFF,
+    QK_UNICODE_MAP_MAX    = 0x5BFF,
 #endif
     QK_MOD_TAP            = 0x6000,
     QK_MOD_TAP_MAX        = 0x7FFF,
@@ -54,7 +54,7 @@ enum quantum_keycodes {
 
     // Loose keycodes - to be used directly
 
-    RESET = 0x7000,
+    RESET = 0x5C00,
     DEBUG,
     MAGIC_SWAP_CONTROL_CAPSLOCK,
     MAGIC_CAPSLOCK_TO_CONTROL,

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -39,14 +39,14 @@ enum quantum_keycodes {
     QK_CHORDING           = 0x5600,
     QK_CHORDING_MAX       = 0x56FF,
 #endif
-    QK_MOD_TAP            = 0x6000,
-    QK_MOD_TAP_MAX        = 0x6FFF,
-    QK_TAP_DANCE          = 0x7100,
-    QK_TAP_DANCE_MAX      = 0x71FF,
+    QK_TAP_DANCE          = 0x5700,
+    QK_TAP_DANCE_MAX      = 0x57FF,
 #ifdef UNICODEMAP_ENABLE
-    QK_UNICODE_MAP        = 0x7800,
-    QK_UNICODE_MAP_MAX    = 0x7FFF,
+    QK_UNICODE_MAP        = 0x5800,
+    QK_UNICODE_MAP_MAX    = 0x5FFF,
 #endif
+    QK_MOD_TAP            = 0x6000,
+    QK_MOD_TAP_MAX        = 0x7FFF,
 #ifdef UNICODE_ENABLE
     QK_UNICODE            = 0x8000,
     QK_UNICODE_MAX        = 0xFFFF,
@@ -298,15 +298,29 @@ enum quantum_keycodes {
 #define OSM(mod) (mod | QK_ONE_SHOT_MOD)
 
 // M-od, T-ap - 256 keycode max
-#define MT(mod, kc) (kc | QK_MOD_TAP | ((mod & 0xF) << 8))
+#define MT(mod, kc) (kc | QK_MOD_TAP | ((mod & 0x1F) << 8))
+
 #define CTL_T(kc) MT(MOD_LCTL, kc)
+#define LCTL_T(kc) MT(MOD_LCTL, kc)
+#define RCTL_T(kc) MT(MOD_RCTL, kc)
+
 #define SFT_T(kc) MT(MOD_LSFT, kc)
+#define LSFT_T(kc) MT(MOD_LSFT, kc)
+#define RSFT_T(kc) MT(MOD_RSFT, kc)
+
 #define ALT_T(kc) MT(MOD_LALT, kc)
+#define LALT_T(kc) MT(MOD_LALT, kc)
+#define RALT_T(kc) MT(MOD_RALT, kc)
 #define ALGR_T(kc) MT(MOD_RALT, kc) // dual-function AltGR
+
 #define GUI_T(kc) MT(MOD_LGUI, kc)
+#define LGUI_T(kc) MT(MOD_LGUI, kc)
+#define RGUI_T(kc) MT(MOD_RGUI, kc)
+
 #define C_S_T(kc) MT((MOD_LCTL | MOD_LSFT), kc) // Control + Shift e.g. for gnome-terminal
 #define MEH_T(kc) MT((MOD_LCTL | MOD_LSFT | MOD_LALT), kc) // Meh is a less hyper version of the Hyper key -- doesn't include Win or Cmd, so just alt+shift+ctrl
 #define LCAG_T(kc) MT((MOD_LCTL | MOD_LALT | MOD_LGUI), kc) // Left control alt and gui
+#define RCAG_T(kc) MT((MOD_RCTL | MOD_RALT | MOD_RGUI), kc) // Right control alt and gui
 #define ALL_T(kc) MT((MOD_LCTL | MOD_LSFT | MOD_LALT | MOD_LGUI), kc) // see http://brettterpstra.com/2012/12/08/a-useful-caps-lock-key/
 #define SCMD_T(kc) MT((MOD_LGUI | MOD_LSFT), kc)
 #define SWIN_T(kc) SCMD_T(kc)


### PR DESCRIPTION
This is hopefully a complete fix for pull request https://github.com/qmk/qmk_firmware/pull/1059 . I'm using this to implement AltGr-Compose dual role key (tap for Compose, press for AltGr).