### PR TITLE
Remove MIDI from Planck Rev5 to fix compile build size issue

### DIFF
--- a/keyboards/planck/rev5/rules.mk
+++ b/keyboards/planck/rev5/rules.mk
@@ -1,1 +1,2 @@
 AUDIO_ENABLE = yes           # Audio output on port C6
+MIDI_ENABLE = no


### PR DESCRIPTION
Removes MIDI from rev5, so that the default Planck keymap will compile "under size". 

