### PR TITLE
Add QMK version to make output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -390,6 +390,7 @@ endef
 define BUILD
     MAKE_VARS += VERBOSE=$(VERBOSE) COLOR=$(COLOR)
     COMMANDS += $$(COMMAND)
+    MAKE_MSG = QMK Firmware v$$(shell git describe --abbrev=0 --tags 2>/dev/null)\n\n$(MAKE_MSG)
     COMMAND_true_$$(COMMAND) := \
         printf "$$(MAKE_MSG)" | \
         $$(MAKE_MSG_FORMAT); \
@@ -420,7 +421,7 @@ define BUILD_TEST
     COMMAND := $1
     MAKE_CMD := $$(MAKE) -r -R -C $(ROOT_DIR) -f build_test.mk $$(MAKE_TARGET)
     MAKE_VARS := TEST=$$(TEST_NAME) FULL_TESTS="$$(FULL_TESTS)"
-    MAKE_MSG := $$(MSG_MAKE_TEST)
+    MAKE_MSG := QMK Firmware v$$(shell git describe --abbrev=0 --tags 2>/dev/null)\n\n$$(MSG_MAKE_TEST)
     $$(eval $$(call BUILD))
     ifneq ($$(MAKE_TARGET),clean)
         TEST_EXECUTABLE := $$(TEST_DIR)/$$(TEST_NAME).elf

--- a/tmk_core/rules.mk
+++ b/tmk_core/rules.mk
@@ -237,6 +237,10 @@ sizeafter: $(BUILD_DIR)/$(TARGET).hex
 	# test file sizes eventually
 	# @if [[ $($(SIZE) --target=$(FORMAT) $(TARGET).hex | $(AWK) 'NR==2 {print "0x"$5}') -gt 0x200 ]]; then $(SECHO) "File is too big!"; fi
 
+# Display qmk version information.
+qmkversion :
+	@$(SILENT) || printf "QMK Firmware v$(shell git describe --abbrev=0 --tags 2>/dev/null)\n\n"
+
 # Display compiler version information.
 gccversion :
 	@$(SILENT) || $(CC) --version
@@ -275,7 +279,7 @@ gccversion :
 	$(eval CMD=$(BIN) $< $@ || exit 0)
 	@$(BUILD_CMD)
 
-BEGIN = gccversion sizebefore
+BEGIN = qmkversion gccversion sizebefore
 
 # Link: create ELF output file from object files.
 .SECONDARY : $(BUILD_DIR)/$(TARGET).elf
@@ -382,7 +386,7 @@ $(eval $(foreach OUTPUT,$(OUTPUTS),$(shell mkdir -p $(OUTPUT) 2>/dev/null)))
 
 
 # Listing of phony targets.
-.PHONY : all finish sizebefore sizeafter gccversion \
-build elf hex eep lss sym coff extcoff \
+.PHONY : all finish sizebefore sizeafter qmkversion \
+gccversion build elf hex eep lss sym coff extcoff \
 clean clean_list debug gdb-config show_path \
 program teensy dfu flip dfu-ee flip-ee dfu-start 

--- a/tmk_core/rules.mk
+++ b/tmk_core/rules.mk
@@ -237,10 +237,6 @@ sizeafter: $(BUILD_DIR)/$(TARGET).hex
 	# test file sizes eventually
 	# @if [[ $($(SIZE) --target=$(FORMAT) $(TARGET).hex | $(AWK) 'NR==2 {print "0x"$5}') -gt 0x200 ]]; then $(SECHO) "File is too big!"; fi
 
-# Display qmk version information.
-qmkversion :
-	@$(SILENT) || printf "QMK Firmware v$(shell git describe --abbrev=0 --tags 2>/dev/null)\n\n"
-
 # Display compiler version information.
 gccversion :
 	@$(SILENT) || $(CC) --version
@@ -279,7 +275,7 @@ gccversion :
 	$(eval CMD=$(BIN) $< $@ || exit 0)
 	@$(BUILD_CMD)
 
-BEGIN = qmkversion gccversion sizebefore
+BEGIN = gccversion sizebefore
 
 # Link: create ELF output file from object files.
 .SECONDARY : $(BUILD_DIR)/$(TARGET).elf


### PR DESCRIPTION
I've opted for just the bare tag rather than a unique commit to make things a little easier to understand. The -<commits>-<hash> makes it a bit more confusing, but I'm open to suggestions on this!

This is what it looks like:

```
QMK Firmware v0.5.95

Making planck/rev4 with keymap default

avr-gcc (GCC) 4.8.2
Copyright (C) 2013 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Size before:
   text    data     bss     dec     hex filename
      0   26968       0   26968    6958 planck_rev4_default.hex


Size after:
   text    data     bss     dec     hex filename
      0   26968       0   26968    6958 planck_rev4_default.hex
```