### PR TITLE
move `#include "rgb.h"` from quantum.h to quantum.c

### DIFF
--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -15,6 +15,11 @@
  */
 
 #include "quantum.h"
+
+#if !defined(RGBLIGHT_ENABLE) && !defined(RGB_MATRIX_ENABLE)
+	#include "rgb.h"
+#endif
+
 #ifdef PROTOCOL_LUFA
 #include "outputselect.h"
 #endif

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -30,9 +30,6 @@
 #ifdef BACKLIGHT_ENABLE
     #include "backlight.h"
 #endif
-#if !defined(RGBLIGHT_ENABLE) && !defined(RGB_MATRIX_ENABLE)
-	#include "rgb.h"
-#endif
 #ifdef RGBLIGHT_ENABLE
   #include "rgblight.h"
 #else


### PR DESCRIPTION

## Description

I think `quantum.h` should contain only API declarations that `quantum.c` provides externally. `rgb.h` contains function weak definitions. This should not be in `quantum.h`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Core
- [ ] Bugfix
- [ ] New Feature
- [x] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation


## Effect of change


```
$ git checkout master
$ make lets_split:default:clean
$ make SILENT=true lets_split:default
$ grep -A1 rgblight_toggle .build/lets_split_rev2_default.map
 .text.rgblight_toggle
      0x0000000000000000  0x2 .build/obj_lets_split_rev2_default/keyboards/lets_split/lets_split.o
--
 .text.rgblight_toggle
      0x0000000000000000  0x2 .build/obj_lets_split_rev2_default/keyboards/lets_split/rev2/rev2.o
--
 .text.rgblight_toggle
      0x0000000000000000  0x2 .build/obj_lets_split_rev2_default/keyboards/lets_split/keymaps/default/keymap.o
--
 .text.rgblight_toggle
      0x0000000000000000  0x2 .build/obj_lets_split_rev2_default/quantum/quantum.o
--
 .text.rgblight_toggle
      0x0000000000000000  0x2 .build/obj_lets_split_rev2_default/quantum/keymap_common.o
--
 .text.rgblight_toggle
      0x0000000000000000  0x2 .build/obj_lets_split_rev2_default/quantum/split_common/matrix.o
--
 .text.rgblight_toggle
      0x0000000000000000  0x2 .build/obj_lets_split_rev2_default/quantum/split_common/split_util.o
--
 .text.rgblight_toggle
      0x0000000000000000  0x2 .build/obj_lets_split_rev2_default/common/command.o
--
 .text.rgblight_toggle
      0x0000000000000000  0x2 .build/obj_lets_split_rev2_default/lufa.o
--
rgblight_toggle                                   .build/obj_lets_split_rev2_default/keyboards/lets_split/lets_split.o
send_byte                                         .build/obj_lets_split_rev2_default/quantum/quantum.o
```

```
$ git checkout move-rgb.h-from-quantum.h-to-quantum.c
$ make lets_split:default:clean
$ make SILENT=true lets_split:default
$ grep -A1 rgblight_toggle .build/lets_split_rev2_default.map
 .text.rgblight_toggle
      0x0000000000000000  0x2 .build/obj_lets_split_rev2_default/quantum/quantum.o
--
rgblight_toggle                                   .build/obj_lets_split_rev2_default/quantum/quantum.o
send_byte                                         .build/obj_lets_split_rev2_default/quantum/quantum.o
```


## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).