### PR TITLE
Document the correct path to the split keyboard EEPROM files

### DIFF
--- a/keyboards/handwired/dactyl_manuform/readme.md
+++ b/keyboards/handwired/dactyl_manuform/readme.md
@@ -131,13 +131,13 @@ file will run on both hands instead of having to flash left and right handed
 versions of the firmware to each half. To flash the EEPROM file for the left
 half run:
 ```
-avrdude -p atmega32u4 -P $(COM_PORT) -c avr109 -U eeprom:w:eeprom-lefthand.eep
+avrdude -p atmega32u4 -P $(COM_PORT) -c avr109 -U eeprom:w:"./quantum/split_common/eeprom-lefthand.eep"
 // or the equivalent in dfu-programmer
 
 ```
 and similarly for right half
 ```
-avrdude -p atmega32u4 -P $(COM_PORT) -c avr109 -U eeprom:w:eeprom-righhand.eep
+avrdude -p atmega32u4 -P $(COM_PORT) -c avr109 -U eeprom:w:"./quantum/split_common/eeprom-righthand.eep"
 // or the equivalent in dfu-programmer
 ```
 

--- a/keyboards/handwired/not_so_minidox/readme.md
+++ b/keyboards/handwired/not_so_minidox/readme.md
@@ -50,13 +50,13 @@ file will run on both hands instead of having to flash left and right handed
 versions of the firmware to each half. To flash the EEPROM file for the left
 half run:
 ```
-avrdude -p atmega32u4 -P $(COM_PORT) -c avr109 -U eeprom:w:eeprom-lefthand.eep
+avrdude -p atmega32u4 -P $(COM_PORT) -c avr109 -U eeprom:w:"./quantum/split_common/eeprom-lefthand.eep"
 // or the equivalent in dfu-programmer
 
 ```
 and similarly for right half
 ```
-avrdude -p atmega32u4 -P $(COM_PORT) -c avr109 -U eeprom:w:eeprom-righhand.eep
+avrdude -p atmega32u4 -P $(COM_PORT) -c avr109 -U eeprom:w:"./quantum/split_common/eeprom-righthand.eep"
 // or the equivalent in dfu-programmer
 ```
 

--- a/keyboards/handwired/xealous/readme.md
+++ b/keyboards/handwired/xealous/readme.md
@@ -130,13 +130,13 @@ file will run on both hands instead of having to flash left and right handed
 versions of the firmware to each half. To flash the EEPROM file for the left
 half run:
 ```
-avrdude -p atmega32u4 -P $(COM_PORT) -c avr109 -U eeprom:w:eeprom-lefthand.eep
+avrdude -p atmega32u4 -P $(COM_PORT) -c avr109 -U eeprom:w:"./quantum/split_common/eeprom-lefthand.eep"
 // or the equivalent in dfu-programmer
 
 ```
 and similarly for right half
 ```
-avrdude -p atmega32u4 -P $(COM_PORT) -c avr109 -U eeprom:w:eeprom-righhand.eep
+avrdude -p atmega32u4 -P $(COM_PORT) -c avr109 -U eeprom:w:"./quantum/split_common/eeprom-righthand.eep"
 // or the equivalent in dfu-programmer
 ```
 

--- a/keyboards/lets_split/readme.md
+++ b/keyboards/lets_split/readme.md
@@ -151,13 +151,13 @@ file will run on both hands instead of having to flash left and right handed
 versions of the firmware to each half. To flash the EEPROM file for the left
 half run:
 ```
-avrdude -p atmega32u4 -P $(COM_PORT) -c avr109 -U eeprom:w:eeprom-lefthand.eep
+avrdude -p atmega32u4 -P $(COM_PORT) -c avr109 -U eeprom:w:"./quantum/split_common/eeprom-lefthand.eep"
 // or the equivalent in dfu-programmer
 
 ```
 and similarly for right half
 ```
-avrdude -p atmega32u4 -P $(COM_PORT) -c avr109 -U eeprom:w:eeprom-righhand.eep
+avrdude -p atmega32u4 -P $(COM_PORT) -c avr109 -U eeprom:w:"./quantum/split_common/eeprom-righthand.eep"
 // or the equivalent in dfu-programmer
 ```
 

--- a/keyboards/minidox/readme.md
+++ b/keyboards/minidox/readme.md
@@ -54,13 +54,13 @@ file will run on both hands instead of having to flash left and right handed
 versions of the firmware to each half. To flash the EEPROM file for the left
 half run:
 ```
-avrdude -p atmega32u4 -P $(COM_PORT) -c avr109 -U eeprom:w:eeprom-lefthand.eep
+avrdude -p atmega32u4 -P $(COM_PORT) -c avr109 -U eeprom:w:"./quantum/split_common/eeprom-lefthand.eep"
 // or the equivalent in dfu-programmer
 
 ```
 and similarly for right half
 ```
-avrdude -p atmega32u4 -P $(COM_PORT) -c avr109 -U eeprom:w:eeprom-righhand.eep
+avrdude -p atmega32u4 -P $(COM_PORT) -c avr109 -U eeprom:w:"./quantum/split_common/eeprom-righthand.eep"
 // or the equivalent in dfu-programmer
 ```
 

--- a/keyboards/orthodox/readme.md
+++ b/keyboards/orthodox/readme.md
@@ -125,7 +125,7 @@ EEPROM for the left and right halves.
 
 The EEPROM is used to store whether the
 half is left handed or right handed. This makes it so that the same firmware
-file will run on both hands instead of having to flash [left](../lets_split/eeprom-lefthand.eep) and [right](../lets_split/eeprom-righthand.eep) handed
+file will run on both hands instead of having to flash [left](../../quantum/split_common/eeprom-lefthand.eep) and [right](../../quantum/split_common/eeprom-righthand.eep) handed
 versions of the firmware to each half. To flash the EEPROM file for the left
 half run:
 ```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- This template is entirely option and can be removed, but is here to help both you and us. -->
<!--- This text and anything on lines wrapped like this one will not show up in the final text. This text is to help us and you. -->

## Description
<!--- Describe your changes in detail -->
This fixes incorrect paths to the split keyboard EEPROM files within the repo.

Other items for potential review:

- Should all references to eeprom files be updated to the full path `./quantum/split_common/eeprom-lefthand.eep` and `./quantum/split_common/eeprom-righthand.eep`?
- ~~Should this PR update the location within `./keyboards/lets_split/keymaps/bbaserdem/README.md`?~~ Not required
- ~~Should this PR remove the other eeprom files within `minidox` and `deltasplit75` so that the only eeprom files are within the common folder?~~ Not required

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Core
- [ ] Bugfix
- [ ] New Feature
- [ ] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [x] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
