### PR TITLE
Handwired/Dactyl refactor and Configurator support

### DIFF
--- a/keyboards/handwired/dactyl/dactyl.h
+++ b/keyboards/handwired/dactyl/dactyl.h
@@ -29,9 +29,12 @@ extern bool i2c_initialized;
 void init_dactyl(void);
 void init_expander(void);
 
-#define KEYMAP(                                                         \
+/*
+ *   LEFT HAND: LINES 38-45
+ *  RIGHT HAND: LINES 47-54
+ */
+#define LAYOUT_dactyl(                                                  \
                                                                         \
-    /* left hand, spatial positions */                                  \
     k00,k01,k02,k03,k04,k05,                                            \
     k10,k11,k12,k13,k14,k15,                                            \
     k20,k21,k22,k23,k24,k25,                                            \
@@ -41,7 +44,6 @@ void init_expander(void);
                                 k54,                                    \
                         k53,k52,k51,                                    \
                                                                         \
-    /* right hand, spatial positions */                                 \
             k06,k07,k08,k09,k0A,k0B,                                    \
             k16,k17,k18,k19,k1A,k1B,                                    \
             k26,k27,k28,k29,k2A,k2B,                                    \
@@ -61,7 +63,5 @@ void init_expander(void);
     { k50, k51, k52, k53, k54, k55,     k56, k57, k58, k59, k5A, k5B }, \
    }
 
-
-#define LAYOUT_dactyl KEYMAP
 
 #endif

--- a/keyboards/handwired/dactyl/info.json
+++ b/keyboards/handwired/dactyl/info.json
@@ -1,0 +1,13 @@
+{
+  "keyboard_name": "Dactyl",
+  "url": "",
+  "maintainer": "qmk",
+  "width": 17,
+  "height": 8,
+  "layouts": {
+    "LAYOUT_dactyl": {
+      "key_count": 70,
+      "layout": [{"label":"k00", "x":0, "y":0}, {"label":"k01", "x":1, "y":0}, {"label":"k02", "x":2, "y":0}, {"label":"k03", "x":3, "y":0}, {"label":"k04", "x":4, "y":0}, {"label":"k05", "x":5, "y":0}, {"label":"k10", "x":0, "y":1}, {"label":"k11", "x":1, "y":1}, {"label":"k12", "x":2, "y":1}, {"label":"k13", "x":3, "y":1}, {"label":"k14", "x":4, "y":1}, {"label":"k15", "x":5, "y":1}, {"label":"k20", "x":0, "y":2}, {"label":"k21", "x":1, "y":2}, {"label":"k22", "x":2, "y":2}, {"label":"k23", "x":3, "y":2}, {"label":"k24", "x":4, "y":2}, {"label":"k25", "x":5, "y":2}, {"label":"k30", "x":0, "y":3}, {"label":"k31", "x":1, "y":3}, {"label":"k32", "x":2, "y":3}, {"label":"k33", "x":3, "y":3}, {"label":"k34", "x":4, "y":3}, {"label":"k35", "x":5, "y":3}, {"label":"k40", "x":0, "y":4}, {"label":"k41", "x":1, "y":4}, {"label":"k42", "x":2, "y":4}, {"label":"k43", "x":3, "y":4}, {"label":"k44", "x":4, "y":4}, {"label":"k55", "x":6, "y":5}, {"label":"k50", "x":7, "y":5}, {"label":"k54", "x":7, "y":6}, {"label":"k53", "x":5, "y":6, "h":2}, {"label":"k52", "x":6, "y":6, "h":2}, {"label":"k51", "x":7, "y":7}, {"label":"k06", "x":11, "y":0}, {"label":"k07", "x":12, "y":0}, {"label":"k08", "x":13, "y":0}, {"label":"k09", "x":14, "y":0}, {"label":"k0A", "x":15, "y":0}, {"label":"k0B", "x":16, "y":0}, {"label":"k16", "x":11, "y":1}, {"label":"k17", "x":12, "y":1}, {"label":"k18", "x":13, "y":1}, {"label":"k19", "x":14, "y":1}, {"label":"k1A", "x":15, "y":1}, {"label":"k1B", "x":16, "y":1}, {"label":"k26", "x":11, "y":2}, {"label":"k27", "x":12, "y":2}, {"label":"k28", "x":13, "y":2}, {"label":"k29", "x":14, "y":2}, {"label":"k2A", "x":15, "y":2}, {"label":"k2B", "x":16, "y":2}, {"label":"k36", "x":11, "y":3}, {"label":"k37", "x":12, "y":3}, {"label":"k38", "x":13, "y":3}, {"label":"k39", "x":14, "y":3}, {"label":"k3A", "x":15, "y":3}, {"label":"k3B", "x":16, "y":3}, {"label":"k47", "x":12, "y":4}, {"label":"k48", "x":13, "y":4}, {"label":"k49", "x":14, "y":4}, {"label":"k4A", "x":15, "y":4}, {"label":"k4B", "x":16, "y":4}, {"label":"k5B", "x":9, "y":5}, {"label":"k56", "x":10, "y":5}, {"label":"k57", "x":9, "y":6}, {"label":"k5A", "x":9, "y":7}, {"label":"k59", "x":10, "y":6, "h":2}, {"label":"k58", "x":11, "y":6, "h":2}]
+    }
+  }
+}

--- a/keyboards/handwired/dactyl/keymaps/default/keymap.c
+++ b/keyboards/handwired/dactyl/keymaps/default/keymap.c
@@ -1,6 +1,4 @@
-#include "dactyl.h"
-#include "debug.h"
-#include "action_layer.h"
+#include QMK_KEYBOARD_H
 #include "version.h"
 
 #define BASE 0 // default layer

--- a/keyboards/handwired/dactyl/keymaps/dvorak/keymap.c
+++ b/keyboards/handwired/dactyl/keymaps/dvorak/keymap.c
@@ -1,6 +1,4 @@
-#include "dactyl.h"
-#include "debug.h"
-#include "action_layer.h"
+#include QMK_KEYBOARD_H
 #include "version.h"
 
 #define BASE 0 // default layer

--- a/keyboards/handwired/dactyl/keymaps/erincalling/keymap.c
+++ b/keyboards/handwired/dactyl/keymaps/erincalling/keymap.c
@@ -1,6 +1,4 @@
-#include "dactyl.h"
-#include "debug.h"
-#include "action_layer.h"
+#include QMK_KEYBOARD_H
 #include "version.h"
 
 #define BASE 0 // default layer


### PR DESCRIPTION
Spotted after browsing /r/olkb. Same issue the Ergodox-type boards had, with comments in the matrix definition.

- Matrix `KEYMAP` renamed to `LAYOUT_dactyl`
  - matrix alias `LAYOUT_dactyl` deleted
- added `info.json`
- Keymaps refactored to use `#include QMK_KEYBOARD_H`