### PR TITLE
Add Function level EECONFIG code for EEPROM

### DIFF
--- a/docs/custom_quantum_functions.md
+++ b/docs/custom_quantum_functions.md
@@ -317,7 +317,7 @@ uint32_t layer_state_set_user(uint32_t state) {
   return state;
 }
 ```
-This will cause the RGB underglow to be changed ONLY if the value was enabled.  Now to configure this value, create a new keycode for `process_record_user` called `RGB_LYR`. Additionally, we want to make sure that if you use the normal RGB codes, that it turns off  Using the example above, make it look this:
+This will cause the RGB underglow to be changed ONLY if the value was enabled.  Now to configure this value, create a new keycode for `process_record_user` called `RGB_LYR` and `EPRM`. Additionally, we want to make sure that if you use the normal RGB codes, that it turns off  Using the example above, make it look this:
 ```
 
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
@@ -330,11 +330,16 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
       }
       return false; // Skip all further processing of this key
     case KC_ENTER:
-      // Play a tone when enter is pressed
-      if (record->event.pressed) {
-        PLAY_NOTE_ARRAY(tone_qwerty);
-      }
-      return true; // Let QMK send the enter press/release events
+        // Play a tone when enter is pressed
+        if (record->event.pressed) {
+            PLAY_NOTE_ARRAY(tone_qwerty);
+        }
+        return true; // Let QMK send the enter press/release events
+    case EPRM:
+        if (record->event.pressed) {
+            eeconfig_init(); // resets the EEPROM to default
+        }
+        return false;
     case RGB_LYR:  // This allows me to use underglow as layer indication, or as normal
         if (record->event.pressed) { 
             user_config.rgb_layer_change ^= 1; // Toggles the status
@@ -368,7 +373,7 @@ void eeconfig_init_user(void) {  // EEPROM is getting reset!
   rgblight_enable(); // Enable RGB by default
   rgblight_sethsv_cyan();  // Set it to CYAN by default
   rgblight_mode(1); // set to solid by default
-  }
+}
 ```
 
 And you're done.  The RGB layer indication will only work if you want it to. And it will be saved, even after unplugging the board. And if you use any of the RGB codes, it will disable the layer indication, so that it stays on the mode and color that you set it to. 

--- a/docs/custom_quantum_functions.md
+++ b/docs/custom_quantum_functions.md
@@ -248,7 +248,7 @@ The `state` is the bitmask of the active layers, as explained in the [Keymap Ove
 
 # Persistent Configuration (EEPROM)
 
-This allows you to configure persistent settings for your keyboard.  These settings are stored in the EEPROM of your controller, and are retained even after power loss. The settings can be read with `eeconfig_read_kb` and `eeconfig_read_user`, and can be written to using `eeconfig_update_kb` and `eeconfig_update_user`. This is useful for features that you want to be able to toggle (like toggling rgb layer indication).
+This allows you to configure persistent settings for your keyboard.  These settings are stored in the EEPROM of your controller, and are retained even after power loss. The settings can be read with `eeconfig_read_kb` and `eeconfig_read_user`, and can be written to using `eeconfig_update_kb` and `eeconfig_update_user`. This is useful for features that you want to be able to toggle (like toggling rgb layer indication).  Additionally, you can use `eeconfig_init_kb` and `eeconfig_init_user` to set the default values for the EEPROM. 
 
 The complicated part here, is that there are a bunch of ways that you can store and access data via EEPROM, and there is no "correct" way to do this.  However, you only have a DWORD (4 bytes) for each function.
 
@@ -356,6 +356,19 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
       return true; // Process all other keycodes normally
   }
 }
+```
+And lastly, you want to add the `eeconfig_init_user` function, so that when the EEPROM is reset, you can specify default values, and even custom actions. For example, if you want to set rgb layer indication by default, and save the default valued. 
+
+```
+void eeconfig_init_user(void) {  // EEPROM is getting reset! 
+  user_config.rgb_layer_change = true; // We want this enabled by default
+  eeconfig_update_user(user_config.raw); // Write default value to EEPROM now
+
+  // use the non noeeprom versions, to write these values to EEPROM too
+  rgblight_enable(); // Enable RGB by default
+  rgblight_sethsv_cyan();  // Set it to CYAN by default
+  rgblight_mode(1); // set to solid by default
+  }
 ```
 
 And you're done.  The RGB layer indication will only work if you want it to. And it will be saved, even after unplugging the board. And if you use any of the RGB codes, it will disable the layer indication, so that it stays on the mode and color that you set it to. 

--- a/docs/custom_quantum_functions.md
+++ b/docs/custom_quantum_functions.md
@@ -380,7 +380,7 @@ And you're done.  The RGB layer indication will only work if you want it to. And
 
 ### 'EECONFIG' Function Documentation
 
-* Keyboard/Revision: `uint32_t eeconfig_read_kb(void)` and `void eeconfig_update_kb(uint32_t val)`
-* Keymap: `uint32_t eeconfig_read_user(void)` and `void eeconfig_update_user(uint32_t val)`
+* Keyboard/Revision: `void eeconfig_init_kb(void)`, `uint32_t eeconfig_read_kb(void)` and `void eeconfig_update_kb(uint32_t val)`
+* Keymap: `void eeconfig_init_user(void)`, `uint32_t eeconfig_read_user(void)` and `void eeconfig_update_user(uint32_t val)`
 
 The `val` is the value of the data that you want to write to EEPROM.  And the `eeconfig_read_*` function return a 32 bit (DWORD) value from the EEPROM. 

--- a/docs/custom_quantum_functions.md
+++ b/docs/custom_quantum_functions.md
@@ -244,3 +244,125 @@ uint32_t layer_state_set_user(uint32_t state) {
 * Keymap: `uint32_t layer_state_set_user(uint32_t state)`
 
 The `state` is the bitmask of the active layers, as explained in the [Keymap Overview](keymap.md#keymap-layer-status)
+
+
+# Persistent Configuration (EEPROM)
+
+This allows you to configure persistent settings for your keyboard.  These settings are stored in the EEPROM of your controller, and are retained even after power loss. The settings can be read with `eeconfig_read_kb` and `eeconfig_read_user`, and can be written to using `eeconfig_update_kb` and `eeconfig_update_user`. This is useful for features that you want to be able to toggle (like toggling rgb layer indication).
+
+The complicated part here, is that there are a bunch of ways that you can store and access data via EEPROM, and there is no "correct" way to do this.  However, you only have a DWORD (4 bytes) for each function.
+
+Keep in mind that EEPROM has a limited number of writes. While this is very high, it's not the only thing writing to the EEPROM, and if you write too often, you can potentially drastically shorten the life of your MCU.
+
+* If you don't understand the example, then you may want to avoid using this feature, as it is rather complicated. 
+
+### Example  Implementation
+
+This is an example of how to add settings, and read and write it. We're using the user keymap for the example here.  This is a complex function, and has a lot going on.  In fact, it uses a lot of the above functions to work! 
+
+
+In your keymap.c file, add this to the top:
+```
+typedef union {
+  uint32_t raw;
+  struct {
+    bool     rgb_layer_change :1;
+  };
+} user_config_t;
+
+user_config_t user_config;
+```
+
+This sets up a 32 bit structure that we can store settings with in memory, and write to the EEPROM. Using this removes the need to define variables, since they're defined in this structure. Remember that `bool` (boolean) values use 1 bit, `uint8_t` uses 8 bits, `uint16_t` uses up 16 bits.  You can mix and match, but changing the order can cause issues, as it will change the values that are read and written. 
+
+We're using `rgb_layer_change`, for the `layer_state_set_*` function, and use `matrix_init_user` and `process_record_user` to configure everything. 
+
+Now, using the `matrix_init_user` code above, you want to add `eeconfig_read_user()` to it, to populate the structure you've just created. And you can then immediately use this structure to control functionality in your keymap.  And It should look like: 
+```
+void matrix_init_user(void) {
+  // Call the keymap level matrix init.
+
+  // Read the user config from EEPROM
+  user_config.raw = eeconfig_read_user();
+
+  // Set default layer, if enabled
+  if (user_config.rgb_layer_change) {
+    rgblight_enable_noeeprom();
+    rgblight_sethsv_noeeprom_cyan(); 
+    rgblight_mode_noeeprom(1);
+  }
+}
+```
+The above function will use the EEPROM config immediately after reading it, to set the default layer's RGB color. The "raw" value of it is converted in a usable structure based on the "union" that you created above. 
+
+```
+uint32_t layer_state_set_user(uint32_t state) {
+    switch (biton32(state)) {
+    case _RAISE:
+        if (user_config.rgb_layer_change) { rgblight_sethsv_noeeprom_magenta(); rgblight_mode_noeeprom(1); }
+        break;
+    case _LOWER:
+        if (user_config.rgb_layer_change) { rgblight_sethsv_noeeprom_red(); rgblight_mode_noeeprom(1); }
+        break;
+    case _PLOVER:
+        if (user_config.rgb_layer_change) { rgblight_sethsv_noeeprom_green(); rgblight_mode_noeeprom(1); }
+        break;
+    case _ADJUST:
+        if (user_config.rgb_layer_change) { rgblight_sethsv_noeeprom_white(); rgblight_mode_noeeprom(1); }
+        break;
+    default: //  for any other layers, or the default layer
+        if (user_config.rgb_layer_change) { rgblight_sethsv_noeeprom_cyan(); rgblight_mode_noeeprom(1); }
+        break;
+    }
+  return state;
+}
+```
+This will cause the RGB underglow to be changed ONLY if the value was enabled.  Now to configure this value, create a new keycode for `process_record_user` called `RGB_LYR`. Additionally, we want to make sure that if you use the normal RGB codes, that it turns off  Using the example above, make it look this:
+```
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  switch (keycode) {
+    case FOO:
+      if (record->event.pressed) {
+        // Do something when pressed
+      } else {
+        // Do something else when release
+      }
+      return false; // Skip all further processing of this key
+    case KC_ENTER:
+      // Play a tone when enter is pressed
+      if (record->event.pressed) {
+        PLAY_NOTE_ARRAY(tone_qwerty);
+      }
+      return true; // Let QMK send the enter press/release events
+    case RGB_LYR:  // This allows me to use underglow as layer indication, or as normal
+        if (record->event.pressed) { 
+            user_config.rgb_layer_change ^= 1; // Toggles the status
+            eeconfig_update_user(user_config.raw); // Writes the new status to EEPROM
+            if (user_config.rgb_layer_change) { // if layer state indication is enabled, 
+                layer_state_set(layer_state);   // then immediately update the layer color
+            }
+        }
+        return false; break;
+    case RGB_MODE_FORWARD ... RGB_MODE_GRADIENT: // For any of the RGB codes (see quantum_keycodes.h, L400 for reference)
+        if (record->event.pressed) { //This disables layer indication, as it's assumed that if you're changing this ... you want that disabled
+            if (user_config.rgb_layer_change) {        // only if this is enabled 
+                user_config.rgb_layer_change = false;  // disable it, and 
+                eeconfig_update_user(user_config.raw); // write the setings to EEPROM
+            }
+        }
+        return true; break;
+    default:
+      return true; // Process all other keycodes normally
+  }
+}
+```
+
+And you're done.  The RGB layer indication will only work if you want it to. And it will be saved, even after unplugging the board. And if you use any of the RGB codes, it will disable the layer indication, so that it stays on the mode and color that you set it to. 
+
+### 'EECONFIG' Function Documentation
+
+* Keyboard/Revision: `uint32_t eeconfig_read_kb(void)` and `void eeconfig_update_kb(uint32_t val)`
+* Keymap: `uint32_t eeconfig_read_user(void)` and `void eeconfig_update_user(uint32_t val)`
+
+The `val` is the value of the data that you want to write to EEPROM.  And the `eeconfig_read_*` function return a 32 bit (DWORD) value from the EEPROM. 

--- a/keyboards/ergodox_ez/keymaps/rgb_layer/config.h
+++ b/keyboards/ergodox_ez/keymaps/rgb_layer/config.h
@@ -1,0 +1,24 @@
+#ifndef KEYMAP_CONFIG_H
+#define KEYMAP_CONFIG_H
+
+
+    #define RGBLIGHT_SLEEP
+
+
+#ifndef QMK_KEYS_PER_SCAN
+#define QMK_KEYS_PER_SCAN 4
+#endif // !QMK_KEYS_PER_SCAN
+
+#define IGNORE_MOD_TAP_INTERRUPT
+#undef PERMISSIVE_HOLD
+#undef PREVENT_STUCK_MODIFIERS
+
+
+#define FORCE_NKRO
+
+#ifndef TAPPING_TOGGLE
+#define TAPPING_TOGGLE  1
+#endif
+
+#endif // !USERSPACE_CONFIG_H
+

--- a/keyboards/ergodox_ez/keymaps/rgb_layer/keymap.c
+++ b/keyboards/ergodox_ez/keymaps/rgb_layer/keymap.c
@@ -91,10 +91,10 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 [SYMB] = LAYOUT_ergodox(
        // left hand
        VRSN,   KC_F1,  KC_F2,  KC_F3,  KC_F4,  KC_F5,  KC_TRNS,
-       KC_TRNS,KC_EXLM,KC_AT,  KC_LCBR,KC_RCBR,KC_PIPE,KC_TRNS,
+       RESET,  KC_EXLM,KC_AT,  KC_LCBR,KC_RCBR,KC_PIPE,KC_TRNS,
        KC_TRNS,KC_HASH,KC_DLR, KC_LPRN,KC_RPRN,KC_GRV,
-       KC_TRNS,KC_PERC,KC_CIRC,KC_LBRC,KC_RBRC,KC_TILD,KC_TRNS,
-          EPRM,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,
+       EPRM,KC_PERC,KC_CIRC,KC_LBRC,KC_RBRC,KC_TILD,KC_TRNS,
+          KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,
                                        RGB_MOD,RGB_LYR,
                                                KC_TRNS,
                                RGB_VAD,RGB_VAI,KC_TRNS,
@@ -151,6 +151,13 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 ),
 };
 
+void eeconfig_init_user(void) {
+  rgblight_enable();
+  rgblight_sethsv_cyan();
+  rgblight_mode(1);
+  user_config.rgb_layer_change = true;
+  eeconfig_update_user(user_config.raw);
+}
 
 
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {

--- a/keyboards/ergodox_ez/keymaps/rgb_layer/keymap.c
+++ b/keyboards/ergodox_ez/keymaps/rgb_layer/keymap.c
@@ -1,0 +1,264 @@
+#include QMK_KEYBOARD_H
+#include "version.h"
+
+#define BASE 0 // default layer
+#define SYMB 1 // symbols
+#define MDIA 2 // media keys
+
+enum custom_keycodes {
+  PLACEHOLDER = SAFE_RANGE, // can always be here
+  EPRM,
+  VRSN,
+  RGB_SLD,
+  RGB_LYR
+};
+
+typedef union {
+  uint32_t raw;
+  struct {
+    bool     rgb_layer_change :1;
+  };
+} user_config_t;
+
+user_config_t user_config;
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+/* Keymap 0: Basic layer
+ *
+ * ,--------------------------------------------------.           ,--------------------------------------------------.
+ * |   =    |   1  |   2  |   3  |   4  |   5  | LEFT |           | RIGHT|   6  |   7  |   8  |   9  |   0  |   -    |
+ * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
+ * | Del    |   Q  |   W  |   E  |   R  |   T  |  L1  |           |  L1  |   Y  |   U  |   I  |   O  |   P  |   \    |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * | BkSp   |   A  |   S  |   D  |   F  |   G  |------|           |------|   H  |   J  |   K  |   L  |; / L2|' / Cmd |
+ * |--------+------+------+------+------+------| Hyper|           | Meh  |------+------+------+------+------+--------|
+ * | LShift |Z/Ctrl|   X  |   C  |   V  |   B  |      |           |      |   N  |   M  |   ,  |   .  |//Ctrl| RShift |
+ * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
+ *   |Grv/L1|  '"  |AltShf| Left | Right|                                       |  Up  | Down |   [  |   ]  | ~L1  |
+ *   `----------------------------------'                                       `----------------------------------'
+ *                                        ,-------------.       ,-------------.
+ *                                        | App  | LGui |       | Alt  |Ctrl/Esc|
+ *                                 ,------|------|------|       |------+--------+------.
+ *                                 |      |      | Home |       | PgUp |        |      |
+ *                                 | Space|Backsp|------|       |------|  Tab   |Enter |
+ *                                 |      |ace   | End  |       | PgDn |        |      |
+ *                                 `--------------------'       `----------------------'
+ */
+// If it accepts an argument (i.e, is a function), it doesn't need KC_.
+// Otherwise, it needs KC_*
+[BASE] = LAYOUT_ergodox(  // layer 0 : default
+        // left hand
+        KC_EQL,         KC_1,         KC_2,   KC_3,   KC_4,   KC_5,   KC_LEFT,
+        KC_DELT,        KC_Q,         KC_W,   KC_E,   KC_R,   KC_T,   TG(SYMB),
+        KC_BSPC,        KC_A,         KC_S,   KC_D,   KC_F,   KC_G,
+        KC_LSFT,        CTL_T(KC_Z),  KC_X,   KC_C,   KC_V,   KC_B,   ALL_T(KC_NO),
+        LT(SYMB,KC_GRV),KC_QUOT,      LALT(KC_LSFT),  KC_LEFT,KC_RGHT,
+                                              ALT_T(KC_APP),  KC_LGUI,
+                                                              KC_HOME,
+                                               KC_SPC,KC_BSPC,KC_END,
+        // right hand
+             KC_RGHT,     KC_6,   KC_7,  KC_8,   KC_9,   KC_0,             KC_MINS,
+             TG(SYMB),    KC_Y,   KC_U,  KC_I,   KC_O,   KC_P,             KC_BSLS,
+                          KC_H,   KC_J,  KC_K,   KC_L,   LT(MDIA, KC_SCLN),GUI_T(KC_QUOT),
+             MEH_T(KC_NO),KC_N,   KC_M,  KC_COMM,KC_DOT, CTL_T(KC_SLSH),   KC_RSFT,
+                                  KC_UP, KC_DOWN,KC_LBRC,KC_RBRC,          TT(SYMB),
+             KC_LALT,        CTL_T(KC_ESC),
+             KC_PGUP,
+             KC_PGDN,KC_TAB, KC_ENT
+    ),
+/* Keymap 1: Symbol Layer
+ *
+ * ,---------------------------------------------------.           ,--------------------------------------------------.
+ * |Version  |  F1  |  F2  |  F3  |  F4  |  F5  |      |           |      |  F6  |  F7  |  F8  |  F9  |  F10 |   F11  |
+ * |---------+------+------+------+------+------+------|           |------+------+------+------+------+------+--------|
+ * |         |   !  |   @  |   {  |   }  |   |  |      |           |      |   Up |   7  |   8  |   9  |   *  |   F12  |
+ * |---------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |         |   #  |   $  |   (  |   )  |   `  |------|           |------| Down |   4  |   5  |   6  |   +  |        |
+ * |---------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |         |   %  |   ^  |   [  |   ]  |   ~  |      |           |      |   &  |   1  |   2  |   3  |   \  |        |
+ * `---------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
+ *   | EPRM  |      |      |      |      |                                       |      |    . |   0  |   =  |      |
+ *   `-----------------------------------'                                       `----------------------------------'
+ *                                        ,-------------.       ,-------------.
+ *                                        |Animat| LYR  |       |Toggle|Solid |
+ *                                 ,------|------|------|       |------+------+------.
+ *                                 |Bright|Bright|      |       |      |Hue-  |Hue+  |
+ *                                 |ness- |ness+ |------|       |------|      |      |
+ *                                 |      |      |      |       |      |      |      |
+ *                                 `--------------------'       `--------------------'
+ */
+// SYMBOLS
+[SYMB] = LAYOUT_ergodox(
+       // left hand
+       VRSN,   KC_F1,  KC_F2,  KC_F3,  KC_F4,  KC_F5,  KC_TRNS,
+       KC_TRNS,KC_EXLM,KC_AT,  KC_LCBR,KC_RCBR,KC_PIPE,KC_TRNS,
+       KC_TRNS,KC_HASH,KC_DLR, KC_LPRN,KC_RPRN,KC_GRV,
+       KC_TRNS,KC_PERC,KC_CIRC,KC_LBRC,KC_RBRC,KC_TILD,KC_TRNS,
+          EPRM,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,
+                                       RGB_MOD,RGB_LYR,
+                                               KC_TRNS,
+                               RGB_VAD,RGB_VAI,KC_TRNS,
+       // right hand
+       KC_TRNS, KC_F6,   KC_F7,  KC_F8,   KC_F9,   KC_F10,  KC_F11,
+       KC_TRNS, KC_UP,   KC_7,   KC_8,    KC_9,    KC_ASTR, KC_F12,
+                KC_DOWN, KC_4,   KC_5,    KC_6,    KC_PLUS, KC_TRNS,
+       KC_TRNS, KC_AMPR, KC_1,   KC_2,    KC_3,    KC_BSLS, KC_TRNS,
+                         KC_TRNS,KC_DOT,  KC_0,    KC_EQL,  KC_TRNS,
+       RGB_TOG, RGB_SLD,
+       KC_TRNS,
+       KC_TRNS, RGB_HUD, RGB_HUI
+),
+/* Keymap 2: Media and mouse keys
+ *
+ * ,--------------------------------------------------.           ,--------------------------------------------------.
+ * |        |      |      |      |      |      |      |           |      |      |      |      |      |      |        |
+ * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
+ * |        |      |      | MsUp |      |      |      |           |      |      |      |      |      |      |        |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |        |      |MsLeft|MsDown|MsRght|      |------|           |------|      |      |      |      |      |  Play  |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |        |      |      |      |      |      |      |           |      |      |      | Prev | Next |      |        |
+ * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
+ *   |      |      |      | Lclk | Rclk |                                       |VolUp |VolDn | Mute |      |      |
+ *   `----------------------------------'                                       `----------------------------------'
+ *                                        ,-------------.       ,-------------.
+ *                                        |      |      |       |      |      |
+ *                                 ,------|------|------|       |------+------+------.
+ *                                 |      |      |      |       |      |      |Brwser|
+ *                                 |      |      |------|       |------|      |Back  |
+ *                                 |      |      |      |       |      |      |      |
+ *                                 `--------------------'       `--------------------'
+ */
+// MEDIA AND MOUSE
+[MDIA] = LAYOUT_ergodox(
+       KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+       KC_TRNS, KC_TRNS, KC_TRNS, KC_MS_U, KC_TRNS, KC_TRNS, KC_TRNS,
+       KC_TRNS, KC_TRNS, KC_MS_L, KC_MS_D, KC_MS_R, KC_TRNS,
+       KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+       KC_TRNS, KC_TRNS, KC_TRNS, KC_BTN1, KC_BTN2,
+                                           KC_TRNS, KC_TRNS,
+                                                    KC_TRNS,
+                                  KC_TRNS, KC_TRNS, KC_TRNS,
+    // right hand
+       KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+       KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+                 KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_MPLY,
+       KC_TRNS,  KC_TRNS, KC_TRNS, KC_MPRV, KC_MNXT, KC_TRNS, KC_TRNS,
+                          KC_VOLU, KC_VOLD, KC_MUTE, KC_TRNS, KC_TRNS,
+       KC_TRNS, KC_TRNS,
+       KC_TRNS,
+       KC_TRNS, KC_TRNS, KC_WBAK
+),
+};
+
+
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  switch (keycode) {
+    // dynamically generate these.
+    case EPRM:
+      if (record->event.pressed) {
+        eeconfig_init();
+      }
+      return false;
+      break;
+    case VRSN:
+      if (record->event.pressed) {
+        SEND_STRING (QMK_KEYBOARD "/" QMK_KEYMAP " @ " QMK_VERSION);
+      }
+      return false;
+      break;
+    case RGB_SLD:
+      if (record->event.pressed) {
+        #ifdef RGBLIGHT_ENABLE
+          rgblight_mode(1);
+        #endif
+      }
+      return false;
+      break;
+     case RGB_LYR:  // This allows me to use underglow as layer indication, or as normal
+        if (record->event.pressed) {
+            user_config.rgb_layer_change ^= 1; // Toggles the status
+            eeconfig_update_user(user_config.raw); // Writes the new status to EEPROM
+            if (user_config.rgb_layer_change) { // if layer state indication is enabled,
+                layer_state_set(layer_state);   // then immediately update the layer color
+            }
+        }
+        return false; break;
+    case RGB_MODE_FORWARD ... RGB_MODE_GRADIENT: // For any of the RGB codes (see quantum_keycodes.h, L400 for reference)
+        if (record->event.pressed) { //This disables layer indication, as it's assumed that if you're changing this ... you want that disabled
+            if (user_config.rgb_layer_change) {        // only if this is enabled
+                user_config.rgb_layer_change = false;  // disable it, and
+                eeconfig_update_user(user_config.raw); // write the setings to EEPROM
+            }
+        }
+        return true; break;
+ }
+  return true;
+}
+
+void matrix_init_user(void) {
+  // Call the keymap level matrix init.
+
+  // Read the user config from EEPROM
+  user_config.raw = eeconfig_read_user();
+
+  // Set default layer, if enabled
+  if (user_config.rgb_layer_change) {
+    rgblight_enable_noeeprom();
+    rgblight_sethsv_noeeprom_cyan();
+    rgblight_mode_noeeprom(1);
+  }
+}
+
+// Runs constantly in the background, in a loop.
+void matrix_scan_user(void) {
+
+};
+
+uint32_t layer_state_set_user(uint32_t state) {
+  ergodox_board_led_off();
+  ergodox_right_led_1_off();
+  ergodox_right_led_2_off();
+  ergodox_right_led_3_off();
+  switch (biton32(state)) {
+    case SYMB:
+        ergodox_right_led_1_on();
+        if (user_config.rgb_layer_change) { rgblight_sethsv_noeeprom_red(); rgblight_mode_noeeprom(1); }
+        break;
+    case MDIA:
+        ergodox_right_led_2_on();
+        if (user_config.rgb_layer_change) { rgblight_sethsv_noeeprom_green(); rgblight_mode_noeeprom(1); }
+        break;
+    case 3:
+        ergodox_right_led_3_on();
+        if (user_config.rgb_layer_change) { rgblight_sethsv_noeeprom_blue(); rgblight_mode_noeeprom(1); }
+        break;
+    case 4:
+        ergodox_right_led_1_on();
+        ergodox_right_led_2_on();
+        if (user_config.rgb_layer_change) { rgblight_sethsv_noeeprom_orange(); rgblight_mode_noeeprom(1); }
+        break;
+    case 5:
+        ergodox_right_led_1_on();
+        ergodox_right_led_3_on();
+        if (user_config.rgb_layer_change) { rgblight_sethsv_noeeprom_yellow(); rgblight_mode_noeeprom(1); }
+        break;
+    case 6:
+        ergodox_right_led_2_on();
+        ergodox_right_led_3_on();
+        if (user_config.rgb_layer_change) { rgblight_sethsv_noeeprom_pink(); rgblight_mode_noeeprom(1); }
+        break;
+    case 7:
+        ergodox_right_led_1_on();
+        ergodox_right_led_2_on();
+        ergodox_right_led_3_on();
+        if (user_config.rgb_layer_change) { rgblight_sethsv_noeeprom_white(); rgblight_mode_noeeprom(1); }
+        break;
+    default: //  for any other layers, or the default layer
+        if (user_config.rgb_layer_change) { rgblight_sethsv_noeeprom_cyan(); rgblight_mode_noeeprom(1); }
+        break;
+    }
+  return state;
+}
+

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -914,14 +914,6 @@ void tap_random_base64(void) {
   }
 }
 
-void eeconfig_init_quantum(void) {
-  #if defined(AUDIO_ENABLE) && defined(DEFAULT_LAYER_SONGS)
-    PLAY_SONG(default_layer_songs[0]);
-  #endif
-  default_layer_set(1U<<0);
-  eeconfig_init_kb();
-}
-
 void matrix_init_quantum() {
   if (!eeconfig_is_enabled() && !eeconfig_is_disabled()) {
     eeconfig_init();

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -915,6 +915,9 @@ void tap_random_base64(void) {
 }
 
 void matrix_init_quantum() {
+  if (!eeconfig_is_enabled() && !eeconfig_is_disabled()) {
+    eeconfig_init();
+  }
   #ifdef BACKLIGHT_ENABLE
     backlight_init_ports();
   #endif

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -914,6 +914,14 @@ void tap_random_base64(void) {
   }
 }
 
+void eeconfig_init_quantum(void) {
+  #if defined(AUDIO_ENABLE) && defined(DEFAULT_LAYER_SONGS)
+    PLAY_SONG(default_layer_songs[0]);
+  #endif
+  default_layer_set(1U<<0);
+  eeconfig_init_kb();
+}
+
 void matrix_init_quantum() {
   if (!eeconfig_is_enabled() && !eeconfig_is_disabled()) {
     eeconfig_init();

--- a/tmk_core/common/eeconfig.c
+++ b/tmk_core/common/eeconfig.c
@@ -32,7 +32,6 @@ void eeconfig_init_kb(void) {
  * FIXME: needs doc
  */
 void eeconfig_init_quantum(void) {
-{
 #ifdef STM32F303xC
     EEPROM_format();
 #endif

--- a/tmk_core/common/eeconfig.c
+++ b/tmk_core/common/eeconfig.c
@@ -35,6 +35,7 @@ void eeconfig_init_quantum(void) {
 #ifdef STM32F303xC
     EEPROM_format();
 #endif
+  eeprom_update_word(EECONFIG_MAGIC,          EECONFIG_MAGIC_NUMBER);
   eeprom_update_byte(EECONFIG_DEBUG,          0);
   eeprom_update_byte(EECONFIG_DEFAULT_LAYER,  0);
   default_layer_state = 0;
@@ -53,7 +54,6 @@ void eeconfig_init_quantum(void) {
  * FIXME: needs doc
  */
 void eeconfig_init(void) {
-  eeprom_update_word(EECONFIG_MAGIC,          EECONFIG_MAGIC_NUMBER);
 
   eeconfig_init_quantum();
 }

--- a/tmk_core/common/eeconfig.c
+++ b/tmk_core/common/eeconfig.c
@@ -8,10 +8,30 @@
 #include "eeprom_stm32.h"
 #endif
 
+/** \brief eeconfig enable
+ *
+ * FIXME: needs doc
+ */
+__attribute__ ((weak))
+void eeconfig_init_user(void) {
+  // Reset user EEPROM value to blank, rather than to a set value
+  eeprom_update_dword(EECONFIG_USER, 0);
+}
+
+__attribute__ ((weak))
+void eeconfig_init_kb(void) {
+  // Reset Keyboard EEPROM value to blank, rather than to a set value
+  eeprom_update_dword(EECONFIG_KEYBOARD, 0);
+
+  eeconfig_init_user();
+}
+
+
 /** \brief eeconfig initialization
  *
  * FIXME: needs doc
  */
+<<<<<<< HEAD
 void eeconfig_init(void)
 {
 #ifdef STM32F303xC
@@ -22,18 +42,32 @@ void eeconfig_init(void)
     eeprom_update_byte(EECONFIG_DEFAULT_LAYER,  0);
     eeprom_update_byte(EECONFIG_KEYMAP,         0);
     eeprom_update_byte(EECONFIG_MOUSEKEY_ACCEL, 0);
+=======
+void eeconfig_init_quantum(void) {
+  eeprom_update_word(EECONFIG_MAGIC,          EECONFIG_MAGIC_NUMBER);
+  eeprom_update_byte(EECONFIG_DEBUG,          0);
+  eeprom_update_byte(EECONFIG_DEFAULT_LAYER,  0);
+  eeprom_update_byte(EECONFIG_KEYMAP,         0);
+  eeprom_update_byte(EECONFIG_MOUSEKEY_ACCEL, 0);
+>>>>>>> Add Function level EEPROM configuration
 #ifdef BACKLIGHT_ENABLE
-    eeprom_update_byte(EECONFIG_BACKLIGHT,      0);
+  eeprom_update_byte(EECONFIG_BACKLIGHT,      0);
 #endif
 #ifdef AUDIO_ENABLE
-    eeprom_update_byte(EECONFIG_AUDIO,             0xFF); // On by default
+  eeprom_update_byte(EECONFIG_AUDIO,             0xFF); // On by default
 #endif
 #if defined(RGBLIGHT_ENABLE) || defined(RGB_MATRIX_ENABLE)
-    eeprom_update_dword(EECONFIG_RGBLIGHT,      0);
+  eeprom_update_dword(EECONFIG_RGBLIGHT,      0);
 #endif
 #ifdef STENO_ENABLE
-    eeprom_update_byte(EECONFIG_STENOMODE,      0);
+  eeprom_update_byte(EECONFIG_STENOMODE,      0);
 #endif
+
+  eeconfig_init_kb();
+}
+
+void eeconfig_init(void) {
+  eeconfig_init_quantum();
 }
 
 /** \brief eeconfig enable
@@ -51,10 +85,14 @@ void eeconfig_enable(void)
  */
 void eeconfig_disable(void)
 {
+<<<<<<< HEAD
 #ifdef STM32F303xC
     EEPROM_format();
 #endif
     eeprom_update_word(EECONFIG_MAGIC, 0xFFFF);
+=======
+    eeprom_update_word(EECONFIG_MAGIC, EECONFIG_MAGIC_NUMBER_OFF);
+>>>>>>> Add Function level EEPROM configuration
 }
 
 /** \brief eeconfig is enabled
@@ -64,6 +102,15 @@ void eeconfig_disable(void)
 bool eeconfig_is_enabled(void)
 {
     return (eeprom_read_word(EECONFIG_MAGIC) == EECONFIG_MAGIC_NUMBER);
+}
+
+/** \brief eeconfig is disabled
+ *
+ * FIXME: needs doc
+ */
+bool eeconfig_is_disabled(void)
+{
+    return (eeprom_read_word(EECONFIG_MAGIC) == EECONFIG_MAGIC_NUMBER_OFF);
 }
 
 /** \brief eeconfig read debug
@@ -123,4 +170,29 @@ uint8_t eeconfig_read_audio(void)      { return eeprom_read_byte(EECONFIG_AUDIO)
  * FIXME: needs doc
  */
 void eeconfig_update_audio(uint8_t val) { eeprom_update_byte(EECONFIG_AUDIO, val); }
+
+
+/** \brief eeconfig read kb
+ *
+ * FIXME: needs doc
+ */
+uint32_t eeconfig_read_kb(void)      { return eeprom_read_dword(EECONFIG_KEYBOARD); }
+/** \brief eeconfig update kb
+ *
+ * FIXME: needs doc
+ */
+
+void eeconfig_update_kb(uint32_t val) { eeprom_update_dword(EECONFIG_KEYBOARD, val); }
+/** \brief eeconfig read user
+ *
+ * FIXME: needs doc
+ */
+uint32_t eeconfig_read_user(void)      { return eeprom_read_dword(EECONFIG_USER); }
+/** \brief eeconfig update user
+ *
+ * FIXME: needs doc
+ */
+void eeconfig_update_user(uint32_t val) { eeprom_update_dword(EECONFIG_USER, val); }
+
+
 #endif

--- a/tmk_core/common/eeconfig.c
+++ b/tmk_core/common/eeconfig.c
@@ -47,18 +47,10 @@ void eeconfig_init_quantum(void) {
   default_layer_state = 0;
   eeprom_update_byte(EECONFIG_KEYMAP,         0);
   eeprom_update_byte(EECONFIG_MOUSEKEY_ACCEL, 0);
-#ifdef BACKLIGHT_ENABLE
   eeprom_update_byte(EECONFIG_BACKLIGHT,      0);
-#endif
-#ifdef AUDIO_ENABLE
   eeprom_update_byte(EECONFIG_AUDIO,             0xFF); // On by default
-#endif
-#if defined(RGBLIGHT_ENABLE) || defined(RGB_MATRIX_ENABLE)
   eeprom_update_dword(EECONFIG_RGBLIGHT,      0);
-#endif
-#ifdef STENO_ENABLE
   eeprom_update_byte(EECONFIG_STENOMODE,      0);
-#endif
 
   eeconfig_init_kb();
 }
@@ -145,7 +137,6 @@ uint8_t eeconfig_read_keymap(void)      { return eeprom_read_byte(EECONFIG_KEYMA
  */
 void eeconfig_update_keymap(uint8_t val) { eeprom_update_byte(EECONFIG_KEYMAP, val); }
 
-#ifdef BACKLIGHT_ENABLE
 /** \brief eeconfig read backlight
  *
  * FIXME: needs doc
@@ -156,9 +147,8 @@ uint8_t eeconfig_read_backlight(void)      { return eeprom_read_byte(EECONFIG_BA
  * FIXME: needs doc
  */
 void eeconfig_update_backlight(uint8_t val) { eeprom_update_byte(EECONFIG_BACKLIGHT, val); }
-#endif
 
-#ifdef AUDIO_ENABLE
+
 /** \brief eeconfig read audio
  *
  * FIXME: needs doc
@@ -169,7 +159,7 @@ uint8_t eeconfig_read_audio(void)      { return eeprom_read_byte(EECONFIG_AUDIO)
  * FIXME: needs doc
  */
 void eeconfig_update_audio(uint8_t val) { eeprom_update_byte(EECONFIG_AUDIO, val); }
-#endif
+
 
 /** \brief eeconfig read kb
  *

--- a/tmk_core/common/eeconfig.c
+++ b/tmk_core/common/eeconfig.c
@@ -8,6 +8,7 @@
 #include "eeprom_stm32.h"
 #endif
 
+extern uint32_t default_layer_state;
 /** \brief eeconfig enable
  *
  * FIXME: needs doc
@@ -30,7 +31,6 @@ void eeconfig_init_kb(void) {
 /*
  * FIXME: needs doc
  */
-__attribute__ ((weak))
 void eeconfig_init_quantum(void) {
 {
 #ifdef STM32F303xC
@@ -44,6 +44,7 @@ void eeconfig_init_quantum(void) {
   eeprom_update_word(EECONFIG_MAGIC,          EECONFIG_MAGIC_NUMBER);
   eeprom_update_byte(EECONFIG_DEBUG,          0);
   eeprom_update_byte(EECONFIG_DEFAULT_LAYER,  0);
+  default_layer_state = 0;
   eeprom_update_byte(EECONFIG_KEYMAP,         0);
   eeprom_update_byte(EECONFIG_MOUSEKEY_ACCEL, 0);
 #ifdef BACKLIGHT_ENABLE
@@ -58,6 +59,9 @@ void eeconfig_init_quantum(void) {
 #ifdef STENO_ENABLE
   eeprom_update_byte(EECONFIG_STENOMODE,      0);
 #endif
+
+  eeconfig_init_kb();
+}
 
 /** \brief eeconfig initialization
  *

--- a/tmk_core/common/eeconfig.c
+++ b/tmk_core/common/eeconfig.c
@@ -15,13 +15,13 @@
 __attribute__ ((weak))
 void eeconfig_init_user(void) {
   // Reset user EEPROM value to blank, rather than to a set value
-  eeprom_update_dword(EECONFIG_USER, 0);
+  eeconfig_update_user(0);
 }
 
 __attribute__ ((weak))
 void eeconfig_init_kb(void) {
   // Reset Keyboard EEPROM value to blank, rather than to a set value
-  eeprom_update_dword(EECONFIG_KEYBOARD, 0);
+  eeconfig_update_kb(0);
 
   eeconfig_init_user();
 }

--- a/tmk_core/common/eeconfig.c
+++ b/tmk_core/common/eeconfig.c
@@ -36,12 +36,6 @@ void eeconfig_init_quantum(void) {
 #ifdef STM32F303xC
     EEPROM_format();
 #endif
-  eeprom_update_word(EECONFIG_MAGIC,          EECONFIG_MAGIC_NUMBER);
-  eeprom_update_byte(EECONFIG_DEBUG,          0);
-  eeprom_update_byte(EECONFIG_DEFAULT_LAYER,  0);
-  eeprom_update_byte(EECONFIG_KEYMAP,         0);
-  eeprom_update_byte(EECONFIG_MOUSEKEY_ACCEL, 0);
-  eeprom_update_word(EECONFIG_MAGIC,          EECONFIG_MAGIC_NUMBER);
   eeprom_update_byte(EECONFIG_DEBUG,          0);
   eeprom_update_byte(EECONFIG_DEFAULT_LAYER,  0);
   default_layer_state = 0;

--- a/tmk_core/common/eeconfig.c
+++ b/tmk_core/common/eeconfig.c
@@ -26,30 +26,31 @@ void eeconfig_init_kb(void) {
   eeconfig_init_user();
 }
 
+__attribute__ ((weak))
+void eeconfig_init_quantum(void) {
+  eeconfig_init_kb();
+}
 
-/** \brief eeconfig initialization
+
+  /** \brief eeconfig initialization
  *
  * FIXME: needs doc
  */
-<<<<<<< HEAD
-void eeconfig_init(void)
+void eeconfig_init_quantum(void) {
 {
 #ifdef STM32F303xC
     EEPROM_format();
 #endif
-    eeprom_update_word(EECONFIG_MAGIC,          EECONFIG_MAGIC_NUMBER);
-    eeprom_update_byte(EECONFIG_DEBUG,          0);
-    eeprom_update_byte(EECONFIG_DEFAULT_LAYER,  0);
-    eeprom_update_byte(EECONFIG_KEYMAP,         0);
-    eeprom_update_byte(EECONFIG_MOUSEKEY_ACCEL, 0);
-=======
-void eeconfig_init_quantum(void) {
   eeprom_update_word(EECONFIG_MAGIC,          EECONFIG_MAGIC_NUMBER);
   eeprom_update_byte(EECONFIG_DEBUG,          0);
   eeprom_update_byte(EECONFIG_DEFAULT_LAYER,  0);
   eeprom_update_byte(EECONFIG_KEYMAP,         0);
   eeprom_update_byte(EECONFIG_MOUSEKEY_ACCEL, 0);
->>>>>>> Add Function level EEPROM configuration
+  eeprom_update_word(EECONFIG_MAGIC,          EECONFIG_MAGIC_NUMBER);
+  eeprom_update_byte(EECONFIG_DEBUG,          0);
+  eeprom_update_byte(EECONFIG_DEFAULT_LAYER,  0);
+  eeprom_update_byte(EECONFIG_KEYMAP,         0);
+  eeprom_update_byte(EECONFIG_MOUSEKEY_ACCEL, 0);
 #ifdef BACKLIGHT_ENABLE
   eeprom_update_byte(EECONFIG_BACKLIGHT,      0);
 #endif
@@ -63,10 +64,13 @@ void eeconfig_init_quantum(void) {
   eeprom_update_byte(EECONFIG_STENOMODE,      0);
 #endif
 
-  eeconfig_init_kb();
-}
-
+/** \brief eeconfig initialization
+ *
+ * FIXME: needs doc
+ */
 void eeconfig_init(void) {
+  eeprom_update_word(EECONFIG_MAGIC,          EECONFIG_MAGIC_NUMBER);
+
   eeconfig_init_quantum();
 }
 
@@ -85,14 +89,10 @@ void eeconfig_enable(void)
  */
 void eeconfig_disable(void)
 {
-<<<<<<< HEAD
 #ifdef STM32F303xC
     EEPROM_format();
 #endif
-    eeprom_update_word(EECONFIG_MAGIC, 0xFFFF);
-=======
     eeprom_update_word(EECONFIG_MAGIC, EECONFIG_MAGIC_NUMBER_OFF);
->>>>>>> Add Function level EEPROM configuration
 }
 
 /** \brief eeconfig is enabled

--- a/tmk_core/common/eeconfig.c
+++ b/tmk_core/common/eeconfig.c
@@ -170,7 +170,7 @@ uint8_t eeconfig_read_audio(void)      { return eeprom_read_byte(EECONFIG_AUDIO)
  * FIXME: needs doc
  */
 void eeconfig_update_audio(uint8_t val) { eeprom_update_byte(EECONFIG_AUDIO, val); }
-
+#endif
 
 /** \brief eeconfig read kb
  *
@@ -195,4 +195,3 @@ uint32_t eeconfig_read_user(void)      { return eeprom_read_dword(EECONFIG_USER)
 void eeconfig_update_user(uint32_t val) { eeprom_update_dword(EECONFIG_USER, val); }
 
 
-#endif

--- a/tmk_core/common/eeconfig.c
+++ b/tmk_core/common/eeconfig.c
@@ -26,16 +26,11 @@ void eeconfig_init_kb(void) {
   eeconfig_init_user();
 }
 
-__attribute__ ((weak))
-void eeconfig_init_quantum(void) {
-  eeconfig_init_kb();
-}
 
-
-  /** \brief eeconfig initialization
- *
+/*
  * FIXME: needs doc
  */
+__attribute__ ((weak))
 void eeconfig_init_quantum(void) {
 {
 #ifdef STM32F303xC

--- a/tmk_core/common/eeconfig.h
+++ b/tmk_core/common/eeconfig.h
@@ -23,21 +23,24 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
 #define EECONFIG_MAGIC_NUMBER                       (uint16_t)0xFEED
+#define EECONFIG_MAGIC_NUMBER_OFF                   (uint16_t)0xFFFF
 
 /* eeprom parameteter address */
 #if !defined(STM32F303xC)
 #define EECONFIG_MAGIC                              (uint16_t *)0
-#define EECONFIG_DEBUG                              (uint8_t *)2
-#define EECONFIG_DEFAULT_LAYER                      (uint8_t *)3
-#define EECONFIG_KEYMAP                             (uint8_t *)4
-#define EECONFIG_MOUSEKEY_ACCEL                     (uint8_t *)5
-#define EECONFIG_BACKLIGHT                          (uint8_t *)6
-#define EECONFIG_AUDIO                              (uint8_t *)7
+#define EECONFIG_DEBUG                               (uint8_t *)2
+#define EECONFIG_DEFAULT_LAYER                       (uint8_t *)3
+#define EECONFIG_KEYMAP                              (uint8_t *)4
+#define EECONFIG_MOUSEKEY_ACCEL                      (uint8_t *)5
+#define EECONFIG_BACKLIGHT                           (uint8_t *)6
+#define EECONFIG_AUDIO                               (uint8_t *)7
 #define EECONFIG_RGBLIGHT                           (uint32_t *)8
 #define EECONFIG_UNICODEMODE                        (uint8_t *)12
 #define EECONFIG_STENOMODE                          (uint8_t *)13
 // EEHANDS for two handed boards
-#define EECONFIG_HANDEDNESS         				(uint8_t *)14
+#define EECONFIG_HANDEDNESS         			        	(uint8_t *)14
+#define EECONFIG_KEYBOARD                          (uint32_t *)15
+#define EECONFIG_USER                              (uint32_t *)19
 
 #else
 /* STM32F3 uses 16byte block. Reconfigure memory map */
@@ -73,8 +76,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
 bool eeconfig_is_enabled(void);
+bool eeconfig_is_disabled(void);
 
 void eeconfig_init(void);
+void eeconfig_init_quantum(void);
+void eeconfig_init_kb(void);
+void eeconfig_init_user(void);
 
 void eeconfig_enable(void);
 
@@ -98,5 +105,10 @@ void eeconfig_update_backlight(uint8_t val);
 uint8_t eeconfig_read_audio(void);
 void eeconfig_update_audio(uint8_t val);
 #endif
+
+uint32_t eeconfig_read_kb(void);
+void eeconfig_update_kb(uint32_t val);
+uint32_t eeconfig_read_user(void);
+void eeconfig_update_user(uint32_t val);
 
 #endif

--- a/tmk_core/common/eeconfig.h
+++ b/tmk_core/common/eeconfig.h
@@ -45,17 +45,19 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #else
 /* STM32F3 uses 16byte block. Reconfigure memory map */
 #define EECONFIG_MAGIC                              (uint16_t *)0
-#define EECONFIG_DEBUG                              (uint8_t *)1
-#define EECONFIG_DEFAULT_LAYER                      (uint8_t *)2
-#define EECONFIG_KEYMAP                             (uint8_t *)3
-#define EECONFIG_MOUSEKEY_ACCEL                     (uint8_t *)4
-#define EECONFIG_BACKLIGHT                          (uint8_t *)5
-#define EECONFIG_AUDIO                              (uint8_t *)6
+#define EECONFIG_DEBUG                               (uint8_t *)1
+#define EECONFIG_DEFAULT_LAYER                       (uint8_t *)2
+#define EECONFIG_KEYMAP                              (uint8_t *)3
+#define EECONFIG_MOUSEKEY_ACCEL                      (uint8_t *)4
+#define EECONFIG_BACKLIGHT                           (uint8_t *)5
+#define EECONFIG_AUDIO                               (uint8_t *)6
 #define EECONFIG_RGBLIGHT                           (uint32_t *)7
-#define EECONFIG_UNICODEMODE                        (uint8_t *)9
+#define EECONFIG_UNICODEMODE                         (uint8_t *)9
 #define EECONFIG_STENOMODE                          (uint8_t *)10
 // EEHANDS for two handed boards
-#define EECONFIG_HANDEDNESS         				(uint8_t *)11
+#define EECONFIG_HANDEDNESS                     		(uint8_t *)11
+#define EECONFIG_KEYBOARD                          (uint32_t *)12
+#define EECONFIG_USER                              (uint32_t *)14
 #endif
 
 /* debug bit */


### PR DESCRIPTION
adds `eeconfig_init_kb` and `eeconfig_init_user` so that both keyboard and user code can add custom handling to the eeprom reset (see customizing functions docs, or rgb_layer keymap for ergodox ez).

Additionally, added a read and update function for the eeprom config, so it can be easily called. 

Used a 32 bit (DWORD) block for keyboard, and a separate one for users.  This is a lot of space for most, but it should be plenty of space to do a LOT of stuff.   This can be reduced easily enough. 

Added a "massive" section to the docs that go through in good detail how to add this to user code.  While this isn't super complex, it isn't super simple either.