### PR TITLE
Fix incorrect doctoring in feature_backlight.md

### DIFF
--- a/docs/feature_backlight.md
+++ b/docs/feature_backlight.md
@@ -61,7 +61,7 @@ In this handler, the value of an incrementing counter is mapped onto a precomput
 |`backlight_increase()` |Increase the backlight level                 |
 |`backlight_decrease()` |Decrease the backlight level                 |
 |`backlight_level(x)`   |Sets the backlight level to specified level  |
-|`get_backlight_level()`|Toggle backlight breathing                   |
+|`get_backlight_level()`|Return the current backlight level           |
 
 ### Backlight Breathing Functions
 


### PR DESCRIPTION
I'm guessing someone deleted a row at some point in the past, but I didn't blame it.