### PR TITLE
Adaptive debounce logic

### DIFF
--- a/keyboards/ergodox_ez/config.h
+++ b/keyboards/ergodox_ez/config.h
@@ -85,17 +85,20 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define RGBW 1
 
-/* "debounce" is measured in keyboard scans. Some users reported
- * needing values as high as 15, which was at the time around 50ms.
+/*
+ * The debounce filtering reports a key/switch change directly,
+ * without any extra delay. After that the debounce logic will filter
+ * all further changes, until the key/switch reports the same state for
+ * the given count of scans.
+ * So a perfect switch will get a short debounce period and
+ * a bad key will get a much longer debounce period.
+ * The result is an adaptive debouncing period for each switch.
+ *
  * If you don't define it here, the matrix code will default to
  * 5, which is now closer to 10ms, but still plenty according to
  * manufacturer specs.
- *
- * Default is quite high, because of reports with some production
- * runs seeming to need it. This may change when configuration for
- * this is more directly exposed.
  */
-#define DEBOUNCE    15
+#define DEBOUNCE    10
 
 #define USB_MAX_POWER_CONSUMPTION 500
 

--- a/keyboards/ergodox_ez/matrix.c
+++ b/keyboards/ergodox_ez/matrix.c
@@ -57,6 +57,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* matrix state(1:on, 0:off) */
 static matrix_row_t matrix[MATRIX_ROWS];
+/*
+ * matrix state(1:on, 0:off)
+ * contains the raw values without debounce filtering of the last read cycle.
+ */
+static matrix_row_t raw_matrix[MATRIX_ROWS];
 
 // Debouncing: store for each key the number of scans until it's eligible to
 // change.  When scanning the matrix, ignore any changes in keys that have
@@ -118,6 +123,7 @@ void matrix_init(void)
     // initialize matrix state: all keys off
     for (uint8_t i=0; i < MATRIX_ROWS; i++) {
         matrix[i] = 0;
+        raw_matrix[i] = 0;
         for (uint8_t j=0; j < MATRIX_COLS; ++j) {
             debounce_matrix[i * MATRIX_COLS + j] = 0;
         }
@@ -151,26 +157,30 @@ void matrix_power_up(void) {
 
 // Returns a matrix_row_t whose bits are set if the corresponding key should be
 // eligible to change in this scan.
-matrix_row_t debounce_mask(uint8_t row) {
+matrix_row_t debounce_mask(matrix_row_t rawcols, uint8_t row) {
   matrix_row_t result = 0;
-  for (uint8_t j=0; j < MATRIX_COLS; ++j) {
-    if (debounce_matrix[row * MATRIX_COLS + j]) {
-      --debounce_matrix[row * MATRIX_COLS + j];
+  matrix_row_t change = rawcols ^ raw_matrix[row];
+  raw_matrix[row] = rawcols;
+  for (uint8_t i = 0; i < MATRIX_COLS; ++i) {
+    if (debounce_matrix[row * MATRIX_COLS + i]) {
+      --debounce_matrix[row * MATRIX_COLS + i];
     } else {
-      result |= (1 << j);
+      result |= (1 << i);
+    }
+    if (change & (1 << i)) {
+      debounce_matrix[row * MATRIX_COLS + i] = DEBOUNCE;
     }
   }
   return result;
 }
 
-// Report changed keys in the given row.  Resets the debounce countdowns
-// corresponding to each set bit in 'change' to DEBOUNCE.
-void debounce_report(matrix_row_t change, uint8_t row) {
-  for (uint8_t i = 0; i < MATRIX_COLS; ++i) {
-    if (change & (1 << i)) {
-      debounce_matrix[row * MATRIX_COLS + i] = DEBOUNCE;
-    }
-  }
+matrix_row_t debounce_read_cols(uint8_t row) {
+  // Read the row without debouncing filtering and store it for later usage.
+  matrix_row_t cols = read_cols(row);
+  // Get the Debounce mask.
+  matrix_row_t mask = debounce_mask(cols, row);
+  // debounce the row and return the result.
+  return (cols & mask) | (matrix[row] & ~mask);;
 }
 
 uint8_t matrix_scan(void)
@@ -214,15 +224,12 @@ uint8_t matrix_scan(void)
         select_row(i + MATRIX_ROWS_PER_SIDE);
         // we don't need a 30us delay anymore, because selecting a
         // left-hand row requires more than 30us for i2c.
-        matrix_row_t mask = debounce_mask(i);
-        matrix_row_t cols = (read_cols(i) & mask) | (matrix[i] & ~mask);
-        debounce_report(cols ^ matrix[i], i);
-        matrix[i] = cols;
+
+        // grab cols from left hand
+        matrix[i] = debounce_read_cols(i);
         // grab cols from right hand
-        mask = debounce_mask(i + MATRIX_ROWS_PER_SIDE);
-        cols = (read_cols(i + MATRIX_ROWS_PER_SIDE) & mask) | (matrix[i + MATRIX_ROWS_PER_SIDE] & ~mask);
-        debounce_report(cols ^ matrix[i + MATRIX_ROWS_PER_SIDE], i + MATRIX_ROWS_PER_SIDE);
-        matrix[i + MATRIX_ROWS_PER_SIDE] = cols;
+        matrix[i + MATRIX_ROWS_PER_SIDE] = debounce_read_cols(i + MATRIX_ROWS_PER_SIDE);
+
         unselect_rows();
     }
 


### PR DESCRIPTION
### About
I extended the current debounce logic with an adaptive by switch debouncing. This way a bad switch gets a higher debouncing as a good switch.

### How it works
The debounce filtering reports a key/switch change directly as before, without any extra delay. The new thing is that the debounce logic will filter all further changes, until the key/switch reports the same state for the given count of scans. As long as the switch toggles the internal debounce counter of the switch will set to DEBOUNCE from config.h. The counter is decreased every scan where the switch didn't changed it's state.
So a perfect switch will get a short debounce period (min. DEBOUNCE) and a bad key will get a much longer debounce period. The result is an adaptive debouncing period for each switch.
In other words this gives an adaptive debouncing period for each switch / keypress.

### Background
I've got an ergodox with kailh cooper switches. I love this switches but the operation point and the reset point are very close together, directly on the pressure point. So a slightly wobbling of the key creates a double key press, when you type slowly without bottoming out. With the old debouncing (before  #1279) this wasn't a problem. But since then, some of my keys needed a debouncing value of 35. With this patch I could reduce DEBOUNCE scan count to 10 without any problems, even super fast double key presses are correctly detected with out bouncing. Slow-mo typing without bottoming out, which means I hold the key directly between operation and reset point, is no longer a problem. So with this patch the ergodox-ez should be faster (DEBOUNCE is now 10) and more robust against bouncing.

@ezuk Do you see any problems with this? I think this should reduce the bounce problem of the mentioned ergodox-ez batches in the comment.