### PR TITLE
Add syscalls.c if autoshift is enabled, to fix compile issue on ChibiOS

### DIFF
--- a/tmk_core/common.mk
+++ b/tmk_core/common.mk
@@ -30,6 +30,9 @@ endif
 ifeq ($(PLATFORM),CHIBIOS)
 	TMK_COMMON_SRC += $(PLATFORM_COMMON_DIR)/printf.c
 	TMK_COMMON_SRC += $(PLATFORM_COMMON_DIR)/eeprom.c
+  ifeq ($(strip $(AUTO_SHIFT_ENABLE)), yes)
+    TMK_COMMON_SRC += $(CHIBIOS)/os/various/syscalls.c
+  endif
 endif
 
 ifeq ($(PLATFORM),TEST)


### PR DESCRIPTION
Otherwise, all chibiOS based boards will error out during linking process.

Only adds syscalls.c when autoshift is enabled. 