### PR TITLE
Fix serial backlight fix breaking

### DIFF
--- a/quantum/split_common/matrix.c
+++ b/quantum/split_common/matrix.c
@@ -341,24 +341,6 @@ void matrix_slave_scan(void) {
         serial_slave_buffer[i] = matrix[offset+i];
     }
 #endif
-#ifdef USE_I2C
-#ifdef BACKLIGHT_ENABLE
-    // Read backlight level sent from master and update level on slave
-    backlight_set(i2c_slave_buffer[0]);
-#endif
-    for (int i = 0; i < ROWS_PER_HAND; ++i) {
-        i2c_slave_buffer[i+1] = matrix[offset+i];
-    }
-#else // USE_SERIAL
-    for (int i = 0; i < ROWS_PER_HAND; ++i) {
-        serial_slave_buffer[i] = matrix[offset+i];
-    }
-
-#ifdef BACKLIGHT_ENABLE
-    // Read backlight level sent from master and update level on slave
-    backlight_set(serial_master_buffer[SERIAL_BACKLIT_START]);
-#endif
-#endif
     matrix_slave_scan_user();
 }
 

--- a/quantum/split_common/split_util.c
+++ b/quantum/split_common/split_util.c
@@ -106,14 +106,14 @@ void keyboard_slave_loop(void) {
     
     // Read Backlight Info
     #ifdef BACKLIGHT_ENABLE
-        if (BACKLIT_DIRTY) {
-            #ifdef USE_I2C
+        #ifdef USE_I2C
+            if (BACKLIT_DIRTY) {
                 backlight_set(i2c_slave_buffer[I2C_BACKLIT_START]);
-            #else // USE_SERIAL
-                backlight_set(serial_master_buffer[SERIAL_BACKLIT_START]);
-            #endif
-            BACKLIT_DIRTY = false;
-        }
+                BACKLIT_DIRTY = false;
+            }
+        #else // USE_SERIAL
+            backlight_set(serial_master_buffer[SERIAL_BACKLIT_START]);
+        #endif
     #endif
     // Read RGB Info
     #ifdef RGBLIGHT_ENABLE


### PR DESCRIPTION
#3586 seems to be breaking rgblight for I2C split boards, see [r/olkb comment thread](https://www.reddit.com/r/olkb/comments/91y053/rgb_over_i2c/e4batqk/) and [thread2](https://www.reddit.com/r/olkb/comments/91y053/rgb_over_i2c/e4d1ddk/)

This PR reverts it and offers a substitute fix: tweak `keyboard_slave_loop()` to always run `backlight_set()` on every loop, ignoring the `BACKLIT_DIRTY` flag, which is effectively what #3586 has done except in the slave matrix scan instead. 

Technically it only needs to run every time there's a serial transaction from master since that will always update the backlight byte, so we _could_ change the serial code to update the `BACKLIT_DIRTY` flag. But it seems like the intent in the rgblight section in `keyboard_slave_loop()` is that serial mode doesn't use the flags, so I think this makes sense. I also don't want to mess with the serial code...

**Note:** I don't have a serial split board to test this with, but my `lets_split_eh` which uses I2C works with this.