### PR TITLE
Fix Blockey compiler (and size) issues

### DIFF
--- a/keyboards/blockey/rules.mk
+++ b/keyboards/blockey/rules.mk
@@ -1,5 +1,3 @@
-SRC += ws2812.c
-
 # MCU name
 #MCU = at90usb1286
 MCU = atmega32u4
@@ -54,7 +52,7 @@ OPT_DEFS += -DBOOTLOADER_SIZE=4096
 #   change yes to no to disable
 #
 BOOTMAGIC_ENABLE = no      # Virtual DIP switch configuration(+1000)
-MOUSEKEY_ENABLE = yes       # Mouse keys(+4700)
+MOUSEKEY_ENABLE = no       # Mouse keys(+4700)
 EXTRAKEY_ENABLE = yes       # Audio control and System control(+450)
 CONSOLE_ENABLE = yes        # Console for debug(+400)
 COMMAND_ENABLE = yes        # Commands for debug and configuration


### PR DESCRIPTION
Specifically, remvove the SRC line addig the ws2812 file, as it's not needed, and disabled mousekeys for space.