### PR TITLE
Extended the help for setting ps2avrGB boards to bootloader mode

### DIFF
--- a/keyboards/ps2avrGB/README.md
+++ b/keyboards/ps2avrGB/README.md
@@ -49,13 +49,26 @@ $ make ps2avrGB
 $ bootloadHID -r ps2avrGB_default.hex
 ```
 
+## Setting the board to bootloader mode
+
+If you're lucky, the programming script does this automagically for you. If
+however this doesn't work for you, you need to enter the bootloader mode manually
+by plugging the keyboard in while holding the bootloader key. If you did this
+correctly the LEDs will blink and you'll be able to flash your firmware.
+
+The bootloader key is the top left key of your matrix. For a standard board
+from winkeyless.kr this is `L_Ctrl`, but for some custom boards running ps2avrGB
+this might be different. For the Pearl it's `Esc`, for a b.fake it is `q`. If 
+you're unsure you should be able to see the key in the bootmapper client.
+
+
 ## Troubleshooting
 
 From my experience, it's really hard to brick these boards. But these
 tricks have been useful when it got stuck in a weird scenario.
 
-1. Try plugging the board in while pressing `L_Ctrl`. This will force it
-   to boot only the bootloader without loading the firmware. Once this is
+1. Try plugging the board in while holding the bootloader key. This will force 
+   it to boot only the bootloader without loading the firmware. Once this is
    done, just reflash the board with the original firmware.
 2. Sometimes USB hubs can act weird, so try connecting the board directly
    to your computer or plugging/unplugging the USB hub.

--- a/keyboards/ps2avrGB/program
+++ b/keyboards/ps2avrGB/program
@@ -76,7 +76,8 @@ if kb is not None:
     print('Found a keyboad in normal mode. Attempting to send it to bootloader mode ...', end='')
     sendDeviceToBootloaderMode(kb)
     print(' done.')
-    print("Hint: If your keyboard can't be set to bootloader mode automatically, plug it in while pressing left control to do so manually.")
+    print("Hint: If your keyboard can't be set to bootloader mode automatically, plug it in while pressing the bootloader key to do so manually.")
+    print("      You can find more infos about this here: https://github.com/qmk/qmk_firmware/tree/master/keyboards/ps2avrGB#setting-the-board-to-bootloader-mode")
 
 attempts = 12  # 60 seconds
 found = False


### PR DESCRIPTION
Before, the programming script for ps2avrGB boards gave a generic hint to enter the bootloader mode with `lctrl`. Unfortunately, this is not true for all boards running the firmware. Therefore I extended README of the folder on how to set the board to bootloader mode and the programming script now links at this section instead of giving a direct key to press.

On a side note, the section about supported keyboards is no longer true, but I did not fix this as this would be a different topic.