### PR TITLE
Fix for issue #3641

### DIFF
--- a/keyboards/6ball/config.h
+++ b/keyboards/6ball/config.h
@@ -39,11 +39,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN F7
-#define RGBLIGHT_TIMER
 #define RGBLIGHT_ANIMATIONS
 #define RGBLED_NUM 6    // Number of LEDs
-#define ws2812_PORTREG  PORTD
-#define ws2812_DDRREG   DDRD
 
 /* COL2ROW or ROW2COL */
 #define DIODE_DIRECTION COL2ROW

--- a/keyboards/9key/config.h
+++ b/keyboards/9key/config.h
@@ -39,10 +39,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN F7
-#define RGBLIGHT_TIMER
 #define RGBLED_NUM 1    // Number of LEDs
-#define ws2812_PORTREG  PORTD
-#define ws2812_DDRREG   DDRD
 
 /* COL2ROW or ROW2COL */
 #define DIODE_DIRECTION COL2ROW

--- a/keyboards/bfo9000/config.h
+++ b/keyboards/bfo9000/config.h
@@ -53,7 +53,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN B4
-#define RGBLIGHT_TIMER
 #define RGBLED_NUM 20    // Number of LEDs
 
 /*

--- a/keyboards/blockey/config.h
+++ b/keyboards/blockey/config.h
@@ -51,7 +51,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN B1
-#define RGBLIGHT_TIMER
 #define RGBLED_NUM 4
 #define ws2812_PORTREG  PORTB
 #define ws2812_DDRREG   DDRB

--- a/keyboards/chocopad/config.h
+++ b/keyboards/chocopad/config.h
@@ -51,9 +51,6 @@
 #define RGBLIGHT_VAL_STEP 8
 #endif
 #define RGB_DI_PIN D3
-#define RGBLIGHT_TIMER
 #define RGBLED_NUM 4
-#define ws2812_PORTREG  PORTD
-#define ws2812_DDRREG   DDRD
 
 #endif

--- a/keyboards/crkbd/rev1/config.h
+++ b/keyboards/crkbd/rev1/config.h
@@ -60,10 +60,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D3
-#define RGBLIGHT_TIMER
 #define RGBLED_NUM 12    // Number of LEDs
-#define ws2812_PORTREG  PORTD
-#define ws2812_DDRREG   DDRD
 
 /*
  * Feature disable options

--- a/keyboards/deltasplit75/v2/config.h
+++ b/keyboards/deltasplit75/v2/config.h
@@ -61,10 +61,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D3
-#define RGBLIGHT_TIMER
 #define RGBLED_NUM 12    // Number of LEDs
-#define ws2812_PORTREG  PORTD
-#define ws2812_DDRREG   DDRD
 
 /*
  * Feature disable options

--- a/keyboards/dilly/config.h
+++ b/keyboards/dilly/config.h
@@ -54,9 +54,6 @@
 #define RGBLIGHT_VAL_STEP 8
 #endif
 #define RGB_DI_PIN D3
-#define RGBLIGHT_TIMER
 #define RGBLED_NUM 10
-#define ws2812_PORTREG  PORTD
-#define ws2812_DDRREG   DDRD
 
 #endif

--- a/keyboards/ergo42/rev1/config.h
+++ b/keyboards/ergo42/rev1/config.h
@@ -66,10 +66,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D3
-#define RGBLIGHT_TIMER
 #define RGBLED_NUM 12    // Number of LEDs
-#define ws2812_PORTREG  PORTD
-#define ws2812_DDRREG   DDRD
 
 /*
  * Feature disable options

--- a/keyboards/ergodash/rev1/config.h
+++ b/keyboards/ergodash/rev1/config.h
@@ -63,10 +63,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D3
-#define RGBLIGHT_TIMER
 #define RGBLED_NUM 24    // Number of LEDs
-#define ws2812_PORTREG  PORTD
-#define ws2812_DDRREG   DDRD
 
 /*
  * Feature disable options

--- a/keyboards/ergodash/rev2/config.h
+++ b/keyboards/ergodash/rev2/config.h
@@ -68,10 +68,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D3
-#define RGBLIGHT_TIMER
 #define RGBLED_NUM 24    // Number of LEDs
-#define ws2812_PORTREG  PORTD
-#define ws2812_DDRREG   DDRD
 
 /*
  * Feature disable options

--- a/keyboards/ergotravel/config.h
+++ b/keyboards/ergotravel/config.h
@@ -64,10 +64,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D3
-#define RGBLIGHT_TIMER
 #define RGBLED_NUM 12    // Number of LEDs
-#define ws2812_PORTREG  PORTD
-#define ws2812_DDRREG   DDRD
 
 /*
  * Feature disable options

--- a/keyboards/ergotravel/rev1/config.h
+++ b/keyboards/ergotravel/rev1/config.h
@@ -64,10 +64,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D3
-#define RGBLIGHT_TIMER
 #define RGBLED_NUM 12    // Number of LEDs
-#define ws2812_PORTREG  PORTD
-#define ws2812_DDRREG   DDRD
 
 /*
  * Feature disable options

--- a/keyboards/fortitude60/rev1/config.h
+++ b/keyboards/fortitude60/rev1/config.h
@@ -65,10 +65,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 /* #define RGB_DI_PIN D3 */
-/* #define RGBLIGHT_TIMER */
 /* #define RGBLED_NUM 16    // Number of LEDs */
-/* #define ws2812_PORTREG  PORTD */
-/* #define ws2812_DDRREG   DDRD */
 
 /*
  * Feature disable options

--- a/keyboards/fourier/rev1/config.h
+++ b/keyboards/fourier/rev1/config.h
@@ -56,11 +56,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D3
-#define RGBLIGHT_TIMER
 #define RGBLIGHT_ANIMATIONS
 #define RGBLED_NUM 14    // Number of LEDs
-#define ws2812_PORTREG  PORTD
-#define ws2812_DDRREG   DDRD
 
 /*
  * Feature disable options

--- a/keyboards/handwired/dactyl_manuform/config.h
+++ b/keyboards/handwired/dactyl_manuform/config.h
@@ -53,7 +53,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D3
-#define RGBLIGHT_TIMER
 #define RGBLED_NUM 12    // Number of LEDs
 
 

--- a/keyboards/handwired/qc60/proto/config.h
+++ b/keyboards/handwired/qc60/proto/config.h
@@ -10,5 +10,3 @@
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D3
 #define RGBLED_NUM 1    // Number of LEDs
-// #define ws2812_PORTREG  PORTD
-// #define ws2812_DDRREG   DDRD

--- a/keyboards/helix/pico/config.h
+++ b/keyboards/helix/pico/config.h
@@ -84,10 +84,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D3
-#define RGBLIGHT_TIMER
 //#define RGBLED_NUM 12    // Number of LEDs. see ./keymaps/default/config.h
-#define ws2812_PORTREG  PORTD
-#define ws2812_DDRREG   DDRD
 
 // Helix keyboard RGB LED support
 //#define RGBLIGHT_ANIMATIONS : see ./rules.mk: LED_ANIMATIONS = yes or no

--- a/keyboards/helix/rev1/config.h
+++ b/keyboards/helix/rev1/config.h
@@ -74,10 +74,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D3
-#define RGBLIGHT_TIMER
 #define RGBLED_NUM 12    // Number of LEDs
-#define ws2812_PORTREG  PORTD
-#define ws2812_DDRREG   DDRD
 
 /*
  * Feature disable options

--- a/keyboards/helix/rev2/config.h
+++ b/keyboards/helix/rev2/config.h
@@ -88,10 +88,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D3
-#define RGBLIGHT_TIMER
 //#define RGBLED_NUM 12    // Number of LEDs. see ./keymaps/default/config.h
-#define ws2812_PORTREG  PORTD
-#define ws2812_DDRREG   DDRD
 
 // Helix keyboard RGB LED support
 //#define RGBLIGHT_ANIMATIONS : see ./rules.mk: LED_ANIMATIONS = yes or no

--- a/keyboards/iris/rev1/config.h
+++ b/keyboards/iris/rev1/config.h
@@ -63,10 +63,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D3
-#define RGBLIGHT_TIMER
 #define RGBLED_NUM 12    // Number of LEDs
-#define ws2812_PORTREG  PORTD
-#define ws2812_DDRREG   DDRD
 
 /*
  * Feature disable options

--- a/keyboards/iris/rev1_led/config.h
+++ b/keyboards/iris/rev1_led/config.h
@@ -63,10 +63,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D3
-#define RGBLIGHT_TIMER
 #define RGBLED_NUM 12    // Number of LEDs
-#define ws2812_PORTREG  PORTD
-#define ws2812_DDRREG   DDRD
 
 /*
  * Feature disable options

--- a/keyboards/iris/rev2/config.h
+++ b/keyboards/iris/rev2/config.h
@@ -63,10 +63,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D3
-#define RGBLIGHT_TIMER
 #define RGBLED_NUM 12    // Number of LEDs
-#define ws2812_PORTREG  PORTD
-#define ws2812_DDRREG   DDRD
 
 /*
  * Feature disable options

--- a/keyboards/lets_split/keymaps/zer09/config.h
+++ b/keyboards/lets_split/keymaps/zer09/config.h
@@ -52,8 +52,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* ws2812 RGB LED */
 #undef RGBLED_NUM
 #define RGB_DI_PIN D3
-#define RGBLIGHT_TIMER
 #define RGBLED_NUM 50
-#define ws2812_PORTREG PORTD
-#define ws2812_DDRREG DDRD
 #endif

--- a/keyboards/lets_split/rev1/config.h
+++ b/keyboards/lets_split/rev1/config.h
@@ -60,10 +60,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D3
-#define RGBLIGHT_TIMER
 #define RGBLED_NUM 16    // Number of LEDs
-#define ws2812_PORTREG  PORTD
-#define ws2812_DDRREG   DDRD
 
 /*
  * Feature disable options

--- a/keyboards/lets_split/rev2/config.h
+++ b/keyboards/lets_split/rev2/config.h
@@ -60,10 +60,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D3
-#define RGBLIGHT_TIMER
 #define RGBLED_NUM 12    // Number of LEDs
-#define ws2812_PORTREG  PORTD
-#define ws2812_DDRREG   DDRD
 
 /*
  * Feature disable options

--- a/keyboards/lets_split/sockets/config.h
+++ b/keyboards/lets_split/sockets/config.h
@@ -60,10 +60,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D4
-#define RGBLIGHT_TIMER
 #define RGBLED_NUM 12    // Number of LEDs
-#define ws2812_PORTREG  PORTD
-#define ws2812_DDRREG   DDRD
 
 /* Audio settings */
 #ifdef AUDIO_ENABLE

--- a/keyboards/levinson/rev1/config.h
+++ b/keyboards/levinson/rev1/config.h
@@ -53,7 +53,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D3
-#define RGBLIGHT_TIMER
 #define RGBLED_NUM 12    // Number of LEDs
 
 /* Backlight LEDs */

--- a/keyboards/levinson/rev2/config.h
+++ b/keyboards/levinson/rev2/config.h
@@ -53,7 +53,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D3
-#define RGBLIGHT_TIMER
 #define RGBLED_NUM 12    // Number of LEDs
 
 /* Backlight LEDs */

--- a/keyboards/meira/config.h
+++ b/keyboards/meira/config.h
@@ -42,7 +42,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #ifdef RGBLIGHT_ENABLE
 #define RGB_DI_PIN D3
-#define RGBLIGHT_TIMER
 #define RGBLED_NUM 15    // Number of LEDs
 #endif
 

--- a/keyboards/minidox/keymaps/alairock/config.h
+++ b/keyboards/minidox/keymaps/alairock/config.h
@@ -30,7 +30,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D7
-#define RGBLIGHT_TIMER
 #define RGBLED_NUM 8   // Number of LEDs
 #define RGBLIGHT_ANIMATIONS
 #define RGBLIGHT_HUE_STEP 10

--- a/keyboards/minidox/keymaps/that_canadian/config.h
+++ b/keyboards/minidox/keymaps/that_canadian/config.h
@@ -29,7 +29,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D7
-#define RGBLIGHT_TIMER
 #define RGBLED_NUM 8   // Number of LEDs
 #define RGBLIGHT_ANIMATIONS
 #define RGBLIGHT_HUE_STEP 10

--- a/keyboards/minidox/keymaps/xyverz/config.h
+++ b/keyboards/minidox/keymaps/xyverz/config.h
@@ -29,7 +29,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D7
-#define RGBLIGHT_TIMER
 #define RGBLED_NUM 8   // Number of LEDs
 #define RGBLIGHT_ANIMATIONS
 #define RGBLIGHT_HUE_STEP 10

--- a/keyboards/mint60/config.h
+++ b/keyboards/mint60/config.h
@@ -153,10 +153,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D3
-#define RGBLIGHT_TIMER
 #define RGBLED_NUM 8
-#define ws2812_PORTREG  PORTD
-#define ws2812_DDRREG   DDRD
 
 #define RGBLIGHT_HUE_STEP 10
 #define RGBLIGHT_SAT_STEP 17

--- a/keyboards/miuni32/config.h
+++ b/keyboards/miuni32/config.h
@@ -159,9 +159,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define NO_ACTION_MACRO
 //#define NO_ACTION_FUNCTION
 
-#define RGBLIGHT_TIMER 
 #define RGB_DI_PIN D0     // The pin your RGB strip is wired to
-#define RGBLIGHT_TIMER    // Require for fancier stuff (not compatible with audio)
 #define RGBLED_NUM 7     // Number of LEDs
 #define RGBLIGHT_ANIMATIONS
 #define RGBLIGHT_HUE_STEP 10

--- a/keyboards/nano/config.h
+++ b/keyboards/nano/config.h
@@ -34,11 +34,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN B1
-#define RGBLIGHT_TIMER
 #define RGBLIGHT_ANIMATIONS
 #define RGBLED_NUM 6    // Number of LEDs
-#define ws2812_PORTREG  PORTD
-#define ws2812_DDRREG   DDRD
 
 /* COL2ROW or ROW2COL */
 #define DIODE_DIRECTION COL2ROW

--- a/keyboards/nyquist/rev1/config.h
+++ b/keyboards/nyquist/rev1/config.h
@@ -61,10 +61,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D3
-#define RGBLIGHT_TIMER
 #define RGBLED_NUM 16    // Number of LEDs
-#define ws2812_PORTREG  PORTD
-#define ws2812_DDRREG   DDRD
 
 /*
  * Feature disable options

--- a/keyboards/nyquist/rev2/config.h
+++ b/keyboards/nyquist/rev2/config.h
@@ -58,7 +58,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D3
-#define RGBLIGHT_TIMER
 #define RGBLED_NUM 16    // Number of LEDs
 
 /* Backlight LEDs */

--- a/keyboards/orthodox/rev1/config.h
+++ b/keyboards/orthodox/rev1/config.h
@@ -70,10 +70,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 //#define RGB_DI_PIN D3
-//#define RGBLIGHT_TIMER
 //#define RGBLED_NUM 16    // Number of LEDs
-//#define ws2812_PORTREG  PORTD
-//#define ws2812_DDRREG   DDRD
 
 /*
  * Feature disable options

--- a/keyboards/orthodox/rev3/config.h
+++ b/keyboards/orthodox/rev3/config.h
@@ -75,10 +75,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 //#define RGB_DI_PIN D3
-//#define RGBLIGHT_TIMER
 //#define RGBLED_NUM 16    // Number of LEDs
-//#define ws2812_PORTREG  PORTD
-//#define ws2812_DDRREG   DDRD
 
 /*
  * Feature disable options

--- a/keyboards/orthodox/rev3_teensy/config.h
+++ b/keyboards/orthodox/rev3_teensy/config.h
@@ -67,10 +67,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 //#define RGB_DI_PIN D3
-//#define RGBLIGHT_TIMER
 //#define RGBLED_NUM 16    // Number of LEDs
-//#define ws2812_PORTREG  PORTD
-//#define ws2812_DDRREG   DDRD
 
 /*
  * Feature disable options

--- a/keyboards/preonic/keymaps/zach/config.h
+++ b/keyboards/preonic/keymaps/zach/config.h
@@ -65,7 +65,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 //#define RGB_DI_PIN D1
-//#define RGBLIGHT_TIMER
 //#define RGBLED_NUM 28     // Number of LEDs
 //#define RGBLIGHT_HUE_STEP 10
 //#define RGBLIGHT_SAT_STEP 17

--- a/keyboards/qwertyydox/config.h
+++ b/keyboards/qwertyydox/config.h
@@ -64,10 +64,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D6
-#define RGBLIGHT_TIMER
 #define RGBLED_NUM 12    // Number of LEDs
-#define ws2812_PORTREG  PORTD
-#define ws2812_DDRREG   DDRD
 
 /*
  * Feature disable options

--- a/keyboards/qwertyydox/rev1/config.h
+++ b/keyboards/qwertyydox/rev1/config.h
@@ -64,10 +64,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D6
-#define RGBLIGHT_TIMER
 #define RGBLED_NUM 12    // Number of LEDs
-#define ws2812_PORTREG  PORTD
-#define ws2812_DDRREG   DDRD
 
 
 /*

--- a/keyboards/redox/rev1/config.h
+++ b/keyboards/redox/rev1/config.h
@@ -62,10 +62,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D3
-#define RGBLIGHT_TIMER
 #define RGBLED_NUM 14    // Number of LEDs
-#define ws2812_PORTREG  PORTD
-#define ws2812_DDRREG   DDRD
 
 /*
  * Feature disable options

--- a/keyboards/the_ruler/config.h
+++ b/keyboards/the_ruler/config.h
@@ -155,9 +155,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define NO_ACTION_MACRO
 //#define NO_ACTION_FUNCTION
 
-#define RGBLIGHT_TIMER 
 #define RGB_DI_PIN E6     // The pin your RGB strip is wired to
-#define RGBLIGHT_TIMER    // Require for fancier stuff (not compatible with audio)
 #define RGBLED_NUM 1      // Number of LEDs
 #define RGBLIGHT_ANIMATIONS
 #define RGBLIGHT_HUE_STEP 10

--- a/keyboards/vitamins_included/rev1/config.h
+++ b/keyboards/vitamins_included/rev1/config.h
@@ -59,7 +59,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN F0
-#define RGBLIGHT_TIMER
 #define RGBLED_NUM 16    // Number of LEDs
 #define ws2812_PORTREG  PORTF
 #define ws2812_DDRREG   DDRF

--- a/keyboards/viterbi/rev1/config.h
+++ b/keyboards/viterbi/rev1/config.h
@@ -61,10 +61,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D3
-#define RGBLIGHT_TIMER
 #define RGBLED_NUM 16    // Number of LEDs
-#define ws2812_PORTREG  PORTD
-#define ws2812_DDRREG   DDRD
 
 /*
  * Feature disable options

--- a/keyboards/zen/rev1/config.h
+++ b/keyboards/zen/rev1/config.h
@@ -65,10 +65,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D1
-#define RGBLIGHT_TIMER
 #define RGBLED_NUM 16    // Number of LEDs
-#define ws2812_PORTREG  PORTD
-#define ws2812_DDRREG   DDRD
 
 /*
  * Feature disable options


### PR DESCRIPTION
Removed all instances of the following:
- `#define ws2812_PORTREG[ ]+PORTD`
- `#define ws2812_DDRREG[ ]+DDRD`
- `#define RGBLIGHT_TIMER`

My execution and log: https://pastebin.com/raw/5qLC8GzN

My command:
```bash
printf '#define ws2812_PORTREG[ ]+PORTD\n#define ws2812_DDRREG[ ]+DDRD\n#define RGBLIGHT_TIMER\n' | while read definer; do find "${PWD}" -name config.h -type f -exec grep -Pl "${definer}" {} \; | while read file; do echo "Found ${definer} in ${file}. Removing."; sed -i "/$(echo ${definer} | sed 's/+/\\+/')/d" "${file}"; done; done; echo "Complete, doing a final check, here are files where the match was still found:"; printf '#define ws2812_PORTREG[ ]+PORTD\n#define ws2812_DDRREG[ ]+DDRD\n#define RGBLIGHT_TIMER\n' | while read definer; do find "${PWD}" -name config.h -type f -exec grep -Pl "${definer}" {} \;; done```