### PR TITLE
Remove problematic unicode_map stub definition in process_unicodemap.c

### DIFF
--- a/keyboards/converter/ibm_terminal/keymaps/default/rules.mk
+++ b/keyboards/converter/ibm_terminal/keymaps/default/rules.mk
@@ -12,9 +12,8 @@ BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 MIDI_ENABLE = no            # MIDI controls
 AUDIO_ENABLE = no           # Audio output on port C6
 UNICODE_ENABLE = no         # Unicode
-UNICODEMAP_ENABLE = yes
 BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
-RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight. 
+RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight.
 PS2_USE_USART = yes
 API_SYSEX_ENABLE = no
 

--- a/keyboards/converter/ibm_terminal/rules.mk
+++ b/keyboards/converter/ibm_terminal/rules.mk
@@ -58,7 +58,6 @@ BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 MIDI_ENABLE = no            # MIDI controls
 AUDIO_ENABLE = no           # Audio output on port C6
 UNICODE_ENABLE = no         # Unicode
-UNICODEMAP_ENABLE = yes
 BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
 RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight.
 PS2_USE_USART = yes

--- a/keyboards/converter/palm_usb/rules.mk
+++ b/keyboards/converter/palm_usb/rules.mk
@@ -22,7 +22,6 @@ BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 MIDI_ENABLE = no            # MIDI controls
 AUDIO_ENABLE = no           # Audio output on port C6
 UNICODE_ENABLE = no         # Unicode
-UNICODEMAP_ENABLE = no
 BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
 RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight.
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE

--- a/keyboards/converter/sun_usb/rules.mk
+++ b/keyboards/converter/sun_usb/rules.mk
@@ -22,7 +22,6 @@ BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 MIDI_ENABLE = no            # MIDI controls
 AUDIO_ENABLE = no           # Audio output on port C6
 UNICODE_ENABLE = no         # Unicode
-UNICODEMAP_ENABLE = yes
 BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
 RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight.
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE

--- a/quantum/process_keycode/process_unicodemap.c
+++ b/quantum/process_keycode/process_unicodemap.c
@@ -17,9 +17,6 @@
 #include "process_unicodemap.h"
 #include "process_unicode_common.h"
 
-__attribute__((weak))
-const uint32_t PROGMEM unicode_map[] = {};
-
 void register_hex32(uint32_t hex) {
   bool onzerostart = true;
   for(int i = 7; i >= 0; i--) {

--- a/quantum/process_keycode/process_unicodemap.h
+++ b/quantum/process_keycode/process_unicodemap.h
@@ -19,5 +19,7 @@
 #include "quantum.h"
 #include "process_unicode_common.h"
 
+extern const uint32_t PROGMEM unicode_map[];
+
 void unicodemap_input_error(void);
 bool process_unicodemap(uint16_t keycode, keyrecord_t *record);


### PR DESCRIPTION
## Description
The weak `unicode_map` stub definition in `process_unicodemap.c` is unneeded and it causes errors when building with LTO enabled.

This definition is unneeded because `unicode_map` is supposed to be an external symbol that the user provides. Furthermore, you would want the build to fail if the user has `UNICODEMAP_ENABLE` on but hasn't defined `unicode_map`; having the stub definition prevents that and may lead to undefined behavior.
Essentially, much the same way you don't see `keymaps` defined anywhere in `quantum` or `tmk_core`, only declared with `extern`; so too should `unicode_map` only be declared in `process_unicodemap.h` and not defined anywhere in core code, only by the user.

This is the error that it causes when building with `-flto`:
<pre><details>
<summary>make whitefox:konstantin</summary>[...]
Linking: .build/whitefox_konstantin.elf                                                             [ERRORS]
 |
 | quantum/process_keycode/process_unicodemap.c:21:24: error: type of 'unicode_map' does not match original declaration [-Werror]
 |  const uint32_t PROGMEM unicode_map[] = {};
 |                         ^
 | users/konstantin/unicode.c:4:26: note: previously declared here
 |    const uint32_t PROGMEM unicode_map[] = {
 |                           ^
 | lto1: all warnings being treated as errors
 | lto-wrapper: fatal error: arm-none-eabi-gcc returned 1 exit status
 | compilation terminated.
 | /usr/lib/gcc/arm-none-eabi/5.4.1/../../../arm-none-eabi/bin/ld: error: lto-wrapper failed
 | collect2: error: ld returned 1 exit status
 |
tmk_core/rules.mk:297: recipe for target '.build/whitefox_konstantin.elf' failed
make[1]: *** [.build/whitefox_konstantin.elf] Error 1
Make finished with errors
</details></pre>
The types don't match because the arrays have different sizes, i.e. because the stub definition has size 0. I spent a couple of hours trying to address the error on its own before realizing the real issue is that the stub definition even exists.

## Types of changes
- [ ] Core
- [x] Bugfix
- [ ] New Feature
- [x] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
