### PR TITLE
KBD4x: corrected info.json file

### DIFF
--- a/keyboards/kbd4x/info.json
+++ b/keyboards/kbd4x/info.json
@@ -53,7 +53,7 @@
               {"label":"/", "x":8, "y":3},
               {"label":"LEFT", "x":9, "y":3},
               {"label":"DOWN", "x":10, "y":3},
-              {"label":"RIGHT", "x":11, "y":3},
+              {"label":"RIGHT", "x":11, "y":3}
             ]
         },
         "LAYOUT_ortho_4x12": {
@@ -105,7 +105,7 @@
               {"label":"/", "x":8, "y":3},
               {"label":"LEFT", "x":9, "y":3},
               {"label":"DOWN", "x":10, "y":3},
-              {"label":"RIGHT", "x":11, "y":3},
+              {"label":"RIGHT", "x":11, "y":3}
             ]
         }
     }


### PR DESCRIPTION
The `info.json` file for the KBD4x was invalid due to a couple of extra commas.