### PR TITLE
Helix: remove old comments from keyboards/helix/rules.mk

### DIFF
--- a/keyboards/helix/rules.mk
+++ b/keyboards/helix/rules.mk
@@ -2,9 +2,6 @@ SRC += i2c.c
 SRC += serial.c
 SRC += ssd1306.c
 
-# if firmware size over limit, try this option
-# CFLAGS += -flto
-
 # MCU name
 #MCU = at90usb1287
 MCU = atmega32u4


### PR DESCRIPTION
remove 2 lines from keyboards/helix/rules.mk

 | -# if firmware size over limit, try this option
 | -# CFLAGS += -flto
 | -

see keyboards/helix/[rev2|pico]/keymaps/EACH_MAP/rules.mk:

 | Link_Time_Optimization = no # if firmware size over limit, try this option
 :
 :
 :
 | ifeq ($(strip $(Link_Time_Optimization)),yes)
 |    EXTRAFLAGS += -flto -DUSE_Link_Time_Optimization
 | endif