### PR TITLE
Seebs/stenodisplay

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -288,6 +288,13 @@ define PARSE_RULE
     endif
 endef
 
+# different from the common.mk version because this needs extra $ because
+# it's used in PARSE_KEYBOARD which is already really magic
+define USE_RULES
+    $$(if $$(filter $(1),$$(RULES_MK_LIST)),,$$(eval RULES_MK_LIST += $(1)))\
+    $$(eval include $(1))
+endef
+
 # $1 = Keyboard
 # Parses a rule in the format <keymap>:<target>
 # the keyboard is already known when entering this function
@@ -301,9 +308,9 @@ define PARSE_KEYBOARD
     DEFAULT_FOLDER := $$(CURRENT_KB)
 
     # We assume that every rules.mk will contain the full default value
-    $$(eval include $(ROOT_DIR)/keyboards/$$(CURRENT_KB)/rules.mk)
+    $(call USE_RULES,$(ROOT_DIR)/keyboards/$$(CURRENT_KB)/rules.mk)
     ifneq ($$(DEFAULT_FOLDER),$$(CURRENT_KB))
-        $$(eval include $(ROOT_DIR)/keyboards/$$(DEFAULT_FOLDER)/rules.mk)
+        $(call USE_RULES,$(ROOT_DIR)/keyboards/$$(DEFAULT_FOLDER)/rules.mk)
     endif
     CURRENT_KB := $$(DEFAULT_FOLDER)
 
@@ -328,27 +335,27 @@ define PARSE_KEYBOARD
     KEYBOARD_LAYOUTS :=
     ifneq ("$$(wildcard $(ROOT_DIR)/keyboards/$$(KEYBOARD_FOLDER_PATH_5)/rules.mk)","")
       LAYOUTS :=
-      $$(eval include $(ROOT_DIR)/keyboards/$$(KEYBOARD_FOLDER_PATH_5)/rules.mk)
+      $(call USE_RULES,$(ROOT_DIR)/keyboards/$$(KEYBOARD_FOLDER_PATH_5)/rules.mk)
       KEYBOARD_LAYOUTS := $$(sort $$(LAYOUTS) $$(KEYBOARD_LAYOUTS))
     endif
     ifneq ("$$(wildcard $(ROOT_DIR)/keyboards/$$(KEYBOARD_FOLDER_PATH_4)/rules.mk)","")
       LAYOUTS :=
-      $$(eval include $(ROOT_DIR)/keyboards/$$(KEYBOARD_FOLDER_PATH_4)/rules.mk)
+      $(call USE_RULES,$(ROOT_DIR)/keyboards/$$(KEYBOARD_FOLDER_PATH_4)/rules.mk)
       KEYBOARD_LAYOUTS := $$(sort $$(LAYOUTS) $$(KEYBOARD_LAYOUTS))
     endif
     ifneq ("$$(wildcard $(ROOT_DIR)/keyboards/$$(KEYBOARD_FOLDER_PATH_3)/rules.mk)","")
       LAYOUTS :=
-      $$(eval include $(ROOT_DIR)/keyboards/$$(KEYBOARD_FOLDER_PATH_3)/rules.mk)
+      $(call USE_RULES,$(ROOT_DIR)/keyboards/$$(KEYBOARD_FOLDER_PATH_3)/rules.mk)
       KEYBOARD_LAYOUTS := $$(sort $$(LAYOUTS) $$(KEYBOARD_LAYOUTS))
     endif
     ifneq ("$$(wildcard $(ROOT_DIR)/keyboards/$$(KEYBOARD_FOLDER_PATH_2)/rules.mk)","")
       LAYOUTS :=
-      $$(eval include $(ROOT_DIR)/keyboards/$$(KEYBOARD_FOLDER_PATH_2)/rules.mk)
+      $(call USE_RULES,$(ROOT_DIR)/keyboards/$$(KEYBOARD_FOLDER_PATH_2)/rules.mk)
       KEYBOARD_LAYOUTS := $$(sort $$(LAYOUTS) $$(KEYBOARD_LAYOUTS))
     endif
     ifneq ("$$(wildcard $(ROOT_DIR)/keyboards/$$(KEYBOARD_FOLDER_PATH_1)/rules.mk)","")
       LAYOUTS :=
-      $$(eval include $(ROOT_DIR)/keyboards/$$(KEYBOARD_FOLDER_PATH_1)/rules.mk)
+      $(call USE_RULES,$(ROOT_DIR)/keyboards/$$(KEYBOARD_FOLDER_PATH_1)/rules.mk)
       KEYBOARD_LAYOUTS := $$(sort $$(LAYOUTS) $$(KEYBOARD_LAYOUTS))
     endif
 
@@ -356,6 +363,8 @@ define PARSE_KEYBOARD
     $$(foreach LAYOUT,$$(KEYBOARD_LAYOUTS),$$(eval LAYOUT_KEYMAPS += $$(notdir $$(patsubst %/.,%,$$(wildcard $(ROOT_DIR)/layouts/*/$$(LAYOUT)/*/.)))))
 
     KEYMAPS := $$(sort $$(KEYMAPS) $$(LAYOUT_KEYMAPS))
+
+    $$(eval include $$(foreach RULES_MK,$$(RULES_MK_LIST),$$(wildcard $$(subst rules.mk,build.mk,$$(RULES_MK)))))
 
     # if the rule after removing the start of it is empty (we haven't specified a kemap or target)
     # compile all the keymaps

--- a/build_keyboard.mk
+++ b/build_keyboard.mk
@@ -76,19 +76,19 @@ endif
 
 # Pull in rules.mk files from all our subfolders
 ifneq ("$(wildcard $(KEYBOARD_PATH_5)/rules.mk)","")
-    include $(KEYBOARD_PATH_5)/rules.mk
+    $(call USE_RULES,$(KEYBOARD_PATH_5)/rules.mk)
 endif
 ifneq ("$(wildcard $(KEYBOARD_PATH_4)/rules.mk)","")
-    include $(KEYBOARD_PATH_4)/rules.mk
+    $(call USE_RULES,$(KEYBOARD_PATH_4)/rules.mk)
 endif
 ifneq ("$(wildcard $(KEYBOARD_PATH_3)/rules.mk)","")
-    include $(KEYBOARD_PATH_3)/rules.mk
+    $(call USE_RULES,$(KEYBOARD_PATH_3)/rules.mk)
 endif
 ifneq ("$(wildcard $(KEYBOARD_PATH_2)/rules.mk)","")
-    include $(KEYBOARD_PATH_2)/rules.mk
+    $(call USE_RULES,$(KEYBOARD_PATH_2)/rules.mk)
 endif
 ifneq ("$(wildcard $(KEYBOARD_PATH_1)/rules.mk)","")
-    include $(KEYBOARD_PATH_1)/rules.mk
+    $(call USE_RULES,$(KEYBOARD_PATH_1)/rules.mk)
 endif
 
 
@@ -291,7 +291,8 @@ ifeq ("$(USER_NAME)","")
 endif
 USER_PATH := users/$(USER_NAME)
 
--include $(USER_PATH)/rules.mk
+$(call USE_RULES,$(USER_PATH)/rules.mk,-)
+$(eval include $(foreach RULES_MK,$(RULES_MK_LIST),$(wildcard $(subst rules.mk,build.mk,$(RULES_MK)))))
 ifneq ("$(wildcard $(USER_PATH)/config.h)","")
     CONFIG_H += $(USER_PATH)/config.h
 endif

--- a/common.mk
+++ b/common.mk
@@ -22,3 +22,8 @@ COMMON_VPATH += $(QUANTUM_PATH)/audio
 COMMON_VPATH += $(QUANTUM_PATH)/process_keycode
 COMMON_VPATH += $(QUANTUM_PATH)/api
 COMMON_VPATH += $(DRIVER_PATH)
+
+define USE_RULES
+    $(if $(filter $(1),$(RULES_MK_LIST)),,$(eval RULES_MK_LIST += $(1)))\
+    $(eval $(2)include $(1))
+endef

--- a/keyboards/ergodox_ez/build.mk
+++ b/keyboards/ergodox_ez/build.mk
@@ -1,0 +1,22 @@
+ifeq ($(strip $(RGB_MATRIX_ENABLE)), no)
+  SRC += i2c_master.c
+endif
+
+ifeq ($(strip $(I2CLCD_AF_ENABLE)), yes)
+    SRC += i2c_lcd_af.c
+    OPT_DEFS += -DI2CLCD_PORT=$(I2CLCD_PORT) -DI2CLCD_ENABLE
+endif
+
+ifeq ($(strip $(I2CLCD_SB_ENABLE)), yes)
+    SRC += i2c_lcd_sb.c
+    OPT_DEFS += -DI2CLCD_PORT=$(I2CLCD_PORT) -DI2CLCD_ENABLE
+endif
+
+ifeq ($(strip $(I2CLCD_ENABLE)), yes)
+  SRC += i2c_lcd.c
+  OPT_DEFS += -DI2CLCD_PORT=$(I2CLCD_PORT)
+endif
+
+ifeq ($(strip $(LCDSTENO_ENABLE)), yes)
+  SRC += lcd_steno.c
+endif

--- a/keyboards/ergodox_ez/ergodox_ez.h
+++ b/keyboards/ergodox_ez/ergodox_ez.h
@@ -26,6 +26,16 @@
 extern i2c_status_t mcp23018_status;
 #define ERGODOX_EZ_I2C_TIMEOUT 100
 
+#ifdef I2CLCD_PORT
+extern void lcd_init(void);
+extern void lcd_update(matrix_row_t *matrix);
+extern uint8_t lcd_move(int row, int col);
+extern uint8_t lcd_clear(void);
+extern uint8_t lcd_char(uint8_t c);
+extern uint8_t lcd_string(char *s, int len);
+extern uint8_t lcd_backlight(uint8_t brightness);
+#endif
+
 void init_ergodox(void);
 void ergodox_blink_all_leds(void);
 uint8_t init_mcp23018(void);

--- a/keyboards/ergodox_ez/i2c_lcd_af.c
+++ b/keyboards/ergodox_ez/i2c_lcd_af.c
@@ -1,0 +1,178 @@
+#include QMK_KEYBOARD_H
+
+/* The backpack uses nearly the same chip as the left hand. The
+ * left hand uses 0x20 as its base i2c address. The backpack has
+ * jumpers for address bits. For instance, if you solder the A0
+ * jumper, you would set I2CLCD_PORT to 1.
+ */
+#define LCD_ADDR (0x20 | (I2CLCD_PORT))
+#define LCD_ADDR_WRITE  ( (LCD_ADDR<<1) | I2C_WRITE )
+#define LCD_ADDR_READ   ( (LCD_ADDR<<1) | I2C_READ  )
+
+#define MCP23008_IODIR 0x00
+#define MCP23008_GPIO 0x09
+
+#define MCP23008_RS 0x2
+#define MCP23008_ENABLE 0x4
+#define MCP23008_DATA (0xF << 3)
+#define MCP23008_BACKLIGHT 0x80
+
+// add-on: mcp23008 used to drive a 4x20 LCD
+static uint8_t mcp23008_status = 0x0;
+static uint8_t mcp23008_gpio = 0x0;
+
+static inline uint8_t
+mcp23008_writeport(uint8_t port, uint8_t value) {
+    mcp23008_status = i2c_start(LCD_ADDR_WRITE, ERGODOX_EZ_I2C_TIMEOUT);    if (mcp23008_status) goto out;
+    mcp23008_status = i2c_write(port, ERGODOX_EZ_I2C_TIMEOUT);              if (mcp23008_status) goto out;
+    mcp23008_status = i2c_write(value, ERGODOX_EZ_I2C_TIMEOUT);	            if (mcp23008_status) goto out;
+out:
+    i2c_stop();
+    return mcp23008_status;
+}
+
+static uint8_t
+lcd_setpins(void) {
+    return mcp23008_writeport(MCP23008_GPIO, mcp23008_gpio);
+}
+
+static uint8_t
+lcd_write4(uint8_t value) {
+    mcp23008_gpio = (mcp23008_gpio & ~MCP23008_DATA) | ((value & 0xF) << 3);
+    mcp23008_status = lcd_setpins();                if (mcp23008_status) goto out;
+    mcp23008_gpio |= MCP23008_ENABLE;
+    mcp23008_status = lcd_setpins();                if (mcp23008_status) goto out;
+    mcp23008_gpio &= ~MCP23008_ENABLE;
+    mcp23008_status = lcd_setpins();                if (mcp23008_status) goto out;
+out:
+    return mcp23008_status;
+}
+
+static uint8_t
+lcd_write8(uint8_t value) {
+    mcp23008_status = lcd_write4((value >> 4) & 0xF); if (mcp23008_status) goto out;
+    mcp23008_status = lcd_write4(value & 0xF);        if (mcp23008_status) goto out;
+out:
+    return mcp23008_status;
+}
+
+static uint8_t
+lcd_command(uint8_t c) {
+    mcp23008_gpio &= ~MCP23008_RS;
+    mcp23008_status = lcd_write8(c);
+    // note: you need to delay about 37us after most commands...
+    // but that's longer than it takes us to write a single set of gpio bits,
+    // so no delay is actually needed.
+    return mcp23008_status;
+}
+
+uint8_t
+lcd_move(int row, int col) {
+    row %= 4;
+    col %= 20;
+    // 0xA * (row & 2) = 0x14 if the high order bit is set.
+    // the display order puts row 2 exactly 20 characters past row 0,
+    // and then row 3 exactly 20 characters past row 1, but this omits
+    // a shift
+    uint8_t addr = 0xA * (row & 2) + 0x40 * (row & 1);
+    return lcd_command(0x80 | (addr + col));
+}
+
+uint8_t
+lcd_char(uint8_t c) {
+    mcp23008_gpio |= MCP23008_RS;
+    return lcd_write8(c);
+}
+
+uint8_t
+lcd_string(char *s, int len) {
+    // cap at one line or end of string
+    if (len < 1)
+        len = 20;
+    for (int i = 0; *s && (i < len); ++i, ++s) {
+        if (lcd_char(*s))
+            return mcp23008_status;
+    }
+    return 0;
+}
+
+uint8_t
+lcd_clear(void) {
+    // clear, which needs a bit over 1ms delay
+    lcd_command(0x01);
+    if (!mcp23008_status)
+        _delay_ms(2);
+    return mcp23008_status;
+}
+
+void lcd_init(void) {
+    uint8_t stopped = 1;
+    // init code for mcp23008 and LCD
+    mcp23008_status = 0x20;
+    stopped = 0;
+    mcp23008_status = i2c_start(LCD_ADDR_WRITE, ERGODOX_EZ_I2C_TIMEOUT); if (mcp23008_status) goto out;
+    mcp23008_status = i2c_write(MCP23008_IODIR, ERGODOX_EZ_I2C_TIMEOUT); if (mcp23008_status) goto out;
+    mcp23008_status = i2c_write(0xFF, ERGODOX_EZ_I2C_TIMEOUT);		 if (mcp23008_status) goto out;
+    mcp23008_status = i2c_write(0x00, ERGODOX_EZ_I2C_TIMEOUT);		 if (mcp23008_status) goto out;
+    mcp23008_status = i2c_write(0x00, ERGODOX_EZ_I2C_TIMEOUT);		 if (mcp23008_status) goto out;
+    mcp23008_status = i2c_write(0x00, ERGODOX_EZ_I2C_TIMEOUT);		 if (mcp23008_status) goto out;
+    mcp23008_status = i2c_write(0x00, ERGODOX_EZ_I2C_TIMEOUT);		 if (mcp23008_status) goto out;
+    mcp23008_status = i2c_write(0x00, ERGODOX_EZ_I2C_TIMEOUT);		 if (mcp23008_status) goto out;
+    mcp23008_status = i2c_write(0x00, ERGODOX_EZ_I2C_TIMEOUT);		 if (mcp23008_status) goto out;
+    mcp23008_status = i2c_write(0x00, ERGODOX_EZ_I2C_TIMEOUT);		 if (mcp23008_status) goto out;
+    mcp23008_status = i2c_write(0x00, ERGODOX_EZ_I2C_TIMEOUT);		 if (mcp23008_status) goto out;
+    mcp23008_status = i2c_write(0x00, ERGODOX_EZ_I2C_TIMEOUT);		 if (mcp23008_status) goto out;
+    i2c_stop();
+    stopped = 1;
+    // IODIR: 1 == input. We want everything but pin 0 to be an output.
+    mcp23008_status = mcp23008_writeport(MCP23008_IODIR, 0x01);    if (mcp23008_status) goto out;
+    // turn on the backlight pin. don't turn on any others, which
+    // means that RS and ENABLE are now off...
+    mcp23008_gpio = MCP23008_BACKLIGHT;
+    mcp23008_status = lcd_setpins();             if (mcp23008_status) goto out;
+    lcd_write4(0x03);				 if (mcp23008_status) goto out;
+    _delay_us(4150);
+    lcd_write4(0x03);				 if (mcp23008_status) goto out;
+    _delay_us(4150);
+    lcd_write4(0x03);				 if (mcp23008_status) goto out;
+    _delay_us(150);
+    lcd_write4(0x02);				 if (mcp23008_status) goto out;
+    // mode settings
+    lcd_command(0x28);				 if (mcp23008_status) goto out;
+    lcd_command(0x0C);				 if (mcp23008_status) goto out;
+    lcd_clear();
+    lcd_command(0x06);				 if (mcp23008_status) goto out;
+out:
+    if (!stopped)
+	    i2c_stop();
+}
+
+// can't set backlight to anything but on or off
+uint8_t
+lcd_backlight(uint8_t brightness) {
+    if (brightness) {
+    	mcp23008_gpio |= MCP23008_BACKLIGHT;
+    } else {
+    	mcp23008_gpio &= ~MCP23008_BACKLIGHT;
+    }
+    return lcd_setpins();
+}
+
+// no default update, but you could define one if you wanted to
+__attribute__ ((weak))
+void lcd_update_user(matrix_row_t *matrix) { }
+
+uint8_t reset_counter = 0;
+
+void
+lcd_update(matrix_row_t *matrix) {
+    if (mcp23008_status) {
+    	++reset_counter;
+	if (reset_counter == 0) {
+	    // try to reset display.
+	    lcd_init();
+	}
+    }
+    lcd_update_user(matrix);
+}
+

--- a/keyboards/ergodox_ez/i2c_lcd_sb.c
+++ b/keyboards/ergodox_ez/i2c_lcd_sb.c
@@ -1,0 +1,116 @@
+#include QMK_KEYBOARD_H
+
+/* This drives a custom lcd driver I built using an atmega
+ * chip because it's way faster than the adafruit one based
+ * on a gpio expander
+ *
+ * https://github.com/seebs/lcd_tiny
+ *
+ * This is badly under-documented, but if anyone wants to
+ * make these or clean it up, you go right ahead.
+ */
+#define LCD_ADDR (0x32 | (I2CLCD_PORT))
+#define LCD_ADDR_WRITE  ( (LCD_ADDR<<1) | I2C_WRITE )
+#define LCD_ADDR_READ   ( (LCD_ADDR<<1) | I2C_READ  )
+
+/* Protocol:
+ * Printable ASCII characters, and 0x00 through 0x0F, are simply
+ * passed on as characters to write. Values from 0x10 through 0x1F
+ * are potentially commands. Specifically:
+ *
+ * 0x10: no operation
+ * 0x11: move, next byte ((row << 5) | (col & 0x1F)
+ * 0x12: brightness, next byte backlight PWM duty cycle (0-255)
+ * 0x13: setcgram: next byte address, then 8 bytes of graphic data
+ * 0x14: clear
+ */
+
+uint8_t lcd_status;
+
+static inline uint8_t
+i2c_startw(uint8_t addr) {
+	uint8_t ret;
+	for (int i = 0; i < 10; ++i) {
+		ret = i2c_start(addr, ERGODOX_EZ_I2C_TIMEOUT);
+		if (!ret)
+			break;
+	}
+	return ret;
+}
+
+
+uint8_t
+lcd_move(int row, int col) {
+    uint8_t addr = ((row & 3) << 5) | (col & 0x1F);
+    // xprintf("lcd_move[%d,%d] => %d | %d", row, col, addr & 0xE0, addr & 0x1F);
+    lcd_status = i2c_startw(LCD_ADDR_WRITE);	if (lcd_status) goto out;
+    lcd_status = i2c_write(0x11, ERGODOX_EZ_I2C_TIMEOUT);		if (lcd_status) goto out;
+    lcd_status = i2c_write(addr, ERGODOX_EZ_I2C_TIMEOUT);		if (lcd_status) goto out;
+out:
+    i2c_stop();
+    // xprintf("->%d\n", lcd_status);
+    return lcd_status;
+}
+
+uint8_t
+lcd_char(uint8_t c) {
+    // xprintf("lcd_char(%c)", c);
+    lcd_status = i2c_startw(LCD_ADDR_WRITE);	if (lcd_status) goto out;
+    lcd_status = i2c_write(c, ERGODOX_EZ_I2C_TIMEOUT);			if (lcd_status) goto out;
+out:
+    i2c_stop();
+    // xprintf("->%d\n", lcd_status);
+    return lcd_status;
+}
+
+uint8_t
+lcd_string(char *s, int len) {
+    if (len < 1)
+        len = 20;
+    // xprintf("lcd_string(%s)", s);
+    lcd_status = i2c_startw(LCD_ADDR_WRITE);	if (lcd_status) goto out;
+    for (int i = 0; *s && (i < len); ++i, ++s) {
+    	if (i2c_write(*s, ERGODOX_EZ_I2C_TIMEOUT))
+	    goto out;
+    }
+out:
+    i2c_stop();
+    // xprintf("->%d\n", lcd_status);
+    return lcd_status;
+}
+
+uint8_t
+lcd_clear(void) {
+    lcd_status = i2c_startw(LCD_ADDR_WRITE);	if (lcd_status) goto out;
+    lcd_status = i2c_write(0x14, ERGODOX_EZ_I2C_TIMEOUT);		if (lcd_status) goto out;
+out:
+    i2c_stop();
+    return lcd_status;
+}
+
+uint8_t
+lcd_backlight(uint8_t brightness) {
+    lcd_status = i2c_startw(LCD_ADDR_WRITE);	if (lcd_status) goto out;
+    lcd_status = i2c_write(0x12, ERGODOX_EZ_I2C_TIMEOUT);		if (lcd_status) goto out;
+    lcd_status = i2c_write(brightness, ERGODOX_EZ_I2C_TIMEOUT);		if (lcd_status) goto out;
+out:
+    i2c_stop();
+    return lcd_status;
+}
+
+void lcd_init(void) {
+    lcd_backlight(0);
+    lcd_clear();
+    // nothing to do, the other end did it already
+}
+
+// no default update, but you could define one if you wanted to
+__attribute__ ((weak))
+void lcd_update_user(matrix_row_t *matrix) { }
+
+uint8_t reset_counter = 0;
+
+void
+lcd_update(matrix_row_t *matrix) {
+    lcd_update_user(matrix);
+}

--- a/keyboards/ergodox_ez/i2c_led.c
+++ b/keyboards/ergodox_ez/i2c_led.c
@@ -1,0 +1,48 @@
+#include QMK_KEYBOARD_H
+#include "keymap_steno.h"
+#include <string.h>
+
+/* Support for HT16K33 backpacks with 16x8 LED drivers.
+ */
+#define LED_ADDR(x) (0x70 | (x))
+#define LED_ADDR_WRITE(x) ((LED_ADDR(x) << 1) | I2C_WRITE)
+
+static uint8_t ht16k33_status_l = 0x0;
+static uint8_t ht16k33_status_r = 0x0;
+
+uint8_t
+ht16k33_cmd(uint8_t cmd, uint8_t addr) {
+    uint8_t status;
+    status = i2c_start(LED_ADDR_WRITE(addr));             if (status) goto out;
+    status = i2c_write(cmd);
+out:
+    i2c_stop();
+    return status;
+}
+
+void init_lcd(void) {
+    int stopped = true;
+    ht16k33_status_r = ht16k33_cmd(0x21, 1);
+    ht16k33_status_l = ht16k33_cmd(0x21, 2);
+    ht16k33_status_r = ht16k33_cmd(0x81, 1);
+    ht16k33_status_l = ht16k33_cmd(0x81, 2);
+    ht16k33_status_r = ht16k33_cmd(0xE8, 1);
+    ht16k33_status_l = ht16k33_cmd(0xE8, 2);
+    ht16k33_status_r = i2c_start(LED_ADDR_WRITE(1));    if (ht16k33_status_r) goto out;
+    stopped = false;
+    ht16k33_status_r = i2c_write(0x00);          if (ht16k33_status_r) goto out;
+    for (int i = 0; i < 16; ++i) {
+	    ht16k33_status_r = i2c_write(0x00);          if (ht16k33_status_r) goto out;
+    }
+    i2c_stop();
+    ht16k33_status_l = i2c_start(LED_ADDR_WRITE(2));    if (ht16k33_status_l) goto out;
+    stopped = false;
+    ht16k33_status_l = i2c_write(0x00);          if (ht16k33_status_l) goto out;
+    for (int i = 0; i < 16; ++i) {
+	    ht16k33_status_r = i2c_write(0x00);          if (ht16k33_status_l) goto out;
+    }
+out:
+    if (!stopped)
+	    i2c_stop();
+}
+

--- a/keyboards/ergodox_ez/keymaps/dvorak_serplover/README.md
+++ b/keyboards/ergodox_ez/keymaps/dvorak_serplover/README.md
@@ -1,0 +1,13 @@
+Dvorak support, plover support, gaming support
+
+This keymap defaults to Dvorak, but has a layer that uses
+the Gemini PR protocol of QMK's internal steno stuff for talking
+to Plover -- much more convenient than the NKRO-derived
+version. It also works nicely with my LCD display hack.
+
+The result is probably a bit idiosyncratic, but it works for me.
+
+I also don't have any press/hold distinction keys, because that
+confuses my fuzzy little brain.
+
+Contributed by seebs (seebs@seebs.net)

--- a/keyboards/ergodox_ez/keymaps/dvorak_serplover/config.h
+++ b/keyboards/ergodox_ez/keymaps/dvorak_serplover/config.h
@@ -1,0 +1,26 @@
+#undef LED_BRIGHTNESS_DEFAULT
+#define LED_BRIGHTNESS_DEFAULT 5
+
+#define QMK_KEYS_PER_SCAN 8
+
+#undef DEBOUNCE
+#define DEBOUNCE 4
+
+/* HIGH: # on number keys, use the qwerty/asdf rows for letters.
+ * default: # on qwerty, use the asdf/zxcv rows for letters.
+ */
+// #define STENO_KEYS_HIGH
+
+/* IN: use the vertical 1.5 keys as *, put the other keys one row in,
+ * don't use the horizontal 1.5 keys.
+ */
+// #define STENO_KEYS_IN
+
+/* use top S as a # key instead */
+#define STENO_KEYS_SNUM
+
+#ifdef STENO_KEYS_SNUM
+#define STN_SN STN_NC
+#else
+#define STN_SN STN_S1
+#endif

--- a/keyboards/ergodox_ez/keymaps/dvorak_serplover/keymap.c
+++ b/keyboards/ergodox_ez/keymaps/dvorak_serplover/keymap.c
@@ -1,0 +1,397 @@
+#include QMK_KEYBOARD_H
+#include "debug.h"
+#include "action_layer.h"
+#include "keymap_steno.h"
+#include "version.h"
+
+enum layers {
+	BASE, // default layer
+	SYMB, // symbols
+	PLVR, // plover steno (gemini protocol)
+	QWRT, // qwerty layer for gaming
+	LEDS,  // LED controls
+};
+
+enum custom_keycodes {
+	PLACEHOLDER = SAFE_RANGE, // can always be here
+	L_MIN,
+	L_MP = L_MIN,
+	L_MM,
+	L_HP,
+	L_HM,
+	L_SP,
+	L_SM,
+	L_VP,
+	L_VM,
+	L_ON,
+	L_OFF,
+	L_MAX
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+/* Keymap 0: Basic layer
+ *
+ * ,--------------------------------------------------.           ,--------------------------------------------------.
+ * |   =    |   1  |   2  |   3  |   4  |   5  | Esc  |           | PLVR |   6  |   7  |   8  |   9  |   0  |   \    |
+ * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
+ * | Tab    |   '  |   ,  |   .  |   P  |   Y  |  L1  |           |      |   F  |   G  |   C  |   R  |   L  |   /    |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * | LCtrl  |   A  |   O  |   E  |   U  |   I  |------|           |------|   D  |   H  |   T  |   N  |   S  |   -    |
+ * |--------+------+------+------+------+------|  L4  |           |  L3  |------+------+------+------+------+--------|
+ * | LShift |   ;  |   Q  |   J  |   K  |   X  |      |           |      |   B  |   M  |   W  |   V  |   Z  | RShift |
+ * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
+ *   |Lalt  |  Grv |      | Left | Right|                                       |  Up  | Down |   [  |   ]  | RAlt |
+ *   `----------------------------------'                                       `----------------------------------'
+ *                                        ,-------------.       ,---------------.
+ *                                        | LCtrl| LGui |       | RGui | RCtrl  |
+ *                                 ,------|------|------|       |------+--------+------.
+ *                                 |      |      | Home |       | PgUp |        |      |
+ *                                 |Backsp|Delete|------|       |------| Enter  |Space |
+ *                                 |   ace|      | End  |       | PgDn |        |      |
+ *                                 `--------------------'       `----------------------'
+ */
+// If it accepts an argument (i.e, is a function), it doesn't need KC_.
+// Otherwise, it needs KC_*
+[BASE] = LAYOUT_ergodox(  // layer 0 : default
+        // left hand
+        KC_EQL,         KC_1,     KC_2,    KC_3,   KC_4,   KC_5,   KC_ESC,
+        KC_TAB,         KC_QUOT,  KC_COMM, KC_DOT, KC_P,   KC_Y,   MO(SYMB),
+        KC_LCTRL,       KC_A,     KC_O,    KC_E,   KC_U,   KC_I,
+        KC_LSFT,        KC_SCLN,  KC_Q,    KC_J,   KC_K,   KC_X,   MO(LEDS),
+        KC_LALT,        KC_GRV,   KC_NO,   KC_LEFT,KC_RGHT,
+                                               KC_LCTL,KC_LGUI,
+                                                              KC_HOME,
+                                               KC_BSPC,KC_DEL,KC_END,
+        // right hand
+        TG(PLVR),       KC_6,     KC_7,    KC_8,   KC_9,   KC_0,     KC_BSLS,
+        KC_NO,          KC_F,     KC_G,    KC_C,   KC_R,   KC_L,     KC_SLSH,
+                        KC_D,     KC_H,    KC_T,   KC_N,   KC_S,     KC_MINS,
+        TG(QWRT),       KC_B,     KC_M,    KC_W,   KC_V,   KC_Z,     KC_RSFT,
+                                  KC_UP,   KC_DOWN,KC_LBRC,KC_RBRC,  KC_RALT,
+        KC_RGUI,KC_RCTL,
+        KC_PGUP,
+        KC_PGDN,KC_ENT, KC_SPC
+    ),
+/* Keymap 1: Symbol Layer
+ *
+ * ,--------------------------------------------------.           ,--------------------------------------------------.
+ * |        |  F1  |  F2  |  F3  |  F4  |  F5  |      |           |      |  F6  |  F7  |  F8  |  F9  |  F10 |   F11  |
+ * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
+ * |        |   !  |   @  |   {  |   }  |   |  |      |           |      |   Up |  KP7 |  KP8 | KP9  |  KP* |   F12  |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |        |   #  |   $  |   (  |   )  |   `  |------|           |------| Down |  KP4 |  KP5 | KP6  |  KP+ |        |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |        |   %  |   ^  |   [  |   ]  |   ~  |      |           |      |   &  |  KP1 |  KP2 | KP3  |  KP/ |        |
+ * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
+ *   |      |      |      |      |      |                                       |      |  KP. | KP0  |  KP= |      |
+ *   `----------------------------------'                                       `----------------------------------'
+ *                                        ,-------------.       ,-------------.
+ *                                        |      |      |       |      |      |
+ *                                 ,------|------|------|       |------+------+------.
+ *                                 |      |      |      |       |      |      |      |
+ *                                 |      |      |------|       |------|      |      |
+ *                                 |      |      |      |       |      |      |      |
+ *                                 `--------------------'       `--------------------'
+ */
+// SYMBOLS
+[SYMB] = LAYOUT_ergodox(
+       // left hand
+       KC_TRNS,KC_F1,  KC_F2,  KC_F3,  KC_F4,  KC_F5,  KC_TRNS,
+       KC_TRNS,KC_EXLM,KC_AT,  KC_LCBR,KC_RCBR,KC_PIPE,KC_TRNS,
+       KC_TRNS,KC_HASH,KC_DLR, KC_LPRN,KC_RPRN,KC_GRV,
+       KC_TRNS,KC_PERC,KC_CIRC,KC_LBRC,KC_RBRC,KC_TILD,KC_TRNS,
+       KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,
+                                       KC_TRNS,KC_TRNS,
+                                               KC_TRNS,
+                               KC_TRNS,KC_TRNS,KC_TRNS,
+       // right hand
+       KC_TRNS, KC_F6,   KC_F7,  KC_F8,   KC_F9,   KC_F10,  KC_F11,
+       KC_TRNS, KC_UP,   KC_P7,  KC_P8,   KC_P9,   KC_PAST, KC_F12,
+                KC_DOWN, KC_P4,  KC_P5,   KC_P6,   KC_PPLS, KC_TRNS,
+       KC_TRNS, KC_AMPR, KC_P1,  KC_P2,   KC_P3,   KC_PSLS, KC_TRNS,
+                         KC_TRNS,KC_PDOT, KC_P0,   KC_PEQL, KC_TRNS,
+       KC_TRNS, KC_TRNS,
+       KC_TRNS,
+       KC_TRNS, KC_TRNS, KC_TRNS
+),
+
+/* Keymap 3: Plover (Gemini PR over Serial)
+ * Note the use of ST[1234] and S[12], which aren't really needed but
+ * I wanted to see whether plover handled them. Not currently using
+ * the FN key, since I have no idea what it would do. Also note
+ * the non-steno arrow keys, added because they would be handy to
+ * have while editing.
+ *
+ * ,--------------------------------------------------.           ,--------------------------------------------------.
+ * | BKSPC  |   #  |   #  |   #  |   #  |   #  |      |           | Leave|   #  |   #  |   #  |   #  |   #  |   #    |
+ * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
+ * |        |   S  |   T  |   P  |   H  |   *  |      |           |      |   *  |   F  |   P  |   L  |   T  |   D    |
+ * |--------+------+------+------+------+------|   *  |           |  *   |------+------+------+------+------+--------|
+ * |        |   S  |   K  |   W  |   R  |   *  |------|           |------|   *  |   R  |   B  |   G  |   S  |   Z    |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |        |      |      |      |      |      |   *  |           |  *   |      |      |      |      |      |        |
+ * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
+ *   |      |      |      | Left | Right|                                       |  Up  | Down |      |      |      |
+ *   `----------------------------------'                                       `----------------------------------'
+ *                                        ,-------------.       ,-------------.
+ *                                        |      |      |       |      |      |
+ *                                 ,------|------|------|       |------+------+------.
+ *                                 |      |      |      |       |      |      |      |
+ *                                 |   A  |   O  |------|       |------|   E  |   U  |
+ *                                 |      |      |      |       |      |      |      |
+ *                                 `--------------------'       `--------------------'
+ */
+[PLVR] = LAYOUT_ergodox(
+#ifdef STENO_KEYS_HIGH
+       KC_BSPC, STN_N1,  STN_N2,  STN_N3,  STN_N4,  STN_N5, KC_NO,
+       KC_NO,   STN_SN,  STN_TL,  STN_PL,  STN_HL,  STN_ST1,STN_ST1,
+       KC_NO,   STN_S2,  STN_KL,  STN_WL,  STN_RL,  STN_ST2,
+       KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,  STN_ST2,
+#else
+  #ifdef STENO_KEYS_IN
+       KC_BSPC, KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,  KC_NO,
+       KC_NO,   KC_NO,   STN_N1,  STN_N2,  STN_N3,  STN_N4, STN_ST1,
+       KC_NO,   KC_NO,   STN_S1,  STN_TL,  STN_PL,  STN_HL,
+       KC_NO,   KC_NO,   STN_S2,  STN_KL,  STN_WL,  STN_RL,  STN_ST2,
+  #else
+       KC_BSPC, KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,  KC_NO,
+       KC_NO,   STN_N1,  STN_N2,  STN_N3,  STN_N4,  STN_N5, STN_ST1,
+       KC_NO,   STN_S1,  STN_TL,  STN_PL,  STN_HL,  STN_ST1,
+       KC_NO,   STN_S2,  STN_KL,  STN_WL,  STN_RL,  STN_ST2, STN_ST2,
+  #endif
+#endif
+       KC_NO,   KC_NO,   KC_NO,   KC_LEFT, KC_RIGHT,
+                                           KC_NO,   KC_NO,
+                                                    KC_NO,
+                                  STN_A,   STN_O,   KC_NO,
+    // right hand
+#ifdef STENO_KEYS_HIGH
+       TG(PLVR),STN_N6,  STN_N7,  STN_N8,  STN_N9,  STN_NA,  STN_NB,
+       STN_ST3, STN_ST3, STN_FR,  STN_PR,  STN_LR,  STN_TR,  STN_DR,
+                STN_ST4, STN_RR,  STN_BR,  STN_GR,  STN_SR,  STN_ZR,
+       STN_ST4, KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,
+#else
+  #ifdef STENO_KEYS_IN
+       TG(PLVR),KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,
+       STN_ST3, STN_N6,  STN_N7,  STN_N8,  STN_N9,  STN_NA,  STN_NB,
+                STN_FR,  STN_PR,  STN_LR,  STN_TR,  STN_DR,  KC_NO,
+       STN_ST4, STN_RR,  STN_BR,  STN_GR,  STN_SR,  STN_ZR,  KC_NO,
+  #else
+       TG(PLVR),KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,
+       STN_ST3, STN_N6,  STN_N7,  STN_N8,  STN_N9,  STN_NA,  STN_NB,
+                STN_ST3, STN_FR,  STN_PR,  STN_LR,  STN_TR,  STN_DR,
+       STN_ST4, STN_ST4, STN_RR,  STN_BR,  STN_GR,  STN_SR,  STN_ZR,
+  #endif
+#endif
+                         KC_UP,   KC_DOWN, KC_NO,   KC_NO,   KC_NO,
+       KC_NO,   KC_NO,
+       KC_NO,
+       KC_NO,   STN_E,   STN_U
+),
+
+/* Keymap 4: qwerty-ish
+ *
+ * ,--------------------------------------------------.           ,--------------------------------------------------.
+ * |   =    |   1  |   2  |   3  |   4  |   5  | Esc  |           | Esc  |   6  |   7  |   8  |   9  |   0  |   -    |
+ * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
+ * | Tab    |   Q  |   W  |   E  |   R  |   T  |      |           |      |   Y  |   U  |   I  |   O  |   P  |   \    |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * | LGui   |   A  |   S  |   D  |   F  |   G  |------|           |------|   H  |   J  |   K  |   L  |   ;  |  LGui  |
+ * |--------+------+------+------+------+------| Spc  |           |  L3  |------+------+------+------+------+--------|
+ * | LShift |   Z  |   X  |   C  |   V  |   B  |      |           |      |   N  |   M  |   ,  |   .  |   /  | RShift |
+ * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
+ *   | Lalt |  Grv |  '"  | Left | Right|                                       |  Up  | Down |   [  |   ]  | RAlt |
+ *   `----------------------------------'                                       `----------------------------------'
+ *                                        ,-------------.       ,---------------.
+ *                                        | LCtrl| LAlt |       | RGui | RCtrl  |
+ *                                 ,------|------|------|       |------+--------+------.
+ *                                 |      |      | Home |       | PgUp |        |      |
+ *                                 |Backsp|Delete|------|       |------| Enter  |Space |
+ *                                 |   ace|      | End  |       | PgDn |        |      |
+ *                                 `--------------------'       `----------------------'
+ */
+[QWRT] = LAYOUT_ergodox(  // layer 4: qwerty for gaming
+        // left hand
+        KC_EQL,       KC_1,         KC_2,    KC_3,   KC_4,   KC_5,   KC_ESC,
+        KC_TAB,       KC_Q,         KC_W,    KC_E,   KC_R,   KC_T,   TG(SYMB),
+        KC_LGUI,      KC_A,         KC_S,    KC_D,   KC_F,   KC_G,
+        KC_LSFT,      KC_Z,         KC_X,    KC_C,   KC_V,   KC_B,   KC_SPACE,
+        KC_LALT,      KC_GRV,       KC_QUOT, KC_LEFT,KC_RGHT,
+						       KC_LCTL,KC_LALT,
+					                       KC_HOME,
+					        KC_BSPC,KC_DEL,KC_END,
+        // right hand
+        KC_ESC,     KC_6,   KC_7,   KC_8,   KC_9,   KC_0,     KC_MINS,
+        KC_NO,      KC_Y,   KC_U,   KC_I,   KC_O,   KC_P,     KC_BSLS,
+                    KC_H,   KC_J,   KC_K,   KC_L,   KC_SCLN,  KC_QUOT,
+        TG(QWRT),   KC_N,   KC_M,   KC_COMM,KC_DOT, KC_SLSH,  KC_RSFT,
+                            KC_UP,  KC_DOWN,KC_LBRC,KC_RBRC,  KC_RALT,
+        KC_RGUI,KC_RCTL,
+        KC_PGUP,
+        KC_PGDN,KC_ENT, KC_SPC
+    ),
+// layer 5: LED controls
+[LEDS] = LAYOUT_ergodox(
+       // left hand
+       KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,
+       KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,
+       KC_NO,  L_MP,   L_HP,   L_SP,   L_VP,   L_ON,
+       KC_NO,  L_MM,   L_HM,   L_SM,   L_VM,   L_OFF,  KC_NO,
+       KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,
+                                       KC_NO,  KC_NO,
+                                               KC_NO,
+                               KC_NO,  KC_NO,  KC_NO,
+       // right hand
+       KC_NO,   KC_NO,   KC_NO,  KC_NO,   KC_NO,   KC_NO,   KC_NO,
+       KC_NO,   KC_NO,   KC_NO,  KC_NO,   KC_NO,   KC_NO,   KC_NO,
+                KC_NO,   KC_NO,  KC_NO,   KC_NO,   KC_NO,   KC_NO,
+       KC_NO,   KC_NO,   KC_NO,  KC_NO,   KC_NO,   KC_NO,   KC_NO,
+                         KC_NO,  KC_NO,   KC_NO,   KC_NO,   KC_NO,
+       KC_NO,   KC_NO,
+       KC_NO,
+       KC_NO,   KC_NO,   KC_NO
+    ),
+};
+
+const uint16_t PROGMEM fn_actions[] = {
+    [1] = ACTION_LAYER_TAP_TOGGLE(SYMB),                // FN1 - Momentary Layer 1 (Symbols)
+    [4] = ACTION_LAYER_TAP_TOGGLE(LEDS),                // FN4 - Momentary Layer 4 (LED controls)
+};
+
+#ifdef RGBLIGHT_ENABLE
+static int32_t rgbmode = 25;
+#endif
+#ifdef I2CLCD_ENABLE
+uint8_t current_brightness = 0, target_brightness = 0;
+#endif
+// Runs just one time when the keyboard initializes.
+void matrix_init_user(void) {
+#ifdef RGBLIGHT_ENABLE
+    rgbmode = rgblight_get_mode();
+#endif
+    steno_set_mode(STENO_MODE_GEMINI);
+#ifdef I2CLCD_ENABLE
+    lcd_backlight(current_brightness);
+#endif
+};
+
+// static rainbow, by default
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+#ifdef RGBLIGHT_ENABLE
+	if (keycode >= L_MIN && keycode < L_MAX) {
+		if (IS_PRESSED(record->event)) {
+			switch (keycode) {
+				case L_MP:
+					rgbmode = (rgbmode + 1) % RGBLIGHT_MODES;
+					rgblight_mode(rgbmode);
+					break;
+				case L_MM:
+					rgbmode = (rgbmode + RGBLIGHT_MODES - 1) % RGBLIGHT_MODES;
+					rgblight_mode(rgbmode);
+					break;
+				case L_HP:
+					rgblight_increase_hue();
+					break;
+				case L_HM:
+					rgblight_decrease_hue();
+					break;
+				case L_SP:
+					rgblight_increase_sat();
+					break;
+				case L_SM:
+					rgblight_decrease_sat();
+					break;
+				case L_VP:
+					rgblight_increase_val();
+					break;
+				case L_VM:
+					rgblight_decrease_val();
+					break;
+				case L_ON:
+					rgblight_enable();
+					break;
+				case L_OFF:
+					rgblight_toggle();
+					break;
+			}
+		}
+	}
+#endif
+	return true;
+}
+
+#ifdef I2CLCD_ENABLE
+void
+lcd_update_user(void) {
+    if (current_brightness == target_brightness)
+        return;
+    if (current_brightness < target_brightness) {
+        ++current_brightness;
+    } else {
+        --current_brightness;
+    }
+    lcd_backlight(current_brightness);
+}
+#endif
+
+// Runs whenever there is a layer state change.
+static uint8_t prev_layer = 0;
+uint32_t layer_state_set_user(uint32_t state) {
+  ergodox_board_led_off();
+  ergodox_right_led_1_off();
+  ergodox_right_led_2_off();
+  ergodox_right_led_3_off();
+
+  uint8_t layer = biton32(state);
+  #ifdef I2CLCD_ENABLE
+  if (layer == PLVR && prev_layer != PLVR) {
+    target_brightness = 150;
+    lcd_move(3, 5);
+    lcd_string("PHROFR R-D", 10);
+  } else {
+    target_brightness = 0;
+    if (prev_layer == PLVR) {
+      lcd_clear();
+    }
+  }
+  #endif
+  prev_layer = layer;
+  switch (layer) {
+      case BASE:
+	#ifdef RGBLIGHT_ENABLE
+        #ifdef RGBLIGHT_COLOR_LAYER_0
+          rgblight_setrgb(RGBLIGHT_COLOR_LAYER_0);
+	#else
+	  // restore defaults (which were saved in eeprom, probably)
+	  rgblight_init();
+        #endif
+	#endif
+        break;
+      case SYMB:
+        ergodox_right_led_1_on();
+        #ifdef RGBLIGHT_COLOR_LAYER_1
+          rgblight_setrgb(RGBLIGHT_COLOR_LAYER_1);
+        #endif
+        break;
+      case PLVR:
+        ergodox_right_led_2_on();
+        #ifdef RGBLIGHT_COLOR_LAYER_2
+          rgblight_setrgb(RGBLIGHT_COLOR_LAYER_2);
+        #endif
+        break;
+      case QWRT:
+        ergodox_right_led_3_on();
+        #ifdef RGBLIGHT_COLOR_LAYER_3
+          rgblight_setrgb(RGBLIGHT_COLOR_LAYER_3);
+        #endif
+        break;
+      case LEDS:
+        ergodox_right_led_1_on();
+        ergodox_right_led_2_on();
+        ergodox_right_led_3_on();
+      default:
+        break;
+    }
+
+    return state;
+};

--- a/keyboards/ergodox_ez/keymaps/dvorak_serplover/rules.mk
+++ b/keyboards/ergodox_ez/keymaps/dvorak_serplover/rules.mk
@@ -1,0 +1,11 @@
+# Steno implies virtual serial.
+STENO_ENABLE     = yes
+# Not enough interupts, so something has to go. You can't have
+# more than one, because virtual serial uses so many things.
+# Note, you don't need NKRO for the Gemini-protocol serial steno.
+MOUSEKEY_ENABLE  = no
+CONSOLE_ENABLE   = no  # this is way too large now :(
+NKRO_ENABLE      = no
+I2CLCD_AF_ENABLE = no  # Use with Adafruit's MCP23008 backpack for LCD displays
+I2CLCD_SB_ENABLE = yes # Use with the weird hacky custom thing seebs built
+LCDSTENO_ENABLE  = yes

--- a/keyboards/ergodox_ez/lcd_steno.c
+++ b/keyboards/ergodox_ez/lcd_steno.c
@@ -1,0 +1,154 @@
+#include "keymap_steno.h"
+#include "ergodox_ez.h"
+#include <string.h>
+
+static char chords[3][9] = { "         ", "         ", "         " };
+/* #TPH FPLTD  ABCDEFGHIJ
+ * SKWR*RBGSZ  KLMNOPQRST
+ *   AO?EU       UVWXY
+ * A = position 1...
+ * position Z isn't displayed, it's there for "don't display this"
+ */
+static const char display_data[] PROGMEM    = "?######SSTKPWHRAO**???**EUFRPBLGTSD######Z";
+static const char ndisplay_data[] PROGMEM   = "?######112K3W4R50**???**EU6R7B8G9SD######Z";
+static const char displaypos_data[] PROGMEM = "WAAAAAAKKBLCMDNUVOOWWWOOXYFPGQHRISJAAAAAAT";
+static const char stenopos_data[] PROGMEM   = "XAAAAAABBCDEFGHIJKKXXXKKLMNOPQRSTUVAAAAAAW";
+
+static inline uint8_t
+display(uint8_t key) {
+    return pgm_read_byte(display_data + key);
+}
+
+static inline uint8_t
+ndisplay(uint8_t key) {
+    return pgm_read_byte(ndisplay_data + key);
+}
+
+static inline uint8_t
+displaypos(uint8_t key) {
+    return pgm_read_byte(displaypos_data + key) - 'A';
+}
+
+static inline uint8_t
+stenopos(uint8_t key) {
+    return pgm_read_byte(stenopos_data + key) - 'A';
+}
+
+static void lcd_goto(int pos) {
+    if (pos >= 20) {
+      pos += 2;
+    }
+    lcd_move(pos / 10, pos % 10);
+}
+
+// update key display for a key that's been changed
+bool
+postprocess_steno_user(uint16_t keycode, keyrecord_t *record, steno_mode_t mode, uint8_t chord[6], int8_t pressed) {
+    if (keycode < STN__MIN || keycode > STN__MAX) {
+        return true;
+    }
+    uint8_t key = (keycode - QK_STENO);
+    uint8_t idx = (key / 7);
+    uint8_t bit = 1 << (6 - (key % 7));
+    uint8_t pos = displaypos(key);
+    lcd_goto(pos);
+    if (IS_PRESSED(record->event)) {
+	lcd_char(display(key));
+    } else {
+	if (chord[idx] & bit) {
+            uint8_t ch = display(key);
+	    if (ch == '#' || ch == '*') {
+	        lcd_char('+');
+	    } else {
+		// tolower() for cheapskates
+	        lcd_char(ch | 0x20);
+	    }
+	} else {
+	    lcd_char(' ');
+	}
+    }
+    return true;
+}
+
+bool
+send_steno_chord_user(steno_mode_t mode, uint8_t chord[6]) {
+    bool numbering = false;
+    bool vowel = false;
+    char keys[26];
+    memset(keys, ' ', 25);
+    keys[25] = '\0';
+    /* the first key is FN, the next six are N1 through N6,
+     * so that's all but the first bit of the 7 bits in the
+     * first byte. Last key is ZR, with N7 through NC before
+     * it, same deal.
+     */
+    if ((chord[0] & 0x3F) || (chord[5] & 0x7E)) {
+        numbering = true;
+    }
+    if ((chord[2] & 0x30) || (chord[3] & 0x0C)) {
+	vowel = true;
+    }
+    for (int i = 0; i < 6; ++i) {
+	if (!chord[i])
+	    continue;
+	for (int j = 0; j < 7; ++j) {
+	    uint8_t bit = 1 << j;
+	    uint8_t idx = (i * 7) + (6 - j);
+	    if (chord[i] & bit) {
+		// write in steno order now
+		uint8_t pos = stenopos(idx);
+		uint8_t ch = numbering ? ndisplay(idx) : display(idx);
+		keys[pos] = ch;
+	    }
+	}
+    }
+    if (!vowel && keys[10] == ' ') {
+	keys[10] = '-';
+    }
+    char *k = keys;
+    for (int i = 0; i < 25; ++i) {
+	if (keys[i] != ' ') {
+	    *k++ = keys[i];
+	}
+    }
+    *k = '\0';
+    uint8_t len = k - keys;
+    // help my family is dying
+    // push fewer keys at once
+    // no
+    if (len > 20) {
+	keys[17] = '.';
+	keys[18] = '.';
+	keys[19] = '.';
+	len = 20;
+    }
+    lcd_move(3, 0);
+    for (int i = 0; i < 20 - len; ++i) {
+	lcd_char(' ');
+    }
+    lcd_string(keys, len);
+    for (int i = 0; i < 3; ++i) {
+	lcd_move(i, 11);
+	lcd_string(chords[i], 9);
+    }
+    memcpy(chords[0], chords[1], 9);
+    memcpy(chords[1], chords[2], 9);
+    if (len > 9) {
+	memcpy(chords[2], keys, 6);
+	chords[2][6] = '.';
+	chords[2][7] = '.';
+	chords[2][8] = '.';
+    } else {
+	memcpy(chords[2] + (9 - len), keys, len);
+	for (int i = 0; i < (9 - len); ++i) {
+	    chords[2][i] = ' ';
+	}
+    }
+    lcd_move(0, 0);
+    lcd_string("          ", 10);
+    lcd_move(1, 0);
+    lcd_string("          ", 10);
+    lcd_move(2, 2);
+    lcd_string("     ", 5);
+    return true;
+}

--- a/keyboards/ergodox_ez/matrix.c
+++ b/keyboards/ergodox_ez/matrix.c
@@ -89,6 +89,10 @@ void matrix_init(void) {
 
   mcp23018_status = init_mcp23018();
 
+#ifdef I2CLCD_PORT
+  lcd_init();
+#endif
+
   unselect_rows();
   init_cols();
 
@@ -174,6 +178,10 @@ uint8_t matrix_scan(void) {
   
   debounce(raw_matrix, matrix, MATRIX_ROWS, true);
   matrix_scan_quantum();
+
+#ifdef I2CLCD_PORT
+  lcd_update(matrix);
+#endif
 
   return 1;
 }

--- a/keyboards/ergodox_ez/rules.mk
+++ b/keyboards/ergodox_ez/rules.mk
@@ -93,28 +93,4 @@ LCDSTENO_ENABLE  = no  # use i2c display for steno
 # For instance, if you solder the A0 jumper, you use 1 here.
 I2CLCD_PORT    = 0
 
-ifeq ($(strip $(I2CLCD_AF_ENABLE)), yes)
-    SRC += i2c_lcd_af.c
-    OPT_DEFS += -DI2CLCD_PORT=$(I2CLCD_PORT) -DI2CLCD_ENABLE
-endif
-
-ifeq ($(strip $(I2CLCD_SB_ENABLE)), yes)
-    SRC += i2c_lcd_sb.c
-    OPT_DEFS += -DI2CLCD_PORT=$(I2CLCD_PORT) -DI2CLCD_ENABLE
-endif
-
-ifeq ($(strip $(I2CLCD_ENABLE)), yes)
-  SRC += i2c_lcd.c
-  OPT_DEFS += -DI2CLCD_PORT=$(I2CLCD_PORT)
-endif
-
-ifeq ($(strip $(LCDSTENO_ENABLE)), yes)
-  SRC += lcd_steno.c
-endif
-
-ifeq ($(strip $(RGB_MATRIX_ENABLE)), no)
-  SRC += i2c_master.c
-endif
-
-
 LAYOUTS = ergodox

--- a/keyboards/ergodox_ez/rules.mk
+++ b/keyboards/ergodox_ez/rules.mk
@@ -84,6 +84,33 @@ API_SYSEX_ENABLE = no
 RGBLIGHT_ENABLE = yes
 RGB_MATRIX_ENABLE = no # enable later
 DEBOUNCE_TYPE = eager_pr
+I2CLCD_AF_ENABLE = no  # i2c access to character LCD (Adafruit backpack)
+I2CLCD_SB_ENABLE = no  # i2c access to character LCD (Seebs implementation)
+STENO_ENABLE     = no
+LCDSTENO_ENABLE  = no  # use i2c display for steno
+# Set to match the address pins on LCD backpack. For the Adafruit
+# backpack, You MUST set at least one address pin or things will work badly.
+# For instance, if you solder the A0 jumper, you use 1 here.
+I2CLCD_PORT    = 0
+
+ifeq ($(strip $(I2CLCD_AF_ENABLE)), yes)
+    SRC += i2c_lcd_af.c
+    OPT_DEFS += -DI2CLCD_PORT=$(I2CLCD_PORT) -DI2CLCD_ENABLE
+endif
+
+ifeq ($(strip $(I2CLCD_SB_ENABLE)), yes)
+    SRC += i2c_lcd_sb.c
+    OPT_DEFS += -DI2CLCD_PORT=$(I2CLCD_PORT) -DI2CLCD_ENABLE
+endif
+
+ifeq ($(strip $(I2CLCD_ENABLE)), yes)
+  SRC += i2c_lcd.c
+  OPT_DEFS += -DI2CLCD_PORT=$(I2CLCD_PORT)
+endif
+
+ifeq ($(strip $(LCDSTENO_ENABLE)), yes)
+  SRC += lcd_steno.c
+endif
 
 ifeq ($(strip $(RGB_MATRIX_ENABLE)), no)
   SRC += i2c_master.c


### PR DESCRIPTION
note there's some overlap with previous pull requests here, I can rebase at some point if needed.

This adds support for a 20x4 LCD display mounted on the ergodox's i2c cable, which can be used to display things... such as steno keyboard state. This isn't a feature I anticipate being widely used, but it's a good proof-of-concept that could be a basis for other development in future.