### PR TITLE
Keep pressed keys on layer state change (fixes #2053, #2279)

### DIFF
--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -891,6 +891,10 @@ void clear_keyboard_but_mods(void)
     clear_keyboard_but_mods_and_keys();
 }
 
+/** \brief Utilities for actions. (FIXME: Needs better description)
+ *
+ * FIXME: Needs documentation.
+ */
 void clear_keyboard_but_mods_and_keys()
 {
     clear_weak_mods();

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -887,9 +887,14 @@ void clear_keyboard(void)
  */
 void clear_keyboard_but_mods(void)
 {
+    clear_keys();
+    clear_keyboard_but_mods_and_keys();
+}
+
+void clear_keyboard_but_mods_and_keys()
+{
     clear_weak_mods();
     clear_macro_mods();
-    clear_keys();
     send_keyboard_report();
 #ifdef MOUSEKEY_ENABLE
     mousekey_clear();

--- a/tmk_core/common/action.h
+++ b/tmk_core/common/action.h
@@ -94,6 +94,7 @@ void unregister_mods(uint8_t mods);
 //void set_mods(uint8_t mods);
 void clear_keyboard(void);
 void clear_keyboard_but_mods(void);
+void clear_keyboard_but_mods_and_keys(void);
 void layer_switch(uint8_t new_layer);
 bool is_tap_key(keypos_t key);
 

--- a/tmk_core/common/action_layer.c
+++ b/tmk_core/common/action_layer.c
@@ -44,7 +44,7 @@ static void default_layer_state_set(uint32_t state)
     default_layer_debug(); debug(" to ");
     default_layer_state = state;
     default_layer_debug(); debug("\n");
-    clear_keyboard_but_mods(); // To avoid stuck keys
+    clear_keyboard_but_mods_and_keys(); // To avoid stuck keys
 }
 
 /** \brief Default Layer Print
@@ -127,7 +127,7 @@ void layer_state_set(uint32_t state)
     layer_debug(); dprint(" to ");
     layer_state = state;
     layer_debug(); dprintln();
-    clear_keyboard_but_mods(); // To avoid stuck keys
+    clear_keyboard_but_mods_and_keys(); // To avoid stuck keys
 }
 
 /** \brief Layer clear

--- a/tmk_core/common/action_layer.c
+++ b/tmk_core/common/action_layer.c
@@ -44,11 +44,10 @@ static void default_layer_state_set(uint32_t state)
     default_layer_debug(); debug(" to ");
     default_layer_state = state;
     default_layer_debug(); debug("\n");
-    // Clear keyboard to avoid stuck keys
-#ifdef PREVENT_STUCK_MODIFIERS
-    clear_keyboard_but_mods_and_keys(); // Prevent held keys from being reset
+#ifdef STRICT_LAYER_RELEASE
+    clear_keyboard_but_mods(); // To avoid stuck keys
 #else
-    clear_keyboard_but_mods();
+    clear_keyboard_but_mods_and_keys(); // Don't reset held keys
 #endif
 }
 
@@ -132,11 +131,10 @@ void layer_state_set(uint32_t state)
     layer_debug(); dprint(" to ");
     layer_state = state;
     layer_debug(); dprintln();
-    // Clear keyboard to avoid stuck keys
-#ifdef PREVENT_STUCK_MODIFIERS
-    clear_keyboard_but_mods_and_keys(); // Prevent held keys from being reset
+#ifdef STRICT_LAYER_RELEASE
+    clear_keyboard_but_mods(); // To avoid stuck keys
 #else
-    clear_keyboard_but_mods();
+    clear_keyboard_but_mods_and_keys(); // Don't reset held keys
 #endif
 }
 

--- a/tmk_core/common/action_layer.c
+++ b/tmk_core/common/action_layer.c
@@ -44,7 +44,12 @@ static void default_layer_state_set(uint32_t state)
     default_layer_debug(); debug(" to ");
     default_layer_state = state;
     default_layer_debug(); debug("\n");
-    clear_keyboard_but_mods_and_keys(); // To avoid stuck keys
+    // Clear keyboard to avoid stuck keys
+#ifdef PREVENT_STUCK_MODIFIERS
+    clear_keyboard_but_mods_and_keys(); // Prevent held keys from being reset
+#else
+    clear_keyboard_but_mods();
+#endif
 }
 
 /** \brief Default Layer Print
@@ -127,7 +132,12 @@ void layer_state_set(uint32_t state)
     layer_debug(); dprint(" to ");
     layer_state = state;
     layer_debug(); dprintln();
-    clear_keyboard_but_mods_and_keys(); // To avoid stuck keys
+    // Clear keyboard to avoid stuck keys
+#ifdef PREVENT_STUCK_MODIFIERS
+    clear_keyboard_but_mods_and_keys(); // Prevent held keys from being reset
+#else
+    clear_keyboard_but_mods();
+#endif
 }
 
 /** \brief Layer clear


### PR DESCRIPTION
This allows pressed keys to stay pressed when a layer change occurs.

Say you're playing a game and you're holding W to run forward. You need to access a menu or skill that's bound to F4. You have that set on a momentary layer, so you try pressing Fn+4 — but as soon as you press Fn, QMK resets the W key and you stop moving forward, even though you're still holding the key.
For a visual explanation of the issue, see [this video](https://youtu.be/O4AKOX7F5SA?t=4h30m34s).

This fixes the problem by not resetting held keys when the layer state changes. It relies on the _prevent stuck modifiers_ implementation keeping track of which key was pressed on which layer and resetting them accordingly so that no keys end up stuck. As a consequence, it's disabled when `STRICT_LAYER_RELEASE` is defined, for backwards compatibility reasons.

I've tested this using every combination of pressing/releasing keys, mods and layers I could think of, and I haven't been able to find any issues (keys getting stuck or similar). I've also made sure that it doesn't affect the existing behavior of `clear_keyboard_but_mods` or the behavior of `layer_state_set` when `STRICT_LAYER_RELEASE` is enabled.

This fixes #2053, and fixes #2279.