### PR TITLE
Remove #define IS_COMMAND line in keyboards/handwired/xealousbrown/config.h

### DIFF
--- a/keyboards/handwired/xealousbrown/config.h
+++ b/keyboards/handwired/xealousbrown/config.h
@@ -46,6 +46,3 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* COL2ROW or ROW2COL */
 #define DIODE_DIRECTION COL2ROW
-
-/* key combination for magic key command */
-// #define IS_COMMAND() ( keyboard_report->mods == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT)))


### PR DESCRIPTION
It uses `keyboard_report->mods`, which is _\*Chyrosran voice\*_ unacceptableeee

The board was added in #4945