### PR TITLE
lets_split: Fix matrix_init for ROW2COL

### DIFF
--- a/keyboards/lets_split/matrix.c
+++ b/keyboards/lets_split/matrix.c
@@ -128,8 +128,13 @@ void matrix_init(void)
     debug_matrix = true;
     debug_mouse = true;
     // initialize row and col
+#if (DIODE_DIRECTION == COL2ROW)
     unselect_rows();
     init_cols();
+#elif (DIODE_DIRECTION == ROW2COL)
+    unselect_cols();
+    init_rows();
+#endif
 
     TX_RX_LED_INIT;
 


### PR DESCRIPTION
Signed-off-by: Marian Rusu <rusumarian91@gmail.com>