### PR TITLE
Autodetect lack of screen presence

### DIFF
--- a/keyboards/tkc1800/keymaps/default/keymap.c
+++ b/keyboards/tkc1800/keymaps/default/keymap.c
@@ -34,6 +34,8 @@ enum {
 	FUNCTION,
 };
 
+bool screenWorks = 0;
+
 //13 characters max without re-writing the "Layer: " format in iota_gfx_task_user()
 static char layer_lookup[][14] = {"Base","Function"};
 
@@ -93,7 +95,9 @@ void matrix_init_user(void) {
   // calls code for the SSD1306 OLED
         _delay_ms(400);
         TWI_Init(TWI_BIT_PRESCALE_1, TWI_BITLENGTH_FROM_FREQ(1, 800000));
-        iota_gfx_init();   // turns on the display
+        if(iota_gfx_init()){ // turns on the display
+			screenWorks = 1;
+		}
   #endif
   #endif
     #ifdef AUDIO_ENABLE
@@ -103,7 +107,9 @@ void matrix_init_user(void) {
 
 void matrix_scan_user(void) {
     #ifdef SSD1306OLED
-     iota_gfx_task();  // this is what updates the display continuously
+     if(screenWorks){
+	 iota_gfx_task();  // this is what updates the display continuously
+	 };
     #endif
 }
 

--- a/keyboards/tkc1800/keymaps/wkl/keymap.c
+++ b/keyboards/tkc1800/keymaps/wkl/keymap.c
@@ -34,6 +34,8 @@ enum {
 	FUNCTION,
 };
 
+bool screenWorks = 0;
+
 //13 characters max without re-writing the "Layer: " format in iota_gfx_task_user()
 static char layer_lookup[][14] = {"Base","Function"};
 
@@ -93,7 +95,9 @@ void matrix_init_user(void) {
   // calls code for the SSD1306 OLED
         _delay_ms(400);
         TWI_Init(TWI_BIT_PRESCALE_1, TWI_BITLENGTH_FROM_FREQ(1, 800000));
-        iota_gfx_init();   // turns on the display
+        if(iota_gfx_init()){ // turns on the display
+			screenWorks = 1;
+		}
   #endif
   #endif
     #ifdef AUDIO_ENABLE
@@ -103,7 +107,9 @@ void matrix_init_user(void) {
 
 void matrix_scan_user(void) {
     #ifdef SSD1306OLED
-     iota_gfx_task();  // this is what updates the display continuously
+     if(screenWorks){
+	 iota_gfx_task();  // this is what updates the display continuously
+	 };
     #endif
 }
 


### PR DESCRIPTION
This is the simplest, most efficient way I could come up with to silence
the "Failed to start write 60" error that occurs when QMK tries to talk
to a screen that doesn't exist.

iota_gfx_init passes a success boolean. We catch that into a global bool
(we could rewrite multiple functions to pass this as an argument, but
given the number of keyboards using this code it seemed less disruptive
this way) and then use that as a conditional on running the
iota_gfx_task in matrix_scan_user.

Tl;dr: if the screen doesn't init, the screen write code doesn't run.