### PR TITLE
Fix RGBLIGHT_SLEEP function

### DIFF
--- a/tmk_core/common/avr/suspend.c
+++ b/tmk_core/common/avr/suspend.c
@@ -48,8 +48,7 @@ __asm__ __volatile__ (  \
  *
  * FIXME: needs doc
  */
-void suspend_idle(uint8_t time)
-{
+void suspend_idle(uint8_t time) {
     cli();
     set_sleep_mode(SLEEP_MODE_IDLE);
     sleep_enable();
@@ -97,8 +96,7 @@ static uint8_t wdt_timeout = 0;
  *
  * FIXME: needs doc
  */
-static void power_down(uint8_t wdto)
-{
+static void power_down(uint8_t wdto) {
 #ifdef PROTOCOL_LUFA
     if (USB_DeviceState == DEVICE_STATE_Configured) return;
 #endif
@@ -148,8 +146,7 @@ static void power_down(uint8_t wdto)
  *
  * FIXME: needs doc
  */
-void suspend_power_down(void)
-{
+void suspend_power_down(void) {
 	suspend_power_down_kb();
 
 #ifndef NO_SUSPEND_POWER_DOWN
@@ -159,8 +156,7 @@ void suspend_power_down(void)
 
 __attribute__ ((weak)) void matrix_power_up(void) {}
 __attribute__ ((weak)) void matrix_power_down(void) {}
-bool suspend_wakeup_condition(void)
-{
+bool suspend_wakeup_condition(void) {
     matrix_power_up();
     matrix_scan();
     matrix_power_down();
@@ -189,8 +185,7 @@ void suspend_wakeup_init_kb(void) {
  *
  * FIXME: needs doc
  */
-void suspend_wakeup_init(void)
-{
+void suspend_wakeup_init(void) {
     // clear keyboard state
     clear_keyboard();
 #ifdef BACKLIGHT_ENABLE
@@ -213,8 +208,7 @@ void suspend_wakeup_init(void)
 
 #ifndef NO_SUSPEND_POWER_DOWN
 /* watchdog timeout */
-ISR(WDT_vect)
-{
+ISR(WDT_vect) {
     // compensate timer for sleep
     switch (wdt_timeout) {
         case WDTO_15MS:

--- a/tmk_core/common/avr/suspend.c
+++ b/tmk_core/common/avr/suspend.c
@@ -22,6 +22,8 @@
 
 #if defined(RGBLIGHT_SLEEP) && defined(RGBLIGHT_ENABLE)
   #include "rgblight.h"
+  extern rgblight_config_t rgblight_config;
+  static bool rgblight_enabled;
 #endif
 
 
@@ -120,6 +122,7 @@ static void power_down(uint8_t wdto)
 #ifdef RGBLIGHT_ANIMATIONS
   rgblight_timer_disable();
 #endif
+  rgblight_enabled = rgblight_config.enable;
   rgblight_disable_noeeprom();
 #endif
   suspend_power_down_kb();
@@ -195,10 +198,12 @@ void suspend_wakeup_init(void)
 #endif
 	led_set(host_keyboard_leds());
 #if defined(RGBLIGHT_SLEEP) && defined(RGBLIGHT_ENABLE)
-#ifdef BOOTLOADER_TEENSY
-  wait_ms(10);
-#endif
-  rgblight_enable_noeeprom();
+  if (rgblight_enabled) {
+    #ifdef BOOTLOADER_TEENSY
+      wait_ms(10);
+    #endif
+    rgblight_enable_noeeprom();
+  }
 #ifdef RGBLIGHT_ANIMATIONS
   rgblight_timer_enable();
 #endif


### PR DESCRIPTION
## Description
This is 100% my fault. 

Since I always want RGB Lights on (in a move that should surprise nobody here), I never botherer to check to see what would happen if the lights were not enabled first.  

As is, this means that if the sleep option is enabled, it will turn the lights on when waking, regardless of the previous setting.

This change should save the previous setting and only re-enable the lights if it was actually enabled previously. 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Core
- [X] Bugfix
- [ ] New Feature
- [X] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation


## Issues Fixed or Closed by this PR

* Feedback from Ergodox EZ

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
