### PR TITLE
M0110 converter ported from TMK

### DIFF
--- a/keyboards/converter/m0110_usb/README.md
+++ b/keyboards/converter/m0110_usb/README.md
@@ -1,11 +1,11 @@
 M0110(A) keyboard converter
 ======================================
-This is a port of the original M0110 converter from TMK to QMK. The original converter was designed to work with **ATmega32U2** and **ATmega32U4** based microcontrollers to convert Apple M0110/M0110A keyboards and M0120 numpads to USB. This port has also been tested to be compatible with the [**Adafruit Feather 32U4 BLE**](https://learn.adafruit.com/adafruit-feather-32u4-bluefruit-le).
+This is a port of the original M0110 converter from TMK to QMK. The original converter was designed to work with **ATmega32U2** and **ATmega32U4** based microcontrollers to convert Apple M0110/M0110A keyboards and M0120 numpads to USB. This port has been tested to be compatible with the [**Adafruit Feather 32U4 BLE**](https://learn.adafruit.com/adafruit-feather-32u4-bluefruit-le).
 
 
 ### Enabling Bluetooth for the Adafruit Feather 32U4 BLE
 ----------------------------------------------------
-Simple add `BLUETOOTH = AdafruitBLE` to your `rules.mk` file. This enables code specifically for the Adafruit Feather 32U4 BLE. If enabled, the device will use the `PRODUCT` and `DESCRIPTION` values from `config.h` for the device name displayed by the Feather on host devices. You can simply change these values to change the device name.
+Simply add `BLUETOOTH = AdafruitBLE` to your `rules.mk` file. This enables code specifically for the Adafruit Feather 32U4 BLE. If enabled, the device will use the `PRODUCT` and `DESCRIPTION` values from `config.h` for the device name displayed by the Feather on host devices. You can simply change these values to change the device name.
 
 
 ### Pins

--- a/keyboards/converter/m0110_usb/README.md
+++ b/keyboards/converter/m0110_usb/README.md
@@ -1,0 +1,51 @@
+M0110(A) keyboard converter
+======================================
+This is a port of the original M0110 converter from TMK to QMK. The original converter was designed to work with **ATmega32U2** and **ATmega32U4** based microcontrollers to convert Apple M0110/M0110A keyboards and M0120 numpads to USB. This port has also been tested to be compatible with the [**Adafruit Feather 32U4 BLE**](https://learn.adafruit.com/adafruit-feather-32u4-bluefruit-le).
+
+
+### Enabling Bluetooth for the Adafruit Feather 32U4 BLE
+----------------------------------------------------
+Simple add `BLUETOOTH = AdafruitBLE` to your `rules.mk` file. This enables code specifically for the Adafruit Feather 32U4 BLE. If enabled, the device will use the `PRODUCT` and `DESCRIPTION` values from `config.h` for the device name displayed by the Feather on host devices. You can simply change these values to change the device name.
+
+
+### Pins
+----
+This port utilizes the same pins that the TMK converter used. `PD1` is used for `CLOCK` and `PD0` is used for the `DATA` from the keyboard. These pins can be changed in `config.h`.
+
+
+### Other important hardware notes from the original TMK converter Readme:
+>### Hardware
+>--------
+>You can buy preassembled [TMK converter] or make yourown with AVR dev board like PJRC [Teensy].
+>
+>Port of the MCU `PD1` is assigned to `CLOCK` line and `PD0` to `DATA` by default, you can change pin configuration with editing `config.h`.
+>
+>[![M0110 Converter](http://i.imgur.com/yEp2eRim.jpg)](http://i.imgur.com/yEp2eRi.jpg)
+>
+>#### 4P4C phone handset cable
+>Note that original cable used with Mac is **straight** while phone handset cable is **crossover**.
+>
+><http://en.wikipedia.org/wiki/Modular_connector#4P4C>
+>
+>[Teensy]: http://www.pjrc.com/teensy/
+>[TMK converter]: https://geekhack.org/index.php?topic=72052.0
+>
+>
+>#### Socket Pinout
+>- <http://pinouts.ru/Inputs/MacKeyboard_pinout.shtml>
+>
+>![Jack fig](http://www.kbdbabel.org/conn/kbd_connector_macplus.png)
+>
+>
+>#### Pull-up Resistor
+>You may need pull-up resistors on signal lines(`CLOCK`, `DATA`) in particular when you have long or coiled cable. **1k-10k Ohm** will be OK >for this purpose. In that case the converter may not read signal from keyboard correctly without pull-up resistors.
+>
+
+[**View the original TMK converter Readme**](https://github.com/tmk/tmk_keyboard/tree/master/converter/m0110_usb)\
+[**View the original TMK converter Repository**](https://github.com/tmk/tmk_keyboard/tree/master/converter/m0110_usb)
+
+
+### QMK Port Changelog
+---------
+- 2018/08/01 - Original Release
+

--- a/keyboards/converter/m0110_usb/config.h
+++ b/keyboards/converter/m0110_usb/config.h
@@ -1,0 +1,59 @@
+/*
+Copyright 2011,2012 Jun Wako <wakojun@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+--------------
+
+Ported to QMK by Techsock <info@techsock.com>
+*/
+
+#pragma once
+
+#define VENDOR_ID       0xFEED
+#define PRODUCT_ID      0x0110
+#define DEVICE_VER      0x0101
+#define MANUFACTURER    Apple
+#define PRODUCT         M0110(A)
+#define DESCRIPTION     Converts M0110(A) to USB and/or BT
+
+/* matrix size */
+#define MATRIX_ROWS 14
+#define MATRIX_COLS 8
+
+/* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
+#define LOCKING_SUPPORT_ENABLE
+/* Locking resynchronize hack */
+#define LOCKING_RESYNC_ENABLE
+
+/* magic key */
+#define IS_COMMAND() ( \
+    keyboard_report->mods == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_LALT) | MOD_BIT(KC_LGUI)) || \
+    keyboard_report->mods == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_LALT) | MOD_BIT(KC_LCTL)) \
+)
+
+/* boot magic key */
+#define BOOTMAGIC_KEY_SALT                      KC_M
+
+/* ports */
+#define M0110_CLOCK_PORT        PORTD
+#define M0110_CLOCK_PIN         PIND
+#define M0110_CLOCK_DDR         DDRD
+#define M0110_CLOCK_BIT         1
+#define M0110_DATA_PORT         PORTD
+#define M0110_DATA_PIN          PIND
+#define M0110_DATA_DDR          DDRD
+#define M0110_DATA_BIT          0
+
+

--- a/keyboards/converter/m0110_usb/keymaps/default/keymap.c
+++ b/keyboards/converter/m0110_usb/keymaps/default/keymap.c
@@ -1,0 +1,92 @@
+/*
+Copyright 2011,2012,2015 Jun Wako <wakojun@gmail.com>
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+--------------
+
+Ported to QMK by Techsock <info@techsock.com>
+*/
+
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+	/* Default:
+	 * M0110                                                       M0120
+	 * ,---------------------------------------------------------. ,---------------.
+	 * |  `|  1|  2|  3|  4|  5|  6|  7|  8|  9|  0|  -|  =|Backs| |Nlk|  =|  /|  *|
+	 * |---------------------------------------------------------| |---------------|
+	 * |Tab  |  Q|  W|  E|  R|  T|  Y|  U|  I|  O|  P|  [|  ]|  \| |  7|  8|  9|  -|
+	 * |---------------------------------------------------------| |---------------|
+	 * |Caps  |  A|  S|  D|  F|  G|  H|  J|  K|  L|  ;|  '|Return| |  4|  5|  6|  +|
+	 * |---------------------------------------------------------| |---------------|
+	 * |Shift   |  Z|  X|  C|  V|  B|  N|  M|  ,|  .|  /|Shift   | |  1|  2|  3|   |
+	 * `---------------------------------------------------------' |-----------|Ent|
+	 *      |Opt|Mac |         Space               |Fn  |Opt|      |      0|  .|   |
+	 *      `-----------------------------------------------'      `---------------'
+	 * M0110A
+	 * ,---------------------------------------------------------. ,---------------.
+	 * |  `|  1|  2|  3|  4|  5|  6|  7|  8|  9|  0|  -|  =|Backs| |Nlk|  =|  /|  *|
+	 * |---------------------------------------------------------| |---------------|
+	 * |Tab  |  Q|  W|  E|  R|  T|  Y|  U|  I|  O|  P|  [|  ]|   | |  7|  8|  9|  -|
+	 * |-----------------------------------------------------'   | |---------------|
+	 * |Caps  |  A|  S|  D|  F|  G|  H|  J|  K|  L|  ;|  '|Return| |  4|  5|  6|  +|
+	 * |---------------------------------------------------------| |---------------|
+	 * |Shift   |  Z|  X|  C|  V|  B|  N|  M|  ,|  .|  /|Shft|Up | |  1|  2|  3|   |
+	 * |---------------------------------------------------------| |-----------|Ent|
+	 * |Opt  |Mac    |         Space             |  \|Lft|Rgt|Dn | |      0|  .|   |
+	 * `---------------------------------------------------------' `---------------'
+	 */
+
+	[0] = LAYOUT_ansi(
+	       KC_GRV,  KC_1,    KC_2, KC_3, KC_4, KC_5,   KC_6, KC_7, KC_8,    KC_9,   KC_0,             KC_MINS, KC_EQL,  KC_BSPC,  KC_NLCK, KC_EQL, KC_PSLS, KC_PAST, \
+	       KC_TAB,  KC_Q,    KC_W, KC_E, KC_R, KC_T,   KC_Y, KC_U, KC_I,    KC_O,   KC_P,             KC_LBRC, KC_RBRC,           KC_P7,   KC_P8,  KC_P9,   KC_PMNS, \
+	       KC_LCAP, KC_A,    KC_S, KC_D, KC_F, KC_G,   KC_H, KC_J, KC_K,    KC_L,   KC_SCLN,          KC_QUOT,          KC_ENT,   KC_P4,   KC_P5,  KC_P6,   KC_PPLS, \
+	       KC_LSFT, KC_Z,    KC_X, KC_C, KC_V, KC_B,   KC_N, KC_M, KC_COMM, KC_DOT, KC_SLSH,                            KC_UP,    KC_P1,   KC_P2,  KC_P3,   KC_PENT, \
+	       KC_LALT, KC_LGUI,                   KC_SPC,                      MO(1),  LT(1, KC_BSLASH), KC_LEFT, KC_RGHT, KC_DOWN,  KC_P0,           KC_PDOT),
+		
+	
+	/* Cursor Layer:
+	 * M0110                                                       M0120
+	 * ,---------------------------------------------------------. ,---------------.
+	 * |Esc| F1| F2| F3| F4| F5| F6| F7| F8| F9|F10|F11|F12|Delet| |Nlk|  =|  /|  *|
+	 * |---------------------------------------------------------| |---------------|
+	 * |Tab  |Hom| Up|PgU|Rst|   |   |   |Psc|Slk|Pau|Up |INS|   | |  7|  8|  9|  -|
+	 * |---------------------------------------------------------| |---------------|
+	 * |Ctrl  |Lef|Dow|Rig|   |   |   |   |Hom|PgU|Lef|Rig|Return| |  4|  5|  6|  +|
+	 * |---------------------------------------------------------| |---------------|
+	 * |Shift   |End|   |PgD|   |   |   |   |End|PgD|Dow|Shift   | |  1|  2|  3|   |
+	 * `---------------------------------------------------------' |-----------|Ent|
+	 *      |Opt|Mac |         Space               |Fn  |Opt|      |      0|  .|   |
+	 *      `-----------------------------------------------'      `---------------'
+	 * M0110A
+	 * ,---------------------------------------------------------. ,---------------.
+	 * |Esc| F1| F2| F3| F4| F5| F6| F7| F8| F9|F10|F11|F12|Delet| |Nlk|  =|  /|  *|
+	 * |---------------------------------------------------------| |---------------|
+	 * |Tab  |Hom| Up|PgU|   |   |   |   |Psc|Slk|Pau|Up |INS|   | |  7|  8|  9|  -|
+	 * |-----------------------------------------------------'   | |---------------|
+	 * |Caps  |Lef|Dow|Rig|   |   |   |   |Hom|PgU|Lef|Rig|Return| |  4|  5|  6|  +|
+	 * |---------------------------------------------------------| |---------------|
+	 * |Ctrl    |End|   |PgD|   |   |   |   |End|PgD|Dow|Shft|PgU| |  1|  2|  3|   |
+	 * |---------------------------------------------------------| |-----------|Ent|
+	 * |Opt  |Mac    |         Space             |  \|Hom|End|PgD| |      0|  .|   |
+	 * `---------------------------------------------------------' `---------------'
+	 */
+	
+	[1] = LAYOUT_ansi(
+	       KC_ESC,  KC_F1,   KC_F2,   KC_F3,   KC_F4, KC_F5, KC_F6, KC_F7, KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12, KC_DEL,   KC_NLCK, KC_EQL, KC_PSLS, KC_PAST, \
+		   KC_TAB,  KC_HOME, KC_UP,   KC_PGUP, RESET, KC_NO, KC_NO, KC_NO, KC_PSCR, KC_SLCK, KC_PAUS, KC_UP,   KC_INS,           KC_P7,   KC_P8,  KC_P9,   KC_PMNS, \
+		   KC_LCAP, KC_LEFT, KC_DOWN, KC_RGHT, KC_NO, KC_NO, KC_NO, KC_NO, KC_HOME, KC_PGUP, KC_LEFT, KC_RGHT,         KC_ENT,   KC_P4,   KC_P5,  KC_P6,   KC_PPLS, \
+		   KC_LCTL, KC_END,  KC_NO,   KC_PGDN, KC_NO, KC_NO, KC_NO, KC_NO, KC_END,  KC_PGDN, KC_DOWN,                  KC_PGUP,  KC_P1,   KC_P2,  KC_P3,   KC_PENT, \
+	       KC_LALT, KC_LGUI,                          KC_SPC,                       KC_TRNS, KC_TRNS, KC_HOME, KC_END, KC_PGDN,  KC_P0,           KC_PDOT),
+
+};

--- a/keyboards/converter/m0110_usb/m0110_usb.c
+++ b/keyboards/converter/m0110_usb/m0110_usb.c
@@ -1,0 +1,3 @@
+#include "m0110_usb.h"
+#include <avr/io.h>
+#include "quantum.h"

--- a/keyboards/converter/m0110_usb/m0110_usb.h
+++ b/keyboards/converter/m0110_usb/m0110_usb.h
@@ -1,0 +1,131 @@
+/*
+Copyright 2011,2012,2014,2015 Jun Wako <wakojun@gmail.com>
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+--------------
+
+Ported to QMK by Techsock <info@techsock.com>
+*/
+
+#ifndef M0110_USB_H
+#define M0110_USB_H
+#endif
+
+#include "quantum.h"
+
+/* Common layout for M0110 and M0110A
+ * This keymap works with both keyboards. As you can see, the M0110A is 
+ * a superset of M0110 keyboard, only one exception is 'Enter'(34) of M0110
+ * does not exist on the M0110A.
+ *
+ * ,---------------------------------------------------------. ,---------------.
+ * |  `|  1|  2|  3|  4|  5|  6|  7|  8|  9|  0|  -|  =|Backs| |Clr|  =|  /|  *|
+ * |---------------------------------------------------------| |---------------|
+ * |Tab  |  Q|  W|  E|  R|  T|  Y|  U|  I|  O|  P|  [|  ]|   | |  7|  8|  9|  -|
+ * |-----------------------------------------------------'   | |---------------|
+ * |Caps  |  A|  S|  D|  F|  G|  H|  J|  K|  L|  ;|  '|Return| |  4|  5|  6|  +|
+ * |---------------------------------------------------------| |---------------|
+ * |Shift   |  Z|  X|  C|  V|  B|  N|  M|  ,|  ,|  /|Shft|Up | |  1|  2|  3|   |
+ * |---------------------------------------------------------| |-----------|Ent|
+ * |Opt  |Mac    |         Space         |Ent|  \|Lft|Rgt|Dn | |      0|  .|   |
+ * `---------------------------------------------------------' `---------------'
+ *
+ * M0110A scan codes
+ * ,---------------------------------------------------------. ,---------------.
+ * | 32| 12| 13| 14| 15| 17| 16| 1A| 1C| 19| 1D| 1B| 18|   33| | 47| 68| 6D| 62|
+ * |---------------------------------------------------------| |---------------|
+ * |   30| 0C| 0D| 0E| 0F| 11| 10| 20| 22| 1F| 23| 21| 1E|   | | 59| 5B| 5C| 4E|
+ * |-----------------------------------------------------'   | |---------------|
+ * |    39| 00| 01| 02| 03| 05| 04| 26| 28| 25| 29| 27|    24| | 56| 57| 58| 66|
+ * |---------------------------------------------------------| |---------------|
+ * |      38| 06| 07| 08| 09| 0B| 2D| 2E| 2B| 2F| 2C|  38| 4D| | 53| 54| 55|   |
+ * `---------------------------------------------------------' |-----------| 4C|
+ * |   3A|     37|             31            | 2A| 46| 42| 48| |     52| 41|   |
+ * `---------------------------------------------------------' `---------------'
+ *
+ * M0110 + M0120 scan codes
+ * ,---------------------------------------------------------. ,---------------.
+ * | 32| 12| 13| 14| 15| 17| 16| 1A| 1C| 19| 1D| 1B| 18|   33| | 47| 68| 6D| 62|
+ * |---------------------------------------------------------| |---------------|
+ * |   30| 0C| 0D| 0E| 0F| 11| 10| 20| 22| 1F| 23| 21| 1E| 2A| | 59| 5B| 5C| 4E|
+ * |---------------------------------------------------------| |---------------|
+ * |    39| 00| 01| 02| 03| 05| 04| 26| 28| 25| 29| 27|    24| | 56| 57| 58| 66|
+ * |---------------------------------------------------------| |---------------|
+ * |      38| 06| 07| 08| 09| 0B| 2D| 2E| 2B| 2F| 2C|      38| | 53| 54| 55|   |
+ * `---------------------------------------------------------' |-----------| 4C|
+ *      | 3A|  37|             31              |   34| 3A|     |     52| 41|   |
+ *      `------------------------------------------------'     `---------------'
+ * Two right and left keys of 38 and 3A are identical, you cannot discriminate those two.
+ */
+#define LAYOUT_ansi( \
+    K32,K12,K13,K14,K15,K17,K16,K1A,K1C,K19,K1D,K1B,K18,K33,  K47,K68,K6D,K62, \
+    K30,K0C,K0D,K0E,K0F,K11,K10,K20,K22,K1F,K23,K21,K1E,      K59,K5B,K5C,K4E, \
+    K39,K00,K01,K02,K03,K05,K04,K26,K28,K25,K29,K27,    K24,  K56,K57,K58,K66, \
+    K38,K06,K07,K08,K09,K0B,K2D,K2E,K2B,K2F,K2C,        K4D,  K53,K54,K55,K4C, \
+    K3A,K37,            K31,            K34,K2A,K46,K42,K48,  K52,    K41      \
+) { \
+    { K00,    K01,    K02,    K03,    K04,    K05,    K06,    K07   }, \
+    { K08,    K09,    KC_NO,  K0B,    K0C,    K0D,    K0E,    K0F   }, \
+    { K10,    K11,    K12,    K13,    K14,    K15,    K16,    K17   }, \
+    { K18,    K19,    K1A,    K1B,    K1C,    K1D,    K1E,    K1F   }, \
+    { K20,    K21,    K22,    K23,    K24,    K25,    K26,    K27   }, \
+    { K28,    K29,    K2A,    K2B,    K2C,    K2D,    K2E,    K2F   }, \
+    { K30,    K31,    K32,    K33,    K34,    KC_NO,  KC_NO,  K37   }, \
+    { K38,    K39,    K3A,    KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO }, \
+    { KC_NO,  K41,    K42,    KC_NO,  KC_NO,  KC_NO,  K46,    K47   }, \
+    { K48,    KC_NO,  KC_NO,  KC_NO,  K4C,    K4D,    K4E,    KC_NO }, \
+    { KC_NO,  KC_NO,  K52,    K53,    K54,    K55,    K56,    K57   }, \
+    { K58,    K59,    KC_NO,  K5B,    K5C,    KC_NO,  KC_NO,  KC_NO }, \
+    { KC_NO,  KC_NO,  K62,    KC_NO,  KC_NO,  KC_NO,  K66,    KC_NO }, \
+    { K68,    KC_NO,  KC_NO,  KC_NO,  KC_NO,  K6D,    KC_NO,  KC_NO }, \
+}
+
+/* International keyboard layout for M0110 + M0120
+ * https://en.wikipedia.org/wiki/File:Apple_Macintosh_Plus_Keyboard.jpg
+ * Probably International keyboard layout of M0110A doesn't exist.
+ *
+ * M0110 + M0120 scan codes
+ * ,---------------------------------------------------------. ,---------------.
+ * | 32| 12| 13| 14| 15| 17| 16| 1A| 1C| 19| 1D| 1B| 18|   33| | 47| 68| 6D| 62|
+ * |---------------------------------------------------------| |---------------|
+ * |   30| 0C| 0D| 0E| 0F| 11| 10| 20| 22| 1F| 23| 21| 1E| 2A| | 59| 5B| 5C| 4E|
+ * |------------------------------------------------------,  | |---------------|
+ * |    39| 00| 01| 02| 03| 05| 04| 26| 28| 25| 29| 27| 24|  | | 56| 57| 58| 66|
+ * |---------------------------------------------------------| |---------------|
+ * |  38| 06| 07| 08| 09| 0B| 2D| 2E| 2B| 2F| 2C| 0A|      38| | 53| 54| 55|   |
+ * `---------------------------------------------------------' |-----------| 4C|
+ *      | 3A|  37|             34              |   31| 3A|     |     52| 41|   |
+ *      `------------------------------------------------'     `---------------'
+ * Two right and left keys of 38 and 3A are identical, you cannot discriminate those two.
+ */
+#define LAYOUT_iso( \
+    K32,K12,K13,K14,K15,K17,K16,K1A,K1C,K19,K1D,K1B,K18,K33,  K47,K68,K6D,K62, \
+    K30,K0C,K0D,K0E,K0F,K11,K10,K20,K22,K1F,K23,K21,K1E,K2A,  K59,K5B,K5C,K4E, \
+    K39,K00,K01,K02,K03,K05,K04,K26,K28,K25,K29,K27,K24,      K56,K57,K58,K66, \
+    K38,K06,K07,K08,K09,K0B,K2D,K2E,K2B,K2F,K2C,K0A,          K53,K54,K55,K4C, \
+        K3A,K37,            K34,                K31,          K52,    K41      \
+) { \
+    { K00,    K01,    K02,    K03,    K04,    K05,    K06,    K07   }, \
+    { K08,    K09,    K0A,    K0B,    K0C,    K0D,    K0E,    K0F   }, \
+    { K10,    K11,    K12,    K13,    K14,    K15,    K16,    K17   }, \
+    { K18,    K19,    K1A,    K1B,    K1C,    K1D,    K1E,    K1F   }, \
+    { K20,    K21,    K22,    K23,    K24,    K25,    K26,    K27   }, \
+    { K28,    K29,    K2A,    K2B,    K2C,    K2D,    K2E,    K2F   }, \
+    { K30,    K31,    K32,    K33,    K34,    KC_NO,  KC_NO,  K37   }, \
+    { K38,    K39,    K3A,    KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO }, \
+    { KC_NO,  K41,    KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  K47   }, \
+    { KC_NO,  KC_NO,  KC_NO,  KC_NO,  K4C,    KC_NO,  K4E,    KC_NO }, \
+    { KC_NO,  KC_NO,  K52,    K53,    K54,    K55,    K56,    K57   }, \
+    { K58,    K59,    KC_NO,  K5B,    K5C,    KC_NO,  KC_NO,  KC_NO }, \
+    { KC_NO,  KC_NO,  K62,    KC_NO,  KC_NO,  KC_NO,  K66,    KC_NO }, \
+    { K68,    KC_NO,  KC_NO,  KC_NO,  KC_NO,  K6D,    KC_NO,  KC_NO }, \
+}

--- a/keyboards/converter/m0110_usb/matrix.c
+++ b/keyboards/converter/m0110_usb/matrix.c
@@ -1,0 +1,121 @@
+/*
+Copyright 2011,2012 Jun Wako <wakojun@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+--------------
+
+Ported to QMK by Techsock <info@techsock.com>
+*/
+
+#include <stdint.h>
+#include <avr/io.h>
+#include <util/delay.h>
+#include "print.h"
+#include "util.h"
+#include "debug.h"
+#include "host.h"
+#include "m0110.h"
+#include "matrix.h"
+#include "report.h"
+#include "timer.h"
+
+
+#define CAPS        0x39
+#define CAPS_BREAK  (CAPS | 0x80)
+#define ROW(key)    ((key)>>3&0x0F)
+#define COL(key)    ((key)&0x07)
+
+
+static bool is_modified = false;
+
+// matrix state buffer(1:on, 0:off)
+static uint8_t *matrix;
+static uint8_t _matrix0[MATRIX_ROWS];
+
+static void register_key(uint8_t key);
+
+
+__attribute__ ((weak))
+void matrix_init_kb(void) {
+    matrix_init_user();
+}
+
+__attribute__ ((weak))
+void matrix_scan_kb(void) {
+    matrix_scan_user();
+}
+
+__attribute__ ((weak))
+void matrix_init_user(void) {
+}
+
+__attribute__ ((weak))
+void matrix_scan_user(void) {
+}
+
+void matrix_init(void)
+{
+    m0110_init();
+    // initialize matrix state: all keys off
+    for (uint8_t i=0; i < MATRIX_ROWS; i++) _matrix0[i] = 0x00;
+    matrix = _matrix0;
+
+	matrix_init_quantum();
+    return;
+}
+
+uint8_t matrix_scan(void)
+{
+    uint8_t key;
+
+    is_modified = false;
+    key = m0110_recv_key();
+
+    if (key == M0110_NULL) {
+        return 0;
+    } else if (key == M0110_ERROR) {
+        return 0;
+    } else {
+        is_modified = true;
+        register_key(key);
+    }
+
+    if (debug_enable) {
+        print("["); phex(key); print("]\n");
+    }
+    
+    matrix_scan_quantum();
+    return 1;
+}
+
+void matrix_print(void){
+
+}
+
+inline
+uint8_t matrix_get_row(uint8_t row)
+{
+    return matrix[row];
+}
+
+inline
+static void register_key(uint8_t key)
+{
+    if (key&0x80) {
+        matrix[ROW(key)] &= ~(1<<COL(key));
+    } else {
+        matrix[ROW(key)] |=  (1<<COL(key));
+    }
+}

--- a/keyboards/converter/m0110_usb/rules.mk
+++ b/keyboards/converter/m0110_usb/rules.mk
@@ -1,0 +1,73 @@
+# MCU name
+# atmega32u4 	Teensy2.0
+# atemga32u4	TMK Converter rev.1
+# atemga32u2	TMK Converter rev.2
+MCU = atmega32u4
+
+# Processor frequency.
+#     This will define a symbol, F_CPU, in all source code files equal to the
+#     processor frequency in Hz. You can then use this symbol in your source code to
+#     calculate timings. Do NOT tack on a 'UL' at the end, this will be done
+#     automatically to create a 32-bit value in your source code.
+#
+#     This will be an integer division of F_USB below, as it is sourced by
+#     F_USB after it has run through any CPU prescalers. Note that this value
+#     does not *change* the processor frequency - it should merely be updated to
+#     reflect the processor speed set externally so that the code can use accurate
+#     software delays.
+#
+#F_CPU = 16000000
+F_CPU = 8000000
+
+#
+# LUFA specific
+#
+# Target architecture (see library "Board Types" documentation).
+ARCH = AVR8
+
+# Input clock frequency.
+#     This will define a symbol, F_USB, in all source code files equal to the
+#     input clock frequency (before any prescaling is performed) in Hz. This value may
+#     differ from F_CPU if prescaling is used on the latter, and is required as the
+#     raw input clock is fed directly to the PLL sections of the AVR for high speed
+#     clock generation for the USB and other AVR subsections. Do NOT tack on a 'UL'
+#     at the end, this will be done automatically to create a 32-bit value in your
+#     source code.
+#
+#     If no clock division is performed on the input clock inside the AVR (via the
+#     CPU clock adjust registers or the clock division fuses), this will be equal to F_CPU.
+F_USB = $(F_CPU)
+
+# Interrupt driven control endpoint task(+60)
+OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
+
+# Bootloader
+#     This definition is optional, and if your keyboard supports multiple bootloaders of
+#     different sizes, comment this out, and the correct address will be loaded 
+#     automatically (+60). See bootloader.mk for all options.
+BOOTLOADER = caterina
+
+# Boot Section Size in *bytes*
+#   Teensy halfKay   512
+#   Teensy++ halfKay 1024
+#   Atmel DFU loader 4096	for TMK Converter rev.1/rev.2
+#   LUFA bootloader  4096
+#   USBaspLoader     2048
+
+# Build Options
+#   comment out to disable the options.
+#
+BOOTMAGIC_ENABLE	= no			# Virtual DIP switch configuration(+1000)
+MOUSEKEY_ENABLE		= no			# Mouse keys(+4700)
+CONSOLE_ENABLE		= yes			# Console for debug(+400)
+COMMAND_ENABLE		= no  			# Commands for debug and configuration
+SLEEP_LED_ENABLE 	= no  			# Breathing sleep LED during USB suspend
+NKRO_ENABLE 		= no			# USB Nkey Rollover - not yet supported in LUFA
+EXTRAKEY_ENABLE		= yes	
+USB_HID_ENABLE 		= yes
+BACKLIGHT_ENABLE 	= no
+#BLUETOOTH 			= AdafruitBLE   # For Adafruit Feather 32U4 BLE support, uncomment this line
+
+CUSTOM_MATRIX = yes
+SRC = matrix.c \
+      m0110.c


### PR DESCRIPTION
Ported the TMK version of the M0110 usb converter to work with QMK. I have tested this with a M0110 running on a Adafruit Feather 32U4 BLE, and I have confirmed that it works with QMK's Adafruit BLE support.