### PR TITLE
mitosis: minor readme improvements

### DIFF
--- a/keyboards/mitosis/keymaps/datagrok/readme.md
+++ b/keyboards/mitosis/keymaps/datagrok/readme.md
@@ -67,7 +67,7 @@ Keyboard layout editor sources:
 
 - I like the way Workman feels and some of its advantages over Colemak.
   Unfortunately, it was designed using a weighting system based on a standard
-  column-staggered keyboard so is probably not as optimal as one could achieve
+  row-staggered keyboard so is probably not as optimal as one could achieve
   on an ergonomic board like the Mitosis. Maybe run an optimizer routine after I
   determine good values for key difficulty on the Mitosis.
 

--- a/keyboards/mitosis/readme.md
+++ b/keyboards/mitosis/readme.md
@@ -14,7 +14,7 @@ Make example for this keyboard (after setting up your build environment):
 
 See [build environment setup](https://docs.qmk.fm/build_environment_setup.html) then the [make instructions](https://docs.qmk.fm/make_instructions.html) for more information.
 
-## Mitosis Notes
+## Notes
 
 Some circuit board manufacturers including [DirtyPCBs](https://dirtypcbs.com/) and [PCBWay](https://www.pcbway.com/) offer a steeply discounted "prototyping" rate for a small quantity of identical circuit boards less than 100x100mm in size. The Mitosis was designed to take advantage of this, so that individuals might affordably manufacture their own without waiting for a group-buy.
 

--- a/keyboards/mitosis/readme.md
+++ b/keyboards/mitosis/readme.md
@@ -1,11 +1,12 @@
-Mitosis
-=======
+# Mitosis
+
+![Mitosis](https://i.imgur.com/JTzXTCD.jpg)
 
 A wireless split compact keyboard.
 
-Keyboard Maintainer: [@reversebias](https://github.com/reversebias)
-Hardware Supported: Mitosis PCB
-Hardware Availability: https://www.reddit.com/r/MechanicalKeyboards/comments/66588f/wireless_split_qmk_mitosis/
+Keyboard Maintainer: [@reversebias](https://github.com/reversebias)  
+Hardware Supported: Mitosis PCB  
+Hardware Availability: See the [Mitosis keyboard announcement and discussion](https://www.reddit.com/r/MechanicalKeyboards/comments/66588f/wireless_split_qmk_mitosis/)
 
 Make example for this keyboard (after setting up your build environment):
 
@@ -15,10 +16,14 @@ See [build environment setup](https://docs.qmk.fm/build_environment_setup.html) 
 
 ## Mitosis Notes
 
-These configuration files were based off the Atreus keyboard. It assumes a Pro Micro is being used, however retains the 'make upload' feature from the Atreus branch. This keyboard uses a completely different 'matrix scan' system to other keyboards, it relies on an external nRF51822 microcontroller maintaining a matrix of keystates received from the keyboard halves. The matrix.c file contains the code to poll the external microcontroller for the key matrix. As long as this file is not changed, all other QMK features are supported.
+Some circuit board manufacturers including [DirtyPCBs](https://dirtypcbs.com/) and [PCBWay](https://www.pcbway.com/) offer a steeply discounted "prototyping" rate for a small quantity of identical circuit boards less than 100x100mm in size. The Mitosis was designed to take advantage of this, so that individuals might affordably manufacture their own without waiting for a group-buy.
 
-Build log of the keyboard can be found [here](https://www.reddit.com/r/MechanicalKeyboards/comments/66588f/wireless_split_qmk_mitosis/)
+These configuration files were based off the Atreus keyboard. It assumes a Pro Micro is being used, however retains the 'make upload' feature from the Atreus branch.
 
-Hardware design files can be found [here](https://github.com/reversebias/mitosis-hardware)
+This keyboard uses a completely different 'matrix scan' system than most other keyboards supported by QMK. Here, QMK runs in a Pro Micro on a receiver module, and communicates only with an nRF51822 microcontroller module that in turn does wireless communication. The nRF51822 maintains a matrix of keystates received from the same microcontrollers on each of the keyboard halves. The matrix.c file contains the code to make the Pro Micro poll the external wireless microcontroller for the key matrix. As long as this file is not changed, all other QMK features are supported.
 
-Firmware for the nordic MCUs can be found [here](https://github.com/reversebias/mitosis)
+[Mitosis keyboard build log](https://imgur.com/a/mwTFj), including many photos and notes about the assembly process.
+
+[Mitosis keyboard hardware design files](https://github.com/reversebias/mitosis-hardware), including PCB schematics and manufacturing files, parts list, and a laser-cutting template for the neoprene base.
+
+[Mitosis keyboard wireless firmware](https://github.com/reversebias/mitosis) for the Nordic microcontrollers.


### PR DESCRIPTION
- added a photo
- make some links more pagerank-friendly
- I think Mitosis's design within "prototype" constraints is one of its most compelling and unique features, and it makes the "hardware availability" link somewhat moot, so I mention it in the readme.