### PR TITLE
crd alps64 updates

### DIFF
--- a/keyboards/alps64/alps64.h
+++ b/keyboards/alps64/alps64.h
@@ -94,16 +94,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     K34, K35, K44, K45, K54, K55, K64, K65, K75, K05, K15, K16, K25, K24, \
     K32, K33, K43, K52, K53, K63, K73, K74, K03, K04, K13, K14, K23, \
     K31,      K42, K51, K61, K62, K71, K72, K01, K02, K11, K12, K21,  \
-    K30, K40, K50,           K60,                     K70, K00,      K20  \
+    K30, K40, K50,           K60,                          K00, K10, K20  \
 ) { \
     { K00,   K01,   K02,   K03, K04, K05, K06,   K07 }, \
-    { KC_NO, K11,   K12,   K13, K14, K15, K16,   K17 }, \
+    { K10,   K11,   K12,   K13, K14, K15, K16,   K17 }, \
     { K20,   K21,   KC_NO, K23, K24, K25, KC_NO, K27 }, \
     { K30,   K31,   K32,   K33, K34, K35, K36,   K37 }, \
     { K40,   KC_NO, K42,   K43, K44, K45, K46,   K47 }, \
     { K50,   K51,   K52,   K53, K54, K55, K56,   K57 }, \
     { K60,   K61,   K62,   K63, K64, K65, K66,   K67 }, \
-    { K70,   K71,   K72,   K73, K74, K75, K76,   K77 } \
+    { KC_NO, K71,   K72,   K73, K74, K75, K76,   K77 } \
 }
 
 #define LAYOUT_kc( \

--- a/keyboards/alps64/keymaps/crd/keymap.c
+++ b/keyboards/alps64/keymaps/crd/keymap.c
@@ -1,31 +1,32 @@
 #include QMK_KEYBOARD_H
 
+enum keyboard_layers {
+  _BL = 0, // Base Layer
+  _FL     // Function Layer
+};
+
+// Custom #defined keycodes (shorter macros for readability)
+#define KC_CTES CTL_T(KC_ESC)
+#define KC_RSUP RSFT_T(KC_UP)
+#define KC_FNDN LT(_FL, KC_DOWN)
+#define KC_RGLT RCMD_T(KC_LEFT)
+#define KC_RCRT RCTL_T(KC_RIGHT)
+
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-  /* 0: qwerty */
-  LAYOUT_all(
-    KC_GRV,        KC_1,    KC_2,    KC_3,   KC_4,     KC_5,    KC_6,    KC_7,    KC_8,    KC_9,     KC_0,    KC_MINS, KC_EQL,  _______, KC_BSPC,
-    KC_TAB,        KC_Q,    KC_W,    KC_E,   KC_R,     KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,     KC_P,    KC_LBRC, KC_RBRC, KC_BSLS,
-    CTL_T(KC_ESC), KC_A,    KC_S,    KC_D,   KC_F,     KC_G,    KC_H,    KC_J,    KC_K,    KC_L,     KC_SCLN, KC_QUOT, KC_ENT,
-    KC_LSFT,       KC_NUBS, KC_Z,    KC_X,   KC_C,     KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM,  KC_DOT,  KC_SLSH, RSFT_T(KC_UP), _______,
-    MO(1),         KC_LALT, KC_LGUI,                   KC_SPC,                                       _______, RGUI_T(KC_LEFT), RALT_T(KC_DOWN), LT(2, KC_RIGHT)
+  [_BL] = LAYOUT_aek_103(
+    KC_GRV,  KC_1,    KC_2,    KC_3,   KC_4,     KC_5,    KC_6,    KC_7,    KC_8,    KC_9,     KC_0,    KC_MINS, KC_EQL,  KC_BSPC,
+    KC_TAB,  KC_Q,    KC_W,    KC_E,   KC_R,     KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,     KC_P,    KC_LBRC, KC_RBRC, KC_BSLS,
+    KC_CTES, KC_A,    KC_S,    KC_D,   KC_F,     KC_G,    KC_H,    KC_J,    KC_K,    KC_L,     KC_SCLN, KC_QUOT, KC_ENT,
+    KC_LSFT, KC_Z,    KC_X,    KC_C,   KC_V,     KC_B,    KC_N,    KC_M,    KC_COMM,  KC_DOT,  KC_SLSH, KC_RSUP,
+    MO(_FL), KC_LALT, KC_LGUI,                            KC_SPC,                              KC_RGLT, KC_FNDN, KC_RCRT
   ),
-  /* 1: fn1 */
-  LAYOUT_all(
-    KC_ESC,        KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,    KC_F10,  KC_F11,  KC_F12,  _______, KC_DEL,
-    _______,       _______, _______, _______, _______, _______, _______, _______, _______, _______,  _______, KC_HOME, KC_PGUP, _______,
-    _______,       _______, _______, _______, _______, _______, KC_LEFT, KC_DOWN, KC_UP,   KC_RIGHT, KC_END,  KC_PGDOWN, _______,
-    _______,       _______, _______, _______, _______, _______, _______, _______, _______, _______,  _______, _______, _______, _______,
-    _______,       _______, _______,                   _______,                                      _______, _______, _______, _______
-  ),
-  /* 2: fn2 */
-  LAYOUT_all(
-    _______,       _______, _______, _______, _______, _______, _______, _______, _______, _______,  _______, _______,  _______, _______, RESET,
-    _______,       _______, _______, _______, RESET,   _______, _______, _______, _______, _______,  KC_MUTE,  KC_VOLD, KC_VOLU, _______,
-    _______,       _______, _______, DEBUG,   _______, _______, _______, _______, _______, _______,  KC_SCROLLLOCK,  KC_PAUSE, _______,
-    _______,       _______, _______, _______, _______, _______, _______, _______, _______, _______,  _______, _______, _______, _______,
-    _______,       _______, _______,                   _______,                                      _______, _______, _______, _______
-  ),
-}
-;
+  [_FL] = LAYOUT_aek_103(
+    KC_ESC,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_DEL,
+    _______, KC_HOME, KC_UP,   KC_END,  _______, _______, _______, _______, KC_MUTE, _______, _______, KC_PGDN, KC_PGUP, RESET,
+    _______, KC_LEFT, KC_DOWN, KC_RGHT, _______, _______, KC_SLCK, KC_VOLD, KC_VOLU, KC_PAUS, _______, _______, _______,
+    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+    _______, _______, _______,                            _______,                            _______, _______, _______
+  )
+};
 
 const uint16_t PROGMEM fn_actions[] = {};

--- a/keyboards/dz60/keymaps/crd_ansi/keymap.c
+++ b/keyboards/dz60/keymaps/crd_ansi/keymap.c
@@ -20,7 +20,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 		KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSUP,
 		KC_LCTL, KC_LALT, KC_LGUI,                            KC_SPC,                             KC_RGUI, KC_FNLT, KC_RADN, KC_RCRT
 	),
-	[_FL] =LAYOUT_60_ansi(
+	[_FL] = LAYOUT_60_ansi(
 		KC_ESC,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_DEL,
 		_______, KC_HOME, KC_UP,   KC_END,  _______, _______, _______, _______, KC_MUTE, _______, _______, KC_PGDN, KC_PGUP, RESET,
 		_______, KC_LEFT, KC_DOWN, KC_RGHT, _______, _______, KC_SLCK, KC_VOLD, KC_VOLU, KC_PAUS, _______, _______, _______,


### PR DESCRIPTION
In the process of updating my alps64 keymap to match conventions inspired by mechmerlin's dz60 keymap, I also attempted to use what I believe to be a more appropriate layout provided as `LAYOUT_aek_103`. However, I noticed that the layout provided uses an incorrect placement of a couple of keys on the bottom row. I have no sense for how many folks actually use this layout in the real world. I did a grep of the repository and the only other instance of it is an identical definition in the paladin64 tree. If I should rather add a new layout matching the AEK layout that I am using, I am happy to do so. FWIW, the key spacing of the `LAYOUT_aek_103` layout in the `info.json` file appears to match what I am using which is a bottom row of `1.5, 1.25, 1.5,    (space) 6.5,  1.5, 1.25, 1.5`.

Thanks in advance for your feedback. Cheers!