### PR TITLE
Hardware PWM backlight support for all MCU

### DIFF
--- a/docs/feature_backlight.md
+++ b/docs/feature_backlight.md
@@ -30,19 +30,16 @@ You should then be able to use the keycodes below to change the backlight level.
 
 This feature is distinct from both the [RGB underglow](feature_rgblight.md) and [RGB matrix](feature_rgb_matrix.md) features as it usually allows for only a single colour per switch, though you can obviously use multiple different coloured LEDs on a keyboard.
 
-Hardware PWM is only supported on certain pins of the MCU, so if the backlighting is not connected to one of them, a software PWM implementation triggered by hardware timer interrupts will be used.
+Hardware PWM is only supported on certain pins of the MCU, so if the backlighting is not connected to one of them, a software implementation triggered by hardware timer interrupts will be used. Currently the supported pins depend on the MCU as defined in the following table:
 
-Hardware PWM is supported according to the following table:
+| MCU                    | Allowed pins           |
+|------------------------|------------------------|
+| ATmega32U4/ATmega16U4  | B5, B6, B7, C6         |
+| ATmega32U2/ATmega16U2  | C5, C6, B7             |
+| ATmega32A              | D4, D5                 |
+| AT90USB1286/AT90USB646 | B5, B6, B7, C5, C6, C7 |
 
-| Backlight Pin | Hardware timer |
-|---------------|----------------|
-|`B5`           | Timer 1        |
-|`B6`           | Timer 1        |
-|`B7`           | Timer 1        |
-|`C6`           | Timer 3        |
-| other         | Software PWM   |
-
-The [audio feature](feature_audio.md) also uses hardware timers. Please refer to the following table to know what hardware timer the software PWM will use depending on the audio configuration:
+The [audio feature](feature_audio.md) also uses timers. Please refer to the following table to know what hardware timer the software PWM will use depending on the audio configuration:
 
 | Audio Pin(s) | Audio Timer | Software PWM Timer |
 |--------------|-------------|--------------------|


### PR DESCRIPTION
The hardware based PWM backlight was only supported on the ATmega32U4 PWM pins. 
This meant that any board using a different MCU couldn’t use the hardware backlight system unless the backlight pin was among `B5`, `B6`, `B7`, `C6`.

This patch adds the correct PWM pins for the current MCU for backlight allowing boards with an ATmega32A, ATmega32/16U2 or AT90USB1286/646 MCU to use the hardware backlight system, instead of rolling their own.

Note that this patch doesn’t remove the various custom backlight implementations that are defined in some keyboards. This could be done once those keyboards maintainer have tested that the common implementation works for them.

This PR doesn't directly depend on #4015, but requires it for the pins addresses to be correct on ATmega32A. So to work correctly on this MCU, #4015 should be applied first.
