### PR TITLE
DZ60: Add Caps Lock LED for default keymap

### DIFF
--- a/keyboards/dz60/keymaps/default/keymap.c
+++ b/keyboards/dz60/keymaps/default/keymap.c
@@ -59,3 +59,11 @@ void action_function(keyrecord_t *record, uint8_t id, uint8_t opt) {
       break;
   }
 }
+
+void led_set_user(uint8_t usb_led) {
+    if (usb_led & (1 << USB_LED_CAPS_LOCK)) {
+        DDRB |= (1 << 2); PORTB &= ~(1 << 2);
+    } else {
+        DDRB &= ~(1 << 2); PORTB &= ~(1 << 2);
+    }
+}


### PR DESCRIPTION
Commit b546da0 added better init handling, but removed Caps Lock LED handling. This re-adds it (in the right place).

I haven't done anything to the other keymaps yet, but this should at least serve as a "sample code" for those planning to work on this board.