### PR TITLE
Fix Ergodox EZ issues introduced with ShinyDox merge (#3229)

### DIFF
--- a/keyboards/ergodox_ez/config.h
+++ b/keyboards/ergodox_ez/config.h
@@ -81,9 +81,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* fix space cadet rollover issue */
 #define DISABLE_SPACE_CADET_ROLLOVER
 
-// #define RGBW_BB_TWI
+#define RGBW_BB_TWI
 
-// #define RGBW 1
+#define RGBW 1
 
 /* "debounce" is measured in keyboard scans. Some users reported
  * needing values as high as 15, which was at the time around 50ms.

--- a/keyboards/ergodox_ez/rules.mk
+++ b/keyboards/ergodox_ez/rules.mk
@@ -82,7 +82,7 @@ UNICODE_ENABLE   = yes # Unicode
 SWAP_HANDS_ENABLE= yes # Allow swapping hands of keyboard
 SLEEP_LED_ENABLE = no
 API_SYSEX_ENABLE = no
-RGBLIGHT_ENABLE = no
-RGB_MATRIX_ENABLE = yes
+RGBLIGHT_ENABLE = yes
+RGB_MATRIX_ENABLE = no // enable later
 
 LAYOUTS = ergodox


### PR DESCRIPTION
This re-enables the RGBW and BitBang features for the RGB Underglow, as it breaks compiling if you want to enable RGB underglow rather than rgb matrix.

Also, defaults to RGB underglow, and NOT matrix (for now).

@ezuk This look good? 

Fixes #3321