### PR TITLE
[Keyboard][S65-X] BACKLIGHT_CAPS_LOCK

### DIFF
--- a/keyboards/s65_x/config.h
+++ b/keyboards/s65_x/config.h
@@ -4,7 +4,7 @@
 #include "config_common.h"
 
 /* USB Device descriptor parameter */
-#define PRODUCT         S65-X-RGB
+#define PRODUCT         S65-X RGB
 #define DESCRIPTION     QMK keyboard firmware for S65-X RGB
 #define VENDOR_ID       0xFEED
 #define PRODUCT_ID      0x6060
@@ -22,7 +22,8 @@
 
 /* number of backlight levels */
 #define BACKLIGHT_PIN B7
-#define BACKLIGHT_LEVELS 3
+#define BACKLIGHT_LEVELS 5
+#define BACKLIGHT_CAPS_LOCK
 
 #define RGB_DI_PIN D3
 #define RGBLIGHT_ANIMATIONS
@@ -31,6 +32,7 @@
 #define RGBLIGHT_SAT_STEP 8
 #define RGBLIGHT_VAL_STEP 8
 #define RGBLIGHT_EFFECT_KNIGHT_OFFSET 20
+#define RGBLIGHT_SLEEP
 
 /* COL2ROW or ROW2COL */
 #define DIODE_DIRECTION COL2ROW

--- a/keyboards/s65_x/s65_x.c
+++ b/keyboards/s65_x/s65_x.c
@@ -1,5 +1,4 @@
 #include "s65_x.h"
-#include "led.h"
 
 void matrix_init_kb(void) {
   // put your keyboard start-up code here
@@ -14,11 +13,6 @@ void matrix_scan_kb(void) {
 };
 
 void led_set_kb(uint8_t usb_led) {
-  if (usb_led & (1<<USB_LED_CAPS_LOCK)) {
-    // Turn capslock on
-    PORTB &= ~(1<<7);
-  } else {
-    // Turn capslock off
-    PORTB |= (1<<7);
-  }
+  // put your keyboard LED indicator (ex: Caps Lock LED) toggling code here
+  led_set_user(usb_led);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- This template is entirely option and can be removed, but is here to help both you and us. -->
<!--- This text and anything on lines wrapped like this one will not show up in the final text. This text is to help us and you. -->

## Description
* Replace buggy implementation of Caps Lock indicator using backlight with new backlight option `BACKLIGHT_CAPS_LOCK` (PR #4769)
* Adding `RGBLIGHT_SLEEP`
* Increasing `BACKLIGHT_LEVELS` from 3 to 5

## 
Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Core
- [x] Bugfix
- [ ] New Feature
- [x] Enhancement/Optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation


## Issues Fixed or Closed by this PR
* End of inconsistency between Caps Lock indicator and backlight state. There's was an inconsistency between backlight_config state and Caps Lock indicator so when toggling backlight sometime it doesn't turn off.
* Keyboard backlight turns off when Host is suspended.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
 