### PR TITLE
Fix missing braces around initializer error on windows toolchain

### DIFF
--- a/users/xtonhasvim/fancylighting.c
+++ b/users/xtonhasvim/fancylighting.c
@@ -45,7 +45,7 @@ void matrix_scan_keymap(void) {
 
 uint16_t effect_start_timer = 0;
 uint8_t user_rgb_mode = 0;
-LED_TYPE shadowed_led[RGBLED_NUM] = {0};
+LED_TYPE shadowed_led[RGBLED_NUM] = {{0}};
 
 void start_firey_return(void) {
   user_rgb_mode = BREATH_FIRE;
@@ -79,7 +79,7 @@ void set_color_for_offsets(uint16_t time_offset, uint16_t space_offset, uint8_t 
   float alpha = (time_progress + 0.1) * 7.0 - space_progress;
   alpha = fmin(1.0, alpha*alpha);
 
-  LED_TYPE px[1] = {0};
+  LED_TYPE px[1] = {{0}};
   sethsv((uint16_t)(fmod(time_progress * 1.5 + space_progress,1.0)*360), 255, (uint8_t)(progress*255),&px[0]);
   led[idx].r = alpha * px[0].r + ( 1.0 - alpha) * shadowed_led[idx].r;
   led[idx].g = alpha * px[0].g + ( 1.0 - alpha) * shadowed_led[idx].g;


### PR DESCRIPTION
Hello, I'm @xton's former intern (see https://github.com/qmk/qmk_firmware/pull/3813) and this is my first time working with QMK.

I'm on the latest version of the Windows toolchain (`avr-gcc.exe (AVR_8_bit_GNU_Toolchain_3.5.4_1709) 4.9.2`) and I'm getting errors when running `make v60_type_r:xtonhasvim`:

```
Compiling: users/xtonhasvim/fancylighting.c                                                                                                                                                                                          In file included from quantum/rgblight.h:76:0,
                 from users/xtonhasvim/fancylighting.c:21:
quantum/rgblight_types.h:33:27: error: missing braces around initializer [-Werro                                                                                                                                  r=missing-braces]
   #define LED_TYPE struct cRGB
                           ^
users/xtonhasvim/fancylighting.c:48:1: note: in expansion of macro 'LED_TYPE'
 LED_TYPE shadowed_led[RGBLED_NUM] = {0};
 ^
quantum/rgblight_types.h:33:27: error: (near initialization for 'shadowed_led[0]                                                                                                                                  ') [-Werror=missing-braces]
   #define LED_TYPE struct cRGB
                           ^
users/xtonhasvim/fancylighting.c:48:1: note: in expansion of macro 'LED_TYPE'
 LED_TYPE shadowed_led[RGBLED_NUM] = {0};
 ^
users/xtonhasvim/fancylighting.c: In function 'set_color_for_offsets':
quantum/rgblight_types.h:33:27: error: missing braces around initializer [-Werro                                                                                                                                  r=missing-braces]
   #define LED_TYPE struct cRGB
                           ^
users/xtonhasvim/fancylighting.c:82:3: note: in expansion of macro 'LED_TYPE'
   LED_TYPE px[1] = {0};
   ^
quantum/rgblight_types.h:33:27: error: (near initialization for 'px[0]') [-Werro                                                                                                                                  r=missing-braces]
   #define LED_TYPE struct cRGB
                           ^
users/xtonhasvim/fancylighting.c:82:3: note: in expansion of macro 'LED_TYPE'
   LED_TYPE px[1] = {0};
   ^
cc1.exe: all warnings being treated as errors
 [ERRORS]
 |
 |
 |
make[1]: *** [tmk_core/rules.mk:360: .build/obj_v60_type_r_xtonhasvim/fancylight                                                                                                                                  ing.o] Error 1
Make finished with errors
make: *** [Makefile:544: v60_type_r:xtonhasvim] Error 1
```

I didn't do that much investigation, but it looks like an instance of [this bug](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53119), so not sure if we want to merge this because it might be fixed in the next update?

The workaround I used with `{{0}}` was suggested [here](https://stackoverflow.com/questions/13746033/how-to-repair-warning-missing-braces-around-initializer)