### PR TITLE
Expand Custom Functions Documentation

### DIFF
--- a/docs/custom_quantum_functions.md
+++ b/docs/custom_quantum_functions.md
@@ -98,10 +98,10 @@ This allows you to control the 5 LED's defined as part of the USB Keyboard spec.
 * `USB_LED_COMPOSE`
 * `USB_LED_KANA`
 
-### Example `led_set_kb()` Implementation
+### Example `led_set_user()` Implementation
 
 ```
-void led_set_kb(uint8_t usb_led) {
+void led_set_user(uint8_t usb_led) {
     if (usb_led & (1<<USB_LED_NUM_LOCK)) {
         PORTB |= (1<<0);
     } else {
@@ -144,9 +144,8 @@ Before a keyboard can be used the hardware must be initialized. QMK handles init
 This example, at the keyboard level, sets up B1, B2, and B3 as LED pins.
 
 ```
-void matrix_init_kb(void) {
+void matrix_init_user(void) {
   // Call the keymap level matrix init.
-  matrix_init_user();
 
   // Set our LED pins as output
   DDRB |= (1<<1);
@@ -176,3 +175,5 @@ This example has been deliberately omitted. You should understand enough about Q
 This function gets called at every matrix scan, which is basically as often as the MCU can handle. Be careful what you put here, as it will get run a lot.
 
 You should use this function if you need custom matrix scanning code. It can also be used for custom status output (such as LED's or a display) or other functionality that you want to trigger regularly even when the user isn't typing.
+
+

--- a/docs/custom_quantum_functions.md
+++ b/docs/custom_quantum_functions.md
@@ -139,7 +139,7 @@ void led_set_user(uint8_t usb_led) {
 
 Before a keyboard can be used the hardware must be initialized. QMK handles initialization of the keyboard matrix itself, but if you have other hardware like LED's or i&#xb2;c controllers you will need to set up that hardware before it can be used.
 
-### Example `matrix_init_kb()` Implementation
+### Example `matrix_init_user()` Implementation
 
 This example, at the keyboard level, sets up B1, B2, and B3 as LED pins.
 
@@ -177,3 +177,39 @@ This function gets called at every matrix scan, which is basically as often as t
 You should use this function if you need custom matrix scanning code. It can also be used for custom status output (such as LED's or a display) or other functionality that you want to trigger regularly even when the user isn't typing.
 
 
+# Layer Change Code
+
+Thir runs code every time that the layers get changed.  This can be useful for layer indication, or custom layer handling. 
+
+### Example `layer_state_set_*` Implementation
+
+This example shows how to set the [RGB Underglow](feature_rgblight.md) lights based on the layer, using the Planck as an example
+
+```
+uint32_t layer_state_set_user(uint32_t state) {
+    switch (biton32(state)) {
+    case _RAISE:
+        rgblight_setrgb (0x00,  0x00, 0xFF);
+        break;
+    case _LOWER:
+        rgblight_setrgb (0xFF,  0x00, 0x00);
+        break;
+    case _PLOVER:
+        rgblight_setrgb (0x00,  0xFF, 0x00);
+        break;
+    case _ADJUST:
+        rgblight_setrgb (0x7A,  0x00, 0xFF);
+        break;
+    default: //  for any other layers, or the default layer
+        rgblight_setrgb (0x00,  0xFF, 0xFF);
+        break;
+    }
+  return state;
+}
+```
+### `matrix_init_*` Function Documentation
+
+* Keyboard/Revision: `void uint32_t layer_state_set_kb(uint32_t state)`
+* Keymap: `uint32_t layer_state_set_user(uint32_t state)`
+
+The `state` is the bitmask of the active layers, as explained in the [Keymap Overview](keymap.md#keymap-layer-status)


### PR DESCRIPTION
* Set everything to use the `_user` function for the example (as most referencing this will be people editing keymaps, so should be using that function, and not the keyboard one)
* Add `layer_state_set_*` with the RGB Underglow layer state indicator as an example