### PR TITLE
Cleanup i2c_slave functions so it can coexist with i2c_master

### DIFF
--- a/drivers/avr/i2c_slave.c
+++ b/drivers/avr/i2c_slave.c
@@ -9,23 +9,26 @@
 
 #include "i2c_slave.h"
 
-void i2c_init(uint8_t address){
+volatile uint8_t i2c_slave_reg[I2C_SLAVE_REG_COUNT];
+
+static volatile uint8_t buffer_address;
+static volatile bool slave_has_register_set = false;
+
+void i2c_slave_init(uint8_t address){
     // load address into TWI address register
     TWAR = (address << 1);
     // set the TWCR to enable address matching and enable TWI, clear TWINT, enable TWI interrupt
     TWCR = (1 << TWIE) | (1 << TWEA) | (1 << TWINT) | (1 << TWEN);
 }
 
-void i2c_stop(void){
+void i2c_slave_stop(void){
     // clear acknowledge and enable bits
     TWCR &= ~((1 << TWEA) | (1 << TWEN));
 }
 
 ISR(TWI_vect){
     uint8_t ack = 1;
-    // temporary stores the received data
-    //uint8_t data;
-    
+
     switch(TW_STATUS){
         case TW_SR_SLA_ACK:
             // The device is now a slave receiver
@@ -38,13 +41,13 @@ ISR(TWI_vect){
             if(!slave_has_register_set){
                 buffer_address = TWDR;
 
-                if (buffer_address >= RX_BUFFER_SIZE){ // address out of bounds dont ack
-                    ack = 0;
-                    buffer_address = 0;
+                if (buffer_address >= I2C_SLAVE_REG_COUNT) {  // address out of bounds dont ack
+                  ack            = 0;
+                  buffer_address = 0;
                 }
                 slave_has_register_set = true; // address has been receaved now fill in buffer
             } else {
-                rxbuffer[buffer_address] = TWDR;
+                i2c_slave_reg[buffer_address] = TWDR;
                 buffer_address++;
             }
             break;
@@ -52,7 +55,7 @@ ISR(TWI_vect){
         case TW_ST_SLA_ACK:
         case TW_ST_DATA_ACK:
             // This device is a slave transmitter and master has requested data
-            TWDR = txbuffer[buffer_address];
+            TWDR = i2c_slave_reg[buffer_address];
             buffer_address++;
             break;
 
@@ -63,6 +66,6 @@ ISR(TWI_vect){
             break;
     }
 
-    // Reset i2c state mahcine to be ready for next interrupt
+    // Reset i2c state machine to be ready for next interrupt
     TWCR |= (1 << TWIE) | (1 << TWINT) | (ack << TWEA) | (1 << TWEN);
 }

--- a/drivers/avr/i2c_slave.h
+++ b/drivers/avr/i2c_slave.h
@@ -8,16 +8,11 @@
 #ifndef I2C_SLAVE_H
 #define I2C_SLAVE_H
 
-#define TX_BUFFER_SIZE 30
-#define RX_BUFFER_SIZE 30
+#define I2C_SLAVE_REG_COUNT 30
 
-volatile uint8_t buffer_address;
-static volatile bool slave_has_register_set = false;
-volatile uint8_t txbuffer[TX_BUFFER_SIZE];
-volatile uint8_t rxbuffer[RX_BUFFER_SIZE];
+extern volatile uint8_t i2c_slave_reg[I2C_SLAVE_REG_COUNT];
 
-void i2c_init(uint8_t address);
-void i2c_stop(void);
-ISR(TWI_vect);
+void i2c_slave_init(uint8_t address);
+void i2c_slave_stop(void);
 
 #endif // I2C_SLAVE_H

--- a/keyboards/dc01/arrow/matrix.c
+++ b/keyboards/dc01/arrow/matrix.c
@@ -195,14 +195,14 @@ uint8_t matrix_scan(void)
             debouncing = false;
         }
 #   endif
-        
+
         if (USB_DeviceState != DEVICE_STATE_Configured){
-            txbuffer[1] = 0x55;
+            i2c_slave_reg[1] = 0x55;
             for (uint8_t i = 0; i < MATRIX_ROWS; i++){
-                txbuffer[i+2] = matrix[i]; //send matrix over i2c
+                i2c_slave_reg[i+2] = matrix[i]; //send matrix over i2c
             }
         }
-    
+
     matrix_scan_quantum();
     return 1;
 }
@@ -396,9 +396,9 @@ static void unselect_cols(void)
 
 //this replases tmk code
 void matrix_setup(void){
-    
+
     if (USB_DeviceState != DEVICE_STATE_Configured){
-        i2c_init(SLAVE_I2C_ADDRESS); //setup address of slave i2c
+        i2c_slave_init(SLAVE_I2C_ADDRESS); //setup address of slave i2c
         sei(); //enable interupts
     }
 }

--- a/keyboards/dc01/numpad/matrix.c
+++ b/keyboards/dc01/numpad/matrix.c
@@ -195,14 +195,14 @@ uint8_t matrix_scan(void)
             debouncing = false;
         }
 #   endif
-        
+
         if (USB_DeviceState != DEVICE_STATE_Configured){
-            txbuffer[1] = 0x55;
+            i2c_slave_reg[1] = 0x55;
             for (uint8_t i = 0; i < MATRIX_ROWS; i++){
-                txbuffer[i+2] = matrix[i]; //send matrix over i2c
+                i2c_slave_reg[i+2] = matrix[i]; //send matrix over i2c
             }
         }
-    
+
     matrix_scan_quantum();
     return 1;
 }
@@ -396,9 +396,9 @@ static void unselect_cols(void)
 
 //this replases tmk code
 void matrix_setup(void){
-    
+
     if (USB_DeviceState != DEVICE_STATE_Configured){
-        i2c_init(SLAVE_I2C_ADDRESS); //setup address of slave i2c
+        i2c_slave_init(SLAVE_I2C_ADDRESS); //setup address of slave i2c
         sei(); //enable interupts
     }
 }

--- a/keyboards/dc01/right/matrix.c
+++ b/keyboards/dc01/right/matrix.c
@@ -195,14 +195,14 @@ uint8_t matrix_scan(void)
             debouncing = false;
         }
 #   endif
-        
+
         if (USB_DeviceState != DEVICE_STATE_Configured){
-            txbuffer[1] = 0x55;
+            i2c_slave_reg[1] = 0x55;
             for (uint8_t i = 0; i < MATRIX_ROWS; i++){
-                txbuffer[i+2] = matrix[i]; //send matrix over i2c
+                i2c_slave_reg[i+2] = matrix[i]; //send matrix over i2c
             }
         }
-    
+
     matrix_scan_quantum();
     return 1;
 }
@@ -396,9 +396,9 @@ static void unselect_cols(void)
 
 //this replases tmk code
 void matrix_setup(void){
-    
+
     if (USB_DeviceState != DEVICE_STATE_Configured){
-        i2c_init(SLAVE_I2C_ADDRESS); //setup address of slave i2c
+        i2c_slave_init(SLAVE_I2C_ADDRESS); //setup address of slave i2c
         sei(); //enable interupts
     }
 }


### PR DESCRIPTION
## Description

The current i2c_master and i2c_slave driver have conflicting symbols. This commit renames the slave side so both can be linked in simultaneously. It also optimises RAM usage slightly (separate rx and tx buffers aren't needed), and fixes a couple of oddities (the variables were being instantiated in the header!?)

The only kbs that uses driver/avr/i2c_slave.c at present are dc01/arrow, dc01/numpad, dc01/right. I've updated them to build successfully against the updated API.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Core
- [x] Bugfix
- [ ] New Feature
- [x] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
