### PR TITLE
Allow HS60 to use Community Layouts

### DIFF
--- a/keyboards/hs60/v1/keymaps/ansi/config.h
+++ b/keyboards/hs60/v1/keymaps/ansi/config.h
@@ -18,4 +18,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* Include overwrites for specific keymap */
 
-#define HS60_ANSI
+#ifdef KEYBOARD_hs60
+  #define HS60_ANSI
+#endif

--- a/keyboards/hs60/v1/readme.md
+++ b/keyboards/hs60/v1/readme.md
@@ -9,7 +9,7 @@ Keyboard Maintainer: [Yiancar](http://yiancar-designs.com/) and on [github](http
 Hardware Supported: HS60 ISO and ANSI PCBs with Atmega 32u4   
 Hardware Availability: https://mechboards.co.uk/shop/all/hs60-pcb/   
 
-If you're using the [community layouts feature](https://docs.qmk.fm/#/feature_layouts), you need to make sure that you include this on your config.h to ensure that the RGB Matrix is properly configuer: 
+If you're using the [community layouts feature](https://docs.qmk.fm/#/feature_layouts) and using the 60_ansi layout, you need to make sure that you include this on your config.h to ensure that the RGB Matrix is properly configuration:
 
     #ifdef KEYBOARD_hs60
       #define HS60_ANSI

--- a/keyboards/hs60/v1/readme.md
+++ b/keyboards/hs60/v1/readme.md
@@ -9,7 +9,7 @@ Keyboard Maintainer: [Yiancar](http://yiancar-designs.com/) and on [github](http
 Hardware Supported: HS60 ISO and ANSI PCBs with Atmega 32u4   
 Hardware Availability: https://mechboards.co.uk/shop/all/hs60-pcb/   
 
-If you're using the [community layouts feature](https://docs.qmk.fm/#/feature_layouts) and using the 60_ansi layout, you need to make sure that you include this on your config.h to ensure that the RGB Matrix is properly configuration:
+If you're using the [community layouts feature](https://docs.qmk.fm/#/feature_layouts) and using the 60_ansi layout, you need to make sure that you include this on your config.h to ensure that the RGB Matrix is properly configured:
 
     #ifdef KEYBOARD_hs60
       #define HS60_ANSI

--- a/keyboards/hs60/v1/readme.md
+++ b/keyboards/hs60/v1/readme.md
@@ -9,7 +9,11 @@ Keyboard Maintainer: [Yiancar](http://yiancar-designs.com/) and on [github](http
 Hardware Supported: HS60 ISO and ANSI PCBs with Atmega 32u4   
 Hardware Availability: https://mechboards.co.uk/shop/all/hs60-pcb/   
 
-Due to the RGB implementation, the HS60 is currently not compatible with community layouts.
+If you're using the [community layouts feature](https://docs.qmk.fm/#/feature_layouts), you need to make sure that you include this on your config.h to ensure that the RGB Matrix is properly configuer: 
+
+    #ifdef KEYBOARD_hs60
+      #define HS60_ANSI
+    #endif
 
 Make example for this keyboard (after setting up your build environment):
 

--- a/keyboards/hs60/v1/rules.mk
+++ b/keyboards/hs60/v1/rules.mk
@@ -69,6 +69,12 @@ AUDIO_ENABLE = no           # Audio output on port C6
 FAUXCLICKY_ENABLE = no      # Use buzzer to emulate clicky switches
 RGB_MATRIX_ENABLE = yes     # Use RGB matrix
 
+LAYOUTS = 60_ansi 60_iso
+
+ifeq ($(strip $(LAYOUT)), ansi)
+    OPT_DEFS += -DHS60_ANSI
+endif
+
 # Experimental features for zealcmd please do no enable
 #RAW_ENABLE = yes
 #USE_KEYMAPS_IN_EEPROM = yes

--- a/keyboards/hs60/v1/rules.mk
+++ b/keyboards/hs60/v1/rules.mk
@@ -71,10 +71,6 @@ RGB_MATRIX_ENABLE = yes     # Use RGB matrix
 
 LAYOUTS = 60_ansi 60_iso
 
-ifeq ($(strip $(LAYOUT)), ansi)
-    OPT_DEFS += -DHS60_ANSI
-endif
-
 # Experimental features for zealcmd please do no enable
 #RAW_ENABLE = yes
 #USE_KEYMAPS_IN_EEPROM = yes


### PR DESCRIPTION
WIth the caveat that the `60_ansi` layout needs a define to work properly.

@yiancar 


I'd like to be able to use the layout makefile stuff, but that's processed too late to be used by the keyboard's rules.mk.  