### PR TITLE
Fix character encoding for Kona Classic's info.json

### DIFF
--- a/keyboards/kona_classic/info.json
+++ b/keyboards/kona_classic/info.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "keyboard_name": "Kona Classic",
   "url": "",
   "maintainer": "qmk",


### PR DESCRIPTION
This file had a bad character encoding when submitted in #3464.