### PR TITLE
Feature : Backlight - New option : BACKLIGHT_CAPS_LOCK

### DIFF
--- a/docs/feature_backlight.md
+++ b/docs/feature_backlight.md
@@ -36,12 +36,13 @@ Hardware PWM is only supported on certain pins of the MCU, so if the backlightin
 
 To change the behaviour of the backlighting, `#define` these in your `config.h`:
 
-|Define               |Default      |Description                                                                                                  |
-|---------------------|-------------|-------------------------------------------------------------------------------------------------------------|
-|`BACKLIGHT_PIN`      |`B7`         |The pin that controls the LEDs. Unless you are designing your own keyboard, you shouldn't need to change this|
-|`BACKLIGHT_LEVELS`   |`3`          |The number of brightness levels (maximum 15 excluding off)                                                   |
-|`BACKLIGHT_BREATHING`|*Not defined*|Enable backlight breathing, if hardware PWM is used                                                          |
-|`BREATHING_PERIOD`   |`6`          |The length of one backlight "breath" in seconds                                                              |
+|Define                         |Default      |Description                                                                                                  |
+|-------------------------------|-------------|-------------------------------------------------------------------------------------------------------------|
+|`BACKLIGHT_PIN`                |`B7`         |The pin that controls the LEDs. Unless you are designing your own keyboard, you shouldn't need to change this|
+|`BACKLIGHT_LEVELS`             |`3`          |The number of brightness levels (maximum 15 excluding off)                                                   |
+|`BACKLIGHT_CAPS_LOCK_INDICATOR`|*Not defined*|Enable Caps Lock indicator using backlight (for keyboards without dedicated LED)                             |
+|`BACKLIGHT_BREATHING`          |*Not defined*|Enable backlight breathing, if hardware PWM is used                                                          |
+|`BREATHING_PERIOD`             |`6`          |The length of one backlight "breath" in seconds                                                              |
 
 ## Hardware PWM Implementation
 

--- a/docs/feature_backlight.md
+++ b/docs/feature_backlight.md
@@ -36,13 +36,13 @@ Hardware PWM is only supported on certain pins of the MCU, so if the backlightin
 
 To change the behaviour of the backlighting, `#define` these in your `config.h`:
 
-|Define                         |Default      |Description                                                                                                  |
-|-------------------------------|-------------|-------------------------------------------------------------------------------------------------------------|
-|`BACKLIGHT_PIN`                |`B7`         |The pin that controls the LEDs. Unless you are designing your own keyboard, you shouldn't need to change this|
-|`BACKLIGHT_LEVELS`             |`3`          |The number of brightness levels (maximum 15 excluding off)                                                   |
-|`BACKLIGHT_CAPS_LOCK_INDICATOR`|*Not defined*|Enable Caps Lock indicator using backlight (for keyboards without dedicated LED)                             |
-|`BACKLIGHT_BREATHING`          |*Not defined*|Enable backlight breathing, if hardware PWM is used                                                          |
-|`BREATHING_PERIOD`             |`6`          |The length of one backlight "breath" in seconds                                                              |
+|Define               |Default      |Description                                                                                                  |
+|---------------------|-------------|-------------------------------------------------------------------------------------------------------------|
+|`BACKLIGHT_PIN`      |`B7`         |The pin that controls the LEDs. Unless you are designing your own keyboard, you shouldn't need to change this|
+|`BACKLIGHT_LEVELS`   |`3`          |The number of brightness levels (maximum 15 excluding off)                                                   |
+|`BACKLIGHT_CAPS_LOCK`|*Not defined*|Enable Caps Lock indicator using backlight (for keyboards without dedicated LED)                             |
+|`BACKLIGHT_BREATHING`|*Not defined*|Enable backlight breathing, if hardware PWM is used                                                          |
+|`BREATHING_PERIOD`   |`6`          |The length of one backlight "breath" in seconds                                                              |
 
 ## Hardware PWM Implementation
 

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -1443,13 +1443,13 @@ void led_set(uint8_t usb_led)
     //     PORTE &= ~(1<<6);
     // }
 
-#if defined(BACKLIGHT_ENABLE) && defined(BACKLIGHT_CAPS_LOCK_INDICATOR)
+#if defined(BACKLIGHT_CAPS_LOCK) && defined(BACKLIGHT_ENABLE)
   // Use backlight as Caps Lock indicator
   uint8_t bl_toggle_lvl = 0;
 
   if (usb_led & (1<<USB_LED_CAPS_LOCK) && !backlight_config.enable) {
     // Turning Caps Lock ON and backlight is disabled in config
-    // Toggling backlight to the highest level
+    // Toggling backlight to the brightest level
     bl_toggle_lvl = BACKLIGHT_LEVELS;
   } else if (!(usb_led & (1<<USB_LED_CAPS_LOCK)) && backlight_config.enable) {
     // Turning Caps Lock OFF and backlight is enabled in config

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -1443,6 +1443,24 @@ void led_set(uint8_t usb_led)
     //     PORTE &= ~(1<<6);
     // }
 
+#if defined(BACKLIGHT_ENABLE) && defined(BACKLIGHT_CAPS_LOCK_INDICATOR)
+  // Use backlight as Caps Lock indicator
+  uint8_t bl_toggle_lvl = 0;
+
+  if (usb_led & (1<<USB_LED_CAPS_LOCK) && !backlight_config.enable) {
+    // Turning Caps Lock ON and backlight is disabled in config
+    // Toggling backlight to the highest level
+    bl_toggle_lvl = BACKLIGHT_LEVELS;
+  } else if (!(usb_led & (1<<USB_LED_CAPS_LOCK)) && backlight_config.enable) {
+    // Turning Caps Lock OFF and backlight is enabled in config
+    // Toggling backlight and restoring config level
+    bl_toggle_lvl = backlight_config.level;
+  }
+
+  // Set level without modify backlight_config to keep ability to restore state
+  backlight_set(bl_toggle_lvl);
+#endif
+
   led_set_kb(usb_led);
 }
 

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -1447,11 +1447,11 @@ void led_set(uint8_t usb_led)
   // Use backlight as Caps Lock indicator
   uint8_t bl_toggle_lvl = 0;
 
-  if (usb_led & (1<<USB_LED_CAPS_LOCK) && !backlight_config.enable) {
+  if (IS_LED_ON(usb_led, USB_LED_CAPS_LOCK) && !backlight_config.enable) {
     // Turning Caps Lock ON and backlight is disabled in config
     // Toggling backlight to the brightest level
     bl_toggle_lvl = BACKLIGHT_LEVELS;
-  } else if (!(usb_led & (1<<USB_LED_CAPS_LOCK)) && backlight_config.enable) {
+  } else if (IS_LED_OFF(usb_led, USB_LED_CAPS_LOCK) && backlight_config.enable) {
     // Turning Caps Lock OFF and backlight is enabled in config
     // Toggling backlight and restoring config level
     bl_toggle_lvl = backlight_config.level;

--- a/tmk_core/common/avr/suspend.c
+++ b/tmk_core/common/avr/suspend.c
@@ -111,7 +111,7 @@ static void power_down(uint8_t wdto)
 
   // Turn off LED indicators
   uint8_t leds_off = 0;
-#ifdef BACKLIGHT_CAPS_LOCK_INDICATOR
+#if defined(BACKLIGHT_CAPS_LOCK) && defined(BACKLIGHT_ENABLE)
   if (is_backlight_enabled()) {
     // Don't try to turn off Caps Lock indicator as it is backlight and backlight is already off
     leds_off |= (1<<USB_LED_CAPS_LOCK);

--- a/tmk_core/common/avr/suspend.c
+++ b/tmk_core/common/avr/suspend.c
@@ -98,26 +98,31 @@ static uint8_t wdt_timeout = 0;
 static void power_down(uint8_t wdto)
 {
 #ifdef PROTOCOL_LUFA
-    if (USB_DeviceState == DEVICE_STATE_Configured) return;
+  if (USB_DeviceState == DEVICE_STATE_Configured) return;
 #endif
-    wdt_timeout = wdto;
+  wdt_timeout = wdto;
 
-    // Watchdog Interrupt Mode
-    wdt_intr_enable(wdto);
+  // Watchdog Interrupt Mode
+  wdt_intr_enable(wdto);
 
 #ifdef BACKLIGHT_ENABLE
-	backlight_set(0);
+  backlight_set(0);
 #endif
 
-#ifndef BACKLIGHT_CAPS_LOCK_INDICATOR
-	// Turn off LED indicators
-	led_set(0);
+  // Turn off LED indicators
+  uint8_t leds_off = 0;
+#ifdef BACKLIGHT_CAPS_LOCK_INDICATOR
+  if (is_backlight_enabled()) {
+    // Don't try to turn off Caps Lock indicator as it is backlight and backlight is already off
+    leds_off |= (1<<USB_LED_CAPS_LOCK);
+  }
 #endif
+  led_set(leds_off);
 
-	#ifdef AUDIO_ENABLE
-        // This sometimes disables the start-up noise, so it's been disabled
-		// stop_all_notes();
-	#endif /* AUDIO_ENABLE */
+#ifdef AUDIO_ENABLE
+  // This sometimes disables the start-up noise, so it's been disabled
+  // stop_all_notes();
+#endif /* AUDIO_ENABLE */
 #if defined(RGBLIGHT_SLEEP) && defined(RGBLIGHT_ENABLE)
 #ifdef RGBLIGHT_ANIMATIONS
   rgblight_timer_disable();
@@ -126,20 +131,20 @@ static void power_down(uint8_t wdto)
 #endif
   suspend_power_down_kb();
 
-    // TODO: more power saving
-    // See PicoPower application note
-    // - I/O port input with pullup
-    // - prescale clock
-    // - BOD disable
-    // - Power Reduction Register PRR
-    set_sleep_mode(SLEEP_MODE_PWR_DOWN);
-    sleep_enable();
-    sei();
-    sleep_cpu();
-    sleep_disable();
+  // TODO: more power saving
+  // See PicoPower application note
+  // - I/O port input with pullup
+  // - prescale clock
+  // - BOD disable
+  // - Power Reduction Register PRR
+  set_sleep_mode(SLEEP_MODE_PWR_DOWN);
+  sleep_enable();
+  sei();
+  sleep_cpu();
+  sleep_disable();
 
-    // Disable watchdog after sleep
-    wdt_disable();
+  // Disable watchdog after sleep
+  wdt_disable();
 }
 #endif
 

--- a/tmk_core/common/avr/suspend.c
+++ b/tmk_core/common/avr/suspend.c
@@ -109,8 +109,10 @@ static void power_down(uint8_t wdto)
 	backlight_set(0);
 #endif
 
+#ifndef BACKLIGHT_CAPS_LOCK_INDICATOR
 	// Turn off LED indicators
 	led_set(0);
+#endif
 
 	#ifdef AUDIO_ENABLE
         // This sometimes disables the start-up noise, so it's been disabled


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- This template is entirely option and can be removed, but is here to help both you and us. -->
<!--- This text and anything on lines wrapped like this one will not show up in the final text. This text is to help us and you. -->

## Description
I've implemented this new option in backlight feature because my keyboard (S65-X) doesn't have LED indicators and the existing led_set_kb(usb_led) function try to use backlight as Caps Lock indicator but that creates an inconsistency with backlight_config state. Another bug, when suspending the power, the backlight stays on instead of turning off.

* define `BACKLIGHT_CAPS_LOCK` to enable Caps Lock indicator using backlight (for keyboards without dedicated LED). Default state : Not defined.
* Don't turn off LED indicators when suspend because backlight is already turned off. Else led_set(0) will turn back on backlight.
* Documentation has been updated

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Core
- [ ] Bugfix
- [x] New Feature
- [x] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [x] Documentation


## Issues Fixed or Closed by this PR


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
  