### PR TITLE
rgblight.h no longer changes behavior when included >1 time

### DIFF
--- a/quantum/rgblight.h
+++ b/quantum/rgblight.h
@@ -16,8 +16,6 @@
 #ifndef RGBLIGHT_H
 #define RGBLIGHT_H
 
-#include "rgblight_reconfig.h"
-
 /***** rgblight_mode(mode)/rgblight_mode_noeeprom(mode) ****
 
  old mode number (before 0.6.117) to new mode name table
@@ -64,19 +62,10 @@
 |-----------------|-----------------------------------|
  *****/
 
-#define _RGBM_SINGLE_STATIC(sym)   RGBLIGHT_MODE_ ## sym,
-#define _RGBM_SINGLE_DYNAMIC(sym)  RGBLIGHT_MODE_ ## sym,
-#define _RGBM_MULTI_STATIC(sym)    RGBLIGHT_MODE_ ## sym,
-#define _RGBM_MULTI_DYNAMIC(sym)   RGBLIGHT_MODE_ ## sym,
-#define _RGBM_TMP_STATIC(sym)      RGBLIGHT_MODE_ ## sym,
-#define _RGBM_TMP_DYNAMIC(sym)     RGBLIGHT_MODE_ ## sym,
-enum RGBLIGHT_EFFECT_MODE {
-    RGBLIGHT_MODE_zero = 0,
-#include "rgblight.h"
-    RGBLIGHT_MODE_last
-};
 
-#ifndef RGBLIGHT_H_DUMMY_DEFINE
+/* contains the `RGBLIGHT_EFFECT_MODE enum` */
+#include "rgblight_modes.h"
+
 
 #define RGBLIGHT_MODES (RGBLIGHT_MODE_last-1)
 
@@ -131,9 +120,11 @@ enum RGBLIGHT_EFFECT_MODE {
 #include <stdint.h>
 #include <stdbool.h>
 #include "eeconfig.h"
+
 #ifndef RGBLIGHT_CUSTOM_DRIVER
 #include "ws2812.h"
 #endif
+
 #include "rgblight_types.h"
 #include "rgblight_list.h"
 
@@ -244,73 +235,4 @@ void rgblight_effect_christmas(void);
 void rgblight_effect_rgbtest(void);
 void rgblight_effect_alternating(void);
 
-#endif // #ifndef RGBLIGHT_H_DUMMY_DEFINE
 #endif // RGBLIGHT_H
-
-#ifdef _RGBM_SINGLE_STATIC
-  _RGBM_SINGLE_STATIC( STATIC_LIGHT )
-  #ifdef RGBLIGHT_EFFECT_BREATHING
-    _RGBM_MULTI_DYNAMIC( BREATHING )
-    _RGBM_TMP_DYNAMIC( breathing_3 )
-    _RGBM_TMP_DYNAMIC( breathing_4 )
-    _RGBM_TMP_DYNAMIC( BREATHING_end )
-  #endif
-  #ifdef RGBLIGHT_EFFECT_RAINBOW_MOOD
-    _RGBM_MULTI_DYNAMIC( RAINBOW_MOOD )
-    _RGBM_TMP_DYNAMIC( rainbow_mood_7 )
-    _RGBM_TMP_DYNAMIC( RAINBOW_MOOD_end )
-  #endif
-  #ifdef RGBLIGHT_EFFECT_RAINBOW_SWIRL
-    _RGBM_MULTI_DYNAMIC( RAINBOW_SWIRL )
-    _RGBM_TMP_DYNAMIC( rainbow_swirl_10 )
-    _RGBM_TMP_DYNAMIC( rainbow_swirl_11 )
-    _RGBM_TMP_DYNAMIC( rainbow_swirl_12 )
-    _RGBM_TMP_DYNAMIC( rainbow_swirl_13 )
-    _RGBM_TMP_DYNAMIC( RAINBOW_SWIRL_end )
-  #endif
-  #ifdef RGBLIGHT_EFFECT_SNAKE
-    _RGBM_MULTI_DYNAMIC( SNAKE )
-    _RGBM_TMP_DYNAMIC( snake_16 )
-    _RGBM_TMP_DYNAMIC( snake_17 )
-    _RGBM_TMP_DYNAMIC( snake_18 )
-    _RGBM_TMP_DYNAMIC( snake_19 )
-    _RGBM_TMP_DYNAMIC( SNAKE_end )
-  #endif
-  #ifdef RGBLIGHT_EFFECT_KNIGHT
-    _RGBM_MULTI_DYNAMIC( KNIGHT )
-    _RGBM_TMP_DYNAMIC( knight_22 )
-    _RGBM_TMP_DYNAMIC( KNIGHT_end )
-  #endif
-  #ifdef RGBLIGHT_EFFECT_CHRISTMAS
-    _RGBM_SINGLE_DYNAMIC( CHRISTMAS )
-  #endif
-  #ifdef RGBLIGHT_EFFECT_STATIC_GRADIENT
-    _RGBM_MULTI_STATIC( STATIC_GRADIENT )
-    _RGBM_TMP_STATIC( static_gradient_26 )
-    _RGBM_TMP_STATIC( static_gradient_27 )
-    _RGBM_TMP_STATIC( static_gradient_28 )
-    _RGBM_TMP_STATIC( static_gradient_29 )
-    _RGBM_TMP_STATIC( static_gradient_30 )
-    _RGBM_TMP_STATIC( static_gradient_31 )
-    _RGBM_TMP_STATIC( static_gradient_32 )
-    _RGBM_TMP_STATIC( static_gradient_33 )
-    _RGBM_TMP_STATIC( STATIC_GRADIENT_end )
-  #endif
-  #ifdef RGBLIGHT_EFFECT_RGB_TEST
-    _RGBM_SINGLE_DYNAMIC( RGB_TEST )
-  #endif
-  #ifdef RGBLIGHT_EFFECT_ALTERNATING
-    _RGBM_SINGLE_DYNAMIC( ALTERNATING )
-  #endif
-  ////  Add a new mode here.
-  // #ifdef RGBLIGHT_EFFECT_<name>
-  //    _RGBM_<SINGLE|MULTI>_<STATIC|DYNAMIC>( <name> )
-  // #endif
-#endif
-
-#undef _RGBM_SINGLE_STATIC
-#undef _RGBM_SINGLE_DYNAMIC
-#undef _RGBM_MULTI_STATIC
-#undef _RGBM_MULTI_DYNAMIC
-#undef _RGBM_TMP_STATIC
-#undef _RGBM_TMP_DYNAMIC

--- a/quantum/rgblight_modes.h
+++ b/quantum/rgblight_modes.h
@@ -1,0 +1,95 @@
+#ifndef RGBLIGHT_MODES_H
+#define RGBLIGHT_MODES_H
+
+#include "rgblight_reconfig.h"
+
+#define _RGBM_SINGLE_STATIC(sym)   RGBLIGHT_MODE_ ## sym,
+#define _RGBM_SINGLE_DYNAMIC(sym)  RGBLIGHT_MODE_ ## sym,
+#define _RGBM_MULTI_STATIC(sym)    RGBLIGHT_MODE_ ## sym,
+#define _RGBM_MULTI_DYNAMIC(sym)   RGBLIGHT_MODE_ ## sym,
+#define _RGBM_TMP_STATIC(sym)      RGBLIGHT_MODE_ ## sym,
+#define _RGBM_TMP_DYNAMIC(sym)     RGBLIGHT_MODE_ ## sym,
+
+enum RGBLIGHT_EFFECT_MODE {
+    RGBLIGHT_MODE_zero = 0,
+
+    _RGBM_SINGLE_STATIC( STATIC_LIGHT )
+    #ifdef RGBLIGHT_EFFECT_BREATHING
+        _RGBM_MULTI_DYNAMIC( BREATHING )
+        _RGBM_TMP_DYNAMIC( breathing_3 )
+        _RGBM_TMP_DYNAMIC( breathing_4 )
+        _RGBM_TMP_DYNAMIC( BREATHING_end )
+    #endif
+
+    #ifdef RGBLIGHT_EFFECT_RAINBOW_MOOD
+        _RGBM_MULTI_DYNAMIC( RAINBOW_MOOD )
+        _RGBM_TMP_DYNAMIC( rainbow_mood_7 )
+        _RGBM_TMP_DYNAMIC( RAINBOW_MOOD_end )
+    #endif
+
+    #ifdef RGBLIGHT_EFFECT_RAINBOW_SWIRL
+        _RGBM_MULTI_DYNAMIC( RAINBOW_SWIRL )
+        _RGBM_TMP_DYNAMIC( rainbow_swirl_10 )
+        _RGBM_TMP_DYNAMIC( rainbow_swirl_11 )
+        _RGBM_TMP_DYNAMIC( rainbow_swirl_12 )
+        _RGBM_TMP_DYNAMIC( rainbow_swirl_13 )
+        _RGBM_TMP_DYNAMIC( RAINBOW_SWIRL_end )
+    #endif
+
+    #ifdef RGBLIGHT_EFFECT_SNAKE
+        _RGBM_MULTI_DYNAMIC( SNAKE )
+        _RGBM_TMP_DYNAMIC( snake_16 )
+        _RGBM_TMP_DYNAMIC( snake_17 )
+        _RGBM_TMP_DYNAMIC( snake_18 )
+        _RGBM_TMP_DYNAMIC( snake_19 )
+        _RGBM_TMP_DYNAMIC( SNAKE_end )
+    #endif
+
+    #ifdef RGBLIGHT_EFFECT_KNIGHT
+        _RGBM_MULTI_DYNAMIC( KNIGHT )
+        _RGBM_TMP_DYNAMIC( knight_22 )
+        _RGBM_TMP_DYNAMIC( KNIGHT_end )
+    #endif
+
+    #ifdef RGBLIGHT_EFFECT_CHRISTMAS
+        _RGBM_SINGLE_DYNAMIC( CHRISTMAS )
+    #endif
+
+    #ifdef RGBLIGHT_EFFECT_STATIC_GRADIENT
+        _RGBM_MULTI_STATIC( STATIC_GRADIENT )
+        _RGBM_TMP_STATIC( static_gradient_26 )
+        _RGBM_TMP_STATIC( static_gradient_27 )
+        _RGBM_TMP_STATIC( static_gradient_28 )
+        _RGBM_TMP_STATIC( static_gradient_29 )
+        _RGBM_TMP_STATIC( static_gradient_30 )
+        _RGBM_TMP_STATIC( static_gradient_31 )
+        _RGBM_TMP_STATIC( static_gradient_32 )
+        _RGBM_TMP_STATIC( static_gradient_33 )
+        _RGBM_TMP_STATIC( STATIC_GRADIENT_end )
+    #endif
+
+    #ifdef RGBLIGHT_EFFECT_RGB_TEST
+        _RGBM_SINGLE_DYNAMIC( RGB_TEST )
+    #endif
+
+    #ifdef RGBLIGHT_EFFECT_ALTERNATING
+        _RGBM_SINGLE_DYNAMIC( ALTERNATING )
+    #endif
+
+    /* Add a new mode here.
+    #ifdef RGBLIGHT_EFFECT_<name>
+       _RGBM_<SINGLE|MULTI>_<STATIC|DYNAMIC>( <name> )
+    #endif
+    */
+
+    RGBLIGHT_MODE_last
+};
+
+#undef _RGBM_SINGLE_STATIC
+#undef _RGBM_SINGLE_DYNAMIC
+#undef _RGBM_MULTI_STATIC
+#undef _RGBM_MULTI_DYNAMIC
+#undef _RGBM_TMP_STATIC
+#undef _RGBM_TMP_DYNAMIC
+
+#endif /* RGBLIGHT_MODES_H */


### PR DESCRIPTION
## Description

Headers should never change behavior dependent on the number of times
they're included. This fixes that defect.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

It works for me, I can't build the whole repo for obvious reasons `make test[s]` seemed to work **shrug**
