### PR TITLE
Documentation Clarification from a new user

### DIFF
--- a/docs/getting_started_build_tools.md
+++ b/docs/getting_started_build_tools.md
@@ -4,6 +4,8 @@ This page describes setting up the build environment for QMK. These instructions
 
 <!-- FIXME: We should have ARM instructions somewhere. -->
 
+Note: If it is your first time here, Check out the "Complete Newbs guide" instead
+
 ## Linux
 
 To ensure you are always up to date, you can just run `sudo util/install_dependencies.sh`. That should always install all the dependencies needed. **This will run `apt-get upgrade`.**

--- a/docs/newbs_getting_started.md
+++ b/docs/newbs_getting_started.md
@@ -2,7 +2,7 @@
 
 Your computer keyboard has a processor inside of it, not unlike the one inside your computer. This processor runs software that is responsible for detecting button presses and sending reports about the state of the keyboard when they are pressed or released. QMK fills the role of that software, detecting button presses and passing that information on to the host computer. When you build your custom layout you are creating the equivalent of an .exe for your keyboard.
 
-QMK tries to put a lot of power into your hands by making easy things easy, and hard things possible. You don't have to know how to program to create powerful layouts, you only have to follow a few simple syntax rules. 
+QMK tries to put a lot of power into your hands by making easy things easy, and hard things possible. You don't have to know how to program to create powerful layouts, you only have to follow a few simple syntax rules.
 
 # Getting Started
 
@@ -12,13 +12,19 @@ Before you can build keymaps you need to install some software and setup your bu
 
 ### Text Editor
 
-You'll need a program that can edit and save **plain text** files. If you are on Windows you can make due with Notepad, and on Linux you can use Gedit, both of which are simple but functional text editors. On macOS you can not use TextEdit.app, it will not save plain text files. You will need to install another program such as Sublime Text.
+You'll need a program that can edit and save **plain text** files. If you are on Windows you can make due with Notepad, and on Linux you can use Gedit, both of which are simple but functional text editors. On macOS be careful with TextEdit.app, it will not save plain text files unless you make sure to select "Make Plain text" from the "Format" menu, or you can use another program such as Sublime Text.
 
 ?> Not sure which text editor to use? Laurence Bradford wrote [a great introduction](https://learntocodewith.me/programming/basics/text-editors/) to the subject.
 
 ### QMK Toolbox
 
-QMK Toolbox is a Windows and macOS program that allows you to both program and debug your custom keyboard. You will want to install it so that you can easily flash your keyboard and receive the debugging messages that your keyboard will print.
+QMK Toolbox is an optional graphical Windows and macOS program that allows you to both program and debug your custom keyboard. You will likely prefer it to easily flash your keyboard and receive the debugging messages that your keyboard will print.
+
+Download the files from the links below:
+
+For Windows: "qmk_toolbox.exe" or "qmk_toolbox_install.exe" (with installer)
+
+For Mac: "QMK.Toolbox.app.zip" or "QMK.Toolbox.pkg" (with installer)
 
 * [Newest Release](https://github.com/qmk/qmk_toolbox/releases/latest)
 * [Source Code](https://github.com/qmk/qmk_toolbox/)
@@ -42,6 +48,8 @@ You will need to install msys2 and git.
 ### macOS
 
 You will need to install homebrew. Follow the instructions on the homebrew homepage: https://brew.sh
+
+After homebrew is installed continue with "Download QMK", following step "Setup QMK" runs a script that will install other packages.
 
 ### Linux
 


### PR DESCRIPTION
For: getting_started_build_tools.md
As a first time user, I was confused by the 2 different guides.  Added a note to see the newbs guide (which seems easier to follow as a first time user, this other doc is almost repetitive)


newbs_getting_started.md
-Line 5: accidental whitespace edit
-Line15: corrected comment about macOS TextEdit
-Line 21: QMK toolbox appears to be completely optional, though easier than CLI for many.  Added note about what to download (as it wasn't clear)
-Line52: I was confused with layout, and between the 2 build tools install instructions. And Different OS sections are a bit hard to see depending on the viewer, added a note about where to go next