### PR TITLE
Adding stephengrier keymap for the tada68 keyboard.

### DIFF
--- a/keyboards/tada68/keymaps/stephengrier/config.h
+++ b/keyboards/tada68/keymaps/stephengrier/config.h
@@ -1,0 +1,3 @@
+#include "../../config.h"
+
+#define BACKLIGHT_BREATHING

--- a/keyboards/tada68/keymaps/stephengrier/keymap.c
+++ b/keyboards/tada68/keymaps/stephengrier/keymap.c
@@ -1,0 +1,52 @@
+#include "tada68.h"
+
+// Each layer gets a name for readability, which is then used in the keymap matrix below.
+// The underscores don't mean anything - you can have a layer called STUFF or any other name.
+// Layer names don't all need to be of the same length, obviously, and you can also skip them
+// entirely and just use numbers.
+#define _BL 0
+#define _FL 1
+
+#define _______ KC_TRNS
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  /* Keymap _BL: (Base Layer) Default Layer
+   * ,----------------------------------------------------------------.
+   * |Esc | 1|  2|  3|  4|  5|  6|  7|  8|  9|  0|  -|  =|Backsp |~ ` |
+   * |----------------------------------------------------------------|
+   * |Tab  |  Q|  W|  E|  R|  T|  Y|  U|  I|  O|  P|  [|  ]|  \  |Del |
+   * |----------------------------------------------------------------|
+   * |FN     |  A|  S|  D|  F|  G|  H|  J|  K|  L|  ;|  '|Return |PgUp|
+   * |----------------------------------------------------------------|
+   * |Shift   |  Z|  X|  C|  V|  B|  N|  M|  ,|  .|  /|Shift | Up|PgDn|
+   * |----------------------------------------------------------------|
+   * |Ctrl|Win |Alt |        Space          |Alt| FN|Ctrl|Lef|Dow|Rig |
+   * `----------------------------------------------------------------'
+   */
+[_BL] = KEYMAP_ANSI(
+  KC_ESC,    KC_1,   KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,   KC_0,   KC_MINS, KC_EQL, KC_BSPC,KC_GRV, \
+  KC_TAB,  KC_Q,   KC_W,   KC_E,   KC_R,   KC_T,   KC_Y,   KC_U,   KC_I,   KC_O,   KC_P,   KC_LBRC, KC_RBRC,KC_BSLS,KC_DEL, \
+  MO(_FL), KC_A,   KC_S,   KC_D,   KC_F,   KC_G,   KC_H,   KC_J,   KC_K,   KC_L,   KC_SCLN,KC_QUOT,         KC_ENT,KC_PGUP,  \
+  KC_LSFT,         KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,   KC_N,   KC_M,   KC_COMM,KC_DOT, KC_SLSH,   KC_RSFT,KC_UP,KC_PGDN, \
+  KC_LCTL, KC_LALT,KC_LGUI,                KC_SPC,                        KC_RALT,MO(_FL),KC_RCTRL, KC_LEFT,KC_DOWN,KC_RGHT),
+
+  /* Keymap _FL: Function Layer
+   * ,----------------------------------------------------------------.
+   * |   | F1|F2 |F3 |F4 |F5 |F6 |F7 |F8 |F9 |F10|F11|F12|Del    |Ins |
+   * |----------------------------------------------------------------|
+   * |     |   |Up |   |   |   |   |   |UP |   |   |   |   |     |Hme |
+   * |----------------------------------------------------------------|
+   * |      |<- |Dn | ->|   |   |   |<- |Dn | ->|   |   |        |End |
+   * |----------------------------------------------------------------|
+   * |        |   |BR |Bl-|BL |BL+|   |VU-|VU+|MUT|   |   McL|MsU|McR |
+   * |----------------------------------------------------------------|
+   * |    |    |    |                       |   |   |    |MsL|MsD|MsR |
+   * `----------------------------------------------------------------'
+   */
+[_FL] = KEYMAP_ANSI(
+  _______, KC_F1 ,KC_F2, KC_F3, KC_F4, KC_F5, KC_F6, KC_F7, KC_F8, KC_F9, KC_F10, KC_F11, KC_F12, KC_DEL, KC_INS ,  \
+  _______,_______, KC_UP,_______,_______, _______,_______,_______, KC_UP,_______,_______,_______,_______, _______,KC_HOME, \
+  _______,KC_LEFT,KC_DOWN,KC_RIGHT,_______,_______,_______,KC_LEFT,KC_DOWN,KC_RIGHT,_______,_______,        _______,KC_END, \
+  _______,_______,BL_BRTG,BL_DEC, BL_TOGG,BL_INC, _______,KC_VOLD,KC_VOLU,KC_MUTE,_______,KC_BTN1, KC_MS_U, KC_BTN2, \
+  _______,_______,_______,                 _______,               _______,_______,_______,KC_MS_L,KC_MS_D, KC_MS_R),
+};

--- a/keyboards/tada68/keymaps/stephengrier/readme.md
+++ b/keyboards/tada68/keymaps/stephengrier/readme.md
@@ -1,0 +1,15 @@
+# stephengrier's TADA68 layout
+
+This layout mostly replicates the default ANSI layout of the TADA68 but with a
+few modifications to suit my tastes.
+
+The modifications from the default keymap are:
+
+* Replaced capslock with a second function key
+* Swapped the left ALT and Win keys to be more like the Mac layout
+* Added an arrow key cluster on the IJKL keys
+* Fn+x toggles backlight breathing mode
+
+With this keymap backlight breathing mode can be enabled/disabled with Fn+x.
+This is not supported at all in the default keymap.
+

--- a/keyboards/tada68/keymaps/stephengrier/rules.mk
+++ b/keyboards/tada68/keymaps/stephengrier/rules.mk
@@ -1,0 +1,21 @@
+# Build Options
+#   change to "no" to disable the options, or define them in the Makefile in 
+#   the appropriate keymap folder that will get included automatically
+#
+BOOTMAGIC_ENABLE = no       # Virtual DIP switch configuration(+1000)
+MOUSEKEY_ENABLE = yes       # Mouse keys(+4700)
+EXTRAKEY_ENABLE = yes       # Audio control and System control(+450)
+CONSOLE_ENABLE = no         # Console for debug(+400)
+COMMAND_ENABLE = yes        # Commands for debug and configuration
+NKRO_ENABLE = yes           # Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+BACKLIGHT_ENABLE = yes       # Enable keyboard backlight functionality
+MIDI_ENABLE = no            # MIDI controls
+AUDIO_ENABLE = no           # Audio output on port C6
+UNICODE_ENABLE = no         # Unicode
+BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
+RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight.  Do not enable this with audio at the same time.
+SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
+
+ifndef QUANTUM_DIR
+	include ../../../../Makefile
+endif


### PR DESCRIPTION
This layout mostly replicates the default ANSI layout of the TADA68 but with a
few modifications to suit my tastes.

The modifications from the default keymap are:

* Replaced capslock with a second function key
* Swapped the left ALT and Win keys to be more like the Mac layout
* Added an arrow key cluster on the IJKL keys
* Fn+x toggles backlight breathing mode

With this keymap backlight breathing mode can be enabled/disabled with Fn+x.
This is not supported at all in the default keymap.