### PR TITLE
Add default to LEADER_TIMEOUT in case it's not defined

### DIFF
--- a/quantum/process_keycode/process_leader.c
+++ b/quantum/process_keycode/process_leader.c
@@ -18,6 +18,10 @@
 
 #include "process_leader.h"
 
+#ifndef LEADER_TIMEOUT
+  #define LEADER_TIMEOUT 300
+#endif
+
 __attribute__ ((weak))
 void leader_start(void) {}
 

--- a/quantum/process_keycode/process_leader.h
+++ b/quantum/process_keycode/process_leader.h
@@ -19,18 +19,13 @@
 
 #include "quantum.h"
 
-#ifndef LEADER_TIMEOUT
-#define LEADER_TIMEOUT 300
-#endif
 
 bool process_leader(uint16_t keycode, keyrecord_t *record);
 
 void leader_start(void);
 void leader_end(void);
 
-#ifndef LEADER_TIMEOUT
-  #define LEADER_TIMEOUT 200
-#endif
+
 #define SEQ_ONE_KEY(key) if (leader_sequence[0] == (key) && leader_sequence[1] == 0 && leader_sequence[2] == 0 && leader_sequence[3] == 0 && leader_sequence[4] == 0)
 #define SEQ_TWO_KEYS(key1, key2) if (leader_sequence[0] == (key1) && leader_sequence[1] == (key2) && leader_sequence[2] == 0 && leader_sequence[3] == 0 && leader_sequence[4] == 0)
 #define SEQ_THREE_KEYS(key1, key2, key3) if (leader_sequence[0] == (key1) && leader_sequence[1] == (key2) && leader_sequence[2] == (key3) && leader_sequence[3] == 0 && leader_sequence[4] == 0)

--- a/quantum/process_keycode/process_leader.h
+++ b/quantum/process_keycode/process_leader.h
@@ -19,6 +19,10 @@
 
 #include "quantum.h"
 
+#ifndef LEADER_TIMEOUT
+#define LEADER_TIMEOUT 300
+#endif
+
 bool process_leader(uint16_t keycode, keyrecord_t *record);
 
 void leader_start(void);


### PR DESCRIPTION
This should fix #2514, in theory.

`LEADER_TIMEOUT` has no default value defined. So it it's not defined, it won't trigger properly. 