### PR TITLE
ergodox_ez: Fix the PORTD bit set when row == 11

### DIFF
--- a/keyboards/ergodox_ez/matrix.c
+++ b/keyboards/ergodox_ez/matrix.c
@@ -379,7 +379,7 @@ static void select_row(uint8_t row)
                 break;
             case 11:
                 DDRD  |= (1<<2);
-                PORTD &= ~(1<<3);
+                PORTD &= ~(1<<2);
                 break;
             case 12:
                 DDRD  |= (1<<3);
@@ -392,4 +392,3 @@ static void select_row(uint8_t row)
         }
     }
 }
-


### PR DESCRIPTION
In the `select_row` implementation of the ErgoDox EZ, when row == 11, the code was changing the 3rd bit of PORTD instead of the 2nd (DDRD was done correctly).

For some odd reason, the keyboard works either way, but it's better to be doing things correctly and not relying on chance.
