### PR TITLE
Fix Orthodox compile issue in online configurator

### DIFF
--- a/keyboards/orthodox/serial.c
+++ b/keyboards/orthodox/serial.c
@@ -12,7 +12,7 @@
 #include <stdbool.h>
 #include "serial.h"
 
-#ifdef USE_SERIAL
+#ifndef USE_I2C
 
 // Serial pulse period in microseconds. Its probably a bad idea to lower this
 // value.


### PR DESCRIPTION
Since the Configurator doesn't use the default keymap's config.h,  `USE_SERIAL` doesn't get defined.

In most places, the Orthodox defaults to using serial, except .... in the `serial.c` file... ironically. 
This should enable serial by default, and allow us to compile it there. 

This may apply to other boards, but wanted to test this first. 