### PR TITLE
add linebreaks to "Keyboard Maintainer:..." blocks where missing

### DIFF
--- a/keyboards/converter/usb_usb/README.md
+++ b/keyboards/converter/usb_usb/README.md
@@ -3,8 +3,8 @@ USB to USB keyboard protocol converter
 A small device to connect between your USB keyboard and your PC that makes (almost) every keyboard fully programmable.
 Original code from the [TMK firmware](https://github.com/tmk/tmk_keyboard/tree/master/converter/usb_usb). Ported to QMK by [Balz Guenat](https://github.com/BalzGuenat).
 
-Keyboard Maintainer: [Balz Guenat](https://github.com/BalzGuenat)
-Hardware Supported: [Hasu's USB-USB converter](https://geekhack.org/index.php?topic=69169.0), [Pro Micro + USB Host Shield](https://geekhack.org/index.php?topic=80421.0), maybe more
+Keyboard Maintainer: [Balz Guenat](https://github.com/BalzGuenat)  
+Hardware Supported: [Hasu's USB-USB converter](https://geekhack.org/index.php?topic=69169.0), [Pro Micro + USB Host Shield](https://geekhack.org/index.php?topic=80421.0), maybe more  
 Hardware Availability: [GH thread](https://geekhack.org/index.php?topic=72052.0), self-built
 
 Make example for this keyboard (after setting up your build environment):

--- a/keyboards/facew/readme.md
+++ b/keyboards/facew/readme.md
@@ -7,8 +7,8 @@ but does have in switch LEDs. Also unlike the B.Face, it is based on ps2avru ins
 is designed and manufactured in Korea.  It originally uses BootMapperClient for programming but 
 can now also use QMK. 
 
-Keyboard Maintainer: [MechMerlin](www.github.com/mechmerlin)
-Hardware Supported: FaceW Sprit Edition PCB
+Keyboard Maintainer: [MechMerlin](www.github.com/mechmerlin)  
+Hardware Supported: FaceW Sprit Edition PCB  
 Hardware Availability: https://mechanicalkeyboards.com/shop/index.php?l=product_detail&p=1352
 
 ## Keyboard Notes

--- a/keyboards/handwired/not_so_minidox/readme.md
+++ b/keyboards/handwired/not_so_minidox/readme.md
@@ -5,7 +5,7 @@ not_so_minidox
 
 A slightly larger version of the MiniDox
 
-Keyboard Maintainer: mtdjr
+Keyboard Maintainer: mtdjr  
 Hardware Supported: None yet/ProMicro
 
 Make example for this keyboard (after setting up your build environment):

--- a/keyboards/infinity60/readme.md
+++ b/keyboards/infinity60/readme.md
@@ -3,8 +3,8 @@ Infinity 60%
 
 A compact community driven keyboard.
 
-Keyboard Maintainer: QMK Community
-Hardware Supported: Infinity 60% PCB
+Keyboard Maintainer: QMK Community  
+Hardware Supported: Infinity 60% PCB  
 Hardware Availability: https://input.club/devices/infinity-keyboard/
 
 Make example for this keyboard (after setting up your build environment):

--- a/keyboards/jd40/readme.md
+++ b/keyboards/jd40/readme.md
@@ -3,8 +3,8 @@ JD40
 
 A compact 40% keyboard.
 
-Keyboard Maintainer: QMK Community
-Hardware Supported: JD40 PCB
+Keyboard Maintainer: QMK Community  
+Hardware Supported: JD40 PCB  
 Hardware Availability: [1up](https://1upkeyboards.com/jd40-mkii-1up-keyboards-logo-pcb.html) [mechanicalkeyboards.com](https://mechanicalkeyboards.com/shop/index.php?l=product_detail&p=2452) [originative](https://www.originativeco.com/products/jd40-pcb)
 
 Make example for this keyboard (after setting up your build environment):

--- a/keyboards/jd45/readme.md
+++ b/keyboards/jd45/readme.md
@@ -3,8 +3,8 @@ JD45
 
 A compact 45% keyboard.
 
-Keyboard Maintainer: QMK Community
-Hardware Supported: JD45 PCB
+Keyboard Maintainer: QMK Community  
+Hardware Supported: JD45 PCB  
 Hardware Availability: https://mechanicalkeyboards.com/shop/index.php?l=product_list&c=346
 
 Make example for this keyboard (after setting up your build environment):

--- a/keyboards/jm60/readme.md
+++ b/keyboards/jm60/readme.md
@@ -3,8 +3,8 @@ JM60
 
 A compact 60% keyboard with full RGB led support.
 
-Keyboard Maintainer: QMK Community
-Hardware Supported: JM60
+Keyboard Maintainer: QMK Community  
+Hardware Supported: JM60  
 Hardware Availability: https://kbdfans.myshopify.com/ (is no longer sold)
 
 Make example for this keyboard (after setting up your build environment):

--- a/keyboards/minidox/readme.md
+++ b/keyboards/minidox/readme.md
@@ -5,7 +5,7 @@ MiniDox
 
 A compact version of the ErgoDox
 
-Keyboard Maintainer: That-Canadian
+Keyboard Maintainer: That-Canadian  
 Hardware Supported: MiniDox PCB rev1 Pro Micro
 
 Make example for this keyboard (after setting up your build environment):

--- a/keyboards/mint60/readme.md
+++ b/keyboards/mint60/readme.md
@@ -4,7 +4,7 @@
 
 A short description of the keyboard/project
 
-Keyboard Maintainer: [Eucalyn](https://github.com/eucalyn)  [@eucalyn_](https://twitter.com/eucalyn_)
+Keyboard Maintainer: [Eucalyn](https://github.com/eucalyn)  [@eucalyn_](https://twitter.com/eucalyn_)  
 Hardware Supported: The Mint60 PCBs, ProMicro supported  
 Hardware Availability: links to where you can find this hardware
 

--- a/keyboards/pegasushoof/README.md
+++ b/keyboards/pegasushoof/README.md
@@ -1,8 +1,8 @@
 Pegasus Hoof Controller
 ===
 
-Keyboard Maintainer: QMK Community
-Hardware Supported: Pegasus Hoof
+Keyboard Maintainer: QMK Community  
+Hardware Supported: Pegasus Hoof  
 Hardware Availability: https://1upkeyboards.com/filco-pegasus-hoof-controller.html
 
 Make example for this keyboard (after setting up your build environment):

--- a/keyboards/phantom/readme.md
+++ b/keyboards/phantom/readme.md
@@ -5,8 +5,8 @@ A community-developed keyboard PCB designed to fit inside the case of a Filco Ma
 
 See the [Deskthority wiki](https://deskthority.net/wiki/Phantom) for more information.
 
-Keyboard Maintainer: QMK Community
-Hardware Supported: Phantom PCB
+Keyboard Maintainer: QMK Community  
+Hardware Supported: Phantom PCB  
 Hardware Availability: https://mechanicalkeyboards.com/shop/index.php?l=product_detail&p=536
 
 Make example for this keyboard (after setting up your build environment):

--- a/keyboards/planck/readme.md
+++ b/keyboards/planck/readme.md
@@ -5,8 +5,8 @@ Planck
 
 A compact 40% (12x4) ortholinear keyboard kit made and sold by OLKB and Massdrop. [More info on qmk.fm](http://qmk.fm/planck/)
 
-Keyboard Maintainer: [Jack Humbert](https://github.com/jackhumbert)
-Hardware Supported: Planck PCB rev1, rev2, rev3, rev4, Teensy 2.0
+Keyboard Maintainer: [Jack Humbert](https://github.com/jackhumbert)  
+Hardware Supported: Planck PCB rev1, rev2, rev3, rev4, Teensy 2.0  
 Hardware Availability: [OLKB.com](https://olkb.com), [Massdrop](https://www.massdrop.com/buy/planck-mechanical-keyboard?mode=guest_open)
 
 Make example for this keyboard (after setting up your build environment):

--- a/keyboards/redox/readme.md
+++ b/keyboards/redox/readme.md
@@ -10,8 +10,8 @@
 
 **Redox**: the **R**educed **E**rgo**dox** project. More information and building instruction [here](https://github.com/mattdibi/redox-keyboard).
 
-- Keyboard Maintainer: [Mattia Dal Ben](https://github.com/mattdibi)
-- Hardware Supported: Redox PCB rev1.0 w/ Pro Micro
+- Keyboard Maintainer: [Mattia Dal Ben](https://github.com/mattdibi)  
+- Hardware Supported: Redox PCB rev1.0 w/ Pro Micro  
 - Hardware Availability: [Falbatech](https://falba.tech/product-category/keyboard-parts/redox-parts/)
 
 Make example for this keyboard (after setting up your build environment):

--- a/keyboards/roadkit/readme.md
+++ b/keyboards/roadkit/readme.md
@@ -3,8 +3,8 @@ roadkit
 
 A programmable macro pad.
 
-Keyboard Maintainer: QMK Community
-Hardware Supported: Roadkit PCB
+Keyboard Maintainer: QMK Community  
+Hardware Supported: Roadkit PCB  
 Hardware Availability: https://thevankeyboards.com/collections/catalog/products/road-kit-diy?variant=603645345806
 
 Make example for this keyboard (after setting up your build environment):

--- a/keyboards/s60_x/readme.md
+++ b/keyboards/s60_x/readme.md
@@ -2,8 +2,8 @@ S60-x
 =====
 DIY compact keyboard designed by VinnyCordeiro for Sentraq. Most of the keymaps are based on GH60 code. This is a port from TMK to QMK based on the [original S60-X Repo](https://github.com/VinnyCordeiro/tmk_keyboard).
 
-Keyboard Maintainer: QMK Community
-Hardware Supported: S60-x PCB
+Keyboard Maintainer: QMK Community  
+Hardware Supported: S60-x PCB  
 Hardware Availability: https://www.massdrop.com/buy/sentraq-60-diy-keyboard-kit?mode=guest_open
 
 There are two versions of this keyboard, an RGB and a non RGB one. 

--- a/keyboards/scrabblepad/readme.md
+++ b/keyboards/scrabblepad/readme.md
@@ -6,7 +6,7 @@ the XDA Scrabble Board sold by [Novelkeys](https://novelkeys.xyz).
 It uses a [Teensy++ 2.0](https://www.pjrc.com/store/teensypp.html) 
 featuring an at90usb1286 8 bit microcontroller. Usage requires modifying the Teensy by removing the LED on pin D6.
 
-Keyboard Maintainer: [MechMerlin](https://github.com/mechmerlin), [Donut Cables](https://donutcables.com/)
+Keyboard Maintainer: [MechMerlin](https://github.com/mechmerlin), [Donut Cables](https://donutcables.com/)  
 Hardware Supported: Teensy++ 2.0 and ScrabblePad PCB  
 Hardware Availability: [Donut Cables](https://donutcables.com/)
 

--- a/keyboards/singa/readme.md
+++ b/keyboards/singa/readme.md
@@ -7,8 +7,8 @@
 A short description of the keyboard/project
 
 
-Keyboard Maintainer: [amnesia0287](https://github.com/amnesia0287)
-Hardware Supported: TGR-Elaine v1.0 PCB
+Keyboard Maintainer: [amnesia0287](https://github.com/amnesia0287)  
+Hardware Supported: TGR-Elaine v1.0 PCB  
 Hardware Availability: http://singakbd.com/
 
 

--- a/keyboards/sx60/readme.md
+++ b/keyboards/sx60/readme.md
@@ -5,8 +5,8 @@ SX60
 ![SX60](https://i.imgur.com/hZZHrRr.jpg)
 
 
-Keyboard Maintainer: [amnobis](https://github.com/amnobis)
-Hardware Supported: SX60
+Keyboard Maintainer: [amnobis](https://github.com/amnobis)  
+Hardware Supported: SX60  
 Hardware Availability: [geekhack.org/index.php?topic=93665.0](https://geekhack.org/index.php?topic=93665.0)
 
 Make example for this keyboard (after setting up your build environment):

--- a/keyboards/the_ruler/readme.md
+++ b/keyboards/the_ruler/readme.md
@@ -3,8 +3,8 @@ The Ruler PCB
 
 A custom keyboard PCB ruler, that can also function as a macro pad
 
-Keyboard Maintainer: Maple Computing
-Hardware Supported: PCB Ruler V1 by That-Canadian and Bishop Keyboards
+Keyboard Maintainer: Maple Computing  
+Hardware Supported: PCB Ruler V1 by That-Canadian and Bishop Keyboards  
 Hardware Availability: https://www.maple-computing.com/products/pcb-ruler-v1-1
 
 Make example for this keyboard (after setting up your build environment):

--- a/keyboards/tv44/readme.md
+++ b/keyboards/tv44/readme.md
@@ -3,8 +3,8 @@ The Van 44
 
 A compact 44% keyboard.
 
-Keyboard Maintainer: QMK Community
-Hardware Supported: The Van PCB
+Keyboard Maintainer: QMK Community  
+Hardware Supported: The Van PCB  
 Hardware Availability: https://thevankeyboards.com/collections/catalog/products/minivan-diy?variant=609138376718
 
 Make example for this keyboard (after setting up your build environment):

--- a/keyboards/v60_type_r/readme.md
+++ b/keyboards/v60_type_r/readme.md
@@ -28,8 +28,8 @@ Note: By default the V60 Type R uses TMK.  You should know what you're doing and
 
 You will then have to use tkg-toolkit to finish the flashing
 
-Keyboard Maintainer:  QMK Community
-Hardware Supported:  KBP V60 Type R PCB
+Keyboard Maintainer:  QMK Community  
+Hardware Supported:  KBP V60 Type R PCB  
 Hardware Availability: [mechanicalkeyboards.com](https://mechanicalkeyboards.com/search.php?keyword=kbp+v60+type+r), [Massdrop](https://www.massdrop.com/buy/kbparadise-v60-type-r-mechanical-keyboard)
 
 Make example for this keyboard (after setting up your build environment):

--- a/keyboards/vision_division/readme.md
+++ b/keyboards/vision_division/readme.md
@@ -3,8 +3,8 @@ Vision Division
 
 Full Size / Split Linear Keyboard PCB
 
-Keyboard Maintainer: QMK Community
-Hardware Supported: Vision Division PCB
+Keyboard Maintainer: QMK Community  
+Hardware Supported: Vision Division PCB  
 Hardware Availability: https://geekhack.org/index.php?topic=83692.msg2227856#msg2227856
 
 Make example for this keyboard (after setting up your build environment):

--- a/keyboards/xd60/readme.md
+++ b/keyboards/xd60/readme.md
@@ -5,8 +5,8 @@ Compact 60% with arrows.
 
 ![Top View of a pair of XD60 Keyboard](https://i.imgur.com/3Jq2743.jpg)
 
-Keyboard Maintainer: QMK Community
-Hardware Supported: XD60 PCB
+Keyboard Maintainer: QMK Community  
+Hardware Supported: XD60 PCB  
 Hardware Availability: https://www.massdrop.com/buy/xd60-xd64-custom-mechanical-keyboard-kit?mode=guest_open
 
 Make example for this keyboard (after setting up your build environment):


### PR DESCRIPTION
This is a trivial change that adds some missing linebreaks to keyboard readmes across all keyboards.

You can quickly verify this is a whitespace-only change here: https://github.com/qmk/qmk_firmware/commit/389f1d7a81b0c51c135ac200514231167fb2fca8?w=1