### PR TITLE
Added KBD66

### DIFF
--- a/keyboards/kbd66/config.h
+++ b/keyboards/kbd66/config.h
@@ -1,0 +1,191 @@
+/*
+Copyright 2018 Alex Peters
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#include "config_common.h"
+
+/* USB Device descriptor parameter */
+#define VENDOR_ID       0xFEED
+#define PRODUCT_ID      0xBD66
+#define DEVICE_VER      0x0001
+#define MANUFACTURER    KBDFans
+#define PRODUCT         KBD66
+#define DESCRIPTION     QMK keyboard firmware for KBD66
+
+/* key matrix size */
+#define MATRIX_ROWS 5
+#define MATRIX_COLS 16
+
+/*
+ * Keyboard Matrix Assignments
+ *
+ * Change this to how you wired your keyboard
+ * COLS: AVR pins used for columns, left to right
+ * ROWS: AVR pins used for rows, top to bottom
+ * DIODE_DIRECTION: COL2ROW = COL = Anode (+), ROW = Cathode (-, marked on diode)
+ *                  ROW2COL = ROW = Anode (+), COL = Cathode (-, marked on diode)
+ *
+*/
+#define MATRIX_ROW_PINS { B0, B1, F0, F1, D4 } // From qmkeyboard.cn
+#define MATRIX_COL_PINS { C6, C7, E2, F5, F6, F4, D3, D2, D5, D0, D1, B4, D7, D6, E6, B3 }
+#define UNUSED_PINS
+
+/* COL2ROW, ROW2COL, or CUSTOM_MATRIX */
+#define DIODE_DIRECTION COL2ROW
+ 
+#define BACKLIGHT_PIN B6
+#define BACKLIGHT_LEVELS 3
+#define BACKLIGHT_BREATHING
+#define BREATHING_PERIOD 6
+
+
+/* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
+#define DEBOUNCING_DELAY 5
+
+/* define if matrix has ghost (lacks anti-ghosting diodes) */
+//#define MATRIX_HAS_GHOST
+
+/* number of backlight levels */
+
+/* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
+#define LOCKING_SUPPORT_ENABLE
+/* Locking resynchronize hack */
+#define LOCKING_RESYNC_ENABLE
+
+/* If defined, GRAVE_ESC will always act as ESC when CTRL is held.
+ * This is userful for the Windows task manager shortcut (ctrl+shift+esc).
+ */
+// #define GRAVE_ESC_CTRL_OVERRIDE
+
+/*
+ * Force NKRO
+ *
+ * Force NKRO (nKey Rollover) to be enabled by default, regardless of the saved
+ * state in the bootmagic EEPROM settings. (Note that NKRO must be enabled in the
+ * makefile for this to work.)
+ *
+ * If forced on, NKRO can be disabled via magic key (default = LShift+RShift+N)
+ * until the next keyboard reset.
+ *
+ * NKRO may prevent your keystrokes from being detected in the BIOS, but it is
+ * fully operational during normal computer usage.
+ *
+ * For a less heavy-handed approach, enable NKRO via magic key (LShift+RShift+N)
+ * or via bootmagic (hold SPACE+N while plugging in the keyboard). Once set by
+ * bootmagic, NKRO mode will always be enabled until it is toggled again during a
+ * power-up.
+ *
+ */
+//#define FORCE_NKRO
+
+/*
+ * Magic Key Options
+ *
+ * Magic keys are hotkey commands that allow control over firmware functions of
+ * the keyboard. They are best used in combination with the HID Listen program,
+ * found here: https://www.pjrc.com/teensy/hid_listen.html
+ *
+ * The options below allow the magic key functionality to be changed. This is
+ * useful if your keyboard/keypad is missing keys and you want magic key support.
+ *
+ */
+
+/* key combination for magic key command */
+#define IS_COMMAND() ( \
+    keyboard_report->mods == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT)) \
+)
+
+/* control how magic key switches layers */
+//#define MAGIC_KEY_SWITCH_LAYER_WITH_FKEYS  true
+//#define MAGIC_KEY_SWITCH_LAYER_WITH_NKEYS  true
+//#define MAGIC_KEY_SWITCH_LAYER_WITH_CUSTOM false
+
+/* override magic key keymap */
+//#define MAGIC_KEY_SWITCH_LAYER_WITH_FKEYS
+//#define MAGIC_KEY_SWITCH_LAYER_WITH_NKEYS
+//#define MAGIC_KEY_SWITCH_LAYER_WITH_CUSTOM
+//#define MAGIC_KEY_HELP1          H
+//#define MAGIC_KEY_HELP2          SLASH
+//#define MAGIC_KEY_DEBUG          D
+//#define MAGIC_KEY_DEBUG_MATRIX   X
+//#define MAGIC_KEY_DEBUG_KBD      K
+//#define MAGIC_KEY_DEBUG_MOUSE    M
+//#define MAGIC_KEY_VERSION        V
+//#define MAGIC_KEY_STATUS         S
+//#define MAGIC_KEY_CONSOLE        C
+//#define MAGIC_KEY_LAYER0_ALT1    ESC
+//#define MAGIC_KEY_LAYER0_ALT2    GRAVE
+//#define MAGIC_KEY_LAYER0         0
+//#define MAGIC_KEY_LAYER1         1
+//#define MAGIC_KEY_LAYER2         2
+//#define MAGIC_KEY_LAYER3         3
+//#define MAGIC_KEY_LAYER4         4
+//#define MAGIC_KEY_LAYER5         5
+//#define MAGIC_KEY_LAYER6         6
+//#define MAGIC_KEY_LAYER7         7
+//#define MAGIC_KEY_LAYER8         8
+//#define MAGIC_KEY_LAYER9         9
+//#define MAGIC_KEY_BOOTLOADER     PAUSE
+//#define MAGIC_KEY_LOCK           CAPS
+//#define MAGIC_KEY_EEPROM         E
+//#define MAGIC_KEY_NKRO           N
+//#define MAGIC_KEY_SLEEP_LED      Z
+
+/*
+ * Feature disable options
+ *  These options are also useful to firmware size reduction.
+ */
+
+/* disable debug print */
+//#define NO_DEBUG
+
+/* disable print */
+//#define NO_PRINT
+
+/* disable action features */
+//#define NO_ACTION_LAYER
+//#define NO_ACTION_TAPPING
+//#define NO_ACTION_ONESHOT
+//#define NO_ACTION_MACRO
+//#define NO_ACTION_FUNCTION
+
+/*
+ * MIDI options
+ */
+
+/* Prevent use of disabled MIDI features in the keymap */
+//#define MIDI_ENABLE_STRICT 1
+
+/* enable basic MIDI features:
+   - MIDI notes can be sent when in Music mode is on
+*/
+//#define MIDI_BASIC
+
+/* enable advanced MIDI features:
+   - MIDI notes can be added to the keymap
+   - Octave shift and transpose
+   - Virtual sustain, portamento, and modulation wheel
+   - etc.
+*/
+//#define MIDI_ADVANCED
+
+/* override number of MIDI tone keycodes (each octave adds 12 keycodes and allocates 12 bytes) */
+//#define MIDI_TONE_KEYCODE_OCTAVES 1
+
+#endif

--- a/keyboards/kbd66/kbd66.c
+++ b/keyboards/kbd66/kbd66.c
@@ -1,0 +1,43 @@
+/* Copyright 2018 Alex Peters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "kbd66.h"
+
+void matrix_init_kb(void) {
+	// put your keyboard start-up code here
+	// runs once when the firmware starts up
+
+	matrix_init_user();
+}
+
+void matrix_scan_kb(void) {
+	// put your looping keyboard code here
+	// runs every cycle (a lot)
+
+	matrix_scan_user();
+}
+
+bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
+	// put your per-action keyboard code here
+	// runs for every action, just before processing by the firmware
+
+	return process_record_user(keycode, record);
+}
+
+void led_set_kb(uint8_t usb_led) {
+	// put your keyboard LED indicator (ex: Caps Lock LED) toggling code here
+
+	led_set_user(usb_led);
+}

--- a/keyboards/kbd66/kbd66.h
+++ b/keyboards/kbd66/kbd66.h
@@ -1,0 +1,36 @@
+/* Copyright 2018 Alex Peters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef KBD66_H
+#define KBD66_H
+
+#include "quantum.h"
+
+// This a shortcut to help you visually see your layout.
+#define KEYMAP( \
+    k00, k01, k02, k03, k04, k05, k06, k07, k08, k09, k0A, k0B, k0C, k0D,k0E,  k0F, \
+    k10,  k11, k12, k13, k14, k15, k16, k17, k18, k19, k1A, k1B, k1C, k1D,     k1F, \
+    k20,   k21, k22, k23, k24, k25, k26, k27, k28, k29, k2A, k2B,   k2D, \
+    k30,  k31, k32, k33, k34, k35, k36, k37, k38, k39, k3A, k3B, k3C, k3D,  k3E, \
+    k40,   k41,  k42,             k45, k48,         k4A,  k4B, k4C,    k4D, k4E, k4F \
+) { \
+    { k00, k01, k02, k03,   k04,   k05, k06,   k07,   k08, k09,   k0A, k0B, k0C,   k0D, k0E,   k0F}, \
+    { k10, k11, k12, k13,   k14,   k15, k16,   k17,   k18, k19,   k1A, k1B, k1C,   k1D, KC_NO, k1F}, \
+    { k20, k21, k22, k23,   k24,   k25, k26,   k27,   k28, k29,   k2A, k2B, KC_NO, k2D, KC_NO, KC_NO}, \
+    { k30, k31, k32, k33,   k34,   k35, k36,   k37,   k38, k39,   k3A, k3B, k3C,   k3D, k3E,   KC_NO}, \
+    { k40, k41, k42, KC_NO, KC_NO, k45, KC_NO, KC_NO, k48, KC_NO, k4A, k4B, k4C,   k4D, k4E,   k4F}, \
+}
+
+#endif

--- a/keyboards/kbd66/keymaps/ansi/config.h
+++ b/keyboards/kbd66/keymaps/ansi/config.h
@@ -1,0 +1,24 @@
+/* Copyright 2018 Alex Peters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef CONFIG_USER_H
+#define CONFIG_USER_H
+
+#include "config_common.h"
+
+// place overrides here
+
+#endif

--- a/keyboards/kbd66/keymaps/ansi/keymap.c
+++ b/keyboards/kbd66/keymaps/ansi/keymap.c
@@ -1,0 +1,103 @@
+/* Copyright 2018 Alex Peters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "kbd66.h"
+
+#define _____ KC_TRNS
+#define XXXXX KC_NO
+#define _L0 0
+#define _L1 1
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+    /* Layer 0
+     * ,-----------------------------------------------------------.   ,---.
+     * |Esc|  1|  2|  3|  4|  5|  6|  7|  8|  9|  0|  -|  =| BckSp |   |INS|
+     * |-----------------------------------------------------------|   |---|
+     * |Tab  |  Q|  W|  E|  R|  T|  Y|  U|  I|  O|  P|  [|  ]|    \|   |DEL|
+     * |-----------------------------------------------------------|   `---'
+     * |Cap  |  A|  S|  D|  F|  G|  H|  J|  K|  L|  ;|  '|  Enter  |
+     * |---------------------------------------------------------------.
+     * |  Shift |  Z|  X|  C|  V|  B|  N|  M|  ,|  .|  /|   Shift  | UP|
+     * |-------------------------------------------------------------------.
+     * |Ctl |OS  |Alt |         Space           |Alt | Fn |Ctl |LFT|DWN|RIG|
+     * `-------------------------------------------------------------------'
+     */
+[_L0] = KEYMAP(
+  KC_GESC, KC_1, KC_2, KC_3, KC_4, KC_5, KC_6, KC_7, KC_8, KC_9, KC_0, KC_MINS, KC_EQL, XXXXX, KC_BSPC,        KC_INS,
+  KC_TAB,   KC_Q, KC_W, KC_E, KC_R, KC_T, KC_Y, KC_U, KC_I, KC_O, KC_P, KC_LBRC, KC_RBRC,   KC_BSLS,           KC_DEL,
+  KC_CAPS,     KC_A, KC_S, KC_D, KC_F, KC_G, KC_H, KC_J, KC_K, KC_L, KC_SCLN, KC_QUOT,    KC_ENT,
+  KC_LSFT, XXXXX, KC_Z, KC_X, KC_C, KC_V, KC_B, KC_N, KC_M, KC_COMM, KC_DOT, KC_SLSH, KC_RSFT, XXXXX, KC_UP,
+  KC_LCTL, KC_LGUI, KC_LALT,   KC_SPC, KC_SPC,               KC_RALT, MO(_L1), KC_RCTL,      KC_LEFT, KC_DOWN, KC_RGHT
+),
+
+    /* Layer 1
+     * ,-----------------------------------------------------------.   ,---.
+     * |  `| F1| F2| F3| F4| F5| F6| F7| F8| F9|F10|F11|F12|       |   |HOM|
+     * |-----------------------------------------------------------|   |---|
+     * |     |   |   |   |   |   |   |   |   |   |PSc|VDn|VUp| Mute|   |END|
+     * |-----------------------------------------------------------|   `---'
+     * |RESET|   |   |   |   |   |   |PRV|PLY|NXT|STP|   |         |
+     * |---------------------------------------------------------------.
+     * |        |   |   |   |   |   |   |   |BLB|BLC|Slp|          |PUp|
+     * |-------------------------------------------------------------------.
+     * |    |    |    |                         |    |    |    |   |PDn|SLk|
+     * `-------------------------------------------------------------------'
+     */
+[_L1] = KEYMAP(
+  KC_GRV, KC_F1, KC_F2, KC_F3, KC_F4, KC_F5, KC_F6, KC_F7, KC_F8, KC_F9, KC_F10, KC_F11, KC_F12, _____, _____,     KC_HOME,
+  _____,  _____, _____, _____, _____, _____, _____, _____, _____, _____, KC_PSCR, KC_VOLD, KC_VOLU, KC_MUTE,       KC_END,
+  RESET,  _____, _____, _____, _____, _____, _____, KC_MPRV, KC_MPLY, KC_MNXT, KC_MSTP, _____, _____,
+  _____, _____, _____, _____, _____, _____, _____, _____, _____, BL_BRTG, BL_STEP, KC_SLEP, _____, _____, KC_PGUP,
+  _____, _____, _____,                     _____, _____,                      _____, _____, _____, _____, KC_PGDN, KC_SLCK
+)
+
+};
+
+const uint16_t PROGMEM fn_actions[] = {
+
+};
+
+const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
+{
+  // MACRODOWN only works in this function
+      switch(id) {
+        case 0:
+          if (record->event.pressed) {
+            register_code(KC_RSFT);
+          } else {
+            unregister_code(KC_RSFT);
+          }
+        break;
+      }
+    return MACRO_NONE;
+};
+
+
+void matrix_init_user(void) {
+
+}
+
+void matrix_scan_user(void) {
+
+}
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  return true;
+}
+
+void led_set_user(uint8_t usb_led) {
+
+}

--- a/keyboards/kbd66/keymaps/ansi/readme.md
+++ b/keyboards/kbd66/keymaps/ansi/readme.md
@@ -1,0 +1,11 @@
+# ANSI keymap for KBD66
+
+![KBD66 Layout Image](https://i.imgur.com/Hmt5QDW.jpg)
+
+Your standard ANSI layout for the KBD66.  
+Cycle backlight: Fn + .  
+Backlight breathing: Fn + ,  
+Volume Up/Down: Fn + [ and Fn + ]  
+Mute: Fn + \  
+Sleep: Fn + /  
+Bootloader Mode: Fn + CapsLock  

--- a/keyboards/kbd66/keymaps/default/config.h
+++ b/keyboards/kbd66/keymaps/default/config.h
@@ -1,0 +1,24 @@
+/* Copyright 2018 Alex Peters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef CONFIG_USER_H
+#define CONFIG_USER_H
+
+#include "config_common.h"
+
+// place overrides here
+
+#endif

--- a/keyboards/kbd66/keymaps/default/keymap.c
+++ b/keyboards/kbd66/keymaps/default/keymap.c
@@ -1,0 +1,103 @@
+/* Copyright 2018 Alex Peters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "kbd66.h"
+
+#define _____ KC_TRNS
+#define XXXXX KC_NO
+#define _L0 0
+#define _L1 1
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+    /* Layer 0
+     * ,-----------------------------------------------------------.   ,---.
+     * |Esc|  1|  2|  3|  4|  5|  6|  7|  8|  9|  0|  -|  =|  `| BS|   |INS|
+     * |-----------------------------------------------------------|   |---|
+     * |Tab  |  Q|  W|  E|  R|  T|  Y|  U|  I|  O|  P|  [|  ]|    \|   |DEL|
+     * |-----------------------------------------------------------|   `---'
+     * |Cap  |  A|  S|  D|  F|  G|  H|  J|  K|  L|  ;|  '|  Enter  |
+     * |---------------------------------------------------------------.
+     * |Shft|  `|  Z|  X|  C|  V|  B|  N|  M|  ,|  .|  /| Shft |Fn | UP|
+     * |-------------------------------------------------------------------.
+     * |Ctl |OS  |Alt |         Space           |Alt | Fn |Ctl |LFT|DWN|RIG|
+     * `-------------------------------------------------------------------'
+     */
+[_L0] = KEYMAP(
+  KC_GESC, KC_1, KC_2, KC_3, KC_4, KC_5, KC_6, KC_7, KC_8, KC_9, KC_0, KC_MINS, KC_EQL, KC_GRV, KC_BSPC,            KC_INS,
+  KC_TAB,   KC_Q, KC_W, KC_E, KC_R, KC_T, KC_Y, KC_U, KC_I, KC_O, KC_P, KC_LBRC, KC_RBRC,   KC_BSLS,               KC_DEL,
+  KC_CAPS,     KC_A, KC_S, KC_D, KC_F, KC_G, KC_H, KC_J, KC_K, KC_L, KC_SCLN, KC_QUOT,    KC_ENT,
+  KC_LSFT, KC_NUBS, KC_Z, KC_X, KC_C, KC_V, KC_B, KC_N, KC_M, KC_COMM, KC_DOT, KC_SLSH, KC_RSFT, MO(_L1), KC_UP,
+  KC_LCTL, KC_LGUI, KC_LALT,   KC_SPC, KC_SPC,               KC_RALT, MO(_L1), KC_RCTL,          KC_LEFT, KC_DOWN, KC_RGHT
+),
+
+    /* Layer 1
+     * ,-----------------------------------------------------------.   ,---.
+     * |  `| F1| F2| F3| F4| F5| F6| F7| F8| F9|F10|F11|F12|   |   |   |HOM|
+     * |-----------------------------------------------------------|   |---|
+     * |     |   |   |   |   |   |   |   |   |   |PSc|VDn|VUp| Mute|   |END|
+     * |-----------------------------------------------------------|   `---'
+     * |RESET|   |   |   |   |   |   |PRV|PLY|NXT|STP|   |         |
+     * |---------------------------------------------------------------.
+     * |    |   |   |   |   |   |   |   |   |BLB|BLC|Slp|      |   |PUp|
+     * |-------------------------------------------------------------------.
+     * |    |    |    |                         |    |    |    |   |PDn|SLk|
+     * `-------------------------------------------------------------------'
+     */
+[_L1] = KEYMAP(
+  KC_GRV, KC_F1, KC_F2, KC_F3, KC_F4, KC_F5, KC_F6, KC_F7, KC_F8, KC_F9, KC_F10, KC_F11, KC_F12, _____, _____,  KC_HOME,
+  _____,  _____, _____, _____, _____, _____, _____, _____, _____, _____, KC_PSCR, KC_VOLD, KC_VOLU, KC_MUTE,    KC_END,
+  RESET,  _____, _____, _____, _____, _____, _____, KC_MPRV, KC_MPLY, KC_MNXT, KC_MSTP, _____, _____,
+  _____, _____, _____, _____, _____, _____, _____, _____, _____, BL_BRTG, BL_STEP, KC_SLEP, _____, _____, KC_PGUP,
+  _____, _____, _____,                     _____, _____,                   _____, _____, _____, _____, KC_PGDN, KC_SLCK
+)
+
+};
+
+const uint16_t PROGMEM fn_actions[] = {
+
+};
+
+const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
+{
+  // MACRODOWN only works in this function
+      switch(id) {
+        case 0:
+          if (record->event.pressed) {
+            register_code(KC_RSFT);
+          } else {
+            unregister_code(KC_RSFT);
+          }
+        break;
+      }
+    return MACRO_NONE;
+};
+
+
+void matrix_init_user(void) {
+
+}
+
+void matrix_scan_user(void) {
+
+}
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  return true;
+}
+
+void led_set_user(uint8_t usb_led) {
+
+}

--- a/keyboards/kbd66/keymaps/default/readme.md
+++ b/keyboards/kbd66/keymaps/default/readme.md
@@ -1,0 +1,12 @@
+# The default keymap for KBD66
+
+![KBD66 Layout Image](https://i.imgur.com/QNpHnMe.jpg)
+
+This is a fairly universal layout that supports standard ANSI, split backspace,
+split left shift, and split right shift.  
+Cycle backlight: Fn + .  
+Backlight breathing: Fn + ,  
+Volume Up/Down: Fn + [ and Fn + ]  
+Mute: Fn + \  
+Sleep: Fn + /  
+Bootloader Mode: Fn + CapsLock  

--- a/keyboards/kbd66/keymaps/iso/config.h
+++ b/keyboards/kbd66/keymaps/iso/config.h
@@ -1,0 +1,24 @@
+/* Copyright 2018 Alex Peters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef CONFIG_USER_H
+#define CONFIG_USER_H
+
+#include "config_common.h"
+
+// place overrides here
+
+#endif

--- a/keyboards/kbd66/keymaps/iso/keymap.c
+++ b/keyboards/kbd66/keymaps/iso/keymap.c
@@ -1,0 +1,103 @@
+/* Copyright 2018 Alex Peters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "kbd66.h"
+
+#define _____ KC_TRNS
+#define XXXXX KC_NO
+#define _L0 0
+#define _L1 1
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+    /* Layer 0
+     * ,-----------------------------------------------------------.   ,---.
+     * |Esc|  1|  2|  3|  4|  5|  6|  7|  8|  9|  0|  -|  =| BckSp |   |INS|
+     * |-----------------------------------------------------------|   |---|
+     * |Tab  |  Q|  W|  E|  R|  T|  Y|  U|  I|  O|  P|  [|  ]|     |   |DEL|
+     * |------------------------------------------------------|Ent |   `---'
+     * |Cap   |  A|  S|  D|  F|  G|  H|  J|  K|  L|  ;|  '|  #|    |
+     * |---------------------------------------------------------------.
+     * |Shft|  \|  Z|  X|  C|  V|  B|  N|  M|  ,|  .|  /| Shft |Fn | UP|
+     * |-------------------------------------------------------------------.
+     * |Ctl |OS  |Alt |         Space           |Alt | Fn |Ctl |LFT|DWN|RIG|
+     * `-------------------------------------------------------------------'
+     */
+[_L0] = KEYMAP(
+  KC_GESC, KC_1, KC_2, KC_3, KC_4, KC_5, KC_6, KC_7, KC_8, KC_9, KC_0, KC_MINS, KC_EQL, KC_GRV, KC_BSPC,            KC_INS,
+  KC_TAB,   KC_Q, KC_W, KC_E, KC_R, KC_T, KC_Y, KC_U, KC_I, KC_O, KC_P, KC_LBRC, KC_RBRC,   KC_NUHS,               KC_DEL,
+  KC_CAPS,     KC_A, KC_S, KC_D, KC_F, KC_G, KC_H, KC_J, KC_K, KC_L, KC_SCLN, KC_QUOT,    KC_ENT,
+  KC_LSFT, KC_NUBS, KC_Z, KC_X, KC_C, KC_V, KC_B, KC_N, KC_M, KC_COMM, KC_DOT, KC_SLSH, KC_RSFT, MO(_L1), KC_UP,
+  KC_LCTL, KC_LGUI, KC_LALT,   KC_SPC, KC_SPC,               KC_RALT, MO(_L1), KC_RCTL,          KC_LEFT, KC_DOWN, KC_RGHT
+),
+
+    /* Layer 1
+     * ,-----------------------------------------------------------.   ,---.
+     * |  `| F1| F2| F3| F4| F5| F6| F7| F8| F9|F10|F11|F12|   |   |   |HOM|
+     * |-----------------------------------------------------------|   |---|
+     * |     |   |   |   |   |   |   |   |   |   |PSc|VDn|VUp|     |   |END|
+     * |------------------------------------------------------|    |   `---'
+     * |RESET |   |   |   |   |   |   |PRV|PLY|NXT|STP|   |Mut|    |
+     * |---------------------------------------------------------------.
+     * |    |   |   |   |   |   |   |   |   |BLB|BLC|Slp|      |   |PUp|
+     * |-------------------------------------------------------------------.
+     * |    |    |    |                         |    |    |    |   |PDn|SLk|
+     * `-------------------------------------------------------------------'
+     */
+[_L1] = KEYMAP(
+  KC_GRV, KC_F1, KC_F2, KC_F3, KC_F4, KC_F5, KC_F6, KC_F7, KC_F8, KC_F9, KC_F10, KC_F11, KC_F12, _____, _____,  KC_HOME,
+  _____,  _____, _____, _____, _____, _____, _____, _____, _____, _____, KC_PSCR, KC_VOLD, KC_VOLU, KC_MUTE,    KC_END,
+  RESET,  _____, _____, _____, _____, _____, _____, KC_MPRV, KC_MPLY, KC_MNXT, KC_MSTP, _____, _____,
+  _____, _____, _____, _____, _____, _____, _____, _____, _____, BL_BRTG, BL_STEP, KC_SLEP, _____, _____, KC_PGUP,
+  _____, _____, _____,                     _____, _____,                   _____, _____, _____, _____, KC_PGDN, KC_SLCK
+)
+
+};
+
+const uint16_t PROGMEM fn_actions[] = {
+
+};
+
+const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
+{
+  // MACRODOWN only works in this function
+      switch(id) {
+        case 0:
+          if (record->event.pressed) {
+            register_code(KC_RSFT);
+          } else {
+            unregister_code(KC_RSFT);
+          }
+        break;
+      }
+    return MACRO_NONE;
+};
+
+
+void matrix_init_user(void) {
+
+}
+
+void matrix_scan_user(void) {
+
+}
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  return true;
+}
+
+void led_set_user(uint8_t usb_led) {
+
+}

--- a/keyboards/kbd66/keymaps/iso/readme.md
+++ b/keyboards/kbd66/keymaps/iso/readme.md
@@ -1,0 +1,11 @@
+# ISO keymap for KBD66
+
+![KBD66 Layout Image](https://i.imgur.com/q6GTOsb.jpg)
+
+Standard ISO layout for KBD66.  
+Cycle backlight: Fn + .  
+Backlight breathing: Fn + ,  
+Volume Up/Down: Fn + [ and Fn + ]  
+Mute: Fn + #  
+Sleep: Fn + /  
+Bootloader Mode: Fn + CapsLock  

--- a/keyboards/kbd66/readme.md
+++ b/keyboards/kbd66/readme.md
@@ -1,0 +1,15 @@
+# KBD66
+
+![KBD66](https://i.imgur.com/qtLuL2o.jpg)
+
+A 65% keyboard from KBDFans.
+
+Keyboard Maintainer: [Alex](https://github.com/allo-world)  
+Hardware Supported: KBD66, ATmega32U4  
+Hardware Availability: [KBDFans](https://kbdfans.cn), [Massdrop](https://www.massdrop.com/buy/kbd66-mechanical-keyboard-kit?mode=guest_open)
+
+Make example for this keyboard (after setting up your build environment):
+
+    make kbd66:default
+
+See [build environment setup](https://docs.qmk.fm/build_environment_setup.html) then the [make instructions](https://docs.qmk.fm/make_instructions.html) for more information.

--- a/keyboards/kbd66/rules.mk
+++ b/keyboards/kbd66/rules.mk
@@ -1,0 +1,68 @@
+# MCU name
+#MCU = at90usb1286
+MCU = atmega32u4
+
+# Processor frequency.
+#     This will define a symbol, F_CPU, in all source code files equal to the
+#     processor frequency in Hz. You can then use this symbol in your source code to
+#     calculate timings. Do NOT tack on a 'UL' at the end, this will be done
+#     automatically to create a 32-bit value in your source code.
+#
+#     This will be an integer division of F_USB below, as it is sourced by
+#     F_USB after it has run through any CPU prescalers. Note that this value
+#     does not *change* the processor frequency - it should merely be updated to
+#     reflect the processor speed set externally so that the code can use accurate
+#     software delays.
+F_CPU = 16000000
+
+
+#
+# LUFA specific
+#
+# Target architecture (see library "Board Types" documentation).
+ARCH = AVR8
+
+# Input clock frequency.
+#     This will define a symbol, F_USB, in all source code files equal to the
+#     input clock frequency (before any prescaling is performed) in Hz. This value may
+#     differ from F_CPU if prescaling is used on the latter, and is required as the
+#     raw input clock is fed directly to the PLL sections of the AVR for high speed
+#     clock generation for the USB and other AVR subsections. Do NOT tack on a 'UL'
+#     at the end, this will be done automatically to create a 32-bit value in your
+#     source code.
+#
+#     If no clock division is performed on the input clock inside the AVR (via the
+#     CPU clock adjust registers or the clock division fuses), this will be equal to F_CPU.
+F_USB = $(F_CPU)
+
+# Interrupt driven control endpoint task(+60)
+OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
+
+
+# Boot Section Size in *bytes*
+#   Teensy halfKay   512
+#   Teensy++ halfKay 1024
+#   Atmel DFU loader 4096
+#   LUFA bootloader  4096
+#   USBaspLoader     2048
+OPT_DEFS += -DBOOTLOADER_SIZE=4096
+
+
+# Build Options
+#   change yes to no to disable
+#
+BOOTMAGIC_ENABLE = no      # Virtual DIP switch configuration(+1000)
+MOUSEKEY_ENABLE = yes       # Mouse keys(+4700)
+EXTRAKEY_ENABLE = yes       # Audio control and System control(+450)
+CONSOLE_ENABLE = yes        # Console for debug(+400)
+COMMAND_ENABLE = yes        # Commands for debug and configuration
+# Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
+SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
+# if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+NKRO_ENABLE = no            # USB Nkey Rollover
+BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality on B7 by default
+MIDI_ENABLE = no            # MIDI support (+2400 to 4200, depending on config)
+UNICODE_ENABLE = no         # Unicode
+BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
+AUDIO_ENABLE = no           # Audio output on port C6
+FAUXCLICKY_ENABLE = no      # Use buzzer to emulate clicky switches


### PR DESCRIPTION
Created keyboard repository for KBD66.  
- Created default keymap. This keymaps supports most of the physical layouts possible on the KBD66, including split backspace, split left shift (ISO left shift), split right shift, and split space.
- Created ANSI keymap. This is just a standard layout seen on boards like the FC660m and Clueboard 66.
- Created ISO keymap. Supports standard ISO layout.

Wiring and pinout were sourced from [qmkeyboard.cn](http://qmkeyboard.cn).