### PR TITLE
Add note about using Unicode Hex Input

### DIFF
--- a/docs/feature_unicode.md
+++ b/docs/feature_unicode.md
@@ -67,7 +67,6 @@ The following input modes are available:
 
   **Note:** Using the _Unicode Hex Input_ input source may disable some Option based shortcuts, such as: Option + Left Arrow (`moveWordLeftAndModifySelection`) and Option + Right Arrow  (`moveWordRightAndModifySelection`).
 
-
 * **`UC_LNX`**: Linux built-in IBus Unicode input. Supports code points up to `0x10FFFF` (all possible code points).
 
   Enabled by default and works almost anywhere on IBus-enabled distros. Without IBus, this mode works under GTK apps, but rarely anywhere else.

--- a/docs/feature_unicode.md
+++ b/docs/feature_unicode.md
@@ -65,7 +65,8 @@ The following input modes are available:
   To enable, go to _System Preferences > Keyboard > Input Sources_, add _Unicode Hex Input_ to the list (it's under _Other_), then activate it from the input dropdown in the Menu Bar.
   By default, this mode uses the left Option key (`KC_LALT`), but this can be changed by defining [`UNICODE_OSX_KEY`](#input-key-configuration) with another keycode.
 
-  This disables some Option based shortcuts including Option + Left Arrow and Option + Right Arrow (`moveWordLeftAndModifySelection` and `moveWordRightAndModifySelection`)
+  **Note:** Using the _Unicode Hex Input_ input source may disable some Option based shortcuts, such as: Option + Left Arrow (`moveWordLeftAndModifySelection`) and Option + Right Arrow  (`moveWordRightAndModifySelection`).
+
 
 * **`UC_LNX`**: Linux built-in IBus Unicode input. Supports code points up to `0x10FFFF` (all possible code points).
 

--- a/docs/feature_unicode.md
+++ b/docs/feature_unicode.md
@@ -65,6 +65,8 @@ The following input modes are available:
   To enable, go to _System Preferences > Keyboard > Input Sources_, add _Unicode Hex Input_ to the list (it's under _Other_), then activate it from the input dropdown in the Menu Bar.
   By default, this mode uses the left Option key (`KC_LALT`), but this can be changed by defining [`UNICODE_OSX_KEY`](#input-key-configuration) with another keycode.
 
+  This disables some Option based shortcuts including Option + Left Arrow and Option + Right Arrow (`moveWordLeftAndModifySelection` and `moveWordRightAndModifySelection`)
+
 * **`UC_LNX`**: Linux built-in IBus Unicode input. Supports code points up to `0x10FFFF` (all possible code points).
 
   Enabled by default and works almost anywhere on IBus-enabled distros. Without IBus, this mode works under GTK apps, but rarely anywhere else.
@@ -121,7 +123,7 @@ For instance, you can add these definitions to your `config.h` file:
 
 ### Additional Customization
 
-Because Unicode is such a large and variable feature, there are a number of options that you can customize to work better on your system. 
+Because Unicode is such a large and variable feature, there are a number of options that you can customize to work better on your system.
 
 #### Start and Finish input functions
 
@@ -183,7 +185,7 @@ AutoHotkey inserts the Text right of `Send, ` when this combination is pressed.
 
 ### US International
 
-If you enable the US International layout on the system, it will use punctuation to accent the characters. 
+If you enable the US International layout on the system, it will use punctuation to accent the characters.
 
 For instance, typing "`a" will result in à.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

Using Unicode Hex Input has a side effect of disabling the option arrow key combos in OSX. This took me a while to understand, so I thought I'd make a note of it here to save anyone else the headache.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The diff will explain better than more description here.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [n/a] I have added tests to cover my changes.
- [n/a] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
