### PR TITLE
mitosis:datagrok layout and readme improvements

### DIFF
--- a/keyboards/mitosis/keymaps/datagrok/config.h
+++ b/keyboards/mitosis/keymaps/datagrok/config.h
@@ -3,15 +3,6 @@
 
 #include "../../config.h"
 
-// I use a pro micro clocked at 8Mhz. It can't reach 1M baud, so this is the
-// next fastest possible baud without errors. I don't notice any difference in
-// behavior at this slower speed. (So I think it should maybe be the default,
-// to allow a single codebase to support both available flavors of pro micro.)
-// This requires a corresponding change to the wireless module firmware; see
-// https://github.com/reversebias/mitosis/pull/10
-#undef SERIAL_UART_BAUD // avoids redefinition warning
-#define SERIAL_UART_BAUD 250000
-
 // TODO: figure out which of these I can safely enable to reduce firmware size.
 //#define NO_ACTION_LAYER
 //#define NO_ACTION_TAPPING

--- a/keyboards/mitosis/keymaps/datagrok/config.h
+++ b/keyboards/mitosis/keymaps/datagrok/config.h
@@ -3,6 +3,13 @@
 
 #include "../../config.h"
 
+// I want to place an underscore as tap behavior on the right shift key. But
+// RSFT_T(KC_UNDS) doesn't work; mod-tap doesn't work with pre-shifted keys. So
+// instead we take advantage of Space Cadet Shift that does something similar
+// and just tweak it to use the -_ key instead of 0) See
+// https://github.com/qmk/qmk_firmware/pull/2055
+#define RSPC_KEY KC_MINS
+
 // TODO: figure out which of these I can safely enable to reduce firmware size.
 //#define NO_ACTION_LAYER
 //#define NO_ACTION_TAPPING

--- a/keyboards/mitosis/keymaps/datagrok/config.h
+++ b/keyboards/mitosis/keymaps/datagrok/config.h
@@ -10,4 +10,16 @@
 //#define NO_ACTION_MACRO
 //#define NO_ACTION_FUNCTION
 
+#ifdef AUDIO_ENABLE
+#define STARTUP_SONG SONG(PLANCK_SOUND)
+// #define STARTUP_SONG SONG(NO_SOUND)
+#define DEFAULT_LAYER_SONGS { SONG(QWERTY_SOUND),   \
+                              SONG(COLEMAK_SOUND),  \
+                              SONG(DVORAK_SOUND)    \
+  }
+#define AUDIO_VOICES
+#define AUDIO_CLICKY
+#define C6_AUDIO
+#endif
+
 #endif

--- a/keyboards/mitosis/keymaps/datagrok/keymap.c
+++ b/keyboards/mitosis/keymaps/datagrok/keymap.c
@@ -10,57 +10,51 @@ enum mitosis_layers
 };
 
 // Fillers to make layering more clear
-#define XXXXXXX KC_NO   // No-op (no key in this location on Mitosis' fake matrix)
-#define _______ KC_TRNS // Transparent, because I haven't decided a mapping yet
-#define KC_LMTA KC_LALT // For fun, name the mods like the space cadet keyboard does
-#define KC_RMTA KC_RALT // META
-#define KC_LSUP KC_LGUI // SUPER
-#define KC_RSUP KC_RGUI //
-#define KC_RHYP KC_INT4 // HYPER (actually muhenkan 無変換 and henkan 変換)
-#define KC_LHYP KC_INT5 // or NFER/XFER.
+#define _______ KC_TRNS // Transparent
+
+// I don't use Japanese myself, but I've placed henkan 変換 and muhenkan 無変換
+// in my layout to act as left and right HYPER
 
 // Momentary tri-state layers. Mitosis default keymap does this too but employs
 // new keymappings and a bunch of conditional code. This simpler keymap
-// accomplishes it, but with a small quirk: triggering both layers then
-// releasing one out-of-order will leave the tri-state triggered until the
-// other is released. Which doesn't bother me.
+// accomplishes it but with a small quirk: triggering both layers then releasing
+// one out-of-order will leave the tri-state triggered until the other is
+// released. Which doesn't bother me.
+
+// The weird /*,*/ comments are a hack to get slightly better automatic
+// tabulation in my editor.
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   [_xQ] = LAYOUT(
-    KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,          KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,
-    KC_A,    KC_S,    KC_D,    KC_F,    KC_G,          KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN,
-    KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,          KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_QUOT,
-             KC_LSUP, KC_LCTL, MO(_xN), SFT_T(KC_TAB), KC_RSFT, MO(_xN), KC_RCTL, KC_RSUP,
-             KC_LHYP, KC_LMTA, MO(_xS), KC_BSPC,       KC_SPC,  MO(_xS), KC_RMTA, KC_RHYP
-  ),
+      KC_Q, KC_W,       KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,     KC_P,
+      KC_A, KC_S,       KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,     KC_SCLN,
+      KC_Z, KC_X,       KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,   KC_QUOT,
+      /*,   */ KC_LGUI, KC_LCTL, MO(_xS), KC_TAB,  KC_SPC,  MO(_xS), KC_RCTL, KC_RGUI,
+      /*,   */ KC_HENK, KC_LALT, MO(_xN), KC_LSFT, KC_RSFT, MO(_xN), KC_RALT, KC_MHEN),
   [_xW] = LAYOUT(
-    KC_Q,    KC_D,    KC_R,    KC_W,    KC_B,    KC_J,    KC_F,    KC_U,    KC_P,    KC_SCLN,
-    KC_A,    KC_S,    KC_H,    KC_T,    KC_G,    KC_Y,    KC_N,    KC_E,    KC_O,    KC_I,
-    KC_Z,    KC_X,    KC_M,    KC_C,    KC_V,    KC_K,    KC_L,    KC_COMM, KC_DOT,  KC_QUOT,
-             _______, _______, _______, _______, _______, _______, _______, _______,
-             _______, _______, _______, _______, _______, _______, _______, _______
-  ),
+      KC_Q, KC_D,       KC_R,    KC_W,    KC_B,    KC_J,    KC_F,    KC_U,    KC_P,     KC_SCLN,
+      KC_A, KC_S,       KC_H,    KC_T,    KC_G,    KC_Y,    KC_N,    KC_E,    KC_O,     KC_I,
+      KC_Z, KC_X,       KC_M,    KC_C,    KC_V,    KC_K,    KC_L,    KC_COMM, KC_DOT,   KC_QUOT,
+      /*,   */ _______, _______, _______, _______, _______, _______, _______, _______,
+      /*,   */ _______, _______, _______, _______, _______, _______, _______, _______),
   [_xS] = LAYOUT(
-    KC_ESC,  _______, KC_UP,   _______, _______, KC_AT,   KC_HASH, KC_DLR,  KC_PERC, KC_TILD,
-    KC_TAB,  KC_LEFT, KC_DOWN, KC_RGHT, _______, KC_CIRC, KC_AMPR, KC_PIPE, KC_GRV,  KC_UNDS,
-    KC_BSLS, KC_RPRN, KC_RCBR, KC_RBRC, KC_RABK, KC_LABK, KC_LBRC, KC_LCBR, KC_LPRN, KC_SLSH,
-             _______, _______, MO(_xF), _______, _______, MO(_xF), _______, _______,
-             _______, _______, _______, KC_DEL,  KC_ENT,  _______, _______, _______
-  ),
+      KC_ESC,  _______,    KC_UP,   _______, KC_GRV,  KC_PLUS, KC_CIRC, KC_AMPR, KC_PERC,  KC_MINS,
+      KC_BSPC, KC_LEFT,    KC_DOWN, KC_RGHT, KC_TILD, KC_PIPE, KC_AT,   KC_DLR,  KC_HASH,  KC_ENT,
+      KC_BSLS, KC_LABK,    KC_LCBR, KC_LPRN, KC_LBRC, KC_RBRC, KC_RCBR, KC_RPRN, KC_RABK,  KC_SLSH,
+      /*,      */ _______, _______, _______, _______, KC_UNDS, _______, _______, _______,
+      /*,      */ _______, _______, MO(_xF), _______, _______, MO(_xF), _______, _______),
   [_xN] = LAYOUT(
-    _______, _______, _______, _______, KC_NLCK, KC_PSLS, KC_P7,   KC_P8,   KC_P9,   KC_P0,
-    _______, _______, _______, _______, _______, KC_PAST, KC_P4,   KC_P5,   KC_P6,   KC_PPLS,
-    _______, _______, _______, _______, _______, KC_PMNS, KC_P1,   KC_P2,   KC_P3,   KC_PEQL,
-             _______, _______, _______, _______, _______, _______, _______, _______,
-             _______, _______, MO(_xF), _______, KC_PENT, MO(_xF), _______, _______
-  ),
+      _______, KC_F7,      KC_F8,   KC_F9,   KC_F10,  KC_PPLS, KC_7,    KC_8,    KC_9,     KC_PMNS,
+      _______, KC_F4,      KC_F5,   KC_F6,   KC_F11,  KC_NLCK, KC_4,    KC_5,    KC_6,     KC_PENT,
+      _______, KC_F1,      KC_F2,   KC_F3,   KC_F12,  KC_PAST, KC_1,    KC_2,    KC_3,     KC_PSLS,
+      /*,      */ _______, _______, MO(_xF), _______, _______, MO(_xF), KC_0,    KC_PDOT,
+      /*,      */ _______, _______, _______, _______, _______, _______, _______, _______),
   [_xF] = LAYOUT(
-    _______, _______, KC_PGUP, _______, KC_VOLU, KC_F13,  KC_F7,   KC_F8,   KC_F9,   KC_F10,
-    _______, KC_HOME, KC_PGDN, KC_END,  KC_VOLD, KC_F14,  KC_F4,   KC_F5,   KC_F6,   KC_F11,
-    TG(_xW), KC_MPRV, KC_MPLY, KC_MNXT, KC_MUTE, KC_F15,  KC_F1,   KC_F2,   KC_F3,   KC_F12,
-             _______, _______, _______, _______, _______, _______, _______, _______,
-             _______, _______, _______, _______, _______, _______, _______, _______
-  ),
+      RESET,   KC_INS,     KC_PGUP, KC_DEL,  KC_VOLU, KC_PPLS, KC_P7,   KC_P8,   KC_P9,    KC_PMNS,
+      CK_TOGG, KC_HOME,    KC_PGDN, KC_END,  KC_VOLD, KC_NLCK, KC_P4,   KC_P5,   KC_P6,    KC_PENT,
+      TG(_xW), KC_MPRV,    KC_MPLY, KC_MNXT, KC_MUTE, KC_PAST, KC_P1,   KC_P2,   KC_P3,    KC_PSLS,
+      /*,      */ CK_UP,   MU_TOG,  _______, _______, _______, _______, KC_P0,   KC_PDOT,
+      /*,      */ CK_DOWN, MU_MOD,  _______, _______, _______, KC_PSCR, KC_SLCK, KC_PAUS),
 };
 
 // This is a hack to place <question mark> on <shift-comma> and <exclaimation

--- a/keyboards/mitosis/keymaps/datagrok/keymap.c
+++ b/keyboards/mitosis/keymaps/datagrok/keymap.c
@@ -1,4 +1,7 @@
 #include QMK_KEYBOARD_H
+#ifdef AUDIO_ENABLE
+#include "audio.h"
+#endif
 
 enum mitosis_layers
 {
@@ -98,6 +101,41 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     return true;
   }
 }
+
+#ifdef AUDIO_ENABLE
+float tone_qwerty[][2]         = SONG(QWERTY_SOUND);
+float tone_dyn_macro_rec[][2]  = SONG(DVORAK_SOUND);
+float tone_dyn_macro_play[][2] = SONG(COLEMAK_SOUND);
+float tone_fnpc[][2]           = SONG(PLOVER_SOUND);
+float tone_fnmac[][2]          = SONG(PLOVER_GOODBYE_SOUND);
+
+void startup_user()
+{
+  float tone_startup[][2]        = SONG(STARTUP_SOUND);
+  _delay_ms(20); // gets rid of tick
+  PLAY_SONG(tone_startup);
+}
+
+void shutdown_user()
+{
+  float tone_goodbye[][2]        = SONG(GOODBYE_SOUND);
+  PLAY_SONG(tone_goodbye);
+  _delay_ms(150);
+  stop_all_notes();
+}
+
+void music_on_user(void)
+{
+  music_scale_user();
+}
+
+void music_scale_user(void)
+{
+  float music_scale[][2]         = SONG(MUSIC_SCALE_SOUND);
+  PLAY_SONG(music_scale);
+}
+
+#endif
 
 // Set the bits of A selected by MASK to the corresponding bits of B
 #define setbits(A, B, MASK) A = (A & (B | ~MASK)) | (B & MASK)

--- a/keyboards/mitosis/keymaps/datagrok/keymap.c
+++ b/keyboards/mitosis/keymaps/datagrok/keymap.c
@@ -27,13 +27,15 @@ enum mitosis_layers
 // The weird /*,*/ comments are a hack to get slightly better automatic
 // tabulation in my editor.
 
+// We use Space Cadet KC_RSPC to get _ on right shift. See config.h for details.
+
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   [_xQ] = LAYOUT(
-      KC_Q, KC_W,       KC_E,    KC_R,    KC_T,    KC_Y,            KC_U,    KC_I,    KC_O,     KC_P,
-      KC_A, KC_S,       KC_D,    KC_F,    KC_G,    KC_H,            KC_J,    KC_K,    KC_L,     KC_SCLN,
-      KC_Z, KC_X,       KC_C,    KC_V,    KC_B,    KC_N,            KC_M,    KC_COMM, KC_DOT,   KC_QUOT,
-      /*,   */ KC_LGUI, KC_LCTL, MO(_xS), KC_TAB,  KC_SPC,          MO(_xS), KC_RCTL, KC_RGUI,
-      /*,   */ KC_HENK, KC_LALT, MO(_xN), KC_LSFT, RSFT_T(KC_UNDS), MO(_xN), KC_RALT, KC_MHEN),
+      KC_Q, KC_W,       KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,     KC_P,
+      KC_A, KC_S,       KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,     KC_SCLN,
+      KC_Z, KC_X,       KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,   KC_QUOT,
+      /*,   */ KC_LGUI, KC_LCTL, MO(_xS), KC_TAB,  KC_SPC,  MO(_xS), KC_RCTL, KC_RGUI,
+      /*,   */ KC_HENK, KC_LALT, MO(_xN), KC_LSFT, KC_RSPC, MO(_xN), KC_RALT, KC_MHEN),
   [_xW] = LAYOUT(
       KC_Q, KC_D,       KC_R,    KC_W,    KC_B,    KC_J,    KC_F,    KC_U,    KC_P,     KC_SCLN,
       KC_A, KC_S,       KC_H,    KC_T,    KC_G,    KC_Y,    KC_N,    KC_E,    KC_O,     KC_I,

--- a/keyboards/mitosis/keymaps/datagrok/keymap.c
+++ b/keyboards/mitosis/keymaps/datagrok/keymap.c
@@ -29,11 +29,11 @@ enum mitosis_layers
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   [_xQ] = LAYOUT(
-      KC_Q, KC_W,       KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,     KC_P,
-      KC_A, KC_S,       KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,     KC_SCLN,
-      KC_Z, KC_X,       KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,   KC_QUOT,
-      /*,   */ KC_LGUI, KC_LCTL, MO(_xS), KC_TAB,  KC_SPC,  MO(_xS), KC_RCTL, KC_RGUI,
-      /*,   */ KC_HENK, KC_LALT, MO(_xN), KC_LSFT, KC_RSFT, MO(_xN), KC_RALT, KC_MHEN),
+      KC_Q, KC_W,       KC_E,    KC_R,    KC_T,    KC_Y,            KC_U,    KC_I,    KC_O,     KC_P,
+      KC_A, KC_S,       KC_D,    KC_F,    KC_G,    KC_H,            KC_J,    KC_K,    KC_L,     KC_SCLN,
+      KC_Z, KC_X,       KC_C,    KC_V,    KC_B,    KC_N,            KC_M,    KC_COMM, KC_DOT,   KC_QUOT,
+      /*,   */ KC_LGUI, KC_LCTL, MO(_xS), KC_TAB,  KC_SPC,          MO(_xS), KC_RCTL, KC_RGUI,
+      /*,   */ KC_HENK, KC_LALT, MO(_xN), KC_LSFT, RSFT_T(KC_UNDS), MO(_xN), KC_RALT, KC_MHEN),
   [_xW] = LAYOUT(
       KC_Q, KC_D,       KC_R,    KC_W,    KC_B,    KC_J,    KC_F,    KC_U,    KC_P,     KC_SCLN,
       KC_A, KC_S,       KC_H,    KC_T,    KC_G,    KC_Y,    KC_N,    KC_E,    KC_O,     KC_I,
@@ -41,10 +41,10 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
       /*,   */ _______, _______, _______, _______, _______, _______, _______, _______,
       /*,   */ _______, _______, _______, _______, _______, _______, _______, _______),
   [_xS] = LAYOUT(
-      KC_ESC,  _______,    KC_UP,   _______, KC_GRV,  KC_PLUS, KC_CIRC, KC_AMPR, KC_PERC,  KC_MINS,
-      KC_BSPC, KC_LEFT,    KC_DOWN, KC_RGHT, KC_TILD, KC_PIPE, KC_AT,   KC_DLR,  KC_HASH,  KC_ENT,
+      KC_ESC,  KC_GRV ,    KC_UP,   KC_EQL , KC_TILD, KC_PLUS, KC_CIRC, KC_AMPR, KC_PERC,  KC_MINS,
+      KC_BSPC, KC_LEFT,    KC_DOWN, KC_RGHT, _______, KC_PIPE, KC_AT,   KC_DLR,  KC_HASH,  KC_ENT,
       KC_BSLS, KC_LABK,    KC_LCBR, KC_LPRN, KC_LBRC, KC_RBRC, KC_RCBR, KC_RPRN, KC_RABK,  KC_SLSH,
-      /*,      */ _______, _______, _______, _______, KC_UNDS, _______, _______, _______,
+      /*,      */ _______, _______, _______, _______, _______, _______, _______, _______,
       /*,      */ _______, _______, MO(_xF), _______, _______, MO(_xF), _______, _______),
   [_xN] = LAYOUT(
       _______, KC_F7,      KC_F8,   KC_F9,   KC_F10,  KC_PPLS, KC_7,    KC_8,    KC_9,     KC_PMNS,

--- a/keyboards/mitosis/keymaps/datagrok/readme.md
+++ b/keyboards/mitosis/keymaps/datagrok/readme.md
@@ -1,12 +1,13 @@
-![mitosis:datagrok layout image](https://i.imgur.com/eum3fsc.png)
+![mitosis:datagrok layout image](https://i.imgur.com/IxSZcOQ.png)
 
 [Keyboard layout editor source](http://www.keyboard-layout-editor.com/#/gists/9cf33be8a8e773647cfa44a0dbc44b31)
 
 # a layout for the Mitosis
 
-- Emphasis on momentary modifiers, all usable from either hand, arranged
-  symmetrically, but distinguishable left/right by the OS. Shift, Red
-  ("Lower"), Blue ("Raise"), Super ("Windows"), Meta ("Alt"), Hyper.
+- Emphasis on momentary modifiers, all usable from either hand, arranged symmetrically, but left/right distinguishable by the OS.
+  Shift, Red ("Lower"), Blue ("Raise"), Super ("Windows"), Meta ("Alt"), Hyper (actually Henkan/Muhenkan).
+  I'm going for a [Space Cadet](https://en.wikipedia.org/wiki/Space-cadet_keyboard) aesthetic;
+  I want a keyboard that can (even just in theory) make use of all the bucky bits my operating system can support.
 
 - Red and Blue are used to momentary-enable (like a shift key) one of three layers:
 
@@ -14,80 +15,169 @@
     - Blue: Numbers layer
     - "Purple" (both Red and Blue): Functions layer
 
-- The base layer is QWERTY. A slight variant of [Workman][] may be toggled-on.
+- The base layer is QWERTY.
+  A slight variant of [Workman][] may be toggled using `Red`+`Blue`+`Z`.
 
-- Emphasis on minimizing hand travel, so as not to lose orientation with
-  homerow.
-
-- Paired programming symbols (braces, brackets, parentheses) are arranged
-  symmetrically in the symbols layer.
+- Minimize hand travel, so as not to lose orientation with home row.
 
 - `?` and `!` are moved to take the place of `<` and `>`. Rationale: unmodded
   and shifted keys should be for prose, while symbols useful for programming
   should be colocated on their own layer.
 
-- No OS keymap modification required.
+- Key positions chosen for mnemonics.
+  For example, you can distinguish between alphanumeric numerals and keypad numerals, but they occupy the same key positions.
 
 ## Design notes
 
-- **I use an 8Mhz Pro Micro.** If you want to use this keymap with the standard
-  16Mhz Pro Micro specified in the Mitosis design:
+### Workman layout
 
-    - Remove the lines in `rules.mk` mentioning `F_CPU` and `F_USB`.
-    - Remove the lines in `config.h` mentioning `SERIAL_UART_BAUD`.
+- I'm learning a new physical key placement, so I might as well go all-out and
+  use an optimal non-QWERTY layout.
 
-- Workman layout
+- I like the way Workman feels and some of its advantages over Colemak.
+  Unfortunately, it was designed using a weighting system based on a standard
+  column-staggered keyboard so is probably not as optimal as one could achieve
+  on an ergonomic board like the Mitosis. Maybe run an optimizer routine after I
+  determine good values for key difficulty on the Mitosis.
 
-    - I'm learning a new physical key placement, so I might as well go all out
-      and use an optimal non-QWERTY layout.
+### 8Mhz Pro Micro
 
-    - I like the way Workman feels and some of its advantages over Colemak.
-      Unfortunately, it was designed using a weighting system based on a
-      standard column-staggered keyboard so is probably not as optimal as one
-      could achieve on an ergonomic board like the Mitosis. Maybe run an
-      optimizer routine after I determine good values for key difficulty on the
-      Mitosis.
+- I (used to) use a 3.3v Pro Micro clocked at 8Mhz rather than the 5v 16Mhz specified in the Mitosis design.
+  That can't communicate with the connected wireless module at the default speed of 1M baud.
+  The next fastest baudrate that works without errors is 250k baud.
+  So if you want to do the same:
 
-- Arrows in the home position (on a layer). Mod+Arrows = PgUp/PgDn/Home/End,
-  which is intuitive for me
+    - Set the Pro Micro clock rate correctly in `rules.mk`:
+      ```
+      F_CPU = 800000
+      ```
+    - Configure it to communicate at 250k baud in `config.h`:
+      ```
+      #undef SERIAL_UART_BAUD // avoids redefinition warning
+      #define SERIAL_UART_BAUD 250000
+      ```
+    - Configure the receiver's wireless module to communicate at 250k baud in `main.c`. See https://github.com/reversebias/mitosis/pull/10
+      ```
+      -          UART_BAUDRATE_BAUDRATE_Baud1M
+      +          UART_BAUDRATE_BAUDRATE_Baud250000
+      ```
 
-- I use tab all the time for autocompletion. To allow it to live on the base
-  layer it is now Mod-Tapped with left shift.
+### Layout mnemonics
+
+- Paired programming symbols (braces, brackets, parentheses) are arranged symmetrically in the Red layer.
+
+- Arrow keys are in the home position on the Red layer.
+
+  - Blue+Arrows = PgUp/PgDn/Home/End, which is intuitive for me.
+
+- The number pad: I placed the ten-key number pad on the Blue layer.
+  However, this would do the wrong thing when Num Lock was not enabled.
+  Rather than attempt to manage the state of Num Lock, I arranged the normal number keys in a ten-key layout on the Blue layer instead.
+  If you explicitly want the keypad keys, they're in the same position on the Red+Blue layer.
+
+- Number-pad add, subtract, multiply, and divide are located on the same keys as alphanumeric plus, dash, asterisk, and slash, respectively.
+
+- The Function-keys are arranged to mimic the order of the ten-key pad.
+
+- Enter is now in a more qwerty-familiar location, and may be activated with one hand.
+  Numpad Enter is in the same position.
+
+- Rather than place Backspace opposite Space, I intentionally place it on a layer where it takes some effort to activate.
+  Backspace is one of the keys I most dislike on a QWERTY keyboard because it moves me away from homerow and I need to use it so often.
+  Rather than make it easier to strike, I want to discourage myself from using it by learning to type more accurately.
+
+## Changelog
+
+### Current
+
+- New combined numbers + keypad arrangement.
+  No more worrying about Num Lock key.
+- Move F-keys to left board to make room.
+  Calling them "the Numbers layer" and "the Functions layer" is now less accurate but the arrangement feels better.
+- Audio working!
+- Move Tab and Space to upper thumb row.
+  I discarded the high-profile acrylic case from my Mitosis.
+  With a low-profile case, it's easier to hit the upper row of thumb keys.
+- Discard all my `#defines` for "Meta", "Super", and "Hyper".
+  I can call them that without making the code confusing to others.
+- Move Backspace to Red+A. I shouldn't be using it much anyway.
+  This means Tab and Shift might as well be separate keys again.
+- Distribute paired symbols symmetrically across boards like `\<{([ ])}>/`.
+  Opening-symbols on the right hand was a failed experiment. 
+- Change default back to target a 16Mhz/5v Pro Micro.
+  I damaged the 8Mhz Pro Micro I was using so now I'm back to using a 16mhz Pro Micro again.
+
+### 0.6.1
+
+- Place Tab on Shift without a modifier. We use it frequently for autocomplete.
+- Make QWERTY the default layout. So more people can try it out. My customized Workman is easily toggled-on.
+- Don't use redundant `#define` for `KC_TRNS`
+- Place Num Lock somewhere. Otherwise (if it gets turned off) we can't type any numbers!
+- Add some media keys
+
+### 0.5.155
+
+- Enable use with my 3.3v Pro Micro
+- Add a toggle-able QWERTY layer
+- Golf down the LED-setting code
+- Place `!` and `?` on `Shift`+`,` and `Shift`+`.`.
+- Distribute paired symbols symmetrically across boards like `\)}]> <[{(/`
+
+### 0.5.129
+
+- A modified Workman variant for Mitosis
+- Arrows in home position, modifier + Arrow = PgUp/PgDn/Home/End
+- Load all paired symbols onto angle-bracket keys.
 
 ### Abandoned ideas
 
-- ~~"Since QWERTY and Workman keep angle brackets together, place other
+- "Since QWERTY and Workman keep angle brackets together, place other
   enclosing symbols on the same keys. This informs the numbers placement,
-  which informs the function-key placement."~~
+  which informs the function-key placement."
 
     - I tried this and it was bad. I don't like having to pick the right
       modifier to get the right flavor of bracket. Instead, now, one modifier
       activates a symbols layer where all brackets are easily accessible.
 
-- Space/Enter to the left of layer select for Enter doesn't work well; I always
-  trigger space first when mashing the keys simultaneously. This might not
-  continue to be true if I change the angle at which I strike the keys e.g.
-  with a neoprene base or a wrist support.
+- Space/Enter to the left of layer select for Enter
+
+    - Doesn't work well; I always trigger space first when mashing the keys
+      simultaneously. ~~This might not continue to be true if I change the angle
+      at which I strike the keys e.g. with a neoprene base or a wrist support.~~
+      Even with a wrist rest or low-profile, this is hard to do with one hand.
+      Need to adjust the firmware to understand chorded thumb keys.
 
 - I used to have Blue on ring finger, but that was too hard to use in
   conjunction with shift.
 
 ## To do
 
-- Figure out where to place non-numpad numbers so we don't need num lock turned
-  on to type them?
-- Improve LED indications (may require modding bluetooth firmware):
+- **Shared Layouts.**
+  Figure out how to make use of QMK's common `layouts/`
+- **Chorded Combos.**
+  Since the thumb keys are arranged such that it's easy to smash pairs of keys with just one thumb, figure out how to enable chording.
+  For example, a single-finger Shift+Space or Red+Space that doesn't do the wrong thing if Space happens to trigger first.
+- Improve **LED indications** (may require modding bluetooth firmware):
+    - Num Lock status
     - Is any board nonresponsive (which one?)
     - Does either board have a low battery?
-- Add Insert, PrintScr, Pause/Break
-- ~~Make QWERTY base layer for people who customize layout in software?~~ I
-  default to QWERTY now.
+- **Num Lock management.**
+  Num lock currently occupies prime real estate, but I never use it except to fix it when it's wrong.
+  Do any of my applications use it?
+  Should I have the firmware ensure it is set how I want it?
+  Maybe cause it to be momentary active with Blue?
 - Store default base layer in eeprom?
 - See if the henkan/muhenkan placement is at all useful for Japanese speakers,
   or abuse different keysyms for Left/Right Hyper. (Original space cadet used
   scancodes 145/175. 145 is LANG2, 175 is "reserved" in USB HID spec.)
-- Mod a buzzer onto my receiver and enable tones
 - Implement "layer lock" key
 - Improve tri-layer behavior
+- Find a better location for PrintScr/SysRq, Scroll Lock, Pause/Break, Caps Lock.
+- ~~Figure out where to place non-numpad numbers so we don't need num lock turned
+  on to type them?~~
+- ~~Add Insert, PrintScr, Pause/Break~~
+- ~~Make QWERTY base layer for people who customize layout in software?~~
+  I default to QWERTY now.
+- ~~Mod a buzzer onto my receiver and enable tones~~ Easy and works!
 
 [Workman]: https://viralintrospection.wordpress.com/2010/09/06/a-different-philosophy-in-designing-keyboard-layouts/

--- a/keyboards/mitosis/keymaps/datagrok/readme.md
+++ b/keyboards/mitosis/keymaps/datagrok/readme.md
@@ -1,7 +1,3 @@
-![mitosis:datagrok layout image](https://i.imgur.com/IxSZcOQ.png)
-
-[Keyboard layout editor source](http://www.keyboard-layout-editor.com/#/gists/9cf33be8a8e773647cfa44a0dbc44b31)
-
 # a layout for the Mitosis
 
 - Emphasis on momentary modifiers, all usable from either hand, arranged symmetrically, but left/right distinguishable by the OS.
@@ -26,6 +22,22 @@
 
 - Key positions chosen for mnemonics.
   For example, you can distinguish between alphanumeric numerals and keypad numerals, but they occupy the same key positions.
+
+## Layout Images
+
+![mitosis:datagrok layout base layer](https://imgur.com/9LoLQUk.png)
+
+![mitosis:datagrok layout red layer](https://imgur.com/B5bnPGM.png)
+
+![mitosis:datagrok layout blue layer](https://imgur.com/HGJ4G1U.png)
+
+![mitosis:datagrok layout purple layer](https://imgur.com/lNsKDtA.png)
+
+Keyboard layout editor sources:
+[base](http://www.keyboard-layout-editor.com/#/gists/bc2d06a3203d1bc3a14ed2245cf39643)
+[red](http://www.keyboard-layout-editor.com/#/gists/dbbf65f726a5522824b75117a62a321e)
+[blue](http://www.keyboard-layout-editor.com/#/gists/240e807f3d7e1d3ddabe1b69ee675048)
+[purple](http://www.keyboard-layout-editor.com/#/gists/9559f0f8bb1ee47677c8f2b4d766829d)
 
 ## Design notes
 
@@ -86,10 +98,16 @@
   Backspace is one of the keys I most dislike on a QWERTY keyboard because it moves me away from homerow and I need to use it so often.
   Rather than make it easier to strike, I want to discourage myself from using it by learning to type more accurately.
 
+- Why do I dislike [snake\_case](https://en.wikipedia.org/wiki/Snake_case) (`__variable_names_that_use_underscores_`)?
+  Maybe because it's hard to type all those underscores requiring the shift key?
+  Hypothesis: I'll be less annoyed by snake case by placing `_` at an unmodded position, right near the `space` key.
+
+
 ## Changelog
 
 ### Current
 
+- Experiment: no-modifier underscore on right shift key.
 - New combined numbers + keypad arrangement.
   No more worrying about Num Lock key.
 - Move F-keys to left board to make room.
@@ -166,6 +184,7 @@
   Do any of my applications use it?
   Should I have the firmware ensure it is set how I want it?
   Maybe cause it to be momentary active with Blue?
+  See [@drashna's comment](https://github.com/qmk/qmk_firmware/pull/2366#issuecomment-404951953)
 - Store default base layer in eeprom?
 - See if the henkan/muhenkan placement is at all useful for Japanese speakers,
   or abuse different keysyms for Left/Right Hyper. (Original space cadet used

--- a/keyboards/mitosis/keymaps/datagrok/readme.md
+++ b/keyboards/mitosis/keymaps/datagrok/readme.md
@@ -27,17 +27,36 @@
 
 ![mitosis:datagrok layout base layer](https://imgur.com/9LoLQUk.png)
 
+Base layer. Notes:
+- customized comma and period, which have exclamation point and question mark on their shift layer.
+- tap right-shift for underscore
+
 ![mitosis:datagrok layout red layer](https://imgur.com/B5bnPGM.png)
+
+Red layer. Intended for common navigation and programming symbols. Notes:
+- symmetric layout of paired braces/brackets/slashes for easier memorization
+- arrows placed directly on home position
 
 ![mitosis:datagrok layout blue layer](https://imgur.com/HGJ4G1U.png)
 
+Blue layer. Intended for "number pad." Notes:
+- Keycodes generated for numbers, enter key, and mathematical symbols are from the alphanumeric keys, not keypad. This way they are not influenced by the state of Num Lock. If you want to send the keypad equivalents, just use Red and Blue modifiers simultaneously.
+
 ![mitosis:datagrok layout purple layer](https://imgur.com/lNsKDtA.png)
+
+Purple (Red+Blue) layer. Intended for "true keypad" and various functions. Notes:
+- Numbers on this layer send Keypad codes, so the result will be affected by the state of Num Lock.
+- "Switch Layout" toggles the alphabet keys between QWERTY and Workman
+- Page Up / Page Down / Home / End are placed on similar arrows
+- To press Print Screen it is necessary to use the left-side Red and Blue modifiers.
 
 Keyboard layout editor sources:
 [base](http://www.keyboard-layout-editor.com/#/gists/bc2d06a3203d1bc3a14ed2245cf39643)
 [red](http://www.keyboard-layout-editor.com/#/gists/dbbf65f726a5522824b75117a62a321e)
 [blue](http://www.keyboard-layout-editor.com/#/gists/240e807f3d7e1d3ddabe1b69ee675048)
 [purple](http://www.keyboard-layout-editor.com/#/gists/9559f0f8bb1ee47677c8f2b4d766829d)
+
+[Imgur album](https://imgur.com/a/KSoVgPx)
 
 ## Design notes
 

--- a/keyboards/mitosis/keymaps/datagrok/rules.mk
+++ b/keyboards/mitosis/keymaps/datagrok/rules.mk
@@ -1,3 +1,5 @@
+AUDIO_ENABLE = yes # audio output
+FAUXCLICKY_ENABLE = no
 BOOTMAGIC_ENABLE = no	# Virtual DIP switch configuration(+1000)
 MOUSEKEY_ENABLE = no	# Mouse keys(+4700)
 EXTRAKEY_ENABLE = yes	# Audio control and System control(+450)

--- a/keyboards/mitosis/keymaps/datagrok/rules.mk
+++ b/keyboards/mitosis/keymaps/datagrok/rules.mk
@@ -1,8 +1,3 @@
-# I use an 8Mhz Pro Micro
-F_CPU = 8000000
-# Necessary, with above change?
-F_USB = $(F_CPU)
-
 BOOTMAGIC_ENABLE = no	# Virtual DIP switch configuration(+1000)
 MOUSEKEY_ENABLE = no	# Mouse keys(+4700)
 EXTRAKEY_ENABLE = yes	# Audio control and System control(+450)


### PR DESCRIPTION
- Added a changelog, clearer layout images, and a heck of a lot more text to the readme.
- Experiment: no-modifier underscore on right shift key, by abusing Space Cadet.
- New combined numbers + keypad arrangement. No more worrying about Num Lock key.
- Move Function-keys to left board.
- Audio is working!
- Move Tab and Space to upper thumb row.
- Discard silly `#defines` for "Meta", "Super", and "Hyper".
- Move Backspace to Red+A. I shouldn't be using it much anyway.
- Distribute paired symbols symmetrically across boards like `\<{([ ])}>/`. (Opening symbols on left hand.)
- Change default back to target a 16Mhz/5v Pro Micro.

Thank you to @cari66ean, @drashna, and @codeincontext for discussion, tips and encouragement. Big thanks to @noroadsleft for helping to get the Mitosis (and many other keyboards!) working with the QMK configurator, which I have not yet attempted to understand :sweat_smile: 