### PR TITLE
Added a clean target to remove build artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,12 @@ generate-keyboards-file:
 	$(foreach PRINTING_KEYBOARD,$(KEYBOARDS),$(eval $(call PRINT_KEYBOARD)))
 	exit 0
 
+clean:
+	echo -n 'Deleting .build ... '
+	rm -rf $(BUILD_DIR)
+	echo 'done'
+	exit 0
+
 #Compatibility with the old make variables, anything you specify directly on the command line
 # always overrides the detected folders
 ifdef keyboard


### PR DESCRIPTION
This commit adds a new clean target to the makefile which deletes the .build directory which in turn removes all build artifacts.

Using it is as simple as `make clean`. I usually needs this if I want to force a rebuilt and thought I'd share as the old `make allkb-clean` does not work any more :)