### PR TITLE
Fixed incorrect link to feature_combo.md in features.md docs file.

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -8,7 +8,7 @@ QMK has a staggering number of features for building your keyboard. It can take 
 * [Auto Shift](feature_auto_shift.md) - Tap for the normal key, hold slightly longer for its shifted state.
 * [Backlight](feature_backlight.md) - LED lighting support for your keyboard.
 * [Bootmagic](feature_bootmagic.md) - Adjust the behavior of your keyboard using hotkeys.
-* [Combos](feature_combos.md) - Custom actions for multiple key holds.
+* [Combos](feature_combo.md) - Custom actions for multiple key holds.
 * [Command](feature_command.md) - Runtime version of bootmagic (Formerly known as "Magic").
 * [Dynamic Macros](feature_dynamic_macros.md) - Record and playback macros from the keyboard itself.
 * [Grave Escape](feature_grave_esc.md) - Lets you use a single key for Esc and Grave. 


### PR DESCRIPTION
Fixed incorrect link to feature_combo.md in features.md docs file. 

Was linked to feature_combos.md, but _sidebar.md, _summary.md, and config_options.md all link to feature_combo.md. 

Assuming that it should not be pluralized.