### PR TITLE
Remap msys2 usb, fix USB port detection

### DIFF
--- a/tmk_core/avr.mk
+++ b/tmk_core/avr.mk
@@ -183,6 +183,10 @@ avrdude: $(BUILD_DIR)/$(TARGET).hex check-size
 		done; \
 		echo ""; \
 		echo "Detected controller on USB port at $$USB"; \
+		if grep -q -s 'MINGW\|MSYS' /proc/version; then \
+			USB=`echo "$$USB" | perl -pne 's/\/dev\/ttyS(\d+)/COM.($$1+1)/e'`; \
+			echo "Remapped MSYS2 USB port to $$USB"; \
+		fi; \
 		sleep 1; \
 		avrdude -p $(MCU) -c avr109 -P $$USB -U flash:w:$(BUILD_DIR)/$(TARGET).hex; \
 	fi

--- a/util/msys2_install.sh
+++ b/util/msys2_install.sh
@@ -16,6 +16,7 @@ function install_avr {
     wget "http://ww1.microchip.com/downloads/en/DeviceDoc/avr8-gnu-toolchain-installer-3.5.4.91-win32.any.x86.exe"
     7z x avr8-gnu-toolchain-installer-3.5.4.91-win32.any.x86.exe
     rm avr8-gnu-toolchain-installer-3.5.4.91-win32.any.x86.exe
+    pacman --needed -S mingw-w64-x86_64-avrdude
 }
 
 function install_arm {


### PR DESCRIPTION
- Maps tty device in MSYS2 to correct COM port for use with avrdude. (Ex. /dev/ttyS2 -> /dev/COM3, /dev/ttyS0 -> /dev/COM1)
- Fix detection of USB port