### PR TITLE
Bucktooth 2.0 key layout for Preonic

### DIFF
--- a/keyboards/preonic/keymaps/bucktooth/keymap.c
+++ b/keyboards/preonic/keymaps/bucktooth/keymap.c
@@ -28,32 +28,32 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 /* QwertSplitly
  * ,-----------------------------------------------------------------------------------.
- * |   1  |   2  |   3  |   4  |   5  |   -  |   =  |   6  |   7  |   8  |   9  |   0  |
+ * |   1  |   2  |   3  |   4  |   5  |   =  |   `  |   6  |   7  |   8  |   9  |   0  |
  * |------+------+------+------+------+------+------+------+------+------+------+------|
  * |   Q  |   W  |   E  |   R  |   T  |   [  |   ]  |   Y  |   U  |   I  |   O  |   P  |
  * |------+------+------+------+------+-------------+------+------+------+------+------|
- * |   A  |   S  |   D  |   F  |   G  |   `  |   '  |   H  |   J  |   K  |   L  |   ;  |
+ * |   A  |   S  |   D  |   F  |   G  |   -  |   '  |   H  |   J  |   K  |   L  |   ;  |
  * |------+------+------+------+------+------|------+------+------+------+------+------|
- * |LShift|   Z  |   X  |   C  |   V  |   B  |   \  |   /  |   N  |   M  |   ,  |./RSft|
+ * |LShift|   Z  |   X  |   C  |   V  |   \  |   /  |   B  |   N  |   M  |   ,  |./RSft|
  * |------+------+------+------+------+------+------+------+------+------+------+------|
  * |ESC/fn|LCtrl | LOpt | LCmd |Space | Tab  | BkSp |Space |En/Cmd|<-/fn |CRSR v|CRSR->|
  * `-----------------------------------------------------------------------------------'
  */
 [L_QWERTSPLITLY] = LAYOUT_preonic_grid( \
-  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_MINUS,KC_EQL,  KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    \
+  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_EQL  ,KC_GRAVE,KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    \
   KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_LBRC, KC_RBRC, KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    \
-  KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_GRAVE,KC_QUOTE,KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, \
-  KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_BSLS, KC_SLASH,KC_N,    KC_M,    KC_COMM, MT_RSDOT,\
+  KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_MINUS,KC_QUOTE,KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, \
+  KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_BSLS, KC_SLASH,KC_B,    KC_N,    KC_M,    KC_COMM, MT_RSDOT,\
   LT_FNESC,KC_LCTL, KC_LALT, KC_LGUI, KC_SPC,  KC_TAB,  KC_BSPC, KC_SPC,  MT_RGENT,LT_FNLFT,KC_DOWN, KC_RIGHT \
 ),
 
 /* Fn
  * ,-----------------------------------------------------------------------------------.
- * |  F1  |  F2  |  F3  |  F4  |  F5  | Vol- | Vol+ |  F6  |  F7  |  F8  |  F9  |  F10 |
+ * |  F1  |  F2  |  F3  |  F4  |  F5  | Vol+ | Mute |  F6  |  F7  |  F8  |  F9  |  F10 |
  * |------+------+------+------+------+------+------+------+------+------+------+------|
  * |  F11 |  F12 |  F13 |  F14 |  F15 |Track-|Track+|M:WhUp|M:Lclk| M:Up |M:Rclk| PgUp |
  * |------+------+------+------+------+-------------+------+------+------+------+------|
- * | Caps |^LPad |^DashB|^Help |^Drawr| Mute | |>|| |M:WhDn|M:Left|M:Down|M:Rght| PgDn |
+ * | Caps |^LPad |^DashB|^Help |^Drawr| Vol- | |>|| |M:WhDn|M:Left|M:Down|M:Rght| PgDn |
  * |------+------+------+------+------+------|------+------+------+------+------+------|
  * |RShift|^Menu |^SMenu|^Dock |^Tools|^Notif|  Ins |M:Slow|M:Norm|M:Fast| Home | End  |
  * |------+------+------+------+------+------+------+------+------+------+------+------|
@@ -61,9 +61,9 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * `-----------------------------------------------------------------------------------'
  */
 [L_FN] = LAYOUT_preonic_grid( \
-  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_VOLD, KC_VOLU, KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  \
+  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_VOLU, KC_MUTE, KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  \
   KC_F11,  KC_F12,  KC_F13,  KC_F14,  KC_F15,  KC_MRWD, KC_MFFD, KC_WH_U, KC_BTN1, KC_MS_U, KC_BTN2, KC_PGUP, \
-  KC_CAPS, MF_LPAD, MF_DASH, MF_HELP, MF_DRWR, KC_MUTE, KC_MPLY, KC_WH_D, KC_MS_L, KC_MS_D, KC_MS_R, KC_PGDN, \
+  KC_CAPS, MF_LPAD, MF_DASH, MF_HELP, MF_DRWR, KC_VOLD, KC_MPLY, KC_WH_D, KC_MS_L, KC_MS_D, KC_MS_R, KC_PGDN, \
   KC_RSFT, MF_MENU, MF_STAT, MF_DOCK, MF_TOOL, MF_NOTI, KC_INS,  KC_ACL0, KC_ACL1, KC_ACL2, KC_HOME, KC_END,  \
   _______, KC_RCTL, KC_RALT, KC_RGUI, _______, LS_TAB,  KC_DEL,  _______, KC_PENT, _______, KC_UP,   KC_LEFT  \
 )
@@ -93,14 +93,12 @@ void matrix_init_user(void) {
 
 void startup_user()
 {
-    _delay_ms(20); // gets rid of tick
     PLAY_SONG(tone_startup);
 }
 
 void shutdown_user()
 {
     PLAY_SONG(tone_goodbye);
-    _delay_ms(150);
     stop_all_notes();
 }
 

--- a/keyboards/preonic/keymaps/bucktooth/readme.md
+++ b/keyboards/preonic/keymaps/bucktooth/readme.md
@@ -1,4 +1,4 @@
-# Bucktooth v1.0 (Mac)
+# Bucktooth v2.0 (Mac)
 
 Bucktooth is an alternate layout that pushes the letters to the edges and puts most punctuation in the center. It's derived in part from my experience with Ergodox boards. I call the main layer layout QWERTSplitlY, you may notice the right side punctuation moving to the center and the control keys missing from the left.
 
@@ -6,13 +6,13 @@ Bucktooth is an alternate layout that pushes the letters to the edges and puts m
 
      QwertSplitly
      ,-----------------------------------------------------------------------------------.
-     |   1  |   2  |   3  |   4  |   5  |   -  |   =  |   6  |   7  |   8  |   9  |   0  |
+     |   1  |   2  |   3  |   4  |   5  |   +  |   `  |   6  |   7  |   8  |   9  |   0  |
      |------+------+------+------+------+------+------+------+------+------+------+------|
      |   Q  |   W  |   E  |   R  |   T  |   [  |   ]  |   Y  |   U  |   I  |   O  |   P  |
      |------+------+------+------+------+-------------+------+------+------+------+------|
-     |   A  |   S  |   D  |   F  |   G  |   `  |   '  |   H  |   J  |   K  |   L  |   ;  |
+     |   A  |   S  |   D  |   F  |   G  |   -  |   '  |   H  |   J  |   K  |   L  |   ;  |
      |------+------+------+------+------+------|------+------+------+------+------+------|
-     |LShift|   Z  |   X  |   C  |   V  |   B  |   \  |   /  |   N  |   M  |   ,  |./RSft|
+     |LShift|   Z  |   X  |   C  |   V  |   \  |   /  |   B  |   N  |   M  |   ,  |./RSft|
      |------+------+------+------+------+------+------+------+------+------+------+------|
      |ESC/fn|LCtrl | LOpt | LCmd |Space | Tab  | BkSp |Space |En/Cmd|<-/fn |CRSR v|CRSR->|
      `-----------------------------------------------------------------------------------'
@@ -24,6 +24,12 @@ That left shift is the only control or modifier key on the top four rows. All th
 
 With all control keys on the bottom row, the ESC key now lives in the bottom left and on my keyboard I actually put a very heavy keyswitch in that space to keep me from hitting it accidentally instead of ctrl. Hold it down and it becomes fn. I usually hit it with my whole hand since it is in the corner, without moving my fingers down to it.
 
+## Revision 2 Changes
+
+The move of B to the right side of the keyboard may be controversial but has felt more and more comfortable to me. Again if you split a staggered layout keyboard down a straight line B has more in common with Y than T. I don't understand breaking the board into left and right on anything but a vertical line despite the long history of bringing the staggered layout slewing left.
+
+Revision 2 also changes the positions of -, =, and ~ for better compatibility with sculpted profile keysets which offer a Dvorak set option that provides the middle row dash because a middle row backtick/tilde is not found anywhere.
+
 ## Function Layer
 
 There are no raise and lower or multiple function pages. The Preonic has enough keys to avoid more than a single function page, and I prefer to have spacebars for both thumbs so the "Bucktooth" name comes from the typical keyset with darker function keys and lighter alphas and space keys giving the keyboard fang-like appearance where the two spaces are.
@@ -31,11 +37,11 @@ There are no raise and lower or multiple function pages. The Preonic has enough 
 
      Fn
      ,-----------------------------------------------------------------------------------.
-     |  F1  |  F2  |  F3  |  F4  |  F5  | Vol- | Vol+ |  F6  |  F7  |  F8  |  F9  |  F10 |
+     |  F1  |  F2  |  F3  |  F4  |  F5  | Vol+ | Mute |  F6  |  F7  |  F8  |  F9  |  F10 |
      |------+------+------+------+------+------+------+------+------+------+------+------|
      |  F11 |  F12 |  F13 |  F14 |  F15 |Track-|Track+|M:WhUp|M:Lclk| M:Up |M:Rclk| PgUp |
      |------+------+------+------+------+-------------+------+------+------+------+------|
-     | Caps |^LPad |^DashB|^Help |^Drawr| Mute | |>|| |M:WhDn|M:Left|M:Down|M:Rght| PgDn |
+     | Caps |^LPad |^DashB|^Help |^Drawr| Vol- | |>|| |M:WhDn|M:Left|M:Down|M:Rght| PgDn |
      |------+------+------+------+------+------|------+------+------+------+------+------|
      |RShift|^Menu |^SMenu|^Dock |^Tools|^Notif|  Ins |M:Slow|M:Norm|M:Fast| Home | End  |
      |------+------+------+------+------+------+------+------+------+------+------+------|
@@ -50,6 +56,6 @@ The cursor keys are a design I stole from the old Commodore computers which had 
 
 On Fn layer ZXCVB and SDFG keys I have set up the default key bindings for Mac OS Keyboard Focus keys since they are obscure and require FKeys mostly. They are pretty convenient for using the keyboard to search the menus, go to the dock, etc. Some like the one to jump to a window's toolbar and the one to jump to a window's accessory drawer are less commonly used.
 
-___
+---
 
-Contributed to QMK and released with the QMK license by J. Eric Mason, 3/16/2018
+Contributed to QMK and released with the QMK license by Jeri C. Mason, 3/16/2018 - Revision 2 2/26/2019


### PR DESCRIPTION
Updated layout slightly for better compatibility with sculpted
(row-specific) profile keysets.

Fix build error on rev 3 toolchain; click waits don't seem to be
necessary anymore.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Over time I found that it was hard to move to sculpted keysets with this layout. I moved a few keys to make this better.

Compiling for my rev3 failed because of lack for a prototype for a time wait function. I removed some calls to wait before creating bleeps since I didn't think they were necessary now anyway.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).