### PR TITLE
Keymap: ave-63's iris layout

### DIFF
--- a/keyboards/iris/keymaps/ave-63/config.h
+++ b/keyboards/iris/keymaps/ave-63/config.h
@@ -1,0 +1,38 @@
+/*
+Copyright 2017 Danny Nguyen <danny@keeb.io>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+/* Use I2C or Serial, not both */
+
+#define USE_SERIAL
+// #define USE_I2C
+
+#define PREVENT_STUCK_MODIFIERS
+#define TAPPING_TERM 150
+
+/* Select hand configuration */
+//#define MASTER_LEFT
+#define MASTER_RIGHT
+// #define EE_HANDS
+
+/*#undef RGBLED_NUMvbvbvbvbvbvbvtesting
+#define RGBLIGHT_ANIMATIONS
+#define RGBLED_NUM 1
+#define RGBLIGHT_HUE_STEP 8
+#define RGBLIGHT_SAT_STEP 8
+#define RGBLIGHT_VAL_STEP 8*/

--- a/keyboards/iris/keymaps/ave-63/keymap.c
+++ b/keyboards/iris/keymaps/ave-63/keymap.c
@@ -1,0 +1,120 @@
+/* Features of this keymap:
+
+--Lots of functionality on left hand for conjunction with mouse or pen in right hand
+--_COMMAND layer ESDF arrow keys
+--_MEH layer ESDF is super handy for switching tabs (SF) and apps (ED)
+--_MEH layer other keys are linked with my AutoHotKey script
+--macro for handling parentheses is very nice (credit: u/drashna)
+
+Some things are very non-standard, like position of number keys, etc.
+Will require heavy modification for most people.
+*/
+#include QMK_KEYBOARD_H
+
+extern keymap_config_t keymap_config;
+
+#define MODS_SHIFT_MASK (MOD_BIT(KC_LSHIFT)|MOD_BIT(KC_RSHIFT))
+
+enum my_layers {
+  _QWERTY,
+  _SYMBOL,
+  _COMMAND,
+  _MEH
+};
+
+enum custom_keycodes {
+    KC_MPRN = SAFE_RANGE,
+    KC_MBRC,
+    KC_MCBR,
+    KC_MABK
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+[_QWERTY] = LAYOUT(
+   KC_ESC,  KC_GRV,  KC_AT, KC_BSLS,   KC_NO, TG(_SYMBOL),                     KC_NO, KC_LGUI, KC_MBRC, KC_RBRC,   KC_NO,  KC_DEL,
+   KC_TAB,  KC_Q,    KC_W,     KC_E,    KC_R,    KC_T,                          KC_Y,    KC_U,    KC_I,    KC_O,    KC_P, KC_BSPC,
+   KC_LCTL, KC_A,    KC_S,     KC_D,    KC_F,    KC_G,                          KC_H,    KC_J,    KC_K,    KC_L, KC_SCLN, MO(_SYMBOL),
+   KC_LALT, KC_Z,    KC_X,     KC_C,    KC_V,    KC_B, MO(_MEH),       KC_QUOT, KC_N,    KC_M, KC_COMM,  KC_DOT, KC_SLSH, KC_RSFT,
+                                 KC_NO,  KC_LSFT, MO(_COMMAND),            KC_ENT,  KC_SPC, KC_NO
+),
+[_SYMBOL] = LAYOUT(
+   KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,                    KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 
+   KC_TRNS,  KC_EQL,    KC_9,    KC_8,    KC_7, KC_PLUS,                    KC_HASH, KC_UNDS, KC_MCBR, KC_RCBR, KC_TRNS, KC_TRNS, 
+   KC_TRNS,    KC_0,    KC_6,    KC_5,    KC_4, KC_MINS,                    KC_CIRC, KC_AMPR, KC_MPRN, KC_RPRN, KC_RBRC, KC_TRNS, 
+   KC_TRNS, KC_SLSH,    KC_3,    KC_2,    KC_1, KC_ASTR, KC_TRNS,  KC_TRNS, KC_EXLM, KC_DLR,  KC_MABK, KC_TRNS, KC_TRNS, KC_TRNS, 
+                                 KC_TRNS, KC_TRNS, KC_TRNS,           KC_TRNS,  KC_TRNS,  KC_TRNS 
+),
+[_COMMAND] = LAYOUT(
+    KC_APP, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,                    KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 
+   KC_TRNS, KC_PGUP, KC_HOME,   KC_UP,  KC_END, KC_VOLU,                    KC_SLCK,   KC_F9,  KC_F10,  KC_F11,  KC_F12, KC_TRNS, 
+   KC_TRNS, KC_PGDN, KC_LEFT, KC_DOWN, KC_RGHT, KC_VOLD,                    KC_CAPS,   KC_F5,   KC_F6,   KC_F7,   KC_F8, KC_TRNS, 
+   KC_TRNS, KC_TRNS, KC_TRNS, KC_PSCR, KC_TRNS, KC_MUTE, KC_TRNS,  KC_TRNS, KC_PAUS,   KC_F1,   KC_F2,   KC_F3,   KC_F4, KC_TRNS, 
+                                 KC_TRNS, KC_TRNS, KC_TRNS,           KC_TRNS,  KC_TRNS,  KC_TRNS 
+),
+[_MEH] = LAYOUT(
+   LALT(KC_F4), KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,                 KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, RESET, 
+   KC_TRNS, MEH(KC_Q), LCTL(KC_W), LSFT(KC_TAB), KC_DEL, MEH(KC_T),          KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 
+   KC_TRNS, MEH(KC_A),LSFT(LCTL(KC_TAB)),KC_TAB,LCTL(KC_TAB),MEH(KC_G),      KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 
+   KC_TRNS,MEH(KC_Z),MEH(KC_X),MEH(KC_C),MEH(KC_V),MEH(KC_B),KC_TRNS,KC_TRNS,KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 
+                                 KC_TRNS, KC_TRNS, KC_TRNS,           KC_TRNS,  KC_TRNS,  KC_TRNS 
+)
+
+};
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  static uint16_t code_timer;
+  switch (keycode) {
+  case KC_MCBR:                                  
+    if(record->event.pressed){
+      code_timer= timer_read();
+      SEND_STRING("{");
+    } else {
+      if (timer_elapsed(code_timer) > TAPPING_TERM) {
+        SEND_STRING("}" SS_TAP(X_LEFT));
+      } 
+    }
+    return false;
+    break;
+  case KC_MBRC:                                  
+    if(record->event.pressed){
+      code_timer= timer_read();
+      SEND_STRING("[");
+    } else {
+      if (timer_elapsed(code_timer) > TAPPING_TERM) {
+        SEND_STRING("]" SS_TAP(X_LEFT));
+      } 
+    }
+    return false;
+    break;
+  case KC_MPRN:                                  
+    if(record->event.pressed){
+      code_timer= timer_read();
+      SEND_STRING("(");
+    } else {
+      if (timer_elapsed(code_timer) > TAPPING_TERM) {
+        SEND_STRING(")" SS_TAP(X_LEFT));
+      } 
+    }
+    return false;
+    break;
+  case KC_MABK:                                  
+    if(record->event.pressed){
+      code_timer= timer_read();
+      if (get_mods() & MODS_SHIFT_MASK){
+        SEND_STRING("<");
+      } else {
+        SEND_STRING(",");
+      }
+    } else {
+      if (timer_elapsed(code_timer) > TAPPING_TERM) {
+        if (get_mods()  & MODS_SHIFT_MASK){
+          SEND_STRING(">" SS_TAP(X_LEFT));
+        }
+      } 
+    }
+    return false;
+    break;
+  }
+  return true;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- This template is entirely option and can be removed, but is here to help both you and us. -->
<!--- This text and anything on lines wrapped like this one will not show up in the final text. This text is to help us and you. -->

## Description
Added the folder keyboards/iris/keymaps/ave-63 and it's keymap.c and config.h files. The style is different than other iris keymaps, but more similar to chimera keymaps. I found it easier to read read and use this way. Features of this keymap:

--Lots of functionality on left hand for conjunction with mouse or pen in right hand
--_COMMAND layer ESDF arrow keys
--_MEH layer ESDF is super handy for switching tabs (SF) and apps (ED)
--_MEH layer other keys are linked with my AutoHotKey script
--macro for handling parentheses is very nice (credit: u/drashna)

Some things are very non-standard, like position of number keys, etc.
Will require heavy modification for most people.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Core
- [ ] Bugfix
- [ ] New Feature
- [ ] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation


## Issues Fixed or Closed by this PR

* 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [probably?] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
