### PR TITLE
Make Travis convert line-endings and push a skippable commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ addons:
     - binutils-arm-none-eabi
     - libnewlib-arm-none-eabi
     - diffutils
+    - dos2unix
 after_success: 
   bash util/travis_compiled_push.sh
 notifications:

--- a/util/travis_compiled_push.sh
+++ b/util/travis_compiled_push.sh
@@ -17,6 +17,12 @@ chmod 600 qmk.fm
 eval `ssh-agent -s`
 ssh-add id_rsa_qmk_firmware
 
+# convert to unix line-endings
+git diff --name-only -n 1 -z ${TRAVIS_COMMIT_RANGE} | xargs -0 dos2unix
+git diff --name-only -n 1 -z ${TRAVIS_COMMIT_RANGE} | xargs -0 git add
+git commit -m "convert to unix line-endings [skip ci]"
+git push git@github.com:qmk/qmk_firmware.git
+
 increment_version ()
 {
   declare -a part=( ${1//\./ } )


### PR DESCRIPTION
This should look through the files in the commits and convert them to unix line-endings, add, commit, and push them to master with a [skip ci] parameter, so it doesn't check them again.

I'm not entirely sure this will ignore binary files, but some research is showing that's the case with `git diff`.