### PR TITLE
Fix macro redefinition for GNUC compilers > 6

### DIFF
--- a/tmk_core/protocol/arm_atsam/usb/compiler.h
+++ b/tmk_core/protocol/arm_atsam/usb/compiler.h
@@ -136,7 +136,7 @@
  */
 #if defined(__CC_ARM)
 #  define __always_inline             __forceinline
-#elif (defined __GNUC__)
+#elif (defined __GNUC__ && __GNUC__ <= 6)
 #  define __always_inline             __attribute__((__always_inline__))
 #elif (defined __ICCARM__)
 #  define __always_inline             _Pragma("inline=forced")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- This template is entirely option and can be removed, but is here to help both you and us. -->
<!--- This text and anything on lines wrapped like this one will not show up in the final text. This text is to help us and you. -->

## Description
<!--- Describe your changes in detail -->
GNUC compilers greater than version 6 already have the macro __always_inline defined. This fix checks GNUC version before defining the macro itself.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Core
- [x] Bugfix
- [ ] New Feature
- [ ] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation


## Issues Fixed or Closed by this PR

* `tmk_core/protocol/arm_atsam/./usb/compiler.h:140: error: "__always_inline" redefined [-Werror]`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
