### PR TITLE
Read user input properly in linux_install.sh for Gentoo

### DIFF
--- a/util/linux_install.sh
+++ b/util/linux_install.sh
@@ -30,7 +30,7 @@ if grep ID /etc/os-release | grep -qE "fedora"; then
 elif grep ID /etc/os-release | grep -qE 'debian|ubuntu'; then
 	DEBIAN_FRONTEND=noninteractive
 	DEBCONF_NONINTERACTIVE_SEEN=true
-        export DEBIAN_FRONTEND DEBCONF_NONINTERACTIVE_SEEN
+	export DEBIAN_FRONTEND DEBCONF_NONINTERACTIVE_SEEN
 	sudo apt-get update
 	sudo apt-get install \
 		build-essential \
@@ -59,7 +59,7 @@ elif grep ID /etc/os-release | grep -q 'arch\|manjaro'; then
 		avr-binutils \
 		avr-libc \
 		avr-gcc \
-    base-devel \
+		base-devel \
 		dfu-util \
 		diff-utils \
 		gcc \

--- a/util/linux_install.sh
+++ b/util/linux_install.sh
@@ -68,7 +68,7 @@ elif grep ID /etc/os-release | grep -q 'arch\|manjaro'; then
 		wget \
 		zip
 	git clone https://aur.archlinux.org/dfu-programmer.git /tmp/dfu-programmer
-	cd /tmp/dfu-programmer
+	cd /tmp/dfu-programmer || exit 1
 	makepkg -sic
 	rm -rf /tmp/dfu-programmer/
 

--- a/util/linux_install.sh
+++ b/util/linux_install.sh
@@ -77,7 +77,7 @@ elif grep ID /etc/os-release | grep -q gentoo; then
 	read -rp "Proceed (y/N)? " answer
 	if echo "$answer" | grep -iq "^y"; then
 		sudo touch /etc/portage/package.use/qmkfirmware
-		echo "sys-devel/gcc multilib" | sudo tee --append /etc/portage/package.use/qmkfirmware > /dev/null
+		echo "sys-devel/gcc multilib" >> /etc/portage/package.use/qmkfirmware
 		sudo emerge -auN \
 			app-arch/unzip \
 			app-arch/zip \

--- a/util/linux_install.sh
+++ b/util/linux_install.sh
@@ -78,7 +78,8 @@ elif grep ID /etc/os-release | grep -q gentoo; then
 	read -r answer
 	if echo "$answer" | grep -iq "^y"; then
 		sudo touch /etc/portage/package.use/qmkfirmware
-		sudo echo "sys-devel/gcc multilib" >> /etc/portage/package.use/qmkfirmware
+		# tee is used here since sudo doesn't apply to >>
+		echo "sys-devel/gcc multilib" | sudo tee --append /etc/portage/package.use/qmkfirmware >/dev/null
 		sudo emerge -auN \
 			app-arch/unzip \
 			app-arch/zip \

--- a/util/linux_install.sh
+++ b/util/linux_install.sh
@@ -74,7 +74,7 @@ elif grep ID /etc/os-release | grep -q 'arch\|manjaro'; then
 
 elif grep ID /etc/os-release | grep -q gentoo; then
 	echo "$GENTOO_WARNING" | fmt
-	echo -n "Proceed (y/N)? "
+	printf "\nProceed (y/N)? "
 	read -r answer
 	if echo "$answer" | grep -iq "^y"; then
 		sudo touch /etc/portage/package.use/qmkfirmware

--- a/util/linux_install.sh
+++ b/util/linux_install.sh
@@ -74,7 +74,8 @@ elif grep ID /etc/os-release | grep -q 'arch\|manjaro'; then
 
 elif grep ID /etc/os-release | grep -q gentoo; then
 	echo GENTOO_WARNING | fmt
-	read -rp "Proceed (y/N)? " answer
+	echo -n "Proceed (y/N)? "
+	read -r answer
 	if echo "$answer" | grep -iq "^y"; then
 		sudo touch /etc/portage/package.use/qmkfirmware
 		echo "sys-devel/gcc multilib" >> /etc/portage/package.use/qmkfirmware

--- a/util/linux_install.sh
+++ b/util/linux_install.sh
@@ -78,7 +78,7 @@ elif grep ID /etc/os-release | grep -q gentoo; then
 	read -r answer
 	if echo "$answer" | grep -iq "^y"; then
 		sudo touch /etc/portage/package.use/qmkfirmware
-		echo "sys-devel/gcc multilib" >> /etc/portage/package.use/qmkfirmware
+		sudo echo "sys-devel/gcc multilib" >> /etc/portage/package.use/qmkfirmware
 		sudo emerge -auN \
 			app-arch/unzip \
 			app-arch/zip \

--- a/util/linux_install.sh
+++ b/util/linux_install.sh
@@ -73,7 +73,7 @@ elif grep ID /etc/os-release | grep -q 'arch\|manjaro'; then
 	rm -rf /tmp/dfu-programmer/
 
 elif grep ID /etc/os-release | grep -q gentoo; then
-	echo GENTOO_WARNING | fmt
+	echo "$GENTOO_WARNING" | fmt
 	echo -n "Proceed (y/N)? "
 	read -r answer
 	if echo "$answer" | grep -iq "^y"; then

--- a/util/linux_install.sh
+++ b/util/linux_install.sh
@@ -74,12 +74,8 @@ elif grep ID /etc/os-release | grep -q 'arch\|manjaro'; then
 
 elif grep ID /etc/os-release | grep -q gentoo; then
 	echo GENTOO_WARNING | fmt
-	echo -n "Proceed (y/N)? "
-	old_stty_cfg=$(stty -g)
-	stty raw -echo
-	answer=$( while ! head -c 1 | grep -i '[ny]' ;do true ;done )
-	stty $old_stty_cfg
-	if echo "$answer" | grep -iq "^y" ;then
+	read -rp "Proceed (y/N)? " answer
+	if echo "$answer" | grep -iq "^y"; then
 		sudo touch /etc/portage/package.use/qmkfirmware
 		echo "sys-devel/gcc multilib" | sudo tee --append /etc/portage/package.use/qmkfirmware > /dev/null
 		sudo emerge -auN \


### PR DESCRIPTION
The script currently uses a very convoluted, hacky and error-prone way of reading user input (y/n) when installing on Gentoo, which involves changing TTY settings. This changes it to a POSIX-compliant `read` call.

It also replaces the non-POSIX `echo -n` with `printf`, as well as fixing some inconsistent indentation.