### PR TITLE
Change to per-key eager debouncing for ErgoDox EZ.

### DIFF
--- a/keyboards/ergodox/ez/config.h
+++ b/keyboards/ergodox/ez/config.h
@@ -58,7 +58,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGBW 1
 
 /* Set 0 if debouncing isn't needed */
-#define DEBOUNCE    5
+#define DEBOUNCE    15
 
 #define USB_MAX_POWER_CONSUMPTION 500
 


### PR DESCRIPTION
Empirically, waiting for N consecutive identical scans as a debouncing
strategy doesn't work very well for the ErgoDox EZ where scans are very
slow compared to most keyboards.  Instead, debounce the signals by
eagerly reporting a change as soon as one scan observes it, but then
ignoring further changes from that key for the next N scans.

This is implemented by keeping an extra matrix of uint8 countdowns, such
that only keys whose countdown is currently zero are eligible to change.
When we do observe a change, we bump that key's countdown to DEBOUNCE.
During each scan, every nonzero countdown is decremented.

With this approach to debouncing, much higher debounce constants are
tolerable, because latency does not increase with the constant, and
debounce countdowns on one key do not interfere with events on other
keys.  The only negative effect of increasing the constant is that the
minimum duration of a keypress increases.  Perhaps I'm just extremely
unlucky w.r.t. key switch quality, but I saw occasional bounces even
with DEBOUNCE=10; with 15, I've seen none so far.  That's around 47ms,
which seems like an absolutely insane amount of time for a key to be
bouncy, but at least it works.

(Note: I'm using DEBOUNCE=18 now since I saw intermittent bounces with 15).