### PR TITLE
Add docs on using keyboard_post_init_user to enable debug modes

### DIFF
--- a/docs/newbs_testing_debugging.md
+++ b/docs/newbs_testing_debugging.md
@@ -15,7 +15,17 @@ Note: These programs are not provided by or endorsed by QMK.
 
 ## Debugging With QMK Toolbox
 
-[QMK Toolbox](https://github.com/qmk/qmk_toolbox) will show messages from your keyboard if you have `CONSOLE_ENABLE = yes` in your `rules.mk`. By default the output is very limited, but you can turn on debug mode to increase the amount of debug output. Use the `DEBUG` keycode in your keymap, or use the [Command](feature_command.md) feature to enable debug mode.
+[QMK Toolbox](https://github.com/qmk/qmk_toolbox) will show messages from your keyboard if you have `CONSOLE_ENABLE = yes` in your `rules.mk`. By default the output is very limited, but you can turn on debug mode to increase the amount of debug output. Use the `DEBUG` keycode in your keymap, use the [Command](feature_command.md) feature to enable debug mode, or add the following code to your keymap.
+
+```c
+void keyboard_post_init_user(void) {
+  // Customise these values to desired behaviour
+  debug_enable=true;
+  debug_matrix=true;
+  //debug_keyboard=true;
+  //debug_mouse=true;
+}
+```
 
 <!-- FIXME: Describe the debugging messages here. -->
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Now that #3113 has been merged, there is a nice programmatic way to toggle debug modes. This is useful when debugging matrix scan issues, where you cannot rely on keycodes/key presses.

**Note:** `keyboard_pre_init_user` still does not allow the same method, however i have [this commit](/zvecr/qmk_firmware/commit/ec051765b2b72617355d1c7877709e400ac4d2f0) that could fix it. The main issue is that `keyboard_pre_init_user` runs before `magic()` in `keyboard_init`
setting anything to do with the debug_x variables in matrix_init_user gets reset by whats in eeconfig_read_debug a little later. It looks like quite a common pattern in the keyboards folder, and these would all be broken... but i'm guessing they may have been from before the magic init code was introduced

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
