### PR TITLE
Fix Caps Lock LEDs once and for all

### DIFF
--- a/tmk_core/protocol/lufa/lufa.c
+++ b/tmk_core/protocol/lufa/lufa.c
@@ -526,7 +526,7 @@ void EVENT_USB_Device_ControlRequest(void)
                       }
 
                       if (report_id == REPORT_ID_KEYBOARD || report_id == REPORT_ID_NKRO) {
-                          keyboard_led_stats = Endpoint_Read_8();
+                        keyboard_led_stats = Endpoint_Read_8();
                       }
                     } else {
                       keyboard_led_stats = Endpoint_Read_8();

--- a/tmk_core/protocol/lufa/lufa.c
+++ b/tmk_core/protocol/lufa/lufa.c
@@ -517,17 +517,20 @@ void EVENT_USB_Device_ControlRequest(void)
                         if (USB_DeviceState == DEVICE_STATE_Unattached)
                           return;
                     }
-#ifdef KEYBOARD_SHARED_EP
-                    uint8_t report_id = REPORT_ID_KEYBOARD;
-                    if (keyboard_protocol) {
-                       report_id = Endpoint_Read_8();
+
+                    if (Endpoint_BytesInEndpoint() == 2) {
+                      uint8_t report_id = REPORT_ID_KEYBOARD;
+
+                      if (keyboard_protocol) {
+                        report_id = Endpoint_Read_8();
+                      }
+
+                      if (report_id == REPORT_ID_KEYBOARD || report_id == REPORT_ID_NKRO) {
+                          keyboard_led_stats = Endpoint_Read_8();
+                      }
+                    } else {
+                      keyboard_led_stats = Endpoint_Read_8();
                     }
-                    if (report_id == REPORT_ID_KEYBOARD || report_id == REPORT_ID_NKRO) {
-                        keyboard_led_stats = Endpoint_Read_8();
-                    }
-#else
-                    keyboard_led_stats = Endpoint_Read_8();
-#endif
 
                     Endpoint_ClearOUT();
                     Endpoint_ClearStatusStage();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- This template is entirely option and can be removed, but is here to help both you and us. -->
<!--- This text and anything on lines wrapped like this one will not show up in the final text. This text is to help us and you. -->

## Description
The status LEDs don't light up/light up incorrectly on Linux in certain circumstances. This is because, if NKRO is enabled it will send two LED states, one for the 6KRO interface, and one for the NKRO interface. QMK interprets the NKRO report ID as the LED state and turn on the num lock and scroll lock LEDs.

If we have two bytes, that probably means the first is a report ID. The 6KRO interface may or may not have one, but the NKRO interface always does, so we need to check this regardless of whether `KEYBOARD_SHARED_EP` is defined.

The status LEDs now function correctly on Windows 10, macOS 10.14 and Ubuntu 18.10 under the following conditions:

 - `KEYBOARD_SHARED_EP=no`, `NKRO_ENABLE=no`
 - `KEYBOARD_SHARED_EP=no`, `NKRO_ENABLE=yes`, NKRO off
 - `KEYBOARD_SHARED_EP=no`, `NKRO_ENABLE=yes`, NKRO on
 - `KEYBOARD_SHARED_EP=yes`, `NKRO_ENABLE=no`
 - `KEYBOARD_SHARED_EP=yes`, `NKRO_ENABLE=yes`, NKRO off
 - `KEYBOARD_SHARED_EP=yes`, `NKRO_ENABLE=yes`, NKRO on

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Core
- [x] Bugfix
- [ ] New Feature
- [ ] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation


## Issues Fixed or Closed by this PR

* Fixes #2471

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
