### PR TITLE
Update input:club boards to use the proper vendor and device

### DIFF
--- a/keyboards/ergodox_infinity/config.h
+++ b/keyboards/ergodox_infinity/config.h
@@ -20,11 +20,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
 /* USB Device descriptor parameter */
-#define VENDOR_ID       0xFEED
-#define PRODUCT_ID      0x6464
+#define VENDOR_ID       0x1c11
+#define PRODUCT_ID      0xb04d
 #define DEVICE_VER      0x0001
 #define MANUFACTURER Input Club
-#define PRODUCT Ergodox Infinity (QMK)
+#define PRODUCT Infinity_Ergodox/QMK
 
 #define MOUSEKEY_INTERVAL       20
 #define MOUSEKEY_DELAY          0

--- a/keyboards/ergodox_infinity/keymaps/halfkeyboard/config.h
+++ b/keyboards/ergodox_infinity/keymaps/halfkeyboard/config.h
@@ -25,10 +25,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define DEVICE_VER      0x0001
 /* in python2: list(u"whatever".encode('utf-16-le')) */
 /*   at most 32 characters or the ugly hack in usb_main.c borks */
-#define MANUFACTURER "TMK"
-#define USBSTR_MANUFACTURER    'T', '\x00', 'M', '\x00', 'K', '\x00', ' ', '\x00'
-#define PRODUCT "Infinity keyboard/TMK"
-#define USBSTR_PRODUCT         'I', '\x00', 'n', '\x00', 'f', '\x00', 'i', '\x00', 'n', '\x00', 'i', '\x00', 't', '\x00', 'y', '\x00', ' ', '\x00', 'k', '\x00', 'e', '\x00', 'y', '\x00', 'b', '\x00', 'o', '\x00', 'a', '\x00', 'r', '\x00', 'd', '\x00', '/', '\x00', 'T', '\x00', 'M', '\x00', 'K', '\x00'
+#define MANUFACTURER "QMK"
+#define PRODUCT "Infinity keyboard/QMK"
 
 #define MOUSEKEY_INTERVAL       20
 #define MOUSEKEY_DELAY          0

--- a/keyboards/infinity60/config.h
+++ b/keyboards/infinity60/config.h
@@ -21,13 +21,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define PREVENT_STUCK_MODIFIERS
 
 /* USB Device descriptor parameter */
-#define VENDOR_ID       0xFEED
-#define PRODUCT_ID      0x6464
+#define VENDOR_ID       0x1c11
+#define PRODUCT_ID      0xb04d
 #define DEVICE_VER      0x0001
 /* in python2: list(u"whatever".encode('utf-16-le')) */
 /*   at most 32 characters or the ugly hack in usb_main.c borks */
 #define MANUFACTURER Input Club
-#define PRODUCT Infinity 60% keyboard (QMK)
+#define PRODUCT Infinity_60%/QMK
 /* key matrix size */
 #define MATRIX_ROWS 9
 #define MATRIX_COLS 7

--- a/keyboards/k_type/config.h
+++ b/keyboards/k_type/config.h
@@ -23,13 +23,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* USB Device descriptor parameter */
 #define VENDOR_ID       0x1c11
 #define PRODUCT_ID      0xb04d
-#define DEVICE_VER      673
+#define DEVICE_VER      0x0001
 /* in python2: list(u"whatever".encode('utf-16-le')) */
 /*   at most 32 characters or the ugly hack in usb_main.c borks */
-#define MANUFACTURER "Input Club"
-#define USBSTR_MANUFACTURER    'I', '\x00', 'n', '\x00', 'p', '\x00', 'u', '\x00', 't', '\x00', ' ', '\x00', 'C', '\x00', 'l', '\x00', 'u', '\x00', 'b', '\x00'
-#define PRODUCT "K-Type/QMK"
-#define USBSTR_PRODUCT         'K', '\x00', '-', '\x00', 'T', '\x00', 'y', '\x00', 'p', '\x00', 'e', '\x00', '/', '\x00', 'Q', '\x00', 'M', '\x00', 'K', '\x00'
+#define MANUFACTURER Input Club
+#define PRODUCT K-Type/QMK
 /* key matrix size */
 #define MATRIX_ROWS 10
 #define MATRIX_COLS 10

--- a/keyboards/whitefox/config.h
+++ b/keyboards/whitefox/config.h
@@ -21,13 +21,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define PREVENT_STUCK_MODIFIERS
 
 /* USB Device descriptor parameter */
-#define VENDOR_ID       0xFEED
-#define PRODUCT_ID      0x0F0F
+#define VENDOR_ID       0x1c11
+#define PRODUCT_ID      0xb04d
 #define DEVICE_VER      0x0001
 /* in python2: list(u"whatever".encode('utf-16-le')) */
 /*   at most 32 characters or the ugly hack in usb_main.c borks */
 #define MANUFACTURER Input Club
-#define PRODUCT WhiteFox (QMK)
+#define PRODUCT WhiteFox/QMK
 
 /* key matrix size */
 #define MATRIX_ROWS 9


### PR DESCRIPTION
Fixes #2143 (At least all the I:C boards I know of)

The device name info comes from https://github.com/kiibohd/configurator/blob/master/src/kii/device/keyboard.cljs

There were a few oddities... One I saw was with the Infinity 60%... in the configurator, the versions with and without LEDs are separate, but they're not separate here. I set the name to the non-LED version, but we may want to revisit that. Additionally, it looks like all I:C keyboards use the same vendor and device IDs... which is a little odd, but it makes this work easier.

I can't confirm the DFU_ARGS workaround I added in the K-Type and WhiteFox boards for boards I don't have so I didn't add it, but I was able to confirm that setting my WhiteFox to the correct vendor and device IDs and changing the name to the other board names, it was recognized in the configurator as the expected board, which I believe was partially the point of #2143 

CC @haata @jbondeson