### PR TITLE
Improve pro micro flash script and centralize it

### DIFF
--- a/keyboards/deltasplit75/rules.mk
+++ b/keyboards/deltasplit75/rules.mk
@@ -73,15 +73,3 @@ USE_I2C ?= yes
 SLEEP_LED_ENABLE ?= no    # Breathing sleep LED during USB suspend
 
 CUSTOM_MATRIX = yes
-
-avrdude: build
-	ls /dev/tty* > /tmp/1; \
-	echo "Reset your Pro Micro now"; \
-	while [[ -z $$USB ]]; do \
-	  sleep 1; \
-	  ls /dev/tty* > /tmp/2; \
-	  USB=`diff /tmp/1 /tmp/2 | grep -o '/dev/tty.*'`; \
-	done; \
-	avrdude -p $(MCU) -c avr109 -P $$USB -U flash:w:$(BUILD_DIR)/$(TARGET).hex
-
-.PHONY: avrdude

--- a/keyboards/handwired/atreus50/rules.mk
+++ b/keyboards/handwired/atreus50/rules.mk
@@ -67,15 +67,3 @@ RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight.  Do not enable this 
 
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
 SLEEP_LED_ENABLE = no    # Breathing sleep LED during USB suspend
-
-avrdude: build
-	ls /dev/tty* > /tmp/1; \
-	echo "Reset your Pro Micro now"; \
-	while [[ -z $$USB ]]; do \
-	  sleep 1; \
-	  ls /dev/tty* > /tmp/2; \
-	  USB=`diff /tmp/1 /tmp/2 | grep -o '/dev/tty.*'`; \
-	done; \
-	avrdude -p $(MCU) -c avr109 -P $$USB -U flash:w:$(BUILD_DIR)/$(TARGET).hex
-
-.PHONY: avrdude

--- a/keyboards/handwired/magicforce61/rules.mk
+++ b/keyboards/handwired/magicforce61/rules.mk
@@ -69,15 +69,3 @@ AUDIO_ENABLE ?= no           # Audio output on port C6
 ifndef QUANTUM_DIR
 	include ../../../Makefile
 endif
-
-avrdude: build
-	ls /dev/tty* > /tmp/1; \
-	echo "Reset your Pro Micro now"; \
-	while [[ -z $$USB ]]; do \
-	  sleep 1; \
-	  ls /dev/tty* > /tmp/2; \
-	  USB=`diff /tmp/1 /tmp/2 | grep -o '/dev/tty.*'`; \
-	done; \
-	avrdude -p $(MCU) -c avr109 -P $$USB -U flash:w:$(BUILD_DIR)/$(TARGET).hex
-
-.PHONY: avrdude

--- a/keyboards/handwired/magicforce68/rules.mk
+++ b/keyboards/handwired/magicforce68/rules.mk
@@ -69,15 +69,3 @@ AUDIO_ENABLE = no           # Audio output on port C6
 ifndef QUANTUM_DIR
 	include ../../../Makefile
 endif
-
-avrdude: build
-	ls /dev/tty* > /tmp/1; \
-	echo "Reset your Pro Micro now"; \
-	while [[ -z $$USB ]]; do \
-	  sleep 1; \
-	  ls /dev/tty* > /tmp/2; \
-	  USB=`diff /tmp/1 /tmp/2 | grep -o '/dev/tty.*'`; \
-	done; \
-	avrdude -p $(MCU) -c avr109 -P $$USB -U flash:w:$(BUILD_DIR)/$(TARGET).hex
-
-.PHONY: avrdude

--- a/keyboards/handwired/numpad20/rules.mk
+++ b/keyboards/handwired/numpad20/rules.mk
@@ -69,15 +69,3 @@ AUDIO_ENABLE = no           # Audio output on port C6
 ifndef QUANTUM_DIR
 	include ../../../Makefile
 endif
-
-avrdude: build
-	ls /dev/tty* > /tmp/1; \
-	echo "Reset your Pro Micro now"; \
-	while [[ -z $$USB ]]; do \
-	  sleep 1; \
-	  ls /dev/tty* > /tmp/2; \
-	  USB=`diff /tmp/1 /tmp/2 | grep -o '/dev/tty.*'`; \
-	done; \
-	avrdude -p $(MCU) -c avr109 -P $$USB -U flash:w:$(BUILD_DIR)/$(TARGET).hex
-
-.PHONY: avrdude

--- a/keyboards/handwired/ortho5x13/rules.mk
+++ b/keyboards/handwired/ortho5x13/rules.mk
@@ -69,15 +69,3 @@ AUDIO_ENABLE = no           # Audio output on port C6
 ifndef QUANTUM_DIR
 	include ../../../Makefile
 endif
-
-avrdude: build
-	ls /dev/tty* > /tmp/1; \
-	echo "Reset your Pro Micro now"; \
-	while [[ -z $$USB ]]; do \
-	  sleep 1; \
-	  ls /dev/tty* > /tmp/2; \
-	  USB=`diff /tmp/1 /tmp/2 | grep -o '/dev/tty.*'`; \
-	done; \
-	avrdude -p $(MCU) -c avr109 -P $$USB -U flash:w:$(BUILD_DIR)/$(TARGET).hex
-
-.PHONY: avrdude

--- a/keyboards/lets_split/readme.md
+++ b/keyboards/lets_split/readme.md
@@ -106,7 +106,7 @@ Notes on Software Configuration
 -------------------------------
 
 Configuring the firmware is similar to any other QMK project. One thing
-to note is that `MATIX_ROWS` in `config.h` is the total number of rows between
+to note is that `MATRIX_ROWS` in `config.h` is the total number of rows between
 the two halves, i.e. if your split keyboard has 4 rows in each half, then
 `MATRIX_ROWS=8`.
 
@@ -115,7 +115,7 @@ not be very difficult to adapt it to support more if required.
 
 Flashing
 -------
-From the keymap directory run `make SUBPROJECT-KEYMAP-avrdude` for automatic serial port resolution and flashing.
+From the `lets_split` directory run `make SUBPROJECT-KEYMAP-avrdude` for automatic serial port resolution and flashing.
 Example: `make rev2-default-avrdude`
 
 

--- a/keyboards/lets_split/rules.mk
+++ b/keyboards/lets_split/rules.mk
@@ -74,15 +74,3 @@ USE_I2C = yes
 SLEEP_LED_ENABLE = no    # Breathing sleep LED during USB suspend
 
 CUSTOM_MATRIX = yes
-
-avrdude: build
-	ls /dev/tty* > /tmp/1; \
-	echo "Reset your Pro Micro now"; \
-	while [ -z $$USB ]; do \
-	  sleep 1; \
-	  ls /dev/tty* > /tmp/2; \
-	  USB=`diff /tmp/1 /tmp/2 | grep -o '/dev/tty.*'`; \
-	done; \
-	avrdude -p $(MCU) -c avr109 -P $$USB -U flash:w:$(BUILD_DIR)/$(TARGET).hex
-
-.PHONY: avrdude

--- a/keyboards/minidox/readme.md
+++ b/keyboards/minidox/readme.md
@@ -1,7 +1,7 @@
 MiniDox
 =====
 
-![MimiDox](http://i.imgur.com/iWb3yO0.jpg)
+![MiniDox](http://i.imgur.com/iWb3yO0.jpg)
 
 A compact version of the ErgoDox
 
@@ -22,7 +22,7 @@ Flashing
 -------
 Note: Most of this is copied from the Let's Split readme, because it is awesome
 
-From the keymap directory run `make SUBPROJECT-KEYMAP-avrdude` for automatic serial port resolution and flashing.
+From the `minidox` directory run `make SUBPROJECT-KEYMAP-avrdude` for automatic serial port resolution and flashing.
 Example: `make rev1-default-avrdude`
 
 Choosing which board to plug the USB cable into (choosing Master)

--- a/keyboards/nyquist/readme.md
+++ b/keyboards/nyquist/readme.md
@@ -6,6 +6,8 @@ The Nyquist is a 60% split ortholinear board by [Keebio](https://keeb.io). It ha
 
 ## Build Guide
 
+A build log of the Nyquist can be found here: [Nyquist Build Log](http://imgur.com/a/dD4sX).
+
 Since the design is very similar to the Let's Split v2, the build guide for that can be used while the build guide for the Nyquist is being fully developed. A build guide for putting together the Let's Split v2 can be found here: [An Overly Verbose Guide to Building a Let's Split Keyboard](https://github.com/nicinabox/lets-split-guide)
 
 There is additional information there about flashing and adding RGB underglow.
@@ -98,7 +100,7 @@ unnecessary in simple use cases.
 
 Flashing
 -------
-From the keymap directory run `make SUBPROJECT-KEYMAP-avrdude` for automatic serial port resolution and flashing.
+From the `nyquist` directory run `make SUBPROJECT-KEYMAP-avrdude` for automatic serial port resolution and flashing.
 Example: `make rev1-serial-avrdude`
 
 

--- a/keyboards/nyquist/rules.mk
+++ b/keyboards/nyquist/rules.mk
@@ -73,15 +73,3 @@ USE_I2C = yes
 SLEEP_LED_ENABLE = no    # Breathing sleep LED during USB suspend
 
 CUSTOM_MATRIX = yes
-
-avrdude: build
-	ls /dev/tty* > /tmp/1; \
-	echo "Reset your Pro Micro now"; \
-	while [[ -z $$USB ]]; do \
-	  sleep 1; \
-	  ls /dev/tty* > /tmp/2; \
-	  USB=`diff /tmp/1 /tmp/2 | grep -o '/dev/tty.*'`; \
-	done; \
-	avrdude -p $(MCU) -c avr109 -P $$USB -U flash:w:$(BUILD_DIR)/$(TARGET).hex
-
-.PHONY: avrdude

--- a/keyboards/orthodox/readme.md
+++ b/keyboards/orthodox/readme.md
@@ -96,7 +96,7 @@ the two halves, i.e. if your split keyboard has 3 rows in each half, then
 
 Flashing
 -------
-From the keymap directory run `make SUBPROJECT-KEYMAP-avrdude` for automatic serial port resolution and flashing.
+From the `orthodox` directory run `make SUBPROJECT-KEYMAP-avrdude` for automatic serial port resolution and flashing.
 Example: `make rev2-default-avrdude`
 
 

--- a/keyboards/orthodox/rules.mk
+++ b/keyboards/orthodox/rules.mk
@@ -73,15 +73,3 @@ USE_I2C = yes
 SLEEP_LED_ENABLE = no    # Breathing sleep LED during USB suspend
 
 CUSTOM_MATRIX = yes
-
-avrdude: build
-	ls /dev/tty* > /tmp/1; \
-	echo "Reset your Pro Micro now"; \
-	while [[ -z $$USB ]]; do \
-	  sleep 1; \
-	  ls /dev/tty* > /tmp/2; \
-	  USB=`diff /tmp/1 /tmp/2 | grep -o '/dev/tty.*'`; \
-	done; \
-	avrdude -p $(MCU) -c avr109 -P $$USB -U flash:w:$(BUILD_DIR)/$(TARGET).hex
-
-.PHONY: avrdude

--- a/tmk_core/avr.mk
+++ b/tmk_core/avr.mk
@@ -144,6 +144,20 @@ dfu-ee: $(BUILD_DIR)/$(TARGET).hex $(BUILD_DIR)/$(TARGET).eep
 	fi
 	$(DFU_PROGRAMMER) $(MCU) reset
 
+avrdude: $(BUILD_DIR)/$(TARGET).hex
+	ls /dev/tty* > /tmp/1; \
+	echo "Detecting Pro Micro port, reset your Pro Micro now.\c"; \
+	while [ -z $$USB ]; do \
+	  sleep 1; \
+	  echo ".\c"; \
+	  ls /dev/tty* > /tmp/2; \
+	  USB=`diff /tmp/1 /tmp/2 | grep -o '/dev/tty.*'`; \
+	done; \
+	echo ""; \
+	echo "Detected Pro Micro port at $$USB"; \
+	sleep 1; \
+	avrdude -p $(MCU) -c avr109 -P $$USB -U flash:w:$(BUILD_DIR)/$(TARGET).hex
+
 # Convert hex to bin.
 flashbin: $(BUILD_DIR)/$(TARGET).hex
 	$(OBJCOPY) -Iihex -Obinary $(BUILD_DIR)/$(TARGET).hex $(BUILD_DIR)/$(TARGET).bin


### PR DESCRIPTION
This PR makes a couple improvements to the script used to flash the Pro Micro on macOS/Linux by making the text a bit more descriptive and adding a delay to deal with the first time flashing of a Pro Micro.

Also fixes incorrect documentation on which directory to run the avrdude make command in.