### PR TITLE
Let's Split avrdude portability fix

### DIFF
--- a/keyboards/lets_split/rules.mk
+++ b/keyboards/lets_split/rules.mk
@@ -78,7 +78,7 @@ CUSTOM_MATRIX = yes
 avrdude: build
 	ls /dev/tty* > /tmp/1; \
 	echo "Reset your Pro Micro now"; \
-	while [[ -z $$USB ]]; do \
+	while [ -z $$USB ]; do \
 	  sleep 1; \
 	  ls /dev/tty* > /tmp/2; \
 	  USB=`diff /tmp/1 /tmp/2 | grep -o '/dev/tty.*'`; \


### PR DESCRIPTION
Recently ran into a problem where someone was flashing from a raspberry pi and double brackets isn't available. 