### PR TITLE
Dedupe shifted keycodes listing

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -68,11 +68,10 @@
   * [One Shot Keys](feature_advanced_keycodes.md#one-shot-keys)
   * [RGB Light](feature_rgblight.md#rgblight-keycodes)
   * [RGB Matrix](feature_rgb_matrix.md#keycodes)
-  * [Shifted Keys](feature_advanced_keycodes.md#shifted-keycodes)
+  * [Shifted Keys](keycodes_us_ansi_shifted.md)
   * [Stenography](feature_stenography.md#keycode-reference)
   * [Swap Hands](feature_swap_hands.md#swap-keycodes)
   * [Thermal Printer](feature_thermal_printer.md#thermal-printer-keycodes)
-  * [US ANSI Shifted Keys](keycodes_us_ansi_shifted.md)
 
 * Reference
   * [Config Options](config_options.md)

--- a/docs/_summary.md
+++ b/docs/_summary.md
@@ -68,11 +68,10 @@
   * [One Shot Keys](feature_advanced_keycodes.md#one-shot-keys)
   * [RGB Light](feature_rgblight.md#rgblight-keycodes)
   * [RGB Matrix](feature_rgb_matrix.md#keycodes)
-  * [Shifted Keys](feature_advanced_keycodes.md#shifted-keycodes)
+  * [Shifted Keys](keycodes_us_ansi_shifted.md)
   * [Stenography](feature_stenography.md#keycode-reference)
   * [Swap Hands](feature_swap_hands.md#swap-keycodes)
   * [Thermal Printer](feature_thermal_printer.md#thermal-printer-keycodes)
-  * [US ANSI Shifted Keys](keycodes_us_ansi_shifted.md)
 
 * Reference
   * [Config Options](config_options.md)

--- a/docs/feature_advanced_keycodes.md
+++ b/docs/feature_advanced_keycodes.md
@@ -1,6 +1,6 @@
 # Advanced Keycodes
 
-Your keymap can include keycodes that are more advanced than normal, for example shifted keys. This page documents the functions that are available to you.
+Your keymap can include keycodes that are more advanced than normal, for example keys that switch layers or send modifiers when held, but send regular keycodes when tapped. This page documents the functions that are available to you.
 
 ### Assigning Custom Names
 
@@ -72,34 +72,6 @@ These functions allow you to combine a mod with a keycode. When pressed the keyd
 You can also chain these, like this:
 
     LALT(LCTL(KC_DEL)) -- this makes a key that sends Alt, Control, and Delete in a single keypress.
-
-# Shifted Keycodes
-
-The following shortcuts automatically add `LSFT()` to keycodes to get commonly used symbols.
-
-|Key                     |Aliases           |Description        |
-|------------------------|------------------|-------------------|
-|`KC_TILDE`              |`KC_TILD`         |`~`                |
-|`KC_EXCLAIM`            |`KC_EXLM`         |`!`                |
-|`KC_AT`                 |                  |`@`                |
-|`KC_HASH`               |                  |`#`                |
-|`KC_DOLLAR`             |`KC_DLR`          |`$`                |
-|`KC_PERCENT`            |`KC_PERC`         |`%`                |
-|`KC_CIRCUMFLEX`         |`KC_CIRC`         |`^`                |
-|`KC_AMPERSAND`          |`KC_AMPR`         |`&`                |
-|`KC_ASTERISK`           |`KC_ASTR`         |`*`                |
-|`KC_LEFT_PAREN`         |`KC_LPRN`         |`(`                |
-|`KC_RIGHT_PAREN`        |`KC_RPRN`         |`)`                |
-|`KC_UNDERSCORE`         |`KC_UNDS`         |`_`                |
-|`KC_PLUS`               |                  |`+`                |
-|`KC_LEFT_CURLY_BRACE`   |`KC_LCBR`         |`{`                |
-|`KC_RIGHT_CURLY_BRACE`  |`KC_RCBR`         |`}`                |
-|`KC_PIPE`               |                  |<code>&#124;</code>|
-|`KC_COLON`              |`KC_COLN`         |`:`                |
-|`KC_DOUBLE_QUOTE`       |`KC_DQT`/`KC_DQUO`|`"`                |
-|`KC_LEFT_ANGLE_BRACKET` |`KC_LT`/`KC_LABK` |`<`                |
-|`KC_RIGHT_ANGLE_BRACKET`|`KC_GT`/`KC_RABK` |`>`                |
-|`KC_QUESTION`           |`KC_QUES`         |`?`                |
 
 # Mod Tap
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -3,7 +3,7 @@
 QMK has a staggering number of features for building your keyboard. It can take some time to understand all of them and determine which one will achieve your goal.
 
 
-* [Advanced Keycodes](feature_advanced_keycodes.md) - Change layers, type shifted keys, and more. Go beyond typing simple characters.
+* [Advanced Keycodes](feature_advanced_keycodes.md) - Change layers, dual-action keys, and more. Go beyond typing simple characters.
 * [Audio](feature_audio.md) - Connect a speaker to your keyboard for audio feedback, midi support, and music mode.
 * [Auto Shift](feature_auto_shift.md) - Tap for the normal key, hold slightly longer for its shifted state.
 * [Backlight](feature_backlight.md) - LED lighting support for your keyboard.

--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -402,7 +402,7 @@ This is a reference only. Each group of keys links to the page documenting their
 |`PRINT_ON` |Start printing everything the user types|
 |`PRINT_OFF`|Stop printing everything the user types |
 
-## [US ANSI Shifted Keys](keycodes_us_ansi_shifted.md)
+## [US ANSI Shifted Symbols](keycodes_us_ansi_shifted.md)
 
 |Key                     |Aliases            |Description        |
 |------------------------|-------------------|-------------------|


### PR DESCRIPTION
These keycodes are currently documented in three (!) places: the master keycode list, the shifted symbols feature page, and the advanced keycodes page. I think they don't need to be in the last one as they already have their own page and are relatively simple compared to, say, a layer tap.