### PR TITLE
Don't "unselect" left-hand rows

### DIFF
--- a/keyboards/ergodox_ez/matrix.c
+++ b/keyboards/ergodox_ez/matrix.c
@@ -326,17 +326,9 @@ static matrix_row_t read_cols(uint8_t row)
  */
 static void unselect_rows(void)
 {
-    // unselect on mcp23018
-    if (mcp23018_status) { // if there was an error
-        // do nothing
-    } else {
-        // set all rows hi-Z : 1
-        mcp23018_status = i2c_start(I2C_ADDR_WRITE);    if (mcp23018_status) goto out;
-        mcp23018_status = i2c_write(GPIOA);             if (mcp23018_status) goto out;
-        mcp23018_status = i2c_write(0xFF);              if (mcp23018_status) goto out;
-    out:
-        i2c_stop();
-    }
+    // no need to unselect on mcp23018, because the select step sets all
+    // the other row bits high, and it's not changing to a different
+    // direction
 
     // unselect on teensy
     // Hi-Z(DDR:0, PORT:0) to unselect


### PR DESCRIPTION
"unselecting" left-hand rows is a wasted i2c transaction.

On the left-hand side, the ergodox uses a GPIO expander. It
does *not* change "direction" (input/output) of pins, it just
sets pins high or low.

But all the pins are written at once. There's no way to
change just one pin's value; you send a full byte of all eight
row pins. (Not all of them are in use, but that doesn't matter.)
So every pin is either +V or ground. This is in contrast
with the right-hand side, which is using input mode to make pins
be neutral.

So there's no need to "deselect" the rows on the left side
at all. To select row 0, you set the GPIO register for the
rows to 0xFE. The previous code would then set it back to
0xFF, then set it to 0xFD on the next cycle. But we can just
omit the intervening step, and set it to 0xFD next cycle,
and get the same results.

And yes, I tested that the keyboard still works.

On my system, scan rate as reported by DEBUG_SCAN_RATE goes
from 445 or so to 579 or so, thus, from ~2.24ms to ~1.73ms.

Signed-off-by: seebs <seebs@seebs.net>