### PR TITLE
Add RN42 Bluetooth module support

### DIFF
--- a/tmk_core/common.mk
+++ b/tmk_core/common.mk
@@ -107,6 +107,11 @@ ifeq ($(strip $(BLUETOOTH)), AdafruitEZKey)
 		TMK_COMMON_DEFS += -DMODULE_ADAFRUIT_EZKEY
 endif
 
+ifeq ($(strip $(BLUETOOTH)), RN42)
+		TMK_COMMON_DEFS += -DBLUETOOTH_ENABLE
+		TMK_COMMON_DEFS += -DMODULE_RN42
+endif
+
 ifeq ($(strip $(ONEHAND_ENABLE)), yes)
     TMK_COMMON_DEFS += -DONEHAND_ENABLE
 endif

--- a/tmk_core/protocol/lufa.mk
+++ b/tmk_core/protocol/lufa.mk
@@ -36,6 +36,11 @@ ifeq ($(strip $(BLUETOOTH)), AdafruitEZKey)
 	$(TMK_DIR)/protocol/serial_uart.c
 endif
 
+ifeq ($(strip $(BLUETOOTH)), RN42)
+	LUFA_SRC += $(LUFA_DIR)/bluetooth.c \
+	$(TMK_DIR)/protocol/serial_uart.c
+endif
+
 ifeq ($(strip $(VIRTSER_ENABLE)), yes)
 	LUFA_SRC += $(LUFA_ROOT_PATH)/Drivers/USB/Class/Device/CDCClassDevice.c
 endif

--- a/tmk_core/protocol/lufa/bluetooth.h
+++ b/tmk_core/protocol/lufa/bluetooth.h
@@ -62,4 +62,18 @@ void bluefruit_serial_send(uint8_t data);
     (usage == AC_REFRESH           ? 0x0000  : \
     (usage == AC_BOOKMARKS         ? 0x0000  : 0)))))))))))))))))))
 
-#endif
+#define CONSUMER2RN42(usage) \
+    (usage == AUDIO_MUTE           ? 0x0040 : \
+    (usage == AUDIO_VOL_UP         ? 0x0010 : \
+    (usage == AUDIO_VOL_DOWN       ? 0x0020 : \
+    (usage == TRANSPORT_NEXT_TRACK ? 0x0100 : \
+    (usage == TRANSPORT_PREV_TRACK ? 0x0200 : \
+    (usage == TRANSPORT_STOP       ? 0x0400 : \
+    (usage == TRANSPORT_STOP_EJECT ? 0x0800 : \
+    (usage == TRANSPORT_PLAY_PAUSE ? 0x0080 : \
+    (usage == AL_EMAIL             ? 0x0200 : \
+    (usage == AL_LOCAL_BROWSER     ? 0x8000 : \
+    (usage == AC_SEARCH            ? 0x0400 : \
+    (usage == AC_HOME              ? 0x0100 : 0))))))))))))
+
+ #endif

--- a/tmk_core/protocol/lufa/lufa.c
+++ b/tmk_core/protocol/lufa/lufa.c
@@ -606,6 +606,13 @@ static void send_keyboard(report_keyboard_t *report)
   if (where == OUTPUT_BLUETOOTH || where == OUTPUT_USB_AND_BT) {
     #ifdef MODULE_ADAFRUIT_BLE
       adafruit_ble_send_keys(report->mods, report->keys, sizeof(report->keys));
+    #elif MODULE_RN42
+       bluefruit_serial_send(0xFD);
+       bluefruit_serial_send(0x09);
+       bluefruit_serial_send(0x01);
+       for (uint8_t i = 0; i < KEYBOARD_EPSIZE; i++) {
+         bluefruit_serial_send(report->raw[i]);
+       }
     #else
       bluefruit_serial_send(0xFD);
       for (uint8_t i = 0; i < KEYBOARD_EPSIZE; i++) {
@@ -726,6 +733,16 @@ static void send_consumer(uint16_t data)
     if (where == OUTPUT_BLUETOOTH || where == OUTPUT_USB_AND_BT) {
       #ifdef MODULE_ADAFRUIT_BLE
         adafruit_ble_send_consumer_key(data, 0);
+      #elif MODULE_RN42
+        static uint16_t last_data = 0;
+        if (data == last_data) return;
+        last_data = data;
+        uint16_t bitmap = CONSUMER2RN42(data);
+        bluefruit_serial_send(0xFD);
+        bluefruit_serial_send(0x03);
+        bluefruit_serial_send(0x03);
+        bluefruit_serial_send(bitmap&0xFF);
+        bluefruit_serial_send((bitmap>>8)&0xFF);
       #else
         static uint16_t last_data = 0;
         if (data == last_data) return;
@@ -1132,7 +1149,7 @@ int main(void)
     // midi_send_noteoff(&midi_device, 0, 64, 127);
 #endif
 
-#ifdef MODULE_ADAFRUIT_EZKEY
+#if defined(MODULE_ADAFRUIT_EZKEY) || defined(MODULE_RN42)
     serial_init();
 #endif
 


### PR DESCRIPTION
Added support for sending HID keycodes over the RN42/reflashed HC05 module. Tested on OS X and iOS and Planck. Will add documentation to Wiki on configuring module soon.