### PR TITLE
Update Mechmini keymap, reduce reported power consumption for iOS Cam…

### DIFF
--- a/keyboards/mechmini/keymaps/default/keymap.c
+++ b/keyboards/mechmini/keymaps/default/keymap.c
@@ -14,15 +14,48 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include "mechmini.h"
+#define _BL 0
+#define _FN1 1
+#define _FN2 2
+#define _FN3 3
+#define _____ KC_TRNS
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    KEYMAP(
-        TAB,  Q,    W,    E,    R,    T,    Y,    U,   I,    O,    P,    BSLS,
-        LCTL, A,    S,    D,    F,    G,    H,    J,   K,    L,    SCLN,
-        LSFT, Z,    X,    C,    V,    B,    N,    M,   COMM, DOT,  SLSH,
-        GRV,  LALT, LGUI,       SPC,        ENT,       RGUI, RALT, RCTL
-    )
+   [_BL] = KEYMAP(
+     KC_ESC,     KC_Q,       KC_W,       KC_E,     KC_R,     KC_T,     KC_Y,     KC_U,     KC_I,     KC_O,     KC_P,     KC_BSPC,
+     KC_TAB,     KC_A,       KC_S,       KC_D,     KC_F,     KC_G,     KC_H,     KC_J,     KC_K,     KC_L,     KC_ENT,
+     KC_LSFT,    KC_Z,       KC_X,       KC_C,     KC_V,     KC_B,     KC_N,     KC_M,     KC_COMM,  KC_DOT,   MO(_FN2),
+     KC_LCTL,    KC_LGUI,    KC_LALT,         _____,         KC_SPC,        _____,                   MO(_FN1), MO(_FN3)
+   ),
+   [_FN1] = KEYMAP(
+     _____,      _____,      KC_UP,      KC_MUTE,  KC_VOLD,  KC_VOLU,  KC_MRWD,  KC_MPLY,  KC_MFFD,  KC_SLCK,  KC_PAUS,  KC_DEL,
+     KC_CAPS,    KC_LEFT,    KC_DOWN,    KC_RIGHT, _____,    _____,    _____,    KC_INS,   KC_HOME,  KC_PGUP,  KC_PSCR,
+     _____,      _____,      _____,      _____,    _____,    _____,    _____,    KC_END,   KC_PGDN,  _____,    _____,
+     _____,      _____,      _____,            _____,        _____,         _____,                   _____,    _____
+   ),
+   [_FN2] = KEYMAP(
+     KC_GRAVE,   KC_1,       KC_2,       KC_3,     KC_4,     KC_5,     KC_6,     KC_7,     KC_8,     KC_9,     KC_0,     KC_DEL,
+     KC_CAPS,    _____,      _____,      _____,    _____,    KC_LBRC,  KC_RBRC,  KC_BSLS,  KC_MINS,  KC_EQL,   _____,
+     _____,      _____,      _____,      _____,    _____,    _____,    _____,    KC_SCLN,  KC_QUOT,  KC_SLSH,  _____,
+     _____,      _____,      _____,            _____,        _____,         _____,                   _____,    _____
+   ),
+   [_FN3] = KEYMAP(
+     KC_F1,      KC_F2,      KC_F3,      KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,
+     _____,      _____,      _____,      _____,    _____,    _____,    _____,    _____,    _____,    _____,    _____,
+     _____,      _____,      _____,      _____,    _____,    _____,    _____,    _____,    _____,    _____,    _____,
+     _____,      _____,      _____,            _____,        _____,         _____,                   _____,    _____
+   )
 };
+
+/**
+ * Blank keymap
+ [0] = KEYMAP(
+   _____,      _____,      _____,      _____,    _____,    _____,    _____,    _____,    _____,    _____,    _____,    _____
+   _____,      _____,      _____,      _____,    _____,    _____,    _____,    _____,    _____,    _____,    _____,
+   _____,      _____,      _____,      _____,    _____,    _____,    _____,    _____,    _____,    _____,    _____,
+   _____,      _____,      _____,            _____,        _____,         _____,                   _____,    _____
+ )
+ */
 
 const uint16_t PROGMEM fn_actions[] = {
 };

--- a/keyboards/mechmini/mechmini.h
+++ b/keyboards/mechmini/mechmini.h
@@ -20,18 +20,19 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "keycode.h"
 #include "action.h"
+#include "quantum.h"
 
 #define KEYMAP( \
     K03, K13, K23, K33, K43, K53, K26, KC6, KC7, K27, KA3, KB3, \
     K02, K12, K22, K32, K42, K52, K36, KD6, KD7, K37, KA2, \
     K01, K11, K21, K31, K41, K51, K46, KE6, KE7, K47, KA1, \
-    K00, K10, K20,      K56,      K57,      KB0, KC0, K66  \
+    K00, K10, K20,      K56, K57, KB0,           KC0, K66  \
 ) \
 { \
-    { KC_##K00, KC_##K10, KC_##K20, KC_##K56, KC_NO,    KC_NO,    KC_##K57, KC_NO,    KC_##KB0, KC_##KC0, KC_##K66, KC_NO,    KC_NO,    KC_NO,    KC_NO }, \
-    { KC_##K01, KC_##K11, KC_##K21, KC_##K31, KC_##K41, KC_##K51, KC_##K46, KC_##KE6, KC_##KE7, KC_##K47, KC_##KA1, KC_NO,    KC_NO,    KC_NO,    KC_NO }, \
-    { KC_##K02, KC_##K12, KC_##K22, KC_##K32, KC_##K42, KC_##K52, KC_##K36, KC_##KD6, KC_##KD7, KC_##K37, KC_##KA2, KC_NO,    KC_NO,    KC_NO,    KC_NO }, \
-    { KC_##K03, KC_##K13, KC_##K23, KC_##K33, KC_##K43, KC_##K53, KC_##K26, KC_##KC6, KC_##KC7, KC_##K27, KC_##KA3, KC_##KB3, KC_NO,    KC_NO,    KC_NO }, \
+    { K00, K10, K20, K56, KC_NO,    K57,    KC_NO, KC_NO,    KB0, KC0, K66, KC_NO,    KC_NO,    KC_NO,    KC_NO }, \
+    { K01, K11, K21, K31, K41, K51, K46, KE6, KE7, K47, KA1, KC_NO,    KC_NO,    KC_NO,    KC_NO }, \
+    { K02, K12, K22, K32, K42, K52, K36, KD6, KD7, K37, KA2, KC_NO,    KC_NO,    KC_NO,    KC_NO }, \
+    { K03, K13, K23, K33, K43, K53, K26, KC6, KC7, K27, KA3, KB3, KC_NO,    KC_NO,    KC_NO }, \
     { KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO }, \
     { KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO }, \
     { KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO }, \

--- a/keyboards/mechmini/usbconfig.h
+++ b/keyboards/mechmini/usbconfig.h
@@ -118,7 +118,7 @@ section at the end of this file).
 /* Define this to 1 if the device has its own power supply. Set it to 0 if the
  * device is powered from the USB bus.
  */
-#define USB_CFG_MAX_BUS_POWER           500
+#define USB_CFG_MAX_BUS_POWER           100
 /* Set this variable to the maximum USB bus power consumption of your device.
  * The value is in milliamperes. [It will be divided by two since USB
  * communicates power requirements in units of 2 mA.]


### PR DESCRIPTION
…era Adapter compatibility

Updated the Mechmini keymap file:
- the `KEYMAP()` macro defined in `mechmini.h` previously prepends every entry with KC_ making it impossible to use `M()` and other functions
- update layout with multiple layers
- add support for standard spacebar build - current keymap only supports split spacebar
- reduce reported power draw (since I presume QMK does not support underglow for the Mechmini yet) for compatibility with iOS devices using the USB Camera Adapter