### PR TITLE
Planck Light info.json fix

### DIFF
--- a/keyboards/planck/light/info.json
+++ b/keyboards/planck/light/info.json
@@ -1,4 +1,4 @@
 {
   "keyboard_name": "Planck Light",
-  "keyboard_folder": "planck/light",
+  "keyboard_folder": "planck/light"
 }


### PR DESCRIPTION
Tiny (one byte!) commit that eliminates the last Configurator API error.

I feel kind of ridiculous for submitting this.
