### PR TITLE
Fix internal links in docs/

### DIFF
--- a/docs/_summary.md
+++ b/docs/_summary.md
@@ -1,7 +1,7 @@
 * [Getting started](README.md)
   * [QMK Introduction](getting_started_introduction.md)
   * [Install Build Tools](getting_started_build_tools.md)
-    * Alternative: [Vagrant Guide](getting_started_vagrant_guide.md)
+    * Alternative: [Vagrant Guide](getting_started_vagrant.md)
   * [Build/Compile instructions](getting_started_make_guide.md)
   * [Flashing instructions](flashing.md)
   * [Contributing to QMK](contributing.md)
@@ -70,7 +70,6 @@
 * For Makers and Modders
   * [Hand Wiring Guide](hand_wire.md)
   * [ISP flashing guide](isp_flashing_guide.md)
-  * [Modding your keyboard](modding_your_keyboard.md)
 
 * For a Deeper Understanding
   * [How Keyboards Work](how_keyboards_work.md)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -122,7 +122,7 @@ We also ask that you follow these guidelines:
 
 ## Quantum/TMK Core
 
-Before you put a lot of work into building your new feature you should make sure you are implementing it in the best way. You can get a basic understanding of QMK by reading [Understaning QMK](understanding_qmk.html), which will take you on a tour of the QMK program flow. From here you should talk to us to get a sense of the best way to implement your idea. There are two main ways to do this:
+Before you put a lot of work into building your new feature you should make sure you are implementing it in the best way. You can get a basic understanding of QMK by reading [Understaning QMK](understanding_qmk.md), which will take you on a tour of the QMK program flow. From here you should talk to us to get a sense of the best way to implement your idea. There are two main ways to do this:
 
 * [Chat on Gitter](https://gitter.im/qmk/qmk_firmware)
 * [Open an Issue](https://github.com/qmk/qmk_firmware/issues/new)

--- a/docs/custom_quantum_functions.md
+++ b/docs/custom_quantum_functions.md
@@ -2,7 +2,7 @@
 
 For a lot of people a custom keyboard is about more than sending button presses to your computer. You want to be able to do things that are more complex than simple button presses and macros. QMK has hooks that allow you to inject code, override functionality, and otherwise customize how your keyboard behaves in different situations. 
 
-This page does not assume any special knowledge about QMK, but reading [Understanding QMK](understanding_qmk.html) will help you understand what is going on at a more fundamental level.
+This page does not assume any special knowledge about QMK, but reading [Understanding QMK](understanding_qmk.md) will help you understand what is going on at a more fundamental level.
 
 ## A Word on Core vs Keyboards vs Keymap
 

--- a/docs/faq_build.md
+++ b/docs/faq_build.md
@@ -1,6 +1,6 @@
 # Frequently Asked Build Questions
 
-This page covers questions about building QMK. If you have not yet you should read the [Build Environment Setup](getting_started_build_tools.md) and [Make Instructions](make_instructions.md) guides.
+This page covers questions about building QMK. If you have not yet you should read the [Build Environment Setup](getting_started_build_tools.md) and [Make Instructions](getting_started_make_guide.md) guides.
 
 ## Can't program on Linux
 You will need proper permission to operate a device. For Linux users see udev rules below. Easy way is to use `sudo` command, if you are not familiar with this command check its manual with `man sudo` or this page on line.

--- a/docs/feature_advanced_keycodes.md
+++ b/docs/feature_advanced_keycodes.md
@@ -15,7 +15,7 @@ This will allow you to use `FN_CAPS` and `ALT_TAB` in your `KEYMAP()`, keeping i
 
 ### Limits of these aliases
 
-Currently, the keycodes able to used with these functions are limited to the [Basic Keycodes](keycodes_basic.html), meaning you can't use keycodes like `KC_TILD`, or anything greater than 0xFF. For a full list of the keycodes able to be used see [Basic Keycodes](keycodes_basic.html).
+Currently, the keycodes able to used with these functions are limited to the [Basic Keycodes](keycodes_basic.md), meaning you can't use keycodes like `KC_TILD`, or anything greater than 0xFF. For a full list of the keycodes able to be used see [Basic Keycodes](keycodes_basic.md).
 
 # Switching and toggling layers
 

--- a/docs/feature_key_lock.md
+++ b/docs/feature_key_lock.md
@@ -8,4 +8,4 @@ Here's how to use it:
 2. Enable key lock by including `KEY_LOCK_ENABLE = yes` in your Makefile.
 3. That's it!
 
-Important: switching layers does not cancel the key lock. Additionally, key lock is only able to hold standard action keys and One Shot modifier keys (for example, if you have your shift defined as `OSM(KC_LSFT)`; see [One Shot Keys](quantum_keycodes.md#one-shot-keys)). This does not include any of the QMK special functions (except One Shot modifiers), or shifted versions of keys such as KC_LPRN. If it's in the [basic_keycodes](basic_keycodes.md) list, it can be held. If it's not, then it can't be.
+Important: switching layers does not cancel the key lock. Additionally, key lock is only able to hold standard action keys and One Shot modifier keys (for example, if you have your shift defined as `OSM(KC_LSFT)`; see [One Shot Keys](quantum_keycodes.md#one-shot-keys)). This does not include any of the QMK special functions (except One Shot modifiers), or shifted versions of keys such as KC_LPRN. If it's in the [Basic Keycodes](keycodes_basic.md) list, it can be held. If it's not, then it can't be.

--- a/docs/features.md
+++ b/docs/features.md
@@ -17,7 +17,7 @@ QMK has a staggering number of features for building your keyboard. It can take 
 * [Pointing Device](feature_pointing_device.md) - Framework for connecting your custom pointing device to your keyboard.
 * [PS2 Mouse](feature_ps2_mouse.md) - Driver for connecting a ps2 mouse directly to your keyboard.
 * [RGB Light](feature_rgblight.md) - RGB lighting for your keyboard.
-* [Space Cadet](feature_space_cadet_shift.md) - Use your left/right shift keys to type parenthesis and brackets.
+* [Space Cadet](feature_space_cadet.md) - Use your left/right shift keys to type parenthesis and brackets.
 * [Stenography](feature_stenography.md) - Put your keyboard into Plover mode for stenography use.
 * [Tap Dance](feature_tap_dance.md) - Make a single key do as many things as you want.
 * [Terminal](feature_terminal.md) - CLI interface to the internals of your keyboard.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -41,7 +41,7 @@ A macro which has been recorded on the keyboard and which will be lost when the 
 ## Eclipse
 An IDE that is popular with many C developers.
 
-* [Eclipse Setup Instructions](eclipse.html)
+* [Eclipse Setup Instructions](eclipse.md)
 
 ## Firmware
 The software that controls your MCU.
@@ -62,7 +62,7 @@ In-system programming, a method of programming an AVR chip using external hardwa
 An interface for receiving debugging messages from your keyboard. You can view these messages using [QMK Flasher](https://github.com/qmk/qmk_flasher) or [PJRC's hid_listen](https://www.pjrc.com/teensy/hid_listen.html)
 
 ## Keycode
-A 2-byte number that represents a particular key. `0x00`-`0xFF` are used for [Basic Keycodes](keycodes_basic.html) while `0x100`-`0xFFFF` are used for [Quantum Keycodes](quantum_keycodes.html).
+A 2-byte number that represents a particular key. `0x00`-`0xFF` are used for [Basic Keycodes](keycodes_basic.md) while `0x100`-`0xFFFF` are used for [Quantum Keycodes](quantum_keycodes.md).
 
 ## Key Down
 An event that happens when a key is pressed down, but is completed before a key is released.
@@ -79,7 +79,7 @@ An abstraction used to allow a key to serve multiple purposes. The highest activ
 ## Leader Key
 A feature that allows you to tap the leader key followed by a sequence of 1, 2, or 3 keys to activate key presses or other quantum features.
 
-* [Leader Key Documentation](feature_leader_key.html)
+* [Leader Key Documentation](feature_leader_key.md)
 
 ## LED
 Light Emitting Diode, the most common device used for indicators on a keyboard.
@@ -104,7 +104,7 @@ A key that is held down while typing another key to modify the action of that ke
 ## Mousekeys
 A feature that lets you control your mouse cursor and click from your keyboard.
 
-* [Mousekeys Documentation](feature_mouse_keys.html)
+* [Mousekeys Documentation](feature_mouse_keys.md)
 
 ## N-Key Rollover (NKRO)
 A term that applies to keyboards that are capable of reporting any number of key-presses at once.
@@ -133,7 +133,7 @@ A 1 byte number that is sent as part of a HID report over USB that represents a 
 ## Space Cadet Shift
 A special set of shift keys which allow you to type various types of braces by tapping the left or right shift one or more times.
 
-* [Space Cadet Shift Documentation](feature_space_cadet.html)
+* [Space Cadet Shift Documentation](feature_space_cadet.md)
 
 ## Tap
 Pressing and releasing a key. In some situations you will need to distinguish between a key down and a key up event, and Tap always refers to both at once.

--- a/docs/understanding_qmk.md
+++ b/docs/understanding_qmk.md
@@ -2,7 +2,7 @@
 
 This document attempts to explain how the QMK firmware works from a very high level. It assumes you understand basic programming concepts but does not (except where needed to demonstrate) assume familiarity with C. It assumes that you have a basic understanding of the following documents:
 
-* [QMK Overview](qmk_overview.md)
+* [Introduction](getting_started_introduction.md)
 * [How Keyboards Work](how_keyboards_work.md)
 * [FAQ](faq.md)
 


### PR DESCRIPTION
One link in the summary (Modding your keyboard) referred to a page that
was deleted; the rest have been updated to point to the new names.