### PR TITLE
Custom keymap for clueboard 60

### DIFF
--- a/keyboards/clueboard/60/keymaps/yanfali/keymap.c
+++ b/keyboards/clueboard/60/keymaps/yanfali/keymap.c
@@ -1,0 +1,134 @@
+#include "60.h"
+
+#define _______ KC_TRNS
+
+enum keyboard_layers {
+    _BL,
+    _FL,
+    _CL,
+    _YF
+};
+
+enum custom_keycodes {
+    S_BSKTC = SAFE_RANGE,
+    S_ODEJY,
+    S_RCKBY,
+    S_DOEDR,
+    S_SCALE,
+    S_ONEUP,
+    S_COIN,
+    S_SONIC,
+    S_ZELDA
+};
+
+#ifdef AUDIO_ENABLE
+  float song_basketcase[][2] = SONG(BASKET_CASE);
+  float song_ode_to_joy[][2]  = SONG(ODE_TO_JOY);
+  float song_rock_a_bye_baby[][2]  = SONG(ROCK_A_BYE_BABY);
+  float song_doe_a_deer[][2]  = SONG(DOE_A_DEER);
+  float song_scale[][2]  = SONG(MUSIC_SCALE_SOUND);
+  float song_coin[][2]  = SONG(COIN_SOUND);
+  float song_one_up[][2]  = SONG(ONE_UP_SOUND);
+  float song_sonic_ring[][2]  = SONG(SONIC_RING);
+  float song_zelda_puzzle[][2]  = SONG(ZELDA_PUZZLE);
+#endif
+
+const uint16_t keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    /* Layer 0: Default Layer
+     * ,-----------------------------------------------------------------.
+     * |Esc      |  1|  2|  3|  4|  5|  6|  7|  8|  9|  0|  -|  =|  `|BSp|
+     * |-----------------------------------------------------------------|
+     * |Tab        |  Q|  W|  E|  R|  T|  Y|  U|  I|  O|  P|  [|  ]|    \|
+     * |-----------------------------------------------------------------|
+     * |MT(CTL, ESC)|  A|  S|  D|  F|  G|  H|  J|  K|  L|  ;|  '|Enter   |
+     * |-----------------------------------------------------------------|
+     * |Shift         |  Z|  X|  C|  V|  B|  N|  M|  ,|  .|  /|Shift |Fn0|
+     * |-----------------------------------------------------------------'
+     * |Ctrl       |Alt|Gui  |         Space         |Alt  |Gui|Fn |Ctrl |
+     * `-----------------------------------------------------------------'
+     */
+    [_BL] = KEYMAP(
+      KC_GESC,KC_1,   KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,   KC_0,   KC_MINS,KC_EQL, KC_GRV, KC_BSPC,\
+      KC_TAB,    KC_Q,   KC_W,   KC_E,   KC_R,   KC_T,   KC_Y,   KC_U,   KC_I,   KC_O,   KC_P,   KC_LBRC,KC_RBRC,KC_BSLS,     \
+      MT(MOD_LCTL, KC_ESC),     KC_A,   KC_S,   KC_D,   KC_F,   KC_G,   KC_H,   KC_J,   KC_K,   KC_L,   KC_SCLN,KC_QUOT,KC_NUHS,  KC_ENT,  \
+      KC_LSFT,  KC_NUBS,KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,   KC_N,   KC_M,   KC_COMM,KC_DOT, KC_SLSH,  KC_RSFT,   MO(_YF), \
+      KC_LCTL,  KC_LALT,  KC_LGUI,                        KC_SPC,                      KC_RALT,  KC_RGUI,  MO(_FL),   KC_RCTL),
+    [_FL] = KEYMAP(
+      KC_ESC, KC_F1,  KC_F2,  KC_F3,  KC_F4,  KC_F5,  KC_F6,  KC_F7,  KC_F8,  KC_F9,  KC_F10, KC_F11, KC_F12, _______,_______,\
+      _______,   _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,     \
+      _______,     _______,MO(_CL),_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,  _______, \
+      _______,  _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,  _______,   MO(_YF), \
+      _______,_______,_______,                        _______,                     _______,  _______,  MO(_FL),   _______),
+    [_CL] = KEYMAP(
+      BL_STEP,S_BSKTC,S_ODEJY,S_RCKBY,S_DOEDR,S_SCALE,S_ONEUP,S_COIN, S_SONIC,S_ZELDA,_______,_______,_______,_______,_______,\
+      _______,   _______,_______,_______,RESET,  _______,_______,_______,_______,_______,_______,_______,_______,_______,     \
+      _______,     _______,MO(_CL),_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,  _______, \
+      _______,  _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,     MO(_YF), \
+      _______,  _______,  _______,                        _______,                     _______,  _______,  MO(_FL),   _______),
+    [_YF] = KEYMAP(
+      _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,\
+      _______,_______,KC_UP  ,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,        \
+      _______,KC_LEFT,KC_DOWN,KC_RIGHT,_______,_______,_______,_______,_______,_______,_______,_______,_______,  _______,     \
+      _______,  _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,     MO(_YF), \
+      _______,  _______,  _______,                        _______,                     _______,  _______,  MO(_FL),   _______)
+};
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    switch (keycode) {
+        case S_BSKTC:
+            if (record->event.pressed) {
+                stop_all_notes();
+                PLAY_SONG(song_basketcase);
+            }
+            return false;
+        case S_ODEJY:
+            if (record->event.pressed) {
+                stop_all_notes();
+                PLAY_SONG(song_ode_to_joy);
+            }
+            return false;
+        case S_RCKBY:
+            if (record->event.pressed) {
+                stop_all_notes();
+                PLAY_SONG(song_rock_a_bye_baby);
+            }
+            return false;
+        case S_DOEDR:
+            if (record->event.pressed) {
+                stop_all_notes();
+                PLAY_SONG(song_doe_a_deer);
+            }
+            return false;
+        case S_SCALE:
+            if (record->event.pressed) {
+                stop_all_notes();
+                PLAY_SONG(song_scale);
+            }
+            return false;
+        case S_ONEUP:
+            if (record->event.pressed) {
+                stop_all_notes();
+                PLAY_SONG(song_one_up);
+            }
+            return false;
+        case S_COIN:
+            if (record->event.pressed) {
+                stop_all_notes();
+                PLAY_SONG(song_coin);
+            }
+            return false;
+        case S_SONIC:
+            if (record->event.pressed) {
+                stop_all_notes();
+                PLAY_SONG(song_sonic_ring);
+            }
+            return false;
+        case S_ZELDA:
+            if (record->event.pressed) {
+                stop_all_notes();
+                PLAY_SONG(song_zelda_puzzle);
+            }
+            return false;
+    }
+    return true;
+}

--- a/keyboards/clueboard/60/keymaps/yanfali/readme.md
+++ b/keyboards/clueboard/60/keymaps/yanfali/readme.md
@@ -1,0 +1,14 @@
+# /u/yanfali keymap for clueboard 60%
+
+Almost the same as default but differs in the following ways
+
+ 1. `Caps Lock` -> `MT(KC_LCTL, KC_ESC)`.
+    I'm a heavy vim user and I prefer escape to be closer than default. I also move `Control` to this key if you hold it.
+ 1. Switch Alt and GUI.
+    I spend most of my time on OSX, so I reverse Alt and GUI to be
+    more comfortable on OSX.
+ 1. Added a custom layer.
+    I use this to map the cursor keys to WASD, the familiar directional
+    gaming keys. As I use a split right shift, this naturally leads
+    to the left hand being used for navigation. This is also the
+    best place to add custom mappings, macros and combo keys.


### PR DESCRIPTION
My customized keymap for the clueboard 60.

 - Maps MT(LCTL,ESC) to Caps lock
 - Swaps ALT and GUI for OSX
 - Adds layer for WASD key navigation

Thanks to @skullydazed for a great keeb