### PR TITLE
VUSB fix report dropping if usbInterruptIsReady() returns false

### DIFF
--- a/tmk_core/protocol/vusb/vusb.c
+++ b/tmk_core/protocol/vusb/vusb.c
@@ -27,6 +27,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "host_driver.h"
 #include "vusb.h"
 #include "bootloader.h"
+#include <util/delay.h>
 
 
 static uint8_t vusb_keyboard_leds = 0;
@@ -46,22 +47,26 @@ typedef struct {
 
 static keyboard_report_t keyboard_report; // sent to PC
 
+#define VUSB_TRANSFER_KEYBOARD_MAX_TRIES 10
+
 /* transfer keyboard report from buffer */
 void vusb_transfer_keyboard(void)
 {
-    if (usbInterruptIsReady()) {
-        if (kbuf_head != kbuf_tail) {
-            usbSetInterrupt((void *)&kbuf[kbuf_tail], sizeof(report_keyboard_t));
-            kbuf_tail = (kbuf_tail + 1) % KBUF_SIZE;
-            if (debug_keyboard) {
-                print("V-USB: kbuf["); pdec(kbuf_tail); print("->"); pdec(kbuf_head); print("](");
-                phex((kbuf_head < kbuf_tail) ? (KBUF_SIZE - kbuf_tail + kbuf_head) : (kbuf_head - kbuf_tail));
-                print(")\n");
+    for (int i = 0; i < VUSB_TRANSFER_KEYBOARD_MAX_TRIES; i++) {
+        if (usbInterruptIsReady()) {
+            if (kbuf_head != kbuf_tail) {
+                usbSetInterrupt((void *)&kbuf[kbuf_tail], sizeof(report_keyboard_t));
+                kbuf_tail = (kbuf_tail + 1) % KBUF_SIZE;
+                if (debug_keyboard) {
+                    print("V-USB: kbuf["); pdec(kbuf_tail); print("->"); pdec(kbuf_head); print("](");
+                    phex((kbuf_head < kbuf_tail) ? (KBUF_SIZE - kbuf_tail + kbuf_head) : (kbuf_head - kbuf_tail));
+                    print(")\n");
+                }
             }
+            break;
         }
-    } else {
-      usbPoll();
-      vusb_transfer_keyboard();
+        usbPoll();
+        _delay_ms(1);
     }
 }
 

--- a/tmk_core/protocol/vusb/vusb.c
+++ b/tmk_core/protocol/vusb/vusb.c
@@ -59,6 +59,9 @@ void vusb_transfer_keyboard(void)
                 print(")\n");
             }
         }
+    } else {
+      usbPoll();
+      vusb_transfer_keyboard();
     }
 }
 


### PR DESCRIPTION
This commit should fix #2191.

I have tested it out with Leeku L3 PCB that runs with ATmega32A. So far I haven't seen any side issues caused by this drop and macros with SEND_STRING are working now, but it would be nice if someone else could also test it out or give some feedback.

Marked MR currently as WIP before getting some more feedback.