### PR TITLE
Cast readPin output to bool for AVR to match ChibiOS

### DIFF
--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -161,7 +161,7 @@ extern uint32_t default_layer_state;
         }
     }
 
-    #define readPin(pin) (PIN_ADDRESS(pin, 0) & _BV(pin & 0xF))
+    #define readPin(pin) ((bool)(PIN_ADDRESS(pin, 0) & _BV(pin & 0xF)))
 #elif defined(PROTOCOL_CHIBIOS)
     #define pin_t ioline_t
     #define setPinInput(pin) palSetLineMode(pin, PAL_MODE_INPUT)


### PR DESCRIPTION
## Description
Cast output of `readPin()` to bool when using AVR, so that it matches the output for ChibiOS. This also fixes the issue of encoders not working probably with AVR, as `encoder.c` uses `readPin`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Core
- [x] Bugfix
- [ ] New Feature
- [ ] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation


## Issues Fixed or Closed by this PR

* https://github.com/qmk/qmk_firmware/issues/4627

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
