### PR TITLE
Added a key to handle copy/paste in and out of a terminal

### DIFF
--- a/keyboards/handwired/dactyl_manuform/5x6/keymaps/333fred/keymap.c
+++ b/keyboards/handwired/dactyl_manuform/5x6/keymaps/333fred/keymap.c
@@ -10,14 +10,14 @@ enum custom_macros {
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
   [BASE] = LAYOUT_5x6(
-     KC_GRV,        KC_1,        KC_2,  KC_3,  KC_4,    KC_5,                                KC_6,   KC_7,     KC_8,         KC_9,   KC_0,    KC_MINS,
-     KC_TAB,        KC_Q,        KC_W,  KC_E,  KC_R,    KC_T,                                KC_Y,   KC_U,     KC_I,         KC_O,   KC_P,    KC_BSLS,
-     KC_ESC,        KC_A,        KC_S,  KC_D,  KC_F,    KC_G,                                KC_H,   KC_J,     KC_K,         KC_L,   KC_SCLN, KC_QUOT,
-     OSM(MOD_LSFT), CTL_T(KC_Z), KC_X,  KC_C,  KC_V,    KC_B,                                KC_N,   KC_M,     KC_COMM,      KC_DOT, KC_SLSH, OSM(MOD_RSFT),
-                                 KC_F4, KC_F5,                                                                 TG(CODEFLOW), KC_EQL,
-                                               KC_LALT, KC_BSPC,                             KC_SPC, OSL(VIM),
-                                                        KC_TAB,  TD(TD_SYM_VIM),     KC_ENT, KC_RGUI,
-                                                        KC_LCTL, KC_DEL,             KC_UP,  KC_DOWN
+     KC_GRV,        KC_1,        KC_2,  KC_3,  KC_4,    KC_5,                                          KC_6,   KC_7,     KC_8,         KC_9,   KC_0,    KC_MINS,
+     KC_TAB,        KC_Q,        KC_W,  KC_E,  KC_R,    KC_T,                                          KC_Y,   KC_U,     KC_I,         KC_O,   KC_P,    KC_BSLS,
+     KC_ESC,        KC_A,        KC_S,  KC_D,  KC_F,    KC_G,                                          KC_H,   KC_J,     KC_K,         KC_L,   KC_SCLN, KC_QUOT,
+     OSM(MOD_LSFT), CTL_T(KC_Z), KC_X,  KC_C,  KC_V,    KC_B,                                          KC_N,   KC_M,     KC_COMM,      KC_DOT, KC_SLSH, OSM(MOD_RSFT),
+                                 KC_F4, KC_F5,                                                                           TG(CODEFLOW), KC_EQL,
+                                               KC_LALT, KC_BSPC,                                       KC_SPC, OSL(VIM),
+                                                        TD(TD_COPY_PASTE), TD(TD_SYM_VIM),     KC_ENT, KC_RGUI,
+                                                        KC_LCTL,           KC_DEL,             KC_UP,  KC_DOWN
   ),
 
   [CODEFLOW] = LAYOUT_5x6(

--- a/users/333fred/333fred.c
+++ b/users/333fred/333fred.c
@@ -9,7 +9,7 @@ typedef enum {
 static tap_dance_state_enum tap_dance_state;
 static bool tap_dance_active = false;
 
-void tap_dance_layer_finished(qk_tap_dance_state_t *state, void *user_data) {
+void tap_dance_sym_vim_finished(qk_tap_dance_state_t *state, void *user_data) {
     // Determine the current state
     if (state->count == 1) {
         if (state->interrupted || state->pressed == 0) tap_dance_state = SINGLE_TAP;
@@ -38,8 +38,7 @@ void tap_dance_layer_finished(qk_tap_dance_state_t *state, void *user_data) {
     }
 }
 
-
-void tap_dance_layer_reset(qk_tap_dance_state_t *state, void *user_data) {
+void tap_dance_sym_vim_reset(qk_tap_dance_state_t *state, void *user_data) {
     switch(tap_dance_state) {
         case SINGLE_TAP:
             clear_oneshot_layer_state(ONESHOT_PRESSED);
@@ -53,8 +52,38 @@ void tap_dance_layer_reset(qk_tap_dance_state_t *state, void *user_data) {
     }
 }
 
+void tap_dance_copy_paste_finished(qk_tap_dance_state_t *state, void *user_data) {
+    bool is_paste = state->count == 2;
+    // If either the one-shot shift is set, or if shift is being held, count as shift being held.
+    // We'll clear the one-shot shift if it was held
+    uint8_t one_shot_mods = get_oneshot_mods();
+    bool is_shift = false;
+
+    if (get_mods() & MOD_MASK_SHIFT) {
+        is_shift = true;
+    } else if (one_shot_mods & MOD_MASK_SHIFT) {
+        set_oneshot_mods(one_shot_mods & ~MOD_MASK_SHIFT);
+        is_shift = true;
+    }
+
+    if (is_paste) {
+        if (is_shift) {
+            SEND_STRING(SS_LSFT(SS_TAP(X_INSERT)));
+        } else {
+            SEND_STRING(SS_LCTRL("v"));
+        }
+    } else {
+        if (is_shift) {
+            SEND_STRING(SS_LCTRL(SS_TAP(X_INSERT)));
+        } else {
+            SEND_STRING(SS_LCTRL("c"));
+        }
+    }
+}
+
 qk_tap_dance_action_t tap_dance_actions[] = {
-    [TD_SYM_VIM] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, tap_dance_layer_finished, tap_dance_layer_reset)
+    [TD_SYM_VIM] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, tap_dance_sym_vim_finished, tap_dance_sym_vim_reset),
+    [TD_COPY_PASTE] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, tap_dance_copy_paste_finished, NULL)
 };
 
 void tap_dance_process_record(uint16_t keycode) {

--- a/users/333fred/333fred.h
+++ b/users/333fred/333fred.h
@@ -13,9 +13,10 @@
 
 // Tap dance config shared between my keyboards
 enum tap_dance_declarations {
-    TD_SYM_VIM = 0
+    TD_SYM_VIM = 0,
+    TD_COPY_PASTE,
 };
 
-void tap_dance_layer_finished(qk_tap_dance_state_t*, void*);
-void tap_dance_layer_reset(qk_tap_dance_state_t*, void*);
+void tap_dance_sym_vim_finished(qk_tap_dance_state_t*, void*);
+void tap_dance_sym_vim_reset(qk_tap_dance_state_t*, void*);
 void tap_dance_process_record(uint16_t);


### PR DESCRIPTION
## Description

Small update to my keymap adding a tap-dance for copying and pasting in both terminal and non-terminal scenarios.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
