### PR TITLE
Fix up process_leader to be a bit more optimized

### DIFF
--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -146,6 +146,8 @@ If you define these options you will enable the associated feature, which may in
     * If you're having issues finishing the sequence before it times out, you may need to increase the timeout setting. Or you may want to enable the `LEADER_PER_KEY_TIMING` option, which resets the timeout after each key is tapped. 
 * `#define LEADER_PER_KEY_TIMING`
   * sets the timer for leader key chords to run on each key press rather than overall
+* `#define LEADER_KEY_STRICT_KEY_PROCESSING`
+  * Disables keycode filtering for Mod-Tap and Layer-Tap keycodes. Eg, if you enable this, you would need to specify `MT(MOD_CTL, KC_A)` if you want to use `KC_A`.
 * `#define ONESHOT_TIMEOUT 300`
   * how long before oneshot times out
 * `#define ONESHOT_TAP_TOGGLE 2`

--- a/docs/feature_leader_key.md
+++ b/docs/feature_leader_key.md
@@ -72,6 +72,12 @@ SEQ_THREE_KEYS(KC_C, KC_C, KC_C) {
 }
 ```
 
+## Strict Key Processing
+
+By default, the Leader Key feature will filter the keycode out of [`Mod-Tap`](feature_advanced_keycodes.md#mod-tap) and [`Layer Tap`](feature_advanced_keycodes.md#switching-and-toggling-layers) functions when checking for the Leader sequences. That means if you're using `LT(3, KC_A)`, it will pick this up as `KC_A` for the sequence, rather than `LT(3, KC_A)`, giving a more expected behavior for newer users.
+
+While, this may be fine for most, if you want to specify the whole keycode (eg, `LT(3, KC_A)` from the example above) in the sequence, you can enable this by added `#define LEADER_KEY_STRICT_KEY_PROCESSING` to your `config.h` file.  This well then disable the filtering, and you'll need to specify the whole keycode.
+
 ## Customization 
 
 The Leader Key feature has some additional customization to how the Leader Key feature works.  It has two functions that can be called at certain parts of the process.  Namely `leader_start()` and `leader_end()`.

--- a/quantum/process_keycode/process_leader.c
+++ b/quantum/process_keycode/process_leader.c
@@ -35,6 +35,18 @@ uint16_t leader_time = 0;
 uint16_t leader_sequence[5] = {0, 0, 0, 0, 0};
 uint8_t leader_sequence_size = 0;
 
+void qk_leader_start(void) {
+  leader_start();
+  leading = true;
+  leader_time = timer_read();
+  leader_sequence_size = 0;
+  leader_sequence[0] = 0;
+  leader_sequence[1] = 0;
+  leader_sequence[2] = 0;
+  leader_sequence[3] = 0;
+  leader_sequence[4] = 0;
+}
+
 bool process_leader(uint16_t keycode, keyrecord_t *record) {
   // Leader key set-up
   if (record->event.pressed) {
@@ -54,16 +66,7 @@ bool process_leader(uint16_t keycode, keyrecord_t *record) {
 #endif
     } else {
       if (keycode == KC_LEAD) {
-        leader_start();
-        leading = true;
-        leader_time = timer_read();
-        leader_time = timer_read();
-        leader_sequence_size = 0;
-        leader_sequence[0] = 0;
-        leader_sequence[1] = 0;
-        leader_sequence[2] = 0;
-        leader_sequence[3] = 0;
-        leader_sequence[4] = 0;
+        qk_leader_start();
       }
       break;
     }

--- a/quantum/process_keycode/process_leader.c
+++ b/quantum/process_keycode/process_leader.c
@@ -40,6 +40,11 @@ bool process_leader(uint16_t keycode, keyrecord_t *record) {
   if (record->event.pressed) {
     if (leading) {
       if (timer_elapsed(leader_time) < LEADER_TIMEOUT) {
+#ifndef LEADER_KEY_STRICT_KEY_PROCESSING
+        if ((keycode >= QK_MOD_TAP && keycode <= QK_MOD_TAP_MAX) || (keycode >= QK_LAYER_TAP && keycode <= QK_LAYER_TAP_MAX)) {
+          keycode = keycode & 0xFF;
+        }
+#endif // LEADER_KEY_STRICT_KEY_PROCESSING
         leader_sequence[leader_sequence_size] = keycode;
         leader_sequence_size++;
         return false;

--- a/quantum/process_keycode/process_leader.c
+++ b/quantum/process_keycode/process_leader.c
@@ -59,11 +59,11 @@ bool process_leader(uint16_t keycode, keyrecord_t *record) {
 #endif // LEADER_KEY_STRICT_KEY_PROCESSING
         leader_sequence[leader_sequence_size] = keycode;
         leader_sequence_size++;
+#ifdef LEADER_PER_KEY_TIMING
+        leader_time = timer_read();
+#endif
         return false;
       }
-#ifdef LEADER_PER_KEY_TIMING
-      else { leader_time = timer_read(); }
-#endif
     } else {
       if (keycode == KC_LEAD) {
         qk_leader_start();

--- a/quantum/process_keycode/process_leader.c
+++ b/quantum/process_keycode/process_leader.c
@@ -68,6 +68,7 @@ bool process_leader(uint16_t keycode, keyrecord_t *record) {
     } else {
       if (keycode == KC_LEAD) {
         qk_leader_start();
+        return false;
       }
       break;
     }

--- a/quantum/process_keycode/process_leader.c
+++ b/quantum/process_keycode/process_leader.c
@@ -36,6 +36,7 @@ uint16_t leader_sequence[5] = {0, 0, 0, 0, 0};
 uint8_t leader_sequence_size = 0;
 
 void qk_leader_start(void) {
+  if (leading) { return; }
   leader_start();
   leading = true;
   leader_time = timer_read();

--- a/quantum/process_keycode/process_leader.c
+++ b/quantum/process_keycode/process_leader.c
@@ -38,28 +38,29 @@ uint8_t leader_sequence_size = 0;
 bool process_leader(uint16_t keycode, keyrecord_t *record) {
   // Leader key set-up
   if (record->event.pressed) {
+    if (leading) {
+      if (timer_elapsed(leader_time) < LEADER_TIMEOUT) {
+        leader_sequence[leader_sequence_size] = keycode;
+        leader_sequence_size++;
+        return false;
+      }
 #ifdef LEADER_PER_KEY_TIMING
-    leader_time = timer_read();
+      else { leader_time = timer_read(); }
 #endif
-    if (!leading && keycode == KC_LEAD) {
-      leader_start();
-      leading = true;
-#ifndef LEADER_PER_KEY_TIMING
-      leader_time = timer_read();
-#endif
-      leader_time = timer_read();
-      leader_sequence_size = 0;
-      leader_sequence[0] = 0;
-      leader_sequence[1] = 0;
-      leader_sequence[2] = 0;
-      leader_sequence[3] = 0;
-      leader_sequence[4] = 0;
-      return false;
-    }
-    if (leading && timer_elapsed(leader_time) < LEADER_TIMEOUT) {
-      leader_sequence[leader_sequence_size] = keycode;
-      leader_sequence_size++;
-      return false;
+    } else {
+      if (keycode == KC_LEAD) {
+        leader_start();
+        leading = true;
+        leader_time = timer_read();
+        leader_time = timer_read();
+        leader_sequence_size = 0;
+        leader_sequence[0] = 0;
+        leader_sequence[1] = 0;
+        leader_sequence[2] = 0;
+        leader_sequence[3] = 0;
+        leader_sequence[4] = 0;
+      }
+      break;
     }
   }
   return true;

--- a/quantum/process_keycode/process_leader.h
+++ b/quantum/process_keycode/process_leader.h
@@ -24,7 +24,7 @@ bool process_leader(uint16_t keycode, keyrecord_t *record);
 
 void leader_start(void);
 void leader_end(void);
-
+void qk_leader_start(void);
 
 #define SEQ_ONE_KEY(key) if (leader_sequence[0] == (key) && leader_sequence[1] == 0 && leader_sequence[2] == 0 && leader_sequence[3] == 0 && leader_sequence[4] == 0)
 #define SEQ_TWO_KEYS(key1, key2) if (leader_sequence[0] == (key1) && leader_sequence[1] == (key2) && leader_sequence[2] == 0 && leader_sequence[3] == 0 && leader_sequence[4] == 0)


### PR DESCRIPTION
## Description
Re-order the `process_leader` function so that it removes a redundant timer read, and make it a bit more orderly/optimized. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Core
- [ ] Bugfix
- [ ] New Feature
- [x] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
