### PR TITLE
Add support for Quefrency left half with 2x5 macro section

### DIFF
--- a/keyboards/quefrency/keymaps/default65macro/config.h
+++ b/keyboards/quefrency/keymaps/default65macro/config.h
@@ -1,0 +1,24 @@
+/*
+This is the c configuration file for the keymap
+
+Copyright 2012 Jun Wako <wakojun@gmail.com>
+Copyright 2015 Jack Humbert
+Copyright 2018 Danny Nguyen <danny@keeb.io>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+// #define USE_I2C

--- a/keyboards/quefrency/keymaps/default65macro/keymap.c
+++ b/keyboards/quefrency/keymaps/default65macro/keymap.c
@@ -1,0 +1,35 @@
+#include QMK_KEYBOARD_H
+
+extern keymap_config_t keymap_config;
+
+// Each layer gets a name for readability, which is then used in the keymap matrix below.
+// The underscores don't mean anything - you can have a layer called STUFF or any other name.
+// Layer names don't all need to be of the same length, obviously, and you can also skip them
+// entirely and just use numbers.
+#define _BASE 0
+#define _FN1 1
+
+enum custom_keycodes {
+  QWERTY = SAFE_RANGE,
+};
+
+#define _______ KC_TRNS
+#define XXXXXXX KC_NO
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  [_BASE] = LAYOUT_65_with_macro(
+    KC_F1,   KC_F2,   KC_GESC, KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_DEL,  KC_BSPC, KC_HOME, \
+    KC_F3,   KC_F4,   KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS, KC_END, \
+    KC_F5,   KC_F6,   KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_ENT,  KC_PGUP, \
+    KC_F7,   KC_F8,   KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT, KC_UP,   KC_PGDN, \
+    KC_F9,   KC_F10,  KC_LCTL, KC_LALT, KC_LGUI, MO(_FN1),KC_SPC,           MO(_FN1),KC_SPC,  KC_RALT, KC_RCTL, KC_RGUI, KC_LEFT, KC_DOWN, KC_RGHT
+  ),
+
+  [_FN1] = LAYOUT_65_with_macro(
+    _______, _______, KC_GESC, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_DEL,  KC_BSPC, _______, \
+    _______, _______, RGB_TOG, RGB_MOD, _______, KC_UP,   _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, \
+    _______, _______, _______, _______, KC_LEFT, KC_DOWN, KC_RGHT, _______, _______, _______, _______, _______, _______, _______, _______, _______, \
+    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, \
+    _______, _______, KC_TILD, _______, _______, _______, _______,          _______, _______, _______, _______, _______, _______, _______, _______
+  )
+};

--- a/keyboards/quefrency/rev1/rev1.h
+++ b/keyboards/quefrency/rev1/rev1.h
@@ -56,3 +56,48 @@
     { RE1, RE2, RE9, RE4, RE5, RE6, RE7, RE8 }, \
     { KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, RA9, RB9 } \
   }
+
+#define LAYOUT_60_with_macro( \
+  LA9, LA8, LA1, LA2, LA3, LA4, LA5, LA6, LA7, RA1, RA2, RA3, RA4, RA5, RA6, RA7, RA8, \
+  LB9, LB8, LB1, LB2, LB3, LB4, LB5, LB6,      RB1, RB2, RB3, RB4, RB5, RB6, RB7, RB8, \
+  LC9, LC8, LC1, LC2, LC3, LC4, LC5, LC6,      RC1, RC2, RC3, RC4, RC5, RC6,      RC8, \
+  LD9, LD8, LD1,      LD3, LD4, LD5, LD6, LD7, RD1, RD2, RD3, RD4,      RD6, RD7, RD8, \
+  LE9, LE8, LE1, LE2, LE3,      LE5,      LE7, RE1, RE2,      RE4, RE5, RE6, RE7, RE8 \
+  ) \
+  { \
+    { LA1, LA2, LA3, LA4, LA5, LA6, LA7, LA8 }, \
+    { LB1, LB2, LB3, LB4, LB5, LB6, LB9, LB8 }, \
+    { LC1, LC2, LC3, LC4, LC5, LC6, LC9, LC8 }, \
+    { LD1, LD9, LD3, LD4, LD5, LD6, LD7, LD8 }, \
+    { LE1, LE2, LE3, LA9, LE5, LE9, LE7, LE8 }, \
+    { KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO }, \
+    { RA1, RA2, RA3, RA4, RA5, RA6, RA7, RA8 }, \
+    { RB1, RB2, RB3, RB4, RB5, RB6, RB7, RB8 }, \
+    { RC1, RC2, RC3, RC4, RC5, RC6, KC_NO, RC8 }, \
+    { RD1, RD2, RD3, RD4, KC_NO, RD6, RD7, RD8 }, \
+    { RE1, RE2, KC_NO, RE4, RE5, RE6, RE7, RE8 }, \
+    { KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO } \
+  }
+
+
+#define LAYOUT_65_with_macro( \
+  LA9, LA8, LA1, LA2, LA3, LA4, LA5, LA6, LA7, RA1, RA2, RA3, RA4, RA5, RA6, RA7, RA8, RA9, \
+  LB9, LB8, LB1, LB2, LB3, LB4, LB5, LB6,      RB1, RB2, RB3, RB4, RB5, RB6, RB7, RB8, RB9, \
+  LC9, LC8, LC1, LC2, LC3, LC4, LC5, LC6,      RC1, RC2, RC3, RC4, RC5, RC6,      RC8, RC9, \
+  LD9, LD8, LD1,      LD3, LD4, LD5, LD6, LD7, RD1, RD2, RD3, RD4,      RD6, RD7, RD8, RD9, \
+  LE9, LE8, LE1, LE2, LE3,      LE5,      LE7, RE1, RE2,      RE4, RE5, RE6, RE7, RE8, RE9 \
+  ) \
+  { \
+    { LA1, LA2, LA3, LA4, LA5, LA6, LA7, LA8 }, \
+    { LB1, LB2, LB3, LB4, LB5, LB6, LB9, LB8 }, \
+    { LC1, LC2, LC3, LC4, LC5, LC6, LC9, LC8 }, \
+    { LD1, LD9, LD3, LD4, LD5, LD6, LD7, LD8 }, \
+    { LE1, LE2, LE3, LA9, LE5, LE9, LE7, LE8 }, \
+    { KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO }, \
+    { RA1, RA2, RA3, RA4, RA5, RA6, RA7, RA8 }, \
+    { RB1, RB2, RB3, RB4, RB5, RB6, RB7, RB8 }, \
+    { RC1, RC2, RC3, RC4, RC5, RC6, RC9, RC8 }, \
+    { RD1, RD2, RD3, RD4, RD9, RD6, RD7, RD8 }, \
+    { RE1, RE2, RE9, RE4, RE5, RE6, RE7, RE8 }, \
+    { KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, RA9, RB9 } \
+  }


### PR DESCRIPTION
## Description
Adds support for new left half of Quefrency with 2x5 macro section. Backwards compatible with other Quefrency halves.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Core
- [ ] Bugfix
- [ ] New Feature
- [ ] Enhancement/Optimization
- [x] Keyboard (addition or update)
- [x] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation


## Issues Fixed or Closed by this PR

* 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
