### PR TITLE
Found a bug in `layer_state_cmp`

### DIFF
--- a/tests/basic/test_action_layer.cpp
+++ b/tests/basic/test_action_layer.cpp
@@ -1,0 +1,92 @@
+/* Copyright 2017 Colin T.A. Gray
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "test_common.hpp"
+
+using testing::_;
+using testing::Return;
+
+class ActionLayer : public TestFixture {};
+
+// TEST_F(ActionLayer, LayerStateDBG) {
+//     layer_state_set(0);
+// }
+
+// TEST_F(ActionLayer, LayerStateSet) {
+//     layer_state_set(0);
+//     EXPECT_EQ(layer_state, 0);
+//     layer_state_set(0b001100);
+//     EXPECT_EQ(layer_state, 0b001100);
+// }
+
+// TEST_F(ActionLayer, LayerStateIs) {
+//     layer_state_set(0);
+//     EXPECT_EQ(layer_state_is(0), true);
+//     EXPECT_EQ(layer_state_is(1), true);
+//     layer_state_set(1);
+//     EXPECT_EQ(layer_state_is(0), true);
+//     EXPECT_EQ(layer_state_is(1), true);
+//     layer_state_set(2);
+//     EXPECT_EQ(layer_state_is(0), false);
+//     EXPECT_EQ(layer_state_is(1), false);
+//     EXPECT_EQ(layer_state_is(2), true);
+// }
+
+TEST_F(ActionLayer, LayerStateCmp) {
+    uint32_t prev_layer;
+
+    prev_layer = 0;
+    EXPECT_EQ(layer_state_cmp(prev_layer, 0), true);
+    EXPECT_EQ(layer_state_cmp(prev_layer, 1), false);
+
+    prev_layer = 1;
+    EXPECT_EQ(layer_state_cmp(prev_layer, 0), true);
+    EXPECT_EQ(layer_state_cmp(prev_layer, 1), false);
+
+    prev_layer = 2;
+    EXPECT_EQ(layer_state_cmp(prev_layer, 0), false);
+    EXPECT_EQ(layer_state_cmp(prev_layer, 1), true);
+    EXPECT_EQ(layer_state_cmp(prev_layer, 2), false);
+}
+
+// TEST_F(ActionLayer, LayerClear) {
+//     layer_clear();
+//     EXPECT_EQ(layer_state, 0);
+// }
+
+// TEST_F(ActionLayer, LayerMove) {
+//     layer_move(0);
+//     EXPECT_EQ(layer_state, 1);
+//     layer_move(3);
+//     EXPECT_EQ(layer_state, 0b1000);
+// }
+
+// TEST_F(ActionLayer, LayerOn) {
+//     layer_clear();
+//     layer_on(1);
+//     layer_on(3);
+//     layer_on(3);
+//     EXPECT_EQ(layer_state, 0b1010);
+// }
+
+// TEST_F(ActionLayer, LayerOff) {
+//     layer_clear();
+//     layer_on(1);
+//     layer_on(3);
+//     layer_off(3);
+//     layer_off(2);
+//     EXPECT_EQ(layer_state, 0b1000);
+// }

--- a/tests/test_common/test_common.hpp
+++ b/tests/test_common/test_common.hpp
@@ -17,7 +17,9 @@
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 
+extern "C" {
 #include "quantum.h"
+}
 #include "test_driver.hpp"
 #include "test_matrix.h"
 #include "keyboard_report_util.hpp"

--- a/tests/test_common/test_fixture.cpp
+++ b/tests/test_common/test_fixture.cpp
@@ -7,6 +7,10 @@
 #include "action_tapping.h"
 
 extern "C" {
+#include "action_layer.h"
+}
+
+extern "C" {
     void set_time(uint32_t t);
     void advance_time(uint32_t ms);
 }
@@ -30,11 +34,12 @@ TestFixture::TestFixture() {
 
 TestFixture::~TestFixture() {
     TestDriver driver;
+    layer_clear();
     clear_all_keys();
     // Run for a while to make sure all keys are completely released
     EXPECT_CALL(driver, send_keyboard_mock(_)).Times(AnyNumber());
     idle_for(TAPPING_TERM + 10);
-    testing::Mock::VerifyAndClearExpectations(&driver); 
+    testing::Mock::VerifyAndClearExpectations(&driver);
     // Verify that the matrix really is cleared
     EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport())).Times(Between(0, 1));
 }

--- a/tmk_core/common/action_layer.c
+++ b/tmk_core/common/action_layer.c
@@ -73,7 +73,7 @@ uint32_t layer_state_set_kb(uint32_t state) {
     return layer_state_set_user(state);
 }
 
-static void layer_state_set(uint32_t state)
+void layer_state_set(uint32_t state)
 {
     state = layer_state_set_kb(state);
     dprint("layer_state: ");

--- a/tmk_core/common/action_layer.c
+++ b/tmk_core/common/action_layer.c
@@ -94,8 +94,8 @@ bool layer_state_is(uint8_t layer)
 }
 
 bool layer_state_cmp(uint32_t cmp_layer_state, uint8_t layer) {
-    if (layer == 0) { return cmp_layer_state == 0; }
-    return (cmp_layer_state & (1UL<<layer)) > 0;
+    if (!cmp_layer_state) { return layer == 0; }
+    return (cmp_layer_state & (1UL<<layer)) != 0;
 }
 
 void layer_move(uint8_t layer)

--- a/tmk_core/common/action_layer.h
+++ b/tmk_core/common/action_layer.h
@@ -49,10 +49,13 @@ void default_layer_xor(uint32_t state);
  */
 #ifndef NO_ACTION_LAYER
 extern uint32_t layer_state;
-void layer_debug(void);
-void layer_clear(void);
+
+void layer_state_set(uint32_t state);
 bool layer_state_is(uint8_t layer);
 bool layer_state_cmp(uint32_t layer1, uint8_t layer2);
+
+void layer_debug(void);
+void layer_clear(void);
 void layer_move(uint8_t layer);
 void layer_on(uint8_t layer);
 void layer_off(uint8_t layer);
@@ -62,17 +65,21 @@ void layer_or(uint32_t state);
 void layer_and(uint32_t state);
 void layer_xor(uint32_t state);
 #else
-#define layer_state             0
+#define layer_state                    0
+
+#define layer_state_set(layer)
+#define layer_state_is(layer)          (layer == 0)
+#define layer_state_cmp(state, layer)  (state == 0 ? layer == 0 : (state & 1UL << layer) != 0)
+
+#define layer_debug()
 #define layer_clear()
 #define layer_move(layer)
 #define layer_on(layer)
 #define layer_off(layer)
 #define layer_invert(layer)
-
 #define layer_or(state)
 #define layer_and(state)
 #define layer_xor(state)
-#define layer_debug()
 
 __attribute__((weak))
 uint32_t layer_state_set_user(uint32_t state);


### PR DESCRIPTION
Fixes `layer_state_cmp` when layer is "default" layer.  The default layer, `0`, can be activated two ways:

```
layer_clear();  // layer_state = 0
layer_move(0);  // layer_state = 1UL<<0 = 1;
```

My initial implementation of `layer_state_cmp` had a special case for when `layer_state == 0`, but not for `layer_state == 1`

@jackhumbert I'd love to add tests to make sure `layer_state_cmp` works as I'd expect, but I couldn't figure out how to write specs.