### PR TITLE
Allow multiple process_record() calls per scan

### DIFF
--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -123,6 +123,9 @@ If you define these options you will enable the associated feature, which may in
   * how many taps before oneshot toggle is triggered
 * `#define IGNORE_MOD_TAP_INTERRUPT`
   * makes it possible to do rolling combos (zx) with keys that convert to other keys on hold
+* `#define QMK_KEYS_PER_SCAN`
+  * Allows sending more than one key per scan. (By default, only one key event gets
+    sent via `process_record()` per scan.)
 
 ### RGB Light Configuration
 

--- a/keyboards/ergodox_ez/config.h
+++ b/keyboards/ergodox_ez/config.h
@@ -114,5 +114,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define NO_ACTION_MACRO
 //#define NO_ACTION_FUNCTION
 //#define DEBUG_MATRIX_SCAN_RATE
+#define QMK_KEYS_PER_SCAN 8
 
 #endif

--- a/tmk_core/common/keyboard.c
+++ b/tmk_core/common/keyboard.c
@@ -177,6 +177,9 @@ void keyboard_task(void)
     static uint8_t led_status = 0;
     matrix_row_t matrix_row = 0;
     matrix_row_t matrix_change = 0;
+#ifdef QMK_KEYS_PER_SCAN
+    uint8_t keys_processed = 0;
+#endif
 
     matrix_scan();
     if (is_keyboard_master()) {
@@ -208,6 +211,10 @@ void keyboard_task(void)
                         });
                         // record a processed key
                         matrix_prev[r] ^= ((matrix_row_t)1<<c);
+#ifdef QMK_KEYS_PER_SCAN
+                        // only jump out if we have processed "enough" keys.
+                        if (++keys_processed >= QMK_KEYS_PER_SCAN)
+#endif
                         // process a key per task call
                         goto MATRIX_LOOP_END;
                     }
@@ -216,6 +223,10 @@ void keyboard_task(void)
         }
     }
     // call with pseudo tick event when no real key event.
+#ifdef QMK_KEYS_PER_SCAN
+    // we can get here with some keys processed now.
+    if (!keys_processed)
+#endif
     action_exec(TICK);
 
 MATRIX_LOOP_END:


### PR DESCRIPTION
This is particularly relevant for, e.g., the ergodox EZ and
other keyboards with slow scan rates. Without changing the API or
behavior of individual process_record() calls, we allow a
configuration flag to make multiple calls in a single scan.

This will probably have miniscule effects on non-steno users,
and it's not enabled by default for any keyboards except
the one where it was causing me trouble.

Now with stupid typo fixed.

Signed-off-by: seebs <seebs@seebs.net>