### PR TITLE
Fix Ortho Compile issue

### DIFF
--- a/keyboards/orthodox/keymaps/default/keymap.c
+++ b/keyboards/orthodox/keymaps/default/keymap.c
@@ -35,8 +35,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 enum custom_keycodes {
   QWERTY = SAFE_RANGE,
   COLEMAK,
-  DVORAK,
-  ADJUST,
+  DVORAK
 };
 
 // Fillers to make layering more clear
@@ -112,5 +111,6 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     }
     return false;
     break;
+  }
   return true;
 }


### PR DESCRIPTION
I missed a curly bracket, default keymap doesn't compile properly without it.  

Didn't push the fix in time!