### PR TITLE
added SS_LSFT to featured macros

### DIFF
--- a/docs/feature_macros.md
+++ b/docs/feature_macros.md
@@ -96,6 +96,7 @@ There's also a couple of mod shortcuts you can use:
 * `SS_LCTRL(string)`
 * `SS_LGUI(string)`
 * `SS_LALT(string)`
+* `SS_LSFT(string)`
 
 These press the respective modifier, send the supplied string and then release the modifier.
 They can be used like this:

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -124,6 +124,7 @@ extern uint32_t default_layer_state;
 #define SS_LCTRL(string) SS_DOWN(X_LCTRL) string SS_UP(X_LCTRL)
 #define SS_LGUI(string) SS_DOWN(X_LGUI) string SS_UP(X_LGUI)
 #define SS_LALT(string) SS_DOWN(X_LALT) string SS_UP(X_LALT)
+#define SS_LSFT(string) SS_DOWN(X_LSHIFT) string SS_UP(X_LSHIFT)
 
 #define SEND_STRING(str) send_string_P(PSTR(str))
 extern const bool ascii_to_shift_lut[0x80];


### PR DESCRIPTION
Example use-case, sending unicode characters by CTRL + SHIFT + U on tap dance.

```
   case DOUBLE_TAP:
     SEND_STRING(SS_LCTRL(SS_LSFT("u")));
     SEND_STRING("f1 "); // will send ñ
     break;
```
Thanks