### PR TITLE
Fix fc980c.h update

### DIFF
--- a/keyboards/fc980c/fc980c.h
+++ b/keyboards/fc980c/fc980c.h
@@ -63,4 +63,3 @@ LAYOUT(
 )
 */
 
-#endif


### PR DESCRIPTION
Remove depreciated `#endif` from fc980c.h file, due to pragma once update. 