### PR TITLE
Fixed Build Guide to show correctly.

### DIFF
--- a/keyboards/deltasplit75/readme.md
+++ b/keyboards/deltasplit75/readme.md
@@ -11,7 +11,7 @@ based boards.
 ## Case Files
 Files are available here: https://github.com/xyxjj/DeltaSplit75-Case-files
 
-#Build Guide
+## Build Guide
 The build guide should be found at https://qmk.fm/deltasplit75
 
 


### PR DESCRIPTION
After all the edits from yesterday, I guess I overlooked the markdown syntax when adding Build Guide. Fixed now.