### PR TITLE
Make type 5 the default sun keyboard.

### DIFF
--- a/keyboards/converter/sun_usb/rules.mk
+++ b/keyboards/converter/sun_usb/rules.mk
@@ -40,3 +40,5 @@ ifdef HARDWARE_SERIAL
 else
         SRC += protocol/serial_soft.c
 endif
+
+DEFAULT_FOLDER = converter/sun_usb/type5


### PR DESCRIPTION
Type 5 is better polished, and probably more common as the last non-USB Sun
keyboard.