### PR TITLE
Fix audio issues with Split keyboards that were missed previously

### DIFF
--- a/keyboards/ergo42/rev1/rev1.c
+++ b/keyboards/ergo42/rev1/rev1.c
@@ -1,10 +1,5 @@
 #include "ergo42.h"
 
-#ifdef AUDIO_ENABLE
-    float tone_startup[][2] = SONG(STARTUP_SOUND);
-    float tone_goodbye[][2] = SONG(GOODBYE_SOUND);
-#endif
-
 #ifdef SSD1306OLED
 void led_set_kb(uint8_t usb_led) {
     // put your keyboard LED indicator (ex: Caps Lock LED) toggling code here
@@ -13,11 +8,6 @@ void led_set_kb(uint8_t usb_led) {
 #endif
 
 void matrix_init_kb(void) {
-
-    #ifdef AUDIO_ENABLE
-        _delay_ms(20); // gets rid of tick
-        PLAY_SONG(tone_startup);
-    #endif
 
     // // green led on
     // DDRD |= (1<<5);
@@ -30,10 +20,3 @@ void matrix_init_kb(void) {
 	matrix_init_user();
 };
 
-void shutdown_user(void) {
-    #ifdef AUDIO_ENABLE
-        PLAY_SONG(tone_goodbye);
-	_delay_ms(150);
-	stop_all_notes();
-    #endif
-}

--- a/keyboards/helix/rev1/rev1.c
+++ b/keyboards/helix/rev1/rev1.c
@@ -1,9 +1,5 @@
 #include "helix.h"
 
-#ifdef AUDIO_ENABLE
-    float tone_startup[][2] = SONG(STARTUP_SOUND);
-    float tone_goodbye[][2] = SONG(GOODBYE_SOUND);
-#endif
 
 #ifdef SSD1306OLED
 void led_set_kb(uint8_t usb_led) {
@@ -13,11 +9,6 @@ void led_set_kb(uint8_t usb_led) {
 #endif
 
 void matrix_init_kb(void) {
-
-    #ifdef AUDIO_ENABLE
-        _delay_ms(20); // gets rid of tick
-        PLAY_SONG(tone_startup);
-    #endif
 
     // // green led on
     // DDRD |= (1<<5);
@@ -29,11 +20,3 @@ void matrix_init_kb(void) {
 
 	matrix_init_user();
 };
-
-void shutdown_kb(void) {
-    #ifdef AUDIO_ENABLE
-        PLAY_SONG(tone_goodbye);
-	_delay_ms(150);
-	stop_all_notes();
-    #endif
-}

--- a/keyboards/helix/rev2/rev2.c
+++ b/keyboards/helix/rev2/rev2.c
@@ -1,11 +1,6 @@
 #include "helix.h"
 
 
-#ifdef AUDIO_ENABLE
-    float tone_startup[][2] = SONG(STARTUP_SOUND);
-    float tone_goodbye[][2] = SONG(GOODBYE_SOUND);
-#endif
-
 #ifdef SSD1306OLED
 void led_set_kb(uint8_t usb_led) {
     // put your keyboard LED indicator (ex: Caps Lock LED) toggling code here
@@ -15,18 +10,6 @@ void led_set_kb(uint8_t usb_led) {
 
 void matrix_init_kb(void) {
 
-    #ifdef AUDIO_ENABLE
-        _delay_ms(20); // gets rid of tick
-        PLAY_SONG(tone_startup);
-    #endif
-
 	matrix_init_user();
 };
 
-void shutdown_kb(void) {
-    #ifdef AUDIO_ENABLE
-        PLAY_SONG(tone_goodbye);
-      	_delay_ms(150);
-      	stop_all_notes();
-    #endif
-}

--- a/keyboards/nyquist/rev1/rev1.c
+++ b/keyboards/nyquist/rev1/rev1.c
@@ -1,10 +1,5 @@
 #include "rev1.h"
 
-#ifdef AUDIO_ENABLE
-    float tone_startup[][2] = SONG(STARTUP_SOUND);
-    float tone_goodbye[][2] = SONG(GOODBYE_SOUND);
-#endif
-
 #ifdef SSD1306OLED
 void led_set_kb(uint8_t usb_led) {
     // put your keyboard LED indicator (ex: Caps Lock LED) toggling code here
@@ -13,11 +8,6 @@ void led_set_kb(uint8_t usb_led) {
 #endif
 
 void matrix_init_kb(void) {
-
-    #ifdef AUDIO_ENABLE
-        _delay_ms(20); // gets rid of tick
-        PLAY_SONG(tone_startup);
-    #endif
 
     // // green led on
     // DDRD |= (1<<5);
@@ -30,10 +20,3 @@ void matrix_init_kb(void) {
 	matrix_init_user();
 };
 
-void shutdown_user(void) {
-    #ifdef AUDIO_ENABLE
-        PLAY_SONG(tone_goodbye);
-	_delay_ms(150);
-	stop_all_notes();
-    #endif
-}


### PR DESCRIPTION
Looks like I didn't get the audio code in a few of the split keyboards, that overrides the user configuration. 

This should get the remaining split boards that do this. 