### PR TITLE
Fix these links, as they appear to be broken

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ Otherwise, you can either download it directly ([zip](https://github.com/qmk/qmk
 
 ## How to compile {#how-to-compile}
 
-Before you are able to compile, you'll need to [install an environment](build_environment_setup.md) for AVR or/and ARM development. Once that is complete, you'll use the `make` command to build a keyboard and keymap with the following notation:
+Before you are able to compile, you'll need to [install an environment](getting_started_build_tools.md) for AVR or/and ARM development. Once that is complete, you'll use the `make` command to build a keyboard and keymap with the following notation:
 
     make planck-rev4-default
 

--- a/docs/faq_build.md
+++ b/docs/faq_build.md
@@ -1,6 +1,6 @@
 # Frequently Asked Build Questions
 
-This page covers questions about building QMK. If you have not yet you should read the [Build Environment Setup](build_environment_setup.md) and [Make Instructions](make_instructions.md) guides.
+This page covers questions about building QMK. If you have not yet you should read the [Build Environment Setup](getting_started_build_tools.md) and [Make Instructions](make_instructions.md) guides.
 
 ## Can't program on Linux
 You will need proper permission to operate a device. For Linux users see udev rules below. Easy way is to use `sudo` command, if you are not familiar with this command check its manual with `man sudo` or this page on line.


### PR DESCRIPTION
Attempting to fix #1594 

It looks like build_environment_setup.md got renamed to getting_started_build_tools.md in this commit:

	commit e6c638bed1fa0a48bb6f8697b2a61717c4fd0992
	Author: skullY <skullydazed@gmail.com>
	Date:   Sat Aug 5 20:54:34 2017 -0700

		Overhaul the Getting Started section and add a FAQ section

	 docs/{build_environment_setup.md => getting_started_build_tools.md} | 132 ++++++++++++++++++++++++++++++++++++-------------------------------------

This commit adjusts the links to match the new name.