### PR TITLE
Add Dvorak Svorak A5 layout for Ergodox-EZ

### DIFF
--- a/layouts/community/ergodox/dvorak_svorak_a5/keymap.c
+++ b/layouts/community/ergodox/dvorak_svorak_a5/keymap.c
@@ -1,0 +1,171 @@
+#include QMK_KEYBOARD_H
+#include "debug.h"
+#include "action_layer.h"
+#include "version.h"
+#include "keymap_nordic.h"
+#include "keymap_norwegian.h"
+
+#define BASE 0 // default layer
+#define SYMB 1 // symbols
+#define MOUS 2 // mouse keys
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+/* Keymap 0: Basic layer
+ *
+ * ,--------------------------------------------------.           ,--------------------------------------------------.
+ * |        |   1  |   2  |   3  |   4  |   5  | ~MOUS|           |      |   6  |   7  |   8  |   9  |   0  |   \    |
+ * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
+ * |        |   Å  |   Ä  |   Ö  |   P  |   Y  |      |           |      |   F  |   G  |   C  |   R  |   L  |   ,    |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * | Escape |   A  |   O  |   E  |   U  |   I  |------|           |------|   D  |   H  |   T  |   N  |   S  |  -/_   |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * | LShift |   .  |   Q  |   J  |   K  |   X  |      |           |      |   B  |   M  |   W  |   V  |   Z  | RShift |
+ * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
+ *  | LCTRL |      |      |      | Super|                                       | ~SYMB| Left | Down |  Up  | Right |
+ *  `-----------------------------------'                                       `----------------------------------'
+ *                                        ,-------------.       ,-------------.
+ *                                        |      |      |       |      |      |
+ *                                 ,------|------|------|       |------+--------+-------.
+ *                                 |      |      |      |       |      |        |       |
+ *                                 | BSP  | Tab  |------|       |------|  Enter | Space |
+ *                                 |      |      |      |       |      |        |       |
+ *                                 `--------------------'       `-----------------------'
+ */
+[BASE] = LAYOUT_ergodox(  // layer 0 : default
+        // left hand
+        KC_NO,    KC_1,   KC_2,     KC_3,    KC_4,    KC_5,   MO(MOUS),
+        KC_NO,    NO_AA,  NO_AE,    NO_OSLH, KC_P,    KC_Y,   KC_NO,
+        KC_ESC,   KC_A,   KC_O,     KC_E,    KC_U,    KC_I,
+        KC_LSFT,  KC_DOT, KC_Q,     KC_J,    KC_K,    KC_X,   KC_NO,
+        KC_LCTRL, KC_NO,  KC_NO,    KC_NO,   KC_LGUI,
+                                                      KC_NO,  KC_NO,
+                                                              KC_NO,
+                                             KC_BSPC, KC_TAB, KC_NO,
+        // right hand
+        KC_NO,    KC_6,   KC_7,     KC_8,    KC_9,    KC_0,   KC_BSLASH,
+        KC_NO,    KC_F,   KC_G,     KC_C,    KC_R,    KC_L,   KC_COMM,
+                  KC_D,   KC_H,     KC_T,    KC_N,    KC_S,   KC_MINUS,
+        KC_NO,    KC_B,   KC_M,     KC_W,    KC_V,    KC_Z,   KC_RSFT,
+                          MO(SYMB), KC_LEFT, KC_DOWN, KC_UP,  KC_RGHT,
+        KC_NO,    KC_NO,
+        KC_NO,
+        KC_NO,    KC_ENT, KC_SPACE
+    ),
+/* Keymap 1: Symbol Layer
+ *
+ * ,--------------------------------------------------.           ,--------------------------------------------------.
+ * |        |      |      |      |      |      |      |           |      |      |      |      |      |      |        |
+ * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
+ * |        |   {  |   }  |   [  |   ]  |   $  |      |           |      |   "  |   &  |   <  |   >  |      |        |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |        |   ;  |   /  |   (  |   )  |   |  |------|           |------|   #  |   ^  |   #  |   "  |   ~  |        |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |        |   :  |   =  |   @  |   !  |   \  |      |           |      |   %  |   `  |   '  |   *  |      |        |
+ * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
+ *   |      |      |      |      |      |                                       |      |      |      |      |       |
+ *   `----------------------------------'                                       `----------------------------------'
+ *                                        ,-------------.       ,-------------.
+ *                                        |      |      |       |      |      |
+ *                                 ,------|------|------|       |------+------+------.
+ *                                 |      |      |      |       |      |      |      |
+ *                                 |      |      |------|       |------|      |      |
+ *                                 |      |      |      |       |      |      |      |
+ *                                 `--------------------'       `--------------------'
+ */
+// SYMBOLS
+[SYMB] = LAYOUT_ergodox(
+       // left hand
+       KC_NO, KC_NO,   KC_NO,       KC_NO,   KC_NO,   KC_NO,   KC_NO,
+       KC_NO, KC_LCBR, KC_RCBR,     KC_LBRC, KC_RBRC, KC_DLR,  KC_NO,
+       KC_NO, KC_SCLN, KC_KP_SLASH, KC_LPRN, KC_RPRN, KC_PIPE,
+       KC_NO, KC_COLN, KC_PEQL,     KC_AT,   KC_EXLM, KC_BSLS, KC_NO,
+       KC_NO, KC_NO,   KC_NO,       KC_NO,   KC_NO,
+                                                      KC_NO,   KC_NO,
+                                                               KC_NO,
+                                             KC_NO,   KC_NO,   KC_NO,
+       // right hand
+       KC_NO, KC_NO,   KC_NO,       KC_NO,   KC_NO,   KC_NO,   KC_NO,
+       KC_NO, KC_DQT,  KC_AMPR,     KC_LT,   KC_GT,   KC_NO,   KC_NO,
+              KC_HASH, KC_CIRC,     KC_HASH, KC_DQT,  KC_TILD, KC_NO,
+       KC_NO, KC_PERC, KC_GRV,      KC_QUOT, KC_ASTR, KC_NO,   KC_NO,
+                       KC_NO,       KC_NO,   KC_NO,   KC_NO,   KC_NO,
+       KC_NO, KC_NO,
+       KC_NO,
+       KC_NO, KC_NO,   KC_NO
+),
+/* Keymap 2: Media and mouse keys
+ *
+ * ,--------------------------------------------------.           ,--------------------------------------------------.
+ * |        |      |      |      |      |      |      |           |      |      |      |      |      |      |        |
+ * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
+ * |        |      |      |      |      |      |      |           |      |      |      |      |      |      |        |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |        |      |      |      |      |      |------|           |------|      |      |      |      |      |        |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |        |      |      |      |      |      |      |           |      |      |      |      |  B1  |  B2  |        |
+ * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
+ *   |      |      |      |      |      |                                       |      |  M_L |  M_D |  M_U |  M_R  |
+ *   `----------------------------------'                                       `----------------------------------'
+ *                                        ,-------------.       ,-------------.
+ *                                        |      |      |       |      |      |
+ *                                 ,------|------|------|       |------+------+------.
+ *                                 |      |      |      |       |      |      |      |
+ *                                 |      |      |------|       |------|      |      |
+ *                                 |      |      |      |       |      |      |      |
+ *                                 `--------------------'       `--------------------'
+ */
+// MEDIA AND MOUSE
+[MOUS] = LAYOUT_ergodox(
+       KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO,
+       KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO,
+       KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO,
+       KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO,
+       KC_NO, KC_NO, KC_NO, KC_NO, KC_NO,
+                                                KC_NO, KC_NO,
+                                                       KC_NO,
+                                       KC_NO,   KC_NO, KC_NO,
+    // right hand
+       KC_NO,  KC_NO, KC_NO, KC_NO,   KC_NO,   KC_NO,   KC_NO,
+       KC_NO,  KC_NO, KC_NO, KC_NO,   KC_NO,   KC_NO,   KC_NO,
+       KC_NO,  KC_NO, KC_NO, KC_NO,   KC_NO,   KC_NO,
+       KC_NO,  KC_NO, KC_NO, KC_NO,   KC_BTN1, KC_BTN2, KC_NO,
+                      KC_NO, KC_MS_L, KC_MS_D, KC_MS_U, KC_MS_R,
+       KC_NO, KC_NO,
+       KC_NO,
+       KC_NO, KC_NO, KC_NO
+),
+};
+
+const uint16_t PROGMEM fn_actions[] = {
+    [1] = ACTION_LAYER_TAP_TOGGLE(SYMB)                // FN1 - Momentary Layer 1 (Symbols)
+};
+
+
+// Runs just one time when the keyboard initializes.
+void matrix_init_user(void) {
+
+};
+
+// Runs constantly in the background, in a loop.
+void matrix_scan_user(void) {
+
+    uint8_t layer = biton32(layer_state);
+
+    ergodox_board_led_off();
+    ergodox_right_led_1_off();
+    ergodox_right_led_2_off();
+    ergodox_right_led_3_off();
+    switch (layer) {
+      // TODO: Make this relevant to the ErgoDox EZ.
+        case 1:
+            ergodox_right_led_1_on();
+            break;
+        case 2:
+            ergodox_right_led_2_on();
+            break;
+        default:
+            // none
+            break;
+    }
+
+};

--- a/layouts/community/ergodox/dvorak_svorak_a5/keymap.c
+++ b/layouts/community/ergodox/dvorak_svorak_a5/keymap.c
@@ -6,12 +6,13 @@
 #define BASE 0 // default layer
 #define SYMB 1 // symbols
 #define MOUS 2 // mouse keys
+#define QWRT 3 // qwerty layout
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 /* Keymap 0: Basic layer
  *
  * ,--------------------------------------------------.           ,--------------------------------------------------.
- * |        |   1  |   2  |   3  |   4  |   5  | ~MOUS|           |      |   6  |   7  |   8  |   9  |   0  |    +   |
+ * |        |   1  |   2  |   3  |   4  |   5  | ~MOUS|           | QWRT |   6  |   7  |   8  |   9  |   0  |    +   |
  * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
  * |        |   Å  |   Ä  |   Ö  |   P  |   Y  |      |           |      |   F  |   G  |   C  |   R  |   L  |   ,    |
  * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
@@ -40,7 +41,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
                                                                  KC_NO,
                                              KC_BSPC, KC_TAB,    KC_NO,
         // right hand
-        KC_NO,    KC_6,   KC_7,     KC_8,    KC_9,    KC_0,      NO_PLUS,
+        TG(QWRT), KC_6,   KC_7,     KC_8,    KC_9,    KC_0,      NO_PLUS,
         KC_NO,    KC_F,   KC_G,     KC_C,    KC_R,    KC_L,      KC_COMM,
                   KC_D,   KC_H,     KC_T,    KC_N,    KC_S,      NO_MINS,
         KC_NO,    KC_B,   KC_M,     KC_W,    KC_V,    KC_Z,      KC_RSFT,
@@ -54,7 +55,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * ,--------------------------------------------------.           ,--------------------------------------------------.
  * |        |      |      |      |      |      |      |           |      |      |      |      |      |      |        |
  * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
- * |        |   {  |   }  |   [  |   ]  |   $  |      |           |      |   "  |   &  |   <  |   >  |      |        |
+ * |        |   {  |   }  |   [  |   ]  |   $  |      |           |      |   "  |   ?  |   &  |   <  |   >  |        |
  * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
  * |        |   ;  |   /  |   (  |   )  |   |  |------|           |------|   #  |   ^  |   #  |   "  |   ~  |        |
  * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
@@ -83,9 +84,9 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
                                              KC_TRNS, KC_NO,   KC_NO,
        // right hand
        KC_NO, KC_NO,         KC_NO,       KC_NO,       KC_NO,       KC_NO,   KC_NO,
-       KC_NO, LSFT(KC_2),    LSFT(KC_6),  NO_LESS,     NO_GRTR,     KC_NO,   KC_NO,
+       KC_NO, LSFT(KC_2),    NO_QUES,     LSFT(KC_6),  NO_LESS,     NO_GRTR, KC_NO,
               KC_HASH,       NO_CIRC,     KC_HASH,     LSFT(KC_2),  NO_TILD, KC_NO,
-       KC_NO, KC_PERC,       NO_ACUT,     NO_APOS,     NO_ASTR,     KC_NO,   KC_NO,
+       KC_NO, KC_PERC,       NO_ACUT,     NO_APOS,     NO_ASTR,     NO_GRV,  KC_NO,
                              KC_NO,       KC_NO,       KC_NO,       KC_NO,   KC_NO,
        KC_NO, KC_NO,
        KC_NO,
@@ -132,6 +133,49 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
        KC_NO,
        KC_NO, KC_NO, KC_NO
 ),
+/* Keymap 3: QWERTY Layer
+ *
+ * ,--------------------------------------------------.           ,--------------------------------------------------.
+ * | Print  |   !  |  "   |  #   |  #   |  %   |      |           |Middle|   &  |  /   |  (   |  )   |  =   |  ?     |
+ * | Screen |   1  |  2 @ |  3 £ |  4 $ |  5   | F11  |           |Mouse |   6  |  7 { |  8 [ |  9 ] |  0 } |  + \   |
+ * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
+ * | Tab    | Q    | W    | E    | R    | T    |      |           |      | Y    | U    | I    | O    | P    | Å      |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * | CapsLk | A    | S    | D    | F    | G    |------|           |------| H    | J    | K    | L    | Ö    | Ä      |
+ * |--------+------+------+------+------+------| `    |           | Del  |------+------+------+------+------+--------|
+ * | LShft  | Z    | X    | C    | V    | B    |  '   |           |      | N    | M    | ,    | .    | -    | RShift |
+ * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
+ *   | LCtl |  ^   | *    | LAlt | LGui |                                       | AltGr| Down |  Up  | Left | Right|
+ *   | (')  |  " ~ | '  ´ |      |      |                                       |      |      |      |      |      |
+ *   `----------------------------------'                                       `----------------------------------'
+ *                                        ,-------------.       ,--------------.
+ *                                        | LCtl | LAlt |       | Home |   End  |
+ *                                 ,------|------|------|       |------+-------+------.
+ *                                 |      |      |  ~   |       | PgUp |       |      |
+ *                                 | BSP  |  TAB |------|       |------| Enter | Space|
+ *                                 |      |      | Esc  |       | PgDn |       |      |
+ *                                 `--------------------'       `---------------------'
+ */
+[QWRT] = LAYOUT_ergodox(
+    // left hand
+    KC_PSCR,        KC_1,    KC_2,    KC_3,    KC_4,    KC_5,     KC_TRNS,
+    KC_TAB,         KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,     KC_TRNS,
+    KC_CAPS,        KC_A,    KC_S,    KC_D,    KC_F,    KC_G,
+    KC_LSFT,        KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,     NO_ACUT,
+    CTL_T(NO_APOS), NO_CIRC, NO_ASTR, KC_LALT, KC_LGUI,
+                                                        KC_LCTRL, KC_LALT,
+                                                                  NO_TILD,
+                                               KC_BSPC, KC_TAB,   KC_ESC,
+    // right hand
+    KC_TRNS,        KC_6,    KC_7,    KC_8,    KC_9,    KC_0,     NO_PLUS,
+    KC_TRNS,        KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,     NO_AA,
+                    KC_H,    KC_J,    KC_K,    KC_L,    NO_OSLH,  NO_AE,
+    KC_DELT,        KC_N,    KC_M,    KC_COMM, KC_DOT,  NO_MINS,  KC_RSFT,
+                             NO_ALGR, KC_DOWN, KC_UP,   KC_LEFT,  KC_RGHT,
+    KC_HOME,        KC_END,
+    KC_PGUP,
+    KC_PGDN,        KC_ENT, KC_SPACE
+),
 };
 
 const uint16_t PROGMEM fn_actions[] = {
@@ -154,15 +198,16 @@ void matrix_scan_user(void) {
     ergodox_right_led_2_off();
     ergodox_right_led_3_off();
     switch (layer) {
-      // TODO: Make this relevant to the ErgoDox EZ.
         case 1:
             ergodox_right_led_1_on();
             break;
         case 2:
             ergodox_right_led_2_on();
             break;
+        case 3:
+            ergodox_right_led_3_on();
+            break;
         default:
-            // none
             break;
     }
 

--- a/layouts/community/ergodox/dvorak_svorak_a5/keymap.c
+++ b/layouts/community/ergodox/dvorak_svorak_a5/keymap.c
@@ -14,20 +14,20 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * ,--------------------------------------------------.           ,--------------------------------------------------.
  * |        |   1  |   2  |   3  |   4  |   5  | ~MOUS|           | QWRT |   6  |   7  |   8  |   9  |   0  |    +   |
  * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
- * |        |   Å  |   Ä  |   Ö  |   P  |   Y  |      |           |      |   F  |   G  |   C  |   R  |   L  |   ,    |
+ * |        |   Å  |   Ä  |   Ö  |   P  |   Y  |      |           |  Del |   F  |   G  |   C  |   R  |   L  |   ,    |
  * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
  * | Escape |   A  |   O  |   E  |   U  |   I  |------|           |------|   D  |   H  |   T  |   N  |   S  |  -/_   |
- * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |--------+------+------+------+------+------|      |           | RCTRL|------+------+------+------+------+--------|
  * | LShift |   .  |   Q  |   J  |   K  |   X  |      |           |      |   B  |   M  |   W  |   V  |   Z  | RShift |
  * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
  *  | LCTRL |      |      | LAlt | Super|                                       | ~SYMB| Left | Down |  Up  | Right |
  *  `-----------------------------------'                                       `----------------------------------'
  *                                        ,-------------.       ,-------------.
- *                                        |  Ins |  Del |       |      |      |
+ *                                        |  Ins |  Del |       | HOME |  END |
  *                                 ,------|------|------|       |------+--------+-------.
- *                                 |      |      |      |       |      |        |       |
+ *                                 |      |      |      |       | PgUp |        |       |
  *                                 | BSP  | Tab  |------|       |------|  Enter | Space |
- *                                 |      |      |      |       |      |        |       |
+ *                                 |      |      |      |       | PgDn |        |       |
  *                                 `--------------------'       `-----------------------'
  */
 [BASE] = LAYOUT_ergodox(  // layer 0 : default
@@ -42,13 +42,13 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
                                              KC_BSPC, KC_TAB,    KC_NO,
         // right hand
         TG(QWRT), KC_6,   KC_7,     KC_8,    KC_9,    KC_0,      NO_PLUS,
-        KC_NO,    KC_F,   KC_G,     KC_C,    KC_R,    KC_L,      KC_COMM,
+        KC_DEL,   KC_F,   KC_G,     KC_C,    KC_R,    KC_L,      KC_COMM,
                   KC_D,   KC_H,     KC_T,    KC_N,    KC_S,      NO_MINS,
-        KC_NO,    KC_B,   KC_M,     KC_W,    KC_V,    KC_Z,      KC_RSFT,
+        KC_RCTRL, KC_B,   KC_M,     KC_W,    KC_V,    KC_Z,      KC_RSFT,
                           MO(SYMB), KC_LEFT, KC_DOWN, KC_UP,     KC_RGHT,
-        KC_NO,    KC_NO,
-        KC_NO,
-        KC_NO,    KC_ENT, KC_SPACE
+        KC_HOME,  KC_END,
+        KC_PGUP,
+        KC_PGDN,  KC_ENT, KC_SPACE
     ),
 /* Keymap 1: Symbol Layer
  *
@@ -95,13 +95,13 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 /* Keymap 2: Media and mouse keys
  *
  * ,--------------------------------------------------.           ,--------------------------------------------------.
- * |        |      |      |      |      |      |      |           |      |      |      |      |      |      |        |
+ * |        |  F1  |  F2  |  F3  |  F4  |  F5  |      |           |      |  F6  |  F7  |  F8  |  F9  | F10  |        |
  * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
- * |        |      |      |      |      |      |      |           |      |      |      |      |      |      |        |
+ * |        | F11  | F12  |      |      |      |      |           |      |      |      |      |      |      |        |
  * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
- * |        |      |      |      |      |      |------|           |------|      |      |      |      |      |        |
+ * |        |      |      |      |      |      |------|           |------|      |      |      |      |      | Vol Up |
  * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
- * |        |      |      |      |      |      |      |           |      |      |      |      |  B1  |  B2  |        |
+ * |        |      |      |      |      |      |      |           |      |      |      |      |  B1  |  B2  |Vol Down|
  * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
  *   |      |      |      |      |      |                                       |      |  M_L |  M_D |  M_U |  M_R  |
  *   `----------------------------------'                                       `----------------------------------'
@@ -109,29 +109,29 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  *                                        |      |      |       |      |      |
  *                                 ,------|------|------|       |------+------+------.
  *                                 |      |      |      |       |      |      |      |
- *                                 |      |      |------|       |------|      |      |
- *                                 |      |      |      |       |      |      |      |
+ *                                 |      |      |------|       |------|      | Play |
+ *                                 |      |      |      |       |      |      | Pause|
  *                                 `--------------------'       `--------------------'
  */
 // MEDIA AND MOUSE
 [MOUS] = LAYOUT_ergodox(
-       KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO,
-       KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO,
-       KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO,
-       KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO,
-       KC_NO, KC_NO, KC_NO, KC_NO, KC_NO,
+       KC_NO, KC_F1,  KC_F2, KC_F3,  KC_F4, KC_F5, KC_NO,
+       KC_NO, KC_F11, KC_NO, KC_F12, KC_NO, KC_NO, KC_NO,
+       KC_NO, KC_NO,  KC_NO, KC_NO,  KC_NO, KC_NO,
+       KC_NO, KC_NO,  KC_NO, KC_NO,  KC_NO, KC_NO, KC_NO,
+       KC_NO, KC_NO,  KC_NO, KC_NO,  KC_NO,
                                                 KC_NO, KC_NO,
                                                        KC_NO,
                                        KC_NO,   KC_NO, KC_NO,
     // right hand
+       KC_NO,  KC_F6, KC_F7, KC_F8,   KC_F9,   KC_F10,  KC_NO,
        KC_NO,  KC_NO, KC_NO, KC_NO,   KC_NO,   KC_NO,   KC_NO,
-       KC_NO,  KC_NO, KC_NO, KC_NO,   KC_NO,   KC_NO,   KC_NO,
-       KC_NO,  KC_NO, KC_NO, KC_NO,   KC_NO,   KC_NO,
-       KC_NO,  KC_NO, KC_NO, KC_NO,   KC_BTN1, KC_BTN2, KC_NO,
+               KC_NO, KC_NO, KC_NO,   KC_NO,   KC_NO,   KC_VOLU,
+       KC_NO,  KC_NO, KC_NO, KC_NO,   KC_BTN1, KC_BTN2, KC_VOLD,
                       KC_NO, KC_MS_L, KC_MS_D, KC_MS_U, KC_MS_R,
        KC_NO, KC_NO,
        KC_NO,
-       KC_NO, KC_NO, KC_NO
+       KC_NO, KC_NO, KC_MPLY
 ),
 /* Keymap 3: QWERTY Layer
  *

--- a/layouts/community/ergodox/dvorak_svorak_a5/keymap.c
+++ b/layouts/community/ergodox/dvorak_svorak_a5/keymap.c
@@ -100,10 +100,10 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |        | F11  | F12  |      |      |      |      |           |      |      |      |      |      |      |        |
  * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
  * |        |      |      |      |      |      |------|           |------|      |      |      |      |      | Vol Up |
- * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |--------+------+------+------+------+------|      |           | RCTRL|------+------+------+------+------+--------|
  * |        |      |      |      |      |      |      |           |      |      |      |      |  B1  |  B2  |Vol Down|
  * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
- *   |      |      |      |      |      |                                       |      |  M_L |  M_D |  M_U |  M_R  |
+ *   | LCTRL|      |      | LALT |      |                                       |      |  M_L |  M_D |  M_U |  M_R  |
  *   `----------------------------------'                                       `----------------------------------'
  *                                        ,-------------.       ,-------------.
  *                                        |      |      |       |      |      |
@@ -115,23 +115,23 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  */
 // MEDIA AND MOUSE
 [MOUS] = LAYOUT_ergodox(
-       KC_NO, KC_F1,  KC_F2, KC_F3,  KC_F4, KC_F5, KC_NO,
-       KC_NO, KC_F11, KC_NO, KC_F12, KC_NO, KC_NO, KC_NO,
-       KC_NO, KC_NO,  KC_NO, KC_NO,  KC_NO, KC_NO,
-       KC_NO, KC_NO,  KC_NO, KC_NO,  KC_NO, KC_NO, KC_NO,
-       KC_NO, KC_NO,  KC_NO, KC_NO,  KC_NO,
+       KC_NO,   KC_F1,  KC_F2, KC_F3,   KC_F4, KC_F5, KC_NO,
+       KC_NO,   KC_F11, KC_F12, KC_NO,  KC_NO, KC_NO, KC_NO,
+       KC_NO,   KC_NO,  KC_NO, KC_NO,   KC_NO, KC_NO,
+       KC_NO,   KC_NO,  KC_NO, KC_NO,   KC_NO, KC_NO, KC_NO,
+       KC_TRNS, KC_NO,  KC_NO, KC_TRNS, KC_NO,
                                                 KC_NO, KC_NO,
                                                        KC_NO,
                                        KC_NO,   KC_NO, KC_NO,
     // right hand
-       KC_NO,  KC_F6, KC_F7, KC_F8,   KC_F9,   KC_F10,  KC_NO,
-       KC_NO,  KC_NO, KC_NO, KC_NO,   KC_NO,   KC_NO,   KC_NO,
-               KC_NO, KC_NO, KC_NO,   KC_NO,   KC_NO,   KC_VOLU,
-       KC_NO,  KC_NO, KC_NO, KC_NO,   KC_BTN1, KC_BTN2, KC_VOLD,
+       KC_NO,    KC_F6, KC_F7, KC_F8,   KC_F9,   KC_F10,  KC_NO,
+       KC_NO,   KC_NO, KC_NO, KC_NO,   KC_NO,   KC_NO,   KC_NO,
+                KC_NO, KC_NO, KC_NO,   KC_NO,   KC_NO,   KC_VOLU,
+       KC_TRNS, KC_NO, KC_NO, KC_NO,   KC_BTN1, KC_BTN2, KC_VOLD,
                       KC_NO, KC_MS_L, KC_MS_D, KC_MS_U, KC_MS_R,
-       KC_NO, KC_NO,
+       KC_NO,   KC_NO,
        KC_NO,
-       KC_NO, KC_NO, KC_MPLY
+       KC_NO,   KC_NO, KC_MPLY
 ),
 /* Keymap 3: QWERTY Layer
  *

--- a/layouts/community/ergodox/dvorak_svorak_a5/keymap.c
+++ b/layouts/community/ergodox/dvorak_svorak_a5/keymap.c
@@ -1,9 +1,7 @@
 #include QMK_KEYBOARD_H
 #include "debug.h"
 #include "action_layer.h"
-#include "version.h"
-#include "keymap_nordic.h"
-#include "keymap_norwegian.h"
+#include "keymap_swedish.h"
 
 #define BASE 0 // default layer
 #define SYMB 1 // symbols
@@ -13,18 +11,18 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 /* Keymap 0: Basic layer
  *
  * ,--------------------------------------------------.           ,--------------------------------------------------.
- * |        |   1  |   2  |   3  |   4  |   5  | ~MOUS|           |      |   6  |   7  |   8  |   9  |   0  |   \    |
+ * |        |   1  |   2  |   3  |   4  |   5  | ~MOUS|           |      |   6  |   7  |   8  |   9  |   0  |    +   |
  * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
- * |        |   Ã…  |   Ã„  |   Ã–  |   P  |   Y  |      |           |      |   F  |   G  |   C  |   R  |   L  |   ,    |
+ * |        |   Å  |   Ä  |   Ö  |   P  |   Y  |      |           |      |   F  |   G  |   C  |   R  |   L  |   ,    |
  * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
  * | Escape |   A  |   O  |   E  |   U  |   I  |------|           |------|   D  |   H  |   T  |   N  |   S  |  -/_   |
  * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
  * | LShift |   .  |   Q  |   J  |   K  |   X  |      |           |      |   B  |   M  |   W  |   V  |   Z  | RShift |
  * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
- *  | LCTRL |      |      |      | Super|                                       | ~SYMB| Left | Down |  Up  | Right |
+ *  | LCTRL |      |      | LAlt | Super|                                       | ~SYMB| Left | Down |  Up  | Right |
  *  `-----------------------------------'                                       `----------------------------------'
  *                                        ,-------------.       ,-------------.
- *                                        |      |      |       |      |      |
+ *                                        |  Ins |  Del |       |      |      |
  *                                 ,------|------|------|       |------+--------+-------.
  *                                 |      |      |      |       |      |        |       |
  *                                 | BSP  | Tab  |------|       |------|  Enter | Space |
@@ -33,20 +31,20 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  */
 [BASE] = LAYOUT_ergodox(  // layer 0 : default
         // left hand
-        KC_NO,    KC_1,   KC_2,     KC_3,    KC_4,    KC_5,   MO(MOUS),
-        KC_NO,    NO_AA,  NO_AE,    NO_OSLH, KC_P,    KC_Y,   KC_NO,
+        KC_NO,    KC_1,   KC_2,     KC_3,    KC_4,    KC_5,      MO(MOUS),
+        KC_TAB,   NO_AA,  NO_AE,    NO_OSLH, KC_P,    KC_Y,      KC_NO,
         KC_ESC,   KC_A,   KC_O,     KC_E,    KC_U,    KC_I,
-        KC_LSFT,  KC_DOT, KC_Q,     KC_J,    KC_K,    KC_X,   KC_NO,
-        KC_LCTRL, KC_NO,  KC_NO,    KC_NO,   KC_LGUI,
-                                                      KC_NO,  KC_NO,
-                                                              KC_NO,
-                                             KC_BSPC, KC_TAB, KC_NO,
+        KC_LSFT,  KC_DOT, KC_Q,     KC_J,    KC_K,    KC_X,      KC_NO,
+        KC_LCTRL, KC_NO,  KC_NO,    KC_LALT, KC_LCMD,
+                                                      KC_INSERT, KC_DEL,
+                                                                 KC_NO,
+                                             KC_BSPC, KC_TAB,    KC_NO,
         // right hand
-        KC_NO,    KC_6,   KC_7,     KC_8,    KC_9,    KC_0,   KC_BSLASH,
-        KC_NO,    KC_F,   KC_G,     KC_C,    KC_R,    KC_L,   KC_COMM,
-                  KC_D,   KC_H,     KC_T,    KC_N,    KC_S,   KC_MINUS,
-        KC_NO,    KC_B,   KC_M,     KC_W,    KC_V,    KC_Z,   KC_RSFT,
-                          MO(SYMB), KC_LEFT, KC_DOWN, KC_UP,  KC_RGHT,
+        KC_NO,    KC_6,   KC_7,     KC_8,    KC_9,    KC_0,      NO_PLUS,
+        KC_NO,    KC_F,   KC_G,     KC_C,    KC_R,    KC_L,      KC_COMM,
+                  KC_D,   KC_H,     KC_T,    KC_N,    KC_S,      NO_MINS,
+        KC_NO,    KC_B,   KC_M,     KC_W,    KC_V,    KC_Z,      KC_RSFT,
+                          MO(SYMB), KC_LEFT, KC_DOWN, KC_UP,     KC_RGHT,
         KC_NO,    KC_NO,
         KC_NO,
         KC_NO,    KC_ENT, KC_SPACE
@@ -60,7 +58,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
  * |        |   ;  |   /  |   (  |   )  |   |  |------|           |------|   #  |   ^  |   #  |   "  |   ~  |        |
  * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
- * |        |   :  |   =  |   @  |   !  |   \  |      |           |      |   %  |   `  |   '  |   *  |      |        |
+ * |        |   :  |   =  |   @  |   !  |   \  |      |           |      |   %  |   ´  |   '  |   *  |      |        |
  * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
  *   |      |      |      |      |      |                                       |      |      |      |      |       |
  *   `----------------------------------'                                       `----------------------------------'
@@ -68,30 +66,30 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  *                                        |      |      |       |      |      |
  *                                 ,------|------|------|       |------+------+------.
  *                                 |      |      |      |       |      |      |      |
- *                                 |      |      |------|       |------|      |      |
+ *                                 |  BSP |      |------|       |------|      |      |
  *                                 |      |      |      |       |      |      |      |
  *                                 `--------------------'       `--------------------'
  */
 // SYMBOLS
 [SYMB] = LAYOUT_ergodox(
        // left hand
-       KC_NO, KC_NO,   KC_NO,       KC_NO,   KC_NO,   KC_NO,   KC_NO,
-       KC_NO, KC_LCBR, KC_RCBR,     KC_LBRC, KC_RBRC, KC_DLR,  KC_NO,
-       KC_NO, KC_SCLN, KC_KP_SLASH, KC_LPRN, KC_RPRN, KC_PIPE,
-       KC_NO, KC_COLN, KC_PEQL,     KC_AT,   KC_EXLM, KC_BSLS, KC_NO,
-       KC_NO, KC_NO,   KC_NO,       KC_NO,   KC_NO,
+       KC_NO, KC_NO,         KC_NO,       KC_NO,      KC_NO,      KC_NO,            KC_NO,
+       KC_NO, ALGR(KC_7),    ALGR(KC_0),  ALGR(KC_8), ALGR(KC_9), ALGR(KC_4),       KC_NO,
+       KC_NO, LSFT(KC_COMM), KC_KP_SLASH, LSFT(KC_8), LSFT(KC_9), ALGR(KC_NUBS),
+       KC_NO, LSFT(KC_DOT),  LSFT(KC_0),  ALGR(KC_2), KC_EXLM,    ALGR(KC_MINS),    KC_NO,
+       KC_NO, KC_NO,         KC_NO,       KC_NO,      KC_NO,
                                                       KC_NO,   KC_NO,
                                                                KC_NO,
-                                             KC_NO,   KC_NO,   KC_NO,
+                                             KC_TRNS, KC_NO,   KC_NO,
        // right hand
-       KC_NO, KC_NO,   KC_NO,       KC_NO,   KC_NO,   KC_NO,   KC_NO,
-       KC_NO, KC_DQT,  KC_AMPR,     KC_LT,   KC_GT,   KC_NO,   KC_NO,
-              KC_HASH, KC_CIRC,     KC_HASH, KC_DQT,  KC_TILD, KC_NO,
-       KC_NO, KC_PERC, KC_GRV,      KC_QUOT, KC_ASTR, KC_NO,   KC_NO,
-                       KC_NO,       KC_NO,   KC_NO,   KC_NO,   KC_NO,
+       KC_NO, KC_NO,         KC_NO,       KC_NO,       KC_NO,       KC_NO,   KC_NO,
+       KC_NO, LSFT(KC_2),    LSFT(KC_6),  NO_LESS,     NO_GRTR,     KC_NO,   KC_NO,
+              KC_HASH,       NO_CIRC,     KC_HASH,     LSFT(KC_2),  NO_TILD, KC_NO,
+       KC_NO, KC_PERC,       NO_ACUT,     NO_APOS,     NO_ASTR,     KC_NO,   KC_NO,
+                             KC_NO,       KC_NO,       KC_NO,       KC_NO,   KC_NO,
        KC_NO, KC_NO,
        KC_NO,
-       KC_NO, KC_NO,   KC_NO
+       KC_NO, KC_NO,         KC_NO
 ),
 /* Keymap 2: Media and mouse keys
  *

--- a/layouts/community/ergodox/dvorak_svorak_a5/readme.md
+++ b/layouts/community/ergodox/dvorak_svorak_a5/readme.md
@@ -6,6 +6,15 @@ one column for the right hand, why the three buttons furthest to the right, on
 the right half, are missing. I have tried to move them around and have yet to
 find a perfect position for them.
 
+
+## Note
+
+The keyboard assumes that the operating system interprets your keyboard as
+Swedish. If you get weird issues (like, most letters work, but not all special
+characters) please make sure your operating system uses a Swedish keyboard
+layout.
+
+
 ## Flashing
 
 In order to compile and flash your Ergodox EZ, invoke the following at the root
@@ -13,10 +22,19 @@ of the repository.
 
 `make ergodox_ez:dvorak_svorak_a5:teensy`
 
+I haven't gotten the above to work on Windows. Instead I use
+[Msys2](https://www.msys2.org/) to compile the .hex-file (`make ergodox_ez:dvorak_svorak_a5`)
+and [Teensy Loader](https://www.pjrc.com/teensy/loader_win10.html) to flash the
+board.
+
+
 ## Changelog
 
 * 2018-08-09
   * Initial release
+* 2018-08-10
+  * Make special characters work in Windows
+  * Add QWERTY layer
 
 # Author
 Erik Thorsell

--- a/layouts/community/ergodox/dvorak_svorak_a5/readme.md
+++ b/layouts/community/ergodox/dvorak_svorak_a5/readme.md
@@ -1,0 +1,24 @@
+# ErgoDox EZ Svorak A5 
+
+This layout is supposed to be an implementation of the [Svorak A5
+layout](http://aoeu.info/s/dvorak/svorak). Unfortunately, the Ergodox EZ lacks
+one column for the right hand, why the three buttons furthest to the right, on
+the right half, are missing. I have tried to move them around and have yet to
+find a perfect position for them.
+
+## Flashing
+
+In order to compile and flash your Ergodox EZ, invoke the following at the root
+of the repository.
+
+`make ergodox_ez:dvorak_svorak_a5:teensy`
+
+## Changelog
+
+* 2018-08-09
+  * Initial release
+
+# Author
+Erik Thorsell
+erikthorsell @ github and twitter
+


### PR DESCRIPTION
The Svorak A5 layout was primarily developed for being used with the Kinesis Contoured, but I find it very useful on the Ergodox-EZ. Svorak A5 takes the most common Swedish Dvorak version and adds all special characters as an Alt-Gr combination on the letters of the keymap. In my implementation I make use of the ability to program layers and dedicate a SYMB layer to this purpose.

In addition to the base and symb layers I have also added a media layer (very sparse at the moment, but I don't use it for many things) and a QWERTY layer that can be toggled on if need be.