### PR TITLE
Fix travis_compiled_push.sh script issue

### DIFF
--- a/util/travis_compiled_push.sh
+++ b/util/travis_compiled_push.sh
@@ -70,7 +70,7 @@ if [[ "$TRAVIS_COMMIT_MESSAGE" != *"[skip build]"* ]] ; then
 
 	# ignore errors here
   # In theory, this is more flexible, and will allow for additional expansion of additional types of files and other names
-  eval `mv -t compiled ../qmk_firmware/*_default.*(hex|bin))`
+  eval `mv -t compiled ../qmk_firmware/*_default.*(hex|bin)`
 
 	bash _util/generate_keyboard_page.sh
 	git add -A

--- a/util/travis_compiled_push.sh
+++ b/util/travis_compiled_push.sh
@@ -70,7 +70,7 @@ if [[ "$TRAVIS_COMMIT_MESSAGE" != *"[skip build]"* ]] ; then
 
 	# ignore errors here
   # In theory, this is more flexible, and will allow for additional expansion of additional types of files and other names
-  mv -t compiled ../qmk_firmware/*_default.*(hex|bin) || true
+  eval `mv -t compiled ../qmk_firmware/*_default.*(hex|bin))`
 
 	bash _util/generate_keyboard_page.sh
 	git add -A

--- a/util/travis_compiled_push.sh
+++ b/util/travis_compiled_push.sh
@@ -70,7 +70,7 @@ if [[ "$TRAVIS_COMMIT_MESSAGE" != *"[skip build]"* ]] ; then
 
 	# ignore errors here
   # In theory, this is more flexible, and will allow for additional expansion of additional types of files and other names
-  eval `mv -t compiled ../qmk_firmware/*_default.*(hex|bin)`
+  mv ../qmk_firmware/*_default.*[hb][ei][xn] ./compiled/ || true
 
 	bash _util/generate_keyboard_page.sh
 	git add -A


### PR DESCRIPTION
Looks like Travis/Trusty doesn't like the `mv` command I used:
```
util/travis_compiled_push.sh: line 73: syntax error near unexpected token `('
```

I think this should work properly. Or, at least, it doesn't error out on my local branch. 