### PR TITLE
Fix dead link to USB keycodes doc

### DIFF
--- a/tmk_core/common/keycode.h
+++ b/tmk_core/common/keycode.h
@@ -17,7 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /*
  * Keycodes based on HID Usage Keyboard/Keypad Page(0x07) plus special codes
- * http://www.usb.org/developers/devclass_docs/Hut1_12.pdf
+ * https://web.archive.org/web/20060218214400/http://www.usb.org/developers/devclass_docs/Hut1_12.pdf
  */
 #ifndef KEYCODE_H
 #define KEYCODE_H

--- a/tmk_core/common/keycode.h
+++ b/tmk_core/common/keycode.h
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /*
  * Keycodes based on HID Usage Keyboard/Keypad Page(0x07) plus special codes
  * https://web.archive.org/web/20060218214400/http://www.usb.org/developers/devclass_docs/Hut1_12.pdf
+ * or http://www.usb.org/developers/hidpage/Hut1_12v2.pdf (older)
  */
 #ifndef KEYCODE_H
 #define KEYCODE_H


### PR DESCRIPTION
Link was dead and the fresher version I could find on usb.org (http://www.usb.org/developers/hidpage/Hut1_12v2.pdf) is still older than this one.

Thus, WaybackMachine seems the best option.