### PR TITLE
Fix Pointing Device code

### DIFF
--- a/common_features.mk
+++ b/common_features.mk
@@ -70,7 +70,8 @@ ifeq ($(strip $(FAUXCLICKY_ENABLE)), yes)
 endif
 
 ifeq ($(strip $(POINTING_DEVICE_ENABLE)), yes)
-	SRC += $(QUANTUM_DIR)/pointing_device.c
+    OPT_DEFS += -POINTING_DEVICE_ENABLE
+    SRC += $(QUANTUM_DIR)/pointing_device.c
 endif
 
 ifeq ($(strip $(UCIS_ENABLE)), yes)

--- a/common_features.mk
+++ b/common_features.mk
@@ -70,7 +70,7 @@ ifeq ($(strip $(FAUXCLICKY_ENABLE)), yes)
 endif
 
 ifeq ($(strip $(POINTING_DEVICE_ENABLE)), yes)
-    OPT_DEFS += -POINTING_DEVICE_ENABLE
+    OPT_DEFS += -DPOINTING_DEVICE_ENABLE
     SRC += $(QUANTUM_DIR)/pointing_device.c
 endif
 

--- a/quantum/pointing_device.h
+++ b/quantum/pointing_device.h
@@ -22,7 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "host.h"
 #include "report.h"
 
-void pointingdevice_init(void);
+void pointing_device_init(void);
 void pointing_device_task(void);
 void pointing_device_send(void);
 report_mouse_t pointing_device_get_report(void);


### PR DESCRIPTION
It was missing the opt_def in the common_features.mk file.

Additionally, the pointing_device.h file improperly named the function.