### PR TITLE
Add missing parenthesis back to backlight_tick to fix #2226

### DIFF
--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -904,7 +904,7 @@ void backlight_task(void) {
       _SFR_IO8((backlight_pin >> 4) + 2) &= ~_BV(backlight_pin & 0xF);
     #endif
   }
-  backlight_tick = backlight_tick + 1 % 16;
+  backlight_tick = (backlight_tick + 1) % 16;
 }
 #endif
 


### PR DESCRIPTION
xd60 and xd75 keyboards (others using soft PWM as well?) experience backlight flashing when this math is incorrect.

Fixes #2226.