### PR TITLE
Fractal layout macro and readme cleanup

### DIFF
--- a/keyboards/fractal/fractal.h
+++ b/keyboards/fractal/fractal.h
@@ -1,5 +1,4 @@
-#ifndef FRACTAL_H
-#define FRACTAL_H
+#pragma once
 
 #include "quantum.h"
 
@@ -30,7 +29,3 @@
   { K300,  K301,  K302,  K303,  K304,  K305,  K306,  K307,  K308,  K309,  K310,  K311 }, \
   { K400,  K401,  K402,  K403,  K404,  KC_NO, K406,  K407,  K408,  K409,  K410,  K411 }  \
 }
-
-#define KEYMAP LAYOUT_preonic_mit
-
-#endif

--- a/keyboards/fractal/readme.md
+++ b/keyboards/fractal/readme.md
@@ -11,4 +11,4 @@ Make example for this keyboard (after setting up your build environment):
 
     make fractal:default
 
-See [build environment setup](https://docs.qmk.fm/build_environment_setup.html) then the [make instructions](https://docs.qmk.fm/make_instructions.html) for more information.
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).

--- a/keyboards/fractal/rules.mk
+++ b/keyboards/fractal/rules.mk
@@ -57,5 +57,5 @@ UNICODE_ENABLE = no         # Unicode
 BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
 AUDIO_ENABLE = no           # Audio output on port C6
 
-LAYOUTS = preonic_mit ortho_5x12
+LAYOUTS = ortho_5x12 # preonic_mit
 LAYOUTS_HAS_RGB = no


### PR DESCRIPTION
## Commit Log

### Fractal: layout macro cleanup (62c69ce)

Removed KEYMAP alias for LAYOUT_preonic_mit. Alias was unused, and the terminology usage is deprecated.

### Fractal: readme cleanup (a23e18c)

Updated the line containing the documentation links in the readme.