### PR TITLE
Add user level to default_layer_state_set

### DIFF
--- a/tmk_core/common/action_layer.c
+++ b/tmk_core/common/action_layer.c
@@ -15,13 +15,22 @@
  */
 uint32_t default_layer_state = 0;
 
+/** \brief Default Layer State Set At user Level
+ *
+ * FIXME: Needs docs
+ */
+__attribute__((weak))
+uint32_t default_layer_state_set_user(uint32_t state) {
+    return state;
+}
+
 /** \brief Default Layer State Set At Keyboard Level
  *
  * FIXME: Needs docs
  */
 __attribute__((weak))
 uint32_t default_layer_state_set_kb(uint32_t state) {
-    return state;
+    return default_layer_state_set_user(state);
 }
 
 /** \brief Default Layer State Set

--- a/tmk_core/common/action_layer.h
+++ b/tmk_core/common/action_layer.h
@@ -31,6 +31,8 @@ void default_layer_set(uint32_t state);
 
 __attribute__((weak))
 uint32_t default_layer_state_set_kb(uint32_t state);
+__attribute__((weak))
+uint32_t default_layer_state_set_user(uint32_t state);
 
 #ifndef NO_ACTION_LAYER
 /* bitwise operation */

--- a/users/drashna/drashna.c
+++ b/users/drashna/drashna.c
@@ -391,8 +391,8 @@ uint32_t layer_state_set_user(uint32_t state) {
 }
 
 
-uint32_t default_layer_state_set_kb(uint32_t state) {
-  return default_layer_state_set_keymap (state);
+uint32_t default_layer_state_set_user(uint32_t state) {
+  return default_layer_state_set_keymap(state);
 }
 
 


### PR DESCRIPTION
Right now, there is `default_layer_state_set_kb` but no `default_layer_state_set_user`. 

This adds it, and in a way that should be confirm to the normal standards.  