### PR TITLE
Disable JTAG via keyboard_init on AT90USB and ATmega32U4 boards

### DIFF
--- a/quantum/matrix.c
+++ b/quantum/matrix.c
@@ -148,12 +148,6 @@ uint8_t matrix_cols(void) {
 
 void matrix_init(void) {
 
-    // To use PORTF disable JTAG with writing JTD bit twice within four cycles.
-    #if  (defined(__AVR_AT90USB1286__) || defined(__AVR_AT90USB1287__) || defined(__AVR_ATmega32U4__))
-        MCUCR |= _BV(JTD);
-        MCUCR |= _BV(JTD);
-    #endif
-
     // initialize row and col
 #if (DIODE_DIRECTION == COL2ROW)
     unselect_rows();

--- a/tmk_core/common/keyboard.c
+++ b/tmk_core/common/keyboard.c
@@ -148,6 +148,11 @@ bool is_keyboard_master(void) {
  */
 void keyboard_init(void) {
     timer_init();
+// To use PORTF disable JTAG with writing JTD bit twice within four cycles.
+#if  (defined(__AVR_AT90USB1286__) || defined(__AVR_AT90USB1287__) || defined(__AVR_ATmega32U4__))
+  MCUCR |= _BV(JTD);
+  MCUCR |= _BV(JTD);
+#endif
     matrix_init();
 #ifdef PS2_MOUSE_ENABLE
     ps2_mouse_init();
@@ -185,7 +190,7 @@ void keyboard_init(void) {
 
 /** \brief Keyboard task: Do keyboard routine jobs
  *
- * Do routine keyboard jobs: 
+ * Do routine keyboard jobs:
  *
  * * scan matrix
  * * handle mouse movements


### PR DESCRIPTION
The main matrix.c file automatically disables JTAG on certain boards.  However, most of the split boards do not do this, by default. 

Added the JTAG disable code, so that the boards properly disable JTAG.