### PR TITLE
Seebs/ergodox optimize

### DIFF
--- a/keyboards/ergodox_ez/config.h
+++ b/keyboards/ergodox_ez/config.h
@@ -31,6 +31,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* key matrix size */
 #define MATRIX_ROWS 14
+#define MATRIX_ROWS_PER_SIDE (MATRIX_ROWS / 2)
 #define MATRIX_COLS 6
 
 #define MOUSEKEY_INTERVAL       20
@@ -80,7 +81,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define RGBW 1
 
-/* Set 0 if debouncing isn't needed */
+/* "debounce" is measured in keyboard scans. Some users reported
+ * needing values as high as 15, which was at the time around 50ms.
+ * If you don't define it here, the matrix code will default to
+ * 5, which is now closer to 10ms, but still plenty according to
+ * manufacturer specs.
+ *
+ * Default is quite high, because of reports with some production
+ * runs seeming to need it. This may change when configuration for
+ * this is more directly exposed.
+ */
 #define DEBOUNCE    15
 
 #define PREVENT_STUCK_MODIFIERS

--- a/keyboards/ergodox_ez/ergodox_ez.c
+++ b/keyboards/ergodox_ez/ergodox_ez.c
@@ -38,7 +38,7 @@ void matrix_init_kb(void) {
     PORTB &= ~(1<<4);  // set B(4) internal pull-up disabled
 
     // unused pins - C7, D4, D5, D7, E6
-    // set as input with internal pull-ip enabled
+    // set as input with internal pull-up enabled
     DDRC  &= ~(1<<7);
     DDRD  &= ~(1<<5 | 1<<4);
     DDRE  &= ~(1<<6);

--- a/keyboards/ergodox_ez/matrix.c
+++ b/keyboards/ergodox_ez/matrix.c
@@ -47,7 +47,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  * Now it's only 317 scans/second, or about 3.15 msec/scan.
  * According to Cherry specs, debouncing time is 5 msec.
  *
- * And so, there is no sense to have DEBOUNCE higher than 2.
+ * However, some switches seem to have higher debouncing requirements, or
+ * something else might be wrong. (Also, the scan speed has improved since
+ * that comment was written.)
  */
 
 #ifndef DEBOUNCE
@@ -203,16 +205,23 @@ uint8_t matrix_scan(void)
 #endif
 
 #ifdef LEFT_LEDS
-     mcp23018_status = ergodox_left_leds_update();
+    mcp23018_status = ergodox_left_leds_update();
 #endif // LEFT_LEDS
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
+    for (uint8_t i = 0; i < MATRIX_ROWS_PER_SIDE; i++) {
         select_row(i);
-        wait_us(30);  // without this wait read unstable value.
+        // and select on left hand
+        select_row(i + MATRIX_ROWS_PER_SIDE);
+        // we don't need a 30us delay anymore, because selecting a
+        // left-hand row requires more than 30us for i2c.
         matrix_row_t mask = debounce_mask(i);
         matrix_row_t cols = (read_cols(i) & mask) | (matrix[i] & ~mask);
         debounce_report(cols ^ matrix[i], i);
         matrix[i] = cols;
-
+        // grab cols from right hand
+        mask = debounce_mask(i + MATRIX_ROWS_PER_SIDE);
+        cols = (read_cols(i + MATRIX_ROWS_PER_SIDE) & mask) | (matrix[i + MATRIX_ROWS_PER_SIDE] & ~mask);
+        debounce_report(cols ^ matrix[i + MATRIX_ROWS_PER_SIDE], i + MATRIX_ROWS_PER_SIDE);
+        matrix[i + MATRIX_ROWS_PER_SIDE] = cols;
         unselect_rows();
     }
 
@@ -295,14 +304,13 @@ static matrix_row_t read_cols(uint8_t row)
             return data;
         }
     } else {
-        // read from teensy
-        return
-            (PINF&(1<<0) ? 0 : (1<<0)) |
-            (PINF&(1<<1) ? 0 : (1<<1)) |
-            (PINF&(1<<4) ? 0 : (1<<2)) |
-            (PINF&(1<<5) ? 0 : (1<<3)) |
-            (PINF&(1<<6) ? 0 : (1<<4)) |
-            (PINF&(1<<7) ? 0 : (1<<5)) ;
+        /* read from teensy
+	 * bitmask is 0b11110011, but we want those all
+	 * in the lower six bits.
+	 * we'll return 1s for the top two, but that's harmless.
+	 */
+
+        return ~((PINF & 0x03) | ((PINF & 0xF0) >> 2));
     }
 }
 
@@ -325,9 +333,7 @@ static void unselect_rows(void)
         // set all rows hi-Z : 1
         mcp23018_status = i2c_start(I2C_ADDR_WRITE);    if (mcp23018_status) goto out;
         mcp23018_status = i2c_write(GPIOA);             if (mcp23018_status) goto out;
-        mcp23018_status = i2c_write( 0xFF
-                              & ~(0<<7)
-                          );                            if (mcp23018_status) goto out;
+        mcp23018_status = i2c_write(0xFF);              if (mcp23018_status) goto out;
     out:
         i2c_stop();
     }
@@ -353,9 +359,7 @@ static void select_row(uint8_t row)
             // set other rows hi-Z : 1
             mcp23018_status = i2c_start(I2C_ADDR_WRITE);        if (mcp23018_status) goto out;
             mcp23018_status = i2c_write(GPIOA);                 if (mcp23018_status) goto out;
-            mcp23018_status = i2c_write( 0xFF & ~(1<<row)
-                                  & ~(0<<7)
-                              );                                if (mcp23018_status) goto out;
+            mcp23018_status = i2c_write(0xFF & ~(1<<row));      if (mcp23018_status) goto out;
         out:
             i2c_stop();
         }


### PR DESCRIPTION
Performance improvements for the ergodox ez, which reduce scan time from ~3.17ms to ~2.24ms, mostly by performing scans of the two sides in parallel, also dropping some redundant or inefficient operations.