### PR TITLE
Update templates used for new_project.sh

### DIFF
--- a/quantum/template/avr/config.h
+++ b/quantum/template/avr/config.h
@@ -52,6 +52,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // #define BACKLIGHT_BREATHING
 // #define BACKLIGHT_LEVELS 3
 
+// #define RGB_DI_PIN E2
+// #ifdef RGB_DI_PIN
+// #define RGBLIGHT_ANIMATIONS
+// #define RGBLED_NUM 16
+// #define RGBLIGHT_HUE_STEP 8
+// #define RGBLIGHT_SAT_STEP 8
+// #define RGBLIGHT_VAL_STEP 8
+// #endif
 
 /* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
 #define DEBOUNCING_DELAY 5

--- a/quantum/template/avr/rules.mk
+++ b/quantum/template/avr/rules.mk
@@ -61,6 +61,7 @@ SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
 # if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
 NKRO_ENABLE = no            # USB Nkey Rollover
 BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality on B7 by default
+RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 MIDI_ENABLE = no            # MIDI support (+2400 to 4200, depending on config)
 UNICODE_ENABLE = no         # Unicode
 BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID

--- a/quantum/template/avr/template.h
+++ b/quantum/template/avr/template.h
@@ -20,15 +20,17 @@
 
 // This a shortcut to help you visually see your layout.
 // The following is an example using the Planck MIT layout
-// The first section contains all of the arguments
-// The second converts the arguments into a two-dimensional array
+// The first section contains all of the arguments representing the physical
+// layout of the board and position of the keys
+// The second converts the arguments into a two-dimensional array which 
+// represents the switch matrix. 
 #define LAYOUT( \
-    k00, k01, k02, \
-      k10,  k11   \
+    K00, K01, K02, \
+      K10,  K11   \
 ) \
 { \
-    { k00, k01,   k02 }, \
-    { k10, KC_NO, k11 }, \
+    { K00, K01,   K02 }, \
+    { K10, KC_NO, K11 }, \
 }
 
 #endif


### PR DESCRIPTION
1. Add RGBLIGHT_ENABLE option. With more keyboards coming out that support it, it should be included in the template by default. The code that configures it has been added commented out, and the enable flag has been set to no in `rules.mk`

2. Change switch arguments from lower case k to upper case K since that's what all the keyboards I've seen do. 

3. Add some explanation as to what the top and bottom part of the LAYOUT macro represent. 