### PR TITLE
Fixes for failures during 'make lets_split'

### DIFF
--- a/keyboards/40percentclub/4x4/rules.mk
+++ b/keyboards/40percentclub/4x4/rules.mk
@@ -77,3 +77,4 @@ FAUXCLICKY_ENABLE = no      # Use buzzer to emulate clicky switches
 HD44780_ENABLE = no 				# Enable support for HD44780 based LCDs (+400)
 
 LAYOUTS = ortho_4x4  ortho_4x8  ortho_4x12  ortho_4x16
+LAYOUTS_HAS_BACKLIGHT = no

--- a/keyboards/lets_split/keymaps/OLED_sample/keymap.c
+++ b/keyboards/lets_split/keymaps/OLED_sample/keymap.c
@@ -369,7 +369,6 @@ void matrix_update(struct CharacterMatrix *dest,
 #define L_NUMLAY 128
 #define L_NLOWER 136
 #define L_NFNLAYER 192
-#define L_MOUSECURSOR 256
 #define L_ADJUST 65560
 
 void iota_gfx_task_user(void) {

--- a/keyboards/lets_split/keymaps/OLED_sample/rules.mk
+++ b/keyboards/lets_split/keymaps/OLED_sample/rules.mk
@@ -4,7 +4,7 @@
 #   the appropriate keymap folder that will get included automatically
 #
 BOOTMAGIC_ENABLE = no       # Virtual DIP switch configuration(+1000)
-MOUSEKEY_ENABLE = yes       # Mouse keys(+4700)
+MOUSEKEY_ENABLE = no        # Mouse keys(+4700)
 EXTRAKEY_ENABLE = yes       # Audio control and System control(+450)
 CONSOLE_ENABLE = no         # Console for debug(+400)
 COMMAND_ENABLE = no        # Commands for debug and configuration

--- a/keyboards/lets_split/keymaps/adam/rules.mk
+++ b/keyboards/lets_split/keymaps/adam/rules.mk
@@ -1,0 +1,1 @@
+TAP_DANCE_ENABLE = yes

--- a/keyboards/lets_split/keymaps/pyrol/keymap.c
+++ b/keyboards/lets_split/keymaps/pyrol/keymap.c
@@ -1,6 +1,4 @@
-#include QMK_KEYBOARD_h
-
-extern keymap_config_t keymap_config;
+#include QMK_KEYBOARD_H
 
 // Each layer gets a name for readability, which is then used in the keymap matrix below.
 // The underscores don't mean anything - you can have a layer called STUFF or any other name.

--- a/keyboards/lets_split/rules.mk
+++ b/keyboards/lets_split/rules.mk
@@ -42,7 +42,7 @@ F_USB = $(F_CPU)
 
 # Bootloader
 #     This definition is optional, and if your keyboard supports multiple bootloaders of
-#     different sizes, comment this out, and the correct address will be loaded 
+#     different sizes, comment this out, and the correct address will be loaded
 #     automatically (+60). See bootloader.mk for all options.
 BOOTLOADER = caterina
 
@@ -64,7 +64,7 @@ MIDI_ENABLE = no            # MIDI controls
 AUDIO_ENABLE = no           # Audio output on port C6
 UNICODE_ENABLE = no         # Unicode
 BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
-RGBLIGHT_ENABLE = no       # Enable WS2812 RGB underlight. 
+RGBLIGHT_ENABLE = no       # Enable WS2812 RGB underlight.
 SUBPROJECT_rev1 = yes
 USE_I2C = yes
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
@@ -73,5 +73,6 @@ SLEEP_LED_ENABLE = no    # Breathing sleep LED during USB suspend
 CUSTOM_MATRIX = yes
 
 LAYOUTS = ortho_4x12
+LAYOUTS_HAS_BACKLIGHT = no
 
 DEFAULT_FOLDER = lets_split/rev2

--- a/keyboards/zlant/rules.mk
+++ b/keyboards/zlant/rules.mk
@@ -56,3 +56,4 @@ AUDIO_ENABLE = no
 RGBLIGHT_ENABLE = yes
 
 LAYOUTS = ortho_4x12 planck_mit
+LAYOUTS_HAS_BACKLIGHT = no

--- a/layouts/community/ortho_4x12/bakingpy/rules.mk
+++ b/layouts/community/ortho_4x12/bakingpy/rules.mk
@@ -3,10 +3,8 @@ ifeq ($(LAYOUTS_HAS_RGB),yes)
 	RGBLIGHT_ENABLE = yes
 endif
 AUDIO_ENABLE = no
-ifeq ($(strip $(KEYBOARD)), zlant)
+ifeq ($(LAYOUTS_HAS_BACKLIGHT),no)
   BACKLIGHT_ENABLE = no
-else ifeq ($(strip $(KEYBOARD)), 40percentclub/4x4)
-	  BACKLIGHT_ENABLE = no
 else
   BACKLIGHT_ENABLE = yes
 endif

--- a/users/talljoe/talljoe.c
+++ b/users/talljoe/talljoe.c
@@ -108,7 +108,9 @@ bool process_record_keymap(uint16_t keycode, keyrecord_t *record) {
 extern backlight_config g_config;
 #endif
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+#ifdef ZEAL_RGB
   static uint8_t last_effect;
+#endif
 
 #ifdef RGBLIGHT_ENABLE
   static uint32_t savedRgbMode;


### PR DESCRIPTION
Before i make any changes to the lets_split board, i wanted to make sure the whole folder was building. The failures are as follows

- OLED_sample
  -   firmware too large - disabled mouse support to trim size as it was not used
- pyrol
  -   bad case on the `#include`
- bakingpy
  - Instead of adding a lets_split case to a wall of `else ifeq` I've refactored in the style of LAYOUTS_HAS_RGB
- talljoe
  - ~~the community layout talljoe, is still failing as mentioned in #4487.~~
  - #4487 was merged so ive added the required conditional build fixes