### PR TITLE
Fix backlight code

### DIFF
--- a/keyboards/xd75/config.h
+++ b/keyboards/xd75/config.h
@@ -50,7 +50,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define DIODE_DIRECTION COL2ROW
  
 #define BACKLIGHT_PIN F5
-#define BACKLIGHT_BREATHING
 #define BACKLIGHT_LEVELS 6
 
 

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -935,6 +935,11 @@ void backlight_task(void) {
 
 #ifdef BACKLIGHT_BREATHING
 
+#ifdef NO_BACKLIGHT_CLOCK
+void breathing_defaults(void) {}
+void breathing_intensity_default(void) {}
+#else
+
 #define BREATHING_NO_HALT  0
 #define BREATHING_HALT_OFF 1
 #define BREATHING_HALT_ON  2
@@ -1134,6 +1139,7 @@ ISR(TIMER1_COMPA_vect)
 
 }
 
+#endif // NO_BACKLIGHT_CLOCK
 #endif // breathing
 
 #else // backlight


### PR DESCRIPTION
I was getting "undefined `OCR1x`" error, it's because no timer was defined.

Really the error was that `BACKLIGHT_BREATHING` was defined, but the pin doesn't support it.  This at least gets the code to compile with NO-OP functions.