### PR TITLE
Added support for the Knops Configurator for the Knops Mini Macropad

### DIFF
--- a/keyboards/knops/mini/keymaps/knops/config.h
+++ b/keyboards/knops/mini/keymaps/knops/config.h
@@ -1,0 +1,24 @@
+/* Copyright 2017 Pawnerd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef CONFIG_USER_H
+#define CONFIG_USER_H
+
+#include "../../config.h"
+
+// place overrides here
+
+#endif

--- a/keyboards/knops/mini/keymaps/knops/keymap.c
+++ b/keyboards/knops/mini/keymaps/knops/keymap.c
@@ -1,0 +1,127 @@
+#include "mini.h"
+
+/*KNOPS_MISC*/
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+	/*KNOPS_KEYMAP*/
+
+};
+
+void set_led_state(int ledId, bool state) {
+	if(state) {
+		switch(ledId) {
+			/* LED 0 to 5 are the leds of each keyswitch. From left to right, top to bottom. These are equal to the numbers in the legends of the default keycaps. */
+			case 0:
+				PORTD |= (1<<7);
+				break;
+			case 1:
+				PORTC |= (1<<6);
+				break;
+			case 2:
+				PORTD |= (1<<4);
+				break;
+			case 3:
+				PORTE |= (1<<6);
+				break;
+			case 4:
+				PORTB |= (1<<4);
+				break;
+			case 5:
+				PORTD |= (1<<6);
+				break;
+				/* LED 6 to 8 are the three layer leds in front of the device from left to right. */
+			case 6:
+				PORTD &= ~(1<<5);
+				break;
+			case 7:
+				PORTB |= (1<<6);
+				break;
+			case 8:
+				PORTB &= ~(1<<0);
+				break;
+		}
+	} else {
+		switch(ledId) {
+			case 0:
+				PORTD &= ~(1<<7);
+				break;
+			case 1:
+				PORTC &= ~(1<<6);
+				break;
+			case 2:
+				PORTD &= ~(1<<4);
+				break;
+			case 3:
+				PORTE &= ~(1<<6);
+				break;
+			case 4:
+				PORTB &= ~(1<<4);
+				break;
+			case 5:
+				PORTD &= ~(1<<6);
+				break;
+			case 6:
+				PORTD |= (1<<5);
+				break;
+			case 7:
+				PORTB &= ~(1<<6);
+				break;
+			case 8:
+				PORTB |= (1<<0);
+				break;
+		}
+	}
+}
+
+void led_init_ports() {
+	DDRD |= (1<<7);
+	DDRC |= (1<<6);
+	DDRD |= (1<<4);
+	DDRE |= (1<<6);
+	DDRB |= (1<<4);
+	DDRD |= (1<<6);
+
+	DDRD |= (1<<5);
+	DDRB |= (1<<6);
+	DDRB |= (1<<0);
+}
+
+void matrix_init_user(void) {
+	led_init_ports();
+	
+	led_set_layer(0);
+	
+	/*KNOPS_INIT*/
+}
+
+const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt) {
+	//keyevent_t event = record->event;
+
+	/*KNOPS_MACRO*/
+}
+
+
+void matrix_scan_user(void) {
+	/*KNOPS_SCAN*/
+}
+
+void led_set_user(uint8_t usb_led) {
+
+	/*KNOPS_FUNCTIONALLED_STATES*/
+
+}
+
+void led_set_layer(int layer) {
+
+	/*KNOPS_SIMPLELED_STATES*/
+
+}
+
+bool process_record_user (uint16_t keycode, keyrecord_t *record) {
+  
+	/*KNOPS_PROCESS_STATE*/
+  
+}
+
+

--- a/keyboards/knops/mini/keymaps/knops/readme.md
+++ b/keyboards/knops/mini/keymaps/knops/readme.md
@@ -1,0 +1,11 @@
+# Default Knops Mini Layout
+
+![Knops logo](http://knops.io/img/Knops_logo.jpg)
+
+![Knops Mini Layout Image](https://i.imgur.com/WQBQctm.png)
+
+This is the keymap that our configurator uses to compile new keymaps and features. Here is a screenshot:
+
+![Knops Mini Layout Image](https://i.imgur.com/afH1NOt.png)
+
+As of 12th of february 2018, this tool has not yet been released to the public. You may have a look at our older tool, KBFlasher: [our (almost outdated) configurator tool](http://knops.io/configurator.html) for this.


### PR DESCRIPTION
Title probably says it all. I am talking about this configurator:
![screenshot](https://camo.githubusercontent.com/08f193fa6f8779eda7c295024eeb7f5e90406005/68747470733a2f2f692e696d6775722e636f6d2f616648314e4f742e706e67)

It is basically a keymap with every non-critical part replaced with variable-like comments which can automatically be replaced by the configurator builder. Once a USB hid replacement is made, this keymap will probably not be required anymore.