### PR TITLE
Keymap: mitosis/datagrok: bug fix

### DIFF
--- a/keyboards/mitosis/keymaps/datagrok/keymap.c
+++ b/keyboards/mitosis/keymaps/datagrok/keymap.c
@@ -3,7 +3,7 @@
 #ifdef AUDIO_ENABLE
 #include "audio.h"
 #ifdef DEFAULT_LAYER_SONGS
-extern float default_layer_songs[][][];
+extern float default_layer_songs[][16][2];
 #endif
 #endif
 


### PR DESCRIPTION
I don't know how this slipped past both my local compiles and the test suite in my last merged PR (#3835), but this simplified declaration (that I guessed at) is invalid and doesn't compile. Fixed.