### PR TITLE
Add non-US Hash and Backslash to AutoShift handling

### DIFF
--- a/quantum/process_keycode/process_auto_shift.c
+++ b/quantum/process_keycode/process_auto_shift.c
@@ -173,6 +173,8 @@ bool process_auto_shift(uint16_t keycode, keyrecord_t *record) {
       case KC_DOT:
       case KC_SLSH:
       case KC_GRAVE:
+      case KC_NONUS_BSLASH:
+      case KC_NONUS_HASH:
 #endif
 
         autoshift_flush();


### PR DESCRIPTION
Fixes #4070 by adding the non-US characters to the list in process_auto_shift.

Tested and confirmed that this fixes the issue.