### PR TITLE
handwired/arrow_pad Refactor and Configurator support

### DIFF
--- a/keyboards/handwired/arrow_pad/arrow_pad.h
+++ b/keyboards/handwired/arrow_pad/arrow_pad.h
@@ -10,4 +10,34 @@
 #include <avr/io.h>
 #include <stddef.h>
 
+// This is the 21-key keypad to 4x6 element matrix mapping
+#define LAYOUT( \
+    KM_ESC, KM_TAB, KM_BSL, KM_ARR, \
+    KM_NUM, KM_FSL, KM_AST, KM_MIN, \
+    KM___7, KM___8, KM___9, KM_EQU, \
+    KM___4, KM___5, KM___6, KM_PLS, \
+    KM___1, KM___2, KM___3, ___ENT, \
+    KM___0, _____0, KM_DOT, KM_ENT  \
+) { \
+    { KM_ESC, KM_TAB, KM_BSL, KM_ARR  }, \
+    { KM_NUM, KM_FSL, KM_AST, KM_MIN  }, \
+    { KM___7, KM___8, KM___9, KM_EQU  }, \
+    { KM___4, KM___5, KM___6, KM_PLS  }, \
+    { KM___1, KM___2, KM___3, KC_NO   }, \
+    { KM___0, KC_NO,  KM_DOT, KM_ENT  }  \
+}
+
+// This is the 21-key keypad to 2x11 element matrix mapping
+#define LAYOUT_pad21( \
+    KM_ESC, KM_TAB, KM_BSL, KM_ARR, \
+    KM_NUM, KM_FSL, KM_AST, KM_MIN, \
+    KM___7, KM___8, KM___9,         \
+    KM___4, KM___5, KM___6, KM_PLS, \
+    KM___1, KM___2, KM___3,         \
+    KM___0,         KM_DOT, KM_ENT  \
+) { \
+    { KM_ESC, KM_TAB, KM_BSL, KM_ARR, KM___7, KM___8, KM___9, KM_PLS, KM___1, KM___2, KM___3, }, \
+    { KM_NUM, KM_FSL, KM_AST, KM_MIN, KM___4, KM___5, KM___6, KM_ENT, KC_NO,  KM___0, KM_DOT, }, \
+}
+
 #endif

--- a/keyboards/handwired/arrow_pad/info.json
+++ b/keyboards/handwired/arrow_pad/info.json
@@ -1,0 +1,62 @@
+{
+  "keyboard_name": "arrow_pad",
+  "url": "",
+  "maintainer": "qmk",
+  "width": 4,
+  "height": 6,
+  "layouts": {
+    "LAYOUT": {
+      "layout": [
+        {"label":"KM_ESC", "x":0, "y":0},
+        {"label":"KM_TAB", "x":1, "y":0},
+        {"label":"KM_BSL", "x":2, "y":0},
+        {"label":"KM_ARR", "x":3, "y":0},
+        {"label":"KM_NUM", "x":0, "y":1},
+        {"label":"KM_FSL", "x":1, "y":1},
+        {"label":"KM_AST", "x":2, "y":1},
+        {"label":"KM_MIN", "x":3, "y":1},
+        {"label":"KM___7", "x":0, "y":2},
+        {"label":"KM___8", "x":1, "y":2},
+        {"label":"KM___9", "x":2, "y":2},
+        {"label":"KM_EQU", "x":3, "y":2},
+        {"label":"KM___4", "x":0, "y":3},
+        {"label":"KM___5", "x":1, "y":3},
+        {"label":"KM___6", "x":2, "y":3},
+        {"label":"KM_PLS", "x":3, "y":3},
+        {"label":"KM___1", "x":0, "y":4},
+        {"label":"KM___2", "x":1, "y":4},
+        {"label":"KM___3", "x":2, "y":4},
+        {"label":"___ENT", "x":3, "y":4},
+        {"label":"KM___0", "x":0, "y":5},
+        {"label":"_____0", "x":1, "y":5},
+        {"label":"KM_DOT", "x":2, "y":5},
+        {"label":"KM_ENT", "x":3, "y":5}
+      ]
+    },
+    "LAYOUT_pad21": {
+      "layout": [
+        {"label":"KM_ESC", "x":0, "y":0},
+        {"label":"KM_TAB", "x":1, "y":0},
+        {"label":"KM_BSL", "x":2, "y":0},
+        {"label":"KM_ARR", "x":3, "y":0},
+        {"label":"KM_NUM", "x":0, "y":1},
+        {"label":"KM_FSL", "x":1, "y":1},
+        {"label":"KM_AST", "x":2, "y":1},
+        {"label":"KM_MIN", "x":3, "y":1},
+        {"label":"KM___7", "x":0, "y":2},
+        {"label":"KM___8", "x":1, "y":2},
+        {"label":"KM___9", "x":2, "y":2},
+        {"label":"KM___4", "x":0, "y":3},
+        {"label":"KM___5", "x":1, "y":3},
+        {"label":"KM___6", "x":2, "y":3},
+        {"label":"KM_PLS", "x":3, "y":2, "h":2},
+        {"label":"KM___1", "x":0, "y":4},
+        {"label":"KM___2", "x":1, "y":4},
+        {"label":"KM___3", "x":2, "y":4},
+        {"label":"KM___0", "x":0, "y":5, "w":2},
+        {"label":"KM_DOT", "x":2, "y":5},
+        {"label":"KM_ENT", "x":3, "y":4, "h":2}
+      ]
+    }
+  }
+}

--- a/keyboards/handwired/arrow_pad/keymaps/default/keymap.c
+++ b/keyboards/handwired/arrow_pad/keymaps/default/keymap.c
@@ -1,35 +1,18 @@
 
-#include "arrow_pad.h"
+#include QMK_KEYBOARD_H
 #include "led.h"
 
-// This is the 21-key keypad to 2x11 element matrix mapping
-#define LAYOUT( \
-    KM_ESC, KM_TAB, KM_BSL, KM_ARR, \
-    KM_NUM, KM_FSL, KM_AST, KM_MIN, \
-    KM___7, KM___8, KM___9, KM_EQU, \
-    KM___4, KM___5, KM___6, KM_PLS, \
-    KM___1, KM___2, KM___3, ___ENT, \
-    KM___0, _____0, KM_DOT, KM_ENT  \
-) { \
-    { KM_ESC, KM_TAB, KM_BSL, KM_ARR  }, \
-    { KM_NUM, KM_FSL, KM_AST, KM_MIN  }, \
-    { KM___7, KM___8, KM___9, KM_EQU  }, \
-    { KM___4, KM___5, KM___6, KM_PLS  }, \
-    { KM___1, KM___2, KM___3, KC_NO   }, \
-    { KM___0, KC_NO,  KM_DOT, KM_ENT  }  \
-}
+enum layers {
+  LAYER_BASE,
+  LAYER_EDIT,
+  LAYER_FUNCTION
+};
 
-#define LAYER_BASE                      0
-#define LAYER_EDIT                      1
-#define LAYER_FUNCTION                  2
-
-#define MACRO_COPY_CUT                  0
-#define MACRO_SHIFT_CONTROL             1
-#define MACRO_CONTROL_ALT               2
-
-#define M_COPY              KC_FN5
-#define M_SHFCT             KC_FN6
-#define M_CTALT             KC_FN7
+enum custom_keycodes {
+  M_COPY = SAFE_RANGE,  // KC_FN5: MACRO_COPY_CUT
+  M_SHFCT,              // KC_FN6: MACRO_SHIFT_CONTROL
+  M_CTALT               // KC_FN7: MACRO_CONTROL_ALT
+};
 
 #define SC_UNDO             LCTL(KC_Z)
 #define SC_REDO             LCTL(KC_Y)
@@ -42,13 +25,10 @@
 #define SC_ACLS             LALT(KC_F4)
 #define SC_CCLS             LCTL(KC_F4)
 
-#define _______             KC_TRNS
-#define XXXXXXX             KC_NO
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 [LAYER_BASE] = LAYOUT(                \
-  KC_ESC,  KC_TAB,  KC_BSLS, KC_FN0,  \
+  KC_ESC,  KC_TAB,  KC_BSLS, MO(2),   \
   KC_NLCK, KC_PSLS, KC_PAST, KC_PMNS, \
   KC_P7,   KC_P8,   KC_P9,   KC_PEQL, \
   KC_P4,   KC_P5,   KC_P6,   KC_PPLS, \
@@ -57,15 +37,15 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 [LAYER_EDIT] = LAYOUT(                \
   KC_ESC,  KC_TAB,  KC_SPC,  _______, \
-  KC_FN1,  SC_PSTE, SC_REDO, SC_UNDO, \
+  TG(1),   SC_PSTE, SC_REDO, SC_UNDO, \
   KC_HOME, KC_UP,   KC_PGUP, KC_LALT, \
   KC_LEFT, M_COPY,  KC_RGHT, KC_LCTL, \
   KC_END,  KC_DOWN, KC_PGDN, XXXXXXX, \
-  KC_BSPC, KC_PENT, KC_DEL,  M_SHFCT),
+  KC_BSPC, KC_PENT, KC_DEL,  M_SHFCT  ),
 
 [LAYER_FUNCTION] = LAYOUT(            \
-  KC_FN2,  KC_FN3,  KC_FN4,  _______, \
-  KC_FN1,  _______, _______, _______, \
+  BL_TOGG, BL_INC,  BL_DEC,  _______, \
+  TG(1),   _______, _______, _______, \
   _______, _______, _______, _______, \
   _______, _______, _______, _______, \
   _______, _______, _______, XXXXXXX, \
@@ -74,68 +54,46 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 };
 
 
-const uint16_t PROGMEM fn_actions[] = {
-	[0] = ACTION_LAYER_MOMENTARY(LAYER_FUNCTION),
-	[1] = ACTION_LAYER_TOGGLE(LAYER_EDIT),
-	[2] = ACTION_BACKLIGHT_TOGGLE(),
-	[3] = ACTION_BACKLIGHT_INCREASE(),
-	[4] = ACTION_BACKLIGHT_DECREASE(),
-	[5] = ACTION_MACRO_TAP(MACRO_COPY_CUT),
-    [6] = ACTION_MACRO_TAP(MACRO_SHIFT_CONTROL),
-    [7] = ACTION_MACRO_TAP(MACRO_CONTROL_ALT),
-
-};
-
-
-void action_function(keyrecord_t *record, uint8_t id, uint8_t opt)
-{
-}
-
-
-const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
-{
+bool process_record_user(uint16_t keycode, keyrecord_t * record) {
   // MACRODOWN only works in this function
-    switch (id) {
+  switch (keycode) {
 
-    case MACRO_COPY_CUT:
-        if (record->event.pressed) {
-            register_code(KC_LCTL);
-            if (record->tap.count == 1) {
-                register_code(KC_C);
-                unregister_code(KC_C);
-            }
-            else if (record->tap.count == 2) {
-                register_code(KC_X);
-                unregister_code(KC_X);
-            }
-            unregister_code(KC_LCTL);
-        }
-        break;
-
-    case MACRO_SHIFT_CONTROL:
-        if (record->event.pressed) {
-            if (record->tap.count <= 2) register_mods(MOD_BIT(KC_LSFT));
-            if (record->tap.count == 2) register_mods(MOD_BIT(KC_LCTL));
-            if (record->tap.count == 3) register_code(KC_PENT);;
-        }
-        else {
-            unregister_mods(MOD_BIT(KC_LSFT) | MOD_BIT(KC_LCTL));
-            unregister_code(KC_PENT);
-        }
-        break;
-
-    case MACRO_CONTROL_ALT:
-        if (record->event.pressed) {
-            if (record->tap.count < 2)  register_mods(MOD_BIT(KC_LCTL));
-            if (record->tap.count >= 2) register_mods(MOD_BIT(KC_LALT));
-        }
-        else {
-            unregister_mods(MOD_BIT(KC_LCTL) | MOD_BIT(KC_LALT));
-        }
-        break;
+  case M_COPY:
+    if (record->event.pressed) {
+      register_code(KC_LCTL);
+      if (record->tap.count == 1) {
+        register_code(KC_C);
+        unregister_code(KC_C);
+      } else if (record->tap.count == 2) {
+        register_code(KC_X);
+        unregister_code(KC_X);
+      }
+      unregister_code(KC_LCTL);
     }
+    break;
 
-    return MACRO_NONE;
+  case M_SHFCT:
+    if (record->event.pressed) {
+      if (record->tap.count <= 2) register_mods(MOD_BIT(KC_LSFT));
+      if (record->tap.count == 2) register_mods(MOD_BIT(KC_LCTL));
+      if (record->tap.count == 3) register_code(KC_PENT);;
+    } else {
+      unregister_mods(MOD_BIT(KC_LSFT) | MOD_BIT(KC_LCTL));
+      unregister_code(KC_PENT);
+    }
+    break;
+
+  case M_CTALT:
+    if (record->event.pressed) {
+      if (record->tap.count < 2) register_mods(MOD_BIT(KC_LCTL));
+      if (record->tap.count >= 2) register_mods(MOD_BIT(KC_LALT));
+    } else {
+      unregister_mods(MOD_BIT(KC_LCTL) | MOD_BIT(KC_LALT));
+    }
+    break;
+  }
+
+  return true;
 }
 
 void led_set_user(uint8_t usb_led)

--- a/keyboards/handwired/arrow_pad/keymaps/pad_21/keymap.c
+++ b/keyboards/handwired/arrow_pad/keymaps/pad_21/keymap.c
@@ -1,32 +1,18 @@
 
-#include "arrow_pad.h"
+#include QMK_KEYBOARD_H
 #include "led.h"
 
-// This is the 21-key keypad to 2x11 element matrix mapping
-#define LAYOUT( \
-    KM_ESC, KM_TAB, KM_BSL, KM_ARR, \
-    KM_NUM, KM_FSL, KM_AST, KM_MIN, \
-    KM___7, KM___8, KM___9, ___PLS, \
-    KM___4, KM___5, KM___6, KM_PLS, \
-    KM___1, KM___2, KM___3, ___ENT, \
-    KM___0, _____0, KM_DOT, KM_ENT  \
-) { \
-    { KM_ESC, KM_TAB, KM_BSL, KM_ARR, KM___7, KM___8, KM___9, KM_PLS, KM___1, KM___2, KM___3, }, \
-    { KM_NUM, KM_FSL, KM_AST, KM_MIN, KM___4, KM___5, KM___6, KM_ENT, KC_NO,  KM___0, KM_DOT, }, \
-}
+enum layers {
+  LAYER_BASE,
+  LAYER_EDIT,
+  LAYER_FUNCTION
+};
 
-
-#define LAYER_BASE                      0
-#define LAYER_EDIT                      1
-#define LAYER_FUNCTION                  2
-
-#define MACRO_COPY_CUT                  0
-#define MACRO_SHIFT_CONTROL             1
-#define MACRO_CONTROL_ALT               2
-
-#define M_COPY              KC_FN5
-#define M_SHFCT             KC_FN6
-#define M_CTALT             KC_FN7
+enum custom_keycodes {
+  M_COPY = SAFE_RANGE,  // KC_FN5: MACRO_COPY_CUT
+  M_SHFCT,              // KC_FN6: MACRO_SHIFT_CONTROL
+  M_CTALT               // KC_FN7: MACRO_CONTROL_ALT
+};
 
 #define SC_UNDO             LCTL(KC_Z)
 #define SC_REDO             LCTL(KC_Y)
@@ -39,100 +25,75 @@
 #define SC_ACLS             LALT(KC_F4)
 #define SC_CCLS             LCTL(KC_F4)
 
-#define _______             KC_TRNS
-#define XXXXXXX             KC_NO
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
-[LAYER_BASE] = LAYOUT(                \
-  KC_ESC,  KC_TAB,  KC_BSLS, KC_FN0,  \
+[LAYER_BASE] = LAYOUT_pad21(          \
+  KC_ESC,  KC_TAB,  KC_BSLS, MO(2),   \
   KC_NLCK, KC_PSLS, KC_PAST, KC_PMNS, \
-  KC_P7,   KC_P8,   KC_P9,   XXXXXXX, \
+  KC_P7,   KC_P8,   KC_P9,            \
   KC_P4,   KC_P5,   KC_P6,   KC_PPLS, \
-  KC_P1,   KC_P2,   KC_P3,   XXXXXXX, \
-  KC_P0,   XXXXXXX, KC_PDOT, KC_PENT  ),
+  KC_P1,   KC_P2,   KC_P3,            \
+  KC_P0,            KC_PDOT, KC_PENT  ),
 
-[LAYER_EDIT] = LAYOUT(                \
+[LAYER_EDIT] = LAYOUT_pad21(          \
   KC_ESC,  KC_TAB,  KC_SPC,  _______, \
-  KC_FN1,  SC_PSTE, SC_REDO, SC_UNDO, \
-  KC_HOME, KC_UP,   KC_PGUP, XXXXXXX, \
+  TG(1),   SC_PSTE, SC_REDO, SC_UNDO, \
+  KC_HOME, KC_UP,   KC_PGUP,          \
   KC_LEFT, M_COPY,  KC_RGHT, M_CTALT, \
-  KC_END,  KC_DOWN, KC_PGDN, XXXXXXX, \
-  KC_BSPC, XXXXXXX, KC_DEL,  M_SHFCT),
+  KC_END,  KC_DOWN, KC_PGDN,          \
+  KC_BSPC,          KC_DEL,  M_SHFCT),
 
-[LAYER_FUNCTION] = LAYOUT(            \
-  KC_FN2,  KC_FN3,  KC_FN4,  _______, \
-  KC_FN1,  _______, _______, _______, \
-  _______, _______, _______, XXXXXXX, \
+[LAYER_FUNCTION] = LAYOUT_pad21(      \
+  BL_TOGG, BL_INC,  BL_DEC,  _______, \
+  TG(1),   _______, _______, _______, \
+  _______, _______, _______,          \
   _______, _______, _______, _______, \
-  _______, _______, _______, XXXXXXX, \
-  RESET,   XXXXXXX, _______, _______  ),
+  _______, _______, _______,          \
+  RESET,            _______, _______  ),
 
 };
 
 
-const uint16_t PROGMEM fn_actions[] = {
-	[0] = ACTION_LAYER_MOMENTARY(LAYER_FUNCTION),
-	[1] = ACTION_LAYER_TOGGLE(LAYER_EDIT),
-	[2] = ACTION_BACKLIGHT_TOGGLE(),
-	[3] = ACTION_BACKLIGHT_INCREASE(),
-	[4] = ACTION_BACKLIGHT_DECREASE(),
-	[5] = ACTION_MACRO_TAP(MACRO_COPY_CUT),
-    [6] = ACTION_MACRO_TAP(MACRO_SHIFT_CONTROL),
-    [7] = ACTION_MACRO_TAP(MACRO_CONTROL_ALT),
-
-};
-
-
-void action_function(keyrecord_t *record, uint8_t id, uint8_t opt)
-{
-}
-
-
-const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
-{
+bool process_record_user(uint16_t keycode, keyrecord_t * record) {
   // MACRODOWN only works in this function
-    switch (id) {
+  switch (keycode) {
 
-    case MACRO_COPY_CUT:
-        if (record->event.pressed) {
-            register_code(KC_LCTL);
-            if (record->tap.count == 1) {
-                register_code(KC_C);
-                unregister_code(KC_C);
-            }
-            else if (record->tap.count == 2) {
-                register_code(KC_X);
-                unregister_code(KC_X);
-            }
-            unregister_code(KC_LCTL);
-        }
-        break;
-
-    case MACRO_SHIFT_CONTROL:
-        if (record->event.pressed) {
-            if (record->tap.count <= 2) register_mods(MOD_BIT(KC_LSFT));
-            if (record->tap.count == 2) register_mods(MOD_BIT(KC_LCTL));
-            if (record->tap.count == 3) register_code(KC_PENT);;
-        }
-        else {
-            unregister_mods(MOD_BIT(KC_LSFT) | MOD_BIT(KC_LCTL));
-            unregister_code(KC_PENT);
-        }
-        break;
-
-    case MACRO_CONTROL_ALT:
-        if (record->event.pressed) {
-            if (record->tap.count < 2)  register_mods(MOD_BIT(KC_LCTL));
-            if (record->tap.count >= 2) register_mods(MOD_BIT(KC_LALT));
-        }
-        else {
-            unregister_mods(MOD_BIT(KC_LCTL) | MOD_BIT(KC_LALT));
-        }
-        break;
+  case M_COPY:
+    if (record->event.pressed) {
+      register_code(KC_LCTL);
+      if (record->tap.count == 1) {
+        register_code(KC_C);
+        unregister_code(KC_C);
+      } else if (record->tap.count == 2) {
+        register_code(KC_X);
+        unregister_code(KC_X);
+      }
+      unregister_code(KC_LCTL);
     }
+    break;
 
-    return MACRO_NONE;
+  case M_SHFCT:
+    if (record->event.pressed) {
+      if (record->tap.count <= 2) register_mods(MOD_BIT(KC_LSFT));
+      if (record->tap.count == 2) register_mods(MOD_BIT(KC_LCTL));
+      if (record->tap.count == 3) register_code(KC_PENT);;
+    } else {
+      unregister_mods(MOD_BIT(KC_LSFT) | MOD_BIT(KC_LCTL));
+      unregister_code(KC_PENT);
+    }
+    break;
+
+  case M_CTALT:
+    if (record->event.pressed) {
+      if (record->tap.count < 2) register_mods(MOD_BIT(KC_LCTL));
+      if (record->tap.count >= 2) register_mods(MOD_BIT(KC_LALT));
+    } else {
+      unregister_mods(MOD_BIT(KC_LCTL) | MOD_BIT(KC_LALT));
+    }
+    break;
+  }
+
+  return true;
 }
 
 void led_set_user(uint8_t usb_led)

--- a/keyboards/handwired/arrow_pad/keymaps/pad_24/keymap.c
+++ b/keyboards/handwired/arrow_pad/keymaps/pad_24/keymap.c
@@ -1,35 +1,18 @@
 
-#include "arrow_pad.h"
+#include QMK_KEYBOARD_H
 #include "led.h"
 
-// This is the 21-key keypad to 2x11 element matrix mapping
-#define LAYOUT( \
-    KM_ESC, KM_TAB, KM_BSL, KM_ARR, \
-    KM_NUM, KM_FSL, KM_AST, KM_MIN, \
-    KM___7, KM___8, KM___9, KM_EQU, \
-    KM___4, KM___5, KM___6, KM_PLS, \
-    KM___1, KM___2, KM___3, ___ENT, \
-    KM___0, _____0, KM_DOT, KM_ENT  \
-) { \
-    { KM_ESC, KM_TAB, KM_BSL, KM_ARR  }, \
-    { KM_NUM, KM_FSL, KM_AST, KM_MIN  }, \
-    { KM___7, KM___8, KM___9, KM_EQU  }, \
-    { KM___4, KM___5, KM___6, KM_PLS  }, \
-    { KM___1, KM___2, KM___3, KC_NO   }, \
-    { KM___0, KC_NO,  KM_DOT, KM_ENT  }  \
-}
+enum layers {
+  LAYER_BASE,
+  LAYER_EDIT,
+  LAYER_FUNCTION
+};
 
-#define LAYER_BASE                      0
-#define LAYER_EDIT                      1
-#define LAYER_FUNCTION                  2
-
-#define MACRO_COPY_CUT                  0
-#define MACRO_SHIFT_CONTROL             1
-#define MACRO_CONTROL_ALT               2
-
-#define M_COPY              KC_FN5
-#define M_SHFCT             KC_FN6
-#define M_CTALT             KC_FN7
+enum custom_keycodes {
+  M_COPY = SAFE_RANGE,  // KC_FN5: MACRO_COPY_CUT
+  M_SHFCT,              // KC_FN6: MACRO_SHIFT_CONTROL
+  M_CTALT               // KC_FN7: MACRO_CONTROL_ALT
+};
 
 #define SC_UNDO             LCTL(KC_Z)
 #define SC_REDO             LCTL(KC_Y)
@@ -42,13 +25,10 @@
 #define SC_ACLS             LALT(KC_F4)
 #define SC_CCLS             LCTL(KC_F4)
 
-#define _______             KC_TRNS
-#define XXXXXXX             KC_NO
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 [LAYER_BASE] = LAYOUT(                \
-  KC_ESC,  KC_TAB,  KC_BSLS, KC_FN0,  \
+  KC_ESC,  KC_TAB,  KC_BSLS, MO(2),   \
   KC_NLCK, KC_PSLS, KC_PAST, KC_PMNS, \
   KC_P7,   KC_P8,   KC_P9,   KC_PEQL, \
   KC_P4,   KC_P5,   KC_P6,   KC_PPLS, \
@@ -57,15 +37,15 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 [LAYER_EDIT] = LAYOUT(                \
   KC_ESC,  KC_TAB,  KC_SPC,  _______, \
-  KC_FN1,  SC_PSTE, SC_REDO, SC_UNDO, \
+  TG(1),   SC_PSTE, SC_REDO, SC_UNDO, \
   KC_HOME, KC_UP,   KC_PGUP, KC_LALT, \
   KC_LEFT, M_COPY,  KC_RGHT, KC_LCTL, \
   KC_END,  KC_DOWN, KC_PGDN, XXXXXXX, \
-  KC_BSPC, KC_PENT, KC_DEL,  M_SHFCT),
+  KC_BSPC, KC_PENT, KC_DEL,  M_SHFCT  ),
 
 [LAYER_FUNCTION] = LAYOUT(            \
-  KC_FN2,  KC_FN3,  KC_FN4,  _______, \
-  KC_FN1,  _______, _______, _______, \
+  BL_TOGG, BL_INC,  BL_DEC,  _______, \
+  TG(1),   _______, _______, _______, \
   _______, _______, _______, _______, \
   _______, _______, _______, _______, \
   _______, _______, _______, XXXXXXX, \
@@ -74,68 +54,46 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 };
 
 
-const uint16_t PROGMEM fn_actions[] = {
-	[0] = ACTION_LAYER_MOMENTARY(LAYER_FUNCTION),
-	[1] = ACTION_LAYER_TOGGLE(LAYER_EDIT),
-	[2] = ACTION_BACKLIGHT_TOGGLE(),
-	[3] = ACTION_BACKLIGHT_INCREASE(),
-	[4] = ACTION_BACKLIGHT_DECREASE(),
-	[5] = ACTION_MACRO_TAP(MACRO_COPY_CUT),
-    [6] = ACTION_MACRO_TAP(MACRO_SHIFT_CONTROL),
-    [7] = ACTION_MACRO_TAP(MACRO_CONTROL_ALT),
-
-};
-
-
-void action_function(keyrecord_t *record, uint8_t id, uint8_t opt)
-{
-}
-
-
-const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
-{
+bool process_record_user(uint16_t keycode, keyrecord_t * record) {
   // MACRODOWN only works in this function
-    switch (id) {
+  switch (keycode) {
 
-    case MACRO_COPY_CUT:
-        if (record->event.pressed) {
-            register_code(KC_LCTL);
-            if (record->tap.count == 1) {
-                register_code(KC_C);
-                unregister_code(KC_C);
-            }
-            else if (record->tap.count == 2) {
-                register_code(KC_X);
-                unregister_code(KC_X);
-            }
-            unregister_code(KC_LCTL);
-        }
-        break;
-
-    case MACRO_SHIFT_CONTROL:
-        if (record->event.pressed) {
-            if (record->tap.count <= 2) register_mods(MOD_BIT(KC_LSFT));
-            if (record->tap.count == 2) register_mods(MOD_BIT(KC_LCTL));
-            if (record->tap.count == 3) register_code(KC_PENT);;
-        }
-        else {
-            unregister_mods(MOD_BIT(KC_LSFT) | MOD_BIT(KC_LCTL));
-            unregister_code(KC_PENT);
-        }
-        break;
-
-    case MACRO_CONTROL_ALT:
-        if (record->event.pressed) {
-            if (record->tap.count < 2)  register_mods(MOD_BIT(KC_LCTL));
-            if (record->tap.count >= 2) register_mods(MOD_BIT(KC_LALT));
-        }
-        else {
-            unregister_mods(MOD_BIT(KC_LCTL) | MOD_BIT(KC_LALT));
-        }
-        break;
+  case M_COPY:
+    if (record->event.pressed) {
+      register_code(KC_LCTL);
+      if (record->tap.count == 1) {
+        register_code(KC_C);
+        unregister_code(KC_C);
+      } else if (record->tap.count == 2) {
+        register_code(KC_X);
+        unregister_code(KC_X);
+      }
+      unregister_code(KC_LCTL);
     }
+    break;
 
-    return MACRO_NONE;
+  case M_SHFCT:
+    if (record->event.pressed) {
+      if (record->tap.count <= 2) register_mods(MOD_BIT(KC_LSFT));
+      if (record->tap.count == 2) register_mods(MOD_BIT(KC_LCTL));
+      if (record->tap.count == 3) register_code(KC_PENT);;
+    } else {
+      unregister_mods(MOD_BIT(KC_LSFT) | MOD_BIT(KC_LCTL));
+      unregister_code(KC_PENT);
+    }
+    break;
+
+  case M_CTALT:
+    if (record->event.pressed) {
+      if (record->tap.count < 2) register_mods(MOD_BIT(KC_LCTL));
+      if (record->tap.count >= 2) register_mods(MOD_BIT(KC_LALT));
+    } else {
+      unregister_mods(MOD_BIT(KC_LCTL) | MOD_BIT(KC_LALT));
+    }
+    break;
+  }
+
+  return true;
 }
 
 void led_set_user(uint8_t usb_led)

--- a/keyboards/handwired/arrow_pad/readme.md
+++ b/keyboards/handwired/arrow_pad/readme.md
@@ -94,13 +94,13 @@ More info can be found on [GeekHack](https://geekhack.org/index.php?topic=73632.
 The second ArrowPad was a conversion from a 21-key Genovation keypad. It used a 2 row x 11 column matrix.
 
 ```
-#define KEYMAP( \
+#define LAYOUT_pad21( \
     KM_ESC, KM_TAB, KM_BSL, KM_ARR, \
     KM_NUM, KM_FSL, KM_AST, KM_MIN, \
-    KM___7, KM___8, KM___9, ___PLS, \
+    KM___7, KM___8, KM___9,         \
     KM___4, KM___5, KM___6, KM_PLS, \
-    KM___1, KM___2, KM___3, ___ENT, \
-    KM___0, _____0, KM_DOT, KM_ENT  \
+    KM___1, KM___2, KM___3,         \
+    KM___0,         KM_DOT, KM_ENT  \
 ) { \
     { KM_ESC, KM_TAB, KM_BSL, KM_ARR, KM___7, KM___8, KM___9, KM_PLS, KM___1, KM___2, KM___3, }, \
     { KM_NUM, KM_FSL, KM_AST, KM_MIN, KM___4, KM___5, KM___6, KM_ENT, KC_NO,  KM___0, KM_DOT, }, \
@@ -119,7 +119,7 @@ Download or clone the whole firmware and navigate to the keyboards/arrow_pad fol
 Depending on which keymap you would like to use, you will have to compile slightly differently.
 
 ### Default
-To build with the default keymap, simply run `make default`.
+To build with the default keymap, simply run `make handwired/arrow_pad:default`.
 
 ### Other Keymaps
 Several version of keymap are available in advance but you are recommended to define your favorite layout yourself. To define your own keymap create file named `<name>.c` in the keymaps folder, and see keymap document (you can find in top readme.md) and existent keymap files.
@@ -127,7 +127,7 @@ Several version of keymap are available in advance but you are recommended to de
 To build the firmware binary hex file with a keymap just do `make` with a keymap like this:
 
 ```
-$ make [default|pad_21|pad_24|<name>]
+$ make handwired/arrow_pad:[default|pad_21|pad_24|<name>]
 ```
 
 Keymaps follow the format **__\<name\>.c__** and are stored in the `keymaps` folder.


### PR DESCRIPTION
## handwired/arrow_pad: layout macro and keymap refactor

- Layout macros moved from the keymaps to arrow_pad.h.
- LAYOUT_pad21 refactored to only accept keys that are physical present (no KC_NO entries required in keymap)
- Keymaps now use #include QMK_KEYBOARD_H
- Keymaps refactored to use process_record_user function (from action_get_macro)

## handwired/arrow_pad: Readme cleanup

Fixed the make commands and updated the layout macro.

## handwired/arrow_pad: Configurator support