### PR TITLE
Remove redefinition of `_______` in documentation example

### DIFF
--- a/docs/keymap.md
+++ b/docs/keymap.md
@@ -93,7 +93,6 @@ At the top of the file you'll find this:
 
     // Helpful defines
     #define GRAVE_MODS  (MOD_BIT(KC_LSHIFT)|MOD_BIT(KC_RSHIFT)|MOD_BIT(KC_LGUI)|MOD_BIT(KC_RGUI)|MOD_BIT(KC_LALT)|MOD_BIT(KC_RALT))
-    #define _______ KC_TRNS
 
     // Each layer gets a name for readability.
     // The underscores don't mean anything - you can
@@ -105,7 +104,7 @@ At the top of the file you'll find this:
     #define _FL 1
     #define _CL 2
 
-These are some handy definitions we can use when building our keymap and our custom function. The `GRAVE_MODS` definition will be used later in our custom function. The `_______` define makes it easier to see what keys a layer is overriding, while the `_BL`, `_FL`, and `_CL` defines make it easier to refer to each of our layers.
+These are some handy definitions we can use when building our keymap and our custom function. The `GRAVE_MODS` definition will be used later in our custom function, and the following `_BL`, `_FL`, and `_CL` defines make it easier to refer to each of our layers.
 
 ### Layers and Keymaps
 

--- a/docs/keymap.md
+++ b/docs/keymap.md
@@ -89,7 +89,7 @@ There are 3 main sections of a `keymap.c` file you'll want to concern yourself w
 
 At the top of the file you'll find this:
 
-    #include "clueboard.h"
+    #include QMK_KEYBOARD_H
 
     // Helpful defines
     #define GRAVE_MODS  (MOD_BIT(KC_LSHIFT)|MOD_BIT(KC_RSHIFT)|MOD_BIT(KC_LGUI)|MOD_BIT(KC_RGUI)|MOD_BIT(KC_LALT)|MOD_BIT(KC_RALT))

--- a/docs/keymap.md
+++ b/docs/keymap.md
@@ -94,6 +94,11 @@ At the top of the file you'll find this:
     // Helpful defines
     #define GRAVE_MODS  (MOD_BIT(KC_LSHIFT)|MOD_BIT(KC_RSHIFT)|MOD_BIT(KC_LGUI)|MOD_BIT(KC_RGUI)|MOD_BIT(KC_LALT)|MOD_BIT(KC_RALT))
 
+    /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * 
+     *  You can use _______ in place for KC_TRNS (transparent)   *
+     *  Or you can use XXXXXXX for KC_NO (NOOP)                  *
+     * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
     // Each layer gets a name for readability.
     // The underscores don't mean anything - you can
     // have a layer called STUFF or any other name.
@@ -105,6 +110,8 @@ At the top of the file you'll find this:
     #define _CL 2
 
 These are some handy definitions we can use when building our keymap and our custom function. The `GRAVE_MODS` definition will be used later in our custom function, and the following `_BL`, `_FL`, and `_CL` defines make it easier to refer to each of our layers.
+
+Note: You may also find some older keymap files may also have a define(s) for `_______` and/or `XXXXXXX`. These can be used in place for `KC_TRNS` and `KC_NO` respectively, making it easier to see what keys a layer is overriding. These definitions are now unecessary, as they are included by default.
 
 ### Layers and Keymaps
 


### PR DESCRIPTION
After [being caught out](https://github.com/qmk/qmk_firmware/pull/3908#discussion_r217840949) I thought it might be useful to edit the keymaps documentation to remove the redefinition of the alias of `KC_TRNS`; `_______` in the Definitions section of "Anatomy of a keymap.c".

I've put a suggested rewording for the following paragraph to remove the mention of this, and looked through and not spotted any other mentions of this. That being said, I am newer to this project, so if there are any other suggested updates/rewording suggestions then please feel free to comment.

I've also spotted that there are notes about the included `_______` definition above (and below) in the documentation file so did not add any other note to the section in which it was removed.