### PR TITLE
Fix Drashna keymap compile issues

### DIFF
--- a/users/drashna/rules.mk
+++ b/users/drashna/rules.mk
@@ -1,5 +1,9 @@
 
-SRC += drashna.c secrets.c rgb_stuff.c
+SRC += drashna.c rgb_stuff.c
+
+ifneq ("$(wildcard $(USER_PATH)/secrets.c)","")
+  SRC += secrets.c
+endif
 
 ifeq ($(strip $(TAP_DANCE_ENABLE)), yes)
   SRC += tap_dances.c


### PR DESCRIPTION
By checking to see if secret.c exists before actually trying to add it