### PR TITLE
Correct keyboard and layout dimensions for 40percent.club Foobar

### DIFF
--- a/keyboards/40percentclub/foobar/info.json
+++ b/keyboards/40percentclub/foobar/info.json
@@ -2,10 +2,12 @@
     "keyboard_name": "foobar",
     "url": "",
     "maintainer": "qmk",
-    "width": 6,
-    "height": 2,
+    "width": 10,
+    "height": 3,
     "layouts": {
         "LAYOUT_macro": {
+            "width": 5,
+            "height": 3,
             "key_count": 15,
             "layout": [
               {"x":0, "y":0}, {"x":1, "y":0}, {"x":2, "y":0}, {"x":3, "y":0}, {"x":4, "y":0},


### PR DESCRIPTION
## Description / Notes

More clean-up tasks pertaining to the API and QMK Configurator.

Checking was prompted by a report from @i5ar in #4098.

For reference:

- https://github.com/qmk/qmk_firmware/issues/4098#issuecomment-469055391
- https://github.com/qmk/qmk_firmware/issues/4098#issuecomment-469081332


## Commit Log

### Correct keyboard and layout dimensions for 40percent.club Foobar (19a6793)
