### PR TITLE
Update .editorconfig end of line

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,7 @@ indent_style = space
 indent_size = 2
 
 # We recommend you to keep these unchanged
-end_of_line = lf
+end_of_line = crlf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true


### PR DESCRIPTION
Unless I'm mistaken, the end of line should be "crlf" and not "lf". 
This should be changed for consistency.

Additionally, while 2 spaces for tabs  is what is listed in the documentation, it appears that almost ALL of the code is actually using 4 spaces. 
However, I didn't want to change this without verifying.