### PR TITLE
Fix build break `make hotdox:default` and `make hotdox:bocaj`

### DIFF
--- a/keyboards/hotdox/left.c
+++ b/keyboards/hotdox/left.c
@@ -39,7 +39,7 @@ void left_scan(void)
 
     if (ret == 0)
     {
-        i2c_stop(HOTDOX_I2C_TIMEOUT);
+        i2c_stop();
 
         if (!i2c_initialized)
         {
@@ -105,7 +105,7 @@ uint8_t left_write(uint8_t reg, uint8_t data)
   ret = i2c_write(data, HOTDOX_I2C_TIMEOUT); 
 
 out:
-  i2c_stop(HOTDOX_I2C_TIMEOUT);
+  i2c_stop();
   return ret;
 }
 
@@ -125,6 +125,6 @@ uint8_t left_read(uint8_t reg, uint8_t *data)
   *data = i2c_read_nack(HOTDOX_I2C_TIMEOUT);
 
 out:
-  i2c_stop(HOTDOX_I2C_TIMEOUT);
+  i2c_stop();
   return ret;
 }

--- a/users/bocaj/process_records.c
+++ b/users/bocaj/process_records.c
@@ -53,7 +53,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case KC_MAKE:  // Compiles the firmware, and adds the flash command based on keyboard bootloader
       if (!record->event.pressed) {
         uint8_t temp_mod = get_mods();
-        uint8_t temp_osm = get_oneshot_mods();
+        //uint8_t temp_osm = get_oneshot_mods();
         clear_mods();
         clear_oneshot_mods();
         if (biton32(default_layer_state) == _WINWORKMAN) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
With the change of PR #4974, `i2c_stop()` of `i2c_master.c` has no arguments. So I also change the caller.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

*  #4974

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).