### PR TITLE
Add missing weak attributes to led_set_user definitions in keyboard files

### DIFF
--- a/keyboards/ergodash/rev1/rev1.c
+++ b/keyboards/ergodash/rev1/rev1.c
@@ -30,6 +30,7 @@ void matrix_init_kb(void) {
 	matrix_init_user();
 };
 
+__attribute__ ((weak))
 void shutdown_user(void) {
     #ifdef AUDIO_ENABLE
         PLAY_SONG(tone_goodbye);

--- a/keyboards/ergodash/rev2/rev2.c
+++ b/keyboards/ergodash/rev2/rev2.c
@@ -30,6 +30,7 @@ void matrix_init_kb(void) {
 	matrix_init_user();
 };
 
+__attribute__ ((weak))
 void shutdown_user(void) {
     #ifdef AUDIO_ENABLE
         PLAY_SONG(tone_goodbye);

--- a/keyboards/exclusive/e6v2/le/le.c
+++ b/keyboards/exclusive/e6v2/le/le.c
@@ -21,12 +21,13 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
 	return process_record_user(keycode, record);
 }
 
+__attribute__ ((weak))
 void led_set_user(uint8_t usb_led) {
 	if (usb_led & (1 << USB_LED_CAPS_LOCK)) {
-		DDRB |= (1 << 7); 
+		DDRB |= (1 << 7);
 		PORTB &= ~(1 << 7);
 	} else {
-		DDRB &= ~(1 << 7); 
+		DDRB &= ~(1 << 7);
 		PORTB &= ~(1 << 7);
 	}
 }

--- a/keyboards/melody96/melody96.c
+++ b/keyboards/melody96/melody96.c
@@ -1,5 +1,6 @@
 #include "melody96.h"
 
+__attribute__ ((weak))
 void led_set_user(uint8_t usb_led) {
 
 	if (usb_led & (1 << USB_LED_NUM_LOCK)) {

--- a/keyboards/noxary/268_2/268_2.c
+++ b/keyboards/noxary/268_2/268_2.c
@@ -42,7 +42,7 @@ void led_set_kb(uint8_t usb_led) {
 	led_set_user(usb_led);
 }
 
-__attribute__((weak))
+__attribute__ ((weak))
 void led_set_user(uint8_t usb_led) {
 
     if (usb_led & (1 << USB_LED_CAPS_LOCK)) {

--- a/keyboards/noxary/x268/x268.c
+++ b/keyboards/noxary/x268/x268.c
@@ -42,6 +42,7 @@ void led_set_kb(uint8_t usb_led) {
 	led_set_user(usb_led);
 }
 
+__attribute__ ((weak))
 void led_set_user(uint8_t usb_led) {
 
     if (usb_led & (1 << USB_LED_CAPS_LOCK)) {

--- a/keyboards/toad/toad.c
+++ b/keyboards/toad/toad.c
@@ -1,5 +1,6 @@
 #include "toad.h"
 
+__attribute__ ((weak))
 void led_set_user(uint8_t usb_led) {
 
 	//LED1

--- a/keyboards/xmmx/xmmx.c
+++ b/keyboards/xmmx/xmmx.c
@@ -1,5 +1,6 @@
 #include "xmmx.h"
 
+__attribute__ ((weak))
 void led_set_user(uint8_t usb_led) {
 
 	//LED1


### PR DESCRIPTION
## Description

If `led_set_user` is defined in a base keyboard file (e.g. `keyboards/melody96/melody96.c`), it should be declared weak to prevent multiple-definition problems when linking with user code. This is already the case with most keyboards, but some of them are lacking it, so linking fails if `led_set_user` is also defined in user code. Same goes for `shutdown_user` and other `*_user` functions defined in base keyboard files.

This PR fixes that by adding the missing `__attribute__ ((weak))` declarations.

P.S. I went with `__attribute__ ((weak))` instead of `__attribute__((weak))` (even though I prefer the latter) because the majority of existing weak attributes in keyboards use the form with the space.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
