### PR TITLE
handwired/atreus50 Refactor, Configurator support, and readme cleanup

### DIFF
--- a/keyboards/handwired/atreus50/atreus50.h
+++ b/keyboards/handwired/atreus50/atreus50.h
@@ -5,7 +5,7 @@
 
 // The first section contains all of the arguements
 // The second converts the arguments into a two-dimensional array
-#define KEYMAP( \
+#define LAYOUT( \
   k00, k01, k02, k03, k04, k05,           k06, k07, k08, k09, k0a, k0b, \
   k10, k11, k12, k13, k14, k15,           k16, k17, k18, k19, k1a, k1b, \
   k20, k21, k22, k23, k24, k25,           k26, k27, k28, k29, k2a, k2b, \
@@ -18,7 +18,7 @@
 	{ k30, k31, k32, k33, k34, k35, km1,   k36, k37, k38, k39, k3a, k3b } \
 }
 
-#define COMPACT_KEYMAP( \
+#define LAYOUT_kc( \
   k00, k01, k02, k03, k04, k05,           k06, k07, k08, k09, k0a, k0b, \
   k10, k11, k12, k13, k14, k15,           k16, k17, k18, k19, k1a, k1b, \
   k20, k21, k22, k23, k24, k25,           k26, k27, k28, k29, k2a, k2b, \

--- a/keyboards/handwired/atreus50/info.json
+++ b/keyboards/handwired/atreus50/info.json
@@ -1,0 +1,70 @@
+{
+  "keyboard_name": "Atreus50",
+  "url": "",
+  "maintainer": "qmk",
+  "width": 15,
+  "height": 4.5,
+  "layouts": {
+    "LAYOUT": {
+      "layout": [
+        {"label":"Tab", "x":0, "y":0.5},
+        {"label":"Q", "x":1, "y":0.5},
+        {"label":"W", "x":2, "y":0.25},
+        {"label":"E", "x":3, "y":0},
+        {"label":"R", "x":4, "y":0.25},
+        {"label":"T", "x":5, "y":0.5},
+
+        {"label":"Y", "x":9, "y":0.5},
+        {"label":"U", "x":10, "y":0.25},
+        {"label":"I", "x":11, "y":0},
+        {"label":"O", "x":12, "y":0.25},
+        {"label":"P", "x":13, "y":0.5},
+        {"label":"-", "x":14, "y":0.5},
+
+        {"label":"Ctrl/Esc", "x":0, "y":1.5},
+        {"label":"A", "x":1, "y":1.5},
+        {"label":"S", "x":2, "y":1.25},
+        {"label":"D", "x":3, "y":1},
+        {"label":"F", "x":4, "y":1.25},
+        {"label":"G", "x":5, "y":1.5},
+
+        {"label":"H", "x":9, "y":1.5},
+        {"label":"J", "x":10, "y":1.25},
+        {"label":"K", "x":11, "y":1},
+        {"label":"L", "x":12, "y":1.25},
+        {"label":";", "x":13, "y":1.5},
+        {"label":"'", "x":14, "y":1.5},
+
+        {"label":"LShift", "x":0, "y":2.5},
+        {"label":"Z", "x":1, "y":2.5},
+        {"label":"X", "x":2, "y":2.25},
+        {"label":"C", "x":3, "y":2},
+        {"label":"V", "x":4, "y":2.25},
+        {"label":"B", "x":5, "y":2.5},
+
+        {"label":"N", "x":9, "y":2.5},
+        {"label":"M", "x":10, "y":2.25},
+        {"label":",", "x":11, "y":2},
+        {"label":".", "x":12, "y":2.25},
+        {"label":"/", "x":13, "y":2.5},
+        {"label":"Shift/Enter", "x":14, "y":2.5},
+
+        {"label":"`", "x":0, "y":3.5},
+        {"label":"LCtrl", "x":1, "y":3.5},
+        {"label":"LAlt", "x":2, "y":3.25},
+        {"label":"LGUI", "x":3, "y":3},
+        {"label":"Lower", "x":4, "y":3.25},
+        {"label":"Space", "x":5, "y":3.5},
+        {"label":"Fn", "x":6, "y":2.75, "h":1.5},
+
+        {"label":"RShift", "x":8, "y":2.75, "h":1.5},
+        {"label":"Back Space", "x":9, "y":3.5},
+        {"label":"Raise", "x":10, "y":3.25},
+        {"label":"Left", "x":11, "y":3},
+        {"label":"Down", "x":12, "y":3.25},
+        {"label":"Up", "x":13, "y":3.5},
+        {"label":"Right", "x":14, "y":3.5}
+      ]
+    }
+  }
+}

--- a/keyboards/handwired/atreus50/keymaps/ajp10304/keymap.c
+++ b/keyboards/handwired/atreus50/keymaps/ajp10304/keymap.c
@@ -1,6 +1,4 @@
-#include "atreus50.h"
-#include "action_layer.h"
-#include "eeconfig.h"
+#include QMK_KEYBOARD_H
 #include "keymap_uk.h"
 
 extern keymap_config_t keymap_config;
@@ -37,10 +35,6 @@ enum planck_keycodes {
 
 #include "dynamic_macro.h"
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 /* Qwerty
@@ -54,7 +48,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * | Fn   | Ctrl | Alt  | GUI  |Lower | Bksp | Ctrl | Alt  |Space |Raise | Shift| MENU | Ctrl | Fn2  |
  * `-------------------------------------------------------------------------------------------------'
  */
-[_QWERTY] = KEYMAP(
+[_QWERTY] = LAYOUT(
   KC_ESC,                KC_Q,       KC_W,        KC_E,      KC_R,    KC_T,                      KC_Y,    KC_U,    KC_I,      KC_O,      KC_P,       KC_BSPC              ,
   MT(MOD_LSFT, KC_TAB),  KC_A,       KC_S,        KC_D,      KC_F,    KC_G,                      KC_H,    KC_J,    KC_K,      KC_L,      KC_SCLN,    MT(MOD_RSFT, KC_ENT) ,
   KC_LSHIFT,             KC_Z,       KC_X,        KC_C,      KC_V,    KC_B,                      KC_N,    KC_M,    KC_COMM,   KC_DOT,    KC_SLSH,    KC_RSHIFT            ,
@@ -72,7 +66,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * | Fn   | Ctrl | Alt  | GUI  |Lower | Bksp | Ctrl | Alt  |Space |Mouse | MENU | Alt  | Ctrl | Fn   |
  * `-------------------------------------------------------------------------------------------------'
  */
-[_FUNC] = KEYMAP(
+[_FUNC] = LAYOUT(
   KC_F1,     KC_F2,           KC_F3,    KC_F4,         KC_F5,   KC_F6,                     KC_F7,   KC_F8,      KC_F9,    KC_F10,  KC_F11,  KC_F12               ,
   KC_1,      KC_2,            KC_3,     KC_4,          KC_5,    KC_6,                      KC_7,    KC_8,       KC_9,     KC_0,    UK_TILD, KC_INSERT            ,
   KC_LSHIFT, KC_NONUS_BSLASH, KC_GRAVE, KC_NONUS_HASH, KC_PAST, KC_MINS,                   KC_EQL,  KC_BSLASH,  KC_LBRC,  KC_RBRC, KC_QUOT, MT(MOD_RSFT, KC_ENT) ,
@@ -90,7 +84,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |      |      |      |      |Lower | Del  | Ctrl | Alt  |Space |      | Next | Vol- | Vol+ | Play |
  * `-------------------------------------------------------------------------------------------------'
  */
-[_LOWER] = KEYMAP(
+[_LOWER] = LAYOUT(
   KC_1,        KC_2,            KC_3,        KC_4,           KC_5,        KC_6,                         KC_7,       KC_8,          KC_9,       KC_0,       KC_DEL,       KC_BSPC              ,
   LSFT(KC_1),  LSFT(KC_2),      LSFT(KC_3),  LSFT(KC_4),     LSFT(KC_5),  LSFT(KC_6),                   LSFT(KC_7), LSFT(KC_8),    LSFT(KC_9), LSFT(KC_0), LCTL(KC_DEL), LCTL(KC_BSPC)        ,
   KC_LSPO,     KC_NONUS_BSLASH, KC_GRAVE,    KC_NONUS_HASH,  KC_QUOT,     KC_MINS,                      KC_EQL,     KC_NONUS_HASH, KC_LBRC,    KC_RBRC,    KC_QUOT,      MT(MOD_RSFT, KC_ENT) ,
@@ -108,7 +102,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * | Mouse|      |      |      |      |  Alt | Ctrl | Alt  |Enter |Raise |      |      |      |      |
  * `-------------------------------------------------------------------------------------------------'
  */
-[_RAISE] = KEYMAP(
+[_RAISE] = LAYOUT(
   KC_GRV,     XXXXXXX, M(1),    KC_LBRC,       KC_RBRC,       XXXXXXX,                   XXXXXXX,       KC_PGUP,  KC_HOME,  KC_PGDOWN,  XXXXXXX,        KC_PSCREEN         ,
   KC_GRV,     XXXXXXX, XXXXXXX, LSFT(KC_9),    LSFT(KC_0),    XXXXXXX,                   XXXXXXX,       KC_HOME,  KC_UP,    KC_END,     XXXXXXX,        LCTL(LSFT(KC_EQL)) ,
   _______,    XXXXXXX, XXXXXXX, LSFT(KC_LBRC), LSFT(KC_RBRC), XXXXXXX,                   LCTL(KC_LEFT), KC_LEFT,  KC_DOWN,  KC_RIGHT,   LCTL(KC_RIGHT), LCTL(KC_MINS)      ,
@@ -126,11 +120,11 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |      |      |      |      |      |      |      |      |      |      |      |      |      |      |
  * `-------------------------------------------------------------------------------------------------'
  */
-[_ADJUST] = KEYMAP(
+[_ADJUST] = LAYOUT(
   M(0),     RESET,   QWERTY,  _______, _______, DYN_REC_START1,                    DYN_REC_START2,  _______,             _______,           _______,              _______,  KC_DEL  ,
   KC_CAPS,  _______, _______, _______, _______, DYN_MACRO_PLAY1,                   DYN_MACRO_PLAY2, KC_AUDIO_MUTE,       KC_AUDIO_VOL_UP,   KC_MEDIA_PLAY_PAUSE,  _______,  _______ ,
   TG(_MAC), _______, _______, _______, _______, DYN_REC_STOP,                      DYN_REC_STOP,    KC_MEDIA_PREV_TRACK, KC_AUDIO_VOL_DOWN, KC_MEDIA_NEXT_TRACK,  _______,  _______ ,
-  _______,  _______, _______, _______, _______, _______,         _______, _______, _______,         _______,             _______,           _______,              _______,  _______ 
+  _______,  _______, _______, _______, _______, _______,         _______, _______, _______,         _______,             _______,           _______,              _______,  _______
 ),
 
 /* Mouse
@@ -144,7 +138,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |      |      |      |      |      |      |      |      |      |      |      |      |      |      |
  * `-------------------------------------------------------------------------------------------------'
  */
-[_MOUSE] = KEYMAP(
+[_MOUSE] = LAYOUT(
     KC_ESC ,      _______,      _______,      _______, _______, _______,                   _______, _______,    _______,     _______,    _______, _______ ,
     KC_MS_ACCEL0, KC_MS_ACCEL1, KC_MS_ACCEL2, _______, _______, _______,                   _______, KC_MS_BTN1, KC_MS_UP,   KC_MS_BTN2,  _______, _______ ,
     KC_MS_ACCEL0, KC_MS_ACCEL1, KC_MS_ACCEL2, _______, _______, _______,                   _______, KC_MS_LEFT, KC_MS_DOWN, KC_MS_RIGHT, _______, _______ ,
@@ -162,42 +156,42 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |      |      |      |      |      |      |      |      |      |      |      |      |      |      |
  * `-------------------------------------------------------------------------------------------------'
  */
-[_FUNC2] = KEYMAP(
+[_FUNC2] = LAYOUT(
     _______,  _______,    M(1),       _______,    _______,    _______,                   M(5),    _______, _______, _______, _______, _______,
     _______,  _______,    M(3),       M(7),       _______,    _______,                   _______, M(10),   _______, _______, _______, _______,
     _______,  LCTL(KC_Z), LCTL(KC_X), LCTL(KC_C), LCTL(KC_V), _______,                   _______, _______, _______, _______, _______, M(98)  ,
     _______,  _______,    _______,    _______,    _______,    _______, _______, _______, _______, _______, _______, _______, _______, _______
 ),
 
-[_MAC] = KEYMAP(
+[_MAC] = LAYOUT(
     _______,  _______, _______, _______, _______, _______,                   _______, _______, _______, _______, _______, _______,
     _______,  _______, _______, _______, _______, _______,                   _______, _______, _______, _______, _______, _______,
     _______,  _______, _______, _______, _______, _______,                   _______, _______, _______, _______, _______, _______,
     MFNC,     _______, _______, _______, MLWR,    _______, _______, _______, _______, MRSE,    _______, _______, _______, MFNC2
 ),
 
-[_MLWR] = KEYMAP(
+[_MLWR] = LAYOUT(
     _______,  _______,  _______, _______, _______, _______,                   _______, _______, _______, _______, _______, _______,
     _______,  _______,  _______, _______, _______, _______,                   _______, _______, _______, _______, _______, _______,
     _______,  _______,  _______, _______, _______, _______,                   _______, _______, _______, _______, _______, _______,
     _______,  _______,  _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______
 ),
 
-[_MRSE] = KEYMAP(
+[_MRSE] = LAYOUT(
     _______,  _______,  M(2),    _______, _______, _______,                   _______,       _______,    _______, _______,    _______,        _______       ,
     _______,  _______,  _______, _______, _______, _______,                   _______,       LCTL(KC_A), _______, LCTL(KC_E), _______,        LGUI(KC_EQL)  ,
     _______,  _______,  _______, _______, _______, _______,                   LALT(KC_LEFT), _______,    _______, _______,    LALT(KC_RIGHT), LGUI(KC_MINS) ,
     _______,  _______,  _______, _______, _______, _______, _______, _______, _______,       _______,    _______, _______,    _______,        _______
 ),
 
-[_MFNC] = KEYMAP(
+[_MFNC] = LAYOUT(
     _______,  _______,  _______, _______, _______, _______,                   _______, _______, _______, _______, _______, _______       ,
     _______,  _______,  _______, _______, _______, _______,                   _______, _______, _______, _______, _______, LGUI(KC_PENT) ,
     _______,  _______,  _______, _______, _______, _______,                   _______, _______, _______, _______, _______, _______       ,
     _______,  _______,  _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______
 ),
 
-[_MFNC2] = KEYMAP(
+[_MFNC2] = LAYOUT(
     _______,  _______,    M(2),       _______,    _______,    _______,                   M(6),    _______, _______, _______, _______, _______,
     _______,  _______,    M(4),       M(8),       _______,    _______,                   _______, M(10),   _______, _______, _______, _______,
     _______,  LGUI(KC_Z), LGUI(KC_X), LGUI(KC_C), LGUI(KC_V), _______,                   _______, _______, _______, _______, _______, M(99)  ,

--- a/keyboards/handwired/atreus50/keymaps/default/keymap.c
+++ b/keyboards/handwired/atreus50/keymaps/default/keymap.c
@@ -1,9 +1,4 @@
-#include "atreus50.h"
-#include "action_layer.h"
-#include "eeconfig.h"
-#ifdef AUDIO_ENABLE
-  #include "audio.h"
-#endif
+#include QMK_KEYBOARD_H
 
 // Each layer gets a name for readability, which is then used in the keymap matrix below.
 // The underscores don't mean anything - you can have a layer called STUFF or any other name.
@@ -28,86 +23,52 @@ enum custom_keycodes {
 };
 
 // Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-#define KC_X0 MT(MOD_LCTL, KC_ESC)  // Hold for Left Ctrl, Tap for ESC
-#define KC_X1 LOWER
-#define KC_X2 RAISE
-#define KC_X3 MO(_MOVEMENT)
-#define KC_X4 MT(MOD_LSFT, KC_ENT)  // Hold for Left Shift, Tap for Enter
+#define X0 MT(MOD_LCTL, KC_ESC)  // Hold for Left Ctrl, Tap for ESC
+#define X3 MO(_MOVEMENT)
+#define X4 MT(MOD_LSFT, KC_ENT)  // Hold for Left Shift, Tap for Enter
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
-  [_QWERTY] = COMPACT_KEYMAP(
-  //,----+----+----+----+----+----.         ,----+----+----+----+----+----.
-     TAB , Q  , W  , E  , R  , T  ,           Y  , U  , I  , O  , P  ,MINS,
-  //|----+----+----+----+----+----|         |----+----+----+----+----+----|
-      X0 , A  , S  , D  , F  , G  ,           H  , J  , K  , L  ,SCLN,QUOT,
-  //|----+----+----+----+----+----|         |----+----+----+----+----+----|
-     LSFT, Z  , X  , C  , V  , B  ,           N  , M  ,COMM,DOT ,SLSH, X4 ,
-  //|----+----+----+----+----+----|----+----|----+----+----+----+----+----|
-     GRV ,LCTL,LALT,LGUI, X1 ,SPC , X3 ,RSFT,BSPC, X2 ,LEFT,DOWN, UP ,RGHT
-  //`----+----+----+----+----+----+----+----+----+----+----+----+----+----'
+  [_QWERTY] = LAYOUT(
+    KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,                      KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_MINS,
+    X0,      KC_A,    KC_S,    KC_D,    KC_F,    KC_G,                      KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,
+    KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,                      KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, X4,
+    KC_GRV,  KC_LCTL, KC_LALT, KC_LGUI, LOWER,   KC_SPC,  X3,      KC_RSFT, KC_BSPC, RAISE,   KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT
   ),
 
-  [_COLEMAK] = COMPACT_KEYMAP(
-  //,----+----+----+----+----+----.         ,----+----+----+----+----+----.
-     TAB , Q  , W  , F  , P  , G  ,           J  , L  , U  , Y  ,SCLN,MINS,
-  //|----+----+----+----+----+----|         |----+----+----+----+----+----|
-      X0 , A  , R  , S  , T  , D  ,           H  , N  , E  , I  , O  ,QUOT,
-  //|----+----+----+----+----+----|         |----+----+----+----+----+----|
-     LSFT, Z  , X  , C  , V  , B  ,           K  , M  ,COMM,DOT ,SLSH, X4 ,
-  //|----+----+----+----+----+----|----+----|----+----+----+----+----+----|
-     GRV ,LCTL,LALT,LGUI, X1 ,SPC , X3 ,RSFT,BSPC, X2 ,LEFT,DOWN, UP ,RGHT
-  //`----+----+----+----+----+----+----+----+----+----+----+----+----+----'
+  [_COLEMAK] = LAYOUT(
+    KC_TAB,  KC_Q,    KC_W,    KC_F,    KC_P,    KC_G,                      KC_J,    KC_L,    KC_U,    KC_Y,    KC_SCLN, KC_MINS,
+    X0,      KC_A,    KC_R,    KC_S,    KC_T,    KC_D,                      KC_H,    KC_N,    KC_E,    KC_I,    KC_O,    KC_QUOT,
+    KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,                      KC_K,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, X4,
+    KC_GRV,  KC_LCTL, KC_LALT, KC_LGUI, LOWER,   KC_SPC,  X3,      KC_RSFT, KC_BSPC, RAISE,   KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT
   ),
 
-  [_DVORAK] = COMPACT_KEYMAP(
-  //,----+----+----+----+----+----.         ,----+----+----+----+----+----.
-     TAB ,QUOT,COMM,DOT , P  , Y  ,           F  , G  , C  , R  , L  ,MINS,
-  //|----+----+----+----+----+----|         |----+----+----+----+----+----|
-      X0 , A  , O  , E  , U  , I  ,           D  , H  , T  , N  , S  ,SLSH,
-  //|----+----+----+----+----+----|         |----+----+----+----+----+----|
-     LSFT,SCLN, Q  , J  , K  , X  ,           B  , M  , W  , V  , Z  , X4 ,
-  //|----+----+----+----+----+----|----+----|----+----+----+----+----+----|
-     GRV ,LCTL,LALT,LGUI, X1 ,SPC , X3 ,RSFT,BSPC, X2 ,LEFT,DOWN, UP ,RGHT
-  //`----+----+----+----+----+----+----+----+----+----+----+----+----+----'
+  [_DVORAK] = LAYOUT(
+    KC_TAB,  KC_QUOT, KC_COMM, KC_DOT,  KC_P,    KC_Y,                      KC_F,    KC_G,    KC_C,    KC_R,    KC_L,    KC_MINS,
+    X0,      KC_A,    KC_O,    KC_E,    KC_U,    KC_I,                      KC_D,    KC_H,    KC_T,    KC_N,    KC_S,    KC_SLSH,
+    KC_LSFT, KC_SCLN, KC_Q,    KC_J,    KC_K,    KC_X,                      KC_B,    KC_M,    KC_W,    KC_V,    KC_Z,    X4,
+    KC_GRV,  KC_LCTL, KC_LALT, KC_LGUI, LOWER,   KC_SPC,  X3,      KC_RSFT, KC_BSPC, RAISE,   KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT
   ),
 
-  [_LOWER] = COMPACT_KEYMAP(
-  //,----+----+----+----+----+----.         ,----+----+----+----+----+----.
-     TILD,EXLM, AT ,HASH,DLR ,PERC,          CIRC,AMPR,ASTR,LPRN,RPRN,DEL ,
-  //|----+----+----+----+----+----|         |----+----+----+----+----+----|
-     DEL , F1 , F2 , F3 , F4 , F5 ,           F6 ,UNDS,PLUS,LCBR,RCBR,PIPE,
-  //|----+----+----+----+----+----|         |----+----+----+----+----+----|
-         , F7 , F8 , F9 ,F10 ,F11 ,          F12 ,END ,    ,    ,    ,    ,
-  //|----+----+----+----+----+----|----+----|----+----+----+----+----+----|
-         ,    ,    ,    ,    ,    ,    ,    ,    ,    ,MNXT,VOLD,VOLU,MPLY
-  //`----+----+----+----+----+----+----+----+----+----+----+----+----+----'
+  [_LOWER] = LAYOUT(
+    KC_TILD, KC_EXLM, KC_AT,   KC_HASH, KC_DLR,  KC_PERC,                   KC_CIRC, KC_AMPR, KC_ASTR, KC_LPRN, KC_RPRN, KC_DEL,
+    KC_DEL,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,                     KC_F6,   KC_UNDS, KC_PLUS, KC_LCBR, KC_RCBR, KC_PIPE,
+    _______, KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,                    KC_F12,  KC_END,  _______, _______, _______, _______,
+    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, KC_MNXT, KC_VOLD, KC_VOLU, KC_MPLY
   ),
 
-  [_RAISE] = COMPACT_KEYMAP(
-  //,----+----+----+----+----+----.         ,----+----+----+----+----+----.
-     GRV , 1  , 2  , 3  , 4  , 5  ,           6  , 7  , 8  , 9  , 0  ,DEL ,
-  //|----+----+----+----+----+----|         |----+----+----+----+----+----|
-     DEL , F1 , F2 , F3 , F4 , F5 ,           F6 ,MINS,EQL ,LBRC,RBRC,BSLS,
-  //|----+----+----+----+----+----|         |----+----+----+----+----+----|
-         , F7 , F8 , F9 ,F10 ,F11 ,          F12 ,NUHS,NUBS,    ,    ,    ,
-  //|----+----+----+----+----+----|----+----|----+----+----+----+----+----|
-         ,    ,    ,    ,    ,    ,    ,    ,    ,    ,MNXT,VOLD,VOLU,MPLY
-  //`----+----+----+----+----+----+----+----+----+----+----+----+----+----'
+  [_RAISE] = LAYOUT(
+    KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,                      KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_DEL,
+    KC_DEL,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,                     KC_F6,   KC_MINS, KC_EQL,  KC_LBRC, KC_RBRC, KC_BSLS,
+    _______, KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,                    KC_F12,  KC_NUHS, KC_NUBS, _______, _______, _______,
+    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, KC_MNXT, KC_VOLD, KC_VOLU, KC_MPLY
   ),
 
-  [_MOVEMENT] = COMPACT_KEYMAP(
-  //,----+----+----+----+----+----.         ,----+----+----+----+----+----.
-     TILD,EXLM, AT ,HASH,DLR ,PERC,          CIRC,AMPR, UP ,LPRN,RPRN,DEL ,
-  //|----+----+----+----+----+----|         |----+----+----+----+----+----|
-     DEL , F1 , F2 , F3 , F4 , F5 ,           F6 ,LEFT,DOWN,RGHT,RCBR,PIPE,
-  //|----+----+----+----+----+----|         |----+----+----+----+----+----|
-         , F7 , F8 , F9 ,F10 ,F11 ,          F12 ,END ,    ,    ,    ,    ,
-  //|----+----+----+----+----+----|----+----|----+----+----+----+----+----|
-         ,    ,    ,    ,    ,    ,    ,    ,PGDN,PGUP,MNXT,VOLD,VOLU,MPLY
-  //`----+----+----+----+----+----+----+----+----+----+----+----+----+----'
+  [_MOVEMENT] = LAYOUT(
+    KC_TILD, KC_EXLM, KC_AT,   KC_HASH, KC_DLR,  KC_PERC,                   KC_CIRC, KC_AMPR, KC_UP,   KC_LPRN, KC_RPRN, KC_DEL,
+    KC_DEL,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,                     KC_F6,   KC_LEFT, KC_DOWN, KC_RGHT, KC_RCBR, KC_PIPE,
+    _______, KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,                    KC_F12,  KC_END,  _______, _______, _______, _______,
+    _______, _______, _______, _______, _______, _______, _______, _______, KC_PGDN, KC_PGUP, KC_MNXT, KC_VOLD, KC_VOLU, KC_MPLY
   ),
 
 /* Adjust (Lower + Raise)
@@ -121,7 +82,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |      |      |      |      |      |      |      |      |      |      |      |      |      |      |
  * `-------------------------------------------------------------------------------------------------'
  */
-  [_ADJUST] = KEYMAP( \
+  [_ADJUST] = LAYOUT( \
     _______, RESET,   RGB_TOG, RGB_MOD, RGB_HUD, RGB_HUI,                   RGB_SAD, RGB_SAI, RGB_VAD, RGB_VAI, _______, KC_DEL, \
     _______, _______, _______, AU_ON,   AU_OFF,  AG_NORM,                   AG_SWAP, QWERTY,  COLEMAK, DVORAK,  _______, _______, \
     _______, MUV_DE,  MUV_IN,  MU_ON,   MU_OFF,  MI_ON,                     MI_OFF,  _______, _______, _______, _______, _______, \

--- a/keyboards/handwired/atreus50/readme.md
+++ b/keyboards/handwired/atreus50/readme.md
@@ -1,7 +1,9 @@
-Handwired Atreus50
-==================
+# Handwired Atreus50
 
-This firmware is for a Handwired Atreus50 using an Arduino Pro Micro.
+This firmware is for a handwired Atreus50 using an Arduino Pro Micro.
+
+Keyboard Maintainer: [The QMK Community](https://github.com/qmk)  
+Hardware Supported: Arduino Pro Micro  
 
 ## Pinout
 
@@ -11,6 +13,12 @@ The following pins are used:
 
 ## Compiling and loading the firmware
 
-To build the firmware, run `make`.
+Make example for this keyboard (after setting up your build environment):
 
-To flash the firemware onto the microcontroller, run `make avrdude`, and press the reset button.
+    make handwired/atreus50:default
+
+To flash the firmware onto the microcontroller, run `make avrdude`, and press the reset button.
+
+    make handwired/atreus50:default:avrdude
+
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).


### PR DESCRIPTION
## handwired/atreus50: refactor

- layout macro renames:
  - KEYMAP is now LAYOUT
  - COMPACT_KEYMAP is now LAYOUT_kc
- keymap updates:
  - both keymaps now use #include QMK_KEYBOARD_H
  - removed redundant KC_TRNS and KC_NO definitions
  - default keymap now uses LAYOUT macro instead of LAYOUT_kc

## handwired/atreus50: Configurator support

## handwired/atreus50: readme cleanup

Reformatted the readme to be more closely aligned to current QMK
template, and fixed some typos/grammar.