### PR TITLE
Add teensy revision folder for Orthodox Rev3

### DIFF
--- a/keyboards/orthodox/orthodox.h
+++ b/keyboards/orthodox/orthodox.h
@@ -5,7 +5,10 @@
     #include "rev1.h"
 #endif
 #ifdef KEYBOARD_orthodox_rev3
-    #include "rev3.h"
+#include "rev3.h"
+#endif
+#ifdef KEYBOARD_orthodox_rev3_teensy
+#include "rev3_teensy.h"
 #endif
 
 // Used to create a keymap using only KC_ prefixed keys

--- a/keyboards/orthodox/rev1/config.h
+++ b/keyboards/orthodox/rev1/config.h
@@ -45,11 +45,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MATRIX_COL_PINS { D7, F4, F5, F6, F7, B1, B3, B2, B6 }
 //#define MATRIX_COL_PINS { B2, B3, B1, F7, F6, F5, F4, D7 }
 
-/*/
-//TEENSY
-#define MATRIX_ROW_PINS { D0, C6, C7, }
-#define MATRIX_COL_PINS { D2, F5, F6, F7, B6, B5, B4, D7, D6 }
-/*/
 
 /* COL2ROW or ROW2COL */
 #define DIODE_DIRECTION COL2ROW
@@ -70,7 +65,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* key combination for command */
 #define IS_COMMAND() ( \
-    keyboard_report->mods == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT)) \
+    keyboard_report->mods == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_LGUI)) \
 )
 
 /* ws2812 RGB LED */

--- a/keyboards/orthodox/rev1/rules.mk
+++ b/keyboards/orthodox/rev1/rules.mk
@@ -1,1 +1,2 @@
 BACKLIGHT_ENABLE = no
+BOOTLOADER = caterina

--- a/keyboards/orthodox/rev3/config.h
+++ b/keyboards/orthodox/rev3/config.h
@@ -70,7 +70,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* key combination for command */
 #define IS_COMMAND() ( \
-    keyboard_report->mods == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT)) \
+    keyboard_report->mods == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_LGUI)) \
 )
 
 /* ws2812 RGB LED */

--- a/keyboards/orthodox/rev3/rules.mk
+++ b/keyboards/orthodox/rev3/rules.mk
@@ -1,1 +1,2 @@
 BACKLIGHT_ENABLE = no
+BOOTLOADER = caterina

--- a/keyboards/orthodox/rev3_teensy/config.h
+++ b/keyboards/orthodox/rev3_teensy/config.h
@@ -1,0 +1,95 @@
+/*
+This is the c configuration file for the subproject
+
+Copyright 2012 Jun Wako <wakojun@gmail.com>
+Copyright 2015 Jack Humbert
+Copyright 2017 Art Ortenburger
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef REV3_TEENSY_CONFIG_H
+#define REV3_TEENSY_CONFIG_H
+
+#include "config_common.h"
+
+/* USB Device descriptor parameter */
+#define VENDOR_ID       0xFEED
+#define PRODUCT_ID      0x3060
+#define DEVICE_VER      0x0001
+#define MANUFACTURER    deductivemonkee
+#define PRODUCT         Monkeebs Orthodox Rev.3 (Teensy)
+#define DESCRIPTION     Bananadox
+
+/* key matrix size */
+// Rows are doubled-up
+#define MATRIX_ROWS 6
+#define MATRIX_COLS 9
+
+// wiring of each half
+
+//REV.3 TEENSY
+#define MATRIX_ROW_PINS { B0, C6, C7, }
+#define MATRIX_COL_PINS { D2, F5, F6, D6, D7, B4, B5, B6, F7 }
+
+#define CATERINA_BOOTLOADER
+
+/* COL2ROW or ROW2COL */
+#define DIODE_DIRECTION COL2ROW
+
+/* define if matrix has ghost */
+//#define MATRIX_HAS_GHOST
+
+/* number of backlight levels */
+// #define BACKLIGHT_LEVELS 3
+
+/* Set 0 if debouncing isn't needed */
+#define DEBOUNCING_DELAY 5
+
+/* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
+// #define LOCKING_SUPPORT_ENABLE
+/* Locking resynchronize hack */
+// #define LOCKING_RESYNC_ENABLE
+
+/* key combination for command */
+#define IS_COMMAND() ( \
+    keyboard_report->mods == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT)) \
+)
+
+/* ws2812 RGB LED */
+//#define RGB_DI_PIN D3
+//#define RGBLIGHT_TIMER
+//#define RGBLED_NUM 16    // Number of LEDs
+//#define ws2812_PORTREG  PORTD
+//#define ws2812_DDRREG   DDRD
+
+/*
+ * Feature disable options
+ *  These options are also useful to firmware size reduction.
+ */
+
+/* disable debug print */
+// #define NO_DEBUG
+
+/* disable print */
+// #define NO_PRINT
+
+/* disable action features */
+//#define NO_ACTION_LAYER
+//#define NO_ACTION_TAPPING
+//#define NO_ACTION_ONESHOT
+//#define NO_ACTION_MACRO
+//#define NO_ACTION_FUNCTION
+
+#endif

--- a/keyboards/orthodox/rev3_teensy/config.h
+++ b/keyboards/orthodox/rev3_teensy/config.h
@@ -43,8 +43,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MATRIX_ROW_PINS { B0, C6, C7, }
 #define MATRIX_COL_PINS { D2, F5, F6, D6, D7, B4, B5, B6, F7 }
 
-#define CATERINA_BOOTLOADER
-
 /* COL2ROW or ROW2COL */
 #define DIODE_DIRECTION COL2ROW
 
@@ -64,7 +62,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* key combination for command */
 #define IS_COMMAND() ( \
-    keyboard_report->mods == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT)) \
+    keyboard_report->mods == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_LGUI)) \
 )
 
 /* ws2812 RGB LED */

--- a/keyboards/orthodox/rev3_teensy/rev3_teensy.c
+++ b/keyboards/orthodox/rev3_teensy/rev3_teensy.c
@@ -1,0 +1,35 @@
+/*
+This is the source file for the subproject
+
+Copyright 2012 Jun Wako <wakojun@gmail.com>
+Copyright 2015 Jack Humbert
+Copyright 2017 Art Ortenburger
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "orthodox.h"
+
+void matrix_init_kb(void) {
+
+  //// // green led on
+  //// DDRD |= (1<<5);
+  //// PORTD &= ~(1<<5);
+
+  //// // orange led on
+  //// DDRB |= (1<<0);
+  //// PORTB &= ~(1<<0);
+
+  matrix_init_user();
+};

--- a/keyboards/orthodox/rev3_teensy/rev3_teensy.h
+++ b/keyboards/orthodox/rev3_teensy/rev3_teensy.h
@@ -1,0 +1,47 @@
+/*
+This is the header file for the subproject
+
+Copyright 2012 Jun Wako <wakojun@gmail.com>
+Copyright 2015 Jack Humbert
+Copyright 2017 Art Ortenburger
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef REV3_TEENSY_H
+#define REV3_TEENSY_H
+
+#include "orthodox.h"
+
+//void promicro_bootloader_jmp(bool program);
+#include "quantum.h"
+
+//void promicro_bootloader_jmp(bool program);
+
+#define KEYMAP( \
+	L00, L01, L02, L03, L04, L05,                                  R00, R01, R02, R03, R04, R05, \
+	L10, L11, L12, L13, L14, L15,      L16, L18,    R10, R12,      R13, R14, R15, R16, R17, R18,  \
+	L20, L21, L22, L23, L24, L25, L26, L27, L28,    R20, R21, R22, R23, R24, R25, R26, R27, R28 \
+	) \
+	{ \
+		{ L00, L01, L02, L03, L04, L05 }, \
+		{ L10, L11, L12, L13, L14, L15, L16, KC_NO, L18}, \
+		{ L20, L21, L22, L23, L24, L25, L26, L27, L28 }, \
+		{ R05, R04, R03, R02, R01, R00 }, \
+		{ R18, R17, R16, R15, R14, R13, R12, KC_NO, R10 }, \
+		{ R28, R27, R26, R25, R24, R23, R22, R21, R20 } \
+	}
+
+#endif
+

--- a/keyboards/orthodox/rev3_teensy/rules.mk
+++ b/keyboards/orthodox/rev3_teensy/rules.mk
@@ -1,0 +1,1 @@
+BACKLIGHT_ENABLE = no

--- a/keyboards/orthodox/rev3_teensy/rules.mk
+++ b/keyboards/orthodox/rev3_teensy/rules.mk
@@ -1,1 +1,2 @@
 BACKLIGHT_ENABLE = no
+BOOTLOADER = halfkay

--- a/keyboards/orthodox/rules.mk
+++ b/keyboards/orthodox/rules.mk
@@ -4,7 +4,6 @@ SRC += matrix.c \
 	   serial.c
 
 # MCU name
-#MCU = at90usb1287
 MCU = atmega32u4
 
 # Processor frequency.
@@ -43,7 +42,6 @@ F_USB = $(F_CPU)
 #     This definition is optional, and if your keyboard supports multiple bootloaders of
 #     different sizes, comment this out, and the correct address will be loaded 
 #     automatically (+60). See bootloader.mk for all options.
-BOOTLOADER = caterina
 
 # Interrupt driven control endpoint task(+60)
 OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT


### PR DESCRIPTION
Create seperate revision folders for the teensy versions (rev 3 board supports both the Teensy 2.0 and Pro Micro controllers).