### PR TITLE
Import userspace config.h according to USER_NAME

### DIFF
--- a/build_keyboard.mk
+++ b/build_keyboard.mk
@@ -210,8 +210,8 @@ endif
 USER_PATH := users/$(USER_NAME)
 
 -include $(USER_PATH)/rules.mk
-ifneq ("$(wildcard users/$(USER_NAME)/config.h)","")
-    CONFIG_H += users/$(USER_NAME)/config.h
+ifneq ("$(wildcard $(USER_PATH)/config.h)","")
+    CONFIG_H += $(USER_PATH)/config.h
 endif
 
 

--- a/build_keyboard.mk
+++ b/build_keyboard.mk
@@ -210,8 +210,8 @@ endif
 USER_PATH := users/$(USER_NAME)
 
 -include $(USER_PATH)/rules.mk
-ifneq ("$(wildcard users/$(KEYMAP)/config.h)","")
-    CONFIG_H += users/$(KEYMAP)/config.h
+ifneq ("$(wildcard users/$(USER_NAME)/config.h)","")
+    CONFIG_H += users/$(USER_NAME)/config.h
 endif
 
 


### PR DESCRIPTION
Previously, when layouts and userspace were used simultaneously, `config.h` were imported from `user/[LAYOUT_NAME]/` regardless of what `USER_NAME` is set to.