### PR TITLE
Fixed Unicode Support heading

### DIFF
--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -459,6 +459,7 @@ This is a reference only. Each group of keys links to the page documenting their
 |`SH_MOFF`  |Momentarily turns off swap.                                              |
 |`SH_TG`    |Toggles swap on and off with every key press.                            |
 |`SH_TT`    |Toggles with a tap; momentary when held.                                 |
+
 ## [Unicode Support](feature_unicode.md)
 
 |Key         |Aliases|                                                 |


### PR DESCRIPTION
Previously, Unicode Support heading appeared as the last row in the Swap Hands table.