### PR TITLE
Use qmk docker image for travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,31 +11,21 @@ env:
   global:
   - secure: vBTSL34BDPxDilKUuTXqU4CJ26Pv5hogD2nghatkxSQkI1/jbdnLj/DQdPUrMJFDIY6TK3AltsBx72MaMsLQ1JO/Ou24IeHINHXzUC1FlS9yQa48cpxnhX5kzXNyGs3oa0qaFbvnr7RgYRWtmD52n4bIZuSuW+xpBv05x2OCizdT2ZonH33nATaHGFasxROm4qYZ241VfzcUv766V6RVHgL4x9V08warugs+RENVkfzxxwhk3NmkrISabze0gSVJLHBPHxroZC6EUcf/ocobcuDrCwFqtEt90i7pNIAFUE7gZsN2uE75LmpzAWin21G7lLPcPL2k4FJVd8an1HiP2WmscJU6U89fOfMb2viObnKcCzebozBCmKGtHEuXZo9FcReOx49AnQSpmESJGs+q2dL/FApkTjQiyT4J6O5dJpoww0/r57Wx0cmmqjETKBb5rSgXM51Etk3wO09mvcPHsEwrT7qH8r9XWdyCDoEn7FCLX3/LYnf/D4SmZ633YPl5gv3v9XEwxR5+04akjgnvWDSNIaDbWBdxHNb7l4pMc+WR1bwCyMyA7KXj0RrftEGOrm9ZRLe6BkbT4cycA+j77nbPOMcyZChliV9pPQos+4TOJoTzcK2L8yWVoY409aDNVuAjdP6Yum0R2maBGl/etLmIMpJC35C5/lZ+dUNjJAM=
   - MAKEFLAGS="-j3 --output-sync"
+services:
+  - docker
 before_install:
-  - wget http://ww1.microchip.com/downloads/en/DeviceDoc/avr8-gnu-toolchain-3.5.4.1709-linux.any.x86_64.tar.gz || wget http://qmk.fm/avr8-gnu-toolchain-3.5.4.1709-linux.any.x86_64.tar.gz
-  # Need DFU > .5 for dfu-suffix
-  - sudo add-apt-repository --yes ppa:tormodvolden/ppa
-  - sudo apt-get update -qq
+  - docker build -t qmkfm/qmk_firmware .
 install:
-  - tar -zxf avr8-gnu-toolchain-3.5.4.1709-linux.any.x86_64.tar.gz
-  - export PATH="$PATH:$TRAVIS_BUILD_DIR/avr8-gnu-toolchain-linux_x86_64/bin"
   - npm install -g moxygen
-  - sudo apt-get -y --force-yes install dfu-util
-before_script:
-  - avr-gcc --version
 script:
-- git rev-parse --short HEAD
-- bash util/travis_test.sh
-- bash util/travis_build.sh
-- bash util/travis_docs.sh
+  - git rev-parse --short HEAD
+  - bash util/travis_test.sh
+  - bash util/travis_build.sh
+  - bash util/travis_docs.sh
 addons:
   apt:
     packages:
-    - dfu-programmer
     - pandoc
-    - gcc-arm-none-eabi
-    - binutils-arm-none-eabi
-    - libnewlib-arm-none-eabi
     - diffutils
     - dos2unix
     - doxygen

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,11 +19,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     zip \
     && rm -rf /var/lib/apt/lists/*
 
-ENV KEYBOARD=ergodox_ez
-ENV KEYMAP=default
-
 VOLUME /qmk_firmware
 WORKDIR /qmk_firmware
 COPY . .
 
-CMD make $KEYBOARD:$KEYMAP
+CMD make all:default

--- a/util/travis_build.sh
+++ b/util/travis_build.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# if docker is installed - call make within the qmk docker image
+if command -v docker >/dev/null; then
+  function make() {
+    docker run --rm -e MAKEFLAGS="$MAKEFLAGS" -w /qmk_firmware/ -v "$PWD":/qmk_firmware qmkfm/qmk_firmware make "$@"
+  }
+fi
+
 # test force push
 #TRAVIS_COMMIT_RANGE="c287f1bfc5c8...81f62atc4c1d"
 

--- a/util/travis_test.sh
+++ b/util/travis_test.sh
@@ -19,4 +19,11 @@ if [ "$BRANCH" != "master" ] && [ "$NUM_IMPACTING_CHANGES" == "0" ]; then
     exit 0
 fi
 
+# if docker is installed - call make within the qmk docker image
+if command -v docker >/dev/null; then
+  function make() {
+    docker run --rm -e MAKEFLAGS="$MAKEFLAGS" -w /qmk_firmware/ -v "$PWD":/qmk_firmware qmkfm/qmk_firmware make "$@"
+  }
+fi
+
 make test:all


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- This template is entirely option and can be removed, but is here to help both you and us. -->
<!--- This text and anything on lines wrapped like this one will not show up in the final text. This text is to help us and you. -->

## Description
<!--- Describe your changes in detail -->
In order to locally reproduce build issues, it is essential to minimise differences. Getting an environment to mimic travis is rather troublesome and involves far too many steps. Using the current docker image for both local builds and CI builds allows contributors to get the same results locally with minimal changes. While it potentially adds the optional docker dependency on the development environment, this still cuts out an entire section of the currently supported platform/compiler matrix.

This PR switches travis to use docker with the following changes:

- Added docker support to the travis configuration
- Removed install of compile dependencies
- Build current qmk_firmware docker image
  - This could pull the one from docker hub if its reliably up to date
  - Alternatively the build could later push this if the image changes
- Added a wrapper script for the test phase
- Force builds to use the make within the qmk docker image when available
  - The current implementation replaces make with a shim but there are other ways to do this if its too hacky

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Core
- [ ] Bugfix
- [ ] New Feature
- [x] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
