### PR TITLE
Add support for msys2 build environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ quantum/version.h
 CMakeLists.txt
 .DS_STORE
 /util/wsl_downloaded
+/util/win_downloaded
 
 # Eclipse/PyCharm/Other IDE Settings
 .cproject

--- a/message.mk
+++ b/message.mk
@@ -21,8 +21,8 @@ OK_STRING=$(OK_COLOR)[OK]$(NO_COLOR)\n
 ERROR_STRING=$(ERROR_COLOR)[ERRORS]$(NO_COLOR)\n
 WARN_STRING=$(WARN_COLOR)[WARNINGS]$(NO_COLOR)\n
 
-TAB_LOG = printf "\n$$LOG\n\n" | $(AWK) '{ sub(/^/," | "); print }'
-TAB_LOG_PLAIN = printf "$$LOG\n"
+TAB_LOG = printf "\n%s\n\n" "$$LOG" | $(AWK) '{ sub(/^/," | "); print }'
+TAB_LOG_PLAIN = printf "%s\n" "$$LOG"
 AWK_STATUS = $(AWK) '{ printf " %-10s\n", $$1; }'
 AWK_CMD = $(AWK) '{ printf "%-99s", $$0; }'
 PRINT_ERROR = ($(SILENT) ||printf " $(ERROR_STRING)" | $(AWK_STATUS)) && $(TAB_LOG) && $(ON_ERROR)

--- a/quantum/keymap_common.c
+++ b/quantum/keymap_common.c
@@ -169,7 +169,6 @@ void action_function(keyrecord_t *record, uint8_t id, uint8_t opt)
 }
 
 // translates key to keycode
-__attribute__ ((weak))
 uint16_t keymap_key_to_keycode(uint8_t layer, keypos_t key)
 {
     // Read entire word (16bits)

--- a/tests/basic/keymap.c
+++ b/tests/basic/keymap.c
@@ -41,3 +41,6 @@ const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt) {
     }
     return MACRO_NONE;
 };
+
+void action_function(keyrecord_t *record, uint8_t id, uint8_t opt) {
+}

--- a/tests/test_common/matrix.c
+++ b/tests/test_common/matrix.c
@@ -58,3 +58,6 @@ void release_key(uint8_t col, uint8_t row) {
 void clear_all_keys(void) {
     memset(matrix, 0, sizeof(matrix));
 }
+
+void led_set(uint8_t usb_led) {
+}

--- a/tests/test_common/test_fixture.cpp
+++ b/tests/test_common/test_fixture.cpp
@@ -44,8 +44,8 @@ void TestFixture::run_one_scan_loop() {
     advance_time(1);
 }
 
-void TestFixture::idle_for(uint time) {
-    for (uint i=0; i<time; i++) {
+void TestFixture::idle_for(unsigned time) {
+    for (unsigned i=0; i<time; i++) {
         run_one_scan_loop();
     }
 }

--- a/tests/test_common/test_fixture.hpp
+++ b/tests/test_common/test_fixture.hpp
@@ -26,5 +26,5 @@ public:
     static void TearDownTestCase();
 
     void run_one_scan_loop();
-    void idle_for(uint ms);
+    void idle_for(unsigned ms);
 };

--- a/tmk_core/native.mk
+++ b/tmk_core/native.mk
@@ -1,3 +1,5 @@
+SYSTEM_TYPE := $(shell gcc -dumpmachine)
+
 CC = gcc
 OBJCOPY = 
 OBJDUMP = 
@@ -14,6 +16,9 @@ COMPILEFLAGS += -funsigned-bitfields
 COMPILEFLAGS += -ffunction-sections
 COMPILEFLAGS += -fdata-sections
 COMPILEFLAGS += -fshort-enums
+ifneq ($(findstring mingw, ${SYSTEM_TYPE}),)
+COMPILEFLAGS += -mno-ms-bitfields
+endif
 
 CFLAGS += $(COMPILEFLAGS)
 CFLAGS += -fno-inline-small-functions

--- a/util/activate_msys2.sh
+++ b/util/activate_msys2.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+function export_variables {
+    local util_dir=~/qmk_utils
+    export PATH=$PATH:$util_dir/dfu-programmer
+    export PATH=$PATH:$util_dir/dfu-util-0.9-win64
+    export PATH=$PATH:$util_dir/flip/bin
+    export PATH=$PATH:$util_dir/avr8-gnu-toolchain/bin
+    export PATH=$PATH:$util_dir/gcc-arm-none-eabi/bin
+}
+
+export_variables
+
+
+
+

--- a/util/msys2_install.sh
+++ b/util/msys2_install.sh
@@ -1,13 +1,51 @@
 #!/bin/bash
 
 dir=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+download_dir=~/qmk_utils
+avrtools=avr8-gnu-toolchain
 
 echo "Installing dependencies needed for the installation (quazip)"
-pacman --needed -S msys/unzip
+pacman --needed -S msys/unzip msys/p7zip
 
-export download_dir=~/qmk_utils
+
 
 source "$dir/win_shared_install.sh"
+
+function install_avr {
+    rm -f -r "$avrtools"
+    wget "http://www.atmel.com/images/avr8-gnu-toolchain-installer-3.5.4.91-win32.any.x86.exe"
+    7z x avr8-gnu-toolchain-installer-3.5.4.91-win32.any.x86.exe
+    rm avr8-gnu-toolchain-installer-3.5.4.91-win32.any.x86.exe
+}
+
+pushd "$download_dir"
+
+
+if [ ! -d "$avrtools" ]; then
+    while true; do
+        echo
+        echo "The AVR toolchain is not installed."
+        echo "This is needed for building AVR based keboards."
+        read -p "Do you want to install it? (Y/N) " res
+        case $res in
+            [Yy]* ) install_avr; break;;
+            [Nn]* ) break;;
+            * ) echo "Invalid answer";;
+        esac
+    done
+else
+    while true; do
+        echo
+        echo "The AVR toolchain is already installed"
+        read -p "Do you want to reinstall? (Y/N) " res
+        case $res in
+            [Yy]* ) install_avr; break;;
+            [Nn]* ) break;;
+            * ) echo "Invalid answer";;
+        esac
+    done
+fi
+popd
 
 echo
 echo "******************************************************************************"

--- a/util/msys2_install.sh
+++ b/util/msys2_install.sh
@@ -3,11 +3,10 @@
 dir=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 download_dir=~/qmk_utils
 avrtools=avr8-gnu-toolchain
+armtools=gcc-arm-none-eabi
 
 echo "Installing dependencies needed for the installation (quazip)"
 pacman --needed -S msys/unzip msys/p7zip
-
-
 
 source "$dir/win_shared_install.sh"
 
@@ -18,8 +17,13 @@ function install_avr {
     rm avr8-gnu-toolchain-installer-3.5.4.91-win32.any.x86.exe
 }
 
-pushd "$download_dir"
+function install_arm {
+    wget -O gcc-arm-none-eabi.zip "https://developer.arm.com/-/media/Files/downloads/gnu-rm/6-2017q2/gcc-arm-none-eabi-6-2017-q2-update-win32.zip?product=GNU%20ARM%20Embedded%20Toolchain,ZIP,,Windows,6-2017-q2-update"
+    unzip -d gcc-arm-none-eabi gcc-arm-none-eabi.zip
+    rm gcc-arm-none-eabi.zip
+}
 
+pushd "$download_dir"
 
 if [ ! -d "$avrtools" ]; then
     while true; do
@@ -40,6 +44,31 @@ else
         read -p "Do you want to reinstall? (Y/N) " res
         case $res in
             [Yy]* ) install_avr; break;;
+            [Nn]* ) break;;
+            * ) echo "Invalid answer";;
+        esac
+    done
+fi
+
+if [ ! -d "$armtools" ]; then
+    while true; do
+        echo
+        echo "The ARM toolchain is not installed."
+        echo "This is needed for building ARM based keboards."
+        read -p "Do you want to install it? (Y/N) " res
+        case $res in
+            [Yy]* ) install_arm; break;;
+            [Nn]* ) break;;
+            * ) echo "Invalid answer";;
+        esac
+    done
+else
+    while true; do
+        echo
+        echo "The ARM toolchain is already installed"
+        read -p "Do you want to reinstall? (Y/N) " res
+        case $res in
+            [Yy]* ) install_arm; break;;
             [Nn]* ) break;;
             * ) echo "Invalid answer";;
         esac

--- a/util/msys2_install.sh
+++ b/util/msys2_install.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
 dir=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+
+echo "Installing dependencies needed for the installation (quazip)"
+pacman -S msys/unzip
+
 source "$dir/win_shared_install.sh"
 
 echo

--- a/util/msys2_install.sh
+++ b/util/msys2_install.sh
@@ -2,3 +2,9 @@
 
 dir=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 source "$dir/win_shared_install.sh"
+
+echo
+echo "******************************************************************************"
+echo "Installation completed!"
+echo "You need to open a new batch command prompt for all the utils to work properly"
+echo "******************************************************************************"

--- a/util/msys2_install.sh
+++ b/util/msys2_install.sh
@@ -88,8 +88,30 @@ else
 fi
 popd
 
+cp -f "$dir/activate_msys2.sh" "$download_dir/"
+
+if grep "^source ~/qmk_utils/activate_msys2.sh$" ~/.bashrc
+then
+    echo
+    echo "The line source ~/qmk_utils/activate_msys2.sh is already added to your /.bashrc"
+    echo "Not adding it twice!"
+else
+    while true; do
+        echo
+        echo "Do you want to add 'source ~/qmk_utils/activate_msys2.sh' to the end of your"
+        echo ".bashrc file? Without this make won't find the needed utils, so if you don't"
+        echo "want to do it automatically, then you have to do it manually later."
+        read -p "(Y/N)? " res
+        case $res in
+            [Yy]* ) echo "source ~/qmk_utils/activate_msys2.sh" >> ~/.bashrc; break;;
+            [Nn]* ) break;;
+            * ) echo "Invalid answer";;
+        esac
+    done
+fi
+
 echo
 echo "******************************************************************************"
 echo "Installation completed!"
-echo "You need to open a new batch command prompt for all the utils to work properly"
+echo "Please close this Window and restart MSYS2 MinGW"
 echo "******************************************************************************"

--- a/util/msys2_install.sh
+++ b/util/msys2_install.sh
@@ -4,6 +4,7 @@ dir=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 download_dir=~/qmk_utils
 avrtools=avr8-gnu-toolchain
 armtools=gcc-arm-none-eabi
+installflip=false
 
 echo "Installing dependencies needed for the installation (quazip)"
 pacman --needed -S msys/unzip msys/p7zip
@@ -23,7 +24,18 @@ function install_arm {
     rm gcc-arm-none-eabi.zip
 }
 
+function extract_flip {
+    rm -f -r flip
+    7z -oflip x FlipInstaller.exe
+}
+
 pushd "$download_dir"
+
+if [ -f "FlipInstaller.exe" ]; then
+    echo
+    echo "Extracting flip"
+    extract_flip
+fi
 
 if [ ! -d "$avrtools" ]; then
     while true; do

--- a/util/msys2_install.sh
+++ b/util/msys2_install.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+dir=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+source "$dir/win_shared_install.sh"

--- a/util/msys2_install.sh
+++ b/util/msys2_install.sh
@@ -3,7 +3,9 @@
 dir=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 
 echo "Installing dependencies needed for the installation (quazip)"
-pacman -S msys/unzip
+pacman --needed -S msys/unzip
+
+export download_dir=~/qmk_utils
 
 source "$dir/win_shared_install.sh"
 

--- a/util/msys2_install.sh
+++ b/util/msys2_install.sh
@@ -7,7 +7,7 @@ armtools=gcc-arm-none-eabi
 installflip=false
 
 echo "Installing dependencies needed for the installation (quazip)"
-pacman --needed -S msys/unzip msys/p7zip
+pacman --needed -S msys/unzip msys/p7zip base-devel msys/git mingw-w64-x86_64-toolchain
 
 source "$dir/win_shared_install.sh"
 

--- a/util/win_shared_install.sh
+++ b/util/win_shared_install.sh
@@ -1,13 +1,10 @@
 #!/bin/bash
 
-download_dir=win_downloaded
-wsl_download_dir=wsl_downloaded
-
 function install_utils {
-    rm -f -r $download_dir
-    mkdir $download_dir
+    rm -f -r "$download_dir"
+    mkdir "$download_dir"
 
-    pushd $download_dir
+    pushd "$download_dir"
 
     echo "Installing dfu-programmer"
     wget 'http://downloads.sourceforge.net/project/dfu-programmer/dfu-programmer/0.7.2/dfu-programmer-win-0.7.2.zip'
@@ -34,18 +31,14 @@ function install_utils {
 }
 
 function install_drivers {
-    pushd $download_dir
+    pushd "$download_dir"
+    cp -f "$dir/drivers.txt" .
     echo 
-    cmd.exe /c "qmk_driver_installer.exe $1 $2 ..\\drivers.txt"
+    cmd.exe /c "qmk_driver_installer.exe $1 $2 drivers.txt"
     popd > /dev/null
 }
 
 pushd "$dir"
-
-if [ -d "$wsl_download_dir" ]; then
-    echo "Renaming existing wsl_download_dir to win_download"
-    mv -f "$wsl_download_dir" "$download_dir"
-fi
 
 if [ ! -d "$download_dir" ]; then
     install_utils
@@ -61,15 +54,17 @@ else
     done
 fi
 
+pushd "$download_dir"
 while true; do
     echo
     read -p "Flip need to be installed if you want to use that for programming, do you want to install it now? (Y/N) " res
     case $res in
-        [Yy]* ) cmd.exe /c $download_dir\\FlipInstaller.exe; break;;
+        [Yy]* ) cmd.exe /c FlipInstaller.exe; break;;
         [Nn]* ) break;;
         * ) echo "Invalid answer";;
     esac
 done
+popd
 
 
 while true; do

--- a/util/win_shared_install.sh
+++ b/util/win_shared_install.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+
+download_dir=win_downloaded
+wsl_download_dir=wsl_downloaded
+
+function install_utils {
+    rm -f -r $download_dir
+    mkdir $download_dir
+
+    pushd $download_dir
+
+    echo "Installing dfu-programmer"
+    wget 'http://downloads.sourceforge.net/project/dfu-programmer/dfu-programmer/0.7.2/dfu-programmer-win-0.7.2.zip'
+    unzip -d dfu-programmer dfu-programmer-win-0.7.2.zip
+
+    echo "Installing dfu-util"
+    wget 'http://dfu-util.sourceforge.net/releases/dfu-util-0.9-win64.zip'
+    unzip dfu-util-0.9-win64.zip
+
+    echo "Installing teensy_loader_cli"
+    wget 'https://www.pjrc.com/teensy/teensy_loader_cli_windows.zip'
+    unzip teensy_loader_cli_windows.zip
+
+    echo "Installing Atmel Flip"
+    wget 'http://www.atmel.com/images/Flip%20Installer%20-%203.4.7.112.exe'
+    mv Flip\ Installer\ \-\ 3.4.7.112.exe FlipInstaller.exe
+
+    echo "Downloading the QMK driver installer"
+    wget -qO- https://api.github.com/repos/qmk/qmk_driver_installer/releases | grep browser_download_url | head -n 1 | cut -d '"' -f 4 | wget -i -
+
+    rm -f *.zip
+
+    popd > /dev/null
+}
+
+function install_drivers {
+    pushd $download_dir
+    cmd.exe /C qmk_driver_installer.exe $1 $2 ../drivers.txt
+    popd > /dev/null
+}
+
+pushd "$dir"
+
+if [ -d "$wsl_download_dir" ]; then
+    echo "Renaming existing wsl_download_dir to win_download"
+    mv -f "$wsl_download_dir" "$download_dir"
+fi
+
+if [ ! -d "$download_dir" ]; then
+    install_utils
+else
+    while true; do
+        echo
+        read -p "The utils seem to already be downloaded, do you want to re-download them and update to the newest version (Y/N) " res
+        case $res in
+            [Yy]* ) install_utils; break;;
+            [Nn]* ) break;;
+            * ) echo "Invalid answer";;
+        esac
+    done
+fi
+
+while true; do
+    echo
+    read -p "Flip need to be installed if you want to use that for programming, do you want to install it now? (Y/N) " res
+    case $res in
+        [Yy]* ) cmd.exe /c $download_dir\\FlipInstaller.exe; break;;
+        [Nn]* ) break;;
+        * ) echo "Invalid answer";;
+    esac
+done
+
+
+while true; do
+    echo
+    echo "Which USB drivers do you want to install?"
+    echo "(A)all - All supported drivers will be installed"
+    echo "(C)onnected - Only drivers for connected keyboards (in bootloader/flashing mode) will be installed"
+    echo "(F)force - Like all, but will also override existing drivers for connected keyboards"
+    echo "(N)one - No drivers will be installed, flashing your keyboard will most likely not work"
+    read -p "(A/C/F/N)? " res
+    case $res in
+        [Aa]* ) install_drivers --all; break;;
+        [Cc]* ) install_drivers; break;;
+        [Ff]* ) install_drivers --all --force; break;;
+        [Nn]* ) break;;
+        * ) echo "Invalid answer";;
+    esac
+done
+
+echo 
+echo "Creating a softlink to the utils directory as ~/qmk_utils."
+echo "This is needed so that the the make system can find all utils it need."
+read -p "Press any key to continue (ctrl-c to abort)"
+ln -sfn "$dir" ~/qmk_utils
+
+if grep "^source ~/qmk_utils/activate_wsl.sh$" ~/.bashrc
+then
+    echo
+    echo "The line source ~/qmk_utils/activate_wsl.sh is already added to your /.bashrc"
+    echo "Not adding it twice"
+else
+    while true; do
+        echo
+        echo "Do you want to add 'source ~/qmk_utils/activate_wsl.sh' to the end of you .bashrc file?"
+        echo "Without this make won't find the needed utils, so if you don't want to do it automatically,"
+        echo "then you have to do it manually."
+        read -p "(Y/N)? " res
+        case $res in
+            [Yy]* ) echo "source ~/qmk_utils/activate_wsl.sh" >> ~/.bashrc; break;;
+            [Nn]* ) break;;
+            * ) echo "Invalid answer";;
+        esac
+    done
+fi
+
+while true; do
+    echo
+    echo "Do you want to add a symlink to the QMK repository in your home directory for convenience?"
+    echo "This will create a folder 'qmk_firmware' in your home directory."
+    echo "In the future you can use this folder instead of the full path on your windows file system"
+    read -p "(Y/N)? " res
+    case $res in
+        [Yy]* ) ln -sfn "$dir/.." ~/qmk_firmware; break;;
+        [Nn]* ) break;;
+        * ) echo "Invalid answer";;
+    esac
+done
+
+echo
+echo "******************************************************************************"
+echo "Installation completed!"
+echo "You need to open a new batch command prompt for all the utils to work properly"
+echo "******************************************************************************"
+
+popd > /dev/null
+

--- a/util/win_shared_install.sh
+++ b/util/win_shared_install.sh
@@ -55,21 +55,6 @@ else
     done
 fi
 
-pushd "$download_dir"
-while true; do
-    echo
-    echo "Flip need to be installed if you want to use that for programming."
-    echo "Please install it to the default location!"
-    read -p "Do you want to install it now? (Y/N) " res
-    case $res in
-        [Yy]* ) cmd.exe /c FlipInstaller.exe; break;;
-        [Nn]* ) break;;
-        * ) echo "Invalid answer";;
-    esac
-done
-popd
-
-
 while true; do
     echo
     echo "Which USB drivers do you want to install?"

--- a/util/win_shared_install.sh
+++ b/util/win_shared_install.sh
@@ -45,7 +45,8 @@ if [ ! -d "$download_dir" ]; then
 else
     while true; do
         echo
-        read -p "The utils seem to already be downloaded, do you want to re-download them and update to the newest version (Y/N) " res
+        echo "The utils seem to already be downloaded."
+        read -p "Do you want to re-download them and update to the newest version (Y/N) " res
         case $res in
             [Yy]* ) install_utils; break;;
             [Nn]* ) break;;
@@ -57,7 +58,9 @@ fi
 pushd "$download_dir"
 while true; do
     echo
-    read -p "Flip need to be installed if you want to use that for programming, do you want to install it now? (Y/N) " res
+    echo "Flip need to be installed if you want to use that for programming."
+    echo "Please install it to the default location!"
+    read -p "Do you want to install it now? (Y/N) " res
     case $res in
         [Yy]* ) cmd.exe /c FlipInstaller.exe; break;;
         [Nn]* ) break;;
@@ -71,9 +74,12 @@ while true; do
     echo
     echo "Which USB drivers do you want to install?"
     echo "(A)all - All supported drivers will be installed"
-    echo "(C)onnected - Only drivers for connected keyboards (in bootloader/flashing mode) will be installed"
-    echo "(F)force - Like all, but will also override existing drivers for connected keyboards"
-    echo "(N)one - No drivers will be installed, flashing your keyboard will most likely not work"
+    echo "(C)onnected - Only drivers for connected keyboards (in bootloader/flashing mode)"
+    echo "              will be installed"
+    echo "(F)force - Like all, but will also override existing drivers for connected"
+    echo "           keyboards"
+    echo "(N)one - No drivers will be installed,"
+    echo "         flashing your keyboard will most likely not work"
     read -p "(A/C/F/N)? " res
     case $res in
         [Aa]* ) install_drivers --all; break;;

--- a/util/win_shared_install.sh
+++ b/util/win_shared_install.sh
@@ -35,7 +35,8 @@ function install_utils {
 
 function install_drivers {
     pushd $download_dir
-    cmd.exe /C qmk_driver_installer.exe $1 $2 ../drivers.txt
+    echo 
+    cmd.exe /c "qmk_driver_installer.exe $1 $2 ..\\drivers.txt"
     popd > /dev/null
 }
 

--- a/util/win_shared_install.sh
+++ b/util/win_shared_install.sh
@@ -89,50 +89,6 @@ while true; do
     esac
 done
 
-echo 
-echo "Creating a softlink to the utils directory as ~/qmk_utils."
-echo "This is needed so that the the make system can find all utils it need."
-read -p "Press any key to continue (ctrl-c to abort)"
-ln -sfn "$dir" ~/qmk_utils
-
-if grep "^source ~/qmk_utils/activate_wsl.sh$" ~/.bashrc
-then
-    echo
-    echo "The line source ~/qmk_utils/activate_wsl.sh is already added to your /.bashrc"
-    echo "Not adding it twice"
-else
-    while true; do
-        echo
-        echo "Do you want to add 'source ~/qmk_utils/activate_wsl.sh' to the end of you .bashrc file?"
-        echo "Without this make won't find the needed utils, so if you don't want to do it automatically,"
-        echo "then you have to do it manually."
-        read -p "(Y/N)? " res
-        case $res in
-            [Yy]* ) echo "source ~/qmk_utils/activate_wsl.sh" >> ~/.bashrc; break;;
-            [Nn]* ) break;;
-            * ) echo "Invalid answer";;
-        esac
-    done
-fi
-
-while true; do
-    echo
-    echo "Do you want to add a symlink to the QMK repository in your home directory for convenience?"
-    echo "This will create a folder 'qmk_firmware' in your home directory."
-    echo "In the future you can use this folder instead of the full path on your windows file system"
-    read -p "(Y/N)? " res
-    case $res in
-        [Yy]* ) ln -sfn "$dir/.." ~/qmk_firmware; break;;
-        [Nn]* ) break;;
-        * ) echo "Invalid answer";;
-    esac
-done
-
-echo
-echo "******************************************************************************"
-echo "Installation completed!"
-echo "You need to open a new batch command prompt for all the utils to work properly"
-echo "******************************************************************************"
 
 popd > /dev/null
 

--- a/util/wsl_install.sh
+++ b/util/wsl_install.sh
@@ -33,6 +33,21 @@ download_dir=wsl_downloaded
 
 source "$dir/win_shared_install.sh"
 
+pushd "$download_dir"
+while true; do
+    echo
+    echo "Flip need to be installed if you want to use that for programming."
+    echo "Please install it to the default location!"
+    read -p "Do you want to install it now? (Y/N) " res
+    case $res in
+        [Yy]* ) cmd.exe /c FlipInstaller.exe; break;;
+        [Nn]* ) break;;
+        * ) echo "Invalid answer";;
+    esac
+done
+popd
+
+
 echo 
 echo "Creating a softlink to the utils directory as ~/qmk_utils."
 echo "This is needed so that the the make system can find all utils it need."

--- a/util/wsl_install.sh
+++ b/util/wsl_install.sh
@@ -1,44 +1,7 @@
 #!/bin/bash
 
-download_dir=wsl_downloaded
-
-function install_utils {
-    rm -f -r $download_dir
-    mkdir $download_dir
-
-    pushd $download_dir
-
-    echo "Installing dfu-programmer"
-    wget 'http://downloads.sourceforge.net/project/dfu-programmer/dfu-programmer/0.7.2/dfu-programmer-win-0.7.2.zip'
-    unzip -d dfu-programmer dfu-programmer-win-0.7.2.zip
-
-    echo "Installing dfu-util"
-    wget 'http://dfu-util.sourceforge.net/releases/dfu-util-0.9-win64.zip'
-    unzip dfu-util-0.9-win64.zip
-
-    echo "Installing teensy_loader_cli"
-    wget 'https://www.pjrc.com/teensy/teensy_loader_cli_windows.zip'
-    unzip teensy_loader_cli_windows.zip
-
-    echo "Installing Atmel Flip"
-    wget 'http://www.atmel.com/images/Flip%20Installer%20-%203.4.7.112.exe'
-    mv Flip\ Installer\ \-\ 3.4.7.112.exe FlipInstaller.exe
-
-    echo "Downloading the QMK driver installer"
-    wget -qO- https://api.github.com/repos/qmk/qmk_driver_installer/releases | grep browser_download_url | head -n 1 | cut -d '"' -f 4 | wget -i -
-
-    rm -f *.zip
-
-    popd > /dev/null
-}
-
-function install_drivers {
-    pushd $download_dir
-    cmd.exe /C qmk_driver_installer.exe $1 $2 ../drivers.txt
-    popd > /dev/null
-}
-
 dir=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+pushd "$dir";
 
 if [[ $dir != /mnt/* ]];
 then
@@ -48,7 +11,6 @@ then
     exit 1
 fi
 
-pushd "$dir"
 
 while true; do
     echo
@@ -66,94 +28,6 @@ done
 echo "Installing dependencies needed for the installation (unzip, wget)"
 echo "This will ask for the sudo password"
 sudo apt-get install unzip wget
-
-
-if [ ! -d "$download_dir" ]; then
-    install_utils
-else
-    while true; do
-        echo
-        read -p "The utils seem to already be downloaded, do you want to re-download them and update to the newest version (Y/N) " res
-        case $res in
-            [Yy]* ) install_utils; break;;
-            [Nn]* ) break;;
-            * ) echo "Invalid answer";;
-        esac
-    done
-fi
-
-while true; do
-    echo
-    read -p "Flip need to be installed if you want to use that for programming, do you want to install it now? (Y/N) " res
-    case $res in
-        [Yy]* ) cmd.exe /c $download_dir\\FlipInstaller.exe; break;;
-        [Nn]* ) break;;
-        * ) echo "Invalid answer";;
-    esac
-done
-
-
-while true; do
-    echo
-    echo "Which USB drivers do you want to install?"
-    echo "(A)all - All supported drivers will be installed"
-    echo "(C)onnected - Only drivers for connected keyboards (in bootloader/flashing mode) will be installed"
-    echo "(F)force - Like all, but will also override existing drivers for connected keyboards"
-    echo "(N)one - No drivers will be installed, flashing your keyboard will most likely not work"
-    read -p "(A/C/F/N)? " res
-    case $res in
-        [Aa]* ) install_drivers --all; break;;
-        [Cc]* ) install_drivers; break;;
-        [Ff]* ) install_drivers --all --force; break;;
-        [Nn]* ) break;;
-        * ) echo "Invalid answer";;
-    esac
-done
-
-echo 
-echo "Creating a softlink to the utils directory as ~/qmk_utils."
-echo "This is needed so that the the make system can find all utils it need."
-read -p "Press any key to continue (ctrl-c to abort)"
-ln -sfn "$dir" ~/qmk_utils
-
-if grep "^source ~/qmk_utils/activate_wsl.sh$" ~/.bashrc
-then
-    echo
-    echo "The line source ~/qmk_utils/activate_wsl.sh is already added to your /.bashrc"
-    echo "Not adding it twice"
-else
-    while true; do
-        echo
-        echo "Do you want to add 'source ~/qmk_utils/activate_wsl.sh' to the end of you .bashrc file?"
-        echo "Without this make won't find the needed utils, so if you don't want to do it automatically,"
-        echo "then you have to do it manually."
-        read -p "(Y/N)? " res
-        case $res in
-            [Yy]* ) echo "source ~/qmk_utils/activate_wsl.sh" >> ~/.bashrc; break;;
-            [Nn]* ) break;;
-            * ) echo "Invalid answer";;
-        esac
-    done
-fi
-
-while true; do
-    echo
-    echo "Do you want to add a symlink to the QMK repository in your home directory for convenience?"
-    echo "This will create a folder 'qmk_firmware' in your home directory."
-    echo "In the future you can use this folder instead of the full path on your windows file system"
-    read -p "(Y/N)? " res
-    case $res in
-        [Yy]* ) ln -sfn "$dir/.." ~/qmk_firmware; break;;
-        [Nn]* ) break;;
-        * ) echo "Invalid answer";;
-    esac
-done
-
-echo
-echo "******************************************************************************"
-echo "Installation completed!"
-echo "You need to open a new batch command prompt for all the utils to work properly"
-echo "******************************************************************************"
+source "$dir/win_shared_install.sh"
 
 popd > /dev/null
-

--- a/util/wsl_install.sh
+++ b/util/wsl_install.sh
@@ -28,6 +28,9 @@ done
 echo "Installing dependencies needed for the installation (unzip, wget)"
 echo "This will ask for the sudo password"
 sudo apt-get install unzip wget
+
+download_dir=wsl_downloaded
+
 source "$dir/win_shared_install.sh"
 
 echo 

--- a/util/wsl_install.sh
+++ b/util/wsl_install.sh
@@ -30,4 +30,49 @@ echo "This will ask for the sudo password"
 sudo apt-get install unzip wget
 source "$dir/win_shared_install.sh"
 
+echo 
+echo "Creating a softlink to the utils directory as ~/qmk_utils."
+echo "This is needed so that the the make system can find all utils it need."
+read -p "Press any key to continue (ctrl-c to abort)"
+ln -sfn "$dir" ~/qmk_utils
+
+if grep "^source ~/qmk_utils/activate_wsl.sh$" ~/.bashrc
+then
+    echo
+    echo "The line source ~/qmk_utils/activate_wsl.sh is already added to your /.bashrc"
+    echo "Not adding it twice"
+else
+    while true; do
+        echo
+        echo "Do you want to add 'source ~/qmk_utils/activate_wsl.sh' to the end of you .bashrc file?"
+        echo "Without this make won't find the needed utils, so if you don't want to do it automatically,"
+        echo "then you have to do it manually."
+        read -p "(Y/N)? " res
+        case $res in
+            [Yy]* ) echo "source ~/qmk_utils/activate_wsl.sh" >> ~/.bashrc; break;;
+            [Nn]* ) break;;
+            * ) echo "Invalid answer";;
+        esac
+    done
+fi
+
+while true; do
+    echo
+    echo "Do you want to add a symlink to the QMK repository in your home directory for convenience?"
+    echo "This will create a folder 'qmk_firmware' in your home directory."
+    echo "In the future you can use this folder instead of the full path on your windows file system"
+    read -p "(Y/N)? " res
+    case $res in
+        [Yy]* ) ln -sfn "$dir/.." ~/qmk_firmware; break;;
+        [Nn]* ) break;;
+        * ) echo "Invalid answer";;
+    esac
+done
+
+echo
+echo "******************************************************************************"
+echo "Installation completed!"
+echo "You need to open a new batch command prompt for all the utils to work properly"
+echo "******************************************************************************"
+
 popd > /dev/null

--- a/util/wsl_install.sh
+++ b/util/wsl_install.sh
@@ -47,9 +47,9 @@ then
 else
     while true; do
         echo
-        echo "Do you want to add 'source ~/qmk_utils/activate_wsl.sh' to the end of you .bashrc file?"
-        echo "Without this make won't find the needed utils, so if you don't want to do it automatically,"
-        echo "then you have to do it manually."
+        echo "Do you want to add 'source ~/qmk_utils/activate_wsl.sh' to the end of your"
+        echo ".bashrc file? Without this make won't find the needed utils, so if you don't"
+        echo "want to do it automatically, then you have to do it manually later."
         read -p "(Y/N)? " res
         case $res in
             [Yy]* ) echo "source ~/qmk_utils/activate_wsl.sh" >> ~/.bashrc; break;;
@@ -61,9 +61,10 @@ fi
 
 while true; do
     echo
-    echo "Do you want to add a symlink to the QMK repository in your home directory for convenience?"
-    echo "This will create a folder 'qmk_firmware' in your home directory."
-    echo "In the future you can use this folder instead of the full path on your windows file system"
+    echo "Do you want to add a symlink to the QMK repository in your home directory for"
+    echo "convenience? This will create a folder 'qmk_firmware' in your home directory."
+    echo "In the future you can use this folder instead of the full path on your Windows"
+    echo "file system."
     read -p "(Y/N)? " res
     case $res in
         [Yy]* ) ln -sfn "$dir/.." ~/qmk_firmware; break;;


### PR DESCRIPTION
This adds support for msys2, which is an improved version of mingw. This will hopefully be the default for Windows along with the WSL variation.

Everything installed is totally isolated inside that environment, so if something goes wrong, you can just unistall and delete the installation folder and try again. Programs installed on your Windows machine should also not affect anything.

Before it's merged I would like to have this tested on some other machines too.

I haven't written any instructions yet, but it should be something like this
1. Install msys2, following these [instructions](http://www.msys2.org/)
2. Run `MSYS2 MingGW 64-bit`
3. Navigate to your qmk_checkout, paths are represented like this `/c/path/to/folder`
4. Run `util/msys2_install.sh` and follow the instructions

