### PR TITLE
Keymap file to match the TMK the board came flashed with

### DIFF
--- a/keyboards/ut47/keymaps/default/keymap.c
+++ b/keyboards/ut47/keymaps/default/keymap.c
@@ -69,9 +69,9 @@ LAYOUT( /* Right */
 
   /* FN Layer 2
    * ,-------------------------------------------------------------------------.
-   * | FN6 | FN7 | FN8 | FN9 | FN9 | FN10| FN11| FN12| FN13| FN14| FN15| Delete|
+   * |   ~  |  !  |  @  |  #  |  $  |  %  |  ^  |  &  |  *  |  (  |  )  |Delete|
    * |-------------------------------------------------------------------------+
-   * |      |     |     |     |     |     |     | FN17| FN18| FN19| FN20|  FN21|
+   * |      |     |     |     |     |     |     |  _  |  +  |  { |  }  |   |   |
    * |-------------------------------------------------------------------------+
    * |       | F1  | F2  | F3  | F4  | F5  | F6  | F7  | F8  | F9  | F10 |     |
    * |-------------------------------------------------------------------------+
@@ -80,8 +80,8 @@ LAYOUT( /* Right */
    */
 
 LAYOUT( /* Left */
-  KC_FN6,  KC_FN7,  KC_FN8,  KC_FN9,  KC_FN10, KC_FN11, KC_FN12, KC_FN13, KC_FN14, KC_FN15, KC_FN16, KC_DELETE,
-  _______, _______, _______, _______, _______, _______, _______, KC_FN17, KC_FN18, KC_FN19, KC_FN20, KC_FN21,
+  KC_TILDE,  KC_EXCLAIM,  KC_AT,  KC_HASH,  KC_DOLLAR, KC_PERCENT, KC_CIRCUMFLEX, KC_AMPERSAND, KC_ASTERISK, KC_LEFT_PAREN, KC_RIGHT_PAREN, KC_DELETE,
+  _______, _______, _______, _______, _______, _______, _______, KC_UNDERSCORE, KC_PLUS, KC_LEFT_CURLY_BRACE, KC_RIGHT_CURLY_BRACE, KC_PIPE,
   _______, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  _______,
   _______, _______, _______, KC_CAPS, _______,     _______,      _______, KC_HOME, KC_PGDN, KC_PGUP, KC_END
 ),

--- a/keyboards/ut47/keymaps/non-us/config.h
+++ b/keyboards/ut47/keymaps/non-us/config.h
@@ -1,0 +1,24 @@
+/* Copyright 2018 Carlos Filoteo
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef CONFIG_USER_H
+#define CONFIG_USER_H
+
+#include "config_common.h"
+
+// place overrides here
+
+#endif

--- a/keyboards/ut47/keymaps/non-us/keymap.c
+++ b/keyboards/ut47/keymaps/non-us/keymap.c
@@ -1,0 +1,136 @@
+/* Copyright 2018 Carlos Filoteo
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include QMK_KEYBOARD_H
+#ifdef LED_ENABLE
+  #include "protocol/serial.h"
+#endif
+
+#define _______ KC_TRNS
+#define LT3_TAB LT(3, KC_TAB)
+#define MT_RSFT_ENT MT(MOD_RSFT, KC_ENT)
+
+enum custom_keycodes {
+    LED_TOG = SAFE_RANGE,
+    LED_CHG
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+  /* Base Layer
+   * ,-------------------------------------------------------------------------.
+   * | Esc |  Q  |  W  |  E  |  R  |  T  |  Y  |  U  |  I  |  O  |  P  |Bspace |
+   * |-------------------------------------------------------------------------+
+   * |Tab/L3|  A  |  S  |  D  |  F  |  G  |  H  |  J  |  K  |  L  |  ;  |   '  |
+   * |-------------------------------------------------------------------------+
+   * | Shift |  Z  |  X  |  C  |  V  |  B  |  N  |  M  |  ,  |  .  |  /  |Sh/En|
+   * |-------------------------------------------------------------------------+
+   * | Ctrl| Alt | Gui | App |  L2  |   Space   |  L1  | Left| Down|  Up |Right|
+   * `-------------------------------------------------------------------------'
+   */
+
+LAYOUT(
+  KC_ESC,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_BSPC,
+  LT3_TAB, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,
+  KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, MT_RSFT_ENT,
+  KC_LCTL, KC_LALT, KC_LGUI, KC_APP,  MO(2),      KC_SPC,        MO(1),  KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT
+),
+
+  /* FN Layer 1
+   * ,-------------------------------------------------------------------------.
+   * | ` ~ |  1  |  2  |  3  |  4  |  5  |  6  |  7  |  8  |  9  |  0  | Delete|
+   * |-------------------------------------------------------------------------+
+   * |      |     |     |     |     |     |  #  |  -  |  =  |  [  |  ]  |  \   |
+   * |-------------------------------------------------------------------------+
+   * |       | F11 | F12 | F13 | F14 | F15 | F16 | F17 | F18 | F19 | F20 |     |
+   * |-------------------------------------------------------------------------+
+   * |     |     |     |Capsl|      |          |       | Home| PgDn| PgUp| End |
+   * `-------------------------------------------------------------------------'
+   */
+
+LAYOUT( /* Right */
+  KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_DELETE,
+  _______, _______, _______, _______, _______, _______, KC_NUHS, KC_MINS, KC_EQL,  KC_LBRC, KC_RBRC, KC_NUBS,
+  _______, KC_F11,  KC_F12,  KC_F13,  KC_F14,  KC_F15,  KC_F16,  KC_F17,  KC_F18,  KC_F19,  KC_F20,  _______,
+  _______, _______, _______, KC_CAPS, _______,     _______,      _______, KC_HOME, KC_PGDN, KC_PGUP, KC_END
+),
+
+  /* FN Layer 2
+   * ,-------------------------------------------------------------------------.
+   * |   ~  |  !  |  @  |  #  |  $  |  %  |  ^  |  &  |  *  |  (  |  )  |Delete|
+   * |-------------------------------------------------------------------------+
+   * |      |     |     |     |     |     |     |  _  |  +  |  { |  }  |   |   |
+   * |-------------------------------------------------------------------------+
+   * |       | F1  | F2  | F3  | F4  | F5  | F6  | F7  | F8  | F9  | F10 |     |
+   * |-------------------------------------------------------------------------+
+   * |     |     |     |Capsl|      |          |       | Home| PgDn| PgUp| End |
+   * `-------------------------------------------------------------------------'
+   */
+
+LAYOUT( /* Left */
+  KC_TILDE,  KC_EXCLAIM,  KC_AT,  KC_HASH,  KC_DOLLAR, KC_PERCENT, KC_CIRCUMFLEX, KC_AMPERSAND, KC_ASTERISK, KC_LEFT_PAREN, KC_RIGHT_PAREN, KC_DELETE,
+  _______, _______, _______, _______, _______, _______, _______, KC_UNDERSCORE, KC_PLUS, KC_LEFT_CURLY_BRACE, KC_RIGHT_CURLY_BRACE, KC_PIPE,
+  _______, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  _______,
+  _______, _______, _______, KC_CAPS, _______,     _______,      _______, KC_HOME, KC_PGDN, KC_PGUP, KC_END
+),
+
+  /* FN Layer 2
+   * ,-------------------------------------------------------------------------.
+   * | Esc | Calc|Webhm| Mail| Comp|     |     |     |     |     |PrtSc|       |
+   * |-------------------------------------------------------------------------+
+   * |      |     |     |     |     |     |     |     |     |     |     |      |
+   * |-------------------------------------------------------------------------+
+   * |       |LEDtg|LEDch|     |     |     |     |     |     |     |     |     |
+   * |-------------------------------------------------------------------------+
+   * |     |     |     |     |      |          |       |MousL|MousD|MousU|MousR|
+   * `-------------------------------------------------------------------------'
+   */
+
+LAYOUT( /* Tab */
+  KC_ESC,  KC_CALC, KC_WHOM, KC_MAIL, KC_MYCM, _______, _______, _______, _______, _______, KC_PSCR, _______,
+  _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+  _______, LED_TOG, LED_CHG, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+  _______, _______, _______, _______, _______,     _______,      _______, KC_MS_L, KC_MS_D, KC_MS_U, KC_MS_R
+),
+};
+
+//LED keymap functions
+ #ifdef LED_ENABLE
+void led_chmode(void) {
+  serial_send(101);
+}
+
+void led_toggle(void) {
+  serial_send(100);
+}
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  if (record->event.pressed) {
+    switch(keycode) {
+      case LED_TOG:
+        #ifdef LED_ENABLE
+        led_toggle();
+        #endif
+        return false;
+      case LED_CHG:
+        #ifdef LED_ENABLE
+        led_chmode();
+        #endif
+        return false;
+    }
+  }
+  return true;
+};
+#endif

--- a/keyboards/ut47/keymaps/non-us/readme.md
+++ b/keyboards/ut47/keymaps/non-us/readme.md
@@ -1,0 +1,19 @@
+# UT47 default keymap
+
+![UT47 layout image](https://i.imgur.com/Tsz5qsF.png)
+
+[KLE](http://www.keyboard-layout-editor.com/##@@_y:0%3B&=Esc&=Q&=W&=E&=R&=T&=Y&=U&=I&=O&=P&_w:1.5%3B&=Back%20Space&_x:0.25&a:4&f:4&w:4&h:4&d:true%3B&=%3Cb%3EGNAP!%3C%2F%2Fb%3E%3Cp%3E%3Cp%3EMinimum%20stagger%3Cp%3E47%20key%20layout%3B&@_a:7&f:3&w:1.25%3B&=Tab&=A&=S&=D&=F&=G&=H&=J&=K&=L&=%2F%3B&_w:1.25%3B&=%27%3B&@_w:1.5%3B&=Shift&=Z&=X&=C&=V&=B&=N&=M&=,&=.&=%2F%2F&=Return%3B&@=Ctrl&=Alt&=Super&=Menu&_w:1.25%3B&=%2F&dArr%2F%3B&_w:2%3B&=&_w:1.25%3B&=%2F&uArr%2F%3B&=%2F&larr%2F%3B&=%2F&darr%2F%3B&=%2F&uarr%2F%3B&=%2F&rarr%2F%3B%3B&=undefined)
+
+### LED Controls
+
+Use <kbd>TAB</kbd>+<kbd>Z</kbd> to cycle through brightness (8 steps)
+
+Use <kbd>TAB</kbd>+<kbd>X</kbd> to cycle through the following LED modes: 
+
+- solid
+- breathing
+- random
+- rain
+- reactive
+- poptang
+- off


### PR DESCRIPTION
The UT47 shipped with TMK falsed with a keymap that put symbols on layer 2. This is broken on master.

This pull request uses native QMK codes to match that shipped layout,