### PR TITLE
Fix typo in make example

### DIFF
--- a/docs/getting_started_make_guide.md
+++ b/docs/getting_started_make_guide.md
@@ -13,7 +13,7 @@ The full syntax of the `make` command is `<keyboard_folder>:<keymap>:<target>`, 
 
 The `<target>` means the following
 * If no target is given, then it's the same as `all` below
-* `all` compiles as many keyboard/revision/keymap combinations as specified. For example, `make planck/rev4:default:all` will generate a single .hex, while `make planck/rev4:all` will generate a hex for every keymap available to the planck.
+* `all` compiles as many keyboard/revision/keymap combinations as specified. For example, `make planck/rev4:default` will generate a single .hex, while `make planck/rev4:all` will generate a hex for every keymap available to the planck.
 * `dfu`, `teensy` or `dfu-util`, compile and upload the firmware to the keyboard. If the compilation fails, then nothing will be uploaded. The programmer to use depends on the keyboard. For most keyboards it's `dfu`, but for ChibiOS keyboards you should use `dfu-util`, and `teensy` for standard Teensys. To find out which command you should use for your keyboard, check the keyboard specific readme. 
  * **Note**: some operating systems need root access for these commands to work, so in that case you need to run for example `sudo make planck/rev4:default:dfu`.
 * `clean`, cleans the build output folders to make sure that everything is built from scratch. Run this before normal compilation if you have some unexplainable problems.


### PR DESCRIPTION
It has `:all" when it clearly is referencing the command without `:all`.