### PR TITLE
Fix mixed tabs/spaces and typos in keyboards/converter makefiles

### DIFF
--- a/keyboards/converter/adb_usb/rules.mk
+++ b/keyboards/converter/adb_usb/rules.mk
@@ -67,6 +67,6 @@ EXTRAKEY_ENABLE  = yes
 USB_HID_ENABLE   = yes
 BACKLIGHT_ENABLE = no
 #BLUETOOTH        = AdafruitBLE  # For Adafruit Feather 32U4 BLE support, uncomment this line
+CUSTOM_MATRIX    = yes
 
-CUSTOM_MATRIX = yes
 SRC = matrix.c adb.c led.c

--- a/keyboards/converter/adb_usb/rules.mk
+++ b/keyboards/converter/adb_usb/rules.mk
@@ -1,7 +1,7 @@
 # MCU name
-# atmega32u4 	Teensy2.0
-# atemga32u4	TMK Converter rev.1
-# atemga32u2	TMK Converter rev.2
+# atmega32u4  Teensy2.0
+# atemga32u4  TMK Converter rev.1
+# atemga32u2  TMK Converter rev.2
 MCU = atmega32u4
 
 # Processor frequency.
@@ -50,25 +50,23 @@ BOOTLOADER = caterina
 # Boot Section Size in *bytes*
 #   Teensy halfKay   512
 #   Teensy++ halfKay 1024
-#   Atmel DFU loader 4096	for TMK Converter rev.1/rev.2
+#   Atmel DFU loader 4096  for TMK Converter rev.1/rev.2
 #   LUFA bootloader  4096
 #   USBaspLoader     2048
 
 # Build Options
 #   comment out to disable the options.
 #
-BOOTMAGIC_ENABLE	= no			# Virtual DIP switch configuration(+1000)
-MOUSEKEY_ENABLE		= no			# Mouse keys(+4700)
-CONSOLE_ENABLE		= no			# Console for debug(+400)
-COMMAND_ENABLE		= no  		# Commands for debug and configuration
-SLEEP_LED_ENABLE 	= no  		# Breathing sleep LED during USB suspend
-NKRO_ENABLE 		  = no			# USB Nkey Rollover - not yet supported in LUFA
-EXTRAKEY_ENABLE		= yes
-USB_HID_ENABLE 		= yes
-BACKLIGHT_ENABLE 	= no
-#BLUETOOTH 			= AdafruitBLE   # For Adafruit Feather 32U4 BLE support, uncomment this line
+BOOTMAGIC_ENABLE = no   # Virtual DIP switch configuration(+1000)
+MOUSEKEY_ENABLE  = no   # Mouse keys(+4700)
+CONSOLE_ENABLE   = no   # Console for debug(+400)
+COMMAND_ENABLE   = no   # Commands for debug and configuration
+SLEEP_LED_ENABLE = no   # Breathing sleep LED during USB suspend
+NKRO_ENABLE      = no   # USB Nkey Rollover - not yet supported in LUFA
+EXTRAKEY_ENABLE  = yes
+USB_HID_ENABLE   = yes
+BACKLIGHT_ENABLE = no
+#BLUETOOTH        = AdafruitBLE  # For Adafruit Feather 32U4 BLE support, uncomment this line
 
 CUSTOM_MATRIX = yes
-SRC = matrix.c \
-      adb.c \
-			led.c
+SRC = matrix.c adb.c led.c

--- a/keyboards/converter/hp_46010a/rules.mk
+++ b/keyboards/converter/hp_46010a/rules.mk
@@ -39,7 +39,7 @@ OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
 
 # Bootloader
 #     This definition is optional, and if your keyboard supports multiple bootloaders of
-#     different sizes, comment this out, and the correct address will be loaded 
+#     different sizes, comment this out, and the correct address will be loaded
 #     automatically (+60). See bootloader.mk for all options.
 BOOTLOADER = halfkay
 
@@ -48,8 +48,8 @@ BOOTLOADER = halfkay
 #   the appropriate keymap folder that will get included automatically
 #
 BOOTMAGIC_ENABLE = no       # Virtual DIP switch configuration(+1000)
-MOUSEKEY_ENABLE = yes        # Mouse keys(+4700)
-EXTRAKEY_ENABLE = yes        # Audio control and System control(+450)
+MOUSEKEY_ENABLE = yes       # Mouse keys(+4700)
+EXTRAKEY_ENABLE = yes       # Audio control and System control(+450)
 CONSOLE_ENABLE = yes        # Console for debug(+400)
 COMMAND_ENABLE = no         # Commands for debug and configuration
 NKRO_ENABLE = yes           # Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
@@ -62,11 +62,9 @@ RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight.
 API_SYSEX_ENABLE = no
 SPLIT_KEYBOARD = no
 WAIT_FOR_USB = yes
-
-# Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
-SLEEP_LED_ENABLE = no    # Breathing sleep LED during USB suspend
-
 LAYOUTS_HAS_RGB = no
-
+# Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
+SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
 CUSTOM_MATRIX = yes
+
 SRC = matrix.c

--- a/keyboards/converter/hp_46010a/rules.mk
+++ b/keyboards/converter/hp_46010a/rules.mk
@@ -66,7 +66,7 @@ WAIT_FOR_USB = yes
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
 SLEEP_LED_ENABLE = no    # Breathing sleep LED during USB suspend
 
-LAYOUTS_HAS_RGB = NO
+LAYOUTS_HAS_RGB = no
 
 CUSTOM_MATRIX = yes
 SRC = matrix.c

--- a/keyboards/converter/ibm_5291/rules.mk
+++ b/keyboards/converter/ibm_5291/rules.mk
@@ -39,7 +39,7 @@ OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
 
 # Bootloader
 #     This definition is optional, and if your keyboard supports multiple bootloaders of
-#     different sizes, comment this out, and the correct address will be loaded 
+#     different sizes, comment this out, and the correct address will be loaded
 #     automatically (+60). See bootloader.mk for all options.
 BOOTLOADER = halfkay
 
@@ -62,11 +62,9 @@ RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight.
 API_SYSEX_ENABLE = no
 SPLIT_KEYBOARD = no
 WAIT_FOR_USB = yes
-
-# Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
-SLEEP_LED_ENABLE = no    # Breathing sleep LED during USB suspend
-
 LAYOUTS_HAS_RGB = no
-
+# Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
+SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
 CUSTOM_MATRIX = yes
+
 SRC = matrix.c

--- a/keyboards/converter/ibm_5291/rules.mk
+++ b/keyboards/converter/ibm_5291/rules.mk
@@ -66,7 +66,7 @@ WAIT_FOR_USB = yes
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
 SLEEP_LED_ENABLE = no    # Breathing sleep LED during USB suspend
 
-LAYOUTS_HAS_RGB = NO
+LAYOUTS_HAS_RGB = no
 
 CUSTOM_MATRIX = yes
 SRC = matrix.c

--- a/keyboards/converter/ibm_terminal/rules.mk
+++ b/keyboards/converter/ibm_terminal/rules.mk
@@ -63,7 +63,7 @@ UNICODEMAP_ENABLE = yes
 BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
 RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight. 
 PS2_USE_USART = yes
-API_SYSEX_ENABLE = n
+API_SYSEX_ENABLE = no
 CUSTOM_MATRIX = yes
 
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE

--- a/keyboards/converter/ibm_terminal/rules.mk
+++ b/keyboards/converter/ibm_terminal/rules.mk
@@ -36,7 +36,6 @@ F_USB = $(F_CPU)
 # Interrupt driven control endpoint task(+60)
 OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
 
-
 # Boot Section Size in *bytes*
 #   Teensy halfKay   512
 #   Teensy++ halfKay 1024
@@ -46,11 +45,11 @@ OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
 OPT_DEFS += -DBOOTLOADER_SIZE=4096
 
 # Build Options
-#   change to "no" to disable the options, or define them in the Makefile in 
+#   change to "no" to disable the options, or define them in the Makefile in
 #   the appropriate keymap folder that will get included automatically
 #
 BOOTMAGIC_ENABLE = no       # Virtual DIP switch configuration(+1000)
-MOUSEKEY_ENABLE = yes        # Mouse keys(+4700)
+MOUSEKEY_ENABLE = yes       # Mouse keys(+4700)
 EXTRAKEY_ENABLE = yes       # Audio control and System control(+450)
 CONSOLE_ENABLE = no         # Console for debug(+400)
 COMMAND_ENABLE = no         # Commands for debug and configuration
@@ -61,12 +60,11 @@ AUDIO_ENABLE = no           # Audio output on port C6
 UNICODE_ENABLE = no         # Unicode
 UNICODEMAP_ENABLE = yes
 BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
-RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight. 
+RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight.
 PS2_USE_USART = yes
 API_SYSEX_ENABLE = no
-CUSTOM_MATRIX = yes
-
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
-SLEEP_LED_ENABLE = no    # Breathing sleep LED during USB suspend
+SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
+CUSTOM_MATRIX = yes
 
 SRC = matrix.c led.c

--- a/keyboards/converter/m0110_usb/rules.mk
+++ b/keyboards/converter/m0110_usb/rules.mk
@@ -1,7 +1,7 @@
 # MCU name
-# atmega32u4 	Teensy2.0
-# atemga32u4	TMK Converter rev.1
-# atemga32u2	TMK Converter rev.2
+# atmega32u4  Teensy2.0
+# atemga32u4  TMK Converter rev.1
+# atemga32u2  TMK Converter rev.2
 MCU = atmega32u4
 
 # Processor frequency.
@@ -43,31 +43,30 @@ OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
 
 # Bootloader
 #     This definition is optional, and if your keyboard supports multiple bootloaders of
-#     different sizes, comment this out, and the correct address will be loaded 
+#     different sizes, comment this out, and the correct address will be loaded
 #     automatically (+60). See bootloader.mk for all options.
 BOOTLOADER = caterina
 
 # Boot Section Size in *bytes*
 #   Teensy halfKay   512
 #   Teensy++ halfKay 1024
-#   Atmel DFU loader 4096	for TMK Converter rev.1/rev.2
+#   Atmel DFU loader 4096  for TMK Converter rev.1/rev.2
 #   LUFA bootloader  4096
 #   USBaspLoader     2048
 
 # Build Options
 #   comment out to disable the options.
 #
-BOOTMAGIC_ENABLE	= no			# Virtual DIP switch configuration(+1000)
-MOUSEKEY_ENABLE		= no			# Mouse keys(+4700)
-CONSOLE_ENABLE		= yes			# Console for debug(+400)
-COMMAND_ENABLE		= no  			# Commands for debug and configuration
-SLEEP_LED_ENABLE 	= no  			# Breathing sleep LED during USB suspend
-NKRO_ENABLE 		= no			# USB Nkey Rollover - not yet supported in LUFA
-EXTRAKEY_ENABLE		= yes	
-USB_HID_ENABLE 		= yes
-BACKLIGHT_ENABLE 	= no
-#BLUETOOTH 			= AdafruitBLE   # For Adafruit Feather 32U4 BLE support, uncomment this line
+BOOTMAGIC_ENABLE = no   # Virtual DIP switch configuration(+1000)
+MOUSEKEY_ENABLE  = no   # Mouse keys(+4700)
+CONSOLE_ENABLE   = yes  # Console for debug(+400)
+COMMAND_ENABLE   = no   # Commands for debug and configuration
+SLEEP_LED_ENABLE = no   # Breathing sleep LED during USB suspend
+NKRO_ENABLE      = no   # USB Nkey Rollover - not yet supported in LUFA
+EXTRAKEY_ENABLE  = yes
+USB_HID_ENABLE   = yes
+BACKLIGHT_ENABLE = no
+#BLUETOOTH        = AdafruitBLE  # For Adafruit Feather 32U4 BLE support, uncomment this line
 
 CUSTOM_MATRIX = yes
-SRC = matrix.c \
-      m0110.c
+SRC = matrix.c m0110.c

--- a/keyboards/converter/m0110_usb/rules.mk
+++ b/keyboards/converter/m0110_usb/rules.mk
@@ -67,6 +67,6 @@ EXTRAKEY_ENABLE  = yes
 USB_HID_ENABLE   = yes
 BACKLIGHT_ENABLE = no
 #BLUETOOTH        = AdafruitBLE  # For Adafruit Feather 32U4 BLE support, uncomment this line
+CUSTOM_MATRIX    = yes
 
-CUSTOM_MATRIX = yes
 SRC = matrix.c m0110.c

--- a/keyboards/converter/palm_usb/rules.mk
+++ b/keyboards/converter/palm_usb/rules.mk
@@ -9,38 +9,34 @@ OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
 BOOTLOADER = caterina
 
 # Build Options
-#   change to "no" to disable the options, or define them in the Makefile in 
+#   change to "no" to disable the options, or define them in the Makefile in
 #   the appropriate keymap folder that will get included automatically
 #
 BOOTMAGIC_ENABLE = no       # Virtual DIP switch configuration(+1000)
 MOUSEKEY_ENABLE = no        # Mouse keys(+4700)
-EXTRAKEY_ENABLE = no       # Audio control and System control(+450)
-CONSOLE_ENABLE = yes         # Console for debug(+400)
-COMMAND_ENABLE = yes         # Commands for debug and configuration
-NKRO_ENABLE = no           # Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+EXTRAKEY_ENABLE = no        # Audio control and System control(+450)
+CONSOLE_ENABLE = yes        # Console for debug(+400)
+COMMAND_ENABLE = yes        # Commands for debug and configuration
+NKRO_ENABLE = no            # Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
 BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 MIDI_ENABLE = no            # MIDI controls
 AUDIO_ENABLE = no           # Audio output on port C6
 UNICODE_ENABLE = no         # Unicode
-UNICODEMAP_ENABLE = no 
+UNICODEMAP_ENABLE = no
 BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
-RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight. 
+RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight.
+# Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
+SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
+#HARDWARE_SERIAL = yes
 CUSTOM_MATRIX = yes
 
-# Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
-SLEEP_LED_ENABLE = no    # Breathing sleep LED during USB suspend
-
-#HARDWARE_SERIAL = yes
-
 SRC += matrix.c
-
 ifdef HARDWARE_SERIAL
-	# untested with palm_usb
-        SRC += protocol/serial_uart.c
-        OPT_DEFS += -DHARDWARE_SERIAL
+  # Untested with palm_usb
+  SRC += protocol/serial_uart.c
+  OPT_DEFS += -DHARDWARE_SERIAL
 else
-        SRC += protocol/serial_soft.c
+  SRC += protocol/serial_soft.c
 endif
 
 DEFAULT_FOLDER = converter/palm_usb/stowaway
-

--- a/keyboards/converter/sun_usb/rules.mk
+++ b/keyboards/converter/sun_usb/rules.mk
@@ -9,14 +9,14 @@ OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
 BOOTLOADER = lufa-dfu
 
 # Build Options
-#   change to "no" to disable the options, or define them in the Makefile in 
+#   change to "no" to disable the options, or define them in the Makefile in
 #   the appropriate keymap folder that will get included automatically
 #
 BOOTMAGIC_ENABLE = no       # Virtual DIP switch configuration(+1000)
-MOUSEKEY_ENABLE = yes        # Mouse keys(+4700)
+MOUSEKEY_ENABLE = yes       # Mouse keys(+4700)
 EXTRAKEY_ENABLE = yes       # Audio control and System control(+450)
-CONSOLE_ENABLE = yes         # Console for debug(+400)
-COMMAND_ENABLE = yes         # Commands for debug and configuration
+CONSOLE_ENABLE = yes        # Console for debug(+400)
+COMMAND_ENABLE = yes        # Commands for debug and configuration
 NKRO_ENABLE = yes           # Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
 BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 MIDI_ENABLE = no            # MIDI controls
@@ -24,21 +24,18 @@ AUDIO_ENABLE = no           # Audio output on port C6
 UNICODE_ENABLE = no         # Unicode
 UNICODEMAP_ENABLE = yes
 BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
-RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight. 
+RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight.
+# Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
+SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
+#HARDWARE_SERIAL = yes
 CUSTOM_MATRIX = yes
 
-# Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
-SLEEP_LED_ENABLE = no    # Breathing sleep LED during USB suspend
-
-#HARDWARE_SERIAL = yes
-
 SRC += matrix.c led.c
-
 ifdef HARDWARE_SERIAL
-        SRC += protocol/serial_uart.c
-        OPT_DEFS += -DHARDWARE_SERIAL
+  SRC += protocol/serial_uart.c
+  OPT_DEFS += -DHARDWARE_SERIAL
 else
-        SRC += protocol/serial_soft.c
+  SRC += protocol/serial_soft.c
 endif
 
 DEFAULT_FOLDER = converter/sun_usb/type5

--- a/keyboards/converter/usb_usb/rules.mk
+++ b/keyboards/converter/usb_usb/rules.mk
@@ -1,7 +1,6 @@
 # MCU name
 MCU = atmega32u4
 
-
 # Processor frequency.
 #     This will define a symbol, F_CPU, in all source code files equal to the
 #     processor frequency in Hz. You can then use this symbol in your source code to
@@ -22,7 +21,6 @@ MCU = atmega32u4
 F_CPU ?= 16000000
 
 DEFAULT_FOLDER = converter/usb_usb/hasu
-
 
 #
 # LUFA specific
@@ -45,7 +43,7 @@ F_USB = $(F_CPU)
 
 # Bootloader
 #     This definition is optional, and if your keyboard supports multiple bootloaders of
-#     different sizes, comment this out, and the correct address will be loaded 
+#     different sizes, comment this out, and the correct address will be loaded
 #     automatically (+60). See bootloader.mk for all options.
 BOOTLOADER = caterina
 
@@ -55,15 +53,15 @@ OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
 # Build Options
 #   comment out to disable the options.
 #
-# BOOTMAGIC_ENABLE	= yes	# Virtual DIP switch configuration(+1000)
-# MOUSEKEY_ENABLE		= yes	# Mouse keys(+4700)
-EXTRAKEY_ENABLE		= yes	# Audio control and System control(+450)
-# CONSOLE_ENABLE		= yes	# Console for debug(+400)
-# COMMAND_ENABLE		= yes  # Commands for debug and configuration
-# SLEEP_LED_ENABLE = yes  # Breathing sleep LED during USB suspend
-# NKRO_ENABLE = yes	# USB Nkey Rollover - not yet supported in LUFA
-# BACKLIGHT_ENABLE = yes
-USB_HID_ENABLE = yes
+#BOOTMAGIC_ENABLE = yes  # Virtual DIP switch configuration(+1000)
+#MOUSEKEY_ENABLE  = yes  # Mouse keys(+4700)
+EXTRAKEY_ENABLE  = yes  # Audio control and System control(+450)
+#CONSOLE_ENABLE   = yes  # Console for debug(+400)
+#COMMAND_ENABLE   = yes  # Commands for debug and configuration
+#SLEEP_LED_ENABLE = yes  # Breathing sleep LED during USB suspend
+#NKRO_ENABLE      = yes  # USB Nkey Rollover - not yet supported in LUFA
+#BACKLIGHT_ENABLE = yes
+USB_HID_ENABLE   = yes
+CUSTOM_MATRIX    = yes
 
-CUSTOM_MATRIX = yes
 SRC = custom_matrix.cpp

--- a/keyboards/converter/xt_usb/rules.mk
+++ b/keyboards/converter/xt_usb/rules.mk
@@ -14,7 +14,6 @@ MCU = atmega32u4
 #     software delays.
 F_CPU = 16000000
 
-
 #
 # LUFA specific
 #
@@ -42,21 +41,19 @@ OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
 # BOOTLOADER = caterina # Pro Micro
 BOOTLOADER = halfkay # Teensy
 
-
 # Build Options
 #   comment out to disable the options.
 #
-BOOTMAGIC_ENABLE = no	# Virtual DIP switch configuration(+1000)
-MOUSEKEY_ENABLE = yes	# Mouse keys(+4700)
-EXTRAKEY_ENABLE = yes	# Audio control and System control(+450)
-CONSOLE_ENABLE = yes	# Console for debug(+400)
-COMMAND_ENABLE = yes   # Commands for debug and configuration
-NKRO_ENABLE = yes	# USB Nkey Rollover
-XT_ENABLE = yes
-CUSTOM_MATRIX = yes
+BOOTMAGIC_ENABLE = no   # Virtual DIP switch configuration(+1000)
+MOUSEKEY_ENABLE  = yes  # Mouse keys(+4700)
+EXTRAKEY_ENABLE  = yes  # Audio control and System control(+450)
+CONSOLE_ENABLE   = yes  # Console for debug(+400)
+COMMAND_ENABLE   = yes  # Commands for debug and configuration
+NKRO_ENABLE      = yes  # USB Nkey Rollover
+XT_ENABLE        = yes
+CUSTOM_MATRIX    = yes
 
+SRC = matrix.c led.c
 
 # Optimize size but this may cause error "relocation truncated to fit"
 #EXTRALDFLAGS = -Wl,--relax
-
-SRC = matrix.c led.c


### PR DESCRIPTION
## Description
I noticed in #5035 that `rules.mk` files in `keyboards/converter/adb_usb`, `keyboards/converter/m0110_usb` etc. mix tabs and spaces heavily, and not in a good or meaningful way. This PR replaces all tabs in those files with spaces, since none of the tabs were semantic (i.e. part of a recipe), and we prefer to use spaces for visual indentation.

I also fixed typos in some of the build options, e.g. `LAYOUTS_HAS_RGB = NO` and `API_SYSEX_ENABLE = n`.

Finally, I improved the visual alignment and ordering of build options, made them consistent between file; and I added some newlines that were missing at EOF.

## Types of changes
- [ ] Core
- [ ] Bugfix
- [ ] New Feature
- [ ] Enhancement/Optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
