### PR TITLE
Add DYN_REC_STOP to the dynamic macros, cleanup PR #1267

### DIFF
--- a/keyboards/hhkb/keymaps/cinaeco/Makefile
+++ b/keyboards/hhkb/keymaps/cinaeco/Makefile
@@ -1,0 +1,23 @@
+# cinaeco's HHKB firmware
+
+# Build Options
+#   change to "no" to disable the options, or define them in the Makefile in
+#   the appropriate keymap folder that will get included automatically
+#
+BOOTMAGIC_ENABLE = no       # Virtual DIP switch configuration(+1000)
+MOUSEKEY_ENABLE = yes       # Mouse keys(+4700)
+EXTRAKEY_ENABLE = yes       # Audio control and System control(+450)
+CONSOLE_ENABLE = no         # Console for debug(+400)
+COMMAND_ENABLE = yes        # Commands for debug and configuration
+NKRO_ENABLE = yes           # Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+BACKLIGHT_ENABLE = yes      # Enable keyboard backlight functionality
+MIDI_ENABLE = no            # MIDI controls
+AUDIO_ENABLE = no           # Audio output on port C6
+UNICODE_ENABLE = no         # Unicode
+BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
+RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight.  Do not enable this with audio at the same time.
+SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
+
+ifndef QUANTUM_DIR
+	include ../../../../Makefile
+endif

--- a/keyboards/hhkb/keymaps/cinaeco/README.md
+++ b/keyboards/hhkb/keymaps/cinaeco/README.md
@@ -1,0 +1,23 @@
+# QMK Keyboard Firmware for HHKB
+
+## Modifications
+
+### HHKB Fn Layer
+
+Added some Media keys.
+
+### Utility Layer (SpaceFN)
+
+Hold `Space` for:
+
+- Vi-style direction keys.
+- WASD-style mouse keys.
+- Dynamic macro playback on `1` and `2`.
+- Qwerty/Colemak/Dvorak layout selection on `-`, `=` and `\ `
+
+### Dynamic Macros
+
+Hold `q` and press:
+
+- `1` or `2` to record macro 1 or 2.
+- `s` to stop recording.

--- a/keyboards/hhkb/keymaps/cinaeco/config.h
+++ b/keyboards/hhkb/keymaps/cinaeco/config.h
@@ -1,0 +1,20 @@
+#ifndef CONFIG_CINAECO_H
+#define CONFIG_CINAECO_H
+
+#include "../../config.h"
+
+#undef MANUFACTURER
+#undef PRODUCT
+#undef DESCRIPTION
+#define MANUFACTURER    QMK
+#define PRODUCT         HHKB QMK cinaeco
+#define DESCRIPTION     HHKB on QMK Firmware with cinaeco keymap
+
+// Increase "Tap" detection window. Avoid missing 'q' or 'z' when typing slowly.
+#undef TAPPING_TERM
+#define TAPPING_TERM 230
+
+// Uncomment to enable NKRO by default. May cause issues with KVM switches.
+//#define FORCE_NKRO
+
+#endif

--- a/keyboards/hhkb/keymaps/cinaeco/keymap.c
+++ b/keyboards/hhkb/keymaps/cinaeco/keymap.c
@@ -1,0 +1,186 @@
+/*  -*-  eval: (turn-on-orgtbl); -*-
+ * cinaeco's HHKB Layout
+ */
+#include "hhkb.h"
+
+// Layers.
+#define QWER 0
+#define COLE 1
+#define DVOR 2
+#define HHKB 3
+#define UTIL 4
+#define MREC 5
+
+// Easier-to-read Layer Arrays.
+#define ____ KC_TRNS
+
+enum hhkb_keycodes {
+  DYNAMIC_MACRO_RANGE = SAFE_RANGE,
+};
+
+#include "dynamic_macro.h"
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+
+    /* QWER Layer: Qwerty Default
+     *
+     * ,--------------------------------------------------------------.
+     * |Esc|    1 |  2|  3|  4|  5|  6|  7|  8|  9|  0|  -|  =|  \|  `|
+     * |--------------------------------------------------------------|
+     * |Tab  |Q/MREC|  W|  E|  R|  T|  Y|  U|  I|  O|  P|  [|  ]|Backs|
+     * |--------------------------------------------------------------|
+     * |Ctrl  |     A|  S|  D|  F|  G|  H|  J|  K|  L|  ;|  '|Ent/Ctrl|
+     * |--------------------------------------------------------------|
+     * |Shift   |     Z|  X|  C|  V|  B|  N|  M|  ,|  .|  /|Shift |Fn0|
+     * `--------------------------------------------------------------'
+     *       |Alt|Gui  |       Space/UTIL      |Gui  |Alt|
+     *       `-------------------------------------------'
+     *
+     */
+
+  [QWER] = KEYMAP(
+  KC_ESC,  KC_1,           KC_2,    KC_3,             KC_4,    KC_5,     KC_6, KC_7, KC_8,    KC_9,   KC_0,    KC_MINS, KC_EQL,        KC_BSLS, KC_GRV, \
+  KC_TAB,  LT(MREC, KC_Q), KC_W,    KC_E,             KC_R,    KC_T,     KC_Y, KC_U, KC_I,    KC_O,   KC_P,    KC_LBRC, KC_RBRC,       KC_BSPC,         \
+  KC_LCTL, KC_A,           KC_S,    KC_D,             KC_F,    KC_G,     KC_H, KC_J, KC_K,    KC_L,   KC_SCLN, KC_QUOT, CTL_T(KC_ENT),                  \
+  KC_LSFT, KC_Z,           KC_X,    KC_C,             KC_V,    KC_B,     KC_N, KC_M, KC_COMM, KC_DOT, KC_SLSH, KC_RSFT, MO(HHKB),                       \
+           KC_LALT,        KC_LGUI, LT(UTIL, KC_SPC), KC_RGUI, KC_RALT),
+
+
+    /* COLE Layer: Colemak
+     *
+     * ,--------------------------------------------------------------.
+     * |Esc|    1 |  2|  3|  4|  5|  6|  7|  8|  9|  0|  -|  =|  \|  `|
+     * |--------------------------------------------------------------|
+     * |Tab  |Q/MREC|  W|  F|  P|  G|  J|  L|  U|  Y|  ;|  [|  ]|Backs|
+     * |--------------------------------------------------------------|
+     * |Ctrl  |     A|  R|  S|  T|  D|  H|  N|  E|  I|  O|  '|Ent/Ctrl|
+     * |--------------------------------------------------------------|
+     * |Shift   |     Z|  X|  C|  V|  K|  B|  M|  ,|  .|  /|Shift |Fn0|
+     * `--------------------------------------------------------------'
+     *       |Alt|Gui  |       Space/UTIL      |Gui  |Alt|
+     *       `-------------------------------------------'
+     *
+     */
+
+  [COLE] = KEYMAP(
+  KC_ESC,  KC_1,           KC_2,    KC_3,             KC_4,    KC_5,     KC_6, KC_7, KC_8,    KC_9,   KC_0,    KC_MINS, KC_EQL,        KC_BSLS, KC_GRV, \
+  KC_TAB,  LT(MREC, KC_Q), KC_W,    KC_F,             KC_P,    KC_G,     KC_J, KC_L, KC_U,    KC_Y,   KC_SCLN, KC_LBRC, KC_RBRC,       KC_BSPC,         \
+  KC_LCTL, KC_A,           KC_R,    KC_S,             KC_T,    KC_D,     KC_H, KC_N, KC_E,    KC_I,   KC_O,    KC_QUOT, CTL_T(KC_ENT),                  \
+  KC_LSFT, KC_Z,           KC_X,    KC_C,             KC_V,    KC_K,     KC_B, KC_M, KC_COMM, KC_DOT, KC_SLSH, KC_RSFT, MO(HHKB),                       \
+           KC_LALT,        KC_LGUI, LT(UTIL, KC_SPC), KC_RGUI, KC_RALT),
+
+
+    /* DVOR Layer: Dvorak
+     *
+     * ,--------------------------------------------------------------.
+     * |Esc|    1 |  2|  3|  4|  5|  6|  7|  8|  9|  0|  [|  ]|  \|  `|
+     * |--------------------------------------------------------------|
+     * |Tab  |'/MREC|  ,|  .|  P|  Y|  F|  G|  C|  R|  L|  /|  =|Backs|
+     * |--------------------------------------------------------------|
+     * |Ctrl  |     A|  O|  E|  U|  I|  D|  H|  T|  N|  S|  -|Ent/Ctrl|
+     * |--------------------------------------------------------------|
+     * |Shift   |     ;|  Q|  J|  K|  X|  B|  M|  W|  V|  Z|Shift |Fn0|
+     * `--------------------------------------------------------------'
+     *       |Alt|Gui  |       Space/UTIL      |Gui  |Alt|
+     *       `-------------------------------------------'
+     *
+     */
+
+  [DVOR] = KEYMAP(
+  KC_ESC,  KC_1,              KC_2,    KC_3,             KC_4,    KC_5,     KC_6, KC_7, KC_8, KC_9, KC_0, KC_LBRC, KC_RBRC,       KC_BSLS, KC_GRV, \
+  KC_TAB,  LT(MREC, KC_QUOT), KC_COMM, KC_DOT,           KC_P,    KC_Y,     KC_F, KC_G, KC_C, KC_R, KC_L, KC_SLSH, KC_EQL,        KC_BSPC,         \
+  KC_LCTL, KC_A,              KC_O,    KC_E,             KC_U,    KC_I,     KC_D, KC_H, KC_T, KC_N, KC_S, KC_MINS, CTL_T(KC_ENT),                  \
+  KC_LSFT, KC_SCLN,           KC_Q,    KC_J,             KC_K,    KC_X,     KC_B, KC_M, KC_W, KC_V, KC_Z, KC_RSFT, MO(HHKB),                       \
+           KC_LALT,           KC_LGUI, LT(UTIL, KC_SPC), KC_RGUI, KC_RALT),
+
+
+    /* HHKB Layer: HHKB mode (HHKB Fn)
+     *
+     * ,-----------------------------------------------------------.
+     * |Pwr| F1| F2| F3| F4| F5| F6| F7| F8| F9|F10|F11|F12|Ins|Del|
+     * |-----------------------------------------------------------|
+     * |Caps |PLA|PRV|NXT|   |   |   |   |Psc|Slk|Pus|Up |   |Backs|
+     * |-----------------------------------------------------------|
+     * |      |VoD|VoU|Mut|Ejc|   |  *|  /|Hom|PgU|Lef|Rig|Enter   |
+     * |-----------------------------------------------------------|
+     * |        |   |   |   |   |   |  +|  -|End|PgD|Dow|      |   |
+     * `-----------------------------------------------------------'
+     *       |   |     |                       |STOP |   |
+     *       `-------------------------------------------'
+     */
+
+  [HHKB] = KEYMAP(
+  KC_PWR,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5, KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_INS,  KC_DEL, \
+  KC_CAPS, KC_MPLY, KC_MPRV, KC_MNXT, ____,    ____,  ____,    ____,    KC_PSCR, KC_SLCK, KC_PAUS, KC_UP,   ____,    KC_BSPC,         \
+  ____,    KC_VOLD, KC_VOLU, KC_MUTE, KC_EJCT, ____,  KC_PAST, KC_PSLS, KC_HOME, KC_PGUP, KC_LEFT, KC_RGHT, KC_PENT,                  \
+  ____,    ____,    ____,    ____,    ____,    ____,  KC_PPLS, KC_PMNS, KC_END,  KC_PGDN, KC_DOWN, ____,    ____,                     \
+           ____,    ____,    ____,    KC_MSTP, ____),
+
+
+    /* UTIL Layer: Extra utilities
+     *
+     * ,-------------------------------------------------------------.
+     * |DFU|PLY1|PLY2|   |   |   |   |   |   |   |   |QWE|COL|DVO|DBG|
+     * |-------------------------------------------------------------|
+     * |     |MLB |M-Up|MRB|MwU|   |Hom|PgD|PgU|End|   |   |   |     |
+     * |-------------------------------------------------------------|
+     * |      |M-Lt|M-Dn|M-R|MwD|   |LEF|DOW|UP |RIG|   |   |        |
+     * |-------------------------------------------------------------|
+     * |        |    |    |   |   |SPC|   |   |   |   |   |      |   |
+     * `-------------------------------------------------------------'
+     *       |   |     |                       |     |   |
+     *       `-------------------------------------------'
+     *
+     */
+
+  [UTIL] = KEYMAP(
+  RESET, DYN_MACRO_PLAY1, DYN_MACRO_PLAY2, ____,    ____,    ____,   ____,    ____,    ____,    ____,    ____, DF(QWER), DF(COLE), DF(DVOR), DEBUG, \
+  ____,  KC_BTN1,         KC_MS_U,         KC_BTN2, KC_WH_U, ____,   KC_HOME, KC_PGDN, KC_PGUP, KC_END,  ____, ____,     ____,     ____,            \
+  ____,  KC_MS_L,         KC_MS_D,         KC_MS_R, KC_WH_D, ____,   KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT, ____, ____,     ____,                      \
+  ____,  ____,            ____,            ____,    ____,    KC_SPC, ____,    ____,    ____,    ____,    ____, ____,     ____,                      \
+         ____,            ____,            ____,    ____,    ____),
+
+
+    /* MREC Layer: Record macros with `q`
+     *
+     * ,-------------------------------------------------------------.
+     * |   |REC1|REC2|   |   |   |   |   |   |   |   |   |   |   |   |
+     * |-------------------------------------------------------------|
+     * |     |    |    |   |   |   |   |   |   |   |   |   |   |     |
+     * |-------------------------------------------------------------|
+     * |      |    |RSTP|   |   |   |   |   |   |   |   |   |        |
+     * |-------------------------------------------------------------|
+     * |        |    |    |   |   |   |   |   |   |   |   |      |   |
+     * `-------------------------------------------------------------'
+     *       |   |     |                       |     |   |
+     *       `-------------------------------------------'
+     *
+     */
+
+  [MREC] = KEYMAP(
+  ____, DYN_REC_START1, DYN_REC_START2, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, \
+  ____, ____,           ____,           ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____,       \
+  ____, ____,           DYN_REC_STOP,   ____, ____, ____, ____, ____, ____, ____, ____, ____, ____,             \
+  ____, ____,           ____,           ____, ____, ____, ____, ____, ____, ____, ____, ____, ____,             \
+        ____,           ____,           ____, ____, ____)
+
+};
+
+
+
+const uint16_t PROGMEM fn_actions[] = {
+
+};
+
+const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt) {
+  return MACRO_NONE;
+};
+
+// For Dynamic Macros.
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  if (!process_record_dynamic_macro(keycode, record)) {
+    return false;
+  }
+  return true;
+}

--- a/keyboards/planck/keymaps/vifon/keymap.c
+++ b/keyboards/planck/keymaps/vifon/keymap.c
@@ -107,7 +107,8 @@ const uint16_t PROGMEM fn_actions[] = {
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     static uint16_t key_timer;
 
-    if (!process_record_dynamic_macro(keycode, record)) {
+    uint16_t macro_kc = (keycode == MO(_DYN) ? DYN_REC_STOP : keycode);
+    if (!process_record_dynamic_macro(macro_kc, record)) {
         return false;
     }
 

--- a/quantum/dynamic_macro.h
+++ b/quantum/dynamic_macro.h
@@ -40,6 +40,7 @@
 enum dynamic_macro_keycodes {
     DYN_REC_START1 = DYNAMIC_MACRO_RANGE,
     DYN_REC_START2,
+    DYN_REC_STOP,
     DYN_MACRO_PLAY1,
     DYN_MACRO_PLAY2,
 };
@@ -209,9 +210,8 @@ bool process_record_dynamic_macro(uint16_t keycode, keyrecord_t *record)
     } else {
         /* A macro is being recorded right now. */
         switch (keycode) {
-        case MO(_DYN):
-            /* Use the layer key used to access the macro recording as
-             * a stop button. */
+        case DYN_REC_STOP:
+            /* Stop the macro recording. */
             if (record->event.pressed) { /* Ignore the initial release
                                           * just after the recoding
                                           * starts. */

--- a/quantum/dynamic_macro.h
+++ b/quantum/dynamic_macro.h
@@ -119,9 +119,7 @@ void dynamic_macro_record_key(
         **macro_pointer = *record;
         *macro_pointer += direction;
     } else {
-        /* Notify about the end of buffer. The blinks are paired
-         * because they should happen on both down and up events. */
-        backlight_toggle();
+        dynamic_macro_led_blink();
     }
 }
 

--- a/quantum/dynamic_macro.h
+++ b/quantum/dynamic_macro.h
@@ -97,17 +97,24 @@ void dynamic_macro_play(
 /**
  * Record a single key in a dynamic macro.
  *
+ * @param macro_buffer[in] The start of the used macro buffer.
  * @param macro_pointer[in,out] The current buffer position.
  * @param macro_end2[in] The end of the other macro which shouldn't be overwritten.
  * @param direction[in]  Either +1 or -1, which way to iterate the buffer.
  * @param record[in]     The current keypress.
  */
 void dynamic_macro_record_key(
+    keyrecord_t *macro_buffer,
     keyrecord_t **macro_pointer,
     keyrecord_t *macro_end2,
     int8_t direction,
     keyrecord_t *record)
 {
+    /* If we've just started recording, ignore all the key releases. */
+    if (!record->event.pressed && *macro_pointer == macro_buffer) {
+        return;
+    }
+
     if (*macro_pointer + direction != macro_end2) {
         **macro_pointer = *record;
         *macro_pointer += direction;
@@ -230,10 +237,10 @@ bool process_record_dynamic_macro(uint16_t keycode, keyrecord_t *record)
             /* Store the key in the macro buffer and process it normally. */
             switch (macro_id) {
             case 1:
-                dynamic_macro_record_key(&macro_pointer, r_macro_end, +1, record);
+                dynamic_macro_record_key(macro_buffer, &macro_pointer, r_macro_end, +1, record);
                 break;
             case 2:
-                dynamic_macro_record_key(&macro_pointer, macro_end, -1, record);
+                dynamic_macro_record_key(r_macro_buffer, &macro_pointer, macro_end, -1, record);
                 break;
             }
             return true;

--- a/quantum/dynamic_macro.h
+++ b/quantum/dynamic_macro.h
@@ -99,14 +99,14 @@ void dynamic_macro_play(
  *
  * @param macro_buffer[in] The start of the used macro buffer.
  * @param macro_pointer[in,out] The current buffer position.
- * @param macro_end2[in] The end of the other macro which shouldn't be overwritten.
+ * @param macro2_end[in] The last buffer element it is safe to use before overwriting the other macro.
  * @param direction[in]  Either +1 or -1, which way to iterate the buffer.
  * @param record[in]     The current keypress.
  */
 void dynamic_macro_record_key(
     keyrecord_t *macro_buffer,
     keyrecord_t **macro_pointer,
-    keyrecord_t *macro_end2,
+    keyrecord_t *macro2_end,
     int8_t direction,
     keyrecord_t *record)
 {
@@ -115,7 +115,7 @@ void dynamic_macro_record_key(
         return;
     }
 
-    if (*macro_pointer + direction != macro_end2) {
+    if (*macro_pointer - direction != macro2_end) {
         **macro_pointer = *record;
         *macro_pointer += direction;
     } else {


### PR DESCRIPTION
Do not record the layer modifiers (and other keys) released just after initiating the macro recording.

Includes and closes #1267.