### PR TITLE
Felix: Refactor, Rules, and Configurator Support

### DIFF
--- a/keyboards/felix/felix.h
+++ b/keyboards/felix/felix.h
@@ -3,7 +3,7 @@
 
 #include "quantum.h"
 
-#define KEYMAP( \
+#define LAYOUT_ortho_5x4( \
     K000, K001, K002, K003, \
     K100, K101, K102, K103, \
     K200, K201, K202, K203, \
@@ -16,5 +16,7 @@
     { K300, K301, K302, K303 }, \
     { K400, K401, K402, K403 }  \
 }
+
+#define LAYOUT LAYOUT_ortho_5x4
 
 #endif

--- a/keyboards/felix/info.json
+++ b/keyboards/felix/info.json
@@ -1,0 +1,12 @@
+{
+  "keyboard_name": "Felix",
+  "url": "",
+  "maintainer": "qmk",
+  "width": 4,
+  "height": 5,
+  "layouts": {
+    "LAYOUT": {
+      "layout": [{"label":"K000", "x":0, "y":0}, {"label":"K001", "x":1, "y":0}, {"label":"K002", "x":2, "y":0}, {"label":"K003", "x":3, "y":0}, {"label":"K100", "x":0, "y":1}, {"label":"K101", "x":1, "y":1}, {"label":"K102", "x":2, "y":1}, {"label":"K103", "x":3, "y":1}, {"label":"K200", "x":0, "y":2}, {"label":"K201", "x":1, "y":2}, {"label":"K202", "x":2, "y":2}, {"label":"K203", "x":3, "y":2}, {"label":"K300", "x":0, "y":3}, {"label":"K301", "x":1, "y":3}, {"label":"K302", "x":2, "y":3}, {"label":"K303", "x":3, "y":3}, {"label":"K400", "x":0, "y":4}, {"label":"K401", "x":1, "y":4}, {"label":"K402", "x":2, "y":4}, {"label":"K403", "x":3, "y":4}]
+    }
+  }
+}

--- a/keyboards/felix/keymaps/default/keymap.c
+++ b/keyboards/felix/keymaps/default/keymap.c
@@ -1,20 +1,20 @@
-#include "felix.h"
-#include "action_layer.h"
+#include QMK_KEYBOARD_H
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
-    KEYMAP(
-        KC_NLCK, KC_PSLS, KC_PAST, KC_PMNS,
-        KC_P7,   KC_P8,   KC_P9,   KC_PPLS,
-        KC_P4,   KC_P5,   KC_P6,   KC_HOME,
-        KC_P1,   KC_P2,   KC_P3,   KC_END,
-        KC_P0,   KC_PEQL, KC_PDOT, KC_PENT),
+  LAYOUT(
+    KC_NLCK, KC_PSLS, KC_PAST, KC_PMNS,
+    KC_P7,   KC_P8,   KC_P9,   KC_PPLS,
+    KC_P4,   KC_P5,   KC_P6,   KC_HOME,
+    KC_P1,   KC_P2,   KC_P3,   KC_END,
+    KC_P0,   KC_PEQL, KC_PDOT, KC_PENT
+  ),
 
 };
 
 void persistant_default_layer_set(uint16_t default_layer) {
 }
-  
+
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
   switch (keycode) {
   }

--- a/keyboards/felix/rules.mk
+++ b/keyboards/felix/rules.mk
@@ -54,3 +54,5 @@ NKRO_ENABLE = yes		# USB Nkey Rollover - if this doesn't work, see here: https:/
 BACKLIGHT_ENABLE = no  # Enable keyboard backlight functionality
 AUDIO_ENABLE = no
 RGBLIGHT_ENABLE = no
+
+LAYOUTS = ortho_5x4


### PR DESCRIPTION
Refactor:

- `KEYMAP` renamed `LAYOUT_ortho_5x4`
  - alias `LAYOUT`
- default `keymap.c` now uses `QMK_KEYBOARD_H` include

Rules:

- added `LAYOUTS = ortho_5x4` to rules.mk

Configurator:

- added `info.json`

