### PR TITLE
Add support for slackware distribution (linux_install.sh)

### DIFF
--- a/util/linux_install.sh
+++ b/util/linux_install.sh
@@ -4,6 +4,20 @@
 
 GENTOO_WARNING="This script will make a USE change in order to ensure that that QMK works on your system. All changes will be sent to the the file /etc/portage/package.use/qmk_firmware -- please review it, and read Portage's output carefully before installing any packages on your system. You will also need to ensure that your kernel is compiled with support for the keyboard chip that you are using (e.g. enable Arduino for the Pro Micro). Further information can be found on the Gentoo wiki."
 
+read -rd '' SLACKWARE_WARNING << EOF
+You will need the following packages from slackbuilds.org:
+	arm-binutils
+	arm-gcc
+	avr-binutils
+	avr-gcc
+	avr-libc
+	avrdude
+	dfu-programmer
+	dfu-util
+	newlib
+
+EOF
+
 if grep ID /etc/os-release | grep -qE "fedora"; then
 	sudo dnf install \
 		arm-none-eabi-binutils-cs \
@@ -127,22 +141,8 @@ elif grep ID /etc/os-release | grep -qE "opensuse|tumbleweed"; then
 		zip
 
 elif grep ID /etc/os-release | grep -q slackware; then
-	echo "You will need the following packages from slackbuilds.org:"
-	echo " avr-binutils"
-	echo " avr-gcc"
-	echo " avr-libc"
-	echo " avrdude"
-	echo " dfu-programmer"
-	echo " dfu-util"
-	echo " arm-binutils"
-	echo " arm-gcc"
-	echo " newlib"
-	echo ""
-	echo -n "Would you like to install them with sudo and sboinstall (y/N)? "
-	old_stty_cfg=$(stty -g)
-	stty raw -echo
-	answer=$( while ! head -c 1 | grep -i '[ny]' ;do true ;done )
-	stty $old_stty_cfg
+	echo $SLACKWARE_WARNING
+	read -rp "Would you like to install them with sudo and sboinstall (y/N)? " answer
 	if echo "$answer" | grep -iq "^y" ;then
 		sudo sboinstall \
 			avr-binutils \

--- a/util/linux_install.sh
+++ b/util/linux_install.sh
@@ -126,6 +126,39 @@ elif grep ID /etc/os-release | grep -qE "opensuse|tumbleweed"; then
 		wget \
 		zip
 
+elif grep ID /etc/os-release | grep -q slackware; then
+	echo "You will need the following packages from slackbuilds.org:"
+	echo " avr-binutils"
+	echo " avr-gcc"
+	echo " avr-libc"
+	echo " avrdude"
+	echo " dfu-programmer"
+	echo " dfu-util"
+	echo " arm-binutils"
+	echo " arm-gcc"
+	echo " newlib"
+	echo ""
+	echo -n "Would you like to install them with sudo and sboinstall (y/N)? "
+	old_stty_cfg=$(stty -g)
+	stty raw -echo
+	answer=$( while ! head -c 1 | grep -i '[ny]' ;do true ;done )
+	stty $old_stty_cfg
+	if echo "$answer" | grep -iq "^y" ;then
+		sudo sboinstall \
+			avr-binutils \
+			avr-gcc \
+			avr-libc \
+			avrdude \
+			dfu-programmer \
+			dfu-util \
+			arm-binutils \
+			arm-gcc \
+			newlib
+		echo "Done!"
+	else
+		echo "Quitting..."
+	fi
+
 else
 	echo "Sorry, we don't recognize your OS. Help us by contributing support!"
 	echo

--- a/util/linux_install.sh
+++ b/util/linux_install.sh
@@ -4,19 +4,7 @@
 
 GENTOO_WARNING="This script will make a USE change in order to ensure that that QMK works on your system. All changes will be sent to the the file /etc/portage/package.use/qmk_firmware -- please review it, and read Portage's output carefully before installing any packages on your system. You will also need to ensure that your kernel is compiled with support for the keyboard chip that you are using (e.g. enable Arduino for the Pro Micro). Further information can be found on the Gentoo wiki."
 
-read -rd '' SLACKWARE_WARNING << EOF
-You will need the following packages from slackbuilds.org:
-	arm-binutils
-	arm-gcc
-	avr-binutils
-	avr-gcc
-	avr-libc
-	avrdude
-	dfu-programmer
-	dfu-util
-	newlib
-
-EOF
+SLACKWARE_WARNING="You will need the following packages from slackbuilds.org:\n\tarm-binutils\n\tarm-gcc\n\tavr-binutils\n\tavr-gcc\n\tavr-libc\n\tavrdude\n\tdfu-programmer\n\tdfu-util\n\tnewlib\nThese packages will be installed with sudo and sboinstall, so ensure that your user is added to sudoers and that sboinstall is configured."
 
 if grep ID /etc/os-release | grep -qE "fedora"; then
 	sudo dnf install \
@@ -141,8 +129,9 @@ elif grep ID /etc/os-release | grep -qE "opensuse|tumbleweed"; then
 		zip
 
 elif grep ID /etc/os-release | grep -q slackware; then
-	echo $SLACKWARE_WARNING
-	read -rp "Would you like to install them with sudo and sboinstall (y/N)? " answer
+	printf "$SLACKWARE_WARNING\n"
+	printf "\nProceed (y/N)? "
+	read -r answer
 	if echo "$answer" | grep -iq "^y" ;then
 		sudo sboinstall \
 			avr-binutils \


### PR DESCRIPTION
The required packages are not provided by the official repository. The packages
need to be installed from slackbuilds.org either manually or with the help of
third party tools like sbotools.