### PR TITLE
[WIP] rgblight.[ch] more configurable

### DIFF
--- a/quantum/rgblight-macro-test1.c
+++ b/quantum/rgblight-macro-test1.c
@@ -1,0 +1,29 @@
+// temporary code for test
+// rgblight.c new macro test on HOST computer
+// cc -o rgblight-macro-test rgblight-macro-test.c
+//
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+#define _RGBM_SINGLE(sym)  RGBLIGHT_MODE_ ## sym,
+#define _RGBM_MULTI(sym)   RGBLIGHT_MODE_ ## sym,
+#define _RGBM_TMP(sym)     RGBLIGHT_MODE_ ## sym,
+enum RGBLIGHT_EFFECT_MODE {
+    RGBLIGHT_MODE_zero = 0,
+#include "rgblight-macro-test1.h"
+    RGBLIGHT_MODE_end
+};
+
+int main(int argc, char *argv[])
+{
+#define _RGBM_SINGLE(sym) \
+  printf( "RGBLIGHT_MODE_%s = %d\n", #sym, RGBLIGHT_MODE_ ## sym);
+#define _RGBM_MULTI(sym) \
+  printf( "RGBLIGHT_MODE_%s = %d-%d\n", #sym, \
+          RGBLIGHT_MODE_ ## sym, \
+          RGBLIGHT_MODE_ ## sym ## _end);
+#define _RGBM_TMP(sym)
+  #include "rgblight-macro-test1.h"
+    exit(0);
+}

--- a/quantum/rgblight-macro-test1.h
+++ b/quantum/rgblight-macro-test1.h
@@ -1,0 +1,44 @@
+// temporary code for test
+
+#ifdef _RGBM_SINGLE
+  _RGBM_SINGLE( STATIC_LIGHT )
+  _RGBM_MULTI( BREATHING )
+  _RGBM_TMP( breathing_3 )
+  _RGBM_TMP( breathing_4 )
+  _RGBM_TMP( BREATHING_end )
+  _RGBM_MULTI( RAINBOW_MOOD )
+  _RGBM_TMP( rainbow_mood_7 )
+  _RGBM_TMP( RAINBOW_MOOD_end )
+  _RGBM_MULTI( RAINBOW_SWIRL )
+  _RGBM_TMP( rainbow_swirl_10 )
+  _RGBM_TMP( rainbow_swirl_11 )
+  _RGBM_TMP( rainbow_swirl_12 )
+  _RGBM_TMP( rainbow_swirl_13 )
+  _RGBM_TMP( RAINBOW_SWIRL_end )
+  _RGBM_MULTI( SNAKE )
+  _RGBM_TMP( snake_16 )
+  _RGBM_TMP( snake_17 )
+  _RGBM_TMP( snake_18 )
+  _RGBM_TMP( snake_19 )
+  _RGBM_TMP( SNAKE_end )
+  _RGBM_MULTI( KNIGHT )
+  _RGBM_TMP( knight_22 )
+  _RGBM_TMP( KNIGHT_end )
+  _RGBM_SINGLE( CHRISTMAS )
+  _RGBM_MULTI( STATIC_GRADIENT )
+  _RGBM_TMP( static_gradient_26 )
+  _RGBM_TMP( static_gradient_27 )
+  _RGBM_TMP( static_gradient_28 )
+  _RGBM_TMP( static_gradient_29 )
+  _RGBM_TMP( static_gradient_30 )
+  _RGBM_TMP( static_gradient_31 )
+  _RGBM_TMP( static_gradient_32 )
+  _RGBM_TMP( static_gradient_33 )
+  _RGBM_TMP( STATIC_GRADIENT_end )
+  _RGBM_SINGLE( RGB_TEST )
+  _RGBM_SINGLE( ALTERNATING )
+#endif
+
+#undef _RGBM_SINGLE
+#undef _RGBM_MULTI
+#undef _RGBM_TMP  

--- a/quantum/rgblight.h
+++ b/quantum/rgblight.h
@@ -16,10 +16,19 @@
 #ifndef RGBLIGHT_H
 #define RGBLIGHT_H
 
+#define _RGBM_SINGLE(sym)  RGBLIGHT_MODE_ ## sym,
+#define _RGBM_MULTI(sym)   RGBLIGHT_MODE_ ## sym,
+#define _RGBM_TMP(sym)     RGBLIGHT_MODE_ ## sym,
+enum RGBLIGHT_EFFECT_MODE {
+    RGBLIGHT_MODE_zero = 0,
+#include "rgblight.h"
+    RGBLIGHT_MODE_end
+};
+
 #ifdef RGBLIGHT_ANIMATIONS
-	#define RGBLIGHT_MODES 36
+    #define RGBLIGHT_MODES (RGBLIGHT_MODE_end-1)
 #else
-	#define RGBLIGHT_MODES 1
+    #define RGBLIGHT_MODES 1
 #endif
 
 #ifndef RGBLIGHT_EFFECT_BREATHE_CENTER
@@ -169,3 +178,46 @@ void rgblight_effect_rgbtest(void);
 void rgblight_effect_alternating(void);
 
 #endif
+
+#ifdef _RGBM_SINGLE
+  _RGBM_SINGLE( STATIC_LIGHT )
+  _RGBM_MULTI( BREATHING )
+  _RGBM_TMP( breathing_3 )
+  _RGBM_TMP( breathing_4 )
+  _RGBM_TMP( BREATHING_end )
+  _RGBM_MULTI( RAINBOW_MOOD )
+  _RGBM_TMP( rainbow_mood_7 )
+  _RGBM_TMP( RAINBOW_MOOD_end )
+  _RGBM_MULTI( RAINBOW_SWIRL )
+  _RGBM_TMP( rainbow_swirl_10 )
+  _RGBM_TMP( rainbow_swirl_11 )
+  _RGBM_TMP( rainbow_swirl_12 )
+  _RGBM_TMP( rainbow_swirl_13 )
+  _RGBM_TMP( RAINBOW_SWIRL_end )
+  _RGBM_MULTI( SNAKE )
+  _RGBM_TMP( snake_16 )
+  _RGBM_TMP( snake_17 )
+  _RGBM_TMP( snake_18 )
+  _RGBM_TMP( snake_19 )
+  _RGBM_TMP( SNAKE_end )
+  _RGBM_MULTI( KNIGHT )
+  _RGBM_TMP( knight_22 )
+  _RGBM_TMP( KNIGHT_end )
+  _RGBM_SINGLE( CHRISTMAS )
+  _RGBM_MULTI( STATIC_GRADIENT )
+  _RGBM_TMP( static_gradient_26 )
+  _RGBM_TMP( static_gradient_27 )
+  _RGBM_TMP( static_gradient_28 )
+  _RGBM_TMP( static_gradient_29 )
+  _RGBM_TMP( static_gradient_30 )
+  _RGBM_TMP( static_gradient_31 )
+  _RGBM_TMP( static_gradient_32 )
+  _RGBM_TMP( static_gradient_33 )
+  _RGBM_TMP( STATIC_GRADIENT_end )
+  _RGBM_SINGLE( RGB_TEST )
+  _RGBM_SINGLE( ALTERNATING )
+#endif
+
+#undef _RGBM_SINGLE
+#undef _RGBM_MULTI
+#undef _RGBM_TMP


### PR DESCRIPTION
The goal of this PullRequest is to make compilation on and off for each rgblight effect settable in config.h.

- [ ] step1: mode auto numberring and auto generate mode name symbol
- [ ] step2: use mode name at rgblight.c and quantum.c
