### PR TITLE
docker_build.sh: Docker requires access to hosts devices

### DIFF
--- a/util/docker_build.sh
+++ b/util/docker_build.sh
@@ -35,7 +35,7 @@ else
 fi
 if [ -n "$target" ]; then
 	if [ "$(uname)" = "Linux" ] || docker-machine active >/dev/null 2>&1; then
-		usb_args="--privileged -v /dev/bus/usb:/dev/bus/usb"
+		usb_args="--privileged -v /dev:/dev"
 	else
 		echo "Error: target requires docker-machine to work on your platform" >&2
 		echo "See http://gw.tnode.com/docker/docker-machine-with-usb-support-on-windows-macos" >&2
@@ -45,5 +45,5 @@ fi
 dir=$(pwd -W 2>/dev/null) || dir=$PWD  # Use Windows path if on Windows
 
 # Run container and build firmware
-docker run --rm $usb_args --interactive --tty -v "/dev:/dev" -v "$dir":/qmk_firmware qmkfm/qmk_firmware \
+docker run --rm -it $usb_args -v "$dir":/qmk_firmware qmkfm/qmk_firmware \
 	make "$keyboard${keymap:+:$keymap}${target:+:$target}"

--- a/util/docker_build.sh
+++ b/util/docker_build.sh
@@ -45,5 +45,5 @@ fi
 dir=$(pwd -W 2>/dev/null) || dir=$PWD  # Use Windows path if on Windows
 
 # Run container and build firmware
-docker run --rm $usb_args -v "$dir":/qmk_firmware qmkfm/qmk_firmware \
+docker run --rm $usb_args --interactive --tty -v "/dev:/dev" -v "$dir":/qmk_firmware qmkfm/qmk_firmware \
 	make "$keyboard${keymap:+:$keymap}${target:+:$target}"


### PR DESCRIPTION
## Description
Docker requires access to hosts `/dev` in order to find the correct serial devices. It's possible that this fix is only required on Linux as I am unable to test this on a Windows machine.

If somebody has access to a Windows machine with Docker I would appreciate help in testing this.

This also runs the container interactively which allows the user to
interupt the build with Ctrl-C. This smaller change is not a separate pull request mostly because it affects the same line and would cause a merge conflict.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Core
- [x] Bugfix
- [ ] New Feature
- [ ] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation


## Issues Fixed or Closed by this PR

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
