### PR TITLE
Prevent the recording of looping dynamic macros.

### DIFF
--- a/quantum/dynamic_macro.h
+++ b/quantum/dynamic_macro.h
@@ -274,6 +274,10 @@ bool process_record_dynamic_macro(uint16_t keycode, keyrecord_t *record)
                 macro_id = 0;
             }
             return false;
+        case DYN_MACRO_PLAY1:
+        case DYN_MACRO_PLAY2:
+            dprintln("dynamic macro: ignoring macro play key while recording");
+            return false;
         default:
             /* Store the key in the macro buffer and process it normally. */
             switch (macro_id) {


### PR DESCRIPTION
If a macro play key is inadvertently recorded in a dynamic macro
a loop is created and the macro will not terminate when played.

This should be prevented.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qmk/qmk_firmware/1294)
<!-- Reviewable:end -->
