### PR TITLE
Fix UTF-8 encoding for DC01 Numpad info.json

### DIFF
--- a/keyboards/dc01/numpad/info.json
+++ b/keyboards/dc01/numpad/info.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "keyboard_name": "DC01 Numpad",
   "url": "",
   "maintainer": "qmk",


### PR DESCRIPTION
This file had a bad character encoding when submitted in #3445. This PR is a fix.