### PR TITLE
.editorconfig: Make tabs the preferred indentation style for make and shell files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,14 +20,17 @@ indent_size = 4
 [*.mk]
 end_of_line = lf
 indent_style = tab
+indent_size = 4
 
 [Makefile]
 end_of_line = lf
 indent_style = tab
+indent_size = 4
 
 [*.sh]
 end_of_line = lf
 indent_style = tab
+indent_size = 4
 
 # The gitattributes file will handle the line endings conversion properly according to the operating system settings for other files
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -19,12 +19,10 @@ indent_size = 4
 # Make these match what we have in .gitattributes
 [*.mk]
 end_of_line = lf
-indent_style = tab
 indent_size = 4
 
 [Makefile]
 end_of_line = lf
-indent_style = tab
 indent_size = 4
 
 [*.sh]

--- a/.editorconfig
+++ b/.editorconfig
@@ -19,12 +19,15 @@ indent_size = 4
 # Make these match what we have in .gitattributes
 [*.mk]
 end_of_line = lf
+indent_style = tab
 
 [Makefile]
 end_of_line = lf
+indent_style = tab
 
 [*.sh]
 end_of_line = lf
+indent_style = tab
 
 # The gitattributes file will handle the line endings conversion properly according to the operating system settings for other files
 


### PR DESCRIPTION
Traditionally, `make` only supports tabs for indentation ([see here](https://stackoverflow.com/questions/2131213/can-you-make-valid-makefiles-without-tab-characters)). Although I don't think this is a requirement anymore with GNU Make (since it obviously works for us even with spaces in files), it'd still be nice to have tabs declared as the preferred indentation style in `.editorconfig`.

Shell scripts, on the other hand, still have hard limitations regarding tabs and spaces. For example, [`<<-` heredocs only support tabs](https://unix.stackexchange.com/a/76483/27637) for indenting the contents. This is as true for Bash as it is for most (all?) other POSIX shells.

That is why I'm proposing that `indent_style = tab` be set as the default for make and shell files.
**Note:** This PR doesn't change any existing source files; it only adds the declarations to `.editorconfig`.

`indent_size = 4`, on the other hand, is optional. I set that based on what the majority of make/shell files currently use. Here are the stats:

| File type          | # of files using tabs | # of lines using tabs | # of files using spaces | # of lines using 2 spaces | # of lines using 4 spaces |
| ------------------ | --------------------- | --------------------- | ----------------------- | ------------------------- | ------------------------- |
| `Makefile`,  `*.mk` | 846                   | 379                   | 87                      | 385                       | 958                       |
| `*.sh`             | 15                    | 342                   | 14                      | 7                         | 237                       |

Keep in mind that this is not entirely accurate and that there is some overlap (e.g. files using both tabs and spaces or both 2-space and 4-space indents), but it should give you a rough idea of what the current state of the codebase is.