### PR TITLE
Refactor Bluetooth Handling

### DIFF
--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -294,14 +294,6 @@ bool process_record_quantum(keyrecord_t *record) {
       return false;
       break;
     #endif
-    #ifdef ADAFRUIT_BLE_ENABLE
-    case OUT_BLE:
-      if (record->event.pressed) {
-        set_output(OUTPUT_ADAFRUIT_BLE);
-      }
-      return false;
-      break;
-    #endif
     #endif
     case MAGIC_SWAP_CONTROL_CAPSLOCK ... MAGIC_TOGGLE_NKRO:
       if (record->event.pressed) {

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -159,9 +159,6 @@ enum quantum_keycodes {
 #ifdef BLUETOOTH_ENABLE
     OUT_BT,
 #endif
-#ifdef ADAFRUIT_BLE_ENABLE
-    OUT_BLE,
-#endif
 
     // always leave at the end
     SAFE_RANGE

--- a/tmk_core/common.mk
+++ b/tmk_core/common.mk
@@ -93,12 +93,16 @@ ifeq ($(strip $(BACKLIGHT_ENABLE)), yes)
     TMK_COMMON_DEFS += -DBACKLIGHT_ENABLE
 endif
 
-ifeq ($(strip $(ADAFRUIT_BLE_ENABLE)), yes)
-    TMK_COMMON_DEFS += -DADAFRUIT_BLE_ENABLE
-endif
-
 ifeq ($(strip $(BLUETOOTH_ENABLE)), yes)
     TMK_COMMON_DEFS += -DBLUETOOTH_ENABLE
+endif
+
+ifeq ($(strip $(BLUETOOTH)), AdafruitBLE)
+		TMK_COMMON_DEFS += -DBLUETOOTH_ENABLE
+endif
+
+ifeq ($(strip $(BLUETOOTH)), AdafruitEZKey)
+		TMK_COMMON_DEFS += -DBLUETOOTH_ENABLE
 endif
 
 ifeq ($(strip $(ONEHAND_ENABLE)), yes)

--- a/tmk_core/common.mk
+++ b/tmk_core/common.mk
@@ -99,10 +99,12 @@ endif
 
 ifeq ($(strip $(BLUETOOTH)), AdafruitBLE)
 		TMK_COMMON_DEFS += -DBLUETOOTH_ENABLE
+		TMK_COMMON_DEFS += -DMODULE_ADAFRUIT_BLE
 endif
 
 ifeq ($(strip $(BLUETOOTH)), AdafruitEZKey)
 		TMK_COMMON_DEFS += -DBLUETOOTH_ENABLE
+		TMK_COMMON_DEFS += -DMODULE_ADAFRUIT_EZKEY
 endif
 
 ifeq ($(strip $(ONEHAND_ENABLE)), yes)

--- a/tmk_core/protocol/lufa.mk
+++ b/tmk_core/protocol/lufa.mk
@@ -22,11 +22,16 @@ ifeq ($(strip $(MIDI_ENABLE)), yes)
 	include $(TMK_PATH)/protocol/midi.mk
 endif
 
-ifeq ($(strip $(ADAFRUIT_BLE_ENABLE)), yes)
-	LUFA_SRC += $(LUFA_DIR)/adafruit_ble.cpp
+ifeq ($(strip $(BLUETOOTH_ENABLE)), yes)
+	LUFA_SRC += $(LUFA_DIR)/bluetooth.c \
+	$(TMK_DIR)/protocol/serial_uart.c
 endif
 
-ifeq ($(strip $(BLUETOOTH_ENABLE)), yes)
+ifeq ($(strip $(BLUETOOTH)), AdafruitBLE)
+		LUFA_SRC += $(LUFA_DIR)/adafruit_ble.cpp
+endif
+
+ifeq ($(strip $(BLUETOOTH)), AdafruitEZKey)
 	LUFA_SRC += $(LUFA_DIR)/bluetooth.c \
 	$(TMK_DIR)/protocol/serial_uart.c
 endif
@@ -54,6 +59,7 @@ LUFA_OPTS += -DUSE_FLASH_DESCRIPTORS
 LUFA_OPTS += -DUSE_STATIC_OPTIONS="(USB_DEVICE_OPT_FULLSPEED | USB_OPT_REG_ENABLED | USB_OPT_AUTO_PLL)"
 #LUFA_OPTS += -DINTERRUPT_CONTROL_ENDPOINT
 LUFA_OPTS += -DFIXED_CONTROL_ENDPOINT_SIZE=8 
+LUFA_OPTS += -DFIXED_CONTROL_ENDPOINT_SIZE=8
 LUFA_OPTS += -DFIXED_NUM_CONFIGURATIONS=1
 
 # Remote wakeup fix for ATmega32U2        https://github.com/tmk/tmk_keyboard/issues/361

--- a/tmk_core/protocol/lufa/adafruit_ble.h
+++ b/tmk_core/protocol/lufa/adafruit_ble.h
@@ -3,7 +3,7 @@
  * Supports the Adafruit BLE board built around the nRF51822 chip.
  */
 #pragma once
-#ifdef ADAFRUIT_BLE_ENABLE
+#ifdef MODULE_ADAFRUIT_BLE
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
@@ -57,4 +57,4 @@ extern bool adafruit_ble_set_power_level(int8_t level);
 }
 #endif
 
-#endif // ADAFRUIT_BLE_ENABLE
+#endif // MODULE_ADAFRUIT_BLE

--- a/tmk_core/protocol/lufa/lufa.c
+++ b/tmk_core/protocol/lufa/lufa.c
@@ -603,14 +603,16 @@ static void send_keyboard(report_keyboard_t *report)
     uint8_t where = where_to_send();
 
 #ifdef BLUETOOTH_ENABLE
-  #ifdef MODULE_ADAFRUIT_BLE
-    adafruit_ble_send_keys(report->mods, report->keys, sizeof(report->keys));
-  #else
-    bluefruit_serial_send(0xFD);
-    for (uint8_t i = 0; i < KEYBOARD_EPSIZE; i++) {
-      bluefruit_serial_send(report->raw[i]);
-    }
-  #endif
+  if (where == OUTPUT_BLUETOOTH || where == OUTPUT_USB_AND_BT) {
+    #ifdef MODULE_ADAFRUIT_BLE
+      adafruit_ble_send_keys(report->mods, report->keys, sizeof(report->keys));
+    #else
+      bluefruit_serial_send(0xFD);
+      for (uint8_t i = 0; i < KEYBOARD_EPSIZE; i++) {
+        bluefruit_serial_send(report->raw[i]);
+      }
+    #endif
+  }
 #endif
 
     if (where != OUTPUT_USB && where != OUTPUT_USB_AND_BT) {

--- a/tmk_core/protocol/lufa/lufa.c
+++ b/tmk_core/protocol/lufa/lufa.c
@@ -67,10 +67,11 @@
 #endif
 
 #ifdef BLUETOOTH_ENABLE
-    #include "bluetooth.h"
-#endif
-#ifdef ADAFRUIT_BLE_ENABLE
+  #ifdef MODULE_ADAFRUIT_BLE
     #include "adafruit_ble.h"
+  #else
+    #include "bluetooth.h"
+  #endif
 #endif
 
 #ifdef VIRTSER_ENABLE
@@ -602,18 +603,14 @@ static void send_keyboard(report_keyboard_t *report)
     uint8_t where = where_to_send();
 
 #ifdef BLUETOOTH_ENABLE
-    if (where == OUTPUT_BLUETOOTH || where == OUTPUT_USB_AND_BT) {
-        bluefruit_serial_send(0xFD);
-        for (uint8_t i = 0; i < KEYBOARD_EPSIZE; i++) {
-            bluefruit_serial_send(report->raw[i]);
-        }
+  #ifdef MODULE_ADAFRUIT_BLE
+    adafruit_ble_send_keys(report->mods, report->keys, sizeof(report->keys));
+  #else
+    bluefruit_serial_send(0xFD);
+    for (uint8_t i = 0; i < KEYBOARD_EPSIZE; i++) {
+      bluefruit_serial_send(report->raw[i]);
     }
-#endif
-
-#ifdef ADAFRUIT_BLE_ENABLE
-    if (where == OUTPUT_ADAFRUIT_BLE) {
-      adafruit_ble_send_keys(report->mods, report->keys, sizeof(report->keys));
-    }
+  #endif
 #endif
 
     if (where != OUTPUT_USB && where != OUTPUT_USB_AND_BT) {
@@ -660,24 +657,22 @@ static void send_mouse(report_mouse_t *report)
     uint8_t where = where_to_send();
 
 #ifdef BLUETOOTH_ENABLE
-    if (where == OUTPUT_BLUETOOTH || where == OUTPUT_USB_AND_BT) {
-        bluefruit_serial_send(0xFD);
-        bluefruit_serial_send(0x00);
-        bluefruit_serial_send(0x03);
-        bluefruit_serial_send(report->buttons);
-        bluefruit_serial_send(report->x);
-        bluefruit_serial_send(report->y);
-        bluefruit_serial_send(report->v); // should try sending the wheel v here
-        bluefruit_serial_send(report->h); // should try sending the wheel h here
-        bluefruit_serial_send(0x00);
-    }
-#endif
-
-#ifdef ADAFRUIT_BLE_ENABLE
-    if (where == OUTPUT_ADAFRUIT_BLE) {
+  if (where == OUTPUT_BLUETOOTH || where == OUTPUT_USB_AND_BT) {
+    #ifdef MODULE_ADAFRUIT_BLE
       // FIXME: mouse buttons
       adafruit_ble_send_mouse_move(report->x, report->y, report->v, report->h);
-    }
+    #else
+      bluefruit_serial_send(0xFD);
+      bluefruit_serial_send(0x00);
+      bluefruit_serial_send(0x03);
+      bluefruit_serial_send(report->buttons);
+      bluefruit_serial_send(report->x);
+      bluefruit_serial_send(report->y);
+      bluefruit_serial_send(report->v); // should try sending the wheel v here
+      bluefruit_serial_send(report->h); // should try sending the wheel h here
+      bluefruit_serial_send(0x00);
+    #endif
+  }
 #endif
 
     if (where != OUTPUT_USB && where != OUTPUT_USB_AND_BT) {
@@ -727,6 +722,9 @@ static void send_consumer(uint16_t data)
 
 #ifdef BLUETOOTH_ENABLE
     if (where == OUTPUT_BLUETOOTH || where == OUTPUT_USB_AND_BT) {
+      #ifdef MODULE_ADAFRUIT_BLE
+        adafruit_ble_send_consumer_key(data, 0);
+      #else
         static uint16_t last_data = 0;
         if (data == last_data) return;
         last_data = data;
@@ -740,12 +738,7 @@ static void send_consumer(uint16_t data)
         bluefruit_serial_send(0x00);
         bluefruit_serial_send(0x00);
         bluefruit_serial_send(0x00);
-    }
-#endif
-
-#ifdef ADAFRUIT_BLE_ENABLE
-    if (where == OUTPUT_ADAFRUIT_BLE) {
-      adafruit_ble_send_consumer_key(data, 0);
+      #endif
     }
 #endif
 
@@ -1130,10 +1123,6 @@ int main(void)
     // midi_send_noteoff(&midi_device, 0, 64, 127);
 #endif
 
-#ifdef BLUETOOTH_ENABLE
-    serial_init();
-#endif
-
     /* wait for USB startup & debug output */
 
 #ifdef WAIT_FOR_USB
@@ -1161,7 +1150,7 @@ int main(void)
 
     print("Keyboard start.\n");
     while (1) {
-        #if !defined(BLUETOOTH_ENABLE) && !defined(ADAFRUIT_BLE_ENABLE)
+        #if !defined(BLUETOOTH_ENABLE)
         while (USB_DeviceState == DEVICE_STATE_Suspended) {
             print("[s]");
             suspend_power_down();
@@ -1182,7 +1171,11 @@ int main(void)
         rgblight_task();
 #endif
 
-#ifdef ADAFRUIT_BLE_ENABLE
+#ifdef MODULE_ADAFRUIT_EZKEY
+    serial_init();
+#endif
+
+#ifdef MODULE_ADAFRUIT_BLE
         adafruit_ble_task();
 #endif
 

--- a/tmk_core/protocol/lufa/lufa.c
+++ b/tmk_core/protocol/lufa/lufa.c
@@ -1125,6 +1125,10 @@ int main(void)
     // midi_send_noteoff(&midi_device, 0, 64, 127);
 #endif
 
+#ifdef MODULE_ADAFRUIT_EZKEY
+    serial_init();
+#endif
+
     /* wait for USB startup & debug output */
 
 #ifdef WAIT_FOR_USB
@@ -1171,10 +1175,6 @@ int main(void)
 
 #if defined(RGBLIGHT_ANIMATIONS) & defined(RGBLIGHT_ENABLE)
         rgblight_task();
-#endif
-
-#ifdef MODULE_ADAFRUIT_EZKEY
-    serial_init();
 #endif
 
 #ifdef MODULE_ADAFRUIT_BLE

--- a/tmk_core/protocol/lufa/outputselect.c
+++ b/tmk_core/protocol/lufa/outputselect.c
@@ -14,7 +14,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "lufa.h"
 #include "outputselect.h"
-#ifdef ADAFRUIT_BLE_ENABLE
+#ifdef MODULE_ADAFRUIT_BLE
     #include "adafruit_ble.h"
 #endif
 
@@ -34,9 +34,9 @@ uint8_t auto_detect_output(void) {
         return OUTPUT_USB;
     }
 
-#ifdef ADAFRUIT_BLE_ENABLE
+#ifdef MODULE_ADAFRUIT_BLE
     if (adafruit_ble_is_connected()) {
-        return OUTPUT_ADAFRUIT_BLE;
+        return OUTPUT_BLUETOOTH;
     }
 #endif
 

--- a/tmk_core/protocol/lufa/outputselect.h
+++ b/tmk_core/protocol/lufa/outputselect.h
@@ -18,7 +18,6 @@ enum outputs {
     OUTPUT_NONE,
     OUTPUT_USB,
     OUTPUT_BLUETOOTH,
-    OUTPUT_ADAFRUIT_BLE,
 
     // backward compatibility
     OUTPUT_USB_AND_BT


### PR DESCRIPTION
Refactored Bluetooth support to make adding new Bluetooth modules easier in the future.

* Remove `OUT_BLE` key from QMK's keymap. `OUT_BT` is all we need now as there's no difference anymore.
* Made `BLUETOOTH_ENABLE` build option legacy as not to break existing keymaps (Falls back to existing EZ Key support if turned on)
* Removed `ADAFRUIT_BLE_ENABLE` build option
* Created new build option `BLUETOOTH` with module option (Currently `AdafruitEZKey` & `AdafruitBLE`)
* Moved all LUFA bluetooth key/mouse events under `BLUETOOTH_ENABLE` ifdef with selected modules output.