### PR TITLE
Add dz60 iso layout with vim-style arrows

### DIFF
--- a/keyboards/dz60/keymaps/iso_vim_arrow/README.md
+++ b/keyboards/dz60/keymaps/iso_vim_arrow/README.md
@@ -1,0 +1,6 @@
+# ISO layout with VIM style arrow cluster
+
+This layout is ISO-DE and similar to a standard 60 ISO layout. There are vim style arrow keys on the function layer and in the bottom right corner of the main layer.
+
+![Layout](https://i.imgur.com/Wu8VT43.png)
+

--- a/keyboards/dz60/keymaps/iso_vim_arrow/keymap.c
+++ b/keyboards/dz60/keymaps/iso_vim_arrow/keymap.c
@@ -1,0 +1,68 @@
+#include QMK_KEYBOARD_H
+
+#define MODS_CTRL_MASK  (MOD_BIT(KC_LSHIFT)|MOD_BIT(KC_RSHIFT))
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+/* ISO VIM arrow
+* ,-----------------------------------------------------------------------------------------.
+* | Esc |  1  |  2  |  3  |  4  |  5  |  6  |  7  |  8  |  9  |  0  |  ß  |  ´  |   BSPC    |
+* |-----------------------------------------------------------------------------------------+
+* | Tab    |  Q  |  W  |  E  |  R  |  T  |  Z  |  U  |  I  |  O  |  P  |  P  |  Ü  | *  |   |
+* |-------------------------------------------------------------------------------------|   +
+* | Layer_1    |  A  |  S  |  D  |  F  |  G  |  H  |  J  |  K  |  L  |  Ö  |  Ä |  # |Enter |
+* |-----------------------------------------------------------------------------------------+
+* | Shift|  < |  Y  |  X  |  C  |  V  |  B  |  N  |  M  |  ,  |  .  |  .  |  -  |  RShift   |
+* |-----------------------------------------------------------------------------------------+
+* | LCtrl |  LGUI  |  LAlt  |          Space           |  RAlt | Left |  Down | Up  | Right |
+* `-----------------------------------------------------------------------------------------'
+*/
+	LAYOUT(
+		KC_ESC, KC_1, KC_2, KC_3, KC_4, KC_5, KC_6, KC_7, KC_8, KC_9, KC_0, KC_MINS, KC_EQL, KC_NO, KC_BSPC,
+		KC_TAB, KC_Q, KC_W, KC_E, KC_R, KC_T, KC_Y, KC_U, KC_I, KC_O, KC_P, KC_LBRC, KC_RBRC, KC_BSLS,
+		MO(1), KC_A, KC_S, KC_D, KC_F, KC_G, KC_H, KC_J, KC_K, KC_L, KC_SCLN, KC_QUOT, KC_ENT,
+		KC_LSFT, KC_NUBS, KC_Z, KC_X, KC_C, KC_V, KC_B, KC_N, KC_M, KC_COMM, KC_DOT, KC_SLSH, KC_RSFT, KC_NO,
+    KC_LCTL, KC_LGUI, KC_LALT, KC_SPC, KC_SPC, KC_SPC, KC_RALT, KC_LEFT, KC_DOWN, KC_UP, KC_RIGHT),
+
+
+	LAYOUT(
+		KC_GRV, KC_F1, KC_F2, KC_F3, KC_F4, KC_F5, KC_F6, KC_F7, KC_F8, KC_F9, KC_F10, KC_F11, KC_F12, KC_NO, KC_DEL,
+		KC_NO, KC_NO, KC_NO, KC_NO, RESET, KC_NO, KC_HOME, KC_PGDN, KC_PGUP, KC_END, KC_PSCR, KC_NO, KC_NO, KC_NO,
+		KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_LEFT, KC_DOWN, KC_UP, KC_RIGHT, KC_END, KC_DEL, KC_NO,
+		KC_LSFT, BL_TOGG, KC_APP, KC_PAUS, KC_INS, KC_NO, KC_MPLY, KC_MSTP, KC_MUTE, KC_VOLD, KC_VOLU, KC_NO, KC_RSFT, KC_NO,
+		KC_LCTL, KC_LGUI, KC_LALT, KC_BSPC, KC_BSPC, KC_BSPC, KC_DEL, KC_HOME, KC_PGDN, KC_PGUP, KC_END),
+
+};
+
+enum function_id {
+    SHIFT_ESC,
+};
+
+const uint16_t PROGMEM fn_actions[] = {
+  [0]  = ACTION_FUNCTION(SHIFT_ESC),
+};
+
+void action_function(keyrecord_t *record, uint8_t id, uint8_t opt) {
+  static uint8_t shift_esc_shift_mask;
+  switch (id) {
+    case SHIFT_ESC:
+      shift_esc_shift_mask = get_mods()&MODS_CTRL_MASK;
+      if (record->event.pressed) {
+        if (shift_esc_shift_mask) {
+          add_key(KC_GRV);
+          send_keyboard_report();
+        } else {
+          add_key(KC_ESC);
+          send_keyboard_report();
+        }
+      } else {
+        if (shift_esc_shift_mask) {
+          del_key(KC_GRV);
+          send_keyboard_report();
+        } else {
+          del_key(KC_ESC);
+          send_keyboard_report();
+        }
+      }
+      break;
+  }
+}

--- a/keyboards/dz60/keymaps/iso_vim_arrow/rules.mk
+++ b/keyboards/dz60/keymaps/iso_vim_arrow/rules.mk
@@ -1,0 +1,15 @@
+# Build Options
+#   comment out to disable the options.
+#
+BOOTMAGIC_ENABLE = no	# Virtual DIP switch configuration(+1000)
+MOUSEKEY_ENABLE = no	# Mouse keys(+4700)
+EXTRAKEY_ENABLE = yes	# Audio control and System control(+450)
+CONSOLE_ENABLE = no	# Console for debug(+400)
+COMMAND_ENABLE = no    # Commands for debug and configuration
+SLEEP_LED_ENABLE = no  # Breathing sleep LED during USB suspend
+NKRO_ENABLE = yes		# USB Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+BACKLIGHT_ENABLE = no  # Enable keyboard backlight functionality
+AUDIO_ENABLE = no
+RGBLIGHT_ENABLE = no
+AUTO_SHIFT_ENABLE = no # If the time depressed is greater than or equal to the AUTO_SHIFT_TIMEOUT, then a shifted version of the key is emitted. If the time is less than the AUTO_SHIFT_TIMEOUT time, then the normal state is emitted
+TAP_DANCE_ENABLE = no


### PR DESCRIPTION
I added a new layout for the dz60 board targeting iso layout. There are vim style arrow keys on the function layer and in the bottom right corner of the main layer.

I've tested it and am using it on my current keyboard.