### PR TITLE
Add userspace config.h handling to build script

### DIFF
--- a/build_keyboard.mk
+++ b/build_keyboard.mk
@@ -204,6 +204,10 @@ endif
 # User space stuff
 USER_PATH := users/$(KEYMAP)
 -include $(USER_PATH)/rules.mk
+ifneq ("$(wildcard users/$(KEYMAP)/config.h)","")
+    CONFIG_H += users/$(KEYMAP)/config.h
+endif
+
 
 # Object files directory
 #     To put object files in current directory, use a dot (.), do NOT make

--- a/docs/feature_userspace.md
+++ b/docs/feature_userspace.md
@@ -7,6 +7,7 @@ If you use more than one keyboard with a similar keymap, you might see the benef
   * `rules.mk` (included automatically)
   * `<name>.h` (optional)
   * `<name>.c` (optional)
+  * `config.h` (optional)
 
 `<name>.c` will need to be added to the SRC in `rules.mk` like this:
 
@@ -24,6 +25,12 @@ For example,
 
 Will include the `/users/jack/` folder in the path, along with `/users/jack/rules.mk`.
 
+Additionally, `config.h` here will be processed like the same file in your keymap folder.  This is handled seperately from the `<name>.h` file.  
+
+The reason for this, is that `<name>.h` won't be added in time to add settings (such as `#define TAPPING_TERM 100`), and may cause conflicts if you try adding the `<name.h>` file to your keymap's `config.h`.  Namely, you need `quantum.h` for the macros and other settings, but including that in the `config.h` of your keymap causes compiling errors.  
+
+So you should use the `config.h` for QMK settings, and the `<name>.h` file for user specific settings. 
+ 
 ## Readme
 
 Please include authorship (your name, github username, email), and optionally [a license that's GPL compatible](https://www.gnu.org/licenses/license-list.html#GPLCompatibleLicenses).

--- a/keyboards/ergodox_ez/keymaps/drashna/config.h
+++ b/keyboards/ergodox_ez/keymaps/drashna/config.h
@@ -10,16 +10,7 @@
 #define RGBLIGHT_EFFECT_KNIGHT_LENGTH 7
 #define RGBLIGHT_EFFECT_SNAKE_LENGTH 7
 #define RGBLIGHT_EFFECT_BREATHE_CENTER 1
-#define RGBLIGHT_SLEEP
 #endif // RGBLIGHT_ENABLE
-
-#ifdef TAPPING_TERM
-#undef TAPPING_TERM
-#endif
-#define TAPPING_TERM 175
-#undef PERMISSIVE_HOLD
-#define IGNORE_MOD_TAP_INTERRUPT // this makes it possible to do rolling combos (zx) with keys that convert to other keys on hold (z becomes ctrl when you hold it, and when this option isn't enabled, z rapidly followed by x actually sends Ctrl-x. That's bad.)
-#define ONESHOT_TAP_TOGGLE 2
 
 #undef PRODUCT
 #define PRODUCT         DrashnaDox - Hacked ErgoDox EZ Shine

--- a/keyboards/orthodox/keymaps/drashna/config.h
+++ b/keyboards/orthodox/keymaps/drashna/config.h
@@ -35,15 +35,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // #define MASTER_RIGHT
 #define EE_HANDS
 
-#ifdef TAPPING_TERM
-#undef TAPPING_TERM
-#endif
-#define TAPPING_TERM 150
-#undef PERMISSIVE_HOLD
-#define IGNORE_MOD_TAP_INTERRUPT // this makes it possible to do rolling combos (zx) with keys that convert to other keys on hold (z becomes ctrl when you hold it, and when this option isn't enabled, z rapidly followed by x actually sends Ctrl-x. That's bad.)
-#define ONESHOT_TAP_TOGGLE 2
-
-
 
 /* key combination for command */
 #ifdef IS_COMMAND
@@ -64,12 +55,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGBLIGHT_EFFECT_KNIGHT_LENGTH 2
 #define RGBLIGHT_EFFECT_SNAKE_LENGTH 2
 #define RGBLIGHT_EFFECT_BREATHE_CENTER 1
-#define RGBLIGHT_SLEEP
 #endif // RGBLIGHT_ENABLE
 
 #ifdef AUDIO_ENABLE
 #define C6_AUDIO
-#define STARTUP_SONG SONG(IMPERIAL_MARCH)
 #define NO_MUSIC_MODE
 #endif
 
@@ -79,4 +68,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #elif KEYBOARD_orthodox_rev3
 #define PRODUCT         Drashna Hacked Orthodox Rev.3
 #endif
+
+
 #endif

--- a/keyboards/viterbi/keymaps/drashna/config.h
+++ b/keyboards/viterbi/keymaps/drashna/config.h
@@ -31,31 +31,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGBLIGHT_EFFECT_KNIGHT_LENGTH 2
 #define RGBLIGHT_EFFECT_SNAKE_LENGTH 2
 #define RGBLIGHT_EFFECT_BREATHE_CENTER 1
-#define RGBLIGHT_SLEEP
 #define RGBLIGHT_EFFECT_CHRISTMAS_INTERVAL 300
 #define RGBLIGHT_EFFECT_CHRISTMAS_STEP 1
-
 #endif // RGBLIGHT_ENABLE
 
-#define TAPPING_TOGGLE  1
-
-#ifdef AUDIO_ENABLE
-#define C6_AUDIO
-#define STARTUP_SONG SONG(IMPERIAL_MARCH)
-#define GOODBYE_SONG  SONG(SONIC_RING)
-#endif
 
 #undef LOCKING_SUPPORT_ENABLE
 #undef LOCKING_RESYNC_ENABLE
 
 #ifndef NO_DEBUG
 #define NO_DEBUG
-#endif // NO_DEBUG
-
-/* disable print */
+#endif // !NO_DEBUG
 #ifndef NO_PRINT
 #define NO_PRINT
-#endif // NO_PRINT
+
+#endif // !NO_PRINT
+
 /* disable action features */
 //#define NO_ACTION_LAYER
 //#define NO_ACTION_TAPPING
@@ -82,4 +73,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         L30, L31, L32, L33, L34, L35, L36, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, \
         L40, L41, L42, L43, L44, L45, L46, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO \
     )
+
 #endif

--- a/users/drashna/config.h
+++ b/users/drashna/config.h
@@ -1,0 +1,61 @@
+#ifndef USERSPACE_CONFIG_H
+#define USERSPACE_CONFIG_H
+
+
+#ifdef AUDIO_ENABLE
+#define STARTUP_SONG SONG(IMPERIAL_MARCH)
+#define GOODBYE_SONG  SONG(SONIC_RING)
+#define DEFAULT_LAYER_SONGS { SONG(QWERTY_SOUND), \
+                                  SONG(COLEMAK_SOUND), \
+                                  SONG(DVORAK_SOUND), \
+                                  SONG(PLOVER_SOUND) \
+                                }
+#endif
+
+#ifdef RGBLIGHT_ENABLE
+#define RGBLIGHT_SLEEP
+#endif // RGBLIGHT_ENABLE
+
+
+
+#ifndef ONESHOT_TAP_TOGGLE
+#define ONESHOT_TAP_TOGGLE 2
+#endif // !ONESHOT_TAP_TOGGLE
+
+#ifndef ONESHOT_TIMEOUT
+#define ONESHOT_TIMEOUT 3000
+#endif// !ONESHOT_TIMEOUT
+
+#ifndef QMK_KEYS_PER_SCAN
+#define QMK_KEYS_PER_SCAN 8
+#endif // !QMK_KEYS_PER_SCAN
+
+
+
+// this makes it possible to do rolling combos (zx) with keys that
+// convert to other keys on hold (z becomes ctrl when you hold it,
+// and when this option isn't enabled, z rapidly followed by x
+// actually sends Ctrl-x. That's bad.)
+#define IGNORE_MOD_TAP_INTERRUPT
+#undef PERMISSIVE_HOLD
+
+
+#ifndef TAPPING_TOGGLE
+#define TAPPING_TOGGLE  1
+#endif
+
+#ifdef TAPPING_TERM
+#undef TAPPING_TERM
+#endif
+#define TAPPING_TERM 175
+
+
+// Disable action_get_macro and fn_actions, since we don't use these
+// and it saves on space in the firmware.
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
+
+
+
+#endif // !USERSPACE_CONFIG_H
+


### PR DESCRIPTION
The reason for this is that the user.h file doesn't get called in such a way that will modify QMK settings.  (ie, my settings were not being honored).    

Additionally, if I included the file in the config.h file, it would error out.
* with `#include "quantum.h"` would attempt to redefine everything in them, and error.
*without would not define `SAFE_RANGE` and stuff like "bool". 

So this allows for you to use a config.h file in the userspace folder that is processed like the keyboard/keymap file.   Thus allowing for more consistent and global handling of settings.  

TL;DR: `<name>.h` is for user specific stuff, and `config.h` is for globally configuring keyboard settings

Caveat: it would be best if I could figure out how to get `<name>.h` added to all `keymap.c` files, but that can wait. 