### PR TITLE
Improve RGB Light code

### DIFF
--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -137,7 +137,7 @@ void rgblight_check_config(void) {
   if (rgblight_config.hue < 0) {
     rgblight_config.hue = 0;
   } else if (rgblight_config.hue > 360) {
-    rgblight_config.hue = 360;
+    rgblight_config.hue %= 360;
   }
 
   if (rgblight_config.sat < 0) {

--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -58,6 +58,7 @@ const uint16_t RGBLED_GRADIENT_RANGES[] PROGMEM = {360, 240, 180, 120, 90};
 #endif
 
 rgblight_config_t rgblight_config;
+bool is_rgblight_initialized = false;
 
 LED_TYPE led[RGBLED_NUM];
 bool rgblight_timer_enabled = false;
@@ -123,6 +124,35 @@ void setrgb(uint8_t r, uint8_t g, uint8_t b, LED_TYPE *led1) {
   (*led1).b = b;
 }
 
+void rgblight_check_config(void) {
+  /* Add some out of bound checks for RGB light config */
+
+  if (rgblight_config.mode < RGBLIGHT_MODE_STATIC_LIGHT) {
+    rgblight_config.mode = RGBLIGHT_MODE_STATIC_LIGHT;
+  }
+  else if (rgblight_config.mode > RGBLIGHT_MODES) {
+    rgblight_config.mode = RGBLIGHT_MODES;
+  }
+
+  if (rgblight_config.hue < 0) {
+    rgblight_config.hue = 0;
+  } else if (rgblight_config.hue > 360) {
+    rgblight_config.hue = 360;
+  }
+
+  if (rgblight_config.sat < 0) {
+    rgblight_config.sat = 0;
+  } else if (rgblight_config.sat > 255) {
+    rgblight_config.sat = 255;
+  }
+
+  if (rgblight_config.val < 0) {
+    rgblight_config.val = 0;
+  } else if (rgblight_config.val > RGBLIGHT_LIMIT_VAL) {
+    rgblight_config.val = RGBLIGHT_LIMIT_VAL;
+  }
+
+}
 
 uint32_t eeconfig_read_rgblight(void) {
   #if defined(__AVR__) || defined(STM32_EEPROM_ENABLE) || defined(PROTOCOL_ARM_ATSAM) || defined(EEPROM_SIZE)
@@ -131,13 +161,14 @@ uint32_t eeconfig_read_rgblight(void) {
     return 0;
   #endif
 }
+
 void eeconfig_update_rgblight(uint32_t val) {
   #if defined(__AVR__) || defined(STM32_EEPROM_ENABLE) || defined(PROTOCOL_ARM_ATSAM) || defined(EEPROM_SIZE)
-  if (eeconfig_read_rgblight() != val) {
+    rgblight_check_config();
     eeprom_update_dword(EECONFIG_RGBLIGHT, val);
-  }
   #endif
 }
+
 void eeconfig_update_rgblight_default(void) {
   //dprintf("eeconfig_update_rgblight_default\n");
   rgblight_config.enable = 1;
@@ -148,6 +179,7 @@ void eeconfig_update_rgblight_default(void) {
   rgblight_config.speed = 0;
   eeconfig_update_rgblight(rgblight_config.raw);
 }
+
 void eeconfig_debug_rgblight(void) {
   dprintf("rgblight_config eprom\n");
   dprintf("rgblight_config.enable = %d\n", rgblight_config.enable);
@@ -159,6 +191,11 @@ void eeconfig_debug_rgblight(void) {
 }
 
 void rgblight_init(void) {
+  /* if already initialized, don't do it again.
+     If you must do it again, extern this and set to false, first.
+     This is a dirty, dirty hack until proper hooks can be added for keyboard startup. */
+  if (is_rgblight_initialized) { return; }
+
   debug_enable = 1; // Debug ON!
   dprintf("rgblight_init called.\n");
   dprintf("rgblight_init start!\n");
@@ -173,6 +210,8 @@ void rgblight_init(void) {
     eeconfig_update_rgblight_default();
     rgblight_config.raw = eeconfig_read_rgblight();
   }
+  rgblight_check_config();
+
   eeconfig_debug_rgblight(); // display current eeprom values
 
 #ifdef RGBLIGHT_USE_TIMER
@@ -182,6 +221,9 @@ void rgblight_init(void) {
   if (rgblight_config.enable) {
     rgblight_mode_noeeprom(rgblight_config.mode);
   }
+
+  is_rgblight_initialized = true;
+
 }
 
 void rgblight_update_dword(uint32_t dword) {

--- a/quantum/rgblight.h
+++ b/quantum/rgblight.h
@@ -146,6 +146,7 @@ extern const uint8_t RGBLED_RAINBOW_SWIRL_INTERVALS[3] PROGMEM;
 extern const uint8_t RGBLED_SNAKE_INTERVALS[3] PROGMEM;
 extern const uint8_t RGBLED_KNIGHT_INTERVALS[3] PROGMEM;
 extern const uint16_t RGBLED_RGBTEST_INTERVALS[1] PROGMEM;
+extern bool is_rgblight_initialized;
 
 typedef union {
   uint32_t raw;


### PR DESCRIPTION
* Add out of bound checks for initialization, and eeprom writing.
* Add run guard (?) so rgblight_init only runs once.
  * This should allow users to call it in matrix_scan_user and not overwrite the values.
  * Can set `is_rgblight_initialized` to false to re-initialize, if needed.