### PR TITLE
Adding keymap to the XD60

### DIFF
--- a/keyboards/xd60/keymaps/edulpn64/keymap.c
+++ b/keyboards/xd60/keymaps/edulpn64/keymap.c
@@ -1,0 +1,46 @@
+#include QMK_KEYBOARD_H
+#include "action_layer.h"
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+  // 0: Base Layer
+  LAYOUT_all(
+      KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,    KC_0,    KC_MINS,  KC_EQL,  KC_BSPC,  KC_BSPC,   \
+      KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,   KC_T,   KC_Y,   KC_U,   KC_I,   KC_O,    KC_P,    KC_LBRC,  KC_RBRC,           KC_BSLS,   \
+      KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,   KC_G,   KC_H,   KC_J,   KC_K,   KC_L,    KC_SCLN, KC_QUOT,  KC_NO,             KC_ENT,    \
+      KC_LSFT, KC_NO,   KC_Z,    KC_X,    KC_C,   KC_V,   KC_B,   KC_N,   KC_M,   KC_COMM, KC_DOT,  KC_SLSH,  KC_RSFT, KC_UP,    KC_DEL,    \
+      KC_LCTL, KC_LGUI, KC_LALT,                          KC_SPC,                          F(0)   , KC_RCTL,  KC_LEFT, KC_DOWN,  KC_RIGHT),
+
+  // 1: Function Layer
+  LAYOUT_all(
+      KC_ESC,  KC_F1,   KC_F2,   KC_F3,   KC_F4,  KC_F5,  KC_F6,  KC_F7,  KC_F8,  KC_F9,   KC_F10,  KC_F11,   KC_F12,  KC_BSPC,  KC_BSPC,   \
+      KC_TAB,  KC_NO,   KC_NO,   KC_NO,   KC_NO,  KC_NO,  KC_NO,  KC_PSCR,KC_SLCK,KC_PAUS, RGB_RMOD,RGB_MOD,  RGB_VAD,           RGB_VAI,   \
+      KC_CAPS, KC_NO,   KC_NO,   KC_NO,   KC_NO,  KC_NO,  KC_NO,  KC_INS, KC_HOME,KC_PGUP, RGB_HUD, RGB_HUI,  KC_NO,             KC_ENT,    \
+      KC_LSFT, KC_NO,   KC_NO,   KC_NO,   KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_END,  KC_PGDN, KC_NO,    KC_RSFT, KC_UP,    KC_DEL,    \
+      KC_LCTL, KC_LGUI, KC_LALT,                          KC_SPC,                          F(0),    KC_RCTRL, KC_LEFT, KC_DOWN,  KC_RIGHT),
+
+};
+
+// Custom Actions
+const uint16_t PROGMEM fn_actions[] = {
+    [0] = ACTION_LAYER_MOMENTARY(1),  // to Fn overlay
+};
+
+// Macros
+const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt) {
+
+  // MACRODOWN only works in this function
+  switch(id) {
+    case 0:
+      if (record->event.pressed) { register_code(KC_RSFT); }
+      else { unregister_code(KC_RSFT); }
+      break;
+  }
+
+  return MACRO_NONE;
+};
+
+// Loop
+void matrix_scan_user(void) {
+  // Empty
+};

--- a/keyboards/xd60/keymaps/edulpn64/readme.md
+++ b/keyboards/xd60/keymaps/edulpn64/readme.md
@@ -1,6 +1,6 @@
 # Edulpn64 Keymap for XIUDI's 60% XD60 PCB
 
-![Default Keymap for XD60](https://img.alicdn.com/imgextra/i1/1713761720/TB2K0gTalPxQeBjy1XcXXXHzVXa_!!1713761720.png)
+![Edulpn64 Keymap for XD60](https://dl2.pushbulletusercontent.com/K6bdlBlP5ix7jdMAr8QKes4johmpUfPI/image.png)
 
 ## Additional Notes
 This keymap uses the Default XD60 base layer, but follows the GK64 function layer (one of my XD60 boards use GK64 keycaps).

--- a/keyboards/xd60/keymaps/edulpn64/readme.md
+++ b/keyboards/xd60/keymaps/edulpn64/readme.md
@@ -1,0 +1,9 @@
+# Edulpn64 Keymap for XIUDI's 60% XD60 PCB
+
+![Default Keymap for XD60](https://img.alicdn.com/imgextra/i1/1713761720/TB2K0gTalPxQeBjy1XcXXXHzVXa_!!1713761720.png)
+
+## Additional Notes
+This keymap uses the Default XD60 base layer, but follows the GK64 function layer (one of my XD60 boards use GK64 keycaps).
+
+## Build
+To build the default keymap, simply run `make xd60:edulpn64`.


### PR DESCRIPTION
Created a keymap based on the default XD60. Function layer is based on the keycaps from the GK64.