### PR TITLE
Fix the two failing keymaps and improve the travis build script

### DIFF
--- a/keyboards/ergodox/keymaps/belak/keymap.c
+++ b/keyboards/ergodox/keymaps/belak/keymap.c
@@ -2,6 +2,7 @@
 #include "debug.h"
 #include "action_layer.h"
 #include "eeconfig.h"
+#include "eeprom.h"
 
 #define LAYER_ON(pos) ((layer_state) & (1<<(pos)))
 #define _______ KC_TRNS

--- a/keyboards/lets_split/keymaps/khord/config.h
+++ b/keyboards/lets_split/keymaps/khord/config.h
@@ -20,9 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define USE_SERIAL
 #define EE_HANDS
 
-#undef RGBLED_NUM
 #define RGBLIGHT_ANIMATIONS
-#define RGBLED_NUM 12
 
 #ifdef SUBPROJECT_rev1
     #include "../../rev1/config.h"

--- a/util/travis_build.sh
+++ b/util/travis_build.sh
@@ -6,7 +6,8 @@ TRAVIS_COMMIT_RANGE="${TRAVIS_COMMIT_RANGE:-HEAD~1..HEAD}"
 if [[ "$TRAVIS_COMMIT_MESSAGE" != *"[skip build]"* ]] ; then 
 	exit_code=0
 	NEFM=$(git diff --name-only -n 1 ${TRAVIS_COMMIT_RANGE} | grep -Ev '^(keyboards/)'  | grep -Ev '^(docs/)' | wc -l)
-	if [[ $NEFM -gt 0 ]] ; then
+	BRANCH=$(git rev-parse --abbrev-ref HEAD)
+	if [ $NEFM -gt 0 -o "$BRANCH" = "master" ]; then
 		echo "Making all keymaps for all keyboards"
 		make all-keyboards AUTOGEN="true"
 		: $((exit_code = $exit_code + $?))

--- a/util/travis_build.sh
+++ b/util/travis_build.sh
@@ -14,7 +14,7 @@ if [[ "$TRAVIS_COMMIT_MESSAGE" != *"[skip build]"* ]] ; then
 		MKB=$(git diff --name-only -n 1 ${TRAVIS_COMMIT_RANGE} | grep -oP '(?<=keyboards\/)([a-zA-Z0-9_]+)(?=\/)' | sort -u)
 		for KB in $MKB ; do
 			echo "Making all keymaps for $KB"
-			make "$KB" AUTOGEN=true
+			make ${KB}-allsp-allkm AUTOGEN=true
 			: $((exit_code = $exit_code + $?))
 		done
 	fi


### PR DESCRIPTION
The Travis build script has been improved in the following way:

1. Compile all subprojects when a keyboard or keymap is changed
2. Always compile everything on master
3. Build only the keymap for all subprojects if a single keymap is changed

@belak and @khord, I fixed a minor issue in your keymaps.
