### PR TITLE
Added support for per key colours.

### DIFF
--- a/keyboards/massdrop/alt/led_programs.c
+++ b/keyboards/massdrop/alt/led_programs.c
@@ -118,3 +118,23 @@ void *led_setups[] = {
 };
 
 const uint8_t led_setups_count = sizeof(led_setups) / sizeof(led_setups[0]);
+
+led_keyrgb_t layer_one[] = {
+    { .end = 1 },
+};
+
+led_keyrgb_t layer_two[] = {
+    { .ss = 36, .se = 36, .r = 255, .g = 0, .b = 0 },
+    { .ss = 52, .se = 54, .r = 255, .g = 0, .b = 0 },
+    { .ss = 82, .se = 82, .r = 255, .g = 0, .b = 0 },
+    { .ss = 31, .se = 31, .r = 255, .g = 0, .b = 0 },
+    { .ss = 48, .se = 49, .r = 255, .g = 0, .b = 0 },
+    { .aid = 0, .end = 1 },
+};
+
+void *led_keyrgbs[] = {
+    layer_one,
+    layer_two
+};
+
+const uint8_t led_keyrgbs_count = sizeof(led_keyrgbs) / sizeof(led_keyrgbs[0]);

--- a/keyboards/massdrop/ctrl/keymaps/default/keymap.c
+++ b/keyboards/massdrop/ctrl/keymaps/default/keymap.c
@@ -89,12 +89,16 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             if (record->event.pressed) {
                 if (led_animation_id == led_setups_count - 1) led_animation_id = 0;
                 else led_animation_id++;
+                if ( led_keyrgb_id == led_keyrgbs_count - 1) led_keyrgb_id = 0;
+                else led_keyrgb_id++;
             }
             return false;
         case L_PTP:
             if (record->event.pressed) {
                 if (led_animation_id == 0) led_animation_id = led_setups_count - 1;
                 else led_animation_id--;
+                if ( led_keyrgb_id == 0 ) led_keyrgb_id = led_keyrgbs_count - 1;
+                else led_keyrgb_id--;
             }
             return false;
         case L_PSI:

--- a/keyboards/massdrop/ctrl/keymaps/default/keymap.c
+++ b/keyboards/massdrop/ctrl/keymaps/default/keymap.c
@@ -63,6 +63,14 @@ void matrix_init_user(void) {
 void matrix_scan_user(void) {
 };
 
+// Runs on layer change.
+uint32_t layer_state_set_user(uint32_t state) {
+    led_keyrgb_id = biton32(state);
+    if ( led_keyrgb_id < 0 ) led_keyrgb_id = 0;
+    if ( led_keyrgb_id > led_keyrgbs_count ) led_keyrgb_id = 0;
+    return state;
+}
+
 #define MODS_SHIFT  (keyboard_report->mods & MOD_BIT(KC_LSHIFT) || keyboard_report->mods & MOD_BIT(KC_RSHIFT))
 #define MODS_CTRL  (keyboard_report->mods & MOD_BIT(KC_LCTL) || keyboard_report->mods & MOD_BIT(KC_RCTRL))
 #define MODS_ALT  (keyboard_report->mods & MOD_BIT(KC_LALT) || keyboard_report->mods & MOD_BIT(KC_RALT))
@@ -89,16 +97,12 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             if (record->event.pressed) {
                 if (led_animation_id == led_setups_count - 1) led_animation_id = 0;
                 else led_animation_id++;
-                if ( led_keyrgb_id == led_keyrgbs_count - 1) led_keyrgb_id = 0;
-                else led_keyrgb_id++;
             }
             return false;
         case L_PTP:
             if (record->event.pressed) {
                 if (led_animation_id == 0) led_animation_id = led_setups_count - 1;
                 else led_animation_id--;
-                if ( led_keyrgb_id == 0 ) led_keyrgb_id = led_keyrgbs_count - 1;
-                else led_keyrgb_id--;
             }
             return false;
         case L_PSI:

--- a/keyboards/massdrop/ctrl/led_programs.c
+++ b/keyboards/massdrop/ctrl/led_programs.c
@@ -18,14 +18,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "ctrl.h"
 #include "led_matrix.h"
 
-//Teal <-> Purple
-led_setup_t leds_teal_purple[] = {
-    { .hs = 0,  .he = 30,  .rs = 24,  .re = 24,  .gs = 127, .ge = 127, .bs = 80, .be = 80, .ef = EF_NONE },
-    { .hs = 30, .he = 66,  .rs = 24,  .re = 145, .gs = 127, .ge = 48, .bs = 80, .be = 255, .ef = EF_NONE },
-    { .hs = 66, .he = 100, .rs = 145, .re = 145, .gs = 48, .ge = 48, .bs = 255, .be = 255, .ef = EF_NONE },
-    { .end = 1 },
-};
-
 //Teal <-> Salmon
 led_setup_t leds_teal_salmon[] = {
     { .hs = 0,  .he = 33,  .rs = 24,  .re = 24,  .gs = 215, .ge = 215, .bs = 204, .be = 204, .ef = EF_NONE },
@@ -112,7 +104,6 @@ led_setup_t leds_rainbow_s[] = {
 //Add the new animation name to the list below following its format
 
 void *led_setups[] = {
-    leds_teal_purple,
     leds_rainbow_s,
     leds_rainbow_ns,
     leds_teal_salmon,
@@ -131,18 +122,21 @@ const uint8_t led_setups_count = sizeof(led_setups) / sizeof(led_setups[0]);
 // Customize Specific key Colours.
 
 led_keyrgb_t layer_one[] = {
-    { .ss = 17, .se = 20, .r = 255, .g = 0, .b = 0 },
     { .end = 1 },
 };
 
-led_keyrgb_t esc_key[] = {
-    { .ss = 0, .se = 0, .r = 255, .g = 0, .b = 0 },
-    { .end = 1 },
+led_keyrgb_t layer_two[] = {
+    { .ss = 36, .se = 36, .r = 255, .g = 0, .b = 0 },
+    { .ss = 52, .se = 54, .r = 255, .g = 0, .b = 0 },
+    { .ss = 82, .se = 82, .r = 255, .g = 0, .b = 0 },
+    { .ss = 31, .se = 31, .r = 255, .g = 0, .b = 0 },
+    { .ss = 48, .se = 49, .r = 255, .g = 0, .b = 0 },
+    { .aid = 0, .end = 1 },
 };
 
 void *led_keyrgbs[] = {
     layer_one,
-    esc_key
+    layer_two
 };
 
 const uint8_t led_keyrgbs_count = sizeof(led_keyrgbs) / sizeof(led_keyrgbs[0]);

--- a/keyboards/massdrop/ctrl/led_programs.c
+++ b/keyboards/massdrop/ctrl/led_programs.c
@@ -18,6 +18,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "ctrl.h"
 #include "led_matrix.h"
 
+//Teal <-> Purple
+led_setup_t leds_teal_purple[] = {
+    { .hs = 0,  .he = 30,  .rs = 24,  .re = 24,  .gs = 127, .ge = 127, .bs = 80, .be = 80, .ef = EF_NONE },
+    { .hs = 30, .he = 66,  .rs = 24,  .re = 145, .gs = 127, .ge = 48, .bs = 80, .be = 255, .ef = EF_NONE },
+    { .hs = 66, .he = 100, .rs = 145, .re = 145, .gs = 48, .ge = 48, .bs = 255, .be = 255, .ef = EF_NONE },
+    { .end = 1 },
+};
+
 //Teal <-> Salmon
 led_setup_t leds_teal_salmon[] = {
     { .hs = 0,  .he = 33,  .rs = 24,  .re = 24,  .gs = 215, .ge = 215, .bs = 204, .be = 204, .ef = EF_NONE },
@@ -104,6 +112,7 @@ led_setup_t leds_rainbow_s[] = {
 //Add the new animation name to the list below following its format
 
 void *led_setups[] = {
+    leds_teal_purple,
     leds_rainbow_s,
     leds_rainbow_ns,
     leds_teal_salmon,
@@ -118,3 +127,22 @@ void *led_setups[] = {
 };
 
 const uint8_t led_setups_count = sizeof(led_setups) / sizeof(led_setups[0]);
+
+// Customize Specific key Colours.
+
+led_keyrgb_t layer_one[] = {
+    { .ss = 17, .se = 20, .r = 255, .g = 0, .b = 0 },
+    { .end = 1 },
+};
+
+led_keyrgb_t esc_key[] = {
+    { .ss = 0, .se = 0, .r = 255, .g = 0, .b = 0 },
+    { .end = 1 },
+};
+
+void *led_keyrgbs[] = {
+    layer_one,
+    esc_key
+};
+
+const uint8_t led_keyrgbs_count = sizeof(led_keyrgbs) / sizeof(led_keyrgbs[0]);

--- a/tmk_core/protocol/arm_atsam/led_matrix.c
+++ b/tmk_core/protocol/arm_atsam/led_matrix.c
@@ -252,6 +252,7 @@ uint8_t breathe_dir;
 uint64_t led_next_run;
 
 uint8_t led_animation_id;
+uint8_t led_keyrgb_id;
 uint8_t led_lighting_mode;
 
 issi3733_led_t *led_cur;
@@ -267,6 +268,7 @@ void led_matrix_run(void)
     float po;
     uint8_t led_this_run = 0;
     led_setup_t *f = (led_setup_t*)led_setups[led_animation_id];
+    led_keyrgb_t *k = (led_keyrgb_t*)led_keyrgbs[led_keyrgb_id];
 
     if (led_cur == 0) //Denotes start of new processing cycle in the case of chunked processing
     {
@@ -408,6 +410,18 @@ void led_matrix_run(void)
         *led_cur->rgb.g = (uint8_t)go;
         *led_cur->rgb.b = (uint8_t)bo;
 
+        uint8_t kcur = 0;
+        while( k[kcur].end != 1 )
+        {
+            if ( led_cur->scan >= k[kcur].ss && led_cur->scan <= k[kcur].se )
+            {
+                *led_cur->rgb.r = k[kcur].r;
+                *led_cur->rgb.g = k[kcur].g;
+                *led_cur->rgb.b = k[kcur].b;
+            }
+            kcur++;
+        }
+
 #ifdef USB_LED_INDICATOR_ENABLE
         if (keyboard_leds())
         {
@@ -458,6 +472,7 @@ uint8_t led_matrix_init(void)
 
     led_enabled = 1;
     led_animation_id = 0;
+    led_keyrgb_id = 0;
     led_lighting_mode = LED_MODE_NORMAL;
     led_animation_speed = 4.0f;
     led_animation_direction = 0;

--- a/tmk_core/protocol/arm_atsam/led_matrix.c
+++ b/tmk_core/protocol/arm_atsam/led_matrix.c
@@ -297,13 +297,22 @@ void led_matrix_run(void)
     uint8_t fcur = 0;
     uint8_t fmax = 0;
 
+    uint8_t kcur = 0;
+    uint8_t kmax = 0;
+
     //Frames setup
     while (f[fcur].end != 1)
     {
         fcur++; //Count frames
     }
 
+    while( k[kcur].end != 1 )
+    {
+        kcur++;
+    }
+
     fmax = fcur; //Store total frames count
+    kmax = kcur;
 
     while (led_cur < lede && led_this_run < led_per_run)
     {
@@ -392,6 +401,19 @@ void led_matrix_run(void)
                     bo += (po * (f[fcur].be - f[fcur].bs)) + f[fcur].bs;// + 0.5;
                 }
             }
+
+            if ( k[kmax].aid == led_animation_id || k[kmax].aid == -1 )
+            {
+                for (kcur = 0; kcur < kmax; kcur++)
+                {        
+                    if ( led_cur->id >= k[kcur].ss && led_cur->id <= k[kcur].se )
+                    {
+                        ro = k[kcur].r;
+                        go = k[kcur].g;
+                        bo = k[kcur].b;
+                    }
+                }
+            }
         }
 
         //Clamp values 0-255
@@ -409,18 +431,6 @@ void led_matrix_run(void)
         *led_cur->rgb.r = (uint8_t)ro;
         *led_cur->rgb.g = (uint8_t)go;
         *led_cur->rgb.b = (uint8_t)bo;
-
-        uint8_t kcur = 0;
-        while( k[kcur].end != 1 )
-        {
-            if ( led_cur->scan >= k[kcur].ss && led_cur->scan <= k[kcur].se )
-            {
-                *led_cur->rgb.r = k[kcur].r;
-                *led_cur->rgb.g = k[kcur].g;
-                *led_cur->rgb.b = k[kcur].b;
-            }
-            kcur++;
-        }
 
 #ifdef USB_LED_INDICATOR_ENABLE
         if (keyboard_leds())

--- a/tmk_core/protocol/arm_atsam/led_matrix.h
+++ b/tmk_core/protocol/arm_atsam/led_matrix.h
@@ -114,6 +114,7 @@ typedef struct led_setup_s {
 } led_setup_t;
 
 typedef struct led_keyrgb_s {
+    uint8_t aid;
     uint8_t ss;
     uint8_t se;
     uint8_t r;

--- a/tmk_core/protocol/arm_atsam/led_matrix.h
+++ b/tmk_core/protocol/arm_atsam/led_matrix.h
@@ -113,6 +113,15 @@ typedef struct led_setup_s {
   uint8_t end;      //Set to signal end of the setup
 } led_setup_t;
 
+typedef struct led_keyrgb_s {
+    uint8_t ss;
+    uint8_t se;
+    uint8_t r;
+    uint8_t g;
+    uint8_t b;
+    uint8_t end;
+} led_keyrgb_t;
+
 extern issi3733_driver_t issidrv[ISSI3733_DRIVER_COUNT];
 
 extern uint8_t gcr_desired;
@@ -121,6 +130,7 @@ extern uint8_t gcr_actual;
 extern uint8_t gcr_actual_last;
 
 extern uint8_t led_animation_id;
+extern uint8_t led_keyrgb_id;
 extern uint8_t led_enabled;
 extern float led_animation_speed;
 extern uint8_t led_lighting_mode;
@@ -130,8 +140,10 @@ extern uint8_t led_animation_breathing;
 extern uint8_t led_animation_breathe_cur;
 extern uint8_t breathe_dir;
 extern const uint8_t led_setups_count;
+extern const uint8_t led_keyrgbs_count;
 
 extern void *led_setups[];
+extern void *led_keyrgbs[];
 
 extern issi3733_led_t *led_cur;
 extern issi3733_led_t *lede;


### PR DESCRIPTION
![cb9](https://user-images.githubusercontent.com/3096584/51098341-a3602b00-1797-11e9-8807-0937f9d1ace4.gif)
### A kinda hacky implementation of per key colouring for all!

## Description
Adds a way to add single key colours in the `led_programs.c` file. This was made specifically with the Massdrop/CTRL in mind and I've not tested it on anything else.

## Note
I'd love this to also work with layers but I'm not sure how to do that, so any help would be much appreciated. I'm also quite paranoid that the code isn't at all optimized so that's something to lookout for. 

P.S. Please don't hurt me Drashna.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Core
- [ ] Bugfix
- [x] New Feature
- [x] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation


## Issues Fixed or Closed by this PR

* 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

I forgot to update the defaults for the Massdrop/ALT. ;w;