### PR TITLE
[Keymap] Smarter KC_MAKE code and removed duplicate MOD_MASK entries

### DIFF
--- a/users/stanrc85/stanrc85.c
+++ b/users/stanrc85/stanrc85.c
@@ -18,17 +18,15 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
           //RESET board for flashing if SHIFT held or tapped with KC_MAKE
           #if defined(__arm__)
             send_string_with_delay_P(PSTR(":dfu-util"), 10);
-            wait_ms(100);
-            reset_keyboard();
           #elif defined(BOOTLOADER_DFU)
             send_string_with_delay_P(PSTR(":dfu"), 10);
           #elif defined(BOOTLOADER_HALFKAY)
             send_string_with_delay_P(PSTR(":teensy"), 10);
           #elif defined(BOOTLOADER_CATERINA)
             send_string_with_delay_P(PSTR(":avrdude"), 10);
-          #else
-            reset_keyboard();
           #endif // bootloader options
+          send_string_with_delay_P(PSTR(SS_TAP(X_ENTER)), 10);
+          reset_keyboard();
         }
         if (temp_mod & MOD_MASK_CTRL || temp_osm & MOD_MASK_CTRL) { send_string_with_delay_P(PSTR(" -j8 --output-sync"), 10); }
         send_string_with_delay_P(PSTR(SS_TAP(X_ENTER)), 10);

--- a/users/stanrc85/stanrc85.c
+++ b/users/stanrc85/stanrc85.c
@@ -9,12 +9,10 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
   switch (keycode) {
   case KC_MAKE:
     if (!record->event.pressed) {
-      uint8_t temp_mod = get_mods();
-      uint8_t temp_osm = get_oneshot_mods();
+      uint8_t mods = get_mods();
       clear_mods();
-      clear_oneshot_mods();
       send_string_with_delay_P(PSTR("make " QMK_KEYBOARD ":" QMK_KEYMAP), 10);
-        if (temp_mod & MOD_MASK_SHIFT || temp_osm & MOD_MASK_SHIFT ) {
+        if (mods & MOD_MASK_SHIFT) {
           //RESET board for flashing if SHIFT held or tapped with KC_MAKE
           #if defined(__arm__)
             send_string_with_delay_P(PSTR(":dfu-util"), 10);
@@ -28,9 +26,11 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
           send_string_with_delay_P(PSTR(SS_TAP(X_ENTER)), 10);
           reset_keyboard();
         }
-        if (temp_mod & MOD_MASK_CTRL || temp_osm & MOD_MASK_CTRL) { send_string_with_delay_P(PSTR(" -j8 --output-sync"), 10); }
+        if (mods & MOD_MASK_CTRL) {
+          send_string_with_delay_P(PSTR(" -j8 --output-sync"), 10);
+        }
         send_string_with_delay_P(PSTR(SS_TAP(X_ENTER)), 10);
-        set_mods(temp_mod);
+        set_mods(mods);
       }
     return false;
     break;

--- a/users/stanrc85/stanrc85.c
+++ b/users/stanrc85/stanrc85.c
@@ -14,7 +14,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
       clear_mods();
       clear_oneshot_mods();
       send_string_with_delay_P(PSTR("make " QMK_KEYBOARD ":" QMK_KEYMAP), 10);
-        if (temp_mod & MODS_SHIFT_MASK || temp_osm & MODS_SHIFT_MASK ) {
+        if (temp_mod & MOD_MASK_SHIFT || temp_osm & MOD_MASK_SHIFT ) {
           //RESET board for flashing if SHIFT held or tapped with KC_MAKE
           #if defined(__arm__)
             send_string_with_delay_P(PSTR(":dfu-util"), 10);
@@ -30,7 +30,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             reset_keyboard();
           #endif // bootloader options
         }
-        if (temp_mod & MODS_CTRL_MASK || temp_osm & MODS_CTRL_MASK) { send_string_with_delay_P(PSTR(" -j8 --output-sync"), 10); }
+        if (temp_mod & MOD_MASK_CTRL || temp_osm & MOD_MASK_CTRL) { send_string_with_delay_P(PSTR(" -j8 --output-sync"), 10); }
         send_string_with_delay_P(PSTR(SS_TAP(X_ENTER)), 10);
         set_mods(temp_mod);
       }

--- a/users/stanrc85/stanrc85.h
+++ b/users/stanrc85/stanrc85.h
@@ -13,9 +13,6 @@ enum custom_keycodes {
   NEW_SAFE_RANGE  //use "NEW_SAFE_RANGE" for keymap specific codes
 };
 
-#define MODS_SHIFT_MASK  (MOD_BIT(KC_LSHIFT)|MOD_BIT(KC_RSHIFT))
-#define MODS_CTRL_MASK  (MOD_BIT(KC_LCTL)|MOD_BIT(KC_RCTRL))
-
 //Aliases for longer keycodes
 #define KC_CAD	LALT(LCTL(KC_DEL))
 #define KC_LOCK	LGUI(KC_L)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

- Better reset_keyboard() code in KC_MAKE macro
- Removed duplicate MOD_MASK entries

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
