### PR TITLE
Fix pinout for Quefrency left half w/macros

### DIFF
--- a/keyboards/keebio/quefrency/rev1/config.h
+++ b/keyboards/keebio/quefrency/rev1/config.h
@@ -34,8 +34,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MATRIX_COLS 8
 
 // wiring of each half
-#define MATRIX_ROW_PINS { F4, D4, D7, E6, B4, B5 }
-#define MATRIX_COL_PINS { F5, F6, F7, B1, B3, B2, B6, C6 }
+#define MATRIX_ROW_PINS { F4, D4, D7, E6, B4, C6 }
+#define MATRIX_COL_PINS { F5, F6, F7, B1, B3, B2, B6, B5 }
+#define MATRIX_ROW_PINS_RIGHT { F4, D4, D7, E6, B4, B5 }
+#define MATRIX_COL_PINS_RIGHT { F5, F6, F7, B1, B3, B2, B6, C6 }
 #define SPLIT_HAND_PIN D2
 
 /* Set 0 if debouncing isn't needed */


### PR DESCRIPTION
## Description

Fix pinout for Quefrency left half with 2x5 macro.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
