### PR TITLE
Changing Zeal60/Zeal65 VID/PID to be unique

### DIFF
--- a/keyboards/zeal60/config.h
+++ b/keyboards/zeal60/config.h
@@ -18,12 +18,12 @@
 #include "config_common.h"
 
 // USB Device descriptor parameter
-#define VENDOR_ID       0xFEED
-#define PRODUCT_ID      0x6060
+#define VENDOR_ID       0x5A45 // ZealPC ("ZE")
+#define PRODUCT_ID      0x0060 // Zeal60
 #define DEVICE_VER      0x0001
 #define MANUFACTURER    ZealPC
 #define PRODUCT         Zeal60
-#define DESCRIPTION     Zeal60 (QMK Firmware)
+#define DESCRIPTION     Zeal60
 
 // key matrix size
 #define MATRIX_ROWS 5

--- a/keyboards/zeal65/config.h
+++ b/keyboards/zeal65/config.h
@@ -18,12 +18,12 @@
 #include "config_common.h"
 
 // USB Device descriptor parameter
-#define VENDOR_ID       0xFEED
-#define PRODUCT_ID      0x6065
+#define VENDOR_ID       0x5A45 // ZealPC ("ZE")
+#define PRODUCT_ID      0x0065 // Zeal65
 #define DEVICE_VER      0x0001
 #define MANUFACTURER    ZealPC
 #define PRODUCT         Zeal65
-#define DESCRIPTION     Zeal65 (QMK Firmware)
+#define DESCRIPTION     Zeal65
 
 // key matrix size
 #define MATRIX_ROWS 5


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- This template is entirely option and can be removed, but is here to help both you and us. -->
<!--- This text and anything on lines wrapped like this one will not show up in the final text. This text is to help us and you. -->

## Description
<!--- Describe your changes in detail -->
Changing Zeal60/Zeal65 VID/PID to be unique, because 100+ other QMK keyboard implementations are using the same VENDOR_ID/PRODUCT_ID combination (0xFEED/0x6060). VIA Configurator uses VID/PID as the identifier of a device, so this avoids any confusion between Zeal60 PCBs and other QMK devices (with 0xFEED/0x6060) which may have enabled raw HID and/or have implemented VIA Configurator compatibility without changing VID/PID.

Obviously this change will break compatibility with VIA Configurator 0.2.6 and requires 0.2.7 and later, but since Zeal60/Zeal65 is still not officially supported yet, ¯\\\_(ツ)\_/¯

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Core
- [ ] Bugfix
- [ ] New Feature
- [ ] Enhancement/Optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation


## Issues Fixed or Closed by this PR

* 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
