### PR TITLE
Backport fixes for GCC 8.1

### DIFF
--- a/lib/lufa/Demos/Device/ClassDriver/DualVirtualSerial/DualVirtualSerial.c
+++ b/lib/lufa/Demos/Device/ClassDriver/DualVirtualSerial/DualVirtualSerial.c
@@ -231,12 +231,14 @@ void EVENT_CDC_Device_ControLineStateChanged(USB_ClassInfo_CDC_Device_t *const C
 	*/
 	bool HostReady = (CDCInterfaceInfo->State.ControlLineStates.HostToDevice & CDC_CONTROL_LINE_OUT_DTR) != 0;
 
+	(void)HostReady;
+
 	if (CDCInterfaceInfo == &VirtualSerial1_CDC_Interface)
 	{
-		// CDC interface 1's host is ready to send/receive data
+		// CDC interface 1's host is ready to send/receive data if HostReady is true
 	}
 	else
 	{
-		// CDC interface 2's host is ready to send/receive data
+		// CDC interface 2's host is ready to send/receive data if HostReady is true
 	}
 }

--- a/lib/lufa/Demos/Device/ClassDriver/VirtualSerial/VirtualSerial.c
+++ b/lib/lufa/Demos/Device/ClassDriver/VirtualSerial/VirtualSerial.c
@@ -199,4 +199,6 @@ void EVENT_CDC_Device_ControLineStateChanged(USB_ClassInfo_CDC_Device_t *const C
 	   in the pending data from the USB endpoints.
 	*/
 	bool HostReady = (CDCInterfaceInfo->State.ControlLineStates.HostToDevice & CDC_CONTROL_LINE_OUT_DTR) != 0;
+
+	(void)HostReady;
 }

--- a/lib/lufa/Demos/Device/ClassDriver/VirtualSerialMassStorage/VirtualSerialMassStorage.c
+++ b/lib/lufa/Demos/Device/ClassDriver/VirtualSerialMassStorage/VirtualSerialMassStorage.c
@@ -238,6 +238,8 @@ void EVENT_CDC_Device_ControLineStateChanged(USB_ClassInfo_CDC_Device_t *const C
 	   in the pending data from the USB endpoints.
 	*/
 	bool HostReady = (CDCInterfaceInfo->State.ControlLineStates.HostToDevice & CDC_CONTROL_LINE_OUT_DTR) != 0;
+
+	(void)HostReady;
 }
 
 /** Mass Storage class driver callback function the reception of SCSI commands from the host, which must be processed.

--- a/lib/lufa/Demos/Device/ClassDriver/VirtualSerialMouse/VirtualSerialMouse.c
+++ b/lib/lufa/Demos/Device/ClassDriver/VirtualSerialMouse/VirtualSerialMouse.c
@@ -279,4 +279,6 @@ void EVENT_CDC_Device_ControLineStateChanged(USB_ClassInfo_CDC_Device_t *const C
 	   in the pending data from the USB endpoints.
 	*/
 	bool HostReady = (CDCInterfaceInfo->State.ControlLineStates.HostToDevice & CDC_CONTROL_LINE_OUT_DTR) != 0;
+
+	(void)HostReady;
 }

--- a/lib/lufa/LUFA/Drivers/USB/Class/Device/AudioClassDevice.c
+++ b/lib/lufa/LUFA/Drivers/USB/Class/Device/AudioClassDevice.c
@@ -188,7 +188,7 @@ bool Audio_Device_ConfigureEndpoints(USB_ClassInfo_Audio_Device_t* const AudioIn
 	return true;
 }
 
-void Audio_Device_Event_Stub(void)
+void Audio_Device_Event_Stub(USB_ClassInfo_Audio_Device_t* const AudioInterfaceInfo)
 {
 
 }

--- a/lib/lufa/LUFA/Drivers/USB/Class/Device/AudioClassDevice.h
+++ b/lib/lufa/LUFA/Drivers/USB/Class/Device/AudioClassDevice.h
@@ -377,7 +377,7 @@
 	#if !defined(__DOXYGEN__)
 		/* Function Prototypes: */
 			#if defined(__INCLUDE_FROM_AUDIO_DEVICE_C)
-				void Audio_Device_Event_Stub(void);
+				void Audio_Device_Event_Stub(USB_ClassInfo_Audio_Device_t* const AudioInterfaceInfo);
 
 				void EVENT_Audio_Device_StreamStartStop(USB_ClassInfo_Audio_Device_t* const AudioInterfaceInfo)
 				                                        ATTR_WEAK ATTR_NON_NULL_PTR_ARG(1) ATTR_ALIAS(Audio_Device_Event_Stub);

--- a/lib/lufa/LUFA/Drivers/USB/Class/Device/AudioClassDevice.h
+++ b/lib/lufa/LUFA/Drivers/USB/Class/Device/AudioClassDevice.h
@@ -377,7 +377,7 @@
 	#if !defined(__DOXYGEN__)
 		/* Function Prototypes: */
 			#if defined(__INCLUDE_FROM_AUDIO_DEVICE_C)
-				void Audio_Device_Event_Stub(void) ATTR_CONST;
+				void Audio_Device_Event_Stub(void);
 
 				void EVENT_Audio_Device_StreamStartStop(USB_ClassInfo_Audio_Device_t* const AudioInterfaceInfo)
 				                                        ATTR_WEAK ATTR_NON_NULL_PTR_ARG(1) ATTR_ALIAS(Audio_Device_Event_Stub);

--- a/lib/lufa/LUFA/Drivers/USB/Class/Device/CDCClassDevice.c
+++ b/lib/lufa/LUFA/Drivers/USB/Class/Device/CDCClassDevice.c
@@ -353,9 +353,14 @@ static int CDC_Device_getchar_Blocking(FILE* Stream)
 }
 #endif
 
-void CDC_Device_Event_Stub(void)
+void CDC_Device_Event_Stub(USB_ClassInfo_CDC_Device_t* const CDCInterfaceInfo)
 {
 
+}
+
+void CDC_Device_Event_Stub_2(USB_ClassInfo_CDC_Device_t* const CDCInterfaceInfo, const uint8_t _1)
+{
+	CDC_Device_Event_Stub(CDCInterfaceInfo);
 }
 
 #endif

--- a/lib/lufa/LUFA/Drivers/USB/Class/Device/CDCClassDevice.h
+++ b/lib/lufa/LUFA/Drivers/USB/Class/Device/CDCClassDevice.h
@@ -362,7 +362,8 @@
 				static int CDC_Device_getchar_Blocking(FILE* Stream) ATTR_NON_NULL_PTR_ARG(1);
 				#endif
 
-				void CDC_Device_Event_Stub(void);
+				void CDC_Device_Event_Stub(USB_ClassInfo_CDC_Device_t* const CDCInterfaceInfo);
+				void CDC_Device_Event_Stub_2(USB_ClassInfo_CDC_Device_t* const CDCInterfaceInfo, const uint8_t _1);
 
 				void EVENT_CDC_Device_LineEncodingChanged(USB_ClassInfo_CDC_Device_t* const CDCInterfaceInfo)
 				                                          ATTR_WEAK ATTR_NON_NULL_PTR_ARG(1) ATTR_ALIAS(CDC_Device_Event_Stub);
@@ -370,7 +371,7 @@
 				                                             ATTR_WEAK ATTR_NON_NULL_PTR_ARG(1) ATTR_ALIAS(CDC_Device_Event_Stub);
 				void EVENT_CDC_Device_BreakSent(USB_ClassInfo_CDC_Device_t* const CDCInterfaceInfo,
 				                                const uint8_t Duration) ATTR_WEAK ATTR_NON_NULL_PTR_ARG(1)
-				                                ATTR_ALIAS(CDC_Device_Event_Stub);
+				                                ATTR_ALIAS(CDC_Device_Event_Stub_2);
 			#endif
 
 	#endif

--- a/lib/lufa/LUFA/Drivers/USB/Class/Device/CDCClassDevice.h
+++ b/lib/lufa/LUFA/Drivers/USB/Class/Device/CDCClassDevice.h
@@ -362,7 +362,7 @@
 				static int CDC_Device_getchar_Blocking(FILE* Stream) ATTR_NON_NULL_PTR_ARG(1);
 				#endif
 
-				void CDC_Device_Event_Stub(void) ATTR_CONST;
+				void CDC_Device_Event_Stub(void);
 
 				void EVENT_CDC_Device_LineEncodingChanged(USB_ClassInfo_CDC_Device_t* const CDCInterfaceInfo)
 				                                          ATTR_WEAK ATTR_NON_NULL_PTR_ARG(1) ATTR_ALIAS(CDC_Device_Event_Stub);

--- a/lib/lufa/LUFA/Drivers/USB/Class/Device/PrinterClassDevice.c
+++ b/lib/lufa/LUFA/Drivers/USB/Class/Device/PrinterClassDevice.c
@@ -305,7 +305,7 @@ static int PRNT_Device_getchar_Blocking(FILE* Stream)
 }
 #endif
 
-void PRNT_Device_Event_Stub(void)
+void PRNT_Device_Event_Stub(USB_ClassInfo_PRNT_Device_t* const PRNTInterfaceInfo)
 {
 
 }

--- a/lib/lufa/LUFA/Drivers/USB/Class/Device/PrinterClassDevice.h
+++ b/lib/lufa/LUFA/Drivers/USB/Class/Device/PrinterClassDevice.h
@@ -273,7 +273,7 @@
 				static int PRNT_Device_getchar_Blocking(FILE* Stream) ATTR_NON_NULL_PTR_ARG(1);
 				#endif
 
-				void PRNT_Device_Event_Stub(void) ATTR_CONST;
+				void PRNT_Device_Event_Stub(void);
 
 				void EVENT_PRNT_Device_SoftReset(USB_ClassInfo_PRNT_Device_t* const PRNTInterfaceInfo)
 				                                 ATTR_WEAK ATTR_NON_NULL_PTR_ARG(1) ATTR_ALIAS(PRNT_Device_Event_Stub);

--- a/lib/lufa/LUFA/Drivers/USB/Class/Device/PrinterClassDevice.h
+++ b/lib/lufa/LUFA/Drivers/USB/Class/Device/PrinterClassDevice.h
@@ -273,7 +273,7 @@
 				static int PRNT_Device_getchar_Blocking(FILE* Stream) ATTR_NON_NULL_PTR_ARG(1);
 				#endif
 
-				void PRNT_Device_Event_Stub(void);
+				void PRNT_Device_Event_Stub(USB_ClassInfo_PRNT_Device_t* const PRNTInterfaceInfo);
 
 				void EVENT_PRNT_Device_SoftReset(USB_ClassInfo_PRNT_Device_t* const PRNTInterfaceInfo)
 				                                 ATTR_WEAK ATTR_NON_NULL_PTR_ARG(1) ATTR_ALIAS(PRNT_Device_Event_Stub);

--- a/lib/lufa/LUFA/Drivers/USB/Class/Host/CDCClassHost.c
+++ b/lib/lufa/LUFA/Drivers/USB/Class/Host/CDCClassHost.c
@@ -503,7 +503,7 @@ static int CDC_Host_getchar_Blocking(FILE* Stream)
 }
 #endif
 
-void CDC_Host_Event_Stub(void)
+void CDC_Host_Event_Stub(USB_ClassInfo_CDC_Host_t* const CDCInterfaceInfo)
 {
 
 }

--- a/lib/lufa/LUFA/Drivers/USB/Class/Host/CDCClassHost.h
+++ b/lib/lufa/LUFA/Drivers/USB/Class/Host/CDCClassHost.h
@@ -360,7 +360,7 @@
 				static int CDC_Host_getchar_Blocking(FILE* Stream) ATTR_NON_NULL_PTR_ARG(1);
 				#endif
 
-				void CDC_Host_Event_Stub(void);
+				void CDC_Host_Event_Stub(USB_ClassInfo_CDC_Host_t* const CDCInterfaceInfo);
 
 				void EVENT_CDC_Host_ControLineStateChanged(USB_ClassInfo_CDC_Host_t* const CDCInterfaceInfo)
 				                                           ATTR_WEAK ATTR_NON_NULL_PTR_ARG(1) ATTR_ALIAS(CDC_Host_Event_Stub);

--- a/lib/lufa/LUFA/Drivers/USB/Class/Host/CDCClassHost.h
+++ b/lib/lufa/LUFA/Drivers/USB/Class/Host/CDCClassHost.h
@@ -360,7 +360,7 @@
 				static int CDC_Host_getchar_Blocking(FILE* Stream) ATTR_NON_NULL_PTR_ARG(1);
 				#endif
 
-				void CDC_Host_Event_Stub(void) ATTR_CONST;
+				void CDC_Host_Event_Stub(void);
 
 				void EVENT_CDC_Host_ControLineStateChanged(USB_ClassInfo_CDC_Host_t* const CDCInterfaceInfo)
 				                                           ATTR_WEAK ATTR_NON_NULL_PTR_ARG(1) ATTR_ALIAS(CDC_Host_Event_Stub);

--- a/lib/lufa/LUFA/Drivers/USB/Core/Events.c
+++ b/lib/lufa/LUFA/Drivers/USB/Core/Events.c
@@ -37,3 +37,12 @@ void USB_Event_Stub(void)
 
 }
 
+void USB_Event_Stub_2(const uint8_t _1)
+{
+	USB_Event_Stub();
+}
+
+void USB_Event_Stub_3(const uint8_t _1, const uint8_t _2)
+{
+	USB_Event_Stub();
+}

--- a/lib/lufa/LUFA/Drivers/USB/Core/Events.h
+++ b/lib/lufa/LUFA/Drivers/USB/Core/Events.h
@@ -332,19 +332,21 @@
 		/* Function Prototypes: */
 			#if defined(__INCLUDE_FROM_EVENTS_C)
 				void USB_Event_Stub(void);
+				void USB_Event_Stub_2(const uint8_t _1);
+				void USB_Event_Stub_3(const uint8_t _1, const uint8_t _2);
 
 				#if defined(USB_CAN_BE_BOTH)
 					void EVENT_USB_UIDChange(void) ATTR_WEAK ATTR_ALIAS(USB_Event_Stub);
 				#endif
 
 				#if defined(USB_CAN_BE_HOST)
-					void EVENT_USB_Host_HostError(const uint8_t ErrorCode) ATTR_WEAK ATTR_ALIAS(USB_Event_Stub);
+					void EVENT_USB_Host_HostError(const uint8_t ErrorCode) ATTR_WEAK ATTR_ALIAS(USB_Event_Stub_2);
 					void EVENT_USB_Host_DeviceAttached(void) ATTR_WEAK ATTR_ALIAS(USB_Event_Stub);
 					void EVENT_USB_Host_DeviceUnattached(void) ATTR_WEAK ATTR_ALIAS(USB_Event_Stub);
 					void EVENT_USB_Host_DeviceEnumerationComplete(void) ATTR_WEAK ATTR_ALIAS(USB_Event_Stub);
 					void EVENT_USB_Host_DeviceEnumerationFailed(const uint8_t ErrorCode,
                                                                 const uint8_t SubErrorCode)
-					                                            ATTR_WEAK ATTR_ALIAS(USB_Event_Stub);
+					                                            ATTR_WEAK ATTR_ALIAS(USB_Event_Stub_3);
 					void EVENT_USB_Host_StartOfFrame(void) ATTR_WEAK ATTR_ALIAS(USB_Event_Stub);
 				#endif
 


### PR DESCRIPTION
Hi,

This PR just backports https://github.com/abcminiuser/lufa/commit/d8e0d67caefa312970787645180ec5db2eff92cb and https://github.com/abcminiuser/lufa/commit/a08a02481ba9e68933ad0b89483f5328767df9f3 so that QMK compiles with avr-gcc 8.1.

Before this PR, I would get:

```
Compiling: lib/lufa/LUFA/Drivers/USB/Class/Device/AudioClassDevice.c                               In file included from lib/lufa/LUFA/Drivers/USB/Class/Device/AudioClassDevice.c:38:
lib/lufa/LUFA/Drivers/USB/Class/Device/AudioClassDevice.h:382:10: error: 'EVENT_Audio_Device_StreamStartStop' alias between functions of incompatible types 'void(USB_ClassInfo_Audio_Device_t * const)' {aka 'void(struct <anonymous> * const)'} and 'void(void)' [-Werror=attribute-alias]
     void EVENT_Audio_Device_StreamStartStop(USB_ClassInfo_Audio_Device_t* const AudioInterfaceInfo)
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
lib/lufa/LUFA/Drivers/USB/Class/Device/AudioClassDevice.c:191:6: note: aliased declaration here
 void Audio_Device_Event_Stub(void)
      ^~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
 [ERRORS]
 | 
 | 
 | 
make[1]: *** [.build/obj_planck_light_tenderlove/lib/lufa/LUFA/Drivers/USB/Class/Device/AudioClassDevice.o] Error 1
make: *** [planck/light:tenderlove] Error 1
Make finished with errors
```

After this PR everything seems to compile.  I think this also fixes #3316 

Refs: https://github.com/abcminiuser/lufa/issues/130