### PR TITLE
Add PROGMEM keyword to Clueboard keymaps

### DIFF
--- a/keyboards/clueboard/60/keymaps/default/keymap.c
+++ b/keyboards/clueboard/60/keymaps/default/keymap.c
@@ -1,4 +1,4 @@
-#include "60.h"
+#include QMK_KEYBOARD_H
 
 #define _______ KC_TRNS
 
@@ -32,7 +32,7 @@ enum custom_keycodes {
   float song_zelda_puzzle[][2]  = SONG(ZELDA_PUZZLE);
 #endif
 
-const uint16_t keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Layer 0: Default Layer
      * ,-----------------------------------------------------------.
      * |Esc|  1|  2|  3|  4|  5|  6|  7|  8|  9|  0|  -|  =|  `|BSp|

--- a/keyboards/clueboard/60/keymaps/default_aek/keymap.c
+++ b/keyboards/clueboard/60/keymaps/default_aek/keymap.c
@@ -1,4 +1,4 @@
-#include "60.h"
+#include QMK_KEYBOARD_H
 
 #define _______ KC_TRNS
 
@@ -8,7 +8,7 @@ enum keyboard_layers {
   _CL
 };
 
-const uint16_t keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Layer 0: Default Layer
      * ,-----------------------------------------------------------.
      * |Esc|  1|  2|  3|  4|  5|  6|  7|  8|  9|  0|  -|  =|   BkSp|

--- a/keyboards/clueboard/60/keymaps/yanfali/keymap.c
+++ b/keyboards/clueboard/60/keymaps/yanfali/keymap.c
@@ -1,4 +1,4 @@
-#include "60.h"
+#include QMK_KEYBOARD_H
 
 #define _______ KC_TRNS
 
@@ -33,7 +33,7 @@ enum custom_keycodes {
   float song_zelda_puzzle[][2]  = SONG(ZELDA_PUZZLE);
 #endif
 
-const uint16_t keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Layer 0: Default Layer
      * ,-----------------------------------------------------------------.
      * |Esc      |  1|  2|  3|  4|  5|  6|  7|  8|  9|  0|  -|  =|  `|BSp|


### PR DESCRIPTION

## Description
PROGMEM keyword was missing, prevented the firmware from running on my Clueboard 60% 1.0.1.

I read [some](https://www.nongnu.org/avr-libc/user-manual/group__avr__pgmspace.html#ga75acaba9e781937468d0911423bc0c35) [docs](https://www.arduino.cc/reference/en/language/variables/utilities/progmem/) docs but don't quite understand what the implications are here. Is the firmware bumping up against memory limits? Or did whatever is reading the keymap assume it was in program memory and hit an error at runtime?

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Core
- [x] Bugfix
- [ ] New Feature
- [ ] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation


## Issues Fixed or Closed by this PR

* https://github.com/qmk/qmk_firmware/issues/4690

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
