### PR TITLE
Added archlinux support to linux_install.sh

### DIFF
--- a/util/linux_install.sh
+++ b/util/linux_install.sh
@@ -10,6 +10,15 @@ elif grep ID /etc/os-release | grep -q debian; then
 	sudo apt-get install gcc unzip wget zip gcc-avr binutils-avr avr-libc \
 	    dfu-programmer dfu-util gcc-arm-none-eabi binutils-arm-none-eabi \
 	    libnewlib-arm-none-eabi
+elif grep ID /etc/os-release | grep -q arch; then
+	sudo pacman -S gcc unzip wget zip avr-gcc avr-binutils avr-libc \
+	    dfu-util arm-none-eabi-gcc arm-none-eabi-binutils \
+	    arm-none-eabi-newlib
+	git clone https://aur.archlinux.org/dfu-programmer.git /tmp/dfu-programmer
+	cd /tmp/dfu-programmer
+	makepkg -sic
+	rm -rf /tmp/dfu-programmer/
+
 else
 	echo "Sorry, we don't recognize your OS. Help us by contributing support!"
 	echo


### PR DESCRIPTION
dfu-programmer is cloned using git from the AUR and installed with arch's included package builder (makepkg).