### PR TITLE
Fix RGBLIGHT startup color

### DIFF
--- a/keyboards/ergodox_ez/keymaps/default/keymap.c
+++ b/keyboards/ergodox_ez/keymaps/default/keymap.c
@@ -194,7 +194,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 
 // Runs just one time when the keyboard initializes.
 void matrix_init_user(void) {
-#ifdef RGBLIGHT_COLOR_|LAYER_0
+#ifdef RGBLIGHT_COLOR_LAYER_0
   rgblight_setrgb(RGBLIGHT_COLOR_LAYER_0);
 #endif
 };

--- a/keyboards/ergodox_ez/keymaps/default/keymap.c
+++ b/keyboards/ergodox_ez/keymaps/default/keymap.c
@@ -194,7 +194,9 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 
 // Runs just one time when the keyboard initializes.
 void matrix_init_user(void) {
-
+#ifdef RGBLIGHT_COLOR_|LAYER_0
+  rgblight_setrgb(RGBLIGHT_COLOR_LAYER_0);
+#endif
 };
 
 // Runs constantly in the background, in a loop.


### PR DESCRIPTION
While it's awesome to see the layer indicating code in here (no really!), and the general rule is to not alter the default keymap/code....

The problem with the layer_state_set_kb call handling this, is that the code doesn't seem to be called at startup.  So the default layer color won't ever get set on startup.  It needs to be called in the init function to be properly set. 

I've played with this a lot, and if you check my keymaps, that is precisely why I have the setrgb/sethsv in the init function.