### PR TITLE
Add the ability to disable the USB startup check for Chibios

### DIFF
--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -248,3 +248,7 @@ Use these to enable or disable building certain features. The more you have enab
   * Enable Bluetooth with the Adafruit EZ-Key HID
 * `SPLIT_KEYBOARD`
   * Enables split keyboard support (dual MCU like the let's split and bakingpy's boards) and includes all necessary files located at quantum/split_common
+* `WAIT_FOR_USB`
+  * Forces the keyboard to wait for a USB connection to be established before it starts up
+* `NO_USB_STARTUP_CHECK`
+  * Disables usb suspend check after keyboard startup. Usually the keyboard waits for the host to wake it up before any tasks are performed. This is useful for split keyboards as one half will not get a wakeup call but must send commands to the master.

--- a/tmk_core/protocol/chibios/main.c
+++ b/tmk_core/protocol/chibios/main.c
@@ -135,10 +135,15 @@ int main(void) {
 
   /* Wait until the USB or serial link is active */
   while (true) {
+#if defined(WAIT_FOR_USB) || defined(SERIAL_LINK_ENABLE)
     if(USB_DRIVER.state == USB_ACTIVE) {
       driver = &chibios_driver;
       break;
     }
+#else
+    driver = &chibios_driver;
+    break;
+#endif
 #ifdef SERIAL_LINK_ENABLE
     if(is_serial_link_connected()) {
       driver = get_serial_link_driver();
@@ -171,6 +176,7 @@ int main(void) {
   /* Main loop */
   while(true) {
 
+#if !defined(NO_USB_STARTUP_CHECK)
     if(USB_DRIVER.state == USB_SUSPENDED) {
       print("[s]");
 #ifdef VISUALIZER_ENABLE
@@ -198,6 +204,7 @@ int main(void) {
       visualizer_resume();
 #endif
     }
+#endif
 
     keyboard_task();
 #ifdef CONSOLE_ENABLE


### PR DESCRIPTION
- Added support for NO_USB_STARTUP_CHECK in Chibios. This allows the keyboard do function and not get stuck in a SUSPENDED state loop in case of no USB host connection.
- Added support for WAIT_FOR_USB in Chibios. No LUFA keyboard has this flag enable therefor no keyboard waits for usb to be active.
- Added documentation for both configuration flags as they were missing.