### PR TITLE
make check_size work across platforms

### DIFF
--- a/tmk_core/rules.mk
+++ b/tmk_core/rules.mk
@@ -370,6 +370,7 @@ show_path:
 	@echo SRC=$(SRC)
 	@echo OBJ=$(OBJ)
 
+ifeq ($(CC),avr-gcc)
 check-size:
 	$(eval MAX_SIZE=$(shell n=`avr-gcc -E -mmcu=$(MCU) $(CFLAGS) $(OPT_DEFS) tmk_core/common/avr/bootloader_size.c 2> /dev/null | sed -ne '/^#/n;/^AVR_SIZE:/,$${s/^AVR_SIZE: //;p;}'`; echo $$(($$n)) || echo 0))
 	$(eval CURRENT_SIZE=$(shell if [ -f $(BUILD_DIR)/$(TARGET).hex ]; then $(SIZE) --target=$(FORMAT) $(BUILD_DIR)/$(TARGET).hex | $(AWK) 'NR==2 {print $$4}'; else printf 0; fi))
@@ -377,6 +378,10 @@ check-size:
 		$(SILENT) || printf "$(MSG_CHECK_FILESIZE)" | $(AWK_CMD); \
 		if [ $(CURRENT_SIZE) -gt $(MAX_SIZE) ]; then $(PRINT_WARNING_PLAIN); $(SILENT) || printf " * $(MSG_FILE_TOO_BIG)" ; else $(PRINT_OK); $(SILENT) || printf " * $(MSG_FILE_JUST_RIGHT)";  fi \
 	fi
+else
+check-size:
+	echo "(Firmware size check does not yet support $(MCU) microprocessors; skipping.)"
+endif
 
 # Create build directory
 $(shell mkdir -p $(BUILD_DIR) 2>/dev/null)

--- a/tmk_core/rules.mk
+++ b/tmk_core/rules.mk
@@ -371,7 +371,7 @@ show_path:
 	@echo OBJ=$(OBJ)
 
 check-size:
-	$(eval MAX_SIZE=$(shell n=`avr-gcc -E -mmcu=$(MCU) $(CFLAGS) $(OPT_DEFS) tmk_core/common/avr/bootloader_size.c 2> /dev/null | perl -ne 'print "$&\n" if /(?<=AVR_SIZE: ).+/'`; echo $$(($$n)) || echo 0))
+	$(eval MAX_SIZE=$(shell n=`avr-gcc -E -mmcu=$(MCU) $(CFLAGS) $(OPT_DEFS) tmk_core/common/avr/bootloader_size.c 2> /dev/null | sed -ne '/^#/n;/^AVR_SIZE:/,$${s/^AVR_SIZE: //;p;}'`; echo $$(($$n)) || echo 0))
 	$(eval CURRENT_SIZE=$(shell if [ -f $(BUILD_DIR)/$(TARGET).hex ]; then $(SIZE) --target=$(FORMAT) $(BUILD_DIR)/$(TARGET).hex | $(AWK) 'NR==2 {print $$4}'; else printf 0; fi))
 	if [ $(MAX_SIZE) -gt 0 ] && [ $(CURRENT_SIZE) -gt 0 ]; then \
 		$(SILENT) || printf "$(MSG_CHECK_FILESIZE)" | $(AWK_CMD); \


### PR DESCRIPTION
fixes #2252
fixes #2152 
fixes #2307 
closes #2189 

There have been some troubles making check_size work across all platforms used to compile QMK.

check_size is tricky because it needs to discover how much space is available on the chip being flashed, to calculate if the hex file it just compiled is too big. That data is set into the `FLASHEND` C macro at compile time by the C preprocessor, but only when invoked with definitions that avr-gcc sets in response to the -m flag. So we can't simply look it up from the environment, nor can we compile a host-native C program that outputs the value of the macro for make to use.

Our solution seems to be to use avr-gcc to invoke only the preprocessor on a simplistic pseudo-c language file, to get it to resolve the macros. We have to filter everything out of the output except the numbers we want, and then interpret the resulting arithmetic expression using other tools, which in the case of grep, sed, and shell behave slightly differently on different platforms.

#2299 seems to have almost solved the problem (#2122) by using perl, which is often preinstalled on Linux and OSX machines and is more reliably consistent across platforms. But on my Debian machine, the input passed into it from avr-gcc is split across multiple lines interspersed with comments and does not correctly get output for arithmetic evaluation.

Unfortunately I don't know perl anymore well enough to update the regex @ErinCall authored, so I've returned to using sed, but still no grep. But I tested that this syntax works on FreeBSD sed (should be similar to OSX), and I tested both with and without comments and newlines from the preprocessor.

This PR is similar to that of #2189 by @skullydazed but avoids the use of grep and should successfully avoid the problem reported in its comments.

I tested this manually at the command line so this patch would still benefit from OSX and BSD users verifying that the check_size invoked by "make" now (or still) does what it should, before merge.

If we prefer to keep perl and someone figures out a way to improve the regex to accomplish the same, I'm happy to see that change accepted and this PR closed instead.

Edit: boards using `MCU=cortex-m4` are not compiled by avr-gcc and so are unsupported by check-size as currently implemented. For now, I've wrapped the rule in a Makefile conditional to disable it when not targeting an avr chip, because the logic in check-size to handle that failure from within a pipe is difficult to fix in a cross-platform way.