### PR TITLE
RGB underglow support for JJ40, clean up redundant code in Mechmini keymap

### DIFF
--- a/keyboards/jj40/config.h
+++ b/keyboards/jj40/config.h
@@ -15,6 +15,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "config_common.h"
+
 #ifndef CONFIG_H
 #define CONFIG_H
 
@@ -38,6 +40,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define TAPPING_TOGGLE 3
 
 #define NO_UART 1
+
+/* RGB underglow */
+// The RGB_DI_PIN value seems to be shared between all PS2AVRGB boards.
+// The same pin is used on the JJ40, at least.
+#define RGBLED_NUM 5
+#define RGB_DI_PIN E2
+#define RGBLIGHT_ANIMATIONS
 
 /* key combination for command */
 #define IS_COMMAND() (keyboard_report->mods == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT)))

--- a/keyboards/jj40/jj40.c
+++ b/keyboards/jj40/jj40.c
@@ -22,9 +22,25 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "action_layer.h"
 #include "quantum.h"
 
+// custom RGB driver
+extern rgblight_config_t rgblight_config;
+void rgblight_set(void) {
+  if (!rgblight_config.enable) {
+    for (uint8_t i=0; i<RGBLED_NUM; i++) {
+      led[i].r = 0;
+      led[i].g = 0;
+      led[i].b = 0;
+    }
+  }
+
+  i2c_init();
+  i2c_send(0xb0, (uint8_t*)led, 3 * RGBLED_NUM);
+}
+
 __attribute__ ((weak))
 void matrix_scan_user(void) {
-    /* Nothing to do here... yet */
+    rgblight_task();
+    /* add other tasks to be done on each matrix scan */
 }
 
 void matrix_init_kb(void) {

--- a/keyboards/jj40/jj40.c
+++ b/keyboards/jj40/jj40.c
@@ -22,6 +22,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "action_layer.h"
 #include "quantum.h"
 
+#include "i2c.h"
+
 // custom RGB driver
 extern rgblight_config_t rgblight_config;
 void rgblight_set(void) {
@@ -40,17 +42,5 @@ void rgblight_set(void) {
 __attribute__ ((weak))
 void matrix_scan_user(void) {
     rgblight_task();
-    /* add other tasks to be done on each matrix scan */
-}
-
-void matrix_init_kb(void) {
-
-  // Call the keymap level matrix init.
-  matrix_init_user();
-
-  // Set our LED pins as output
-  DDRB |= (1<<6);
-}
-
-void matrix_init_user(void) {
+    /* Nothing else for now. */
 }

--- a/keyboards/jj40/jj40.h
+++ b/keyboards/jj40/jj40.h
@@ -65,6 +65,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   { K312, K311, K310, K39, K35, K36, K3X, KC_NO, K34, K33, K32, K31 }  \
 }
 
-#define KEYMAP KEYMAP_OFFSET
+#define KEYMAP KEYMAP_MIT
 
 #endif

--- a/keyboards/jj40/keymaps/default/keymap.c
+++ b/keyboards/jj40/keymaps/default/keymap.c
@@ -80,6 +80,6 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_BSPC, \
   KC_DEL,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_MINS, KC_EQL,  KC_LBRC, KC_RBRC, KC_BSLS, \
   _______, KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  RGB_TOG, RGB_MOD, RGB_VAD, RGB_VAI, _______, \
-  _______, RGB_HUD, RGB_HUI, RGB_SAI, RGB_SAD, _______, _______, KC_MNXT, KC_VOLD, KC_VOLU, KC_MPLY \
+  _______, RGB_HUD, RGB_HUI, RGB_SAD, RGB_SAI, _______, _______, KC_MNXT, KC_VOLD, KC_VOLU, KC_MPLY \
 )
 };

--- a/keyboards/jj40/keymaps/default/keymap.c
+++ b/keyboards/jj40/keymaps/default/keymap.c
@@ -53,7 +53,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |------+------+------+------+------+-------------+------+------+------+------+------|
  * | Del  |  F1  |  F2  |  F3  |  F4  |  F5  |  F6  |   _  |   +  |     |    \  |  |   |
  * |------+------+------+------+------+------|------+------+------+------+------+------|
- * |      |  F7  |  F8  |  F9  |  F10 |  F11 |  F12 |ISO ~ |ISO | |      |      |Enter |
+ * |      |  F7  |  F8  |  F9  |  F10 |  F11 |  F12 |      |      |      |      |Enter |
  * |------+------+------+------+------+------+------+------+------+------+------+------|
  * |      |      |      |      |      |             |      | Next | Vol- | Vol+ | Play |
  * `-----------------------------------------------------------------------------------'
@@ -61,7 +61,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 [_LOWER] = KEYMAP( \
   KC_TILD, KC_EXLM, KC_AT,   KC_HASH, KC_DLR,  KC_PERC, KC_CIRC, KC_AMPR, KC_ASTR, KC_LPRN, KC_RPRN, KC_BSPC, \
   KC_DEL,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_UNDS, KC_PLUS, KC_LCBR, KC_RCBR, KC_PIPE, \
-  _______, KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,S(KC_NUHS),S(KC_NUBS),_______, _______, _______, \
+  _______, KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  _______, _______,_______, _______, _______, \
   _______, _______, _______, _______, _______, _______, _______, KC_MNXT, KC_VOLD, KC_VOLU, KC_MPLY \
 ),
 
@@ -71,15 +71,15 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |------+------+------+------+------+-------------+------+------+------+------+------|
  * | Del  |  F1  |  F2  |  F3  |  F4  |  F5  |  F6  |   -  |   =  |   [  |   ]  |  \   |
  * |------+------+------+------+------+------|------+------+------+------+------+------|
- * |      |  F7  |  F8  |  F9  |  F10 |  F11 |  F12 |ISO # |ISO / |      |      |Enter |
+ * |      |  F7  |  F8  |  F9  |  F10 |  F11 |  F12 | RGB  | RGB  | RGB  | RGB  |Enter |
  * |------+------+------+------+------+------+------+------+------+------+------+------|
- * |      |      |      |      |      |             |      | Next | Vol- | Vol+ | Play |
+ * |      | RGB  | RGB  | RGB  | RGB  |             |      | Next | Vol- | Vol+ | Play |
  * `-----------------------------------------------------------------------------------'
  */
 [_RAISE] = KEYMAP( \
   KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_BSPC, \
   KC_DEL,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_MINS, KC_EQL,  KC_LBRC, KC_RBRC, KC_BSLS, \
-  _______, KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_NUHS, KC_NUBS, _______, _______, _______, \
-  _______, _______, _______, _______, _______, _______, _______, KC_MNXT, KC_VOLD, KC_VOLU, KC_MPLY \
+  _______, KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  RGB_TOG, RGB_MOD, RGB_VAD, RGB_VAI, _______, \
+  _______, RGB_HUD, RGB_HUI, RGB_SAI, RGB_SAD, _______, _______, KC_MNXT, KC_VOLD, KC_VOLU, KC_MPLY \
 )
 };

--- a/keyboards/jj40/keymaps/fun40/rules.mk
+++ b/keyboards/jj40/keymaps/fun40/rules.mk
@@ -11,7 +11,11 @@ MIDI_ENABLE = no            # MIDI controls
 AUDIO_ENABLE = yes          # Audio output on port C6
 UNICODE_ENABLE = no         # Unicode
 BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
-RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight.  Do not enable this with audio at the same time.
+
+RGBLIGHT_ENABLE = yes
+RGBLIGHT_CUSTOM_DRIVER = yes
+DISABLE_WS2812 = yes
+
 
 SLEEP_LED_ENABLE = no    # Breathing sleep LED during USB suspend
 

--- a/keyboards/jj40/keymaps/krusli/keymap.c
+++ b/keyboards/jj40/keymaps/krusli/keymap.c
@@ -53,7 +53,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |------+------+------+------+------+-------------+------+------+------+------+------|
  * | Del  |  F1  |  F2  |  F3  |  F4  |  F5  |  F6  |   _  |   +  |     |    \  |  |   |
  * |------+------+------+------+------+------|------+------+------+------+------+------|
- * |      |  F7  |  F8  |  F9  |  F10 |  F11 |  F12 |ISO ~ |ISO | |      |      |Enter |
+ * |      |  F7  |  F8  |  F9  |  F10 |  F11 |  F12 |      |      |      |      |Enter |
  * |------+------+------+------+------+------+------+------+------+------+------+------|
  * |      |      |      |      |      |             |      | Next | Vol- | Vol+ | Play |
  * `-----------------------------------------------------------------------------------'
@@ -61,7 +61,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 [_LOWER] = KEYMAP( \
   KC_TILD, KC_EXLM, KC_AT,   KC_HASH, KC_DLR,  KC_PERC, KC_CIRC, KC_AMPR, KC_ASTR, KC_LPRN, KC_RPRN, KC_BSPC, \
   KC_DEL,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_UNDS, KC_PLUS, KC_LCBR, KC_RCBR, KC_PIPE, \
-  _______, KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,S(KC_NUHS),S(KC_NUBS),_______, _______, _______, \
+  _______, KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  _______, _______,_______, _______, _______, \
   _______, _______, _______, _______, _______, _______, _______, KC_MNXT, KC_VOLD, KC_VOLU, KC_MPLY \
 ),
 
@@ -71,15 +71,15 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |------+------+------+------+------+-------------+------+------+------+------+------|
  * | Del  |  F1  |  F2  |  F3  |  F4  |  F5  |  F6  |   -  |   =  |   [  |   ]  |  \   |
  * |------+------+------+------+------+------|------+------+------+------+------+------|
- * |      |  F7  |  F8  |  F9  |  F10 |  F11 |  F12 |ISO # |ISO / |      |      |Enter |
+ * |      |  F7  |  F8  |  F9  |  F10 |  F11 |  F12 | RGB  | RGB  | RGB  | RGB  |Enter |
  * |------+------+------+------+------+------+------+------+------+------+------+------|
- * |      |      |      |      |      |             |      | Next | Vol- | Vol+ | Play |
+ * |      | RGB  | RGB  | RGB  | RGB  |             |      | Next | Vol- | Vol+ | Play |
  * `-----------------------------------------------------------------------------------'
  */
 [_RAISE] = KEYMAP( \
   KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_BSPC, \
   KC_DEL,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_MINS, KC_EQL,  KC_LBRC, KC_RBRC, KC_BSLS, \
-  _______, KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_NUHS, KC_NUBS, _______, _______, _______, \
-  _______, _______, _______, _______, _______, _______, _______, KC_MNXT, KC_VOLD, KC_VOLU, KC_MPLY \
+  _______, KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  RGB_TOG, RGB_MOD, RGB_VAD, RGB_VAI, _______, \
+  _______, RGB_HUD, RGB_HUI, RGB_SAD, RGB_SAI, _______, _______, KC_MNXT, KC_VOLD, KC_VOLU, KC_MPLY \
 )
 };

--- a/keyboards/jj40/keymaps/krusli/keymap.c
+++ b/keyboards/jj40/keymaps/krusli/keymap.c
@@ -37,14 +37,14 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |------+------+------+------+------+------|------+------+------+------+------+------|
  * | Shift|   Z  |   X  |   C  |   V  |   B  |   N  |   M  |   ,  |   .  |   /  |Enter |
  * |------+------+------+------+------+------+------+------+------+------+------+------|
- * |      | Ctrl | Alt  | GUI  |Lower |    Space    |Raise | Left | Down |  Up  |Right |
+ * |      | Ctrl | GUI  | Alt  |Lower |    Space    |Raise | Left | Down |  Up  |Right |
  * `-----------------------------------------------------------------------------------'
  */
 [_QWERTY] = KEYMAP( \
   KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_BSPC, \
   KC_ESC,  KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, \
   KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_ENT , \
-  _______, KC_LCTL, KC_LALT, KC_LGUI, MO(_LOWER),  KC_SPC,  MO(_RAISE),   KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT \
+  _______, KC_LCTL, KC_LGUI, KC_LALT, MO(_LOWER),  KC_SPC,  MO(_RAISE),   KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT \
 ),
 
 /* Lower

--- a/keyboards/jj40/keymaps/krusli/readme.md
+++ b/keyboards/jj40/keymaps/krusli/readme.md
@@ -1,0 +1,2 @@
+# krusli
+Default JJ40 keymap, adapted with RGB underglow support. GUI and LAlt is also swapped.

--- a/keyboards/jj40/rules.mk
+++ b/keyboards/jj40/rules.mk
@@ -37,8 +37,11 @@ EXTRAKEY_ENABLE = yes
 CONSOLE_ENABLE = no
 COMMAND_ENABLE = yes
 BACKLIGHT_ENABLE = no
+
 RGBLIGHT_ENABLE = yes
 RGBLIGHT_CUSTOM_DRIVER = yes
+DISABLE_WS2812 = yes  # TODO check if this is necessary
+
 KEY_LOCK_ENABLE = yes
 
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE

--- a/keyboards/jj40/rules.mk
+++ b/keyboards/jj40/rules.mk
@@ -26,7 +26,7 @@ F_CPU = 12000000
 
 # Bootloader
 #     This definition is optional, and if your keyboard supports multiple bootloaders of
-#     different sizes, comment this out, and the correct address will be loaded 
+#     different sizes, comment this out, and the correct address will be loaded
 #     automatically (+60). See bootloader.mk for all options.
 BOOTLOADER = bootloadHID
 
@@ -37,8 +37,8 @@ EXTRAKEY_ENABLE = yes
 CONSOLE_ENABLE = no
 COMMAND_ENABLE = yes
 BACKLIGHT_ENABLE = no
-RGBLIGHT_ENABLE = no
-RGBLIGHT_CUSTOM_DRIVER = no
+RGBLIGHT_ENABLE = yes
+RGBLIGHT_CUSTOM_DRIVER = yes
 KEY_LOCK_ENABLE = yes
 
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE

--- a/keyboards/jj40/usbconfig.h
+++ b/keyboards/jj40/usbconfig.h
@@ -118,7 +118,8 @@ section at the end of this file).
 /* Define this to 1 if the device has its own power supply. Set it to 0 if the
  * device is powered from the USB bus.
  */
-#define USB_CFG_MAX_BUS_POWER           500
+// max power draw with maxed white underglow measured at 120 mA (peaks)
+#define USB_CFG_MAX_BUS_POWER           150
 /* Set this variable to the maximum USB bus power consumption of your device.
  * The value is in milliamperes. [It will be divided by two since USB
  * communicates power requirements in units of 2 mA.]

--- a/keyboards/mechmini/config.h
+++ b/keyboards/mechmini/config.h
@@ -30,11 +30,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MATRIX_ROWS 8
 #define MATRIX_COLS 15
 
+#define NO_UART 1
+
+/* RGB underglow */
+// The RGB_DI_PIN value seems to be shared between all PS2AVRGB boards.
+// The same pin is used on the JJ40, at least.
 #define RGBLED_NUM 16
 #define RGBLIGHT_ANIMATIONS
 #define RGB_DI_PIN E2
-
-#define NO_UART 1
 
 /* key combination for command */
 #define IS_COMMAND() (keyboard_report->mods == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT)))

--- a/keyboards/mechmini/keymaps/default/keymap.c
+++ b/keyboards/mechmini/keymaps/default/keymap.c
@@ -14,16 +14,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include "mechmini.h"
-#include "rgblight.h"
 #include "quantum.h"
 
-#define MAX_BRIGHTNESS 15
-#define MAX_BRIGHTNESS_IOS 5  // max brightness suitable for iOS devices
-
-#define _BL 0
-#define _FN1 1
-#define _FN2 2
-#define _FN3 3
+#define _BL  0   // base layer
+#define _FN1 1  // function layer 1
+#define _FN2 2  // function layer 2
+#define _FN3 3  // function layer 3
 #define _____ KC_TRNS
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
@@ -52,109 +48,3 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
      _____,      _____,      _____,            _____,        _____,         _____,                   _____,    _____
    )
 };
-
-/**
- * Blank keymap
- [0] = KEYMAP(
-   _____,      _____,      _____,      _____,    _____,    _____,    _____,    _____,    _____,    _____,    _____,    _____
-   _____,      _____,      _____,      _____,    _____,    _____,    _____,    _____,    _____,    _____,    _____,
-   _____,      _____,      _____,      _____,    _____,    _____,    _____,    _____,    _____,    _____,    _____,
-   _____,      _____,      _____,            _____,        _____,         _____,                   _____,    _____
- )
- */
-
-uint8_t current_level = 4;
-int is_on = 0;
-
-uint8_t r = 0xFF;
-uint8_t g = 0xFF;
-uint8_t b = 0xFF;
-
-uint8_t max_brightness = MAX_BRIGHTNESS_IOS;
-
-enum macro_id {
-  TOGGLE_RGB,
-  BRIGHTNESS_DOWN,
-  BRIGHTNESS_UP,
-  COLOR_1,
-  COLOR_2,
-  COLOR_3,
-  ENABLE_MAX_BRIGHTNESS
-};
-
-const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt) {
-  keyevent_t event = record->event;
-
-  switch (id) {
-    case TOGGLE_RGB:
-      if (event.pressed) {
-       if (!is_on) {
-         current_level = 4;
-         is_on = 1;
-       } else {
-         is_on = 0;
-       }
-      }
-    case BRIGHTNESS_DOWN:
-      if (event.pressed && current_level > 0) {
-        current_level--;
-      }
-      break;
-    case BRIGHTNESS_UP:
-      if (event.pressed && current_level < max_brightness) {
-        current_level++;
-      }
-      break;
-    case COLOR_1:  // set to pink
-      if (event.pressed) {
-        r = 0xFF;
-        g = 0x81;
-        b = 0xC2;
-      }
-      break;
-    case COLOR_2:  // set to cyan
-      if (event.pressed) {
-        r = 0x00;
-        g = 0xE0;
-        b = 0xFF;
-      }
-      break;
-    case COLOR_3:  // set to white
-      if (event.pressed) {
-        r = 0xFF;
-        g = 0xFF;
-        b = 0xFF;
-      }
-      break;
-    case ENABLE_MAX_BRIGHTNESS: // enable all 16 brightness steps
-      if (event.pressed) {
-        max_brightness = MAX_BRIGHTNESS;
-      }
-      break;
-  }
-
-  return MACRO_NONE;
-}
-
-const uint16_t fn_actions[] PROGMEM = {
-};
-
-void rgblight_setrgb(uint8_t r, uint8_t g, uint8_t b);
-
-uint8_t dim(uint8_t color, uint8_t opacity) {
-   return ((uint16_t) color * opacity / 0xFF) & 0xFF;
-}
-
-void user_setrgb(uint8_t r, uint8_t g, uint8_t b) {
-   uint8_t alpha = current_level * 0x11;
-   rgblight_setrgb(dim(r, alpha), dim(g, alpha), dim(b, alpha));
-}
-
-void matrix_scan_user(void) {
-  if (!is_on) {
-    current_level = 0;
-    user_setrgb(r, g, b);
-  } else {
-    user_setrgb(r, g, b);
-  }
-}

--- a/keyboards/mechmini/mechmini.c
+++ b/keyboards/mechmini/mechmini.c
@@ -16,16 +16,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include "mechmini.h"
-#include "rgblight.h"
-
 #include <avr/pgmspace.h>
 
 #include "action_layer.h"
 #include "i2c.h"
 #include "quantum.h"
 
-extern rgblight_config_t rgblight_config;
+#include "rgblight.h"
 
+// custom RGB driver
+extern rgblight_config_t rgblight_config;
 void rgblight_set(void) {
     if (!rgblight_config.enable) {
         for (uint8_t i = 0; i < RGBLED_NUM; i++) {
@@ -42,4 +42,5 @@ void rgblight_set(void) {
 __attribute__ ((weak))
 void matrix_scan_user(void) {
     rgblight_task();
+    /* add other tasks to be done on each matrix scan */
 }

--- a/keyboards/mechmini/usbconfig.h
+++ b/keyboards/mechmini/usbconfig.h
@@ -118,7 +118,7 @@ section at the end of this file).
 /* Define this to 1 if the device has its own power supply. Set it to 0 if the
  * device is powered from the USB bus.
  */
-#define USB_CFG_MAX_BUS_POWER           100
+#define USB_CFG_MAX_BUS_POWER           500
 /* Set this variable to the maximum USB bus power consumption of your device.
  * The value is in milliamperes. [It will be divided by two since USB
  * communicates power requirements in units of 2 mA.]


### PR DESCRIPTION
I just built my JJ40 today and decided to port over some of the RGB underglow code I used on the Mechmini QMK subdirectory (which is also a PS2AVRGB board). The code turned out to move over pretty easily: it's a matter of defining a custom `rgblight_set()` function in `jj40.c`, and changing a few things in `config.h` and `rules.mk` to enable RGB underglow as I did with the Mechmini. All that is different is the number of RGB LEDs - 5 for the JJ40 versus 16 on the Mechmini. Perhaps this implementation could be used with other PS2AVRGB boards?

I also cleaned up the redundant/extraneous RGB backlighting code on the Mechmini subdirectory (as setting RGB underglow modes/colours is already handled by QMK's built-in RGB support), and reset the keyboard's advertised power draw to 500 mA in `usbconfig.h`, as I am not sure that the keyboard only draws 100 mA with the underglow set on full. On this - I do now have a USB power draw meter, but I feel like setting the value back to the default is better, with the option for users to modify the value in `usbconfig.h` as needed instead.