### PR TITLE
Fix preonic/rev2 bootloader config

### DIFF
--- a/keyboards/preonic/rev2/info.json
+++ b/keyboards/preonic/rev2/info.json
@@ -1,3 +1,4 @@
 {
-  "identifier": "FEED:6061:0002"
+  "identifier": "FEED:6061:0002",
+  "bootloader": "qmk-dfu"
 }


### PR DESCRIPTION
Preonic/rev2 using `qmk-dfu` as bootloader.