### PR TITLE
Keymap: add jyh levinson keymaps

### DIFF
--- a/keyboards/levinson/keymaps/jyh/config.h
+++ b/keyboards/levinson/keymaps/jyh/config.h
@@ -1,0 +1,40 @@
+/*
+This is the c configuration file for the keymap
+
+Copyright 2012 Jun Wako <wakojun@gmail.com>
+Copyright 2015 Jack Humbert
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef CONFIG_USER_H
+#define CONFIG_USER_H
+
+#include "config_common.h"
+
+/* Select hand configuration */
+
+#define MASTER_LEFT
+// #define MASTER_RIGHT
+// #define EE_HANDS
+
+/* Tap Dance timing */
+#define TAPPING_TERM 150
+
+/* Toggling layer requires # taps */
+#define TAPPING_TOGGLE 2
+
+
+
+#endif

--- a/keyboards/levinson/keymaps/jyh/config.h
+++ b/keyboards/levinson/keymaps/jyh/config.h
@@ -17,24 +17,13 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "config_common.h"
+#pragma once
 
 /* Select hand configuration */
-
 #define MASTER_LEFT
-// #define MASTER_RIGHT
-// #define EE_HANDS
 
 /* Tap Dance timing */
 #define TAPPING_TERM 150
 
 /* Toggling layer requires # taps */
 #define TAPPING_TOGGLE 2
-
-
-
-#endif

--- a/keyboards/levinson/keymaps/jyh/keymap.c
+++ b/keyboards/levinson/keymaps/jyh/keymap.c
@@ -1,0 +1,232 @@
+#include "levinson.h"
+#include "action_layer.h"
+#include "eeconfig.h"
+
+
+extern keymap_config_t keymap_config;
+
+// Each layer gets a name for readability, which is then used in the keymap matrix below.
+// The underscores don't mean anything - you can have a layer called STUFF or any other name.
+// Layer names don't all need to be of the same length, obviously, and you can also skip them
+// entirely and just use numbers.
+#define _QWERTY 0
+#define _LOWER 3																/* Symbols, Media */
+#define _RAISE 4																/* Numbers, Arrows */
+#define _FUNC  5																/* Function Keys */
+#define _NUMS  6																/* Numpad */
+#define _ADJUST 16
+
+enum custom_keycodes {
+  QWERTY = SAFE_RANGE,
+  LOWER,
+  RAISE,
+  ADJUST,
+};
+
+// Fillers to make layering more clear
+#define KC_ KC_TRNS
+#define _______ KC_TRNS
+#define XXXXXXX KC_NO
+
+// tap toggle numpad on
+#define NUMPAD TT(_NUMS)
+
+// Mod Tap Definitions
+// -------------------
+                                      //  Tap     Hold
+                                      //  ------------------
+#define CTL_ESC MT(MOD_LCTL, KC_ESC)  //  Esc     Left Control
+#define SFT_ENT MT(MOD_RSFT, KC_ENT)  //  Enter   Right Shift
+#define CTL_SPC MT(MOD_LCTL, KC_SPC)  //  Space   Left Control
+#define ALT_SPC MT(MOD_LALT, KC_SPC)  //  Space   Left Alt
+#define ALT_BSP MT(MOD_LALT, KC_BSPC) //  Bkspace Left Alt
+#define HPR_TAB MT(MOD_HYPR, KC_TAB)  //  Tab     Hyper (Super+Ctrl+Alt+Shift)
+#define HPR_GRV MT(MOD_HYPR, KC_GRV)  //  `       Hyper
+#define HPR_TIL MT(MOD_HYPR, KC_TILD) //  ~       Hyper
+#define MEH_TIL MT(MOD_MEH,  KC_GRV)  //  `       Meh (Ctrl+Alt+Shift)
+#define SFT_MIN MT(MOD_LSFT, KC_MINS) //  -       Left Shift
+#define NPD_UND LT(_NUMS,    KC_UNDS) //  _       Layer Numpad
+#define FNC_PIP LT(_FUNC,    KC_PIPE) //  |       Layer Function Keys
+
+#define CTL_DEL MT(MOD_LCTL, KC_DEL)  //  Del     Left Control
+#define CTL_QOT MT(MOD_RCTL, KC_QUOT) //  '       Right Control
+#define CTL_BSL MT(MOD_RCTL, KC_BSLS) //  \       Right Control
+#define CTL_PIP MT(MOD_RCTL, KC_PIPE) //  |       Right Control
+
+// Redefine for KC_KEYMAP
+#define KC_CTL_BSL CTL_BSL
+#define KC_CTL_PIP CTL_PIP
+#define KC_CTL_DEL CTL_DEL
+#define KC_HPR_TIL HPR_TIL
+#define KC_HPR_GRV HPR_GRV
+
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+/* Qwerty
+ *
+ * ,-----------------------------------------.    ,-----------------------------------------.
+ * | Tab  |  Q   |  W   |  E   |  R   |  T   |    |  Y   |  U   |  I   |  O   |  P   | Bksp |
+ * |------+------+------+------+------+------|    |------+------+------+------+------+------|
+ * | Esc  |  A   |  S   |  D   |  F   |  G   |    |  H   |  J   |  K   |  L   |  ;   |  '   |
+ * |------+------+------+------+------+------|    |------+------+------+------+------+------|
+ * |  -   |  Z   |  X   |  C   |  V   |  B   |    |  N   |  M   |  ,   |  .   |  /   | Enter|
+ * |------+------+------+------+------+------|    |------+------+------+------+------+------|
+ * | Numpd| Meh  | Meta | Alt  | Lower| Space|    | Space| Raise| Alt  | Meta | Hyper| Func |
+ * `-----------------------------------------'    `-----------------------------------------'
+ *
+ * with Hold (Emacs-oriented)
+ * ,-----------------------------------------.    ,-----------------------------------------.
+ * | Hyper|      |      |      |      |      |    |      |      |      |      |      |      |
+ * |------+------+------+------+------+------|    |------+------+------+------+------+------|
+ * | Ctrl |      |      |      |      |      |    |      |      |      |      |      | Ctrl |
+ * |------+------+------+------+------+------|    |------+------+------+------+------+------|
+ * | Shift|      |      |      |      |      |    |      |      |      |      |      | Shift|
+ * |------+------+------+------+------+------|    |------+------+------+------+------+------|
+ * |      |      |      |      |      |      |    |      |      |      |      |      |      |
+ * `-----------------------------------------'    `-----------------------------------------'
+ */
+				[_QWERTY] = KEYMAP(
+								HPR_TAB, KC_Q   , KC_W   , KC_E   , KC_R , KC_T   ,    KC_Y   , KC_U , KC_I   , KC_O   , KC_P   , KC_BSPC,
+								CTL_ESC, KC_A   , KC_S   , KC_D   , KC_F , KC_G   ,    KC_H   , KC_J , KC_K   , KC_L   , KC_SCLN, CTL_QOT,
+								SFT_MIN, KC_Z   , KC_X   , KC_C   , KC_V , KC_B   ,    KC_N   , KC_M , KC_COMM, KC_DOT , KC_SLSH, SFT_ENT,
+								NUMPAD , KC_MEH , KC_LGUI, KC_LALT, LOWER, CTL_SPC,    KC_SPC, RAISE, KC_RALT, KC_RGUI, KC_HYPR, MO(_FUNC)
+								),
+
+
+/* Raise
+ * ,-----------------------------------------.    ,-----------------------------------------.
+ * |  `   |  1   |  2   |  3   |  4   |  5   |    |  6   |  7   |  8   |  9   |  0   |      |
+ * |------+------+------+------+------+------|    |------+------+------+------+------+------|
+ * |      | Left |  Up  | Down | Right|  (   |    |  )   |  -   |  =   |  [   |  ]   |  |   |
+ * |------+------+------+------+------+------|    |------+------+------+------+------+------|
+ * |      |  ;   |  '   |  *   |  ,   |  {   |    |  }   |  _   |  +   |  .   |  /   |      |
+ * |------+------+------+------+------+------|    |------+------+------+------+------+------|
+ * |      |      |      |      |      |      |    |      |      |      |      |      |      |
+ * `-----------------------------------------'    `-----------------------------------------'
+ */
+				[_RAISE] = KC_KEYMAP(
+								HPR_GRV, 1  , 2  , 3  , 4  , 5  ,      6  , 7  , 8  , 9  , 0  ,       ,
+               ,LEFT, UP ,DOWN,RGHT,LPRN,     RPRN,MINS, EQL,LBRC,RBRC,CTL_PIP,
+								       ,COLN,QUOT,ASTR,COMM,LCBR,     RCBR,UNDS,PLUS,    ,    ,       ,
+								       ,    ,    ,    ,    ,    ,         ,    ,    ,    ,    ,
+								),
+
+/* Lower
+ * ,-----------------------------------------.    ,-----------------------------------------.
+ * |  ~   |  !   |  @   |  #   |  $   |  %   |    |  ^   |  &   |  *   |  (   |  )   |      |
+ * |------+------+------+------+------+------|    |------+------+------+------+------+------|
+ * | Del  | Vol+ | Mute | Play | PgUp |  :   |    |  '   |  -   |  =   |  [   |  ]   |  \   |
+ * |------+------+------+------+------+------|    |------+------+------+------+------+------|
+ * |      | Vol- | < M  |  M > | PgDn |  ;   |    |  "   |  |   |  ,   |  .   |  /   |      |
+ * |------+------+------+------+------+------|    |------+------+------+------+------+------|
+ * |      |      |      |      |      |      |    |      |      |      |      |      |      |
+ * `-----------------------------------------'    `-----------------------------------------'
+ */
+				[_LOWER] = KC_KEYMAP(
+								HPR_TIL,EXLM, AT ,HASH,DLR , PERC  ,     CIRC,AMPR,ASTR,LPRN,RPRN,       ,
+								CTL_DEL,VOLU,MUTE,MPLY,PGUP, COLN  ,     QUOT,MINS, EQL,LBRC,RBRC,CTL_BSL,
+								       ,VOLD,MPRV,MNXT,PGDN, SCLN  ,     DQUO,PIPE,COMM, DOT,SLSH,       ,
+								       ,    ,    ,    ,    ,       ,         ,    ,    ,    ,    ,
+								),
+
+				[_FUNC] = KC_KEYMAP(
+// ,----+----+----+----+----+----.    ,----+----+----+----+----+----.
+								, F1 , F2 , F3 , F4 , F5 ,      F6 , F7 , F8 , F9 , F10,    ,
+// |----+----+----+----+----+----|    |----+----+----+----+----+----|
+								, F11, F12, F13, F14, F15,      F16, F17, F18, F19, F20,    ,
+// |----+----+----+----+----+----|    |----+----+----+----+----+----|
+								, F21, F22, F23, F24, NO ,      NO , NO , NO , NO , NO ,    ,
+// |----+----+----+----+----+----|    |----+----+----+----+----+----|
+								,    ,    ,    ,    ,    ,         ,    ,    ,    ,    ,
+// `----+----+----+----+----+----'    `----+----+----+----+----+----'
+  ),
+
+				[_NUMS] = KC_KEYMAP(
+// ,----+----+----+----+----+----.    ,----+----+----+----+----+----.
+								, 1  , 2  , 3  , 4  , 5  ,      6  , 7  , 8  , 9  ,SLSH,    ,
+// |----+----+----+----+----+----|    |----+----+----+----+----+----|
+								,CAPS, INS,HOME,PGUP,LPRN,     RPRN, 4  , 5  , 6  ,ASTR,    ,
+// |----+----+----+----+----+----|    |----+----+----+----+----+----|
+								,NLCK, DEL, END,PGDN,SCLN,     COMM, 1  , 2  , 3  ,MINS,    ,
+// |----+----+----+----+----+----|    |----+----+----+----+----+----|
+								,    ,    ,    ,    ,    ,         , 0  ,DOT ,EQL ,PLUS,
+// `----+----+----+----+----+----'    `----+----+----+----+----+----'
+								),
+
+				[_ADJUST] = KEYMAP(
+// ,-------+--------+--------+--------+--------+--------.   ,-------+--------+--------+--------+--------+--------.
+		   RESET , XXXXXXX,  KC_UP , XXXXXXX, XXXXXXX, XXXXXXX,    XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, KC_DEL , \
+// |-------+--------+--------+--------+--------+--------|   |-------+--------+--------+--------+--------+--------|
+			 _______, KC_LEFT, KC_DOWN, KC_RGHT, XXXXXXX, XXXXXXX,    BL_TOGG, BL_STEP, XXXXXXX, XXXXXXX, XXXXXXX, _______, \
+// |-------+--------+--------+--------+--------+--------|   |-------+--------+--------+--------+--------+--------|
+		  _______, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,    XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, _______, \
+// |-------+--------+--------+--------+--------+--------|   |-------+--------+--------+--------+--------+--------|
+		  _______, _______, _______, _______, _______, _______,    _______, _______, _______, _______, _______, _______  \
+// `-------+--------+--------+--------+--------+--------'   `-------+--------+--------+--------+--------+--------,
+		)
+
+/*
+ * ,-----------------------------------------.    ,-----------------------------------------.
+ * |      |      |      |      |      |      |    |      |      |      |      |      |      |
+ * |------+------+------+------+------+------|    |------+------+------+------+------+------|
+ * |      |      |      |      |      |      |    |      |      |      |      |      |      |
+ * |------+------+------+------+------+------|    |------+------+------+------+------+------|
+ * |      |      |      |      |      |      |    |      |      |      |      |      |      |
+ * |------+------+------+------+------+------|    |------+------+------+------+------+------|
+ * |      |      |      |      |      |      |    |      |      |      |      |      |      |
+ * `-----------------------------------------'    `-----------------------------------------'
+ */
+};
+
+#ifdef AUDIO_ENABLE
+float tone_qwerty[][2]     = SONG(QWERTY_SOUND);
+#endif
+
+void persistent_default_layer_set(uint16_t default_layer) {
+  eeconfig_update_default_layer(default_layer);
+  default_layer_set(default_layer);
+}
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  switch (keycode) {
+    case QWERTY:
+      if (record->event.pressed) {
+        #ifdef AUDIO_ENABLE
+          PLAY_SONG(tone_qwerty);
+        #endif
+        persistent_default_layer_set(1UL<<_QWERTY);
+      }
+      return false;
+      break;
+    case LOWER:
+      if (record->event.pressed) {
+        layer_on(_LOWER);
+        update_tri_layer(_LOWER, _RAISE, _ADJUST);
+      } else {
+        layer_off(_LOWER);
+        update_tri_layer(_LOWER, _RAISE, _ADJUST);
+      }
+      return false;
+      break;
+    case RAISE:
+      if (record->event.pressed) {
+        layer_on(_RAISE);
+        update_tri_layer(_LOWER, _RAISE, _ADJUST);
+      } else {
+        layer_off(_RAISE);
+        update_tri_layer(_LOWER, _RAISE, _ADJUST);
+      }
+      return false;
+      break;
+    case ADJUST:
+      if (record->event.pressed) {
+        layer_on(_ADJUST);
+      } else {
+        layer_off(_ADJUST);
+      }
+      return false;
+      break;
+  }
+  return true;
+}

--- a/keyboards/levinson/keymaps/jyh/keymap.c
+++ b/keyboards/levinson/keymaps/jyh/keymap.c
@@ -1,7 +1,4 @@
-#include "levinson.h"
-#include "action_layer.h"
-#include "eeconfig.h"
-
+#include QMK_KEYBOARD_H
 
 extern keymap_config_t keymap_config;
 
@@ -25,8 +22,6 @@ enum custom_keycodes {
 
 // Fillers to make layering more clear
 #define KC_ KC_TRNS
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
 
 // tap toggle numpad on
 #define NUMPAD TT(_NUMS)
@@ -53,7 +48,7 @@ enum custom_keycodes {
 #define CTL_BSL MT(MOD_RCTL, KC_BSLS) //  \       Right Control
 #define CTL_PIP MT(MOD_RCTL, KC_PIPE) //  |       Right Control
 
-// Redefine for KC_KEYMAP
+// Redefine for LAYOUT_kc
 #define KC_CTL_BSL CTL_BSL
 #define KC_CTL_PIP CTL_PIP
 #define KC_CTL_DEL CTL_DEL
@@ -86,7 +81,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |      |      |      |      |      |      |    |      |      |      |      |      |      |
  * `-----------------------------------------'    `-----------------------------------------'
  */
-				[_QWERTY] = KEYMAP(
+				[_QWERTY] = LAYOUT_ortho_4x12(
 								HPR_TAB, KC_Q   , KC_W   , KC_E   , KC_R , KC_T   ,    KC_Y   , KC_U , KC_I   , KC_O   , KC_P   , KC_BSPC,
 								CTL_ESC, KC_A   , KC_S   , KC_D   , KC_F , KC_G   ,    KC_H   , KC_J , KC_K   , KC_L   , KC_SCLN, CTL_QOT,
 								SFT_MIN, KC_Z   , KC_X   , KC_C   , KC_V , KC_B   ,    KC_N   , KC_M , KC_COMM, KC_DOT , KC_SLSH, SFT_ENT,
@@ -105,7 +100,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |      |      |      |      |      |      |    |      |      |      |      |      |      |
  * `-----------------------------------------'    `-----------------------------------------'
  */
-				[_RAISE] = KC_KEYMAP(
+				[_RAISE] = LAYOUT_kc_ortho_4x12(
 								HPR_GRV, 1  , 2  , 3  , 4  , 5  ,      6  , 7  , 8  , 9  , 0  ,       ,
                ,LEFT, UP ,DOWN,RGHT,LPRN,     RPRN,MINS, EQL,LBRC,RBRC,CTL_PIP,
 								       ,COLN,QUOT,ASTR,COMM,LCBR,     RCBR,UNDS,PLUS,    ,    ,       ,
@@ -123,14 +118,14 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |      |      |      |      |      |      |    |      |      |      |      |      |      |
  * `-----------------------------------------'    `-----------------------------------------'
  */
-				[_LOWER] = KC_KEYMAP(
+				[_LOWER] = LAYOUT_kc_ortho_4x12(
 								HPR_TIL,EXLM, AT ,HASH,DLR , PERC  ,     CIRC,AMPR,ASTR,LPRN,RPRN,       ,
 								CTL_DEL,VOLU,MUTE,MPLY,PGUP, COLN  ,     QUOT,MINS, EQL,LBRC,RBRC,CTL_BSL,
 								       ,VOLD,MPRV,MNXT,PGDN, SCLN  ,     DQUO,PIPE,COMM, DOT,SLSH,       ,
 								       ,    ,    ,    ,    ,       ,         ,    ,    ,    ,    ,
 								),
 
-				[_FUNC] = KC_KEYMAP(
+				[_FUNC] = LAYOUT_kc_ortho_4x12(
 // ,----+----+----+----+----+----.    ,----+----+----+----+----+----.
 								, F1 , F2 , F3 , F4 , F5 ,      F6 , F7 , F8 , F9 , F10,    ,
 // |----+----+----+----+----+----|    |----+----+----+----+----+----|
@@ -142,7 +137,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 // `----+----+----+----+----+----'    `----+----+----+----+----+----'
   ),
 
-				[_NUMS] = KC_KEYMAP(
+				[_NUMS] = LAYOUT_kc_ortho_4x12(
 // ,----+----+----+----+----+----.    ,----+----+----+----+----+----.
 								, 1  , 2  , 3  , 4  , 5  ,      6  , 7  , 8  , 9  ,SLSH,    ,
 // |----+----+----+----+----+----|    |----+----+----+----+----+----|
@@ -154,7 +149,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 // `----+----+----+----+----+----'    `----+----+----+----+----+----'
 								),
 
-				[_ADJUST] = KEYMAP(
+				[_ADJUST] = LAYOUT_ortho_4x12(
 // ,-------+--------+--------+--------+--------+--------.   ,-------+--------+--------+--------+--------+--------.
 		   RESET , XXXXXXX,  KC_UP , XXXXXXX, XXXXXXX, XXXXXXX,    XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, KC_DEL , \
 // |-------+--------+--------+--------+--------+--------|   |-------+--------+--------+--------+--------+--------|
@@ -179,23 +174,11 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  */
 };
 
-#ifdef AUDIO_ENABLE
-float tone_qwerty[][2]     = SONG(QWERTY_SOUND);
-#endif
-
-void persistent_default_layer_set(uint16_t default_layer) {
-  eeconfig_update_default_layer(default_layer);
-  default_layer_set(default_layer);
-}
-
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
   switch (keycode) {
     case QWERTY:
       if (record->event.pressed) {
-        #ifdef AUDIO_ENABLE
-          PLAY_SONG(tone_qwerty);
-        #endif
-        persistent_default_layer_set(1UL<<_QWERTY);
+        set_single_persistent_default_layer(_QWERTY);
       }
       return false;
       break;

--- a/keyboards/levinson/keymaps/jyh/readme.md
+++ b/keyboards/levinson/keymaps/jyh/readme.md
@@ -1,0 +1,32 @@
+# jyh's levinson layout
+
+[Levinson](https://keeb.io/products/levinson-lets-split-w-led-backlight)
+built on rev2 PCBs. A split 4x12 keyboard with LED backlights.
+
+The layout is oriented towards needs for programming, Emacs, XMonad,
+and experience with 60% keyboards with no base layer arrow keys
+(Poker). It makes heavy use of modifiers and layers.
+
+## Layout features
+
+  * Extensive use of _Mod Tap_, e.g.
+     * Tap sends Esc, Hold sends Left Control
+     * Tap sends Enter, Hold sends Right Shift
+     * ... and many more
+  * Hyper and Meh keys
+  * Right modifier keys in place of arrow keys
+    * Arrows are instead available in two alternate locations:
+    * WASD arrows on _Adjust_
+    * Arrow cluster on _Raise_ (inspired by hexwire)
+  * Centered symbol/bracket cluster on _Lower/Raise_
+    * Inspired by hexwire layout
+    * Programming-oriented
+  * Spacebar sends modifier keys on hold (_this is finicky in practice. may shut off completely_)
+    * Control ~~and Alt/Meta~~ on left ~~and right~~ space, respectively
+    * Strict space available on _Function_ and _Numpad_ layers
+    * For Emacs keychords
+  * Extra dedicated layers
+    * Numpad (available with tap toggle)
+    * Function key (F01-24)
+  * Redunant keys where it is convenient to have characters together
+    on one layer

--- a/keyboards/levinson/keymaps/jyh/rules.mk
+++ b/keyboards/levinson/keymaps/jyh/rules.mk
@@ -1,0 +1,6 @@
+ifndef QUANTUM_DIR
+	include ../../../../Makefile
+endif
+
+BACKLIGHT_ENABLE=yes
+USE_I2C=yes

--- a/keyboards/levinson/keymaps/jyh/rules.mk
+++ b/keyboards/levinson/keymaps/jyh/rules.mk
@@ -1,6 +1,1 @@
-ifndef QUANTUM_DIR
-	include ../../../../Makefile
-endif
-
 BACKLIGHT_ENABLE=yes
-USE_I2C=yes

--- a/keyboards/levinson/keymaps/jyh2/config.h
+++ b/keyboards/levinson/keymaps/jyh2/config.h
@@ -1,0 +1,43 @@
+/*
+This is the c configuration file for the keymap
+
+Copyright 2012 Jun Wako <wakojun@gmail.com>
+Copyright 2015 Jack Humbert
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef CONFIG_USER_H
+#define CONFIG_USER_H
+
+#include "config_common.h"
+
+/* Select hand configuration */
+
+#define MASTER_LEFT
+// #define MASTER_RIGHT
+// #define EE_HANDS
+
+/* Tap Dance timing */
+#define TAPPING_TERM 150
+
+/* Toggling layer requires # taps */
+#define TAPPING_TOGGLE 3
+
+#define RGBLIGHT_ANIMATIONS
+#define RGBLED_NUM 12
+
+#define PREVENT_STUCK_MODIFIERS
+
+#endif

--- a/keyboards/levinson/keymaps/jyh2/config.h
+++ b/keyboards/levinson/keymaps/jyh2/config.h
@@ -31,4 +31,3 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGBLIGHT_ANIMATIONS
 #define RGBLED_NUM 12
 
-#define PREVENT_STUCK_MODIFIERS

--- a/keyboards/levinson/keymaps/jyh2/config.h
+++ b/keyboards/levinson/keymaps/jyh2/config.h
@@ -17,17 +17,10 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "config_common.h"
+#pragma once
 
 /* Select hand configuration */
-
 #define MASTER_LEFT
-// #define MASTER_RIGHT
-// #define EE_HANDS
 
 /* Tap Dance timing */
 #define TAPPING_TERM 150
@@ -39,5 +32,3 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGBLED_NUM 12
 
 #define PREVENT_STUCK_MODIFIERS
-
-#endif

--- a/keyboards/levinson/keymaps/jyh2/keymap.c
+++ b/keyboards/levinson/keymaps/jyh2/keymap.c
@@ -1,0 +1,241 @@
+#include "levinson.h"
+#include "action_layer.h"
+#include "eeconfig.h"
+
+
+extern keymap_config_t keymap_config;
+
+// Each layer gets a name for readability, which is then used in the keymap matrix below.
+// The underscores don't mean anything - you can have a layer called STUFF or any other name.
+// Layer names don't all need to be of the same length, obviously, and you can also skip them
+// entirely and just use numbers.
+#define _QWERTY 0
+#define _LOWER 3																/* Symbols, Media */
+#define _RAISE 4																/* Numbers, Arrows */
+#define _FUNC  5																/* Function Keys */
+#define _NUMS  6																/* Numpad */
+#define _ADJUST 16
+
+/* short layer aliases */
+#define _QW _QWERTY
+#define _LW _LOWER
+#define _RS _RAISE
+#define _NM _NUMS
+#define _AD _ADJUST
+
+enum custom_keycodes {
+  QWERTY = SAFE_RANGE,
+  LOWER,
+  RAISE,
+  ADJUST,
+  MKITPNK,
+  DYNAMIC_MACRO_RANGE
+};
+
+#include "dynamic_macro.h"
+
+// Fillers to make layering more clear
+#define _______ KC_TRNS
+#define XXXXXXX KC_NO
+
+#define DREC_1  DYN_REC_START1
+#define DREC_2  DYN_REC_START2
+#define DPLAY_1 DYN_MACRO_PLAY1
+#define DPLAY_2 DYN_MACRO_PLAY2
+#define DSTOP   DYN_REC_STOP
+
+
+// Mod Tap Definitions
+// -------------------
+                                      //  Tap     Hold
+                                      //  ------------------
+#define GUI_GRV MT(MOD_LGUI, KC_GRV)  //  `       Meta
+#define CTL_ESC MT(MOD_LCTL, KC_ESC)  //  Esc     Left Control
+#define SFT_MIN MT(MOD_LSFT, KC_MINS) //  -       Left Shift
+#define MEH_LBC MT(MOD_MEH,  KC_LBRC) //  [       Meh
+#define CTL_BSP MT(MOD_LCTL, KC_BSPC)  // Bkspce  Left Control
+#define HPR_RBC MT(MOD_HYPR, KC_RBRC) //  ]       Hyper
+#define SFT_EQL MT(MOD_RSFT, KC_EQL)  //  =       Right Shift
+#define GUI_BSL MT(MOD_RGUI, KC_BSLS) //  \       Meta
+
+#define NUM_TAB LT(_NUMS, KC_TAB)     //  Tab     Layer Numpad
+
+#define CTL_DEL MT(MOD_LCTL, KC_DEL)  //  Del     Left Control
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+/* Qwerty
+ * ,-----------------------------------------.    ,-----------------------------------------.
+ * |  `   |  Q   |  W   |  E   |  R   |  T   |    |  Y   |  U   |  I   |  O   |  P   |  \   |
+ * |------+------+------+------+------+------|    |------+------+------+------+------+------|
+ * | Esc  |  A   |  S   |  D   |  F   |  G   |    |  H   |  J   |  K   |  L   |  ;   |  '   |
+ * |------+------+------+------+------+------|    |------+------+------+------+------+------|
+ * |  -   |  Z   |  X   |  C   |  V   |  B   |    |  N   |  M   |  ,   |  .   |  /   |  =   |
+ * |------+------+------+------+------+------|    |------+------+------+------+------+------|
+ * | Tab  |  [   | Meta | Alt  | Lower| Bksp |    | Space| Raise| Alt  | Meta |  ]   | Enter|
+ * `-----------------------------------------'    `-----------------------------------------'
+ * with Hold (Emacs-oriented)
+ * ,-----------------------------------------.    ,-----------------------------------------.
+ * | Meta |      |      |      |      |      |    |      |      |      |      |      | Meta |
+ * |------+------+------+------+------+------|    |------+------+------+------+------+------|
+ * | Ctrl |      |      |      |      |      |    |      |      |      |      |      |      |
+ * |------+------+------+------+------+------|    |------+------+------+------+------+------|
+ * | Shift|      |      |      |      |      |    |      |      |      |      |      | Shift|
+ * |------+------+------+------+------+------|    |------+------+------+------+------+------|
+ * | Numpd| Meh  |      |      |      | Ctrl |    |      |      |      |      | Hyper|      |
+ * `-----------------------------------------'    `-----------------------------------------'
+ */
+	[_QW] = KEYMAP(
+		GUI_GRV, KC_Q   , KC_W   , KC_E   , KC_R   , KC_T   , KC_Y   , KC_U   , KC_I   , KC_O   , KC_P   , GUI_BSL,
+		CTL_ESC, KC_A   , KC_S   , KC_D   , KC_F   , KC_G   , KC_H   , KC_J   , KC_K   , KC_L   , KC_SCLN, KC_QUOT,
+		SFT_MIN, KC_Z   , KC_X   , KC_C   , KC_V   , KC_B   , KC_N   , KC_M   , KC_COMM, KC_DOT , KC_SLSH, SFT_EQL,
+		NUM_TAB, MEH_LBC, KC_LGUI, KC_LALT, LOWER  , CTL_BSP, KC_SPC , RAISE  , KC_RALT, KC_RGUI, HPR_RBC, KC_ENT
+		),
+
+/* Raise
+ * ,-----------------------------------------.    ,-----------------------------------------.
+ * |      |  1   |  2   |  3   |  4   |  5   |    |  6   |  7   |  8   |  9   |  0   |      |
+ * |------+------+------+------+------+------|    |------+------+------+------+------+------|
+ * |      | Left |  Up  | Down | Right|  ;   |    |  '   |  4   |  5   |  6   |  *   |      |
+ * |------+------+------+------+------+------|    |------+------+------+------+------+------|
+ * |      |  {   |  }   |  (   |  )   |  ,   |    |  -   |  1   |  2   |  3   |  /   |  =   |
+ * |------+------+------+------+------+------|    |------+------+------+------+------+------|
+ * |      |      |      |      |Adjust|      |    |      | RAISE|   .  |  0   |  +   | Enter|
+ * `-----------------------------------------'    `-----------------------------------------'
+ */
+	[_RS] = KEYMAP(
+		_______, KC_1   , KC_2   , KC_3   , KC_4   , KC_5   , KC_6   , KC_7   , KC_8   , KC_9   , KC_0   , _______,
+		_______, KC_LEFT, KC_UP  , KC_DOWN, KC_RGHT, KC_SCLN, KC_QUOT, KC_4   , KC_5   , KC_6   , KC_ASTR, _______,
+		_______, KC_LCBR, KC_RCBR, KC_LPRN, KC_RPRN, KC_COMM, KC_MINS, KC_1   , KC_2   , KC_3   , KC_SLSH, _______,
+		_______, _______, _______, _______, _______, _______, _______, _______, KC_DOT , KC_0   , KC_PLUS, _______
+		),
+
+/* Lower
+ * ,-----------------------------------------.    ,-----------------------------------------.
+ * |  ~   |  !   |  @   |  #   |  $   |  %   |    |  ^   |  &   |  *   |  (   |  )   |      |
+ * |------+------+------+------+------+------|    |------+------+------+------+------+------|
+ * | Del  | Vol+ | Mute | Play | PgUp | Home |    |  F1  |  F2  |  F3  |  F4  |  F5  |  F6  |
+ * |------+------+------+------+------+------|    |------+------+------+------+------+------|
+ * |      | Vol- | < M  |  M > | PgDn | End  |    |  F7  |  F8  |  F9  |  F10 |  F11 |  F12 |
+ * |------+------+------+------+------+------|    |------+------+------+------+------+------|
+ * |      |      |      |      |LOWER |      |    |      |Adjust|      |      |      | Enter|
+ * `-----------------------------------------'    `-----------------------------------------'
+ */
+	[_LW] = KEYMAP(
+		_______, KC_EXLM, KC_AT  , KC_HASH, KC_DLR , KC_PERC,    KC_CIRC, KC_AMPR, KC_ASTR, KC_LPRN, KC_RPRN, _______,
+		CTL_DEL, KC_VOLU, KC_MUTE, KC_MPLY, KC_PGUP, KC_HOME,    KC_F1  , KC_F2  , KC_F3  , KC_F4  , KC_F5  , KC_F6  ,
+		_______, KC_VOLD, KC_MPRV, KC_MNXT, KC_PGDN, KC_END ,    KC_F7  , KC_F8  , KC_F9  , KC_F10 , KC_F11 , KC_F12 ,
+		_______, _______, _______, _______, _______, _______,    _______, _______, _______, _______, _______, _______
+		),
+
+/* Numpad
+ * ,-----------------------------------------.    ,-----------------------------------------.
+ * |      |      | PrSc | ScrLk| Pause|      |    |      |  7   |  8   |  9   |  0   | Lock |
+ * |------+------+------+------+------+------|    |------+------+------+------+------+------|
+ * |      |      | Ins  | Home | PgUp |      |    |      |  4   |  5   |  6   |  /   |      |
+ * |------+------+------+------+------+------|    |------+------+------+------+------+------|
+ * |      |      | Del  | End  | PgDn |      |    |      |  1   |  2   |  3   |  *   |  =   |
+ * |------+------+------+------+------+------|    |------+------+------+------+------+------|
+ * |NUMPAD|      |      |      |      |      |    |      |  0   |  .   |  +   |  -   | Enter|
+ * `-----------------------------------------'    `-----------------------------------------'
+ */
+	[_NM] = KEYMAP(
+		XXXXXXX, XXXXXXX, KC_PSCR, KC_SLCK, KC_PAUS, XXXXXXX,    XXXXXXX, KC_7   , KC_8   , KC_9   , KC_0   , TO(_NM),
+		XXXXXXX, XXXXXXX, KC_INS , KC_HOME, KC_PGUP, XXXXXXX,    XXXXXXX, KC_4   , KC_5   , KC_6   , KC_SLSH, XXXXXXX,
+		XXXXXXX, XXXXXXX, KC_DEL , KC_END , KC_PGDN, XXXXXXX,    XXXXXXX, KC_1   , KC_2   , KC_3   , KC_ASTR, KC_EQL ,
+		_______, XXXXXXX, XXXXXXX, XXXXXXX, _______, _______,    _______, KC_0   , KC_DOT , KC_PLUS, KC_MINS, _______
+		),
+
+/* Adjust
+ * ,-----------------------------------------.    ,-----------------------------------------.
+ * | Reset|      |  Up  |      |      | Rec1 |    | Rec2 | Plain| Snake|Gradnt|      | Del  |
+ * |------+------+------+------+------+------|    |------+------+------+------+------+------|
+ * | Caps | Left | Down | Right|MkItPk| Play1|    | Play2| RGB  | HUE+ | SAT+ | BRI+ |      |
+ * |------+------+------+------+------+------|    |------+------+------+------+------+------|
+ * |      |      |      |      |      | Stop1|    | Stop2| MODE | HUE- | SAT- | BRI- |      |
+ * |------+------+------+------+------+------|    |------+------+------+------+------+------|
+ * |      |      |      |      |      |      |    |      |      |      |      |      |      |
+ * `-----------------------------------------'    `-----------------------------------------'
+ */
+	[_ADJUST] = KEYMAP(
+		RESET  , XXXXXXX,  KC_UP , XXXXXXX, XXXXXXX, DREC_1 ,    DREC_2 , RGB_M_P, RGB_M_SN,RGB_M_G, XXXXXXX, KC_DEL ,
+		KC_CAPS, KC_LEFT, KC_DOWN, KC_RGHT, MKITPNK, DPLAY_1,    DPLAY_2, RGB_TOG, RGB_HUI, RGB_SAI, RGB_VAI, _______,
+		_______, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, DSTOP  ,    DSTOP  , RGB_MOD, RGB_HUD, RGB_SAD, RGB_VAD, _______,
+		_______, _______, _______, _______, _______, _______,    _______, _______, _______, _______, _______, _______
+		)
+};
+
+#ifdef AUDIO_ENABLE
+float tone_qwerty[][2]     = SONG(QWERTY_SOUND);
+#endif
+
+void make_it_pink_blue(void) {
+	uint16_t blue_hue = 210;
+	uint16_t pink_hue = 315;
+
+	/* key is pressed */
+	uint16_t hue = rgblight_get_hue();
+	uint8_t sat = rgblight_get_sat();
+	uint8_t val = rgblight_get_val();
+
+	if (hue != blue_hue)
+		rgblight_sethsv(blue_hue, sat, val);
+	else
+		rgblight_sethsv(pink_hue, sat, val);
+}
+
+void persistent_default_layer_set(uint16_t default_layer) {
+	eeconfig_update_default_layer(default_layer);
+	default_layer_set(default_layer);
+}
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+	if (!process_record_dynamic_macro(keycode, record))
+		return false;
+
+	switch (keycode) {
+    case QWERTY:
+		if (record->event.pressed) {
+#ifdef AUDIO_ENABLE
+			PLAY_SONG(tone_qwerty);
+#endif
+			persistent_default_layer_set(1UL<<_QWERTY);
+		}
+		return false;
+		break;
+    case LOWER:
+		if (record->event.pressed) {
+			layer_on(_LOWER);
+			update_tri_layer(_LOWER, _RAISE, _ADJUST);
+		} else {
+			layer_off(_LOWER);
+			update_tri_layer(_LOWER, _RAISE, _ADJUST);
+		}
+		return false;
+		break;
+    case RAISE:
+		if (record->event.pressed) {
+			layer_on(_RAISE);
+			update_tri_layer(_LOWER, _RAISE, _ADJUST);
+		} else {
+			layer_off(_RAISE);
+			update_tri_layer(_LOWER, _RAISE, _ADJUST);
+		}
+		return false;
+		break;
+    case ADJUST:
+		if (record->event.pressed) {
+			layer_on(_ADJUST);
+		} else {
+			layer_off(_ADJUST);
+		}
+		return false;
+		break;
+	case MKITPNK:
+		if (record->event.pressed)
+			make_it_pink_blue();
+		return false;
+		break;
+	}
+	return true;
+}

--- a/keyboards/levinson/keymaps/jyh2/keymap.c
+++ b/keyboards/levinson/keymaps/jyh2/keymap.c
@@ -1,7 +1,4 @@
-#include "levinson.h"
-#include "action_layer.h"
-#include "eeconfig.h"
-
+#include QMK_KEYBOARD_H
 
 extern keymap_config_t keymap_config;
 
@@ -10,10 +7,10 @@ extern keymap_config_t keymap_config;
 // Layer names don't all need to be of the same length, obviously, and you can also skip them
 // entirely and just use numbers.
 #define _QWERTY 0
-#define _LOWER 3																/* Symbols, Media */
-#define _RAISE 4																/* Numbers, Arrows */
-#define _FUNC  5																/* Function Keys */
-#define _NUMS  6																/* Numpad */
+#define _LOWER 3                                                                /* Symbols, Media */
+#define _RAISE 4                                                                /* Numbers, Arrows */
+#define _FUNC  5                                                                /* Function Keys */
+#define _NUMS  6                                                                /* Numpad */
 #define _ADJUST 16
 
 /* short layer aliases */
@@ -33,10 +30,6 @@ enum custom_keycodes {
 };
 
 #include "dynamic_macro.h"
-
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
 
 #define DREC_1  DYN_REC_START1
 #define DREC_2  DYN_REC_START2
@@ -85,12 +78,12 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * | Numpd| Meh  |      |      |      | Ctrl |    |      |      |      |      | Hyper|      |
  * `-----------------------------------------'    `-----------------------------------------'
  */
-	[_QW] = KEYMAP(
-		GUI_GRV, KC_Q   , KC_W   , KC_E   , KC_R   , KC_T   , KC_Y   , KC_U   , KC_I   , KC_O   , KC_P   , GUI_BSL,
-		CTL_ESC, KC_A   , KC_S   , KC_D   , KC_F   , KC_G   , KC_H   , KC_J   , KC_K   , KC_L   , KC_SCLN, KC_QUOT,
-		SFT_MIN, KC_Z   , KC_X   , KC_C   , KC_V   , KC_B   , KC_N   , KC_M   , KC_COMM, KC_DOT , KC_SLSH, SFT_EQL,
-		NUM_TAB, MEH_LBC, KC_LGUI, KC_LALT, LOWER  , CTL_BSP, KC_SPC , RAISE  , KC_RALT, KC_RGUI, HPR_RBC, KC_ENT
-		),
+    [_QW] = LAYOUT_ortho_4x12(
+        GUI_GRV, KC_Q   , KC_W   , KC_E   , KC_R   , KC_T   , KC_Y   , KC_U   , KC_I   , KC_O   , KC_P   , GUI_BSL,
+        CTL_ESC, KC_A   , KC_S   , KC_D   , KC_F   , KC_G   , KC_H   , KC_J   , KC_K   , KC_L   , KC_SCLN, KC_QUOT,
+        SFT_MIN, KC_Z   , KC_X   , KC_C   , KC_V   , KC_B   , KC_N   , KC_M   , KC_COMM, KC_DOT , KC_SLSH, SFT_EQL,
+        NUM_TAB, MEH_LBC, KC_LGUI, KC_LALT, LOWER  , CTL_BSP, KC_SPC , RAISE  , KC_RALT, KC_RGUI, HPR_RBC, KC_ENT
+        ),
 
 /* Raise
  * ,-----------------------------------------.    ,-----------------------------------------.
@@ -103,12 +96,12 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |      |      |      |      |Adjust|      |    |      | RAISE|   .  |  0   |  +   | Enter|
  * `-----------------------------------------'    `-----------------------------------------'
  */
-	[_RS] = KEYMAP(
-		_______, KC_1   , KC_2   , KC_3   , KC_4   , KC_5   , KC_6   , KC_7   , KC_8   , KC_9   , KC_0   , _______,
-		_______, KC_LEFT, KC_UP  , KC_DOWN, KC_RGHT, KC_SCLN, KC_QUOT, KC_4   , KC_5   , KC_6   , KC_ASTR, _______,
-		_______, KC_LCBR, KC_RCBR, KC_LPRN, KC_RPRN, KC_COMM, KC_MINS, KC_1   , KC_2   , KC_3   , KC_SLSH, _______,
-		_______, _______, _______, _______, _______, _______, _______, _______, KC_DOT , KC_0   , KC_PLUS, _______
-		),
+    [_RS] = LAYOUT_ortho_4x12(
+        _______, KC_1   , KC_2   , KC_3   , KC_4   , KC_5   , KC_6   , KC_7   , KC_8   , KC_9   , KC_0   , _______,
+        _______, KC_LEFT, KC_UP  , KC_DOWN, KC_RGHT, KC_SCLN, KC_QUOT, KC_4   , KC_5   , KC_6   , KC_ASTR, _______,
+        _______, KC_LCBR, KC_RCBR, KC_LPRN, KC_RPRN, KC_COMM, KC_MINS, KC_1   , KC_2   , KC_3   , KC_SLSH, _______,
+        _______, _______, _______, _______, _______, _______, _______, _______, KC_DOT , KC_0   , KC_PLUS, _______
+        ),
 
 /* Lower
  * ,-----------------------------------------.    ,-----------------------------------------.
@@ -121,12 +114,12 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |      |      |      |      |LOWER |      |    |      |Adjust|      |      |      | Enter|
  * `-----------------------------------------'    `-----------------------------------------'
  */
-	[_LW] = KEYMAP(
-		_______, KC_EXLM, KC_AT  , KC_HASH, KC_DLR , KC_PERC,    KC_CIRC, KC_AMPR, KC_ASTR, KC_LPRN, KC_RPRN, _______,
-		CTL_DEL, KC_VOLU, KC_MUTE, KC_MPLY, KC_PGUP, KC_HOME,    KC_F1  , KC_F2  , KC_F3  , KC_F4  , KC_F5  , KC_F6  ,
-		_______, KC_VOLD, KC_MPRV, KC_MNXT, KC_PGDN, KC_END ,    KC_F7  , KC_F8  , KC_F9  , KC_F10 , KC_F11 , KC_F12 ,
-		_______, _______, _______, _______, _______, _______,    _______, _______, _______, _______, _______, _______
-		),
+    [_LW] = LAYOUT_ortho_4x12(
+        _______, KC_EXLM, KC_AT  , KC_HASH, KC_DLR , KC_PERC,    KC_CIRC, KC_AMPR, KC_ASTR, KC_LPRN, KC_RPRN, _______,
+        CTL_DEL, KC_VOLU, KC_MUTE, KC_MPLY, KC_PGUP, KC_HOME,    KC_F1  , KC_F2  , KC_F3  , KC_F4  , KC_F5  , KC_F6  ,
+        _______, KC_VOLD, KC_MPRV, KC_MNXT, KC_PGDN, KC_END ,    KC_F7  , KC_F8  , KC_F9  , KC_F10 , KC_F11 , KC_F12 ,
+        _______, _______, _______, _______, _______, _______,    _______, _______, _______, _______, _______, _______
+        ),
 
 /* Numpad
  * ,-----------------------------------------.    ,-----------------------------------------.
@@ -139,12 +132,12 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |NUMPAD|      |      |      |      |      |    |      |  0   |  .   |  +   |  -   | Enter|
  * `-----------------------------------------'    `-----------------------------------------'
  */
-	[_NM] = KEYMAP(
-		XXXXXXX, XXXXXXX, KC_PSCR, KC_SLCK, KC_PAUS, XXXXXXX,    XXXXXXX, KC_7   , KC_8   , KC_9   , KC_0   , TO(_NM),
-		XXXXXXX, XXXXXXX, KC_INS , KC_HOME, KC_PGUP, XXXXXXX,    XXXXXXX, KC_4   , KC_5   , KC_6   , KC_SLSH, XXXXXXX,
-		XXXXXXX, XXXXXXX, KC_DEL , KC_END , KC_PGDN, XXXXXXX,    XXXXXXX, KC_1   , KC_2   , KC_3   , KC_ASTR, KC_EQL ,
-		_______, XXXXXXX, XXXXXXX, XXXXXXX, _______, _______,    _______, KC_0   , KC_DOT , KC_PLUS, KC_MINS, _______
-		),
+    [_NM] = LAYOUT_ortho_4x12(
+        XXXXXXX, XXXXXXX, KC_PSCR, KC_SLCK, KC_PAUS, XXXXXXX,    XXXXXXX, KC_7   , KC_8   , KC_9   , KC_0   , TO(_NM),
+        XXXXXXX, XXXXXXX, KC_INS , KC_HOME, KC_PGUP, XXXXXXX,    XXXXXXX, KC_4   , KC_5   , KC_6   , KC_SLSH, XXXXXXX,
+        XXXXXXX, XXXXXXX, KC_DEL , KC_END , KC_PGDN, XXXXXXX,    XXXXXXX, KC_1   , KC_2   , KC_3   , KC_ASTR, KC_EQL ,
+        _______, XXXXXXX, XXXXXXX, XXXXXXX, _______, _______,    _______, KC_0   , KC_DOT , KC_PLUS, KC_MINS, _______
+        ),
 
 /* Adjust
  * ,-----------------------------------------.    ,-----------------------------------------.
@@ -157,85 +150,73 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |      |      |      |      |      |      |    |      |      |      |      |      |      |
  * `-----------------------------------------'    `-----------------------------------------'
  */
-	[_ADJUST] = KEYMAP(
-		RESET  , XXXXXXX,  KC_UP , XXXXXXX, XXXXXXX, DREC_1 ,    DREC_2 , RGB_M_P, RGB_M_SN,RGB_M_G, XXXXXXX, KC_DEL ,
-		KC_CAPS, KC_LEFT, KC_DOWN, KC_RGHT, MKITPNK, DPLAY_1,    DPLAY_2, RGB_TOG, RGB_HUI, RGB_SAI, RGB_VAI, _______,
-		_______, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, DSTOP  ,    DSTOP  , RGB_MOD, RGB_HUD, RGB_SAD, RGB_VAD, _______,
-		_______, _______, _______, _______, _______, _______,    _______, _______, _______, _______, _______, _______
-		)
+    [_ADJUST] = LAYOUT_ortho_4x12(
+        RESET  , XXXXXXX,  KC_UP , XXXXXXX, XXXXXXX, DREC_1 ,    DREC_2 , RGB_M_P, RGB_M_SN,RGB_M_G, XXXXXXX, KC_DEL ,
+        KC_CAPS, KC_LEFT, KC_DOWN, KC_RGHT, MKITPNK, DPLAY_1,    DPLAY_2, RGB_TOG, RGB_HUI, RGB_SAI, RGB_VAI, _______,
+        _______, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, DSTOP  ,    DSTOP  , RGB_MOD, RGB_HUD, RGB_SAD, RGB_VAD, _______,
+        _______, _______, _______, _______, _______, _______,    _______, _______, _______, _______, _______, _______
+        )
 };
 
-#ifdef AUDIO_ENABLE
-float tone_qwerty[][2]     = SONG(QWERTY_SOUND);
-#endif
-
 void make_it_pink_blue(void) {
-	uint16_t blue_hue = 210;
-	uint16_t pink_hue = 315;
+    uint16_t blue_hue = 210;
+    uint16_t pink_hue = 315;
 
-	/* key is pressed */
-	uint16_t hue = rgblight_get_hue();
-	uint8_t sat = rgblight_get_sat();
-	uint8_t val = rgblight_get_val();
+    /* key is pressed */
+    uint16_t hue = rgblight_get_hue();
+    uint8_t sat = rgblight_get_sat();
+    uint8_t val = rgblight_get_val();
 
-	if (hue != blue_hue)
-		rgblight_sethsv(blue_hue, sat, val);
-	else
-		rgblight_sethsv(pink_hue, sat, val);
-}
-
-void persistent_default_layer_set(uint16_t default_layer) {
-	eeconfig_update_default_layer(default_layer);
-	default_layer_set(default_layer);
+    if (hue != blue_hue)
+        rgblight_sethsv(blue_hue, sat, val);
+    else
+        rgblight_sethsv(pink_hue, sat, val);
 }
 
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
-	if (!process_record_dynamic_macro(keycode, record))
-		return false;
+    if (!process_record_dynamic_macro(keycode, record))
+        return false;
 
-	switch (keycode) {
-    case QWERTY:
-		if (record->event.pressed) {
-#ifdef AUDIO_ENABLE
-			PLAY_SONG(tone_qwerty);
-#endif
-			persistent_default_layer_set(1UL<<_QWERTY);
-		}
-		return false;
-		break;
-    case LOWER:
-		if (record->event.pressed) {
-			layer_on(_LOWER);
-			update_tri_layer(_LOWER, _RAISE, _ADJUST);
-		} else {
-			layer_off(_LOWER);
-			update_tri_layer(_LOWER, _RAISE, _ADJUST);
-		}
-		return false;
-		break;
-    case RAISE:
-		if (record->event.pressed) {
-			layer_on(_RAISE);
-			update_tri_layer(_LOWER, _RAISE, _ADJUST);
-		} else {
-			layer_off(_RAISE);
-			update_tri_layer(_LOWER, _RAISE, _ADJUST);
-		}
-		return false;
-		break;
-    case ADJUST:
-		if (record->event.pressed) {
-			layer_on(_ADJUST);
-		} else {
-			layer_off(_ADJUST);
-		}
-		return false;
-		break;
-	case MKITPNK:
-		if (record->event.pressed)
-			make_it_pink_blue();
-		return false;
-		break;
-	}
-	return true;
+    switch (keycode) {
+      case QWERTY:
+          if (record->event.pressed) {
+              set_single_persistent_default_layer(_QWERTY);
+          }
+          return false;
+          break;
+      case LOWER:
+          if (record->event.pressed) {
+              layer_on(_LOWER);
+              update_tri_layer(_LOWER, _RAISE, _ADJUST);
+          } else {
+              layer_off(_LOWER);
+              update_tri_layer(_LOWER, _RAISE, _ADJUST);
+          }
+          return false;
+          break;
+      case RAISE:
+          if (record->event.pressed) {
+              layer_on(_RAISE);
+              update_tri_layer(_LOWER, _RAISE, _ADJUST);
+          } else {
+              layer_off(_RAISE);
+              update_tri_layer(_LOWER, _RAISE, _ADJUST);
+          }
+          return false;
+          break;
+      case ADJUST:
+          if (record->event.pressed) {
+              layer_on(_ADJUST);
+          } else {
+              layer_off(_ADJUST);
+          }
+          return false;
+          break;
+      case MKITPNK:
+          if (record->event.pressed)
+              make_it_pink_blue();
+          return false;
+          break;
+    }
+    return true;
 }

--- a/keyboards/levinson/keymaps/jyh2/readme.md
+++ b/keyboards/levinson/keymaps/jyh2/readme.md
@@ -1,0 +1,32 @@
+# jyh's levinson layout
+
+[Levinson](https://keeb.io/products/levinson-lets-split-w-led-backlight)
+built on rev2 PCBs. A split 4x12 keyboard with LED backlights.
+
+The layout is oriented towards needs for programming, Emacs, XMonad,
+and experience with 60% keyboards with no base layer arrow keys
+(Poker). It makes heavy use of modifiers and layers. It is influenced
+by good ideas from the Atreus keyboard layout.
+
+## Layout features
+
+  * Extensive use of _Mod Tap_, e.g.
+     * Tap sends Esc, Hold sends Left Control
+     * Tap sends Tab, Hold activates Numpad layer
+     * Tap sends  - , Hold sends Shift
+     * ... and many more
+  * Places Tab and Enter on bottom corners, for hitting with palm
+  * Meta is available on top corners, for controlling XMonad
+  * Control on center key, for Emacs (among other things)
+  * Backspace (Control Hold) and Space on center keys
+  * All 60% keys available on base layer, except for numbers
+  * Hyper and Meh keys
+  * Right modifier keys in place of arrow keys
+    * Arrows are instead available in two alternate locations:
+    * WASD arrows on _Adjust_
+    * Arrow cluster on _Raise_ (inspired by hexwire)
+  * Numpad and Numrow on _Raise_ layer. Each is faster in some contexts
+  * Function keys on _Lower_
+  * Dynamic macros from QMK firmware on _Adjust_
+  * Redunant keys where it is convenient to have characters together
+    on one layer

--- a/keyboards/levinson/keymaps/jyh2/rules.mk
+++ b/keyboards/levinson/keymaps/jyh2/rules.mk
@@ -1,0 +1,6 @@
+ifndef QUANTUM_DIR
+	include ../../../../Makefile
+endif
+
+RGBLIGHT_ENABLE=yes
+BOOTMAGIC_ENABLE=no

--- a/keyboards/levinson/keymaps/jyh2/rules.mk
+++ b/keyboards/levinson/keymaps/jyh2/rules.mk
@@ -1,6 +1,2 @@
-ifndef QUANTUM_DIR
-	include ../../../../Makefile
-endif
-
 RGBLIGHT_ENABLE=yes
 BOOTMAGIC_ENABLE=no


### PR DESCRIPTION
My personal keymaps (2 alternatives) for the levinson/let's split keyboard

  * remove tap dance number keys due to sluggish responses
  * simplify I2C configuration
  * reverse hyper and meh positions
  * reduce tapping term to allow fast typing with mod tap space keys
  * remove Alt hold on right space key. too many false touches.
  * add vim-style arrows (hjkl) on asdf; semicolon/quote on raise
  * correct documentation string for jyh levinson layout
  * add alternative levinson layout for jyh
  * more inspiration from atreus keyboard. keeps shift in the expected
places. reduces number of layers. puts numpad layout easily
accessible. places important keys on palms and meta keys on top
corners for xmonad.
  * correct layer switching in jyh2 levinson layout
  * I was getting stuck on the numpad layer because the numpad hold key
was remapped once the layer was activated. Bad idea. Minor other
refinements.
  * use curly bracket { instead of brace [ on raise layer
  * add RGB keys on adjust layer
  * bootmagic key is confusing. turn it off.
  * try out permissive hold setting to make mod-tap better
  * remove hold for right control on quote key. too many mistakes
  * turn off permissive hold. it was causing unexpected behavior
  * enable rgb underglow animations
  * add make it pink/blue key to levinson layout
  * prevent stuck modifiers in jyh2 levinson keymap