### PR TITLE
Add the ability to disable Music Mode completely

### DIFF
--- a/docs/feature_audio.md
+++ b/docs/feature_audio.md
@@ -82,6 +82,10 @@ The pitch standard (`PITCH_STANDARD_A`) is 440.0f by default - to change this, a
 
     #define PITCH_STANDARD_A 432.0f
 
+You can completely disable Music Mode as well. This is useful, if you're pressed for space on your controller.  To disable it, add this to your `confid.h`:
+
+    #define NO_MUSIC_MODE
+
 ## MIDI Functionality
 
 This is still a WIP, but check out `quantum/keymap_midi.c` to see what's happening. Enable from the Makefile.

--- a/keyboards/orthodox/keymaps/drashna/config.h
+++ b/keyboards/orthodox/keymaps/drashna/config.h
@@ -69,6 +69,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifdef AUDIO_ENABLE
 #define C6_AUDIO
 #define STARTUP_SONG SONG(IMPERIAL_MARCH)
+#define NO_MUSIC_MODE
 #endif
 
 #undef PRODUCT

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -139,7 +139,7 @@ void reset_keyboard(void) {
 #if defined(MIDI_ENABLE) && defined(MIDI_BASIC)
   process_midi_all_notes_off();
 #endif
-#if defined(AUDIO_ENABLE)
+#if defined(AUDIO_ENABLE) 
   music_all_notes_off();
   uint16_t timer_start = timer_read();
   PLAY_SONG(goodbye_song);
@@ -228,7 +228,7 @@ bool process_record_quantum(keyrecord_t *record) {
   #ifdef STENO_ENABLE
     process_steno(keycode, record) &&
   #endif
-  #if defined(AUDIO_ENABLE) || (defined(MIDI_ENABLE) && defined(MIDI_BASIC))
+  #if ( defined(AUDIO_ENABLE) || (defined(MIDI_ENABLE) && defined(MIDI_BASIC))) && !defined(NO_MUSIC_MODE) 
     process_music(keycode, record) &&
   #endif
   #ifdef TAP_DANCE_ENABLE
@@ -826,7 +826,7 @@ void matrix_init_quantum() {
 }
 
 void matrix_scan_quantum() {
-  #ifdef AUDIO_ENABLE
+  #if defined(AUDIO_ENABLE) 
     matrix_scan_music();
   #endif
 

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -139,7 +139,7 @@ void reset_keyboard(void) {
 #if defined(MIDI_ENABLE) && defined(MIDI_BASIC)
   process_midi_all_notes_off();
 #endif
-#if defined(AUDIO_ENABLE) 
+#if defined(AUDIO_ENABLE) && !defined(NO_MUSIC_MODE)
   music_all_notes_off();
   uint16_t timer_start = timer_read();
   PLAY_SONG(goodbye_song);

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -826,7 +826,7 @@ void matrix_init_quantum() {
 }
 
 void matrix_scan_quantum() {
-  #if defined(AUDIO_ENABLE) && !defined(NO_MUSIC_MODE)
+  #if defined(AUDIO_ENABLE)
     matrix_scan_music();
   #endif
 

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -826,7 +826,7 @@ void matrix_init_quantum() {
 }
 
 void matrix_scan_quantum() {
-  #if defined(AUDIO_ENABLE) 
+  #if defined(AUDIO_ENABLE) && !defined(NO_MUSIC_MODE)
     matrix_scan_music();
   #endif
 


### PR DESCRIPTION
This essentially completely removes the music mode. 

The feature is on by default (as to not interfere with existing keymaps/configs), so it has to be explicitly defined. 

Also, for whatever reason, removing "matrix_scan_music" from quantum.c causes it to be 150-200 bytes larger... so it's left in, for now. 