### PR TITLE
Adds default value for TAPPING_TERM if Tap Dance is enabled

### DIFF
--- a/quantum/process_keycode/process_tap_dance.c
+++ b/quantum/process_keycode/process_tap_dance.c
@@ -16,6 +16,10 @@
 #include "quantum.h"
 #include "action_tapping.h"
 
+#ifndef TAPPING_TERM
+#define TAPPING_TERM 200
+#endif
+
 #ifndef NO_ACTION_ONESHOT
 uint8_t get_oneshot_mods(void);
 #endif

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -104,7 +104,12 @@ extern uint32_t default_layer_state;
     #include "process_unicodemap.h"
 #endif
 
-#include "process_tap_dance.h"
+#ifdef TAP_DANCE_ENABLE
+#ifndef TAPPING_TERM
+#error TAPPING_TERM not defined
+#endif
+  #include "process_tap_dance.h"
+#endif
 
 #ifdef PRINTING_ENABLE
     #include "process_printer.h"

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -28,7 +28,7 @@
     #include "backlight.h"
 #endif
 #if !defined(RGBLIGHT_ENABLE) && !defined(RGB_MATRIX_ENABLE)
-    #include "rgb.h"
+	#include "rgb.h"
 #endif
 #ifdef RGBLIGHT_ENABLE
   #include "rgblight.h"
@@ -105,9 +105,6 @@ extern uint32_t default_layer_state;
 #endif
 
 #ifdef TAP_DANCE_ENABLE
-#ifndef TAPPING_TERM
-#error TAPPING_TERM not defined
-#endif
   #include "process_tap_dance.h"
 #endif
 


### PR DESCRIPTION
~~AKA, give it a meaningful reason why it failed, rather than something cryptic.~~

~~Alternatively, could manually force a tapping term here instead.  Not sure which is better~~

Edited this, so that if tap dancing is enabled, and `TAPPING_TERM` isn't defined, that it forces a default value of 200 (ms), since Tap Dance requires this to function properly. 

This is more graceful than just erroring out.