### PR TITLE
Create sv_SE Qwerty layout for ErgoDox EZ

### DIFF
--- a/keyboards/ergodox/keymaps/swedish/keymap.c
+++ b/keyboards/ergodox/keymaps/swedish/keymap.c
@@ -1,0 +1,247 @@
+/* Copyright 2017 Andreas Lindhé
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ergodox.h"
+#include "debug.h"
+#include "action_layer.h"
+#include "version.h"
+#include "keymap_swedish.h"
+
+#define BASE 0 // default layer
+#define SYMB 1 // symbols
+#define MDIA 2 // media keys
+
+enum custom_keycodes {
+  PLACEHOLDER = SAFE_RANGE, // can always be here
+  EPRM,
+  VRSN,
+  RGB_SLD
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+/* Keymap 0: Basic layer
+ *
+ * ,--------------------------------------------------.           ,--------------------------------------------------.
+ * |   ½    |   !  |  "   |  #   |  #   |  %   | LEFT |           | RIGHT|   &  |  /   |  (   |  )   |  =   |  ?     |
+ * |   §    |   1  |  2 @ |  3 £ |  4 $ |  5   |      |           |      |   6  |  7 { |  8 [ |  9 ] |  0 } |  + \   |
+ * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
+ * | Delete |   Q  |   W  |   E  |   R  |   T  |  L1  |           |  L1  |   Y  |   U  |   I  |   O  |   P  |   Å    |
+ * |        |      |      |      |      |      |      |           |      |      |      |      |      |      |        |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * | Caps   |   A  |   S  |   D  |   F  |   G  |------|           |------|   H  |   J  |   K  |   L  |Ö / L2|Ä / Cmd |
+ * | Lock   |      |      |      |      |      | Hyper|           | Meh  |      |      |      |      |      |        |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * | Left   |Z/Ctrl|   X  |   C  |   V  |   B  |      |           |      |   N  |   M  |   ;  |   :  |_/Ctrl| RShift |
+ * | Shift  |      |      |      |      |      |      |           |      |      |      |   ,  |   .  |-     |        |
+ * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
+ *   | '/L1 |  `   |AltShf| Left | Right|                                       |  Up  | Down |  ^   |  *   | ~L1  |
+ *   |      |  '   |      |      |      |                                       |      |      |      |      |      |
+ *   `----------------------------------'                                       `----------------------------------'
+ *                                        ,-------------.       ,---------------.
+ *                                        | App  | LGui |       | AltGr|Ctrl/Esc|
+ *                                 ,------|------|------|       |------+--------+------.
+ *                                 |      |      | Home |       | PgUp |        |      |
+ *                                 | Space|Back- |------|       |------|  Tab   |Enter |
+ *                                 |      |space | End  |       | PgDn |        |      |
+ *                                 `--------------------'       `----------------------'
+ */
+// If it accepts an argument (i.e, is a function), it doesn't need KC_.
+// Otherwise, it needs KC_*
+[BASE] = KEYMAP(  // layer 0 : default
+    // left hand
+    NO_HALF,          KC_1,           KC_2,          KC_3,    KC_4,    KC_5,   KC_LEFT,
+    KC_DELT,          KC_Q,           KC_W,          KC_E,    KC_R,    KC_T,   TG(SYMB),
+    KC_BSPC,          KC_A,           KC_S,          KC_D,    KC_F,    KC_G,
+    KC_LSFT,          CTL_T(KC_Z),    KC_X,          KC_C,    KC_V,    KC_B,   ALL_T(KC_NO),
+    LT(SYMB,NO_APOS), NO_ACUT,        LALT(KC_LSFT), KC_LEFT, KC_RGHT,
+                                          ALT_T(KC_APP),  KC_LGUI,
+                                                          KC_HOME,
+                                           KC_SPC,KC_BSPC,KC_END,
+    // right hand
+         KC_RGHT,      KC_6,   KC_7,   KC_8,    KC_9,    KC_0,              NO_PLUS,
+         TG(SYMB),     KC_Y,   KC_U,   KC_I,    KC_O,    KC_P,              NO_AA,
+                       KC_H,   KC_J,   KC_K,    KC_L,    LT(MDIA, NO_OSLH), GUI_T(NO_AE),
+         MEH_T(KC_NO), KC_N,   KC_M,   KC_COMM, KC_DOT,  CTL_T(NO_MINS),    KC_RSFT,
+                               KC_UP,  KC_DOWN, NO_CIRC, NO_ASTR,           KC_FN1,
+         NO_ALGR,        CTL_T(KC_ESC),
+         KC_PGUP,
+         KC_PGDN,KC_TAB, KC_ENT
+),
+
+/* Keymap 1: Symbol Layer
+ *
+ * ,--------------------------------------------------.           ,--------------------------------------------------.
+ * |Version |  F1  |  F2  |  F3  |  F4  |  F5  |      |           |      |  F6  |  F7  |  F8  |  F9  |  F10 |   F11  |
+ * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
+ * |        |   !  |   @  |   {  |   }  |   |  |      |           |      |   Up |   7  |   8  |   9  |   *  |   F12  |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |        |   #  |   $  |   (  |   )  |   `  |------|           |------| Down |   4  |   5  |   6  |   +  |        |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |        |   %  |   ^  |   [  |   ]  |   ~  |      |           |      |   &  |   1  |   2  |   3  |   \  |        |
+ * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
+ *   |      |      |      |      |      |                                       |      |    . |   0  |   =  |      |
+ *   `----------------------------------'                                       `----------------------------------'
+ *                                        ,-------------.       ,-------------.
+ *                                        |Animat|      |       |Toggle|Solid |
+ *                                 ,------|------|------|       |------+------+------.
+ *                                 |Bright|Bright|      |       |      |Hue-  |Hue+  |
+ *                                 |ness- |ness+ |------|       |------|      |      |
+ *                                 |      |      |      |       |      |      |      |
+ *                                 `--------------------'       `--------------------'
+ */
+// SYMBOLS
+[SYMB] = KEYMAP(
+       // left hand
+       VRSN,   KC_F1,  KC_F2,  KC_F3,  KC_F4,  KC_F5,  KC_TRNS,
+       KC_TRNS,KC_EXLM,NO_AT,  NO_LCBR,NO_RCBR,NO_PIPE,KC_TRNS,
+       KC_TRNS,KC_HASH,NO_DLR, NO_LPRN,NO_RPRN,NO_GRV,
+       KC_TRNS,KC_PERC,NO_CIRC,NO_LBRC,NO_RBRC,NO_TILD,KC_TRNS,
+          EPRM,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,
+                                       RGB_MOD,KC_TRNS,
+                                               KC_TRNS,
+                               RGB_VAD,RGB_VAI,KC_TRNS,
+       // right hand
+       KC_TRNS, KC_F6,   KC_F7,  KC_F8,   KC_F9,   KC_F10,  KC_F11,
+       KC_TRNS, KC_UP,   KC_7,   KC_8,    KC_9,    NO_ASTR, KC_F12,
+                KC_DOWN, KC_4,   KC_5,    KC_6,    NO_PLUS, KC_TRNS,
+       KC_TRNS, NO_AMPR, KC_1,   KC_2,    KC_3,    NO_MINS, KC_TRNS,
+                         KC_TRNS,KC_DOT,  KC_0,    NO_EQL,  KC_TRNS,
+       RGB_TOG, RGB_SLD,
+       KC_TRNS,
+       KC_TRNS, RGB_HUD, RGB_HUI
+),
+
+/* Keymap 2: Media and mouse keys
+ *
+ * ,--------------------------------------------------.           ,--------------------------------------------------.
+ * |        |      |      |      |      |      |      |           |      |      |      |      |      |      |        |
+ * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
+ * |        |      |      | MsUp |      |      |      |           |      |      |      |      |      |      |        |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |        |      |MsLeft|MsDown|MsRght|      |------|           |------|      |      |      |      |      |  Play  |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |        |      |      |      |      |      |      |           |      |      |      | Prev | Next |      |        |
+ * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
+ *   |      |      |      | Lclk | Rclk |                                       |VolUp |VolDn | Mute |      |      |
+ *   `----------------------------------'                                       `----------------------------------'
+ *                                        ,-------------.       ,-------------.
+ *                                        |      |      |       |      |      |
+ *                                 ,------|------|------|       |------+------+------.
+ *                                 |      |      |      |       |      |      |Brwser|
+ *                                 |      |      |------|       |------|      |Back  |
+ *                                 |      |      |      |       |      |      |      |
+ *                                 `--------------------'       `--------------------'
+ */
+// MEDIA AND MOUSE
+[MDIA] = KEYMAP(
+       KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+       KC_TRNS, KC_TRNS, KC_TRNS, KC_MS_U, KC_TRNS, KC_TRNS, KC_TRNS,
+       KC_TRNS, KC_TRNS, KC_MS_L, KC_MS_D, KC_MS_R, KC_TRNS,
+       KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+       KC_TRNS, KC_TRNS, KC_TRNS, KC_BTN1, KC_BTN2,
+                                           KC_TRNS, KC_TRNS,
+                                                    KC_TRNS,
+                                  KC_TRNS, KC_TRNS, KC_TRNS,
+    // right hand
+       KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+       KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+                 KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_MPLY,
+       KC_TRNS,  KC_TRNS, KC_TRNS, KC_MPRV, KC_MNXT, KC_TRNS, KC_TRNS,
+                          KC_VOLU, KC_VOLD, KC_MUTE, KC_TRNS, KC_TRNS,
+       KC_TRNS, KC_TRNS,
+       KC_TRNS,
+       KC_TRNS, KC_TRNS, KC_WBAK
+),
+};
+
+const uint16_t PROGMEM fn_actions[] = {
+    [1] = ACTION_LAYER_TAP_TOGGLE(SYMB)                // FN1 - Momentary Layer 1 (Symbols)
+};
+
+const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
+{
+  // MACRODOWN only works in this function
+      switch(id) {
+        case 0:
+        if (record->event.pressed) {
+          SEND_STRING (QMK_KEYBOARD "/" QMK_KEYMAP " @ " QMK_VERSION);
+        }
+        break;
+        case 1:
+        if (record->event.pressed) { // For resetting EEPROM
+          eeconfig_init();
+        }
+        break;
+      }
+    return MACRO_NONE;
+};
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  switch (keycode) {
+    // dynamically generate these.
+    case EPRM:
+      if (record->event.pressed) {
+        eeconfig_init();
+      }
+      return false;
+      break;
+    case VRSN:
+      if (record->event.pressed) {
+        SEND_STRING (QMK_KEYBOARD "/" QMK_KEYMAP " @ " QMK_VERSION);
+      }
+      return false;
+      break;
+    case RGB_SLD:
+      if (record->event.pressed) {
+        #ifdef RGBLIGHT_ENABLE
+          rgblight_mode(1);
+        #endif
+      }
+      return false;
+      break;
+  }
+  return true;
+}
+
+// Runs just one time when the keyboard initializes.
+void matrix_init_user(void) {
+
+};
+
+
+// Runs constantly in the background, in a loop.
+void matrix_scan_user(void) {
+
+    uint8_t layer = biton32(layer_state);
+
+    ergodox_board_led_off();
+    ergodox_right_led_1_off();
+    ergodox_right_led_2_off();
+    ergodox_right_led_3_off();
+    switch (layer) {
+      // TODO: Make this relevant to the ErgoDox EZ.
+        case 1:
+            ergodox_right_led_1_on();
+            break;
+        case 2:
+            ergodox_right_led_2_on();
+            break;
+        default:
+            // none
+            break;
+    }
+
+};

--- a/keyboards/ergodox/keymaps/swedish/readme.md
+++ b/keyboards/ergodox/keymaps/swedish/readme.md
@@ -1,0 +1,36 @@
+# Swedish (sv_SE) Qwerty layout for ErgoDox EZ, based on the Default configuration
+
+*NOTE:* it might still be desirable to set the software layout to sv_SE in your
+OS.
+
+Remind me and I'll provide a picture of the layout.
+
+I have tried making this as close of a match I could between the [default
+ErgoDox EZ configuration](https://ergodox-ez.com/pages/our-firmware) and a
+standard Swedish Qwerty layout.
+
+## Notable differences from default:
+
+* There are three special character buttons (acute accent, circumflex/tilde and
+  apostrophe/asterisk) that don't have any buttons to map to naturally. I've put
+  these at other places:
+
+    * Acute accent (´) can be found in the lower left corner, conveniently
+      placed to reach for making an é.
+
+    * Apostrophe (') was put in the lower left corner, close to acute accent.
+
+    * Circumflex (^) and asterisk (*) was placed in the lower right corner.
+
+    * Tilde (~) and diaeresis (¨) I couldn't find a good place for, so I left
+      those out. I could only get the buttons to produce a single one of the
+      characters. How can I get it to work properly?
+
+* The Alt button on right thumb was exchanged for AltGr (RAlt).
+
+* I changed the backslash in the numpad (layer 1) for a minus. Thought it was
+  more sensible.
+
+* I didn't find a good place for the "<>|" button, so that one was left out.
+  That is a problem that really needs to be resolved. Pipe can be found on layer
+  one, however.

--- a/quantum/keymap_extras/keymap_swedish.h
+++ b/quantum/keymap_extras/keymap_swedish.h
@@ -1,0 +1,52 @@
+/* Copyright 2017 Andreas Lindhé
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEYMAP_SWEDISH_H
+#define KEYMAP_SWEDISH_H
+
+#include "keymap_nordic.h"
+
+// There are slight differrences in the keyboards in the nordic contries
+
+// Swedish redifinitions from the nordic keyset
+#undef  NO_AE
+#define NO_AE   KC_QUOT  // ä
+#undef  NO_CIRC
+#define NO_CIRC LSFT(KC_RBRC)  // ^
+#undef  NO_GRV
+#define NO_GRV  LSFT(NO_BSLS)  //
+#undef  NO_OSLH
+#define NO_OSLH KC_SCLN  // ö
+
+// Additional Swedish keys not defined in the nordic keyset
+#define NO_AA   KC_LBRC  // å
+#define NO_ASTR LSFT(KC_BSLS)  // *
+
+// Norwegian unique MAC characters (not vetted for Swedish)
+#define NO_ACUT_MAC KC_EQL  // =
+#define NO_APOS_MAC KC_NUBS  // '
+#define NO_AT_MAC   KC_BSLS  // @
+#define NO_BSLS_MAC ALGR(LSFT(KC_7)) // '\'
+#define NO_DLR_MAC  LSFT(KC_4) // $
+#define NO_GRV_MAC ALGR(NO_BSLS) // `
+#define NO_GRTR_MAC LSFT(KC_GRV)  // >
+#define NO_LCBR_MAC ALGR(LSFT(KC_8))  // }
+#define NO_LESS_MAC KC_GRV  // >
+#define NO_PIPE_MAC ALGR(KC_7)  // |
+#define NO_RCBR_MAC ALGR(LSFT(KC_9))  // }
+
+#endif
+


### PR DESCRIPTION
*NOTE:* it might still be desirable to set the software layout to sv_SE in your
OS.

Swedish (sv_SE) Qwerty layout for ErgoDox, based on the Default configuration

I have tried making this as close of a match I could between the [default
ErgoDox EZ configuration](https://ergodox-ez.com/pages/our-firmware) and a
standard Swedish Qwerty layout.

Notable differences from default:
=================================

* There are three special character buttons (acute accent, circumflex/tilde and
  apostrophe/asterisk) that don't have any buttons to map to naturally. I've put
  these at other places:

    * Acute accent (´) can be found in the lower left corner, conveniently
      placed to reach for making an é.

    * Apostrophe (') was put in the lower left corner, close to acute accent.

    * Circumflex (^) and asterisk (*) was placed in the lower right corner.

    * Tilde (~) and diaeresis (¨) I couldn't find a good place for, so I left
      those out. I could only get the buttons to produce a single one of the
      characters. How can I get it to work properly?

* The Alt button on right thumb was exchanged for AltGr (RAlt).

* I changed the backslash in the numpad (layer 1) for a minus. Thought it was
  more sensible.

* I didn't find a good place for the "<>|" button, so that one was left out.
  That is a problem that really needs to be resolved. Pipe can be found on layer
  one, however.