### PR TITLE
CA66 Backlighting FIx

### DIFF
--- a/keyboards/ca66/ca66.h
+++ b/keyboards/ca66/ca66.h
@@ -1,5 +1,5 @@
-#ifndef KB_H
-#define KB_H
+#ifndef CA66_H
+#define CA66_H
 
 #include "quantum.h"
 

--- a/keyboards/ca66/config.h
+++ b/keyboards/ca66/config.h
@@ -25,9 +25,8 @@
 
 /* number of backlight levels */
 
-#ifdef BACKLIGHT_PIN
+#define BACKLIGHT_PIN F0
 #define BACKLIGHT_LEVELS 3
-#endif
 
 /* Set 0 if debouncing isn't needed */
 #define DEBOUNCING_DELAY 5

--- a/keyboards/ca66/rules.mk
+++ b/keyboards/ca66/rules.mk
@@ -51,6 +51,6 @@ CONSOLE_ENABLE ?= no	# Console for debug(+400)
 COMMAND_ENABLE ?= no    # Commands for debug and configuration
 SLEEP_LED_ENABLE ?= no  # Breathing sleep LED during USB suspend
 NKRO_ENABLE ?= yes		# USB Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
-BACKLIGHT_ENABLE ?= no  # Enable keyboard backlight functionality
+BACKLIGHT_ENABLE ?= yes  # Enable keyboard backlight functionality
 AUDIO_ENABLE ?= no
 RGBLIGHT_ENABLE ?= yes


### PR DESCRIPTION
Backlight pin was never set. Discovered by u/thebeephaha and traced to be F0.