### PR TITLE
Add underscores to names of brightness control constants in report.h

### DIFF
--- a/tmk_core/common/report.h
+++ b/tmk_core/common/report.h
@@ -48,8 +48,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define TRANSPORT_STOP          0x00B7
 #define TRANSPORT_STOP_EJECT    0x00CC
 #define TRANSPORT_PLAY_PAUSE    0x00CD
-#define BRIGHTNESSUP            0x006F
-#define BRIGHTNESSDOWN          0x0070
+#define BRIGHTNESS_UP           0x006F
+#define BRIGHTNESS_DOWN         0x0070
 /* application launch */
 #define AL_CC_CONFIG            0x0183
 #define AL_EMAIL                0x018A
@@ -192,8 +192,8 @@ typedef struct {
     (key == KC_WWW_FORWARD      ?  AC_FORWARD : \
     (key == KC_WWW_STOP         ?  AC_STOP : \
     (key == KC_WWW_REFRESH      ?  AC_REFRESH : \
-    (key == KC_BRIGHTNESS_UP    ?  BRIGHTNESSUP : \
-    (key == KC_BRIGHTNESS_DOWN  ?  BRIGHTNESSDOWN : \
+    (key == KC_BRIGHTNESS_UP    ?  BRIGHTNESS_UP : \
+    (key == KC_BRIGHTNESS_DOWN  ?  BRIGHTNESS_DOWN : \
     (key == KC_WWW_FAVORITES    ?  AC_BOOKMARKS : 0)))))))))))))))))))))))
 
 uint8_t has_anykey(report_keyboard_t* keyboard_report);


### PR DESCRIPTION
Change `BRIGHTNESSUP` to `BRIGHTNESS_UP` and `BRIGHTNESSDOWN` to `BRIGHTNESS_DOWN`.

This makes the constants' names consistent with their corresponding keycodes (`KC_BRIGHTNESS_UP`, `KC_BRIGHTNESS_DOWN`), as well as other constants defined in `report.h`. The changed constants are only used in this file, so this change shouldn't affect anything at all.

These constants were added in #4477.