### PR TITLE
fix: Make escape work after changing the backlight settings on the HS60 V2

### DIFF
--- a/keyboards/hs60/v2/config.h
+++ b/keyboards/hs60/v2/config.h
@@ -130,10 +130,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // Backlight config starts after EEPROM version
 #define RGB_BACKLIGHT_CONFIG_EEPROM_ADDR 35
-// Dynamic keymap starts after backlight config (35+31)
-#define DYNAMIC_KEYMAP_EEPROM_ADDR 66
+// Dynamic keymap starts after backlight config (35+32)
+#define DYNAMIC_KEYMAP_EEPROM_ADDR 67
 #define DYNAMIC_KEYMAP_LAYER_COUNT 4
-// Dynamic macro starts after dynamic keymaps (66+(4*5*14*2)) = (66+560)
-#define DYNAMIC_KEYMAP_MACRO_EEPROM_ADDR 626
+// Dynamic macro starts after dynamic keymaps (67+(4*5*14*2)) = (67+560)
+#define DYNAMIC_KEYMAP_MACRO_EEPROM_ADDR 627
 #define DYNAMIC_KEYMAP_MACRO_EEPROM_SIZE 398
 #define DYNAMIC_KEYMAP_MACRO_COUNT 16


### PR DESCRIPTION
## Description
This pull request fixes a bug where the keymap for the the top left key (usually escape) would be overwritten by the config for the rgb-backlight when it was written to the EEPROM. This would render the key unusable as the first byte of the keymap seems to be overwritten with the last byte of the backlight config. This is fixed by offsetting the keymap and everything there after by moving it by one byte

### Steps to reproduce
1. Flash the [current version](https://github.com/qmk/qmk_firmware/commit/b6e1e6aeeb2e2affce36a302ae0e14c07c8772c8)  of HS60 V2 ANSI to the board  `make hs60/v2:ansi:dfu-util`
2. The escape key should be working as expected
3. Change backlight effect/hue/brightness
4. The escape key will no longer be responsive, layer 2+ and the escape key still works fine.
5. Reset the EEPROM `Unplug -> Hold escape -> Plug in -> Unplug -> Release escape -> Plug in`
6. The escape key should now be functional until you change the backlight settings again.

My friend tested the [current version](https://github.com/qmk/qmk_firmware/commit/b6e1e6aeeb2e2affce36a302ae0e14c07c8772c8)  on the ISO version of this PCB and the issue does not seem to be present on that version. He also tested this branch and it did not break anything for him.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation


## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
