### PR TITLE
Add Planck rev1 and rev2

### DIFF
--- a/keyboards/planck/rev1/config.h
+++ b/keyboards/planck/rev1/config.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#define DEVICE_VER 0x0001

--- a/keyboards/planck/rev1/rules.mk
+++ b/keyboards/planck/rev1/rules.mk
@@ -1,0 +1,1 @@
+AUDIO_ENABLE = no           # Audio output on port C6

--- a/keyboards/planck/rev2/config.h
+++ b/keyboards/planck/rev2/config.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#define DEVICE_VER 0x0002

--- a/keyboards/planck/rev2/rules.mk
+++ b/keyboards/planck/rev2/rules.mk
@@ -1,0 +1,1 @@
+AUDIO_ENABLE = no           # Audio output on port C6

--- a/keyboards/planck/rev3/config.h
+++ b/keyboards/planck/rev3/config.h
@@ -1,8 +1,3 @@
-#ifndef REV3_CONFIG_H
-#define REV3_CONFIG_H
-
-#include "config_common.h"
+#pragma once
 
 #define DEVICE_VER 0x0003
-
-#endif

--- a/keyboards/planck/rev4/config.h
+++ b/keyboards/planck/rev4/config.h
@@ -1,8 +1,3 @@
-#ifndef REV4_CONFIG_H
-#define REV4_CONFIG_H
-
-#include "config_common.h"
+#pragma once
 
 #define DEVICE_VER 0x0004
-
-#endif

--- a/keyboards/planck/rev5/config.h
+++ b/keyboards/planck/rev5/config.h
@@ -1,8 +1,3 @@
-#ifndef REV5_CONFIG_H
-#define REV5_CONFIG_H
-
-#include "config_common.h"
+#pragma once
 
 #define DEVICE_VER 0x0005
-
-#endif


### PR DESCRIPTION
## Description
Added Planck rev1 and rev2 hardware configs. They're both identical to the rev3 hardware, but will allow rev1 and rev2 owners to use e.g. `make planck/rev2:default` without needing to determine whether rev1 and rev2 are equivalent to rev3. An alias would probably be better, but I don't know how that would be implemented.

## Types of changes
- [ ] Core
- [ ] Bugfix
- [ ] New Feature
- [ ] Enhancement/Optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
