### PR TITLE
Change handling of adjust layer to make it more LT(...) friendly.

### DIFF
--- a/keyboards/planck/keymaps/default/keymap.c
+++ b/keyboards/planck/keymaps/default/keymap.c
@@ -34,11 +34,12 @@ enum planck_keycodes {
   COLEMAK,
   DVORAK,
   PLOVER,
-  LOWER,
-  RAISE,
   BACKLIT,
   EXT_PLV
 };
+
+#define LOWER MO(_LOWER)
+#define RAISE MO(_RAISE)
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
@@ -177,6 +178,17 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   float plover_gb_song[][2]  = SONG(PLOVER_GOODBYE_SOUND);
 #endif
 
+#define LOWER_AND_RAISE ((1UL << _LOWER) | (1UL << _RAISE))
+
+uint32_t layer_state_set_kb(uint32_t state) {
+  if ((state & LOWER_AND_RAISE) == LOWER_AND_RAISE) {
+    state |= 1UL << _ADJUST;
+  } else {
+    state &= ~(1UL << _ADJUST);
+  }
+  return state;
+}
+
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
   switch (keycode) {
     case QWERTY:
@@ -195,26 +207,6 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case DVORAK:
       if (record->event.pressed) {
         set_single_persistent_default_layer(_DVORAK);
-      }
-      return false;
-      break;
-    case LOWER:
-      if (record->event.pressed) {
-        layer_on(_LOWER);
-        update_tri_layer(_LOWER, _RAISE, _ADJUST);
-      } else {
-        layer_off(_LOWER);
-        update_tri_layer(_LOWER, _RAISE, _ADJUST);
-      }
-      return false;
-      break;
-    case RAISE:
-      if (record->event.pressed) {
-        layer_on(_RAISE);
-        update_tri_layer(_LOWER, _RAISE, _ADJUST);
-      } else {
-        layer_off(_RAISE);
-        update_tri_layer(_LOWER, _RAISE, _ADJUST);
       }
       return false;
       break;

--- a/keyboards/planck/keymaps/default/keymap.c
+++ b/keyboards/planck/keymaps/default/keymap.c
@@ -178,15 +178,8 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   float plover_gb_song[][2]  = SONG(PLOVER_GOODBYE_SOUND);
 #endif
 
-#define LOWER_AND_RAISE ((1UL << _LOWER) | (1UL << _RAISE))
-
 uint32_t layer_state_set_kb(uint32_t state) {
-  if ((state & LOWER_AND_RAISE) == LOWER_AND_RAISE) {
-    state |= 1UL << _ADJUST;
-  } else {
-    state &= ~(1UL << _ADJUST);
-  }
-  return state;
+  return update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
 }
 
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {

--- a/keyboards/planck/keymaps/default/keymap.c
+++ b/keyboards/planck/keymaps/default/keymap.c
@@ -178,7 +178,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   float plover_gb_song[][2]  = SONG(PLOVER_GOODBYE_SOUND);
 #endif
 
-uint32_t layer_state_set_kb(uint32_t state) {
+uint32_t layer_state_set_user(uint32_t state) {
   return update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
 }
 

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -781,13 +781,13 @@ void set_single_persistent_default_layer(uint8_t default_layer) {
 }
 
 uint32_t update_tri_layer_state(uint32_t state, uint8_t layer1, uint8_t layer2, uint8_t layer3) {
-  uint32_t mask12 = LAYER_MASK(layer1) | LAYER_MASK(layer2);
-  uint32_t mask3 = LAYER_MASK(layer3);
+  uint32_t mask12 = (1UL << layer1) | (1UL << layer2);
+  uint32_t mask3 = 1UL << layer3;
   return (state & mask12) == mask12 ? (state | mask3) : (state & ~mask3);
 }
 
 void update_tri_layer(uint8_t layer1, uint8_t layer2, uint8_t layer3) {
-  layer_set(update_tri_layer_state(layer_state, layer1, layer2, layer3));
+  layer_state_set(update_tri_layer_state(layer_state, layer1, layer2, layer3));
 }
 
 void tap_random_base64(void) {

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -780,12 +780,14 @@ void set_single_persistent_default_layer(uint8_t default_layer) {
   default_layer_set(1U<<default_layer);
 }
 
+uint32_t update_tri_layer_state(uint32_t state, uint8_t layer1, uint8_t layer2, uint8_t layer3) {
+  uint32_t mask12 = LAYER_MASK(layer1) | LAYER_MASK(layer2);
+  uint32_t mask3 = LAYER_MASK(layer3);
+  return (state & mask12) == mask12 ? (state | mask3) : (state & ~mask3);
+}
+
 void update_tri_layer(uint8_t layer1, uint8_t layer2, uint8_t layer3) {
-  if (IS_LAYER_ON(layer1) && IS_LAYER_ON(layer2)) {
-    layer_on(layer3);
-  } else {
-    layer_off(layer3);
-  }
+  layer_set(update_tri_layer_state(layer_state, layer1, layer2, layer3));
 }
 
 void tap_random_base64(void) {

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -142,13 +142,15 @@ void send_char(char ascii_code);
 
 // For tri-layer
 void update_tri_layer(uint8_t layer1, uint8_t layer2, uint8_t layer3);
+uint32_t update_tri_layer_state(uint32_t state, uint8_t layer1, uint8_t layer2, uint8_t layer3);
 
 void set_single_persistent_default_layer(uint8_t default_layer);
 
 void tap_random_base64(void);
 
-#define IS_LAYER_ON(layer)  (layer_state & (1UL << (layer)))
-#define IS_LAYER_OFF(layer) (~layer_state & (1UL << (layer)))
+#define LAYER_MASK(layer)   (1UL << (layer))
+#define IS_LAYER_ON(layer)  (layer_state & LAYER_MASK(layer))
+#define IS_LAYER_OFF(layer) (~layer_state & LAYER_MASK(layer))
 
 void matrix_init_kb(void);
 void matrix_scan_kb(void);

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -148,9 +148,8 @@ void set_single_persistent_default_layer(uint8_t default_layer);
 
 void tap_random_base64(void);
 
-#define LAYER_MASK(layer)   (1UL << (layer))
-#define IS_LAYER_ON(layer)  (layer_state & LAYER_MASK(layer))
-#define IS_LAYER_OFF(layer) (~layer_state & LAYER_MASK(layer))
+#define IS_LAYER_ON(layer)  (layer_state & (1UL << (layer)))
+#define IS_LAYER_OFF(layer) (~layer_state & (1UL << (layer)))
 
 void matrix_init_kb(void);
 void matrix_scan_kb(void);


### PR DESCRIPTION
When setting up a custom keymap, I found that using `LT(_LOWER, ...)` and `LT(_RAISE, ...)` macros resulted in the `_ADJUST` layer becoming inaccessible when using the default code.  This can be avoided by implementing a suitable `layer_state_set_kb(...)` function.