### PR TITLE
[On Hold] Use default_state_set in eeprom init

### DIFF
--- a/docs/custom_quantum_functions.md
+++ b/docs/custom_quantum_functions.md
@@ -366,6 +366,7 @@ And lastly, you want to add the `eeconfig_init_user` function, so that when the 
 
 ```
 void eeconfig_init_user(void) {  // EEPROM is getting reset! 
+  user_config.raw = 0;
   user_config.rgb_layer_change = true; // We want this enabled by default
   eeconfig_update_user(user_config.raw); // Write default value to EEPROM now
 

--- a/docs/custom_quantum_functions.md
+++ b/docs/custom_quantum_functions.md
@@ -203,7 +203,7 @@ void suspend_wakeup_init_user(void)
 
 ```
 
-### `keyboard_init_*` Function Documentation
+### Keyboard wake/suspend Function Documentation
 
 * Keyboard/Revision: `void suspend_power_down_kb(void)` and `void suspend_wakeup_init_user(void)`
 * Keymap: `void suspend_power_down_kb(void)` and `void suspend_wakeup_init_user(void)`

--- a/tmk_core/common/eeconfig.c
+++ b/tmk_core/common/eeconfig.c
@@ -2,13 +2,13 @@
 #include <stdbool.h>
 #include "eeprom.h"
 #include "eeconfig.h"
+#include "action_layer.h"
 
 #ifdef STM32_EEPROM_ENABLE
 #include "hal.h"
 #include "eeprom_stm32.h"
 #endif
 
-extern uint32_t default_layer_state;
 /** \brief eeconfig enable
  *
  * FIXME: needs doc
@@ -38,7 +38,7 @@ void eeconfig_init_quantum(void) {
   eeprom_update_word(EECONFIG_MAGIC,          EECONFIG_MAGIC_NUMBER);
   eeprom_update_byte(EECONFIG_DEBUG,          0);
   eeprom_update_byte(EECONFIG_DEFAULT_LAYER,  0);
-  default_layer_state = 0;
+  default_layer_set(0);
   eeprom_update_byte(EECONFIG_KEYMAP,         0);
   eeprom_update_byte(EECONFIG_MOUSEKEY_ACCEL, 0);
   eeprom_update_byte(EECONFIG_BACKLIGHT,      0);


### PR DESCRIPTION
Not sure why this wasn't working before, but it's working now. 

So this calls `default_layer_set` when you the eeprom is initialized/reset.