### PR TITLE
Kona_classic: ANSI arrows keymap with locking caps lock support

### DIFF
--- a/keyboards/kona_classic/keymaps/ansi_arrows_lcap/config.h
+++ b/keyboards/kona_classic/keymaps/ansi_arrows_lcap/config.h
@@ -1,0 +1,24 @@
+/* Copyright 2017 Mathias Andersson <wraul@dbox.se>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef CONFIG_USER_H
+#define CONFIG_USER_H
+
+#include "../../config.h"
+
+// place overrides here
+
+#endif

--- a/keyboards/kona_classic/keymaps/ansi_arrows_lcap/keymap.c
+++ b/keyboards/kona_classic/keymaps/ansi_arrows_lcap/keymap.c
@@ -1,0 +1,98 @@
+/* Copyright 2017 Mathias Andersson <wraul@dbox.se>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "kona_classic.h"
+
+#define MODS_SHFT_MASK  (MOD_BIT(KC_LSHIFT)|MOD_BIT(KC_RSHIFT)|MOD_BIT(KC_LGUI)|MOD_BIT(KC_RGUI))
+#define MODS_GUI_MASK   (MOD_BIT(KC_LGUI)|MOD_BIT(KC_RGUI))
+
+// Helpful defines
+#define ______ KC_TRNS
+#define XXXXXX KC_NO
+
+#define _DEFAULT 0
+#define _FN 1
+
+//RGB_TOG, RGB_MOD, RGB_HUI, RGB_HUD, RGB_SAI, RGB_SAD, RGB_VAI, RGB_VAD
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+	[_DEFAULT] = KEYMAP(
+		KC_F1, KC_F2,  F(0),	KC_1,    KC_2,     KC_3,   KC_4,    KC_5,    KC_6,    KC_7,   KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, \
+		KC_F3, KC_F4,  KC_TAB,	KC_Q,    KC_W,     KC_E,   KC_R,    KC_T,    KC_Y,    KC_U,   KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS, \
+		KC_F5, KC_F6,  KC_LCAP, KC_A,    KC_S,     KC_D,   KC_F,    KC_G,    KC_H,    KC_J,   KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_ENT,  ______, \
+		KC_F7, KC_F8,  KC_LSFT, ______,  KC_Z,     KC_X,   KC_C,    KC_V,    KC_B,    KC_N,   KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_UP,   MO(_FN), \
+		KC_F9, KC_F10, KC_LCTL, KC_LGUI, KC_LALT,  ______,          KC_SPC, ______,                    KC_RALT, KC_RCTL, KC_LEFT, KC_DOWN, KC_RGHT
+	),
+	[_FN] = KEYMAP(
+		RGB_TOG, RGB_MOD, KC_TILD, ______, ______, ______, ______, ______, ______, ______, ______, ______, ______, ______, ______, RESET, \
+		______,  ______,  ______,  ______, ______, ______, ______, ______, ______, ______, ______, ______, ______, ______, ______, ______, \
+		RGB_HUI, RGB_HUD, ______,  ______, ______, ______, ______, ______, ______, ______, ______, ______, ______, ______, ______, ______, \
+		RGB_SAI, RGB_SAD, ______,  ______, ______, ______, ______, ______, ______, ______, ______, ______, ______, ______, ______, ______, \
+		RGB_VAI, RGB_VAD, ______,  ______, ______, ______,         ______, ______,                 ______, ______, ______, ______, ______
+	)
+};
+
+// const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt) {};
+
+
+void matrix_init_user(void) {
+
+}
+
+void matrix_scan_user(void) {
+
+}
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    return true;
+}
+
+void led_set_user(uint8_t usb_led) {
+
+}
+
+enum function_id {
+    ESCAPE,
+};
+
+const uint16_t PROGMEM fn_actions[] = {
+  [0]  = ACTION_FUNCTION(ESCAPE),
+};
+
+void action_function(keyrecord_t *record, uint8_t id, uint8_t opt) {
+  static uint8_t shift_esc_shift_mask;
+  switch (id) {
+    case ESCAPE:
+      shift_esc_shift_mask = get_mods()&MODS_SHFT_MASK;
+      if (record->event.pressed) {
+        if (shift_esc_shift_mask) {
+          add_key(KC_GRV);
+          send_keyboard_report();
+        } else {
+          add_key(KC_ESC);
+          send_keyboard_report();
+        }
+      } else {
+        if (shift_esc_shift_mask) {
+          del_key(KC_GRV);
+          send_keyboard_report();
+        } else {
+          del_key(KC_ESC);
+          send_keyboard_report();
+        }
+      }
+      break;
+  }
+}

--- a/keyboards/kona_classic/keymaps/ansi_arrows_lcap/rules.mk
+++ b/keyboards/kona_classic/keymaps/ansi_arrows_lcap/rules.mk
@@ -1,0 +1,37 @@
+# Copyright 2013 Jun Wako <wakojun@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+# QMK Build Options
+#   change to "no" to disable the options, or define them in the Makefile in
+#   the appropriate keymap folder that will get included automatically
+#
+BOOTMAGIC_ENABLE = yes      # Virtual DIP switch configuration(+1000)
+MOUSEKEY_ENABLE = yes       # Mouse keys(+4700)
+EXTRAKEY_ENABLE = yes       # Audio control and System control(+450)
+CONSOLE_ENABLE = no         # Console for debug(+400)
+COMMAND_ENABLE = yes        # Commands for debug and configuration
+NKRO_ENABLE = yes           # Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
+MIDI_ENABLE = no            # MIDI support (+2400 to 4200, depending on config)
+AUDIO_ENABLE = no           # Audio output on port C6
+UNICODE_ENABLE = no         # Unicode
+BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
+RGBLIGHT_ENABLE = yes       # Enable WS2812 RGB underlight. Do not enable this with audio at the same time.
+SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
+
+ifndef QUANTUM_DIR
+	include ../../../../Makefile
+endif


### PR DESCRIPTION
Since the Kona Classic lacks the support for in-switch LEDs including a Caps Lock indicator, a locking MX switch for Caps Lock makes a lot of sense.