### PR TITLE
On ARM, run stop_all_notes on startup

### DIFF
--- a/quantum/audio/audio_arm.c
+++ b/quantum/audio/audio_arm.c
@@ -317,6 +317,8 @@ void audio_init() {
 
   if (audio_config.enable) {
     PLAY_SONG(startup_song);
+  } else {
+    stop_all_notes();
   }
 
 }


### PR DESCRIPTION
If there is no song and audio is disabled, do this to prevent continous tone from playing