### PR TITLE
[Let's Split] Add ability to write additional code in matrix scan loop on slave.

### DIFF
--- a/keyboards/lets_split/matrix.c
+++ b/keyboards/lets_split/matrix.c
@@ -101,6 +101,10 @@ __attribute__ ((weak))
 void matrix_scan_user(void) {
 }
 
+__attribute__ ((weak))
+void matrix_slave_scan_user(void) {
+}
+
 inline
 uint8_t matrix_rows(void)
 {
@@ -286,6 +290,7 @@ void matrix_slave_scan(void) {
         serial_slave_buffer[i] = matrix[offset+i];
     }
 #endif
+    matrix_slave_scan_user();
 }
 
 bool matrix_is_modified(void)


### PR DESCRIPTION
This PR adds possibility to define custom code on slave part of the Let's Split keyboard within keymap scope without altering the keyboard scope code. This was achieved by defining a weak attribute `matrix_slave_scan_user(void)` that will be called during `matrix_slave_scan(void)`.

This allows to perform some actions on the slave part by defining a `matrix_slave_scan_user(void)` function within your keymap. I've tested this to make slave's TX LED blink every 100ms.

This idea was briefly discussed on Gitter (thanks @drashna)