### PR TITLE
Crkbd stands for Corne Keyboard, not helidox

### DIFF
--- a/keyboards/crkbd/info.json
+++ b/keyboards/crkbd/info.json
@@ -1,5 +1,5 @@
 {
-  "keyboard_name": "crkbd (helidox) rev. 1",
+  "keyboard_name": "crkbd rev. 1",
   "url": "",
   "maintainer": "qmk",
   "width": 15,


### PR DESCRIPTION
'helidox' is GB title by a third party.
Crkbd stands for Corne Keyboard.