### PR TITLE
Commented out some code to fix #2094

### DIFF
--- a/quantum/audio/audio.c
+++ b/quantum/audio/audio.c
@@ -151,16 +151,16 @@ void audio_init()
 
         #ifdef C6_AUDIO
             DDRC |= _BV(PORTC6);
-        #else
-            DDRC |= _BV(PORTC6);
-            PORTC &= ~_BV(PORTC6);
+        //#else
+        //    DDRC |= _BV(PORTC6); // Why is PC6 being set as output low, if C6_audio isn't defined?
+        //    PORTC &= ~_BV(PORTC6); 
         #endif
 
         #ifdef B5_AUDIO
             DDRB |= _BV(PORTB5);
-        #else
-            DDRB |= _BV(PORTB5);
-            PORTB &= ~_BV(PORTB5);
+        //#else
+        //    DDRB |= _BV(PORTB5); // Same as with PC6
+        //    PORTB &= ~_BV(PORTB5);
         #endif
 
         #ifdef C6_AUDIO


### PR DESCRIPTION
As mentioned in #2094, setting audio enable will set both audio-pins as outputs, meaning they can't be used.

Make all compiles just as much as it did on a fresh clone of your repo, so it seems the change doesn't break anything
