### PR TITLE
Revert "Instruct macos users to use avr-gcc@7 (#3337)"

### DIFF
--- a/docs/faq_build.md
+++ b/docs/faq_build.md
@@ -104,17 +104,3 @@ brew install dfu-programmer
 brew install gcc-arm-none-eabi
 brew install avrdude
 ```
-
-### avr-gcc 8.1 and LUFA
-
-If you updated your avr-gcc to above 7 you may see errors involving LUFA. For example:
-
-`lib/lufa/LUFA/Drivers/USB/Class/Device/AudioClassDevice.h:380:5: error: 'const' attribute on function returning 'void'`
-
-For now, you need to rollback avr-gcc to 7 in brew.
-
-```
-brew uninstall --force avr-gcc
-brew install avr-gcc@7
-brew link avr-gcc@7
-```

--- a/docs/getting_started_build_tools.md
+++ b/docs/getting_started_build_tools.md
@@ -56,7 +56,7 @@ If you're using [homebrew,](http://brew.sh/) you can use the following commands:
     brew tap osx-cross/avr
     brew tap PX4/homebrew-px4
     brew update
-    brew install avr-gcc@7
+    brew install avr-gcc
     brew install dfu-programmer
     brew install gcc-arm-none-eabi
     brew install avrdude

--- a/util/macos_install.sh
+++ b/util/macos_install.sh
@@ -22,4 +22,4 @@ fi
 brew tap osx-cross/avr
 brew tap PX4/homebrew-px4
 brew update
-brew install avr-gcc@7 gcc-arm-none-eabi dfu-programmer avrdude
+brew install avr-gcc gcc-arm-none-eabi dfu-programmer avrdude


### PR DESCRIPTION
Thanks to #3510, we don't have to pin `avr-gcc` to 7 now!

This reverts commit 0d5a8b048a62aebdf5a699cae367dc0dd063d4e7.