### PR TITLE
Add support for RETRO_TAPPING to LT(layer, kc)

### DIFF
--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -653,7 +653,7 @@ void process_action(keyrecord_t *record, action_t action)
 
 #ifndef NO_ACTION_TAPPING
   #ifdef RETRO_TAPPING
-  if (!is_tap_key(record->event.key)) {
+  if (!is_tap_action(action)) {
     retro_tapping_counter = 0;
   } else {
     if (event.pressed) {
@@ -895,7 +895,15 @@ void clear_keyboard_but_mods(void)
 bool is_tap_key(keypos_t key)
 {
     action_t action = layer_switch_get_action(key);
+    return is_tap_action(action);
+}
 
+/** \brief Utilities for actions. (FIXME: Needs better description)
+ *
+ * FIXME: Needs documentation.
+ */
+bool is_tap_action(action_t action)
+{
     switch (action.kind.id) {
         case ACT_LMODS_TAP:
         case ACT_RMODS_TAP:

--- a/tmk_core/common/action.h
+++ b/tmk_core/common/action.h
@@ -95,6 +95,7 @@ void clear_keyboard(void);
 void clear_keyboard_but_mods(void);
 void layer_switch(uint8_t new_layer);
 bool is_tap_key(keypos_t key);
+bool is_tap_action(action_t action);
 
 #ifndef NO_ACTION_TAPPING
 void process_record_tap_hint(keyrecord_t *record);


### PR DESCRIPTION
Fixed a problem that does not work when combining `LT` macro and `RETRO_TAPPING`.

RETORO_TAPPING uses `is_tap_key` to determine if it is a TAP key. However, `is_tap_key` does not work properly for keys that use `LT`. It returns whether the key after layer change is TAP key or not.

Fix to detect if it is TAP key from the current layer information.
Fix #1521 
 