### PR TITLE
Adding Ergodox EZ and Atreus Dvorak 42-key layouts

### DIFF
--- a/keyboards/atreus/keymaps/dvorak_42_key/README.md
+++ b/keyboards/atreus/keymaps/dvorak_42_key/README.md
@@ -1,0 +1,12 @@
+Overview
+========
+
+This is a dvorak based layout for the Atreus. Its basic key layout is similar to the ergodox_ez "dvorak_42_key" layout. In fact this layout was created for seamless switching between the Ergodox EZ and Atreus. 
+
+Layers
+------
+* BASE: basic dvorak layout
+* KEYNAV: arrow-key navigation. Momentary toggle held by thumb allows the right hand to navigate through text as well as copy/paste/cut, page up/page down
+* KEYSEL: similar to KEYNAV, except for shift-selection
+* COMBINED: this is a layer that combines numbers, brackets and special characters. !@#$%^&*( can be type by shift+COMBINED+1/2/3/etc..
+* MOUSE: mouse navigation, as well as browser tab-left/tab-right shortcuts

--- a/keyboards/atreus/keymaps/dvorak_42_key/README.md
+++ b/keyboards/atreus/keymaps/dvorak_42_key/README.md
@@ -3,6 +3,15 @@ Overview
 
 This is a dvorak based layout for the Atreus. Its basic key layout is similar to the ergodox_ez "dvorak_42_key" layout. In fact this layout was created for seamless switching between the Ergodox EZ and Atreus. 
 
+How to build and flash
+----------------------
+
+to build;
+make atreus-dvorak_42_key
+
+to flash:
+avrdude -p atmega32u4 -c avr109 -U flash:w:atreus_dvorak_42_key.hex  -P COM7
+
 Layers
 ------
 * BASE: basic dvorak layout

--- a/keyboards/atreus/keymaps/dvorak_42_key/config.h
+++ b/keyboards/atreus/keymaps/dvorak_42_key/config.h
@@ -1,0 +1,106 @@
+/*
+Copyright 2012 Jun Wako <wakojun@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef CONFIG_H
+#define CONFIG_H
+
+
+#include "config_common.h"
+
+
+// mouse speed
+
+#define MOUSEKEY_INTERVAL       15
+#define MOUSEKEY_DELAY          100
+#define MOUSEKEY_TIME_TO_MAX    100
+#define MOUSEKEY_MAX_SPEED      3
+
+#define MOUSEKEY_WHEEL_DELAY    500
+#define MOUSEKEY_WHEEL_DELTA    1
+#define MOUSEKEY_WHEEL_MAX_SPEED 1
+#define MOUSEKEY_WHEEL_TIME_TO_MAX 100
+
+/* USB Device descriptor parameter */
+
+#define VENDOR_ID       0xFEED
+#define PRODUCT_ID      0x6060
+#define DEVICE_VER      0x0001
+#define MANUFACTURER    Technomancy
+#define PRODUCT         Atreus
+#define DESCRIPTION     q.m.k. keyboard firmware for Atreus
+
+/* key matrix size */
+#define MATRIX_ROWS 4
+#define MATRIX_COLS 11
+
+// Change this to how you wired your keyboard
+// COLS: Left to right, ROWS: Top to bottom
+#if defined(ATREUS_ASTAR)
+#   define MATRIX_ROW_PINS { D0, D1, D3, D2 }
+#if defined(PCBDOWN)
+#   define MATRIX_COL_PINS { B7, D6, F7, F6, B6, D4, E6, B4, B5, C6, D7 }
+#else
+#   define MATRIX_COL_PINS { D7, C6, B5, B4, E6, D4, B6, F6, F7, D6, B7 }
+#endif
+#   define UNUSED_PINS
+#elif defined(ATREUS_TEENSY2)
+#   define MATRIX_ROW_PINS { D0, D1, D2, D3 }
+#   define MATRIX_COL_PINS { F6, F5, F4, B7, B6, B5, B4, B3, B2, B1, B0 }
+#   define UNUSED_PINS
+#endif
+
+/* COL2ROW or ROW2COL */
+#define DIODE_DIRECTION COL2ROW
+
+/* define if matrix has ghost */
+//#define MATRIX_HAS_GHOST
+
+/* number of backlight levels */
+//#define BACKLIGHT_LEVELS 3
+
+/* Set 0 if debouncing isn't needed */
+#define DEBOUNCING_DELAY 5
+
+/* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
+#define LOCKING_SUPPORT_ENABLE
+/* Locking resynchronize hack */
+#define LOCKING_RESYNC_ENABLE
+
+/* key combination for command */
+#define IS_COMMAND() ( \
+    keyboard_report->mods == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT)) \
+)
+
+/*
+ * Feature disable options
+ *  These options are also useful to firmware size reduction.
+ */
+
+/* disable debug print */
+//#define NO_DEBUG
+
+/* disable print */
+//#define NO_PRINT
+
+/* disable action features */
+//#define NO_ACTION_LAYER
+//#define NO_ACTION_TAPPING
+//#define NO_ACTION_ONESHOT
+//#define NO_ACTION_MACRO
+//#define NO_ACTION_FUNCTION
+
+#endif

--- a/keyboards/atreus/keymaps/dvorak_42_key/keymap.c
+++ b/keyboards/atreus/keymaps/dvorak_42_key/keymap.c
@@ -15,7 +15,7 @@
 static bool mouse_lock = false;
 
 // building instructions:
-// make ergodox_ez-dvorak_42_key-teensy
+// make atreus-dvorak_42_key
 
 // flashing instructions:
 // avrdude -p atmega32u4 -c avr109 -U flash:w:atreus_dvorak_42_key.hex  -P COM7

--- a/keyboards/atreus/keymaps/dvorak_42_key/keymap.c
+++ b/keyboards/atreus/keymaps/dvorak_42_key/keymap.c
@@ -1,0 +1,93 @@
+
+#include "atreus.h"
+
+// layers
+#define BASE      0
+#define KEYNAV    1
+#define KEYSEL    2
+#define MOUSE     3
+#define COMBINED  4
+
+// macros
+#define MOUSE_TOGGLE 1
+#define MOUSE_LOCK 2
+
+static bool mouse_lock = false;
+
+// building instructions:
+// make ergodox_ez-dvorak_42_key-teensy
+
+// flashing instructions:
+// avrdude -p atmega32u4 -c avr109 -U flash:w:atreus_dvorak_42_key.hex  -P COM7
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+	
+[BASE] = { 
+  {KC_QUOTE,      KC_COMMA,      KC_DOT,    KC_P,       KC_Y,         KC_TRNS,    KC_F,  KC_G,  KC_C,   KC_R,   KC_L, },
+  {KC_A,          KC_O,          KC_E,      KC_U,       KC_I,         KC_TRNS,    KC_D,  KC_H,  KC_T,   KC_N,   KC_S, },
+  {KC_SCOLON,     KC_Q,          KC_J,      KC_K,       KC_X,         MO(KEYNAV), KC_B,  KC_M,  KC_W,   KC_V,   KC_Z, },
+  {OSM(MOD_LSFT), OSM(MOD_LCTL), M(MOUSE_TOGGLE), MO(KEYSEL), MO(COMBINED), KC_ENTER,   KC_SPACE,  KC_BSPC, RCTL(KC_BSPC), KC_CAPSLOCK, OSM(MOD_LSFT), }
+},	
+
+[KEYNAV] = { 
+  {KC_ESC,    MEH(KC_A), RCTL(KC_Z),   RCTL(KC_S), MEH(KC_B), KC_TRNS,    KC_TRNS,       KC_HOME,    KC_UP,           KC_END,     KC_PGUP, },
+  {MEH(KC_C), MEH(KC_D), RSFT(KC_TAB), KC_TAB,     MEH(KC_E), KC_TRNS,    LCTL(KC_LEFT), KC_LEFT,    KC_DOWN,         KC_RIGHT,   LCTL(KC_RIGHT), },
+  {MEH(KC_F), MEH(KC_G), MEH(KC_H),    MEH(KC_I),  MEH(KC_J), KC_TRNS,    KC_TRNS,       RCTL(KC_C), RCTL(KC_X),      RCTL(KC_V), KC_PGDOWN, },
+  {KC_TRNS, KC_TRNS,   KC_TRNS,      KC_TRNS,    KC_TRNS,   KC_ENTER,   KC_SPACE,      KC_BSPC,   RCTL(KC_BSPC),    KC_DELETE,  LCTL(KC_DELETE), }
+},	
+
+[KEYSEL] = { 
+  {KC_TRNS, KC_TRNS, RCTL(KC_Z),   RCTL(KC_S), KC_TRNS, KC_TRNS,    KC_TRNS,             RSFT(KC_HOME), RSFT(KC_UP),  RSFT(KC_END), RSFT(KC_PGUP), },
+  {KC_TRNS, KC_TRNS, RSFT(KC_TAB), KC_TAB,     KC_TRNS, KC_TRNS,    RSFT(RCTL(KC_LEFT)), RSFT(KC_LEFT), RSFT(KC_DOWN), RSFT(KC_RIGHT), RSFT(RCTL(KC_RIGHT)), },
+  {KC_TRNS, KC_TRNS, KC_TRNS,      KC_TRNS,    KC_TRNS, KC_TRNS,    KC_TRNS,             RCTL(KC_C),RCTL(KC_X),     RCTL(KC_V), RSFT(KC_PGDN), },
+  {RESET,   KC_TRNS, KC_TRNS,      KC_TRNS,    KC_TRNS, KC_ENTER,   KC_SPACE,            KC_BSPC,   RCTL(KC_BSPC),  KC_DELETE,  LCTL(KC_DELETE), }
+},	
+
+[COMBINED] = { 
+  {KC_ESC,  KC_LABK, KC_RABK,     KC_DQUO,     KC_GRAVE, KC_TRNS,    KC_PLUS,     KC_7,    KC_8,    KC_9,    KC_ASTR, },
+  {KC_LPRN, KC_RPRN, KC_LBRACKET, KC_RBRACKET, KC_UNDS,  KC_TRNS,    KC_MINS,     KC_4,    KC_5,    KC_6,    KC_SLSH, },
+  {KC_LCBR, KC_RCBR, KC_BSLS,     KC_PIPE,     KC_TILD,  KC_TRNS,    KC_EQUAL,    KC_1,    KC_2,    KC_3,    KC_QUES, },
+  {KC_TRNS, KC_TRNS, KC_TRNS,     KC_TRNS,     KC_TRNS,  KC_TRNS,    KC_TRNS,     KC_0,  KC_DOT,  KC_TRNS, KC_TRNS, }
+},	
+
+[MOUSE] = { 
+  {KC_TRNS,      KC_PGUP, KC_MS_WH_UP,   KC_UP,        KC_TRNS, KC_TRNS, KC_UP,     KC_HOME,   KC_MS_U,   KC_END,  KC_MS_WH_UP,  },
+  {KC_MS_ACCEL0, KC_PGDN, KC_MS_WH_DOWN, KC_DOWN,      KC_TRNS, KC_TRNS, KC_DOWN,   KC_MS_L,   KC_MS_D,   KC_MS_R, KC_MS_WH_DOWN, },
+  {KC_TRNS,      KC_TRNS, KC_TRNS,       KC_TRNS,      KC_TRNS, KC_BTN3, MEH(KC_X), MEH(KC_Y), MEH(KC_Z), KC_F5,   RCTL(KC_W), },
+  {KC_TRNS, M(MOUSE_LOCK), KC_TRNS, KC_MS_ACCEL0, KC_TRNS, KC_BTN1, KC_BTN2, RSFT(RCTL(KC_TAB)), RCTL(KC_TAB), RCTL(KC_T), LALT(KC_LEFT), }
+},	
+
+
+};
+
+const uint16_t PROGMEM fn_actions[] = {
+
+};
+
+const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
+{
+  // MACRODOWN only works in this function
+      switch(id) {
+		case MOUSE_TOGGLE:
+            if (record->event.pressed) {
+				layer_on(MOUSE);
+            } else {
+				if(!mouse_lock)
+					layer_off(MOUSE);
+			}
+			break;
+		case MOUSE_LOCK:
+			if (record->event.pressed)
+			{
+				if(mouse_lock)
+				{
+					mouse_lock = false;
+					layer_off(MOUSE);
+				}
+				else
+					mouse_lock = true;
+			}
+			break;		  
+      }
+    return MACRO_NONE;
+};

--- a/keyboards/ergodox_ez/keymaps/dvorak_42_key/README.md
+++ b/keyboards/ergodox_ez/keymaps/dvorak_42_key/README.md
@@ -3,6 +3,10 @@ Overview
 
 This is a dvorak based layout for the Ergodox EZ. Its basic key layout is similar to the Atreus "dvorak_42_key" layout. In fact this layout was created for seamless switching between the Ergodox EZ and Atreus. On the base layer, the keys that don't exist on the Atreus are mapped to MEH shortcuts and can be interpreted by Autohotkey. This layout only makes use of the 42 keys that the Atreus also has for the main functionality. 
 
+How to build 
+------------
+make ergodox_ez-dvorak_42_key-teensy
+
 Layers
 ------
 * BASE: basic dvorak layout

--- a/keyboards/ergodox_ez/keymaps/dvorak_42_key/README.md
+++ b/keyboards/ergodox_ez/keymaps/dvorak_42_key/README.md
@@ -1,0 +1,13 @@
+Overview
+========
+
+This is a dvorak based layout for the Ergodox EZ. Its basic key layout is similar to the Atreus "dvorak_42_key" layout. In fact this layout was created for seamless switching between the Ergodox EZ and Atreus. On the base layer, the keys that don't exist on the Atreus are mapped to MEH shortcuts and can be interpreted by Autohotkey. This layout only makes use of the 42 keys that the Atreus also has for the main functionality. 
+
+Layers
+------
+* BASE: basic dvorak layout
+* KEYNAV: arrow-key navigation. Momentary toggle held by thumb allows the right hand to navigate through text as well as copy/paste/cut, page up/page down
+* KEYSEL: similar to KEYNAV, except for shift-selection
+* COMBINED: this is a layer that combines numbers, brackets and special characters. !@#$%^&*( can be type by shift+COMBINED+1/2/3/etc..
+* MOUSE: mouse navigation, as well as browser tab-left/tab-right shortcuts
+* SHELL_NAV: Linux Bash shortcuts (move forward/backward in command line, move between screen windows, Ctrl+C, recall last argument, etc

--- a/keyboards/ergodox_ez/keymaps/dvorak_42_key/keymap.c
+++ b/keyboards/ergodox_ez/keymaps/dvorak_42_key/keymap.c
@@ -1,0 +1,319 @@
+#include QMK_KEYBOARD_H
+#include "debug.h"
+#include "action_layer.h"
+#include "version.h"
+
+
+static bool mouse_lock = false;
+
+enum custom_keycodes {
+  PLACEHOLDER = SAFE_RANGE, // can always be here
+  EPRM,
+  VRSN,
+  RGB_SLD,
+  
+};
+
+// make ergodox-dvorak_atreus_like-teensy
+
+#define BASE      0 // base dvorak layer
+#define KEYNAV    1 // arrow navigation (right hand)
+#define KEYSEL    2 // arrow navigation + shift (allow text selection)
+#define SHELL_NAV 3 // bash shortcuts
+#define MOUSE     4 // mouse layer (can be locked with lock key)
+#define COMBINED  5 // combined numbers and symbols layer
+
+// macros
+#define MOUSE_TOGGLE 1
+#define MOUSE_LOCK 2
+#define SCREEN_TAB_LEFT 4
+#define SCREEN_TAB_RIGHT 5
+#define SCREEN_NEW_TAB 6
+#define SWITCH_NDS 7
+#define SCREEN_COPY_MODE 8
+#define SCREEN_PASTE 9
+#define SHELL_RECALL_LAST_ARG_REMOVE_FIRST_COMMAND 15
+
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+  [BASE] = KEYMAP(
+	  // left hand
+	  KC_ESC,         KC_F1,         KC_F2,      KC_F3,        KC_F4,   KC_F5,   KC_F6,
+	  KC_TAB,         KC_QUOTE,      KC_COMMA,   KC_DOT,       KC_P,    KC_Y,    MEH(KC_2),
+	  MO(SHELL_NAV),  KC_A,          KC_O,       KC_E,         KC_U,    KC_I,
+	  MEH(KC_0),      KC_SCOLON,     KC_Q,       KC_J,         KC_K,    KC_X,    MEH(KC_3),
+	  MEH(KC_1),      OSM(MOD_LSFT), OSM(MOD_LCTL), M(MOUSE_TOGGLE), MO(KEYSEL),
+	  
+	  // left thumb cluster
+	            MEH(KC_4),      MEH(KC_5),
+	                            MEH(KC_6),
+	  MO(COMBINED),MO(KEYNAV),  OSM(MOD_LALT),
+	  
+	  // right hand
+	  KC_F7,     KC_F8, KC_F9, KC_F10, KC_F11, KC_F12, MEH(KC_9),
+	  MEH(KC_7), KC_F,  KC_G,  KC_C,   KC_R,   KC_L,   MEH(KC_F1),
+			     KC_D,  KC_H,  KC_T,   KC_N,   KC_S,   MEH(KC_F2),
+	  MEH(KC_8), KC_B,  KC_M,  KC_W,   KC_V,   KC_Z,   MEH(KC_F3),
+	  KC_BSPC,   RCTL(KC_BSPC), KC_CAPSLOCK, OSM(MOD_LSFT),MEH(KC_F4),
+    
+	  // right thumb cluster
+	  MEH(KC_F5),MEH(KC_F6),MEH(KC_F7),MEH(KC_F8),KC_ENTER,KC_SPACE
+  
+  ),
+  
+  [KEYNAV] = KEYMAP(
+	// left hand
+	KC_TRNS,KC_TRNS,     KC_TRNS,     KC_TRNS,      KC_TRNS,    KC_TRNS,     KC_TRNS,
+	KC_TRNS,KC_ESC,      MEH(KC_F9),  RCTL(KC_Z),   RCTL(KC_S), MEH(KC_F10), KC_TRNS,
+	KC_TRNS,MEH(KC_F11), MEH(KC_F12), RSFT(KC_TAB), KC_TAB,     MEH(KC_A),
+	KC_TRNS,MEH(KC_B),   MEH(KC_C),   MEH(KC_D),    MEH(KC_E),  MEH(KC_F),   KC_TRNS,
+	KC_TRNS,KC_TRNS,     KC_TRNS,     KC_TRNS,      KC_TRNS,
+	// left thumb cluster
+	KC_TRNS,KC_TRNS,KC_TRNS,TO(MOUSE),KC_TRNS,KC_TRNS,
+	
+	// right hand
+	KC_TRNS,KC_TRNS,       KC_TRNS,    KC_TRNS,         KC_TRNS,    KC_TRNS,         KC_TRNS,
+	KC_TRNS,KC_NO,         KC_HOME,    KC_UP,           KC_END,     KC_PGUP,         KC_TRNS,
+	        LCTL(KC_LEFT), KC_LEFT,    KC_DOWN,         KC_RIGHT,   LCTL(KC_RIGHT),  KC_TRNS,
+	KC_TRNS,KC_NO,         RCTL(KC_C), RCTL(KC_X),      RCTL(KC_V), KC_PGDOWN,       KC_TRNS,
+	                       KC_BSPC,   RCTL(KC_BSPC),    KC_DELETE,  LCTL(KC_DELETE), KC_TRNS,
+	
+	// right thumb cluster
+	KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS
+  ),  
+  
+	// key selection layer
+	[KEYSEL] = KEYMAP(
+		   // left hand
+		   KC_TRNS,KC_TRNS,   KC_TRNS,  KC_TRNS,   KC_TRNS,   KC_TRNS,   KC_TRNS,
+		   KC_TRNS,MEH(KC_G), MEH(KC_H),MEH(KC_I), MEH(KC_J), MEH(KC_K), KC_TRNS,
+		   KC_TRNS,MEH(KC_L), MEH(KC_M),MEH(KC_N), MEH(KC_O), MEH(KC_P),
+		   KC_TRNS,MEH(KC_Q), MEH(KC_R),MEH(KC_S), MEH(KC_T), MEH(KC_U), KC_TRNS,
+				   // bottom row
+				   KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,
+										   // thumb cluster
+										   KC_TRNS,KC_TRNS,
+												   KC_TRNS,
+								   KC_TRNS,KC_TRNS,KC_TRNS,
+		   // right hand
+		   KC_TRNS,       KC_TRNS,             KC_TRNS,       KC_TRNS,       KC_TRNS,        KC_TRNS,              KC_TRNS,
+		   RSFT(KC_PGUP), KC_TRNS,             RSFT(KC_HOME), RSFT(KC_UP),   RSFT(KC_END),   RSFT(KC_PGUP),        KC_TRNS,
+						  RSFT(RCTL(KC_LEFT)), RSFT(KC_LEFT), RSFT(KC_DOWN), RSFT(KC_RIGHT), RSFT(RCTL(KC_RIGHT)), KC_TRNS,
+		   RSFT(KC_PGDN), KC_TRNS,             RCTL(KC_C),    RCTL(KC_X),    RCTL(KC_V),     RSFT(KC_PGDN),        KC_TRNS,
+					// bottom row
+					KC_BSPC,   RCTL(KC_BSPC),    KC_DELETE,  LCTL(KC_DELETE),    KC_TRNS,
+		   // thumb cluster
+		   KC_TRNS, KC_TRNS,
+		   KC_TRNS,
+		   KC_TRNS, KC_TRNS, KC_TRNS
+	),  
+  
+  // shell navigation layer
+  [SHELL_NAV] = KEYMAP(
+       // left hand
+       KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,
+       KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,
+       KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,
+       KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,
+               // bottom row
+               KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,
+                                       // thumb cluster
+                                       KC_TRNS,KC_TRNS,
+                                               LALT(KC_D),
+                               KC_TRNS,RCTL(KC_W),KC_TRNS,
+       // right hand
+       KC_TRNS,    KC_TRNS,        KC_TRNS,             KC_TRNS,         KC_TRNS,         KC_TRNS,        M(SWITCH_NDS),
+       RCTL(KC_L), RCTL(KC_W),     KC_HOME,             KC_UP,           KC_END,          LALT(KC_D),     RCTL(KC_R),
+                   LALT(KC_B),     KC_LEFT,             KC_DOWN,         KC_RIGHT,        LALT(KC_F),     LALT(KC_DOT),
+       RCTL(KC_C), RCTL(KC_U),     M(SCREEN_COPY_MODE), M(SCREEN_PASTE), MEH(KC_V),      RCTL(KC_K),     M(SHELL_RECALL_LAST_ARG_REMOVE_FIRST_COMMAND),
+                // bottom row
+                 M(SCREEN_TAB_LEFT), M(SCREEN_TAB_RIGHT), M(SCREEN_NEW_TAB),  KC_TRNS,    KC_TRNS,
+       // thumb cluster
+       KC_TRNS, KC_TRNS,
+       KC_TRNS,
+       KC_TRNS, KC_TRNS, KC_TRNS
+  ),
+  
+
+  
+  [COMBINED] = KEYMAP(
+  
+	// left hand
+	KC_NO,  KC_TRNS, KC_TRNS,    KC_TRNS,     KC_TRNS,     KC_TRNS,KC_TRNS,
+	KC_TRNS,KC_ESC,  KC_LABK,    KC_RABK,     KC_DQUO,     KC_GRAVE,KC_TRNS,
+	KC_TRNS,KC_LPRN, KC_RPRN,    KC_LBRACKET, KC_RBRACKET, KC_UNDS,
+	KC_TRNS,KC_LCBR, KC_RCBR,    KC_BSLS,     KC_PIPE,     KC_TILD,KC_TRNS,
+	// bottom row
+	KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,
+	// thumb cluster
+	KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,
+	
+	// right hand
+	KC_TRNS, KC_TRNS,     KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,     KC_TRNS,
+	KC_TRNS, KC_PLUS,     KC_7,    KC_8,    KC_9,    KC_ASTR,     KC_TRNS,
+	         KC_MINS,     KC_4,    KC_5,    KC_6,    KC_SLSH,     KC_TRNS,
+	KC_TRNS, KC_EQUAL,    KC_1,    KC_2,    KC_3,    KC_QUES,     KC_TRNS,
+	// bottom row 
+	                      KC_0,  KC_DOT,  KC_TRNS, KC_TRNS,     KC_TRNS,
+	// thumb cluster
+	KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS),
+  
+  
+	[MOUSE] = KEYMAP(
+		   KC_TRNS, KC_TRNS,      KC_TRNS,       KC_TRNS,       KC_TRNS,      KC_TRNS, KC_TRNS,
+		   KC_TRNS, KC_TRNS,      KC_PGUP,       KC_MS_WH_UP,   KC_UP,        KC_TRNS, KC_TRNS,
+		   KC_TRNS, KC_MS_ACCEL0, KC_PGDN,       KC_MS_WH_DOWN, KC_DOWN,      KC_TRNS,
+		   KC_TRNS, KC_TRNS,      KC_TRNS,       KC_TRNS,       KC_TRNS,      KC_TRNS, KC_TRNS,
+		   KC_TRNS, KC_TRNS,      M(MOUSE_LOCK), KC_TRNS,       KC_MS_ACCEL0,
+		   
+											   KC_TRNS, KC_TRNS,
+														KC_TRNS,
+									  KC_TRNS, KC_BTN3, KC_TRNS,
+		// right hand
+		   KC_TRNS,  KC_TRNS,   KC_TRNS,      KC_TRNS,      KC_TRNS,      KC_TRNS,       KC_TRNS,
+		   KC_TRNS,  KC_UP,     KC_HOME,      KC_MS_U,      KC_END,       KC_MS_WH_UP,   KC_TRNS,
+					 KC_DOWN,   KC_MS_L,      KC_MS_D,      KC_MS_R,      KC_MS_WH_DOWN, KC_TRNS,
+		   KC_TRNS,  MEH(KC_X), MEH(KC_Y),    MEH(KC_Z),    KC_F5,        RCTL(KC_W),    KC_TRNS,
+									// browser tab control
+							        RSFT(RCTL(KC_TAB)), RCTL(KC_TAB), RCTL(KC_T), LALT(KC_LEFT), KC_TRNS,
+		   KC_TRNS, KC_TRNS,
+		   KC_TRNS,
+		   KC_TRNS, KC_BTN1, KC_BTN2
+	),  
+	
+
+};
+
+const uint16_t PROGMEM fn_actions[] = {
+  [1] = ACTION_LAYER_TAP_TOGGLE(1)
+};
+
+// leaving this in place for compatibilty with old keymaps cloned and re-compiled.
+const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
+{
+      switch(id) {
+		case MOUSE_TOGGLE:
+            if (record->event.pressed) {
+				layer_on(MOUSE);
+            } else {
+				if(!mouse_lock)
+					layer_off(MOUSE);
+			}
+			break;
+		case MOUSE_LOCK:
+			if (record->event.pressed)
+			{
+				if(mouse_lock)
+				{
+					mouse_lock = false;
+					layer_off(MOUSE);
+				}
+				else
+					mouse_lock = true;
+			}
+			break;
+        case SCREEN_TAB_LEFT:
+            if (record->event.pressed) {
+                return MACRO( D(LCTL), T(A), U(LCTL), T(P), END);
+            }        
+            break;
+        case SCREEN_TAB_RIGHT:
+             if (record->event.pressed) {
+                return MACRO( D(LCTL), T(A), U(LCTL), T(N), END);
+            }                    
+            break;
+        case SCREEN_NEW_TAB:
+             if (record->event.pressed) {
+                return MACRO( D(LCTL), T(A), U(LCTL), T(C), END);
+            }                                
+        break;
+        case SCREEN_COPY_MODE:
+            if (record->event.pressed) {
+                return MACRO( D(LCTL), T(A), U(LCTL), T(ESC), END);
+            }
+        break;
+        case SCREEN_PASTE:
+            if (record->event.pressed) {
+                return MACRO( D(LCTL), T(A), U(LCTL), T(RBRC), END); 
+            }
+        break;        
+        case SWITCH_NDS:
+            if (record->event.pressed) {
+                return MACRO( D(LSFT), 
+							  T(F11), 
+							  U(LSFT), 
+							  W(255), 
+							  D(LALT), 
+							  T(TAB), 
+							  U(LALT), 
+							  END); 
+            }                                
+        break;        
+        case SHELL_RECALL_LAST_ARG_REMOVE_FIRST_COMMAND:
+            if (record->event.pressed) {
+                return MACRO( T(UP), T(HOME), D(LALT), T(D), U(LALT), END);
+            }
+        break;                                
+      }
+    return MACRO_NONE;
+};
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  switch (keycode) {
+    // dynamically generate these.
+    case EPRM:
+      if (record->event.pressed) {
+        eeconfig_init();
+      }
+      return false;
+      break;
+    case VRSN:
+      if (record->event.pressed) {
+        SEND_STRING (QMK_KEYBOARD "/" QMK_KEYMAP " @ " QMK_VERSION);
+      }
+      return false;
+      break;
+    case RGB_SLD:
+      if (record->event.pressed) {
+        rgblight_mode(1);
+      }
+      return false;
+      break;
+    
+  }
+  return true;
+}
+
+void led_set_user(uint8_t usb_led) {
+    if (usb_led & (1<<USB_LED_CAPS_LOCK)) {
+        ergodox_right_led_1_on();
+    } else {
+        ergodox_right_led_1_off();
+    }
+}
+
+void matrix_scan_user(void) {
+
+    uint8_t layer = biton32(layer_state);
+
+    ergodox_board_led_off();
+    ergodox_right_led_2_off();
+    ergodox_right_led_3_off();
+    switch (layer) {
+		case COMBINED:
+		    ergodox_right_led_2_on();		
+			break;
+	    case KEYNAV:
+		case KEYSEL:
+		    ergodox_right_led_3_on();
+			break;
+        case MOUSE:
+            ergodox_right_led_2_on();
+            ergodox_right_led_3_on();
+            break;
+        default:
+            break;
+    }
+
+};

--- a/keyboards/ergodox_ez/keymaps/dvorak_42_key/keymap.c
+++ b/keyboards/ergodox_ez/keymaps/dvorak_42_key/keymap.c
@@ -17,7 +17,6 @@ enum custom_keycodes {
   
 };
 
-// make ergodox-dvorak_atreus_like-teensy
 
 #define BASE      0 // base dvorak layer
 #define KEYNAV    1 // arrow navigation (right hand)

--- a/keyboards/ergodox_ez/keymaps/dvorak_42_key/keymap.c
+++ b/keyboards/ergodox_ez/keymaps/dvorak_42_key/keymap.c
@@ -4,6 +4,9 @@
 #include "version.h"
 
 
+// to build this keymap
+// make ergodox_ez-dvorak_42_key-teensy
+
 static bool mouse_lock = false;
 
 enum custom_keycodes {

--- a/keyboards/ergodox_ez/keymaps/dvorak_42_key/keymap.c
+++ b/keyboards/ergodox_ez/keymaps/dvorak_42_key/keymap.c
@@ -75,11 +75,11 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 	KC_TRNS,KC_TRNS,KC_TRNS,TO(MOUSE),KC_TRNS,KC_TRNS,
 	
 	// right hand
-	KC_TRNS,KC_TRNS,       KC_TRNS,    KC_TRNS,         KC_TRNS,    KC_TRNS,         KC_TRNS,
-	KC_TRNS,KC_NO,         KC_HOME,    KC_UP,           KC_END,     KC_PGUP,         KC_TRNS,
-	        LCTL(KC_LEFT), KC_LEFT,    KC_DOWN,         KC_RIGHT,   LCTL(KC_RIGHT),  KC_TRNS,
-	KC_TRNS,KC_NO,         RCTL(KC_C), RCTL(KC_X),      RCTL(KC_V), KC_PGDOWN,       KC_TRNS,
-	                       KC_BSPC,   RCTL(KC_BSPC),    KC_DELETE,  LCTL(KC_DELETE), KC_TRNS,
+	KC_TRNS,KC_TRNS,       KC_TRNS,    KC_TRNS,         KC_TRNS,    KC_TRNS,         MEH(KC_G),
+	KC_TRNS,KC_NO,         KC_HOME,    KC_UP,           KC_END,     KC_PGUP,         MEH(KC_H),
+	        LCTL(KC_LEFT), KC_LEFT,    KC_DOWN,         KC_RIGHT,   LCTL(KC_RIGHT),  MEH(KC_I),
+	KC_TRNS,KC_NO,         RCTL(KC_C), RCTL(KC_X),      RCTL(KC_V), KC_PGDOWN,       MEH(KC_J),
+	                       KC_BSPC,   RCTL(KC_BSPC),    KC_DELETE,  LCTL(KC_DELETE), MEH(KC_K),
 	
 	// right thumb cluster
 	KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS
@@ -99,12 +99,12 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 												   KC_TRNS,
 								   KC_TRNS,KC_TRNS,KC_TRNS,
 		   // right hand
-		   KC_TRNS,       KC_TRNS,             KC_TRNS,       KC_TRNS,       KC_TRNS,        KC_TRNS,              KC_TRNS,
-		   RSFT(KC_PGUP), KC_TRNS,             RSFT(KC_HOME), RSFT(KC_UP),   RSFT(KC_END),   RSFT(KC_PGUP),        KC_TRNS,
-						  RSFT(RCTL(KC_LEFT)), RSFT(KC_LEFT), RSFT(KC_DOWN), RSFT(KC_RIGHT), RSFT(RCTL(KC_RIGHT)), KC_TRNS,
-		   RSFT(KC_PGDN), KC_TRNS,             RCTL(KC_C),    RCTL(KC_X),    RCTL(KC_V),     RSFT(KC_PGDN),        KC_TRNS,
+		   KC_TRNS,       KC_TRNS,             KC_TRNS,       KC_TRNS,       KC_TRNS,        KC_TRNS,              MEH(KC_Q),
+		   RSFT(KC_PGUP), KC_TRNS,             RSFT(KC_HOME), RSFT(KC_UP),   RSFT(KC_END),   RSFT(KC_PGUP),        MEH(KC_R),
+						  RSFT(RCTL(KC_LEFT)), RSFT(KC_LEFT), RSFT(KC_DOWN), RSFT(KC_RIGHT), RSFT(RCTL(KC_RIGHT)), MEH(KC_S),
+		   RSFT(KC_PGDN), KC_TRNS,             RCTL(KC_C),    RCTL(KC_X),    RCTL(KC_V),     RSFT(KC_PGDN),        MEH(KC_T),
 					// bottom row
-					KC_BSPC,   RCTL(KC_BSPC),    KC_DELETE,  LCTL(KC_DELETE),    KC_TRNS,
+					KC_BSPC,   RCTL(KC_BSPC),    KC_DELETE,  LCTL(KC_DELETE),                                      MEH(KC_U),
 		   // thumb cluster
 		   KC_TRNS, KC_TRNS,
 		   KC_TRNS,
@@ -152,12 +152,12 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 	KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,
 	
 	// right hand
-	KC_TRNS, KC_TRNS,     KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,     KC_TRNS,
-	KC_TRNS, KC_PLUS,     KC_7,    KC_8,    KC_9,    KC_ASTR,     KC_TRNS,
-	         KC_MINS,     KC_4,    KC_5,    KC_6,    KC_SLSH,     KC_TRNS,
-	KC_TRNS, KC_EQUAL,    KC_1,    KC_2,    KC_3,    KC_QUES,     KC_TRNS,
+	KC_TRNS, KC_TRNS,     KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,     MEH(KC_L),
+	KC_TRNS, KC_PLUS,     KC_7,    KC_8,    KC_9,    KC_ASTR,     MEH(KC_M),
+	         KC_MINS,     KC_4,    KC_5,    KC_6,    KC_SLSH,     MEH(KC_N),
+	KC_TRNS, KC_EQUAL,    KC_1,    KC_2,    KC_3,    KC_QUES,     MEH(KC_O),
 	// bottom row 
-	                      KC_0,  KC_DOT,  KC_TRNS, KC_TRNS,     KC_TRNS,
+	                      KC_0,  KC_DOT,  KC_TRNS, KC_TRNS,     MEH(KC_P),
 	// thumb cluster
 	KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS),
   


### PR DESCRIPTION
Adding Ergodox EZ and Atreus Dvorak 42-key layouts. These two layouts are meant to allow easy switching between the two keyboards.