### PR TITLE
Removed LT macros

### DIFF
--- a/keyboards/tv44/keymaps/xyverz/keymap.c
+++ b/keyboards/tv44/keymaps/xyverz/keymap.c
@@ -23,9 +23,9 @@ enum planck_keycodes {
 };
 
 // Layer-Tapping macros
-#define ESCLOWR LT(_LOWER, KC_ESC)
-#define MINSRSE LT(_RAISE, KC_MINS)
-#define QUOTRSE LT(_RAISE, KC_QUOT)
+#define ESCRAIS LT(_RAISE, KC_ESC)
+#define MINSLWR LT(_LOWER, KC_MINS)
+#define QUOTLWR LT(_LOWER, KC_QUOT)
 
 // Fillers to make layering more clear
 #define _______ KC_TRNS
@@ -35,21 +35,21 @@ enum planck_keycodes {
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   [_DVORAK] = { /* 0: Dvorak */
     {KC_TAB,  KC_QUOT, KC_COMM, KC_DOT,  KC_P,    KC_Y,    KC_F,    KC_G,    KC_C,    KC_R,    KC_L,    KC_SLSH },
-    {ESCLOWR, KC_A,    KC_O,    KC_E,    KC_U,    KC_I,    KC_D,    KC_H,    KC_T,    KC_N,    KC_S,    MINSRSE },
+    {ESCRAIS, KC_A,    KC_O,    KC_E,    KC_U,    KC_I,    KC_D,    KC_H,    KC_T,    KC_N,    KC_S,    MINSLWR },
     {KC_LSFT, KC_SCLN, KC_Q,    KC_J,    KC_K,    KC_X,    KC_B,    KC_M,    KC_W,    KC_V,    KC_Z,    KC_RSFT },
     {KC_LCTL, KC_LALT, LOWER,   KC_BSPC, XXXXXXX, XXXXXXX, XXXXXXX, KC_SPC,  RAISE,   KC_LGUI, XXXXXXX, KC_ENT  }
   },
 
   [_QWERTY] = { /* 1: Qwerty */
     {KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_BSPC },
-    {ESCLOWR, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, QUOTRSE },
+    {ESCRAIS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, QUOTLWR },
     {KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT },
     {KC_LCTL, KC_LALT, LOWER,   KC_BSPC, XXXXXXX, XXXXXXX, XXXXXXX, KC_SPC,  RAISE,   KC_LGUI, XXXXXXX, KC_ENT  }
   },
 
   [_COLEMAK] = { /* 2: Colemak */
     {KC_TAB,  KC_Q,    KC_W,    KC_F,    KC_P,    KC_G,    KC_J,    KC_L,    KC_U,    KC_Y,    KC_SCLN, KC_BSPC },
-    {ESCLOWR, KC_A,    KC_R,    KC_S,    KC_T,    KC_D,    KC_H,    KC_N,    KC_E,    KC_I,    KC_O,    QUOTRSE },
+    {ESCRAIS, KC_A,    KC_R,    KC_S,    KC_T,    KC_D,    KC_H,    KC_N,    KC_E,    KC_I,    KC_O,    QUOTLWR },
     {KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_K,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT },
     {KC_LCTL, KC_LALT, LOWER,   KC_BSPC, XXXXXXX, XXXXXXX, XXXXXXX, KC_SPC,  RAISE,   KC_LGUI, XXXXXXX, KC_ENT  }
   },

--- a/keyboards/tv44/keymaps/xyverz/keymap.c
+++ b/keyboards/tv44/keymaps/xyverz/keymap.c
@@ -22,11 +22,6 @@ enum planck_keycodes {
   ADJUST
 };
 
-// Layer-Tapping macros
-#define ESCRAIS LT(_RAISE, KC_ESC)
-#define MINSLWR LT(_LOWER, KC_MINS)
-#define QUOTLWR LT(_LOWER, KC_QUOT)
-
 // Fillers to make layering more clear
 #define _______ KC_TRNS
 #define XXXXXXX KC_NO
@@ -34,38 +29,38 @@ enum planck_keycodes {
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   [_DVORAK] = { /* 0: Dvorak */
-    {KC_TAB,  KC_QUOT, KC_COMM, KC_DOT,  KC_P,    KC_Y,    KC_F,    KC_G,    KC_C,    KC_R,    KC_L,    KC_SLSH },
-    {ESCRAIS, KC_A,    KC_O,    KC_E,    KC_U,    KC_I,    KC_D,    KC_H,    KC_T,    KC_N,    KC_S,    MINSLWR },
-    {KC_LSFT, KC_SCLN, KC_Q,    KC_J,    KC_K,    KC_X,    KC_B,    KC_M,    KC_W,    KC_V,    KC_Z,    KC_RSFT },
-    {KC_LCTL, KC_LALT, LOWER,   KC_BSPC, XXXXXXX, XXXXXXX, XXXXXXX, KC_SPC,  RAISE,   KC_LGUI, XXXXXXX, KC_ENT  }
+    {KC_TAB,  KC_QUOT, KC_COMM, KC_DOT,  KC_P,    KC_Y,    KC_F,    KC_G,    KC_C,    KC_R,    KC_L,    KC_SLSH},
+    {KC_ESC,  KC_A,    KC_O,    KC_E,    KC_U,    KC_I,    KC_D,    KC_H,    KC_T,    KC_N,    KC_S,    KC_MINS},
+    {KC_LSFT, KC_SCLN, KC_Q,    KC_J,    KC_K,    KC_X,    KC_B,    KC_M,    KC_W,    KC_V,    KC_Z,    KC_RSFT},
+    {KC_LCTL, KC_LALT, LOWER,   KC_BSPC, XXXXXXX, XXXXXXX, XXXXXXX, KC_SPC,  RAISE,   KC_LGUI, XXXXXXX, KC_ENT }
   },
 
   [_QWERTY] = { /* 1: Qwerty */
-    {KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_BSPC },
-    {ESCRAIS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, QUOTLWR },
-    {KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT },
-    {KC_LCTL, KC_LALT, LOWER,   KC_BSPC, XXXXXXX, XXXXXXX, XXXXXXX, KC_SPC,  RAISE,   KC_LGUI, XXXXXXX, KC_ENT  }
+    {KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_BSPC},
+    {KC_ESC,  KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT},
+    {KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT},
+    {KC_LCTL, KC_LALT, LOWER,   KC_BSPC, XXXXXXX, XXXXXXX, XXXXXXX, KC_SPC,  RAISE,   KC_LGUI, XXXXXXX, KC_ENT }
   },
 
   [_COLEMAK] = { /* 2: Colemak */
-    {KC_TAB,  KC_Q,    KC_W,    KC_F,    KC_P,    KC_G,    KC_J,    KC_L,    KC_U,    KC_Y,    KC_SCLN, KC_BSPC },
-    {ESCRAIS, KC_A,    KC_R,    KC_S,    KC_T,    KC_D,    KC_H,    KC_N,    KC_E,    KC_I,    KC_O,    QUOTLWR },
-    {KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_K,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT },
-    {KC_LCTL, KC_LALT, LOWER,   KC_BSPC, XXXXXXX, XXXXXXX, XXXXXXX, KC_SPC,  RAISE,   KC_LGUI, XXXXXXX, KC_ENT  }
+    {KC_TAB,  KC_Q,    KC_W,    KC_F,    KC_P,    KC_G,    KC_J,    KC_L,    KC_U,    KC_Y,    KC_SCLN, KC_BSPC},
+    {KC_ESC,  KC_A,    KC_R,    KC_S,    KC_T,    KC_D,    KC_H,    KC_N,    KC_E,    KC_I,    KC_O,    KC_QUOT},
+    {KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_K,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT},
+    {KC_LCTL, KC_LALT, LOWER,   KC_BSPC, XXXXXXX, XXXXXXX, XXXXXXX, KC_SPC,  RAISE,   KC_LGUI, XXXXXXX, KC_ENT }
   },
 
   [_LOWER] = {/* 1: FN 1 */
-    {KC_TILD, KC_EXLM, KC_AT,   KC_HASH, KC_DLR,  KC_PERC, KC_CIRC, KC_AMPR, KC_ASTR, KC_LPRN, KC_RPRN, KC_PIPE },
-    {_______, _______, _______, _______, _______, _______, _______, KC_UNDS, KC_PLUS, KC_LCBR, KC_RCBR, KC_PIPE },
-    {KC_CAPS, _______, _______, _______, _______, _______, _______, KC_MUTE, KC_VOLD, KC_VOLU, _______, _______ },
-    {KC_LEFT, KC_RGHT, _______, KC_DEL,  XXXXXXX, XXXXXXX, XXXXXXX, KC_INS,  _______, KC_UP,   XXXXXXX, KC_DOWN }
+    {KC_TILD, KC_EXLM, KC_AT,   KC_HASH, KC_DLR,  KC_PERC, KC_CIRC, KC_AMPR, KC_ASTR, KC_LPRN, KC_RPRN, KC_PIPE},
+    {_______, _______, _______, _______, _______, _______, _______, KC_UNDS, KC_PLUS, KC_LCBR, KC_RCBR, KC_PIPE},
+    {KC_CAPS, _______, _______, _______, _______, _______, _______, KC_MUTE, KC_VOLD, KC_VOLU, _______, _______},
+    {KC_LEFT, KC_RGHT, _______, KC_DEL,  XXXXXXX, XXXXXXX, XXXXXXX, KC_INS,  _______, KC_UP,   XXXXXXX, KC_DOWN}
   },
 
   [_RAISE] = { /* 2: FN 2 */
-    {KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_BSLS },
-    {_______, _______, _______, _______, _______, _______, _______, KC_MINS, KC_EQL,  KC_LBRC, KC_RBRC, KC_BSLS },
-    {KC_CAPS, _______, _______, _______, _______, _______, _______, KC_MPRV, KC_MPLY, KC_MNXT, _______, _______ },
-    {KC_LEFT, KC_RGHT, _______, KC_DEL,  XXXXXXX, XXXXXXX, XXXXXXX, KC_INS,  _______, KC_UP,   XXXXXXX, KC_DOWN }
+    {KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_BSLS},
+    {_______, _______, _______, _______, _______, _______, _______, KC_MINS, KC_EQL,  KC_LBRC, KC_RBRC, KC_BSLS},
+    {KC_CAPS, _______, _______, _______, _______, _______, _______, KC_MPRV, KC_MPLY, KC_MNXT, _______, _______},
+    {KC_LEFT, KC_RGHT, _______, KC_DEL,  XXXXXXX, XXXXXXX, XXXXXXX, KC_INS,  _______, KC_UP,   XXXXXXX, KC_DOWN}
   },
 
   [_ADJUST] = {


### PR DESCRIPTION
The LT macros caused the keyboard to get stuck in the ADJUST layer. This removes those macros and fixes the problem.