### PR TITLE
Fix broken link in docs

### DIFF
--- a/docs/keymap.md
+++ b/docs/keymap.md
@@ -77,7 +77,7 @@ Key with `KC_TRANS` (`KC_TRNS` and `_______` are the alias) doesn't has its own 
 
 ## Anatomy Of A `keymap.c`
 
-For this example we will walk through the [default Clueboard 66% keymap](https://github.com/qmk/qmk_firmware/blob/master/keyboards/clueboard_66/keymaps/default/keymap.c). You'll find it helpful to open that file in another browser window so you can look at everything in context.
+For this example we will walk through an [older version of the default Clueboard 66% keymap](https://github.com/qmk/qmk_firmware/blob/ca01d94005f67ec4fa9528353481faa622d949ae/keyboards/clueboard/keymaps/default/keymap.c). You'll find it helpful to open that file in another browser window so you can look at everything in context.
 
 There are 3 main sections of a `keymap.c` file you'll want to concern yourself with:
 


### PR DESCRIPTION
This link was broken. And the latest, live version of that keymap link doesn't line up with the docs below, so the link will now point to the older version of the file in the git history

See issue #1845 