### PR TITLE
Added default case to process_record_user in docs

### DIFF
--- a/docs/custom_quantum_functions.md
+++ b/docs/custom_quantum_functions.md
@@ -60,6 +60,8 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         PLAY_NOTE_ARRAY(tone_qwerty);
       }
       return true; // Let QMK send the enter press/release events
+    default:
+      return true; // Process all other keycodes normally
   }
 }
 ```


### PR DESCRIPTION
I tried using process_record_user and if I had to add the default case for it to compile.