### PR TITLE
Fourier: Refactor and readme updates

### DIFF
--- a/keyboards/fourier/keymaps/default/keymap.c
+++ b/keyboards/fourier/keymaps/default/keymap.c
@@ -1,6 +1,4 @@
-#include "fourier.h"
-#include "action_layer.h"
-#include "eeconfig.h"
+#include QMK_KEYBOARD_H
 
 extern keymap_config_t keymap_config;
 
@@ -16,61 +14,33 @@ enum custom_keycodes {
   QWERTY = SAFE_RANGE,
 };
 
-#define KC_ KC_TRNS
 #define _______ KC_TRNS
 #define XXXXXXX KC_NO
 #define KC_FN1 MO(_FN1)
 #define KC_FN2 MO(_FN2)
 #define KC_SPFN1 LT(_FN1, KC_SPACE)
-#define KC_SPFN2 LT(_FN2, KC_SPACE)
-#define KC_BSFN1 LT(_FN1, KC_BSPC)
 #define KC_BSFN2 LT(_FN2, KC_BSPC)
-#define KC_RST RESET
-#define KC_DBUG DEBUG
-#define KC_RTOG RGB_TOG
-#define KC_RMOD RGB_MOD
-#define KC_RHUI RGB_HUI
-#define KC_RHUD RGB_HUD
-#define KC_RSAI RGB_SAI
-#define KC_RSAD RGB_SAD
-#define KC_RVAI RGB_VAI
-#define KC_RVAD RGB_VAD
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-  [_BASE] = LAYOUT_kc(
- //,----+----+----+----+----+----|----+----+----+----+----+----+----.
-    ESC , Q  , W  , E  , R  , T  , Y  , U  , I  , O  , P  ,DEL ,BSPC,
- //|----`----`----`----`----`----|----`----`----`----`----`----`----|
-    TAB  , A  , S  , D  , F  , G  , H  , J  , K  , L  ,QUOT, ENTER  ,
- //|-----`----`----`----`----`----|----`----`----`----`----`--------|
-    LSFT   , Z  , X  , C  , V  , B  , N  , M  ,COMM,DOT ,SLSH, RSFT ,
- //|-------`----`----`----`----`----|----`----`----`----`----`------|
-    LCTL ,LALT,LGUI ,FN1 , SPFN1  ,  BSFN2 ,RGUI ,RALT , FN2 , RCTL
- //`-----+----+-----+----+--------|--------+-----+-----+-----+------'
+  [_BASE] = LAYOUT(
+    KC_ESC,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_DEL,  KC_BSPC,
+    KC_TAB,  KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_QUOT,          KC_ENT,
+    KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,             KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT,
+    KC_LCTL, KC_LALT, KC_LGUI, KC_FN1,  KC_SPFN1,         KC_BSFN2,                  KC_RGUI, KC_RALT, KC_FN2,  KC_RCTL
   ),
 
-  [_FN1] = LAYOUT_kc(
- //,----+----+----+----+----+----|----+----+----+----+----+----+----.
-    GRV , 1  , 2  , 3  , 4  , 5  , 6  , 7  , 8  , 9  , 0  ,MINS,EQL ,
- //|----`----`----`----`----`----|----`----`----`----`----`----`----|
-    RST  ,RHUI,RSAI,RVAI,VOLU,LBRC,RBRC, 4  , 5  , 6  ,SCLN,        ,
- //|-----`----`----`----`----`----|----`----`----`----`----`--------|
-    RMOD   ,RHUD,RSAD,RVAD,VOLD,LCBR,RCBR, 1  , 2  , 3  , UP ,      ,
- //|-------`----`----`----`----`----|----`----`----`----`----`------|
-    RTOG ,    ,     ,    ,        ,  DEL   ,  0  ,LEFT ,DOWN , RGHT
- //`-----+----+-----+----+--------|--------+-----+-----+-----+------'
+  [_FN1] = LAYOUT(
+    KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,
+    RESET,   RGB_HUI, RGB_SAI, RGB_VAI, KC_VOLU, KC_LBRC, KC_RBRC, KC_4,    KC_5,    KC_6,    KC_SCLN,          _______,
+    RGB_MOD, RGB_HUD, RGB_SAD, RGB_VAD, KC_VOLD, KC_LCBR, KC_RCBR,          KC_1,    KC_2,    KC_3,    KC_UP,   _______,
+    RGB_TOG, _______, _______, _______, _______,          KC_DEL,                    KC_0,    KC_LEFT, KC_DOWN, KC_RGHT
   ),
 
-  [_FN2] = LAYOUT_kc(
- //,----+----+----+----+----+----|----+----+----+----+----+----+----.
-    TILD,EXLM, AT ,HASH,DLR ,PERC,CIRC,AMPR,ASTR,LPRN,RPRN,UNDS,PLUS,
- //|----`----`----`----`----`----|----`----`----`----`----`----`----|
-         ,    ,    ,INS ,PGUP,HOME,    ,    ,    ,    ,COLN,        ,
- //|-----`----`----`----`----`----|----`----`----`----`----`--------|
-           ,    ,    ,DEL ,PGDN,END ,    ,    ,    ,    ,    ,      ,
- //|-------`----`----`----`----`----|----`----`----`----`----`------|
-         ,    ,     ,    ,  DEL   ,        ,     ,     ,     ,
- //`-----+----+-----+----+--------|--------+-----+-----+-----+------'
+  [_FN2] = LAYOUT(
+    KC_TILD, KC_EXLM, KC_AT,   KC_HASH, KC_DLR,  KC_PERC, KC_CIRC, KC_AMPR, KC_ASTR, KC_LPRN, KC_RPRN, KC_UNDS, KC_PLUS,
+    _______, _______, _______, KC_INS,  KC_PGUP, KC_HOME, _______, _______, _______, _______, KC_COLN,          _______,
+    _______, _______, _______, KC_DEL,  KC_PGDN, KC_END,  _______,          _______, _______, _______, _______, _______,
+    _______, _______, _______, _______, KC_DEL,           _______,                   _______, _______, _______, _______
   )
 
 };

--- a/keyboards/fourier/keymaps/valgrahf/keymap.c
+++ b/keyboards/fourier/keymaps/valgrahf/keymap.c
@@ -1,6 +1,4 @@
-#include "fourier.h"
-#include "action_layer.h"
-#include "eeconfig.h"
+#include QMK_KEYBOARD_H
 
 extern keymap_config_t keymap_config;
 
@@ -66,7 +64,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  //|-----`----`----`----`----`----|----`----`----`----`----`--------|
            ,RHUD,RSAD,RVAD,    ,    ,VOLU,VOLD,    ,    , UP ,      ,
  //|-------`----`----`----`----`----|----`----`----`----`----`------|
-         ,RTOG,RMOD ,    ,        ,        ,     , LEFT, DOWN, RIGHT 
+         ,RTOG,RMOD ,    ,        ,        ,     , LEFT, DOWN, RIGHT
  //`-----+----+-----+-------------|--------+-----+-----+-----+------'
   )
 

--- a/keyboards/fourier/readme.md
+++ b/keyboards/fourier/readme.md
@@ -5,7 +5,7 @@ A split 40% staggered keyboard made and sold by Keebio. [More info at Keebio](ht
 
 Keyboard Maintainer: [Bakingpy/nooges](https://github.com/nooges)  
 Hardware Supported: Pro Micro  
-Hardware Availability: [Keebio](https://keeb.io)  
+Hardware Availability: [Keebio](https://keeb.io/collections/frontpage/products/fourier-40-split-staggered-keyboard)  
 
 Make example for this keyboard (after setting up your build environment):
 


### PR DESCRIPTION
Readme:

- Added direct product link

Refactor:

- all keymaps now use `QMK_KEYBOARD_H` include
- default keymap no longer uses `LAYOUT_kc` macro
