### PR TITLE
Fix playback of long songs

### DIFF
--- a/quantum/audio/audio.c
+++ b/quantum/audio/audio.c
@@ -141,7 +141,7 @@ uint16_t notes_count;
 bool     notes_repeat;
 bool     note_resting = false;
 
-uint8_t current_note = 0;
+uint16_t current_note = 0;
 uint8_t rest_counter = 0;
 
 #ifdef VIBRATO_ENABLE

--- a/quantum/audio/audio_arm.c
+++ b/quantum/audio/audio_arm.c
@@ -54,7 +54,7 @@ uint16_t notes_count;
 bool     notes_repeat;
 bool     note_resting = false;
 
-uint8_t current_note = 0;
+uint16_t current_note = 0;
 uint8_t rest_counter = 0;
 
 #ifdef VIBRATO_ENABLE

--- a/quantum/audio/audio_pwm.c
+++ b/quantum/audio/audio_pwm.c
@@ -94,7 +94,7 @@ bool     notes_repeat;
 float    notes_rest;
 bool     note_resting = false;
 
-uint8_t current_note = 0;
+uint16_t current_note = 0;
 uint8_t rest_counter = 0;
 
 #ifdef VIBRATO_ENABLE


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
The `play_notes` function takes a `uint16` as the parameter for the length of the song, but the loop playing it uses a `uint8` as a counter, which will overflow on songs longer than 256 notes and loop even when `n_repeat` is `false` (and only play the first 256 notes of the song)

If anyone needs a long song to test this with (I've done this on my preonic rev3) this monstrosity exists https://github.com/inve1/qmk_firmware/blob/mrco/quantum/audio/song_list.h#L507

Anyway.. thanks for the cool firmware
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
