### PR TITLE
Plain60 rgb

### DIFF
--- a/keyboards/plain60/config.h
+++ b/keyboards/plain60/config.h
@@ -17,7 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
-#include QMK_KEYBOARD_CONFIG_H
+#include "config_common.h"
 
 /* USB Device descriptor parameter */
 #define VENDOR_ID       0x4705

--- a/keyboards/plain60/keymaps/RGB/config.h
+++ b/keyboards/plain60/keymaps/RGB/config.h
@@ -15,7 +15,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "../../config.h"
+#pragma once
 
 /* RGB Underglow */
 #define RGB_DI_PIN B7

--- a/keyboards/plain60/keymaps/RGB/config.h
+++ b/keyboards/plain60/keymaps/RGB/config.h
@@ -1,0 +1,26 @@
+/*
+Copyright 2019 Sebastian Spindler <sebastian.spindler@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "../../config.h"
+
+/* RGB Underglow */
+#define RGB_DI_PIN B7
+#define RGBLIGHT_ANIMATIONS
+#define RGBLED_NUM 30    			// Number of LEDs
+#define RGBLIGHT_HUE_STEP 8
+#define RGBLIGHT_SAT_STEP 8
+#define RGBLIGHT_VAL_STEP 8

--- a/keyboards/plain60/keymaps/RGB/keymap.c
+++ b/keyboards/plain60/keymaps/RGB/keymap.c
@@ -16,7 +16,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include QMK_KEYBOARD_H
-#include "config.h"
+
 #include "keymap_extras/keymap_german.h"
 
 //Layer renaming
@@ -32,9 +32,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MONKEY  LCTL(LALT(KC_DEL)) //ctrl+alt+del == monkey grip
 #define SPECIAL LT(_FUN, DE_CIRC)  //
 
-//Macro renaming
-#define KVM_SW  M(0)               //switch desktop macro for KVM
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
   [_DL] = LAYOUT(
@@ -42,36 +39,19 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
       KC_TAB,  KC_Q,    KC_W,    KC_E,   KC_R,      KC_T,    DE_Z,    KC_U,   KC_I,    KC_O, KC_P,   DE_UE,   DE_PLUS,          ______,   \
       SPECIAL, KC_A,    KC_S,    KC_D,   KC_F,      KC_G,    KC_H,    KC_J,   KC_K,    KC_L, DE_OE,  DE_AE,   DE_HASH,          KC_ENT,   \
       KC_LSFT, DE_LESS, DE_Y,    KC_X,   KC_C,      KC_V,    KC_B,    KC_N,   KC_M, KC_COMM, KC_DOT, DE_MINS,          KC_RSFT, MONKEY,   \
-      KC_LCTL, KC_LGUI, KC_LALT,                             KC_SPC                        , ______, KC_ALGR, KVM_SW,           KC_RCTL   ),
+      KC_LCTL, KC_LGUI, KC_LALT,                             KC_SPC                        , ______, KC_ALGR, TG(_LED),         KC_RCTL   ),
 
   [_FUN] = LAYOUT(
       ______, KC_F1,   KC_F2,   KC_F3,    KC_F4,   KC_F5,   KC_F6,  KC_F7,  KC_F8,  KC_F9, KC_F10, KC_F11,  KC_F12, ______, KC_DEL,   \
       ______, KC_PGUP, KC_UP,   KC_PGDN,  ______,  ______, ______, ______, ______, ______, ______, ______,  ______,         ______,   \
       ______, KC_LEFT, KC_DOWN, KC_RIGHT, KC_HOME, ______, ______, KC_END, ______, ______, ______, ______,  ______,         ______,   \
-      ______, ______, ______,   ______,   ______,  ______, ______, ______, ______, ______, ______, ______,           KC_UP, TG(_LED), \
+      ______, ______, ______,   ______,   ______,  ______, ______, ______, ______, ______, ______, ______,           KC_UP, ______,   \
       ______, ______, ______,                              ______                        , ______, KC_LEFT, KC_DOWN,        KC_RIGHT  ),
 
   [_LED] = LAYOUT(
-      ______, ______,  ______,  ______,  ______,  ______,  ______,  ______, ______, ______, ______, ______, ______, ______, RESET,    \
-      ______, RGB_TOG, RGB_MI,  RGB_MD,  RGB_ST,  ______,  ______,  ______, ______, ______, ______, ______, ______,         ______,   \
-      ______, RGB_HUI, RGB_HUD, RGB_SAI, RGB_SAD, ______,  ______,  ______, ______, ______, ______, ______, ______,         ______,   \
-      ______, ______,  RGB_VAI, RGB_VAD, ______,  ______,  ______,  ______, ______, ______, ______, ______,         ______, TG(_LED), \
-      ______, ______,  ______,                             ______                         , ______, ______, ______,         ______    ),
-};
-
-// Macros
-const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt) {
-
-  // MACRODOWN only works in this function
-  	switch(id) {
-		case 0:
-			return (record->event.pressed ?
-					MACRO( T(SLCK), W(100), T(SLCK), W(150), T(ENT), END )
-					:MACRO( END ));
-			break;
-		default:
-			break;
-  }
-
-  return MACRO_NONE;
+      ______, ______,  ______,  ______,  ______,  ______,  ______,  ______, ______, ______, ______, ______, ______,   ______, RESET,    \
+      ______, RGB_TOG, RGB_MI,  RGB_MD,  RGB_ST,  ______,  ______,  ______, ______, ______, ______, ______, ______,           ______,   \
+      ______, RGB_HUI, RGB_HUD, RGB_SAI, RGB_SAD, ______,  ______,  ______, ______, ______, ______, ______, ______,           ______,   \
+      ______, ______,  RGB_VAI, RGB_VAD, ______,  ______,  ______,  ______, ______, ______, ______, ______,           ______, ______,   \
+      ______, ______,  ______,                             ______                         , ______, ______, TG(_LED),         ______    ),
 };

--- a/keyboards/plain60/keymaps/RGB/keymap.c
+++ b/keyboards/plain60/keymaps/RGB/keymap.c
@@ -1,0 +1,77 @@
+/*
+Copyright 2019 Sebastian Spindler <sebastian.spindler@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include QMK_KEYBOARD_H
+#include "config.h"
+#include "keymap_extras/keymap_german.h"
+
+//Layer renaming
+#define _DL  0                     //default
+#define _FUN 1                     //function layer
+#define _LED 2                     //LED configurations
+
+//Keymapping renaming
+#define ______  KC_TRNS            //renaming KC_TRNS for readability in keymaps
+#define RGB_MI  RGB_MODE_FORWARD   //increase RGB mode
+#define RGB_MD  RGB_MODE_REVERSE   //decrease RGB mode
+#define RGB_ST  RGB_M_P            //rgb static
+#define MONKEY  LCTL(LALT(KC_DEL)) //ctrl+alt+del == monkey grip
+#define SPECIAL LT(_FUN, DE_CIRC)  //
+
+//Macro renaming
+#define KVM_SW  M(0)               //switch desktop macro for KVM
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+  [_DL] = LAYOUT(
+      KC_ESC,  KC_1,    KC_2,    KC_3,   KC_4,      KC_5,    KC_6,    KC_7,   KC_8,    KC_9, KC_0,   DE_SS,   DE_ACUT, ______, KC_BSPC,   \
+      KC_TAB,  KC_Q,    KC_W,    KC_E,   KC_R,      KC_T,    DE_Z,    KC_U,   KC_I,    KC_O, KC_P,   DE_UE,   DE_PLUS,          ______,   \
+      SPECIAL, KC_A,    KC_S,    KC_D,   KC_F,      KC_G,    KC_H,    KC_J,   KC_K,    KC_L, DE_OE,  DE_AE,   DE_HASH,          KC_ENT,   \
+      KC_LSFT, DE_LESS, DE_Y,    KC_X,   KC_C,      KC_V,    KC_B,    KC_N,   KC_M, KC_COMM, KC_DOT, DE_MINS,          KC_RSFT, MONKEY,   \
+      KC_LCTL, KC_LGUI, KC_LALT,                             KC_SPC                        , ______, KC_ALGR, KVM_SW,           KC_RCTL   ),
+
+  [_FUN] = LAYOUT(
+      ______, KC_F1,   KC_F2,   KC_F3,    KC_F4,   KC_F5,   KC_F6,  KC_F7,  KC_F8,  KC_F9, KC_F10, KC_F11,  KC_F12, ______, KC_DEL,   \
+      ______, KC_PGUP, KC_UP,   KC_PGDN,  ______,  ______, ______, ______, ______, ______, ______, ______,  ______,         ______,   \
+      ______, KC_LEFT, KC_DOWN, KC_RIGHT, KC_HOME, ______, ______, KC_END, ______, ______, ______, ______,  ______,         ______,   \
+      ______, ______, ______,   ______,   ______,  ______, ______, ______, ______, ______, ______, ______,           KC_UP, TG(_LED), \
+      ______, ______, ______,                              ______                        , ______, KC_LEFT, KC_DOWN,        KC_RIGHT  ),
+
+  [_LED] = LAYOUT(
+      ______, ______,  ______,  ______,  ______,  ______,  ______,  ______, ______, ______, ______, ______, ______, ______, RESET,    \
+      ______, RGB_TOG, RGB_MI,  RGB_MD,  RGB_ST,  ______,  ______,  ______, ______, ______, ______, ______, ______,         ______,   \
+      ______, RGB_HUI, RGB_HUD, RGB_SAI, RGB_SAD, ______,  ______,  ______, ______, ______, ______, ______, ______,         ______,   \
+      ______, ______,  RGB_VAI, RGB_VAD, ______,  ______,  ______,  ______, ______, ______, ______, ______,         ______, TG(_LED), \
+      ______, ______,  ______,                             ______                         , ______, ______, ______,         ______    ),
+};
+
+// Macros
+const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt) {
+
+  // MACRODOWN only works in this function
+  	switch(id) {
+		case 0:
+			return (record->event.pressed ?
+					MACRO( T(SLCK), W(100), T(SLCK), W(150), T(ENT), END )
+					:MACRO( END ));
+			break;
+		default:
+			break;
+  }
+
+  return MACRO_NONE;
+};

--- a/keyboards/plain60/keymaps/RGB/rules.mk
+++ b/keyboards/plain60/keymaps/RGB/rules.mk
@@ -19,6 +19,5 @@
 BOOTMAGIC_ENABLE = no	# Virtual DIP switch configuration(+1000)
 NKRO_ENABLE = yes		# USB Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
 RGBLIGHT_ENABLE = yes   # Enable keyboard underlight functionality (+4870)
-MIDI_ENABLE = no 		# MIDI controls
 RAW_ENABLE = no
 DYNAMIC_KEYMAP_ENABLE = no

--- a/keyboards/plain60/keymaps/RGB/rules.mk
+++ b/keyboards/plain60/keymaps/RGB/rules.mk
@@ -1,0 +1,24 @@
+#Copyright 2019 Sebastian Spindler <sebastian.spindler@gmail.com>
+
+#This program is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 2 of the License, or
+#(at your option) any later version.
+
+#This program is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Build Options
+#   comment out to disable the options.
+#
+BOOTMAGIC_ENABLE = no	# Virtual DIP switch configuration(+1000)
+NKRO_ENABLE = yes		# USB Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+RGBLIGHT_ENABLE = yes   # Enable keyboard underlight functionality (+4870)
+MIDI_ENABLE = no 		# MIDI controls
+RAW_ENABLE = no
+DYNAMIC_KEYMAP_ENABLE = no


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- This template is entirely option and can be removed, but is here to help both you and us. -->
<!--- This text and anything on lines wrapped like this one will not show up in the final text. This text is to help us and you. -->

## Description
Fixes an error with the Plain60 PCB when compiling QMK without VIA support enabled and also adds a new RGB keymap as an example how to enable RGB for the board (if you have soldered a WS2812b strip to it)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Core
- [x] Bugfix
- [ ] New Feature
- [ ] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation


## Issues Fixed or Closed by this PR

* None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
