### PR TITLE
Improved fix for __always_inline redefinition bug

### DIFF
--- a/tmk_core/protocol/arm_atsam/usb/compiler.h
+++ b/tmk_core/protocol/arm_atsam/usb/compiler.h
@@ -134,12 +134,14 @@
  * heuristics and inline the function no matter how big it thinks it
  * becomes.
  */
+#if !defined(__always_inline)
 #if defined(__CC_ARM)
 #  define __always_inline             __forceinline
-#elif (defined __GNUC__ && __GNUC__ <= 6)
+#elif (defined __GNUC__)
 #  define __always_inline             __attribute__((__always_inline__))
 #elif (defined __ICCARM__)
 #  define __always_inline             _Pragma("inline=forced")
+#endif
 #endif
 
 /**


### PR DESCRIPTION
## Description
ATSAM's code defines __always_inline, but it's also defined in newlib, where it was added *sometime* during GCC 6. Checking the GCC version isn't sufficient to determine whether it's there or not, so the current check fails for some people. It's also trivial to just check for the symbol directly, so this PR does that.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Core
- [x] Bugfix
- [ ] New Feature
- [ ] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
