### PR TITLE
Move disable JTAG code from `keyboard_init` to `keyboard_setup`

### DIFF
--- a/quantum/split_common/matrix.c
+++ b/quantum/split_common/matrix.c
@@ -128,12 +128,6 @@ uint8_t matrix_cols(void)
 
 void matrix_init(void)
 {
-#ifdef DISABLE_JTAG
-  // JTAG disable for PORT F. write JTD bit twice within four cycles.
-  MCUCR |= (1<<JTD);
-  MCUCR |= (1<<JTD);
-#endif
-
     debug_enable = true;
     debug_matrix = true;
     debug_mouse = true;

--- a/quantum/split_common/split_util.c
+++ b/quantum/split_common/split_util.c
@@ -92,7 +92,6 @@ void split_keyboard_setup(void) {
    sei();
 }
 
-void disable_JTAG(void);
 void keyboard_slave_loop(void) {
    matrix_init();
 

--- a/quantum/split_common/split_util.c
+++ b/quantum/split_common/split_util.c
@@ -94,10 +94,6 @@ void split_keyboard_setup(void) {
 
 void disable_JTAG(void);
 void keyboard_slave_loop(void) {
-   // Disable JTAG since we skip calling keyboard_init() on the slave side
-   // Future fix will possible call keyboard_init() on the slave to remove this need
-   disable_JTAG();
-
    matrix_init();
 
    //Init RGB
@@ -156,14 +152,4 @@ void matrix_setup(void) {
         //rgblight_init();
         keyboard_slave_loop();
     }
-}
-
-// Temporary code to disable JTAG on the slave board
-void disable_JTAG(void) {
-    /* Copied from tmk_core/common/keybaord.c */
-    // To use PORTF disable JTAG with writing JTD bit twice within four cycles.
-    #if  (defined(__AVR_AT90USB1286__) || defined(__AVR_AT90USB1287__) || defined(__AVR_ATmega32U4__))
-      MCUCR |= _BV(JTD);
-      MCUCR |= _BV(JTD);
-    #endif
 }

--- a/tmk_core/common/keyboard.c
+++ b/tmk_core/common/keyboard.c
@@ -120,6 +120,14 @@ static inline bool has_ghost_in_row(uint8_t row, matrix_row_t rowdata)
 
 #endif
 
+void disable_jtag(void) {
+// To use PORTF disable JTAG with writing JTD bit twice within four cycles.
+#if (defined(__AVR_AT90USB1286__) || defined(__AVR_AT90USB1287__) || defined(__AVR_ATmega32U4__))
+    MCUCR |= _BV(JTD);
+    MCUCR |= _BV(JTD);
+#endif
+}
+
 /** \brief matrix_setup
  *
  * FIXME: needs doc
@@ -133,6 +141,7 @@ void matrix_setup(void) {
  * FIXME: needs doc
  */
 void keyboard_setup(void) {
+    disable_jtag();
     matrix_setup();
 }
 
@@ -151,11 +160,6 @@ bool is_keyboard_master(void) {
  */
 void keyboard_init(void) {
     timer_init();
-// To use PORTF disable JTAG with writing JTD bit twice within four cycles.
-#if  (defined(__AVR_AT90USB1286__) || defined(__AVR_AT90USB1287__) || defined(__AVR_ATmega32U4__))
-  MCUCR |= _BV(JTD);
-  MCUCR |= _BV(JTD);
-#endif
     matrix_init();
 #ifdef PS2_MOUSE_ENABLE
     ps2_mouse_init();

--- a/tmk_core/common/keyboard.h
+++ b/tmk_core/common/keyboard.h
@@ -57,6 +57,8 @@ static inline bool IS_RELEASED(keyevent_t event) { return (!IS_NOEVENT(event) &&
     .time = (timer_read() | 1)                          \
 }
 
+void disable_jtag(void);
+
 /* it runs once at early stage of startup before keyboard_init. */
 void keyboard_setup(void);
 /* it runs once after initializing host side protocol, debug and MCU peripherals. */


### PR DESCRIPTION
This way all split keyboards are using that code instead of just those using split_common with the fix