### PR TITLE
fix swap_hands keycodes in documentation

### DIFF
--- a/docs/feature_swap_hands.md
+++ b/docs/feature_swap_hands.md
@@ -22,9 +22,9 @@ Note that the array indices are reversed same as the matrix and the values are o
 |Key        |Description                                                              |
 |-----------|-------------------------------------------------------------------------|
 |`SH_T(key)`|Sends `key` with a tap; momentary swap when held.                        |
-|`SW_ON`    |Turns on swapping and leaves it on.                                      |
-|`SW_OFF`   |Turn off swapping and leaves it off. Good for returning to a known state.|
-|`SW_MON`   |Swaps hands when pressed, returns to normal when released (momentary).   |
-|`SW_MOFF`  |Momentarily turns off swap.                                              |
+|`SH_ON`    |Turns on swapping and leaves it on.                                      |
+|`SH_OFF`   |Turn off swapping and leaves it off. Good for returning to a known state.|
+|`SH_MON`   |Swaps hands when pressed, returns to normal when released (momentary).   |
+|`SH_MOFF`  |Momentarily turns off swap.                                              |
 |`SH_TG`    |Toggles swap on and off with every key press.                            |
 |`SH_TT`    |Toggles with a tap; momentary when held.                                 |


### PR DESCRIPTION
keycodes in the documentation are wrong. led to compile errors.