### PR TITLE
Updated templates for use by new_project.sh

### DIFF
--- a/quantum/template/avr/readme.md
+++ b/quantum/template/avr/readme.md
@@ -12,4 +12,4 @@ Make example for this keyboard (after setting up your build environment):
 
     make %KEYBOARD%:default
 
-See [build environment setup](https://docs.qmk.fm/build_environment_setup.html) then the [make instructions](https://docs.qmk.fm/make_instructions.html) for more information.
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).

--- a/quantum/template/avr/rules.mk
+++ b/quantum/template/avr/rules.mk
@@ -48,6 +48,13 @@ OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
 OPT_DEFS += -DBOOTLOADER_SIZE=4096
 
 
+# Bootloader
+#     This definition is optional, and if your keyboard supports multiple bootloaders of
+#     different sizes, comment this out, and the correct address will be loaded
+#     automatically (+60). See bootloader.mk for all options.
+BOOTLOADER = atmel-dfu
+
+
 # Build Options
 #   change yes to no to disable
 #

--- a/quantum/template/avr/rules.mk
+++ b/quantum/template/avr/rules.mk
@@ -39,20 +39,24 @@ F_USB = $(F_CPU)
 OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
 
 
-# Boot Section Size in *bytes*
-#   Teensy halfKay   512
-#   Teensy++ halfKay 1024
-#   Atmel DFU loader 4096
-#   LUFA bootloader  4096
-#   USBaspLoader     2048
-OPT_DEFS += -DBOOTLOADER_SIZE=4096
-
-
-# Bootloader
-#     This definition is optional, and if your keyboard supports multiple bootloaders of
-#     different sizes, comment this out, and the correct address will be loaded
-#     automatically (+60). See bootloader.mk for all options.
+# Bootloader selection
+#   Teensy       halfkay
+#   Pro Micro    caterina
+#   Atmel DFU    atmel-dfu
+#   LUFA DFU     lufa-dfu
+#   QMK DFU      qmk-dfu
+#   atmega32a    bootloadHID
 BOOTLOADER = atmel-dfu
+
+
+# If you don't know the bootloader type, then you can specify the
+# Boot Section Size in *bytes* by uncommenting out the OPT_DEFS line
+#   Teensy halfKay      512
+#   Teensy++ halfKay    1024
+#   Atmel DFU loader    4096
+#   LUFA bootloader     4096
+#   USBaspLoader        2048
+# OPT_DEFS += -DBOOTLOADER_SIZE=4096
 
 
 # Build Options

--- a/quantum/template/avr/template.h
+++ b/quantum/template/avr/template.h
@@ -18,12 +18,14 @@
 
 #include "quantum.h"
 
-// This a shortcut to help you visually see your layout.
-// The following is an example using the Planck MIT layout
-// The first section contains all of the arguments representing the physical
-// layout of the board and position of the keys
-// The second converts the arguments into a two-dimensional array which 
-// represents the switch matrix. 
+/* This a shortcut to help you visually see your layout.
+ *
+ * The first section contains all of the arguments representing the physical
+ * layout of the board and position of the keys.
+ *
+ * The second converts the arguments into a two-dimensional array which
+ * represents the switch matrix.
+ */
 #define LAYOUT( \
     K00, K01, K02, \
       K10,  K11   \

--- a/quantum/template/base/keymaps/default/keymap.c
+++ b/quantum/template/base/keymaps/default/keymap.c
@@ -41,7 +41,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case QMKURL:
       if (record->event.pressed) {
         // when keycode QMKURL is pressed
-        SEND_STRING("https://qmk.fm/" SS_TAP(X_ENTER)");
+        SEND_STRING("https://qmk.fm/" SS_TAP(X_ENTER));
       } else {
         // when keycode QMKURL is released
       }

--- a/quantum/template/base/keymaps/default/keymap.c
+++ b/quantum/template/base/keymaps/default/keymap.c
@@ -15,32 +15,40 @@
  */
 #include QMK_KEYBOARD_H
 
+// Defines the keycodes used by our macros in process_record_user
+enum custom_keycodes {
+  QMKBEST = SAFE_RANGE,
+  QMKURL
+};
+
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-[0] = LAYOUT( /* Base */
-  KC_A,  KC_1,  KC_H, \
-    KC_TAB,  KC_SPC   \
-),
+  [0] = LAYOUT( /* Base */
+    KC_A,  KC_1,  KC_H, \
+      KC_TAB,  KC_SPC   \
+  ),
 };
 
-const uint16_t PROGMEM fn_actions[] = {
-
-};
-
-const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
-{
-  // MACRODOWN only works in this function
-      switch(id) {
-        case 0:
-          if (record->event.pressed) {
-            register_code(KC_RSFT);
-          } else {
-            unregister_code(KC_RSFT);
-          }
-        break;
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  switch (keycode) {
+    case QMKBEST:
+      if (record->event.pressed) {
+        // when keycode QMKBEST is pressed
+        SEND_STRING("QMK is the best thing ever!");
+      } else {
+        // when keycode QMKBEST is released
       }
-    return MACRO_NONE;
-};
-
+      break;
+    case QMKURL:
+      if (record->event.pressed) {
+        // when keycode QMKURL is pressed
+        SEND_STRING("https://qmk.fm/" SS_TAP(X_ENTER)");
+      } else {
+        // when keycode QMKURL is released
+      }
+      break;
+  }
+  return true;
+}
 
 void matrix_init_user(void) {
 
@@ -48,10 +56,6 @@ void matrix_init_user(void) {
 
 void matrix_scan_user(void) {
 
-}
-
-bool process_record_user(uint16_t keycode, keyrecord_t *record) {
-  return true;
 }
 
 void led_set_user(uint8_t usb_led) {

--- a/quantum/template/ps2avrgb/readme.md
+++ b/quantum/template/ps2avrgb/readme.md
@@ -41,4 +41,4 @@ macOS:
 4. Place your keyboard into reset. 
 5. Flash the board by typing `bootloadHID -r` followed by the path to your `.hex` file. 
 
-See [build environment setup](https://docs.qmk.fm/build_environment_setup.html) then the [make instructions](https://docs.qmk.fm/make_instructions.html) for more information.
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).

--- a/quantum/template/ps2avrgb/template.h
+++ b/quantum/template/ps2avrgb/template.h
@@ -18,10 +18,14 @@
 
 #include "quantum.h"
 
-// This a shortcut to help you visually see your layout.
-// The following is an example using the Planck MIT layout
-// The first section contains all of the arguments
-// The second converts the arguments into a two-dimensional array
+/* This a shortcut to help you visually see your layout.
+ *
+ * The first section contains all of the arguments representing the physical
+ * layout of the board and position of the keys.
+ *
+ * The second converts the arguments into a two-dimensional array which
+ * represents the switch matrix.
+ */
 #define LAYOUT( \
     k00, k01, k02, \
       k10,  k11   \


### PR DESCRIPTION
# `template.h` file cleanup

Reformatted the pre-macro comments as block comments.

Updated the ps2avrgb template comment to match the avr template's comment, which was more informative.

Deleted the line about the macro representing the Planck MIT layout, because the macro doesn't represent that layout anymore.

# base template `keymap.c` refactor

Deleted the deprecated TMK macro functions.

Defined two custom keycodes for use as macros by `process_record_user`.

`process_record_user` is now after the keymap and before `matrix_init_user`, where the deleted TMK functions were.

Keymap function has a white space change to make it follow QMK white space guidelines.