### PR TITLE
Ergodox ez left leds support

### DIFF
--- a/keyboards/ergodox_ez/ergodox_ez.c
+++ b/keyboards/ergodox_ez/ergodox_ez.c
@@ -61,11 +61,46 @@ void ergodox_blink_all_leds(void)
     _delay_ms(50);
     ergodox_right_led_3_on();
     _delay_ms(50);
+#ifdef LEFT_LEDS
+    ergodox_left_led_1_on();
+    _delay_ms(50);
+    if (!mcp23018_status) {
+      mcp23018_status = ergodox_left_leds_update();
+    }
+    ergodox_left_led_2_on();
+    _delay_ms(50);
+    if (!mcp23018_status) {
+      mcp23018_status = ergodox_left_leds_update();
+    }
+    ergodox_left_led_3_on();
+    _delay_ms(50);
+    if (!mcp23018_status) {
+      mcp23018_status = ergodox_left_leds_update();
+    }
+#endif
     ergodox_right_led_1_off();
     _delay_ms(50);
     ergodox_right_led_2_off();
     _delay_ms(50);
     ergodox_right_led_3_off();
+#ifdef LEFT_LEDS
+    _delay_ms(50);
+    ergodox_left_led_1_off();
+    if (!mcp23018_status) {
+      mcp23018_status = ergodox_left_leds_update();
+    }
+    _delay_ms(50);
+    ergodox_left_led_2_off();
+    if (!mcp23018_status) {
+      mcp23018_status = ergodox_left_leds_update();
+    }
+    _delay_ms(50);
+    ergodox_left_led_3_off();
+    if (!mcp23018_status) {
+      mcp23018_status = ergodox_left_leds_update();
+    }
+#endif
+    
     //ergodox_led_all_on();
     //_delay_ms(333);
     ergodox_led_all_off();
@@ -106,6 +141,10 @@ uint8_t init_mcp23018(void) {
 
 out:
     i2c_stop();
+
+#ifdef LEFT_LEDS
+    if (!mcp23018_status) mcp23018_status = ergodox_left_leds_update();
+#endif // LEFT_LEDS
 
     // SREG=sreg_prev;
 

--- a/keyboards/ergodox_ez/ergodox_ez.c
+++ b/keyboards/ergodox_ez/ergodox_ez.c
@@ -151,6 +151,40 @@ out:
     return mcp23018_status;
 }
 
+#ifdef LEFT_LEDS
+uint8_t ergodox_left_leds_update(void) {
+    if (mcp23018_status) { // if there was an error
+        return mcp23018_status;
+    }
+#define LEFT_LED_1_SHIFT        7       // in MCP23018 port B
+#define LEFT_LED_2_SHIFT        6       // in MCP23018 port B
+#define LEFT_LED_3_SHIFT        7       // in MCP23018 port A
+
+    // set logical value (doesn't matter on inputs)
+    // - unused  : hi-Z : 1
+    // - input   : hi-Z : 1
+    // - driving : hi-Z : 1
+    mcp23018_status = i2c_start(I2C_ADDR_WRITE);
+    if (mcp23018_status) goto out;
+    mcp23018_status = i2c_write(OLATA);
+    if (mcp23018_status) goto out;
+    mcp23018_status = i2c_write(0b11111111
+                                & ~(ergodox_left_led_3<<LEFT_LED_3_SHIFT)
+                                );
+    if (mcp23018_status) goto out;
+    mcp23018_status = i2c_write(0b11111111
+                                & ~(ergodox_left_led_2<<LEFT_LED_2_SHIFT)
+                                & ~(ergodox_left_led_1<<LEFT_LED_1_SHIFT)
+                                );
+    if (mcp23018_status) goto out;
+
+ out:
+    i2c_stop();
+    return mcp23018_status;
+}
+#endif
+
+
 #ifdef ONEHAND_ENABLE
 __attribute__ ((weak))
 // swap-hands action needs a matrix to define the swap

--- a/keyboards/ergodox_ez/ergodox_ez.h
+++ b/keyboards/ergodox_ez/ergodox_ez.h
@@ -46,12 +46,31 @@ inline void ergodox_right_led_2_off(void)   { DDRB &= ~(1<<6); PORTB &= ~(1<<6);
 inline void ergodox_right_led_3_off(void)   { DDRB &= ~(1<<7); PORTB &= ~(1<<7); }
 inline void ergodox_right_led_off(uint8_t led) { DDRB &= ~(1<<(led+4)); PORTB &= ~(1<<(led+4)); }
 
+#ifdef LEFT_LEDS
+bool ergodox_left_led_1;
+bool ergodox_left_led_2;
+bool ergodox_left_led_3;
+
+inline void ergodox_left_led_1_on(void)    { ergodox_left_led_1 = 1; }
+inline void ergodox_left_led_2_on(void)    { ergodox_left_led_2 = 1; }
+inline void ergodox_left_led_3_on(void)    { ergodox_left_led_3 = 1; }
+
+inline void ergodox_left_led_1_off(void)    { ergodox_left_led_1 = 0; }
+inline void ergodox_left_led_2_off(void)    { ergodox_left_led_2 = 0; }
+inline void ergodox_left_led_3_off(void)    { ergodox_left_led_3 = 0; }
+#endif // LEFT_LEDS
+
 inline void ergodox_led_all_on(void)
 {
     ergodox_board_led_on();
     ergodox_right_led_1_on();
     ergodox_right_led_2_on();
     ergodox_right_led_3_on();
+#ifdef LEFT_LEDS
+    ergodox_left_led_1_on();
+    ergodox_left_led_2_on();
+    ergodox_left_led_3_on();
+#endif // LEFT_LEDS
 }
 
 inline void ergodox_led_all_off(void)
@@ -60,6 +79,11 @@ inline void ergodox_led_all_off(void)
     ergodox_right_led_1_off();
     ergodox_right_led_2_off();
     ergodox_right_led_3_off();
+#ifdef LEFT_LEDS
+    ergodox_left_led_1_off();
+    ergodox_left_led_2_off();
+    ergodox_left_led_3_off();
+#endif // LEFT_LEDS
 }
 
 inline void ergodox_right_led_1_set(uint8_t n)    { OCR1A = n; }

--- a/keyboards/ergodox_ez/matrix.c
+++ b/keyboards/ergodox_ez/matrix.c
@@ -202,6 +202,9 @@ uint8_t matrix_scan(void)
     }
 #endif
 
+#ifdef LEFT_LEDS
+     mcp23018_status = ergodox_left_leds_update();
+#endif // LEFT_LEDS
     for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
         select_row(i);
         wait_us(30);  // without this wait read unstable value.

--- a/keyboards/ergodox_ez/rules.mk
+++ b/keyboards/ergodox_ez/rules.mk
@@ -66,6 +66,10 @@ OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
 #   USBaspLoader     2048
 OPT_DEFS += -DBOOTLOADER_SIZE=512
 
+# If you have Left LEDs (see
+# https://geekhack.org/index.php?topic=22780.msg873819#msg873819 for
+# details), include the following define:
+# OPT_DEFS += -DLEFT_LEDS
 
 # Build Options
 #   comment out to disable the options.


### PR DESCRIPTION
I have an Ergodox EZ with the left LED hack in place
(https://geekhack.org/index.php?topic=22780.msg873819#msg873819), and
would like to add back in support in erogodox_ez.c for this hack.

Currently it's implemented using #define LEFT_LEDS (as it was done
previously), but I'm totally flexible.

The current implementation just cycles the lights on boot; keymap
specific code is required to do anything useful on layer switch, etc. (You can see a trivial example here: https://github.com/dondelelcaro/qmk_firmware/blob/don_left_leds/layouts/community/ergodox/don/keymap.c#L206)
