### PR TITLE
KBD19x Bootmagic Enable (lite) and other fixes

### DIFF
--- a/keyboards/kbdfans/kbd19x/kbd19x.c
+++ b/keyboards/kbdfans/kbd19x/kbd19x.c
@@ -17,6 +17,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "kbd19x.h"
 
+extern inline void kbd19x_caps_led_on(void);
+extern inline void kbd19x_caps_led_off(void);
+
+extern inline void kbd19x_sclk_led_on(void);
+extern inline void kbd19x_sclk_led_off(void);
+
+extern inline void kbd19x_nmlk_led_on(void);
+extern inline void kbd19x_nmlk_led_off(void);
+
 void matrix_init_kb(void) {
 	// put your keyboard start-up code here
 	// runs once when the firmware starts up

--- a/keyboards/kbdfans/kbd19x/kbd19x.h
+++ b/keyboards/kbdfans/kbd19x/kbd19x.h
@@ -15,8 +15,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef KBD19X_H
-#define KBD19X_H
+#pragma once
 
 #include "quantum.h"
 #include "led.h"
@@ -100,4 +99,3 @@ inline void kbd19x_nmlk_led_off(void)   { DDRB &= ~(1<<2); PORTB &= ~(1<<2); }
   {k05, k06, k07, k08, k15, k16, k17, k18, k25, k26, k27, k28, k36},\
   {XXX, k1e, k0e, k2e, k4e, k37, k38, k39, k45, k46, k47, k48, XXX},\
 }
-#endif

--- a/keyboards/kbdfans/kbd19x/readme.md
+++ b/keyboards/kbdfans/kbd19x/readme.md
@@ -8,6 +8,8 @@
 
 The KBD19x is a compact-1800 keyboard kit produced by KBDfans, offering a number of layout options.
 
+**Reset Sequence:** Using this firmware sets `BOOTLOADER_ENABLE` to `lite`. While plugging in, hold the top left key, commonly programmed as `Esc` to put your board into bootloader mode. 
+
 Keyboard Maintainer: [jshuf](https://github.com/jshuf)  
 Hardware Supported: KBD19x PCB  
 Hardware Availability: [KBDfans](https://kbdfans.cn)

--- a/keyboards/kbdfans/kbd19x/rules.mk
+++ b/keyboards/kbdfans/kbd19x/rules.mk
@@ -62,7 +62,7 @@ BOOTLOADER = atmel-dfu
 #   change yes to no to disable
 #
 BOOTMAGIC_ENABLE = lite      # Virtual DIP switch configuration(+1000)
-MOUSEKEY_ENABLE = no       # Mouse keys(+4700)
+MOUSEKEY_ENABLE = yes       # Mouse keys(+4700)
 EXTRAKEY_ENABLE = yes       # Audio control and System control(+450)
 CONSOLE_ENABLE = no        # Console for debug(+400)
 COMMAND_ENABLE = no        # Commands for debug and configuration

--- a/keyboards/kbdfans/kbd19x/rules.mk
+++ b/keyboards/kbdfans/kbd19x/rules.mk
@@ -61,7 +61,7 @@ BOOTLOADER = atmel-dfu
 # Build Options
 #   change yes to no to disable
 #
-BOOTMAGIC_ENABLE = no      # Virtual DIP switch configuration(+1000)
+BOOTMAGIC_ENABLE = lite      # Virtual DIP switch configuration(+1000)
 MOUSEKEY_ENABLE = no       # Mouse keys(+4700)
 EXTRAKEY_ENABLE = yes       # Audio control and System control(+450)
 CONSOLE_ENABLE = no        # Console for debug(+400)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- This template is entirely option and can be removed, but is here to help both you and us. -->
<!--- This text and anything on lines wrapped like this one will not show up in the final text. This text is to help us and you. -->

## Description
Responding to R_InvestCantReadGood on the #help channel of QMK Discord. KBD19x QMK port had the space+b disabled due to Bootmagic being set to `no`. 

Fixes implemented:
- bootmagic set to lite
- use pragma once in kbd19x h file
- found a compile issue when compiling default keymap. Realized led functions were not properly externed in the .c file. 
- lots of space left, might as well turn on mousekeys. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Core
- [x] Bugfix
- [ ] New Feature
- [x] Enhancement/Optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
