### PR TITLE
Fix helix:led_test build break

### DIFF
--- a/keyboards/helix/rev2/keymaps/led_test/keymap.c
+++ b/keyboards/helix/rev2/keymaps/led_test/keymap.c
@@ -32,7 +32,7 @@ extern uint8_t is_master;
 #define _DVORAK 2
 #define _LOWER 3
 #define _RAISE 4
-#define _ADJUST 16
+#define _ADJUST 6
 
 enum custom_keycodes {
   QWERTY = SAFE_RANGE,
@@ -513,6 +513,12 @@ void music_scale_user(void)
 #ifdef SSD1306OLED
 
 void matrix_scan_user(void) {
+    static int scan_count = 0;
+    if( scan_count == 2 ) {
+      rgblight_enable();
+      rgblight_mode(35);
+    }
+    if( scan_count < 3 ) scan_count ++;
      iota_gfx_task();  // this is what updates the display continuously
 }
 

--- a/keyboards/helix/rev2/keymaps/led_test/rgblight.h
+++ b/keyboards/helix/rev2/keymaps/led_test/rgblight.h
@@ -17,7 +17,7 @@
 #define RGBLIGHT_H
 
 #ifdef RGBLIGHT_ANIMATIONS
-	#define RGBLIGHT_MODES 5
+	#define RGBLIGHT_MODES 35
 #else
 	#define RGBLIGHT_MODES 1
 #endif
@@ -74,14 +74,16 @@
 #include "ws2812.h"
 #endif
 #include "rgblight_types.h"
+#include "rgblight_list.h"
 
 extern LED_TYPE led[RGBLED_NUM];
 
-extern const uint16_t RGBLED_BREATHING_INTERVALS[4] PROGMEM; //modify for led_test
+extern const uint8_t RGBLED_BREATHING_INTERVALS[4] PROGMEM;
 extern const uint8_t RGBLED_RAINBOW_MOOD_INTERVALS[3] PROGMEM;
 extern const uint8_t RGBLED_RAINBOW_SWIRL_INTERVALS[3] PROGMEM;
 extern const uint8_t RGBLED_SNAKE_INTERVALS[3] PROGMEM;
 extern const uint8_t RGBLED_KNIGHT_INTERVALS[3] PROGMEM;
+extern const uint16_t RGBLED_RGBCYCLIC_INTERVALS[1] PROGMEM;
 
 typedef union {
   uint32_t raw;
@@ -91,6 +93,7 @@ typedef union {
     uint16_t hue     :9;
     uint8_t  sat     :8;
     uint8_t  val     :8;
+    uint8_t  speed   :8;//EECONFIG needs to be increased to support this
   };
 } rgblight_config_t;
 
@@ -112,6 +115,8 @@ void rgblight_increase_sat(void);
 void rgblight_decrease_sat(void);
 void rgblight_increase_val(void);
 void rgblight_decrease_val(void);
+void rgblight_increase_speed(void);
+void rgblight_decrease_speed(void);
 void rgblight_sethsv(uint16_t hue, uint8_t sat, uint8_t val);
 uint16_t rgblight_get_hue(void);
 uint8_t rgblight_get_sat(void);
@@ -125,9 +130,21 @@ void eeconfig_update_rgblight(uint32_t val);
 void eeconfig_update_rgblight_default(void);
 void eeconfig_debug_rgblight(void);
 
+void rgb_matrix_increase(void);
+void rgb_matrix_decrease(void);
+
 void sethsv(uint16_t hue, uint8_t sat, uint8_t val, LED_TYPE *led1);
 void setrgb(uint8_t r, uint8_t g, uint8_t b, LED_TYPE *led1);
+
 void rgblight_sethsv_noeeprom(uint16_t hue, uint8_t sat, uint8_t val);
+void rgblight_mode_noeeprom(uint8_t mode);
+void rgblight_toggle_noeeprom(void);
+void rgblight_enable_noeeprom(void);
+void rgblight_disable_noeeprom(void);
+
+void rgblight_sethsv_eeprom_helper(uint16_t hue, uint8_t sat, uint8_t val, bool write_to_eeprom);
+void rgblight_mode_eeprom_helper(uint8_t mode, bool write_to_eeprom);
+
 
 #define EZ_RGB(val) rgblight_show_solid_color((val >> 16) & 0xFF, (val >> 8) & 0xFF, val & 0xFF)
 void rgblight_show_solid_color(uint8_t r, uint8_t g, uint8_t b);
@@ -144,5 +161,6 @@ void rgblight_effect_rainbow_swirl(uint8_t interval);
 void rgblight_effect_snake(uint8_t interval);
 void rgblight_effect_knight(uint8_t interval);
 void rgblight_effect_christmas(void);
+void rgblight_effect_rgbcyclic(void);
 
 #endif


### PR DESCRIPTION
#2922 cause helix:led_test build break.

This PullRequest fix build break.
 * copy new quantum/rgblight.[ch] into keyboards/helix/rev2/keymaps/led_test/
 * add new rgblight mode 35 (RGB cyclic) into local rgblight.[ch]
