### PR TITLE
Fix Configurator JSON data for Massdrop ALT and CTRL keyboards

### DIFF
--- a/keyboards/massdrop/alt67/info.json
+++ b/keyboards/massdrop/alt67/info.json
@@ -5,7 +5,7 @@
     "width": 16,
     "height": 5,
     "layouts": {
-        "LAYOUT_all": {
+        "LAYOUT": {
             "layout": [
               {"label":"ESCAPE", "x":0, "y":0},
               {"label":"1", "x":1, "y":0},

--- a/keyboards/massdrop/ctrl/info.json
+++ b/keyboards/massdrop/ctrl/info.json
@@ -5,7 +5,7 @@
     "width": 18.5,
     "height": 6.5,
     "layouts": {
-        "LAYOUT_all": {
+        "LAYOUT": {
             "layout": [
               {"label":"ESCAPE", "x":0, "y":0},
               {"label":"F1", "x":2, "y":0},


### PR DESCRIPTION
The layout names were `LAYOUT_all` when they needed to be `LAYOUT`.

Zero logic change.
