### PR TITLE
Enable mouse keys in register_code and unregister_code

### DIFF
--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -773,6 +773,9 @@ void register_code(uint8_t code)
     else if IS_CONSUMER(code) {
         host_consumer_send(KEYCODE2CONSUMER(code));
     }
+    else if IS_MOUSEKEY(code) {
+      mousekey_on(code);
+    }
 }
 
 /** \brief Utilities for actions. (FIXME: Needs better description)
@@ -831,6 +834,9 @@ void unregister_code(uint8_t code)
     }
     else if IS_CONSUMER(code) {
         host_consumer_send(0);
+    }
+    else if IS_MOUSEKEY(code) {
+      mousekey_off(code);
     }
 }
 


### PR DESCRIPTION
This allows for macros to be assigned to press two mouse directions at same time, which allows for one key diagonals.

Example:

```c
    case MS_UPLEFT:
      if (record->event.pressed) {
        print("MS_UPLEFT PRESSED\n");
        register_code(KC_MS_UP);
        register_code(KC_MS_LEFT);
      }
      if (!record->event.pressed) {
        print("MS_UPLEFT RELEASED\n");
        unregister_code(KC_MS_UP);
        unregister_code(KC_MS_LEFT);
      }
      return false;
      break;
```