### PR TITLE
optimize rgblight_effect_alternating(void)

### DIFF
--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -860,13 +860,13 @@ void rgblight_effect_alternating(void){
   last_timer = timer_read();
 
   for(int i = 0; i<RGBLED_NUM; i++){
-		  if(i<RGBLED_NUM/2 && pos){
-			  rgblight_sethsv_at(rgblight_config.hue, rgblight_config.sat, rgblight_config.val, i);
-		  }else if (i>=RGBLED_NUM/2 && !pos){
-			  rgblight_sethsv_at(rgblight_config.hue, rgblight_config.sat, rgblight_config.val, i);
-		  }else{
-			  rgblight_sethsv_at(rgblight_config.hue, rgblight_config.sat, 0, i);
-		  }
+      if(i<RGBLED_NUM/2 && pos){
+          sethsv(rgblight_config.hue, rgblight_config.sat, rgblight_config.val, (LED_TYPE *)&led[i]);
+      }else if (i>=RGBLED_NUM/2 && !pos){
+          sethsv(rgblight_config.hue, rgblight_config.sat, rgblight_config.val, (LED_TYPE *)&led[i]);
+      }else{
+          sethsv(rgblight_config.hue, rgblight_config.sat, 0, (LED_TYPE *)&led[i]);
+      }
   }
   rgblight_set();
   pos = (pos + 1) % 2;


### PR DESCRIPTION
rgblight_effect_alternating(void) calls rgblight_sethsv_at() RGBLED_NUM times. As a result, rgblight_set() is called RGBLED_NUM + 1 times. This is wasteful processing.