### PR TITLE
Fix rgblight_enable ifdefs in my userspace

### DIFF
--- a/users/mechmerlin/changelog.md
+++ b/users/mechmerlin/changelog.md
@@ -1,10 +1,13 @@
 # Changelog
 All notable changes to my userspace will be documented in this file.
 
+## [0.2.1] - 2019-03-01
+### Fixed
+- `config.h` usage of `#ifdef RGBLIGHT_ENABLE` caused problems for other of my boards that had `RGBLIGHT_ENABLE`.  
+
 ## [0.2.0] - 2019-02-27
 ### Changed
 - Moved `AUDIO_CLICKY` from community layout `66_ansi` into user space. 
-- 
 
 ## [0.1.1] - 2018-10-26
 ### Added

--- a/users/mechmerlin/config.h
+++ b/users/mechmerlin/config.h
@@ -18,10 +18,20 @@
 
 // Enable features depending on keyboard
 #if defined(KEYBOARD_clueboard_66_hotswap_prototype)
-    #define RGBLIGHT_ENABLE
-    #define AUDIO_CLICKY
+    #ifndef RGBLIGHT_ENABLE
+        #define RGBLIGHT_ENABLE
+    #endif
+
+    #ifndef AUDIO_CLICKY
+        #define AUDIO_CLICKY
+    #endif
+
 #elif defined(KEYBOARD_clueboard_66_hotswap_gen1)
-    #define AUDIO_CLICKY
+    #ifndef AUDIO_CLICKY
+        #define AUDIO_CLICKY
+    #endif
 #else
-    #define RGBLIGHT_ENABLE
+    #ifndef RGBLIGHT_ENABLE
+        #define RGBLIGHT_ENABLE
+    #endif
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Looks like I broke some of the mechmerlin community layouts when it came to rgb lights. This should fix it by checking for RGBLIGHT_ENABLE before actually using `#define RGBLIGHT_ENABLE`. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
