### PR TITLE
Add #include "config_common.h" after #pragma once to config.h templates

### DIFF
--- a/quantum/template/avr/config.h
+++ b/quantum/template/avr/config.h
@@ -17,6 +17,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
+#include "config_common.h"
+
 /* USB Device descriptor parameter */
 #define VENDOR_ID       0xFEED
 #define PRODUCT_ID      0x0000
@@ -201,14 +203,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define LCD_DATA3_PORT   LCD_PORT     //< port for 4bit data bit 3
 #define LCD_DATA0_PIN    4            //< pin for 4bit data bit 0
 #define LCD_DATA1_PIN    5            //< pin for 4bit data bit 1
-#define LCD_DATA2_PIN    6            //< pin for 4bit data bit 2 
+#define LCD_DATA2_PIN    6            //< pin for 4bit data bit 2
 #define LCD_DATA3_PIN    7            //< pin for 4bit data bit 3
-#define LCD_RS_PORT      LCD_PORT     //< port for RS line        
-#define LCD_RS_PIN       3            //< pin  for RS line        
-#define LCD_RW_PORT      LCD_PORT     //< port for RW line        
-#define LCD_RW_PIN       2            //< pin  for RW line        
-#define LCD_E_PORT       LCD_PORT     //< port for Enable line     
-#define LCD_E_PIN        1            //< pin  for Enable line    
+#define LCD_RS_PORT      LCD_PORT     //< port for RS line
+#define LCD_RS_PIN       3            //< pin  for RS line
+#define LCD_RW_PORT      LCD_PORT     //< port for RW line
+#define LCD_RW_PIN       2            //< pin  for RW line
+#define LCD_E_PORT       LCD_PORT     //< port for Enable line
+#define LCD_E_PIN        1            //< pin  for Enable line
 #endif
-*/ 
+*/
 

--- a/quantum/template/ps2avrgb/config.h
+++ b/quantum/template/ps2avrgb/config.h
@@ -17,6 +17,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
+#include "config_common.h"
+
 #define VENDOR_ID       0x20A0
 #define PRODUCT_ID      0x422D
 #define MANUFACTURER    You


### PR DESCRIPTION
per @drashna 

Added `#include "config_common.h"` after `#pragma once` in:

- `quantum/template/avr/config.h`
- `quantum/template/ps2avrgb/config.h`
