### PR TITLE
AL1 Unable to Compile on Configurator

### DIFF
--- a/keyboards/al1/al1.c
+++ b/keyboards/al1/al1.c
@@ -15,14 +15,6 @@
  */
 #include "al1.h"
 
-void matrix_init_kb(void) {
-	matrix_init_user();
-}
-
-void matrix_scan_kb(void) {
-    matrix_scan_user();
-}
-
 bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
 	return process_record_user(keycode, record);
 }

--- a/keyboards/al1/al1.c
+++ b/keyboards/al1/al1.c
@@ -15,6 +15,16 @@
  */
 #include "al1.h"
 
+__attribute__ ((weak))
+void matrix_init_kb(void) {
+	matrix_init_user();
+}
+
+__attribute__ ((weak))
+void matrix_scan_kb(void) {
+    matrix_scan_user();
+}
+
 bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
 	return process_record_user(keycode, record);
 }

--- a/keyboards/al1/keymaps/splitbs/keymap.c
+++ b/keyboards/al1/keymaps/splitbs/keymap.c
@@ -1,4 +1,4 @@
-#include "al1.h"
+#include QMK_KEYBOARD_H
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 	[0] = LAYOUT_split_bs(\

--- a/keyboards/al1/matrix.c
+++ b/keyboards/al1/matrix.c
@@ -28,6 +28,13 @@ inline uint8_t matrix_cols(void) {
   return MATRIX_COLS;
 }
 
+void matrix_init_kb(void) {
+	matrix_init_user();
+}
+
+void matrix_scan_kb(void) {
+    matrix_scan_user();
+}
 
 void matrix_init(void) {
   // initialize row and col
@@ -104,7 +111,7 @@ uint8_t matrix_key_count(void) {
 
 /* Row pin configuration
  *
- * row: 0    1    2    3    4    5 
+ * row: 0    1    2    3    4    5
  * pin: C7   B1   B2   C6   B4   B5
  *
  */

--- a/keyboards/al1/matrix.c
+++ b/keyboards/al1/matrix.c
@@ -28,14 +28,6 @@ inline uint8_t matrix_cols(void) {
   return MATRIX_COLS;
 }
 
-void matrix_init_kb(void) {
-	matrix_init_user();
-}
-
-void matrix_scan_kb(void) {
-    matrix_scan_user();
-}
-
 void matrix_init(void) {
   // initialize row and col
     unselect_cols();


### PR DESCRIPTION
On the Configurator, you get the following
```
Linking: .build/al1_layout_mine.elf                                                                 
 | 
 | .build/obj_al1_layout_mine/keyboards/al1/al1.o: In function `matrix_init_kb':
 | /qmk_compiler_worker/qmk_firmware/keyboards/al1/al1.c:19: undefined reference to `matrix_init_user'
 | .build/obj_al1_layout_mine/keyboards/al1/al1.o: In function `matrix_scan_kb':
 | /qmk_compiler_worker/qmk_firmware/keyboards/al1/al1.c:23: undefined reference to `matrix_scan_user'
 | collect2: error: ld returned 1 exit status
 | 
```

However you don't hit this when making any of the two default keymaps currently in AL1 directory.

The two matrix routines need matrix.h included. I figured it would be better to just define them in matrix. c which already has matrix.h included. 