### PR TITLE
Added tada68 Linux flashing instructions

### DIFF
--- a/keyboards/tada68/readme.md
+++ b/keyboards/tada68/readme.md
@@ -56,3 +56,30 @@ $ make tada68:default:flashbin
 `rm -fr .Trashes/ .fseventsd/ ._.Trashes ._FLASH.bin`
 
 7) Eject the USB device or hit ESC on the keyboard. The lights will stop flashing and your firmware is loaded!
+
+## Flashing Instructions (Linux)
+
+*Use these instructions at your own risk. Mount settings originally found at https://www.reddit.com/r/MechanicalKeyboards/comments/8e2nnp/help_problems_flashing_firmware_on_tada68_from/*
+
+1) from the `qmk_firmware\` directory run:
+```
+$ make tada68:default:flashbin
+```
+
+2) Connect your keyboard to Windows computer, hit the reset button on the TADA, the lights will start flashing.
+
+3) A new entry should appear at `/dev/sd*`. Mount the board using this command:
+
+```
+mount -t vfat -o rw,nosuid,nodev,relatime,uid=1000,gid=1000,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,showexec,utf8,flush,errors=remount-ro,uhelper=udisks2 <path to device> /mnt/tada68
+```
+
+4) Back up the original firmware
+
+`mv /mnt/tada68/FLASH.BIN ~`
+
+5) Copy over your new firmware to the keybaord
+
+`cp <path to your qmk_firmware folder>/FLASH.bin /mnt/tada68`
+
+5) *Do not eject the USB device.* Hit ESC on the keyboard. The lights will stop flashing and your firmware is loaded!


### PR DESCRIPTION
This adds instructions for flashing tada68 on Linux based on working mount instructions I found on Reddit.

I haven't actually confirmed if all of these mount settings will have side effects, or if they're all required, or if they'll act differently on different systems. Let me know if I need to put this homework in.