### PR TITLE
Fix up tap_code functionality

### DIFF
--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -161,7 +161,7 @@ If you define these options you will enable the associated feature, which may in
 * `#define COMBO_TERM 200`
   * how long for the Combo keys to be detected. Defaults to `TAPPING_TERM` if not defined.
 * `#define TAP_CODE_DELAY 100`
-  * Sets the delay between `register_code` and `unregister_code`, if you're having issues with it registering properly (common on VUSB boards).
+  * Sets the delay between `register_code` and `unregister_code`, if you're having issues with it registering properly (common on VUSB boards). The value is in milliseconds.
 
 ## RGB Light Configuration
 

--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -160,6 +160,8 @@ If you define these options you will enable the associated feature, which may in
   * Set this to the number of combos that you're using in the [Combo](feature_combo.md) feature.
 * `#define COMBO_TERM 200`
   * how long for the Combo keys to be detected. Defaults to `TAPPING_TERM` if not defined.
+* `#define TAP_CODE_DELAY 100`
+  * Sets the delay between `register_code` and `unregister_code`, if you're having issues with it registering properly (common on VUSB boards).
 
 ## RGB Light Configuration
 

--- a/docs/feature_macros.md
+++ b/docs/feature_macros.md
@@ -232,6 +232,8 @@ Parallel to `register_code` function, this sends the `<kc>` keyup event to the c
 
 This will send `register_code(<kc>)` and then `unregister_code(<kc>)`. This is useful if you want to send both the press and release events ("tap" the key, rather than hold it).
 
+You can add a delay between the register and unregister event by adding `#define TAP_CODE_DELAY 100` to your `config.h` file. 
+
 ### `clear_keyboard();`
 
 This will clear all mods and keys currently pressed.

--- a/docs/feature_macros.md
+++ b/docs/feature_macros.md
@@ -232,7 +232,7 @@ Parallel to `register_code` function, this sends the `<kc>` keyup event to the c
 
 This will send `register_code(<kc>)` and then `unregister_code(<kc>)`. This is useful if you want to send both the press and release events ("tap" the key, rather than hold it).
 
-You can add a delay between the register and unregister event by adding `#define TAP_CODE_DELAY 100` to your `config.h` file. 
+If you're having issues with taps (un)registering, you can add a delay between the register and unregister events by setting `#define TAP_CODE_DELAY 100` in your `config.h` file. The value is in milliseconds.
 
 ### `clear_keyboard();`
 

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -132,6 +132,14 @@ void unregister_code16 (uint16_t code) {
   }
 }
 
+void tap_code16(uint8_t code) {
+  register_code16(code);
+  #if defined(TAP_CODE_DELAY) && TAP_CODE_DELAY > 0
+    wait_ms(TAP_CODE_DELAY);
+  #endif
+  unregister_code16(code);
+}
+
 __attribute__ ((weak))
 bool process_action_kb(keyrecord_t *record) {
   return true;

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -134,7 +134,7 @@ void unregister_code16 (uint16_t code) {
 
 void tap_code16(uint16_t code) {
   register_code16(code);
-  #if defined(TAP_CODE_DELAY) && TAP_CODE_DELAY > 0
+  #if TAP_CODE_DELAY > 0
     wait_ms(TAP_CODE_DELAY);
   #endif
   unregister_code16(code);

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -132,7 +132,7 @@ void unregister_code16 (uint16_t code) {
   }
 }
 
-void tap_code16(uint8_t code) {
+void tap_code16(uint16_t code) {
   register_code16(code);
   #if defined(TAP_CODE_DELAY) && TAP_CODE_DELAY > 0
     wait_ms(TAP_CODE_DELAY);

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -242,7 +242,7 @@ void shutdown_user(void);
 
 void register_code16(uint16_t code);
 void unregister_code16(uint16_t code);
-inline void tap_code16(uint16_t code) { register_code16(code); unregister_code16(code); }
+void tap_code16(uint16_t code);
 
 #ifdef BACKLIGHT_ENABLE
 void backlight_init_ports(void);

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -853,7 +853,9 @@ void unregister_code(uint8_t code)
  */
 void tap_code(uint8_t code) {
   register_code(code);
-  wait_ms(100);
+  #if defined(TAP_CODE_DELAY) && TAP_CODE_DELAY > 0
+    wait_ms(TAP_CODE_DELAY);
+  #endif
   unregister_code(code);
 }
 

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -853,7 +853,7 @@ void unregister_code(uint8_t code)
  */
 void tap_code(uint8_t code) {
   register_code(code);
-  #if defined(TAP_CODE_DELAY) && TAP_CODE_DELAY > 0
+  #if TAP_CODE_DELAY > 0
     wait_ms(TAP_CODE_DELAY);
   #endif
   unregister_code(code);

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -851,6 +851,16 @@ void unregister_code(uint8_t code)
  *
  * FIXME: Needs documentation.
  */
+void tap_code(uint8_t code) {
+  register_code(code);
+  wait_ms(100);
+  unregister_code(code);
+}
+
+/** \brief Utilities for actions. (FIXME: Needs better description)
+ *
+ * FIXME: Needs documentation.
+ */
 void register_mods(uint8_t mods)
 {
     if (mods) {

--- a/tmk_core/common/action.h
+++ b/tmk_core/common/action.h
@@ -88,7 +88,7 @@ void process_record(keyrecord_t *record);
 void process_action(keyrecord_t *record, action_t action);
 void register_code(uint8_t code);
 void unregister_code(uint8_t code);
-inline void tap_code(uint8_t code) { register_code(code); unregister_code(code); }
+void tap_code(uint8_t code);
 void register_mods(uint8_t mods);
 void unregister_mods(uint8_t mods);
 //void set_mods(uint8_t mods);


### PR DESCRIPTION
## Description
* Moves `tap_code` to c files, since some compilers don't like the inline. 
* Adds a delay between registering and unregistering the keycodes (since some systems have issues)
* Adds documentation of this setting. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Core
- [X] Bugfix
- [ ] New Feature
- [X] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [X] Documentation



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
