### PR TITLE
Re-order feature list in sidebar

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -43,6 +43,7 @@
 
 * [Features](features.md)
   * [Basic Keycodes](keycodes_basic.md)
+  * [US ANSI Shifted Keys](keycodes_us_ansi_shifted.md)
   * [Quantum Keycodes](quantum_keycodes.md)
   * [Advanced Keycodes](feature_advanced_keycodes.md)
   * [Audio](feature_audio.md)
@@ -74,7 +75,6 @@
   * [Thermal Printer](feature_thermal_printer.md)
   * [Unicode](feature_unicode.md)
   * [Userspace](feature_userspace.md)
-  * [US ANSI Shifted Keys](keycodes_us_ansi_shifted.md)
 
 * For Makers and Modders
   * [Hand Wiring Guide](hand_wire.md)

--- a/docs/_summary.md
+++ b/docs/_summary.md
@@ -43,6 +43,7 @@
 
 * [Features](features.md)
   * [Basic Keycodes](keycodes_basic.md)
+  * [US ANSI Shifted Keys](keycodes_us_ansi_shifted.md)
   * [Quantum Keycodes](quantum_keycodes.md)
   * [Advanced Keycodes](feature_advanced_keycodes.md)
   * [Audio](feature_audio.md)
@@ -74,7 +75,6 @@
   * [Thermal Printer](feature_thermal_printer.md)
   * [Unicode](feature_unicode.md)
   * [Userspace](feature_userspace.md)
-  * [US ANSI Shifted Keys](keycodes_us_ansi_shifted.md)
 
 * For Makers and Modders
   * [Hand Wiring Guide](hand_wire.md)


### PR DESCRIPTION
Specifically, moved the shifted keycodes to the top of the 'Feature' list, so it's more visible.  This way, all of the keycodes are at the top of the list, rather than having the shifted keys at the bottom, so they should be easier to find since they're all in one place.