### PR TITLE
rgblight split transfer non-eeprom config

### DIFF
--- a/quantum/api.c
+++ b/quantum/api.c
@@ -67,7 +67,7 @@ void process_api(uint16_t length, uint8_t * data) {
                 case DT_RGBLIGHT: {
                     #ifdef RGBLIGHT_ENABLE
                         uint32_t rgblight = bytes_to_dword(data, 2);
-                        rgblight_update_dword(rgblight);
+                        eeconfig_update_rgblight(rgblight);
                     #endif
                     break;
                 }

--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -225,11 +225,14 @@ void rgblight_init(void) {
 
 }
 
+uint32_t rgblight_read_dword(void) {
+  return rgblight_config.raw;
+}
+
 void rgblight_update_dword(uint32_t dword) {
   rgblight_config.raw = dword;
-  eeconfig_update_rgblight(rgblight_config.raw);
   if (rgblight_config.enable)
-    rgblight_mode(rgblight_config.mode);
+    rgblight_mode_noeeprom(rgblight_config.mode);
   else {
 #ifdef RGBLIGHT_USE_TIMER
       rgblight_timer_disable();

--- a/quantum/rgblight.h
+++ b/quantum/rgblight.h
@@ -174,6 +174,7 @@ void rgblight_step_reverse(void);
 uint8_t rgblight_get_mode(void);
 void rgblight_mode(uint8_t mode);
 void rgblight_set(void);
+uint32_t rgblight_read_dword(void);
 void rgblight_update_dword(uint32_t dword);
 void rgblight_increase_hue(void);
 void rgblight_decrease_hue(void);

--- a/quantum/split_common/transport.c
+++ b/quantum/split_common/transport.c
@@ -46,7 +46,7 @@ bool transport_master(matrix_row_t matrix[]) {
 
 #  ifdef RGBLIGHT_ENABLE
   static uint32_t prev_rgb = ~0;
-  uint32_t        rgb      = eeconfig_read_rgblight();
+  uint32_t        rgb      = rgblight_read_dword();
   if (rgb != prev_rgb) {
     i2c_writeReg(SLAVE_I2C_ADDRESS, I2C_RGB_START, (void *)&rgb, sizeof(rgb), TIMEOUT);
     prev_rgb = rgb;

--- a/quantum/split_common/transport.c
+++ b/quantum/split_common/transport.c
@@ -39,8 +39,9 @@ bool transport_master(matrix_row_t matrix[]) {
   static uint8_t prev_level = ~0;
   uint8_t        level      = get_backlight_level();
   if (level != prev_level) {
-    i2c_writeReg(SLAVE_I2C_ADDRESS, I2C_BACKLIT_START, (void *)&level, sizeof(level), TIMEOUT);
-    prev_level = level;
+    if (i2c_writeReg(SLAVE_I2C_ADDRESS, I2C_BACKLIT_START, (void *)&level, sizeof(level), TIMEOUT) >= 0) {
+      prev_level = level;
+    }
   }
 #  endif
 
@@ -48,8 +49,9 @@ bool transport_master(matrix_row_t matrix[]) {
   static uint32_t prev_rgb = ~0;
   uint32_t        rgb      = rgblight_read_dword();
   if (rgb != prev_rgb) {
-    i2c_writeReg(SLAVE_I2C_ADDRESS, I2C_RGB_START, (void *)&rgb, sizeof(rgb), TIMEOUT);
-    prev_rgb = rgb;
+    if (i2c_writeReg(SLAVE_I2C_ADDRESS, I2C_RGB_START, (void *)&rgb, sizeof(rgb), TIMEOUT) >= 0) {
+      prev_rgb = rgb;
+    }
   }
 #  endif
 


### PR DESCRIPTION
Currently split-common transfers the eeprom version of rgblight config to the slave side, meaning it is not possible to make any transient changes to configuration that also propagate to the slave side. (in my case, I turn off the rgb lights after a period of inactivity).

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Add `rgblight_read_dword` function to retrieve the active config rather than directly reading the struct.

Make split i2c keyboards transfer this active rgblight config rather than eeprom saved version of rgblight config, enabling runtime changes that aren't persisted to eeprom.

Make `rgblight_update_dword` not update eeprom (we already have `eeconfig_update_rgblight` for that, so that the slave transport side doesn't persist changes to eeprom.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
