### PR TITLE
Generated commit for github merge request of Papageno features

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "lib/googletest"]
 	path = lib/googletest
 	url = https://github.com/google/googletest
+[submodule "lib/papageno"]
+	path = lib/papageno
+	url = https://github.com/noseglasses/papageno.git

--- a/common_features.mk
+++ b/common_features.mk
@@ -108,6 +108,21 @@ ifeq ($(strip $(TAP_DANCE_ENABLE)), yes)
     SRC += $(QUANTUM_DIR)/process_keycode/process_tap_dance.c
 endif
 
+ifeq ($(strip $(PAPAGENO_ENABLE)), yes)
+
+    OPT_DEFS += -DPAPAGENO_ENABLE
+    
+    EXTRAINCDIRS += $(QUANTUM_DIR)/../lib/papageno/src
+    EXTRAINCDIRS += $(QUANTUM_DIR)/../lib/papageno/3rd_party
+    EXTRAINCDIRS += $(QUANTUM_DIR)/../lib/papageno/build/atmega32u4/src
+
+    LDFLAGS += -Wl,-L$(QUANTUM_DIR)/../lib/papageno/build/atmega32u4/src
+
+    LDFLAGS += -lpapageno
+    
+    SRC += $(QUANTUM_DIR)/process_keycode/process_papageno.c       
+
+endif
 ifeq ($(strip $(KEY_LOCK_ENABLE)), yes)
     OPT_DEFS += -DKEY_LOCK_ENABLE
     SRC += $(QUANTUM_DIR)/process_keycode/process_key_lock.c

--- a/docs/features.md
+++ b/docs/features.md
@@ -103,3 +103,8 @@ case MACRO_RAISED:
   }
   break;
 ```
+
+## Papageno: Turn your keyboard into a magical musical instrument
+
+Define multi-key tap-dances, highly customizable leader key-sequences, chords, key-clusters or mixtures of it all. [Papageno](https://github.com/noseglasses/papageno/) an advanced pattern matching library seamlessly integrates with QMK to provide ultimate flexibility in the generation of multi-key-commands. An automatized compression mechanism converts easy-to-define search-tree data structures into statically allocated, compile-time static compressed data-sets. This allows for Flash and RAM memory-saving definitions of large amounts of key-patterns in a clearly arranged fashion.
+See the [QMK-Papageno](papageno.md) page for detailed information.

--- a/docs/papageno.md
+++ b/docs/papageno.md
@@ -1,0 +1,334 @@
+
+# Papageno-QMK: Turn your keyboard into a magical instrument
+
+## Abstract
+
+Define multi-key tap-dances, highly customizable leader key-sequences, chords, key-clusters or mixtures of it all. [Papageno](https://github.com/noseglasses/papageno/) an advanced pattern matching library seamlessly integrates with QMK to provide ultimate flexibility in the generation of multi-key-commands. An automatized compression mechanism converts easy-to-define search-tree data structures into statically allocated, compile-time static compressed data-sets. This allows for Flash and RAM memory-saving definitions of large amounts of key-patterns in a clearly arranged fashion.
+
+## Introduction
+
+A description of Papageno, its basic features and a motivation of its development and application is followed by a brief example how to use the Papageno-QMK API in `key-map.c` definitions. Links to further documents that describe Papageno and its QMK-API are provided at the end of the document.
+
+## Motivation
+
+### Utilization of thumb keys on ergonomic keyboards
+
+Most modern ergonomic keyboards come with dedicated thumb key clusters. These are mainly motivated by the obvious under-utilization of the thumbs on traditional computer keyboards. 
+As our thumbs are the most powerful fingers, it is desirable to shift as much work as possible from the other fingers towards the thumbs. The actual number of (reachable) thumb keys varies between different keyboard designs. Typically there are between four and eight (reachable) and freely programmable thumb keys available.
+This restriction in number means that when assigning key-codes or actions to these special keys it is important to do it in a way that optimizes both, utilization and usability. In the recent past there occurred a significant number of innovative ideas that aim to assign more than two key-codes or actions to a physical key.
+
+### Existing QMK-features
+
+[Tap-dances](tap_dance.md), modifier keys, with and without one-touch, as well as multiple key-map-layers provide different ways to creatively assign work to thumb keys using QMK. These methods all have specific advantages and drawbacks. A thorough analysis of the many possible ways to utilize and combine those could fill a research article of its own. Therefore, we will concentrate on tap-dances to explain the enhancements introduced by Papageno. 
+
+[Tap-dances](tap_dance.md) theoretically allow to assign an infinite number of meanings to a single physical key. A specific number of key-presses, usually entered in rapid succession, triggers a specific action.
+This is probably the only, but also the greatest disadvantage of *traditional* tap-dances. Hitting a key a given number of times in a row can be fairly difficult to accomplish, especially for non pianists and when there are definitions for say, three, four and five strokes of the same key.
+
+### Towards multi-key tap-dances
+
+As a keyboard comes with a multitude of keys, why not extend the concept of tap-dances to combinations of several keys? It is much easier to hit two, three or more keys in a defined order than to hit the same key a given number of times. Entering key sequences, i.e. words, is precisely what typists are trained to do.
+ 
+Of course, we want the action that is triggered when the key sequence has been completed to replace the actual series of key-codes that is assigned with the keys when hit independently, same as with tap-dances.
+
+### Some numbers
+
+Let's go back to where we came from, shifting work, e.g. to thumb keys. It would be useful to assign actions to two key combinations (two key words) of thumb keys that are assigned to the left and the right hand.
+For a keyboard with two thumb keys for each hand, this would mean that we would end up with eight possible two-key combinations of thumb keys assigned to different hands. Hereby, we assume that hitting two keys A and B in two different orders is supposed to trigger two different actions. 
+
+If we add to these eight combinations the four possible actions assigned to keys when hit independently, this sums up to twelve different actions for four thumb keys.
+
+It is up to the reader to solve the task of computing the drastic increase in number if we would also consider three-key combinations and so forth.
+
+### A real-life use case
+
+Let's look at a brief example how multi-key tap-dances (in Papageno jargon called single-note lines, clusters and chords) could be applied to enhance QMK's capability. 
+
+Imagine editing some sort of program source code. A hereby common task is to indent lines, either to improve readability or because the language requires indentation as part of its semantic. Often it is also necessary to un-indent lines of code. Most editors assign shortcuts to both operations that are more or less simple to enter.
+As indentation/un-indentation are a fairly common operations when programming, it seems to be a good idea to trigger them through thumb-keys of our possibly ergonomic, programmable keyboard. 
+
+In the following we use the letter `A` for one of the left hand thumb-keys and `B` for one of the right hand thumb keys. 
+One possible solution for the given task would be to indent
+ when keys `A` and `B` are hit in order `A-B` and un-indent when hit in order `B-A`. Both operations would, of course, be programmed to emit the required shortcut.
+ 
+From a neuromuscular point of view this key-assignment strategy is doubtlessly a good choice as it is fairly easy to learn. Moreover, it is rather intuitive as we assign a forward-backward relation to indentation and un-indentation with respect to the order of the two thumb keys being hit. This certainly aids memorizing our new key assignment.
+
+### Papageno - a pattern matching library
+
+To bring the above example to life, we need a mechanism that is capable to recognize more or less complex keystroke patterns. The requirements described, among others,
+led to the development of [Papageno](https://github.com/noseglasses/papageno/), an advanced pattern matching library. Originally implemented as part of QMK, Papageno emerged to a stand-alone multi-platform library that still seamlessly integrates with QMK. It provides a variety of different ways to define patterns that go far beyond advanced tap-dances only.
+
+## A QMK example
+
+The impatient may directly jump to a [QMK example key-map](https://github.com/noseglasses/noseglasses_qmk_layout/) that demonstrates how Papageno can be employed to effectively shift load from fingers to thumbs.
+
+## Papageno-QMK
+
+Papageno allows for the definition of general multi-key patterns, chords, key clusters, arbitrary leader sequences with multiple leader keys and more. All features utilize the same efficient and optimized pattern matching algorithm. To be used with QMK, Papageno provides a wrapper API. It allows to define patterns in a simple and readable way and encapsules common tasks through C-pre-processor macros.
+
+The heart of Papageno is a search tree that is established based on the definitions that are part of user-implemented QMK key-map files.
+As typical for dynamically assembled tree data structures, this tree-based approach relies on dynamic memory allocation. Many believe that dynamically allocated data structures are a no-go on embedded architectures, such as those used in programmable keyboards. Actually, it is not that much of a hindrance as Papageno mainly allocates memory but does not free it during program execution. This inherently avoids RAM fragmentation which would otherwise lead to an early exhaustion of RAM. 
+
+To optimize the utilization of both, Flash memory and SRAM, Papageno comes with an integrated compression mechanism.
+
+## Compression of data-structures
+
+Where the dynamic creation of tree data structures works well for a moderate amount of key patterns, it can be problematic when a large amount of patterns is defined or if many other features of QMK are used along with Papageno. In such a case the limited resources of the keyboard hardware might be a problem.
+
+Before we talk about compression of data structures, let us look at the two modes of operation, that Papageno provides. The first and general one requires the generation of dynamic data structures during firmware execution on the keyboard. The second, a more advanced and optimized mode of operation allows for a two stage compile process that compresses most of Papageno's data structures and aims to be as memory efficient as possible, both with respect to flash memory and RAM.
+
+This integrated compression mechanism turns the dynamically allocated pattern matching search tree into a compile-time static data structure. We, thus, avoid dynamic memory allocations and significantly shrink binary size. Apart from the sheer compactification of data structures, compression also helps to safe program memory as no code is required to establish dynamic data structures during firmware execution. The respective C-functions are, therefore, automatically stripped from the binary as part of the firmware build process. 
+
+When applied to [noseglasses'](https://github.com/noseglasses/noseglasses_qmk_layout/) QMK-key-map compiled for an ErgoDox EZ, Papageno's compression mechanism reduces the size of the emerging hex-file by 2420 byte. Program storage and RAM saved can e.g. be used for other valuable QMK features.
+
+## Compatibility with existing QMK features
+
+The efficiency of Papageno's tree based pattern matching approach is one of the reasons why some features that were already part of QMK, such as tap-dances and leader sequences, have been incorporated into Papageno. (Another reason is that they were just fun to implement based on Papageno).
+
+Let's concentrate on our primary motivation, efficiency.
+If features provided by Papageno are used in common with equivalent pre-existing QMK-features, such as e.g. leader sequences, that are now also supported by Papageno, resource usage can be expected to be significantly higher than if Papageno would deal with the given tasks alone. The reason is obvious, more program memory and probably more RAM is required to store binary code and variables for two or more modules instead of only one. 
+
+Although optimized resource utilization is never a bad idea, Papageno plays along well with other QMK features.
+
+## Papageno as a wrapper to QMK
+
+Papageno-QMK is designed as a wrapper for the rest of QMK. Any keystrokes are intercepted and passed through Papageno's pattern matching engine. Only if a series of keystrokes is identified as non-matching any defined pattern, it is passed over to the main QMK engine. To QMK these keystrokes appear as if they had just emerged during the most recent keyboard matrix scan.
+
+This allows for a strong decoupling of Papageno and QMK that is robust and can be expected to work quite well with most other features provided by QMK.
+
+For compatibility reasons, Papageno provides a layer mechanism that is fairly similay to that of QMK's key-maps. At their point of definition, patterns are associated with layers. They are only active while their associated layer is activated, which is controlled by the rest of QMK.
+Layer fall through, works similar to the assignment of transparent key-codes in QMK key-maps.
+
+It is most common to emit QMK key-codes when a defined pattern matches a series of keystrokes.
+To allow for more advanced functionality Papageno provides an interface to define arbitrary user callback functions that can be supplied with user defined data.
+
+## An introduction to Papageno' QMK API
+
+### Key definitions
+
+Papageno as integrated with QMK operates on key-positions or key-codes as building blocks for patterns. Using key-positions means that a physical key, i.d. the key-switch at a given position on the keyboard is assigned with an identifier. QMK/TMK key-codes can also be assigned an identifier that is used by Papageno for pattern matching. This means that several keys that have been assigned the same key-code have the same meaning during pattern matching.
+
+To enable key-code lookup, keystrokes are passed through QMK's lookup engine to determine the key-code that is defined in the key-map of the current layer. The key-code found is then passed over to Papageno's pattern matching engine.
+
+As it is the more common approach, we will restrict the provided example below to the use of key-positions as building blocks of pattern definitions.
+
+### Using key-positions to define patterns
+
+To use key-positions as tokens to define patterns, add the following code to your key-map. The example assumes that we want to assign names to the matrix key-position `(5,2)` and `(5,B)` which represent the left and right inner thumb keys on an ErgoDox EZ. 
+
+Please note the auxiliary macro parameter `S`. It is necessary for implementation purposes. The parameter name `S` can be replaced arbitrarily.
+
+```C
+#define LEFT_INNER_THUMB_KEY(S)     PPG_QMK_KEYPOS_HEX(5, 2, S)
+#define RIGHT_INNER_THUMB_KEY(S)    PPG_QMK_KEYPOS_HEX(5, B, S)
+```
+
+All keys that are supposed to be used in Papageno patterns must be macro-defined in the provided way.
+
+All key-positions must be registered with Papageno by defining a macro `PPG_QMK_MATRIX_POSITION_INPUTS` that registers all key-position macros that we have defined.
+
+```C
+// Define a set of Papageno inputs that are associated with
+// keyboard matrix positions.
+//
+// Important: - The macro must be named PPG_QMK_MATRIX_POSITION_INPUTS!
+//            - If no inputs are supposed to be associated with
+//              matrix positions, define an empty PPG_QMK_MATRIX_POSITION_INPUTS
+//
+#define PPG_QMK_MATRIX_POSITION_INPUTS(OP) \
+\
+__NL__      OP(LEFT_INNER_THUMB_KEY) \
+__NL__      OP(RIGHT_INNER_THUMB_KEY)
+```
+
+In the current example we concentrate on key-positions as input tokens. Nevertheless, we must inform Papageno of the key-codes (here none) that we want to use as input tokens.
+
+```C
+// Define a set of Papageno inputs that are associated with
+// qmk keycodes.
+//
+// Important: - The macro must be named PPG_QMK_KEYCOKC_INPUTS!
+//            - If no inputs are supposed to be associated with
+//              keycodes, define an empty PPG_QMK_KEYCOKC_INPUTS
+//
+#define PPG_QMK_KEYCODE_INPUTS(OP)
+```
+
+Finally, we initialize any global data structures used by Papageno-QMK.
+
+```C
+// Initialize Papageno data structures for qmk
+// This is based on the definitions of
+//
+//    PPG_QMK_MATRIX_POSITION_INPUTS
+//
+// and
+//
+//    PPG_QMK_KEYCODE_INPUTS
+//
+// and assumes these to be already defined.
+//
+PPG_QMK_INIT_DATA_STRUCTURES
+```
+
+### Initialization of the pattern matching engine
+
+To set up Papageno patterns it is recommended to define a dedicated initialization function. The name `init_papageno` can be arbitrarily replaced. However, please note that some auxiliary macros might rely on the name being `init_papageno` when used.
+
+```C
+void init_papageno(void)
+{
+   // Initialize the Papageno-QMK system
+   //
+   PPG_QMK_INIT
+   
+   // Define an individual timeout for Papageno-QMK. 
+   // Keystrokes whose time interval
+   // exceeds the timeout are considered individually, i.e. as not
+   // part of a Papageno pattern and are thus passed directly over to QMK.
+   //
+   ppg_qmk_set_timeout_ms(200);
+   
+   // Left inner and right inner thumb key are supposed to 
+   // trigger emission of the enter key-code (KC_ENTER) if clustered,
+   // i.e. when hit one after the other in arbitrary order.
+   //
+   PPG_QMK_KEYPOS_CLUSTER_ACTION_KEYCODE(
+      0, // Layer 0, equivalent to the respective QMK layer
+      KC_ENTER, // Keycode action
+      
+      // An unlimited number of matrix key-positions may follow.
+      // Here we use the key-position macros defined above.
+      //
+      LEFT_INNER_THUMB_KEY,
+      RIGHT_INNER_THUMB_KEY
+      // ...
+   );
+   
+   // ... more Papageno-QMK pattern definitions
+  
+   // Compile and establish Papageno's search tree
+   //
+   PPG_QMK_COMPILE
+}
+```
+
+### Connection with QMK
+
+Our initialization function must be linked to the QMK system by overriding
+the QMK-interface function `matrix_init_user`.
+
+```C
+void matrix_init_user(void) 
+{ 
+   init_papageno();
+   
+   // ... other initialization tasks
+}
+```
+
+Two more interface function must be overridden to connect Papageno with QMK.
+
+The overridden function `matrix_scan_user` ensures, amongst others, that pattern matching timeouts are correctly handled.
+```C
+void matrix_scan_user(void) 
+{
+   ppg_qmk_matrix_scan();
+   
+   // ... other matrix scan tasks
+};
+```
+
+The actually key-press handling is performed by an overriden version of `action_exec_user`.
+```C
+void action_exec_user(keyevent_t event)
+{
+   ppg_qmk_process_event(event);
+   
+   // ... other matrix scan tasks
+}
+```
+
+If no other tasks are to be performed by the overridden QMK-interface functions, all above overrides can be defined automatically by calling the macro `PPG_QMK_CONNECT` at global scope. Please ensure to name the initialization function `init_papageno` in this case.
+
+### A small working example
+
+The following is a short version of the keymap file `keyboards/ergodox_ex/keymaps/papageno/keymap.c' file that is part of the QMK source distribution.
+The example can be build for an ErgoDox EZ and with slight modifications (adapt the keymap definition to your keyboard) for any other keyboard that QMK supports. It demonstrates how the two inner thumb keys of the keyboard trigger emission of the key-code KC_ENTER when hit in arbitrary order.
+
+```C
+#include QMK_KEYBOARD_H
+#include "debug.h"
+#include "action_layer.h"
+#include "version.h"
+
+#include "process_papageno.h"
+
+// ... define your QMK-key-codes here
+
+// Define key positions that are supposed to be used by Papageno
+//
+#define LEFT_INNER_THUMB_KEY(S)  PPG_QMK_KEYPOS_HEX(5, 2, S)
+#define RIGHT_INNER_THUMB_KEY(S) PPG_QMK_KEYPOS_HEX(5, B, S)
+
+// Define a set of Papageno inputs that are associated with
+// keyboard matrix positions.
+//
+// Important: - The macro must be named PPG_QMK_MATRIX_POSITION_INPUTS!
+//            - If no inputs are supposed to be associated with
+//              matrix positions, define an empty PPG_QMK_MATRIX_POSITION_INPUTS
+//
+#define PPG_QMK_MATRIX_POSITION_INPUTS(OP) \
+\
+__NL__      OP(LEFT_INNER_THUMB_KEY) \
+__NL__      OP(RIGHT_INNER_THUMB_KEY)
+
+// Define a set of Papageno inputs that are associated with
+// qmk keycodes.
+//
+// Important: - The macro must be named PPG_QMK_KEYCOKC_INPUTS!
+//            - If no inputs are supposed to be associated with
+//              keycodes, define an empty PPG_QMK_KEYCOKC_INPUTS
+//
+#define PPG_QMK_KEYCODE_INPUTS(OP)
+
+// Initialize Papageno data structures for qmk
+// This is based on the definitions of 
+//
+//    PPG_QMK_MATRIX_POSITION_INPUTS
+//
+// and
+//
+//    PPG_QMK_KEYCODE_INPUTS
+//
+PPG_QMK_INIT_DATA_STRUCTURES
+
+void init_papageno(void)
+{
+   PPG_QMK_INIT
+
+   ppg_qmk_set_timeout_ms(200);
+
+   PPG_QMK_KEYPOS_CLUSTER_ACTION_KEYCODE(
+      0,
+      KC_ENTER,
+      LEFT_INNER_THUMB_KEY,
+      RIGHT_INNER_THUMB_KEY
+   );
+   
+   // ... more pattern definitions
+
+   PPG_QMK_COMPILE
+}
+
+PPG_QMK_CONNECT
+```
+
+## Advanced usage - further reading
+
+For matters of simplicity, the introductory example above only demonstrates one of the many features provided by Papageno. A complete documentation of Papageno's QMK-API goes far beyond the scope of this document. 
+
+The application of a large portion of Papageno's features is exemplified with the help of noseglasses' [QMK-key-map](https://github.com/noseglasses/noseglasses_qmk_layout/).
+
+Please see also the file `process_key-code/process_papageno.h` in the root directory of QMK's source tree. It contains the definition of the overall Papageno-QMK API in terms of C-functions and utility pre-processor macros.
+
+All of the functions and macros defined in `process_key-code/process_papageno.h` are some sort of wrappers to the actual Papageno API [Papageno API](https://github.com/noseglasses/papageno/).

--- a/keyboards/ergodox_ez/keymaps/papageno/keymap.c
+++ b/keyboards/ergodox_ez/keymaps/papageno/keymap.c
@@ -1,0 +1,117 @@
+/* Copyright 2017 Florian Fleissner
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include QMK_KEYBOARD_H
+#include "debug.h"
+#include "action_layer.h"
+#include "version.h"
+
+#include "process_papageno.h"
+
+// ... define your QMK-key-codes here
+
+// The following is taken from the ErgoDox EZ default layout
+
+#define BASE 0 // default layer
+#define SYMB 1 // symbols
+#define MDIA 2 // media keys
+
+enum custom_keycodes {
+  PLACEHOLDER = SAFE_RANGE, // can always be here
+  EPRM,
+  VRSN,
+  RGB_SLD
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+[BASE] = LAYOUT_ergodox(  // layer 0 : default
+        // left hand
+        KC_EQL,         KC_1,         KC_2,   KC_3,   KC_4,   KC_5,   KC_LEFT,
+        KC_DELT,        KC_Q,         KC_W,   KC_E,   KC_R,   KC_T,   TG(SYMB),
+        KC_BSPC,        KC_A,         KC_S,   KC_D,   KC_F,   KC_G,
+        KC_LSFT,        CTL_T(KC_Z),  KC_X,   KC_C,   KC_V,   KC_B,   ALL_T(KC_NO),
+        LT(SYMB,KC_GRV),KC_QUOT,      LALT(KC_LSFT),  KC_LEFT,KC_RGHT,
+                                              ALT_T(KC_APP),  KC_LGUI,
+                                                              KC_HOME,
+                                               KC_SPC,KC_BSPC,KC_END,
+        // right hand
+             KC_RGHT,     KC_6,   KC_7,  KC_8,   KC_9,   KC_0,             KC_MINS,
+             TG(SYMB),    KC_Y,   KC_U,  KC_I,   KC_O,   KC_P,             KC_BSLS,
+                          KC_H,   KC_J,  KC_K,   KC_L,   LT(MDIA, KC_SCLN),GUI_T(KC_QUOT),
+             MEH_T(KC_NO),KC_N,   KC_M,  KC_COMM,KC_DOT, CTL_T(KC_SLSH),   KC_RSFT,
+                                  KC_UP, KC_DOWN,KC_LBRC,KC_RBRC,          KC_FN1,
+             KC_LALT,        CTL_T(KC_ESC),
+             KC_PGUP,
+             KC_PGDN,KC_TAB, KC_ENT
+    ),
+};
+
+// Define key positions that are supposed to be used by Papageno
+//
+#define LEFT_INNER_THUMB_KEY(S)  PPG_QMK_KEYPOS_HEX(5, 2, S)
+#define RIGHT_INNER_THUMB_KEY(S) PPG_QMK_KEYPOS_HEX(5, B, S)
+
+// Define a set of Papageno inputs that are associated with
+// keyboard matrix positions.
+//
+// Important: - The macro must be named PPG_QMK_MATRIX_POSITION_INPUTS!
+//            - If no inputs are supposed to be associated with
+//              matrix positions, define an empty PPG_QMK_MATRIX_POSITION_INPUTS
+//
+#define PPG_QMK_MATRIX_POSITION_INPUTS(OP) \
+\
+__NL__      OP(LEFT_INNER_THUMB_KEY) \
+__NL__      OP(RIGHT_INNER_THUMB_KEY)
+
+// Define a set of Papageno inputs that are associated with
+// qmk keycodes.
+//
+// Important: - The macro must be named PPG_QMK_KEYCOKC_INPUTS!
+//            - If no inputs are supposed to be associated with
+//              keycodes, define an empty PPG_QMK_KEYCOKC_INPUTS
+//
+#define PPG_QMK_KEYCODE_INPUTS(OP)
+
+// Initialize Papageno data structures for qmk
+// This is based on the definitions of 
+//
+//    PPG_QMK_MATRIX_POSITION_INPUTS
+//
+// and
+//
+//    PPG_QMK_KEYCODE_INPUTS
+//
+PPG_QMK_INIT_DATA_STRUCTURES
+
+void init_papageno(void)
+{
+   PPG_QMK_INIT
+
+   ppg_qmk_set_timeout_ms(200);
+
+   PPG_QMK_KEYPOS_CLUSTER_ACTION_KEYCODE(
+      0,
+      KC_ENTER,
+      LEFT_INNER_THUMB_KEY,
+      RIGHT_INNER_THUMB_KEY
+   );
+   
+   // ... more pattern definitions
+
+   PPG_QMK_COMPILE
+}
+
+PPG_QMK_CONNECT

--- a/keyboards/ergodox_ez/keymaps/papageno/rules.mk
+++ b/keyboards/ergodox_ez/keymaps/papageno/rules.mk
@@ -1,0 +1,31 @@
+BOOTMAGIC_ENABLE=no
+COMMAND_ENABLE = no        # Commands for debug and configuration
+# Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
+SLEEP_LED_ENABLE = no    # Breathing sleep LED during USB suspend
+FORCE_NKRO ?= yes
+DEBUG_ENABLE = no
+CONSOLE_ENABLE = no
+TAP_DANCE_ENABLE = no
+PAPAGENO_ENABLE = yes
+KEYLOGGER_ENABLE ?= no
+UCIS_ENABLE = no
+MOUSEKEY_ENABLE = no
+AUTOLOG_ENABLE ?= no
+#EXTRAKEY_ENABLE = yes       # Audio control and System control(+450)
+EXTRAKEY_ENABLE = no       # Audio control and System control(+450)
+NKRO_ENABLE = yes            # Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+BACKLIGHT_ENABLE = no      # Enable keyboard backlight functionality
+MIDI_ENABLE = no            # MIDI controls
+
+# ifeq (${KEYBOARD},planck)
+# AUDIO_ENABLE = yes           # Audio output on port C6
+# else
+AUDIO_ENABLE = no           # Audio output on port C6
+# endif
+UNICODE_ENABLE = no         # Unicode
+BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
+RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight.  Do not enable this with audio at the same time.
+
+ifndef QUANTUM_DIR
+	include ../../../../Makefile
+endif

--- a/quantum/keymap_common.c
+++ b/quantum/keymap_common.c
@@ -37,15 +37,9 @@ extern keymap_config_t keymap_config;
 
 #include <inttypes.h>
 
-/* converts key to action */
-action_t action_for_key(uint8_t layer, keypos_t key)
+/* converts keycode to action */
+action_t action_for_configured_keycode(uint16_t keycode)
 {
-    // 16bit keycodes - important
-    uint16_t keycode = keymap_key_to_keycode(layer, key);
-
-    // keycode remapping
-    keycode = keycode_config(keycode);
-
     action_t action;
     uint8_t action_layer, when, mod;
 
@@ -148,6 +142,18 @@ action_t action_for_key(uint8_t layer, keypos_t key)
             break;
     }
     return action;
+}
+
+/* converts key to action */
+action_t action_for_key(uint8_t layer, keypos_t key)
+{
+    // 16bit keycodes - important
+    uint16_t keycode = keymap_key_to_keycode(layer, key);
+
+    // keycode remapping
+    keycode = keycode_config(keycode);
+	 
+    return action_for_configured_keycode(keycode);
 }
 
 __attribute__ ((weak))

--- a/quantum/process_keycode/process_papageno.c
+++ b/quantum/process_keycode/process_papageno.c
@@ -1,0 +1,429 @@
+/* Copyright 2017 Florian Fleissner
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "process_papageno.h"
+
+#include "quantum.h"
+#include "tmk_core/common/action.h"
+#include "tmk_core/common/action_tapping.h"
+
+#define PPG_IMMEDIATE_EVENT_PROCESSING
+
+#ifndef PPG_IMMEDIATE_EVENT_PROCESSING
+static PPG_Event ppg_qmk_flush_queue[30];
+static uint8_t ppg_qmk_flush_queue_end;
+#endif
+
+#ifdef PPG_QMK_ERGODOX_EZ
+#include "ergodox_ez.h"
+
+typedef struct {
+   uint8_t DDRD__;
+   uint8_t DDRB__;
+   uint8_t PORTD__;
+   uint8_t PORTB__;
+} Led_Registers;
+
+static Led_Registers led_registers;
+
+#define SAFE_REG(S) led_registers.S##__ = S;
+#define RESTORE_REG(S) S = led_registers.S##__;
+
+static void ff_safe_led_state(void)
+{
+   SAFE_REG(DDRD)
+   SAFE_REG(DDRB)
+   SAFE_REG(PORTD)
+   SAFE_REG(PORTB)
+}
+
+static void ff_restore_led_state(void)
+{
+   RESTORE_REG(DDRD)
+   RESTORE_REG(DDRB)
+   RESTORE_REG(PORTD)
+   RESTORE_REG(PORTB)
+}
+
+void ppg_qmk_led_signal(void)
+{
+   ff_safe_led_state();
+   
+   wait_ms(100);
+   
+   ergodox_led_all_on();
+   
+   wait_ms(100);
+   
+   ff_restore_led_state();
+}
+
+#define FF_LED_FLASH(LED_ID) \
+   ergodox_right_led_##LED_ID##_on(); \
+   wait_ms(100);  \
+   ergodox_right_led_##LED_ID##_off();
+
+void ppg_qmk_led_flash(void)
+{
+   ff_safe_led_state();
+   
+   ergodox_led_all_off();
+   
+   FF_LED_FLASH(1)
+   FF_LED_FLASH(2)
+   FF_LED_FLASH(3)
+   
+   ff_restore_led_state();
+}
+
+void ppg_qmk_led_superflash(void)
+{
+   ppg_qmk_led_flash();
+   wait_ms(200);
+   ppg_qmk_led_flash();
+   wait_ms(200);
+   ppg_qmk_led_flash();
+}
+
+void ppg_qmk_code_key_considered(void)
+{
+   ff_safe_led_state();
+   
+   ergodox_led_all_off();
+   ergodox_right_led_2_on();
+   
+   wait_ms(100);
+   
+   ff_restore_led_state();
+}
+
+void ppg_qmk_code_key_flushed(void)
+{
+   ff_safe_led_state();
+   
+   ergodox_led_all_off();
+   ergodox_right_led_3_on();
+   
+   wait_ms(100);
+   
+   ff_restore_led_state();
+}
+
+void ppg_qmk_code_key_blocked(void)
+{
+   ff_safe_led_state();
+   
+   ergodox_led_all_off();
+   ergodox_right_led_1_on();
+   
+   wait_ms(100);
+   
+   ff_restore_led_state();
+}
+
+#endif // PPG_QMK_ERGODOX_EZ
+
+/* This function is defined in quantum/keymap_common.c 
+ */
+
+action_t action_for_configured_keycode(uint16_t keycode);
+
+static void ppg_qmk_enter_keycode(uint16_t keycode, 
+                                  bool pressed,
+                                  uint16_t time,
+                                  bool synthesized
+                                 )
+{
+   /* Construct a dummy record
+   */
+   keyrecord_t record; 
+      record.event.key.row = 0;
+      record.event.key.col = 0;
+      record.event.pressed = pressed;
+      record.event.time = time;
+      record.tap.count = 1;
+      
+   /* Use the quantum/tmk system to trigger the action
+      * thereby using a fictituous key (0, 0) with which the action 
+      * keycode is associated. We pretend that the respective key
+      * was hit and released to make sure that any action that
+      * requires both events is correctly processed.
+      * Unfortunatelly this means that some actions that
+      * require keys to be held do not make sense, e.g.
+      * modifier keys or MO(...), etc.
+      */
+   
+//    uprintf("keycode: %d, active: %d\n", keycode, pressed);
+   
+   uint16_t configured_keycode = keycode_config(keycode);
+   
+   action_t action = action_for_configured_keycode(configured_keycode); 
+   
+   process_action(&record, action);
+   
+//    dprintf("keycode = %d\n", keycode);
+}
+
+static void ppg_qmk_flush_event(PPG_Event *event)
+{
+   #ifdef PPG_QMK_ERGODOX_EZ
+   ppg_qmk_code_key_flushed();
+   #endif
+   
+   uint16_t keycode = 0;
+   
+   int16_t highest_keypos = ppg_qmk_highest_keypos_input();
+
+   // Note: Input-IDs are assigned contiguously
+   //
+   //       Input ids assigned to keypos-inputs are {0..PPG_Highest_Keypos_Input}
+   //       
+   //       Input ids assigned to keycode-inputs are {PPG_Highest_Keypos_Input + 1..PPG_Highest_Keycode_Input}
+
+   if(event->input > highest_keypos) {
+      
+      // Map the input to a range starting from zero to be suitable
+      // for lookup in the ppg_qmk_keycode_lookup array
+      //
+      keycode = ppg_qmk_keycode_lookup[event->input - highest_keypos - 1];
+      
+      ppg_qmk_enter_keycode(keycode, 
+                        event->flags & PPG_Event_Active, 
+                        event->time,
+                        false /* not synthesized, i.e. already 
+                        partially processed by the qmk system */
+                     );
+   }
+   else {
+   
+      // Keypos input-IDs already start from zero
+      //
+      keyevent_t k_event = {
+         .key = ppg_qmk_keypos_lookup[event->input],
+         .pressed = event->flags & PPG_Event_Active,
+         .time = event->time
+      };
+      
+      // Let the qmk system process the event just as if it
+      // had just been detected during matrix scan
+      //
+      action_exec(k_event);
+   }
+}
+
+#ifndef PPG_IMMEDIATE_EVENT_PROCESSING
+static void ppg_qmk_delayed_flush_events(void)
+{
+   if(ppg_qmk_flush_queue_end == 0) { return; }
+   
+   uint8_t fqe = ppg_qmk_flush_queue_end;
+   ppg_qmk_flush_queue_end = 0;
+   
+   for(uint8_t i = 0; i < fqe; ++i) {
+
+      PPG_Event *event = ppg_qmk_flush_queue + i;
+      
+      ppg_qmk_flush_event(event);
+   }
+}
+#endif
+
+void ppg_qmk_process_event_callback(   
+                              PPG_Event *event,
+                              void *user_data)
+{
+   // Ignore events that were considered
+   //
+   if(event->flags & PPG_Event_Considered) {
+      
+      #ifdef PPG_QMK_ERGODOX_EZ
+      ppg_qmk_code_key_blocked();
+      #endif
+      
+      return; 
+   }
+   
+   #ifdef PPG_IMMEDIATE_EVENT_PROCESSING
+   ppg_qmk_flush_event(event);
+   #else
+   ppg_qmk_flush_queue[ppg_qmk_flush_queue_end] = *event;
+   ++ppg_qmk_flush_queue_end;
+   #endif
+}
+
+void ppg_qmk_flush_events(void)
+{  
+   ppg_event_buffer_iterate(
+      ppg_qmk_process_event_callback,
+      NULL
+   );
+}
+
+void ppg_qmk_process_keycode(bool activation, void *user_data) {
+   
+   uint16_t keycode = (uint16_t)user_data;
+      
+//    uprintf("keycode %u\n", keycode);
+   
+   if(keycode != 0) {
+      
+      ppg_qmk_enter_keycode(keycode, 
+                            activation, 
+                            timer_read(), 
+                            true /* is synthesized */);
+   }
+}
+
+void ppg_qmk_process_event(keyevent_t event)
+{   
+   uint16_t keycode = keymap_key_to_keycode(layer_switch_get_layer(event.key), event.key);
+   
+   #define PPG_QMK_INPUT_CHECK_A \
+__NL__   ppg_qmk_input_id_from_keypos( \
+__NL__                        event.key.row, \
+__NL__                        event.key.col)
+
+   #define PPG_QMK_INPUT_CHECK_B \
+         ppg_qmk_input_id_from_keycode(keycode)
+         
+   // The default behavior is to first check it an 
+   // input is defined through the keypos of a key.
+   // If not then we check the assigned keycode.
+   //
+   // By defining PPG_QMK_REVERSE_KEYPOS_TO_KEYCODE_PRECEDENCE
+   // this order can be reversed.
+   //
+   #ifndef PPG_QMK_REVERSE_KEYPOS_TO_KEYCODE_PRECEDENCE
+      #define PPG_QMK_INPUT_CHECK_1 PPG_QMK_INPUT_CHECK_A
+      #define PPG_QMK_INPUT_CHECK_2 PPG_QMK_INPUT_CHECK_B
+   #else // PPG_QMK_REVERSE_KEYPOS_TO_KEYCODE_PRECEDENCE
+      #define PPG_QMK_INPUT_CHECK_1 PPG_QMK_INPUT_CHECK_B
+      #define PPG_QMK_INPUT_CHECK_2 PPG_QMK_INPUT_CHECK_A
+   #endif // PPG_QMK_REVERSE_KEYPOS_TO_KEYCODE_PRECEDENCE
+         
+   uint8_t input = PPG_QMK_INPUT_CHECK_1;
+   
+   if(input == PPG_QMK_Not_An_Input) { 
+      
+      input = PPG_QMK_INPUT_CHECK_2;
+      
+      if(input == PPG_QMK_Not_An_Input) { 
+         
+         PPG_LOG("not an input\n");
+
+         // Whenever a key occurs that is not an input,
+         // we immediately abort pattern matching
+         //
+         ppg_global_abort_pattern_matching();
+         
+         // Let qmk process the key in a regular way
+         //
+         action_exec(event);
+         
+         return;
+      }
+      else {
+         PPG_LOG("input %u, keycode %d\n", input, keycode);
+      }
+   }
+// else {
+//    uprintf("input %u, row %u, col %u\n", input, record->event.key.row, 
+//                         record->event.key.col);
+//   }
+   
+   #ifdef PPG_QMK_ERGODOX_EZ
+   ppg_qmk_code_key_considered();
+   #endif
+   
+   PPG_Event p_event = {
+      .input = input,
+      .time = (PPG_Time)event.time,
+      .flags = (event.pressed) 
+                     ? PPG_Event_Active : PPG_Event_Flags_Empty
+   };
+   
+   uint8_t cur_layer = biton32(layer_state);
+   
+   ppg_global_set_layer(cur_layer);
+   
+   ppg_event_process(&p_event);
+}
+
+void ppg_qmk_time(PPG_Time *time)
+{
+   uint16_t time_tmp = timer_read();
+   *time = *((PPG_Time*)&time_tmp);
+}
+
+void  ppg_qmk_time_difference(PPG_Time time1, PPG_Time time2, PPG_Time *delta)
+{
+   uint16_t *delta_t = (uint16_t *)delta;
+   
+   *delta_t = (uint16_t)time2 - (uint16_t)time1; 
+}
+
+int8_t ppg_qmk_time_comparison(
+                        PPG_Time time1,
+                        PPG_Time time2)
+{
+   if((uint16_t)time1 > (uint16_t)time2) {
+      return 1;
+   }
+   else if((uint16_t)time1 == (uint16_t)time2) {
+      return 0;
+   }
+    
+   return -1;
+}
+
+void ppg_qmk_signal_callback(PPG_Signal_Id signal_id, void *user_data)
+{
+//    uprintf("signal %u\n", signal_id  );
+   
+   switch(signal_id) {
+      case PPG_On_Abort:
+         ppg_qmk_flush_events();
+         break;
+      case PPG_On_Timeout:
+         ppg_qmk_flush_events();
+         break;
+      case PPG_On_Match_Failed:
+         break;      
+      case PPG_On_Flush_Events:
+         ppg_qmk_flush_events();
+         break;
+      default:
+         return;
+   }
+   #ifdef PPG_QMK_ERGODOX_EZ
+   ppg_qmk_code_key_blocked();
+   #endif
+}
+
+// void ppg_qmk_set_timeout_ms(uint16_t timeout)
+// {
+//    printf("ppg_qmk_set_timeout_ms: %d\n", (int)timeout);
+//    ppg_global_set_timeout((PPG_Time)timeout);
+// }
+
+void ppg_qmk_matrix_scan(void)
+{
+   #ifndef PPG_IMMEDIATE_EVENT_PROCESSING
+   ppg_qmk_delayed_flush_events();
+   #endif
+   
+   ppg_timeout_check();
+}

--- a/quantum/process_keycode/process_papageno.h
+++ b/quantum/process_keycode/process_papageno.h
@@ -1,0 +1,568 @@
+/* Copyright 2017 Florian Fleissner
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef PROCESS_PAPAGENO_H
+#define PROCESS_PAPAGENO_H
+
+/**
+ * This is an interface to the Papageno library. It allows for using 
+ * Papageno magic melodies as part of the qmk firmware.
+ * 
+ * As Papageno's definition of what is an input is very arbitrary, it is possible to
+ * use keyboard matix coordinates as well as qmk keycodes to define keys (=inputs in Papageno jargon).
+ * 
+ * Key press and release actions are passed to Papageno.
+ * Use the macro PPG_QMK_INPUT_FROM_KEYPOS_ALIAS to specify a physical key with respect to its
+ * hexadecimal row and column ids or the macro PPG_QMK_KEYCODE_KEY to specify a qmk keycode
+ * as key identifier.
+ * 
+ * Please note that layer switching aborts
+ * matching of the current pattern and flushes all keypress events that queued up.
+*/
+
+#include "papageno.h"
+// #include "quantum.h"
+#include "tmk_core/common/keycode.h"
+#include "tmk_core/common/keyboard.h"
+#include "quantum/quantum_keycodes.h"
+
+#ifdef PAPAGENO_COMPRESSION_ENABLED
+#define PPG_CALLBACK__(...) { return __VA_ARGS__; }
+#else
+#define PPG_CALLBACK__(...) ;
+#endif
+
+// Enable the flag below if you want to compile 
+// led effects for ErgoDox EZ
+//
+// #define PPG_QMK_ERGODOX_EZ
+
+// The following extern entities are defined through preprocessor
+// macros in the keymap
+//
+extern keypos_t ppg_qmk_keypos_lookup[];
+extern uint16_t ppg_qmk_keycode_lookup[];
+
+extern PPG_Input_Id ppg_qmk_input_id_from_keypos(uint8_t row, uint8_t col);
+extern PPG_Input_Id ppg_qmk_input_id_from_keycode(uint16_t keycode);
+
+extern int16_t ppg_qmk_highest_keypos_input(void);
+
+void ppg_qmk_process_event_callback(   
+                        PPG_Event *key_event,
+                        void *user_data) PPG_CALLBACK__()
+
+void ppg_qmk_signal_callback(PPG_Signal_Id signal_id, void *user_data) PPG_CALLBACK__()
+
+void ppg_qmk_flush_key_events(void);
+
+void ppg_qmk_process_keycode(bool activation, void *user_data) PPG_CALLBACK__()
+
+void ppg_qmk_process_event(keyevent_t event);
+
+void ppg_qmk_time(         PPG_Time *time) PPG_CALLBACK__()
+
+void  ppg_qmk_time_difference(
+                        PPG_Time time1,
+                        PPG_Time time2,
+                        PPG_Time *delta) PPG_CALLBACK__()
+
+int8_t ppg_qmk_time_comparison(
+                        PPG_Time time1,
+                        PPG_Time time2) PPG_CALLBACK__(0)
+
+inline
+void ppg_qmk_set_timeout_ms(uint16_t timeout)
+{
+   ppg_global_set_timeout((PPG_Time)timeout);
+}
+
+void ppg_qmk_matrix_scan(void);
+
+/* Call this to flush key events that
+ * were encountered by papageno
+ */
+void ppg_qmk_flush_key_events(void);
+
+inline
+uint16_t ppg_qmk_report_keycode(uint16_t kk)
+{
+   PPG_LOG("   act. kk. 0x%" PRIXPTR "\n", (uintptr_t)kk);
+   
+   return kk;
+}
+
+#ifdef PPG_QMK_ERGODOX_EZ
+
+// Methods for LED-signals (e.g. to use on ErgoDox EZ)
+//
+void ppg_qmk_led_signal(void);
+void ppg_qmk_led_flash(void);
+void ppg_qmk_led_superflash(void);
+#endif
+
+enum { PPG_QMK_Not_An_Input = (PPG_Input_Id)-1 };
+
+// Note: Preprocessor macro functions can be 
+//       hard to debug.
+//
+//       One approach is to take a look at
+//       the preprocessed code to find out 
+//       what goes wrong. 
+//
+//       Unfortunatelly macro replacement cannot deal with newlines.
+//       Because of this, code that emerges from excessive macro
+//       replacement looks very unreadable due to the absence of 
+//       any line breaks.
+//
+//       To deal with this restriction, comment the
+//       definition of the __NL__ macro below, during
+//       preprocessor debugging. In that case, the
+//       occurrences of __NL__ will not be replaced by
+//       and empty string as in the compiled version but
+//       will still be present in the preprocessed code.
+//       Replace all occurrences of __NL__ in the preprocessed
+//       with newlines using a text editor to gain a
+//       readable version of the generated code.
+
+#define __NL__
+
+#define PPG_QMK_STRINGIZE(S) #S
+
+#ifdef PAPAGENO_COMPRESSION_ENABLED
+
+   #define PPG_QMK_COMPRESSION_REGISTER_SYMBOL(S) \
+         PPG_COMPRESSION_REGISTER_SYMBOL(ccontext, S)
+   
+   #define PPG_QMK_INIT_COMPRESSION \
+\
+__NL__   PPG_Compression_Context ccontext =  \
+__NL__              ppg_compression_init(); \
+__NL__   \
+__NL__   PPG_QMK_COMPRESSION_REGISTER_SYMBOL(ppg_qmk_process_keycode) \
+__NL__   PPG_QMK_COMPRESSION_REGISTER_SYMBOL(  \
+                                       ppg_qmk_process_event_callback)
+
+   #define PPG_QMK_COMPRESSION_RUN \
+__NL__   ppg_compression_run(ccontext, "noseglasses"); \
+__NL__   ppg_compression_finalize(ccontext);
+
+   #define PPG_QMK_COMPRESSION_REGISTER_SYMBOLS(REGISTRATION_MFUNC) \
+      REGISTRATION_MFUNC(PPG_QMK_COMPRESSION_REGISTER_SYMBOL)
+      
+   #define PPG_QMK_COMPRESSION_CALLBACK_STUB(NAME) \
+      void NAME(void) {}
+      
+   #define PPG_QMK_COMPRESSION_PREPARE_SYMBOLS(REGISTRATION_MFUNC) \
+      REGISTRATION_MFUNC(PPG_QMK_COMPRESSION_CALLBACK_STUB)
+
+#else
+
+   #define PPG_QMK_COMPRESSION_REGISTER_SYMBOL(S)
+   #define PPG_QMK_INIT_COMPRESSION
+   #define PPG_QMK_COMPRESSION_RUN
+   
+   #define PPG_QMK_COMPRESSION_REGISTER_SYMBOLS(REGISTRATION_MFUNC)
+   #define PPG_QMK_COMPRESSION_PREPARE_SYMBOLS(REGISTRATION_MFUNC)
+#endif
+
+#define PPG_QMK_COMPILE \
+ \
+         ppg_global_compile(); \
+__NL__   PPG_QMK_COMPRESSION_RUN
+
+#define PPG_QMK_KEYPOS_HEX(COL_HEX, ROW_HEX, S___) \
+   S___(COL_HEX, ROW_HEX)
+   
+// #define PPG_QMK_KEYCODE_KEY(KK) 
+//    (PPG_Input) { 
+//       .input_id = ppg_qmk_create_key_data(PPG_QMK_KEYPOS_HEX(0, 0), KK) 
+//    }  
+
+#define PPG_QMK_ACTION_KEYCODE(KK) \
+__NL__   (PPG_Action) { \
+__NL__      .callback = (PPG_Action_Callback) { \
+__NL__         .func = (PPG_Action_Callback_Fun)ppg_qmk_process_keycode,  \
+__NL__         .user_data = (void*)(uint16_t)ppg_qmk_report_keycode(KK) \
+__NL__      } \
+__NL__   }
+
+#define PPG_QMK_SETUP_NON_DEFAULT_MANAGERS \
+__NL__   \
+__NL__   ppg_global_set_default_event_processor( \
+__NL__      (PPG_Event_Processor_Fun)ppg_qmk_process_event_callback); \
+__NL__   \
+__NL__   ppg_global_set_signal_callback( \
+__NL__      (PPG_Signal_Callback) { \
+__NL__            .func = (PPG_Signal_Callback_Fun)ppg_qmk_signal_callback, \
+__NL__            .user_data = NULL \
+__NL__      } \
+__NL__   ); \
+__NL__   \
+__NL__   ppg_global_set_time_manager( \
+__NL__      (PPG_Time_Manager) { \
+__NL__         .time \
+__NL__            = (PPG_Time_Fun)ppg_qmk_time, \
+__NL__         .time_difference \
+__NL__            = (PPG_Time_Difference_Fun)ppg_qmk_time_difference, \
+__NL__         .compare_times \
+__NL__            = (PPG_Time_Comparison_Fun)ppg_qmk_time_comparison \
+__NL__      } \
+__NL__   ); \
+
+#define PPG_QMK_INIT \
+__NL__   \
+__NL__   ppg_global_init(); \
+__NL__   \
+__NL__   PPG_QMK_SETUP_NON_DEFAULT_MANAGERS \
+__NL__   \
+__NL__   PPG_QMK_INIT_COMPRESSION
+   
+#define PPG_QMK_KEYS(...) PPG_INPUTS(__VA_ARGS__)
+
+#define PPG_QMK_TRICAT(S1, S2, S3) S1##S2##S3
+
+#define PPG_QMK_KEYPOS_ENUM(KEYPOS_NAME) \
+   PPG_QMK_TRICAT(PPG_, KEYPOS_NAME, _Keypos_Name)
+
+#define PPG_QMK_CONVERT_KEYPOS_TO_CASE_LABEL(COL_HEX, ROW_HEX) \
+   256*0x##ROW_HEX + 0x##COL_HEX
+
+#define PPG_QMK_DEFINE_KEYPOS_ENUM(KEYPOS_NAME) \
+__NL__   enum { PPG_QMK_KEYPOS_ENUM(KEYPOS_NAME) \
+__NL__               = __COUNTER__ - PPG_Keypos_Input_Offset - 1 };
+
+#define PPG_DEFINE_KEYPOS_INPUT_ENUMS \
+__NL__   \
+__NL__   enum { PPG_Keypos_Input_Offset = __COUNTER__ }; \
+__NL__   \
+__NL__   PPG_QMK_MATRIX_POSITION_INPUTS(PPG_QMK_DEFINE_KEYPOS_ENUM) \
+__NL__   \
+__NL__   /* Careful, PPG_Highest_Keypos_Input may be negative in case that no keypos \
+__NL__      inputs are defined \
+__NL__   */ \
+__NL__   enum { PPG_Highest_Keypos_Input = (int16_t)(__COUNTER__) - PPG_Keypos_Input_Offset - 2 }; \
+__NL__   \
+__NL__   int16_t ppg_qmk_highest_keypos_input(void) { \
+__NL__      return PPG_Highest_Keypos_Input; \
+__NL__   }
+
+#define PPG_QMK_KEYCODE_ENUM(KEYCODE_ALIAS) \
+   PPG_##KEYCODE_ALIAS##_Keycode_Name
+
+#define PPG_QMK_DEFINE_KEYCODE_ENUM(KEYCODE_ALIAS) \
+__NL__   enum { PPG_QMK_KEYCODE_ENUM(KEYCODE_ALIAS) \
+__NL__               = PPG_Highest_Keypos_Input + __COUNTER__ - PPG_Keycode_Input_Offset };
+
+#define PPG_DEFINE_KEYCODE_INPUT_ENUMS \
+__NL__   \
+__NL__   enum { PPG_Keycode_Input_Offset = __COUNTER__ }; \
+__NL__   \
+__NL__   PPG_QMK_KEYCODE_INPUTS(PPG_QMK_DEFINE_KEYCODE_ENUM) \
+__NL__   \
+__NL__   /* Careful, PPG_Highest_Keycode_Input may be negative in case that no keypos and keycode \
+__NL__      inputs are defined \
+__NL__    */ \
+__NL__   enum { PPG_Highest_Keycode_Input = PPG_Highest_Keypos_Input - __COUNTER__ - PPG_Keypos_Input_Offset - 1 };
+
+#define PPG_QMK_CONVERT_KEYPOS_TO_CASE_LABEL(COL_HEX, ROW_HEX) \
+   256*0x##ROW_HEX + 0x##COL_HEX
+
+#define PPG_QMK_KEYPOS_CASE_LABEL(KEYPOS_ALIAS) \
+__NL__   case KEYPOS_ALIAS(PPG_QMK_CONVERT_KEYPOS_TO_CASE_LABEL): \
+__NL__      return PPG_QMK_KEYPOS_ENUM(KEYPOS_ALIAS); \
+__NL__      break;
+   
+#define PPG_INIT_INPUT_ID_FROM_KEYPOS_FUNCTION \
+__NL__   \
+__NL__   PPG_Input_Id ppg_qmk_input_id_from_keypos(uint8_t row, uint8_t col) \
+__NL__   { \
+__NL__      uint16_t id = 256*row + col; \
+__NL__      \
+__NL__      switch(id) { \
+__NL__         \
+__NL__         PPG_QMK_MATRIX_POSITION_INPUTS(PPG_QMK_KEYPOS_CASE_LABEL) \
+__NL__      } \
+__NL__      \
+__NL__      return PPG_QMK_Not_An_Input; \
+__NL__   } 
+
+#define PPG_QMK_KEYCODE_CASE_LABEL(KEYCODE_ALIAS) \
+__NL__   case (KEYCODE_ALIAS): \
+__NL__      return PPG_QMK_KEYCODE_ENUM(KEYCODE_ALIAS); \
+__NL__      break;
+
+#define PPG_INIT_INPUT_ID_FROM_KEYCODE_FUNCTION \
+__NL__   \
+__NL__   PPG_Input_Id ppg_qmk_input_id_from_keycode(uint16_t keycode) \
+__NL__   { \
+__NL__      switch(keycode) { \
+__NL__         \
+__NL__         PPG_QMK_KEYCODE_INPUTS(PPG_QMK_KEYCODE_CASE_LABEL) \
+__NL__      } \
+__NL__      \
+__NL__      return PPG_QMK_Not_An_Input; \
+__NL__   }
+  
+#define PPG_QMK_CONVERT_TO_KEYPOS_ARRAY_ENTRY_AUX(COL_HEX, ROW_HEX) \
+   { .row = 0x##ROW_HEX, .col = 0x##COL_HEX }
+   
+#define PPG_QMK_CONVERT_TO_KEYPOS_ARRAY_ENTRY(COL_HEX, ROW_HEX) \
+   PPG_QMK_CONVERT_TO_KEYPOS_ARRAY_ENTRY_AUX(COL_HEX, ROW_HEX),
+   
+#define PPG_QMK_KEYPOS_TO_LOOKUP_ENTRY(KEYPOS_ALIAS) \
+   KEYPOS_ALIAS(PPG_QMK_CONVERT_TO_KEYPOS_ARRAY_ENTRY)
+   
+#define PPG_QMK_INIT_KEYPOS_LOOKUP \
+__NL__   \
+__NL__   keypos_t ppg_qmk_keypos_lookup[] = { \
+__NL__      \
+__NL__      PPG_QMK_MATRIX_POSITION_INPUTS(PPG_QMK_KEYPOS_TO_LOOKUP_ENTRY) \
+__NL__      \
+__NL__      PPG_QMK_CONVERT_TO_KEYPOS_ARRAY_ENTRY_AUX(FF, FF) \
+__NL__   };
+
+#define PPG_QMK_CONVERT_TO_KEYCODE_ARRAY_ENTRY_AUX(KEYCODE) KEYCODE
+
+#define PPG_QMK_CONVERT_TO_KEYCODE_ARRAY_ENTRY(KEYCODE) \
+   PPG_QMK_CONVERT_TO_KEYCODE_ARRAY_ENTRY_AUX(KEYCODE),
+   
+#define PPG_QMK_INIT_KEYCODE_LOOKUP \
+__NL__   \
+__NL__   uint16_t ppg_qmk_keycode_lookup[] = { \
+__NL__      \
+__NL__      PPG_QMK_KEYCODE_INPUTS(PPG_QMK_CONVERT_TO_KEYCODE_ARRAY_ENTRY) \
+__NL__      \
+__NL__      PPG_QMK_CONVERT_TO_KEYCODE_ARRAY_ENTRY_AUX((uint16_t)-1) \
+__NL__   };
+   
+#define PPG_QMK_INPUT_FROM_KEYPOS_CALL(COL_HEX, ROW_HEX) \
+   ppg_qmk_input_id_from_keypos(0x##ROW_HEX, 0x##COL_HEX)
+   
+#define PPG_QMK_INPUT_FROM_KEYPOS_ALIAS(KEYPOS_ALIAS) \
+   PPG_QMK_KEYPOS_ENUM(KEYPOS_ALIAS)
+   
+#define PPG_QMK_INPUT_FROM_KEYCODE_ALIAS(KEYCODE_ALIAS) \
+   PPG_QMK_KEYCODE_ENUM(KEYCODE_ALIAS)
+   
+#define PPG_QMK_ADD_ONE(KEYPOS_ALIAS) \
+   + 1
+   
+#define PPG_QMK_STORE_N_INPUTS \
+__NL__   enum { PPG_QMK_N_Inputs = 0 \
+__NL__      PPG_QMK_MATRIX_POSITION_INPUTS(PPG_QMK_ADD_ONE) \
+__NL__      PPG_QMK_KEYCODE_INPUTS(PPG_QMK_ADD_ONE) \
+__NL__   };
+
+#define PPG_QMK_INIT_DATA_STRUCTURES \
+__NL__   \
+__NL__   PPG_DEFINE_KEYPOS_INPUT_ENUMS \
+__NL__   \
+__NL__   PPG_DEFINE_KEYCODE_INPUT_ENUMS \
+__NL__   \
+__NL__   PPG_INIT_INPUT_ID_FROM_KEYPOS_FUNCTION \
+__NL__   \
+__NL__   PPG_INIT_INPUT_ID_FROM_KEYCODE_FUNCTION \
+__NL__   \
+__NL__   PPG_QMK_INIT_KEYPOS_LOOKUP \
+__NL__   \
+__NL__   PPG_QMK_INIT_KEYCODE_LOOKUP \
+__NL__   \
+__NL__   PPG_QMK_STORE_N_INPUTS
+
+#define PPG_QMK_CONNECT \
+__NL__   \
+__NL__   void matrix_init_user(void) { \
+__NL__      init_papageno(); \
+__NL__   } \
+__NL__   \
+__NL__   void matrix_scan_user(void) { \
+__NL__      ppg_qmk_matrix_scan(); \
+__NL__   }; \
+__NL__   \
+__NL__   void action_exec_user(keyevent_t event) { \
+__NL__      ppg_qmk_process_event(event); \
+__NL__   }
+
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+// Some macros to simplify definition of patterns
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+#include "boost/preprocessor/tuple/to_list.hpp"
+#include "boost/preprocessor/list/for_each.hpp"
+
+#define PPG_QMK_NOTE_CREATE_STANDARD_KEYPOS(r, data, elem) \
+__NL__   ppg_note_create_standard(PPG_QMK_INPUT_FROM_KEYPOS_ALIAS(elem)),
+
+#define PPG_QMK_NOTE_CREATE_STANDARD_KEYCODE(r, data, elem) \
+__NL__   ppg_note_create_standard(PPG_QMK_INPUT_FROM_KEYCODE_ALIAS(elem)),
+   
+#define PPG_QMK_ACTION_GENERATOR_KEYCODE(KEYCODE) \
+__NL__   PPG_QMK_ACTION_KEYCODE( \
+__NL__         KEYCODE \
+__NL__   )
+
+#define PPG_QMK_PATTERN__(LAYER, ACTION, NOTE_GENERATOR, ACTION_GENERATOR, ...) \
+__NL__   ppg_token_set_action( \
+__NL__      ppg_pattern( \
+__NL__         (LAYER), \
+__NL__         PPG_TOKENS(  \
+__NL__            \
+__NL__            /* This generates a list of notes \
+__NL__             */ \
+__NL__            BOOST_PP_LIST_FOR_EACH(NOTE_GENERATOR, _, BOOST_PP_TUPLE_TO_LIST((__VA_ARGS__))) \
+__NL__         ) \
+__NL__      ), \
+__NL__      ACTION_GENERATOR(ACTION) \
+__NL__   )
+   
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+// Single note lines
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+#define PPG_QMK_KEYPOS_NOTE_LINE_ACTION_KEYCODE(LAYER, ACTION, ...) \
+   \
+   PPG_QMK_PATTERN__(LAYER,  \
+                     ACTION,  \
+                     PPG_QMK_NOTE_CREATE_STANDARD_KEYPOS,  \
+                     PPG_QMK_ACTION_GENERATOR_KEYCODE, \
+                     __VA_ARGS__ \
+   )
+   
+#define PPG_QMK_KEYCODE_NOTE_LINE_ACTION_KEYCODE(LAYER, ACTION, ...) \
+   \
+   PPG_QMK_PATTERN__(LAYER,  \
+                     ACTION,  \
+                     PPG_QMK_NOTE_CREATE_STANDARD_KEYCODE,  \
+                     PPG_QMK_ACTION_GENERATOR_KEYCODE, \
+                     __VA_ARGS__ \
+   )
+   
+#define PPG_QMK_KEYPOS_AGGREGATE_MEMBER__(r, data, elem) \
+__NL__   PPG_QMK_INPUT_FROM_KEYPOS_ALIAS(elem),
+
+#define PPG_QMK_KEYCODE_AGGREGATE_MEMBER__(r, data, elem) \
+__NL__   PPG_QMK_INPUT_FROM_KEYCODE_ALIAS(elem),
+   
+#define PPG_QMK_AGGREGATE_TOKEN__(TYPE, NOTE_GENERATOR, ...) \
+   \
+__NL__    PPG_##TYPE##_CREATE( \
+__NL__      BOOST_PP_LIST_FOR_EACH(NOTE_GENERATOR, _, BOOST_PP_TUPLE_TO_LIST((__VA_ARGS__))) \
+__NL__    )
+         
+#define PPG_QMK_KEYPOS_CHORD_TOKEN(...) \
+   \
+   PPG_QMK_AGGREGATE_TOKEN__( CHORD, \
+                              PPG_QMK_KEYPOS_AGGREGATE_MEMBER__, \
+                              __VA_ARGS__)
+                              
+#define PPG_QMK_KEYCODE_CHORD_TOKEN(...) \
+   \
+   PPG_QMK_AGGREGATE_TOKEN__( CHORD, \
+                              PPG_QMK_KEYCODE_AGGREGATE_MEMBER__, \
+                              __VA_ARGS__)
+
+#define PPG_QMK_KEYPOS_CLUSTER_TOKEN(...) \
+   \
+   PPG_QMK_AGGREGATE_TOKEN__( CLUSTER, \
+                              PPG_QMK_KEYPOS_AGGREGATE_MEMBER__, \
+                              __VA_ARGS__)
+                              
+#define PPG_QMK_KEYCODE_CLUSTER_TOKEN(...) \
+   \
+   PPG_QMK_AGGREGATE_TOKEN__( CLUSTER, \
+                              PPG_QMK_KEYCODE_AGGREGATE_MEMBER__, \
+                              __VA_ARGS__)
+
+#define PPG_QMK_KEYPOS_KEYS(...) \
+__NL__   PPG_QMK_KEYS( \
+__NL__      BOOST_PP_LIST_FOR_EACH(PPG_QMK_KEYPOS_AGGREGATE_MEMBER__, _, BOOST_PP_TUPLE_TO_LIST((__VA_ARGS__))) \
+__NL__      \
+__NL__      /* The list generated above ends with a comma. To fix this, \
+__NL__       * we add a NULL ptr. Papageno can cope with that. \
+__NL__       */ \
+__NL__      /*NULL*/ \
+__NL__   )
+
+#define PPG_QMK_KEYCODE_KEYS(...) \
+__NL__   PPG_QMK_KEYS( \
+__NL__      BOOST_PP_LIST_FOR_EACH(PPG_QMK_KEYCODE_AGGREGATE_MEMBER__, _, BOOST_PP_TUPLE_TO_LIST((__VA_ARGS__))) \
+__NL__      \
+__NL__      /* The list generated above ends with a comma. To fix this, \
+__NL__       * we add a NULL ptr. Papageno can cope with that. \
+__NL__       */ \
+__NL__      /*NULL*/ \
+__NL__   )
+
+#define PPG_QMK_AGGREGATE__(TYPE, LAYER, ACTION, NOTE_GENERATOR, ACTION_GENERATOR, ...) \
+\
+__NL__   ppg_##TYPE(  \
+__NL__      (LAYER), \
+__NL__      ACTION_GENERATOR( \
+__NL__         ACTION \
+__NL__      ), \
+__NL__      PPG_QMK_KEYPOS_KEYS(__VA_ARGS__) \
+__NL__   )
+   
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+// Chords
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+#define PPG_QMK_KEYPOS_CHORD_ACTION_KEYCODE(LAYER, ACTION, ...) \
+   PPG_QMK_AGGREGATE__( \
+                        chord, \
+                        LAYER, \
+                        ACTION, \
+                        PPG_QMK_KEYPOS_AGGREGATE_MEMBER__, \
+                        PPG_QMK_ACTION_GENERATOR_KEYCODE,   \
+                        __VA_ARGS__ \
+   )
+   
+#define PPG_QMK_KEYCODE_CHORD_ACTION_KEYCODE(LAYER, ACTION, ...) \
+   PPG_QMK_AGGREGATE__( \
+                        chord,  \
+                        LAYER,  \
+                        ACTION,  \
+                        PPG_QMK_KEYCODE_AGGREGATE_MEMBER__,  \
+                        PPG_QMK_ACTION_GENERATOR_KEYCODE,  \
+                        __VA_ARGS__ \
+   )
+  
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+// Clusters
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+#define PPG_QMK_KEYPOS_CLUSTER_ACTION_KEYCODE(LAYER, ACTION, ...) \
+   PPG_QMK_AGGREGATE__( \
+                        cluster, \
+                        LAYER, \
+                        ACTION, \
+                        PPG_QMK_KEYPOS_AGGREGATE_MEMBER__, \
+                        PPG_QMK_ACTION_GENERATOR_KEYCODE, \
+                        __VA_ARGS__ \
+   )
+   
+#define PPG_QMK_KEYCODE_CLUSTER_ACTION_KEYCODE(LAYER, ACTION, ...) \
+   PPG_QMK_AGGREGATE__( \
+                        cluster,  \
+                        LAYER,  \
+                        ACTION,  \
+                        PPG_QMK_KEYCODE_AGGREGATE_MEMBER__,  \
+                        PPG_QMK_ACTION_GENERATOR_KEYCODE,  \
+                        __VA_ARGS__ \
+   )
+                
+#endif

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -40,6 +40,12 @@ int tp_buttons;
 #include <fauxclicky.h>
 #endif
 
+__attribute__ ((weak))
+void action_exec_user(keyevent_t event)
+{
+   action_exec(event);
+}
+
 void action_exec(keyevent_t event)
 {
     if (!IS_NOEVENT(event)) {

--- a/tmk_core/common/action.h
+++ b/tmk_core/common/action.h
@@ -46,6 +46,9 @@ typedef struct {
 #endif
 } keyrecord_t;
 
+/* Can be overridden and executes action_exec by default */
+void action_exec_user(keyevent_t event);
+
 /* Execute action per keyevent */
 void action_exec(keyevent_t event);
 

--- a/tmk_core/common/keyboard.c
+++ b/tmk_core/common/keyboard.c
@@ -195,7 +195,7 @@ void keyboard_task(void)
                 if (debug_matrix) matrix_print();
                 for (uint8_t c = 0; c < MATRIX_COLS; c++) {
                     if (matrix_change & ((matrix_row_t)1<<c)) {
-                        action_exec((keyevent_t){
+                        action_exec_user((keyevent_t){
                             .key = (keypos_t){ .row = r, .col = c },
                             .pressed = (matrix_row & ((matrix_row_t)1<<c)),
                             .time = (timer_read() | 1) /* time should not be 0 */


### PR DESCRIPTION
Hi,
I added means to generate multi-key tap-dances, multi-leader key sequences and many other features to QMK, all based on a new pattern matching library Papageno (https://github.com/noseglasses/papageno) that I coupled with QMK.

Changes:
Due to a wrapper-type design only small modifications of QMK files were necessary to make things work. Unfortunately I did not find an appropriate way to get what I want without any modifications of QMK stuff.

I added Papageno as a git submodule to the lib directory. 

Documentation:
Please see the added markdown file in the doc directory for a documentation of the new features.

My own QMK keymap that highly utilizes features provided by Papageno can be found here: https://github.com/noseglasses/noseglasses_qmk_layout

The information about compression of data structures currently resides in my own keymap project. It might be a good idea to move it to the documentation file docs/papageno.md

I use an ErgoDox EZ and a Planck (48 keys) for my daily work. All implemented features have been tested and are in daily use on those two keyboards. If interested, see https://github.com/noseglasses/noseglasses_qmk_layout for information about how I use both keyboards with the same layout.