### PR TITLE
Nordic keymap fixes

### DIFF
--- a/quantum/keymap_extras/keymap_nordic.h
+++ b/quantum/keymap_extras/keymap_nordic.h
@@ -23,52 +23,53 @@
 #define NO_ALGR KC_RALT
 
 // Normal characters
-#define NO_HALF	KC_GRV
-#define NO_PLUS	KC_MINS
-#define NO_ACUT	KC_EQL
+#define NO_HALF KC_GRV
+#define NO_PLUS KC_MINS
+#define NO_ACUT KC_EQL
 
-#define NO_AM	KC_LBRC
-#define NO_QUOT	KC_RBRC // this is the "umlaut" char on Nordic keyboards, Apple layout
-#define NO_AE	KC_SCLN
-#define NO_OSLH	KC_QUOT
-#define	NO_APOS	KC_NUHS
-
-#define NO_LESS	KC_NUBS
+#define NO_AM   KC_LBRC
+#define NO_UMLT KC_RBRC // this is the umlaut key on a Nordic keyboard
+#define NO_AE   KC_SCLN
+#define NO_OSLH KC_QUOT
+#define NO_APOS KC_NUHS
+#define NO_QUOT KC_BSLS // quote key is on the backslash key on a US keyboard
+#define NO_LESS KC_NUBS
 #define NO_MINS KC_SLSH
 
 // Shifted characters
 #define NO_SECT LSFT(NO_HALF)
-#define NO_QUO2	LSFT(KC_2)
+#define NO_QUO2 LSFT(KC_2)
 #define NO_BULT LSFT(KC_4)
-#define NO_AMPR	LSFT(KC_6)
+#define NO_AMPR LSFT(KC_6)
 #define NO_SLSH LSFT(KC_7)
-#define NO_LPRN	LSFT(KC_8)
-#define NO_RPRN	LSFT(KC_9)
-#define NO_EQL	LSFT(KC_0)
-#define NO_QUES	LSFT(NO_PLUS)
-#define NO_GRV	LSFT(NO_ACUT)
+#define NO_LPRN LSFT(KC_8)
+#define NO_RPRN LSFT(KC_9)
+#define NO_EQL  LSFT(KC_0)
+#define NO_QUES LSFT(NO_PLUS)
+#define NO_GRV  LSFT(NO_ACUT)
 
-#define NO_CIRC LSFT(NO_QUOT)
+#define NO_ASTR LSFT(NO_QUOT)
+#define NO_CIRC LSFT(NO_UMLT)
 
-#define NO_GRTR	LSFT(NO_LESS)
+#define NO_GRTR LSFT(NO_LESS)
 #define NO_SCLN LSFT(KC_COMM)
 #define NO_COLN LSFT(KC_DOT)
 #define NO_UNDS LSFT(NO_MINS)
 
 // Alt Gr-ed characters
-#define NO_AT	ALGR(KC_2)
-#define NO_PND	ALGR(KC_3)
-#define NO_DLR	ALGR(KC_4)
+#define NO_AT   ALGR(KC_2)
+#define NO_PND  ALGR(KC_3)
+#define NO_DLR  ALGR(KC_4)
 #define NO_LCBR ALGR(KC_7)
 #define NO_LBRC ALGR(KC_8)
 #define NO_RBRC ALGR(KC_9)
-#define NO_RCBR	ALGR(KC_0)
+#define NO_RCBR ALGR(KC_0)
 #define NO_PIPE ALGR(KC_NUBS)
 
 #define NO_EURO ALGR(KC_E)
-#define NO_TILD ALGR(NO_QUOT)
+#define NO_TILD ALGR(NO_UMLT)
 
 #define NO_BSLS ALGR(KC_MINS)
-#define NO_MU 	ALGR(KC_M)
+#define NO_MU   ALGR(KC_M)
 
 #endif

--- a/quantum/keymap_extras/keymap_norwegian.h
+++ b/quantum/keymap_extras/keymap_norwegian.h
@@ -38,7 +38,6 @@
 
 // Additional norwegian keys not defined in the nordic keyset
 #define NO_AA	KC_LBRC  // å
-#define NO_ASTR LSFT(KC_BSLS)  // *
 
 // Norwegian unique MAC characters
 #define NO_ACUT_MAC KC_EQL  // =

--- a/quantum/keymap_extras/keymap_swedish.h
+++ b/quantum/keymap_extras/keymap_swedish.h
@@ -26,14 +26,8 @@
 #define NO_AE   KC_QUOT  // ä
 #undef  NO_CIRC
 #define NO_CIRC LSFT(KC_RBRC)  // ^
-#undef  NO_GRV
-#define NO_GRV  LSFT(NO_BSLS)  //
 #undef  NO_OSLH
 #define NO_OSLH KC_SCLN  // ö
-
-// Additional Swedish keys not defined in the nordic keyset
-#define NO_AA   KC_LBRC  // å
-#define NO_ASTR LSFT(KC_BSLS)  // *
 
 // Norwegian unique MAC characters (not vetted for Swedish)
 #define NO_ACUT_MAC KC_EQL  // =
@@ -49,4 +43,3 @@
 #define NO_RCBR_MAC ALGR(LSFT(KC_9))  // }
 
 #endif
-


### PR DESCRIPTION
The Nordic keymap was incorrectly labeling the umlaut/tilde/circ key as NO_QUOT (which is mapped to KC_BSLS) and not NO_UMLT (or what have you). I have corrected this, introduced a new keycode NO_UMLT (as in umlaut) and updated depending keycodes in the Nordic layout to reflect this. 

I have also removed a few redudant keycodes in the Swedish and Norwegian layouts and cleaned up some whitespace. Sorry for the last bit but I couldn't stand it.

Any other Nordic users are more than welcome to have a look at the changes. The only breaking issue is that I removed the redundant definition of NO_AA in the Swedish layout as it already existed as NO_AM.