### PR TITLE
Added Ardakilic keymap for Tada68

### DIFF
--- a/keyboards/tada68/keymaps/ardakilic/keymap.c
+++ b/keyboards/tada68/keymaps/ardakilic/keymap.c
@@ -17,7 +17,7 @@
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   /* Keymap _BL: (Base Layer) Default Layer
    * ,----------------------------------------------------------------.
-   * |Esc | 1|  2|  3|  4|  5|  6|  7|  8|  9|  0|  -|  =|Backsp |⏏   |
+   * |Esc | 1|  2|  3|  4|  5|  6|  7|  8|  9|  0|  -|  =|Backsp |PWR |
    * |----------------------------------------------------------------|
    * |Tab  |  Q|  W|  E|  R|  T|  Y|  U|  I|  O|  P|  [|  ]|  \  |Del |
    * |----------------------------------------------------------------|
@@ -29,7 +29,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    * `----------------------------------------------------------------'
    */
 [_BL] = KEYMAP_ANSI(
-  KC_ESC,    KC_1,   KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,   KC_0,   KC_MINS, KC_EQL, KC_BSPC,KC_EJCT, \
+  KC_ESC,    KC_1,   KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,   KC_0,   KC_MINS, KC_EQL, KC_BSPC,KC_POWER, \
   KC_TAB,  KC_Q,   KC_W,   KC_E,   KC_R,   KC_T,   KC_Y,   KC_U,   KC_I,   KC_O,   KC_P,   KC_LBRC, KC_RBRC,KC_BSLS,KC_DEL, \
   KC_CAPS, KC_A,   KC_S,   KC_D,   KC_F,   KC_G,   KC_H,   KC_J,   KC_K,   KC_L,   KC_SCLN,KC_QUOT,         KC_ENT,KC_NONUS_BSLASH,  \
   KC_LSFT,         KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,   KC_N,   KC_M,   KC_COMM,KC_DOT, KC_SLSH,   KC_RSFT,KC_UP,KC_GRV, \

--- a/keyboards/tada68/keymaps/ardakilic/keymap.c
+++ b/keyboards/tada68/keymaps/ardakilic/keymap.c
@@ -1,0 +1,57 @@
+#include "tada68.h"
+
+//KC_NONUS_BSLASH (\|) is equivalent to ["é] key in Turkish keyboards.
+//KC_GRV (~ `) is equivalent to [<>|] key in Turkish keyboards.
+//I've put grave to bottom, and nonUS backslash to top to make it more similar to Turkish layout.  ["é] key is more above than [<>|] key.
+//Default top right button was KC_GRV (~ `) (Grave key) even if it looks like Tilde key.
+
+// Each layer gets a name for readability, which is then used in the keymap matrix below.
+// The underscores don't mean anything - you can have a layer called STUFF or any other name.
+// Layer names don't all need to be of the same length, obviously, and you can also skip them
+// entirely and just use numbers.
+#define _BL 0
+#define _FL 1
+
+#define _______ KC_TRNS
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  /* Keymap _BL: (Base Layer) Default Layer
+   * ,----------------------------------------------------------------.
+   * |Esc | 1|  2|  3|  4|  5|  6|  7|  8|  9|  0|  -|  =|Backsp |⏏   |
+   * |----------------------------------------------------------------|
+   * |Tab  |  Q|  W|  E|  R|  T|  Y|  U|  I|  O|  P|  [|  ]|  \  |Del |
+   * |----------------------------------------------------------------|
+   * |CAPS   |  A|  S|  D|  F|  G|  H|  J|  K|  L|  ;|  '|Return |\ | |
+   * |----------------------------------------------------------------|
+   * |Shift   |  Z|  X|  C|  V|  B|  N|  M|  ,|  .|  /|Shift | Up|~ ` |
+   * |----------------------------------------------------------------|
+   * |Ctrl|Alt |CMD |        Space          |CMD |FN |Alt|Lef|Dow|Rig |
+   * `----------------------------------------------------------------'
+   */
+[_BL] = KEYMAP_ANSI(
+  KC_ESC,    KC_1,   KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,   KC_0,   KC_MINS, KC_EQL, KC_BSPC,KC_EJCT, \
+  KC_TAB,  KC_Q,   KC_W,   KC_E,   KC_R,   KC_T,   KC_Y,   KC_U,   KC_I,   KC_O,   KC_P,   KC_LBRC, KC_RBRC,KC_BSLS,KC_DEL, \
+  KC_CAPS, KC_A,   KC_S,   KC_D,   KC_F,   KC_G,   KC_H,   KC_J,   KC_K,   KC_L,   KC_SCLN,KC_QUOT,         KC_ENT,KC_NONUS_BSLASH,  \
+  KC_LSFT,         KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,   KC_N,   KC_M,   KC_COMM,KC_DOT, KC_SLSH,   KC_RSFT,KC_UP,KC_GRV, \
+  KC_LCTL, KC_LALT,KC_LGUI,                KC_SPC,                        KC_RGUI,MO(_FL),KC_RALT, KC_LEFT,KC_DOWN,KC_RGHT),
+
+  /* Keymap _FL: Function Layer
+   * ,----------------------------------------------------------------.
+   * |   | F1|F2 |F3 |F4 |F5 |F6 |F7 |F8 |F9 |F10|F11|F12|Del    |Ins |
+   * |----------------------------------------------------------------|
+   * |     |   |   |   |   |   |   |   |   |   |   |   |   |     |Hme |
+   * |----------------------------------------------------------------|
+   * |      |   |   |   |   |   |   | PP|PLA|PN |   |   |        |End |
+   * |----------------------------------------------------------------|
+   * |        |   |   |Bl-|BL |BL+|   |MUT|VU-|VU+|   |      |   |    |
+   * |----------------------------------------------------------------|
+   * |    |    |    |                       |   |   |    |   |   |    |
+   * `----------------------------------------------------------------'
+   */
+[_FL] = KEYMAP_ANSI(
+  _______, KC_F1 ,KC_F2, KC_F3, KC_F4, KC_F5, KC_F6, KC_F7, KC_F8, KC_F9, KC_F10, KC_F11, KC_F12, KC_DEL, KC_INS ,  \
+  _______,_______,_______,_______,_______, _______,_______,_______,_______,_______,_______,_______,_______, _______,KC_HOME, \
+  _______,_______,_______,_______,_______,_______,_______,KC_MPRV,KC_MPLY,KC_MNXT,_______,_______,        _______,KC_END, \
+  _______,_______,_______,BL_DEC, BL_TOGG,BL_INC, _______,KC_MUTE,KC_VOLD,KC_VOLU,_______,_______,_______,_______, \
+  _______,_______,_______,                 _______,               _______,_______,_______,_______,_______,_______),
+};

--- a/keyboards/tada68/keymaps/ardakilic/readme.md
+++ b/keyboards/tada68/keymaps/ardakilic/readme.md
@@ -1,0 +1,17 @@
+# Ardakilic's TADA68 layout
+
+This layout aims to use Ansi keyboard for my needs in ease, especially to work on macOS, and to have a layout more similar to Apple keyboards.
+
+This layout aims to have a similar layout to Apple keyboards while using ISO layouts with the ANSI keymap. The layout is directly considered using Turkish Qwerty keyboards.
+
+The changes that were applied over default layout:
+
+* Make Win/cmd keys right next to space bar just like Apple keyboards.
+* Adding an Eject (⏏, `KC_EJCT`) key, so the lock screen shortcut works.
+* Re-use the page up and page down keys to make ["é] (`KC_NONUS_BSLASH`) and [<>|] (`KC_GRAVE`) keys more accessible.
+* Optimize the function layer, by removing the mouse movement combinations and adding additional media keys.
+* Swap the positions of volume up and volume down and mute buttons on function layer, so these keys are actually with the same order as Apple keyboard layout.
+
+I'm re-purposing page up and page down keys in this layout, because in macOS alt/option + arrow keys, in Windows and Linux, space bar/shift spacebar combinations already cover their work, and is more accessible if you'd ask me.
+
+This layout is still a WIP.

--- a/keyboards/tada68/keymaps/ardakilic/readme.md
+++ b/keyboards/tada68/keymaps/ardakilic/readme.md
@@ -7,11 +7,9 @@ This layout aims to have a similar layout to Apple keyboards while using ISO lay
 The changes that were applied over default layout:
 
 * Make Win/cmd keys right next to space bar just like Apple keyboards.
-* Adding an Eject (⏏, `KC_EJCT`) key, so the lock screen shortcut works.
+* Adding a power (`KC_POWER`) key, so the lock screen shortcut works.
 * Re-use the page up and page down keys to make ["é] (`KC_NONUS_BSLASH`) and [<>|] (`KC_GRAVE`) keys more accessible.
 * Optimize the function layer, by removing the mouse movement combinations and adding additional media keys.
 * Swap the positions of volume up and volume down and mute buttons on function layer, so these keys are actually with the same order as Apple keyboard layout.
 
 I'm re-purposing page up and page down keys in this layout, because in macOS alt/option + arrow keys, in Windows and Linux, space bar/shift spacebar combinations already cover their work, and is more accessible if you'd ask me.
-
-This layout is still a WIP.

--- a/keyboards/tada68/keymaps/ardakilic/rules.mk
+++ b/keyboards/tada68/keymaps/ardakilic/rules.mk
@@ -1,0 +1,21 @@
+# Build Options
+#   change to "no" to disable the options, or define them in the Makefile in 
+#   the appropriate keymap folder that will get included automatically
+#
+BOOTMAGIC_ENABLE = no       # Virtual DIP switch configuration(+1000)
+MOUSEKEY_ENABLE = yes       # Mouse keys(+4700)
+EXTRAKEY_ENABLE = yes       # Audio control and System control(+450)
+CONSOLE_ENABLE = no         # Console for debug(+400)
+COMMAND_ENABLE = yes        # Commands for debug and configuration
+NKRO_ENABLE = yes           # Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+BACKLIGHT_ENABLE = yes       # Enable keyboard backlight functionality
+MIDI_ENABLE = no            # MIDI controls
+AUDIO_ENABLE = no           # Audio output on port C6
+UNICODE_ENABLE = no         # Unicode
+BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
+RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight.  Do not enable this with audio at the same time.
+SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
+
+ifndef QUANTUM_DIR
+	include ../../../../Makefile
+endif


### PR DESCRIPTION
This layout aims to use Ansi keyboard for my needs in ease, especially to work on macOS, and to have a layout more similar to Apple keyboards.

This layout aims to have a similar layout to Apple keyboards while using ISO layouts with the ANSI keymap. The layout is directly considered using Turkish Qwerty keyboards.

The changes that were applied over default layout:

* Make Win/cmd keys right next to space bar just like Apple keyboards.
* Adding a power (`KC_POWER`) key, so the lock screen shortcut works.
* Re-use the page up and page down keys to make ["é] (`KC_NONUS_BSLASH`) and [<>|] (`KC_GRAVE`) keys more accessible.
* Optimize the function layer, by removing the mouse movement combinations and adding additional media keys.
* Swap the positions of volume up and volume down and mute buttons on function layer, so these keys are actually with the same order as Apple keyboard layout.

I'm re-purposing page up and page down keys in this layout, because in macOS alt/option + arrow keys, in Windows and Linux, space bar/shift spacebar combinations already cover their work, and is more accessible if you'd ask me.
