### PR TITLE
Fix YMDK NP21 keyboard to use proper keyboard level functions

### DIFF
--- a/keyboards/ymdk_np21/backlight.c
+++ b/keyboards/ymdk_np21/backlight.c
@@ -70,6 +70,7 @@ void led_set_user(uint8_t usb_led) {
       DDRD  &= ~SCROLLLOCK_PORT;
       PORTD &= ~SCROLLLOCK_PORT;
     }
+    led_set_user(usb_led);
 }
 
 #ifdef BACKLIGHT_ENABLE

--- a/keyboards/ymdk_np21/backlight.c
+++ b/keyboards/ymdk_np21/backlight.c
@@ -70,7 +70,6 @@ void led_set_user(uint8_t usb_led) {
       DDRD  &= ~SCROLLLOCK_PORT;
       PORTD &= ~SCROLLLOCK_PORT;
     }
-    led_set_user(usb_led);
 }
 
 #ifdef BACKLIGHT_ENABLE

--- a/keyboards/ymdk_np21/keymaps/default/keymap.c
+++ b/keyboards/ymdk_np21/keymaps/default/keymap.c
@@ -1,5 +1,4 @@
-#include "ymdk_np21.h"
-#include "action_layer.h"
+#include QMK_KEYBOARD_H
 
 #define _NP 0
 #define _BL  1
@@ -21,7 +20,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * | Enter| Enter|   +  |   +  |   -  | FN   |
  * `-----------------------------------------'
  */
-[_NP] = KEYMAP( \
+[_NP] = LAYOUT( \
   KC_KP_0,     KC_KP_1,     KC_KP_4,    KC_KP_7,    KC_NUMLOCK,     KC_ESC,    \
   KC_DOT,      KC_KP_2,     KC_KP_5,    KC_KP_8,    KC_KP_SLASH,    KC_TAB,    \
   KC_KP_DOT,   KC_KP_3,     KC_KP_6,    KC_KP_9,    KC_KP_ASTERISK, KC_BSPACE, \
@@ -38,7 +37,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * | BL_DEC  | BL_DEC | BL_INC  | BL_INC |   |   |
  * `---------------------------------------------'
  */
-[_BL] = KEYMAP( \
+[_BL] = LAYOUT( \
   BL_BRTG, _______, _______, _______, _______, _______, \
   _______, BL_OFF,  BL_TOGG, BL_ON,   _______, _______, \
   _______, _______, _______, _______, _______, _______, \

--- a/keyboards/ymdk_np21/matrix.c
+++ b/keyboards/ymdk_np21/matrix.c
@@ -101,6 +101,13 @@ void matrix_scan_kb(void) {
   matrix_scan_user();
 };
 
+__attribute__ ((weak))
+void matrix_init_user(void) {};
+
+__attribute__ ((weak))
+void matrix_init_kb(void) {
+  matrix_init_user();
+}
 // declarations
 void matrix_set_row_status(uint8_t row) {
     DDRB = (1 << row);

--- a/keyboards/ymdk_np21/matrix.c
+++ b/keyboards/ymdk_np21/matrix.c
@@ -91,6 +91,10 @@ uint8_t matrix_scan(void) {
     return 1;
 }
 
+__attribute__ ((weak))
+void matrix_scan_user(void) {};
+
+__attribute__ ((weak))
 void matrix_scan_kb(void) {
   // Looping keyboard code goes here
   // This runs every cycle (a lot)

--- a/keyboards/ymdk_np21/ymdk_np21.c
+++ b/keyboards/ymdk_np21/ymdk_np21.c
@@ -77,5 +77,6 @@ void matrix_scan_kb(void) {
 
   rgblight_task();
   /* Nothing else for now. */
+
   matrix_scan_user();
 }

--- a/keyboards/ymdk_np21/ymdk_np21.c
+++ b/keyboards/ymdk_np21/ymdk_np21.c
@@ -34,7 +34,7 @@ extern rgblight_config_t rgblight_config;
 // @Override
 void matrix_init_kb(void) {
   // call user level keymaps, if any
-  // matrix_init_user();
+  matrix_init_user();
 }
 
 #ifdef BACKLIGHT_ENABLE
@@ -67,7 +67,7 @@ void rgblight_set(void) {
 }
 
 bool rgb_init = false;
-void matrix_scan_user(void) {
+void matrix_scan_kb(void) {
   // if LEDs were previously on before poweroff, turn them back on
   if (rgb_init == false && rgblight_config.enable) {
     i2c_init();
@@ -77,4 +77,5 @@ void matrix_scan_user(void) {
 
   rgblight_task();
   /* Nothing else for now. */
+  matrix_scan_user();
 }

--- a/keyboards/ymdk_np21/ymdk_np21.h
+++ b/keyboards/ymdk_np21/ymdk_np21.h
@@ -25,7 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 void matrix_init_user(void);  // TODO port this to other PS2AVRGB boards
 
-#define KEYMAP_GRID( \
+#define LAYOUT( \
     K01, K02, K03, K04, K05, K06, \
     K11, K12, K13, K14, K15, K16, \
     K21, K22, K23, K24, K25, K26, \
@@ -37,7 +37,5 @@ void matrix_init_user(void);  // TODO port this to other PS2AVRGB boards
   { K26, K25, K24, K23, K22, K21 }, \
   { K36, K35, K34, K33, K32, K31 }  \
 }
-
-#define KEYMAP KEYMAP_GRID
 
 #endif


### PR DESCRIPTION
It's using the _user functions in the KB code, and doesn't allow for user customization.