### PR TITLE
Sleep until USB port becomes writable before running avrdude

### DIFF
--- a/tmk_core/avr.mk
+++ b/tmk_core/avr.mk
@@ -214,12 +214,13 @@ define EXEC_AVRDUDE
 			mv /tmp/2 /tmp/1; \
 		done; \
 		echo ""; \
-		echo "Detected controller on USB port at $$USB"; \
+		echo "Device $$USB has appeared; assuming it is the controller."; \
 		if $(GREP) -q -s 'MINGW\|MSYS' /proc/version; then \
 			USB=`echo "$$USB" | perl -pne 's/\/dev\/ttyS(\d+)/COM.($$1+1)/e'`; \
 			echo "Remapped MSYS2 USB port to $$USB"; \
 		fi; \
-		sleep 1; \
+		printf "Waiting for $$USB to become writable."; \
+		while [ ! -w "$$USB" ]; do sleep 0.5; printf "."; done; echo ""; \
 		avrdude -p $(MCU) -c avr109 -P $$USB -U flash:w:$(BUILD_DIR)/$(TARGET).hex; \
 	fi
 endef

--- a/tmk_core/avr.mk
+++ b/tmk_core/avr.mk
@@ -219,7 +219,7 @@ define EXEC_AVRDUDE
 			USB=`echo "$$USB" | perl -pne 's/\/dev\/ttyS(\d+)/COM.($$1+1)/e'`; \
 			echo "Remapped MSYS2 USB port to $$USB"; \
 			sleep 1; \
-		else; \
+		else \
 			printf "Waiting for $$USB to become writable."; \
 			while [ ! -w "$$USB" ]; do sleep 0.5; printf "."; done; echo ""; \
 		fi; \

--- a/tmk_core/avr.mk
+++ b/tmk_core/avr.mk
@@ -218,7 +218,7 @@ define EXEC_AVRDUDE
 		if $(GREP) -q -s 'MINGW\|MSYS' /proc/version; then \
 			USB=`echo "$$USB" | perl -pne 's/\/dev\/ttyS(\d+)/COM.($$1+1)/e'`; \
 			echo "Remapped MSYS2 USB port to $$USB"; \
-			sleep 1;
+			sleep 1; \
 		else; \
 			printf "Waiting for $$USB to become writable."; \
 			while [ ! -w "$$USB" ]; do sleep 0.5; printf "."; done; echo ""; \

--- a/tmk_core/avr.mk
+++ b/tmk_core/avr.mk
@@ -218,9 +218,11 @@ define EXEC_AVRDUDE
 		if $(GREP) -q -s 'MINGW\|MSYS' /proc/version; then \
 			USB=`echo "$$USB" | perl -pne 's/\/dev\/ttyS(\d+)/COM.($$1+1)/e'`; \
 			echo "Remapped MSYS2 USB port to $$USB"; \
+			sleep 1;
+		else; \
+			printf "Waiting for $$USB to become writable."; \
+			while [ ! -w "$$USB" ]; do sleep 0.5; printf "."; done; echo ""; \
 		fi; \
-		printf "Waiting for $$USB to become writable."; \
-		while [ ! -w "$$USB" ]; do sleep 0.5; printf "."; done; echo ""; \
 		avrdude -p $(MCU) -c avr109 -P $$USB -U flash:w:$(BUILD_DIR)/$(TARGET).hex; \
 	fi
 endef


### PR DESCRIPTION
## Description

Currently, running with :avrdude as a target will monitor /dev/tty* for the appearance of a new device, then sleep for one second, then launch avrdude to flash the keyboard.

For reasons that I haven't yet determined, that one-second sleep is insufficient on my system. `/dev/ttyACM0` appears with root:root ownership, and it takes udev a good 2.5 seconds or so to change its permissions to root:dialout, giving my normal user write access. This causes avrdude (and make) to exit with an error most of the time:

```
avrdude: ser_open(): can't open device "/dev/ttyACM0": Permission denied

avrdude done.  Thank you.

make[1]: *** [tmk_core/avr.mk:228: avrdude] Error 1
Make finished with errors
make: *** [Makefile:551: mitosis:datagrok:avrdude] Error 1
```

To account for this I have replaced the 1-second sleep with a small loop, similar to the other, to wait for the device to become writable. This seems to successfully resolve the problem, at least on my Debian Linux machine.

If there is a known fix that will make my udev rules do their thing faster, I'm eager to hear about it.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

None that I am aware of.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
