### PR TITLE
Use steno mode from base

### DIFF
--- a/keyboards/ergodox_ez/keymaps/steno/keymap.c
+++ b/keyboards/ergodox_ez/keymaps/steno/keymap.c
@@ -1,8 +1,7 @@
 #include QMK_KEYBOARD_H
 #include "debug.h"
 #include "action_layer.h"
-#include "sendchar.h"
-#include "virtser.h"
+#include "keymap_steno.h"
 
 #define BASE 0 // default layer
 #define SYMB 1 // symbols
@@ -137,35 +136,6 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
        KC_TRNS,
        KC_TRNS, KC_TRNS, KC_WBAK
 ),
-// TxBolt Codes
-#define Sl 0b00000001
-#define Tl 0b00000010
-#define Kl 0b00000100
-#define Pl 0b00001000
-#define Wl 0b00010000
-#define Hl 0b00100000
-#define Rl 0b01000001
-#define Al 0b01000010
-#define Ol 0b01000100
-#define X  0b01001000
-#define Er 0b01010000
-#define Ur 0b01100000
-#define Fr 0b10000001
-#define Rr 0b10000010
-#define Pr 0b10000100
-#define Br 0b10001000
-#define Lr 0b10010000
-#define Gr 0b10100000
-#define Tr 0b11000001
-#define Sr 0b11000010
-#define Dr 0b11000100
-#define Zr 0b11001000
-#define NM 0b11010000
-#define GRPMASK 0b11000000
-#define GRP0 0b00000000
-#define GRP1 0b01000000
-#define GRP2 0b10000000
-#define GRP3 0b11000000
 /* Keymap 3: TxBolt (Serial)
  *
  * ,--------------------------------------------------.           ,--------------------------------------------------.
@@ -190,22 +160,22 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 // TxBolt over Serial
 [TXBOLT] = LAYOUT_ergodox(
        KC_BSPC, KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,
-       KC_NO,   M(NM),   M(NM),   M(NM),   M(NM),   M(NM),  KC_NO,
-       KC_NO,   M(Sl),   M(Tl),   M(Pl),   M(Hl),   M(X),
-       KC_NO,   M(Sl),   M(Kl),   M(Wl),   M(Rl),   M(X),   KC_NO,
+       KC_NO,   STN_N1,  STN_N2,  STN_N3,  STN_N4,  STN_N5,  KC_NO,
+       KC_NO,   STN_S1,  STN_TL,  STN_PL,  STN_HL,  STN_ST1,
+       KC_NO,   STN_S2,  STN_KL,  STN_WL,  STN_RL,  STN_ST2, KC_NO,
        KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,
                                            KC_NO,   KC_NO,
                                                     KC_NO,
-                                  M(Al),   M(Ol),   KC_NO,
+                                  STN_A,   STN_O,   KC_NO,
     // right hand
        KC_NO,    KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,
-       KC_TRNS,  M(NM),   M(NM),   M(NM),   M(NM),   M(NM),   M(NM),
-                 M(X),    M(Fr),   M(Pr),   M(Lr),   M(Tr),   M(Dr),
-       KC_NO,    M(X),    M(Rr),   M(Br),   M(Gr),   M(Sr),   M(Zr),
+       KC_TRNS,  STN_N6,  STN_N7,  STN_N8,  STN_N9,  STN_NA,  STN_NB,
+                 STN_ST3, STN_FR,  STN_PR,  STN_LR,  STN_TR,  STN_DR,
+       KC_NO,    STN_ST4, STN_RR,  STN_BR,  STN_GR,  STN_SR,  STN_ZR,
                           KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,
        KC_NO,   KC_NO,
        KC_NO,
-       KC_NO,   M(Er),   M(Ur)
+       KC_NO,   STN_E,   STN_U
 ),
 /* Keymap 4: TxBolt (Serial) Alternative
  *
@@ -230,69 +200,29 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  */
 // TxBolt over Serial
 [TXBOLT2] = LAYOUT_ergodox(
-       KC_NO,   M(NM),   M(NM),   M(NM),   M(NM),   M(NM),  KC_NO,
-       KC_NO,   M(Sl),   M(Tl),   M(Pl),   M(Hl),   M(X),   KC_NO,
-       KC_NO,   M(Sl),   M(Kl),   M(Wl),   M(Rl),   M(X),
+       KC_NO,   STN_N1,  STN_N2,  STN_N3,  STN_N4,  STN_N5,  KC_NO,
+       KC_NO,   STN_S1,  STN_TL,  STN_PL,  STN_HL,  STN_ST1, KC_NO,
+       KC_NO,   STN_S2,  STN_KL,  STN_WL,  STN_RL,  STN_ST2,
        KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,
-       KC_NO,   KC_NO,   KC_NO,   M(Al),   M(Ol),
+       KC_NO,   KC_NO,   KC_NO,   STN_A,   STN_O,
                                            KC_NO,   KC_NO,
                                                     KC_NO,
                                   KC_NO,   KC_NO,   KC_NO,
     // right hand
-       KC_NO,    M(NM),   M(NM),   M(NM),   M(NM),   M(NM),   M(NM),
-       KC_TRNS,  M(X),    M(Fr),   M(Pr),   M(Lr),   M(Tr),   M(Dr),
-                 M(X),    M(Rr),   M(Br),   M(Gr),   M(Sr),   M(Zr),
+       KC_NO,    STN_N6,  STN_N7,  STN_N8,  STN_N9,  STN_NA,  STN_NB,
+       KC_TRNS,  STN_ST3, STN_FR,  STN_PR,  STN_LR,  STN_TR,  STN_DR,
+                 STN_ST4, STN_RR,  STN_BR,  STN_GR,  STN_SR,  STN_ZR,
        KC_NO,    KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,
-                          M(Er),   M(Ur),   KC_NO,   KC_NO,   KC_NO,
+                          STN_E,   STN_U,   KC_NO,   KC_NO,   KC_NO,
        KC_NO,   KC_NO,
        KC_NO,
        KC_NO,   KC_NO,   KC_NO
 ),
 };
 
-uint8_t chord[4] = {0,0,0,0};
-uint8_t pressed_count = 0;
-
-void send_chord(void)
-{
-  for(uint8_t i = 0; i < 4; i++)
-  {
-    if(chord[i])
-      virtser_send(chord[i]);
-  }
-  virtser_send(0);
-}
-
-bool process_record_user(uint16_t keycode, keyrecord_t *record)
-{
-  // We need to track keypresses in all modes, in case the user
-  // changes mode whilst pressing other keys.
-  if (record->event.pressed)
-    pressed_count++;
-  else
-    pressed_count--;
-  return true;
-}
-
-const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
-{
-  // MACRODOWN only works in this function
-
-  if (record->event.pressed) {
-    uint8_t grp = (id & GRPMASK) >> 6;
-    chord[grp] |= id;
-  }
-  else {
-    if (pressed_count == 0) {
-      send_chord();
-      chord[0] = chord[1] = chord[2] = chord[3] = 0;
-    }
-  }
-  return MACRO_NONE;
-};
-
 // Runs just one time when the keyboard initializes.
 void matrix_init_user(void) {
+    steno_set_mode(STENO_MODE_BOLT); // or STENO_MODE_GEMINI
 };
 
 // Runs constantly in the background, in a loop.

--- a/keyboards/ergodox_ez/keymaps/steno/rules.mk
+++ b/keyboards/ergodox_ez/keymaps/steno/rules.mk
@@ -1,3 +1,3 @@
-VIRTSER_ENABLE = yes
+STENO_ENABLE = yes          # Additional protocols for Stenography(+1700), requires VIRTSER
 # Not enough interupts, so something has to go
 MOUSEKEY_ENABLE = no


### PR DESCRIPTION
## Description

AFAIK this was the first layout to use a steno mode, and I think the keymap_steno was derived from it. But it was never changed to use keymap_steno.h.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

Currently these changes break the layout due to #4578. When changing to Gemini mode, it works. 

Since this might be used as a copy template, I think it is better to have it changed to use keymap_steno.h. 

You might consider waiting until #4578 is fixed before accepting this pull request, though.