### PR TITLE
Add get_all_mods() function + clean up and reformat action_util files

### DIFF
--- a/tmk_core/common/action_util.c
+++ b/tmk_core/common/action_util.c
@@ -28,10 +28,10 @@ static uint8_t weak_mods = 0;
 static uint8_t macro_mods = 0;
 
 #ifdef USB_6KRO_ENABLE
-  #define RO_ADD(a, b) (((a) + (b)) % KEYBOARD_REPORT_KEYS)
-  #define RO_SUB(a, b) (((a) - (b) + KEYBOARD_REPORT_KEYS) % KEYBOARD_REPORT_KEYS)
-  #define RO_INC(a) RO_ADD(a, 1)
-  #define RO_DEC(a) RO_SUB(a, 1)
+#define RO_ADD(a, b) (((a) + (b)) % KEYBOARD_REPORT_KEYS)
+#define RO_SUB(a, b) (((a) - (b) + KEYBOARD_REPORT_KEYS) % KEYBOARD_REPORT_KEYS)
+#define RO_INC(a) RO_ADD(a, 1)
+#define RO_DEC(a) RO_SUB(a, 1)
 
 static int8_t cb_head = 0;
 static int8_t cb_tail = 0;
@@ -66,15 +66,15 @@ void clear_oneshot_locked_mods(void) {
   }
 }
 
-  #if defined(ONESHOT_TIMEOUT) && ONESHOT_TIMEOUT > 0
+#if defined(ONESHOT_TIMEOUT) && ONESHOT_TIMEOUT > 0
 static uint16_t oneshot_time = 0;
 
 bool has_oneshot_mods_timed_out(void) {
   return TIMER_DIFF_16(timer_read(), oneshot_time) >= ONESHOT_TIMEOUT;
 }
-  #else
+#else
 bool has_oneshot_mods_timed_out(void) { return false; }
-  #endif
+#endif
 #endif
 
 /* oneshot layer */
@@ -90,14 +90,14 @@ static int8_t oneshot_layer_data = 0;
 inline uint8_t get_oneshot_layer(void) { return oneshot_layer_data >> 3; }
 inline uint8_t get_oneshot_layer_state(void) { return oneshot_layer_data & 0b111; }
 
-  #if defined(ONESHOT_TIMEOUT) && ONESHOT_TIMEOUT > 0
+#if defined(ONESHOT_TIMEOUT) && ONESHOT_TIMEOUT > 0
 static uint16_t oneshot_layer_time = 0;
 
 inline bool has_oneshot_layer_timed_out() {
   return TIMER_DIFF_16(timer_read(), oneshot_layer_time) >= ONESHOT_TIMEOUT
       && !(get_oneshot_layer_state() & ONESHOT_TOGGLED);
 }
-  #endif
+#endif
 
 /** \brief Set oneshot layer
  *
@@ -106,9 +106,9 @@ inline bool has_oneshot_layer_timed_out() {
 void set_oneshot_layer(uint8_t layer, uint8_t state) {
   oneshot_layer_data = (layer << 3) | state;
   layer_on(layer);
-  #if defined(ONESHOT_TIMEOUT) && ONESHOT_TIMEOUT > 0
+#if defined(ONESHOT_TIMEOUT) && ONESHOT_TIMEOUT > 0
   oneshot_layer_time = timer_read();
-  #endif
+#endif
   oneshot_layer_changed_kb(get_oneshot_layer());
 }
 
@@ -118,9 +118,9 @@ void set_oneshot_layer(uint8_t layer, uint8_t state) {
  */
 void reset_oneshot_layer(void) {
   oneshot_layer_data = 0;
-  #if defined(ONESHOT_TIMEOUT) && ONESHOT_TIMEOUT > 0
+#if defined(ONESHOT_TIMEOUT) && ONESHOT_TIMEOUT > 0
   oneshot_layer_time = 0;
-  #endif
+#endif
   oneshot_layer_changed_kb(get_oneshot_layer());
 }
 
@@ -251,9 +251,9 @@ void clear_macro_mods(void) { macro_mods = 0; }
  */
 void set_oneshot_mods(uint8_t mods) {
   if (oneshot_mods != mods) {
-  #if defined(ONESHOT_TIMEOUT) && ONESHOT_TIMEOUT > 0
+#if defined(ONESHOT_TIMEOUT) && ONESHOT_TIMEOUT > 0
     oneshot_time = timer_read();
-  #endif
+#endif
     oneshot_mods = mods;
     oneshot_mods_changed_kb(mods);
   }
@@ -266,9 +266,9 @@ void set_oneshot_mods(uint8_t mods) {
 void clear_oneshot_mods(void) {
   if (oneshot_mods) {
     oneshot_mods = 0;
-  #if defined(ONESHOT_TIMEOUT) && ONESHOT_TIMEOUT > 0
+#if defined(ONESHOT_TIMEOUT) && ONESHOT_TIMEOUT > 0
     oneshot_time = 0;
-  #endif
+#endif
     oneshot_mods_changed_kb(oneshot_mods);
   }
 }
@@ -336,12 +336,12 @@ uint8_t get_all_mods(void) {
   uint8_t mods = real_mods | weak_mods | macro_mods;
 #ifndef NO_ACTION_ONESHOT
   if (oneshot_mods) {
-  #if defined(ONESHOT_TIMEOUT) && ONESHOT_TIMEOUT > 0
+#if defined(ONESHOT_TIMEOUT) && ONESHOT_TIMEOUT > 0
     if (has_oneshot_mods_timed_out()) {
       dprintf("Oneshot: timeout\n");
       clear_oneshot_mods();
     }
-  #endif
+#endif
     mods |= oneshot_mods;
     if (has_anykey(keyboard_report)) {
       clear_oneshot_mods();

--- a/tmk_core/common/action_util.c
+++ b/tmk_core/common/action_util.c
@@ -148,24 +148,7 @@ bool is_oneshot_layer_active(void)
  * FIXME: needs doc
  */
 void send_keyboard_report(void) {
-    keyboard_report->mods  = real_mods;
-    keyboard_report->mods |= weak_mods;
-    keyboard_report->mods |= macro_mods;
-#ifndef NO_ACTION_ONESHOT
-    if (oneshot_mods) {
-#if (defined(ONESHOT_TIMEOUT) && (ONESHOT_TIMEOUT > 0))
-        if (has_oneshot_mods_timed_out()) {
-            dprintf("Oneshot: timeout\n");
-            clear_oneshot_mods();
-        }
-#endif
-        keyboard_report->mods |= oneshot_mods;
-        if (has_anykey(keyboard_report)) {
-            clear_oneshot_mods();
-        }
-    }
-
-#endif
+    keyboard_report->mods = get_all_mods();
     host_keyboard_send(keyboard_report);
 }
 
@@ -331,6 +314,29 @@ void oneshot_layer_changed_user(uint8_t layer) { }
 __attribute__((weak))
 void oneshot_layer_changed_kb(uint8_t layer) {
     oneshot_layer_changed_user(layer);
+}
+
+/** \brief get all mods (mods + weak mods + macro mods + oneshot mods)
+ *
+ * FIXME: needs doc
+ */
+uint8_t get_all_mods(void) {
+    uint8_t mods = real_mods | weak_mods | macro_mods;
+#ifndef NO_ACTION_ONESHOT
+    if (oneshot_mods) {
+  #if defined(ONESHOT_TIMEOUT) && ONESHOT_TIMEOUT > 0
+        if (has_oneshot_mods_timed_out()) {
+            dprintf("Oneshot: timeout\n");
+            clear_oneshot_mods();
+        }
+  #endif
+        mods |= oneshot_mods;
+        if (has_anykey(keyboard_report)) {
+            clear_oneshot_mods();
+        }
+    }
+#endif
+    return mods;
 }
 
 /** \brief inspect keyboard state

--- a/tmk_core/common/action_util.c
+++ b/tmk_core/common/action_util.c
@@ -53,17 +53,17 @@ static uint8_t oneshot_locked_mods = 0;
 uint8_t get_oneshot_locked_mods(void) { return oneshot_locked_mods; }
 
 void set_oneshot_locked_mods(uint8_t mods) {
-    if (mods != oneshot_locked_mods) {
-        oneshot_locked_mods = mods;
-        oneshot_locked_mods_changed_kb(oneshot_locked_mods);
-    }
+  if (mods != oneshot_locked_mods) {
+    oneshot_locked_mods = mods;
+    oneshot_locked_mods_changed_kb(oneshot_locked_mods);
+  }
 }
 
 void clear_oneshot_locked_mods(void) {
-    if (oneshot_locked_mods) {
-        oneshot_locked_mods = 0;
-        oneshot_locked_mods_changed_kb(oneshot_locked_mods);
-    }
+  if (oneshot_locked_mods) {
+    oneshot_locked_mods = 0;
+    oneshot_locked_mods_changed_kb(oneshot_locked_mods);
+  }
 }
 
   #if defined(ONESHOT_TIMEOUT) && ONESHOT_TIMEOUT > 0
@@ -94,8 +94,8 @@ inline uint8_t get_oneshot_layer_state(void) { return oneshot_layer_data & 0b111
 static uint16_t oneshot_layer_time = 0;
 
 inline bool has_oneshot_layer_timed_out() {
-    return TIMER_DIFF_16(timer_read(), oneshot_layer_time) >= ONESHOT_TIMEOUT &&
-        !(get_oneshot_layer_state() & ONESHOT_TOGGLED);
+  return TIMER_DIFF_16(timer_read(), oneshot_layer_time) >= ONESHOT_TIMEOUT
+      && !(get_oneshot_layer_state() & ONESHOT_TOGGLED);
 }
   #endif
 
@@ -104,12 +104,12 @@ inline bool has_oneshot_layer_timed_out() {
  * FIXME: needs doc
  */
 void set_oneshot_layer(uint8_t layer, uint8_t state) {
-    oneshot_layer_data = (layer << 3) | state;
-    layer_on(layer);
+  oneshot_layer_data = (layer << 3) | state;
+  layer_on(layer);
   #if defined(ONESHOT_TIMEOUT) && ONESHOT_TIMEOUT > 0
-    oneshot_layer_time = timer_read();
+  oneshot_layer_time = timer_read();
   #endif
-    oneshot_layer_changed_kb(get_oneshot_layer());
+  oneshot_layer_changed_kb(get_oneshot_layer());
 }
 
 /** \brief Reset oneshot layer
@@ -117,11 +117,11 @@ void set_oneshot_layer(uint8_t layer, uint8_t state) {
  * FIXME: needs doc
  */
 void reset_oneshot_layer(void) {
-    oneshot_layer_data = 0;
+  oneshot_layer_data = 0;
   #if defined(ONESHOT_TIMEOUT) && ONESHOT_TIMEOUT > 0
-    oneshot_layer_time = 0;
+  oneshot_layer_time = 0;
   #endif
-    oneshot_layer_changed_kb(get_oneshot_layer());
+  oneshot_layer_changed_kb(get_oneshot_layer());
 }
 
 /** \brief Clear oneshot layer
@@ -129,12 +129,12 @@ void reset_oneshot_layer(void) {
  * FIXME: needs doc
  */
 void clear_oneshot_layer_state(oneshot_fullfillment_t state) {
-    uint8_t start_state = oneshot_layer_data;
-    oneshot_layer_data &= ~state;
-    if (!get_oneshot_layer_state() && start_state != oneshot_layer_data) {
-        layer_off(get_oneshot_layer());
-        reset_oneshot_layer();
-    }
+  uint8_t start_state = oneshot_layer_data;
+  oneshot_layer_data &= ~state;
+  if (!get_oneshot_layer_state() && start_state != oneshot_layer_data) {
+    layer_off(get_oneshot_layer());
+    reset_oneshot_layer();
+  }
 }
 
 /** \brief Is oneshot layer active
@@ -149,8 +149,8 @@ bool is_oneshot_layer_active(void) { return get_oneshot_layer_state(); }
  * FIXME: needs doc
  */
 void send_keyboard_report(void) {
-    keyboard_report->mods = get_all_mods();
-    host_keyboard_send(keyboard_report);
+  keyboard_report->mods = get_all_mods();
+  host_keyboard_send(keyboard_report);
 }
 
 /** \brief Get mods
@@ -293,7 +293,7 @@ void oneshot_locked_mods_changed_user(uint8_t mods) {}
  */
 __attribute__((weak))
 void oneshot_locked_mods_changed_kb(uint8_t mods) {
-    oneshot_locked_mods_changed_user(mods);
+  oneshot_locked_mods_changed_user(mods);
 }
 
 /** \brief Called when the one shot modifiers have been changed.
@@ -309,7 +309,7 @@ void oneshot_mods_changed_user(uint8_t mods) {}
  */
 __attribute__((weak))
 void oneshot_mods_changed_kb(uint8_t mods) {
-    oneshot_mods_changed_user(mods);
+  oneshot_mods_changed_user(mods);
 }
 
 /** \brief Called when the one shot layers have been changed.
@@ -325,7 +325,7 @@ void oneshot_layer_changed_user(uint8_t layer) {}
  */
 __attribute__((weak))
 void oneshot_layer_changed_kb(uint8_t layer) {
-    oneshot_layer_changed_user(layer);
+  oneshot_layer_changed_user(layer);
 }
 
 /** \brief get all mods (mods + weak mods + macro mods + oneshot mods)
@@ -333,22 +333,22 @@ void oneshot_layer_changed_kb(uint8_t layer) {
  * FIXME: needs doc
  */
 uint8_t get_all_mods(void) {
-    uint8_t mods = real_mods | weak_mods | macro_mods;
+  uint8_t mods = real_mods | weak_mods | macro_mods;
 #ifndef NO_ACTION_ONESHOT
-    if (oneshot_mods) {
+  if (oneshot_mods) {
   #if defined(ONESHOT_TIMEOUT) && ONESHOT_TIMEOUT > 0
-        if (has_oneshot_mods_timed_out()) {
-            dprintf("Oneshot: timeout\n");
-            clear_oneshot_mods();
-        }
-  #endif
-        mods |= oneshot_mods;
-        if (has_anykey(keyboard_report)) {
-            clear_oneshot_mods();
-        }
+    if (has_oneshot_mods_timed_out()) {
+      dprintf("Oneshot: timeout\n");
+      clear_oneshot_mods();
     }
+  #endif
+    mods |= oneshot_mods;
+    if (has_anykey(keyboard_report)) {
+      clear_oneshot_mods();
+    }
+  }
 #endif
-    return mods;
+  return mods;
 }
 
 /** \brief inspect keyboard state

--- a/tmk_core/common/action_util.c
+++ b/tmk_core/common/action_util.c
@@ -278,7 +278,6 @@ void clear_oneshot_mods(void) {
  * FIXME: needs doc
  */
 uint8_t get_oneshot_mods(void) { return oneshot_mods; }
-#endif
 
 /** \brief Called when the one shot modifiers have been changed.
  *
@@ -327,6 +326,7 @@ __attribute__((weak))
 void oneshot_layer_changed_kb(uint8_t layer) {
   oneshot_layer_changed_user(layer);
 }
+#endif
 
 /** \brief get all mods (mods + weak mods + macro mods + oneshot mods)
  *

--- a/tmk_core/common/action_util.h
+++ b/tmk_core/common/action_util.h
@@ -97,6 +97,7 @@ void oneshot_layer_changed_user(uint8_t layer);
 void oneshot_layer_changed_kb(uint8_t layer);
 
 /* inspect */
+uint8_t get_all_mods(void);
 uint8_t has_anymod(void);
 
 #ifdef __cplusplus

--- a/tmk_core/common/action_util.h
+++ b/tmk_core/common/action_util.h
@@ -17,6 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #pragma once
 
 #include "report.h"
+#include <stdbool.h>
 #include <stdint.h>
 
 #ifdef __cplusplus

--- a/tmk_core/common/action_util.h
+++ b/tmk_core/common/action_util.h
@@ -14,11 +14,10 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#ifndef ACTION_UTIL_H
-#define ACTION_UTIL_H
+#pragma once
 
-#include <stdint.h>
 #include "report.h"
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -29,17 +28,11 @@ extern report_keyboard_t *keyboard_report;
 void send_keyboard_report(void);
 
 /* key */
-inline void add_key(uint8_t key) {
-  add_key_to_report(keyboard_report, key);
-}
+inline void add_key(uint8_t key) { add_key_to_report(keyboard_report, key); }
 
-inline void del_key(uint8_t key) {
-  del_key_from_report(keyboard_report, key);
-}
+inline void del_key(uint8_t key) { del_key_from_report(keyboard_report, key); }
 
-inline void clear_keys(void) {
-  clear_keys_from_report(keyboard_report);
-}
+inline void clear_keys(void) { clear_keys_from_report(keyboard_report); }
 
 /* modifier */
 uint8_t get_mods(void);
@@ -81,6 +74,7 @@ typedef enum {
   ONESHOT_START = 0b11,
   ONESHOT_TOGGLED = 0b100
 } oneshot_fullfillment_t;
+
 void set_oneshot_layer(uint8_t layer, uint8_t state);
 uint8_t get_oneshot_layer(void);
 void clear_oneshot_layer_state(oneshot_fullfillment_t state);
@@ -102,6 +96,4 @@ uint8_t has_anymod(void);
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif


### PR DESCRIPTION
## Description

Add a `get_all_mods()` function to core that can be used to easily retrieve the current state of all mods (essentially `real_mods | weak_mods | macro_mods | oneshot_mods`).

I extracted this behavior from `send_keyboard_report()` into a separate function. As a side note, this is why `IS_COMMAND` and other things used to use `keyboard_report->mods` instead of `get_mods()`: the former contained the actual combined state of all mods, whereas the latter only returned real mods.

At some point after this PR, most or all remaining uses of `keyboard_report->mods` should probably be replaced with calls to `get_all_mods()` in order to avoid issues with the report format being different between 6KRO and NKRO, as described in #4838.

I also cleaned up the `action_util.*` files a bit. Namely, I removed trailing whitespace, added blank lines for readability, ensured 2-space indentation is used consistently, added missing parenthses around macro parameters, and so on.

### To-do
- [ ] Add `get_all_mods()` documentation.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
