### PR TITLE
Add default keymap and layout information to the Contra keyboard

### DIFF
--- a/keyboards/contra/contra.h
+++ b/keyboards/contra/contra.h
@@ -14,5 +14,20 @@
 	{ K200,  K201,  K202,  K203,  K204,  K205,  K206,  K207,  K208,  K209,  K210,  K211 }, \
 	{ K300,  K301,  K302,  K303,  K304,  K305,  K306,  K307,  K308,  K309,  K310,  K311 }  \
 }
+#define KC_KEYMAP( \
+	k00, k01, k02, k03, k04, k05, k06, k07, k08, k09, k0a, k0b, \
+	k10, k11, k12, k13, k14, k15, k16, k17, k18, k19, k1a, k1b, \
+	k20, k21, k22, k23, k24, k25, k26, k27, k28, k29, k2a, k2b, \
+	k30, k31, k32, k33, k34, k35, k36, k37, k38, k39, k3a, k3b \
+	) \
+	KEYMAP( \
+		KC_##k00, KC_##k01, KC_##k02, KC_##k03, KC_##k04, KC_##k05, KC_##k06, KC_##k07, KC_##k08, KC_##k09, KC_##k0a, KC_##k0b, \
+		KC_##k10, KC_##k11, KC_##k12, KC_##k13, KC_##k14, KC_##k15, KC_##k16, KC_##k17, KC_##k18, KC_##k19, KC_##k1a, KC_##k1b, \
+		KC_##k20, KC_##k21, KC_##k22, KC_##k23, KC_##k24, KC_##k25, KC_##k26, KC_##k27, KC_##k28, KC_##k29, KC_##k2a, KC_##k2b, \
+		KC_##k30, KC_##k31, KC_##k32, KC_##k33, KC_##k34, KC_##k35, KC_##k36, KC_##k37, KC_##k38, KC_##k39, KC_##k3a, KC_##k3b \
+    )
+
+#define LAYOUT_ortho_4x12 KEYMAP
+#define KC_LAYOUT_ortho_4x12 KC_KEYMAP
 
 #endif

--- a/keyboards/contra/contra.h
+++ b/keyboards/contra/contra.h
@@ -3,7 +3,18 @@
 
 #include "quantum.h"
 
-#define KEYMAP( \
+#define LAYOUT_contra_2U_space( \
+	K000, K001, K002, K003, K004, K005, K006, K007, K008, K009, K010, K011, \
+	K100, K101, K102, K103, K104, K105, K106, K107, K108, K109, K110, K111, \
+	K200, K201, K202, K203, K204, K205, K206, K207, K208, K209, K210, K211, \
+	K300, K301, K302, K303, K304,    K305,    K307, K308, K309, K310, K311  \
+) { \
+	{ K000,  K001,  K002,  K003,  K004,  K005,  K006,  K007,  K008,  K009,  K010,  K011 }, \
+	{ K100,  K101,  K102,  K103,  K104,  K105,  K106,  K107,  K108,  K109,  K110,  K111 }, \
+	{ K200,  K201,  K202,  K203,  K204,  K205,  K206,  K207,  K208,  K209,  K210,  K211 }, \
+	{ K300,  K301,  K302,  K303,  K304,  K305,  K305,  K307,  K308,  K309,  K310,  K311 }  \
+}
+#define LAYOUT_contra_grid( \
 	K000, K001, K002, K003, K004, K005, K006, K007, K008, K009, K010, K011, \
 	K100, K101, K102, K103, K104, K105, K106, K107, K108, K109, K110, K111, \
 	K200, K201, K202, K203, K204, K205, K206, K207, K208, K209, K210, K211, \
@@ -20,14 +31,15 @@
 	k20, k21, k22, k23, k24, k25, k26, k27, k28, k29, k2a, k2b, \
 	k30, k31, k32, k33, k34, k35, k36, k37, k38, k39, k3a, k3b \
 	) \
-	KEYMAP( \
+	LAYOUT_contra_grid( \
 		KC_##k00, KC_##k01, KC_##k02, KC_##k03, KC_##k04, KC_##k05, KC_##k06, KC_##k07, KC_##k08, KC_##k09, KC_##k0a, KC_##k0b, \
 		KC_##k10, KC_##k11, KC_##k12, KC_##k13, KC_##k14, KC_##k15, KC_##k16, KC_##k17, KC_##k18, KC_##k19, KC_##k1a, KC_##k1b, \
 		KC_##k20, KC_##k21, KC_##k22, KC_##k23, KC_##k24, KC_##k25, KC_##k26, KC_##k27, KC_##k28, KC_##k29, KC_##k2a, KC_##k2b, \
 		KC_##k30, KC_##k31, KC_##k32, KC_##k33, KC_##k34, KC_##k35, KC_##k36, KC_##k37, KC_##k38, KC_##k39, KC_##k3a, KC_##k3b \
     )
 
-#define LAYOUT_ortho_4x12 KEYMAP
+#define KEYMAP LAYOUT_contra_grid
+#define LAYOUT_ortho_4x12 LAYOUT_contra_grid
 #define KC_LAYOUT_ortho_4x12 KC_KEYMAP
 
 #endif

--- a/keyboards/contra/keymaps/default/keymap.c
+++ b/keyboards/contra/keymaps/default/keymap.c
@@ -1,0 +1,262 @@
+/* Copyright 2015-2017 Jack Humbert
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 2 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include QMK_KEYBOARD_H
+
+extern keymap_config_t keymap_config;
+
+enum layers {
+  _QWERTY,
+  _COLEMAK,
+  _DVORAK,
+  _LOWER,
+  _RAISE,
+  _PLOVER,
+  _ADJUST
+};
+
+enum custom_keycodes {
+  QWERTY = SAFE_RANGE,
+  COLEMAK,
+  DVORAK,
+  PLOVER,
+  LOWER,
+  RAISE,
+  BACKLIT,
+  EXT_PLV
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+    /* Qwerty
+    * ,-----------------------------------------------------------------------------------.
+    * | Tab  |   Q  |   W  |   E  |   R  |   T  |   Y  |   U  |   I  |   O  |   P  | Bksp |
+    * |------+------+------+------+------+-------------+------+------+------+------+------|
+    * | Esc  |   A  |   S  |   D  |   F  |   G  |   H  |   J  |   K  |   L  |   ;  |  "   |
+    * |------+------+------+------+------+------|------+------+------+------+------+------|
+    * | Shift|   Z  |   X  |   C  |   V  |   B  |   N  |   M  |   ,  |   .  |   /  |Enter |
+    * |------+------+------+------+------+------+------+------+------+------+------+------|
+    * | Brite| Ctrl | Alt  | GUI  |Lower |    Space    |Raise | Left | Down |  Up  |Right |
+    * `-----------------------------------------------------------------------------------'
+    */
+  [_QWERTY] = LAYOUT_ortho_4x12(
+    KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_BSPC,
+    KC_ESC,  KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,
+    KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_ENT,
+    BACKLIT, KC_LCTL, KC_LALT, KC_LGUI, LOWER,   KC_SPC,  KC_SPC,  RAISE,   KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT
+  ),
+
+  /* Colemak
+  * ,-----------------------------------------------------------------------------------.
+  * | Tab  |   Q  |   W  |   F  |   P  |   G  |   J  |   L  |   U  |   Y  |   ;  | Bksp |
+  * |------+------+------+------+------+-------------+------+------+------+------+------|
+  * | Esc  |   A  |   R  |   S  |   T  |   D  |   H  |   N  |   E  |   I  |   O  |  "   |
+  * |------+------+------+------+------+------|------+------+------+------+------+------|
+  * | Shift|   Z  |   X  |   C  |   V  |   B  |   K  |   M  |   ,  |   .  |   /  |Enter |
+  * |------+------+------+------+------+------+------+------+------+------+------+------|
+  * | Brite| Ctrl | Alt  | GUI  |Lower |    Space    |Raise | Left | Down |  Up  |Right |
+  * `-----------------------------------------------------------------------------------'
+  */
+  [_COLEMAK] = LAYOUT_ortho_4x12(
+    KC_TAB,  KC_Q,    KC_W,    KC_F,    KC_P,    KC_G,    KC_J,    KC_L,    KC_U,    KC_Y,    KC_SCLN, KC_BSPC,
+    KC_ESC,  KC_A,    KC_R,    KC_S,    KC_T,    KC_D,    KC_H,    KC_N,    KC_E,    KC_I,    KC_O,    KC_QUOT,
+    KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_K,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_ENT,
+    BACKLIT, KC_LCTL, KC_LALT, KC_LGUI, LOWER,   KC_SPC,  KC_SPC,  RAISE,   KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT
+  ),
+
+  /* Dvorak
+  * ,-----------------------------------------------------------------------------------.
+  * | Tab  |   "  |   ,  |   .  |   P  |   Y  |   F  |   G  |   C  |   R  |   L  | Bksp |
+  * |------+------+------+------+------+-------------+------+------+------+------+------|
+  * | Esc  |   A  |   O  |   E  |   U  |   I  |   D  |   H  |   T  |   N  |   S  |  /   |
+  * |------+------+------+------+------+------|------+------+------+------+------+------|
+  * | Shift|   ;  |   Q  |   J  |   K  |   X  |   B  |   M  |   W  |   V  |   Z  |Enter |
+  * |------+------+------+------+------+------+------+------+------+------+------+------|
+  * | Brite| Ctrl | Alt  | GUI  |Lower |    Space    |Raise | Left | Down |  Up  |Right |
+  * `-----------------------------------------------------------------------------------'
+  */
+  [_DVORAK] = LAYOUT_ortho_4x12(
+    KC_TAB,  KC_QUOT, KC_COMM, KC_DOT,  KC_P,    KC_Y,    KC_F,    KC_G,    KC_C,    KC_R,    KC_L,    KC_BSPC,
+    KC_ESC,  KC_A,    KC_O,    KC_E,    KC_U,    KC_I,    KC_D,    KC_H,    KC_T,    KC_N,    KC_S,    KC_SLSH,
+    KC_LSFT, KC_SCLN, KC_Q,    KC_J,    KC_K,    KC_X,    KC_B,    KC_M,    KC_W,    KC_V,    KC_Z,    KC_ENT,
+    BACKLIT, KC_LCTL, KC_LALT, KC_LGUI, LOWER,   KC_SPC,  KC_SPC,  RAISE,   KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT
+  ),
+
+  /* Lower
+  * ,-----------------------------------------------------------------------------------.
+  * |   ~  |   !  |   @  |   #  |   $  |   %  |   ^  |   &  |   *  |   (  |   )  | Bksp |
+  * |------+------+------+------+------+-------------+------+------+------+------+------|
+  * | Del  |  F1  |  F2  |  F3  |  F4  |  F5  |  F6  |   _  |   +  |   {  |   }  |  |   |
+  * |------+------+------+------+------+------|------+------+------+------+------+------|
+  * |      |  F7  |  F8  |  F9  |  F10 |  F11 |  F12 |ISO ~ |ISO | | Home | End  |      |
+  * |------+------+------+------+------+------+------+------+------+------+------+------|
+  * |      |      |      |      |      |             |      | Next | Vol- | Vol+ | Play |
+  * `-----------------------------------------------------------------------------------'
+  */
+  [_LOWER] = LAYOUT_ortho_4x12(
+    KC_TILD, KC_EXLM, KC_AT,   KC_HASH, KC_DLR,  KC_PERC, KC_CIRC, KC_AMPR,    KC_ASTR,    KC_LPRN, KC_RPRN, KC_BSPC,
+    KC_DEL,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_UNDS,    KC_PLUS,    KC_LCBR, KC_RCBR, KC_PIPE,
+    _______, KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  S(KC_NUHS), S(KC_NUBS), KC_HOME, KC_END,  _______,
+    _______, _______, _______, _______, _______, _______, _______, _______,    KC_MNXT,    KC_VOLD, KC_VOLU, KC_MPLY
+  ),
+
+  /* Raise
+  * ,-----------------------------------------------------------------------------------.
+  * |   `  |   1  |   2  |   3  |   4  |   5  |   6  |   7  |   8  |   9  |   0  | Bksp |
+  * |------+------+------+------+------+-------------+------+------+------+------+------|
+  * | Del  |  F1  |  F2  |  F3  |  F4  |  F5  |  F6  |   -  |   =  |   [  |   ]  |  \   |
+  * |------+------+------+------+------+------|------+------+------+------+------+------|
+  * |      |  F7  |  F8  |  F9  |  F10 |  F11 |  F12 |ISO # |ISO / |Pg Up |Pg Dn |      |
+  * |------+------+------+------+------+------+------+------+------+------+------+------|
+  * |      |      |      |      |      |             |      | Next | Vol- | Vol+ | Play |
+  * `-----------------------------------------------------------------------------------'
+  */
+  [_RAISE] = LAYOUT_ortho_4x12(
+    KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_BSPC,
+    KC_DEL,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_MINS, KC_EQL,  KC_LBRC, KC_RBRC, KC_BSLS,
+    _______, KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_NUHS, KC_NUBS, KC_PGUP, KC_PGDN, _______,
+    _______, _______, _______, _______, _______, _______, _______, _______, KC_MNXT, KC_VOLD, KC_VOLU, KC_MPLY
+  ),
+
+  /* Plover layer (http://opensteno.org)
+  * ,-----------------------------------------------------------------------------------.
+  * |   #  |   #  |   #  |   #  |   #  |   #  |   #  |   #  |   #  |   #  |   #  |   #  |
+  * |------+------+------+------+------+-------------+------+------+------+------+------|
+  * |      |   S  |   T  |   P  |   H  |   *  |   *  |   F  |   P  |   L  |   T  |   D  |
+  * |------+------+------+------+------+------|------+------+------+------+------+------|
+  * |      |   S  |   K  |   W  |   R  |   *  |   *  |   R  |   B  |   G  |   S  |   Z  |
+  * |------+------+------+------+------+------+------+------+------+------+------+------|
+  * | Exit |      |      |   A  |   O  |             |   E  |   U  |      |      |      |
+  * `-----------------------------------------------------------------------------------'
+  */
+
+  [_PLOVER] = LAYOUT_ortho_4x12(
+    KC_1,    KC_1,    KC_1,    KC_1,    KC_1,    KC_1,    KC_1,    KC_1,    KC_1,    KC_1,    KC_1,    KC_1   ,
+    XXXXXXX, KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC,
+    XXXXXXX, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,
+    EXT_PLV, XXXXXXX, XXXXXXX, KC_C,    KC_V,    XXXXXXX, XXXXXXX, KC_N,    KC_M,    XXXXXXX, XXXXXXX, XXXXXXX
+  ),
+
+  /* Adjust (Lower + Raise)
+  * ,-----------------------------------------------------------------------------------.
+  * |      | Reset|      |      |      |      |      |      |      |      |      |  Del |
+  * |------+------+------+------+------+-------------+------+------+------+------+------|
+  * |      |      |      |Aud on|Audoff|AGnorm|AGswap|Qwerty|Colemk|Dvorak|Plover|      |
+  * |------+------+------+------+------+------|------+------+------+------+------+------|
+  * |      |Voice-|Voice+|Mus on|Musoff|MIDIon|MIDIof|      |      |      |      |      |
+  * |------+------+------+------+------+------+------+------+------+------+------+------|
+  * |      |      |      |      |      |             |      |      |      |      |      |
+  * `-----------------------------------------------------------------------------------'
+  */
+  [_ADJUST] = LAYOUT_ortho_4x12(
+    _______, RESET,   DEBUG,   RGB_TOG, RGB_MOD, RGB_HUI, RGB_HUD, RGB_SAI, RGB_SAD, RGB_VAI, RGB_VAD, KC_DEL,
+    _______, _______, MU_MOD,  AU_ON,   AU_OFF,  AG_NORM, AG_SWAP, QWERTY,  COLEMAK, DVORAK,  PLOVER,  _______,
+    _______, MUV_DE,  MUV_IN,  MU_ON,   MU_OFF,  MI_ON,   MI_OFF,  TERM_ON, TERM_OFF,_______, _______, _______,
+    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______
+  )
+
+};
+
+#ifdef AUDIO_ENABLE
+float plover_song[][2]     = SONG(PLOVER_SOUND);
+float plover_gb_song[][2]  = SONG(PLOVER_GOODBYE_SOUND);
+#endif
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  switch (keycode) {
+    case QWERTY:
+      if (record->event.pressed) {
+        print("mode just switched to qwerty and this is a huge string\n");
+        set_single_persistent_default_layer(_QWERTY);
+      }
+      return false;
+      break;
+    case COLEMAK:
+      if (record->event.pressed) {
+        set_single_persistent_default_layer(_COLEMAK);
+      }
+      return false;
+      break;
+    case DVORAK:
+      if (record->event.pressed) {
+        set_single_persistent_default_layer(_DVORAK);
+      }
+      return false;
+      break;
+    case LOWER:
+      if (record->event.pressed) {
+        layer_on(_LOWER);
+        update_tri_layer(_LOWER, _RAISE, _ADJUST);
+      } else {
+        layer_off(_LOWER);
+        update_tri_layer(_LOWER, _RAISE, _ADJUST);
+      }
+      return false;
+      break;
+    case RAISE:
+      if (record->event.pressed) {
+        layer_on(_RAISE);
+        update_tri_layer(_LOWER, _RAISE, _ADJUST);
+      } else {
+        layer_off(_RAISE);
+        update_tri_layer(_LOWER, _RAISE, _ADJUST);
+      }
+      return false;
+      break;
+    case BACKLIT:
+      if (record->event.pressed) {
+        register_code(KC_RSFT);
+#ifdef BACKLIGHT_ENABLE
+        backlight_step();
+#endif
+        PORTE &= ~(1<<6);
+      } else {
+        unregister_code(KC_RSFT);
+        PORTE |= (1<<6);
+      }
+      return false;
+      break;
+    case PLOVER:
+      if (record->event.pressed) {
+#ifdef AUDIO_ENABLE
+        stop_all_notes();
+        PLAY_SONG(plover_song);
+#endif
+        layer_off(_RAISE);
+        layer_off(_LOWER);
+        layer_off(_ADJUST);
+        layer_on(_PLOVER);
+        if (!eeconfig_is_enabled()) {
+          eeconfig_init();
+        }
+        keymap_config.raw = eeconfig_read_keymap();
+        keymap_config.nkro = 1;
+        eeconfig_update_keymap(keymap_config.raw);
+      }
+      return false;
+      break;
+    case EXT_PLV:
+      if (record->event.pressed) {
+#ifdef AUDIO_ENABLE
+        PLAY_SONG(plover_gb_song);
+#endif
+        layer_off(_PLOVER);
+      }
+      return false;
+      break;
+  }
+  return true;
+}

--- a/keyboards/contra/rules.mk
+++ b/keyboards/contra/rules.mk
@@ -57,4 +57,4 @@ UNICODE_ENABLE = no         # Unicode
 BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
 AUDIO_ENABLE = no           # Audio output on port C6
 
-LAYOUTS = ortho_4x12 
+LAYOUTS = ortho_4x12 contra_grid contra_2USPC

--- a/keyboards/contra/rules.mk
+++ b/keyboards/contra/rules.mk
@@ -37,8 +37,7 @@ F_USB = $(F_CPU)
 OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
 
 
-# Boot Section Size in *bytes*
-OPT_DEFS += -DBOOTLOADER_SIZE=4096
+BOOTLOADER = caterina
 
 
 # Build Options

--- a/keyboards/contra/rules.mk
+++ b/keyboards/contra/rules.mk
@@ -56,3 +56,5 @@ MIDI_ENABLE = no            # MIDI controls
 UNICODE_ENABLE = no         # Unicode
 BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
 AUDIO_ENABLE = no           # Audio output on port C6
+
+LAYOUTS = ortho_4x12 

--- a/keyboards/contra/rules.mk
+++ b/keyboards/contra/rules.mk
@@ -57,4 +57,4 @@ UNICODE_ENABLE = no         # Unicode
 BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
 AUDIO_ENABLE = no           # Audio output on port C6
 
-LAYOUTS = ortho_4x12 contra_grid contra_2USPC
+LAYOUTS = ortho_4x12 contra_grid contra_2U_space


### PR DESCRIPTION
It was missing the default keymap, so added that, using the planck as a default (since both are 4x12 ortho boards).
And was causing compile errors in other people's PR's. 

Also added layout information to the keyboard, so the layouts feature can be used. 

Not 100% sure the 2U spacebar layout works properly, but somebody else can test/verify that (sorry)