### PR TITLE
Fix missing teensy path

### DIFF
--- a/util/activate_msys2.sh
+++ b/util/activate_msys2.sh
@@ -7,6 +7,7 @@ function export_variables {
     export PATH=$PATH:$util_dir/flip/bin
     export PATH=$PATH:$util_dir/avr8-gnu-toolchain/bin
     export PATH=$PATH:$util_dir/gcc-arm-none-eabi/bin
+    export PATH=$PATH:$util_dir/teensy_loader_cli.exe
 }
 
 export_variables


### PR DESCRIPTION
I tried to `make ergodox_ez-default-teensy` in msys2, but encountered `teensy_loader_cli` command not found.
