### PR TITLE
Add the words "Sticky/Dead keys" to "One Shot" docs sections

### DIFF
--- a/docs/feature_advanced_keycodes.md
+++ b/docs/feature_advanced_keycodes.md
@@ -131,7 +131,7 @@ We've added shortcuts to make common modifier/tap (mod-tap) mappings more compac
 
 # One Shot Keys
 
-One shot keys are keys that remain active until the next key is pressed, and then are releasd. This allows you to type keyboard combinations without pressing more than one key at a time.
+One shot keys are keys that remain active until the next key is pressed, and then are released. This allows you to type keyboard combinations without pressing more than one key at a time. These keys are usually called "Sticky keys" or "Dead keys".
 
 For example, if you define a key as `OSM(MOD_LSFT)`, you can type a capital A character by first pressing and releasing shift, and then pressing and releasing A. Your computer will see the shift key being held the moment shift is pressed, and it will see the shift key being released immediately after A is released.
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -110,7 +110,7 @@ A feature that lets you control your mouse cursor and click from your keyboard.
 A term that applies to keyboards that are capable of reporting any number of key-presses at once.
 
 ## Oneshot Modifier
-A modifier that acts as if it is held down until another key is released, so you can press the mod and then press the key, rather than holding the mod while pressing the key.
+A modifier that acts as if it is held down until another key is released, so you can press the mod and then press the key, rather than holding the mod while pressing the key. Also known as a Sticky key or a Dead key.
 
 ## ProMicro
 A low cost AVR development board. Clones of this device are often found on ebay very inexpensively (under $5) but people often struggle with flashing their pro micros.


### PR DESCRIPTION
I've never heard the term "Oneshot" modifier key before. I've only heard of the terms "Sticky key" or "Dead key". So when I was searching through the QMK docs, I couldn't find this feature. I think updating the docs as proposed will assist for other people searching as well.

Ref: Issue #212