### PR TITLE
Hadron: Readme, Refactor, and Configurator support

### DIFF
--- a/keyboards/hadron/hadron.h
+++ b/keyboards/hadron/hadron.h
@@ -11,7 +11,7 @@
 #include "quantum.h"
 
 
-#define KEYMAP( \
+#define LAYOUT( \
     K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, \
     K10, K11, K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, K1C, K1D, K1E, \
     K20, K21, K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B, K2C, K2D, K2E, \

--- a/keyboards/hadron/info.json
+++ b/keyboards/hadron/info.json
@@ -1,0 +1,13 @@
+{
+  "keyboard_name": "Hadron", 
+  "url": "", 
+  "maintainer": "qmk", 
+  "width": 15, 
+  "height": 5, 
+  "layouts": {
+    "LAYOUT": {
+      "key_count": 72,
+      "layout": [{"label":"K00", "x":0, "y":0}, {"label":"K01", "x":1, "y":0}, {"label":"K02", "x":2, "y":0}, {"label":"K03", "x":3, "y":0}, {"label":"K04", "x":4, "y":0}, {"label":"K05", "x":5, "y":0}, {"label":"K06", "x":6, "y":0}, {"label":"K07", "x":7, "y":0}, {"label":"K08", "x":8, "y":0}, {"label":"K09", "x":9, "y":0}, {"label":"K0A", "x":10, "y":0}, {"label":"K0B", "x":11, "y":0}, {"label":"K10", "x":0, "y":1}, {"label":"K11", "x":1, "y":1}, {"label":"K12", "x":2, "y":1}, {"label":"K13", "x":3, "y":1}, {"label":"K14", "x":4, "y":1}, {"label":"K15", "x":5, "y":1}, {"label":"K16", "x":6, "y":1}, {"label":"K17", "x":7, "y":1}, {"label":"K18", "x":8, "y":1}, {"label":"K19", "x":9, "y":1}, {"label":"K1A", "x":10, "y":1}, {"label":"K1B", "x":11, "y":1}, {"label":"K1C", "x":12, "y":1}, {"label":"K1D", "x":13, "y":1}, {"label":"K1E", "x":14, "y":1}, {"label":"K20", "x":0, "y":2}, {"label":"K21", "x":1, "y":2}, {"label":"K22", "x":2, "y":2}, {"label":"K23", "x":3, "y":2}, {"label":"K24", "x":4, "y":2}, {"label":"K25", "x":5, "y":2}, {"label":"K26", "x":6, "y":2}, {"label":"K27", "x":7, "y":2}, {"label":"K28", "x":8, "y":2}, {"label":"K29", "x":9, "y":2}, {"label":"K2A", "x":10, "y":2}, {"label":"K2B", "x":11, "y":2}, {"label":"K2C", "x":12, "y":2}, {"label":"K2D", "x":13, "y":2}, {"label":"K2E", "x":14, "y":2}, {"label":"K30", "x":0, "y":3}, {"label":"K31", "x":1, "y":3}, {"label":"K32", "x":2, "y":3}, {"label":"K33", "x":3, "y":3}, {"label":"K34", "x":4, "y":3}, {"label":"K35", "x":5, "y":3}, {"label":"K36", "x":6, "y":3}, {"label":"K37", "x":7, "y":3}, {"label":"K38", "x":8, "y":3}, {"label":"K39", "x":9, "y":3}, {"label":"K3A", "x":10, "y":3}, {"label":"K3B", "x":11, "y":3}, {"label":"K3C", "x":12, "y":3}, {"label":"K3D", "x":13, "y":3}, {"label":"K3E", "x":14, "y":3}, {"label":"K40", "x":0, "y":4}, {"label":"K41", "x":1, "y":4}, {"label":"K42", "x":2, "y":4}, {"label":"K43", "x":3, "y":4}, {"label":"K44", "x":4, "y":4}, {"label":"K45", "x":5, "y":4}, {"label":"K46", "x":6, "y":4}, {"label":"K47", "x":7, "y":4}, {"label":"K48", "x":8, "y":4}, {"label":"K49", "x":9, "y":4}, {"label":"K4A", "x":10, "y":4}, {"label":"K4B", "x":11, "y":4}, {"label":"K4C", "x":12, "y":4}, {"label":"K4D", "x":13, "y":4}, {"label":"K4E", "x":14, "y":4}]
+    }
+  }
+}

--- a/keyboards/hadron/keymaps/default/keymap.c
+++ b/keyboards/hadron/keymaps/default/keymap.c
@@ -1,7 +1,4 @@
-#include "hadron.h"
-#include "bootloader.h"
-#include "action_layer.h"
-#include "eeconfig.h"
+#include QMK_KEYBOARD_H
 #include "LUFA/Drivers/Peripheral/TWI.h"
 #ifdef AUDIO_ENABLE
   #include "audio.h"
@@ -79,7 +76,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |  `   | Ctrl | Alt  | GUI  |Lower |Space |   0  |   .  |   =  |Space |Raise | Left | Down |  Up  |Right |
  * `--------------------------------------------------------------------------------------------------------'
  */
-[_QWERTY] = KEYMAP(
+[_QWERTY] = LAYOUT(
   KC_ESC,   KC_F1,    KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,    KC_F9,   KC_F10,  KC_DEL,\
   KC_TAB,   KC_Q,     KC_W,    KC_E,    KC_R,    KC_T,    KC_P7,   KC_P8,   KC_P9,    KC_Y,    KC_U,    KC_I,   KC_O,    KC_P,     KC_BSPC, \
   KC_CAPS,  KC_A,     KC_S,    KC_D,    KC_F,    KC_G,    KC_P4,   KC_P5,   KC_P6,    KC_H,    KC_J,    KC_K,   KC_L,LT_MC(KC_SCLN), KC_QUOT, \
@@ -100,7 +97,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |   `  | Ctrl | Alt  | GUI  |Lower |Space |   0  |   .  |   =  |Space |Raise | Left | Down |  Up  |Right |
  * `--------------------------------------------------------------------------------------------------------'
  */
-[_COLEMAK] = KEYMAP(
+[_COLEMAK] = LAYOUT(
   KC_ESC,   KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,    KC_F9,   KC_F10, KC_DEL,\
   KC_TAB,   KC_Q,    KC_W,    KC_F,    KC_P,    KC_G,    KC_P7,   KC_P8,   KC_P9,    KC_J,    KC_L,    KC_U,    KC_Y,    KC_SCLN,  KC_BSPC, \
   KC_LCTRL, KC_A,    KC_R,    KC_S,    KC_T,    KC_D,    KC_P4,   KC_P5,   KC_P6,    KC_H,    KC_N,    KC_E,    KC_I, LT_MC(KC_O), KC_QUOT, \
@@ -121,7 +118,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |   `  | Ctrl | Alt  | GUI  |Lower |Space |   0  |   .  |   =  |Space |Raise | Left | Down |  Up  |Right |
  * `--------------------------------------------------------------------------------------------------------'
  */
-[_DVORAK] = KEYMAP(
+[_DVORAK] = LAYOUT(
   KC_ESC,   KC_F1,    KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,    KC_F9,   KC_F10, KC_DEL,\
   KC_TAB,   KC_QUOT,  KC_COMM, KC_DOT,  KC_P,    KC_Y,    KC_P7,   KC_P8,   KC_P9,    KC_F,    KC_G,   KC_C,    KC_R,    KC_L,     KC_BSPC, \
   KC_LCTL,  KC_A,     KC_O,    KC_E,    KC_U,    KC_I,    KC_P4,   KC_P5,   KC_P6,    KC_D,    KC_H,   KC_T,    KC_N, LT_MC(KC_S), KC_SLSH, \
@@ -142,7 +139,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |      |      |      |      |      |      |      |      |      |      |      | Next | Vol- | Vol+ | Play |
  * `--------------------------------------------------------------------------------------------------------'
  */
-[_LOWER] = KEYMAP(
+[_LOWER] = LAYOUT(
   KC_TILD, KC_EXLM, KC_AT,   KC_HASH, KC_DLR,  KC_PERC, KC_CIRC, KC_AMPR, KC_ASTR, KC_LPRN, KC_RPRN, KC_BSPC, \
   KC_TILD, KC_EXLM, KC_AT,   KC_HASH, KC_DLR,  KC_PERC, _______, _______, _______, KC_CIRC, KC_AMPR, KC_ASTR,  KC_LPRN, KC_RPRN, KC_DEL, \
   _______, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   _______, _______, _______, KC_F6,   KC_UNDS, KC_PLUS,  KC_LBRC, KC_RBRC, KC_PIPE, \
@@ -163,7 +160,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |      |      |      |      |      |      |      |      |      |      |      | Next | Vol- | Vol+ | Play |
  * `--------------------------------------------------------------------------------------------------------'
  */
-[_RAISE] = KEYMAP(
+[_RAISE] = LAYOUT(
   KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_BSPC, \
   KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    _______, _______, _______, KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_DEL, \
   KC_DEL,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   _______, _______, _______, KC_F6,   KC_MINS, KC_EQL,  KC_LBRC, KC_RBRC, KC_BSLS, \
@@ -185,7 +182,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * `--------------------------------------------------------------------------------------------------------'
  */
 
-[_MOUSECURSOR] = KEYMAP(
+[_MOUSECURSOR] = LAYOUT(
   KC_ACL0, KC_ACL1, KC_ACL2, _______, _______, _______, _______, _______, _______, _______, _______, _______, \
   _______, _______, _______, _______, _______, _______, _______, _______, KC_HOME, KC_PGUP, KC_WH_L, KC_MS_U, KC_WH_R,DEMOMACRO,_______, \
   _______, _______, _______, _______, _______, _______, _______, _______, KC_END , KC_PGDN, KC_MS_L, KC_MS_D, KC_MS_R, _______, _______, \
@@ -206,7 +203,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |      |      |      |      |      |      |      |      |      |      |      |      |      |      |      |
  * `--------------------------------------------------------------------------------------------------------'
  */
-[_ADJUST] = KEYMAP(
+[_ADJUST] = LAYOUT(
   KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12, \
   RESET,   RGB_TOG, RGB_MOD, RGB_HUI, RGB_HUD, RGB_SAI, RGB_SAD, RGB_VAI, RGB_VAD, _______, _______, _______, _______, _______, KC_DEL, \
   _______, _______, _______, AU_ON,   AU_OFF,  AG_NORM, _______, _______, _______, AG_SWAP, QWERTY,  COLEMAK, _______,  _______,  _______, \

--- a/keyboards/hadron/keymaps/side_numpad/keymap.c
+++ b/keyboards/hadron/keymaps/side_numpad/keymap.c
@@ -1,7 +1,4 @@
-#include "hadron.h"
-#include "bootloader.h"
-#include "action_layer.h"
-#include "eeconfig.h"
+#include QMK_KEYBOARD_H
 #include "LUFA/Drivers/Peripheral/TWI.h"
 #ifdef AUDIO_ENABLE
   #include "audio.h"
@@ -81,7 +78,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |   ~  | Ctrl | Alt  | GUI  |Lower |Space |Space |Raise | RAlt | Ins  |  Del |NumLay|   0  |   .  |  ENT |
  * `--------------------------------------------------------------------------------------------------------'
  */
-[_QWERTY] = KEYMAP(
+[_QWERTY] = LAYOUT(
   KC_ESC,    KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,          KC_MINS,\
   KC_TAB,    KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,           KC_BSPC,    KC_P7,   KC_P8,   KC_P9, \
   KC_CAPS,   KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    LT_MC(KC_SCLN), CTL_ENT,    KC_P4,   KC_P5,   KC_P6, \
@@ -102,7 +99,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |      |      |      |      |      |      |      |      | Next | Vol- | Vol+ | Play |      |      |      |
  * `--------------------------------------------------------------------------------------------------------'
  */
-[_LOWER] = KEYMAP(
+[_LOWER] = LAYOUT(
   KC_ESC,    KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,      KC_NO,      KC_NO,   KC_NO,   KC_NO,   KC_NO, \
   KC_1,       KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,       KC_8,       KC_9,    KC_0,  KC_GRV, KC_BSLS, _______, _______, _______, \
   KC_CAPS,   KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,    KC_UNDS,     KC_EQL, KC_LBRC, KC_RBRC, KC_PIPE, _______, _______, _______, \
@@ -123,7 +120,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |      |      |      |      |      |Space |   0  |      | Left | Down | Right|      |      |      |      |
  * `--------------------------------------------------------------------------------------------------------'
  */
-[_RAISE] = KEYMAP(
+[_RAISE] = LAYOUT(
   KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,   KC_F6, KC_F7,   KC_F8,      KC_F9,  KC_F10,   KC_F11,  KC_F12, \
   KC_1,    KC_2,    KC_3,    KC_4,     KC_5,        KC_6,  KC_7,    KC_8,       KC_9,    KC_0,  KC_PLUS, KC_BSLS, _______, _______, _______, \
   _______, KC_A,    KC_UP,   KC_D,     KC_PSCR,  _______,  KC_4,    KC_5,       KC_6, KC_PAST,  KC_COLN, KC_QUOT, _______, _______, _______, \
@@ -144,7 +141,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |      |      |      |      |      |      |      |      | Next | Vol- | Vol+ | Play |      |      |      |
  * `--------------------------------------------------------------------------------------------------------'
  */
-[_FNLAYER] = KEYMAP(
+[_FNLAYER] = LAYOUT(
   _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,   _______, _______,\
   _______, KC_EXLM,   KC_AT, KC_HASH,  KC_DLR, KC_PERC, KC_CIRC,   KC_AMPR,    KC_ASTR, KC_LPRN, KC_RPRN, KC_PLUS, _______, _______, _______, \
   _______,   KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_UNDS,     KC_EQL, KC_LBRC, KC_RBRC, KC_QUOT, _______, _______, _______, \
@@ -165,7 +162,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |      |      |      |      |      |      |      |      |      |      |      | Exit | Left | Down | Rght |
  * `--------------------------------------------------------------------------------------------------------'
  */
-[_NUMLAY] = KEYMAP(
+[_NUMLAY] = LAYOUT(
   _______, _______, _______, _______, _______, _______,  _______, _______, _______, _______, _______, _______,\
   _______, _______, _______, _______, _______, _______,  _______, _______, _______, _______, _______, _______, KC_INS,  KC_HOME,  KC_PGUP,   \
   _______, _______, _______, _______, _______, _______,  _______, _______, _______, _______, _______, _______, KC_DEL,   KC_END,  KC_PGDN,   \
@@ -187,7 +184,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * `--------------------------------------------------------------------------------------------------------'
  */
 
-[_MOUSECURSOR] = KEYMAP(
+[_MOUSECURSOR] = LAYOUT(
   _______, KC_ACL0, KC_ACL1, KC_ACL2, _______, _______, _______, _______, _______, _______,   _______, _______,\
   _______, _______, _______, _______, _______, KC_HOME, KC_PGUP, KC_WH_L, KC_MS_U, KC_WH_R, DEMOMACRO, _______, _______, _______, _______, \
   _______, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, KC_END , KC_PGDN, KC_MS_L, KC_MS_D, KC_MS_R,   _______, _______, _______, _______, _______, \
@@ -209,7 +206,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |      |      |      |      |      |      |      |      |      |      |      |      |      |      |      |
  * `--------------------------------------------------------------------------------------------------------'
  */
-[_ADJUST] = KEYMAP(
+[_ADJUST] = LAYOUT(
   RESET,     KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO, KC_VOLD, KC_VOLU, KC_MUTE, \
   _______, RGB_TOG, RGB_MOD, RGB_HUI, RGB_HUD, RGB_SAI, RGB_SAD, RGB_VAI, RGB_VAD, _______, _______,  KC_DEL, _______, _______, _______, \
   _______, _______, _______,   AU_ON,  AU_OFF, AG_NORM, AG_SWAP,  QWERTY, _______, _______, _______, _______, _______, _______, _______, \

--- a/keyboards/hadron/readme.md
+++ b/keyboards/hadron/readme.md
@@ -1,1 +1,14 @@
+# Hadron
 
+![Hadron](https://i.imgur.com/aFbvV08.jpg)
+
+A low-profile Cherry ML ortholinear build.
+
+Keyboard Maintainer: [ishtob](https://github.com/ishtob), [QMK](https://github.com/qmk)  
+Hardware Supported: Hadron PCB rev0, rev2  
+
+Make example for this keyboard (after setting up your build environment):
+
+    make hadron:default
+
+See [build environment setup](https://docs.qmk.fm/build_environment_setup.html) then the [make instructions](https://docs.qmk.fm/make_instructions.html) for more information.


### PR DESCRIPTION
# Readme

- Fleshed out a readme file

# Refactor

- matrix `KEYMAP` renamed to `LAYOUT`
- all keymaps now use `#include QMK_KEYBOARD_H` and new matrix name

# Configurator

- added `info.json`
