### PR TITLE
Treasure Type9 Fix: change diode direction to ROW2COL

### DIFF
--- a/keyboards/treasure/type9/config.h
+++ b/keyboards/treasure/type9/config.h
@@ -46,7 +46,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define UNUSED_PINS
 
 /* COL2ROW, ROW2COL, or CUSTOM_MATRIX */
-#define DIODE_DIRECTION COL2ROW
+#define DIODE_DIRECTION ROW2COL
 
 #define BACKLIGHT_PIN B5
 // #define BACKLIGHT_BREATHING


### PR DESCRIPTION
Jukem reported that after flashing, his board is unresponsive. 
Issue was that I chose the wrong DIODE_DIRECTION. 