### PR TITLE
Add support for running custom actions when modifiers are held.

### DIFF
--- a/docs/ref_functions.md
+++ b/docs/ref_functions.md
@@ -126,7 +126,7 @@ key. When pressed, qmk will send these events: shift pressed, slash (/) pressed,
 slash released, shift released. But then what happens when pressing shift and
 that key? QMK Firmware will send shift pressed, slash pressed, slash released and shift
 released. The OS won't be able to distinguish between the two and you might just
-have lost a usefull keycombo on your shiny new keymap. This is  where the
+have lost a useful key combo on your shiny new keymap. This is where the
 `custom_keycode_on_modifiers` function comes in. It can be used to have qmk send
 another keycode when some modifiers are pressed. Its prototype is
 

--- a/docs/ref_functions.md
+++ b/docs/ref_functions.md
@@ -127,7 +127,7 @@ slash released, shift released. But then what happens when pressing shift and
 that key? QMK Firmware will send shift pressed, slash pressed, slash released and shift
 released. The OS won't be able to distinguish between the two and you might just
 have lost a useful key combo on your shiny new keymap. This is where the
-`custom_keycode_on_modifiers` function comes in. It can be used to have qmk send
+`custom_keycode_on_modifiers` function comes in. It can be used to have QMK Firmware send
 another keycode when some modifiers are pressed. Its prototype is
 
 ```c

--- a/docs/ref_functions.md
+++ b/docs/ref_functions.md
@@ -157,7 +157,7 @@ When ? is pressed and left shift is hold, on any layer, send !. You can combine
 multiple modifiers like this:
 
 ```c
-MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_LCTRL())
+MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_LCTRL)
 ```
 
 This means that left shift and left control must be held for the custom keycode

--- a/docs/ref_functions.md
+++ b/docs/ref_functions.md
@@ -117,3 +117,71 @@ if (timer_elapsed(key_timer) < 100) {
   // do something if 100ms or more have passed
 }
 ```
+## Custom modified keycode handling
+
+Sometimes you might want to send a specific keycode or execute a specific macro
+when some modifiers and a key are pressed. For example let's say that your
+keymap binds a shifted keycode like question mark (?) on a qwerty keyboard to a
+key. When pressed, qmk will send these events: shift pressed, slash (/) pressed,
+slash released, shift released. But then what happens when pressing shift and
+that key ? Qmk will send shitf pressed, slash pressed, slash released and shift
+released. The OS won't be able to distinguish between the two and you might just
+have lost a usefull keycombo on your shiny new keymap. This is  where the
+`custom_keycode_on_modifiers` function comes in. It can be used to have qmk send
+another keycode when some modifiers are pressed. Its prototype is
+
+```c
+bool custom_keycode_on_modifiers(uint8_t modifier_mask, uint8_t layer, keyrecord_t *record, uint16_t custom_keycode)
+```
+
+The first argument is the modifiers that must be held for the custom keycode to
+be sent. Use the `MOD_BIT(keycode)` macro to create it. The second argument is
+the layer that must be active for the custom keycode to be sent. Use -1 if it
+must be available on all layers. The third argument is the key record being
+processed and the last one is the custom keycode you want to set when the
+modifiers and layer conditions are met. For example:
+
+```c
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  switch(keycode) {
+    case KC_QUESTION:
+      return custom_keycode_on_modifiers(MOD_BIT(KC_LSHIFT), -1, record,  KC_EXCLAIM);
+  }
+
+  return true;
+}
+
+```
+
+When ? is pressed and left shift is hold, on any layer, send !. You can combine
+multiple modifiers like this:
+
+```c
+MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_LCTRL())
+```
+
+This means that left shift and left control must be held for the custom keycode
+to register. If you want to send the custom keycode on both left and right
+shift, you'll have to call the function twice:
+
+```c
+return custom_keycode_on_modifiers(MOD_BIT(KC_LSHIFT), -1, record,  KC_EXCLAIM) && custom_keycode_on_modifiers(MOD_BIT(KC_RSHIFT), -1, record,  KC_EXCLAIM);
+```
+
+If you need to do something else than registering a keycode, you can use the
+`run_on_modifiers` function. It is used internaly by the
+`custom_keycode_on_modifiers` function. It's prototype is
+
+```c
+bool run_on_modifiers(uint8_t modifier_mask, int16_t layer, uint16_t keycode,  keyrecord_t *record,
+                      void *data,  bool (*handler)(uint16_t keycode,  keyrecord_t *record, void *data))
+```
+
+The two first arguments are the same as the `custom_keycode_on_modifiers`
+function. The `keycode` argument is the currently processed key code, the
+`record` argument is the currently processed record. The last argument is a
+function pointer that will be called with the current key code, the current
+record and any data you have given as the `data` argument when the modifiers are
+layer conditions are met. This function will send to the os a release event for
+the currently hold modifiers, run your code and then make sure that the internal qmk
+state is consistent when releasing the key.

--- a/docs/ref_functions.md
+++ b/docs/ref_functions.md
@@ -119,27 +119,13 @@ if (timer_elapsed(key_timer) < 100) {
 ```
 ## Custom modified keycode handling
 
-Sometimes you might want to send a specific keycode or execute a specific macro
-when some modifiers and a key are pressed. For example let's say that your
-keymap binds a shifted keycode like question mark (?) on a qwerty keyboard to a
-key. When pressed, qmk will send these events: shift pressed, slash (/) pressed,
-slash released, shift released. But then what happens when pressing shift and
-that key? QMK Firmware will send shift pressed, slash pressed, slash released and shift
-released. The OS won't be able to distinguish between the two and you might just
-have lost a useful key combo on your shiny new keymap. This is where the
-`custom_keycode_on_modifiers` function comes in. It can be used to have QMK Firmware send
-another keycode when some modifiers are pressed. Its prototype is
+Sometimes you might want to send a specific keycode or execute a specific macro when some modifiers and a key are pressed. For example let's say that your keymap binds a shifted keycode like question mark (?) on a qwerty keyboard to a key. When pressed, qmk will send these events: shift pressed, slash (/) pressed, slash released, shift released. But then what happens when pressing shift and that key? QMK Firmware will send shift pressed, slash pressed, slash released and shift released. The OS won't be able to distinguish between the two and you might just have lost a useful key combo on your shiny new keymap. This is where the `custom_keycode_on_modifiers` function comes in. It can be used to have QMK Firmware send another keycode when some modifiers are pressed. Its prototype is
 
 ```c
 bool custom_keycode_on_modifiers(uint8_t modifier_mask, uint8_t layer, keyrecord_t *record, uint16_t custom_keycode)
 ```
 
-The first argument is the modifiers that must be held for the custom keycode to
-be sent. Use the `MOD_BIT(keycode)` macro to create it. The second argument is
-the layer that must be active for the custom keycode to be sent. Use -1 if it
-must be available on all layers. The third argument is the key record being
-processed and the last one is the custom keycode you want to set when the
-modifiers and layer conditions are met. For example:
+The first argument is the modifiers that must be held for the custom keycode to be sent. Use the `MOD_BIT(keycode)` macro to create it. The second argument is the layer that must be active for the custom keycode to be sent. Use -1 if it must be available on all layers. The third argument is the key record being processed and the last one is the custom keycode you want to set when the modifiers and layer conditions are met. For example:
 
 ```c
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
@@ -153,23 +139,19 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 
 ```
 
-When ? is pressed and left shift is hold, on any layer, send !. You can combine
-multiple modifiers like this:
+When ? is pressed and left shift is hold, on any layer, send !. You can combine multiple modifiers like this:
 
 ```c
 MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_LCTRL)
 ```
 
-This means that left shift and left control must be held for the custom keycode
-to register. If you want to send the custom keycode on both left and right
-shift, you'll have to call the function twice:
+This means that left shift and left control must be held for the custom keycode to register. If you want to send the custom keycode on both left and right shift, you'll have to call the function twice:
 
 ```c
 return custom_keycode_on_modifiers(MOD_BIT(KC_LSHIFT), -1, record,  KC_EXCLAIM) && custom_keycode_on_modifiers(MOD_BIT(KC_RSHIFT), -1, record,  KC_EXCLAIM);
 ```
 
-If you need to do something else than registering a keycode, you can use the
-`run_on_modifiers` function. It is used internaly by the
+If you need to do something else than registering a keycode, you can use the `run_on_modifiers` function. It is used internaly by the
 `custom_keycode_on_modifiers` function. It's prototype is
 
 ```c
@@ -177,11 +159,4 @@ bool run_on_modifiers(uint8_t modifier_mask, int16_t layer, uint16_t keycode,  k
                       void *data,  bool (*handler)(uint16_t keycode,  keyrecord_t *record, void *data))
 ```
 
-The two first arguments are the same as the `custom_keycode_on_modifiers`
-function. The `keycode` argument is the currently processed key code, the
-`record` argument is the currently processed record. The last argument is a
-function pointer that will be called with the current key code, the current
-record and any data you have given as the `data` argument when the modifiers are
-layer conditions are met. This function will send to the os a release event for
-the currently hold modifiers, run your code and then make sure that the internal qmk
-state is consistent when releasing the key.
+The two first arguments are the same as the `custom_keycode_on_modifiers` function. The `keycode` argument is the currently processed key code, the `record` argument is the currently processed record. The last argument is a function pointer that will be called with the current key code, the current record and any data you have given as the `data` argument when the modifiers are layer conditions are met. This function will send to the os a release event for the currently hold modifiers, run your code and then make sure that the internal qmk state is consistent when releasing the key.

--- a/docs/ref_functions.md
+++ b/docs/ref_functions.md
@@ -124,7 +124,7 @@ when some modifiers and a key are pressed. For example let's say that your
 keymap binds a shifted keycode like question mark (?) on a qwerty keyboard to a
 key. When pressed, qmk will send these events: shift pressed, slash (/) pressed,
 slash released, shift released. But then what happens when pressing shift and
-that key ? Qmk will send shitf pressed, slash pressed, slash released and shift
+that key? QMK Firmware will send shift pressed, slash pressed, slash released and shift
 released. The OS won't be able to distinguish between the two and you might just
 have lost a usefull keycombo on your shiny new keymap. This is  where the
 `custom_keycode_on_modifiers` function comes in. It can be used to have qmk send

--- a/tmk_core/common/action_util.c
+++ b/tmk_core/common/action_util.c
@@ -21,7 +21,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "action_layer.h"
 #include "timer.h"
 #include "keycode_config.h"
-#include <quantum_keycodes.h>
 #include <quantum/quantum.h>
 
 extern keymap_config_t keymap_config;

--- a/tmk_core/common/action_util.c
+++ b/tmk_core/common/action_util.c
@@ -22,6 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "timer.h"
 #include "keycode_config.h"
 #include <quantum_keycodes.h>
+#include <quantum/quantum.h>
 
 extern keymap_config_t keymap_config;
 

--- a/tmk_core/common/action_util.c
+++ b/tmk_core/common/action_util.c
@@ -464,7 +464,7 @@ static bool custom_keycode_on_modifiers_handler(uint16_t keycode, keyrecord_t *r
     register_code16(custom_keycode);
   } else {
     /* release the alternate key */
-    unregister_code(custom_keycode);
+    unregister_code16(custom_keycode);
 
     /* make sure all mods we sat up earlier are released */
     clear_weak_mods();

--- a/tmk_core/common/action_util.c
+++ b/tmk_core/common/action_util.c
@@ -461,7 +461,7 @@ static bool custom_keycode_on_modifiers_handler(uint16_t keycode, keyrecord_t *r
     send_keyboard_report();
 
     /* send alternate key code */
-    register_code(custom_keycode);
+    register_code16(custom_keycode);
   } else {
     /* release the alternate key */
     unregister_code(custom_keycode);

--- a/tmk_core/common/action_util.h
+++ b/tmk_core/common/action_util.h
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <stdint.h>
 #include "report.h"
+#include "action.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -95,6 +96,11 @@ void release_oneshot_swaphands(void);
 void use_oneshot_swaphands(void);
 void clear_oneshot_swaphands(void);
 #endif
+
+bool run_on_modifiers(uint8_t modifier_mask, int16_t layer, uint16_t keycode,  keyrecord_t *record,
+                      void *data, bool (*handler)(uint16_t keycode,  keyrecord_t *record, void *data));
+
+bool custom_keycode_on_modifiers(uint8_t modifier_mask, int16_t layer, keyrecord_t *record, uint16_t custom_keycode);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Description

It is possible currently via the new macro code to execute specific code when a key is pressed and some modifiers are held but it's a bit complicated. Let's say you want to send alt-x when shift-y is pressed (just a bad example here), you need to check if y is pressed, if shift is held, unregister shift to the os, send alt pressed event, send x pressed event, send x released event, send alt released event and send shift pressed event so that the os state is matching the keyboard state afterward. 

This PR adds helper functions to do that more easily. It adds the `run_on_modifiers` and `custom_keycode_on_modifiers` function to ease executing custom action when modifiers are hold. The `run_on_modifiers` function checks the currently held modifiers. If the specified ones are held, it unregisters them to the os, execute a given function and restore the state on release. The `custom_keycode_on_modifiers` function use the previous one to send a keycode when modifiers are held.

## Types of changes
- [ ] Core
- [ ] Bugfix
- [x] New Feature
- [ ] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).