### PR TITLE
Remove redundant KC_TRNS and KC_NO fillers in default keymaps

### DIFF
--- a/keyboards/amj40/keymaps/default/keymap.c
+++ b/keyboards/amj40/keymaps/default/keymap.c
@@ -21,14 +21,6 @@ enum custom_keycodes {
   ADJUST,
 };
 
-
-
-
-
-// increase readability 
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         /* Default Layer
      * ,-----------------------------------------------------------.

--- a/keyboards/amj60/keymaps/default/keymap.c
+++ b/keyboards/amj60/keymaps/default/keymap.c
@@ -11,10 +11,6 @@
 // dual-role shortcuts
 #define SPACEDUAL LT(_SPC, KC_SPACE)
 
-
-// increase readability 
-#define _______ KC_TRNS
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Keymap _DEF: Default Layer
      * ,-----------------------------------------------------------.

--- a/keyboards/amj60/keymaps/iso_split_rshift/keymap.c
+++ b/keyboards/amj60/keymaps/iso_split_rshift/keymap.c
@@ -30,10 +30,6 @@
 #define GER_BRC_L RALT(KC_8)    // [
 #define GER_BRC_R RALT(KC_9)    // ]
 
-// increase readability 
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Keymap _DEF: Default Layer
      * ,-----------------------------------------------------------.

--- a/keyboards/amjpad/keymaps/default/keymap.c
+++ b/keyboards/amjpad/keymaps/default/keymap.c
@@ -11,8 +11,6 @@
 #define _BL 0
 #define _FL 1
 
-#define _______ KC_TRNS
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   /* Keymap _BL: (Base Layer) Default Layer
    * ,-------------------.

--- a/keyboards/atom47/keymaps/default/keymap.c
+++ b/keyboards/atom47/keymaps/default/keymap.c
@@ -10,8 +10,6 @@
 #define _FN1 2 //Fn1
 #define _PN 3 //Pn
 
-#define _______ KC_TRNS
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 [_MA] = LAYOUT(
   KC_ESC,		KC_Q,		KC_W,		KC_E,		KC_R,		KC_T,		KC_Y,		KC_U,		KC_I,		KC_O,		KC_P,		KC_DEL,		KC_BSPC,	\

--- a/keyboards/atomic/keymaps/default/keymap.c
+++ b/keyboards/atomic/keymaps/default/keymap.c
@@ -1,9 +1,7 @@
 #include QMK_KEYBOARD_H
 
 // Fillers to make layering more clear
-#define _______ KC_TRNS
 #define ___T___ KC_TRNS
-#define XXXXXXX KC_NO
 
 // Layer shorthand
 #define _QW 0

--- a/keyboards/blockey/keymaps/default/keymap.c
+++ b/keyboards/blockey/keymaps/default/keymap.c
@@ -20,11 +20,6 @@
 extern rgblight_config_t rgblight_config;
 #endif
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   [0] = LAYOUT(
     KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, \

--- a/keyboards/catch22/keymaps/default/keymap.c
+++ b/keyboards/catch22/keymaps/default/keymap.c
@@ -3,8 +3,6 @@
 #define _BASE 0
 #define _FN   1
 
-#define _______ KC_TRNS
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 [_BASE] = LAYOUT( /* Base */
            KC_NLCK, KC_PSLS,  KC_PAST,  KC_BSPC,  \

--- a/keyboards/chimera_ergo/keymaps/default/keymap.c
+++ b/keyboards/chimera_ergo/keymaps/default/keymap.c
@@ -36,10 +36,6 @@ enum chimera_ergo_layers
 #define LONGPRESS_DELAY 150
 //#define LAYER_TOGGLE_DELAY 300
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
   [_QWERTY] = LAYOUT(

--- a/keyboards/christmas_tree/keymaps/default/keymap.c
+++ b/keyboards/christmas_tree/keymaps/default/keymap.c
@@ -28,8 +28,6 @@ enum custom_keycodes {
   BACKLIT
 };
 
-#define _______ KC_TRNS
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
   /* Base

--- a/keyboards/comet46/keymaps/default-rgbled/keymap.c
+++ b/keyboards/comet46/keymaps/default-rgbled/keymap.c
@@ -25,9 +25,6 @@ enum custom_keycodes {
   RAISE,
 };
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
 #define LOWER MO(_LOWER)
 #define RAISE MO(_RAISE)
 

--- a/keyboards/comet46/keymaps/default/keymap.c
+++ b/keyboards/comet46/keymaps/default/keymap.c
@@ -29,9 +29,6 @@ enum custom_keycodes {
   RAISE,
 };
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
 #define LOWER MO(_LOWER)
 #define RAISE MO(_RAISE)
 

--- a/keyboards/cospad/keymaps/default/keymap.c
+++ b/keyboards/cospad/keymaps/default/keymap.c
@@ -12,8 +12,6 @@
 #define _BL 0
 #define _FL 1
 
-#define _______ KC_TRNS
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   /* Keymap _BL: (Base Layer) Default Layer
    * ,-------------------.

--- a/keyboards/cu75/keymaps/default/keymap.c
+++ b/keyboards/cu75/keymaps/default/keymap.c
@@ -1,8 +1,5 @@
 #include QMK_KEYBOARD_H
 
-//Define a clearer 'transparent' key code
-#define _______ KC_TRNS
-
 enum keymap_layout {
     VANILLA = 0,
     FUNC,

--- a/keyboards/cu75/keymaps/iso/keymap.c
+++ b/keyboards/cu75/keymaps/iso/keymap.c
@@ -1,8 +1,5 @@
 #include QMK_KEYBOARD_H
 
-//Define a clearer 'transparent' key code
-#define _______ KC_TRNS
-
 enum keymap_layout {
     VANILLA = 0,
     FUNC,

--- a/keyboards/dc01/numpad/keymaps/default/keymap.c
+++ b/keyboards/dc01/numpad/keymaps/default/keymap.c
@@ -15,9 +15,6 @@
  */
 #include QMK_KEYBOARD_H
 
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   [0] = LAYOUT_numpad_5x4(
     TG(1),   KC_PSLS, KC_PAST, KC_PMNS, \

--- a/keyboards/deltasplit75/keymaps/default/keymap.c
+++ b/keyboards/deltasplit75/keymaps/default/keymap.c
@@ -7,11 +7,6 @@ extern keymap_config_t keymap_config;
 // Layer names don't all need to be of the same length, obviously, and you can also skip them
 // entirely and just use numbers.
 
-// Fillers to make layering more clear
-
-#define _______ KC_TRNS
-
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   LAYOUT_v2(
     KC_ESC,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_INS,  KC_HOME, KC_PGUP,

--- a/keyboards/dichotomy/keymaps/default/keymap.c
+++ b/keyboards/dichotomy/keymaps/default/keymap.c
@@ -40,10 +40,6 @@ enum dichotomy_keycodes
 #define GREEN_BRIGHTNESS 2
 #define BLUE_BRIGHTNESS 2
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 [_BS] = LAYOUT( /* Base layout, nearly qwerty but with modifications because it's not a full keyboard. Obviously. */
   CK_TE,   KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,           KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_BSPC,

--- a/keyboards/diverge3/keymaps/default/keymap.c
+++ b/keyboards/diverge3/keymaps/default/keymap.c
@@ -95,9 +95,6 @@ enum custom_keycodes {
   PSELF_MACRO
 };
 
-// Make layer undefined do nothing
-#define _______ KC_TRNS
-
 // Macros
 #define KC_PMAC PAREN_MACRO
 #define KC_AMAC ARROW_MACRO

--- a/keyboards/dz60/keymaps/iso_split-spacebar/keymap.c
+++ b/keyboards/dz60/keymaps/iso_split-spacebar/keymap.c
@@ -9,11 +9,6 @@
 
 #include QMK_KEYBOARD_H
 
-
-// Helpful defines
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 /* 
 * Each layer gets a name for readability.
 * The underscores don't mean anything - you can

--- a/keyboards/dz60/keymaps/iso_uk/keymap.c
+++ b/keyboards/dz60/keymaps/iso_uk/keymap.c
@@ -10,12 +10,6 @@
 #define _CONTROL 2     // Control layer
 #define _CN _CONTROL
 
-// KEYCODES
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
-#define MO_FN MO(1)
-#define MO_FN MO(1)
 #define MO_FN MO(1)
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {

--- a/keyboards/eco/keymaps/default/keymap.c
+++ b/keyboards/eco/keymaps/default/keymap.c
@@ -18,10 +18,6 @@ enum eco_keycodes {
   QWERTY = SAFE_RANGE
 };
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 // Defines for task manager and such
 #define CALTDEL LCTL(LALT(KC_DEL))
 #define TSKMGR LCTL(LSFT(KC_ESC))

--- a/keyboards/ergo42/keymaps/default-underglow/keymap.c
+++ b/keyboards/ergo42/keymaps/default-underglow/keymap.c
@@ -8,10 +8,6 @@ extern keymap_config_t keymap_config;
 #define GAME 3
 #define RGB  4
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 #ifdef RGBLIGHT_ENABLE
 //Following line allows macro to read current RGB settings
 extern rgblight_config_t rgblight_config;

--- a/keyboards/ergo42/keymaps/default/keymap.c
+++ b/keyboards/ergo42/keymaps/default/keymap.c
@@ -7,10 +7,6 @@ extern keymap_config_t keymap_config;
 #define SYMB 2
 #define GAME 3
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
   /* BASE

--- a/keyboards/ergodash/mini/keymaps/default/keymap.c
+++ b/keyboards/ergodash/mini/keymaps/default/keymap.c
@@ -14,9 +14,6 @@ enum custom_keycodes {
   ADJUST,
 };
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
 #define EISU LALT(KC_GRV)
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {

--- a/keyboards/ergodash/rev1/keymaps/default/keymap.c
+++ b/keyboards/ergodash/rev1/keymaps/default/keymap.c
@@ -16,9 +16,6 @@ enum custom_keycodes {
   ADJUST,
 };
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
 #define KC_JPN LALT(KC_GRV)
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {

--- a/keyboards/ergodash/rev2/keymaps/default/keymap.c
+++ b/keyboards/ergodash/rev2/keymaps/default/keymap.c
@@ -16,9 +16,6 @@ enum custom_keycodes {
   ADJUST,
 };
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
 #define EISU LALT(KC_GRV)
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {

--- a/keyboards/ergotravel/keymaps/default/keymap.c
+++ b/keyboards/ergotravel/keymaps/default/keymap.c
@@ -14,8 +14,6 @@ enum custom_keycodes {
   ADJUST,
 };
 
-// #define KC_ KC_TRNS
-#define _______ KC_TRNS
 #define CALTDEL LCTL(LALT(KC_DEL))
 #define TSKMGR LCTL(LSFT(KC_ESC))
 

--- a/keyboards/fleuron/keymaps/default/keymap.c
+++ b/keyboards/fleuron/keymaps/default/keymap.c
@@ -34,9 +34,6 @@ enum custom_keycodes {
 #define _RAISE 2
 */
 
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 [_QWERTY] = LAYOUT_ortho_6x16(
   /* Qwerty

--- a/keyboards/fortitude60/keymaps/default/keymap.c
+++ b/keyboards/fortitude60/keymaps/default/keymap.c
@@ -23,9 +23,6 @@ enum custom_keycodes {
   ADJUST,
 };
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
 #define LOWER MO(_LOWER)
 #define RAISE MO(_RAISE)
 

--- a/keyboards/gh60/keymaps/default/keymap.c
+++ b/keyboards/gh60/keymaps/default/keymap.c
@@ -1,8 +1,5 @@
 #include QMK_KEYBOARD_H
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
   /* 0: qwerty */

--- a/keyboards/hadron/ver2/keymaps/default/keymap.c
+++ b/keyboards/hadron/ver2/keymaps/default/keymap.c
@@ -46,9 +46,6 @@ enum macro_keycodes {
   KC_DEMOMACRO,
 };
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
 // Custom macros
 #define CTL_ESC     CTL_T(KC_ESC)               // Tap for Esc, hold for Ctrl
 #define CTL_TTAB    CTL_T(KC_TAB)               // Tap for Esc, hold for Ctrl

--- a/keyboards/hadron/ver3/keymaps/default/keymap.c
+++ b/keyboards/hadron/ver3/keymaps/default/keymap.c
@@ -33,9 +33,6 @@ enum macro_keycodes {
   KC_DEMOMACRO,
 };
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
 // Custom macros
 #define CTL_ESC     CTL_T(KC_ESC)               // Tap for Esc, hold for Ctrl
 #define CTL_TTAB    CTL_T(KC_TAB)               // Tap for Esc, hold for Ctrl

--- a/keyboards/handwired/dactyl_manuform/5x6/keymaps/default/keymap.c
+++ b/keyboards/handwired/dactyl_manuform/5x6/keymaps/default/keymap.c
@@ -11,10 +11,6 @@ extern keymap_config_t keymap_config;
 #define RAISE MO(_RAISE)
 #define LOWER MO(_LOWER)
 
-#define _______ KC_TRNS
-
-
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
   [_QWERTY] = LAYOUT_5x6(

--- a/keyboards/handwired/dactyl_manuform/5x7/keymaps/default/keymap.c
+++ b/keyboards/handwired/dactyl_manuform/5x7/keymaps/default/keymap.c
@@ -10,10 +10,6 @@ extern keymap_config_t keymap_config;
 #define _FN     1
 #define _NUMPAD 2
 
-
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
 // Some basic macros
 #define TASK    LCTL(LSFT(KC_ESC))
 #define TAB_R   LCTL(KC_TAB)

--- a/keyboards/handwired/dactyl_manuform/6x6/keymaps/default/keymap.c
+++ b/keyboards/handwired/dactyl_manuform/6x6/keymaps/default/keymap.c
@@ -9,8 +9,6 @@ extern keymap_config_t keymap_config;
 #define RAISE MO(_RAISE)
 #define LOWER MO(_LOWER)
 
-#define _______ KC_TRNS
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
   [_QWERTY] = LAYOUT_6x6(

--- a/keyboards/handwired/maartenwut/keymaps/default/keymap.c
+++ b/keyboards/handwired/maartenwut/keymaps/default/keymap.c
@@ -6,9 +6,6 @@
 #define _GA 3
 #define _AR 4
 
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 #define LSHIFT OSM(MOD_LSFT)
 #define SPACE LT(_AR, KC_SPC)
 

--- a/keyboards/handwired/not_so_minidox/keymaps/default/keymap.c
+++ b/keyboards/handwired/not_so_minidox/keymaps/default/keymap.c
@@ -18,10 +18,6 @@ enum custom_keycodes {
   ADJUST,
 };
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 #define KC_LOWR LOWER
 #define KC_RASE RAISE
 #define KC_RST  RESET

--- a/keyboards/handwired/promethium/keymaps/default/keymap.c
+++ b/keyboards/handwired/promethium/keymaps/default/keymap.c
@@ -57,9 +57,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "led.h"
 #define COUNT(x) (sizeof (x) / sizeof (*(x)))
 
-// Fillers to make layering clearer
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
 #define KC_WWWB KC_WWW_BACK
 #define KC_WWWF KC_WWW_FORWARD
 

--- a/keyboards/handwired/terminus_mini/keymaps/default/keymap.c
+++ b/keyboards/handwired/terminus_mini/keymaps/default/keymap.c
@@ -60,11 +60,6 @@ enum custom_macros {
 #define PIPE M(R_PIPE)
 #define POINT M(R_POINT)
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 /* Colemak -
  * ,----------------------------------------------------------------------------------.

--- a/keyboards/handwired/woodpad/keymaps/default/keymap.c
+++ b/keyboards/handwired/woodpad/keymaps/default/keymap.c
@@ -24,10 +24,6 @@
 #define _ALT 2
 #define _ADJUST 3
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 [_NUMLOCK] = KEYMAP( /* Base */
   KC_NLCK, KC_PSLS, KC_PAST, KC_PMNS,\

--- a/keyboards/handwired/xealous/keymaps/default/keymap.c
+++ b/keyboards/handwired/xealous/keymaps/default/keymap.c
@@ -11,9 +11,6 @@ extern keymap_config_t keymap_config;
 #define _NUMPAD 1
 #define _FN 2
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
 #define FN MO(_FN)
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {

--- a/keyboards/helix/pico/keymaps/default/keymap.c
+++ b/keyboards/helix/pico/keymaps/default/keymap.c
@@ -50,10 +50,6 @@ enum macro_keycodes {
   KC_SAMPLEMACRO,
 };
 
-
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
 //Macros
 #define M_SAMPLE M(KC_SAMPLEMACRO)
 

--- a/keyboards/helix/rev1/keymaps/OLED_sample/keymap.c
+++ b/keyboards/helix/rev1/keymaps/OLED_sample/keymap.c
@@ -47,10 +47,6 @@ enum macro_keycodes {
   KC_SAMPLEMACRO,
 };
 
-
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
 //Macros
 #define M_SAMPLE M(KC_SAMPLEMACRO)
 

--- a/keyboards/helix/rev1/keymaps/default/keymap.c
+++ b/keyboards/helix/rev1/keymaps/default/keymap.c
@@ -22,10 +22,6 @@ enum custom_keycodes {
   ADJUST,
 };
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 #if HELIX_ROWS == 5
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 

--- a/keyboards/helix/rev2/keymaps/default/keymap.c
+++ b/keyboards/helix/rev2/keymaps/default/keymap.c
@@ -50,10 +50,6 @@ enum macro_keycodes {
   KC_SAMPLEMACRO,
 };
 
-
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
 //Macros
 #define M_SAMPLE M(KC_SAMPLEMACRO)
 

--- a/keyboards/hid_liber/keymaps/default/keymap.c
+++ b/keyboards/hid_liber/keymaps/default/keymap.c
@@ -16,9 +16,6 @@
  */
 #include "hid_liber.h"
 
-// Helpful defines
-#define _______ KC_TRNS
-
 // Each layer gets a name for readability, which is then used in the keymap matrix below.
 // The underscores don't mean anything - you can have a layer called STUFF or any other name.
 // Layer names don't all need to be of the same length, obviously, and you can also skip them

--- a/keyboards/jm60/keymaps/default/keymap.c
+++ b/keyboards/jm60/keymaps/default/keymap.c
@@ -11,8 +11,6 @@
 #define _BL 0
 #define _FL 1
 
-#define _______ KC_TRNS
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   /* Keymap _BL: (Base Layer) Default Layer
    * ,-----------------------------------------------------------.

--- a/keyboards/katana60/keymaps/default/keymap.c
+++ b/keyboards/katana60/keymaps/default/keymap.c
@@ -15,9 +15,6 @@
  */
 #include QMK_KEYBOARD_H
 
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 // Windows based definitions.
 #define K_SPCFN LT(SYMB, KC_SPACE) // Tap for space, hold for symbols layer
 #define K_PRVWD LCTL(KC_LEFT)      // Previous word

--- a/keyboards/kmac/keymaps/default/keymap.c
+++ b/keyboards/kmac/keymaps/default/keymap.c
@@ -15,9 +15,6 @@
  */
 #include QMK_KEYBOARD_H
 
-// Helpful defines
-#define _______ KC_TRNS
-
 // Each layer gets a name for readability, which is then used in the keymap matrix below.
 // The underscores don't mean anything - you can have a layer called STUFF or any other name.
 // Layer names don't all need to be of the same length, obviously, and you can also skip them

--- a/keyboards/kmac/keymaps/winkeyless/keymap.c
+++ b/keyboards/kmac/keymaps/winkeyless/keymap.c
@@ -15,9 +15,6 @@
  */
 #include QMK_KEYBOARD_H
 
-// Helpful defines
-#define _______ KC_TRNS
-
 // Each layer gets a name for readability, which is then used in the keymap matrix below.
 // The underscores don't mean anything - you can have a layer called STUFF or any other name.
 // Layer names don't all need to be of the same length, obviously, and you can also skip them

--- a/keyboards/kona_classic/keymaps/ansi/keymap.c
+++ b/keyboards/kona_classic/keymaps/ansi/keymap.c
@@ -22,10 +22,6 @@ enum custom_keycodes {
   SFT_ESC = SAFE_RANGE
 };
 
-// Helpful defines
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 #define _DEFAULT 0
 #define _FN 1
 

--- a/keyboards/kona_classic/keymaps/ansi_arrows/keymap.c
+++ b/keyboards/kona_classic/keymaps/ansi_arrows/keymap.c
@@ -22,10 +22,6 @@ enum custom_keycodes {
   SFT_ESC = SAFE_RANGE
 };
 
-// Helpful defines
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 #define _DEFAULT 0
 #define _FN 1
 

--- a/keyboards/kona_classic/keymaps/ansi_arrows_lcap/keymap.c
+++ b/keyboards/kona_classic/keymaps/ansi_arrows_lcap/keymap.c
@@ -22,10 +22,6 @@ enum custom_keycodes {
   SFT_ESC = SAFE_RANGE
 };
 
-// Helpful defines
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 #define _DEFAULT 0
 #define _FN 1
 

--- a/keyboards/kona_classic/keymaps/ansi_split/keymap.c
+++ b/keyboards/kona_classic/keymaps/ansi_split/keymap.c
@@ -18,10 +18,6 @@
 #define MODS_SHIFT_GUI_MASK (MOD_BIT(KC_LSHIFT)|MOD_BIT(KC_RSHIFT)|MOD_BIT(KC_LGUI)|MOD_BIT(KC_RGUI))
 #define MODS_GUI_MASK   (MOD_BIT(KC_LGUI)|MOD_BIT(KC_RGUI))
 
-// Helpful defines
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 #define _DEFAULT 0
 #define _FN 1
 

--- a/keyboards/kona_classic/keymaps/ansi_split_arrows/keymap.c
+++ b/keyboards/kona_classic/keymaps/ansi_split_arrows/keymap.c
@@ -18,10 +18,6 @@
 #define MODS_SHIFT_GUI_MASK (MOD_BIT(KC_LSHIFT)|MOD_BIT(KC_RSHIFT)|MOD_BIT(KC_LGUI)|MOD_BIT(KC_RGUI))
 #define MODS_GUI_MASK   (MOD_BIT(KC_LGUI)|MOD_BIT(KC_RGUI))
 
-// Helpful defines
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 #define _DEFAULT 0
 #define _FN 1
 

--- a/keyboards/kona_classic/keymaps/default/keymap.c
+++ b/keyboards/kona_classic/keymaps/default/keymap.c
@@ -22,10 +22,6 @@ enum custom_keycodes {
   SFT_ESC = SAFE_RANGE
 };
 
-// Helpful defines
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 #define _DEFAULT 0
 #define _FN 1
 

--- a/keyboards/kona_classic/keymaps/iso/keymap.c
+++ b/keyboards/kona_classic/keymaps/iso/keymap.c
@@ -18,10 +18,6 @@
 #define MODS_SHIFT_GUI_MASK (MOD_BIT(KC_LSHIFT)|MOD_BIT(KC_RSHIFT)|MOD_BIT(KC_LGUI)|MOD_BIT(KC_RGUI))
 #define MODS_GUI_MASK   (MOD_BIT(KC_LGUI)|MOD_BIT(KC_RGUI))
 
-// Helpful defines
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 #define _DEFAULT 0
 #define _FN 1
 

--- a/keyboards/kona_classic/keymaps/iso_arrows/keymap.c
+++ b/keyboards/kona_classic/keymaps/iso_arrows/keymap.c
@@ -18,10 +18,6 @@
 #define MODS_SHIFT_GUI_MASK (MOD_BIT(KC_LSHIFT)|MOD_BIT(KC_RSHIFT)|MOD_BIT(KC_LGUI)|MOD_BIT(KC_RGUI))
 #define MODS_GUI_MASK   (MOD_BIT(KC_LGUI)|MOD_BIT(KC_RGUI))
 
-// Helpful defines
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 #define _DEFAULT 0
 #define _FN 1
 

--- a/keyboards/kona_classic/keymaps/iso_split/keymap.c
+++ b/keyboards/kona_classic/keymaps/iso_split/keymap.c
@@ -18,10 +18,6 @@
 #define MODS_SHIFT_GUI_MASK (MOD_BIT(KC_LSHIFT)|MOD_BIT(KC_RSHIFT)|MOD_BIT(KC_LGUI)|MOD_BIT(KC_RGUI))
 #define MODS_GUI_MASK   (MOD_BIT(KC_LGUI)|MOD_BIT(KC_RGUI))
 
-// Helpful defines
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 #define _DEFAULT 0
 #define _FN 1
 

--- a/keyboards/kona_classic/keymaps/iso_split_arrows/keymap.c
+++ b/keyboards/kona_classic/keymaps/iso_split_arrows/keymap.c
@@ -18,10 +18,6 @@
 #define MODS_SHIFT_GUI_MASK (MOD_BIT(KC_LSHIFT)|MOD_BIT(KC_RSHIFT)|MOD_BIT(KC_LGUI)|MOD_BIT(KC_RGUI))
 #define MODS_GUI_MASK   (MOD_BIT(KC_LGUI)|MOD_BIT(KC_RGUI))
 
-// Helpful defines
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 #define _DEFAULT 0
 #define _FN 1
 

--- a/keyboards/launchpad/keymaps/default/keymap.c
+++ b/keyboards/launchpad/keymaps/default/keymap.c
@@ -13,10 +13,6 @@ extern keymap_config_t keymap_config;
 
 #define _FUNC 15
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 // Defines for task manager and such
 #define CALTDEL LCTL(LALT(KC_DEL))
 #define TSKMGR LCTL(LSFT(KC_ESC))

--- a/keyboards/lets_split/keymaps/OLED_sample/keymap.c
+++ b/keyboards/lets_split/keymaps/OLED_sample/keymap.c
@@ -43,10 +43,6 @@ enum macro_keycodes {
   KC_SAMPLEMACRO,
 };
 
-
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
 //Macros
 #define M_SAMPLE M(KC_SAMPLEMACRO)
 

--- a/keyboards/lfkeyboards/lfk78/keymaps/default/keymap.c
+++ b/keyboards/lfkeyboards/lfk78/keymaps/default/keymap.c
@@ -1,9 +1,5 @@
 #include QMK_KEYBOARD_H
 
-// readability
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 enum keymap_layout {
     VANILLA = 0,  // matches MF68 layout
     FUNC,         // 0x02

--- a/keyboards/lfkeyboards/lfk78/keymaps/iso/keymap.c
+++ b/keyboards/lfkeyboards/lfk78/keymaps/iso/keymap.c
@@ -1,9 +1,5 @@
 #include QMK_KEYBOARD_H
 
-// readability
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 enum keymap_layout {
     VANILLA = 0,  // matches MF68 layout
     FUNC,         // 0x02

--- a/keyboards/lfkeyboards/lfk87/keymaps/default/keymap.c
+++ b/keyboards/lfkeyboards/lfk87/keymaps/default/keymap.c
@@ -1,9 +1,5 @@
 #include QMK_KEYBOARD_H
 
-// readability
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 enum keymap_layout {
     VANILLA = 0,  // matches MF68 layout
     FUNC,         // 0x08

--- a/keyboards/lfkeyboards/lfk87/keymaps/iso/keymap.c
+++ b/keyboards/lfkeyboards/lfk87/keymaps/iso/keymap.c
@@ -1,9 +1,5 @@
 #include QMK_KEYBOARD_H
 
-// readability
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 enum keymap_layout {
     VANILLA = 0,
     FUNC,         // 0x02

--- a/keyboards/lfkeyboards/lfkpad/keymaps/default/keymap.c
+++ b/keyboards/lfkeyboards/lfkpad/keymaps/default/keymap.c
@@ -1,9 +1,5 @@
 #include QMK_KEYBOARD_H
 
-// readability
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   [0] = LAYOUT_numpad_6x4( /* Base */
     KC_ESC,   KC_TAB,   KC_PEQL,  MO(1),   \

--- a/keyboards/lfkeyboards/smk65/keymaps/default/keymap.c
+++ b/keyboards/lfkeyboards/smk65/keymaps/default/keymap.c
@@ -1,9 +1,5 @@
 #include QMK_KEYBOARD_H
 
-// readability
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 enum keymap_layout {
     VANILLA = 0,
     FUNC,

--- a/keyboards/lfkeyboards/smk65/keymaps/iso/keymap.c
+++ b/keyboards/lfkeyboards/smk65/keymaps/iso/keymap.c
@@ -1,9 +1,5 @@
 #include QMK_KEYBOARD_H
 
-// readability
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 enum keymap_layout {
     VANILLA = 0,
     FUNC,

--- a/keyboards/m10a/keymaps/default/keymap.c
+++ b/keyboards/m10a/keymaps/default/keymap.c
@@ -23,10 +23,6 @@ enum layers {
   _LAYER9
 };
 
-// // Fillers to make layering more clear
-// #define _______ KC_TRNS
-// #define XXXXXXX KC_NO
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   [_LAYER0] = {{KC_A, KC_B, KC_C}, {KC_D, KC_E, KC_F}, {KC_G, KC_H, KC_I}, {KC_NO, KC_NO, KC_J}},
   [_LAYER1] = {{KC_A, KC_B, KC_C}, {KC_D, KC_E, KC_F}, {KC_G, KC_H, KC_I}, {KC_NO, KC_NO, KC_J}},

--- a/keyboards/minidox/keymaps/default/keymap.c
+++ b/keyboards/minidox/keymaps/default/keymap.c
@@ -18,10 +18,6 @@ enum custom_keycodes {
   ADJUST,
 };
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 // Defines for task manager and such
 #define CALTDEL LCTL(LALT(KC_DEL))
 #define TSKMGR LCTL(LSFT(KC_ESC))

--- a/keyboards/mint60/keymaps/default/keymap.c
+++ b/keyboards/mint60/keymaps/default/keymap.c
@@ -26,10 +26,6 @@ extern keymap_config_t keymap_config;
 extern rgblight_config_t rgblight_config;
 #endif
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 enum custom_keycodes {
   RGBRST = SAFE_RANGE
 };

--- a/keyboards/mitosis/keymaps/default/keymap.c
+++ b/keyboards/mitosis/keymaps/default/keymap.c
@@ -33,10 +33,6 @@ enum mitosis_macros
 #define LONGPRESS_DELAY 150
 #define LAYER_TOGGLE_DELAY 300
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
   [_MALT] = LAYOUT( /* Malt Layout, customised for reduced columns (ex: quote and shift locations) */

--- a/keyboards/miuni32/keymaps/default/keymap.c
+++ b/keyboards/miuni32/keymaps/default/keymap.c
@@ -1,8 +1,5 @@
 #include QMK_KEYBOARD_H
 
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Level 0: Default Layer
      * ,---------------------------------------------------------------------------------------.

--- a/keyboards/mt40/keymaps/default/keymap.c
+++ b/keyboards/mt40/keymaps/default/keymap.c
@@ -15,8 +15,6 @@
  */
 #include QMK_KEYBOARD_H
 
-
-#define _______ KC_TRNS
 #define OOOOOOO KC_TRNS
 
 #define C_LCTL MT(MOD_LCTL, KC_QUOT)

--- a/keyboards/mxss/templates/keymap.c
+++ b/keyboards/mxss/templates/keymap.c
@@ -16,9 +16,6 @@
 #include QMK_KEYBOARD_H
 #include "mxss_frontled.h"
 
-// Helpful defines
-#define _______ KC_TRNS
-
 // Predefined colors for layers
 // Format: {hue, saturation}
 // {0, 0} to turn off the LED

--- a/keyboards/newgame40/keymaps/default/keymap.c
+++ b/keyboards/newgame40/keymaps/default/keymap.c
@@ -38,7 +38,6 @@ enum layers {
    ADJUST,
  };
 
- // Fillers to make layering more clear
  #define LOWER MO(_LOWER)
  #define RAISE MO(_RAISE)
 

--- a/keyboards/niu_mini/keymaps/default/keymap.c
+++ b/keyboards/niu_mini/keymaps/default/keymap.c
@@ -1,9 +1,5 @@
 #include QMK_KEYBOARD_H
 
-// readability
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 	/* Layer 0

--- a/keyboards/novelpad/keymaps/default/keymap.c
+++ b/keyboards/novelpad/keymaps/default/keymap.c
@@ -16,8 +16,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include QMK_KEYBOARD_H
 
-#define _______ KC_TRNS
-
 enum custom_keycodes {
   BL = SAFE_RANGE,
   WK_RED,

--- a/keyboards/noxary/268/keymaps/ansi/keymap.c
+++ b/keyboards/noxary/268/keymaps/ansi/keymap.c
@@ -1,8 +1,5 @@
 #include QMK_KEYBOARD_H
 
-// Helpful defines
-#define _______ KC_TRNS
-
 // Each layer gets a name for readability, which is then used in the keymap matrix below.
 // The underscores don't mean anything - you can have a layer called STUFF or any other name.
 // Layer names don't all need to be of the same length, obviously, and you can also skip them

--- a/keyboards/noxary/268/keymaps/default/keymap.c
+++ b/keyboards/noxary/268/keymaps/default/keymap.c
@@ -1,8 +1,5 @@
 #include QMK_KEYBOARD_H
 
-// Helpful defines
-#define _______ KC_TRNS
-
 // Each layer gets a name for readability, which is then used in the keymap matrix below.
 // The underscores don't mean anything - you can have a layer called STUFF or any other name.
 // Layer names don't all need to be of the same length, obviously, and you can also skip them

--- a/keyboards/noxary/268/keymaps/iso/keymap.c
+++ b/keyboards/noxary/268/keymaps/iso/keymap.c
@@ -1,8 +1,5 @@
 #include QMK_KEYBOARD_H
 
-// Helpful defines
-#define _______ KC_TRNS
-
 // Each layer gets a name for readability, which is then used in the keymap matrix below.
 // The underscores don't mean anything - you can have a layer called STUFF or any other name.
 // Layer names don't all need to be of the same length, obviously, and you can also skip them

--- a/keyboards/ok60/keymaps/default/keymap.c
+++ b/keyboards/ok60/keymaps/default/keymap.c
@@ -1,7 +1,5 @@
 #include QMK_KEYBOARD_H
 
-#define _______ KC_TRNS
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
     [0] = LAYOUT_60_ansi(

--- a/keyboards/orthodox/keymaps/default/keymap.c
+++ b/keyboards/orthodox/keymaps/default/keymap.c
@@ -38,10 +38,6 @@ enum custom_keycodes {
   DVORAK
 };
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 #define LS__SPC MT(MOD_LSFT, KC_SPC)
 #define LOWER MO(_LOWER)
 #define RAISE MO(_RAISE)

--- a/keyboards/phantom/keymaps/default/keymap.c
+++ b/keyboards/phantom/keymaps/default/keymap.c
@@ -15,9 +15,6 @@
  */
 #include QMK_KEYBOARD_H
 
-// Helpful defines
-#define _______ KC_TRNS
-
 // Each layer gets a name for readability, which is then used in the keymap matrix below.
 // The underscores don't mean anything - you can have a layer called STUFF or any other name.
 // Layer names don't all need to be of the same length, obviously, and you can also skip them

--- a/keyboards/phantom/keymaps/iso_uk/keymap.c
+++ b/keyboards/phantom/keymaps/iso_uk/keymap.c
@@ -15,9 +15,6 @@
  */
 #include QMK_KEYBOARD_H
 
-// Helpful defines
-#define _______ KC_TRNS
-
 // Each layer gets a name for readability, which is then used in the keymap matrix below.
 // The underscores don't mean anything - you can have a layer called STUFF or any other name.
 // Layer names don't all need to be of the same length, obviously, and you can also skip them

--- a/keyboards/playkbtw/pk60/keymaps/default/keymap.c
+++ b/keyboards/playkbtw/pk60/keymaps/default/keymap.c
@@ -1,7 +1,5 @@
 #include QMK_KEYBOARD_H
 
-#define _______ KC_TRNS
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
   [0] = LAYOUT_all( \

--- a/keyboards/primekb/prime_r/keymaps/default/keymap.c
+++ b/keyboards/primekb/prime_r/keymaps/default/keymap.c
@@ -19,10 +19,6 @@
 
 #include QMK_KEYBOARD_H
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   /* (Base Layer) Default Layer
    * ,---------------------------------------------------------------.

--- a/keyboards/satan/keymaps/default/keymap.c
+++ b/keyboards/satan/keymaps/default/keymap.c
@@ -14,8 +14,6 @@ enum custom_keycodes {
 #define _BL 0
 #define _FL 1
 
-#define _______ KC_TRNS
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   /* Keymap _BL: (Base Layer) Default Layer
    * ,-----------------------------------------------------------.

--- a/keyboards/satan/keymaps/isoHHKB/keymap.c
+++ b/keyboards/satan/keymaps/isoHHKB/keymap.c
@@ -13,9 +13,6 @@
 #define KC_ENYE M(0)
 #define KC_CEDL M(1)
 
-#define _______ KC_TRNS
-
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   /* Keymap _BL: (Base Layer) Default Layer
    * ,-----------------------------------------------------------.

--- a/keyboards/satan/keymaps/iso_split_rshift/keymap.c
+++ b/keyboards/satan/keymaps/iso_split_rshift/keymap.c
@@ -32,10 +32,6 @@
 #define GER_BRC_L RALT(KC_8)    // [
 #define GER_BRC_R RALT(KC_9)    // ]
 
-// increase readability
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Keymap _DEF: Default Layer
      * ,-----------------------------------------------------------.

--- a/keyboards/sentraq/s60_x/keymaps/ansi_qwertz/keymap.c
+++ b/keyboards/sentraq/s60_x/keymaps/ansi_qwertz/keymap.c
@@ -16,10 +16,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include QMK_KEYBOARD_H
 
-//make keymap a little easier to read
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 #define ONESHOT_TAP_TOGGLE 2
 #define ONESHOT_TIMEOUT 1
 

--- a/keyboards/sentraq/s60_x/keymaps/default/keymap.c
+++ b/keyboards/sentraq/s60_x/keymaps/default/keymap.c
@@ -1,9 +1,5 @@
 #include QMK_KEYBOARD_H
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
   /* 0: Main layer

--- a/keyboards/sentraq/s60_x/keymaps/default_rgb/keymap.c
+++ b/keyboards/sentraq/s60_x/keymaps/default_rgb/keymap.c
@@ -1,9 +1,5 @@
 #include QMK_KEYBOARD_H
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
   /* 0: Main layer

--- a/keyboards/speedo/keymaps/default/keymap.c
+++ b/keyboards/speedo/keymaps/default/keymap.c
@@ -15,7 +15,6 @@
  */
 #include QMK_KEYBOARD_H
 
-#define _______ KC_TRNS
 #define FN MO(_FN)
 #define TORST TO(_RESET)
 #define TODFT TO(_DEFAULT)

--- a/keyboards/subatomic/keymaps/default/keymap.c
+++ b/keyboards/subatomic/keymaps/default/keymap.c
@@ -25,10 +25,6 @@ enum subatomic_keycodes {
   BACKLIT
 };
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 /* Qwerty

--- a/keyboards/tada68/keymaps/default/keymap.c
+++ b/keyboards/tada68/keymaps/default/keymap.c
@@ -7,8 +7,6 @@
 #define _BL 0
 #define _FL 1
 
-#define _______ KC_TRNS
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   /* Keymap _BL: (Base Layer) Default Layer
    * ,----------------------------------------------------------------.

--- a/keyboards/tada68/keymaps/iso-nor/keymap.c
+++ b/keyboards/tada68/keymaps/iso-nor/keymap.c
@@ -3,8 +3,6 @@
 #define _BL 0
 #define _FL 1
 
-#define _______ KC_TRNS
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   /* Keymap _BL: (Base Layer) Default Layer
    * ,----------------------------------------------------------------.

--- a/keyboards/tada68/keymaps/iso-uk/keymap.c
+++ b/keyboards/tada68/keymaps/iso-uk/keymap.c
@@ -3,8 +3,6 @@
 #define _BL 0
 #define _FL 1
 
-#define _______ KC_TRNS
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   /* Keymap _BL: (Base Layer) Default Layer
    * ,----------------------------------------------------------------.

--- a/keyboards/tada68/keymaps/isoish/keymap.c
+++ b/keyboards/tada68/keymaps/isoish/keymap.c
@@ -3,8 +3,6 @@
 #define _BL 0
 #define _FL 1
 
-#define _______ KC_TRNS
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   /* Keymap _BL: (Base Layer) Default Layer
    * ,----------------------------------------------------------------.

--- a/keyboards/tada68/keymaps/rgb/keymap.c
+++ b/keyboards/tada68/keymaps/rgb/keymap.c
@@ -7,8 +7,6 @@
 #define _BL 0
 #define _FL 1
 
-#define _______ KC_TRNS
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   /* Keymap _BL: (Base Layer) Default Layer
    * ,----------------------------------------------------------------.

--- a/keyboards/telophase/keymaps/default/keymap.c
+++ b/keyboards/telophase/keymaps/default/keymap.c
@@ -25,10 +25,6 @@ enum telophase_keycodes
 #define LONGPRESS_DELAY 150
 #define LAYER_TOGGLE_DELAY 300
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 [_QWERTY] = { /*QWERTY*/
 	{KC_ESC,    KC_Q,      KC_W,    KC_E,    KC_R,    KC_T,      KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_BSPC },

--- a/keyboards/tetris/keymaps/default/keymap.c
+++ b/keyboards/tetris/keymaps/default/keymap.c
@@ -6,10 +6,6 @@
   float  tone_taps[][2]     = SONG( E__NOTE( _A6 ) );
 #endif
 
-/* Fillers to make layering more clear */
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 #define _BASE  0
 #define _CODE  1
 #define _NAVI  2

--- a/keyboards/the_ruler/keymaps/default/keymap.c
+++ b/keyboards/the_ruler/keymaps/default/keymap.c
@@ -18,10 +18,6 @@ enum custom_keycodes {
   FN_2
 };
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 // Defines for task manager and such
 #define CALTDEL LCTL(LALT(KC_DEL))
 #define TSKMGR LCTL(LSFT(KC_ESC))

--- a/keyboards/thevankeyboards/minivan/keymaps/default/keymap.c
+++ b/keyboards/thevankeyboards/minivan/keymaps/default/keymap.c
@@ -24,10 +24,6 @@ extern keymap_config_t keymap_config;
 #define L_CURBR LSFT(KC_LBRC)
 #define R_CURBR LSFT(KC_RBRC)
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   [_QW] = LAYOUT( /* Qwerty */
     KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_BSPC,

--- a/keyboards/thevankeyboards/roadkit/keymaps/default/keymap.c
+++ b/keyboards/thevankeyboards/roadkit/keymaps/default/keymap.c
@@ -12,11 +12,6 @@ extern keymap_config_t keymap_config;
 // Macro name shortcuts
 #define NUMPAD M(_NP)
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   [_NP] = LAYOUT_numpad_4x4( /* Numpad */
     KC_P7, KC_P8,   KC_P9,   KC_PPLS, \

--- a/keyboards/vision_division/keymaps/default/keymap.c
+++ b/keyboards/vision_division/keymaps/default/keymap.c
@@ -137,8 +137,6 @@ enum keyboard_macros {
 #define TG_NKRO             MAGIC_TOGGLE_NKRO
 #define OS_SHFT             OSM(MOD_LSFT)
 
-#define _______             KC_TRNS
-#define XXXXXXX             KC_NO
 #define ________________    _______, _______
 #define XXXXXXXXXXXXXXXX    XXXXXXX, XXXXXXX
 

--- a/keyboards/vitamins_included/keymaps/default/keymap.c
+++ b/keyboards/vitamins_included/keymaps/default/keymap.c
@@ -22,10 +22,6 @@ enum custom_keycodes {
   ADJUST
 };
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 /* Qwerty

--- a/keyboards/zen/keymaps/default/keymap.c
+++ b/keyboards/zen/keymaps/default/keymap.c
@@ -16,10 +16,6 @@ enum custom_keycodes {
 
 };
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define XXXXXXX KC_NO
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
   /* Qwerty


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Default keymaps and a few other ones that looked defaultish.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
