### PR TITLE
Add missing serial_link.h include

### DIFF
--- a/keyboards/ergodox/infinity/matrix.c
+++ b/keyboards/ergodox/infinity/matrix.c
@@ -24,6 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "print.h"
 #include "debug.h"
 #include "matrix.h"
+#include "serial_link/system/serial_link.h"
 
 
 /*


### PR DESCRIPTION
Which fixes a warning when building Ergodox Infinity as a righthand master.