### PR TITLE
Updates to noroadsleft keymap for KC60

### DIFF
--- a/keyboards/kc60/keymaps/noroadsleft/keymap.c
+++ b/keyboards/kc60/keymaps/noroadsleft/keymap.c
@@ -1,4 +1,5 @@
 #include QMK_KEYBOARD_H
+#include "version.h"
 #include <sendstring_dvorak.h>
 //#include <sendstring_colemak.h>
 #include <print.h>
@@ -85,7 +86,8 @@ enum custom_keycodes {
   Q2_GRV,
   MC_UNDO,
   MC_PSTE,
-  NUBS_Z
+  NUBS_Z,
+  VRSN
 };
 
 
@@ -94,6 +96,7 @@ enum custom_keycodes {
 #define MODS_CTRL_MASK   (MOD_BIT(KC_LCTL)|MOD_BIT(KC_RCTRL))
 #define MODS_ALT_MASK    (MOD_BIT(KC_LALT)|MOD_BIT(KC_RALT))
 #define MODS_GUI_MASK    (MOD_BIT(KC_LGUI)|MOD_BIT(KC_RGUI))
+#define MODS_RALT_MASK   (MOD_BIT(KC_RALT))
 
 
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
@@ -237,12 +240,18 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
       break;
     case NUBS_Z:
       if (record->event.pressed) {
-        if ( modifiers & MODS_ALT_MASK ) {
+        if ( modifiers & MODS_RALT_MASK ) {
           SEND_STRING( SS_TAP(X_NONUS_BSLASH) );
         } else {
           SEND_STRING( SS_TAP(X_Z) );
         }
       };
+      return false;
+      break;
+    case VRSN:
+      if (record->event.pressed) {
+        SEND_STRING( QMK_KEYBOARD "/" QMK_KEYMAP " @ " QMK_VERSION );
+      }
       return false;
       break;
   } // switch()
@@ -394,7 +403,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   /* System layer */
   [_SYSTEM] = LAYOUT_60_ansi(
     //       2        3        4        5        6        7        8        9        10       11       12       13       14       15       16
-    TG(_SY), TO(_QW), TO(_DV), TO(_CM), GO_Q2,   XXXXXXX, XXXXXXX, XXXXXXX, RESET,   XXXXXXX, DEBUG,   XXXXXXX, XXXXXXX, XXXXXXX, \
+    TG(_SY), TO(_QW), TO(_DV), TO(_CM), GO_Q2,   XXXXXXX, XXXXXXX, XXXXXXX, RESET,   XXXXXXX, DEBUG,   XXXXXXX, VRSN,    XXXXXXX, \
     XXXXXXX, XXXXXXX, TG(_MC), XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, \
     XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,          \
     XXXXXXX, XXXXXXX, XXXXXXX, BL_DEC,  BL_TOGG, BL_INC,  BL_BRTG, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,                   \

--- a/keyboards/kc60/keymaps/noroadsleft/keymap.c
+++ b/keyboards/kc60/keymaps/noroadsleft/keymap.c
@@ -84,7 +84,8 @@ enum custom_keycodes {
   Q2_ESC,
   Q2_GRV,
   MC_UNDO,
-  MC_PSTE
+  MC_PSTE,
+  NUBS_Z
 };
 
 
@@ -234,6 +235,16 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
       };
       return false;
       break;
+    case NUBS_Z:
+      if (record->event.pressed) {
+        if ( modifiers & MODS_ALT_MASK ) {
+          SEND_STRING( SS_TAP(X_NONUS_BSLASH) );
+        } else {
+          SEND_STRING( SS_TAP(X_Z) );
+        }
+      };
+      return false;
+      break;
   } // switch()
   return true;
 };
@@ -252,7 +263,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     KC_GESC, KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, \
     KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS, \
     FW_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_ENT,           \
-    KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT,                   \
+    KC_LSFT, NUBS_Z,  KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT,                   \
     KC_LCTL, KC_LGUI, KC_LALT,                   KC_SPC,                                      KC_RALT, KC_RGUI, MO(_FW), KC_RCTL  \
   ),
 

--- a/keyboards/kc60/keymaps/noroadsleft/keymap.c
+++ b/keyboards/kc60/keymaps/noroadsleft/keymap.c
@@ -91,16 +91,13 @@ enum custom_keycodes {
 };
 
 
-// define modifiers
-#define MODS_SHIFT_MASK  (MOD_BIT(KC_LSHIFT)|MOD_BIT(KC_RSHIFT))
-#define MODS_CTRL_MASK   (MOD_BIT(KC_LCTL)|MOD_BIT(KC_RCTRL))
-#define MODS_ALT_MASK    (MOD_BIT(KC_LALT)|MOD_BIT(KC_RALT))
-#define MODS_GUI_MASK    (MOD_BIT(KC_LGUI)|MOD_BIT(KC_RGUI))
-#define MODS_RALT_MASK   (MOD_BIT(KC_RALT))
+/*******************
+** MODIFIER MASKS **
+*******************/
+#define MOD_MASK_RALT   (MOD_BIT(KC_RALT))
 
 
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
-  uint8_t modifiers = get_mods();
   switch(keycode) {
     // these are our macros!
     case F_CAPS:
@@ -134,7 +131,12 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
       return false;
     case G_FTCH:
       if (record->event.pressed) {
-        SEND_STRING("git fetch upstream");
+        if ( get_mods() & MOD_MASK_SHIFT ) {
+          clear_mods();
+          SEND_STRING("git pull upstream ");
+        } else {
+          SEND_STRING("git fetch upstream ");
+        }
       };
       return false;
     case G_COMM:
@@ -143,21 +145,14 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         layer_off(_MACROS);
       };
       return false;
-    case G_RST:
-      if (record->event.pressed) {
-        SEND_STRING("git histt -n 10" SS_TAP(X_ENTER) "git reset --soft ");
-        layer_off(_MACROS);
-      };
-      return false;
-    case G_C10R:
-      if (record->event.pressed) {
-        SEND_STRING("cf/");
-        layer_off(_MACROS);
-      };
-      return false;
     case G_BRCH:
       if (record->event.pressed) {
-        SEND_STRING("$(git branch-name)");
+        if ( get_mods() & MOD_MASK_SHIFT ) {
+          clear_mods();
+          SEND_STRING("master");
+        } else {
+          SEND_STRING("$(git branch-name)");
+        }
         layer_off(_MACROS);
       };
       return false;
@@ -206,7 +201,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
       return false;
     case MC_UNDO:
       if (record->event.pressed) {
-        if ( modifiers & MODS_SHIFT_MASK ) {
+        if ( get_mods() & MOD_MASK_SHIFT ) {
           SEND_STRING( SS_DOWN(X_LSHIFT) SS_DOWN(X_LGUI) SS_TAP(X_Z) SS_UP(X_LGUI) SS_UP(X_LSHIFT) );
         } else {
           SEND_STRING( SS_DOWN(X_LGUI) SS_TAP(X_Z) SS_UP(X_LGUI) );
@@ -215,7 +210,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
       return false;
     case MC_PSTE:
       if (record->event.pressed) {
-        if ( modifiers & MODS_SHIFT_MASK ) {
+        if ( get_mods() & MOD_MASK_SHIFT ) {
           SEND_STRING( SS_DOWN(X_LSHIFT) SS_DOWN(X_LGUI) SS_DOWN(X_LALT) SS_TAP(X_V) SS_UP(X_LALT) SS_UP(X_LGUI) SS_UP(X_LSHIFT) );
         } else {
           SEND_STRING( SS_DOWN(X_LGUI) SS_TAP(X_V) SS_UP(X_LGUI) );
@@ -224,7 +219,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
       return false;
     case NUBS_Z:
       if (record->event.pressed) {
-        if ( modifiers & MODS_RALT_MASK ) {
+        if ( get_mods() & MOD_MASK_RALT ) {
           SEND_STRING( SS_TAP(X_NONUS_BSLASH) );
         } else {
           SEND_STRING( SS_TAP(X_Z) );
@@ -377,8 +372,8 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     //       2        3        4        5        6        7        8        9        10       11       12       13       14       15       16
     TG(_MA), _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, \
     _______, _______, _______, G_PUSH,  _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, \
-    _______, _______, G_RST,   G_FTCH,  G_COMM,  _______, _______, _______, _______, T_L3DED, _______, _______, _______,          \
-    _______, _______, _______, G_C10R,  _______, G_BRCH,  SIGNA,   _______, _______, _______, _______, _______,                   \
+    _______, _______, _______, G_FTCH,  G_COMM,  _______, _______, _______, _______, T_L3DED, _______, _______, _______,          \
+    _______, _______, _______, _______, _______, G_BRCH,  SIGNA,   _______, _______, _______, _______, _______,                   \
     _______, _______, _______,                   _______,                                     _______, _______, NO_CHNG, _______  \
   ),
 

--- a/keyboards/kc60/keymaps/noroadsleft/keymap.c
+++ b/keyboards/kc60/keymaps/noroadsleft/keymap.c
@@ -122,60 +122,51 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         }
       };
       return false;
-      break;
     case T_L3DED:
       if (record->event.pressed) {
         SEND_STRING("lavak3DED ");
       };
       return false;
-      break;
     case G_PUSH:
       if (record->event.pressed) {
         SEND_STRING("git push origin ");
       };
       return false;
-      break;
     case G_FTCH:
       if (record->event.pressed) {
         SEND_STRING("git fetch upstream");
       };
       return false;
-      break;
     case G_COMM:
       if (record->event.pressed) {
         SEND_STRING("git commit -m \"\"" SS_TAP(X_LEFT));
         layer_off(_MACROS);
       };
       return false;
-      break;
     case G_RST:
       if (record->event.pressed) {
         SEND_STRING("git histt -n 10" SS_TAP(X_ENTER) "git reset --soft ");
         layer_off(_MACROS);
       };
       return false;
-      break;
     case G_C10R:
       if (record->event.pressed) {
         SEND_STRING("cf/");
         layer_off(_MACROS);
       };
       return false;
-      break;
     case G_BRCH:
       if (record->event.pressed) {
         SEND_STRING("$(git branch-name)");
         layer_off(_MACROS);
       };
       return false;
-      break;
     case SIGNA:
       if (record->event.pressed) {
         SEND_STRING("\\- @noroadsleft" SS_TAP(X_ENTER));
         layer_off(_MACROS);
       };
       return false;
-      break;
     case GO_Q2:
       if (record->event.pressed) {
         //default_layer_set(_QWERTY);
@@ -184,7 +175,6 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         //layer_off(_SYSTEM);
       };
       return false;
-      break;
     case Q2_ON:
       if (record->event.pressed) {
         SEND_STRING(SS_TAP(X_ENTER));
@@ -192,7 +182,6 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         layer_on(_QUAKE2_DVORAK);
       };
       return false;
-      break;
     case Q2_OFF:
       if (record->event.pressed) {
         SEND_STRING(SS_TAP(X_ENTER));
@@ -200,7 +189,6 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         layer_on(_QUAKE2);
       };
       return false;
-      break;
     case Q2_ESC:
       if (record->event.pressed) {
         SEND_STRING(SS_TAP(X_ESCAPE));
@@ -208,7 +196,6 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         layer_on(_QUAKE2);
       };
       return false;
-      break;
     case Q2_GRV:
       if (record->event.pressed) {
         SEND_STRING(SS_TAP(X_GRAVE));
@@ -217,7 +204,6 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         layer_on(_QUAKE2_CONSOLE);
       };
       return false;
-      break;
     case MC_UNDO:
       if (record->event.pressed) {
         if ( modifiers & MODS_SHIFT_MASK ) {
@@ -227,7 +213,6 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         }
       };
       return false;
-      break;
     case MC_PSTE:
       if (record->event.pressed) {
         if ( modifiers & MODS_SHIFT_MASK ) {
@@ -237,7 +222,6 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         }
       };
       return false;
-      break;
     case NUBS_Z:
       if (record->event.pressed) {
         if ( modifiers & MODS_RALT_MASK ) {
@@ -247,13 +231,11 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         }
       };
       return false;
-      break;
     case VRSN:
       if (record->event.pressed) {
         SEND_STRING( QMK_KEYBOARD "/" QMK_KEYMAP " @ " QMK_VERSION );
       }
       return false;
-      break;
   } // switch()
   return true;
 };

--- a/keyboards/kc60/keymaps/noroadsleft/readme.md
+++ b/keyboards/kc60/keymaps/noroadsleft/readme.md
@@ -1,6 +1,6 @@
 # @noroadsleft's KC60 keymap
 
-### Last updated: September 2, 2018, 1:03 PM UTC-0700
+### Last updated: February 14, 2019, 3:50 AM UTC-0800
 
 ![](https://i.imgur.com/tzhXQYI.jpg)
 

--- a/keyboards/kc60/keymaps/noroadsleft/readme_ch1.md
+++ b/keyboards/kc60/keymaps/noroadsleft/readme_ch1.md
@@ -7,8 +7,6 @@
   4. [Function Layers](./readme_ch4.md)
   5. [Other Layers](./readme_ch5.md)
 
-### Last updated: September 2, 2018, 1:03 PM UTC-0700
-
 
 ----
 

--- a/keyboards/kc60/keymaps/noroadsleft/readme_ch2.md
+++ b/keyboards/kc60/keymaps/noroadsleft/readme_ch2.md
@@ -7,8 +7,6 @@
   4. [Function Layers](./readme_ch4.md)
   5. [Other Layers](./readme_ch5.md)
 
-### Last updated: September 2, 2018, 1:03 PM UTC-0700
-
 
 ----
 

--- a/keyboards/kc60/keymaps/noroadsleft/readme_ch3.md
+++ b/keyboards/kc60/keymaps/noroadsleft/readme_ch3.md
@@ -7,8 +7,6 @@
   4. [Function Layers](./readme_ch4.md)
   5. [Other Layers](./readme_ch5.md)
 
-### Last updated: September 2, 2018, 1:03 PM UTC-0700
-
 
 ----
 
@@ -18,9 +16,9 @@
 
 These layers were born out of the confusion I have had trying to use the in-game chat and the console in [Quake 2](https://en.wikipedia.org/wiki/Quake_II). When Quake 2 came out, alternate keyboard layouts weren't really a thing. As a result, all in-game text input is hard-locked to US QWERTY, regardless of what the operating system is using for its input method.
 
-I'm attempting to solve this by some creative use of QMK's macro feature. The keycode in the System layer that enables these layers, [`GO_Q2`](./keymap.c#L386), is a [macro](./keymap.c#L175-183) that sets the default layer to the QWERTY layer, then turns the Quake 2 layer `_Q2` on. The result is a partially-overwritten QWERTY layer, that has some keycodes with some creative layer switching.
+I'm attempting to solve this by some creative use of QMK's macro feature. The keycode in the System layer that enables these layers, [`GO_Q2`](./keymap.c#L383), is a [macro](./keymap.c#L165-172) that sets the default layer to the QWERTY layer, then turns the Quake 2 layer `_Q2` on. The result is a partially-overwritten QWERTY layer, that has some keycodes with some creative layer switching.
 
-When I hit the `Enter` key (bound in-game to text chat), the [macro keycode](./keymap.c#L184-L191) I've created sends the keycode for `Enter`, then follows with enabling the Hardware Dvorak layer and its corresponding overlay. Now the game is in text chat mode, and my keyboard is in Dvorak. When I hit `Enter` again, another `Enter` [keycode macro](./keymap.c#L192-L199) is sent, which sends the message, then the macro brings me back to the standard QWERTY+Quake 2 setup. Hitting `Escape` instead runs a [macro](./keymap.c#L200-L207) that cancels the sending of the message, and undoes the layers.
+When I hit the `Enter` key (bound in-game to text chat), the [macro keycode](./keymap.c#L173-L179) I've created sends the keycode for `Enter`, then follows with enabling the Hardware Dvorak layer and its corresponding overlay. Now the game is in text chat mode, and my keyboard is in Dvorak. When I hit `Enter` again, another `Enter` [keycode macro](./keymap.c#L180-L186) is sent, which sends the message, then the macro brings me back to the standard QWERTY+Quake 2 setup. Hitting `Escape` instead runs a [macro](./keymap.c#L187-L193) that cancels the sending of the message, and undoes the layers.
 
 I have been testing this configuration for a few months. Sometimes I end up still in Dvorak mode without any text input systems (in-game chat or the console) running, but it pretty much always happens when I'm focused on the game, so I don't know the cause yet.
 

--- a/keyboards/kc60/keymaps/noroadsleft/readme_ch4.md
+++ b/keyboards/kc60/keymaps/noroadsleft/readme_ch4.md
@@ -7,8 +7,6 @@
   4. **Function Layers**
   5. [Other Layers](./readme_ch5.md)
 
-### Last updated: September 2, 2018, 1:03 PM UTC-0700
-
 
 ----
 
@@ -44,7 +42,7 @@ Based on the Windows function layer, but removes some functions that are pointle
 
 Keycode(s) Sent                   | Notes
 :-------------------------------- | :----
-[`Q2_GRV`](./keymap.c#L208-L216)  | Sends `KC_GRV`, then enables the Dvorak, Quake 2 Dvorak, and Quake 2 Console layers.
+[`Q2_GRV`](./keymap.c#L194-L201)  | Sends `KC_GRV`, then enables the Dvorak, Quake 2 Dvorak, and Quake 2 Console layers.
 
 
 

--- a/keyboards/kc60/keymaps/noroadsleft/readme_ch5.md
+++ b/keyboards/kc60/keymaps/noroadsleft/readme_ch5.md
@@ -7,8 +7,6 @@
   4. [Function Layers](./readme_ch4.md)
   5. **Other Layers**
 
-### Last updated: September 2, 2018, 1:03 PM UTC-0700
-
 
 ----
 
@@ -36,37 +34,79 @@ Tapping `Esc` exits the Macro layer, if the macro used doesn't do it automatical
 
 ### Macros
 
-[![lavak3DED](https://static-cdn.jtvnw.net/emoticons/v1/821796/1.0)](./keymap.c#L122-L127)  
-Inputs: `lavak3DED `  
-Twitch emote for [a streamer I watch a lot](https://www.twitch.tv/lavak3_).
+#### [T_L3DED](./keymap.c#L122-L126)
 
-[G_PUSH](./keymap.c#L128-L133)  
-Inputs: `git push origin `  
+Output: `lavak3DED `
+
+Twitch emote for [a streamer I watch a lot](https://www.twitch.tv/lavak3_).  
+![lavak3DED](https://static-cdn.jtvnw.net/emoticons/v1/821796/1.0)
+
+#### [G_PUSH](./keymap.c#L127-L131)
+
+Output: `git push origin `
+
 Everything from here down is related to Git or GitHub.
 
-[G_FTCH](./keymap.c#L134-L139)  
-Inputs: `git fetch upstream`
+#### [G_FTCH](./keymap.c#L132-L141)
 
-[G_COMM](./keymap.c#L140-L146)  
-Inputs: `git commit -m ""` `[Left]`  
+| Condition | Output |
+| :-------- | :----- |
+| If <kbd>Shift</kbd> is active | `git pull upstream ` |
+| Otherwise | `git fetch upstream ` |
+
+#### [G_COMM](./keymap.c#L142-L147)
+
+Output: `git commit -m ""` <kbd>Left</kbd>
+
 Readies a `git commit` command, moves the cursor between the quotation marks, then disables the Macro layer.
 
-[G_RST](./keymap.c#L147-L153)  
-Inputs: `git histt -n 10`, Enter, `git reset --soft `  
-Runs a [git alias](./readme_git.md) that shows my last ten commits, then readies a `git reset --soft`. For when I commit something too soon. Disables the Macro layer when complete.
+#### [G_BRCH](./keymap.c#L148-158)
 
-[G_C10R](./keymap.c#L154-L160)  
-Inputs: `cf/`  
-A branch prefix I use for my current work in QMK. Disables the Macro layer when finished.
+| Condition | Output |
+| :-------- | :----- |
+| If <kbd>Shift</kbd> is active | `master` |
+| Otherwise | `$(git branch-name)` |
 
-[G_BRCH](./keymap.c#L161-L167)  
-Inputs: `$(git branch-name)`  
-A [git alias](./readme_git.md) that returns the name of the current branch. Disables the Macro layer when finished.
+`$(git branch-name)` is a [git alias](./readme_git.md) that returns the name of the current branch. This macro disables the Macro layer when finished.
 
-[SIGNA](./keymap.c#L168-L174)  
-Inputs: `\- @noroadsleft` `[Enter]`  
+#### [SIGNA](./keymap.c#L159-L164)
+
+Output: `\- @noroadsleft` <kbd>Enter</kbd>
+
 Sometimes on GitHub, I sign my comments. Types my GitHub name in Markdown syntax, and then taps the `Enter` key. Disables the Macro layer when finished.
 
+#### [MC_UNDO](./keymap.c#L202-L210)
+
+| Condition | Output |
+| :-------- | :----- |
+| If <kbd>Shift</kbd> is active | <kbd>Shift</kbd> + <kbd>Command</kbd> + <kbd>Z</kbd> |
+| Otherwise | <kbd>Command</kbd> + <kbd>Z</kbd> |
+
+An Undo shortcut that turns to Redo if <kbd>Shift</kbd> is being held. I'm not sure that part is required to get that behavior, but it works as desired, so I'm not messing with it.
+
+#### [MC_PSTE](./keymap.c#L211-L219)
+
+| Condition | Output |
+| :-------- | :----- |
+| If <kbd>Shift</kbd> is active | <kbd>Shift</kbd> + <kbd>Command</kbd> + <kbd>Option</kbd> + <kbd>V</kbd> |
+| Otherwise | <kbd>Command</kbd> + <kbd>V</kbd> |
+
+The program I use this in uses <kbd>Shift</kbd> + <kbd>Command</kbd> + <kbd>Option</kbd> + <kbd>V</kbd> to paste while maintaining formatting (typeface, text size, etc.). Sometimes I want this and sometimes I don't. Using <kbd>Shift</kbd> changes the behavior.
+
+#### [NUBS_Z](./keymap.c#L220-L228)
+
+| Condition | Output |
+| :-------- | :----- |
+| If Right <kbd>Alt</kbd> is active | `KC_NUBS` |
+| Otherwise | `KC_Z` |
+
+Sometimes I type in languages from countries that use ISO layout, but my keyboard is ANSI, so I have one key fewer. This macro simulates the Non-US Backslash key if I use Right Alt + Z.
+
+#### [VRSN](./keymap.c#L229-L233)
+
+Outputs a string that tells me the Git commit from which my flashed firmware was built. Looks something like:
+
+    kc60/noroadsleft @ 0.6.240-20-ge91549-dirty
 
 ----
 

--- a/keyboards/kc60/keymaps/noroadsleft/readme_git.md
+++ b/keyboards/kc60/keymaps/noroadsleft/readme_git.md
@@ -4,45 +4,54 @@
 
 ```
 [alias]
-    # change branches
+    # Change branches
     co = checkout
     cob = checkout -b
 
-    # sync master
-    sync = "!f() { if [ $(git branch-name) != "master" ]; then git checkout master; fi; git pull upstream master; git push origin master; }; f"
+    # Cherry Pick
+    cp = cherry-pick
+
+    # Check out a Pull Request
+    cop = "!f() { git fetch upstream pull/$1/head:pr/$1; git checkout pr/$1; }; f"
+
+    # Sync master branch
+    sync = !git checkout master && git fetch upstream 2> /dev/null && git pull -n upstream master && git push origin master
+
+    # Return the abbreviated SHA-1 of the last three commits, oldest to newest
+    rl = rev-list -n 3 --abbrev-commit --reverse HEAD
+
+    # Add remote repo (for sending PRs to other forks, or checking out someone else's developments)
+    ar = "!f() { git remote add $1 https://github.com/$2/qmk_firmware.git; }; f"
 
     # Return the last five commits on the branch, in a more compact format
-    hist = log --pretty=format:\"%C(yellow)%h%Creset %Cgreen%ad%Creset%n   %w(100,0,3)%s%d [%an]%n\" --graph --date=iso-local -n 5
-    histm = log --pretty=format:\"%C(yellow)%h%Creset %w(100,0,3)%s%d [%an]\" --graph --date=iso-local -n 5
-    histt = log --pretty=format:\"%C(yellow)%h%Creset %<(88,trunc)%s [%an]\" --graph --date=iso-local -n 5
-    histb = log --reverse --pretty=format:\"- %<(98,trunc)%s [%an]\" --date=iso-local -n 5
+    hist  = log --pretty=format:\"%C(yellow)%h%Creset %Cgreen%ad%Creset %Cblue[%an%Cgreen% GK%Cblue]%C(yellow)%d%Creset%n  %w(100,0,2)%s%n\" --graph --date=iso-local -n 5
+    histt = log --pretty=format:\"* %C(yellow)%h%Creset %<(58,trunc)%s %Cblue%>(18,trunc)%an%Cgreen% G?%Creset @ %Cgreen%ad%Creset\" --date=iso-local -n 5
+    histb = log --reverse --pretty=format:\"- %Cblue%>(20,trunc)%an %Creset%<(97,trunc)%s\" --date=iso-local -n 5
+
+    # Follow a file's filename history
+    follow = log --follow --name-only --pretty=format:\"%C(yellow)commit %H%Creset%d\nAuthor: %an <%ae>\nDate:   %ad%n%n    %s%n\" --date=iso-local
 
     # compact diff
     df = "diff --compact-summary"
 
+    # List all the files changed in a commit
+    dt = "diff-tree --no-commit-id --name-only -r"
+
     # Short-form status
-    st = "!git status --short"
+    st = "!git status --short --untracked-files=no"
 
     # Returns the name of the current branch
     branch-name = "!git rev-parse --abbrev-ref HEAD"
+    bn          = "!git branch-name"                 # short-form of the above
 
-    # short-form of the above
-    bn = "!git branch-name"
+    # Compare commit counts between current branch and QMK master
+    cc = "!f() { git fetch upstream; echo \"[0;32m$(git branch-name)[0m vs. [0;31mupstream/master[0m\"; git rev-list --left-right --count $(git branch-name)...upstream/master; }; f"
 
-    po = "push origin ($(git branch-name))"
+    # Push to origin repo
+    po = "push origin $(git branch-name)"
 
     # List the stashes
     sl = "stash list"
-
-    # Show the contents of a numbered stash
-    # Syntax:
-    #   git st-show <int>
-    st-show = "!f() { git stash show stash@{$1} -p; }; f"
-
-    # Apply a stash, without deleting it from the list of stashes
-    # Syntax:
-    #   git st-copy <int>
-    st-copy = "!f() { git stash apply stash@{$1}; }; f"
 
     # Unstage a file
     unstage = "reset HEAD"
@@ -53,4 +62,15 @@
     # Compare local master repo to its upstream branch. If anything is returned, local branch has diverged from upstream.
     cm = "!f() { git fetch upstream master; git diff $(git branch-name) upstream/master --compact-summary; }; f"
     cml = "!f() { git fetch upstream master; git diff $(git branch-name) upstream/master; }; f"
+
+    # Delete a branch from local and remote
+    del-branch = "!f() { git branch -d $1; git push origin :$1; git fetch -p origin; }; f"
+
+    # Rebase with signatures
+    rbv = rebase --exec 'git commit --amend --no-edit -n -S' -i
+
+    # Force push without overwriting established history
+    pushf = push --force-with-lease
+
+
 ```


### PR DESCRIPTION
## Description

Updates to my KC60 keymap.


## Commit Log

### NUBS_Z: initial version (67bd632)

Create a keycode that is normally Z, but KC_NUBS when tapped while Alt is being held.

This removes the possibility of using an Alt+Z shortcut.

### NUBS_Z: modification (450102a)

Modify NUBS_Z macro to only use alternate operation if Right Alt is being held, rather than responding to either Alt key.

Also add QMK version keycode to System layer, Equals key.

### Remove unneeded breaks from process_record_user (7af5d1a)

### Macro refactoring (73900e4)

- removed G_RST and G_C10R macros
- updated G_BRCH macro
  - outputs `master` if used while Shift is held down; or my git alias for the current branch otherwise
- updated G_FTCH macro
  - outputs `git pull upstream ` if used with Shift; `git fetch upstream ` otherwise
- swapped `modifiers` variable for `get_mods()` function directly for checking modifier state
- swapped keymap-level modifier mask macros for QMK-core mod mask macros (thanks vomindoraan #4337)
- renamed MODS_RALT_MASK to MOD_MASK_RALT (more consistent with the above change)

### Update readme files (0340d6f)
