### PR TITLE
Add missing parentheses to some important macros

### DIFF
--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -489,9 +489,8 @@ enum quantum_keycodes {
 #define SWIN(kc) SGUI(kc)
 #define LCA(kc)  (QK_LCTL | QK_LALT | (kc))
 
-#define MOD_HYPR 0xf
-#define MOD_MEH 0x7
-
+#define MOD_HYPR 0xF
+#define MOD_MEH  0x7
 
 // Aliases for shifted symbols
 // Each key has a 4-letter code, and some have longer aliases too.
@@ -601,7 +600,7 @@ enum quantum_keycodes {
 #define RGB_M_T RGB_MODE_RGBTEST
 
 // L-ayer, T-ap - 256 keycode max, 16 layer max
-#define LT(layer, kc) (QK_LAYER_TAP | ((layer & 0xF) << 8) | ((kc) & 0xFF))
+#define LT(layer, kc) (QK_LAYER_TAP | (((layer) & 0xF) << 8) | ((kc) & 0xFF))
 
 #define AG_SWAP MAGIC_SWAP_ALT_GUI
 #define AG_NORM MAGIC_UNSWAP_ALT_GUI
@@ -615,28 +614,28 @@ enum quantum_keycodes {
 // In fact, we changed it to assume ON_PRESS for sanity/simplicity. If needed, you can add your own
 // keycode modeled after the old version, kept below for this.
 /* #define TO(layer, when) (QK_TO | (when << 0x4) | (layer & 0xFF)) */
-#define TO(layer) (QK_TO | (ON_PRESS << 0x4) | (layer & 0xFF))
+#define TO(layer) (QK_TO | (ON_PRESS << 0x4) | ((layer) & 0xFF))
 
 // Momentary switch layer - 256 layer max
-#define MO(layer) (QK_MOMENTARY | (layer & 0xFF))
+#define MO(layer) (QK_MOMENTARY | ((layer) & 0xFF))
 
 // Set default layer - 256 layer max
-#define DF(layer) (QK_DEF_LAYER | (layer & 0xFF))
+#define DF(layer) (QK_DEF_LAYER | ((layer) & 0xFF))
 
 // Toggle to layer - 256 layer max
-#define TG(layer) (QK_TOGGLE_LAYER | (layer & 0xFF))
+#define TG(layer) (QK_TOGGLE_LAYER | ((layer) & 0xFF))
 
 // One-shot layer - 256 layer max
-#define OSL(layer) (QK_ONE_SHOT_LAYER | (layer & 0xFF))
+#define OSL(layer) (QK_ONE_SHOT_LAYER | ((layer) & 0xFF))
 
 // L-ayer M-od: Momentary switch layer with modifiers active - 16 layer max, left mods only
-#define LM(layer, mod) (QK_LAYER_MOD | ((layer & 0xF) << 4) | ((mod) & 0xF))
+#define LM(layer, mod) (QK_LAYER_MOD | (((layer) & 0xF) << 4) | ((mod) & 0xF))
 
 // One-shot mod
 #define OSM(mod) (QK_ONE_SHOT_MOD | ((mod) & 0xFF))
 
 // Layer tap-toggle
-#define TT(layer) (QK_LAYER_TAP_TOGGLE | (layer & 0xFF))
+#define TT(layer) (QK_LAYER_TAP_TOGGLE | ((layer) & 0xFF))
 
 // M-od, T-ap - 256 keycode max
 #define MT(mod, kc) (QK_MOD_TAP | (((mod) & 0x1F) << 8) | ((kc) & 0xFF))

--- a/tmk_core/common/progmem.h
+++ b/tmk_core/common/progmem.h
@@ -5,9 +5,9 @@
 #   include <avr/pgmspace.h>
 #else
 #   define PROGMEM
-#   define pgm_read_byte(p)     *((unsigned char*)p)
-#   define pgm_read_word(p)     *((uint16_t*)p)
-#   define pgm_read_dword(p)    *((uint32_t*)p)
+#   define pgm_read_byte(p)     *((unsigned char*)(p))
+#   define pgm_read_word(p)     *((uint16_t*)(p))
+#   define pgm_read_dword(p)    *((uint32_t*)(p))
 #endif
 
 #endif


### PR DESCRIPTION
Add missing parentheses around arguments in macros like `LT`, `MO`, `TT`, `pgm_read_byte` etc.

## Description
This is done to prevent unintended grouping of operands due to operator precedence. Take the `MO` macro in its current state, for example:

```c
#define MO(layer) (QK_MOMENTARY | (layer & 0xFF))
```

Calling this macro with e.g. `MO(cond ? _RAISE : _LOWER)` would result in unexpected behavior. The macro would be expanded like so: `(QK_MOMENTARY | (cond ? _RAISE : _LOWER & 0xFF))`. Then, because of operator precedence, `_LOWER & 0xFF` would be grouped together, which likely isn't what was intended.
To fix this, we instead define `MO` as follows:

```c
#define MO(layer) (QK_MOMENTARY | ((layer) & 0xFF))
```

Same goes for
```c
#define pgm_read_dword(p) *((uint32_t*)p)
```
If we call that with `pgm_read_dword(unicode_map + index)`, `unicode_map` will be cast to a pointer before addition, likely resulting in _the wrong address being calculated_ due to how pointer arithmetic works.
The argument, `p`, must be wrapped in parentheses:
```c
#define pgm_read_dword(p) *((uint32_t*)(p))
```

This is a common pitfall in C. Macro arguments should always be parenthesized. See [this SO question](https://stackoverflow.com/questions/7186504/c-macros-and-use-of-arguments-in-parentheses) for more information.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Core
- [x] Bugfix
- [ ] New Feature
- [ ] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
