### PR TITLE
Change rgblight_get_mode & rgb_matrix_get_mode's return type to uint8_t.

### DIFF
--- a/keyboards/mxss/rgblight.c
+++ b/keyboards/mxss/rgblight.c
@@ -234,7 +234,7 @@ void rgblight_step_reverse(void) {
   rgblight_mode(mode);
 }
 
-uint32_t rgblight_get_mode(void) {
+uint8_t rgblight_get_mode(void) {
   if (!rgblight_config.enable) {
     return false;
   }

--- a/quantum/rgb_matrix.c
+++ b/quantum/rgb_matrix.c
@@ -973,7 +973,7 @@ void rgb_matrix_mode_noeeprom(uint8_t mode) {
     rgb_matrix_config.mode = mode;
 }
 
-uint32_t rgb_matrix_get_mode(void) {
+uint8_t rgb_matrix_get_mode(void) {
     return rgb_matrix_config.mode;
 }
 

--- a/quantum/rgb_matrix.h
+++ b/quantum/rgb_matrix.h
@@ -180,7 +180,7 @@ void rgb_matrix_increase_speed(void);
 void rgb_matrix_decrease_speed(void);
 void rgb_matrix_mode(uint8_t mode);
 void rgb_matrix_mode_noeeprom(uint8_t mode);
-uint32_t rgb_matrix_get_mode(void);
+uint8_t rgb_matrix_get_mode(void);
 
 #ifndef RGBLIGHT_ENABLE
 #define rgblight_toggle() rgb_matrix_toggle()

--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -234,7 +234,7 @@ void rgblight_step_reverse(void) {
   rgblight_step_reverse_helper(true);
 }
 
-uint32_t rgblight_get_mode(void) {
+uint8_t rgblight_get_mode(void) {
   if (!rgblight_config.enable) {
     return false;
   }

--- a/quantum/rgblight.h
+++ b/quantum/rgblight.h
@@ -167,7 +167,7 @@ void rgblight_enable(void);
 void rgblight_disable(void);
 void rgblight_step(void);
 void rgblight_step_reverse(void);
-uint32_t rgblight_get_mode(void);
+uint8_t rgblight_get_mode(void);
 void rgblight_mode(uint8_t mode);
 void rgblight_set(void);
 void rgblight_update_dword(uint32_t dword);


### PR DESCRIPTION
## Description
`rgblight_get_mode()`'s return type right now is `uint32_t`, but upon inspection of its implementation, it's actually returning `rgblight_config_t.mode`, which is an `uint8_t`.  The return type should match `rgblight_config_t.mode`'s.  

I've grep'd through all the keymaps, there does seem to be a few places where `rgblight_get_mode`'s return value is being saved into another uint32_t variable.  These are probably be OK as they're just upcasting.

Also updating `rgb_matrix_get_mode` to return `uint8_t` for similar reason.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Core
- [x] Bugfix
- [ ] New Feature
- [x] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
