### PR TITLE
Fix for the Split Common I2C code's SCL_CLOCK issue

### DIFF
--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -91,6 +91,8 @@ This is a C header file that is one of the first things included, and will persi
   * key combination that allows the use of magic commands (useful for debugging)
 * `#define USB_MAX_POWER_CONSUMPTION`
   * sets the maximum power (in mA) over USB for the device (default: 500)
+* '#define SCL_CLOCK 400000L` 
+  * sets the SCL_CLOCK speed for split keyboards. The default is `400000L` but some boards need to be set to `100000L`.
 
 ## Features That Can Be Disabled
 

--- a/keyboards/iris/config.h
+++ b/keyboards/iris/config.h
@@ -15,9 +15,9 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef CONFIG_H
-#define CONFIG_H
+#pragma once
 
 #include "config_common.h"
 
-#endif  // CONFIG_H
+#define SCL_CLOCK 100000L
+

--- a/quantum/split_common/i2c.h
+++ b/quantum/split_common/i2c.h
@@ -25,7 +25,9 @@
 #define SLAVE_BUFFER_SIZE 0x20
 
 // i2c SCL clock frequency
+#ifndef SCL_CLOCK
 #define SCL_CLOCK  400000L
+#endif
 
 // Support 8bits right now (8 cols) will need to edit to take higher (code exists in delta split?)
 extern volatile uint8_t i2c_slave_buffer[SLAVE_BUFFER_SIZE];


### PR DESCRIPTION
Sets up the SCL_CLOCK speed to be configurable, per keyboard. And adds documentation for the setting. 

@That-Canadian and @nooges Did this look good?  Or did we want to handle this in a different way, or use a different default? 