### PR TITLE
Fix link and name spelling in Space65's readme

### DIFF
--- a/keyboards/gray_studio/space65/readme.md
+++ b/keyboards/gray_studio/space65/readme.md
@@ -1,10 +1,10 @@
 # Gray Studio Space65
 
-A 65% keyboard with RGB Underglow, Backlight, USB C. 
+A 65% keyboard with RGB underglow, backlighting and USB C, whose design was inspired by the Voyager I space probe and Apple II home computer.
 
 Keyboard Maintainer: [MechMerlin](https://github.com/mechmerlin)  
-Hardware Supported: Gray Studio Space 65  
-Hardware Availability: [Geekhack Group Buy](https://geekhack.org/index.php?topic=97216.0)
+Hardware Supported: Gray Studio Space65  
+Hardware Availability: [Geekhack Group Buy](https://geekhack.org/index.php?topic=98768.0)
 
 Make example for this keyboard (after setting up your build environment):
 


### PR DESCRIPTION
The current link is for Gray Studio's HB85 keyboard. As far as I can tell, the “Space65” spelling (no space) is used everywhere except for on this one line.
I also reworded the summary a bit to include some information from the GB page.

This board was added in #5001.

~~On another note, COD67 was also designed by Gray Studio; that board should probably be moved to the `gray_studio` directory as well.~~ Never mind, just saw #5002 😄 