### PR TITLE
Add support for the YD68/YD68v2 bluetooth module

### DIFF
--- a/keyboards/yd68/config.h
+++ b/keyboards/yd68/config.h
@@ -222,3 +222,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #endif
 */
 
+#ifdef YD68_XM04_ENABLE
+// rn42 support -- acquired from the tmk repo. This is almost certainly not
+// integrated with qmk in the correct way.
+
+#define SUART_OUT_PORT  PORTB
+#define SUART_OUT_BIT   1
+#define SUART_IN_PIN    PINF
+#define SUART_IN_BIT    7
+
+#endif

--- a/keyboards/yd68/rules.mk
+++ b/keyboards/yd68/rules.mk
@@ -66,7 +66,7 @@ BOOTMAGIC_ENABLE = no      # Virtual DIP switch configuration(+1000)
 MOUSEKEY_ENABLE = yes       # Mouse keys(+4700)
 EXTRAKEY_ENABLE = yes       # Audio control and System control(+450)
 CONSOLE_ENABLE = no         # Console for debug(+400)
-COMMAND_ENABLE = no         # Commands for debug and configuration
+COMMAND_ENABLE = yes         # Commands for debug and configuration
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
 SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
 # if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
@@ -79,3 +79,21 @@ BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
 AUDIO_ENABLE = no           # Audio output on port C6
 FAUXCLICKY_ENABLE = no      # Use buzzer to emulate clicky switches
 HD44780_ENABLE = no 		# Enable support for HD44780 based LCDs (+400)
+YD68_XM04_ENABLE = yes
+
+ifeq ($(strip $(YD68_XM04_ENABLE)), yes)
+
+OPT_DEFS += -DYD68_XM04_ENABLE
+
+XM04_DIR = xm04
+
+SRC +=  $(XM04_DIR)/suart.S \
+	$(XM04_DIR)/xm04.c \
+	$(XM04_DIR)/xm04_task.c \
+	$(XM04_DIR)/main.c
+
+OPT_DEFS += -DPROTOCOL_XM04
+
+VPATH += $(XM04_DIR)
+
+endif

--- a/keyboards/yd68/xm04/main.c
+++ b/keyboards/yd68/xm04/main.c
@@ -1,0 +1,99 @@
+#include <avr/io.h>
+#include <avr/power.h>
+#include <avr/wdt.h>
+#include "lufa.h"
+#include "print.h"
+#include "sendchar.h"
+#include "xm04.h"
+#include "xm04_task.h"
+//#include "serial.h"
+#include "keyboard.h"
+#include "keycode.h"
+#include "action.h"
+#include "action_util.h"
+#include "wait.h"
+#include "suart.h"
+#include "suspend.h"
+extern bool dozing;
+extern bool sleeping;
+extern bool force_usb;
+
+static int8_t sendchar_func(uint8_t c)
+{
+    //xmit(c);        // SUART
+    sendchar(c);    // LUFA
+    return 0;
+}
+
+static void SetupHardware(void)
+{
+    /* Disable watchdog if enabled by bootloader/fuses */
+    MCUSR &= ~(1 << WDRF);
+    wdt_disable();
+
+    /* Disable clock division */
+    clock_prescale_set(clock_div_1);
+
+    // Leonardo needs. Without this USB device is not recognized.
+    USB_Disable();
+
+    USB_Init();
+
+    // for Console_Task
+    USB_Device_EnableSOFEvents();
+    print_set_sendchar(sendchar_func);
+}
+
+int main(void)  __attribute__ ((weak));
+int main(void)
+{
+    SetupHardware();
+    sei();
+
+    /* wait for USB startup to get ready for debug output */
+    uint8_t timeout = 255;  // timeout when USB is not available(Bluetooth)
+    while (timeout-- && USB_DeviceState != DEVICE_STATE_Configured) {
+        wait_ms(4);
+#if defined(INTERRUPT_CONTROL_ENDPOINT)
+        ;
+#else
+        USB_USBTask();
+#endif
+    }
+    if (USB_DeviceState == DEVICE_STATE_Configured) {
+        force_usb = true;
+    }
+    print("\nUSB init\n");
+
+    xm04_init();
+    xm04_task_init();
+
+    /* init modules */
+    keyboard_init();
+
+
+#ifdef SLEEP_LED_ENABLE
+    sleep_led_init();
+#endif
+
+    print("Keyboard start\n");
+    while (1) {
+        if (dozing) {  //if using while, when waking up the first or more keys will be missed.
+            suspend_power_down();
+            if (suspend_wakeup_condition()) {
+                dozing = 0;
+                if (sleeping) {
+                    sleeping = 0;
+                    turn_on_bt();
+                }
+            }
+        }
+        if (!sleeping){
+            keyboard_task();
+#if !defined(INTERRUPT_CONTROL_ENDPOINT)
+            USB_USBTask();
+#endif
+            xm04_task();
+        }
+    }
+}

--- a/keyboards/yd68/xm04/main.c
+++ b/keyboards/yd68/xm04/main.c
@@ -18,13 +18,6 @@ extern bool dozing;
 extern bool sleeping;
 extern bool force_usb;
 
-static int8_t sendchar_func(uint8_t c)
-{
-    //xmit(c);        // SUART
-    sendchar(c);    // LUFA
-    return 0;
-}
-
 static void SetupHardware(void)
 {
     /* Disable watchdog if enabled by bootloader/fuses */
@@ -41,7 +34,6 @@ static void SetupHardware(void)
 
     // for Console_Task
     USB_Device_EnableSOFEvents();
-    print_set_sendchar(sendchar_func);
 }
 
 int main(void)  __attribute__ ((weak));

--- a/keyboards/yd68/xm04/suart.S
+++ b/keyboards/yd68/xm04/suart.S
@@ -1,0 +1,156 @@
+;---------------------------------------------------------------------------;
+; Software implemented UART module                                          ;
+; (C)ChaN, 2005 (http://elm-chan.org/)                                      ;
+;---------------------------------------------------------------------------;
+; Bit rate settings:
+;
+;            1MHz  2MHz  4MHz  6MHz  8MHz  10MHz  12MHz  16MHz  20MHz
+;   2.4kbps   138     -     -     -     -      -      -      -      -
+;   4.8kbps    68   138     -     -     -      -      -      -      -
+;   9.6kbps    33    68   138   208     -      -      -      -      -
+;  19.2kbps     -    33    68   102   138    173    208      -      -
+;  38.4kbps     -     -    33    50    68     85    102    138    172
+;  57.6kbps     -     -    21    33    44     56     68     91    114
+; 115.2kbps     -     -     -     -    21     27     33     44     56
+
+.nolist
+#include <avr/io.h>
+.list
+
+#define	BPS	91 	/* Bit delay. (see above table) */
+#define	BIDIR	0	/* 0:Separated Tx/Rx, 1:Shared Tx/Rx */
+
+#define	OUT_1		sbi _SFR_IO_ADDR(SUART_OUT_PORT), SUART_OUT_BIT	/* Output 1 */
+#define	OUT_0		cbi _SFR_IO_ADDR(SUART_OUT_PORT), SUART_OUT_BIT	/* Output 0 */
+#define	SKIP_IN_1	sbis _SFR_IO_ADDR(SUART_IN_PIN), SUART_IN_BIT	/* Skip if 1 */
+#define	SKIP_IN_0	sbic _SFR_IO_ADDR(SUART_IN_PIN), SUART_IN_BIT	/* Skip if 0 */
+
+
+
+#ifdef SPM_PAGESIZE
+.macro	_LPMI	reg
+	lpm	\reg, Z+
+.endm
+.macro	_MOVW	dh,dl, sh,sl
+	movw	\dl, \sl
+.endm
+#else
+.macro	_LPMI	reg
+	lpm
+	mov	\reg, r0
+	adiw	ZL, 1
+.endm
+.macro	_MOVW	dh,dl, sh,sl
+	mov	\dl, \sl
+	mov	\dh, \sh
+.endm
+#endif
+
+
+
+;---------------------------------------------------------------------------;
+; Transmit a byte in serial format of N81
+;
+;Prototype: void xmit (uint8_t data);
+;Size: 16 words
+
+.global xmit
+.func xmit
+xmit:
+#if BIDIR
+	ldi	r23, BPS-1	;Pre-idle time for bidirectional data line
+5:	dec	r23     	;
+	brne	5b		;/
+#endif
+	in	r0, _SFR_IO_ADDR(SREG)	;Save flags
+
+	com	r24		;C = start bit
+	ldi	r25, 10		;Bit counter
+	cli			;Start critical section
+
+1:	ldi	r23, BPS-1	;----- Bit transferring loop
+2:	dec	r23     	;Wait for a bit time
+	brne	2b		;/
+	brcs	3f		;MISO = bit to be sent
+	OUT_1			;
+3:	brcc	4f		;
+	OUT_0			;/
+4:	lsr	r24     	;Get next bit into C
+	dec	r25     	;All bits sent?
+	brne	1b	     	;  no, coutinue
+
+	out	_SFR_IO_ADDR(SREG), r0	;End of critical section
+	ret
+.endfunc
+
+
+
+;---------------------------------------------------------------------------;
+; Receive a byte
+;
+;Prototype: uint8_t rcvr (void);
+;Size: 19 words
+
+.global rcvr
+.func rcvr
+rcvr:
+	in	r0, _SFR_IO_ADDR(SREG)	;Save flags
+
+	ldi	r24, 0x80	;Receiving shift reg
+	cli			;Start critical section
+
+1:	SKIP_IN_1		;Wait for idle
+	rjmp	1b
+2:	SKIP_IN_0		;Wait for start bit
+	rjmp	2b
+	ldi	r25, BPS/2	;Wait for half bit time
+3:	dec	r25
+	brne	3b
+
+4:	ldi	r25, BPS	;----- Bit receiving loop
+5:	dec	r25     	;Wait for a bit time
+	brne	5b		;/
+	lsr	r24     	;Next bit
+	SKIP_IN_0		;Get a data bit into r24.7
+	ori	r24, 0x80
+	brcc	4b	     	;All bits received?  no, continue
+
+	out	_SFR_IO_ADDR(SREG), r0	;End of critical section
+	ret
+.endfunc
+
+
+; Not wait for start bit. This should be called after detecting start bit.
+.global recv
+.func recv
+recv:
+	in	r0, _SFR_IO_ADDR(SREG)	;Save flags
+
+	ldi	r24, 0x80	;Receiving shift reg
+	cli			;Start critical section
+
+;1:	SKIP_IN_1		;Wait for idle
+;	rjmp	1b
+;2:	SKIP_IN_0		;Wait for start bit
+;	rjmp	2b
+	ldi	r25, BPS/2	;Wait for half bit time
+3:	dec	r25
+	brne	3b
+
+4:	ldi	r25, BPS	;----- Bit receiving loop
+5:	dec	r25     	;Wait for a bit time
+	brne	5b		;/
+	lsr	r24     	;Next bit
+	SKIP_IN_0		;Get a data bit into r24.7
+	ori	r24, 0x80
+	brcc	4b	     	;All bits received?  no, continue
+
+	ldi	r25, BPS/2	;Wait for half bit time
+6:	dec	r25
+	brne	6b
+7:	SKIP_IN_1		;Wait for stop bit
+	rjmp	7b
+
+	out	_SFR_IO_ADDR(SREG), r0	;End of critical section
+	ret
+.endfunc

--- a/keyboards/yd68/xm04/suart.h
+++ b/keyboards/yd68/xm04/suart.h
@@ -1,0 +1,8 @@
+#ifndef SUART
+#define SUART
+
+void xmit(uint8_t);
+uint8_t rcvr(void);
+uint8_t recv(void);
+
+#endif	/* SUART */

--- a/keyboards/yd68/xm04/xm04.c
+++ b/keyboards/yd68/xm04/xm04.c
@@ -1,0 +1,128 @@
+#include <avr/io.h>
+#include "host.h"
+#include "host_driver.h"
+#include "xm04.h"
+#include "print.h"
+#include "timer.h"
+#include "wait.h"
+#include "suart.h"
+
+/* Host driver */
+static uint8_t keyboard_leds(void);
+static void send_keyboard(report_keyboard_t *report);
+static void send_mouse(report_mouse_t *report);
+static void send_system(uint16_t data);
+static void send_consumer(uint16_t data);
+
+host_driver_t xm04_driver = {
+    keyboard_leds,
+    send_keyboard,
+    send_mouse,
+    send_system,
+    send_consumer
+};
+
+void xm04_init(void)
+{
+    DDRF |= (1<<4);
+    DDRF |= (1<<7);
+	PORTF &= ~(1<<7);
+}
+
+static uint8_t leds = 0;
+static uint8_t keyboard_leds(void) { return leds; }
+void xm04_set_leds(uint8_t l) { leds = l; }
+
+static void send_keyboard(report_keyboard_t *report)
+{
+    xmit(0x0C);             //L2CAP length low byte
+    xmit(0);                //L2CAP length high byte
+    xmit(0xA1);             //BT HID DATA INPUT header type 
+    xmit(1);                //BT HID Boot Protocol Report ID, Keyboard
+    xmit(report->mods);     //HID report
+    xmit(0x00);
+    xmit(report->keys[0]);
+    xmit(report->keys[1]);
+    xmit(report->keys[2]);
+    xmit(report->keys[3]);
+    xmit(report->keys[4]);
+    xmit(report->keys[5]);
+}
+
+static void send_mouse(report_mouse_t *report)
+{
+    xmit(0x08);             //L2CAP length low byte
+    xmit(0);                //L2CAP length high byte
+    xmit(0xA1);             //BT HID DATA INPUT header type 
+    xmit(2);                //BT HID Boot Protocol Report ID, Mouse
+    xmit(report->buttons);  //HID report
+    xmit(report->x);
+    xmit(report->y);
+    xmit(report->v);
+}
+
+static void send_system(uint16_t data)
+{
+}
+
+static uint32_t usage2bits(uint16_t usage)
+{
+    switch (usage) {
+        case AC_BACK:                   return 1<<0;
+        case AC_FORWARD:                return 1<<1;
+        case AC_STOP:                   return 1<<2;
+        case AC_REFRESH:                return 1<<3;
+        case AC_SEARCH:                 return 1<<4;
+        case AC_BOOKMARKS:              return 1<<5;
+        case AC_HOME:                   return 1<<6;
+        case AL_EMAIL:                  return 1<<7;
+        case AUDIO_MUTE:                return 1<<8;
+        case AUDIO_VOL_DOWN:            return 1<<9;
+        case AUDIO_VOL_UP:              return 1<<10;
+        case TRANSPORT_PLAY_PAUSE:      return 1<<11;
+        case TRANSPORT_STOP:            return 1<<12;
+        case TRANSPORT_PREV_TRACK:      return 1<<13;
+        case TRANSPORT_NEXT_TRACK:      return 1<<14;
+        case AL_LOCAL_BROWSER:          return 1UL<<16;   
+        case AL_CALCULATOR:             return 1UL<<17;   
+        case TRANSPORT_RECORD:          return 1UL<<19;   
+        case TRANSPORT_FAST_FORWARD:    return 1UL<<20;   
+        case TRANSPORT_REWIND:          return 1UL<<21;   
+        case TRANSPORT_EJECT:           return 1UL<<29;   
+    };
+    return 0;
+}
+
+static void send_consumer(uint16_t data)
+{
+    uint32_t bits = usage2bits(data);
+    xmit(0x08);             //L2CAP length low byte
+    xmit(0);                //L2CAP length high byte
+    xmit(0xA1);             //BT HID DATA INPUT header type 
+    xmit(0x03);             //BT HID Boot Protocol Report ID, Consumer Control?
+    xmit(bits&0xFF);        //HID report
+    xmit((bits>>8)&0xFF);
+    xmit((bits>>16)&0xFF);
+    xmit((bits>>24)&0xFF);
+}
+
+bool bt_powered(void)
+{
+    return !(PORTB&(1<<PB2));
+}
+
+void turn_off_bt(void)
+{
+    PORTB |= (1<<PB2);
+}
+
+void turn_on_bt(void)
+{
+    PORTB &= ~(1<<PB2);
+}
+
+void toggle_bt(void)
+{
+    PORTB ^= (1<<PB2);
+}
+

--- a/keyboards/yd68/xm04/xm04.h
+++ b/keyboards/yd68/xm04/xm04.h
@@ -1,0 +1,16 @@
+#ifndef XM04_H
+#define XM04_H
+
+#include <stdbool.h>
+#include "host.h"
+
+host_driver_t xm04_driver;
+
+void xm04_init(void);
+
+bool bt_powered(void);
+void turn_off_bt(void);
+void turn_on_bt(void);
+void toggle_bt(void);
+
+#endif

--- a/keyboards/yd68/xm04/xm04_task.c
+++ b/keyboards/yd68/xm04/xm04_task.c
@@ -1,0 +1,107 @@
+#include <stdint.h>
+#include <string.h>
+#include <avr/pgmspace.h>
+#include <avr/eeprom.h>
+#include "keycode.h"
+//#include "serial.h"
+#include "host.h"
+#include "action.h"
+#include "action_util.h"
+#include "lufa.h"
+#include "xm04_task.h"
+#include "print.h"
+#include "debug.h"
+#include "timer.h"
+#include "wait.h"
+#include "command.h"
+#include "bootloader.h"
+
+bool force_usb = false;
+#ifndef NO_BT_STATUS_CHECK
+//static bool host_connected = false;
+//static bool usb_nkro_status = false;
+static bool usb_connected = false;
+//static uint16_t disconnect_timer = 0; 
+//static uint8_t disconnect_s=0;
+//static uint16_t check_timer = 0;
+#endif
+uint32_t kb_idle_timer = 0; 
+
+bool dozing = false;
+bool sleeping = false;
+bool no_sleep = false;
+
+void xm04_task_init(void)
+{
+    kb_idle_timer = timer_read32();
+}
+
+void xm04_task(void)
+{
+
+    /* Bluetooth mode when ready */
+    if (!force_usb) {
+        if (host_get_driver() != &xm04_driver) {
+            clear_keyboard(); //Prevents stuck keys.
+            print("Bluetooth\n");
+#ifdef NKRO_ENABLE
+            xmo04_nkro_last = keymap_config.nkro;
+            keymap_config.nkro = false;
+#endif
+            host_set_driver(&xm04_driver);
+        } else if (!usb_connected && (USB_DeviceState == DEVICE_STATE_Configured)) {
+            force_usb = 1;
+            usb_connected = 1;
+        }
+    } else {
+        if (host_get_driver() != &lufa_driver) {
+            usb_connected = 1;
+            clear_keyboard();
+            print("USB\n");
+#ifdef NKRO_ENABLE
+            keymap_config.nkro = xmo04_nkro_last;
+#endif
+            host_set_driver(&lufa_driver);
+        } else if (USB_DeviceState != DEVICE_STATE_Configured) {
+            force_usb = 0;
+            usb_connected = 0;
+        }            
+    }
+    if (!no_sleep && (!dozing && (timer_elapsed32(kb_idle_timer) > 30000))) {
+        dozing = 1;
+    }
+    if (bt_powered() && (dozing && (timer_elapsed32(kb_idle_timer) > 3600000))) {
+        sleeping = 1;
+        turn_off_bt();
+  }
+}
+
+
+
+
+bool command_extra(uint8_t code)
+{
+    switch (code) {
+        case KC_B:
+            clear_keyboard();
+            print("\n\nbootloader... ");
+            wait_ms(500);
+            bootloader_jump(); // not return
+            break;
+        case KC_U:
+            if (force_usb) {
+                print("Auto mode\n");
+                force_usb = false;
+            } else {
+                print("USB mode\n");
+                force_usb = true;
+            }
+            return true;
+        case KC_P:
+            no_sleep ^= 1;
+            return true;
+        default:
+                return false;   // yield to default command
+    }
+    return true;
+}

--- a/keyboards/yd68/xm04/xm04_task.h
+++ b/keyboards/yd68/xm04/xm04_task.h
@@ -1,0 +1,14 @@
+#ifndef XM04_TASK_H
+#define XM04_TASK_H
+
+#include <stdbool.h>
+#include "xm04.h"
+
+#ifdef NKRO_ENABLE
+bool xm04_nkro_last;
+#endif
+
+void xm04_task_init(void);
+void xm04_task(void);
+
+#endif

--- a/keyboards/yd68/yd68.c
+++ b/keyboards/yd68/yd68.c
@@ -27,17 +27,27 @@ void matrix_init_kb(void) {
 	DDRD |= (1<<6);
     PORTD &= ~(1<<6);
 	
-	//RGB power output low
+	//RGB power output low(on)
 	DDRE |= (1<<2);
     PORTE &= ~(1<<2);
-	
-	//Bluetooth power output high
+
+#ifndef YD68_XM04_ENABLE
+	//Bluetooth power output high(off)
 	DDRB |= (1<<2);
     PORTB |= (1<<2);
-	
+#else
+	//Bluetooth power output low(on)
+	DDRB |= (1<<2);
+	PORTB &= ~(1<<2);
+#endif
+
 	//RGB data output low
 	DDRB |= (1<<3);
 	PORTB &= ~(1<<3);
+
+	//BT UART TX output low
+	DDRB |= (1<<1);
+	PORTB &= ~(1<<1);
 	
 	matrix_init_user();
 }


### PR DESCRIPTION
Probably not well integrated, but it does seem to work. Not sure if there's a way to hook this into the "normal" bluetooth stuff.

COMMAND+U switches between USB and Bluetooth modes. Bluetooth module can be disabled entirely with the YD68_XM04_ENABLE option in rules.mk.

Currently if the option is enabled, the bluetooth module is always left on, but there is the possibility to turn it on and off when toggling between USB and Bluetooth modes. Not sure if that's a better "default" thing.