### PR TITLE
Customizable mousekey accel

### DIFF
--- a/docs/feature_mouse_keys.md
+++ b/docs/feature_mouse_keys.md
@@ -47,12 +47,15 @@ You can see an example in the `_ML` here: https://github.com/qmk/qmk_firmware/bl
 The default speed for controlling the mouse with the keyboard is intentionally slow. You can adjust these parameters by adding these settings to your keymap's `config.h` file. All times are specified in milliseconds (ms).
 
 ```
-#define MOUSEKEY_DELAY             300
-#define MOUSEKEY_INTERVAL          50
-#define MOUSEKEY_MAX_SPEED         10
-#define MOUSEKEY_TIME_TO_MAX       20
-#define MOUSEKEY_WHEEL_MAX_SPEED   8
-#define MOUSEKEY_WHEEL_TIME_TO_MAX 40
+#define MOUSEKEY_DELAY                   300
+#define MOUSEKEY_INTERVAL                50
+#define MOUSEKEY_MAX_SPEED               10
+#define MOUSEKEY_TIME_TO_MAX             20
+#define MOUSEKEY_WHEEL_MAX_SPEED         8
+#define MOUSEKEY_WHEEL_TIME_TO_MAX       40
+#define MOUSEKEY_ACCEL0_SPEED(max_speed) max_speed / 4
+#define MOUSEKEY_ACCEL1_SPEED(max_speed) max_speed / 2
+#define MOUSEKEY_ACCEL2_SPEED(max_speed) max_speed
 ```
 
 
@@ -79,3 +82,7 @@ The top speed for scrolling movements.
 ### `MOUSEKEY_WHEEL_TIME_TO_MAX`
 
 How long you want to hold down a scroll key for until `MOUSEKEY_WHEEL_MAX_SPEED` is reached. This controls how quickly your scrolling will accelerate.
+
+### `MOUSEKEY_ACCEL*_SPEED`
+
+How movement is accelerated with acceleration keys (`KC_ACL*`). This macro takes max speed as an argument, which equals to `MOUSEKEY_MOVE_DELTA * MOUSEKEY_MAX_SPEED`, unless it is customized via [Command Console](feature_command.md).

--- a/tmk_core/common/mousekey.c
+++ b/tmk_core/common/mousekey.c
@@ -68,11 +68,11 @@ static uint8_t move_unit(void)
 {
     uint16_t unit;
     if (mousekey_accel & (1<<0)) {
-        unit = (MOUSEKEY_MOVE_DELTA * mk_max_speed)/4;
+        unit = MOUSEKEY_ACCEL0_SPEED((MOUSEKEY_MOVE_DELTA * mk_max_speed));
     } else if (mousekey_accel & (1<<1)) {
-        unit = (MOUSEKEY_MOVE_DELTA * mk_max_speed)/2;
+        unit = MOUSEKEY_ACCEL1_SPEED((MOUSEKEY_MOVE_DELTA * mk_max_speed));
     } else if (mousekey_accel & (1<<2)) {
-        unit = (MOUSEKEY_MOVE_DELTA * mk_max_speed);
+        unit = MOUSEKEY_ACCEL2_SPEED((MOUSEKEY_MOVE_DELTA * mk_max_speed));
     } else if (mousekey_repeat == 0) {
         unit = MOUSEKEY_MOVE_DELTA;
     } else if (mousekey_repeat >= mk_time_to_max) {

--- a/tmk_core/common/mousekey.h
+++ b/tmk_core/common/mousekey.h
@@ -60,6 +60,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MOUSEKEY_WHEEL_TIME_TO_MAX 40
 #endif
 
+#ifndef MOUSEKEY_ACCEL0_SPEED
+#define MOUSEKEY_ACCEL0_SPEED(max_speed) max_speed / 4
+#endif
+#ifndef MOUSEKEY_ACCEL1_SPEED
+#define MOUSEKEY_ACCEL1_SPEED(max_speed) max_speed / 2
+#endif
+#ifndef MOUSEKEY_ACCEL2_SPEED
+#define MOUSEKEY_ACCEL2_SPEED(max_speed) max_speed
+#endif
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
# Description

This PR makes it possible to customize `KC_ACL*` behavior with `#define` s.

I have considered to add some keycodes like `KC_ACL3`, `KC_ACL4`, ... to add options, but adding `#define`s seems to be more flexible and backward-compatible.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Core
- [ ] Bugfix
- [ ] New Feature
- [x] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [x] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

I have tried `make all`, but it failed with the following error:

```
Making 40percentclub/4x4 with keymap buswerks                                                          [ERRORS]
In file included from layouts/community/ortho_4x12/buswerks/keymap.c:1:0:
layouts/community/ortho_4x12/buswerks/keymap.c:81:13: error: 'xxxxxxx' undeclared here (not in a function)
             xxxxxxx, KC_LCTL, KC_LGUI, KC_LALT, LOWER  , KC_SPC , KC_SPC , RSE_ENT, KC_LEFT, KC_DOWN, KC_UP  , KC_RGHT \
             ^
keyboards/40percentclub/4x4/4x4.h:44:7: note: in definition of macro 'LAYOUT_ortho_4x12'
     { K30, K31, K32, K33, K34, K35, K36, K37, K38, K39, K3a, K3b, ___, ___, ___, ___} \
       ^~~
layouts/community/ortho_4x12/buswerks/keymap.c:84:17: error: implicit declaration of function 'LAYOUT_planck_grid' [-Werror=implicit-function-declaration]
     [_ADJUST] = LAYOUT_planck_grid(
                 ^~~~~~~~~~~~~~~~~~
```

This also happens without my changes, so I could not verify that my changes actually pass the `make all` test.