### PR TITLE
Fix up RGB Matrix code

### DIFF
--- a/quantum/rgb_matrix.c
+++ b/quantum/rgb_matrix.c
@@ -841,18 +841,20 @@ void rgb_matrix_init(void) {
   eeconfig_debug_rgb_matrix(); // display current eeprom values
 }
 
+#ifndef RGBLIGHT_ENABLE
 // Deals with the messy details of incrementing an integer
-uint8_t increment( uint8_t value, uint8_t step, uint8_t min, uint8_t max ) {
+static uint8_t increment( uint8_t value, uint8_t step, uint8_t min, uint8_t max ) {
     int16_t new_value = value;
     new_value += step;
     return MIN( MAX( new_value, min ), max );
 }
 
-uint8_t decrement( uint8_t value, uint8_t step, uint8_t min, uint8_t max ) {
+static uint8_t decrement( uint8_t value, uint8_t step, uint8_t min, uint8_t max ) {
     int16_t new_value = value;
     new_value -= step;
     return MIN( MAX( new_value, min ), max );
 }
+#endif
 
 // void *backlight_get_custom_key_color_eeprom_address( uint8_t led )
 // {
@@ -887,9 +889,28 @@ uint32_t rgb_matrix_get_tick(void) {
     return g_tick;
 }
 
+#ifndef RGBLIGHT_ENABLE
 void rgblight_toggle(void) {
 	rgb_matrix_config.enable ^= 1;
     eeconfig_update_rgb_matrix(rgb_matrix_config.raw);
+}
+
+void rgblight_enable(void) {
+	rgb_matrix_config.enable = 1;
+    eeconfig_update_rgb_matrix(rgb_matrix_config.raw);
+}
+
+void rgblight_enable_noeeprom(void) {
+	rgb_matrix_config.enable = 1;
+}
+
+void rgblight_disable(void) {
+	rgb_matrix_config.enable = 0;
+    eeconfig_update_rgb_matrix(rgb_matrix_config.raw);
+}
+
+void rgblight_disable_noeeprom(void) {
+	rgb_matrix_config.enable = 0;
 }
 
 void rgblight_step(void) {
@@ -951,6 +972,10 @@ void rgblight_mode(uint8_t mode) {
     eeconfig_update_rgb_matrix(rgb_matrix_config.raw);
 }
 
+void rgblight_mode_noeeprom(uint8_t mode) {
+    rgb_matrix_config.mode = mode;
+}
+
 uint32_t rgblight_get_mode(void) {
     return rgb_matrix_config.mode;
 }
@@ -961,3 +986,10 @@ void rgblight_sethsv(uint16_t hue, uint8_t sat, uint8_t val) {
   rgb_matrix_config.val = val;
   eeconfig_update_rgb_matrix(rgb_matrix_config.raw);
 }
+
+void rgblight_sethsv_noeeprom(uint16_t hue, uint8_t sat, uint8_t val) {
+  rgb_matrix_config.hue = hue;
+  rgb_matrix_config.sat = sat;
+  rgb_matrix_config.val = val;
+}
+#endif

--- a/quantum/rgb_matrix.h
+++ b/quantum/rgb_matrix.h
@@ -127,6 +127,7 @@ enum rgb_matrix_effects {
 };
 
 void rgb_matrix_set_color( int index, uint8_t red, uint8_t green, uint8_t blue );
+void rgb_matrix_set_color_all( uint8_t red, uint8_t green, uint8_t blue );
 
 // This runs after another backlight effect and replaces
 // colors already set
@@ -160,9 +161,15 @@ void rgb_matrix_decrease(void);
 
 uint32_t rgb_matrix_get_tick(void);
 
+#ifndef RGBLIGHT_ENABLE
 void rgblight_toggle(void);
+void rgblight_enable(void);
+void rgblight_enable_noeeprom(void);
+void rgblight_disable(void);
+void rgblight_disable_noeeprom(void);
 void rgblight_step(void);
 void rgblight_sethsv(uint16_t hue, uint8_t sat, uint8_t val);
+void rgblight_sethsv_noeeprom(uint16_t hue, uint8_t sat, uint8_t val);
 void rgblight_step_reverse(void);
 void rgblight_increase_hue(void);
 void rgblight_decrease_hue(void);
@@ -173,7 +180,9 @@ void rgblight_decrease_val(void);
 void rgblight_increase_speed(void);
 void rgblight_decrease_speed(void);
 void rgblight_mode(uint8_t mode);
+void rgblight_mode_noeeprom(uint8_t mode);
 uint32_t rgblight_get_mode(void);
+#endif
 
 typedef struct {
     /* Perform any initialisation required for the other driver functions to work. */

--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -325,13 +325,13 @@ void rgblight_disable_noeeprom(void) {
 
 
 // Deals with the messy details of incrementing an integer
-uint8_t increment( uint8_t value, uint8_t step, uint8_t min, uint8_t max ) {
+static uint8_t increment( uint8_t value, uint8_t step, uint8_t min, uint8_t max ) {
     int16_t new_value = value;
     new_value += step;
     return MIN( MAX( new_value, min ), max );
 }
 
-uint8_t decrement( uint8_t value, uint8_t step, uint8_t min, uint8_t max ) {
+static uint8_t decrement( uint8_t value, uint8_t step, uint8_t min, uint8_t max ) {
     int16_t new_value = value;
     new_value -= step;
     return MIN( MAX( new_value, min ), max );


### PR DESCRIPTION
This adds noeeprom versions of the `rgblight` functions, so they are not written to EEPROM
Also, it wraps the `rgblight` functions for the rgbmatrix in ifdefs, so you can enable both underglow and matrix at the same time