### PR TITLE
Tidy up keycode.h

### DIFF
--- a/tmk_core/common/keycode.h
+++ b/tmk_core/common/keycode.h
@@ -43,7 +43,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define IS_MOUSEKEY_WHEEL(code)  (KC_MS_WH_UP  <= (code) && (code) <= KC_MS_WH_RIGHT)
 #define IS_MOUSEKEY_ACCEL(code)  (KC_MS_ACCEL0 <= (code) && (code) <= KC_MS_ACCEL2)
 
-#define MOD_BIT(code)            ( 1<< MOD_INDEX(code))
+#define MOD_BIT(code)            (1 << MOD_INDEX(code))
 #define MOD_INDEX(code)          ((code) & 0x07)
 
 #define FN_BIT(code)             (1 << FN_INDEX(code))

--- a/tmk_core/common/keycode.h
+++ b/tmk_core/common/keycode.h
@@ -16,8 +16,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 /*
- * Keycodes based on HID Usage Keyboard/Keypad Page(0x07) plus special codes
- * https://web.archive.org/web/20060218214400/http://www.usb.org/developers/devclass_docs/Hut1_12.pdf
+ * Keycodes based on HID Keyboard/Keypad Usage Page (0x07) plus media keys from Generic Desktop Page (0x01) and Consumer Page (0x0C)
+ *
+ * See https://web.archive.org/web/20060218214400/http://www.usb.org/developers/devclass_docs/Hut1_12.pdf
  * or http://www.usb.org/developers/hidpage/Hut1_12v2.pdf (older)
  */
 #ifndef KEYCODE_H
@@ -30,76 +31,82 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define IS_KEY(code)             (KC_A         <= (code) && (code) <= KC_EXSEL)
 #define IS_MOD(code)             (KC_LCTRL     <= (code) && (code) <= KC_RGUI)
 
-
 #define IS_SPECIAL(code)         ((0xA5 <= (code) && (code) <= 0xDF) || (0xE8 <= (code) && (code) <= 0xFF))
 #define IS_SYSTEM(code)          (KC_PWR       <= (code) && (code) <= KC_WAKE)
 #define IS_CONSUMER(code)        (KC_MUTE      <= (code) && (code) <= KC_MRWD)
+
 #define IS_FN(code)              (KC_FN0       <= (code) && (code) <= KC_FN31)
+
 #define IS_MOUSEKEY(code)        (KC_MS_UP     <= (code) && (code) <= KC_MS_ACCEL2)
 #define IS_MOUSEKEY_MOVE(code)   (KC_MS_UP     <= (code) && (code) <= KC_MS_RIGHT)
 #define IS_MOUSEKEY_BUTTON(code) (KC_MS_BTN1   <= (code) && (code) <= KC_MS_BTN5)
 #define IS_MOUSEKEY_WHEEL(code)  (KC_MS_WH_UP  <= (code) && (code) <= KC_MS_WH_RIGHT)
 #define IS_MOUSEKEY_ACCEL(code)  (KC_MS_ACCEL0 <= (code) && (code) <= KC_MS_ACCEL2)
 
-#define MOD_BIT(code)   (1<<MOD_INDEX(code))
-#define MOD_INDEX(code) ((code) & 0x07)
-#define FN_BIT(code)    (1<<FN_INDEX(code))
-#define FN_INDEX(code)  ((code) - KC_FN0)
-#define FN_MIN          KC_FN0
-#define FN_MAX          KC_FN31
+#define MOD_BIT(code)            ( 1<< MOD_INDEX(code))
+#define MOD_INDEX(code)          ((code) & 0x07)
 
+#define FN_BIT(code)             (1 << FN_INDEX(code))
+#define FN_INDEX(code)           ((code) - KC_FN0)
+#define FN_MIN                   KC_FN0
+#define FN_MAX                   KC_FN31
 
 /*
  * Short names for ease of definition of keymap
  */
-#define KC_LCTL KC_LCTRL
-#define KC_RCTL KC_RCTRL
-#define KC_LSFT KC_LSHIFT
-#define KC_RSFT KC_RSHIFT
+/* Transparent */
+#define KC_TRANSPARENT 0x01
+#define KC_TRNS        KC_TRANSPARENT
+
+/* Punctuation */
+#define KC_ENT  KC_ENTER
 #define KC_ESC  KC_ESCAPE
 #define KC_BSPC KC_BSPACE
-#define KC_ENT  KC_ENTER
-#define KC_DEL  KC_DELETE
-#define KC_INS  KC_INSERT
-#define KC_CAPS KC_CAPSLOCK
-#define KC_CLCK KC_CAPSLOCK
-#define KC_RGHT KC_RIGHT
-#define KC_PGDN KC_PGDOWN
-#define KC_PSCR KC_PSCREEN
-#define KC_SLCK KC_SCROLLLOCK
-#define KC_PAUS KC_PAUSE
-#define KC_BRK  KC_PAUSE
-#define KC_NLCK KC_NUMLOCK
 #define KC_SPC  KC_SPACE
 #define KC_MINS KC_MINUS
 #define KC_EQL  KC_EQUAL
-#define KC_GRV  KC_GRAVE
-#define KC_RBRC KC_RBRACKET
 #define KC_LBRC KC_LBRACKET
-#define KC_COMM KC_COMMA
+#define KC_RBRC KC_RBRACKET
 #define KC_BSLS KC_BSLASH
-#define KC_SLSH KC_SLASH
+#define KC_NUHS KC_NONUS_HASH
 #define KC_SCLN KC_SCOLON
 #define KC_QUOT KC_QUOTE
-#define KC_APP  KC_APPLICATION
-#define KC_NUHS KC_NONUS_HASH
+#define KC_GRV  KC_GRAVE
+#define KC_COMM KC_COMMA
+#define KC_SLSH KC_SLASH
 #define KC_NUBS KC_NONUS_BSLASH
+
+/* Lock Keys */
+#define KC_CLCK KC_CAPSLOCK
+#define KC_CAPS KC_CAPSLOCK
+#define KC_SLCK KC_SCROLLLOCK
+#define KC_NLCK KC_NUMLOCK
 #define KC_LCAP KC_LOCKING_CAPS
 #define KC_LNUM KC_LOCKING_NUM
 #define KC_LSCR KC_LOCKING_SCROLL
+
+/* Commands */
+#define KC_PSCR KC_PSCREEN
+#define KC_PAUS KC_PAUSE
+#define KC_BRK  KC_PAUSE
+#define KC_INS  KC_INSERT
+#define KC_DEL  KC_DELETE
+#define KC_PGDN KC_PGDOWN
+#define KC_RGHT KC_RIGHT
+#define KC_APP  KC_APPLICATION
+#define KC_EXEC KC_EXECUTE
+#define KC_SLCT KC_SELECT
+#define KC_AGIN KC_AGAIN
+#define KC_PSTE KC_PASTE
 #define KC_ERAS KC_ALT_ERASE
 #define KC_CLR  KC_CLEAR
-/* Japanese specific */
-#define KC_ZKHK KC_GRAVE
-#define KC_RO   KC_INT1
-#define KC_KANA KC_INT2
-#define KC_JYEN KC_INT3
-#define KC_HENK KC_INT4
-#define KC_MHEN KC_INT5
-/* Korean specific */
-#define KC_HAEN KC_LANG1
-#define KC_HANJ KC_LANG2
+
 /* Keypad */
+#define KC_PSLS KC_KP_SLASH
+#define KC_PAST KC_KP_ASTERISK
+#define KC_PMNS KC_KP_MINUS
+#define KC_PPLS KC_KP_PLUS
+#define KC_PENT KC_KP_ENTER
 #define KC_P1   KC_KP_1
 #define KC_P2   KC_KP_2
 #define KC_P3   KC_KP_3
@@ -111,19 +118,60 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define KC_P9   KC_KP_9
 #define KC_P0   KC_KP_0
 #define KC_PDOT KC_KP_DOT
-#define KC_PCMM KC_KP_COMMA
-#define KC_PSLS KC_KP_SLASH
-#define KC_PAST KC_KP_ASTERISK
-#define KC_PMNS KC_KP_MINUS
-#define KC_PPLS KC_KP_PLUS
 #define KC_PEQL KC_KP_EQUAL
-#define KC_PENT KC_KP_ENTER
-/* Unix function key */
-#define KC_EXEC KC_EXECUTE
-#define KC_SLCT KC_SELECT
-#define KC_AGIN KC_AGAIN
-#define KC_PSTE KC_PASTE
-/* Mousekey */
+#define KC_PCMM KC_KP_COMMA
+
+/* Japanese specific */
+#define KC_ZKHK KC_GRAVE
+#define KC_RO   KC_INT1
+#define KC_KANA KC_INT2
+#define KC_JYEN KC_INT3
+#define KC_HENK KC_INT4
+#define KC_MHEN KC_INT5
+
+/* Korean specific */
+#define KC_HAEN KC_LANG1
+#define KC_HANJ KC_LANG2
+
+/* Modifiers */
+#define KC_LCTL KC_LCTRL
+#define KC_LSFT KC_LSHIFT
+#define KC_LCMD KC_LGUI
+#define KC_LWIN KC_LGUI
+#define KC_RCTL KC_RCTRL
+#define KC_RSFT KC_RSHIFT
+#define KC_RCMD KC_RGUI
+#define KC_RWIN KC_RGUI
+
+/* Generic Desktop Page (0x01) */
+#define KC_PWR  KC_SYSTEM_POWER
+#define KC_SLEP KC_SYSTEM_SLEEP
+#define KC_WAKE KC_SYSTEM_WAKE
+
+/* Consumer Page (0x0C) */
+#define KC_MUTE KC_AUDIO_MUTE
+#define KC_VOLU KC_AUDIO_VOL_UP
+#define KC_VOLD KC_AUDIO_VOL_DOWN
+#define KC_MNXT KC_MEDIA_NEXT_TRACK
+#define KC_MPRV KC_MEDIA_PREV_TRACK
+#define KC_MSTP KC_MEDIA_STOP
+#define KC_MPLY KC_MEDIA_PLAY_PAUSE
+#define KC_MSEL KC_MEDIA_SELECT
+#define KC_EJCT KC_MEDIA_EJECT
+#define KC_MAIL KC_MAIL
+#define KC_CALC KC_CALCULATOR
+#define KC_MYCM KC_MY_COMPUTER
+#define KC_WSCH KC_WWW_SEARCH
+#define KC_WHOM KC_WWW_HOME
+#define KC_WBAK KC_WWW_BACK
+#define KC_WFWD KC_WWW_FORWARD
+#define KC_WSTP KC_WWW_STOP
+#define KC_WREF KC_WWW_REFRESH
+#define KC_WFAV KC_WWW_FAVORITES
+#define KC_MFFD KC_MEDIA_FAST_FORWARD
+#define KC_MRWD KC_MEDIA_REWIND
+
+/* Mouse Keys */
 #define KC_MS_U KC_MS_UP
 #define KC_MS_D KC_MS_DOWN
 #define KC_MS_L KC_MS_LEFT
@@ -140,365 +188,332 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define KC_ACL0 KC_MS_ACCEL0
 #define KC_ACL1 KC_MS_ACCEL1
 #define KC_ACL2 KC_MS_ACCEL2
-/* Sytem Control */
-#define KC_PWR  KC_SYSTEM_POWER
-#define KC_SLEP KC_SYSTEM_SLEEP
-#define KC_WAKE KC_SYSTEM_WAKE
-/* Consumer Page */
-#define KC_MUTE KC_AUDIO_MUTE
-#define KC_VOLU KC_AUDIO_VOL_UP
-#define KC_VOLD KC_AUDIO_VOL_DOWN
-#define KC_MNXT KC_MEDIA_NEXT_TRACK
-#define KC_MPRV KC_MEDIA_PREV_TRACK
-#define KC_MFFD KC_MEDIA_FAST_FORWARD
-#define KC_MRWD KC_MEDIA_REWIND
-#define KC_MSTP KC_MEDIA_STOP
-#define KC_MPLY KC_MEDIA_PLAY_PAUSE
-#define KC_MSEL KC_MEDIA_SELECT
-#define KC_EJCT KC_MEDIA_EJECT
-#define KC_MAIL KC_MAIL
-#define KC_CALC KC_CALCULATOR
-#define KC_MYCM KC_MY_COMPUTER
-#define KC_WSCH KC_WWW_SEARCH
-#define KC_WHOM KC_WWW_HOME
-#define KC_WBAK KC_WWW_BACK
-#define KC_WFWD KC_WWW_FORWARD
-#define KC_WSTP KC_WWW_STOP
-#define KC_WREF KC_WWW_REFRESH
-#define KC_WFAV KC_WWW_FAVORITES
-/* Transparent */
-#define KC_TRANSPARENT  1
-#define KC_TRNS KC_TRANSPARENT
-/* GUI key aliases */
-#define KC_LCMD KC_LGUI
-#define KC_LWIN KC_LGUI
-#define KC_RCMD KC_RGUI
-#define KC_RWIN KC_RGUI
 
-
-
-/* USB HID Keyboard/Keypad Usage(0x07) */
+/* Keyboard/Keypad Page (0x07) */
 enum hid_keyboard_keypad_usage {
-    KC_NO               = 0x00,
-    KC_ROLL_OVER,
-    KC_POST_FAIL,
-    KC_UNDEFINED,
-    KC_A,
-    KC_B,
-    KC_C,
-    KC_D,
-    KC_E,
-    KC_F,
-    KC_G,
-    KC_H,
-    KC_I,
-    KC_J,
-    KC_K,
-    KC_L,
-    KC_M,               /* 0x10 */
-    KC_N,
-    KC_O,
-    KC_P,
-    KC_Q,
-    KC_R,
-    KC_S,
-    KC_T,
-    KC_U,
-    KC_V,
-    KC_W,
-    KC_X,
-    KC_Y,
-    KC_Z,
-    KC_1,
-    KC_2,
-    KC_3,               /* 0x20 */
-    KC_4,
-    KC_5,
-    KC_6,
-    KC_7,
-    KC_8,
-    KC_9,
-    KC_0,
-    KC_ENTER,
-    KC_ESCAPE,
-    KC_BSPACE,
-    KC_TAB,
-    KC_SPACE,
-    KC_MINUS,
-    KC_EQUAL,
-    KC_LBRACKET,
-    KC_RBRACKET,        /* 0x30 */
-    KC_BSLASH,          /* \ (and |) */
-    KC_NONUS_HASH,      /* Non-US # and ~ (Typically near the Enter key) */
-    KC_SCOLON,          /* ; (and :) */
-    KC_QUOTE,           /* ' and " */
-    KC_GRAVE,           /* Grave accent and tilde */
-    KC_COMMA,           /* , and < */
-    KC_DOT,             /* . and > */
-    KC_SLASH,           /* / and ? */
-    KC_CAPSLOCK,
-    KC_F1,
-    KC_F2,
-    KC_F3,
-    KC_F4,
-    KC_F5,
-    KC_F6,
-    KC_F7,              /* 0x40 */
-    KC_F8,
-    KC_F9,
-    KC_F10,
-    KC_F11,
-    KC_F12,
-    KC_PSCREEN,
-    KC_SCROLLLOCK,
-    KC_PAUSE,
-    KC_INSERT,
-    KC_HOME,
-    KC_PGUP,
-    KC_DELETE,
-    KC_END,
-    KC_PGDOWN,
-    KC_RIGHT,
-    KC_LEFT,            /* 0x50 */
-    KC_DOWN,
-    KC_UP,
-    KC_NUMLOCK,
-    KC_KP_SLASH,
-    KC_KP_ASTERISK,
-    KC_KP_MINUS,
-    KC_KP_PLUS,
-    KC_KP_ENTER,
-    KC_KP_1,
-    KC_KP_2,
-    KC_KP_3,
-    KC_KP_4,
-    KC_KP_5,
-    KC_KP_6,
-    KC_KP_7,
-    KC_KP_8,            /* 0x60 */
-    KC_KP_9,
-    KC_KP_0,
-    KC_KP_DOT,
-    KC_NONUS_BSLASH,    /* Non-US \ and | (Typically near the Left-Shift key) */
-    KC_APPLICATION,
-    KC_POWER,
-    KC_KP_EQUAL,
-    KC_F13,
-    KC_F14,
-    KC_F15,
-    KC_F16,
-    KC_F17,
-    KC_F18,
-    KC_F19,
-    KC_F20,
-    KC_F21,             /* 0x70 */
-    KC_F22,
-    KC_F23,
-    KC_F24,
-    KC_EXECUTE,
-    KC_HELP,
-    KC_MENU,
-    KC_SELECT,
-    KC_STOP,
-    KC_AGAIN,
-    KC_UNDO,
-    KC_CUT,
-    KC_COPY,
-    KC_PASTE,
-    KC_FIND,
-    KC__MUTE,
-    KC__VOLUP,          /* 0x80 */
-    KC__VOLDOWN,
-    KC_LOCKING_CAPS,    /* locking Caps Lock */
-    KC_LOCKING_NUM,     /* locking Num Lock */
-    KC_LOCKING_SCROLL,  /* locking Scroll Lock */
-    KC_KP_COMMA,
-    KC_KP_EQUAL_AS400,  /* equal sign on AS/400 */
-    KC_INT1,
-    KC_INT2,
-    KC_INT3,
-    KC_INT4,
-    KC_INT5,
-    KC_INT6,
-    KC_INT7,
-    KC_INT8,
-    KC_INT9,
-    KC_LANG1,           /* 0x90 */
-    KC_LANG2,
-    KC_LANG3,
-    KC_LANG4,
-    KC_LANG5,
-    KC_LANG6,
-    KC_LANG7,
-    KC_LANG8,
-    KC_LANG9,
-    KC_ALT_ERASE,
-    KC_SYSREQ,
-    KC_CANCEL,
-    KC_CLEAR,
-    KC_PRIOR,
-    KC_RETURN,
-    KC_SEPARATOR,
-    KC_OUT,             /* 0xA0 */
-    KC_OPER,
-    KC_CLEAR_AGAIN,
-    KC_CRSEL,
-    KC_EXSEL,           /* 0xA4 */
-
-    /* NOTE: 0xA5-DF are used for internal special purpose */
+  KC_NO                   = 0x00,
+  KC_ROLL_OVER,
+  KC_POST_FAIL,
+  KC_UNDEFINED,
+  KC_A,
+  KC_B,
+  KC_C,
+  KC_D,
+  KC_E,
+  KC_F,
+  KC_G,
+  KC_H,
+  KC_I,
+  KC_J,
+  KC_K,
+  KC_L,
+  KC_M,                   //0x10
+  KC_N,
+  KC_O,
+  KC_P,
+  KC_Q,
+  KC_R,
+  KC_S,
+  KC_T,
+  KC_U,
+  KC_V,
+  KC_W,
+  KC_X,
+  KC_Y,
+  KC_Z,
+  KC_1,
+  KC_2,
+  KC_3,                   //0x20
+  KC_4,
+  KC_5,
+  KC_6,
+  KC_7,
+  KC_8,
+  KC_9,
+  KC_0,
+  KC_ENTER,
+  KC_ESCAPE,
+  KC_BSPACE,
+  KC_TAB,
+  KC_SPACE,
+  KC_MINUS,
+  KC_EQUAL,
+  KC_LBRACKET,
+  KC_RBRACKET,            //0x30
+  KC_BSLASH,
+  KC_NONUS_HASH,
+  KC_SCOLON,
+  KC_QUOTE,
+  KC_GRAVE,
+  KC_COMMA,
+  KC_DOT,
+  KC_SLASH,
+  KC_CAPSLOCK,
+  KC_F1,
+  KC_F2,
+  KC_F3,
+  KC_F4,
+  KC_F5,
+  KC_F6,
+  KC_F7,                  //0x40
+  KC_F8,
+  KC_F9,
+  KC_F10,
+  KC_F11,
+  KC_F12,
+  KC_PSCREEN,
+  KC_SCROLLLOCK,
+  KC_PAUSE,
+  KC_INSERT,
+  KC_HOME,
+  KC_PGUP,
+  KC_DELETE,
+  KC_END,
+  KC_PGDOWN,
+  KC_RIGHT,
+  KC_LEFT,                //0x50
+  KC_DOWN,
+  KC_UP,
+  KC_NUMLOCK,
+  KC_KP_SLASH,
+  KC_KP_ASTERISK,
+  KC_KP_MINUS,
+  KC_KP_PLUS,
+  KC_KP_ENTER,
+  KC_KP_1,
+  KC_KP_2,
+  KC_KP_3,
+  KC_KP_4,
+  KC_KP_5,
+  KC_KP_6,
+  KC_KP_7,
+  KC_KP_8,                //0x60
+  KC_KP_9,
+  KC_KP_0,
+  KC_KP_DOT,
+  KC_NONUS_BSLASH,
+  KC_APPLICATION,
+  KC_POWER,
+  KC_KP_EQUAL,
+  KC_F13,
+  KC_F14,
+  KC_F15,
+  KC_F16,
+  KC_F17,
+  KC_F18,
+  KC_F19,
+  KC_F20,
+  KC_F21,                 //0x70
+  KC_F22,
+  KC_F23,
+  KC_F24,
+  KC_EXECUTE,
+  KC_HELP,
+  KC_MENU,
+  KC_SELECT,
+  KC_STOP,
+  KC_AGAIN,
+  KC_UNDO,
+  KC_CUT,
+  KC_COPY,
+  KC_PASTE,
+  KC_FIND,
+  KC__MUTE,
+  KC__VOLUP,              //0x80
+  KC__VOLDOWN,
+  KC_LOCKING_CAPS,
+  KC_LOCKING_NUM,
+  KC_LOCKING_SCROLL,
+  KC_KP_COMMA,
+  KC_KP_EQUAL_AS400,
+  KC_INT1,
+  KC_INT2,
+  KC_INT3,
+  KC_INT4,
+  KC_INT5,
+  KC_INT6,
+  KC_INT7,
+  KC_INT8,
+  KC_INT9,
+  KC_LANG1,               //0x90
+  KC_LANG2,
+  KC_LANG3,
+  KC_LANG4,
+  KC_LANG5,
+  KC_LANG6,
+  KC_LANG7,
+  KC_LANG8,
+  KC_LANG9,
+  KC_ALT_ERASE,
+  KC_SYSREQ,
+  KC_CANCEL,
+  KC_CLEAR,
+  KC_PRIOR,
+  KC_RETURN,
+  KC_SEPARATOR,
+  KC_OUT,                 //0xA0
+  KC_OPER,
+  KC_CLEAR_AGAIN,
+  KC_CRSEL,
+  KC_EXSEL,
 
 #if 0
-    /* NOTE: Following codes(0xB0-DD) are not used. Leave them for reference. */
-    KC_KP_00            = 0xB0,
-    KC_KP_000,
-    KC_THOUSANDS_SEPARATOR,
-    KC_DECIMAL_SEPARATOR,
-    KC_CURRENCY_UNIT,
-    KC_CURRENCY_SUB_UNIT,
-    KC_KP_LPAREN,
-    KC_KP_RPAREN,
-    KC_KP_LCBRACKET,    /* { */
-    KC_KP_RCBRACKET,    /* } */
-    KC_KP_TAB,
-    KC_KP_BSPACE,
-    KC_KP_A,
-    KC_KP_B,
-    KC_KP_C,
-    KC_KP_D,
-    KC_KP_E,            /* 0xC0 */
-    KC_KP_F,
-    KC_KP_XOR,
-    KC_KP_HAT,
-    KC_KP_PERC,
-    KC_KP_LT,
-    KC_KP_GT,
-    KC_KP_AND,
-    KC_KP_LAZYAND,
-    KC_KP_OR,
-    KC_KP_LAZYOR,
-    KC_KP_COLON,
-    KC_KP_HASH,
-    KC_KP_SPACE,
-    KC_KP_ATMARK,
-    KC_KP_EXCLAMATION,
-    KC_KP_MEM_STORE,    /* 0xD0 */
-    KC_KP_MEM_RECALL,
-    KC_KP_MEM_CLEAR,
-    KC_KP_MEM_ADD,
-    KC_KP_MEM_SUB,
-    KC_KP_MEM_MUL,
-    KC_KP_MEM_DIV,
-    KC_KP_PLUS_MINUS,
-    KC_KP_CLEAR,
-    KC_KP_CLEAR_ENTRY,
-    KC_KP_BINARY,
-    KC_KP_OCTAL,
-    KC_KP_DECIMAL,
-    KC_KP_HEXADECIMAL,  /* 0xDD */
+  // ***************************************************************
+  // These keycodes are present in the HID spec, but are           *
+  // nonfunctional on modern OSes. QMK uses this range (0xA5-0xDF) *
+  // for the media and function keys instead - see below.          *
+  // ***************************************************************
+
+  KC_KP_00                = 0xB0,
+  KC_KP_000,
+  KC_THOUSANDS_SEPARATOR,
+  KC_DECIMAL_SEPARATOR,
+  KC_CURRENCY_UNIT,
+  KC_CURRENCY_SUB_UNIT,
+  KC_KP_LPAREN,
+  KC_KP_RPAREN,
+  KC_KP_LCBRACKET,
+  KC_KP_RCBRACKET,
+  KC_KP_TAB,
+  KC_KP_BSPACE,
+  KC_KP_A,
+  KC_KP_B,
+  KC_KP_C,
+  KC_KP_D,
+  KC_KP_E,                //0xC0
+  KC_KP_F,
+  KC_KP_XOR,
+  KC_KP_HAT,
+  KC_KP_PERC,
+  KC_KP_LT,
+  KC_KP_GT,
+  KC_KP_AND,
+  KC_KP_LAZYAND,
+  KC_KP_OR,
+  KC_KP_LAZYOR,
+  KC_KP_COLON,
+  KC_KP_HASH,
+  KC_KP_SPACE,
+  KC_KP_ATMARK,
+  KC_KP_EXCLAMATION,
+  KC_KP_MEM_STORE,        //0xD0
+  KC_KP_MEM_RECALL,
+  KC_KP_MEM_CLEAR,
+  KC_KP_MEM_ADD,
+  KC_KP_MEM_SUB,
+  KC_KP_MEM_MUL,
+  KC_KP_MEM_DIV,
+  KC_KP_PLUS_MINUS,
+  KC_KP_CLEAR,
+  KC_KP_CLEAR_ENTRY,
+  KC_KP_BINARY,
+  KC_KP_OCTAL,
+  KC_KP_DECIMAL,
+  KC_KP_HEXADECIMAL,
 #endif
 
-    /* Modifiers */
-    KC_LCTRL            = 0xE0,
-    KC_LSHIFT,
-    KC_LALT,
-    KC_LGUI,
-    KC_RCTRL,
-    KC_RSHIFT,
-    KC_RALT,
-    KC_RGUI,
+  /* Modifiers */
+  KC_LCTRL                = 0xE0,
+  KC_LSHIFT,
+  KC_LALT,
+  KC_LGUI,
+  KC_RCTRL,
+  KC_RSHIFT,
+  KC_RALT,
+  KC_RGUI
 
-    /* NOTE: 0xE8-FF are used for internal special purpose */
+  // **********************************************
+  // * 0xF0-0xFF are unallocated in the HID spec. *
+  // * QMK uses these for Mouse Keys - see below. *
+  // **********************************************
 };
 
-/* Special keycodes */
-/* NOTE: 0xA5-DF and 0xE8-FF are used for internal special purpose */
+/* Media and Function keys */
 enum internal_special_keycodes {
-    /* System Control */
-    KC_SYSTEM_POWER     = 0xA5,
-    KC_SYSTEM_SLEEP,
-    KC_SYSTEM_WAKE,
+  /* Generic Desktop Page (0x01) */
+  KC_SYSTEM_POWER         = 0xA5,
+  KC_SYSTEM_SLEEP,
+  KC_SYSTEM_WAKE,
 
-    /* Media Control */
-    KC_AUDIO_MUTE,
-    KC_AUDIO_VOL_UP,
-    KC_AUDIO_VOL_DOWN,
-    KC_MEDIA_NEXT_TRACK,
-    KC_MEDIA_PREV_TRACK,
-    KC_MEDIA_STOP,
-    KC_MEDIA_PLAY_PAUSE,
-    KC_MEDIA_SELECT,
-    KC_MEDIA_EJECT,
-    KC_MAIL,
-    KC_CALCULATOR,
-    KC_MY_COMPUTER,
-    KC_WWW_SEARCH,
-    KC_WWW_HOME,
-    KC_WWW_BACK,
-    KC_WWW_FORWARD,
-    KC_WWW_STOP,
-    KC_WWW_REFRESH,
-    KC_WWW_FAVORITES,
-    KC_MEDIA_FAST_FORWARD,
-    KC_MEDIA_REWIND,    /* 0xBC */
+  /* Consumer Page (0x0C) */
+  KC_AUDIO_MUTE,
+  KC_AUDIO_VOL_UP,
+  KC_AUDIO_VOL_DOWN,
+  KC_MEDIA_NEXT_TRACK,
+  KC_MEDIA_PREV_TRACK,
+  KC_MEDIA_STOP,
+  KC_MEDIA_PLAY_PAUSE,
+  KC_MEDIA_SELECT,
+  KC_MEDIA_EJECT,         //0xB0
+  KC_MAIL,
+  KC_CALCULATOR,
+  KC_MY_COMPUTER,
+  KC_WWW_SEARCH,
+  KC_WWW_HOME,
+  KC_WWW_BACK,
+  KC_WWW_FORWARD,
+  KC_WWW_STOP,
+  KC_WWW_REFRESH,
+  KC_WWW_FAVORITES,
+  KC_MEDIA_FAST_FORWARD,
+  KC_MEDIA_REWIND,
 
-    /* Fn key */
-    KC_FN0              = 0xC0,
-    KC_FN1,
-    KC_FN2,
-    KC_FN3,
-    KC_FN4,
-    KC_FN5,
-    KC_FN6,
-    KC_FN7,
-    KC_FN8,
-    KC_FN9,
-    KC_FN10,
-    KC_FN11,
-    KC_FN12,
-    KC_FN13,
-    KC_FN14,
-    KC_FN15,
-
-    KC_FN16             = 0xD0,
-    KC_FN17,
-    KC_FN18,
-    KC_FN19,
-    KC_FN20,
-    KC_FN21,
-    KC_FN22,
-    KC_FN23,
-    KC_FN24,
-    KC_FN25,
-    KC_FN26,
-    KC_FN27,
-    KC_FN28,
-    KC_FN29,
-    KC_FN30,
-    KC_FN31,            /* 0xDF */
-
-    /**************************************/
-    /* 0xE0-E7 for Modifiers. DO NOT USE. */
-    /**************************************/
-
-    /* Mousekey */
-    KC_MS_UP            = 0xF0,
-    KC_MS_DOWN,
-    KC_MS_LEFT,
-    KC_MS_RIGHT,
-    KC_MS_BTN1,
-    KC_MS_BTN2,
-    KC_MS_BTN3,
-    KC_MS_BTN4,
-    KC_MS_BTN5,         /* 0xF8 */
-    /* Mousekey wheel */
-    KC_MS_WH_UP,
-    KC_MS_WH_DOWN,
-    KC_MS_WH_LEFT,
-    KC_MS_WH_RIGHT,     /* 0xFC */
-    /* Mousekey accel */
-    KC_MS_ACCEL0,
-    KC_MS_ACCEL1,
-    KC_MS_ACCEL2        /* 0xFF */
+  /* Fn keys */
+  KC_FN0                  = 0xC0,
+  KC_FN1,
+  KC_FN2,
+  KC_FN3,
+  KC_FN4,
+  KC_FN5,
+  KC_FN6,
+  KC_FN7,
+  KC_FN8,
+  KC_FN9,
+  KC_FN10,
+  KC_FN11,
+  KC_FN12,
+  KC_FN13,
+  KC_FN14,
+  KC_FN15,
+  KC_FN16                 //0xD0
+  KC_FN17,
+  KC_FN18,
+  KC_FN19,
+  KC_FN20,
+  KC_FN21,
+  KC_FN22,
+  KC_FN23,
+  KC_FN24,
+  KC_FN25,
+  KC_FN26,
+  KC_FN27,
+  KC_FN28,
+  KC_FN29,
+  KC_FN30,
+  KC_FN31
 };
 
-#endif /* KEYCODE_H */
+enum mouse_keys {
+  /* Mouse Buttons */
+  KC_MS_UP                = 0xF0,
+  KC_MS_DOWN,
+  KC_MS_LEFT,
+  KC_MS_RIGHT,
+  KC_MS_BTN1,
+  KC_MS_BTN2,
+  KC_MS_BTN3,
+  KC_MS_BTN4,
+  KC_MS_BTN5,
+
+  /* Mouse Wheel */
+  KC_MS_WH_UP,
+  KC_MS_WH_DOWN,
+  KC_MS_WH_LEFT,
+  KC_MS_WH_RIGHT,
+
+  /* Acceleration */
+  KC_MS_ACCEL0,
+  KC_MS_ACCEL1,
+  KC_MS_ACCEL2
+};
+#endif

--- a/tmk_core/common/keycode.h
+++ b/tmk_core/common/keycode.h
@@ -475,7 +475,7 @@ enum internal_special_keycodes {
   KC_FN13,
   KC_FN14,
   KC_FN15,
-  KC_FN16                 //0xD0
+  KC_FN16,                //0xD0
   KC_FN17,
   KC_FN18,
   KC_FN19,


### PR DESCRIPTION
Changed the indentation to 2 spaces as per the [coding conventions](https://docs.qmk.fm/#/contributing?id=coding-conventions). Also ordered and grouped the shortcut keycodes (`KC_XXXX`) in order of appearance.