### PR TITLE
Initial Ortholinear Commit for AMJPad

### DIFF
--- a/keyboards/amjpad/keymaps/ortho_left/keymap.c
+++ b/keyboards/amjpad/keymaps/ortho_left/keymap.c
@@ -1,0 +1,65 @@
+#include "amjpad.h"
+
+#ifdef RGBLIGHT_ENABLE
+#include "rgblight.h"
+#endif
+
+// Each layer gets a name for readability, which is then used in the keymap matrix below.
+// The underscores don't mean anything - you can have a layer called STUFF or any other name.
+// Layer names don't all need to be of the same length, obviously, and you can also skip them
+// entirely and just use numbers.
+#define _BL 0
+#define _FL 1
+
+#define _______ KC_TRNS
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  /* Keymap _BL: (Base Layer) Default Layer
+   * ,-------------------.
+   * | T  | G  | B  |Spac|
+   * |----|----|----|----|
+   * | R  | F  | V  | Fn |
+   * |----|----|----|----|
+   * | E  | D  | C  | OS |
+   * |----|----|----|----|
+   * | W  | S  | X  | Alt|
+   * |----|----|----|----|
+   * | Q  | A  | Z  | Ctl|
+   * |----|----|----|----|
+   * | Esc| Tab|Shft| Fn2|
+   * `-------------------'
+   */
+
+[_BL] = MAXKEYMAP(
+
+  KC_T,   KC_G,   KC_B,      KC_SPACE,\
+  KC_R,   KC_F,   KC_V,      MO(1),    \
+  KC_E,   KC_D,   KC_C,      KC_LGUI, \
+  KC_W,   KC_S,   KC_X,      KC_LALT, \
+  KC_Q,   KC_A,   KC_Z,      KC_LCTL, \
+  KC_TAB, KC_ESC, KC_LSHIFT, MO(1)),
+
+  /* Keymap _FL: Function Layer
+   * ,-------------------.
+   * | 5  | F5 | F11|Spac|
+   * |----|----|----|----|
+   * | 4  | F4 | F10|    |
+   * |----|----|----|----|
+   * | 3  | F3 | F9 | OS |
+   * |----|----|----|----|
+   * | 2  | F2 | F8 | Alt|
+   * |----|----|----|----|
+   * | 1  | F1 | F7 | Ctl|
+   * |----|----|----|----|
+   * | `  | Del|Shft|    |
+   * `-------------------'
+   */
+[_FL] = MAXKEYMAP(
+
+  KC_5,  KC_F5,  KC_F11,  _______, \
+  KC_4,  KC_F4,  KC_F10,  _______, \
+  KC_3,  KC_F3,  KC_F9,   _______, \
+  KC_2,  KC_F2,  KC_F8,   _______, \
+  KC_1,  KC_F1,  KC_F7,   _______, \
+  KC_GRV,KC_DEL, _______, _______),
+};

--- a/keyboards/amjpad/keymaps/ortho_right/keymap.c
+++ b/keyboards/amjpad/keymaps/ortho_right/keymap.c
@@ -1,0 +1,65 @@
+#include "amjpad.h"
+
+#ifdef RGBLIGHT_ENABLE
+#include "rgblight.h"
+#endif
+
+// Each layer gets a name for readability, which is then used in the keymap matrix below.
+// The underscores don't mean anything - you can have a layer called STUFF or any other name.
+// Layer names don't all need to be of the same length, obviously, and you can also skip them
+// entirely and just use numbers.
+#define _BL 0
+#define _FL 1
+
+#define _______ KC_TRNS
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  /* Keymap _BL: (Base Layer) Default Layer
+   * ,-------------------.
+   * |Spac| N  | H  | Y  |
+   * |----|----|----|----|
+   * | Fn | M  | J  | U  |
+   * |----|----|----|----|
+   * |Left| ,  | K  | I  |
+   * |----|----|----|----|
+   * |Down| .  | L  | O  |
+   * |----|----|----|----|
+   * | Up | /  | ;  | P  |
+   * |----|----|----|----|
+   * |Rght| Ret| "  |Bspc|
+   * `-------------------'
+   */
+
+[_BL] = MAXKEYMAP(
+
+  KC_SPACE, KC_N,     KC_H,      KC_Y, \
+  MO(1),    KC_M,     KC_J,      KC_U, \
+  KC_LEFT,  KC_COMM,  KC_K,      KC_I, \
+  KC_DOWN,  KC_DOT,   KC_L,      KC_O, \
+  KC_UP,    KC_SLASH, KC_SCLN,   KC_P, \
+  KC_RIGHT, KC_ENT,   KC_QUOT,   KC_BSPC),
+
+  /* Keymap _FL: Function Layer
+   * ,-------------------.
+   * |Esc | F12| F6 | 6  |
+   * |----|----|----|----|
+   * | NL | M  | -  | 7  |
+   * |----|----|----|----|
+   * |Left| ,  | =  | 8  |
+   * |----|----|----|----|
+   * |Down| .  | [  | 9  |
+   * |----|----|----|----|
+   * | Up | /  | ]  | 0  |
+   * |----|----|----|----|
+   * |Rght| Ret| \  | Del|
+   * `-------------------'
+   */
+[_FL] = MAXKEYMAP(
+
+  _______, KC_F12,  KC_F6,   KC_6, \
+  _______, _______, KC_MINS, KC_7, \
+  _______, _______, KC_EQL,  KC_8, \
+  _______, _______, KC_LBRC, KC_9, \
+  _______, _______, KC_RBRC, KC_0, \
+  _______, _______, KC_BSLS, KC_DEL),
+};


### PR DESCRIPTION
Using only one layer, and activating it with two keys on the left, one on the right at the moment. 
As with previous comments, this isn't final, but is a good starting point for a one-handed keyboard, two halves of a split Planck-like ortholinear keyboard, or a sample AMJPad keymap to show a layout with a function layer.