### PR TITLE
Fix Audio Clicky

### DIFF
--- a/quantum/process_keycode/process_clicky.c
+++ b/quantum/process_keycode/process_clicky.c
@@ -32,7 +32,7 @@ extern bool midi_activated;
 
 void clicky_play(void) {
 #ifndef NO_MUSIC_MODE
-  if (music_activated || midi_activated || audio_config.enable) return;
+  if (music_activated || midi_activated || !audio_config.enable) return;
 #endif // !NO_MUSIC_MODE
   clicky_song[0][0] = 2.0f * clicky_freq * (1.0f + clicky_rand * ( ((float)rand()) / ((float)(RAND_MAX)) ) );
   clicky_song[1][0] = clicky_freq * (1.0f + clicky_rand * ( ((float)rand()) / ((float)(RAND_MAX)) ) );


### PR DESCRIPTION

## Description

When I was trying to fix some issues on ARM, I added a check to `clicky_play` to make sure that it only clicked when audio was enabled.  But I apparently missed the exclamation mark, and hard disabled it....

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [X] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
