### PR TITLE
Fix pointer device options

### DIFF
--- a/common_features.mk
+++ b/common_features.mk
@@ -70,7 +70,8 @@ ifeq ($(strip $(FAUXCLICKY_ENABLE)), yes)
 endif
 
 ifeq ($(strip $(POINTING_DEVICE_ENABLE)), yes)
-	SRC += $(QUANTUM_DIR)/pointing_device.c
+    OPT_DEFS += -POINTING_DEVICE_ENABLE
+    SRC += $(QUANTUM_DIR)/pointing_device.c
 endif
 
 ifeq ($(strip $(UCIS_ENABLE)), yes)

--- a/common_features.mk
+++ b/common_features.mk
@@ -70,7 +70,7 @@ ifeq ($(strip $(FAUXCLICKY_ENABLE)), yes)
 endif
 
 ifeq ($(strip $(POINTING_DEVICE_ENABLE)), yes)
-    OPT_DEFS += -POINTING_DEVICE_ENABLE
+    OPT_DEFS += -DPOINTING_DEVICE_ENABLE
     SRC += $(QUANTUM_DIR)/pointing_device.c
 endif
 


### PR DESCRIPTION
when the feature was added, the appropriate option definition wasn't created.   