### PR TITLE
Add a custom USB driver for ARM

### DIFF
--- a/keyboards/chibios_test/stm32_f072_onekey/halconf.h
+++ b/keyboards/chibios_test/stm32_f072_onekey/halconf.h
@@ -139,7 +139,7 @@
  * @brief   Enables the SERIAL over USB subsystem.
  */
 #if !defined(HAL_USE_SERIAL_USB) || defined(__DOXYGEN__)
-#define HAL_USE_SERIAL_USB          TRUE
+#define HAL_USE_SERIAL_USB          FALSE
 #endif
 
 /**

--- a/keyboards/chibios_test/stm32_f103_onekey/halconf.h
+++ b/keyboards/chibios_test/stm32_f103_onekey/halconf.h
@@ -139,7 +139,7 @@
  * @brief   Enables the SERIAL over USB subsystem.
  */
 #if !defined(HAL_USE_SERIAL_USB) || defined(__DOXYGEN__)
-#define HAL_USE_SERIAL_USB          TRUE
+#define HAL_USE_SERIAL_USB          FALSE
 #endif
 
 /**

--- a/keyboards/chibios_test/teensy_lc_onekey/halconf.h
+++ b/keyboards/chibios_test/teensy_lc_onekey/halconf.h
@@ -139,7 +139,7 @@
  * @brief   Enables the SERIAL over USB subsystem.
  */
 #if !defined(HAL_USE_SERIAL_USB) || defined(__DOXYGEN__)
-#define HAL_USE_SERIAL_USB          TRUE
+#define HAL_USE_SERIAL_USB          FALSE
 #endif
 
 /**

--- a/keyboards/clueboard/60/halconf.h
+++ b/keyboards/clueboard/60/halconf.h
@@ -146,7 +146,7 @@
  * @brief   Enables the SERIAL over USB subsystem.
  */
 #if !defined(HAL_USE_SERIAL_USB) || defined(__DOXYGEN__)
-#define HAL_USE_SERIAL_USB          TRUE
+#define HAL_USE_SERIAL_USB          FALSE
 #endif
 
 /**

--- a/keyboards/ergodox_infinity/halconf.h
+++ b/keyboards/ergodox_infinity/halconf.h
@@ -139,7 +139,7 @@
  * @brief   Enables the SERIAL over USB subsystem.
  */
 #if !defined(HAL_USE_SERIAL_USB) || defined(__DOXYGEN__)
-#define HAL_USE_SERIAL_USB          TRUE
+#define HAL_USE_SERIAL_USB          FALSE
 #endif
 
 /**

--- a/keyboards/infinity60/halconf.h
+++ b/keyboards/infinity60/halconf.h
@@ -139,7 +139,7 @@
  * @brief   Enables the SERIAL over USB subsystem.
  */
 #if !defined(HAL_USE_SERIAL_USB) || defined(__DOXYGEN__)
-#define HAL_USE_SERIAL_USB          TRUE
+#define HAL_USE_SERIAL_USB          FALSE
 #endif
 
 /**

--- a/keyboards/jm60/halconf.h
+++ b/keyboards/jm60/halconf.h
@@ -139,7 +139,7 @@
  * @brief   Enables the SERIAL over USB subsystem.
  */
 #if !defined(HAL_USE_SERIAL_USB) || defined(__DOXYGEN__)
-#define HAL_USE_SERIAL_USB          TRUE
+#define HAL_USE_SERIAL_USB          FALSE
 #endif
 
 /**

--- a/keyboards/k_type/halconf.h
+++ b/keyboards/k_type/halconf.h
@@ -139,7 +139,7 @@
  * @brief   Enables the SERIAL over USB subsystem.
  */
 #if !defined(HAL_USE_SERIAL_USB) || defined(__DOXYGEN__)
-#define HAL_USE_SERIAL_USB          TRUE
+#define HAL_USE_SERIAL_USB          FALSE
 #endif
 
 /**

--- a/keyboards/whitefox/halconf.h
+++ b/keyboards/whitefox/halconf.h
@@ -139,7 +139,7 @@
  * @brief   Enables the SERIAL over USB subsystem.
  */
 #if !defined(HAL_USE_SERIAL_USB) || defined(__DOXYGEN__)
-#define HAL_USE_SERIAL_USB          TRUE
+#define HAL_USE_SERIAL_USB          FALSE
 #endif
 
 /**

--- a/tmk_core/protocol/chibios.mk
+++ b/tmk_core/protocol/chibios.mk
@@ -5,6 +5,7 @@ CHIBIOS_DIR = $(PROTOCOL_DIR)/chibios
 SRC += $(CHIBIOS_DIR)/usb_main.c
 SRC += $(CHIBIOS_DIR)/main.c
 SRC += usb_descriptor.c
+SRC += $(CHIBIOS_DIR)/usb_driver.c
 
 VPATH += $(TMK_PATH)/$(PROTOCOL_DIR)
 VPATH += $(TMK_PATH)/$(CHIBIOS_DIR)

--- a/tmk_core/protocol/chibios/usb_driver.c
+++ b/tmk_core/protocol/chibios/usb_driver.c
@@ -1,0 +1,495 @@
+/*
+    ChibiOS - Copyright (C) 2006..2016 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    hal_serial_usb.c
+ * @brief   Serial over USB Driver code.
+ *
+ * @addtogroup SERIAL_USB
+ * @{
+ */
+
+#include "hal.h"
+
+#if (HAL_USE_SERIAL_USB == TRUE) || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver exported variables.                                                */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local variables and types.                                         */
+/*===========================================================================*/
+
+/*
+ * Current Line Coding.
+ */
+static cdc_linecoding_t linecoding = {
+  {0x00, 0x96, 0x00, 0x00},             /* 38400.                           */
+  LC_STOP_1, LC_PARITY_NONE, 8
+};
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+static bool sdu_start_receive(SerialUSBDriver *sdup) {
+  uint8_t *buf;
+
+  /* If the USB driver is not in the appropriate state then transactions
+     must not be started.*/
+  if ((usbGetDriverStateI(sdup->config->usbp) != USB_ACTIVE) ||
+      (sdup->state != SDU_READY)) {
+    return true;
+  }
+
+  /* Checking if there is already a transaction ongoing on the endpoint.*/
+  if (usbGetReceiveStatusI(sdup->config->usbp, sdup->config->bulk_in)) {
+    return true;
+  }
+
+  /* Checking if there is a buffer ready for incoming data.*/
+  buf = ibqGetEmptyBufferI(&sdup->ibqueue);
+  if (buf == NULL) {
+    return true;
+  }
+
+  /* Buffer found, starting a new transaction.*/
+  usbStartReceiveI(sdup->config->usbp, sdup->config->bulk_out,
+                   buf, sdup->ibqueue.bsize - sizeof(size_t));
+
+  return false;
+}
+
+/*
+ * Interface implementation.
+ */
+
+static size_t _write(void *ip, const uint8_t *bp, size_t n) {
+
+  return obqWriteTimeout(&((SerialUSBDriver *)ip)->obqueue, bp,
+                         n, TIME_INFINITE);
+}
+
+static size_t _read(void *ip, uint8_t *bp, size_t n) {
+
+  return ibqReadTimeout(&((SerialUSBDriver *)ip)->ibqueue, bp,
+                        n, TIME_INFINITE);
+}
+
+static msg_t _put(void *ip, uint8_t b) {
+
+  return obqPutTimeout(&((SerialUSBDriver *)ip)->obqueue, b, TIME_INFINITE);
+}
+
+static msg_t _get(void *ip) {
+
+  return ibqGetTimeout(&((SerialUSBDriver *)ip)->ibqueue, TIME_INFINITE);
+}
+
+static msg_t _putt(void *ip, uint8_t b, systime_t timeout) {
+
+  return obqPutTimeout(&((SerialUSBDriver *)ip)->obqueue, b, timeout);
+}
+
+static msg_t _gett(void *ip, systime_t timeout) {
+
+  return ibqGetTimeout(&((SerialUSBDriver *)ip)->ibqueue, timeout);
+}
+
+static size_t _writet(void *ip, const uint8_t *bp, size_t n, systime_t timeout) {
+
+  return obqWriteTimeout(&((SerialUSBDriver *)ip)->obqueue, bp, n, timeout);
+}
+
+static size_t _readt(void *ip, uint8_t *bp, size_t n, systime_t timeout) {
+
+  return ibqReadTimeout(&((SerialUSBDriver *)ip)->ibqueue, bp, n, timeout);
+}
+
+static const struct SerialUSBDriverVMT vmt = {
+  _write, _read, _put, _get,
+  _putt, _gett, _writet, _readt
+};
+
+/**
+ * @brief   Notification of empty buffer released into the input buffers queue.
+ *
+ * @param[in] bqp       the buffers queue pointer.
+ */
+static void ibnotify(io_buffers_queue_t *bqp) {
+  SerialUSBDriver *sdup = bqGetLinkX(bqp);
+  (void) sdu_start_receive(sdup);
+}
+
+/**
+ * @brief   Notification of filled buffer inserted into the output buffers queue.
+ *
+ * @param[in] bqp       the buffers queue pointer.
+ */
+static void obnotify(io_buffers_queue_t *bqp) {
+  size_t n;
+  SerialUSBDriver *sdup = bqGetLinkX(bqp);
+
+  /* If the USB driver is not in the appropriate state then transactions
+     must not be started.*/
+  if ((usbGetDriverStateI(sdup->config->usbp) != USB_ACTIVE) ||
+      (sdup->state != SDU_READY)) {
+    return;
+  }
+
+  /* Checking if there is already a transaction ongoing on the endpoint.*/
+  if (!usbGetTransmitStatusI(sdup->config->usbp, sdup->config->bulk_in)) {
+    /* Trying to get a full buffer.*/
+    uint8_t *buf = obqGetFullBufferI(&sdup->obqueue, &n);
+    if (buf != NULL) {
+      /* Buffer found, starting a new transaction.*/
+      usbStartTransmitI(sdup->config->usbp, sdup->config->bulk_in, buf, n);
+    }
+  }
+}
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   Serial Driver initialization.
+ * @note    This function is implicitly invoked by @p halInit(), there is
+ *          no need to explicitly initialize the driver.
+ *
+ * @init
+ */
+void sduInit(void) {
+}
+
+/**
+ * @brief   Initializes a generic full duplex driver object.
+ * @details The HW dependent part of the initialization has to be performed
+ *          outside, usually in the hardware initialization code.
+ *
+ * @param[out] sdup     pointer to a @p SerialUSBDriver structure
+ *
+ * @init
+ */
+void sduObjectInit(SerialUSBDriver *sdup) {
+
+  sdup->vmt = &vmt;
+  osalEventObjectInit(&sdup->event);
+  sdup->state = SDU_STOP;
+  ibqObjectInit(&sdup->ibqueue, true, sdup->ib,
+                SERIAL_USB_BUFFERS_SIZE, SERIAL_USB_BUFFERS_NUMBER,
+                ibnotify, sdup);
+  obqObjectInit(&sdup->obqueue, true, sdup->ob,
+                SERIAL_USB_BUFFERS_SIZE, SERIAL_USB_BUFFERS_NUMBER,
+                obnotify, sdup);
+}
+
+/**
+ * @brief   Configures and starts the driver.
+ *
+ * @param[in] sdup      pointer to a @p SerialUSBDriver object
+ * @param[in] config    the serial over USB driver configuration
+ *
+ * @api
+ */
+void sduStart(SerialUSBDriver *sdup, const SerialUSBConfig *config) {
+  USBDriver *usbp = config->usbp;
+
+  osalDbgCheck(sdup != NULL);
+
+  osalSysLock();
+  osalDbgAssert((sdup->state == SDU_STOP) || (sdup->state == SDU_READY),
+                "invalid state");
+  usbp->in_params[config->bulk_in - 1U]   = sdup;
+  usbp->out_params[config->bulk_out - 1U] = sdup;
+  if (config->int_in > 0U) {
+    usbp->in_params[config->int_in - 1U]  = sdup;
+  }
+  sdup->config = config;
+  sdup->state = SDU_READY;
+  osalSysUnlock();
+}
+
+/**
+ * @brief   Stops the driver.
+ * @details Any thread waiting on the driver's queues will be awakened with
+ *          the message @p MSG_RESET.
+ *
+ * @param[in] sdup      pointer to a @p SerialUSBDriver object
+ *
+ * @api
+ */
+void sduStop(SerialUSBDriver *sdup) {
+  USBDriver *usbp = sdup->config->usbp;
+
+  osalDbgCheck(sdup != NULL);
+
+  osalSysLock();
+
+  osalDbgAssert((sdup->state == SDU_STOP) || (sdup->state == SDU_READY),
+                "invalid state");
+
+  /* Driver in stopped state.*/
+  usbp->in_params[sdup->config->bulk_in - 1U]   = NULL;
+  usbp->out_params[sdup->config->bulk_out - 1U] = NULL;
+  if (sdup->config->int_in > 0U) {
+    usbp->in_params[sdup->config->int_in - 1U]  = NULL;
+  }
+  sdup->config = NULL;
+  sdup->state  = SDU_STOP;
+
+  /* Enforces a disconnection.*/
+  chnAddFlagsI(sdup, CHN_DISCONNECTED);
+  ibqResetI(&sdup->ibqueue);
+  obqResetI(&sdup->obqueue);
+  osalOsRescheduleS();
+
+  osalSysUnlock();
+}
+
+/**
+ * @brief   USB device suspend handler.
+ * @details Generates a @p CHN_DISCONNECT event and puts queues in
+ *          non-blocking mode, this way the application cannot get stuck
+ *          in the middle of an I/O operations.
+ * @note    If this function is not called from an ISR then an explicit call
+ *          to @p osalOsRescheduleS() in necessary afterward.
+ *
+ * @param[in] sdup      pointer to a @p SerialUSBDriver object
+ *
+ * @iclass
+ */
+void sduSuspendHookI(SerialUSBDriver *sdup) {
+
+  chnAddFlagsI(sdup, CHN_DISCONNECTED);
+  bqSuspendI(&sdup->ibqueue);
+  bqSuspendI(&sdup->obqueue);
+}
+
+/**
+ * @brief   USB device wakeup handler.
+ * @details Generates a @p CHN_CONNECT event and resumes normal queues
+ *          operations.
+ *
+ * @note    If this function is not called from an ISR then an explicit call
+ *          to @p osalOsRescheduleS() in necessary afterward.
+ *
+ * @param[in] sdup      pointer to a @p SerialUSBDriver object
+ *
+ * @iclass
+ */
+void sduWakeupHookI(SerialUSBDriver *sdup) {
+
+  chnAddFlagsI(sdup, CHN_CONNECTED);
+  bqResumeX(&sdup->ibqueue);
+  bqResumeX(&sdup->obqueue);
+}
+
+/**
+ * @brief   USB device configured handler.
+ *
+ * @param[in] sdup      pointer to a @p SerialUSBDriver object
+ *
+ * @iclass
+ */
+void sduConfigureHookI(SerialUSBDriver *sdup) {
+
+  ibqResetI(&sdup->ibqueue);
+  bqResumeX(&sdup->ibqueue);
+  obqResetI(&sdup->obqueue);
+  bqResumeX(&sdup->obqueue);
+  chnAddFlagsI(sdup, CHN_CONNECTED);
+  (void) sdu_start_receive(sdup);
+}
+
+/**
+ * @brief   Default requests hook.
+ * @details Applications wanting to use the Serial over USB driver can use
+ *          this function as requests hook in the USB configuration.
+ *          The following requests are emulated:
+ *          - CDC_GET_LINE_CODING.
+ *          - CDC_SET_LINE_CODING.
+ *          - CDC_SET_CONTROL_LINE_STATE.
+ *          .
+ *
+ * @param[in] usbp      pointer to the @p USBDriver object
+ * @return              The hook status.
+ * @retval true         Message handled internally.
+ * @retval false        Message not handled.
+ */
+bool sduRequestsHook(USBDriver *usbp) {
+
+  if ((usbp->setup[0] & USB_RTYPE_TYPE_MASK) == USB_RTYPE_TYPE_CLASS) {
+    switch (usbp->setup[1]) {
+    case CDC_GET_LINE_CODING:
+      usbSetupTransfer(usbp, (uint8_t *)&linecoding, sizeof(linecoding), NULL);
+      return true;
+    case CDC_SET_LINE_CODING:
+      usbSetupTransfer(usbp, (uint8_t *)&linecoding, sizeof(linecoding), NULL);
+      return true;
+    case CDC_SET_CONTROL_LINE_STATE:
+      /* Nothing to do, there are no control lines.*/
+      usbSetupTransfer(usbp, NULL, 0, NULL);
+      return true;
+    default:
+      return false;
+    }
+  }
+  return false;
+}
+
+/**
+ * @brief   SOF handler.
+ * @details The SOF interrupt is used for automatic flushing of incomplete
+ *          buffers pending in the output queue.
+ *
+ * @param[in] sdup      pointer to a @p SerialUSBDriver object
+ *
+ * @iclass
+ */
+void sduSOFHookI(SerialUSBDriver *sdup) {
+
+  /* If the USB driver is not in the appropriate state then transactions
+     must not be started.*/
+  if ((usbGetDriverStateI(sdup->config->usbp) != USB_ACTIVE) ||
+      (sdup->state != SDU_READY)) {
+    return;
+  }
+
+  /* If there is already a transaction ongoing then another one cannot be
+     started.*/
+  if (usbGetTransmitStatusI(sdup->config->usbp, sdup->config->bulk_in)) {
+    return;
+  }
+
+  /* Checking if there only a buffer partially filled, if so then it is
+     enforced in the queue and transmitted.*/
+  if (obqTryFlushI(&sdup->obqueue)) {
+    size_t n;
+    uint8_t *buf = obqGetFullBufferI(&sdup->obqueue, &n);
+
+    osalDbgAssert(buf != NULL, "queue is empty");
+
+    usbStartTransmitI(sdup->config->usbp, sdup->config->bulk_in, buf, n);
+  }
+}
+
+/**
+ * @brief   Default data transmitted callback.
+ * @details The application must use this function as callback for the IN
+ *          data endpoint.
+ *
+ * @param[in] usbp      pointer to the @p USBDriver object
+ * @param[in] ep        IN endpoint number
+ */
+void sduDataTransmitted(USBDriver *usbp, usbep_t ep) {
+  uint8_t *buf;
+  size_t n;
+  SerialUSBDriver *sdup = usbp->in_params[ep - 1U];
+
+  if (sdup == NULL) {
+    return;
+  }
+
+  osalSysLockFromISR();
+
+  /* Signaling that space is available in the output queue.*/
+  chnAddFlagsI(sdup, CHN_OUTPUT_EMPTY);
+
+  /* Freeing the buffer just transmitted, if it was not a zero size packet.*/
+  if (usbp->epc[ep]->in_state->txsize > 0U) {
+    obqReleaseEmptyBufferI(&sdup->obqueue);
+  }
+
+  /* Checking if there is a buffer ready for transmission.*/
+  buf = obqGetFullBufferI(&sdup->obqueue, &n);
+
+  if (buf != NULL) {
+    /* The endpoint cannot be busy, we are in the context of the callback,
+       so it is safe to transmit without a check.*/
+    usbStartTransmitI(usbp, ep, buf, n);
+  }
+  else if ((usbp->epc[ep]->in_state->txsize > 0U) &&
+           ((usbp->epc[ep]->in_state->txsize &
+            ((size_t)usbp->epc[ep]->in_maxsize - 1U)) == 0U)) {
+    /* Transmit zero sized packet in case the last one has maximum allowed
+       size. Otherwise the recipient may expect more data coming soon and
+       not return buffered data to app. See section 5.8.3 Bulk Transfer
+       Packet Size Constraints of the USB Specification document.*/
+    usbStartTransmitI(usbp, ep, usbp->setup, 0);
+
+  }
+  else {
+    /* Nothing to transmit.*/
+  }
+
+  osalSysUnlockFromISR();
+}
+
+/**
+ * @brief   Default data received callback.
+ * @details The application must use this function as callback for the OUT
+ *          data endpoint.
+ *
+ * @param[in] usbp      pointer to the @p USBDriver object
+ * @param[in] ep        OUT endpoint number
+ */
+void sduDataReceived(USBDriver *usbp, usbep_t ep) {
+  SerialUSBDriver *sdup = usbp->out_params[ep - 1U];
+  if (sdup == NULL) {
+    return;
+  }
+
+  osalSysLockFromISR();
+
+  /* Signaling that data is available in the input queue.*/
+  chnAddFlagsI(sdup, CHN_INPUT_AVAILABLE);
+
+  /* Posting the filled buffer in the queue.*/
+  ibqPostFullBufferI(&sdup->ibqueue,
+                     usbGetReceiveTransactionSizeX(sdup->config->usbp,
+                                                   sdup->config->bulk_out));
+
+  /* The endpoint cannot be busy, we are in the context of the callback,
+     so a packet is in the buffer for sure. Trying to get a free buffer
+     for the next transaction.*/
+  (void) sdu_start_receive(sdup);
+
+  osalSysUnlockFromISR();
+}
+
+/**
+ * @brief   Default data received callback.
+ * @details The application must use this function as callback for the IN
+ *          interrupt endpoint.
+ *
+ * @param[in] usbp      pointer to the @p USBDriver object
+ * @param[in] ep        endpoint number
+ */
+void sduInterruptTransmitted(USBDriver *usbp, usbep_t ep) {
+
+  (void)usbp;
+  (void)ep;
+}
+
+#endif /* HAL_USE_SERIAL_USB == TRUE */
+
+/** @} */

--- a/tmk_core/protocol/chibios/usb_driver.c
+++ b/tmk_core/protocol/chibios/usb_driver.c
@@ -24,6 +24,7 @@
 
 #include "hal.h"
 #include "usb_driver.h"
+#include <string.h>
 
 /*===========================================================================*/
 /* Driver local definitions.                                                 */
@@ -385,6 +386,12 @@ void qmkusbSOFHookI(QMKUSBDriver *qmkusbp) {
   if (obqTryFlushI(&qmkusbp->obqueue)) {
     size_t n;
     uint8_t *buf = obqGetFullBufferI(&qmkusbp->obqueue, &n);
+
+    /* For fixed size drivers, fill the end with zeros */
+    if (qmkusbp->config->fixed_size) {
+      memset(buf + n, 0, qmkusbp->config->in_size - n);
+      n = qmkusbp->config->in_size;
+    }
 
     osalDbgAssert(buf != NULL, "queue is empty");
 

--- a/tmk_core/protocol/chibios/usb_driver.c
+++ b/tmk_core/protocol/chibios/usb_driver.c
@@ -193,11 +193,12 @@ void qmkusbObjectInit(QMKUSBDriver *qmkusbp) {
   qmkusbp->vmt = &vmt;
   osalEventObjectInit(&qmkusbp->event);
   qmkusbp->state = QMKUSB_STOP;
-  ibqObjectInit(&qmkusbp->ibqueue, true, qmkusbp->ib,
-                SERIAL_USB_BUFFERS_SIZE, SERIAL_USB_BUFFERS_NUMBER,
+  // Note that the config uses the USB direction naming
+  ibqObjectInit(&qmkusbp->ibqueue, true, qmkusbp->config->ob,
+                qmkusbp->config->out_size, qmkusbp->config->out_buffers,
                 ibnotify, qmkusbp);
-  obqObjectInit(&qmkusbp->obqueue, true, qmkusbp->ob,
-                SERIAL_USB_BUFFERS_SIZE, SERIAL_USB_BUFFERS_NUMBER,
+  obqObjectInit(&qmkusbp->obqueue, true, qmkusbp->config->ib,
+                qmkusbp->config->in_size, qmkusbp->config->in_buffers,
                 obnotify, qmkusbp);
 }
 

--- a/tmk_core/protocol/chibios/usb_driver.c
+++ b/tmk_core/protocol/chibios/usb_driver.c
@@ -189,17 +189,17 @@ void qmkusbInit(void) {
  *
  * @init
  */
-void qmkusbObjectInit(QMKUSBDriver *qmkusbp) {
+void qmkusbObjectInit(QMKUSBDriver *qmkusbp, const QMKUSBConfig *config) {
 
   qmkusbp->vmt = &vmt;
   osalEventObjectInit(&qmkusbp->event);
   qmkusbp->state = QMKUSB_STOP;
   // Note that the config uses the USB direction naming
-  ibqObjectInit(&qmkusbp->ibqueue, true, qmkusbp->config->ob,
-                qmkusbp->config->out_size, qmkusbp->config->out_buffers,
+  ibqObjectInit(&qmkusbp->ibqueue, true, config->ob,
+                config->out_size, config->out_buffers,
                 ibnotify, qmkusbp);
-  obqObjectInit(&qmkusbp->obqueue, true, qmkusbp->config->ib,
-                qmkusbp->config->in_size, qmkusbp->config->in_buffers,
+  obqObjectInit(&qmkusbp->obqueue, true, config->ib,
+                config->in_size, config->in_buffers,
                 obnotify, qmkusbp);
 }
 

--- a/tmk_core/protocol/chibios/usb_driver.c
+++ b/tmk_core/protocol/chibios/usb_driver.c
@@ -441,7 +441,9 @@ void qmkusbDataTransmitted(USBDriver *usbp, usbep_t ep) {
        size. Otherwise the recipient may expect more data coming soon and
        not return buffered data to app. See section 5.8.3 Bulk Transfer
        Packet Size Constraints of the USB Specification document.*/
-    usbStartTransmitI(usbp, ep, usbp->setup, 0);
+    if (!qmkusbp->config->fixed_size) {
+      usbStartTransmitI(usbp, ep, usbp->setup, 0);
+    }
 
   }
   else {

--- a/tmk_core/protocol/chibios/usb_driver.h
+++ b/tmk_core/protocol/chibios/usb_driver.h
@@ -1,0 +1,196 @@
+/*
+    ChibiOS - Copyright (C) 2006..2016 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    hal_serial_usb.h
+ * @brief   Serial over USB Driver macros and structures.
+ *
+ * @addtogroup SERIAL_USB
+ * @{
+ */
+
+#ifndef HAL_SERIAL_USB_H
+#define HAL_SERIAL_USB_H
+
+#if (HAL_USE_SERIAL_USB == TRUE) || defined(__DOXYGEN__)
+
+#include "hal_usb_cdc.h"
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/**
+ * @name    SERIAL_USB configuration options
+ * @{
+ */
+/**
+ * @brief   Serial over USB buffers size.
+ * @details Configuration parameter, the buffer size must be a multiple of
+ *          the USB data endpoint maximum packet size.
+ * @note    The default is 256 bytes for both the transmission and receive
+ *          buffers.
+ */
+#if !defined(SERIAL_USB_BUFFERS_SIZE) || defined(__DOXYGEN__)
+#define SERIAL_USB_BUFFERS_SIZE     256
+#endif
+
+/**
+ * @brief   Serial over USB number of buffers.
+ * @note    The default is 2 buffers.
+ */
+#if !defined(SERIAL_USB_BUFFERS_NUMBER) || defined(__DOXYGEN__)
+#define SERIAL_USB_BUFFERS_NUMBER   2
+#endif
+/** @} */
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+#if HAL_USE_USB == FALSE
+#error "Serial over USB Driver requires HAL_USE_USB"
+#endif
+
+/*===========================================================================*/
+/* Driver data structures and types.                                         */
+/*===========================================================================*/
+
+/**
+ * @brief Driver state machine possible states.
+ */
+typedef enum {
+  SDU_UNINIT = 0,                   /**< Not initialized.                   */
+  SDU_STOP = 1,                     /**< Stopped.                           */
+  SDU_READY = 2                     /**< Ready.                             */
+} sdustate_t;
+
+/**
+ * @brief   Structure representing a serial over USB driver.
+ */
+typedef struct SerialUSBDriver SerialUSBDriver;
+
+/**
+ * @brief   Serial over USB Driver configuration structure.
+ * @details An instance of this structure must be passed to @p sduStart()
+ *          in order to configure and start the driver operations.
+ */
+typedef struct {
+  /**
+   * @brief   USB driver to use.
+   */
+  USBDriver                 *usbp;
+  /**
+   * @brief   Bulk IN endpoint used for outgoing data transfer.
+   */
+  usbep_t                   bulk_in;
+  /**
+   * @brief   Bulk OUT endpoint used for incoming data transfer.
+   */
+  usbep_t                   bulk_out;
+  /**
+   * @brief   Interrupt IN endpoint used for notifications.
+   * @note    If set to zero then the INT endpoint is assumed to be not
+   *          present, USB descriptors must be changed accordingly.
+   */
+  usbep_t                   int_in;
+} SerialUSBConfig;
+
+/**
+ * @brief   @p SerialDriver specific data.
+ */
+#define _serial_usb_driver_data                                             \
+  _base_asynchronous_channel_data                                           \
+  /* Driver state.*/                                                        \
+  sdustate_t                state;                                          \
+  /* Input buffers queue.*/                                                 \
+  input_buffers_queue_t     ibqueue;                                        \
+  /* Output queue.*/                                                        \
+  output_buffers_queue_t    obqueue;                                        \
+  /* Input buffer.*/                                                        \
+  uint8_t                   ib[BQ_BUFFER_SIZE(SERIAL_USB_BUFFERS_NUMBER,    \
+                                              SERIAL_USB_BUFFERS_SIZE)];    \
+  /* Output buffer.*/                                                       \
+  uint8_t                   ob[BQ_BUFFER_SIZE(SERIAL_USB_BUFFERS_NUMBER,    \
+                                              SERIAL_USB_BUFFERS_SIZE)];    \
+  /* End of the mandatory fields.*/                                         \
+  /* Current configuration data.*/                                          \
+  const SerialUSBConfig     *config;
+
+/**
+ * @brief   @p SerialUSBDriver specific methods.
+ */
+#define _serial_usb_driver_methods                                          \
+  _base_asynchronous_channel_methods
+
+/**
+ * @extends BaseAsynchronousChannelVMT
+ *
+ * @brief   @p SerialDriver virtual methods table.
+ */
+struct SerialUSBDriverVMT {
+  _serial_usb_driver_methods
+};
+
+/**
+ * @extends BaseAsynchronousChannel
+ *
+ * @brief   Full duplex serial driver class.
+ * @details This class extends @p BaseAsynchronousChannel by adding physical
+ *          I/O queues.
+ */
+struct SerialUSBDriver {
+  /** @brief Virtual Methods Table.*/
+  const struct SerialUSBDriverVMT *vmt;
+  _serial_usb_driver_data
+};
+
+/*===========================================================================*/
+/* Driver macros.                                                            */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void sduInit(void);
+  void sduObjectInit(SerialUSBDriver *sdup);
+  void sduStart(SerialUSBDriver *sdup, const SerialUSBConfig *config);
+  void sduStop(SerialUSBDriver *sdup);
+  void sduSuspendHookI(SerialUSBDriver *sdup);
+  void sduWakeupHookI(SerialUSBDriver *sdup);
+  void sduConfigureHookI(SerialUSBDriver *sdup);
+  bool sduRequestsHook(USBDriver *usbp);
+  void sduSOFHookI(SerialUSBDriver *sdup);
+  void sduDataTransmitted(USBDriver *usbp, usbep_t ep);
+  void sduDataReceived(USBDriver *usbp, usbep_t ep);
+  void sduInterruptTransmitted(USBDriver *usbp, usbep_t ep);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HAL_USE_SERIAL_USB == TRUE */
+
+#endif /* HAL_SERIAL_USB_H */
+
+/** @} */

--- a/tmk_core/protocol/chibios/usb_driver.h
+++ b/tmk_core/protocol/chibios/usb_driver.h
@@ -164,7 +164,7 @@ struct QMKUSBDriver {
 extern "C" {
 #endif
   void qmkusbInit(void);
-  void qmkusbObjectInit(QMKUSBDriver *qmkusbp);
+  void qmkusbObjectInit(QMKUSBDriver *qmkusbp, const QMKUSBConfig * config);
   void qmkusbStart(QMKUSBDriver *qmkusbp, const QMKUSBConfig *config);
   void qmkusbStop(QMKUSBDriver *qmkusbp);
   void qmkusbSuspendHookI(QMKUSBDriver *qmkusbp);

--- a/tmk_core/protocol/chibios/usb_driver.h
+++ b/tmk_core/protocol/chibios/usb_driver.h
@@ -15,17 +15,15 @@
 */
 
 /**
- * @file    hal_serial_usb.h
- * @brief   Serial over USB Driver macros and structures.
+ * @file    usb_driver.h
+ * @brief   Usb driver suitable for both packet and serial formats
  *
  * @addtogroup SERIAL_USB
  * @{
  */
 
-#ifndef HAL_SERIAL_USB_H
-#define HAL_SERIAL_USB_H
-
-#if (HAL_USE_SERIAL_USB == TRUE) || defined(__DOXYGEN__)
+#ifndef USB_DRIVER_H
+#define USB_DRIVER_H
 
 #include "hal_usb_cdc.h"
 
@@ -34,39 +32,11 @@
 /*===========================================================================*/
 
 /*===========================================================================*/
-/* Driver pre-compile time settings.                                         */
-/*===========================================================================*/
-
-/**
- * @name    SERIAL_USB configuration options
- * @{
- */
-/**
- * @brief   Serial over USB buffers size.
- * @details Configuration parameter, the buffer size must be a multiple of
- *          the USB data endpoint maximum packet size.
- * @note    The default is 256 bytes for both the transmission and receive
- *          buffers.
- */
-#if !defined(SERIAL_USB_BUFFERS_SIZE) || defined(__DOXYGEN__)
-#define SERIAL_USB_BUFFERS_SIZE     256
-#endif
-
-/**
- * @brief   Serial over USB number of buffers.
- * @note    The default is 2 buffers.
- */
-#if !defined(SERIAL_USB_BUFFERS_NUMBER) || defined(__DOXYGEN__)
-#define SERIAL_USB_BUFFERS_NUMBER   2
-#endif
-/** @} */
-
-/*===========================================================================*/
 /* Derived constants and error checks.                                       */
 /*===========================================================================*/
 
 #if HAL_USE_USB == FALSE
-#error "Serial over USB Driver requires HAL_USE_USB"
+#error "The USB Driver requires HAL_USE_USB"
 #endif
 
 /*===========================================================================*/
@@ -77,15 +47,15 @@
  * @brief Driver state machine possible states.
  */
 typedef enum {
-  SDU_UNINIT = 0,                   /**< Not initialized.                   */
-  SDU_STOP = 1,                     /**< Stopped.                           */
-  SDU_READY = 2                     /**< Ready.                             */
-} sdustate_t;
+  QMKUSB_UNINIT = 0,                   /**< Not initialized.                   */
+  QMKUSB_STOP = 1,                     /**< Stopped.                           */
+  QMKUSB_READY = 2                     /**< Ready.                             */
+} qmkusbstate_t;
 
 /**
  * @brief   Structure representing a serial over USB driver.
  */
-typedef struct SerialUSBDriver SerialUSBDriver;
+typedef struct QMKUSBDriver QMKUSBDriver;
 
 /**
  * @brief   Serial over USB Driver configuration structure.
@@ -111,15 +81,15 @@ typedef struct {
    *          present, USB descriptors must be changed accordingly.
    */
   usbep_t                   int_in;
-} SerialUSBConfig;
+} QMKUSBConfig;
 
 /**
  * @brief   @p SerialDriver specific data.
  */
-#define _serial_usb_driver_data                                             \
+#define _qmk_usb_driver_data                                                \
   _base_asynchronous_channel_data                                           \
   /* Driver state.*/                                                        \
-  sdustate_t                state;                                          \
+  qmkusbstate_t             state;                                          \
   /* Input buffers queue.*/                                                 \
   input_buffers_queue_t     ibqueue;                                        \
   /* Output queue.*/                                                        \
@@ -132,12 +102,12 @@ typedef struct {
                                               SERIAL_USB_BUFFERS_SIZE)];    \
   /* End of the mandatory fields.*/                                         \
   /* Current configuration data.*/                                          \
-  const SerialUSBConfig     *config;
+  const QMKUSBConfig     *config;
 
 /**
  * @brief   @p SerialUSBDriver specific methods.
  */
-#define _serial_usb_driver_methods                                          \
+#define _qmk_usb_driver_methods                                             \
   _base_asynchronous_channel_methods
 
 /**
@@ -145,8 +115,8 @@ typedef struct {
  *
  * @brief   @p SerialDriver virtual methods table.
  */
-struct SerialUSBDriverVMT {
-  _serial_usb_driver_methods
+struct QMKUSBDriverVMT {
+  _qmk_usb_driver_methods
 };
 
 /**
@@ -156,10 +126,10 @@ struct SerialUSBDriverVMT {
  * @details This class extends @p BaseAsynchronousChannel by adding physical
  *          I/O queues.
  */
-struct SerialUSBDriver {
+struct QMKUSBDriver {
   /** @brief Virtual Methods Table.*/
-  const struct SerialUSBDriverVMT *vmt;
-  _serial_usb_driver_data
+  const struct QMKUSBDriverVMT *vmt;
+  _qmk_usb_driver_data
 };
 
 /*===========================================================================*/
@@ -173,24 +143,22 @@ struct SerialUSBDriver {
 #ifdef __cplusplus
 extern "C" {
 #endif
-  void sduInit(void);
-  void sduObjectInit(SerialUSBDriver *sdup);
-  void sduStart(SerialUSBDriver *sdup, const SerialUSBConfig *config);
-  void sduStop(SerialUSBDriver *sdup);
-  void sduSuspendHookI(SerialUSBDriver *sdup);
-  void sduWakeupHookI(SerialUSBDriver *sdup);
-  void sduConfigureHookI(SerialUSBDriver *sdup);
-  bool sduRequestsHook(USBDriver *usbp);
-  void sduSOFHookI(SerialUSBDriver *sdup);
-  void sduDataTransmitted(USBDriver *usbp, usbep_t ep);
-  void sduDataReceived(USBDriver *usbp, usbep_t ep);
-  void sduInterruptTransmitted(USBDriver *usbp, usbep_t ep);
+  void qmkusbInit(void);
+  void qmkusbObjectInit(QMKUSBDriver *qmkusbp);
+  void qmkusbStart(QMKUSBDriver *qmkusbp, const QMKUSBConfig *config);
+  void qmkusbStop(QMKUSBDriver *qmkusbp);
+  void qmkusbSuspendHookI(QMKUSBDriver *qmkusbp);
+  void qmkusbWakeupHookI(QMKUSBDriver *qmkusbp);
+  void qmkusbConfigureHookI(QMKUSBDriver *qmkusbp);
+  bool qmkusbRequestsHook(USBDriver *usbp);
+  void qmkusbSOFHookI(QMKUSBDriver *qmkusbp);
+  void qmkusbDataTransmitted(USBDriver *usbp, usbep_t ep);
+  void qmkusbDataReceived(USBDriver *usbp, usbep_t ep);
+  void qmkusbInterruptTransmitted(USBDriver *usbp, usbep_t ep);
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* HAL_USE_SERIAL_USB == TRUE */
-
-#endif /* HAL_SERIAL_USB_H */
+#endif /* USB_DRIVER_H */
 
 /** @} */

--- a/tmk_core/protocol/chibios/usb_driver.h
+++ b/tmk_core/protocol/chibios/usb_driver.h
@@ -81,6 +81,27 @@ typedef struct {
    *          present, USB descriptors must be changed accordingly.
    */
   usbep_t                   int_in;
+
+  /**
+   * @brief The number of buffers in the queues
+   */
+  size_t                    in_buffers;
+  size_t                    out_buffers;
+
+  /**
+   * @brief The size of each buffer in the queue, typically the same as the endpoint size
+   */
+  size_t                    in_size;
+  size_t                    out_size;
+
+  /* Input buffer
+   * @note needs to be initialized with a memory buffer of the right size
+   */
+  uint8_t*                  ib;
+  /* Output buffer
+   * @note needs to be initialized with a memory buffer of the right size
+   */
+  uint8_t*                  ob;
 } QMKUSBConfig;
 
 /**
@@ -94,12 +115,6 @@ typedef struct {
   input_buffers_queue_t     ibqueue;                                        \
   /* Output queue.*/                                                        \
   output_buffers_queue_t    obqueue;                                        \
-  /* Input buffer.*/                                                        \
-  uint8_t                   ib[BQ_BUFFER_SIZE(SERIAL_USB_BUFFERS_NUMBER,    \
-                                              SERIAL_USB_BUFFERS_SIZE)];    \
-  /* Output buffer.*/                                                       \
-  uint8_t                   ob[BQ_BUFFER_SIZE(SERIAL_USB_BUFFERS_NUMBER,    \
-                                              SERIAL_USB_BUFFERS_SIZE)];    \
   /* End of the mandatory fields.*/                                         \
   /* Current configuration data.*/                                          \
   const QMKUSBConfig     *config;

--- a/tmk_core/protocol/chibios/usb_driver.h
+++ b/tmk_core/protocol/chibios/usb_driver.h
@@ -94,6 +94,11 @@ typedef struct {
   size_t                    in_size;
   size_t                    out_size;
 
+  /**
+   * @brief Always send full buffers in_size (the rest is filled with zeroes)
+   */
+  bool                      fixed_size;
+
   /* Input buffer
    * @note needs to be initialized with a memory buffer of the right size
    */

--- a/tmk_core/protocol/chibios/usb_main.c
+++ b/tmk_core/protocol/chibios/usb_main.c
@@ -569,7 +569,7 @@ void init_usb_driver(USBDriver *usbp) {
     drivers.array[i].in_ep_config.in_state = &drivers.array[i].in_ep_state;
     drivers.array[i].out_ep_config.out_state = &drivers.array[i].out_ep_state;
     drivers.array[i].int_ep_config.in_state = &drivers.array[i].int_ep_state;
-    qmkusbObjectInit(driver);
+    qmkusbObjectInit(driver, &drivers.array[i].config);
     qmkusbStart(driver, &drivers.array[i].config);
   }
 


### PR DESCRIPTION
This now properly handles both interrupt based endpoints, like the console output, and stream endpoints like the virtual serial port, which is used by steno.

This fixes the debug console output, and possibly some other issues, because the input queues and output queues were the same by mistake.