### PR TITLE
Remove _quantum functions from custom matrix.c code

### DIFF
--- a/keyboards/chimera_ortho/matrix.c
+++ b/keyboards/chimera_ortho/matrix.c
@@ -48,16 +48,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 static matrix_row_t matrix[MATRIX_ROWS];
 
 __attribute__ ((weak))
-void matrix_init_quantum(void) {
-    matrix_init_kb();
-}
-
-__attribute__ ((weak))
-void matrix_scan_quantum(void) {
-    matrix_scan_kb();
-}
-
-__attribute__ ((weak))
 void matrix_init_kb(void) {
     matrix_init_user();
 }

--- a/keyboards/deltasplit75/matrix.c
+++ b/keyboards/deltasplit75/matrix.c
@@ -82,15 +82,6 @@ static matrix_row_t matrix_debouncing[MATRIX_ROWS];
     static void unselect_col(uint8_t col);
     static void select_col(uint8_t col);
 #endif
-__attribute__ ((weak))
-void matrix_init_quantum(void) {
-    matrix_init_kb();
-}
-
-__attribute__ ((weak))
-void matrix_scan_quantum(void) {
-    matrix_scan_kb();
-}
 
 __attribute__ ((weak))
 void matrix_init_kb(void) {

--- a/keyboards/dichotemy/matrix.c
+++ b/keyboards/dichotemy/matrix.c
@@ -51,16 +51,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 static matrix_row_t matrix[MATRIX_ROWS];
 
 __attribute__ ((weak))
-void matrix_init_quantum(void) {
-    matrix_init_kb();
-}
-
-__attribute__ ((weak))
-void matrix_scan_quantum(void) {
-    matrix_scan_kb();
-}
-
-__attribute__ ((weak))
 void matrix_init_kb(void) {
     matrix_init_user();
 }

--- a/keyboards/eagle_viper/v2/matrix.c
+++ b/keyboards/eagle_viper/v2/matrix.c
@@ -33,15 +33,6 @@ static void init_rows(void);
 static void unselect_cols(void);
 static void select_col(uint8_t col);
 
-__attribute__ ((weak))
-void matrix_init_quantum(void) {
-    matrix_init_kb();
-}
-
-__attribute__ ((weak))
-void matrix_scan_quantum(void) {
-    matrix_scan_kb();
-}
 
 __attribute__ ((weak))
 void matrix_init_kb(void) {

--- a/keyboards/ergo42/matrix.c
+++ b/keyboards/ergo42/matrix.c
@@ -82,15 +82,6 @@ static matrix_row_t matrix_debouncing[MATRIX_ROWS];
     static void unselect_col(uint8_t col);
     static void select_col(uint8_t col);
 #endif
-__attribute__ ((weak))
-void matrix_init_quantum(void) {
-    matrix_init_kb();
-}
-
-__attribute__ ((weak))
-void matrix_scan_quantum(void) {
-    matrix_scan_kb();
-}
 
 __attribute__ ((weak))
 void matrix_init_kb(void) {

--- a/keyboards/fc660c/matrix.c
+++ b/keyboards/fc660c/matrix.c
@@ -86,15 +86,6 @@ static matrix_row_t _matrix0[MATRIX_ROWS];
 static matrix_row_t _matrix1[MATRIX_ROWS];
 
 
-__attribute__ ((weak))
-void matrix_init_quantum(void) {
-    matrix_init_kb();
-}
-
-__attribute__ ((weak))
-void matrix_scan_quantum(void) {
-    matrix_scan_kb();
-}
 
 __attribute__ ((weak))
 void matrix_init_kb(void) {

--- a/keyboards/fc980c/matrix.c
+++ b/keyboards/fc980c/matrix.c
@@ -85,15 +85,6 @@ static matrix_row_t _matrix0[MATRIX_ROWS];
 static matrix_row_t _matrix1[MATRIX_ROWS];
 
 
-__attribute__ ((weak))
-void matrix_init_quantum(void) {
-    matrix_init_kb();
-}
-
-__attribute__ ((weak))
-void matrix_scan_quantum(void) {
-    matrix_scan_kb();
-}
 
 __attribute__ ((weak))
 void matrix_init_kb(void) {

--- a/keyboards/handwired/promethium/matrix.c
+++ b/keyboards/handwired/promethium/matrix.c
@@ -74,15 +74,6 @@ static void unselect_rows(void);
 static void select_row(uint8_t row);
 static void unselect_row(uint8_t row);
 
-__attribute__ ((weak))
-void matrix_init_quantum(void) {
-    matrix_init_kb();
-}
-
-__attribute__ ((weak))
-void matrix_scan_quantum(void) {
-    matrix_scan_kb();
-}
 
 __attribute__ ((weak))
 void matrix_init_kb(void) {

--- a/keyboards/helix/rev1/matrix.c
+++ b/keyboards/helix/rev1/matrix.c
@@ -60,15 +60,6 @@ static void init_cols(void);
 static void unselect_rows(void);
 static void select_row(uint8_t row);
 
-__attribute__ ((weak))
-void matrix_init_quantum(void) {
-    matrix_init_kb();
-}
-
-__attribute__ ((weak))
-void matrix_scan_quantum(void) {
-    matrix_scan_kb();
-}
 
 __attribute__ ((weak))
 void matrix_init_kb(void) {

--- a/keyboards/helix/rev2/matrix.c
+++ b/keyboards/helix/rev2/matrix.c
@@ -62,15 +62,6 @@ static void unselect_rows(void);
 static void select_row(uint8_t row);
 static uint8_t matrix_master_scan(void);
 
-__attribute__ ((weak))
-void matrix_init_quantum(void) {
-    matrix_init_kb();
-}
-
-__attribute__ ((weak))
-void matrix_scan_quantum(void) {
-    matrix_scan_kb();
-}
 
 __attribute__ ((weak))
 void matrix_init_kb(void) {

--- a/keyboards/iris/matrix.c
+++ b/keyboards/iris/matrix.c
@@ -85,15 +85,7 @@ static matrix_row_t matrix_debouncing[MATRIX_ROWS];
     static void unselect_col(uint8_t col);
     static void select_col(uint8_t col);
 #endif
-__attribute__ ((weak))
-void matrix_init_quantum(void) {
-    matrix_init_kb();
-}
 
-__attribute__ ((weak))
-void matrix_scan_quantum(void) {
-    matrix_scan_kb();
-}
 
 __attribute__ ((weak))
 void matrix_init_kb(void) {

--- a/keyboards/kinesis/alvicstep/matrix.c
+++ b/keyboards/kinesis/alvicstep/matrix.c
@@ -43,15 +43,6 @@ static matrix_row_t read_row(uint8_t row);
 static void unselect_rows(void);
 static void select_rows(uint8_t row);
 
-__attribute__ ((weak))
-void matrix_init_quantum(void) {
-    matrix_init_kb();
-}
-
-__attribute__ ((weak))
-void matrix_scan_quantum(void) {
-    matrix_scan_kb();
-}
 
 __attribute__ ((weak))
 void matrix_init_kb(void) {

--- a/keyboards/lets_split/matrix.c
+++ b/keyboards/lets_split/matrix.c
@@ -82,15 +82,6 @@ static matrix_row_t matrix_debouncing[MATRIX_ROWS];
     static void unselect_col(uint8_t col);
     static void select_col(uint8_t col);
 #endif
-__attribute__ ((weak))
-void matrix_init_quantum(void) {
-    matrix_init_kb();
-}
-
-__attribute__ ((weak))
-void matrix_scan_quantum(void) {
-    matrix_scan_kb();
-}
 
 __attribute__ ((weak))
 void matrix_init_kb(void) {

--- a/keyboards/levinson/matrix.c
+++ b/keyboards/levinson/matrix.c
@@ -85,15 +85,6 @@ static matrix_row_t matrix_debouncing[MATRIX_ROWS];
     static void unselect_col(uint8_t col);
     static void select_col(uint8_t col);
 #endif
-__attribute__ ((weak))
-void matrix_init_quantum(void) {
-    matrix_init_kb();
-}
-
-__attribute__ ((weak))
-void matrix_scan_quantum(void) {
-    matrix_scan_kb();
-}
 
 __attribute__ ((weak))
 void matrix_init_kb(void) {

--- a/keyboards/lightsaver/matrix.c
+++ b/keyboards/lightsaver/matrix.c
@@ -34,15 +34,6 @@ static void init_rows(void);
 static void unselect_cols(void);
 static void select_col(uint8_t col);
 
-__attribute__ ((weak))
-void matrix_init_quantum(void) {
-    matrix_init_kb();
-}
-
-__attribute__ ((weak))
-void matrix_scan_quantum(void) {
-    matrix_scan_kb();
-}
 
 __attribute__ ((weak))
 void matrix_init_kb(void) {

--- a/keyboards/meira/matrix.c
+++ b/keyboards/meira/matrix.c
@@ -75,15 +75,6 @@ static bool read_rows_on_col(matrix_row_t current_matrix[], uint8_t current_col)
 static void unselect_cols(void);
 static void select_col(uint8_t col);
 
-__attribute__ ((weak))
-void matrix_init_quantum(void) {
-    matrix_init_kb();
-}
-
-__attribute__ ((weak))
-void matrix_scan_quantum(void) {
-    matrix_scan_kb();
-}
 
 __attribute__ ((weak))
 void matrix_init_kb(void) {

--- a/keyboards/minidox/matrix.c
+++ b/keyboards/minidox/matrix.c
@@ -60,15 +60,6 @@ static void init_cols(void);
 static void unselect_rows(void);
 static void select_row(uint8_t row);
 
-__attribute__ ((weak))
-void matrix_init_quantum(void) {
-    matrix_init_kb();
-}
-
-__attribute__ ((weak))
-void matrix_scan_quantum(void) {
-    matrix_scan_kb();
-}
 
 __attribute__ ((weak))
 void matrix_init_kb(void) {

--- a/keyboards/mitosis/matrix.c
+++ b/keyboards/mitosis/matrix.c
@@ -47,15 +47,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* matrix state(1:on, 0:off) */
 static matrix_row_t matrix[MATRIX_ROWS];
 
-__attribute__ ((weak))
-void matrix_init_quantum(void) {
-    matrix_init_kb();
-}
-
-__attribute__ ((weak))
-void matrix_scan_quantum(void) {
-    matrix_scan_kb();
-}
 
 __attribute__ ((weak))
 void matrix_init_kb(void) {

--- a/keyboards/nyquist/matrix.c
+++ b/keyboards/nyquist/matrix.c
@@ -82,15 +82,6 @@ static matrix_row_t matrix_debouncing[MATRIX_ROWS];
     static void unselect_col(uint8_t col);
     static void select_col(uint8_t col);
 #endif
-__attribute__ ((weak))
-void matrix_init_quantum(void) {
-    matrix_init_kb();
-}
-
-__attribute__ ((weak))
-void matrix_scan_quantum(void) {
-    matrix_scan_kb();
-}
 
 __attribute__ ((weak))
 void matrix_init_kb(void) {

--- a/keyboards/octagon/v1/matrix.c
+++ b/keyboards/octagon/v1/matrix.c
@@ -33,15 +33,6 @@ static void init_rows(void);
 static void unselect_cols(void);
 static void select_col(uint8_t col);
 
-__attribute__ ((weak))
-void matrix_init_quantum(void) {
-    matrix_init_kb();
-}
-
-__attribute__ ((weak))
-void matrix_scan_quantum(void) {
-    matrix_scan_kb();
-}
 
 __attribute__ ((weak))
 void matrix_init_kb(void) {

--- a/keyboards/octagon/v2/matrix.c
+++ b/keyboards/octagon/v2/matrix.c
@@ -33,15 +33,6 @@ static void init_rows(void);
 static void unselect_cols(void);
 static void select_col(uint8_t col);
 
-__attribute__ ((weak))
-void matrix_init_quantum(void) {
-    matrix_init_kb();
-}
-
-__attribute__ ((weak))
-void matrix_scan_quantum(void) {
-    matrix_scan_kb();
-}
 
 __attribute__ ((weak))
 void matrix_init_kb(void) {

--- a/keyboards/orthodox/matrix.c
+++ b/keyboards/orthodox/matrix.c
@@ -64,15 +64,6 @@ static void init_cols(void);
 static void unselect_rows(void);
 static void select_row(uint8_t row);
 
-__attribute__ ((weak))
-void matrix_init_quantum(void) {
-    matrix_init_kb();
-}
-
-__attribute__ ((weak))
-void matrix_scan_quantum(void) {
-    matrix_scan_kb();
-}
 
 __attribute__ ((weak))
 void matrix_init_kb(void) {

--- a/keyboards/viterbi/matrix.c
+++ b/keyboards/viterbi/matrix.c
@@ -82,15 +82,6 @@ static matrix_row_t matrix_debouncing[MATRIX_ROWS];
     static void unselect_col(uint8_t col);
     static void select_col(uint8_t col);
 #endif
-__attribute__ ((weak))
-void matrix_init_quantum(void) {
-    matrix_init_kb();
-}
-
-__attribute__ ((weak))
-void matrix_scan_quantum(void) {
-    matrix_scan_kb();
-}
 
 __attribute__ ((weak))
 void matrix_init_kb(void) {


### PR DESCRIPTION
I think that somebody copied the `/quantum/matrix.c` file, and never cleaned it up.  And then that got copied by others, and so on. 

It's defined as weak, so it may not be breaking anything, but ... 