### PR TITLE
Chimera Ortho fixes

### DIFF
--- a/keyboards/chimera_ortho/keymaps/gordon/keymap.c
+++ b/keyboards/chimera_ortho/keymaps/gordon/keymap.c
@@ -127,6 +127,7 @@ enum {
   CALC_PRINTSCREEN
 };
 
+#ifdef TAP_DANCE_ENABLE
 static xtap ttt_state = { 
   .is_press_action = true,
   .state = 0
@@ -202,7 +203,7 @@ qk_tap_dance_action_t tap_dance_actions[] = {
   [HOME_END] = ACTION_TAP_DANCE_DOUBLE(KC_END, KC_HOME),
   [TTT] = ACTION_TAP_DANCE_FN_ADVANCED(NULL,TTT_finished, TTT_reset),
 };
-
+#endif
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 

--- a/keyboards/chimera_ortho/matrix.c
+++ b/keyboards/chimera_ortho/matrix.c
@@ -21,11 +21,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <avr/io.h>
 #endif
 #include "wait.h"
+#include "action_layer.h"
 #include "print.h"
 #include "debug.h"
 #include "util.h"
 #include "matrix.h"
 #include "timer.h"
+#include QMK_KEYBOARD_H
 
 #if (MATRIX_COLS <= 8)
 #    define print_matrix_header()  print("\nr/c 01234567\n")
@@ -47,15 +49,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* matrix state(1:on, 0:off) */
 static matrix_row_t matrix[MATRIX_ROWS];
 
-__attribute__ ((weak))
-void matrix_init_quantum(void) {
-    matrix_init_kb();
-}
-
-__attribute__ ((weak))
-void matrix_scan_quantum(void) {
-    matrix_scan_kb();
-}
 
 __attribute__ ((weak))
 void matrix_init_kb(void) {

--- a/users/gordon/gordon.c
+++ b/users/gordon/gordon.c
@@ -17,6 +17,7 @@ const char secret[][64] = {
 
 
 
+#ifdef TAP_DANCE_ENABLE
 
 void register_hyper (void) { //Helper function to invoke Hyper
   register_code (KC_LSFT);
@@ -261,6 +262,7 @@ void bt_reset (qk_tap_dance_state_t *state, void *user_data) {
   }
   S1_state.state = 0;
 }
+#endif
 
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
   switch (keycode) {

--- a/users/gordon/gordon.h
+++ b/users/gordon/gordon.h
@@ -95,7 +95,7 @@ enum gordon_layers
 };
 
 
-
+#ifdef TAP_DANCE_ENABLE
 void register_hyper (void);
 void unregister_hyper (void);
 
@@ -131,6 +131,7 @@ void comma_reset (qk_tap_dance_state_t *state, void *user_data);
 
 void bt_finished (qk_tap_dance_state_t *state, void *user_data);
 void bt_reset (qk_tap_dance_state_t *state, void *user_data);
+#endif
 
 // Macro Declarations
 enum {


### PR DESCRIPTION
This fixes the Gordon keymap errors, by wrapping all the tap dance based code in `ifdef`s. 

And this removes the _quantum functions from the Chimera Ortho, since this breaks some of the core functionality, since it's overwriting the functions and not including the removed content (and it shouldn't be defined here anyways, not sure why it is, other than forking another board that did it, maybe)

Should probably get @GlenPickle and @DanielGGordon to okay first.