### PR TITLE
Add a mechanism for force building a particular community layout

### DIFF
--- a/build_keyboard.mk
+++ b/build_keyboard.mk
@@ -135,6 +135,10 @@ ifeq ($(strip $(CONVERT_TO_PROTON_C)), yes)
     OPT_DEFS += -DCONVERT_TO_PROTON_C
 endif
 
+ifneq ($(FORCE_LAYOUT),)
+    TARGET := $(TARGET)_$(FORCE_LAYOUT)
+endif
+
 include quantum/mcu_selection.mk
 
 ifdef MCU_FAMILY

--- a/build_layout.mk
+++ b/build_layout.mk
@@ -15,4 +15,13 @@ define SEARCH_LAYOUTS
     $$(foreach LAYOUTS_REPO,$$(LAYOUTS_REPOS),$$(eval $$(call SEARCH_LAYOUTS_REPO)))
 endef
 
+ifneq ($(FORCE_LAYOUT),)
+    ifneq (,$(findstring $(FORCE_LAYOUT),$(LAYOUTS)))
+        $(info Forcing layout: $(FORCE_LAYOUT))
+        LAYOUTS := $(FORCE_LAYOUT)
+    else
+        $(error Forced layout does not exist)
+    endif
+endif
+
 $(foreach LAYOUT,$(LAYOUTS),$(eval $(call SEARCH_LAYOUTS)))

--- a/docs/feature_layouts.md
+++ b/docs/feature_layouts.md
@@ -51,6 +51,35 @@ The folder name must be added to the keyboard's `rules.mk`:
 
 but the `LAYOUT_<layout>` variable must be defined in `<folder>.h` as well.
 
+## Building a Keymap
+
+You should be able to build the keyboard keymap with a command in this format:
+
+    make <keyboard>:<layout>
+
+### Conflicting layouts
+When a keyboard supports multiple layout options,
+
+    LAYOUTS = ortho_4x4 ortho_4x12
+
+And a layout exists for both options,
+```
+layouts/
++ community/
+| + ortho_4x4/
+| | + <layout>/
+| | | + ...
+| + ortho_4x12/
+| | + <layout>/
+| | | + ...
+| + ...
+```
+
+The FORCE_LAYOUT argument can be used to specify which layout to build
+
+    make <keyboard>:<layout> FORCE_LAYOUT=ortho_4x4
+    make <keyboard>:<layout> FORCE_LAYOUT=ortho_4x12
+
 ## Tips for Making Layouts Keyboard-Agnostic
 
 ### Includes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- This template is entirely option and can be removed, but is here to help both you and us. -->
<!--- This text and anything on lines wrapped like this one will not show up in the final text. This text is to help us and you. -->

## Description
<!--- Describe your changes in detail -->
I use a nori as a 4x12 keyboard and 4x4 macro pad, and have community layouts for both. [Branch here](/zvecr/qmk_firmware/tree/feature/zvecr-keymap)
```bash
vagrant@vagrant:/vagrant$ ls layouts/community/*/zvecr
layouts/community/ortho_4x12/zvecr:
config.h  keymap.c  readme.md  rules.mk

layouts/community/ortho_4x4/zvecr:
config.h  keymap.c  readme.md  rules.mk
```

Currently there is no way to build both keymaps and `make 40percentclub/nori:zvecr` builds whatever it finds first, in this case ortho_4x12.

So far, i have added an additional flag that allows a particular keymap to be targeted
```
make 40percentclub/nori:zvecr FORCE_LAYOUT=ortho_4x4
make 40percentclub/nori:zvecr FORCE_LAYOUT=ortho_4x12
````
~~TBD~~
- ~~What docs would need updating?~~ done
- ~~Should the filename contain the layout used?~~ done
- ~~Should this be extended to allow it to be specified in the keymap argument, eg
`make 40percentclub/nori:ortho_4x4/zvecr`~~ will not do for now, but could add in a future PR

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Core
- [ ] Bugfix
- [ ] New Feature
- [x] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
