### PR TITLE
E6V2 LE: Top Right Keys are Reversed

### DIFF
--- a/keyboards/e6v2/le/le.h
+++ b/keyboards/e6v2/le/le.h
@@ -4,7 +4,7 @@
 #include "../e6v2.h"
 
 #define LAYOUT( \
-    K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C, K0D, K0E, \
+    K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C, K0E, K0D, \
     K10,      K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, K1C, K1D, K1E, \
     K20,      K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B, K2C, K2D,      \
     K30, K31, K32, K33, K34, K35, K36, K37, K38, K39, K3A, K3B, K3C, K3D, K3E, \


### PR DESCRIPTION
Bug was reported in which in a hhkb layout, the top right keys, backslash and delete were reversed.

Fix is to literally change the positioning of those two in the LAYOUT macro. 