### PR TITLE
Add readme for "major" keyboards to eliminate more QMK Configurator errors

### DIFF
--- a/keyboards/k_type/readme.md
+++ b/keyboards/k_type/readme.md
@@ -1,0 +1,13 @@
+# Input Club K-Type
+
+Firmware for custom keyboard PCB with TKL Key Layout
+
+Keyboard Maintainer: [Kaleb Elwert](https://github.com/belak)  
+Hardware Supported: Input Club K-Type   
+Hardware Availability: [Input Club](https://input.club/k-type/), [Massdrop](https://www.massdrop.com/buy/massdrop-x-input-club-k-type-mechanical-keyboard?utm_source=linkshare&referer=WJJG5M)
+
+Make example for this keyboard (after setting up your build environment):
+
+    make k_type:default
+
+See [build environment setup](https://docs.qmk.fm/build_environment_setup.html) then the [make instructions](https://docs.qmk.fm/make_instructions.html) for more information.

--- a/keyboards/lfkeyboards/mini1800/readme.md
+++ b/keyboards/lfkeyboards/mini1800/readme.md
@@ -1,0 +1,12 @@
+Mini1800
+===
+
+Keyboard Maintainer: [LFKeyboards](https://github.com/lfkeyboards)  
+Hardware Supported: Mini1800  
+Hardware Availability: [LFKeyboards.com](https://www.lfkeyboards.com/)
+
+Make example for this keyboard (after setting up your build environment):
+
+    make lfkeyboards/mini1800:default
+
+See [build environment setup](https://docs.qmk.fm/build_environment_setup.html) then the [make instructions](https://docs.qmk.fm/make_instructions.html) for more information. 

--- a/keyboards/lfkeyboards/readme.md
+++ b/keyboards/lfkeyboards/readme.md
@@ -1,0 +1,8 @@
+LFKeyboards
+===
+This is the parent directory for all LFKeyboard keyboards.
+
+Keyboard Maintainer: [LFKeyboards](https://github.com/lfkeyboards)  
+Hardware Availability: [LFKeyboards.com](https://www.lfkeyboards.com/)
+
+See [build environment setup](https://docs.qmk.fm/build_environment_setup.html) then the [make instructions](https://docs.qmk.fm/make_instructions.html) for more information. 

--- a/keyboards/m10a/readme.md
+++ b/keyboards/m10a/readme.md
@@ -1,0 +1,13 @@
+# Rama Works X Machine Industries M10-A Macropad
+
+Firmware for custom macropad PCB
+
+Keyboard Maintainer: QMK Community   
+Hardware Supported: Rama Works M10-A  
+Hardware Availability: [Rama Works](https://rama.works/m10-a)
+
+Make example for this keyboard (after setting up your build environment):
+
+    make m10a:default
+
+See [build environment setup](https://docs.qmk.fm/build_environment_setup.html) then the [make instructions](https://docs.qmk.fm/make_instructions.html) for more information.


### PR DESCRIPTION
Add readme to "major" keyboards
LFKeyboards parent directory and mini1800
K-Type
M10-A