### PR TITLE
Add avrdude split EE_HANDS flash commands

### DIFF
--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -208,8 +208,12 @@ There are a few different ways to set handedness for split keyboards (listed in 
 
 1. Set `SPLIT_HAND_PIN`: Reads a pin to determine handedness. If pin is high, it's the left side, if low, the half is determined to be the right side
 2. Set `EE_HANDS` and flash `eeprom-lefthand.eep`/`eeprom-righthand.eep` to each half
+   * For boards with DFU bootloader you can use `:dfu-split-left`/`:dfu-split-right` to flash these EEPROM files
+   * For boards with Caterina bootloader (like stock Pro Micros), use `:avrdude-split-left`/`:avrdude-split-right`
 3. Set `MASTER_RIGHT`: Half that is plugged into the USB port is determined to be the master and right half (inverse of the default)
 4. Default: The side that is plugged into the USB port is the master half and is assumed to be the left half. The slave side is the right half
+
+#### Defines for handedness
 
 * `#define SPLIT_HAND_PIN B7`
   * For using high/low pin to determine handedness, low = right hand, high = left hand. Replace `B7` with the pin you are using. This is optional, and if you leave `SPLIT_HAND_PIN` undefined, then you can still use the EE_HANDS method or MASTER_LEFT / MASTER_RIGHT defines like the stock Let's Split uses.

--- a/tmk_core/avr.mk
+++ b/tmk_core/avr.mk
@@ -223,7 +223,11 @@ define EXEC_AVRDUDE
 			printf "Waiting for $$USB to become writable."; \
 			while [ ! -w "$$USB" ]; do sleep 0.5; printf "."; done; echo ""; \
 		fi; \
-		avrdude -p $(MCU) -c avr109 -P $$USB -U flash:w:$(BUILD_DIR)/$(TARGET).hex; \
+		if [ -z "$(1)" ]; then \
+			avrdude -p $(MCU) -c avr109 -P $$USB -U flash:w:$(BUILD_DIR)/$(TARGET).hex; \
+		else \
+			avrdude -p $(MCU) -c avr109 -P $$USB -U flash:w:$(BUILD_DIR)/$(TARGET).hex -U eeprom:w:$(QUANTUM_PATH)/split_common/$(1); \
+		fi \
 	fi
 endef
 
@@ -232,8 +236,14 @@ avrdude: $(BUILD_DIR)/$(TARGET).hex check-size cpfirmware
 
 avrdude-loop: $(BUILD_DIR)/$(TARGET).hex check-size cpfirmware
 	while true; do \
-	    $(call EXEC_AVRDUDE) ; \
+		$(call EXEC_AVRDUDE) ; \
 	done
+
+avrdude-split-left: $(BUILD_DIR)/$(TARGET).hex check-size cpfirmware
+	$(call EXEC_AVRDUDE,eeprom-lefthand.eep)
+
+avrdude-split-right: $(BUILD_DIR)/$(TARGET).hex check-size cpfirmware
+	$(call EXEC_AVRDUDE,eeprom-righthand.eep)
 
 # Convert hex to bin.
 bin: $(BUILD_DIR)/$(TARGET).hex


### PR DESCRIPTION
## Description

Adds ability to flash .eep files for setting hands with `:avrdude-split-<left/right>` commands

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
