### PR TITLE
Fix custom functions documation for layer_state_set* typo

### DIFF
--- a/docs/custom_quantum_functions.md
+++ b/docs/custom_quantum_functions.md
@@ -207,7 +207,7 @@ uint32_t layer_state_set_user(uint32_t state) {
   return state;
 }
 ```
-### `matrix_init_*` Function Documentation
+### `layer_state_set_*` Function Documentation
 
 * Keyboard/Revision: `void uint32_t layer_state_set_kb(uint32_t state)`
 * Keymap: `uint32_t layer_state_set_user(uint32_t state)`


### PR DESCRIPTION
bad copy/paste job. Didn't catch it before. Quite embarrassing. 