### PR TITLE
Enable support for Linux Mint 18 with linux_install.sh

### DIFF
--- a/util/linux_install.sh
+++ b/util/linux_install.sh
@@ -4,7 +4,7 @@ if grep ID /etc/os-release | grep -qE "rhel|fedora"; then
 	sudo dnf install gcc unzip wget zip dfu-util dfu-programmer avr-gcc \
 	    avr-libc binutils-avr32-linux-gnu arm-none-eabi-gcc-cs \
 	    arm-none-eabi-binutils-cs arm-none-eabi-newlib
-elif grep ID /etc/os-release | grep -q debian; then
+elif grep ID /etc/os-release | grep -qE 'debian|ubuntu'; then
 	sudo apt-get update
 	sudo apt-get install gcc unzip wget zip gcc-avr binutils-avr avr-libc \
 	    dfu-programmer dfu-util gcc-arm-none-eabi binutils-arm-none-eabi \

--- a/util/linux_install.sh
+++ b/util/linux_install.sh
@@ -38,5 +38,5 @@ fi
 else
 	echo "Sorry, we don't recognize your OS. Help us by contributing support!"
 	echo
-	echo "https://docs.qmk.fm"
+	echo "https://docs.qmk.fm/#/contributing"
 fi

--- a/util/linux_install.sh
+++ b/util/linux_install.sh
@@ -38,5 +38,5 @@ fi
 else
 	echo "Sorry, we don't recognize your OS. Help us by contributing support!"
 	echo
-	echo "https://docs.qmk.fm/contributing.html"
+	echo "https://docs.qmk.fm"
 fi


### PR DESCRIPTION
When running `qmk_install.sh` on my Linux Mint 18 machine, I encountered the following error:

```console
$ ./qmk_install.sh 
Sorry, we don't recognize your OS. Help us by contributing support!

https://docs.qmk.fm/contributing.html
```

`qmk_install.sh` was correctly running the `linux_install.sh` script, but that wasn't correctly identifying my distro as being compatible.

Unlike the results that I see on my Ubuntu VM, when I view the contents of `/etc/os-release`, I do not see `debian`, like the script expects. Here are the relevant contents of this file:

```console
$ grep ID /etc/os-release 
ID=linuxmint
ID_LIKE=ubuntu
VERSION_ID="18.3"
```

Surely this change will impact other ubuntu-derived linux distros also? I would appreciate any feedback if anyone is able to test on another distro.

I have verified that running this modified script will begin installing software packages. Before this change, I had previously installed QMK by copying/pasting these commands into my terminal.

```console
$ ./qmk_install.sh 
Hit:1 http://....
```