### PR TITLE
Fix Helix ws2812.c listed more than once warning.

### DIFF
--- a/keyboards/helix/pico/rules.mk
+++ b/keyboards/helix/pico/rules.mk
@@ -1,3 +1,2 @@
-SRC += pico/matrix.c \
-	   pico/split_util.c \
-	   ws2812.c
+SRC += pico/matrix.c
+SRC += pico/split_util.c

--- a/keyboards/helix/rev2/rules.mk
+++ b/keyboards/helix/rev2/rules.mk
@@ -1,4 +1,3 @@
 SRC += rev2/matrix.c
 SRC += rev2/split_util.c
 SRC += rev2/split_scomm.c
-SRC += ws2812.c


### PR DESCRIPTION
Remove `SRC += ws2812.c` from helix/rev2/rules.mk and helix/pico/rules.mk.
Because it will be added in common_features.mk.