### PR TITLE
add UC_OSX_RALT to make unicode use the Right Alt key on OSX

### DIFF
--- a/docs/unicode.md
+++ b/docs/unicode.md
@@ -24,6 +24,7 @@ sort of like macro. Unfortunately, each OS has different ideas on how Unicode is
 This is the current list of Unicode input method in QMK:
 
 * UC_OSX: MacOS Unicode Hex Input support. Works only up to 0xFFFF. Disabled by default. To enable: go to System Preferences -> Keyboard -> Input Sources, and enable Unicode Hex.
+* UC_OSX_RALT: Same as UC_OSX, but sends the Rigt Alt key for unicode input
 * UC_LNX: Unicode input method under Linux. Works up to 0xFFFFF. Should work almost anywhere on ibus enabled distros. Without ibus, this works under GTK apps, but rarely anywhere else.
 * UC_WIN: (not recommended) Windows built-in Unicode input. To enable: create registry key under `HKEY_CURRENT_USER\Control Panel\Input Method\EnableHexNumpad` of type `REG_SZ` called `EnableHexNumpad`, set its value to 1, and reboot. This method is not recommended because of reliability and compatibility issue, use WinCompose method below instead.
 * UC_WINC: Windows Unicode input using WinCompose. Requires [WinCompose](https://github.com/samhocevar/wincompose). Works reliably under many (all?) variations of Windows.

--- a/quantum/process_keycode/process_unicode_common.c
+++ b/quantum/process_keycode/process_unicode_common.c
@@ -49,6 +49,9 @@ void unicode_input_start (void) {
   case UC_OSX:
     register_code(KC_LALT);
     break;
+  case UC_OSX_RALT:
+    register_code(KC_RALT);
+    break;
   case UC_LNX:
     register_code(KC_LCTL);
     register_code(KC_LSFT);
@@ -77,6 +80,9 @@ void unicode_input_finish (void) {
     case UC_OSX:
     case UC_WIN:
       unregister_code(KC_LALT);
+      break;
+    case UC_OSX_RALT:
+      unregister_code(KC_RALT);
       break;
     case UC_LNX:
       register_code(KC_SPC);

--- a/quantum/process_keycode/process_unicode_common.h
+++ b/quantum/process_keycode/process_unicode_common.h
@@ -37,6 +37,7 @@ void register_hex(uint16_t hex);
 #define UC_WIN 2  // Windows 'HexNumpad'
 #define UC_BSD 3  // BSD (not implemented)
 #define UC_WINC 4 // WinCompose https://github.com/samhocevar/wincompose
+#define UC_OSX_RALT 5 // Mac OS X using Right Alt key for Unicode Compose
 
 #define UC_BSPC	UC(0x0008)
 

--- a/quantum/process_keycode/process_unicodemap.c
+++ b/quantum/process_keycode/process_unicodemap.c
@@ -50,7 +50,7 @@ bool process_unicode_map(uint16_t keycode, keyrecord_t *record) {
     const uint32_t* map = unicode_map;
     uint16_t index = keycode - QK_UNICODE_MAP;
     uint32_t code = pgm_read_dword(&map[index]);
-    if (code > 0xFFFF && code <= 0x10ffff && input_mode == UC_OSX) {
+    if (code > 0xFFFF && code <= 0x10ffff && (input_mode == UC_OSX || input_mode == UC_OSX_RALT)) {
       // Convert to UTF-16 surrogate pair
       code -= 0x10000;
       uint32_t lo = code & 0x3ff;
@@ -59,7 +59,7 @@ bool process_unicode_map(uint16_t keycode, keyrecord_t *record) {
       register_hex32(hi + 0xd800);
       register_hex32(lo + 0xdc00);
       unicode_input_finish();
-    } else if ((code > 0x10ffff && input_mode == UC_OSX) || (code > 0xFFFFF && input_mode == UC_LNX)) {
+    } else if ((code > 0x10ffff && (input_mode == UC_OSX || input_mode == UC_OSX_RALT)) || (code > 0xFFFFF && input_mode == UC_LNX)) {
       // when character is out of range supported by the OS
       unicode_map_input_error();
     } else {


### PR DESCRIPTION
Hi,

I'd been debugging exactly _why_ unicode input wasn't working for me.
I'd used the correct input layout (Unicode Hex Input), and had initialised the layout for use with OSX, via `void matrix_init_user(void) { set_unicode_input_mode(UC_OSX); }`

Unfortunately it looks like my Macbook Pro only enables unicode input if one uses the *right* (not *left*) alt key.

This pull request adds a `UC_OSX_RALT` unicode target, which behaves exactly like `UC_OSX` but uses the right alt key instead of the left key.

I hope it's going to be useful to more people than just myself, hence the pull request.