### PR TITLE
Keymap: port atreus layout to levinson keyboard

### DIFF
--- a/keyboards/levinson/keymaps/atreus/config.h
+++ b/keyboards/levinson/keymaps/atreus/config.h
@@ -1,0 +1,28 @@
+/*
+This is the c configuration file for the keymap
+
+Copyright 2012 Jun Wako <wakojun@gmail.com>
+Copyright 2015 Jack Humbert
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef CONFIG_USER_H
+#define CONFIG_USER_H
+
+#include "config_common.h"
+
+#define MASTER_LEFT
+
+#endif

--- a/keyboards/levinson/keymaps/atreus/keymap.c
+++ b/keyboards/levinson/keymaps/atreus/keymap.c
@@ -1,0 +1,62 @@
+#include "levinson.h"
+#include "action_layer.h"
+#include "eeconfig.h"
+
+#define _QW 0
+#define _RS 1
+#define _LW 2
+
+/*
+ *  q       w      e     r    t        ||       y     u     i     o    p
+ *  a       s      d     f    g        ||       h     j     k     l    ;
+ *  z       x      c     v    b        ||       n     m     ,     .    /
+ * esc     tab    gui  shift bksp ctrl || alt space raise   -     '  enter
+ */
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+[_QW] = KEYMAP( /* Qwerty */
+	KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_NO,   KC_NO,   KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,
+	KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_NO,   KC_NO,   KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN ,
+	KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_NO,   KC_NO,   KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH ,
+	KC_ESC, KC_TAB, KC_LGUI,  KC_LSFT, KC_BSPC,  KC_LCTL, KC_LALT, KC_SPC,  MO(_RS), KC_MINS, KC_QUOT, KC_ENT  ),
+/*
+ *  !       @     up     {    }        ||     pgup    7     8     9    *
+ *  #     left   down  right  $        ||     pgdn    4     5     6    +
+ *  [       ]      (     )    &        ||       `     1     2     3    \
+ * lower  insert super shift bksp ctrl || alt space   fn    .     0    =
+ */
+[_RS] = KEYMAP( /* [> RAISE <] */
+	KC_EXLM, KC_AT,   KC_UP,   KC_LCBR, KC_RCBR, KC_NO,   KC_NO,   KC_PGUP, KC_7,    KC_8,   KC_9, KC_ASTR ,
+	KC_HASH, KC_LEFT, KC_DOWN, KC_RGHT, KC_DLR,  KC_NO,   KC_NO,   KC_PGDN, KC_4,    KC_5,   KC_6, KC_PLUS ,
+	KC_LBRC, KC_RBRC, KC_LPRN, KC_RPRN, KC_AMPR, KC_NO,   KC_NO,   KC_GRV,  KC_1,    KC_2,   KC_3, KC_BSLS ,
+	TG(_LW), KC_INS,  KC_LGUI, KC_LSFT, KC_BSPC, KC_LCTL, KC_LALT, KC_SPC,  KC_TRNS, KC_DOT, KC_0, KC_EQL  ),
+/*
+ * insert home   up  end   pgup       ||      up     F7    F8    F9   F10
+ *  del   left  down right pgdn       ||     down    F4    F5    F6   F11
+ *       volup             reset      ||             F1    F2    F3   F12
+ *       voldn  super shift bksp ctrl || alt space   L0  prtsc scroll pause
+ */
+[_LW] = KEYMAP( /* [> LOWER <] */
+	KC_INS,  KC_HOME, KC_UP,   KC_END,  KC_PGUP, KC_NO,   KC_NO,   KC_UP,   KC_F7,   KC_F8,   KC_F9,   KC_F10  ,
+	KC_DELT, KC_LEFT, KC_DOWN, KC_RGHT, KC_DOWN, KC_NO,   KC_NO,   KC_DOWN, KC_F4,   KC_F5,   KC_F6,   KC_F11  ,
+	KC_NO,   KC_VOLU, KC_NO,   KC_NO,   RESET,   KC_NO,   KC_NO,   KC_NO,   KC_F1,   KC_F2,   KC_F3,   KC_F12  ,
+	KC_NO,   KC_VOLD, KC_LGUI, KC_LSFT, KC_BSPC, KC_LCTL, KC_LALT, KC_SPC,  TO(_QW), KC_PSCR, KC_SLCK, KC_PAUS )
+};
+
+const uint16_t PROGMEM fn_actions[] = {
+
+};
+
+const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
+{
+  // MACRODOWN only works in this function
+      switch(id) {
+        case 0:
+          if (record->event.pressed) {
+            register_code(KC_RSFT);
+          } else {
+            unregister_code(KC_RSFT);
+          }
+        break;
+      }
+    return MACRO_NONE;
+};

--- a/keyboards/levinson/keymaps/atreus/keymap2.c
+++ b/keyboards/levinson/keymaps/atreus/keymap2.c
@@ -1,0 +1,62 @@
+#include "levinson.h"
+#include "action_layer.h"
+#include "eeconfig.h"
+
+#define _QW 0
+#define _RS 1
+#define _LW 2
+
+/*
+ *  q       w      e     r    t        ||       y     u     i     o    p
+ *  a       s      d     f    g        ||       h     j     k     l    ;
+ *  z       x      c     v    b        ||       n     m     ,     .    /
+ * esc     tab    gui  shift bksp ctrl || alt space raise   -     '  enter
+ */
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+[_QW] = KEYMAP( /* Qwerty */
+	KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_NO,   KC_NO,   KC_Y,    KC_U,    KC_I,    KC_O,    KC_P    ,
+	KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_NO,   KC_NO,   KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN ,
+	KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_NO,   KC_NO,   KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH ,
+	KC_ESC, KC_TAB, KC_LGUI,  KC_LSFT, KC_BSPC,  KC_LCTL, KC_LALT, KC_SPC,  MO(_RS), KC_MINS, KC_QUOT, KC_ENT  ),
+/*
+ *  !       @     up     {    }        ||     pgup    7     8     9    *
+ *  #     left   down  right  $        ||     pgdn    4     5     6    +
+ *  [       ]      (     )    &        ||       `     1     2     3    \
+ * lower  insert super shift bksp ctrl || alt space   fn    .     0    =
+ */
+[_RS] = KEYMAP( /* [> RAISE <] */
+	KC_EXLM, KC_AT,   KC_UP,   KC_LCBR, KC_RCBR, KC_NO,   KC_NO,   KC_PGUP, KC_7,    KC_8,   KC_9, KC_ASTR ,
+	KC_HASH, KC_LEFT, KC_DOWN, KC_RGHT, KC_DLR,  KC_NO,   KC_NO,   KC_PGDN, KC_4,    KC_5,   KC_6, KC_PLUS ,
+	KC_LBRC, KC_RBRC, KC_LPRN, KC_RPRN, KC_AMPR, KC_NO,   KC_NO,   KC_GRV,  KC_1,    KC_2,   KC_3, KC_BSLS ,
+	TG(_LW), KC_INS,  KC_LGUI, KC_LSFT, KC_BSPC, KC_LCTL, KC_LALT, KC_SPC,  KC_TRNS, KC_DOT, KC_0, KC_EQL  ),
+/*
+ * insert home   up  end   pgup       ||      up     F7    F8    F9   F10
+ *  del   left  down right pgdn       ||     down    F4    F5    F6   F11
+ *       volup             reset      ||             F1    F2    F3   F12
+ *       voldn  super shift bksp ctrl || alt space   L0  prtsc scroll pause
+ */
+[_LW] = KEYMAP( /* [> LOWER <] */
+	KC_INS,  KC_HOME, KC_UP,   KC_END,  KC_PGUP, KC_NO,   KC_NO,   KC_UP,   KC_F7,   KC_F8,   KC_F9,   KC_F10  ,
+	KC_DELT, KC_LEFT, KC_DOWN, KC_RGHT, KC_DOWN, KC_NO,   KC_NO,   KC_DOWN, KC_F4,   KC_F5,   KC_F6,   KC_F11  ,
+	KC_NO,   KC_VOLU, KC_NO,   KC_NO,   RESET,   KC_NO,   KC_NO,   KC_NO,   KC_F1,   KC_F2,   KC_F3,   KC_F12  ,
+	KC_NO,   KC_VOLD, KC_LGUI, KC_LSFT, KC_BSPC, KC_LCTL, KC_LALT, KC_SPC,  TO(_QW), KC_PSCR, KC_SLCK, KC_PAUS )
+};
+
+const uint16_t PROGMEM fn_actions[] = {
+
+};
+
+const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
+{
+  // MACRODOWN only works in this function
+      switch(id) {
+        case 0:
+          if (record->event.pressed) {
+            register_code(KC_RSFT);
+          } else {
+            unregister_code(KC_RSFT);
+          }
+        break;
+      }
+    return MACRO_NONE;
+};

--- a/keyboards/levinson/keymaps/atreus/readme.md
+++ b/keyboards/levinson/keymaps/atreus/readme.md
@@ -1,0 +1,8 @@
+# Atreus layout port
+
+Port the default Atreus layout to the Levinson/Let's Split.
+
+The purpose is to try out the layout to get a sense of what works in it.
+
+The 'extra' keys on the Levinson are dead in this version, to make a
+more faithful emulation of the atreus layout.

--- a/keyboards/levinson/keymaps/atreus/rules.mk
+++ b/keyboards/levinson/keymaps/atreus/rules.mk
@@ -1,0 +1,5 @@
+ifndef QUANTUM_DIR
+	include ../../../../Makefile
+endif
+
+USE_I2C=yes


### PR DESCRIPTION
Port the default Atreus keymap layout to the Levinson/Let's Split.

The 'extra' keys on the Levinson are dead in this version, to make a
more faithful emulation of the atreus layout.