### PR TITLE
Reduce file size of Lets Split Socket to fix Travis CI size warnings

### DIFF
--- a/keyboards/lets_split/sockets/config.h
+++ b/keyboards/lets_split/sockets/config.h
@@ -65,7 +65,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* Audio settings */
 #ifdef AUDIO_ENABLE
-    #define C6_AUDIO // Define this to enable the buzzer
+  #define C6_AUDIO // Define this to enable the buzzer
 #endif
 
 /*
@@ -83,5 +83,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define NO_ACTION_LAYER
 //#define NO_ACTION_TAPPING
 //#define NO_ACTION_ONESHOT
-//#define NO_ACTION_MACRO
-//#define NO_ACTION_FUNCTION
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION

--- a/keyboards/lets_split/sockets/rules.mk
+++ b/keyboards/lets_split/sockets/rules.mk
@@ -1,3 +1,11 @@
 BACKLIGHT_ENABLE = no
 AUDIO_ENABLE = yes
 RGBLIGHT_ENABLE = yes #Don't enable this along with I2C
+MOUSEKEY_ENABLE = no       # Mouse keys(+4700)
+
+
+ ifeq ($(strip $(AUDIO_ENABLE)), yes)
+   ifeq ($(strip $(RGBLIGHT_ENABLE)), yes)
+     EXTRAFLAGS += -flto
+   endif
+ endif


### PR DESCRIPTION

## Description
Feature creep and old compiler is causing a "too large" error (by 16-20 bytes).

This turns off MOUSEKEYS and enables LTO to reduce compile size. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Core
- [ ] Bugfix
- [ ] New Feature
- [X] Enhancement/Optimization
- [X] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation


## Issues Fixed or Closed by this PR

* Travis CI Errors

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
