### PR TITLE
Backlighting docs

### DIFF
--- a/docs/feature_backlight.md
+++ b/docs/feature_backlight.md
@@ -1,10 +1,16 @@
 # Backlighting
 
-<!-- FIXME: Describe how backlighting works in QMK -->
+Many keyboards support backlit keys by way of individual LEDs placed through or underneath the keyswitches. QMK is able to control the brightness of these LEDs by switching them on and off rapidly in a certain ratio, a technique known as *Pulse Width Modulation*, or PWM. By altering the duty cycle of the PWM signal, it creates the illusion of dimming.
 
-## Backlight Keycodes
+The MCU can only supply so much current to its GPIO pins. Instead of powering the backlight directly from the MCU, the backlight pin is connected to a transistor or MOSFET that switches the power to the LEDs.
 
-These keycodes control the backlight. Most keyboards use this for single color in-switch lighting.
+## Caveats
+
+This feature is distinct from both the RGB underglow and RGB matrix features as it usually allows for only a single colour per switch, though you can obviously use multiple different coloured LEDs on a keyboard.
+
+Hardware PWM is only supported on certain pins of the MCU, so if the backlighting is not connected to one of them, a software implementation will be used, and backlight breathing will not be available. Currently the supported pins are `B5`, `B6`, `B7`, and `C6`.
+
+## Keycodes
 
 |Key      |Description                               |
 |---------|------------------------------------------|
@@ -16,24 +22,22 @@ These keycodes control the backlight. Most keyboards use this for single color i
 |`BL_DEC` |Decrease the backlight level              |
 |`BL_BRTG`|Toggle backlight breathing                |
 
-Note that for backlight breathing, you need to have `#define BACKLIGHT_BREATHING` in your config.h.
+## Configuration
 
-## Configuration Options in `config.h`
+To change the behaviour of the backlighting, `#define` these in your `config.h`:
 
-* `BACKLIGHT_PIN B7` defines the pin that controlls the LEDs. Unless you design your own keyboard, you don't need to set this.
-* `BACKLIGHT_LEVELS 3` defines the number of brightness levels (maximum 15 excluding off).
-* `BACKLIGHT_BREATHING` if defined, enables backlight breathing. Note that this is only available if `BACKLIGHT_PIN` is B5, B6 or B7.
-* `BREATHING_PERIOD 6` defines the length of one backlight "breath" in seconds.
+|Define               |Default      |Description                                                                                                  |
+|---------------------|-------------|-------------------------------------------------------------------------------------------------------------|
+|`BACKLIGHT_PIN`      |`B7`         |The pin that controls the LEDs. Unless you are designing your own keyboard, you shouldn't need to change this|
+|`BACKLIGHT_LEVELS`   |`3`          |The number of brightness levels (maximum 15 excluding off)                                                   |
+|`BACKLIGHT_BREATHING`|*Not defined*|Enable backlight breathing, if hardware PWM is used                                                          |
+|`BREATHING_PERIOD`   |`6`          |The length of one backlight "breath" in seconds                                                              |
 
-## Notes on Implementation
+## Hardware PWM Implementation
 
-To change the brightness when using pins B5, B6 or B7, the PWM (Pulse Width Modulation) functionality of the on-chip timer is used.
-The timer is a counter that counts up to a certain TOP value (`0xFFFF` set in ICR1) before resetting to 0.
-We also set an OCR1x register.
-When the counter reaches the value stored in that register, the PWM pin drops to low.
-The PWM pin is pulled high again when the counter resets to 0.
-Therefore, OCR1x basically sets the duty cycle of the LEDs and as such the brightness where `0` is the darkest and `0xFFFF` the brightest setting.
+When using the supported pins for backlighting, QMK will use a hardware timer configured to output a PWM signal. This timer will count up to `ICRx` (by default `0xFFFF`) before resetting to 0.
+The desired brightness is calculated and stored in the `OCRxx` register. When the counter reaches this value, the backlight pin will go low, and is pulled high again when the counter resets.
+In this way `OCRxx` essentially controls the duty cycle of the LEDs, and thus the brightness, where `0x0000` is completely off and `0xFFFF` is completely on.
 
-To enable the breathing effect, we register an interrupt handler to be called whenever the counter resets (with `ISR(TIMER1_OVF_vect)`).
-In this handler, which gets called roughly 244 times per second, we compute the desired brightness using a precomputed brightness curve.
-To disable breathing, we can just disable the respective interrupt vector and reset the brightness to the desired level.
+The breathing effect is achieved by registering an interrupt handler for `TIMER1_OVF_vect` that is called whenever the counter resets, roughly 244 times per second.
+In this handler, the value of an incrementing counter is mapped onto a precomputed brightness curve. To turn off breathing, the interrupt handler is simply disabled, and the brightness reset to the level stored in EEPROM.

--- a/docs/feature_backlight.md
+++ b/docs/feature_backlight.md
@@ -6,7 +6,7 @@ The MCU can only supply so much current to its GPIO pins. Instead of powering th
 
 ## Caveats
 
-This feature is distinct from both the RGB underglow and RGB matrix features as it usually allows for only a single colour per switch, though you can obviously use multiple different coloured LEDs on a keyboard.
+This feature is distinct from both the [RGB underglow](feature_rgblight.md) and [RGB matrix](feature_rgb_matrix.md) features as it usually allows for only a single colour per switch, though you can obviously use multiple different coloured LEDs on a keyboard.
 
 Hardware PWM is only supported on certain pins of the MCU, so if the backlighting is not connected to one of them, a software implementation will be used, and backlight breathing will not be available. Currently the supported pins are `B5`, `B6`, `B7`, and `C6`.
 


### PR DESCRIPTION
Fleshing out the backlight feature page. I really like the idea of structuring feature pages (and pages in general) a little more, with common sections like "Keycodes", "Configuration", and "Caveats". I feel it makes the docs more predictable and easy to navigate, but I would like to hear other people's thoughts on this.