### PR TITLE
Allow rgblight changes on split i2c boards without EEPROM writes

### DIFF
--- a/docs/feature_rgblight.md
+++ b/docs/feature_rgblight.md
@@ -42,6 +42,8 @@ Changing the **Value** sets the overall brightness.
 
 ## Keycodes
 
+All these keycodes will write the config to EEPROM:
+
 |Key                |Aliases   |Description                                                         |
 |-------------------|----------|--------------------------------------------------------------------|
 |`RGB_TOG`          |          |Toggle RGB lighting on or off                                       |
@@ -144,13 +146,15 @@ If you need to change your RGB lighting in code, for example in a macro to chang
 |`rgblight_disable_noeeprom()`      |Turn LEDs off (not written to EEPROM)                                                                                                                                  |
 |`rgblight_mode(x)`                 |Set the mode, if RGB animations are enabled                                                                                                                            |
 |`rgblight_mode_noeeprom(x)`        |Set the mode, if RGB animations are enabled (not written to EEPROM)                                                                                                    |
-|`rgblight_setrgb(r, g, b)`         |Set all LEDs to the given RGB value where `r`/`g`/`b` are between 0 and 255 (not written to EEPROM)                                                                    |
-|`rgblight_setrgb_at(r, g, b, led)` |Set a single LED to the given RGB value, where `r`/`g`/`b` are between 0 and 255 and `led` is between 0 and `RGBLED_NUM` (not written to EEPROM)                       |
 |`rgblight_sethsv(h, s, v)`         |Set all LEDs to the given HSV value where `h` is between 0 and 360 and `s`/`v` are between 0 and 255                                                                   |
 |`rgblight_sethsv_noeeprom(h, s, v)`|Set all LEDs to the given HSV value where `h` is between 0 and 360 and `s`/`v` are between 0 and 255 (not written to EEPROM)                                           |
 |`rgblight_sethsv_at(h, s, v, led)` |Set a single LED to the given HSV value, where `h` is between 0 and 360, `s`/`v` are between 0 and 255, and `led` is between 0 and `RGBLED_NUM` (not written to EEPROM)|
+|`rgblight_setrgb(r, g, b)`         |Set all LEDs to the given RGB value where `r`/`g`/`b` are between 0 and 255 (not written to EEPROM)                                                                    |
+|`rgblight_setrgb_at(r, g, b, led)` |Set a single LED to the given RGB value, where `r`/`g`/`b` are between 0 and 255 and `led` is between 0 and `RGBLED_NUM` (not written to EEPROM)                       |
 
 Additionally, [`rgblight_list.h`](https://github.com/qmk/qmk_firmware/blob/master/quantum/rgblight_list.h) defines several predefined shortcuts for various colors. Feel free to add to this list!
+
+?> The `rgblight_setrgb` functions are an exception, as they neither write to memory nor to EEPROM, but _only_ to the RGB LEDs. They are called by the `rgblight_sethsv` functions after the conversion from HSV to RGB (and writing to EEPROM, if any). All other functions write to memory.
 
 ## Hardware Modification
 

--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -225,6 +225,10 @@ uint32_t rgblight_get_mode(void) {
   return rgblight_config.mode;
 }
 
+uint32_t rgblight_get_raw(void) {
+  return rgblight_config.raw;
+}
+
 void rgblight_mode_eeprom_helper(uint8_t mode, bool write_to_eeprom) {
   if (!rgblight_config.enable) {
     return;

--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -185,6 +185,18 @@ void rgblight_update_dword(uint32_t dword) {
   }
 }
 
+void rgblight_update_dword_noeeprom(uint32_t dword) {
+  rgblight_config.raw = dword;
+  if (rgblight_config.enable)
+    rgblight_mode_noeeprom(rgblight_config.mode);
+  else {
+    #ifdef RGBLIGHT_ANIMATIONS
+      rgblight_timer_disable();
+    #endif
+      rgblight_set();
+  }
+}
+
 void rgblight_increase(void) {
   uint8_t mode = 0;
   if (rgblight_config.mode < RGBLIGHT_MODES) {

--- a/quantum/rgblight.h
+++ b/quantum/rgblight.h
@@ -114,6 +114,7 @@ uint32_t rgblight_get_raw(void);
 void rgblight_mode(uint8_t mode);
 void rgblight_set(void);
 void rgblight_update_dword(uint32_t dword);
+void rgblight_update_dword_noeeprom(uint32_t dword);
 void rgblight_increase_hue(void);
 void rgblight_decrease_hue(void);
 void rgblight_increase_sat(void);

--- a/quantum/rgblight.h
+++ b/quantum/rgblight.h
@@ -110,6 +110,7 @@ void rgblight_disable(void);
 void rgblight_step(void);
 void rgblight_step_reverse(void);
 uint32_t rgblight_get_mode(void);
+uint32_t rgblight_get_raw(void);
 void rgblight_mode(uint8_t mode);
 void rgblight_set(void);
 void rgblight_update_dword(uint32_t dword);

--- a/quantum/split_common/matrix.c
+++ b/quantum/split_common/matrix.c
@@ -261,7 +261,7 @@ i2c_error: // the cable is disconnceted, or something else went wrong
             err = i2c_master_write(I2C_RGB_START);
             if (err) goto i2c_error;
             
-            uint32_t dword = eeconfig_read_rgblight();
+            uint32_t dword = rgblight_get_raw();
             
             // Write RGB
             err = i2c_master_write_data(&dword, 4);

--- a/quantum/split_common/split_util.c
+++ b/quantum/split_common/split_util.c
@@ -131,7 +131,7 @@ void keyboard_slave_loop(void) {
                 }
                 
                 // Update the RGB now with the new data and set RGB_DIRTY to false
-                rgblight_update_dword(dword);
+                rgblight_update_dword_noeeprom(dword);
                 RGB_DIRTY = false;
                 // Re-enable interupts now that RGB is set
                 sei();

--- a/quantum/split_common/split_util.c
+++ b/quantum/split_common/split_util.c
@@ -61,9 +61,10 @@ static void keyboard_master_setup(void) {
   serial_master_init();
 #endif
 
-    // For master the Backlight info needs to be sent on startup
-    // Otherwise the salve won't start with the proper info until an update
-    BACKLIT_DIRTY = true;
+  // For master the backlight and rgblight info needs to be sent on startup
+  // Otherwise the slave won't start with the proper info until an update
+  BACKLIT_DIRTY = true;
+  RGB_DIRTY = true;
 }
 
 static void keyboard_slave_setup(void) {


### PR DESCRIPTION
**Why:**
This affects dual-controller split boards **using I2C**. I doubt it affects other types of split boards like those with I/O expanders, but the changes definitely only affect I2C.

Currently in `split_common` when `RGB_DIRTY==true`, master reads `rgblight_config` from EEPROM and sends to slave, and slave then writes it to EEPROM before updating the config in memory and in the LEDs.

This means that keycodes like `RGB_HUI` and functions like `rgblight_sethsv()` changes color on both halves as they update EEPROM, but `rgblight_sethsv_noeeprom()` and `rgblight_setrgb()` only changes color on the master half as they don't update EEPROM, only in memory and set the LEDs.

This makes it infeasible to change color frequently as a layer change indicator on split boards, since the EEPROM has limited writes.

**What:**
This PR changes `split_common` to read and write from the `rgblight_config` in memory, so that changes to `rgblight_config` will be sent regardless of whether they're written to EEPROM or not, and not written to EEPROM when received.

Change master to send rgblight config on startup, just like backlight config, so that both halves will start at the same state without having to wait for the first rgblight change.

`rgblight_update_dword()` was simply duplicated into `rgblight_update_dword_noeeprom()` instead of refactoring it out into a shared helper, as the only other client (apart from `split_common`) seems to be `quantum/api.c`.

Update docs to call out `rgblight_setrgb()` as being the exception in the list – it's actually manipulating only the LEDs and not the `rgblight_config` in memory nor the EEPROM, even though it doesn't say `_noeeprom`.

**Side effect:**
The `RGB_HUI` keycodes no longer update the rgblight config in EEPROM on the slave half. Effectively, if you manipulate the EEPROM using those keycodes or elsewhere in code after this PR, _the two halves will end up with different rgblight configs in EEPROM_.

I think this is fine since it's just like having a different keymap on each half – plugging in each halve makes a difference, but both halves will behave the same depending on the master.

**Potential side-effect:**
~If the `rgblight_config` in EEPROM is different between the two halves, they might remain different until the first `RGB_DIRTY` change? I haven't had the chance to look at the various inits to see if this is the case and if it's possible to always send the initial config over on init.~ 
Fixed in `keyboard_master_setup()` in 5ec8793.