### PR TITLE
Helix default to 5rows

### DIFF
--- a/keyboards/helix/helix.h
+++ b/keyboards/helix/helix.h
@@ -33,7 +33,7 @@
           KC_##L20, KC_##L21, KC_##L22, KC_##L23, KC_##L24, KC_##L25, KC_##R20, KC_##R21, KC_##R22, KC_##R23, KC_##R24, KC_##R25, \
           KC_##L30, KC_##L31, KC_##L32, KC_##L33, KC_##L34, KC_##L35, KC_##R30, KC_##R31, KC_##R32, KC_##R33, KC_##R34, KC_##R35 \
       )
-#elif HELIX_ROWS == 5
+#else
   #define LAYOUT_kc( \
       L00, L01, L02, L03, L04, L05, R00, R01, R02, R03, R04, R05, \
       L10, L11, L12, L13, L14, L15, R10, R11, R12, R13, R14, R15, \
@@ -48,8 +48,6 @@
           KC_##L30, KC_##L31, KC_##L32, KC_##L33, KC_##L34, KC_##L35, KC_##R30, KC_##R31, KC_##R32, KC_##R33, KC_##R34, KC_##R35, \
           KC_##L40, KC_##L41, KC_##L42, KC_##L43, KC_##L44, KC_##L45, KC_##R40, KC_##R41, KC_##R42, KC_##R43, KC_##R44, KC_##R45 \
       )
-#else
-  #error "expected HELIX_ROWS 3 or 4 or 5"
 #endif
 
 #include "quantum.h"


### PR DESCRIPTION
defaulted to 5 rows when HELIX_ROWS is not defined.
I hope qmk configrator will not get errors..