### PR TITLE
fix Logical Maximum to be recognized as 255 instead of -1

### DIFF
--- a/tmk_core/protocol/chibios/usb_main.c
+++ b/tmk_core/protocol/chibios/usb_main.c
@@ -146,7 +146,7 @@ static const uint8_t keyboard_hid_report_desc_data[] = {
   0x95, KBD_REPORT_KEYS,          //   Report Count (),
   0x75, 0x08,                //   Report Size (8),
   0x15, 0x00,                //   Logical Minimum (0),
-  0x25, 0xFF,                //   Logical Maximum(255),
+  0x26, 0xFF, 0x00,          //   Logical Maximum(255),
   0x05, 0x07,                //   Usage Page (Key Codes),
   0x19, 0x00,                //   Usage Minimum (0),
   0x29, 0xFF,                //   Usage Maximum (255),


### PR DESCRIPTION
I would like to use KC_LANG1 & KC_LANG2 key for Infinity ErgoDox but the same problem as #312 is happening.

## Environment

- Mac OSX
- Infinity ErgoDox

## My investigation results

I confimed that Infinity ErgoDox sends both KC_LANG1 & KC_LANG2 using hid_listen.mac.

Next i tried to change [this line](https://github.com/qmk/qmk_firmware/blob/4c1164c469a103981478222b21ef5ffaa364448d/tmk_core/protocol/chibios/usb_main.c#L149) as the following:

```
0x25, 0x68,                //   Logical Maximum(104),
```

Then KC_LANG1 & KC_LANG2 were worked correctly.
"0x68" is 104 so OS recognizes my keyboard as 104-key keyboard.
I assumed that same problem as #312 is happening for chibios.
So i changed like the following:

```
0x26, 0xFF, 0x00                //   Logical Maximum(255),
```

I'm not sure this change is completely correct, but KC_LANG1 & KC_LANG2 is worked on Infinity ErgoDox.

