### PR TITLE
Fix indentation in quantum_keycodes.h

### DIFF
--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -449,36 +449,35 @@ enum quantum_keycodes {
     KC_LOCK,
 #endif
 
-    #ifdef TERMINAL_ENABLE
-        TERM_ON,
-        TERM_OFF,
-    #endif
+#ifdef TERMINAL_ENABLE
+    TERM_ON,
+    TERM_OFF,
+#endif
 
-        EEPROM_RESET,
+    EEPROM_RESET,
 
-        UNICODE_MODE_FORWARD,
-        UNICODE_MODE_REVERSE,
+    UNICODE_MODE_FORWARD,
+    UNICODE_MODE_REVERSE,
+    UNICODE_MODE_OSX,
+    UNICODE_MODE_LNX,
+    UNICODE_MODE_WIN,
+    UNICODE_MODE_BSD,
+    UNICODE_MODE_WINC,
 
-        UNICODE_MODE_OSX,
-        UNICODE_MODE_LNX,
-        UNICODE_MODE_WIN,
-        UNICODE_MODE_BSD,
-        UNICODE_MODE_WINC,
+    HPT_ON,
+    HPT_OFF,
+    HPT_TOG,
+    HPT_RST,
+    HPT_FBK,
+    HPT_BUZ,
+    HPT_MODI,
+    HPT_MODD,
+    HPT_DWLI,
+    HPT_DWLD,
 
-        HPT_ON,
-        HPT_OFF,
-        HPT_TOG,
-        HPT_RST,
-        HPT_FBK,
-        HPT_BUZ,
-        HPT_MODI,
-        HPT_MODD,
-        HPT_DWLI,
-        HPT_DWLD,
-
-        // always leave at the end
-        SAFE_RANGE
-    };
+    // always leave at the end
+    SAFE_RANGE
+};
 
 // Ability to use mods in layouts
 #define LCTL(kc) (QK_LCTL | (kc))


### PR DESCRIPTION
#4939 messed up some of the indentation in `quantum/quantum_keycodes.h`. This fixes that.