### PR TITLE
Fix Ergodox EZ Matrix scan

### DIFF
--- a/keyboards/ergodox_ez/matrix.c
+++ b/keyboards/ergodox_ez/matrix.c
@@ -379,7 +379,7 @@ static void select_row(uint8_t row)
                 break;
             case 11:
                 DDRD  |= (1<<2);
-                PORTD &= ~(1<<3);
+                PORTD &= ~(1<<2);
                 break;
             case 12:
                 DDRD  |= (1<<3);
@@ -392,4 +392,3 @@ static void select_row(uint8_t row)
         }
     }
 }
-


### PR DESCRIPTION
Specifically, row 11 was wrong.

Thanks algernon, for catching that. 