### PR TITLE
Temporary work around for CB60 sound issues

### DIFF
--- a/keyboards/clueboard/60/chconf.h
+++ b/keyboards/clueboard/60/chconf.h
@@ -48,7 +48,7 @@
  * @details Frequency of the system timer that drives the system ticks. This
  *          setting also defines the system tick time unit.
  */
-#define CH_CFG_ST_FREQUENCY                 10000
+#define CH_CFG_ST_FREQUENCY                 100000
 
 /**
  * @brief   Time delta constant for the tick-less mode.

--- a/keyboards/clueboard/keymaps/xyverz/config.h
+++ b/keyboards/clueboard/keymaps/xyverz/config.h
@@ -1,3 +1,0 @@
-#include "../config.h"
-
-#define TAPPING_TERM 600 // ms	


### PR DESCRIPTION
Discussed this with @fredizzimo, upping the system ticks to 100K fixes
the sound issues I was having with the CB60; speaker would fail to shut
off after playing music, sometimes at startup. This changes the matrix
scan time from it's default of every 2ms to once ever 200us.

Fred has a more extensive change to the way matrices are scanned which
will require less clock cycles and we can then revert this change at
that time.

FYI @skullydazed 