### PR TITLE
Add Soft Serial Pin to Lets Split boards

### DIFF
--- a/keyboards/lets_split/rev1/config.h
+++ b/keyboards/lets_split/rev1/config.h
@@ -45,6 +45,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* Set 0 if debouncing isn't needed */
 #define DEBOUNCING_DELAY 5
 
+/* serial.c configuration for split keyboard */
+#define SOFT_SERIAL_PIN D0
+
 /* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
 #define LOCKING_SUPPORT_ENABLE
 /* Locking resynchronize hack */

--- a/keyboards/lets_split/rev2/config.h
+++ b/keyboards/lets_split/rev2/config.h
@@ -45,6 +45,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* Set 0 if debouncing isn't needed */
 #define DEBOUNCING_DELAY 5
 
+/* serial.c configuration for split keyboard */
+#define SOFT_SERIAL_PIN D0
+
 /* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
 #define LOCKING_SUPPORT_ENABLE
 /* Locking resynchronize hack */

--- a/keyboards/lets_split/sockets/config.h
+++ b/keyboards/lets_split/sockets/config.h
@@ -45,6 +45,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* Set 0 if debouncing isn't needed */
 #define DEBOUNCING_DELAY 5
 
+/* serial.c configuration for split keyboard */
+#define SOFT_SERIAL_PIN D0
+
 /* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
 #define LOCKING_SUPPORT_ENABLE
 /* Locking resynchronize hack */


### PR DESCRIPTION
The changes that mtei added break the lets split board, since it wasn't update too. 

This updates the Lets Split to use the D0 pin for Soft Serial, and fixes the issue.