### PR TITLE
Add -yq flags to actually make debian installs noninteractive

### DIFF
--- a/util/linux_install.sh
+++ b/util/linux_install.sh
@@ -34,7 +34,7 @@ elif grep ID /etc/os-release | grep -qE 'debian|ubuntu'; then
 	DEBCONF_NONINTERACTIVE_SEEN=true
 	export DEBIAN_FRONTEND DEBCONF_NONINTERACTIVE_SEEN
 	sudo apt-get update
-	sudo apt-get install \
+	sudo apt-get -yq install \
 		build-essential \
 		avr-libc \
 		binutils-arm-none-eabi \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
I'm assuming that because `DEBIAN_FRONTEND=noninteractive` is set, we actually want this to be non interactive. However when I run this on my system, it actually is interactive. Adding the -yq flag will fix this. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
