### PR TITLE
Update s60_x/default/rule.mk for original Sentraq S60-X

### DIFF
--- a/keyboards/s60_x/default/rules.mk
+++ b/keyboards/s60_x/default/rules.mk
@@ -1,7 +1,7 @@
 CONSOLE_ENABLE = no        # Console for debug(+400)
 COMMAND_ENABLE = no        # Commands for debug and configuration
 NKRO_ENABLE = no          # USB Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
-BACKLIGHT_ENABLE = yes     # Enable keyboard backlight functionality
+BACKLIGHT_ENABLE = no     # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no
 
 ifndef QUANTUM_DIR


### PR DESCRIPTION
Fix and issue with the original Sentraq S60-X not being compatible with 'default'. If 'default' shouldn't be changed, perhaps I can create an 'original' revision.