### PR TITLE
Added VIA Configurator support to Snagpad

### DIFF
--- a/keyboards/snagpad/config.h
+++ b/keyboards/snagpad/config.h
@@ -3,8 +3,8 @@
 #include "config_common.h"
 
 /* USB Device descriptor parameter */
-#define VENDOR_ID       0xFEED
-#define PRODUCT_ID      0x6060
+#define VENDOR_ID       0x4443 // "DC" = Don Chiou
+#define PRODUCT_ID      0x5350 // "SP" = Snagpad
 #define DEVICE_VER      0x0001
 #define MANUFACTURER    Flehrad
 #define PRODUCT         Snagpad
@@ -54,3 +54,25 @@
 #define RGBLIGHT_VAL_STEP 8
 #endif
 
+// Does not use WT_MONO_BACKLIGHT
+// #define WT_MONO_BACKLIGHT
+
+#define DYNAMIC_KEYMAP_LAYER_COUNT 4
+
+// EEPROM usage
+
+// TODO: refactor with new user EEPROM code (coming soon)
+#define EEPROM_MAGIC 0x451F
+#define EEPROM_MAGIC_ADDR 32
+// Bump this every time we change what we store
+// This will automatically reset the EEPROM with defaults
+// and avoid loading invalid data from the EEPROM
+#define EEPROM_VERSION 0x08
+#define EEPROM_VERSION_ADDR 34
+
+// Dynamic keymap starts after EEPROM version
+#define DYNAMIC_KEYMAP_EEPROM_ADDR 35
+// Dynamic macro starts after dynamic keymaps (35+(4*5*4*2)) = (35+160)
+#define DYNAMIC_KEYMAP_MACRO_EEPROM_ADDR 195
+#define DYNAMIC_KEYMAP_MACRO_EEPROM_SIZE 829
+#define DYNAMIC_KEYMAP_MACRO_COUNT 16

--- a/keyboards/snagpad/keymaps/via/keymap.c
+++ b/keyboards/snagpad/keymaps/via/keymap.c
@@ -1,0 +1,76 @@
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+	LAYOUT_ortho_5x4(
+		KC_NLCK, KC_PSLS, KC_PAST, KC_PMNS,
+		KC_P7,   KC_P8,   KC_P9,   KC_PPLS,
+		KC_P4,   KC_P5,   KC_P6,   KC_PPLS,
+		KC_P1,   KC_P2,   KC_P3,   KC_PENT,
+		KC_P0,   KC_P0,   KC_PDOT, KC_PENT),
+
+	LAYOUT_ortho_5x4(
+		KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+		KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+		KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+		KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+		KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS),
+
+	LAYOUT_ortho_5x4(
+		KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+		KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+		KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+		KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+		KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS),
+
+	LAYOUT_ortho_5x4(
+		KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+		KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+		KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+		KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+		KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS)
+};
+
+
+void matrix_init_user(void) {
+}
+
+void matrix_scan_user(void) {
+}
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+	return true;
+}
+
+void led_set_user(uint8_t usb_led) {
+
+	if (usb_led & (1 << USB_LED_NUM_LOCK)) {
+		
+	} else {
+		
+	}
+
+	if (usb_led & (1 << USB_LED_CAPS_LOCK)) {
+		
+	} else {
+		
+	}
+
+	if (usb_led & (1 << USB_LED_SCROLL_LOCK)) {
+		
+	} else {
+		
+	}
+
+	if (usb_led & (1 << USB_LED_COMPOSE)) {
+		
+	} else {
+		
+	}
+
+	if (usb_led & (1 << USB_LED_KANA)) {
+		
+	} else {
+		
+	}
+
+}

--- a/keyboards/snagpad/keymaps/via/rules.mk
+++ b/keyboards/snagpad/keymaps/via/rules.mk
@@ -1,0 +1,76 @@
+# MCU name
+MCU = atmega32u4
+
+# Processor frequency.
+#     This will define a symbol, F_CPU, in all source code files equal to the
+#     processor frequency in Hz. You can then use this symbol in your source code to
+#     calculate timings. Do NOT tack on a 'UL' at the end, this will be done
+#     automatically to create a 32-bit value in your source code.
+#
+#     This will be an integer division of F_USB below, as it is sourced by
+#     F_USB after it has run through any CPU prescalers. Note that this value
+#     does not *change* the processor frequency - it should merely be updated to
+#     reflect the processor speed set externally so that the code can use accurate
+#     software delays.
+F_CPU = 16000000
+
+#
+# LUFA specific
+#
+# Target architecture (see library "Board Types" documentation).
+ARCH = AVR8
+
+# Input clock frequency.
+#     This will define a symbol, F_USB, in all source code files equal to the
+#     input clock frequency (before any prescaling is performed) in Hz. This value may
+#     differ from F_CPU if prescaling is used on the latter, and is required as the
+#     raw input clock is fed directly to the PLL sections of the AVR for high speed
+#     clock generation for the USB and other AVR subsections. Do NOT tack on a 'UL'
+#     at the end, this will be done automatically to create a 32-bit value in your
+#     source code.
+#
+#     If no clock division is performed on the input clock inside the AVR (via the
+#     CPU clock adjust registers or the clock division fuses), this will be equal to F_CPU.
+F_USB = $(F_CPU)
+
+# Interrupt driven control endpoint task(+60)
+OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
+
+# Bootloader selection
+#   Teensy       halfkay
+#   Pro Micro    caterina
+#   Atmel DFU    atmel-dfu
+#   LUFA DFU     lufa-dfu
+#   QMK DFU      qmk-dfu
+#   atmega32a    bootloadHID
+BOOTLOADER = caterina
+
+# Boot Section Size in *bytes*
+# OPT_DEFS += -DBOOTLOADER_SIZE=4096
+
+
+# Build Options
+#   change yes to no to disable
+#
+BOOTMAGIC_ENABLE = no      # Virtual DIP switch configuration(+1000)
+MOUSEKEY_ENABLE = no       # Mouse keys(+4700)
+EXTRAKEY_ENABLE = yes       # Audio control and System control(+450)
+CONSOLE_ENABLE = no        # Console for debug(+400)
+COMMAND_ENABLE = no        # Commands for debug and configuration
+# Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
+SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
+# if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+NKRO_ENABLE = yes            # USB Nkey Rollover
+BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality on B7 by default
+MIDI_ENABLE = no            # MIDI support (+2400 to 4200, depending on config)
+UNICODE_ENABLE = no         # Unicode
+BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
+AUDIO_ENABLE = no           # Audio output on port C6
+FAUXCLICKY_ENABLE = no      # Use buzzer to emulate clicky switches
+
+# This is the VIA magic
+RAW_ENABLE = yes
+DYNAMIC_KEYMAP_ENABLE = yes
+SRC += keyboards/wilba_tech/wt_main.c
+
+LAYOUTS = ortho_5x4 numpad_5x4


### PR DESCRIPTION
Added VIA Configurator support to Snagpad.

Approved by @flehrad 

Also demonstrates using a keymap directory called `via` to build a VIA compatible firmware, yet leaving the `default` and other keymap directories as-is, without the VIA magic (raw HID protocol, dynamic keymaps).

Tested on real hardware.

## Types of changes
- [ ] Core
- [ ] Bugfix
- [ ] New Feature
- [ ] Enhancement/Optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation
