### PR TITLE
Avoid READ command in stream mode

### DIFF
--- a/tmk_core/protocol/ps2.h
+++ b/tmk_core/protocol/ps2.h
@@ -91,7 +91,7 @@ uint8_t ps2_host_send(uint8_t data);
 uint8_t ps2_host_recv_response(void);
 uint8_t ps2_host_recv(void);
 void ps2_host_set_led(uint8_t usb_led);
-
+bool pbuf_has_data(void);
 
 /*--------------------------------------------------------------------
  * static functions

--- a/tmk_core/protocol/ps2_interrupt.c
+++ b/tmk_core/protocol/ps2_interrupt.c
@@ -60,7 +60,6 @@ uint8_t ps2_error = PS2_ERR_NONE;
 
 static inline uint8_t pbuf_dequeue(void);
 static inline void pbuf_enqueue(uint8_t data);
-static inline bool pbuf_has_data(void);
 static inline void pbuf_clear(void);
 
 
@@ -261,7 +260,7 @@ static inline uint8_t pbuf_dequeue(void)
 
     return val;
 }
-static inline bool pbuf_has_data(void)
+bool pbuf_has_data(void)
 {
     uint8_t sreg = SREG;
     cli();

--- a/tmk_core/protocol/ps2_mouse.c
+++ b/tmk_core/protocol/ps2_mouse.c
@@ -75,6 +75,7 @@ void ps2_mouse_task(void) {
     extern int tp_buttons;
 
     /* receives packet from mouse */
+#ifdef PS2_MOUSE_USE_REMOTE_MODE
     uint8_t rcv;
     rcv = ps2_host_send(PS2_MOUSE_READ_DATA);
     if (rcv == PS2_ACK) {
@@ -88,6 +89,19 @@ void ps2_mouse_task(void) {
         if (debug_mouse) print("ps2_mouse: fail to get mouse packet\n");
         return;
     }
+#else
+    if (pbuf_has_data()) {
+        mouse_report.buttons = ps2_host_recv_response() | tp_buttons;
+        mouse_report.x = ps2_host_recv_response() * PS2_MOUSE_X_MULTIPLIER;
+        mouse_report.y = ps2_host_recv_response() * PS2_MOUSE_Y_MULTIPLIER;
+#ifdef PS2_MOUSE_ENABLE_SCROLLING
+        mouse_report.v = -(ps2_host_recv_response() & PS2_MOUSE_SCROLL_MASK) * PS2_MOUSE_V_MULTIPLIER;
+#endif
+    } else {
+        if (debug_mouse) print("ps2_mouse: fail to get mouse packet\n");
+        return;
+    }
+#endif
 
     /* if mouse moves or buttons state changes */
     if (mouse_report.x || mouse_report.y || mouse_report.v ||


### PR DESCRIPTION
## Description

Some mouse modules (in my case, X19 trackball) seems not responding to
PS2_MOUSE_READ command when operating in stream mode.  Instead, new data
are uploaded by push from the device to the host. Because of that, when
mouse cursor is not moving, read commands succeed but no data arrive, so
the following routine must wait for 4 x 25 = 100 ms. This slows down
all other proocedures in the chip.

This change is to use pushed data, and stop pulling when no data are
available.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #5357

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
