### PR TITLE
Improved dynamic keymaps

### DIFF
--- a/keyboards/zeal60/zeal60.c
+++ b/keyboards/zeal60/zeal60.c
@@ -81,9 +81,9 @@ void raw_hid_receive( uint8_t *data, uint8_t length )
 			dynamic_keymap_set_keycode( command_data[0], command_data[1], command_data[2], ( command_data[3] << 8 ) | command_data[4] );
 			break;
 		}
-		case id_dynamic_keymap_clear_all:
+		case id_dynamic_keymap_reset:
 		{
-			dynamic_keymap_clear_all();
+			dynamic_keymap_reset();
 			break;
 		}
 #endif // DYNAMIC_KEYMAP_ENABLE
@@ -171,9 +171,8 @@ void matrix_init_kb(void)
 #endif // RGB_BACKLIGHT_ENABLED
 
 #ifdef DYNAMIC_KEYMAP_ENABLE
-		// This saves "empty" keymaps so it falls back to the keymaps
-		// in the firmware (aka. progmem/flash)
-		dynamic_keymap_clear_all();
+		// This resets the keymaps in EEPROM to what is in flash.
+		dynamic_keymap_reset();
 #endif
 
 		// Save the magic number last, in case saving was interrupted

--- a/keyboards/zeal60/zeal60_api.h
+++ b/keyboards/zeal60/zeal60_api.h
@@ -24,7 +24,7 @@ enum zeal60_command_id
 	id_set_keyboard_value,
 	id_dynamic_keymap_get_keycode,
 	id_dynamic_keymap_set_keycode,
-	id_dynamic_keymap_clear_all,
+	id_dynamic_keymap_reset,
 	id_backlight_config_set_value,
 	id_backlight_config_get_value,
 	id_backlight_config_save,

--- a/quantum/dynamic_keymap.c
+++ b/quantum/dynamic_keymap.c
@@ -16,6 +16,8 @@
 
 #include "config.h"
 #include "keymap.h" // to get keymaps[][][]
+#include "tmk_core/common/eeprom.h"
+#include "progmem.h"// to read default from flash
 
 #include "dynamic_keymap.h"
 
@@ -28,8 +30,6 @@
 #ifndef DYNAMIC_KEYMAP_LAYER_COUNT
 #error DYNAMIC_KEYMAP_LAYER_COUNT not defined
 #endif
-
-#define KC_EENULL 0xFFFF // TODO: move to enum quantum_keycodes
 
 void *dynamic_keymap_key_to_eeprom_address(uint8_t layer, uint8_t row, uint8_t column)
 {
@@ -55,16 +55,18 @@ void dynamic_keymap_set_keycode(uint8_t layer, uint8_t row, uint8_t column, uint
 	eeprom_update_byte(address+1, (uint8_t)(keycode & 0xFF));
 }
 
-void dynamic_keymap_clear_all(void)
+void dynamic_keymap_reset(void)
 {
-	// Save "empty" keymaps.
+	// Reset the keymaps in EEPROM to what is in flash.
+	// All keyboards using dynamic keymaps should define a layout
+	// for the same number of layers as DYNAMIC_KEYMAP_LAYER_COUNT.
 	for ( int layer = 0; layer < DYNAMIC_KEYMAP_LAYER_COUNT; layer++ )
 	{
 		for ( int row = 0; row < MATRIX_ROWS; row++ )
 		{
 			for ( int column = 0; column < MATRIX_COLS; column++ )
 			{
-				dynamic_keymap_set_keycode(layer, row, column, KC_EENULL);
+				dynamic_keymap_set_keycode(layer, row, column, pgm_read_word(&keymaps[layer][row][column]));
 			}
 		}
 	}
@@ -73,24 +75,16 @@ void dynamic_keymap_clear_all(void)
 // This overrides the one in quantum/keymap_common.c
 uint16_t keymap_key_to_keycode(uint8_t layer, keypos_t key)
 {
-	// This used to test EEPROM for magic bytes, but it was redundant.
-	// Test for EEPROM usage change (fresh install, address change, etc.)
-	// externally and call dynamic_keymap_default_save()
 	if ( layer < DYNAMIC_KEYMAP_LAYER_COUNT &&
 		 key.row < MATRIX_ROWS && // possibly redundant
 		 key.col < MATRIX_COLS ) // possibly redundant
 	{
-		uint16_t keycode = dynamic_keymap_get_keycode(layer, key.row, key.col);
-
-		// If keycode is not "empty", return it, otherwise
-		// drop down to return the one in flash
-		if ( keycode != KC_EENULL)
-		{
-			return keycode;
-		}
+		return dynamic_keymap_get_keycode(layer, key.row, key.col);
 	}
-
-	return pgm_read_word(&keymaps[layer][key.row][key.col]);
+	else
+	{
+		return KC_NO;
+	}
 }
 
 #endif // DYNAMIC_KEYMAP_ENABLE

--- a/quantum/dynamic_keymap.c
+++ b/quantum/dynamic_keymap.c
@@ -60,12 +60,9 @@ void dynamic_keymap_reset(void)
 	// Reset the keymaps in EEPROM to what is in flash.
 	// All keyboards using dynamic keymaps should define a layout
 	// for the same number of layers as DYNAMIC_KEYMAP_LAYER_COUNT.
-	for ( int layer = 0; layer < DYNAMIC_KEYMAP_LAYER_COUNT; layer++ )
-	{
-		for ( int row = 0; row < MATRIX_ROWS; row++ )
-		{
-			for ( int column = 0; column < MATRIX_COLS; column++ )
-			{
+	for ( int layer = 0; layer < DYNAMIC_KEYMAP_LAYER_COUNT; layer++ )	{
+		for ( int row = 0; row < MATRIX_ROWS; row++ ) {
+			for ( int column = 0; column < MATRIX_COLS; column++ )	{
 				dynamic_keymap_set_keycode(layer, row, column, pgm_read_word(&keymaps[layer][row][column]));
 			}
 		}
@@ -76,13 +73,10 @@ void dynamic_keymap_reset(void)
 uint16_t keymap_key_to_keycode(uint8_t layer, keypos_t key)
 {
 	if ( layer < DYNAMIC_KEYMAP_LAYER_COUNT &&
-		 key.row < MATRIX_ROWS && // possibly redundant
-		 key.col < MATRIX_COLS ) // possibly redundant
-	{
+			key.row < MATRIX_ROWS &&
+			key.col < MATRIX_COLS ) {
 		return dynamic_keymap_get_keycode(layer, key.row, key.col);
-	}
-	else
-	{
+	} else {
 		return KC_NO;
 	}
 }

--- a/quantum/dynamic_keymap.h
+++ b/quantum/dynamic_keymap.h
@@ -13,9 +13,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-#ifndef DYNAMIC_KEYMAP_H
-#define DYNAMIC_KEYMAP_H
+#pragma once
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -23,9 +21,8 @@
 void *dynamic_keymap_key_to_eeprom_address(uint8_t layer, uint8_t row, uint8_t column);
 uint16_t dynamic_keymap_get_keycode(uint8_t layer, uint8_t row, uint8_t column);
 void dynamic_keymap_set_keycode(uint8_t layer, uint8_t row, uint8_t column, uint16_t keycode);
-void dynamic_keymap_clear_all(void);
+void dynamic_keymap_reset(void);
 
 // This overrides the one in quantum/keymap_common.c
 // uint16_t keymap_key_to_keycode(uint8_t layer, keypos_t key);
 
-#endif //DYNAMIC_KEYMAP_H


### PR DESCRIPTION
I changed the behaviour of dynamic keymaps. Previously it would store 0xFFFF in EEPROM as an "empty" value, and getting a keycode would fall back to reading from flash if the value in EEPROM was 0xFFFF. Thus "clearing" the dynamic keymaps (i.e. resetting to whatever is in flash) would be a write of 0xFFFF to everything.

Now, a reset operation will load the keymap in flash (i.e. the "default" keymap) and store it in EEPROM. Since this happens on a fresh install (i.e. first time running new firmware), now the host (i.e. configurator) can read the default keymap for editing.
