### PR TITLE
Add KBD75 keymap

### DIFF
--- a/keyboards/kbd75/keymaps/edulpn/README.md
+++ b/keyboards/kbd75/keymaps/edulpn/README.md
@@ -4,10 +4,10 @@
 75% Keymap for KBD75 with default ANSI layout + default layer switching for Windows and Mac "modes" + custom Fn layers for each mode.
 
 ### Windows Mode
-![Edulpn Keymap for the KBD75 PCB Windows Mode](https://i.imgur.com/PoL5qcr.png)
+![Edulpn Keymap for the KBD75 PCB Windows Mode](https://imgur.com/doI46vP.png)
 
 ### Mac Mode
-![Edulpn Keymap for the KBD75 PCB Mac Mode](https://i.imgur.com/PoL5qcr.png)
+![Edulpn Keymap for the KBD75 PCB Mac Mode](https://i.imgur.com/t7oTjjc.png)
 
 ## Build
 To build the default keymap, simply run `make kbd75/rev2:edulpn`.

--- a/keyboards/kbd75/keymaps/edulpn/README.md
+++ b/keyboards/kbd75/keymaps/edulpn/README.md
@@ -1,0 +1,10 @@
+# Edulpn Keymap for the KBD75 PCB
+
+## Additional Notes
+75% Keymap for KBD75 with default ANSI layout + default layer switching for Windows and Mac "modes" + custom Fn layers for each mode.
+
+![Edulpn Keymap for the KBD75 PCB Windows Mode](https://i.imgur.com/PoL5qcr.png)
+![Edulpn Keymap for the KBD75 PCB Mac Mode](https://i.imgur.com/PoL5qcr.png)
+
+## Build
+To build the default keymap, simply run `make kbd75/rev2:edulpn`.

--- a/keyboards/kbd75/keymaps/edulpn/README.md
+++ b/keyboards/kbd75/keymaps/edulpn/README.md
@@ -3,7 +3,10 @@
 ## Additional Notes
 75% Keymap for KBD75 with default ANSI layout + default layer switching for Windows and Mac "modes" + custom Fn layers for each mode.
 
+### Windows Mode
 ![Edulpn Keymap for the KBD75 PCB Windows Mode](https://i.imgur.com/PoL5qcr.png)
+
+### Mac Mode
 ![Edulpn Keymap for the KBD75 PCB Mac Mode](https://i.imgur.com/PoL5qcr.png)
 
 ## Build

--- a/keyboards/kbd75/keymaps/edulpn/keymap.c
+++ b/keyboards/kbd75/keymaps/edulpn/keymap.c
@@ -1,0 +1,67 @@
+#include QMK_KEYBOARD_H
+
+#define WINDOWS_LAYER 0
+#define WINDOWS_FN_LAYER 1
+#define MAC_LAYER 2
+#define MAC_FN_LAYER 3
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+  [WINDOWS_LAYER] = LAYOUT(
+    KC_ESC,   KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,                 KC_F11,   KC_F12,   KC_PSCR,  TG(MAC_LAYER),  KC_DEL,
+    KC_GRV,   KC_1,     KC_2,     KC_3,     KC_4,     KC_5,     KC_6,     KC_7,     KC_8,     KC_9,     KC_0,                   KC_MINS,  KC_EQL,   KC_BSPC,  KC_BSPC,        KC_HOME,
+    KC_TAB,   KC_Q,     KC_W,     KC_E,     KC_R,     KC_T,     KC_Y,     KC_U,     KC_I,     KC_O,     KC_P,                   KC_LBRC,  KC_RBRC,  KC_BSLS,                  KC_END,
+    KC_CAPS,  KC_A,     KC_S,     KC_D,     KC_F,     KC_G,     KC_H,     KC_J,     KC_K,     KC_L,     KC_SCLN,                KC_QUOT,                      KC_ENT,         KC_PGUP,
+    KC_LSFT,  KC_TRNS,  KC_Z,     KC_X,     KC_C,     KC_V,     KC_B,     KC_N,     KC_M,     KC_COMM,  KC_DOT,                 KC_SLSH,  KC_RSFT,            KC_UP,          KC_PGDN,
+    KC_LCTL,  KC_LWIN,  KC_LALT,                      KC_SPC,   KC_SPC,   KC_SPC,                       MO(WINDOWS_FN_LAYER),   KC_TRNS,  KC_RCTL,  KC_LEFT,  KC_DOWN,        KC_RGHT
+  ),
+
+  [WINDOWS_FN_LAYER] = LAYOUT(
+    KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_MPRV,  KC_MPLY,  KC_MNXT,  KC_MUTE,  KC_VOLD,  KC_VOLU,  KC_TRNS,  KC_TRNS,  KC_TRNS,
+    KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,
+    KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,            KC_TRNS,
+    KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,                      KC_TRNS,  KC_TRNS,
+    KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,            KC_TRNS,  KC_TRNS,
+    KC_TRNS,  KC_TRNS,  KC_TRNS,                      KC_TRNS,  KC_TRNS,  KC_TRNS,                      KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS
+  ),
+
+  [MAC_LAYER] = LAYOUT(
+    KC_ESC,   KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,             KC_F11,   KC_F12,   KC_PSCR,  TG(MAC_LAYER),  KC_DEL,
+    KC_GRV,   KC_1,     KC_2,     KC_3,     KC_4,     KC_5,     KC_6,     KC_7,     KC_8,     KC_9,     KC_0,               KC_MINS,  KC_EQL,   KC_BSPC,  KC_BSPC,            KC_HOME,
+    KC_TAB,   KC_Q,     KC_W,     KC_E,     KC_R,     KC_T,     KC_Y,     KC_U,     KC_I,     KC_O,     KC_P,               KC_LBRC,  KC_RBRC,  KC_BSLS,                      KC_END,
+    KC_CAPS,  KC_A,     KC_S,     KC_D,     KC_F,     KC_G,     KC_H,     KC_J,     KC_K,     KC_L,     KC_SCLN,            KC_QUOT,                      KC_ENT,             KC_PGUP,
+    KC_LSFT,  KC_TRNS,  KC_Z,     KC_X,     KC_C,     KC_V,     KC_B,     KC_N,     KC_M,     KC_COMM,  KC_DOT,             KC_SLSH,  KC_RSFT,            KC_UP,              KC_PGDN,
+    KC_LCTL,  KC_LALT,  KC_LCMD,                      KC_SPC,   KC_SPC,   KC_SPC,                       MO(MAC_FN_LAYER),   KC_TRNS,  KC_RCTL,  KC_LEFT,  KC_DOWN,            KC_RGHT
+  ),
+
+  [MAC_FN_LAYER] = LAYOUT(
+    RESET,    KC_BRID,  KC_BRIU,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_MRWD,  KC_MPLY,  KC_MFFD,  KC__VOLDOWN,  KC__VOLUP,  KC_TRNS,  KC_TRNS,  KC_TRNS,
+    KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,      KC_TRNS,    KC_TRNS,  KC_TRNS,  KC_TRNS,
+    KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,      KC_TRNS,    KC_TRNS,            KC_TRNS,
+    KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,                            KC_TRNS,  KC_TRNS,
+    KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,      KC_TRNS,              KC_TRNS,  KC_TRNS,
+    KC_TRNS,  KC_TRNS,  KC_TRNS,                      KC_TRNS,  KC_TRNS,  KC_TRNS,                      KC_TRNS,  KC_TRNS,      KC_TRNS,    KC_TRNS,  KC_TRNS,  KC_TRNS
+  )
+};
+
+uint32_t layer_state_set_user(uint32_t state) {
+    switch (biton32(state)) {
+    case WINDOWS_LAYER:
+        rgblight_setrgb_blue();
+        break;
+    case WINDOWS_FN_LAYER:
+        rgblight_setrgb_blue();
+        break;
+    case MAC_LAYER:
+        rgblight_setrgb_white();
+        break;
+    case MAC_FN_LAYER:
+        rgblight_setrgb_white();
+        break;
+    default:
+        rgblight_setrgb (0x00,  0xFF, 0xFF);
+        break;
+    }
+    return state;
+}
+


### PR DESCRIPTION
## Description
75% Keymap for KBD75 with default ANSI layout + default layer switching for Windows and Mac "modes" (using `TG()`) + custom Fn layers for each mode

## Types of changes
- [ ] Core
- [ ] Bugfix
- [ ] New Feature
- [ ] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [X] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation
