### PR TITLE
Travis CI - skip unit tests for documentation changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
   - avr-gcc --version
 script:
 - git rev-parse --short HEAD
-- make test:all
+- bash util/travis_test.sh
 - bash util/travis_build.sh
 - bash util/travis_docs.sh
 addons:

--- a/util/travis_test.sh
+++ b/util/travis_test.sh
@@ -6,7 +6,7 @@ TRAVIS_COMMIT_RANGE="${TRAVIS_COMMIT_RANGE:-HEAD~1..HEAD}"
 # test force push
 #TRAVIS_COMMIT_RANGE="c287f1bfc5c8...81f62atc4c1d"
 
-NUM_IMPACTING_CHANGES=$(git diff --name-only -n 1 ${TRAVIS_COMMIT_RANGE} | grep -Ev '^(docs/)' | wc -l)
+NUM_IMPACTING_CHANGES=$(git diff --name-only -n 1 ${TRAVIS_COMMIT_RANGE} | grep -Ecv '^(docs/)')
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
 if [[ "$TRAVIS_COMMIT_MESSAGE" == *"[skip test]"* ]]; then

--- a/util/travis_test.sh
+++ b/util/travis_test.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+TRAVIS_COMMIT_MESSAGE="${TRAVIS_COMMIT_MESSAGE:-none}"
+TRAVIS_COMMIT_RANGE="${TRAVIS_COMMIT_RANGE:-HEAD~1..HEAD}"
+
+# test force push
+#TRAVIS_COMMIT_RANGE="c287f1bfc5c8...81f62atc4c1d"
+
+NUM_IMPACTING_CHANGES=$(git diff --name-only -n 1 ${TRAVIS_COMMIT_RANGE} | grep -Ev '^(docs/)' | wc -l)
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+if [[ "$TRAVIS_COMMIT_MESSAGE" == *"[skip test]"* ]]; then
+    echo "Skipping due to commit message"
+    exit 0
+fi
+
+if [ "$BRANCH" != "master" ] && [ "$NUM_IMPACTING_CHANGES" == "0" ]; then
+    echo "Skipping due to changes not impacting tests"
+    exit 0
+fi
+
+make test:all


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Currently unit tests take 35s, which if you have only changed docs is a waste of cpu cycles. Given the limit of 5 concurrent builds, any time saved helps to keep the build job backlog free.

This PR follows the ideas configured within `travis_build.sh` and sets up Travis to skip tests on non master branches with only docs changes.

This could safely be extended to keyboard and community layout folders if required.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
