### PR TITLE
Reduce tetris firmware size by disabling default audio

### DIFF
--- a/keyboards/tetris/rules.mk
+++ b/keyboards/tetris/rules.mk
@@ -52,7 +52,7 @@ COMMAND_ENABLE = no    # Commands for debug and configuration
 SLEEP_LED_ENABLE = no  # Breathing sleep LED during USB suspend
 NKRO_ENABLE = yes		# USB Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
 BACKLIGHT_ENABLE = no  # Enable keyboard backlight functionality
-AUDIO_ENABLE = yes
+AUDIO_ENABLE = no
 RGBLIGHT_ENABLE = yes
 TAP_DANCE_ENABLE = no
 


### PR DESCRIPTION
## Description
The `tetris:default` keymap rests just a few bytes below its maximum, such that even small overheads of new features (e.g `eeconfig` additions) push it over the limit.

Disabling default audio for this keyboard frees up a few thousand bytes while allowing those that want it to easily re-enable it.

The keyboard owner @YCF may also make additional size updates further on.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation