### PR TITLE
Add NO_PIN guards before setPinXXX()

### DIFF
--- a/quantum/matrix.c
+++ b/quantum/matrix.c
@@ -235,19 +235,25 @@ static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
 
 static void select_row(uint8_t row)
 {
-    setPinOutput(row_pins[row]);
-    writePinLow(row_pins[row]);
+    if (row_pins[row] != NO_PIN) {
+        setPinOutput(row_pins[row]);
+        writePinLow(row_pins[row]);
+    }
 }
 
 static void unselect_row(uint8_t row)
 {
-    setPinInputHigh(row_pins[row]);
+    if (row_pins[row] != NO_PIN) {
+        setPinInputHigh(row_pins[row]);
+    }
 }
 
 static void unselect_rows(void)
 {
     for(uint8_t x = 0; x < MATRIX_ROWS; x++) {
-        setPinInput(row_pins[x]);
+        if (row_pins[x] != NO_PIN) {
+            setPinInput(row_pins[x]);
+        }
     }
 }
 
@@ -256,7 +262,9 @@ static void unselect_rows(void)
 static void init_rows(void)
 {
     for(uint8_t x = 0; x < MATRIX_ROWS; x++) {
-        setPinInputHigh(row_pins[x]);
+        if (row_pins[x] != NO_PIN) {
+            setPinInputHigh(row_pins[x]);
+        }
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The keeb.io BDN9 macropad is one of two boards that use `NO_PIN` in their `config.h`. When the BDN9 is compiled & run on a Proton-C with `CONVERT_TO_PROTON_C=yes`, the firmware crashes and the user receives 'USB device descriptor request failed.' I've added guards to prevent this that mimic the ones in `quantum/split_common/matrix.c` for the purpose of discussion, but if `NO_PIN` should not be a thing, this can easily go another direction.

cc: @nooges 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
