### PR TITLE
Dactyl - Only initialize relevant variables 

### DIFF
--- a/keyboards/handwired/dactyl/matrix.c
+++ b/keyboards/handwired/dactyl/matrix.c
@@ -48,8 +48,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 static const uint8_t onboard_row_pins[MATRIX_ROWS] = MATRIX_ONBOARD_ROW_PINS;
 static const uint8_t onboard_col_pins[MATRIX_COLS] = MATRIX_ONBOARD_COL_PINS;
 static const bool col_expanded[MATRIX_COLS] = COL_EXPANDED;
-static const uint8_t expander_row_pins[MATRIX_ROWS] = MATRIX_EXPANDER_ROW_PINS;
-static const uint8_t expander_col_pins[MATRIX_COLS] = MATRIX_EXPANDER_COL_PINS;
 #endif
 
 /* matrix state(1:on, 0:off) */
@@ -58,12 +56,14 @@ static matrix_row_t matrix[MATRIX_ROWS];
 static matrix_row_t matrix_debouncing[MATRIX_ROWS];
 
 #if (DIODE_DIRECTION == COL2ROW)
+    static const uint8_t expander_col_pins[MATRIX_COLS] = MATRIX_EXPANDER_COL_PINS;
     static void init_cols(void);
     static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row);
     static void unselect_rows(void);
     static void select_row(uint8_t row);
     static void unselect_row(uint8_t row);
 #elif (DIODE_DIRECTION == ROW2COL)
+    static const uint8_t expander_row_pins[MATRIX_ROWS] = MATRIX_EXPANDER_ROW_PINS;
     static void init_rows(void);
     static bool read_rows_on_col(matrix_row_t current_matrix[], uint8_t current_col);
     static void unselect_cols(void);


### PR DESCRIPTION
This small change prevents an unused variable from being initialized, throwing a warning during compilation, thus ending fatally.

```
[07:47:10] [Daniels-MacBook-Pro-3] [dburkhol] [ /Users/dburkhol/git/qmk_firmware ] [develop ]
: make handwired/dactyl:default
QMK Firmware 0.6.97
Making handwired/dactyl with keymap default

avr-gcc (GCC) 7.3.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Size before:
   text    data     bss     dec     hex filename
      0   19972       0   19972    4e04 .build/handwired_dactyl_default.hex

Compiling: keyboards/handwired/dactyl/twimaster.c                                                   [OK]
Compiling: keyboards/handwired/dactyl/matrix.c                                                     keyboards/handwired/dactyl/matrix.c:52:22: error: 'expander_col_pins' defined but not used [-Werror=unused-const-variable=]
 static const uint8_t expander_col_pins[MATRIX_COLS] = MATRIX_EXPANDER_COL_PINS;
                      ^~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
 [ERRORS]
 |
 |
 |
make[1]: *** [.build/obj_handwired_dactyl_default/matrix.o] Error 1
make: *** [handwired/dactyl:default] Error 1
Make finished with errors

```

Only one of these variables is used later on in the init_expander() function in matrix.c:
```
void init_expander(void) {
    if (! i2c_initialized) {
        i2c_init();
        wait_us(1000000);
    }

    if (! expander_input_pin_mask) {
#if (DIODE_DIRECTION == COL2ROW)
        for (int col = 0; col < MATRIX_COLS; col++) {
            if (col_expanded[col]) {
                expander_input_pin_mask |= (1 << expander_col_pins[col]);
            }
        }
#elif (DIODE_DIRECTION == ROW2COL)
        for (int row = 0; row < MATRIX_ROWS; row++) {
            expander_input_pin_mask |= (1 << expander_row_pins[row]);
        }
#endif
```
