### PR TITLE
Make new_project.sh a bit more robust

### DIFF
--- a/util/new_project.sh
+++ b/util/new_project.sh
@@ -12,19 +12,11 @@ cd "$(dirname "$0")/.."
 KEYBOARD=$1
 KEYBOARD_UPPERCASE=$(echo $1 | awk '{print toupper($0)}')
 
-mkdir keyboards/$1
-mkdir keyboards/$1/keymaps
-mkdir keyboards/$1/keymaps/default
-sed -e "s;%KEYBOARD%;$KEYBOARD;g" -e "s;%KEYBOARD_UPPERCASE%;$KEYBOARD_UPPERCASE;g" quantum/template/template.h > keyboards/$KEYBOARD/$KEYBOARD.h
-sed -e "s;%KEYBOARD%;$KEYBOARD;g" quantum/template/template.c > keyboards/$KEYBOARD/$KEYBOARD.c
-sed -e "s;%KEYBOARD%;$KEYBOARD;g" quantum/template/config.h > keyboards/$KEYBOARD/config.h
-sed -e "s;%KEYBOARD%;$KEYBOARD;g" quantum/template/readme.md > keyboards/$KEYBOARD/readme.md
-sed -e "s;%KEYBOARD%;$KEYBOARD;g" quantum/template/Makefile > keyboards/$KEYBOARD/Makefile
-sed -e "s;%KEYBOARD%;$KEYBOARD;g" quantum/template/rules.mk > keyboards/$KEYBOARD/rules.mk
-sed -e "s;%KEYBOARD%;$KEYBOARD;g" quantum/template/keymaps/default/config.h > keyboards/$KEYBOARD/keymaps/default/config.h
-sed -e "s;%KEYBOARD%;$KEYBOARD;g" quantum/template/keymaps/default/keymap.c > keyboards/$KEYBOARD/keymaps/default/keymap.c
-sed -e "s;%KEYBOARD%;$KEYBOARD;g" quantum/template/keymaps/default/Makefile > keyboards/$KEYBOARD/keymaps/default/Makefile
-sed -e "s;%KEYBOARD%;$KEYBOARD;g" quantum/template/keymaps/default/readme.md > keyboards/$KEYBOARD/keymaps/default/readme.md
+cp -r quantum/template keyboards/$KEYBOARD
+mv keyboards/$KEYBOARD/template.c keyboards/$KEYBOARD/$KEYBOARD.c
+mv keyboards/$KEYBOARD/template.h keyboards/$KEYBOARD/$KEYBOARD.h
+find keyboards/${KEYBOARD} -type f -exec sed -i "s;%KEYBOARD%;$KEYBOARD;g" {} \;
+find keyboards/${KEYBOARD} -type f -exec sed -i "s;%KEYBOARD_UPPERCASE%;$KEYBOARD_UPPERCASE;g" {} \;
 
 echo "######################################################"
 echo "# /keyboards/$KEYBOARD project created. To start"


### PR DESCRIPTION
It seems [this commit](https://github.com/qmk/qmk_firmware/commit/e2e387f8f83af67f5946ffd5d3a41ecc1f11132b) broke `new_project.sh`. This should fix it.