### PR TITLE
handwired/nicekey Refactor and readme cleanup

### DIFF
--- a/keyboards/handwired/nicekey/keymaps/default/keymap.c
+++ b/keyboards/handwired/nicekey/keymaps/default/keymap.c
@@ -71,5 +71,5 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 };
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-  {{ RANDOM_STRING_MACRO }}
+  LAYOUT( RANDOM_STRING_MACRO )
 };

--- a/keyboards/handwired/nicekey/nicekey.h
+++ b/keyboards/handwired/nicekey/nicekey.h
@@ -1,1 +1,12 @@
+#ifndef NICEKEY_H
+#define NICEKEY_H
+
 #include "quantum.h"
+
+#define LAYOUT( \
+    k00 \
+  ) { \
+    { k00 }  \
+}
+
+#endif

--- a/keyboards/handwired/nicekey/readme.md
+++ b/keyboards/handwired/nicekey/readme.md
@@ -5,7 +5,7 @@
 
 Custom handwired nicekey, a one key keyboard that writes random compliments.
 
-Keyboard Maintainer:  spydon  
+Keyboard Maintainer: [spydon](https://github.com/spydon)  
 Hardware Supported: Custom handwired one key  
 Hardware Availability:
 
@@ -15,4 +15,4 @@ Make example for this keyboard (after setting up your build environment):
 
     make handwired/nicekey:default
 
-See [build environment setup](https://docs.qmk.fm/build_environment_setup.html) then the [make instructions](https://docs.qmk.fm/make_instructions.html) for more information.
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).


### PR DESCRIPTION
## handwired/nicekey: refactor (d8a8dce)

Now uses a layout macro.

This keyboard will now be supported in the Configurator with this commit's changes.

## handwired/nicekey: readme cleanup (bb97f9e)

- linked maintainer's GitHub account
- updated Docs links