### PR TITLE
New "dual role" feature

### DIFF
--- a/common_features.mk
+++ b/common_features.mk
@@ -98,6 +98,11 @@ ifeq ($(strip $(TAP_DANCE_ENABLE)), yes)
     SRC += $(QUANTUM_DIR)/process_keycode/process_tap_dance.c
 endif
 
+ifeq ($(strip $(DUAL_ROLE_ENABLE)), yes)
+    OPT_DEFS += -DDUAL_ROLE_ENABLE
+    SRC += $(QUANTUM_DIR)/process_keycode/process_dual_role.c
+endif
+
 ifeq ($(strip $(PRINTING_ENABLE)), yes)
     OPT_DEFS += -DPRINTING_ENABLE
     SRC += $(QUANTUM_DIR)/process_keycode/process_printer.c

--- a/quantum/process_keycode/process_dual_role.c
+++ b/quantum/process_keycode/process_dual_role.c
@@ -1,0 +1,111 @@
+/* Copyright 2017 Peter Jones <pjones@devalot.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "quantum.h"
+
+static qk_dual_role_state_t dual_role_state = {0, 0, 0, false};
+
+// An existing dual role was interrupted.
+static inline void dual_role_interrupted(void) {
+  qk_dual_role_action_t *action;
+  dual_role_state.interrupted = true;
+
+  for (uint8_t i=0; i <= dual_role_state.max; i++) {
+    action = &dual_role_keys[i];
+    if (action->active) register_mods(action->mod);
+  }
+}
+
+// Start tracking a dual role key.
+static inline void dual_role_start(qk_dual_role_action_t *action) {
+  if (dual_role_state.count && dual_role_state.interrupted) {
+    // There is already an active modifier that has been interrupted.
+    // Therefore this key will act like a normal, non-dual-role key.
+    dual_role_interrupted();
+    register_code(action->key);
+    return;
+  }
+
+  action->active = true;
+  dual_role_state.count++;
+  dual_role_state.timer = timer_read();
+
+  if (dual_role_state.count == 1) {
+    dual_role_state.interrupted = false;
+  }
+}
+
+// The dual role should end now.
+static inline void dual_role_end(qk_dual_role_action_t *action) {
+  if (!action->active) {
+    // This key was acting like a normal key.
+    unregister_code(action->key);
+    return;
+  }
+
+
+  // Clean up after the key.
+  action->active = false;
+  dual_role_state.count--;
+
+  // See if this dual role key should be used as a normal key or a
+  // modifier.  When more than one dual-role keys is held down we need
+  // to consider that releasing one of the dual-role keys might mean
+  // it should have been used as a normal key.
+  if (dual_role_state.count &&
+      !dual_role_state.interrupted &&
+      timer_elapsed(dual_role_state.timer) < TAPPING_TERM)
+  {
+    dual_role_interrupted();
+    register_code(action->key);
+    unregister_code(action->key);
+  } else if (!dual_role_state.count &&
+             !dual_role_state.interrupted &&
+             timer_elapsed(dual_role_state.timer) < TAPPING_TERM)
+  {
+    register_code(action->key);
+    unregister_code(action->key);
+  }
+  else {
+    unregister_mods(action->mod);
+  }
+}
+
+// Called for each key press.
+bool process_dual_role(uint16_t keycode, keyrecord_t *record) {
+  qk_dual_role_action_t *action;
+  uint16_t index = 0;
+
+  switch(keycode) {
+  case QK_DUAL_ROLE ... QK_DUAL_ROLE_MAX:
+    index = keycode - QK_DUAL_ROLE;
+    action = &dual_role_keys[index];
+
+    if (record->event.pressed) {
+      if (index > dual_role_state.max) dual_role_state.max = index;
+      dual_role_start(action);
+    } else {
+      dual_role_end(action);
+    }
+
+    return false;
+
+  default:
+    if (record->event.pressed && dual_role_state.count)
+      dual_role_interrupted();
+  }
+
+  return true;
+}

--- a/quantum/process_keycode/process_dual_role.h
+++ b/quantum/process_keycode/process_dual_role.h
@@ -1,0 +1,50 @@
+/* Copyright 2017 Peter Jones <pjones@devalot.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef PROCESS_DUAL_ROLE_H
+#define PROCESS_DUAL_ROLE_H
+
+#ifdef DUAL_ROLE_ENABLE
+
+#include <stdbool.h>
+#include <inttypes.h>
+
+typedef struct
+{
+  uint16_t timer;
+  uint8_t  count;
+  uint8_t  max;
+  bool     interrupted;
+} qk_dual_role_state_t;
+
+typedef struct
+{
+  uint16_t mod;
+  uint16_t key;
+  bool     active;
+} qk_dual_role_action_t;
+
+#define DR(n) (QK_DUAL_ROLE + n)
+#define DUAL_ROLE(mod, key) {mod, key, false}
+extern qk_dual_role_action_t dual_role_keys[];
+
+/* To be used internally */
+bool process_dual_role(uint16_t keycode, keyrecord_t *record);
+
+#else // DUAL_ROLE_ENABLE
+#define DR(n) KC_NO
+#endif // DUAL_ROLE_ENABLE
+
+#endif // PROCESS_TAP_DANCE_H

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -178,6 +178,9 @@ bool process_record_quantum(keyrecord_t *record) {
   #if defined(AUDIO_ENABLE) || (defined(MIDI_ENABLE) && defined(MIDI_BASIC))
     process_music(keycode, record) &&
   #endif
+  #ifdef DUAL_ROLE_ENABLE
+    process_dual_role(keycode, record) &&
+  #endif
   #ifdef TAP_DANCE_ENABLE
     process_tap_dance(keycode, record) &&
   #endif

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -84,6 +84,7 @@ extern uint32_t default_layer_state;
 	#include "process_unicodemap.h"
 #endif
 
+#include "process_dual_role.h"
 #include "process_tap_dance.h"
 
 #ifdef PRINTING_ENABLE

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -67,6 +67,8 @@ enum quantum_keycodes {
     QK_TAP_DANCE_MAX      = 0x57FF,
     QK_LAYER_TAP_TOGGLE   = 0x5800,
     QK_LAYER_TAP_TOGGLE_MAX = 0x58FF,
+    QK_DUAL_ROLE          = 0x5900,
+    QK_DUAL_ROLE_MAX      = 0x59FF,
     QK_MOD_TAP            = 0x6000,
     QK_MOD_TAP_MAX        = 0x7FFF,
 #if defined(UNICODEMAP_ENABLE) && defined(UNICODE_ENABLE)


### PR DESCRIPTION
Alternative to the `MT()` family with an implementation geared towards fast typists.

I'm submitting this to see what kind of interest there is in this feature.  If it's something that is acceptable for merging I will include full documentation before merging.

The primary motivation for dual role is to have a key that can be both a modifier and a normal keycode.  Unlike `MT()`, as soon as a dual role key is interrupted it registers its modifier and no longer acts like a normal key.  On key up, if it didn't act like a modifier it sends its keycode.  `MT()`, on the other hand, waits for a timeout before the key turns into a modifier.  The slight delay can be annoying for fast typists.

I have been using this implementation all week without any issues.  You can see how I'm using it [here](https://github.com/pjones/qmk_firmware/blob/pjones-dual-role/keyboards/minidox/keymaps/pjones/keymap.c).