### PR TITLE
Doesn't need a 50ms debounce

### DIFF
--- a/keyboards/catch22/config.h
+++ b/keyboards/catch22/config.h
@@ -39,7 +39,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define DIODE_DIRECTION COL2ROW
 
 /* Set 0 if debouncing isn't needed */
-#define DEBOUNCING_DELAY 50
+// #define DEBOUNCING_DELAY 0
 
 /* key combination for command */
 #define IS_COMMAND() ( \


### PR DESCRIPTION
Set it to default. I have no idea what I was thinking. I think this was a left over from the big switch keyboard I copied over. It makes sense to have a high debounce value for the big switch because the switch is physically large and slow.