### PR TITLE
shell.nix: add teensy loader

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,5 @@
 { pkgs ? import <nixpkgs> {}
-, avr ? true, arm ? true }:
+, avr ? true, arm ? true, teensy ? true }:
 
 with pkgs;
 let
@@ -19,7 +19,8 @@ stdenv.mkDerivation {
 
   buildInputs = [ dfu-programmer dfu-util diffutils git ]
     ++ lib.optional avr [ avrbinutils avrgcc avrlibc ]
-    ++ lib.optional arm [ gcc-arm-embedded ];
+    ++ lib.optional arm [ gcc-arm-embedded ]
+    ++ lib.optional teensy [ teensy-loader-cli ];
 
   CFLAGS = lib.optional avr avr_incflags;
   ASFLAGS = lib.optional avr avr_incflags;


### PR DESCRIPTION
Needed for `make <keyboard>:<keymap>:teensy` to work