### PR TITLE
Update Shifted keycodes docs

### DIFF
--- a/docs/keycodes_us_ansi_shifted.md
+++ b/docs/keycodes_us_ansi_shifted.md
@@ -1,10 +1,12 @@
 # US ANSI Shifted Symbols
 
-These keycodes correspond to characters that are "shifted" on a standard US ANSI keyboards. They do not have dedicated keycodes but are instead typed by holding down shift and then sending a keycode.
+These keycodes correspond to characters that are "shifted" on a standard US ANSI keyboard. They do not have keycodes of their own but are simply shortcuts for `LSFT(kc)`, and as such send a Left Shift with the unshifted keycode, not the symbol itself.
 
-It's important to remember that all of these keycodes send a left shift - this may cause unintended actions if unaccounted for. The short code is preferred in most situations.
+## Caveats
 
-## US ANSI Shifted Keycodes
+Unfortunately, these keycodes cannot be used in Mod-Taps or Layer-Taps, since any modifiers specified in the keycode are ignored.
+
+## Keycodes
 
 |Key                     |Aliases            |Description        |
 |------------------------|-------------------|-------------------|


### PR DESCRIPTION
A bit of rewording here so it flows better.

I'd also like to request #3430 be looked at too so the Caveats section is completely true (at present, the unshifted keycode is indeed sent, but the modifier spills into the layer or mod part of the keycode, resulting in odd behaviour).