### PR TITLE
Fix QWERTZ <> QWERTY issue in sendstring_german.h

### DIFF
--- a/quantum/keymap_extras/sendstring_german.h
+++ b/quantum/keymap_extras/sendstring_german.h
@@ -67,7 +67,7 @@ const uint8_t ascii_to_keycode_lut[0x80] PROGMEM = {
   /*   P     Q     R     S     T     U     V     W                    */
     KC_P, KC_Q, KC_R, KC_S, KC_T, KC_U, KC_V, KC_W,
   /*   X     Y     Z      [         \       ]       ^      _                    */
-    KC_X, KC_Y, KC_Z, KC_LBRC, KC_BSLS, KC_RBRC, DE_CIRC, DE_MINS,
+    KC_X, DE_Y, DE_Z, KC_LBRC, KC_BSLS, KC_RBRC, DE_CIRC, DE_MINS,
   /*   `       a     b     c     d     e     f     g                    */
     DE_ACUT, KC_A, KC_B, KC_C, KC_D, KC_E, KC_F, KC_G,
   /*   h     i     j     k     l     m     n     o                    */
@@ -75,7 +75,7 @@ const uint8_t ascii_to_keycode_lut[0x80] PROGMEM = {
   /*    p    q     r     s     t     u     v     w                      */
     KC_P, KC_Q, KC_R, KC_S, KC_T, KC_U, KC_V, KC_W,
   /*    x    y     z      {        |        }        ~    DELETE                    */
-    KC_X, KC_Y, KC_Z, KC_LBRC, KC_BSLS, KC_RBRC, KC_GRV, KC_DEL
+    KC_X, DE_Y, DE_Z, KC_LBRC, KC_BSLS, KC_RBRC, KC_GRV, KC_DEL
 };
 
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- This template is entirely option and can be removed, but is here to help both you and us. -->
<!--- This text and anything on lines wrapped like this one will not show up in the final text. This text is to help us and you. -->

## Description
<!--- Describe your changes in detail -->
German keyboards usually have, opposed to the standard keyboards, QWERTZ and not QWERTY. This was not reflected in the `sendstring_german.h` which caused the letters y and z to be exchanged when using sendstring. (E.g. if you wanted to send "pretty", "prettz" would come out)

This was very simple to fix by just exchanging KC_Y with DE_Y (=KC_Z) and KC_Z with DE_Z (=KC_Y)
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Core
- [x] Bugfix
- [ ] New Feature
- [ ] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation


## Issues Fixed or Closed by this PR

* I didn't open an issue, since I had the fix on hand right away

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
