### PR TITLE
Fix Spacing issue in Terminal Config makefile that break compiling

### DIFF
--- a/tmk_core/common.mk
+++ b/tmk_core/common.mk
@@ -46,7 +46,7 @@ ifeq ($(PLATFORM),CHIBIOS)
   endif
   ifeq ($(strip $(AUTO_SHIFT_ENABLE)), yes)
     TMK_COMMON_SRC += $(CHIBIOS)/os/various/syscalls.c
-  else ifeq($(strip $(TERMINAL_ENABLE)), yes)
+  else ifeq ($(strip $(TERMINAL_ENABLE)), yes)
     TMK_COMMON_SRC += $(CHIBIOS)/os/various/syscalls.c
   endif
 endif


### PR DESCRIPTION
Specifically, I missed a space, and Travis didn't flag it, because it causes a warning, not an error