### PR TITLE
Fix diode and split keyboard configuration for 40percentclub/half_n_half

### DIFF
--- a/keyboards/40percentclub/half_n_half/config.h
+++ b/keyboards/40percentclub/half_n_half/config.h
@@ -46,12 +46,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define UNUSED_PINS
 
 /* COL2ROW, ROW2COL*/
-#define DIODE_DIRECTION ROW2COL
+#define DIODE_DIRECTION COL2ROW
 
 /*
  * Split Keyboard specific options, make sure you have 'SPLIT_KEYBOARD = yes' in your rules.mk, and define SOFT_SERIAL_PIN.
  */
 #define SOFT_SERIAL_PIN D0 // or D1, D2, D3, E6
+#define USE_SERIAL
 
 // #define BACKLIGHT_PIN B7
 // #define BACKLIGHT_BREATHING

--- a/keyboards/40percentclub/half_n_half/half_n_half.h
+++ b/keyboards/40percentclub/half_n_half/half_n_half.h
@@ -42,3 +42,7 @@
     { R26, R25, R24, R23, R22, R21, R20 }, \
     { ___, ___, ___, ___, R32, ___, ___ }  \
 }
+
+#ifdef USE_I2C
+  #error "I2C not Supported"
+#endif

--- a/keyboards/40percentclub/half_n_half/rules.mk
+++ b/keyboards/40percentclub/half_n_half/rules.mk
@@ -79,3 +79,6 @@ BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
 AUDIO_ENABLE = no           # Audio output on port C6
 FAUXCLICKY_ENABLE = no      # Use buzzer to emulate clicky switches
 HD44780_ENABLE = no 		# Enable support for HD44780 based LCDs (+400)
+
+# Enable generic behavior for split boards
+SPLIT_KEYBOARD = yes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

@Boy-314 raised on Discord,
> can someone check what's wrong with my half_n_half port?
>
> i flashed both halves pro-micro with the same hex file and only the left spacebar works

The issues are as follows
- Split keyboard not configured
  - Also configured to force SERIAL as the board does not support I2C
- COL2ROW diode configuration required


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
