### PR TITLE
Add links to lets_split EEPROM files for orthodox kb

### DIFF
--- a/keyboards/orthodox/readme.md
+++ b/keyboards/orthodox/readme.md
@@ -125,13 +125,12 @@ EEPROM for the left and right halves.
 
 The EEPROM is used to store whether the
 half is left handed or right handed. This makes it so that the same firmware
-file will run on both hands instead of having to flash left and right handed
+file will run on both hands instead of having to flash [left](../lets_split/eeprom-lefthand.eep) and [right](../lets_split/eeprom-righthand.eep) handed
 versions of the firmware to each half. To flash the EEPROM file for the left
 half run:
 ```
 avrdude -p atmega32u4 -P $(COM_PORT) -c avr109 -U eeprom:w:eeprom-lefthand.eep
 // or the equivalent in dfu-programmer
-
 ```
 and similarly for right half
 ```


### PR DESCRIPTION
I reached out to the author via Reddit to inquire about some files referenced in the README and was pointed to the files in a separate keyboard src (the orthodox is based on the lets_split). This change simply links to those files for the EEPROM method explained in the orthodox's README.