### PR TITLE
Allow one-shot modifiers to be chained

### DIFF
--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -258,10 +258,10 @@ void process_action(keyrecord_t *record, action_t action)
                         if (event.pressed) {
                             if (tap_count == 0) {
                                 dprint("MODS_TAP: Oneshot: 0\n");
-                                register_mods(mods);
+                                register_mods(mods | get_oneshot_mods());
                             } else if (tap_count == 1) {
                                 dprint("MODS_TAP: Oneshot: start\n");
-                                set_oneshot_mods(mods);
+                                set_oneshot_mods(mods | get_oneshot_mods());
                     #if defined(ONESHOT_TAP_TOGGLE) && ONESHOT_TAP_TOGGLE > 1
                             } else if (tap_count == ONESHOT_TAP_TOGGLE) {
                                 dprint("MODS_TAP: Toggling oneshot");
@@ -270,7 +270,7 @@ void process_action(keyrecord_t *record, action_t action)
                                 register_mods(mods);
                     #endif
                             } else {
-                                register_mods(mods);
+                                register_mods(mods | get_oneshot_mods());
                             }
                         } else {
                             if (tap_count == 0) {


### PR DESCRIPTION
Many a times one would want to use multiple modifiers with the same key, preferably without having to hold anything, like `Ctrl+Shift+C` or `Ctrl+Shift+V` to copy/paste in GNOME Terminal. To make this possible, we need to be able to chain one-shot modifiers, so that we can have multiple of them active at the same time.

The easiest way to accomplish this is that whenever we activate a one-shot modifier, we apply it on top of the existing set, instead of re-setting the state. When deactivating, either due to an interrupt, or due to a timeout, we deactivate all oneshots anyway, so the clearing part is covered. When we turn the one-shot modifier into a toggle, that will also clear all one-shot modifiers first, so we covered that case too.

Fixes #2796, #1580, and #856.