### PR TITLE
Update Mac build environment setup

### DIFF
--- a/docs/build_environment_setup.md
+++ b/docs/build_environment_setup.md
@@ -50,10 +50,10 @@ If you have trouble and want to ask for help, it is useful to generate a *Win_Ch
 If you're using [homebrew,](http://brew.sh/) you can use the following commands:
 
     brew tap osx-cross/avr
-    brew install avr-libc
+    brew install avr-gcc
     brew install dfu-programmer
 
-This is the recommended method. If you don't have homebrew, [install it!](http://brew.sh/) It's very much worth it for anyone who works in the command line. Note that the `make` and `make install` portion during the homebrew installation of avr-libc can take over 20 minutes and exhibit high CPU usage.
+This is the recommended method. If you don't have homebrew, [install it!](http://brew.sh/) It's very much worth it for anyone who works in the command line. Note that the `make` and `make install` portion during the homebrew installation of avr-gcc can take over 20 minutes and exhibit high CPU usage.
 
 You can also try these instructions:
 


### PR DESCRIPTION
Change installation of avr-libc to avr-gcc, now that avr-libc is integrated into the avr-gcc build with this PR: https://github.com/osx-cross/homebrew-avr/pull/54