### PR TITLE
[WIP]Fix up screen off timer of helix

### DIFF
--- a/keyboards/helix/helix.c
+++ b/keyboards/helix/helix.c
@@ -1,7 +1,7 @@
 #include "helix.h"
 #include "ssd1306.h" 
 
-#ifdef OLED_ENABLED
+#ifdef SSD1306OLED
 bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
     process_record_gfx(keycode,record);
 	return process_record_user(keycode, record);

--- a/keyboards/helix/helix.c
+++ b/keyboards/helix/helix.c
@@ -1,10 +1,1 @@
 #include "helix.h"
-
-
-#ifdef SSD1306OLED
-#include "ssd1306.h"
-
-bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
-	return process_record_gfx(keycode,record) && process_record_user(keycode, record);
-}
-#endif

--- a/keyboards/helix/helix.c
+++ b/keyboards/helix/helix.c
@@ -3,7 +3,6 @@
 
 #ifdef SSD1306OLED
 bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
-    process_record_gfx(keycode,record);
-	return process_record_user(keycode, record);
+	return process_record_gfx(keycode,record) && process_record_user(keycode, record);
 }
 #endif

--- a/keyboards/helix/helix.c
+++ b/keyboards/helix/helix.c
@@ -1,1 +1,9 @@
 #include "helix.h"
+#include "ssd1306.h" 
+
+#ifdef OLED_ENABLED
+bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
+    process_record_gfx(keycode,record);
+	return process_record_user(keycode, record);
+}
+#endif

--- a/keyboards/helix/helix.c
+++ b/keyboards/helix/helix.c
@@ -1,7 +1,9 @@
 #include "helix.h"
-#include "ssd1306.h" 
+
 
 #ifdef SSD1306OLED
+#include "ssd1306.h"
+
 bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
 	return process_record_gfx(keycode,record) && process_record_user(keycode, record);
 }

--- a/keyboards/helix/pico/pico.c
+++ b/keyboards/helix/pico/pico.c
@@ -2,6 +2,12 @@
 
 
 #ifdef SSD1306OLED
+#include "ssd1306.h"
+
+bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
+	return process_record_gfx(keycode,record) && process_record_user(keycode, record);
+}
+
 void led_set_kb(uint8_t usb_led) {
     // put your keyboard LED indicator (ex: Caps Lock LED) toggling code here
     //led_set_user(usb_led);

--- a/keyboards/helix/rev1/rev1.c
+++ b/keyboards/helix/rev1/rev1.c
@@ -2,6 +2,12 @@
 
 
 #ifdef SSD1306OLED
+#include "ssd1306.h"
+
+bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
+	return process_record_gfx(keycode,record) && process_record_user(keycode, record);
+}
+
 void led_set_kb(uint8_t usb_led) {
     // put your keyboard LED indicator (ex: Caps Lock LED) toggling code here
     led_set_user(usb_led);

--- a/keyboards/helix/rev2/rev2.c
+++ b/keyboards/helix/rev2/rev2.c
@@ -2,6 +2,12 @@
 
 
 #ifdef SSD1306OLED
+#include "ssd1306.h"
+
+bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
+	return process_record_gfx(keycode,record) && process_record_user(keycode, record);
+}
+
 void led_set_kb(uint8_t usb_led) {
     // put your keyboard LED indicator (ex: Caps Lock LED) toggling code here
     //led_set_user(usb_led);

--- a/keyboards/helix/ssd1306.c
+++ b/keyboards/helix/ssd1306.c
@@ -1,3 +1,4 @@
+
 #ifdef SSD1306OLED
 
 #include "ssd1306.h"
@@ -27,11 +28,16 @@
 //static uint16_t last_battery_update;
 //static uint32_t vbat;
 //#define BatteryUpdateInterval 10000 /* milliseconds */
-#define ScreenOffInterval 300000 /* milliseconds */
+
+// 'last_flush' is declared as uint16_t,
+// so this must be less than 65535 
+#define ScreenOffInterval 60000 /* milliseconds */
 #if DEBUG_TO_SCREEN
 static uint8_t displaying;
 #endif
 static uint16_t last_flush;
+
+static bool force_dirty = true;
 
 // Write command sequence.
 // Returns true on success.
@@ -318,12 +324,19 @@ void iota_gfx_task_user(void) {
 void iota_gfx_task(void) {
   iota_gfx_task_user();
 
-  if (display.dirty) {
+  if (display.dirty|| force_dirty) {
     iota_gfx_flush();
+    force_dirty = false;
   }
 
   if (timer_elapsed(last_flush) > ScreenOffInterval) {
     iota_gfx_off();
   }
 }
+
+bool process_record_gfx(uint16_t keycode, keyrecord_t *record) {
+  force_dirty = true;
+  return true;
+}
+
 #endif

--- a/keyboards/helix/ssd1306.h
+++ b/keyboards/helix/ssd1306.h
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include "pincontrol.h"
+#include "action.h"
 
 enum ssd1306_cmds {
   DisplayOff = 0xAE,
@@ -87,6 +88,6 @@ void matrix_write(struct CharacterMatrix *matrix, const char *data);
 void matrix_write_P(struct CharacterMatrix *matrix, const char *data);
 void matrix_render(struct CharacterMatrix *matrix);
 
-
+bool process_record_gfx(uint16_t keycode, keyrecord_t *record);
 
 #endif


### PR DESCRIPTION
This patch fixes the following two problems related screen off timer on helix.

1. Never screen off because ScreenOffInterval exceeds uint16_t
2. Do not return from screen off until there is no change in the screen contents between screen off and on

This is the helix version of #4346 
I don't have Helix with OLED. so I have not verified this patch.
I hope someone verify this.