### PR TITLE
Fix `process_leader` return code

### DIFF
--- a/quantum/process_keycode/process_leader.c
+++ b/quantum/process_keycode/process_leader.c
@@ -68,9 +68,7 @@ bool process_leader(uint16_t keycode, keyrecord_t *record) {
     } else {
       if (keycode == KC_LEAD) {
         qk_leader_start();
-        return false;
       }
-      break;
     }
   }
   return true;


### PR DESCRIPTION
## Description

I think the rc of `process_leader` must be `true`, I recently added leader support in [my fork](https://github.com/grota/qmk_firmware/tree/grota/ergodoxez) but after flashing, the keyboard was unresponsive.  

## Types of changes

- [x] Core
- [x] Bugfix
- [ ] New Feature
- [ ] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation


## Issues Fixed or Closed by this PR

* Fixes bug introduced in #4662 

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
