### PR TITLE
Keyboard: add generic ortho 5x15 layout support to Idobo

### DIFF
--- a/keyboards/idobo/rules.mk
+++ b/keyboards/idobo/rules.mk
@@ -79,3 +79,5 @@ BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
 AUDIO_ENABLE = no           # Audio output on port C6
 FAUXCLICKY_ENABLE = no      # Use buzzer to emulate clicky switches
 HD44780_ENABLE = no 		# Enable support for HD44780 based LCDs (+400)
+
+LAYOUTS = ortho_5x15


### PR DESCRIPTION
This allows users of the Idobo board to use generic 5x15 layouts as well as custom Idobo layouts