### PR TITLE
Register the interrupting keycode in the tap dance state struct

### DIFF
--- a/quantum/process_keycode/process_tap_dance.c
+++ b/quantum/process_keycode/process_tap_dance.c
@@ -131,6 +131,7 @@ void preprocess_tap_dance(uint16_t keycode, keyrecord_t *record) {
       if (keycode == action->state.keycode && keycode == last_td)
         continue;
       action->state.interrupted = true;
+      action->state.interrupting_keycode = keycode;
       process_tap_dance_action_on_dance_finished (action);
       reset_tap_dance (&action->state);
     }
@@ -209,5 +210,6 @@ void reset_tap_dance (qk_tap_dance_state_t *state) {
   state->count = 0;
   state->interrupted = false;
   state->finished = false;
+  state->interrupting_keycode = 0;
   last_td = 0;
 }

--- a/quantum/process_keycode/process_tap_dance.h
+++ b/quantum/process_keycode/process_tap_dance.h
@@ -27,6 +27,7 @@ typedef struct
   uint8_t oneshot_mods;
   uint8_t weak_mods;
   uint16_t keycode;
+  uint16_t interrupting_keycode;
   uint16_t timer;
   bool interrupted;
   bool pressed;


### PR DESCRIPTION
## Description

This PR makes it so that the tap dance state struct also has the keycode responsible of the interruption.
I found it very useful to have that info in the finished/reset functions, see [here](https://github.com/grota/qmk_firmware/blob/c80eb9c1eaa89201c0f25dcd156281209a1f382f/layouts/community/ergodox/grota/tap_dance.c#L70) for an example.
Not sure if there's a saner way to do this.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Core
- [ ] Bugfix
- [x] New Feature
- [x] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation


## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
