### PR TITLE
Fixes bootloader size and typo

### DIFF
--- a/keyboards/xd75/rules.mk
+++ b/keyboards/xd75/rules.mk
@@ -45,7 +45,7 @@ OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
 #   Atmel DFU loader 4096
 #   LUFA bootloader  4096
 #   USBaspLoader     2048
-OPT_DEFS += -DBOOTLOADER_SIZE=4996
+OPT_DEFS += -DBOOTLOADER_SIZE=4096
 
 # QMK Build Options
 #   change to "no" to disable the options, or define them in the Makefile in 

--- a/tmk_core/common/keyboard.c
+++ b/tmk_core/common/keyboard.c
@@ -165,7 +165,7 @@ void keyboard_init(void) {
 }
 
 /*
- * Do keyboard routine jobs: scan mantrix, light LEDs, ...
+ * Do keyboard routine jobs: scan matrix, light LEDs, ...
  * This is repeatedly called as fast as possible.
  */
 void keyboard_task(void)


### PR DESCRIPTION
The bootloader size was `4996` instead of `4096`, and "mantrix" instead of "matrix".