### PR TITLE
Add weak layer_state_set_kb hook

### DIFF
--- a/tmk_core/common/action_layer.c
+++ b/tmk_core/common/action_layer.c
@@ -57,8 +57,14 @@ void default_layer_xor(uint32_t state)
  */
 uint32_t layer_state = 0;
 
+__attribute__((weak))
+uint32_t layer_state_set_kb(uint32_t state) {
+    return state;
+}
+
 static void layer_state_set(uint32_t state)
 {
+    state = layer_state_set_kb(state);
     dprint("layer_state: ");
     layer_debug(); dprint(" to ");
     layer_state = state;

--- a/tmk_core/common/action_layer.c
+++ b/tmk_core/common/action_layer.c
@@ -16,8 +16,14 @@
  */
 uint32_t default_layer_state = 0;
 
+__attribute__((weak))
+uint32_t default_layer_state_set_kb(uint32_t state) {
+    return state;
+}
+
 static void default_layer_state_set(uint32_t state)
 {
+    state = default_layer_state_set_kb(state);
     debug("default_layer_state: ");
     default_layer_debug(); debug(" to ");
     default_layer_state = state;

--- a/tmk_core/common/action_layer.h
+++ b/tmk_core/common/action_layer.h
@@ -27,10 +27,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 extern uint32_t default_layer_state;
 void default_layer_debug(void);
-uint32_t default_layer_set(uint32_t state);
+void default_layer_set(uint32_t state);
 
 __attribute__((weak))
-void default_layer_state_set_kb(uint32_t state);
+uint32_t default_layer_state_set_kb(uint32_t state);
 
 #ifndef NO_ACTION_LAYER
 /* bitwise operation */

--- a/tmk_core/common/action_layer.h
+++ b/tmk_core/common/action_layer.h
@@ -27,7 +27,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 extern uint32_t default_layer_state;
 void default_layer_debug(void);
-void default_layer_set(uint32_t state);
+uint32_t default_layer_set(uint32_t state);
+
+__attribute__((weak))
+void default_layer_state_set_kb(uint32_t state);
 
 #ifndef NO_ACTION_LAYER
 /* bitwise operation */
@@ -70,7 +73,7 @@ void layer_xor(uint32_t state);
 #define layer_debug()
 
 __attribute__((weak))
-void layer_state_set_kb(uint32_t oldstate, uint32_t newstate);
+uint32_t layer_state_set_kb(uint32_t state);
 #endif
 
 /* pressed actions cache */

--- a/tmk_core/common/action_layer.h
+++ b/tmk_core/common/action_layer.h
@@ -69,6 +69,8 @@ void layer_xor(uint32_t state);
 #define layer_xor(state)
 #define layer_debug()
 
+__attribute__((weak))
+void layer_state_set_kb(uint32_t oldstate, uint32_t newstate);
 #endif
 
 /* pressed actions cache */


### PR DESCRIPTION
Added layer_state_set_kb hook very late in layer activation. This can be used to modify layer state before it is set.

Something similar to update_tri_layer() can be used here, and will cover all cases of layer activation (normal, tap, oneshot, toggle, etc). This is also a good place to add layer switching indicator or beeps.