### PR TITLE
Flip definitions of macOS brightness alias

### DIFF
--- a/tmk_core/common/keycode.h
+++ b/tmk_core/common/keycode.h
@@ -175,8 +175,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define KC_BRID KC_BRIGHTNESS_DOWN
 
 /* System Specific */
-#define KC_BRMU KC_SCROLLLOCK
-#define KC_BRMD KC_PAUSE
+#define KC_BRMU KC_PAUSE
+#define KC_BRMD KC_SCROLLLOCK
 
 /* Mouse Keys */
 #define KC_MS_U KC_MS_UP


### PR DESCRIPTION
## Description

The brightness aliases for macOS (`KC_BRMU` and `KC_BRMD`) seems to be mistakenly flipped.

in `docs/keycodes.md`:

| Key | Aliases | Description |
----|----|----
| KC_SCROLLLOCK | KC_SLCK, KC_BRMD | Scroll Lock, Brightness Down (macOS) |
| KC_PAUSE | KC_PAUS, KC_BRK, KC_BRMU | Pause, Brightness Up (macOS) |

in `tmk_core/common/keycode.h`:

```c
#define KC_BRMU KC_SCROLLLOCK
#define KC_BRMD KC_PAUSE
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Core
- [ ] Bugfix
- [ ] New Feature
- [ ] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation


## Issues Fixed or Closed by this PR

* 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
