### PR TITLE
Add Pretty Keymaps to Ergodox EZ

### DIFF
--- a/keyboards/ergodox_ez/ergodox_ez.h
+++ b/keyboards/ergodox_ez/ergodox_ez.h
@@ -188,6 +188,67 @@ inline void ergodox_led_all_set(uint8_t n)
     { k0D, k1D, k2D, k3D, k4D, KC_NO }    \
    }
 
+#define KEYMAP_PRETTY(                                                                                        \
+    /* left hand, spatial positions */     /* right hand, spatial positions */                         \
+    L00,L01,L02,L03,L04,L05,L06,               R00,R01,R02,R03,R04,R05,R06,                            \
+    L10,L11,L12,L13,L14,L15,L16,               R10,R11,R12,R13,R14,R15,R16,                            \
+    L20,L21,L22,L23,L24,L25,                       R21,R22,R23,R24,R25,R26,                            \
+    L30,L31,L32,L33,L34,L35,L36,               R30,R31,R32,R33,R34,R35,R36,                            \
+    L40,L41,L42,L43,L44,                               R42,R43,R44,R45,R46,                            \
+                            L55,L56,       R50,R51,                                                    \
+                                L54,       R52,                                                        \
+                        L53,L52,L51,       R55,R54,R53 )                                               \
+                                          \
+   /* matrix positions */                 \
+    {                                     \
+    { L00, L10, L20, L30, L40, KC_NO },   \
+    { L01, L11, L21, L31, L41, L51 },     \
+    { L02, L12, L22, L32, L42, L52 },     \
+    { L03, L13, L23, L33, L43, L53 },     \
+    { L04, L14, L24, L34, L44, L54 },     \
+    { L05, L15, L25, L35, KC_NO, L55 },   \
+    { L06, L16, KC_NO, L36, KC_NO, L56 }, \
+                                          \
+    { R00, R10, KC_NO, R30,KC_NO, R50 },  \
+    { R01, R11, R21, R31,KC_NO, R51 },    \
+    { R02, R12, R22, R32, R42, R52 },     \
+    { R03, R13, R23, R33, R43, R53 },     \
+    { R04, R14, R24, R34, R44, R54 },     \
+    { R05, R15, R25, R35, R45, R55 },     \
+    { R06, R16, R26, R36, R46, KC_NO }    \
+    }
+
+#define KEYMAP_PRETTY_80(                                                                              \
+    /* left hand, spatial positions */     /* right hand, spatial positions */                         \
+    L00,L01,L02,L03,L04,L05,L06,               R00,R01,R02,R03,R04,R05,R06,                            \
+    L10,L11,L12,L13,L14,L15,L16,               R10,R11,R12,R13,R14,R15,R16,                            \
+    L20,L21,L22,L23,L24,L25,                       R21,R22,R23,R24,R25,R26,                            \
+    L30,L31,L32,L33,L34,L35,L36,               R30,R31,R32,R33,R34,R35,R36,                            \
+    L40,L41,L42,L43,L44,                               R42,R43,R44,R45,R46,                            \
+                            L55,L56,       R50,R51,                                                    \
+                        L45,L46,L54,       R52,R40,R41,                                                \
+                        L53,L52,L51,       R55,R54,R53 )                                               \
+                                          \
+      /* matrix positions */              \
+    {                                     \
+    { L00, L10, L20, L30, L40, KC_NO },   \
+    { L01, L11, L21, L31, L41, L51 },     \
+    { L02, L12, L22, L32, L42, L52 },     \
+    { L03, L13, L23, L33, L43, L53 },     \
+    { L04, L14, L24, L34, L44, L54 },     \
+    { L05, L15, L25, L35, L45, L55 },     \
+    { L06, L16, KC_NO, L36, L46, L56 },   \
+                                          \
+    { R00, R10, KC_NO, R30, R40, R50 },   \
+    { R01, R11, R21, R31, R41, R51 },     \
+    { R02, R12, R22, R32, R42, R52 },     \
+    { R03, R13, R23, R33, R43, R53 },     \
+    { R04, R14, R24, R34, R44, R54 },     \
+    { R05, R15, R25, R35, R45, R55 },     \
+    { R06, R16, R26, R36, R46, KC_NO }    \
+    }
+
 #define LAYOUT_ergodox KEYMAP
+#define LAYOUT_ergodox_pretty KEYMAP_PRETTY
 
 #endif

--- a/keyboards/ergodox_ez/keymaps/drashna/keymap.c
+++ b/keyboards/ergodox_ez/keymaps/drashna/keymap.c
@@ -52,25 +52,18 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  *                                 |      |      | End   |       | PgDn |       |      |
  *                                 `---------------------'       `---------------------'
  */
-  [_QWERTY] = LAYOUT_ergodox_wrapper(
-                KC_EQL,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    OSL(_MOUS),
-                KC_TAB,  _________________QWERTY_L1_________________, TG(_DIABLO),
-                KC_BSPC, _________________QWERTY_L2_________________,
-                KC_MLSF, _________________QWERTY_L3_________________, TG(_GAMEPAD),
-       LT(_SYMB,KC_GRV), ___________ERGODOX_BOTTOM_LEFT_____________,
-                
-                                            ALT_T(KC_APP),   KC_LGUI,
-                                                             KC_HOME,
-                                           KC_SPACE,KC_BSPC, KC_END,
+  [_QWERTY] = LAYOUT_ergodox_pretty_wrapper(
+        // left hand                                                                       // right hand
+             KC_EQL,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    OSL(_MOUS),           OSL(_MOUS), KC_6,    KC_7,    KC_8,    KC_9,     KC_0,   KC_MINS,
+             KC_TAB,  _________________QWERTY_L1_________________, TG(_DIABLO),         TG(_DIABLO), _________________QWERTY_R1_________________, KC_BSLS,
+           TG(_MODS), _________________QWERTY_L2_________________,                                   _________________QWERTY_R2_________________, GUI_T(KC_QUOT),
+             KC_MLSF, _________________QWERTY_L3_________________, TG(_GAMEPAD),       TG(_GAMEPAD), _________________QWERTY_R3_________________, KC_MRSF,
+    LT(_SYMB,KC_GRV), ___________ERGODOX_BOTTOM_LEFT_____________,                                   ___________ERGODOX_BOTTOM_RIGHT____________, TT(_SYMB),
+                                                    ALT_T(KC_APP), KC_LGUI,                 KC_RGUI, CTL_T(KC_ESCAPE),
+                                                                   KC_HOME,                 KC_PGUP,
+                                                 KC_SPACE,KC_BSPC, KC_END,                  KC_PGDN, KC_DEL,  KC_ENTER
+
                                     
-           OSL(_MOUS),    KC_6,    KC_7,    KC_8,    KC_9,     KC_0,   KC_MINS,
-           TG(_DIABLO),  _________________QWERTY_R1_________________, KC_BSLS,
-                         _________________QWERTY_R2_________________, GUI_T(KC_QUOT),
-           TG(_GAMEPAD), _________________QWERTY_R3_________________, KC_MRSF,
-                         ___________ERGODOX_BOTTOM_RIGHT____________, TT(_SYMB),
-           KC_RGUI,      CTL_T(KC_ESCAPE),
-           KC_PGUP,
-           KC_PGDOWN,    KC_DELETE,  KC_ENTER
     ),
 /* Keymap 0: Basic layer
  *
@@ -95,25 +88,16 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  */
 // If it accepts an argument (i.e, is a function), it doesn't need KC_.
 // Otherwise, it needs KC_*
-[_COLEMAK] = LAYOUT_ergodox_wrapper(  
-        // left hand
-                KC_EQL,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    OSL(_MOUS),
-                KC_TAB,  _________________COLEMAK_L1________________, TG(_DIABLO),
-                KC_BSPC, _________________COLEMAK_L2________________,
-                KC_MLSF, _________________COLEMAK_L3________________, TG(_GAMEPAD),
-       LT(_SYMB,KC_GRV), ___________ERGODOX_BOTTOM_LEFT_____________,
-                                            ALT_T(KC_APP),   KC_LGUI,
-                                                             KC_HOME,
-                                           KC_SPACE,KC_BSPC, KC_END,
-        // right hand
-           OSL(_MOUS),    KC_6,    KC_7,    KC_8,    KC_9,     KC_0,   KC_MINS,
-           TG(_DIABLO),  _________________COLEMAK_R1________________, KC_BSLS,
-                         _________________COLEMAK_R2________________, GUI_T(KC_QUOT),
-           TG(_GAMEPAD), _________________COLEMAK_R3________________, KC_MRSF,
-                         ___________ERGODOX_BOTTOM_RIGHT____________, TT(_SYMB),
-           KC_RGUI,      CTL_T(KC_ESCAPE),
-           KC_PGUP,
-           KC_PGDOWN,    KC_DELETE,  KC_ENTER
+[_COLEMAK] = LAYOUT_ergodox_pretty_wrapper(  
+        // left hand                                                                       // right hand
+             KC_EQL,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    OSL(_MOUS),           OSL(_MOUS), KC_6,    KC_7,    KC_8,    KC_9,     KC_0,   KC_MINS,
+             KC_TAB,  _________________COLEMAK_L1________________, TG(_DIABLO),         TG(_DIABLO), _________________COLEMAK_R1________________, KC_BSLS,
+           TG(_MODS), _________________COLEMAK_L2________________,                                   _________________COLEMAK_R2________________, GUI_T(KC_QUOT),
+             KC_MLSF, _________________COLEMAK_L3________________, TG(_GAMEPAD),       TG(_GAMEPAD), _________________COLEMAK_R3________________, KC_MRSF,
+    LT(_SYMB,KC_GRV), ___________ERGODOX_BOTTOM_LEFT_____________,                                   ___________ERGODOX_BOTTOM_RIGHT____________, TT(_SYMB),
+                                                    ALT_T(KC_APP), KC_LGUI,                 KC_RGUI, CTL_T(KC_ESCAPE),
+                                                                   KC_HOME,                 KC_PGUP,
+                                                 KC_SPACE,KC_BSPC, KC_END,                  KC_PGDN, KC_DEL,  KC_ENTER
     ),
 /* Keymap 0: Basic layer
  *
@@ -138,25 +122,16 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  */
 // If it accepts an argument (i.e, is a function), it doesn't need KC_.
 // Otherwise, it needs KC_*
-[_DVORAK] = LAYOUT_ergodox_wrapper(  
-        // left hand
-                KC_EQL,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    OSL(_MOUS),
-                KC_TAB,  _________________DVORAK_L1_________________, TG(_DIABLO),
-                KC_BSPC, _________________DVORAK_L2_________________,
-                KC_MLSF, _________________DVORAK_L3_________________, TG(_GAMEPAD),
-       LT(_SYMB,KC_GRV), ___________ERGODOX_BOTTOM_LEFT_____________,
-                                            ALT_T(KC_APP),   KC_LGUI,
-                                                             KC_HOME,
-                                           KC_SPACE,KC_BSPC, KC_END,
-        // right hand
-           OSL(_MOUS),    KC_6,    KC_7,    KC_8,    KC_9,     KC_0,   KC_BSLS,
-           TG(_DIABLO),  _________________DVORAK_R1_________________, KC_SLSH,
-                         _________________DVORAK_R2_________________, GUI_T(KC_MINS),
-           TG(_GAMEPAD), _________________DVORAK_R3_________________, KC_MRSF,
-                         ___________ERGODOX_BOTTOM_RIGHT____________, TT(_SYMB),
-           KC_RGUI,      CTL_T(KC_ESCAPE),
-           KC_PGUP,
-           KC_PGDOWN,    KC_DELETE,  KC_ENTER
+[_DVORAK] = LAYOUT_ergodox_pretty_wrapper(  
+        // left hand        // right hand
+             KC_EQL,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    OSL(_MOUS),           OSL(_MOUS), KC_6,    KC_7,    KC_8,    KC_9,     KC_0,   KC_BSLS,
+             KC_TAB,  _________________DVORAK_L1_________________, TG(_DIABLO),         TG(_DIABLO), _________________DVORAK_R1_________________, KC_SLSH,
+           TG(_MODS), _________________DVORAK_L2_________________,                                   _________________DVORAK_R2_________________, GUI_T(KC_MINS),
+             KC_MLSF, _________________DVORAK_L3_________________, TG(_GAMEPAD),       TG(_GAMEPAD), _________________DVORAK_R3_________________, KC_MRSF,
+    LT(_SYMB,KC_GRV), ___________ERGODOX_BOTTOM_LEFT_____________,                                   ___________ERGODOX_BOTTOM_RIGHT____________, TT(_SYMB),
+                                                    ALT_T(KC_APP), KC_LGUI,                 KC_RGUI, CTL_T(KC_ESCAPE),
+                                                                   KC_HOME,                 KC_PGUP,
+                                                 KC_SPACE,KC_BSPC, KC_END,                  KC_PGDN, KC_DEL,  KC_ENTER
     ),
 /* Keymap 0: Basic layer
  *
@@ -181,45 +156,27 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  */
 // If it accepts an argument (i.e, is a function), it doesn't need KC_.
 // Otherwise, it needs KC_*
-[_WORKMAN] = LAYOUT_ergodox_wrapper(  
+[_WORKMAN] = LAYOUT_ergodox_pretty_wrapper(  
         // left hand
-                KC_EQL,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    OSL(_MOUS),
-                KC_TAB,  _________________WORKMAN_L1________________, TG(_DIABLO),
-                KC_BSPC, _________________WORKMAN_L2________________,
-                KC_MLSF, _________________WORKMAN_L3________________, TG(_GAMEPAD),
-       LT(_SYMB,KC_GRV), ___________ERGODOX_BOTTOM_LEFT_____________,
-                                            ALT_T(KC_APP),   KC_LGUI,
-                                                             KC_HOME,
-                                           KC_SPACE,KC_BSPC, KC_END,
-        // right hand
-           OSL(_MOUS),    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS,
-           TG(_DIABLO),  _________________WORKMAN_R1________________, KC_BSLS,
-                         _________________WORKMAN_R2________________, GUI_T(KC_QUOT),
-           TG(_GAMEPAD), _________________WORKMAN_R3________________, KC_MRSF,
-                         ___________ERGODOX_BOTTOM_RIGHT____________, TT(_SYMB),
-           KC_RGUI,      CTL_T(KC_ESCAPE),
-           KC_PGUP,
-           KC_PGDOWN,    KC_DELETE,  KC_ENTER
+             KC_EQL,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    OSL(_MOUS),           OSL(_MOUS), KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS,
+             KC_TAB,  _________________WORKMAN_L1________________, TG(_DIABLO),         TG(_DIABLO), _________________WORKMAN_R1________________, KC_BSLS,
+           TG(_MODS), _________________WORKMAN_L2________________,                                   _________________WORKMAN_R2________________, GUI_T(KC_QUOT),
+             KC_MLSF, _________________WORKMAN_L3________________, TG(_GAMEPAD),       TG(_GAMEPAD), _________________WORKMAN_R3________________, KC_MRSF,
+    LT(_SYMB,KC_GRV), ___________ERGODOX_BOTTOM_LEFT_____________,                                   ___________ERGODOX_BOTTOM_RIGHT____________, TT(_SYMB),
+                                                    ALT_T(KC_APP), KC_LGUI,                 KC_RGUI, CTL_T(KC_ESCAPE),
+                                                                   KC_HOME,                 KC_PGUP,
+                                                 KC_SPACE,KC_BSPC, KC_END,                  KC_PGDN, KC_DEL,  KC_ENTER
     ),
 
-  [_MODS] = LAYOUT_ergodox(
-                KC_TRNS,      KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,      KC_TRNS,      KC_TRNS,
-                KC_TRNS,      KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,      KC_TRNS,      KC_TRNS,
-                KC_TRNS,      KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,      KC_TRNS,
-                KC_LSFT,KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,      KC_TRNS,      KC_TRNS,
-                KC_TRNS,      KC_TRNS,    KC_TRNS,    KC_TRNS,    KC_TRNS,
-                                                                                KC_TRNS,      KC_TRNS,
-                                                                                              KC_TRNS,
-                                                                  KC_TRNS,      KC_TRNS,      KC_TRNS,
-                
-                KC_TRNS,    KC_TRNS,      KC_TRNS,      KC_TRNS,      KC_TRNS,      KC_TRNS,      KC_TRNS,
-                KC_TRNS,    KC_TRNS,      KC_TRNS,      KC_TRNS,      KC_TRNS,      KC_TRNS,      KC_TRNS,
-                            KC_TRNS,      KC_TRNS,      KC_TRNS,      KC_TRNS,      KC_TRNS,      KC_TRNS,
-                KC_TRNS,    KC_TRNS,      KC_TRNS,      KC_TRNS,      KC_TRNS,      KC_TRNS,      KC_RSFT,
-                                          KC_TRNS,      KC_TRNS,      KC_TRNS,      KC_TRNS,      KC_TRNS,
-                KC_TRNS,    KC_TRNS,
-                KC_TRNS,
-                KC_TRNS,    KC_TRNS,      KC_TRNS
+  [_MODS] = LAYOUT_ergodox_pretty(
+             _______, _______, _______, _______, _______, _______, _______,                 _______, _______, _______, _______, _______, _______, _______,
+             _______, _______, _______, _______, _______, _______, _______,                 _______, _______, _______, _______, _______, _______, _______,
+             _______, _______, _______, _______, _______, _______,                                   _______, _______, _______, _______, _______, _______,
+             KC_LSFT, _______, _______, _______, _______, _______, _______,                 _______, _______, _______, _______, _______, _______, KC_RSFT,
+             _______, _______, _______, _______, _______,                                                     _______, _______, _______, _______, _______,
+                                                          _______, _______,                 _______, _______,
+                                                                   _______,                 _______,
+                                                 _______, _______, _______,                 _______, _______, _______
             ),
 
     /* Keymap 3: Symbol Layer
@@ -243,24 +200,15 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 *                                 | DARK |BRITE | BLUE |       |      |      |      |
 *                                 `--------------------'       `--------------------'
 */
-  [_SYMB] = LAYOUT_ergodox(
-                EPRM,           KC_F1,      KC_F2,      KC_F3,      KC_F4,      KC_F5,      TG(_MODS),
-                KC_RESET,       KC_EXLM,    KC_AT,      KC_LCBR,    KC_RCBR,    KC_PIPE,    KC_WORKMAN,
-                KC_MAKE,        KC_HASH,    KC_DLR,     KC_LPRN,    KC_RPRN,    KC_GRAVE,
-                VRSN,           KC_PERC,    KC_CIRC,    KC_LBRACKET,KC_RBRACKET,KC_TILD,    KC_COLEMAK,
-                KC_TRNS,        KC_AMPR,    KC_ASTR,    KC_COLN,    KC_SCOLON,
-                                                                  RGB_SMOD, KC_RGB_T,
-                                                                  RGB_HUI,
-                                                                  RGB_M_R, RGB_M_SW, RGB_HUD,
-                
-                KC_QWERTY,   KC_F6,      KC_F7,      KC_F8,      KC_F9,      KC_F10,         KC_F11,
-                KC_DVORAK,   KC_KP_PLUS, KC_KP_7,    KC_KP_8,    KC_KP_9,    KC_KP_ASTERISK, KC_F12,
-                             KC_KP_MINUS,KC_KP_4,    KC_KP_5,    KC_KP_6,    KC_KP_SLASH,    KC_PSCREEN,
-                KC_COLEMAK,  KC_NUMLOCK, KC_KP_1,    KC_KP_2,    KC_KP_3,    KC_EQUAL,       KC_PAUSE,
-                                         KC_KP_0,    KC_KP_0,    KC_KP_DOT,  KC_KP_ENTER,    KC_TRNS,
-                KC_TRNS,    KC_TRNS,
-                KC_TRNS,
-                KC_KP_DOT, KC_KP_0, KC_KP_ENTER
+  [_SYMB] = LAYOUT_ergodox_pretty(
+             EPRM,    KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_QWERTY,             KC_QWERTY, KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,
+            KC_RESET, KC_EXLM, KC_AT,   KC_LCBR, KC_RCBR, KC_PIPE, KC_WORKMAN,            KC_DVORAK, KC_PPLS, KC_KP_7, KC_KP_8, KC_KP_9, KC_PAST, KC_F12,
+             KC_MAKE, KC_HASH, KC_DLR,  KC_LPRN, KC_RPRN, KC_GRAVE,                                  KC_PMNS, KC_KP_4, KC_KP_5, KC_KP_6, KC_PSLS, KC_PSCREEN,
+             VRSN,    KC_PERC, KC_CIRC, KC_LBRC, KC_RBRC, KC_TILD, KC_COLEMAK,           KC_COLEMAK, KC_NLCK, KC_KP_1, KC_KP_2, KC_KP_3, KC_PEQL, KC_PAUSE,
+             KC_TRNS, KC_AMPR, KC_ASTR, KC_COLN, KC_SCLN,                                                     KC_KP_0, KC_KP_0, KC_PDOT, KC_PENT, KC_TRNS,
+                                                          RGB_SMOD, KC_RGB_T,               KC_TRNS, KC_TRNS,
+                                                                    RGB_HUI,                KC_TRNS,
+                                                 RGB_M_R, RGB_M_SW, RGB_HUD,                KC_PDOT, KC_KP_0, KC_PENT
             ),
 
 /* Keymap 4: Customized Overwatch Layout
@@ -284,24 +232,15 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  *                                 |      |      |  H   |       |      |      |      |
  *                                 `--------------------'       `--------------------'
  */
-  [_GAMEPAD] = LAYOUT_ergodox(
-                KC_ESCAPE,      KC_TRNS,    KC_TRNS,    KC_TRNS,    HYPR(KC_D), HYPR(KC_Q), HYPR(KC_GRV),
-                KC_F1,          KC_K,       KC_Q,       KC_W,       KC_E,       KC_R,       KC_T,
-                KC_TAB,         KC_G,       KC_A,       KC_S,       KC_D,       KC_F,
-                KC_LCTL,        KC_LSHIFT,  KC_Z,       KC_X,       KC_C,       KC_V,       KC_TRNS,
-                KC_G,           KC_U,       KC_I,       KC_Y,       KC_T,
-                                            KC_O,   KC_P,
-                                                    KC_LGUI,
-                                KC_V,   KC_SPACE,   KC_H,
-                                    
-                KC_TRNS,        KC_F9,      KC_F10,     KC_F11,     KC_F12,     KC_NO,      KC_NO,
-                KC_NO,          KC_NO,      KC_NO,      KC_NO,      KC_NO,      KC_NO,      KC_NO,
-                                KC_I,       KC_O,       KC_NO,      KC_NO,      KC_NO,      KC_NO,
-                TG(_GAMEPAD),   KC_N,       KC_M,       KC_NO,      KC_NO,      KC_NO,      KC_NO,
-                                            KC_LEFT,    KC_DOWN,    KC_UP,      KC_RIGHT,      KC_NO,
-                KC_HYPR,         MAGIC_TOGGLE_NKRO,
-                KC_NO,
-                KC_PGDOWN,      KC_DELETE, KC_ENTER
+  [_GAMEPAD] = LAYOUT_ergodox_pretty(
+             KC_ESC,  KC_TRNS, KC_TRNS, KC_TRNS, HYPR(KC_D), HYPR(KC_Q), HYPR(KC_GRV),      KC_TRNS, KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_NO,   KC_NO,
+             KC_F1,   KC_K,    KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,                    KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,
+             KC_TAB,  KC_G,    KC_A,    KC_S,    KC_D,    KC_F,                                      KC_I,    KC_O,    KC_NO,   KC_NO,   KC_NO,   KC_NO,
+             KC_LCTL, KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_TRNS,            TG(_GAMEPAD), KC_N,    KC_M,    KC_NO,   KC_NO,   KC_NO,   KC_NO,
+             KC_G,    KC_U,    KC_I,    KC_Y,    KC_T,                                                        KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT, KC_NO,
+                                                          KC_O,    KC_P,                    KC_HYPR, MAGIC_TOGGLE_NKRO,
+                                                                   KC_LGUI,                 KC_NO,
+                                                 KC_V,    KC_SPC,  KC_H,                    KC_PGDN, KC_DEL,  KC_ENTER
             ),
 
 /* Keymap 3:
@@ -325,26 +264,15 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  *                                 | SHIFT| ALT  | 0MAC |       |      |      |      |
  *                                 `--------------------'       `--------------------'
  */
-  [_DIABLO] = LAYOUT_ergodox(
-                KC_ESCAPE,  KC_V,       KC_D,       KC_LALT,    KC_NO,      KC_NO,      KC_NO,
-                KC_TAB,     KC_S,       KC_I,       KC_F,       KC_M,       KC_T,       KC_TRNS,
-                KC_Q,       KC_1,       KC_2,       KC_3,       KC_4,       KC_G,
-                KC_LCTL,    KC_D3_1,    KC_D3_2,    KC_D3_3,    KC_D3_4, KC_Z,       KC_NO,
-                KC_NO,      KC_NO,      KC_NO,      KC_NO,      KC_NO,
-                                                KC_L,   KC_J,
-                                                        KC_F,
-                    SFT_T(KC_SPACE),    ALT_T(KC_Q),    KC_DIABLO_CLEAR,
-                                    
-                                    
-                                    
-                KC_TRNS,        KC_F9,      KC_F10,     KC_F11,     KC_F12,     KC_NO,      KC_NO,
-                KC_TRNS,        KC_NO,      KC_NO,      KC_NO,      KC_NO,      KC_NO,      KC_NO,
-                                KC_NO,      KC_NO,      KC_NO,      KC_NO,      KC_NO,      KC_NO,
-                KC_NO,          KC_N,       KC_M,       KC_NO,      KC_NO,      KC_NO,      KC_NO,
-                                            KC_NO,      KC_NO,      KC_NO,      KC_NO,      KC_NO,
-                KC_NO,          KC_NO,
-                KC_NO,
-                KC_PGDOWN,      KC_DELETE, KC_ENTER
+  [_DIABLO] = LAYOUT_ergodox_pretty(
+             KC_ESC,  KC_V,    KC_D,    KC_LALT, KC_NO,   KC_NO,   KC_NO,                   KC_TRNS, KC_F9,   KC_F10,   KC_F11,  KC_F12,  KC_NO,   KC_NO,
+             KC_TAB,  KC_S,    KC_I,    KC_F,    KC_M,    KC_T,    KC_TRNS,                 KC_TRNS, KC_NO,   KC_NO,    KC_NO,   KC_NO,   KC_NO,   KC_NO,
+             KC_Q,    KC_1,    KC_2,    KC_3,    KC_4,    KC_G,                                      KC_NO,   KC_NO,    KC_NO,   KC_NO,   KC_NO,   KC_NO,
+             KC_LCTL, KC_D3_1, KC_D3_2, KC_D3_3, KC_D3_4, KC_Z,    KC_NO,                   KC_NO,   KC_N,    KC_M,     KC_NO,   KC_NO,   KC_NO,   KC_NO,
+             KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,                                                       KC_NO,    KC_NO,   KC_NO,   KC_NO,   KC_NO,
+                                                             KC_L,    KC_J,                 KC_NO,   KC_NO,
+                                                                      KC_F,                 KC_NO,
+                          SFT_T(KC_SPACE),  ALT_T(KC_Q),   KC_DIABLO_CLEAR,                 KC_PGDN, KC_DEL,  KC_ENT
             ),
 
 /* Keymap 4: Media and mouse keys
@@ -368,24 +296,15 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  *                                 |      |      | MWDn |       | Mclk |      |      |
  *                                 `--------------------'       `--------------------'
  */
-  [_MOUS] = LAYOUT_ergodox(
-                KC_NO,      KC_SECRET_1,KC_SECRET_2,KC_SECRET_3,KC_SECRET_4,KC_SECRET_5,KC_TRNS,
-                KC_NO,      KC_NO,      KC_MS_U,    KC_NO,      KC_NO,      KC_NO,      KC_TRNS,
-                KC_NO,      KC_MS_L,    KC_MS_D,    KC_MS_R,    KC_NO,      KC_NO,
-                KC_NO,      KC_ACL0,    KC_ACL1,    KC_ACL2,    KC_NO,      KC_NO,      KC_TRNS,
-                KC_NO,      KC_NO,      KC_NO,      KC_NO,      KC_NO,
-                                                                            KC_NO,      KC_NO,
-                                                                                        KC_WH_U,
-                                                                KC_BTN1,    KC_BTN2,    KC_WH_D,
-                
-                KC_TRNS,    KC_NO,      KC_NO,      KC_NO,      KC_NO,      KC_NO,      KC_NO,
-                KC_TRNS,    KC_NO,      KC_NO,      KC_NO,      KC_NO,      KC_NO,      KC_NO,
-                            KC_NO,      KC_ACL0,    KC_ACL1,    KC_ACL2,    KC_NO,      KC_NO,
-                KC_TRNS,    KC_NO,      KC_MUTE,    KC_VOLD,    KC_VOLU,    KC_NO,      KC_NO,
-                                        KC_NO,      KC_NO,      KC_NO,      KC_NO,      KC_NO,
-                KC_NO,KC_NO,
-                KC_NO,
-                KC_MS_BTN3,KC_MS_BTN4,KC_MS_BTN5
+  [_MOUS] = LAYOUT_ergodox_pretty(
+             KC_NO,   KC_SECRET_1,KC_SECRET_2,KC_SECRET_3,KC_SECRET_4,KC_SECRET_5,KC_TRNS,  KC_TRNS, KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,
+             KC_NO,   KC_NO,   KC_MS_U, KC_NO,   KC_NO,   KC_NO,   KC_TRNS,                 KC_TRNS, KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,
+             KC_NO,   KC_MS_L, KC_MS_D, KC_MS_R, KC_NO,   KC_NO,                                     KC_NO,   KC_ACL0, KC_ACL1, KC_ACL2, KC_NO,   KC_NO,
+             KC_NO,   KC_ACL0, KC_ACL1, KC_ACL2, KC_NO,   KC_NO,   KC_TRNS,                 KC_TRNS, KC_NO,   KC_MUTE, KC_VOLD, KC_VOLU, KC_NO,   KC_NO,
+             KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,                                                       KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,
+                                                          KC_NO,   KC_NO,                   KC_NO,   KC_NO,
+                                                                   KC_WH_U,                 KC_NO,
+                                                 KC_BTN1, KC_BTN2, KC_WH_D,                 KC_BTN3, KC_BTN4, KC_BTN5
             ),
 
 };

--- a/users/drashna/drashna.h
+++ b/users/drashna/drashna.h
@@ -181,6 +181,7 @@ enum {
 // arguments, we need a wrapper in order for these definitions to be 
 // expanded before being used as arguments to the LAYOUT_xxx macro.
 #define LAYOUT_ergodox_wrapper(...)   LAYOUT_ergodox(__VA_ARGS__)
+#define LAYOUT_ergodox_pretty_wrapper(...)   LAYOUT_ergodox_pretty(__VA_ARGS__)
 #define KEYMAP_wrapper(...)           KEYMAP(__VA_ARGS__)
 
 


### PR DESCRIPTION
Created new keymaps for the Ergodox EZ, so that they're formatted to be more "visually accurate" and pretty.

IE, the left and right halves are side by side, rather than stacked vertically. 

Specifically, it's `KEYMAP_PRETTY` and `KEYMAP_PRETTY_80`, with `LAYOUT_ergodox_pretty`, as well.