### PR TITLE
Make sure that avr-gcc@7 gets linked into the path on MacOS.

### DIFF
--- a/docs/faq_build.md
+++ b/docs/faq_build.md
@@ -126,5 +126,5 @@ For now, you need to rollback avr-gcc to 7 in brew.
 ```
 brew uninstall --force avr-gcc
 brew install avr-gcc@7
-brew link avr-gcc@7
+brew link --force avr-gcc@7
 ```

--- a/docs/getting_started_build_tools.md
+++ b/docs/getting_started_build_tools.md
@@ -57,6 +57,7 @@ If you're using [homebrew,](http://brew.sh/) you can use the following commands:
     brew tap PX4/homebrew-px4
     brew update
     brew install avr-gcc@7
+    brew link --force avr-gcc@7
     brew install dfu-programmer
     brew install dfu-util
     brew install gcc-arm-none-eabi

--- a/util/macos_install.sh
+++ b/util/macos_install.sh
@@ -23,3 +23,4 @@ brew tap osx-cross/avr
 brew tap PX4/homebrew-px4
 brew update
 brew install avr-gcc@7 gcc-arm-none-eabi dfu-programmer avrdude dfu-util
+brew link --force avr-gcc@7


### PR DESCRIPTION
I've seen a few posts recently with people having issues and manually having to link avr-gcc@7 into the path, since it is keg-only.