### PR TITLE
add option to let ctrl override shift/gui for the GRAVE_ESC.

### DIFF
--- a/docs/faq_keymap.md
+++ b/docs/faq_keymap.md
@@ -116,7 +116,9 @@ https://github.com/tekezo/Karabiner/issues/403
 
 ## Esc and `~ on a key
 
-Use `GRAVE_ESC` or `KC_GESC` in your keymap.
+Use `GRAVE_ESC` or `KC_GESC` in your keymap. `GUI`+`GRAVE_ESC` results in `\`` and `SHIFT`+`GRAVE_ESC` results in `~`.
+
+Note that this will break the CTRL+SHIFT+ESC shortcut to the Windows task manager. Use `#define GRAVE_ESC_CTRL_OVERRIDE` in your `config.h` to get the shortcut back. With this option, `ESC_GRAVE` results in `ESC` if `CTRL` is held, even if `SHIFT` or `GUI` are also held.
 
 ## Arrow on Right Modifier keys with Dual-Role
 This turns right modifer keys into arrow keys when the keys are tapped while still modifiers when the keys are hold. In TMK the dual-role function is dubbed **TAP**.

--- a/keyboards/bananasplit/keymaps/coloneljesus/config.h
+++ b/keyboards/bananasplit/keymaps/coloneljesus/config.h
@@ -20,5 +20,6 @@
 #include "../../config.h"
 
 // place overrides here
+#define GRAVE_ESC_CTRL_OVERRIDE
 
 #endif

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -477,6 +477,8 @@ bool process_record_quantum(keyrecord_t *record) {
                                       |MOD_BIT(KC_LGUI)|MOD_BIT(KC_RGUI)));
       
 #ifdef GRAVE_ESC_CTRL_OVERRIDE
+      // if CTRL is pressed, ESC is always read as ESC, even if SHIFT or GUI is pressed.
+      // this is handy for the ctrl+shift+esc shortcut on windows, among other things.
       if (get_mods() & (MOD_BIT(KC_LCTL) | MOD_BIT(KC_RCTL)))
         shifted = 0;
 #endif

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -475,6 +475,11 @@ bool process_record_quantum(keyrecord_t *record) {
       void (*method)(uint8_t) = (record->event.pressed) ? &add_key : &del_key;
       uint8_t shifted = get_mods() & ((MOD_BIT(KC_LSHIFT)|MOD_BIT(KC_RSHIFT)
                                       |MOD_BIT(KC_LGUI)|MOD_BIT(KC_RGUI)));
+      
+#ifdef GRAVE_ESC_CTRL_OVERRIDE
+      if (get_mods() & (MOD_BIT(KC_LCTL) | MOD_BIT(KC_RCTL)))
+        shifted = 0;
+#endif
 
       method(shifted ? KC_GRAVE : KC_ESCAPE);
       send_keyboard_report(); 

--- a/quantum/template/config.h
+++ b/quantum/template/config.h
@@ -67,6 +67,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* Locking resynchronize hack */
 #define LOCKING_RESYNC_ENABLE
 
+/* If defined, GRAVE_ESC will always act as ESC when CTRL is held.
+ * This is userful for the Windows task manager shortcut (ctrl+shift+esc).
+ */
+// #define GRAVE_ESC_CTRL_OVERRIDE
+
 /*
  * Force NKRO
  *


### PR DESCRIPTION
This makes the ctrl+shift+esc shortcut to task manager on windows work.
currently, this is OFF by default but I could see it becoming ON by default, since ctrl+~ and ctrl+` aren't used much, afaik.