### PR TITLE
Fixed the behavior of a custom key on the Iris keyboard's edvorakjp layout.

### DIFF
--- a/keyboards/iris/keymaps/edvorakjp/keymap.c
+++ b/keyboards/iris/keymaps/edvorakjp/keymap.c
@@ -139,7 +139,7 @@ bool process_record_keymap(uint16_t keycode, keyrecord_t *record) {
         if (edvorakjp_config.enable_kc_lang) {
           SEND_STRING( SS_LCTRL(SS_LSFT(SS_TAP(X_POWER))) );
         } else {
-          SEND_STRING( SS_LGUI("L") );
+          SEND_STRING( SS_LGUI("l") );
         }
       }
       return false;

--- a/keyboards/iris/keymaps/edvorakjp/readme.md
+++ b/keyboards/iris/keymaps/edvorakjp/readme.md
@@ -1,7 +1,7 @@
 # edvorakjp
 
 Epaew's Enhanced Dvorak layout for Japanese Programmer  
-see [here](../../../../users/edvorakjp) for more informations.
+see [here](/users/edvorakjp) for more informations.
 
 ## License
 


### PR DESCRIPTION
Win+Shift+L => Win+L
and update readme