### PR TITLE
Remove unnecessary IS_COMMAND definitions in recently added keyboards

### DIFF
--- a/keyboards/meishi/config.h
+++ b/keyboards/meishi/config.h
@@ -104,11 +104,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
 
-/* key combination for magic key command */
-#define IS_COMMAND() ( \
-    keyboard_report->mods == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT)) \
-)
-
 /* control how magic key switches layers */
 //#define MAGIC_KEY_SWITCH_LAYER_WITH_FKEYS  true
 //#define MAGIC_KEY_SWITCH_LAYER_WITH_NKEYS  true

--- a/keyboards/scarletbandana/config.h
+++ b/keyboards/scarletbandana/config.h
@@ -15,8 +15,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef CONFIG_H
-#define CONFIG_H
+#pragma once
 
 #include "config_common.h"
 
@@ -54,10 +53,3 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #endif
 
 #define DEBOUNCING_DELAY 5
-
-/* key combination for command */
-#define IS_COMMAND() ( \
-    keyboard_report->mods == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT)) \
-)
-
-#endif

--- a/keyboards/sentraq/number_pad/config.h
+++ b/keyboards/sentraq/number_pad/config.h
@@ -76,8 +76,3 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
 #define DEBOUNCING_DELAY 5
-
-/* key combination for magic key command */
-#define IS_COMMAND() ( \
-    keyboard_report->mods == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT)) \
-)

--- a/tmk_core/protocol/usb_hid/test/config.h
+++ b/tmk_core/protocol/usb_hid/test/config.h
@@ -15,9 +15,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef CONFIG_H
-#define CONFIG_H
-
+#pragma once
 
 #define VENDOR_ID       0xFEED
 #define PRODUCT_ID      0xCAFE
@@ -25,16 +23,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MANUFACTURER    t.m.k.
 #define PRODUCT         USB to USB keyboard converter
 
-
 #define DESCRIPTION     Product from t.m.k. keyboard firmware project
-
 
 /* matrix size */
 #define MATRIX_ROWS 32
 #define MATRIX_COLS 8
-
-
-/* key combination for command */
-#define IS_COMMAND() (get_mods() == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT)))
-
-#endif


### PR DESCRIPTION
## Description
These made it past code review in #3397, #5047, #5054. Merlin also removed the definition in the Scarlet Bandana keyboard in #5058, but since the diffs are compatible there shouldn't be any conflicts between that PR and this one (I've double-checked and confirmed that this is the case, so this can be merged without any problems).

## Types of changes
- [ ] Core
- [ ] Bugfix
- [ ] New Feature
- [ ] Enhancement/Optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
