### PR TITLE
Laplace Refactor

### DIFF
--- a/keyboards/laplace/keymaps/bakingpy/keymap.c
+++ b/keyboards/laplace/keymaps/bakingpy/keymap.c
@@ -1,4 +1,4 @@
-#include "laplace.h"
+#include QMK_KEYBOARD_H
 
 #define _BASE 0
 #define _FN1 1
@@ -25,7 +25,7 @@
 #define KC_RVAD RGB_VAD
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-  [_BASE] = KC_KEYMAP(
+  [_BASE] = LAYOUT_kc(
  //,----+----+----+----+----+----+----+----+----+----+----+----+----.
     ESC , Q  , W  , E  , R  , T  , Y  , U  , I  , O  , P  ,DEL ,BSPC,
  //|----`----`----`----`----`----`----`----`----`----`----`----`----+
@@ -37,7 +37,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  //`-----+----+-----+----+--------+--------+-----+-----+-----+------'
   ),
 
-  [_FN1] = KC_KEYMAP(
+  [_FN1] = LAYOUT_kc(
  //,----+----+----+----+----+----+----+----+----+----+----+----+----.
     GRV , 1  , 2  , 3  , 4  , 5  , 6  , 7  , 8  , 9  , 0  ,MINS,EQL ,
  //|----`----`----`----`----`----`----`----`----`----`----`----`----+
@@ -49,7 +49,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  //`-----+----+-----+----+--------+--------+-----+-----+-----+------'
   ),
 
-  [_FN2] = KC_KEYMAP(
+  [_FN2] = LAYOUT_kc(
  //,----+----+----+----+----+----+----+----+----+----+----+----+----.
     TILD,EXLM, AT ,HASH,DLR ,PERC,CIRC,AMPR,ASTR,LPRN,RPRN,UNDS,PLUS,
  //|----`----`----`----`----`----`----`----`----`----`----`----`----+

--- a/keyboards/laplace/keymaps/default/keymap.c
+++ b/keyboards/laplace/keymaps/default/keymap.c
@@ -1,63 +1,39 @@
-#include "laplace.h"
+#include QMK_KEYBOARD_H
 
 #define _BASE 0
 #define _FN1 1
 #define _FN2 2
 
-#define KC_ KC_TRNS
 #define _______ KC_TRNS
 #define XXXXXXX KC_NO
-#define KC_FN1 MO(_FN1)
-#define KC_FN2 MO(_FN2)
-#define KC_SPFN1 LT(_FN1, KC_SPACE)
-#define KC_SPFN2 LT(_FN2, KC_SPACE)
-#define KC_BSFN1 LT(_FN1, KC_BSPC)
-#define KC_BSFN2 LT(_FN2, KC_BSPC)
-#define KC_RST RESET
-#define KC_DBUG DEBUG
-#define KC_RTOG RGB_TOG
-#define KC_RMOD RGB_MOD
-#define KC_RHUI RGB_HUI
-#define KC_RHUD RGB_HUD
-#define KC_RSAI RGB_SAI
-#define KC_RSAD RGB_SAD
-#define KC_RVAI RGB_VAI
-#define KC_RVAD RGB_VAD
+
+#define FN1 MO(_FN1)
+#define FN2 MO(_FN2)
+#define SP_FN1 LT(_FN1, KC_SPACE)
+#define SP_FN2 LT(_FN2, KC_SPACE)
+#define BS_FN1 LT(_FN1, KC_BSPC)
+#define BS_FN2 LT(_FN2, KC_BSPC)
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-  [_BASE] = KC_KEYMAP(
- //,----+----+----+----+----+----|----+----+----+----+----+----+----.
-    ESC , Q  , W  , E  , R  , T  , Y  , U  , I  , O  , P  ,DEL ,BSPC,
- //|----`----`----`----`----`----`----`----`----`----`----`----`----+
-    TAB  , A  , S  , D  , F  , G  , H  , J  , K  , L  ,QUOT, ENTER  ,
- //|-----`----`----`----`----`----`----`----`----`----`----`--------|
-    LSFT   , Z  , X  , C  , V  , B  , N  , M  ,COMM,DOT ,SLSH, RSFT ,
- //|-------`----`----`----`----`----`----`----`----`----`----`------|
-    LCTL ,LALT,LGUI ,FN1 , SPFN1  ,  BSFN2 ,RGUI ,RALT , FN2 , RCTL 
- //`-----+----+-----+----+--------`--------+-----+-----+-----+------'
+
+  [_BASE] = LAYOUT(
+    KC_ESC,   KC_Q,     KC_W,     KC_E,     KC_R,     KC_T,     KC_Y,     KC_U,     KC_I,     KC_O,     KC_P,     KC_DEL,   KC_BSPC,
+    KC_TAB,   KC_A,     KC_S,     KC_D,     KC_F,     KC_G,     KC_H,     KC_J,     KC_K,     KC_L,     KC_QUOT,  KC_ENT,
+    KC_LSFT,  KC_Z,     KC_X,     KC_C,     KC_V,     KC_B,     KC_N,     KC_M,     KC_COMM,  KC_DOT,   KC_SLSH,  KC_RSFT,
+    KC_LCTL,  KC_LALT,  KC_LGUI,  FN1,      SP_FN1,   BS_FN2,   KC_RGUI,  KC_RALT,  FN2,      KC_RCTL
   ),
 
-  [_FN1] = KC_KEYMAP(
- //,----+----+----+----+----+----+----+----+----+----+----+----+----.
-    GRV , 1  , 2  , 3  , 4  , 5  , 6  , 7  , 8  , 9  , 0  ,MINS,EQL ,
- //|----`----`----`----`----`----`----`----`----`----`----`----`----+
-    RST  ,RHUI,RSAI,RVAI,VOLU,LBRC,RBRC, 4  , 5  , 6  ,SCLN,        ,
- //|-----`----`----`----`----`----`----`----`----`----`----`--------+
-    RMOD   ,RHUD,RSAD,RVAD,VOLD,LCBR,RCBR, 1  , 2  , 3  , UP ,      ,
- //|-------`----`----`----`----`----`----`----`----`----`----`------+
-    RTOG ,    ,     ,    ,        ,  DEL   ,  0  ,LEFT ,DOWN , RGHT 
- //`-----+----+-----+----+--------+--------+-----+-----+-----+------'
+  [_FN1] = LAYOUT(
+    KC_GRV,   KC_1,     KC_2,     KC_3,     KC_4,     KC_5,     KC_6,     KC_7,     KC_8,     KC_9,     KC_0,     KC_MINS,  KC_EQL,
+    RESET,    RGB_HUI,  RGB_SAI,  RGB_VAI,  KC_VOLU,  KC_LBRC,  KC_RBRC,  KC_4,     KC_5,     KC_6,     KC_SCLN,  _______,
+    RGB_MOD,  RGB_HUD,  RGB_SAD,  RGB_VAD,  KC_VOLD,  KC_LCBR,  KC_RCBR,  KC_1,     KC_2,     KC_3,     KC_UP,    _______,
+    RGB_TOG,  _______,  _______,  _______,  _______,  KC_DEL,   KC_0,     KC_LEFT,  KC_DOWN,  KC_RGHT
   ),
 
-  [_FN2] = KC_KEYMAP(
- //,----+----+----+----+----+----+----+----+----+----+----+----+----.
-    TILD,EXLM, AT ,HASH,DLR ,PERC,CIRC,AMPR,ASTR,LPRN,RPRN,UNDS,PLUS,
- //|----`----`----`----`----`----`----`----`----`----`----`----`----+
-         ,    ,    ,INS ,PGUP,HOME,    ,    ,    ,    ,COLN,        ,
- //|-----`----`----`----`----`----`----`----`----`----`----`--------+
-           ,    ,    ,DEL ,PGDN,END ,    ,    ,    ,    ,    ,      ,
- //|-------`----`----`----`----`----`----`----`----`----`----`------+
-         ,    ,     ,    ,  DEL   ,        ,     ,     ,     ,      
- //`-----+----+-----+----+--------+--------+-----+-----+-----+------'
+  [_FN2] = LAYOUT(
+    KC_TILD,  KC_EXLM,  KC_AT,    KC_HASH,  KC_DLR,   KC_PERC,  KC_CIRC,  KC_AMPR,  KC_ASTR,  KC_LPRN,  KC_RPRN,  KC_UNDS,  KC_PLUS,
+    _______,  _______,  _______,  KC_INS,   KC_PGUP,  KC_HOME,  _______,  _______,  _______,  _______,  KC_COLN,  _______,
+    _______,  _______,  _______,  KC_DEL,   KC_PGDN,  KC_END,   _______,  _______,  _______,  _______,  _______,  _______,
+    _______,  _______,  _______,  _______,  KC_DEL,   _______,  _______,  _______,  _______,  _______
   )
 };

--- a/keyboards/laplace/laplace.h
+++ b/keyboards/laplace/laplace.h
@@ -3,7 +3,7 @@
 
 #include "quantum.h"
 
-#define KEYMAP( \
+#define LAYOUT( \
     A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, \
     B1, B2, B3, B4, B5, B6, B7, B8, B9, B10, B11,      B13, \
     C1, C2, C3, C4, C5, C6, C7,     C9, C10, C11, C12, C13, \
@@ -20,13 +20,13 @@
     }
 
 // Used to create a keymap using only KC_ prefixed keys
-#define KC_KEYMAP( \
+#define LAYOUT_kc( \
     A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, \
     B1, B2, B3, B4, B5, B6, B7, B8, B9, B10, B11,      B13, \
     C1, C2, C3, C4, C5, C6, C7,     C9, C10, C11, C12, C13, \
     D1, D2, D3, D4, D5,     D7,         D10, D11, D12, D13 \
     ) \
-    KEYMAP( \
+    LAYOUT( \
         KC_##A1, KC_##A2, KC_##A3, KC_##A4, KC_##A5, KC_##A6, KC_##A7, KC_##A8, KC_##A9, KC_##A10, KC_##A11, KC_##A12, KC_##A13, \
         KC_##B1, KC_##B2, KC_##B3, KC_##B4, KC_##B5, KC_##B6, KC_##B7, KC_##B8, KC_##B9, KC_##B10, KC_##B11,           KC_##B13, \
         KC_##C1, KC_##C2, KC_##C3, KC_##C4, KC_##C5, KC_##C6, KC_##C7,          KC_##C9, KC_##C10, KC_##C11, KC_##C12, KC_##C13, \


### PR DESCRIPTION
- Matrix `KEYMAP` renamed to `LAYOUT`
- Matrix `KC_KEYMAP` renamed to `LAYOUT_kc`
- Keymaps updated to `#include QMK_KEYBOARD_H`
- Keymaps updated to use new matrix names
- Default keymap refactored to use `LAYOUT` matrix instead of `LAYOUT_kc`
