### PR TITLE
Refactor MF68 default keymap to use LAYOUT_68_ansi macro

### DIFF
--- a/keyboards/40percentclub/mf68/keymaps/default/keymap.c
+++ b/keyboards/40percentclub/mf68/keymaps/default/keymap.c
@@ -3,51 +3,29 @@
 #define _QWERTY 0
 #define _FN1 1
 #define _FN2 2
-#define KC_ KC_TRNS
-#define KC_X0 LT(_FN2, KC_GRV)
-#define KC_X1 MO(_FN1)
-#define KC_X2 BL_STEP
+
+#define FN2_GRV LT(_FN2, KC_GRV)
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-  [_QWERTY] = LAYOUT_kc(
- /*,----+----+----+----+----+----+----+----+----+----+----+----+----+--------.  ,----+----. */
-    ESC , 1  , 2  , 3  , 4  , 5  , 6  , 7  , 8  , 9  , 0  ,MINS,EQL ,  BSPC  ,   INS ,PGUP,
- /*|----`----`----`----`----`----`----`----`----`----`----`----`----`--------|  |----`----| */
-    TAB   , Q  , W  , E  , R  , T  , Y  , U  , I  , O  , P  ,LBRC,RBRC, BSLS ,   DEL ,PGDN,
- /*|------`----`----`----`----`----`----`----`----`----`----`----`----`------|  `----`----' */
-    X0     , A  , S  , D  , F  , G  , H  , J  , K  , L  ,SCLN,QUOT,    ENTER ,
- /*|-------`----`----`----`----`----`----`----`----`----`----`----`----------|  ,----. */
-    LSFT     , Z  , X  , C  , V  , B  , N  , M  ,COMM,DOT ,SLSH,       RSFT  ,    UP ,
- /*|---------`----`----`----`----`----`----`----`----`----`----`-------------.--|----|----. */
-    LCTL ,LGUI ,LALT ,            SPACE             ,  X1  ,RALT ,RCTL ,    LEFT,DOWN,RGHT
- /*`-----+-----+-----+------------------------------+------+-----+-----'   `----+----+----' */
+  [_QWERTY] = LAYOUT_68_ansi(
+    KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC,          KC_INS,  KC_PGUP,
+    KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS,          KC_DEL,  KC_PGDN,
+    FN2_GRV, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,          KC_ENT,
+    KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH,                   KC_RSFT,          KC_UP,
+    KC_LCTL, KC_LGUI, KC_LALT,                            KC_SPC,                             MO(1),   KC_RALT, KC_RCTL,          KC_LEFT, KC_DOWN, KC_RGHT
   ),
-
-  [_FN1] = LAYOUT_kc(
- /*,----+----+----+----+----+----+----+----+----+----+----+----+----+--------.  ,----+----. */
-    GRV , F1 , F2 , F3 , F4 , F5 , F6 , F7 , F8 , F9 ,F10 ,F11 ,F12 ,   BSPC ,   VOLU,HOME,
- /*|esc-`-1--`-2--`-3--`-4--`-5--`-6--`-7--`-8--`-9--`-0--`mnus`plus`--bksp--|  |ins-`pgup| */
-          ,    ,    , UP ,    ,    ,    ,    ,    ,    ,    ,    , X2 ,      ,   VOLD,END,
- /*|tab---`-q--`-w--`-e--`-r--`-t--`-y--`-u--`-i--`-o--`-p--`-{--`-}--`--|---|  `del-`pgdn' */
-           ,    ,LEFT,DOWN,RGHT,    ,    ,    ,    ,    ,    ,    ,          ,
- /*|caps---`-a--`-s--`-d--`-f--`-g--`-h--`-j--`-k--`-l--`-;--`-'--`----enter-|  ,----. */
-             ,    ,    ,    ,    ,    ,    ,MUTE,    ,    ,    ,             ,   MUTE,
- /*|shift----`-z--`-x--`-c--`-v--`-b--`-n--`-m--`-,--`-.--`-/--`-------shift-.--|-up-|----. */
-         ,     ,     ,                              ,      ,     ,     ,    MPRV,MPLY,MNXT
- /*`ctrl-+-gui-+-alt-+----------space---------------+-fn---+-alt-+ctrl-'   `left+down+rght' */
+  [_FN1] = LAYOUT_68_ansi(
+    KC_GRV,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_BSPC,          KC_VOLU, KC_HOME,
+    _______, _______, _______, KC_UP,   _______, _______, _______, _______, _______, _______, _______, _______, BL_STEP, _______,          KC_VOLD, KC_END,
+    _______, _______, KC_LEFT, KC_DOWN, KC_RGHT, _______, _______, _______, _______, _______, _______, _______,          _______,
+    _______, _______, _______, _______, _______, _______, _______, KC_MUTE, _______, _______, _______,                   _______,          KC_MUTE,
+    _______, _______, _______,                            _______,                            _______, _______, _______,          KC_MPRV, KC_MPLY, KC_MNXT
   ),
-
-  [_FN2] = LAYOUT_kc(
- /*,----+----+----+----+----+----+----+----+----+----+----+----+----+--------.  ,----+----. */
-    GRV , F1 , F2 , F3 , F4 , F5 , F6 , F7 , F8 , F9 ,F10 ,F11 ,F12 ,   BSPC ,   VOLU,HOME,
- /*|esc-`-1--`-2--`-3--`-4--`-5--`-6--`-7--`-8--`-9--`-0--`mnus`plus`--bksp--|  |ins-`pgup| */
-          ,    ,    , UP ,    ,    ,    , 7  , 8  , 9  ,    ,    ,    ,      ,   VOLD,END,
- /*|tab---`-q--`-w--`-e--`-r--`-t--`-y--`-u--`-i--`-o--`-p--`-{--`-}--`--|---|  `del-`pgdn' */
-           ,    ,LEFT,DOWN,RGHT,    ,    , 4  , 5  , 6  ,    ,    ,          ,
- /*|caps---`-a--`-s--`-d--`-f--`-g--`-h--`-j--`-k--`-l--`-;--`-'--`----enter-|  ,----. */
-             ,    ,    ,    ,    ,    , 0  , 1  , 2  , 3  ,    ,             ,   MUTE,
- /*|shift----`-z--`-x--`-c--`-v--`-b--`-n--`-m--`-,--`-.--`-/--`-------shift-.--|-up-|----. */
-         ,     ,     ,                              ,      ,     ,     ,    MPRV,MPLY,MNXT
- /*`ctrl-+-gui-+-alt-+----------space---------------+-fn---+-alt-+ctrl-'   `left+down+rght' */
+  [_FN2] = LAYOUT_68_ansi(
+    KC_GRV,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_BSPC,          KC_VOLU, KC_HOME,
+    _______, _______, _______, KC_UP,   _______, _______, _______, KC_7,    KC_8,    KC_9,    _______, _______, _______, _______,          KC_VOLD, KC_END,
+    _______, _______, KC_LEFT, KC_DOWN, KC_RGHT, _______, _______, KC_4,    KC_5,    KC_6,    _______, _______,          _______,
+    _______, _______, _______, _______, _______, _______, KC_0,    KC_1,    KC_2,    KC_3,    _______,                   _______,          KC_MUTE,
+    _______, _______, _______,                            _______,                            _______, _______, _______,          KC_MPRV, KC_MPLY, KC_MNXT
   )
 };


### PR DESCRIPTION
## Description / Notes

Been sort of checking default/reference keymaps for issues, as I am wont to do.


## Commit Log

### Refactor MF68 default keymap to use LAYOUT_68_ansi macro (e6976c7)
