### PR TITLE
AMJ60 LAYOUT_iso matrix fix

### DIFF
--- a/keyboards/amj60/amj60.h
+++ b/keyboards/amj60/amj60.h
@@ -3,7 +3,7 @@
 
 #include "quantum.h"
 
-// readability  
+// readability
 #define XXX KC_NO
 
 /* AMJ60 layout to the best of my knowledge matrix layout
@@ -34,7 +34,7 @@
     {k40, k41, k42, XXX, XXX, k45, XXX, XXX, XXX, k49, k4a, k4b, k4c, k4d}  \
 }
 
-/* 
+/*
    * ANSI
    * ,-----------------------------------------------------------.
    * | 00 |01| 02| 03| 04| 05| 06| 07| 08| 09| 0a| 0b| 0c|   0d  |
@@ -92,7 +92,7 @@
     {k40, k41, k42, XXX, XXX, k45, XXX, XXX, XXX, k49, k4a, k4b, k4c, k4d}  \
 }
 
-/* ISO 
+/* ISO
    * ,-----------------------------------------------------------.
    * | 00 |01| 02| 03| 04| 05| 06| 07| 08| 09| 0a| 0b| 0c| 0d    |
    * |-----------------------------------------------------------|
@@ -116,7 +116,7 @@
     {k00, k01, k02, k03, k04, k05, k06, k07, k08, k09, k0a, k0b, k0c, k0d}, \
     {k10, k11, k12, k13, k14, k15, k16, k17, k18, k19, k1a, k1b, k1c, k1d}, \
     {k20, k21, k22, k23, k24, k25, k26, k27, k28, k29, k2a, k2b, k2c, k2d}, \
-    {k30, k31, k32, k33, k34, k35, k36, k37, k38, k39, k3a, k3b, k3c, XXX}, \
+    {k30, k31, k32, k33, k34, k35, k36, k37, k38, k39, k3a, k3b, XXX, k3d}, \
     {k40, k41, k42, XXX, XXX, k45, XXX, XXX, XXX, XXX, k4a, k4b, k4c, k4d}  \
 }
 


### PR DESCRIPTION
`LAYOUT_iso` matrix was invalid. (Macro was searching for `k3c`, which is unused in this layout.)