### PR TITLE
Helix: Enable audio control keys

### DIFF
--- a/keyboards/helix/rev2/keymaps/default/rules.mk
+++ b/keyboards/helix/rev2/keymaps/default/rules.mk
@@ -5,7 +5,7 @@
 #
 BOOTMAGIC_ENABLE = no       # Virtual DIP switch configuration(+1000)
 MOUSEKEY_ENABLE = no       # Mouse keys(+4700)
-EXTRAKEY_ENABLE = no       # Audio control and System control(+450)
+EXTRAKEY_ENABLE = yes       # Audio control and System control(+450)
 CONSOLE_ENABLE = no         # Console for debug(+400)
 COMMAND_ENABLE = no        # Commands for debug and configuration
 NKRO_ENABLE = no            # Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work


### PR DESCRIPTION
Hi,

The default Helix keymap contains a few audio-related keys e,g. `KC_VOLD`, but this actually doesn't work because `EXTRAKEY_ENABLE` is set off by default.
I think this is not something the original author wanted, so I propose this problem to be fixed with this PR.
Helix contains several possibly redundant Makefile's and I'm not 100% sure this line is the one (and the only one) to be modified.
Tested with Windows 10.

Hope this helps!

cc: @MakotoKurauchi san.