### PR TITLE
Allow multiple process_record() calls per scan

### DIFF
--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -123,6 +123,15 @@ If you define these options you will enable the associated feature, which may in
   * how many taps before oneshot toggle is triggered
 * `#define IGNORE_MOD_TAP_INTERRUPT`
   * makes it possible to do rolling combos (zx) with keys that convert to other keys on hold
+* `#define QMK_KEYS_PER_SCAN 4`
+  * Allows sending more than one key per scan. By default, only one key event gets
+    sent via `process_record()` per scan. This has little impact on most typing, but
+    if you're doing a lot of chords, or your scan rate is slow to begin with, you can
+    have some delay in processing key events. Each press and release is a separate
+    event. For a keyboard with 1ms or so scan times, even a very fast typist isn't
+    going to produce the 500 keystrokes a second needed to actually get more than a
+    few ms of delay from this. But if you're doing chording on something with 3-4ms
+    scan times? You probably want this.
 
 ### RGB Light Configuration
 

--- a/keyboards/ergodox_ez/readme.md
+++ b/keyboards/ergodox_ez/readme.md
@@ -31,3 +31,8 @@ To flash with ´teensy-loader-cli´:
 
   - Press the Reset button by inserting a paperclip gently into the reset hole
     in the top right corder.
+
+## Settings
+
+You may want to enable QMK_KEYS_PER_SCAN because the Ergodox has a relatively
+slow scan rate.

--- a/tmk_core/common/keyboard.c
+++ b/tmk_core/common/keyboard.c
@@ -177,6 +177,9 @@ void keyboard_task(void)
     static uint8_t led_status = 0;
     matrix_row_t matrix_row = 0;
     matrix_row_t matrix_change = 0;
+#ifdef QMK_KEYS_PER_SCAN
+    uint8_t keys_processed = 0;
+#endif
 
     matrix_scan();
     if (is_keyboard_master()) {
@@ -208,6 +211,10 @@ void keyboard_task(void)
                         });
                         // record a processed key
                         matrix_prev[r] ^= ((matrix_row_t)1<<c);
+#ifdef QMK_KEYS_PER_SCAN
+                        // only jump out if we have processed "enough" keys.
+                        if (++keys_processed >= QMK_KEYS_PER_SCAN)
+#endif
                         // process a key per task call
                         goto MATRIX_LOOP_END;
                     }
@@ -216,6 +223,10 @@ void keyboard_task(void)
         }
     }
     // call with pseudo tick event when no real key event.
+#ifdef QMK_KEYS_PER_SCAN
+    // we can get here with some keys processed now.
+    if (!keys_processed)
+#endif
     action_exec(TICK);
 
 MATRIX_LOOP_END:


### PR DESCRIPTION
This is particularly relevant for, e.g., the ergodox EZ and
other keyboards with slow scan rates. Without changing the API or
behavior of individual process_record() calls, we allow a
configuration flag to make multiple calls in a single scan.

This will probably have miniscule effects on non-steno users,
and it's not enabled by default for any keyboards except
the one where it was causing me trouble.

(Relevant to issue #1476)

Signed-off-by: seebs <seebs@seebs.net>