### PR TITLE
Fixed a problem with underglow with froggy keymap

### DIFF
--- a/keyboards/helix/rev2/keymaps/froggy/keymap.c
+++ b/keyboards/helix/rev2/keymaps/froggy/keymap.c
@@ -593,19 +593,39 @@ void matrix_scan_user(void) {
     if(!RGBAnimation){
       switch (layer_state) {
         case L_BASE:
-          led_ripple_effect(0,112,127);
+          #ifdef RGBLED_BACK
+            led_ripple_effect(0,112,127);
+          #else
+            rgblight_setrgb(0,112,127);
+          #endif
           break;
         case L_OPT:
-          led_ripple_effect(127,0,100);
+          #ifdef RGBLED_BACK
+            led_ripple_effect(127,0,100);
+          #else
+            rgblight_setrgb(127,0,100);
+          #endif
           break;
         case L_NUM:
-          led_ripple_effect(127,23,0);
+          #ifdef RGBLED_BACK
+            led_ripple_effect(127,23,0);
+          #else
+            rgblight_setrgb(127,23,0);
+          #endif
           break;
         case L_SYM:
-          led_ripple_effect(0,127,0);
+          #ifdef RGBLED_BACK
+            led_ripple_effect(0,127,0);
+          #else
+            rgblight_setrgb(0,127,0);
+          #endif
           break;
         case L_FUNC:
-          led_ripple_effect(127,0,61);
+          #ifdef RGBLED_BACK
+            led_ripple_effect(127,0,61);
+          #else
+            rgblight_setrgb(127,0,61);
+          #endif
           break;
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- This template is entirely option and can be removed, but is here to help both you and us. -->
<!--- This text and anything on lines wrapped like this one will not show up in the final text. This text is to help us and you. -->

## Description
<!--- Describe your changes in detail -->
Fixed a problem with underglow with froggy keymap

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Core
- [ ] Bugfix
- [ ] New Feature
- [ ] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation


## Issues Fixed or Closed by this PR

* Fixed a problem that keyboard stopped when underglow was used in helix's froggy keymap

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
