### PR TITLE
add 'mavrdude' target into tmk_core/avr.mk

### DIFF
--- a/docs/flashing.md
+++ b/docs/flashing.md
@@ -82,6 +82,8 @@ or if you want to flash multiple boards, please do as follows.
 
     make <keyboard>:<keymap>:avrdude-loop
 
+When you're done flashing boards, you'll need to hit Ctrl + C or whatever the correct keystroke is for your operating system to break the loop.
+
 ## Halfkay
 
 Halfkay is a super-slim protocol developed by PJRC that uses HID, and come on all Teensys (namely the 2.0).

--- a/docs/flashing.md
+++ b/docs/flashing.md
@@ -78,7 +78,7 @@ or
 
     make <keyboard>:<keymap>:avrdude
 
-or if you want to flash multiple boards, please do as follows.
+or if you want to flash multiple boards, use the following command
 
     make <keyboard>:<keymap>:avrdude-loop
 

--- a/docs/flashing.md
+++ b/docs/flashing.md
@@ -78,6 +78,10 @@ or
 
     make <keyboard>:<keymap>:avrdude
 
+or if you want to flash multiple boards, please do as follows.
+
+    make <keyboard>:<keymap>:avrdude-loop
+
 ## Halfkay
 
 Halfkay is a super-slim protocol developed by PJRC that uses HID, and come on all Teensys (namely the 2.0).

--- a/tmk_core/avr.mk
+++ b/tmk_core/avr.mk
@@ -197,7 +197,7 @@ endef
 avrdude: $(BUILD_DIR)/$(TARGET).hex check-size cpfirmware
 	$(call EXEC_AVRDUDE)
 
-mavrdude: $(BUILD_DIR)/$(TARGET).hex check-size cpfirmware
+avrdude-loop: $(BUILD_DIR)/$(TARGET).hex check-size cpfirmware
 	while true; do \
 	    $(call EXEC_AVRDUDE) ; \
 	done

--- a/tmk_core/avr.mk
+++ b/tmk_core/avr.mk
@@ -169,7 +169,8 @@ dfu-ee: $(BUILD_DIR)/$(TARGET).hex $(BUILD_DIR)/$(TARGET).eep
 	fi
 	$(DFU_PROGRAMMER) $(MCU) reset
 
-avrdude: $(BUILD_DIR)/$(TARGET).hex check-size cpfirmware
+define EXEC_AVRDUDE
+	USB= ;\
 	if $(GREP) -q -s Microsoft /proc/version; then \
 		echo 'ERROR: AVR flashing cannot be automated within the Windows Subsystem for Linux (WSL) currently. Instead, take the .hex file generated and flash it using AVRDUDE, AVRDUDESS, or XLoader.'; \
 	else \
@@ -191,6 +192,15 @@ avrdude: $(BUILD_DIR)/$(TARGET).hex check-size cpfirmware
 		sleep 1; \
 		avrdude -p $(MCU) -c avr109 -P $$USB -U flash:w:$(BUILD_DIR)/$(TARGET).hex; \
 	fi
+endef
+
+avrdude: $(BUILD_DIR)/$(TARGET).hex check-size cpfirmware
+	$(call EXEC_AVRDUDE)
+
+mavrdude: $(BUILD_DIR)/$(TARGET).hex check-size cpfirmware
+	while true; do \
+	    $(call EXEC_AVRDUDE) ; \
+	done
 
 # Convert hex to bin.
 bin: $(BUILD_DIR)/$(TARGET).hex


### PR DESCRIPTION
I made it a little convenient when writing the same binary to multiple Pro Micro.