### PR TITLE
Helix led_test keymap reduce size

### DIFF
--- a/keyboards/helix/config.h
+++ b/keyboards/helix/config.h
@@ -48,4 +48,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   #define DISABLE_LEADER
 #endif // USE_Link_Time_Optimization
 
+#if defined(LED_ANIMATIONS) || defined(RGBLIGHT_ANIMATIONS)
+   #undef RGBLIGHT_ANIMATIONS
+   #define RGBLIGHT_EFFECT_BREATHING
+   #define RGBLIGHT_EFFECT_RAINBOW_MOOD
+   #define RGBLIGHT_EFFECT_RAINBOW_SWIRL
+   #define RGBLIGHT_EFFECT_SNAKE
+   #define RGBLIGHT_EFFECT_KNIGHT
+   #define RGBLIGHT_EFFECT_CHRISTMAS
+   #define RGBLIGHT_EFFECT_STATIC_GRADIENT
+   #define RGBLIGHT_EFFECT_RGB_TEST
+   #define RGBLIGHT_EFFECT_ALTERNATING
+#endif
+
 #endif /* CONFIG_H */

--- a/keyboards/helix/rev2/keymaps/default/keymap.c
+++ b/keyboards/helix/rev2/keymaps/default/keymap.c
@@ -512,7 +512,7 @@ void music_scale_user(void)
 
 // hook point for 'led_test' keymap
 //   'default' keymap's led_test_init() is empty function, do nothing
-//   'led_test' keymap's led_test_init() force rgblight_mode_noeeprom(35);
+//   'led_test' keymap's led_test_init() force rgblight_mode_noeeprom(RGBLIGHT_MODE_RGB_TEST);
 __attribute__ ((weak))
 void led_test_init(void) {}
 

--- a/keyboards/helix/rev2/keymaps/led_test/config.h
+++ b/keyboards/helix/rev2/keymaps/led_test/config.h
@@ -21,9 +21,19 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef CONFIG_USER_H
 #define CONFIG_USER_H
 
-// if you need more program area, try uncomment follow line
-#include "serial_config_simpleapi.h"
-
 // place overrides here
+
+// If you need more program area, try select and reduce rgblight modes to use.
+
+// Selection of RGBLIGHT MODE to use.
+#undef RGBLIGHT_EFFECT_BREATHING
+#undef RGBLIGHT_EFFECT_RAINBOW_MOOD
+#undef RGBLIGHT_EFFECT_RAINBOW_SWIRL
+#undef RGBLIGHT_EFFECT_SNAKE
+#undef RGBLIGHT_EFFECT_KNIGHT
+#undef RGBLIGHT_EFFECT_CHRISTMAS
+#undef RGBLIGHT_EFFECT_STATIC_GRADIENT
+//#undef RGBLIGHT_EFFECT_RGB_TEST // led_test keymap need only this.
+#undef RGBLIGHT_EFFECT_ALTERNATING
 
 #endif /* CONFIG_USER_H */

--- a/keyboards/helix/rev2/keymaps/led_test/led_test_init.c
+++ b/keyboards/helix/rev2/keymaps/led_test/led_test_init.c
@@ -5,7 +5,7 @@ void led_test_init(void) {
     static int scan_count = 0;
     if( scan_count == 2 ) {
 	rgblight_enable_noeeprom();
-	rgblight_mode_noeeprom(35);
+	rgblight_mode_noeeprom(RGBLIGHT_MODE_RGB_TEST);
     }
     if( scan_count < 3 ) scan_count ++;
 }
@@ -15,6 +15,6 @@ void led_test_init(void) {
 // can use this?
 void startup_user(void) {
     rgblight_enable_noeeprom();
-    rgblight_mode_noeeprom(35);
+    rgblight_mode_noeeprom(RGBLIGHT_MODE_RGB_TEST);
 }
 #endif


### PR DESCRIPTION
Removed unnecessary mode by setting rgblight.c modes.