### PR TITLE
Convert split_common to use generic GPIO api

### DIFF
--- a/quantum/split_common/matrix.c
+++ b/quantum/split_common/matrix.c
@@ -20,17 +20,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include <stdint.h>
 #include <stdbool.h>
-#include <avr/io.h>
 #include "wait.h"
-#include "print.h"
-#include "debug.h"
 #include "util.h"
 #include "matrix.h"
 #include "split_util.h"
-#include "pro_micro.h"
 #include "config.h"
 #include "timer.h"
 #include "split_flags.h"
+#include "quantum.h"
 
 #ifdef BACKLIGHT_ENABLE
 #   include "backlight.h"
@@ -91,8 +88,8 @@ static matrix_row_t matrix_debouncing[MATRIX_ROWS];
 
 static uint8_t error_count = 0;
 
-static uint8_t row_pins[MATRIX_ROWS] = MATRIX_ROW_PINS;
-static uint8_t col_pins[MATRIX_COLS] = MATRIX_COL_PINS;
+static pin_t row_pins[MATRIX_ROWS] = MATRIX_ROW_PINS;
+static pin_t col_pins[MATRIX_COLS] = MATRIX_COL_PINS;
 
 /* matrix state(1:on, 0:off) */
 static matrix_row_t matrix[MATRIX_ROWS];
@@ -440,9 +437,7 @@ uint8_t matrix_key_count(void)
 static void init_cols(void)
 {
     for(uint8_t x = 0; x < MATRIX_COLS; x++) {
-        uint8_t pin = col_pins[x];
-        _SFR_IO8((pin >> 4) + 1) &= ~_BV(pin & 0xF); // IN
-        _SFR_IO8((pin >> 4) + 2) |=  _BV(pin & 0xF); // HI
+        setPinInputHigh(col_pins[x]);
     }
 }
 
@@ -460,13 +455,8 @@ static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
 
     // For each col...
     for(uint8_t col_index = 0; col_index < MATRIX_COLS; col_index++) {
-
-        // Select the col pin to read (active low)
-        uint8_t pin = col_pins[col_index];
-        uint8_t pin_state = (_SFR_IO8(pin >> 4) & _BV(pin & 0xF));
-
         // Populate the matrix row with the state of the col pin
-        current_matrix[current_row] |=  pin_state ? 0 : (ROW_SHIFTER << col_index);
+        current_matrix[current_row] |=  readPin(col_pins[col_index]) ? 0 : (ROW_SHIFTER << col_index);
     }
 
     // Unselect row
@@ -477,24 +467,19 @@ static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
 
 static void select_row(uint8_t row)
 {
-    uint8_t pin = row_pins[row];
-    _SFR_IO8((pin >> 4) + 1) |=  _BV(pin & 0xF); // OUT
-    _SFR_IO8((pin >> 4) + 2) &= ~_BV(pin & 0xF); // LOW
+    writePinLow(row_pins[row]);
+    setPinOutput(row_pins[row]);
 }
 
 static void unselect_row(uint8_t row)
 {
-    uint8_t pin = row_pins[row];
-    _SFR_IO8((pin >> 4) + 1) &= ~_BV(pin & 0xF); // IN
-    _SFR_IO8((pin >> 4) + 2) |=  _BV(pin & 0xF); // HI
+    setPinInputHigh(row_pins[row]);
 }
 
 static void unselect_rows(void)
 {
     for(uint8_t x = 0; x < ROWS_PER_HAND; x++) {
-        uint8_t pin = row_pins[x];
-        _SFR_IO8((pin >> 4) + 1) &= ~_BV(pin & 0xF); // IN
-        _SFR_IO8((pin >> 4) + 2) |=  _BV(pin & 0xF); // HI
+        setPinInputHigh(row_pins[x]);
     }
 }
 
@@ -503,9 +488,7 @@ static void unselect_rows(void)
 static void init_rows(void)
 {
     for(uint8_t x = 0; x < ROWS_PER_HAND; x++) {
-        uint8_t pin = row_pins[x];
-        _SFR_IO8((pin >> 4) + 1) &= ~_BV(pin & 0xF); // IN
-        _SFR_IO8((pin >> 4) + 2) |=  _BV(pin & 0xF); // HI
+        setPinInputHigh(row_pins[x]);
     }
 }
 
@@ -525,15 +508,15 @@ static bool read_rows_on_col(matrix_row_t current_matrix[], uint8_t current_col)
         matrix_row_t last_row_value = current_matrix[row_index];
 
         // Check row pin state
-        if ((_SFR_IO8(row_pins[row_index] >> 4) & _BV(row_pins[row_index] & 0xF)) == 0)
-        {
-            // Pin LO, set col bit
-            current_matrix[row_index] |= (ROW_SHIFTER << current_col);
-        }
-        else
+        if (readPin(row_pins[row_index]))
         {
             // Pin HI, clear col bit
             current_matrix[row_index] &= ~(ROW_SHIFTER << current_col);
+        }
+        else
+        {
+            // Pin LO, set col bit
+            current_matrix[row_index] |= (ROW_SHIFTER << current_col);
         }
 
         // Determine if the matrix changed state
@@ -551,24 +534,19 @@ static bool read_rows_on_col(matrix_row_t current_matrix[], uint8_t current_col)
 
 static void select_col(uint8_t col)
 {
-    uint8_t pin = col_pins[col];
-    _SFR_IO8((pin >> 4) + 1) |=  _BV(pin & 0xF); // OUT
-    _SFR_IO8((pin >> 4) + 2) &= ~_BV(pin & 0xF); // LOW
+    writePinLow(col_pins[col]);
+    setPinOutput(col_pins[col]);
 }
 
 static void unselect_col(uint8_t col)
 {
-    uint8_t pin = col_pins[col];
-    _SFR_IO8((pin >> 4) + 1) &= ~_BV(pin & 0xF); // IN
-    _SFR_IO8((pin >> 4) + 2) |=  _BV(pin & 0xF); // HI
+    setPinInputHigh(col_pins[col]);
 }
 
 static void unselect_cols(void)
 {
     for(uint8_t x = 0; x < MATRIX_COLS; x++) {
-        uint8_t pin = col_pins[x];
-        _SFR_IO8((pin >> 4) + 1) &= ~_BV(pin & 0xF); // IN
-        _SFR_IO8((pin >> 4) + 2) |=  _BV(pin & 0xF); // HI
+        setPinInputHigh(col_pins[x]);
     }
 }
 

--- a/quantum/split_common/split_util.c
+++ b/quantum/split_common/split_util.c
@@ -6,6 +6,10 @@
 #include "split_flags.h"
 #include "quantum.h"
 
+#ifdef EE_HANDS
+#   include "tmk_core/common/eeprom.h"
+#endif
+
 #ifdef BACKLIGHT_ENABLE
 #   include "backlight.h"
 #endif

--- a/quantum/split_common/split_util.c
+++ b/quantum/split_common/split_util.c
@@ -1,22 +1,13 @@
-#include <avr/io.h>
-#include <avr/wdt.h>
-#include <avr/power.h>
-#include <avr/interrupt.h>
-#include <util/delay.h>
-#include <avr/eeprom.h>
 #include "split_util.h"
 #include "matrix.h"
 #include "keyboard.h"
 #include "config.h"
 #include "timer.h"
 #include "split_flags.h"
+#include "quantum.h"
 
 #ifdef BACKLIGHT_ENABLE
 #   include "backlight.h"
-#endif
-
-#ifdef SPLIT_HAND_PIN
-#   include "pincontrol.h"
 #endif
 
 #if defined(USE_I2C) || defined(EH)
@@ -30,8 +21,8 @@ volatile uint8_t setTries = 0;
 static void setup_handedness(void) {
   #ifdef SPLIT_HAND_PIN
     // Test pin SPLIT_HAND_PIN for High/Low, if low it's right hand
-    pinMode(SPLIT_HAND_PIN, PinDirectionInput);
-    isLeftHand = digitalRead(SPLIT_HAND_PIN);
+    setPinInput(SPLIT_HAND_PIN);
+    isLeftHand = readPin(SPLIT_HAND_PIN);
   #else
     #ifdef EE_HANDS
       isLeftHand = eeprom_read_byte(EECONFIG_HANDEDNESS);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- This template is entirely option and can be removed, but is here to help both you and us. -->
<!--- This text and anything on lines wrapped like this one will not show up in the final text. This text is to help us and you. -->

## Description
<!--- Describe your changes in detail -->
One tiny step towards refactoring split_common so it can be used by both AVR and ARM builds. This PR replaces the raw AVR gpio accesses with the generic QMK GPIO api calls. Functionality should be completely unchanged for existing users, but this needs verification.

This is just a starting point for discussion; as I see it to get split_common properly decoupled there are several significant issues that will require discussion/buy-in from other interested parties:
- [x] Replace raw AVR GPIO accesses
- [ ] Replace raw AVR USB master/slave test (should use/override is_keyboard_master instead)
- [ ] Allow overriding handedness check by keyboard code (maybe calling a weak is_keyboard_lefthanded function?)
- [ ] Properly separate matrix and i2c/serial code, use a transport-agnostic API like that in the hydra serial code and link in the desired transport code at build time (allows replacing the existing AVR-specific transports with a custom one)
- [ ] Rework chibios main loop (is tightly coupled to ergodox-infinity and quantum/serial-link)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Core
- [ ] Bugfix
- [ ] New Feature
- [x] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
