### PR TITLE
Added more mousekey acceleration keys

### DIFF
--- a/doc/PCB_GUIDE.md
+++ b/doc/PCB_GUIDE.md
@@ -85,11 +85,11 @@ Unlike the other keymaps, prefixing the keycodes with `KC_` is required. A full 
 You can use modifiers with keycodes like this:
 
     LCTL(KC_C)
-    
+
 Which will generate Ctrl+c. These are daisy-chainable, meaning you can do things like:
 
     LCTL(LALT(KC_C))
-    
+
 That will generate Ctrl+Alt+c. The entire list of these functions is here:
 
 * `LCTL()`: Left control
@@ -117,7 +117,7 @@ A number of other keycodes have been added that you may find useful:
 
 ### Function layers
 
-The extended keymap extends the number of function layers from 32 to the near-infinite value of 256. Rather than using `FN<num>` notation (still available, but limited to `FN0`-`FN31`), you can use the `FUNC(<num>)` notation. `F(<num>)` is a shortcut for this.
+The extended keymap extends the number of function layers from 32 to the near-infinite value of 256. Rather than using `FN<num>` notation (still available, but limited to `FN0`-`FN28`), you can use the `FUNC(<num>)` notation. `F(<num>)` is a shortcut for this.
 
 The function actions are unchanged, and you can see the full list of them [here](https://github.com/jackhumbert/tmk_keyboard/blob/master/common/action_code.h). They are explained in detail [here](https://github.com/jackhumbert/tmk_keyboard/blob/master/doc/keymap.md#2-action).
 
@@ -138,7 +138,7 @@ Macros have been setup in the `keymaps/keymap_default.c` file so that you can us
       case 3:
         return MACRODOWN(TYPE(KC_D), END);
         break;
-    } 
+    }
     return MACRO_NONE;
 
 `MACRODOWN()` is a shortcut for `(record->event.pressed ? MACRO(__VA_ARGS__) : MACRO_NONE)` which tells the macro to execute when the key is pressed. Without this, the macro will be executed on both the down and up stroke.

--- a/doc/keycode.txt
+++ b/doc/keycode.txt
@@ -183,7 +183,7 @@ KC_RSHIFT           KC_RSFT         E5 Keyboard RightShift
 KC_RALT                             E6 Keyboard RightAlt
 KC_RGUI                             E7 Keyboard Right GUI(Windows/Apple/Meta key)
 
-/* 
+/*
  * Virtual keycodes
  */
 /* System Control */
@@ -226,6 +226,9 @@ KC_MS_WH_RIGHT      KC_WH_R         Mouse Wheel Right
 KC_MS_ACCEL0        KC_ACL0         Mouse Acceleration 0
 KC_MS_ACCEL1        KC_ACL1         Mouse Acceleration 1
 KC_MS_ACCEL2        KC_ACL2         Mouse Acceleration 2
+KC_MS_ACCEL3        KC_ACL3         Mouse Acceleration 3
+KC_MS_UPSPED        KC_USPD         Mouse Speed Up
+KC_MS_DNSPED        KC_DSPD         Mouse Speed Down
 /* Fn key */
 KC_FN0
 KC_FN1
@@ -256,6 +259,3 @@ KC_FN25
 KC_FN26
 KC_FN27
 KC_FN28
-KC_FN29
-KC_FN30
-KC_FN31

--- a/quantum/keymap_common.c
+++ b/quantum/keymap_common.c
@@ -63,7 +63,7 @@ action_t action_for_key(uint8_t layer, keypos_t key)
         case KC_AUDIO_MUTE ... KC_MEDIA_REWIND:
             action.code = ACTION_USAGE_CONSUMER(KEYCODE2CONSUMER(keycode));
             break;
-        case KC_MS_UP ... KC_MS_ACCEL2:
+        case KC_MS_UP ... KC_MS_UPSPED:
             action.code = ACTION_MOUSEKEY(keycode);
             break;
         case KC_TRNS:

--- a/quantum/keymap_common.c
+++ b/quantum/keymap_common.c
@@ -63,9 +63,12 @@ action_t action_for_key(uint8_t layer, keypos_t key)
         case KC_AUDIO_MUTE ... KC_MEDIA_REWIND:
             action.code = ACTION_USAGE_CONSUMER(KEYCODE2CONSUMER(keycode));
             break;
-        case KC_MS_UP ... KC_MS_UPSPED:
+        case KC_MS_UP ... KC_MS_LEFT:
             action.code = ACTION_MOUSEKEY(keycode);
             break;
+				case KC_MS_RIGHT ... KC_MS_DNSPED:
+						action.code = ACTION_MOUSEKEY(keycode);
+						break;
         case KC_TRNS:
             action.code = ACTION_TRANSPARENT;
             break;

--- a/quantum/keymap_common.c
+++ b/quantum/keymap_common.c
@@ -50,7 +50,7 @@ action_t action_for_key(uint8_t layer, keypos_t key)
     uint8_t action_layer, when, mod;
 
     switch (keycode) {
-        case KC_FN0 ... KC_FN31:
+        case KC_FN0 ... KC_FN28:
             action.code = keymap_function_id_to_action(FN_INDEX(keycode));
             break;
         case KC_A ... KC_EXSEL:

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -260,7 +260,7 @@ enum quantum_keycodes {
 
 #define KC_DELT KC_DELETE // Del key (four letter code)
 
-// Alias for function layers than expand past FN31
+// Alias for function layers than expand past FN28
 #define FUNC(kc) (kc | QK_FUNCTION)
 
 // Aliases

--- a/tmk_core/common/keycode.h
+++ b/tmk_core/common/keycode.h
@@ -32,19 +32,20 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define IS_SPECIAL(code)         ((0xA5 <= (code) && (code) <= 0xDF) || (0xE8 <= (code) && (code) <= 0xFF))
 #define IS_SYSTEM(code)          (KC_PWR       <= (code) && (code) <= KC_WAKE)
 #define IS_CONSUMER(code)        (KC_MUTE      <= (code) && (code) <= KC_MRWD)
-#define IS_FN(code)              (KC_FN0       <= (code) && (code) <= KC_FN31)
+#define IS_FN(code)              (KC_FN0       <= (code) && (code) <= KC_FN28)
 #define IS_MOUSEKEY(code)        (KC_MS_UP     <= (code) && (code) <= KC_MS_ACCEL2)
 #define IS_MOUSEKEY_MOVE(code)   (KC_MS_UP     <= (code) && (code) <= KC_MS_RIGHT)
 #define IS_MOUSEKEY_BUTTON(code) (KC_MS_BTN1   <= (code) && (code) <= KC_MS_BTN5)
 #define IS_MOUSEKEY_WHEEL(code)  (KC_MS_WH_UP  <= (code) && (code) <= KC_MS_WH_RIGHT)
-#define IS_MOUSEKEY_ACCEL(code)  (KC_MS_ACCEL0 <= (code) && (code) <= KC_MS_ACCEL2)
+#define IS_MOUSEKEY_ACCEL(code)  (KC_MS_ACCEL0 <= (code) && (code) <= KC_MS_ACCEL3)
+#define IS_MOUSEKEY_SPEED(code)  (KC_MS_UPSPED <= (code) && (code) <= KC_MS_DNSPED)
 
 #define MOD_BIT(code)   (1<<MOD_INDEX(code))
 #define MOD_INDEX(code) ((code) & 0x07)
 #define FN_BIT(code)    (1<<FN_INDEX(code))
 #define FN_INDEX(code)  ((code) - KC_FN0)
 #define FN_MIN          KC_FN0
-#define FN_MAX          KC_FN31
+#define FN_MAX          KC_FN28
 
 
 /*
@@ -459,17 +460,14 @@ enum internal_special_keycodes {
     KC_FN25,
     KC_FN26,
     KC_FN27,
-    KC_FN28,
-    KC_FN29,
-    KC_FN30,
-    KC_FN31,            /* 0xDF */
+    KC_FN28,            /* 0xDF */
 
     /**************************************/
     /* 0xE0-E7 for Modifiers. DO NOT USE. */
     /**************************************/
 
     /* Mousekey */
-    KC_MS_UP            = 0xF0,
+    KC_MS_UP            = 0xDD,
     KC_MS_DOWN,
     KC_MS_LEFT,
     KC_MS_RIGHT,
@@ -484,6 +482,9 @@ enum internal_special_keycodes {
     KC_MS_WH_LEFT,
     KC_MS_WH_RIGHT,     /* 0xFC */
     /* Mousekey accel */
+    KC_MS_ACCEL0,
+    KC_MS_ACCEL1,
+    KC_MS_ACCEL2,
     KC_MS_ACCEL3,
     KC_MS_DNSPED,
     KC_MS_UPSPED        /* 0xFF */

--- a/tmk_core/common/keycode.h
+++ b/tmk_core/common/keycode.h
@@ -29,7 +29,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define IS_MOD(code)             (KC_LCTRL     <= (code) && (code) <= KC_RGUI)
 
 
-#define IS_SPECIAL(code)         ((0xA5 <= (code) && (code) <= 0xDF) || (0xE8 <= (code) && (code) <= 0xFF))
+#define IS_SPECIAL(code)         ((0xA5 <= (code) && (code) <= 0xDC) || (0xE8 <= (code) && (code) <= 0xFF))
 #define IS_SYSTEM(code)          (KC_PWR       <= (code) && (code) <= KC_WAKE)
 #define IS_CONSUMER(code)        (KC_MUTE      <= (code) && (code) <= KC_MRWD)
 #define IS_FN(code)              (KC_FN0       <= (code) && (code) <= KC_FN28)
@@ -470,7 +470,7 @@ enum internal_special_keycodes {
     KC_MS_UP            = 0xDD,
     KC_MS_DOWN,
     KC_MS_LEFT,
-    KC_MS_RIGHT,
+    KC_MS_RIGHT         = 0xF0,
     KC_MS_BTN1,
     KC_MS_BTN2,
     KC_MS_BTN3,
@@ -486,8 +486,8 @@ enum internal_special_keycodes {
     KC_MS_ACCEL1,
     KC_MS_ACCEL2,
     KC_MS_ACCEL3,
-    KC_MS_DNSPED,
-    KC_MS_UPSPED        /* 0xFF */
+    KC_MS_UPSPED,
+    KC_MS_DNSPED         /* 0xFF */
 };
 
 #endif /* KEYCODE_H */

--- a/tmk_core/common/keycode.h
+++ b/tmk_core/common/keycode.h
@@ -460,7 +460,7 @@ enum internal_special_keycodes {
     KC_FN25,
     KC_FN26,
     KC_FN27,
-    KC_FN28,            /* 0xDF */
+    KC_FN28,            /* 0xDC */
 
     /**************************************/
     /* 0xE0-E7 for Modifiers. DO NOT USE. */

--- a/tmk_core/common/keycode.h
+++ b/tmk_core/common/keycode.h
@@ -130,6 +130,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define KC_ACL0 KC_MS_ACCEL0
 #define KC_ACL1 KC_MS_ACCEL1
 #define KC_ACL2 KC_MS_ACCEL2
+#define KC_ACL3 KC_MS_ACCEL3
+#define KC_USPD KC_MS_UPSPED
+#define KC_DSPD KC_MS_DNSPED
 /* Sytem Control */
 #define KC_PWR  KC_SYSTEM_POWER
 #define KC_SLEP KC_SYSTEM_SLEEP
@@ -481,9 +484,9 @@ enum internal_special_keycodes {
     KC_MS_WH_LEFT,
     KC_MS_WH_RIGHT,     /* 0xFC */
     /* Mousekey accel */
-    KC_MS_ACCEL0,
-    KC_MS_ACCEL1,
-    KC_MS_ACCEL2        /* 0xFF */
+    KC_MS_ACCEL3,
+    KC_MS_DNSPED,
+    KC_MS_UPSPED        /* 0xFF */
 };
 
 #endif /* KEYCODE_H */

--- a/tmk_core/common/mousekey.c
+++ b/tmk_core/common/mousekey.c
@@ -148,8 +148,8 @@ void mousekey_on(uint8_t code)
     else if (code == KC_MS_ACCEL1)   mousekey_accel |= (1<<1);
     else if (code == KC_MS_ACCEL2)   mousekey_accel |= (1<<2);
     else if (code == KC_MS_ACCEL3)   mousekey_accel |= (1<<3);
-    else if (code == KC_MS_UPSPED)   changeMouseSpeed(1);
-    else if (code == KC_MS_DNSPED)   changeMouseSpeed(-1);
+    else if (code == KC_MS_UPSPED)   mousekey_change_speed(1);
+    else if (code == KC_MS_DNSPED)   mousekey_change_speed(-1);
 }
 
 void mousekey_off(uint8_t code)
@@ -189,10 +189,17 @@ void mousekey_clear(void)
     mousekey_accel = 0;
 }
 
-void changeMouseSpeed(int change){
-  changedMouseSpeed = true;
-  if (mk_move_delta > 1 && mk_move_delta < 10)
-    mk_move_delta += change
+void mousekey_change_speed(int change)
+{
+  if (!changedMouseSpeed){
+    if (change < 0 && mk_move_delta > mk_delta_min) {
+      changedMouseSpeed = true;
+      mk_move_delta--;
+    } else if (change > 0 && mk_move_delta < mk_delta_max) {
+      changedMouseSpeed = true;
+      mk_move_delta++;
+    }
+  }
 }
 
 static void mousekey_debug(void)

--- a/tmk_core/common/mousekey.c
+++ b/tmk_core/common/mousekey.c
@@ -48,6 +48,7 @@ uint8_t mk_max_speed = MOUSEKEY_MAX_SPEED;
 uint8_t mk_time_to_max = MOUSEKEY_TIME_TO_MAX;
 /* ramp used to reach maximum pointer speed (NOT SUPPORTED) */
 //int8_t mk_curve = 0;
+uint8_t mk_move_delta = MOUSEKEY_MOVE_DELTA;
 /* wheel params */
 uint8_t mk_wheel_max_speed = MOUSEKEY_WHEEL_MAX_SPEED;
 uint8_t mk_wheel_time_to_max = MOUSEKEY_WHEEL_TIME_TO_MAX;
@@ -60,17 +61,27 @@ static uint8_t move_unit(void)
 {
     uint16_t unit;
     if (mousekey_accel & (1<<0)) {
-        unit = (MOUSEKEY_MOVE_DELTA * mk_max_speed)/4;
+        unit = (mk_move_delta * mk_max_speed)*2;
     } else if (mousekey_accel & (1<<1)) {
-        unit = (MOUSEKEY_MOVE_DELTA * mk_max_speed)/2;
+        if (mk_move_delta < 10) mk_move_delta++;
+        unit = (mk_move_delta * mk_max_speed);
     } else if (mousekey_accel & (1<<2)) {
-        unit = (MOUSEKEY_MOVE_DELTA * mk_max_speed);
+        if (mk_move_delta > 1) mk_move_delta--;
+        unit = (mk_move_delta * mk_max_speed);
+    // } else if (mousekey_accel & (1<<3)) {
+    //     unit = (mk_move_delta * mk_max_speed)*2;
+    // } else if (mousekey_accel & (1<<4)) {
+    //     mk_move_delta++;
+    //     unit = (mk_move_delta * mk_max_speed);
+    // } else if (mousekey_accel & (1<<5)) {
+    //     mk_move_delta--;
+    //     unit = (mk_move_delta * mk_max_speed);
     } else if (mousekey_repeat == 0) {
-        unit = MOUSEKEY_MOVE_DELTA;
+        unit = mk_move_delta;
     } else if (mousekey_repeat >= mk_time_to_max) {
-        unit = MOUSEKEY_MOVE_DELTA * mk_max_speed;
+        unit = mk_move_delta * mk_max_speed;
     } else {
-        unit = (MOUSEKEY_MOVE_DELTA * mk_max_speed * mousekey_repeat) / mk_time_to_max;
+        unit = (mk_move_delta * mk_max_speed * mousekey_repeat) / mk_time_to_max;
     }
     return (unit > MOUSEKEY_MOVE_MAX ? MOUSEKEY_MOVE_MAX : (unit == 0 ? 1 : unit));
 }
@@ -137,12 +148,12 @@ void mousekey_on(uint8_t code)
     else if (code == KC_MS_WH_RIGHT) mouse_report.h = wheel_unit();
     else if (code == KC_MS_BTN1)     mouse_report.buttons |= MOUSE_BTN1;
     else if (code == KC_MS_BTN2)     mouse_report.buttons |= MOUSE_BTN2;
-    else if (code == KC_MS_BTN3)     mouse_report.buttons |= MOUSE_BTN3;
-    else if (code == KC_MS_BTN4)     mouse_report.buttons |= MOUSE_BTN4;
-    else if (code == KC_MS_BTN5)     mouse_report.buttons |= MOUSE_BTN5;
-    else if (code == KC_MS_ACCEL0)   mousekey_accel |= (1<<0);
-    else if (code == KC_MS_ACCEL1)   mousekey_accel |= (1<<1);
-    else if (code == KC_MS_ACCEL2)   mousekey_accel |= (1<<2);
+    else if (code == KC_MS_ACCEL3)   mousekey_accel |= (1<<0);
+    else if (code == KC_MS_UPSPED)   mousekey_accel |= (1<<1);
+      else if (code == KC_MS_DNSPED)   mousekey_accel |= (1<<2);
+    // else if (code == KC_MS_ACCEL3)   mousekey_accel |= (1<<3);
+    // else if (code == KC_MS_UPSPED)   mousekey_accel |= (1<<4);
+    // else if (code == KC_MS_DNSPED)   mousekey_accel |= (1<<5);
 }
 
 void mousekey_off(uint8_t code)
@@ -157,12 +168,12 @@ void mousekey_off(uint8_t code)
     else if (code == KC_MS_WH_RIGHT && mouse_report.h > 0) mouse_report.h = 0;
     else if (code == KC_MS_BTN1) mouse_report.buttons &= ~MOUSE_BTN1;
     else if (code == KC_MS_BTN2) mouse_report.buttons &= ~MOUSE_BTN2;
-    else if (code == KC_MS_BTN3) mouse_report.buttons &= ~MOUSE_BTN3;
-    else if (code == KC_MS_BTN4) mouse_report.buttons &= ~MOUSE_BTN4;
-    else if (code == KC_MS_BTN5) mouse_report.buttons &= ~MOUSE_BTN5;
-    else if (code == KC_MS_ACCEL0) mousekey_accel &= ~(1<<0);
-    else if (code == KC_MS_ACCEL1) mousekey_accel &= ~(1<<1);
-    else if (code == KC_MS_ACCEL2) mousekey_accel &= ~(1<<2);
+    // else if (code == KC_MS_ACCEL0) mousekey_accel &= ~(1<<0);
+    // else if (code == KC_MS_ACCEL1) mousekey_accel &= ~(1<<1);
+    // else if (code == KC_MS_ACCEL2) mousekey_accel &= ~(1<<2);
+    else if (code == KC_MS_ACCEL3) mousekey_accel &= ~(1<<0);
+    else if (code == KC_MS_UPSPED) mousekey_accel &= ~(1<<1);
+    else if (code == KC_MS_DNSPED) mousekey_accel &= ~(1<<2);
 
     if (mouse_report.x == 0 && mouse_report.y == 0 && mouse_report.v == 0 && mouse_report.h == 0)
         mousekey_repeat = 0;

--- a/tmk_core/common/mousekey.h
+++ b/tmk_core/common/mousekey.h
@@ -69,6 +69,7 @@ void mousekey_on(uint8_t code);
 void mousekey_off(uint8_t code);
 void mousekey_clear(void);
 void mousekey_send(void);
+void mousekey_change_speed(int);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
I added more mousekey acceleration keys, one so that the speed can be doubled, and 2 keys to permanently change the speed both up and down. I found these keys to be necessary as the current mouse speed is quite slow especially when going across several monitors. This makes it so you can choose a faster speed, or if you want to stick with the slower base speed, you at least have an option to go faster.

Also, to do these changes I removed 3 FN keys to be able to handle the 3 new keymaps. I'm not sure if this is the best method to go about this, or if starting a new store would be better. I was looking into seeing who uses the FN keys removed, and it seems like there are about 5 keymaps that all use FN29-31. I believe that all these layouts were for the planck. Also, these keys were used to do some chained commands, I believe that if we wanted to permanently remove these keys we could just change the planck layouts to use something like KC_LCTL(cmd(cmd)) etc.. 

@ezuk 