### PR TITLE
Added bending to MIDI

### DIFF
--- a/quantum/process_keycode/process_midi.c
+++ b/quantum/process_keycode/process_midi.c
@@ -222,6 +222,26 @@ bool process_midi(uint16_t keycode, keyrecord_t *record)
                 dprintf("midi modulation interval %d\n", midi_config.modulation_interval);
             }
             return false;
+        case MI_BENDD:
+            if (record->event.pressed) {
+                midi_send_pitchbend(&midi_device, midi_config.channel, -0x2000);
+                dprintf("midi pitchbend channel:%d amount:%d\n", midi_config.channel, -0x2000);
+            }
+            else {
+                midi_send_pitchbend(&midi_device, midi_config.channel, 0);
+                dprintf("midi pitchbend channel:%d amount:%d\n", midi_config.channel, 0);
+            }
+            return false;
+        case MI_BENDU:
+            if (record->event.pressed) {
+                midi_send_pitchbend(&midi_device, midi_config.channel, 0x1fff);
+                dprintf("midi pitchbend channel:%d amount:%d\n", midi_config.channel, 0x1fff);
+            }
+            else {
+                midi_send_pitchbend(&midi_device, midi_config.channel, 0);
+                dprintf("midi pitchbend channel:%d amount:%d\n", midi_config.channel, 0);
+            }
+            return false;
     };
 
     return true;

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -383,6 +383,9 @@ enum quantum_keycodes {
     MI_MOD, // modulation
     MI_MODSD, // decrease modulation speed
     MI_MODSU, // increase modulation speed
+
+    MI_BENDD, // Bend down
+    MI_BENDU, // Bend up
 #endif // MIDI_ADVANCED
 
     // Backlight functionality


### PR DESCRIPTION
This is done via MI_BENDD and MI_BENDU. At the moment the value is
hardcoded and cannot be adjusted (future commit?) and is the max for the
`midi_send_pitchbend` function (up or down).

`MI_BENDD` and `MI_BENDU` both require `#define MIDI_ADVANCED`

MIDI pitch bend was already implemented in `protocol/midi.c`, I merely
added the keycodes to trigger them. :) (thanks to Jack, two years ago
in commit fb4fe52c apparently)