### PR TITLE
Add Teensy ++ 2.0 bootloader support

### DIFF
--- a/bootloader.mk
+++ b/bootloader.mk
@@ -61,7 +61,12 @@ ifeq ($(strip $(BOOTLOADER)), qmk-dfu)
 endif
 ifeq ($(strip $(BOOTLOADER)), halfkay)
     OPT_DEFS += -DBOOTLOADER_HALFKAY
-    BOOTLOADER_SIZE = 512
+    ifeq ($(strip $(MCU)), atmega32u4)
+      BOOTLOADER_SIZE = 512
+    endif
+    ifeq ($(strip $(MCU)), at90usb1286)
+      BOOTLOADER_SIZE = 1024
+    endif
 endif
 ifeq ($(strip $(BOOTLOADER)), caterina)
     OPT_DEFS += -DBOOTLOADER_CATERINA


### PR DESCRIPTION
@jackhumbert Yeah, this is what I was referring to. 

Even documented here: 
https://github.com/qmk/qmk_firmware/blob/master/quantum/template/rules.mk#L44