### PR TITLE
Fix build multiple tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -419,7 +419,7 @@ define BUILD_TEST
     MAKE_TARGET := $2
     COMMAND := $1
     MAKE_CMD := $$(MAKE) -r -R -C $(ROOT_DIR) -f build_test.mk $$(MAKE_TARGET)
-    MAKE_VARS := TEST=$$(TEST_NAME) FULL_TESTS=$$(FULL_TESTS)
+    MAKE_VARS := TEST=$$(TEST_NAME) FULL_TESTS="$$(FULL_TESTS)"
     MAKE_MSG := $$(MSG_MAKE_TEST)
     $$(eval $$(call BUILD))
     ifneq ($$(MAKE_TARGET),clean)

--- a/build_full_test.mk
+++ b/build_full_test.mk
@@ -21,12 +21,13 @@ $(TEST)_SRC= \
 	$(TEST_PATH)/keymap.c \
 	$(TMK_COMMON_SRC) \
 	$(QUANTUM_SRC) \
+	$(SRC) \
 	tests/test_common/matrix.c \
 	tests/test_common/test_driver.cpp \
 	tests/test_common/keyboard_report_util.cpp \
 	tests/test_common/test_fixture.cpp
 $(TEST)_SRC += $(patsubst $(ROOTDIR)/%,%,$(wildcard $(TEST_PATH)/*.cpp))
 
-$(TEST)_DEFS=$(TMK_COMMON_DEFS)
+$(TEST)_DEFS=$(TMK_COMMON_DEFS) $(OPT_DEFS)
 $(TEST)_CONFIG=$(TEST_PATH)/config.h
 VPATH+=$(TOP_DIR)/tests/test_common


### PR DESCRIPTION
Building multiple test directories was broken and the tests didn't use all source files and options.

This fixes both issues.