### PR TITLE
Fix redox if DIODE_DIRECTION == ROW2COL

### DIFF
--- a/keyboards/redox/matrix.c
+++ b/keyboards/redox/matrix.c
@@ -119,8 +119,13 @@ void matrix_init(void)
     debug_matrix = true;
     debug_mouse = true;
     // initialize row and col
+#if (DIODE_DIRECTION == COL2ROW)
     unselect_rows();
     init_cols();
+#elif (DIODE_DIRECTION == ROW2COL)
+    unselect_cols();
+    init_rows();
+#endif
 
     TX_RX_LED_INIT;
 


### PR DESCRIPTION
The code for the redox keyboard was missing an appropriate #ifdef in the matrix_init function for the case where DIODE_DIRECTION == ROW2COL