### PR TITLE
Fix RG Sleep issues for Teensy Controllers

### DIFF
--- a/tmk_core/common/avr/suspend.c
+++ b/tmk_core/common/avr/suspend.c
@@ -189,6 +189,9 @@ void suspend_wakeup_init(void)
 #endif
 	led_set(host_keyboard_leds());
 #if defined(RGBLIGHT_SLEEP) && defined(RGBLIGHT_ENABLE)
+#ifdef BOOTLOADER_TEENSY
+  wait_ms(10);
+#endif
   rgblight_enable_noeeprom();
 #ifdef RGBLIGHT_ANIMATIONS
   rgblight_timer_enable();


### PR DESCRIPTION
Appearenly, teensy controllers have some issues with waking up.  If the rgblight is called "too soon", it will cause the controller to lock up, intermittently. Adding a 10 ms
delay seems to fix this issue, as it lets it have enough time to handle things properly.

This has been tested extensively on my Ergodox EZ, and can be seen in the @drashna userspace, under the "suspend_wakeup_init_user" function.


Notes: 
* I'm not sure this is the best way to detect the Teensy, but it should work. 
* I haven't tested without this, in a while, because it's a PITA. But I think this is still needed