### PR TITLE
Required overridden function for keymaps in EEPROM

### DIFF
--- a/quantum/keymap_common.c
+++ b/quantum/keymap_common.c
@@ -169,6 +169,7 @@ void action_function(keyrecord_t *record, uint8_t id, uint8_t opt)
 }
 
 // translates key to keycode
+__attribute__ ((weak))
 uint16_t keymap_key_to_keycode(uint8_t layer, keypos_t key)
 {
     // Read entire word (16bits)


### PR DESCRIPTION
`__attribute__ ((weak))` was recently removed in #1491, this breaks the keymaps in EEPROM implementations, as you need to override this function because it's the main hook.