### PR TITLE
Rule to enable Modifiers with Auto-Shift

### DIFF
--- a/common_features.mk
+++ b/common_features.mk
@@ -132,6 +132,11 @@ endif
 ifeq ($(strip $(AUTO_SHIFT_ENABLE)), yes)
     OPT_DEFS += -DAUTO_SHIFT_ENABLE
     SRC += $(QUANTUM_DIR)/process_keycode/process_auto_shift.c
+
+  ifeq ($(strip $(AUTO_SHIFT_MODIFIERS)), yes)
+      OPT_DEFS += -DAUTO_SHIFT_MODIFIERS
+  endif
+
 endif
 
 ifeq ($(strip $(SERIAL_LINK_ENABLE)), yes)

--- a/common_features.mk
+++ b/common_features.mk
@@ -132,11 +132,9 @@ endif
 ifeq ($(strip $(AUTO_SHIFT_ENABLE)), yes)
     OPT_DEFS += -DAUTO_SHIFT_ENABLE
     SRC += $(QUANTUM_DIR)/process_keycode/process_auto_shift.c
-
-  ifeq ($(strip $(AUTO_SHIFT_MODIFIERS)), yes)
-      OPT_DEFS += -DAUTO_SHIFT_MODIFIERS
-  endif
-
+    ifeq ($(strip $(AUTO_SHIFT_MODIFIERS)), yes)
+        OPT_DEFS += -DAUTO_SHIFT_MODIFIERS
+    endif
 endif
 
 ifeq ($(strip $(SERIAL_LINK_ENABLE)), yes)

--- a/docs/feature_auto_shift.md
+++ b/docs/feature_auto_shift.md
@@ -28,10 +28,7 @@ Yes, unfortunately.
    characters, you could press and hold the 'a' key for a second or two. This no
    longer works with Auto Shift because it is timing your depressed time instead
    of emitting a depressed key state to your operating system.
-2. Auto Shift is disabled for any key press that is accompanied by one or more
-   modifiers. Thus, Ctrl+A that you hold for a really long time is not the same
-   as Ctrl+Shift+A.
-3. You will have characters that are shifted when you did not intend on shifting, and
+2. You will have characters that are shifted when you did not intend on shifting, and
    other characters you wanted shifted, but were not. This simply comes down to
    practice. As we get in a hurry, we think we have hit the key long enough
    for a shifted version, but we did not. On the other hand, we may think we are
@@ -47,6 +44,18 @@ Add to your `rules.mk` in the keymap folder:
 If no `rules.mk` exists, you can create one.
 
 Then compile and install your new firmware with Auto Key enabled! That's it!
+
+## Modifiers
+
+By default, Auto Shift is disabled for any key press that is accompanied by one or more
+modifiers. Thus, Ctrl+A that you hold for a really long time is not the same
+as Ctrl+Shift+A.
+
+You can re-enable Auto Shift for modifiers by adding another rule to your `rules.mk`
+
+    AUTO_SHIFT_MODIFIERS = yes
+
+In which case, Ctrl+A held past the `AUTO_SHIFT_TIMEOUT` will be sent as Ctrl+Shift+A
 
 ## Configuring Auto Shift
 

--- a/quantum/process_keycode/process_auto_shift.c
+++ b/quantum/process_keycode/process_auto_shift.c
@@ -92,7 +92,7 @@ bool autoshift_state(void) {
 }
 
 bool process_auto_shift(uint16_t keycode, keyrecord_t *record) {
-  static uint8_t any_mod_pressed;
+  // static uint8_t any_mod_pressed;
 
   if (record->event.pressed) {
     switch (keycode) {
@@ -175,6 +175,7 @@ bool process_auto_shift(uint16_t keycode, keyrecord_t *record) {
         autoshift_flush();
         if (!autoshift_enabled) return true;
 
+/*
         any_mod_pressed = get_mods() & (
           MOD_BIT(KC_LGUI)|MOD_BIT(KC_RGUI)|
           MOD_BIT(KC_LALT)|MOD_BIT(KC_RALT)|
@@ -185,6 +186,7 @@ bool process_auto_shift(uint16_t keycode, keyrecord_t *record) {
         if (any_mod_pressed) {
           return true;
         }
+        */
 
         autoshift_on(keycode);
         return false;

--- a/quantum/process_keycode/process_auto_shift.c
+++ b/quantum/process_keycode/process_auto_shift.c
@@ -175,7 +175,7 @@ bool process_auto_shift(uint16_t keycode, keyrecord_t *record) {
         autoshift_flush();
         if (!autoshift_enabled) return true;
 
-/*
+#ifndef AUTO_SHIFT_MODIFIERS
         any_mod_pressed = get_mods() & (
           MOD_BIT(KC_LGUI)|MOD_BIT(KC_RGUI)|
           MOD_BIT(KC_LALT)|MOD_BIT(KC_RALT)|
@@ -186,7 +186,7 @@ bool process_auto_shift(uint16_t keycode, keyrecord_t *record) {
         if (any_mod_pressed) {
           return true;
         }
-        */
+#endif
 
         autoshift_on(keycode);
         return false;

--- a/quantum/process_keycode/process_auto_shift.c
+++ b/quantum/process_keycode/process_auto_shift.c
@@ -92,7 +92,9 @@ bool autoshift_state(void) {
 }
 
 bool process_auto_shift(uint16_t keycode, keyrecord_t *record) {
-  // static uint8_t any_mod_pressed;
+#ifndef AUTO_SHIFT_MODIFIERS
+  static uint8_t any_mod_pressed;
+#endif
 
   if (record->event.pressed) {
     switch (keycode) {


### PR DESCRIPTION
Modifiers seem to be compatible with Auto-Shift. You just need a way to enable them. 

This PR adds a rule to `rules.mk` that you can use to re-enable modifiers used in conjuction with Auto-Shift. i.e.  With this rule enabled. Ctrl+A help long enough will count as Ctrl-Shift-A. 

The default behavior, though, is not modified in any way, so existing auto-shift users won't see any changes.


### Original Summary
This is less of a PR for merging, and more of a question with example code.

I have auto-shift enabled, and with the below patch, I'm having no issues combining modifiers with auto-shift. Am I missing something technical? Or was it just a kind of UX decision?