### PR TITLE
Add possibility to override the command to execute when flashing

### DIFF
--- a/tmk_core/chibios.mk
+++ b/tmk_core/chibios.mk
@@ -151,5 +151,7 @@ endif
 # List any extra directories to look for libraries here.
 EXTRALIBDIRS = $(RULESPATH)/ld
 
+DFU_UTIL ?= dfu-util
+
 dfu-util: $(BUILD_DIR)/$(TARGET).bin sizeafter
-	dfu-util $(DFU_ARGS) -D $(BUILD_DIR)/$(TARGET).bin
+	$(DFU_UTIL) $(DFU_ARGS) -D $(BUILD_DIR)/$(TARGET).bin


### PR DESCRIPTION
This exposes the following makefile variables
```
TEENSY_LOADER_CLI
BATCHISP
DFU_PROGRAMMER
DFU_UTIL
```
This could be used for passing extra arguments to the flashing tool. But more importantly it allows you to specify a different executable to support for example the Windows subystem for Linux. You can for example add this to your `.profile` file. `export DFU_PROGRAMMER=/mnt/c/path/to/dfu_programmer.exe` to make it use the Windows version of `dfu-programmer`. Note that you need the Windows 10 Creators update, and that the command has to end with `.exe`.

I have tested this with both `dfu` and `dfu-util`. 