### PR TITLE
Update Dockerfile to support build keyboard by giving a path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,9 @@ RUN apt-get update && apt-get install --no-install-recommends -y build-essential
     avrdude \
     && rm -rf /var/lib/apt/lists/*
 
-ENV keyboard=ergodox
-ENV subproject=ez
+ENV keyboard=ergodox_ez
 ENV keymap=default
 
 VOLUME /qmk
 WORKDIR /qmk
-CMD make clean ; make keyboard=${keyboard} subproject=${subproject} keymap=${keymap}
+CMD make clean ; make ${keyboard}:${keymap}

--- a/docs/getting_started_build_tools.md
+++ b/docs/getting_started_build_tools.md
@@ -126,9 +126,9 @@ If this is a bit complex for you, Docker might be the turn-key solution you need
 ```bash
 # You'll run this every time you want to build a keymap
 # modify the keymap and keyboard assignment to compile what you want
-# defaults are ergodox/default
+# defaults are ergodox_ez:default
 
-docker run -e keymap=gwen -e keyboard=ergodox_ez --rm -v $('pwd'):/qmk:rw edasque/qmk_firmware
+docker run -e keymap=default -e keyboard=handwired/dactyl_manuform/4x5 --rm -v $('pwd'):/qmk:rw edasque/qmk_firmware
 ```
 
 On Windows Docker seems to have issues with the VOLUME tag in Dockerfile, and `$('pwd')` won't print a Windows compliant path; use full path instead, like this:


### PR DESCRIPTION
The QMK docker image requires two environment variables `keyboard` and `subproject` to specify the keyboard to be built. However the makefile has been changed to accept a path to the keyboard folder. Using current docker image, it's unable to build a keyboard which folder is inside a subfolder deeper than two levels, for example: `handwired/dactyl_manuform/4x5`.

This PR changes the `keyboard` environment variable to a path. It aligns with the usage of `make`.

``` shell
docker run -e keymap=default -e keyboard=handwired/dactyl_manuform/4x5 --rm -v $('pwd'):/qmk:rw edasque/qmk_firmware
```