### PR TITLE
fixed two typos

### DIFF
--- a/docs/feature_tap_dance.md
+++ b/docs/feature_tap_dance.md
@@ -200,12 +200,12 @@ typedef struct {
 int cur_dance (qk_tap_dance_state_t *state) {
   if (state->count == 1) {
     //If count = 1, and it has been interrupted - it doesn't matter if it is pressed or not: Send SINGLE_TAP
-    if (state->interrupted || state->!pressed) return SINGLE_TAP;
+    if (state->interrupted || state->pressed==0) return SINGLE_TAP;
     else return SINGLE_HOLD;
   }
   //If count = 2, and it has been interrupted - assume that user is trying to type the letter associated
   //with single tap. In example below, that means to send `xx` instead of `Escape`.
-  else if (state->count = 2) {
+  else if (state->count == 2) {
     if (state->interrupted) return DOUBLE_SINGLE_TAP;
     else if (state->pressed) return DOUBLE_HOLD;
     else return DOUBLE_TAP;


### PR DESCRIPTION
I'm almost 100% sure "else if (state->count = 2) {" was a typo (it should have two ='s for a logical operator).

I'm **_pretty_** sure "if (state->interrupted || state->!pressed) return SINGLE_TAP;" has a typo. At least, it returns an error on my machine saying something about an unexpected '!'.  
I changed it to a slightly longer form (i.e., "state->pressed==0"), and that worked fine.