### PR TITLE
Add qmk-dfuse flash target for STM32 devices

### DIFF
--- a/tmk_core/chibios.mk
+++ b/tmk_core/chibios.mk
@@ -198,10 +198,14 @@ ifneq ("$(SERIAL)","")
 	DFU_ARGS += -S $(SERIAL)
 endif
 
+DFUSE_ARGS ?=
+
 # List any extra directories to look for libraries here.
 EXTRALIBDIRS = $(RULESPATH)/ld
 
 DFU_UTIL ?= dfu-util
+
+QMK_DFUSE ?= qmk-dfuse
 
 # Generate a .qmk for the QMK-FF
 qmk: $(BUILD_DIR)/$(TARGET).bin
@@ -229,6 +233,9 @@ qmk: $(BUILD_DIR)/$(TARGET).bin
 
 dfu-util: $(BUILD_DIR)/$(TARGET).bin cpfirmware sizeafter
 	$(DFU_UTIL) $(DFU_ARGS) -D $(BUILD_DIR)/$(TARGET).bin
+
+qmk-dfuse: $(BUILD_DIR)/$(TARGET).hex cpfirmware sizeafter
+	$(QMK_DFUSE) $(DFUSE_ARGS) --download $(BUILD_DIR)/$(TARGET).hex --verify --restart
 
 bin: $(BUILD_DIR)/$(TARGET).bin sizeafter
 	$(COPY) $(BUILD_DIR)/$(TARGET).bin $(TARGET).bin;

--- a/util/activate_wsl.sh
+++ b/util/activate_wsl.sh
@@ -8,6 +8,7 @@ function export_variables {
     export DFU_UTIL=$download_dir/dfu-util-0.9-win64/dfu-util.exe
     export TEENSY_LOADER_CLI=$download_dir/teensy_loader_cli.exe
     export BATCHISP=batchisp.exe
+    export QMK_DFUSE=$download_dir/qmk-dfuse.exe
 }
 
 export_variables

--- a/util/drivers.txt
+++ b/util/drivers.txt
@@ -4,7 +4,6 @@
 # Driver can be one of winusb,libusb,libusbk
 # Use Windows Powershell and type [guid]::NewGuid() to generate guids
 winusb,Kiibohd DFU Bootloader,1C11,B007,aa5a3f86-b81e-4416-89ad-0c1ea1ed63af
-winusb,STM32 Bootloader,0483,df11,6d98a87f-4ecf-464d-89ed-8c684d857a75
 libusb,ATxmega16C4,03EB,2FD8,23266ee7-5423-4cc4-993b-034571c43a90
 libusb,ATxmega32C4,03EB,2FD9,d4b62886-2ac8-4534-aa24-eae0a2c3ce43
 libusb,ATxmega64C3,03EB,2FD6,08467ca7-9b5a-41d2-8d8a-4a26d0b5285b

--- a/util/win_shared_install.sh
+++ b/util/win_shared_install.sh
@@ -21,12 +21,16 @@ function install_utils {
     # This URL has changed and I can't find the new location. Commenting out until we figure out the new URL or determine this isn't needed. -skullY
     echo "Installing Atmel Flip"
     wget 'http://ww1.microchip.com/downloads/en/DeviceDoc/Flip%20Installer%20-%203.4.7.112.exe'
-    # This is the JRE-less installer, if we need the larger bundled with JRE installer, use this: 
+    # This is the JRE-less installer, if we need the larger bundled with JRE installer, use this:
     #wget 'http://ww1.microchip.com/downloads/en/DeviceDoc/JRE%20-%20Flip%20Installer%20-%203.4.7.112.exe'
     mv Flip\ Installer\ \-\ 3.4.7.112.exe FlipInstaller.exe
 
     echo "Downloading the QMK driver installer"
     wget -qO- https://api.github.com/repos/qmk/qmk_driver_installer/releases | grep browser_download_url | head -n 1 | cut -d '"' -f 4 | wget -i -
+
+    echo "Downloading qmk-dfuse"
+    wget -qO- https://api.github.com/repos/qmk/qmk_dfuse/releases | grep browser_download_url | head -n 2 | cut -d '"' -f 4 | wget -i -
+    unzip -d dfuse_driver Driver.zip
 
     rm -f *.zip
 
@@ -36,8 +40,15 @@ function install_utils {
 function install_drivers {
     pushd "$download_dir"
     cp -f "$dir/drivers.txt" .
-    echo 
+    echo
     cmd.exe /c "qmk_driver_installer.exe $1 $2 drivers.txt"
+    popd > /dev/null
+}
+
+function install_dfuse {
+    pushd "$download_dir/dfuse_driver"
+    echo
+    cmd.exe /c install.bat
     popd > /dev/null
 }
 
@@ -78,6 +89,15 @@ while true; do
     esac
 done
 
+while true; do
+    echo
+    read -p "Do you want install the STM32 dfuse drivers (Y/N)" res
+    case $res in
+        [Yy]* ) install_dfuse; break;;
+        [Nn]* ) break;;
+        * ) echo "Invalid answer";;
+    esac
+done
 
 popd > /dev/null
 


### PR DESCRIPTION
The dfu-util tool requires uncertified drivers on Windows, which can cause compatibility problems, so the recommended tool and make target is now qmk-dfuse.

The needed drivers should be installed by default on Windows 10, but are also installed by the installation scripts as an additional safety guard.

**NOTE** This target only works on Windows machines, Linux and Mac users should continue to use dfu-util.