### PR TITLE
Updates for 'qwerty_code_friendly'

### DIFF
--- a/layouts/community/ergodox/qwerty_code_friendly/keymap.c
+++ b/layouts/community/ergodox/qwerty_code_friendly/keymap.c
@@ -1,3 +1,5 @@
+/* -*- Mode:C; c-basic-offset:2; tab-width:2; indent-tabs-mode:nil; evil-indent-convert-tabs:t; -*- */
+
 #include QMK_KEYBOARD_H
 #include "debug.h"
 #include "action_layer.h"
@@ -7,51 +9,153 @@
  * See `readme.md` for notes on each define.
  */
 
-// Personal preference (enable by passing EXTRAFLAGS=... to make).
-// #define CFQ_USE_MOMENTARY_LAYER_KEYS
-// #define CFQ_USE_EXPEREMENTAL_LAYER
+/* Personal preference (enable by passing EXTRAFLAGS=... to make). */
+/* #define CFQ_USE_MOMENTARY_LAYER_KEYS */
 
-// keep enabled for now
 #define CFQ_USE_DYNAMIC_MACRO
 
+#if !defined(CFQ_USER_KEY0)
+#  define CFQ_USER_KEY0 KC_BSPC
+#endif
 #if !defined(CFQ_USER_KEY1)
 #  define CFQ_USER_KEY1 CFQ_KC_FN1
 #endif
 #if !defined(CFQ_USER_KEY2)
-#  define CFQ_USER_KEY2 KC_INS
+#  define CFQ_USER_KEY2 KC_LT
 #endif
 #if !defined(CFQ_USER_KEY3)
-#  ifdef CFQ_USE_EXPEREMENTAL_LAYER
-#    define CFQ_USER_KEY3 CFQ_KC_FN3
-#  else
-#    define CFQ_USER_KEY3 KC_CAPS
-#  endif
+#  define CFQ_USER_KEY3 KC_GT
 #endif
 #if !defined(CFQ_USER_KEY4)
-#  define CFQ_USER_KEY4 KC_SPC
+#  define CFQ_USER_KEY4 KC_BSPC
 #endif
 #if !defined(CFQ_USER_KEY5)
-#  define CFQ_USER_KEY5 KC_ENT
+#  define CFQ_USER_KEY5 KC_DELT
 #endif
 #if !defined(CFQ_USER_KEY6)
-#  define CFQ_USER_KEY6 CFQ_KC_FN2
+#  define CFQ_USER_KEY6 KC_CAPS
 #endif
 #if !defined(CFQ_USER_KEY7)
-#  define CFQ_USER_KEY7 CFQ_KC_FN1
+#  define CFQ_USER_KEY7 CFQ_KC_FN3
 #endif
 
-#define BASE 0 // default layer
-#define SYMB 1 // symbols
-#define MDIA 2 // media keys
-#ifdef CFQ_USE_EXPEREMENTAL_LAYER
-#  define EXPR 3 // experimental keys
+#ifndef CFQ_WORD_A
+#define CFQ_WORD_A ""
 #endif
+#ifndef CFQ_WORD_B
+#define CFQ_WORD_B ""
+#endif
+#ifndef CFQ_WORD_C
+#define CFQ_WORD_C ""
+#endif
+#ifndef CFQ_WORD_D
+#define CFQ_WORD_D ""
+#endif
+#ifndef CFQ_WORD_E
+#define CFQ_WORD_E ""
+#endif
+#ifndef CFQ_WORD_F
+#define CFQ_WORD_F ""
+#endif
+#ifndef CFQ_WORD_G
+#define CFQ_WORD_G ""
+#endif
+#ifndef CFQ_WORD_H
+#define CFQ_WORD_H ""
+#endif
+#ifndef CFQ_WORD_I
+#define CFQ_WORD_I ""
+#endif
+#ifndef CFQ_WORD_J
+#define CFQ_WORD_J ""
+#endif
+#ifndef CFQ_WORD_K
+#define CFQ_WORD_K ""
+#endif
+#ifndef CFQ_WORD_L
+#define CFQ_WORD_L ""
+#endif
+#ifndef CFQ_WORD_M
+#define CFQ_WORD_M ""
+#endif
+#ifndef CFQ_WORD_N
+#define CFQ_WORD_N ""
+#endif
+#ifndef CFQ_WORD_O
+#define CFQ_WORD_O ""
+#endif
+#ifndef CFQ_WORD_P
+#define CFQ_WORD_P ""
+#endif
+#ifndef CFQ_WORD_Q
+#define CFQ_WORD_Q ""
+#endif
+#ifndef CFQ_WORD_R
+#define CFQ_WORD_R ""
+#endif
+#ifndef CFQ_WORD_S
+#define CFQ_WORD_S ""
+#endif
+#ifndef CFQ_WORD_T
+#define CFQ_WORD_T ""
+#endif
+#ifndef CFQ_WORD_U
+#define CFQ_WORD_U ""
+#endif
+#ifndef CFQ_WORD_V
+#define CFQ_WORD_V ""
+#endif
+#ifndef CFQ_WORD_W
+#define CFQ_WORD_W ""
+#endif
+#ifndef CFQ_WORD_X
+#define CFQ_WORD_X ""
+#endif
+#ifndef CFQ_WORD_Y
+#define CFQ_WORD_Y ""
+#endif
+#ifndef CFQ_WORD_Z
+#define CFQ_WORD_Z ""
+#endif
+
+static const char *cfq_word_lut[26] = {
+  CFQ_WORD_A, CFQ_WORD_B, CFQ_WORD_C, CFQ_WORD_D, CFQ_WORD_E, CFQ_WORD_F,
+  CFQ_WORD_G, CFQ_WORD_H, CFQ_WORD_I, CFQ_WORD_J, CFQ_WORD_K, CFQ_WORD_L,
+  CFQ_WORD_M, CFQ_WORD_N, CFQ_WORD_O, CFQ_WORD_P, CFQ_WORD_Q, CFQ_WORD_R,
+  CFQ_WORD_S, CFQ_WORD_T, CFQ_WORD_U, CFQ_WORD_V, CFQ_WORD_W, CFQ_WORD_X,
+  CFQ_WORD_Y, CFQ_WORD_Z,
+};
+
+#define BASE 0 /* default layer */
+#define SYMB 1 /* symbols */
+#define MDIA 2 /* media keys */
+#define WORD 3 /* experimental keys */
 
 enum custom_keycodes {
-  PLACEHOLDER = SAFE_RANGE, // can always be here
-  EPRM,
-  VRSN,
+  PLACEHOLDER = SAFE_RANGE, /* can always be here */
   RGB_SLD,
+
+  M_BRACKET_IN_CBR,
+  M_BRACKET_IN_PRN,
+  M_BRACKET_IN_BRC,
+  M_BRACKET_IN_ANG,
+  M_BRACKET_OUT_CBR,
+  M_BRACKET_OUT_PRN,
+  M_BRACKET_OUT_BRC,
+  M_BRACKET_OUT_ANG,
+  M_ARROW_RMINUS,
+  M_ARROW_LMINUS,
+  M_ARROW_REQL,
+  M_ARROW_LEQL,
+
+  /* allow user defined words for each character:
+   * use CFQ_WORD_[A-Z] defines. */
+  M_WORD_A, M_WORD_B, M_WORD_C, M_WORD_D, M_WORD_E, M_WORD_F,
+  M_WORD_G, M_WORD_H, M_WORD_I, M_WORD_J, M_WORD_K, M_WORD_L,
+  M_WORD_M, M_WORD_N, M_WORD_O, M_WORD_P, M_WORD_Q, M_WORD_R,
+  M_WORD_S, M_WORD_T, M_WORD_U, M_WORD_V, M_WORD_W, M_WORD_X,
+  M_WORD_Y, M_WORD_Z,
+
 #ifdef CFQ_USE_DYNAMIC_MACRO
   DYNAMIC_MACRO_RANGE,
 #endif
@@ -60,30 +164,6 @@ enum custom_keycodes {
 #ifdef CFQ_USE_DYNAMIC_MACRO
 #include "dynamic_macro.h"
 #endif
-
-// macros
-#ifdef CFQ_USE_EXPEREMENTAL_LAYER
-#define M_SPACES_1 2
-#define M_SPACES_2 3
-#define M_SPACES_3 4
-#define M_SPACES_4 5
-#define M_SPACES_5 6
-#define M_SPACES_6 7
-#define M_SPACES_7 8
-#define M_SPACES_8 9
-#endif
-#define M_BRACKET_IN_CBR 10
-#define M_BRACKET_IN_PRN 11
-#define M_BRACKET_IN_BRC 12
-#define M_BRACKET_IN_ANG 13
-#define M_BRACKET_OUT_CBR 14
-#define M_BRACKET_OUT_PRN 15
-#define M_BRACKET_OUT_BRC 16
-#define M_BRACKET_OUT_ANG 17
-#define M_ARROW_RMINUS 18
-#define M_ARROW_LMINUS 19
-#define M_ARROW_REQL 20
-#define M_ARROW_LEQL 21
 
 #ifdef CFQ_USE_MOMENTARY_LAYER_KEYS
 #define CFQ_KC_FN1 MO(1)
@@ -99,42 +179,49 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 /* Keymap 0: Basic layer
  * ,--------------------------------------------------.           ,--------------------------------------------------.
  * | Grave  |   !  |   @  |   #  |   $  |   %  |   {  |           |  }   |   ^  |   &  |   *  |   -  |   =  | BSpace |
- * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
+ * |--------+------+------+------+------+------+------|           |------+------+------+------+------+------+--------|
  * | Tab    |   Q  |   W  |   E  |   R  |   T  |   (  |           |  )   |   Y  |   U  |   I  |   O  |   P  |   \    |
  * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
  * | Esc    |   A  |   S  |   D  |   F  |   G  |------|           |------|   H  |   J  |   K  |   L  |   ;  |   '    |
  * |--------+------+------+------+------+------|   [  |           |  ]   |------+------+------+------+------+--------|
  * | LShift |   Z  |   X  |   C  |   V  |   B  |      |           |      |   N  |   M  |   ,  |   .  |   /  | RShift |
  * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
- *   | LCtl |Super | Alt  | ~L1  |Space |                                       | Left | Down | Up   |Right | Del  |
+ *   | LCtl |Super | Alt  | ~L1  |Space |                                       | Left | Down | Up   |Right | Ins  |
  *   `----------------------------------'                                       `----------------------------------'
  *                                        ,-------------.       ,-------------.
- *                                        | Ins  |CapsLk|       | Home | End  |
- *                                 ,------|------|------|       |------+------+------.
- *                                 |      |      | ~L2  |       | PgUp |      |      |
- *                                 |Space |Enter |------|       |------|Enter |Space |
- *                                 |      |      | ~L1  |       | PgDn |      |      |
+ *                                        |   <  |  >   |       | Home | End  |
+ *                                 ,------+------+------|       |------+------+------.
+ *                                 |      |      |CapsLk|       | PgUp |      |      |
+ *                                 |BSpace| Del  |------|       |------| ~L2  |Space |
+ *                                 |      |      | ~L3  |       | PgDn |      |      |
  *                                 `--------------------'       `--------------------'
  *
  * Optional overrides: see CFQ_USER_KEY# defines.
  *
- *   -------+------+------+------+------+
- *   |      |      |      | USR1 |      |
- *   `----------------------------------'
- *
- *                                        ,-------------.
- *                                        | USR2 | USR3 |
- *                                 ,------|------|------|
- *                                 |      |      | USR6 |
- *                                 | USR4 | USR5 |------|
- *                                 |      |      | USR7 |
- *                                 `--------------------'
+ * ,--------------------------------------------------.           ,--------------------------------------------------.
+ * |        |      |      |      |      |      |      |           |      |      |      |      |      |      | USR0   |
+ * |--------+------+------+------+------+------+------|           |------+------+------+------+------+------+--------|
+ * |        |      |      |      |      |      |      |           |      |      |      |      |      |      |        |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |        |      |      |      |      |      |------|           |------|      |      |      |      |      |        |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |        |      |      |      |      |      |      |           |      |      |      |      |      |      |        |
+ * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
+ *   |      |      |      | USR1 |      |                                       |      |      |      |      |      |
+ *   `----------------------------------'                                       `----------------------------------'
+ *                                        ,-------------.       ,-------------.
+ *                                        | USR2 | USR3 |       |      |      |
+ *                                 ,------+------+------|       |------+------+------.
+ *                                 |      |      | USR6 |       |      |      |      |
+ *                                 | USR4 | USR5 |------|       |------|      |      |
+ *                                 |      |      | USR7 |       |      |      |      |
+ *                                 `--------------------'       `--------------------'
  */
 
-// If it accepts an argument (i.e, is a function), it doesn't need KC_.
-// Otherwise, it needs KC_*
-[BASE] = LAYOUT_ergodox(  // layer 0 : default
-  // left hand
+/* If it accepts an argument (i.e, is a function), it doesn't need KC_.
+ * Otherwise, it needs KC_* */
+[BASE] = LAYOUT_ergodox(  /* layer 0 : default */
+  /* left hand */
   KC_GRV,  KC_EXLM, KC_AT,   KC_HASH,       KC_DLR, KC_PERC, KC_LCBR,
   KC_TAB,  KC_Q,    KC_W,    KC_E,          KC_R,   KC_T,    KC_LPRN,
   KC_ESC,  KC_A,    KC_S,    KC_D,          KC_F,   KC_G,
@@ -143,48 +230,43 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
                                                     CFQ_USER_KEY2, CFQ_USER_KEY3,
                                                                    CFQ_USER_KEY6,
                                      CFQ_USER_KEY4, CFQ_USER_KEY5, CFQ_USER_KEY7,
-  // right hand
-  KC_RCBR,     KC_CIRC, KC_AMPR, KC_ASTR,KC_MINS, KC_EQL,    KC_BSPC,
+  /* right hand */
+  KC_RCBR,     KC_CIRC, KC_AMPR, KC_ASTR,KC_MINS, KC_EQL,    CFQ_USER_KEY0,
   KC_RPRN,     KC_Y,    KC_U,    KC_I,   KC_O,    KC_P,      KC_BSLS,
                KC_H,    KC_J,    KC_K,   KC_L,    KC_SCLN,   KC_QUOT,
   KC_RBRC,     KC_N,    KC_M,    KC_COMM,KC_DOT,  KC_SLSH,   KC_RSFT,
-                        KC_LEFT, KC_DOWN,KC_UP,   KC_RGHT,   KC_DELT,
+                        KC_LEFT, KC_DOWN,KC_UP,   KC_RGHT,   KC_INS,
   KC_HOME, KC_END,
   KC_PGUP,
-#ifdef CFQ_USE_SWAP_RIGHT_SPACE_ENTER
-  KC_PGDN, KC_SPC, KC_ENT
-#else
-  KC_PGDN, KC_ENT, KC_SPC
-#endif
-),
-/* Keymap 1: Symbol layer
+  KC_PGDN, CFQ_KC_FN2, KC_ENT
+),/* Keymap 1: KeyPad, Macro Record
  *
  * ,--------------------------------------------------.           ,--------------------------------------------------.
- * |        |  F1  |  F2  |  F3  |  F4  |  F5  |  {}  |           |  }{  |  F6  |  F7  |  F8  |  F9  |  F10 |        |
- * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
- * |        |      |      |      |      |  =>  |  ()  |           |  )(  |  <=  |   7  |   8  |   9  |   \  |   F11  |
+ * |        |      |      |      |      |      |  {}  |           |  }{  |      |NumLck|   /  |   *  |   -  |        |
+ * |--------+------+------+------+------+------+------|           |------+------+------+------+------+------+--------|
+ * |        |      |      |      |      |  =>  |  ()  |           |  )(  |  <=  |   7  |   8  |   9  |   +  |        |
  * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
- * |        |      |      |      |      |  ->  |------|           |------|  <-  |   4  |   5  |   6  |   *  |   F12  |
+ * |        |      |      |      |      |  ->  |------|           |------|  <-  |   4  |   5  |   6  |   +  |        |
  * |--------+------+------+------+------+------|  []  |           |  ][  |------+------+------+------+------+--------|
- * |        |      |      |      |      |  <>  |      |           |      |  ><  |   1  |   2  |   3  |   -  |        |
+ * |        |      |      |      |      |  <>  |      |           |      |  ><  |   1  |   2  |   3  | Enter|        |
  * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
- *   |      |      |      |      |      |                                       |   0  |      |   .  |   +  |      |
+ *   |      |      |      |      |      |                                       |   0  |      |   .  | Enter|      |
  *   `----------------------------------'                                       `----------------------------------'
- *                                        ,-------------.       ,---------------.
- *                                        |Start1|Start2|       |      |        |
- *                                 ,------|------|------|       |------+--------+------.
- *                                 |      |      | Stop |       |      |        |      |
- *                                 |Play1 |Play2 |------|       |------|        |      |
- *                                 |      |      |      |       |      |        |      |
- *                                 `--------------------'       `----------------------'
+ *                                        ,-------------.       ,--------------.
+ *                                        |Start1|Start2|       |      |       |
+ *                                 ,------+------+------|       |------+-------+------.
+ *                                 |      |      | Stop |       |      |       |      |
+ *                                 |Play1 |Play2 |------|       |------|       |      |
+ *                                 |      |      |      |       |      |       |      |
+ *                                 `--------------------'       `---------------------'
  */
-// SYMBOLS
+/* SYMBOLS */
 [SYMB] = LAYOUT_ergodox(
-  // left hand
-  KC_TRNS, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,               M(M_BRACKET_IN_CBR),
-  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, M(M_ARROW_REQL),     M(M_BRACKET_IN_PRN),
-  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, M(M_ARROW_RMINUS),
-  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, M(M_BRACKET_IN_ANG), M(M_BRACKET_IN_BRC),
+  /* left hand */
+  KC_TRNS, KC_TRNS,   KC_TRNS,   KC_TRNS,   KC_TRNS,   KC_TRNS,            M_BRACKET_IN_CBR,
+  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, M_ARROW_REQL,     M_BRACKET_IN_PRN,
+  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, M_ARROW_RMINUS,
+  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, M_BRACKET_IN_ANG, M_BRACKET_IN_BRC,
   KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
 #ifdef CFQ_USE_DYNAMIC_MACRO
                                DYN_REC_START1, DYN_REC_START2,
@@ -195,21 +277,21 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
                                                KC_TRNS,
                              KC_TRNS, KC_TRNS, KC_TRNS,
 #endif
-  // right hand
-  M(M_BRACKET_OUT_CBR), KC_F6,                KC_F7,   KC_F8,   KC_F9,     KC_F10,         KC_TRNS,
-  M(M_BRACKET_OUT_PRN), M(M_ARROW_LEQL),      KC_KP_7, KC_KP_8, KC_KP_9,   KC_KP_SLASH,    KC_F11,
-                        M(M_ARROW_LMINUS),    KC_KP_4, KC_KP_5, KC_KP_6,   KC_KP_ASTERISK, KC_F12,
-  M(M_BRACKET_OUT_BRC), M(M_BRACKET_OUT_ANG), KC_KP_1, KC_KP_2, KC_KP_3,   KC_KP_MINUS,    KC_TRNS,
-                                              KC_KP_0, KC_TRNS, KC_KP_DOT, KC_KP_PLUS,     KC_TRNS,
+  /* right hand */
+  M_BRACKET_OUT_CBR, KC_TRNS,           KC_NLCK, KC_KP_SLASH, KC_KP_ASTERISK, KC_KP_MINUS,  KC_TRNS,
+  M_BRACKET_OUT_PRN, M_ARROW_LEQL,      KC_KP_7, KC_KP_8,     KC_KP_9,        KC_KP_PLUS,  KC_TRNS,
+                     M_ARROW_LMINUS,    KC_KP_4, KC_KP_5,     KC_KP_6,        KC_KP_PLUS,  KC_TRNS,
+  M_BRACKET_OUT_BRC, M_BRACKET_OUT_ANG, KC_KP_1, KC_KP_2,     KC_KP_3,        KC_KP_ENTER, KC_TRNS,
+                                        KC_KP_0, KC_TRNS,     KC_KP_DOT,      KC_KP_ENTER, KC_TRNS,
   KC_TRNS, KC_TRNS,
   KC_TRNS,
   KC_TRNS, KC_TRNS, KC_TRNS
 ),
-/* Keymap 2: Media and mouse keys
+/* Keymap 2: F-Keys, media and mouse keys
  *
  * ,--------------------------------------------------.           ,--------------------------------------------------.
  * |        |      |      |      |      |      |      |           |      |      |      |      |      |      |        |
- * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
+ * |--------+------+------+------+------+------+------|           |------+------+------+------+------+------+--------|
  * |        |      |      | MsUp |      |      |MWhlUp|           |      |      |      |      |      |      |        |
  * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
  * |        |      |MsLeft|MsDown|MsRght|      |------|           |------| Left | Down | Up   |Right |      |        |
@@ -220,15 +302,15 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  *   `----------------------------------'                                       `----------------------------------'
  *                                        ,-------------.       ,-------------.
  *                                        | MRwd | MFwd |       | MPrv | MNxt |
- *                                 ,------|------|------|       |------+------+------.
+ *                                 ,------+------+------|       |------+------+------.
  *                                 |      |      |      |       |VolUp |      |      |
- *                                 |      |      |------|       |------| Mute | Play |
+ *                                 | Mute |      |------|       |------|      | Play |
  *                                 |      |      |      |       |VolDn |      |      |
  *                                 `--------------------'       `--------------------'
  */
-// MEDIA AND MOUSE
+/* MEDIA AND MOUSE */
 [MDIA] = LAYOUT_ergodox(
-  // left hand
+  /* left hand */
   KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
   KC_TRNS, KC_TRNS, KC_TRNS, KC_MS_U, KC_TRNS, KC_TRNS, KC_WH_U,
   KC_TRNS, KC_TRNS, KC_MS_L, KC_MS_D, KC_MS_R, KC_TRNS,
@@ -236,131 +318,66 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
                                       KC_MRWD, KC_MFFD,
                                                KC_TRNS,
-                             KC_TRNS, KC_TRNS, KC_TRNS,
-  // right hand
-  KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+                             KC_MUTE, KC_TRNS, KC_TRNS,
+  /* right hand */
+  KC_TRNS, KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,
   KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
             KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT, KC_TRNS, KC_TRNS,
   KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
                      KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
   KC_MPRV, KC_MNXT,
   KC_VOLU,
-  KC_VOLD, KC_MUTE, KC_MPLY
+  KC_VOLD, KC_TRNS, KC_MPLY
 ),
-#ifdef CFQ_USE_EXPEREMENTAL_LAYER
-/* Keymap 3: My own testing keys!
+/* Keymap 3: Entire Words (one for each key)
  *
  * ,--------------------------------------------------.           ,--------------------------------------------------.
- * |        |      |      |  {   |   }  |      |   }  |           |      |      |      |      |      |      |        |
- * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
- * |        |      |      |  (   |   )  |      |   )  |           |      | Spc7 | Spc8 |      |      |      |        |
+ * |        |  F1  |  F2  |  F3  |  F4  |  F5  |  F11 |           | F12  |  F6  |  F7  |  F8  |  F9  |  F10 |        |
+ * |--------+------+------+------+------+------+------|           |------+------+------+------+------+------+--------|
+ * |        |   Q  |   W  |   E  |   R  |   T  |      |           |      |   Y  |   U  |   I  |   O  |   P  |        |
  * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
- * |        |      |      |  [   |   ]  |      |------|           |------| Spc4 | Spc5 | Spc6 |      |      |        |
- * |--------+------+------+------+------+------|   ]  |           |      |------+------+------+------+------+--------|
- * |        |      |      |  <   |   >  |      |      |           |      | Spc1 | Spc2 | Spc3 |      |      |        |
+ * |        |   A  |   S  |   D  |   F  |   G  |------|           |------|   H  |   J  |   K  |   L  |      |        |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |        |   Z  |   X  |   C  |   V  |   B  |      |           |      |   N  |   M  |      |      |      |        |
  * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
  *   |      |      |      |      |      |                                       |      |      |      |      |      |
  *   `----------------------------------'                                       `----------------------------------'
  *                                        ,-------------.       ,-------------.
  *                                        |      |      |       |      |      |
- *                                 ,------|------|------|       |------+------+------.
+ *                                 ,------+------+------|       |------+------+------.
  *                                 |      |      |      |       |      |      |      |
  *                                 |      |      |------|       |------|      |      |
  *                                 |      |      |      |       |      |      |      |
  *                                 `--------------------'       `--------------------'
  */
 
-// EXPERIMENT
-[EXPR] = LAYOUT_ergodox(
-  // left hand
-  KC_TRNS, KC_TRNS, KC_TRNS, KC_LCBR,    KC_RCBR,    KC_TRNS, KC_RCBR,
-  KC_TRNS, KC_TRNS, KC_TRNS, KC_LPRN,    KC_RPRN,    KC_TRNS, KC_RPRN,
-  KC_TRNS, KC_TRNS, KC_TRNS, KC_LBRC,    KC_RBRC,	 KC_TRNS,
-  KC_TRNS, KC_TRNS, KC_TRNS, S(KC_COMM), S(KC_DOT),  KC_TRNS, KC_RBRC,
-  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,    KC_TRNS,
-                                         KC_TRNS, KC_TRNS,
-                                                  KC_TRNS,
-                                KC_TRNS, KC_TRNS, KC_TRNS,
-  // right hand
-  KC_TRNS, KC_TRNS, KC_TRNS,       KC_TRNS,       KC_TRNS,       KC_TRNS, KC_TRNS,
-  KC_TRNS, KC_TRNS, M(M_SPACES_7), M(M_SPACES_8), KC_TRNS,       KC_TRNS, KC_TRNS,
-           KC_TRNS, M(M_SPACES_4), M(M_SPACES_5), M(M_SPACES_6), KC_TRNS, KC_TRNS,
-  KC_TRNS, KC_TRNS, M(M_SPACES_1), M(M_SPACES_2), M(M_SPACES_3), KC_TRNS, KC_TRNS,
-  KC_TRNS, KC_TRNS, KC_TRNS,       KC_TRNS,       KC_TRNS,
+/* WORDS */
+[WORD] = LAYOUT_ergodox(
+  /* left hand */
+  KC_TRNS, KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F11,
+  KC_TRNS, M_WORD_Q, M_WORD_W, M_WORD_E, M_WORD_R, M_WORD_T, KC_TRNS,
+  KC_TRNS, M_WORD_A, M_WORD_S, M_WORD_D, M_WORD_F, M_WORD_G,
+  KC_TRNS, M_WORD_Z, M_WORD_X, M_WORD_C, M_WORD_V, M_WORD_B, KC_TRNS,
+  KC_TRNS, KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,
+                                                   KC_TRNS,  KC_TRNS,
+                                                             KC_TRNS,
+                                         KC_TRNS,  KC_TRNS,  KC_TRNS,
+  /* right hand */
+  KC_F12,  KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_TRNS,
+  KC_TRNS, M_WORD_Y, M_WORD_U, M_WORD_I, M_WORD_O, M_WORD_P, KC_TRNS,
+           M_WORD_H, M_WORD_J, M_WORD_K, M_WORD_L, KC_TRNS,  KC_TRNS,
+  KC_TRNS, M_WORD_N, M_WORD_M, KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,
+                     KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,
   KC_TRNS, KC_TRNS,
   KC_TRNS,
   KC_TRNS, KC_TRNS, KC_TRNS
 ),
-#endif // CFQ_USE_EXPEREMENTAL_LAYER
 };
 
 const uint16_t PROGMEM fn_actions[] = {
-  [1] = ACTION_LAYER_TAP_TOGGLE(SYMB),               // FN1 - Momentary Layer 1 (Symbols)
-  [2] = ACTION_LAYER_TAP_TOGGLE(MDIA),               // FN2 - Momentary Layer 2 (Media)
-#ifdef CFQ_USE_EXPEREMENTAL_LAYER
-  [3] = ACTION_LAYER_TAP_TOGGLE(EXPR),               // FN3 - Momentary Layer 3 (Expremental)
-#endif
-};
-
-const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
-{
-  // MACRODOWN only works in this function
-  switch(id) {
-    case 0:
-    if (record->event.pressed) {
-      SEND_STRING (QMK_KEYBOARD "/" QMK_KEYMAP " @ " QMK_VERSION);
-    }
-    break;
-    case 1:
-    if (record->event.pressed) { // For resetting EEPROM
-      eeconfig_init();
-    }
-    break;
-#ifdef CFQ_USE_EXPEREMENTAL_LAYER
-    case M_SPACES_1:
-      if (record->event.pressed) { return MACRO(T(SPC), END); }
-    case M_SPACES_2:
-      if (record->event.pressed) { return MACRO(T(SPC), T(SPC), END); }
-    case M_SPACES_3:
-      if (record->event.pressed) { return MACRO(T(SPC), T(SPC), T(SPC), END); }
-    case M_SPACES_4:
-      if (record->event.pressed) { return MACRO(T(SPC), T(SPC), T(SPC), T(SPC), END); }
-    case M_SPACES_5:
-      if (record->event.pressed) { return MACRO(T(SPC), T(SPC), T(SPC), T(SPC), T(SPC), END); }
-    case M_SPACES_6:
-      if (record->event.pressed) { return MACRO(T(SPC), T(SPC), T(SPC), T(SPC), T(SPC), T(SPC), END); }
-    case M_SPACES_7:
-      if (record->event.pressed) { return MACRO(T(SPC), T(SPC), T(SPC), T(SPC), T(SPC), T(SPC), T(SPC), END); }
-    case M_SPACES_8:
-      if (record->event.pressed) { return MACRO(T(SPC), T(SPC), T(SPC), T(SPC), T(SPC), T(SPC), T(SPC), T(SPC), END); }
-#endif // CFQ_USE_EXPEREMENTAL_LAYER
-    case M_BRACKET_IN_CBR: // {}
-      if (record->event.pressed) { return MACRO(D(LSFT), T(LBRC), T(RBRC), U(LSFT), T(LEFT), END); }
-    case M_BRACKET_IN_PRN: // ()
-      if (record->event.pressed) { return MACRO(D(LSFT), T(9), T(0), U(LSFT), T(LEFT), END); }
-    case M_BRACKET_IN_BRC: // []
-      if (record->event.pressed) { return MACRO(T(LBRC), T(RBRC), T(LEFT), END); }
-    case M_BRACKET_IN_ANG: // <>
-      if (record->event.pressed) { return MACRO(D(LSFT), T(COMM), T(DOT), U(LSFT), T(LEFT), END); }
-    case M_BRACKET_OUT_CBR: // }{
-      if (record->event.pressed) { return MACRO(D(LSFT), T(RBRC), T(LBRC), U(LSFT), T(LEFT), END); }
-    case M_BRACKET_OUT_PRN: // )(
-      if (record->event.pressed) { return MACRO(D(LSFT), T(0), T(9), U(LSFT), T(LEFT), END); }
-    case M_BRACKET_OUT_BRC: // ][
-      if (record->event.pressed) { return MACRO(T(RBRC), T(LBRC), T(LEFT), END); }
-    case M_BRACKET_OUT_ANG: // ><
-      if (record->event.pressed) { return MACRO(D(LSFT), T(DOT), T(COMM), U(LSFT), T(LEFT), END); }
-
-    case M_ARROW_RMINUS:
-      if (record->event.pressed) { return MACRO(T(MINUS), D(LSFT), T(DOT), U(LSFT), END); }
-    case M_ARROW_LMINUS:
-      if (record->event.pressed) { return MACRO(D(LSFT), T(COMM), U(LSFT), T(MINUS), END); }
-    case M_ARROW_REQL:
-      if (record->event.pressed) { return MACRO(T(EQL), D(LSFT), T(DOT), U(LSFT), END); }
-    case M_ARROW_LEQL:
-      if (record->event.pressed) { return MACRO(D(LSFT), T(COMM), U(LSFT), T(EQL), END); }
-  }
-  return MACRO_NONE;
+  [1] = ACTION_LAYER_TAP_TOGGLE(SYMB),               /* FN1 - Momentary Layer 1 (Symbols) */
+  [2] = ACTION_LAYER_TAP_TOGGLE(MDIA),               /* FN2 - Momentary Layer 2 (Media) */
+  [3] = ACTION_LAYER_TAP_TOGGLE(WORD),               /* FN3 - Momentary Layer 3 (Words) */
 };
 
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
@@ -370,19 +387,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
   }
 #endif
   switch (keycode) {
-    // dynamically generate these.
-    case EPRM:
-      if (record->event.pressed) {
-        eeconfig_init();
-      }
-      return false;
-      break;
-    case VRSN:
-      if (record->event.pressed) {
-        SEND_STRING (QMK_KEYBOARD "/" QMK_KEYMAP " @ " QMK_VERSION);
-      }
-      return false;
-      break;
+    /* dynamically generate these. */
     case RGB_SLD:
       if (record->event.pressed) {
 #ifdef RGBLIGHT_ENABLE
@@ -391,16 +396,115 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
       }
       return false;
       break;
+    case M_BRACKET_IN_CBR:  /* {} */
+      if (record->event.pressed) {
+        SEND_STRING("{}" SS_TAP(X_LEFT));
+        return false;
+      }
+      break;
+    case M_BRACKET_IN_PRN:  /* () */
+      if (record->event.pressed) {
+        SEND_STRING("()" SS_TAP(X_LEFT));
+        return false;
+      }
+      break;
+    case M_BRACKET_IN_BRC:  /* [] */
+      if (record->event.pressed) {
+        SEND_STRING("[]" SS_TAP(X_LEFT));
+        return false;
+      }
+      break;
+    case M_BRACKET_IN_ANG:  /* <> */
+      if (record->event.pressed) {
+        SEND_STRING("<>" SS_TAP(X_LEFT));
+        return false;
+      }
+      break;
+    case M_BRACKET_OUT_CBR:  /* }{ */
+      if (record->event.pressed) {
+        SEND_STRING("}{" SS_TAP(X_LEFT));
+        return false;
+      }
+      break;
+    case M_BRACKET_OUT_PRN:  /* )( */
+      if (record->event.pressed) {
+        SEND_STRING(")(" SS_TAP(X_LEFT));
+        return false;
+      }
+      break;
+    case M_BRACKET_OUT_BRC:  /* ][ */
+      if (record->event.pressed) {
+        SEND_STRING("][" SS_TAP(X_LEFT));
+        return false;
+      }
+      break;
+    case M_BRACKET_OUT_ANG:  /* >< */
+      if (record->event.pressed) {
+        SEND_STRING("><" SS_TAP(X_LEFT));
+        return false;
+      }
+      break;
+    case M_ARROW_LMINUS:  /* <- */
+      if (record->event.pressed) {
+        SEND_STRING("<-");
+        return false;
+      }
+      break;
+    case M_ARROW_RMINUS:  /* -> */
+      if (record->event.pressed) {
+        SEND_STRING("->");
+        return false;
+      }
+      break;
+    case M_ARROW_LEQL:  /* <= */
+      if (record->event.pressed) {
+        SEND_STRING("<=");
+        return false;
+      }
+      break;
+    case M_ARROW_REQL:  /* => */
+      if (record->event.pressed) {
+        SEND_STRING("=>");
+        return false;
+      }
+      break;
+    case KC_LSHIFT:  /* '' */
+      if (record->event.pressed && (keyboard_report->mods & (MOD_BIT(KC_RSFT)))) {
+        clear_mods();
+        SEND_STRING("''" SS_TAP(X_LEFT) SS_DOWN(X_RSHIFT) SS_DOWN(X_LSHIFT));
+        return false;
+      }
+      break;
+    case KC_RSHIFT:  /* "" */
+      if (record->event.pressed && (keyboard_report->mods & (MOD_BIT(KC_LSFT)))) {
+        clear_mods();
+        SEND_STRING("\x22\x22" SS_TAP(X_LEFT) SS_DOWN(X_LSHIFT) SS_DOWN(X_RSHIFT));
+        return false;
+      }
+      break;
+
+    case M_WORD_A...M_WORD_Z:
+    {
+      const char *word = cfq_word_lut[keycode - M_WORD_A];
+      if (record->event.pressed) {
+        if (*word) {
+          send_string(word);
+        }
+        return false;
+      }
+      break;
+    }
   }
+
   return true;
 }
 
-// Runs just one time when the keyboard initializes.
+/* Runs just one time when the keyboard initializes. */
 void matrix_init_user(void) {
 
 };
 
-// Runs constantly in the background, in a loop.
+/* Runs constantly in the background, in a loop. */
 void matrix_scan_user(void) {
 
   uint8_t layer = biton32(layer_state);
@@ -416,13 +520,11 @@ void matrix_scan_user(void) {
     case 2:
       ergodox_right_led_2_on();
       break;
-#ifdef CFQ_USE_EXPEREMENTAL_LAYER
     case 3:
       ergodox_right_led_3_on();
       break;
-#endif
     default:
-      // none
+      /* none */
       break;
   }
 

--- a/layouts/community/ergodox/qwerty_code_friendly/readme.md
+++ b/layouts/community/ergodox/qwerty_code_friendly/readme.md
@@ -3,7 +3,8 @@
 - This layout aims to balance muscle memory from a typical QWERTY layout
   with having keys used for software development easily accessible.
 
-- Arrow keys follow VIM convention (the media layer even uses arrow keys for HJKL).
+- Arrow keys follow VIM convention
+  (the media layer even uses arrow keys for HJKL).
 
 - On the top row only symbols are used (not numbers),
   it's expected the symbol layer's number-pad layout will be used for numbers.
@@ -17,65 +18,75 @@
   at the same key locations to type matching pairs.
 
 - The extra space-bar on the lower-left looks like it's in an obscure location,
-  however using the larger thumb cluster ended up being more of a reach while typing.
+  however using the larger thumb cluster
+  ended up being more of a reach while typing.
 
-- L3 is currently only used if `CFQ_USE_EXPEREMENTAL_LAYER` is defined,
-  this is a layer to place extra functionality and test new keys.
+- There is a handy shortcut for writing quotes that inserts the cursor
+  between the quotation marks.
+
+  Holding LShift, then RShift types: "" (then presses left).
+
+  Holding RShift, then LShift types: '' (then presses left).
 
 ## Configuration
 
 Some optional behavior is configurable without editing the code
 using `CFQ_` prefixed defines which can be set by passing `EXTRAFLAGS` to make.
 
-- `CFQ_USER_KEY1` (1..7) are used for custom-keys
-- `CFQ_USE_MOMENTARY_LAYER_KEYS` is used to prevent layer keys from toggling when tapped.
-- `CFQ_USE_SWAP_RIGHT_SPACE_ENTER` swap Enter and Space on the right hand thumb cluster.
-  While asymmetric, it makes Enter more easily accessible.
-- `CFQ_USE_EXPEREMENTAL_LAYER` defines an extra layer for misc extra keys/macros.
-  When set, Caps-Lock is replace by Layer3.
-  Currently it's mostly empty.
+- `CFQ_USER_KEY0`
+  (0..7) are used for custom-keys
+- `CFQ_USE_MOMENTARY_LAYER_KEYS`
+  is used to prevent layer keys from toggling when tapped.
+- `CFQ_WORD_[A-Z]`
+  defines can bind a key to an entire user defined word.
 
 
 
 ## Keymap 0: Basic layer
 
 ```
-Keymap 0: Basic layer
 ,--------------------------------------------------.           ,--------------------------------------------------.
 | Grave  |   !  |   @  |   #  |   $  |   %  |   {  |           |  }   |   ^  |   &  |   *  |   -  |   =  | BSpace |
-|--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
+|--------+------+------+------+------+------+------|           |------+------+------+------+------+------+--------|
 | Tab    |   Q  |   W  |   E  |   R  |   T  |   (  |           |  )   |   Y  |   U  |   I  |   O  |   P  |   \    |
 |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
 | Esc    |   A  |   S  |   D  |   F  |   G  |------|           |------|   H  |   J  |   K  |   L  |   ;  |   '    |
 |--------+------+------+------+------+------|   [  |           |  ]   |------+------+------+------+------+--------|
 | LShift |   Z  |   X  |   C  |   V  |   B  |      |           |      |   N  |   M  |   ,  |   .  |   /  | RShift |
 `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
-  | LCtl |Super | Alt  | ~L1  |Space |                                       | Left | Down | Up   |Right | Del  |
+  | LCtl |Super | Alt  | ~L1  |Space |                                       | Left | Down | Up   |Right | Ins  |
   `----------------------------------'                                       `----------------------------------'
                                        ,-------------.       ,-------------.
-                                       | Ins  |CapsLk|       | Home | End  |
-                                ,------|------|------|       |------+------+------.
-                                |      |      | ~L2  |       | PgUp |      |      |
-                                |Space |Enter |------|       |------|Enter |Space |
-                                |      |      | ~L1  |       | PgDn |      |      |
+                                       |   <  |  >   |       | Home | End  |
+                                ,------+------+------|       |------+------+------.
+                                |      |      |CapsLk|       | PgUp |      |      |
+                                |BSpace| Del  |------|       |------| ~L2  |Space |
+                                |      |      | ~L3  |       | PgDn |      |      |
                                 `--------------------'       `--------------------'
 
-Optional overrides: see CFQ_USER_KEY# defines
+Optional overrides: see CFQ_USER_KEY# defines.
 
-  -------+------+------+------+------+
-  |      |      |      | USR1 |      |
-  `----------------------------------'
-
-                                       ,-------------.
-                                       | USR2 | USR3 |
-                                ,------|------|------|
-                                |      |      | USR6 |
-                                | USR4 | USR5 |------|
-                                |      |      | USR7 |
-                                `--------------------'
+,--------------------------------------------------.           ,--------------------------------------------------.
+|        |      |      |      |      |      |      |           |      |      |      |      |      |      | USR0   |
+|--------+------+------+------+------+------+------|           |------+------+------+------+------+------+--------|
+|        |      |      |      |      |      |      |           |      |      |      |      |      |      |        |
+|--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+|        |      |      |      |      |      |------|           |------|      |      |      |      |      |        |
+|--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+|        |      |      |      |      |      |      |           |      |      |      |      |      |      |        |
+`--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
+  |      |      |      | USR1 |      |                                       |      |      |      |      |      |
+  `----------------------------------'                                       `----------------------------------'
+                                       ,-------------.       ,-------------.
+                                       | USR2 | USR3 |       |      |      |
+                                ,------+------+------|       |------+------+------.
+                                |      |      | USR6 |       |      |      |      |
+                                | USR4 | USR5 |------|       |------|      |      |
+                                |      |      | USR7 |       |      |      |      |
+                                `--------------------'       `--------------------'
 ```
 
-## Keymap 1: Symbol layer
+## Keymap 1: KeyPad, Macro Record
 
 Notes:
 
@@ -84,31 +95,31 @@ Notes:
 
 ```
 ,--------------------------------------------------.           ,--------------------------------------------------.
-|        |  F1  |  F2  |  F3  |  F4  |  F5  |  {}  |           |  }{  |  F6  |  F7  |  F8  |  F9  |  F10 |        |
-|--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
-|        |      |      |      |      |  =>  |  ()  |           |  )(  |  <=  |   7  |   8  |   9  |   \  |   F11  |
+|        |      |      |      |      |      |  {}  |           |  }{  |      |NumLck|   /  |   *  |   -  |        |
+|--------+------+------+------+------+------+------|           |------+------+------+------+------+------+--------|
+|        |      |      |      |      |  =>  |  ()  |           |  )(  |  <=  |   7  |   8  |   9  |   +  |        |
 |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
-|        |      |      |      |      |  ->  |------|           |------|  <-  |   4  |   5  |   6  |   *  |   F12  |
+|        |      |      |      |      |  ->  |------|           |------|  <-  |   4  |   5  |   6  |   +  |        |
 |--------+------+------+------+------+------|  []  |           |  ][  |------+------+------+------+------+--------|
-|        |      |      |      |      |  <>  |      |           |      |  ><  |   1  |   2  |   3  |   -  |        |
+|        |      |      |      |      |  <>  |      |           |      |  ><  |   1  |   2  |   3  | Enter|        |
 `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
-  |      |      |      |      |      |                                       |   0  |      |   .  |   +  |      |
+  |      |      |      |      |      |                                       |   0  |      |   .  | Enter|      |
   `----------------------------------'                                       `----------------------------------'
-                                       ,-------------.       ,---------------.
-                                       |Start1|Start2|       |      |        |
-                                ,------|------|------|       |------+--------+------.
-                                |      |      | Stop |       |      |        |      |
-                                |Play1 |Play2 |------|       |------|        |      |
-                                |      |      |      |       |      |        |      |
-                                `--------------------'       `----------------------'
+                                       ,-------------.       ,--------------.
+                                       |Start1|Start2|       |      |       |
+                                ,------+------+------|       |------+-------+------.
+                                |      |      | Stop |       |      |       |      |
+                                |Play1 |Play2 |------|       |------|       |      |
+                                |      |      |      |       |      |       |      |
+                                `--------------------'       `---------------------'
 ```
 
-## Keymap 2: Media and mouse keys
+## Keymap 2: Keymap 2: Media and mouse keys
 
 ```
 ,--------------------------------------------------.           ,--------------------------------------------------.
 |        |      |      |      |      |      |      |           |      |      |      |      |      |      |        |
-|--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
+|--------+------+------+------+------+------+------|           |------+------+------+------+------+------+--------|
 |        |      |      | MsUp |      |      |MWhlUp|           |      |      |      |      |      |      |        |
 |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
 |        |      |MsLeft|MsDown|MsRght|      |------|           |------| Left | Down | Up   |Right |      |        |
@@ -119,14 +130,52 @@ Notes:
   `----------------------------------'                                       `----------------------------------'
                                        ,-------------.       ,-------------.
                                        | MRwd | MFwd |       | MPrv | MNxt |
-                                ,------|------|------|       |------+------+------.
+                                ,------+------+------|       |------+------+------.
                                 |      |      |      |       |VolUp |      |      |
-                                |      |      |------|       |------| Mute | Play |
+                                | Mute |      |------|       |------|      | Play |
                                 |      |      |      |       |VolDn |      |      |
                                 `--------------------'       `--------------------'
 ```
 
+## Keymap 3: K-Keys & User defined words
+
+This is for assigning whole words to single keys.
+You can define the arguments (which must be quoted) using: `CFQ_WORD_[A-Z]`
+eg: `-DCFQ_WORD_E=\"my@email.com\"`
+
+```
+,--------------------------------------------------.           ,--------------------------------------------------.
+|        |  F1  |  F2  |  F3  |  F4  |  F5  |  F11 |           | F12  |  F6  |  F7  |  F8  |  F9  |  F10 |        |
+|--------+------+------+------+------+------+------|           |------+------+------+------+------+------+--------|
+|        |   Q  |   W  |   E  |   R  |   T  |      |           |      |   Y  |   U  |   I  |   O  |   P  |        |
+|--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+|        |   A  |   S  |   D  |   F  |   G  |------|           |------|   H  |   J  |   K  |   L  |      |        |
+|--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+|        |   Z  |   X  |   C  |   V  |   B  |      |           |      |   N  |   M  |      |      |      |        |
+`--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
+  |      |      |      |      |      |                                       |      |      |      |      |      |
+  `----------------------------------'                                       `----------------------------------'
+                                       ,-------------.       ,-------------.
+                                       |      |      |       |      |      |
+                                ,------+------+------|       |------+------+------.
+                                |      |      |      |       |      |      |      |
+                                |      |      |------|       |------|      |      |
+                                |      |      |      |       |      |      |      |
+                                `--------------------'       `--------------------'
+```
+
 ## Changelog
+
+- 2018/03/06
+  Add layer for user defined words (replaces `CFQ_USE_EXPEREMENTAL_LAYER`).
+
+  Minor changes to thumb cluster.
+
+  Move backspace to left thumb, optionally remap the top right backspace.
+
+  Make keypad layout match a typical numpad.
+
+  Move F-Keys to layer 3.
 
 - 2017/11/09
   Use Caps-Lock when `CFQ_USE_EXPEREMENTAL_LAYER` isn't defined.


### PR DESCRIPTION
- Remove action_get_macro in favor of process_record_user
- Support user defined words on layer 3 (pass via flags)
- Support backspace & del on left thumb cluster.
  (optionally override top right backspace).