### PR TITLE
mitosis:datagrok: minor layout improvements

### DIFF
--- a/keyboards/mitosis/keymaps/datagrok/keymap.c
+++ b/keyboards/mitosis/keymaps/datagrok/keymap.c
@@ -30,7 +30,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     {KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P},
     {KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN},
     {KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_QUOT},
-    {XXXXXXX, KC_LSUP, KC_LCTL, MO(_xN), KC_LSFT, KC_RSFT, MO(_xN), KC_RCTL, KC_RSUP, XXXXXXX},
+    {XXXXXXX, KC_LSUP, KC_LCTL, MO(_xN), SFT_T(KC_TAB), KC_RSFT, MO(_xN), KC_RCTL, KC_RSUP, XXXXXXX},
     {XXXXXXX, KC_LHYP, KC_LMTA, MO(_xS), KC_BSPC, KC_SPC,  MO(_xS), KC_RMTA, KC_RHYP, XXXXXXX}
   },
   [_xW] = {

--- a/keyboards/mitosis/keymaps/datagrok/keymap.c
+++ b/keyboards/mitosis/keymaps/datagrok/keymap.c
@@ -2,8 +2,8 @@
 
 enum mitosis_layers
 {
-    _xW, // workman
     _xQ, // qwerty
+    _xW, // workman
     _xS, // symbols
     _xN, // numbers
     _xF  // functions
@@ -27,17 +27,17 @@ enum mitosis_layers
 // other is released. Which doesn't bother me.
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-  [_xW] = {
-    {KC_Q,    KC_D,    KC_R,    KC_W,    KC_B,    KC_J,    KC_F,    KC_U,    KC_P,    KC_SCLN},
-    {KC_A,    KC_S,    KC_H,    KC_T,    KC_G,    KC_Y,    KC_N,    KC_E,    KC_O,    KC_I},
-    {KC_Z,    KC_X,    KC_M,    KC_C,    KC_V,    KC_K,    KC_L,    KC_COMM, KC_DOT,  KC_QUOT},
-    {XXXXXXX, KC_LSUP, KC_LCTL, MO(_xN), KC_LSFT, KC_RSFT, MO(_xN), KC_RCTL, KC_RSUP, XXXXXXX},
-    {XXXXXXX, KC_LHYP, KC_LMTA, MO(_xS), KC_BSPC, KC_SPC,  MO(_xS), KC_RMTA, KC_RHYP, XXXXXXX}
-  },
   [_xQ] = {
     {KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P},
     {KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN},
     {KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_QUOT},
+    {XXXXXXX, KC_LSUP, KC_LCTL, MO(_xN), KC_LSFT, KC_RSFT, MO(_xN), KC_RCTL, KC_RSUP, XXXXXXX},
+    {XXXXXXX, KC_LHYP, KC_LMTA, MO(_xS), KC_BSPC, KC_SPC,  MO(_xS), KC_RMTA, KC_RHYP, XXXXXXX}
+  },
+  [_xW] = {
+    {KC_Q,    KC_D,    KC_R,    KC_W,    KC_B,    KC_J,    KC_F,    KC_U,    KC_P,    KC_SCLN},
+    {KC_A,    KC_S,    KC_H,    KC_T,    KC_G,    KC_Y,    KC_N,    KC_E,    KC_O,    KC_I},
+    {KC_Z,    KC_X,    KC_M,    KC_C,    KC_V,    KC_K,    KC_L,    KC_COMM, KC_DOT,  KC_QUOT},
     {XXXXXXX, _______, _______, _______, _______, _______, _______, _______, _______, XXXXXXX},
     {XXXXXXX, _______, _______, _______, _______, _______, _______, _______, _______, XXXXXXX}
   },
@@ -58,7 +58,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   [_xF] = {
     {_______, _______, KC_PGUP, _______, KC_VOLU, KC_F13,  KC_F7,   KC_F8,   KC_F9,   KC_F10},
     {_______, KC_HOME, KC_PGDN, KC_END,  KC_VOLD, KC_F14,  KC_F4,   KC_F5,   KC_F6,   KC_F11},
-    {TG(_xQ), KC_MPRV, KC_MPLY, KC_MNXT, KC_MUTE, KC_F15,  KC_F1,   KC_F2,   KC_F3,   KC_F12},
+    {TG(_xW), KC_MPRV, KC_MPLY, KC_MNXT, KC_MUTE, KC_F15,  KC_F1,   KC_F2,   KC_F3,   KC_F12},
     {XXXXXXX, _______, _______, ___M___, _______, _______, ___M___, _______, _______, XXXXXXX},
     {XXXXXXX, _______, _______, _______, ___M___, ___M___, _______, _______, _______, XXXXXXX},
   },

--- a/keyboards/mitosis/keymaps/datagrok/keymap.c
+++ b/keyboards/mitosis/keymaps/datagrok/keymap.c
@@ -48,7 +48,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     {XXXXXXX, _______, _______, _______, KC_DEL,  KC_ENT,  _______, _______, _______, XXXXXXX},
   },
   [_xN] = {
-    {_______, _______, _______, _______, _______, KC_PSLS, KC_P7,   KC_P8,   KC_P9,   KC_P0},
+    {_______, _______, _______, _______, KC_NLCK, KC_PSLS, KC_P7,   KC_P8,   KC_P9,   KC_P0},
     {_______, _______, _______, _______, _______, KC_PAST, KC_P4,   KC_P5,   KC_P6,   KC_PPLS},
     {_______, _______, _______, _______, _______, KC_PMNS, KC_P1,   KC_P2,   KC_P3,   KC_PEQL},
     {XXXXXXX, _______, _______, _______, _______, _______, _______, _______, _______, XXXXXXX},

--- a/keyboards/mitosis/keymaps/datagrok/keymap.c
+++ b/keyboards/mitosis/keymaps/datagrok/keymap.c
@@ -12,7 +12,6 @@ enum mitosis_layers
 // Fillers to make layering more clear
 #define XXXXXXX KC_NO   // No-op (no key in this location on Mitosis' fake matrix)
 #define _______ KC_TRNS // Transparent, because I haven't decided a mapping yet
-#define ___M___ KC_TRNS // Transparent, as required by modifier key on another layer
 #define KC_LMTA KC_LALT // For fun, name the mods like the space cadet keyboard does
 #define KC_RMTA KC_RALT // META
 #define KC_LSUP KC_LGUI // SUPER
@@ -46,21 +45,21 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     {KC_TAB,  KC_LEFT, KC_DOWN, KC_RGHT, _______, KC_CIRC, KC_AMPR, KC_PIPE, KC_GRV,  KC_UNDS},
     {KC_BSLS, KC_RPRN, KC_RCBR, KC_RBRC, KC_RABK, KC_LABK, KC_LBRC, KC_LCBR, KC_LPRN, KC_SLSH},
     {XXXXXXX, _______, _______, MO(_xF), _______, _______, MO(_xF), _______, _______, XXXXXXX},
-    {XXXXXXX, _______, _______, ___M___, KC_DEL,  KC_ENT,  ___M___, _______, _______, XXXXXXX},
+    {XXXXXXX, _______, _______, _______, KC_DEL,  KC_ENT,  _______, _______, _______, XXXXXXX},
   },
   [_xN] = {
     {_______, _______, _______, _______, _______, KC_PSLS, KC_P7,   KC_P8,   KC_P9,   KC_P0},
     {_______, _______, _______, _______, _______, KC_PAST, KC_P4,   KC_P5,   KC_P6,   KC_PPLS},
     {_______, _______, _______, _______, _______, KC_PMNS, KC_P1,   KC_P2,   KC_P3,   KC_PEQL},
-    {XXXXXXX, _______, _______, ___M___, _______, _______, ___M___, _______, _______, XXXXXXX},
+    {XXXXXXX, _______, _______, _______, _______, _______, _______, _______, _______, XXXXXXX},
     {XXXXXXX, _______, _______, MO(_xF), _______, KC_PENT, MO(_xF), _______, _______, XXXXXXX},
   },
   [_xF] = {
     {_______, _______, KC_PGUP, _______, KC_VOLU, KC_F13,  KC_F7,   KC_F8,   KC_F9,   KC_F10},
     {_______, KC_HOME, KC_PGDN, KC_END,  KC_VOLD, KC_F14,  KC_F4,   KC_F5,   KC_F6,   KC_F11},
     {TG(_xW), KC_MPRV, KC_MPLY, KC_MNXT, KC_MUTE, KC_F15,  KC_F1,   KC_F2,   KC_F3,   KC_F12},
-    {XXXXXXX, _______, _______, ___M___, _______, _______, ___M___, _______, _______, XXXXXXX},
-    {XXXXXXX, _______, _______, _______, ___M___, ___M___, _______, _______, _______, XXXXXXX},
+    {XXXXXXX, _______, _______, _______, _______, _______, _______, _______, _______, XXXXXXX},
+    {XXXXXXX, _______, _______, _______, _______, _______, _______, _______, _______, XXXXXXX},
   },
 };
 

--- a/keyboards/mitosis/keymaps/datagrok/readme.md
+++ b/keyboards/mitosis/keymaps/datagrok/readme.md
@@ -1,6 +1,6 @@
-![mitosis:datagrok layout image](https://i.imgur.com/Lt0t0nq.png)
+![mitosis:datagrok layout image](https://i.imgur.com/MnzeKjZ.png)
 
-[Keyboard layout editor source](http://www.keyboard-layout-editor.com/#/gists/e1a6a7a480fd4984c0bed38ee35f6c4f)
+[Keyboard layout editor source](http://www.keyboard-layout-editor.com/#/gists/9cf33be8a8e773647cfa44a0dbc44b31)
 
 # a layout for the Mitosis
 

--- a/keyboards/mitosis/keymaps/datagrok/readme.md
+++ b/keyboards/mitosis/keymaps/datagrok/readme.md
@@ -8,17 +8,23 @@
   symmetrically, but distinguishable left/right by the OS. Shift, Red
   ("Lower"), Blue ("Raise"), Super ("Windows"), Meta ("Alt"), Hyper.
 
-- Fn1 and Fn2 are used to momentary-enable (like a shift key) one of three layers:
+- Red and Blue are used to momentary-enable (like a shift key) one of three layers:
 
     - Red: Symbols layer
     - Blue: Numbers layer
-    - Both: Functions layer
+    - "Purple" (both Red and Blue): Functions layer
 
 - The base layer is QWERTY. A slight variant of [Workman][] may be toggled-on.
 
+- Emphasis on minimizing hand travel, so as not to lose orientation with
+  homerow.
+
 - Paired programming symbols (braces, brackets, parentheses) are arranged
-  symmetrically in the symbols layer. `?` and `!` are moved to take the place
-  of `<` and `>`.
+  symmetrically in the symbols layer.
+
+- `?` and `!` are moved to take the place of `<` and `>`. Rationale: unmodded
+  and shifted keys should be for prose, while symbols useful for programming
+  should be colocated on their own layer.
 
 - No OS keymap modification required.
 
@@ -30,16 +36,23 @@
     - Remove the lines in `rules.mk` mentioning `F_CPU` and `F_USB`.
     - Remove the lines in `config.h` mentioning `SERIAL_UART_BAUD`.
 
-- I'm learning a new key placement, so might as well go all out and use an
-  optimal non-QWERTY layout.
+- Workman layout
 
-- I like the way Workman feels and some of its advantages over Colemak.
-  Unfortunately, it was designed using a weighting system based on a standard
-  column-staggered keyboard so is probably not as optimal as one could achieve
-  on an ergonomic board like the Mitosis.
+    - I'm learning a new physical key placement, so I might as well go all out
+      and use an optimal non-QWERTY layout.
+
+    - I like the way Workman feels and some of its advantages over Colemak.
+      Unfortunately, it was designed using a weighting system based on a
+      standard column-staggered keyboard so is probably not as optimal as one
+      could achieve on an ergonomic board like the Mitosis. Maybe run an
+      optimizer routine after I determine good values for key difficulty on the
+      Mitosis.
 
 - Arrows in the home position (on a layer). Mod+Arrows = PgUp/PgDn/Home/End,
   which is intuitive for me
+
+- I use tab all the time for autocompletion. To allow it to live on the base
+  layer it is now Mod-Tapped with left shift.
 
 ### Abandoned ideas
 
@@ -52,9 +65,11 @@
       activates a symbols layer where all brackets are easily accessible.
 
 - Space/Enter to the left of layer select for Enter doesn't work well; I always
-  trigger space first.
+  trigger space first when mashing the keys simultaneously. This might not
+  continue to be true if I change the angle at which I strike the keys e.g.
+  with a neoprene base or a wrist support.
 
-- I used to have Blue layer on ring finger, but that was too hard to use in
+- I used to have Blue on ring finger, but that was too hard to use in
   conjunction with shift.
 
 ## To do
@@ -63,11 +78,13 @@
     - Is any board nonresponsive (which one?)
     - Does either board have a low battery?
 - Add Insert, PrintScr, Pause/Break
-- Make QWERTY base layer for people who customize layout in software? Store
-  default base layer in eeprom?
-- See if the henkans placement is at all useful for Japanese speakers, or abuse
-  different keysyms
-- Mod a speaker onto my receiver and enable tones
+- ~~Make QWERTY base layer for people who customize layout in software?~~ I
+  default to QWERTY now.
+- Store default base layer in eeprom?
+- See if the henkan/muhenkan placement is at all useful for Japanese speakers,
+  or abuse different keysyms for Left/Right Hyper. (Original space cadet used
+  scancodes 145/175. 145 is LANG2, 175 is "reserved" in USB HID spec.)
+- Mod a buzzer onto my receiver and enable tones
 - Implement "layer lock" key
 - Improve tri-layer behavior
 

--- a/keyboards/mitosis/keymaps/datagrok/readme.md
+++ b/keyboards/mitosis/keymaps/datagrok/readme.md
@@ -1,20 +1,20 @@
-![mitosis:datagrok layout image](https://i.imgur.com/MnzeKjZ.png)
+![mitosis:datagrok layout image](https://i.imgur.com/eum3fsc.png)
 
 [Keyboard layout editor source](http://www.keyboard-layout-editor.com/#/gists/9cf33be8a8e773647cfa44a0dbc44b31)
 
 # a layout for the Mitosis
 
 - Emphasis on momentary modifiers, all usable from either hand, arranged
-  symmetrically, but distinguishable left/right by the OS. Shift, Fn1
-  ("Lower"), Fn2 ("Raise"), Super ("Windows"), Meta ("Alt"), Hyper.
+  symmetrically, but distinguishable left/right by the OS. Shift, Red
+  ("Lower"), Blue ("Raise"), Super ("Windows"), Meta ("Alt"), Hyper.
 
 - Fn1 and Fn2 are used to momentary-enable (like a shift key) one of three layers:
 
-    - Fn1 (Red): Symbols layer
-    - Fn2 (Blue): Numbers layer
+    - Red: Symbols layer
+    - Blue: Numbers layer
     - Both: Functions layer
 
-- The base layer is a slight variant of [Workman][]. QWERTY may be toggled-on.
+- The base layer is QWERTY. A slight variant of [Workman][] may be toggled-on.
 
 - Paired programming symbols (braces, brackets, parentheses) are arranged
   symmetrically in the symbols layer. `?` and `!` are moved to take the place

--- a/keyboards/mitosis/keymaps/datagrok/readme.md
+++ b/keyboards/mitosis/keymaps/datagrok/readme.md
@@ -74,6 +74,8 @@
 
 ## To do
 
+- Figure out where to place non-numpad numbers so we don't need num lock turned
+  on to type them?
 - Improve LED indications (may require modding bluetooth firmware):
     - Is any board nonresponsive (which one?)
     - Does either board have a low battery?


### PR DESCRIPTION
Minor changes to the datagrok layout of the mitosis keyboard only.

- Makes QWERTY the default which should make this layout easier to try for others. Workman now may be toggled-on.
- Num Lock must be on for numbers to work. Added a Num Lock key on Blue + T
- Added a bunch of notes in the README, updated the layout image, etc.
- Special macro name for "transparent with a mod underneath" was tedious; lose it
- Tab is used all the time for autocomplete; place it on left-shift.