### PR TITLE
Changed QMK_USB_DRIVER_CONFIG to fix #4783

### DIFF
--- a/tmk_core/protocol/chibios/usb_main.c
+++ b/tmk_core/protocol/chibios/usb_main.c
@@ -168,43 +168,43 @@ typedef struct {
   .queue_capacity_in = stream##_IN_CAPACITY, \
   .queue_capacity_out = stream##_OUT_CAPACITY, \
   .in_ep_config = { \
-    .ep_mode = stream##_IN_MODE, \
-    .setup_cb = NULL, \
-    .in_cb = qmkusbDataTransmitted, \
-    .out_cb = NULL, \
-    .in_maxsize = stream##_EPSIZE, \
-    .out_maxsize = 0, \
+    stream##_IN_MODE,           /* Interrupt EP */ \
+    NULL,                       /* SETUP packet notification callback */ \
+    qmkusbDataTransmitted,      /* IN notification callback */ \
+    NULL,                       /* OUT notification callback */ \
+    stream##_EPSIZE,            /* IN maximum packet size */ \
+    0,                          /* OUT maximum packet size */ \
     /* The pointer to the states will be filled during initialization */ \
-    .in_state = NULL, \
-    .out_state = NULL, \
-    .ep_buffers = 2, \
-    .setup_buf = NULL \
+    NULL,                       /* IN Endpoint state */ \
+    NULL,                       /* OUT endpoint state */ \
+    2,                          /* IN multiplier */ \
+    NULL                        /* SETUP buffer (not a SETUP endpoint) */ \
   }, \
   .out_ep_config = { \
-    .ep_mode = stream##_OUT_MODE, \
-    .setup_cb = NULL, \
-    .in_cb = NULL, \
-    .out_cb = qmkusbDataReceived, \
-    .in_maxsize = 0, \
-    .out_maxsize = stream##_EPSIZE, \
+    stream##_OUT_MODE,          /* Interrupt EP */ \
+    NULL,                       /* SETUP packet notification callback */ \
+    NULL,                       /* IN notification callback */ \
+    qmkusbDataReceived,         /* OUT notification callback */ \
+    0,                          /* IN maximum packet size */ \
+    stream##_EPSIZE,            /* OUT maximum packet size */ \
     /* The pointer to the states will be filled during initialization */ \
-    .in_state = NULL, \
-    .out_state = NULL, \
-    .ep_buffers = 2, \
-    .setup_buf = NULL, \
+    NULL,                       /* IN Endpoint state */ \
+    NULL,                       /* OUT endpoint state */ \
+    2,                          /* IN multiplier */ \
+    NULL                        /* SETUP buffer (not a SETUP endpoint) */ \
   }, \
   .int_ep_config = { \
-    .ep_mode = USB_EP_MODE_TYPE_INTR, \
-    .setup_cb = NULL, \
-    .in_cb = qmkusbInterruptTransmitted, \
-    .out_cb = NULL, \
-    .in_maxsize = CDC_NOTIFICATION_EPSIZE, \
-    .out_maxsize = 0, \
+    USB_EP_MODE_TYPE_INTR,      /* Interrupt EP */ \
+    NULL,                       /* SETUP packet notification callback */ \
+    qmkusbInterruptTransmitted, /* IN notification callback */ \
+    NULL,                       /* OUT notification callback */ \
+    CDC_NOTIFICATION_EPSIZE,    /* IN maximum packet size */ \
+    0,                          /* OUT maximum packet size */ \
     /* The pointer to the states will be filled during initialization */ \
-    .in_state = NULL, \
-    .out_state = NULL, \
-    .ep_buffers = 2, \
-    .setup_buf = NULL, \
+    NULL,                       /* IN Endpoint state */ \
+    NULL,                       /* OUT endpoint state */ \
+    2,                          /* IN multiplier */ \
+    NULL                        /* SETUP buffer (not a SETUP endpoint) */ \
   }, \
   .config = { \
     .usbp = &USB_DRIVER, \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- This template is entirely option and can be removed, but is here to help both you and us. -->
<!--- This text and anything on lines wrapped like this one will not show up in the final text. This text is to help us and you. -->

## Description
<!--- Describe your changes in detail -->
Updates QMK_USB_DRIVER_CONFIG macro to use implicit field names for the
3 USBEndpointConfig structs. ChibiOS sometimes uses the field name
`ep_buffers` and other times uses `in_multiplier`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Core
- [x] Bugfix
- [ ] New Feature
- [ ] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation


## Issues Fixed or Closed by this PR

* #4783 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
