### PR TITLE
Use the new Quantum KC_GESC instead of custom code

### DIFF
--- a/keyboards/s65_x/keymaps/default/keymap.c
+++ b/keyboards/s65_x/keymaps/default/keymap.c
@@ -1,5 +1,4 @@
 #include "s65_x.h"
-#include "action_layer.h"
 
 #define _BL 0
 #define _AL 1
@@ -23,10 +22,10 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
   /* 0: ANSI qwerty */
   [_BL] = ANSI_KEYMAP(
-        F(4),   KC_1, KC_2, KC_3, KC_4, KC_5, KC_6, KC_7, KC_8, KC_9, KC_0, KC_MINS, KC_EQL, KC_BSPC, KC_DEL, \
-        KC_TAB, KC_Q, KC_W, KC_E, KC_R, KC_T, KC_Y, KC_U, KC_I, KC_O, KC_P, KC_LBRC, KC_RBRC, KC_BSLS, KC_END, \
-        F(2),   KC_A, KC_S, KC_D, KC_F, KC_G, KC_H, KC_J, KC_K, KC_L, KC_SCLN, KC_QUOT,       KC_ENT,     KC_PGUP, \
-        KC_LSFT,     KC_Z, KC_X, KC_C, KC_V, KC_B, KC_N, KC_M, KC_COMM, KC_DOT, KC_SLSH,    KC_RSFT, KC_UP, KC_PGDN, \
+        KC_GESC, KC_1, KC_2, KC_3, KC_4, KC_5, KC_6, KC_7, KC_8, KC_9, KC_0, KC_MINS, KC_EQL, KC_BSPC, KC_DEL, \
+        KC_TAB,  KC_Q, KC_W, KC_E, KC_R, KC_T, KC_Y, KC_U, KC_I, KC_O, KC_P, KC_LBRC, KC_RBRC, KC_BSLS, KC_END, \
+        F(2),    KC_A, KC_S, KC_D, KC_F, KC_G, KC_H, KC_J, KC_K, KC_L, KC_SCLN, KC_QUOT,       KC_ENT,     KC_PGUP, \
+        KC_LSFT,       KC_Z, KC_X, KC_C, KC_V, KC_B, KC_N, KC_M, KC_COMM, KC_DOT, KC_SLSH,    KC_RSFT, KC_UP, KC_PGDN, \
         KC_LCTL, KC_LALT, KC_LGUI,            KC_SPC,            KC_RALT, MO(_FL), KC_RCTL, KC_LEFT, KC_DOWN, KC_RIGHT),
 
 
@@ -94,74 +93,11 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
       KC_TRNS, KC_TRNS, KC_TRNS,               KC_TRNS,                KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS),
 };
 
-enum function_id {
-  SHIFT_ESC,
-};
 
 const uint16_t PROGMEM fn_actions[] = {
   [0] = ACTION_LAYER_MOMENTARY(_FL),       // Momentary Fn overlay
   [1] = ACTION_LAYER_TOGGLE(_AL),          // Toggle Arrow Layer overlay
   [2] = ACTION_LAYER_TAP_KEY(_FL, KC_CAPS),// Tap to toggle caps lock and hold to activate function layer
   [3] = ACTION_LAYER_TOGGLE(_UL),          // Toggle Underglow Layer overlay
-  [4] = ACTION_FUNCTION(SHIFT_ESC),
 };
 
-void matrix_scan_user(void) {
-
-  // Would like to do something like this, that would be cool
-  // Turn off all the LEDs on except for the ones mapped on the UL layer, for example
-  /* uint32_t layer = layer_state; */
-  /* if (layer & (1<<1)) { */
-  /*   gh60_wasd_leds_on(); */
-  /* } else { */
-  /*   gh60_wasd_leds_off(); */
-  /* } */
-  /*  */
-  /* if (layer & (1<<2)) { */
-  /*   gh60_esc_led_on(); */
-  /* } else { */
-  /*   gh60_esc_led_off(); */
-  /* } */
-};
-
-const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt) {
-  // MACRODOWN only works in this function
-  switch(id) {
-    case 0:
-      if (record->event.pressed) {
-        register_code(KC_RSFT);
-      } else {
-        unregister_code(KC_RSFT);
-      }
-      break;
-  }
-  return MACRO_NONE;
-};
-
-#define MODS_CTRL_MASK  (MOD_BIT(KC_LSHIFT)|MOD_BIT(KC_RSHIFT))
-void action_function(keyrecord_t *record, uint8_t id, uint8_t opt) {
-  switch (id) {
-    static uint8_t shift_esc_shift_mask;
-    // Shift + ESC = ~
-    case SHIFT_ESC:
-      shift_esc_shift_mask = get_mods()&MODS_CTRL_MASK;
-      if (record->event.pressed) {
-        if (shift_esc_shift_mask) {
-          add_key(KC_GRV);
-          send_keyboard_report();
-        } else {
-          add_key(KC_ESC);
-          send_keyboard_report();
-        }
-      } else {
-        if (shift_esc_shift_mask) {
-          del_key(KC_GRV);
-          send_keyboard_report();
-        } else {
-          del_key(KC_ESC);
-          send_keyboard_report();
-        }
-      }
-      break;
-  }
-};

--- a/keyboards/s65_x/keymaps/iso/keymap.c
+++ b/keyboards/s65_x/keymaps/iso/keymap.c
@@ -1,5 +1,4 @@
 #include "s65_x.h"
-#include "action_layer.h"
 
 #define _BL 0
 #define _AL 1
@@ -23,7 +22,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
   /* 0: ISO qwerty */
   [_BL] = ISO_KEYMAP(
-        F(4),   KC_1, KC_2, KC_3, KC_4, KC_5, KC_6, KC_7, KC_8, KC_9, KC_0, KC_MINS, KC_EQL,       KC_BSPC,  KC_DEL, \
+        KC_GESC, KC_1, KC_2, KC_3, KC_4, KC_5, KC_6, KC_7, KC_8, KC_9, KC_0, KC_MINS, KC_EQL,       KC_BSPC,  KC_DEL, \
         KC_TAB,  KC_Q, KC_W, KC_E, KC_R, KC_T, KC_Y, KC_U, KC_I, KC_O, KC_P, KC_LBRC, KC_RBRC,                KC_END, \
         F(2),    KC_A, KC_S, KC_D, KC_F, KC_G, KC_H, KC_J, KC_K, KC_L, KC_SCLN, KC_QUOT, KC_GRAVE,    KC_ENT, KC_PGUP, \
         KC_LSFT, KC_BSLS, KC_Z, KC_X, KC_C, KC_V, KC_B, KC_N, KC_M, KC_COMM, KC_DOT, KC_SLSH,   KC_RSFT, KC_UP, KC_PGDN, \
@@ -95,74 +94,10 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 };
 
 
-enum function_id {
-  SHIFT_ESC,
-};
-
 const uint16_t PROGMEM fn_actions[] = {
   [0]  = ACTION_LAYER_MOMENTARY(_FL),       // Momentary Fn overlay
   [1]  = ACTION_LAYER_TOGGLE(_AL),          // Toggle Arrow Layer overlay
   [2]  = ACTION_LAYER_TAP_KEY(_FL, KC_CAPS),// Tap to toggle caps lock and hold to activate function layer
   [3]  = ACTION_LAYER_TOGGLE(_UL),          // Toggle Underglow Layer overlay
-  [12] = ACTION_FUNCTION(SHIFT_ESC),
 };
 
-void matrix_scan_user(void) {
-
-  // Would like to do something like this, that would be cool
-  // Turn off all the LEDs on except for the ones mapped on the UL layer, for example
-  /* uint32_t layer = layer_state; */
-  /* if (layer & (1<<1)) { */
-  /*   gh60_wasd_leds_on(); */
-  /* } else { */
-  /*   gh60_wasd_leds_off(); */
-  /* } */
-  /*  */
-  /* if (layer & (1<<2)) { */
-  /*   gh60_esc_led_on(); */
-  /* } else { */
-  /*   gh60_esc_led_off(); */
-  /* } */
-};
-
-const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt) {
-  // MACRODOWN only works in this function
-  switch(id) {
-    case 0:
-      if (record->event.pressed) {
-        register_code(KC_RSFT);
-      } else {
-        unregister_code(KC_RSFT);
-      }
-      break;
-  }
-  return MACRO_NONE;
-};
-
-#define MODS_CTRL_MASK  (MOD_BIT(KC_LSHIFT)|MOD_BIT(KC_RSHIFT))
-void action_function(keyrecord_t *record, uint8_t id, uint8_t opt) {
-  switch (id) {
-    static uint8_t shift_esc_shift_mask;
-    // Shift + ESC = ~
-    case SHIFT_ESC:
-      shift_esc_shift_mask = get_mods()&MODS_CTRL_MASK;
-      if (record->event.pressed) {
-        if (shift_esc_shift_mask) {
-          add_key(KC_GRV);
-          send_keyboard_report();
-        } else {
-          add_key(KC_ESC);
-          send_keyboard_report();
-        }
-      } else {
-        if (shift_esc_shift_mask) {
-          del_key(KC_GRV);
-          send_keyboard_report();
-        } else {
-          del_key(KC_ESC);
-          send_keyboard_report();
-        }
-      }
-      break;
-  }
-};

--- a/keyboards/s65_x/keymaps/nall/keymap.c
+++ b/keyboards/s65_x/keymaps/nall/keymap.c
@@ -1,5 +1,4 @@
 #include "s65_x.h"
-#include "action_layer.h"
 
 #define _BL 0
 #define _AL 1
@@ -23,7 +22,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
   /* 0: ANSI qwerty */
   [_BL] = ANSI_KEYMAP(
-        F(4),   KC_1, KC_2, KC_3, KC_4, KC_5, KC_6, KC_7, KC_8, KC_9, KC_0, KC_MINS, KC_EQL, KC_BSPC, KC_DEL, \
+        KC_GESC,KC_1, KC_2, KC_3, KC_4, KC_5, KC_6, KC_7, KC_8, KC_9, KC_0, KC_MINS, KC_EQL, KC_BSPC, KC_DEL, \
         KC_TAB, KC_Q, KC_W, KC_E, KC_R, KC_T, KC_Y, KC_U, KC_I, KC_O, KC_P, KC_LBRC, KC_RBRC, KC_BSLS, KC_END, \
         F(2),   KC_A, KC_S, KC_D, KC_F, KC_G, KC_H, KC_J, KC_K, KC_L, KC_SCLN, KC_QUOT,       KC_ENT,     KC_PGUP, \
         KC_LSPO,     KC_Z, KC_X, KC_C, KC_V, KC_B, KC_N, KC_M, KC_COMM, KC_DOT, KC_SLSH,    KC_RSPC, KC_UP, KC_PGDN, \
@@ -94,74 +93,10 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
       KC_TRNS, KC_TRNS, KC_TRNS,               KC_TRNS,                KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS),
 };
 
-enum function_id {
-  SHIFT_ESC,
-};
-
 const uint16_t PROGMEM fn_actions[] = {
   [0] = ACTION_LAYER_MOMENTARY(_FL),       // Momentary Fn overlay
   [1] = ACTION_LAYER_TOGGLE(_AL),          // Toggle Arrow Layer overlay
   [2] = ACTION_LAYER_TAP_KEY(_FL, KC_CAPS),// Tap to toggle caps lock and hold to activate function layer
   [3] = ACTION_LAYER_TOGGLE(_UL),          // Toggle Underglow Layer overlay
-  [4] = ACTION_FUNCTION(SHIFT_ESC),
 };
 
-void matrix_scan_user(void) {
-
-  // Would like to do something like this, that would be cool
-  // Turn off all the LEDs on except for the ones mapped on the UL layer, for example
-  /* uint32_t layer = layer_state; */
-  /* if (layer & (1<<1)) { */
-  /*   gh60_wasd_leds_on(); */
-  /* } else { */
-  /*   gh60_wasd_leds_off(); */
-  /* } */
-  /*  */
-  /* if (layer & (1<<2)) { */
-  /*   gh60_esc_led_on(); */
-  /* } else { */
-  /*   gh60_esc_led_off(); */
-  /* } */
-};
-
-const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt) {
-  // MACRODOWN only works in this function
-  switch(id) {
-    case 0:
-      if (record->event.pressed) {
-        register_code(KC_RSFT);
-      } else {
-        unregister_code(KC_RSFT);
-      }
-      break;
-  }
-  return MACRO_NONE;
-};
-
-#define MODS_CTRL_MASK  (MOD_BIT(KC_LSHIFT)|MOD_BIT(KC_RSHIFT))
-void action_function(keyrecord_t *record, uint8_t id, uint8_t opt) {
-  switch (id) {
-    static uint8_t shift_esc_shift_mask;
-    // Shift + ESC = ~
-    case SHIFT_ESC:
-      shift_esc_shift_mask = get_mods()&MODS_CTRL_MASK;
-      if (record->event.pressed) {
-        if (shift_esc_shift_mask) {
-          add_key(KC_GRV);
-          send_keyboard_report();
-        } else {
-          add_key(KC_ESC);
-          send_keyboard_report();
-        }
-      } else {
-        if (shift_esc_shift_mask) {
-          del_key(KC_GRV);
-          send_keyboard_report();
-        } else {
-          del_key(KC_ESC);
-          send_keyboard_report();
-        }
-      }
-      break;
-  }
-};


### PR DESCRIPTION
Make use of the recently added KC_GESC instead of custom code for handling that in all of the keymaps. Delete unused code.