### PR TITLE
Fix KC_P00 macro for ortho_5x4 layout

### DIFF
--- a/layouts/default/ortho_5x4/default_ortho_5x4/keymap.c
+++ b/layouts/default/ortho_5x4/default_ortho_5x4/keymap.c
@@ -12,7 +12,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         switch(keycode) {
             case KC_P00:
                 // types Numpad 0 twice
-                SEND_STRING(SS_TAP(X_P0) SS_TAP(X_P0));
+                SEND_STRING(SS_TAP(X_KP_0) SS_TAP(X_KP_0));
                 return false;
         }
     }


### PR DESCRIPTION
So today I learned that the [Macros feature](https://docs.qmk.fm/#/feature_macros) doesn't support the short-form keycodes in `SEND_STRING`, only the long form (*e.g.* `SS_TAP(X_ENTER)` works, but `SS_TAP(X_ENT)` does not).

That being the case, this PR will fix the custom "double-zero" macro for ortho_5x4 boards (the only place where it's used).