### PR TITLE
Candybar: adjust rules.mk defaults

### DIFF
--- a/keyboards/candybar/rules.mk
+++ b/keyboards/candybar/rules.mk
@@ -39,11 +39,11 @@ EXTRAFLAGS+=-flto
 BACKLIGHT_ENABLE = no
 BOOTMAGIC_ENABLE = yes  # Virtual DIP switch configuration
 ## (Note that for BOOTMAGIC on Teensy LC you have to use a custom .ld script.)
-MOUSEKEY_ENABLE = yes # Mouse keys
+MOUSEKEY_ENABLE = no # Mouse keys
 EXTRAKEY_ENABLE = yes # Audio control and System control
 CONSOLE_ENABLE = yes  # Console for debug
 COMMAND_ENABLE = yes    # Commands for debug and configuration
-SLEEP_LED_ENABLE = yes  # Breathing sleep LED during USB suspend
+SLEEP_LED_ENABLE = no  # Breathing sleep LED during USB suspend
 NKRO_ENABLE = yes     # USB Nkey Rollover
 AUDIO_ENABLE = no
 RGBLIGHT_ENABLE = no


### PR DESCRIPTION
Binaries compiled at config.qmk.fm are oversized for the MCU. Adjusting
default options to compensate.