### PR TITLE
Add pin initialization for KBD75's LED

### DIFF
--- a/keyboards/kbdfans/kbd75/rev1/rev1.c
+++ b/keyboards/kbdfans/kbd75/rev1/rev1.c
@@ -10,3 +10,8 @@ void led_set_kb(uint8_t usb_led) {
 
 	led_set_user(usb_led);
 }
+
+void matrix_init_kb(void) {
+  setPinOutput(B2);
+  matrix_init_user();
+}

--- a/keyboards/kbdfans/kbd75/rev2/rev2.c
+++ b/keyboards/kbdfans/kbd75/rev2/rev2.c
@@ -10,3 +10,8 @@ void led_set_kb(uint8_t usb_led) {
 
 	led_set_user(usb_led);
 }
+
+void matrix_init_kb(void) {
+  setPinOutput(B2);
+  matrix_init_user();
+}


### PR DESCRIPTION


## Description
So that the LED indicator actually works

Specifically, the keyboard sets the pin high/low to set the LED, but never actually sets the output mode, so it doesn't work. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Core
- [ ] Bugfix
- [ ] New Feature
- [ ] Enhancement/Optimization
- [X] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation


## Issues Fixed or Closed by this PR

* Fixes #5118

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
