### PR TITLE
ErgoDone: VID/PID/NKRO

### DIFF
--- a/keyboards/ergodone/config.h
+++ b/keyboards/ergodone/config.h
@@ -58,7 +58,9 @@
 #define USB_MAX_POWER_CONSUMPTION 500
 
 /* NKRO */
-#define FORCE_NKRO  // Depends on NKRO_ENABLE.
+#ifndef FORCE_NKRO
+    #define FORCE_NKRO  // Depends on NKRO_ENABLE.
+#endif
 
 /*
  * Feature disable options

--- a/keyboards/ergodone/config.h
+++ b/keyboards/ergodone/config.h
@@ -4,10 +4,11 @@
 #include "config_common.h"
 
 /* USB Device descriptor parameter */
-#define VENDOR_ID       0xFEED
-#define PRODUCT_ID      0x1307
+#define VENDOR_ID       0xFEED  // You may want to use 0x47EC for "KTEC", which doesn't seem to be in official use as of October 2017.
+#define PRODUCT_ID      0xE60D  // For "EGOD"/"ErgoDone".
+// The official ErgoDone VID and PID are documented at http://pid.codes/1209/2328/.
 #define DEVICE_VER      0x0001
-#define MANUFACTURER    ErgoDone
+#define MANUFACTURER    K.T.E.C.
 #define PRODUCT         ErgoDone
 #define DESCRIPTION     QMK keyboard firmware for ErgoDone
 
@@ -55,6 +56,9 @@
 #define PREVENT_STUCK_MODIFIERS
 
 #define USB_MAX_POWER_CONSUMPTION 500
+
+/* NKRO */
+#define FORCE_NKRO  // Depends on NKRO_ENABLE.
 
 /*
  * Feature disable options


### PR DESCRIPTION
- Fancy default PID and option for corresponding VID.
- Information about official VID/PID.
- Correct manufacturer name.
- NKRO enabled by default.

*This replaces the PR https://github.com/qmk/qmk_firmware/pull/1801.*