### PR TITLE
Fix Caps key led for dz60.

### DIFF
--- a/keyboards/dz60/dz60.c
+++ b/keyboards/dz60/dz60.c
@@ -23,11 +23,9 @@ void led_init_ports(void) {
 
 void led_set_kb(uint8_t usb_led) {
     if (usb_led & (1 << USB_LED_CAPS_LOCK)) {
-        DDRB |= (1 << 2);
         PORTB &= ~(1 << 2);
     } else {
-        DDRB &= ~(1 << 2);
-        PORTB &= ~(1 << 2);
+        PORTB |= (1 << 2);
     }
 
     led_set_user(usb_led);


### PR DESCRIPTION
## Description
As the state of dz60.c in this repo right now, the caps key led isn't working. This fix caps led for dz60 tested on multiple OS(Linux, macOS, and windows).

## Types of changes
- [ ] Core
- [x] Bugfix
- [ ] New Feature
- [ ] Enhancement/Optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation


## Issues Fixed or Closed by this PR

*  #4471 but not only for macOS.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

This is my first pr, so please correct me if I have done something wrong.