### PR TITLE
Swap KBD75 caps lock LED pin levels

### DIFF
--- a/keyboards/kbdfans/kbd75/rev1/rev1.c
+++ b/keyboards/kbdfans/kbd75/rev1/rev1.c
@@ -1,14 +1,14 @@
 #include "rev1.h"
 
 void led_set_kb(uint8_t usb_led) {
-	// put your keyboard LED indicator (ex: Caps Lock LED) toggling code here
+  // put your keyboard LED indicator (ex: Caps Lock LED) toggling code here
   if (IS_LED_ON(usb_led, USB_LED_CAPS_LOCK)) {
-    writePinHigh(B2);
-  } else {
     writePinLow(B2);
+  } else {
+    writePinHigh(B2);
   }
 
-	led_set_user(usb_led);
+  led_set_user(usb_led);
 }
 
 void matrix_init_kb(void) {

--- a/keyboards/kbdfans/kbd75/rev2/rev2.c
+++ b/keyboards/kbdfans/kbd75/rev2/rev2.c
@@ -1,14 +1,14 @@
 #include "rev2.h"
 
 void led_set_kb(uint8_t usb_led) {
-	// put your keyboard LED indicator (ex: Caps Lock LED) toggling code here
+  // put your keyboard LED indicator (ex: Caps Lock LED) toggling code here
   if (IS_LED_ON(usb_led, USB_LED_CAPS_LOCK)) {
-    writePinHigh(B2);
-  } else {
     writePinLow(B2);
+  } else {
+    writePinHigh(B2);
   }
 
-	led_set_user(usb_led);
+  led_set_user(usb_led);
 }
 
 void matrix_init_kb(void) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- This template is entirely option and can be removed, but is here to help both you and us. -->
<!--- This text and anything on lines wrapped like this one will not show up in the final text. This text is to help us and you. -->

## Description
It appears that the Caps Lock LED on the KBD75 is wired in current sink configuration (see #5118). Therefore pulling the pin *low* when Caps Lock is on results in the LED lighting up.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Core
- [x] Bugfix
- [ ] New Feature
- [ ] Enhancement/Optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation


## Issues Fixed or Closed by this PR

* None.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
