### PR TITLE
[keymap] Add new keymap for TADA68

### DIFF
--- a/keyboards/tada68/keymaps/mattgemmell/keymap.c
+++ b/keyboards/tada68/keymaps/mattgemmell/keymap.c
@@ -3,8 +3,6 @@
 #define _BL 0
 #define _FL 1
 
-#define _______ KC_TRNS
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   /* Keymap _BL: (Base Layer) Default Layer
    * ,----------------------------------------------------------------.

--- a/keyboards/tada68/keymaps/mattgemmell/keymap.c
+++ b/keyboards/tada68/keymaps/mattgemmell/keymap.c
@@ -1,0 +1,50 @@
+#include QMK_KEYBOARD_H
+
+#define _BL 0
+#define _FL 1
+
+#define _______ KC_TRNS
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  /* Keymap _BL: (Base Layer) Default Layer
+   * ,----------------------------------------------------------------.
+   * |Esc | 1|  2|  3|  4|  5|  6|  7|  8|  9|  0|  -|  =|Backsp |~ ` |
+   * |----------------------------------------------------------------|
+   * |Tab  |  Q|  W|  E|  R|  T|  Y|  U|  I|  O|  P|  [|  ]|     |Del |
+   * |-------------------------------------------------------    -----|
+   * |CAPS   |  A|  S|  D|  F|  G|  H|  J|  K|  L|  ;| '|  #|Entr|PgUp|
+   * |----------------------------------------------------------------|
+   * |Shift|  \ |  Z|  X|  C|  V|  B|  N|  M|  ,|  .| /|Rshift|Up|PgDn|
+   * |----------------------------------------------------------------|
+   * |Ctrl|Alt |LGUI|        Space          |Alt| FN|Ctrl|Lef|Dow|Rig |
+   * `----------------------------------------------------------------'
+   */
+  [_BL] = LAYOUT_iso(
+    KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_GRV,  \
+    KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC,          KC_DEL,  \
+    KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_NUHS, KC_ENT,  KC_PGUP, \
+    KC_LSFT, KC_NUBS, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT, KC_UP,   KC_PGDN, \
+    KC_LCTL, KC_LALT, KC_LGUI,                   KC_SPC,                             KC_RALT, MO(_FL), KC_RCTL, KC_LEFT, KC_DOWN, KC_RGHT
+	),
+
+  /* Keymap _FL1: Function Layer 1
+   * ,----------------------------------------------------------------.
+   * |   | F1| F2| F3| F4| F5| F6| F7| F8| F9|F10|F11|F12|       | :D |
+   * |----------------------------------------------------------------|
+   * |     |LMB| Up|RMB|   |   |   |   |   |   |   |   |   |     |    |
+   * |-------------------------------------------------------    -----|
+   * |       |Lef|Dow|Rig|   |   |   |   |   |   |   |  |   |    |Home|
+   * |----------------------------------------------------------------|
+   * |     |   |   |   | L+|LED| L-|   | V+|  V-|Mut|  | MsBtn|↑ | End|
+   * |----------------------------------------------------------------|
+   * |    |    |    |      Reset            |   |   |    | ← | ↓ | →  |
+   * `----------------------------------------------------------------'
+   */
+  [_FL] = LAYOUT_iso(
+    _______, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  _______, _______, \
+    _______, KC_BTN1, KC_UP,   KC_BTN2, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, \
+    _______, KC_LEFT, KC_DOWN, KC_RGHT, _______, _______, _______, _______, _______, _______, _______, _______,          _______, KC_HOME, \
+    _______, _______, _______, _______, BL_DEC,  BL_TOGG, BL_INC,  _______, KC_VOLU, KC_VOLD, KC_MUTE, _______, _______, KC_MS_U, KC_END,  \
+    _______, _______, _______,                   _______,                            _______, _______, _______, KC_MS_L, KC_MS_D, KC_MS_R
+	),
+};

--- a/keyboards/tada68/keymaps/mattgemmell/readme.md
+++ b/keyboards/tada68/keymaps/mattgemmell/readme.md
@@ -1,0 +1,15 @@
+# Custom Tada68 layout for ISO UK with Apple-y tweaks
+
+This layout is based on the [ISO UK](../iso-uk) layout, with the following
+changes:
+
+Swap Win and Alt on the left side (Option and Command on macOS)
+
+## Installation
+
+Please see the [Tada68 readme](../../readme.md). Make the firmware wih the
+following command:
+
+```
+make tada68:mattgemmell:flashbin
+```

--- a/keyboards/tada68/keymaps/mattgemmell/rules.mk
+++ b/keyboards/tada68/keymaps/mattgemmell/rules.mk
@@ -1,0 +1,16 @@
+# Build Options
+#   change to "no" to disable the options, or define them in the Makefile in 
+#   the appropriate keymap folder that will get included automatically
+#
+BOOTMAGIC_ENABLE = no       # Virtual DIP switch configuration(+1000)
+MOUSEKEY_ENABLE = yes       # Mouse keys(+4700)
+EXTRAKEY_ENABLE = yes       # Audio control and System control(+450)
+CONSOLE_ENABLE = no         # Console for debug(+400)
+COMMAND_ENABLE = yes        # Commands for debug and configuration
+NKRO_ENABLE = yes           # Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+MIDI_ENABLE = no            # MIDI controls
+AUDIO_ENABLE = no           # Audio output on port C6
+UNICODE_ENABLE = no         # Unicode
+BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
+RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight. 
+SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend

--- a/keyboards/tada68/keymaps/rys/keymap.c
+++ b/keyboards/tada68/keymaps/rys/keymap.c
@@ -3,8 +3,6 @@
 #define _BL 0
 #define _FL 1
 
-#define _______ KC_TRNS
-
 enum rys_keycodes {
   PSTOKEN = SAFE_RANGE,
   QSTOKEN


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- This template is entirely option and can be removed, but is here to help both you and us. -->
<!--- This text and anything on lines wrapped like this one will not show up in the final text. This text is to help us and you. -->

## Description
<!--- Describe your changes in detail -->
Adds a new layout for the TADA68. It's similar to my `rys` layout where the main feature is `KC_LALT` and `KC_LGUI` swapped to work better on macOS, and it has tested fine on a brand new TADA68 build I'm giving away to someone. I'm starting the layout for him to work on and customise later!

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Core
- [ ] Bugfix
- [ ] New Feature
- [ ] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation


## Issues Fixed or Closed by this PR

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
