### PR TITLE
Add MOD_MASK_* macros to core code

### DIFF
--- a/tmk_core/common/keycode.h
+++ b/tmk_core/common/keycode.h
@@ -46,6 +46,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MOD_BIT(code)            (1 << MOD_INDEX(code))
 #define MOD_INDEX(code)          ((code) & 0x07)
 
+#define MOD_MASK_CTRL            (MOD_BIT(KC_LCTRL)  | MOD_BIT(KC_RCTRL))
+#define MOD_MASK_SHIFT           (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT))
+#define MOD_MASK_ALT             (MOD_BIT(KC_LALT)   | MOD_BIT(KC_RALT))
+#define MOD_MASK_GUI             (MOD_BIT(KC_LGUI)   | MOD_BIT(KC_RGUI))
+#define MOD_MASK_CS              (MOD_MASK_CTRL  | MOD_MASK_SHIFT)
+#define MOD_MASK_CA              (MOD_MASK_CTRL  | MOD_MASK_ALT)
+#define MOD_MASK_CG              (MOD_MASK_CTRL  | MOD_MASK_GUI)
+#define MOD_MASK_SA              (MOD_MASK_SHIFT | MOD_MASK_ALT)
+#define MOD_MASK_SG              (MOD_MASK_SHIFT | MOD_MASK_GUI)
+#define MOD_MASK_AG              (MOD_MASK_ALT   | MOD_MASK_GUI)
+#define MOD_MASK_CSA             (MOD_MASK_CTRL  | MOD_MASK_SHIFT | MOD_MASK_ALT)
+#define MOD_MASK_CSG             (MOD_MASK_CTRL  | MOD_MASK_SHIFT | MOD_MASK_GUI)
+#define MOD_MASK_CAG             (MOD_MASK_CTRL  | MOD_MASK_ALT   | MOD_MASK_GUI)
+#define MOD_MASK_SAG             (MOD_MASK_SHIFT | MOD_MASK_ALT   | MOD_MASK_GUI)
+#define MOD_MASK_ALL             (MOD_MASK_CTRL  | MOD_MASK_SHIFT | MOD_MASK_ALT | MOD_MASK_GUI)
+
 #define FN_BIT(code)             (1 << FN_INDEX(code))
 #define FN_INDEX(code)           ((code) - KC_FN0)
 #define FN_MIN                   KC_FN0

--- a/tmk_core/common/keycode.h
+++ b/tmk_core/common/keycode.h
@@ -60,7 +60,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MOD_MASK_CSG             (MOD_MASK_CTRL  | MOD_MASK_SHIFT | MOD_MASK_GUI)
 #define MOD_MASK_CAG             (MOD_MASK_CTRL  | MOD_MASK_ALT   | MOD_MASK_GUI)
 #define MOD_MASK_SAG             (MOD_MASK_SHIFT | MOD_MASK_ALT   | MOD_MASK_GUI)
-#define MOD_MASK_ALL             (MOD_MASK_CTRL  | MOD_MASK_SHIFT | MOD_MASK_ALT | MOD_MASK_GUI)
+#define MOD_MASK_CSAG            (MOD_MASK_CTRL  | MOD_MASK_SHIFT | MOD_MASK_ALT | MOD_MASK_GUI)
 
 #define FN_BIT(code)             (1 << FN_INDEX(code))
 #define FN_INDEX(code)           ((code) - KC_FN0)


### PR DESCRIPTION
Checks of the form `get_mods() & (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT))` are very common. This adds standard macros for mod masks so that they don't have to be specified manually, which makes user code shorter and clearer, and slightly reduces the chance for errors.