### PR TITLE
Refactor `RGB_MOD` keys

### DIFF
--- a/docs/feature_rgblight.md
+++ b/docs/feature_rgblight.md
@@ -87,8 +87,8 @@ These control the RGB Lighting functionality.
 | Long Name | Short Name | Description |
 |-----------|------------|-------------|
 ||`RGB_TOG`|toggle on/off|
-||`RGB_MOD`|cycle through modes|
-||`RGB_SMOD`|cycle through modes, use reverse direction when shift is hold|
+|`RGB_MODE_FORWARD`|`RGB_MOD`|cycle through modes, use reverse direction when shift is held|
+|`RGB_MODE_REVERSE`|`RGB_RMOD`|cycle through modes in reverse (also suppost shift to go forward)|
 ||`RGB_HUI`|hue increase|
 ||`RGB_HUD`|hue decrease|
 ||`RGB_SAI`|saturation increase|
@@ -103,6 +103,8 @@ These control the RGB Lighting functionality.
 |`RGB_MODE_KNIGHT`|`RGB_M_K`| Switch to the knight animation |
 |`RGB_MODE_XMAS`|`RGB_M_X`| Switch to the Christmas animation |
 |`RGB_MODE_GRADIENT`|`RGB_M_G`| Switch to the static gradient mode |
+
+note: for backwards compatibility, `RGB_SMOD` is an alias for `RGB_MOD`.
 
 ## Hardware Modification
 

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -286,13 +286,7 @@ bool process_record_quantum(keyrecord_t *record) {
       rgblight_toggle();
     }
     return false;
-  case RGB_MOD:
-    if (record->event.pressed) {
-      rgblight_step();
-    }
-    return false;
-  case RGB_SMOD:
-    // same as RBG_MOD, but if shift is pressed, it will use the reverese direction instead.
+  case RGB_MODE_FORWARD:
     if (record->event.pressed) {
       uint8_t shifted = get_mods() & (MOD_BIT(KC_LSHIFT)|MOD_BIT(KC_RSHIFT));
       if(shifted) {
@@ -300,6 +294,17 @@ bool process_record_quantum(keyrecord_t *record) {
       }
       else {
         rgblight_step();
+      }
+    }
+    return false;
+  case RGB_MODE_REVERSE:
+    if (record->event.pressed) {
+      uint8_t shifted = get_mods() & (MOD_BIT(KC_LSHIFT)|MOD_BIT(KC_RSHIFT));
+      if(shifted) {
+        rgblight_step();
+      }
+      else {
+        rgblight_step_reverse();
       }
     }
     return false;

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -399,8 +399,8 @@ enum quantum_keycodes {
 
     // RGB functionality
     RGB_TOG,
-    RGB_MOD,
-    RGB_SMOD,
+    RGB_MODE_FORWARD,
+    RGB_MODE_REVERSE,
     RGB_HUI,
     RGB_HUD,
     RGB_SAI,
@@ -552,6 +552,10 @@ enum quantum_keycodes {
 #define MACRODOWN(...) (record->event.pressed ? MACRO(__VA_ARGS__) : MACRO_NONE)
 
 #define KC_GESC GRAVE_ESC
+
+#define RGB_MOD RGB_MODE_FORWARD
+#define RGB_SMOD RGB_MODE_FORWARD
+#define RGB_RMOD RGB_MODE_REVERSE
 
 #define RGB_M_P RGB_MODE_PLAIN
 #define RGB_M_B RGB_MODE_BREATHE


### PR DESCRIPTION
First, `RGB_MOD` now behaves like `RGB_SMOD` (hold shift to go to the previous mode).  `RGB_SMOD` is still around  as an alias for backwards compatibility.

Next, added `RGB_RMOD` which moves in reverse (and holding shift goes to the *next* mode, so it's the inverse of `RGB_MOD`).

Long names `RGB_MODE_FORWARD` and `RGB_MODE_REVERSE` are also added for consistency with `RGB_MODE_PLAIN` and friends.

Docs updated.