### PR TITLE
Added reference to previously undefined (out of context) function

### DIFF
--- a/keyboards/ergodone/ergodone.c
+++ b/keyboards/ergodone/ergodone.c
@@ -12,6 +12,8 @@ extern inline void ergodox_right_led_2_off(void);
 extern inline void ergodox_right_led_3_off(void);
 extern inline void ergodox_right_led_off(uint8_t led);
 
+extern inline void ergodox_led_all_off(void);
+
 void ergodox_led_init(void);
 void ergodox_blink_all_leds(void);
 


### PR DESCRIPTION
This caused a compile error before as it was called in "ergodox_blink_all_leds" but didn't exist in this context (since it was not imported from "ergodone.h")