### PR TITLE
XD84 no longer detecting key presses / ARM I2C behaviour recently changed

### DIFF
--- a/drivers/avr/i2c_master.c
+++ b/drivers/avr/i2c_master.c
@@ -140,7 +140,7 @@ i2c_status_t i2c_receive(uint8_t address, uint8_t* data, uint16_t length, uint16
 
   i2c_stop();
 
-  return status;
+  return (status < 0) ? status : I2C_STATUS_SUCCESS;
 }
 
 i2c_status_t i2c_writeReg(uint8_t devaddr, uint8_t regaddr, uint8_t* data, uint16_t length, uint16_t timeout) {
@@ -188,7 +188,7 @@ i2c_status_t i2c_readReg(uint8_t devaddr, uint8_t regaddr, uint8_t* data, uint16
 error:
   i2c_stop();
 
-  return status;
+  return (status < 0) ? status : I2C_STATUS_SUCCESS;
 }
 
 void i2c_stop(void) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
XD84 has stopped successfully reading the matrix state from the port expanders. From discord:
>How are the reads succeeding if are only getting error codes back from the port expanders? I  tried turning on console and got immediately spammed

#4974 changed the behaviour of `i2c_readReg`. Instead of returning `I2C_STATUS_SUCCESS`, it now returns last result from i2c_read_nack, which is data. Anything doing a `!= I2C_STATUS_SUCCESS` check now fails.

This PR returns back the old behaviour of `i2c_readReg` and `i2c_receive`, returning `I2C_STATUS_SUCCESS` on success.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* xd84/xd96 not detecting matrix and spamming errors

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
