### PR TITLE
Proposal: hsv_to_rgb conversion fix

### DIFF
--- a/quantum/color.c
+++ b/quantum/color.c
@@ -37,8 +37,8 @@ RGB hsv_to_rgb( HSV hsv )
 	s = hsv.s;
 	v = hsv.v;
 
-	region = h / 43;
-	remainder = (h - (region * 43)) * 6;
+	region = h / 60;
+	remainder = (h - (region * 60)) * 6;
 
 	p = (v * (255 - s)) >> 8;
 	q = (v * (255 - ((s * remainder) >> 8))) >> 8;


### PR DESCRIPTION
When converting HSV to RGB, the region should be equal to the `hue / 60°`. Right now it is divided by 43°. Not sure if it was done on purpose, so treat this as a proposal more than a fix :)

Source to the formula: https://en.wikipedia.org/wiki/HSL_and_HSV#From_HSV