### PR TITLE
Enable tap dance and other features for Whitefox

### DIFF
--- a/keyboards/whitefox/matrix.c
+++ b/keyboards/whitefox/matrix.c
@@ -49,6 +49,7 @@ void matrix_init(void)
 
     memset(matrix, 0, MATRIX_ROWS);
     memset(matrix_debouncing, 0, MATRIX_ROWS);
+    matrix_init_quantum();
 }
 
 uint8_t matrix_scan(void)
@@ -102,6 +103,7 @@ uint8_t matrix_scan(void)
         }
         debouncing = false;
     }
+    matrix_scan_quantum();
     return 1;
 }
 

--- a/keyboards/whitefox/whitefox.c
+++ b/keyboards/whitefox/whitefox.c
@@ -15,3 +15,20 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "whitefox.h"
+
+__attribute__ ((weak))
+void matrix_init_user(void) {
+}
+
+__attribute__ ((weak))
+void matrix_scan_user(void) {
+}
+
+void matrix_init_kb(void) {
+  matrix_init_user();
+};
+
+void matrix_scan_kb(void) {
+  matrix_scan_user();
+};
+


### PR DESCRIPTION
The custom matrix code was missing calls to matrix_*_quantum, disabling quantum features.
Tested on my Whitefox.