### PR TITLE
keycodes: add screen brightness up/down usages

### DIFF
--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -191,6 +191,8 @@ This is a reference only. Each group of keys links to the page documenting their
 |`KC_MEDIA_PLAY_PAUSE`  |`KC_MPLY`           |Play/Pause Track                               |
 |`KC_MEDIA_SELECT`      |`KC_MSEL`           |Launch Media Player (Windows)                  |
 |`KC_MEDIA_EJECT`       |`KC_EJCT`           |Eject (macOS)                                  |
+|`KC_SCREEN_BRIGHTNESS_UP`   | `KC_SBRU`       |Increase screen brightness                   |
+|`KC_SCREEN_BRIGHTNESS_DOWN` | `KC_SBRD`       |Decrease screen brightness                   |
 |`KC_MAIL`              |                    |Launch Mail (Windows)                          |
 |`KC_CALCULATOR`        |`KC_CALC`           |Launch Calculator (Windows)                    |
 |`KC_MY_COMPUTER`       |`KC_MYCM`           |Launch My Computer (Windows)                   |

--- a/quantum/keymap_common.c
+++ b/quantum/keymap_common.c
@@ -64,7 +64,7 @@ action_t action_for_key(uint8_t layer, keypos_t key)
         case KC_SYSTEM_POWER ... KC_SYSTEM_WAKE:
             action.code = ACTION_USAGE_SYSTEM(KEYCODE2SYSTEM(keycode));
             break;
-        case KC_AUDIO_MUTE ... KC_MEDIA_REWIND:
+        case KC_AUDIO_MUTE ... KC_SCREEN_BRIGHTNESS_DOWN:
             action.code = ACTION_USAGE_CONSUMER(KEYCODE2CONSUMER(keycode));
             break;
         case KC_MS_UP ... KC_MS_ACCEL2:

--- a/tmk_core/common/keycode.h
+++ b/tmk_core/common/keycode.h
@@ -158,6 +158,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define KC_MPLY KC_MEDIA_PLAY_PAUSE
 #define KC_MSEL KC_MEDIA_SELECT
 #define KC_EJCT KC_MEDIA_EJECT
+#define KC_SBRU KC_SCREEN_BRIGHTNESS_UP
+#define KC_SBRD KC_SCREEN_BRIGHTNESS_DOWN
 #define KC_MAIL KC_MAIL
 #define KC_CALC KC_CALCULATOR
 #define KC_MYCM KC_MY_COMPUTER
@@ -457,6 +459,8 @@ enum internal_special_keycodes {
   KC_WWW_FAVORITES,
   KC_MEDIA_FAST_FORWARD,
   KC_MEDIA_REWIND,
+  KC_SCREEN_BRIGHTNESS_UP,
+  KC_SCREEN_BRIGHTNESS_DOWN,
 
   /* Fn keys */
   KC_FN0                  = 0xC0,

--- a/tmk_core/common/report.h
+++ b/tmk_core/common/report.h
@@ -45,6 +45,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define TRANSPORT_STOP          0x00B7
 #define TRANSPORT_STOP_EJECT    0x00CC
 #define TRANSPORT_PLAY_PAUSE    0x00CD
+#define SCREEN_BRIGHTNESS_UP    0x006F
+#define SCREEN_BRIGHTNESS_DOWN  0x0070
 /* application launch */
 #define AL_CC_CONFIG            0x0183
 #define AL_EMAIL                0x018A
@@ -166,6 +168,8 @@ typedef struct {
     (key == KC_MEDIA_EJECT      ?  TRANSPORT_STOP_EJECT : \
     (key == KC_MEDIA_PLAY_PAUSE ?  TRANSPORT_PLAY_PAUSE : \
     (key == KC_MEDIA_SELECT     ?  AL_CC_CONFIG : \
+    (key == KC_SCREEN_BRIGHTNESS_UP ? SCREEN_BRIGHTNESS_UP : \
+    (key == KC_SCREEN_BRIGHTNESS_DOWN ? SCREEN_BRIGHTNESS_DOWN : \
     (key == KC_MAIL             ?  AL_EMAIL : \
     (key == KC_CALCULATOR       ?  AL_CALCULATOR : \
     (key == KC_MY_COMPUTER      ?  AL_LOCAL_BROWSER : \
@@ -175,7 +179,7 @@ typedef struct {
     (key == KC_WWW_FORWARD      ?  AC_FORWARD : \
     (key == KC_WWW_STOP         ?  AC_STOP : \
     (key == KC_WWW_REFRESH      ?  AC_REFRESH : \
-    (key == KC_WWW_FAVORITES    ?  AC_BOOKMARKS : 0)))))))))))))))))))))
+    (key == KC_WWW_FAVORITES    ?  AC_BOOKMARKS : 0)))))))))))))))))))))))
 
 uint8_t has_anykey(report_keyboard_t* keyboard_report);
 uint8_t get_first_key(report_keyboard_t* keyboard_report);


### PR DESCRIPTION
These are supported by Windows and Linux at least. Not tested on OS X. Anyone have a Mac handy?

Windows reference: https://docs.microsoft.com/en-us/windows-hardware/drivers/hid/display-brightness-control