### PR TITLE
Cleanup Audio Clicky code (add EEPROM, and user friendly functions)

### DIFF
--- a/docs/feature_audio.md
+++ b/docs/feature_audio.md
@@ -128,13 +128,11 @@ This adds a click sound each time you hit a button, to simulate click sounds fro
 * `CK_UP` - Increases the frequency of the clicks
 * `CK_DOWN` - Decreases the frequency of the clicks
 
+
 The feature is disabled by default, to save space.  To enable it, add this to your `config.h`:
 
     #define AUDIO_CLICKY
 
-Additionally, even when enabled, the feature is not enabled by default, so you would need to turn it on first.  And since we don't use EEPROM to store the setting (yet), you can default this to on by adding this to your `config.h`:
-
-    #define AUDIO_CLICKY_ON
 
 You can configure the default, min and max frequencies, the stepping and built in randomness by defining these values: 
 

--- a/docs/feature_audio.md
+++ b/docs/feature_audio.md
@@ -119,14 +119,16 @@ You can completely disable Music Mode as well. This is useful, if you're pressed
 
     #define NO_MUSIC_MODE
 
-## Faux Click
+## Audio Click
 
 This adds a click sound each time you hit a button, to simulate click sounds from the keyboard. And the sounds are slightly different for each keypress, so it doesn't sound like a single long note, if you type rapidly. 
 
 * `CK_TOGG` - Toggles the status (will play sound if enabled)
-* `CK_RST` - Resets the frequency to the default state 
-* `CK_UP` - Increases the frequency of the clicks
-* `CK_DOWN` - Decreases the frequency of the clicks
+* `CK_ON` - Turns on Audio Click (plays sound)
+* `CK_OFF` - Turns off Audio Click (doesn't play sound)
+* `CK_RST` - Resets the frequency to the default state (plays sound at default frequency)
+* `CK_UP` - Increases the frequency of the clicks (plays sound at new frequency)
+* `CK_DOWN` - Decreases the frequency of the clicks (plays sound at new frequency)
 
 
 The feature is disabled by default, to save space.  To enable it, add this to your `config.h`:
@@ -142,7 +144,7 @@ You can configure the default, min and max frequencies, the stepping and built i
 | `AUDIO_CLICKY_FREQ_MIN` | 65.0f | Sets the lowest frequency (under 60f are a bit buggy). |
 | `AUDIO_CLICKY_FREQ_MAX` | 1500.0f | Sets the the highest frequency. Too high may result in coworkers attacking you. |
 | `AUDIO_CLICKY_FREQ_FACTOR` | 1.18921f| Sets the stepping of UP/DOWN key codes. |
-| `AUDIO_CLICKY_FREQ_RANDOMNESS`     |  0.05f |  Sets a factor of randomness for the clicks, Setting this to `0f` will make each click identical. | 
+| `AUDIO_CLICKY_FREQ_RANDOMNESS`     |  0.05f |  Sets a factor of randomness for the clicks, Setting this to `0f` will make each click identical, and `1.0f` will make this sound much like the 90's computer screen scrolling/typing effect. | 
 
 
 

--- a/quantum/audio/audio.c
+++ b/quantum/audio/audio.c
@@ -223,7 +223,7 @@ void audio_init()
             TCCR1B = (1 << WGM13)  | (1 << WGM12)  | (0 << CS12)  | (1 << CS11) | (0 << CS10);
             TIMER_1_PERIOD = (uint16_t)(((float)F_CPU) / (440 * CPU_PRESCALER));
             TIMER_1_DUTY_CYCLE = (uint16_t)((((float)F_CPU) / (440 * CPU_PRESCALER)) * note_timbre);
-        #endif 
+        #endif
 
         audio_initialized = true;
     }
@@ -231,7 +231,7 @@ void audio_init()
     if (audio_config.enable) {
         PLAY_SONG(startup_song);
     }
-    
+
 }
 
 void stop_all_notes()
@@ -464,7 +464,7 @@ ISR(TIMER3_AUDIO_vect)
         note_position++;
         bool end_of_note = false;
         if (TIMER_3_PERIOD > 0) {
-            if (!note_resting) 
+            if (!note_resting)
                 end_of_note = (note_position >= (note_length / TIMER_3_PERIOD * 0xFFFF - 1));
             else
                 end_of_note = (note_position >= (note_length));
@@ -604,7 +604,7 @@ ISR(TIMER1_AUDIO_vect)
         note_position++;
         bool end_of_note = false;
         if (TIMER_1_PERIOD > 0) {
-            if (!note_resting) 
+            if (!note_resting)
                 end_of_note = (note_position >= (note_length / TIMER_1_PERIOD * 0xFFFF - 1));
             else
                 end_of_note = (note_position >= (note_length));

--- a/quantum/audio/audio.h
+++ b/quantum/audio/audio.h
@@ -40,7 +40,8 @@ typedef union {
     uint8_t raw;
     struct {
         bool    enable :1;
-        uint8_t level  :7;
+        bool    clicky_enable :1;
+        uint8_t level  :6;
     };
 } audio_config_t;
 

--- a/quantum/process_keycode/process_clicky.c
+++ b/quantum/process_keycode/process_clicky.c
@@ -56,17 +56,17 @@ void clicky_freq_reset(void) {
   clicky_freq = AUDIO_CLICKY_FREQ_DEFAULT;
 }
 
-void clicky_freq_toggle(void) {
+void clicky_toggle(void) {
   audio_config.clicky_enable ^= 1;
   eeconfig_update_audio(audio_config.raw);
 }
 
-void clicky_freq_on(void) {
+void clicky_on(void) {
   audio_config.clicky_enable = 1;
   eeconfig_update_audio(audio_config.raw);
 }
 
-void clicky_freq_off(void) {
+void clicky_off(void) {
   audio_config.clicky_enable = 0;
   eeconfig_update_audio(audio_config.raw);
 }
@@ -76,7 +76,10 @@ bool is_clicky_on(void) {
 }
 
 bool process_clicky(uint16_t keycode, keyrecord_t *record) {
-    if (keycode == CLICKY_TOGGLE && record->event.pressed) { clicky_freq_toggle(); }
+    if (keycode == CLICKY_TOGGLE && record->event.pressed) { clicky_toggle(); }
+
+    if (keycode == CLICKY_ENABLE && record->event.pressed) { clicky_on(); }
+    if (keycode == CLICKY_DISABLE && record->event.pressed) { clicky_off(); }
 
     if (keycode == CLICKY_RESET && record->event.pressed) { clicky_freq_reset(); }
 

--- a/quantum/process_keycode/process_clicky.c
+++ b/quantum/process_keycode/process_clicky.c
@@ -38,29 +38,53 @@ void clicky_play(void) {
   PLAY_SONG(clicky_song);
 }
 
+void clicky_freq_up(void) {
+  float new_freq = clicky_freq * AUDIO_CLICKY_FREQ_FACTOR;
+  if (new_freq < AUDIO_CLICKY_FREQ_MAX) {
+    clicky_freq = new_freq;
+  }
+}
+
+void clicky_freq_down(void) {
+  float new_freq = clicky_freq / AUDIO_CLICKY_FREQ_FACTOR;
+  if (new_freq > AUDIO_CLICKY_FREQ_MIN) {
+    clicky_freq = new_freq;
+  }
+}
+
+void clicky_freq_reset(void) {
+  clicky_freq = AUDIO_CLICKY_FREQ_DEFAULT;
+}
+
+void clicky_freq_toggle(void) {
+  audio_config.clicky_enable ^= 1;
+  eeconfig_update_audio(audio_config.raw);
+}
+
+void clicky_freq_on(void) {
+  audio_config.clicky_enable = 1;
+  eeconfig_update_audio(audio_config.raw);
+}
+
+void clicky_freq_off(void) {
+  audio_config.clicky_enable = 0;
+  eeconfig_update_audio(audio_config.raw);
+}
+
+bool is_clicky_on(void) {
+      return (audio_config.clicky_enable != 0);
+}
+
 bool process_clicky(uint16_t keycode, keyrecord_t *record) {
-    if (keycode == CLICKY_TOGGLE && record->event.pressed) {
-      audio_config.clicky ^= 1;
-      eeconfig_update_audio(audio_config.raw);
-    }
+    if (keycode == CLICKY_TOGGLE && record->event.pressed) { clicky_freq_toggle(); }
 
-    if (keycode == CLICKY_RESET && record->event.pressed) { clicky_freq = AUDIO_CLICKY_FREQ_DEFAULT; }
+    if (keycode == CLICKY_RESET && record->event.pressed) { clicky_freq_reset(); }
 
-    if (keycode == CLICKY_UP && record->event.pressed) {
-      float new_freq = clicky_freq * AUDIO_CLICKY_FREQ_FACTOR;
-      if (new_freq < AUDIO_CLICKY_FREQ_MAX) {
-        clicky_freq = new_freq;
-      }
-    }
-    if (keycode == CLICKY_DOWN && record->event.pressed) {
-      float new_freq = clicky_freq / AUDIO_CLICKY_FREQ_FACTOR;
-      if (new_freq > AUDIO_CLICKY_FREQ_MIN) {
-        clicky_freq = new_freq;
-      }
-    }
+    if (keycode == CLICKY_UP && record->event.pressed) { clicky_freq_up(); }
+    if (keycode == CLICKY_DOWN && record->event.pressed) { clicky_freq_down(); }
 
 
-    if ( audio_config.clicky ) {
+    if ( audio_config.clicky_enable ) {
       if (record->event.pressed) {
         clicky_play();;
       }

--- a/quantum/process_keycode/process_clicky.c
+++ b/quantum/process_keycode/process_clicky.c
@@ -3,11 +3,6 @@
 
 #ifdef AUDIO_CLICKY
 
-#ifdef AUDIO_CLICKY_ON
-bool clicky_enable = true;
-#else // AUDIO_CLICKY_ON
-bool clicky_enable = false;
-#endif // AUDIO_CLICKY_ON
 #ifndef AUDIO_CLICKY_FREQ_DEFAULT
 #define AUDIO_CLICKY_FREQ_DEFAULT 440.0f
 #endif // !AUDIO_CLICKY_FREQ_DEFAULT
@@ -27,6 +22,8 @@ bool clicky_enable = false;
 float clicky_freq = AUDIO_CLICKY_FREQ_DEFAULT;
 float clicky_song[][2]  = {{AUDIO_CLICKY_FREQ_DEFAULT, 3}, {AUDIO_CLICKY_FREQ_DEFAULT, 1}}; // 3 and 1 --> durations
 
+extern audio_config_t audio_config;
+
 #ifndef NO_MUSIC_MODE
 extern bool music_activated;
 extern bool midi_activated;
@@ -42,7 +39,10 @@ void clicky_play(void) {
 }
 
 bool process_clicky(uint16_t keycode, keyrecord_t *record) {
-    if (keycode == CLICKY_TOGGLE && record->event.pressed) { clicky_enable = !clicky_enable; }
+    if (keycode == CLICKY_TOGGLE && record->event.pressed) {
+      audio_config.clicky ^= 1;
+      eeconfig_update_audio(audio_config.raw);
+    }
 
     if (keycode == CLICKY_RESET && record->event.pressed) { clicky_freq = AUDIO_CLICKY_FREQ_DEFAULT; }
 
@@ -60,7 +60,7 @@ bool process_clicky(uint16_t keycode, keyrecord_t *record) {
     }
 
 
-    if ( clicky_enable ) {
+    if ( audio_config.clicky ) {
       if (record->event.pressed) {
         clicky_play();;
       }

--- a/quantum/process_keycode/process_clicky.h
+++ b/quantum/process_keycode/process_clicky.h
@@ -4,4 +4,13 @@
 void clicky_play(void);
 bool process_clicky(uint16_t keycode, keyrecord_t *record);
 
+void clicky_freq_up(void);
+void clicky_freq_down(void);
+void clicky_freq_reset(void);
+void clicky_freq_toggle(void);
+void clicky_freq_on(void);
+void clicky_freq_off(void);
+
+bool is_clicky_on(void);
+
 #endif

--- a/quantum/process_keycode/process_clicky.h
+++ b/quantum/process_keycode/process_clicky.h
@@ -7,9 +7,10 @@ bool process_clicky(uint16_t keycode, keyrecord_t *record);
 void clicky_freq_up(void);
 void clicky_freq_down(void);
 void clicky_freq_reset(void);
-void clicky_freq_toggle(void);
-void clicky_freq_on(void);
-void clicky_freq_off(void);
+
+void clicky_toggle(void);
+void clicky_on(void);
+void clicky_off(void);
 
 bool is_clicky_on(void);
 

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -142,9 +142,12 @@ enum quantum_keycodes {
 
     // Faux clicky as part of main audio feature
     CLICKY_TOGGLE,
+    CLICKY_ENABLE,
+    CLICKY_DISABLE,
     CLICKY_UP,
     CLICKY_DOWN,
     CLICKY_RESET,
+
 
 #ifdef FAUXCLICKY_ENABLE
     // Faux clicky
@@ -574,6 +577,8 @@ enum quantum_keycodes {
 #define CK_RST CLICKY_RESET
 #define CK_UP CLICKY_UP
 #define CK_DOWN CLICKY_DOWN
+#define CK_ON CLICKY_ENABLE
+#define CK_OFF CLICKY_DISABLE
 
 #define RGB_MOD RGB_MODE_FORWARD
 #define RGB_SMOD RGB_MODE_FORWARD

--- a/users/drashna/drashna.h
+++ b/users/drashna/drashna.h
@@ -49,7 +49,7 @@ enum userspace_layers {
 // RGB color codes are no longer located here anymore.  Instead, you will want to
 // head to https://github.com/qmk/qmk_firmware/blob/master/quantum/rgblight_list.h
 
-extern bool clicky_enable;
+extern bool rgb_layer_change;
 
 #ifdef RGBLIGHT_ENABLE
 void rgblight_sethsv_default_helper(uint8_t index);
@@ -64,7 +64,6 @@ bool mod_key_press (uint16_t code, uint16_t mod_code, bool pressed, uint16_t thi
 typedef union {
   uint8_t raw;
   struct {
-    bool     clicky_enable    :1;
     bool     rgb_layer_change :1;
     bool     is_overwatch     :1;
     bool     nuke_switch      :1;


### PR DESCRIPTION
The on/off status is stored in the audio config EEPROM now

~~but I'd like to store the frequency, as well.  But it's float, and I'm not really sure how to handle that.~~  
Not enough room in the eeprom structure for this.  So, no need, for now. On/Off status should be good for now.
(could accomplish this by creating an array with floats, but that's not as customizable I think). 

Edit:
I've also cleaned it up, so that the functions can be called from anywhere. 
For instance, when rotary encoder support is added, you can use it to change the frequency with the encoder (yes, I tested this, it's AMAZING).