### PR TITLE
Add smt keymap for Satan 'GH60'

### DIFF
--- a/keyboards/satan/keymaps/smt/Makefile
+++ b/keyboards/satan/keymaps/smt/Makefile
@@ -1,0 +1,21 @@
+# Build Options
+#   change to "no" to disable the options, or define them in the Makefile in 
+#   the appropriate keymap folder that will get included automatically
+#
+BOOTMAGIC_ENABLE = no       # Virtual DIP switch configuration(+1000)
+MOUSEKEY_ENABLE = yes       # Mouse keys(+4700)
+EXTRAKEY_ENABLE = yes       # Audio control and System control(+450)
+CONSOLE_ENABLE = no         # Console for debug(+400)
+COMMAND_ENABLE = yes        # Commands for debug and configuration
+NKRO_ENABLE = yes           # Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+BACKLIGHT_ENABLE = yes       # Enable keyboard backlight functionality
+MIDI_ENABLE = no            # MIDI controls
+AUDIO_ENABLE = no           # Audio output on port C6
+UNICODE_ENABLE = no         # Unicode
+BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
+RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight.  Do not enable this with audio at the same time.
+SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
+
+ifndef QUANTUM_DIR
+	include ../../../../Makefile
+endif

--- a/keyboards/satan/keymaps/smt/Makefile
+++ b/keyboards/satan/keymaps/smt/Makefile
@@ -8,13 +8,14 @@ EXTRAKEY_ENABLE = yes       # Audio control and System control(+450)
 CONSOLE_ENABLE = no         # Console for debug(+400)
 COMMAND_ENABLE = yes        # Commands for debug and configuration
 NKRO_ENABLE = yes           # Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
-BACKLIGHT_ENABLE = yes       # Enable keyboard backlight functionality
+BACKLIGHT_ENABLE = yes      # Enable keyboard backlight functionality
 MIDI_ENABLE = no            # MIDI controls
 AUDIO_ENABLE = no           # Audio output on port C6
 UNICODE_ENABLE = no         # Unicode
 BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
 RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight.  Do not enable this with audio at the same time.
 SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
+TAP_DANCE_ENABLE = yes      # Enable tap dance
 
 ifndef QUANTUM_DIR
 	include ../../../../Makefile

--- a/keyboards/satan/keymaps/smt/Makefile
+++ b/keyboards/satan/keymaps/smt/Makefile
@@ -15,7 +15,6 @@ UNICODE_ENABLE = no         # Unicode
 BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
 RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight.  Do not enable this with audio at the same time.
 SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
-TAP_DANCE_ENABLE = yes      # Enable tap dance
 
 ifndef QUANTUM_DIR
 	include ../../../../Makefile

--- a/keyboards/satan/keymaps/smt/keymap.c
+++ b/keyboards/satan/keymaps/smt/keymap.c
@@ -1,0 +1,204 @@
+#include "satan.h"
+
+
+// Used for SHIFT_ESC
+#define MODS_CTRL_MASK  (MOD_BIT(KC_LSHIFT)|MOD_BIT(KC_RSHIFT))
+
+// Each layer gets a name for readability, which is then used in the keymap matrix below.
+// The underscores don't mean anything - you can have a layer called STUFF or any other name.
+// Layer names don't all need to be of the same length, obviously, and you can also skip them
+// entirely and just use numbers.
+#define _QWERTY 0
+#define _COLEMAK 1
+#define _DVORAK 2
+#define _LOWER 3
+#define _RAISE 4
+
+enum planck_keycodes {
+  QWERTY = SAFE_RANGE,
+  COLEMAK,
+  DVORAK
+};
+
+#define _______ KC_TRNS
+#define XXXXXXX KC_NO
+
+// Custom macros
+#define CTL_ESC     CTL_T(KC_ESC)               // Tap for Esc, hold for Ctrl
+#define SFT_ENT     SFT_T(KC_ENT)               // Tap for Enter, hold for Shift
+#define HPR_TAB     ALL_T(KC_TAB)               // Tap for Tab, hold for Hyper (Super+Ctrl+Shift+Alt)
+#define ALT_GRV     ALT_T(KC_GRV)               // Tap for Backtick, hold for Alt
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  /* Keymap _QWERTY: (Base Layer) Default Layer
+   * ,-----------------------------------------------------------.
+   * |Esc~| 1|  2|  3|  4|  5|  6|  7|  8|  9|  0|  -|  =|Backsp |
+   * |-----------------------------------------------------------|
+   * |Tab  |  Q|  W|  E|  R|  T|  Y|  U|  I|  O|  P|  [|  ]|  \  |
+   * |-----------------------------------------------------------|
+   * |CAPS   |  A|  S|  D|  F|  G|  H|  J|  K|  L|  ;|  '|Return |
+   * |-----------------------------------------------------------|
+   * |Shift   |  Z|  X|  C|  V|  B|  N|  M|  ,|  .|  /|Shift     |
+   * |-----------------------------------------------------------|
+   * |Ctrl|Gui |Alt |      Space/Fn         |Alt |Gui |Fn  |Ctrl |
+   * `-----------------------------------------------------------'
+   */
+[_QWERTY] = KEYMAP_ANSI(
+  F(0),    KC_1,   KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,   KC_0,   KC_MINS, KC_EQL, KC_BSPC, \
+  HPR_TAB, KC_Q,   KC_W,   KC_E,   KC_R,   KC_T,   KC_Y,   KC_U,   KC_I,   KC_O,   KC_P,   KC_LBRC, KC_RBRC,KC_BSLS, \
+  CTL_ESC, KC_A,   KC_S,   KC_D,   KC_F,   KC_G,   KC_H,   KC_J,   KC_K,   KC_L,   KC_SCLN,KC_QUOT,         KC_ENT,  \
+  KC_LSFT,         KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,   KC_N,   KC_M,   KC_COMM,KC_DOT, KC_SLSH,         SFT_ENT, \
+  KC_LCTL, KC_LGUI,KC_LALT,                LT(_RAISE, KC_SPC),                     KC_RALT,KC_RGUI,MO(_LOWER),KC_RCTL),
+
+  /* Keymap _COLEMAK: (Base Layer) Default Layer
+   * ,-----------------------------------------------------------.
+   * |Esc~| 1|  2|  3|  4|  5|  6|  7|  8|  9|  0|  -|  =|Backsp |
+   * |-----------------------------------------------------------|
+   * |Tab  |  Q|  W|  F|  P|  G|  J|  L|  U|  Y|  ;|  [|  ]|  \  |
+   * |-----------------------------------------------------------|
+   * |CAPS   |  A|  R|  S|  T|  D|  H|  N|  E|  I|  O|  '|Return |
+   * |-----------------------------------------------------------|
+   * |Shift   |  Z|  X|  C|  V|  B|  K|  M|  ,|  .|  /|Shift     |
+   * |-----------------------------------------------------------|
+   * |Ctrl|Gui |Alt |      Space/Fn         |Alt |Gui |Fn  |Ctrl |
+   * `-----------------------------------------------------------'
+   */
+[_COLEMAK] = KEYMAP_ANSI(
+  F(0),    KC_1,   KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,   KC_0,   KC_MINS, KC_EQL, KC_BSPC, \
+  HPR_TAB, KC_Q,   KC_W,   KC_F,   KC_P,   KC_G,   KC_J,   KC_L,   KC_U,   KC_Y,   KC_SCLN,KC_LBRC, KC_RBRC,KC_BSLS, \
+  CTL_ESC, KC_A,   KC_R,   KC_S,   KC_T,   KC_D,   KC_H,   KC_N,   KC_E,   KC_I,   KC_O   ,KC_QUOT,         KC_ENT,  \
+  KC_LSFT,         KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,   KC_K,   KC_M,   KC_COMM,KC_DOT, KC_SLSH,         SFT_ENT, \
+  KC_LCTL, KC_LGUI,KC_LALT,                LT(_RAISE, KC_SPC),                     KC_RALT,KC_RGUI,MO(_LOWER),KC_RCTL),
+
+  /* Keymap _DVORAK: (Base Layer) Default Layer
+   * ,-----------------------------------------------------------.
+   * |Esc~| 1|  2|  3|  4|  5|  6|  7|  8|  9|  0|  [|  ]|Backsp |
+   * |-----------------------------------------------------------|
+   * |HypTb|  '|  ,|  .|  P|  Y|  F|  G|  C|  R|  L|  /|  =|  \  |
+   * |-----------------------------------------------------------|
+   * |CtrlEsc|  A|  O|  E|  U|  I|  D|  H|  T|  N|  S|  -|Return |
+   * |-----------------------------------------------------------|
+   * |Shift   |  ;|  Q|  J|  K|  X|  B|  M|  W|  V|  Z|ShiftEnter|
+   * |-----------------------------------------------------------|
+   * |Ctrl|Gui |Alt |      Space/Fn         |Alt |Gui |Fn  |Ctrl |
+   * `-----------------------------------------------------------'
+   */
+[_DVORAK] = KEYMAP_ANSI(
+  F(0),    KC_1,   KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,   KC_0,   KC_LBRC, KC_RBRC,KC_BSPC, \
+  HPR_TAB, KC_QUOT,KC_COMM,KC_DOT, KC_P,   KC_Y,   KC_F,   KC_G,   KC_C,   KC_R,   KC_L,   KC_SLSH, KC_EQL, KC_BSLS, \
+  CTL_ESC, KC_A,   KC_O,   KC_E,   KC_U,   KC_I,   KC_D,   KC_H,   KC_T,   KC_N,   KC_S,   KC_MINS,         KC_ENT,  \
+  KC_LSFT,         KC_SCLN,KC_Q,   KC_J,   KC_K,   KC_X,   KC_B,   KC_M,   KC_W,   KC_V,   KC_Z,            SFT_ENT, \
+  KC_LCTL, KC_LGUI,KC_LALT,                LT(_RAISE, KC_SPC),                     KC_RALT,KC_RGUI,MO(_LOWER),KC_RCTL),
+
+  /* Keymap _LOWER: Function Layer
+   * ,-----------------------------------------------------------.
+   * |   | F1| F2| F3| F4| F5| F6| F7| F8| F9|F10|F11|F12|Delete |
+   * |-----------------------------------------------------------|
+   * |     |Hom| UP|End|   |   |   |   |   |   |   |Vo-|Vo+|     |
+   * |-----------------------------------------------------------|
+   * |      |LFT| DN| RT|   |   |LFT| DN| UP| RT|   |Pg+|        |
+   * |-----------------------------------------------------------|
+   * |        |   |   |   |   |   |   |   |   |   |Pg-|          |
+   * |-----------------------------------------------------------|
+   * |    |    |Prev|         Play           |Next|    |    |    |
+   * `-----------------------------------------------------------'
+   */
+[_LOWER] = KEYMAP_ANSI(
+  KC_GRV ,KC_F1  ,KC_F2  ,KC_F3  ,KC_F4  ,KC_F5  ,KC_F6  ,KC_F7  ,KC_F8  ,KC_F9  ,KC_F10 ,KC_F11 ,KC_F12 ,KC_DEL,  \
+  _______,KC_HOME,KC_UP  ,KC_END ,_______,_______,_______,_______,_______,_______,_______,KC_VOLD,KC_VOLU,_______, \
+  _______,KC_LEFT,KC_DOWN,KC_RGHT,_______,_______,KC_LEFT,KC_DOWN,KC_UP  ,KC_RGHT,_______,KC_PGUP        ,_______, \
+  _______        ,_______,_______,_______,_______,_______,_______,_______,_______,_______,KC_PGDN        ,_______, \
+  _______,_______,KC_MPRV                        ,KC_MPLY                        ,KC_MNXT,_______,_______,_______),
+
+  /* Keymap _RAISE: Function Layer
+   * ,-----------------------------------------------------------.
+   * |   |   |   |   |   |   |   |   |   |   |   |   |   | RESET |
+   * |-----------------------------------------------------------|
+   * |     |   |   |   |   |   |   |   |   |   |   |BL-|BL+|BL   |
+   * |-----------------------------------------------------------|
+   * |      |   |   |   |   |   |   |QWT|CLM|DVK|   |   |        |
+   * |-----------------------------------------------------------|
+   * |        | F1|F2 | F3|F4 | F5| F6| F7| F8|   |   |          |
+   * |-----------------------------------------------------------|
+   * |    |    |    |                        |    |    |    |    |
+   * `-----------------------------------------------------------'
+   */
+[_RAISE] = KEYMAP_ANSI(
+  #ifdef RGBLIGHT_ENABLE
+  _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,RESET  , \
+  _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,BL_DEC ,BL_INC ,BL_TOGG, \
+  _______,_______,_______,_______,_______,_______,_______,QWERTY ,COLEMAK,DVORAK ,_______,_______        ,_______, \
+  _______        ,RGB_TOG,RGB_MOD,RGB_HUI,RGB_HUD,RGB_SAI,RGB_SAD,RGB_VAI,RGB_VAD,_______,_______        ,_______, \
+  _______,_______,_______                        ,_______                        ,_______,_______,_______,_______
+  #else
+  _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,RESET  , \
+  _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,BL_DEC ,BL_INC ,BL_TOGG, \
+  _______,_______,_______,_______,_______,_______,_______,QWERTY ,COLEMAK,DVORAK ,_______,_______        ,_______, \
+  _______        ,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______        ,_______, \
+  _______,_______,_______                        ,_______                        ,_______,_______,XXXXXXX,_______
+  #endif
+  )
+};
+
+void persistant_default_layer_set(uint16_t default_layer) {
+  eeconfig_update_default_layer(default_layer);
+  default_layer_set(default_layer);
+}
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  switch (keycode) {
+    case QWERTY:
+      if (record->event.pressed) {
+        persistant_default_layer_set(1UL<<_QWERTY);
+      }
+      return false;
+      break;
+    case COLEMAK:
+      if (record->event.pressed) {
+        persistant_default_layer_set(1UL<<_COLEMAK);
+      }
+      return false;
+      break;
+    case DVORAK:
+      if (record->event.pressed) {
+        persistant_default_layer_set(1UL<<_DVORAK);
+      }
+      return false;
+      break;
+  }
+  return true;
+}
+
+enum function_id {
+    SHIFT_ESC,
+};
+
+const uint16_t PROGMEM fn_actions[] = {
+  [0]  = ACTION_FUNCTION(SHIFT_ESC),
+};
+
+void action_function(keyrecord_t *record, uint8_t id, uint8_t opt) {
+  static uint8_t shift_esc_shift_mask;
+  switch (id) {
+    case SHIFT_ESC:
+      shift_esc_shift_mask = get_mods()&MODS_CTRL_MASK;
+      if (record->event.pressed) {
+        if (shift_esc_shift_mask) {
+          add_key(KC_GRV);
+          send_keyboard_report();
+        } else {
+          add_key(KC_ESC);
+          send_keyboard_report();
+        }
+      } else {
+        if (shift_esc_shift_mask) {
+          del_key(KC_GRV);
+          send_keyboard_report();
+        } else {
+          del_key(KC_ESC);
+          send_keyboard_report();
+        }
+      }
+      break;
+  }
+}

--- a/keyboards/satan/keymaps/smt/keymap.c
+++ b/keyboards/satan/keymaps/smt/keymap.c
@@ -17,11 +17,9 @@
 enum planck_keycodes {
   QWERTY = SAFE_RANGE,
   COLEMAK,
-  DVORAK
-};
-
-enum {
-  TD_SHIFT_RAISE = 0
+  DVORAK,
+  LOWER,
+  RAISE
 };
 
 #define _______ KC_TRNS
@@ -32,7 +30,6 @@ enum {
 #define CTL_ESC     CTL_T(KC_ESC)               // Tap for Esc, hold for Ctrl
 #define HPR_TAB     ALL_T(KC_TAB)               // Tap for Tab, hold for Hyper (Super+Ctrl+Shift+Alt)
 #define SFT_ENT     SFT_T(KC_ENT)               // Tap for Enter, hold for Shift
-#define SFT_RSE     TD(TD_SHIFT_RAISE)          // Double-tap for RAISE one-shot, otherwise Left Shift
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   /* Keymap _QWERTY: (Base Layer) Default Layer
@@ -52,7 +49,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   KC_GRV,  KC_1,   KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,   KC_0,   KC_MINS, KC_EQL, KC_BSPC, \
   HPR_TAB, KC_Q,   KC_W,   KC_E,   KC_R,   KC_T,   KC_Y,   KC_U,   KC_I,   KC_O,   KC_P,   KC_LBRC, KC_RBRC,KC_BSLS, \
   CTL_ESC, KC_A,   KC_S,   KC_D,   KC_F,   KC_G,   KC_H,   KC_J,   KC_K,   KC_L,   KC_SCLN,KC_QUOT,         KC_ENT,  \
-  SFT_RSE,         KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,   KC_N,   KC_M,   KC_COMM,KC_DOT, KC_SLSH,         SFT_ENT, \
+  KC_LSFT,         KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,   KC_N,   KC_M,   KC_COMM,KC_DOT, KC_SLSH,         SFT_ENT, \
   KC_LCTL, KC_LGUI,KC_LALT,                      KC_SPC,                           KC_RALT,KC_RGUI,MO(_LOWER),KC_RCTL),
 
   /* Keymap _COLEMAK: (Base Layer) Default Layer
@@ -72,7 +69,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   KC_GRV,  KC_1,   KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,   KC_0,   KC_MINS, KC_EQL, KC_BSPC, \
   HPR_TAB, KC_Q,   KC_W,   KC_F,   KC_P,   KC_G,   KC_J,   KC_L,   KC_U,   KC_Y,   KC_SCLN,KC_LBRC, KC_RBRC,KC_BSLS, \
   CTL_ESC, KC_A,   KC_R,   KC_S,   KC_T,   KC_D,   KC_H,   KC_N,   KC_E,   KC_I,   KC_O   ,KC_QUOT,         KC_ENT,  \
-  SFT_RSE,         KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,   KC_K,   KC_M,   KC_COMM,KC_DOT, KC_SLSH,         SFT_ENT, \
+  KC_LSFT,         KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,   KC_K,   KC_M,   KC_COMM,KC_DOT, KC_SLSH,         SFT_ENT, \
   KC_LCTL, KC_LGUI,KC_LALT,                      KC_SPC,                           KC_RALT,KC_RGUI,MO(_LOWER),KC_RCTL),
 
   /* Keymap _DVORAK: (Base Layer) Default Layer
@@ -92,7 +89,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   KC_GRV,  KC_1,   KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,   KC_0,   KC_LBRC, KC_RBRC,KC_BSPC, \
   HPR_TAB, KC_QUOT,KC_COMM,KC_DOT, KC_P,   KC_Y,   KC_F,   KC_G,   KC_C,   KC_R,   KC_L,   KC_SLSH, KC_EQL, KC_BSLS, \
   CTL_ESC, KC_A,   KC_O,   KC_E,   KC_U,   KC_I,   KC_D,   KC_H,   KC_T,   KC_N,   KC_S,   KC_MINS,         KC_ENT,  \
-  SFT_RSE,         KC_SCLN,KC_Q,   KC_J,   KC_K,   KC_X,   KC_B,   KC_M,   KC_W,   KC_V,   KC_Z,            SFT_ENT, \
+  KC_LSFT,         KC_SCLN,KC_Q,   KC_J,   KC_K,   KC_X,   KC_B,   KC_M,   KC_W,   KC_V,   KC_Z,            SFT_ENT, \
   KC_LCTL, KC_LGUI,KC_LALT,                      KC_SPC,                           KC_RALT,KC_RGUI,MO(_LOWER),KC_RCTL),
 
   /* Keymap _LOWER: Function Layer
@@ -112,7 +109,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   _______,KC_F1  ,KC_F2  ,KC_F3  ,KC_F4  ,KC_F5  ,KC_F6  ,KC_F7  ,KC_F8  ,KC_F9  ,KC_F10 ,KC_F11 ,KC_F12 ,KC_DEL,  \
   _______,KC_HOME,KC_UP  ,KC_END ,_______,_______,_______,_______,_______,_______,_______,BL_DEC ,BL_INC ,BL_TOGG, \
   _______,KC_LEFT,KC_DOWN,KC_RGHT,_______,_______,KC_LEFT,KC_DOWN,KC_UP  ,KC_RGHT,KC_VOLU,KC_PGUP        ,_______, \
-  KC_LSFT        ,_______,_______,KC_MPRV,KC_MPLY,KC_MNXT,_______,_______,_______,KC_VOLD,KC_PGDN        ,_______, \
+  RAISE          ,_______,_______,KC_MPRV,KC_MPLY,KC_MNXT,_______,_______,_______,KC_VOLD,KC_PGDN        ,_______, \
   _______,_______,_______                        ,_______                        ,_______,_______,_______,_______),
 
   /* Keymap _RAISE: Function Layer
@@ -133,14 +130,14 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,RESET  , \
   _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______, \
   _______,_______,_______,_______,_______,_______,_______,QWERTY ,COLEMAK,DVORAK ,_______,_______        ,_______, \
-  KC_LSFT        ,RGB_TOG,RGB_MOD,RGB_HUI,RGB_HUD,RGB_SAI,RGB_SAD,RGB_VAI,RGB_VAD,_______,_______        ,_______, \
-  _______,_______,_______                        ,_______                        ,_______,_______,XXXXXXX,_______
+  _______        ,RGB_TOG,RGB_MOD,RGB_HUI,RGB_HUD,RGB_SAI,RGB_SAD,RGB_VAI,RGB_VAD,_______,_______        ,_______, \
+  _______,_______,_______                        ,_______                        ,_______,_______,_______,_______
   #else
   _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,RESET  , \
   _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______, \
   _______,_______,_______,_______,_______,_______,_______,QWERTY ,COLEMAK,DVORAK ,_______,_______        ,_______, \
-  KC_LSFT        ,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______        ,_______, \
-  _______,_______,_______                        ,_______                        ,_______,_______,XXXXXXX,_______
+  _______        ,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______        ,_______, \
+  _______,_______,_______                        ,_______                        ,_______,_______,_______,_______
   #endif
   )
 };
@@ -173,10 +170,3 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
   }
   return true;
 }
-
-// Tap Dance Definitions
-qk_tap_dance_action_t tap_dance_actions[] = {
-  // Tap/hold once for Shift, tap twice for raise layer
-  [TD_SHIFT_RAISE] = ACTION_TAP_DANCE_DOUBLE(KC_LSFT, _RAISE)
-// Other declarations would go here, separated by commas, if you have them
-};

--- a/keyboards/satan/keymaps/smt/keymap.c
+++ b/keyboards/satan/keymaps/smt/keymap.c
@@ -49,7 +49,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    * `-----------------------------------------------------------'
    */
 [_QWERTY] = KEYMAP_ANSI(
-  F(0),    KC_1,   KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,   KC_0,   KC_MINS, KC_EQL, KC_BSPC, \
+  KC_GRV,  KC_1,   KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,   KC_0,   KC_MINS, KC_EQL, KC_BSPC, \
   HPR_TAB, KC_Q,   KC_W,   KC_E,   KC_R,   KC_T,   KC_Y,   KC_U,   KC_I,   KC_O,   KC_P,   KC_LBRC, KC_RBRC,KC_BSLS, \
   CTL_ESC, KC_A,   KC_S,   KC_D,   KC_F,   KC_G,   KC_H,   KC_J,   KC_K,   KC_L,   KC_SCLN,KC_QUOT,         KC_ENT,  \
   SFT_RSE,         KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,   KC_N,   KC_M,   KC_COMM,KC_DOT, KC_SLSH,         SFT_ENT, \
@@ -69,7 +69,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    * `-----------------------------------------------------------'
    */
 [_COLEMAK] = KEYMAP_ANSI(
-  F(0),    KC_1,   KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,   KC_0,   KC_MINS, KC_EQL, KC_BSPC, \
+  KC_GRV,  KC_1,   KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,   KC_0,   KC_MINS, KC_EQL, KC_BSPC, \
   HPR_TAB, KC_Q,   KC_W,   KC_F,   KC_P,   KC_G,   KC_J,   KC_L,   KC_U,   KC_Y,   KC_SCLN,KC_LBRC, KC_RBRC,KC_BSLS, \
   CTL_ESC, KC_A,   KC_R,   KC_S,   KC_T,   KC_D,   KC_H,   KC_N,   KC_E,   KC_I,   KC_O   ,KC_QUOT,         KC_ENT,  \
   SFT_RSE,         KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,   KC_K,   KC_M,   KC_COMM,KC_DOT, KC_SLSH,         SFT_ENT, \
@@ -89,7 +89,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    * `-----------------------------------------------------------'
    */
 [_DVORAK] = KEYMAP_ANSI(
-  F(0),    KC_1,   KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,   KC_0,   KC_LBRC, KC_RBRC,KC_BSPC, \
+  KC_GRV,  KC_1,   KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,   KC_0,   KC_LBRC, KC_RBRC,KC_BSPC, \
   HPR_TAB, KC_QUOT,KC_COMM,KC_DOT, KC_P,   KC_Y,   KC_F,   KC_G,   KC_C,   KC_R,   KC_L,   KC_SLSH, KC_EQL, KC_BSLS, \
   CTL_ESC, KC_A,   KC_O,   KC_E,   KC_U,   KC_I,   KC_D,   KC_H,   KC_T,   KC_N,   KC_S,   KC_MINS,         KC_ENT,  \
   SFT_RSE,         KC_SCLN,KC_Q,   KC_J,   KC_K,   KC_X,   KC_B,   KC_M,   KC_W,   KC_V,   KC_Z,            SFT_ENT, \
@@ -109,7 +109,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    * `-----------------------------------------------------------'
    */
 [_LOWER] = KEYMAP_ANSI(
-  KC_GRV ,KC_F1  ,KC_F2  ,KC_F3  ,KC_F4  ,KC_F5  ,KC_F6  ,KC_F7  ,KC_F8  ,KC_F9  ,KC_F10 ,KC_F11 ,KC_F12 ,KC_DEL,  \
+  _______,KC_F1  ,KC_F2  ,KC_F3  ,KC_F4  ,KC_F5  ,KC_F6  ,KC_F7  ,KC_F8  ,KC_F9  ,KC_F10 ,KC_F11 ,KC_F12 ,KC_DEL,  \
   _______,KC_HOME,KC_UP  ,KC_END ,_______,_______,_______,_______,_______,_______,_______,BL_DEC ,BL_INC ,BL_TOGG, \
   _______,KC_LEFT,KC_DOWN,KC_RGHT,_______,_______,KC_LEFT,KC_DOWN,KC_UP  ,KC_RGHT,KC_VOLU,KC_PGUP        ,_______, \
   KC_LSFT        ,_______,_______,KC_MPRV,KC_MPLY,KC_MNXT,_______,_______,_______,KC_VOLD,KC_PGDN        ,_______, \

--- a/keyboards/satan/keymaps/smt/keymap.c
+++ b/keyboards/satan/keymaps/smt/keymap.c
@@ -24,10 +24,11 @@ enum planck_keycodes {
 #define XXXXXXX KC_NO
 
 // Custom macros
-#define CTL_ESC     CTL_T(KC_ESC)               // Tap for Esc, hold for Ctrl
-#define SFT_ENT     SFT_T(KC_ENT)               // Tap for Enter, hold for Shift
-#define HPR_TAB     ALL_T(KC_TAB)               // Tap for Tab, hold for Hyper (Super+Ctrl+Shift+Alt)
 #define ALT_GRV     ALT_T(KC_GRV)               // Tap for Backtick, hold for Alt
+#define CTL_ESC     CTL_T(KC_ESC)               // Tap for Esc, hold for Ctrl
+#define HPR_TAB     ALL_T(KC_TAB)               // Tap for Tab, hold for Hyper (Super+Ctrl+Shift+Alt)
+#define SFT_ENT     SFT_T(KC_ENT)               // Tap for Enter, hold for Shift
+#define SFT_RSE     TD(KC_LSFT, OS(_RAISE))     // Double-tap for RAISE one-shot, otherwise Left Shift
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   /* Keymap _QWERTY: (Base Layer) Default Layer
@@ -40,15 +41,15 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    * |-----------------------------------------------------------|
    * |Shift   |  Z|  X|  C|  V|  B|  N|  M|  ,|  .|  /|Shift     |
    * |-----------------------------------------------------------|
-   * |Ctrl|Gui |Alt |      Space/Fn         |Alt |Gui |Fn  |Ctrl |
+   * |Ctrl|Gui |Alt |         Space         |Alt |Gui |Fn  |Ctrl |
    * `-----------------------------------------------------------'
    */
 [_QWERTY] = KEYMAP_ANSI(
   F(0),    KC_1,   KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,   KC_0,   KC_MINS, KC_EQL, KC_BSPC, \
   HPR_TAB, KC_Q,   KC_W,   KC_E,   KC_R,   KC_T,   KC_Y,   KC_U,   KC_I,   KC_O,   KC_P,   KC_LBRC, KC_RBRC,KC_BSLS, \
   CTL_ESC, KC_A,   KC_S,   KC_D,   KC_F,   KC_G,   KC_H,   KC_J,   KC_K,   KC_L,   KC_SCLN,KC_QUOT,         KC_ENT,  \
-  KC_LSFT,         KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,   KC_N,   KC_M,   KC_COMM,KC_DOT, KC_SLSH,         SFT_ENT, \
-  KC_LCTL, KC_LGUI,KC_LALT,                LT(_RAISE, KC_SPC),                     KC_RALT,KC_RGUI,MO(_LOWER),KC_RCTL),
+  SFT_RSE,         KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,   KC_N,   KC_M,   KC_COMM,KC_DOT, KC_SLSH,         SFT_ENT, \
+  KC_LCTL, KC_LGUI,KC_LALT,                      KC_SPC,                           KC_RALT,KC_RGUI,MO(_LOWER),KC_RCTL),
 
   /* Keymap _COLEMAK: (Base Layer) Default Layer
    * ,-----------------------------------------------------------.
@@ -60,15 +61,15 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    * |-----------------------------------------------------------|
    * |Shift   |  Z|  X|  C|  V|  B|  K|  M|  ,|  .|  /|Shift     |
    * |-----------------------------------------------------------|
-   * |Ctrl|Gui |Alt |      Space/Fn         |Alt |Gui |Fn  |Ctrl |
+   * |Ctrl|Gui |Alt |         Space         |Alt |Gui |Fn  |Ctrl |
    * `-----------------------------------------------------------'
    */
 [_COLEMAK] = KEYMAP_ANSI(
   F(0),    KC_1,   KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,   KC_0,   KC_MINS, KC_EQL, KC_BSPC, \
   HPR_TAB, KC_Q,   KC_W,   KC_F,   KC_P,   KC_G,   KC_J,   KC_L,   KC_U,   KC_Y,   KC_SCLN,KC_LBRC, KC_RBRC,KC_BSLS, \
   CTL_ESC, KC_A,   KC_R,   KC_S,   KC_T,   KC_D,   KC_H,   KC_N,   KC_E,   KC_I,   KC_O   ,KC_QUOT,         KC_ENT,  \
-  KC_LSFT,         KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,   KC_K,   KC_M,   KC_COMM,KC_DOT, KC_SLSH,         SFT_ENT, \
-  KC_LCTL, KC_LGUI,KC_LALT,                LT(_RAISE, KC_SPC),                     KC_RALT,KC_RGUI,MO(_LOWER),KC_RCTL),
+  SFT_RSE,         KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,   KC_K,   KC_M,   KC_COMM,KC_DOT, KC_SLSH,         SFT_ENT, \
+  KC_LCTL, KC_LGUI,KC_LALT,                      KC_SPC,                           KC_RALT,KC_RGUI,MO(_LOWER),KC_RCTL),
 
   /* Keymap _DVORAK: (Base Layer) Default Layer
    * ,-----------------------------------------------------------.
@@ -80,35 +81,35 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    * |-----------------------------------------------------------|
    * |Shift   |  ;|  Q|  J|  K|  X|  B|  M|  W|  V|  Z|ShiftEnter|
    * |-----------------------------------------------------------|
-   * |Ctrl|Gui |Alt |      Space/Fn         |Alt |Gui |Fn  |Ctrl |
+   * |Ctrl|Gui |Alt |         Space         |Alt |Gui |Fn  |Ctrl |
    * `-----------------------------------------------------------'
    */
 [_DVORAK] = KEYMAP_ANSI(
   F(0),    KC_1,   KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,   KC_0,   KC_LBRC, KC_RBRC,KC_BSPC, \
   HPR_TAB, KC_QUOT,KC_COMM,KC_DOT, KC_P,   KC_Y,   KC_F,   KC_G,   KC_C,   KC_R,   KC_L,   KC_SLSH, KC_EQL, KC_BSLS, \
   CTL_ESC, KC_A,   KC_O,   KC_E,   KC_U,   KC_I,   KC_D,   KC_H,   KC_T,   KC_N,   KC_S,   KC_MINS,         KC_ENT,  \
-  KC_LSFT,         KC_SCLN,KC_Q,   KC_J,   KC_K,   KC_X,   KC_B,   KC_M,   KC_W,   KC_V,   KC_Z,            SFT_ENT, \
-  KC_LCTL, KC_LGUI,KC_LALT,                LT(_RAISE, KC_SPC),                     KC_RALT,KC_RGUI,MO(_LOWER),KC_RCTL),
+  SFT_RSE,         KC_SCLN,KC_Q,   KC_J,   KC_K,   KC_X,   KC_B,   KC_M,   KC_W,   KC_V,   KC_Z,            SFT_ENT, \
+  KC_LCTL, KC_LGUI,KC_LALT,                      KC_SPC,                           KC_RALT,KC_RGUI,MO(_LOWER),KC_RCTL),
 
   /* Keymap _LOWER: Function Layer
    * ,-----------------------------------------------------------.
    * |   | F1| F2| F3| F4| F5| F6| F7| F8| F9|F10|F11|F12|Delete |
    * |-----------------------------------------------------------|
-   * |     |Hom| UP|End|   |   |   |   |   |   |   |Vo-|Vo+|     |
+   * |     |Hom| UP|End|   |   |   |   |   |   |   |BL-|BL+|BL   |
    * |-----------------------------------------------------------|
-   * |      |LFT| DN| RT|   |   |LFT| DN| UP| RT|   |Pg+|        |
+   * |      |LFT| DN| RT|   |   |LFT| DN| UP| RT|Vo+|Pg+|        |
    * |-----------------------------------------------------------|
-   * |        |   |   |   |   |   |   |   |   |   |Pg-|          |
+   * |        |   |   |Prv|Ply|Nxt|   |   |   |Vo-|Pg-|          |
    * |-----------------------------------------------------------|
-   * |    |    |Prev|         Play           |Next|    |    |    |
+   * |    |    |    |                        |    |    |    |    |
    * `-----------------------------------------------------------'
    */
 [_LOWER] = KEYMAP_ANSI(
   KC_GRV ,KC_F1  ,KC_F2  ,KC_F3  ,KC_F4  ,KC_F5  ,KC_F6  ,KC_F7  ,KC_F8  ,KC_F9  ,KC_F10 ,KC_F11 ,KC_F12 ,KC_DEL,  \
-  _______,KC_HOME,KC_UP  ,KC_END ,_______,_______,_______,_______,_______,_______,_______,KC_VOLD,KC_VOLU,_______, \
-  _______,KC_LEFT,KC_DOWN,KC_RGHT,_______,_______,KC_LEFT,KC_DOWN,KC_UP  ,KC_RGHT,_______,KC_PGUP        ,_______, \
-  _______        ,_______,_______,_______,_______,_______,_______,_______,_______,_______,KC_PGDN        ,_______, \
-  _______,_______,KC_MPRV                        ,KC_MPLY                        ,KC_MNXT,_______,_______,_______),
+  _______,KC_HOME,KC_UP  ,KC_END ,_______,_______,_______,_______,_______,_______,_______,BL_DEC ,BL_INC ,BL_TOGG, \
+  _______,KC_LEFT,KC_DOWN,KC_RGHT,_______,_______,KC_LEFT,KC_DOWN,KC_UP  ,KC_RGHT,KC_VOLU,KC_PGUP        ,_______, \
+  KC_LSFT        ,_______,_______,KC_MPRV,KC_MPLY,KC_MNXT,_______,_______,_______,KC_VOLD,KC_PGDN        ,_______, \
+  _______,_______,_______                        ,_______                        ,_______,_______,_______,_______),
 
   /* Keymap _RAISE: Function Layer
    * ,-----------------------------------------------------------.
@@ -126,15 +127,15 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 [_RAISE] = KEYMAP_ANSI(
   #ifdef RGBLIGHT_ENABLE
   _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,RESET  , \
-  _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,BL_DEC ,BL_INC ,BL_TOGG, \
+  _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______, \
   _______,_______,_______,_______,_______,_______,_______,QWERTY ,COLEMAK,DVORAK ,_______,_______        ,_______, \
-  _______        ,RGB_TOG,RGB_MOD,RGB_HUI,RGB_HUD,RGB_SAI,RGB_SAD,RGB_VAI,RGB_VAD,_______,_______        ,_______, \
-  _______,_______,_______                        ,_______                        ,_______,_______,_______,_______
+  KC_LSFT        ,RGB_TOG,RGB_MOD,RGB_HUI,RGB_HUD,RGB_SAI,RGB_SAD,RGB_VAI,RGB_VAD,_______,_______        ,_______, \
+  _______,_______,_______                        ,_______                        ,_______,_______,XXXXXXX,_______
   #else
   _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,RESET  , \
-  _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,BL_DEC ,BL_INC ,BL_TOGG, \
+  _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______, \
   _______,_______,_______,_______,_______,_______,_______,QWERTY ,COLEMAK,DVORAK ,_______,_______        ,_______, \
-  _______        ,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______        ,_______, \
+  KC_LSFT        ,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______        ,_______, \
   _______,_______,_______                        ,_______                        ,_______,_______,XXXXXXX,_______
   #endif
   )

--- a/keyboards/satan/keymaps/smt/keymap.c
+++ b/keyboards/satan/keymaps/smt/keymap.c
@@ -11,15 +11,12 @@
 #define _QWERTY 0
 #define _COLEMAK 1
 #define _DVORAK 2
-#define _LOWER 3
-#define _RAISE 4
+#define _FUNC 3
 
 enum planck_keycodes {
   QWERTY = SAFE_RANGE,
   COLEMAK,
-  DVORAK,
-  LOWER,
-  RAISE
+  DVORAK
 };
 
 #define _______ KC_TRNS
@@ -50,7 +47,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   HPR_TAB, KC_Q,   KC_W,   KC_E,   KC_R,   KC_T,   KC_Y,   KC_U,   KC_I,   KC_O,   KC_P,   KC_LBRC, KC_RBRC,KC_BSLS, \
   CTL_ESC, KC_A,   KC_S,   KC_D,   KC_F,   KC_G,   KC_H,   KC_J,   KC_K,   KC_L,   KC_SCLN,KC_QUOT,         KC_ENT,  \
   KC_LSFT,         KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,   KC_N,   KC_M,   KC_COMM,KC_DOT, KC_SLSH,         SFT_ENT, \
-  KC_LCTL, KC_LGUI,KC_LALT,                      KC_SPC,                           KC_RALT,KC_RGUI,MO(_LOWER),KC_RCTL),
+  KC_LCTL, KC_LGUI,KC_LALT,                      KC_SPC,                           KC_RALT,KC_RGUI,MO(_FUNC),KC_RCTL),
 
   /* Keymap _COLEMAK: (Base Layer) Default Layer
    * ,-----------------------------------------------------------.
@@ -70,7 +67,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   HPR_TAB, KC_Q,   KC_W,   KC_F,   KC_P,   KC_G,   KC_J,   KC_L,   KC_U,   KC_Y,   KC_SCLN,KC_LBRC, KC_RBRC,KC_BSLS, \
   CTL_ESC, KC_A,   KC_R,   KC_S,   KC_T,   KC_D,   KC_H,   KC_N,   KC_E,   KC_I,   KC_O   ,KC_QUOT,         KC_ENT,  \
   KC_LSFT,         KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,   KC_K,   KC_M,   KC_COMM,KC_DOT, KC_SLSH,         SFT_ENT, \
-  KC_LCTL, KC_LGUI,KC_LALT,                      KC_SPC,                           KC_RALT,KC_RGUI,MO(_LOWER),KC_RCTL),
+  KC_LCTL, KC_LGUI,KC_LALT,                      KC_SPC,                           KC_RALT,KC_RGUI,MO(_FUNC),KC_RCTL),
 
   /* Keymap _DVORAK: (Base Layer) Default Layer
    * ,-----------------------------------------------------------.
@@ -90,55 +87,27 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   HPR_TAB, KC_QUOT,KC_COMM,KC_DOT, KC_P,   KC_Y,   KC_F,   KC_G,   KC_C,   KC_R,   KC_L,   KC_SLSH, KC_EQL, KC_BSLS, \
   CTL_ESC, KC_A,   KC_O,   KC_E,   KC_U,   KC_I,   KC_D,   KC_H,   KC_T,   KC_N,   KC_S,   KC_MINS,         KC_ENT,  \
   KC_LSFT,         KC_SCLN,KC_Q,   KC_J,   KC_K,   KC_X,   KC_B,   KC_M,   KC_W,   KC_V,   KC_Z,            SFT_ENT, \
-  KC_LCTL, KC_LGUI,KC_LALT,                      KC_SPC,                           KC_RALT,KC_RGUI,MO(_LOWER),KC_RCTL),
+  KC_LCTL, KC_LGUI,KC_LALT,                      KC_SPC,                           KC_RALT,KC_RGUI,MO(_FUNC),KC_RCTL),
 
-  /* Keymap _LOWER: Function Layer
+  /* Keymap _FUNC: Function Layer
    * ,-----------------------------------------------------------.
    * |   | F1| F2| F3| F4| F5| F6| F7| F8| F9|F10|F11|F12|Delete |
    * |-----------------------------------------------------------|
-   * |     |Hom| UP|End|   |   |   |   |   |   |   |BL-|BL+|BL   |
+   * |     |Hom| UP|End|   |   |   |Qwt|Cmk|Dvk|   |BL-|BL+|BL   |
    * |-----------------------------------------------------------|
    * |      |LFT| DN| RT|   |   |LFT| DN| UP| RT|Vo+|Pg+|        |
    * |-----------------------------------------------------------|
    * |        |   |   |Prv|Ply|Nxt|   |   |   |Vo-|Pg-|          |
    * |-----------------------------------------------------------|
-   * |    |    |    |                        |    |    |    |    |
+   * |RESET|    |    |                       |    |    |    |    |
    * `-----------------------------------------------------------'
    */
-[_LOWER] = KEYMAP_ANSI(
+[_FUNC] = KEYMAP_ANSI(
   _______,KC_F1  ,KC_F2  ,KC_F3  ,KC_F4  ,KC_F5  ,KC_F6  ,KC_F7  ,KC_F8  ,KC_F9  ,KC_F10 ,KC_F11 ,KC_F12 ,KC_DEL,  \
-  _______,KC_HOME,KC_UP  ,KC_END ,_______,_______,_______,_______,_______,_______,_______,BL_DEC ,BL_INC ,BL_TOGG, \
+  _______,KC_HOME,KC_UP  ,KC_END ,_______,_______,_______,QWERTY ,COLEMAK,DVORAK ,_______,BL_DEC ,BL_INC ,BL_TOGG, \
   _______,KC_LEFT,KC_DOWN,KC_RGHT,_______,_______,KC_LEFT,KC_DOWN,KC_UP  ,KC_RGHT,KC_VOLU,KC_PGUP        ,_______, \
-  RAISE          ,_______,_______,KC_MPRV,KC_MPLY,KC_MNXT,_______,_______,_______,KC_VOLD,KC_PGDN        ,_______, \
-  _______,_______,_______                        ,_______                        ,_______,_______,_______,_______),
-
-  /* Keymap _RAISE: Function Layer
-   * ,-----------------------------------------------------------.
-   * |   |   |   |   |   |   |   |   |   |   |   |   |   | RESET |
-   * |-----------------------------------------------------------|
-   * |     |   |   |   |   |   |   |   |   |   |   |BL-|BL+|BL   |
-   * |-----------------------------------------------------------|
-   * |      |   |   |   |   |   |   |QWT|CLM|DVK|   |   |        |
-   * |-----------------------------------------------------------|
-   * |        | F1|F2 | F3|F4 | F5| F6| F7| F8|   |   |          |
-   * |-----------------------------------------------------------|
-   * |    |    |    |                        |    |    |    |    |
-   * `-----------------------------------------------------------'
-   */
-[_RAISE] = KEYMAP_ANSI(
-  #ifdef RGBLIGHT_ENABLE
-  _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,RESET  , \
-  _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______, \
-  _______,_______,_______,_______,_______,_______,_______,QWERTY ,COLEMAK,DVORAK ,_______,_______        ,_______, \
-  _______        ,RGB_TOG,RGB_MOD,RGB_HUI,RGB_HUD,RGB_SAI,RGB_SAD,RGB_VAI,RGB_VAD,_______,_______        ,_______, \
-  _______,_______,_______                        ,_______                        ,_______,_______,_______,_______
-  #else
-  _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,RESET  , \
-  _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______, \
-  _______,_______,_______,_______,_______,_______,_______,QWERTY ,COLEMAK,DVORAK ,_______,_______        ,_______, \
-  _______        ,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______        ,_______, \
-  _______,_______,_______                        ,_______                        ,_______,_______,_______,_______
-  #endif
+  _______        ,_______,_______,KC_MPRV,KC_MPLY,KC_MNXT,_______,_______,_______,KC_VOLD,KC_PGDN        ,_______, \
+  RESET  ,_______,_______                        ,_______                        ,_______,_______,_______,_______
   )
 };
 

--- a/keyboards/satan/keymaps/smt/keymap.c
+++ b/keyboards/satan/keymaps/smt/keymap.c
@@ -20,6 +20,10 @@ enum planck_keycodes {
   DVORAK
 };
 
+enum {
+  TD_SHIFT_RAISE = 0
+};
+
 #define _______ KC_TRNS
 #define XXXXXXX KC_NO
 
@@ -28,7 +32,7 @@ enum planck_keycodes {
 #define CTL_ESC     CTL_T(KC_ESC)               // Tap for Esc, hold for Ctrl
 #define HPR_TAB     ALL_T(KC_TAB)               // Tap for Tab, hold for Hyper (Super+Ctrl+Shift+Alt)
 #define SFT_ENT     SFT_T(KC_ENT)               // Tap for Enter, hold for Shift
-#define SFT_RSE     TD(KC_LSFT, OS(_RAISE))     // Double-tap for RAISE one-shot, otherwise Left Shift
+#define SFT_RSE     TD(TD_SHIFT_RAISE)          // Double-tap for RAISE one-shot, otherwise Left Shift
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   /* Keymap _QWERTY: (Base Layer) Default Layer
@@ -170,36 +174,9 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
   return true;
 }
 
-enum function_id {
-    SHIFT_ESC,
+// Tap Dance Definitions
+qk_tap_dance_action_t tap_dance_actions[] = {
+  // Tap/hold once for Shift, tap twice for raise layer
+  [TD_SHIFT_RAISE] = ACTION_TAP_DANCE_DOUBLE(KC_LSFT, _RAISE)
+// Other declarations would go here, separated by commas, if you have them
 };
-
-const uint16_t PROGMEM fn_actions[] = {
-  [0]  = ACTION_FUNCTION(SHIFT_ESC),
-};
-
-void action_function(keyrecord_t *record, uint8_t id, uint8_t opt) {
-  static uint8_t shift_esc_shift_mask;
-  switch (id) {
-    case SHIFT_ESC:
-      shift_esc_shift_mask = get_mods()&MODS_CTRL_MASK;
-      if (record->event.pressed) {
-        if (shift_esc_shift_mask) {
-          add_key(KC_GRV);
-          send_keyboard_report();
-        } else {
-          add_key(KC_ESC);
-          send_keyboard_report();
-        }
-      } else {
-        if (shift_esc_shift_mask) {
-          del_key(KC_GRV);
-          send_keyboard_report();
-        } else {
-          del_key(KC_ESC);
-          send_keyboard_report();
-        }
-      }
-      break;
-  }
-}

--- a/keyboards/satan/keymaps/smt/readme.md
+++ b/keyboards/satan/keymaps/smt/readme.md
@@ -1,0 +1,1 @@
+# smt's Satan GH60 layout


### PR DESCRIPTION
Based on default Satan keymap, but added Planck-style base layers for Qwerty, Colemac, and Dvorak.

~~"Raise" is a one-shot layer, activated by double-tapping left shift.~~  
Opted for a simplified single function layer, for the time being.