### PR TITLE
Update MSYS' AVR-GCC to use the 5.4.0 toolchain

### DIFF
--- a/util/msys2_install.sh
+++ b/util/msys2_install.sh
@@ -13,9 +13,11 @@ source "$dir/win_shared_install.sh"
 
 function install_avr {
     rm -f -r "$avrtools"
-    wget "http://ww1.microchip.com/downloads/en/DeviceDoc/avr8-gnu-toolchain-installer-3.5.4.91-win32.any.x86.exe"
-    7z x avr8-gnu-toolchain-installer-3.5.4.91-win32.any.x86.exe
-    rm avr8-gnu-toolchain-installer-3.5.4.91-win32.any.x86.exe
+    wget "http://ww1.microchip.com/downloads/en/DeviceDoc/avr8-gnu-toolchain-3.6.1.1752-win32.any.x86.zip"
+    7z x avr8-gnu-toolchain-3.6.1.1752-win32.any.x86.zip
+    mv avr8-gnu-toolchain-win32_x86/ avr8-gnu-toolchain
+    rm __MACOSX -R
+    rm avr8-gnu-toolchain-3.6.1.1752-win32.any.x86.zip
     pacman --needed -S mingw-w64-x86_64-avrdude
 }
 


### PR DESCRIPTION
This updates the MSYS install script to grab the newer  toolchain version AVR-GCC for Windows (version 5.4.0). 

Either way, I tested that it works (it does), and this version actually compiles a bit smaller in size, so it's a bit more efficient. And this should make sure that Travis shows the same size as MSYS systems. 