### PR TITLE
Fixed minor typo in my MAKE macro code

### DIFF
--- a/docs/feature_userspace.md
+++ b/docs/feature_userspace.md
@@ -76,7 +76,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
       SEND_STRING("make " QMK_KEYBOARD ":" QMK_KEYMAP
 #if  (defined(BOOTLOADER_DFU) || defined(BOOTLOADER_LUFA_DFU) || defined(BOOTLOADER_QMK_DFU))
        ":dfu "
-#elif defined(BOOTLOADER_HALFKEY)
+#elif defined(BOOTLOADER_HALFKAY)
       ":teensy "
 #elif defined(BOOTLOADER_CATERINA)
        ":avrdude "
@@ -92,5 +92,5 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 
 This will add a new `KC_MAKE`  keycode that can be used in any of your keymaps.  And this keycode will output `make <keyboard>:<keymap">`, making frequent compiling easier.  And this will work with any keyboard and any keymap as it will output the current boards info, so that you don't have to type this out every time. 
 
-Additionally, this should flash the newly compiled firmware automatically, using the correct utility, based on the bootloader settings (or default to just generating the HEX file). However, it should be noted that this may not work on all systems (AVRDUDE doesn't work on WSL, namely).
+Additionally, this should flash the newly compiled firmware automatically, using the correct utility, based on the bootloader settings (or default to just generating the HEX file). However, it should be noted that this may not work on all systems. AVRDUDE doesn't work on WSL, namely (and will dump the HEX in the ".build" folder instead).
 

--- a/users/drashna/template.c
+++ b/users/drashna/template.c
@@ -45,7 +45,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
       SEND_STRING("make " QMK_KEYBOARD ":" QMK_KEYMAP
 #if  (defined(BOOTLOADER_DFU) || defined(BOOTLOADER_LUFA_DFU) || defined(BOOTLOADER_QMK_DFU))
         ":dfu"
-#elif defined(BOOTLOADER_HALFKEY)
+#elif defined(BOOTLOADER_HALFKAY)
         ":teensy"
 #elif defined(BOOTLOADER_CATERINA)
         ":avrdude"


### PR DESCRIPTION
In the "MAKE" macros, it should be `BOOTLOADER_HALFKAY`, not `BOOTLOADER_HALFKEY`.  Which breaks teensy flashing. 