### PR TITLE
Enable RGB Underglow for Idobo Boards

### DIFF
--- a/keyboards/idobo/rules.mk
+++ b/keyboards/idobo/rules.mk
@@ -66,7 +66,7 @@ BOOTMAGIC_ENABLE = no      # Virtual DIP switch configuration(+1000)
 MOUSEKEY_ENABLE = yes       # Mouse keys(+4700)
 EXTRAKEY_ENABLE = yes       # Audio control and System control(+450)
 CONSOLE_ENABLE = yes        # Console for debug(+400)
-COMMAND_ENABLE = yes        # Commands for debug and configuration
+COMMAND_ENABLE = no        # Commands for debug and configuration
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
 SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
 # if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- This template is entirely option and can be removed, but is here to help both you and us. -->
<!--- This text and anything on lines wrapped like this one will not show up in the final text. This text is to help us and you. -->

## Description
<!--- Describe your changes in detail -->
Flipped the `RGBLIGHT_ENABLE` flag for the idobo keyboard format to true
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Core
- [ ] Bugfix
- [ ] New Feature
- [ ] Enhancement/Optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation


## Issues Fixed or Closed by this PR

* 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
