### PR TITLE
Always read two bytes from the endpoint if we have two bytes to read

### DIFF
--- a/tmk_core/protocol/lufa/lufa.c
+++ b/tmk_core/protocol/lufa/lufa.c
@@ -519,11 +519,7 @@ void EVENT_USB_Device_ControlRequest(void)
                     }
 
                     if (Endpoint_BytesInEndpoint() == 2) {
-                      uint8_t report_id = REPORT_ID_KEYBOARD;
-
-                      if (keyboard_protocol) {
-                        report_id = Endpoint_Read_8();
-                      }
+                      uint8_t report_id = Endpoint_Read_8();
 
                       if (report_id == REPORT_ID_KEYBOARD || report_id == REPORT_ID_NKRO) {
                         keyboard_led_stats = Endpoint_Read_8();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- This template is entirely option and can be removed, but is here to help both you and us. -->
<!--- This text and anything on lines wrapped like this one will not show up in the final text. This text is to help us and you. -->

## Description
I know I said in #4824 that I had fixed the status LEDs "once and for all", but... I missed something obvious and only noticed it in #4901. Whoops.

The report ID will only be read when `keyboard_protocol` evaluates to true. Otherwise, only one byte is read from the endpoint (the report ID as LED state again) even if there are two in there!

Honestly I don't know what `keyboard_protocol` is for (something to do with the HID Boot protocol?), but it's not necessary here because we've already checked how many bytes we've received. So, we can simply read a byte immediately after this check and assume it to be the report ID.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Core
- [x] Bugfix
- [ ] New Feature
- [ ] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation


## Issues Fixed or Closed by this PR

* Possibly #4901, however I can't reproduce the reported issue and the reported fix does not seem to make sense

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
