### PR TITLE
Fix compilation error when RGB light is disabled

### DIFF
--- a/keyboards/ergodox_ez/keymaps/default/keymap.c
+++ b/keyboards/ergodox_ez/keymaps/default/keymap.c
@@ -217,7 +217,9 @@ uint32_t layer_state_set_user(uint32_t state) {
         #ifdef RGBLIGHT_COLOR_LAYER_0
           rgblight_setrgb(RGBLIGHT_COLOR_LAYER_0);
         #else
+        #ifdef RGBLIGHT_ENABLE
           rgblight_init();
+        #endif
         #endif
         break;
       case 1:


### PR DESCRIPTION
When disabling RGB light for ergodox_ez, the compiler will raise an error:
```
implicit declaration of function 'rgblight_init'
```

You can reproduce it by disabling RGBLIGHT_ENABLE in rules.mk

This patch aims to fix this error.