### PR TITLE
Add french iso layout for dz60 (thomasviaud)

### DIFF
--- a/keyboards/dz60/keymaps/thomasviaud/README.md
+++ b/keyboards/dz60/keymaps/thomasviaud/README.md
@@ -1,0 +1,4 @@
+## French ISO Layout
+
+Here is a very simple version of a French ISO Layout (handled by OS).
+Feel free to take this as base for your own layout.

--- a/keyboards/dz60/keymaps/thomasviaud/keymap.c
+++ b/keyboards/dz60/keymaps/thomasviaud/keymap.c
@@ -1,0 +1,18 @@
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+	LAYOUT_60_iso(
+		KC_ESC,		KC_1, 		KC_2, 		KC_3, 		KC_4, 		KC_5, 		KC_6, 		KC_7, 		KC_8, 		KC_9, 		KC_0, 		KC_MINS, 	KC_EQL, 	     			KC_BSPC,
+		KC_TAB,					 		KC_Q,			KC_W, 		KC_E, 		KC_R, 		KC_T, 		KC_Y, 		KC_U, 		KC_I, 		KC_O, 		KC_P, 		KC_LBRC, 	KC_RBRC,	
+		KC_CAPS, 						KC_A, 		KC_S, 		KC_D,			KC_F,			KC_G,			KC_H,			KC_J,			KC_K, 		KC_L,			KC_SCLN,	KC_QUOT,  KC_NUHS	,	KC_ENT,
+		KC_LSFT, 	KC_NUBS,	KC_Z, 		KC_X,			KC_C, 		KC_V, 		KC_B, 		KC_N, 		KC_M, 		KC_COMM, 	KC_DOT, 	KC_SLSH, 						KC_RSFT,
+		KC_LCTL, 	KC_LGUI,						KC_LALT, 											KC_SPC, 																KC_RALT, 	KC_RGUI, 					 	MO(1), 		KC_RCTL),
+
+	LAYOUT_60_iso(
+		KC_GRV,		KC_F1, 		KC_F2, 		KC_F3, 		KC_F4, 		KC_F5, 		KC_F6, 		KC_F7, 		KC_F8, 		KC_F9, 		KC_F10, 	KC_F11, 	KC_F12,	      			KC_DEL,
+		_______,					 	_______, 	KC_UP, 		_______, 	_______, 	_______, 	_______, 	_______, 	_______, 	_______, 	_______,  _______, _______,	
+		_______, 						KC_LEFT, 	KC_DOWN, 	KC_RIGHT,	_______,	_______,	_______,	_______,	_______, 	_______,	_______,	_______, _______,		_______,
+		_______, 	_______,	RGB_TOG, 	RGB_MOD, 	RGB_HUI, 	RGB_HUD, 	RGB_SAI, 	RGB_SAD, 	RGB_VAI, 	RGB_VAD, 	_______, 	_______, 					 _______,
+		_______, 	_______,						_______, 											RESET, 																  _______, 	_______, 					 _______, 	_______),
+};


### PR DESCRIPTION
Azerty (FR ISO) layout for DZ60 keyboard.