### PR TITLE
Fix command line options prefix.

### DIFF
--- a/keyboards/chibios_test/teensy_lc_onekey/instructions.md
+++ b/keyboards/chibios_test/teensy_lc_onekey/instructions.md
@@ -15,7 +15,7 @@ Next, you'll need ChibiOS. For Teensies, you'll need code from two repositories:
 
 ### If you’re using git
 
-Run `git submodule sync —recursive && git submodule update --init —recursive`. This will install ChibiOS and ChibiOS-Contrib in the `/lib/` directory.
+Run `git submodule sync --recursive && git submodule update --init --recursive`. This will install ChibiOS and ChibiOS-Contrib in the `/lib/` directory.
 
 ### If you’re not using Git
 


### PR DESCRIPTION
Fixed because option prefix on command line was incorrect in 'Installing ChibiOS' section.