### PR TITLE
Add standard definitions for ALGR and KC_ALGR, fix inconsistencies

### DIFF
--- a/docs/feature_advanced_keycodes.md
+++ b/docs/feature_advanced_keycodes.md
@@ -68,7 +68,7 @@ These allow you to combine a modifier with a keycode. When pressed, the keydown 
 |`LGUI(kc)`|`LCMD(kc)`, `LWIN(kc)`|Hold Left GUI and press `kc`                        |
 |`RCTL(kc)`|                      |Hold Right Control and press `kc`                   |
 |`RSFT(kc)`|                      |Hold Right Shift and press `kc`                     |
-|`RALT(kc)`|                      |Hold Right Alt and press `kc`                       |
+|`RALT(kc)`|`ALGR(kc)`            |Hold Right Alt and press `kc`                       |
 |`RGUI(kc)`|`RCMD(kc)`, `LWIN(kc)`|Hold Right GUI and press `kc`                       |
 |`HYPR(kc)`|                      |Hold Left Control, Shift, Alt and GUI and press `kc`|
 |`MEH(kc)` |                      |Hold Left Control, Shift and Alt and press `kc`     |
@@ -92,7 +92,7 @@ The modifiers this keycode and `OSM()` accept are prefixed with `MOD_`, not `KC_
 |`MOD_LGUI`|Left GUI (Windows/Command/Meta key)     |
 |`MOD_RCTL`|Right Control                           |
 |`MOD_RSFT`|Right Shift                             |
-|`MOD_RALT`|Right Alt                               |
+|`MOD_RALT`|Right Alt (AltGr)                       |
 |`MOD_RGUI`|Right GUI (Windows/Command/Meta key)    |
 |`MOD_HYPR`|Hyper (Left Control, Shift, Alt and GUI)|
 |`MOD_MEH` |Meh (Left Control, Shift, and Alt)      |

--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -177,7 +177,7 @@ This is a reference only. Each group of keys links to the page documenting their
 |`KC_LGUI`              |`KC_LCMD`, `KC_LWIN`|Left GUI (Windows/Command/Meta key)            |
 |`KC_RCTRL`             |`KC_RCTL`           |Right Control                                  |
 |`KC_RSHIFT`            |`KC_RSFT`           |Right Shift                                    |
-|`KC_RALT`              |                    |Right Alt                                      |
+|`KC_RALT`              |`KC_ALGR`           |Right Alt (AltGr)                              |
 |`KC_RGUI`              |`KC_RCMD`, `KC_RWIN`|Right GUI (Windows/Command/Meta key)           |
 |`KC_SYSTEM_POWER`      |`KC_PWR`            |System Power Down                              |
 |`KC_SYSTEM_SLEEP`      |`KC_SLEP`           |System Sleep                                   |
@@ -331,7 +331,7 @@ This is a reference only. Each group of keys links to the page documenting their
 |`LGUI(kc)`|`LCMD(kc)`, `LWIN(kc)`|Hold Left GUI and press `kc`                        |
 |`RCTL(kc)`|                      |Hold Right Control and press `kc`                   |
 |`RSFT(kc)`|                      |Hold Right Shift and press `kc`                     |
-|`RALT(kc)`|                      |Hold Right Alt and press `kc`                       |
+|`RALT(kc)`|`ALGR(kc)`            |Hold Right Alt and press `kc`                       |
 |`RGUI(kc)`|`RCMD(kc)`, `LWIN(kc)`|Hold Right GUI and press `kc`                       |
 |`HYPR(kc)`|                      |Hold Left Control, Shift, Alt and GUI and press `kc`|
 |`MEH(kc)` |                      |Hold Left Control, Shift and Alt and press `kc`     |

--- a/docs/keycodes_basic.md
+++ b/docs/keycodes_basic.md
@@ -116,7 +116,7 @@ The basic set of keycodes are based on the [HID Keyboard/Keypad Usage Page (0x07
 |`KC_LGUI`  |`KC_LCMD`, `KC_LWIN`|Left GUI (Windows/Command/Meta key) |
 |`KC_RCTRL` |`KC_RCTL`           |Right Control                       |
 |`KC_RSHIFT`|`KC_RSFT`           |Right Shift                         |
-|`KC_RALT`  |                    |Right Alt                           |
+|`KC_RALT`  |`KC_ALGR`           |Right Alt (AltGr)                   |
 |`KC_RGUI`  |`KC_RCMD`, `KC_RWIN`|Right GUI (Windows/Command/Meta key)|
 
 ## International

--- a/keyboards/handwired/reddot/keymaps/default/keymap.c
+++ b/keyboards/handwired/reddot/keymaps/default/keymap.c
@@ -8,14 +8,14 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  KC_LALT,    FR_AMP, FR_EACU,  FR_QUOT, FR_APOS,    FR_LPRN,  KC_BSPACE,   KC_DELETE, FR_MINS,  FR_EGRV, FR_UNDS,  FR_CCED,       FR_AGRV,    FR_RPRN,  FR_EQL,       KC_INSERT,    KC_HOME,    KC_PGUP,\
  KC_LGUI,    FR_A,     FR_Z,     KC_E,      KC_R,     KC_T,  KC_LSFT,   KC_ENT,     KC_Y,     KC_U,     KC_I,     KC_O,          KC_P,    FR_CIRC,      FR_DLR,       KC_DELETE,    KC_END,    KC_PGDOWN, KC_KP_PLUS,\
  KC_LCTL,    FR_Q,     KC_S,     KC_D,      KC_F,     KC_G,   KC_ENT,            KC_H,     KC_J,     KC_K,     KC_L,          FR_M,  FR_UGRV,  FR_ASTR,       KC_KP_1,    KC_UP,    KC_KP_3,\
- FR_LESS, FR_W,     KC_X,     KC_C,      KC_V,     KC_B,   KC_SPACE,          KC_SPACE,     KC_N, FR_COMM,   FR_SCLN,  FR_COLN,     FR_EXLM,  NO_ALGR,    KC_LEFT,    KC_DOWN, KC_RIGHT, KC_KP_ENTER),
+ FR_LESS, FR_W,     KC_X,     KC_C,      KC_V,     KC_B,   KC_SPACE,          KC_SPACE,     KC_N, FR_COMM,   FR_SCLN,  FR_COLN,     FR_EXLM,  FR_ALGR,    KC_LEFT,    KC_DOWN, KC_RIGHT, KC_KP_ENTER),
 
  [1] = KEYMAP(
   KC_ESC,    KC_F1,    KC_F2,    KC_F3,     KC_F4,    KC_F5,   KC_TAB,  KC_CAPS,    KC_F6,    KC_F7,    KC_F8,    KC_F9,        KC_F10,  KC_F11,    KC_F12,   KC_FN0, KC_KP_SLASH, KC_KP_ASTERISK, KC_KP_MINUS,\
   KC_LALT,    FR_AMP, FR_EACU,  FR_QUOT, FR_APOS,    FR_LPRN,  KC_BSPACE,   KC_DELETE, FR_MINS,  FR_EGRV, FR_UNDS,  FR_CCED,       FR_AGRV,    FR_RPRN,  FR_EQL,       KC_7,    KC_8,    KC_9,\
   KC_LGUI,    FR_A,     FR_Z,     KC_E,      KC_R,     KC_T,  KC_LSFT,   KC_ENT,     KC_Y,     KC_U,     KC_I,     KC_O,          KC_P,    FR_CIRC,      FR_DLR,       KC_4,    KC_5,    KC_6, KC_KP_PLUS,\
   KC_LCTL,    FR_Q,     KC_S,     KC_D,      KC_F,     KC_G,   KC_ENT,            KC_H,     KC_J,     KC_K,     KC_L,          FR_M,  FR_UGRV,  FR_ASTR,       KC_1,    KC_2,    KC_3,\
-  FR_LESS, FR_W,     KC_X,     KC_C,      KC_V,     KC_B,   KC_SPACE,          KC_SPACE,     KC_N, FR_COMM,   FR_SCLN,  FR_COLN,     FR_EXLM,  NO_ALGR,    KC_LEFT,    KC_DOWN, KC_RIGHT, KC_KP_ENTER),
+  FR_LESS, FR_W,     KC_X,     KC_C,      KC_V,     KC_B,   KC_SPACE,          KC_SPACE,     KC_N, FR_COMM,   FR_SCLN,  FR_COLN,     FR_EXLM,  FR_ALGR,    KC_LEFT,    KC_DOWN, KC_RIGHT, KC_KP_ENTER),
 };
 
 

--- a/keyboards/xd75/keymaps/germanized/config.h
+++ b/keyboards/xd75/keymaps/germanized/config.h
@@ -28,7 +28,6 @@
 #define TAPPING_TERM 200
 
 // Alt gr
-#define ALGR(kc) RALT(kc)
 #define DE_ALGR KC_RALT
 
 // normal characters

--- a/quantum/keymap_extras/keymap_belgian.h
+++ b/quantum/keymap_extras/keymap_belgian.h
@@ -22,7 +22,7 @@
 #define BE_LALT KC_LGUI
 
 // Alt gr
-#define NO_ALGR KC_RALT
+#define BE_ALGR KC_RALT
 
 // Normal characters
 // Line 1

--- a/quantum/keymap_extras/keymap_belgian.h
+++ b/quantum/keymap_extras/keymap_belgian.h
@@ -22,9 +22,6 @@
 #define BE_LALT KC_LGUI
 
 // Alt gr
-#ifndef ALGR
-#define ALGR(kc) RALT(kc)
-#endif
 #define NO_ALGR KC_RALT
 
 // Normal characters

--- a/quantum/keymap_extras/keymap_bepo.h
+++ b/quantum/keymap_extras/keymap_bepo.h
@@ -23,9 +23,6 @@
 #ifndef ALTGR
 #define ALTGR(kc)   RALT(kc)
 #endif
-#ifndef ALGR
-#define ALGR(kc)    ALTGR(kc)
-#endif
 #define BP_ALGR KC_RALT
 
 // Normal characters

--- a/quantum/keymap_extras/keymap_bepo.h
+++ b/quantum/keymap_extras/keymap_bepo.h
@@ -21,7 +21,7 @@
 
 // Alt gr
 #ifndef ALTGR
-#define ALTGR(kc)   RALT(kc)
+#define ALTGR(kc)   ALGR(kc)
 #endif
 #define BP_ALGR KC_RALT
 

--- a/quantum/keymap_extras/keymap_canadian_multilingual.h
+++ b/quantum/keymap_extras/keymap_canadian_multilingual.h
@@ -22,9 +22,6 @@
 #ifndef ALTGR
 #define ALTGR(kc)   RALT(kc)
 #endif
-#ifndef ALGR
-#define ALGR(kc)    ALTGR(kc)
-#endif
 
 #define CSA_ALTGR   KC_RALT
 #define CSA_ALGR    CSA_ALTGR

--- a/quantum/keymap_extras/keymap_canadian_multilingual.h
+++ b/quantum/keymap_extras/keymap_canadian_multilingual.h
@@ -20,7 +20,7 @@
 
 // Alt gr
 #ifndef ALTGR
-#define ALTGR(kc)   RALT(kc)
+#define ALTGR(kc)   ALGR(kc)
 #endif
 
 #define CSA_ALTGR   KC_RALT

--- a/quantum/keymap_extras/keymap_fr_ch.h
+++ b/quantum/keymap_extras/keymap_fr_ch.h
@@ -19,7 +19,6 @@
 #include "keymap.h"
 
 // Alt gr
-#define ALGR(kc) RALT(kc)
 #define FR_CH_ALGR KC_RALT
 
 // normal characters

--- a/quantum/keymap_extras/keymap_french.h
+++ b/quantum/keymap_extras/keymap_french.h
@@ -19,7 +19,7 @@
 #include "keymap.h"
 
 // Alt gr
-#define NO_ALGR KC_RALT
+#define FR_ALGR KC_RALT
 
 // Normal characters
 #define FR_SUP2	KC_GRV

--- a/quantum/keymap_extras/keymap_french.h
+++ b/quantum/keymap_extras/keymap_french.h
@@ -19,9 +19,6 @@
 #include "keymap.h"
 
 // Alt gr
-#ifndef ALGR
-#define ALGR(kc) RALT(kc)
-#endif
 #define NO_ALGR KC_RALT
 
 // Normal characters

--- a/quantum/keymap_extras/keymap_german.h
+++ b/quantum/keymap_extras/keymap_german.h
@@ -20,7 +20,6 @@
 #include "keymap.h"
 
 // Alt gr
-#define ALGR(kc) RALT(kc)
 #define DE_ALGR KC_RALT
 
 // normal characters

--- a/quantum/keymap_extras/keymap_german_ch.h
+++ b/quantum/keymap_extras/keymap_german_ch.h
@@ -19,7 +19,6 @@
 #include "keymap.h"
 
 // Alt gr
-#define ALGR(kc) RALT(kc)
 #define CH_ALGR KC_RALT
 
 // normal characters

--- a/quantum/keymap_extras/keymap_hungarian.h
+++ b/quantum/keymap_extras/keymap_hungarian.h
@@ -20,7 +20,6 @@
 #include "keymap.h"
 
 // Alt gr
-#define ALGR(kc) RALT(kc)
 #define HU_ALGR KC_RALT
 
 // basic letters

--- a/quantum/keymap_extras/keymap_italian.h
+++ b/quantum/keymap_extras/keymap_italian.h
@@ -20,7 +20,6 @@
 #include "keymap.h"
 
 // Alt gr
-#define ALGR(kc) RALT(kc)
 #define IT_ALGR KC_RALT
 
 // normal characters

--- a/quantum/keymap_extras/keymap_nordic.h
+++ b/quantum/keymap_extras/keymap_nordic.h
@@ -19,7 +19,6 @@
 #include "keymap.h"
 
 // Alt gr
-#define ALGR(kc) RALT(kc)
 #define NO_ALGR KC_RALT
 
 // Normal characters

--- a/quantum/keymap_extras/keymap_slovenian.h
+++ b/quantum/keymap_extras/keymap_slovenian.h
@@ -21,7 +21,6 @@
 #include "keymap.h"
 
 // Alt gr
-#define ALGR(kc) RALT(kc)
 #define SI_ALGR KC_RALT
 
 //Swapped Z and Y

--- a/quantum/keymap_extras/keymap_spanish.h
+++ b/quantum/keymap_extras/keymap_spanish.h
@@ -19,7 +19,6 @@
 #include "keymap.h"
 
 // Alt gr
-#define ALGR(kc) RALT(kc)
 #define NO_ALGR KC_RALT
 
 // Normal characters

--- a/quantum/keymap_extras/keymap_spanish.h
+++ b/quantum/keymap_extras/keymap_spanish.h
@@ -19,7 +19,7 @@
 #include "keymap.h"
 
 // Alt gr
-#define NO_ALGR KC_RALT
+#define ES_ALGR KC_RALT
 
 // Normal characters
 #define ES_OVRR KC_GRV

--- a/quantum/keymap_extras/keymap_uk.h
+++ b/quantum/keymap_extras/keymap_uk.h
@@ -19,7 +19,6 @@
 #include "keymap.h"
 
 // Alt gr
-#define ALGR(kc) RALT(kc)
 #define NO_ALGR KC_RALT
 
 // Normal characters

--- a/quantum/keymap_extras/keymap_uk.h
+++ b/quantum/keymap_extras/keymap_uk.h
@@ -19,7 +19,7 @@
 #include "keymap.h"
 
 // Alt gr
-#define NO_ALGR KC_RALT
+#define UK_ALGR KC_RALT
 
 // Normal characters
 #define UK_HASH KC_NUHS

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -197,6 +197,7 @@ extern uint32_t default_layer_state;
 #define SS_LALT(string) SS_DOWN(X_LALT) string SS_UP(X_LALT)
 #define SS_LSFT(string) SS_DOWN(X_LSHIFT) string SS_UP(X_LSHIFT)
 #define SS_RALT(string) SS_DOWN(X_RALT) string SS_UP(X_RALT)
+#define SS_ALGR(string) SS_RALT(string)
 
 #define SEND_STRING(str) send_string_P(PSTR(str))
 extern const bool ascii_to_shift_lut[0x80];

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -646,7 +646,7 @@ enum quantum_keycodes {
 #define ALT_T(kc) MT(MOD_LALT, kc)
 #define LALT_T(kc) MT(MOD_LALT, kc)
 #define RALT_T(kc) MT(MOD_RALT, kc)
-#define ALGR_T(kc) MT(MOD_RALT, kc) // dual-function AltGR
+#define ALGR_T(kc) RALT_T(kc)
 
 #define GUI_T(kc) MT(MOD_LGUI, kc)
 #define CMD_T(kc) GUI_T(kc)

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -470,6 +470,7 @@ enum quantum_keycodes {
 #define RCTL(kc) (QK_RCTL | (kc))
 #define RSFT(kc) (QK_RSFT | (kc))
 #define RALT(kc) (QK_RALT | (kc))
+#define ALGR(kc) RALT(kc)
 #define RGUI(kc) (QK_RGUI | (kc))
 #define RCMD(kc) RGUI(kc)
 #define RWIN(kc) RGUI(kc)
@@ -480,7 +481,7 @@ enum quantum_keycodes {
 #define SGUI(kc) (QK_LGUI | QK_LSFT | (kc))
 #define SCMD(kc) SGUI(kc)
 #define SWIN(kc) SGUI(kc)
-#define LCA(kc) (QK_LCTL | QK_LALT | (kc))
+#define LCA(kc)  (QK_LCTL | QK_LALT | (kc))
 
 #define MOD_HYPR 0xf
 #define MOD_MEH 0x7

--- a/tmk_core/common/keycode.h
+++ b/tmk_core/common/keycode.h
@@ -140,6 +140,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define KC_LWIN KC_LGUI
 #define KC_RCTL KC_RCTRL
 #define KC_RSFT KC_RSHIFT
+#define KC_ALGR KC_RALT
 #define KC_RCMD KC_RGUI
 #define KC_RWIN KC_RGUI
 


### PR DESCRIPTION
At the moment, every language keymap that uses `ALGR` defines it separately. There's no need for this — `ALGR` should be a standard modifier definition in core code, and this PR makes it so. `ALGR_T` for mod tap already existed, so now a regular `ALGR` modifier exists too.

This PR also fixes inconsistencies in AltGr keycodes: some non-Nordic keymaps (namely: Belgian, French, Spanish, UK) used `NO_ALGR` instead of `BE_ALGR`, `FR_ALGR` etc.

Finally, this PR adds a standard alias `KC_ALGR` for `KC_RALT` that matches the aforementioned language-specific definitions. It also adds `SS_ALGR` for `SS_RALT`. This makes `ALGR` totally consistent with the `CMD` and `WIN` aliases for `GUI`.