### PR TITLE
readme keymap.h to quantum_keycodes.h

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,5 +35,5 @@ This is not a tiny project. While this is the main readme, there are many other 
 * The readme for your own keyboard: This is found under `keyboards/<your keyboards's name>/`. So for the ErgoDox EZ, it's [here](keyboards/ergodox/ez/); for the Planck, it's [here](keyboards/planck/) and so on.
 * The list of possible keycodes you can use in your keymap is actually spread out in a few different places:
   * [doc/keycode.txt](doc/keycode.txt) - an explanation of those same keycodes.
-  * [quantum/keymap.h](quantum/keymap.h) - this is where the QMK-specific aliases are all set up. Things like the Hyper and Meh key, the Leader key, and all of the other QMK innovations. These are also explained and documented below, but `keymap.h` is where they're actually defined.
+  * [quantum/quantum_keycodes.h](quantum/quantum_keycodes.h) - this is where the QMK-specific aliases are all set up. Things like the Hyper and Meh key, the Leader key, and all of the other QMK innovations. These are also explained and documented below, but `quantum_keycodes.h` is where they're actually defined.
 * The [TMK documentation](doc/TMK_README.md). QMK is based on TMK, and this explains how it works internally.


### PR DESCRIPTION
Changed the quantum/keymap.h to quantum/quantum_keycodes.h because this seems to be the file where they keycodes are defined.
See issue #1151 