### PR TITLE
Make brightness easier to change

### DIFF
--- a/keyboards/ergodox_ez/config.h
+++ b/keyboards/ergodox_ez/config.h
@@ -61,8 +61,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* number of backlight levels */
 #define BACKLIGHT_LEVELS 3
 
+#ifndef LED_BRIGHTNESS_LO
 #define LED_BRIGHTNESS_LO       15
+#endif
+#ifndef LED_BRIGHTNESS_HI
 #define LED_BRIGHTNESS_HI       255
+#endif
+#define LED_BRIGHTNESS_DEFAULT (LED_BRIGHTNESS_HI)
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D7

--- a/keyboards/ergodox_ez/ergodox_ez.c
+++ b/keyboards/ergodox_ez/ergodox_ez.c
@@ -54,7 +54,7 @@ void matrix_init_kb(void) {
 void ergodox_blink_all_leds(void)
 {
     ergodox_led_all_off();
-    ergodox_led_all_set(LED_BRIGHTNESS_HI);
+    ergodox_led_all_set(LED_BRIGHTNESS_DEFAULT);
     ergodox_right_led_1_on();
     _delay_ms(50);
     ergodox_right_led_2_on();

--- a/keyboards/ergodox_ez/ergodox_ez.h
+++ b/keyboards/ergodox_ez/ergodox_ez.h
@@ -30,8 +30,12 @@ void ergodox_blink_all_leds(void);
 uint8_t init_mcp23018(void);
 uint8_t ergodox_left_leds_update(void);
 
+#ifndef LED_BRIGHTNESS_LO
 #define LED_BRIGHTNESS_LO       15
+#endif
+#ifndef LED_BRIGHTNESS_LO
 #define LED_BRIGHTNESS_HI       255
+#endif
 
 
 inline void ergodox_board_led_on(void)      { DDRD |=  (1<<6); PORTD |=  (1<<6); }


### PR DESCRIPTION
Don't make the #defines unconditional, make them
optional so users can override them with per-keymap
settings more easily.

(It turns out that 255 is, on my hardware, basically painful.)