### PR TITLE
adjust install_avr function to use unzip for broader compatibility

### DIFF
--- a/util/msys2_install.sh
+++ b/util/msys2_install.sh
@@ -14,8 +14,9 @@ source "$dir/win_shared_install.sh"
 function install_avr {
     rm -f -r "$avrtools"
     wget "http://ww1.microchip.com/downloads/en/DeviceDoc/avr8-gnu-toolchain-3.6.1.1752-win32.any.x86.zip"
-    7z x avr8-gnu-toolchain-3.6.1.1752-win32.any.x86.zip
-    mv avr8-gnu-toolchain-win32_x86/ avr8-gnu-toolchain
+    echo "Extracting AVR toolchain..."
+	unzip -q avr8-gnu-toolchain-3.6.1.1752-win32.any.x86.zip
+	mv avr8-gnu-toolchain-win32_x86/ avr8-gnu-toolchain
     rm __MACOSX -R
     rm avr8-gnu-toolchain-3.6.1.1752-win32.any.x86.zip
     pacman --needed -S mingw-w64-x86_64-avrdude


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- This template is entirely option and can be removed, but is here to help both you and us. -->
<!--- This text and anything on lines wrapped like this one will not show up in the final text. This text is to help us and you. -->

## Description
On a laptop with god knows what mandatory security software (Cylance?), running up-to-date Windows 10 with msys2 mingw-64, attempting to install the AVR toolkit results in the following error:

```
1 [main] 7z (13316) C:\msys32\usr\lib\p7zip\7z.exe: *** fatal error - cygheap base mismatch detected - 0x612A5410/0x2375410.
This problem is probably due to using incompatible versions of the cygwin DLL.
Search for cygwin1.dll using the Windows Start->Find/Search facility
and delete all but the most recent version.  The most recent version *should*
reside in x:\cygwin\bin, where 'x' is the drive on which you have
installed the cygwin distribution.  Rebooting is also suggested if you
are unable to find another cygwin DLL.
```

This appears to be related in some way, based on my research, to ASLR functionality in security software. Since I'm unable to override whatever is enforcing ASLR on my system, after trying several other approaches (removing other copies of msys-2.0.dll, which is what this is apparently actually referencing, rebasing that file in Windows to address 0x61000000, a few other things) I simply edited the installation shell script to use `unzip` instead of 7zip; `unzip`'s binary does not provoke a mismatch error and the installation proceeds as it should.

I'm not aware of the reason why some parts of the install script use `unzip` (e.g. `install_arm`) and others use 7zip, but it seems that for broader compatibility and sparing users on locked down machines the 120 minutes or so of futzing this took me to fix, it might be better to just use `unzip` in all cases.

Note: There is another function that uses 7zip, `extract_flip`. The line is `7z -oflip x FlipInstaller.exe`. I'm not sure what this is doing, or whether it's possible to do it with `unzip`, but it produces the same error. I haven't attempted to fix that in this PR, but it might be good to fix it for the same reason.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Core
- [ ] Bugfix
- [ ] New Feature
- [x] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation


## Issues Fixed or Closed by this PR

* None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] (n/a AFAICT) I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
