### PR TITLE
Disable mouse keys for kbd6x

### DIFF
--- a/keyboards/kbd6x/rules.mk
+++ b/keyboards/kbd6x/rules.mk
@@ -52,7 +52,7 @@ OPT_DEFS += -DBOOTLOADER_SIZE=4096
 #   change yes to no to disable
 #
 BOOTMAGIC_ENABLE = no      # Virtual DIP switch configuration(+1000)
-MOUSEKEY_ENABLE = yes       # Mouse keys(+4700)
+MOUSEKEY_ENABLE = no       # Mouse keys(+4700)
 EXTRAKEY_ENABLE = yes       # Audio control and System control(+450)
 CONSOLE_ENABLE = yes        # Console for debug(+400)
 COMMAND_ENABLE = yes        # Commands for debug and configuration


### PR DESCRIPTION
Configurator generates larger file sizes because of this. 