### PR TITLE
Pointing to the right build URL

### DIFF
--- a/keyboards/iris/readme.md
+++ b/keyboards/iris/readme.md
@@ -17,4 +17,4 @@ Example of flashing this keyboard:
 
 See [build environment setup](https://docs.qmk.fm/build_environment_setup.html) then the [make instructions](https://docs.qmk.fm/make_instructions.html) for more information.
 
-A build guide for this keyboard can be found here: [Nyquist Build Guide](https://docs.keeb.io)
+A build guide for this keyboard can be found here: [Iris Build Guide](https://docs.keeb.io/iris-build-guide.html)


### PR DESCRIPTION
The previous URI used to point to the Nyquist keyboard build guide.