### PR TITLE
Reset color after submodule warning message

### DIFF
--- a/message.mk
+++ b/message.mk
@@ -58,7 +58,7 @@ MSG_SUBMODULE_DIRTY = $(WARN_COLOR)WARNING:$(NO_COLOR)\n \
 	Some git sub-modules are out of date or modified, please consider runnning:$(BOLD)\n\
         make git-submodule\n\
 	You can ignore this warning if you are not compiling any ChibiOS keyboards,\n\
-	or if you have modified the ChibiOS libraries yourself. \n\n
+	or if you have modified the ChibiOS libraries yourself. \n\n$(NO_COLOR)
 MSG_NO_CMP = $(ERROR_COLOR)Error:$(NO_COLOR)$(BOLD) cmp command not found, please install diffutils\n$(NO_COLOR)
 
 define GENERATE_MSG_MAKE_KB


### PR DESCRIPTION
Fixes leaking bold text

Before:

![screenshot from 2018-01-08 23-12-28](https://user-images.githubusercontent.com/4211302/34697105-78fdc94a-f4c9-11e7-9e96-2678d558ca81.png)

After:

![screenshot from 2018-01-08 23-12-46](https://user-images.githubusercontent.com/4211302/34697107-7cdca374-f4c9-11e7-9a80-47a591144315.png)
