### PR TITLE
Fix Audio chime overrides in split keyboards

### DIFF
--- a/keyboards/iris/rev1/rev1.c
+++ b/keyboards/iris/rev1/rev1.c
@@ -1,9 +1,5 @@
 #include "rev1.h"
 
-#ifdef AUDIO_ENABLE
-    float tone_startup[][2] = SONG(STARTUP_SOUND);
-    float tone_goodbye[][2] = SONG(GOODBYE_SOUND);
-#endif
 
 #ifdef SSD1306OLED
 void led_set_kb(uint8_t usb_led) {
@@ -13,11 +9,6 @@ void led_set_kb(uint8_t usb_led) {
 #endif
 
 void matrix_init_kb(void) {
-
-    #ifdef AUDIO_ENABLE
-        _delay_ms(20); // gets rid of tick
-        PLAY_SONG(tone_startup);
-    #endif
 
     // // green led on
     // DDRD |= (1<<5);
@@ -29,11 +20,3 @@ void matrix_init_kb(void) {
 
 	matrix_init_user();
 };
-
-void shutdown_user(void) {
-    #ifdef AUDIO_ENABLE
-        PLAY_SONG(tone_goodbye);
-	_delay_ms(150);
-	stop_all_notes();
-    #endif
-}

--- a/keyboards/iris/rev2/rev2.c
+++ b/keyboards/iris/rev2/rev2.c
@@ -1,10 +1,5 @@
 #include "rev2.h"
 
-#ifdef AUDIO_ENABLE
-    float tone_startup[][2] = SONG(STARTUP_SOUND);
-    float tone_goodbye[][2] = SONG(GOODBYE_SOUND);
-#endif
-
 #ifdef SSD1306OLED
 void led_set_kb(uint8_t usb_led) {
     // put your keyboard LED indicator (ex: Caps Lock LED) toggling code here
@@ -13,11 +8,6 @@ void led_set_kb(uint8_t usb_led) {
 #endif
 
 void matrix_init_kb(void) {
-
-    #ifdef AUDIO_ENABLE
-        _delay_ms(20); // gets rid of tick
-        PLAY_SONG(tone_startup);
-    #endif
 
     // // green led on
     // DDRD |= (1<<5);
@@ -30,10 +20,3 @@ void matrix_init_kb(void) {
 	matrix_init_user();
 };
 
-void shutdown_user(void) {
-    #ifdef AUDIO_ENABLE
-        PLAY_SONG(tone_goodbye);
-	_delay_ms(150);
-	stop_all_notes();
-    #endif
-}

--- a/keyboards/lets_split/rev1/rev1.c
+++ b/keyboards/lets_split/rev1/rev1.c
@@ -1,16 +1,6 @@
 #include "lets_split.h"
 
-#ifdef AUDIO_ENABLE
-    float tone_startup[][2] = SONG(STARTUP_SOUND);
-    float tone_goodbye[][2] = SONG(GOODBYE_SOUND);
-#endif
-
 void matrix_init_kb(void) {
-
-    #ifdef AUDIO_ENABLE
-        _delay_ms(20); // gets rid of tick
-        PLAY_SONG(tone_startup);
-    #endif
 
     // // green led on
     // DDRD |= (1<<5);
@@ -23,10 +13,3 @@ void matrix_init_kb(void) {
 	matrix_init_user();
 };
 
-void shutdown_user(void) {
-    #ifdef AUDIO_ENABLE
-        PLAY_SONG(tone_goodbye);
-	_delay_ms(150);
-	stop_all_notes();
-    #endif
-}

--- a/keyboards/lets_split/rev2/rev2.c
+++ b/keyboards/lets_split/rev2/rev2.c
@@ -1,9 +1,5 @@
 #include "lets_split.h"
 
-#ifdef AUDIO_ENABLE
-    float tone_startup[][2] = SONG(STARTUP_SOUND);
-    float tone_goodbye[][2] = SONG(GOODBYE_SOUND);
-#endif
 
 #ifdef SSD1306OLED
 void led_set_kb(uint8_t usb_led) {
@@ -13,11 +9,6 @@ void led_set_kb(uint8_t usb_led) {
 #endif
 
 void matrix_init_kb(void) {
-
-    #ifdef AUDIO_ENABLE
-        _delay_ms(20); // gets rid of tick
-        PLAY_SONG(tone_startup);
-    #endif
 
     // // green led on
     // DDRD |= (1<<5);
@@ -30,10 +21,3 @@ void matrix_init_kb(void) {
 	matrix_init_user();
 };
 
-void shutdown_user(void) {
-    #ifdef AUDIO_ENABLE
-        PLAY_SONG(tone_goodbye);
-	_delay_ms(150);
-	stop_all_notes();
-    #endif
-}

--- a/keyboards/lets_split/sockets/sockets.c
+++ b/keyboards/lets_split/sockets/sockets.c
@@ -1,9 +1,5 @@
 #include "lets_split.h"
 
-#ifdef AUDIO_ENABLE
-    float tone_startup[][2] = SONG(STARTUP_SOUND);
-    float tone_goodbye[][2] = SONG(GOODBYE_SOUND);
-#endif
 
 #ifdef SSD1306OLED
 void led_set_kb(uint8_t usb_led) {
@@ -13,11 +9,6 @@ void led_set_kb(uint8_t usb_led) {
 #endif
 
 void matrix_init_kb(void) {
-
-    #ifdef AUDIO_ENABLE
-        _delay_ms(20); // gets rid of tick
-        PLAY_SONG(tone_startup);
-    #endif
 
     // // green led on
     // DDRD |= (1<<5);
@@ -29,11 +20,3 @@ void matrix_init_kb(void) {
 
 	matrix_init_user();
 };
-
-void shutdown_user(void) {
-    #ifdef AUDIO_ENABLE
-        PLAY_SONG(tone_goodbye);
-	_delay_ms(150);
-	stop_all_notes();
-    #endif
-}

--- a/keyboards/levinson/rev1/rev1.c
+++ b/keyboards/levinson/rev1/rev1.c
@@ -1,9 +1,5 @@
 #include "levinson.h"
 
-#ifdef AUDIO_ENABLE
-    float tone_startup[][2] = SONG(STARTUP_SOUND);
-    float tone_goodbye[][2] = SONG(GOODBYE_SOUND);
-#endif
 
 #ifdef SSD1306OLED
 void led_set_kb(uint8_t usb_led) {
@@ -13,11 +9,6 @@ void led_set_kb(uint8_t usb_led) {
 #endif
 
 void matrix_init_kb(void) {
-
-    #ifdef AUDIO_ENABLE
-        _delay_ms(20); // gets rid of tick
-        PLAY_SONG(tone_startup);
-    #endif
 
     // // green led on
     // DDRD |= (1<<5);
@@ -30,10 +21,3 @@ void matrix_init_kb(void) {
 	matrix_init_user();
 };
 
-void shutdown_user(void) {
-    #ifdef AUDIO_ENABLE
-        PLAY_SONG(tone_goodbye);
-	_delay_ms(150);
-	stop_all_notes();
-    #endif
-}

--- a/keyboards/levinson/rev2/rev2.c
+++ b/keyboards/levinson/rev2/rev2.c
@@ -1,10 +1,5 @@
 #include "levinson.h"
 
-#ifdef AUDIO_ENABLE
-    float tone_startup[][2] = SONG(STARTUP_SOUND);
-    float tone_goodbye[][2] = SONG(GOODBYE_SOUND);
-#endif
-
 #ifdef SSD1306OLED
 void led_set_kb(uint8_t usb_led) {
     // put your keyboard LED indicator (ex: Caps Lock LED) toggling code here
@@ -13,11 +8,6 @@ void led_set_kb(uint8_t usb_led) {
 #endif
 
 void matrix_init_kb(void) {
-
-    #ifdef AUDIO_ENABLE
-        _delay_ms(20); // gets rid of tick
-        PLAY_SONG(tone_startup);
-    #endif
 
     // // green led on
     // DDRD |= (1<<5);
@@ -30,10 +20,3 @@ void matrix_init_kb(void) {
 	matrix_init_user();
 };
 
-void shutdown_user(void) {
-    #ifdef AUDIO_ENABLE
-        PLAY_SONG(tone_goodbye);
-	_delay_ms(150);
-	stop_all_notes();
-    #endif
-}

--- a/keyboards/viterbi/rev1/rev1.c
+++ b/keyboards/viterbi/rev1/rev1.c
@@ -1,9 +1,5 @@
 #include "viterbi.h"
 
-#ifdef AUDIO_ENABLE
-    float tone_startup[][2] = SONG(STARTUP_SOUND);
-    float tone_goodbye[][2] = SONG(GOODBYE_SOUND);
-#endif
 
 #ifdef SSD1306OLED
 void led_set_kb(uint8_t usb_led) {
@@ -13,11 +9,6 @@ void led_set_kb(uint8_t usb_led) {
 #endif
 
 void matrix_init_kb(void) {
-
-    #ifdef AUDIO_ENABLE
-        _delay_ms(20); // gets rid of tick
-        PLAY_NOTE_ARRAY(tone_startup, false, 0);
-    #endif
 
     // // green led on
     // DDRD |= (1<<5);
@@ -29,11 +20,3 @@ void matrix_init_kb(void) {
 
 	matrix_init_user();
 };
-
-void shutdown_user(void) {
-    #ifdef AUDIO_ENABLE
-        PLAY_NOTE_ARRAY(tone_goodbye, false, 0);
-	_delay_ms(150);
-	stop_all_notes();
-    #endif
-}


### PR DESCRIPTION
 This code isn't necessary and breaks the normal audio chimes.
Namely, the startup and shutdown sounds are not configurable because of this, and cannot be changed without editing the revision file. And it serves no purpose other than to override the audio chimes.

I've test this out "quickly" on a spare controller, and looks like this works fine.  However, I don't own these boards, so I can't properly test.

Additionally, I'm not the designer/maintainer of these boards either. 
