### PR TITLE
Fixed default Preonic keymap's encoder handling

### DIFF
--- a/keyboards/preonic/keymaps/default/keymap.c
+++ b/keyboards/preonic/keymaps/default/keymap.c
@@ -233,7 +233,7 @@ uint16_t muse_counter = 0;
 uint8_t muse_offset = 70;
 uint16_t muse_tempo = 50;
 
-void encoder_update(bool clockwise) {
+void encoder_update_user(uint8_t index, bool clockwise) {
   if (muse_mode) {
     if (IS_LAYER_ON(_RAISE)) {
       if (clockwise) {


### PR DESCRIPTION
The function had the wrong name & arguments. This commit fixes this.
This in turn should also close issue #4997

## Types of changes
- [ ] Core
- [x] Bugfix
- [ ] New Feature
- [ ] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation


## Issues Fixed or Closed by this PR

* #4997 