### PR TITLE
Add a compile-time provided macro and assign to _FL

### DIFF
--- a/keyboards/tada68/keymaps/rys/keymap.c
+++ b/keyboards/tada68/keymaps/rys/keymap.c
@@ -5,6 +5,21 @@
 
 #define _______ KC_TRNS
 
+enum rys_keycodes {
+  PSTOKEN = SAFE_RANGE,
+};
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  switch (keycode) {
+    case PSTOKEN:
+      if (record->event.pressed) {
+        SEND_STRING(RYS_PSTOKEN);
+      }
+      break;
+  }
+  return true;
+};
+
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   /* Keymap _BL: (Base Layer) Default Layer
    * ,----------------------------------------------------------------.
@@ -16,7 +31,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    * |----------------------------------------------------------------|
    * |Shift|  \ |  Z|  X|  C|  V|  B|  N|  M|  ,|  .| /|Rshift|Up|PgDn|
    * |----------------------------------------------------------------|
-   * |Ctrl|Win |Alt |        Space          |Alt| FN|Ctrl|Lef|Dow|Rig |
+   * |Ctrl|Alt |LGUI|        Space          |Alt| FN|Ctrl|Lef|Dow|Rig |
    * `----------------------------------------------------------------'
    */
   [_BL] = LAYOUT_iso(
@@ -29,22 +44,22 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
   /* Keymap _FL1: Function Layer 1
    * ,----------------------------------------------------------------.
-   * |   | F1| F2| F3| F4| F5| F6| F7| F8| F9|F10|F11|F12| Delete| Ins|
+   * |   | F1| F2| F3| F4| F5| F6| F7| F8| F9|F10|F11|F12|       | :D |
    * |----------------------------------------------------------------|
-   * |     |   | ↑ |   |   |   |   |   |   |   |   |   |   |     |Home|
+   * |     |LMB| Up|RMB|   |   |   |   |   |   |   |   |   |     |    |
    * |-------------------------------------------------------    -----|
-   * |       | ← | ↓ | → |   |   |   |   |   |   |   |  |   |    | End|
+   * |       |Lef|Dow|Rig|   |   |   |   |   |   |   |  |   |    |Home|
    * |----------------------------------------------------------------|
-   * |     |   |   |   | L+|LED| L-|   | V+|  V-|Mut|  | MsBtn|Up|MsBn|
+   * |     |   |   |   | L+|LED| L-|   | V+|  V-|Mut|  | MsBtn|↑ | End|
    * |----------------------------------------------------------------|
-   * |    |    |    |                       |   |   |    | Lt| Dn| Rt |
+   * |    |    |    |      Reset            |   |   |    | ← | ↓ | →  |
    * `----------------------------------------------------------------'
    */
   [_FL] = LAYOUT_iso(
-    _______, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  _______, _______, \
+    _______, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  _______, PSTOKEN, \
     _______, KC_BTN1, KC_UP,   KC_BTN2, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, \
     _______, KC_LEFT, KC_DOWN, KC_RGHT, _______, _______, _______, _______, _______, _______, _______, _______,          _______, KC_HOME, \
     _______, _______, _______, _______, BL_DEC,  BL_TOGG, BL_INC,  _______, KC_VOLU, KC_VOLD, KC_MUTE, _______, _______, KC_MS_U, KC_END,  \
-    _______, _______, _______,                   _______,                            _______, _______, _______, KC_MS_L, KC_MS_D, KC_MS_R
+    _______, _______, _______,                   RESET,                              _______, _______, _______, KC_MS_L, KC_MS_D, KC_MS_R
 	),
 };

--- a/keyboards/tada68/keymaps/rys/readme.md
+++ b/keyboards/tada68/keymaps/rys/readme.md
@@ -11,5 +11,5 @@ Please see the [Tada68 readme](../../readme.md). Make the firmware wih the
 following command:
 
 ```
-make tada68:rys:bin
+make tada68:rys:flashbin
 ```

--- a/keyboards/tada68/keymaps/rys/rules.mk
+++ b/keyboards/tada68/keymaps/rys/rules.mk
@@ -15,3 +15,6 @@ UNICODE_ENABLE = no         # Unicode
 BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
 RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight. 
 SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
+
+RYS_PSTOKEN = $(shell security find-generic-password -a qmk -s tada68 -w)
+CFLAGS += -DRYS_PSTOKEN=\"$(RYS_PSTOKEN)\"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Emit a compile time provided `SEND_STRING()` macro on a new keycode, and assign it to `_FL`
<!--- This template is entirely option and can be removed, but is here to help both you and us. -->
<!--- This text and anything on lines wrapped like this one will not show up in the final text. This text is to help us and you. -->

## Description
<!--- Describe your changes in detail -->
Define a new keycode (`PSTOKEN`) and assign it to a key in the `_FL` layer. Assign `RESET` to `_FL` at the same time.

The associated `SEND_STRING()` macro emits a compile time defined string that we populate in `rules.mk`. This _only_ works on macOS, since it shells out to the macOS `security` utility, which securely fetches a string from the specified service name and account.

That avoids storing the string in the source code or in the clear anywhere on the filesystem. It also avoids changing any of QMK's makefiles, keeping the change local to my keymap. Since the keymap is macOS-specific due to left of spacebar key swaps, I figure the makefile changes being a bit macOS specific is OK.

I plan to document the change, including how to interact with the `security` utility on macOS, on my blog. I would wrap the `rules.mk` changes in macOS-specific ifdefs, but I don't think the QMK makefile system defines any I can easily check against.

I also updated the layout README with the correct make invocation, and the layout comments in keymap.c while I was at it, to tidy up a bit.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Core
- [ ] Bugfix
- [ ] New Feature
- [ ] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation


## Issues Fixed or Closed by this PR

None.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
