### PR TITLE
Support for Raw HID on Linux/OSX and chrome.hid

### DIFF
--- a/tmk_core/protocol/lufa/descriptor.h
+++ b/tmk_core/protocol/lufa/descriptor.h
@@ -133,10 +133,19 @@ typedef struct
 /* index of interface */
 #define KEYBOARD_INTERFACE          0
 
-#ifdef MOUSE_ENABLE
-#   define MOUSE_INTERFACE          (KEYBOARD_INTERFACE + 1)
+// It is important that the Raw HID interface is at a constant
+// interface number, to support Linux/OSX platforms and chrome.hid
+// If Raw HID is enabled, let it be always 1.
+#ifdef RAW_ENABLE
+#   define RAW_INTERFACE        	(KEYBOARD_INTERFACE + 1)
 #else
-#   define MOUSE_INTERFACE          KEYBOARD_INTERFACE
+#   define RAW_INTERFACE        	KEYBOARD_INTERFACE
+#endif
+
+#ifdef MOUSE_ENABLE
+#   define MOUSE_INTERFACE          (RAW_INTERFACE + 1)
+#else
+#   define MOUSE_INTERFACE          RAW_INTERFACE
 #endif
 
 #ifdef EXTRAKEY_ENABLE
@@ -145,16 +154,10 @@ typedef struct
 #   define EXTRAKEY_INTERFACE       MOUSE_INTERFACE
 #endif
 
-#ifdef RAW_ENABLE
-#   define RAW_INTERFACE        	(EXTRAKEY_INTERFACE + 1)
-#else
-#   define RAW_INTERFACE        	EXTRAKEY_INTERFACE
-#endif
-
 #ifdef CONSOLE_ENABLE
-#   define CONSOLE_INTERFACE        (RAW_INTERFACE + 1)
+#   define CONSOLE_INTERFACE        (EXTRAKEY_INTERFACE + 1)
 #else
-#   define CONSOLE_INTERFACE        RAW_INTERFACE
+#   define CONSOLE_INTERFACE        EXTRAKEY_INTERFACE
 #endif
 
 #ifdef NKRO_ENABLE


### PR DESCRIPTION
It's important that hosts can identify the Raw HID interface (HID device) separate from the others, like keyboard, mouse, etc. On Windows, it has been done with "usage" and "usage page" IDs, but this isn't possible on other platforms. Switching to using the HID interface number, and forcing it constant regardless of other compile flags, gives a hard reference to that interface for all platforms.

The change is just a reordering of the interface number assignments so the Raw HID is always second (if enabled)... Seems fine for me on Windows.