### PR TITLE
Fix #1566 - NKRO resetting issue

### DIFF
--- a/quantum/keycode_config.c
+++ b/quantum/keycode_config.c
@@ -90,7 +90,6 @@ uint16_t keycode_config(uint16_t keycode) {
 }
 
 uint8_t mod_config(uint8_t mod) {
-    keymap_config.raw = eeconfig_read_keymap();
     if (keymap_config.swap_lalt_lgui) {
         if ((mod & MOD_RGUI) == MOD_LGUI) {
             mod &= ~MOD_LGUI;


### PR DESCRIPTION
It's calling `keymap_config.raw = eeconfig_read_keymap();` despite having `extern keymap_config_t keymap_config;` at the top.

It's refreshing the settings from default and overriding "on the fly" changes (such as true NKRO). 

Compiles and works fine from what I can tell.

Closes #1566