### PR TITLE
Add delay in Tap Code to avoid issues

### DIFF
--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -851,6 +851,16 @@ void unregister_code(uint8_t code)
  *
  * FIXME: Needs documentation.
  */
+void tap_code(uint8_t code) {
+  register_code(code);
+  wait_ms(100);
+  unregister_code(code);
+}
+
+/** \brief Utilities for actions. (FIXME: Needs better description)
+ *
+ * FIXME: Needs documentation.
+ */
 void register_mods(uint8_t mods)
 {
     if (mods) {

--- a/tmk_core/common/action.h
+++ b/tmk_core/common/action.h
@@ -88,7 +88,7 @@ void process_record(keyrecord_t *record);
 void process_action(keyrecord_t *record, action_t action);
 void register_code(uint8_t code);
 void unregister_code(uint8_t code);
-inline void tap_code(uint8_t code) { register_code(code); unregister_code(code); }
+void tap_code(uint8_t code);
 void register_mods(uint8_t mods);
 void unregister_mods(uint8_t mods);
 //void set_mods(uint8_t mods);


### PR DESCRIPTION
I think a few people have reporting issues with it working properly, and it may be a timing issue.  The 'register_code' uses this sort of delay in some of the functions, and
this is probably why.

Adding the 100ms delay should hopefully fix any issues with it.