### PR TITLE
Fix EE HANDS on splits losing handedness if RGB is enabled

### DIFF
--- a/keyboards/deltasplit75/split_util.h
+++ b/keyboards/deltasplit75/split_util.h
@@ -2,11 +2,8 @@
 #define SPLIT_KEYBOARD_UTIL_H
 
 #include <stdbool.h>
++#include "eeconfig.h"
 
-#ifdef EE_HANDS
-	#define EECONFIG_BOOTMAGIC_END      (uint8_t *)10
-	#define EECONFIG_HANDEDNESS         EECONFIG_BOOTMAGIC_END
-#endif
 
 #define SLAVE_I2C_ADDRESS           0x32
 

--- a/keyboards/deltasplit75/split_util.h
+++ b/keyboards/deltasplit75/split_util.h
@@ -2,7 +2,7 @@
 #define SPLIT_KEYBOARD_UTIL_H
 
 #include <stdbool.h>
-+#include "eeconfig.h"
+#include "eeconfig.h"
 
 
 #define SLAVE_I2C_ADDRESS           0x32

--- a/keyboards/helix/rev1/split_util.h
+++ b/keyboards/helix/rev1/split_util.h
@@ -2,11 +2,7 @@
 #define SPLIT_KEYBOARD_UTIL_H
 
 #include <stdbool.h>
-
-#ifdef EE_HANDS
-	#define EECONFIG_BOOTMAGIC_END      (uint8_t *)10
-	#define EECONFIG_HANDEDNESS         EECONFIG_BOOTMAGIC_END
-#endif
++#include "eeconfig.h"
 
 #define SLAVE_I2C_ADDRESS           0x32
 

--- a/keyboards/helix/rev1/split_util.h
+++ b/keyboards/helix/rev1/split_util.h
@@ -2,7 +2,7 @@
 #define SPLIT_KEYBOARD_UTIL_H
 
 #include <stdbool.h>
-+#include "eeconfig.h"
+#include "eeconfig.h"
 
 #define SLAVE_I2C_ADDRESS           0x32
 

--- a/keyboards/helix/rev2/split_util.h
+++ b/keyboards/helix/rev2/split_util.h
@@ -2,11 +2,7 @@
 #define SPLIT_KEYBOARD_UTIL_H
 
 #include <stdbool.h>
-
-#ifdef EE_HANDS
-	#define EECONFIG_BOOTMAGIC_END      (uint8_t *)10
-	#define EECONFIG_HANDEDNESS         EECONFIG_BOOTMAGIC_END
-#endif
++#include "eeconfig.h"
 
 #define SLAVE_I2C_ADDRESS           0x32
 

--- a/keyboards/helix/rev2/split_util.h
+++ b/keyboards/helix/rev2/split_util.h
@@ -2,7 +2,7 @@
 #define SPLIT_KEYBOARD_UTIL_H
 
 #include <stdbool.h>
-+#include "eeconfig.h"
+#include "eeconfig.h"
 
 #define SLAVE_I2C_ADDRESS           0x32
 

--- a/keyboards/nyquist/split_util.h
+++ b/keyboards/nyquist/split_util.h
@@ -2,11 +2,7 @@
 #define SPLIT_KEYBOARD_UTIL_H
 
 #include <stdbool.h>
-
-#ifdef EE_HANDS
-	#define EECONFIG_BOOTMAGIC_END      (uint8_t *)10
-	#define EECONFIG_HANDEDNESS         EECONFIG_BOOTMAGIC_END
-#endif
++#include "eeconfig.h"
 
 #define SLAVE_I2C_ADDRESS           0x32
 

--- a/keyboards/nyquist/split_util.h
+++ b/keyboards/nyquist/split_util.h
@@ -2,7 +2,7 @@
 #define SPLIT_KEYBOARD_UTIL_H
 
 #include <stdbool.h>
-+#include "eeconfig.h"
+#include "eeconfig.h"
 
 #define SLAVE_I2C_ADDRESS           0x32
 

--- a/keyboards/orthodox/split_util.h
+++ b/keyboards/orthodox/split_util.h
@@ -2,11 +2,8 @@
 #define SPLIT_KEYBOARD_UTIL_H
 
 #include <stdbool.h>
++#include "eeconfig.h"
 
-#ifdef EE_HANDS
-	#define EECONFIG_BOOTMAGIC_END      (uint8_t *)10
-	#define EECONFIG_HANDEDNESS         EECONFIG_BOOTMAGIC_END
-#endif
 
 #define SLAVE_I2C_ADDRESS           0x32
 

--- a/keyboards/orthodox/split_util.h
+++ b/keyboards/orthodox/split_util.h
@@ -2,7 +2,7 @@
 #define SPLIT_KEYBOARD_UTIL_H
 
 #include <stdbool.h>
-+#include "eeconfig.h"
+#include "eeconfig.h"
 
 
 #define SLAVE_I2C_ADDRESS           0x32

--- a/keyboards/viterbi/split_util.h
+++ b/keyboards/viterbi/split_util.h
@@ -2,11 +2,8 @@
 #define SPLIT_KEYBOARD_UTIL_H
 
 #include <stdbool.h>
++#include "eeconfig.h"
 
-#ifdef EE_HANDS
-	#define EECONFIG_BOOTMAGIC_END      (uint8_t *)10
-	#define EECONFIG_HANDEDNESS         EECONFIG_BOOTMAGIC_END
-#endif
 
 #define SLAVE_I2C_ADDRESS           0x32
 

--- a/keyboards/viterbi/split_util.h
+++ b/keyboards/viterbi/split_util.h
@@ -2,7 +2,7 @@
 #define SPLIT_KEYBOARD_UTIL_H
 
 #include <stdbool.h>
-+#include "eeconfig.h"
+#include "eeconfig.h"
 
 
 #define SLAVE_I2C_ADDRESS           0x32


### PR DESCRIPTION
Because I just ran into this myself and it was annoying AF.

Imports the changes from #1655 and #1576 to the remaining split keyboards.
EEPROM files not changes, since I didn't want to mess with those.

And #1600 hasn't progressed, so ...