### PR TITLE
[WIP] Unicode improvements: cycling through input modes, no-EEPROM functions, documentation

### DIFF
--- a/quantum/process_keycode/process_unicode_common.c
+++ b/quantum/process_keycode/process_unicode_common.c
@@ -35,6 +35,7 @@ uint8_t get_unicode_input_mode(void) {
 }
 
 void set_unicode_input_mode(uint8_t mode) {
+  dprintf("Unicode input mode: %u\n", mode);
   input_mode = mode;
   eeprom_update_byte(EECONFIG_UNICODEMODE, mode);
 }

--- a/quantum/process_keycode/process_unicode_common.c
+++ b/quantum/process_keycode/process_unicode_common.c
@@ -22,15 +22,6 @@
 static uint8_t input_mode;
 uint8_t mods;
 
-void set_unicode_input_mode(uint8_t os_target) {
-  input_mode = os_target;
-  eeprom_update_byte(EECONFIG_UNICODEMODE, os_target);
-}
-
-uint8_t get_unicode_input_mode(void) {
-  return input_mode;
-}
-
 void unicode_input_mode_init(void) {
   static bool first_flag = false;
   if (!first_flag) {
@@ -39,8 +30,17 @@ void unicode_input_mode_init(void) {
   }
 }
 
+uint8_t get_unicode_input_mode(void) {
+  return input_mode;
+}
+
+void set_unicode_input_mode(uint8_t mode) {
+  input_mode = mode;
+  eeprom_update_byte(EECONFIG_UNICODEMODE, mode);
+}
+
 __attribute__((weak))
-void unicode_input_start (void) {
+void unicode_input_start(void) {
   // save current mods
   mods = keyboard_report->mods;
 
@@ -84,7 +84,7 @@ void unicode_input_start (void) {
 }
 
 __attribute__((weak))
-void unicode_input_finish (void) {
+void unicode_input_finish(void) {
   switch(input_mode) {
     case UC_OSX:
     case UC_WIN:

--- a/quantum/process_keycode/process_unicode_common.c
+++ b/quantum/process_keycode/process_unicode_common.c
@@ -39,6 +39,13 @@ void set_unicode_input_mode(uint8_t mode) {
   eeprom_update_byte(EECONFIG_UNICODEMODE, mode);
 }
 
+void cycle_unicode_input_mode(void)
+{
+  do {
+    input_mode = (input_mode + 1) % UC__COUNT;
+  } while (!(UC_CYCLE_MODES & 1<<input_mode)); // Skip modes that aren't selected
+}
+
 __attribute__((weak))
 void unicode_input_start(void) {
   // save current mods

--- a/quantum/process_keycode/process_unicode_common.h
+++ b/quantum/process_keycode/process_unicode_common.h
@@ -23,12 +23,9 @@
 #define UNICODE_TYPE_DELAY 10
 #endif
 
-__attribute__ ((unused))
-static uint8_t input_mode;
-
-void set_unicode_input_mode(uint8_t os_target);
-uint8_t get_unicode_input_mode(void);
 void unicode_input_mode_init(void);
+uint8_t get_unicode_input_mode(void);
+void set_unicode_input_mode(uint8_t mode);
 void unicode_input_start(void);
 void unicode_input_finish(void);
 void register_hex(uint16_t hex);

--- a/quantum/process_keycode/process_unicode_common.h
+++ b/quantum/process_keycode/process_unicode_common.h
@@ -60,10 +60,9 @@ enum unicode_input_modes {
 // Example: UC_MODES(UC_OSX, UC_LNX, UC_WINC) → 00010011 (0x13)
 #define UC_MODES(...) UC_M_HELPER(NUM_ARGS(__VA_ARGS__), __VA_ARGS__)
 
-// Bitmask selecting which Unicode modes can be cycled through
-// Example usage: #define UC_CYCLE_MODES UC_MODES(UC_OSX, UC_LNX, UC_WINC)
+// Bitmask that selects which Unicode modes can be cycled through
 #if !defined(UC_CYCLE_MODES) || UC_CYCLE_MODES == 0
-#define UC_CYCLE_MODES ((1<<UC__COUNT) - 1) // Default: all modes
+#define UC_CYCLE_MODES UC_MODES(UC_OSX, UC_LNX, UC_WINC) // Default: OS X, Linux, WinCompose
 #endif
 
 #define UC_BSPC	UC(0x0008)

--- a/quantum/process_keycode/process_unicode_common.h
+++ b/quantum/process_keycode/process_unicode_common.h
@@ -26,6 +26,7 @@
 void unicode_input_mode_init(void);
 uint8_t get_unicode_input_mode(void);
 void set_unicode_input_mode(uint8_t mode);
+void cycle_unicode_input_mode(void)
 void unicode_input_start(void);
 void unicode_input_finish(void);
 void register_hex(uint16_t hex);
@@ -37,6 +38,31 @@ void send_unicode_hex_string(const char *str);
 #define UC_BSD 3  // BSD (not implemented)
 #define UC_WINC 4 // WinCompose https://github.com/samhocevar/wincompose
 #define UC_OSX_RALT 5 // Mac OS X using Right Alt key for Unicode Compose
+#define UC__COUNT 6 // Number of available input modes
+
+// Helper macros for UC_MODES
+#define UC_M_1(m)      1<<(m)
+#define UC_M_2(m, ...) 1<<(m) | UC_M_1(__VA_ARGS__)
+#define UC_M_3(m, ...) 1<<(m) | UC_M_2(__VA_ARGS__)
+#define UC_M_4(m, ...) 1<<(m) | UC_M_3(__VA_ARGS__)
+#define UC_M_5(m, ...) 1<<(m) | UC_M_4(__VA_ARGS__)
+#define UC_M_6(m, ...) 1<<(m) | UC_M_5(__VA_ARGS__)
+#define UC_M_7(m, ...) 1<<(m) | UC_M_6(__VA_ARGS__)
+#define UC_M_8(m, ...) 1<<(m) | UC_M_7(__VA_ARGS__)
+#define _NUM_ARGS(_8, _7, _6, _5, _4, _3, _2, _1, n, ...) n
+#define NUM_ARGS(...) _NUM_ARGS(__VA_ARGS__, 8, 7, 6, 5, 4, 3, 2, 1, 0)
+#define _UC_M_HELPER(n, ...) UC_M_ ## n(__VA_ARGS__)
+#define UC_M_HELPER(n, ...) (_UC_M_HELPER(n, __VA_ARGS__))
+
+// Turns a list of Unicode input modes into a bitmask
+// Example: UC_MODES(UC_OSX, UC_LNX, UC_WINC) → 00010011 (0x13)
+#define UC_MODES(...) UC_M_HELPER(NUM_ARGS(__VA_ARGS__), __VA_ARGS__)
+
+// Bitmask selecting which Unicode modes can be cycled through
+// Example usage: #define UC_CYCLE_MODES UC_MODES(UC_OSX, UC_LNX, UC_WINC)
+#ifndef UC_CYCLE_MODES
+#define UC_CYCLE_MODES ((1<<UC__COUNT) - 1) // Default: all modes
+#endif
 
 #define UC_BSPC	UC(0x0008)
 

--- a/quantum/process_keycode/process_unicode_common.h
+++ b/quantum/process_keycode/process_unicode_common.h
@@ -62,7 +62,7 @@ enum unicode_input_modes {
 
 // Bitmask selecting which Unicode modes can be cycled through
 // Example usage: #define UC_CYCLE_MODES UC_MODES(UC_OSX, UC_LNX, UC_WINC)
-#ifndef UC_CYCLE_MODES
+#if !defined(UC_CYCLE_MODES) || UC_CYCLE_MODES == 0
 #define UC_CYCLE_MODES ((1<<UC__COUNT) - 1) // Default: all modes
 #endif
 

--- a/quantum/process_keycode/process_unicode_common.h
+++ b/quantum/process_keycode/process_unicode_common.h
@@ -32,13 +32,15 @@ void unicode_input_finish(void);
 void register_hex(uint16_t hex);
 void send_unicode_hex_string(const char *str);
 
-#define UC_OSX 0  // Mac OS X
-#define UC_LNX 1  // Linux
-#define UC_WIN 2  // Windows 'HexNumpad'
-#define UC_BSD 3  // BSD (not implemented)
-#define UC_WINC 4 // WinCompose https://github.com/samhocevar/wincompose
-#define UC_OSX_RALT 5 // Mac OS X using Right Alt key for Unicode Compose
-#define UC__COUNT 6 // Number of available input modes
+enum unicode_input_modes {
+  UC_OSX,      // Mac OS X using Option
+  UC_LNX,      // Linux using ibus
+  UC_WIN,      // Windows using HexNumpad
+  UC_BSD,      // BSD (not implemented)
+  UC_WINC,     // Windows using WinCompose (https://github.com/samhocevar/wincompose)
+  UC_OSX_RALT, // Mac OS X using right Option (Compose)
+  UC__COUNT    // Number of available input modes (always keep at bottom)
+};
 
 // Helper macros for UC_MODES
 #define UC_M_1(m)      1<<(m)


### PR DESCRIPTION
**Added:**

- `set_unicode_input_mode_noeeprom` for setting the input mode without writing to EEPROM.
- `persist_unicode_input_mode` for explicitly storing the current input mode to EEPROM.
- `cycle_unicode_input_mode` for cycling through desired input modes. Input modes can be selected by defining `UC_CYCLE_MODES` (OS X, Linux and WinCompose by default).

**Changed:**

- Unicode input mode constants (`UC_OSX`, `UC_LNX`, `UC_WINC` etc.) are now an enum instead of preprocessor constants.
- Revised and improved the Unicode documentation.

**To-do:**
- [ ] Update docs.
- [x] Add debug printing to the cycle function.