### PR TITLE
Seebs/dvorak serplover

### DIFF
--- a/keyboards/ergodox_ez/config.h
+++ b/keyboards/ergodox_ez/config.h
@@ -82,7 +82,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGBW 1
 
 /* Set 0 if debouncing isn't needed */
-#define DEBOUNCE    15
+/* 15 is ridiculously high, though. */
+/* #define DEBOUNCE    15 */
 
 #define PREVENT_STUCK_MODIFIERS
 

--- a/keyboards/ergodox_ez/config.h
+++ b/keyboards/ergodox_ez/config.h
@@ -61,8 +61,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* number of backlight levels */
 #define BACKLIGHT_LEVELS 3
 
-#define LED_BRIGHTNESS_LO       15
+#define LED_BRIGHTNESS_LO       5
 #define LED_BRIGHTNESS_HI       255
+#define LED_BRIGHTNESS_DEFAULT	LED_BRIGHTNESS_LO
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D7

--- a/keyboards/ergodox_ez/ergodox_ez.c
+++ b/keyboards/ergodox_ez/ergodox_ez.c
@@ -1,6 +1,8 @@
 #include QMK_KEYBOARD_H
 #include "i2cmaster.h"
 #include <ctype.h>
+#include <string.h>
+#include <stdio.h>
 
 
 extern inline void ergodox_board_led_on(void);
@@ -168,15 +170,17 @@ static char *displaypos = "WAAAAAAKKBLCMDNUVOOWWWOOXYFPGQHRISJAAAAAAT";
 static uint8_t counter = 0;
 static uint8_t prev_state[6];
 static uint8_t prev_chord[6];
-void update_lcd(void) {
+void lcd_update(void) {
+    char keys[26];
+    int pressed = 0;
     if (!memcmp(state, prev_state, 6))
         return;
     memcpy(prev_state, state, 6);
-    char keys[26];
-    int pressed = 0;
 
     memset(keys, ' ', 25);
     for (int i = 0; i < 6; ++i) {
+	if (!chord[i])
+	    continue;
 	for (int j = 0; j < 7; ++j) {
 	    uint8_t bit = 1 << j;
 	    uint8_t idx = (i * 7) + (6 - j);
@@ -209,6 +213,8 @@ void update_lcd(void) {
     if (!pressed) {
 	    memset(keys, ' ', 25);
 	    for (int i = 0; i < 6; ++i) {
+	        if (!prev_chord[i])
+	            continue;
 		for (int j = 0; j < 7; ++j) {
 		    uint8_t bit = 1 << j;
 		    uint8_t idx = (i * 7) + (6 - j);

--- a/keyboards/ergodox_ez/ergodox_ez.c
+++ b/keyboards/ergodox_ez/ergodox_ez.c
@@ -54,7 +54,7 @@ void matrix_init_kb(void) {
 void ergodox_blink_all_leds(void)
 {
     ergodox_led_all_off();
-    ergodox_led_all_set(LED_BRIGHTNESS_HI);
+    ergodox_led_all_set(LED_BRIGHTNESS_DEFAULT);
     ergodox_right_led_1_on();
     _delay_ms(50);
     ergodox_right_led_2_on();

--- a/keyboards/ergodox_ez/ergodox_ez.h
+++ b/keyboards/ergodox_ez/ergodox_ez.h
@@ -43,7 +43,7 @@ void init_ergodox(void);
 void ergodox_blink_all_leds(void);
 uint8_t init_mcp23018(void);
 uint8_t init_lcd(void);
-void update_lcd(void);
+void lcd_update(void);
 uint8_t ergodox_left_leds_update(void);
 
 #define LED_BRIGHTNESS_LO       5

--- a/keyboards/ergodox_ez/ergodox_ez.h
+++ b/keyboards/ergodox_ez/ergodox_ez.h
@@ -45,8 +45,6 @@ uint8_t init_mcp23018(void);
 uint8_t init_lcd(void);
 void update_lcd(void);
 uint8_t ergodox_left_leds_update(void);
-// hacky: we look into the steno code for this
-extern uint8_t state[6];
 
 #define LED_BRIGHTNESS_LO       5
 #define LED_BRIGHTNESS_HI       255

--- a/keyboards/ergodox_ez/ergodox_ez.h
+++ b/keyboards/ergodox_ez/ergodox_ez.h
@@ -23,12 +23,30 @@
 #define OLATA           0x14            // output latch register
 #define OLATB           0x15
 
+/* these are the only registers needed for the LCD driver */
+#define LCD_ADDR (I2C_ADDR | 0x01)
+#define LCD_ADDR_WRITE  ( (LCD_ADDR<<1) | I2C_WRITE )
+#define LCD_ADDR_READ   ( (LCD_ADDR<<1) | I2C_READ  )
+
+#define MCP23008_IODIR 0x00
+#define MCP23008_GPIO 0x09
+
+#define MCP23008_RS 0x2
+#define MCP23008_ENABLE 0x4
+#define MCP23008_DATA (0xF << 3)
+#define MCP23008_BACKLIGHT 0x80
+
 extern uint8_t mcp23018_status;
+extern uint8_t mcp23008_status;
 
 void init_ergodox(void);
 void ergodox_blink_all_leds(void);
 uint8_t init_mcp23018(void);
+uint8_t init_lcd(void);
+void update_lcd(void);
 uint8_t ergodox_left_leds_update(void);
+// hacky: we look into the steno code for this
+extern uint8_t state[6];
 
 #define LED_BRIGHTNESS_LO       5
 #define LED_BRIGHTNESS_HI       255

--- a/keyboards/ergodox_ez/ergodox_ez.h
+++ b/keyboards/ergodox_ez/ergodox_ez.h
@@ -30,21 +30,49 @@ void ergodox_blink_all_leds(void);
 uint8_t init_mcp23018(void);
 uint8_t ergodox_left_leds_update(void);
 
-#define LED_BRIGHTNESS_LO       15
+#define LED_BRIGHTNESS_LO       5
 #define LED_BRIGHTNESS_HI       255
+#define LED_BRIGHTNESS_DEFAULT	LED_BRIGHTNESS_LO
 
+inline void ergodox_right_led_1_set(uint8_t n)    { OCR1A = n; }
+inline void ergodox_right_led_2_set(uint8_t n)    { OCR1B = n; }
+inline void ergodox_right_led_3_set(uint8_t n)    { OCR1C = n; }
+inline void ergodox_right_led_set(uint8_t led, uint8_t n)  {
+    (led == 1) ? (OCR1A = n) :
+    (led == 2) ? (OCR1B = n) :
+                 (OCR1C = n);
+}
+
+inline void ergodox_led_all_set(uint8_t n)
+{
+    ergodox_right_led_1_set(n);
+    ergodox_right_led_2_set(n);
+    ergodox_right_led_3_set(n);
+}
 
 inline void ergodox_board_led_on(void)      { DDRD |=  (1<<6); PORTD |=  (1<<6); }
-inline void ergodox_right_led_1_on(void)    { DDRB |=  (1<<5); PORTB |=  (1<<5); }
-inline void ergodox_right_led_2_on(void)    { DDRB |=  (1<<6); PORTB |=  (1<<6); }
-inline void ergodox_right_led_3_on(void)    { DDRB |=  (1<<7); PORTB |=  (1<<7); }
-inline void ergodox_right_led_on(uint8_t led) { DDRB |= (1<<(led+4)); PORTB |= (1<<(led+4)); }
+inline void ergodox_right_led_1_on(void)    { DDRB |=  (1<<5); ergodox_right_led_1_set(LED_BRIGHTNESS_DEFAULT); }
+inline void ergodox_right_led_2_on(void)    { DDRB |=  (1<<6); ergodox_right_led_2_set(LED_BRIGHTNESS_DEFAULT); }
+inline void ergodox_right_led_3_on(void)    { DDRB |=  (1<<7); ergodox_right_led_3_set(LED_BRIGHTNESS_DEFAULT); }
+inline void ergodox_right_led_on(uint8_t led) {
+	switch (led) {
+		case 1: ergodox_right_led_1_on(); break;
+		case 2: ergodox_right_led_2_on(); break;
+		case 3: ergodox_right_led_3_on(); break;
+	}
+}
 
 inline void ergodox_board_led_off(void)     { DDRD &= ~(1<<6); PORTD &= ~(1<<6); }
-inline void ergodox_right_led_1_off(void)   { DDRB &= ~(1<<5); PORTB &= ~(1<<5); }
-inline void ergodox_right_led_2_off(void)   { DDRB &= ~(1<<6); PORTB &= ~(1<<6); }
-inline void ergodox_right_led_3_off(void)   { DDRB &= ~(1<<7); PORTB &= ~(1<<7); }
-inline void ergodox_right_led_off(uint8_t led) { DDRB &= ~(1<<(led+4)); PORTB &= ~(1<<(led+4)); }
+inline void ergodox_right_led_1_off(void)   { DDRB &= ~(1<<5); OCR1A = 0; }
+inline void ergodox_right_led_2_off(void)   { DDRB &= ~(1<<6); OCR1B = 0; }
+inline void ergodox_right_led_3_off(void)   { DDRB &= ~(1<<7); OCR1C = 0; }
+inline void ergodox_right_led_off(uint8_t led) {
+	switch (led) {
+		case 1: ergodox_right_led_1_off(); break;
+		case 2: ergodox_right_led_2_off(); break;
+		case 3: ergodox_right_led_3_off(); break;
+	}
+}
 
 #ifdef LEFT_LEDS
 bool ergodox_left_led_1;
@@ -84,22 +112,6 @@ inline void ergodox_led_all_off(void)
     ergodox_left_led_2_off();
     ergodox_left_led_3_off();
 #endif // LEFT_LEDS
-}
-
-inline void ergodox_right_led_1_set(uint8_t n)    { OCR1A = n; }
-inline void ergodox_right_led_2_set(uint8_t n)    { OCR1B = n; }
-inline void ergodox_right_led_3_set(uint8_t n)    { OCR1C = n; }
-inline void ergodox_right_led_set(uint8_t led, uint8_t n)  {
-    (led == 1) ? (OCR1A = n) :
-    (led == 2) ? (OCR1B = n) :
-                 (OCR1C = n);
-}
-
-inline void ergodox_led_all_set(uint8_t n)
-{
-    ergodox_right_led_1_set(n);
-    ergodox_right_led_2_set(n);
-    ergodox_right_led_3_set(n);
 }
 
 #define KEYMAP(                                                 \

--- a/keyboards/ergodox_ez/keymaps/dvorak_plover/README.md
+++ b/keyboards/ergodox_ez/keymaps/dvorak_plover/README.md
@@ -1,0 +1,14 @@
+Dvorak support, plover support, gaming support
+
+I'm used to the Kinesis, so originally I was just going to patch up
+the thumb keys to be more familiar. But the ergodox is really well
+suited to NKRO support in Plover, so I added a layer for that, and
+then I remembered that dvorak can be really annoying for video
+games (try to reach WASD), so I added a layer for that.
+
+The result is probably a bit idiosyncratic, but it works for me.
+
+(I also don't have any press/hold distinction keys, because that
+confuses my fuzzy little brain.)
+
+Contributed by seebs (seebs@seebs.net)

--- a/keyboards/ergodox_ez/keymaps/dvorak_plover/config.h
+++ b/keyboards/ergodox_ez/keymaps/dvorak_plover/config.h
@@ -1,0 +1,6 @@
+#ifndef CONFIG_USER_H
+#define CONFIG_USER_H
+
+#define FORCE_NKRO
+
+#endif

--- a/keyboards/ergodox_ez/keymaps/dvorak_plover/keymap.c
+++ b/keyboards/ergodox_ez/keymaps/dvorak_plover/keymap.c
@@ -1,0 +1,237 @@
+#include QMK_KEYBOARD_H
+#include "debug.h"
+#include "action_layer.h"
+#include "virtser.h"
+#include "keymap_steno.h"
+
+#define BASE 0 // default layer
+#define SYMB 1 // symbols
+#define PLVR 2 // plover steno (gemini protocol)
+#define QWRT 3 // qwerty layer for gaming
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+/* Keymap 0: Basic layer
+ *
+ * ,--------------------------------------------------.           ,--------------------------------------------------.
+ * |   =    |   1  |   2  |   3  |   4  |   5  | Esc  |           | Esc  |   6  |   7  |   8  |   9  |   0  |   \    |
+ * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
+ * | Tab    |   '  |   ,  |   .  |   P  |   Y  |  L1  |           |  L2  |   F  |   G  |   C  |   R  |   L  |   /    |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * | LGui   |   A  |   O  |   E  |   U  |   I  |------|           |------|   D  |   H  |   T  |   N  |   S  |   -    |
+ * |--------+------+------+------+------+------| Esc  |           |  L3  |------+------+------+------+------+--------|
+ * | LShift |   ;  |   Q  |   J  |   K  |   X  |      |           |      |   B  |   M  |   W  |   V  |   Z  | RShift |
+ * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
+ *   |Lalt  |  Grv |      | Left | Right|                                       |  Up  | Down |   [  |   ]  | RAlt |
+ *   `----------------------------------'                                       `----------------------------------'
+ *                                        ,-------------.       ,---------------.
+ *                                        | LCtrl| Alt  |       | RGui | RCtrl  |
+ *                                 ,------|------|------|       |------+--------+------.
+ *                                 |      |      | Home |       | PgUp |        |      |
+ *                                 |Backsp|Delete|------|       |------| Enter  |Space |
+ *                                 |   ace|      | End  |       | PgDn |        |      |
+ *                                 `--------------------'       `----------------------'
+ */
+// If it accepts an argument (i.e, is a function), it doesn't need KC_.
+// Otherwise, it needs KC_*
+[BASE] = KEYMAP(  // layer 0 : default
+        // left hand
+        KC_EQL,         KC_1,           KC_2,    KC_3,   KC_4,   KC_5,   KC_ESC,
+        KC_TAB,         KC_QUOT,        KC_COMM, KC_DOT, KC_P,   KC_Y,   MO(SYMB),
+        KC_LGUI,        KC_A,           KC_O,    KC_E,   KC_U,   KC_I,
+        KC_LSFT,        KC_SCLN,        KC_Q,    KC_J,   KC_K,   KC_X,   KC_ESC,
+        KC_LALT,        KC_GRV,         KC_ESC,  KC_LEFT,KC_RGHT,
+                                               KC_LCTL,  KC_LALT,
+                                                              KC_HOME,
+                                               KC_BSPC,KC_DEL,KC_END,
+        // right hand
+            KC_ESC,      KC_6,   KC_7,   KC_8,   KC_9,   KC_0,             KC_BSLS,
+             TG(PLVR),       KC_F,   KC_G,   KC_C,   KC_R,   KC_L,             KC_SLSH,
+                          KC_D,   KC_H,   KC_T,   KC_N,   KC_S,             KC_MINS,
+             TG(QWRT),KC_B,   KC_M,   KC_W,   KC_V,   KC_Z,             KC_RSFT,
+                                  KC_UP,  KC_DOWN,KC_LBRC,KC_RBRC,          KC_RALT,
+             KC_RGUI,        KC_RCTL,
+             KC_PGUP,
+             KC_PGDN,KC_ENT, KC_SPC
+    ),
+/* Keymap 1: Symbol Layer
+ *
+ * ,--------------------------------------------------.           ,--------------------------------------------------.
+ * |        |  F1  |  F2  |  F3  |  F4  |  F5  |      |           |      |  F6  |  F7  |  F8  |  F9  |  F10 |   F11  |
+ * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
+ * |        |   !  |   @  |   {  |   }  |   |  |      |           |      |   Up |  KP7 |  KP8 | KP9  |  KP* |   F12  |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |        |   #  |   $  |   (  |   )  |   `  |------|           |------| Down |  KP4 |  KP5 | KP6  |  KP+ |        |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |        |   %  |   ^  |   [  |   ]  |   ~  |      |           |      |   &  |  KP1 |  KP2 | KP3  |  KP/ |        |
+ * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
+ *   |      |      |      |      |      |                                       |      |  KP. | KP0  |  KP= |      |
+ *   `----------------------------------'                                       `----------------------------------'
+ *                                        ,-------------.       ,-------------.
+ *                                        |      |      |       |      |      |
+ *                                 ,------|------|------|       |------+------+------.
+ *                                 |      |      |      |       |      |      |      |
+ *                                 |      |      |------|       |------|      |      |
+ *                                 |      |      |      |       |      |      |      |
+ *                                 `--------------------'       `--------------------'
+ */
+// SYMBOLS
+[SYMB] = KEYMAP(
+       // left hand
+       KC_TRNS,KC_F1,  KC_F2,  KC_F3,  KC_F4,  KC_F5,  KC_TRNS,
+       KC_TRNS,KC_EXLM,KC_AT,  KC_LCBR,KC_RCBR,KC_PIPE,KC_TRNS,
+       KC_TRNS,KC_HASH,KC_DLR, KC_LPRN,KC_RPRN,KC_GRV,
+       KC_TRNS,KC_PERC,KC_CIRC,KC_LBRC,KC_RBRC,KC_TILD,KC_TRNS,
+       KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,
+                                       KC_TRNS,KC_TRNS,
+                                               KC_TRNS,
+                               KC_TRNS,KC_TRNS,KC_TRNS,
+       // right hand
+       KC_TRNS, KC_F6,   KC_F7,  KC_F8,   KC_F9,   KC_F10,  KC_F11,
+       KC_TRNS, KC_UP,   KC_P7,  KC_P8,   KC_P9,   KC_PAST, KC_F12,
+                KC_DOWN, KC_P4,  KC_P5,   KC_P6,   KC_PPLS, KC_TRNS,
+       KC_TRNS, KC_AMPR, KC_P1,  KC_P2,   KC_P3,   KC_PSLS, KC_TRNS,
+                         KC_TRNS,KC_PDOT,  KC_P0,   KC_PEQL,  KC_TRNS,
+       KC_TRNS, KC_TRNS,
+       KC_TRNS,
+       KC_TRNS, KC_TRNS, KC_TRNS
+),
+
+/* Keymap 3: Plover (Gemini PR over Serial)
+ *
+ * ,--------------------------------------------------.           ,--------------------------------------------------.
+ * | BKSPC  |      |      |      |      |      |      |           | Leave|      |      |      |      |      |        |
+ * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
+ * |        |   #  |   #  |   #  |   #  |   #  |      |           |      |   #  |   #  |   #  |   #  |   #  |   #    |
+ * |--------+------+------+------+------+------|   *  |           |  *   |------+------+------+------+------+--------|
+ * |        |   S  |   T  |   P  |   H  |   *  |------|           |------|   *  |   F  |   P  |   L  |   T  |   D    |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |        |   S  |   K  |   W  |   R  |   *  |   *  |           |  *   |   *  |   R  |   B  |   G  |   S  |   Z    |
+ * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
+ *   |      |      |      |      |      |                                       |      |      |      |      |      |
+ *   `----------------------------------'                                       `----------------------------------'
+ *                                        ,-------------.       ,-------------.
+ *                                        |      |      |       |      |      |
+ *                                 ,------|------|------|       |------+------+------.
+ *                                 |      |      |      |       |      |      |      |
+ *                                 |   A  |   O  |------|       |------|   E  |   U  |
+ *                                 |      |      |      |       |      |      |      |
+ *                                 `--------------------'       `--------------------'
+ */
+/* Gemini PR over Serial
+ * S1/ST1/ST3 don't seem to work as expected in Plover for me, but the
+ * ones below them do. Moved the toggle up because I kept accidentally
+ * hitting it when reaching for star.
+ */
+[PLVR] = KEYMAP(
+       KC_BSPC, KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,  
+       KC_NO,   STN_N1,  STN_N2,  STN_N3,  STN_N4,  STN_N5,  STN_ST2,
+       KC_NO,   STN_S2,  STN_TL,  STN_PL,  STN_HL,  STN_ST2,
+       KC_NO,   STN_S2,  STN_KL,  STN_WL,  STN_RL,  STN_ST2, STN_ST2,
+       KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,
+                                           KC_NO,   KC_NO,  
+                                                    KC_NO,  
+                                  STN_A,   STN_O,   KC_NO,  
+    // right hand
+       TG(PLVR), KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,  
+       STN_ST4,  STN_N6,  STN_N7,  STN_N8,  STN_N9,  STN_NA,  STN_NB,
+                 STN_ST4, STN_FR,  STN_PR,  STN_LR,  STN_TR,  STN_DR,
+       STN_ST4,  STN_ST4, STN_RR,  STN_BR,  STN_GR,  STN_SR,  STN_ZR,
+                          KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,  
+       KC_NO,   KC_NO,  
+       KC_NO,  
+       KC_NO,   STN_E,   STN_U
+),
+
+/* Keymap 3: qwerty-ish
+ *
+ * ,--------------------------------------------------.           ,--------------------------------------------------.
+ * |   =    |   1  |   2  |   3  |   4  |   5  | Esc  |           | Esc  |   6  |   7  |   8  |   9  |   0  |   -    |
+ * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
+ * | Tab    |   Q  |   W  |   E  |   R  |   T  |      |           |      |   Y  |   U  |   I  |   O  |   P  |   \    |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * | LGui   |   A  |   S  |   D  |   F  |   G  |------|           |------|   H  |   J  |   K  |   L  |   ;  |  LGui  |
+ * |--------+------+------+------+------+------| Spc  |           |  L3  |------+------+------+------+------+--------|
+ * | LShift |   Z  |   X  |   C  |   V  |   B  |      |           |      |   N  |   M  |   ,  |   .  |   /  | RShift |
+ * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
+ *   | Lalt |  Grv |  '"  | Left | Right|                                       |  Up  | Down |   [  |   ]  | RAlt |
+ *   `----------------------------------'                                       `----------------------------------'
+ *                                        ,-------------.       ,---------------.
+ *                                        | LCtrl| LAlt |       | RGui | RCtrl  |
+ *                                 ,------|------|------|       |------+--------+------.
+ *                                 |      |      | Home |       | PgUp |        |      |
+ *                                 |Backsp|Delete|------|       |------| Enter  |Space |
+ *                                 |   ace|      | End  |       | PgDn |        |      |
+ *                                 `--------------------'       `----------------------'
+ */
+[QWRT] = KEYMAP(  // layer 3: qwerty for gaming
+        // left hand
+        KC_EQL,       KC_1,         KC_2,   KC_3,   KC_4,   KC_5,   KC_ESC,
+        KC_TAB,       KC_Q,         KC_W,   KC_E,   KC_R,   KC_T,   TG(SYMB),
+        KC_LGUI,      KC_A,         KC_S,   KC_D,   KC_F,   KC_G,
+        KC_LSFT,      KC_Z,         KC_X,   KC_C,   KC_V,   KC_B,   KC_SPACE,
+        KC_LALT,      KC_GRV,      KC_QUOT,  KC_LEFT,KC_RGHT,
+										        KC_LCTL,KC_LALT,
+										                       KC_HOME,
+										        KC_BSPC,KC_DEL,KC_END,
+        // right hand
+             KC_ESC,     KC_6,   KC_7,   KC_8,   KC_9,   KC_0,             KC_MINS,
+             TG(PLVR),   KC_Y,   KC_U,   KC_I,   KC_O,   KC_P,             KC_BSLS,
+                         KC_H,   KC_J,   KC_K,   KC_L,   KC_SCLN,          KC_QUOT,
+             TG(QWRT),   KC_N,   KC_M,   KC_COMM,KC_DOT, KC_SLSH,          KC_RSFT,
+                                 KC_UP,  KC_DOWN,KC_LBRC,KC_RBRC,          KC_RALT,
+              KC_RGUI,KC_RCTL,
+              KC_PGUP,
+              KC_PGDN,KC_ENT, KC_SPC
+    ),
+};
+
+const uint16_t PROGMEM fn_actions[] = {
+    [1] = ACTION_LAYER_TAP_TOGGLE(SYMB)                // FN1 - Momentary Layer 1 (Symbols)
+};
+
+const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
+{
+  // MACRODOWN only works in this function
+      switch(id) {
+        case 0:
+        if (record->event.pressed) {
+          register_code(KC_RSFT);
+        } else {
+          unregister_code(KC_RSFT);
+        }
+        break;
+      }
+    return MACRO_NONE;
+};
+
+// Runs just one time when the keyboard initializes.
+void matrix_init_user(void) {
+	steno_set_mode(STENO_MODE_GEMINI);
+};
+
+// Runs constantly in the background, in a loop.
+void matrix_scan_user(void) {
+
+    uint8_t layer = biton32(layer_state);
+
+    ergodox_board_led_off();
+    ergodox_right_led_1_off();
+    ergodox_right_led_2_off();
+    ergodox_right_led_3_off();
+    switch (layer) {
+      // TODO: Make this relevant to the ErgoDox EZ.
+        case 1:
+            ergodox_right_led_1_on();
+            break;
+        case 2:
+            ergodox_right_led_2_on();
+            break;
+	case 3:
+	    ergodox_right_led_3_on();
+	    break;
+        default:
+            // none
+            break;
+    }
+
+};

--- a/keyboards/ergodox_ez/keymaps/dvorak_plover/rules.mk
+++ b/keyboards/ergodox_ez/keymaps/dvorak_plover/rules.mk
@@ -1,3 +1,6 @@
 STENO_ENABLE = yes
 # Not enough interupts, so something has to go
 MOUSEKEY_ENABLE = no
+# Sadly, you can't have both. Console is nice for debugging.
+CONSOLE_ENABLE = no
+NKRO_ENABLE = yes

--- a/keyboards/ergodox_ez/keymaps/dvorak_plover/rules.mk
+++ b/keyboards/ergodox_ez/keymaps/dvorak_plover/rules.mk
@@ -1,0 +1,3 @@
+STENO_ENABLE = yes
+# Not enough interupts, so something has to go
+MOUSEKEY_ENABLE = no

--- a/keyboards/ergodox_ez/matrix.c
+++ b/keyboards/ergodox_ez/matrix.c
@@ -108,7 +108,7 @@ void matrix_init(void)
     // initialize row and col
 
     mcp23018_status = init_mcp23018();
-
+    mcp23008_status = init_lcd();
 
     unselect_rows();
     init_cols();
@@ -217,6 +217,7 @@ uint8_t matrix_scan(void)
     }
 
     matrix_scan_quantum();
+    update_lcd();
 
     return 1;
 }

--- a/keyboards/ergodox_ez/matrix.c
+++ b/keyboards/ergodox_ez/matrix.c
@@ -296,13 +296,7 @@ static matrix_row_t read_cols(uint8_t row)
         }
     } else {
         // read from teensy
-        return
-            (PINF&(1<<0) ? 0 : (1<<0)) |
-            (PINF&(1<<1) ? 0 : (1<<1)) |
-            (PINF&(1<<4) ? 0 : (1<<2)) |
-            (PINF&(1<<5) ? 0 : (1<<3)) |
-            (PINF&(1<<6) ? 0 : (1<<4)) |
-            (PINF&(1<<7) ? 0 : (1<<5)) ;
+	return ~((PINF & 0x03) | ((PINF & 0xF0) >> 2)) & 0x3F;
     }
 }
 

--- a/keyboards/ergodox_ez/rules.mk
+++ b/keyboards/ergodox_ez/rules.mk
@@ -85,6 +85,6 @@ UNICODE_ENABLE   = yes # Unicode
 ONEHAND_ENABLE   = yes # Allow swapping hands of keyboard
 SLEEP_LED_ENABLE = no
 API_SYSEX_ENABLE = no
-RGBLIGHT_ENABLE = yes
+RGBLIGHT_ENABLE  = no
 
 LAYOUTS = ergodox

--- a/quantum/process_keycode/process_steno.h
+++ b/quantum/process_keycode/process_steno.h
@@ -27,5 +27,7 @@ typedef enum { STENO_MODE_BOLT, STENO_MODE_GEMINI } steno_mode_t;
 bool process_steno(uint16_t keycode, keyrecord_t *record);
 void steno_init(void);
 void steno_set_mode(steno_mode_t mode);
+uint8_t *steno_get_state(void);
+uint8_t *steno_get_chord(void);
 
 #endif


### PR DESCRIPTION
This provides a much cleaner steno implementation (using the QMK steno support) than the existing steno keymap, also a dvorak-friendly one since there's some overlap.

There's also a tweak to brightness, because the ergodox_ez support appears to have half-implemented PWM support for the LEDs, but not actually be using it for anything but setting the brightness to "eye-searing".