### PR TITLE
Double knight rider for split keyboards

### DIFF
--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -814,7 +814,8 @@ void rgblight_effect_doubleknight(uint8_t interval) {
 
   //turn on led if it is 'offset' away from the beginning or end of strip
   for(int i = 0; i<RGBLED_NUM; i++){
-    if(i == offset || offset == (RGBLED_NUM - 1 - i)){
+    if(i == offset || i == offset-increment || offset == (RGBLED_NUM - 1 - i) ||
+		    offset == (RGBLED_NUM - 1 - i + increment)){
       rgblight_sethsv_at(rgblight_config.hue, rgblight_config.sat, rgblight_config.val, i);
     }else{
       rgblight_sethsv_at(rgblight_config.hue, rgblight_config.sat, 0, i);

--- a/quantum/rgblight.h
+++ b/quantum/rgblight.h
@@ -17,7 +17,7 @@
 #define RGBLIGHT_H
 
 #ifdef RGBLIGHT_ANIMATIONS
-	#define RGBLIGHT_MODES 36
+	#define RGBLIGHT_MODES 39
 #else
 	#define RGBLIGHT_MODES 1
 #endif
@@ -167,5 +167,6 @@ void rgblight_effect_knight(uint8_t interval);
 void rgblight_effect_christmas(void);
 void rgblight_effect_rgbtest(void);
 void rgblight_effect_alternating(void);
+void rgblight_effect_doubleknight(uint8_t interval);
 
 #endif


### PR DESCRIPTION
This is a new rgb underglow mode inspired from the knight rider mode.
It splits the animation into mirrored halves. This is designed for split keyboards.
It uses the config values for hue/val/sat and uses 3 different speeds from the original knight rider mode.