### PR TITLE
Add cKeys Handwire 101 Keyboard

### DIFF
--- a/keyboards/ckeys/handwire_101/config.h
+++ b/keyboards/ckeys/handwire_101/config.h
@@ -16,7 +16,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #pragma once
-#define CONFIG_H
 
 #include "config_common.h"
 

--- a/keyboards/ckeys/handwire_101/config.h
+++ b/keyboards/ckeys/handwire_101/config.h
@@ -15,7 +15,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef CONFIG_H
+#pragma once
 #define CONFIG_H
 
 #include "config_common.h"

--- a/keyboards/ckeys/handwire_101/config.h
+++ b/keyboards/ckeys/handwire_101/config.h
@@ -195,4 +195,3 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define NO_ACTION_MACRO
 //#define NO_ACTION_FUNCTION
 
-#endif

--- a/keyboards/ckeys/handwire_101/config.h
+++ b/keyboards/ckeys/handwire_101/config.h
@@ -1,0 +1,199 @@
+/*
+Copyright 2012 Jun Wako <wakojun@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#include "config_common.h"
+
+/* USB Device descriptor parameter */
+#define VENDOR_ID       0xFEED
+#define PRODUCT_ID      0x6060
+#define DEVICE_VER      0x0001
+#define MANUFACTURER    You
+#define PRODUCT         ckeys_handwire
+#define DESCRIPTION     4x4 handwire workshop board
+
+/* key matrix size */
+#define MATRIX_ROWS 4
+#define MATRIX_COLS 4
+
+/*
+ * Keyboard Matrix Assignments
+ *
+ * Change this to how you wired your keyboard
+ * COLS: AVR pins used for columns, left to right
+ * ROWS: AVR pins used for rows, top to bottom
+ * DIODE_DIRECTION: COL2ROW = COL = Anode (+), ROW = Cathode (-, marked on diode)
+ *                  ROW2COL = ROW = Anode (+), COL = Cathode (-, marked on diode)
+ *
+*/
+#define MATRIX_ROW_PINS { F4, F5, F6, F7 }
+#define MATRIX_COL_PINS { D4, C6, D7, E6 }
+
+/* COL2ROW, ROW2COL, or CUSTOM_MATRIX */
+#define DIODE_DIRECTION COL2ROW
+
+//#define BACKLIGHT_PIN B7
+// #define BACKLIGHT_BREATHING
+//#define BACKLIGHT_LEVELS 3
+
+
+/* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
+#define DEBOUNCING_DELAY 5
+
+/* define if matrix has ghost (lacks anti-ghosting diodes) */
+//#define MATRIX_HAS_GHOST
+
+/* number of backlight levels */
+
+/* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
+#define LOCKING_SUPPORT_ENABLE
+/* Locking resynchronize hack */
+#define LOCKING_RESYNC_ENABLE
+
+/*
+ * MIDI options
+ */
+
+/* Prevent use of disabled MIDI features in the keymap */
+//#define MIDI_ENABLE_STRICT 1
+
+/* enable basic MIDI features:
+   - MIDI notes can be sent when in Music mode is on
+*/
+//#define MIDI_BASIC
+
+/* enable advanced MIDI features:
+   - MIDI notes can be added to the keymap
+   - Octave shift and transpose
+   - Virtual sustain, portamento, and modulation wheel
+   - etc.
+*/
+#define MIDI_ADVANCED
+
+/* override number of MIDI tone keycodes (each octave adds 12 keycodes and allocates 12 bytes) */
+//#define MIDI_TONE_KEYCODE_OCTAVES 1
+
+/*
+ * Force NKRO
+ *
+ * Force NKRO (nKey Rollover) to be enabled by default, regardless of the saved
+ * state in the bootmagic EEPROM settings. (Note that NKRO must be enabled in the
+ * makefile for this to work.)
+ *
+ * If forced on, NKRO can be disabled via magic key (default = LShift+RShift+N)
+ * until the next keyboard reset.
+ *
+ * NKRO may prevent your keystrokes from being detected in the BIOS, but it is
+ * fully operational during normal computer usage.
+ *
+ * For a less heavy-handed approach, enable NKRO via magic key (LShift+RShift+N)
+ * or via bootmagic (hold SPACE+N while plugging in the keyboard). Once set by
+ * bootmagic, NKRO mode will always be enabled until it is toggled again during a
+ * power-up.
+ *
+ */
+//#define FORCE_NKRO
+
+/*
+ * Magic Key Options
+ *
+ * Magic keys are hotkey commands that allow control over firmware functions of
+ * the keyboard. They are best used in combination with the HID Listen program,
+ * found here: https://www.pjrc.com/teensy/hid_listen.html
+ *
+ * The options below allow the magic key functionality to be changed. This is
+ * useful if your keyboard/keypad is missing keys and you want magic key support.
+ *
+ */
+
+/* key combination for magic key command */
+#define IS_COMMAND() ( \
+    keyboard_report->mods == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT)) \
+)
+
+/* control how magic key switches layers */
+//#define MAGIC_KEY_SWITCH_LAYER_WITH_FKEYS  true
+//#define MAGIC_KEY_SWITCH_LAYER_WITH_NKEYS  true
+//#define MAGIC_KEY_SWITCH_LAYER_WITH_CUSTOM false
+
+/* override magic key keymap */
+//#define MAGIC_KEY_SWITCH_LAYER_WITH_FKEYS
+//#define MAGIC_KEY_SWITCH_LAYER_WITH_NKEYS
+//#define MAGIC_KEY_SWITCH_LAYER_WITH_CUSTOM
+//#define MAGIC_KEY_HELP1          H
+//#define MAGIC_KEY_HELP2          SLASH
+//#define MAGIC_KEY_DEBUG          D
+//#define MAGIC_KEY_DEBUG_MATRIX   X
+//#define MAGIC_KEY_DEBUG_KBD      K
+//#define MAGIC_KEY_DEBUG_MOUSE    M
+//#define MAGIC_KEY_VERSION        V
+//#define MAGIC_KEY_STATUS         S
+//#define MAGIC_KEY_CONSOLE        C
+//#define MAGIC_KEY_LAYER0_ALT1    ESC
+//#define MAGIC_KEY_LAYER0_ALT2    GRAVE
+//#define MAGIC_KEY_LAYER0         0
+//#define MAGIC_KEY_LAYER1         1
+//#define MAGIC_KEY_LAYER2         2
+//#define MAGIC_KEY_LAYER3         3
+//#define MAGIC_KEY_LAYER4         4
+//#define MAGIC_KEY_LAYER5         5
+//#define MAGIC_KEY_LAYER6         6
+//#define MAGIC_KEY_LAYER7         7
+//#define MAGIC_KEY_LAYER8         8
+//#define MAGIC_KEY_LAYER9         9
+//#define MAGIC_KEY_BOOTLOADER     PAUSE
+//#define MAGIC_KEY_LOCK           CAPS
+//#define MAGIC_KEY_EEPROM         E
+//#define MAGIC_KEY_NKRO           N
+//#define MAGIC_KEY_SLEEP_LED      Z
+
+// Audio Click
+#define AUDIO_CLICKY
+
+// Music Mode Polyphony
+// NOTE: Must change polyphony_rate to a number higher than 0 in voices.c
+#define AUDIO_VOICES
+#define PITCH_STANDARD_A 880.0f
+
+// Mouse keys
+#define MOUSEKEY_DELAY          0
+#define MOUSEKEY_INTERVAL       20
+#define MOUSEKEY_MAX_SPEED      2
+#define MOUSEKEY_TIME_TO_MAX    5
+#define MOUSEKEY_WHEEL_DELAY    0
+
+/*
+ * Feature disable options
+ *  These options are also useful to firmware size reduction.
+ */
+
+/* disable debug print */
+//#define NO_DEBUG
+
+/* disable print */
+//#define NO_PRINT
+
+/* disable action features */
+//#define NO_ACTION_LAYER
+//#define NO_ACTION_TAPPING
+//#define NO_ACTION_ONESHOT
+//#define NO_ACTION_MACRO
+//#define NO_ACTION_FUNCTION
+
+#endif

--- a/keyboards/ckeys/handwire_101/config.h
+++ b/keyboards/ckeys/handwire_101/config.h
@@ -23,7 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0xFEED
 #define PRODUCT_ID      0x6060
 #define DEVICE_VER      0x0001
-#define MANUFACTURER    You
+#define MANUFACTURER    ckeys_handwire
 #define PRODUCT         ckeys_handwire
 #define DESCRIPTION     4x4 handwire workshop board
 

--- a/keyboards/ckeys/handwire_101/handwire_101.c
+++ b/keyboards/ckeys/handwire_101/handwire_101.c
@@ -1,0 +1,28 @@
+#include "handwire_101.h"
+
+void matrix_init_kb(void) {
+	// put your keyboard start-up code here
+	// runs once when the firmware starts up
+	// Turn status LED on
+	//DDRD |= (1<<6);
+	//PORTD |= (1<<6);
+
+	matrix_init_user();
+}
+
+void matrix_scan_kb(void) {
+	// put your looping keyboard code here
+	// runs every cycle (a lot)
+	matrix_scan_user();
+}
+
+bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
+	// put your per-action keyboard code here
+	// runs for every action, just before processing by the firmware
+	return process_record_user(keycode, record);
+}
+
+void led_set_kb(uint8_t usb_led) {
+	// put your keyboard LED indicator (ex: Caps Lock LED) toggling code here
+	led_set_user(usb_led);
+}

--- a/keyboards/ckeys/handwire_101/handwire_101.h
+++ b/keyboards/ckeys/handwire_101/handwire_101.h
@@ -6,7 +6,7 @@
 // The following is an example using the Planck MIT layout
 // The first section contains all of the arguements
 // The second converts the arguments into a two-dimensional array
-#define KEYMAP( \
+#define LAYOUT( \
     k00, k01, k02, k03, \
     k10, k11, k12, k13, \
     k20, k21, k22, k23, \
@@ -19,4 +19,3 @@
     { k30, k31, k32, k33 } \
 }
 
-#endif

--- a/keyboards/ckeys/handwire_101/handwire_101.h
+++ b/keyboards/ckeys/handwire_101/handwire_101.h
@@ -1,0 +1,23 @@
+#ifndef HANDWIRE_101_H
+#define HANDWIRE_101_H
+
+#include "quantum.h"
+
+// This a shortcut to help you visually see your layout.
+// The following is an example using the Planck MIT layout
+// The first section contains all of the arguements
+// The second converts the arguments into a two-dimensional array
+#define KEYMAP( \
+    k00, k01, k02, k03, \
+    k10, k11, k12, k13, \
+    k20, k21, k22, k23, \
+    k30, k31, k32, k33 \
+) \
+{ \
+    { k00, k01, k02, k03 }, \
+    { k10, k11, k12, k13 }, \
+    { k20, k21, k22, k23 }, \
+    { k30, k31, k32, k33 } \
+}
+
+#endif

--- a/keyboards/ckeys/handwire_101/handwire_101.h
+++ b/keyboards/ckeys/handwire_101/handwire_101.h
@@ -1,5 +1,4 @@
 #pragma once
-#define HANDWIRE_101_H
 
 #include "quantum.h"
 

--- a/keyboards/ckeys/handwire_101/handwire_101.h
+++ b/keyboards/ckeys/handwire_101/handwire_101.h
@@ -1,4 +1,4 @@
-#ifndef HANDWIRE_101_H
+#pragma once
 #define HANDWIRE_101_H
 
 #include "quantum.h"

--- a/keyboards/ckeys/handwire_101/info.json
+++ b/keyboards/ckeys/handwire_101/info.json
@@ -1,0 +1,13 @@
+{
+  "keyboard_name": "cKeys Handwire 101",
+  "url": "https://ckeys.org/slides/handwire/",
+  "maintainer": "brandenbyers",
+  "width": 4,
+  "height": 4,
+  "layouts": {
+    "LAYOUT_ortho_4x4": {
+      "key_count": 16,
+      "layout": [{"x":0, "y":0}, {"x":1, "y":0}, {"x":2, "y":0}, {"x":3, "y":0}, {"x":0, "y":1}, {"x":1, "y":1}, {"x":2, "y":1}, {"x":3, "y":1}, {"x":0, "y":2}, {"x":1, "y":2}, {"x":2, "y":2}, {"x":3, "y":2}, {"x":0, "y":3}, {"x":1, "y":3}, {"x":2, "y":3}, {"x":3, "y":3}]
+    }
+  }
+}

--- a/keyboards/ckeys/handwire_101/keymaps/default/config.h
+++ b/keyboards/ckeys/handwire_101/keymaps/default/config.h
@@ -1,0 +1,6 @@
+#ifndef CONFIG_USER_H
+#define CONFIG_USER_H
+
+#include "../../config.h"
+// Add overrides here 
+#endif

--- a/keyboards/ckeys/handwire_101/keymaps/default/config.h
+++ b/keyboards/ckeys/handwire_101/keymaps/default/config.h
@@ -1,6 +1,3 @@
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
+#pragma once
 
-#include "../../config.h"
 // Add overrides here 
-#endif

--- a/keyboards/ckeys/handwire_101/keymaps/default/keymap.c
+++ b/keyboards/ckeys/handwire_101/keymaps/default/keymap.c
@@ -85,7 +85,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    * |  ♫  |  ♫  |  ♫  |  ♫  |
    * `---------------------- '
    */
-  [_MUSIC_4_LIFE] = KEYMAP(
+  [_MUSIC_4_LIFE] = LAYOUT(
     KC_M, KC_M, KC_M, KC_M, \
     KC_M, KC_M, KC_M, KC_M, \
     KC_M, KC_M, KC_M, KC_M, \

--- a/keyboards/ckeys/handwire_101/keymaps/default/keymap.c
+++ b/keyboards/ckeys/handwire_101/keymaps/default/keymap.c
@@ -119,7 +119,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    * |TERMINAL ON |HELP |          |         |
    * `--------=======------------------------'
    */
-  [_TERMINAL] = KEYMAP(
+  [_TERMINAL] = LAYOUT(
     _____,    TERM_ABOUT, _____, _____, \
     TERM_OFF, TERM_PRINT, _____, _____, \
     _____,    TERM_FLUSH, _____, _____, \

--- a/keyboards/ckeys/handwire_101/keymaps/default/keymap.c
+++ b/keyboards/ckeys/handwire_101/keymaps/default/keymap.c
@@ -1,14 +1,14 @@
 #include QMK_KEYBOARD_H
 
-#define _BASE           0  // base layer
-#define _LAYERS         1  // layer of all layers
-#define _MUSIC          2  // music mode
-#define _MUSIC_4_LIFE   3  // music mode until unplugged
-#define _MOUSE          4  // mousekeys
-#define _TERMINAL       5  // terminal
-#define _ADMIN          6  // admin duties
-
-#define _____ KC_TRNS
+enum layers {
+  _BASE,                // base layer
+  _LAYERS,              // layer of all layers
+  _MUSIC,               // music mode
+  _MUSIC_4_LIFE,        // music mode until unplugged
+  _MOUSE,               // mousekeys
+  _TERMINAL,            // terminal
+  _ADMIN                // admin duties
+};
 
 enum custom_keycodes {
   TERM_ABOUT = SAFE_RANGE,
@@ -50,10 +50,10 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    * `---------------------------'
    */
   [_LAYERS] = LAYOUT(
-    TG(_MUSIC),    _____, _____, _____, \
-    TG(_MOUSE),    _____, _____, _____, \
-    TG(_TERMINAL), _____, _____, _____, \
-    TG(_ADMIN),    _____, _____, _____ \
+    TG(_MUSIC),    _______, _______, _______, \
+    TG(_MOUSE),    _______, _______, _______, \
+    TG(_TERMINAL), _______, _______, _______, \
+    TG(_ADMIN),    _______, _______, _______\
   ),
     /* MUSIC
    * ,-----------------------.
@@ -68,10 +68,10 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    */
   // TODO: Make this music layer the one to jump to other music layers (different octaves)
   [_MUSIC] = LAYOUT(
-    _____,  _____, _____, _____,             \
-    _____,  _____, _____, TG(_MUSIC_4_LIFE), \
-    MU_OFF, _____, _____, _____,             \
-    MU_ON,  _____, _____, MU_MOD \
+    _______,  _______, _______, _______,             \
+    _______,  _______, _______, TG(_MUSIC_4_LIFE), \
+    MU_OFF,   _______, _______, _______,             \
+    MU_ON,    _______, _______, MU_MOD \
   ),
     /* MUSIC_4_LIFE
    * ,-----------------------.
@@ -102,8 +102,8 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    * `-------------------------------------------------'
    */
   [_MOUSE] = LAYOUT(
-    KC_MS_BTN5, _____,         KC_MS_WH_UP,   _____,         \
-    _____,      KC_MS_BTN1,    KC_MS_UP,      KC_MS_BTN2,    \
+    KC_MS_BTN5, _______,       KC_MS_WH_UP,   _______,         \
+    _______,    KC_MS_BTN1,    KC_MS_UP,      KC_MS_BTN2,    \
     KC_MS_BTN4, KC_MS_LEFT,    KC_MS_DOWN,    KC_MS_RIGHT,   \
     KC_MS_BTN3, KC_MS_WH_LEFT, KC_MS_WH_DOWN, KC_MS_WH_RIGHT \
   ),
@@ -119,10 +119,10 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    * `--------=======------------------------'
    */
   [_TERMINAL] = LAYOUT(
-    _____,    TERM_ABOUT, _____, _____, \
-    TERM_OFF, TERM_PRINT, _____, _____, \
-    _____,    TERM_FLUSH, _____, _____, \
-    TERM_ON,  TERM_HELP , _____, _____ \
+    _______,    TERM_ABOUT, _______, _______, \
+    TERM_OFF,   TERM_PRINT, _______, _______, \
+    _______,    TERM_FLUSH, _______, _______, \
+    TERM_ON,    TERM_HELP , _______, _______\
   ),
     /* ADMIN
    * ,-----------------------------------------.
@@ -136,10 +136,10 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    * `-----------------------------------------'
    */
   [_ADMIN] = LAYOUT(
-    RESET,       _____, _____, _____,  \
-    CKEYS_ABOUT, _____, _____, _____,  \
-    _____,       _____, _____, CK_OFF, \
-    _____,       _____, _____, CK_ON \
+    RESET,       _______, _______, _______,  \
+    CKEYS_ABOUT, _______, _______, _______,  \
+    _______,     _______, _______, CK_OFF, \
+    _______,     _______, _______, CK_ON \
   ),
 };
 

--- a/keyboards/ckeys/handwire_101/keymaps/default/keymap.c
+++ b/keyboards/ckeys/handwire_101/keymaps/default/keymap.c
@@ -1,5 +1,4 @@
-#include "handwire_101.h"
-#include "action_layer.h"
+#include QMK_KEYBOARD_H
 
 #define _BASE           0  // base layer
 #define _LAYERS         1  // layer of all layers

--- a/keyboards/ckeys/handwire_101/keymaps/default/keymap.c
+++ b/keyboards/ckeys/handwire_101/keymaps/default/keymap.c
@@ -136,7 +136,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    * |     X      |     |CLICKY DOWN|CLICKY ON |
    * `-----------------------------------------'
    */
-  [_ADMIN] = KEYMAP(
+  [_ADMIN] = LAYOUT(
     RESET,       _____, _____, _____,  \
     CKEYS_ABOUT, _____, _____, _____,  \
     _____,       _____, _____, CK_OFF, \

--- a/keyboards/ckeys/handwire_101/keymaps/default/keymap.c
+++ b/keyboards/ckeys/handwire_101/keymaps/default/keymap.c
@@ -33,7 +33,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    * |  0  |  .  |  =  |  +  |
    * `---------------------- '
    */
-  [_BASE] = KEYMAP(
+  [_BASE] = LAYOUT(
     KC_KP_7, KC_KP_8, KC_KP_9, LT(MO(_LAYERS), KC_PSLS), \
     KC_KP_4, KC_KP_5, KC_KP_6, KC_PAST,                  \
     KC_KP_1, KC_KP_2, KC_KP_3, KC_PMNS,                  \
@@ -50,7 +50,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    * |  ADMIN  |     |     |     |
    * `---------------------------'
    */
-  [_LAYERS] = KEYMAP(
+  [_LAYERS] = LAYOUT(
     TG(_MUSIC),    _____, _____, _____, \
     TG(_MOUSE),    _____, _____, _____, \
     TG(_TERMINAL), _____, _____, _____, \
@@ -68,7 +68,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    * `---------------------- '
    */
   // TODO: Make this music layer the one to jump to other music layers (different octaves)
-  [_MUSIC] = KEYMAP(
+  [_MUSIC] = LAYOUT(
     _____,  _____, _____, _____,             \
     _____,  _____, _____, TG(_MUSIC_4_LIFE), \
     MU_OFF, _____, _____, _____,             \

--- a/keyboards/ckeys/handwire_101/keymaps/default/keymap.c
+++ b/keyboards/ckeys/handwire_101/keymaps/default/keymap.c
@@ -102,7 +102,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    * |  BUTTON 3 |SCROLL LEFT|SCROLL DOWN |SCROLL RIGHT|
    * `-------------------------------------------------'
    */
-  [_MOUSE] = KEYMAP(
+  [_MOUSE] = LAYOUT(
     KC_MS_BTN5, _____,         KC_MS_WH_UP,   _____,         \
     _____,      KC_MS_BTN1,    KC_MS_UP,      KC_MS_BTN2,    \
     KC_MS_BTN4, KC_MS_LEFT,    KC_MS_DOWN,    KC_MS_RIGHT,   \

--- a/keyboards/ckeys/handwire_101/keymaps/default/keymap.c
+++ b/keyboards/ckeys/handwire_101/keymaps/default/keymap.c
@@ -171,7 +171,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
       break;
     case CKEYS_ABOUT:
       if (record->event.pressed) {
-        SEND_STRING("https://cKeys.org"SS_TAP(X_ENTER)"Making people smile one keyboard at a time."SS_TAP(X_ENTER)"cKeys is a volunteer run 501(c)(3) nonprofit."SS_TAP(X_ENTER));
+        SEND_STRING("https://cKeys.org"SS_TAP(X_ENTER)"Making people smile one keyboard at a time."SS_TAP(X_ENTER)"cKeys is a volunteer-run 501(c)(3) nonprofit organization."SS_TAP(X_ENTER));
       } else { }
       break;
   }

--- a/keyboards/ckeys/handwire_101/keymaps/default/keymap.c
+++ b/keyboards/ckeys/handwire_101/keymaps/default/keymap.c
@@ -1,0 +1,179 @@
+#include "handwire_101.h"
+#include "action_layer.h"
+
+#define _BASE           0  // base layer
+#define _LAYERS         1  // layer of all layers
+#define _MUSIC          2  // music mode
+#define _MUSIC_4_LIFE   3  // music mode until unplugged
+#define _MOUSE          4  // mousekeys
+#define _TERMINAL       5  // terminal
+#define _ADMIN          6  // admin duties
+
+#define _____ KC_TRNS
+
+enum custom_keycodes {
+  TERM_ABOUT = SAFE_RANGE,
+  TERM_PRINT,
+  TERM_FLUSH,
+  TERM_HELP,
+  CKEYS_ABOUT,
+};
+
+extern keymap_config_t keymap_config;
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    /* BASE (numpad)
+   * ,-----------------------.
+   * |  7  |  8  |  9  |  /  | <-- Hold for LAYERS
+   * |-----+-----+-----+-----|
+   * |  4  |  5  |  6  |  *  |
+   * |-----+-----+-----+-----|
+   * |  1  |  2  |  3  |  -  |
+   * |-----+-----+-----+-----|
+   * |  0  |  .  |  =  |  +  |
+   * `---------------------- '
+   */
+  [_BASE] = KEYMAP(
+    KC_KP_7, KC_KP_8, KC_KP_9, LT(MO(_LAYERS), KC_PSLS), \
+    KC_KP_4, KC_KP_5, KC_KP_6, KC_PAST,                  \
+    KC_KP_1, KC_KP_2, KC_KP_3, KC_PMNS,                  \
+    KC_KP_0, KC_KP_DOT, KC_KP_EQUAL, KC_PPLS \
+  ),
+    /* LAYERS
+   * ,---------------------------.
+   * |  MUSIC  |     |     |  X  |
+   * |---------+-----+-----+-----|
+   * |  MOUSE  |     |     |     |
+   * |---------+-----+-----+-----|
+   * |TERMINAL |     |     |     |
+   * |---------+-----+-----+-----|
+   * |  ADMIN  |     |     |     |
+   * `---------------------------'
+   */
+  [_LAYERS] = KEYMAP(
+    TG(_MUSIC),    _____, _____, _____, \
+    TG(_MOUSE),    _____, _____, _____, \
+    TG(_TERMINAL), _____, _____, _____, \
+    TG(_ADMIN),    _____, _____, _____ \
+  ),
+    /* MUSIC
+   * ,-----------------------.
+   * |  X  |     |     |  X  |
+   * |-----+-----+-----+-----|
+   * |     |     |     |4EVER|
+   * |-----+-----+-----+-----|
+   * | OFF |     |     |     |
+   * |-----+-----+-----+-----|
+   * |  ON |     |     |MODES|
+   * `---------------------- '
+   */
+  // TODO: Make this music layer the one to jump to other music layers (different octaves)
+  [_MUSIC] = KEYMAP(
+    _____,  _____, _____, _____,             \
+    _____,  _____, _____, TG(_MUSIC_4_LIFE), \
+    MU_OFF, _____, _____, _____,             \
+    MU_ON,  _____, _____, MU_MOD \
+  ),
+    /* MUSIC_4_LIFE
+   * ,-----------------------.
+   * |  ♫  |  ♫  |  ♫  |  ♫  |
+   * |-----+-----+-----+-----|
+   * |  ♫  |  ♫  |  ♫  |  ♫  |
+   * |-----+-----+-----+-----|
+   * |  ♫  |  ♫  |  ♫  |  ♫  |
+   * |-----+-----+-----+-----|
+   * |  ♫  |  ♫  |  ♫  |  ♫  |
+   * `---------------------- '
+   */
+  [_MUSIC_4_LIFE] = KEYMAP(
+    KC_M, KC_M, KC_M, KC_M, \
+    KC_M, KC_M, KC_M, KC_M, \
+    KC_M, KC_M, KC_M, KC_M, \
+    KC_M, KC_M, KC_M, KC_M \
+  ),
+    /* MOUSE
+   * ,-------------------------------------------------.
+   * |  BUTTON 5 |           | SCROLL UP  |     X      |
+   * |-----------+-----------+------------+------------|
+   * |     X     |LEFT CLICK |     UP     |RIGHT CLICK |
+   * |-----------+-----------+------------+------------|
+   * |  BUTTON 4 |   LEFT    |    DOWN    |   RIGHT    |
+   * |-----------+-----------+------------+------=-----|
+   * |  BUTTON 3 |SCROLL LEFT|SCROLL DOWN |SCROLL RIGHT|
+   * `-------------------------------------------------'
+   */
+  [_MOUSE] = KEYMAP(
+    KC_MS_BTN5, _____,         KC_MS_WH_UP,   _____,         \
+    _____,      KC_MS_BTN1,    KC_MS_UP,      KC_MS_BTN2,    \
+    KC_MS_BTN4, KC_MS_LEFT,    KC_MS_DOWN,    KC_MS_RIGHT,   \
+    KC_MS_BTN3, KC_MS_WH_LEFT, KC_MS_WH_DOWN, KC_MS_WH_RIGHT \
+  ),
+    /* TERMINAL
+   * ,---------------------------------------.
+   * |            |ABOUT|          |    X    |
+   * |------------+-----+----------+---------|
+   * |TERMINAL OFF|PRINT|          |         |
+   * |------------+-----+----------+---------|
+   * |     X      |FLUSH|          |         |
+   * |------------+-----+----------+---------|
+   * |TERMINAL ON |HELP |          |         |
+   * `--------=======------------------------'
+   */
+  [_TERMINAL] = KEYMAP(
+    _____,    TERM_ABOUT, _____, _____, \
+    TERM_OFF, TERM_PRINT, _____, _____, \
+    _____,    TERM_FLUSH, _____, _____, \
+    TERM_ON,  TERM_HELP , _____, _____ \
+  ),
+    /* ADMIN
+   * ,-----------------------------------------.
+   * |   RESET    |     |           |    X     |
+   * |------------+-----+-----------+----------|
+   * |ABOUT CKEYS |     |           |          |
+   * |------------+-----+-----------+----------|
+   * |            |     |CLICKY UP  |CLICKY OFF|
+   * |------------+-----+-----------+----------|
+   * |     X      |     |CLICKY DOWN|CLICKY ON |
+   * `-----------------------------------------'
+   */
+  [_ADMIN] = KEYMAP(
+    RESET,       _____, _____, _____,  \
+    CKEYS_ABOUT, _____, _____, _____,  \
+    _____,       _____, _____, CK_OFF, \
+    _____,       _____, _____, CK_ON \
+  ),
+};
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  switch (keycode) {
+    case TERM_ABOUT:
+      if (record->event.pressed) {
+        // when keycode TERM_ABOUT is pressed
+        SEND_STRING("about"SS_TAP(X_ENTER));
+      } else {
+        // when keycode TERM_ABOUT is released
+      }
+      break;
+    case TERM_PRINT:
+      if (record->event.pressed) {
+        SEND_STRING("print"SS_TAP(X_ENTER));
+      } else { }
+      break;
+    case TERM_FLUSH:
+      if (record->event.pressed) {
+        SEND_STRING("flush"SS_TAP(X_ENTER));
+      } else { }
+      break;
+    case TERM_HELP:
+      if (record->event.pressed) {
+        SEND_STRING("help"SS_TAP(X_ENTER));
+      } else { }
+      break;
+    case CKEYS_ABOUT:
+      if (record->event.pressed) {
+        SEND_STRING("https://cKeys.org"SS_TAP(X_ENTER)"Making people smile one keyboard at a time."SS_TAP(X_ENTER)"cKeys is a volunteer run 501(c)(3) nonprofit."SS_TAP(X_ENTER));
+      } else { }
+      break;
+  }
+  return true;
+};

--- a/keyboards/ckeys/handwire_101/keymaps/default/readme.md
+++ b/keyboards/ckeys/handwire_101/keymaps/default/readme.md
@@ -1,0 +1,1 @@
+# The default keymap for the cKeys Handwire 101 4x4 keyboard.

--- a/keyboards/ckeys/handwire_101/readme.md
+++ b/keyboards/ckeys/handwire_101/readme.md
@@ -1,0 +1,163 @@
+# cKeys Handwire 101 Workshop
+
+![](https://ckeys.org/images/proton-c-handwire-1.jpg)
+
+## Slides
+
+Slides can be found at: https://ckeys.org/slides/handwire/
+
+## Case Design
+
+The laser cutting file is ideal for Ponoko's P1 board size.
+
+## Firmware
+
+If you want to reflash the pre-installed firmware, use the `.bin` file for Proton C and the `.hex` file for Pro Micro builds. Flash with the QMK Toolbox or via the command line.
+
+Building for Proton C: `make ckeys/handwire_101:default CTPC=yes`
+Building for Pro Micro: `make ckeys/handwire_101:default`
+
+Pre-built firmware files (and laser cutting case files) can be found here: https://github.com/c-keys/handwire
+
+## Default Layout
+
+You can find the default layout in `qmk-handwire/keymaps/default/keymap.c`
+
+### Layers
+
+When you plug in your keyboard, it will function as a numpad. You will remain in the `Base` numpad layer unless you hold down the top right corner key and select one of the keys in the left most column. In QMK, this is called a momentary switch and looks like `MO(LAYERS)` in the default `keymap.c`. You can read more about layer switching in the [QMK Documentation](https://beta.docs.qmk.fm/features/feature_advanced_keycodes#switching-and-toggling-layers).
+
+#### Base
+```
+    /* BASE (numpad)
+   * ,-----------------------.
+   * |  7  |  8  |  9  |  /  | <-- Hold for LAYERS
+   * |-----+-----+-----+-----|
+   * |  4  |  5  |  6  |  *  |
+   * |-----+-----+-----+-----|
+   * |  1  |  2  |  3  |  -  |
+   * |-----+-----+-----+-----|
+   * |  0  |  .  |  =  |  +  |
+   * `---------------------- '
+   */
+```
+
+#### Layers
+
+```
+    /* LAYERS
+   * ,---------------------------.
+   * |  MUSIC  |     |     |  X  |
+   * |---------+-----+-----+-----|
+   * |  MOUSE  |     |     |     |
+   * |---------+-----+-----+-----|
+   * |TERMINAL |     |     |     |
+   * |---------+-----+-----+-----|
+   * |  ADMIN  |     |     |     |
+   * `---------------------------'
+   */
+```
+
+This is the layers layer. This is how you toggle other layers on and off. If you toggle on a layer, it is important that you re-toggle that layer offbefore switching to a new layer.
+
+#### Music
+
+```
+    /* MUSIC
+   * ,-----------------------.
+   * |  X  |     |     |  X  |
+   * |-----+-----+-----+-----|
+   * |     |     |     |4EVER|
+   * |-----+-----+-----+-----|
+   * | OFF |     |     |     |
+   * |-----+-----+-----+-----|
+   * |  ON |     |     |MODES|
+   * `---------------------- '
+   */
+```
+
+You can toggle the music mode on and off. You can also change the mode of music modes. Lastly, you can switch to the Music 4 Life mode but tapping the key marked `4EVER` above (see below). For more information on music mode, see the [QMK Documentation](https://beta.docs.qmk.fm/features/feature_audio).
+
+_NOTE: This layer will only make sounds if you install a speaker. At the time of this writing, you can get the Proton C specific piezo speaker for [$2.61 with free overnight shipping](https://www.arrow.com/en/products/ast1109mltrq/mallory-sonalert-products). You can solder it on by desoldering the row wires where they contact the cathode end of the diodes. Then flip over the Proton C and solder the piezo speaker in. Then re-solder the row wires and you should hear beeps and boops the next time you plug in your keyboard._
+
+#### Music 4 Life
+
+```
+    /* MUSIC_4_LIFE
+   * ,-----------------------.
+   * |  ♫  |  ♫  |  ♫  |  ♫  |
+   * |-----+-----+-----+-----|
+   * |  ♫  |  ♫  |  ♫  |  ♫  |
+   * |-----+-----+-----+-----|
+   * |  ♫  |  ♫  |  ♫  |  ♫  |
+   * |-----+-----+-----+-----|
+   * |  ♫  |  ♫  |  ♫  |  ♫  |
+   * `---------------------- '
+   */
+```
+
+Music mode on every single key. However, you will need to unplug your keyboard in order to get out of this mode. The benefit of this is that you can use every single key as opposed to the few left over in the Music Mode layer. Try changing the chromatic mode before switching to this mode.
+
+#### Mouse
+
+```
+    /* MOUSE
+   * ,-------------------------------------------------.
+   * |  BUTTON 5 |           | SCROLL UP  |     X      |
+   * |-----------+-----------+------------+------------|
+   * |     X     |LEFT CLICK |     UP     |RIGHT CLICK |
+   * |-----------+-----------+------------+------------|
+   * |  BUTTON 4 |   LEFT    |    DOWN    |   RIGHT    |
+   * |-----------+-----------+------------+------=-----|
+   * |  BUTTON 3 |SCROLL LEFT|SCROLL DOWN |SCROLL RIGHT|
+   * `-------------------------------------------------'
+   */
+```
+
+Switch to this mode, force yourself through the steep transitionary period, and then you can ditch mice and trackpads forever!
+
+#### Terminal
+
+```
+    /* TERMINAL
+   * ,---------------------------------------.
+   * |            |ABOUT|          |    X    |
+   * |------------+-----+----------+---------|
+   * |TERMINAL OFF|PRINT|          |         |
+   * |------------+-----+----------+---------|
+   * |     X      |FLUSH|          |         |
+   * |------------+-----+----------+---------|
+   * |TERMINAL ON |HELP |          |         |
+   * `--------=======------------------------'
+   */
+```
+
+This layer is not currently working but has been left as an example of how to write macros.
+
+#### Admin
+
+```
+    /* ADMIN
+   * ,-----------------------------------------.
+   * |   RESET    |     |           |    X     |
+   * |------------+-----+-----------+----------|
+   * |ABOUT CKEYS |     |           |          |
+   * |------------+-----+-----------+----------|
+   * |            |     |CLICKY UP  |CLICKY OFF|
+   * |------------+-----+-----------+----------|
+   * |     X      |     |CLICKY DOWN|CLICKY ON |
+   * `-----------------------------------------'
+   */
+```
+
+The most important key in this layer is the `RESET` switch. Use it to flash new firmware. It does the same thing as the hardware button on the Proton C. But since you soldered the Proton C with the reset button facing towards the keys, the only way to reach it is to de-solder wires. The reset switch solves this. Program a reset switch into all of your future keyboards.
+
+The `ABOUT CKEYS` is another example of using a macro. It will type out a few sentences about cKeys.
+
+The clicky buttons will only make a difference if you install a piezo speaker. If you install a speaker, then you can make your keyboard extra clicky sounding even if you did not install clicky switches.
+
+![](https://ckeys.org/images/proton-c-handwire-2.jpg)
+![](https://ckeys.org/images/proton-c-handwire-3.jpg)
+![](https://ckeys.org/images/handwire-1.jpg)
+![](https://ckeys.org/images/handwire-2.jpg)
+![](https://ckeys.org/images/handwire-3.jpg)

--- a/keyboards/ckeys/handwire_101/rules.mk
+++ b/keyboards/ckeys/handwire_101/rules.mk
@@ -1,0 +1,69 @@
+# MCU name
+#MCU = at90usb1287
+MCU = atmega32u4
+
+# Processor frequency.
+#     This will define a symbol, F_CPU, in all source code files equal to the
+#     processor frequency in Hz. You can then use this symbol in your source code to
+#     calculate timings. Do NOT tack on a 'UL' at the end, this will be done
+#     automatically to create a 32-bit value in your source code.
+#
+#     This will be an integer division of F_USB below, as it is sourced by
+#     F_USB after it has run through any CPU prescalers. Note that this value
+#     does not *change* the processor frequency - it should merely be updated to
+#     reflect the processor speed set externally so that the code can use accurate
+#     software delays.
+F_CPU = 16000000
+
+
+#
+# LUFA specific
+#
+# Target architecture (see library "Board Types" documentation).
+ARCH = AVR8
+
+# Input clock frequency.
+#     This will define a symbol, F_USB, in all source code files equal to the
+#     input clock frequency (before any prescaling is performed) in Hz. This value may
+#     differ from F_CPU if prescaling is used on the latter, and is required as the
+#     raw input clock is fed directly to the PLL sections of the AVR for high speed
+#     clock generation for the USB and other AVR subsections. Do NOT tack on a 'UL'
+#     at the end, this will be done automatically to create a 32-bit value in your
+#     source code.
+#
+#     If no clock division is performed on the input clock inside the AVR (via the
+#     CPU clock adjust registers or the clock division fuses), this will be equal to F_CPU.
+F_USB = $(F_CPU)
+
+# Interrupt driven control endpoint task(+60)
+OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
+
+
+# Boot Section Size in *bytes*
+#   Teensy halfKay   512
+#   Teensy++ halfKay 1024
+#   Atmel DFU loader 4096
+#   LUFA bootloader  4096
+#   USBaspLoader     2048
+OPT_DEFS += -DBOOTLOADER_SIZE=4096
+
+
+# Build Options
+#   change yes to no to disable
+#
+BOOTMAGIC_ENABLE = no      # Virtual DIP switch configuration(+1000)
+MOUSEKEY_ENABLE = yes       # Mouse keys(+4700)
+EXTRAKEY_ENABLE = yes       # Audio control and System control(+450)
+CONSOLE_ENABLE = no        # Console for debug(+400)
+COMMAND_ENABLE = no        # Commands for debug and configuration
+TERMINAL_ENABLE = yes
+# Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
+SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
+# if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+NKRO_ENABLE = yes            # USB Nkey Rollover
+BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality on B7 by default
+#MIDI_ENABLE = yes            # MIDI controls
+UNICODE_ENABLE = no         # Unicode
+BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
+AUDIO_ENABLE = yes           # Audio output on port C6
+FAUXCLICKY_ENABLE = no      # Use buzzer to emulate clicky switches

--- a/keyboards/ckeys/handwire_101/rules.mk
+++ b/keyboards/ckeys/handwire_101/rules.mk
@@ -45,7 +45,7 @@ OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
 #   Atmel DFU loader 4096
 #   LUFA bootloader  4096
 #   USBaspLoader     2048
-OPT_DEFS += -DBOOTLOADER_SIZE=4096
+BOOTLOADER = caterina
 
 
 # Build Options

--- a/keyboards/ckeys/readme.md
+++ b/keyboards/ckeys/readme.md
@@ -1,6 +1,6 @@
 # cKeys.org
 
-[ckeys](https://ckeys.org/) is a mechanical keyboard based non profit, located in Seattle, Washington.
+[cKeys](https://ckeys.org/) is a mechanical keyboard-based nonprofit organization located in Seattle, Washington.
 
 In addition, to hosting the [Seattle Mechanical Keyboard Meetups](https://ckeys.org/events/), they have [soldering workshops](https://ckeys.org/workshops/) featuring hardware hosted in this repository.
 

--- a/keyboards/ckeys/readme.md
+++ b/keyboards/ckeys/readme.md
@@ -1,9 +1,10 @@
-# Ckeys.org
+# cKeys.org
 
-[ckeys](https://ckeys.org/) is a mechanical keyboard based non profit, located in Seattle, Washington. 
+[ckeys](https://ckeys.org/) is a mechanical keyboard based non profit, located in Seattle, Washington.
 
-In addition, to hosting the [Seattle Mechanical Keyboard Meetups](https://ckeys.org/events/), they have [soldering workshops](https://ckeys.org/workshops/) featuring hardware hosted in this repository. 
+In addition, to hosting the [Seattle Mechanical Keyboard Meetups](https://ckeys.org/events/), they have [soldering workshops](https://ckeys.org/workshops/) featuring hardware hosted in this repository.
 
 * Supported Hardware
-    * The Obelus - 4x4 Macropad
-    * naKey      - Through hole numpad
+    * The Obelus   - 4x4 Macropad
+    * naKey        - Through hole numpad
+    * Handwire 101 - Handwired 4x4 (Proton C or Pro Micro)


### PR DESCRIPTION
## Description
Added the cKeys handwire keyboard that coincides with the cKeys Handwire 101 workshop. The default keymap is used as a teaching tool and introduction to QMK.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Core
- [ ] Bugfix
- [ ] New Feature
- [ ] Enhancement/Optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by this PR
*  N/A

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
