### PR TITLE
Fix RGB Matrix feature processing in common_features.mk

### DIFF
--- a/common_features.mk
+++ b/common_features.mk
@@ -115,7 +115,7 @@ ifeq ($(strip $(RGBLIGHT_ENABLE)), yes)
 endif
 
 RGB_MATRIX_ENABLE ?= no
-VALID_MATRIX_TYPES := yes IS31FL3731L IS31FL3733L custom
+VALID_MATRIX_TYPES := yes IS31FL3731 IS31FL3733 custom
 ifneq ($(strip $(RGB_MATRIX_ENABLE)), no)
 ifeq ($(filter $(RGB_MATRIX_ENABLE),$(VALID_MATRIX_TYPES)),)
     $(error RGB_MATRIX_ENABLE="$(RGB_MATRIX_ENABLE)" is not a valid matrix type)


### PR DESCRIPTION
Specifically, an "L" got appended to the controller names for the "valid types",
but did not get appended to the blocks that include the specific drives.
So, this breaks anything that isn't "Yes".