### PR TITLE
Fix Unicode EEPROM handling so it is consistent.

### DIFF
--- a/quantum/process_keycode/process_ucis.c
+++ b/quantum/process_keycode/process_ucis.c
@@ -89,7 +89,6 @@ void register_ucis(const char *hex) {
 }
 
 bool process_ucis (uint16_t keycode, keyrecord_t *record) {
-  uint8_t i;
   initialize_unicode_input_mode();
 
   if (!qk_ucis_state.in_progress)
@@ -119,7 +118,7 @@ bool process_ucis (uint16_t keycode, keyrecord_t *record) {
   if (keycode == KC_ENT || keycode == KC_SPC || keycode == KC_ESC) {
     bool symbol_found = false;
 
-    for (i = qk_ucis_state.count; i > 0; i--) {
+    for (uint8_t i = qk_ucis_state.count; i > 0; i--) {
       register_code (KC_BSPC);
       unregister_code (KC_BSPC);
       wait_ms(UNICODE_TYPE_DELAY);
@@ -131,7 +130,7 @@ bool process_ucis (uint16_t keycode, keyrecord_t *record) {
     }
 
     unicode_input_start();
-    for (i = 0; ucis_symbol_table[i].symbol; i++) {
+    for (uint8_t i = 0; ucis_symbol_table[i].symbol; i++) {
       if (is_uni_seq (ucis_symbol_table[i].symbol)) {
         symbol_found = true;
         register_ucis(ucis_symbol_table[i].code + 2);

--- a/quantum/process_keycode/process_ucis.c
+++ b/quantum/process_keycode/process_ucis.c
@@ -89,7 +89,7 @@ void register_ucis(const char *hex) {
 }
 
 bool process_ucis (uint16_t keycode, keyrecord_t *record) {
-  initialize_unicode_input_mode();
+  unicode_input_mode_init();
 
   if (!qk_ucis_state.in_progress)
     return true;

--- a/quantum/process_keycode/process_ucis.c
+++ b/quantum/process_keycode/process_ucis.c
@@ -90,6 +90,7 @@ void register_ucis(const char *hex) {
 
 bool process_ucis (uint16_t keycode, keyrecord_t *record) {
   uint8_t i;
+  get_unicode_input_mode();
 
   if (!qk_ucis_state.in_progress)
     return true;

--- a/quantum/process_keycode/process_ucis.c
+++ b/quantum/process_keycode/process_ucis.c
@@ -90,7 +90,7 @@ void register_ucis(const char *hex) {
 
 bool process_ucis (uint16_t keycode, keyrecord_t *record) {
   uint8_t i;
-  get_unicode_input_mode();
+  initialize_unicode_input_mode();
 
   if (!qk_ucis_state.in_progress)
     return true;

--- a/quantum/process_keycode/process_unicode.c
+++ b/quantum/process_keycode/process_unicode.c
@@ -20,7 +20,7 @@
 bool process_unicode(uint16_t keycode, keyrecord_t *record) {
   if (keycode > QK_UNICODE && record->event.pressed) {
     uint16_t unicode = keycode & 0x7FFF;
-    initialize_unicode_input_mode();
+    unicode_input_mode_init();
     unicode_input_start();
     register_hex(unicode);
     unicode_input_finish();

--- a/quantum/process_keycode/process_unicode.c
+++ b/quantum/process_keycode/process_unicode.c
@@ -20,7 +20,7 @@
 bool process_unicode(uint16_t keycode, keyrecord_t *record) {
   if (keycode > QK_UNICODE && record->event.pressed) {
     uint16_t unicode = keycode & 0x7FFF;
-    get_unicode_input_mode();
+    initialize_unicode_input_mode();
     unicode_input_start();
     register_hex(unicode);
     unicode_input_finish();

--- a/quantum/process_keycode/process_unicode.c
+++ b/quantum/process_keycode/process_unicode.c
@@ -17,15 +17,10 @@
 #include "action_util.h"
 #include "eeprom.h"
 
-static uint8_t first_flag = 0;
-
 bool process_unicode(uint16_t keycode, keyrecord_t *record) {
   if (keycode > QK_UNICODE && record->event.pressed) {
-    if (first_flag == 0) {
-      set_unicode_input_mode(eeprom_read_byte(EECONFIG_UNICODEMODE));
-      first_flag = 1;
-    }
     uint16_t unicode = keycode & 0x7FFF;
+    get_unicode_input_mode();
     unicode_input_start();
     register_hex(unicode);
     unicode_input_finish();

--- a/quantum/process_keycode/process_unicode_common.c
+++ b/quantum/process_keycode/process_unicode_common.c
@@ -20,11 +20,9 @@
 #include <ctype.h>
 
 static uint8_t input_mode;
-
 uint8_t mods;
 
-void set_unicode_input_mode(uint8_t os_target)
-{
+void set_unicode_input_mode(uint8_t os_target) {
   input_mode = os_target;
   eeprom_update_byte(EECONFIG_UNICODEMODE, os_target);
 }
@@ -34,7 +32,7 @@ uint8_t get_unicode_input_mode(void) {
 }
 
 void initialize_unicode_input_mode(void) {
-  static bool first_flag = false;
+  static bool first_flag;
   if (!first_flag) {
     input_mode = eeprom_read_byte(EECONFIG_UNICODEMODE);
     first_flag = true;
@@ -113,8 +111,7 @@ void unicode_input_finish (void) {
 }
 
 __attribute__((weak))
-uint16_t hex_to_keycode(uint8_t hex)
-{
+uint16_t hex_to_keycode(uint8_t hex) {
   if (hex == 0x0) {
     return KC_0;
   } else if (hex < 0xA) {
@@ -132,8 +129,7 @@ void register_hex(uint16_t hex) {
   }
 }
 
-void send_unicode_hex_string(const char *str)
-{
+void send_unicode_hex_string(const char *str) {
   if (!str) { return; } // Safety net
 
   while (*str) {

--- a/quantum/process_keycode/process_unicode_common.c
+++ b/quantum/process_keycode/process_unicode_common.c
@@ -20,6 +20,7 @@
 #include <ctype.h>
 
 static uint8_t input_mode;
+static uint8_t first_flag = 0;
 uint8_t mods;
 
 void set_unicode_input_mode(uint8_t os_target)
@@ -29,6 +30,10 @@ void set_unicode_input_mode(uint8_t os_target)
 }
 
 uint8_t get_unicode_input_mode(void) {
+  if (first_flag == 0) {
+    input_mode = eeprom_read_byte(EECONFIG_UNICODEMODE);
+    first_flag = 1;
+  }
   return input_mode;
 }
 

--- a/quantum/process_keycode/process_unicode_common.c
+++ b/quantum/process_keycode/process_unicode_common.c
@@ -32,7 +32,7 @@ uint8_t get_unicode_input_mode(void) {
 }
 
 void initialize_unicode_input_mode(void) {
-  static bool first_flag;
+  static bool first_flag = false;
   if (!first_flag) {
     input_mode = eeprom_read_byte(EECONFIG_UNICODEMODE);
     first_flag = true;

--- a/quantum/process_keycode/process_unicode_common.c
+++ b/quantum/process_keycode/process_unicode_common.c
@@ -20,7 +20,7 @@
 #include <ctype.h>
 
 static uint8_t input_mode;
-static uint8_t first_flag = 0;
+static bool first_flag = false;
 uint8_t mods;
 
 void set_unicode_input_mode(uint8_t os_target)
@@ -30,9 +30,9 @@ void set_unicode_input_mode(uint8_t os_target)
 }
 
 uint8_t get_unicode_input_mode(void) {
-  if (first_flag == 0) {
+  if (!first_flag) {
     input_mode = eeprom_read_byte(EECONFIG_UNICODEMODE);
-    first_flag = 1;
+    first_flag = true;
   }
   return input_mode;
 }

--- a/quantum/process_keycode/process_unicode_common.c
+++ b/quantum/process_keycode/process_unicode_common.c
@@ -20,7 +20,7 @@
 #include <ctype.h>
 
 static uint8_t input_mode;
-static bool first_flag = false;
+
 uint8_t mods;
 
 void set_unicode_input_mode(uint8_t os_target)
@@ -30,11 +30,15 @@ void set_unicode_input_mode(uint8_t os_target)
 }
 
 uint8_t get_unicode_input_mode(void) {
+  return input_mode;
+}
+
+void initialize_unicode_input_mode(void) {
+  static bool first_flag = false;
   if (!first_flag) {
     input_mode = eeprom_read_byte(EECONFIG_UNICODEMODE);
     first_flag = true;
   }
-  return input_mode;
 }
 
 __attribute__((weak))

--- a/quantum/process_keycode/process_unicode_common.c
+++ b/quantum/process_keycode/process_unicode_common.c
@@ -31,7 +31,7 @@ uint8_t get_unicode_input_mode(void) {
   return input_mode;
 }
 
-void initialize_unicode_input_mode(void) {
+void unicode_input_mode_init(void) {
   static bool first_flag = false;
   if (!first_flag) {
     input_mode = eeprom_read_byte(EECONFIG_UNICODEMODE);

--- a/quantum/process_keycode/process_unicode_common.h
+++ b/quantum/process_keycode/process_unicode_common.h
@@ -28,6 +28,7 @@ static uint8_t input_mode;
 
 void set_unicode_input_mode(uint8_t os_target);
 uint8_t get_unicode_input_mode(void);
+void initialize_unicode_input_mode(void);
 void unicode_input_start(void);
 void unicode_input_finish(void);
 void register_hex(uint16_t hex);

--- a/quantum/process_keycode/process_unicode_common.h
+++ b/quantum/process_keycode/process_unicode_common.h
@@ -28,7 +28,7 @@ static uint8_t input_mode;
 
 void set_unicode_input_mode(uint8_t os_target);
 uint8_t get_unicode_input_mode(void);
-void initialize_unicode_input_mode(void);
+void unicode_input_mode_init(void);
 void unicode_input_start(void);
 void unicode_input_finish(void);
 void register_hex(uint16_t hex);

--- a/quantum/process_keycode/process_unicodemap.c
+++ b/quantum/process_keycode/process_unicodemap.c
@@ -45,7 +45,7 @@ __attribute__((weak))
 void unicode_map_input_error() {}
 
 bool process_unicode_map(uint16_t keycode, keyrecord_t *record) {
-  initialize_unicode_input_mode();
+  unicode_input_mode_init();
   uint8_t input_mode = get_unicode_input_mode();
   if ((keycode & QK_UNICODE_MAP) == QK_UNICODE_MAP && record->event.pressed) {
     const uint32_t* map = unicode_map;

--- a/quantum/process_keycode/process_unicodemap.c
+++ b/quantum/process_keycode/process_unicodemap.c
@@ -45,6 +45,7 @@ __attribute__((weak))
 void unicode_map_input_error() {}
 
 bool process_unicode_map(uint16_t keycode, keyrecord_t *record) {
+  initialize_unicode_input_mode();
   uint8_t input_mode = get_unicode_input_mode();
   if ((keycode & QK_UNICODE_MAP) == QK_UNICODE_MAP && record->event.pressed) {
     const uint32_t* map = unicode_map;

--- a/users/drashna/drashna.h
+++ b/users/drashna/drashna.h
@@ -165,13 +165,8 @@ enum userspace_custom_keycodes {
 
 #define MG_NKRO MAGIC_TOGGLE_NKRO
 
-#ifdef UNICODE_ENABLE
 #define UC_IRNY UC(0x2E2E)
 #define UC_CLUE UC(0x203D)
-#else
-#define UC_IRNY KC_NO
-#define UC_CLUE KC_NO
-#endif
 
 #ifdef TAP_DANCE_ENABLE
 enum {

--- a/users/drashna/drashna.h
+++ b/users/drashna/drashna.h
@@ -165,8 +165,13 @@ enum userspace_custom_keycodes {
 
 #define MG_NKRO MAGIC_TOGGLE_NKRO
 
+#ifdef UNICODE_ENABLE
 #define UC_IRNY UC(0x2E2E)
 #define UC_CLUE UC(0x203D)
+#else
+#define UC_IRNY KC_NO
+#define UC_CLUE KC_NO
+#endif
 
 #ifdef TAP_DANCE_ENABLE
 enum {


### PR DESCRIPTION
Specifically, it wasn't being calling always, so you would have to run it every time.  Which means writing to EEPROM (and as you know, I hate unnecessary writing to EEPROM! :D).

Specifically, the `process_*` function for each unicode method now calls `get_unicode_input_mode()` during it.  The first time it's run after power on, it will read from EEPROM. 
Afterwards, it will read from the static uint, so minimize performance hits by reading EEPROM.