### PR TITLE
tap-dance: key + layer helper

### DIFF
--- a/quantum/process_keycode/process_tap_dance.c
+++ b/quantum/process_keycode/process_tap_dance.c
@@ -41,6 +41,24 @@ void qk_tap_dance_pair_reset (qk_tap_dance_state_t *state, void *user_data) {
   }
 }
 
+void qk_tap_dance_dual_role_finished (qk_tap_dance_state_t *state, void *user_data) {
+  qk_tap_dance_dual_role_t *pair = (qk_tap_dance_dual_role_t *)user_data;
+
+  if (state->count == 1) {
+    register_code16 (pair->kc);
+  } else if (state->count == 2) {
+    layer_invert (pair->layer);
+  }
+}
+
+void qk_tap_dance_dual_role_reset (qk_tap_dance_state_t *state, void *user_data) {
+  qk_tap_dance_dual_role_t *pair = (qk_tap_dance_dual_role_t *)user_data;
+
+  if (state->count == 1) {
+    unregister_code16 (pair->kc);
+  }
+}
+
 static inline void _process_tap_dance_action_fn (qk_tap_dance_state_t *state,
                                                  void *user_data,
                                                  qk_tap_dance_user_fn_t fn)

--- a/quantum/process_keycode/process_tap_dance.h
+++ b/quantum/process_keycode/process_tap_dance.h
@@ -54,9 +54,20 @@ typedef struct
   uint16_t kc2;
 } qk_tap_dance_pair_t;
 
+typedef struct
+{
+  uint16_t kc;
+  uint8_t layer;
+} qk_tap_dance_dual_role_t;
+
 #define ACTION_TAP_DANCE_DOUBLE(kc1, kc2) { \
     .fn = { NULL, qk_tap_dance_pair_finished, qk_tap_dance_pair_reset }, \
     .user_data = (void *)&((qk_tap_dance_pair_t) { kc1, kc2 }),  \
+  }
+
+#define ACTION_TAP_DANCE_DUAL_ROLE(kc, layer) { \
+    .fn = { NULL, qk_tap_dance_dual_role_finished, qk_tap_dance_dual_role_reset }, \
+    .user_data = (void *)&((qk_tap_dance_dual_role_t) { kc, layer }), \
   }
 
 #define ACTION_TAP_DANCE_FN(user_fn) {  \
@@ -85,6 +96,9 @@ void reset_tap_dance (qk_tap_dance_state_t *state);
 
 void qk_tap_dance_pair_finished (qk_tap_dance_state_t *state, void *user_data);
 void qk_tap_dance_pair_reset (qk_tap_dance_state_t *state, void *user_data);
+
+void qk_tap_dance_dual_role_finished (qk_tap_dance_state_t *state, void *user_data);
+void qk_tap_dance_dual_role_reset (qk_tap_dance_state_t *state, void *user_data);
 
 #else
 


### PR DESCRIPTION
This adds the `ACTION_TAP_DANCE_DUAL_ROLE` helper, which makes it easy to have keys that act as a key on the first tap, and as a layer toggle on the second.

Fixes #1532, reported by @Ptomerty.