### PR TITLE
Added instructions for how to build and flash the firmware with teensy_cli

### DIFF
--- a/keyboards/ergodox/readme.md
+++ b/keyboards/ergodox/readme.md
@@ -1,6 +1,6 @@
 # The Easy Way
 
-If you have an ErgoDox EZ, the absolute easiest way for you to customize your firmware is using the [graphical configurator](http://configure.ergodox-ez.com), which uses QMK under the hood. 
+If you have an ErgoDox EZ, the absolute easiest way for you to customize your firmware is using the [graphical configurator](http://configure.ergodox-ez.com), which uses QMK under the hood.
 
 If you can find firmware someone else has made that does what you want, that
 is the easiest way to customize your ErgoDox.  It requires no programming
@@ -69,12 +69,13 @@ files.  Check them out with:
 
 The Ez uses the [Teensy Loader](https://www.pjrc.com/teensy/loader.html).
 
-Linux users need to modify udev rules as described on the Teensy Linux page.
-Some distributions provide a binary, maybe called `teensy-loader-cli`).
+Linux users need to modify udev rules as described on the Teensy Linux page (which page?).
+Some distributions provide a binary, maybe called `teensy-loader-cli`.
 
 To flash the firmware:
 
-  - Build the firmware with `make keymapname`, for example `make default` 
+  - Build the firmware with `make keymapname`, for example `make default`
+
   - This will result in a hex file called `ergodox_ez_keymapname.hex`, e.g.
     `ergodox_ez_default.hex`
 
@@ -86,6 +87,15 @@ To flash the firmware:
     in the top right corder.
 
   - Click the button in the Teensy app to download the firmware.
+
+To flash with ´teensy-loader-cli´:
+
+  - Build the firmware with `make keymapname`, for example `make default`
+
+  - Run ´<path/to/>teensy_loader_cli --mcu=atmega32u4 -w ergodox_ez_<keymap>.hex´
+
+  - Press the Reset button by inserting a paperclip gently into the reset hole
+    in the top right corder.
 
 ## ErgoDox Infinity
 

--- a/keyboards/ergodox/readme.md
+++ b/keyboards/ergodox/readme.md
@@ -69,8 +69,11 @@ files.  Check them out with:
 
 The Ez uses the [Teensy Loader](https://www.pjrc.com/teensy/loader.html).
 
-Linux users need to modify udev rules as described on the Teensy Linux page (which page?).
-Some distributions provide a binary, maybe called `teensy-loader-cli`.
+Linux users need to modify udev rules as described on the [Teensy
+Linux page].  Some distributions provide a binary, maybe called
+`teensy-loader-cli`.
+
+[Teensy Linux page]: https://www.pjrc.com/teensy/loader_linux.html
 
 To flash the firmware:
 


### PR DESCRIPTION
Updated the ergodox readme to contain instructions for how to use the teensy_loader_cli to flash the keyboard.

This PR superseeds #1031 and contains the needed URL.