### PR TITLE
Fix LAYOUT define generation

### DIFF
--- a/build_keyboard.mk
+++ b/build_keyboard.mk
@@ -51,31 +51,21 @@ KEYBOARD_PATH_2 := keyboards/$(KEYBOARD_FOLDER_PATH_2)
 KEYBOARD_PATH_3 := keyboards/$(KEYBOARD_FOLDER_PATH_3)
 KEYBOARD_PATH_4 := keyboards/$(KEYBOARD_FOLDER_PATH_4)
 KEYBOARD_PATH_5 := keyboards/$(KEYBOARD_FOLDER_PATH_5)
-KEYBOARD_FILESAFE_1 := $(subst .,,$(subst /,_,$(KEYBOARD_FOLDER_PATH_1)))
-KEYBOARD_FILESAFE_2 := $(subst .,,$(subst /,_,$(KEYBOARD_FOLDER_PATH_2)))
-KEYBOARD_FILESAFE_3 := $(subst .,,$(subst /,_,$(KEYBOARD_FOLDER_PATH_3)))
-KEYBOARD_FILESAFE_4 := $(subst .,,$(subst /,_,$(KEYBOARD_FOLDER_PATH_4)))
-KEYBOARD_FILESAFE_5 := $(subst .,,$(subst /,_,$(KEYBOARD_FOLDER_PATH_5)))
 
 ifneq ("$(wildcard $(KEYBOARD_PATH_5)/)","")
     KEYBOARD_PATHS += $(KEYBOARD_PATH_5)
-    OPT_DEFS += -DKEYBOARD_$(KEYBOARD_FILESAFE_5)
 endif
 ifneq ("$(wildcard $(KEYBOARD_PATH_4)/)","")
     KEYBOARD_PATHS += $(KEYBOARD_PATH_4)
-    OPT_DEFS += -DKEYBOARD_$(KEYBOARD_FILESAFE_4)
 endif
 ifneq ("$(wildcard $(KEYBOARD_PATH_3)/)","")
     KEYBOARD_PATHS += $(KEYBOARD_PATH_3)
-    OPT_DEFS += -DKEYBOARD_$(KEYBOARD_FILESAFE_3)
 endif
 ifneq ("$(wildcard $(KEYBOARD_PATH_2)/)","")
     KEYBOARD_PATHS += $(KEYBOARD_PATH_2)
-    OPT_DEFS += -DKEYBOARD_$(KEYBOARD_FILESAFE_2)
 endif
 ifneq ("$(wildcard $(KEYBOARD_PATH_1)/)","")
     KEYBOARD_PATHS += $(KEYBOARD_PATH_1)
-    OPT_DEFS += -DKEYBOARD_$(KEYBOARD_FILESAFE_1)
 endif
 
 # Pull in rules.mk files from all our subfolders
@@ -120,7 +110,28 @@ ifneq ("$(wildcard $(KEYBOARD_C_1))","")
     KEYBOARD_SRC += $(KEYBOARD_C_1)
 endif
 
+# Generate KEYBOARD_name_subname for all levels of the keyboard folder
+KEYBOARD_FILESAFE_1 := $(subst .,,$(subst /,_,$(KEYBOARD_FOLDER_PATH_1)))
+KEYBOARD_FILESAFE_2 := $(subst .,,$(subst /,_,$(KEYBOARD_FOLDER_PATH_2)))
+KEYBOARD_FILESAFE_3 := $(subst .,,$(subst /,_,$(KEYBOARD_FOLDER_PATH_3)))
+KEYBOARD_FILESAFE_4 := $(subst .,,$(subst /,_,$(KEYBOARD_FOLDER_PATH_4)))
+KEYBOARD_FILESAFE_5 := $(subst .,,$(subst /,_,$(KEYBOARD_FOLDER_PATH_5)))
 
+ifneq ("$(wildcard $(KEYBOARD_PATH_5)/)","")
+    OPT_DEFS += -DKEYBOARD_$(KEYBOARD_FILESAFE_5)
+endif
+ifneq ("$(wildcard $(KEYBOARD_PATH_4)/)","")
+    OPT_DEFS += -DKEYBOARD_$(KEYBOARD_FILESAFE_4)
+endif
+ifneq ("$(wildcard $(KEYBOARD_PATH_3)/)","")
+    OPT_DEFS += -DKEYBOARD_$(KEYBOARD_FILESAFE_3)
+endif
+ifneq ("$(wildcard $(KEYBOARD_PATH_2)/)","")
+    OPT_DEFS += -DKEYBOARD_$(KEYBOARD_FILESAFE_2)
+endif
+ifneq ("$(wildcard $(KEYBOARD_PATH_1)/)","")
+    OPT_DEFS += -DKEYBOARD_$(KEYBOARD_FILESAFE_1)
+endif
 
 # Setup the define for QMK_KEYBOARD_H. This is used inside of keymaps so
 # that the same keymap may be used on multiple keyboards.

--- a/build_keyboard.mk
+++ b/build_keyboard.mk
@@ -51,21 +51,31 @@ KEYBOARD_PATH_2 := keyboards/$(KEYBOARD_FOLDER_PATH_2)
 KEYBOARD_PATH_3 := keyboards/$(KEYBOARD_FOLDER_PATH_3)
 KEYBOARD_PATH_4 := keyboards/$(KEYBOARD_FOLDER_PATH_4)
 KEYBOARD_PATH_5 := keyboards/$(KEYBOARD_FOLDER_PATH_5)
+KEYBOARD_FILESAFE_1 := $(subst .,,$(subst /,_,$(KEYBOARD_FOLDER_PATH_1)))
+KEYBOARD_FILESAFE_2 := $(subst .,,$(subst /,_,$(KEYBOARD_FOLDER_PATH_2)))
+KEYBOARD_FILESAFE_3 := $(subst .,,$(subst /,_,$(KEYBOARD_FOLDER_PATH_3)))
+KEYBOARD_FILESAFE_4 := $(subst .,,$(subst /,_,$(KEYBOARD_FOLDER_PATH_4)))
+KEYBOARD_FILESAFE_5 := $(subst .,,$(subst /,_,$(KEYBOARD_FOLDER_PATH_5)))
 
 ifneq ("$(wildcard $(KEYBOARD_PATH_5)/)","")
     KEYBOARD_PATHS += $(KEYBOARD_PATH_5)
+    OPT_DEFS += -DKEYBOARD_$(KEYBOARD_FILESAFE_5)
 endif
 ifneq ("$(wildcard $(KEYBOARD_PATH_4)/)","")
     KEYBOARD_PATHS += $(KEYBOARD_PATH_4)
+    OPT_DEFS += -DKEYBOARD_$(KEYBOARD_FILESAFE_4)
 endif
 ifneq ("$(wildcard $(KEYBOARD_PATH_3)/)","")
     KEYBOARD_PATHS += $(KEYBOARD_PATH_3)
+    OPT_DEFS += -DKEYBOARD_$(KEYBOARD_FILESAFE_3)
 endif
 ifneq ("$(wildcard $(KEYBOARD_PATH_2)/)","")
     KEYBOARD_PATHS += $(KEYBOARD_PATH_2)
+    OPT_DEFS += -DKEYBOARD_$(KEYBOARD_FILESAFE_2)
 endif
 ifneq ("$(wildcard $(KEYBOARD_PATH_1)/)","")
     KEYBOARD_PATHS += $(KEYBOARD_PATH_1)
+    OPT_DEFS += -DKEYBOARD_$(KEYBOARD_FILESAFE_1)
 endif
 
 # Pull in rules.mk files from all our subfolders
@@ -110,7 +120,6 @@ ifneq ("$(wildcard $(KEYBOARD_C_1))","")
     KEYBOARD_SRC += $(KEYBOARD_C_1)
 endif
 
-OPT_DEFS += -DKEYBOARD_$(KEYBOARD_FILESAFE)
 
 
 # Setup the define for QMK_KEYBOARD_H. This is used inside of keymaps so


### PR DESCRIPTION
Prior to this, only the full keyboard path was defined.  Eg `KEYBOARD_planck_rev6`. But the docs mention `KEYBOAD_planck`, which never actually gets defined.

This addresses this, and creates a define for each level of the keyboard folder, so that stuff like `KEYBOARD_planck` actually exists.