### PR TITLE
fixed misplaced parenthesis in arm usb mouse send function

### DIFF
--- a/tmk_core/protocol/chibios/usb_main.c
+++ b/tmk_core/protocol/chibios/usb_main.c
@@ -704,7 +704,7 @@ void send_mouse(report_mouse_t *report) {
      * every iteration - otherwise the system will remain locked,
      * no interrupts served, so USB not going through as well.
      * Note: for suspend, need USB_USE_WAIT == TRUE in halconf.h */
-    if (osalThreadSuspendTimeoutS(&(&USB_DRIVER)->epc[MOUSE_IN_EPNUM]->in_state->thread, MS2ST(10)==MSG_TIMEOUT)) {
+    if (osalThreadSuspendTimeoutS(&(&USB_DRIVER)->epc[MOUSE_IN_EPNUM]->in_state->thread, MS2ST(10))==MSG_TIMEOUT) {
       osalSysUnlock();
       return;
     }


### PR DESCRIPTION
bug was causing lots of dropped events for me.