### PR TITLE
Enable Lights by Default for Kira 75

### DIFF
--- a/keyboards/kira75/rules.mk
+++ b/keyboards/kira75/rules.mk
@@ -60,7 +60,8 @@ COMMAND_ENABLE = yes        # Commands for debug and configuration
 SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
 # if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
 NKRO_ENABLE = no            # USB Nkey Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality on B7 by default
+BACKLIGHT_ENABLE = yes      # Enable keyboard backlight functionality on B7 by default
+RGBLIGHT_ENABLE = yes        # Enable keyboard RGB underglow
 MIDI_ENABLE = no            # MIDI support (+2400 to 4200, depending on config)
 UNICODE_ENABLE = no         # Unicode
 BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID


### PR DESCRIPTION
This is a fix for Issue #4431 

Modify the `rules.mk` file to enable RGB Underglow and Backlights.