### PR TITLE
New XD60 keymap (Standard/GH60 ANSI + custom Fn layer)

### DIFF
--- a/keyboards/xd60/keymaps/edulpn/keymap.c
+++ b/keyboards/xd60/keymaps/edulpn/keymap.c
@@ -1,0 +1,46 @@
+#include "xd60.h"
+#include "action_layer.h"
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+  // 0: Base Layer
+  LAYOUT_ALL(
+      KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,    KC_0,    KC_MINS,  KC_EQL,  KC_BSPC,  KC_NO,    \
+      KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,   KC_T,   KC_Y,   KC_U,   KC_I,   KC_O,    KC_P,    KC_LBRC,  KC_RBRC,           KC_BSLS,   \
+      KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,   KC_G,   KC_H,   KC_J,   KC_K,   KC_L,    KC_SCLN, KC_QUOT,  KC_NO,             KC_ENT,    \
+      KC_LSFT, KC_NO,   KC_Z,    KC_X,    KC_C,   KC_V,   KC_B,   KC_N,   KC_M,   KC_COMM, KC_DOT,  KC_SLSH,  KC_NO, KC_RSHIFT,  KC_NO,      \
+      KC_LCTL, KC_LGUI, KC_LALT,                          KC_SPC,                          KC_RALT,    F(0),  KC_NO, KC_RGUI,    KC_RCTL),
+
+  // 1: Function Layer
+  LAYOUT_ALL(
+      KC_ESC,   KC_F1,    KC_F2,    KC_F3,    KC_F4,      KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   KC_DEL,   KC_NO,    \
+      KC_NO,    KC_NO,    KC_UP,    KC_NO,    KC_INSERT,  KC_HOME,  KC_PGUP,  RGB_TOG,  RGB_MOD,  RGB_HUI,  RGB_HUD,  KC_NO,    KC_NO,              KC_NO,    \
+      KC_NO,    KC_LEFT,  KC_DOWN,  KC_RIGHT, KC_DEL,     KC_END,   KC_PGDN,  RGB_SAI,  RGB_SAD,  RGB_VAI,  RGB_VAD,  KC_NO,    KC_NO,              KC_ENT,    \
+      KC_LSFT,  KC_NO,    KC_MPRV,  KC_MPLY,  KC_MNXT,    KC_VOLD,  KC_VOLU,  KC_MUTE,  KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_RSFT,  KC_NO,    KC_NO,      \
+      KC_LCTL,  KC_LGUI,  KC_LALT,                           KC_SPC,                                      KC_RALT,  F(0),     KC_NO,    KC_RGUI,  KC_RCTL),
+
+};
+
+// Custom Actions
+const uint16_t PROGMEM fn_actions[] = {
+    [0] = ACTION_LAYER_MOMENTARY(1),  // to Fn overlay
+};
+
+// Macros
+const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt) {
+
+  // MACRODOWN only works in this function
+  switch(id) {
+    case 0:
+      if (record->event.pressed) { register_code(KC_RSFT); }
+      else { unregister_code(KC_RSFT); }
+      break;
+  }
+
+  return MACRO_NONE;
+};
+
+// Loop
+void matrix_scan_user(void) {
+  // Empty
+};

--- a/keyboards/xd60/keymaps/edulpn/readme.md
+++ b/keyboards/xd60/keymaps/edulpn/readme.md
@@ -3,7 +3,7 @@
 ## Additional Notes
 60% Keymap for XD60 with GH60 ANSI layout (based on Supercoffe's keymap) + customized Fn layer.
 
-![Edulpn Keymap for the XD60 PCB](https://imgur.com/PoL5qcr)
+![Edulpn Keymap for the XD60 PCB](https://i.imgur.com/PoL5qcr.png)
 
 ## Build
 To build the default keymap, simply run `make xd60:edulpn`.

--- a/keyboards/xd60/keymaps/edulpn/readme.md
+++ b/keyboards/xd60/keymaps/edulpn/readme.md
@@ -1,0 +1,9 @@
+# Edulpn Keymap for the XD60 PCB
+
+## Additional Notes
+60% Keymap for XD60 with GH60 ANSI layout (based on Supercoffe's keymap) + customized Fn layer.
+
+![Edulpn Keymap for the XD60 PCB](https://imgur.com/PoL5qcr)
+
+## Build
+To build the default keymap, simply run `make xd60:edulpn`.


### PR DESCRIPTION
Keymap based on SuperCoffee's other XD60 GH60 ANSI keymap with some fixed positions and custom Fn layer with arrow cluster (Fn + WASD), navigation cluster (Fn + RTYFGH), media keys (Fn + ZXCVBN) and RGB controls (Fn + UIOPJKL;).