### PR TITLE
docs/contributing: add `#pragma once` to Coding Conventions

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -70,6 +70,7 @@ Most of our style is pretty easy to pick up on, but right now it's not entirely 
   * Do not write obvious comments
   * If you not sure if a comment is obvious, go ahead and include it.
 * In general we don't wrap lines, they can be as long as needed. If you do choose to wrap lines please do not wrap any wider than 76 columns.
+* We use `#pragma once` at the start of header files rather than old-style include guards (`#ifndef THIS_FILE_H`, `#define THIS_FILE_H`, ..., `#endif`)
 
 # General Guidelines
 


### PR DESCRIPTION
This supersedes the older include guard mechanism since all the
compilers now support it. It's easier for new users and less prone
to error.