### PR TITLE
Disable Mouse Keys to reduce Vitamins Included firmware size

### DIFF
--- a/keyboards/vitamins_included/config.h
+++ b/keyboards/vitamins_included/config.h
@@ -23,5 +23,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define NO_ACTION_MACRO
 #define NO_ACTION_FUNCTION
 
-#define DISABLE_LEADER
+
 

--- a/keyboards/vitamins_included/rules.mk
+++ b/keyboards/vitamins_included/rules.mk
@@ -53,7 +53,7 @@ OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
 #   the appropriate keymap folder that will get included automatically
 #
 BOOTMAGIC_ENABLE = no       # Virtual DIP switch configuration(+1000)
-MOUSEKEY_ENABLE = yes       # Mouse keys(+4700)
+MOUSEKEY_ENABLE = no       # Mouse keys(+4700)
 EXTRAKEY_ENABLE = yes       # Audio control and System control(+450)
 CONSOLE_ENABLE = no         # Console for debug(+400)
 COMMAND_ENABLE = no        # Commands for debug and configuration


### PR DESCRIPTION
This one fails Travis, but that's because of bakingpy's keymap using LAYOUT_kc,  my keymap not having a uint for the timer due to a merge issue, talljoe's being 16 bytes too large,  and wanleg's having SWAP HANDS enabled, but this board not supporting it. 

Otherwise, the default keymap passes. 