### PR TITLE
k_type: add belak keymap

### DIFF
--- a/keyboards/k_type/keymaps/belak/keymap.c
+++ b/keyboards/k_type/keymaps/belak/keymap.c
@@ -1,0 +1,37 @@
+#include "k_type.h"
+
+#define _______ KC_TRNS
+
+#define _QW 0
+#define _L1 1
+
+const uint16_t keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [_QW] = KEYMAP(
+      KC_ESC,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,           KC_PSCR, KC_SLCK, KC_PAUS, \
+      KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_INS,  KC_HOME, KC_PGUP, \
+      KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS, KC_DEL,  KC_END,  KC_PGDN, \
+      MO(_L1), KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_ENT, \
+      KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT,                            KC_UP, \
+      KC_LCTL, KC_LGUI, KC_LALT,          KC_SPC,                    KC_RALT, KC_RGUI, MO(_L1), KC_RCTL,                            KC_LEFT, KC_DOWN, KC_RGHT),
+    [_L1] = KEYMAP(
+      _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          _______, _______, _______, \
+      _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, KC_MPLY, KC_MNXT, KC_VOLU, \
+      _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, KC_MSTP, KC_MPRV, KC_VOLD, \
+      _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, \
+      _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,                            KC_PGUP, \
+      _______, _______, _______,          _______,                   _______, _______, _______, _______,                            KC_HOME, KC_PGDN, KC_END),
+};
+
+const uint16_t fn_actions[] = {
+
+};
+
+// Runs just one time when the keyboard initializes.
+void matrix_init_user(void) {
+
+};
+
+// Runs constantly in the background, in a loop.
+void matrix_scan_user(void) {
+
+};


### PR DESCRIPTION
Pretty simple keymap which replaces caps lock with a fn transition and adds some other conveniences such as media keys.

This is the keymap I've been using with the k-type, ported over from the official configurator so I can start using qmk again.