### PR TITLE
Corrected LFK65_HS LAYOUT_all matrix

### DIFF
--- a/keyboards/lfkeyboards/lfk65_hs/lfk65_hs.h
+++ b/keyboards/lfkeyboards/lfk65_hs/lfk65_hs.h
@@ -23,6 +23,9 @@
 
 void reset_keyboard_kb(void);
 
+// readability
+#define ___ KC_NO
+
 /* All Keymap - contains every possible switch
 * ,-------------------------------------------------------------------------------.
 * | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 1A | 1B | 1C | 1D | 1E | 1F | 1G |
@@ -41,15 +44,15 @@ void reset_keyboard_kb(void);
 #define LAYOUT_all( \
     k11, k12, k13, k14, k15, k16, k17, k18, k19, k1A, k1B, k1C, k1D, k1E, k1F, k1G, \
     k21,   k22, k23, k24, k25, k26, k27, k28, k29, k2A, k2B, k2C, k2D,    k2F, k2G, \
-    k31,    k32, k33, k34, k35, k36, k37, k38, k39, k3A, k3B, k3C, K3D,   k3F, k3G, \
+    k31,    k32, k33, k34, k35, k36, k37, k38, k39, k3A, k3B, k3C, k3D,   k3F, k3G, \
     k41, k42, k43, k44,  k45, k46, k47, k48, k49, k4A, k4B, k4C,     k4D, k4F, k4G, \
     k51, k52, k53,              k57,                   k5B, k5C, k5D, k5E, k3E, k4E \
 ) { \
-    {k11, k12, k13, k14, k15, k16, k17, k18, k19, k1A, k1B, k1C, k1D, k1E, k1F, k1G}, \
-    {k21, k22, k23, k24, k25, k26, k27, k28, k29, k2A, k2B, k2C, k2D, KC_NO, k2F, k2G}, \
-    {k31, k32, k33, k34, k35, k36, k37, k38, k39, k3A, k3B, k3C, k3D, k3E, k3F, k3G}, \
-    {k41, k42, k43, k44, k45, k46, k47, k48, k49, k4A, k4B, k4C, k4D, k4E, k4F, k4G}, \
-    {k51, k52, k53, KC_NO, KC_NO, KC_NO, k57, KC_NO, KC_NO, KC_NO, k5B, k5C, k5D, k5E, KC_NO, KC_NO} \
+    { k11, k12, k13, k14, k15, k16, k17, k18, k19, k1A, k1B, k1C, k1D, k1E, k1F, k1G }, \
+    { k21, k22, k23, k24, k25, k26, k27, k28, k29, k2A, k2B, k2C, k2D, ___, k2F, k2G }, \
+    { k31, k32, k33, k34, k35, k36, k37, k38, k39, k3A, k3B, k3C, k3D, k3E, k3F, k3G }, \
+    { k41, k42, k43, k44, k45, k46, k47, k48, k49, k4A, k4B, k4C, k4D, k4E, k4F, k4G }, \
+    { k51, k52, k53, ___, ___, ___, k57, ___, ___, ___, k5B, k5C, k5D, k5E, ___, ___ } \
 }
 
 /* ANSI Keymap
@@ -72,11 +75,11 @@ void reset_keyboard_kb(void);
     k41,     k43, k44,  k45, k46, k47, k48, k49, k4A, k4B, k4C,         k4D, k4F, k4G, \
     k51, k52, k53,              k57,                      k5B, k5C, k5D, k5E, k3E, k4E \
 ) { \
-    {k11, k12, k13, k14, k15, k16, k17, k18, k19, k1A, k1B, k1C, k1D, KC_NO, k1F, k1G}, \
-    {k21, k22, k23, k24, k25, k26, k27, k28, k29, k2A, k2B, k2C, k2D, KC_NO, k2F, k2G}, \
-    {k31, k32, k33, k34, k35, k36, k37, k38, k39, k3A, k3B, k3C, KC_NO, k3E, k3F, k3G}, \
-    {k41, KC_NO, k43, k44, k45, k46, k47, k48, k49, k4A, k4B, k4C, k4D, k4E, k4F, k4G}, \
-    {k51, k52, k53, KC_NO, KC_NO, KC_NO, k57, KC_NO, KC_NO, KC_NO, k5B, k5C, k5D, k5E, KC_NO, KC_NO} \
+    { k11, k12, k13, k14, k15, k16, k17, k18, k19, k1A, k1B, k1C, k1D, ___, k1F, k1G }, \
+    { k21, k22, k23, k24, k25, k26, k27, k28, k29, k2A, k2B, k2C, k2D, ___, k2F, k2G }, \
+    { k31, k32, k33, k34, k35, k36, k37, k38, k39, k3A, k3B, k3C, ___, k3E, k3F, k3G }, \
+    { k41, ___, k43, k44, k45, k46, k47, k48, k49, k4A, k4B, k4C, k4D, k4E, k4F, k4G }, \
+    { k51, k52, k53, ___, ___, ___, k57, ___, ___, ___, k5B, k5C, k5D, k5E, ___, ___ } \
 }
 
 #endif //LFK65_HS_H


### PR DESCRIPTION
Switch `k3D` was listed as `K3D` in the parameter list, causing a compile error (undeclared variable).

Also aliased `KC_NO` as `___` for readability.