### PR TITLE
Remove keyboard description from Adafruit BLE device name

### DIFF
--- a/tmk_core/protocol/lufa/adafruit_ble.cpp
+++ b/tmk_core/protocol/lufa/adafruit_ble.cpp
@@ -533,8 +533,7 @@ bool adafruit_ble_enable_keyboard(void) {
   // Disable command echo
   static const char kEcho[] PROGMEM = "ATE=0";
   // Make the advertised name match the keyboard
-  static const char kGapDevName[] PROGMEM =
-      "AT+GAPDEVNAME=" STR(PRODUCT) " " STR(DESCRIPTION);
+  static const char kGapDevName[] PROGMEM = "AT+GAPDEVNAME=" STR(PRODUCT);
   // Turn on keyboard support
   static const char kHidEnOn[] PROGMEM = "AT+BLEHIDEN=1";
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- This template is entirely option and can be removed, but is here to help both you and us. -->
<!--- This text and anything on lines wrapped like this one will not show up in the final text. This text is to help us and you. -->

## Description
As I mentioned in https://github.com/qmk/qmk_firmware/pull/4967#discussion_r252911811, Adafruit BLE keyboards include the keyboard description from `config.h` in the device name. I think this is not really the right place for it, especially since some descriptions can be quite long.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Core
- [ ] Bugfix
- [ ] New Feature
- [x] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation


## Issues Fixed or Closed by this PR

* None.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
