### PR TITLE
Add support for Steno protocols

### DIFF
--- a/common_features.mk
+++ b/common_features.mk
@@ -54,6 +54,12 @@ ifeq ($(strip $(COMBO_ENABLE)), yes)
     SRC += $(QUANTUM_DIR)/process_keycode/process_combo.c
 endif
 
+ifeq ($(strip $(STENO_ENABLE)), yes)
+    OPT_DEFS += -DSTENO_ENABLE
+	VIRTSER_ENABLE := yes
+	SRC += $(QUANTUM_DIR)/process_keycode/process_steno.c
+endif
+
 ifeq ($(strip $(VIRTSER_ENABLE)), yes)
     OPT_DEFS += -DVIRTSER_ENABLE
 endif

--- a/docs/_summary.md
+++ b/docs/_summary.md
@@ -1,4 +1,4 @@
-* [Getting started](README.md) 
+* [Getting started](README.md)
   * [QMK Overview](qmk_overview.md)
   * [Build Environment Setup](build_environment_setup.md)
     * [Vagrant Guide](vagrant_guide.md)
@@ -16,6 +16,7 @@
   * [Tap Dance](tap_dance.md)
   * [Mouse keys](mouse_keys.md)
   * [Unicode](unicode.md)
+  * [Stenography](stenography.md)
 
 * Reference
   * [Glossary](glossary.md)
@@ -27,7 +28,7 @@
   * [Customizing Functionality](custom_quantum_functions.md)
   * [Documentation Best Practices](documentation_best_practices.md)
   * [Unit Testing](unit_testing.md)
-  
+
 * For Makers and Modders
   * [Adding a keyboard to QMK](adding_a_keyboard_to_qmk.md)
   * [Adding features to QMK](adding_features_to_qmk.md)
@@ -39,7 +40,7 @@
 * For a Deeper Understanding
   * [How Keyboards Work](basic_how_keyboards_work.md)
   * [Understanding QMK](understanding_qmk.md)
-  
+
 * Other Topics
   * [General FAQ](faq.md)
   * [Using Eclipse with QMK](eclipse.md)

--- a/docs/stenography.md
+++ b/docs/stenography.md
@@ -47,7 +47,7 @@ void matrix_init_user() {
 
 Once you have your keyboard flashed launch Plover. Click the 'Configure...' button. In the 'Machine' tab select the Stenotype Machine that corresponds to your desired protocol. Click the 'Configure...' button on this tab and enter the serial port or click 'Scan'. Baud rate is fine at 9600 (although you should be able to set as high as 115200 with no issues). Use the default settings for everything else (Data Bits: 8, Stop Bits: 1, Parity: N, no flow control).
 
-On the display tab click 'Open stroke display'. With Plover disables you should be able to hit keys on your keyboard and see them show up in the stroke display window. Use this to make sure you have set up your keymap correctly. You are now ready to steno!
+On the display tab click 'Open stroke display'. With Plover disabled you should be able to hit keys on your keyboard and see them show up in the stroke display window. Use this to make sure you have set up your keymap correctly. You are now ready to steno!
 
 ## Learning Stenography
 

--- a/docs/stenography.md
+++ b/docs/stenography.md
@@ -1,0 +1,108 @@
+# Stenography in QMK
+
+[Stenography](https://en.wikipedia.org/wiki/Stenotype) is a method of writing most often used by court reports, closed-captioning, and real-time transcription for the deaf. In stenography words are chorded syllable by syllable with a mixture of spelling, phonetic, and shortcut (briefs) strokes. Professional stenographers can reach 200-300 WPM without any of the strain usually found in standard typing and with far fewer errors (>99.9% accuracy).
+
+The [Open Steno Project](http://www.openstenoproject.org/) has built an open-source program called Plover that provides real-time translation of steno strokes into words and commands. It has an established dictionary and supports
+
+## Plover with QWERTY Keyboard
+
+Plover can work with any standard QWERTY keyboard, although it is more efficient if the keyboard supports NKRO (n-key rollover) to allow Plover to see all the pressed keys at once. An example keymap for Plover can be found in `planck/keymaps/default`. Switching to the `PLOVER` layer adjusts the position of the keyboard to support the number bar.
+
+To use Plover with QMK just enable NKRO and optionally adjust your layout if you have anything other than a standard layout. You may also want to purchase some steno-friendly keycaps to make it easier to hit multiple keys.
+
+## Plover with Steno Protocol
+
+Plover also understands the language of several steno machines. QMK can speak a couple of these languages, TX Bolt and GeminiRP. An example layout can be found in `planck/keymaps/steno`.
+
+When QMK speaks to Plover over a steno protocol Plover will not use the keyboard as input. This means that you can switch back and forth between a standard keyboard and your steno keyboard, or even switch layers from Plover to standard and back without needing to activate/deactive Plover.
+
+In this mode Plover expects to speak with a steno machine over a serial port so QMK will present itself to the operating system as a virtual serial port in addition to a keyboard. By default QMK will speak the TX Bolt protocol but can be switched to GeminiRP; the last protocol used is stored in non-volatile memory so QMK will use the same protocol on restart.
+
+> Note: Due to hardware limitations you may not be able to run both a virtual serial port and mouse emulation at the same time.
+
+### TX Bolt
+
+TX Bolt communicates the status of 24 keys over a very simple protocol in variable-sized (1-5 byte) packets.
+
+### GeminiRP
+
+GeminiRP encodes 42 keys into a 6-byte packet. While TX Bolt contains everything that is necessary for standard stenography, GeminiRP opens up many more options, including supporting non-English theories.
+
+## Configuring QMK for Steno
+
+Firstly, enable steno in your keymap's Makefile. You should also diable mousekeys to prevent conflicts.
+
+```Makefile
+STENO_ENABLE = yes
+MOUSEKEY_ENABLE = no
+```
+
+In your keymap create a new layer for Plover. You will need to include `keymap_steno.h`. See `planck/keymaps/steno/keymap.c` for an example. Remember to create a key to switch to the layer as well as a key for exiting the layer. If you would like to switch modes on the fly you can use the keycodes `QK_STENO_BOLT` and `QK_STENO_GEMINI`. If you only want to use one of the protocols you may set it up in your initialization function:
+
+```C
+void matrix_init_user() {
+  steno_set_mode(STENO_MODE_GEMINI); // or STENO_MODE_BOLT
+}
+```
+
+Once you have your keyboard flashed launch Plover. Click the 'Configure...' button. In the 'Machine' tab select the Stenotype Machine that corresponds to your desired protocol. Click the 'Configure...' button on this tab and enter the serial port or click 'Scan'. Baud rate is fine at 9600 (although you should be able to set as high as 115200 with no issues). Use the default settings for everything else (Data Bits: 8, Stop Bits: 1, Parity: N, no flow control).
+
+On the display tab click 'Open stroke display'. With Plover disables you should be able to hit keys on your keyboard and see them show up in the stroke display window. Use this to make sure you have set up your keymap correctly. You are now ready to steno!
+
+## Learning Stenography
+
+* [Learn Plover!](https://sites.google.com/site/ploverdoc/)
+* [QWERTY Steno](http://qwertysteno.com/Home/)
+* [Steno Jig](https://joshuagrams.github.io/steno-jig/)
+* More resources at the Plover [Learning Stenography](https://github.com/openstenoproject/plover/wiki/Learning-Stenography) wiki
+
+## Keycode Reference
+
+As defined in `keymap_steno.h`.
+
+> Note: TX Bolt does not support the full set of keys. The TX Bolt implementation in QMK will map the GeminiRP keys to the nearest TX Bolt key so that one key map will work for both.
+
+|GeminiRP|TX Bolt|Steno Key|
+|--------|-------|-----------|
+|`STN_N1`|`STN_NUM`|Number bar #1|
+|`STN_N2`|`STN_NUM`|Number bar #2|
+|`STN_N3`|`STN_NUM`|Number bar #3|
+|`STN_N4`|`STN_NUM`|Number bar #4|
+|`STN_N5`|`STN_NUM`|Number bar #5|
+|`STN_N6`|`STN_NUM`|Number bar #6|
+|`STN_N7`|`STN_NUM`|Number bar #7|
+|`STN_N8`|`STN_NUM`|Number bar #8|
+|`STN_N9`|`STN_NUM`|Number bar #9|
+|`STN_NA`|`STN_NUM`|Number bar #A|
+|`STN_NB`|`STN_NUM`|Number bar #B|
+|`STN_NC`|`STN_NUM`|Number bar #C|
+|`STN_S1`|`STN_SL`| `S-` upper|
+|`STN_S2`|`STN_SL`| `S-` lower|
+|`STN_TL`|`STN_TL`| `T-`|
+|`STN_KL`|`STN_KL`| `K-`|
+|`STN_PL`|`STN_PL`| `P-`|
+|`STN_WL`|`STN_WL`| `W-`|
+|`STN_HL`|`STN_HL`| `H-`|
+|`STN_RL`|`STN_RL`| `R-`|
+|`STN_A`|`STN_A`| `A` vowel|
+|`STN_O`|`STN_O`| `O` vowel|
+|`STN_ST1`|`STN_STR`| `*` upper-left |
+|`STN_ST2`|`STN_STR`| `*` lower-left|
+|`STN_ST3`|`STN_STR`| `*` upper-right|
+|`STN_ST4`|`STN_STR`| `*` lower-right|
+|`STN_E`|`STN_E`| `E` vowel|
+|`STN_U`|`STN_U`| `U` vowel|
+|`STN_FR`|`STN_FR`| `-F`|
+|`STN_PR`|`STN_PR`| `-P`|
+|`STN_RR`|`STN_RR`| `-R`|
+|`STN_BR`|`STN_BR`| `-B`|
+|`STN_LR`|`STN_LR`| `-L`|
+|`STN_GR`|`STN_GR`| `-G`|
+|`STN_TR`|`STN_TR`| `-T`|
+|`STN_SR`|`STN_SR`| `-S`|
+|`STN_DR`|`STN_DR`| `-D`|
+|`STN_ZR`|`STN_ZR`| `-Z`|
+|`STN_FN`|| (GeminiRP only)|
+|`STN_RES1`||(GeminiRP only)|
+|`STN_RES2`||(GeminiRP only)|
+|`STN_PWR`||(GeminiRP only)|

--- a/keyboards/planck/keymaps/experimental/Makefile
+++ b/keyboards/planck/keymaps/experimental/Makefile
@@ -1,11 +1,11 @@
 
 
 # Build Options
-#   change to "no" to disable the options, or define them in the Makefile in 
+#   change to "no" to disable the options, or define them in the Makefile in
 #   the appropriate keymap folder that will get included automatically
 #
 BOOTMAGIC_ENABLE = no       # Virtual DIP switch configuration(+1000)
-MOUSEKEY_ENABLE = yes       # Mouse keys(+4700)
+MOUSEKEY_ENABLE = no        # Mouse keys(+4700)
 EXTRAKEY_ENABLE = yes       # Audio control and System control(+450)
 CONSOLE_ENABLE = no         # Console for debug(+400)
 COMMAND_ENABLE = yes        # Commands for debug and configuration
@@ -17,6 +17,7 @@ UNICODE_ENABLE = no         # Unicode
 BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
 RGBLIGHT_ENABLE = yes        # Enable WS2812 RGB underlight.  Do not enable this with audio at the same time.
 ONEHAND_ENABLE = yes        # Enable one-hand typing
+STENO_ENABLE = yes					# Enable TX Bolt protocol for Stenography, requires VIRTSER and may not work with mouse keys
 
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
 SLEEP_LED_ENABLE = no    # Breathing sleep LED during USB suspend

--- a/keyboards/planck/keymaps/experimental/keymap.c
+++ b/keyboards/planck/keymaps/experimental/keymap.c
@@ -3,6 +3,7 @@
 
 #include "planck.h"
 #include "action_layer.h"
+#include "keymap_steno.h"
 #ifdef AUDIO_ENABLE
   #include "audio.h"
 #endif
@@ -49,7 +50,7 @@ enum planck_keycodes {
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 [0] = {
-  {KC_NO, KC_NO, KC_NO, KC_NO, RGBLED_TOGGLE, RGBLED_STEP_MODE, RGBLED_INCREASE_HUE, RGBLED_DECREASE_HUE, RGBLED_INCREASE_SAT, RGBLED_DECREASE_SAT, RGBLED_INCREASE_VAL, RGBLED_DECREASE_VAL},
+  {QWERTY, KC_NO, KC_NO, KC_NO, RGBLED_TOGGLE, RGBLED_STEP_MODE, RGBLED_INCREASE_HUE, RGBLED_DECREASE_HUE, RGBLED_INCREASE_SAT, RGBLED_DECREASE_SAT, RGBLED_INCREASE_VAL, RGBLED_DECREASE_VAL},
   {KC_NO, KC_NO, KC_NO, KC_NO, RGBLED_TOGGLE, RGBLED_STEP_MODE, RGBLED_INCREASE_HUE, RGBLED_DECREASE_HUE, RGBLED_INCREASE_SAT, RGBLED_DECREASE_SAT, RGBLED_INCREASE_VAL, RGBLED_DECREASE_VAL},
   {KC_NO, KC_NO, KC_NO, KC_NO, RGBLED_TOGGLE, RGBLED_STEP_MODE, RGBLED_INCREASE_HUE, RGBLED_DECREASE_HUE, RGBLED_INCREASE_SAT, RGBLED_DECREASE_SAT, RGBLED_INCREASE_VAL, RGBLED_DECREASE_VAL},
   {KC_NO, KC_NO, KC_NO, KC_NO, RGBLED_TOGGLE, RGBLED_STEP_MODE, RGBLED_INCREASE_HUE, RGBLED_DECREASE_HUE, RGBLED_INCREASE_SAT, RGBLED_DECREASE_SAT, RGBLED_INCREASE_VAL, RGBLED_DECREASE_VAL}
@@ -158,10 +159,10 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  */
 
 [_PLOVER] = {
-  {KC_1,    KC_1,    KC_1,    KC_1,    KC_1,    KC_1,    KC_1,    KC_1,    KC_1,    KC_1,    KC_1,    KC_1   },
-  {XXXXXXX, KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC},
-  {XXXXXXX, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT},
-  {EXT_PLV, XXXXXXX, XXXXXXX, KC_C,    KC_V,    XXXXXXX, XXXXXXX, KC_N,    KC_M,    XXXXXXX, XXXXXXX, XXXXXXX}
+  {STN_N1,  STN_N2,  STN_N3,  STN_N4,  STN_N5,  STN_N6,  STN_N7,  STN_N8,  STN_N9,  STN_NA,  STN_NB,  STN_NC },
+  {STN_FN,  STN_S1,  STN_TL,  STN_PL,  STN_HL,  STN_ST1, STN_ST3, STN_FR,  STN_PR,  STN_LR,  STN_TR,  STN_DR },
+  {XXXXXXX, STN_S2,  STN_KL,  STN_WL,  STN_RL,  STN_ST2, STN_ST4, STN_RR,  STN_BR,  STN_GR,  STN_SR,  STN_ZR },
+  {EXT_PLV, XXXXXXX, XXXXXXX, STN_A,   STN_O,   XXXXXXX, XXXXXXX, STN_E,   STN_U,   STN_PWR, STN_RE1, STN_RE2}
 },
 
 /* Adjust (Lower + Raise)
@@ -279,21 +280,12 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         break;
       return false;
         case PLOVER:
-          if (record->event.pressed) {
+          if (!record->event.pressed) {
             #ifdef AUDIO_ENABLE
               stop_all_notes();
               PLAY_NOTE_ARRAY(tone_plover, false, 0);
             #endif
-            layer_off(_RAISE);
-            layer_off(_LOWER);
-            layer_off(_ADJUST);
             layer_on(_PLOVER);
-            if (!eeconfig_is_enabled()) {
-                eeconfig_init();
-            }
-            keymap_config.raw = eeconfig_read_keymap();
-            keymap_config.nkro = 1;
-            eeconfig_update_keymap(keymap_config.raw);
           }
         break;
       return false;
@@ -397,9 +389,9 @@ void music_scale_user(void)
 LEADER_EXTERNS();
 
 void matrix_scan_user(void) {
-  LEADER_DICTIONARY() { 
+  LEADER_DICTIONARY() {
     leading = false;
-    leader_end(); 
+    leader_end();
 
     SEQ_ONE_KEY (KC_R) {
       tap_random_base64();

--- a/keyboards/planck/keymaps/steno/Makefile
+++ b/keyboards/planck/keymaps/steno/Makefile
@@ -1,0 +1,7 @@
+ifndef QUANTUM_DIR
+	include ../../../../Makefile
+endif
+
+MOUSEKEY_ENABLE = no        # Mouse keys(+4700)
+STENO_ENABLE = yes					# Enable TX Bolt protocol for Stenography, requires VIRTSER and may not work with mouse keys
+

--- a/keyboards/planck/keymaps/steno/Makefile
+++ b/keyboards/planck/keymaps/steno/Makefile
@@ -3,5 +3,5 @@ ifndef QUANTUM_DIR
 endif
 
 MOUSEKEY_ENABLE = no        # Mouse keys(+4700)
-STENO_ENABLE = yes					# Enable TX Bolt protocol for Stenography, requires VIRTSER and may not work with mouse keys
-
+STENO_ENABLE = yes          # Additional protocols for Stenography(+1700), requires VIRTSER
+AUDIO_ENABLE = no           # Audio output on port C6

--- a/keyboards/planck/keymaps/steno/config.h
+++ b/keyboards/planck/keymaps/steno/config.h
@@ -3,17 +3,19 @@
 
 #include "../../config.h"
 
-#define LEADER_TIMEOUT 300
-#define BACKLIGHT_BREATHING
+#ifdef AUDIO_ENABLE
+    #define STARTUP_SONG SONG(PLANCK_SOUND)
+    // #define STARTUP_SONG SONG(NO_SOUND)
+
+    #define DEFAULT_LAYER_SONGS { SONG(QWERTY_SOUND), \
+                                  SONG(COLEMAK_SOUND), \
+                                  SONG(DVORAK_SOUND) \
+                                }
+#endif
+
+#define MUSIC_MASK (keycode != KC_NO)
+
 #define PREVENT_STUCK_MODIFIERS
-
-
-/* ws2812 RGB LED */
-#define RGB_DI_PIN B1
-#define RGBLIGHT_ANIMATIONS
-#define RGBLED_NUM 8     // Number of LEDs
-#define RGBLIGHT_HUE_STEP 10
-#define RGBLIGHT_SAT_STEP 17
 
 /*
  * MIDI options
@@ -25,6 +27,7 @@
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */
+
 #define MIDI_BASIC
 
 /* enable advanced MIDI features:

--- a/keyboards/planck/keymaps/steno/keymap.c
+++ b/keyboards/planck/keymaps/steno/keymap.c
@@ -1,0 +1,253 @@
+/* Copyright 2015-2017 Jack Humbert
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "planck.h"
+#include "action_layer.h"
+#include "keymap_steno.h"
+
+extern keymap_config_t keymap_config;
+
+enum planck_layers {
+  _QWERTY,
+  _COLEMAK,
+  _DVORAK,
+  _LOWER,
+  _RAISE,
+  _PLOVER,
+  _ADJUST
+};
+
+enum planck_keycodes {
+  QWERTY = SAFE_RANGE,
+  COLEMAK,
+  DVORAK,
+  PLOVER,
+  LOWER,
+  RAISE,
+  BACKLIT,
+  EXT_PLV
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+/* Qwerty
+ * ,-----------------------------------------------------------------------------------.
+ * | Tab  |   Q  |   W  |   E  |   R  |   T  |   Y  |   U  |   I  |   O  |   P  | Bksp |
+ * |------+------+------+------+------+-------------+------+------+------+------+------|
+ * | Esc  |   A  |   S  |   D  |   F  |   G  |   H  |   J  |   K  |   L  |   ;  |  "   |
+ * |------+------+------+------+------+------|------+------+------+------+------+------|
+ * | Shift|   Z  |   X  |   C  |   V  |   B  |   N  |   M  |   ,  |   .  |   /  |Enter |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * | Brite| Ctrl | Alt  | GUI  |Lower |    Space    |Raise | Left | Down |  Up  |Right |
+ * `-----------------------------------------------------------------------------------'
+ */
+[_QWERTY] = {
+  {KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_BSPC},
+  {KC_ESC,  KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT},
+  {KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_ENT },
+  {BACKLIT, KC_LCTL, KC_LALT, KC_LGUI, LOWER,   KC_SPC,  KC_SPC,  RAISE,   KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT}
+},
+
+/* Colemak
+ * ,-----------------------------------------------------------------------------------.
+ * | Tab  |   Q  |   W  |   F  |   P  |   G  |   J  |   L  |   U  |   Y  |   ;  | Bksp |
+ * |------+------+------+------+------+-------------+------+------+------+------+------|
+ * | Esc  |   A  |   R  |   S  |   T  |   D  |   H  |   N  |   E  |   I  |   O  |  "   |
+ * |------+------+------+------+------+------|------+------+------+------+------+------|
+ * | Shift|   Z  |   X  |   C  |   V  |   B  |   K  |   M  |   ,  |   .  |   /  |Enter |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * | Brite| Ctrl | Alt  | GUI  |Lower |    Space    |Raise | Left | Down |  Up  |Right |
+ * `-----------------------------------------------------------------------------------'
+ */
+[_COLEMAK] = {
+  {KC_TAB,  KC_Q,    KC_W,    KC_F,    KC_P,    KC_G,    KC_J,    KC_L,    KC_U,    KC_Y,    KC_SCLN, KC_BSPC},
+  {KC_ESC,  KC_A,    KC_R,    KC_S,    KC_T,    KC_D,    KC_H,    KC_N,    KC_E,    KC_I,    KC_O,    KC_QUOT},
+  {KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_K,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_ENT },
+  {BACKLIT, KC_LCTL, KC_LALT, KC_LGUI, LOWER,   KC_SPC,  KC_SPC,  RAISE,   KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT}
+},
+
+/* Dvorak
+ * ,-----------------------------------------------------------------------------------.
+ * | Tab  |   "  |   ,  |   .  |   P  |   Y  |   F  |   G  |   C  |   R  |   L  | Bksp |
+ * |------+------+------+------+------+-------------+------+------+------+------+------|
+ * | Esc  |   A  |   O  |   E  |   U  |   I  |   D  |   H  |   T  |   N  |   S  |  /   |
+ * |------+------+------+------+------+------|------+------+------+------+------+------|
+ * | Shift|   ;  |   Q  |   J  |   K  |   X  |   B  |   M  |   W  |   V  |   Z  |Enter |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * | Brite| Ctrl | Alt  | GUI  |Lower |    Space    |Raise | Left | Down |  Up  |Right |
+ * `-----------------------------------------------------------------------------------'
+ */
+[_DVORAK] = {
+  {KC_TAB,  KC_QUOT, KC_COMM, KC_DOT,  KC_P,    KC_Y,    KC_F,    KC_G,    KC_C,    KC_R,    KC_L,    KC_BSPC},
+  {KC_ESC,  KC_A,    KC_O,    KC_E,    KC_U,    KC_I,    KC_D,    KC_H,    KC_T,    KC_N,    KC_S,    KC_SLSH},
+  {KC_LSFT, KC_SCLN, KC_Q,    KC_J,    KC_K,    KC_X,    KC_B,    KC_M,    KC_W,    KC_V,    KC_Z,    KC_ENT },
+  {BACKLIT, KC_LCTL, KC_LALT, KC_LGUI, LOWER,   KC_SPC,  KC_SPC,  RAISE,   KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT}
+},
+
+/* Lower
+ * ,-----------------------------------------------------------------------------------.
+ * |   ~  |   !  |   @  |   #  |   $  |   %  |   ^  |   &  |   *  |   (  |   )  | Bksp |
+ * |------+------+------+------+------+-------------+------+------+------+------+------|
+ * | Del  |  F1  |  F2  |  F3  |  F4  |  F5  |  F6  |   _  |   +  |   {  |   }  |  |   |
+ * |------+------+------+------+------+------|------+------+------+------+------+------|
+ * |      |  F7  |  F8  |  F9  |  F10 |  F11 |  F12 |ISO ~ |ISO | | Home | End  |      |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      |      |      |      |      |             |      | Next | Vol- | Vol+ | Play |
+ * `-----------------------------------------------------------------------------------'
+ */
+[_LOWER] = {
+  {KC_TILD, KC_EXLM, KC_AT,   KC_HASH, KC_DLR,  KC_PERC, KC_CIRC, KC_AMPR,    KC_ASTR,    KC_LPRN, KC_RPRN, KC_BSPC},
+  {KC_DEL,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_UNDS,    KC_PLUS,    KC_LCBR, KC_RCBR, KC_PIPE},
+  {_______, KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  S(KC_NUHS), S(KC_NUBS), KC_HOME, KC_END,  _______},
+  {_______, _______, _______, _______, _______, _______, _______, _______,    KC_MNXT,    KC_VOLD, KC_VOLU, KC_MPLY}
+},
+
+/* Raise
+ * ,-----------------------------------------------------------------------------------.
+ * |   `  |   1  |   2  |   3  |   4  |   5  |   6  |   7  |   8  |   9  |   0  | Bksp |
+ * |------+------+------+------+------+-------------+------+------+------+------+------|
+ * | Del  |  F1  |  F2  |  F3  |  F4  |  F5  |  F6  |   -  |   =  |   [  |   ]  |  \   |
+ * |------+------+------+------+------+------|------+------+------+------+------+------|
+ * |      |  F7  |  F8  |  F9  |  F10 |  F11 |  F12 |ISO # |ISO / |Pg Up |Pg Dn |      |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      |      |      |      |      |             |      | Next | Vol- | Vol+ | Play |
+ * `-----------------------------------------------------------------------------------'
+ */
+[_RAISE] = {
+  {KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_BSPC},
+  {KC_DEL,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_MINS, KC_EQL,  KC_LBRC, KC_RBRC, KC_BSLS},
+  {_______, KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_NUHS, KC_NUBS, KC_PGUP, KC_PGDN, _______},
+  {_______, _______, _______, _______, _______, _______, _______, _______, KC_MNXT, KC_VOLD, KC_VOLU, KC_MPLY}
+},
+
+/* Plover layer (http://opensteno.org)
+ * ,-----------------------------------------------------------------------------------.
+ * |   #  |   #  |   #  |   #  |   #  |   #  |   #  |   #  |   #  |   #  |   #  |   #  |
+ * |------+------+------+------+------+-------------+------+------+------+------+------|
+ * |  FN  |   S  |   T  |   P  |   H  |   *  |   *  |   F  |   P  |   L  |   T  |   D  |
+ * |------+------+------+------+------+------|------+------+------+------+------+------|
+ * |      |   S  |   K  |   W  |   R  |   *  |   *  |   R  |   B  |   G  |   S  |   Z  |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * | Exit |      |      |   A  |   O  |             |   E  |   U  |  PWR | RES1 | RES2 |
+ * `-----------------------------------------------------------------------------------'
+ */
+
+[_PLOVER] = {
+  {STN_N1,  STN_N2,  STN_N3,  STN_N4,  STN_N5,  STN_N6,  STN_N7,  STN_N8,  STN_N9,  STN_NA,  STN_NB,  STN_NC },
+  {STN_FN,  STN_S1,  STN_TL,  STN_PL,  STN_HL,  STN_ST1, STN_ST3, STN_FR,  STN_PR,  STN_LR,  STN_TR,  STN_DR },
+  {XXXXXXX, STN_S2,  STN_KL,  STN_WL,  STN_RL,  STN_ST2, STN_ST4, STN_RR,  STN_BR,  STN_GR,  STN_SR,  STN_ZR },
+  {EXT_PLV, XXXXXXX, XXXXXXX, STN_A,   STN_O,   XXXXXXX, XXXXXXX, STN_E,   STN_U,   STN_PWR, STN_RE1, STN_RE2}
+},
+
+/* Adjust (Lower + Raise)
+ * ,-----------------------------------------------------------------------------------.
+ * |      | Reset|      |      |      |      |      |      |      |      |      |  Del |
+ * |------+------+------+------+------+-------------+------+------+------+------+------|
+ * |      |      |      |Aud on|Audoff|AGnorm|AGswap|Qwerty|Colemk|Dvorak|Plover|      |
+ * |------+------+------+------+------+------|------+------+------+------+------+------|
+ * |      |Voice-|Voice+|Mus on|Musoff|MIDIon|MIDIof|      |      |      |TXBOLT|GEM RP|
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      |      |      |      |      |             |      |      |      |      |      |
+ * `-----------------------------------------------------------------------------------'
+ */
+[_ADJUST] = {
+  {_______, RESET,   _______, _______, _______, _______, _______, _______, _______, _______, _______, KC_DEL },
+  {_______, _______, MU_MOD,  AU_ON,   AU_OFF,  AG_NORM, AG_SWAP, QWERTY,  COLEMAK, DVORAK,  PLOVER,  _______},
+  {_______, MUV_DE,  MUV_IN,  MU_ON,   MU_OFF,  MI_ON,   MI_OFF,  _______, _______, _______, _______, _______},
+  {_______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______}
+}
+
+
+};
+
+#ifdef AUDIO_ENABLE
+  float plover_song[][2]     = SONG(PLOVER_SOUND);
+  float plover_gb_song[][2]  = SONG(PLOVER_GOODBYE_SOUND);
+#endif
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  switch (keycode) {
+    case QWERTY:
+      if (record->event.pressed) {
+        set_single_persistent_default_layer(_QWERTY);
+      }
+      return false;
+      break;
+    case COLEMAK:
+      if (record->event.pressed) {
+        set_single_persistent_default_layer(_COLEMAK);
+      }
+      return false;
+      break;
+    case DVORAK:
+      if (record->event.pressed) {
+        set_single_persistent_default_layer(_DVORAK);
+      }
+      return false;
+      break;
+    case LOWER:
+      if (record->event.pressed) {
+        layer_on(_LOWER);
+        update_tri_layer(_LOWER, _RAISE, _ADJUST);
+      } else {
+        layer_off(_LOWER);
+        update_tri_layer(_LOWER, _RAISE, _ADJUST);
+      }
+      return false;
+      break;
+    case RAISE:
+      if (record->event.pressed) {
+        layer_on(_RAISE);
+        update_tri_layer(_LOWER, _RAISE, _ADJUST);
+      } else {
+        layer_off(_RAISE);
+        update_tri_layer(_LOWER, _RAISE, _ADJUST);
+      }
+      return false;
+      break;
+    case BACKLIT:
+      if (record->event.pressed) {
+        register_code(KC_RSFT);
+        #ifdef BACKLIGHT_ENABLE
+          backlight_step();
+        #endif
+      } else {
+        unregister_code(KC_RSFT);
+      }
+      return false;
+      break;
+    case PLOVER:
+      if (!record->event.pressed) {
+        #ifdef AUDIO_ENABLE
+          stop_all_notes();
+          PLAY_SONG(plover_song);
+        #endif
+        layer_on(_PLOVER);
+      }
+      return false;
+      break;
+    case EXT_PLV:
+      if (record->event.pressed) {
+        #ifdef AUDIO_ENABLE
+          PLAY_SONG(plover_gb_song);
+        #endif
+        layer_off(_PLOVER);
+      }
+      return false;
+      break;
+  }
+  return true;
+}

--- a/keyboards/planck/keymaps/steno/keymap.c
+++ b/keyboards/planck/keymaps/steno/keymap.c
@@ -41,6 +41,9 @@ enum planck_keycodes {
   EXT_PLV
 };
 
+#define ST_BOLT QK_STENO_BOLT
+#define ST_GEM  QK_STENO_GEMINI
+
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 /* Qwerty
@@ -166,7 +169,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 [_ADJUST] = {
   {_______, RESET,   _______, _______, _______, _______, _______, _______, _______, _______, _______, KC_DEL },
   {_______, _______, MU_MOD,  AU_ON,   AU_OFF,  AG_NORM, AG_SWAP, QWERTY,  COLEMAK, DVORAK,  PLOVER,  _______},
-  {_______, MUV_DE,  MUV_IN,  MU_ON,   MU_OFF,  MI_ON,   MI_OFF,  _______, _______, _______, _______, _______},
+  {_______, MUV_DE,  MUV_IN,  MU_ON,   MU_OFF,  MI_ON,   MI_OFF,  _______, _______, _______, ST_BOLT, ST_GEM},
   {_______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______}
 }
 

--- a/keyboards/planck/keymaps/steno/readme.md
+++ b/keyboards/planck/keymaps/steno/readme.md
@@ -1,0 +1,4 @@
+# The Default Planck Layout with TX Bolt for the Plover Layer
+
+To use set Plover to TX Bolt and select the COM port that represents your keyboard.
+

--- a/quantum/keymap_extras/keymap_steno.h
+++ b/quantum/keymap_extras/keymap_steno.h
@@ -1,0 +1,71 @@
+/* Copyright 2017 Joseph Wasson
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef KEYMAP_STENO_H
+#define KEYMAP_STENO_H
+
+#include "keymap.h"
+
+enum steno_keycodes {
+  STN_FN  = QK_STENO,
+  STN_NUM,
+  STN_N1 = STN_NUM,
+  STN_N2,
+  STN_N3,
+  STN_N4,
+  STN_N5,
+  STN_N6,
+  STN_SL,
+  STN_S1 = STN_SL,
+  STN_S2,
+  STN_TL,
+  STN_KL,
+  STN_PL,
+  STN_WL,
+  STN_HL,
+  STN_RL,
+  STN_A,
+  STN_O,
+  STN_STR,
+  STN_ST1 = STN_STR,
+  STN_ST2,
+  STN_RES1,
+  STN_RE1 = STN_RES1,
+  STN_RES2,
+  STN_RE2 = STN_RES2,
+  STN_PWR,
+  STN_ST3,
+  STN_ST4,
+  STN_E,
+  STN_U,
+  STN_FR,
+  STN_RR,
+  STN_PR,
+  STN_BR,
+  STN_LR,
+  STN_GR,
+  STN_TR,
+  STN_SR,
+  STN_DR,
+  STN_N7,
+  STN_N8,
+  STN_N9,
+  STN_NA,
+  STN_NB,
+  STN_NC,
+  STN_ZR
+};
+
+#endif

--- a/quantum/keymap_extras/keymap_steno.h
+++ b/quantum/keymap_extras/keymap_steno.h
@@ -18,8 +18,12 @@
 
 #include "keymap.h"
 
+// List of keycodes for the steno keyboard. To prevent
+// errors, this must be <= 42 total entries in order to
+// support the GeminiPR protocol.
 enum steno_keycodes {
-  STN_FN  = QK_STENO,
+  STN__MIN = QK_STENO,
+  STN_FN  = STN__MIN,
   STN_NUM,
   STN_N1 = STN_NUM,
   STN_N2,
@@ -65,7 +69,8 @@ enum steno_keycodes {
   STN_NA,
   STN_NB,
   STN_NC,
-  STN_ZR
+  STN_ZR,
+  STN__MAX = STN_ZR, // must be less than QK_STENO_BOLT
 };
 
 #endif

--- a/quantum/process_keycode/process_steno.c
+++ b/quantum/process_keycode/process_steno.c
@@ -1,4 +1,19 @@
- #include "process_steno.h"
+/* Copyright 2017 Joseph Wasson
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "process_steno.h"
 #include "quantum_keycodes.h"
 #include "keymap_steno.h"
 #include "virtser.h"

--- a/quantum/process_keycode/process_steno.c
+++ b/quantum/process_keycode/process_steno.c
@@ -1,0 +1,82 @@
+#include "process_steno.h"
+#include "quantum_keycodes.h"
+#include "keymap_steno.h"
+#include "virtser.h"
+
+uint8_t state[4] = {0};
+uint8_t pressed = 0;
+
+
+// TxBolt Codes
+#define TXB_NUL 0
+#define TXB_S_L 0b00000001
+#define TXB_T_L 0b00000010
+#define TXB_K_L 0b00000100
+#define TXB_P_L 0b00001000
+#define TXB_W_L 0b00010000
+#define TXB_H_L 0b00100000
+#define TXB_R_L 0b01000001
+#define TXB_A_L 0b01000010
+#define TXB_O_L 0b01000100
+#define TXB_STR 0b01001000
+#define TXB_E_R 0b01010000
+#define TXB_U_R 0b01100000
+#define TXB_F_R 0b10000001
+#define TXB_R_R 0b10000010
+#define TXB_P_R 0b10000100
+#define TXB_B_R 0b10001000
+#define TXB_L_R 0b10010000
+#define TXB_G_R 0b10100000
+#define TXB_T_R 0b11000001
+#define TXB_S_R 0b11000010
+#define TXB_D_R 0b11000100
+#define TXB_Z_R 0b11001000
+#define TXB_NUM 0b11010000
+
+#define TXB_GRP0 0b00000000
+#define TXB_GRP1 0b01000000
+#define TXB_GRP2 0b10000000
+#define TXB_GRP3 0b11000000
+#define TXB_GRPMASK 0b11000000
+
+#define TXB_GET_GROUP(code) ((code & TXB_GRPMASK) >> 6)
+
+uint8_t boltmap[64] = {
+  TXB_NUL, TXB_NUM, TXB_NUM, TXB_NUM, TXB_NUM, TXB_NUM, TXB_NUM,
+  TXB_S_L, TXB_S_L, TXB_T_L, TXB_K_L, TXB_P_L, TXB_W_L, TXB_H_L,
+  TXB_R_L, TXB_A_L, TXB_O_L, TXB_STR, TXB_STR, TXB_NUL, TXB_NUL,
+  TXB_NUL, TXB_STR, TXB_STR, TXB_E_R, TXB_U_R, TXB_F_R, TXB_R_R,
+  TXB_P_R, TXB_B_R, TXB_L_R, TXB_G_R, TXB_T_R, TXB_S_R, TXB_D_R,
+  TXB_NUM, TXB_NUM, TXB_NUM, TXB_NUM, TXB_NUM, TXB_NUM, TXB_Z_R
+};
+
+#define BOLTMAP_MASK (sizeof(boltmap) - 1)
+
+void send_steno_state(void) {
+  for (uint8_t i = 0; i < 4; ++i) {
+    if (state[i]) {
+      virtser_send(state[i]);
+      state[i] = 0;
+    }
+  }
+  virtser_send(0);
+}
+
+bool process_steno(uint16_t keycode, keyrecord_t *record) {
+  if(keycode >= QK_STENO && keycode <= QK_STENO_MAX) {
+    if(IS_PRESSED(record->event)) {
+      uint8_t boltcode = boltmap[keycode & BOLTMAP_MASK];
+      ++pressed;
+      state[TXB_GET_GROUP(boltcode)] |= boltcode;
+    } else {
+      --pressed;
+      if (pressed <= 0) {
+        pressed = 0; // protect against spurious up keys
+        send_steno_state();
+      }
+    }
+    return false;
+  }
+
+  return true;
+}

--- a/quantum/process_keycode/process_steno.c
+++ b/quantum/process_keycode/process_steno.c
@@ -1,11 +1,7 @@
-#include "process_steno.h"
+ #include "process_steno.h"
 #include "quantum_keycodes.h"
 #include "keymap_steno.h"
 #include "virtser.h"
-
-uint8_t state[4] = {0};
-uint8_t pressed = 0;
-
 
 // TxBolt Codes
 #define TXB_NUL 0
@@ -41,6 +37,13 @@ uint8_t pressed = 0;
 
 #define TXB_GET_GROUP(code) ((code & TXB_GRPMASK) >> 6)
 
+#define BOLT_STATE_SIZE 4
+#define GEMINI_STATE_SIZE 6
+
+uint8_t state[MAX(BOLT_STATE_SIZE, GEMINI_STATE_SIZE)] = {0};
+uint8_t pressed = 0;
+steno_mode_t mode;
+
 uint8_t boltmap[64] = {
   TXB_NUL, TXB_NUM, TXB_NUM, TXB_NUM, TXB_NUM, TXB_NUM, TXB_NUM,
   TXB_S_L, TXB_S_L, TXB_T_L, TXB_K_L, TXB_P_L, TXB_W_L, TXB_H_L,
@@ -52,31 +55,97 @@ uint8_t boltmap[64] = {
 
 #define BOLTMAP_MASK (sizeof(boltmap) - 1)
 
-void send_steno_state(void) {
-  for (uint8_t i = 0; i < 4; ++i) {
-    if (state[i]) {
+
+void steno_clear_state(void) {
+  memset(state, 0, sizeof(state));
+}
+
+void steno_init() {
+  if (!eeconfig_is_enabled()) {
+    eeconfig_init();
+  }
+  mode = eeprom_read_byte(EECONFIG_STENOMODE);
+}
+
+void steno_set_mode(steno_mode_t new_mode) {
+  steno_clear_state();
+  mode = new_mode;
+  eeprom_update_byte(EECONFIG_STENOMODE, mode);
+}
+
+void send_steno_state(uint8_t size, bool send_empty) {
+  for (uint8_t i = 0; i < size; ++i) {
+    if (state[i] || send_empty) {
       virtser_send(state[i]);
-      state[i] = 0;
     }
   }
-  virtser_send(0);
+  steno_clear_state();
+}
+
+bool update_state_bolt(uint8_t key) {
+  uint8_t boltcode = boltmap[key];
+  state[TXB_GET_GROUP(boltcode)] |= boltcode;
+  return false;
+}
+
+bool send_state_bolt(void) {
+  send_steno_state(BOLT_STATE_SIZE, false);
+  virtser_send(0); // terminating byte
+  return false;
+}
+
+bool update_state_gemini(uint8_t key) {
+  state[key / 7] |= 1 << (6 - (key % 7));
+  return false;
+}
+
+bool send_state_gemini(void) {
+  state[0] |= 0x80; // Indicate start of packet
+  send_steno_state(GEMINI_STATE_SIZE, true);
+  return false;
 }
 
 bool process_steno(uint16_t keycode, keyrecord_t *record) {
-  if(keycode >= QK_STENO && keycode <= QK_STENO_MAX) {
-    if(IS_PRESSED(record->event)) {
-      uint8_t boltcode = boltmap[keycode & BOLTMAP_MASK];
-      ++pressed;
-      state[TXB_GET_GROUP(boltcode)] |= boltcode;
-    } else {
-      --pressed;
-      if (pressed <= 0) {
-        pressed = 0; // protect against spurious up keys
-        send_steno_state();
+  switch (keycode) {
+    case QK_STENO_BOLT:
+      if (IS_PRESSED(record->event)) {
+        steno_set_mode(STENO_MODE_BOLT);
       }
-    }
-    return false;
-  }
+      return false;
 
+    case QK_STENO_GEMINI:
+      if (IS_PRESSED(record->event)) {
+        steno_set_mode(STENO_MODE_GEMINI);
+      }
+      return false;
+
+    case STN__MIN...STN__MAX:
+      if (IS_PRESSED(record->event)) {
+        uint8_t key = keycode - QK_STENO;
+        ++pressed;
+        switch(mode) {
+          case STENO_MODE_BOLT:
+            return update_state_bolt(key);
+          case STENO_MODE_GEMINI:
+            return update_state_gemini(key);
+          default:
+            return false;
+        }
+      } else {
+        --pressed;
+        if (pressed <= 0) {
+          pressed = 0;
+          switch(mode) {
+            case STENO_MODE_BOLT:
+              return send_state_bolt();
+            case STENO_MODE_GEMINI:
+              return send_state_gemini();
+            default:
+              return false;
+          }
+        }
+      }
+
+  }
   return true;
 }

--- a/quantum/process_keycode/process_steno.h
+++ b/quantum/process_keycode/process_steno.h
@@ -7,6 +7,10 @@
   #error "must have virtser enabled to use steno"
 #endif
 
+typedef enum { STENO_MODE_BOLT, STENO_MODE_GEMINI } steno_mode_t;
+
 bool process_steno(uint16_t keycode, keyrecord_t *record);
+void steno_init(void);
+void steno_set_mode(steno_mode_t mode);
 
 #endif

--- a/quantum/process_keycode/process_steno.h
+++ b/quantum/process_keycode/process_steno.h
@@ -1,3 +1,18 @@
+/* Copyright 2017 Joseph Wasson
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 #ifndef PROCESS_STENO_H
 #define PROCESS_STENO_H
 

--- a/quantum/process_keycode/process_steno.h
+++ b/quantum/process_keycode/process_steno.h
@@ -1,0 +1,12 @@
+#ifndef PROCESS_STENO_H
+#define PROCESS_STENO_H
+
+#include "quantum.h"
+
+#if defined(STENO_ENABLE) && !defined(VIRTSER_ENABLE)
+  #error "must have virtser enabled to use steno"
+#endif
+
+bool process_steno(uint16_t keycode, keyrecord_t *record);
+
+#endif

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -200,6 +200,9 @@ bool process_record_quantum(keyrecord_t *record) {
   #ifdef AUDIO_ENABLE
     process_audio(keycode, record) &&
   #endif
+  #ifdef STENO_ENABLE
+    process_steno(keycode, record) &&
+  #endif
   #if defined(AUDIO_ENABLE) || (defined(MIDI_ENABLE) && defined(MIDI_BASIC))
     process_music(keycode, record) &&
   #endif
@@ -722,14 +725,14 @@ void backlight_set(uint8_t level)
       //   _SFR_IO8((backlight_pin >> 4) + 2) &= ~_BV(backlight_pin & 0xF);
       // #endif
     #endif
-  } 
+  }
   #ifndef NO_BACKLIGHT_CLOCK
     else if ( level == BACKLIGHT_LEVELS ) {
       // Turn on PWM control of backlight pin
       TCCR1A |= _BV(COM1x1);
       // Set the brightness
       OCR1x = 0xFFFF;
-    } 
+    }
     else {
       // Turn on PWM control of backlight pin
       TCCR1A |= _BV(COM1x1);
@@ -747,7 +750,7 @@ uint8_t backlight_tick = 0;
 
 void backlight_task(void) {
   #ifdef NO_BACKLIGHT_CLOCK
-  if ((0xFFFF >> ((BACKLIGHT_LEVELS - backlight_config.level) * ((BACKLIGHT_LEVELS + 1) / 2))) & (1 << backlight_tick)) { 
+  if ((0xFFFF >> ((BACKLIGHT_LEVELS - backlight_config.level) * ((BACKLIGHT_LEVELS + 1) / 2))) & (1 << backlight_tick)) {
     #if BACKLIGHT_ON_STATE == 0
       // PORTx &= ~n
       _SFR_IO8((backlight_pin >> 4) + 2) &= ~_BV(backlight_pin & 0xF);

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -60,6 +60,10 @@ extern uint32_t default_layer_state;
  	#include "process_audio.h"
 #endif
 
+#ifdef STENO_ENABLE
+	#include "process_steno.h"
+#endif
+
 #if defined(AUDIO_ENABLE) || (defined(MIDI_ENABLE) && defined(MIDI_BASIC))
 	#include "process_music.h"
 #endif

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -73,6 +73,8 @@ enum quantum_keycodes {
     QK_LAYER_TAP_TOGGLE_MAX = 0x58FF,
 #ifdef STENO_ENABLE
     QK_STENO              = 0x5900,
+    QK_STENO_BOLT         = 0x5930,
+    QK_STENO_GEMINI       = 0x5931,
     QK_STENO_MAX          = 0x593F,
 #endif
     QK_MOD_TAP            = 0x6000,

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -71,6 +71,10 @@ enum quantum_keycodes {
     QK_TAP_DANCE_MAX      = 0x57FF,
     QK_LAYER_TAP_TOGGLE   = 0x5800,
     QK_LAYER_TAP_TOGGLE_MAX = 0x58FF,
+#ifdef STENO_ENABLE
+    QK_STENO              = 0x5900,
+    QK_STENO_MAX          = 0x593F,
+#endif
     QK_MOD_TAP            = 0x6000,
     QK_MOD_TAP_MAX        = 0x7FFF,
 #if defined(UNICODEMAP_ENABLE) && defined(UNICODE_ENABLE)

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -72,10 +72,10 @@ enum quantum_keycodes {
     QK_LAYER_TAP_TOGGLE   = 0x5800,
     QK_LAYER_TAP_TOGGLE_MAX = 0x58FF,
 #ifdef STENO_ENABLE
-    QK_STENO              = 0x5900,
-    QK_STENO_BOLT         = 0x5930,
-    QK_STENO_GEMINI       = 0x5931,
-    QK_STENO_MAX          = 0x593F,
+    QK_STENO              = 0x5A00,
+    QK_STENO_BOLT         = 0x5A30,
+    QK_STENO_GEMINI       = 0x5A31,
+    QK_STENO_MAX          = 0x5A3F,
 #endif
     QK_MOD_TAP            = 0x6000,
     QK_MOD_TAP_MAX        = 0x7FFF,

--- a/tmk_core/common/eeconfig.c
+++ b/tmk_core/common/eeconfig.c
@@ -19,6 +19,9 @@ void eeconfig_init(void)
 #ifdef RGBLIGHT_ENABLE
     eeprom_update_dword(EECONFIG_RGBLIGHT,      0);
 #endif
+#ifdef STENO_ENABLE
+    eeprom_update_byte(EECONFIG_STENOMODE,      0);
+#endif
 }
 
 void eeconfig_enable(void)

--- a/tmk_core/common/eeconfig.h
+++ b/tmk_core/common/eeconfig.h
@@ -34,6 +34,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define EECONFIG_AUDIO                              (uint8_t *)7
 #define EECONFIG_RGBLIGHT                           (uint32_t *)8
 #define EECONFIG_UNICODEMODE                        (uint8_t *)12
+#define EECONFIG_STENOMODE                          (uint8_t *)13
 
 
 /* debug bit */

--- a/tmk_core/common/keyboard.c
+++ b/tmk_core/common/keyboard.c
@@ -51,6 +51,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifdef RGBLIGHT_ENABLE
 #   include "rgblight.h"
 #endif
+#ifdef STENO_ENABLE
+#   include "process_steno.h"
+#endif
 #ifdef FAUXCLICKY_ENABLE
 #   include "fauxclicky.h"
 #endif
@@ -138,6 +141,9 @@ void keyboard_init(void) {
 #endif
 #ifdef RGBLIGHT_ENABLE
     rgblight_init();
+#endif
+#ifdef STENO_ENABLE
+    steno_init();
 #endif
 #ifdef FAUXCLICKY_ENABLE
     fauxclicky_init();


### PR DESCRIPTION
This adds support for a couple of stenography protocols, TX Bolt and GeminiPR, to allow the keyboard to speak natively to stenography applications--such as Plover--without needing to takeover the keyboard input. The biggest benefit of this is that a standard keyboard and a steno keyboard can be used at the same time without needing to enable/disable Plover. This implementation uses the virtual serial port.