### PR TITLE
Added a better way to cycle through RGB modes

### DIFF
--- a/docs/feature_rgblight.md
+++ b/docs/feature_rgblight.md
@@ -88,6 +88,7 @@ These control the RGB Lighting functionality.
 |-----------|------------|-------------|
 ||`RGB_TOG`|toggle on/off|
 ||`RGB_MOD`|cycle through modes|
+||`RGB_SMOD`|cycle through modes, use reverse direction when shift is hold|
 ||`RGB_HUI`|hue increase|
 ||`RGB_HUD`|hue decrease|
 ||`RGB_SAI`|saturation increase|

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -290,6 +290,18 @@ bool process_record_quantum(keyrecord_t *record) {
       rgblight_step();
     }
     return false;
+  case RGB_SMOD:
+    // same as RBG_MOD, but if shift is pressed, it will use the reverese direction instead.
+    if (record->event.pressed) {
+      uint8_t shifted = get_mods() & (MOD_BIT(KC_LSHIFT)|MOD_BIT(KC_RSHIFT));
+      if(shifted) {
+        rgblight_step_reverse();
+      }
+      else {
+        rgblight_step();
+      }
+    }
+    return false;
   case RGB_HUI:
     if (record->event.pressed) {
       rgblight_increase_hue();

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -400,6 +400,7 @@ enum quantum_keycodes {
     // RGB functionality
     RGB_TOG,
     RGB_MOD,
+    RGB_SMOD,
     RGB_HUI,
     RGB_HUD,
     RGB_SAI,


### PR DESCRIPTION
This commit adds a new keycode `RGB_SMOD` which is the same as `RGB_MOD` (cycle through all modes), but when it is used in combination with shift it will reverse the direction. The documentation is also updated.

It works on my b.face and it's pretty awesome if you just missed that one mode you wanted ;)