### PR TITLE
Fix RGB Matrix issue with EEPROM 

### DIFF
--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -253,10 +253,10 @@ A similar function works in the keymap as `rgb_matrix_indicators_user`.
 The EEPROM for it is currently shared with the RGBLIGHT system (it's generally assumed only one RGB would be used at a time), but could be configured to use its own 32bit address with:
 
 ```C
-#define EECONFIG_RGB_MATRIX (uint32_t *)16
+#define EECONFIG_RGB_MATRIX (uint32_t *)28
 ```
 
-Where `16` is an unused index from `eeconfig.h`.
+Where `28` is an unused index from `eeconfig.h`.
 
 ## Suspended state
 

--- a/tmk_core/common/eeconfig.c
+++ b/tmk_core/common/eeconfig.c
@@ -47,6 +47,9 @@ void eeconfig_init_quantum(void) {
   eeprom_update_byte(EECONFIG_STENOMODE,      0);
   eeprom_update_dword(EECONFIG_HAPTIC,        0);
   eeprom_update_byte(EECONFIG_VELOCIKEY,      0);
+#ifdef EECONFIG_RGB_MATRIX
+  eeprom_update_dword(EECONFIG_RGB_MATRIX,    0);
+#endif
 
   eeconfig_init_kb();
 }
@@ -185,5 +188,3 @@ uint32_t eeconfig_read_haptic(void)      { return eeprom_read_dword(EECONFIG_HAP
  * FIXME: needs doc
  */
 void eeconfig_update_haptic(uint32_t val) { eeprom_update_dword(EECONFIG_HAPTIC, val); }
-
-


### PR DESCRIPTION
## Description

If you define `EECONFIG_RGB_MATRIX` in your config.h file, it's not actually initialized.  This leads to a number of issues with the feature (namely that it just won't work). 

This will allow it to be initialized, properly, if it's defined.  


Also, this updates the doc to point to an unused address in EEPROM. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* Drashna CI failure, trying to get rgb matrix and light working. 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [X] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).