### PR TITLE
New 'rgblight' functions: disable and "setrgb_at/sethsv_at"

### DIFF
--- a/docs/feature_rgblight.md
+++ b/docs/feature_rgblight.md
@@ -80,6 +80,20 @@ const uint8_t RGBLED_KNIGHT_INTERVALS[] PROGMEM = {127, 63, 31};
 const uint16_t RGBLED_GRADIENT_RANGES[] PROGMEM = {360, 240, 180, 120, 90};
 ```
 
+### LED control
+
+Look in `rgblights.h` for all available functions, but if you want to control all or some LEDs your goto functions are:
+
+```c
+rgblight_disable();  // turn all lights off
+rgblight_enable();  // turn lights on, based on their previous state (stored in EEPROM)
+
+rgblight_setrgb(r, g, b);  // where r/g/b is a number from 0..255.  Turns all the LEDs to this color
+rgblight_sethsv(h, s, v);  // HSV color control
+rgblight_setrgb_at(r,g,b, LED);  // control a single LED.  0 <= LED < RGBLED_NUM
+rgblight_sethsv_at(h,s,v, LED);  // control a single LED.  0 <= LED < RGBLED_NUM
+```
+
 ## RGB Lighting Keycodes
 
 These control the RGB Lighting functionality.

--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -245,17 +245,12 @@ void rgblight_mode(uint8_t mode) {
 }
 
 void rgblight_toggle(void) {
-  rgblight_config.enable ^= 1;
-  eeconfig_update_rgblight(rgblight_config.raw);
-  xprintf("rgblight toggle: rgblight_config.enable = %u\n", rgblight_config.enable);
+  xprintf("rgblight toggle: rgblight_config.enable = %u\n", !rgblight_config.enable);
   if (rgblight_config.enable) {
-    rgblight_mode(rgblight_config.mode);
-  } else {
-    #ifdef RGBLIGHT_ANIMATIONS
-      rgblight_timer_disable();
-    #endif
-    _delay_ms(50);
-    rgblight_set();
+    rgblight_disable();
+  }
+  else {
+    rgblight_enable();
   }
 }
 
@@ -264,6 +259,17 @@ void rgblight_enable(void) {
   eeconfig_update_rgblight(rgblight_config.raw);
   xprintf("rgblight enable: rgblight_config.enable = %u\n", rgblight_config.enable);
   rgblight_mode(rgblight_config.mode);
+}
+
+void rgblight_disable(void) {
+  rgblight_config.enable = 0;
+  eeconfig_update_rgblight(rgblight_config.raw);
+  xprintf("rgblight disable: rgblight_config.enable = %u\n", rgblight_config.enable);
+  #ifdef RGBLIGHT_ANIMATIONS
+    rgblight_timer_disable();
+  #endif
+  _delay_ms(50);
+  rgblight_set();
 }
 
 
@@ -365,13 +371,31 @@ void rgblight_sethsv(uint16_t hue, uint8_t sat, uint8_t val) {
 }
 
 void rgblight_setrgb(uint8_t r, uint8_t g, uint8_t b) {
-  // dprintf("rgblight set rgb: %u,%u,%u\n", r,g,b);
+  if (!rgblight_config.enable) { return; }
+
   for (uint8_t i = 0; i < RGBLED_NUM; i++) {
     led[i].r = r;
     led[i].g = g;
     led[i].b = b;
   }
   rgblight_set();
+}
+
+void rgblight_setrgb_at(uint8_t r, uint8_t g, uint8_t b, uint8_t index) {
+  if (!rgblight_config.enable || index >= RGBLED_NUM) { return; }
+
+  led[index].r = r;
+  led[index].g = g;
+  led[index].b = b;
+  rgblight_set();
+}
+
+void rgblight_sethsv_at(uint16_t hue, uint8_t sat, uint8_t val, uint8_t index) {
+  if (!rgblight_config.enable) { return; }
+
+  LED_TYPE tmp_led;
+  sethsv(hue, sat, val, &tmp_led);
+  rgblight_setrgb_at(tmp_led.r, tmp_led.g, tmp_led.b, index);
 }
 
 #ifndef RGBLIGHT_CUSTOM_DRIVER

--- a/quantum/rgblight.h
+++ b/quantum/rgblight.h
@@ -99,6 +99,7 @@ void rgblight_increase(void);
 void rgblight_decrease(void);
 void rgblight_toggle(void);
 void rgblight_enable(void);
+void rgblight_disable(void);
 void rgblight_step(void);
 void rgblight_step_reverse(void);
 uint32_t rgblight_get_mode(void);
@@ -113,6 +114,8 @@ void rgblight_increase_val(void);
 void rgblight_decrease_val(void);
 void rgblight_sethsv(uint16_t hue, uint8_t sat, uint8_t val);
 void rgblight_setrgb(uint8_t r, uint8_t g, uint8_t b);
+void rgblight_setrgb_at(uint8_t r, uint8_t g, uint8_t b, uint8_t index);
+void rgblight_sethsv_at(uint16_t hue, uint8_t sat, uint8_t val, uint8_t index);
 
 uint32_t eeconfig_read_rgblight(void);
 void eeconfig_update_rgblight(uint32_t val);


### PR DESCRIPTION
`rgblight_disable` is a complement to `rgblight_enable`.  Use case: turn rgb lights on or off based on internal state instead of a keypress.

`rgblight_setrgb_at` can be used to set a single WS2812 LED using RGB values, or `rgblight_sethsv_at` does the same using HSV.

Also refactors `rgblight_toggle` to delegate to `rgblight_enable` or `rgblight_disable`.
