### PR TITLE
Only try to read the report ID from SetReport when the keyboard is part of the shared EP

### DIFF
--- a/tmk_core/protocol/lufa/lufa.c
+++ b/tmk_core/protocol/lufa/lufa.c
@@ -517,7 +517,7 @@ void EVENT_USB_Device_ControlRequest(void)
                         if (USB_DeviceState == DEVICE_STATE_Unattached)
                           return;
                     }
-#if defined(SHARED_EP_ENABLE)
+#ifdef KEYBOARD_SHARED_EP
                     uint8_t report_id = REPORT_ID_KEYBOARD;
                     if (keyboard_protocol) {
                        report_id = Endpoint_Read_8();


### PR DESCRIPTION
If the keyboard has media keys or NKRO on, `SHARED_EP_ENABLE` is automatically enabled to merge them into a single endpoint (see #3951). The different interfaces are then identified by a unique report ID. However, the keyboard interface is by default not part of that shared endpoint unless `KEYBOARD_SHARED_EP = yes` in your rules.mk, and so it does not need a report ID.

The end result is that when LUFA tries to ask the host which LEDs to turn on, it expects there to be a report ID byte first, then the LED state. It will then set the report ID to the actual LED state, and no LEDs come on.