### PR TITLE
Fixed compilation of the ps2avrGB keyboard/firmware (resolving #2425)

### DIFF
--- a/keyboards/ps2avrGB/README.md
+++ b/keyboards/ps2avrGB/README.md
@@ -10,11 +10,13 @@ Note that this is a complete replacement for the firmware, so you won't be
 using Bootmapper Client to change any keyboard settings, since not all the
 USB report options are supported.
 
+This is an example based on the b.mini keyboard for making other keyboards
+compatible with QMK; fully supported boards have their own directory.
+
 ## Supported Boards
 
-Only the [B.mini X2](http://winkeyless.kr/product/b-mini-x2-pcb/) has been
-tested so far (since it's the only one I own). But other boards that use
-the ps2avrGB firmware should work as well.
+- [b.fake](https://github.com/qmk/qmk_firmware/tree/master/keyboards/bfake)
+- [b.mini](https://github.com/qmk/qmk_firmware/tree/master/keyboards/bmini)
 
 ## Installing
 

--- a/keyboards/ps2avrGB/README.md
+++ b/keyboards/ps2avrGB/README.md
@@ -17,6 +17,7 @@ compatible with QMK; fully supported boards have their own directory.
 
 - [b.fake](https://github.com/qmk/qmk_firmware/tree/master/keyboards/bfake)
 - [b.mini](https://github.com/qmk/qmk_firmware/tree/master/keyboards/bmini)
+- [pearl](https://github.com/qmk/qmk_firmware/tree/master/keyboards/pearl)
 
 ## Installing
 

--- a/keyboards/ps2avrGB/bmini.h
+++ b/keyboards/ps2avrGB/bmini.h
@@ -1,0 +1,60 @@
+/*
+Copyright 2017 Luiz Ribeiro <luizribeiro@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef BMINI_H
+#define BMINI_H
+
+#include "quantum.h"
+
+#define KEYMAP( \
+  K05, K25, K35, K45, K55, K06, KA6, KA7, K07, KB5, KC5, KD5, KE5, KD1, KE1, KE2, \
+  K04, K14, K24, K34, K44, K54, K16, KB6, KB7, K17, KA4, KB4, KC4, KE4,      KD0, \
+  K03, K13, K23, K33, K43, K53, K26, KC6, KC7, K27, KA3, KB3, KC3, KD3,      K67, \
+  K02, K12, K22, K32, K42, K52, K36, KD6, KD7, K37, KA2, KB2, KD2,           KE0, \
+  K01, K11, K21, K31, K41, K51, K46, KE6, KE7, K47, KA1, KB1,           K86, K77, \
+  K00, K10, K20,           K56,                     K57, KB0, KC0, K66, K76, K96  \
+){ \
+  { K00, K10,   K20, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KB0, KC0,   KD0,   KE0   }, \
+  { K01, K11,   K21, K31,   K41,   K51,   KC_NO, KC_NO, KC_NO, KC_NO, KA1,   KB1, KC_NO, KD1,   KE1   }, \
+  { K02, K12,   K22, K32,   K42,   K52,   KC_NO, KC_NO, KC_NO, KC_NO, KA2,   KB2, KC_NO, KD2,   KE2   }, \
+  { K03, K13,   K23, K33,   K43,   K53,   KC_NO, KC_NO, KC_NO, KC_NO, KA3,   KB3, KC3,   KD3,   KC_NO }, \
+  { K04, K14,   K24, K34,   K44,   K54,   KC_NO, KC_NO, KC_NO, KC_NO, KA4,   KB4, KC4,   KC_NO, KE4   }, \
+  { K05, KC_NO, K25, K35,   K45,   K55,   KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KB5, KC5,   KD5,   KE5   }, \
+  { K06, K16,   K26, K36,   K46,   K56,   K66,   K76,   K86,   K96,   KA6,   KB6, KC6,   KD6,   KE6   }, \
+  { K07, K17,   K27, K37,   K47,   K57,   K67,   K77,   KC_NO, KC_NO, KA7,   KB7, KC7,   KD7,   KE7   } \
+}
+
+#define KC_KEYMAP( \
+    K05, K25, K35, K45, K55, K06, KA6, KA7, K07, KB5, KC5, KD5, KE5, KD1, KE1, KE2, \
+    K04, K14, K24, K34, K44, K54, K16, KB6, KB7, K17, KA4, KB4, KC4, KE4,      KD0, \
+    K03, K13, K23, K33, K43, K53, K26, KC6, KC7, K27, KA3, KB3, KC3, KD3,      K67, \
+    K02, K12, K22, K32, K42, K52, K36, KD6, KD7, K37, KA2, KB2, KD2,           KE0, \
+    K01, K11, K21, K31, K41, K51, K46, KE6, KE7, K47, KA1, KB1,           K86, K77, \
+    K00, K10, K20,           K56,                     K57, KB0, KC0, K66, K76, K96  \
+) \
+{ \
+    { KC_##K00, KC_##K10, KC_##K20, KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_##KB0, KC_##KC0, KC_##KD0, KC_##KE0 }, \
+    { KC_##K01, KC_##K11, KC_##K21, KC_##K31, KC_##K41, KC_##K51, KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_##KA1, KC_##KB1, KC_NO,    KC_##KD1, KC_##KE1 }, \
+    { KC_##K02, KC_##K12, KC_##K22, KC_##K32, KC_##K42, KC_##K52, KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_##KA2, KC_##KB2, KC_NO,    KC_##KD2, KC_##KE2 }, \
+    { KC_##K03, KC_##K13, KC_##K23, KC_##K33, KC_##K43, KC_##K53, KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_##KA3, KC_##KB3, KC_##KC3, KC_##KD3, KC_NO    }, \
+    { KC_##K04, KC_##K14, KC_##K24, KC_##K34, KC_##K44, KC_##K54, KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_##KA4, KC_##KB4, KC_##KC4, KC_NO,    KC_##KE4 }, \
+    { KC_##K05, KC_NO,    KC_##K25, KC_##K35, KC_##K45, KC_##K55, KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_##KB5, KC_##KC5, KC_##KD5, KC_##KE5 }, \
+    { KC_##K06, KC_##K16, KC_##K26, KC_##K36, KC_##K46, KC_##K56, KC_##K66, KC_##K76, KC_##K86, KC_##K96, KC_##KA6, KC_##KB6, KC_##KC6, KC_##KD6, KC_##KE6 }, \
+    { KC_##K07, KC_##K17, KC_##K27, KC_##K37, KC_##K47, KC_##K57, KC_##K67, KC_##K77, KC_NO,    KC_NO,    KC_##KA7, KC_##KB7, KC_##KC7, KC_##KD7, KC_##KE7 }  \
+}
+
+#endif

--- a/keyboards/ps2avrGB/config.h
+++ b/keyboards/ps2avrGB/config.h
@@ -18,15 +18,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef CONFIG_H
 #define CONFIG_H
 
-#include "config_common.h"
-
 #define VENDOR_ID       0x20A0
 #define PRODUCT_ID      0x422D
+// TODO: share these strings with usbconfig.h
+// Edit usbconfig.h to change these.
+#define MANUFACTURER    winkeyless.kr
 #define PRODUCT         ps2avrGB
 
+/* matrix size */
+#define MATRIX_ROWS 8
+#define MATRIX_COLS 15
+
+#define RGBLED_NUM 16
 #define RGBLIGHT_ANIMATIONS
 
 #define NO_UART 1
+#define BOOTLOADHID_BOOTLOADER 1
 
 /* key combination for command */
 #define IS_COMMAND() (keyboard_report->mods == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT)))

--- a/keyboards/ps2avrGB/keymaps/default/keymap.c
+++ b/keyboards/ps2avrGB/keymaps/default/keymap.c
@@ -1,0 +1,37 @@
+/*
+Copyright 2017 Luiz Ribeiro <luizribeiro@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "bmini.h"
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [0] = KEYMAP(
+        KC_ESC, KC_F1,  KC_F2,  KC_F3,  KC_F4,  KC_F5,  KC_F6,  KC_F7,  KC_F8,  KC_F9,  KC_F10, KC_F11, KC_F12, KC_PSCR,KC_HOME,KC_END,
+        KC_GRV, KC_1,   KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,   KC_0,   KC_MINS,KC_EQL, KC_BSPC,        KC_DEL,
+        KC_TAB, KC_Q,   KC_W,   KC_E,   KC_R,   KC_T,   KC_Y,   KC_U,   KC_I,   KC_O,   KC_P,   KC_LBRC,KC_RBRC,KC_BSLS,        KC_INS,
+        MO(0), KC_A,   KC_S,   KC_D,   KC_F,   KC_G,   KC_H,   KC_J,   KC_K,   KC_L,   KC_SCLN,KC_QUOT,KC_ENT,                 KC_PGUP,
+        KC_LSFT,KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,   KC_N,   KC_M,   KC_COMM,KC_DOT, KC_SLSH,KC_RSFT,                KC_UP,  KC_PGDN,
+        KC_LCTL,KC_LALT,KC_LGUI,                KC_SPC,                                 KC_RGUI,KC_RALT,KC_RCTL,KC_LEFT,KC_DOWN,KC_RGHT
+    ),
+    [1] = KEYMAP(
+        KC_TRNS,RGB_TOG,RGB_MOD,RGB_HUI,RGB_SAI,RGB_VAI,RGB_HUD,RGB_SAD,RGB_VAD,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_END,
+        KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,        KC_DEL,
+        KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,        KC_INS,
+        KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,                KC_TRNS,
+        KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,                KC_TRNS,KC_TRNS,
+        KC_TRNS,KC_TRNS,KC_TRNS,                KC_TRNS,                                KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_RGHT
+    ),
+};


### PR DESCRIPTION
This PR fixes the silent compilation error for the ps2avrGB keyboard/firmware. This error was caused by a lacking default keymap which it did not have because all keyboards based on it were moved to another directory. I also added the required config.h options so it's possible to compile it again and (probably) flash it on a b.mini.

Lastly, I updated the README to reflect the current state.

This commit fixes #2425