### PR TITLE
Added the possibility to have shifted(modded) tap dance combos

### DIFF
--- a/quantum/process_keycode/process_tap_dance.c
+++ b/quantum/process_keycode/process_tap_dance.c
@@ -79,6 +79,7 @@ static inline void process_tap_dance_action_on_dance_finished (qk_tap_dance_acti
     return;
   action->state.finished = true;
   add_mods(action->state.oneshot_mods);
+  add_weak_mods(action->state.weak_mods);
   send_keyboard_report();
   _process_tap_dance_action_fn (&action->state, action->user_data, action->fn.on_dance_finished);
 }
@@ -87,6 +88,7 @@ static inline void process_tap_dance_action_on_reset (qk_tap_dance_action_t *act
 {
   _process_tap_dance_action_fn (&action->state, action->user_data, action->fn.on_reset);
   del_mods(action->state.oneshot_mods);
+  del_weak_mods(action->state.weak_mods);
   send_keyboard_report();
 }
 
@@ -110,6 +112,8 @@ bool process_tap_dance(uint16_t keycode, keyrecord_t *record) {
       action->state.count++;
       action->state.timer = timer_read();
       action->state.oneshot_mods = get_oneshot_mods();
+      action->state.weak_mods = get_mods();
+      action->state.weak_mods |= get_weak_mods();
       process_tap_dance_action_on_each_tap (action);
 
       if (last_td && last_td != keycode) {

--- a/quantum/process_keycode/process_tap_dance.h
+++ b/quantum/process_keycode/process_tap_dance.h
@@ -25,6 +25,7 @@ typedef struct
 {
   uint8_t count;
   uint8_t oneshot_mods;
+  uint8_t weak_mods;
   uint16_t keycode;
   uint16_t timer;
   bool interrupted;


### PR DESCRIPTION
As discussed in #1707 

This code uses weak mods to store mods pressed before the tap dance is executed.