### PR TITLE
Adds led control functions to XD75 layout

### DIFF
--- a/keyboards/xd75/readme.md
+++ b/keyboards/xd75/readme.md
@@ -26,6 +26,46 @@ firmware likely requires a command line like:
 $ sudo make xd75:default:dfu
 ```
 
+### LED control
+
+There are 3 individual LEDs that can be turned on and off, plus the keycap LEDs (which are all wired into the same pin).  The functions are named according to how they're labeled on the PCB.
+
+TODO: it would be nice to have PWM support on these LEDs for fade-in/fade-out effects.
+
+```c
+capslock_led_on();
+gp100_led_on();
+gp103_led_on();
+keycaps_led_on();
+
+
+// led_set_user example - you could also turn these on/off in response
+// to events in process_record_user or matrix_scan_user
+void led_set_user(uint8_t usb_led) {
+    if (usb_led & (1<<USB_LED_CAPS_LOCK)) {
+        capslock_led_on();
+    } else {
+        capslock_led_off();
+    }
+
+    if (some_custom_state) {
+      gp100_led_on();
+    }
+    else {
+      gp100_led_off();
+    }
+}
+```
+
+For the curious:
+
+```
+CAPSLOCK_LED    B2
+GP103_LED       F4
+KEYCAPS_LED     F5
+GP100_LED       F7
+```
+
 ### Other Keymaps
 
 The "default" keymap included is basically the OLKB Atomic keymap with

--- a/keyboards/xd75/xd75.c
+++ b/keyboards/xd75/xd75.c
@@ -15,9 +15,19 @@
  */
 #include "xd75.h"
 
+#define XD75_CAPSLOCK_LED 2  // B2
+#define XD75_GP103_LED 4  // F4
+#define XD75_KEYCAPS_LED 5  // F5
+#define XD75_GP100_LED 7  // F7
+
 void matrix_init_kb(void) {
 	// put your keyboard start-up code here
 	// runs once when the firmware starts up
+
+	capslock_led_init();
+	gp100_led_init();
+	gp103_led_init();
+	keycaps_led_init();
 
 	matrix_init_user();
 }
@@ -40,4 +50,56 @@ void led_set_kb(uint8_t usb_led) {
 	// put your keyboard LED indicator (ex: Caps Lock LED) toggling code here
 
 	led_set_user(usb_led);
+}
+
+void capslock_led_init(void) {
+	DDRB |= (1 << XD75_CAPSLOCK_LED);
+	capslock_led_off();
+}
+
+void capslock_led_off(void) {
+	PORTB |= (1 << XD75_CAPSLOCK_LED);
+}
+
+void capslock_led_on(void) {
+	PORTB &= ~(1 << XD75_CAPSLOCK_LED);
+}
+
+void gp100_led_init(void) {
+	DDRF |= (1 << XD75_GP100_LED);
+	gp100_led_off();
+}
+
+void gp100_led_off(void) {
+	PORTF |= (1 << XD75_GP100_LED);
+}
+
+void gp100_led_on(void) {
+	PORTF &= ~(1 << XD75_GP100_LED);
+}
+
+void gp103_led_init(void) {
+	DDRF |= (1 << XD75_GP103_LED);
+	gp103_led_off();
+}
+
+void gp103_led_off(void) {
+	PORTF &= ~(1 << XD75_GP103_LED);
+}
+
+void gp103_led_on(void) {
+	PORTF |= (1 << XD75_GP103_LED);
+}
+
+void keycaps_led_init(void) {
+	DDRF |= (1 << XD75_KEYCAPS_LED);
+	keycaps_led_off();
+}
+
+void keycaps_led_off(void) {
+	PORTF |= (1 << XD75_KEYCAPS_LED);
+}
+
+void keycaps_led_on(void) {
+	PORTF &= ~(1 << XD75_KEYCAPS_LED);
 }

--- a/keyboards/xd75/xd75.h
+++ b/keyboards/xd75/xd75.h
@@ -52,4 +52,20 @@
 
 #define LAYOUT_ortho_5x15 KEYMAP
 
+void capslock_led_init(void);
+void capslock_led_off(void);
+void capslock_led_on(void);
+
+void gp100_led_init(void);
+void gp100_led_off(void);
+void gp100_led_on(void);
+
+void gp103_led_init(void);
+void gp103_led_off(void);
+void gp103_led_on(void);
+
+void keycaps_led_init(void);
+void keycaps_led_off(void);
+void keycaps_led_on(void);
+
 #endif


### PR DESCRIPTION
Functions to control the CAPS and "GP100" (why is it called that? General Purpose?) LEDs.

The `led_init` functions are called as part of `matrix_init_kb` to set the data-direction bits, added example usage to the README.
