### PR TITLE
Keymap update: Use `register_code16()` and its variants in lieu of separate mod registration

### DIFF
--- a/keyboards/minidox/keymaps/dustypomerleau/keymap.c
+++ b/keyboards/minidox/keymaps/dustypomerleau/keymap.c
@@ -58,7 +58,7 @@ void sftpls_reset (qk_tap_dance_state_t *state, void *user_data);
 #define ALT_D LALT_T(KC_D)
 #define ALT_E LALT_T(KC_E)
 #define ALT_K LALT_T(KC_K)
-#define ALT_OB LALT_T(KC_LBRC)
+#define ALT_LB LALT_T(KC_LBRC)
 #define ALT_S LALT_T(KC_S)
 #define CTRL_2 LCTL_T(KC_2)
 #define CTRL_4 LCTL_T(KC_4)
@@ -73,7 +73,7 @@ void sftpls_reset (qk_tap_dance_state_t *state, void *user_data);
 #define GUI_1 LGUI_T(KC_1)
 #define GUI_4 LGUI_T(KC_4)
 #define GUI_7 LGUI_T(KC_7)
-#define GUI_CB LGUI_T(KC_RBRC)
+#define GUI_RB LGUI_T(KC_RBRC)
 #define GUI_F LGUI_T(KC_F)
 #define GUI_J LGUI_T(KC_J)
 #define GUI_N LGUI_T(KC_N)
@@ -252,7 +252,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  */
 [_SYM] = LAYOUT( \
   KC_EXLM,     KC_AT,   KC_HASH,    KC_DLR,     KC_PERC,       KC_CIRC, KC_AMPR, KC_ASTR, KC_QUES,     KC_QUOT,     \
-  TD(SFT_PLS), CTRL_EQ, TD(ALT_LP), TD(GUI_RP), KC_DQT,        KC_COLN, GUI_CB,  ALT_OB,  TD(CTL_RCB), TD(SFT_LCB), \
+  TD(SFT_PLS), CTRL_EQ, TD(ALT_LP), TD(GUI_RP), KC_DQT,        KC_COLN, GUI_RB,  ALT_LB,  TD(CTL_RCB), TD(SFT_LCB), \
   KC_LT,       KC_PIPE, KC_MINS,    KC_GT,      KC_BSLS,       KC_GRV,  KC_UNDS, KC_SLSH, KC_TILD,     KC_SCLN,     \
                         _______,    MAC_EN,     _______,       _______, MAC_EM,  _______                            \
 )

--- a/keyboards/minidox/keymaps/dustypomerleau/keymap.c
+++ b/keyboards/minidox/keymaps/dustypomerleau/keymap.c
@@ -289,31 +289,27 @@ void altop_finished (qk_tap_dance_state_t *state, void *user_data) {
   td_state = cur_dance(state);
   switch (td_state) {
     case SINGLE_TAP:
-      register_mods(MOD_BIT(KC_LSFT));
-      register_code(KC_9);
+      register_code16(KC_LPRN);
       break;
     case SINGLE_HOLD:
       register_mods(MOD_BIT(KC_LALT));
       break;
     case DOUBLE_SINGLE_TAP:
-      register_mods(MOD_BIT(KC_LSFT));
-      tap_code(KC_9);
-      register_code(KC_9);
+      tap_code16(KC_LPRN);
+      register_code16(KC_LPRN);
   }
 }
 
 void altop_reset (qk_tap_dance_state_t *state, void *user_data) {
   switch (td_state) {
     case SINGLE_TAP:
-      unregister_code(KC_9);
-      unregister_mods(MOD_BIT(KC_LSFT));
+      unregister_code16(KC_LPRN);
       break;
     case SINGLE_HOLD:
       unregister_mods(MOD_BIT(KC_LALT));
       break;
     case DOUBLE_SINGLE_TAP:
-      unregister_code(KC_9);
-      unregister_mods(MOD_BIT(KC_LSFT));
+      unregister_code16(KC_LPRN);
   }
 }
 
@@ -321,31 +317,27 @@ void ctlccb_finished (qk_tap_dance_state_t *state, void *user_data) {
   td_state = cur_dance(state);
   switch (td_state) {
     case SINGLE_TAP:
-      register_mods(MOD_BIT(KC_LSFT));
-      register_code(KC_RBRC);
+      register_code16(KC_RCBR);
       break;
     case SINGLE_HOLD:
       register_mods(MOD_BIT(KC_LCTL));
       break;
     case DOUBLE_SINGLE_TAP:
-      register_mods(MOD_BIT(KC_LSFT));
-      tap_code(KC_RBRC);
-      register_code(KC_RBRC);
+      tap_code16(KC_RCBR);
+      register_code16(KC_RCBR);
   }
 }
 
 void ctlccb_reset (qk_tap_dance_state_t *state, void *user_data) {
   switch (td_state) {
     case SINGLE_TAP:
-      unregister_code(KC_RBRC);
-      unregister_mods(MOD_BIT(KC_LSFT));
+      unregister_code16(KC_RCBR);
       break;
     case SINGLE_HOLD:
       unregister_mods(MOD_BIT(KC_LCTL));
       break;
     case DOUBLE_SINGLE_TAP:
-      unregister_code(KC_RBRC);
-      unregister_mods(MOD_BIT(KC_LSFT));
+      unregister_code16(KC_RCBR);
   }
 }
 
@@ -353,31 +345,27 @@ void guicp_finished (qk_tap_dance_state_t *state, void *user_data) {
   td_state = cur_dance(state);
   switch (td_state) {
     case SINGLE_TAP:
-      register_mods(MOD_BIT(KC_LSFT));
-      register_code(KC_0);
+      register_code16(KC_RPRN);
       break;
     case SINGLE_HOLD:
       register_mods(MOD_BIT(KC_LGUI));
       break;
     case DOUBLE_SINGLE_TAP:
-      register_mods(MOD_BIT(KC_LSFT));
-      tap_code(KC_0);
-      register_code(KC_0);
+      tap_code16(KC_RPRN);
+      register_code16(KC_RPRN);
   }
 }
 
 void guicp_reset (qk_tap_dance_state_t *state, void *user_data) {
   switch (td_state) {
     case SINGLE_TAP:
-      unregister_code(KC_0);
-      unregister_mods(MOD_BIT(KC_LSFT));
+      unregister_code16(KC_RPRN);
       break;
     case SINGLE_HOLD:
       unregister_mods(MOD_BIT(KC_LGUI));
       break;
     case DOUBLE_SINGLE_TAP:
-      unregister_code(KC_0);
-      unregister_mods(MOD_BIT(KC_LSFT));
+      unregister_code16(KC_RPRN);
   }
 }
 
@@ -385,31 +373,27 @@ void sftocb_finished (qk_tap_dance_state_t *state, void *user_data) {
   td_state = cur_dance(state);
   switch (td_state) {
     case SINGLE_TAP:
-      register_mods(MOD_BIT(KC_LSFT));
-      register_code(KC_LBRC);
+      register_code16(KC_LCBR);
       break;
     case SINGLE_HOLD:
       register_mods(MOD_BIT(KC_LSFT));
       break;
     case DOUBLE_SINGLE_TAP:
-      register_mods(MOD_BIT(KC_LSFT));
-      tap_code(KC_LBRC);
-      register_code(KC_LBRC);
+      tap_code16(KC_LCBR);
+      register_code16(KC_LCBR);
   }
 }
 
 void sftocb_reset (qk_tap_dance_state_t *state, void *user_data) {
   switch (td_state) {
     case SINGLE_TAP:
-      unregister_code(KC_LBRC);
-      unregister_mods(MOD_BIT(KC_LSFT));
+      unregister_code16(KC_LCBR);
       break;
     case SINGLE_HOLD:
       unregister_mods(MOD_BIT(KC_LSFT));
       break;
     case DOUBLE_SINGLE_TAP:
-      unregister_code(KC_LBRC);
-      unregister_mods(MOD_BIT(KC_LSFT));
+      unregister_code16(KC_LCBR);
   }
 }
 
@@ -417,31 +401,27 @@ void sftpls_finished (qk_tap_dance_state_t *state, void *user_data) {
   td_state = cur_dance(state);
   switch (td_state) {
     case SINGLE_TAP:
-      register_mods(MOD_BIT(KC_LSFT));
-      register_code(KC_EQL);
+      register_code16(KC_PLUS);
       break;
     case SINGLE_HOLD:
       register_mods(MOD_BIT(KC_LSFT));
       break;
     case DOUBLE_SINGLE_TAP:
-      register_mods(MOD_BIT(KC_LSFT));
-      tap_code(KC_EQL);
-      register_code(KC_EQL);
+      tap_code16(KC_PLUS);
+      register_code16(KC_PLUS);
   }
 }
 
 void sftpls_reset (qk_tap_dance_state_t *state, void *user_data) {
   switch (td_state) {
     case SINGLE_TAP:
-      unregister_code(KC_EQL);
-      unregister_mods(MOD_BIT(KC_LSFT));
+      unregister_code16(KC_PLUS);
       break;
     case SINGLE_HOLD:
       unregister_mods(MOD_BIT(KC_LSFT));
       break;
     case DOUBLE_SINGLE_TAP:
-      unregister_code(KC_EQL);
-      unregister_mods(MOD_BIT(KC_LSFT));
+      unregister_code16(KC_PLUS);
   }
 }
 

--- a/keyboards/minidox/keymaps/dustypomerleau/keymap.c
+++ b/keyboards/minidox/keymaps/dustypomerleau/keymap.c
@@ -26,10 +26,10 @@ enum my_keycodes {
 };
 
 enum td_keycodes {
-  ALT_OP,
-  CTL_CCB,
-  GUI_CP,
-  SFT_OCB,
+  ALT_LP,
+  CTL_RCB,
+  GUI_RP,
+  SFT_LCB,
   SFT_PLS
 };
 
@@ -41,14 +41,14 @@ typedef enum {
 
 static td_state_t td_state;
 int cur_dance (qk_tap_dance_state_t *state);
-void altop_finished (qk_tap_dance_state_t *state, void *user_data);
-void altop_reset (qk_tap_dance_state_t *state, void *user_data);
-void ctlccb_finished (qk_tap_dance_state_t *state, void *user_data);
-void ctlccb_reset (qk_tap_dance_state_t *state, void *user_data);
-void guicp_finished (qk_tap_dance_state_t *state, void *user_data);
-void guicp_reset (qk_tap_dance_state_t *state, void *user_data);
-void sftocb_finished (qk_tap_dance_state_t *state, void *user_data);
-void sftocb_reset (qk_tap_dance_state_t *state, void *user_data);
+void altlp_finished (qk_tap_dance_state_t *state, void *user_data);
+void altlp_reset (qk_tap_dance_state_t *state, void *user_data);
+void ctlrcb_finished (qk_tap_dance_state_t *state, void *user_data);
+void ctlrcb_reset (qk_tap_dance_state_t *state, void *user_data);
+void guirp_finished (qk_tap_dance_state_t *state, void *user_data);
+void guirp_reset (qk_tap_dance_state_t *state, void *user_data);
+void sftlcb_finished (qk_tap_dance_state_t *state, void *user_data);
+void sftlcb_reset (qk_tap_dance_state_t *state, void *user_data);
 void sftpls_finished (qk_tap_dance_state_t *state, void *user_data);
 void sftpls_reset (qk_tap_dance_state_t *state, void *user_data);
 
@@ -252,7 +252,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  */
 [_SYM] = LAYOUT( \
   KC_EXLM,     KC_AT,   KC_HASH,    KC_DLR,     KC_PERC,       KC_CIRC, KC_AMPR, KC_ASTR, KC_QUES,     KC_QUOT,     \
-  TD(SFT_PLS), CTRL_EQ, TD(ALT_OP), TD(GUI_CP), KC_DQT,        KC_COLN, GUI_CB,  ALT_OB,  TD(CTL_CCB), TD(SFT_OCB), \
+  TD(SFT_PLS), CTRL_EQ, TD(ALT_LP), TD(GUI_RP), KC_DQT,        KC_COLN, GUI_CB,  ALT_OB,  TD(CTL_RCB), TD(SFT_LCB), \
   KC_LT,       KC_PIPE, KC_MINS,    KC_GT,      KC_BSLS,       KC_GRV,  KC_UNDS, KC_SLSH, KC_TILD,     KC_SCLN,     \
                         _______,    MAC_EN,     _______,       _______, MAC_EM,  _______                            \
 )
@@ -285,7 +285,7 @@ int cur_dance (qk_tap_dance_state_t *state) {
   else return 3;
 }
 
-void altop_finished (qk_tap_dance_state_t *state, void *user_data) {
+void altlp_finished (qk_tap_dance_state_t *state, void *user_data) {
   td_state = cur_dance(state);
   switch (td_state) {
     case SINGLE_TAP:
@@ -300,7 +300,7 @@ void altop_finished (qk_tap_dance_state_t *state, void *user_data) {
   }
 }
 
-void altop_reset (qk_tap_dance_state_t *state, void *user_data) {
+void altlp_reset (qk_tap_dance_state_t *state, void *user_data) {
   switch (td_state) {
     case SINGLE_TAP:
       unregister_code16(KC_LPRN);
@@ -313,7 +313,7 @@ void altop_reset (qk_tap_dance_state_t *state, void *user_data) {
   }
 }
 
-void ctlccb_finished (qk_tap_dance_state_t *state, void *user_data) {
+void ctlrcb_finished (qk_tap_dance_state_t *state, void *user_data) {
   td_state = cur_dance(state);
   switch (td_state) {
     case SINGLE_TAP:
@@ -328,7 +328,7 @@ void ctlccb_finished (qk_tap_dance_state_t *state, void *user_data) {
   }
 }
 
-void ctlccb_reset (qk_tap_dance_state_t *state, void *user_data) {
+void ctlrcb_reset (qk_tap_dance_state_t *state, void *user_data) {
   switch (td_state) {
     case SINGLE_TAP:
       unregister_code16(KC_RCBR);
@@ -341,7 +341,7 @@ void ctlccb_reset (qk_tap_dance_state_t *state, void *user_data) {
   }
 }
 
-void guicp_finished (qk_tap_dance_state_t *state, void *user_data) {
+void guirp_finished (qk_tap_dance_state_t *state, void *user_data) {
   td_state = cur_dance(state);
   switch (td_state) {
     case SINGLE_TAP:
@@ -356,7 +356,7 @@ void guicp_finished (qk_tap_dance_state_t *state, void *user_data) {
   }
 }
 
-void guicp_reset (qk_tap_dance_state_t *state, void *user_data) {
+void guirp_reset (qk_tap_dance_state_t *state, void *user_data) {
   switch (td_state) {
     case SINGLE_TAP:
       unregister_code16(KC_RPRN);
@@ -369,7 +369,7 @@ void guicp_reset (qk_tap_dance_state_t *state, void *user_data) {
   }
 }
 
-void sftocb_finished (qk_tap_dance_state_t *state, void *user_data) {
+void sftlcb_finished (qk_tap_dance_state_t *state, void *user_data) {
   td_state = cur_dance(state);
   switch (td_state) {
     case SINGLE_TAP:
@@ -384,7 +384,7 @@ void sftocb_finished (qk_tap_dance_state_t *state, void *user_data) {
   }
 }
 
-void sftocb_reset (qk_tap_dance_state_t *state, void *user_data) {
+void sftlcb_reset (qk_tap_dance_state_t *state, void *user_data) {
   switch (td_state) {
     case SINGLE_TAP:
       unregister_code16(KC_LCBR);
@@ -426,9 +426,9 @@ void sftpls_reset (qk_tap_dance_state_t *state, void *user_data) {
 }
 
 qk_tap_dance_action_t tap_dance_actions[] = {
-  [ALT_OP] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, altop_finished, altop_reset),
-  [CTL_CCB] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, ctlccb_finished, ctlccb_reset),
-  [GUI_CP] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, guicp_finished, guicp_reset),
-  [SFT_OCB] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, sftocb_finished, sftocb_reset),
+  [ALT_LP] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, altlp_finished, altlp_reset),
+  [CTL_RCB] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, ctlrcb_finished, ctlrcb_reset),
+  [GUI_RP] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, guirp_finished, guirp_reset),
+  [SFT_LCB] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, sftlcb_finished, sftlcb_reset),
   [SFT_PLS] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, sftpls_finished, sftpls_reset)
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Switch to using `register_code16()` and rename tapdance keys to match the `left` and `right` terminology preferred in QMK.
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
