### PR TITLE
Fix ATSAM's USB HID descriptor to support higher keycodes

### DIFF
--- a/tmk_core/protocol/arm_atsam/usb/udi_hid_kbd.c
+++ b/tmk_core/protocol/arm_atsam/usb/udi_hid_kbd.c
@@ -109,7 +109,7 @@ UDC_DESC_STORAGE udi_hid_kbd_report_desc_t udi_hid_kbd_report_desc = {
         0x81, 0x02,     //   Input (Data, Variable, Absolute)
         0x81, 0x01,     //   Input (Constant)
         0x19, 0x00,     //   Usage Minimum (0)
-        0x29, 0x65,     //   Usage Maximum (101)
+        0x29, 0xE7,     //   Usage Maximum (231)
         0x15, 0x00,     //   Logical Minimum (0)
         0x25, 0x65,     //   Logical Maximum (101)
         0x75, 0x08,     //   Report Size (8)


### PR DESCRIPTION
Assuming I understand this correctly, this should set the max scancode to E7 (RGUI), which is the last listed code in the main list (everything else use for internal QMK/TMK stuff).

fixes #4597 and fixes #4548