### PR TITLE
XD60 ANSI (GH60) layout

### DIFF
--- a/keyboards/xd60/keymaps/supercoffee/keymap.c
+++ b/keyboards/xd60/keymaps/supercoffee/keymap.c
@@ -5,19 +5,19 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
   // 0: Base Layer
   KEYMAP(
-      KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,    KC_0,    KC_MINS,  KC_EQL,  KC_BSPC,  KC_NO,    \
+      KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,    KC_0,    KC_MINS,  KC_EQL,  KC_BSPC,  KC_NO,    \
       KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,   KC_T,   KC_Y,   KC_U,   KC_I,   KC_O,    KC_P,    KC_LBRC,  KC_RBRC,           KC_BSLS,   \
       KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,   KC_G,   KC_H,   KC_J,   KC_K,   KC_L,    KC_SCLN, KC_QUOT,  KC_NO,             KC_ENT,    \
       KC_LSFT, KC_NO,   KC_Z,    KC_X,    KC_C,   KC_V,   KC_B,   KC_N,   KC_M,   KC_COMM, KC_DOT,  KC_SLSH,  KC_NO, KC_RSHIFT,  KC_NO,      \
-      KC_LCTL, KC_LGUI, KC_LALT,                          KC_SPC,                          KC_RALT, KC_RGUI,  KC_NO, KC_RCTL,    F(0)),
+      KC_LCTL, KC_LGUI, KC_LALT,                          KC_SPC,                          F(0),    KC_RALT,  KC_NO, KC_RGUI,    KC_RCTL),
 
   // 1: Function Layer
   KEYMAP(
-      RESET,   KC_F1,   KC_F2,   KC_F3,   KC_F4,  KC_F5,  KC_F6,  KC_F7,  KC_F8,  KC_F9,   KC_F10,  KC_F11,   KC_F12,  KC_F13,   KC_F14,    \
-      KC_NO,   KC_WH_U, KC_UP,   KC_WH_D, KC_BSPC,KC_HOME,KC_CALC,KC_NO,  KC_INS, KC_NO,   KC_PSCR, KC_SLCK,  KC_PAUS,           KC_DEL,    \
-      KC_NO,   KC_LEFT, KC_DOWN, KC_RIGHT,KC_DEL, KC_END, KC_PGDN,KC_NO,  KC_NO,  KC_NO,   KC_HOME, KC_PGUP,  KC_NO,             KC_ENT,    \
-      KC_LSFT, KC_NO,   KC_NO,   KC_APP,  BL_STEP,KC_NO,  KC_NO,  KC_VOLD,KC_VOLU,KC_MUTE, KC_END,  KC_PGDN,  KC_RSFT, KC_PGUP,  KC_INS,      \
-      KC_LCTL, KC_LGUI, KC_LALT,                          KC_SPC,                          KC_RALT, KC_RGUI,  KC_NO, KC_RCTL,    F(0)),
+      KC_ESC,   KC_F1,   KC_F2,   KC_F3,   KC_F4,  KC_F5,   KC_F6,   KC_F7,   KC_F8,  KC_F9,  KC_F10, KC_F11,   KC_F12,  KC_F13,   KC_F14,    \
+      KC_NO,   KC_NO,   KC_UP,   KC_END,  KC_NO,  KC_NO,   KC_CALC, KC_PGUP, KC_NO, KC_NO,    KC_NO,  KC_NO,    KC_NO,             KC_DEL,    \
+      KC_NO,   KC_LEFT, KC_DOWN, KC_RIGHT,KC_NO,  KC_NO,   KC_HOME, KC_PGDN, KC_NO,  KC_NO,   KC_NO,  KC_PGUP,  KC_NO,             KC_ENT,    \
+      KC_LSFT, KC_NO,   KC_NO,   KC_DEL,  BL_STEP,KC_NO,   KC_NO,   KC_VOLD, KC_VOLU,KC_MUTE, KC_NO,  KC_PGDN,  KC_RSFT, KC_NO,    KC_NO,      \
+      KC_LCTL, KC_LGUI, KC_LALT,                           KC_SPC,                            F(0),   KC_RALT,  KC_NO, KC_RGUI,    KC_RCTL),
 
 };
 

--- a/keyboards/xd60/keymaps/supercoffee/keymap.c
+++ b/keyboards/xd60/keymaps/supercoffee/keymap.c
@@ -1,0 +1,46 @@
+#include "xd60.h"
+#include "action_layer.h"
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+  // 0: Base Layer
+  KEYMAP(
+      KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,    KC_0,    KC_MINS,  KC_EQL,  KC_BSPC,  KC_NO,    \
+      KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,   KC_T,   KC_Y,   KC_U,   KC_I,   KC_O,    KC_P,    KC_LBRC,  KC_RBRC,           KC_BSLS,   \
+      KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,   KC_G,   KC_H,   KC_J,   KC_K,   KC_L,    KC_SCLN, KC_QUOT,  KC_NO,             KC_ENT,    \
+      KC_LSFT, KC_NO,   KC_Z,    KC_X,    KC_C,   KC_V,   KC_B,   KC_N,   KC_M,   KC_COMM, KC_DOT,  KC_SLSH,  KC_NO, KC_RSHIFT,  KC_NO,      \
+      KC_LCTL, KC_LGUI, KC_LALT,                          KC_SPC,                          KC_RALT, KC_RGUI,  KC_NO, KC_RCTL,    F(0)),
+
+  // 1: Function Layer
+  KEYMAP(
+      RESET,   KC_F1,   KC_F2,   KC_F3,   KC_F4,  KC_F5,  KC_F6,  KC_F7,  KC_F8,  KC_F9,   KC_F10,  KC_F11,   KC_F12,  KC_F13,   KC_F14,    \
+      KC_NO,   KC_WH_U, KC_UP,   KC_WH_D, KC_BSPC,KC_HOME,KC_CALC,KC_NO,  KC_INS, KC_NO,   KC_PSCR, KC_SLCK,  KC_PAUS,           KC_DEL,    \
+      KC_NO,   KC_LEFT, KC_DOWN, KC_RIGHT,KC_DEL, KC_END, KC_PGDN,KC_NO,  KC_NO,  KC_NO,   KC_HOME, KC_PGUP,  KC_NO,             KC_ENT,    \
+      KC_LSFT, KC_NO,   KC_NO,   KC_APP,  BL_STEP,KC_NO,  KC_NO,  KC_VOLD,KC_VOLU,KC_MUTE, KC_END,  KC_PGDN,  KC_RSFT, KC_PGUP,  KC_INS,      \
+      KC_LCTL, KC_LGUI, KC_LALT,                          KC_SPC,                          KC_RALT, KC_RGUI,  KC_NO, KC_RCTL,    F(0)),
+
+};
+
+// Custom Actions
+const uint16_t PROGMEM fn_actions[] = {
+    [0] = ACTION_LAYER_MOMENTARY(1),  // to Fn overlay
+};
+
+// Macros
+const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt) {
+
+  // MACRODOWN only works in this function
+  switch(id) {
+    case 0:
+      if (record->event.pressed) { register_code(KC_RSFT); }
+      else { unregister_code(KC_RSFT); }
+      break;
+  }
+
+  return MACRO_NONE;
+};
+
+// Loop
+void matrix_scan_user(void) {
+  // Empty
+};

--- a/keyboards/xd60/keymaps/supercoffee/readme.md
+++ b/keyboards/xd60/keymaps/supercoffee/readme.md
@@ -1,0 +1,9 @@
+# Supercoffee Keymap for DeskCandy 60% XD60 PCB
+
+![Supercoffee Keymap for XD60](https://img.alicdn.com/imgextra/i1/1713761720/TB2K0gTalPxQeBjy1XcXXXHzVXa_!!1713761720.png)
+
+## Additional Notes
+60% ANSI Keymap for XD60 as indicated on the original sale page.
+
+## Build
+To build the default keymap, simply run `make xd60:default`.

--- a/keyboards/xd60/keymaps/supercoffee/readme.md
+++ b/keyboards/xd60/keymaps/supercoffee/readme.md
@@ -1,9 +1,9 @@
 # Supercoffee Keymap for DeskCandy 60% XD60 PCB
 
-![Supercoffee Keymap for XD60](https://img.alicdn.com/imgextra/i1/1713761720/TB2K0gTalPxQeBjy1XcXXXHzVXa_!!1713761720.png)
+![Supercoffee Keymap for XD60](https://i.imgur.com/SPg4wXw.jpg)
 
 ## Additional Notes
-60% ANSI Keymap for XD60 as indicated on the original sale page.
+60% Keymap for XD60 with GH60 ANSI layout. Arrow keys mapped to WASD in function layer.
 
 ## Build
-To build the default keymap, simply run `make xd60:default`.
+To build the default keymap, simply run `make xd60:supercoffee`.


### PR DESCRIPTION
# Problem
Existing XD60 keymaps are all focused around layouts with arrow keys.  My original build used a GH60 which is geared for a 60% ANSI layout which does not include arrow keys.  The keycaps I purchased did not match any existing layout designed for the XD60 board despite its similarity to the GH60.  Existing GH60 layouts were not 100% compatible with the XD60 board due to slight wiring differences. 

# Solution
Build a (mostly) ANSI 60% layout for the XD60 board with the arrow keys mapped to a function layer. 