### PR TITLE
Alterations and documentation updates for j3rn Ergodox EZ keymap

### DIFF
--- a/layouts/community/ergodox/j3rn/keymap.c
+++ b/layouts/community/ergodox/j3rn/keymap.c
@@ -18,7 +18,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |--------+------+------+------+------+------| Hyper|           | Meh  |------+------+------+------+------+--------|
  * | LShift |   Z  |   X  |   C  |   V  |   B  |      |           |      |   N  |   M  |   ,  |   .  |   /  | RShift |
  * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
- *   | ~L1  | Alt  |AltShf| Left | Right|                                       |  Up  | Down |   [  |   ]  | ~L1  |
+ *   | ~L1  | Alt  |AltShf| Left | Right|                                       |  Up  | Down |AltShf|  Alt | ~L1  |
  *   `----------------------------------'                                       `----------------------------------'
  *                                        ,-------------.       ,-------------.
  *                                        | App  | Home |       | PgUp |Ctrl/Esc|
@@ -46,7 +46,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
              KC_EQL,      KC_Y,   KC_U,   KC_I,   KC_O,   KC_P,             KC_BSLS,
                           KC_H,   KC_J,   KC_K,   KC_L,   KC_SCLN,          KC_QUOT,
              MEH_T(KC_NO),KC_N,   KC_M,   KC_COMM,KC_DOT, KC_SLSH,          KC_RSFT,
-                                  KC_UP,  KC_DOWN,KC_LBRC,KC_RBRC,          MO(SYMB),
+                          KC_UP,  KC_DOWN,RALT(KC_RSFT),  KC_RALT,          MO(SYMB),
 
              KC_PGUP,         CTL_T(KC_ESC),
              KC_PGDN,

--- a/layouts/community/ergodox/j3rn/keymap.c
+++ b/layouts/community/ergodox/j3rn/keymap.c
@@ -102,9 +102,9 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
  * |        |      |      |      |      |      |      |           |      |      |      | Lclk | Rclk |      |   F12  |
  * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
- * |        |      |      |      |      |      |------|           |------|MsLeft|MsDown| MsUp |MsRght|      |  Play  |
+ * |        |      |      |      |      |      |------|           |------|MsLeft|MsDown| MsUp |MsRght|      |        |
  * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
- * |        |      |      |      |      |      |      |           |      |      |      | Prev | Next |      |        |
+ * |        |      |      |      |      |      |      |           |      |      | Prev | Play | Next |      |        |
  * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
  *   |      |      |      |      |      |                                       |VolUp |VolDn | Mute |      |      |
  *   `----------------------------------'                                       `----------------------------------'
@@ -129,8 +129,8 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     // right hand
        KC_TRNS,  KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,
        KC_TRNS,  KC_TRNS, KC_TRNS, KC_BTN1, KC_BTN2, KC_TRNS, KC_F12,
-                 KC_MS_L, KC_MS_D, KC_MS_U, KC_MS_R, KC_TRNS, KC_MPLY,
-       KC_TRNS,  KC_TRNS, KC_TRNS, KC_MPRV, KC_MNXT, KC_TRNS, KC_TRNS,
+                 KC_MS_L, KC_MS_D, KC_MS_U, KC_MS_R, KC_TRNS, KC_TRNS,
+       KC_TRNS,  KC_TRNS, KC_MPRV, KC_MPLY, KC_MNXT, KC_TRNS, KC_TRNS,
                           KC_VOLU, KC_VOLD, KC_MUTE, KC_TRNS, KC_TRNS,
        KC_TRNS, KC_TRNS,
        KC_TRNS,

--- a/layouts/community/ergodox/j3rn/readme.md
+++ b/layouts/community/ergodox/j3rn/readme.md
@@ -28,5 +28,6 @@ This layout more closely resembles that of the Mac keyboard, and has some other 
 - **The bottommost-inner keys on the left and right thumb are momentary L2 and momentary L1, respectively**. I have found that both modes are useful, and this seemed like a reasonably accessible place to put these.
 - **Traditional numpad layout.** The base of most numpads is a double-wide "0" key to the left of a "." key. This is reflected in my layout by having two "0" keys to the left of a "." key.
 - **The function keys (F1-F12) have been moved to L2.** They were in the way in L1.
+- **The keys on the bottom-right that were formerly "[" and "]" are now Alt-Shift and Alt, respectively.** This enables me to do those `C-M-<key>` bindings in emacs. I use L1 for "[" and "]".
 
 **I'm always open to feedback and/or suggestions!**

--- a/layouts/community/ergodox/j3rn/readme.md
+++ b/layouts/community/ergodox/j3rn/readme.md
@@ -28,6 +28,7 @@ This layout more closely resembles that of the Mac keyboard, and has some other 
 - **The bottommost-inner keys on the left and right thumb are momentary L2 and momentary L1, respectively**. I have found that both modes are useful, and this seemed like a reasonably accessible place to put these.
 - **Traditional numpad layout.** The base of most numpads is a double-wide "0" key to the left of a "." key. This is reflected in my layout by having two "0" keys to the left of a "." key.
 - **The function keys (F1-F12) have been moved to L2.** They were in the way in L1.
+- **⏯ lives on ',' in the media layer, between ⏪ on 'm' and ⏩ on '.'.** This is the way they are laid out on the mac keyboard, and makes the most sense to me.
 - **The keys on the bottom-right that were formerly "[" and "]" are now Alt-Shift and Alt, respectively.** This enables me to do those `C-M-<key>` bindings in emacs. I use L1 for "[" and "]".
 
 **I'm always open to feedback and/or suggestions!**

--- a/layouts/community/ergodox/j3rn/readme.md
+++ b/layouts/community/ergodox/j3rn/readme.md
@@ -4,7 +4,7 @@
 
 Essentially, I wanted to switch to a layout that was less jarring than the default ErgoDox EZ layout, and did not require finger gymnastics to perform common OS X shortcuts (most of which involve the CMD (LGui) key).
 
-## How is it different from the default ErgoDox EZ layout?
+## How is it different from the default ErgoDox EZ default_osx layout?
 
 This layout more closely resembles that of the Mac keyboard, and has some other goodness baked in. Here is a rundown of what that means:
 
@@ -18,14 +18,13 @@ This layout more closely resembles that of the Mac keyboard, and has some other 
 
 ### Other changes
 
-- **The button to the left of "A" is Ctrl/Esc instead of Backspace.** This is actually how I have the keyboard on my Macbook set up to be, since it's loads more convenient than a  CAPS LOCK key. This is the Ctrl key I find myself using most.
-- **Mouse uses Vim-style navigation**. To activate "Media mode," hold the 'a' key. This allows you to move the mouse around with hjkl just like in Vim. Additionally, right and left click are the conveniently placed 'i' and 'o' keys.
+- **The button to the left of "A" is Ctrl/Esc instead of Backspace.** This is actually how I have the keyboard on my Macbook set up to be, since it's loads more convenient than a CAPS LOCK key. This is the Ctrl key I find myself using most.
+- **Mouse uses Vim-style navigation**. This allows you to move the mouse around with hjkl just like in Vim. Additionally, right and left click are the conveniently placed 'i' and 'o' keys.
 - **The key to the right of "5" and the key to left of "6" are "[" and "]", respectively, instead of Left and Right.** There is a more convenient set of Left and Right already present. Truth be told, I don't really use these keys, as they are a stretch to reach.
-- **The Toggle L1 keys have been replaced by the otherwise displaced "-" and "=".** They are laid out, left-to-right, in the same order as on the Mac keyboard. Honestly, they are not terribly conveniently placed, and their placement might change in a later version. I found that I did not toggle L1 frequently at all, and found using the momentary keys to access L1 to fit my workflow better.
-- **The "~"/L1 key in the bottom-left is now just momentary L1.** The "~" key was moved to the top-left as mentioned before, and I like to keep my multi-use keys to a minimum due to the latency for them to switch from "press" to "hold."
-- **The Home and End buttons have been shifted up on the left thumb, and Shift inserted below them.** This makes doing Shift-5 and other such combinations less painful.
-- **The Page Up and Page Down buttons have been shifted up on the right thumb.** I don't use either of these keys often, and wanted to free up some real estate.
-- **The bottommost-inner keys on the left and right thumb are momentary L2 and momentary L1, respectively**. I have found that both modes are useful, and this seemed like a reasonably accessible place to put these.
+- **The Toggle L1 keys in the center of the keyboard have been replaced by the otherwise displaced "-" and "=".** They are laid out, left-to-right, in the same order as on the Mac keyboard. Honestly, they are not terribly conveniently placed, and their placement might change in a later version. I found that the ~L1 would be better situated elsewhere.
+- **The "~" key in the extreme bottom-left is now just momentary L1.** The "~" key was moved to the top-left as mentioned before, and I like to keep my multi-use keys to a minimum due to the latency for them to switch from "press" to "hold."
+- **The Home and End buttons have been shifted up on the left thumb, and ~L2 inserted below them.** Nearly all of my media layer changes are on the right side, so the ~L2 key is on the left side.
+- **The Page Up and Page Down buttons have been shifted up on the right thumb, and ~L1 inserted below them.** I don't use either of the "Page" keys often, and use this ~L1 more than any other.
 - **Traditional numpad layout.** The base of most numpads is a double-wide "0" key to the left of a "." key. This is reflected in my layout by having two "0" keys to the left of a "." key.
 - **The function keys (F1-F12) have been moved to L2.** They were in the way in L1.
 - **⏯ lives on ',' in the media layer, between ⏪ on 'm' and ⏩ on '.'.** This is the way they are laid out on the mac keyboard, and makes the most sense to me.


### PR DESCRIPTION
This set of changes includes:
- Adding an `AltSft` and `Alt` on the bottom-right of the keyboard
- Relocating the "Play" button to between the "previous" and "next" buttons
- Documentation updates