### PR TITLE
Adding keymap layers for 40precentclub/foobar

### DIFF
--- a/keyboards/40percentclub/foobar/keymaps/default/config.h
+++ b/keyboards/40percentclub/foobar/keymaps/default/config.h
@@ -17,3 +17,5 @@
 #pragma once
 
 // place overrides here
+
+#define PERMISSIVE_HOLD

--- a/keyboards/40percentclub/foobar/keymaps/default/keymap.c
+++ b/keyboards/40percentclub/foobar/keymaps/default/keymap.c
@@ -15,19 +15,62 @@
  */
 #include QMK_KEYBOARD_H
 
-#define FN1_Q LT(1, KC_Q)
+enum foobar_layers {
+  QWERTY,
+  FN1,
+  FN2,
+  FN3,
+  FN4,
+  FN5
+};
+
+#define FN1_SPC  LT(FN1, KC_SPC)
+#define FN2_BSC  LT(FN2, KC_BSPC)
+#define FN3_C    LT(FN3, KC_C)
+#define FN4_V    LT(FN4, KC_V)
+#define FN5_B    LT(FN5, KC_B)
+#define RALT_N   RALT_T(KC_N)
+#define LALT_X   LALT_T(KC_X)
+#define LCTL_Z   LCTL_T(KC_Z)
+#define RCTL_M   RCTL_T(KC_M)
+#define LSFT_ENT LSFT_T(KC_ENT)
+#define RGUI_ESC RGUI_T(KC_ESC)
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-  [0] = LAYOUT_split(
-    FN1_Q,   KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,
-    KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_ESC,
-    KC_Z,    KC_X,    KC_C,    KC_V,    KC_BSPC, KC_SPC,  KC_B,    KC_N,    KC_M,    KC_ENT
+  [QWERTY] = LAYOUT_split(
+    KC_Q,   KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,
+    KC_A,   KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    RGUI_ESC,
+    LCTL_Z, LALT_X,  FN3_C,   FN4_V,   FN2_BSC, FN1_SPC, FN5_B,   RALT_N,  RCTL_M,  LSFT_ENT
   ),
 
-  [1] = LAYOUT_split(
+  [FN1] = LAYOUT_split(
+    KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,
+    KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,
+    _______, _______, _______, _______, KC_DEL,  _______, _______, _______, _______, _______
+  ),
+
+  [FN2] = LAYOUT_split(
+    KC_EXLM, KC_AT,   KC_HASH, KC_DLR,  KC_PERC, KC_CIRC, KC_AMPR, KC_ASTR, KC_LPRN, KC_RPRN,
+    KC_F11,  KC_F12,  _______, _______, _______, _______, _______, _______, _______, KC_GRV,
+    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______
+  ),
+
+  [FN3] = LAYOUT_split(
+    _______, _______, _______, _______, _______, KC_MINS, KC_EQL,  KC_LBRC, KC_RBRC, KC_BSLS,
+    KC_TAB,  _______, _______, _______, _______, KC_COMM, KC_DOT,  KC_SLSH, KC_SCLN, KC_QUOT,
+    _______, _______, _______, _______, _______, _______, KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT
+  ),
+
+  [FN4] = LAYOUT_split(
+    _______, _______, _______, _______, _______, KC_UNDS, KC_PLUS, KC_LCBR, KC_RCBR, KC_PIPE,
+    KC_TAB,  _______, _______, _______, _______, KC_LABK, KC_RABK, KC_QUES, KC_COLN, KC_DQUO,
+    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______
+  ),
+
+  [FN5] = LAYOUT_split(
     _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
     _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
-    _______, _______, _______, _______, _______, _______, RESET,   _______, _______, _______
+    _______, _______, _______, _______, _______, RESET,   _______, _______, _______, _______
   ),
 };
 


### PR DESCRIPTION
Hi,

I'm submitting a flushed out keymap for the 40percentclub/foobar keyboard. This is basically the default Gherkin layout but it has a mod tap RGUI for the ESC key. I also omitted most of what comprises the FN5 layer (page up/ page down) since IMHO these are easy to accidentally type and can be a somewhat jarring experience when that happens. Completely open to adding those for completeness though.

@zvecr 