### PR TITLE
Define RGB colors

### DIFF
--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -189,6 +189,35 @@ Custom layer effects can be done by defining this in your `<keyboard>.c`:
 
 A similar function works in the keymap as `rgb_matrix_indicators_user`.
 
+
+## Colors
+
+These are shorthands to popular colors. The `RGB` ones can be passed to the `setrgb` functions, while the `HSV` ones to the `sethsv` functions.
+
+|RGB                |HSV                |
+|-------------------|-------------------|
+|`RGB_WHITE`        |`HSV_WHITE`        |
+|`RGB_RED`          |`HSV_RED`          |
+|`RGB_CORAL`        |`HSV_CORAL`        |
+|`RGB_ORANGE`       |`HSV_ORANGE`       |
+|`RGB_GOLDENROD`    |`HSV_GOLDENROD`    |
+|`RGB_GOLD`         |`HSV_GOLD`         |
+|`RGB_YELLOW`       |`HSV_YELLOW`       |
+|`RGB_CHARTREUSE`   |`HSV_CHARTREUSE`   |
+|`RGB_GREEN`        |`HSV_GREEN`        |
+|`RGB_SPRINGGREEN`  |`HSV_SPRINGGREEN`  |
+|`RGB_TURQUOISE`    |`HSV_TURQUOISE`    |
+|`RGB_TEAL`         |`HSV_TEAL`         |
+|`RGB_CYAN`         |`HSV_CYAN`         |
+|`RGB_AZURE`        |`HSV_AZURE`        |
+|`RGB_BLUE`         |`HSV_BLUE`         |
+|`RGB_PURPLE`       |`HSV_PURPLE`       |
+|`RGB_MAGENTA`      |`HSV_MAGENTA`      |
+|`RGB_PINK`         |`HSV_PINK`         |
+
+These are defined in [`rgblight_list.h`](https://github.com/qmk/qmk_firmware/blob/master/quantum/rgblight_list.h). Feel free to add to this list!
+
+
 ## Additional `config.h` Options
 
 	#define RGB_MATRIX_KEYPRESSES // reacts to keypresses (will slow down matrix scan by a lot)

--- a/docs/feature_rgblight.md
+++ b/docs/feature_rgblight.md
@@ -218,8 +218,8 @@ rgblight_setrgb_at(RGB_GOLD, 3);
 rgblight_sethsv_range(HSV_WHITE, 0, 6);
 ```
 
+These are defined in [`rgblight_list.h`](https://github.com/qmk/qmk_firmware/blob/master/quantum/rgblight_list.h). Feel free to add to this list!
 
-Additionally, [`rgblight_list.h`](https://github.com/qmk/qmk_firmware/blob/master/quantum/rgblight_list.h) defines several predefined shortcuts for various colors. Feel free to add to this list!
 
 ## Hardware Modification
 

--- a/docs/feature_rgblight.md
+++ b/docs/feature_rgblight.md
@@ -186,6 +186,39 @@ If you need to change your RGB lighting in code, for example in a macro to chang
 |`rgblight_decrease_val()`                   |Decrease the value for all LEDs. This wraps around at minimum value                                                                                           |
 |`rgblight_decrease_val_noeeprom()`          |Decrease the value for all LEDs. This wraps around at minimum value (not written to EEPROM)                                                                   |
 
+## Colors
+
+These are shorthands to popular colors. The `RGB` ones can be passed to the `setrgb` functions, while the `HSV` ones to the `sethsv` functions.
+
+|RGB                |HSV                |
+|-------------------|-------------------|
+|`RGB_WHITE`        |`HSV_WHITE`        |
+|`RGB_RED`          |`HSV_RED`          |
+|`RGB_CORAL`        |`HSV_CORAL`        |
+|`RGB_ORANGE`       |`HSV_ORANGE`       |
+|`RGB_GOLDENROD`    |`HSV_GOLDENROD`    |
+|`RGB_GOLD`         |`HSV_GOLD`         |
+|`RGB_YELLOW`       |`HSV_YELLOW`       |
+|`RGB_CHARTREUSE`   |`HSV_CHARTREUSE`   |
+|`RGB_GREEN`        |`HSV_GREEN`        |
+|`RGB_SPRINGGREEN`  |`HSV_SPRINGGREEN`  |
+|`RGB_TURQUOISE`    |`HSV_TURQUOISE`    |
+|`RGB_TEAL`         |`HSV_TEAL`         |
+|`RGB_CYAN`         |`HSV_CYAN`         |
+|`RGB_AZURE`        |`HSV_AZURE`        |
+|`RGB_BLUE`         |`HSV_BLUE`         |
+|`RGB_PURPLE`       |`HSV_PURPLE`       |
+|`RGB_MAGENTA`      |`HSV_MAGENTA`      |
+|`RGB_PINK`         |`HSV_PINK`         |
+
+```c
+rgblight_setrgb(RGB_ORANGE);
+rgblight_sethsv_noeeprom(HSV_GREEN);
+rgblight_setrgb_at(RGB_GOLD, 3);
+rgblight_sethsv_range(HSV_WHITE, 0, 6);
+```
+
+
 Additionally, [`rgblight_list.h`](https://github.com/qmk/qmk_firmware/blob/master/quantum/rgblight_list.h) defines several predefined shortcuts for various colors. Feel free to add to this list!
 
 ## Hardware Modification

--- a/quantum/rgb_matrix.h
+++ b/quantum/rgb_matrix.h
@@ -23,6 +23,7 @@
 #include <stdbool.h>
 #include "color.h"
 #include "quantum.h"
+#include "rgblight_list.h"
 
 #ifdef IS31FL3731
     #include "is31fl3731.h"

--- a/quantum/rgblight_list.h
+++ b/quantum/rgblight_list.h
@@ -13,111 +13,148 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef RGBLIGHT_LIST_H
-#define RGBLIGHT_LIST_H
+#pragma once
+
+/*              RGB COLORS             */
+#define RGB_WHITE        0xFF, 0xFF, 0xFF
+#define RGB_RED          0xFF, 0x00, 0x00
+#define RGB_CORAL        0xFF, 0x7C, 0x4D
+#define RGB_ORANGE       0xFF, 0x80, 0x00
+#define RGB_GOLDENROD    0xD9, 0xA5, 0x21
+#define RGB_GOLD         0xFF, 0xD9, 0x00
+#define RGB_YELLOW       0xFF, 0xFF, 0x00
+#define RGB_CHARTREUSE   0x80, 0xFF, 0x00
+#define RGB_GREEN        0x00, 0xFF, 0x00
+#define RGB_SPRINGGREEN  0x00, 0xFF, 0x80
+#define RGB_TURQUOISE    0x47, 0x6E, 0x6A
+#define RGB_TEAL         0x00, 0x80, 0x80
+#define RGB_CYAN         0x00, 0xFF, 0xFF
+#define RGB_AZURE        0x99, 0xf5, 0xFF
+#define RGB_BLUE         0x00, 0x00, 0xFF
+#define RGB_PURPLE       0x7A, 0x00, 0xFF
+#define RGB_MAGENTA      0xFF, 0x00, 0xFF
+#define RGB_PINK         0xFF, 0x80, 0xBF
+
+/*            HSV COLORS            */
+#define HSV_WHITE          0,   0, 255
+#define HSV_RED            0, 255, 255
+#define HSV_CORAL         16, 176, 255
+#define HSV_ORANGE        39, 255, 255
+#define HSV_GOLDENROD     43, 218, 218
+#define HSV_GOLD          51, 255, 255
+#define HSV_YELLOW        60, 255, 255
+#define HSV_CHARTREUSE    90, 255, 255
+#define HSV_GREEN        120, 255, 255
+#define HSV_SPRINGGREEN  150, 255, 255
+#define HSV_TURQUOISE    174,  90, 112
+#define HSV_TEAL         180, 255, 128
+#define HSV_CYAN         180, 255, 255
+#define HSV_AZURE        186, 102, 255
+#define HSV_BLUE         240, 255, 255
+#define HSV_PURPLE       270, 255, 255
+#define HSV_MAGENTA      300, 255, 255
+#define HSV_PINK         330, 128, 255
 
 /*                            SET RGB List                            */
-#define rgblight_setrgb_white()       rgblight_setrgb (0xFF, 0xFF, 0xFF)
-#define rgblight_setrgb_red()         rgblight_setrgb (0xFF, 0x00, 0x00)
-#define rgblight_setrgb_coral()       rgblight_setrgb (0xFF, 0x7C, 0x4D)
-#define rgblight_setrgb_orange()      rgblight_setrgb (0xFF, 0x80, 0x00)
-#define rgblight_setrgb_goldenrod()   rgblight_setrgb (0xD9, 0xA5, 0x21)
-#define rgblight_setrgb_gold()        rgblight_setrgb (0xFF, 0xD9, 0x00)
-#define rgblight_setrgb_yellow()      rgblight_setrgb (0xFF, 0xFF, 0x00)
-#define rgblight_setrgb_chartreuse()  rgblight_setrgb (0x80, 0xFF, 0x00)
-#define rgblight_setrgb_green()       rgblight_setrgb (0x00, 0xFF, 0x00)
-#define rgblight_setrgb_springgreen() rgblight_setrgb (0x00, 0xFF, 0x80)
-#define rgblight_setrgb_turquoise()   rgblight_setrgb (0x47, 0x6E, 0x6A)
-#define rgblight_setrgb_teal()        rgblight_setrgb (0x00, 0x80, 0x80)
-#define rgblight_setrgb_cyan()        rgblight_setrgb (0x00, 0xFF, 0xFF)
-#define rgblight_setrgb_azure()       rgblight_setrgb (0x99, 0xf5, 0xFF)
-#define rgblight_setrgb_blue()        rgblight_setrgb (0x00, 0x00, 0xFF)
-#define rgblight_setrgb_purple()      rgblight_setrgb (0x7A, 0x00, 0xFF)
-#define rgblight_setrgb_magenta()     rgblight_setrgb (0xFF, 0x00, 0xFF)
-#define rgblight_setrgb_pink()        rgblight_setrgb (0xFF, 0x80, 0xBF)
+#define rgblight_setrgb_white()       rgblight_setrgb (RGB_WHITE)
+#define rgblight_setrgb_red()         rgblight_setrgb (RGB_RED)
+#define rgblight_setrgb_coral()       rgblight_setrgb (RGB_CORAL)
+#define rgblight_setrgb_orange()      rgblight_setrgb (RGB_ORANGE)
+#define rgblight_setrgb_goldenrod()   rgblight_setrgb (RGB_GOLDENROD)
+#define rgblight_setrgb_gold()        rgblight_setrgb (RGB_GOLD)
+#define rgblight_setrgb_yellow()      rgblight_setrgb (RGB_YEllOW)
+#define rgblight_setrgb_chartreuse()  rgblight_setrgb (RGB_CHARTREUSE)
+#define rgblight_setrgb_green()       rgblight_setrgb (RGB_GREEN)
+#define rgblight_setrgb_springgreen() rgblight_setrgb (RGB_SPRINGGREEN)
+#define rgblight_setrgb_turquoise()   rgblight_setrgb (RGB_TURQUOISE)
+#define rgblight_setrgb_teal()        rgblight_setrgb (RGB_TEAL)
+#define rgblight_setrgb_cyan()        rgblight_setrgb (RGB_CYAN)
+#define rgblight_setrgb_azure()       rgblight_setrgb (RGB_AZURE)
+#define rgblight_setrgb_blue()        rgblight_setrgb (RGB_BLUE)
+#define rgblight_setrgb_purple()      rgblight_setrgb (RGB_PURPLE)
+#define rgblight_setrgb_magenta()     rgblight_setrgb (RGB_MAGENTA)
+#define rgblight_setrgb_pink()        rgblight_setrgb (RGB_PINK)
 
 /*                            SET RGB List                            */
-#define rgblight_setrgb_white_at(at)       rgblight_setrgb_at (0xFF, 0xFF, 0xFF, at)
-#define rgblight_setrgb_red_at(at)         rgblight_setrgb_at (0xFF, 0x00, 0x00, at)
-#define rgblight_setrgb_coral_at(at)       rgblight_setrgb_at (0xFF, 0x7C, 0x4D, at)
-#define rgblight_setrgb_orange_at(at)      rgblight_setrgb_at (0xFF, 0x80, 0x00, at)
-#define rgblight_setrgb_goldenrod_at(at)   rgblight_setrgb_at (0xD9, 0xA5, 0x21, at)
-#define rgblight_setrgb_gold_at(at)        rgblight_setrgb_at (0xFF, 0xD9, 0x00, at)
-#define rgblight_setrgb_yellow_at(at)      rgblight_setrgb_at (0xFF, 0xFF, 0x00, at)
-#define rgblight_setrgb_chartreuse_at(at)  rgblight_setrgb_at (0x80, 0xFF, 0x00, at)
-#define rgblight_setrgb_green_at(at)       rgblight_setrgb_at (0x00, 0xFF, 0x00, at)
-#define rgblight_setrgb_springgreen_at(at) rgblight_setrgb_at (0x00, 0xFF, 0x80, at)
-#define rgblight_setrgb_turquoise_at(at)   rgblight_setrgb_at (0x47, 0x6E, 0x6A, at)
-#define rgblight_setrgb_teal_at(at)        rgblight_setrgb_at (0x00, 0x80, 0x80, at)
-#define rgblight_setrgb_cyan_at(at)        rgblight_setrgb_at (0x00, 0xFF, 0xFF, at)
-#define rgblight_setrgb_azure_at(at)       rgblight_setrgb_at (0x99, 0xf5, 0xFF, at)
-#define rgblight_setrgb_blue_at(at)        rgblight_setrgb_at (0x00, 0x00, 0xFF, at)
-#define rgblight_setrgb_purple_at(at)      rgblight_setrgb_at (0x7A, 0x00, 0xFF, at)
-#define rgblight_setrgb_magenta_at(at)     rgblight_setrgb_at (0xFF, 0x00, 0xFF, at)
-#define rgblight_setrgb_pink_at(at)        rgblight_setrgb_at (0xFF, 0x80, 0xBF, at)
+#define rgblight_setrgb_white_at(at)       rgblight_setrgb_at (RGB_WHITE, at)
+#define rgblight_setrgb_red_at(at)         rgblight_setrgb_at (RGB_RED, at)
+#define rgblight_setrgb_coral_at(at)       rgblight_setrgb_at (RGB_CORAL, at)
+#define rgblight_setrgb_orange_at(at)      rgblight_setrgb_at (RGB_ORANGE at)
+#define rgblight_setrgb_goldenrod_at(at)   rgblight_setrgb_at (RGB_GOLDENROD, at)
+#define rgblight_setrgb_gold_at(at)        rgblight_setrgb_at (RGB_GOLD, at)
+#define rgblight_setrgb_yellow_at(at)      rgblight_setrgb_at (RGB_YELLOW, at)
+#define rgblight_setrgb_chartreuse_at(at)  rgblight_setrgb_at (RGB_CHARTREUSE, at)
+#define rgblight_setrgb_green_at(at)       rgblight_setrgb_at (RGB_GREEN, at)
+#define rgblight_setrgb_springgreen_at(at) rgblight_setrgb_at (RGB_SPRINGGREEN, at)
+#define rgblight_setrgb_turquoise_at(at)   rgblight_setrgb_at (RGB_TURQUOISE, at)
+#define rgblight_setrgb_teal_at(at)        rgblight_setrgb_at (RGB_TEAL, at)
+#define rgblight_setrgb_cyan_at(at)        rgblight_setrgb_at (RGB_CYAN, at)
+#define rgblight_setrgb_azure_at(at)       rgblight_setrgb_at (RGB_AZURE, at)
+#define rgblight_setrgb_blue_at(at)        rgblight_setrgb_at (RGB_BLUE, at)
+#define rgblight_setrgb_purple_at(at)      rgblight_setrgb_at (RGB_PURPLE, at)
+#define rgblight_setrgb_magenta_at(at)     rgblight_setrgb_at (RGB_MAGENTA, at)
+#define rgblight_setrgb_pink_at(at)        rgblight_setrgb_at (RGB_PINK, at)
 
 /*                            SET HSV List                            */
-#define rgblight_sethsv_white()       rgblight_sethsv (  0,   0, 255)
-#define rgblight_sethsv_red()         rgblight_sethsv (  0, 255, 255)
-#define rgblight_sethsv_coral()       rgblight_sethsv ( 16, 176, 255)
-#define rgblight_sethsv_orange()      rgblight_sethsv ( 39, 255, 255)
-#define rgblight_sethsv_goldenrod()   rgblight_sethsv ( 43, 218, 218)
-#define rgblight_sethsv_gold()        rgblight_sethsv ( 51, 255, 255)
-#define rgblight_sethsv_yellow()      rgblight_sethsv ( 60, 255, 255)
-#define rgblight_sethsv_chartreuse()  rgblight_sethsv ( 90, 255, 255)
-#define rgblight_sethsv_green()       rgblight_sethsv (120, 255, 255)
-#define rgblight_sethsv_springgreen() rgblight_sethsv (150, 255, 255)
-#define rgblight_sethsv_turquoise()   rgblight_sethsv (174,  90, 112)
-#define rgblight_sethsv_teal()        rgblight_sethsv (180, 255, 128)
-#define rgblight_sethsv_cyan()        rgblight_sethsv (180, 255, 255)
-#define rgblight_sethsv_azure()       rgblight_sethsv (186, 102, 255)
-#define rgblight_sethsv_blue()        rgblight_sethsv (240, 255, 255)
-#define rgblight_sethsv_purple()      rgblight_sethsv (270, 255, 255)
-#define rgblight_sethsv_magenta()     rgblight_sethsv (300, 255, 255)
-#define rgblight_sethsv_pink()        rgblight_sethsv (330, 128, 255)
+#define rgblight_sethsv_white()       rgblight_sethsv (HSV_WHITE)
+#define rgblight_sethsv_red()         rgblight_sethsv (HSV_RED)
+#define rgblight_sethsv_coral()       rgblight_sethsv (HSV_CORAL)
+#define rgblight_sethsv_orange()      rgblight_sethsv (HSV_ORANGE)
+#define rgblight_sethsv_goldenrod()   rgblight_sethsv (HSV_GOLDENROD)
+#define rgblight_sethsv_gold()        rgblight_sethsv (HSV_GOLD)
+#define rgblight_sethsv_yellow()      rgblight_sethsv (HSV_YELLOW)
+#define rgblight_sethsv_chartreuse()  rgblight_sethsv (HSV_CHARTREUSE)
+#define rgblight_sethsv_green()       rgblight_sethsv (HSV_GREEN)
+#define rgblight_sethsv_springgreen() rgblight_sethsv (HSV_SPRINGGREEN)
+#define rgblight_sethsv_turquoise()   rgblight_sethsv (HSV_TURQUOISE)
+#define rgblight_sethsv_teal()        rgblight_sethsv (HSV_TEAL)
+#define rgblight_sethsv_cyan()        rgblight_sethsv (HSV_CYAN)
+#define rgblight_sethsv_azure()       rgblight_sethsv (HSV_AZURE)
+#define rgblight_sethsv_blue()        rgblight_sethsv (HSV_BLUE)
+#define rgblight_sethsv_purple()      rgblight_sethsv (HSV_PURPLE)
+#define rgblight_sethsv_magenta()     rgblight_sethsv (HSV_MAGENTA)
+#define rgblight_sethsv_pink()        rgblight_sethsv (HSV_PINK)
 
 /*                            SET HSV List                            */
 /*   If you're doing layer indication, this is best, as it won't      */
 /*   write to the eeprom, since it's limited (very high value).       */
 /*   If you want to use modes with this (since you can), then you     */
 /*   want to use rgblight_mode_noeeprom(x) instead.                   */
-#define rgblight_sethsv_noeeprom_white()       rgblight_sethsv_noeeprom (  0,   0, 255)
-#define rgblight_sethsv_noeeprom_red()         rgblight_sethsv_noeeprom (  0, 255, 255)
-#define rgblight_sethsv_noeeprom_coral()       rgblight_sethsv_noeeprom ( 16, 176, 255)
-#define rgblight_sethsv_noeeprom_orange()      rgblight_sethsv_noeeprom ( 39, 255, 255)
-#define rgblight_sethsv_noeeprom_goldenrod()   rgblight_sethsv_noeeprom ( 43, 218, 218)
-#define rgblight_sethsv_noeeprom_gold()        rgblight_sethsv_noeeprom ( 51, 255, 255)
-#define rgblight_sethsv_noeeprom_yellow()      rgblight_sethsv_noeeprom ( 60, 255, 255)
-#define rgblight_sethsv_noeeprom_chartreuse()  rgblight_sethsv_noeeprom ( 90, 255, 255)
-#define rgblight_sethsv_noeeprom_green()       rgblight_sethsv_noeeprom (120, 255, 255)
-#define rgblight_sethsv_noeeprom_springgreen() rgblight_sethsv_noeeprom (150, 255, 255)
-#define rgblight_sethsv_noeeprom_turquoise()   rgblight_sethsv_noeeprom (174,  90, 112)
-#define rgblight_sethsv_noeeprom_teal()        rgblight_sethsv_noeeprom (180, 255, 128)
-#define rgblight_sethsv_noeeprom_cyan()        rgblight_sethsv_noeeprom (180, 255, 255)
-#define rgblight_sethsv_noeeprom_azure()       rgblight_sethsv_noeeprom (186, 102, 255)
-#define rgblight_sethsv_noeeprom_blue()        rgblight_sethsv_noeeprom (240, 255, 255)
-#define rgblight_sethsv_noeeprom_purple()      rgblight_sethsv_noeeprom (270, 255, 255)
-#define rgblight_sethsv_noeeprom_magenta()     rgblight_sethsv_noeeprom (300, 255, 255)
-#define rgblight_sethsv_noeeprom_pink()        rgblight_sethsv_noeeprom (330, 128, 255)
+#define rgblight_sethsv_noeeprom_white()       rgblight_sethsv_noeeprom (HSV_WHITE)
+#define rgblight_sethsv_noeeprom_red()         rgblight_sethsv_noeeprom (HSV_RED)
+#define rgblight_sethsv_noeeprom_coral()       rgblight_sethsv_noeeprom (HSV_CORAL)
+#define rgblight_sethsv_noeeprom_orange()      rgblight_sethsv_noeeprom (HSV_ORANGE)
+#define rgblight_sethsv_noeeprom_goldenrod()   rgblight_sethsv_noeeprom (HSV_GOLDENROD)
+#define rgblight_sethsv_noeeprom_gold()        rgblight_sethsv_noeeprom (HSV_GOLD)
+#define rgblight_sethsv_noeeprom_yellow()      rgblight_sethsv_noeeprom (HSV_YELLOW)
+#define rgblight_sethsv_noeeprom_chartreuse()  rgblight_sethsv_noeeprom (HSV_CHARTREUSE)
+#define rgblight_sethsv_noeeprom_green()       rgblight_sethsv_noeeprom (HSV_GREEN)
+#define rgblight_sethsv_noeeprom_springgreen() rgblight_sethsv_noeeprom (HSV_SPRINGGREEN)
+#define rgblight_sethsv_noeeprom_turquoise()   rgblight_sethsv_noeeprom (HSV_TURQUOISE)
+#define rgblight_sethsv_noeeprom_teal()        rgblight_sethsv_noeeprom (HSV_TEAL)
+#define rgblight_sethsv_noeeprom_cyan()        rgblight_sethsv_noeeprom (HSV_CYAN)
+#define rgblight_sethsv_noeeprom_azure()       rgblight_sethsv_noeeprom (HSV_AZURE)
+#define rgblight_sethsv_noeeprom_blue()        rgblight_sethsv_noeeprom (HSV_BLUE)
+#define rgblight_sethsv_noeeprom_purple()      rgblight_sethsv_noeeprom (HSV_PURPLE)
+#define rgblight_sethsv_noeeprom_magenta()     rgblight_sethsv_noeeprom (HSV_MAGENTA)
+#define rgblight_sethsv_noeeprom_pink()        rgblight_sethsv_noeeprom (HSV_PINK)
 
 /*                            SET HSV List                            */
-#define rgblight_sethsv_white_at(at)       rgblight_sethsv_at (  0,   0, 255, at)
-#define rgblight_sethsv_red_at(at)         rgblight_sethsv_at (  0, 255, 255, at)
-#define rgblight_sethsv_coral_at(at)       rgblight_sethsv_at ( 16, 176, 255, at)
-#define rgblight_sethsv_orange_at(at)      rgblight_sethsv_at ( 39, 255, 255, at)
-#define rgblight_sethsv_goldenrod_at(at)   rgblight_sethsv_at ( 43, 218, 218, at)
-#define rgblight_sethsv_gold_at(at)        rgblight_sethsv_at ( 51, 255, 255, at)
-#define rgblight_sethsv_yellow_at(at)      rgblight_sethsv_at ( 60, 255, 255, at)
-#define rgblight_sethsv_chartreuse_at(at)  rgblight_sethsv_at ( 90, 255, 255, at)
-#define rgblight_sethsv_green_at(at)       rgblight_sethsv_at (120, 255, 255, at)
-#define rgblight_sethsv_springgreen_at(at) rgblight_sethsv_at (150, 255, 255, at)
-#define rgblight_sethsv_turquoise_at(at)   rgblight_sethsv_at (174,  90, 112, at)
-#define rgblight_sethsv_teal_at(at)        rgblight_sethsv_at (180, 255, 128, at)
-#define rgblight_sethsv_cyan_at(at)        rgblight_sethsv_at (180, 255, 255, at)
-#define rgblight_sethsv_azure_at(at)       rgblight_sethsv_at (186, 102, 255, at)
-#define rgblight_sethsv_blue_at(at)        rgblight_sethsv_at (240, 255, 255, at)
-#define rgblight_sethsv_purple_at(at)      rgblight_sethsv_at (270, 255, 255, at)
-#define rgblight_sethsv_magenta_at(at)     rgblight_sethsv_at (300, 255, 255, at)
-#define rgblight_sethsv_pink_at(at)        rgblight_sethsv_at (330, 128, 255, at)
-
-#endif
+#define rgblight_sethsv_white_at(at)       rgblight_sethsv_at (HSV_WHITE, at)
+#define rgblight_sethsv_red_at(at)         rgblight_sethsv_at (HSV_RED, at)
+#define rgblight_sethsv_coral_at(at)       rgblight_sethsv_at (HSV_CORAL, at)
+#define rgblight_sethsv_orange_at(at)      rgblight_sethsv_at (HSV_ORANGE, at)
+#define rgblight_sethsv_goldenrod_at(at)   rgblight_sethsv_at (HSV_GOLDENROD, at)
+#define rgblight_sethsv_gold_at(at)        rgblight_sethsv_at (HSV_GOLD, at)
+#define rgblight_sethsv_yellow_at(at)      rgblight_sethsv_at (HSV_YELLOW, at)
+#define rgblight_sethsv_chartreuse_at(at)  rgblight_sethsv_at (HSV_CHARTREUSE, at)
+#define rgblight_sethsv_green_at(at)       rgblight_sethsv_at (HSV_GREEN, at)
+#define rgblight_sethsv_springgreen_at(at) rgblight_sethsv_at (HSV_SPRINGGREEN, at)
+#define rgblight_sethsv_turquoise_at(at)   rgblight_sethsv_at (HSV_TURQUOISE, at)
+#define rgblight_sethsv_teal_at(at)        rgblight_sethsv_at (HSV_TEAL, at)
+#define rgblight_sethsv_cyan_at(at)        rgblight_sethsv_at (HSV_CYAN, at)
+#define rgblight_sethsv_azure_at(at)       rgblight_sethsv_at (HSV_AZURE, at)
+#define rgblight_sethsv_blue_at(at)        rgblight_sethsv_at (HSV_BLUE, at)
+#define rgblight_sethsv_purple_at(at)      rgblight_sethsv_at (HSV_PURPLE, at)
+#define rgblight_sethsv_magenta_at(at)     rgblight_sethsv_at (HSV_MAGENTA, at)
+#define rgblight_sethsv_pink_at(at)        rgblight_sethsv_at (HSV_PINK, at)

--- a/quantum/rgblight_list.h
+++ b/quantum/rgblight_list.h
@@ -55,6 +55,21 @@
 #define HSV_MAGENTA      300, 255, 255
 #define HSV_PINK         330, 128, 255
 
+
+/*
+########################################################################################
+##                                                                                    ##
+##                                                                                    ##
+##                                                                                    ##
+##  The functions below have been deprecated and may be removed in a future release.  ##
+##                                                                                    ##
+##                Please use the values above with the RGB functions.                 ##
+##                                                                                    ##
+##                                                                                    ##
+##                                                                                    ##
+########################################################################################
+*/
+
 /*                            SET RGB List                            */
 #define rgblight_setrgb_white()       rgblight_setrgb (RGB_WHITE)
 #define rgblight_setrgb_red()         rgblight_setrgb (RGB_RED)


### PR DESCRIPTION
Define RGB colors and pass them to the rgblight functions, instead of
defining multiple macros.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Instead of having multiple macros for each color, the PR defines the color twice (RGB/HSV) that can be passed to the appropriate functions.
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
