### PR TITLE
60_ansi keymap for DZ60

### DIFF
--- a/keyboards/dz60/keymaps/60_ansi/keymap.c
+++ b/keyboards/dz60/keymaps/60_ansi/keymap.c
@@ -1,0 +1,18 @@
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+	LAYOUT_60_ansi(
+		KC_GESC, KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,           KC_BSPC,
+		KC_TAB,           KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS,
+		KC_CAPS,          KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_ENT,
+		KC_LSFT,          KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH,          KC_RSFT,
+		KC_LCTL, KC_LGUI,          KC_LALT,                   KC_SPC,                             KC_RALT, KC_RGUI,          MO(1),   KC_RCTL),
+
+	LAYOUT_60_ansi(
+		KC_GRV,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,           KC_DEL,
+		KC_TRNS,          RGB_TOG, RGB_MOD, RGB_HUI, RGB_HUD, RGB_SAI, RGB_SAD, RGB_VAI, RGB_VAD, KC_TRNS, KC_PSCR, KC_SLCK, KC_PAUS, RESET,
+		KC_TRNS,          KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_INS,  KC_HOME, KC_PGUP, KC_TRNS,
+		KC_TRNS,          KC_TRNS, KC_TRNS, BL_DEC,  BL_TOGG, BL_INC,  BL_STEP, KC_TRNS, KC_DEL,  KC_END,  KC_PGDN,          KC_TRNS,
+		KC_TRNS, KC_TRNS,          KC_TRNS,                   KC_TRNS,                            KC_TRNS, KC_TRNS,          KC_TRNS, KC_TRNS)
+};

--- a/keyboards/dz60/keymaps/60_ansi/readme.md
+++ b/keyboards/dz60/keymaps/60_ansi/readme.md
@@ -1,0 +1,9 @@
+![60_ansi DZ60 base layer](https://i.imgur.com/MqBLh3D.png)
+
+![60_ansi DZ60 fn layer](https://i.imgur.com/ml1djHi.png)
+
+# 60_ansi DZ60 Layout
+
+This is a basic keymap for the 60_ansi layout of the DZ60.
+The default layer is normal ANSI and the Fn layer is used for RGB
+and backlighting functions.


### PR DESCRIPTION
Adding a straight-up 60_ansi keymap (no arrows) for the layout that already existed.

First pull request for QMK - your patience is appreciated :^)