### PR TITLE
Temporary fix for MacOS compiling issue

### DIFF
--- a/docs/faq_build.md
+++ b/docs/faq_build.md
@@ -99,8 +99,19 @@ brew rm avr-gcc
 brew rm dfu-programmer
 brew rm gcc-arm-none-eabi
 brew rm avrdude
-brew install avr-gcc
+brew install avr-gcc@7.3
+brew pin osx-cross/avr/avr-gcc
 brew install dfu-programmer
 brew install gcc-arm-none-eabi
 brew install avrdude
+```
+
+## AVR-GCC compiler issue on LUFA files in MacOS
+This is an issue with the 8.1 version of `avr-gcc`. Brew is updating to a newer version that our code isn't fully compatible with yet. 
+
+For now, the fix is to install the older version and "pin" it, so it doesn't get updated.
+
+```
+brew install avr-gcc@7.3
+brew pin osx-cross/avr/avr-gcc
 ```

--- a/docs/getting_started_build_tools.md
+++ b/docs/getting_started_build_tools.md
@@ -56,7 +56,8 @@ If you're using [homebrew,](http://brew.sh/) you can use the following commands:
     brew tap osx-cross/avr
     brew tap PX4/homebrew-px4
     brew update
-    brew install avr-gcc
+    brew install avr-gcc@7.3
+    brew pin osx-cross/avr/avr-gcc
     brew install dfu-programmer
     brew install gcc-arm-none-eabi
     brew install avrdude

--- a/util/macos_install.sh
+++ b/util/macos_install.sh
@@ -22,4 +22,5 @@ fi
 brew tap osx-cross/avr
 brew tap PX4/homebrew-px4
 brew update
-brew install avr-gcc gcc-arm-none-eabi dfu-programmer avrdude
+brew install avr-gcc@7.3 gcc-arm-none-eabi dfu-programmer avrdude
+brew pin osx-cross/avr/avr-gcc


### PR DESCRIPTION
Since avr-gcc is getting updated to 8.1, and that breaks LUFA, for now.... until we're able to get a more permanent fix in place, this is decent stop-gap until we are able to investigate the issue
