### PR TITLE
Pin avr-gcc in shell.nix pending release of 8.3.0

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -13,6 +13,13 @@ let
     "-B${avrlibc}/avr/lib/avr51"
     "-L${avrlibc}/avr/lib/avr51"
   ];
+  avrgcc = pkgs.avrgcc.overrideAttrs (oldAttrs: rec {
+    name = "avr-gcc-8.1.0";
+    src = fetchurl {
+      url = "mirror://gcc/releases/gcc-8.1.0/gcc-8.1.0.tar.xz";
+      sha256 = "0lxil8x0jjx7zbf90cy1rli650akaa6hpk8wk8s62vk2jbwnc60x";
+    };
+  });
 in
 
 stdenv.mkDerivation {

--- a/util/linux_install.sh
+++ b/util/linux_install.sh
@@ -10,7 +10,9 @@ elif grep ID /etc/os-release | grep -q debian; then
 	    dfu-programmer dfu-util gcc-arm-none-eabi binutils-arm-none-eabi \
 	    libnewlib-arm-none-eabi
 elif grep ID /etc/os-release | grep -q 'arch\|manjaro'; then
-	sudo pacman -S gcc unzip wget zip avr-gcc avr-binutils avr-libc \
+  # install avr-gcc 8.1 until 8.3 is available. See #3657 for details of the bug.
+  sudo pacman -U https://archive.archlinux.org/packages/a/avr-gcc/avr-gcc-8.1.0-1-x86_64.pkg.tar.xz
+	sudo pacman -S gcc unzip wget zip avr-binutils avr-libc \
 	    dfu-util arm-none-eabi-gcc arm-none-eabi-binutils \
 	    arm-none-eabi-newlib
 	git clone https://aur.archlinux.org/dfu-programmer.git /tmp/dfu-programmer


### PR DESCRIPTION
There's apparently a critical bug in 8.2.0, which is now the nixpkgs default. This change overrides that default in favor of the known good version. Once 8.3.0 is the default, the override can be dropped.