### PR TITLE
Fix Audio Clicky sub-feature

### DIFF
--- a/common_features.mk
+++ b/common_features.mk
@@ -34,6 +34,7 @@ ifeq ($(strip $(AUDIO_ENABLE)), yes)
     OPT_DEFS += -DAUDIO_ENABLE
     MUSIC_ENABLE := 1
     SRC += $(QUANTUM_DIR)/process_keycode/process_audio.c
+    SRC += $(QUANTUM_DIR)/process_keycode/process_clicky.c
     ifeq ($(PLATFORM),AVR)
         SRC += $(QUANTUM_DIR)/audio/audio.c
     else

--- a/quantum/process_keycode/process_audio.c
+++ b/quantum/process_keycode/process_audio.c
@@ -10,45 +10,7 @@ float voice_change_song[][2] = VOICE_CHANGE_SONG;
     #define PITCH_STANDARD_A 440.0f
 #endif
 
-#ifdef AUDIO_CLICKY
-#ifdef AUDIO_CLICKY_ON
-bool clicky_enable = true;
-#else
-bool clicky_enable = false;
-#endif
-#ifndef AUDIO_CLICKY_FREQ_DEFAULT
-#define AUDIO_CLICKY_FREQ_DEFAULT 440.0f
-#endif
-#ifndef AUDIO_CLICKY_FREQ_MIN
-#define AUDIO_CLICKY_FREQ_MIN 65.0f
-#endif
-#ifndef AUDIO_CLICKY_FREQ_MAX
-#define AUDIO_CLICKY_FREQ_MAX 1500.0f
-#endif
-#ifndef AUDIO_CLICKY_FREQ_FACTOR
-#define AUDIO_CLICKY_FREQ_FACTOR 1.18921f
-#endif
-#ifndef AUDIO_CLICKY_FREQ_RANDOMNESS
-#define AUDIO_CLICKY_FREQ_RANDOMNESS 0.05f
-#endif
 
-float clicky_freq = AUDIO_CLICKY_FREQ_DEFAULT;
-float clicky_song[][2]  = {{AUDIO_CLICKY_FREQ_DEFAULT, 3}, {AUDIO_CLICKY_FREQ_DEFAULT, 1}}; // 3 and 1 --> durations
-
-#ifndef NO_MUSIC_MODE
-extern bool music_activated;
-extern bool midi_activated;
-#endif
-
-void clicky_play(void) {
-#ifndef NO_MUSIC_MODE
-  if (music_activated || midi_activated) return;
-#endif
-  clicky_song[0][0] = 2.0f * clicky_freq * (1.0f + AUDIO_CLICKY_FREQ_RANDOMNESS * ( ((float)rand()) / ((float)(RAND_MAX)) ) );
-  clicky_song[1][0] = clicky_freq * (1.0f + AUDIO_CLICKY_FREQ_RANDOMNESS * ( ((float)rand()) / ((float)(RAND_MAX)) ) );
-  PLAY_SONG(clicky_song);
-}
-#endif
 
 static float compute_freq_for_midi_note(uint8_t note)
 {
@@ -88,33 +50,6 @@ bool process_audio(uint16_t keycode, keyrecord_t *record) {
         PLAY_SONG(voice_change_song);
         return false;
     }
-
-#ifdef AUDIO_CLICKY
-    if (keycode == CLICKY_TOGGLE && record->event.pressed) { clicky_enable = !clicky_enable; }
-
-    if (keycode == CLICKY_RESET && record->event.pressed) { clicky_freq = AUDIO_CLICKY_FREQ_DEFAULT; }
-
-    if (keycode == CLICKY_UP && record->event.pressed) {
-      float new_freq = clicky_freq * AUDIO_CLICKY_FREQ_FACTOR;
-      if (new_freq < AUDIO_CLICKY_FREQ_MAX) {
-        clicky_freq = new_freq;
-      }
-    }
-    if (keycode == CLICKY_TOGGLE && record->event.pressed) {
-      float new_freq = clicky_freq / AUDIO_CLICKY_FREQ_FACTOR;
-      if (new_freq > AUDIO_CLICKY_FREQ_MIN) {
-        clicky_freq = new_freq;
-      }
-      }
-
-
-    if ( clicky_enable ) {
-      if (record->event.pressed) {
-        stop_all_notes();
-        clicky_play();;
-      }
-    }
-#endif // AUDIO_CLICKY
 
     return true;
 }

--- a/quantum/process_keycode/process_clicky.c
+++ b/quantum/process_keycode/process_clicky.c
@@ -1,6 +1,8 @@
 #include "audio.h"
 #include "process_clicky.h"
 
+#ifdef AUDIO_CLICKY
+
 #ifdef AUDIO_CLICKY_ON
 bool clicky_enable = true;
 #else // AUDIO_CLICKY_ON
@@ -39,7 +41,7 @@ void clicky_play(void) {
   PLAY_SONG(clicky_song);
 }
 
-bool process_audio(uint16_t keycode, keyrecord_t *record) {
+bool process_clicky(uint16_t keycode, keyrecord_t *record) {
     if (keycode == CLICKY_TOGGLE && record->event.pressed) { clicky_enable = !clicky_enable; }
 
     if (keycode == CLICKY_RESET && record->event.pressed) { clicky_freq = AUDIO_CLICKY_FREQ_DEFAULT; }
@@ -67,3 +69,4 @@ bool process_audio(uint16_t keycode, keyrecord_t *record) {
     return true;
 }
 
+#endif //AUDIO_CLICKY

--- a/quantum/process_keycode/process_clicky.c
+++ b/quantum/process_keycode/process_clicky.c
@@ -1,0 +1,69 @@
+#include "audio.h"
+#include "process_clicky.h"
+
+#ifdef AUDIO_CLICKY_ON
+bool clicky_enable = true;
+#else // AUDIO_CLICKY_ON
+bool clicky_enable = false;
+#endif // AUDIO_CLICKY_ON
+#ifndef AUDIO_CLICKY_FREQ_DEFAULT
+#define AUDIO_CLICKY_FREQ_DEFAULT 440.0f
+#endif // !AUDIO_CLICKY_FREQ_DEFAULT
+#ifndef AUDIO_CLICKY_FREQ_MIN
+#define AUDIO_CLICKY_FREQ_MIN 65.0f
+#endif // !AUDIO_CLICKY_FREQ_MIN
+#ifndef AUDIO_CLICKY_FREQ_MAX
+#define AUDIO_CLICKY_FREQ_MAX 1500.0f
+#endif // !AUDIO_CLICKY_FREQ_MAX
+#ifndef AUDIO_CLICKY_FREQ_FACTOR
+#define AUDIO_CLICKY_FREQ_FACTOR 1.18921f
+#endif // !AUDIO_CLICKY_FREQ_FACTOR
+#ifndef AUDIO_CLICKY_FREQ_RANDOMNESS
+#define AUDIO_CLICKY_FREQ_RANDOMNESS 0.05f
+#endif // !AUDIO_CLICKY_FREQ_RANDOMNESS
+
+float clicky_freq = AUDIO_CLICKY_FREQ_DEFAULT;
+float clicky_song[][2]  = {{AUDIO_CLICKY_FREQ_DEFAULT, 3}, {AUDIO_CLICKY_FREQ_DEFAULT, 1}}; // 3 and 1 --> durations
+
+#ifndef NO_MUSIC_MODE
+extern bool music_activated;
+extern bool midi_activated;
+#endif // !NO_MUSIC_MODE
+
+void clicky_play(void) {
+#ifndef NO_MUSIC_MODE
+  if (music_activated || midi_activated) return;
+#endif // !NO_MUSIC_MODE
+  clicky_song[0][0] = 2.0f * clicky_freq * (1.0f + AUDIO_CLICKY_FREQ_RANDOMNESS * ( ((float)rand()) / ((float)(RAND_MAX)) ) );
+  clicky_song[1][0] = clicky_freq * (1.0f + AUDIO_CLICKY_FREQ_RANDOMNESS * ( ((float)rand()) / ((float)(RAND_MAX)) ) );
+  PLAY_SONG(clicky_song);
+}
+
+bool process_audio(uint16_t keycode, keyrecord_t *record) {
+    if (keycode == CLICKY_TOGGLE && record->event.pressed) { clicky_enable = !clicky_enable; }
+
+    if (keycode == CLICKY_RESET && record->event.pressed) { clicky_freq = AUDIO_CLICKY_FREQ_DEFAULT; }
+
+    if (keycode == CLICKY_UP && record->event.pressed) {
+      float new_freq = clicky_freq * AUDIO_CLICKY_FREQ_FACTOR;
+      if (new_freq < AUDIO_CLICKY_FREQ_MAX) {
+        clicky_freq = new_freq;
+      }
+    }
+    if (keycode == CLICKY_TOGGLE && record->event.pressed) {
+      float new_freq = clicky_freq / AUDIO_CLICKY_FREQ_FACTOR;
+      if (new_freq > AUDIO_CLICKY_FREQ_MIN) {
+        clicky_freq = new_freq;
+      }
+    }
+
+
+    if ( clicky_enable ) {
+      if (record->event.pressed) {
+        stop_all_notes();
+        clicky_play();;
+      }
+    }
+    return true;
+}
+

--- a/quantum/process_keycode/process_clicky.h
+++ b/quantum/process_keycode/process_clicky.h
@@ -1,0 +1,7 @@
+#ifndef PROCESS_CLICKY_H
+#define PROCESS_CLICKY_H
+
+void clicky_play(void);
+bool process_clicky(uint16_t keycode, keyrecord_t *record);
+
+#endif

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -226,6 +226,9 @@ bool process_record_quantum(keyrecord_t *record) {
     // Must run first to be able to mask key_up events.
     process_key_lock(&keycode, record) &&
   #endif
+  #if defined(AUDIO_ENABLE) && defined(AUDIO_CLICKY)
+      process_clicky(keycode, record) &&
+  #endif //AUDIO_CLICKY
     process_record_kb(keycode, record) &&
   #if defined(MIDI_ENABLE) && defined(MIDI_ADVANCED)
     process_midi(keycode, record) &&
@@ -236,7 +239,7 @@ bool process_record_quantum(keyrecord_t *record) {
   #ifdef STENO_ENABLE
     process_steno(keycode, record) &&
   #endif
-  #if ( defined(AUDIO_ENABLE) || (defined(MIDI_ENABLE) && defined(MIDI_BASIC))) && !defined(NO_MUSIC_MODE) 
+  #if ( defined(AUDIO_ENABLE) || (defined(MIDI_ENABLE) && defined(MIDI_BASIC))) && !defined(NO_MUSIC_MODE)
     process_music(keycode, record) &&
   #endif
   #ifdef TAP_DANCE_ENABLE

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -57,6 +57,9 @@ extern uint32_t default_layer_state;
 #ifdef AUDIO_ENABLE
 	#include "audio.h"
  	#include "process_audio.h"
+  #ifdef AUDIO_CLICKY
+    #include "process_clicky.h"
+  #endif // AUDIO_CLICKY
 #endif
 
 #ifdef STENO_ENABLE


### PR DESCRIPTION
After playing with this more ... I realized that the process_audio was being called "too late". 

specifically, any custom macro (like KC_MAKE, RAISE, or LOWER) would return false, and not process the audio code. 

Added a new process function to handle this before process_record_kb, so this should ALWAYS cause clicky sounds (which is the desired effect). 

