### PR TITLE
Remove redundant KC_TRNS and KC_NO fillers in layouts

### DIFF
--- a/layouts/community/ergodox/adam/keymap.c
+++ b/layouts/community/ergodox/adam/keymap.c
@@ -11,9 +11,6 @@
 #define SFLOCK 11 // symbols arrows and F keys on F held down
 #define SJLOCK 12 // same as Flock but with fall thru J and mapped to J held down
 
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 // Sends macro when key is tapped, presses mod when key is held
 #define tap_mod_macro(record, mod, macro) ( ((record)->event.pressed) ? \
      ( ((record)->tap.count <= 0 || (record)->tap.interrupted) ? MACRO(D(mod), END) : MACRO_NONE ) : \

--- a/layouts/community/ergodox/belak/keymap.c
+++ b/layouts/community/ergodox/belak/keymap.c
@@ -5,7 +5,6 @@
 #include "eeprom.h"
 
 #define LAYER_ON(pos) ((layer_state) & (1<<(pos)))
-#define _______ KC_TRNS
 
 #define EECONFIG_BELAK_MAGIC (uint16_t)0xBE42
 

--- a/layouts/community/ergodox/familiar/keymap.c
+++ b/layouts/community/ergodox/familiar/keymap.c
@@ -10,10 +10,6 @@
 #define NUMP 3 // numpad
 #define ARRW 4 // function, media, arrow keys
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 // Tap Dancing
 void dance_lock (qk_tap_dance_state_t *state, void *user_data) {
     if (state->count == 1) { // Press once for NUMLOCK

--- a/layouts/community/ergodox/haegin/keymap.c
+++ b/layouts/community/ergodox/haegin/keymap.c
@@ -9,8 +9,6 @@
 #define SYMBOLS 1 // symbols
 #define MEDIA 2 // media keys
 
-#define _______ KC_TRNS
-
 enum {
   TD_BSPC = 0
 };

--- a/layouts/community/ergodox/meagerfindings/keymap.c
+++ b/layouts/community/ergodox/meagerfindings/keymap.c
@@ -42,7 +42,6 @@ enum custom_keycodes {
 };
 
 //Redefine Key Names for Readaibilty
-#define XXXXXXX KC_NO
 #define SCRN_CLIPB LCTL(LGUI(LSFT(KC_4)))
 #define CHRM_L LALT(LGUI(KC_LEFT)) //Move left one tab in Chrome
 #define CHRM_R LALT(LGUI(KC_RIGHT)) //Move right one tab in Chrome

--- a/layouts/community/ergodox/xyverz/keymap.c
+++ b/layouts/community/ergodox/xyverz/keymap.c
@@ -31,11 +31,6 @@ extern keymap_config_t keymap_config;
 #define QWERTY M(_QW)
 #define COLEMAK M(_CM)
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 /* Layer 0 : Dvorak

--- a/layouts/community/ortho_4x12/bakingpy/keymap.c
+++ b/layouts/community/ortho_4x12/bakingpy/keymap.c
@@ -21,7 +21,6 @@ enum custom_keycodes {
 };
 
 #define KC_ KC_TRNS
-#define _______ KC_TRNS
 
 #define KC_CAPW LGUI(LSFT(KC_3))        // Capture whole screen
 #define KC_CPYW LGUI(LSFT(LCTL(KC_3)))  // Copy whole screen

--- a/layouts/community/ortho_4x12/colemak_mod_dh_wide/keymap.c
+++ b/layouts/community/ortho_4x12/colemak_mod_dh_wide/keymap.c
@@ -20,10 +20,6 @@ enum custom_keycodes {
   ADJUST,
 };
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 /* Colemak

--- a/layouts/community/ortho_4x12/crs/keymap.c
+++ b/layouts/community/ortho_4x12/crs/keymap.c
@@ -33,10 +33,6 @@ enum custom_keycodes {
   EXT_PLV
 };
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 /* Qwerty

--- a/layouts/community/ortho_4x12/ergodoxish/keymap.c
+++ b/layouts/community/ortho_4x12/ergodoxish/keymap.c
@@ -24,10 +24,6 @@ enum custom_keycodes {
   ADJUST,
 };
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 /* Qwerty

--- a/layouts/community/ortho_4x12/grahampheath/keymap.c
+++ b/layouts/community/ortho_4x12/grahampheath/keymap.c
@@ -54,10 +54,6 @@ enum custom_keycodes {
 #define HYPR_1 HYPR(KC_EXLM)  // Send Hyper + !.
 #define HYPR_2 HYPR(KC_AT)  // Send Hyper + @.
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 /* Qwerty

--- a/layouts/community/ortho_4x12/mindsound/keymap.c
+++ b/layouts/community/ortho_4x12/mindsound/keymap.c
@@ -33,10 +33,6 @@ const uint8_t flicker_max_levels = 7;
 uint8_t flicker_restore_level = 0;
 #endif
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 #define LOWER MO(_LOWER)
 #define RAISE MO(_RAISE)
 

--- a/layouts/community/ortho_4x12/symbolic/keymap.c
+++ b/layouts/community/ortho_4x12/symbolic/keymap.c
@@ -19,12 +19,6 @@ enum custom_keycodes {
   R_RAISE
 };
 
-
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 /* Qwerty

--- a/layouts/community/ortho_4x12/xyverz/keymap.c
+++ b/layouts/community/ortho_4x12/xyverz/keymap.c
@@ -24,10 +24,6 @@ enum custom_keycodes {
   ADJUST
 };
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 // Aliases to keep the keymap tidy
 #define GUIBSPC GUI_T(KC_BSPC) // GUI when held, BSPC when tapped.
 #define RGB_SWR RGB_M_SW // Swirl Animation alias

--- a/layouts/community/ortho_5x12/xyverz/keymap.c
+++ b/layouts/community/ortho_5x12/xyverz/keymap.c
@@ -24,10 +24,6 @@ enum custom_keycodes {
   ADJUST,
 };
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 // Aliases to keep the keymap tidy
 #define GUIBSPC GUI_T(KC_BSPC) // GUI when held, BSPC when tapped.
 #define RGB_SWR RGB_M_SW // Swirl Animation alias

--- a/layouts/default/numpad_5x4/default_numpad_5x4/keymap.c
+++ b/layouts/default/numpad_5x4/default_numpad_5x4/keymap.c
@@ -1,8 +1,5 @@
 #include QMK_KEYBOARD_H
 
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   [0] = LAYOUT_numpad_5x4(
     TG(1),   KC_PSLS, KC_PAST, KC_PMNS, \

--- a/layouts/default/ortho_5x4/default_ortho_5x4/keymap.c
+++ b/layouts/default/ortho_5x4/default_ortho_5x4/keymap.c
@@ -1,8 +1,5 @@
 #include QMK_KEYBOARD_H
 
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 enum custom_keycodes {
     KC_P00 = SAFE_RANGE
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

...

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
