### PR TITLE
Fix ChibiOS for MCUs with FPU support

### DIFF
--- a/keyboards/clueboard/60/rules.mk
+++ b/keyboards/clueboard/60/rules.mk
@@ -28,11 +28,13 @@ MCU  = cortex-m4
 # ARM version, CORTEX-M0/M1 are 6, CORTEX-M3/M4/M7 are 7
 ARMV = 7
 
+USE_FPU = yes
+
 # Vector table for application
 # 0x00000000-0x00001000 area is occupied by bootlaoder.*/
 # The CORTEX_VTOR... is needed only for MCHCK/Infinity KB
 # OPT_DEFS = -DCORTEX_VTOR_INIT=0x08005000
-OPT_DEFS = 
+OPT_DEFS =
 
 # Options to pass to dfu-util when flashing
 DFU_ARGS = -d 0483:df11 -a 0 -s 0x08000000 -R

--- a/tmk_core/chibios.mk
+++ b/tmk_core/chibios.mk
@@ -26,7 +26,7 @@ endif
 # Imported source files and paths
 CHIBIOS = $(TOP_DIR)/lib/chibios
 CHIBIOS_CONTRIB = $(TOP_DIR)/lib/chibios-contrib
-# Startup files. Try a few different locations, for compability with old versions and 
+# Startup files. Try a few different locations, for compability with old versions and
 # for things hardware in the contrib repository
 STARTUP_MK = $(CHIBIOS)/os/common/ports/ARMCMx/compilers/GCC/mk/startup_$(MCU_STARTUP).mk
 ifeq ("$(wildcard $(STARTUP_MK))","")
@@ -46,7 +46,7 @@ endif
 include $(PLATFORM_MK)
 
 
-BOARD_MK := 
+BOARD_MK :=
 
 ifneq ("$(wildcard $(KEYBOARD_PATH_5)/boards/$(BOARD)/board.mk)","")
     BOARD_PATH = $(KEYBOARD_PATH_5)
@@ -115,14 +115,14 @@ CHIBISRC = $(STARTUPSRC) \
        $(STREAMSSRC) \
 	   $(STARTUPASM) \
 	   $(PORTASM) \
-	   $(OSALASM)         
+	   $(OSALASM)
 
 CHIBISRC := $(patsubst $(TOP_DIR)/%,%,$(CHIBISRC))
-	   
+
 EXTRAINCDIRS += $(CHIBIOS)/os/license \
          $(STARTUPINC) $(KERNINC) $(PORTINC) $(OSALINC) \
          $(HALINC) $(PLATFORMINC) $(BOARDINC) $(TESTINC) \
-         $(STREAMSINC) $(CHIBIOS)/os/various 
+         $(STREAMSINC) $(CHIBIOS)/os/various
 
 #
 # Project, sources and paths
@@ -139,17 +139,17 @@ SIZE = arm-none-eabi-size
 AR = arm-none-eabi-ar
 NM = arm-none-eabi-nm
 HEX = $(OBJCOPY) -O $(FORMAT)
-EEP = 
+EEP =
 BIN = $(OBJCOPY) -O binary
 
-THUMBFLAGS = -DTHUMB_PRESENT -mno-thumb-interwork -DTHUMB_NO_INTERWORKING -mthumb -DTHUMB 
+THUMBFLAGS = -DTHUMB_PRESENT -mno-thumb-interwork -DTHUMB_NO_INTERWORKING -mthumb -DTHUMB
 
-COMPILEFLAGS += -fomit-frame-pointer 
+COMPILEFLAGS += -fomit-frame-pointer
 COMPILEFLAGS += -falign-functions=16
 COMPILEFLAGS += -ffunction-sections
 COMPILEFLAGS += -fdata-sections
 COMPILEFLAGS += -fno-common
-COMPILEFLAGS += $(THUMBFLAGS) 
+COMPILEFLAGS += $(THUMBFLAGS)
 
 CFLAGS += $(COMPILEFLAGS)
 
@@ -167,6 +167,22 @@ LDFLAGS += -Wl,--script=$(LDSCRIPT)$(LDSYMBOLS)
 OPT_DEFS += -DPROTOCOL_CHIBIOS
 
 MCUFLAGS = -mcpu=$(MCU)
+
+# FPU options default (Cortex-M4 and Cortex-M7 single precision).
+ifeq ($(USE_FPU_OPT),)
+  USE_FPU_OPT = -mfloat-abi=$(USE_FPU) -mfpu=fpv4-sp-d16 -fsingle-precision-constant
+endif
+
+# FPU-related options
+ifeq ($(USE_FPU),)
+  USE_FPU = no
+endif
+ifneq ($(USE_FPU),no)
+  OPT    += $(USE_FPU_OPT)
+  OPT_DEFS  += -DCORTEX_USE_FPU=TRUE
+else
+  OPT_DEFS  += -DCORTEX_USE_FPU=FALSE
+endif
 
 DEBUG = gdb
 

--- a/tmk_core/common/wait.h
+++ b/tmk_core/common/wait.h
@@ -13,13 +13,8 @@ extern "C" {
 #   define wait_us(us)  _delay_us(us)
 #elif defined PROTOCOL_CHIBIOS
 #   include "ch.h"
-#   if defined(STM32F3xx_MCUCONF)
-#       define wait_ms(ms) chSysPolledDelayX(MS2RTC(STM32_HCLK, (ms)))
-#       define wait_us(us) chSysPolledDelayX(US2RTC(STM32_HCLK, (us)))
-#   else
-#       define wait_ms(ms) chThdSleepMilliseconds(ms)
-#       define wait_us(us) chThdSleepMicroseconds(us)
-#   endif
+#   define wait_ms(ms) chThdSleepMilliseconds(ms)
+#   define wait_us(us) chThdSleepMicroseconds(us)
 #elif defined(__arm__)
 #   include "wait_api.h"
 #else  // Unit tests


### PR DESCRIPTION
This caused the Clueboard60% to hang. 

Unfortunately the fix is not complete yet, since it can still hang, but it's much less likeley to do so now.