### PR TITLE
Port VIA Support over to core feature

### DIFF
--- a/build_keyboard.mk
+++ b/build_keyboard.mk
@@ -142,6 +142,9 @@ ifdef MCU_FAMILY
     KEYBOARD_PATHS += $(STM32_PATH)
 endif
 
+ifeq ($(strip $(VIA)), true)
+  TARGET := $(TARGET)_via
+endif
 
 # Find all the C source files to be compiled in subfolders.
 KEYBOARD_SRC :=

--- a/common_features.mk
+++ b/common_features.mk
@@ -28,10 +28,6 @@ ifeq ($(strip $(API_SYSEX_ENABLE)), yes)
     MIDI_ENABLE=yes
 endif
 
-ifeq ($(strip $(VIA)), true)
-  DYNAMIC_KEYMAP_ENABLE=yes
-endif
-
 MUSIC_ENABLE := 0
 
 ifeq ($(strip $(AUDIO_ENABLE)), yes)
@@ -239,6 +235,12 @@ endif
 ifeq ($(strip $(HD44780_ENABLE)), yes)
     SRC += drivers/avr/hd44780.c
     OPT_DEFS += -DHD44780_ENABLE
+endif
+
+ifeq ($(strip $(VIA_SUPPORT_ENABLE)), yes)
+  OPT_DEFS += -DVIA_SUPPORT_ENABLE
+  SRC += $(QUANTUM_DIR)/via_support.c
+  DYNAMIC_KEYMAP_ENABLE=yes
 endif
 
 ifeq ($(strip $(DYNAMIC_KEYMAP_ENABLE)), yes)

--- a/common_features.mk
+++ b/common_features.mk
@@ -28,6 +28,10 @@ ifeq ($(strip $(API_SYSEX_ENABLE)), yes)
     MIDI_ENABLE=yes
 endif
 
+ifeq ($(strip $(VIA)), true)
+  DYNAMIC_KEYMAP_ENABLE=yes
+endif
+
 MUSIC_ENABLE := 0
 
 ifeq ($(strip $(AUDIO_ENABLE)), yes)

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -246,6 +246,9 @@ bool process_record_quantum(keyrecord_t *record) {
     process_clicky(keycode, record) &&
   #endif //AUDIO_CLICKY
     process_record_kb(keycode, record) &&
+  #ifdef VIA_SUPPORT_ENABLE
+    process_via(keycode, record) &&
+  #endif
   #if defined(RGB_MATRIX_ENABLE) && defined(RGB_MATRIX_KEYPRESSES)
     process_rgb_matrix(keycode, record) &&
   #endif
@@ -1006,6 +1009,9 @@ void matrix_init_quantum() {
   #endif
   #if defined(UNICODE_ENABLE) || defined(UNICODEMAP_ENABLE) || defined(UCIS_ENABLE)
     unicode_input_mode_init();
+  #endif
+  #ifdef VIA_SUPPORT_ENABLE
+    via_init();
   #endif
   matrix_init_kb();
 }

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -138,6 +138,10 @@ extern uint32_t default_layer_state;
     #include "hd44780.h"
 #endif
 
+#ifdef VIA_SUPPORT_ENABLE
+  #include "via_support.h"
+#endif
+
 //Function substitutions to ease GPIO manipulation
 #ifdef __AVR__
     #define PIN_ADDRESS(p, offset) _SFR_IO8(ADDRESS_BASE + (p >> PORT_SHIFTER) + offset)

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -462,6 +462,23 @@ enum quantum_keycodes {
     UNICODE_MODE_BSD,
     UNICODE_MODE_WINC,
 
+    VIA_MACRO00,
+    VIA_MACRO01,
+    VIA_MACRO02,
+    VIA_MACRO03,
+    VIA_MACRO04,
+    VIA_MACRO05,
+    VIA_MACRO06,
+    VIA_MACRO07,
+    VIA_MACRO08,
+    VIA_MACRO09,
+    VIA_MACRO10,
+    VIA_MACRO11,
+    VIA_MACRO12,
+    VIA_MACRO13,
+    VIA_MACRO14,
+    VIA_MACRO15,
+
     // always leave at the end
     SAFE_RANGE
 };

--- a/quantum/via_support.c
+++ b/quantum/via_support.c
@@ -1,0 +1,158 @@
+/* Copyright 2018 Jason Williams (Wilba)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "quantum.h"
+#include "via_support.h"
+
+
+#ifdef RAW_ENABLE
+void raw_hid_receive( uint8_t *data, uint8_t length ) {
+	uint8_t *command_id = &(data[0]);
+	uint8_t *command_data = &(data[1]);
+	switch ( *command_id ) {
+		case id_get_protocol_version:
+			command_data[0] = PROTOCOL_VERSION >> 8;
+			command_data[1] = PROTOCOL_VERSION & 0xFF;
+			break;
+		case id_get_keyboard_value:
+			if ( command_data[0] == id_uptime ) {
+				uint32_t value = timer_read32();
+				command_data[1] = (value >> 24 ) & 0xFF;
+				command_data[2] = (value >> 16 ) & 0xFF;
+				command_data[3] = (value >> 8 ) & 0xFF;
+				command_data[4] = value & 0xFF;
+			} else {
+				*command_id = id_unhandled;
+			}
+			break;
+#ifdef DYNAMIC_KEYMAP_ENABLE
+		case id_dynamic_keymap_get_keycode:
+      {
+        uint16_t keycode = dynamic_keymap_get_keycode( command_data[0], command_data[1], command_data[2] );
+        command_data[3] = keycode >> 8;
+        command_data[4] = keycode & 0xFF;
+        break;
+      }
+		case id_dynamic_keymap_set_keycode:
+			dynamic_keymap_set_keycode( command_data[0], command_data[1], command_data[2], ( command_data[3] << 8 ) | command_data[4] );
+			break;
+		case id_dynamic_keymap_reset:
+			dynamic_keymap_reset();
+			break;
+		case id_dynamic_keymap_macro_get_count:
+			command_data[0] = dynamic_keymap_macro_get_count();
+			break;
+		case id_dynamic_keymap_macro_get_buffer_size:
+			{
+        uint16_t size = dynamic_keymap_macro_get_buffer_size();
+        command_data[0] = size >> 8;
+        command_data[1] = size & 0xFF;
+        break;
+      }
+		case id_dynamic_keymap_macro_get_buffer:
+      {
+        uint16_t offset = ( command_data[0] << 8 ) | command_data[1];
+        uint16_t size = command_data[2]; // size <= 28
+        dynamic_keymap_macro_get_buffer( offset, size, &command_data[3] );
+        break;
+      }
+		case id_dynamic_keymap_macro_set_buffer:
+      {
+        uint16_t offset = ( command_data[0] << 8 ) | command_data[1];
+        uint16_t size = command_data[2]; // size <= 28
+        dynamic_keymap_macro_set_buffer( offset, size, &command_data[3] );
+        break;
+      }
+		case id_dynamic_keymap_macro_reset:
+			dynamic_keymap_macro_reset();
+			break;
+		case id_dynamic_keymap_get_layer_count:
+			command_data[0] = dynamic_keymap_get_layer_count();
+			break;
+		case id_dynamic_keymap_get_buffer:
+      {
+        uint16_t offset = ( command_data[0] << 8 ) | command_data[1];
+        uint16_t size = command_data[2]; // size <= 28
+        dynamic_keymap_get_buffer( offset, size, &command_data[3] );
+        break;
+      }
+		case id_dynamic_keymap_set_buffer:
+      {
+        uint16_t offset = ( command_data[0] << 8 ) | command_data[1];
+        uint16_t size = command_data[2]; // size <= 28
+        dynamic_keymap_set_buffer( offset, size, &command_data[3] );
+        break;
+      }
+#endif // DYNAMIC_KEYMAP_ENABLE
+		case id_eeprom_reset:
+			eeprom_reset();
+			break;
+		case id_bootloader_jump:
+			// Need to send data back before the jump
+			// Informs host that the command is handled
+			raw_hid_send( data, length );
+			// Give host time to read it
+			wait_ms(100);
+			bootloader_jump();
+			break;
+		default:
+			// Unhandled message.
+			*command_id = id_unhandled;
+			break;
+	}
+
+	// Return same buffer with values changed
+	raw_hid_send( data, length );
+
+}
+#endif // RAW_ENABLE
+
+void via_init(void) {
+	// If the EEPROM has the magic, the data is good.
+	// OK to load from EEPROM.
+	if (eeprom_is_valid()) {
+		//backlight_config_load();
+	} else {
+		// If the EEPROM has not been saved before, or is out of date,
+		// save the default values to the EEPROM. Default values
+		// come from construction of the zeal_backlight_config instance.
+		//backlight_config_save();
+#ifdef DYNAMIC_KEYMAP_ENABLE
+		// This resets the keymaps in EEPROM to what is in flash.
+		dynamic_keymap_reset();
+		// This resets the macros in EEPROM to nothing.
+		dynamic_keymap_macro_reset();
+#endif
+		// Save the magic number last, in case saving was interrupted
+		eeprom_set_valid(true);
+	}
+}
+
+bool process_via(uint16_t keycode, keyrecord_t *record) {
+
+#ifdef DYNAMIC_KEYMAP_ENABLE
+	// Handle macros
+	if (record->event.pressed) {
+		if ( keycode >= VIA_MACRO00 && keycode <= VIA_MACRO15 ) {
+			uint8_t id = keycode - VIA_MACRO00;
+			dynamic_keymap_macro_send(id);
+			return false;
+		}
+	}
+#endif //DYNAMIC_KEYMAP_ENABLE
+
+	return true;
+}

--- a/quantum/via_support.h
+++ b/quantum/via_support.h
@@ -8,10 +8,6 @@
 
 #define PROTOCOL_VERSION 0x0008
 
-#define DYNAMIC_KEYMAP_LAYER_COUNT 4
-
-
-
 enum via_command_id {
 	id_get_protocol_version = 0x01, // always 0x01
 	id_get_keyboard_value,

--- a/quantum/via_support.h
+++ b/quantum/via_support.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "raw_hid.h"
+#include "dynamic_keymap.h"
+#include "timer.h"
+#include "tmk_core/common/eeprom.h"
+
+
+#define PROTOCOL_VERSION 0x0008
+
+#define DYNAMIC_KEYMAP_LAYER_COUNT 4
+
+
+
+enum via_command_id {
+	id_get_protocol_version = 0x01, // always 0x01
+	id_get_keyboard_value,
+	id_set_keyboard_value,
+	id_dynamic_keymap_get_keycode,
+	id_dynamic_keymap_set_keycode,
+	id_dynamic_keymap_reset,
+	id_backlight_config_set_value,
+	id_backlight_config_get_value,
+	id_backlight_config_save,
+	id_eeprom_reset,
+	id_bootloader_jump,
+	id_dynamic_keymap_macro_get_count,
+	id_dynamic_keymap_macro_get_buffer_size,
+	id_dynamic_keymap_macro_get_buffer,
+	id_dynamic_keymap_macro_set_buffer,
+	id_dynamic_keymap_macro_reset,
+	id_dynamic_keymap_get_layer_count,
+	id_dynamic_keymap_get_buffer,
+	id_dynamic_keymap_set_buffer,
+	id_unhandled = 0xFF,
+};
+
+enum zeal60_keyboard_value_id {
+	id_uptime = 0x01
+};
+
+
+
+void via_init(void);
+bool process_via(uint16_t keycode, keyrecord_t *record);

--- a/tmk_core/common.mk
+++ b/tmk_core/common.mk
@@ -109,7 +109,7 @@ ifeq ($(strip $(EXTRAKEY_ENABLE)), yes)
     SHARED_EP_ENABLE = yes
 endif
 
-ifeq ($(strip $(VIA)), true)
+ifeq ($(strip $(VIA_SUPPORT_ENABLE)), yes)
   RAW_ENABLE=yes
 endif
 

--- a/tmk_core/common.mk
+++ b/tmk_core/common.mk
@@ -109,6 +109,10 @@ ifeq ($(strip $(EXTRAKEY_ENABLE)), yes)
     SHARED_EP_ENABLE = yes
 endif
 
+ifeq ($(strip $(VIA)), true)
+  RAW_ENABLE=yes
+endif
+
 ifeq ($(strip $(RAW_ENABLE)), yes)
     TMK_COMMON_DEFS += -DRAW_ENABLE
 endif

--- a/tmk_core/common/eeconfig.c
+++ b/tmk_core/common/eeconfig.c
@@ -62,8 +62,7 @@ void eeconfig_init(void) {
  *
  * FIXME: needs doc
  */
-void eeconfig_enable(void)
-{
+void eeconfig_enable(void) {
     eeprom_update_word(EECONFIG_MAGIC, EECONFIG_MAGIC_NUMBER);
 }
 
@@ -71,8 +70,7 @@ void eeconfig_enable(void)
  *
  * FIXME: needs doc
  */
-void eeconfig_disable(void)
-{
+void eeconfig_disable(void) {
 #ifdef STM32_EEPROM_ENABLE
     EEPROM_Erase();
 #endif
@@ -83,8 +81,7 @@ void eeconfig_disable(void)
  *
  * FIXME: needs doc
  */
-bool eeconfig_is_enabled(void)
-{
+bool eeconfig_is_enabled(void) {
     return (eeprom_read_word(EECONFIG_MAGIC) == EECONFIG_MAGIC_NUMBER);
 }
 
@@ -92,8 +89,7 @@ bool eeconfig_is_enabled(void)
  *
  * FIXME: needs doc
  */
-bool eeconfig_is_disabled(void)
-{
+bool eeconfig_is_disabled(void) {
     return (eeprom_read_word(EECONFIG_MAGIC) == EECONFIG_MAGIC_NUMBER_OFF);
 }
 
@@ -177,3 +173,19 @@ uint32_t eeconfig_read_user(void)      { return eeprom_read_dword(EECONFIG_USER)
 void eeconfig_update_user(uint32_t val) { eeprom_update_dword(EECONFIG_USER, val); }
 
 
+bool eeprom_is_valid(void) {
+	return (eeprom_read_word(((void*)EEPROM_MAGIC_ADDR)) == EEPROM_MAGIC &&
+			eeprom_read_byte(((void*)EEPROM_VERSION_ADDR)) == EEPROM_VERSION);
+}
+
+void eeprom_set_valid(bool valid) {
+	eeprom_update_word(((void*)EEPROM_MAGIC_ADDR), valid ? EEPROM_MAGIC : 0xFFFF);
+	eeprom_update_byte(((void*)EEPROM_VERSION_ADDR), valid ? EEPROM_VERSION : 0xFF);
+}
+
+void eeprom_reset(void) {
+	// Set the Zeal60 specific EEPROM state as invalid.
+	eeprom_set_valid(false);
+	// Set the TMK/QMK EEPROM state as invalid.
+	eeconfig_disable();
+}

--- a/tmk_core/common/eeconfig.h
+++ b/tmk_core/common/eeconfig.h
@@ -40,6 +40,26 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define EECONFIG_HANDEDNESS         			        	(uint8_t *)14
 #define EECONFIG_KEYBOARD                          (uint32_t *)15
 #define EECONFIG_USER                              (uint32_t *)19
+/* Note that Via Support uses address 32 and up for dynamic keymap support */
+
+// VIA Support EEPROM usage
+
+// TODO: refactor with new user EEPROM code (coming soon)
+#define EEPROM_MAGIC 0x451F
+#define EEPROM_MAGIC_ADDR 32
+// Bump this every time we change what we store
+// This will automatically reset the EEPROM with defaults
+// and avoid loading invalid data from the EEPROM
+#define EEPROM_VERSION 0x08
+#define EEPROM_VERSION_ADDR 34
+
+// Dynamic keymap starts after EEPROM version
+#define DYNAMIC_KEYMAP_EEPROM_ADDR 35
+// Dynamic macro starts after dynamic keymaps (35+(4*10*6*2)) = (35+480)
+#define DYNAMIC_KEYMAP_MACRO_EEPROM_ADDR 515
+#define DYNAMIC_KEYMAP_MACRO_EEPROM_SIZE 509    // 1024-DYNAMIC_KEYMAP_MACRO_EEPROM_ADDR
+#define DYNAMIC_KEYMAP_MACRO_COUNT 16
+
 
 /* debug bit */
 #define EECONFIG_DEBUG_ENABLE                       (1<<0)
@@ -93,5 +113,9 @@ uint32_t eeconfig_read_kb(void);
 void eeconfig_update_kb(uint32_t val);
 uint32_t eeconfig_read_user(void);
 void eeconfig_update_user(uint32_t val);
+
+bool eeprom_is_valid(void);
+void eeprom_set_valid(bool valid);
+void eeprom_reset(void);
 
 #endif

--- a/tmk_core/common/eeconfig.h
+++ b/tmk_core/common/eeconfig.h
@@ -60,6 +60,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define DYNAMIC_KEYMAP_MACRO_EEPROM_SIZE 509    // 1024-DYNAMIC_KEYMAP_MACRO_EEPROM_ADDR
 #define DYNAMIC_KEYMAP_MACRO_COUNT 16
 
+#define DYNAMIC_KEYMAP_LAYER_COUNT 4
 
 /* debug bit */
 #define EECONFIG_DEBUG_ENABLE                       (1<<0)

--- a/util/travis_build.sh
+++ b/util/travis_build.sh
@@ -5,7 +5,7 @@
 
 TRAVIS_COMMIT_MESSAGE="${TRAVIS_COMMIT_MESSAGE:-none}"
 TRAVIS_COMMIT_RANGE="${TRAVIS_COMMIT_RANGE:-HEAD~1..HEAD}"
-MAKE_ALL="make all:default AUTOGEN=\"true\" && all:default AUTOGEN=\"true\" VIA=\"true\""
+MAKE_ALL="make all:default AUTOGEN=\"true\""
 
 if [[ "$TRAVIS_COMMIT_MESSAGE" != *"[skip build]"* ]] ; then
 	exit_code=0
@@ -14,6 +14,7 @@ if [[ "$TRAVIS_COMMIT_MESSAGE" != *"[skip build]"* ]] ; then
 		echo "Making default keymaps for all keyboards"
 		eval $MAKE_ALL
 		: $((exit_code = $exit_code + $?))
+     make all:default AUTOGEN=true VIA=true BREAK_ON_ERRORS=no
 	else
 		NEFM=$(git diff --name-only -n 1 ${TRAVIS_COMMIT_RANGE} | grep -Ev '^(keyboards/)'  | grep -Ev '^(docs/)' | wc -l)
 		BRANCH=$(git rev-parse --abbrev-ref HEAD)
@@ -21,6 +22,7 @@ if [[ "$TRAVIS_COMMIT_MESSAGE" != *"[skip build]"* ]] ; then
 			echo "Making default keymaps for all keyboards"
 			eval $MAKE_ALL
 			: $((exit_code = $exit_code + $?))
+      make all:default AUTOGEN=true VIA=true BREAK_ON_ERRORS=no
 		else
 			MKB=$(git diff --name-only -n 1 ${TRAVIS_COMMIT_RANGE} | grep -oP '(?<=keyboards\/)([a-zA-Z0-9_\/]+)(?=\/)' | sort -u)
 			for KB in $MKB ; do
@@ -30,14 +32,16 @@ if [[ "$TRAVIS_COMMIT_MESSAGE" != *"[skip build]"* ]] ; then
 				KEYMAP_ONLY=$(git diff --name-only -n 1 ${TRAVIS_COMMIT_RANGE} | grep -Ev '^(keyboards/'${KB}'/keymaps/)' | wc -l)
 				if [[ $KEYMAP_ONLY -gt 0 ]]; then
 					echo "Making all keymaps for $KB"
-					make ${KB}:all AUTOGEN=true && ${KB}:all AUTOGEN=true VIA=true
+					make ${KB}:all AUTOGEN=true
 					: $((exit_code = $exit_code + $?))
+					make ${KB}:all AUTOGEN=true VIA=true BREAK_ON_ERRORS=no
 				else
 					MKM=$(git diff --name-only -n 1 ${TRAVIS_COMMIT_RANGE} | grep -oP '(?<=keyboards/'${KB}'/keymaps/)([a-zA-Z0-9_]+)(?=\/)' | sort -u)
 					for KM in $MKM ; do
 						echo "Making $KM for $KB"
-						make ${KB}:${KM} AUTOGEN=true && ${KB}:${KM} AUTOGEN=true VIA=true
+						make ${KB}:${KM} AUTOGEN=true
 						: $((exit_code = $exit_code + $?))
+						make ${KB}:${KM} AUTOGEN=true VIA=true BREAK_ON_ERRORS=no
 					done
 				fi
 			done

--- a/util/travis_build.sh
+++ b/util/travis_build.sh
@@ -5,9 +5,9 @@
 
 TRAVIS_COMMIT_MESSAGE="${TRAVIS_COMMIT_MESSAGE:-none}"
 TRAVIS_COMMIT_RANGE="${TRAVIS_COMMIT_RANGE:-HEAD~1..HEAD}"
-MAKE_ALL="make all:default AUTOGEN=\"true\""
+MAKE_ALL="make all:default AUTOGEN=\"true\" && all:default AUTOGEN=\"true\" VIA=\"true\""
 
-if [[ "$TRAVIS_COMMIT_MESSAGE" != *"[skip build]"* ]] ; then 
+if [[ "$TRAVIS_COMMIT_MESSAGE" != *"[skip build]"* ]] ; then
 	exit_code=0
 	git diff --name-only -n 1 ${TRAVIS_COMMIT_RANGE}
 	if [ $? -eq 128 ]; then
@@ -30,15 +30,15 @@ if [[ "$TRAVIS_COMMIT_MESSAGE" != *"[skip build]"* ]] ; then
 				KEYMAP_ONLY=$(git diff --name-only -n 1 ${TRAVIS_COMMIT_RANGE} | grep -Ev '^(keyboards/'${KB}'/keymaps/)' | wc -l)
 				if [[ $KEYMAP_ONLY -gt 0 ]]; then
 					echo "Making all keymaps for $KB"
-					make ${KB}:all AUTOGEN=true
+					make ${KB}:all AUTOGEN=true && ${KB}:all AUTOGEN=true VIA=true
 					: $((exit_code = $exit_code + $?))
 				else
 					MKM=$(git diff --name-only -n 1 ${TRAVIS_COMMIT_RANGE} | grep -oP '(?<=keyboards/'${KB}'/keymaps/)([a-zA-Z0-9_]+)(?=\/)' | sort -u)
 					for KM in $MKM ; do
-						echo "Making $KM for $KB"	
-						make ${KB}:${KM} AUTOGEN=true
+						echo "Making $KM for $KB"
+						make ${KB}:${KM} AUTOGEN=true && ${KB}:${KM} AUTOGEN=true VIA=true
 						: $((exit_code = $exit_code + $?))
-					done		
+					done
 				fi
 			done
 		fi

--- a/util/travis_build.sh
+++ b/util/travis_build.sh
@@ -14,7 +14,7 @@ if [[ "$TRAVIS_COMMIT_MESSAGE" != *"[skip build]"* ]] ; then
 		echo "Making default keymaps for all keyboards"
 		eval $MAKE_ALL
 		: $((exit_code = $exit_code + $?))
-     make all:default AUTOGEN=true VIA=true BREAK_ON_ERRORS=no
+     make all:default AUTOGEN=true VIA_SUPPORT_ENABLE=yes BREAK_ON_ERRORS=no
 	else
 		NEFM=$(git diff --name-only -n 1 ${TRAVIS_COMMIT_RANGE} | grep -Ev '^(keyboards/)'  | grep -Ev '^(docs/)' | wc -l)
 		BRANCH=$(git rev-parse --abbrev-ref HEAD)
@@ -22,7 +22,7 @@ if [[ "$TRAVIS_COMMIT_MESSAGE" != *"[skip build]"* ]] ; then
 			echo "Making default keymaps for all keyboards"
 			eval $MAKE_ALL
 			: $((exit_code = $exit_code + $?))
-      make all:default AUTOGEN=true VIA=true BREAK_ON_ERRORS=no
+      make all:default AUTOGEN=true VIA_SUPPORT_ENABLE=yes BREAK_ON_ERRORS=no
 		else
 			MKB=$(git diff --name-only -n 1 ${TRAVIS_COMMIT_RANGE} | grep -oP '(?<=keyboards\/)([a-zA-Z0-9_\/]+)(?=\/)' | sort -u)
 			for KB in $MKB ; do
@@ -34,14 +34,15 @@ if [[ "$TRAVIS_COMMIT_MESSAGE" != *"[skip build]"* ]] ; then
 					echo "Making all keymaps for $KB"
 					make ${KB}:all AUTOGEN=true
 					: $((exit_code = $exit_code + $?))
-					make ${KB}:all AUTOGEN=true VIA=true BREAK_ON_ERRORS=no
+					make ${KB}:default AUTOGEN=true VIA_SUPPORT_ENABLE=yes BREAK_ON_ERRORS=no
 				else
 					MKM=$(git diff --name-only -n 1 ${TRAVIS_COMMIT_RANGE} | grep -oP '(?<=keyboards/'${KB}'/keymaps/)([a-zA-Z0-9_]+)(?=\/)' | sort -u)
 					for KM in $MKM ; do
 						echo "Making $KM for $KB"
 						make ${KB}:${KM} AUTOGEN=true
 						: $((exit_code = $exit_code + $?))
-						make ${KB}:${KM} AUTOGEN=true VIA=true BREAK_ON_ERRORS=no
+						# Ideally, this should be run if the keymap is the "default" keymap, but I'm not sure how to do that
+						make ${KB}:${KM} AUTOGEN=true VIA_SUPPORT_ENABLE=yes BREAK_ON_ERRORS=no
 					done
 				fi
 			done

--- a/util/travis_compiled_push.sh
+++ b/util/travis_compiled_push.sh
@@ -73,6 +73,10 @@ if [[ "$TRAVIS_COMMIT_MESSAGE" != *"[skip build]"* ]] ; then
 	for file in ../qmk_firmware/keyboards/*/*/keymaps/*/*_default.hex; do mv -v "$file" "compiled/${file##*/}" || true; done
 	for file in ../qmk_firmware/keyboards/*/*/*/keymaps/*/*_default.hex; do mv -v "$file" "compiled/${file##*/}" || true; done
 	for file in ../qmk_firmware/keyboards/*/*/*/*/keymaps/*/*_default.hex; do mv -v "$file" "compiled/${file##*/}" || true; done
+	for file in ../qmk_firmware/keyboards/*/keymaps/*/*_default_via.hex; do mv -v "$file" "compiled/${file##*/}" || true; done
+	for file in ../qmk_firmware/keyboards/*/*/keymaps/*/*_default_via.hex; do mv -v "$file" "compiled/${file##*/}" || true; done
+	for file in ../qmk_firmware/keyboards/*/*/*/keymaps/*/*_default_via.hex; do mv -v "$file" "compiled/${file##*/}" || true; done
+	for file in ../qmk_firmware/keyboards/*/*/*/*/keymaps/*/*_default_via.hex; do mv -v "$file" "compiled/${file##*/}" || true; done
 	bash _util/generate_keyboard_page.sh
 	git add -A
 	git commit -m "generated from qmk/qmk_firmware@${rev}"


### PR DESCRIPTION
## Description
This Pull Request decouples the VIA support config from the Wilba Tech and Zeal keyboards, and moves it into the quantum code, as a core feature. 

This introduces a `VIA_SUPPORT_ENABLE` makefile setting that enables both RAW HID, and Dynamic Keymap support, to facilitate the ability to easy enable support.

Additionally, this converts the kb functions (matrix_int, and process_record) into core functions, so they no longer replace existing functions.  They have been moved to `via_init` and `process_via` respectively. 

Also, this changes the Travis CI build scripts to compile with VIA support, and to copy those keymaps to qmk.fm

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Core
- [ ] Bugfix
- [X] New Feature
- [ ] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation


## Issues Fixed or Closed by this PR

* Various issues brought up

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
