### PR TITLE
Fix line endings in Qwertyydox

### DIFF
--- a/keyboards/qwertyydox/rules.mk
+++ b/keyboards/qwertyydox/rules.mk
@@ -36,7 +36,7 @@ F_USB = $(F_CPU)
 
 # Bootloader
 #     This definition is optional, and if your keyboard supports multiple bootloaders of
-#     different sizes, comment this out, and the correct address will be loaded 
+#     different sizes, comment this out, and the correct address will be loaded
 #     automatically (+60). See bootloader.mk for all options.
 BOOTLOADER = caterina
 
@@ -58,7 +58,7 @@ MIDI_ENABLE = no            # MIDI controls
 AUDIO_ENABLE = no           # Audio output on port C6
 UNICODE_ENABLE = no         # Unicode
 BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
-RGBLIGHT_ENABLE = no       # Enable WS2812 RGB underlight. 
+RGBLIGHT_ENABLE = no       # Enable WS2812 RGB underlight.
 SUBPROJECT_rev1 = yes
 USE_I2C = yes               # I2C is used between the sides
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE


### PR DESCRIPTION
The rules.mk is using CRLF....  This fixes it.

Fixes #4280