### PR TITLE
GON NerD: Add reset button to documentation and default keymap

### DIFF
--- a/keyboards/gonnerd/keymaps/default/keymap.c
+++ b/keyboards/gonnerd/keymaps/default/keymap.c
@@ -4,11 +4,20 @@
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   [0] = KEYMAP_60( /* Base */
-    KC_ESC, KC_1,   KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,   KC_0,   KC_MINS,KC_EQL, KC_BSPC,\
-    KC_TAB, KC_Q,   KC_W,   KC_E,   KC_R,   KC_T,   KC_Y,   KC_U,   KC_I,   KC_O,   KC_P,   KC_LBRC,KC_RBRC,KC_BSLS,\
-    KC_LCTL,KC_A,   KC_S,   KC_D,   KC_F,   KC_G,   KC_H,   KC_J,   KC_K,   KC_L,   KC_SCLN,KC_QUOT,KC_NO,  KC_ENT, \
-    KC_LSFT,KC_NO,  KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,   KC_N,   KC_M,   KC_COMM,KC_DOT, KC_SLSH,KC_RSFT,KC_NO,  \
-    KC_LCTL,KC_LGUI,KC_LALT,                        KC_SPC,                         KC_RALT,KC_RGUI,MO(1),  KC_RCTL),
+    KC_ESC, KC_1,   KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,   KC_0,   KC_MINS,KC_EQL, KC_BSPC, \
+    KC_TAB, KC_Q,   KC_W,   KC_E,   KC_R,   KC_T,   KC_Y,   KC_U,   KC_I,   KC_O,   KC_P,   KC_LBRC,KC_RBRC,KC_BSLS, \
+    KC_LCTL,KC_A,   KC_S,   KC_D,   KC_F,   KC_G,   KC_H,   KC_J,   KC_K,   KC_L,   KC_SCLN,KC_QUOT,KC_NO,  KC_ENT,  \
+    KC_LSFT,KC_NO,  KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,   KC_N,   KC_M,   KC_COMM,KC_DOT, KC_SLSH,KC_RSFT,KC_NO,   \
+    KC_LCTL,KC_LGUI,KC_LALT,                        KC_SPC,                         KC_RALT,KC_RGUI,MO(1),  KC_RCTL  \
+  ),
+
+  [1] = KEYMAP_60( /* System layer to have access to RESET button */
+      RESET,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,   __x__, \
+      __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,   __x__, \
+      __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,   __x__, \
+      __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,   __x__, \
+      __x__,  __x__,  __x__,                  __x__,                                  __x__,  __x__,  KC_TRNS, __x__  \
+  ),
 };
 
 const uint16_t PROGMEM fn_actions[] = {

--- a/keyboards/gonnerd/keymaps/default/keymap.c
+++ b/keyboards/gonnerd/keymaps/default/keymap.c
@@ -1,14 +1,15 @@
 #include "gonnerd.h"
 
-// Keymap layers
+#define __x__ KC_NO
 
+// Keymap layers
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   [0] = KEYMAP_60( /* Base */
-    KC_ESC, KC_1,   KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,   KC_0,   KC_MINS,KC_EQL, KC_BSPC, \
-    KC_TAB, KC_Q,   KC_W,   KC_E,   KC_R,   KC_T,   KC_Y,   KC_U,   KC_I,   KC_O,   KC_P,   KC_LBRC,KC_RBRC,KC_BSLS, \
-    KC_LCTL,KC_A,   KC_S,   KC_D,   KC_F,   KC_G,   KC_H,   KC_J,   KC_K,   KC_L,   KC_SCLN,KC_QUOT,KC_NO,  KC_ENT,  \
-    KC_LSFT,KC_NO,  KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,   KC_N,   KC_M,   KC_COMM,KC_DOT, KC_SLSH,KC_RSFT,KC_NO,   \
-    KC_LCTL,KC_LGUI,KC_LALT,                        KC_SPC,                         KC_RALT,KC_RGUI,MO(1),  KC_RCTL  \
+    KC_ESC,  KC_1,    KC_2,    KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, \
+    KC_TAB,  KC_Q,    KC_W,    KC_E,   KC_R,   KC_T,   KC_Y,   KC_U,   KC_I,   KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS, \
+    KC_LCTL, KC_A,    KC_S,    KC_D,   KC_F,   KC_G,   KC_H,   KC_J,   KC_K,   KC_L,    KC_SCLN, KC_QUOT, __x__,   KC_ENT,  \
+    KC_LSFT, __x__,   KC_Z,    KC_X,   KC_C,   KC_V,   KC_B,   KC_N,   KC_M,   KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT, __x__,   \
+    KC_LCTL, KC_LGUI, KC_LALT,                         KC_SPC,                          KC_RALT, KC_RGUI, MO(1),   KC_RCTL  \
   ),
 
   [1] = KEYMAP_60( /* System layer to have access to RESET button */

--- a/keyboards/gonnerd/keymaps/mauin/keymap.c
+++ b/keyboards/gonnerd/keymaps/mauin/keymap.c
@@ -23,11 +23,11 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    * `-----------------------------------------------------------'
    */
   [BASE_LAYER] = KEYMAP_60(
-      KC_ESC,   KC_1,     KC_2,     KC_3,    KC_4,     KC_5,     KC_6,     KC_7,    KC_8,    KC_9,     KC_0,     KC_MINS,  KC_EQL,   KC_BSPC, \
+      F(0),     KC_1,     KC_2,     KC_3,    KC_4,     KC_5,     KC_6,     KC_7,    KC_8,    KC_9,     KC_0,     KC_MINS,  KC_EQL,   KC_BSPC, \
       KC_TAB,   KC_Q,     KC_W,     KC_E,    KC_R,     KC_T,     KC_Y,     KC_U,    KC_I,    KC_O,     KC_P,     KC_LBRC,  KC_RBRC,  KC_BSLS, \
-      MO(1),    KC_A,     KC_S,     KC_D,    KC_F,     KC_G,     KC_H,     KC_J,    KC_K,    KC_L,     KC_SCLN,  KC_QUOT,  __x__,    KC_ENT, \
-      KC_LSFT,  __x__,    KC_Z,     KC_X,     KC_C,    KC_V,     KC_B,     KC_N,    KC_M,    KC_COMM,  KC_DOT,   KC_SLSH,  KC_RSFT,  __x__, \
-      KC_LCTL,  KC_LALT,  KC_LGUI,                     KC_SPC,                                         KC_RGUI,  KC_RALT,  MO(3),    KC_RCTL \
+      MO(1),    KC_A,     KC_S,     KC_D,    KC_F,     KC_G,     KC_H,     KC_J,    KC_K,    KC_L,     KC_SCLN,  KC_QUOT,  __x__,    KC_ENT,  \
+      KC_LSFT,  __x__,    KC_Z,     KC_X,     KC_C,    KC_V,     KC_B,     KC_N,    KC_M,    KC_COMM,  KC_DOT,   KC_SLSH,  KC_RSFT,  __x__,   \
+      KC_LCTL,  KC_LALT,  KC_LGUI,                               KC_SPC,                               KC_RGUI,  KC_RALT,  MO(2),    KC_RCTL  \
   ),
 
   /* Layer 1: Function Layer
@@ -45,10 +45,10 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    */
    [FUNCTION_LAYER] = KEYMAP_60(
        KC_GRV,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_DEL, \
-       __x__,   KC_MPRV, KC_MPLY, KC_MNXT, __x__,   __x__,   KC_PGUP, KC_HOME, KC_UP,   KC_END,  __x__,   KC_SLCK, KC_PAUS, __x__, \
-       KC_TRNS, KC_MUTE, KC_VOLD, KC_VOLU, __x__,   __x__,   KC_PGDN, KC_LEFT, KC_DOWN, KC_RGHT, __x__,   __x__,   __x__,   __x__, \
-       KC_LSFT,  __x__,  __x__,   __x__,   __x__,   __x__,   __x__,   __x__,   __x__,   __x__,   __x__,   __x__,   __x__,   __x__, \
-       KC_LCTL, KC_LALT, KC_LGUI,                   KC_SPC,                                      __x__,   __x__,   __x__,   __x__ \
+       __x__,   KC_MPRV, KC_MPLY, KC_MNXT, __x__,   __x__,   KC_PGUP, KC_HOME, KC_UP,   KC_END,  __x__,   KC_SLCK, KC_PAUS, __x__,  \
+       KC_TRNS, KC_MUTE, KC_VOLD, KC_VOLU, __x__,   __x__,   KC_PGDN, KC_LEFT, KC_DOWN, KC_RGHT, __x__,   __x__,    __x__,  __x__,  \
+       KC_LSFT,  __x__,  __x__,   __x__,   __x__,   __x__,   __x__,   __x__,   __x__,   __x__,   __x__,   __x__,    __x__,  __x__,  \
+       KC_LCTL, KC_LALT, KC_LGUI,                            KC_SPC,                             __x__,   __x__,   __x__,   __x__   \
    ),
 
   /* Layer 2: System Layer
@@ -69,10 +69,40 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
       __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,   __x__, \
       __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,   __x__, \
       __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,  __x__,   __x__, \
-      __x__,  __x__,  __x__,                  __x__,                                  __x__,  __x__,  KC_TRNS, __x__ \
+      __x__,  __x__,  __x__,                          __x__,                          __x__,  __x__,  KC_TRNS, __x__  \
   ),
 };
 
-const uint16_t PROGMEM fn_actions[] = {
-
+enum function_id {
+    ESC_GRV, // Makes Esc behave like `~ when pressed with the left GUI modifier. This is the "switch between windows of the same application" key combination in macOS
 };
+
+const uint16_t PROGMEM fn_actions[] = {
+  [0]  = ACTION_FUNCTION(ESC_GRV),
+};
+
+void action_function(keyrecord_t *record, uint8_t id, uint8_t opt) {
+  static uint8_t esc_grv_mask;
+  switch (id) {
+    case ESC_GRV:
+      esc_grv_mask = get_mods() & MOD_BIT(KC_LGUI);
+      if (record->event.pressed) {
+        if (esc_grv_mask) {
+          add_key(KC_GRV);
+          send_keyboard_report();
+        } else {
+          add_key(KC_ESC);
+          send_keyboard_report();
+        }
+      } else {
+        if (esc_grv_mask) {
+          del_key(KC_GRV);
+          send_keyboard_report();
+        } else {
+          del_key(KC_ESC);
+          send_keyboard_report();
+        }
+      }
+      break;
+  }
+}

--- a/keyboards/gonnerd/readme.md
+++ b/keyboards/gonnerd/readme.md
@@ -11,6 +11,10 @@ It is possible to change the bootloader of the GON NerD with an ISP programmer. 
 _After changing the bootloader on your GON NerD PCB you will not be able to go back to the original firmware and the official configuration software will
 not work anymore. You will lose your warranty and official support from GON!_
 
+## Reset button
+
+To run the `make dfu` command to flash keymaps onto the board, you need to put the board into DFU mode. As the GON NerD PCBs do not have a reset button on the board to put it into DFU mode, be sure to include a `RESET` button on your keymap. Otherwise you'll have to unscrew your keyboard from the case and short the GND and RST pins.
+
 ## Building
 
 Download or clone the whole firmware and navigate to the keyboards/gonnerd folder. Once your dev env is setup, you'll be able to type `make` to generate your .hex - you can then use the Teensy Loader to program your .hex file.


### PR DESCRIPTION
As the NerD PCBs don't have a physical reset button on the board this adds a note to remind people to put an accessible `RESET` key on their keymaps so that they don't have to unscrew the PCB from the case and short the pins manually.

- Improve `README.md` of the GON NerD to include RESET button
- Include a `RESET` button on the function layer of the default keymap.
- Includes some changes to my keymap (let me know if these changes should be in a separate PR)

