### PR TITLE
Remove lfkeyboards parent rules.mk as its only required for mini1800

### DIFF
--- a/keyboards/lfkeyboards/mini1800/rules.mk
+++ b/keyboards/lfkeyboards/mini1800/rules.mk
@@ -52,6 +52,8 @@ F_USB = $(F_CPU)
 # Interrupt driven control endpoint task(+60)
 OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
 
+# Extra source files for IS3731 lighting
+SRC = TWIlib.c issi.c lighting.c
 
 ifeq ($(strip $(ISSI_ENABLE)), yes)
     # TMK_COMMON_DEFS += -DISSI_ENABLE

--- a/keyboards/lfkeyboards/rules.mk
+++ b/keyboards/lfkeyboards/rules.mk
@@ -1,1 +1,0 @@
-SRC = TWIlib.c issi.c lighting.c


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- This template is entirely option and can be removed, but is here to help both you and us. -->
<!--- This text and anything on lines wrapped like this one will not show up in the final text. This text is to help us and you. -->

## Description
<!--- Describe your changes in detail -->
Pulled out from the discussions within #4862, Remove lfkeyboards parent rules.mk as its only required for mini1800. All other boards re-add the extra src files, so to follow convention, and to avoid adding a DEFAULT_FOLDER, its simpler to just remove the rules.mk and add the src files in the only board that is missing them, the mini1800.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Core
- [ ] Bugfix
- [ ] New Feature
- [x] Enhancement/Optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
