### PR TITLE
Small fixes to memset usage in Input:Club keyboards

### DIFF
--- a/keyboards/clueboard/60/matrix.c
+++ b/keyboards/clueboard/60/matrix.c
@@ -11,7 +11,7 @@
 
 /* Clueboard 60%
  *
- * Column pins are input with internal pull-down. 
+ * Column pins are input with internal pull-down.
  * Row pins are output and strobe with high.
  * Key is high or 1 when it turns on.
  *
@@ -68,8 +68,8 @@ void matrix_init(void) {
     palSetPadMode(GPIOA, 15,  PAL_MODE_INPUT_PULLDOWN);
     palSetPadMode(GPIOA, 10,  PAL_MODE_INPUT_PULLDOWN);
 
-    memset(matrix, 0, MATRIX_ROWS);
-    memset(matrix_debouncing, 0, MATRIX_COLS);
+    memset(matrix, 0, MATRIX_ROWS * sizeof(matrix_row_t));
+    memset(matrix_debouncing, 0, MATRIX_COLS * sizeof(matrix_row_t));
 
     /* Setup capslock */
     // palSetPadMode(GPIOB, 7,  PAL_MODE_OUTPUT_PUSHPULL);
@@ -84,20 +84,20 @@ uint8_t matrix_scan(void) {
 
         // strobe col { PA2, PA3, PA6, PB14, PB15, PA8, PA9, PA7, PB3, PB4, PC14, PC15, PC13, PB5, PB6 }
         switch (col) {
-            case 0: palSetPad(GPIOA, 2); break; 
-            case 1: palSetPad(GPIOA, 3); break; 
-            case 2: palSetPad(GPIOA, 6); break; 
-            case 3: palSetPad(GPIOB, 14); break; 
-            case 4: palSetPad(GPIOB, 15); break; 
-            case 5: palSetPad(GPIOA, 8); break; 
-            case 6: palSetPad(GPIOA, 9); break; 
-            case 7: palSetPad(GPIOA, 7); break; 
-            case 8: palSetPad(GPIOB, 3); break; 
-            case 9: palSetPad(GPIOB, 4); break; 
-            case 10: palSetPad(GPIOC, 15); break; 
-            case 11: palSetPad(GPIOC, 14); break; 
-            case 12: palSetPad(GPIOC, 13); break; 
-            case 13: palSetPad(GPIOB, 5); break; 
+            case 0: palSetPad(GPIOA, 2); break;
+            case 1: palSetPad(GPIOA, 3); break;
+            case 2: palSetPad(GPIOA, 6); break;
+            case 3: palSetPad(GPIOB, 14); break;
+            case 4: palSetPad(GPIOB, 15); break;
+            case 5: palSetPad(GPIOA, 8); break;
+            case 6: palSetPad(GPIOA, 9); break;
+            case 7: palSetPad(GPIOA, 7); break;
+            case 8: palSetPad(GPIOB, 3); break;
+            case 9: palSetPad(GPIOB, 4); break;
+            case 10: palSetPad(GPIOC, 15); break;
+            case 11: palSetPad(GPIOC, 14); break;
+            case 12: palSetPad(GPIOC, 13); break;
+            case 13: palSetPad(GPIOB, 5); break;
             case 14: palSetPad(GPIOB, 6); break;
         }
 
@@ -115,20 +115,20 @@ uint8_t matrix_scan(void) {
 
         // unstrobe  col { PA2, PA3, PA6, PB14, PB15, PA8, PA9, PA7, PB3, PB4, PC15, PC14, PC13, PB5, PB6 }
         switch (col) {
-            case 0: palClearPad(GPIOA, 2); break; 
-            case 1: palClearPad(GPIOA, 3); break; 
-            case 2: palClearPad(GPIOA, 6); break; 
-            case 3: palClearPad(GPIOB, 14); break; 
-            case 4: palClearPad(GPIOB, 15); break; 
-            case 5: palClearPad(GPIOA, 8); break; 
-            case 6: palClearPad(GPIOA, 9); break; 
-            case 7: palClearPad(GPIOA, 7); break; 
-            case 8: palClearPad(GPIOB, 3); break; 
-            case 9: palClearPad(GPIOB, 4); break; 
-            case 10: palClearPad(GPIOC, 15); break; 
-            case 11: palClearPad(GPIOC, 14); break; 
-            case 12: palClearPad(GPIOC, 13); break; 
-            case 13: palClearPad(GPIOB, 5); break; 
+            case 0: palClearPad(GPIOA, 2); break;
+            case 1: palClearPad(GPIOA, 3); break;
+            case 2: palClearPad(GPIOA, 6); break;
+            case 3: palClearPad(GPIOB, 14); break;
+            case 4: palClearPad(GPIOB, 15); break;
+            case 5: palClearPad(GPIOA, 8); break;
+            case 6: palClearPad(GPIOA, 9); break;
+            case 7: palClearPad(GPIOA, 7); break;
+            case 8: palClearPad(GPIOB, 3); break;
+            case 9: palClearPad(GPIOB, 4); break;
+            case 10: palClearPad(GPIOC, 15); break;
+            case 11: palClearPad(GPIOC, 14); break;
+            case 12: palClearPad(GPIOC, 13); break;
+            case 13: palClearPad(GPIOB, 5); break;
             case 14: palClearPad(GPIOB, 6); break;
         }
 

--- a/keyboards/ergodox_infinity/matrix.c
+++ b/keyboards/ergodox_infinity/matrix.c
@@ -62,8 +62,8 @@ void matrix_init(void)
     palSetPadMode(GPIOC, 11, PAL_MODE_OUTPUT_PUSHPULL);
     palSetPadMode(GPIOD, 0,  PAL_MODE_OUTPUT_PUSHPULL);
 
-    memset(matrix, 0, MATRIX_ROWS);
-    memset(matrix_debouncing, 0, LOCAL_MATRIX_ROWS);
+    memset(matrix, 0, MATRIX_ROWS * sizeof(matrix_row_t));
+    memset(matrix_debouncing, 0, LOCAL_MATRIX_ROWS * sizeof(matrix_row_t));
 
     matrix_init_quantum();
 }

--- a/keyboards/infinity60/matrix.c
+++ b/keyboards/infinity60/matrix.c
@@ -60,8 +60,8 @@ void matrix_init(void)
     palSetPadMode(GPIOC, 5,  PAL_MODE_OUTPUT_PUSHPULL);
     palSetPadMode(GPIOD, 0,  PAL_MODE_OUTPUT_PUSHPULL);
 #endif
-    memset(matrix, 0, MATRIX_ROWS);
-    memset(matrix_debouncing, 0, MATRIX_ROWS);
+    memset(matrix, 0, MATRIX_ROWS * sizeof(matrix_row_t));
+    memset(matrix_debouncing, 0, MATRIX_ROWS * sizeof(matrix_row_t));
 
     matrix_init_quantum();
 }

--- a/keyboards/jm60/matrix.c
+++ b/keyboards/jm60/matrix.c
@@ -49,8 +49,8 @@ void matrix_init(void)
     palSetPadMode(GPIOB, 1, PAL_MODE_OUTPUT_PUSHPULL);
     palSetPadMode(GPIOB, 0,  PAL_MODE_OUTPUT_PUSHPULL);
 
-    memset(matrix, 0, MATRIX_ROWS);
-    memset(matrix_debouncing, 0, MATRIX_ROWS);
+    memset(matrix, 0, MATRIX_ROWS * sizeof(matrix_row_t));
+    memset(matrix_debouncing, 0, MATRIX_ROWS * sizeof(matrix_row_t));
 }
 
 uint8_t matrix_scan(void)

--- a/keyboards/k_type/matrix.c
+++ b/keyboards/k_type/matrix.c
@@ -42,8 +42,8 @@ void matrix_init(void)
     palSetPadMode(GPIOD, 1,   PAL_MODE_OUTPUT_PUSHPULL);
     palSetPadMode(GPIOD, 4,   PAL_MODE_OUTPUT_PUSHPULL);
 
-    memset(matrix, 0, MATRIX_ROWS);
-    memset(matrix_debouncing, 0, MATRIX_ROWS);
+    memset(matrix, 0, MATRIX_ROWS * sizeof(matrix_row_t));
+    memset(matrix_debouncing, 0, MATRIX_ROWS * sizeof(matrix_row_t));
 
     matrix_init_quantum();
 }

--- a/keyboards/whitefox/matrix.c
+++ b/keyboards/whitefox/matrix.c
@@ -47,8 +47,9 @@ void matrix_init(void)
     palSetPadMode(GPIOC, 10, PAL_MODE_OUTPUT_PUSHPULL);
     palSetPadMode(GPIOC, 11, PAL_MODE_OUTPUT_PUSHPULL);
 
-    memset(matrix, 0, MATRIX_ROWS);
-    memset(matrix_debouncing, 0, MATRIX_ROWS);
+    memset(matrix, 0, MATRIX_ROWS * sizeof(matrix_row_t));
+    memset(matrix_debouncing, 0, MATRIX_ROWS * sizeof(matrix_row_t));
+
     matrix_init_quantum();
 }
 


### PR DESCRIPTION
This was noticed by @jsvana when he tried to compile the k-type firmware with a relatively new version of gcc (`arm-none-eabi-gcc (devkitARM release 47) 7.1.0`)

```
keyboards/k_type/matrix.c:46:5: error: 'memset' used with length equal to number of elements without multiplication by element size [-Werror=memset-elt-size]
```

This led to a small investigation relating to those memset calls, which simply use `MATRIX_ROWS` and don't multiply that by the size of the struct we're zeroing out. Unfortunately `matrix_row_t` can be one of `uint8_t`. `uint16_t` or `uint32_t` so we can't assume its size.

~Additionally, the jm60 fix is similar to an almost identical fix which went out for the whitefox and other relevant keyboards a while back... it was just found when I was looking for other places we don't use memset properly.~ This broke and I don't know why, so I'm dropping this portion for now.