### PR TITLE
u/yanfali custom keymap for Iris

### DIFF
--- a/keyboards/iris/keymaps/yanfali/config.h
+++ b/keyboards/iris/keymaps/yanfali/config.h
@@ -1,0 +1,43 @@
+/*
+Copyright 2017 Danny Nguyen <danny@hexwire.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef CONFIG_USER_H
+#define CONFIG_USER_H
+
+#include "config_common.h"
+
+/* Use I2C or Serial, not both */
+
+#define USE_SERIAL
+// #define USE_I2C
+
+/* Select hand configuration */
+
+#define MASTER_LEFT
+// #define MASTER_RIGHT
+// #define EE_HANDS
+
+#define TAPPING_TERM 150
+
+#undef RGBLED_NUM
+#define RGBLIGHT_ANIMATIONS
+#define RGBLED_NUM 12
+#define RGBLIGHT_HUE_STEP 8
+#define RGBLIGHT_SAT_STEP 8
+#define RGBLIGHT_VAL_STEP 8
+
+#endif

--- a/keyboards/iris/keymaps/yanfali/keymap.c
+++ b/keyboards/iris/keymaps/yanfali/keymap.c
@@ -1,0 +1,145 @@
+#include "iris.h"
+#include "action_layer.h"
+#include "eeconfig.h"
+
+extern keymap_config_t keymap_config;
+
+#define _QWERTY 0
+#define _LOWER 1
+#define _RAISE 2
+#define _ADJUST 16
+
+enum custom_keycodes {
+  QWERTY = SAFE_RANGE,
+  LOWER,
+  RAISE,
+  ADJUST,
+};
+
+#define KC_ KC_TRNS
+#define _______ KC_TRNS
+
+#define KC_CAPW LGUI(LSFT(KC_3))        // Capture whole screen
+#define KC_CPYW LGUI(LSFT(LCTL(KC_3)))  // Copy whole screen
+#define KC_CAPP LGUI(LSFT(KC_4))        // Capture portion of screen
+#define KC_CPYP LGUI(LSFT(LCTL(KC_4)))  // Copy portion of screen
+#define KC_ESCC MT(MOD_LCTL, KC_ESC)    // Control (hold), Escape (tap)
+#define KC_BACK LGUI(KC_LEFT)           // Browser Back
+#define KC_FORW LGUI(KC_RIGHT)          // Browser Forward
+#define KC_LOWR LOWER
+#define KC_RASE RAISE
+#define KC_RST RESET
+#define KC_BL_S BL_STEP
+#define KC_ENTS MT(MOD_LSFT, KC_ENT)
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+  [_QWERTY] = KC_KEYMAP(
+  //,----+----+----+----+----+----.              ,----+----+----+----+----+----.
+     GRV , 1  , 2  , 3  , 4  , 5  ,                6  , 7  , 8  , 9  , 0  ,MINS,
+  //|----+----+----+----+----+----|              |----+----+----+----+----+----|
+     TAB , Q  , W  , E  , R  , T  ,                Y  , U  , I  , O  , P  ,PLUS,
+  //|----+----+----+----+----+----|              |----+----+----+----+----+----|
+     ESCC, A  , S  , D  , F  , G  ,                H  , J  , K  , L  ,SCLN,QUOT,
+  //|----+----+----+----+----+----+----.    ,----|----+----+----+----+----+----|
+     LSFT, Z  , X  , C  , V  , B  ,SPC ,     LALT, N  , M  ,COMM,DOT ,SLSH,DEL ,
+  //`----+----+----+--+-+----+----+----/    \----+----+----+----+----+----+----'
+                       LGUI,LOWR,SPC ,         BSPC,ENTS,RASE
+  //                  `----+----+----'        `----+----+----'
+  ),
+
+  [_LOWER] = KC_KEYMAP(
+  //,----+----+----+----+----+----.              ,----+----+----+----+----+----.
+     TILD,EXLM, AT ,HASH,DLR ,PERC,               CIRC,AMPR,ASTR,LPRN,RPRN,BSPC,
+  //|----+----+----+----+----+----|              |----+----+----+----+----+----|
+     RST , 1  , 2  , 3  , 4  , 5  ,                6  , 7  , 8  , 9  , 0  ,    ,
+  //|----+----+----+----+----+----|              |----+----+----+----+----+----|
+     DEL ,CAPP,LEFT,RGHT, UP ,LBRC,               RBRC, P4 , P5 , P6 ,PLUS,PIPE,
+  //|----+----+----+----+----+----+----.    ,----|----+----+----+----+----+----|
+     BL_S,CPYP,    ,    ,DOWN,LCBR,LPRN,     RPRN,RCBR, P1 , P2 , P3 ,MINS,    ,
+  //`----+----+----+--+-+----+----+----/    \----+----+----+----+----+----+----'
+                           ,    ,DEL ,         DEL ,    , P0
+  //                  `----+----+----'        `----+----+----'
+  ),
+
+  [_RAISE] = KC_KEYMAP(
+  //,----+----+----+----+----+----.              ,----+----+----+----+----+----.
+     F12 , F1 , F2 , F3 , F4 , F5 ,                F6 , F7 , F8 , F9 ,F10 ,F11 ,
+  //|----+----+----+----+----+----|              |----+----+----+----+----+----|
+         ,EXLM, AT ,HASH,DLR ,PERC,               CIRC,AMPR,ASTR,LPRN,RPRN,    ,
+  //|----+----+----+----+----+----|              |----+----+----+----+----+----|
+     DEL ,MPRV,BACK,FORW,PGUP,UNDS,               EQL ,HOME,    ,    ,    ,BSLS,
+  //|----+----+----+----+----+----+----.    ,----|----+----+----+----+----+----|
+     MUTE,MSTP,MPLY,VOLD,PGDN,MINS,    ,         ,PLUS,END ,    ,    ,    ,    ,
+  //`----+----+----+--+-+----+----+----/    \----+----+----+----+----+----+----'
+                           ,    ,    ,             ,    ,
+  //                  `----+----+----'        `----+----+----'
+  ),
+
+  [_ADJUST] = KEYMAP(
+  //,--------+--------+--------+--------+--------+--------.                          ,--------+--------+--------+--------+--------+--------.
+      _______, _______, _______, _______, _______, _______,                            _______, _______, _______, _______, _______, _______,
+  //|--------+--------+--------+--------+--------+--------|                          |--------+--------+--------+--------+--------+--------|
+      RGB_TOG, RGB_MOD, RGB_HUI, RGB_SAI, RGB_VAI, _______,                            _______, _______, _______, _______, _______, _______,
+  //|--------+--------+--------+--------+--------+--------|                          |--------+--------+--------+--------+--------+--------|
+      RESET  , DEBUG  , RGB_HUD, RGB_SAD, RGB_VAD, _______,                            _______, _______, _______, _______, _______, _______,
+  //|--------+--------+--------+--------+--------+--------+--------.        ,--------|--------+--------+--------+--------+--------+--------|
+      _______, _______, _______, _______, _______, _______, _______,          _______, _______, _______, _______, _______, _______, _______,
+  //`--------+--------+--------+----+---+--------+--------+--------/        \--------+--------+--------+---+----+--------+--------+--------'
+                                      _______, _______, _______,                  _______, _______, _______
+  //                                `--------+--------+--------'                `--------+--------+--------'
+  )
+
+};
+
+#ifdef AUDIO_ENABLE
+float tone_qwerty[][2]     = SONG(QWERTY_SOUND);
+#endif
+
+void persistent_default_layer_set(uint16_t default_layer) {
+  eeconfig_update_default_layer(default_layer);
+  default_layer_set(default_layer);
+}
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  switch (keycode) {
+    case QWERTY:
+      if (record->event.pressed) {
+        #ifdef AUDIO_ENABLE
+          PLAY_SONG(tone_qwerty);
+        #endif
+        persistent_default_layer_set(1UL<<_QWERTY);
+      }
+      return false;
+      break;
+    case LOWER:
+      if (record->event.pressed) {
+        layer_on(_LOWER);
+        update_tri_layer(_LOWER, _RAISE, _ADJUST);
+      } else {
+        layer_off(_LOWER);
+        update_tri_layer(_LOWER, _RAISE, _ADJUST);
+      }
+      return false;
+      break;
+    case RAISE:
+      if (record->event.pressed) {
+        layer_on(_RAISE);
+        update_tri_layer(_LOWER, _RAISE, _ADJUST);
+      } else {
+        layer_off(_RAISE);
+        update_tri_layer(_LOWER, _RAISE, _ADJUST);
+      }
+      return false;
+      break;
+    case ADJUST:
+      if (record->event.pressed) {
+        layer_on(_ADJUST);
+      } else {
+        layer_off(_ADJUST);
+      }
+      return false;
+      break;
+  }
+  return true;
+}

--- a/keyboards/iris/keymaps/yanfali/readme.md
+++ b/keyboards/iris/keymaps/yanfali/readme.md
@@ -1,0 +1,17 @@
+## u/yanfali keymap for Iris
+
+Based heavily off Hexwire's configuration. Differs in following ways:
+
+ 1. Moved LALT to LCTL; I don't need CTL because of ESCC.
+ 1. Moved RAISE to old LALT.
+ 1. Moved ENTER to old RAISE.
+ 1. Move QUOTE to old ENTER.
+ 1. Moved PLUS to old QUOTE.
+ 1. replaced music next and volume up with browser forward and back
+    through history
+
+This configuration lets me use my thumbs for enter and backspace.
+It turns out I need `+` a lot for programming so I moved it logically
+below `-`.  I also added a couple of web specific short cuts for
+navigating previous and next in web history on OSX Chrome.
+

--- a/keyboards/iris/keymaps/yanfali/rules.mk
+++ b/keyboards/iris/keymaps/yanfali/rules.mk
@@ -1,0 +1,6 @@
+RGBLIGHT_ENABLE = yes
+BACKLIGHT_ENABLE = yes
+
+ifndef QUANTUM_DIR
+	include ../../../../Makefile
+endif


### PR DESCRIPTION
Based heavily on the keymap by hexwire.

 1. Moved LALT to LCTL; I don't need CTL because of ESCC.
 1. Moved RAISE to old LALT.
 1. Moved ENTER to old RAISE.
 1. Move QUOTE to old ENTER.
 1. Moved PLUS to old QUOTE.
 1. replaced music next and volume up with browser forward and back
    through history