### PR TITLE
Broken links in readme file pertaining to clueboards

### DIFF
--- a/keyboards/readme.md
+++ b/keyboards/readme.md
@@ -23,9 +23,9 @@ Made in Taiwan using advanced robotic manufacturing, the ErgoDox EZ is a fully-a
 
 Designed and built in Felton, CA, Clueboards keyboard emphasize quality and locally sourced components, available on [clueboard.co](http://clueboard.co)
 
-* [Clueboard](/keyboards/clueboard/) &mdash; The 66% custom keyboard.
-* [Cluecard](/keyboards/cluecard/) &mdash; A small board to help you hack on QMK.
-* [Cluepad](/keyboards/cluepad/) &mdash; A mechanical numpad with QMK superpowers.
+* [Clueboard](/keyboards/clueboard/66/) &mdash; The 66% custom keyboard.
+* [Cluecard](/keyboards/clueboard/card/) &mdash; A small board to help you hack on QMK.
+* [Cluepad](/keyboards/clueboard/17/) &mdash; A mechanical numpad with QMK superpowers.
 
 
 ## Community-supported QMK Keyboards

--- a/readme.md
+++ b/readme.md
@@ -18,8 +18,8 @@ This is a keyboard firmware based on the [tmk\_keyboard firmware](http://github.
 * [Planck](/keyboards/planck/)
 * [Preonic](/keyboards/preonic/)
 * [ErgoDox EZ](/keyboards/ergodox_ez/)
-* [Clueboard](/keyboards/clueboard_66/)
-* [Cluepad](/keyboards/clueboard_17/)
+* [Clueboard](/keyboards/clueboard/)
+* [Cluepad](/keyboards/clueboard/17/)
 
 The project also includes community support for [lots of other keyboards](/keyboards/).
 


### PR DESCRIPTION
While searching through the repo for ARM support I stumbled upon a few broken links pertaining to clueboards. 