### PR TITLE
Serial Backlight LED fix for split_common

### DIFF
--- a/quantum/split_common/matrix.c
+++ b/quantum/split_common/matrix.c
@@ -341,6 +341,24 @@ void matrix_slave_scan(void) {
         serial_slave_buffer[i] = matrix[offset+i];
     }
 #endif
+#ifdef USE_I2C
+#ifdef BACKLIGHT_ENABLE
+    // Read backlight level sent from master and update level on slave
+    backlight_set(i2c_slave_buffer[0]);
+#endif
+    for (int i = 0; i < ROWS_PER_HAND; ++i) {
+        i2c_slave_buffer[i+1] = matrix[offset+i];
+    }
+#else // USE_SERIAL
+    for (int i = 0; i < ROWS_PER_HAND; ++i) {
+        serial_slave_buffer[i] = matrix[offset+i];
+    }
+
+#ifdef BACKLIGHT_ENABLE
+    // Read backlight level sent from master and update level on slave
+    backlight_set(serial_master_buffer[SERIAL_BACKLIT_START]);
+#endif
+#endif
     matrix_slave_scan_user();
 }
 


### PR DESCRIPTION
Myself and others have noticed the slave half of Iris keyboards not having the LED backlight synced. This was fixed by copying over the slave sync code previously in the Iris matrix.c. i2C did not have this problem.