### PR TITLE
Don't process keycodes on the slave

### DIFF
--- a/keyboards/ergodox_infinity/ergodox_infinity.c
+++ b/keyboards/ergodox_infinity/ergodox_infinity.c
@@ -126,6 +126,10 @@ void matrix_scan_kb(void) {
 	matrix_scan_user();
 }
 
+bool is_keyboard_master(void) {
+    return is_serial_link_master();
+}
+
 __attribute__ ((weak))
 void ergodox_board_led_on(void){
 }


### PR DESCRIPTION
The Ergodox Infinity was processing keycodes on the slave, which cause problems with the backlights for example. This is fixed by adding a weak function for checking if the keyboard is a master.

The other split keyboards are not affected, since they run a different loop on the slaves.