### PR TITLE
Enable custom chibios sub-platform

### DIFF
--- a/tmk_core/chibios.mk
+++ b/tmk_core/chibios.mk
@@ -39,9 +39,13 @@ include $(STARTUP_MK)
 # HAL-OSAL files (optional).
 include $(CHIBIOS)/os/hal/hal.mk
 
-PLATFORM_MK = $(CHIBIOS)/os/hal/ports/$(MCU_FAMILY)/$(MCU_SERIES)/platform.mk
+ifeq ("$(PLATFORM_NAME)","")
+	PLATFORM_NAME = platform
+endif
+
+PLATFORM_MK = $(CHIBIOS)/os/hal/ports/$(MCU_FAMILY)/$(MCU_SERIES)/$(PLATFORM_NAME).mk
 ifeq ("$(wildcard $(PLATFORM_MK))","")
-PLATFORM_MK = $(CHIBIOS_CONTRIB)/os/hal/ports/$(MCU_FAMILY)/$(MCU_SERIES)/platform.mk
+PLATFORM_MK = $(CHIBIOS_CONTRIB)/os/hal/ports/$(MCU_FAMILY)/$(MCU_SERIES)/$(PLATFORM_NAME).mk
 endif
 include $(PLATFORM_MK)
 


### PR DESCRIPTION
For following directory structure:
```
ls ./qmk_firmware/lib/chibios/os/hal/ports/STM32/STM32L4xx/
platform.mk
platform_l432.mk
```
This pull request enable to custom the correct platform makefile by add
```PLATFORM_NAME = platform_l432``` into the rules.mk 

## Description


## Types of changes
- [ ] Core
- [ ] Bugfix
- [ ] New Feature
- [x] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation