### PR TITLE
 Cleanup Default Keymaps 

### DIFF
--- a/keyboards/1upkeyboards/1up60rgb/keymaps/default/keymap.c
+++ b/keyboards/1upkeyboards/1up60rgb/keymaps/default/keymap.c
@@ -1,4 +1,4 @@
-#include "1up60rgb.h"
+#include QMK_KEYBOARD_H
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 

--- a/keyboards/1upkeyboards/sweet16/keymaps/default/keymap.c
+++ b/keyboards/1upkeyboards/sweet16/keymaps/default/keymap.c
@@ -1,4 +1,4 @@
-#include "sweet16.h"
+#include QMK_KEYBOARD_H
 
 enum custom_keycodes {
   UP_URL = SAFE_RANGE

--- a/keyboards/40percentclub/ut47/keymaps/default/config.h
+++ b/keyboards/40percentclub/ut47/keymaps/default/config.h
@@ -16,6 +16,4 @@
 
 #pragma once
 
-#include "config_common.h"
-
 // place overrides here

--- a/keyboards/amj96/keymaps/default/config.h
+++ b/keyboards/amj96/keymaps/default/config.h
@@ -14,11 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
+#pragma once
 
-#include "config_common.h"
 
 // place overrides here
-
-#endif

--- a/keyboards/amjpad/keymaps/default/keymap.c
+++ b/keyboards/amjpad/keymaps/default/keymap.c
@@ -1,9 +1,5 @@
 #include QMK_KEYBOARD_H
 
-#ifdef RGBLIGHT_ENABLE
-#include "rgblight.h"
-#endif
-
 // Each layer gets a name for readability, which is then used in the keymap matrix below.
 // The underscores don't mean anything - you can have a layer called STUFF or any other name.
 // Layer names don't all need to be of the same length, obviously, and you can also skip them

--- a/keyboards/bpiphany/tiger_lily/keymaps/default/config.h
+++ b/keyboards/bpiphany/tiger_lily/keymaps/default/config.h
@@ -1,8 +1,3 @@
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "../../config.h"
+#pragma once
 
 // place overrides here
-
-#endif

--- a/keyboards/bpiphany/unloved_bastard/keymaps/default/config.h
+++ b/keyboards/bpiphany/unloved_bastard/keymaps/default/config.h
@@ -14,11 +14,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "config_common.h"
+#pragma once
 
 // place overrides here
-
-#endif

--- a/keyboards/candybar/keymaps/default/keymap.c
+++ b/keyboards/candybar/keymaps/default/keymap.c
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "candybar.h"
+#include QMK_KEYBOARD_H
 
 #define _BL 0
 #define _FL 1

--- a/keyboards/chibios_test/keymaps/default/keymap.c
+++ b/keyboards/chibios_test/keymaps/default/keymap.c
@@ -15,7 +15,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "chibios_test.h"
+#include QMK_KEYBOARD_H
 
 const uint16_t keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     {{KC_CAPS}}, // test with KC_CAPS, KC_A, RESET

--- a/keyboards/christmas_tree/keymaps/default/config.h
+++ b/keyboards/christmas_tree/keymaps/default/config.h
@@ -1,6 +1,3 @@
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
+#pragma once
 
-#include "../../config.h"
-
-#endif
+// place overrides here

--- a/keyboards/ckeys/obelus/keymaps/default/config.h
+++ b/keyboards/ckeys/obelus/keymaps/default/config.h
@@ -1,6 +1,3 @@
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
+#pragma once
 
-#include "../../config.h"
-// Add overrides here 
-#endif
+// place overrides here

--- a/keyboards/ckeys/obelus/keymaps/default/keymap.c
+++ b/keyboards/ckeys/obelus/keymaps/default/keymap.c
@@ -1,7 +1,4 @@
 #include QMK_KEYBOARD_H
-#ifdef AUDIO_ENABLE
-  #include "audio.h"
-#endif
 
 extern keymap_config_t keymap_config;
 

--- a/keyboards/clueboard/2x1800/keymaps/default/config.h
+++ b/keyboards/clueboard/2x1800/keymaps/default/config.h
@@ -16,6 +16,4 @@
 
 #pragma once
 
-#include "config_common.h"
-
 // place overrides here

--- a/keyboards/comet46/keymaps/default/config.h
+++ b/keyboards/comet46/keymaps/default/config.h
@@ -18,14 +18,12 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
+#pragma once
 
-// #include "../../config.h"
+// place overrides here
+
 
 /* Use I2C or Serial */
 
 #define USE_I2C
 #define SSD1306OLED
-
-#endif

--- a/keyboards/contra/keymaps/default/config.h
+++ b/keyboards/contra/keymaps/default/config.h
@@ -1,7 +1,5 @@
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
+#pragma once
 
-#include "config_common.h"
 
 #ifdef AUDIO_ENABLE
     #define STARTUP_SONG SONG(PLANCK_SOUND)
@@ -25,7 +23,7 @@
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */
-                                
+
 #define MIDI_BASIC
 
 /* enable advanced MIDI features:
@@ -38,5 +36,3 @@
 
 /* override number of MIDI tone keycodes (each octave adds 12 keycodes and allocates 12 bytes) */
 //#define MIDI_TONE_KEYCODE_OCTAVES 2
-
-#endif

--- a/keyboards/converter/usb_usb/keymaps/default/config.h
+++ b/keyboards/converter/usb_usb/keymaps/default/config.h
@@ -1,6 +1,3 @@
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
+#pragma once
 
-#include "../../config.h"
-
-#endif
+// place overrides here

--- a/keyboards/cospad/keymaps/default/keymap.c
+++ b/keyboards/cospad/keymaps/default/keymap.c
@@ -1,10 +1,6 @@
 #include QMK_KEYBOARD_H
 #include "led.h"
 
-#ifdef RGBLIGHT_ENABLE
-#include "rgblight.h"
-#endif
-
 // Each layer gets a name for readability, which is then used in the keymap matrix below.
 // The underscores don't mean anything - you can have a layer called STUFF or any other name.
 // Layer names don't all need to be of the same length, obviously, and you can also skip them

--- a/keyboards/cu24/keymaps/default/keymap.c
+++ b/keyboards/cu24/keymaps/default/keymap.c
@@ -13,7 +13,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include "cu24.h"
+#include QMK_KEYBOARD_H
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 [0] = LAYOUT_grid( /* Base */

--- a/keyboards/cu75/keymaps/default/config.h
+++ b/keyboards/cu75/keymaps/default/config.h
@@ -1,8 +1,3 @@
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "../../config.h"
+#pragma once
 
 // place overrides here
-
-#endif

--- a/keyboards/deltasplit75/keymaps/default/config.h
+++ b/keyboards/deltasplit75/keymaps/default/config.h
@@ -16,16 +16,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 
+#pragma once
+
 #define USE_SERIAL
 
 #define MASTER_LEFT
 // #define MASTER_RIGHT
 // #define EE_HANDS
-
-
-#ifdef SUBPROJECT_v2
-    #include "../../v2/config.h"
-#endif
-#ifdef SUBPROJECT_protosplit
-    #include "../../protosplit/config.h"
-#endif

--- a/keyboards/dichotomy/keymaps/default/keymap.c
+++ b/keyboards/dichotomy/keymaps/default/keymap.c
@@ -1,7 +1,7 @@
 // this is the style you want to emulate.
 // This is the canonical layout file for the Quantum project. If you want to add another keyboard,
 
-#include "dichotomy.h"
+#include QMK_KEYBOARD_H
 
 // Each layer gets a name for readability, which is then used in the keymap matrix below.
 // The underscores don't mean anything - you can have a layer called STUFF or any other name.

--- a/keyboards/diverge3/keymaps/default/config.h
+++ b/keyboards/diverge3/keymaps/default/config.h
@@ -14,14 +14,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "config_common.h"
+#pragma once
 
 // place overrides here
 #define MASTER_RIGHT
 #define PERMISSIVE_HOLD
 #define TAPPING_TERM 150
-
-#endif

--- a/keyboards/do60/keymaps/default/keymap.c
+++ b/keyboards/do60/keymaps/default/keymap.c
@@ -1,5 +1,4 @@
 #include QMK_KEYBOARD_H
-#include "action_layer.h"
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 

--- a/keyboards/ergodash/rev1/keymaps/default/config.h
+++ b/keyboards/ergodash/rev1/keymaps/default/config.h
@@ -18,10 +18,9 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
+#pragma once
 
-#include "../../config.h"
+// place overrides here
 
 /* Use I2C or Serial, not both */
 
@@ -33,8 +32,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MASTER_LEFT
 // #define MASTER_RIGHT
 // #define EE_HANDS
-
-#endif
 
 #undef RGBLED_NUM
 #define RGBLIGHT_ANIMATIONS

--- a/keyboards/ergodash/rev1/keymaps/default/keymap.c
+++ b/keyboards/ergodash/rev1/keymaps/default/keymap.c
@@ -1,6 +1,4 @@
 #include QMK_KEYBOARD_H
-#include "action_layer.h"
-#include "eeconfig.h"
 
 extern keymap_config_t keymap_config;
 

--- a/keyboards/ergodash/rev2/keymaps/default/config.h
+++ b/keyboards/ergodash/rev2/keymaps/default/config.h
@@ -18,10 +18,9 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
+#pragma once
 
-#include "../../config.h"
+// place overrides here
 
 /* Use I2C or Serial, not both */
 
@@ -34,7 +33,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // #define MASTER_RIGHT
 // #define EE_HANDS
 
-#endif
 
 #undef RGBLED_NUM
 #define RGBLIGHT_ANIMATIONS

--- a/keyboards/ergodash/rev2/keymaps/default/keymap.c
+++ b/keyboards/ergodash/rev2/keymaps/default/keymap.c
@@ -1,6 +1,4 @@
 #include QMK_KEYBOARD_H
-#include "action_layer.h"
-#include "eeconfig.h"
 
 extern keymap_config_t keymap_config;
 

--- a/keyboards/ergodone/keymaps/default/keymap.c
+++ b/keyboards/ergodone/keymaps/default/keymap.c
@@ -1,6 +1,4 @@
 #include QMK_KEYBOARD_H
-#include "debug.h"
-#include "action_layer.h"
 #include "version.h"
 
 #define BASE 0 // default layer

--- a/keyboards/ergodox_infinity/keymaps/default/keymap.c
+++ b/keyboards/ergodox_infinity/keymaps/default/keymap.c
@@ -1,6 +1,4 @@
 #include QMK_KEYBOARD_H
-#include "debug.h"
-#include "action_layer.h"
 #include "version.h"
 
 #define BASE 0 // default layer

--- a/keyboards/fc660c/keymaps/default/config.h
+++ b/keyboards/fc660c/keymaps/default/config.h
@@ -14,11 +14,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "config_common.h"
+#pragma once
 
 // place overrides here
-
-#endif

--- a/keyboards/fc980c/keymaps/default/config.h
+++ b/keyboards/fc980c/keymaps/default/config.h
@@ -14,11 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
+#pragma once
 
-#include "config_common.h"
 
 // place overrides here
-
-#endif

--- a/keyboards/fortitude60/keymaps/default/config.h
+++ b/keyboards/fortitude60/keymaps/default/config.h
@@ -15,10 +15,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "config_common.h"
+#pragma once
 
 #define USE_SERIAL
 
@@ -34,5 +31,3 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* #define RGBLIGHT_HUE_STEP 8 */
 /* #define RGBLIGHT_SAT_STEP 8 */
 /* #define RGBLIGHT_VAL_STEP 8 */
-
-#endif

--- a/keyboards/fortitude60/keymaps/default/keymap.c
+++ b/keyboards/fortitude60/keymaps/default/keymap.c
@@ -1,5 +1,4 @@
 #include QMK_KEYBOARD_H
-#include "eeconfig.h"
 
 extern keymap_config_t keymap_config;
 

--- a/keyboards/four_banger/keymaps/default/keymap.c
+++ b/keyboards/four_banger/keymaps/default/keymap.c
@@ -1,4 +1,4 @@
-#include "four_banger.h"
+#include QMK_KEYBOARD_H
 
 enum custom_keycodes {
   UP_URL = SAFE_RANGE

--- a/keyboards/hadron/ver2/keymaps/default/keymap.c
+++ b/keyboards/hadron/ver2/keymaps/default/keymap.c
@@ -1,7 +1,4 @@
 #include QMK_KEYBOARD_H
-#ifdef AUDIO_ENABLE
-  #include "audio.h"
-#endif
 #ifdef USE_I2C
 #include "i2c.h"
 #endif

--- a/keyboards/handwired/dactyl_manuform/4x5/keymaps/default/config.h
+++ b/keyboards/handwired/dactyl_manuform/4x5/keymaps/default/config.h
@@ -20,8 +20,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
-#include "../../config.h"
-
 /* Use I2C or Serial, not both */
 
 #define USE_SERIAL

--- a/keyboards/handwired/dactyl_manuform/4x5/keymaps/default/keymap.c
+++ b/keyboards/handwired/dactyl_manuform/4x5/keymaps/default/keymap.c
@@ -1,6 +1,4 @@
-#include "dactyl_manuform.h"
-#include "action_layer.h"
-#include "eeconfig.h"
+#include QMK_KEYBOARD_H
 
 extern keymap_config_t keymap_config;
 
@@ -126,4 +124,3 @@ void persistent_default_layer_set(uint16_t default_layer) {
   eeconfig_update_default_layer(default_layer);
   default_layer_set(default_layer);
 }
-

--- a/keyboards/handwired/frenchdev/keymaps/default/keymap.c
+++ b/keyboards/handwired/frenchdev/keymaps/default/keymap.c
@@ -1,4 +1,5 @@
 #include QMK_KEYBOARD_H
+#include "mousekey.h"
 #include "keymap_bepo.h"
 
 

--- a/keyboards/handwired/frenchdev/keymaps/default/keymap.c
+++ b/keyboards/handwired/frenchdev/keymaps/default/keymap.c
@@ -1,5 +1,4 @@
 #include QMK_KEYBOARD_H
-#include "mousekey.h"
 #include "keymap_bepo.h"
 
 
@@ -394,5 +393,3 @@ void led_set_user(uint8_t usb_led) {
   }
   return ;
 }
-
-

--- a/keyboards/handwired/hexon38/keymaps/default/keymap.c
+++ b/keyboards/handwired/hexon38/keymaps/default/keymap.c
@@ -1,6 +1,6 @@
 // see https://github.com/pepaslabs/hexon38
 
-#include "hexon38.h"
+#include QMK_KEYBOARD_H
 
 #define A_ KC_A
 #define B_ KC_B

--- a/keyboards/handwired/maartenwut/keymaps/default/keymap.c
+++ b/keyboards/handwired/maartenwut/keymaps/default/keymap.c
@@ -1,4 +1,4 @@
-#include "maartenwut.h"
+#include QMK_KEYBOARD_H
 
 #define _MA 0
 #define _NU 1

--- a/keyboards/handwired/magicforce61/keymaps/default/keymap.c
+++ b/keyboards/handwired/magicforce61/keymaps/default/keymap.c
@@ -1,4 +1,4 @@
-#include "magicforce61.h"
+#include QMK_KEYBOARD_H
 
 #define _QWERTY 0
 #define _FN1 1

--- a/keyboards/handwired/minorca/keymaps/default/config.h
+++ b/keyboards/handwired/minorca/keymaps/default/config.h
@@ -1,12 +1,10 @@
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
+#pragma once
 
-#include "../../config.h"
+// place overrides here
+
 
 /* bootmagic salt key */
 #define BOOTMAGIC_KEY_SALT              KC_ESC
 
 /* skip bootmagic and eeconfig */
 #define BOOTMAGIC_KEY_SKIP              KC_SPACE
-
-#endif

--- a/keyboards/handwired/terminus_mini/keymaps/default/config.h
+++ b/keyboards/handwired/terminus_mini/keymaps/default/config.h
@@ -14,13 +14,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define TAPPING_TERM 150 //reduce time required to register a held key
-
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "../../config.h"
+#pragma once
 
 // place overrides here
 
-#endif
+#define TAPPING_TERM 150 //reduce time required to register a held key

--- a/keyboards/handwired/traveller/keymaps/default/keymap.c
+++ b/keyboards/handwired/traveller/keymaps/default/keymap.c
@@ -1,4 +1,5 @@
 #include QMK_KEYBOARD_H
+#include "mousekey.h"
 
 // Each layer gets a name for readability, which is then used in the keymap matrix below.
 // The underscores don't mean anything - you can have a layer called STUFF or any other name.

--- a/keyboards/handwired/traveller/keymaps/default/keymap.c
+++ b/keyboards/handwired/traveller/keymaps/default/keymap.c
@@ -1,6 +1,4 @@
-#include "traveller.h"
-#include "mousekey.h"
-#include "action_layer.h"
+#include QMK_KEYBOARD_H
 
 // Each layer gets a name for readability, which is then used in the keymap matrix below.
 // The underscores don't mean anything - you can have a layer called STUFF or any other name.
@@ -9,7 +7,7 @@
 #define _HI 2
 #define _NAV 4
 #define _CUR 5
-#define _FKEYS 6 
+#define _FKEYS 6
 #define _TRNS 8
 
 // We do the same trick for functions
@@ -20,7 +18,7 @@
 #define  MDL 4
 #define  MDR 5
 #define  MUR 6
-#define  MUL 3 
+#define  MUL 3
 
 
 
@@ -35,9 +33,9 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |------+------+------+------+------+------+  //  +------+------+------+------+------+------|
  * | Shift|   Z  | Del  | GUI  | Low  | Bspc |/Enter| Spc  | Hi   | GUI  | Alt  |  /   |Shift |
  * `------------------------------------------------------------------------------------------'
- * 
+ *
  */
-[_QW] = KEYMAP( 
+[_QW] = KEYMAP(
   TG(_NAV),         KC_GRV, KC_W,    KC_E,    KC_R,    KC_T,             KC_Y,    KC_U,    KC_I,    KC_O,    KC_MINS,  KC_EQL,
   KC_TAB,           KC_Q,    KC_S,    KC_D,    KC_F,    KC_G,            KC_H,    KC_J,    KC_K,    KC_L,    KC_P,  KC_BSLS,
   CTL_T(KC_ESC),    KC_A,    KC_X,    KC_C,    KC_V,    KC_B,    KC_RCTL,  KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SCLN,   KC_QUOT,
@@ -45,7 +43,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  ),
 
 /* LOW  - numbers, missing or awkward programming keys
- Doubled 1 key allows lazy reach with ring finger. 
+ Doubled 1 key allows lazy reach with ring finger.
  * ,-----------------------------------------.      .-----------------------------------------.
  * | FKeys|   1  |   2  |  3   |   4  |   5  |      |  6   |  7   |   8  |   9  |   0  |Ctrl-alt-del|
  * |------+------+------+------+------+------|      +------+------+------+------+------+------|
@@ -55,18 +53,18 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |------+------+------+------+------+------+  //  +------+------+------+------+------+------|
  * | Shift|      |      |      | Low  |      |/     |      |  Hi  |      |      |      |Shift |
  * `------------------------------------------------------------------------------------------'
- * 
+ *
  */
 
-[_LW] = KEYMAP( 
+[_LW] = KEYMAP(
   TG(_FKEYS),  KC_1,     KC_2,      KC_3,     KC_4,    KC_5,             KC_6,    KC_7,       KC_8,      KC_9,    KC_0,  LCTL(LALT(KC_DEL)) ,
   KC_TRNS,  KC_1,     KC_RBRC,   KC_LPRN,  KC_RPRN, KC_NO,               KC_ASTR, KC_LPRN,    KC_RPRN,    KC_LBRC,    KC_NO, KC_NO,
   KC_CAPS,   KC_LBRC,  KC_NO,     KC_LCBR,  KC_RCBR, KC_TILD,   KC_TRNS,  KC_HASH, KC_LCBR,    KC_RCBR,   KC_NO,    KC_RBRC,   KC_NO,
   KC_TRNS,  KC_TRNS,  KC_TRNS,   KC_TRNS,  KC_TRNS, KC_TRNS,  KC_TRNS,  KC_TRNS, KC_TRNS,    KC_TRNS,   KC_TRNS,  KC_TRNS,  KC_TRNS
 ),
 
-/* HI - Punctuation, shell and 
-url ://@.com  row on bottom,    && is opposite ||       ^$ are in regex order: ^.*$    
+/* HI - Punctuation, shell and
+url ://@.com  row on bottom,    && is opposite ||       ^$ are in regex order: ^.*$
 Right hand nav keys work pretty well chorded with the Right hand Hi Key
  * ,-----------------------------------------.      .-----------------------------------------.
  * |FKEYS |   !  |   @  |   #  |   $  |   %  |      |  ^   |   &  |   *  |   (  |   )  |   +  |
@@ -77,19 +75,19 @@ Right hand nav keys work pretty well chorded with the Right hand Hi Key
  * |------+------+------+------+------+------+  //  +------+------+------+------+------+------|
  * |      |   /  |      |      | Low  |      |/     |      |  Hi  | PgDn | Left| Down | Right |
  * `------------------------------------------------------------------------------------------'
- * 
+ *
  */
 
-[_HI] = KEYMAP( 
+[_HI] = KEYMAP(
  TG(_FKEYS),KC_EXLM,  KC_AT,   KC_HASH,  KC_DLR,   KC_PERC,           KC_CIRC,  KC_AMPR,    KC_ASTR,   KC_LPRN,  KC_RPRN,  KC_PLUS,
- KC_TRNS, KC_EXLM,  KC_AMPR, KC_PIPE,  KC_DLR,   KC_PERC,             KC_VOLU, KC_MUTE,    KC_NO,     KC_NO,    KC_NO,    KC_NO, 
+ KC_TRNS, KC_EXLM,  KC_AMPR, KC_PIPE,  KC_DLR,   KC_PERC,             KC_VOLU, KC_MUTE,    KC_NO,     KC_NO,    KC_NO,    KC_NO,
  KC_CAPS, KC_CIRC,  KC_COLN,  KC_DOT,  KC_ASTR,  KC_MINS,   KC_TRNS,  KC_VOLD, KC_PPLS,    KC_PGUP,   KC_HOME,  KC_UP,    KC_END,
- KC_TRNS, KC_SLSH,  KC_TRNS,  KC_TRNS, TT(_LW),  KC_TRNS,   KC_TRNS,  KC_TRNS, KC_TRNS,    KC_PGDN,   KC_LEFT,  KC_DOWN,  KC_RIGHT 
-),  
+ KC_TRNS, KC_SLSH,  KC_TRNS,  KC_TRNS, TT(_LW),  KC_TRNS,   KC_TRNS,  KC_TRNS, KC_TRNS,    KC_PGDN,   KC_LEFT,  KC_DOWN,  KC_RIGHT
+),
 
 /* NAV - mouse &  navigation
 //gui left and right are line home/end, or fore & back in browser
-// Mouse buttons are reversed for comfort - bigger stretch is to the right button. 
+// Mouse buttons are reversed for comfort - bigger stretch is to the right button.
 
  * ,-----------------------------------------.      .-----------------------------------------.
 * | NAV  |      |      | Up   |      |Gui-> |      | MwU  | MS_UL| MS_U |MS_UR |      |Ms Norm|
@@ -102,7 +100,7 @@ Right hand nav keys work pretty well chorded with the Right hand Hi Key
 * `------------------------------------------------------------------------------------------'
 */
 
-[_NAV] = KEYMAP( 
+[_NAV] = KEYMAP(
   TG(_NAV), KC_NO,         KC_NO,    KC_UP,       KC_NO,     RGUI(KC_RIGHT),            KC_WH_U,  M(MUL), KC_MS_U,   M(MUR), KC_NO, KC_ACL2,
   KC_TRNS, RGUI(KC_LEFT),  KC_LEFT,  KC_DOWN,     KC_RIGHT,  LCTL(KC_E),                KC_BTN3,  KC_MS_L,  KC_MS_U,   KC_MS_R,  KC_NO, KC_ACL1,
   KC_TRNS, LCTL(KC_A),     LGUI(KC_X),RGUI(KC_C), RGUI(KC_V),KC_NO,         KC_ENTER,   KC_WH_D,  M(MDL), KC_MS_D,  M(MDR),  KC_UP, KC_ACL0,
@@ -111,7 +109,7 @@ Right hand nav keys work pretty well chorded with the Right hand Hi Key
 
 /* FKEYS - Funtion keys & mac stuff
  * ,-----------------------------------------.      .-----------------------------------------.
- * | FKEYS| F1   | F2   | F3   |  F4  | F5   |      | F6   | F7   | F8   | F9   | F10  | Ctrl | 
+ * | FKEYS| F1   | F2   | F3   |  F4  | F5   |      | F6   | F7   | F8   | F9   | F10  | Ctrl |
  * |------+------+------+------+------+------|      |------+------+------+------+------+------|
  * |      |      |      |      |      |      |      |  F11 | F12  |  F13 | F14  |  F15 | Alt  |
  * |------+------+------+------+------+------|------+------+------+------+------+------+------|
@@ -120,9 +118,9 @@ Right hand nav keys work pretty well chorded with the Right hand Hi Key
  * |    . |RGBTog|  .   |      | LO   | Bspc |/     |      | HI   |      |      |      |      |
  * `------------------------------------------------------------------------------------------'
  *
- */ 
- 
-[_FKEYS] = KEYMAP( 
+ */
+
+[_FKEYS] = KEYMAP(
   TG(_FKEYS),KC_F1,    KC_F2,   KC_F3,      KC_F4,     KC_F5,               KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,    KC_RCTL,
   KC_TRNS,   KC_NO,    KC_NO,   KC_NO,      KC_NO,     KC_NO,               KC_F11,   KC_F12,   KC_F13,    KC_F14,  KC_F15,    KC_LALT ,
   TO(_QW),  KC_NO,     KC_NO,   KC_NO,      KC_NO,     KC_NO,    KC_TRNS,   KC_NO,    KC_NO,    KC_NO,      KC_NO,   KC_NO,    KC_DEL,
@@ -140,7 +138,7 @@ Right hand nav keys work pretty well chorded with the Right hand Hi Key
  * |------+------+------+------+------+------+  //  +------+------+------+------+------+------|
  * |    . |   .  |  .   | GUI  |  LO  |   .  |/     | Spc  |  HI  | GUI  |  M0  |  /   |LSFT |
  * `------------------------------------------------------------------------------------------'
- * 
+ *
  */
 
 [_TRNS] = {
@@ -226,12 +224,12 @@ void LayerLEDSet(uint8_t layr) {
         break;
         case _LW:
             // deep purple
-            rgblight_setrgb(20,0,35); 
-            break;  
+            rgblight_setrgb(20,0,35);
+            break;
         case _HI:
             // light blue
-           rgblight_setrgb(0,20,20); 
-            break;    
+           rgblight_setrgb(0,20,20);
+            break;
         case _NAV:
             // Yellowy orange
             rgblight_setrgb(25,20,0); // brighter
@@ -239,14 +237,14 @@ void LayerLEDSet(uint8_t layr) {
         case _FKEYS:
          // RED
            rgblight_setrgb(20,0,0); // brighter
-            break;  
+            break;
         default:
             rgblight_setrgb(20,2,20);//error
             break;
     }
- 
+
  return;
-  
+
 }
 
 void matrix_init_user(void) {
@@ -271,5 +269,3 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 void led_set_user(uint8_t usb_led) {
 
 }
-
-

--- a/keyboards/handwired/woodpad/keymaps/default/config.h
+++ b/keyboards/handwired/woodpad/keymaps/default/config.h
@@ -14,11 +14,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "../../config.h"
+#pragma once
 
 // place overrides here
-
-#endif

--- a/keyboards/handwired/woodpad/keymaps/default/keymap.c
+++ b/keyboards/handwired/woodpad/keymaps/default/keymap.c
@@ -13,7 +13,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include "woodpad.h"
+#include QMK_KEYBOARD_H
 
 // Each layer gets a name for readability, which is then used in the keymap matrix below.
 // The underscores don't mean anything - you can have a layer called STUFF or any other name.
@@ -86,7 +86,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 			layer_off(_ADJUST);
 		}
 		numlock_down = false;
-	  } 
+	  }
       return false;
       break;
 	  case KC_LALT:

--- a/keyboards/hecomi/keymaps/default/keymap.c
+++ b/keyboards/hecomi/keymaps/default/keymap.c
@@ -14,7 +14,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include QMK_KEYBOARD_H
-#include "hecomi.h"
 
 // Defines the keycodes used by our macros in process_record_user
 enum custom_keycodes {

--- a/keyboards/helix/pico/keymaps/default/config.h
+++ b/keyboards/helix/pico/keymaps/default/config.h
@@ -18,8 +18,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
+#pragma once
 
 // place overrides here
 
@@ -42,5 +41,3 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
    //#define RGBLIGHT_EFFECT_RGB_TEST
    //#define RGBLIGHT_EFFECT_ALTERNATING
 #endif
-
-#endif /* CONFIG_USER_H */

--- a/keyboards/helix/rev1/keymaps/default/config.h
+++ b/keyboards/helix/rev1/keymaps/default/config.h
@@ -18,8 +18,9 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
+#pragma once
+
+// place overrides here
 
 /* Use I2C or Serial, not both */
 
@@ -31,5 +32,3 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MASTER_LEFT
 // #define _MASTER_RIGHT
 // #define EE_HANDS
-
-#endif

--- a/keyboards/helix/rev2/keymaps/default/config.h
+++ b/keyboards/helix/rev2/keymaps/default/config.h
@@ -18,8 +18,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
+#pragma once
 
 // place overrides here
 
@@ -37,5 +36,3 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
    //#define RGBLIGHT_EFFECT_RGB_TEST
    //#define RGBLIGHT_EFFECT_ALTERNATING
 #endif
-
-#endif /* CONFIG_USER_H */

--- a/keyboards/hid_liber/keymaps/default/keymap.c
+++ b/keyboards/hid_liber/keymaps/default/keymap.c
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include "hid_liber.h"
+#include QMK_KEYBOARD_H
 
 // Each layer gets a name for readability, which is then used in the keymap matrix below.
 // The underscores don't mean anything - you can have a layer called STUFF or any other name.

--- a/keyboards/jc65/v32u4/keymaps/default/config.h
+++ b/keyboards/jc65/v32u4/keymaps/default/config.h
@@ -1,1 +1,3 @@
-#include "../../config.h"
+#pragma once
+
+// place overrides here

--- a/keyboards/jj50/keymaps/default/keymap.c
+++ b/keyboards/jj50/keymaps/default/keymap.c
@@ -18,8 +18,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include QMK_KEYBOARD_H
-#include "action_layer.h"
-#include "rgblight.h"
 
 #define ______ KC_TRNS
 #define _DEFLT 0
@@ -113,7 +111,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         _______, _______, _______, _______, _______, _______, _______,S(KC_NUHS),S(KC_NUBS),KC_HOME, KC_END, _______, \
         BL_STEP, _______, _______, _______, _______, _______, _______, _______, KC_MNXT, KC_VOLD, KC_VOLU, KC_MPLY    \
     ),
-    
+
     /* Fn
      * ,-----------------------------------------------------------------------------------.
      * |      |      |  £   |      |      |      |      |      |      |      |      |      |

--- a/keyboards/k_type/keymaps/default/keymap.c
+++ b/keyboards/k_type/keymaps/default/keymap.c
@@ -1,4 +1,4 @@
-#include "k_type.h"
+#include QMK_KEYBOARD_H
 
 const uint16_t keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [0] = KEYMAP(

--- a/keyboards/katana60/keymaps/default/config.h
+++ b/keyboards/katana60/keymaps/default/config.h
@@ -14,11 +14,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "../../config.h"
+#pragma once
 
 // place overrides here
-
-#endif

--- a/keyboards/kbdfans/kbd66/keymaps/default/config.h
+++ b/keyboards/kbdfans/kbd66/keymaps/default/config.h
@@ -14,11 +14,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "config_common.h"
+#pragma once
 
 // place overrides here
-
-#endif

--- a/keyboards/kc60se/keymaps/default/config.h
+++ b/keyboards/kc60se/keymaps/default/config.h
@@ -14,6 +14,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#pragma once"
+#pragma once
 
 // place overrides here

--- a/keyboards/kc60se/keymaps/default/config.h
+++ b/keyboards/kc60se/keymaps/default/config.h
@@ -14,11 +14,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "config_common.h"
+#pragma once"
 
 // place overrides here
-
-#endif

--- a/keyboards/keebio/chocopad/keymaps/default/config.h
+++ b/keyboards/keebio/chocopad/keymaps/default/config.h
@@ -1,6 +1,3 @@
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
+#pragma once
 
-#include "../../config.h"
-
-#endif
+// place overrides here

--- a/keyboards/kinesis/keymaps/default/config.h
+++ b/keyboards/kinesis/keymaps/default/config.h
@@ -1,8 +1,3 @@
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "../../config.h"
+#pragma once
 
 // place overrides here
-
-#endif

--- a/keyboards/kira75/keymaps/default/config.h
+++ b/keyboards/kira75/keymaps/default/config.h
@@ -14,11 +14,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "config_common.h"
+#pragma once
 
 // place overrides here
-
-#endif

--- a/keyboards/kmac/keymaps/default/config.h
+++ b/keyboards/kmac/keymaps/default/config.h
@@ -14,11 +14,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "../../config.h"
+#pragma once
 
 // place overrides here
-
-#endif

--- a/keyboards/knops/mini/keymaps/default/config.h
+++ b/keyboards/knops/mini/keymaps/default/config.h
@@ -14,11 +14,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "../../config.h"
+#pragma once
 
 // place overrides here
-
-#endif

--- a/keyboards/kona_classic/keymaps/default/config.h
+++ b/keyboards/kona_classic/keymaps/default/config.h
@@ -14,11 +14,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "../../config.h"
+#pragma once
 
 // place overrides here
-
-#endif

--- a/keyboards/launchpad/keymaps/default/keymap.c
+++ b/keyboards/launchpad/keymaps/default/keymap.c
@@ -1,7 +1,5 @@
 // Below layout is based upon /u/That-Canadian's planck layout
-#include "launchpad.h"
-#include "action_layer.h"
-#include "eeconfig.h"
+#include QMK_KEYBOARD_H
 
 extern keymap_config_t keymap_config;
 
@@ -21,9 +19,9 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 /* Qwerty
  * ,-------------.
- * |   1  |  2   |  
+ * |   1  |  2   |
  * |------+------|
- * |   3  |  4   | 
+ * |   3  |  4   |
  * |------+------|
  * |   5  |  6   |
  * |------+------|
@@ -39,9 +37,9 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 /* Function
  * ,-------------.
- * |   Q  |CALDEL|  
+ * |   Q  |CALDEL|
  * |------+------|
- * |   A  |TSKMGR| 
+ * |   A  |TSKMGR|
  * |------+------|
  * |   Z  |  X   |
  * |------+------|
@@ -58,5 +56,5 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 };
 
 void matrix_init_user(void) {
-    
+
 }

--- a/keyboards/lfkeyboards/lfk87/keymaps/default/config.h
+++ b/keyboards/lfkeyboards/lfk87/keymaps/default/config.h
@@ -1,8 +1,3 @@
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "../../config.h"
+#pragma once
 
 // place overrides here
-
-#endif

--- a/keyboards/lfkeyboards/lfkpad/keymaps/default/config.h
+++ b/keyboards/lfkeyboards/lfkpad/keymaps/default/config.h
@@ -1,8 +1,3 @@
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "../../config.h"
+#pragma once
 
 // place overrides here
-
-#endif

--- a/keyboards/lfkeyboards/mini1800/keymaps/default/config.h
+++ b/keyboards/lfkeyboards/mini1800/keymaps/default/config.h
@@ -1,8 +1,3 @@
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "../../config.h"
+#pragma once
 
 // place overrides here
-
-#endif

--- a/keyboards/lfkeyboards/smk65/keymaps/default/config.h
+++ b/keyboards/lfkeyboards/smk65/keymaps/default/config.h
@@ -1,8 +1,3 @@
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "../../config.h"
+#pragma once
 
 // place overrides here
-
-#endif

--- a/keyboards/m10a/keymaps/default/keymap.c
+++ b/keyboards/m10a/keymaps/default/keymap.c
@@ -1,7 +1,4 @@
-
-#include "m10a.h"
-#include "action_layer.h"
-#include "eeconfig.h"
+#include QMK_KEYBOARD_H
 
 extern keymap_config_t keymap_config;
 

--- a/keyboards/mechmini/v1/keymaps/default/keymap.c
+++ b/keyboards/mechmini/v1/keymaps/default/keymap.c
@@ -13,8 +13,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "mechmini.h"
-#include "quantum.h"
+#include QMK_KEYBOARD_H
 
 #define _BL  0   // base layer
 #define _FN1 1  // function layer 1

--- a/keyboards/meira/keymaps/default/config.h
+++ b/keyboards/meira/keymaps/default/config.h
@@ -14,10 +14,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
+#pragma once
 
-#include "../../config.h"
+// place overrides here
 
 // place overrides here
 #define MUSIC_MASK (keycode != KC_NO)
@@ -29,6 +28,4 @@
                                   SONG(COLEMAK_SOUND), \
                                   SONG(DVORAK_SOUND) \
                                 }
-#endif
-
 #endif

--- a/keyboards/meira/keymaps/default/keymap.c
+++ b/keyboards/meira/keymaps/default/keymap.c
@@ -13,7 +13,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include "meira.h"
+#include QMK_KEYBOARD_H
 #include "lighting.h"
 
 #ifdef RGBLIGHT_ENABLE

--- a/keyboards/meishi/keymaps/default/keymap.c
+++ b/keyboards/meishi/keymaps/default/keymap.c
@@ -13,7 +13,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include "meishi.h"
+#include QMK_KEYBOARD_H
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 [0] = LAYOUT( /* Base */

--- a/keyboards/meme/keymaps/default/config.h
+++ b/keyboards/meme/keymaps/default/config.h
@@ -14,11 +14,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "config_common.h"
+#pragma once
 
 // place overrides here
-
-#endif

--- a/keyboards/miuni32/keymaps/default/config.h
+++ b/keyboards/miuni32/keymaps/default/config.h
@@ -1,8 +1,3 @@
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "../../config.h"
+#pragma once
 
 // place overrides here
-
-#endif

--- a/keyboards/mt40/keymaps/default/config.h
+++ b/keyboards/mt40/keymaps/default/config.h
@@ -1,5 +1,6 @@
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
+#pragma once
+
+// place overrides here
 
 #define TAPPING_TERM 200
 
@@ -7,5 +8,3 @@
 #define RGBLIGHT_HUE_STEP 12
 #define RGBLIGHT_SAT_STEP 15
 #define RGBLIGHT_VAL_STEP 18
-
-#endif

--- a/keyboards/mt980/keymaps/default/keymap.c
+++ b/keyboards/mt980/keymaps/default/keymap.c
@@ -1,9 +1,9 @@
-#include "mt980.h"
+#include QMK_KEYBOARD_H
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
   [0] = LAYOUT(
-    KC_ESC,   KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   KC_NO,              KC_INS,   KC_PSCR,  KC_PGUP,  KC_PGDN, 
+    KC_ESC,   KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   KC_NO,              KC_INS,   KC_PSCR,  KC_PGUP,  KC_PGDN,
     KC_GRV,   KC_1,     KC_2,     KC_3,     KC_4,     KC_5,     KC_6,     KC_7,     KC_8,     KC_9,     KC_0,     KC_MINS,  KC_EQL,   KC_BSPC,  KC_BSPC,  KC_NLCK,  KC_PSLS,  KC_PAST,  KC_PMNS,
     KC_TAB,   KC_Q,     KC_W,     KC_E,     KC_R,     KC_T,     KC_Y,     KC_U,     KC_I,     KC_O,     KC_P,     KC_LBRC,  KC_RBRC,  KC_BSLS,            KC_P7,    KC_P8,    KC_P9,    KC_PPLS,
     KC_CAPS,  KC_A,     KC_S,     KC_D,     KC_F,     KC_G,     KC_H,     KC_J,     KC_K,     KC_L,     KC_SCLN,  KC_QUOT,  KC_ENT,                       KC_P4,    KC_P5,    KC_P6,    KC_PPLS,
@@ -11,11 +11,11 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     KC_LCTL,  KC_LGUI,  KC_LALT,                      KC_SPC,                                 KC_RALT,  MO(1),    KC_RCTL,  KC_LEFT,  KC_DOWN,  KC_RGHT,            KC_P0,    KC_PDOT,  KC_PENT),
 
   [1] = LAYOUT(
-    KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,            KC_PAUSE, KC_SLCK,  KC_HOME,  KC_END,   
-    KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  RGB_TOG,  RESET,    KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,   
-    KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,            KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,   
-    KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,                      KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,   
-    KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  RGB_VAI,            KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,   
-    KC_TRNS,  KC_TRNS,  KC_TRNS,                      RESET,                                  KC_TRNS,  KC_TRNS,  KC_TRNS,  RGB_RMOD, RGB_VAD,  RGB_MOD,            KC_TRNS,  KC_TRNS,  KC_TRNS)  
+    KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,            KC_PAUSE, KC_SLCK,  KC_HOME,  KC_END,
+    KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  RGB_TOG,  RESET,    KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,
+    KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,            KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,
+    KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,                      KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,
+    KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  RGB_VAI,            KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,
+    KC_TRNS,  KC_TRNS,  KC_TRNS,                      RESET,                                  KC_TRNS,  KC_TRNS,  KC_TRNS,  RGB_RMOD, RGB_VAD,  RGB_MOD,            KC_TRNS,  KC_TRNS,  KC_TRNS)
 
 };

--- a/keyboards/mxss/keymaps/default/config.h
+++ b/keyboards/mxss/keymaps/default/config.h
@@ -14,11 +14,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "config_common.h"
+#pragma once
 
 // place overrides here
-
-#endif

--- a/keyboards/org60/keymaps/default/keymap.c
+++ b/keyboards/org60/keymaps/default/keymap.c
@@ -1,5 +1,4 @@
 #include QMK_KEYBOARD_H
-#include "action_layer.h"
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 

--- a/keyboards/orthodox/keymaps/default/config.h
+++ b/keyboards/orthodox/keymaps/default/config.h
@@ -19,10 +19,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "config_common.h"
+#pragma once
 
 /* Use I2C or Serial, not both */
 
@@ -43,7 +40,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                   SONG(COLEMAK_SOUND), \
                                   SONG(DVORAK_SOUND) \
                                 }
-#endif
-
-
 #endif

--- a/keyboards/phantom/keymaps/default/config.h
+++ b/keyboards/phantom/keymaps/default/config.h
@@ -14,11 +14,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "../../config.h"
+#pragma once
 
 // place overrides here
-
-#endif

--- a/keyboards/preonic/keymaps/default/config.h
+++ b/keyboards/preonic/keymaps/default/config.h
@@ -1,7 +1,4 @@
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "config_common.h"
+#pragma once
 
 #ifdef AUDIO_ENABLE
     #define STARTUP_SONG SONG(PREONIC_SOUND)
@@ -38,5 +35,3 @@
 
 /* override number of MIDI tone keycodes (each octave adds 12 keycodes and allocates 12 bytes) */
 //#define MIDI_TONE_KEYCODE_OCTAVES 2
-
-#endif

--- a/keyboards/primekb/prime_r/keymaps/default/config.h
+++ b/keyboards/primekb/prime_r/keymaps/default/config.h
@@ -14,11 +14,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "config_common.h"
+#pragma once
 
 // place overrides here
-
-#endif

--- a/keyboards/ps2avrGB/keymaps/default/keymap.c
+++ b/keyboards/ps2avrGB/keymaps/default/keymap.c
@@ -15,7 +15,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "bmini.h"
+#include QMK_KEYBOARD_H
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [0] = KEYMAP(

--- a/keyboards/ps2avrGB/ps2avrGB.h
+++ b/keyboards/ps2avrGB/ps2avrGB.h
@@ -19,13 +19,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define KEYMAP_COMMON_H
 
 #include "quantum.h"
-
-#ifdef KEYBOARD_ps2avrGB_bfake
-  #include "bfake.h"
-#endif
-
-#ifdef KEYBOARD_ps2avrGB_bmini_x2
-  #include "bmini_x2.h"
-#endif
+#include "bmini.h"
 
 #endif

--- a/keyboards/rama/m10_b/keymaps/default/config.h
+++ b/keyboards/rama/m10_b/keymaps/default/config.h
@@ -14,11 +14,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "../../config.h"
+#pragma once
 
 // place overrides here
-
-#endif

--- a/keyboards/scarletbandana/keymaps/default/config.h
+++ b/keyboards/scarletbandana/keymaps/default/config.h
@@ -14,11 +14,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "../../config.h"
+#pragma once
 
 // place overrides here
-
-#endif

--- a/keyboards/scrabblepad/keymaps/default/config.h
+++ b/keyboards/scrabblepad/keymaps/default/config.h
@@ -14,11 +14,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "config_common.h"
+#pragma once
 
 // place overrides here
-
-#endif

--- a/keyboards/scrabblepad/keymaps/default/keymap.c
+++ b/keyboards/scrabblepad/keymaps/default/keymap.c
@@ -13,7 +13,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include "scrabblepad.h"
+#include QMK_KEYBOARD_H
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 [0] = LAYOUT( /* Base */

--- a/keyboards/singa/keymaps/default/config.h
+++ b/keyboards/singa/keymaps/default/config.h
@@ -14,11 +14,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "config_common.h"
+#pragma once
 
 // place overrides here
-
-#endif

--- a/keyboards/speedo/keymaps/default/config.h
+++ b/keyboards/speedo/keymaps/default/config.h
@@ -14,11 +14,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "config_common.h"
+#pragma once
 
 // place overrides here
-
-#endif

--- a/keyboards/staryu/keymaps/default/keymap.c
+++ b/keyboards/staryu/keymaps/default/keymap.c
@@ -15,7 +15,6 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include QMK_KEYBOARD_H
-#include "action_layer.h"
 
 enum layers {
   _LAYER0,

--- a/keyboards/subatomic/keymaps/default/config.h
+++ b/keyboards/subatomic/keymaps/default/config.h
@@ -1,7 +1,6 @@
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
+#pragma once
 
-#include "../../config.h"
+// place overrides here
 
 /*
  * MIDI options
@@ -25,5 +24,3 @@
 
 /* override number of MIDI tone keycodes (each octave adds 12 keycodes and allocates 12 bytes) */
 //#define MIDI_TONE_KEYCODE_OCTAVES 2
-
-#endif

--- a/keyboards/subatomic/keymaps/default/keymap.c
+++ b/keyboards/subatomic/keymaps/default/keymap.c
@@ -1,9 +1,4 @@
-#include "subatomic.h"
-#include "action_layer.h"
-#include "eeconfig.h"
-#ifdef AUDIO_ENABLE
-  #include "audio.h"
-#endif
+#include QMK_KEYBOARD_H
 
 // Each layer gets a name for readability, which is then used in the keymap matrix below.
 // The underscores don't mean anything - you can have a layer called STUFF or any other name.

--- a/keyboards/sx60/keymaps/default/config.h
+++ b/keyboards/sx60/keymaps/default/config.h
@@ -1,1 +1,3 @@
-#include "../../config.h"
+#pragma once
+
+// place overrides here

--- a/keyboards/tanuki/keymaps/default/keymap.c
+++ b/keyboards/tanuki/keymaps/default/keymap.c
@@ -1,5 +1,4 @@
 #include QMK_KEYBOARD_H
-#include "rgblight.h"
 
 //Layer definitions
 #define _BL 0

--- a/keyboards/telophase/keymaps/default/keymap.c
+++ b/keyboards/telophase/keymaps/default/keymap.c
@@ -1,7 +1,7 @@
 // this is the style you want to emulate.
 // This is the canonical layout file for the Quantum project. If you want to add another keyboard,
 
-#include "telophase.h"
+#include QMK_KEYBOARD_H
 
 // Each layer gets a name for readability, which is then used in the keymap matrix below.
 // The underscores don't mean anything - you can have a layer called STUFF or any other name.
@@ -15,7 +15,7 @@ enum telophase_layers
 	_ADJUST,
 };
 
-enum telophase_keycodes 
+enum telophase_keycodes
 {
   LOWER = SAFE_RANGE,
   RAISE,
@@ -97,4 +97,3 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 void matrix_scan_user(void) {
 		return;
 };
-

--- a/keyboards/tetris/keymaps/default/keymap.c
+++ b/keyboards/tetris/keymaps/default/keymap.c
@@ -1,7 +1,6 @@
 #include QMK_KEYBOARD_H
 
 #ifdef AUDIO_ENABLE
-  #include "audio.h"
   float  tone_caps[][2]  = SONG( CAPS_LOCK_ON_SOUND );
   float  tone_taps[][2]     = SONG( E__NOTE( _A6 ) );
 #endif

--- a/keyboards/the_ruler/keymaps/default/config.h
+++ b/keyboards/the_ruler/keymaps/default/config.h
@@ -1,8 +1,3 @@
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "../../config.h"
+#pragma once
 
 // place overrides here
-
-#endif

--- a/keyboards/the_ruler/keymaps/default/keymap.c
+++ b/keyboards/the_ruler/keymaps/default/keymap.c
@@ -1,6 +1,4 @@
 #include QMK_KEYBOARD_H
-#include "action_layer.h"
-#include "eeconfig.h"
 
 extern keymap_config_t keymap_config;
 

--- a/keyboards/thevankeyboards/bananasplit/keymaps/default/config.h
+++ b/keyboards/thevankeyboards/bananasplit/keymaps/default/config.h
@@ -14,11 +14,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "../../config.h"
+#pragma once
 
 // place overrides here
-
-#endif

--- a/keyboards/thevankeyboards/minivan/keymaps/default/config.h
+++ b/keyboards/thevankeyboards/minivan/keymaps/default/config.h
@@ -1,8 +1,3 @@
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "../../config.h"
+#pragma once
 
 // place overrides here
-
-#endif

--- a/keyboards/thevankeyboards/roadkit/keymaps/default/config.h
+++ b/keyboards/thevankeyboards/roadkit/keymaps/default/config.h
@@ -1,8 +1,3 @@
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "../../config.h"
+#pragma once
 
 // place overrides here
-
-#endif

--- a/keyboards/v60_type_r/keymaps/default/config.h
+++ b/keyboards/v60_type_r/keymaps/default/config.h
@@ -13,14 +13,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+#pragma once
 
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
+// place overrides here
 
-#include "../../config.h"
 
 #ifdef V60_POLESTAR
 #undef V60_POLESTAR
-#endif
-
 #endif

--- a/keyboards/vision_division/keymaps/default/config.h
+++ b/keyboards/vision_division/keymaps/default/config.h
@@ -1,7 +1,7 @@
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
+#pragma once
 
-#include "../../config.h"
+// place overrides here
+
 #include "matrix_types.h"
 
 /* USB Device descriptor parameter */
@@ -77,5 +77,3 @@ KEYMAP_MASTER(MATRIX_LAYER,                      NUMERIC_NORMAL,          HOMING
       k601, k602, k603, k604, k605, k606, k607, k608, k609, k60A, KC_NO, KC_NO, k611, k612, k613, k614, k615, k616, k617, k618, k619, k61A, k61B, KC_NO  \
 )
 */
-
-#endif

--- a/keyboards/vision_division/keymaps/default/keymap.c
+++ b/keyboards/vision_division/keymaps/default/keymap.c
@@ -1,12 +1,5 @@
-#include "vision_division.h"
-#include "action_layer.h"
-#include "eeconfig.h"
+#include QMK_KEYBOARD_H
 #include "led.h"
-
-#ifdef AUDIO_ENABLE
-    #include "audio.h"
-    #include "song_list.h"
-#endif
 
 enum keyboard_layers {
   LAYER_QWERTY = 0,

--- a/keyboards/xd60/keymaps/default/keymap.c
+++ b/keyboards/xd60/keymaps/default/keymap.c
@@ -1,5 +1,4 @@
 #include QMK_KEYBOARD_H
-#include "action_layer.h"
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 

--- a/keyboards/ymd96/keymaps/default/keymap.c
+++ b/keyboards/ymd96/keymaps/default/keymap.c
@@ -16,9 +16,7 @@ You should have received a copy of the GNU General Public LicensezZZ
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "ymd96.h"
-#include "action_layer.h"
-#include "rgblight.h"
+#include QMK_KEYBOARD_H
 
 #define ______ KC_TRNS
 #define _DEFLT 0
@@ -27,7 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define KEYMAP KEYMAP_DEFAULT
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-	
+
 	/* Layer 0, default layer
 	*  | Esc  |  F1  |  F2  |  F3  |  F4  |  F5  |  F6  |  F7  |  F8  |  F9  |  F10 |  F11 |  F12 |Print | Home | End  |Insert|Delete| PgUp | 19 keys
 	*  |  ~`  |   1  |   2  |   3  |   4  |   5  |   6  |   7  |   8  |   9  |    0 |    - |    = |    BkSpc    |NumLck|   /  |   *  | PgDn | 18 keys
@@ -36,7 +34,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 	*  |    LShft     |   Z  |   X  |   C  |   V  |   B  |   N  |   M  |   ,  |   .  |   /  |       RShft       |  1   |   2  |   3  |  En  | 16 keys
 	*  | Ctrl  |  Win  |  Alt  |                  Space                      |  Fn  |  Win | Left | Down |  Up  | Right|   0  |   .  |      | 12 keys
 	*/
-	
+
     [_DEFLT] = KEYMAP(
 			KC_ESC,  KC_F1,  KC_F2,  KC_F3,  KC_F4,  KC_F5,  KC_F6,  KC_F7,  KC_F8,  KC_F9,  KC_F10, KC_F11,       KC_F12,      KC_PSCR, KC_HOME,    KC_END,     KC_INSERT,   KC_DELETE,      KC_PGUP, \
 			KC_GRV,  KC_1,   KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,   KC_0,   KC_MINS,      KC_EQL,          KC_BSPC,         KC_NUMLOCK, KC_KP_SLASH, KC_KP_ASTERISK, KC_PGDN, \
@@ -52,7 +50,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 	*  |          |      |      |      |      |      |      |      |      |      |      |      |                |      |      |      |      |
 	*  |              |      |      |      |      |      |      |      | VolDn| VolUp| Mute |     Play/Pause    |      |      |      |      |
 	*  |       |       |       |                                             |      |      |MPrev |      |      | MNext|      |      |      |
-	*/ 
+	*/
 	[_RAISE] = KEYMAP(
 			______,  ______,  ______,  ______,  ______,  ______,  ______,  ______,  ______,  ______,  ______,  ______,  ______,  ______,  ______,  ______,  ______,  ______,  ______, \
 			______,  ______,  ______,  ______,  ______,  ______,  ______,  ______,  ______,  ______,  ______,  ______,  ______,  ______,           ______,  ______,  ______,  ______, \

--- a/keyboards/zen/keymaps/default/config.h
+++ b/keyboards/zen/keymaps/default/config.h
@@ -15,10 +15,9 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
+#pragma once
 
-#include "config_common.h"
+// place overrides here
 
 /* Use I2C or Serial, not both */
 
@@ -37,5 +36,3 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGBLIGHT_HUE_STEP 8
 #define RGBLIGHT_SAT_STEP 8
 #define RGBLIGHT_VAL_STEP 8
-
-#endif


### PR DESCRIPTION
## Description

Cleans up the default keymap files for all keyboards:
* Remove includes for `config.h` or `config_common.h` from keymap's `config.h` files
* Replace include for keyboard file, with `QMK_KEYBOARD_H`
* Remove extra includes that aren't needed (like action_layer.h, eeconfig.h, audio.h, rgblight.h, etc)
* Remove unnecessary defines for `XXXXXXX` and `_______` from default `keymap.c`


## Types of Changes
- [X] Enhancement/optimization
- [X] Keyboard (addition or update)
- [X] Keymap/layout/userspace (addition or update)

## Issues Fixed or Closed by This PR

* Closes #5349

## Checklist
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
