### PR TITLE
Remove redundant KC_TRNS and KC_NO fillers in userspace

### DIFF
--- a/users/bbaserdem/bbaserdem.h
+++ b/users/bbaserdem/bbaserdem.h
@@ -3,8 +3,6 @@
 
 #include "quantum.h"
 
-// Use 7 wide characters for keymaps
-#define _______ KC_TRNS
 #define XXX     KC_NO
 
 // Layers

--- a/users/bocaj/process_records.h
+++ b/users/bocaj/process_records.h
@@ -44,8 +44,6 @@ bool process_record_keymap(uint16_t keycode, keyrecord_t *record);
 #define KC_ADJS TT(_ADJUST)
 #define KC_NUMS TT(_LOWER)
 #define KC_GAME TT(_DIABLO)
-#define XXXXXXX KC_NO
-#define _______ KC_TRNS
 
 // Other Keycodes
 #define KC_RST RESET

--- a/users/gordon/gordon.h
+++ b/users/gordon/gordon.h
@@ -6,11 +6,9 @@
 
 
 // Fillers to make layering more clear
-#define _______   KC_TRNS
 #define ________  KC_TRNS
 #define _________ KC_TRNS
 #define _XXXXXX_  KC_TRNS
-#define XXXXXXX   KC_NO
 
 // KC codes that are too long
 #define DOLLAR    KC_DOLLAR

--- a/users/ishtob/ishtob.h
+++ b/users/ishtob/ishtob.h
@@ -43,9 +43,6 @@ enum userspace_keycodes {
 #define LOWER MO(_LOWER)
 #define RAISE MO(_RAISE)
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
 // Custom macros
 #define CTL_ESC     CTL_T(KC_ESC)               // Tap for Esc, hold for Ctrl
 #define CTL_TTAB    CTL_T(KC_TAB)               // Tap for Esc, hold for Ctrl

--- a/users/losinggeneration/losinggeneration-common.h
+++ b/users/losinggeneration/losinggeneration-common.h
@@ -3,9 +3,6 @@
 
 /* Custom keys & combinations to be shorter for keymaps */
 #define KC_LCA LCA(KC_NO)
-/* Fillers to make layering more clear */
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
 
 #define OSM_LSFT OSM(MOD_LSFT)
 #define TD_CTL TD(TD_CTL_CTLALT)

--- a/users/mtdjr/mtdjr.h
+++ b/users/mtdjr/mtdjr.h
@@ -55,8 +55,6 @@ enum user_tapdance {
 
 // Custom Keycodes
 #define KC_     KC_TRNS
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
 #define KC_xxxx KC_NO
 #define KC_LOWR LOWER
 #define KC_RASE RAISE

--- a/users/not-quite-neo/nqn-common.h
+++ b/users/not-quite-neo/nqn-common.h
@@ -6,9 +6,4 @@
 This file holds some commen NQN definitions
 */
 
-
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
-
 #endif

--- a/users/replicaJunction/replicaJunction.h
+++ b/users/replicaJunction/replicaJunction.h
@@ -20,7 +20,6 @@
 // #define L_LL_I   10
 
 // Keyboard aliases
-#define _______ KC_TRNS
 #define ooooooo KC_TRNS
 
 #define MO_FUNC MO(L_FUNC)

--- a/users/romus/romus.h
+++ b/users/romus/romus.h
@@ -4,8 +4,6 @@
 
 #include "quantum.h"
 
-// Use 7 wide characters for keymaps
-#define _______ KC_TRNS
 #define XXX     KC_NO
 
 // Layers

--- a/users/talljoe/talljoe.h
+++ b/users/talljoe/talljoe.h
@@ -35,9 +35,6 @@ enum tap_dancers {
   TD_QUOTE,
 };
 
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 #define MO_NAV    MO(_NAV)
 #define MO_ADJ    MO(_ADJUST)
 #define MO_RST    MO(_RESET)

--- a/users/zer09/zer09.h
+++ b/users/zer09/zer09.h
@@ -11,7 +11,6 @@ enum custom_keycodes {
   NEW_SAFE_RANGE
 };
 
-#define _______ KC_TRNS
 #define KC_RGUP RGUP
 #define KC_RGDWN RGDWN
 #define KC_YREG YREG


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

A small diversion from the fn_actions stuff. I'm hoping the reason this hasn't been done yet is because no one's had the time 😄

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* None.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
