### PR TITLE
Add ISO-NOR keymap for TADA68

### DIFF
--- a/keyboards/tada68/keymaps/iso-nor/config.h
+++ b/keyboards/tada68/keymaps/iso-nor/config.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/keyboards/tada68/keymaps/iso-nor/keymap.c
+++ b/keyboards/tada68/keymaps/iso-nor/keymap.c
@@ -1,0 +1,51 @@
+#include QMK_KEYBOARD_H
+
+#define _BL 0
+#define _FL 1
+
+#define _______ KC_TRNS
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  /* Keymap _BL: (Base Layer) Default Layer
+   * ,----------------------------------------------------------------.
+   * |Esc | 1|  2|  3|  4|  5|  6|  7|  8|  9|  0|  +|  '|Backspa |  ´|
+   * |----------------------------------------------------------------|
+   * |Tab  |  Q|  W|  E|  R|  T|  Y|  U|  I|  O|  P|  Å|  ¨| Ent-|Del |
+   * |-------------------------------------------------------| er|----|
+   * |CAPS   |  A|  S|  D|  F|  G|  H|  J|  K|  L|  Ø|  Æ| @ |   |PgUp|
+   * |----------------------------------------------------------------|
+   * |Shif| <>|  Z|  X|  C|  V|  B|  N|  M|  ,|  .|  -| Shift| Up|PgDn|
+   * |----------------------------------------------------------------|
+   * |Ctrl|Alt |Cmd |        Space          |Alt| FN|Ctrl|Lef|Dow|Rig |
+   * `----------------------------------------------------------------'
+   */
+  [_BL] = LAYOUT_iso(
+    KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_GRV,  KC_BSPC, KC_EQL,  \
+    KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_NUHS, KC_DEL,  \
+    KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,          KC_ENT,  KC_PGUP, \
+    KC_LSFT, KC_NUBS, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT, KC_UP,   KC_PGDN, \
+    KC_LCTL, KC_LGUI, KC_LALT,                   KC_SPC,                             KC_RALT, MO(_FL), KC_RCTL, KC_LEFT, KC_DOWN, KC_RGHT
+  ),
+
+  /* Keymap _FL1: Function Layer
+   * ,----------------------------------------------------------------.
+   * |   | F1| F2| F3| F4| F5| F6| F7| F8| F9|F10|F11|F12|  RESET|PSCR|
+   * |----------------------------------------------------------------|
+   * |     |   | Up|   |   |   |   |   |   |   |   |BL-|BL+|BL   | INS|
+   * |----------------------------------------------------------------|
+   * |      |Lef|Dow|Rig|   |   |   |   |   | PP|PLA| PN|    |   |HOME|
+   * |----------------------------------------------------------------|
+   * |    |   |   |   |   |   |   |   |   |  V-| MV| V+|     |   | END|
+   * |----------------------------------------------------------------|
+   * |    |    |    |                       |   |   |    |   |   |    |
+   * `----------------------------------------------------------------'
+   */
+  [_FL] = LAYOUT_iso(
+    _______, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  RESET,   KC_PSCR, \
+    _______, _______,   KC_UP, _______, _______, _______, _______, _______, _______, _______, _______, BL_DEC,  BL_INC,  BL_TOGG, KC_INS,  \
+    _______, KC_LEFT, KC_DOWN,KC_RIGHT, _______, _______, _______, _______, _______, KC_MPRV, KC_MPLY, KC_MNXT, _______, _______, KC_HOME, \
+    _______,          _______, _______, _______, _______, _______, _______, _______, KC_VOLD, KC_MUTE, KC_VOLU, _______, _______, KC_END,  \
+    _______, _______, _______,                   _______,                            _______, _______, _______, _______, _______, _______
+  ),
+
+};

--- a/keyboards/tada68/keymaps/iso-nor/readme.md
+++ b/keyboards/tada68/keymaps/iso-nor/readme.md
@@ -1,0 +1,17 @@
+# TADA68 layout for ISO-NOR
+
+> An ISO-style layout for Norwegian keyboards.
+
+This layout was specifically made for Norwegian keyboards (i.e. includes `Æ`, `Ø` and `Å`), and is tested on a TADA68 purchased from [kbdfans](https://kbdfans.cn/) in September 2018.
+
+### Specifics
+
+As it's an ISO style keymap, it works with the fat double-row `Enter` key and the narrower left `Shift` and `<>` key. In addition, it switches the `'` key and the `´` key since the latter one is less common in Norwegian, and the first one normally is placed where the `Escape` key is located on a TADA68.
+
+## Installation
+
+Please see the [tada68 readme](../../readme.md) using the following command
+
+```
+make tada68:iso-nor:bin
+```

--- a/keyboards/tada68/keymaps/iso-nor/rules.mk
+++ b/keyboards/tada68/keymaps/iso-nor/rules.mk
@@ -1,0 +1,21 @@
+# Build Options
+#   change to "no" to disable the options, or define them in the Makefile in 
+#   the appropriate keymap folder that will get included automatically
+#
+BOOTMAGIC_ENABLE = no       # Virtual DIP switch configuration(+1000)
+MOUSEKEY_ENABLE = yes       # Mouse keys(+4700)
+EXTRAKEY_ENABLE = yes       # Audio control and System control(+450)
+CONSOLE_ENABLE = no         # Console for debug(+400)
+COMMAND_ENABLE = yes        # Commands for debug and configuration
+NKRO_ENABLE = yes           # Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+BACKLIGHT_ENABLE = yes       # Enable keyboard backlight functionality
+MIDI_ENABLE = no            # MIDI controls
+AUDIO_ENABLE = no           # Audio output on port C6
+UNICODE_ENABLE = no         # Unicode
+BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
+RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight.  Do not enable this with audio at the same time.
+SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
+
+ifndef QUANTUM_DIR
+	include ../../../../Makefile
+endif


### PR DESCRIPTION
Adds a new ISO style keymap layout for TADA68s, tailored for Norwegian keyboards (i.e. including `Æ`, `Ø` and `Å`).

Works with the button between the `LSFT` and `Z` (set to `<>`). Also switches the `'` key and the `´` key, since the latter one is less common in Norwegian.