### PR TITLE
Add AltGr/RALT support to Send String

### DIFF
--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -839,6 +839,26 @@ const bool ascii_to_shift_lut[0x80] PROGMEM = {
 };
 
 __attribute__ ((weak))
+const bool ascii_to_alt_lut[0x80] PROGMEM = {
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0
+};
+
+__attribute__ ((weak))
 const uint8_t ascii_to_keycode_lut[0x80] PROGMEM = {
     0, 0, 0, 0, 0, 0, 0, 0,
     KC_BSPC, KC_TAB, KC_ENT, 0, 0, 0, 0, 0,
@@ -920,16 +940,21 @@ void send_string_with_delay_P(const char *str, uint8_t interval) {
 
 void send_char(char ascii_code) {
   uint8_t keycode;
+  bool is_shifted;
+  bool is_alted;
+
   keycode = pgm_read_byte(&ascii_to_keycode_lut[(uint8_t)ascii_code]);
-  if (pgm_read_byte(&ascii_to_shift_lut[(uint8_t)ascii_code])) {
-      register_code(KC_LSFT);
-      register_code(keycode);
-      unregister_code(keycode);
-      unregister_code(KC_LSFT);
-  } else {
-      register_code(keycode);
-      unregister_code(keycode);
-  }
+  if (pgm_read_byte(&ascii_to_shift_lut[(uint8_t)ascii_code])) { is_shifted = true; } else { is_shifted = false; }
+ if (pgm_read_byte(&ascii_to_alt_lut[(uint8_t)ascii_code])) { is_alted = true; } else { is_alted = false; }
+
+  if (is_shifted) { register_code(KC_LSFT); }
+  if (is_alted) { register_code(KC_RALT); }
+
+  register_code(keycode);
+  unregister_code(keycode);
+
+  if (is_alted) { unregister_code(KC_RALT); }
+  if (is_shifted) { unregister_code(KC_LSFT); }
 }
 
 void set_single_persistent_default_layer(uint8_t default_layer) {

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -939,17 +939,9 @@ void send_string_with_delay_P(const char *str, uint8_t interval) {
 }
 
 void send_char(char ascii_code) {
-  uint8_t keycode;
-  bool is_shifted = false;
-  bool is_alted = false;
-
-  keycode = pgm_read_byte(&ascii_to_keycode_lut[(uint8_t)ascii_code]);
-  if (pgm_read_byte(&ascii_to_shift_lut[(uint8_t)ascii_code])) {
-    is_shifted = true;
-  }
-  if (pgm_read_byte(&ascii_to_alt_lut[(uint8_t)ascii_code])) {
-    is_alted = true;
-  }
+  uint8_t keycode = pgm_read_byte(&ascii_to_keycode_lut[(uint8_t)ascii_code]);
+  bool is_shifted = pgm_read_byte(&ascii_to_shift_lut[(uint8_t)ascii_code]);
+  bool is_alted = pgm_read_byte(&ascii_to_alt_lut[(uint8_t)ascii_code]);
 
   if (is_shifted) {
     register_code(KC_LSFT);
@@ -957,9 +949,7 @@ void send_char(char ascii_code) {
   if (is_alted) {
     register_code(KC_RALT);
   }
-
   tap_code(keycode);
-
   if (is_alted) {
     unregister_code(KC_RALT);
   }

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -839,7 +839,7 @@ const bool ascii_to_shift_lut[0x80] PROGMEM = {
 };
 
 __attribute__ ((weak))
-const bool ascii_to_alt_lut[0x80] PROGMEM = {
+const bool ascii_to_altgr_lut[0x80] PROGMEM = {
     0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0,
@@ -941,16 +941,16 @@ void send_string_with_delay_P(const char *str, uint8_t interval) {
 void send_char(char ascii_code) {
   uint8_t keycode = pgm_read_byte(&ascii_to_keycode_lut[(uint8_t)ascii_code]);
   bool is_shifted = pgm_read_byte(&ascii_to_shift_lut[(uint8_t)ascii_code]);
-  bool is_alted = pgm_read_byte(&ascii_to_alt_lut[(uint8_t)ascii_code]);
+  bool is_altgred = pgm_read_byte(&ascii_to_altgr_lut[(uint8_t)ascii_code]);
 
   if (is_shifted) {
     register_code(KC_LSFT);
   }
-  if (is_alted) {
+  if (is_altgred) {
     register_code(KC_RALT);
   }
   tap_code(keycode);
-  if (is_alted) {
+  if (is_altgred) {
     unregister_code(KC_RALT);
   }
   if (is_shifted) {

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -940,20 +940,32 @@ void send_string_with_delay_P(const char *str, uint8_t interval) {
 
 void send_char(char ascii_code) {
   uint8_t keycode;
-  bool is_shifted;
-  bool is_alted;
+  bool is_shifted = false;
+  bool is_alted = false;
 
   keycode = pgm_read_byte(&ascii_to_keycode_lut[(uint8_t)ascii_code]);
-  if (pgm_read_byte(&ascii_to_shift_lut[(uint8_t)ascii_code])) { is_shifted = true; } else { is_shifted = false; }
-  if (pgm_read_byte(&ascii_to_alt_lut[(uint8_t)ascii_code])) { is_alted = true; } else { is_alted = false; }
+  if (pgm_read_byte(&ascii_to_shift_lut[(uint8_t)ascii_code])) {
+    is_shifted = true;
+  }
+  if (pgm_read_byte(&ascii_to_alt_lut[(uint8_t)ascii_code])) {
+    is_alted = true;
+  }
 
-  if (is_shifted) { register_code(KC_LSFT); }
-  if (is_alted) { register_code(KC_RALT); }
+  if (is_shifted) {
+    register_code(KC_LSFT);
+  }
+  if (is_alted) {
+    register_code(KC_RALT);
+  }
 
   tap_code(keycode);
 
-  if (is_alted) { unregister_code(KC_RALT); }
-  if (is_shifted) { unregister_code(KC_LSFT); }
+  if (is_alted) {
+    unregister_code(KC_RALT);
+  }
+  if (is_shifted) {
+    unregister_code(KC_LSFT);
+  }
 }
 
 void set_single_persistent_default_layer(uint8_t default_layer) {

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -945,13 +945,12 @@ void send_char(char ascii_code) {
 
   keycode = pgm_read_byte(&ascii_to_keycode_lut[(uint8_t)ascii_code]);
   if (pgm_read_byte(&ascii_to_shift_lut[(uint8_t)ascii_code])) { is_shifted = true; } else { is_shifted = false; }
- if (pgm_read_byte(&ascii_to_alt_lut[(uint8_t)ascii_code])) { is_alted = true; } else { is_alted = false; }
+  if (pgm_read_byte(&ascii_to_alt_lut[(uint8_t)ascii_code])) { is_alted = true; } else { is_alted = false; }
 
   if (is_shifted) { register_code(KC_LSFT); }
   if (is_alted) { register_code(KC_RALT); }
 
-  register_code(keycode);
-  unregister_code(keycode);
+  tap_code(keycode);
 
   if (is_alted) { unregister_code(KC_RALT); }
   if (is_shifted) { unregister_code(KC_LSFT); }

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -202,7 +202,7 @@ extern uint32_t default_layer_state;
 
 #define SEND_STRING(str) send_string_P(PSTR(str))
 extern const bool ascii_to_shift_lut[0x80];
-extern const bool ascii_to_alt_lut[0x80];
+extern const bool ascii_to_altgr_lut[0x80];
 extern const uint8_t ascii_to_keycode_lut[0x80];
 void send_string(const char *str);
 void send_string_with_delay(const char *str, uint8_t interval);

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -202,6 +202,7 @@ extern uint32_t default_layer_state;
 
 #define SEND_STRING(str) send_string_P(PSTR(str))
 extern const bool ascii_to_shift_lut[0x80];
+extern const bool ascii_to_alt_lut[0x80];
 extern const uint8_t ascii_to_keycode_lut[0x80];
 void send_string(const char *str);
 void send_string_with_delay(const char *str, uint8_t interval);


### PR DESCRIPTION
This should allow for AltGr based codes (eg Right Alt) to be used for send string mappings. 

Also, this cleans up the code a bit.

Though, I'm not sure how useful this actually is?  But hey, it was an idea, and I felt like doing it. :D