### PR TITLE
shell.nix: Packages relocated in upstream cleanup

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -4,6 +4,10 @@
 
 with pkgs;
 let
+  avrbinutils = pkgsCross.avr.buildPackages.binutils;
+  avrlibc = pkgsCross.avr.libcCross;
+  gcc-arm-embedded = pkgsCross.arm-embedded.buildPackages.gcc;
+
   avr_incflags = [
     "-isystem ${avrlibc}/avr/include"
     "-B${avrlibc}/avr/lib/avr5"
@@ -13,7 +17,7 @@ let
     "-B${avrlibc}/avr/lib/avr51"
     "-L${avrlibc}/avr/lib/avr51"
   ];
-  avrgcc = pkgs.avrgcc.overrideAttrs (oldAttrs: rec {
+  avrgcc = pkgsCross.avr.buildPackages.gcc.overrideAttrs (oldAttrs: rec {
     name = "avr-gcc-8.1.0";
     src = fetchurl {
       url = "mirror://gcc/releases/gcc-8.1.0/gcc-8.1.0.tar.xz";


### PR DESCRIPTION
## Description
There was a bit of a cleanup recently in `nixpkgs`, causing most of the package names in `shell.nix` to be undefined. I've fixed that.
