### PR TITLE
Fix Readme for S60X

### DIFF
--- a/keyboards/s60_x/readme.md
+++ b/keyboards/s60_x/readme.md
@@ -6,8 +6,14 @@ Keyboard Maintainer: QMK Community
 Hardware Supported: S60-x PCB
 Hardware Availability: https://www.massdrop.com/buy/sentraq-60-diy-keyboard-kit?mode=guest_open
 
+There are two versions of this keyboard, an RGB and a non RGB one. 
+
 Make example for this keyboard (after setting up your build environment):
 
     make s60_x:default
+
+Make example for rgb version of this keyboard:
+
+    make s60_x/rgb:default
 
 See [build environment setup](https://docs.qmk.fm/build_environment_setup.html) then the [make instructions](https://docs.qmk.fm/make_instructions.html) for more information.


### PR DESCRIPTION
The readme fails to point out that there are two different versions of the PCB supported and that one should use different make targets when doing them. 

This is a no logic change commit and is only a text readme fix. 