### PR TITLE
Remove fp mouse

### DIFF
--- a/quantum/process_keycode/process_leader.c
+++ b/quantum/process_keycode/process_leader.c
@@ -14,6 +14,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef DISABLE_LEADER
+
 #include "process_leader.h"
 
 __attribute__ ((weak))
@@ -52,3 +54,5 @@ bool process_leader(uint16_t keycode, keyrecord_t *record) {
   }
   return true;
 }
+
+#endif

--- a/tmk_core/common/mousekey.c
+++ b/tmk_core/common/mousekey.c
@@ -55,6 +55,14 @@ uint8_t mk_wheel_time_to_max = MOUSEKEY_WHEEL_TIME_TO_MAX;
 
 static uint16_t last_timer = 0;
 
+inline int8_t times_inv_sqrt2(int8_t x)
+{
+    // 181/256 is pretty close to 1/sqrt(2)
+    // 0.70703125                 0.707106781
+    // 1 too small for x=99 and x=198
+    // This ends up being a mult and discard lower 8 bits
+    return (x * 181) >> 8;
+}
 
 static uint8_t move_unit(void)
 {
@@ -111,10 +119,10 @@ void mousekey_task(void)
     if (mouse_report.y > 0) mouse_report.y = move_unit();
     if (mouse_report.y < 0) mouse_report.y = move_unit() * -1;
 
-    /* diagonal move [1/sqrt(2) = 0.7] */
+    /* diagonal move [1/sqrt(2)] */
     if (mouse_report.x && mouse_report.y) {
-        mouse_report.x *= 0.7;
-        mouse_report.y *= 0.7;
+        mouse_report.x = times_inv_sqrt2(mouse_report.x);
+        mouse_report.y = times_inv_sqrt2(mouse_report.y);
     }
 
     if (mouse_report.v > 0) mouse_report.v = wheel_unit();


### PR DESCRIPTION
Tiny patch to:
1. Remove floating point calcs from mousekey.c.  Some potential efficiencies in code size and execution time.
2. Wrap process_leader.c in #ifndef DISABLE_LEADER to allow compilation with DISABLE_LEADER defined.