### PR TITLE
Remove unnecessary audio code from orthodox

### DIFF
--- a/keyboards/orthodox/rev1/rev1.c
+++ b/keyboards/orthodox/rev1/rev1.c
@@ -21,33 +21,39 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "orthodox.h"
 
-#ifdef AUDIO_ENABLE
-    float tone_startup[][2] = SONG(STARTUP_SOUND);
-    float tone_goodbye[][2] = SONG(GOODBYE_SOUND);
-#endif
+// This code isn't necessary and breaks the normal audio features
+// Namely, the startup and shutdown sounds are not configurable
+// without editing this file. And it serves no purpose other than
+// to over ride the audio chimes.
 
-void matrix_init_kb(void) {
 
-    #ifdef AUDIO_ENABLE
-        _delay_ms(20); // gets rid of tick
-        PLAY_SONG(tone_startup);
-    #endif
-
-    // // green led on
-    // DDRD |= (1<<5);
-    // PORTD &= ~(1<<5);
-
-    // // orange led on
-    // DDRB |= (1<<0);
-    // PORTB &= ~(1<<0);
-
-	matrix_init_user();
-};
-
-void shutdown_user(void) {
-    #ifdef AUDIO_ENABLE
-        PLAY_SONG(tone_goodbye);
-	_delay_ms(150);
-	stop_all_notes();
-    #endif
-}
+//#ifdef AUDIO_ENABLE
+//    float tone_startup[][2] = SONG(STARTUP_SOUND);
+//    float tone_goodbye[][2] = SONG(GOODBYE_SOUND);
+//#endif
+//
+//void matrix_init_kb(void) {
+//
+//    #ifdef AUDIO_ENABLE
+//        _delay_ms(20); // gets rid of tick
+//        PLAY_SONG(tone_startup);
+//    #endif
+//
+//    // // green led on
+//    // DDRD |= (1<<5);
+//    // PORTD &= ~(1<<5);
+//
+//    // // orange led on
+//    // DDRB |= (1<<0);
+//    // PORTB &= ~(1<<0);
+//
+//	matrix_init_user();
+//};
+//
+//void shutdown_user(void) {
+//    #ifdef AUDIO_ENABLE
+//        PLAY_SONG(tone_goodbye);
+//	_delay_ms(150);
+//	stop_all_notes();
+//    #endif
+//}

--- a/keyboards/orthodox/rev1/rev1.c
+++ b/keyboards/orthodox/rev1/rev1.c
@@ -21,18 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "orthodox.h"
 
-
-//#ifdef AUDIO_ENABLE
-//    float tone_startup[][2] = SONG(STARTUP_SOUND);
-//    float tone_goodbye[][2] = SONG(GOODBYE_SOUND);
-//#endif
-
 void matrix_init_kb(void) {
-
-  //#ifdef AUDIO_ENABLE
-  //    _delay_ms(20); // gets rid of tick
-  //    PLAY_SONG(tone_startup);
-  //#endif
 
   //// // green led on
   //// DDRD |= (1<<5);
@@ -44,11 +33,3 @@ void matrix_init_kb(void) {
 
   matrix_init_user();
 };
-
-void shutdown_user(void) {
-  //   /*#ifdef AUDIO_ENABLE
-  //       PLAY_SONG(tone_goodbye);
-  //_delay_ms(150);
-  //stop_all_notes();
-  //   #endif*/
-}

--- a/keyboards/orthodox/rev1/rev1.c
+++ b/keyboards/orthodox/rev1/rev1.c
@@ -21,39 +21,34 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "orthodox.h"
 
-// This code isn't necessary and breaks the normal audio features
-// Namely, the startup and shutdown sounds are not configurable
-// without editing this file. And it serves no purpose other than
-// to over ride the audio chimes.
-
 
 //#ifdef AUDIO_ENABLE
 //    float tone_startup[][2] = SONG(STARTUP_SOUND);
 //    float tone_goodbye[][2] = SONG(GOODBYE_SOUND);
 //#endif
-//
-//void matrix_init_kb(void) {
-//
-//    #ifdef AUDIO_ENABLE
-//        _delay_ms(20); // gets rid of tick
-//        PLAY_SONG(tone_startup);
-//    #endif
-//
-//    // // green led on
-//    // DDRD |= (1<<5);
-//    // PORTD &= ~(1<<5);
-//
-//    // // orange led on
-//    // DDRB |= (1<<0);
-//    // PORTB &= ~(1<<0);
-//
-//	matrix_init_user();
-//};
-//
-//void shutdown_user(void) {
-//    #ifdef AUDIO_ENABLE
-//        PLAY_SONG(tone_goodbye);
-//	_delay_ms(150);
-//	stop_all_notes();
-//    #endif
-//}
+
+void matrix_init_kb(void) {
+
+  //#ifdef AUDIO_ENABLE
+  //    _delay_ms(20); // gets rid of tick
+  //    PLAY_SONG(tone_startup);
+  //#endif
+
+  //// // green led on
+  //// DDRD |= (1<<5);
+  //// PORTD &= ~(1<<5);
+
+  //// // orange led on
+  //// DDRB |= (1<<0);
+  //// PORTB &= ~(1<<0);
+
+  matrix_init_user();
+};
+
+void shutdown_user(void) {
+  //   /*#ifdef AUDIO_ENABLE
+  //       PLAY_SONG(tone_goodbye);
+  //_delay_ms(150);
+  //stop_all_notes();
+  //   #endif*/
+}


### PR DESCRIPTION
 This code isn't necessary and breaks the normal audio chimes.
Namely, the startup and shutdown sounds are not configurable because of this, and cannot be changed without editing this file. And it serves no purpose other than to override the audio chimes.

This should probably be done to the other split keyboards as well, but since I can't test them... I'd rather not change them blindly. 

I'm not the maintainer for this keyboard, either.