### PR TITLE
dynamic macros: Trim the trailing modifiers; further cleanup

### DIFF
--- a/quantum/dynamic_macro.h
+++ b/quantum/dynamic_macro.h
@@ -127,9 +127,21 @@ void dynamic_macro_record_key(
  * End recording of the dynamic macro. Essentially just update the
  * pointer to the end of the macro.
  */
-void dynamic_macro_record_end(keyrecord_t *macro_pointer, keyrecord_t **macro_end)
+void dynamic_macro_record_end(
+    keyrecord_t *macro_buffer,
+    keyrecord_t *macro_pointer,
+    int8_t direction,
+    keyrecord_t **macro_end)
 {
     dynamic_macro_led_blink();
+
+    /* Do not save the keys being held when stopping the recording,
+     * i.e. the keys used to access the layer DYN_REC_STOP is on.
+     */
+    while (macro_pointer != macro_buffer &&
+           (macro_pointer - direction)->event.pressed) {
+        macro_pointer -= direction;
+    }
 
     *macro_end = macro_pointer;
 }
@@ -222,10 +234,10 @@ bool process_record_dynamic_macro(uint16_t keycode, keyrecord_t *record)
                                           * starts. */
                 switch (macro_id) {
                 case 1:
-                    dynamic_macro_record_end(macro_pointer, &macro_end);
+                    dynamic_macro_record_end(macro_buffer, macro_pointer, +1, &macro_end);
                     break;
                 case 2:
-                    dynamic_macro_record_end(macro_pointer, &r_macro_end);
+                    dynamic_macro_record_end(r_macro_buffer, macro_pointer, -1, &r_macro_end);
                     break;
                 }
                 macro_id = 0;

--- a/quantum/dynamic_macro.h
+++ b/quantum/dynamic_macro.h
@@ -48,9 +48,11 @@ enum dynamic_macro_keycodes {
 /* Blink the LEDs to notify the user about some event. */
 void dynamic_macro_led_blink(void)
 {
+#ifdef BACKLIGHT_ENABLE
     backlight_toggle();
     _delay_ms(100);
     backlight_toggle();
+#endif
 }
 
 /* Convenience macros used for retrieving the debug info. All of them

--- a/quantum/dynamic_macro.h
+++ b/quantum/dynamic_macro.h
@@ -99,7 +99,7 @@ void dynamic_macro_play(
  *
  * @param macro_buffer[in] The start of the used macro buffer.
  * @param macro_pointer[in,out] The current buffer position.
- * @param macro2_end[in] The last buffer element it is safe to use before overwriting the other macro.
+ * @param macro2_end[in] The end of the other macro.
  * @param direction[in]  Either +1 or -1, which way to iterate the buffer.
  * @param record[in]     The current keypress.
  */
@@ -115,6 +115,9 @@ void dynamic_macro_record_key(
         return;
     }
 
+    /* The other end of the other macro is the last buffer element it
+     * is safe to use before overwriting the other macro.
+     */
     if (*macro_pointer - direction != macro2_end) {
         **macro_pointer = *record;
         *macro_pointer += direction;
@@ -170,7 +173,7 @@ bool process_record_dynamic_macro(uint16_t keycode, keyrecord_t *record)
      * &macro_buffer   macro_end
      *  v                   v
      * +------------------------------------------------------------+
-     * |>>>>>> MACRO1 >>>>>>|    |<<<<<<<<<<<<< MACRO2 <<<<<<<<<<<<<|
+     * |>>>>>> MACRO1 >>>>>>      <<<<<<<<<<<<< MACRO2 <<<<<<<<<<<<<|
      * +------------------------------------------------------------+
      *                           ^                                 ^
      *                         r_macro_end                  r_macro_buffer


### PR DESCRIPTION
I was a bit late with the last batch of commits for the last PR (#1273), so here they are.