### PR TITLE
Add initial version of TheVan Keyboards Roadkit Firmware

### DIFF
--- a/keyboards/roadkit/Makefile
+++ b/keyboards/roadkit/Makefile
@@ -1,0 +1,3 @@
+ifndef MAKEFILE_INCLUDED
+	include ../../Makefile
+endif

--- a/keyboards/roadkit/config.h
+++ b/keyboards/roadkit/config.h
@@ -1,0 +1,162 @@
+/*
+Copyright 2012 Jun Wako <wakojun@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#include "config_common.h"
+
+/* USB Device descriptor parameter */
+#define VENDOR_ID       0xFEAE
+#define PRODUCT_ID      0x8846
+#define DEVICE_VER      0x0001
+#define MANUFACTURER    TheVan Keyboards
+#define PRODUCT         Roadkit Micro
+#define DESCRIPTION     keyboard firmware for Roadkit Micro
+
+/* key matrix size */
+#define MATRIX_ROWS 4
+#define MATRIX_COLS 4
+
+/*
+ * Keyboard Matrix Assignments
+ *
+ * Change this to how you wired your keyboard
+ * COLS: AVR pins used for columns, left to right
+ * ROWS: AVR pins used for rows, top to bottom
+ * DIODE_DIRECTION: COL2ROW = COL = Anode (+), ROW = Cathode (-, marked on diode)
+ *                  ROW2COL = ROW = Anode (+), COL = Cathode (-, marked on diode)
+ *
+*/
+#define MATRIX_ROW_PINS { F0, F5, D7, B4 }
+#define MATRIX_COL_PINS { F1, F4, D6, D4 }
+#define UNUSED_PINS
+
+/* COL2ROW or ROW2COL */
+#define DIODE_DIRECTION COL2ROW
+ 
+// #define BACKLIGHT_PIN B7
+// #define BACKLIGHT_BREATHING
+// #define BACKLIGHT_LEVELS 3
+
+
+/* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
+#define DEBOUNCING_DELAY 5
+
+/* define if matrix has ghost (lacks anti-ghosting diodes) */
+//#define MATRIX_HAS_GHOST
+
+/* number of backlight levels */
+
+/* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
+#define LOCKING_SUPPORT_ENABLE
+/* Locking resynchronize hack */
+#define LOCKING_RESYNC_ENABLE
+
+/*
+ * Force NKRO
+ *
+ * Force NKRO (nKey Rollover) to be enabled by default, regardless of the saved
+ * state in the bootmagic EEPROM settings. (Note that NKRO must be enabled in the
+ * makefile for this to work.)
+ *
+ * If forced on, NKRO can be disabled via magic key (default = LShift+RShift+N)
+ * until the next keyboard reset.
+ *
+ * NKRO may prevent your keystrokes from being detected in the BIOS, but it is
+ * fully operational during normal computer usage.
+ *
+ * For a less heavy-handed approach, enable NKRO via magic key (LShift+RShift+N)
+ * or via bootmagic (hold SPACE+N while plugging in the keyboard). Once set by
+ * bootmagic, NKRO mode will always be enabled until it is toggled again during a
+ * power-up.
+ *
+ */
+//#define FORCE_NKRO
+
+/*
+ * Magic Key Options
+ *
+ * Magic keys are hotkey commands that allow control over firmware functions of
+ * the keyboard. They are best used in combination with the HID Listen program,
+ * found here: https://www.pjrc.com/teensy/hid_listen.html
+ *
+ * The options below allow the magic key functionality to be changed. This is
+ * useful if your keyboard/keypad is missing keys and you want magic key support.
+ *
+ */
+
+/* key combination for magic key command */
+#define IS_COMMAND() ( \
+    keyboard_report->mods == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT)) \
+)
+
+/* control how magic key switches layers */
+//#define MAGIC_KEY_SWITCH_LAYER_WITH_FKEYS  true
+//#define MAGIC_KEY_SWITCH_LAYER_WITH_NKEYS  true
+//#define MAGIC_KEY_SWITCH_LAYER_WITH_CUSTOM false
+
+/* override magic key keymap */
+//#define MAGIC_KEY_SWITCH_LAYER_WITH_FKEYS
+//#define MAGIC_KEY_SWITCH_LAYER_WITH_NKEYS
+//#define MAGIC_KEY_SWITCH_LAYER_WITH_CUSTOM
+//#define MAGIC_KEY_HELP1          H
+//#define MAGIC_KEY_HELP2          SLASH
+//#define MAGIC_KEY_DEBUG          D
+//#define MAGIC_KEY_DEBUG_MATRIX   X
+//#define MAGIC_KEY_DEBUG_KBD      K
+//#define MAGIC_KEY_DEBUG_MOUSE    M
+//#define MAGIC_KEY_VERSION        V
+//#define MAGIC_KEY_STATUS         S
+//#define MAGIC_KEY_CONSOLE        C
+//#define MAGIC_KEY_LAYER0_ALT1    ESC
+//#define MAGIC_KEY_LAYER0_ALT2    GRAVE
+//#define MAGIC_KEY_LAYER0         0
+//#define MAGIC_KEY_LAYER1         1
+//#define MAGIC_KEY_LAYER2         2
+//#define MAGIC_KEY_LAYER3         3
+//#define MAGIC_KEY_LAYER4         4
+//#define MAGIC_KEY_LAYER5         5
+//#define MAGIC_KEY_LAYER6         6
+//#define MAGIC_KEY_LAYER7         7
+//#define MAGIC_KEY_LAYER8         8
+//#define MAGIC_KEY_LAYER9         9
+//#define MAGIC_KEY_BOOTLOADER     PAUSE
+//#define MAGIC_KEY_LOCK           CAPS
+//#define MAGIC_KEY_EEPROM         E
+//#define MAGIC_KEY_NKRO           N
+//#define MAGIC_KEY_SLEEP_LED      Z
+
+/*
+ * Feature disable options
+ *  These options are also useful to firmware size reduction.
+ */
+
+/* disable debug print */
+//#define NO_DEBUG
+
+/* disable print */
+//#define NO_PRINT
+
+/* disable action features */
+//#define NO_ACTION_LAYER
+//#define NO_ACTION_TAPPING
+//#define NO_ACTION_ONESHOT
+//#define NO_ACTION_MACRO
+//#define NO_ACTION_FUNCTION
+
+#endif

--- a/keyboards/roadkit/keymaps/default/Makefile
+++ b/keyboards/roadkit/keymaps/default/Makefile
@@ -1,0 +1,21 @@
+# Build Options
+#   change to "no" to disable the options, or define them in the Makefile in 
+#   the appropriate keymap folder that will get included automatically
+#
+BOOTMAGIC_ENABLE = no       # Virtual DIP switch configuration(+1000)
+MOUSEKEY_ENABLE = yes       # Mouse keys(+4700)
+EXTRAKEY_ENABLE = yes       # Audio control and System control(+450)
+CONSOLE_ENABLE = no         # Console for debug(+400)
+COMMAND_ENABLE = yes        # Commands for debug and configuration
+NKRO_ENABLE = yes           # Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
+MIDI_ENABLE = no            # MIDI controls
+AUDIO_ENABLE = no           # Audio output on port C6
+UNICODE_ENABLE = no         # Unicode
+BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
+RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight.  Do not enable this with audio at the same time.
+SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
+
+ifndef QUANTUM_DIR
+	include ../../../../Makefile
+endif

--- a/keyboards/roadkit/keymaps/default/config.h
+++ b/keyboards/roadkit/keymaps/default/config.h
@@ -1,0 +1,8 @@
+#ifndef CONFIG_USER_H
+#define CONFIG_USER_H
+
+#include "../../config.h"
+
+// place overrides here
+
+#endif

--- a/keyboards/roadkit/keymaps/default/keymap.c
+++ b/keyboards/roadkit/keymaps/default/keymap.c
@@ -1,0 +1,49 @@
+#include "roadkit.h"
+#include "action_layer.h"
+#include "eeconfig.h"
+
+extern keymap_config_t keymap_config;
+
+// Each layer gets a name for readability, which is then used in the keymap matrix below.
+// The underscores don't mean anything - you can have a layer called STUFF or any other name.
+// Layer names don't all need to be of the same length, obviously, and you can also skip them
+// entirely and just use numbers.
+
+#define _NP 0
+
+// Macro name shortcuts
+#define NUMPAD M(_NP)
+
+// Fillers to make layering more clear
+#define _______ KC_TRNS
+#define XXXXXXX KC_NO
+
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  [_NP] = /* Numpad */
+    KEYMAP(KC_KP_7, KC_KP_8,   KC_KP_9, KC_KP_PLUS,  \
+           KC_KP_4, KC_KP_5,   KC_KP_6,              \
+           KC_KP_1, KC_KP_2,   KC_KP_3, KC_KP_ENTER, \
+           KC_KP_0,            KC_KP_DOT),
+};
+
+const uint16_t PROGMEM fn_actions[] = {
+
+};
+
+void persistant_default_layer_set(uint16_t default_layer) {
+  eeconfig_update_default_layer(default_layer);
+  default_layer_set(default_layer);
+}
+
+const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
+{
+      switch(id) {
+        case _NP:
+          if (record->event.pressed) {
+            persistant_default_layer_set(1UL<<_NP);
+          }
+          break;
+      }
+    return MACRO_NONE;
+};

--- a/keyboards/roadkit/keymaps/default/readme.md
+++ b/keyboards/roadkit/keymaps/default/readme.md
@@ -1,0 +1,1 @@
+# The default keymap for roadkit

--- a/keyboards/roadkit/keymaps/singles/Makefile
+++ b/keyboards/roadkit/keymaps/singles/Makefile
@@ -1,0 +1,21 @@
+# Build Options
+#   change to "no" to disable the options, or define them in the Makefile in 
+#   the appropriate keymap folder that will get included automatically
+#
+BOOTMAGIC_ENABLE = no       # Virtual DIP switch configuration(+1000)
+MOUSEKEY_ENABLE = yes       # Mouse keys(+4700)
+EXTRAKEY_ENABLE = yes       # Audio control and System control(+450)
+CONSOLE_ENABLE = no         # Console for debug(+400)
+COMMAND_ENABLE = yes        # Commands for debug and configuration
+NKRO_ENABLE = yes           # Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
+MIDI_ENABLE = no            # MIDI controls
+AUDIO_ENABLE = no           # Audio output on port C6
+UNICODE_ENABLE = no         # Unicode
+BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
+RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight.  Do not enable this with audio at the same time.
+SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
+
+ifndef QUANTUM_DIR
+	include ../../../../Makefile
+endif

--- a/keyboards/roadkit/keymaps/singles/config.h
+++ b/keyboards/roadkit/keymaps/singles/config.h
@@ -1,0 +1,8 @@
+#ifndef CONFIG_USER_H
+#define CONFIG_USER_H
+
+#include "../../config.h"
+
+// place overrides here
+
+#endif

--- a/keyboards/roadkit/keymaps/singles/keymap.c
+++ b/keyboards/roadkit/keymaps/singles/keymap.c
@@ -1,0 +1,61 @@
+#include "roadkit.h"
+#include "action_layer.h"
+#include "eeconfig.h"
+
+extern keymap_config_t keymap_config;
+
+// Each layer gets a name for readability, which is then used in the keymap matrix below.
+// The underscores don't mean anything - you can have a layer called STUFF or any other name.
+// Layer names don't all need to be of the same length, obviously, and you can also skip them
+// entirely and just use numbers.
+
+#define _NP 0
+#define _L1 1
+
+// Macro name shortcuts
+#define NUMPAD M(_NP)
+#define LAYER1 M(_L1)
+
+// Fillers to make layering more clear
+#define _______ KC_TRNS
+#define XXXXXXX KC_NO
+
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  [_NP] = /* Numpad */
+    SINGLES_KEYMAP(KC_KP_7, KC_KP_8,   KC_KP_9, KC_KP_PLUS,  \
+                   KC_KP_4, KC_KP_5,   KC_KP_6, KC_KP_MINUS, \
+                   KC_KP_1, KC_KP_2,   KC_KP_3, KC_KP_ENTER, \
+                   KC_KP_0, KC_KP_DOT, TG(_L1), KC_BSPC),
+  [_L1] = /* LAYER 1 */
+    SINGLES_KEYMAP(KC_NUMLOCK, KC_TRNS, KC_TRNS,  KC_VOLU, \
+                   KC_TRNS,    KC_UP,   KC_TRNS,  KC_VOLD, \
+                   KC_LEFT,    KC_DOWN, KC_RIGHT, KC_TRNS, \
+                   KC_TRNS,    KC_TRNS, KC_TRNS,  KC_TRNS)
+};
+
+const uint16_t PROGMEM fn_actions[] = {
+
+};
+
+void persistant_default_layer_set(uint16_t default_layer) {
+  eeconfig_update_default_layer(default_layer);
+  default_layer_set(default_layer);
+}
+
+const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
+{
+      switch(id) {
+        case _L1:
+          if (record->event.pressed) {
+            persistant_default_layer_set(1UL<<_L1);
+          }
+          break;
+        case _NP:
+          if (record->event.pressed) {
+            persistant_default_layer_set(1UL<<_NP);
+          }
+          break;
+      }
+    return MACRO_NONE;
+};

--- a/keyboards/roadkit/keymaps/singles/readme.md
+++ b/keyboards/roadkit/keymaps/singles/readme.md
@@ -1,0 +1,3 @@
+# The singles keymap for roadkit
+
+This keymap has a base layer with numpad functionality, and then a second layer with some additional keys. The user is encouraged to develop their own keymap using this as a starting point.

--- a/keyboards/roadkit/readme.md
+++ b/keyboards/roadkit/readme.md
@@ -1,0 +1,32 @@
+roadkit keyboard firmware
+======================
+
+## Quantum MK Firmware
+
+For the full Quantum feature list, see [the QMK Wiki](https://github.com/qmk/qmk_firmware/wiki).
+
+## Building
+
+Download or clone the whole firmware and navigate to the `keyboards/roadkit` folder. Once your dev env is setup, you'll be able to type `make` to generate your .hex. You can then use the programmer of your choice to program your .hex file.
+
+Depending on which keymap you would like to use, you will have to compile slightly differently.
+
+### Default
+
+To build with the default keymap, simply run `make default`. For the roadkit, the default layout is a standard numpad layout.
+
+### Singles
+
+The singles layout for the roadkit corresponds to the configuration where only 1u keys are used and there are 16 of them on the board. To build the singles keymap, run `make singles`.
+
+### Other Keymaps
+
+Several version of keymap are available in advance but you are recommended to define your favorite layout yourself. To define your own keymap create a folder with the name of your keymap in the keymaps folder, and see keymap documentation (you can find in top readme.md) and existant keymap files.
+
+To build the firmware binary hex file with a keymap just do `make` with a keymap like this:
+
+```
+$ make [default|jack|<name>]
+```
+
+Keymaps follow the format **__keymap.c__** and are stored in folders in the `keymaps` folder, eg `keymaps/my_keymap/`

--- a/keyboards/roadkit/roadkit.c
+++ b/keyboards/roadkit/roadkit.c
@@ -1,0 +1,28 @@
+#include "roadkit.h"
+
+void matrix_init_kb(void) {
+	// put your keyboard start-up code here
+	// runs once when the firmware starts up
+
+	matrix_init_user();
+}
+
+void matrix_scan_kb(void) {
+	// put your looping keyboard code here
+	// runs every cycle (a lot)
+
+	matrix_scan_user();
+}
+
+bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
+	// put your per-action keyboard code here
+	// runs for every action, just before processing by the firmware
+
+	return process_record_user(keycode, record);
+}
+
+void led_set_kb(uint8_t usb_led) {
+	// put your keyboard LED indicator (ex: Caps Lock LED) toggling code here
+
+	led_set_user(usb_led);
+}

--- a/keyboards/roadkit/roadkit.h
+++ b/keyboards/roadkit/roadkit.h
@@ -1,0 +1,33 @@
+#ifndef ROADKIT_H
+#define ROADKIT_H
+
+#include "quantum.h"
+
+// This is a shortcut to help you visually see your layout.
+#define KEYMAP( \
+    K00, K01, K02, K03, \
+    K10, K11, K12,      \
+    K20, K21, K22, K23, \
+    K30,      K32       \
+) \
+{ \
+    { K00, K01,   K02, K03   }, \
+    { K10, K11,   K12, KC_NO }, \
+    { K20, K21,   K22, K23   }, \
+    { K30, KC_NO, K32, KC_NO }  \
+}
+
+#define SINGLES_KEYMAP( \
+    K00, K01, K02, K03, \
+    K10, K11, K12, K13, \
+    K20, K21, K22, K23, \
+    K30, K31, K32, K33  \
+) \
+{ \
+    { K00,   K01,   K02,   K03 }, \
+    { K10,   K11,   K12,   K13 }, \
+    { K20,   K21,   K22,   K23 }, \
+    { K30,   K31,   K32,   K33 }  \
+}
+
+#endif

--- a/keyboards/roadkit/rules.mk
+++ b/keyboards/roadkit/rules.mk
@@ -1,0 +1,69 @@
+
+
+# MCU name
+#MCU = at90usb1287
+MCU = atmega32u4
+
+# Processor frequency.
+#     This will define a symbol, F_CPU, in all source code files equal to the
+#     processor frequency in Hz. You can then use this symbol in your source code to
+#     calculate timings. Do NOT tack on a 'UL' at the end, this will be done
+#     automatically to create a 32-bit value in your source code.
+#
+#     This will be an integer division of F_USB below, as it is sourced by
+#     F_USB after it has run through any CPU prescalers. Note that this value
+#     does not *change* the processor frequency - it should merely be updated to
+#     reflect the processor speed set externally so that the code can use accurate
+#     software delays.
+F_CPU = 16000000
+
+
+#
+# LUFA specific
+#
+# Target architecture (see library "Board Types" documentation).
+ARCH = AVR8
+
+# Input clock frequency.
+#     This will define a symbol, F_USB, in all source code files equal to the
+#     input clock frequency (before any prescaling is performed) in Hz. This value may
+#     differ from F_CPU if prescaling is used on the latter, and is required as the
+#     raw input clock is fed directly to the PLL sections of the AVR for high speed
+#     clock generation for the USB and other AVR subsections. Do NOT tack on a 'UL'
+#     at the end, this will be done automatically to create a 32-bit value in your
+#     source code.
+#
+#     If no clock division is performed on the input clock inside the AVR (via the
+#     CPU clock adjust registers or the clock division fuses), this will be equal to F_CPU.
+F_USB = $(F_CPU)
+
+# Interrupt driven control endpoint task(+60)
+OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
+
+
+# Boot Section Size in *bytes*
+#   Teensy halfKay   512
+#   Teensy++ halfKay 1024
+#   Atmel DFU loader 4096
+#   LUFA bootloader  4096
+#   USBaspLoader     2048
+OPT_DEFS += -DBOOTLOADER_SIZE=4096
+
+
+# Build Options
+#   change yes to no to disable
+#
+BOOTMAGIC_ENABLE ?= yes      # Virtual DIP switch configuration(+1000)
+MOUSEKEY_ENABLE ?= yes       # Mouse keys(+4700)
+EXTRAKEY_ENABLE ?= yes       # Audio control and System control(+450)
+CONSOLE_ENABLE ?= yes        # Console for debug(+400)
+COMMAND_ENABLE ?= yes        # Commands for debug and configuration
+# Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
+SLEEP_LED_ENABLE ?= no       # Breathing sleep LED during USB suspend
+# if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+NKRO_ENABLE ?= yes           # USB Nkey Rollover
+BACKLIGHT_ENABLE ?= no       # Enable keyboard backlight functionality on B7 by default
+MIDI_ENABLE ?= no            # MIDI controls
+UNICODE_ENABLE ?= no         # Unicode
+BLUETOOTH_ENABLE ?= no       # Enable Bluetooth with the Adafruit EZ-Key HID
+AUDIO_ENABLE ?= no           # Audio output on port C6


### PR DESCRIPTION
This PR brings support for TheVan Keyboards Roadkit into QMK and resolves issue #1123. The code is based heavily on both the QMK Minivan code (tv44) and the TMK Roadkit code. Note that I do not have LEDs on my Roadkit, so I haven't been able to implement any of the LED functionality.