### PR TITLE
Override hamburger placement

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -8,6 +8,7 @@
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
   <link rel="stylesheet" href="//unpkg.com/docsify/lib/themes/vue.css" title="light">
   <link rel="stylesheet" href="qmk.css" title="dark" disabled>
+  <link rel="stylesheet" href="sidebar.css" />
 </head>
 <body>
   <div id="app"></div>

--- a/docs/sidebar.css
+++ b/docs/sidebar.css
@@ -1,0 +1,10 @@
+.sidebar-toggle {
+  position: absolute;
+  top: 0;
+  bottom: auto;
+  left: 0;
+}
+
+.search {
+  margin-top: 40px;
+}


### PR DESCRIPTION
Overrides hamburger button and search bar placement in the sidebar. Fixes #2918.

![new placement](https://cl.ly/rYgM/Screen%20Shot%202018-05-13%20at%2010.57.53.png)