### PR TITLE
Fix Split keyboards so they compile on Configurator

### DIFF
--- a/keyboards/bfo9000/serial.c
+++ b/keyboards/bfo9000/serial.c
@@ -12,7 +12,7 @@
 #include <stdbool.h>
 #include "serial.h"
 
-#ifdef USE_SERIAL
+#ifndef USE_I2C
 
 // Serial pulse period in microseconds. Its probably a bad idea to lower this
 // value.

--- a/keyboards/deltasplit75/serial.c
+++ b/keyboards/deltasplit75/serial.c
@@ -12,7 +12,7 @@
 #include <stdbool.h>
 #include "serial.h"
 
-#ifdef USE_SERIAL
+#ifndef USE_I2C
 
 // Serial pulse period in microseconds. Its probably a bad idea to lower this
 // value.

--- a/keyboards/helix/serial.c
+++ b/keyboards/helix/serial.c
@@ -12,7 +12,7 @@
 #include <stdbool.h>
 #include "serial.h"
 
-#ifdef USE_SERIAL
+#ifndef USE_I2C
 
 // Serial pulse period in microseconds. Its probably a bad idea to lower this
 // value.

--- a/keyboards/helix/serial.c
+++ b/keyboards/helix/serial.c
@@ -12,7 +12,7 @@
 #include <stdbool.h>
 #include "serial.h"
 
-#ifndef USE_I2C
+#ifdef USE_SERIAL
 
 // Serial pulse period in microseconds. Its probably a bad idea to lower this
 // value.

--- a/keyboards/minidox/serial.c
+++ b/keyboards/minidox/serial.c
@@ -12,7 +12,7 @@
 #include <stdbool.h>
 #include "serial.h"
 
-#ifdef USE_SERIAL
+#ifndef USE_I2C
 
 // Serial pulse period in microseconds. Its probably a bad idea to lower this
 // value.

--- a/keyboards/viterbi/serial.c
+++ b/keyboards/viterbi/serial.c
@@ -12,7 +12,7 @@
 #include <stdbool.h>
 #include "serial.h"
 
-#ifdef USE_SERIAL
+#ifndef USE_I2C
 
 // Serial pulse period in microseconds. Its probably a bad idea to lower this
 // value.


### PR DESCRIPTION
As the #3044, fixes the split boards to use serial by default, so that they'll actually compile successfully on the configurator. 