### PR TITLE
Allows Terminal to use ModTap/LayerTap keys

### DIFF
--- a/quantum/process_keycode/process_terminal.c
+++ b/quantum/process_keycode/process_terminal.c
@@ -274,7 +274,7 @@ bool process_terminal(uint16_t keycode, keyrecord_t *record) {
             return false;
         }
 
-        if (keycode >= QK_MOD_TAP && keycode <= QK_MOD_TAP_MAX) {
+        if ((keycode >= QK_MOD_TAP && keycode <= QK_MOD_TAP_MAX) || (keycode >= QK_LAYER_TAP && keycode <= QK_LAYER_TAP_MAX)) {
             keycode = keycode & 0xFF;
         }
 

--- a/quantum/process_keycode/process_terminal.c
+++ b/quantum/process_keycode/process_terminal.c
@@ -273,11 +273,17 @@ bool process_terminal(uint16_t keycode, keyrecord_t *record) {
             disable_terminal();
             return false;
         }
+
+        if (keycode >= QK_MOD_TAP && keycode <= QK_MOD_TAP_MAX) {
+            keycode = keycode & 0xFF;
+        }
+
         if (keycode < 256) {
             uint8_t str_len;
             char char_to_add;
             switch (keycode) {
                 case KC_ENTER:
+                case KC_KP_ENTER:
                     push_to_cmd_buffer();
                     current_cmd_buffer_pos = 0;
                     process_terminal_command();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- This template is entirely option and can be removed, but is here to help both you and us. -->
<!--- This text and anything on lines wrapped like this one will not show up in the final text. This text is to help us and you. -->

## Description
This PR fixes issue described in  #4583

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Core
- [x] Bugfix
- [ ] New Feature
- [ ] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation


## Issues Fixed or Closed by this PR

* Fixes #4583

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
