### PR TITLE
Grammatical fixes for GPIO Control doc

### DIFF
--- a/docs/internals_gpio_control.md
+++ b/docs/internals_gpio_control.md
@@ -17,7 +17,7 @@ The following functions can provide basic control of GPIOs and are found in `qua
 |`writePin(pin, level)`|Set pin level, assuming it is an output                           |
 |`readPin(pin)`        |Returns the level of the pin                                      |
 
-## Advance settings
+## Advanced Settings
 
-Each micro-controller can have multiple advance settings regarding its GPIO. This abstraction layer does not limit the use of architecture specific functions. Advance users should consult the datasheet of there desired device and include any needed libraries. For AVR the standard avr/io.h library is used and for STM32 the Chibios [PAL library](http://chibios.sourceforge.net/docs3/hal/group___p_a_l.html) is used.
+Each micro-controller can have multiple advanced settings regarding its GPIO. This abstraction layer does not limit the use of architecture-specific functions. Advanced users should consult the datasheet of their desired device and include any needed libraries. For AVR, the standard avr/io.h library is used; for STM32, the Chibios [PAL library](http://chibios.sourceforge.net/docs3/hal/group___p_a_l.html) is used.
 

--- a/docs/internals_gpio_control.md
+++ b/docs/internals_gpio_control.md
@@ -19,5 +19,5 @@ The following functions can provide basic control of GPIOs and are found in `qua
 
 ## Advanced Settings
 
-Each micro-controller can have multiple advanced settings regarding its GPIO. This abstraction layer does not limit the use of architecture-specific functions. Advanced users should consult the datasheet of their desired device and include any needed libraries. For AVR, the standard avr/io.h library is used; for STM32, the Chibios [PAL library](http://chibios.sourceforge.net/docs3/hal/group___p_a_l.html) is used.
+Each microcontroller can have multiple advanced settings regarding its GPIO. This abstraction layer does not limit the use of architecture-specific functions. Advanced users should consult the datasheet of their desired device and include any needed libraries. For AVR, the standard avr/io.h library is used; for STM32, the ChibiOS [PAL library](http://chibios.sourceforge.net/docs3/hal/group___p_a_l.html) is used.
 

--- a/docs/internals_gpio_control.md
+++ b/docs/internals_gpio_control.md
@@ -1,6 +1,6 @@
 # GPIO Control
 
-QMK has a GPIO control abstraction layer which is micro-controller agnostic. This is done to allow easy access to pin control across different platforms.
+QMK has a GPIO control abstraction layer which is microcontroller agnostic. This is done to allow easy access to pin control across different platforms.
 
 ## Functions
 


### PR DESCRIPTION
I found the Advanced Settings section to be poorly written.