### PR TITLE
Add mousekey_send to (un)register_code

### DIFF
--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -777,6 +777,7 @@ void register_code(uint8_t code)
     #ifdef MOUSEKEY_ENABLE
       else if IS_MOUSEKEY(code) {
         mousekey_on(code);
+        mousekey_send();
       }
     #endif
 }
@@ -841,6 +842,7 @@ void unregister_code(uint8_t code)
     #ifdef MOUSEKEY_ENABLE
       else if IS_MOUSEKEY(code) {
         mousekey_off(code);
+        mousekey_send();
       }
     #endif
 }


### PR DESCRIPTION
It handles mouse keys, but it never actually "sent" the report, so it didn't work.

This should fix that.