### PR TITLE
More improvements to keycode docs

### DIFF
--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -8,40 +8,8 @@ This is a reference only. Each group of keys links to the page documenting their
 
 |Key                    |Aliases             |Description                                    |
 |-----------------------|--------------------|-----------------------------------------------|
-|`KC_1`                 |                    |`1` and `!`                                    |
-|`KC_2`                 |                    |`2` and `@`                                    |
-|`KC_3`                 |                    |`3` and `#`                                    |
-|`KC_4`                 |                    |`4` and `$`                                    |
-|`KC_5`                 |                    |`5` and `%`                                    |
-|`KC_6`                 |                    |`6` and `^`                                    |
-|`KC_7`                 |                    |`7` and `&`                                    |
-|`KC_8`                 |                    |`8` and `*`                                    |
-|`KC_9`                 |                    |`9` and `(`                                    |
-|`KC_0`                 |                    |`0` and `)`                                    |
-|`KC_F1`                |                    |                                               |
-|`KC_F2`                |                    |                                               |
-|`KC_F3`                |                    |                                               |
-|`KC_F4`                |                    |                                               |
-|`KC_F5`                |                    |                                               |
-|`KC_F6`                |                    |                                               |
-|`KC_F7`                |                    |                                               |
-|`KC_F8`                |                    |                                               |
-|`KC_F9`                |                    |                                               |
-|`KC_F10`               |                    |                                               |
-|`KC_F11`               |                    |                                               |
-|`KC_F12`               |                    |                                               |
-|`KC_F13`               |                    |                                               |
-|`KC_F14`               |                    |                                               |
-|`KC_F15`               |                    |                                               |
-|`KC_F16`               |                    |                                               |
-|`KC_F17`               |                    |                                               |
-|`KC_F18`               |                    |                                               |
-|`KC_F19`               |                    |                                               |
-|`KC_F20`               |                    |                                               |
-|`KC_F21`               |                    |                                               |
-|`KC_F22`               |                    |                                               |
-|`KC_F23`               |                    |                                               |
-|`KC_F24`               |                    |                                               |
+|`KC_NO`                |                    |Ignore this key (NOOP)                         |
+|`KC_TRANSPARENT`       |`KC_TRNS`           |Use the next lowest non-transparent key        |
 |`KC_A`                 |                    |`a` and `A`                                    |
 |`KC_B`                 |                    |`b` and `B`                                    |
 |`KC_C`                 |                    |`c` and `C`                                    |
@@ -68,6 +36,16 @@ This is a reference only. Each group of keys links to the page documenting their
 |`KC_X`                 |                    |`x` and `X`                                    |
 |`KC_Y`                 |                    |`y` and `Y`                                    |
 |`KC_Z`                 |                    |`z` and `Z`                                    |
+|`KC_1`                 |                    |`1` and `!`                                    |
+|`KC_2`                 |                    |`2` and `@`                                    |
+|`KC_3`                 |                    |`3` and `#`                                    |
+|`KC_4`                 |                    |`4` and `$`                                    |
+|`KC_5`                 |                    |`5` and `%`                                    |
+|`KC_6`                 |                    |`6` and `^`                                    |
+|`KC_7`                 |                    |`7` and `&`                                    |
+|`KC_8`                 |                    |`8` and `*`                                    |
+|`KC_9`                 |                    |`9` and `(`                                    |
+|`KC_0`                 |                    |`0` and `)`                                    |
 |`KC_ENTER`             |`KC_ENT`            |Return (Enter)                                 |
 |`KC_ESCAPE`            |`KC_ESC`            |Escape                                         |
 |`KC_BSPACE`            |`KC_BSPC`           |Delete (Backspace)                             |
@@ -79,10 +57,6 @@ This is a reference only. Each group of keys links to the page documenting their
 |`KC_RBRACKET`          |`KC_RBRC`           |`]` and `}`                                    |
 |`KC_BSLASH`            |`KC_BSLS`           |`\` and <code>&#124;</code>                    |
 |`KC_NONUS_HASH`        |`KC_NUHS`           |Non-US `#` and `~`                             |
-|`KC_NONUS_BSLASH`      |`KC_NUBS`           |Non-US `\` and <code>&#124;</code>             |
-|`KC_INT1`              |`KC_RO`             |JIS `\` and <code>&#124;</code>                |
-|`KC_INT2`              |`KC_KANA`           |JIS Katakana/Hiragana                          |
-|`KC_INT3`              |`KC_JYEN`           |JIS `¥`                                        |
 |`KC_SCOLON`            |`KC_SCLN`           |`;` and `:`                                    |
 |`KC_QUOTE`             |`KC_QUOT`           |`'` and `"`                                    |
 |`KC_GRAVE`             |`KC_GRV`            |<code>&#96;</code> and `~`                     |
@@ -90,19 +64,18 @@ This is a reference only. Each group of keys links to the page documenting their
 |`KC_DOT`               |                    |`.` and `>`                                    |
 |`KC_SLASH`             |`KC_SLSH`           |`/` and `?`                                    |
 |`KC_CAPSLOCK`          |`KC_CAPS`           |Caps Lock                                      |
-|`KC_LCTRL`             |`KC_LCTL`           |Left Control                                   |
-|`KC_LSHIFT`            |`KC_LSFT`           |Left Shift                                     |
-|`KC_LALT`              |                    |Left Alt                                       |
-|`KC_LGUI`              |`KC_LCMD`, `KC_LWIN`|Left GUI (Windows/Command/Meta key)            |
-|`KC_RCTRL`             |`KC_RCTL`           |Right Control                                  |
-|`KC_RSHIFT`            |`KC_RSFT`           |Right Shift                                    |
-|`KC_RALT`              |                    |Right Alt                                      |
-|`KC_RGUI`              |`KC_RCMD`, `KC_RWIN`|Right GUI (Windows/Command/Meta key)           |
-|`KC_LOCKING_CAPS`      |`KC_LCAP`           |Locking Caps Lock                              |
-|`KC_LOCKING_NUM`       |`KC_LNUM`           |Locking Num Lock                               |
-|`KC_LOCKING_SCROLL`    |`KC_LSCR`           |Locking Scroll Lock                            |
-|`KC_INT4`              |`KC_HENK`           |JIS Henkan                                     |
-|`KC_INT5`              |`KC_MHEN`           |JIS Muhenkan                                   |
+|`KC_F1`                |                    |F1                                             |
+|`KC_F2`                |                    |F2                                             |
+|`KC_F3`                |                    |F3                                             |
+|`KC_F4`                |                    |F4                                             |
+|`KC_F5`                |                    |F5                                             |
+|`KC_F6`                |                    |F6                                             |
+|`KC_F7`                |                    |F7                                             |
+|`KC_F8`                |                    |F8                                             |
+|`KC_F9`                |                    |F9                                             |
+|`KC_F10`               |                    |F10                                            |
+|`KC_F11`               |                    |F11                                            |
+|`KC_F12`               |                    |F12                                            |
 |`KC_PSCREEN`           |`KC_PSCR`           |Print Screen                                   |
 |`KC_SCROLLLOCK`        |`KC_SLCK`           |Scroll Lock                                    |
 |`KC_PAUSE`             |`KC_PAUS`           |Pause                                          |
@@ -116,58 +89,6 @@ This is a reference only. Each group of keys links to the page documenting their
 |`KC_LEFT`              |                    |Left Arrow                                     |
 |`KC_DOWN`              |                    |Down Arrow                                     |
 |`KC_UP`                |                    |Up Arrow                                       |
-|`KC_APPLICATION`       |`KC_APP`            |Application (Windows Menu Key)                 |
-|`KC_POWER`             |                    |Deprecated by MS in favor of `KC_SYSTEM_POWER`.|
-|`KC_EXECUTE`           |                    |Execute                                        |
-|`KC_HELP`              |                    |Help                                           |
-|`KC_MENU`              |                    |Menu                                           |
-|`KC_SELECT`            |                    |Select                                         |
-|`KC_AGAIN`             |                    |Again                                          |
-|`KC_UNDO`              |                    |Undo                                           |
-|`KC_CUT`               |                    |Cut                                            |
-|`KC_COPY`              |                    |Copy                                           |
-|`KC_PASTE`             |                    |Paste                                          |
-|`KC_FIND`              |                    |Find                                           |
-|`KC_ALT_ERASE`         |                    |Alternate Erase                                |
-|`KC_SYSREQ`            |                    |SysReq/Attention                               |
-|`KC_CANCEL`            |                    |Cancel                                         |
-|`KC_CLEAR`             |                    |Clear                                          |
-|`KC_PRIOR`             |                    |Prior                                          |
-|`KC_RETURN`            |                    |Return                                         |
-|`KC_SEPARATOR`         |                    |Separator                                      |
-|`KC_OUT`               |                    |Out                                            |
-|`KC_OPER`              |                    |Oper                                           |
-|`KC_CLEAR_AGAIN`       |                    |Clear/Again                                    |
-|`KC_CRSEL`             |                    |CrSel/Props                                    |
-|`KC_EXSEL`             |                    |ExSel                                          |
-|`KC_SYSTEM_POWER`      |`KC_PWR`            |System Power Down. Recommended over `KC_POWER`.|
-|`KC_SYSTEM_SLEEP`      |`KC_SLEP`           |System Sleep                                   |
-|`KC_SYSTEM_WAKE`       |`KC_WAKE`           |System Wake                                    |
-|`KC_MAIL`              |`KC_MAIL`           |                                               |
-|`KC_CALCULATOR`        |`KC_CALC`           |                                               |
-|`KC_MY_COMPUTER`       |`KC_MYCM`           |                                               |
-|`KC_WWW_SEARCH`        |`KC_WSCH`           |                                               |
-|`KC_WWW_HOME`          |`KC_WHOM`           |                                               |
-|`KC_WWW_BACK`          |`KC_WBAK`           |                                               |
-|`KC_WWW_FORWARD`       |`KC_WFWD`           |                                               |
-|`KC_WWW_STOP`          |`KC_WSTP`           |                                               |
-|`KC_WWW_REFRESH`       |`KC_WREF`           |                                               |
-|`KC_WWW_FAVORITES`     |`KC_WFAV`           |                                               |
-|`KC_STOP`              |                    |Stop                                           |
-|`KC__MUTE`             |                    |Mute (macOS)                                   |
-|`KC__VOLUP`            |                    |Volume Up (macOS)                              |
-|`KC__VOLDOWN`          |                    |Volume Down (macOS)                            |
-|`KC_AUDIO_MUTE`        |`KC_MUTE`           |Mute (Windows/macOS/Linux)                     |
-|`KC_AUDIO_VOL_UP`      |`KC_VOLU`           |Volume Up (Windows/macOS/Linux)                |
-|`KC_AUDIO_VOL_DOWN`    |`KC_VOLD`           |Volume Down (Windows/macOS/Linux)              |
-|`KC_MEDIA_NEXT_TRACK`  |`KC_MNXT`           |Next Track (Windows)                           |
-|`KC_MEDIA_PREV_TRACK`  |`KC_MPRV`           |Previous Track (Windows)                       |
-|`KC_MEDIA_FAST_FORWARD`|`KC_MFFD`           |Next Track (macOS)                             |
-|`KC_MEDIA_REWIND`      |`KC_MRWD`           |Previous Track (macOS)                         |
-|`KC_MEDIA_STOP`        |`KC_MSTP`           |Stop Track                                     |
-|`KC_MEDIA_PLAY_PAUSE`  |`KC_MPLY`           |Play/Pause Track                               |
-|`KC_MEDIA_SELECT`      |`KC_MSEL`           |                                               |
-|`KC_MEDIA_EJECT`       |`KC_EJCT`           |Eject (macOS)                                  |
 |`KC_NUMLOCK`           |`KC_NLCK`           |Keypad Num Lock and Clear                      |
 |`KC_KP_SLASH`          |`KC_PSLS`           |Keypad `/`                                     |
 |`KC_KP_ASTERISK`       |`KC_PAST`           |Keypad `*`                                     |
@@ -185,11 +106,90 @@ This is a reference only. Each group of keys links to the page documenting their
 |`KC_KP_9`              |`KC_P9`             |Keypad `9` and Page Up                         |
 |`KC_KP_0`              |`KC_P0`             |Keypad `0` and Insert                          |
 |`KC_KP_DOT`            |`KC_PDOT`           |Keypad `.` and Delete                          |
+|`KC_NONUS_BSLASH`      |`KC_NUBS`           |Non-US `\` and <code>&#124;</code>             |
+|`KC_APPLICATION`       |`KC_APP`            |Application (Windows Menu Key)                 |
+|`KC_POWER`             |                    |Deprecated by MS in favor of `KC_SYSTEM_POWER`.|
 |`KC_KP_EQUAL`          |`KC_PEQL`           |Keypad `=`                                     |
+|`KC_F13`               |                    |F13                                            |
+|`KC_F14`               |                    |F14                                            |
+|`KC_F15`               |                    |F15                                            |
+|`KC_F16`               |                    |F16                                            |
+|`KC_F17`               |                    |F17                                            |
+|`KC_F18`               |                    |F18                                            |
+|`KC_F19`               |                    |F19                                            |
+|`KC_F20`               |                    |F20                                            |
+|`KC_F21`               |                    |F21                                            |
+|`KC_F22`               |                    |F22                                            |
+|`KC_F23`               |                    |F23                                            |
+|`KC_F24`               |                    |F24                                            |
+|`KC_EXECUTE`           |                    |Execute                                        |
+|`KC_HELP`              |                    |Help                                           |
+|`KC_MENU`              |                    |Menu                                           |
+|`KC_SELECT`            |                    |Select                                         |
+|`KC_STOP`              |                    |Stop                                           |
+|`KC_AGAIN`             |                    |Again                                          |
+|`KC_UNDO`              |                    |Undo                                           |
+|`KC_CUT`               |                    |Cut                                            |
+|`KC_COPY`              |                    |Copy                                           |
+|`KC_PASTE`             |                    |Paste                                          |
+|`KC_FIND`              |                    |Find                                           |
+|`KC__MUTE`             |                    |Mute (macOS)                                   |
+|`KC__VOLUP`            |                    |Volume Up (macOS)                              |
+|`KC__VOLDOWN`          |                    |Volume Down (macOS)                            |
+|`KC_LOCKING_CAPS`      |`KC_LCAP`           |Locking Caps Lock                              |
+|`KC_LOCKING_NUM`       |`KC_LNUM`           |Locking Num Lock                               |
+|`KC_LOCKING_SCROLL`    |`KC_LSCR`           |Locking Scroll Lock                            |
 |`KC_KP_COMMA`          |`KC_PCMM`           |Keypad `,`                                     |
 |`KC_KP_EQUAL_AS400`    |                    |Keypad `=` on AS/400 keyboards                 |
-|`KC_NO`                |                    |Ignore this key (NOOP)                         |
-|`KC_TRANSPARENT`       |`KC_TRNS`           |Use the next lowest non-transparent key        |
+|`KC_INT1`              |`KC_RO`             |JIS `\` and <code>&#124;</code>                |
+|`KC_INT2`              |`KC_KANA`           |JIS Katakana/Hiragana                          |
+|`KC_INT3`              |`KC_JYEN`           |JIS `¥`                                        |
+|`KC_INT4`              |`KC_HENK`           |JIS Henkan                                     |
+|`KC_INT5`              |`KC_MHEN`           |JIS Muhenkan                                   |
+|`KC_ALT_ERASE`         |                    |Alternate Erase                                |
+|`KC_SYSREQ`            |                    |SysReq/Attention                               |
+|`KC_CANCEL`            |                    |Cancel                                         |
+|`KC_CLEAR`             |                    |Clear                                          |
+|`KC_PRIOR`             |                    |Prior                                          |
+|`KC_RETURN`            |                    |Return                                         |
+|`KC_SEPARATOR`         |                    |Separator                                      |
+|`KC_OUT`               |                    |Out                                            |
+|`KC_OPER`              |                    |Oper                                           |
+|`KC_CLEAR_AGAIN`       |                    |Clear/Again                                    |
+|`KC_CRSEL`             |                    |CrSel/Props                                    |
+|`KC_EXSEL`             |                    |ExSel                                          |
+|`KC_LCTRL`             |`KC_LCTL`           |Left Control                                   |
+|`KC_LSHIFT`            |`KC_LSFT`           |Left Shift                                     |
+|`KC_LALT`              |                    |Left Alt                                       |
+|`KC_LGUI`              |`KC_LCMD`, `KC_LWIN`|Left GUI (Windows/Command/Meta key)            |
+|`KC_RCTRL`             |`KC_RCTL`           |Right Control                                  |
+|`KC_RSHIFT`            |`KC_RSFT`           |Right Shift                                    |
+|`KC_RALT`              |                    |Right Alt                                      |
+|`KC_RGUI`              |`KC_RCMD`, `KC_RWIN`|Right GUI (Windows/Command/Meta key)           |
+|`KC_SYSTEM_POWER`      |`KC_PWR`            |System Power Down. Recommended over `KC_POWER`.|
+|`KC_SYSTEM_SLEEP`      |`KC_SLEP`           |System Sleep                                   |
+|`KC_SYSTEM_WAKE`       |`KC_WAKE`           |System Wake                                    |
+|`KC_AUDIO_MUTE`        |`KC_MUTE`           |Mute (Windows/macOS/Linux)                     |
+|`KC_AUDIO_VOL_UP`      |`KC_VOLU`           |Volume Up (Windows/macOS/Linux)                |
+|`KC_AUDIO_VOL_DOWN`    |`KC_VOLD`           |Volume Down (Windows/macOS/Linux)              |
+|`KC_MEDIA_NEXT_TRACK`  |`KC_MNXT`           |Next Track (Windows)                           |
+|`KC_MEDIA_PREV_TRACK`  |`KC_MPRV`           |Previous Track (Windows)                       |
+|`KC_MEDIA_STOP`        |`KC_MSTP`           |Stop Track                                     |
+|`KC_MEDIA_PLAY_PAUSE`  |`KC_MPLY`           |Play/Pause Track                               |
+|`KC_MEDIA_SELECT`      |`KC_MSEL`           |                                               |
+|`KC_MEDIA_EJECT`       |`KC_EJCT`           |Eject (macOS)                                  |
+|`KC_MAIL`              |`KC_MAIL`           |                                               |
+|`KC_CALCULATOR`        |`KC_CALC`           |                                               |
+|`KC_MY_COMPUTER`       |`KC_MYCM`           |                                               |
+|`KC_WWW_SEARCH`        |`KC_WSCH`           |                                               |
+|`KC_WWW_HOME`          |`KC_WHOM`           |                                               |
+|`KC_WWW_BACK`          |`KC_WBAK`           |                                               |
+|`KC_WWW_FORWARD`       |`KC_WFWD`           |                                               |
+|`KC_WWW_STOP`          |`KC_WSTP`           |                                               |
+|`KC_WWW_REFRESH`       |`KC_WREF`           |                                               |
+|`KC_WWW_FAVORITES`     |`KC_WFAV`           |                                               |
+|`KC_MEDIA_FAST_FORWARD`|`KC_MFFD`           |Next Track (macOS)                             |
+|`KC_MEDIA_REWIND`      |`KC_MRWD`           |Previous Track (macOS)                         |
 
 ## [Quantum Keycodes](quantum_keycodes.md#qmk-keycodes)
 

--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -8,8 +8,8 @@ This is a reference only. Each group of keys links to the page documenting their
 
 |Key                    |Aliases             |Description                                    |
 |-----------------------|--------------------|-----------------------------------------------|
-|`KC_NO`                |                    |Ignore this key (NOOP)                         |
-|`KC_TRANSPARENT`       |`KC_TRNS`           |Use the next lowest non-transparent key        |
+|`KC_NO`                |`XXXXXXX`           |Ignore this key (NOOP)                         |
+|`KC_TRANSPARENT`       |`KC_TRNS`, `_______`|Use the next lowest non-transparent key        |
 |`KC_A`                 |                    |`a` and `A`                                    |
 |`KC_B`                 |                    |`b` and `B`                                    |
 |`KC_C`                 |                    |`c` and `C`                                    |
@@ -59,11 +59,11 @@ This is a reference only. Each group of keys links to the page documenting their
 |`KC_NONUS_HASH`        |`KC_NUHS`           |Non-US `#` and `~`                             |
 |`KC_SCOLON`            |`KC_SCLN`           |`;` and `:`                                    |
 |`KC_QUOTE`             |`KC_QUOT`           |`'` and `"`                                    |
-|`KC_GRAVE`             |`KC_GRV`            |<code>&#96;</code> and `~`                     |
+|`KC_GRAVE`             |`KC_GRV`, `KC_ZKHK` |<code>&#96;</code> and `~`, JIS Zenkaku/Hankaku|
 |`KC_COMMA`             |`KC_COMM`           |`,` and `<`                                    |
 |`KC_DOT`               |                    |`.` and `>`                                    |
 |`KC_SLASH`             |`KC_SLSH`           |`/` and `?`                                    |
-|`KC_CAPSLOCK`          |`KC_CAPS`           |Caps Lock                                      |
+|`KC_CAPSLOCK`          |`KC_CLCK`, `KC_CAPS`|Caps Lock                                      |
 |`KC_F1`                |                    |F1                                             |
 |`KC_F2`                |                    |F2                                             |
 |`KC_F3`                |                    |F3                                             |
@@ -78,7 +78,7 @@ This is a reference only. Each group of keys links to the page documenting their
 |`KC_F12`               |                    |F12                                            |
 |`KC_PSCREEN`           |`KC_PSCR`           |Print Screen                                   |
 |`KC_SCROLLLOCK`        |`KC_SLCK`           |Scroll Lock                                    |
-|`KC_PAUSE`             |`KC_PAUS`           |Pause                                          |
+|`KC_PAUSE`             |`KC_PAUS`, `KC_BRK` |Pause                                          |
 |`KC_INSERT`            |`KC_INS`            |Insert                                         |
 |`KC_HOME`              |                    |Home                                           |
 |`KC_PGUP`              |                    |Page Up                                        |
@@ -108,7 +108,7 @@ This is a reference only. Each group of keys links to the page documenting their
 |`KC_KP_DOT`            |`KC_PDOT`           |Keypad `.` and Delete                          |
 |`KC_NONUS_BSLASH`      |`KC_NUBS`           |Non-US `\` and <code>&#124;</code>             |
 |`KC_APPLICATION`       |`KC_APP`            |Application (Windows Menu Key)                 |
-|`KC_POWER`             |                    |Deprecated by MS in favor of `KC_SYSTEM_POWER`.|
+|`KC_POWER`             |                    |System Power (macOS)                           |
 |`KC_KP_EQUAL`          |`KC_PEQL`           |Keypad `=`                                     |
 |`KC_F13`               |                    |F13                                            |
 |`KC_F14`               |                    |F14                                            |
@@ -122,16 +122,16 @@ This is a reference only. Each group of keys links to the page documenting their
 |`KC_F22`               |                    |F22                                            |
 |`KC_F23`               |                    |F23                                            |
 |`KC_F24`               |                    |F24                                            |
-|`KC_EXECUTE`           |                    |Execute                                        |
+|`KC_EXECUTE`           |`KC_EXEC`           |Execute                                        |
 |`KC_HELP`              |                    |Help                                           |
 |`KC_MENU`              |                    |Menu                                           |
-|`KC_SELECT`            |                    |Select                                         |
+|`KC_SELECT`            |`KC_SLCT`           |Select                                         |
 |`KC_STOP`              |                    |Stop                                           |
-|`KC_AGAIN`             |                    |Again                                          |
+|`KC_AGAIN`             |`KC_AGIN`           |Again                                          |
 |`KC_UNDO`              |                    |Undo                                           |
 |`KC_CUT`               |                    |Cut                                            |
 |`KC_COPY`              |                    |Copy                                           |
-|`KC_PASTE`             |                    |Paste                                          |
+|`KC_PASTE`             |`KC_PSTE`           |Paste                                          |
 |`KC_FIND`              |                    |Find                                           |
 |`KC__MUTE`             |                    |Mute (macOS)                                   |
 |`KC__VOLUP`            |                    |Volume Up (macOS)                              |
@@ -146,10 +146,23 @@ This is a reference only. Each group of keys links to the page documenting their
 |`KC_INT3`              |`KC_JYEN`           |JIS `¥`                                        |
 |`KC_INT4`              |`KC_HENK`           |JIS Henkan                                     |
 |`KC_INT5`              |`KC_MHEN`           |JIS Muhenkan                                   |
-|`KC_ALT_ERASE`         |                    |Alternate Erase                                |
+|`KC_INT6`              |                    |JIS Numpad `,`                                 |
+|`KC_INT7`              |                    |International 7                                |
+|`KC_INT8`              |                    |International 8                                |
+|`KC_INT9`              |                    |International 9                                |
+|`KC_LANG1`             |`KC_HAEN`           |Hangul/English                                 |
+|`KC_LANG2`             |`KC_HANJ`           |Hanja                                          |
+|`KC_LANG3`             |                    |JIS Katakana                                   |
+|`KC_LANG4`             |                    |JIS Hiragana                                   |
+|`KC_LANG5`             |                    |JIS Zenkaku/Hankaku                            |
+|`KC_LANG6`             |                    |Language 6                                     |
+|`KC_LANG7`             |                    |Language 7                                     |
+|`KC_LANG8`             |                    |Language 8                                     |
+|`KC_LANG9`             |                    |Language 9                                     |
+|`KC_ALT_ERASE`         |`KC_ERAS`           |Alternate Erase                                |
 |`KC_SYSREQ`            |                    |SysReq/Attention                               |
 |`KC_CANCEL`            |                    |Cancel                                         |
-|`KC_CLEAR`             |                    |Clear                                          |
+|`KC_CLEAR`             |`KC_CLR`            |Clear                                          |
 |`KC_PRIOR`             |                    |Prior                                          |
 |`KC_RETURN`            |                    |Return                                         |
 |`KC_SEPARATOR`         |                    |Separator                                      |
@@ -166,28 +179,28 @@ This is a reference only. Each group of keys links to the page documenting their
 |`KC_RSHIFT`            |`KC_RSFT`           |Right Shift                                    |
 |`KC_RALT`              |                    |Right Alt                                      |
 |`KC_RGUI`              |`KC_RCMD`, `KC_RWIN`|Right GUI (Windows/Command/Meta key)           |
-|`KC_SYSTEM_POWER`      |`KC_PWR`            |System Power Down. Recommended over `KC_POWER`.|
+|`KC_SYSTEM_POWER`      |`KC_PWR`            |System Power Down                              |
 |`KC_SYSTEM_SLEEP`      |`KC_SLEP`           |System Sleep                                   |
 |`KC_SYSTEM_WAKE`       |`KC_WAKE`           |System Wake                                    |
-|`KC_AUDIO_MUTE`        |`KC_MUTE`           |Mute (Windows/macOS/Linux)                     |
-|`KC_AUDIO_VOL_UP`      |`KC_VOLU`           |Volume Up (Windows/macOS/Linux)                |
-|`KC_AUDIO_VOL_DOWN`    |`KC_VOLD`           |Volume Down (Windows/macOS/Linux)              |
+|`KC_AUDIO_MUTE`        |`KC_MUTE`           |Mute                                           |
+|`KC_AUDIO_VOL_UP`      |`KC_VOLU`           |Volume Up                                      |
+|`KC_AUDIO_VOL_DOWN`    |`KC_VOLD`           |Volume Down                                    |
 |`KC_MEDIA_NEXT_TRACK`  |`KC_MNXT`           |Next Track (Windows)                           |
 |`KC_MEDIA_PREV_TRACK`  |`KC_MPRV`           |Previous Track (Windows)                       |
-|`KC_MEDIA_STOP`        |`KC_MSTP`           |Stop Track                                     |
+|`KC_MEDIA_STOP`        |`KC_MSTP`           |Stop Track (Windows)                           |
 |`KC_MEDIA_PLAY_PAUSE`  |`KC_MPLY`           |Play/Pause Track                               |
-|`KC_MEDIA_SELECT`      |`KC_MSEL`           |                                               |
+|`KC_MEDIA_SELECT`      |`KC_MSEL`           |Launch Media Player (Windows)                  |
 |`KC_MEDIA_EJECT`       |`KC_EJCT`           |Eject (macOS)                                  |
-|`KC_MAIL`              |`KC_MAIL`           |                                               |
-|`KC_CALCULATOR`        |`KC_CALC`           |                                               |
-|`KC_MY_COMPUTER`       |`KC_MYCM`           |                                               |
-|`KC_WWW_SEARCH`        |`KC_WSCH`           |                                               |
-|`KC_WWW_HOME`          |`KC_WHOM`           |                                               |
-|`KC_WWW_BACK`          |`KC_WBAK`           |                                               |
-|`KC_WWW_FORWARD`       |`KC_WFWD`           |                                               |
-|`KC_WWW_STOP`          |`KC_WSTP`           |                                               |
-|`KC_WWW_REFRESH`       |`KC_WREF`           |                                               |
-|`KC_WWW_FAVORITES`     |`KC_WFAV`           |                                               |
+|`KC_MAIL`              |                    |Launch Mail (Windows)                          |
+|`KC_CALCULATOR`        |`KC_CALC`           |Launch Calculator (Windows)                    |
+|`KC_MY_COMPUTER`       |`KC_MYCM`           |Launch My Computer (Windows)                   |
+|`KC_WWW_SEARCH`        |`KC_WSCH`           |Browser Search (Windows)                       |
+|`KC_WWW_HOME`          |`KC_WHOM`           |Browser Home (Windows)                         |
+|`KC_WWW_BACK`          |`KC_WBAK`           |Browser Back (Windows)                         |
+|`KC_WWW_FORWARD`       |`KC_WFWD`           |Browser Forward (Windows)                      |
+|`KC_WWW_STOP`          |`KC_WSTP`           |Browser Stop (Windows)                         |
+|`KC_WWW_REFRESH`       |`KC_WREF`           |Browser Refresh (Windows)                      |
+|`KC_WWW_FAVORITES`     |`KC_WFAV`           |Browser Favorites (Windows)                    |
 |`KC_MEDIA_FAST_FORWARD`|`KC_MFFD`           |Next Track (macOS)                             |
 |`KC_MEDIA_REWIND`      |`KC_MRWD`           |Previous Track (macOS)                         |
 
@@ -391,29 +404,29 @@ This is a reference only. Each group of keys links to the page documenting their
 
 ## [US ANSI Shifted Keys](keycodes_us_ansi_shifted.md)
 
-|Key                     |Aliases           |Description        |
-|------------------------|------------------|-------------------|
-|`KC_TILDE`              |`KC_TILD`         |`~`                |
-|`KC_EXCLAIM`            |`KC_EXLM`         |`!`                |
-|`KC_AT`                 |                  |`@`                |
-|`KC_HASH`               |                  |`#`                |
-|`KC_DOLLAR`             |`KC_DLR`          |`$`                |
-|`KC_PERCENT`            |`KC_PERC`         |`%`                |
-|`KC_CIRCUMFLEX`         |`KC_CIRC`         |`^`                |
-|`KC_AMPERSAND`          |`KC_AMPR`         |`&`                |
-|`KC_ASTERISK`           |`KC_ASTR`         |`*`                |
-|`KC_LEFT_PAREN`         |`KC_LPRN`         |`(`                |
-|`KC_RIGHT_PAREN`        |`KC_RPRN`         |`)`                |
-|`KC_UNDERSCORE`         |`KC_UNDS`         |`_`                |
-|`KC_PLUS`               |                  |`+`                |
-|`KC_LEFT_CURLY_BRACE`   |`KC_LCBR`         |`{`                |
-|`KC_RIGHT_CURLY_BRACE`  |`KC_RCBR`         |`}`                |
-|`KC_PIPE`               |                  |<code>&#124;</code>|
-|`KC_COLON`              |`KC_COLN`         |`:`                |
-|`KC_DOUBLE_QUOTE`       |`KC_DQT`/`KC_DQUO`|`"`                |
-|`KC_LEFT_ANGLE_BRACKET` |`KC_LT`/`KC_LABK` |`<`                |
-|`KC_RIGHT_ANGLE_BRACKET`|`KC_GT`/`KC_RABK` |`>`                |
-|`KC_QUESTION`           |`KC_QUES`         |`?`                |
+|Key                     |Aliases            |Description        |
+|------------------------|-------------------|-------------------|
+|`KC_TILDE`              |`KC_TILD`          |`~`                |
+|`KC_EXCLAIM`            |`KC_EXLM`          |`!`                |
+|`KC_AT`                 |                   |`@`                |
+|`KC_HASH`               |                   |`#`                |
+|`KC_DOLLAR`             |`KC_DLR`           |`$`                |
+|`KC_PERCENT`            |`KC_PERC`          |`%`                |
+|`KC_CIRCUMFLEX`         |`KC_CIRC`          |`^`                |
+|`KC_AMPERSAND`          |`KC_AMPR`          |`&`                |
+|`KC_ASTERISK`           |`KC_ASTR`          |`*`                |
+|`KC_LEFT_PAREN`         |`KC_LPRN`          |`(`                |
+|`KC_RIGHT_PAREN`        |`KC_RPRN`          |`)`                |
+|`KC_UNDERSCORE`         |`KC_UNDS`          |`_`                |
+|`KC_PLUS`               |                   |`+`                |
+|`KC_LEFT_CURLY_BRACE`   |`KC_LCBR`          |`{`                |
+|`KC_RIGHT_CURLY_BRACE`  |`KC_RCBR`          |`}`                |
+|`KC_PIPE`               |                   |<code>&#124;</code>|
+|`KC_COLON`              |`KC_COLN`          |`:`                |
+|`KC_DOUBLE_QUOTE`       |`KC_DQUO`, `KC_DQT`|`"`                |
+|`KC_LEFT_ANGLE_BRACKET` |`KC_LABK`, `KC_LT` |`<`                |
+|`KC_RIGHT_ANGLE_BRACKET`|`KC_RABK`, `KC_GT` |`>`                |
+|`KC_QUESTION`           |`KC_QUES`          |`?`                |
 
 ## [Switching and Toggling Layers](feature_advanced_keycodes.md#switching-and-toggling-layers)
 

--- a/docs/keycodes_basic.md
+++ b/docs/keycodes_basic.md
@@ -74,37 +74,37 @@ The basic set of keycodes are based on the [HID Keyboard/Keypad Usage Page (0x07
 
 ## Punctuation
 
-|Key              |Aliases  |Description                       |
-|-----------------|---------|----------------------------------|
-|`KC_ENTER`       |`KC_ENT` |Return (Enter)                    |
-|`KC_ESCAPE`      |`KC_ESC` |Escape                            |
-|`KC_BSPACE`      |`KC_BSPC`|Delete (Backspace)                |
-|`KC_TAB`         |         |Tab                               |
-|`KC_SPACE`       |`KC_SPC` |Spacebar                          |
-|`KC_MINUS`       |`KC_MINS`|`-` and `_`                       |
-|`KC_EQUAL`       |`KC_EQL` |`=` and `+`                       |
-|`KC_LBRACKET`    |`KC_LBRC`|`[` and `{`                       |
-|`KC_RBRACKET`    |`KC_RBRC`|`]` and `}`                       |
-|`KC_BSLASH`      |`KC_BSLS`|`\` and <code>&#124;</code>       |
-|`KC_NONUS_HASH`  |`KC_NUHS`|Non-US `#` and `~`                |
-|`KC_SCOLON`      |`KC_SCLN`|`;` and `:`                       |
-|`KC_QUOTE`       |`KC_QUOT`|`'` and `"`                       |
-|`KC_GRAVE`       |`KC_GRV` |<code>&#96;</code> and `~`        |
-|`KC_COMMA`       |`KC_COMM`|`,` and `<`                       |
-|`KC_DOT`         |         |`.` and `>`                       |
-|`KC_SLASH`       |`KC_SLSH`|`/` and `?`                       |
-|`KC_NONUS_BSLASH`|`KC_NUBS`|Non-US `\` and <code>&#124;</code>|
+|Key              |Aliases            |Description                                    |
+|-----------------|-------------------|-----------------------------------------------|
+|`KC_ENTER`       |`KC_ENT`           |Return (Enter)                                 |
+|`KC_ESCAPE`      |`KC_ESC`           |Escape                                         |
+|`KC_BSPACE`      |`KC_BSPC`          |Delete (Backspace)                             |
+|`KC_TAB`         |                   |Tab                                            |
+|`KC_SPACE`       |`KC_SPC`           |Spacebar                                       |
+|`KC_MINUS`       |`KC_MINS`          |`-` and `_`                                    |
+|`KC_EQUAL`       |`KC_EQL`           |`=` and `+`                                    |
+|`KC_LBRACKET`    |`KC_LBRC`          |`[` and `{`                                    |
+|`KC_RBRACKET`    |`KC_RBRC`          |`]` and `}`                                    |
+|`KC_BSLASH`      |`KC_BSLS`          |`\` and <code>&#124;</code>                    |
+|`KC_NONUS_HASH`  |`KC_NUHS`          |Non-US `#` and `~`                             |
+|`KC_SCOLON`      |`KC_SCLN`          |`;` and `:`                                    |
+|`KC_QUOTE`       |`KC_QUOT`          |`'` and `"`                                    |
+|`KC_GRAVE`       |`KC_GRV`, `KC_ZKHK`|<code>&#96;</code> and `~`, JIS Zenkaku/Hankaku|
+|`KC_COMMA`       |`KC_COMM`          |`,` and `<`                                    |
+|`KC_DOT`         |                   |`.` and `>`                                    |
+|`KC_SLASH`       |`KC_SLSH`          |`/` and `?`                                    |
+|`KC_NONUS_BSLASH`|`KC_NUBS`          |Non-US `\` and <code>&#124;</code>             |
 
 ## Lock Keys
 
-|Key                |Aliases  |Description              |
-|-------------------|---------|-------------------------|
-|`KC_CAPSLOCK`      |`KC_CAPS`|Caps Lock                |
-|`KC_SCROLLLOCK`    |`KC_SLCK`|Scroll Lock              |
-|`KC_NUMLOCK`       |`KC_NLCK`|Keypad Num Lock and Clear|
-|`KC_LOCKING_CAPS`  |`KC_LCAP`|Locking Caps Lock        |
-|`KC_LOCKING_NUM`   |`KC_LNUM`|Locking Num Lock         |
-|`KC_LOCKING_SCROLL`|`KC_LSCR`|Locking Scroll Lock      |
+|Key                |Aliases             |Description              |
+|-------------------|--------------------|-------------------------|
+|`KC_CAPSLOCK`      |`KC_CLCK`, `KC_CAPS`|Caps Lock                |
+|`KC_SCROLLLOCK`    |`KC_SLCK`           |Scroll Lock              |
+|`KC_NUMLOCK`       |`KC_NLCK`           |Keypad Num Lock and Clear|
+|`KC_LOCKING_CAPS`  |`KC_LCAP`           |Locking Caps Lock        |
+|`KC_LOCKING_NUM`   |`KC_LNUM`           |Locking Num Lock         |
+|`KC_LOCKING_SCROLL`|`KC_LSCR`           |Locking Scroll Lock      |
 
 ## Modifiers
 
@@ -121,58 +121,71 @@ The basic set of keycodes are based on the [HID Keyboard/Keypad Usage Page (0x07
 
 ## International
 
-|Key      |Aliases  |Description                    |
-|---------|---------|-------------------------------|
-|`KC_INT1`|`KC_RO`  |JIS `\` and <code>&#124;</code>|
-|`KC_INT2`|`KC_KANA`|JIS Katakana/Hiragana          |
-|`KC_INT3`|`KC_JYEN`|JIS `¥`                        |
-|`KC_INT4`|`KC_HENK`|JIS Henkan                     |
-|`KC_INT5`|`KC_MHEN`|JIS Muhenkan                   |
+|Key       |Aliases  |Description                    |
+|----------|---------|-------------------------------|
+|`KC_INT1` |`KC_RO`  |JIS `\` and <code>&#124;</code>|
+|`KC_INT2` |`KC_KANA`|JIS Katakana/Hiragana          |
+|`KC_INT3` |`KC_JYEN`|JIS `¥`                        |
+|`KC_INT4` |`KC_HENK`|JIS Henkan                     |
+|`KC_INT5` |`KC_MHEN`|JIS Muhenkan                   |
+|`KC_INT6` |         |JIS Numpad `,`                 |
+|`KC_INT7` |         |International 7                |
+|`KC_INT8` |         |International 8                |
+|`KC_INT9` |         |International 9                |
+|`KC_LANG1`|`KC_HAEN`|Hangul/English                 |
+|`KC_LANG2`|`KC_HANJ`|Hanja                          |
+|`KC_LANG3`|         |JIS Katakana                   |
+|`KC_LANG4`|         |JIS Hiragana                   |
+|`KC_LANG5`|         |JIS Zenkaku/Hankaku            |
+|`KC_LANG6`|         |Language 6                     |
+|`KC_LANG7`|         |Language 7                     |
+|`KC_LANG8`|         |Language 8                     |
+|`KC_LANG9`|         |Language 9                     |
 
 ## Commands
 
-|Key               |Aliases  |Description                   |
-|------------------|---------|------------------------------|
-|`KC_PSCREEN`      |`KC_PSCR`|Print Screen                  |
-|`KC_PAUSE`        |`KC_PAUS`|Pause                         |
-|`KC_INSERT`       |`KC_INS` |Insert                        |
-|`KC_HOME`         |         |Home                          |
-|`KC_PGUP`         |         |Page Up                       |
-|`KC_DELETE`       |`KC_DEL` |Forward Delete                |
-|`KC_END`          |         |End                           |
-|`KC_PGDOWN`       |`KC_PGDN`|Page Down                     |
-|`KC_RIGHT`        |`KC_RGHT`|Right Arrow                   |
-|`KC_LEFT`         |         |Left Arrow                    |
-|`KC_DOWN`         |         |Down Arrow                    |
-|`KC_UP`           |         |Up Arrow                      |
-|`KC_APPLICATION`  |`KC_APP` |Application (Windows Menu Key)|
-|`KC_POWER`        |         |Power                         |
-|`KC_EXECUTE`      |         |Execute                       |
-|`KC_HELP`         |         |Help                          |
-|`KC_MENU`         |         |Menu                          |
-|`KC_SELECT`       |         |Select                        |
-|`KC_STOP`         |         |Stop                          |
-|`KC_AGAIN`        |         |Again                         |
-|`KC_UNDO`         |         |Undo                          |
-|`KC_CUT`          |         |Cut                           |
-|`KC_COPY`         |         |Copy                          |
-|`KC_PASTE`        |         |Paste                         |
-|`KC_FIND`         |         |Find                          |
-|`KC__MUTE`        |         |Mute (macOS)                  |
-|`KC__VOLUP`       |         |Volume Up (macOS)             |
-|`KC__VOLDOWN`     |         |Volume Down (macOS)           |
-|`KC_ALT_ERASE`    |         |Alternate Erase               |
-|`KC_SYSREQ`       |         |SysReq/Attention              |
-|`KC_CANCEL`       |         |Cancel                        |
-|`KC_CLEAR`        |         |Clear                         |
-|`KC_PRIOR`        |         |Prior                         |
-|`KC_RETURN`       |         |Return                        |
-|`KC_SEPARATOR`    |         |Separator                     |
-|`KC_OUT`          |         |Out                           |
-|`KC_OPER`         |         |Oper                          |
-|`KC_CLEAR_AGAIN`  |         |Clear/Again                   |
-|`KC_CRSEL`        |         |CrSel/Props                   |
-|`KC_EXSEL`        |         |ExSel                         |
+|Key               |Aliases            |Description                   |
+|------------------|-------------------|------------------------------|
+|`KC_PSCREEN`      |`KC_PSCR`          |Print Screen                  |
+|`KC_PAUSE`        |`KC_PAUS`, `KC_BRK`|Pause                         |
+|`KC_INSERT`       |`KC_INS`           |Insert                        |
+|`KC_HOME`         |                   |Home                          |
+|`KC_PGUP`         |                   |Page Up                       |
+|`KC_DELETE`       |`KC_DEL`           |Forward Delete                |
+|`KC_END`          |                   |End                           |
+|`KC_PGDOWN`       |`KC_PGDN`          |Page Down                     |
+|`KC_RIGHT`        |`KC_RGHT`          |Right Arrow                   |
+|`KC_LEFT`         |                   |Left Arrow                    |
+|`KC_DOWN`         |                   |Down Arrow                    |
+|`KC_UP`           |                   |Up Arrow                      |
+|`KC_APPLICATION`  |`KC_APP`           |Application (Windows Menu Key)|
+|`KC_POWER`        |                   |System Power (macOS/Linux)    |
+|`KC_EXECUTE`      |`KC_EXEC`          |Execute                       |
+|`KC_HELP`         |                   |Help                          |
+|`KC_MENU`         |                   |Menu                          |
+|`KC_SELECT`       |`KC_SLCT`          |Select                        |
+|`KC_STOP`         |                   |Stop                          |
+|`KC_AGAIN`        |`KC_AGIN`          |Again                         |
+|`KC_UNDO`         |                   |Undo                          |
+|`KC_CUT`          |                   |Cut                           |
+|`KC_COPY`         |                   |Copy                          |
+|`KC_PASTE`        |`KC_PSTE`          |Paste                         |
+|`KC_FIND`         |                   |Find                          |
+|`KC__MUTE`        |                   |Mute (macOS)                  |
+|`KC__VOLUP`       |                   |Volume Up (macOS)             |
+|`KC__VOLDOWN`     |                   |Volume Down (macOS)           |
+|`KC_ALT_ERASE`    |`KC_ERAS`          |Alternate Erase               |
+|`KC_SYSREQ`       |                   |SysReq/Attention              |
+|`KC_CANCEL`       |                   |Cancel                        |
+|`KC_CLEAR`        |`KC_CLR`           |Clear                         |
+|`KC_PRIOR`        |                   |Prior                         |
+|`KC_RETURN`       |                   |Return                        |
+|`KC_SEPARATOR`    |                   |Separator                     |
+|`KC_OUT`          |                   |Out                           |
+|`KC_OPER`         |                   |Oper                          |
+|`KC_CLEAR_AGAIN`  |                   |Clear/Again                   |
+|`KC_CRSEL`        |                   |CrSel/Props                   |
+|`KC_EXSEL`        |                   |ExSel                         |
 
 ## Media Keys
 
@@ -180,32 +193,32 @@ These keycodes are not part of the Keyboard/Keypad usage page. The `SYSTEM_` key
 
 Windows and macOS use different keycodes for "next track" and "previous track". Make sure you choose the keycode that corresponds to your OS.
 
-|Key                    |Aliases  |Description                      |
-|-----------------------|---------|---------------------------------|
-|`KC_SYSTEM_POWER`      |`KC_PWR` |System Power Down                |
-|`KC_SYSTEM_SLEEP`      |`KC_SLEP`|System Sleep                     |
-|`KC_SYSTEM_WAKE`       |`KC_WAKE`|System Wake                      |
-|`KC_AUDIO_MUTE`        |`KC_MUTE`|Mute (Windows/macOS/Linux)       |
-|`KC_AUDIO_VOL_UP`      |`KC_VOLU`|Volume Up (Windows/macOS/Linux)  |
-|`KC_AUDIO_VOL_DOWN`    |`KC_VOLD`|Volume Down (Windows/macOS/Linux)|
-|`KC_MEDIA_NEXT_TRACK`  |`KC_MNXT`|Next Track (Windows)             |
-|`KC_MEDIA_PREV_TRACK`  |`KC_MPRV`|Previous Track (Windows)         |
-|`KC_MEDIA_STOP`        |`KC_MSTP`|Stop Track                       |
-|`KC_MEDIA_PLAY_PAUSE`  |`KC_MPLY`|Play/Pause Track                 |
-|`KC_MEDIA_SELECT`      |`KC_MSEL`|                                 |
-|`KC_MEDIA_EJECT`       |`KC_EJCT`|Eject (macOS)                    |
-|`KC_MAIL`              |`KC_MAIL`|                                 |
-|`KC_CALCULATOR`        |`KC_CALC`|                                 |
-|`KC_MY_COMPUTER`       |`KC_MYCM`|                                 |
-|`KC_WWW_SEARCH`        |`KC_WSCH`|                                 |
-|`KC_WWW_HOME`          |`KC_WHOM`|                                 |
-|`KC_WWW_BACK`          |`KC_WBAK`|                                 |
-|`KC_WWW_FORWARD`       |`KC_WFWD`|                                 |
-|`KC_WWW_STOP`          |`KC_WSTP`|                                 |
-|`KC_WWW_REFRESH`       |`KC_WREF`|                                 |
-|`KC_WWW_FAVORITES`     |`KC_WFAV`|                                 |
-|`KC_MEDIA_FAST_FORWARD`|`KC_MFFD`|Next Track (macOS)               |
-|`KC_MEDIA_REWIND`      |`KC_MRWD`|Previous Track (macOS)           |
+|Key                    |Aliases  |Description                  |
+|-----------------------|---------|-----------------------------|
+|`KC_SYSTEM_POWER`      |`KC_PWR` |System Power Down            |
+|`KC_SYSTEM_SLEEP`      |`KC_SLEP`|System Sleep                 |
+|`KC_SYSTEM_WAKE`       |`KC_WAKE`|System Wake                  |
+|`KC_AUDIO_MUTE`        |`KC_MUTE`|Mute                         |
+|`KC_AUDIO_VOL_UP`      |`KC_VOLU`|Volume Up                    |
+|`KC_AUDIO_VOL_DOWN`    |`KC_VOLD`|Volume Down                  |
+|`KC_MEDIA_NEXT_TRACK`  |`KC_MNXT`|Next Track (Windows)         |
+|`KC_MEDIA_PREV_TRACK`  |`KC_MPRV`|Previous Track (Windows)     |
+|`KC_MEDIA_STOP`        |`KC_MSTP`|Stop Track (Windows)         |
+|`KC_MEDIA_PLAY_PAUSE`  |`KC_MPLY`|Play/Pause Track             |
+|`KC_MEDIA_SELECT`      |`KC_MSEL`|Launch Media Player (Windows)|
+|`KC_MEDIA_EJECT`       |`KC_EJCT`|Eject (macOS)                |
+|`KC_MAIL`              |         |Launch Mail (Windows)        |
+|`KC_CALCULATOR`        |`KC_CALC`|Launch Calculator (Windows)  |
+|`KC_MY_COMPUTER`       |`KC_MYCM`|Launch My Computer (Windows) |
+|`KC_WWW_SEARCH`        |`KC_WSCH`|Browser Search (Windows)     |
+|`KC_WWW_HOME`          |`KC_WHOM`|Browser Home (Windows)       |
+|`KC_WWW_BACK`          |`KC_WBAK`|Browser Back (Windows)       |
+|`KC_WWW_FORWARD`       |`KC_WFWD`|Browser Forward (Windows)    |
+|`KC_WWW_STOP`          |`KC_WSTP`|Browser Stop (Windows)       |
+|`KC_WWW_REFRESH`       |`KC_WREF`|Browser Refresh (Windows)    |
+|`KC_WWW_FAVORITES`     |`KC_WFAV`|Browser Favorites (Windows)  |
+|`KC_MEDIA_FAST_FORWARD`|`KC_MFFD`|Next Track (macOS)           |
+|`KC_MEDIA_REWIND`      |`KC_MRWD`|Previous Track (macOS)       |
 
 ## Number Pad
 
@@ -235,7 +248,7 @@ Windows and macOS use different keycodes for "next track" and "previous track". 
 
 In addition to these, keycodes in the range of `0xA5-DF` are reserved for internal use by TMK.
 
-|Key             |Aliases  |Description                            |
-|----------------|---------|---------------------------------------|
-|`KC_NO`         |         |Ignore this key (NOOP)                 |
-|`KC_TRANSPARENT`|`KC_TRNS`|Use the next lowest non-transparent key|
+|Key             |Aliases             |Description                            |
+|----------------|--------------------|---------------------------------------|
+|`KC_NO`         |`XXXXXXX`           |Ignore this key (NOOP)                 |
+|`KC_TRANSPARENT`|`KC_TRNS`, `_______`|Use the next lowest non-transparent key|

--- a/docs/keycodes_basic.md
+++ b/docs/keycodes_basic.md
@@ -47,30 +47,30 @@ The basic set of keycodes are based on the [HID Keyboard/Keypad Usage Page (0x07
 
 |Key     |Description|
 |--------|-----------|
-|`KC_F1` |           |
-|`KC_F2` |           |
-|`KC_F3` |           |
-|`KC_F4` |           |
-|`KC_F5` |           |
-|`KC_F6` |           |
-|`KC_F7` |           |
-|`KC_F8` |           |
-|`KC_F9` |           |
-|`KC_F10`|           |
-|`KC_F11`|           |
-|`KC_F12`|           |
-|`KC_F13`|           |
-|`KC_F14`|           |
-|`KC_F15`|           |
-|`KC_F16`|           |
-|`KC_F17`|           |
-|`KC_F18`|           |
-|`KC_F19`|           |
-|`KC_F20`|           |
-|`KC_F21`|           |
-|`KC_F22`|           |
-|`KC_F23`|           |
-|`KC_F24`|           |
+|`KC_F1` |F1         |
+|`KC_F2` |F2         |
+|`KC_F3` |F3         |
+|`KC_F4` |F4         |
+|`KC_F5` |F5         |
+|`KC_F6` |F6         |
+|`KC_F7` |F7         |
+|`KC_F8` |F8         |
+|`KC_F9` |F9         |
+|`KC_F10`|F10        |
+|`KC_F11`|F11        |
+|`KC_F12`|F12        |
+|`KC_F13`|F13        |
+|`KC_F14`|F14        |
+|`KC_F15`|F15        |
+|`KC_F16`|F16        |
+|`KC_F17`|F17        |
+|`KC_F18`|F18        |
+|`KC_F19`|F19        |
+|`KC_F20`|F20        |
+|`KC_F21`|F21        |
+|`KC_F22`|F22        |
+|`KC_F23`|F23        |
+|`KC_F24`|F24        |
 
 ## Punctuation
 
@@ -87,42 +87,53 @@ The basic set of keycodes are based on the [HID Keyboard/Keypad Usage Page (0x07
 |`KC_RBRACKET`    |`KC_RBRC`|`]` and `}`                       |
 |`KC_BSLASH`      |`KC_BSLS`|`\` and <code>&#124;</code>       |
 |`KC_NONUS_HASH`  |`KC_NUHS`|Non-US `#` and `~`                |
-|`KC_NONUS_BSLASH`|`KC_NUBS`|Non-US `\` and <code>&#124;</code>|
-|`KC_INT1`        |`KC_RO`  |JIS `\` and <code>&#124;</code>   |
-|`KC_INT2`        |`KC_KANA`|JIS Katakana/Hiragana             |
-|`KC_INT3`        |`KC_JYEN`|JIS `¥`                           |
 |`KC_SCOLON`      |`KC_SCLN`|`;` and `:`                       |
 |`KC_QUOTE`       |`KC_QUOT`|`'` and `"`                       |
 |`KC_GRAVE`       |`KC_GRV` |<code>&#96;</code> and `~`        |
 |`KC_COMMA`       |`KC_COMM`|`,` and `<`                       |
 |`KC_DOT`         |         |`.` and `>`                       |
 |`KC_SLASH`       |`KC_SLSH`|`/` and `?`                       |
-|`KC_CAPSLOCK`    |`KC_CAPS`|Caps Lock                         |
+|`KC_NONUS_BSLASH`|`KC_NUBS`|Non-US `\` and <code>&#124;</code>|
+
+## Lock Keys
+
+|Key                |Aliases  |Description              |
+|-------------------|---------|-------------------------|
+|`KC_CAPSLOCK`      |`KC_CAPS`|Caps Lock                |
+|`KC_SCROLLLOCK`    |`KC_SLCK`|Scroll Lock              |
+|`KC_NUMLOCK`       |`KC_NLCK`|Keypad Num Lock and Clear|
+|`KC_LOCKING_CAPS`  |`KC_LCAP`|Locking Caps Lock        |
+|`KC_LOCKING_NUM`   |`KC_LNUM`|Locking Num Lock         |
+|`KC_LOCKING_SCROLL`|`KC_LSCR`|Locking Scroll Lock      |
 
 ## Modifiers
 
-|Key                |Aliases             |Description                         |
-|-------------------|--------------------|------------------------------------|
-|`KC_LCTRL`         |`KC_LCTL`           |Left Control                        |
-|`KC_LSHIFT`        |`KC_LSFT`           |Left Shift                          |
-|`KC_LALT`          |                    |Left Alt                            |
-|`KC_LGUI`          |`KC_LCMD`, `KC_LWIN`|Left GUI (Windows/Command/Meta key) |
-|`KC_RCTRL`         |`KC_RCTL`           |Right Control                       |
-|`KC_RSHIFT`        |`KC_RSFT`           |Right Shift                         |
-|`KC_RALT`          |                    |Right Alt                           |
-|`KC_RGUI`          |`KC_RCMD`, `KC_RWIN`|Right GUI (Windows/Command/Meta key)|
-|`KC_LOCKING_CAPS`  |`KC_LCAP`           |Locking Caps Lock                   |
-|`KC_LOCKING_NUM`   |`KC_LNUM`           |Locking Num Lock                    |
-|`KC_LOCKING_SCROLL`|`KC_LSCR`           |Locking Scroll Lock                 |
-|`KC_INT4`          |`KC_HENK`           |JIS Henkan                          |
-|`KC_INT5`          |`KC_MHEN`           |JIS Muhenkan                        |
+|Key        |Aliases             |Description                         |
+|-----------|--------------------|------------------------------------|
+|`KC_LCTRL` |`KC_LCTL`           |Left Control                        |
+|`KC_LSHIFT`|`KC_LSFT`           |Left Shift                          |
+|`KC_LALT`  |                    |Left Alt                            |
+|`KC_LGUI`  |`KC_LCMD`, `KC_LWIN`|Left GUI (Windows/Command/Meta key) |
+|`KC_RCTRL` |`KC_RCTL`           |Right Control                       |
+|`KC_RSHIFT`|`KC_RSFT`           |Right Shift                         |
+|`KC_RALT`  |                    |Right Alt                           |
+|`KC_RGUI`  |`KC_RCMD`, `KC_RWIN`|Right GUI (Windows/Command/Meta key)|
+
+## International
+
+|Key      |Aliases  |Description                    |
+|---------|---------|-------------------------------|
+|`KC_INT1`|`KC_RO`  |JIS `\` and <code>&#124;</code>|
+|`KC_INT2`|`KC_KANA`|JIS Katakana/Hiragana          |
+|`KC_INT3`|`KC_JYEN`|JIS `¥`                        |
+|`KC_INT4`|`KC_HENK`|JIS Henkan                     |
+|`KC_INT5`|`KC_MHEN`|JIS Muhenkan                   |
 
 ## Commands
 
 |Key               |Aliases  |Description                   |
 |------------------|---------|------------------------------|
 |`KC_PSCREEN`      |`KC_PSCR`|Print Screen                  |
-|`KC_SCROLLLOCK`   |`KC_SLCK`|Scroll Lock                   |
 |`KC_PAUSE`        |`KC_PAUS`|Pause                         |
 |`KC_INSERT`       |`KC_INS` |Insert                        |
 |`KC_HOME`         |         |Home                          |
@@ -140,12 +151,16 @@ The basic set of keycodes are based on the [HID Keyboard/Keypad Usage Page (0x07
 |`KC_HELP`         |         |Help                          |
 |`KC_MENU`         |         |Menu                          |
 |`KC_SELECT`       |         |Select                        |
+|`KC_STOP`         |         |Stop                          |
 |`KC_AGAIN`        |         |Again                         |
 |`KC_UNDO`         |         |Undo                          |
 |`KC_CUT`          |         |Cut                           |
 |`KC_COPY`         |         |Copy                          |
 |`KC_PASTE`        |         |Paste                         |
 |`KC_FIND`         |         |Find                          |
+|`KC__MUTE`        |         |Mute (macOS)                  |
+|`KC__VOLUP`       |         |Volume Up (macOS)             |
+|`KC__VOLDOWN`     |         |Volume Down (macOS)           |
 |`KC_ALT_ERASE`    |         |Alternate Erase               |
 |`KC_SYSREQ`       |         |SysReq/Attention              |
 |`KC_CANCEL`       |         |Cancel                        |
@@ -170,6 +185,15 @@ Windows and macOS use different keycodes for "next track" and "previous track". 
 |`KC_SYSTEM_POWER`      |`KC_PWR` |System Power Down                |
 |`KC_SYSTEM_SLEEP`      |`KC_SLEP`|System Sleep                     |
 |`KC_SYSTEM_WAKE`       |`KC_WAKE`|System Wake                      |
+|`KC_AUDIO_MUTE`        |`KC_MUTE`|Mute (Windows/macOS/Linux)       |
+|`KC_AUDIO_VOL_UP`      |`KC_VOLU`|Volume Up (Windows/macOS/Linux)  |
+|`KC_AUDIO_VOL_DOWN`    |`KC_VOLD`|Volume Down (Windows/macOS/Linux)|
+|`KC_MEDIA_NEXT_TRACK`  |`KC_MNXT`|Next Track (Windows)             |
+|`KC_MEDIA_PREV_TRACK`  |`KC_MPRV`|Previous Track (Windows)         |
+|`KC_MEDIA_STOP`        |`KC_MSTP`|Stop Track                       |
+|`KC_MEDIA_PLAY_PAUSE`  |`KC_MPLY`|Play/Pause Track                 |
+|`KC_MEDIA_SELECT`      |`KC_MSEL`|                                 |
+|`KC_MEDIA_EJECT`       |`KC_EJCT`|Eject (macOS)                    |
 |`KC_MAIL`              |`KC_MAIL`|                                 |
 |`KC_CALCULATOR`        |`KC_CALC`|                                 |
 |`KC_MY_COMPUTER`       |`KC_MYCM`|                                 |
@@ -179,28 +203,14 @@ Windows and macOS use different keycodes for "next track" and "previous track". 
 |`KC_WWW_FORWARD`       |`KC_WFWD`|                                 |
 |`KC_WWW_STOP`          |`KC_WSTP`|                                 |
 |`KC_WWW_REFRESH`       |`KC_WREF`|                                 |
-|`KC_STOP`              |         |Stop                             |
 |`KC_WWW_FAVORITES`     |`KC_WFAV`|                                 |
-|`KC__MUTE`             |         |Mute (macOS)                     |
-|`KC__VOLUP`            |         |Volume Up (macOS)                |
-|`KC__VOLDOWN`          |         |Volume Down (macOS)              |
-|`KC_AUDIO_MUTE`        |`KC_MUTE`|Mute (Windows/macOS/Linux)       |
-|`KC_AUDIO_VOL_UP`      |`KC_VOLU`|Volume Up (Windows/macOS/Linux)  |
-|`KC_AUDIO_VOL_DOWN`    |`KC_VOLD`|Volume Down (Windows/macOS/Linux)|
-|`KC_MEDIA_NEXT_TRACK`  |`KC_MNXT`|Next Track (Windows)             |
-|`KC_MEDIA_PREV_TRACK`  |`KC_MPRV`|Previous Track (Windows)         |
 |`KC_MEDIA_FAST_FORWARD`|`KC_MFFD`|Next Track (macOS)               |
 |`KC_MEDIA_REWIND`      |`KC_MRWD`|Previous Track (macOS)           |
-|`KC_MEDIA_STOP`        |`KC_MSTP`|Stop Track                       |
-|`KC_MEDIA_PLAY_PAUSE`  |`KC_MPLY`|Play/Pause Track                 |
-|`KC_MEDIA_SELECT`      |`KC_MSEL`|                                 |
-|`KC_MEDIA_EJECT`       |`KC_EJCT`|Eject (macOS)                    |
 
 ## Number Pad
 
 |Key                |Aliases  |Description                   |
 |-------------------|---------|------------------------------|
-|`KC_NUMLOCK`       |`KC_NLCK`|Keypad Num Lock and Clear     |
 |`KC_KP_SLASH`      |`KC_PSLS`|Keypad `/`                    |
 |`KC_KP_ASTERISK`   |`KC_PAST`|Keypad `*`                    |
 |`KC_KP_MINUS`      |`KC_PMNS`|Keypad `-`                    |

--- a/docs/keycodes_us_ansi_shifted.md
+++ b/docs/keycodes_us_ansi_shifted.md
@@ -6,26 +6,26 @@ It's important to remember that all of these keycodes send a left shift - this m
 
 ## US ANSI Shifted Keycodes
 
-|Key                     |Aliases           |Description        |
-|------------------------|------------------|-------------------|
-|`KC_TILDE`              |`KC_TILD`         |`~`                |
-|`KC_EXCLAIM`            |`KC_EXLM`         |`!`                |
-|`KC_AT`                 |                  |`@`                |
-|`KC_HASH`               |                  |`#`                |
-|`KC_DOLLAR`             |`KC_DLR`          |`$`                |
-|`KC_PERCENT`            |`KC_PERC`         |`%`                |
-|`KC_CIRCUMFLEX`         |`KC_CIRC`         |`^`                |
-|`KC_AMPERSAND`          |`KC_AMPR`         |`&`                |
-|`KC_ASTERISK`           |`KC_ASTR`         |`*`                |
-|`KC_LEFT_PAREN`         |`KC_LPRN`         |`(`                |
-|`KC_RIGHT_PAREN`        |`KC_RPRN`         |`)`                |
-|`KC_UNDERSCORE`         |`KC_UNDS`         |`_`                |
-|`KC_PLUS`               |                  |`+`                |
-|`KC_LEFT_CURLY_BRACE`   |`KC_LCBR`         |`{`                |
-|`KC_RIGHT_CURLY_BRACE`  |`KC_RCBR`         |`}`                |
-|`KC_PIPE`               |                  |<code>&#124;</code>|
-|`KC_COLON`              |`KC_COLN`         |`:`                |
-|`KC_DOUBLE_QUOTE`       |`KC_DQT`/`KC_DQUO`|`"`                |
-|`KC_LEFT_ANGLE_BRACKET` |`KC_LT`/`KC_LABK` |`<`                |
-|`KC_RIGHT_ANGLE_BRACKET`|`KC_GT`/`KC_RABK` |`>`                |
-|`KC_QUESTION`           |`KC_QUES`         |`?`                |
+|Key                     |Aliases            |Description        |
+|------------------------|-------------------|-------------------|
+|`KC_TILDE`              |`KC_TILD`          |`~`                |
+|`KC_EXCLAIM`            |`KC_EXLM`          |`!`                |
+|`KC_AT`                 |                   |`@`                |
+|`KC_HASH`               |                   |`#`                |
+|`KC_DOLLAR`             |`KC_DLR`           |`$`                |
+|`KC_PERCENT`            |`KC_PERC`          |`%`                |
+|`KC_CIRCUMFLEX`         |`KC_CIRC`          |`^`                |
+|`KC_AMPERSAND`          |`KC_AMPR`          |`&`                |
+|`KC_ASTERISK`           |`KC_ASTR`          |`*`                |
+|`KC_LEFT_PAREN`         |`KC_LPRN`          |`(`                |
+|`KC_RIGHT_PAREN`        |`KC_RPRN`          |`)`                |
+|`KC_UNDERSCORE`         |`KC_UNDS`          |`_`                |
+|`KC_PLUS`               |                   |`+`                |
+|`KC_LEFT_CURLY_BRACE`   |`KC_LCBR`          |`{`                |
+|`KC_RIGHT_CURLY_BRACE`  |`KC_RCBR`          |`}`                |
+|`KC_PIPE`               |                   |<code>&#124;</code>|
+|`KC_COLON`              |`KC_COLN`          |`:`                |
+|`KC_DOUBLE_QUOTE`       |`KC_DQUO`, `KC_DQT`|`"`                |
+|`KC_LEFT_ANGLE_BRACKET` |`KC_LABK`, `KC_LT` |`<`                |
+|`KC_RIGHT_ANGLE_BRACKET`|`KC_RABK`, `KC_GT` |`>`                |
+|`KC_QUESTION`           |`KC_QUES`          |`?`                |


### PR DESCRIPTION
The basic keycodes are now in order of appearance in the enum. While this means some of them are now scattered across the `keycodes.md` list (eg. F keys), `keycodes_basic.md` still groups them together. The former should be used mostly for looking up single keycodes.

I also expanded upon the media keys, in particular it turns out `KC_MSEL` opens the default media player under Windows, but has no effect in macOS or (I assume) Linux. `KC_MPLY` will launch iTunes on macOS. 

Lastly, I added the aliases `XXXXXXX` and `_______` - I see many keyboards do this unnecessarily as they are actually already defined in `quantum_keycodes.h`.