### PR TITLE
Decouple RGB Matrix from RGB Light

### DIFF
--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -183,7 +183,11 @@ All RGB keycodes are currently shared with the RGBLIGHT system:
 * `RGB_VAD` - decrease value
 * `RGB_SPI` - increase speed effect (no EEPROM support)
 * `RGB_SPD` - decrease speed effect (no EEPROM support)
-* `RGB_MODE_*` keycodes will generally work, but are not currently mapped to the correct effects for the RGB Matrix system
+
+
+* `RGB_MODE_*` keycodes will not work, since they are not properly mapped
+
+!> By default, if you have both the [RGB Light](feature_rgblight.md) and the RGB Matrix feature enabled, these keycodes will work for both features, at the same time. You can disable the keycode functionality by defining the `*_DISABLE_KEYCODES` option for the specific feature.
 
 ## RGB Matrix Effects
 
@@ -375,6 +379,7 @@ These are defined in [`rgblight_list.h`](https://github.com/qmk/qmk_firmware/blo
 #define RGB_MATRIX_LED_FLUSH_LIMIT 16 // limits in milliseconds how frequently an animation will update the LEDs. 16 (16ms) is equivalent to limiting to 60fps (increases keyboard responsiveness)
 #define RGB_MATRIX_MAXIMUM_BRIGHTNESS 200 // limits maximum brightness of LEDs to 200 out of 255. If not defined maximum brightness is set to 255
 #define RGB_MATRIX_STARTUP_MODE RGB_MATRIX_CYCLE_LEFT_RIGHT // Sets the default mode, if none has been set
+#define RGB_MATRIX_DISABLE_KEYCODES // disables control of rgb matrix by keycodes (must use code functions to control the feature)
 ```
 
 ## EEPROM storage
@@ -392,13 +397,11 @@ Where `28` is an unused index from `eeconfig.h`.
 To use the suspend feature, add this to your `<keyboard>.c`:
 
 ```C
-void suspend_power_down_kb(void)
-{
+void suspend_power_down_kb(void) {
     rgb_matrix_set_suspend_state(true);
 }
 
-void suspend_wakeup_init_kb(void)
-{
+void suspend_wakeup_init_kb(void) {
     rgb_matrix_set_suspend_state(false);
 }
 ```

--- a/docs/feature_rgblight.md
+++ b/docs/feature_rgblight.md
@@ -64,6 +64,9 @@ Changing the **Value** sets the overall brightness.<br>
 |`RGB_MODE_GRADIENT`|`RGB_M_G` |Static gradient animation mode                                      |
 |`RGB_MODE_RGBTEST` |`RGB_M_T` |Red, Green, Blue test animation mode                                |
 
+!> By default, if you have both the [RGB Light](feature_rgblight.md) and the RGB Matrix feature enabled, these keycodes will work for both features, at the same time. You can disable the keycode functionality by defining the `*_DISABLE_KEYCODES` option for the specific feature.
+
+
 ## Configuration
 
 Your RGB lighting can be configured by placing these `#define`s in your `config.h`:
@@ -76,6 +79,7 @@ Your RGB lighting can be configured by placing these `#define`s in your `config.
 |`RGBLIGHT_LIMIT_VAL` |`255`        |The maximum brightness level                                                 |
 |`RGBLIGHT_SLEEP`     |*Not defined*|If defined, the RGB lighting will be switched off when the host goes to sleep|
 |`RGBLIGHT_SPLIT`     |*Not defined*|If defined, synchronization functionality for split keyboards is added|
+|`RGBLIGHT_DISABLE_KEYCODES`|*not defined*|If defined, disables the ability to control RGB Light from the keycodes. You must use code functions to control the feature| 
 
 ## Effects and Animations
 

--- a/docs/feature_rgblight.md
+++ b/docs/feature_rgblight.md
@@ -64,7 +64,7 @@ Changing the **Value** sets the overall brightness.<br>
 |`RGB_MODE_GRADIENT`|`RGB_M_G` |Static gradient animation mode                                      |
 |`RGB_MODE_RGBTEST` |`RGB_M_T` |Red, Green, Blue test animation mode                                |
 
-!> By default, if you have both the [RGB Light](feature_rgblight.md) and the RGB Matrix feature enabled, these keycodes will work for both features, at the same time. You can disable the keycode functionality by defining the `*_DISABLE_KEYCODES` option for the specific feature.
+!> By default, if you have both the RGB Light and the [RGB Matrix](feature_rgb_matrix.md) feature enabled, these keycodes will work for both features, at the same time. You can disable the keycode functionality by defining the `*_DISABLE_KEYCODES` option for the specific feature.
 
 
 ## Configuration

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -16,9 +16,6 @@
 
 #include "quantum.h"
 
-#if !defined(RGBLIGHT_ENABLE) && !defined(RGB_MATRIX_ENABLE)
-#    include "rgb.h"
-#endif
 
 #ifdef PROTOCOL_LUFA
 #    include "outputselect.h"
@@ -219,66 +216,67 @@ bool process_record_quantum(keyrecord_t *record) {
 
     if (!(
 #if defined(KEY_LOCK_ENABLE)
-            // Must run first to be able to mask key_up events.
-            process_key_lock(&keycode, record) &&
+        // Must run first to be able to mask key_up events.
+        process_key_lock(&keycode, record) &&
 #endif
 #if defined(DYNAMIC_MACRO_ENABLE) && !defined(DYNAMIC_MACRO_USER_CALL)
             // Must run asap to ensure all keypresses are recorded.
             process_dynamic_macro(keycode, record) &&
 #endif
 #if defined(AUDIO_ENABLE) && defined(AUDIO_CLICKY)
-            process_clicky(keycode, record) &&
-#endif  // AUDIO_CLICKY
+        process_clicky(keycode, record) &&
+#endif //AUDIO_CLICKY
 #ifdef HAPTIC_ENABLE
-            process_haptic(keycode, record) &&
-#endif  // HAPTIC_ENABLE
+        process_haptic(keycode, record) &&
+#endif //HAPTIC_ENABLE
 #if defined(RGB_MATRIX_ENABLE)
-            process_rgb_matrix(keycode, record) &&
+        process_rgb_matrix(keycode, record) &&
 #endif
-            process_record_kb(keycode, record) &&
+        process_record_kb(keycode, record) &&
 #if defined(MIDI_ENABLE) && defined(MIDI_ADVANCED)
-            process_midi(keycode, record) &&
+        process_midi(keycode, record) &&
 #endif
 #ifdef AUDIO_ENABLE
-            process_audio(keycode, record) &&
+        process_audio(keycode, record) &&
 #endif
 #ifdef STENO_ENABLE
-            process_steno(keycode, record) &&
+        process_steno(keycode, record) &&
 #endif
 #if (defined(AUDIO_ENABLE) || (defined(MIDI_ENABLE) && defined(MIDI_BASIC))) && !defined(NO_MUSIC_MODE)
-            process_music(keycode, record) &&
+        process_music(keycode, record) &&
 #endif
 #ifdef TAP_DANCE_ENABLE
-            process_tap_dance(keycode, record) &&
+        process_tap_dance(keycode, record) &&
 #endif
 #if defined(UNICODE_ENABLE) || defined(UNICODEMAP_ENABLE) || defined(UCIS_ENABLE)
-            process_unicode_common(keycode, record) &&
+        process_unicode_common(keycode, record) &&
 #endif
 #ifdef LEADER_ENABLE
-            process_leader(keycode, record) &&
+        process_leader(keycode, record) &&
 #endif
 #ifdef COMBO_ENABLE
-            process_combo(keycode, record) &&
+        process_combo(keycode, record) &&
 #endif
 #ifdef PRINTING_ENABLE
-            process_printer(keycode, record) &&
+        process_printer(keycode, record) &&
 #endif
 #ifdef AUTO_SHIFT_ENABLE
-            process_auto_shift(keycode, record) &&
+        process_auto_shift(keycode, record) &&
 #endif
 #ifdef TERMINAL_ENABLE
-            process_terminal(keycode, record) &&
+        process_terminal(keycode, record) &&
 #endif
 #ifdef SPACE_CADET_ENABLE
-            process_space_cadet(keycode, record) &&
+        process_space_cadet(keycode, record) &&
 #endif
-            true)) {
+        true)) {
         return false;
     }
 
+
     // Shift / paren setup
 
-    switch (keycode) {
+    switch(keycode) {
         case RESET:
             if (record->event.pressed) {
                 reset_keyboard();
@@ -288,9 +286,9 @@ bool process_record_quantum(keyrecord_t *record) {
             if (record->event.pressed) {
                 debug_enable ^= 1;
                 if (debug_enable) {
-                    print("DEBUG: enabled.\n");
+                print("DEBUG: enabled.\n");
                 } else {
-                    print("DEBUG: disabled.\n");
+                print("DEBUG: disabled.\n");
                 }
             }
             return false;
@@ -302,207 +300,282 @@ bool process_record_quantum(keyrecord_t *record) {
 #ifdef FAUXCLICKY_ENABLE
         case FC_TOG:
             if (record->event.pressed) {
-                FAUXCLICKY_TOGGLE;
+            FAUXCLICKY_TOGGLE;
             }
             return false;
         case FC_ON:
             if (record->event.pressed) {
-                FAUXCLICKY_ON;
+            FAUXCLICKY_ON;
             }
             return false;
         case FC_OFF:
             if (record->event.pressed) {
-                FAUXCLICKY_OFF;
+            FAUXCLICKY_OFF;
             }
             return false;
 #endif
 #if defined(RGBLIGHT_ENABLE) || defined(RGB_MATRIX_ENABLE)
         case RGB_TOG:
-// Split keyboards need to trigger on key-up for edge-case issue
+            // Split keyboards need to trigger on key-up for edge-case issue
 #    ifndef SPLIT_KEYBOARD
             if (record->event.pressed) {
 #    else
             if (!record->event.pressed) {
 #    endif
+#    if defined(RGBLIGHT_ENABLE) && !defined(RGBLIGHT_DISABLE_KEYCODES)
                 rgblight_toggle();
+#    endif
+#    if defined(RGB_MATRIX_ENABLE) && !defined(RGB_MATRIX_DISABLE_KEYCODES)
+                rgb_matrix_toggle();
+#    endif
             }
             return false;
         case RGB_MODE_FORWARD:
             if (record->event.pressed) {
-                uint8_t shifted = get_mods() & (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT));
-                if (shifted) {
-                    rgblight_step_reverse();
-                } else {
-                    rgblight_step();
-                }
+            uint8_t shifted = get_mods() & (MOD_MASK_SHIFT);
+            if(shifted) {
+#    if defined(RGBLIGHT_ENABLE) && !defined(RGBLIGHT_DISABLE_KEYCODES)
+                rgblight_step_reverse();
+#    endif
+#    if defined(RGB_MATRIX_ENABLE) && !defined(RGB_MATRIX_DISABLE_KEYCODES)
+                rgb_matrix_step_reverse();
+#    endif
+            }
+            else {
+#    if defined(RGBLIGHT_ENABLE) && !defined(RGBLIGHT_DISABLE_KEYCODES)
+                rgblight_step();
+#    endif
+#    if defined(RGB_MATRIX_ENABLE) && !defined(RGB_MATRIX_DISABLE_KEYCODES)
+                rgb_matrix_step();
+#    endif
+            }
             }
             return false;
         case RGB_MODE_REVERSE:
             if (record->event.pressed) {
-                uint8_t shifted = get_mods() & (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT));
-                if (shifted) {
-                    rgblight_step();
-                } else {
-                    rgblight_step_reverse();
-                }
+            uint8_t shifted = get_mods() & (MOD_MASK_SHIFT);
+            if(shifted) {
+#    if defined(RGBLIGHT_ENABLE) && !defined(RGBLIGHT_DISABLE_KEYCODES)
+                rgblight_step();
+#    endif
+#    if defined(RGB_MATRIX_ENABLE) && !defined(RGB_MATRIX_DISABLE_KEYCODES)
+                rgb_matrix_step();
+#    endif
+            }
+            else {
+#    if defined(RGBLIGHT_ENABLE) && !defined(RGBLIGHT_DISABLE_KEYCODES)
+                rgblight_step_reverse();
+#    endif
+#    if defined(RGB_MATRIX_ENABLE) && !defined(RGB_MATRIX_DISABLE_KEYCODES)
+                rgb_matrix_step_reverse();
+#    endif
+            }
             }
             return false;
         case RGB_HUI:
-// Split keyboards need to trigger on key-up for edge-case issue
+            // Split keyboards need to trigger on key-up for edge-case issue
 #    ifndef SPLIT_KEYBOARD
             if (record->event.pressed) {
 #    else
             if (!record->event.pressed) {
 #    endif
+#    if defined(RGBLIGHT_ENABLE) && !defined(RGBLIGHT_DISABLE_KEYCODES)
                 rgblight_increase_hue();
+#    endif
+#    if defined(RGB_MATRIX_ENABLE) && !defined(RGB_MATRIX_DISABLE_KEYCODES)
+                rgb_matrix_increase_hue();
+#    endif
             }
             return false;
         case RGB_HUD:
-// Split keyboards need to trigger on key-up for edge-case issue
+            // Split keyboards need to trigger on key-up for edge-case issue
 #    ifndef SPLIT_KEYBOARD
             if (record->event.pressed) {
 #    else
             if (!record->event.pressed) {
 #    endif
+#    if defined(RGBLIGHT_ENABLE) && !defined(RGBLIGHT_DISABLE_KEYCODES)
                 rgblight_decrease_hue();
+#    endif
+#    if defined(RGB_MATRIX_ENABLE) && !defined(RGB_MATRIX_DISABLE_KEYCODES)
+                rgb_matrix_decrease_hue();
+#    endif
             }
             return false;
         case RGB_SAI:
-// Split keyboards need to trigger on key-up for edge-case issue
+            // Split keyboards need to trigger on key-up for edge-case issue
 #    ifndef SPLIT_KEYBOARD
             if (record->event.pressed) {
 #    else
             if (!record->event.pressed) {
 #    endif
+#    if defined(RGBLIGHT_ENABLE) && !defined(RGBLIGHT_DISABLE_KEYCODES)
                 rgblight_increase_sat();
+#endif
+#    if defined(RGB_MATRIX_ENABLE) && !defined(RGB_MATRIX_DISABLE_KEYCODES)
+                rgb_matrix_increase_sat();
+#    endif
             }
             return false;
         case RGB_SAD:
-// Split keyboards need to trigger on key-up for edge-case issue
+            // Split keyboards need to trigger on key-up for edge-case issue
 #    ifndef SPLIT_KEYBOARD
             if (record->event.pressed) {
 #    else
             if (!record->event.pressed) {
 #    endif
+#    if defined(RGBLIGHT_ENABLE) && !defined(RGBLIGHT_DISABLE_KEYCODES)
                 rgblight_decrease_sat();
+#    endif
+#    if defined(RGB_MATRIX_ENABLE) && !defined(RGB_MATRIX_DISABLE_KEYCODES)
+                rgb_matrix_decrease_sat();
+#    endif
             }
             return false;
         case RGB_VAI:
-// Split keyboards need to trigger on key-up for edge-case issue
+            // Split keyboards need to trigger on key-up for edge-case issue
 #    ifndef SPLIT_KEYBOARD
             if (record->event.pressed) {
 #    else
             if (!record->event.pressed) {
 #    endif
+#    if defined(RGBLIGHT_ENABLE) && !defined(RGBLIGHT_DISABLE_KEYCODES)
                 rgblight_increase_val();
+#    endif
+#    if defined(RGB_MATRIX_ENABLE) && !defined(RGB_MATRIX_DISABLE_KEYCODES)
+                rgb_matrix_increase_val();
+#    endif
             }
             return false;
         case RGB_VAD:
-// Split keyboards need to trigger on key-up for edge-case issue
+            // Split keyboards need to trigger on key-up for edge-case issue
 #    ifndef SPLIT_KEYBOARD
             if (record->event.pressed) {
 #    else
             if (!record->event.pressed) {
 #    endif
+#    if defined(RGBLIGHT_ENABLE) && !defined(RGBLIGHT_DISABLE_KEYCODES)
                 rgblight_decrease_val();
+#    endif
+#    if defined(RGB_MATRIX_ENABLE) && !defined(RGB_MATRIX_DISABLE_KEYCODES)
+                rgb_matrix_decrease_val();
+#    endif
             }
             return false;
         case RGB_SPI:
             if (record->event.pressed) {
+#    if defined(RGBLIGHT_ENABLE) && !defined(RGBLIGHT_DISABLE_KEYCODES)
                 rgblight_increase_speed();
+#    endif
+#    if defined(RGB_MATRIX_ENABLE) && !defined(RGB_MATRIX_DISABLE_KEYCODES)
+                rgb_matrix_increase_speed();
+#    endif
             }
             return false;
         case RGB_SPD:
             if (record->event.pressed) {
+#    if defined(RGBLIGHT_ENABLE) && !defined(RGBLIGHT_DISABLE_KEYCODES)
                 rgblight_decrease_speed();
+#    endif
+#    if defined(RGB_MATRIX_ENABLE) && !defined(RGB_MATRIX_DISABLE_KEYCODES)
+                rgb_matrix_decrease_speed();
+#    endif
             }
             return false;
+#   if defined(RGBLIGHT_ENABLE) && !defined(RGBLIGHT_DISABLE_KEYCODES)
         case RGB_MODE_PLAIN:
             if (record->event.pressed) {
                 rgblight_mode(RGBLIGHT_MODE_STATIC_LIGHT);
             }
             return false;
         case RGB_MODE_BREATHE:
-#    ifdef RGBLIGHT_EFFECT_BREATHING
+#        ifdef RGBLIGHT_EFFECT_BREATHING
             if (record->event.pressed) {
-                if ((RGBLIGHT_MODE_BREATHING <= rgblight_get_mode()) && (rgblight_get_mode() < RGBLIGHT_MODE_BREATHING_end)) {
+                if ((RGBLIGHT_MODE_BREATHING <= rgblight_get_mode()) &&
+                    (rgblight_get_mode() < RGBLIGHT_MODE_BREATHING_end)) {
                     rgblight_step();
                 } else {
                     rgblight_mode(RGBLIGHT_MODE_BREATHING);
                 }
             }
-#    endif
+#        endif
             return false;
         case RGB_MODE_RAINBOW:
-#    ifdef RGBLIGHT_EFFECT_RAINBOW_MOOD
+#        ifdef RGBLIGHT_EFFECT_RAINBOW_MOOD
             if (record->event.pressed) {
-                if ((RGBLIGHT_MODE_RAINBOW_MOOD <= rgblight_get_mode()) && (rgblight_get_mode() < RGBLIGHT_MODE_RAINBOW_MOOD_end)) {
+                if ((RGBLIGHT_MODE_RAINBOW_MOOD <= rgblight_get_mode()) &&
+                    (rgblight_get_mode() < RGBLIGHT_MODE_RAINBOW_MOOD_end)) {
                     rgblight_step();
                 } else {
                     rgblight_mode(RGBLIGHT_MODE_RAINBOW_MOOD);
                 }
             }
-#    endif
+#        endif
             return false;
         case RGB_MODE_SWIRL:
-#    ifdef RGBLIGHT_EFFECT_RAINBOW_SWIRL
+#        ifdef RGBLIGHT_EFFECT_RAINBOW_SWIRL
             if (record->event.pressed) {
-                if ((RGBLIGHT_MODE_RAINBOW_SWIRL <= rgblight_get_mode()) && (rgblight_get_mode() < RGBLIGHT_MODE_RAINBOW_SWIRL_end)) {
+                if ((RGBLIGHT_MODE_RAINBOW_SWIRL <= rgblight_get_mode()) &&
+                    (rgblight_get_mode() < RGBLIGHT_MODE_RAINBOW_SWIRL_end)) {
                     rgblight_step();
                 } else {
                     rgblight_mode(RGBLIGHT_MODE_RAINBOW_SWIRL);
                 }
             }
-#    endif
+#        endif
             return false;
         case RGB_MODE_SNAKE:
-#    ifdef RGBLIGHT_EFFECT_SNAKE
+#        ifdef RGBLIGHT_EFFECT_SNAKE
             if (record->event.pressed) {
-                if ((RGBLIGHT_MODE_SNAKE <= rgblight_get_mode()) && (rgblight_get_mode() < RGBLIGHT_MODE_SNAKE_end)) {
+                if ((RGBLIGHT_MODE_SNAKE <= rgblight_get_mode()) &&
+                    (rgblight_get_mode() < RGBLIGHT_MODE_SNAKE_end)) {
                     rgblight_step();
                 } else {
                     rgblight_mode(RGBLIGHT_MODE_SNAKE);
                 }
             }
-#    endif
+#        endif
             return false;
         case RGB_MODE_KNIGHT:
-#    ifdef RGBLIGHT_EFFECT_KNIGHT
+#        ifdef RGBLIGHT_EFFECT_KNIGHT
             if (record->event.pressed) {
-                if ((RGBLIGHT_MODE_KNIGHT <= rgblight_get_mode()) && (rgblight_get_mode() < RGBLIGHT_MODE_KNIGHT_end)) {
+                if ((RGBLIGHT_MODE_KNIGHT <= rgblight_get_mode()) &&
+                    (rgblight_get_mode() < RGBLIGHT_MODE_KNIGHT_end)) {
                     rgblight_step();
                 } else {
                     rgblight_mode(RGBLIGHT_MODE_KNIGHT);
                 }
             }
-#    endif
+#        endif
             return false;
         case RGB_MODE_XMAS:
-#    ifdef RGBLIGHT_EFFECT_CHRISTMAS
+#        ifdef RGBLIGHT_EFFECT_CHRISTMAS
             if (record->event.pressed) {
                 rgblight_mode(RGBLIGHT_MODE_CHRISTMAS);
             }
-#    endif
+#        endif
             return false;
         case RGB_MODE_GRADIENT:
-#    ifdef RGBLIGHT_EFFECT_STATIC_GRADIENT
+#        ifdef RGBLIGHT_EFFECT_STATIC_GRADIENT
             if (record->event.pressed) {
-                if ((RGBLIGHT_MODE_STATIC_GRADIENT <= rgblight_get_mode()) && (rgblight_get_mode() < RGBLIGHT_MODE_STATIC_GRADIENT_end)) {
+                if ((RGBLIGHT_MODE_STATIC_GRADIENT <= rgblight_get_mode()) &&
+                    (rgblight_get_mode() < RGBLIGHT_MODE_STATIC_GRADIENT_end)) {
                     rgblight_step();
                 } else {
                     rgblight_mode(RGBLIGHT_MODE_STATIC_GRADIENT);
                 }
             }
-#    endif
+#        endif
             return false;
         case RGB_MODE_RGBTEST:
-#    ifdef RGBLIGHT_EFFECT_RGB_TEST
+#        ifdef RGBLIGHT_EFFECT_RGB_TEST
             if (record->event.pressed) {
                 rgblight_mode(RGBLIGHT_MODE_RGB_TEST);
             }
-#    endif
+#        endif
             return false;
-#endif  // defined(RGBLIGHT_ENABLE) || defined(RGB_MATRIX_ENABLE)
+#    endif
+#endif // RGBLIGHT_ENABLE
 #ifdef VELOCIKEY_ENABLE
         case VLK_TOG:
             if (record->event.pressed) {
@@ -661,7 +734,7 @@ bool process_record_quantum(keyrecord_t *record) {
                         break;
                 }
                 eeconfig_update_keymap(keymap_config.raw);
-                clear_keyboard();  // clear to prevent stuck keys
+                clear_keyboard(); // clear to prevent stuck keys
 
                 return false;
             }

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -16,7 +16,6 @@
 
 #include "quantum.h"
 
-
 #ifdef PROTOCOL_LUFA
 #    include "outputselect.h"
 #endif
@@ -216,67 +215,66 @@ bool process_record_quantum(keyrecord_t *record) {
 
     if (!(
 #if defined(KEY_LOCK_ENABLE)
-        // Must run first to be able to mask key_up events.
-        process_key_lock(&keycode, record) &&
+            // Must run first to be able to mask key_up events.
+            process_key_lock(&keycode, record) &&
 #endif
 #if defined(DYNAMIC_MACRO_ENABLE) && !defined(DYNAMIC_MACRO_USER_CALL)
             // Must run asap to ensure all keypresses are recorded.
             process_dynamic_macro(keycode, record) &&
 #endif
 #if defined(AUDIO_ENABLE) && defined(AUDIO_CLICKY)
-        process_clicky(keycode, record) &&
-#endif //AUDIO_CLICKY
+            process_clicky(keycode, record) &&
+#endif  // AUDIO_CLICKY
 #ifdef HAPTIC_ENABLE
-        process_haptic(keycode, record) &&
-#endif //HAPTIC_ENABLE
+            process_haptic(keycode, record) &&
+#endif  // HAPTIC_ENABLE
 #if defined(RGB_MATRIX_ENABLE)
-        process_rgb_matrix(keycode, record) &&
+            process_rgb_matrix(keycode, record) &&
 #endif
-        process_record_kb(keycode, record) &&
+            process_record_kb(keycode, record) &&
 #if defined(MIDI_ENABLE) && defined(MIDI_ADVANCED)
-        process_midi(keycode, record) &&
+            process_midi(keycode, record) &&
 #endif
 #ifdef AUDIO_ENABLE
-        process_audio(keycode, record) &&
+            process_audio(keycode, record) &&
 #endif
 #ifdef STENO_ENABLE
-        process_steno(keycode, record) &&
+            process_steno(keycode, record) &&
 #endif
 #if (defined(AUDIO_ENABLE) || (defined(MIDI_ENABLE) && defined(MIDI_BASIC))) && !defined(NO_MUSIC_MODE)
-        process_music(keycode, record) &&
+            process_music(keycode, record) &&
 #endif
 #ifdef TAP_DANCE_ENABLE
-        process_tap_dance(keycode, record) &&
+            process_tap_dance(keycode, record) &&
 #endif
 #if defined(UNICODE_ENABLE) || defined(UNICODEMAP_ENABLE) || defined(UCIS_ENABLE)
-        process_unicode_common(keycode, record) &&
+            process_unicode_common(keycode, record) &&
 #endif
 #ifdef LEADER_ENABLE
-        process_leader(keycode, record) &&
+            process_leader(keycode, record) &&
 #endif
 #ifdef COMBO_ENABLE
-        process_combo(keycode, record) &&
+            process_combo(keycode, record) &&
 #endif
 #ifdef PRINTING_ENABLE
-        process_printer(keycode, record) &&
+            process_printer(keycode, record) &&
 #endif
 #ifdef AUTO_SHIFT_ENABLE
-        process_auto_shift(keycode, record) &&
+            process_auto_shift(keycode, record) &&
 #endif
 #ifdef TERMINAL_ENABLE
-        process_terminal(keycode, record) &&
+            process_terminal(keycode, record) &&
 #endif
 #ifdef SPACE_CADET_ENABLE
-        process_space_cadet(keycode, record) &&
+            process_space_cadet(keycode, record) &&
 #endif
-        true)) {
+            true)) {
         return false;
     }
 
-
     // Shift / paren setup
 
-    switch(keycode) {
+    switch (keycode) {
         case RESET:
             if (record->event.pressed) {
                 reset_keyboard();
@@ -286,9 +284,9 @@ bool process_record_quantum(keyrecord_t *record) {
             if (record->event.pressed) {
                 debug_enable ^= 1;
                 if (debug_enable) {
-                print("DEBUG: enabled.\n");
+                    print("DEBUG: enabled.\n");
                 } else {
-                print("DEBUG: disabled.\n");
+                    print("DEBUG: disabled.\n");
                 }
             }
             return false;
@@ -300,17 +298,17 @@ bool process_record_quantum(keyrecord_t *record) {
 #ifdef FAUXCLICKY_ENABLE
         case FC_TOG:
             if (record->event.pressed) {
-            FAUXCLICKY_TOGGLE;
+                FAUXCLICKY_TOGGLE;
             }
             return false;
         case FC_ON:
             if (record->event.pressed) {
-            FAUXCLICKY_ON;
+                FAUXCLICKY_ON;
             }
             return false;
         case FC_OFF:
             if (record->event.pressed) {
-            FAUXCLICKY_OFF;
+                FAUXCLICKY_OFF;
             }
             return false;
 #endif
@@ -332,44 +330,42 @@ bool process_record_quantum(keyrecord_t *record) {
             return false;
         case RGB_MODE_FORWARD:
             if (record->event.pressed) {
-            uint8_t shifted = get_mods() & (MOD_MASK_SHIFT);
-            if(shifted) {
+                uint8_t shifted = get_mods() & (MOD_MASK_SHIFT);
+                if (shifted) {
 #    if defined(RGBLIGHT_ENABLE) && !defined(RGBLIGHT_DISABLE_KEYCODES)
-                rgblight_step_reverse();
+                    rgblight_step_reverse();
 #    endif
 #    if defined(RGB_MATRIX_ENABLE) && !defined(RGB_MATRIX_DISABLE_KEYCODES)
-                rgb_matrix_step_reverse();
+                    rgb_matrix_step_reverse();
 #    endif
-            }
-            else {
+                } else {
 #    if defined(RGBLIGHT_ENABLE) && !defined(RGBLIGHT_DISABLE_KEYCODES)
-                rgblight_step();
+                    rgblight_step();
 #    endif
 #    if defined(RGB_MATRIX_ENABLE) && !defined(RGB_MATRIX_DISABLE_KEYCODES)
-                rgb_matrix_step();
+                    rgb_matrix_step();
 #    endif
-            }
+                }
             }
             return false;
         case RGB_MODE_REVERSE:
             if (record->event.pressed) {
-            uint8_t shifted = get_mods() & (MOD_MASK_SHIFT);
-            if(shifted) {
+                uint8_t shifted = get_mods() & (MOD_MASK_SHIFT);
+                if (shifted) {
 #    if defined(RGBLIGHT_ENABLE) && !defined(RGBLIGHT_DISABLE_KEYCODES)
-                rgblight_step();
+                    rgblight_step();
 #    endif
 #    if defined(RGB_MATRIX_ENABLE) && !defined(RGB_MATRIX_DISABLE_KEYCODES)
-                rgb_matrix_step();
+                    rgb_matrix_step();
 #    endif
-            }
-            else {
+                } else {
 #    if defined(RGBLIGHT_ENABLE) && !defined(RGBLIGHT_DISABLE_KEYCODES)
-                rgblight_step_reverse();
+                    rgblight_step_reverse();
 #    endif
 #    if defined(RGB_MATRIX_ENABLE) && !defined(RGB_MATRIX_DISABLE_KEYCODES)
-                rgb_matrix_step_reverse();
+                    rgb_matrix_step_reverse();
 #    endif
-            }
+                }
             }
             return false;
         case RGB_HUI:
@@ -411,7 +407,7 @@ bool process_record_quantum(keyrecord_t *record) {
 #    endif
 #    if defined(RGBLIGHT_ENABLE) && !defined(RGBLIGHT_DISABLE_KEYCODES)
                 rgblight_increase_sat();
-#endif
+#    endif
 #    if defined(RGB_MATRIX_ENABLE) && !defined(RGB_MATRIX_DISABLE_KEYCODES)
                 rgb_matrix_increase_sat();
 #    endif
@@ -482,7 +478,7 @@ bool process_record_quantum(keyrecord_t *record) {
 #    endif
             }
             return false;
-#   if defined(RGBLIGHT_ENABLE) && !defined(RGBLIGHT_DISABLE_KEYCODES)
+#    if defined(RGBLIGHT_ENABLE) && !defined(RGBLIGHT_DISABLE_KEYCODES)
         case RGB_MODE_PLAIN:
             if (record->event.pressed) {
                 rgblight_mode(RGBLIGHT_MODE_STATIC_LIGHT);
@@ -491,8 +487,7 @@ bool process_record_quantum(keyrecord_t *record) {
         case RGB_MODE_BREATHE:
 #        ifdef RGBLIGHT_EFFECT_BREATHING
             if (record->event.pressed) {
-                if ((RGBLIGHT_MODE_BREATHING <= rgblight_get_mode()) &&
-                    (rgblight_get_mode() < RGBLIGHT_MODE_BREATHING_end)) {
+                if ((RGBLIGHT_MODE_BREATHING <= rgblight_get_mode()) && (rgblight_get_mode() < RGBLIGHT_MODE_BREATHING_end)) {
                     rgblight_step();
                 } else {
                     rgblight_mode(RGBLIGHT_MODE_BREATHING);
@@ -503,8 +498,7 @@ bool process_record_quantum(keyrecord_t *record) {
         case RGB_MODE_RAINBOW:
 #        ifdef RGBLIGHT_EFFECT_RAINBOW_MOOD
             if (record->event.pressed) {
-                if ((RGBLIGHT_MODE_RAINBOW_MOOD <= rgblight_get_mode()) &&
-                    (rgblight_get_mode() < RGBLIGHT_MODE_RAINBOW_MOOD_end)) {
+                if ((RGBLIGHT_MODE_RAINBOW_MOOD <= rgblight_get_mode()) && (rgblight_get_mode() < RGBLIGHT_MODE_RAINBOW_MOOD_end)) {
                     rgblight_step();
                 } else {
                     rgblight_mode(RGBLIGHT_MODE_RAINBOW_MOOD);
@@ -515,8 +509,7 @@ bool process_record_quantum(keyrecord_t *record) {
         case RGB_MODE_SWIRL:
 #        ifdef RGBLIGHT_EFFECT_RAINBOW_SWIRL
             if (record->event.pressed) {
-                if ((RGBLIGHT_MODE_RAINBOW_SWIRL <= rgblight_get_mode()) &&
-                    (rgblight_get_mode() < RGBLIGHT_MODE_RAINBOW_SWIRL_end)) {
+                if ((RGBLIGHT_MODE_RAINBOW_SWIRL <= rgblight_get_mode()) && (rgblight_get_mode() < RGBLIGHT_MODE_RAINBOW_SWIRL_end)) {
                     rgblight_step();
                 } else {
                     rgblight_mode(RGBLIGHT_MODE_RAINBOW_SWIRL);
@@ -527,8 +520,7 @@ bool process_record_quantum(keyrecord_t *record) {
         case RGB_MODE_SNAKE:
 #        ifdef RGBLIGHT_EFFECT_SNAKE
             if (record->event.pressed) {
-                if ((RGBLIGHT_MODE_SNAKE <= rgblight_get_mode()) &&
-                    (rgblight_get_mode() < RGBLIGHT_MODE_SNAKE_end)) {
+                if ((RGBLIGHT_MODE_SNAKE <= rgblight_get_mode()) && (rgblight_get_mode() < RGBLIGHT_MODE_SNAKE_end)) {
                     rgblight_step();
                 } else {
                     rgblight_mode(RGBLIGHT_MODE_SNAKE);
@@ -539,8 +531,7 @@ bool process_record_quantum(keyrecord_t *record) {
         case RGB_MODE_KNIGHT:
 #        ifdef RGBLIGHT_EFFECT_KNIGHT
             if (record->event.pressed) {
-                if ((RGBLIGHT_MODE_KNIGHT <= rgblight_get_mode()) &&
-                    (rgblight_get_mode() < RGBLIGHT_MODE_KNIGHT_end)) {
+                if ((RGBLIGHT_MODE_KNIGHT <= rgblight_get_mode()) && (rgblight_get_mode() < RGBLIGHT_MODE_KNIGHT_end)) {
                     rgblight_step();
                 } else {
                     rgblight_mode(RGBLIGHT_MODE_KNIGHT);
@@ -558,8 +549,7 @@ bool process_record_quantum(keyrecord_t *record) {
         case RGB_MODE_GRADIENT:
 #        ifdef RGBLIGHT_EFFECT_STATIC_GRADIENT
             if (record->event.pressed) {
-                if ((RGBLIGHT_MODE_STATIC_GRADIENT <= rgblight_get_mode()) &&
-                    (rgblight_get_mode() < RGBLIGHT_MODE_STATIC_GRADIENT_end)) {
+                if ((RGBLIGHT_MODE_STATIC_GRADIENT <= rgblight_get_mode()) && (rgblight_get_mode() < RGBLIGHT_MODE_STATIC_GRADIENT_end)) {
                     rgblight_step();
                 } else {
                     rgblight_mode(RGBLIGHT_MODE_STATIC_GRADIENT);
@@ -575,7 +565,7 @@ bool process_record_quantum(keyrecord_t *record) {
 #        endif
             return false;
 #    endif
-#endif // RGBLIGHT_ENABLE
+#endif  // RGBLIGHT_ENABLE
 #ifdef VELOCIKEY_ENABLE
         case VLK_TOG:
             if (record->event.pressed) {
@@ -734,7 +724,7 @@ bool process_record_quantum(keyrecord_t *record) {
                         break;
                 }
                 eeconfig_update_keymap(keymap_config.raw);
-                clear_keyboard(); // clear to prevent stuck keys
+                clear_keyboard();  // clear to prevent stuck keys
 
                 return false;
             }
@@ -1189,7 +1179,7 @@ __attribute__((weak)) void led_set(uint8_t usb_led) {
 #endif
 
     led_set_kb(usb_led);
-    led_update_kb((led_t) usb_led);
+    led_update_kb((led_t)usb_led);
 }
 
 //------------------------------------------------------------------------------

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -36,14 +36,9 @@
 #    endif
 #endif
 
-#if defined(RGBLIGHT_ENABLE)
-#    include "rgblight.h"
-#elif defined(RGB_MATRIX_ENABLE)
-// Dummy define RGBLIGHT_MODE_xxxx
-#    define RGBLIGHT_H_DUMMY_DEFINE
+#ifdef RGBLIGHT_ENABLE
 #    include "rgblight.h"
 #endif
-
 #ifdef RGB_MATRIX_ENABLE
 #    include "rgb_matrix.h"
 #endif

--- a/quantum/rgb_matrix.h
+++ b/quantum/rgb_matrix.h
@@ -127,28 +127,6 @@ uint8_t     rgb_matrix_get_mode(void);
 void        rgb_matrix_sethsv(uint16_t hue, uint8_t sat, uint8_t val);
 void        rgb_matrix_sethsv_noeeprom(uint16_t hue, uint8_t sat, uint8_t val);
 
-#ifndef RGBLIGHT_ENABLE
-#    define rgblight_toggle() rgb_matrix_toggle()
-#    define rgblight_enable() rgb_matrix_enable()
-#    define rgblight_enable_noeeprom() rgb_matrix_enable_noeeprom()
-#    define rgblight_disable() rgb_matrix_disable()
-#    define rgblight_disable_noeeprom() rgb_matrix_disable_noeeprom()
-#    define rgblight_step() rgb_matrix_step()
-#    define rgblight_sethsv(hue, sat, val) rgb_matrix_sethsv(hue, sat, val)
-#    define rgblight_sethsv_noeeprom(hue, sat, val) rgb_matrix_sethsv_noeeprom(hue, sat, val)
-#    define rgblight_step_reverse() rgb_matrix_step_reverse()
-#    define rgblight_increase_hue() rgb_matrix_increase_hue()
-#    define rgblight_decrease_hue() rgb_matrix_decrease_hue()
-#    define rgblight_increase_sat() rgb_matrix_increase_sat()
-#    define rgblight_decrease_sat() rgb_matrix_decrease_sat()
-#    define rgblight_increase_val() rgb_matrix_increase_val()
-#    define rgblight_decrease_val() rgb_matrix_decrease_val()
-#    define rgblight_increase_speed() rgb_matrix_increase_speed()
-#    define rgblight_decrease_speed() rgb_matrix_decrease_speed()
-#    define rgblight_mode(mode) rgb_matrix_mode(mode)
-#    define rgblight_mode_noeeprom(mode) rgb_matrix_mode_noeeprom(mode)
-#    define rgblight_get_mode() rgb_matrix_get_mode()
-#endif
 
 typedef struct {
     /* Perform any initialisation required for the other driver functions to work. */

--- a/quantum/rgblight.h
+++ b/quantum/rgblight.h
@@ -76,9 +76,7 @@ enum RGBLIGHT_EFFECT_MODE {
     RGBLIGHT_MODE_last
 };
 
-#ifndef RGBLIGHT_H_DUMMY_DEFINE
-
-#    define RGBLIGHT_MODES (RGBLIGHT_MODE_last - 1)
+#define RGBLIGHT_MODES (RGBLIGHT_MODE_last - 1)
 
 // sample: #define RGBLIGHT_EFFECT_BREATHE_CENTER   1.85
 
@@ -307,8 +305,6 @@ void rgblight_effect_knight(animation_status_t *anim);
 void rgblight_effect_christmas(animation_status_t *anim);
 void rgblight_effect_rgbtest(animation_status_t *anim);
 void rgblight_effect_alternating(animation_status_t *anim);
-
 #    endif
 
-#endif  // #ifndef RGBLIGHT_H_DUMMY_DEFINE
 #endif  // RGBLIGHT_H


### PR DESCRIPTION
## Description

Right now, the RGB Matrix feature works by taking control of a number of the RGB Light functions, when it's disabled.  

This is fine if you want to run one or the other. But if you're a madman like me, and want to run both, there is no choice.  You are only able to control the RGB Light feature from keycodes.  

This changes the functionality so that the `rgb_matrix_*` functions are called explicitly, so that there is no need to to remap the functions. 

However, this would mean that if you have both features enabled at the same time, it would control both sets of features.  This is also less than idea.  So a `RGB*_DISABLE_KEYCODES` setting has been added so that you can selective which features are controlled by the keycodes (rather than introducing a new set of keycodes, and remapping)
However, I think that adding RGB_MATRIX keycodes and remapping if the RGBLIGHT feature is disabled would be best. Though, I'm not sure of what keycode prefix should be used. 
 
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [X] Core
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [X] Documentation

## Issues Fixed or Closed by This PR

* Drashna's sanity (insanity?), and his Planck Light

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
   - I have tested that this works on a board with just RGB Light enabled, just RGB Matrix enabled, and both enabled. As well as with neither enabled.  All compile and appear to work. 