### PR TITLE
And list of predefined RGB colors (like song_list)

### DIFF
--- a/docs/feature_rgblight.md
+++ b/docs/feature_rgblight.md
@@ -96,6 +96,7 @@ rgblight_sethsv(h, s, v);  // HSV color control - h is a value from 0..360 and s
 rgblight_setrgb_at(r,g,b, LED);  // control a single LED.  0 <= LED < RGBLED_NUM
 rgblight_sethsv_at(h,s,v, LED);  // control a single LED.  0 <= LED < RGBLED_NUM
 ```
+You can find a list of predefined colors at [`quantum/rgblight_list.h`](https://github.com/qmk/qmk_firmware/blob/master/quantum/rgblight_list.h). Free to add to this list!
 
 ## RGB Lighting Keycodes
 

--- a/quantum/rgblight.h
+++ b/quantum/rgblight.h
@@ -74,6 +74,7 @@
 #include "ws2812.h"
 #endif
 #include "rgblight_types.h"
+#include "rgblight_list.h"
 
 extern LED_TYPE led[RGBLED_NUM];
 

--- a/quantum/rgblight_list.h
+++ b/quantum/rgblight_list.h
@@ -1,0 +1,44 @@
+#ifndef RGBLIGHT_LIST_H
+#define RGBLIGHT_LIST_H
+
+
+#define rgblight_setrgb_white()       rgblight_setrgb (0xFF, 0xFF, 0xFF);
+#define rgblight_setrgb_red()         rgblight_setrgb (0xFF, 0x00, 0x00);
+#define rgblight_setrgb_coral()       rgblight_setrgb (0xFF, 0x7C, 0x4D);
+#define rgblight_setrgb_orange()      rgblight_setrgb (0xFF, 0x80, 0x00);
+#define rgblight_setrgb_goldenrod()   rgblight_setrgb (0xD9, 0xA5, 0x21);
+#define rgblight_setrgb_gold()        rgblight_setrgb (0xFF, 0xD9, 0x00);
+#define rgblight_setrgb_yellow()      rgblight_setrgb (0xFF, 0xFF, 0x00);
+#define rgblight_setrgb_chartreuse()  rgblight_setrgb (0x80, 0xFF, 0x00);
+#define rgblight_setrgb_green()       rgblight_setrgb (0x00, 0xFF, 0x00);
+#define rgblight_setrgb_springgreen() rgblight_setrgb (0x00, 0xFF, 0x80);
+#define rgblight_setrgb_turquoise()   rgblight_setrgb (0x47, 0x6E, 0x6A);
+#define rgblight_setrgb_teal()        rgblight_setrgb (0x00, 0x80, 0x80);
+#define rgblight_setrgb_cyan()        rgblight_setrgb (0x00, 0xFF, 0xFF);
+#define rgblight_setrgb_azure()       rgblight_setrgb (0x99, 0xf5, 0xFF);
+#define rgblight_setrgb_blue()        rgblight_setrgb (0x00, 0x00, 0xFF);
+#define rgblight_setrgb_purple()      rgblight_setrgb (0x7A, 0x00, 0xFF);
+#define rgblight_setrgb_magenta()     rgblight_setrgb (0xFF, 0x00, 0xFF);
+#define rgblight_setrgb_pink()        rgblight_setrgb (0xFF, 0x80, 0xBF);
+
+
+#define rgblight_sethsv_white()       rgblight_sethsv (0,  0x00, 255);
+#define rgblight_sethsv_red()         rgblight_sethsv (0,  255, 255);
+#define rgblight_sethsv_coral()       rgblight_sethsv (16, 176, 255);
+#define rgblight_sethsv_orange()      rgblight_sethsv (39,  255, 255);
+#define rgblight_sethsv_goldenrod()   rgblight_sethsv (43,  218, 218);
+#define rgblight_sethsv_gold()        rgblight_sethsv (51,  255, 255);
+#define rgblight_sethsv_yellow()      rgblight_sethsv (60,  255, 255);
+#define rgblight_sethsv_chartreuse()  rgblight_sethsv (90, 255, 255);
+#define rgblight_sethsv_green()       rgblight_sethsv (120,  255, 255);
+#define rgblight_sethsv_springgreen() rgblight_sethsv (150,  255, 255);
+#define rgblight_sethsv_turquoise()   rgblight_sethsv (174,  90, 112);
+#define rgblight_sethsv_teal()        rgblight_sethsv (180,  255, 128);
+#define rgblight_sethsv_cyan()        rgblight_sethsv (180,  255, 255);
+#define rgblight_sethsv_azure()       rgblight_sethsv (186,  102, 255);
+#define rgblight_sethsv_blue()        rgblight_sethsv (240,  255, 255);
+#define rgblight_sethsv_purple()      rgblight_sethsv (270, 255, 255);
+#define rgblight_sethsv_magenta()     rgblight_sethsv (300, 255, 255);
+#define rgblight_sethsv_pink()        rgblight_sethsv (330, 128, 255);
+
+#endif

--- a/quantum/rgblight_list.h
+++ b/quantum/rgblight_list.h
@@ -1,44 +1,59 @@
+/* Copyright 2018 Jack Humbert
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 #ifndef RGBLIGHT_LIST_H
 #define RGBLIGHT_LIST_H
 
+/*                            SET RGB List                            */
+#define rgblight_setrgb_white()       rgblight_setrgb (0xFF, 0xFF, 0xFF)
+#define rgblight_setrgb_red()         rgblight_setrgb (0xFF, 0x00, 0x00)
+#define rgblight_setrgb_coral()       rgblight_setrgb (0xFF, 0x7C, 0x4D)
+#define rgblight_setrgb_orange()      rgblight_setrgb (0xFF, 0x80, 0x00)
+#define rgblight_setrgb_goldenrod()   rgblight_setrgb (0xD9, 0xA5, 0x21)
+#define rgblight_setrgb_gold()        rgblight_setrgb (0xFF, 0xD9, 0x00)
+#define rgblight_setrgb_yellow()      rgblight_setrgb (0xFF, 0xFF, 0x00)
+#define rgblight_setrgb_chartreuse()  rgblight_setrgb (0x80, 0xFF, 0x00)
+#define rgblight_setrgb_green()       rgblight_setrgb (0x00, 0xFF, 0x00)
+#define rgblight_setrgb_springgreen() rgblight_setrgb (0x00, 0xFF, 0x80)
+#define rgblight_setrgb_turquoise()   rgblight_setrgb (0x47, 0x6E, 0x6A)
+#define rgblight_setrgb_teal()        rgblight_setrgb (0x00, 0x80, 0x80)
+#define rgblight_setrgb_cyan()        rgblight_setrgb (0x00, 0xFF, 0xFF)
+#define rgblight_setrgb_azure()       rgblight_setrgb (0x99, 0xf5, 0xFF)
+#define rgblight_setrgb_blue()        rgblight_setrgb (0x00, 0x00, 0xFF)
+#define rgblight_setrgb_purple()      rgblight_setrgb (0x7A, 0x00, 0xFF)
+#define rgblight_setrgb_magenta()     rgblight_setrgb (0xFF, 0x00, 0xFF)
+#define rgblight_setrgb_pink()        rgblight_setrgb (0xFF, 0x80, 0xBF)
 
-#define rgblight_setrgb_white()       rgblight_setrgb (0xFF, 0xFF, 0xFF);
-#define rgblight_setrgb_red()         rgblight_setrgb (0xFF, 0x00, 0x00);
-#define rgblight_setrgb_coral()       rgblight_setrgb (0xFF, 0x7C, 0x4D);
-#define rgblight_setrgb_orange()      rgblight_setrgb (0xFF, 0x80, 0x00);
-#define rgblight_setrgb_goldenrod()   rgblight_setrgb (0xD9, 0xA5, 0x21);
-#define rgblight_setrgb_gold()        rgblight_setrgb (0xFF, 0xD9, 0x00);
-#define rgblight_setrgb_yellow()      rgblight_setrgb (0xFF, 0xFF, 0x00);
-#define rgblight_setrgb_chartreuse()  rgblight_setrgb (0x80, 0xFF, 0x00);
-#define rgblight_setrgb_green()       rgblight_setrgb (0x00, 0xFF, 0x00);
-#define rgblight_setrgb_springgreen() rgblight_setrgb (0x00, 0xFF, 0x80);
-#define rgblight_setrgb_turquoise()   rgblight_setrgb (0x47, 0x6E, 0x6A);
-#define rgblight_setrgb_teal()        rgblight_setrgb (0x00, 0x80, 0x80);
-#define rgblight_setrgb_cyan()        rgblight_setrgb (0x00, 0xFF, 0xFF);
-#define rgblight_setrgb_azure()       rgblight_setrgb (0x99, 0xf5, 0xFF);
-#define rgblight_setrgb_blue()        rgblight_setrgb (0x00, 0x00, 0xFF);
-#define rgblight_setrgb_purple()      rgblight_setrgb (0x7A, 0x00, 0xFF);
-#define rgblight_setrgb_magenta()     rgblight_setrgb (0xFF, 0x00, 0xFF);
-#define rgblight_setrgb_pink()        rgblight_setrgb (0xFF, 0x80, 0xBF);
-
-
-#define rgblight_sethsv_white()       rgblight_sethsv (0,  0x00, 255);
-#define rgblight_sethsv_red()         rgblight_sethsv (0,  255, 255);
-#define rgblight_sethsv_coral()       rgblight_sethsv (16, 176, 255);
-#define rgblight_sethsv_orange()      rgblight_sethsv (39,  255, 255);
-#define rgblight_sethsv_goldenrod()   rgblight_sethsv (43,  218, 218);
-#define rgblight_sethsv_gold()        rgblight_sethsv (51,  255, 255);
-#define rgblight_sethsv_yellow()      rgblight_sethsv (60,  255, 255);
-#define rgblight_sethsv_chartreuse()  rgblight_sethsv (90, 255, 255);
-#define rgblight_sethsv_green()       rgblight_sethsv (120,  255, 255);
-#define rgblight_sethsv_springgreen() rgblight_sethsv (150,  255, 255);
-#define rgblight_sethsv_turquoise()   rgblight_sethsv (174,  90, 112);
-#define rgblight_sethsv_teal()        rgblight_sethsv (180,  255, 128);
-#define rgblight_sethsv_cyan()        rgblight_sethsv (180,  255, 255);
-#define rgblight_sethsv_azure()       rgblight_sethsv (186,  102, 255);
-#define rgblight_sethsv_blue()        rgblight_sethsv (240,  255, 255);
-#define rgblight_sethsv_purple()      rgblight_sethsv (270, 255, 255);
-#define rgblight_sethsv_magenta()     rgblight_sethsv (300, 255, 255);
-#define rgblight_sethsv_pink()        rgblight_sethsv (330, 128, 255);
+/*                            SET HSV List                            */
+#define rgblight_sethsv_white()       rgblight_sethsv (  0,   0, 255)
+#define rgblight_sethsv_red()         rgblight_sethsv (  0, 255, 255)
+#define rgblight_sethsv_coral()       rgblight_sethsv ( 16, 176, 255)
+#define rgblight_sethsv_orange()      rgblight_sethsv ( 39, 255, 255)
+#define rgblight_sethsv_goldenrod()   rgblight_sethsv ( 43, 218, 218)
+#define rgblight_sethsv_gold()        rgblight_sethsv ( 51, 255, 255)
+#define rgblight_sethsv_yellow()      rgblight_sethsv ( 60, 255, 255)
+#define rgblight_sethsv_chartreuse()  rgblight_sethsv ( 90, 255, 255)
+#define rgblight_sethsv_green()       rgblight_sethsv (120, 255, 255)
+#define rgblight_sethsv_springgreen() rgblight_sethsv (150, 255, 255)
+#define rgblight_sethsv_turquoise()   rgblight_sethsv (174,  90, 112)
+#define rgblight_sethsv_teal()        rgblight_sethsv (180, 255, 128)
+#define rgblight_sethsv_cyan()        rgblight_sethsv (180, 255, 255)
+#define rgblight_sethsv_azure()       rgblight_sethsv (186, 102, 255)
+#define rgblight_sethsv_blue()        rgblight_sethsv (240, 255, 255)
+#define rgblight_sethsv_purple()      rgblight_sethsv (270, 255, 255)
+#define rgblight_sethsv_magenta()     rgblight_sethsv (300, 255, 255)
+#define rgblight_sethsv_pink()        rgblight_sethsv (330, 128, 255)
 
 #endif

--- a/users/drashna/drashna.c
+++ b/users/drashna/drashna.c
@@ -164,16 +164,16 @@ void matrix_init_user(void) {
 
   if (true) {
     if (default_layer & (1UL << _COLEMAK)) {
-      rgblight_set_magenta;
+      rgblight_sethsv_magenta();
     }
     else if (default_layer & (1UL << _DVORAK)) {
-      rgblight_set_green;
+      rgblight_sethsv_green();
     }
     else if (default_layer & (1UL << _WORKMAN)) {
-      rgblight_set_purple;
+      rgblight_sethsv_goldenrod();
     }
     else {
-      rgblight_set_teal;
+      rgblight_sethsv_teal();
     }
   }
   else
@@ -319,7 +319,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 #ifdef RGBLIGHT_ENABLE
       rgblight_enable();
       rgblight_mode(1);
-      rgblight_setrgb(0xff, 0x00, 0x00);
+      rgblight_setrgb_red();
 #endif
       reset_keyboard();
     }
@@ -434,61 +434,61 @@ uint32_t layer_state_set_user(uint32_t state) {
   if (rgb_layer_change) {
     switch (biton32(state)) {
     case _NAV:
-      rgblight_set_blue;
+      rgblight_sethsv_blue();
       rgblight_mode(1);
       break;
     case _SYMB:
-      rgblight_set_blue;
+      rgblight_sethsv_blue();
       rgblight_mode(2);
       break;
     case _MOUS:
-      rgblight_set_yellow;
+      rgblight_sethsv_yellow();
       rgblight_mode(1);
       break;
     case _MACROS:
-      rgblight_set_orange;
+      rgblight_sethsv_orange();
       is_overwatch ? rgblight_mode(17) : rgblight_mode(18);
       break;
     case _MEDIA:
-      rgblight_set_chartreuse;
+      rgblight_sethsv_chartreuse();
       rgblight_mode(22);
       break;
     case _GAMEPAD:
-      rgblight_set_orange;
+      rgblight_sethsv_orange();
       rgblight_mode(17);
       break;
     case _DIABLO:
-      rgblight_set_red;
+      rgblight_sethsv_red();
       rgblight_mode(5);
       break;
     case _RAISE:
-      rgblight_set_yellow;
+      rgblight_sethsv_yellow();
       rgblight_mode(5);
       break;
     case _LOWER:
-      rgblight_set_orange;
+      rgblight_sethsv_orange();
       rgblight_mode(5);
       break;
     case _ADJUST:
-      rgblight_set_red;
+      rgblight_sethsv_red();
       rgblight_mode(23);
       break;
     case _COVECUBE:
-      rgblight_set_green;
+      rgblight_sethsv_green();
       rgblight_mode(2);
       break;
     default: //  for any other layers, or the default layer
       if (default_layer & (1UL << _COLEMAK)) {
-        rgblight_set_magenta;
+        rgblight_sethsv_magenta();
       }
       else if (default_layer & (1UL << _DVORAK)) {
-        rgblight_set_green;
+        rgblight_sethsv_green();
       }
       else if (default_layer & (1UL << _WORKMAN)) {
-        rgblight_set_goldenrod;
+        rgblight_sethsv_goldenrod();
       }
       else {
-        rgblight_set_teal;
+        rgblight_sethsv_teal();
       }
       if (biton32(state) == _MODS) { // If the non-OSM layer is enabled, then breathe
         rgblight_mode(2);


### PR DESCRIPTION
As per #2628, I've added list of RGB light codes, and that should be called by `rgblight_setrgb_blue()`. 

Added setrgb and sethsv to the list. 

Couldn't figure out how to add setrgb_at or sethsv_at without drastically changing things (which may be needed/useful later). But I'm not sure how many are using the "at" code currently. 