### PR TITLE
tv44: Add core layout based on the Core 47

### DIFF
--- a/keyboards/tv44/keymaps/core/Makefile
+++ b/keyboards/tv44/keymaps/core/Makefile
@@ -1,0 +1,3 @@
+ifndef QUANTUM_DIR
+	include ../../../../Makefile
+endif

--- a/keyboards/tv44/keymaps/core/keymap.c
+++ b/keyboards/tv44/keymaps/core/keymap.c
@@ -1,0 +1,34 @@
+#include "tv44.h"
+#include "action_layer.h"
+#include "eeconfig.h"
+
+#define _QW 0
+#define _L1 1
+#define _L2 2
+
+// Fillers to make layering more clear
+#define _______ KC_TRNS
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  [_QW] = KEYMAP( /* Qwerty */
+    KC_ESC,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_BSPC,
+    KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_ENT,
+    KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_RSFT, MO(_L2),
+    KC_LCTL, KC_LGUI, KC_LALT,                   KC_SPC,  KC_SPC,                    MO(_L1), KC_RALT, KC_RCTL
+  ),
+  [_L1] = KEYMAP( /* LAYER 1 */
+    KC_GRV,  KC_VOLD, KC_VOLU, KC_MUTE, _______, _______, KC_CALC, KC_PGUP, KC_UP,   KC_PGDN, KC_PSCR, KC_PAUS,
+    KC_TAB,  KC_MPRV, KC_MPLY, KC_MNXT, _______, _______, KC_HOME, KC_LEFT, KC_DOWN, KC_RGHT, KC_INS,  _______,
+    _______, _______, _______, _______, _______, _______, KC_END,  _______, _______, _______, _______, _______,
+    _______, _______, _______,                   _______, _______,                   _______, _______, _______
+  ),
+  [_L2] = KEYMAP( /* LAYER 2 */
+    KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,
+    KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_UNDS, KC_PLUS,
+    _______, _______, _______, _______, _______, KC_COMM, KC_SLSH, KC_RBRC, KC_LBRC, KC_BSLS, _______, _______,
+    _______, _______, _______,                   _______, _______,                   _______, _______, _______
+  ),
+};
+
+const uint16_t PROGMEM fn_actions[] = {
+};

--- a/keyboards/tv44/keymaps/core/readme.md
+++ b/keyboards/tv44/keymaps/core/readme.md
@@ -1,0 +1,18 @@
+# A minivan keymap based off the Vertex Core
+
+## Main differences
+
+* There are only 3 keys on the bottom right, so menu was dropped
+* There are only 3 keys on the bottom left, so Pn was dropped because there is
+  no programmable layer.
+* There are only 12 keys in the first row, so the delete key (along with scroll
+  lock) has been dropped.
+* The F1-F12 keys have been shifted by 1 so they all fit in the first row of
+  layer 2.
+* Moved the grave/tilde to layer 1 (because in layer 2 it's now taken up by F1).
+* Keys relating to speed have been removed
+* The `L_Win + L_Alt + R_spacebar = R_Shift, R_Alt, Menu and R_Ctrl as arrow
+  keys` as mentioned in the manual does not work.
+* The layer 2 plus shift should have support for symbols in the first row (where
+  the F1-F12 keys are) but this has not been implemented, so you need to use the
+  second row (where the numbers are).


### PR DESCRIPTION
I'm not sure if this is worth including or not, but I've been playing around with a layout roughly based on the Core 47... though I had to make some changes because there are 3 less keys (at least with the base tv44).