### PR TITLE
Updates to drashna keymaps and userspace

### DIFF
--- a/keyboards/ergodox_ez/keymaps/drashna/keymap.c
+++ b/keyboards/ergodox_ez/keymaps/drashna/keymap.c
@@ -244,9 +244,9 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
                 KC_MAKE,        KC_HASH,    KC_DLR,     KC_LPRN,    KC_RPRN,    KC_GRAVE,
                 KC_RESET,       KC_PERC,    KC_CIRC,    KC_LBRACKET,KC_RBRACKET,KC_TILD,    KC_COLEMAK,
                 KC_TRNS,          KC_AMPR,    KC_ASTR,    KC_COLN,    KC_SCOLON,
-                                                                  KC_TRNS, KC_TRNS,
-                                                                  KC_TRNS,
-                                                                  KC_TRNS, KC_TRNS, KC_TRNS,
+                                                                  RGB_SMOD, KC_RGB_T,
+                                                                  RGB_HUI,
+                                                                  RGB_M_R, RGB_M_SW, RGB_HUD,
                 
                 KC_QWERTY,   KC_F6,      KC_F7,      KC_F8,      KC_F9,      KC_F10,         KC_F11,
                 KC_DVORAK,   KC_KP_PLUS, KC_KP_7,    KC_KP_8,    KC_KP_9,    KC_KP_ASTERISK, KC_F12,

--- a/keyboards/handwired/woodpad/keymaps/drashna/keymap.c
+++ b/keyboards/handwired/woodpad/keymaps/drashna/keymap.c
@@ -97,12 +97,6 @@ void matrix_init_keymap(void) {
   // set Numlock LED to output and low
   DDRF |= (1 << 7);
   PORTF &= ~(1 << 7);
-
-
-  if (!(host_keyboard_leds() & (1 << USB_LED_NUM_LOCK))) {
-    register_code(KC_NUMLOCK);
-    unregister_code(KC_NUMLOCK);
-  }
 }
 
 void matrix_scan_keymap(void) {
@@ -114,3 +108,9 @@ void matrix_scan_keymap(void) {
   // Run Diablo 3 macro checking code.
 }
 
+void led_set_keymap(uint8_t usb_led) {
+  if (!(usb_led & (1<<USB_LED_NUM_LOCK))) {
+    register_code(KC_NUMLOCK);
+    unregister_code(KC_NUMLOCK);
+  }
+}

--- a/keyboards/handwired/woodpad/keymaps/drashna/keymap.c
+++ b/keyboards/handwired/woodpad/keymaps/drashna/keymap.c
@@ -13,7 +13,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include "woodpad.h"
+#include QMK_KEYBOARD_H
 #include "drashna.h"
 
  // Each layer gets a name for readability, which is then used in the keymap matrix below.

--- a/keyboards/orthodox/keymaps/drashna/config.h
+++ b/keyboards/orthodox/keymaps/drashna/config.h
@@ -63,6 +63,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #ifdef AUDIO_ENABLE
 #define C6_AUDIO
+#define STARTUP_SONG SONG(ZELDA_PUZZLE)
 #endif
 
 #endif

--- a/keyboards/orthodox/keymaps/drashna/keymap.c
+++ b/keyboards/orthodox/keymaps/drashna/keymap.c
@@ -32,6 +32,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define _______ KC_TRNS
 #define XXXXXXX KC_NO
 
+#ifdef FAUXCLICKY_ENABLE
+float fauxclicky_pressed_note[2] = MUSICAL_NOTE(_A6, 2);  // (_D4, 0.25);
+float fauxclicky_released_note[2] = MUSICAL_NOTE(_A6, 2); // (_C4, 0.125);
+float fauxclicky_beep_note[2] = MUSICAL_NOTE(_C6, 2);       // (_C4, 0.25);
+#define AUD_ON  FC_ON
+#define AUD_OFF FC_OFF
+#else
+#define AUD_ON  AU_ON
+#define AUD_OFF AU_OFF
+
+#endif 
+
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
@@ -72,15 +84,10 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 [_ADJUST] = KEYMAP(\
   KC_MAKE,KC_RESET, _______, _______, _______, _______,                                                                _______, _______, _______, _______, _______, _______,  \
-  RGB_SMOD,RGB_HUI, _______, AU_ON,   AU_OFF,  AG_NORM, _______, XXXXXXX, _______,          _______, XXXXXXX, _______, AG_SWAP, KC_QWERTY, KC_COLEMAK, KC_DVORAK, KC_WORKMAN, _______, \
+  RGB_SMOD,RGB_HUI, _______, AUD_ON,  AUD_OFF, AG_NORM, _______, XXXXXXX, _______,          _______, XXXXXXX, _______, AG_SWAP, KC_QWERTY, KC_COLEMAK, KC_DVORAK, KC_WORKMAN, _______, \
   KC_RGB_T,RGB_HUD, MU_ON,   MU_OFF,  MU_TOG,  MU_MOD,  _______, _______, _______,          _______, _______, _______, MAGIC_TOGGLE_NKRO, KC_MUTE, KC_VOLD, KC_VOLU, KC_MNXT, KC_MPLY  \
 )
 
 
 };
 
-#ifdef FAUXCLICKY_ENABLE
-float fauxclicky_pressed_note[2] = MUSICAL_NOTE(_A6, 2);  // (_D4, 0.25);
-float fauxclicky_released_note[2] = MUSICAL_NOTE(_A6, 2); // (_C4, 0.125);
-float fauxclicky_beep_note[2] = MUSICAL_NOTE(_C6, 2);       // (_C4, 0.25);
-#endif 

--- a/keyboards/orthodox/keymaps/drashna/keymap.c
+++ b/keyboards/orthodox/keymaps/drashna/keymap.c
@@ -48,20 +48,20 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 ),
 
 [_DVORAK] = KEYMAP(\
-    KC_ESC,   KC_QUOT, KC_COMM, KC_DOT, KC_P,     KC_Y,                                                                   KC_F,    KC_G,    KC_C,    KC_R,    KC_L,    KC_BSPC, \
-    KC_TAB,   KC_A,    KC_O,    KC_E,   KC_U,     KC_I,      KC_UP, XXXXXXX,  KC_DOWN,        KC_LEFT, XXXXXXX, KC_RIGHT, KC_D,    KC_H,    KC_T,    KC_N,    KC_S,    KC_MINS, \
-    KC_LSFT, CTL_T(KC_SCLN), KC_Q, KC_J, KC_K,    KC_X,      LOWER, KC_SPACE, KC_BSPC,        KC_DEL,  KC_ENT,  RAISE,    KC_B,    KC_M,    KC_W,    KC_V,    CTL_T(KC_Z), KC_LGUI \
+  KC_ESC,   KC_QUOT, KC_COMM, KC_DOT, KC_P,     KC_Y,                                                                   KC_F,    KC_G,    KC_C,    KC_R,    KC_L,    KC_BSPC, \
+  KC_TAB,   KC_A,    KC_O,    KC_E,   KC_U,     KC_I,      KC_UP, XXXXXXX,  KC_DOWN,        KC_LEFT, XXXXXXX, KC_RIGHT, KC_D,    KC_H,    KC_T,    KC_N,    KC_S,    KC_MINS, \
+  KC_LSFT, CTL_T(KC_SCLN), KC_Q, KC_J, KC_K,    KC_X,      LOWER, KC_SPACE, KC_BSPC,        KC_DEL,  KC_ENT,  RAISE,    KC_B,    KC_M,    KC_W,    KC_V,    CTL_T(KC_Z), KC_LGUI \
 ),
 [_WORKMAN] = KEYMAP(\
-    KC_ESC,   KC_QUOT, KC_COMM, KC_DOT, KC_P,     KC_Y,                                                                   KC_F,    KC_G,    KC_C,    KC_R,    KC_L,    KC_BSPC, \
-    KC_TAB,   KC_A,    KC_O,    KC_E,   KC_U,     KC_I,      KC_UP, XXXXXXX,  KC_DOWN,        KC_LEFT, XXXXXXX, KC_RIGHT, KC_D,    KC_H,    KC_T,    KC_N,    KC_S,    KC_MINS, \
-    KC_LSFT, CTL_T(KC_SCLN), KC_Q, KC_J, KC_K,    KC_X,      LOWER, KC_SPACE, KC_BSPC,        KC_DEL,  KC_ENT,  RAISE,    KC_B,    KC_M,    KC_W,    KC_V,    CTL_T(KC_Z), KC_LGUI \
+  KC_ESC,   KC_QUOT, KC_COMM, KC_DOT, KC_P,     KC_Y,                                                                   KC_F,    KC_G,    KC_C,    KC_R,    KC_L,    KC_BSPC, \
+  KC_TAB,   KC_A,    KC_O,    KC_E,   KC_U,     KC_I,      KC_UP, XXXXXXX,  KC_DOWN,        KC_LEFT, XXXXXXX, KC_RIGHT, KC_D,    KC_H,    KC_T,    KC_N,    KC_S,    KC_MINS, \
+  KC_LSFT, CTL_T(KC_SCLN), KC_Q, KC_J, KC_K,    KC_X,      LOWER, KC_SPACE, KC_BSPC,        KC_DEL,  KC_ENT,  RAISE,    KC_B,    KC_M,    KC_W,    KC_V,    CTL_T(KC_Z), KC_LGUI \
 ),
 
 [_LOWER] = KEYMAP(\
-  KC_TILD,    KC_EXLM, KC_AT,   KC_HASH, KC_DLR,  KC_PERC,                                                                KC_CIRC, KC_AMPR,    KC_ASTR,    KC_LPRN, KC_RPRN, KC_BSPC, \
-  KC_DEL,     KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F11,   XXXXXXX, KC_F12,          _______, XXXXXXX, KC_RCTL, XXXXXXX, KC_UNDS,    KC_PLUS,    KC_LCBR, KC_RCBR, KC_PIPE, \
-  _______,    KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  _______, _______, _______,          _______, _______, _______, XXXXXXX, KC_HOME,    KC_COMM,    KC_DOT,  KC_END,  _______ \
+  KC_TILD, KC_EXLM, KC_AT,   KC_HASH, KC_DLR,  KC_PERC,                                                                KC_CIRC, KC_AMPR,    KC_ASTR,    KC_LPRN, KC_RPRN, KC_BSPC, \
+  KC_DEL,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,      KC_F11,   XXXXXXX, KC_F12,          _______, XXXXXXX, KC_RCTL, XXXXXXX, KC_UNDS,    KC_PLUS,    KC_LCBR, KC_RCBR, KC_PIPE, \
+  _______, KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,     _______, _______, _______,          _______, _______, _______, XXXXXXX, KC_HOME,    KC_COMM,    KC_DOT,  KC_END,  _______ \
 ),
 
 [_RAISE] = KEYMAP(\

--- a/keyboards/orthodox/keymaps/drashna/keymap.c
+++ b/keyboards/orthodox/keymaps/drashna/keymap.c
@@ -19,7 +19,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "orthodox.h"
+#include QMK_KEYBOARD_H
 #include "drashna.h"
 
 

--- a/keyboards/viterbi/keymaps/drashna/keymap.c
+++ b/keyboards/viterbi/keymaps/drashna/keymap.c
@@ -1,4 +1,4 @@
-#include "viterbi.h"
+#include QMK_KEYBOARD_H
 #include "action_layer.h"
 #include "eeconfig.h"
 #include "drashna.h"

--- a/users/drashna/drashna.c
+++ b/users/drashna/drashna.c
@@ -476,9 +476,9 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     }
     return false;
     break;
-  case KC_SECRET_1:
+  case KC_SECRET_1 ... KC_SECRET_5:
     if (!record->event.pressed) {
-      send_string(secret1);
+      send_string(secret[keycode - KC_SECRET_1]);
     }
     return false;
     break;

--- a/users/drashna/drashna.c
+++ b/users/drashna/drashna.c
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "quantum.h"
 #include "action.h"
 #include "version.h"
+#include "sensitive.h"
 
 #ifdef TAP_DANCE_ENABLE
 //define diablo macro timer variables
@@ -434,19 +435,19 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
       SEND_STRING(" ");
 #endif
 #ifdef RGBLIGHT_ENABLE
-      SEND_STRING("RGBLIGHT_ENABLE=yes ");
+      SEND_STRING(" RGBLIGHT_ENABLE=yes");
 #else
-      SEND_STRING("RGBLIGHT_ENABLE=no ");
+      SEND_STRING(" RGBLIGHT_ENABLE=no");
 #endif
 #ifdef AUDIO_ENABLE
-      SEND_STRING("AUDIO_ENABLE=yes ");
+      SEND_STRING(" AUDIO_ENABLE=yes");
 #else
-      SEND_STRING("AUDIO_ENABLE=no ");
+      SEND_STRING(" AUDIO_ENABLE=no");
 #endif
 #ifdef FAUXCLICKY_ENABLE
-      SEND_STRING("FAUXCLICKY_ENABLE=yes ");
+      SEND_STRING(" FAUXCLICKY_ENABLE=yes");
 #else
-      SEND_STRING("FAUXCLICKY_ENABLE=no ");
+      SEND_STRING(" FAUXCLICKY_ENABLE=no");
 #endif
       SEND_STRING(SS_TAP(X_ENTER));
     }
@@ -475,6 +476,13 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     }
     return false;
     break;
+  case KC_SECRET_1:
+    if (!record->event.pressed) {
+      send_string(secret1);
+    }
+    return false;
+    break;
+
   case KC_RGB_T:  // Because I want the option to go back to normal RGB mode rather than always layer indication
     if (record->event.pressed) {
       rgb_layer_change = !rgb_layer_change;

--- a/users/drashna/drashna.c
+++ b/users/drashna/drashna.c
@@ -428,28 +428,30 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 #endif
   case KC_MAKE:
     if (!record->event.pressed) {
-      SEND_STRING("make " QMK_KEYBOARD ":" QMK_KEYMAP);
-#ifndef BOOTLOADER_CATERINA
-      SEND_STRING(":teensy ");
-#else
-      SEND_STRING(" ");
+      SEND_STRING("make " QMK_KEYBOARD ":" QMK_KEYMAP
+#if  (defined(BOOTLOADER_DFU) || defined(BOOTLOADER_LUFA_DFU) || defined(BOOTLOADER_QMK_DFU))
+       ":dfu"
+#elif defined(BOOTLOADER_HALFKEY)
+      ":teensy "
+#elif defined(BOOTLOADER_CATERINA)
+       ":avrdude "
 #endif
 #ifdef RGBLIGHT_ENABLE
-      SEND_STRING(" RGBLIGHT_ENABLE=yes");
+        " RGBLIGHT_ENABLE=yes"
 #else
-      SEND_STRING(" RGBLIGHT_ENABLE=no");
+        " RGBLIGHT_ENABLE=no"
 #endif
 #ifdef AUDIO_ENABLE
-      SEND_STRING(" AUDIO_ENABLE=yes");
+        " AUDIO_ENABLE=yes"
 #else
-      SEND_STRING(" AUDIO_ENABLE=no");
+        " AUDIO_ENABLE=no"
 #endif
 #ifdef FAUXCLICKY_ENABLE
-      SEND_STRING(" FAUXCLICKY_ENABLE=yes");
+        " FAUXCLICKY_ENABLE=yes"
 #else
-      SEND_STRING(" FAUXCLICKY_ENABLE=no");
+        " FAUXCLICKY_ENABLE=no" 
 #endif
-      SEND_STRING(SS_TAP(X_ENTER));
+        SS_TAP(X_ENTER));
     }
     return false;
     break;

--- a/users/drashna/drashna.c
+++ b/users/drashna/drashna.c
@@ -482,34 +482,22 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     }
     return false;
     break;
-
   case KC_RGB_T:  // Because I want the option to go back to normal RGB mode rather than always layer indication
+#ifdef RGBLIGHT_ENABLE
     if (record->event.pressed) {
       rgb_layer_change = !rgb_layer_change;
     }
+#endif
     return false;
     break;
-  case RGB_MOD:
-  case RGB_SMOD:
-  case RGB_HUI:
-  case RGB_HUD:
-  case RGB_SAI:
-  case RGB_SAD:
-  case RGB_VAI:
-  case RGB_VAD:
-  case RGB_MODE_PLAIN:
-  case RGB_MODE_BREATHE:
-  case RGB_MODE_RAINBOW:
-  case RGB_MODE_SWIRL:
-  case RGB_MODE_SNAKE:
-  case RGB_MODE_KNIGHT:
-  case RGB_MODE_XMAS:
-  case RGB_MODE_GRADIENT:
-    if (record->event.pressed) {
+#ifdef RGBLIGHT_ENABLE
+  case RGB_MOD ... RGB_MODE_GRADIENT: // quantum_keycodes.h L400 for definitions
+    if (record->event.pressed) { //This disrables layer indication, as it's assumed that if you're changing this ... you want that disabled
       rgb_layer_change = false;
     }
     return true;
     break;
+#endif
   }
   return process_record_keymap(keycode, record);
 }

--- a/users/drashna/drashna.c
+++ b/users/drashna/drashna.c
@@ -437,7 +437,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
       SEND_STRING("make " QMK_KEYBOARD ":" QMK_KEYMAP
 #if  (defined(BOOTLOADER_DFU) || defined(BOOTLOADER_LUFA_DFU) || defined(BOOTLOADER_QMK_DFU))
        ":dfu"
-#elif defined(BOOTLOADER_HALFKEY)
+#elif defined(BOOTLOADER_HALFKAY)
       ":teensy"
 #elif defined(BOOTLOADER_CATERINA)
        ":avrdude"

--- a/users/drashna/drashna.c
+++ b/users/drashna/drashna.c
@@ -79,6 +79,14 @@ qk_tap_dance_action_t tap_dance_actions[] = {
 };
 #endif
 
+#ifdef AUDIO_ENABLE
+float tone_qwerty[][2]       = SONG(QWERTY_SOUND);
+float tone_dvorak[][2]       = SONG(DVORAK_SOUND);
+float tone_colemak[][2]      = SONG(COLEMAK_SOUND);
+float tone_workman[][2]      = SONG(PLOVER_SOUND);
+float tone_hackstartup[][2]  = SONG(ONE_UP_SOUND);
+#endif
+
 
 // Add reconfigurable functions here, for keymap customization
 // This allows for a global, userspace functions, and continued
@@ -139,6 +147,11 @@ void matrix_init_user(void) {
     rgblight_mode(5);
   }
 #endif
+#ifdef AUDIO_ENABLE
+//  _delay_ms(21); // gets rid of tick
+//  stop_all_notes();
+//  PLAY_SONG(tone_hackstartup);
+#endif
   matrix_init_keymap();
 }
 #ifdef TAP_DANCE_ENABLE
@@ -190,13 +203,6 @@ void led_set_user(uint8_t usb_led) {
   led_set_keymap(usb_led);
 }
 
-
-#ifdef AUDIO_ENABLE
-float tone_qwerty[][2]     = SONG(QWERTY_SOUND);
-float tone_dvorak[][2]     = SONG(DVORAK_SOUND);
-float tone_colemak[][2]    = SONG(COLEMAK_SOUND);
-float tone_workman[][2]    = SONG(PLOVER_SOUND);
-#endif
 
 
 void persistent_default_layer_set(uint16_t default_layer) {
@@ -432,9 +438,9 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 #if  (defined(BOOTLOADER_DFU) || defined(BOOTLOADER_LUFA_DFU) || defined(BOOTLOADER_QMK_DFU))
        ":dfu"
 #elif defined(BOOTLOADER_HALFKEY)
-      ":teensy "
+      ":teensy"
 #elif defined(BOOTLOADER_CATERINA)
-       ":avrdude "
+       ":avrdude"
 #endif
 #ifdef RGBLIGHT_ENABLE
         " RGBLIGHT_ENABLE=yes"

--- a/users/drashna/drashna.c
+++ b/users/drashna/drashna.c
@@ -499,7 +499,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     return false;
     break;
 #ifdef RGBLIGHT_ENABLE
-  case RGB_MOD ... RGB_MODE_GRADIENT: // quantum_keycodes.h L400 for definitions
+  case RGB_MODE_FORWARD ... RGB_MODE_GRADIENT: // quantum_keycodes.h L400 for definitions
     if (record->event.pressed) { //This disrables layer indication, as it's assumed that if you're changing this ... you want that disabled
       rgb_layer_change = false;
     }

--- a/users/drashna/drashna.h
+++ b/users/drashna/drashna.h
@@ -106,4 +106,8 @@ enum {
 
 #define QMK_KEYS_PER_SCAN 6
 
+#ifdef RGBLIGHT_ENABLE
+#define RGBLIGHT_SLEEP
+#endif
+
 #endif

--- a/users/drashna/drashna.h
+++ b/users/drashna/drashna.h
@@ -85,7 +85,10 @@ enum userrpace_custom_keycodes {
   KC_GGEZ,
   KC_MAKE,
   KC_RESET,
+#ifdef RGBLIGHT_ENABLE
   KC_RGB_T,
+#endif
+  KC_SECRET_1,
   NEW_SAFE_RANGE //use "NEWPLACEHOLDER for keymap specific codes
 };
 
@@ -99,6 +102,6 @@ enum {
 #endif
 
 
-
+#define QMK_KEYS_PER_SCAN 6
 
 #endif

--- a/users/drashna/drashna.h
+++ b/users/drashna/drashna.h
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define USERSPACE
 
 #include "quantum.h"
+#include "song_list.h"
 
 // Define layer names 
 #define _QWERTY 0
@@ -104,7 +105,7 @@ enum {
 #endif
 
 
-#define QMK_KEYS_PER_SCAN 6
+#define QMK_KEYS_PER_SCAN 4
 
 #ifdef RGBLIGHT_ENABLE
 #define RGBLIGHT_SLEEP

--- a/users/drashna/drashna.h
+++ b/users/drashna/drashna.h
@@ -89,6 +89,10 @@ enum userrpace_custom_keycodes {
   KC_RGB_T,
 #endif
   KC_SECRET_1,
+  KC_SECRET_2,
+  KC_SECRET_3,
+  KC_SECRET_4,
+  KC_SECRET_5,
   NEW_SAFE_RANGE //use "NEWPLACEHOLDER for keymap specific codes
 };
 

--- a/users/drashna/drashna.h
+++ b/users/drashna/drashna.h
@@ -85,9 +85,7 @@ enum userrpace_custom_keycodes {
   KC_GGEZ,
   KC_MAKE,
   KC_RESET,
-#ifdef RGBLIGHT_ENABLE
   KC_RGB_T,
-#endif
   KC_SECRET_1,
   KC_SECRET_2,
   KC_SECRET_3,

--- a/users/drashna/sensitive.h
+++ b/users/drashna/sensitive.h
@@ -1,6 +1,8 @@
 const char secret[][64] = {
   "test1",
   "test2",
-  "Test"
+  "test3",
+  "test4",
+  "test5"
 };
 

--- a/users/drashna/sensitive.h
+++ b/users/drashna/sensitive.h
@@ -1,0 +1,6 @@
+const char secret[][64] = {
+  "test1",
+  "test2",
+  "Test"
+};
+

--- a/users/drashna/template.c
+++ b/users/drashna/template.c
@@ -21,6 +21,8 @@ __attribute__ ((weak))
 uint32_t layer_state_set_keymap (uint32_t state) {
   return state;
 }
+__attribute__ ((weak))
+void led_set_keymap(uint8_t usb_led) {}
 
 // Call user matrix init, then call the keymap's init function
 void matrix_init_user(void) {
@@ -81,4 +83,8 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 // Then runs keymap's layer change check
 uint32_t layer_state_set_user (uint32_t state) {
   return layer_state_set_keymap (state);
+}
+
+void led_set_user(uint8_t usb_led) {
+   led_set_keymap(usb_led);
 }


### PR DESCRIPTION
* Cleaned up RGB layer indicator toggle (so that the lights won't switch when layer changes occur), so that it compiles without warning if RGB is disabled

* Cleaned up macros (RGB macros, and bootloader macros)

* Added "secret macros", that are configurable via the "sensitive.h" file (use .git/info/exclude to prevent committing, though causes issues when switching branches locally)

* Added audio config, and cleaned up

* Added keycodes that will toggle audio mode or faux clicky mode based on which feature is enabled

