### PR TITLE
Add missing arm gcc compiler for openSUSE 15.0 and Tumbleweed.

### DIFF
--- a/util/linux_install.sh
+++ b/util/linux_install.sh
@@ -110,12 +110,15 @@ elif grep ID /etc/os-release | grep -q sabayon; then
 
 elif grep ID /etc/os-release | grep -qE "opensuse|tumbleweed"; then
 	CROSS_AVR_GCC=cross-avr-gcc8
+	CROSS_ARM_GCC=cross-arm-none-gcc8
 	if grep ID /etc/os-release | grep -q "15.0"; then
 		CROSS_AVR_GCC=cross-avr-gcc7
+		CROSS_ARM_GCC=cross-arm-none-gcc7
 	fi
 	sudo zypper install \
 		avr-libc \
 		$CROSS_AVR_GCC \
+		$CROSS_ARM_GCC \
 		cross-avr-binutils \
 		cross-arm-none-newlib-devel \
 		cross-arm-binutils cross-arm-none-newlib-devel \


### PR DESCRIPTION
Tested on openSUSE 15.0, but should also work on Tumbleweed.