### PR TITLE
Update snake animation while increment is positive

### DIFF
--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -534,6 +534,9 @@ void rgblight_effect_snake(uint8_t interval) {
     led[i].b = 0;
     for (j = 0; j < RGBLIGHT_EFFECT_SNAKE_LENGTH; j++) {
       k = pos + j * increment;
+      if (k > RGBLED_NUM) {
+        k = K % RGBLED_NUM;
+      }
       if (k < 0) {
         k = k + RGBLED_NUM;
       }

--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -535,7 +535,7 @@ void rgblight_effect_snake(uint8_t interval) {
     for (j = 0; j < RGBLIGHT_EFFECT_SNAKE_LENGTH; j++) {
       k = pos + j * increment;
       if (k > RGBLED_NUM) {
-        k = K % RGBLED_NUM;
+        k = k % RGBLED_NUM;
       }
       if (k < 0) {
         k = k + RGBLED_NUM;


### PR DESCRIPTION
While I was mucking around with my niu mini, I decided to play with the RGB animations to get used to the layout and noticed that the LEDs were behaving oddly in the 'snake' animation.

In one direction (while increment is positive), when it got to a certain point in the LEDs, the 'tail' would just shut off all at once. This was happening because it was trying to use LEDs that don't exist/aren't on the board.

Small check to see if the number is too large and using a modulus to get the right position fixes the issue!