### PR TITLE
Added bootmagic_lite() to CA66

### DIFF
--- a/keyboards/ca66/ca66.c
+++ b/keyboards/ca66/ca66.c
@@ -1,1 +1,30 @@
 #include "ca66.h"
+#include "config.h"
+
+void bootmagic_lite(void)
+{
+	// The lite version of TMK's bootmagic.
+	// 100% less potential for accidentally making the
+	// keyboard do stupid things.
+
+	// We need multiple scans because debouncing can't be turned off.
+	matrix_scan();
+	wait_ms(DEBOUNCING_DELAY);
+	matrix_scan();
+
+	// If the Esc (matrix 0,0) is held down on power up,
+	// reset the EEPROM valid state and jump to bootloader.
+	if ( matrix_get_row(0) & (1<<0) )
+	{
+		// Set the TMK/QMK EEPROM state as invalid.
+		eeconfig_disable();
+		// Jump to bootloader.
+		bootloader_jump();
+	}
+}
+
+void matrix_init_kb(void)
+{
+	bootmagic_lite();
+	matrix_init_user();
+}


### PR DESCRIPTION
CA66 PCB doesn't have a reset button. Added "bootmagic lite" feature so holding Esc on power-up will flag EEPROM as invalid and jump to bootloader.

