### PR TITLE
E6V2 LE Caps Lock LED Fix

### DIFF
--- a/keyboards/e6v2/le/le.c
+++ b/keyboards/e6v2/le/le.c
@@ -23,7 +23,7 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
 
 void led_set_kb(uint8_t usb_led) {
 	// put your keyboard LED indicator (ex: Caps Lock LED) toggling code here
-	DDRB |= (1<<6);
+	DDRB |= (1<<7);
 	if (usb_led & (1<<USB_LED_CAPS_LOCK)) {
 			// output low
 			DDRB |= (1<<2);
@@ -33,21 +33,12 @@ void led_set_kb(uint8_t usb_led) {
 			DDRB &= ~(1<<2);
 			PORTB &= ~(1<<2);
 		}
-	// DDRB |= (1<<7);
-	// DDRB |= (1<<1);
-	// DDRB |= (1<<3);
-	// DDRE |= (1<<6);
 	if (usb_led == 0){
-		PORTB |= (1<<6);
-		// PORTB |= (1<<7);
-		// PORTB |= (1<<1);
-		// PORTB |= (1<<3);
-		// PORTE |= (1<<6);
+		PORTB |= (1<<7);
 	}
 	else{
-		PORTB &= ~(1<<6);
-		// PORTB &= ~(1<<7);
+		PORTB &= ~(1<<7);
 	}
-    
+
 	led_set_user(usb_led);
 }


### PR DESCRIPTION
It was reported to me that the Caps Lock LED did not work. 

The fix was to change the pin from B6 to B7. 