### PR TITLE
Add support for the JJ40 Keyboard

### DIFF
--- a/keyboards/jj40/README.md
+++ b/keyboards/jj40/README.md
@@ -1,0 +1,52 @@
+jj40 keyboard firmware
+==========================
+
+This is a port of the QMK firmware for boards that are based on the ps2avrGB firmware.
+
+Note that this is a complete replacement for the firmware, so you won't be
+using Bootmapper Client to change any keyboard settings, since not all the
+USB report options are supported.
+
+## Installing
+
+First, install the requirements. These commands are for OSX, but all you
+need is the AVR toolchain and `bootloadHID` for flashing:
+
+```
+$ brew cask install crosspack-avr
+$ brew install --HEAD https://raw.githubusercontent.com/robertgzr/homebrew-tap/master/bootloadhid.rb
+```
+
+In order to use the `./program` script, which can reboot the board into
+the bootloader, you'll need Python 2 with PyUSB installed:
+
+```
+$ pip install pyusb
+```
+
+Then, with the keyboard plugged in, simply run this command from the
+`qmk_firmware` directory:
+
+```
+$ make jj40-program
+```
+
+If you prefer, you can just build it and flash the firmware directly with
+`bootloadHID` if you boot the board while holding down `L_Ctrl` to keep it
+in the bootloader:
+
+```
+$ make jj40
+$ bootloadHID -r jj40_default.hex
+```
+
+## Troubleshooting
+
+From my experience, it's really hard to brick these boards. But these
+tricks have been useful when it got stuck in a weird scenario.
+
+1. Try plugging the board in while pressing `L_Ctrl`. This will force it
+   to boot only the bootloader without loading the firmware. Once this is
+   done, just reflash the board with the original firmware.
+2. Sometimes USB hubs can act weird, so try connecting the board directly
+   to your computer or plugging/unplugging the USB hub.

--- a/keyboards/jj40/README.md
+++ b/keyboards/jj40/README.md
@@ -4,7 +4,7 @@
 
 A compact 40% (12x4) ortholinear keyboard kit made and KPRepublic on AliExpress.
 
-Keyboard Maintainer: [Jack Humbert](https://github.com/jackhumbert)  
+Keyboard Maintainer: [QMK Community](https://github.com/qmk)  
 Hardware Supported: Atmega32A  
 Hardware Availability: [AliExpress](https://www.aliexpress.com/store/product/jj40-Custom-Mechanical-Keyboard-40-PCB-programmed-40-planck-layouts-bface-firmware-gh40/3034003_32828781103.html)
 

--- a/keyboards/jj40/README.md
+++ b/keyboards/jj40/README.md
@@ -1,16 +1,24 @@
-jj40 keyboard firmware
-==========================
+# jj40
 
-This is a port of the QMK firmware for boards that are based on the ps2avrGB firmware.
+![jj40](https://ae01.alicdn.com/kf/HTB18bq6bOERMeJjSspiq6zZLFXar.jpg?size=359506&height=562&width=750&hash=663a22d0109e2416ec8f54a7658686da)
+
+A compact 40% (12x4) ortholinear keyboard kit made and KPRepublic on AliExpress.
+
+Keyboard Maintainer: [Jack Humbert](https://github.com/jackhumbert)  
+Hardware Supported: Atmega32A  
+Hardware Availability: [AliExpress](https://www.aliexpress.com/store/product/jj40-Custom-Mechanical-Keyboard-40-PCB-programmed-40-planck-layouts-bface-firmware-gh40/3034003_32828781103.html)
+
+Make example for this keyboard (after setting up your build environment):
+
+    make jj40-program
+
+See [build environment setup](https://docs.qmk.fm/build_environment_setup.html) then the [make instructions](https://docs.qmk.fm/make_instructions.html) for more information.
 
 Note that this is a complete replacement for the firmware, so you won't be
 using Bootmapper Client to change any keyboard settings, since not all the
 USB report options are supported.
 
-## Installing
-
-First, install the requirements. These commands are for OSX, but all you
-need is the AVR toolchain and `bootloadHID` for flashing:
+In addition you may need the AVR toolchain and `bootloadHID` for flashing:
 
 ```
 $ brew cask install crosspack-avr
@@ -24,13 +32,6 @@ the bootloader, you'll need Python 2 with PyUSB installed:
 $ pip install pyusb
 ```
 
-Then, with the keyboard plugged in, simply run this command from the
-`qmk_firmware` directory:
-
-```
-$ make jj40-program
-```
-
 If you prefer, you can just build it and flash the firmware directly with
 `bootloadHID` if you boot the board while holding down `L_Ctrl` to keep it
 in the bootloader:
@@ -41,9 +42,6 @@ $ bootloadHID -r jj40_default.hex
 ```
 
 ## Troubleshooting
-
-From my experience, it's really hard to brick these boards. But these
-tricks have been useful when it got stuck in a weird scenario.
 
 1. Try plugging the board in while pressing `L_Ctrl`. This will force it
    to boot only the bootloader without loading the firmware. Once this is

--- a/keyboards/jj40/config.h
+++ b/keyboards/jj40/config.h
@@ -1,0 +1,41 @@
+/*
+Copyright 2017 Luiz Ribeiro <luizribeiro@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#define VENDOR_ID       0x20A0
+#define PRODUCT_ID      0x422D
+// TODO: share these strings with usbconfig.h
+// Edit usbconfig.h to change these.
+#define MANUFACTURER    winkeyless.kr
+#define PRODUCT         jj40
+
+/* matrix size */
+#define MATRIX_ROWS 8
+#define MATRIX_COLS 15
+
+#define RGBLED_NUM 16
+#define RGBLIGHT_ANIMATIONS
+
+#define NO_UART 1
+#define BOOTLOADHID_BOOTLOADER 1
+
+/* key combination for command */
+#define IS_COMMAND() (keyboard_report->mods == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT)))
+
+#endif

--- a/keyboards/jj40/i2c.c
+++ b/keyboards/jj40/i2c.c
@@ -1,0 +1,104 @@
+/*
+Copyright 2016 Luiz Ribeiro <luizribeiro@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <avr/io.h>
+#include <util/twi.h>
+
+#include "i2c.h"
+
+void i2c_set_bitrate(uint16_t bitrate_khz) {
+    uint8_t bitrate_div = ((F_CPU / 1000l) / bitrate_khz);
+    if (bitrate_div >= 16) {
+        bitrate_div = (bitrate_div - 16) / 2;
+    }
+    TWBR = bitrate_div;
+}
+
+void i2c_init(void) {
+    // set pull-up resistors on I2C bus pins
+    PORTC |= 0b11;
+
+    i2c_set_bitrate(400);
+
+    // enable TWI (two-wire interface)
+    TWCR |= (1 << TWEN);
+
+    // enable TWI interrupt and slave address ACK
+    TWCR |= (1 << TWIE);
+    TWCR |= (1 << TWEA);
+}
+
+uint8_t i2c_start(uint8_t address) {
+    // reset TWI control register
+    TWCR = 0;
+
+    // begin transmission and wait for it to end
+    TWCR = (1<<TWINT) | (1<<TWSTA) | (1<<TWEN);
+    while (!(TWCR & (1<<TWINT)));
+
+    // check if the start condition was successfully transmitted
+    if ((TWSR & 0xF8) != TW_START) {
+        return 1;
+    }
+
+    // transmit address and wait
+    TWDR = address;
+    TWCR = (1<<TWINT) | (1<<TWEN);
+    while (!(TWCR & (1<<TWINT)));
+
+    // check if the device has acknowledged the READ / WRITE mode
+    uint8_t twst = TW_STATUS & 0xF8;
+    if ((twst != TW_MT_SLA_ACK) && (twst != TW_MR_SLA_ACK)) {
+        return 1;
+    }
+
+    return 0;
+}
+
+void i2c_stop(void) {
+    TWCR = (1<<TWINT) | (1<<TWEN) | (1<<TWSTO);
+}
+
+uint8_t i2c_write(uint8_t data) {
+    TWDR = data;
+
+    // transmit data and wait
+    TWCR = (1<<TWINT) | (1<<TWEN);
+    while (!(TWCR & (1<<TWINT)));
+
+    if ((TWSR & 0xF8) != TW_MT_DATA_ACK) {
+        return 1;
+    }
+
+    return 0;
+}
+
+uint8_t i2c_send(uint8_t address, uint8_t *data, uint16_t length) {
+    if (i2c_start(address)) {
+        return 1;
+    }
+
+    for (uint16_t i = 0; i < length; i++) {
+        if (i2c_write(data[i])) {
+            return 1;
+        }
+    }
+
+    i2c_stop();
+
+    return 0;
+}

--- a/keyboards/jj40/i2c.h
+++ b/keyboards/jj40/i2c.h
@@ -1,0 +1,25 @@
+/*
+Copyright 2016 Luiz Ribeiro <luizribeiro@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef __I2C_H__
+#define __I2C_H__
+
+void i2c_init(void);
+void i2c_set_bitrate(uint16_t bitrate_khz);
+uint8_t i2c_send(uint8_t address, uint8_t *data, uint16_t length);
+
+#endif

--- a/keyboards/jj40/jj40.c
+++ b/keyboards/jj40/jj40.c
@@ -1,0 +1,45 @@
+/*
+Copyright 2017 Luiz Ribeiro <luizribeiro@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "jj40.h"
+#include "rgblight.h"
+
+#include <avr/pgmspace.h>
+
+#include "action_layer.h"
+#include "i2c.h"
+#include "quantum.h"
+
+extern rgblight_config_t rgblight_config;
+
+void rgblight_set(void) {
+    if (!rgblight_config.enable) {
+        for (uint8_t i = 0; i < RGBLED_NUM; i++) {
+            led[i].r = 0;
+            led[i].g = 0;
+            led[i].b = 0;
+        }
+    }
+
+    i2c_init();
+    i2c_send(0xb0, (uint8_t*)led, 3 * RGBLED_NUM);
+}
+
+__attribute__ ((weak))
+void matrix_scan_user(void) {
+    rgblight_task();
+}

--- a/keyboards/jj40/jj40.h
+++ b/keyboards/jj40/jj40.h
@@ -1,0 +1,39 @@
+/*
+Copyright 2017 Luiz Ribeiro <luizribeiro@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef KEYMAP_COMMON_H
+#define KEYMAP_COMMON_H
+
+#include "quantum_keycodes.h"
+#include "keycode.h"
+#include "action.h"
+
+#define KEYMAP( \
+    K01, K02, K03, K04, K05, K06, K07, K08, K09, K010, K011, K012, \
+    K11, K12, K13, K14, K15, K16, K17, K18, K19, K110, K111, K112, \
+    K21, K22, K23, K24, K25, K26, K27, K28, K29, K210, K211, K212, \
+    K31, K32, K33, K34, K35,    K3X,   K38, K39, K310, K311, K312  \
+) \
+{ \
+  { K012, K011, K010, K09, K05, K06, K07,   K08, K04, K03, K02, K01 }, \
+  { K112, K111, K110, K19, K15, K16, K17,   K18, K14, K13, K12, K11 }, \
+  { KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO }, \
+  { K212, K211, K210, K29, K25, K26, K27,   K28, K24, K23, K22, K21 }, \
+  { K312, K311, K310, K39, K35, K3X, KC_NO, K38, K34, K33, K32, K31 }  \
+}
+
+#endif

--- a/keyboards/jj40/keymaps/default/keymap.c
+++ b/keyboards/jj40/keymaps/default/keymap.c
@@ -1,0 +1,86 @@
+/*
+Copyright 2017 Luiz Ribeiro <luizribeiro@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "jj40.h"
+#include "action_layer.h"
+#include "rgblight.h"
+
+#define _QWERTY 0
+#define _LOWER  1
+#define _RAISE  2
+
+enum custom_keycodes {
+  QWERTY = SAFE_RANGE,
+  LOWER,
+  RAISE,
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+/* Qwerty
+ * ,-----------------------------------------------------------------------------------.
+ * | Tab  |   Q  |   W  |   E  |   R  |   T  |   Y  |   U  |   I  |   O  |   P  | Bksp |
+ * |------+------+------+------+------+-------------+------+------+------+------+------|
+ * | Esc  |   A  |   S  |   D  |   F  |   G  |   H  |   J  |   K  |   L  |   ;  |  "   |
+ * |------+------+------+------+------+------|------+------+------+------+------+------|
+ * | Shift|   Z  |   X  |   C  |   V  |   B  |   N  |   M  |   ,  |   .  |   /  |Enter |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      | Ctrl | Alt  | GUI  |Lower |    Space    |Raise | Left | Down |  Up  |Right |
+ * `-----------------------------------------------------------------------------------'
+ */
+[_QWERTY] = KEYMAP( \
+  KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_BSPC, \
+  KC_ESC,  KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, \
+  KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_ENT , \
+  _______, KC_LCTL, KC_LALT, KC_LGUI, MO(_LOWER),  KC_SPC,  MO(_RAISE),   KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT \
+),
+
+/* Lower
+ * ,-----------------------------------------------------------------------------------.
+ * |   ~  |   !  |   @  |   #  |   $  |   %  |   ^  |   &  |   *  |   (  |   )  | Bksp |
+ * |------+------+------+------+------+-------------+------+------+------+------+------|
+ * | Del  |  F1  |  F2  |  F3  |  F4  |  F5  |  F6  |   _  |   +  |     |    \  |  |   |
+ * |------+------+------+------+------+------|------+------+------+------+------+------|
+ * |      |  F7  |  F8  |  F9  |  F10 |  F11 |  F12 |ISO ~ |ISO | |      |      |Enter |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      |      |      |      |      |             |      | Next | Vol- | Vol+ | Play |
+ * `-----------------------------------------------------------------------------------'
+ */
+[_LOWER] = KEYMAP( \
+  KC_TILD, KC_EXLM, KC_AT,   KC_HASH, KC_DLR,  KC_PERC, KC_CIRC, KC_AMPR, KC_ASTR, KC_LPRN, KC_RPRN, KC_BSPC, \
+  KC_DEL,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_UNDS, KC_PLUS, KC_LCBR, KC_RCBR, KC_PIPE, \
+  _______, KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,S(KC_NUHS),S(KC_NUBS),_______, _______, _______, \
+  _______, _______, _______, _______, _______, _______, _______, KC_MNXT, KC_VOLD, KC_VOLU, KC_MPLY \
+),
+
+/* Raise
+ * ,-----------------------------------------------------------------------------------.
+ * |   `  |   1  |   2  |   3  |   4  |   5  |   6  |   7  |   8  |   9  |   0  | Bksp |
+ * |------+------+------+------+------+-------------+------+------+------+------+------|
+ * | Del  |  F1  |  F2  |  F3  |  F4  |  F5  |  F6  |   -  |   =  |   [  |   ]  |  \   |
+ * |------+------+------+------+------+------|------+------+------+------+------+------|
+ * |      |  F7  |  F8  |  F9  |  F10 |  F11 |  F12 |ISO # |ISO / |      |      |Enter |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      |      |      |      |      |             |      | Next | Vol- | Vol+ | Play |
+ * `-----------------------------------------------------------------------------------'
+ */
+[_RAISE] = KEYMAP( \
+  KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_BSPC, \
+  KC_DEL,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_MINS, KC_EQL,  KC_LBRC, KC_RBRC, KC_BSLS, \
+  _______, KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_NUHS, KC_NUBS, _______, _______, _______, \
+  _______, _______, _______, _______, _______, _______, _______, KC_MNXT, KC_VOLD, KC_VOLU, KC_MPLY \
+)
+};

--- a/keyboards/jj40/matrix.c
+++ b/keyboards/jj40/matrix.c
@@ -1,0 +1,106 @@
+/*
+Copyright 2017 Luiz Ribeiro <luizribeiro@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <avr/io.h>
+#include <util/delay.h>
+
+#include "matrix.h"
+
+#ifndef DEBOUNCE
+#   define DEBOUNCE	5
+#endif
+
+static uint8_t debouncing = DEBOUNCE;
+
+static matrix_row_t matrix[MATRIX_ROWS];
+static matrix_row_t matrix_debouncing[MATRIX_ROWS];
+
+void matrix_init(void) {
+    // all outputs for rows high
+    DDRB = 0xFF;
+    PORTB = 0xFF;
+    // all inputs for columns
+    DDRA = 0x00;
+    DDRC &= ~(0x111111<<2);
+    DDRD &= ~(1<<PIND7);
+    // all columns are pulled-up
+    PORTA = 0xFF;
+    PORTC |= (0b111111<<2);
+    PORTD |= (1<<PIND7);
+
+    // initialize matrix state: all keys off
+    for (uint8_t row = 0; row < MATRIX_ROWS; row++) {
+        matrix[row] = 0x00;
+        matrix_debouncing[row] = 0x00;
+    }
+}
+
+void matrix_set_row_status(uint8_t row) {
+    DDRB = (1 << row);
+    PORTB = ~(1 << row);
+}
+
+uint8_t bit_reverse(uint8_t x) {
+    x = ((x >> 1) & 0x55) | ((x << 1) & 0xaa);
+    x = ((x >> 2) & 0x33) | ((x << 2) & 0xcc);
+    x = ((x >> 4) & 0x0f) | ((x << 4) & 0xf0);
+    return x;
+}
+
+uint8_t matrix_scan(void) {
+    for (uint8_t row = 0; row < MATRIX_ROWS; row++) {
+        matrix_set_row_status(row);
+        _delay_us(5);
+
+        matrix_row_t cols = (
+            // cols 0..7, PORTA 0 -> 7
+            (~PINA) & 0xFF
+        ) | (
+            // cols 8..13, PORTC 7 -> 0
+            bit_reverse((~PINC) & 0xFF) << 8
+        ) | (
+            // col 14, PORTD 7
+            ((~PIND) & (1 << PIND7)) << 7
+        );
+
+        if (matrix_debouncing[row] != cols) {
+            matrix_debouncing[row] = cols;
+            debouncing = DEBOUNCE;
+        }
+    }
+
+    if (debouncing) {
+        if (--debouncing) {
+            _delay_ms(1);
+        } else {
+            for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
+                matrix[i] = matrix_debouncing[i];
+            }
+        }
+    }
+
+    matrix_scan_user();
+
+    return 1;
+}
+
+inline matrix_row_t matrix_get_row(uint8_t row) {
+    return matrix[row];
+}
+
+void matrix_print(void) {
+}

--- a/keyboards/jj40/program
+++ b/keyboards/jj40/program
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+# Copyright 2017 Luiz Ribeiro <luizribeiro@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import print_function
+
+import os
+import sys
+import time
+import usb
+
+if len(sys.argv) < 2:
+    print('Usage: %s <firmware.hex>' % sys.argv[0])
+    sys.exit(1)
+
+print('Searching for jj40... ', end='')
+
+dev = usb.core.find(idVendor=0x20A0, idProduct=0x422D)
+if dev is None:
+    raise ValueError('Device not found')
+
+print('Found', end='\n\n')
+
+print('Device Information:')
+print('  idVendor: %d (0x%04x)' % (dev.idVendor, dev.idVendor))
+print('  idProduct: %d (0x%04x)' % (dev.idProduct, dev.idProduct))
+print('Manufacturer: %s' % (dev.iManufacturer))
+print('Serial: %s' % (dev.iSerialNumber))
+print('Product: %s' % (dev.iProduct), end='\n\n')
+
+print('Transferring control to bootloader... ', end='')
+
+dev.set_configuration()
+
+request_type = usb.util.build_request_type(
+        usb.util.CTRL_OUT,
+        usb.util.CTRL_TYPE_CLASS,
+        usb.util.CTRL_RECIPIENT_DEVICE)
+
+USBRQ_HID_SET_REPORT = 0x09
+HID_REPORT_OPTION = 0x0301
+
+
+try:
+    dev.ctrl_transfer(
+            request_type,
+            USBRQ_HID_SET_REPORT,
+            HID_REPORT_OPTION,
+            0,
+            [0, 0, 0xFF] + [0] * 5
+            )
+except usb.core.USBError:
+    # for some reason I keep getting USBError, but it works!
+    pass
+
+# wait a bit until bootloader starts up
+time.sleep(2)
+
+print('OK')
+print('Programming...')
+if os.system('bootloadHID -r "%s"' % sys.argv[1]) == 0:
+    print('\nDone!')

--- a/keyboards/jj40/rules.mk
+++ b/keyboards/jj40/rules.mk
@@ -1,0 +1,45 @@
+# Copyright 2017 Luiz Ribeiro <luizribeiro@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# MCU name
+MCU = atmega32a
+PROTOCOL = VUSB
+
+# unsupported features for now
+NO_UART = yes
+NO_SUSPEND_POWER_DOWN = yes
+
+# processor frequency
+F_CPU = 12000000
+
+# build options
+BOOTMAGIC_ENABLE = yes
+MOUSEKEY_ENABLE = yes
+EXTRAKEY_ENABLE = yes
+CONSOLE_ENABLE = yes
+COMMAND_ENABLE = yes
+BACKLIGHT_ENABLE = no
+RGBLIGHT_ENABLE = yes
+RGBLIGHT_CUSTOM_DRIVER = yes
+
+OPT_DEFS = -DDEBUG_LEVEL=0
+OPT_DEFS += -DBOOTLOADER_SIZE=2048
+
+# custom matrix setup
+CUSTOM_MATRIX = yes
+SRC = matrix.c i2c.c
+
+# programming options
+PROGRAM_CMD = ./keyboards/jj40/program $(TARGET).hex

--- a/keyboards/jj40/usbconfig.h
+++ b/keyboards/jj40/usbconfig.h
@@ -1,0 +1,396 @@
+/* Name: usbconfig.h
+ * Project: V-USB, virtual USB port for Atmel's(r) AVR(r) microcontrollers
+ * Author: Christian Starkjohann
+ * Creation Date: 2005-04-01
+ * Tabsize: 4
+ * Copyright: (c) 2005 by OBJECTIVE DEVELOPMENT Software GmbH
+ * License: GNU GPL v2 (see License.txt), GNU GPL v3 or proprietary (CommercialLicense.txt)
+ * This Revision: $Id: usbconfig-prototype.h 785 2010-05-30 17:57:07Z cs $
+ */
+
+#ifndef __usbconfig_h_included__
+#define __usbconfig_h_included__
+
+#include "config.h"
+
+/*
+General Description:
+This file is an example configuration (with inline documentation) for the USB
+driver. It configures V-USB for USB D+ connected to Port D bit 2 (which is
+also hardware interrupt 0 on many devices) and USB D- to Port D bit 4. You may
+wire the lines to any other port, as long as D+ is also wired to INT0 (or any
+other hardware interrupt, as long as it is the highest level interrupt, see
+section at the end of this file).
+*/
+
+/* ---------------------------- Hardware Config ---------------------------- */
+
+#define USB_CFG_IOPORTNAME      D
+/* This is the port where the USB bus is connected. When you configure it to
+ * "B", the registers PORTB, PINB and DDRB will be used.
+ */
+#define USB_CFG_DMINUS_BIT      3
+/* This is the bit number in USB_CFG_IOPORT where the USB D- line is connected.
+ * This may be any bit in the port.
+ */
+#define USB_CFG_DPLUS_BIT       2
+/* This is the bit number in USB_CFG_IOPORT where the USB D+ line is connected.
+ * This may be any bit in the port. Please note that D+ must also be connected
+ * to interrupt pin INT0! [You can also use other interrupts, see section
+ * "Optional MCU Description" below, or you can connect D- to the interrupt, as
+ * it is required if you use the USB_COUNT_SOF feature. If you use D- for the
+ * interrupt, the USB interrupt will also be triggered at Start-Of-Frame
+ * markers every millisecond.]
+ */
+#define USB_CFG_CLOCK_KHZ       (F_CPU/1000)
+/* Clock rate of the AVR in kHz. Legal values are 12000, 12800, 15000, 16000,
+ * 16500, 18000 and 20000. The 12.8 MHz and 16.5 MHz versions of the code
+ * require no crystal, they tolerate +/- 1% deviation from the nominal
+ * frequency. All other rates require a precision of 2000 ppm and thus a
+ * crystal!
+ * Since F_CPU should be defined to your actual clock rate anyway, you should
+ * not need to modify this setting.
+ */
+#define USB_CFG_CHECK_CRC       0
+/* Define this to 1 if you want that the driver checks integrity of incoming
+ * data packets (CRC checks). CRC checks cost quite a bit of code size and are
+ * currently only available for 18 MHz crystal clock. You must choose
+ * USB_CFG_CLOCK_KHZ = 18000 if you enable this option.
+ */
+
+/* ----------------------- Optional Hardware Config ------------------------ */
+
+/* #define USB_CFG_PULLUP_IOPORTNAME   D */
+/* If you connect the 1.5k pullup resistor from D- to a port pin instead of
+ * V+, you can connect and disconnect the device from firmware by calling
+ * the macros usbDeviceConnect() and usbDeviceDisconnect() (see usbdrv.h).
+ * This constant defines the port on which the pullup resistor is connected.
+ */
+/* #define USB_CFG_PULLUP_BIT          4 */
+/* This constant defines the bit number in USB_CFG_PULLUP_IOPORT (defined
+ * above) where the 1.5k pullup resistor is connected. See description
+ * above for details.
+ */
+
+/* --------------------------- Functional Range ---------------------------- */
+
+#define USB_CFG_HAVE_INTRIN_ENDPOINT    1
+/* Define this to 1 if you want to compile a version with two endpoints: The
+ * default control endpoint 0 and an interrupt-in endpoint (any other endpoint
+ * number).
+ */
+#define USB_CFG_HAVE_INTRIN_ENDPOINT3   1
+/* Define this to 1 if you want to compile a version with three endpoints: The
+ * default control endpoint 0, an interrupt-in endpoint 3 (or the number
+ * configured below) and a catch-all default interrupt-in endpoint as above.
+ * You must also define USB_CFG_HAVE_INTRIN_ENDPOINT to 1 for this feature.
+ */
+#define USB_CFG_EP3_NUMBER              3
+/* If the so-called endpoint 3 is used, it can now be configured to any other
+ * endpoint number (except 0) with this macro. Default if undefined is 3.
+ */
+/* #define USB_INITIAL_DATATOKEN           USBPID_DATA1 */
+/* The above macro defines the startup condition for data toggling on the
+ * interrupt/bulk endpoints 1 and 3. Defaults to USBPID_DATA1.
+ * Since the token is toggled BEFORE sending any data, the first packet is
+ * sent with the oposite value of this configuration!
+ */
+#define USB_CFG_IMPLEMENT_HALT          0
+/* Define this to 1 if you also want to implement the ENDPOINT_HALT feature
+ * for endpoint 1 (interrupt endpoint). Although you may not need this feature,
+ * it is required by the standard. We have made it a config option because it
+ * bloats the code considerably.
+ */
+#define USB_CFG_SUPPRESS_INTR_CODE      0
+/* Define this to 1 if you want to declare interrupt-in endpoints, but don't
+ * want to send any data over them. If this macro is defined to 1, functions
+ * usbSetInterrupt() and usbSetInterrupt3() are omitted. This is useful if
+ * you need the interrupt-in endpoints in order to comply to an interface
+ * (e.g. HID), but never want to send any data. This option saves a couple
+ * of bytes in flash memory and the transmit buffers in RAM.
+ */
+#define USB_CFG_INTR_POLL_INTERVAL      1
+/* If you compile a version with endpoint 1 (interrupt-in), this is the poll
+ * interval. The value is in milliseconds and must not be less than 10 ms for
+ * low speed devices.
+ */
+#define USB_CFG_IS_SELF_POWERED         0
+/* Define this to 1 if the device has its own power supply. Set it to 0 if the
+ * device is powered from the USB bus.
+ */
+#define USB_CFG_MAX_BUS_POWER           500
+/* Set this variable to the maximum USB bus power consumption of your device.
+ * The value is in milliamperes. [It will be divided by two since USB
+ * communicates power requirements in units of 2 mA.]
+ */
+#define USB_CFG_IMPLEMENT_FN_WRITE      1
+/* Set this to 1 if you want usbFunctionWrite() to be called for control-out
+ * transfers. Set it to 0 if you don't need it and want to save a couple of
+ * bytes.
+ */
+#define USB_CFG_IMPLEMENT_FN_READ       0
+/* Set this to 1 if you need to send control replies which are generated
+ * "on the fly" when usbFunctionRead() is called. If you only want to send
+ * data from a static buffer, set it to 0 and return the data from
+ * usbFunctionSetup(). This saves a couple of bytes.
+ */
+#define USB_CFG_IMPLEMENT_FN_WRITEOUT   0
+/* Define this to 1 if you want to use interrupt-out (or bulk out) endpoints.
+ * You must implement the function usbFunctionWriteOut() which receives all
+ * interrupt/bulk data sent to any endpoint other than 0. The endpoint number
+ * can be found in 'usbRxToken'.
+ */
+#define USB_CFG_HAVE_FLOWCONTROL        0
+/* Define this to 1 if you want flowcontrol over USB data. See the definition
+ * of the macros usbDisableAllRequests() and usbEnableAllRequests() in
+ * usbdrv.h.
+ */
+#define USB_CFG_DRIVER_FLASH_PAGE       0
+/* If the device has more than 64 kBytes of flash, define this to the 64 k page
+ * where the driver's constants (descriptors) are located. Or in other words:
+ * Define this to 1 for boot loaders on the ATMega128.
+ */
+#define USB_CFG_LONG_TRANSFERS          0
+/* Define this to 1 if you want to send/receive blocks of more than 254 bytes
+ * in a single control-in or control-out transfer. Note that the capability
+ * for long transfers increases the driver size.
+ */
+/* #define USB_RX_USER_HOOK(data, len)     if(usbRxToken == (uchar)USBPID_SETUP) blinkLED(); */
+/* This macro is a hook if you want to do unconventional things. If it is
+ * defined, it's inserted at the beginning of received message processing.
+ * If you eat the received message and don't want default processing to
+ * proceed, do a return after doing your things. One possible application
+ * (besides debugging) is to flash a status LED on each packet.
+ */
+/* #define USB_RESET_HOOK(resetStarts)     if(!resetStarts){hadUsbReset();} */
+/* This macro is a hook if you need to know when an USB RESET occurs. It has
+ * one parameter which distinguishes between the start of RESET state and its
+ * end.
+ */
+/* #define USB_SET_ADDRESS_HOOK()              hadAddressAssigned(); */
+/* This macro (if defined) is executed when a USB SET_ADDRESS request was
+ * received.
+ */
+#define USB_COUNT_SOF                   1
+/* define this macro to 1 if you need the global variable "usbSofCount" which
+ * counts SOF packets. This feature requires that the hardware interrupt is
+ * connected to D- instead of D+.
+ */
+/* #ifdef __ASSEMBLER__
+ * macro myAssemblerMacro
+ *     in      YL, TCNT0
+ *     sts     timer0Snapshot, YL
+ *     endm
+ * #endif
+ * #define USB_SOF_HOOK                    myAssemblerMacro
+ * This macro (if defined) is executed in the assembler module when a
+ * Start Of Frame condition is detected. It is recommended to define it to
+ * the name of an assembler macro which is defined here as well so that more
+ * than one assembler instruction can be used. The macro may use the register
+ * YL and modify SREG. If it lasts longer than a couple of cycles, USB messages
+ * immediately after an SOF pulse may be lost and must be retried by the host.
+ * What can you do with this hook? Since the SOF signal occurs exactly every
+ * 1 ms (unless the host is in sleep mode), you can use it to tune OSCCAL in
+ * designs running on the internal RC oscillator.
+ * Please note that Start Of Frame detection works only if D- is wired to the
+ * interrupt, not D+. THIS IS DIFFERENT THAN MOST EXAMPLES!
+ */
+#define USB_CFG_CHECK_DATA_TOGGLING     0
+/* define this macro to 1 if you want to filter out duplicate data packets
+ * sent by the host. Duplicates occur only as a consequence of communication
+ * errors, when the host does not receive an ACK. Please note that you need to
+ * implement the filtering yourself in usbFunctionWriteOut() and
+ * usbFunctionWrite(). Use the global usbCurrentDataToken and a static variable
+ * for each control- and out-endpoint to check for duplicate packets.
+ */
+#define USB_CFG_HAVE_MEASURE_FRAME_LENGTH   0
+/* define this macro to 1 if you want the function usbMeasureFrameLength()
+ * compiled in. This function can be used to calibrate the AVR's RC oscillator.
+ */
+#define USB_USE_FAST_CRC                0
+/* The assembler module has two implementations for the CRC algorithm. One is
+ * faster, the other is smaller. This CRC routine is only used for transmitted
+ * messages where timing is not critical. The faster routine needs 31 cycles
+ * per byte while the smaller one needs 61 to 69 cycles. The faster routine
+ * may be worth the 32 bytes bigger code size if you transmit lots of data and
+ * run the AVR close to its limit.
+ */
+
+/* -------------------------- Device Description --------------------------- */
+
+#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+/* USB vendor ID for the device, low byte first. If you have registered your
+ * own Vendor ID, define it here. Otherwise you may use one of obdev's free
+ * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
+ * *** IMPORTANT NOTE ***
+ * This template uses obdev's shared VID/PID pair for Vendor Class devices
+ * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
+ * the implications!
+ */
+#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+/* This is the ID of the product, low byte first. It is interpreted in the
+ * scope of the vendor ID. If you have registered your own VID with usb.org
+ * or if you have licensed a PID from somebody else, define it here. Otherwise
+ * you may use one of obdev's free shared VID/PID pairs. See the file
+ * USB-IDs-for-free.txt for details!
+ * *** IMPORTANT NOTE ***
+ * This template uses obdev's shared VID/PID pair for Vendor Class devices
+ * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
+ * the implications!
+ */
+#define USB_CFG_DEVICE_VERSION  0x00, 0x02
+/* Version number of the device: Minor number first, then major number.
+ */
+#define USB_CFG_VENDOR_NAME     'w', 'i', 'n', 'k', 'e', 'y', 'l', 'e', 's', 's', '.', 'k', 'r'
+#define USB_CFG_VENDOR_NAME_LEN 13
+/* These two values define the vendor name returned by the USB device. The name
+ * must be given as a list of characters under single quotes. The characters
+ * are interpreted as Unicode (UTF-16) entities.
+ * If you don't want a vendor name string, undefine these macros.
+ * ALWAYS define a vendor name containing your Internet domain name if you use
+ * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
+ * details.
+ */
+#define USB_CFG_DEVICE_NAME     'j', 'j', '4', '0'
+#define USB_CFG_DEVICE_NAME_LEN 4
+/* Same as above for the device name. If you don't want a device name, undefine
+ * the macros. See the file USB-IDs-for-free.txt before you assign a name if
+ * you use a shared VID/PID.
+ */
+/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
+/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
+/* Same as above for the serial number. If you don't want a serial number,
+ * undefine the macros.
+ * It may be useful to provide the serial number through other means than at
+ * compile time. See the section about descriptor properties below for how
+ * to fine tune control over USB descriptors such as the string descriptor
+ * for the serial number.
+ */
+#define USB_CFG_DEVICE_CLASS        0
+#define USB_CFG_DEVICE_SUBCLASS     0
+/* See USB specification if you want to conform to an existing device class.
+ * Class 0xff is "vendor specific".
+ */
+#define USB_CFG_INTERFACE_CLASS     3   /* HID */
+#define USB_CFG_INTERFACE_SUBCLASS  1   /* Boot */
+#define USB_CFG_INTERFACE_PROTOCOL  1   /* Keyboard */
+/* See USB specification if you want to conform to an existing device class or
+ * protocol. The following classes must be set at interface level:
+ * HID class is 3, no subclass and protocol required (but may be useful!)
+ * CDC class is 2, use subclass 2 and protocol 1 for ACM
+ */
+#define USB_CFG_HID_REPORT_DESCRIPTOR_LENGTH    0
+/* Define this to the length of the HID report descriptor, if you implement
+ * an HID device. Otherwise don't define it or define it to 0.
+ * If you use this define, you must add a PROGMEM character array named
+ * "usbHidReportDescriptor" to your code which contains the report descriptor.
+ * Don't forget to keep the array and this define in sync!
+ */
+
+/* #define USB_PUBLIC static */
+/* Use the define above if you #include usbdrv.c instead of linking against it.
+ * This technique saves a couple of bytes in flash memory.
+ */
+
+/* ------------------- Fine Control over USB Descriptors ------------------- */
+/* If you don't want to use the driver's default USB descriptors, you can
+ * provide our own. These can be provided as (1) fixed length static data in
+ * flash memory, (2) fixed length static data in RAM or (3) dynamically at
+ * runtime in the function usbFunctionDescriptor(). See usbdrv.h for more
+ * information about this function.
+ * Descriptor handling is configured through the descriptor's properties. If
+ * no properties are defined or if they are 0, the default descriptor is used.
+ * Possible properties are:
+ *   + USB_PROP_IS_DYNAMIC: The data for the descriptor should be fetched
+ *     at runtime via usbFunctionDescriptor(). If the usbMsgPtr mechanism is
+ *     used, the data is in FLASH by default. Add property USB_PROP_IS_RAM if
+ *     you want RAM pointers.
+ *   + USB_PROP_IS_RAM: The data returned by usbFunctionDescriptor() or found
+ *     in static memory is in RAM, not in flash memory.
+ *   + USB_PROP_LENGTH(len): If the data is in static memory (RAM or flash),
+ *     the driver must know the descriptor's length. The descriptor itself is
+ *     found at the address of a well known identifier (see below).
+ * List of static descriptor names (must be declared PROGMEM if in flash):
+ *   char usbDescriptorDevice[];
+ *   char usbDescriptorConfiguration[];
+ *   char usbDescriptorHidReport[];
+ *   char usbDescriptorString0[];
+ *   int usbDescriptorStringVendor[];
+ *   int usbDescriptorStringDevice[];
+ *   int usbDescriptorStringSerialNumber[];
+ * Other descriptors can't be provided statically, they must be provided
+ * dynamically at runtime.
+ *
+ * Descriptor properties are or-ed or added together, e.g.:
+ * #define USB_CFG_DESCR_PROPS_DEVICE   (USB_PROP_IS_RAM | USB_PROP_LENGTH(18))
+ *
+ * The following descriptors are defined:
+ *   USB_CFG_DESCR_PROPS_DEVICE
+ *   USB_CFG_DESCR_PROPS_CONFIGURATION
+ *   USB_CFG_DESCR_PROPS_STRINGS
+ *   USB_CFG_DESCR_PROPS_STRING_0
+ *   USB_CFG_DESCR_PROPS_STRING_VENDOR
+ *   USB_CFG_DESCR_PROPS_STRING_PRODUCT
+ *   USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER
+ *   USB_CFG_DESCR_PROPS_HID
+ *   USB_CFG_DESCR_PROPS_HID_REPORT
+ *   USB_CFG_DESCR_PROPS_UNKNOWN (for all descriptors not handled by the driver)
+ *
+ * Note about string descriptors: String descriptors are not just strings, they
+ * are Unicode strings prefixed with a 2 byte header. Example:
+ * int  serialNumberDescriptor[] = {
+ *     USB_STRING_DESCRIPTOR_HEADER(6),
+ *     'S', 'e', 'r', 'i', 'a', 'l'
+ * };
+ */
+
+#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
+//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
+#define USB_CFG_DESCR_PROPS_STRINGS                 0
+#define USB_CFG_DESCR_PROPS_STRING_0                0
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
+//#define USB_CFG_DESCR_PROPS_HID                     0
+#define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
+//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
+#define USB_CFG_DESCR_PROPS_UNKNOWN                 0
+
+#define usbMsgPtr_t unsigned short
+/* If usbMsgPtr_t is not defined, it defaults to 'uchar *'. We define it to
+ * a scalar type here because gcc generates slightly shorter code for scalar
+ * arithmetics than for pointer arithmetics. Remove this define for backward
+ * type compatibility or define it to an 8 bit type if you use data in RAM only
+ * and all RAM is below 256 bytes (tiny memory model in IAR CC).
+ */
+
+/* ----------------------- Optional MCU Description ------------------------ */
+
+/* The following configurations have working defaults in usbdrv.h. You
+ * usually don't need to set them explicitly. Only if you want to run
+ * the driver on a device which is not yet supported or with a compiler
+ * which is not fully supported (such as IAR C) or if you use a differnt
+ * interrupt than INT0, you may have to define some of these.
+ */
+/* #define USB_INTR_CFG            MCUCR */
+/* #define USB_INTR_CFG_SET        ((1 << ISC00) | (1 << ISC01)) */
+/* #define USB_INTR_CFG_CLR        0 */
+/* #define USB_INTR_ENABLE         GIMSK */
+/* #define USB_INTR_ENABLE_BIT     INT0 */
+/* #define USB_INTR_PENDING        GIFR */
+/* #define USB_INTR_PENDING_BIT    INTF0 */
+/* #define USB_INTR_VECTOR         INT0_vect */
+
+/* Set INT1 for D- falling edge to count SOF */
+/* #define USB_INTR_CFG            EICRA */
+#define USB_INTR_CFG_SET        ((1 << ISC11) | (0 << ISC10))
+/* #define USB_INTR_CFG_CLR        0 */
+/* #define USB_INTR_ENABLE         EIMSK */
+#define USB_INTR_ENABLE_BIT     INT1
+/* #define USB_INTR_PENDING        EIFR */
+#define USB_INTR_PENDING_BIT    INTF1
+#define USB_INTR_VECTOR         INT1_vect
+
+#endif /* __usbconfig_h_included__ */


### PR DESCRIPTION
This adds support for the JJ40 keyboard from [Aliexpress](https://www.aliexpress.com/item/jj40-Custom-Mechanical-Keyboard-40-PCB-programmed-40-planck-layouts-bface-firmware-gh40/32828781103.html). 

Most of the code is from the `ps2avrgb`, I have adjusted the matrix to work the PCB layout and added a default key mapping.