### PR TITLE
[WIP] 40percentclub - enable 4x4 and 5x5 community keymaps

### DIFF
--- a/keyboards/40percentclub/4x4/4x4.h
+++ b/keyboards/40percentclub/4x4/4x4.h
@@ -56,3 +56,16 @@
     { K20, K21, K22, K23, K24, K25, K26, K27, K28, K29, K2a, K2b, K2c, K2d, K2e, K2f }, \
     { K30, K31, K32, K33, K34, K35, K36, K37, K38, K39, K3a, K3b, K3c, K3d, K3e, K3f } \
 }
+
+#define LAYOUT_kc_ortho_4x12( \
+    K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0a, K0b, \
+    K10, K11, K12, K13, K14, K15, K16, K17, K18, K19, K1a, K1b, \
+    K20, K21, K22, K23, K24, K25, K26, K27, K28, K29, K2a, K2b, \
+    K30, K31, K32, K33, K34, K35, K36, K37, K38, K39, K3a, K3b  \
+) \
+{ \
+    { KC_##K00, KC_##K01, KC_##K02, KC_##K03, KC_##K04, KC_##K05, KC_##K06, KC_##K07, KC_##K08, KC_##K09, KC_##K0a, KC_##K0b, ___, ___, ___, ___}, \
+    { KC_##K10, KC_##K11, KC_##K12, KC_##K13, KC_##K14, KC_##K15, KC_##K16, KC_##K17, KC_##K18, KC_##K19, KC_##K1a, KC_##K1b, ___, ___, ___, ___}, \
+    { KC_##K20, KC_##K21, KC_##K22, KC_##K23, KC_##K24, KC_##K25, KC_##K26, KC_##K27, KC_##K28, KC_##K29, KC_##K2a, KC_##K2b, ___, ___, ___, ___}, \
+    { KC_##K30, KC_##K31, KC_##K32, KC_##K33, KC_##K34, KC_##K35, KC_##K36, KC_##K37, KC_##K38, KC_##K39, KC_##K3a, KC_##K3b, ___, ___, ___, ___} \
+}

--- a/keyboards/40percentclub/4x4/rules.mk
+++ b/keyboards/40percentclub/4x4/rules.mk
@@ -76,5 +76,4 @@ AUDIO_ENABLE = no           # Audio output on port C6
 FAUXCLICKY_ENABLE = no      # Use buzzer to emulate clicky switches
 HD44780_ENABLE = no 				# Enable support for HD44780 based LCDs (+400)
 
-#FIXME: Community keymap build are currently failing due to missing functionality
-#LAYOUTS = ortho_4x4  ortho_4x8  ortho_4x12  ortho_4x16
+LAYOUTS = ortho_4x4  ortho_4x8  ortho_4x12  ortho_4x16

--- a/keyboards/40percentclub/5x5/rules.mk
+++ b/keyboards/40percentclub/5x5/rules.mk
@@ -77,5 +77,4 @@ AUDIO_ENABLE = no           # Audio output on port C6
 FAUXCLICKY_ENABLE = no      # Use buzzer to emulate clicky switches
 HD44780_ENABLE = no 				# Enable support for HD44780 based LCDs (+400)
 
-#FIXME: Community keymap build are currently failing due to missing functionality
-#LAYOUTS = ortho_5x5  ortho_5x10  ortho_5x15
+LAYOUTS = ortho_5x5  ortho_5x10  ortho_5x15

--- a/layouts/community/ortho_4x12/bakingpy/rules.mk
+++ b/layouts/community/ortho_4x12/bakingpy/rules.mk
@@ -5,6 +5,8 @@ endif
 AUDIO_ENABLE = no
 ifeq ($(strip $(KEYBOARD)), zlant)
   BACKLIGHT_ENABLE = no
+else ifeq ($(strip $(KEYBOARD)), 40percentclub/4x4)
+	  BACKLIGHT_ENABLE = no
 else
   BACKLIGHT_ENABLE = yes
 endif

--- a/layouts/community/ortho_4x12/wanleg/rules.mk
+++ b/layouts/community/ortho_4x12/wanleg/rules.mk
@@ -5,7 +5,7 @@ ifeq ($(strip $(KEYBOARD)), jj40)
 	SWAP_HANDS_ENABLE = no
 endif
 
-ifeq ($(strip $(KEYBOARD)), 4x4)
+ifeq ($(strip $(KEYBOARD)), 40percentclub/4x4)
 	SWAP_HANDS_ENABLE = no
 endif
 

--- a/layouts/community/ortho_4x12/xyverz/rules.mk
+++ b/layouts/community/ortho_4x12/xyverz/rules.mk
@@ -3,6 +3,8 @@ AUDIO_ENABLE = no           # Audio output on port C6
 
 ifeq ("$(KEYBOARD)","vitamins_included")
   RGBLIGHT_ENABLE = no
+else ifeq ($(strip $(KEYBOARD)), 40percentclub/4x4)
+	  RGBLIGHT_ENABLE = no
 else
   RGBLIGHT_ENABLE = yes
 endif


### PR DESCRIPTION
During the moving of 40percentclub boards to a common folder (#4380),  community keymaps were disabled for 4x4 and 5x5 boards. @noroadsleft provided fixes, which never got committed.

The major difference to the original fixes are as follows:

- enable all previously disabled layout options
- fixes for guidoism keymap