### PR TITLE
fix: split_common i2c slave backlight not disabled

### DIFF
--- a/quantum/split_common/transport.c
+++ b/quantum/split_common/transport.c
@@ -13,7 +13,6 @@
 
 #ifdef BACKLIGHT_ENABLE
 #  include "backlight.h"
-extern backlight_config_t backlight_config;
 #endif
 
 #ifdef ENCODER_ENABLE
@@ -55,7 +54,7 @@ bool transport_master(matrix_row_t matrix[]) {
 
   // write backlight info
 #  ifdef BACKLIGHT_ENABLE
-  uint8_t level = get_backlight_level();
+  uint8_t level = is_backlight_enabled() ? get_backlight_level() : 0;
   if (level != i2c_buffer->backlight_level) {
     if (i2c_writeReg(SLAVE_I2C_ADDRESS, I2C_BACKLIGHT_START, (void *)&level, sizeof(level), TIMEOUT) >= 0) {
       i2c_buffer->backlight_level = level;
@@ -223,7 +222,7 @@ bool transport_master(matrix_row_t matrix[]) {
 
 #  ifdef BACKLIGHT_ENABLE
   // Write backlight level for slave to read
-  serial_m2s_buffer.backlight_level = backlight_config.enable ? backlight_config.level : 0;
+  serial_m2s_buffer.backlight_level = is_backlight_enabled() ? get_backlight_level() : 0;
 #  endif
 
 #  ifdef ENCODER_ENABLE


### PR DESCRIPTION
slave side matrix scanning copied the matrix *twice* to the i2c slave
buffer... - though, for i2c one copy was put in the wrong offset.

The wrong i2c copy (offset 1) overwrote the unused RGBLIGHT part of the
buffer... and when using more than 5 columns per half also the original
matrix buffer.

removed code that does the unnecessary second copy.