### PR TITLE
Fix i2c splits with >8 columns

### DIFF
--- a/quantum/split_common/transport.c
+++ b/quantum/split_common/transport.c
@@ -1,3 +1,4 @@
+#include <string.h>
 
 #include "config.h"
 #include "matrix.h"
@@ -59,9 +60,8 @@ bool transport_master(matrix_row_t matrix[]) {
 }
 
 void transport_slave(matrix_row_t matrix[]) {
-  for (int i = 0; i < ROWS_PER_HAND * sizeof(matrix_row_t); ++i) {
-    i2c_slave_reg[I2C_KEYMAP_START + i] = matrix[i];
-  }
+  // Copy matrix to I2C buffer
+  memcpy((void*)(i2c_slave_reg + I2C_KEYMAP_START), (void *)matrix, ROWS_PER_HAND * sizeof(matrix_row_t) );
 
 // Read Backlight Info
 #  ifdef BACKLIGHT_ENABLE


### PR DESCRIPTION
## Description

Silly bug in the transport code for i2c splits; was implicitly converting larger row variables to uint8_t. Fixed by using memcpy instead of manually assigning array elements.

## Types of Changes
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Discord

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
