### PR TITLE
Add pearl README, add rask's Pearl layout

### DIFF
--- a/keyboards/pearl/README.md
+++ b/keyboards/pearl/README.md
@@ -1,0 +1,85 @@
+# Pearl 40%
+
+Pearl 40% is a keyboard designed by Koobaczech. It uses an Atmel
+ATMEGA32A MCU.
+
+## Compiling and flashing
+
+These instructions are for building and flashing your Pearl 40% without
+Bootmapper Client.
+
+### Requirements
+
+#### Windows
+
+(to be written, help needed)
+
+#### Mac
+
+Apart from regular QMK and AVR dependencies you need to install
+`bootloadHID`. You can install it with `homebrew` as follows:
+
+    $ brew install --HEAD https://raw.githubusercontent.com/robertgzr/homebrew-tap/master/bootloadhid.rb
+
+If you don't use `homebrew` you can try following the compiling
+instructions defined below in the Linux section.
+
+#### Linux
+
+For Linux you require all regular QMK dependencies, but make sure you're
+using `gcc-avr` version 4.9 or higher. 4.8 and lower do not contain the
+proper definitions for ATMEGA32A MCUs and QMK will fail while attempting
+to compile a HEX for Pearl 40%.
+
+E.g. you cannot compile Pearl 40% HEX on a regular Ubuntu 14.04 as
+`gcc-avr` version is maxed to 4.8 on it.
+
+Additionally you need an operational `bootloadHID` binary.
+
+You can install `bootloadHID` by taking the following steps:
+
+    $ git clone https://github.com/robertgzr/bootloadHID ~/tmp/bootloadHIDsrc
+    $ cd ~/tmp/bootloadHIDsrc/commandline
+    $ make VENDORID=0x16c0 PRODUCTID=0x05DF # vid and pid for atmega32a
+    $ chmod +x bootloadHID && cp bootloadHID /usr/bin/bootloadHID
+    
+Running `which bootloadHID` should return `/usr/bin/bootloadHID`.
+    
+### Compiling
+
+Enter the QMK root directory and compile a keymap with the following
+command:
+
+    $ make pearl:<keymap>
+    
+where `<keymap>` is a layout directory under the `pearl` directory.
+
+QMK should compile a HEX (called `pearl_<keymap>.hex`) for you, which
+you can flash using `bootloadHID`.
+
+### Flashing
+
+To enable Pearl 40% bootloading mode, unplug the keyboard, then plug it
+in while holding `Esc` at the same time (the top-leftmost switch on the
+PCB, next to the USB connector). Once the board is in bootload mode,
+issue the following command (you might require `sudo` to perform the
+command):
+
+    # assuming we're still in the QMK root dir where you compiled a HEX into
+    $ bootloadHID -r ./pearl_<keymap>.hex
+
+You should see something similar to
+
+    > Page size = <value>
+    > Device size = <value>; <value> remaining
+    > Uploading <value> bytes starting at 0 (0x0)
+    > <value> ... <current value>
+    
+where `<current value>` should be slowly increasing as the HEX is being
+flashed to the board. If there is some warning about `resource busy` it
+should still work OK.
+
+Once done the board underglow should turn red and the new firmware has
+been flashed. If you can't type on the board try plugging it in again
+(without holding any keys to prevent accidentally setting it into
+bootload mode again).

--- a/keyboards/pearl/keymaps/rask/.editorconfig
+++ b/keyboards/pearl/keymaps/rask/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.c]
+indent_size = 4
+indent_style = space

--- a/keyboards/pearl/keymaps/rask/README.md
+++ b/keyboards/pearl/keymaps/rask/README.md
@@ -1,0 +1,23 @@
+# rask's Pearl 40%
+
+## Layout
+
+The firmware offers five layers:
+
+1. Base layer
+2. Base with numbers and symbols (Fn1)
+3. Base with F-row and arrows (Fn2)
+4. Base with media and RGB controls (Fn3)
+5. More nav and utils (Fn2+Fn3, aka NavFn)
+
+![rask's Pearl 40% layout](https://i.imgur.com/gKVQapZ.png)
+
+Base for this firmware copied from jetpacktuxedo's QMK firmware.
+
+---
+
+## Compiling and flashing
+
+To compile a HEX follow the Pearl 40% instructions.
+
+Flashing instructions also available at Pearl 40% instructions.

--- a/keyboards/pearl/keymaps/rask/keymap.c
+++ b/keyboards/pearl/keymaps/rask/keymap.c
@@ -1,0 +1,87 @@
+#include "pearl.h"
+
+#define ____ KC_TRNS
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    // BASE LAYER
+    [0] = KEYMAP(
+        KC_TAB,     KC_Q,       KC_W,       KC_E,       KC_R,   KC_T,   KC_Y,   KC_U,   KC_I,       KC_O,   KC_P,       KC_LBRC,    KC_RBRC,
+        MO(2),      KC_A,       KC_S,       KC_D,       KC_F,   KC_G,   KC_H,   KC_J,   KC_K,       KC_L,   KC_SCLN,                KC_ENT,
+        KC_LSFT,    KC_Z,       KC_X,       KC_C,       KC_V,   KC_B,   KC_N,   KC_M,   KC_COMM,    KC_DOT, KC_SLSH,                MO(3),
+                    KC_LCTL,    KC_LALT,    KC_BSPC,    MO(1),          MO(1),          KC_SPC,     KC_RALT,            KC_LGUI
+    ),
+    // BASE LAYER TWO (Fn1)
+    [1] = KEYMAP(
+        KC_GRV,     KC_1,       KC_2,       KC_3,       KC_4,   KC_5,   KC_6,   KC_7,   KC_8,       KC_9,   KC_0,       KC_MINS,    KC_EQL,
+        ____,       ____,       ____,       ____,       ____,   ____,   ____,   ____,   ____,       ____,   KC_QUOT,                KC_BSLS,
+        ____,       ____,       ____,       ____,       ____,   ____,   ____,   ____,   ____,       ____,   ____,                   KC_RSFT,
+                    ____,       ____,       ____,       ____,           ____,           ____,       ____,               ____
+    ),
+    // FROW LAYER AND ARROWS (Fn2)
+    [2] = KEYMAP(
+        KC_ESC,     KC_F1,      KC_F2,      KC_F3,      KC_F4,  KC_F5,  KC_F6,  KC_F7,  KC_F8,      KC_F9,  KC_F10,     KC_F11,     KC_F12,
+        ____,       ____,       ____,       ____,       ____,   ____,   ____,   ____,   ____,       KC_UP,  ____,                   ____,
+        ____,       ____,       ____,       ____,       ____,   ____,   ____,   ____,   KC_LEFT,    KC_DOWN,KC_RGHT,                MO(4),
+                    ____,       ____,       ____,       ____,           ____,           ____,       ____,               ____
+    ),
+    // MEDIA AND RGB (Fn3)
+    [3] = KEYMAP(
+        ____,       ____,       ____,       ____,       ____,   ____,   ____,   ____,   ____,       KC_MPRV,KC_MPLY,    KC_MNXT,    KC_DEL,
+        ____,       ____,       ____,       RGB_HUI,    RGB_SAI,RGB_VAI,____,   ____,   ____,       ____,   ____,                   ____,
+        ____,       RGB_MOD,    RGB_TOG,    RGB_HUD,    RGB_SAD,RGB_VAD,____,   ____,   ____,       ____,   ____,                   ____,
+                    ____,       ____,       ____,       ____,           ____,           ____,       ____,               ____
+    ),
+    // UTIL (Fn1+Fn3)
+    [4] = KEYMAP(
+        ____,       ____,       ____,       ____,       ____,   ____,   ____,   ____,   ____,       ____,   ____,       KC_PSCR,    ____,
+        ____,       ____,       ____,       ____,       ____,   ____,   ____,   ____,   ____,       KC_PGUP,____,                   ____,
+        ____,       ____,       ____,       ____,       ____,   ____,   ____,   ____,   KC_HOME,    KC_PGDN,KC_END,                 ____,
+                    RESET,      ____,       ____,       ____,           ____,           ____,       ____,               ____
+    ),
+};
+
+/**
+ * Status LED layer indicators courtesy of jetpacktuxedo's firmware
+ */
+uint32_t layer_state_set_kb(uint32_t state)
+{
+    // if we are on layer 1
+    if (state & (1<<1)){
+        // light num lock led
+        PORTD |= (1 << PD0);
+    } else{
+        PORTD &= ~(1 << PD0);
+    }
+
+    // if we are on layer 2
+    if (state & (1<<2)){
+        // light caps lock led
+        PORTD |= (1 << PD1);
+    } else{
+        PORTD &= ~(1 << PD1);
+    }
+
+    // if we are on layer 3
+    if (state & (1<<3)){
+        // light scroll lock led
+        PORTD |= (1 << PD6);
+    } else{
+        PORTD &= ~(1 << PD6);
+    }
+
+    /*
+    // if we are on layer 4
+    if (state & (1<<4)){
+        // light all leds
+        PORTD |= (1 << PD0);
+        PORTD |= (1 << PD1);
+        PORTD |= (1 << PD6);
+    } else{
+        PORTD &= ~(1 << PD0);
+        PORTD &= ~(1 << PD1);
+        PORTD &= ~(1 << PD6);
+    }
+    */
+
+    return state;
+}


### PR DESCRIPTION
Adds a README for the Pearl 40% keyboard, contains compiling and flashing instructions for Linux OS.

Additionally adds my personal Pearl 40% layout.