### PR TITLE
add pgm_read_dword for Infinity ErgoDox

### DIFF
--- a/tmk_core/common/progmem.h
+++ b/tmk_core/common/progmem.h
@@ -7,6 +7,7 @@
 #   define PROGMEM
 #   define pgm_read_byte(p)     *((unsigned char*)p)
 #   define pgm_read_word(p)     *((uint16_t*)p)
+#   define pgm_read_dword(p)    *((uint32_t*)p)
 #endif
 
 #endif


### PR DESCRIPTION
I caught the following error when building with `UNICODEMAP_ENABLE = yes` for Infinity ErgoDox.

```
quantum/process_keycode/process_unicodemap.c:52:21: error: implicit declaration of function 'pgm_read_dword'
```

## Environments

- Mac OSX
- Infinity ErgoDox
- `UNICODEMAP_ENABLE = yes`
