### PR TITLE
Swedish layout for iris

### DIFF
--- a/keyboards/iris/keymaps/swedish/config.h
+++ b/keyboards/iris/keymaps/swedish/config.h
@@ -1,0 +1,41 @@
+/*
+Copyright 2017 Danny Nguyen <danny@keeb.io>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef CONFIG_USER_H
+#define CONFIG_USER_H
+
+#include "config_common.h"
+
+/* Use I2C or Serial, not both */
+
+#define USE_SERIAL
+// #define USE_I2C
+
+/* Select hand configuration */
+
+// #define MASTER_LEFT
+// #define MASTER_RIGHT
+#define EE_HANDS
+
+#undef RGBLED_NUM
+#define RGBLIGHT_ANIMATIONS
+#define RGBLED_NUM 12
+#define RGBLIGHT_HUE_STEP 8
+#define RGBLIGHT_SAT_STEP 8
+#define RGBLIGHT_VAL_STEP 8
+
+#endif

--- a/keyboards/iris/keymaps/swedish/keymap.c
+++ b/keyboards/iris/keymaps/swedish/keymap.c
@@ -1,0 +1,110 @@
+#include "iris.h"
+#include "keymap_swedish.h"
+#include "action_layer.h"
+#include "eeconfig.h"
+
+extern keymap_config_t keymap_config;
+
+#define _QWERTY 0
+#define _LOWER 1
+#define _RAISE 2
+#define _EMPTY 16
+
+enum custom_keycodes {
+  QWERTY = SAFE_RANGE,
+  LOWER,
+  RAISE
+};
+
+#define KC_ KC_TRNS
+#define _______ KC_TRNS
+
+#define KC_LOWR LOWER
+#define KC_RASE RAISE
+#define KC_RST RESET
+
+#define KC_AA NO_AA
+#define KC_AE NO_AE
+#define KC_OE NO_OSLH
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+  [_QWERTY] = KC_KEYMAP(
+  //,----+----+----+----+----+----.              ,----+----+----+----+----+----.
+     ESC , 1  , 2  , 3  , 4  , 5  ,                6  , 7  , 8  , 9  , 0  ,BSPC,
+  //|----+----+----+----+----+----|              |----+----+----+----+----+----|
+     TAB , Q  , W  , E  , R  , T  ,                Y  , U  , I  , O  , P  , AA ,
+  //|----+----+----+----+----+----|              |----+----+----+----+----+----|
+     LSFT, A  , S  , D  , F  , G  ,                H  , J  , K  , L  , OE , AE ,
+  //|----+----+----+----+----+----+----.    ,----|----+----+----+----+----+----|
+     LCTL, Z  , X  , C  , V  , B  ,DEL ,     BSPC, N  , M  ,COMM,DOT ,SLSH,MINS,
+  //`----+----+----+--+-+----+----+----/    \----+----+----+----+----+----+----'
+                       LGUI,LOWR,SPC ,         ENT ,RASE,LALT
+  //                  `----+----+----'        `----+----+----'
+  ),
+
+  [_LOWER] = KEYMAP(
+  //,-------+-------+-------+-------+-------+-------.                    ,-------+-------+-------+-------+-------+-------.
+     NO_TILD,KC_EXLM,NO_AT  ,KC_HASH,NO_DLR ,KC_PERC,                     NO_CIRC,NO_AMPR,NO_ASTR,NO_SLSH,NO_LPRN,NO_RPRN,
+  //|-------+-------+-------+-------+-------+-------|                    |-------+-------+-------+-------+-------+-------|
+     NO_ACUT,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,                     KC_TRNS,KC_TRNS,KC_TRNS,NO_PIPE,NO_LCBR,NO_RCBR,
+  //|-------+-------+-------+-------+-------+-------|                    |-------+-------+-------+-------+-------+-------|
+     KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,NO_BSLS,                     KC_LEFT,KC_DOWN,KC_UP  ,KC_RGHT,NO_LBRC,NO_RBRC,
+  //|-------+-------+-------+-------+-------+-------+-------.    ,-------|-------+-------+-------+-------+-------+-------|
+     KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,     KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,NO_LESS,NO_GRTR,
+  //`-------+-------+-------+--+----+-------+-------+-------/    \-------+-------+-------+-------+-------+-------+-------'
+                                   KC_TRNS,KC_TRNS,KC_TRNS,         KC_TRNS,KC_TRNS,KC_TRNS
+  //                              `-------+-------+-------'        `-------+-------+-------'
+  ),
+
+  [_RAISE] = KEYMAP(
+  //,-------+-------+-------+-------+-------+-------.                    ,-------+-------+-------+-------+-------+-------.
+     KC_F12 ,KC_F1  ,KC_F2  ,KC_F3  ,KC_F4  ,KC_F5  ,                     KC_F6  ,KC_F7  ,KC_F8  ,KC_F9  ,KC_F10 ,KC_F11 ,
+  //|-------+-------+-------+-------+-------+-------|                    |-------+-------+-------+-------+-------+-------|
+     NO_GRV ,KC_7   ,KC_8   ,KC_9   ,NO_MINS,NO_ASTR,                     KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,NO_PIPE,
+  //|-------+-------+-------+-------+-------+-------|                    |-------+-------+-------+-------+-------+-------|
+     KC_TRNS,KC_4   ,KC_5   ,KC_6   ,NO_PLUS,NO_SLSH,                     KC_HOME,KC_PGDN,KC_PGUP,KC_END ,KC_TRNS,NO_BSLS,
+  //|-------+-------+-------+-------+-------+-------+-------.    ,-------|-------+-------+-------+-------+-------+-------|
+     KC_TRNS,KC_1   ,KC_2   ,KC_3   ,KC_0   ,NO_EQL ,KC_TRNS,     KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,
+  //`-------+-------+-------+--+----+-------+-------+-------/    \-------+-------+-------+-------+-------+-------+-------'
+                                   KC_TRNS,KC_TRNS,KC_TRNS,         KC_TRNS,KC_TRNS,KC_TRNS
+  //                              `-------+-------+-------'        `-------+-------+-------'
+  )
+};
+
+void persistent_default_layer_set(uint16_t default_layer) { 
+  eeconfig_update_default_layer(default_layer);
+  default_layer_set(default_layer);
+}
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  switch (keycode) {
+    case QWERTY:
+      if (record->event.pressed) {
+        persistent_default_layer_set(1UL<<_QWERTY);
+      }
+      return false;
+      break;
+    case LOWER:
+      if (record->event.pressed) {
+        layer_on(_LOWER);
+        update_tri_layer(_LOWER, _RAISE, _EMPTY);
+      } else {
+        layer_off(_LOWER);
+        update_tri_layer(_LOWER, _RAISE, _EMPTY);
+      }
+      return false;
+      break;
+    case RAISE:
+      if (record->event.pressed) {
+        layer_on(_RAISE);
+        update_tri_layer(_LOWER, _RAISE, _EMPTY);
+      } else {
+        layer_off(_RAISE);
+        update_tri_layer(_LOWER, _RAISE, _EMPTY);
+      }
+      return false;
+      break;
+  }
+  return true;
+}

--- a/keyboards/iris/keymaps/swedish/rules.mk
+++ b/keyboards/iris/keymaps/swedish/rules.mk
@@ -1,0 +1,6 @@
+RGBLIGHT_ENABLE = yes
+BACKLIGHT_ENABLE = yes
+
+ifndef QUANTUM_DIR
+	include ../../../../Makefile
+endif


### PR DESCRIPTION
A Swedish layout for the iris, most importantly it supports Å, Ä and Ö.
Other features that it has is that most focus lay on the thumbs instead of pinkies.