### PR TITLE
Fix layout macro name for Gergo info.json

### DIFF
--- a/keyboards/gergo/info.json
+++ b/keyboards/gergo/info.json
@@ -5,7 +5,7 @@
     "keyboard_name": "Gergo",
     "url": "http://gboards.ca",
     "layouts": {
-        "LAYOUT": {
+        "LAYOUT_GERGO": {
             "layout": [
                 {
                     "label": "L00",


### PR DESCRIPTION
## Commit Log

### Fix layout macro name for Gergo info.json (b0ec1a6)

Layout macro name in info.json was named LAYOUT instead of LAYOUT_GERGO as it is in gergo.h.