### PR TITLE
Fix `1<col` instead of `1<<col` typo in matrix_is_on()

### DIFF
--- a/keyboards/chimera_ergo/matrix.c
+++ b/keyboards/chimera_ergo/matrix.c
@@ -112,7 +112,7 @@ uint8_t matrix_scan(void)
             if (timeout > 10000){
                 break;
             }
-        } 
+        }
         uart_data[i] = SERIAL_UART_DATA;
     }
 
@@ -134,7 +134,7 @@ uint8_t matrix_scan(void)
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {
-    return (matrix[row] & ((matrix_row_t)1<col));
+    return (matrix[row] & ((matrix_row_t)1<<col));
 }
 
 inline

--- a/keyboards/chimera_ls/matrix.c
+++ b/keyboards/chimera_ls/matrix.c
@@ -116,7 +116,7 @@ uint8_t matrix_scan(void)
             if (timeout > 10000){
                 break;
             }
-        } 
+        }
         uart_data[i] = SERIAL_UART_DATA;
     }
 
@@ -138,7 +138,7 @@ uint8_t matrix_scan(void)
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {
-    return (matrix[row] & ((matrix_row_t)1<col));
+    return (matrix[row] & ((matrix_row_t)1<<col));
 }
 
 inline

--- a/keyboards/chimera_ortho/matrix.c
+++ b/keyboards/chimera_ortho/matrix.c
@@ -102,7 +102,7 @@ uint8_t matrix_scan(void)
             if (timeout > 10000){
                 break;
             }
-        } 
+        }
         uart_data[i] = SERIAL_UART_DATA;
     }
 
@@ -124,7 +124,7 @@ uint8_t matrix_scan(void)
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {
-    return (matrix[row] & ((matrix_row_t)1<col));
+    return (matrix[row] & ((matrix_row_t)1<<col));
 }
 
 inline

--- a/keyboards/comet46/matrix.c
+++ b/keyboards/comet46/matrix.c
@@ -102,7 +102,7 @@ uint8_t matrix_scan(void)
             if (timeout > 10000){
                 break;
             }
-        } 
+        }
         uart_data[i] = SERIAL_UART_DATA;
     }
 
@@ -124,7 +124,7 @@ uint8_t matrix_scan(void)
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {
-    return (matrix[row] & ((matrix_row_t)1<col));
+    return (matrix[row] & ((matrix_row_t)1<<col));
 }
 
 inline

--- a/keyboards/dc01/arrow/matrix.c
+++ b/keyboards/dc01/arrow/matrix.c
@@ -218,7 +218,7 @@ bool matrix_is_modified(void)
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {
-    return (matrix[row] & ((matrix_row_t)1<col));
+    return (matrix[row] & ((matrix_row_t)1<<col));
 }
 
 inline

--- a/keyboards/dc01/left/matrix.c
+++ b/keyboards/dc01/left/matrix.c
@@ -158,7 +158,7 @@ void matrix_init(void) {
         matrix[i] = 0;
         matrix_debouncing[i] = 0;
     }
-    
+
     matrix_init_quantum();
 }
 
@@ -209,7 +209,7 @@ uint8_t matrix_scan(void)
             debouncing = false;
         }
 #   endif
-        
+
     if (i2c_transaction(SLAVE_I2C_ADDRESS_RIGHT, 0x3F, 0)){ //error has occured for main right half
         error_count_right++;
         if (error_count_right > ERROR_DISCONNECT_COUNT){ //disconnect half
@@ -220,7 +220,7 @@ uint8_t matrix_scan(void)
    }else{ //no error
         error_count_right = 0;
     }
-    
+
     if (i2c_transaction(SLAVE_I2C_ADDRESS_ARROW, 0X3FFF, 8)){ //error has occured for arrow cluster
         error_count_arrow++;
         if (error_count_arrow > ERROR_DISCONNECT_COUNT){ //disconnect arrow cluster
@@ -258,7 +258,7 @@ bool matrix_is_modified(void)
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {
-    return (matrix[row] & ((matrix_row_t)1<col));
+    return (matrix[row] & ((matrix_row_t)1<<col));
 }
 
 inline

--- a/keyboards/dc01/numpad/matrix.c
+++ b/keyboards/dc01/numpad/matrix.c
@@ -218,7 +218,7 @@ bool matrix_is_modified(void)
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {
-    return (matrix[row] & ((matrix_row_t)1<col));
+    return (matrix[row] & ((matrix_row_t)1<<col));
 }
 
 inline

--- a/keyboards/dc01/right/matrix.c
+++ b/keyboards/dc01/right/matrix.c
@@ -218,7 +218,7 @@ bool matrix_is_modified(void)
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {
-    return (matrix[row] & ((matrix_row_t)1<col));
+    return (matrix[row] & ((matrix_row_t)1<<col));
 }
 
 inline

--- a/keyboards/dichotomy/matrix.c
+++ b/keyboards/dichotomy/matrix.c
@@ -198,7 +198,7 @@ uint8_t matrix_scan(void)
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {
-    return (matrix[row] & ((matrix_row_t)1<col));
+    return (matrix[row] & ((matrix_row_t)1<<col));
 }
 
 inline

--- a/keyboards/handwired/promethium/matrix.c
+++ b/keyboards/handwired/promethium/matrix.c
@@ -167,7 +167,7 @@ inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 
 {
-    return (matrix[row] & ((matrix_row_t)1<col));
+    return (matrix[row] & ((matrix_row_t)1<<col));
 }
 
 inline

--- a/keyboards/kmac/matrix.c
+++ b/keyboards/kmac/matrix.c
@@ -97,7 +97,7 @@ uint8_t matrix_scan(void)
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {
-    return (matrix[row] & ((matrix_row_t)1<col));
+    return (matrix[row] & ((matrix_row_t)1<<col));
 }
 
 inline

--- a/keyboards/kmini/matrix.c
+++ b/keyboards/kmini/matrix.c
@@ -112,7 +112,7 @@ uint8_t matrix_scan(void)
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {
-    return (matrix[row] & ((matrix_row_t)1<col));
+    return (matrix[row] & ((matrix_row_t)1<<col));
 }
 
 inline

--- a/keyboards/mitosis/matrix.c
+++ b/keyboards/mitosis/matrix.c
@@ -103,7 +103,7 @@ uint8_t matrix_scan(void)
             if (timeout > 10000){
                 break;
             }
-        } 
+        }
         uart_data[i] = SERIAL_UART_DATA;
     }
 
@@ -125,7 +125,7 @@ uint8_t matrix_scan(void)
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {
-    return (matrix[row] & ((matrix_row_t)1<col));
+    return (matrix[row] & ((matrix_row_t)1<<col));
 }
 
 inline

--- a/keyboards/redox_w/matrix.c
+++ b/keyboards/redox_w/matrix.c
@@ -1,15 +1,15 @@
 /* Copyright 2017 Mattia Dal Ben
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -132,7 +132,7 @@ uint8_t matrix_scan(void)
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {
-    return (matrix[row] & ((matrix_row_t)1<col));
+    return (matrix[row] & ((matrix_row_t)1<<col));
 }
 
 inline

--- a/keyboards/sx60/matrix.c
+++ b/keyboards/sx60/matrix.c
@@ -137,7 +137,7 @@ void matrix_init(void) {
 
 uint8_t matrix_scan(void)
 {
-    if (mcp23018_status) { 
+    if (mcp23018_status) {
         /* if there was an error */
         if (++mcp23018_reset_loop == 0) {
             /* since mcp23018_reset_loop is 8 bit - we'll try to reset once in 255 matrix scans
@@ -190,7 +190,7 @@ bool matrix_is_modified(void)
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {
-    return (matrix[row] & ((matrix_row_t)1<col));
+    return (matrix[row] & ((matrix_row_t)1<<col));
 }
 
 inline
@@ -246,7 +246,7 @@ static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
     select_row(current_row);
     wait_us(30);
 
-    if (mcp23018_status) { 
+    if (mcp23018_status) {
         /* if there was an error */
         return 0;
     } else {
@@ -279,7 +279,7 @@ static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
 
 static void select_row(uint8_t row)
 {
-    if (mcp23018_status) { 
+    if (mcp23018_status) {
         /* if there was an error do nothing */
     } else {
         /* set active row low  : 0

--- a/keyboards/telophase/matrix.c
+++ b/keyboards/telophase/matrix.c
@@ -112,7 +112,7 @@ uint8_t matrix_scan(void)
             if (timeout > 10000){
                 break;
             }
-        } 
+        }
         uart_data[i] = SERIAL_UART_DATA;
     }
 
@@ -134,7 +134,7 @@ uint8_t matrix_scan(void)
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {
-    return (matrix[row] & ((matrix_row_t)1<col));
+    return (matrix[row] & ((matrix_row_t)1<<col));
 }
 
 inline

--- a/quantum/matrix.c
+++ b/quantum/matrix.c
@@ -184,7 +184,7 @@ bool matrix_is_modified(void)
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {
-    return (matrix[row] & ((matrix_row_t)1<col));
+    return (matrix[row] & ((matrix_row_t)1<<col));
 }
 
 inline


### PR DESCRIPTION
## Description

Wow, can't believe this wasn't spotted sooner!

## Types of changes
- [ ] Core
- [x] Bugfix
- [ ] New Feature
- [ ] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation


## Issues Fixed or Closed by this PR

* #2280

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
