### PR TITLE
Adds a method allowing to set custom colors to the rgb matrix

### DIFF
--- a/quantum/rgb_matrix.c
+++ b/quantum/rgb_matrix.c
@@ -903,3 +903,10 @@ void rgblight_mode(uint8_t mode) {
 uint32_t rgblight_get_mode(void) {
     return rgb_matrix_config.mode;
 }
+
+void rgblight_sethsv(uint16_t hue, uint8_t sat, uint8_t val) {
+  rgb_matrix_config.hue = hue;
+  rgb_matrix_config.sat = sat;
+  rgb_matrix_config.val = val;
+  eeconfig_update_rgb_matrix(rgb_matrix_config.raw);
+}

--- a/quantum/rgb_matrix.h
+++ b/quantum/rgb_matrix.h
@@ -128,6 +128,7 @@ uint32_t rgb_matrix_get_tick(void);
 
 void rgblight_toggle(void);
 void rgblight_step(void);
+void rgblight_sethsv(uint16_t hue, uint8_t sat, uint8_t val);
 void rgblight_step_reverse(void);
 void rgblight_increase_hue(void);
 void rgblight_decrease_hue(void);


### PR DESCRIPTION
This PR adds a `rgblight_sethsv` allowing to set custom colors to the RGB matrix (Similarly to the RGB backlight).

I tested it on a self-wired board. One thing to note, similarly to increasing or decreasing the hue or saturation, some animation colors will inherit the custom color.

Example usage on the `keymap.c` file

```
bool process_record_user(uint16_t keycode, keyrecord_t *record) {
  switch (keycode) {
    case HSV_213_77_255:
      #ifdef RGB_MATRIX_ENABLE
        if (record->event.pressed) {
          rgblight_mode(1);
          rgblight_sethsv(213, 77, 255);
        }
      #endif
      return false;
      break;
  }
}
```