### PR TITLE
[Keyboard] Add support for matrix_scan_user to usb-usb converter

### DIFF
--- a/keyboards/converter/usb_usb/custom_matrix.cpp
+++ b/keyboards/converter/usb_usb/custom_matrix.cpp
@@ -115,6 +115,15 @@ extern "C"
         }
     }
 
+    __attribute__ ((weak))
+    void matrix_scan_kb(void) {
+        matrix_scan_user();
+    }
+
+    __attribute__ ((weak))
+    void matrix_scan_user(void) {
+    }
+
     uint8_t matrix_scan(void) {
         static uint16_t last_time_stamp1 = 0;
         static uint16_t last_time_stamp2 = 0;
@@ -169,6 +178,7 @@ extern "C"
                 keyboard_set_leds(host_keyboard_leds());
             }
         }
+        matrix_scan_kb();
         return 1;
     }
 

--- a/keyboards/converter/usb_usb/custom_matrix.cpp
+++ b/keyboards/converter/usb_usb/custom_matrix.cpp
@@ -98,6 +98,7 @@ extern "C"
         kbd2.SetReportParser(0, (HIDReportParser*)&kbd_parser2);
         kbd3.SetReportParser(0, (HIDReportParser*)&kbd_parser3);
         kbd4.SetReportParser(0, (HIDReportParser*)&kbd_parser4);
+        matrix_init_quantum();
     }
 
     static void or_report(report_keyboard_t report) {
@@ -113,6 +114,16 @@ extern "C"
                 }
             }
         }
+    }
+
+    __attribute__ ((weak))
+    void matrix_init_kb(void) {
+        matrix_init_user();
+    }
+
+    __attribute__ ((weak))
+    void matrix_init_user(void) {
+        matrix_init_user();
     }
 
     __attribute__ ((weak))

--- a/keyboards/converter/usb_usb/custom_matrix.cpp
+++ b/keyboards/converter/usb_usb/custom_matrix.cpp
@@ -178,7 +178,7 @@ extern "C"
                 keyboard_set_leds(host_keyboard_leds());
             }
         }
-        matrix_scan_kb();
+        matrix_scan_quantum();
         return 1;
     }
 


### PR DESCRIPTION
## Description

This change adds the matrix_scan_kb and matrix_scan_user calls to the custom matrix_scan for usb-usb converters. I needed this to make the Leader key code work.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Leader key and other things dependent on matrix_scan_user did not work.

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
