### PR TITLE
Add I2C_MASTER_ENABLE build option

### DIFF
--- a/common_features.mk
+++ b/common_features.mk
@@ -135,14 +135,14 @@ ifeq ($(strip $(RGB_MATRIX_ENABLE)), IS31FL3731)
     OPT_DEFS += -DIS31FL3731
     COMMON_VPATH += $(DRIVER_PATH)/issi
     SRC += is31fl3731.c
-    SRC += i2c_master.c
+    I2C_MASTER_ENABLE = yes
 endif
 
 ifeq ($(strip $(RGB_MATRIX_ENABLE)), IS31FL3733)
     OPT_DEFS += -DIS31FL3733
     COMMON_VPATH += $(DRIVER_PATH)/issi
     SRC += is31fl3733.c
-    SRC += i2c_master.c
+    I2C_MASTER_ENABLE = yes
 endif
 
 ifeq ($(strip $(TAP_DANCE_ENABLE)), yes)
@@ -228,8 +228,8 @@ endif
 ifeq ($(strip $(HAPTIC_ENABLE)), DRV2605L)
     COMMON_VPATH += $(DRIVER_PATH)/haptic
     SRC += DRV2605L.c
-    SRC += i2c_master.c
     OPT_DEFS += -DDRV2605L
+    I2C_MASTER_ENABLE = yes
 endif
 
 ifeq ($(strip $(HD44780_ENABLE)), yes)
@@ -263,11 +263,6 @@ ifneq ($(strip $(CUSTOM_MATRIX)), yes)
     endif
 endif
 
-# Include the standard debounce code if needed
-ifneq ($(strip $(CUSTOM_DEBOUNCE)), yes)
-    QUANTUM_SRC += $(QUANTUM_DIR)/debounce.c
-endif
-
 ifeq ($(strip $(SPLIT_KEYBOARD)), yes)
     OPT_DEFS += -DSPLIT_KEYBOARD
 
@@ -284,4 +279,8 @@ ifeq ($(strip $(SPLIT_KEYBOARD)), yes)
                            $(QUANTUM_DIR)/split_common/serial.c
     endif
     COMMON_VPATH += $(QUANTUM_PATH)/split_common
+endif
+
+ifeq ($(strip $(I2C_MASTER_ENABLE)), yes)
+    SRC += i2c_master.c
 endif

--- a/drivers/qwiic/qwiic.mk
+++ b/drivers/qwiic/qwiic.mk
@@ -2,9 +2,7 @@ ifneq ($(strip $(QWIIC_ENABLE)),)
   COMMON_VPATH += $(DRIVER_PATH)/qwiic
   OPT_DEFS += -DQWIIC_ENABLE
   SRC += qwiic.c
-  ifeq ($(filter "i2c_master.c", $(SRC)),)
-    SRC += i2c_master.c
-  endif
+  I2C_MASTER_ENABLE = yes
 endif
 
 ifneq ($(filter JOYSTIIC, $(QWIIC_ENABLE)),)

--- a/keyboards/ergodox_ez/rules.mk
+++ b/keyboards/ergodox_ez/rules.mk
@@ -84,9 +84,7 @@ API_SYSEX_ENABLE = no
 RGBLIGHT_ENABLE = yes
 RGB_MATRIX_ENABLE = no # enable later
 
-ifeq ($(strip $(RGB_MATRIX_ENABLE)), no)
-  SRC += i2c_master.c
-endif
+I2C_MASTER_ENABLE = yes
 
 
 LAYOUTS = ergodox


### PR DESCRIPTION
Right now, if you have multiple sources adding i2c_master, it generates a warning when compiling. For instance: 
```
tmk_core/rules.mk:373: target '.build/obj_ergodox_ez_drashna_glow/i2c_master.d' given more than once in the same rule
```

While this isn't a critical issues, and there may be a better solution for this, this does work.  And it makes it easy to add i2c_master.c anywhere, without the overlap. 

