### PR TITLE
Circular animation

### DIFF
--- a/tmk_core/protocol/arm_atsam/led_matrix.c
+++ b/tmk_core/protocol/arm_atsam/led_matrix.c
@@ -218,6 +218,7 @@ void disp_calc_extents(void)
 
     disp.width = disp.right - disp.left;
     disp.height = disp.top - disp.bottom;
+    disp.max_distance = sqrtf(powf(disp.width, 2) + powf(disp.height, 2));
 }
 
 void disp_pixel_setup(void)
@@ -267,6 +268,7 @@ void led_matrix_run(void)
     float go;
     float bo;
     float po;
+
     uint8_t led_this_run = 0;
     led_setup_t *f = (led_setup_t*)led_setups[led_animation_id];
 
@@ -330,7 +332,7 @@ void led_matrix_run(void)
             {
 
                 if (led_animation_circular) {
-                  po = sqrtf((powf(fabsf(50 - led_cur->py), 2) + powf(fabsf(50 - led_cur->px), 2)));
+                  po = sqrtf((powf(fabsf((disp.width / 2) - (led_cur->x - disp.left)), 2) + powf(fabsf((disp.height / 2) - (led_cur->y - disp.bottom)), 2))) / disp.max_distance * 100;
                 }
                 else {
                   if (led_animation_orientation)

--- a/tmk_core/protocol/arm_atsam/led_matrix.c
+++ b/tmk_core/protocol/arm_atsam/led_matrix.c
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "arm_atsam_protocol.h"
 #include "tmk_core/common/led.h"
 #include <string.h>
+#include <math.h>
 
 void SERCOM1_0_Handler( void )
 {
@@ -249,6 +250,7 @@ uint8_t led_animation_breathing;
 uint8_t led_animation_breathe_cur;
 uint8_t breathe_step;
 uint8_t breathe_dir;
+uint8_t led_animation_circular;
 uint64_t led_next_run;
 
 uint8_t led_animation_id;
@@ -327,13 +329,18 @@ void led_matrix_run(void)
             for (fcur = 0; fcur < fmax; fcur++)
             {
 
-                if (led_animation_orientation)
-                {
-                  po = led_cur->py;
+                if (led_animation_circular) {
+                  po = sqrtf((powf(fabsf(50 - led_cur->py), 2) + powf(fabsf(50 - led_cur->px), 2)));
                 }
-                else
-                {
-                  po = led_cur->px;
+                else {
+                  if (led_animation_orientation)
+                  {
+                      po = led_cur->py;
+                  }
+                  else
+                  {
+                      po = led_cur->px;
+                  }
                 }
 
                 float pomod;
@@ -466,6 +473,7 @@ uint8_t led_matrix_init(void)
     led_animation_breathe_cur = BREATHE_MIN_STEP;
     breathe_step = 1;
     breathe_dir = 1;
+    led_animation_circular = 0;
 
     gcr_min_counter = 0;
     v_5v_cat_hit = 0;

--- a/tmk_core/protocol/arm_atsam/led_matrix.c
+++ b/tmk_core/protocol/arm_atsam/led_matrix.c
@@ -332,17 +332,17 @@ void led_matrix_run(void)
             {
 
                 if (led_animation_circular) {
-                  po = sqrtf((powf(fabsf((disp.width / 2) - (led_cur->x - disp.left)), 2) + powf(fabsf((disp.height / 2) - (led_cur->y - disp.bottom)), 2))) / disp.max_distance * 100;
+                    po = sqrtf((powf(fabsf((disp.width / 2) - (led_cur->x - disp.left)), 2) + powf(fabsf((disp.height / 2) - (led_cur->y - disp.bottom)), 2))) / disp.max_distance * 100;
                 }
                 else {
-                  if (led_animation_orientation)
-                  {
-                      po = led_cur->py;
-                  }
-                  else
-                  {
-                      po = led_cur->px;
-                  }
+                    if (led_animation_orientation)
+                    {
+                        po = led_cur->py;
+                    }
+                    else
+                    {
+                        po = led_cur->px;
+                    }
                 }
 
                 float pomod;

--- a/tmk_core/protocol/arm_atsam/led_matrix.h
+++ b/tmk_core/protocol/arm_atsam/led_matrix.h
@@ -83,6 +83,7 @@ typedef struct led_disp_s {
     float bottom;
     float width;
     float height;
+    float max_distance;
 } led_disp_t;
 
 uint8_t led_matrix_init(void);

--- a/tmk_core/protocol/arm_atsam/led_matrix.h
+++ b/tmk_core/protocol/arm_atsam/led_matrix.h
@@ -129,6 +129,7 @@ extern uint8_t led_animation_orientation;
 extern uint8_t led_animation_breathing;
 extern uint8_t led_animation_breathe_cur;
 extern uint8_t breathe_dir;
+extern uint8_t led_animation_circular;
 extern const uint8_t led_setups_count;
 
 extern void *led_setups[];


### PR DESCRIPTION
![radiating circles](https://66.media.tumblr.com/b90d0b1b49e7e75ed9ffe808659f1e57/tumblr_peeivqFflS1uag7foo2_500.gif)

## Description
It me, the animation person, here with a new animation PR! This time I'm adding another animation mode to the `arm_atsam` led matrix that animates the defined animation bands outward or inward in regard to the center of a keyboard.

Wanted to explore doing a circular animation out from a pressed key, but I don't know enough about support for animation triggers or getting their coordinates to do that so instead I decided to add a repeating circular animation (we could theoretically add variables to configure where the center is or modifier keys to adjust that if we wanted to). Advice on animation triggers and coordinates for key presses for a follow-up PR would be appreciated!

Forgive the potato quality, but here's a demo video:
![demo video of circular animation](https://cl.ly/b0b2f1ddac20/circular_keyboard_crop.webp)

## Types of changes
- [ ] Core
- [ ] Bugfix
- [ ] New Feature
- [x] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
