### PR TITLE
Added Grave Escape

### DIFF
--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -437,6 +437,16 @@ bool process_record_quantum(keyrecord_t *record) {
       return false;
       // break;
     }
+    case QK_GRAVE_ESC: {
+      void (*method)(uint8_t) = (record->event.pressed) ? &add_key : &del_key;
+      uint8_t shifted = get_mods() & (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT));
+
+      if(layer_state == 0)
+        method(shifted ? KC_GRAVE : KC_ESCAPE);
+      else
+        method(shifted ? KC_ESCAPE : KC_GRAVE);
+      send_keyboard_report(); 
+    }
     default: {
       shift_interrupted[0] = true;
       shift_interrupted[1] = true;

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -439,12 +439,10 @@ bool process_record_quantum(keyrecord_t *record) {
     }
     case GRAVE_ESC: {
       void (*method)(uint8_t) = (record->event.pressed) ? &add_key : &del_key;
-      uint8_t shifted = get_mods() & (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT));
+      uint8_t shifted = get_mods() & ((MOD_BIT(KC_LSHIFT)|MOD_BIT(KC_RSHIFT)
+                                      |MOD_BIT(KC_LGUI)|MOD_BIT(KC_RGUI)));
 
-      if(layer_state == 0)
-        method(shifted ? KC_GRAVE : KC_ESCAPE);
-      else
-        method(shifted ? KC_ESCAPE : KC_GRAVE);
+      method(shifted ? KC_GRAVE : KC_ESCAPE);
       send_keyboard_report(); 
     }
     default: {

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -437,7 +437,7 @@ bool process_record_quantum(keyrecord_t *record) {
       return false;
       // break;
     }
-    case QK_GRAVE_ESC: {
+    case GRAVE_ESC: {
       void (*method)(uint8_t) = (record->event.pressed) ? &add_key : &del_key;
       uint8_t shifted = get_mods() & (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT));
 

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -85,7 +85,7 @@ enum quantum_keycodes {
 
     RESET = 0x5C00,
     DEBUG,
-    QK_GRAVE_ESC      = 0x5900,
+    GRAVE_ESC      = 0x5900,
     MAGIC_SWAP_CONTROL_CAPSLOCK,
     MAGIC_CAPSLOCK_TO_CONTROL,
     MAGIC_SWAP_LALT_LGUI,
@@ -515,7 +515,7 @@ enum quantum_keycodes {
 #define MACROTAP(kc) (kc | QK_MACRO | FUNC_TAP<<8)
 #define MACRODOWN(...) (record->event.pressed ? MACRO(__VA_ARGS__) : MACRO_NONE)
 
-#define KC_GESC QK_GRAVE_ESC
+#define KC_GESC GRAVE_ESC
 
 
 // L-ayer, T-ap - 256 keycode max, 16 layer max

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -85,7 +85,6 @@ enum quantum_keycodes {
 
     RESET = 0x5C00,
     DEBUG,
-    GRAVE_ESC      = 0x5900,
     MAGIC_SWAP_CONTROL_CAPSLOCK,
     MAGIC_CAPSLOCK_TO_CONTROL,
     MAGIC_SWAP_LALT_LGUI,
@@ -105,6 +104,7 @@ enum quantum_keycodes {
     MAGIC_UNHOST_NKRO,
     MAGIC_UNSWAP_ALT_GUI,
     MAGIC_TOGGLE_NKRO,
+    GRAVE_ESC,
 
     // Leader key
 #ifndef DISABLE_LEADER

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -85,6 +85,7 @@ enum quantum_keycodes {
 
     RESET = 0x5C00,
     DEBUG,
+    QK_GRAVE_ESC      = 0x5900,
     MAGIC_SWAP_CONTROL_CAPSLOCK,
     MAGIC_CAPSLOCK_TO_CONTROL,
     MAGIC_SWAP_LALT_LGUI,
@@ -513,6 +514,8 @@ enum quantum_keycodes {
 
 #define MACROTAP(kc) (kc | QK_MACRO | FUNC_TAP<<8)
 #define MACRODOWN(...) (record->event.pressed ? MACRO(__VA_ARGS__) : MACRO_NONE)
+
+#define KC_GESC QK_GRAVE_ESC
 
 
 // L-ayer, T-ap - 256 keycode max, 16 layer max


### PR DESCRIPTION
Adds GRAVE_ESCAPE and KC_GESC. This will act as escape when pressed but when pressed with shift will send a ~

code originally found here: https://github.com/p3lim/keyboard_firmware