### PR TITLE
Remove default folders for the Planck & Preonic

### DIFF
--- a/keyboards/planck/rules.mk
+++ b/keyboards/planck/rules.mk
@@ -77,5 +77,3 @@ SLEEP_LED_ENABLE = no    # Breathing sleep LED during USB suspend
 
 LAYOUTS = ortho_4x12 planck_mit planck_grid
 LAYOUTS_HAS_RGB = no
-
-DEFAULT_FOLDER = planck/rev5

--- a/keyboards/preonic/rules.mk
+++ b/keyboards/preonic/rules.mk
@@ -72,5 +72,3 @@ API_SYSEX_ENABLE = no
 SLEEP_LED_ENABLE = no    # Breathing sleep LED during USB suspend
 
 LAYOUTS = ortho_5x12
-
-DEFAULT_FOLDER = preonic/rev2


### PR DESCRIPTION
Doing this to remove the chance of the wrong firmware being built/flashed, since rev 6/3 firmwares are incompatible with past versions.

I've apparently forgotten how this system works - looks like it'll require some additional changes.