### PR TITLE
add quantum matrix calls to zen matrix calls

### DIFF
--- a/keyboards/zen/matrix.c
+++ b/keyboards/zen/matrix.c
@@ -133,7 +133,7 @@ void matrix_init(void)
         matrix_debouncing[i] = 0;
     }
 
-
+    matrix_init_quantum();
 }
 
 uint8_t _matrix_scan(void)
@@ -264,6 +264,7 @@ uint8_t matrix_scan(void)
         TXLED0;
         error_count = 0;
     }
+    matrix_scan_quantum();
     return ret;
 }
 


### PR DESCRIPTION
## Description

The `matrix_scan()` function for zen keyboards under `keyboards/zen` does not have a call to `matrix_scan_quantum()`, and similarly for the `matrix_init()` function. This prevents certain QMK features from functioning correctly (eg. Tap Dance).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
