### PR TITLE
Default layout for the Redox keyboard

### DIFF
--- a/keyboards/redox/keymaps/default/config.h
+++ b/keyboards/redox/keymaps/default/config.h
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 Danny Nguyen <danny@hexwire.com>
+Copyright 2018 Mattia Dal Ben <matthewdibi@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/keyboards/redox/keymaps/default/readme.md
+++ b/keyboards/redox/keymaps/default/readme.md
@@ -1,1 +1,1 @@
-# The default keymap for redox
+# The default keymap for Redox

--- a/keyboards/redox/keymaps/italian/config.h
+++ b/keyboards/redox/keymaps/italian/config.h
@@ -1,0 +1,41 @@
+/*
+Copyright 2017 Danny Nguyen <danny@hexwire.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef CONFIG_USER_H
+#define CONFIG_USER_H
+
+#include "../../config.h"
+
+/* Use I2C or Serial, not both */
+
+// #define USE_SERIAL
+#define USE_I2C
+
+/* Select hand configuration */
+
+#define MASTER_LEFT
+// #define MASTER_RIGHT
+// #define EE_HANDS
+
+#undef RGBLED_NUM
+#define RGBLIGHT_ANIMATIONS
+#define RGBLED_NUM 14
+#define RGBLIGHT_HUE_STEP 8
+#define RGBLIGHT_SAT_STEP 8
+#define RGBLIGHT_VAL_STEP 8
+
+#endif

--- a/keyboards/redox/keymaps/italian/config.h
+++ b/keyboards/redox/keymaps/italian/config.h
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 Danny Nguyen <danny@hexwire.com>
+Copyright 2018 Mattia Dal Ben <matthewdibi@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/keyboards/redox/keymaps/italian/keymap.c
+++ b/keyboards/redox/keymaps/italian/keymap.c
@@ -28,28 +28,28 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 /* QWERTY
  * ,------------------------------------------------.            ,------------------------------------------------.
- * |`-Lyr2|   1  |   2  |   3  |   4  |   5  | Lyr1 |            | Lyr1 |   6  |   7  |   8  |   9  |   0  |--Lyr2|
+ * |\-Lyr2|   1  |   2  |   3  |   4  |   5  | Lyr1 |            | Lyr1 |   6  |   7  |   8  |   9  |   0  |'-Lyr2|
  * |------+------+------+------+------+------+------|            |------+------+------+------+------+------+------|
- * | Tab  |   Q  |   W  |   E  |   R  |   T  |  [   |            |   ]  |   Y  |   U  |   I  |   O  |   P  |   =  |
+ * | Tab  |   Q  |   W  |   E  |   R  |   T  |  [   |            |   ]  |   Y  |   U  |   I  |   O  |   P  |   è  |
  * |------+------+------+------+------+------+------|            |------+------+------+------+------+------+------|
- * | Esc  |   A  |   S  |   D  |   F  |   G  | PgUp |            | End  |   H  |   J  |   K  |   L  |   ;  |   '  |
+ * | Esc  |   A  |   S  |   D  |   F  |   G  | PgUp |            | End  |   H  |   J  |   K  |   L  |   ò  |   à  |
  * |------+------+------+------+------+------+------|            |------+------+------+------+------+------+------|
- * | Shift|   Z  |   X  |   C  |   V  |   B  | PgDn |            | Home |   N  |   M  |   ,  |   .  |   \  |Shift |
+ * | Shift|   Z  |   X  |   C  |   V  |   B  | PgDn |            | Home |   N  |   M  |   ,  |   .  |   ù  |-(Sft)|
  * |------+------+------+------+------+------+------|            |------+------+------+------+------+------+------|
- * |  Gui |   +  |   -  |*(Alt)|/(Ctr)|Bcksp | Del  |            |Enter |Space |  Alt | Left | Down |  Up  | Right|
+ * |<(Gui)|   +  |   -  |*(Alt)|/(Ctr)|Bcksp | Del  |            |Enter |Space |ì(AlG)| Left | Down |  Up  | Right|
  * `------------------------------------------------'            `------------------------------------------------'
  */
   [_QWERTY] = LAYOUT(
   //,----+----+----+----+----+----+----.                                                         ,----+----+----+----+----+----+----.
      LT(_NAV, KC_GRV) , KC_1  , KC_2  , KC_3  , KC_4  , KC_5  ,MO(_SYMB),                           MO(_SYMB), KC_6  , KC_7  , KC_8  , KC_9  , KC_0  ,LT(_NAV, KC_MINS),
   //|----+----+----+----+----+----+----|                                                         |----+----+----+----+----+----+----|
-     KC_TAB , KC_Q  , KC_W  , KC_E  , KC_R  , KC_T  ,KC_LBRC,                                       KC_RBRC , KC_Y  , KC_U  , KC_I  , KC_O  , KC_P  ,KC_EQL,
+     KC_TAB , KC_Q  , KC_W  , KC_E  , KC_R  , KC_T  ,RALT(KC_LBRC),                            RALT(KC_RBRC) , KC_Y  , KC_U  , KC_I  , KC_O  , KC_P  ,KC_LBRC,
   //|----+----+----+----+----+----+----|                                                         |----+----+----+----+----+----+----|
-     KC_ESC , KC_A  , KC_S  , KC_D  , KC_F  , KC_G  , LT(_ADJUST, KC_PGUP),                         LT( _ADJUST, KC_END) , KC_H  , KC_J  , KC_K  , KC_L  ,KC_SCLN,KC_QUOT,
+     KC_ESC , KC_A  , KC_S  , KC_D  , KC_F  , KC_G  , LT(_ADJUST, KC_PGUP),                                 LT( _ADJUST, KC_END) , KC_H  , KC_J  , KC_K  , KC_L  ,KC_SCLN,KC_QUOT,
   //|----+----+----+----+----+----+----|                                                         |----+----+----+----+----+----+----|
-     KC_LSFT, KC_Z  , KC_X  , KC_C  , KC_V  , KC_B  ,KC_PGDN,                                      KC_HOME , KC_N  , KC_M  ,KC_COMM,KC_DOT ,KC_BSLASH, KC_RSFT,
+     KC_LSFT, KC_Z  , KC_X  , KC_C  , KC_V  , KC_B  ,KC_PGDN,                                      KC_HOME , KC_N  , KC_M  ,KC_COMM,KC_DOT ,KC_BSLASH,RSFT_T(KC_SLSH),
   //|----+----+----+----+----+----+----|                                                         |----+----+----+----+----+----+----|
-     KC_LGUI,KC_PPLS,KC_PMNS,LALT_T(KC_PAST),LCTL_T(KC_PSLS),KC_BSPC,KC_DEL ,                     KC_ENT , KC_SPC, KC_RALT,KC_LEFT,KC_DOWN, KC_UP ,KC_RGHT
+     LGUI_T(KC_NONUS_BSLASH),KC_PPLS,KC_PMNS,LALT_T(KC_PAST),LCTL_T(KC_PSLS),KC_BSPC,KC_DEL ,                     KC_ENT , KC_SPC, RALT_T(KC_EQL),KC_LEFT,KC_DOWN, KC_UP ,KC_RGHT
   //`----+----+----+----+----+----+----'                                                         `----+----+----+----+----+----+----'
   ),
 
@@ -68,11 +68,11 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  */
 
   [_SYMB] = LAYOUT(
-    _______, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   _______,                             _______, KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  XXXXXXX, 
-    _______, KC_EXLM, KC_AT ,  KC_LCBR, KC_RCBR, KC_PIPE, _______,                             _______, XXXXXXX, KC_KP_7, KC_KP_8, KC_KP_9, XXXXXXX, XXXXXXX, 
-    _______, KC_HASH, KC_DLR , KC_LBRC, KC_RBRC, KC_GRV,  _______,                             _______, XXXXXXX, KC_KP_4, KC_KP_5, KC_KP_6, XXXXXXX, XXXXXXX, 
-    _______, KC_PERC, KC_CIRC, KC_LPRN, KC_RPRN, KC_TILD, _______,                             _______, XXXXXXX, KC_KP_1, KC_KP_2, KC_KP_3, XXXXXXX, XXXXXXX, 
-    _______, _______, _______, _______, _______, _______, _______,                             _______, _______, KC_KP_0, KC_KP_0, KC_PDOT, XXXXXXX, XXXXXXX 
+    _______, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,  _______,                             _______, KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  XXXXXXX, 
+    _______, KC_EXLM, RALT(KC_SCLN), RALT(KC_LCBR), RALT(KC_RCBR), KC_TILD, _______,          _______, XXXXXXX, KC_KP_7, KC_KP_8, KC_KP_9, XXXXXXX, XXXXXXX, 
+    _______, RALT(KC_QUOT), KC_DLR , RALT(KC_LBRC), RALT(KC_RBRC), RALT(KC_EQL), _______,     _______, XXXXXXX, KC_KP_4, KC_KP_5, KC_KP_6, XXXXXXX, XXXXXXX, 
+    _______, KC_PERC, LSFT(KC_EQL) , LSFT(KC_8), LSFT(KC_9), RALT(KC_MINS), _______,          _______, XXXXXXX, KC_KP_1, KC_KP_2, KC_KP_3, XXXXXXX, XXXXXXX, 
+    _______, _______, _______, _______, _______, _______, _______,                            _______, _______, KC_KP_0, KC_KP_0, KC_PDOT, XXXXXXX, XXXXXXX 
   ),
 
 /* Navigation

--- a/keyboards/redox/keymaps/italian/readme.md
+++ b/keyboards/redox/keymaps/italian/readme.md
@@ -1,0 +1,1 @@
+# The italian keymap for Redox

--- a/keyboards/redox/keymaps/italian/rules.mk
+++ b/keyboards/redox/keymaps/italian/rules.mk
@@ -1,0 +1,5 @@
+RGBLIGHT_ENABLE = yes
+
+ifndef QUANTUM_DIR
+	include ../../../../Makefile
+endif


### PR DESCRIPTION
Hi,
I changed the default layout of the Redox keyboard and renamed the old one as `italian` layout. The old one made sense only on an italian OS.