### PR TITLE
Fix the LFKeyboards so they work with the QMK Configurator

### DIFF
--- a/keyboards/lfkeyboards/lfk78/keymaps/ca178858/rules.mk
+++ b/keyboards/lfkeyboards/lfk78/keymaps/ca178858/rules.mk
@@ -23,19 +23,6 @@ ISSI_ENABLE = yes			# If the I2C pullup resistors aren't install this must be di
 WATCHDOG_ENABLE = yes		# Resets keyboard if matrix_scan isn't run every 250ms
 
 
-ifndef QUANTUM_DIR
-	include ../../../../Makefile
-endif
-
-ifeq ($(strip $(ISSI_ENABLE)), yes)
-    TMK_COMMON_DEFS += -DISSI_ENABLE
-endif
-
-ifeq ($(strip $(WATCHDOG_ENABLE)), yes)
-    TMK_COMMON_DEFS += -DWATCHDOG_ENABLE
-endif
-
-
 # # Set the LFK78 hardware version. This is defined in rules.mk, but can be overidden here if desired
 # #
 # # RevB - first public release, uses atmega32u4, has audio, ISSI matrix split between RGB and backlight

--- a/keyboards/lfkeyboards/lfk78/keymaps/default/rules.mk
+++ b/keyboards/lfkeyboards/lfk78/keymaps/default/rules.mk
@@ -14,7 +14,7 @@ MIDI_ENABLE = no                # MIDI controls
 AUDIO_ENABLE = yes               # Audio output on port C6
 UNICODE_ENABLE = no             # Unicode
 BLUETOOTH_ENABLE = no           # Enable Bluetooth with the Adafruit EZ-Key HID
-RGBLIGHT_ENABLE = yes           # Enable WS2812 RGB underlight. 
+RGBLIGHT_ENABLE = yes           # Enable WS2812 RGB underlight.
 RGBLIGHT_CUSTOM_DRIVER = yes    # RGB code is implemented in lefkeyboards, not qmk base
 SLEEP_LED_ENABLE = yes          # Breathing sleep LED during USB suspend
 TAP_DANCE_ENABLE = no
@@ -23,21 +23,6 @@ ISSI_ENABLE = yes               # If the I2C pullup resistors aren't install thi
 WATCHDOG_ENABLE = no            # Resets keyboard if matrix_scan isn't run every 250ms
 CAPSLOCK_LED = no              # Toggle back light LED of Caps Lock
 
-ifndef QUANTUM_DIR
-    include ../../../../Makefile
-endif
-
-ifeq ($(strip $(ISSI_ENABLE)), yes)
-    TMK_COMMON_DEFS += -DISSI_ENABLE
-endif
-
-ifeq ($(strip $(WATCHDOG_ENABLE)), yes)
-    TMK_COMMON_DEFS += -DWATCHDOG_ENABLE
-endif
-
-ifeq ($(strip $(CAPSLOCK_LED)), yes)
-    TMK_COMMON_DEFS += -DCAPSLOCK_LED
-endif
 
 # Override the LFK78 hardware version:
 #

--- a/keyboards/lfkeyboards/lfk78/keymaps/iso/rules.mk
+++ b/keyboards/lfkeyboards/lfk78/keymaps/iso/rules.mk
@@ -14,7 +14,7 @@ MIDI_ENABLE = no                # MIDI controls
 AUDIO_ENABLE = yes               # Audio output on port C6
 UNICODE_ENABLE = no             # Unicode
 BLUETOOTH_ENABLE = no           # Enable Bluetooth with the Adafruit EZ-Key HID
-RGBLIGHT_ENABLE = yes           # Enable WS2812 RGB underlight. 
+RGBLIGHT_ENABLE = yes           # Enable WS2812 RGB underlight.
 RGBLIGHT_CUSTOM_DRIVER = yes    # RGB code is implemented in lefkeyboards, not qmk base
 SLEEP_LED_ENABLE = yes          # Breathing sleep LED during USB suspend
 TAP_DANCE_ENABLE = no
@@ -22,18 +22,6 @@ TAP_DANCE_ENABLE = no
 ISSI_ENABLE = yes           # If the I2C pullup resistors aren't install this must be disabled
 WATCHDOG_ENABLE = no       # Resets keyboard if matrix_scan isn't run every 250ms
 
-
-ifndef QUANTUM_DIR
-    include ../../../../Makefile
-endif
-
-ifeq ($(strip $(ISSI_ENABLE)), yes)
-    TMK_COMMON_DEFS += -DISSI_ENABLE
-endif
-
-ifeq ($(strip $(WATCHDOG_ENABLE)), yes)
-    TMK_COMMON_DEFS += -DWATCHDOG_ENABLE
-endif
 
 
 # # Set the LFK78 hardware version. This is defined in rules.mk, but can be overidden here if desired

--- a/keyboards/lfkeyboards/lfk78/keymaps/split_bs_osx/rules.mk
+++ b/keyboards/lfkeyboards/lfk78/keymaps/split_bs_osx/rules.mk
@@ -14,7 +14,7 @@ MIDI_ENABLE = no                # MIDI controls
 AUDIO_ENABLE = yes               # Audio output on port C6
 UNICODE_ENABLE = no             # Unicode
 BLUETOOTH_ENABLE = no           # Enable Bluetooth with the Adafruit EZ-Key HID
-RGBLIGHT_ENABLE = yes           # Enable WS2812 RGB underlight. 
+RGBLIGHT_ENABLE = yes           # Enable WS2812 RGB underlight.
 RGBLIGHT_CUSTOM_DRIVER = yes    # RGB code is implemented in lefkeyboards, not qmk base
 SLEEP_LED_ENABLE = yes          # Breathing sleep LED during USB suspend
 TAP_DANCE_ENABLE = no
@@ -22,22 +22,6 @@ TAP_DANCE_ENABLE = no
 ISSI_ENABLE = yes               # If the I2C pullup resistors aren't install this must be disabled
 WATCHDOG_ENABLE = no            # Resets keyboard if matrix_scan isn't run every 250ms
 CAPSLOCK_LED = no              # Toggle back light LED of Caps Lock
-
-ifndef QUANTUM_DIR
-    include ../../../../Makefile
-endif
-
-ifeq ($(strip $(ISSI_ENABLE)), yes)
-    TMK_COMMON_DEFS += -DISSI_ENABLE
-endif
-
-ifeq ($(strip $(WATCHDOG_ENABLE)), yes)
-    TMK_COMMON_DEFS += -DWATCHDOG_ENABLE
-endif
-
-ifeq ($(strip $(CAPSLOCK_LED)), yes)
-    TMK_COMMON_DEFS += -DCAPSLOCK_LED
-endif
 
 # Override the LFK78 hardware version:
 #

--- a/keyboards/lfkeyboards/lfk78/lfk78.c
+++ b/keyboards/lfkeyboards/lfk78/lfk78.c
@@ -13,6 +13,15 @@ uint16_t click_hz = CLICK_HZ;
 uint16_t click_time = CLICK_MS;
 uint8_t click_toggle = CLICK_ENABLED;
 
+__attribute__((weak))
+const Layer_Info layer_info[] = {
+  // Layer     Mask           Red     Green   Blue
+  {0x00000000, 0xFFFFFFFF, {0x0000, 0x0FFF, 0x0000}}, // base layer - green
+  {0x00000002, 0xFFFFFFFE, {0x0000, 0x0000, 0x0FFF}}, // function layer - blue
+  {0x00000004, 0xFFFFFFFC, {0x0FFF, 0x0000, 0x0FFF}}, // settings layer - magenta
+  {0xFFFFFFFF, 0xFFFFFFFF, {0x0FFF, 0x0FFF, 0x0FFF}}, // unknown layer - REQUIRED - white
+};
+
 void matrix_init_kb(void)
 {
     matrix_init_user();

--- a/keyboards/lfkeyboards/lfk78/rules.mk
+++ b/keyboards/lfkeyboards/lfk78/rules.mk
@@ -32,3 +32,52 @@ F_USB = $(F_CPU)
 
 # Interrupt driven control endpoint task(+60)
 OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
+
+BOOTMAGIC_ENABLE = no           # Virtual DIP switch configuration(+1000)
+MOUSEKEY_ENABLE = no            # Mouse keys(+4700)
+EXTRAKEY_ENABLE = yes           # Audio control and System control(+450)
+CONSOLE_ENABLE = no             # Console for debug(+400)
+COMMAND_ENABLE = no             # Commands for debug and configuration
+NKRO_ENABLE = yes               # Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+BACKLIGHT_ENABLE = yes          # Enable keyboard backlight functionality
+MIDI_ENABLE = no                # MIDI controls
+AUDIO_ENABLE = yes               # Audio output on port C6
+UNICODE_ENABLE = no             # Unicode
+BLUETOOTH_ENABLE = no           # Enable Bluetooth with the Adafruit EZ-Key HID
+RGBLIGHT_ENABLE = yes           # Enable WS2812 RGB underlight.
+RGBLIGHT_CUSTOM_DRIVER = yes    # RGB code is implemented in lefkeyboards, not qmk base
+SLEEP_LED_ENABLE = yes          # Breathing sleep LED during USB suspend
+TAP_DANCE_ENABLE = no
+
+ISSI_ENABLE = yes               # If the I2C pullup resistors aren't install this must be disabled
+WATCHDOG_ENABLE = no            # Resets keyboard if matrix_scan isn't run every 250ms
+CAPSLOCK_LED = no              # Toggle back light LED of Caps Lock
+
+
+ifeq ($(strip $(ISSI_ENABLE)), yes)
+    TMK_COMMON_DEFS += -DISSI_ENABLE
+endif
+
+ifeq ($(strip $(WATCHDOG_ENABLE)), yes)
+    TMK_COMMON_DEFS += -DWATCHDOG_ENABLE
+endif
+
+ifeq ($(strip $(CAPSLOCK_LED)), yes)
+    TMK_COMMON_DEFS += -DCAPSLOCK_LED
+endif
+
+# # Set the LFK78 hardware version. This is defined in rules.mk, but can be overidden here if desired
+# #
+# # RevB - first public release, uses atmega32u4, has audio, ISSI matrix split between RGB and backlight
+# # RevC/D - at90usb1286, no audio, ISSI device 0 is backlight, 4 is RGB
+# #
+# # Set to B, C or D
+# LFK_REV = D
+
+# ifeq ($(LFK_REV), B)
+#   MCU = atmega32u4
+# else
+#   MCU = at90usb1286
+# endif
+# OPT_DEFS += -DLFK_REV_$(LFK_REV)
+# OPT_DEFS += -DUSB_PRODUCT=\"LFK_Rev$(LFK_REV)\"

--- a/keyboards/lfkeyboards/lfk87/keymaps/ca178858/rules.mk
+++ b/keyboards/lfkeyboards/lfk87/keymaps/ca178858/rules.mk
@@ -23,17 +23,6 @@ ISSI_ENABLE = yes			# If the I2C pullup resistors aren't install this must be di
 WATCHDOG_ENABLE = yes		# Resets keyboard if matrix_scan isn't run every 250ms
 
 
-ifndef QUANTUM_DIR
-	include ../../../../Makefile
-endif
-
-ifeq ($(strip $(ISSI_ENABLE)), yes)
-    TMK_COMMON_DEFS += -DISSI_ENABLE
-endif
-
-ifeq ($(strip $(WATCHDOG_ENABLE)), yes)
-    TMK_COMMON_DEFS += -DWATCHDOG_ENABLE
-endif
 
 
 # # Set the LFK78 hardware version. This is defined in rules.mk, but can be overidden here if desired

--- a/keyboards/lfkeyboards/lfk87/keymaps/default/rules.mk
+++ b/keyboards/lfkeyboards/lfk87/keymaps/default/rules.mk
@@ -23,17 +23,6 @@ ISSI_ENABLE = yes			# If the I2C pullup resistors aren't install this must be di
 WATCHDOG_ENABLE = no		# Resets keyboard if matrix_scan isn't run every 250ms
 
 
-ifndef QUANTUM_DIR
-	include ../../../../Makefile
-endif
-
-ifeq ($(strip $(ISSI_ENABLE)), yes)
-    TMK_COMMON_DEFS += -DISSI_ENABLE
-endif
-
-ifeq ($(strip $(WATCHDOG_ENABLE)), yes)
-    TMK_COMMON_DEFS += -DWATCHDOG_ENABLE
-endif
 
 
 # Override the LFK87 hardware version.

--- a/keyboards/lfkeyboards/lfk87/keymaps/gbchk/rules.mk
+++ b/keyboards/lfkeyboards/lfk87/keymaps/gbchk/rules.mk
@@ -23,19 +23,6 @@ ISSI_ENABLE = yes			# If the I2C pullup resistors aren't install this must be di
 WATCHDOG_ENABLE = no		# Resets keyboard if matrix_scan isn't run every 250ms
 
 
-ifndef QUANTUM_DIR
-	include ../../../../Makefile
-endif
-
-ifeq ($(strip $(ISSI_ENABLE)), yes)
-    TMK_COMMON_DEFS += -DISSI_ENABLE
-endif
-
-ifeq ($(strip $(WATCHDOG_ENABLE)), yes)
-    TMK_COMMON_DEFS += -DWATCHDOG_ENABLE
-endif
-
-
 # Override the LFK87 hardware version.
 #
 # A - Green PCB. at90usb1286 Only 3 exist

--- a/keyboards/lfkeyboards/lfk87/keymaps/iso/rules.mk
+++ b/keyboards/lfkeyboards/lfk87/keymaps/iso/rules.mk
@@ -23,17 +23,6 @@ ISSI_ENABLE = yes               # If the I2C pullup resistors aren't install thi
 WATCHDOG_ENABLE = no           # Resets keyboard if matrix_scan isn't run every 250ms
 
 
-ifndef QUANTUM_DIR
-	include ../../../../Makefile
-endif
-
-ifeq ($(strip $(ISSI_ENABLE)), yes)
-    TMK_COMMON_DEFS += -DISSI_ENABLE
-endif
-
-ifeq ($(strip $(WATCHDOG_ENABLE)), yes)
-    TMK_COMMON_DEFS += -DWATCHDOG_ENABLE
-endif
 
 
 # # Set the LFK78 hardware version. This is defined in rules.mk, but can be overidden here if desired

--- a/keyboards/lfkeyboards/lfk87/lfk87.c
+++ b/keyboards/lfkeyboards/lfk87/lfk87.c
@@ -14,6 +14,15 @@ uint16_t click_hz = CLICK_HZ;
 uint16_t click_time = CLICK_MS;
 uint8_t click_toggle = CLICK_ENABLED;
 
+__attribute__((weak))
+const Layer_Info layer_info[] = {
+    // Layer     Mask           Red     Green   Blue
+    {0x00000000, 0xFFFFFFFF, {0x00, 0xFF, 0x00}}, // base layers - green
+    {0x00000002, 0xFFFFFFFE, {0x00, 0x00, 0xFF}}, // function layer - blue
+    {0x00000004, 0xFFFFFFFC, {0xFF, 0x00, 0xFF}}, // settings layer - magenta
+    {0xFFFFFFFF, 0xFFFFFFFF, {0xFF, 0xFF, 0xFF}}, // unknown layer - REQUIRED - white
+};
+
 void matrix_init_kb(void)
 {
     // put your keyboard start-up code here

--- a/keyboards/lfkeyboards/lfk87/rules.mk
+++ b/keyboards/lfkeyboards/lfk87/rules.mk
@@ -31,3 +31,37 @@ F_USB = $(F_CPU)
 OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
 
 LAYOUTS = tkl_ansi tkl_iso
+
+# Build Options
+#   change to "no" to disable the options, or define them in the Makefile in
+#   the appropriate keymap folder that will get included automatically
+#
+
+BOOTMAGIC_ENABLE = no           # Virtual DIP switch configuration(+1000)
+MOUSEKEY_ENABLE = no            # Mouse keys(+4700)
+EXTRAKEY_ENABLE = yes           # Audio control and System control(+450)
+CONSOLE_ENABLE = no             # Console for debug(+400)
+COMMAND_ENABLE = no             # Commands for debug and configuration
+NKRO_ENABLE = yes               # Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+BACKLIGHT_ENABLE = yes           # Enable keyboard backlight functionality
+MIDI_ENABLE = no                # MIDI controls
+AUDIO_ENABLE = yes              # Audio output on port C6
+UNICODE_ENABLE = no             # Unicode
+BLUETOOTH_ENABLE = no           # Enable Bluetooth with the Adafruit EZ-Key HID
+RGBLIGHT_ENABLE = yes           # Enable RGB underlight
+RGBLIGHT_CUSTOM_DRIVER = yes    # RGB code is implemented in lefkeyboards, not WS2812
+SLEEP_LED_ENABLE = yes          # Breathing sleep LED during USB suspend
+TAP_DANCE_ENABLE = no
+
+ISSI_ENABLE = yes			# If the I2C pullup resistors aren't install this must be disabled
+WATCHDOG_ENABLE = no		# Resets keyboard if matrix_scan isn't run every 250ms
+
+
+
+ifeq ($(strip $(ISSI_ENABLE)), yes)
+    OPT_DEFS += -DISSI_ENABLE
+endif
+
+ifeq ($(strip $(WATCHDOG_ENABLE)), yes)
+    OPT_DEFS += -DWATCHDOG_ENABLE
+endif

--- a/keyboards/lfkeyboards/lfkpad/keymaps/default/rules.mk
+++ b/keyboards/lfkeyboards/lfkpad/keymaps/default/rules.mk
@@ -14,7 +14,7 @@ MIDI_ENABLE = no                # MIDI controls
 AUDIO_ENABLE = no               # Audio output on port C6
 UNICODE_ENABLE = no             # Unicode
 BLUETOOTH_ENABLE = no           # Enable Bluetooth with the Adafruit EZ-Key HID
-RGBLIGHT_ENABLE = yes           # Enable WS2812 RGB underlight. 
+RGBLIGHT_ENABLE = yes           # Enable WS2812 RGB underlight.
 RGBLIGHT_CUSTOM_DRIVER = yes    # RGB code is implemented in lefkeyboards, not qmk base
 SLEEP_LED_ENABLE = yes          # Breathing sleep LED during USB suspend
 TAP_DANCE_ENABLE = no
@@ -23,17 +23,6 @@ ISSI_ENABLE = yes           # If the I2C pullup resistors aren't install this mu
 WATCHDOG_ENABLE = no       # Resets keyboard if matrix_scan isn't run every 250ms
 
 
-ifndef QUANTUM_DIR
-    include ../../../../Makefile
-endif
-
-ifeq ($(strip $(ISSI_ENABLE)), yes)
-    TMK_COMMON_DEFS += -DISSI_ENABLE
-endif
-
-ifeq ($(strip $(WATCHDOG_ENABLE)), yes)
-    TMK_COMMON_DEFS += -DWATCHDOG_ENABLE
-endif
 
 
 # # Set the LFK78 hardware version. This is defined in rules.mk, but can be overidden here if desired

--- a/keyboards/lfkeyboards/lfkpad/rules.mk
+++ b/keyboards/lfkeyboards/lfkpad/rules.mk
@@ -11,3 +11,31 @@ ARCH = AVR8
 OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
 
 LAYOUTS = numpad_6x4
+
+BOOTMAGIC_ENABLE = no           # Virtual DIP switch configuration(+1000)
+MOUSEKEY_ENABLE = no            # Mouse keys(+4700)
+EXTRAKEY_ENABLE = yes           # Audio control and System control(+450)
+CONSOLE_ENABLE = no             # Console for debug(+400)
+COMMAND_ENABLE = no             # Commands for debug and configuration
+NKRO_ENABLE = no               # Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+BACKLIGHT_ENABLE = no          # Enable keyboard backlight functionality
+MIDI_ENABLE = no                # MIDI controls
+AUDIO_ENABLE = no               # Audio output on port C6
+UNICODE_ENABLE = no             # Unicode
+BLUETOOTH_ENABLE = no           # Enable Bluetooth with the Adafruit EZ-Key HID
+RGBLIGHT_ENABLE = yes           # Enable WS2812 RGB underlight.
+RGBLIGHT_CUSTOM_DRIVER = yes    # RGB code is implemented in lefkeyboards, not qmk base
+SLEEP_LED_ENABLE = yes          # Breathing sleep LED during USB suspend
+TAP_DANCE_ENABLE = no
+
+ISSI_ENABLE = yes           # If the I2C pullup resistors aren't install this must be disabled
+WATCHDOG_ENABLE = no       # Resets keyboard if matrix_scan isn't run every 250ms
+
+
+ifeq ($(strip $(ISSI_ENABLE)), yes)
+    TMK_COMMON_DEFS += -DISSI_ENABLE
+endif
+
+ifeq ($(strip $(WATCHDOG_ENABLE)), yes)
+    TMK_COMMON_DEFS += -DWATCHDOG_ENABLE
+endif

--- a/keyboards/lfkeyboards/mini1800/keymaps/ca178858/rules.mk
+++ b/keyboards/lfkeyboards/mini1800/keymaps/ca178858/rules.mk
@@ -23,9 +23,6 @@ ISSI_ENABLE = yes			# If the I2C pullup resistors aren't install this must be di
 WATCHDOG_ENABLE = yes		# Resets keyboard if matrix_scan isn't run every 250ms
 
 
-ifndef QUANTUM_DIR
-	include ../../../../Makefile
-endif
 
 ifeq ($(strip $(ISSI_ENABLE)), yes)
     TMK_COMMON_DEFS += -DISSI_ENABLE

--- a/keyboards/lfkeyboards/mini1800/keymaps/default/rules.mk
+++ b/keyboards/lfkeyboards/mini1800/keymaps/default/rules.mk
@@ -23,10 +23,6 @@ ISSI_ENABLE = yes			# If the I2C pullup resistors aren't install this must be di
 WATCHDOG_ENABLE = yes		# Resets keyboard if matrix_scan isn't run every 250ms
 
 
-ifndef QUANTUM_DIR
-	include ../../../../Makefile
-endif
-
 ifeq ($(strip $(ISSI_ENABLE)), yes)
     TMK_COMMON_DEFS += -DISSI_ENABLE
 endif

--- a/keyboards/lfkeyboards/mini1800/mini1800.c
+++ b/keyboards/lfkeyboards/mini1800/mini1800.c
@@ -17,6 +17,16 @@ uint16_t click_time = CLICK_MS;
 uint8_t click_toggle = CLICK_ENABLED;
 float my_song[][2] = SONG(ZELDA_PUZZLE);
 
+// Colors of the layer indicator LED
+// This list needs to define layer 0xFFFFFFFF, it is the end of the list, and the unknown layer
+__attribute__((weak))
+const Layer_Info layer_info[] = {
+    // Layer     Mask           Red     Green   Blue
+    {0x00000000, 0xFFFFFFFF, {0x00, 0xFF, 0x00}}, // base layers - green
+    {0x00000002, 0xFFFFFFFE, {0x00, 0x00, 0xFF}}, // function layer - blue
+    {0x00000004, 0xFFFFFFFC, {0xFF, 0x00, 0xFF}}, // settings layer - magenta
+    {0xFFFFFFFF, 0xFFFFFFFF, {0xFF, 0xFF, 0xFF}}, // unknown layer - REQUIRED - white
+};
 
 void matrix_init_kb(void)
 {


### PR DESCRIPTION
The keyboards need the `layer_info` const to be defined, but it was only defined in the keymap.  So when using the QMK Configurator, it would simply not work. 

Defining it weakly in the keyboard's c file fixes the compiler issue. 

