### PR TITLE
KC60se matrix fixes

### DIFF
--- a/keyboards/kc60se/kc60se.h
+++ b/keyboards/kc60se/kc60se.h
@@ -33,7 +33,7 @@ inline void kc60se_caps_led_off(void) { DDRB &= ~(1<<2); PORTB &= ~(1<<2); }
     K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C, K0D, K49 \
     K10, K11, K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, K1C, K1D, \
     K20, K21, K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B, K2C, K2D, \
-    K30, K31, K32, K33, K34, K35, K36, K37, K38, K39, K3A, K3B, K3C, K3D, \
+    K30, K31, K32, K33, K34, K35, K36, K37, K38, K39, K3A, K3B, K3D, K3C, \
     K40, K41, K42,           K45,                     K4A, K4B, K4C, K4D  \
 ) { \
     { K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C, K0D }, \

--- a/keyboards/kc60se/kc60se.h
+++ b/keyboards/kc60se/kc60se.h
@@ -55,7 +55,7 @@ inline void kc60se_caps_led_off(void) { DDRB &= ~(1<<2); PORTB &= ~(1<<2); }
     { K10, K11, K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, K1C, K1D }, \
     { K20, K21, K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B, ___, K2D }, \
     { K30, ___, K32, K33, K34, K35, K36, K37, K38, K39, K3A, K3B, ___, K3D }, \
-    { K40, K41, K42, ___, ___, K45, ___, ___, ___, K4A, K4B, K4C, K4D }  \
+    { K40, K41, K42, ___, ___, K45, ___, ___, ___, ___, K4A, K4B, K4C, K4D }  \
 }
 
 /* HHKB

--- a/keyboards/kc60se/kc60se.h
+++ b/keyboards/kc60se/kc60se.h
@@ -30,7 +30,7 @@ inline void kc60se_caps_led_off(void) { DDRB &= ~(1<<2); PORTB &= ~(1<<2); }
  */
 // All pads defined in logical layout. The ___ in this section are padless.
 #define LAYOUT( \
-    K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C, K0D, \
+    K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C, K0D, K49 \
     K10, K11, K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, K1C, K1D, \
     K20, K21, K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B, K2C, K2D, \
     K30, K31, K32, K33, K34, K35, K36, K37, K38, K39, K3A, K3B, K3C, K3D, \
@@ -40,7 +40,7 @@ inline void kc60se_caps_led_off(void) { DDRB &= ~(1<<2); PORTB &= ~(1<<2); }
     { K10, K11, K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, K1C, K1D }, \
     { K20, K21, K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B, K2C, K2D }, \
     { K30, K31, K32, K33, K34, K35, K36, K37, K38, K39, K3A, K3B, K3C, K3D }, \
-    { K40, K41, K42, ___, ___, K45, ___, ___, ___, ___, K4A, K4B, K4C, K4D }  \
+    { K40, K41, K42, ___, ___, K45, ___, ___, ___, K49, K4A, K4B, K4C, K4D }  \
 }
 
 /* ANSI */

--- a/keyboards/kc60se/kc60se.h
+++ b/keyboards/kc60se/kc60se.h
@@ -18,6 +18,9 @@
 
 #include "quantum.h"
 
+// readability
+#define ___ KC_NO
+
 inline void kc60se_caps_led_on(void)  { DDRB |=  (1<<2); PORTB &= ~(1<<2); }
 inline void kc60se_caps_led_off(void) { DDRB &= ~(1<<2); PORTB &= ~(1<<2); }
 
@@ -25,7 +28,7 @@ inline void kc60se_caps_led_off(void) { DDRB &= ~(1<<2); PORTB &= ~(1<<2); }
  * K2C, K31 and  K3C are keys for ISO
  * This is the row/column wiring, which different from the physical layout.
  */
-// All pads defined in logical layout. The KC_NO in this section are padless.
+// All pads defined in logical layout. The ___ in this section are padless.
 #define LAYOUT( \
     K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C, K0D, \
     K10, K11, K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, K1C, K1D, \
@@ -37,7 +40,7 @@ inline void kc60se_caps_led_off(void) { DDRB &= ~(1<<2); PORTB &= ~(1<<2); }
     { K10, K11, K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, K1C, K1D }, \
     { K20, K21, K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B, K2C, K2D }, \
     { K30, K31, K32, K33, K34, K35, K36, K37, K38, K39, K3A, K3B, K3C, K3D }, \
-    { K40, K41, K42, KC_NO,KC_NO,K45,KC_NO,KC_NO,KC_NO,KC_NO,K4A,K4B,K4C,K4D }  \
+    { K40, K41, K42, ___, ___, K45, ___, ___, ___, ___, K4A, K4B, K4C, K4D }  \
 }
 
 /* ANSI */
@@ -50,15 +53,15 @@ inline void kc60se_caps_led_off(void) { DDRB &= ~(1<<2); PORTB &= ~(1<<2); }
 ) { \
     { K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C, K0D }, \
     { K10, K11, K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, K1C, K1D }, \
-    { K20, K21, K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B,KC_NO,K2D }, \
-    { K30,KC_NO,K32, K33, K34, K35, K36, K37, K38, K39, K3A, K3B,KC_NO,K3D }, \
-    { K40, K41, K42, KC_NO,KC_NO,K45, KC_NO,KC_NO,KC_NO,K4A, K4B,K4C,  K4D }  \
+    { K20, K21, K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B, ___, K2D }, \
+    { K30, ___, K32, K33, K34, K35, K36, K37, K38, K39, K3A, K3B, ___, K3D }, \
+    { K40, K41, K42, ___, ___, K45, ___, ___, ___, K4A, K4B, K4C, K4D }  \
 }
 
 /* HHKB
- *  K2C & K31 are represented as KC_NO, otherwise this is
+ *  K2C & K31 are represented as ___, otherwise this is
  *  the best representation of the physical layout, (K49 on top right).
- *  The KC_NOs on the space row do not have pads
+ *  The ___s on the space row do not have pads
  */
 #define LAYOUT_60_ansi_split_bs_rshift( \
     K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C, K0D, K49,\
@@ -69,9 +72,9 @@ inline void kc60se_caps_led_off(void) { DDRB &= ~(1<<2); PORTB &= ~(1<<2); }
 ) { \
     { K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C, K0D }, \
     { K10, K11, K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, K1C, K1D }, \
-    { K20, K21, K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B,KC_NO,K2D }, \
-    { K30,KC_NO,K32, K33, K34, K35, K36, K37, K38, K39, K3A, K3B, K3C, K3D }, \
-    { K40, K41,K42,KC_NO,KC_NO,K45,KC_NO,KC_NO,KC_NO,K49,K4A,K4B, K4C, K4D }  \
+    { K20, K21, K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B, ___, K2D }, \
+    { K30, ___, K32, K33, K34, K35, K36, K37, K38, K39, K3A, K3B, K3C, K3D }, \
+    { K40, K41, K42, ___, ___, K45, ___, ___, ___, K49, K4A, K4B, K4C, K4D }  \
 }
 
 


### PR DESCRIPTION
This PR repairs three issues with the KC60se:

1. The `LAYOUT` matrix previously stated that the 10th column on the 5th row (position K49) had no pad, but this position is actually used for the right-hand half of split backspace.
2. `LAYOUT` also placed K3C to the left of K3D when using a split right Shift. but K3D Is actually to the left of K3C in this scenario.
3. Reported by @NimMooMoo on QMK Discord, the right-hand modifiers on the bottom row when using the `LAYOUT_60_ansi` matrix were offset one key to the right. The cause of this behavior was the `LAYOUT_60_ansi` matrix being one column short on the last row, containing 13 columns when the matrix has 14.