### PR TITLE
add JP keycode for MacOSX

### DIFF
--- a/quantum/keymap_extras/keymap_jp.h
+++ b/quantum/keymap_extras/keymap_jp.h
@@ -40,6 +40,9 @@
 #define JP_HENK KC_INT4 // henkan
 #define JP_KANA KC_INT2 // katakana/hiragana|ro-mazi
 
+#define JP_MKANA KC_LANG1 //kana on MacOSX
+#define JP_MEISU KC_LANG2 //eisu on MacOSX
+
 
 //Aliases for shifted symbols
 #define JP_DQT  LSFT(KC_2)    // "


### PR DESCRIPTION
I add 2 JP keycodes for MacOSX.

![image](https://user-images.githubusercontent.com/6106151/46268818-d16a8800-c577-11e8-91ac-caa9c7d8bef2.png)
