### PR TITLE
Create sendstring_spanish.h

### DIFF
--- a/quantum/keymap_extras/sendstring_spanish.h
+++ b/quantum/keymap_extras/sendstring_spanish.h
@@ -1,0 +1,71 @@
+/* Copyright 2018 Daniel Rodríguez
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/* Sendstring definitions for the Spanish layout */
+#ifndef SENDSTRING_SPANISH
+#define SENDSTRING_SPANISH
+
+#include "keymap_spanish.h"
+
+const bool ascii_to_shift_lut[0x80] PROGMEM = {
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+
+    0, 1, 1, 1, 1, 1, 1, 0,
+    1, 1, 1, 0, 0, 0, 0, 1,
+    0, 0, 0, 0, 0, 0, 0, 0,
+
+    0, 0, 1, 1, 0, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,
+    
+    1, 1, 1, 0, 0, 0, 1, 1,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 1, 1, 1, 1, 0
+};
+
+/* Until an ALT table/functionality is added, the following symbols will not work:
+ # @ [ ] { } | ~
+*/
+const uint8_t ascii_to_keycode_lut[0x80] PROGMEM = {
+    0, 0, 0, 0, 0, 0, 0, 0,
+    KC_BSPC, KC_TAB, KC_ENT, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, KC_ESC, 0, 0, 0, 0,
+/*        ,   !    "      #     $    %     &      '    */
+    KC_SPC, KC_1, KC_2, KC_3, KC_4, KC_5, KC_6, ES_APOS,
+/*    (     )       *        +         ,       -        .     /    */
+    KC_8, KC_9, ES_PLUS,  ES_PLUS, KC_COMM, ES_MINS, KC_DOT, KC_7,
+    KC_0, KC_1, KC_2, KC_3, KC_4, KC_5, KC_6, KC_7,
+/*    8     9       :        ;        <      =     >         ?    */
+    KC_8, KC_9, KC_DOT, KC_COMM, KC_NUBS,  KC_0, KC_NUBS,  ES_APOS,
+/*    @     A      B    C    D      E     F     G                 */
+    KC_2, KC_A, KC_B, KC_C, KC_D, KC_E, KC_F, KC_G,
+    KC_H, KC_I, KC_J, KC_K, KC_L, KC_M, KC_N, KC_O,
+    KC_P, KC_Q, KC_R, KC_S, KC_T, KC_U, KC_V, KC_W,
+/*    X     Y     Z      [         \      ]        ^       _    */    
+    KC_X, KC_Y, KC_Z, KC_LBRC, KC_BSLS, KC_RBRC, ES_GRV, ES_MINS,
+    ES_GRV, KC_A, KC_B, KC_C, KC_D, KC_E, KC_F, KC_G,
+    KC_H, KC_I, KC_J, KC_K, KC_L, KC_M, KC_N, KC_O,
+    KC_P, KC_Q, KC_R, KC_S, KC_T, KC_U, KC_V, KC_W,
+    KC_X, KC_Y, KC_Z, KC_LBRC, KC_BSLS, KC_RBRC, KC_GRV, KC_DEL
+};
+
+#endif


### PR DESCRIPTION
This makes possible to use SEND_STRING with a spanish keyboard for almost all symbols except the ones that require ALT, which are documented on the code comments.
I am not adding any documentation because the functionality is not complete until a way to specify alted symbols is added.