### PR TITLE
Oneshot mods timeout

### DIFF
--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -70,6 +70,9 @@ void action_exec(keyevent_t event)
         dprintf("Oneshot layer: timeout\n");
         clear_oneshot_layer_state(ONESHOT_OTHER_KEY_PRESSED);
     }
+    if (has_oneshot_mods_timed_out()) {
+        clear_oneshot_mods();
+    }
 #endif
 
 #ifndef NO_ACTION_TAPPING

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -67,7 +67,6 @@ void action_exec(keyevent_t event)
 
 #if (defined(ONESHOT_TIMEOUT) && (ONESHOT_TIMEOUT > 0))
     if (has_oneshot_layer_timed_out()) {
-        dprintf("Oneshot layer: timeout\n");
         clear_oneshot_layer_state(ONESHOT_OTHER_KEY_PRESSED);
     }
     if (has_oneshot_mods_timed_out()) {


### PR DESCRIPTION
While trying to make a tool to display the one mods I noted that `get_oneshot_mods()` doesn't get cleared after a oneshot mode gets used.

Gitter suggested a fix similar to #1010 so here it is. This solves my problem at least

I also removed a noisy debug statement that's activated on ACTION DEBUG