### PR TITLE
Unsign key argument in add_key_to_report

### DIFF
--- a/tmk_core/common/report.c
+++ b/tmk_core/common/report.c
@@ -176,7 +176,7 @@ void del_key_bit(report_keyboard_t* keyboard_report, uint8_t code)
 }
 #endif
 
-void add_key_to_report(report_keyboard_t* keyboard_report, int8_t key)
+void add_key_to_report(report_keyboard_t* keyboard_report, uint8_t key)
 {
 #ifdef NKRO_ENABLE
     if (keyboard_protocol && keymap_config.nkro) {

--- a/tmk_core/common/report.h
+++ b/tmk_core/common/report.h
@@ -184,7 +184,7 @@ void add_key_bit(report_keyboard_t* keyboard_report, uint8_t code);
 void del_key_bit(report_keyboard_t* keyboard_report, uint8_t code);
 #endif
 
-void add_key_to_report(report_keyboard_t* keyboard_report, int8_t key);
+void add_key_to_report(report_keyboard_t* keyboard_report, uint8_t key);
 void del_key_from_report(report_keyboard_t* keyboard_report, uint8_t key);
 void clear_keys_from_report(report_keyboard_t* keyboard_report);
 


### PR DESCRIPTION
This has no actual effect on functionality, but it's the only place in the chain of calls here where it's signed, and `del_key_from_report` is unsigned, so I think it's a typo 😉 