### PR TITLE
Fix compile issues for KBD8X in Travis

### DIFF
--- a/keyboards/kbd8x/config.h
+++ b/keyboards/kbd8x/config.h
@@ -15,8 +15,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef CONFIG_H
-#define CONFIG_H
+#pragma once
 
 #include "config_common.h"
 
@@ -196,4 +195,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* override number of MIDI tone keycodes (each octave adds 12 keycodes and allocates 12 bytes) */
 //#define MIDI_TONE_KEYCODE_OCTAVES 1
 
-#endif
+

--- a/keyboards/kbd8x/kbd8x.h
+++ b/keyboards/kbd8x/kbd8x.h
@@ -13,8 +13,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef KBD8X_H
-#define KBD8X_H
+#pragma once
 
 #include "quantum.h"
 #include "led.h"
@@ -31,7 +30,7 @@ inline void scroll_led_off(void)  { DDRB &= ~(1<<2); PORTB &= ~(1<<2); }
 
 
 // LAYOUT depicting all possible switch positions.
-// LAYOUT_all supports ISO, split backspace and split left/right shift. 
+// LAYOUT_all supports ISO, split backspace and split left/right shift.
 #define LAYOUT_all( \
     K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C, K0D, K0E, K3D,           \
     K10, K11, K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, K1C, K1D, K1E, K5B, K5C, K3E, \
@@ -49,7 +48,7 @@ inline void scroll_led_off(void)  { DDRB &= ~(1<<2); PORTB &= ~(1<<2); }
     { K50, K51, K52, K53, K54, K55, K56, K57, K58, K59, K5A, K5B, K5C, K5D, K5E }  \
 }
 
-// LAYOUT depicting only switch positions for a standard TKL ANSI keyboard.  
+// LAYOUT depicting only switch positions for a standard TKL ANSI keyboard.
 // TODO: Double check location of backspace key for 2u layout (It's either K1D or K1C).
 #define LAYOUT_tkl_ansi( \
     K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C, K0D, K0E, K3D,      \
@@ -68,4 +67,3 @@ inline void scroll_led_off(void)  { DDRB &= ~(1<<2); PORTB &= ~(1<<2); }
     { K50, K51,   K52, K53, K54, K55, K56, K57, K58, K59, K5A, K5B, K5C, K5D,   K5E }  \
 }
 
-#endif

--- a/keyboards/kbd8x/keymaps/default/config.h
+++ b/keyboards/kbd8x/keymaps/default/config.h
@@ -14,11 +14,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "config_common.h"
-
-// place overrides here
-
-#endif
+#pragma once

--- a/keyboards/kbd8x/keymaps/default_backlighting/config.h
+++ b/keyboards/kbd8x/keymaps/default_backlighting/config.h
@@ -14,11 +14,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "config_common.h"
-
-// place overrides here
-
-#endif
+#pragma once

--- a/keyboards/kbd8x/keymaps/default_backlighting/rules.mk
+++ b/keyboards/kbd8x/keymaps/default_backlighting/rules.mk
@@ -1,7 +1,7 @@
 #Build Options
 
 BOOTMAGIC_ENABLE = no      # Virtual DIP switch configuration(+1000)
-MOUSEKEY_ENABLE = yes       # Mouse keys(+4700)
+MOUSEKEY_ENABLE = no       # Mouse keys(+4700)
 EXTRAKEY_ENABLE = yes       # Audio control and System control(+450)
 CONSOLE_ENABLE = yes        # Console for debug(+400)
 COMMAND_ENABLE = yes        # Commands for debug and configuration

--- a/keyboards/kbd8x/rules.mk
+++ b/keyboards/kbd8x/rules.mk
@@ -45,7 +45,6 @@ OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
 #   Atmel DFU loader 4096
 #   LUFA bootloader  4096
 #   USBaspLoader     2048
-OPT_DEFS += -DBOOTLOADER_SIZE=4096
 BOOTLOADER = atmel-dfu
 
 
@@ -53,7 +52,7 @@ BOOTLOADER = atmel-dfu
 #   change yes to no to disable
 #
 BOOTMAGIC_ENABLE = no      # Virtual DIP switch configuration(+1000)
-MOUSEKEY_ENABLE = yes       # Mouse keys(+4700)
+MOUSEKEY_ENABLE = no       # Mouse keys(+4700)
 EXTRAKEY_ENABLE = yes       # Audio control and System control(+450)
 CONSOLE_ENABLE = yes        # Console for debug(+400)
 COMMAND_ENABLE = yes        # Commands for debug and configuration


### PR DESCRIPTION
This disables mousekeys for the keyboard, so that the compiled size is under the limit.