### PR TITLE
Align docker and vagrant base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian
+FROM debian:9
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
     avr-libc \

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -55,7 +55,7 @@ Vagrant.configure(2) do |config|
   # image, you'll need to: chmod -R a+rw .
   config.vm.provider "docker" do |docker, override|
     override.vm.box = nil
-    docker.image = "jesselang/debian-vagrant:jessie"
+    docker.image = "jesselang/debian-vagrant:stretch"
     docker.has_ssh = true
   end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@ Vagrant.configure(2) do |config|
   config.vm.define "qmk_firmware"
 
   # VMware/Virtualbox ( and also Hyperv/Parallels) 64 bit
-  config.vm.box = "bento/ubuntu-16.04"
+  config.vm.box = "generic/debian9"
 
   # This section allows you to customize the Virtualbox VM
   # settings, ie showing the GUI or upping the memory


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- This template is entirely option and can be removed, but is here to help both you and us. -->
<!--- This text and anything on lines wrapped like this one will not show up in the final text. This text is to help us and you. -->

## Description
<!--- Describe your changes in detail -->
Just noticed docker is using Debian, while vagrant is using Ubuntu. Its easy enough to change either way, but to quote a reply from my question on discord, "Debian is the de facto standard for containers"

While I've only just updated to the "bento/ubuntu-16.04" box, the main aim was to use a box that was updated more frequently and both seem to be updated monthly. Given it was previously broken, now seems a good time to make this change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Core
- [ ] Bugfix
- [ ] New Feature
- [x] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
