### PR TITLE
changed colons into hyphens in getting started guide

### DIFF
--- a/docs/getting_started_make_guide.md
+++ b/docs/getting_started_make_guide.md
@@ -1,6 +1,6 @@
 # More detailed make instruction
 
-The full syntax of the `make` command is `<keyboard_folder>:<keymap>:<target>`, where:
+The full syntax of the `make` command is `<keyboard_folder>-<keymap>-<target>`, where:
 
 * `<keyboard_folder>` is the path of the keyboard, for example `planck`
   * Use `all` to compile all keyboards
@@ -13,9 +13,9 @@ The full syntax of the `make` command is `<keyboard_folder>:<keymap>:<target>`, 
 
 The `<target>` means the following
 * If no target is given, then it's the same as `all` below
-* `all` compiles as many keyboard/revision/keymap combinations as specified. For example, `make planck/rev4:default:all` will generate a single .hex, while `make planck/rev4:all` will generate a hex for every keymap available to the planck.
+* `all` compiles as many keyboard/revision/keymap combinations as specified. For example, `make planck/rev4-default-all` will generate a single .hex, while `make planck/rev4-all` will generate a hex for every keymap available to the planck.
 * `dfu`, `teensy` or `dfu-util`, compile and upload the firmware to the keyboard. If the compilation fails, then nothing will be uploaded. The programmer to use depends on the keyboard. For most keyboards it's `dfu`, but for ChibiOS keyboards you should use `dfu-util`, and `teensy` for standard Teensys. To find out which command you should use for your keyboard, check the keyboard specific readme. 
- * **Note**: some operating systems need root access for these commands to work, so in that case you need to run for example `sudo make planck/rev4:default:dfu`.
+ * **Note**: some operating systems need root access for these commands to work, so in that case you need to run for example `sudo make planck/rev4-default-dfu`.
 * `clean`, cleans the build output folders to make sure that everything is built from scratch. Run this before normal compilation if you have some unexplainable problems.
 
 You can also add extra options at the end of the make command line, after the target
@@ -29,9 +29,9 @@ The make command itself also has some additional options, type `make --help` for
 
 Here are some examples commands
 
-* `make all:all` builds everything (all keyboard folders, all keymaps). Running just `make` from the `root` will also run this.
-* `make ergodox_infinity:algernon:clean` will clean the build output of the Ergodox Infinity keyboard. 
-* `make planck/rev4:default:dfu COLOR=false` builds and uploads the keymap without color output.
+* `make all-all` builds everything (all keyboard folders, all keymaps). Running just `make` from the `root` will also run this.
+* `make ergodox_infinity-algernon-clean` will clean the build output of the Ergodox Infinity keyboard. 
+* `make planck/rev4-default-dfu COLOR=false` builds and uploads the keymap without color output.
 
 ## `rules.mk` options
 


### PR DESCRIPTION
Spent a couple hours pulling my hair out today, trying to flash a layout to my Planck on my Mac.

The docs, specifically https://docs.qmk.fm/getting_started_make_guide.html, say to use the `make` command like: `make planck/rev4:default:dfu`, with colons. 

After going through the Makefile line by line, I realized that it says to use hyphens, i.e.:

```
# The entry point for rule parsing
# parses a rule in the format <keyboard>-<subproject>-<keymap>-<target>
# but this particular function only deals with the first <keyboard> part```

Running this, e.g., `make planck/rev4-default-dfu` works.  I'm assuming that OSX is enough like Linux that the same would be true for that as well.  I've opened a pull request about this issue.
