### PR TITLE
Seebs/debouncez

### DIFF
--- a/keyboards/ergodox_ez/matrix.c
+++ b/keyboards/ergodox_ez/matrix.c
@@ -151,7 +151,17 @@ void matrix_power_up(void) {
 static void matrix_read_row(int row) {
 	matrix_row_t cols = read_cols(row);
 	if (matrix_last_read[row] != cols) {
-		matrix_debouncing[row] = DEBOUNCE;
+		matrix_row_t released = matrix[row] & ~cols;
+		if (released) {
+			/* slow down there! don't report a
+			 * release until it's been stable for at
+			 * least DEBOUNCE scans. (Really,
+			 * DEBOUNCE+1.)
+			 */
+			matrix_debouncing[row] = DEBOUNCE;
+		} else {
+			matrix_debouncing[row] = 1;
+		}
 		matrix_last_read[row] = cols;
 	}
 	if (matrix_debouncing[row] == 0) {


### PR DESCRIPTION
This results from some chat with freddizzimo about the debouncing algorithm. The ergodox EZ tends to need a long debounce period to avoid stutter, which makes it less responsive, and this has been aggravated by the improvements to scan rates. This change gets back some of the responsiveness but has basically entirely elimintated stutter for me.

Note that the underlying innovation (?) of doing debounce per-row, rather than per-keyboard, may also work elsewhere. Debouncing per-key might be better still, but requires a much larger pool of debounce information (note the MATRIX_ROWS*MATRIX_COLS allocation in the old version), which is enough storage to be a problem for some keyboards. The decision to store that per-row is influenced by the fact that, on the ergodox, "row" actually means "column" in that a single "row" is all keys hit by the same finger, meaning there's usually not a lot of very fast movement within a row; fast typists will be causing changes in multiple columns.

Also important: This dramatically reduces reordering. If you hit three adjacent keys with the standard keyboard-wide debounce code, and you hit each before the keyboard's done waiting out the previous one's debounce, you will always get them in matrix order. With this, each row reports as soon as it's done debouncing, and it's much less reordered.