### PR TITLE
Pearl keyboard LAYOUT_spacebar had an undefined constant K34

### DIFF
--- a/keyboards/pearl/pearl.h
+++ b/keyboards/pearl/pearl.h
@@ -54,7 +54,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   { K00, K01, K02,   K03,   K04, K05, K06,   K07,   K08,   K09, K0A, K0B,   K0C}, \
   { K10, K11, K12,   K13,   K14, K15, K16,   K17,   K18,   K19, K1A, K1B,   KC_NO}, \
   { K20, K21, K22,   K23,   K24, K25, K26,   K27,   K28,   K29, K2A, K2B,   KC_NO}, \
-  { K30, K31, KC_NO, KC_NO, K34, K35, KC_NO, KC_NO, KC_NO, K39, K3A, KC_NO, KC_NO}, \
+  { K30, K31, KC_NO, KC_NO, KC_NO, K35, KC_NO, KC_NO, KC_NO, K39, K3A, KC_NO, KC_NO}, \
 }
 
 


### PR DESCRIPTION
This fixes the following error when trying to use LAYOUT_spacebar with the Pearl layout:

```
Compiling: keyboards/pearl/keymaps/mrkeebs/keymap.c                                                
In file included from keyboards/pearl/keymaps/mrkeebs/keymap.c:18:0:
keyboards/pearl/pearl.h:57:29: error: 'K34' undeclared here (not in a function); did you mean 'KC_4'?
   { K30, K31, KC_NO, KC_NO, K34, K35, KC_NO, KC_NO, KC_NO, K39, K3A, KC_NO, KC_NO}, \
```