### PR TITLE
improve looks like hang up when first time execute make git-submodule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -578,7 +578,7 @@ lib/%:
 
 git-submodule:
 	git submodule sync --recursive
-	git submodule update --init --recursive
+	git submodule update --init --recursive --progress
 
 ifdef SKIP_VERSION
 SKIP_GIT := yes


### PR DESCRIPTION
When execute `make git-submodule` first time, depending on network traffic situation, looks like hang up.

```sh
$ make git-submodule
QMK Firmware 0.6.106
Submodule 'lib/chibios' (https://github.com/qmk/ChibiOS) registered for path 'lib/chibios'
Submodule 'lib/chibios-contrib' (https://github.com/qmk/ChibiOS-Contrib) registered for path 'lib/chibios-contrib'
Submodule 'lib/googletest' (https://github.com/google/googletest) registered for path 'lib/googletest'
Submodule 'lib/ugfx' (https://github.com/qmk/uGFX) registered for path 'lib/ugfx'
Cloning into '/Users/leico_studio/qmk_firmware/lib/chibios'...
...
```
_long long time stopped above_

`--progress` option shows cloning progress.

```sh
$ make git-submodule
QMK Firmware 0.6.106
Synchronizing submodule url for 'lib/chibios'
Synchronizing submodule url for 'lib/chibios-contrib'
Synchronizing submodule url for 'lib/googletest'
Synchronizing submodule url for 'lib/ugfx'
Cloning into '/Users/leico_studio/qmk_firmware/lib/chibios'...
remote: Counting objects: 156956, done.        
remote: Compressing objects: 100% (8/8), done.        
remote: Total 156956 (delta 0), reused 0 (delta 0), pack-reused 156948        
Receiving objects: 100% (156956/156956), 131.01 MiB | 4.64 MiB/s, done.
Resolving deltas: 100% (121229/121229), done.
....
```