### PR TITLE
handwired/pilcrow Refactor, Configurator support and readme update

### DIFF
--- a/keyboards/handwired/pilcrow/info.json
+++ b/keyboards/handwired/pilcrow/info.json
@@ -1,0 +1,53 @@
+{
+  "keyboard_name": "pilcrow",
+  "url": "",
+  "maintainer": "qmk",
+  "width": 10,
+  "height": 4,
+  "layouts": {
+    "LAYOUT": {
+      "layout": [
+        {"label":"Q", "x":0, "y":0},
+        {"label":"W", "x":1, "y":0},
+        {"label":"E", "x":2, "y":0},
+        {"label":"R", "x":3, "y":0},
+        {"label":"T", "x":4, "y":0},
+        {"label":"Y", "x":5, "y":0},
+        {"label":"U", "x":6, "y":0},
+        {"label":"I", "x":7, "y":0},
+        {"label":"O", "x":8, "y":0},
+        {"label":"P", "x":9, "y":0},
+        {"label":"A", "x":0, "y":1},
+        {"label":"S", "x":1, "y":1},
+        {"label":"D", "x":2, "y":1},
+        {"label":"F", "x":3, "y":1},
+        {"label":"G", "x":4, "y":1},
+        {"label":"H", "x":5, "y":1},
+        {"label":"J", "x":6, "y":1},
+        {"label":"K", "x":7, "y":1},
+        {"label":"L", "x":8, "y":1},
+        {"label":";", "x":9, "y":1},
+        {"label":"Z", "x":0, "y":2},
+        {"label":"X", "x":1, "y":2},
+        {"label":"C", "x":2, "y":2},
+        {"label":"V", "x":3, "y":2},
+        {"label":"B", "x":4, "y":2},
+        {"label":"N", "x":5, "y":2},
+        {"label":"M", "x":6, "y":2},
+        {"label":",", "x":7, "y":2},
+        {"label":".", "x":8, "y":2},
+        {"label":"/", "x":9, "y":2},
+        {"label":"Ctrl", "x":0, "y":3},
+        {"label":"Alt", "x":1, "y":3},
+        {"label":"GUI", "x":2, "y":3},
+        {"label":"MO(1)", "x":3, "y":3},
+        {"label":"Space", "x":4, "y":3},
+        {"label":"Shift / Space", "x":5, "y":3},
+        {"label":"MO(2)", "x":6, "y":3},
+        {"label":"MO(3)", "x":7, "y":3},
+        {"label":"Delete", "x":8, "y":3},
+        {"label":"Esc", "x":9, "y":3}
+      ]
+    }
+  }
+}

--- a/keyboards/handwired/pilcrow/keymaps/default/config.h
+++ b/keyboards/handwired/pilcrow/keymaps/default/config.h
@@ -1,8 +1,3 @@
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "../../config.h"
+#pragma once
 
 // place overrides here
-
-#endif

--- a/keyboards/handwired/pilcrow/keymaps/default/keymap.c
+++ b/keyboards/handwired/pilcrow/keymaps/default/keymap.c
@@ -1,75 +1,57 @@
-#include "pilcrow.h"
-#define _______ KC_TRNS
+#include QMK_KEYBOARD_H
+
+#define SFT_SPC MT(MOD_LSFT, KC_SPC)
+
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-[0] = KEYMAP( \
-  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P, \
-  KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, \
-  KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, \
-  KC_LCTL, KC_LALT, KC_LGUI, MO(1),   KC_SPC,  MT(MOD_LSFT, KC_SPC), MO(2),   MO(3),   KC_DEL, KC_ESC \
-),
+  [0] = LAYOUT( \
+    KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    \
+    KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, \
+    KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, \
+    KC_LCTL, KC_LALT, KC_LGUI, MO(1),   KC_SPC,  SFT_SPC, MO(2),   MO(3),   KC_DEL,  KC_ESC   \
+  ),
 
-/* Colemak
- * ,-----------------------------------------------------------------------------------.
- * | Tab  |   Q  |   W  |   F  |   P  |   G  |   J  |   L  |   U  |   Y  |   ;  | Bksp |
- * |------+------+------+------+------+-------------+------+------+------+------+------|
- * | Esc  |   A  |   R  |   S  |   T  |   D  |   H  |   N  |   E  |   I  |   O  |  "   |
- * |------+------+------+------+------+------|------+------+------+------+------+------|
- * | Shift|   Z  |   X  |   C  |   V  |   B  |   K  |   M  |   ,  |   .  |   /  |Enter |
- * |------+------+------+------+------+------+------+------+------+------+------+------|
- * |Adjust| Ctrl | Alt  | GUI  |Lower |Space |Space |Raise | Left | Down |  Up  |Right |
- * `-----------------------------------------------------------------------------------'
- */
-[1] = KEYMAP( \
-  KC_EXLM, KC_AT,   KC_HASH, KC_DLR,  KC_PERC, KC_CIRC, KC_AMPR, KC_ASTR, KC_LPRN, KC_RPRN, \
-  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_UNDS, KC_PLUS, KC_LCBR, KC_RCBR, \
-  KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,S(KC_NUHS),S(KC_NUBS),KC_PIPE, S(KC_QUOT), \
-  _______, _______, _______, _______, KC_BSPC, KC_BSPC, _______, KC_MNXT, KC_VOLD, KC_GRV \
-),
-[2] = KEYMAP( \
-  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0, \
-  KC_TAB,  KC_LEFT, KC_DOWN, KC_UP,   KC_RIGHT,KC_F6,   KC_MINS, KC_EQL,  KC_LBRC, KC_RBRC, \
-  OSM(MOD_LSFT),  KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_NUHS, KC_NUBS, KC_BSLS, KC_QUOT, \
-  _______, _______, _______, _______, KC_ENT,  KC_ENT,  _______, KC_MNXT, KC_VOLD, KC_VOLU \
-),
+  /* Colemak
+   * ,-----------------------------------------------------------------------------------.
+   * | Tab  |   Q  |   W  |   F  |   P  |   G  |   J  |   L  |   U  |   Y  |   ;  | Bksp |
+   * |------+------+------+------+------+-------------+------+------+------+------+------|
+   * | Esc  |   A  |   R  |   S  |   T  |   D  |   H  |   N  |   E  |   I  |   O  |  "   |
+   * |------+------+------+------+------+------|------+------+------+------+------+------|
+   * | Shift|   Z  |   X  |   C  |   V  |   B  |   K  |   M  |   ,  |   .  |   /  |Enter |
+   * |------+------+------+------+------+------+------+------+------+------+------+------|
+   * |Adjust| Ctrl | Alt  | GUI  |Lower |Space |Space |Raise | Left | Down |  Up  |Right |
+   * `-----------------------------------------------------------------------------------'
+   */
+  [1] = LAYOUT( \
+    KC_EXLM, KC_AT,   KC_HASH, KC_DLR,  KC_PERC, KC_CIRC, KC_AMPR,    KC_ASTR,    KC_LPRN, KC_RPRN,    \
+    KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_UNDS,    KC_PLUS,    KC_LCBR, KC_RCBR,    \
+    KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  S(KC_NUHS), S(KC_NUBS), KC_PIPE, S(KC_QUOT), \
+    _______, _______, _______, _______, KC_BSPC, KC_BSPC, _______,    KC_MNXT,    KC_VOLD, KC_GRV      \
+  ),
+  [2] = LAYOUT( \
+    KC_1,          KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    \
+    KC_TAB,        KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT, KC_F6,   KC_MINS, KC_EQL,  KC_LBRC, KC_RBRC, \
+    OSM(MOD_LSFT), KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_NUHS, KC_NUBS, KC_BSLS, KC_QUOT, \
+    _______,       _______, _______, _______, KC_ENT,  KC_ENT,  _______, KC_MNXT, KC_VOLD, KC_VOLU  \
+  ),
 
-/* Adjust (Lower + Raise)
- * ,-----------------------------------------------------------------------------------.
- * |      | Reset|      |      |      |      |      |      |      |      |      |  Del |
- * |------+------+------+------+------+-------------+------+------+------+------+------|
- * |      |      |      |Aud on|Audoff|AGnorm|AGswap|Qwerty|Colemk|Dvorak|      |      |
- * |------+------+------+------+------+------|------+------+------+------+------+------|
- * |      |      |      |      |      |      |      |      |      |      |      |      |
- * |------+------+------+------+------+------+------+------+------+------+------+------|
- * |      |      |      |      |      |             |      |      |      |      |      |
- * `-----------------------------------------------------------------------------------'
- */
-[3] =  KEYMAP( \
-  RESET,   KC_UP, _______, _______, _______, _______, _______, KC_MS_WH_DOWN, KC_MS_U, KC_MS_WH_UP, \
-  KC_LEFT, KC_DOWN, KC_RIGHT, AU_ON,   AU_OFF,  AG_NORM, AG_SWAP, KC_MS_L,KC_MS_D, KC_MS_R, \
-  RGB_TOG, RGB_MOD, RGB_HUI, RGB_HUD, RGB_SAI, RGB_SAD, RGB_VAI, RGB_VAD, _______, _______, \
-  _______, _______, _______, _______, KC_MS_BTN1, KC_MS_BTN2, _______, _______, _______, _______ \
-)
+  /* Adjust (Lower + Raise)
+   * ,-----------------------------------------------------------------------------------.
+   * |      | Reset|      |      |      |      |      |      |      |      |      |  Del |
+   * |------+------+------+------+------+-------------+------+------+------+------+------|
+   * |      |      |      |Aud on|Audoff|AGnorm|AGswap|Qwerty|Colemk|Dvorak|      |      |
+   * |------+------+------+------+------+------|------+------+------+------+------+------|
+   * |      |      |      |      |      |      |      |      |      |      |      |      |
+   * |------+------+------+------+------+------+------+------+------+------+------+------|
+   * |      |      |      |      |      |             |      |      |      |      |      |
+   * `-----------------------------------------------------------------------------------'
+   */
+  [3] =  LAYOUT( \
+    RESET,   KC_UP,   _______, _______, _______, _______, _______, KC_WH_D, KC_MS_U, KC_WH_U, \
+    KC_LEFT, KC_DOWN, KC_RGHT, AU_ON,   AU_OFF,  AG_NORM, AG_SWAP, KC_MS_L, KC_MS_D, KC_MS_R, \
+    RGB_TOG, RGB_MOD, RGB_HUI, RGB_HUD, RGB_SAI, RGB_SAD, RGB_VAI, RGB_VAD, _______, _______, \
+    _______, _______, _______, _______, KC_BTN1, KC_BTN2, _______, _______, _______, _______  \
+  )
 };
-
-const uint16_t PROGMEM fn_actions[] = {
-
-};
-
-const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
-{
-  // MACRODOWN only works in this function
-      switch(id) {
-        case 0:
-          if (record->event.pressed) {
-            register_code(KC_RSFT);
-          } else {
-            unregister_code(KC_RSFT);
-          }
-        break;
-      }
-    return MACRO_NONE;
-};
-
 
 void matrix_init_user(void) {
 

--- a/keyboards/handwired/pilcrow/pilcrow.h
+++ b/keyboards/handwired/pilcrow/pilcrow.h
@@ -7,7 +7,7 @@
 // The following is an example using the Planck MIT layout
 // The first section contains all of the arguements
 // The second converts the arguments into a two-dimensional array
-#define KEYMAP( \
+#define LAYOUT( \
     k00, k01, k02, k03, k04, k05, k06, k07, k08, k09, \
     k10, k11, k12, k13, k14, k15, k16, k17, k18, k19, \
     k20, k21, k22, k23, k24, k25, k26, k27, k28, k29, \

--- a/keyboards/handwired/pilcrow/readme.md
+++ b/keyboards/handwired/pilcrow/readme.md
@@ -1,28 +1,14 @@
-pilcrow keyboard firmware
-======================
+# pilcrow
 
-## Quantum MK Firmware
+![pilcrow](https://i.imgur.com/KQdn2kg.jpg)
 
-For the full Quantum feature list, see [the parent readme](/).
+A 4x10 ortholinear keyboard powered by a Teensy.
 
-## Building
+Keyboard Maintainer: [The QMK Community](https://github.com/qmk)  
+Hardware Supported: Teensy-powered pilcrow 
 
-Download or clone the whole firmware and navigate to the keyboards/pilcrow folder. Once your dev env is setup, you'll be able to type `make` to generate your .hex - you can then use the Teensy Loader to program your .hex file. 
+Make example for this keyboard (after setting up your build environment):
 
-Depending on which keymap you would like to use, you will have to compile slightly differently.
+    make handwired/pilcrow:default
 
-### Default
-
-To build with the default keymap, simply run `make default`.
-
-### Other Keymaps
-
-Several version of keymap are available in advance but you are recommended to define your favorite layout yourself. To define your own keymap create a folder with the name of your keymap in the keymaps folder, and see keymap documentation (you can find in top readme.md) and existant keymap files.
-
-To build the firmware binary hex file with a keymap just do `make` with a keymap like this:
-
-```
-$ make [default|jack|<name>]
-```
-
-Keymaps follow the format **__\<name\>.c__** and are stored in the `keymaps` folder.
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).


### PR DESCRIPTION
## handwired/pilcrow: refactor (676653b)

- layout macro renamed from KEYMAP to LAYOUT
- keymap now uses #include QMK_KEYBOARD_H
- layers reformatted for readability
- removed unused and deprecated fn_actions and action_get_macro blocks
- keymap config.h
  - updated to use #pragma once
  - removed redundant config.h include

## handwired/pilcrow: Configurator support (76d7cc9)

## handwired/pilcrow: readme update (42a8089)

Updated readme.md file to use modern template formatting.