### PR TITLE
Fix uninitialized backlight_level in the Visualizer

### DIFF
--- a/quantum/visualizer/visualizer.c
+++ b/quantum/visualizer/visualizer.c
@@ -255,6 +255,9 @@ static DECLARE_THREAD_FUNCTION(visualizerThread, arg) {
         .mods = 0xFF,
         .leds = 0xFFFFFFFF,
         .suspended = false,
+    #ifdef BACKLIGHT_ENABLE
+        .backlight_level = 0,
+    #endif
     #ifdef VISUALIZER_USER_DATA_SIZE
         .user_data = {0},
     #endif
@@ -299,6 +302,7 @@ static DECLARE_THREAD_FUNCTION(visualizerThread, arg) {
                 else {
                     gdispGSetPowerMode(LED_DISPLAY, powerOff);
                 }
+                state.status.backlight_level = current_status.backlight_level;
             }
     #endif
             if (visualizer_enabled) {


### PR DESCRIPTION
I found an unitialized variable in the visualizer that could potentially cause #1415.