### PR TITLE
Helpers to compare layer_state to a user layer

### DIFF
--- a/tmk_core/common/action_layer.c
+++ b/tmk_core/common/action_layer.c
@@ -88,6 +88,16 @@ void layer_clear(void)
     layer_state_set(0);
 }
 
+bool layer_state_is(uint8_t layer)
+{
+    return layer_state_cmp(layer_state, layer);
+}
+
+bool layer_state_cmp(uint32_t cmp_layer_state, uint8_t layer) {
+    if (layer == 0) { return cmp_layer_state == 0; }
+    return (cmp_layer_state & (1UL<<layer)) > 0;
+}
+
 void layer_move(uint8_t layer)
 {
     layer_state_set(1UL<<layer);

--- a/tmk_core/common/action_layer.h
+++ b/tmk_core/common/action_layer.h
@@ -51,6 +51,8 @@ void default_layer_xor(uint32_t state);
 extern uint32_t layer_state;
 void layer_debug(void);
 void layer_clear(void);
+bool layer_state_is(uint8_t layer);
+bool layer_state_cmp(uint32_t layer1, uint8_t layer2);
 void layer_move(uint8_t layer);
 void layer_on(uint8_t layer);
 void layer_off(uint8_t layer);


### PR DESCRIPTION
Performs the same bit comparison that the `layer_move/layer_or/...` functions perform.

- `layer_state_is(layer)` returns true if `layer` is in the `layer_state` bitmask
- `layer_state_cmp(state, layer)` returns true if `layer` is in the `state` bitmask, for use with any layer state, i.e. previous layer.

```c
uint32_t prev_layer;
...
prev_layer = layer_state;
...
if (layer_state_cmp(prev_layer, LAYER_COLEMAK) {
  // the prev layer was colemak, so do something based on that
}
```
