### PR TITLE
Docs: Fix descriptions of KC_INT1 and KC_INT3

### DIFF
--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -141,9 +141,9 @@ This is a reference only. Each group of keys links to the page documenting their
 |`KC_LOCKING_SCROLL`    |`KC_LSCR`           |Locking Scroll Lock                            |
 |`KC_KP_COMMA`          |`KC_PCMM`           |Keypad `,`                                     |
 |`KC_KP_EQUAL_AS400`    |                    |Keypad `=` on AS/400 keyboards                 |
-|`KC_INT1`              |`KC_RO`             |JIS `\` and <code>&#124;</code>                |
+|`KC_INT1`              |`KC_RO`             |JIS `\` and `_`                                |
 |`KC_INT2`              |`KC_KANA`           |JIS Katakana/Hiragana                          |
-|`KC_INT3`              |`KC_JYEN`           |JIS `¥`                                        |
+|`KC_INT3`              |`KC_JYEN`           |JIS `¥` and <code>&#124;</code>                |
 |`KC_INT4`              |`KC_HENK`           |JIS Henkan                                     |
 |`KC_INT5`              |`KC_MHEN`           |JIS Muhenkan                                   |
 |`KC_INT6`              |                    |JIS Numpad `,`                                 |

--- a/docs/keycodes_basic.md
+++ b/docs/keycodes_basic.md
@@ -123,9 +123,9 @@ The basic set of keycodes are based on the [HID Keyboard/Keypad Usage Page (0x07
 
 |Key       |Aliases  |Description                    |
 |----------|---------|-------------------------------|
-|`KC_INT1` |`KC_RO`  |JIS `\` and <code>&#124;</code>|
+|`KC_INT1` |`KC_RO`  |JIS `\` and `_`                |
 |`KC_INT2` |`KC_KANA`|JIS Katakana/Hiragana          |
-|`KC_INT3` |`KC_JYEN`|JIS `¥`                        |
+|`KC_INT3` |`KC_JYEN`|JIS `¥` and <code>&#124;</code>|
 |`KC_INT4` |`KC_HENK`|JIS Henkan                     |
 |`KC_INT5` |`KC_MHEN`|JIS Muhenkan                   |
 |`KC_INT6` |         |JIS Numpad `,`                 |


### PR DESCRIPTION
The standard layout of Japanese keyboard is OADG109A.
See https://ja.wikipedia.org/wiki/JISキーボード