### PR TITLE
Link to Atmel's flip is broken.

### DIFF
--- a/docs/flashing.md
+++ b/docs/flashing.md
@@ -20,7 +20,7 @@ Compatible flashers:
 
 * [QMK Toolbox](https://github.com/qmk/qmk_toolbox/releases) (recommended GUI)
 * [dfu-programmer](https://github.com/dfu-programmer/dfu-programmer) / `:dfu` in QMK (recommended command line)
-* [Atmel's Flip](http://www.atmel.com/tools/flip.aspx) (not recommended)
+* [Atmel's Flip](http://www.microchip.com/developmenttools/productdetails.aspx?partno=flip) (not recommended)
 
 Flashing sequence:
 


### PR DESCRIPTION
The link to Atmel's flip is broken. It re-directs to http://www.microchip.com/. Please update!

I think this is the correct link. Please verify.

http://www.microchip.com/developmenttools/productdetails.aspx?partno=flip