### PR TITLE
Fix some minor errors in tap dance example

### DIFF
--- a/docs/feature_tap_dance.md
+++ b/docs/feature_tap_dance.md
@@ -196,22 +196,22 @@ SRC += your_name.c
 Pretty simple. It is a nice way to keep some rules common on all your keymaps.
 
 
-### In `/qmk_firmware/users/<your_name>/<you_name>.h`
+### In `/qmk_firmware/users/<your_name>/<your_name>.h`
 
 You will need a few things in this file:
 
 ```c
 #ifndef YOUR_NAME
 #define YOUR_NAME
+#endif
 
 #include "quantum.h"
 #include "process_keycode/process_tap_dance.h"
 
-
 typedef struct {
   bool is_press_action;
   int state;
-} xtap;
+} tap;
 
 enum {
   SINGLE_TAP = 1,
@@ -225,9 +225,9 @@ enum {
 
 //Tap dance enums
 enum {
-    CTL_X = 0,
-    SOME_OTHER_DANCE
-}
+  X_CTL = 0,
+  SOME_OTHER_DANCE
+};
 
 int cur_dance (qk_tap_dance_state_t *state);
 
@@ -241,7 +241,7 @@ void x_reset (qk_tap_dance_state_t *state, void *user_data);
 And then in your user's `.c` file you implement the functions above:
 
 ```c
-#include "gordon.h"
+#include "<your_name>.h"
 #include "quantum.h"
 #include "action.h"
 #include "process_keycode/process_tap_dance.h"
@@ -335,4 +335,4 @@ qk_tap_dance_action_t tap_dance_actions[] = {
 };
 ```
 
-And then simply use TD(X_CTL) anywhere in your keymap.
+And then simply use `TD(X_CTL)` anywhere in your keymap after including `<your_name>.h`.

--- a/docs/feature_tap_dance.md
+++ b/docs/feature_tap_dance.md
@@ -201,9 +201,7 @@ Pretty simple. It is a nice way to keep some rules common on all your keymaps.
 You will need a few things in this file:
 
 ```c
-#ifndef YOUR_NAME
-#define YOUR_NAME
-#endif
+#pragma once
 
 #include "quantum.h"
 #include "process_keycode/process_tap_dance.h"


### PR DESCRIPTION
Fix for #3529
Fix minor errors in the code examples for __Example 4: 'Quad Function Tap-Dance'__ and relevant documentation. 
Clarified the need to include the header file in `keymap.c`.