### PR TITLE
[Docs] Fix typo in RGB Matrix Driver configuration

### DIFF
--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -102,8 +102,8 @@ From this point forward the configuration is the same for all the drivers.
 
 The format for the matrix position used in this array is `{row | (col << 4)}`. The `x` is between (inclusive) 0-224, and `y` is between (inclusive) 0-64. The easiest way to calculate these positions is:
 
-    x = 224 / ( NUMBER_OF_ROWS - 1 ) * ROW_POSITION
-    y = 64 / (NUMBER_OF_COLS - 1 ) * COL_POSITION
+    x = 224 / ( NUMBER_OF_COLS - 1 ) * ROW_POSITION
+    y = 64 / (NUMBER_OF_ROWS - 1 ) * COL_POSITION
 
 Where all variables are decimels/floats.
 

--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -67,7 +67,7 @@ Configure the hardware via your `config.h`:
 	#define DRIVER_ADDR_1 0b1010000
 	#define DRIVER_ADDR_2 0b1010000 // this is here for compliancy reasons.
 
-	#define DRIVER_COUNT 1
+	#define DRIVER_COUNT 2
 	#define DRIVER_1_LED_TOTAL 64
 	#define DRIVER_LED_TOTAL DRIVER_1_LED_TOTAL
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
## Commit 1
Fix compiling problems with the default settings in the documentation #3797.
Firmware does not compile with DRIVER_COUNT 1

## Commit 2
The calculation for the matrix position is wrong
```
   x = 224 / ( NUMBER_OF_ROWS - 1 ) * ROW_POSITION
   y = 64 / (NUMBER_OF_COLS - 1 ) * COL_POSITION
```
NUMBER_OF_ROWS and NUMBER_OF_COLS should be switched
```
    x = 224 / ( NUMBER_OF_COLS - 1 ) * ROW_POSITION
    y = 64 / (NUMBER_OF_ROWS - 1 ) * COL_POSITION
```
In [qmk_firmware/keyboards/planck/light/light.c](https://github.com/qmk/qmk_firmware/blob/master/keyboards/planck/light/light.c#L86)
x         = 224 / ( NUMBER_OF_COLS - 1 )
20.36 = 224/ (12-1)

```
    ...
    {{0|(0<<4)},   {20.36*0, 21.33*0}, 1},
    ...
```

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [X] Documentation

## Issues Fixed or Closed by This PR

*  #3797

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).