### PR TITLE
Create custom layout based on swedish

### DIFF
--- a/keyboards/ergodox/keymaps/swedish-lindhe/keymap.c
+++ b/keyboards/ergodox/keymaps/swedish-lindhe/keymap.c
@@ -1,0 +1,199 @@
+/* Copyright 2017 Andreas Lindhé
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ergodox.h"
+#include "debug.h"
+#include "action_layer.h"
+#include "keymap_swedish.h"
+
+#define BASE 0 // default layer
+#define SYMB 1 // symbols
+#define MDIA 2 // media keys
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+/* Keymap 0: Basic layer
+ *
+ * ,--------------------------------------------------.           ,--------------------------------------------------.
+ * | Print  |   !  |  "   |  #   |  #   |  %   |      |           |Middle|   &  |  /   |  (   |  )   |  =   |  ?     |
+ * | Screen |   1  |  2 @ |  3 £ |  4 $ |  5   | F11  |           |Mouse |   6  |  7 { |  8 [ |  9 ] |  0 } |  + \   |
+ * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
+ * | Tab    | Q    | W    | E    | R    | T    | ~L1  |           |  L1  | Y    | U    | I    | O    | P    | Å      |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * | CapsLk | A    | S    | D    | F    | G    |------|           |------| H    | J    | K    | L    | Ö    | Ä      |
+ * |--------+------+------+------+------+------| `    |           | Del  |------+------+------+------+------+--------|
+ * | LShft  | Z    | X    | C    | V    | B    |  '   |           |      | N    | M    | ,    | .    | -    | RShift |
+ * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
+ *   | LCtl |  ^   | *    | LAlt | LGui |                                       | AltGr| Down |  Up  | Left | Right|
+ *   | (')  |  " ~ | '  ´ |      |      |                                       |      |      |      |      |      |
+ *   `----------------------------------'                                       `----------------------------------'
+ *                                        ,-------------.       ,--------------.
+ *                                        | LCtl | LAlt |       | Home |   End  |
+ *                                 ,------|------|------|       |------+-------+------.
+ *                                 |      |      |  ~   |       | PgUp |       |      |
+ *                                 | Space|Back- |------|       |------|  Tab  |Enter |
+ *                                 |      |space | Esc  |       | PgDn |       | L2   |
+ *                                 `--------------------'       `---------------------'
+ */
+
+[BASE] = KEYMAP(  // layer 0 : default
+    // left hand
+    KC_PSCR,         KC_1,     KC_2,     KC_3,    KC_4,    KC_5,   KC_F11,
+    KC_TAB,          KC_Q,     KC_W,     KC_E,    KC_R,    KC_T,   MO(SYMB),
+    KC_CAPS,         KC_A,     KC_S,     KC_D,    KC_F,    KC_G,
+    KC_LSFT,         KC_Z,     KC_X,     KC_C,    KC_V,    KC_B,   NO_ACUT,
+    CTL_T(NO_APOS),  NO_CIRC,  NO_ASTR,  KC_LALT, KC_LGUI,
+                                               KC_LCTRL,  KC_LALT,
+                                                          NO_TILD,
+                                         KC_SPC, KC_BSPC, KC_ESC,
+    // right hand
+         KC_MS_BTN3,   KC_6,   KC_7,    KC_8,    KC_9,    KC_0,     NO_PLUS,
+         TG(SYMB),  KC_Y,   KC_U,    KC_I,    KC_O,    KC_P,     NO_AA,
+                    KC_H,   KC_J,    KC_K,    KC_L,    NO_OSLH,  NO_AE,
+         KC_DELT,   KC_N,   KC_M,    KC_COMM, KC_DOT,  NO_MINS,  KC_RSFT,
+                            NO_ALGR, KC_DOWN, KC_UP,   KC_LEFT,  KC_RGHT,
+         KC_HOME,        KC_END,
+         KC_PGUP,
+         KC_PGDN, KC_TAB, LT(MDIA, KC_ENT)
+),
+
+/* Keymap 1: Symbol Layer
+ *
+ * ,--------------------------------------------------.           ,--------------------------------------------------.
+ * |        |      |      |      |      |      |      |           |      |      |      |  /   |   *  |  -   |        |
+ * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
+ * |        |  F1  |  F2  |  F3  |  F4  |      |      |           |      |      |  7   |  8   |  9   |  +   |        |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |        |  F5  |  F6  |  F7  |  F8  |      |------|           |------|      |  4   |  5   |  6   |  +   |        |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |        |  F9  |  F10 |  F11 |  F12 |      |      |           |      |      |  1   |  2   |  3   | Enter|        |
+ * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
+ *   |      |      |      |      |      |                                       |  0   | ,    | .    | Enter|      |
+ *   `----------------------------------'                                       `----------------------------------'
+ *                                        ,-------------.       ,-------------.
+ *                                        |      |      |       |      |      |
+ *                                 ,------|------|------|       |------+------+------.
+ *                                 |      |      |      |       |      |      |      |
+ *                                 |      |      |------|       |------|      |      |
+ *                                 |      |      |      |       |      |      |      |
+ *                                 `--------------------'       `--------------------'
+ */
+// SYMBOLS
+[SYMB] = KEYMAP(
+       // left hand
+       KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+       KC_TRNS, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_TRNS, KC_TRNS,
+       KC_TRNS, KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_TRNS,
+       KC_TRNS, KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_TRNS, KC_TRNS,
+       KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+                                       KC_TRNS,KC_TRNS,
+                                               KC_TRNS,
+                               KC_TRNS,KC_TRNS,KC_TRNS,
+       // right hand
+       KC_TRNS, KC_TRNS, KC_TRNS, KC_PSLS, KC_PAST, KC_PMNS, KC_TRNS,
+       KC_TRNS, KC_TRNS, KC_7,    KC_8,    KC_9,    KC_PPLS, KC_TRNS,
+                KC_TRNS, KC_4,    KC_5,    KC_6,    KC_PPLS, KC_TRNS,
+       RESET,   KC_TRNS, KC_1,    KC_2,    KC_3,    KC_PENT, KC_TRNS,
+                         KC_0,    KC_COMM, KC_DOT,  KC_PENT, KC_TRNS,
+       KC_TRNS, KC_TRNS,
+       KC_TRNS,
+       KC_TRNS, KC_TRNS, KC_TRNS
+),
+/* Keymap 2: Media and mouse keys
+ *
+ * ,--------------------------------------------------.           ,--------------------------------------------------.
+ * |        |      |      |      |      |      |      |           |      |      |      |      |      |      |        |
+ * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
+ * |        |      |      | MsUp |      |      |      |           |      |      |      |      |      |      |        |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |        |      |MsLeft|MsDown|MsRght|      |------|           |------|      | Play | Pause| Prev | Next |        |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |        |      |      | Lclk | Rclk |      |      |           |      |      |VolDn |VolUp | Mute |      |        |
+ * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
+ *   |      |      |      |      |      |                                       |      |      |      |      |      |
+ *   `----------------------------------'                                       `----------------------------------'
+ *                                        ,-------------.       ,-------------.
+ *                                        |      |      |       |      |      |
+ *                                 ,------|------|------|       |------+------+------.
+ *                                 |      |      |      |       |      |      |      |
+ *                                 |LeClk |RiClk |------|       |------|      |      |
+ *                                 |      |      |      |       |      |      |      |
+ *                                 `--------------------'       `--------------------'
+ */
+// MEDIA AND MOUSE
+[MDIA] = KEYMAP(
+       KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+       KC_TRNS, KC_TRNS, KC_TRNS, KC_MS_U, KC_TRNS, KC_TRNS, KC_TRNS,
+       KC_TRNS, KC_TRNS, KC_MS_L, KC_MS_D, KC_MS_R, KC_TRNS,
+       KC_TRNS, KC_TRNS, KC_TRNS, KC_BTN1, KC_BTN2, KC_TRNS, KC_TRNS,
+       KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+                                           KC_TRNS, KC_TRNS,
+                                                    KC_TRNS,
+                                  KC_BTN1, KC_BTN2, KC_TRNS,
+    // right hand
+       KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+       KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+                 KC_TRNS, KC_MPLY, KC_MPLY, KC_MPRV, KC_MNXT, KC_TRNS,
+       KC_TRNS,  KC_TRNS, KC_VOLD, KC_VOLU, KC_MUTE, KC_TRNS, KC_TRNS,
+                          KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+       KC_TRNS, KC_TRNS,
+       KC_TRNS,
+       KC_TRNS, KC_TRNS, KC_TRNS
+),
+};
+
+const uint16_t PROGMEM fn_actions[] = {
+    [1] = ACTION_LAYER_TAP_TOGGLE(SYMB)                // FN1 - Momentary Layer 1 (Symbols)
+};
+
+// Runs just one time when the keyboard initializes.
+void matrix_init_user(void) {
+
+};
+
+// Runs constantly in the background, in a loop.
+void matrix_scan_user(void) {
+
+    uint8_t layer = biton32(layer_state);
+
+    ergodox_board_led_off();
+    ergodox_right_led_1_off();
+    ergodox_right_led_2_off();
+    ergodox_right_led_3_off();
+    switch (layer) {
+      // TODO: Make this relevant to the ErgoDox EZ.
+        case 1:
+            ergodox_right_led_3_on();
+            break;
+        case 2:
+            ergodox_right_led_2_on();
+            break;
+        case 3:
+            ergodox_right_led_2_on();
+            ergodox_right_led_3_on();
+            break;
+        default:
+            // none
+            break;
+    }
+
+    if (host_keyboard_leds() & (1<<USB_LED_CAPS_LOCK)) {
+        // if capslk is on, set led 1 on
+        ergodox_right_led_1_on();
+    } else {
+        ergodox_right_led_1_off();
+    }
+
+};

--- a/keyboards/ergodox/keymaps/swedish-lindhe/readme.md
+++ b/keyboards/ergodox/keymaps/swedish-lindhe/readme.md
@@ -1,0 +1,12 @@
+# Swedish (sv_SE) Qwerty layout for ErgoDox EZ
+
+This is what I use. It's not very close to the default layout, because this is
+how I want it. Deal with it.
+
+Note that this version does not have proper bindings for the A5 symbol set yet.
+That have to be implemented in software for now.
+
+The layout image can also be found on
+[www.keyboard-layout-editor.com](http://www.keyboard-layout-editor.com/#/gists/d84bc5915707cb30a4f9f754e06ecea3)
+
+![sv_SE Qwerty A5 Lindhe](swedish-qwerty-A5_lindhe.png)

--- a/keyboards/ergodox/keymaps/swedish-lindhe/readme.md
+++ b/keyboards/ergodox/keymaps/swedish-lindhe/readme.md
@@ -1,12 +1,50 @@
-# Swedish (sv_SE) Qwerty layout for ErgoDox EZ
+# swedish-lindhe ErgoDox (EZ) keymap
 
-This is what I use. It's not very close to the default layout, because this is
-how I want it. Deal with it.
+This is a setup that is very useful for me. It may or may not be for
+you. I will use it in conjunction with the A5 overlayed sv_SE layout.
 
-Note that this version does not have proper bindings for the A5 symbol set yet.
-That have to be implemented in software for now.
+The layout is subject to change (in particular I'm thinking about adding
+a macro recording feature), but it have not changed much the past year
+or two so you can expect it to be stable enough to learn it.
 
-The layout image can also be found on
+A5: http://aoeu.info/s/dvorak/svorak
+My xkb map: https://github.com/lindhe/dotfiles/blob/master/usr/share/X11/xkb/symbols/se-A5
+
+The most major points:
+======================
+
+I think the layout image can be found on
 [www.keyboard-layout-editor.com](http://www.keyboard-layout-editor.com/#/gists/d84bc5915707cb30a4f9f754e06ecea3)
 
-![sv_SE Qwerty A5 Lindhe](swedish-qwerty-A5_lindhe.png)
+L0:
+---
+
+* Easily accessible F11 key for fullscreening
+* Print screen
+* Middle mouse button for X-paste
+* Improved reachability of meta buttons (LCtrl, LALt, AltGr, LGui etc.)
+* Cluster Page Up/Down + Home/End by the right thumb
+* Vim-like arrow layout in right bottom row
+
+* Set media layer toggle to right thumb (Enter)
+* Set apostrophe on LCtl (putting it next to some other small
+  characters)
+
+L1:
+---
+
+* Full function key layout
+* Teensy button
+
+L2:
+---
+
+* Improved media buttons layout (close by the jkl; Vim binding)
+* Improved layout of emulated mouse buttons
+
+LED behaviour to binary+CAPS
+============================
+
+The ErgoDox LEDs on this layout is using the two rightmost LEDs as the
+two LSB in a two digit binary number, representing layer 0, 1, 2 and 3.
+The leftmost byte/LED indicates CAPS status.


### PR DESCRIPTION
This is a setup that is very useful for me. It may or may not be for
you. I will use it in conjunction with the A5 overlayed sv_SE layout.

The layout is subject to change (in particular I'm thinking about adding
a macro recording feature), but it have not changed much the past year
or two so you can expect it to be stable enough to learn it.

A5: http://aoeu.info/s/dvorak/svorak
My xkb map: https://github.com/lindhe/dotfiles/blob/master/usr/share/X11/xkb/symbols/se-A5

The most major points:
======================

L0:
---

* Easily accessible F11 key for fullscreening
* Print screen
* Middle mouse button for X-paste
* Improved reachability of meta buttons (LCtrl, LALt, AltGr, LGui etc.)
* Cluster Page Up/Down + Home/End by the right thumb
* Vim-like arrow layout in right bottom row

* Set media layer toggle to right thumb (Enter)
* Set apostrophe on LCtl (putting it next to some other small
  characters)

L1:
---

* Full function key layout
* Teensy button

L2:
---

* Improved media buttons layout (close by the jkl; Vim binding)
* Improved layout of emulated mouse buttons

LED behaviour to binary+CAPS
============================

The ErgoDox LEDs on this layout is using the two rightmost LEDs as the
two LSB in a two digit binary number, representing layer 0, 1, 2 and 3.
The leftmost byte/LED indicates CAPS status.