### PR TITLE
Fix build detection of keymap and board changes

### DIFF
--- a/util/travis_build.sh
+++ b/util/travis_build.sh
@@ -17,16 +17,18 @@ if [[ "$TRAVIS_COMMIT_MESSAGE" != *"[skip build]"* ]] ; then
 	else
 		NEFM=$(git diff --name-only -n 1 ${TRAVIS_COMMIT_RANGE} | grep -Ev '^(keyboards/)'  | grep -Ev '^(docs/)' | wc -l)
 		BRANCH=$(git rev-parse --abbrev-ref HEAD)
+		# is this branch master or a "non docs, non keyboards" change 
 		if [ $NEFM -gt 0 -o "$BRANCH" = "master" ]; then
 			echo "Making default keymaps for all keyboards"
 			eval $MAKE_ALL
 			: $((exit_code = $exit_code + $?))
 		else
-			MKB=$(git diff --name-only -n 1 ${TRAVIS_COMMIT_RANGE} | grep -oP '(?<=keyboards\/)([a-zA-Z0-9_\/]+)(?=\/)' | sort -u)
+		    # keyboards project format
+			#  /keyboards/board1/rev/keymaps/
+			#  /keyboards/board2/keymaps/
+			# ensure we strip everything off after and including the keymaps folder to get board and/or revision
+			MKB=$(git diff --name-only -n 1 ${TRAVIS_COMMIT_RANGE} | grep -oP '(?<=keyboards\/)([a-zA-Z0-9_\/]+)(?=\/)' | sed 's^/keymaps/.*^^' | sort -u)
 			for KB in $MKB ; do
-				if [[ $KB == *keymaps* ]]; then
-					continue
-				fi
 				KEYMAP_ONLY=$(git diff --name-only -n 1 ${TRAVIS_COMMIT_RANGE} | grep -Ev '^(keyboards/'${KB}'/keymaps/)' | wc -l)
 				if [[ $KEYMAP_ONLY -gt 0 ]]; then
 					echo "Making all keymaps for $KB"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
<!--- Describe your changes in detail here. -->
Fix build detection of keymap and board changes

#5127 contains changes that are only keymap, travis decided to skip building the keymap. This is the build output:
```bash
0.02s$ bash util/travis_build.sh
keyboards/kc60/keymaps/noroadsleft/keymap.c
keyboards/kc60/keymaps/noroadsleft/readme.md
keyboards/kc60/keymaps/noroadsleft/readme_ch1.md
keyboards/kc60/keymaps/noroadsleft/readme_ch2.md
keyboards/kc60/keymaps/noroadsleft/readme_ch3.md
keyboards/kc60/keymaps/noroadsleft/readme_ch4.md
keyboards/kc60/keymaps/noroadsleft/readme_ch5.md
keyboards/kc60/keymaps/noroadsleft/readme_git.md
The command "bash util/travis_build.sh" exited with 0.
```

Introduced with this [commit](/qmk/qmk_firmware/commit/800ec55dfca06b4630acf62cbb5f130c4031e4f1). The combination of the continue logic, and the more aggressive grep including slashes result in the KB value containing too much info, as for a keymap change it includes the keymap folder.

This PR fixes the issue by removing the keymap folder, to get back to the previous build logic, while maintaining the new sub project folder structure.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
