### PR TITLE
handwired/gamenum Refactor, Configurator support and readme cleanup

### DIFF
--- a/keyboards/handwired/gamenum/gamenum.h
+++ b/keyboards/handwired/gamenum/gamenum.h
@@ -3,19 +3,19 @@
 
 #include "quantum.h"
 
-#define KEYMAP( \
+#define LAYOUT( \
 	k00, k01, k02, k03, \
 	k10, k11, k12, k13, \
-	k20, k21, k22,        \
-	k30, k31, k32,        \
-	       k41, k42, k43  \
+	k20, k21, k22,      \
+	k30, k31, k32,      \
+	     k41, k42, k43  \
 ) \
 { \
-	{ k00, k01, k02, k03}, \
-	{ k10, k11, k12, k13}, \
-	{ k20, k21, k22, KC_NO}, \
-	{ k30, k31, k32, KC_NO}, \
-	{ KC_NO, k41, k42, k43}  \
+	{ k00,   k01, k02, k03   }, \
+	{ k10,   k11, k12, k13   }, \
+	{ k20,   k21, k22, KC_NO }, \
+	{ k30,   k31, k32, KC_NO }, \
+	{ KC_NO, k41, k42, k43   }  \
 }
 
 #endif

--- a/keyboards/handwired/gamenum/info.json
+++ b/keyboards/handwired/gamenum/info.json
@@ -1,0 +1,30 @@
+{
+  "keyboard_name": "gamenum", 
+  "url": "", 
+  "maintainer": "qmk", 
+  "width": 4, 
+  "height": 5, 
+  "layouts": {
+    "LAYOUT": {
+      "layout": [
+        {"label":"Fn", "x":0, "y":0}, 
+        {"label":"/", "x":1, "y":0}, 
+        {"label":"*", "x":2, "y":0}, 
+        {"label":"-", "x":3, "y":0}, 
+        {"label":"7", "x":0, "y":1}, 
+        {"label":"8", "x":1, "y":1}, 
+        {"label":"9", "x":2, "y":1}, 
+        {"label":"+", "x":3, "y":1, "h":2}, 
+        {"label":"4", "x":0, "y":2}, 
+        {"label":"5", "x":1, "y":2}, 
+        {"label":"6", "x":2, "y":2}, 
+        {"label":"1", "x":0, "y":3}, 
+        {"label":"2", "x":1, "y":3}, 
+        {"label":"3", "x":2, "y":3}, 
+        {"label":"0", "x":0, "y":4, "w":2}, 
+        {"label":".", "x":2, "y":4}, 
+        {"label":"Ent", "x":3, "y":3, "h":2}
+      ]
+    }
+  }
+}

--- a/keyboards/handwired/gamenum/keymaps/default/keymap.c
+++ b/keyboards/handwired/gamenum/keymaps/default/keymap.c
@@ -1,36 +1,32 @@
-#include "gamenum.h"
-#include "action_layer.h"
-#include "eeconfig.h"
+#include QMK_KEYBOARD_H
 
-
-#define _______ KC_TRNS
 
 #define DEF 0
 #define HDN 1
 #define OSY 2
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-[DEF] = KEYMAP(
-  KC_FN0,   KC_SLSH, KC_ASTR, KC_MINS, \
-  KC_7,      KC_8,       KC_9,       KC_PLUS, \
-  KC_4,      KC_5,       KC_6, \
-  KC_1,      KC_2,       KC_3, \
-  KC_0,      KC_DOT,  KC_ENT \
-),
-[HDN] = KEYMAP(
-  KC_FN1,   KC_1,  	KC_2,   	KC_3,  \
-  KC_Q,      KC_W, 	KC_E,   	KC_R, \
-  KC_A,      KC_S,  	KC_D, \
-  KC_Z,      KC_X,  	KC_C, \
-  KC_LSFT, KC_LALT,  KC_SPC \
-),
-[OSY] = KEYMAP(
-  KC_A,    	KC_Q, 	KC_1, 	KC_FN2, \
-  KC_S,    	KC_W, 	KC_2, 	KC_LALT, \
-  KC_D,    	KC_E, 	KC_3, \
-  KC_F,   	KC_R, 	KC_4, \
-  KC_SPC, KC_T, 	KC_TAB \
-)
+  [DEF] = LAYOUT(
+    KC_FN0,  KC_SLSH, KC_ASTR, KC_MINS, \
+    KC_7,    KC_8,    KC_9,    KC_PLUS, \
+    KC_4,    KC_5,    KC_6,             \
+    KC_1,    KC_2,    KC_3,             \
+    KC_0,             KC_DOT,  KC_ENT   \
+  ),
+  [HDN] = LAYOUT(
+    KC_FN1,  KC_1,    KC_2,    KC_3,    \
+    KC_Q,    KC_W,    KC_E,    KC_R,    \
+    KC_A,    KC_S,    KC_D,             \
+    KC_Z,    KC_X,    KC_C,             \
+    KC_LSFT,          KC_LALT, KC_SPC   \
+  ),
+  [OSY] = LAYOUT(
+    KC_A,    KC_Q,    KC_1,    KC_FN2,  \
+    KC_S,    KC_W,    KC_2,    KC_LALT, \
+    KC_D,    KC_E,    KC_3,             \
+    KC_F,    KC_R,    KC_4,             \
+    KC_SPC,           KC_T,    KC_TAB   \
+  )
 };
 
 
@@ -48,21 +44,21 @@ const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt) {
 bool process_record_user (uint16_t keycode, keyrecord_t *record) {
   switch(keycode) {
   case KC_FN0:
-      if (record->event.pressed) {
-        PORTC |= (1 << 6); // PC6 goes high 
-     }
-     break;
+    if (record->event.pressed) {
+      PORTC |= (1 << 6); // PC6 goes high
+    }
+    break;
   case KC_FN1:
-      if (record->event.pressed) {
-        PORTC &= ~(1 << 6); // PC6 goes high 
-		PORTD |= (1<<4);
-     }
-     break;
+    if (record->event.pressed) {
+      PORTC &= ~(1 << 6); // PC6 goes high
+      PORTD |= (1<<4);
+    }
+    break;
   case KC_FN2:
-      if (record->event.pressed) {
-        PORTD &= ~(1 << 4); // PC6 goes high 
-     }
-     break;
+    if (record->event.pressed) {
+      PORTD &= ~(1 << 4); // PC6 goes high
+    }
+    break;
   }
   return true;
 }

--- a/keyboards/handwired/gamenum/readme.md
+++ b/keyboards/handwired/gamenum/readme.md
@@ -1,5 +1,16 @@
-GameNum firmware
-======================
+# GameNum
+
+A handwired standard numpad oriented toward gaming on the go.
+
+Keyboard Maintainer: [The QMK Community](https://github.com/qmk)  
+Hardware Supported: GameNum, Pro Micro  
+
+Make example for this keyboard (after setting up your build environment):
+
+    make handwired/gamenum:default
+
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
+
 ## Board overview
 
 The GameNum was designed to facilitate the use of mechanical keys for gaming even when your packing space is limited.
@@ -22,7 +33,7 @@ The indicator LED's are normally assigned to `pin C6` and `pin D4`, C6 goes high
 
 Keep in mind that the minus of the diodes should point towards the pro micros inputs.
 
-##LED hookup
+## LED hookup
 
 ![led overview](http://i.imgur.com/U6m865n.jpg)
 
@@ -34,13 +45,13 @@ Keep in mind here that the number after the name should correspond with the numb
 Next thing to do is to add the actual layer for the keymap.
 
 ```
-[DEF] = KEYMAP(
-  KC_FN0,   KC_SLSH, KC_ASTR, KC_MINS, \
-  KC_7,      KC_8,       KC_9,       KC_PLUS, \
-  KC_4,      KC_5,       KC_6, \
-  KC_1,      KC_2,       KC_3, \
-  KC_0,      KC_DOT,  KC_ENT \
-)
+  [DEF] = LAYOUT(
+    KC_FN0,  KC_SLSH, KC_ASTR, KC_MINS, \
+    KC_7,    KC_8,    KC_9,    KC_PLUS, \
+    KC_4,    KC_5,    KC_6,             \
+    KC_1,    KC_2,    KC_3,             \
+    KC_0,             KC_DOT,  KC_ENT   \
+  )
 ```
 
 This is the default layer for the gamenum. It's generally easiest to just copy this and change things as you see fit. Keep in mind that at least 1 button on the pad has to be used to switch to the next layer in the stack or you will be stuck in that layer FOREVER! D:
@@ -54,8 +65,8 @@ Now for the LEDs, if you plan on adding extra LED's to the keyboard to indicate 
 Look for this piece of code: 
 
 ```
-	DDRD |= (1<<4);
-	PORTD &= ~(1<<4);
+    DDRD |= (1<<4);
+    PORTD &= ~(1<<4);
 ```
 
 Copy it and change the letter after DDR and PORT to the letter of your pin. Change the 4 to the number of your pin. `DDRx |= (1<<y);` defines that pin as an output. `PORTx &= ~(1<<y);` sets the pin to LOW turning off the LED.
@@ -64,39 +75,11 @@ Now go back to `keymap.c` and look for the `process_record_user` function. The f
 
 ```
   case KC_FN1:
-      if (record->event.pressed) {
-        PORTC &= ~(1 << 6); // PC6 goes low 
-		PORTD |= (1<<4); //PD4 goes high
-     }
-     break;
+    if (record->event.pressed) {
+      PORTC &= ~(1 << 6); // PC6 goes low 
+      PORTD |= (1<<4); //PD4 goes high
+    }
+    break;
 ```
 
 This is the code for the KC_FN1 button. Notice how we check against what key is pressed in the case and then set pin C6 low and pin D4 high. Adjust this as you see fit.
-
-
-## Quantum MK Firmware
-
-For the full Quantum feature list, see [the parent readme.md](/docs/README.md).
-
-## Building
-
-Download or clone the whole firmware and navigate to the keyboards/handwired/gamenum folder.
-Read the README.md for the qmk repository on how to set up your developer enviroment to build your firmware with.
-Building firmware on Windows can be a bit of a hassle. Linux is a lot easier to use if you have some experience with it. A raspberry pi will already be able to build the firmware for you.
-Once your dev env is set up, you'll be able to type `make` to generate your .hex - you can then use AVRDudess to program your .hex file.
-
-### Default
-
-To build with the default keymap, simply run `make`.
-
-### Other Keymaps
-
-To build the firmware binary hex file with a keymap just do `make` with `keymap` option like:
-
-```
-$ make keymap=[default|jack|<name>]
-```
-
-Keymaps follow the format **__keymap.c__** and are stored in folders in the `keymaps` folder, eg `keymaps/my_keymap/`
-
-


### PR DESCRIPTION
## handwired/gamenum: refactor (bb0eef7)

- layout macro KEYMAP renamed to LAYOUT
  - white space changes for alignment
- default keymap
  - now uses #include QMK_KEYBOARD_H
  - updated layout macro names
  - white space changes (for readability)

## handwired/gamenum: Configurator support (94d6ed7)

## handwired/gamenum: readme cleanup (f4cf27e)

- renamed file to lowercase
- updated to match current QMK template more closely
- edits to reflect the other changes in this PR