### PR TITLE
Fix LCD SS pin configuration

### DIFF
--- a/keyboards/ergodox/infinity/drivers/gdisp/st7565ergodox/board_ST7565.h
+++ b/keyboards/ergodox/infinity/drivers/gdisp/st7565ergodox/board_ST7565.h
@@ -75,7 +75,7 @@ static GFXINLINE void init_board(GDisplay *g) {
     palSetPad(ST7565_GPIOPORT, ST7565_RST_PIN);
     palSetPadModeRaw(MOSI, ST7565_SPI_MODE);
     palSetPadModeRaw(SLCK, ST7565_SPI_MODE);
-    palSetPadModeRaw(SS, PAL_MODE_OUTPUT_PUSHPULL);
+    palSetPadModeNamed(SS, PAL_MODE_OUTPUT_PUSHPULL);
 
     spiInit();
     spiStart(&SPID1, &spi1config);


### PR DESCRIPTION
There was a typo, so the attempted configuration probably didn't do what it should have done. I think it left the pin floating, and could cause the LCD problems in #1230.