### PR TITLE
Fix apparent typo in WhiteFox LED config

### DIFF
--- a/keyboards/whitefox/board_is31fl3731c.h
+++ b/keyboards/whitefox/board_is31fl3731c.h
@@ -31,7 +31,7 @@ static const uint8_t led_mask[] = {
 	0xFF, 0x00, /* C6-1 -> C6-16 */
 	0xFF, 0x00, /* C7-1 -> C7-16 */
 	0xFF, 0x00, /* C8-1 -> C8-16 */
-	0xFE, 0x00, /* C9-1 -> C9-16 */
+	0xFF, 0x00, /* C9-1 -> C9-16 */
 };
 
 // The address of the LED


### PR DESCRIPTION
## Description
It seems the led_mask is set incorrectly on the WhiteFox meaning that the LED at C9-1 (the space bar) doesn't get lit.  I can't see any reason for this to be intentional so I am pretty sure it's a typo.  At the very least it fixes the space bar LED for me.

## Types of changes
- [ ] Core
- [x] Bugfix
- [ ] New Feature
- [ ] Enhancement/Optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation
