### PR TITLE
fixed a bug related to mod + Grave with combined ESC/Grave key

### DIFF
--- a/keyboards/clueboard/keymaps/mac_optimized/keymap.c
+++ b/keyboards/clueboard/keymaps/mac_optimized/keymap.c
@@ -49,7 +49,7 @@ const uint16_t PROGMEM fn_actions[] = {
 };
 
 void action_function(keyrecord_t *record, uint8_t id, uint8_t opt) {
-  static uint8_t mods_pressed;
+  static uint8_t mod_pressed;
   static bool mods_flag;
 
   switch (id) {

--- a/keyboards/clueboard/keymaps/mac_optimized/keymap.c
+++ b/keyboards/clueboard/keymaps/mac_optimized/keymap.c
@@ -50,6 +50,7 @@ const uint16_t PROGMEM fn_actions[] = {
 
 void action_function(keyrecord_t *record, uint8_t id, uint8_t opt) {
   static uint8_t mods_pressed;
+  static bool mods_flag;
 
   switch (id) {
     case 0:
@@ -62,6 +63,7 @@ void action_function(keyrecord_t *record, uint8_t id, uint8_t opt) {
          */
         if (mods_pressed) {
           add_key(KC_GRV);
+          mod_flag = true;
           send_keyboard_report();
         } else {
           add_key(KC_ESC);
@@ -70,8 +72,9 @@ void action_function(keyrecord_t *record, uint8_t id, uint8_t opt) {
       } else {
         /* The key is being released.
          */
-        if (mods_pressed) {
+        if (mod_flag) {
           del_key(KC_GRV);
+          mod_flag = false;
           send_keyboard_report();
         } else {
           del_key(KC_ESC);

--- a/keyboards/clueboard/keymaps/mac_optimized/keymap.c
+++ b/keyboards/clueboard/keymaps/mac_optimized/keymap.c
@@ -49,8 +49,8 @@ const uint16_t PROGMEM fn_actions[] = {
 };
 
 void action_function(keyrecord_t *record, uint8_t id, uint8_t opt) {
-  static uint8_t mod_pressed;
-  static bool mods_flag;
+  static uint8_t mods_pressed;
+  static bool mod_flag;
 
   switch (id) {
     case 0:


### PR DESCRIPTION
This only applies to keymaps that has combined esc/grave. Here we call it theKEY.
Think about the motion when we do shift + theKEY (typing ~), or CMD + theKEY (switching window on MAC). Based on the original code, we must do following sequence:  press shift -> press theKEY -> release theKEY -> release shift. However, it is very possible and natural that we do this stroke sequence instead: press shift -> press theKEY -> release shift -> release theKEY.

If we do the 2nd stroke sequence, the code will del_key(ESC) instead of (GRV) when we release theKEY. This caused some inconvenient issues and ghost typing.

By adding a flag, this issue is eliminated and will not affect any other functions.