### PR TITLE
Qwerty Code Friendly: relocate insert key

### DIFF
--- a/layouts/community/ergodox/qwerty_code_friendly/keymap.c
+++ b/layouts/community/ergodox/qwerty_code_friendly/keymap.c
@@ -15,7 +15,7 @@
 #define CFQ_USER_KEY1 KC_F13
 #endif
 #if !defined(CFQ_USER_KEY2)
-#define CFQ_USER_KEY2 KC_F14
+#define CFQ_USER_KEY2 KC_APP
 #endif
 
 #define BASE 0 // default layer
@@ -77,10 +77,10 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |--------+------+------+------+------+------|   [  |           |  ]   |------+------+------+------+------+--------|
  * | LShift |   Z  |   X  |   C  |   V  |   B  |      |           |      |   N  |   M  |   ,  |   .  |   /  | RShift |
  * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
- *   | LCtl |Super | Alt  | Ins  |Space |                                       | Left | Down | Up   |Right | Del  |
+ *   | LCtl |Super | Alt  | USR2 |Space |                                       | Left | Down | Up   |Right | Del  |
  *   `----------------------------------'                                       `----------------------------------'
  *                                        ,-------------.       ,-------------.
- *                                        | USR2 | ~L3  |       | Home | End  |
+ *                                        | Ins  | ~L3  |       | Home | End  |
  *                                 ,------|------|------|       |------+------+------.
  *                                 |      |      | ~L2  |       | PgUp |      |      |
  *                                 |Space | USR1 |------|       |------|Enter |Space |
@@ -91,14 +91,14 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 // Otherwise, it needs KC_*
 [BASE] = LAYOUT_ergodox(  // layer 0 : default
   // left hand
-  KC_GRV,  KC_EXLM, KC_AT,   KC_HASH,  KC_DLR, KC_PERC, KC_LCBR,
-  KC_TAB,  KC_Q,    KC_W,    KC_E,     KC_R,   KC_T,    KC_LPRN,
-  KC_ESC,  KC_A,    KC_S,    KC_D,     KC_F,   KC_G,
-  KC_LSFT, KC_Z,    KC_X,    KC_C,     KC_V,   KC_B,    KC_LBRC,
-  KC_LCTL, KC_LGUI, KC_LALT, KC_INS,   KC_SPC,
-                                               CFQ_USER_KEY2, CFQ_KC_FN3,
-                                                              CFQ_KC_FN2,
-                                       KC_SPC, CFQ_USER_KEY1, CFQ_KC_FN1,
+  KC_GRV,  KC_EXLM, KC_AT,   KC_HASH,       KC_DLR, KC_PERC, KC_LCBR,
+  KC_TAB,  KC_Q,    KC_W,    KC_E,          KC_R,   KC_T,    KC_LPRN,
+  KC_ESC,  KC_A,    KC_S,    KC_D,          KC_F,   KC_G,
+  KC_LSFT, KC_Z,    KC_X,    KC_C,          KC_V,   KC_B,    KC_LBRC,
+  KC_LCTL, KC_LGUI, KC_LALT, CFQ_USER_KEY2, KC_SPC,
+                                                    KC_INS,        CFQ_KC_FN3,
+                                                                   CFQ_KC_FN2,
+                                            KC_SPC, CFQ_USER_KEY1, CFQ_KC_FN1,
   // right hand
   KC_RCBR,     KC_CIRC, KC_AMPR, KC_ASTR,KC_MINS, KC_EQL,    KC_BSPC,
   KC_RPRN,     KC_Y,    KC_U,    KC_I,   KC_O,    KC_P,      KC_BSLS,

--- a/layouts/community/ergodox/qwerty_code_friendly/readme.md
+++ b/layouts/community/ergodox/qwerty_code_friendly/readme.md
@@ -28,16 +28,20 @@ Some optional behavior is configurable without editing the code
 using `CFQ_` prefixed defines which can be set by passing `EXTRAFLAGS` to make.
 
 - `CFQ_USER_KEY1`, `CFQ_USER_KEY2` are used for custom-keys
-  if not set they default to F13, F14.
 - `CFQ_USE_MOMENTARY_LAYER_KEYS` is used to prevent layer keys from toggling when tapped.
-- `CFQ_USE_EXPEREMENTAL_LAYER` defines an extra layer for misc extra keys/macros.
-  Currently it's mostly empty.
 - `CFQ_USE_SWAP_RIGHT_SPACE_ENTER` swap Enter and Space on the right hand thumb cluster.
   While asymmetric, it makes Enter more easily accessible.
+- `CFQ_USE_EXPEREMENTAL_LAYER` defines an extra layer for misc extra keys/macros.
+  Currently it's mostly empty.
 
 
 
 ## Keymap 0: Basic layer
+
+When undefined:
+
+- `USR1` defaults to `F13`, otherwise use `CFQ_USER_KEY1`.
+- `USR2` defaults to `APP`, otherwise use `CFQ_USER_KEY2`.
 
 ```
 ,--------------------------------------------------.           ,--------------------------------------------------.
@@ -49,10 +53,10 @@ using `CFQ_` prefixed defines which can be set by passing `EXTRAFLAGS` to make.
 |--------+------+------+------+------+------|   [  |           |  ]   |------+------+------+------+------+--------|
 | LShift |   Z  |   X  |   C  |   V  |   B  |      |           |      |   N  |   M  |   ,  |   .  |   /  | RShift |
 `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
-  | LCtl |Super | Alt  | Ins  |Space |                                       | Left | Down | Up   |Right | Del  |
+  | LCtl |Super | Alt  | USR2 |Space |                                       | Left | Down | Up   |Right | Del  |
   `----------------------------------'                                       `----------------------------------'
                                        ,-------------.       ,-------------.
-                                       | USR2 | ~L3  |       | Home | End  |
+                                       | Ins  | ~L3  |       | Home | End  |
                                 ,------|------|------|       |------+------+------.
                                 |      |      | ~L2  |       | PgUp |      |      |
                                 |Space | USR1 |------|       |------|Enter |Space |
@@ -110,3 +114,7 @@ Note the double bracket keys on this layer press left to position the cursor bet
 ```
 
 ## Changelog
+
+- 2017/10/4
+  Move Insert key to the left thumb cluster (away from the modifier keys).
+  Replace with `USR2` which defaults to `APP`.


### PR DESCRIPTION
This was too easy to press by accident (next to Alt).
Move to the thumb cluster and make this user configurable.