### PR TITLE
Reverting Docker CMD Changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ ENV keymap=default
 
 VOLUME /qmk
 WORKDIR /qmk
-CMD make clean; make;
+CMD make clean ; make keyboard=${keyboard} subproject=${subproject} keymap=${keymap}


### PR DESCRIPTION
Adding the CMD from @edasque in once more as it allows specifying more than one board via host ENV vars. 
Currently, the Dockerfile is hard-coded.