### PR TITLE
Tidy up IS_{,HOST_}LED_{ON,OFF} macros

### DIFF
--- a/docs/custom_quantum_functions.md
+++ b/docs/custom_quantum_functions.md
@@ -106,8 +106,7 @@ There are two ways to get the host LED state:
 
 ## `led_set_user()`
 
-This function will be called when the state of one of those 5 LEDs changes.
-It receives the LED state as parameter.
+This function will be called when the state of one of those 5 LEDs changes. It receives the LED state as a parameter.
 Use the `IS_LED_ON(usb_led, led_name)` and `IS_LED_OFF(usb_led, led_name)` macros to check the LED status.
 
 !> `host_keyboard_leds()` may already reflect a new value before `led_set_user()` is called.
@@ -151,27 +150,20 @@ void led_set_user(uint8_t usb_led) {
 
 ## `host_keyboard_leds()`
 
-Call this function to get the last received LED state.
-This is useful for reading the LED state outside `led_set_*`, e.g. in [`matrix_scan_user()`](#matrix-scanning-code).
-
+Call this function to get the last received LED state. This is useful for reading the LED state outside `led_set_*`, e.g. in [`matrix_scan_user()`](#matrix-scanning-code).
 For convenience, you can use the `IS_HOST_LED_ON(led_name)` and `IS_HOST_LED_OFF(led_name)` macros instead of calling and checking `host_keyboard_leds()` directly.
 
-## Setting physical LED state
+## Setting Physical LED State
 
 Some keyboard implementations provide convenience methods for setting the state of the physical LEDs.
 
-### Ergodox and Ergodox EZ
+### Ergodox Boards
 
-The Ergodox EZ implementation provides `ergodox_right_led_``1`/`2`/`3_on`/`off()`
-to turn individual LEDs on and off, as well as
-`ergodox_right_led_on`/`off(uint8_t led)`
-to turn them on and off by their number.
+The Ergodox implementations provide `ergodox_right_led_1`/`2`/`3_on`/`off()` to turn individual LEDs on or off, as well as `ergodox_right_led_on`/`off(uint8_t led)` to turn them on or off by their index.
 
-In addition, it is possible to specify the brightness level with `ergodox_led_all_set(uint8_t n)`,
-for individual LEDs with `ergodox_right_led_1`/`2`/`3_set(uint8_t n)`
-or by their number using `ergodox_right_led_set(uint8_t led, uint8_t n)`.
+In addition, it is possible to specify the brightness level of all LEDs with `ergodox_led_all_set(uint8_t n)`; of individual LEDs with `ergodox_right_led_1`/`2`/`3_set(uint8_t n)`; or by index with `ergodox_right_led_set(uint8_t led, uint8_t n)`.
 
-It defines `LED_BRIGHTNESS_LO` for the lowest brightness and `LED_BRIGHTNESS_HI` for the highest brightness, which is also the default.
+Ergodox boards also define `LED_BRIGHTNESS_LO` for the lowest brightness and `LED_BRIGHTNESS_HI` for the highest brightness (which is the default).
 
 # Matrix Initialization Code
 

--- a/docs/custom_quantum_functions.md
+++ b/docs/custom_quantum_functions.md
@@ -108,8 +108,7 @@ There are two ways to get the host LED state:
 
 This function will be called when the state of one of those 5 LEDs changes.
 It receives the LED state as parameter.
-Use the `IS_LED_ON(USB_LED, LED_NAME)` and `IS_LED_OFF(USB_LED, LED_NAME)`
-macros to check the LED status.
+Use the `IS_LED_ON(usb_led, led_name)` and `IS_LED_OFF(usb_led, led_name)` macros to check the LED status.
 
 !> `host_keyboard_leds()` may already reflect a new value before `led_set_user()` is called.
 
@@ -155,7 +154,7 @@ void led_set_user(uint8_t usb_led) {
 Call this function to get the last received LED state.
 This is useful for reading the LED state outside `led_set_*`, e.g. in [`matrix_scan_user()`](#matrix-scanning-code).
 
-For convenience, you can use the `IS_HOST_LED_ON(LED_NAME)` and `IS_HOST_LED_OFF(LED_NAME)` macros instead of calling `host_keyboard_leds()` directly.
+For convenience, you can use the `IS_HOST_LED_ON(led_name)` and `IS_HOST_LED_OFF(led_name)` macros instead of calling and checking `host_keyboard_leds()` directly.
 
 ## Setting physical LED state
 

--- a/tmk_core/common/host.h
+++ b/tmk_core/common/host.h
@@ -15,14 +15,18 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef HOST_H
-#define HOST_H
+#pragma once
 
 #include <stdint.h>
 #include <stdbool.h>
 #include "report.h"
 #include "host_driver.h"
 
+#define IS_LED_ON(leds, led_name)   ( (leds) & (1 << (led_name)))
+#define IS_LED_OFF(leds, led_name)  (~(leds) & (1 << (led_name)))
+
+#define IS_HOST_LED_ON(led_name)    IS_LED_ON(host_keyboard_leds(), led_name)
+#define IS_HOST_LED_OFF(led_name)   IS_LED_OFF(host_keyboard_leds(), led_name)
 
 #ifdef __cplusplus
 extern "C" {
@@ -30,7 +34,6 @@ extern "C" {
 
 extern uint8_t keyboard_idle;
 extern uint8_t keyboard_protocol;
-
 
 /* host driver */
 void host_set_driver(host_driver_t *driver);
@@ -46,14 +49,6 @@ void host_consumer_send(uint16_t data);
 uint16_t host_last_system_report(void);
 uint16_t host_last_consumer_report(void);
 
-#define IS_LED_ON(USB_LED, LED_NAME)    ((USB_LED) & (1 << (LED_NAME)))
-#define IS_LED_OFF(USB_LED, LED_NAME)   (~(USB_LED) & (1 << (LED_NAME)))
-
-#define IS_HOST_LED_ON(LED_NAME)     IS_LED_ON(host_keyboard_leds(), (LED_NAME))
-#define IS_HOST_LED_OFF(LED_NAME)    IS_LED_OFF(host_keyboard_leds(), (LED_NAME))
-
 #ifdef __cplusplus
 }
-#endif
-
 #endif


### PR DESCRIPTION
I missed this while #4853 was open. Move the LED macros out of the function declarations to the top of the file, and make the macro arguments lowercase. Also use `#pragma once` instead of traditional include guards.

Remove unnecessary newlines from LED docs added by the aforementioned PR, fix some Markdown syntax issues, and tweak the wording a bit.