### PR TITLE
E6V2 LE Missing a Default Keymap

### DIFF
--- a/keyboards/e6v2/le/keymaps/default/keymap.c
+++ b/keyboards/e6v2/le/keymaps/default/keymap.c
@@ -2,10 +2,10 @@
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   [0] = LAYOUT(
-      KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,      KC_9,    KC_0,    KC_MINS, KC_EQL,  KC, BSLS, KC_DEL,
-      KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,      KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSPC,
-      KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,      KC_L,    KC_SCLN, KC_QUOT, KC_ENT,
-      KC_LSFT, KC_NUBS, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,      KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT, KC_UP,    KC_DEL,
-      KC_LCTL, KC_LGUI, KC_LALT, KC_MENU           KC_SPACE,                      KC_SPACE,   KC_RGUI, KC_RCTL, KC_LEFT, KC_DOWN, KC_RIGHT
+      KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,     KC_6,    KC_7,    KC_8,      KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSLS, KC_DEL,
+      KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,     KC_Y,    KC_U,    KC_I,      KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSPC,
+      KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,     KC_H,    KC_J,    KC_K,      KC_L,    KC_SCLN, KC_QUOT, KC_ENT,
+      KC_LSFT, KC_NUBS, KC_Z,    KC_X,    KC_C,    KC_V,     KC_B,    KC_N,    KC_M,      KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT, KC_UP,    KC_DEL,
+      KC_LCTL, KC_LGUI, KC_LALT, KC_MENU,          KC_SPACE,                   KC_SPACE,  KC_RGUI, KC_RCTL, KC_LEFT, KC_DOWN, KC_RIGHT
       ),
 };

--- a/keyboards/e6v2/le/keymaps/default/keymap.c
+++ b/keyboards/e6v2/le/keymaps/default/keymap.c
@@ -1,0 +1,11 @@
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  [0] = LAYOUT(
+      KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,      KC_9,    KC_0,    KC_MINS, KC_EQL,  KC, BSLS, KC_DEL,
+      KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,      KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSPC,
+      KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,      KC_L,    KC_SCLN, KC_QUOT, KC_ENT,
+      KC_LSFT, KC_NUBS, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,      KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT, KC_UP,    KC_DEL,
+      KC_LCTL, KC_LGUI, KC_LALT, KC_MENU           KC_SPACE,                      KC_SPACE,   KC_RGUI, KC_RCTL, KC_LEFT, KC_DOWN, KC_RIGHT
+      ),
+};

--- a/keyboards/e6v2/le/le.h
+++ b/keyboards/e6v2/le/le.h
@@ -17,3 +17,5 @@
   { K30, K31,   K32, K33, K34, K35,   K36,   K37, K38,   K39, K3A, K3B, K3C, K3D, K3E   }, \
   { K40, KC_NO, K42, K43, K44, KC_NO, KC_NO, K47, KC_NO, K49, K4A, K4B, K4C, K4D, K4E   }, \
 }
+
+#endif


### PR DESCRIPTION
Figured the adding a default keymap will help those who prefer command line QMK
Looks like I also forgot an #endif 