### PR TITLE
bananasplit LED support and keymap add

### DIFF
--- a/keyboards/bananasplit/config.h
+++ b/keyboards/bananasplit/config.h
@@ -44,6 +44,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* number of backlight levels */
 #define BACKLIGHT_LEVELS  1
 
+/* mapping backlight LEDs to correct Pin */
+#define BACKLIGHT_PIN B7
+
 /* Set 0 if debouncing isn't needed */
 #define DEBOUNCING_DELAY  5
 #define TAPPING_TERM      175

--- a/keyboards/bananasplit/keymaps/0010/Makefile
+++ b/keyboards/bananasplit/keymaps/0010/Makefile
@@ -1,0 +1,37 @@
+# Copyright 2017 Balz Guenat
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+# QMK Build Options
+#   change to "no" to disable the options, or define them in the Makefile in 
+#   the appropriate keymap folder that will get included automatically
+#
+# BOOTMAGIC_ENABLE = no       # Virtual DIP switch configuration(+1000)
+# MOUSEKEY_ENABLE = yes       # Mouse keys(+4700)
+# EXTRAKEY_ENABLE = yes       # Audio control and System control(+450)
+# CONSOLE_ENABLE = no         # Console for debug(+400)
+# COMMAND_ENABLE = yes        # Commands for debug and configuration
+# NKRO_ENABLE = yes           # Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+# BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
+# MIDI_ENABLE = no            # MIDI support (+2400 to 4200, depending on config)
+# AUDIO_ENABLE = no           # Audio output on port C6
+# UNICODE_ENABLE = no         # Unicode
+# BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
+# RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight.  Do not enable this with audio at the same time.
+# SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
+
+ifndef QUANTUM_DIR
+	include ../../../../Makefile
+endif

--- a/keyboards/bananasplit/keymaps/0010/config.h
+++ b/keyboards/bananasplit/keymaps/0010/config.h
@@ -1,0 +1,24 @@
+/* Copyright 2017 Balz Guenat
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef CONFIG_USER_H
+#define CONFIG_USER_H
+
+#include "../../config.h"
+
+// place overrides here
+
+#endif

--- a/keyboards/bananasplit/keymaps/0010/keymap.c
+++ b/keyboards/bananasplit/keymaps/0010/keymap.c
@@ -1,0 +1,73 @@
+/* Copyright 2017 Balz Guenat
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "bananasplit.h"
+
+#define ______ KC_TRNS
+
+/*
+    This switch layout is ANSI with the following modifications:
+        Split right shift
+        225 125 275 spacebar
+        Bottom right singles
+*/
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+/*
+-------------------------------------------------------------------------------------------
+|Esc|  1  |  2  |  3  |  4  |  5  |  6  |  7  |  8  |  9  |  0  |  -  |  =  |  Backspace  |
+-------------------------------------------------------------------------------------------
+|  Tab   |  Q  |  W  |  E  |  R  |  T  |  Y  |  U  |  I  |  O  |  P  |  [  |  ]  |   \    |
+-------------------------------------------------------------------------------------------
+|  Cpslock  |  A  |  S  |  D  |  F  |  G  |  H  |  J  |  K  |  L  |  ;  |  '  |   Enter   |
+-------------------------------------------------------------------------------------------
+|    Shift    |  Z  |  X  |  C  |  V  |  B  |  N  |  M  |  ,  |  .  |  /  |  Shift  | Up  |
+-------------------------------------------------------------------------------------------
+| Ctrl  |  GUI |  Alt | L1(Space)  | LED  |     Space     | Home | End | Left |Rght |Down |
+-------------------------------------------------------------------------------------------
+*/
+[0] = KEYMAP( \
+    KC_ESC,  KC_1,    KC_2,    KC_3, KC_4,   KC_5,  KC_6,   KC_7, KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, \
+    KC_TAB,  KC_Q,    KC_W,    KC_E, KC_R,   KC_T,  KC_Y,   KC_U, KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS, \
+    KC_CAPS, KC_A,    KC_S,    KC_D, KC_F,   KC_G,  KC_H,   KC_J, KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_ENT, \
+    KC_LSFT,          KC_Z,    KC_X, KC_C,   KC_V,  KC_B,   KC_N, KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT, KC_UP,\
+    KC_LCTL, KC_LGUI, KC_LALT, LT(1,KC_SPACE),      BL_TOGG,      KC_SPC,  KC_HOME, KC_END,  KC_LEFT, KC_RGHT, KC_DOWN  \
+),
+/*
+-------------------------------------------------------------------------------------------
+| ~   | F1  | F2  | F3  | F4  | F5  | F6  | F7  | F8  | F9  | F10 | F11 | F12 |  DEL      |
+-------------------------------------------------------------------------------------------
+|      |      | UP |      |     |     |     |     |    |    |      |      |      | PrtSc  |
+-------------------------------------------------------------------------------------------
+|      |Left | Down |Right |  |   |  |  |    | |     |     |             |  SLEEP         |
+-------------------------------------------------------------------------------------------
+|             |     |     |     |     |     | | |     |     |     |         |     |       |
+-------------------------------------------------------------------------------------------
+|       |       |       |            |  Reset  |            |       |       |       |     |
+-------------------------------------------------------------------------------------------
+*/
+[1] = KEYMAP( \
+    KC_GRV,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,  KC_F6, KC_F7,         KC_F8,          KC_F9,   KC_F10, KC_F11, KC_F12, KC_DEL, \
+    ______, ______,   KC_UP,   ______, ______, ______, ______, ______, ______,   ______,  ______, ______, ______, KC_PSCR, \
+    ______,  KC_LEFT, KC_DOWN, KC_RGHT, ______, ______, ______, ______,       ______,          ______, ______, ______, KC_SLEP, \
+    ______,           ______,  ______,  ______,  ______, ______,  ______, ______,   ______,  ______, ______, ______, KC_PGUP, \
+    ______,  ______,  ______,           ______,  RESET, ______,                 ______,         ______,  ______, ______, KC_PGDN \
+),
+};
+
+
+const uint16_t PROGMEM fn_actions[] = {
+};


### PR DESCRIPTION
- Added LED pin mapping for backlight; this is actually the suggested change of @BalzGuenat and works for me.  Backlighting wasn't working before this change.
- Adding my fairly basic keymap for those who might find useful.