### PR TITLE
process_ucis: Add a callback for success

### DIFF
--- a/quantum/process_keycode/process_ucis.c
+++ b/quantum/process_keycode/process_ucis.c
@@ -32,6 +32,10 @@ void qk_ucis_start_user(void) {
   unicode_input_finish();
 }
 
+__attribute__((weak))
+void qk_ucis_success(uint8_t symbol_index) {
+}
+
 static bool is_uni_seq(char *seq) {
   uint8_t i;
 
@@ -141,6 +145,10 @@ bool process_ucis (uint16_t keycode, keyrecord_t *record) {
       qk_ucis_symbol_fallback();
     }
     unicode_input_finish();
+
+    if (symbol_found) {
+      qk_ucis_success(i);
+    }
 
     qk_ucis_state.in_progress = false;
     return false;

--- a/quantum/process_keycode/process_ucis.h
+++ b/quantum/process_keycode/process_ucis.h
@@ -45,6 +45,7 @@ extern const qk_ucis_symbol_t ucis_symbol_table[];
 void qk_ucis_start(void);
 void qk_ucis_start_user(void);
 void qk_ucis_symbol_fallback (void);
+void qk_ucis_success(uint8_t symbol_index);
 void register_ucis(const char *hex);
 bool process_ucis (uint16_t keycode, keyrecord_t *record);
 


### PR DESCRIPTION
There is `qk_ucis_symbol_fallback` for the case where symbol lookup fails, but there wasn't one for the success case. This adds `qk_ucis_success`, called after successfully finishing the UCIS symbol input.

Thanks to @drashna for the idea!

By default, the callback does nothing, but it can be used to flash LEDs, make sounds, or ask the mechanical hands attached to the keyboard to clap excitedly. The possibilities are endless!