### PR TITLE
Updated readmes for 1upkeyboards

### DIFF
--- a/keyboards/1upkeyboards/1up60hse/readme.md
+++ b/keyboards/1upkeyboards/1up60hse/readme.md
@@ -10,6 +10,6 @@ Hardware Availability: [1upkeyboards.com](https://www.1upkeyboards.com/shop/cont
 
 Make example for this keyboard (after setting up your build environment):
 
-    make 1up60hse:default
+    make 1upkeyboards/1up60hse:default
 
-See [build environment setup](https://docs.qmk.fm/build_environment_setup.html) then the [make instructions](https://docs.qmk.fm/make_instructions.html) for more information.
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).

--- a/keyboards/1upkeyboards/1up60rgb/readme.md
+++ b/keyboards/1upkeyboards/1up60rgb/readme.md
@@ -8,6 +8,6 @@ Hardware Availability: [1upkeyboards](https://www.1upkeyboards.com/shop/controll
 
 Make example for this keyboard (after setting up your build environment):
 
-    make 1up60rgb:default
+    make 1upkeyboards/1up60rgb:default
 
-See [build environment setup](https://docs.qmk.fm/build_environment_setup.html) then the [make instructions](https://docs.qmk.fm/make_instructions.html) for more information.
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).

--- a/keyboards/1upkeyboards/sweet16/readme.md
+++ b/keyboards/1upkeyboards/sweet16/readme.md
@@ -9,6 +9,6 @@ Hardware Availability: [1up Keyboards](https://1upkeyboards.com/)
 
 Make example for this keyboard (after setting up your build environment):
 
-    make sweet16:default
+    make 1upkeyboards/sweet16:default
 
-See [build environment setup](https://docs.qmk.fm/build_environment_setup.html) then the [make instructions](https://docs.qmk.fm/make_instructions.html) for more information.
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).


### PR DESCRIPTION
This is an error-correction update with no logic changes, that corrects some issues with the keyboard readme files for 1upKeyboards.

Corrected the make examples for each keyboard, which were wrong now that the keyboards are in a `1upkeyboards` directory.

Updated the QMK Docs links for the build environment setup and the make instructions. Added links to the Newbs Guide.

----

Tagging @mechmerlin, with whom I spoke about these changes.