### PR TITLE
Cleaning Up Dockerfile Layers Per Official Docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM debian:jessie
 MAINTAINER Erik Dasque <erik@frenchguys.com>
 
-RUN apt-get update
-RUN apt-get install --no-install-recommends -y build-essential \
+RUN apt-get update && apt-get install --no-install-recommends -y build-essential \
     gcc \
     unzip \
     wget \
@@ -15,10 +14,8 @@ RUN apt-get install --no-install-recommends -y build-essential \
     gcc-arm-none-eabi \
     binutils-arm-none-eabi \
     libnewlib-arm-none-eabi \
-    git
-
-RUN apt-get clean
-RUN rm -rf /var/lib/apt/lists/*
+    git \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV keyboard=ergodox
 ENV subproject=ez


### PR DESCRIPTION
From the official docs: 

```
Note: The official Debian and Ubuntu images automatically run apt-get clean, 
so explicit invocation is not required.
```

Also added ` && rm -rf /var/lib/apt/lists/*` as part of the install line which probably does what was intended (no need to make a new layer). 

Added `apt-get update` to the `RUN` payload, as it should be part of the same layer. 

All changes are documented here: https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/