### PR TITLE
Oscillope keymap: handy programming macros

### DIFF
--- a/keyboards/jj40/jj40.h
+++ b/keyboards/jj40/jj40.h
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef KEYMAP_COMMON_H
 #define KEYMAP_COMMON_H
 
+#include "quantum.h"
 #include "quantum_keycodes.h"
 #include "keycode.h"
 #include "action.h"

--- a/keyboards/jj40/keymaps/oscillope/keymap.c
+++ b/keyboards/jj40/keymaps/oscillope/keymap.c
@@ -26,6 +26,7 @@ enum custom_keycodes {
   QWERTY = SAFE_RANGE,
   LOWER,
   RAISE,
+  KC_ARRW,
 };
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
@@ -71,7 +72,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |------+------+------+------+------+-------------+------+------+------+------+------|
  * | Tab  |   $  |   %  |   ^  |   [  |   ]  |   4  |   5  |   6  |   -  |   +  |Enter |
  * |------+------+------+------+------+------|------+------+------+------+------+------|
- * |   `  |   !  |   @  |   #  |   {  |   }  |   1  |   2  |   3  |   .  |   \  |  |   |
+ * |  ->  |   !  |   @  |   #  |   {  |   }  |   1  |   2  |   3  |   .  |   \  |  |   |
  * |------+------+------+------+------+------+------+------+------+------+------+------|
  * | Ctrl |  OS  | Alt  |      |Shift |      |      0      | Home | PgDn | PgUp | End  |
  * `-----------------------------------------------------------------------------------'
@@ -79,7 +80,18 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 [_RAISE] = KEYMAP( \
   KC_CAPS, KC_AMPR, KC_ASTR, KC_UNDS, KC_LPRN, KC_RPRN, KC_7,    KC_8,    KC_9,    KC_EQL,  KC_BSPC, KC_DEL, \
   KC_TAB,  KC_DLR,  KC_PERC, KC_CIRC, KC_LBRC, KC_RBRC, KC_4,    KC_5,    KC_6,    KC_MINS, KC_PLUS, _______, \
-  _______, KC_EXLM, KC_AT,   KC_HASH, KC_LCBR, KC_RCBR, KC_1,    KC_2,    KC_3,    _______, KC_BSLS, KC_PIPE, \
+  KC_ARRW, KC_EXLM, KC_AT,   KC_HASH, KC_LCBR, KC_RCBR, KC_1,    KC_2,    KC_3,    _______, KC_BSLS, KC_PIPE, \
   _______, _______, _______, _______, _______, _______, KC_0,    KC_HOME, KC_PGDN, KC_PGUP, KC_END \
 )
 };
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  if (record->event.pressed) {
+    switch(keycode) {
+      case KC_ARRW:
+        SEND_STRING("->");
+        return false;
+    }
+  }
+  return true;
+}

--- a/keyboards/jj40/keymaps/oscillope/keymap.c
+++ b/keyboards/jj40/keymaps/oscillope/keymap.c
@@ -26,7 +26,10 @@ enum custom_keycodes {
   QWERTY = SAFE_RANGE,
   LOWER,
   RAISE,
-  KC_ARRW,
+  CC_ARRW,
+  CC_PRN,
+  CC_BRC,
+  CC_CBR,
 };
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
@@ -52,7 +55,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * ,-----------------------------------------------------------------------------------.
  * |  F1  |  F2  |  F3  |  F4  |  F5  |  F6  |  F7  |  F8  |  F9  | F10  | F11  | F12  |
  * |------+------+------+------+------+-------------+------+------+------+------+------|
- * | Ins  |      |      |      |      |      | Left | Down |  Up  |Right |      |      |
+ * | Ins  |      |      |  ()  |  []  |  {}  | Left | Down |  Up  |Right |      |      |
  * |------+------+------+------+------+------|------+------+------+------+------+------|
  * |PrScr | Back | Fwd  |      |      |      |      |      | Mute | Vol- | Vol+ |      |
  * |------+------+------+------+------+------+------+------+------+------+------+------|
@@ -61,7 +64,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  */
 [_LOWER] = KEYMAP( \
   KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12, \
-  KC_INS,  _______, _______, _______, _______, _______, KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT, _______, _______, \
+  KC_INS,  _______, _______, CC_PRN,  CC_BRC,  CC_CBR,  KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT, _______, _______, \
   KC_PSCR, KC_WBAK, KC_WFWD, _______, _______, _______, _______, _______, KC_MUTE, KC_VOLD, KC_VOLU, _______, \
   _______, _______, _______, _______, KC_LOCK, _______, _______, KC_MPRV, KC_MSTP, KC_MPLY, KC_MNXT \
 ),
@@ -80,7 +83,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 [_RAISE] = KEYMAP( \
   KC_CAPS, KC_AMPR, KC_ASTR, KC_UNDS, KC_LPRN, KC_RPRN, KC_7,    KC_8,    KC_9,    KC_EQL,  KC_BSPC, KC_DEL, \
   KC_TAB,  KC_DLR,  KC_PERC, KC_CIRC, KC_LBRC, KC_RBRC, KC_4,    KC_5,    KC_6,    KC_MINS, KC_PLUS, _______, \
-  KC_ARRW, KC_EXLM, KC_AT,   KC_HASH, KC_LCBR, KC_RCBR, KC_1,    KC_2,    KC_3,    _______, KC_BSLS, KC_PIPE, \
+  CC_ARRW, KC_EXLM, KC_AT,   KC_HASH, KC_LCBR, KC_RCBR, KC_1,    KC_2,    KC_3,    _______, KC_BSLS, KC_PIPE, \
   _______, _______, _______, _______, _______, _______, KC_0,    KC_HOME, KC_PGDN, KC_PGUP, KC_END \
 )
 };
@@ -88,8 +91,17 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
   if (record->event.pressed) {
     switch(keycode) {
-      case KC_ARRW:
+      case CC_ARRW:
         SEND_STRING("->");
+        return false;
+      case CC_PRN:
+        SEND_STRING("()"SS_TAP(X_LEFT));
+        return false;
+      case CC_BRC:
+        SEND_STRING("[]"SS_TAP(X_LEFT));
+        return false;
+      case CC_CBR:
+        SEND_STRING("{}"SS_TAP(X_LEFT));
         return false;
     }
   }


### PR DESCRIPTION
Added a couple of macros which are useful when programming, specifially:
* RAISE + \` inserts `->`
* LOWER + d/f/g inserts `()`, `[]`, and `{}`, and positions the cursor inside the braces