### PR TITLE
Corrected HS60 v2 keyboard name in info.json

### DIFF
--- a/keyboards/hs60/v2/info.json
+++ b/keyboards/hs60/v2/info.json
@@ -1,6 +1,6 @@
 {
-  "keyboard_name": "clueboard/60",
-  "maintainer": "skullydazed",
+  "keyboard_name": "HS60v2",
+  "maintainer": "qmk",
   "url": "",
   "width": 15,
   "height": 5,

--- a/keyboards/hs60/v2/info.json
+++ b/keyboards/hs60/v2/info.json
@@ -1,6 +1,6 @@
 {
   "keyboard_name": "HS60v2",
-  "maintainer": "qmk",
+  "maintainer": "yiancar",
   "url": "",
   "width": 15,
   "height": 5,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
I noticed the keyboard name and maintainer were incorrect in the HS60v2 info.json file, they have been updated now.  Let me know if your standard for "versions" are different, HS60V2 or HS60v2, or something else. 
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
