### PR TITLE
Fixed plank keymaps so that they will compile for planck light

### DIFF
--- a/keyboards/planck/keymaps/aviator/config.h
+++ b/keyboards/planck/keymaps/aviator/config.h
@@ -3,8 +3,10 @@
 
 #include "config_common.h"
 
+#ifndef LIGHT_CONFIG_H
 #define BACKLIGHT_BREATHING
 #define BREATHING_PERIOD 3
+#endif
 
 #ifdef AUDIO_ENABLE
     #define STARTUP_SONG SONG(PLANCK_SOUND)

--- a/keyboards/planck/keymaps/aviator/keymap.c
+++ b/keyboards/planck/keymaps/aviator/keymap.c
@@ -126,14 +126,16 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case QWERTY:
       if (record->event.pressed) {
         set_single_persistent_default_layer(_QWERTY);
-        breathing_self_disable();
+        #ifdef BACKLIGHT_BREATHING
+          breathing_self_disable();
+        #endif
       }
       return false;
       break;
     case DATA:
       if (record->event.pressed) {
         set_single_persistent_default_layer(_DATA);
-        #ifdef BACKLIGHT_ENABLE
+        #ifdef BACKLIGHT_BREATHING
           breathing_enable();
         #endif
       }
@@ -144,7 +146,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         layer_on(_LOWER);
         uint8_t default_layer = biton32(default_layer_state);
         if (default_layer == _QWERTY) {
-          #ifdef BACKLIGHT_ENABLE
+          #ifdef BACKLIGHT_BREATHING
             breathing_enable();
           #endif
         }
@@ -153,7 +155,9 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         layer_off(_LOWER);
         uint8_t default_layer = biton32(default_layer_state);
         if (default_layer == _QWERTY) {
-          breathing_self_disable();
+          #ifdef BACKLIGHT_BREATHING
+            breathing_self_disable();
+          #endif
         }
         update_tri_layer(_LOWER, _RAISE, _ADJUST);
       }
@@ -164,7 +168,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         layer_on(_RAISE);
         uint8_t default_layer = biton32(default_layer_state);
         if (default_layer == _QWERTY) {
-          #ifdef BACKLIGHT_ENABLE
+          #ifdef BACKLIGHT_BREATHING
             breathing_enable();
           #endif
         }
@@ -173,7 +177,9 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         layer_off(_RAISE);
         uint8_t default_layer = biton32(default_layer_state);
         if (default_layer == _QWERTY) {
-          breathing_self_disable();
+          #ifdef BACKLIGHT_BREATHING
+            breathing_self_disable();
+          #endif
         }
         update_tri_layer(_LOWER, _RAISE, _ADJUST);
       }
@@ -182,7 +188,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case BACKLIT:
       if (record->event.pressed) {
         register_code(KC_RSFT);
-        #ifdef BACKLIGHT_ENABLE
+        #ifdef BACKLIGHT_BREATHING
           backlight_step();
         #endif
       } else {

--- a/keyboards/planck/keymaps/cbbrowne/config.h
+++ b/keyboards/planck/keymaps/cbbrowne/config.h
@@ -27,7 +27,10 @@
 #include "../../config.h"
 
 #define LEADER_TIMEOUT 300
+
+#ifndef LIGHT_CONFIG_H
 #define BACKLIGHT_BREATHING
+#endif
 
 /* cbbrowne user configuration */
 

--- a/keyboards/planck/keymaps/cbbrowne/keymap.c
+++ b/keyboards/planck/keymaps/cbbrowne/keymap.c
@@ -219,7 +219,7 @@ const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
     if (record->event.pressed)
       {
 	layer_on(_RAISE);
-#ifdef BACKLIGHT_ENABLE
+#ifdef BACKLIGHT_BREATHING
 	breathing_period_set(2);
 	breathing_pulse();
 #endif
@@ -235,7 +235,7 @@ const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
     if (record->event.pressed)
       {
 	layer_on(_LOWER);
-#ifdef BACKLIGHT_ENABLE
+#ifdef BACKLIGHT_BREATHING
 	breathing_period_set(2);
 	breathing_pulse();
 #endif

--- a/keyboards/planck/keymaps/khord/config.h
+++ b/keyboards/planck/keymaps/khord/config.h
@@ -12,7 +12,9 @@
                                 }
 #endif
 
+#ifndef LIGHT_CONFIG_H
 #define BACKLIGHT_BREATHING
+#endif
 #define TAPPING_TERM 150
 
 #define MUSIC_MASK (keycode != KC_NO)

--- a/keyboards/planck/keymaps/khord/keymap.c
+++ b/keyboards/planck/keymaps/khord/keymap.c
@@ -123,22 +123,30 @@ const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt) {
   switch(id) {
     case MACRO_BREATH_TOGGLE:
       if (record->event.pressed) {
-        breathing_toggle();
+        #ifdef BACKLIGHT_BREATHING
+          breathing_toggle();
+        #endif
       }
       break;
     case MACRO_BREATH_SPEED_INC:
       if (record->event.pressed) {
-        breathing_period_inc();
+        #ifdef BACKLIGHT_BREATHING
+          breathing_period_inc();
+        #endif
       }
       break;
     case MACRO_BREATH_SPEED_DEC:
       if (record->event.pressed) {
-        breathing_period_dec();
+        #ifdef BACKLIGHT_BREATHING
+          breathing_period_dec();
+        #endif
       }
       break;
     case MACRO_BREATH_DEFAULT:
       if (record->event.pressed) {
-        breathing_period_default();
+        #ifdef BACKLIGHT_BREATHING
+          breathing_period_default();
+        #endif
       }
       break;
   }

--- a/keyboards/planck/keymaps/pvc/config.h
+++ b/keyboards/planck/keymaps/pvc/config.h
@@ -25,9 +25,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MATRIX_COLS 12
 
 /* Planck PCB default pin-out */
+#ifndef LIGHT_CONFIG_H
 #define MATRIX_ROW_PINS { D0, D5, B5, B6 }
 #define MATRIX_COL_PINS { F1, F0, B0, C7, F4, F5, F6, F7, D4, D6, B4, D7 }
 #define UNUSED_PINS
+#endif
 
 /*
  * MIDI options
@@ -69,7 +71,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* Only print user print statements */
 #define USER_PRINT
 
+#ifndef LIGHT_CONFIG_H
 #define BACKLIGHT_BREATHING
+#endif
 
 /* disable action features */
 //#define NO_ACTION_LAYER

--- a/keyboards/planck/keymaps/pvc/keymap.c
+++ b/keyboards/planck/keymaps/pvc/keymap.c
@@ -316,28 +316,36 @@ const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
         case MACRO_BREATH_TOGGLE:
             if (record->event.pressed)
             {
+              #ifdef BACKLIGHT_BREATHING
                 breathing_toggle();
+              #endif
             }
             break;
 
         case MACRO_BREATH_SPEED_INC:
             if (record->event.pressed)
             {
+              #ifdef BACKLIGHT_BREATHING
                 breathing_period_inc();
+              #endif
             }
             break;
 
         case MACRO_BREATH_SPEED_DEC:
             if (record->event.pressed)
             {
+              #ifdef BACKLIGHT_BREATHING
                 breathing_period_dec();
+              #endif
             }
             break;
 
         case MACRO_BREATH_DEFAULT:
             if (record->event.pressed)
             {
+              #ifdef BACKLIGHT_BREATHING
                 breathing_period_default();
+              #endif
             }
             break;
 
@@ -352,8 +360,10 @@ const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
             if (record->event.pressed)
             {
                 layer_on(LAYER_UPPER);
-                breathing_period_set(2);
-                breathing_pulse();
+                #ifdef BACKLIGHT_BREATHING
+                  breathing_period_set(2);
+                  breathing_pulse();
+                #endif
                 update_tri_layer(LAYER_LOWER, LAYER_UPPER, LAYER_ADJUST);
             }
             else
@@ -367,8 +377,10 @@ const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
             if (record->event.pressed)
             {
                 layer_on(LAYER_LOWER);
-                breathing_period_set(2);
-                breathing_pulse();
+                #ifdef BACKLIGHT_BREATHING
+                  breathing_period_set(2);
+                  breathing_pulse();
+                #endif
                 update_tri_layer(LAYER_LOWER, LAYER_UPPER, LAYER_ADJUST);
             }
             else
@@ -381,14 +393,18 @@ const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
         case MACRO_FUNCTION:
             if (record->event.pressed)
             {
-                breathing_period_set(3);
-                breathing_enable();
+                #ifdef BACKLIGHT_BREATHING
+                  breathing_period_set(3);
+                  breathing_enable();
+                #endif
                 layer_on(LAYER_FUNCTION);
             }
             else
             {
-                breathing_period_set(1);
-                breathing_self_disable();
+                #ifdef BACKLIGHT_BREATHING
+                  breathing_period_set(1);
+                  breathing_self_disable();
+                #endif
                 layer_off(LAYER_FUNCTION);
             }
             break;

--- a/keyboards/planck/keymaps/zrichard/config.h
+++ b/keyboards/planck/keymaps/zrichard/config.h
@@ -26,9 +26,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MATRIX_COLS 12
 
 /* Planck PCB default pin-out */
+#ifndef LIGHT_CONFIG_H
 #define MATRIX_ROW_PINS { D0, D5, B5, B6 }
 #define MATRIX_COL_PINS { F1, F0, B0, C7, F4, F5, F6, F7, D4, D6, B4, D7 }
 #define UNUSED_PINS
+#endif
 
 /* Prevent use of disabled MIDI features in the keymap */
 //#define MIDI_ENABLE_STRICT 1
@@ -64,7 +66,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* Only print user print statements */
 #define USER_PRINT
 
+#ifndef LIGHT_CONFIG_H
 #define BACKLIGHT_BREATHING
+#endif
 
 /* disable action features */
 //#define NO_ACTION_LAYER

--- a/keyboards/planck/keymaps/zrichard/keymap.c
+++ b/keyboards/planck/keymaps/zrichard/keymap.c
@@ -325,28 +325,36 @@ const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
         case MACRO_BREATH_TOGGLE:
             if (record->event.pressed)
             {
+              #ifdef BACKLIGHT_BREATHING
                 breathing_toggle();
+              #endif
             }
             break;
 
         case MACRO_BREATH_SPEED_INC:
             if (record->event.pressed)
             {
+              #ifdef BACKLIGHT_BREATHING
                 breathing_period_inc();
+              #endif
             }
             break;
 
         case MACRO_BREATH_SPEED_DEC:
             if (record->event.pressed)
             {
+              #ifdef BACKLIGHT_BREATHING
                 breathing_period_dec();
+              #endif
             }
             break;
 
         case MACRO_BREATH_DEFAULT:
             if (record->event.pressed)
             {
+              #ifdef BACKLIGHT_BREATHING
                 breathing_period_default();
+              #endif
             }
             break;
 
@@ -361,8 +369,10 @@ const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
             if (record->event.pressed)
             {
                 layer_on(LAYER_UPPER);
-                breathing_period_set(2);
-                breathing_pulse();
+                #ifdef BACKLIGHT_BREATHING
+                  breathing_period_set(2);
+                  breathing_pulse();
+                #endif
                 update_tri_layer(LAYER_LOWER, LAYER_UPPER, LAYER_ADJUST);
             }
             else
@@ -376,8 +386,10 @@ const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
             if (record->event.pressed)
             {
                 layer_on(LAYER_LOWER);
-                breathing_period_set(2);
-                breathing_pulse();
+                #ifdef BACKLIGHT_BREATHING
+                  breathing_period_set(2);
+                  breathing_pulse();
+                #endif
                 update_tri_layer(LAYER_LOWER, LAYER_UPPER, LAYER_ADJUST);
             }
             else
@@ -390,14 +402,18 @@ const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
         case MACRO_FUNCTION:
             if (record->event.pressed)
             {
-                breathing_period_set(3);
-                breathing_enable();
+                #ifdef BACKLIGHT_BREATHING
+                  breathing_period_set(3);
+                  breathing_enable();
+                #endif
                 layer_on(LAYER_FUNCTION);
             }
             else
             {
-                breathing_period_set(1);
-                breathing_self_disable();
+                #ifdef BACKLIGHT_BREATHING
+                  breathing_period_set(1);
+                  breathing_self_disable();
+                #endif
                 layer_off(LAYER_FUNCTION);
             }
             break;


### PR DESCRIPTION
Keymaps aviator, cbbrowne, khord, pvc, & zrichard will now compile for all planck revisions as will as the planck light