### PR TITLE
rgb_matrix: allow indicators to operate when RGB toggle is off

### DIFF
--- a/quantum/rgb_matrix.c
+++ b/quantum/rgb_matrix.c
@@ -600,7 +600,8 @@ void rgb_matrix_custom(void) {
 void rgb_matrix_task(void) {
     static uint8_t toggle_enable_last = 255;
 	if (!rgb_matrix_config.enable) {
-    	rgb_matrix_all_off();
+        rgb_matrix_all_off();
+        rgb_matrix_indicators();
         toggle_enable_last = rgb_matrix_config.enable;
     	return;
     }


### PR DESCRIPTION
Previously `rgb_matrix_task` overwrote the entire matrix state with black on every iteration when the RGB toggle is off. This makes it impossible for user code to use the matrix for indication.

This patch makes it so the task zeroes the LED state once when the toggle is turned off, but not after that. That way, user code can continue to override values if it so chooses.
It can't do it in `rgb_matrix_indicators_[kb|user]`, though, because those then don't get called. Should they?

This is particularly useful on the Model01 which has no other LEDs, the RGB matrix is the only way to indicate.