### PR TITLE
Make sure Planck light calls user suspend functions

### DIFF
--- a/keyboards/planck/light/light.c
+++ b/keyboards/planck/light/light.c
@@ -159,10 +159,12 @@ void matrix_scan_kb(void)
 void suspend_power_down_kb(void)
 {
     rgb_matrix_set_suspend_state(true);
+    suspend_power_down_user();
 }
 
 void suspend_wakeup_init_kb(void)
 {
     rgb_matrix_set_suspend_state(false);
+    suspend_wakeup_init_user();
 }
 

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -53,6 +53,7 @@
 #include <stdlib.h>
 #include "print.h"
 #include "send_string_keycodes.h"
+#include "suspend.h"
 
 extern uint32_t default_layer_state;
 


### PR DESCRIPTION
The `suspend_power_down_kb` and `suspend_wakeup_init_kb` functions in the planck light are not calling the user versions of these functions.

This adds those calls, so that they should work properly now. 