### PR TITLE
[keymap] Add new keymap for wilba_tech WT8-A

### DIFF
--- a/keyboards/wilba_tech/wt8_a/keymaps/rys/keymap.c
+++ b/keyboards/wilba_tech/wt8_a/keymaps/rys/keymap.c
@@ -1,0 +1,84 @@
+#include QMK_KEYBOARD_H
+
+#define _BL0 0
+#define _FL1 1
+#define _FL2 2
+#define _FL3 3
+
+#define MACOSLK LCTL(LGUI(KC_Q)) // CTRL+CMD+Q == screen lock in macOS 10.13+
+
+enum rys_keycodes {
+  STOKEN1 = SAFE_RANGE,
+  STOKEN2,
+  STOKEN3,
+  STOKEN4
+};
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  switch(keycode) {
+    case STOKEN1:
+      if (record->event.pressed) {
+        SEND_STRING(RYS_STOKEN1);
+      }
+      break;
+    case STOKEN2:
+      if (record->event.pressed) {
+        SEND_STRING(RYS_STOKEN2);
+      }
+      break;
+    case STOKEN3:
+      if (record->event.pressed) {
+        SEND_STRING(RYS_STOKEN3);
+      }
+      break;
+    case STOKEN4:
+      if (record->event.pressed) {
+        SEND_STRING(RYS_STOKEN4);
+      }
+      break;
+  }
+  return true;
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  /* Keymap base layer (_BL0) - default layer
+   * ,---------------------------.
+   * | ST1  | ST2  | ST3  | ST4  |
+   * |---------------------------|
+   * |      | LOCK | VOL- | VOL+ |
+   * `---------------------------'
+   */
+   [_BL0] = LAYOUT(
+     STOKEN1, STOKEN2, STOKEN3,     STOKEN4,
+     _______, MACOSLK, KC__VOLDOWN, KC__VOLUP),
+  /* Keymap base layer (_FL1) - function layer 1
+   * ,---------------------------.
+   * |      |      |      |      |
+   * |---------------------------|
+   * |      |      |      |      |
+   * `---------------------------'
+   */
+   [_FL1] = LAYOUT(
+     _______, _______, _______, _______,
+     _______, _______, _______, _______),
+  /* Keymap base layer (_FL2) - function layer 2
+   * ,---------------------------.
+   * |      |      |      |      |
+   * |---------------------------|
+   * |      |      |      |      |
+   * `---------------------------'
+   */
+   [_FL2] = LAYOUT(
+     _______, _______, _______, _______,
+     _______, _______, _______, _______),
+  /* Keymap base layer (_FL3) - function layer 3
+   * ,---------------------------.
+   * |      |      |      |      |
+   * |---------------------------|
+   * |      |      |      |      |
+   * `---------------------------'
+   */
+   [_FL3] = LAYOUT(
+     _______, _______, _______, _______,
+     _______, _______, _______, _______),
+};

--- a/keyboards/wilba_tech/wt8_a/keymaps/rys/rules.mk
+++ b/keyboards/wilba_tech/wt8_a/keymaps/rys/rules.mk
@@ -1,0 +1,9 @@
+RYS_STOKEN1 = "$(shell security find-generic-password -a qmk -s wt8a-1 -w)"
+RYS_STOKEN2 = "$(shell security find-generic-password -a qmk -s wt8a-2 -w)"
+RYS_STOKEN3 = "$(shell security find-generic-password -a qmk -s wt8a-3 -w)"
+RYS_STOKEN4 = "$(shell security find-generic-password -a qmk -s wt8a-4 -w)"
+
+CFLAGS += -DRYS_STOKEN1=\"$(RYS_STOKEN1)\"
+CFLAGS += -DRYS_STOKEN2=\"$(RYS_STOKEN2)\"
+CFLAGS += -DRYS_STOKEN3=\"$(RYS_STOKEN3)\"
+CFLAGS += -DRYS_STOKEN4=\"$(RYS_STOKEN4)\"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
New user keymap for the WT8-A using the same macOS-only `security`-based macro method from [my TADA68 layout](https://github.com/qmk/qmk_firmware/tree/master/keyboards/tada68/keymaps/rys). 

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Adds a new keymap for the WT8-A with all 4 possible layers in place for future use, but only the base layer programmed with anything. 4 `security`-based `SEND_STRING` macros, macOS vol+-, and a macOS-specific screen lock define called `MACOSLK`.

Tested on a Singa Ocelot.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
