### PR TITLE
Add FreeBSD support in "util/install_dependencies.sh"

### DIFF
--- a/util/install_dependencies.sh
+++ b/util/install_dependencies.sh
@@ -92,4 +92,23 @@ elif [[ -n "$(type -P zypper)" ]]; then
   # TODO: The avr and eabi tools are not available as default packages, so we need 
   # another way to install them
 
+elif [[ -n "$(type -P pkg)" ]]; then
+  # FreeBSD
+  pkg update
+  pkg install -y \
+    git \
+    wget \
+    gmake \
+    gcc \
+    zip \
+    unzip \
+    avr-binutils \
+    avr-gcc \
+    avr-libc \
+    dfu-programmer \
+    dfu-util \
+    arm-none-eabi-gcc \
+    arm-none-eabi-binutils \
+    arm-none-eabi-newlib \
+    diffutils
 fi


### PR DESCRIPTION
A simple addition to the `install_dependencies` script which remaps the debian dependencies to their freebsd package-names. After a recursive clone and using gmake, I can successfully build all firmware from the root directory (minus some warnings generated by gcc-4.9.4 which I can procure on request). 

Testing `serial_link_byte_stuffer`, however, fails due to the lack of the compat library `GLIBCXX_3.4.15` (which only goes up to 3.4.9 in FreeBSD 11.0).