### PR TITLE
RETRO_TAPPING

### DIFF
--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -109,7 +109,7 @@ If you define these options you will enable the associated feature, which may in
 
 * `#define TAPPING_TERM 200`
   * how long before a tap becomes a hold
-* `#define RETRO_TAP`
+* `#define RETRO_TAPPING`
   * tap anyway, even after TAPPING_TERM, if there was no other key interruption between press and release
 * `#define TAPPING_TOGGLE 2`
   * how many taps before triggering the toggle

--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -109,6 +109,8 @@ If you define these options you will enable the associated feature, which may in
 
 * `#define TAPPING_TERM 200`
   * how long before a tap becomes a hold
+* `#define RETRO_TAP`
+  * tap anyway, even after TAPPING_TERM, if there was no other key interruption between press and release
 * `#define TAPPING_TOGGLE 2`
   * how many taps before triggering the toggle
 * `#define PERMISSIVE_HOLD`

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -36,8 +36,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 int tp_buttons;
 
-#ifdef RETRO_TAP
-int retro_tap_counter = 0;
+#ifdef RETRO_TAPPING
+int retro_tapping_counter = 0;
 #endif
 
 #ifdef FAUXCLICKY_ENABLE
@@ -49,8 +49,8 @@ void action_exec(keyevent_t event)
     if (!IS_NOEVENT(event)) {
         dprint("\n---- action_exec: start -----\n");
         dprint("EVENT: "); debug_event(event); dprintln();
-#ifdef RETRO_TAP
-        retro_tap_counter++;
+#ifdef RETRO_TAPPING
+        retro_tapping_counter++;
 #endif
     }
 
@@ -594,25 +594,25 @@ void process_action(keyrecord_t *record, action_t action)
 #endif
 
 #ifndef NO_ACTION_TAPPING
-  #ifdef RETRO_TAP
+  #ifdef RETRO_TAPPING
   if (!is_tap_key(record->event.key)) {
-    retro_tap_counter = 0;
+    retro_tapping_counter = 0;
   } else {
     if (event.pressed) {
         if (tap_count > 0) {
-          retro_tap_counter = 0;
+          retro_tapping_counter = 0;
         } else {
 
         }
     } else {
       if (tap_count > 0) {
-        retro_tap_counter = 0;
+        retro_tapping_counter = 0;
       } else {
-        if (retro_tap_counter == 2) {
+        if (retro_tapping_counter == 2) {
           register_code(action.layer_tap.code);
           unregister_code(action.layer_tap.code);
         }
-        retro_tap_counter = 0;
+        retro_tapping_counter = 0;
       }
     }
   }

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -36,6 +36,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 int tp_buttons;
 
+#ifdef RETRO_TAP
+int slow_tap_counter = 0;
+#endif
+
 #ifdef FAUXCLICKY_ENABLE
 #include <fauxclicky.h>
 #endif
@@ -45,6 +49,9 @@ void action_exec(keyevent_t event)
     if (!IS_NOEVENT(event)) {
         dprint("\n---- action_exec: start -----\n");
         dprint("EVENT: "); debug_event(event); dprintln();
+#ifdef RETRO_TAP
+        slow_tap_counter++;
+#endif
     }
 
 #ifdef FAUXCLICKY_ENABLE
@@ -586,6 +593,32 @@ void process_action(keyrecord_t *record, action_t action)
     }
 #endif
 
+#ifndef NO_ACTION_TAPPING
+  #ifdef RETRO_TAP
+  if (!is_tap_key(record->event.key)) {
+    slow_tap_counter = 0;
+  } else {
+    if (event.pressed) {
+        if (tap_count > 0) {
+          slow_tap_counter = 0;
+        } else {
+
+        }
+    } else {
+      if (tap_count > 0) {
+        slow_tap_counter = 0;
+      } else {
+        if (slow_tap_counter == 2) {
+          register_code(action.layer_tap.code);
+          unregister_code(action.layer_tap.code);
+        }
+        slow_tap_counter = 0;
+      }
+    }
+  }
+  #endif
+#endif
+
 #ifndef NO_ACTION_ONESHOT
     /* Because we switch layers after a oneshot event, we need to release the
      * key before we leave the layer or no key up event will be generated.
@@ -619,7 +652,7 @@ void register_code(uint8_t code)
 #endif
         add_key(KC_CAPSLOCK);
         send_keyboard_report();
-        wait_ms(100);        
+        wait_ms(100);
         del_key(KC_CAPSLOCK);
         send_keyboard_report();
     }
@@ -630,7 +663,7 @@ void register_code(uint8_t code)
 #endif
         add_key(KC_NUMLOCK);
         send_keyboard_report();
-        wait_ms(100);        
+        wait_ms(100);
         del_key(KC_NUMLOCK);
         send_keyboard_report();
     }
@@ -641,7 +674,7 @@ void register_code(uint8_t code)
 #endif
         add_key(KC_SCROLLLOCK);
         send_keyboard_report();
-        wait_ms(100);        
+        wait_ms(100);
         del_key(KC_SCROLLLOCK);
         send_keyboard_report();
     }

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -37,7 +37,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 int tp_buttons;
 
 #ifdef RETRO_TAP
-int slow_tap_counter = 0;
+int retro_tap_counter = 0;
 #endif
 
 #ifdef FAUXCLICKY_ENABLE
@@ -50,7 +50,7 @@ void action_exec(keyevent_t event)
         dprint("\n---- action_exec: start -----\n");
         dprint("EVENT: "); debug_event(event); dprintln();
 #ifdef RETRO_TAP
-        slow_tap_counter++;
+        retro_tap_counter++;
 #endif
     }
 
@@ -596,23 +596,23 @@ void process_action(keyrecord_t *record, action_t action)
 #ifndef NO_ACTION_TAPPING
   #ifdef RETRO_TAP
   if (!is_tap_key(record->event.key)) {
-    slow_tap_counter = 0;
+    retro_tap_counter = 0;
   } else {
     if (event.pressed) {
         if (tap_count > 0) {
-          slow_tap_counter = 0;
+          retro_tap_counter = 0;
         } else {
 
         }
     } else {
       if (tap_count > 0) {
-        slow_tap_counter = 0;
+        retro_tap_counter = 0;
       } else {
-        if (slow_tap_counter == 2) {
+        if (retro_tap_counter == 2) {
           register_code(action.layer_tap.code);
           unregister_code(action.layer_tap.code);
         }
-        slow_tap_counter = 0;
+        retro_tap_counter = 0;
       }
     }
   }

--- a/tmk_core/common/action_tapping.h
+++ b/tmk_core/common/action_tapping.h
@@ -24,7 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define TAPPING_TERM    200
 #endif
 
-#define RETRO_TAP // Tap anyway, even after TAPPING_TERM, as long as there was no interruption
+#define RETRO_TAPPING // Tap anyway, even after TAPPING_TERM, as long as there was no interruption
 
 /* tap count needed for toggling a feature */
 #ifndef TAPPING_TOGGLE

--- a/tmk_core/common/action_tapping.h
+++ b/tmk_core/common/action_tapping.h
@@ -24,7 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define TAPPING_TERM    200
 #endif
 
-#define RETRO_TAPPING // Tap anyway, even after TAPPING_TERM, as long as there was no interruption
+//#define RETRO_TAPPING // Tap anyway, even after TAPPING_TERM, as long as there was no interruption
 
 /* tap count needed for toggling a feature */
 #ifndef TAPPING_TOGGLE

--- a/tmk_core/common/action_tapping.h
+++ b/tmk_core/common/action_tapping.h
@@ -24,6 +24,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define TAPPING_TERM    200
 #endif
 
+#define RETRO_TAP // Tap anyway, even after TAPPING_TERM, as long as there was no interruption
+
 /* tap count needed for toggling a feature */
 #ifndef TAPPING_TOGGLE
 #define TAPPING_TOGGLE  5


### PR DESCRIPTION
Added RETRO_TAPPING option to retroactively trigger TAP, even after TAPPING_TERM, as long as there as no other key interruption.

Without this option, if I press a TAP, and release it after TAPPING_TERM, then it does nothing.
(example: https://www.reddit.com/r/olkb/comments/78ruya/qmk_lt_tap_timeout_question/ )