### PR TITLE
Add support for TAP_CODE_DELAY to Hold-Tap keys

### DIFF
--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -523,6 +523,11 @@ void process_action(keyrecord_t *record, action_t action)
                             if (action.layer_tap.code == KC_CAPS) {
                                 wait_ms(TAP_HOLD_CAPS_DELAY);
                             }
+                            #if TAP_CODE_DELAY > 0
+                              else {
+                                wait_ms(TAP_CODE_DELAY);
+                              }
+                            #endif
                             unregister_code(action.layer_tap.code);
                         } else {
                             dprint("KEYMAP_TAP_KEY: No tap: Off on release\n");
@@ -618,6 +623,9 @@ void process_action(keyrecord_t *record, action_t action)
                         if (event.pressed) {
                             register_code(action.swap.code);
                         } else {
+                            #if TAP_CODE_DELAY > 0
+                              wait_ms(TAP_CODE_DELAY);
+                            #endif
                             unregister_code(action.swap.code);
                             *record = (keyrecord_t){}; // hack: reset tap mode
                         }
@@ -670,8 +678,7 @@ void process_action(keyrecord_t *record, action_t action)
         retro_tapping_counter = 0;
       } else {
         if (retro_tapping_counter == 2) {
-          register_code(action.layer_tap.code);
-          unregister_code(action.layer_tap.code);
+          tap_code(action.layer_tap.code);
         }
         retro_tapping_counter = 0;
       }

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -44,8 +44,11 @@ int retro_tapping_counter = 0;
 #include <fauxclicky.h>
 #endif
 
+#ifndef TAP_CODE_DELAY
+#  define TAP_CODE_DELAY 0
+#endif
 #ifndef TAP_HOLD_CAPS_DELAY
-#  define TAP_HOLD_CAPS_DELAY 200
+#  define TAP_HOLD_CAPS_DELAY 80
 #endif
 /** \brief Called to execute an action.
  *
@@ -330,6 +333,9 @@ void process_action(keyrecord_t *record, action_t action)
                         } else {
                             if (tap_count > 0) {
                                 dprint("MODS_TAP: Tap: unregister_code\n");
+                                if (action.layer_tap.code == KC_CAPS) {
+                                  wait_ms(TAP_HOLD_CAPS_DELAY);
+                                }
                                 unregister_code(action.key.code);
                             } else {
                                 dprint("MODS_TAP: No tap: add_mods\n");
@@ -522,12 +528,9 @@ void process_action(keyrecord_t *record, action_t action)
                             dprint("KEYMAP_TAP_KEY: Tap: unregister_code\n");
                             if (action.layer_tap.code == KC_CAPS) {
                                 wait_ms(TAP_HOLD_CAPS_DELAY);
-                            }
-                            #if TAP_CODE_DELAY > 0
-                              else {
+                            } else {
                                 wait_ms(TAP_CODE_DELAY);
                               }
-                            #endif
                             unregister_code(action.layer_tap.code);
                         } else {
                             dprint("KEYMAP_TAP_KEY: No tap: Off on release\n");
@@ -623,9 +626,7 @@ void process_action(keyrecord_t *record, action_t action)
                         if (event.pressed) {
                             register_code(action.swap.code);
                         } else {
-                            #if TAP_CODE_DELAY > 0
-                              wait_ms(TAP_CODE_DELAY);
-                            #endif
+                            wait_ms(TAP_CODE_DELAY);
                             unregister_code(action.swap.code);
                             *record = (keyrecord_t){}; // hack: reset tap mode
                         }
@@ -865,12 +866,9 @@ void tap_code(uint8_t code) {
   register_code(code);
   if (code == KC_CAPS) {
     wait_ms(TAP_HOLD_CAPS_DELAY);
-  }
-  #if TAP_CODE_DELAY > 0
-  else {
+  } else {
     wait_ms(TAP_CODE_DELAY);
   }
-  #endif
   unregister_code(code);
 }
 


### PR DESCRIPTION
## Description

This adds support for the `TAP_CODE_DELAY` to the tapping code for LT/MT and for SWAP Hand's Hold-Tap key.   And convert retro tap's register-unregister code to just tap_code for simplicity. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [X] Core
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

*  Discord

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [X] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
