### PR TITLE
qwerty_code_friendly: Expose caps-lock & fix typo

### DIFF
--- a/layouts/community/ergodox/qwerty_code_friendly/keymap.c
+++ b/layouts/community/ergodox/qwerty_code_friendly/keymap.c
@@ -15,32 +15,36 @@
 #define CFQ_USE_DYNAMIC_MACRO
 
 #if !defined(CFQ_USER_KEY1)
-#define CFQ_USER_KEY1 CFQ_KC_FN1
+#  define CFQ_USER_KEY1 CFQ_KC_FN1
 #endif
 #if !defined(CFQ_USER_KEY2)
-#define CFQ_USER_KEY2 KC_INS
+#  define CFQ_USER_KEY2 KC_INS
 #endif
 #if !defined(CFQ_USER_KEY3)
-#define CFQ_USER_KEY3 CFQ_KC_FN3
+#  ifdef CFQ_USE_EXPEREMENTAL_LAYER
+#    define CFQ_USER_KEY3 CFQ_KC_FN3
+#  else
+#    define CFQ_USER_KEY3 KC_CAPS
+#  endif
 #endif
 #if !defined(CFQ_USER_KEY4)
-#define CFQ_USER_KEY4 KC_SPC
+#  define CFQ_USER_KEY4 KC_SPC
 #endif
 #if !defined(CFQ_USER_KEY5)
-#define CFQ_USER_KEY5 KC_ENT
+#  define CFQ_USER_KEY5 KC_ENT
 #endif
 #if !defined(CFQ_USER_KEY6)
-#define CFQ_USER_KEY5 CFQ_KC_FN2
+#  define CFQ_USER_KEY6 CFQ_KC_FN2
 #endif
 #if !defined(CFQ_USER_KEY7)
-#define CFQ_USER_KEY5 CFQ_KC_FN1
+#  define CFQ_USER_KEY7 CFQ_KC_FN1
 #endif
 
 #define BASE 0 // default layer
 #define SYMB 1 // symbols
 #define MDIA 2 // media keys
 #ifdef CFQ_USE_EXPEREMENTAL_LAYER
-#define EXPR 3 // experimental keys
+#  define EXPR 3 // experimental keys
 #endif
 
 enum custom_keycodes {
@@ -105,7 +109,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  *   | LCtl |Super | Alt  | ~L1  |Space |                                       | Left | Down | Up   |Right | Del  |
  *   `----------------------------------'                                       `----------------------------------'
  *                                        ,-------------.       ,-------------.
- *                                        | Ins  | ~L3  |       | Home | End  |
+ *                                        | Ins  |CapsLk|       | Home | End  |
  *                                 ,------|------|------|       |------+------+------.
  *                                 |      |      | ~L2  |       | PgUp |      |      |
  *                                 |Space |Enter |------|       |------|Enter |Space |

--- a/layouts/community/ergodox/qwerty_code_friendly/readme.md
+++ b/layouts/community/ergodox/qwerty_code_friendly/readme.md
@@ -32,6 +32,7 @@ using `CFQ_` prefixed defines which can be set by passing `EXTRAFLAGS` to make.
 - `CFQ_USE_SWAP_RIGHT_SPACE_ENTER` swap Enter and Space on the right hand thumb cluster.
   While asymmetric, it makes Enter more easily accessible.
 - `CFQ_USE_EXPEREMENTAL_LAYER` defines an extra layer for misc extra keys/macros.
+  When set, Caps-Lock is replace by Layer3.
   Currently it's mostly empty.
 
 
@@ -52,7 +53,7 @@ Keymap 0: Basic layer
   | LCtl |Super | Alt  | ~L1  |Space |                                       | Left | Down | Up   |Right | Del  |
   `----------------------------------'                                       `----------------------------------'
                                        ,-------------.       ,-------------.
-                                       | Ins  | ~L3  |       | Home | End  |
+                                       | Ins  |CapsLk|       | Home | End  |
                                 ,------|------|------|       |------+------+------.
                                 |      |      | ~L2  |       | PgUp |      |      |
                                 |Space |Enter |------|       |------|Enter |Space |
@@ -126,6 +127,9 @@ Notes:
 ```
 
 ## Changelog
+
+- 2017/11/09
+  Use Caps-Lock when `CFQ_USE_EXPEREMENTAL_LAYER` isn't defined.
 
 - 2017/11/07
   Make thumb left thumb cluster completely configurable with defines.


### PR DESCRIPTION
Correct typo and set useful key when CFQ_USE_EXPEREMENTAL_LAYER is undefined.