### PR TITLE
Change awk detector to work with mawk; fixes #2073

### DIFF
--- a/message.mk
+++ b/message.mk
@@ -9,7 +9,7 @@ ifeq ($(COLOR),true)
 	BOLD=\033[1m
 endif
 
-ifneq ($(shell awk --version 2>/dev/null),)
+ifneq ($(shell echo "1 2 3" | awk '{ printf "%2s", $$3; }' 2>/dev/null)," 3")
 	AWK=awk
 else
 	AWK=cat && test


### PR DESCRIPTION
The awk detector in message.mk doesn't work with [mawk](http://invisible-island.net/mawk/mawk.html), which is the Debian default and doesn't support --version. This change just tests for generic awk functionality and so should improve portability. Failing to detect awk means check-size cannot build correctly.