### PR TITLE
Fix avoid certificate errors that occur during '2-setup-environment-win.bat'

### DIFF
--- a/util/2-setup-environment-win.bat
+++ b/util/2-setup-environment-win.bat
@@ -34,14 +34,14 @@ ECHO ------------------------------------------
 ECHO Installing dfu-programmer.
 ECHO ------------------------------------------
 ECHO.
-wget 'http://downloads.sourceforge.net/project/dfu-programmer/dfu-programmer/0.7.2/dfu-programmer-win-0.7.2.zip' >> %STARTINGDIR%\environment-setup.log
+wget --no-check-certificate 'http://downloads.sourceforge.net/project/dfu-programmer/dfu-programmer/0.7.2/dfu-programmer-win-0.7.2.zip' >> %STARTINGDIR%\environment-setup.log
 unzip -o dfu-programmer-win-0.7.2.zip >> %STARTINGDIR%\environment-setup.log
 COPY dfu-programmer.exe .. >> %STARTINGDIR%\environment-setup.log
 
 ECHO ------------------------------------------
 ECHO Downloading driver
 ECHO ------------------------------------------
-wget http://downloads.sourceforge.net/project/libusb-win32/libusb-win32-releases/1.2.6.0/libusb-win32-bin-1.2.6.0.zip >> %STARTINGDIR%\environment-setup.log
+wget --no-check-certificate http://downloads.sourceforge.net/project/libusb-win32/libusb-win32-releases/1.2.6.0/libusb-win32-bin-1.2.6.0.zip >> %STARTINGDIR%\environment-setup.log
 unzip -o libusb-win32-bin-1.2.6.0.zip >> %STARTINGDIR%\environment-setup.log
 COPY libusb-win32-bin-1.2.6.0\bin\x86\libusb0_x86.dll ../libusb0.dll >> %STARTINGDIR%\environment-setup.log
 


### PR DESCRIPTION
I encountered following errors when attempted execute `2-setup-environment-win.bat` , so I added parameters to the wget command.

```
...
------------------------------------------
Installing dfu-programmer.
------------------------------------------

--2017-08-16 18:48:45--  http://downloads.sourceforge.net/project/dfu-programmer/dfu-programmer/0.7.2/dfu-programmer-win-0.7.2.zip
Resolving downloads.sourceforge.net... 216.34.181.59
Connecting to downloads.sourceforge.net|216.34.181.59|:80... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://jaist.dl.sourceforge.net/project/dfu-programmer/dfu-programmer/0.7.2/dfu-programmer-win-0.7.2.zip [following]
--2017-08-16 18:48:45--  https://jaist.dl.sourceforge.net/project/dfu-programmer/dfu-programmer/0.7.2/dfu-programmer-win-0.7.2.zip
Resolving jaist.dl.sourceforge.net... 150.65.7.130
Connecting to jaist.dl.sourceforge.net|150.65.7.130|:443... connected.
ERROR: cannot verify jaist.dl.sourceforge.net's certificate, issued by `/C=JP/L=Academe/O=National Institute of Informatics/CN=NII Open Domain CA - G4':
  Unable to locally verify the issuer's authority.
ERROR: certificate common name `ftp.jaist.ac.jp' doesn't match requested host name `jaist.dl.sourceforge.net'.
To connect to jaist.dl.sourceforge.net insecurely, use `--no-check-certificate'.
unzip:  cannot find or open dfu-programmer-win-0.7.2.zip, dfu-programmer-win-0.7.2.zip.zip or dfu-programmer-win-0.7.2.zip.ZIP.
------------------------------------------
Downloading driver
------------------------------------------
--2017-08-16 18:48:46--  http://downloads.sourceforge.net/project/libusb-win32/libusb-win32-releases/1.2.6.0/libusb-win32-bin-1.2.6.0.zip
Resolving downloads.sourceforge.net... 216.34.181.59
Connecting to downloads.sourceforge.net|216.34.181.59|:80... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://jaist.dl.sourceforge.net/project/libusb-win32/libusb-win32-releases/1.2.6.0/libusb-win32-bin-1.2.6.0.zip [following]
--2017-08-16 18:48:46--  https://jaist.dl.sourceforge.net/project/libusb-win32/libusb-win32-releases/1.2.6.0/libusb-win32-bin-1.2.6.0.zip
Resolving jaist.dl.sourceforge.net... 150.65.7.130
Connecting to jaist.dl.sourceforge.net|150.65.7.130|:443... connected.
ERROR: cannot verify jaist.dl.sourceforge.net's certificate, issued by `/C=JP/L=Academe/O=National Institute of Informatics/CN=NII Open Domain CA - G4':
  Unable to locally verify the issuer's authority.
ERROR: certificate common name `ftp.jaist.ac.jp' doesn't match requested host name `jaist.dl.sourceforge.net'.
To connect to jaist.dl.sourceforge.net insecurely, use `--no-check-certificate'.
unzip:  cannot find or open libusb-win32-bin-1.2.6.0.zip, libusb-win32-bin-1.2.6.0.zip.zip or libusb-win32-bin-1.2.6.0.zip.ZIP.

------------------------------------------
Installing driver. Accept prompt.
------------------------------------------
...
```

If this is a bad fix please close this Pull Request.