### PR TITLE
Add another secure string emitter to the keymap

### DIFF
--- a/keyboards/tada68/keymaps/rys/keymap.c
+++ b/keyboards/tada68/keymaps/rys/keymap.c
@@ -7,6 +7,7 @@
 
 enum rys_keycodes {
   PSTOKEN = SAFE_RANGE,
+  QSTOKEN
 };
 
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
@@ -14,6 +15,11 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case PSTOKEN:
       if (record->event.pressed) {
         SEND_STRING(RYS_PSTOKEN);
+      }
+      break;
+    case QSTOKEN:
+      if (record->event.pressed) {
+        SEND_STRING(RYS_QSTOKEN);
       }
       break;
   }
@@ -59,7 +65,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     _______, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  _______, PSTOKEN, \
     _______, KC_BTN1, KC_UP,   KC_BTN2, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, \
     _______, KC_LEFT, KC_DOWN, KC_RGHT, _______, _______, _______, _______, _______, _______, _______, _______,          _______, KC_HOME, \
-    _______, _______, _______, _______, BL_DEC,  BL_TOGG, BL_INC,  _______, KC_VOLU, KC_VOLD, KC_MUTE, _______, _______, KC_MS_U, KC_END,  \
+    _______, _______, _______, _______, BL_DEC,  BL_TOGG, BL_INC,  QSTOKEN, KC_VOLU, KC_VOLD, KC_MUTE, _______, _______, KC_MS_U, KC_END,  \
     _______, _______, _______,                   RESET,                              _______, _______, _______, KC_MS_L, KC_MS_D, KC_MS_R
 	),
 };

--- a/keyboards/tada68/keymaps/rys/rules.mk
+++ b/keyboards/tada68/keymaps/rys/rules.mk
@@ -8,7 +8,6 @@ EXTRAKEY_ENABLE = yes       # Audio control and System control(+450)
 CONSOLE_ENABLE = no         # Console for debug(+400)
 COMMAND_ENABLE = yes        # Commands for debug and configuration
 NKRO_ENABLE = yes           # Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
-BACKLIGHT_ENABLE = yes      # Enable keyboard backlight functionality
 MIDI_ENABLE = no            # MIDI controls
 AUDIO_ENABLE = no           # Audio output on port C6
 UNICODE_ENABLE = no         # Unicode

--- a/keyboards/tada68/keymaps/rys/rules.mk
+++ b/keyboards/tada68/keymaps/rys/rules.mk
@@ -8,7 +8,7 @@ EXTRAKEY_ENABLE = yes       # Audio control and System control(+450)
 CONSOLE_ENABLE = no         # Console for debug(+400)
 COMMAND_ENABLE = yes        # Commands for debug and configuration
 NKRO_ENABLE = yes           # Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
-BACKLIGHT_ENABLE = yes       # Enable keyboard backlight functionality
+BACKLIGHT_ENABLE = yes      # Enable keyboard backlight functionality
 MIDI_ENABLE = no            # MIDI controls
 AUDIO_ENABLE = no           # Audio output on port C6
 UNICODE_ENABLE = no         # Unicode
@@ -17,4 +17,6 @@ RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight.
 SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
 
 RYS_PSTOKEN = $(shell security find-generic-password -a qmk -s tada68 -w)
+RYS_QSTOKEN = $(shell security find-generic-password -a qmk -s tada68-2 -w)
 CFLAGS += -DRYS_PSTOKEN=\"$(RYS_PSTOKEN)\"
+CFLAGS += -DRYS_QSTOKEN=\"$(RYS_QSTOKEN)\"


### PR DESCRIPTION
Adds support for fetching another securely stored string from the macOS keychain, to emit in the firmware.

<!--- This template is entirely option and can be removed, but is here to help both you and us. -->
<!--- This text and anything on lines wrapped like this one will not show up in the final text. This text is to help us and you. -->

## Description
Fetch another secure string in `rules.mk` using the `security` binary on macOS, and emit that with a new keycode in the safe range.

Fixes a tiny alignment foible in the makefile rules too. OCD.

I also wrote about the basic process and the threat model on my blog, [here](https://rys.sommefeldt.com/post/securely-define-qmk-firmware-macros/)!

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Core
- [ ] Bugfix
- [ ] New Feature
- [ ] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation


## Issues Fixed or Closed by this PR

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
