### PR TITLE
Updated sixshooter keyboard to move LED macros into the default keymap.

### DIFF
--- a/keyboards/sixshooter/keymaps/default/keymap.c
+++ b/keyboards/sixshooter/keymaps/default/keymap.c
@@ -18,10 +18,16 @@
 #define _BL 0
 #define _FN 1
 
+// Define keyboard specific keycodes for controlling on/off for all LEDs as they
+// are all on different pins with this PCB, rather than a single backlight pin
+enum custom_keycodes {
+    SS_LON = SAFE_RANGE,
+    SS_LOFF
+};
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    /* Keymap 0: Media Keys
+    /* Base Layer: Media Keys
      * ,-----------.
-     * |Mut| V-| V+|
+     * |FN | V-| V+|
      * |---+---+---|
      * |Prv|Ply|Nxt|
      * `-----------'
@@ -30,13 +36,38 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     MO(_FN), KC_VOLD, KC_VOLU, \
     KC_MPRV, KC_MPLY, KC_MNXT  \
   ),
+    /* FN Layer: LED control
+     * ,-----------.
+     * |FN | V-| V+|
+     * |---+---+---|
+     * |Prv|Ply|Nxt|
+     * `-----------'
+     */
   [_FN] = LAYOUT(
     KC_TRNS, SS_LON, SS_LOFF, \
-    KC_TRNS, KC_TRNS, KC_TRNS
+    KC_NO,   KC_NO,  KC_NO
   ),
 };
 
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+	// Put your per-action keyboard code here.
+	// Runs for every action, just before processing by the firmware.
+  if (record->event.pressed) {
+
+    // Check for custom keycodes for turning on and off LEDs
+    switch(keycode) {
+      case SS_LON:
+        sixshooter_led_all_on();
+        return false;
+      case SS_LOFF:
+        sixshooter_led_all_off();
+        return false;
+    }
+  }
+  return true;
+};
+
 void matrix_init_user(void) {
-  /* Default all LEDs to on */
+  // Default all LEDs to on
   sixshooter_led_all_on();
 }

--- a/keyboards/sixshooter/sixshooter.c
+++ b/keyboards/sixshooter/sixshooter.c
@@ -31,25 +31,6 @@ void matrix_scan_kb(void) {
 	matrix_scan_user();
 }
 
-bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
-	// put your per-action keyboard code here
-	// runs for every action, just before processing by the firmware
-  if (record->event.pressed) {
-
-    /* Check for custom keycodes for turning on and off LEDs */
-    switch(keycode) {
-      case SS_LON:
-        sixshooter_led_all_on();
-        return false;
-      case SS_LOFF:
-        sixshooter_led_all_off();
-        return false;
-    }
-  }
-
-	return process_record_user(keycode, record);
-}
-
 void led_set_kb(uint8_t usb_led) {
 	// put your keyboard LED indicator (ex: Caps Lock LED) toggling code here
 

--- a/keyboards/sixshooter/sixshooter.h
+++ b/keyboards/sixshooter/sixshooter.h
@@ -10,17 +10,6 @@
 	{ K00, K01, K02, K03, K04, K05 }, \
 }
 
-
-/*
- * Define keyboard specific keycodes for controlling on/off for all LEDs as they
- * are all on different pins with this PCB, rather than a single backlight pin
- */
-enum keyboard_keycode {
-  SS_LON = SAFE_RANGE,
-  SS_LOFF,
-  SAFE_RANGE_KB
-};
-
 inline void sixshooter_led_0_on(void)    { DDRB |=  (1<<6); PORTB |=  (1<<6); }
 inline void sixshooter_led_1_on(void)    { DDRC |=  (1<<7); PORTC |=  (1<<7); }
 inline void sixshooter_led_2_on(void)    { DDRD |=  (1<<0); PORTD |=  (1<<0); }


### PR DESCRIPTION
Realized having them in the <keyboard>.c and <keyboard>.h file was problematic when setting up macros in keymaps.