### PR TITLE
handwired/onekey Refactor and readme update 

### DIFF
--- a/keyboards/handwired/onekey/keymaps/default/keymap.c
+++ b/keyboards/handwired/onekey/keymaps/default/keymap.c
@@ -1,5 +1,5 @@
-#include "onekey.h"
+#include QMK_KEYBOARD_H
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    {{ KC_A }}
+  LAYOUT( KC_A )
 };

--- a/keyboards/handwired/onekey/onekey.h
+++ b/keyboards/handwired/onekey/onekey.h
@@ -1,1 +1,12 @@
+#ifndef ONEKEY_H
+#define ONEKEY_H
+
 #include "quantum.h"
+
+#define LAYOUT( \
+    k00 \
+  ) { \
+    { k00 }  \
+}
+
+#endif

--- a/keyboards/handwired/onekey/readme.md
+++ b/keyboards/handwired/onekey/readme.md
@@ -12,4 +12,4 @@ Make example for this keyboard (after setting up your build environment):
 
     make handwired/onekey:default
 
-See [build environment setup](https://docs.qmk.fm/build_environment_setup.html) then the [make instructions](https://docs.qmk.fm/make_instructions.html) for more information.
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).


### PR DESCRIPTION
## handwired/onekey: refactor (7146af6)

- keyboard now uses a layout macro (enables Configurator to compile for this keyboard)
- keymap now uses #include QMK_KEYBOARD_H

## handwired/onekey: readme update (ed5d311)

Updated Docs links.