### PR TITLE
MacOS Brightness Alias

### DIFF
--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -77,7 +77,7 @@ This is a reference only. Each group of keys links to the page documenting their
 |`KC_F11`               |                    |F11                                            |
 |`KC_F12`               |                    |F12                                            |
 |`KC_PSCREEN`           |`KC_PSCR`           |Print Screen                                   |
-|`KC_SCROLLLOCK`        |`KC_SLCK`, `KC_BRMD`          |Scroll Lock, Brightness Down (macOS)   |
+|`KC_SCROLLLOCK`        |`KC_SLCK`, `KC_BRMD`|Scroll Lock, Brightness Down (macOS)           |
 |`KC_PAUSE`             |`KC_PAUS`, `KC_BRK` |Pause (macOS: Brightness up)                   |
 |`KC_INSERT`            |`KC_INS`            |Insert                                         |
 |`KC_HOME`              |                    |Home                                           |
@@ -203,7 +203,7 @@ This is a reference only. Each group of keys links to the page documenting their
 |`KC_WWW_FAVORITES`     |`KC_WFAV`           |Browser Favorites (Windows)                    |
 |`KC_MEDIA_FAST_FORWARD`|`KC_MFFD`           |Next Track (macOS)                             |
 |`KC_MEDIA_REWIND`      |`KC_MRWD`           |Previous Track (macOS)                         |
-|`KC_BRIGHTNESS_UP`     |`KC_BRIU`           |Brightness Up (macOS: use `KC_BRMU`) 	         |
+|`KC_BRIGHTNESS_UP`     |`KC_BRIU`           |Brightness Up (macOS: use `KC_BRMU`)           |
 |`KC_BRIGHTNESS_DOWN`   |`KC_BRID`           |Brightness Down (macOS: use `KC_BRMD`)         |
 
 ## [Quantum Keycodes](quantum_keycodes.md#qmk-keycodes)

--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -78,7 +78,7 @@ This is a reference only. Each group of keys links to the page documenting their
 |`KC_F12`               |                    |F12                                            |
 |`KC_PSCREEN`           |`KC_PSCR`           |Print Screen                                   |
 |`KC_SCROLLLOCK`        |`KC_SLCK`, `KC_BRMD`|Scroll Lock, Brightness Down (macOS)           |
-|`KC_PAUSE`             |`KC_PAUS`, `KC_BRK` |Pause (macOS: Brightness up)                   |
+|`KC_PAUSE`             |`KC_PAUS`, `KC_BRK`, `KC_BRMU`|Pause, Brightness Up (macOS)         |
 |`KC_INSERT`            |`KC_INS`            |Insert                                         |
 |`KC_HOME`              |                    |Home                                           |
 |`KC_PGUP`              |                    |Page Up                                        |

--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -77,7 +77,7 @@ This is a reference only. Each group of keys links to the page documenting their
 |`KC_F11`               |                    |F11                                            |
 |`KC_F12`               |                    |F12                                            |
 |`KC_PSCREEN`           |`KC_PSCR`           |Print Screen                                   |
-|`KC_SCROLLLOCK`        |`KC_SLCK`			 |Scroll Lock (macOS: Brightness Down)           |
+|`KC_SCROLLLOCK`        |`KC_SLCK`, `KC_BRMD`          |Scroll Lock, Brightness Down (macOS)   |
 |`KC_PAUSE`             |`KC_PAUS`,`KC_BRK`  |Pause (macOS: Brightness up.)				     |
 |`KC_INSERT`            |`KC_INS`            |Insert                                         |
 |`KC_HOME`              |                    |Home                                           |

--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -205,6 +205,8 @@ This is a reference only. Each group of keys links to the page documenting their
 |`KC_MEDIA_REWIND`      |`KC_MRWD`           |Previous Track (macOS)                         |
 |`KC_BRIGHTNESS_UP`     |`KC_BRIU`           |Brightness Up                                  |
 |`KC_BRIGHTNESS_DOWN`   |`KC_BRID`           |Brightness Down                                |
+|`KC_MAC_BRIGHTNESS_UP` |`KC_MAC_BRIU`       |Brightness Up (macOS)                          |
+|`KC_MAC_BRIGHTNESS_DWN`|`KC_MAC_BRID`       |Brightness Down (macOS)                        |
 
 ## [Quantum Keycodes](quantum_keycodes.md#qmk-keycodes)
 

--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -78,7 +78,7 @@ This is a reference only. Each group of keys links to the page documenting their
 |`KC_F12`               |                    |F12                                            |
 |`KC_PSCREEN`           |`KC_PSCR`           |Print Screen                                   |
 |`KC_SCROLLLOCK`        |`KC_SLCK`, `KC_BRMD`          |Scroll Lock, Brightness Down (macOS)   |
-|`KC_PAUSE`             |`KC_PAUS`,`KC_BRK`  |Pause (macOS: Brightness up.)				     |
+|`KC_PAUSE`             |`KC_PAUS`, `KC_BRK` |Pause (macOS: Brightness up)                   |
 |`KC_INSERT`            |`KC_INS`            |Insert                                         |
 |`KC_HOME`              |                    |Home                                           |
 |`KC_PGUP`              |                    |Page Up                                        |

--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -77,8 +77,8 @@ This is a reference only. Each group of keys links to the page documenting their
 |`KC_F11`               |                    |F11                                            |
 |`KC_F12`               |                    |F12                                            |
 |`KC_PSCREEN`           |`KC_PSCR`           |Print Screen                                   |
-|`KC_SCROLLLOCK`        |`KC_SLCK`           |Scroll Lock                                    |
-|`KC_PAUSE`             |`KC_PAUS`, `KC_BRK` |Pause                                          |
+|`KC_SCROLLLOCK`        |`KC_SLCK`			 |Scroll Lock (macOS: Brightness Down)           |
+|`KC_PAUSE`             |`KC_PAUS`,`KC_BRK`  |Pause (macOS: Brightness up.)				     |
 |`KC_INSERT`            |`KC_INS`            |Insert                                         |
 |`KC_HOME`              |                    |Home                                           |
 |`KC_PGUP`              |                    |Page Up                                        |
@@ -203,10 +203,8 @@ This is a reference only. Each group of keys links to the page documenting their
 |`KC_WWW_FAVORITES`     |`KC_WFAV`           |Browser Favorites (Windows)                    |
 |`KC_MEDIA_FAST_FORWARD`|`KC_MFFD`           |Next Track (macOS)                             |
 |`KC_MEDIA_REWIND`      |`KC_MRWD`           |Previous Track (macOS)                         |
-|`KC_BRIGHTNESS_UP`     |`KC_BRIU`           |Brightness Up                                  |
-|`KC_BRIGHTNESS_DOWN`   |`KC_BRID`           |Brightness Down                                |
-|`KC_MAC_BRIGHTNESS_UP` |`KC_MAC_BRIU`       |Brightness Up (macOS)                          |
-|`KC_MAC_BRIGHTNESS_DWN`|`KC_MAC_BRID`       |Brightness Down (macOS)                        |
+|`KC_BRIGHTNESS_UP`     |`KC_BRIU`           |Brightness Up (macOS: use `KC_BRMU`) 	         |
+|`KC_BRIGHTNESS_DOWN`   |`KC_BRID`           |Brightness Down (macOS: use `KC_BRMD`)         |
 
 ## [Quantum Keycodes](quantum_keycodes.md#qmk-keycodes)
 

--- a/tmk_core/common/keycode.h
+++ b/tmk_core/common/keycode.h
@@ -196,7 +196,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define KC_MAC_BRIU				KC_SLCK
 #define KC_MAC_BRID				KC_PAUS
 #define KC_MAC_BRIGHTNESS_UP	KC_SLCK
-#define KC_MAC_BRIGHTNESS_DOWN	KC_PAUS
+#define KC_MAC_BRIGHTNESS_DWN	KC_PAUS
 
 /* Keyboard/Keypad Page (0x07) */
 enum hid_keyboard_keypad_usage {

--- a/tmk_core/common/keycode.h
+++ b/tmk_core/common/keycode.h
@@ -121,10 +121,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define KC_PEQL KC_KP_EQUAL
 #define KC_PCMM KC_KP_COMMA
 
-/* System Specfic */
-#define KC_BRMU KC_SCROLLLOCK
-#define KC_BRMD KC_PAUSE
-
 /* Japanese specific */
 #define KC_ZKHK KC_GRAVE
 #define KC_RO   KC_INT1
@@ -177,6 +173,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define KC_MRWD KC_MEDIA_REWIND
 #define KC_BRIU KC_BRIGHTNESS_UP
 #define KC_BRID KC_BRIGHTNESS_DOWN
+
+/* System Specfic */
+#define KC_BRMU KC_SCROLLLOCK
+#define KC_BRMD KC_PAUSE
 
 /* Mouse Keys */
 #define KC_MS_U KC_MS_UP

--- a/tmk_core/common/keycode.h
+++ b/tmk_core/common/keycode.h
@@ -174,7 +174,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define KC_BRIU KC_BRIGHTNESS_UP
 #define KC_BRID KC_BRIGHTNESS_DOWN
 
-/* System Specfic */
+/* System Specific */
 #define KC_BRMU KC_SCROLLLOCK
 #define KC_BRMD KC_PAUSE
 

--- a/tmk_core/common/keycode.h
+++ b/tmk_core/common/keycode.h
@@ -121,6 +121,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define KC_PEQL KC_KP_EQUAL
 #define KC_PCMM KC_KP_COMMA
 
+/* System Specfic */
+#define KC_BRMU KC_SCROLLLOCK
+#define KC_BRMD KC_PAUSE
+
 /* Japanese specific */
 #define KC_ZKHK KC_GRAVE
 #define KC_RO   KC_INT1
@@ -191,12 +195,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define KC_ACL0 KC_MS_ACCEL0
 #define KC_ACL1 KC_MS_ACCEL1
 #define KC_ACL2 KC_MS_ACCEL2
-
-/* System Specfic Aliases */
-#define KC_MAC_BRIU				KC_SLCK
-#define KC_MAC_BRID				KC_PAUS
-#define KC_MAC_BRIGHTNESS_UP	KC_SLCK
-#define KC_MAC_BRIGHTNESS_DWN	KC_PAUS
 
 /* Keyboard/Keypad Page (0x07) */
 enum hid_keyboard_keypad_usage {

--- a/tmk_core/common/keycode.h
+++ b/tmk_core/common/keycode.h
@@ -192,6 +192,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define KC_ACL1 KC_MS_ACCEL1
 #define KC_ACL2 KC_MS_ACCEL2
 
+/* System Specfic Aliases */
+#define KC_MAC_BRIU				KC_SLCK
+#define KC_MAC_BRID				KC_PAUS
+#define KC_MAC_BRIGHTNESS_UP	KC_SLCK
+#define KC_MAC_BRIGHTNESS_DOWN	KC_PAUS
+
 /* Keyboard/Keypad Page (0x07) */
 enum hid_keyboard_keypad_usage {
   KC_NO                   = 0x00,


### PR DESCRIPTION
Added aliases to tmk_core for OSX brightness controls (F13, F14)


- [x] Core
- [x] Enhancement/Optimization

closes https://github.com/qmk/qmk_firmware/issues/4750