### PR TITLE
Fixed formatting for Fedora Build Tools Example

### DIFF
--- a/docs/getting_started_build_tools.md
+++ b/docs/getting_started_build_tools.md
@@ -37,6 +37,7 @@ Debian / Ubuntu example:
     sudo apt-get install gcc unzip wget zip gcc-avr binutils-avr avr-libc dfu-programmer dfu-util gcc-arm-none-eabi binutils-arm-none-eabi libnewlib-arm-none-eabi
 
 Fedora / Red Hat example:
+
     sudo dnf install gcc unzip wget zip dfu-util dfu-programmer avr-gcc avr-libc binutils-avr32-linux-gnu arm-none-eabi-gcc-cs arm-none-eabi-binutils-cs arm-none-eabi-newlib
 
 ## Nix


### PR DESCRIPTION
There was a return missing from the build tools area for Fedora/ Red Hat, thus it wasn't displaying properly.