### PR TITLE
Add tap_code16 function

### DIFF
--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -240,8 +240,9 @@ void reset_keyboard(void);
 void startup_user(void);
 void shutdown_user(void);
 
-void register_code16 (uint16_t code);
-void unregister_code16 (uint16_t code);
+void register_code16(uint16_t code);
+void unregister_code16(uint16_t code);
+inline void tap_code16(uint16_t code) { register_code16(code); unregister_code16(code); }
 
 #ifdef BACKLIGHT_ENABLE
 void backlight_init_ports(void);


### PR DESCRIPTION
This is like #3784 for 16-bit keycodes.

At the moment we have `register_code`, `unregister_code`, `tap_code`; but only `register_code16` and `unregister_code16`. This completes the set by adding a `tap_code16` function.