### PR TITLE
Nano refactor and Configurator update

### DIFF
--- a/keyboards/nano/info.json
+++ b/keyboards/nano/info.json
@@ -1,0 +1,12 @@
+{
+  "keyboard_name": "Nano",
+  "url": "",
+  "maintainer": "qmk",
+  "width": 4,
+  "height": 2,
+  "layouts": {
+    "LAYOUT": {
+      "layout": [{"x":0, "y":0}, {"x":1, "y":0}, {"x":2, "y":0}, {"x":3, "y":0}, {"x":0, "y":1}, {"x":1, "y":1}, {"x":2, "y":1}, {"x":3, "y":1}]
+    }
+  }
+}

--- a/keyboards/nano/keymaps/default/keymap.c
+++ b/keyboards/nano/keymaps/default/keymap.c
@@ -1,23 +1,19 @@
-#include "nano.h"
+#include QMK_KEYBOARD_H
 
 #define _MAIN 0
 #define _FN 1
 
-#define KC_ KC_TRNS
+#define _______ KC_TRNS
 #define KC_X0 LT(_FN, KC_ESC)
-#define KC_RTOG RGB_TOG
-#define KC_RMOD RGB_MOD
-#define KC_RHUI RGB_HUI
-#define KC_RHUD RGB_HUD
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   [_MAIN] = LAYOUT(
-     VOLU,MPLY,MPRV,PGUP,
-     VOLD,MUTE,MNXT,PGDN
+     KC_VOLU, KC_MPLY, KC_MPRV, KC_PGUP,
+     KC_VOLD, KC_MUTE, KC_MNXT, KC_PGDN
   ),
 
   [_FN] = LAYOUT(
-      F  ,    ,RHUI,    ,
-     RTOG,RMOD,RHUD,
+     KC_F,    _______, RGB_HUI, _______,
+     RGB_TOG, RGB_MOD, RGB_HUD, _______
   )
 };

--- a/keyboards/nano/nano.h
+++ b/keyboards/nano/nano.h
@@ -3,10 +3,12 @@
 
 #include "quantum.h"
 
-#define LAYOUT(k01, k02, k03, k04, k05, k06, k07, k08) \
-{ \
-    {KC_##k01, KC_##k02, KC_##k03, KC_##k04}, \
-    {KC_##k05, KC_##k06, KC_##k07, KC_##k08} \
+#define LAYOUT( \
+    k01, k02, k03, k04, \
+    k05, k06, k07, k08  \
+  ) { \
+    { k01, k02, k03, k04 }, \
+    { k05, k06, k07, k08 } \
 }
 
 #endif


### PR DESCRIPTION
- matrix/keymap refactor: no longer auto-prefixes keymap codes with `KC_`
- keymap now uses `QMK_KEYBOARD_H` include
- added `info.json`
