### PR TITLE
Add RESET to satan:dbroqua mapping

### DIFF
--- a/keyboards/satan/keymaps/dbroqua/keymap.c
+++ b/keyboards/satan/keymaps/dbroqua/keymap.c
@@ -41,7 +41,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |-----------------------------------------------------------------------------------------+
  * |  CAPS  | BL- | BL+ | BL  |     |     |     |     | Psc | Slck| Paus| Up  |     |        |
  * |-----------------------------------------------------------------------------------------+
- * |         | Vol-| Vol+| Mute|     |     | *   | /   | Home| PgUp| Left|Right|             |
+ * |         | Vol-| Vol+| Mute|RESET|     | *   | /   | Home| PgUp| Left|Right|             |
  * |-----------------------------------------------------------------------------------------+
  * |           | Prev| Play| Next|     |     | +   | -   | End  |PgDn| Down|           |     |
  * |-----------------------------------------------------------------------------------------+
@@ -51,7 +51,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   [_FN] = KEYMAP_HHKB( /* Layer 1 */
       TG(_SFX), KC_F1,  KC_F2,  KC_F3,  KC_F4,  KC_F5,  KC_F6,  KC_F7,  KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12, KC_INS,  KC_DEL, \
       KC_CAPS,  ______, ______, ______, ______, ______, ______, ______, KC_PSCR, KC_SLCK, KC_PAUS, KC_UP,   ______, ______,  \
-      ______,   KC_VOLD,KC_VOLU,KC_MUTE,______, ______, KC_PAST,KC_PSLS,KC_HOME, KC_PGUP, KC_LEFT, KC_RGHT, ______,   \
+      ______,   KC_VOLD,KC_VOLU,KC_MUTE, RESET, ______, KC_PAST,KC_PSLS,KC_HOME, KC_PGUP, KC_LEFT, KC_RGHT, ______,   \
       ______,   KC_MPRV,KC_MPLY,KC_MNXT,______, ______, KC_PPLS,KC_PMNS,KC_END,  KC_PGDN, KC_DOWN, ______,  ______,  \
       ______,   ______, ______,                 ______,                 KC_MSTP, ______,  ______,  ______ \
       ),


### PR DESCRIPTION
Make `Fn+F` (previously not mapped to anything) map to RESET so the case doesn't need to be removed to flash new firmware.