### PR TITLE
Clone chibios and ugfx if it's not already checked out.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -514,6 +514,9 @@ $(SUBPROJECTS): %: %-allkm
 	cmp $(ROOT_DIR)/Makefile $(ROOT_DIR)/Makefile >/dev/null 2>&1; if [ $$? -gt 0 ]; then printf "$(MSG_NO_CMP)"; exit 1; fi;
 	# Check if the submodules are dirty, and display a warning if they are
 ifndef SKIP_GIT
+	if [ ! -e lib/chibios ]; then git submodule sync lib/chibios && git submodule update --init lib/chibios; fi
+	if [ ! -e lib/chibios-contrib ]; then git submodule sync lib/chibios-contrib && git submodule update --init lib/chibios-contrib; fi
+	if [ ! -e lib/ugfx ]; then git submodule sync lib/ugfx && git submodule update --init lib/ugfx; fi
 	git submodule status --recursive 2>/dev/null | \
 	while IFS= read -r x; do \
 		case "$$x" in \
@@ -550,6 +553,10 @@ test: test-all
 
 .PHONY: test-clean
 test-clean: test-all-clean
+
+lib/%:
+	git submodule sync $?
+	git submodule update --init $?
 
 git-submodule:
 	git submodule sync --recursive

--- a/message.mk
+++ b/message.mk
@@ -56,8 +56,7 @@ MSG_CLEANING = Cleaning project:
 MSG_CREATING_LIBRARY = Creating library:
 MSG_SUBMODULE_DIRTY = $(WARN_COLOR)WARNING:$(NO_COLOR)\n \
 	Some git sub-modules are out of date or modified, please consider runnning:$(BOLD)\n\
-	git submodule sync --recursive\n\
-	git submodule update --init --recursive$(NO_COLOR)\n\n\
+        make git-submodule\n\
 	You can ignore this warning if you are not compiling any ChibiOS keyboards,\n\
 	or if you have modified the ChibiOS libraries yourself. \n\n
 MSG_NO_CMP = $(ERROR_COLOR)Error:$(NO_COLOR)$(BOLD) cmp command not found, please install diffutils\n$(NO_COLOR)


### PR DESCRIPTION
This clones chibios and ugfx if the directories don't already exist, and adds make targets for anyone that wants to `make lib/<dep>` themselves.

This will clone even for avr users, but likely most avr users blindly cloned anyway due to the scary looking warning at the top of their make output. If they wish to avoid the automatic clone they can use `SKIP_GIT`, or they can `mkdir lib/chibios lib/chibios-contrib lib/ugfx`.

It would be better if these only cloned for chibios keyboards but due to how make works I can't find a place to hook into before the chibios make infrastructure is imported without running into `*** commands commence before first target.  Stop.` errors.