### PR TITLE
Per Key Leader Timing Option

### DIFF
--- a/docs/feature_leader_key.md
+++ b/docs/feature_leader_key.md
@@ -47,3 +47,26 @@ To add support for Leader Key you simply need to add a single line to your keyma
 ```
 LEADER_ENABLE = yes
 ```
+
+## Per Key Timing on Leader keys
+
+Rather than relying on an incredibly high timeout for long leader key strings or those of us without 200wpm typing skills, we can enable per key timing to ensure that each key pressed provides us with more time to finish our stroke. This is incredibly helpful with leader key emulation of tap dance (read: multiple taps of the same key like C, C, C).
+
+In order to enable this, place this in your `config.h`:
+```
+#define LEADER_PER_KEY_TIMING
+```
+
+After this, it's recommended that you lower your `LEADER_TIMEOUT` to something less that 300ms.
+
+```
+#define LEADER_TIMEOUT 250
+```
+
+Now, something like this won't seem impossible to do without a 1000MS leader key timeout:
+
+```
+SEQ_THREE_KEYS(KC_C, KC_C, KC_C) {
+  SEND_STRING("Per key timing is great!!!");
+}
+```

--- a/quantum/process_keycode/process_leader.c
+++ b/quantum/process_keycode/process_leader.c
@@ -38,9 +38,15 @@ uint8_t leader_sequence_size = 0;
 bool process_leader(uint16_t keycode, keyrecord_t *record) {
   // Leader key set-up
   if (record->event.pressed) {
+#ifdef LEADER_PER_KEY_TIMING
+    leader_time = timer_read();
+#endif
     if (!leading && keycode == KC_LEAD) {
       leader_start();
       leading = true;
+#ifndef LEADER_PER_KEY_TIMING
+      leader_time = timer_read();
+#endif
       leader_time = timer_read();
       leader_sequence_size = 0;
       leader_sequence[0] = 0;


### PR DESCRIPTION
Hi All,

I'll let my quick addition to the documentation speak for itself, but basically this allows us to run shorter leader key delays, which is my preference because it's less laggy overall. I've determined that 250ms is my preferred delay for this feature.

Let me know if anything needs to be changed!

Thanks,
ark