### PR TITLE
Vagrant fix: pass util_dir in using env in shell provisioner, otherwise use dirname

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -59,7 +59,7 @@ Vagrant.configure(2) do |config|
   # add a # before ,args: and run 'vagrant up' to get a working
   # non-updated box and then attempt to troubleshoot or open a Github issue
 
-  config.vm.provision "shell", run: "always", path: "./util/qmk_install.sh", args: "-update"
+  config.vm.provision "shell", run: "always", path: "./util/qmk_install.sh", env: { "util_dir" => "/vagrant/util" }
 
   config.vm.post_up_message = <<-EOT
 

--- a/util/linux_install.sh
+++ b/util/linux_install.sh
@@ -34,7 +34,7 @@ elif grep ID /etc/os-release | grep -qE 'debian|ubuntu'; then
 	DEBCONF_NONINTERACTIVE_SEEN=true
 	export DEBIAN_FRONTEND DEBCONF_NONINTERACTIVE_SEEN
 	sudo apt-get update
-	sudo apt-get install \
+	sudo apt-get -y install \
 		build-essential \
 		avr-libc \
 		binutils-arm-none-eabi \

--- a/util/qmk_install.sh
+++ b/util/qmk_install.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 # Pick the correct install script based on the current OS
 
-util_dir=$(dirname "$0")
+if [ -z "${util_dir+x}" ]; then
+	util_dir=$(dirname "$0")
+fi
 
 case $(uname -a) in
 	*Darwin*)

--- a/util/qmk_install.sh
+++ b/util/qmk_install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Pick the correct install script based on the current OS
 
-if [ -z "${util_dir+x}" ]; then
+if [ -z "$util_dir" ]; then
 	util_dir=$(dirname "$0")
 fi
 


### PR DESCRIPTION
## Description
I made these changes to get Vagrant working for me (in this case with Virtualbox). It should just impact how qmk_install.sh works when it's being run from Vagrant (`util_dir` will be passed in as `/vagrant/util`, where the other shell scripts live on the Vagrant box) and otherwise will use `dirname`. I also had to add `-y` to apt-get, otherwise it aborted; and I removed the `-update` argument to qmk_install.sh because from what I could tell it wasn't actually being used anywhere (maybe I missed something).

## Types of changes
- [ ] Core
- [x] Bugfix
- [ ] New Feature
- [ ] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by this PR
I didn't find any open issues related to this, but I was getting the following output when running `VAGRANT_LOG=debug vagrant up`:

```
 INFO ssh: Execute: chown -R vagrant /tmp/vagrant-shell (sudo=true)
DEBUG ssh: stderr: stdin: is not a tty

DEBUG ssh: stderr: 41e57d38-b4f7-4e46-9c38-13873d338b86-vagrant-ssh
DEBUG ssh: Exit status: 0
DEBUG ssh: Uploading: /var/folders/g8/4hmnsljd2jv_pgww4ggts8q00000gn/T/vagrant-shell20190113-66117-e91381.sh to /tmp/vagrant-shell
DEBUG ssh: Re-using SSH connection.
 INFO interface: detail: Running: /var/folders/g8/4hmnsljd2jv_pgww4ggts8q00000gn/T/vagrant-shell20190113-66117-e91381.sh
 INFO interface: detail:     default: Running: /var/folders/g8/4hmnsljd2jv_pgww4ggts8q00000gn/T/vagrant-shell20190113-66117-e91381.sh
    default: Running: /var/folders/g8/4hmnsljd2jv_pgww4ggts8q00000gn/T/vagrant-shell20190113-66117-e91381.sh
DEBUG ssh: Re-using SSH connection.
 INFO ssh: Execute: chmod +x '/tmp/vagrant-shell' && /tmp/vagrant-shell -update (sudo=true)
DEBUG ssh: stderr: stdin: is not a tty

DEBUG ssh: stderr: 41e57d38-b4f7-4e46-9c38-13873d338b86-vagrant-ssh
DEBUG ssh: stderr: /tmp/vagrant-shell: 17: exec:
 INFO interface: detail: /tmp/vagrant-shell: 17: exec:
 INFO interface: detail:     default: /tmp/vagrant-shell: 17: exec:
    default: /tmp/vagrant-shell: 17: exec:
DEBUG ssh: stderr: /tmp/linux_install.sh: not found
 INFO interface: detail: /tmp/linux_install.sh: not found
 INFO interface: detail:     default: /tmp/linux_install.sh: not found
    default: /tmp/linux_install.sh: not found
DEBUG ssh: stderr:

DEBUG ssh: Exit status: 127
ERROR warden: Error occurred: The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```

It looked like this was because Vagrant uploads qmk_install.sh to /tmp/vagrant-shell on the VM, so the script was setting `util_dir` to `/tmp` instead of the directory where the scripts actually live on the VM (/vagrant/util).

The issue with `apt-get` was this:

```
    default: Need to get 74.9 MB of archives.
    default: After this operation, 353 MB of additional disk space will be used.
    default: Do you want to continue?
    default:  [Y/n]
    default: Abort.
```

The `-y` flag fixed this. There's still an error for a missing signature on a puppetlabs.com repo when `apt-get update` runs, but it wasn't fatal so I didn't really look into it further. For reference:

```
    default: W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http:
//apt.puppetlabs.com trusty Release: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 7F438280EF8D349F
    default:
    default: W: Failed to fetch http://apt.puppetlabs.com/dists/trusty/Release
    default:
    default: W: Some index files failed to download. They have been ignored, or old ones used instead.
```

## Checklist:
- [x] My code follows the code style of this project.
  - I noticed the code style says that indentation should use two spaces, but qmk_install.sh had tabs so I just stuck with that for my small addition.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
