### PR TITLE
Improvement of Space Cadet Shift by preventing to automatically apply…

### DIFF
--- a/docs/feature_space_cadet_shift.md
+++ b/docs/feature_space_cadet_shift.md
@@ -25,9 +25,13 @@ COMMAND_ENABLE = no
 
 By default Space Cadet assumes a US ANSI layout, but if your layout uses different keys for parentheses, you can redefine them in your `config.h`.
 You can also disable the rollover, allowing you to use the opposite Shift key to cancel the Space Cadet state in the event of an erroneous press, instead of emitting a pair of parentheses when the keys are released.
+Also, by default, the Space Cadet applies modifiers LSPO_MOD and RSPC_MOD to keys defined by LSPO_KEY and RSPC_KEY. You can override this behavior by redefining those variables in your `config.h`. You can also prevent the Space Cadet to apply a modifier by defining DISABLE_SPACE_CADET_MODIFIER in your `config.h`.
 
-|Define                        |Default      |Description                                                 |
-|------------------------------|-------------|------------------------------------------------------------|
-|`LSPO_KEY`                    |`KC_9`       |The keycode to send when Left Shift is tapped               |
-|`RSPC_KEY`                    |`KC_0`       |The keycode to send when Right Shift is tapped              |
-|`DISABLE_SPACE_CADET_ROLLOVER`|*Not defined*|If defined, use the opposite Shift key to cancel Space Cadet|
+|Define                        |Default      |Description                                                                     |
+|------------------------------|-------------|--------------------------------------------------------------------------------|
+|`LSPO_KEY`                    |`KC_9`       |The keycode to send when Left Shift is tapped                                   |
+|`RSPC_KEY`                    |`KC_0`       |The keycode to send when Right Shift is tapped                                  |
+|`LSPO_MOD`                    |`KC_LSFT`    |The keycode to send when Left Shift is tapped                                   |
+|`RSPC_MOD`                    |`KC_RSFT`    |The keycode to send when Right Shift is tapped                                  |
+|`DISABLE_SPACE_CADET_ROLLOVER`|*Not defined*|If defined, use the opposite Shift key to cancel Space Cadet                    |
+|`DISABLE_SPACE_CADET_MODIFIER`|*Not defined*|If defined, prevent the Space Cadet to apply a modifier to LSPO_KEY and RSPC_KEY|

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -177,6 +177,13 @@ void reset_keyboard(void) {
   #define RSPC_KEY KC_0
 #endif
 
+#ifndef LSPO_MOD
+  #define LSPO_MOD KC_LSFT
+#endif
+#ifndef RSPC_MOD
+  #define RSPC_MOD KC_RSFT
+#endif
+
 // Shift / Enter setup
 #ifndef SFTENT_KEY
   #define SFTENT_KEY KC_ENT
@@ -627,14 +634,21 @@ bool process_record_quantum(keyrecord_t *record) {
       }
       else {
         #ifdef DISABLE_SPACE_CADET_ROLLOVER
-          if (get_mods() & MOD_BIT(KC_RSFT)) {
+          if (get_mods() & MOD_BIT(RSPC_MOD)) {
             shift_interrupted[0] = true;
             shift_interrupted[1] = true;
           }
         #endif
         if (!shift_interrupted[0] && timer_elapsed(scs_timer[0]) < TAPPING_TERM) {
+          unregister_mods(MOD_BIT(KC_LSFT));
+          #ifndef DISABLE_SPACE_CADET_MODIFIER
+            register_mods(MOD_BIT(LSPO_MOD));
+          #endif
           register_code(LSPO_KEY);
           unregister_code(LSPO_KEY);
+          #ifndef DISABLE_SPACE_CADET_MODIFIER
+            unregister_mods(MOD_BIT(LSPO_MOD));
+          #endif
         }
         unregister_mods(MOD_BIT(KC_LSFT));
       }
@@ -649,14 +663,21 @@ bool process_record_quantum(keyrecord_t *record) {
       }
       else {
         #ifdef DISABLE_SPACE_CADET_ROLLOVER
-          if (get_mods() & MOD_BIT(KC_LSFT)) {
+          if (get_mods() & MOD_BIT(LSPO_MOD)) {
             shift_interrupted[0] = true;
             shift_interrupted[1] = true;
           }
         #endif
         if (!shift_interrupted[1] && timer_elapsed(scs_timer[1]) < TAPPING_TERM) {
+          unregister_mods(MOD_BIT(KC_RSFT));
+          #ifndef DISABLE_SPACE_CADET_MODIFIER
+            register_mods(MOD_BIT(RSPC_MOD));
+          #endif
           register_code(RSPC_KEY);
           unregister_code(RSPC_KEY);
+          #ifndef DISABLE_SPACE_CADET_MODIFIER
+            unregister_mods(MOD_BIT(RSPC_MOD));
+          #endif
         }
         unregister_mods(MOD_BIT(KC_RSFT));
       }

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -640,14 +640,20 @@ bool process_record_quantum(keyrecord_t *record) {
           }
         #endif
         if (!shift_interrupted[0] && timer_elapsed(scs_timer[0]) < TAPPING_TERM) {
-          unregister_mods(MOD_BIT(KC_LSFT));
-          #ifndef DISABLE_SPACE_CADET_MODIFIER
-            register_mods(MOD_BIT(LSPO_MOD));
+          #ifdef DISABLE_SPACE_CADET_MODIFIER
+            unregister_mods(MOD_BIT(KC_LSFT));
+          #else
+            #if LSPO_MOD != KC_LSFT
+              unregister_mods(MOD_BIT(KC_LSFT));
+              register_mods(MOD_BIT(LSPO_MOD));
+            #endif
           #endif
           register_code(LSPO_KEY);
           unregister_code(LSPO_KEY);
           #ifndef DISABLE_SPACE_CADET_MODIFIER
-            unregister_mods(MOD_BIT(LSPO_MOD));
+            #if LSPO_MOD != KC_LSFT
+              unregister_mods(MOD_BIT(LSPO_MOD));
+            #endif
           #endif
         }
         unregister_mods(MOD_BIT(KC_LSFT));
@@ -669,14 +675,20 @@ bool process_record_quantum(keyrecord_t *record) {
           }
         #endif
         if (!shift_interrupted[1] && timer_elapsed(scs_timer[1]) < TAPPING_TERM) {
-          unregister_mods(MOD_BIT(KC_RSFT));
-          #ifndef DISABLE_SPACE_CADET_MODIFIER
-            register_mods(MOD_BIT(RSPC_MOD));
+          #ifdef DISABLE_SPACE_CADET_MODIFIER
+            unregister_mods(MOD_BIT(KC_RSFT));
+          #else
+            #if RSPC_MOD != KC_RSFT
+              unregister_mods(MOD_BIT(KC_RSFT));
+              register_mods(MOD_BIT(RSPC_MOD));
+            #endif
           #endif
           register_code(RSPC_KEY);
           unregister_code(RSPC_KEY);
           #ifndef DISABLE_SPACE_CADET_MODIFIER
-            unregister_mods(MOD_BIT(RSPC_MOD));
+            #if RSPC_MOD != KC_RSFT
+              unregister_mods(MOD_BIT(RSPC_MOD));
+            #endif
           #endif
         }
         unregister_mods(MOD_BIT(KC_RSFT));


### PR DESCRIPTION
… a modifier on the key and allow to override the default modifier. Closes qmk/qmk_firmware#3815.

I added LSPO_MOD and RSPC_MOD which, by default, are set to KC_LSFT and KC_RSFT.
I also added the possibility to define DISABLE_SPACE_CADET_MODIFIER to prevent the firmware to apply a modifier to LSPO_KEY and RSPC_KEY.