### PR TITLE
S65-Plus: fix layout macro name in info.json

### DIFF
--- a/keyboards/s65_plus/info.json
+++ b/keyboards/s65_plus/info.json
@@ -5,7 +5,7 @@
   "width": 18,
   "height": 5,
   "layouts": {
-    "LAYOUT": {
+    "LAYOUT_ansi": {
       "layout": [
         {"label":"F1", "x":0, "y":0},
         {"label":"F2", "x":1, "y":0},


### PR DESCRIPTION
Am I allowed to blame working on a 10" screen for the poorer quality of my pull requests since I went on vacation?