### PR TITLE
Add Post Processing to process_record

### DIFF
--- a/docs/feature_macros.md
+++ b/docs/feature_macros.md
@@ -88,6 +88,46 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 };
 ```
 
+### Advanced Macros
+
+In addition to the `process_record_user()` function, is the `post_process_record_user()` function. This runs after `process_record` and can be used to do things after a keystroke has been sent.  This is useful if you want to have a key pressed before and released after a normal key, for instance. 
+
+In this example, we modify most normal keypresses so that `F22` is pressed before the keystroke is normally sent, and release it __only after__ it's been released.
+
+```c
+static uint8_t f22_tracker;
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  switch (keycode) {
+    case KC_A ... KC_F21: //notice how it skips over F22
+    case KC_F23 ... KC_EXSEL: //exsel is the last one before the modifier keys
+      if (record->event.pressed) {
+        register_code(KC_F22); //this means to send F22 down
+        f22_tracker++;
+        register_code(keycode);
+        return false;
+      }
+      break;
+  }
+  return true;
+}
+
+void post_process_record_user(uint16_t keycode, keyrecord_t *record) {
+  switch (keycode) {
+    case KC_A ... KC_F21: //notice how it skips over F22
+    case KC_F23 ... KC_EXSEL: //exsel is the last one before the modifier keys
+      if (!record->event.pressed) {
+        f22_tracker--;
+        if (!f22_tracker) {
+            unregister_code(KC_F22); //this means to send F22 up
+        }
+      }
+      break;
+  }
+}
+```
+
+
 ### TAP, DOWN and UP
 
 You may want to use keys in your macros that you can't write down, such as `Ctrl` or `Home`.

--- a/docs/understanding_qmk.md
+++ b/docs/understanding_qmk.md
@@ -162,6 +162,15 @@ The `process_record()` function itself is deceptively simple, but hidden within 
 
 At any step during this chain of events a function (such as `process_record_kb()`) can `return false` to halt all further processing.
 
+After this is called, `post_process_record()` is called, which can be used to handle additional cleanup that needs to be run after the keycode is normally handled. 
+
+* [`void post_process_record(keyrecord_t *record)`]()
+  * [`void post_process_record_quantum(keyrecord_t *record)`]()
+    * [Map this record to a keycode]()
+    * [`void post_process_clicky(uint16_t keycode, keyrecord_t *record)`]()
+    * [`void post_process_record_kb(uint16_t keycode, keyrecord_t *record)`]()
+      * [`void post_process_record_user(uint16_t keycode, keyrecord_t *record)`]()
+      
 <!--
 #### Mouse Handling
 

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -122,7 +122,7 @@ __attribute__((weak)) bool process_record_user(uint16_t keycode, keyrecord_t *re
 
 __attribute__ ((weak))
 void post_process_record_kb(uint16_t keycode, keyrecord_t *record) {
-  process_record_user(keycode, record);
+  post_process_record_user(keycode, record);
 }
 
 __attribute__ ((weak))

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -180,11 +180,15 @@ uint16_t get_event_keycode(keyevent_t event) {
         return keymap_key_to_keycode(layer_switch_get_layer(event.key), event.key);
 }
 
+/* Get keycode, and then call keyboard function */
 void post_process_record_quantum(keyrecord_t *record) {
   uint16_t keycode = get_record_keycode(record);
   post_process_record_kb(keycode, record);
 }
 
+/* Core keycode function, hands off handling to other functions,
+    then processes internal quantum keycodes, and then processes
+    ACTIONs.                                                      */
 bool process_record_quantum(keyrecord_t *record) {
     uint16_t keycode = get_record_keycode(record);
 

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -747,7 +747,6 @@ __attribute__((weak)) uint16_t hex_to_keycode(uint8_t hex) {
     } else {
         return KC_A + (hex - 0xA);
     }
-=======
 }
 
 void api_send_unicode(uint32_t unicode) {

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -747,6 +747,7 @@ __attribute__((weak)) uint16_t hex_to_keycode(uint8_t hex) {
     } else {
         return KC_A + (hex - 0xA);
     }
+=======
 }
 
 void api_send_unicode(uint32_t unicode) {

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -120,6 +120,14 @@ __attribute__((weak)) bool process_record_kb(uint16_t keycode, keyrecord_t *reco
 
 __attribute__((weak)) bool process_record_user(uint16_t keycode, keyrecord_t *record) { return true; }
 
+__attribute__ ((weak))
+void post_process_record_kb(uint16_t keycode, keyrecord_t *record) {
+  process_record_user(keycode, record);
+}
+
+__attribute__ ((weak))
+void post_process_record_user(uint16_t keycode, keyrecord_t *record) {}
+
 void reset_keyboard(void) {
     clear_keyboard();
 #if defined(MIDI_ENABLE) && defined(MIDI_BASIC)
@@ -172,9 +180,11 @@ uint16_t get_event_keycode(keyevent_t event) {
         return keymap_key_to_keycode(layer_switch_get_layer(event.key), event.key);
 }
 
-/* Main keycode processing function. Hands off handling to other functions,
- * then processes internal Quantum keycodes, then processes ACTIONs.
- */
+void post_process_record_quantum(keyrecord_t *record) {
+  uint16_t keycode = get_record_keycode(record);
+  post_process_record_kb(keycode, record);
+}
+
 bool process_record_quantum(keyrecord_t *record) {
     uint16_t keycode = get_record_keycode(record);
 

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -253,6 +253,8 @@ uint16_t get_event_keycode(keyevent_t event);
 bool     process_action_kb(keyrecord_t *record);
 bool     process_record_kb(uint16_t keycode, keyrecord_t *record);
 bool     process_record_user(uint16_t keycode, keyrecord_t *record);
+void     post_process_record_kb(uint16_t keycode, keyrecord_t *record);
+void     post_process_record_user(uint16_t keycode, keyrecord_t *record);
 
 #ifndef BOOTMAGIC_LITE_COLUMN
 #    define BOOTMAGIC_LITE_COLUMN 0

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -152,7 +152,7 @@ void process_record_nocache(keyrecord_t *record) { process_record(record); }
 __attribute__((weak)) bool process_record_quantum(keyrecord_t *record) { return true; }
 
 __attribute__ ((weak))
-void process_record_after(keyrecord_t *record) {
+void post_process_record_quantum(keyrecord_t *record) {
 }
 
 #ifndef NO_ACTION_TAPPING
@@ -187,11 +187,11 @@ void process_record(keyrecord_t *record) {
 
     if (!process_record_quantum(record)) return;
 
-    process_record_system(record);
-    process_record_after(record);
+    process_record_handler(record);
+    post_process_record_quantum(record);
 }
 
-void process_record_system(keyrecord_t *record) {
+void process_record_handler(keyrecord_t *record) {
     action_t action = store_or_get_action(record->event.pressed, record->event.key);
     dprint("ACTION: ");
     debug_action(action);

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -151,9 +151,7 @@ void process_record_nocache(keyrecord_t *record) { process_record(record); }
 
 __attribute__((weak)) bool process_record_quantum(keyrecord_t *record) { return true; }
 
-__attribute__ ((weak))
-void post_process_record_quantum(keyrecord_t *record) {
-}
+__attribute__((weak)) void post_process_record_quantum(keyrecord_t *record) {}
 
 #ifndef NO_ACTION_TAPPING
 /** \brief Allows for handling tap-hold actions immediately instead of waiting for TAPPING_TERM or another keypress.
@@ -183,7 +181,9 @@ void process_record_tap_hint(keyrecord_t *record) {
  * FIXME: Needs documentation.
  */
 void process_record(keyrecord_t *record) {
-    if (IS_NOEVENT(record->event)) { return; }
+    if (IS_NOEVENT(record->event)) {
+        return;
+    }
 
     if (!process_record_quantum(record)) return;
 
@@ -933,12 +933,12 @@ void clear_keyboard_but_mods_and_keys() {
     clear_macro_mods();
     send_keyboard_report();
 #ifdef MOUSEKEY_ENABLE
-  mousekey_clear();
-  mousekey_send();
+    mousekey_clear();
+    mousekey_send();
 #endif
 #ifdef EXTRAKEY_ENABLE
-  host_system_send(0);
-  host_consumer_send(0);
+    host_system_send(0);
+    host_consumer_send(0);
 #endif
 }
 
@@ -997,7 +997,7 @@ void debug_event(keyevent_t event) { dprintf("%04X%c(%u)", (event.key.row << 8 |
 void debug_record(keyrecord_t record) {
     debug_event(record.event);
 #ifndef NO_ACTION_TAPPING
-  dprintf(":%u%c", record.tap.count, (record.tap.interrupted ? '-' : ' '));
+    dprintf(":%u%c", record.tap.count, (record.tap.interrupted ? '-' : ' '));
 #endif
 }
 

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -151,6 +151,10 @@ void process_record_nocache(keyrecord_t *record) { process_record(record); }
 
 __attribute__((weak)) bool process_record_quantum(keyrecord_t *record) { return true; }
 
+__attribute__ ((weak))
+void process_record_after(keyrecord_t *record) {
+}
+
 #ifndef NO_ACTION_TAPPING
 /** \brief Allows for handling tap-hold actions immediately instead of waiting for TAPPING_TERM or another keypress.
  *
@@ -179,12 +183,15 @@ void process_record_tap_hint(keyrecord_t *record) {
  * FIXME: Needs documentation.
  */
 void process_record(keyrecord_t *record) {
-    if (IS_NOEVENT(record->event)) {
-        return;
-    }
+    if (IS_NOEVENT(record->event)) { return; }
 
     if (!process_record_quantum(record)) return;
 
+    process_record_system(record);
+    process_record_after(record);
+}
+
+void process_record_system(keyrecord_t *record) {
     action_t action = store_or_get_action(record->event.pressed, record->event.key);
     dprint("ACTION: ");
     debug_action(action);
@@ -926,12 +933,12 @@ void clear_keyboard_but_mods_and_keys() {
     clear_macro_mods();
     send_keyboard_report();
 #ifdef MOUSEKEY_ENABLE
-    mousekey_clear();
-    mousekey_send();
+  mousekey_clear();
+  mousekey_send();
 #endif
 #ifdef EXTRAKEY_ENABLE
-    host_system_send(0);
-    host_consumer_send(0);
+  host_system_send(0);
+  host_consumer_send(0);
 #endif
 }
 
@@ -983,7 +990,6 @@ bool is_tap_action(action_t action) {
  * FIXME: Needs documentation.
  */
 void debug_event(keyevent_t event) { dprintf("%04X%c(%u)", (event.key.row << 8 | event.key.col), (event.pressed ? 'd' : 'u'), event.time); }
-
 /** \brief Debug print (FIXME: Needs better description)
  *
  * FIXME: Needs documentation.
@@ -991,7 +997,7 @@ void debug_event(keyevent_t event) { dprintf("%04X%c(%u)", (event.key.row << 8 |
 void debug_record(keyrecord_t record) {
     debug_event(record.event);
 #ifndef NO_ACTION_TAPPING
-    dprintf(":%u%c", record.tap.count, (record.tap.interrupted ? '-' : ' '));
+  dprintf(":%u%c", record.tap.count, (record.tap.interrupted ? '-' : ' '));
 #endif
 }
 

--- a/tmk_core/common/action.h
+++ b/tmk_core/common/action.h
@@ -84,6 +84,8 @@ void process_hand_swap(keyevent_t *record);
 
 void process_record_nocache(keyrecord_t *record);
 void process_record(keyrecord_t *record);
+void process_record_system(keyrecord_t *record);
+void process_record_after(keyrecord_t *record);
 void process_action(keyrecord_t *record, action_t action);
 void register_code(uint8_t code);
 void unregister_code(uint8_t code);

--- a/tmk_core/common/action.h
+++ b/tmk_core/common/action.h
@@ -84,8 +84,8 @@ void process_hand_swap(keyevent_t *record);
 
 void process_record_nocache(keyrecord_t *record);
 void process_record(keyrecord_t *record);
-void process_record_system(keyrecord_t *record);
-void process_record_after(keyrecord_t *record);
+void process_record_handler(keyrecord_t *record);
+void post_process_record_quantum(keyrecord_t *record);
 void process_action(keyrecord_t *record, action_t action);
 void register_code(uint8_t code);
 void unregister_code(uint8_t code);


### PR DESCRIPTION
## Description
This adds `post_process_record_*` in addition to `process_record_*`, so that you can run cleanup/handling AFTER a keystroke has been sent. 

This code was developed by @colinta, and pursued by myself after conversations on Discord.

This also moves the "report to keycode" code to a separate function, that can be called elsewhere, since it is being used by both `process_record_quantum()` and `post_process_record_quantum()` now. (`get_record_keycode` and `get_event_keycode`)

Also, I updated the formatting of the touched files to follow the Contributing documentation. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Core
- [ ] Bugfix
- [X] New Feature
- [X] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [X] Documentation


## Issues Fixed or Closed by this PR

* fixes #2098

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
