### PR TITLE
Default JIS TKL keymap for Pegasus Hoof

### DIFF
--- a/keyboards/bpiphany/pegasushoof/keymaps/default_jis/keymap.c
+++ b/keyboards/bpiphany/pegasushoof/keymaps/default_jis/keymap.c
@@ -1,0 +1,60 @@
+/*
+Copyright 2016 Daniel Svensson <dsvensson@gmail.com>
+          2018 Charlie McMackin <charliemac@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include QMK_KEYBOARD_H
+
+#define _______ KC_TRNS
+
+#define KM_JIS  0
+#define KM_MEDIA 1
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] =
+  {
+   /* Layer 0: Standard JIS layer */
+   [KM_JIS] = LAYOUT_tkl_jis(KC_ESC,          KC_F1,  KC_F2,  KC_F3,  KC_F4,  KC_F5,  KC_F6,  KC_F7,  KC_F8,  KC_F9,  KC_F10, KC_F11, KC_F12,            KC_PSCR,KC_SLCK,KC_PAUS, \
+                             KC_GRV,  KC_1,   KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,   KC_0,   KC_MINS,KC_EQL, KC_JYEN, KC_BSPC,  KC_INS, KC_HOME,KC_PGUP, \
+                             KC_TAB,  KC_Q,   KC_W,   KC_E,   KC_R,   KC_T,   KC_Y,   KC_U,   KC_I,   KC_O,   KC_P,   KC_LBRC,KC_RBRC,                   KC_DEL, KC_END, KC_PGDN, \
+                             KC_CAPS, KC_A,   KC_S,   KC_D,   KC_F,   KC_G,   KC_H,   KC_J,   KC_K,   KC_L,   KC_SCLN,KC_QUOT,KC_BSLS,KC_ENT, \
+                             KC_LSFT, KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,   KC_N,   KC_M,   KC_COMM,KC_DOT, KC_SLSH,KC_RO,  KC_RSFT,                           KC_UP, \
+                             KC_LCTL, KC_LGUI,KC_LALT,KC_MHEN,        KC_SPC,                 KC_HENK,KC_KANA,KC_RALT,KC_FN0, KC_RCTL,                   KC_LEFT,KC_DOWN,KC_RGHT),
+   /* Layer 1: Function layer */
+   [KM_MEDIA] = LAYOUT_tkl_jis(_______,        _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,           KC_WAKE,KC_PWR, KC_SLEP, \
+                               _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,   _______,_______,KC_VOLU, \
+                               _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,                   _______,_______,KC_VOLD, \
+                               _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______, \
+                               _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,                           KC_MPLY, \
+                               _______,_______,_______,_______,        _______,                _______,_______,_______,_______,RESET  ,                   KC_MPRV,KC_MSTP,KC_MNXT)
+  };
+
+const uint16_t PROGMEM fn_actions[] = {
+  [0] = ACTION_LAYER_MOMENTARY(KM_MEDIA)
+};
+
+void led_set_user(uint8_t usb_led) {
+  if (usb_led & (1 << USB_LED_CAPS_LOCK)) {
+    ph_caps_led_on();
+  } else {
+    ph_caps_led_off();
+  }
+
+  if (usb_led & (1 << USB_LED_SCROLL_LOCK)) {
+    ph_sclk_led_on();
+  } else {
+    ph_sclk_led_off();
+  }
+}

--- a/keyboards/bpiphany/pegasushoof/keymaps/default_jis/keymap.c
+++ b/keyboards/bpiphany/pegasushoof/keymaps/default_jis/keymap.c
@@ -18,8 +18,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include QMK_KEYBOARD_H
 
-#define _______ KC_TRNS
-
 #define KM_JIS  0
 #define KM_MEDIA 1
 

--- a/keyboards/bpiphany/pegasushoof/keymaps/default_jis/keymap.c
+++ b/keyboards/bpiphany/pegasushoof/keymaps/default_jis/keymap.c
@@ -29,7 +29,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] =
                              KC_TAB,  KC_Q,   KC_W,   KC_E,   KC_R,   KC_T,   KC_Y,   KC_U,   KC_I,   KC_O,   KC_P,   KC_LBRC,KC_RBRC,                   KC_DEL, KC_END, KC_PGDN, \
                              KC_CAPS, KC_A,   KC_S,   KC_D,   KC_F,   KC_G,   KC_H,   KC_J,   KC_K,   KC_L,   KC_SCLN,KC_QUOT,KC_BSLS,KC_ENT, \
                              KC_LSFT, KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,   KC_N,   KC_M,   KC_COMM,KC_DOT, KC_SLSH,KC_RO,  KC_RSFT,                           KC_UP, \
-                             KC_LCTL, KC_LGUI,KC_LALT,KC_MHEN,        KC_SPC,                 KC_HENK,KC_KANA,KC_RALT,KC_FN0, KC_RCTL,                   KC_LEFT,KC_DOWN,KC_RGHT),
+                             KC_LCTL, KC_LGUI,KC_LALT,KC_MHEN,        KC_SPC,                 KC_HENK,KC_KANA,KC_RALT,MO(1),  KC_RCTL,                   KC_LEFT,KC_DOWN,KC_RGHT),
    /* Layer 1: Function layer */
    [KM_MEDIA] = LAYOUT_tkl_jis(_______,        _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,           KC_WAKE,KC_PWR, KC_SLEP, \
                                _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,   _______,_______,KC_VOLU, \
@@ -38,10 +38,6 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] =
                                _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,                           KC_MPLY, \
                                _______,_______,_______,_______,        _______,                _______,_______,_______,_______,RESET  ,                   KC_MPRV,KC_MSTP,KC_MNXT)
   };
-
-const uint16_t PROGMEM fn_actions[] = {
-  [0] = ACTION_LAYER_MOMENTARY(KM_MEDIA)
-};
 
 void led_set_user(uint8_t usb_led) {
   if (usb_led & (1 << USB_LED_CAPS_LOCK)) {

--- a/keyboards/bpiphany/pegasushoof/keymaps/default_jis/rules.mk
+++ b/keyboards/bpiphany/pegasushoof/keymaps/default_jis/rules.mk
@@ -1,0 +1,22 @@
+# Build Options
+#   change to "no" to disable the options, or define them in the Makefile in 
+#   the appropriate keymap folder that will get included automatically
+#
+BOOTMAGIC_ENABLE = yes      # Virtual DIP switch configuration(+1000)
+MOUSEKEY_ENABLE = yes       # Mouse keys(+4700)
+EXTRAKEY_ENABLE = yes       # Audio control and System control(+450)
+CONSOLE_ENABLE = yes        # Console for debug(+400)
+COMMAND_ENABLE = yes        # Commands for debug and configuration
+CUSTOM_MATRIX = yes         # Custom matrix file for the Pegasus Hoof due to the 2x74HC42
+NKRO_ENABLE = no            # Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
+MIDI_ENABLE = no            # MIDI controls
+AUDIO_ENABLE = no           # Audio output on port C6
+UNICODE_ENABLE = no         # Unicode
+BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
+RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight. 
+
+
+ifndef QUANTUM_DIR
+	include ../../../../Makefile
+endif

--- a/keyboards/bpiphany/pegasushoof/keymaps/default_jis/rules.mk
+++ b/keyboards/bpiphany/pegasushoof/keymaps/default_jis/rules.mk
@@ -1,5 +1,5 @@
 # Build Options
-#   change to "no" to disable the options, or define them in the Makefile in 
+#   change to "no" to disable the options, or define them in the Makefile in
 #   the appropriate keymap folder that will get included automatically
 #
 BOOTMAGIC_ENABLE = yes      # Virtual DIP switch configuration(+1000)
@@ -14,9 +14,4 @@ MIDI_ENABLE = no            # MIDI controls
 AUDIO_ENABLE = no           # Audio output on port C6
 UNICODE_ENABLE = no         # Unicode
 BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
-RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight. 
-
-
-ifndef QUANTUM_DIR
-	include ../../../../Makefile
-endif
+RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight.

--- a/keyboards/bpiphany/pegasushoof/pegasushoof.h
+++ b/keyboards/bpiphany/pegasushoof/pegasushoof.h
@@ -41,6 +41,24 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 		/* 7 */  { ___ , ___ , ___ , ___ , ___ , KF7 , KG7 , KH7 , KI7 , KJ7 , KK7 , KL7 , KM7 , KN7 , ___ , KP7 , ___ , ___ }, \
 	}
 
+#define LAYOUT_tkl_jis( \
+  KG6,      KH4, KI4, KI2, KI6, KP5, KL6, KM2, KM4, KO4, KO5, KO6, KO0,        KN5, KN7, KP7, \
+  KG4, KG5, KH5, KI5, KJ5, KJ4, KK4, KK5, KL5, KM5, KF5, KF4, KL4, KO7, KO2,   KR4, KC4, KE4, \
+  KG2, KG7, KH7, KI7, KJ7, KJ2, KK2, KK7, KL7, KM7, KF7, KF2, KL2,             KQ4, KC5, KE5, \
+  KH2, KG3, KH3, KI3, KJ3, KJ6, KK6, KK3, KL3, KM3, KF3, KF6, KO3, KO1,                       \
+  KB2, KG1, KH1, KI1, KJ1, KJ0, KK0, KK1, KL1, KM1, KF0, KL0,      KB3,             KC6,      \
+  KP4, KD2, KN6, KG0,           KQ6,           KH0, KI0, KN0, KM0, KP1,        KC0, KQ0, KR0  \
+  ) { /*        00-A  01-B  02-C  03-D  04-E  05-F  06-G  07-H  08-I  09-J  10-K  11-L  12-M  13-N  14-O  15-P  16-Q  17-R */ \
+     /* 0 */  { ___ , ___ , KC0 , ___ , ___ , KF0 , KG0 , KH0 , KI0 , KJ0 , KK0 , KL0 , KM0 , KN0 , KO0 , ___ , KQ0 , KR0 }, \
+     /* 1 */  { ___ , ___ , ___ , ___ , ___ , ___ , KG1 , KH1 , KI1 , KJ1 , KK1 , KL1 , KM1 , ___ , KO1 , KP1 , ___ , ___ }, \
+     /* 2 */  { ___ , KB2 , ___ , KD2 , ___ , KF2 , KG2 , KH2 , KI2 , KJ2 , KK2 , KL2 , KM2 , ___ , KO2 , ___ , ___ , ___ }, \
+     /* 3 */  { ___ , KB3 , ___ , ___ , ___ , KF3 , KG3 , KH3 , KI3 , KJ3 , KK3 , KL3 , KM3 , ___ , KO3 , ___ , ___ , ___ }, \
+     /* 4 */  { ___ , ___ , KC4 , ___ , KE4 , KF4 , KG4 , KH4 , KI4 , KJ4 , KK4 , KL4 , KM4 , ___ , KO4 , KP4 , KQ4 , KR4 }, \
+     /* 5 */  { ___ , ___ , KC5 , ___ , KE5 , KF5 , KG5 , KH5 , KI5 , KJ5 , KK5 , KL5 , KM5 , KN5 , KO5 , KP5 , ___ , ___ }, \
+     /* 6 */  { ___ , ___ , KC6 , ___ , ___ , KF6 , KG6 , ___ , KI6 , KJ6 , KK6 , KL6 , ___ , KN6 , KO6 , ___ , KQ6 , ___ }, \
+     /* 7 */  { ___ , ___ , ___ , ___ , ___ , KF7 , KG7 , KH7 , KI7 , KJ7 , KK7 , KL7 , KM7 , KN7 , KO7 , KP7 , ___ , ___ }, \
+}
+
 inline void ph_caps_led_on(void)  { DDRC |=  (1<<6); PORTC &= ~(1<<6); }
 inline void ph_caps_led_off(void) { DDRC &= ~(1<<6); PORTC &= ~(1<<6); }
 


### PR DESCRIPTION
* Create a new layout for the 91-key JIS version of Majestouch + Pegasus Hoof
* Add standard mapping based on the current default layout
   - in the default layout the `LGUI` was made `FN0`, this keyboard doesn't have `LGUI` so I chose to map the `MENU` key to `FN0`