### PR TITLE
Keymap FAQ: fix positions of KC_HENK and KC_MHEN for JIS layout

### DIFF
--- a/docs/faq_keymap.md
+++ b/docs/faq_keymap.md
@@ -11,8 +11,8 @@ Keycodes are actually defined in [common/keycode.h](https://github.com/qmk/qmk_f
 
 There are 3 standard keyboard layouts in use around the world- ANSI, ISO, and JIS. North America primarily uses ANSI, Europe and Africa primarily use ISO, and Japan uses JIS. Regions not mentioned typically use either ANSI or ISO. The keycodes corresponding to these layouts are shown here:
 
-<!-- Source for this image: http://www.keyboard-layout-editor.com/#/gists/070a530eedaed36a2d77f3f6fd455677 -->
-![Keyboard Layout Image](https://i.imgur.com/gvlNUpQ.png)
+<!-- Source for this image: http://www.keyboard-layout-editor.com/#/gists/bf431647d1001cff5eff20ae55621e9a -->
+![Keyboard Layout Image](https://i.imgur.com/5wsh5wM.png)
 
 ## Some Of My Keys Are Swapped Or Not Working
 


### PR DESCRIPTION
These keys were previously in each other's positions.

According to the OADG 109A spec for JIS-layout keyboards, `KC_MHEN` is to the left of the spacebar, and `KC_HENK` to the right.