### PR TITLE
make clean should remove .bin and .hex too

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,7 @@ $(eval $(call GET_KEYBOARDS))
 # Only consider folders with makefiles, to prevent errors in case there are extra folders
 #KEYBOARDS += $(patsubst $(ROOD_DIR)/keyboards/%/rules.mk,%,$(wildcard $(ROOT_DIR)/keyboards/*/*/rules.mk))
 
+.PHONY: list-keyboards
 list-keyboards:
 	echo $(KEYBOARDS)
 	exit 0
@@ -120,10 +121,12 @@ define PRINT_KEYBOARD
 	$(info $(PRINTING_KEYBOARD))
 endef
 
+.PHONY: generate-keyboards-file
 generate-keyboards-file:
 	$(foreach PRINTING_KEYBOARD,$(KEYBOARDS),$(eval $(call PRINT_KEYBOARD)))
 	exit 0
 
+.PHONY: clean
 clean:
 	echo 'Deleting .build/ ...'
 	rm -rf $(BUILD_DIR)
@@ -579,6 +582,7 @@ lib/%:
 	git submodule sync $?
 	git submodule update --init $?
 
+.PHONY: git-submodule
 git-submodule:
 	git submodule sync --recursive
 	git submodule update --init --recursive --progress

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,6 @@ $(eval $(call GET_KEYBOARDS))
 .PHONY: list-keyboards
 list-keyboards:
 	echo $(KEYBOARDS)
-	exit 0
 
 define PRINT_KEYBOARD
 	$(info $(PRINTING_KEYBOARD))
@@ -124,16 +123,18 @@ endef
 .PHONY: generate-keyboards-file
 generate-keyboards-file:
 	$(foreach PRINTING_KEYBOARD,$(KEYBOARDS),$(eval $(call PRINT_KEYBOARD)))
-	exit 0
 
 .PHONY: clean
 clean:
-	echo 'Deleting .build/ ...'
+	echo -n 'Deleting .build/ ... '
 	rm -rf $(BUILD_DIR)
-	echo 'Deleting *.bin and *.hex ...'
+	echo 'done.'
+
+.PHONY: distclean
+distclean: clean
+	echo -n 'Deleting *.bin and *.hex ... '
 	rm -f *.bin *.hex
-	echo 'Done.'
-	exit 0
+	echo 'done.'
 
 #Compatibility with the old make variables, anything you specify directly on the command line
 # always overrides the detected folders

--- a/Makefile
+++ b/Makefile
@@ -125,9 +125,11 @@ generate-keyboards-file:
 	exit 0
 
 clean:
-	echo -n 'Deleting .build ... '
+	echo 'Deleting .build/ ...'
 	rm -rf $(BUILD_DIR)
-	echo 'done'
+	echo 'Deleting *.bin and *.hex ...'
+	rm -f *.bin *.hex
+	echo 'Done.'
 	exit 0
 
 #Compatibility with the old make variables, anything you specify directly on the command line


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- This template is entirely option and can be removed, but is here to help both you and us. -->
<!--- This text and anything on lines wrapped like this one will not show up in the final text. This text is to help us and you. -->

## Description
It didn't seem correct to me that `make clean` leaves the final firmware behind. Also useful when running `make all` for testing stuff.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Core
- [ ] Bugfix
- [ ] New Feature
- [x] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation


## Issues Fixed or Closed by this PR

* None.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
