### PR TITLE
Backlight status functions

### DIFF
--- a/docs/feature_backlight.md
+++ b/docs/feature_backlight.md
@@ -57,6 +57,9 @@ In this handler, the value of an incrementing counter is mapped onto a precomput
 |Function  |Description                                               |
 |----------|----------------------------------------------------------|
 |`backlight_toggle()`   |Turn the backlight on or off                 |
+|`backlight_enable()`   |Turn the backlight on                        |
+|`backlight_disable()`  |Turn the backlight off                       |
+|`backlight_enabled()`  |Return whether the backlight is currently on |
 |`backlight_step()`     |Cycle through backlight levels               |
 |`backlight_increase()` |Increase the backlight level                 |
 |`backlight_decrease()` |Decrease the backlight level                 |

--- a/docs/feature_backlight.md
+++ b/docs/feature_backlight.md
@@ -54,17 +54,17 @@ In this handler, the value of an incrementing counter is mapped onto a precomput
 
 ## Backlight Functions
 
-|Function  |Description                                               |
-|----------|----------------------------------------------------------|
-|`backlight_toggle()`   |Turn the backlight on or off                 |
-|`backlight_enable()`   |Turn the backlight on                        |
-|`backlight_disable()`  |Turn the backlight off                       |
-|`backlight_enabled()`  |Return whether the backlight is currently on |
-|`backlight_step()`     |Cycle through backlight levels               |
-|`backlight_increase()` |Increase the backlight level                 |
-|`backlight_decrease()` |Decrease the backlight level                 |
-|`backlight_level(x)`   |Sets the backlight level to specified level  |
-|`get_backlight_level()`|Return the current backlight level           |
+|Function  |Description                                                |
+|----------|-----------------------------------------------------------|
+|`backlight_toggle()`    |Turn the backlight on or off                 |
+|`backlight_enable()`    |Turn the backlight on                        |
+|`backlight_disable()`   |Turn the backlight off                       |
+|`backlight_step()`      |Cycle through backlight levels               |
+|`backlight_increase()`  |Increase the backlight level                 |
+|`backlight_decrease()`  |Decrease the backlight level                 |
+|`backlight_level(x)`    |Sets the backlight level to specified level  |
+|`get_backlight_level()` |Return the current backlight level           |
+|`is_backlight_enabled()`|Return whether the backlight is currently on |
 
 ### Backlight Breathing Functions
 

--- a/tmk_core/common/backlight.c
+++ b/tmk_core/common/backlight.c
@@ -118,7 +118,7 @@ void backlight_disable(void)
  *
  * FIXME: needs doc
  */
-bool backlight_enabled(void)
+bool is_backlight_enabled(void)
 {
 	return backlight_config.enable;
 }

--- a/tmk_core/common/backlight.c
+++ b/tmk_core/common/backlight.c
@@ -114,6 +114,13 @@ void backlight_disable(void)
 	backlight_set(0);
 }
 
+/** /brief Get the backlight status
+ *
+ * FIXME: needs doc
+ */
+bool backlight_enabled(void)
+{
+	return backlight_config.enable;
 }
 
 /** \brief Backlight step through levels

--- a/tmk_core/common/backlight.c
+++ b/tmk_core/common/backlight.c
@@ -76,12 +76,44 @@ void backlight_decrease(void)
  */
 void backlight_toggle(void)
 {
-    backlight_config.enable ^= 1;
-    if (backlight_config.raw == 1) // enabled but level = 0
-        backlight_config.level = 1;
-    eeconfig_update_backlight(backlight_config.raw);
-    dprintf("backlight toggle: %u\n", backlight_config.enable);
-    backlight_set(backlight_config.enable ? backlight_config.level : 0);
+	bool enabled = backlight_config.enable;
+	dprintf("backlight toggle: %u\n", enabled);
+	if (enabled) 
+		backlight_disable();
+	else
+		backlight_enable();
+}
+
+/** \brief Enable backlight
+ *
+ * FIXME: needs doc
+ */
+void backlight_enable(void)
+{
+	if (backlight_config.enable) return; // do nothing if backlight is already on
+
+	backlight_config.enable = true;
+	if (backlight_config.raw == 1) // enabled but level == 0
+		backlight_config.level = 1;
+	eeconfig_update_backlight(backlight_config.raw);
+	dprintf("backlight enable\n");
+	backlight_set(backlight_config.level);
+}
+
+/** /brief Disable backlight
+ *
+ * FIXME: needs doc
+ */
+void backlight_disable(void)
+{
+	if (!backlight_config.enable) return; // do nothing if backlight is already off
+
+	backlight_config.enable = false;
+	eeconfig_update_backlight(backlight_config.raw);
+	dprintf("backlight disable\n");
+	backlight_set(0);
+}
+
 }
 
 /** \brief Backlight step through levels

--- a/tmk_core/common/backlight.h
+++ b/tmk_core/common/backlight.h
@@ -34,7 +34,7 @@ void backlight_decrease(void);
 void backlight_toggle(void);
 void backlight_enable(void);
 void backlight_disable(void);
-bool backlight_enabled(void);
+bool is_backlight_enabled(void);
 void backlight_step(void);
 void backlight_set(uint8_t level);
 void backlight_level(uint8_t level);

--- a/tmk_core/common/backlight.h
+++ b/tmk_core/common/backlight.h
@@ -34,6 +34,7 @@ void backlight_decrease(void);
 void backlight_toggle(void);
 void backlight_enable(void);
 void backlight_disable(void);
+bool backlight_enabled(void);
 void backlight_step(void);
 void backlight_set(uint8_t level);
 void backlight_level(uint8_t level);

--- a/tmk_core/common/backlight.h
+++ b/tmk_core/common/backlight.h
@@ -32,7 +32,10 @@ void backlight_init(void);
 void backlight_increase(void);
 void backlight_decrease(void);
 void backlight_toggle(void);
+void backlight_enable(void);
+void backlight_disable(void);
 void backlight_step(void);
 void backlight_set(uint8_t level);
 void backlight_level(uint8_t level);
 uint8_t get_backlight_level(void);
+


### PR DESCRIPTION
Currently, the only way to set the backlight state is through `backlight_toggle()`, and there is no exposed way to get the current backlight state.

This PR adds `backlight_enable()`, `backlight_disable()`, and `backlight_enabled()` to cover this.