### PR TITLE
Fixed no-op ifndef

### DIFF
--- a/keyboards/ergodox_ez/ergodox_ez.h
+++ b/keyboards/ergodox_ez/ergodox_ez.h
@@ -33,7 +33,7 @@ uint8_t ergodox_left_leds_update(void);
 #ifndef LED_BRIGHTNESS_LO
 #define LED_BRIGHTNESS_LO       15
 #endif
-#ifndef LED_BRIGHTNESS_LO
+#ifndef LED_BRIGHTNESS_HI
 #define LED_BRIGHTNESS_HI       255
 #endif
 


### PR DESCRIPTION
Noticed this while scrolling through.  It's defined correctly in config.h - which is probably why it being incorrect here doesn't break anything.