### PR TITLE
Move Space Caded Parentheses to own layer

### DIFF
--- a/keyboards/clueboard/keymaps/magicmonty/config.h
+++ b/keyboards/clueboard/keymaps/magicmonty/config.h
@@ -35,5 +35,6 @@
 */
 #define LSPO_KEY KC_8
 #define RSPC_KEY KC_9
+#define PERMISSIVE_HOLD
 
 #endif

--- a/keyboards/clueboard/keymaps/magicmonty/config.h
+++ b/keyboards/clueboard/keymaps/magicmonty/config.h
@@ -26,13 +26,8 @@
 /* override number of MIDI tone keycodes (each octave adds 12 keycodes and allocates 12 bytes) */
 #define MIDI_TONE_KEYCODE_OCTAVES 2
 
-/* Disabling rollover allows you to use the opposite shift key to cancel the space cadet state in the event
-   of an erroneous press instead of emitting a pair of parentheses when the keys are released.
-*/
-#define DISABLE_SPACE_CADET_ROLLOVER
-
 /*
-  Setting the Space Cadet Parens for German layout
+  Setting the modified Space Cadet Parens for German layout
 
   Default is
   #define LSPO_KEY KC_9

--- a/keyboards/clueboard/keymaps/magicmonty/keymap.c
+++ b/keyboards/clueboard/keymaps/magicmonty/keymap.c
@@ -4,8 +4,6 @@
 #define GRAVE_MODS  (MOD_BIT(KC_LSHIFT)|MOD_BIT(KC_RSHIFT)|MOD_BIT(KC_LGUI)|MOD_BIT(KC_RGUI)|MOD_BIT(KC_LALT)|MOD_BIT(KC_RALT))
 #define _______ KC_TRNS
 #define xxxxxxx KC_NO
-#define HPR_TAB ALL_T(KC_TAB)
-#define CTL_ESC CTL_T(KC_ESC)
 
 // Each layer gets a name for readability, which is then used in the keymap matrix below.
 // The underscores don't mean anything - you can have a layer called STUFF or any other name.
@@ -13,24 +11,70 @@
 // entirely and just use numbers.
 #define _BL 0 // BASE Layer
 #define _FL 1 // Function Layer
-#define _ME 2 // Media Layer
-#define _CL 3 // Control Layer
-#define _ML 4 // Mouse Layer
+#define _ABL 2 // Angle bracket Layer
+#define _CBL 3 // Curly bracket Layer
+#define _ME 4 // Media Layer
+#define _CL 5 // Control Layer
+#define _ML 6 // Mouse Layer
 #if defined(MIDI_ENABLE)
-  #define _MI 5 // MIDI Layer
+  #define _MI 7 // MIDI Layer
   #define TO_MIDI TO(_MI)
 #else
   #define TO_MIDI _______
 #endif
 
+// go back to base layer
 #define TO_BASE TO(_BL)
+
+// switch to function layer while helde
 #define MO_FUNC MO(_FL)
+
+// switch to media layer  while held
 #define   MEDIA MO(_ME)
+
+// switch to Control layer while helde
 #define  MO_CTL MO(_CL)
+
+// switch to angle bracket layer while helde
+#define  MO_ABL MO(_ABL)
+
+// switch to curly brace layer while helde
+#define  MO_CBL MO(_CBL)
+
+// switch to mouse layer if held, else space
 #define L_MOUSE LT(_ML, KC_SPC)
+
+// Function key when held, else ESC
 #define ESC_FUN LT(_FL, KC_ESC)
 
+// Hyper (CTRL+ALT+SHIFT+SUPER) when held, TAB when tapped
+#define HPR_TAB ALL_T(KC_TAB)
+
+// CTRL when held, ESC when tapped
+#define CTL_ESC CTL_T(KC_ESC)
+
+// open parenthesis
+#define KC_PARO LSFT(LSPO_KEY)
+
+// closed parenthesis
+#define KC_PARC LSFT(RSPC_KEY)
+
+// open angle bracket
+#define KC_ABRO RALT(KC_8)
+
+// closed angle bracket
+#define KC_ABRC RALT(KC_9)
+
+// open curly brace
+#define KC_CBRO RALT(KC_7)
+
+// closed curly brace
+#define KC_CBRC RALT(KC_0)
+
+// ESC/Grave mode
 #define ESC_GRV F(0)
+
+// Reset RGB mode to layer signalling
 #define RGB_RST F(1)
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
@@ -39,16 +83,32 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     ESC_GRV,    KC_1,    KC_2,   KC_3,     KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,     KC_0, KC_MINS,   KC_EQL, _______, KC_BSPC,          KC_INS,  \
     HPR_TAB,    KC_Q,    KC_W,   KC_E,     KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,     KC_P, KC_LBRC,  KC_RBRC, KC_BSLS,                   KC_DEL,  \
     ESC_FUN,    KC_A,    KC_S,   KC_D,     KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,  KC_SCLN, KC_QUOT,  KC_NUHS,  KC_ENT,                            \
-    KC_LSPO, KC_NUBS,    KC_Z,   KC_X,     KC_C,    KC_V,    KC_B,    KC_N,    KC_M, KC_COMM,   KC_DOT, KC_SLSH,  _______, KC_RSPC,          KC_UP,            \
+    KC_LSFT, KC_NUBS,    KC_Z,   KC_X,     KC_C,    KC_V,    KC_B,    KC_N,    KC_M, KC_COMM,   KC_DOT, KC_SLSH,  _______, KC_RSFT,          KC_UP,            \
     KC_LCTL, KC_LGUI, KC_LALT,_______,                    L_MOUSE, L_MOUSE,                    _______, KC_RALT,  KC_RCTL, MO_FUNC, KC_LEFT, KC_DOWN, KC_RGHT),
 
-  /* Keymap _FL: Function Layer */
+  /* Keymap _FL: Function layer */
   [_FL] = KEYMAP(
      KC_GRV,   KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,   KC_F12, _______, _______,          BL_STEP, \
     _______, _______, _______, _______, _______, _______, _______, _______, KC_PSCR, _______,  KC_PAUS, _______,  _______, _______,                   _______, \
     _______, _______,  MO_CTL, _______, _______, _______, KC_LEFT, KC_DOWN,   KC_UP, KC_RGHT,  _______, _______,  _______, _______,                            \
-    _______, _______, _______, _______, _______, _______, _______, _______,   MEDIA, _______,  _______, TO_MIDI,  _______, _______,          KC_PGUP,          \
-    _______, _______, _______, _______,                   _______, _______,                    _______, _______,  _______, MO_FUNC, KC_HOME, KC_PGDN, KC_END),
+    KC_PARO, _______, _______, _______, _______, _______, _______, _______,   MEDIA, _______,  _______, TO_MIDI,  _______, KC_PARC,          KC_PGUP,          \
+     MO_ABL, _______,  MO_CBL, _______,                   _______, _______,                    _______,  MO_CBL,   MO_ABL, MO_FUNC, KC_HOME, KC_PGDN, KC_END),
+
+  /* Keymap _ABL: Angle bracket layer */
+  [_ABL] = KEYMAP(
+    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,  _______, _______,  _______, _______, _______,          _______, \
+    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,  _______, _______,  _______, _______,                   _______, \
+    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,  _______, _______,  _______, _______,                            \
+    KC_ABRO, _______, _______, _______, _______, _______, _______, _______, _______, _______,  _______, _______,  _______, KC_ABRC,          _______,          \
+    MO_ABL,  xxxxxxx, _______, _______,                   _______, _______,                    _______, xxxxxxx,   MO_ABL, _______, _______, _______, _______),
+
+  /* Keymap _CBL: Curly brace layer */
+  [_CBL] = KEYMAP(
+    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,  _______, _______,  _______, _______, _______,          _______, \
+    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,  _______, _______,  _______, _______,                   _______, \
+    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,  _______, _______,  _______, _______,                            \
+    KC_CBRO, _______, _______, _______, _______, _______, _______, _______, _______, _______,  _______, _______,  _______, KC_CBRC,          _______,          \
+    xxxxxxx, _______,  MO_CBL, _______,                   _______, _______,                    _______,  MO_CBL,  xxxxxxx, _______, _______, _______, _______),
 
   /* Keymap _ME: Media layer */
   [_ME] = KEYMAP(
@@ -146,6 +206,8 @@ void action_function(keyrecord_t *record, uint8_t id, uint8_t opt) {
 enum layer_id {
   LAYER_BASE,
   LAYER_FUNCTION,
+  LAYER_ANGLE_BRACKET,
+  LAYER_CURLY_BRACKET,
   LAYER_MEDIA,
   LAYER_CONTROL,
   LAYER_MOUSE,
@@ -161,6 +223,12 @@ void clueboard_set_led(uint8_t id, uint8_t val) {
       break;
     case LAYER_FUNCTION:
       rgblight_sethsv_noeeprom(46, 255, val);
+      break;
+    case LAYER_ANGLE_BRACKET:
+      rgblight_sethsv_noeeprom(50, 255, val);
+      break;
+    case LAYER_CURLY_BRACKET:
+      rgblight_sethsv_noeeprom(55, 255, val);
       break;
     case LAYER_MEDIA:
       rgblight_sethsv_noeeprom(86, 255, val);
@@ -193,6 +261,10 @@ void matrix_scan_user(void) {
         clueboard_set_led(LAYER_MEDIA, val);
       } else if (layer & (1<<_CL)) {
         clueboard_set_led(LAYER_CONTROL, val);
+      } else if (layer & (1<<_ABL)) {
+        clueboard_set_led(LAYER_ANGLE_BRACKET, val);
+      } else if (layer & (1<<_CBL)) {
+        clueboard_set_led(LAYER_CURLY_BRACKET, val);
       } else {
         clueboard_set_led(LAYER_FUNCTION, val);
       }

--- a/keyboards/clueboard/keymaps/magicmonty/keymap.c
+++ b/keyboards/clueboard/keymaps/magicmonty/keymap.c
@@ -11,13 +11,11 @@
 // entirely and just use numbers.
 #define _BL 0 // BASE Layer
 #define _FL 1 // Function Layer
-#define _ABL 2 // Angle bracket Layer
-#define _CBL 3 // Curly bracket Layer
-#define _ME 4 // Media Layer
-#define _CL 5 // Control Layer
-#define _ML 6 // Mouse Layer
+#define _ME 2 // Media Layer
+#define _CL 3 // Control Layer
+#define _ML 4 // Mouse Layer
 #if defined(MIDI_ENABLE)
-  #define _MI 7 // MIDI Layer
+  #define _MI 5 // MIDI Layer
   #define TO_MIDI TO(_MI)
 #else
   #define TO_MIDI _______
@@ -35,12 +33,6 @@
 // switch to Control layer while helde
 #define  MO_CTL MO(_CL)
 
-// switch to angle bracket layer while helde
-#define  MO_ABL MO(_ABL)
-
-// switch to curly brace layer while helde
-#define  MO_CBL MO(_CBL)
-
 // switch to mouse layer if held, else space
 #define L_MOUSE LT(_ML, KC_SPC)
 
@@ -52,18 +44,6 @@
 
 // CTRL when held, ESC when tapped
 #define CTL_ESC CTL_T(KC_ESC)
-
-// open angle bracket
-#define KC_ABRO RALT(KC_8)
-
-// closed angle bracket
-#define KC_ABRC RALT(KC_9)
-
-// open curly brace
-#define KC_CBRO RALT(KC_7)
-
-// closed curly brace
-#define KC_CBRC RALT(KC_0)
 
 // ESC/Grave mode
 #define ESC_GRV F(0)
@@ -86,23 +66,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     _______, _______, _______, _______, _______, _______, _______, _______, KC_PSCR, _______,  KC_PAUS, _______,  _______, _______,                   _______, \
     _______, _______,  MO_CTL, _______, _______, _______, KC_LEFT, KC_DOWN,   KC_UP, KC_RGHT,  _______, _______,  _______, _______,                            \
     KC_LSPO, _______, _______, _______, _______, _______, _______, _______,   MEDIA, _______,  _______, TO_MIDI,  _______, KC_RSPC,          KC_PGUP,          \
-     MO_ABL, _______,  MO_CBL, _______,                   _______, _______,                    _______,  MO_CBL,   MO_ABL, MO_FUNC, KC_HOME, KC_PGDN, KC_END),
-
-  /* Keymap _ABL: Angle bracket layer */
-  [_ABL] = KEYMAP(
-    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,  _______, _______,  _______, _______, _______,          _______, \
-    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,  _______, _______,  _______, _______,                   _______, \
-    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,  _______, _______,  _______, _______,                            \
-    KC_ABRO, _______, _______, _______, _______, _______, _______, _______, _______, _______,  _______, _______,  _______, KC_ABRC,          _______,          \
-    MO_ABL,  xxxxxxx, _______, _______,                   _______, _______,                    _______, xxxxxxx,   MO_ABL, _______, _______, _______, _______),
-
-  /* Keymap _CBL: Curly brace layer */
-  [_CBL] = KEYMAP(
-    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,  _______, _______,  _______, _______, _______,          _______, \
-    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,  _______, _______,  _______, _______,                   _______, \
-    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,  _______, _______,  _______, _______,                            \
-    KC_CBRO, _______, _______, _______, _______, _______, _______, _______, _______, _______,  _______, _______,  _______, KC_CBRC,          _______,          \
-    xxxxxxx, _______,  MO_CBL, _______,                   _______, _______,                    _______,  MO_CBL,  xxxxxxx, _______, _______, _______, _______),
+    _______, _______, _______, _______,                   _______, _______,                    _______, _______,  _______, MO_FUNC, KC_HOME, KC_PGDN, KC_END),
 
   /* Keymap _ME: Media layer */
   [_ME] = KEYMAP(
@@ -124,9 +88,9 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   [_ML] = KEYMAP(
     _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,  _______, _______,  _______, _______, _______,          _______, \
     _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,  _______, _______,  _______, _______,                   _______, \
-    _______, _______, KC_BTN3, KC_BTN2, KC_BTN1, _______, KC_MS_L, KC_MS_D, KC_MS_U, KC_MS_R,  _______, _______,  _______, _______,                            \
+    _______, _______, KC_BTN2, KC_BTN3, KC_BTN1, _______, KC_MS_L, KC_MS_D, KC_MS_U, KC_MS_R,  _______, _______,  _______, _______,                            \
     _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,  _______, _______,  _______, _______,          KC_MS_U,          \
-    _______, _______, _______, _______,                   L_MOUSE, L_MOUSE,                    _______, KC_BTN1,  KC_BTN2, KC_BTN3, KC_MS_L, KC_MS_D, KC_MS_R),
+    _______, _______, _______, _______,                   L_MOUSE, L_MOUSE,                    _______, KC_BTN1,  KC_BTN3, KC_BTN2, KC_MS_L, KC_MS_D, KC_MS_R),
 
 #if defined(MIDI_ENABLE) && defined(MIDI_ADVANCED)
   /* Keymap _MI: MIDI layer (Advanced)*/
@@ -200,8 +164,6 @@ void action_function(keyrecord_t *record, uint8_t id, uint8_t opt) {
 enum layer_id {
   LAYER_BASE,
   LAYER_FUNCTION,
-  LAYER_ANGLE_BRACKET,
-  LAYER_CURLY_BRACKET,
   LAYER_MEDIA,
   LAYER_CONTROL,
   LAYER_MOUSE,
@@ -217,12 +179,6 @@ void clueboard_set_led(uint8_t id, uint8_t val) {
       break;
     case LAYER_FUNCTION:
       rgblight_sethsv_noeeprom(46, 255, val);
-      break;
-    case LAYER_ANGLE_BRACKET:
-      rgblight_sethsv_noeeprom(50, 255, val);
-      break;
-    case LAYER_CURLY_BRACKET:
-      rgblight_sethsv_noeeprom(55, 255, val);
       break;
     case LAYER_MEDIA:
       rgblight_sethsv_noeeprom(86, 255, val);
@@ -255,10 +211,6 @@ void matrix_scan_user(void) {
         clueboard_set_led(LAYER_MEDIA, val);
       } else if (layer & (1<<_CL)) {
         clueboard_set_led(LAYER_CONTROL, val);
-      } else if (layer & (1<<_ABL)) {
-        clueboard_set_led(LAYER_ANGLE_BRACKET, val);
-      } else if (layer & (1<<_CBL)) {
-        clueboard_set_led(LAYER_CURLY_BRACKET, val);
       } else {
         clueboard_set_led(LAYER_FUNCTION, val);
       }

--- a/keyboards/clueboard/keymaps/magicmonty/keymap.c
+++ b/keyboards/clueboard/keymaps/magicmonty/keymap.c
@@ -53,12 +53,6 @@
 // CTRL when held, ESC when tapped
 #define CTL_ESC CTL_T(KC_ESC)
 
-// open parenthesis
-#define KC_PARO LSFT(LSPO_KEY)
-
-// closed parenthesis
-#define KC_PARC LSFT(RSPC_KEY)
-
 // open angle bracket
 #define KC_ABRO RALT(KC_8)
 
@@ -91,7 +85,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
      KC_GRV,   KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,   KC_F12, _______, _______,          BL_STEP, \
     _______, _______, _______, _______, _______, _______, _______, _______, KC_PSCR, _______,  KC_PAUS, _______,  _______, _______,                   _______, \
     _______, _______,  MO_CTL, _______, _______, _______, KC_LEFT, KC_DOWN,   KC_UP, KC_RGHT,  _______, _______,  _______, _______,                            \
-    KC_PARO, _______, _______, _______, _______, _______, _______, _______,   MEDIA, _______,  _______, TO_MIDI,  _______, KC_PARC,          KC_PGUP,          \
+    KC_LSPO, _______, _______, _______, _______, _______, _______, _______,   MEDIA, _______,  _______, TO_MIDI,  _______, KC_RSPC,          KC_PGUP,          \
      MO_ABL, _______,  MO_CBL, _______,                   _______, _______,                    _______,  MO_CBL,   MO_ABL, MO_FUNC, KC_HOME, KC_PGDN, KC_END),
 
   /* Keymap _ABL: Angle bracket layer */

--- a/keyboards/clueboard/keymaps/magicmonty/readme.md
+++ b/keyboards/clueboard/keymaps/magicmonty/readme.md
@@ -2,7 +2,9 @@
 
 [Keyboard Layout Editor File]
 
-![Clueboard Layout Image](http://i.imgur.com/53oxbIq.png)
+![Clueboard Layout Image](http://i.imgur.com/uShk3P9.png)
+My ClueBoard Layout as of 2017/06/30
+
 
 This layout is a combination of the `mouse_keys` and the `win_optimized` layouts.
 This layout is optimized for an ISO layout.
@@ -23,7 +25,7 @@ It can be exited with the `ESC`-Key
 ## Space Cadet(ish) Shift Parentheses
 
 If the function layer is active, the `SHIFT`-Keys are configured (not quite) like the [Space Cadet Shift Parentheses]
-as opened (left `SHIFT`) and closed (right `SHIFT`) parentheses.
+as opened (left `SHIFT`) and closed (right `SHIFT`) parentheses if tapped and `SHIFT` if held.
 There are two more layers which enable angle brackets (`FN`+`CTRL`) and curly braces (`FN`+`ALT`) on the `SHIFT` keys
 
 ## Media layer

--- a/keyboards/clueboard/keymaps/magicmonty/readme.md
+++ b/keyboards/clueboard/keymaps/magicmonty/readme.md
@@ -2,7 +2,7 @@
 
 [Keyboard Layout Editor File]
 
-![Clueboard Layout Image](http://i.imgur.com/uShk3P9.png)
+![Clueboard Layout Image](http://i.imgur.com/eEwjLEj.png)
 My ClueBoard Layout as of 2017/06/30
 
 
@@ -24,9 +24,8 @@ It can be exited with the `ESC`-Key
 
 ## Space Cadet(ish) Shift Parentheses
 
-If the function layer is active, the `SHIFT`-Keys are configured (not quite) like the [Space Cadet Shift Parentheses]
+If the function layer is active, the `SHIFT`-Keys are configured like the [Space Cadet Shift Parentheses]
 as opened (left `SHIFT`) and closed (right `SHIFT`) parentheses if tapped and `SHIFT` if held.
-There are two more layers which enable angle brackets (`FN`+`CTRL`) and curly braces (`FN`+`ALT`) on the `SHIFT` keys
 
 ## Media layer
 
@@ -44,8 +43,6 @@ The different layers are signalled throug setting of the underlight:
 
 - Base layer: White
 - Function layer: Yellow
-- Angle bracket layer: Greenish yellow
-- Curly brace layer: more greenish yellow
 - Media layer: Green
 - Mouse layer: Blue
 - Control layer: Red

--- a/keyboards/clueboard/keymaps/magicmonty/readme.md
+++ b/keyboards/clueboard/keymaps/magicmonty/readme.md
@@ -2,33 +2,53 @@
 
 [Keyboard Layout Editor File]
 
-![Clueboard Layout Image](http://i.imgur.com/WFfJ15k.png)
+![Clueboard Layout Image](http://i.imgur.com/53oxbIq.png)
 
 This layout is a combination of the `mouse_keys` and the `win_optimized` layouts.
 This layout is optimized for an ISO layout.
+The CapsLock is disabled and works as ESC when tapped and FN when held.
+The `TAB` key works as `TAB` when tapped, and [HYPER] (`CTRL` + `ALT` + `SHIFT` + `CMD`) when held.
 
-It adds a mouse layer. When you hold down the spacebar the arrow keys
-will move your mouse cursor. You can click using the 3 mods to the left of the
-arrow keys, or the 3 keys under your primary fingers on the home row.
+## Mouse Layer
+
+When you hold down the spacebar the arrow keys will move your mouse cursor.
+You can click using the 3 mods to the left of the arrow keys, or the 3 keys under your primary fingers on the home row.
 The Left, Down, Up and Right for the mouse movement are also VIM-Like on the HJKL keys
 
-There is also a MIDI layer included.
+## MIDI layer
 
-The CapsLock is disabled and works as Escape when tapped and Fn when Hold.
-The Tab key works as Tab when tapped, and [Hyper] (Ctrl + Alt + Shift + Cmd) when hold
-The Shift-Keys are configured as [Space Cadet Shift Parentheses]
+The MIDI layer is permanently enabled by pressing `FN` + `/`.
+It can be exited with the `ESC`-Key
 
-There is also a separate media layer with Volume/Play controls
+## Space Cadet(ish) Shift Parentheses
+
+If the function layer is active, the `SHIFT`-Keys are configured (not quite) like the [Space Cadet Shift Parentheses]
+as opened (left `SHIFT`) and closed (right `SHIFT`) parentheses.
+There are two more layers which enable angle brackets (`FN`+`CTRL`) and curly braces (`FN`+`ALT`) on the `SHIFT` keys
+
+## Media layer
+
+The media layer with Volume/Play controls, can be accessed via `FN` + `m`
+
+## Control layer
+
+The control layer is accessed via `FN` + `s`.
+Here one can control the behavior of the RGB underlight.
+`FN` + `s` + `1` resets the RGB underlight to the Layer signalling mode
+
+## Layer signalling through underlight
 
 The different layers are signalled throug setting of the underlight:
 
 - Base layer: White
 - Function layer: Yellow
+- Angle bracket layer: Greenish yellow
+- Curly brace layer: more greenish yellow
 - Media layer: Green
 - Mouse layer: Blue
 - Control layer: Red
 - Midi layer: Purple
 
-[Hyper]: http://brettterpstra.com/2012/12/08/a-useful-caps-lock-key/
+[HYPER]: http://brettterpstra.com/2012/12/08/a-useful-caps-lock-key/
 [Space Cadet Shift Parentheses]: http://stevelosh.com/blog/2012/10/a-modern-space-cadet/#shift-parentheses
 [Keyboard Layout Editor File]: http://www.keyboard-layout-editor.com/#/gists/f869b8789242a712e0f46eabbd550056


### PR DESCRIPTION
The space cadet parentheses where too much distracting. Therefore they are now on the function layer. 

Also updated the README