### PR TITLE
docker_build.sh: Run container in interactive mode

### DIFF
--- a/docs/getting_started_build_tools.md
+++ b/docs/getting_started_build_tools.md
@@ -129,12 +129,12 @@ If you have trouble and want to ask for help, it is useful to generate a *Win_Ch
 
 ## Docker
 
-If this is a bit complex for you, Docker might be the turn-key solution you need. After installing [Docker CE](https://docs.docker.com/install/#supported-platforms), run the following command from the `qmk_firmware` directory to build a keyboard/keymap:
+If this is a bit complex for you, Docker might be the turnkey solution you need. After installing [Docker CE](https://docs.docker.com/install/#supported-platforms), run the following command from the `qmk_firmware` directory to build a keyboard/keymap:
 ```bash
-util/docker_build.sh keyboard:keymap 
+util/docker_build.sh keyboard:keymap
 # For example: util/docker_build.sh ergodox_ez:steno
 ```
-This will compile the targeted keyboard/keymap and leave the resulting `.hex` or `.bin` file in the QMK directory for you to flash. If `:keymap` is omitted, the `default` keymap is used. Note that the parameter format is the same as when building with `make`.
+This will compile the desired keyboard/keymap and leave the resulting `.hex` or `.bin` file in the QMK directory for you to flash. If `:keymap` is omitted, the `default` keymap is used. Note that the parameter format is the same as when building with `make`.
 
 You can also start the script without any parameters, in which case it will ask you to input the build parameters one by one, which you may find easier to use:
 ```bash
@@ -147,7 +147,7 @@ There is also support for building _and_ flashing the keyboard straight from Doc
 util/docker_build.sh keyboard:keymap:target
 # For example: util/docker_build.sh planck/rev6:default:dfu-util
 ```
-If you're on Linux, this should work out of the box. On Windows and macOS, it requires [Docker Machine](http://gw.tnode.com/docker/docker-machine-with-usb-support-on-windows-macos/) to be running. This is tedious to set up, so it's not recommended; use QMK Toolbox instead.
+If you're on Linux, this should work out of the box. On Windows and macOS, it requires [Docker Machine](http://gw.tnode.com/docker/docker-machine-with-usb-support-on-windows-macos/) to be running. This is tedious to set up, so it's not recommended; use [QMK Toolbox](https://github.com/qmk/qmk_toolbox) instead.
 
 !> Docker for Windows requires [Hyper-V](https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v) to be enabled. This means that it cannot work on versions of Windows which don't have Hyper-V, such as Windows 7, Windows 8 and **Windows 10 Home**.
 

--- a/util/docker_build.sh
+++ b/util/docker_build.sh
@@ -39,6 +39,7 @@ if [ -n "$target" ]; then
 	else
 		echo "Error: target requires docker-machine to work on your platform" >&2
 		echo "See http://gw.tnode.com/docker/docker-machine-with-usb-support-on-windows-macos" >&2
+		echo "Consider flashing with QMK Toolbox (https://github.com/qmk/qmk_toolbox) instead" >&2
 		exit 3
 	fi
 fi

--- a/util/docker_build.sh
+++ b/util/docker_build.sh
@@ -45,5 +45,5 @@ fi
 dir=$(pwd -W 2>/dev/null) || dir=$PWD  # Use Windows path if on Windows
 
 # Run container and build firmware
-docker run --rm $usb_args -v "$dir":/qmk_firmware qmkfm/qmk_firmware \
+docker run --rm -it $usb_args -v "$dir":/qmk_firmware qmkfm/qmk_firmware \
 	make "$keyboard${keymap:+:$keymap}${target:+:$target}"


### PR DESCRIPTION
Taken from #5063. Runs the container in interactive mode so the build can be interrupted with Ctrl+C. No downsides.

Also add a message to the script recommending QMK Toolbox for flashing on Mac and Windows. Tweak the Docker docs as well.