### PR TITLE
Custom Tapping Term per key

### DIFF
--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -126,6 +126,8 @@ If you define these options you will enable the associated feature, which may in
 
 * `#define TAPPING_TERM 200`
   * how long before a tap becomes a hold, if set above 500, a key tapped during the tapping term will turn it into a hold too
+* `#define TAPPING_TERM_PER_KEY`
+  * enables handling for per key `TAPPING_TERM` settings
 * `#define RETRO_TAPPING`
   * tap anyway, even after TAPPING_TERM, if there was no other key interruption between press and release
   * See [Retro Tapping](feature_advanced_keycodes.md#retro-tapping) for details

--- a/docs/custom_quantum_functions.md
+++ b/docs/custom_quantum_functions.md
@@ -466,33 +466,16 @@ And you're done.  The RGB layer indication will only work if you want it to. And
 * Keymap: `void eeconfig_init_user(void)`, `uint32_t eeconfig_read_user(void)` and `void eeconfig_update_user(uint32_t val)`
 
 The `val` is the value of the data that you want to write to EEPROM.  And the `eeconfig_read_*` function return a 32 bit (DWORD) value from the EEPROM. 
+
 # Custom Tapping Term
 
 By default, the tapping term is defined globally, and is not configurable by key.  For most users, this is perfectly fine.  But in come cases, dual function keys would be greatly improved by different timeouts than `LT` keys, or the like.  Instead of using custom key codes for each, this allows for per key configurable `Tapping_Term`.
 
 
 ## Example `get_tapping_term` Implementation
-```c
-uint16_t get_tapping_term(keyevent_t event) {
-  if (event.key.row == 1 && event.ey.col==3)    {
-    return 100;
-  }
-  return TAPPING_TERM;
-}
-```
-If this can be properly mapped, use something like this, instead:
-```c
-uint16_t get_tapping_term(keyevent_t event) {
-  switch (keymap_key_to_keycode(layer_switch_get_layer(event->key), event->key)) {
-    case SFT_T(KC_SPC):
-      return TAPPING_TERM + 1250;
-    case LT(1, KC_GRV):
-      return 130;
-    default:
-      return TAPPING_TERM;
-  }
-```
-And if the post_process_record PR gets merged, we can just use:
+
+To change the `TAPPING TERM` based on the keycode, you'd want to add something like the following to your `keymap.c` file: 
+
 ```c
 uint16_t get_tapping_term(keyevent_t event) {
   switch (get_event_keycode(event)) {
@@ -504,7 +487,7 @@ uint16_t get_tapping_term(keyevent_t event) {
       return TAPPING_TERM;
   }
 }
-````
+```
 
 ### `get_tapping_term` Function Documentation
 

--- a/docs/custom_quantum_functions.md
+++ b/docs/custom_quantum_functions.md
@@ -477,8 +477,8 @@ By default, the tapping term is defined globally, and is not configurable by key
 To change the `TAPPING TERM` based on the keycode, you'd want to add something like the following to your `keymap.c` file: 
 
 ```c
-uint16_t get_tapping_term(keyevent_t event) {
-  switch (get_event_keycode(event)) {
+uint16_t get_tapping_term(uint16_t keycode) {
+  switch (keycode) {
     case SFT_T(KC_SPC):
       return TAPPING_TERM + 1250;
     case LT(1, KC_GRV):

--- a/docs/custom_quantum_functions.md
+++ b/docs/custom_quantum_functions.md
@@ -323,6 +323,7 @@ uint32_t layer_state_set_user(uint32_t state) {
 * Keyboard/Revision: `uint32_t layer_state_set_kb(uint32_t state)`
 * Keymap: `uint32_t layer_state_set_user(uint32_t state)`
 
+
 The `state` is the bitmask of the active layers, as explained in the [Keymap Overview](keymap.md#keymap-layer-status)
 
 
@@ -465,3 +466,25 @@ And you're done.  The RGB layer indication will only work if you want it to. And
 * Keymap: `void eeconfig_init_user(void)`, `uint32_t eeconfig_read_user(void)` and `void eeconfig_update_user(uint32_t val)`
 
 The `val` is the value of the data that you want to write to EEPROM.  And the `eeconfig_read_*` function return a 32 bit (DWORD) value from the EEPROM. 
+# Custom Tapping Term
+
+By default, the tapping term is defined globally, and is not configurable by key.  For most users, this is perfectly fine.  But in come cases, dual function keys would be greatly improved by different timeouts than `LT` keys, or the like.  Instead of using custom key codes for each, this allows for per key configurable `Tapping_Term`.
+
+
+## Example `get_tapping_term` Implementation
+```c
+uint16_t get_tapping_term(keyevent_t* event) {
+    switch (keymap_key_to_keycode(layer_switch_get_layer(event->key), event->key)) {
+        case SFT_T(KC_SPC):
+            return TAPPING_TERM + 1250;
+        case LT(1, KC_GRV):
+            return 130;
+        default:
+            return TAPPING_TERM;
+    }
+}
+```
+
+### `get_tapping_term` Function Documentation
+
+Unlike many of the other functions here, there isn't a need (or even reason) to have a quantum or keyboard level function. Only a user level function is useful here, so no need to mark it as such.

--- a/docs/custom_quantum_functions.md
+++ b/docs/custom_quantum_functions.md
@@ -473,24 +473,39 @@ By default, the tapping term is defined globally, and is not configurable by key
 
 ## Example `get_tapping_term` Implementation
 ```c
-uint16_t get_tapping_term(keyevent_t* event) {
-    if (e->key.row == 1 && e->key.col==3)    {
-        return 100;
-    }
-    return TAPPING_TERM;
-
+uint16_t get_tapping_term(keyevent_t event) {
+  if (event.key.row == 1 && event.ey.col==3)    {
+    return 100;
+  }
+  return TAPPING_TERM;
 }
 ```
-<!-- If this can be properly mapped, use something like this, inst
-    switch (keymap_key_to_keycode(layer_switch_get_layer(event->key), event->key)) {
-        case SFT_T(KC_SPC):
-            return TAPPING_TERM + 1250;
-        case LT(1, KC_GRV):
-            return 130;
-        default:
-            return TAPPING_TERM;
-    }
--->
+If this can be properly mapped, use something like this, instead:
+```c
+uint16_t get_tapping_term(keyevent_t event) {
+  switch (keymap_key_to_keycode(layer_switch_get_layer(event->key), event->key)) {
+    case SFT_T(KC_SPC):
+      return TAPPING_TERM + 1250;
+    case LT(1, KC_GRV):
+      return 130;
+    default:
+      return TAPPING_TERM;
+  }
+```
+And if the post_process_record PR gets merged, we can just use:
+```c
+uint16_t get_tapping_term(keyevent_t event) {
+  switch (get_event_keycode(event)) {
+    case SFT_T(KC_SPC):
+      return TAPPING_TERM + 1250;
+    case LT(1, KC_GRV):
+      return 130;
+    default:
+      return TAPPING_TERM;
+  }
+}
+````
+
 ### `get_tapping_term` Function Documentation
 
 Unlike many of the other functions here, there isn't a need (or even reason) to have a quantum or keyboard level function. Only a user level function is useful here, so no need to mark it as such.

--- a/docs/custom_quantum_functions.md
+++ b/docs/custom_quantum_functions.md
@@ -469,7 +469,9 @@ The `val` is the value of the data that you want to write to EEPROM.  And the `e
 
 # Custom Tapping Term
 
-By default, the tapping term is defined globally, and is not configurable by key.  For most users, this is perfectly fine.  But in come cases, dual function keys would be greatly improved by different timeouts than `LT` keys, or the like.  Instead of using custom key codes for each, this allows for per key configurable `Tapping_Term`.
+By default, the tapping term is defined globally, and is not configurable by key.  For most users, this is perfectly fine.  But in come cases, dual function keys would be greatly improved by different timeouts than `LT` keys, or because some keys may be easier to hold than others.  Instead of using custom key codes for each, this allows for per key configurable `TAPPING_TERM`.
+
+To enable this functionality, you need to add `#define TAPPING_TERM_PER_KEY` to your `config.h`, first.  
 
 
 ## Example `get_tapping_term` Implementation

--- a/docs/custom_quantum_functions.md
+++ b/docs/custom_quantum_functions.md
@@ -474,6 +474,14 @@ By default, the tapping term is defined globally, and is not configurable by key
 ## Example `get_tapping_term` Implementation
 ```c
 uint16_t get_tapping_term(keyevent_t* event) {
+    if (e->key.row == 1 && e->key.col==3)    {
+        return 100;
+    }
+    return TAPPING_TERM;
+
+}
+```
+<!-- If this can be properly mapped, use something like this, inst
     switch (keymap_key_to_keycode(layer_switch_get_layer(event->key), event->key)) {
         case SFT_T(KC_SPC):
             return TAPPING_TERM + 1250;
@@ -482,9 +490,7 @@ uint16_t get_tapping_term(keyevent_t* event) {
         default:
             return TAPPING_TERM;
     }
-}
-```
-
+-->
 ### `get_tapping_term` Function Documentation
 
 Unlike many of the other functions here, there isn't a need (or even reason) to have a quantum or keyboard level function. Only a user level function is useful here, so no need to mark it as such.

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -252,12 +252,6 @@ uint16_t get_event_keycode(keyevent_t event) {
     return keymap_key_to_keycode(layer_switch_get_layer(event.key), event.key);
 }
 
- /* Get keycode, and then call keyboard function */
-void post_process_record_quantum(keyrecord_t *record) {
-  uint16_t keycode = get_record_keycode(record);
-  post_process_record_kb(keycode, record);
-}
-
  /* Core keycode function, hands off handling to other functions,
     then processes internal quantum keycodes, and then processes
     ACTIONs.                                                      */

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -231,8 +231,9 @@ uint16_t get_record_keycode(keyrecord_t *record) {
 }
 
 
- /* Convert event into usable keycode, checks the layer cache to ensure that it
-      retains the correct keycode after a layer change, if it's still pressed. */
+/* Convert event into usable keycode. Checks the layer cache to ensure that it
+ * retains the correct keycode after a layer change, if the key is still pressed.
+ */
 uint16_t get_event_keycode(keyevent_t event) {
 
   #if !defined(NO_ACTION_LAYER) && !defined(STRICT_LAYER_RELEASE)
@@ -252,9 +253,9 @@ uint16_t get_event_keycode(keyevent_t event) {
     return keymap_key_to_keycode(layer_switch_get_layer(event.key), event.key);
 }
 
- /* Core keycode function, hands off handling to other functions,
-    then processes internal quantum keycodes, and then processes
-    ACTIONs.                                                      */
+/* Main keycode processing function. Hands off handling to other functions,
+ * then processes internal Quantum keycodes, then processes ACTIONs.
+ */
 bool process_record_quantum(keyrecord_t *record) {
     uint16_t keycode = get_record_keycode(record);
 

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -240,7 +240,7 @@ uint16_t get_event_keycode(keyevent_t event) {
     if (!disable_action_cache) {
       uint8_t layer;
 
-      if (>event.pressed) {
+      if (event.pressed) {
         layer = layer_switch_get_layer(event.key);
         update_source_layers_cache(event.key, layer);
       } else {

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -225,7 +225,7 @@ static uint16_t scs_timer[2] = {0, 0};
  */
 static bool grave_esc_was_shifted = false;
 
-/* Calls get get_event_keycode to handle the conversion*/
+/* Convert record into usable keycode via the contained event. */
 uint16_t get_record_keycode(keyrecord_t *record) {
   return get_event_keycode(record->event);
 }

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -224,6 +224,8 @@ void matrix_init_kb(void);
 void matrix_scan_kb(void);
 void matrix_init_user(void);
 void matrix_scan_user(void);
+uint16_t get_record_keycode(keyrecord_t *record);
+uint16_t get_event_keycode(keyevent_t event);
 bool process_action_kb(keyrecord_t *record);
 bool process_record_kb(uint16_t keycode, keyrecord_t *record);
 bool process_record_user(uint16_t keycode, keyrecord_t *record);

--- a/tmk_core/common/action_tapping.c
+++ b/tmk_core/common/action_tapping.c
@@ -23,7 +23,12 @@ __attribute__ ((weak))
 uint16_t get_tapping_term(uint16_t keycode) {
   return TAPPING_TERM;
 }
+
+#ifdef TAPPING_TERM_PER_KEY
 #define WITHIN_TAPPING_TERM(e)  (TIMER_DIFF_16(e.time, tapping_key.event.time) < get_tapping_term(get_event_keycode(tapping_key.event)))
+#else
+#define WITHIN_TAPPING_TERM(e)  (TIMER_DIFF_16(e.time, tapping_key.event.time) < TAPPING_TERM)
+#endif
 
 static keyrecord_t tapping_key = {};
 static keyrecord_t waiting_buffer[WAITING_BUFFER_SIZE] = {};
@@ -108,11 +113,8 @@ bool process_tapping(keyrecord_t *keyp)
                  * This can register the key before settlement of tapping,
                  * useful for long TAPPING_TERM but may prevent fast typing.
                  */
-#ifdef PERMISSIVE_HOLD
-                else if ( IS_RELEASED(event) && waiting_buffer_typed(event))
-#else
+#if defined(TAPPING_TERM_PER_KEY)
                 else if ( ( get_tapping_term(get_event_keycode(tapping_key.event)) >= 500) && IS_RELEASED(event) && waiting_buffer_typed(event))
-#endif
                 {
                     debug("Tapping: End. No tap. Interfered by typing key\n");
                     process_record(&tapping_key);
@@ -121,6 +123,17 @@ bool process_tapping(keyrecord_t *keyp)
                     // enqueue
                     return false;
                 }
+#elif !defined(PER_KEY_TAPPING_TERM) && (TAPPING_TERM >= 500 || defined(PERMISSIVE_HOLD))
+                else if ( IS_RELEASED(event) && waiting_buffer_typed(event))
+                {
+                    debug("Tapping: End. No tap. Interfered by typing key\n");
+                    process_record(&tapping_key);
+                    tapping_key = (keyrecord_t){};
+                    debug_tapping_key();
+                    // enqueue
+                    return false;
+                }
+#endif
                 /* Process release event of a key pressed before tapping starts
                  * Without this unexpected repeating will occur with having fast repeating setting
                  * https://github.com/tmk/tmk_keyboard/issues/60

--- a/tmk_core/common/action_tapping.c
+++ b/tmk_core/common/action_tapping.c
@@ -20,7 +20,7 @@
 #define IS_TAPPING_KEY(k)       (IS_TAPPING() && KEYEQ(tapping_key.event.key, (k)))
 
 __attribute__ ((weak))
-uint16_t get_tapping_term(keyevent_t* event) {
+uint16_t get_tapping_term(keyevent_t event) {
   return TAPPING_TERM;
 }
 #define WITHIN_TAPPING_TERM(e)  (TIMER_DIFF_16(e.time, tapping_key.event.time) < get_tapping_term(e))

--- a/tmk_core/common/action_tapping.c
+++ b/tmk_core/common/action_tapping.c
@@ -89,6 +89,12 @@ bool process_tapping(keyrecord_t *keyp)
 {
     keyevent_t event = keyp->event;
 
+#ifdef PERMISSIVE_HOLD  // Because we need to check this, but it doesn't work in a function
+    bool permissive_hold = true;
+#else
+    bool permissive_hold = false;
+#endif
+
     // if tapping
     if (IS_TAPPING_PRESSED()) {
         if (WITHIN_TAPPING_TERM(event)) {
@@ -105,12 +111,11 @@ bool process_tapping(keyrecord_t *keyp)
                     // enqueue
                     return false;
                 }
-#if TAPPING_TERM >= 500 || defined PERMISSIVE_HOLD
                 /* Process a key typed within TAPPING_TERM
                  * This can register the key before settlement of tapping,
                  * useful for long TAPPING_TERM but may prevent fast typing.
                  */
-                else if (IS_RELEASED(event) && waiting_buffer_typed(event)) {
+                else if ( ( permissive_hold || get_tapping_term(event) >= 500) && IS_RELEASED(event) && waiting_buffer_typed(event)) {
                     debug("Tapping: End. No tap. Interfered by typing key\n");
                     process_record(&tapping_key);
                     tapping_key = (keyrecord_t){};
@@ -118,7 +123,6 @@ bool process_tapping(keyrecord_t *keyp)
                     // enqueue
                     return false;
                 }
-#endif
                 /* Process release event of a key pressed before tapping starts
                  * Without this unexpected repeating will occur with having fast repeating setting
                  * https://github.com/tmk/tmk_keyboard/issues/60

--- a/tmk_core/common/action_tapping.c
+++ b/tmk_core/common/action_tapping.c
@@ -21,6 +21,7 @@
 
 __attribute__ ((weak))
 uint16_t get_tapping_term(keyevent_t event) {
+  xprintf("get_tapping_term (main) col: %u, row: %u\n", event.key.col, event.key.row);
   return TAPPING_TERM;
 }
 #define WITHIN_TAPPING_TERM(e)  (TIMER_DIFF_16(e.time, tapping_key.event.time) < get_tapping_term(e))

--- a/tmk_core/common/action_tapping.c
+++ b/tmk_core/common/action_tapping.c
@@ -24,7 +24,7 @@ uint16_t get_tapping_term(keyevent_t event) {
   xprintf("get_tapping_term (main) col: %u, row: %u\n", event.key.col, event.key.row);
   return TAPPING_TERM;
 }
-#define WITHIN_TAPPING_TERM(e)  (TIMER_DIFF_16(e.time, tapping_key.event.time) < get_tapping_term(e))
+#define WITHIN_TAPPING_TERM(e)  (TIMER_DIFF_16(e.time, tapping_key.event.time) < get_tapping_term(tapping_key.event))
 
 static keyrecord_t tapping_key = {};
 static keyrecord_t waiting_buffer[WAITING_BUFFER_SIZE] = {};

--- a/tmk_core/common/action_tapping.c
+++ b/tmk_core/common/action_tapping.c
@@ -19,11 +19,11 @@
 #define IS_TAPPING_RELEASED()   (IS_TAPPING() && !tapping_key.event.pressed)
 #define IS_TAPPING_KEY(k)       (IS_TAPPING() && KEYEQ(tapping_key.event.key, (k)))
 
-__attribute__ ((weak)) 
-uint16_t get_tapping_term(keyevent_t* event) { 
-  return TAPPING_TERM; 
-} 
-#define WITHIN_TAPPING_TERM(e)  (TIMER_DIFF_16(e.time, tapping_key.event.time) < get_tapping_term(&e))
+__attribute__ ((weak))
+uint16_t get_tapping_term(keyevent_t* event) {
+  return TAPPING_TERM;
+}
+#define WITHIN_TAPPING_TERM(e)  (TIMER_DIFF_16(e.time, tapping_key.event.time) < get_tapping_term(e))
 
 static keyrecord_t tapping_key = {};
 static keyrecord_t waiting_buffer[WAITING_BUFFER_SIZE] = {};

--- a/tmk_core/common/action_tapping.c
+++ b/tmk_core/common/action_tapping.c
@@ -20,11 +20,10 @@
 #define IS_TAPPING_KEY(k)       (IS_TAPPING() && KEYEQ(tapping_key.event.key, (k)))
 
 __attribute__ ((weak))
-uint16_t get_tapping_term(keyevent_t event) {
-  xprintf("get_tapping_term (main) col: %u, row: %u\n", event.key.col, event.key.row);
+uint16_t get_tapping_term(uint16_t keycode) {
   return TAPPING_TERM;
 }
-#define WITHIN_TAPPING_TERM(e)  (TIMER_DIFF_16(e.time, tapping_key.event.time) < get_tapping_term(tapping_key.event))
+#define WITHIN_TAPPING_TERM(e)  (TIMER_DIFF_16(e.time, tapping_key.event.time) < get_tapping_term(get_event_keycode(tapping_key.event)))
 
 static keyrecord_t tapping_key = {};
 static keyrecord_t waiting_buffer[WAITING_BUFFER_SIZE] = {};
@@ -112,7 +111,7 @@ bool process_tapping(keyrecord_t *keyp)
 #ifdef PERMISSIVE_HOLD
                 else if ( IS_RELEASED(event) && waiting_buffer_typed(event))
 #else
-                else if ( ( get_tapping_term(tapping_key.event) >= 500) && IS_RELEASED(event) && waiting_buffer_typed(event))
+                else if ( ( get_tapping_term(get_event_keycode(tapping_key.event)) >= 500) && IS_RELEASED(event) && waiting_buffer_typed(event))
 #endif
                 {
                     debug("Tapping: End. No tap. Interfered by typing key\n");

--- a/tmk_core/common/action_tapping.c
+++ b/tmk_core/common/action_tapping.c
@@ -113,18 +113,12 @@ bool process_tapping(keyrecord_t *keyp)
                  * This can register the key before settlement of tapping,
                  * useful for long TAPPING_TERM but may prevent fast typing.
                  */
-#if defined(TAPPING_TERM_PER_KEY)
+#if defined(TAPPING_TERM_PER_KEY) || (!defined(PER_KEY_TAPPING_TERM) && TAPPING_TERM >= 500) || defined(PERMISSIVE_HOLD)
+#ifdef TAPPING_TERM_PER_KEY
                 else if ( ( get_tapping_term(get_event_keycode(tapping_key.event)) >= 500) && IS_RELEASED(event) && waiting_buffer_typed(event))
-                {
-                    debug("Tapping: End. No tap. Interfered by typing key\n");
-                    process_record(&tapping_key);
-                    tapping_key = (keyrecord_t){};
-                    debug_tapping_key();
-                    // enqueue
-                    return false;
-                }
-#elif !defined(PER_KEY_TAPPING_TERM) && (TAPPING_TERM >= 500 || defined(PERMISSIVE_HOLD))
+#else
                 else if ( IS_RELEASED(event) && waiting_buffer_typed(event))
+#endif
                 {
                     debug("Tapping: End. No tap. Interfered by typing key\n");
                     process_record(&tapping_key);

--- a/tmk_core/common/action_tapping.c
+++ b/tmk_core/common/action_tapping.c
@@ -18,8 +18,12 @@
 #define IS_TAPPING_PRESSED()    (IS_TAPPING() && tapping_key.event.pressed)
 #define IS_TAPPING_RELEASED()   (IS_TAPPING() && !tapping_key.event.pressed)
 #define IS_TAPPING_KEY(k)       (IS_TAPPING() && KEYEQ(tapping_key.event.key, (k)))
-#define WITHIN_TAPPING_TERM(e)  (TIMER_DIFF_16(e.time, tapping_key.event.time) < TAPPING_TERM)
 
+__attribute__ ((weak)) 
+uint16_t get_tapping_term(keyevent_t* event) { 
+  return TAPPING_TERM; 
+} 
+#define WITHIN_TAPPING_TERM(e)  (TIMER_DIFF_16(e.time, tapping_key.event.time) < get_tapping_term(&e))
 
 static keyrecord_t tapping_key = {};
 static keyrecord_t waiting_buffer[WAITING_BUFFER_SIZE] = {};

--- a/tmk_core/common/action_tapping.c
+++ b/tmk_core/common/action_tapping.c
@@ -115,7 +115,7 @@ bool process_tapping(keyrecord_t *keyp)
                  * This can register the key before settlement of tapping,
                  * useful for long TAPPING_TERM but may prevent fast typing.
                  */
-                else if ( ( permissive_hold || get_tapping_term(event) >= 500) && IS_RELEASED(event) && waiting_buffer_typed(event)) {
+                else if ( ( permissive_hold || get_tapping_term(tapping_key.event) >= 500) && IS_RELEASED(event) && waiting_buffer_typed(event)) {
                     debug("Tapping: End. No tap. Interfered by typing key\n");
                     process_record(&tapping_key);
                     tapping_key = (keyrecord_t){};

--- a/tmk_core/common/action_tapping.c
+++ b/tmk_core/common/action_tapping.c
@@ -89,12 +89,6 @@ bool process_tapping(keyrecord_t *keyp)
 {
     keyevent_t event = keyp->event;
 
-#ifdef PERMISSIVE_HOLD  // Because we need to check this, but it doesn't work in a function
-    bool permissive_hold = true;
-#else
-    bool permissive_hold = false;
-#endif
-
     // if tapping
     if (IS_TAPPING_PRESSED()) {
         if (WITHIN_TAPPING_TERM(event)) {
@@ -115,7 +109,12 @@ bool process_tapping(keyrecord_t *keyp)
                  * This can register the key before settlement of tapping,
                  * useful for long TAPPING_TERM but may prevent fast typing.
                  */
-                else if ( ( permissive_hold || get_tapping_term(tapping_key.event) >= 500) && IS_RELEASED(event) && waiting_buffer_typed(event)) {
+#ifdef PERMISSIVE_HOLD
+                else if ( IS_RELEASED(event) && waiting_buffer_typed(event))
+#else
+                else if ( ( get_tapping_term(tapping_key.event) >= 500) && IS_RELEASED(event) && waiting_buffer_typed(event))
+#endif
+                {
                     debug("Tapping: End. No tap. Interfered by typing key\n");
                     process_record(&tapping_key);
                     tapping_key = (keyrecord_t){};

--- a/tmk_core/common/action_tapping.h
+++ b/tmk_core/common/action_tapping.h
@@ -35,7 +35,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
 #ifndef NO_ACTION_TAPPING
-uint16_t get_tapping_term( keyevent_t* event );
+uint16_t get_tapping_term(keyevent_t event);
 void action_tapping_process(keyrecord_t record);
 #endif
 

--- a/tmk_core/common/action_tapping.h
+++ b/tmk_core/common/action_tapping.h
@@ -35,7 +35,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
 #ifndef NO_ACTION_TAPPING
-uint16_t get_tapping_term(keyevent_t event);
+uint16_t get_event_keycode(keyevent_t event);
+uint16_t get_tapping_term(uint16_t keycode);
 void action_tapping_process(keyrecord_t record);
 #endif
 

--- a/tmk_core/common/action_tapping.h
+++ b/tmk_core/common/action_tapping.h
@@ -35,6 +35,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
 #ifndef NO_ACTION_TAPPING
+__attribute__( (weak) )
+uint16_t get_tapping_term( keyevent_t* event );
+
 void action_tapping_process(keyrecord_t record);
 #endif
 

--- a/tmk_core/common/action_tapping.h
+++ b/tmk_core/common/action_tapping.h
@@ -35,9 +35,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
 #ifndef NO_ACTION_TAPPING
-__attribute__( (weak) )
 uint16_t get_tapping_term( keyevent_t* event );
-
 void action_tapping_process(keyrecord_t record);
 #endif
 


### PR DESCRIPTION
## Description
Allow a user customizable tapping term, that is configurable, per key.  In theory. 

However, it doesn't work correctly.  The default value works, but I can't seem to get it to properly work using the `keycode`, but does work if you specify the Row and Column of the key. 

This is not ideal, at all.   But I'm not sure sure how to fix this issue.   So, I'm opening the pull request to get some input on this, and see if somebody can help me get this working "properly". 

This isn't originally my code, but is fredizzimo and @danielo515

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Core
- [ ] Bugfix
- [x] New Feature
- [x] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [x] Documentation


## Issues Fixed or Closed by this PR

* #2477

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [X] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
