### PR TITLE
Add EEPROM_RESET keycode to core code

### DIFF
--- a/docs/quantum_keycodes.md
+++ b/docs/quantum_keycodes.md
@@ -8,15 +8,16 @@ On this page we have documented keycodes between `0x00FF` and `0xFFFF` which are
 
 ## QMK Keycodes
 
-|Key          |Aliases    |Description                                                          |
-|-------------|-----------|---------------------------------------------------------------------|
-|`RESET`      |           |Put the keyboard into DFU mode for flashing                          |
-|`DEBUG`      |           |Toggle debug mode                                                    |
-|`KC_GESC`    |`GRAVE_ESC`|Escape when tapped, <code>&#96;</code> when pressed with Shift or GUI|
-|`KC_LSPO`    |           |Left Shift when held, `(` when tapped                                |
-|`KC_RSPC`    |           |Right Shift when held, `)` when tapped                               |
-|`KC_LEAD`    |           |The [Leader key](feature_leader_key.md)                              |
-|`KC_LOCK`    |           |The [Lock key](feature_key_lock.md)                                  |
-|`FUNC(n)`    |`F(n)`     |Call `fn_action(n)` (deprecated)                                     |
-|`M(n)`       |           |Call macro `n`                                                       |
-|`MACROTAP(n)`|           |Macro-tap `n` idk FIXME                                              |
+|Key            |Aliases    |Description                                                          |
+|---------------|-----------|---------------------------------------------------------------------|
+|`RESET`        |           |Put the keyboard into DFU mode for flashing                          |
+|`DEBUG`        |           |Toggle debug mode                                                    |
+|`EEPROM_RESET` |`EEPRST`   |Resets EEPROM state by reinitializing it                             |
+|`KC_GESC`      |`GRAVE_ESC`|Escape when tapped, <code>&#96;</code> when pressed with Shift or GUI|
+|`KC_LSPO`      |           |Left Shift when held, `(` when tapped                                |
+|`KC_RSPC`      |           |Right Shift when held, `)` when tapped                               |
+|`KC_LEAD`      |           |The [Leader key](feature_leader_key.md)                              |
+|`KC_LOCK`      |           |The [Lock key](feature_key_lock.md)                                  |
+|`FUNC(n)`      |`F(n)`     |Call `fn_action(n)` (deprecated)                                     |
+|`M(n)`         |           |Call macro `n`                                                       |
+|`MACROTAP(n)`  |           |Macro-tap `n` idk FIXME                                              |

--- a/docs/quantum_keycodes.md
+++ b/docs/quantum_keycodes.md
@@ -12,7 +12,7 @@ On this page we have documented keycodes between `0x00FF` and `0xFFFF` which are
 |---------------|-----------|---------------------------------------------------------------------|
 |`RESET`        |           |Put the keyboard into DFU mode for flashing                          |
 |`DEBUG`        |           |Toggle debug mode                                                    |
-|`EEPROM_RESET` |`EEPRST`   |Resets EEPROM state by reinitializing it                             |
+|`EEPROM_RESET` |`EEP_RST`  |Resets EEPROM state by reinitializing it                             |
 |`KC_GESC`      |`GRAVE_ESC`|Escape when tapped, <code>&#96;</code> when pressed with Shift or GUI|
 |`KC_LSPO`      |           |Left Shift when held, `(` when tapped                                |
 |`KC_RSPC`      |           |Right Shift when held, `)` when tapped                               |

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -298,6 +298,11 @@ bool process_record_quantum(keyrecord_t *record) {
           print("DEBUG: enabled.\n");
       }
     return false;
+    case EEPROM_RESET:
+      if (record->event.pressed) {
+          eeconfig_init();
+      }
+    return false;
   #ifdef FAUXCLICKY_ENABLE
   case FC_TOG:
     if (record->event.pressed) {

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -460,8 +460,6 @@ enum quantum_keycodes {
     SAFE_RANGE
 };
 
-#define EEPRST EEPROM_RESET
-
 // Ability to use mods in layouts
 #define LCTL(kc) (QK_LCTL | (kc))
 #define LSFT(kc) (QK_LSFT | (kc))
@@ -573,6 +571,8 @@ enum quantum_keycodes {
 #define MACRODOWN(...) (record->event.pressed ? MACRO(__VA_ARGS__) : MACRO_NONE)
 
 #define KC_GESC GRAVE_ESC
+
+#define EEP_RST EEPROM_RESET
 
 #define CK_TOGG CLICKY_TOGGLE
 #define CK_RST CLICKY_RESET

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -97,6 +97,7 @@ enum quantum_keycodes {
 
     RESET = 0x5C00,
     DEBUG,
+    EEPROM_RESET,
     MAGIC_SWAP_CONTROL_CAPSLOCK,
     MAGIC_CAPSLOCK_TO_CONTROL,
     MAGIC_SWAP_LALT_LGUI,
@@ -457,6 +458,8 @@ enum quantum_keycodes {
     // always leave at the end
     SAFE_RANGE
 };
+
+#define EEPRST EEPROM_RESET
 
 // Ability to use mods in layouts
 #define LCTL(kc) (QK_LCTL | (kc))

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -97,7 +97,6 @@ enum quantum_keycodes {
 
     RESET = 0x5C00,
     DEBUG,
-    EEPROM_RESET,
     MAGIC_SWAP_CONTROL_CAPSLOCK,
     MAGIC_CAPSLOCK_TO_CONTROL,
     MAGIC_SWAP_LALT_LGUI,
@@ -454,6 +453,8 @@ enum quantum_keycodes {
     TERM_ON,
     TERM_OFF,
 #endif
+
+    EEPROM_RESET,
 
     // always leave at the end
     SAFE_RANGE


### PR DESCRIPTION
This allows users to reset the eeprom with a press of the button, rather than using bootmagic or other arcane methods.