### PR TITLE
Add shell.nix for NixOS users

### DIFF
--- a/docs/getting_started_build_tools.md
+++ b/docs/getting_started_build_tools.md
@@ -36,7 +36,15 @@ Debian/Ubuntu example:
     sudo apt-get update
     sudo apt-get install gcc unzip wget zip gcc-avr binutils-avr avr-libc dfu-programmer dfu-util gcc-arm-none-eabi binutils-arm-none-eabi libnewlib-arm-none-eabi
 
-# Mac
+## Nix
+
+If you're on [NixOS](https://nixos.org/), or have Nix installed on Linux or macOS, run `nix-shell` from the repository root to get a build environment.
+
+By default, this will download compilers for both AVR and ARM. If you don't need both, disable the `avr` or `arm` arguments, e.g.:
+
+    nix-shell --arg arm false
+
+## Mac
 If you're using [homebrew,](http://brew.sh/) you can use the following commands:
 
     brew tap osx-cross/avr

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,26 @@
+{ pkgs ? import <nixpkgs> {}
+, avr ? true, arm ? true }:
+
+with pkgs;
+let
+  avr_incflags = [
+    "-isystem ${avrlibc}/avr/include"
+    "-B${avrlibc}/avr/lib/avr5"
+    "-L${avrlibc}/avr/lib/avr5"
+    "-B${avrlibc}/avr/lib/avr35"
+    "-L${avrlibc}/avr/lib/avr35"
+    "-B${avrlibc}/avr/lib/avr51"
+    "-L${avrlibc}/avr/lib/avr51"
+  ];
+in
+
+stdenv.mkDerivation {
+  name = "qmk-firmware";
+
+  buildInputs = [ dfu-programmer dfu-util diffutils git ]
+    ++ lib.optional avr [ avrbinutils avrgcc avrlibc ]
+    ++ lib.optional arm [ gcc-arm-embedded ];
+
+  CFLAGS = lib.optional avr avr_incflags;
+  ASFLAGS = lib.optional avr avr_incflags;
+}


### PR DESCRIPTION
[Nix](https://nixos.org/) is a fairly new package manager for Linux and macOS which installs packages based on description in a special programming language. With Nix, you don't install build tools globally but use temporary `nix-shell` environments which put all required build tools for a specific project in your PATH.

This adds a build environment description for QMK, plus a little bit of documentation.

I tested this on Linux and it appears to build everything successfully. Unfortunately, multiple linker library paths are needed for the different AVR microcontrollers which causes some warnings when linking. Maybe there's a better way to specify these paths?

Nixpkg's ARM compiler unfortunately is built for Linux only, but the AVR compiler should work on macOS as well. I can't test that though.