### PR TITLE
Fix Mod Handling for LM keycodes

### DIFF
--- a/quantum/keymap_common.c
+++ b/quantum/keymap_common.c
@@ -127,7 +127,7 @@ action_t action_for_key(uint8_t layer, keypos_t key)
             action.code = ACTION_LAYER_TAP_TOGGLE(keycode & 0xFF);
             break;
         case QK_LAYER_MOD ... QK_LAYER_MOD_MAX:
-            mod = keycode & 0xF;
+            mod = mod_config(keycode & 0xF);
             action_layer = (keycode >> 4) & 0xF;
             action.code = ACTION_LAYER_MODS(action_layer, mod);
             break;


### PR DESCRIPTION
## Description
This updates Layer Mod (`LM`) to properly respect the bootmagic configuration (`AG_SWAP`, and NO_GUI options), by properly processing them. 

Right now, both of these features lack the code to handle the bootmagic configuration, and as such, completely fail to respect the settings.  This simply adds the `mod_confg` function call to process this correctly. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Core
- [x] Bugfix
- [ ] New Feature
- [x] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation


## Issues Fixed or Closed by this PR

* Fixes #4263 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
