### PR TITLE
Fix spanish keymap

### DIFF
--- a/quantum/keymap_extras/keymap_spanish.h
+++ b/quantum/keymap_extras/keymap_spanish.h
@@ -72,6 +72,6 @@
 #define ES_RBRC ALGR(ES_PLUS)
 
 #define ES_LCBR	ALGR(ES_ACUT)
-#define ES_RCRB	ALGR(ES_CCED)
+#define ES_RCBR	ALGR(ES_CCED)
 
 #endif

--- a/quantum/keymap_extras/keymap_spanish.h
+++ b/quantum/keymap_extras/keymap_spanish.h
@@ -55,8 +55,8 @@
 #define ES_UMLT	LSFT(ES_GRV)
 
 #define ES_GRTR	LSFT(ES_LESS)
-#define ES_SCLN	LSFT(ES_COMM)
-#define ES_COLN	LSFT(ES_DOT)
+#define ES_SCLN	LSFT(KC_COMM)
+#define ES_COLN	LSFT(KC_DOT)
 #define ES_UNDS	LSFT(ES_MINS)
 
 // Alt Gr-ed characters


### PR DESCRIPTION
Hi! I was building a custom spanish layout and the firmware failed to compile.
There's two undefined macros being referenced in the shifted characters. They're not necessary as spanish dot and comma are in the same position as in US layout, so I just used the KC macros.
Also, I found confusing that '{' is named ES_LCBR and '}' is named ES_RCRB.

The changes have now been tested on my keyboard, so I thought I'd share.