### PR TITLE
Updates docs - planck.6 and macos instructions

### DIFF
--- a/docs/faq_build.md
+++ b/docs/faq_build.md
@@ -105,10 +105,12 @@ The solution is to remove and reinstall all affected modules.
 ```
 brew rm avr-gcc
 brew rm dfu-programmer
+brew rm dfu-util
 brew rm gcc-arm-none-eabi
 brew rm avrdude
 brew install avr-gcc
 brew install dfu-programmer
+brew install dfu-util
 brew install gcc-arm-none-eabi
 brew install avrdude
 ```

--- a/docs/getting_started_build_tools.md
+++ b/docs/getting_started_build_tools.md
@@ -58,6 +58,7 @@ If you're using [homebrew,](http://brew.sh/) you can use the following commands:
     brew update
     brew install avr-gcc@7
     brew install dfu-programmer
+    brew install dfu-util
     brew install gcc-arm-none-eabi
     brew install avrdude
 

--- a/keyboards/planck/readme.md
+++ b/keyboards/planck/readme.md
@@ -13,4 +13,8 @@ Make example for this keyboard (after setting up your build environment):
 
     make planck/rev4:default
 
+Install examples:
+
+    make planck/rev6:default:dfu-util
+
 See [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) then the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information.


### PR DESCRIPTION
I was helping a buddy with his just-arrived Planck rev6 on Friday, and I *could not* find out what upload tool we were supposed to use.  Eventually I saw someone referencing dfu-util, and figured it was worth a shot.  We hadn't installed it as part of the "getting started" instructions, but once we did it installed correctly.

So I'm adding two things: mention `brew install dfu-util` in the getting started docs, and then added `make planck/rev6:default:dfu-util` in a new "Install examples" in the Planck Readme.