### PR TITLE
katana60: fix bootloader size to work with PCB

### DIFF
--- a/keyboards/katana60/rules.mk
+++ b/keyboards/katana60/rules.mk
@@ -45,7 +45,7 @@ OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
 #   Atmel DFU loader 4096
 #   LUFA bootloader  4096
 #   USBaspLoader     2048
-OPT_DEFS += -DBOOTLOADER_SIZE=512
+OPT_DEFS += -DBOOTLOADER_SIZE=4096
 
 
 # Build Options


### PR DESCRIPTION
Hi I noticed that the `RESET` key on my `Katana60` only works correctly when changing to bootloader size to `-DBOOTLOADER_SIZE=4096`. 

Asking @rominronin to review this first as I am not sure if this is an actual bug or a wrong assumption on my side.