### PR TITLE
Adds basic support for u/flehrad's bigswitch pcb

### DIFF
--- a/keyboards/bigswitch/README.md
+++ b/keyboards/bigswitch/README.md
@@ -1,0 +1,10 @@
+Big Switch PCB by flehrad
+=========================
+
+Designed by Don of the Board Podcast and sold as a kit by [keeb.io](https://keeb.io/collections/frontpage/products/big-switch-pcb?variant=7507922845726)
+
+### Technical Specifications
+
+ * Uses a atmega32u4 pro micro or pin compatible MCU
+ * Pins B5 and B6 connect to the pins on the Big Switch
+ * Optionally you may add a RGB strip to pin D3 for data and take power from VCC and GND

--- a/keyboards/bigswitch/bigswitch.c
+++ b/keyboards/bigswitch/bigswitch.c
@@ -16,3 +16,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "bigswitch.h"
 
+void matrix_init_user(void) {
+  rgblight_enable();
+  rgblight_mode(9);
+}

--- a/keyboards/bigswitch/bigswitch.c
+++ b/keyboards/bigswitch/bigswitch.c
@@ -1,0 +1,18 @@
+/*
+Copyright 2018 QMK Contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "bigswitch.h"
+

--- a/keyboards/bigswitch/bigswitch.h
+++ b/keyboards/bigswitch/bigswitch.h
@@ -19,7 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "quantum.h"
 
-#define KEYMAP( \
+#define LAYOUT( \
   K00  \
 ) { \
   { K00 }  \

--- a/keyboards/bigswitch/bigswitch.h
+++ b/keyboards/bigswitch/bigswitch.h
@@ -1,0 +1,28 @@
+/*
+Copyright 2018 QMK Contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef BIGSWITCH_H
+#define BIGSWITCH_H
+
+#include "quantum.h"
+
+#define KEYMAP( \
+  K00  \
+) { \
+  { K00 }  \
+}
+
+#endif

--- a/keyboards/bigswitch/config.h
+++ b/keyboards/bigswitch/config.h
@@ -1,0 +1,59 @@
+/*
+Copyright 2018 QMK Contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#include "config_common.h"
+
+/* USB Device descriptor parameter */
+#define VENDOR_ID       0x1209
+#define PRODUCT_ID      0xB195
+#define DEVICE_VER      0x0001
+#define MANUFACTURER    flehrad
+#define PRODUCT         BigSwitch PCB
+#define DESCRIPTION     A single key board for Novelkeys Big Switch
+
+/* key matrix size */
+#define MATRIX_ROWS 1
+#define MATRIX_COLS 1
+
+/* key matrix pins */
+#define MATRIX_ROW_PINS { B5 }
+#define MATRIX_COL_PINS { B6 }
+#define UNUSED_PINS { }
+
+/* COL2ROW or ROW2COL */
+#define DIODE_DIRECTION ROW2COL
+
+/* Set 0 if debouncing isn't needed */
+#define DEBOUNCING_DELAY 50
+
+/* key combination for command */
+#define IS_COMMAND() ( \
+    false \
+)
+
+/* prevent stuck modifiers */
+#define PREVENT_STUCK_MODIFIERS
+
+#ifdef RGBLIGHT_ENABLE
+#define RGB_DI_PIN D3
+#define RGBLIGHT_ANIMATIONS
+#define RGBLED_NUM 5
+#endif
+
+#endif

--- a/keyboards/bigswitch/info.json
+++ b/keyboards/bigswitch/info.json
@@ -1,0 +1,13 @@
+{
+    "keyboard_name": "Bigswitch PCB",
+    "url": "",
+    "maintainer": "qmk",
+    "bootloader": "",
+    "width": 4,
+    "height": 4,
+    "layouts": {
+        "LAYOUT": {
+            "layout": [{"x":0, "y":0, "w":4, "h":4}]
+        }
+    }
+}

--- a/keyboards/bigswitch/keymaps/default/keymap.c
+++ b/keyboards/bigswitch/keymaps/default/keymap.c
@@ -1,0 +1,25 @@
+/*
+Copyright 2018 QMK Contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "../../bigswitch.h"
+#define LOCK_OSX LSFT(LCTL(KC_OSX_EJECT))
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+KEYMAP(LOCK_OSX),
+
+};

--- a/keyboards/bigswitch/keymaps/default/keymap.c
+++ b/keyboards/bigswitch/keymaps/default/keymap.c
@@ -15,7 +15,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "../../bigswitch.h"
+#include QMK_KEYBOARD_H
 #define LOCK_OSX LSFT(LCTL(KC_OSX_EJECT))
 #define SLEEP_OSX LALT(LGUI(KC_OSX_EJECT))
 

--- a/keyboards/bigswitch/keymaps/default/keymap.c
+++ b/keyboards/bigswitch/keymaps/default/keymap.c
@@ -17,9 +17,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "../../bigswitch.h"
 #define LOCK_OSX LSFT(LCTL(KC_OSX_EJECT))
+#define SLEEP_OSX LALT(LGUI(KC_OSX_EJECT))
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
-KEYMAP(LOCK_OSX),
+LAYOUT(SLEEP_OSX),
 
 };

--- a/keyboards/bigswitch/keymaps/default/keymap.c
+++ b/keyboards/bigswitch/keymaps/default/keymap.c
@@ -16,6 +16,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include QMK_KEYBOARD_H
+#define KC_OSX_EJECT 0x66
 #define LOCK_OSX LSFT(LCTL(KC_OSX_EJECT))
 #define SLEEP_OSX LALT(LGUI(KC_OSX_EJECT))
 

--- a/keyboards/bigswitch/rules.mk
+++ b/keyboards/bigswitch/rules.mk
@@ -33,6 +33,9 @@ ARCH = AVR8
 #     CPU clock adjust registers or the clock division fuses), this will be equal to F_CPU.
 F_USB = $(F_CPU)
 
+# Bootloader
+BOOTLOADER = caterina
+
 # Interrupt driven control endpoint task(+60)
 OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
 

--- a/keyboards/bigswitch/rules.mk
+++ b/keyboards/bigswitch/rules.mk
@@ -1,0 +1,57 @@
+# MCU name
+MCU = atmega32u4
+
+# Processor frequency.
+#     This will define a symbol, F_CPU, in all source code files equal to the
+#     processor frequency in Hz. You can then use this symbol in your source code to
+#     calculate timings. Do NOT tack on a 'UL' at the end, this will be done
+#     automatically to create a 32-bit value in your source code.
+#
+#     This will be an integer division of F_USB below, as it is sourced by
+#     F_USB after it has run through any CPU prescalers. Note that this value
+#     does not *change* the processor frequency - it should merely be updated to
+#     reflect the processor speed set externally so that the code can use accurate
+#     software delays.
+F_CPU = 16000000
+
+#
+# LUFA specific
+#
+# Target architecture (see library "Board Types" documentation).
+ARCH = AVR8
+
+# Input clock frequency.
+#     This will define a symbol, F_USB, in all source code files equal to the
+#     input clock frequency (before any prescaling is performed) in Hz. This value may
+#     differ from F_CPU if prescaling is used on the latter, and is required as the
+#     raw input clock is fed directly to the PLL sections of the AVR for high speed
+#     clock generation for the USB and other AVR subsections. Do NOT tack on a 'UL'
+#     at the end, this will be done automatically to create a 32-bit value in your
+#     source code.
+#
+#     If no clock division is performed on the input clock inside the AVR (via the
+#     CPU clock adjust registers or the clock division fuses), this will be equal to F_CPU.
+F_USB = $(F_CPU)
+
+# Interrupt driven control endpoint task(+60)
+OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
+
+
+# Boot Section Size in *bytes*
+OPT_DEFS += -DBOOTLOADER_SIZE=4096
+
+
+# Build Options
+#   comment out to disable the options.
+#
+BOOTMAGIC_ENABLE  = no	# Virtual DIP switch configuration(+1000)
+MOUSEKEY_ENABLE  = no	# Mouse keys(+4700)
+EXTRAKEY_ENABLE  = no	# Audio control and System control(+450)
+CONSOLE_ENABLE  = yes	# Console for debug(+400)
+COMMAND_ENABLE  = yes    # Commands for debug and configuration
+SLEEP_LED_ENABLE  = no  # Breathing sleep LED during USB suspend
+NKRO_ENABLE  = no		# USB Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+BACKLIGHT_ENABLE  = no  # Custom backlighting code is used, so this should not be enabled
+AUDIO_ENABLE  = no # This can be enabled if a speaker is connected to the expansion port. Not compatible with RGBLIGHT below
+RGBLIGHT_ENABLE  = yes # This can be enabled if a ws2812 strip is connected to the expansion port.
+

--- a/tmk_core/common/keycode.h
+++ b/tmk_core/common/keycode.h
@@ -412,7 +412,6 @@ enum hid_keyboard_keypad_usage {
 /* Special keycodes */
 /* NOTE: 0xA5-DF and 0xE8-FF are used for internal special purpose */
 enum internal_special_keycodes {
-    KC_OSX_EJECT        = 0x66,
     /* System Control */
     KC_SYSTEM_POWER     = 0xA5,
     KC_SYSTEM_SLEEP,

--- a/tmk_core/common/keycode.h
+++ b/tmk_core/common/keycode.h
@@ -412,6 +412,7 @@ enum hid_keyboard_keypad_usage {
 /* Special keycodes */
 /* NOTE: 0xA5-DF and 0xE8-FF are used for internal special purpose */
 enum internal_special_keycodes {
+    KC_OSX_EJECT        = 0x66,
     /* System Control */
     KC_SYSTEM_POWER     = 0xA5,
     KC_SYSTEM_SLEEP,


### PR DESCRIPTION
 - also adds support for OSX Eject/Power
   The function of this key depends on the version of OSX and if you
   have physical media. For a macbook pro 2017 holding this key down
   brings up the shutdown dialog. If you wrap it in LCTL and LSFT the
   screenlock turns on immediately.