### PR TITLE
Reduce CRKBD firmware size by reducing layer numbers

### DIFF
--- a/keyboards/crkbd/keymaps/default/keymap.c
+++ b/keyboards/crkbd/keymaps/default/keymap.c
@@ -22,9 +22,9 @@ extern uint8_t is_master;
 // Layer names don't all need to be of the same length, obviously, and you can also skip them
 // entirely and just use numbers.
 #define _QWERTY 0
-#define _LOWER 3
-#define _RAISE 4
-#define _ADJUST 16
+#define _LOWER 1
+#define _RAISE 2
+#define _ADJUST 3
 
 enum custom_keycodes {
   QWERTY = SAFE_RANGE,
@@ -246,4 +246,3 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
   }
   return true;
 }
-

--- a/keyboards/crkbd/keymaps/omgvee/keymap.c
+++ b/keyboards/crkbd/keymaps/omgvee/keymap.c
@@ -22,9 +22,9 @@ extern uint8_t is_master;
 // Layer names don't all need to be of the same length, obviously, and you can also skip them
 // entirely and just use numbers.
 #define _QWERTY 0
-#define _LOWER 3
-#define _RAISE 4
-#define _ADJUST 16
+#define _LOWER 1
+#define _RAISE 2
+#define _ADJUST 3
 
 enum custom_keycodes {
   QWERTY = SAFE_RANGE,
@@ -240,4 +240,3 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
   }
   return true;
 }
-

--- a/keyboards/crkbd/keymaps/omgvee/keymap.c
+++ b/keyboards/crkbd/keymaps/omgvee/keymap.c
@@ -22,9 +22,9 @@ extern uint8_t is_master;
 // Layer names don't all need to be of the same length, obviously, and you can also skip them
 // entirely and just use numbers.
 #define _QWERTY 0
-#define _LOWER 1
-#define _RAISE 2
-#define _ADJUST 3
+#define _LOWER 3
+#define _RAISE 4
+#define _ADJUST 16
 
 enum custom_keycodes {
   QWERTY = SAFE_RANGE,
@@ -240,3 +240,4 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
   }
   return true;
 }
+

--- a/keyboards/crkbd/keymaps/thefrey/keymap.c
+++ b/keyboards/crkbd/keymaps/thefrey/keymap.c
@@ -22,9 +22,9 @@ extern uint8_t is_master;
 // Layer names don't all need to be of the same length, obviously, and you can also skip them
 // entirely and just use numbers.
 #define _QWERTY 0
-#define _LOWER 3
-#define _RAISE 4
-#define _ADJUST 16
+#define _LOWER 1
+#define _RAISE 2
+#define _ADJUST 3
 
 enum custom_keycodes {
   QWERTY = SAFE_RANGE,
@@ -241,4 +241,3 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
   }
   return true;
 }
-

--- a/keyboards/crkbd/keymaps/thefrey/keymap.c
+++ b/keyboards/crkbd/keymaps/thefrey/keymap.c
@@ -22,9 +22,9 @@ extern uint8_t is_master;
 // Layer names don't all need to be of the same length, obviously, and you can also skip them
 // entirely and just use numbers.
 #define _QWERTY 0
-#define _LOWER 1
-#define _RAISE 2
-#define _ADJUST 3
+#define _LOWER 3
+#define _RAISE 4
+#define _ADJUST 16
 
 enum custom_keycodes {
   QWERTY = SAFE_RANGE,
@@ -241,3 +241,4 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
   }
   return true;
 }
+

--- a/keyboards/crkbd/lib/layer_state_reader.c
+++ b/keyboards/crkbd/lib/layer_state_reader.c
@@ -4,10 +4,10 @@
 #include "crkbd.h"
 
 #define L_BASE 0
-#define L_LOWER (1<<_LOWER)
-#define L_RAISE (1<<_RAISE)
-#define L_ADJUST (1<<_ADJUST)
-#define L_ADJUST_TRI (L_ADJUST|L_RAISE|L_LOWER)
+#define L_LOWER 2
+#define L_RAISE 4
+#define L_ADJUST 8
+#define L_ADJUST_TRI 14
 
 char layer_state_str[24];
 

--- a/keyboards/crkbd/lib/layer_state_reader.c
+++ b/keyboards/crkbd/lib/layer_state_reader.c
@@ -3,11 +3,11 @@
 #include <stdio.h>
 #include "crkbd.h"
 
-#define L_BASE 0
-#define L_LOWER 2
-#define L_RAISE 4
-#define L_ADJUST 8
-#define L_ADJUST_TRI 14
+ #define L_BASE 0
+ #define L_LOWER (1<<_LOWER)
+ #define L_RAISE (1<<_RAISE)
+ #define L_ADJUST (1<<_ADJUST)
+ #define L_ADJUST_TRI (L_ADJUST|L_RAISE|L_LOWER)
 
 char layer_state_str[24];
 

--- a/keyboards/crkbd/lib/layer_state_reader.c
+++ b/keyboards/crkbd/lib/layer_state_reader.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include "crkbd.h"
 
+// in the future, should use (1U<<_LAYER_NAME) instead, but needs to be moved to keymap,c
 #define L_BASE 0
 #define L_LOWER 2
 #define L_RAISE 4

--- a/keyboards/crkbd/lib/layer_state_reader.c
+++ b/keyboards/crkbd/lib/layer_state_reader.c
@@ -4,10 +4,10 @@
 #include "crkbd.h"
 
 #define L_BASE 0
-#define L_LOWER 8
-#define L_RAISE 16
-#define L_ADJUST 65536
-#define L_ADJUST_TRI 65560
+#define L_LOWER 2
+#define L_RAISE 4
+#define L_ADJUST 8
+#define L_ADJUST_TRI 14
 
 char layer_state_str[24];
 

--- a/keyboards/crkbd/lib/layer_state_reader.c
+++ b/keyboards/crkbd/lib/layer_state_reader.c
@@ -3,11 +3,11 @@
 #include <stdio.h>
 #include "crkbd.h"
 
- #define L_BASE 0
- #define L_LOWER (1<<_LOWER)
- #define L_RAISE (1<<_RAISE)
- #define L_ADJUST (1<<_ADJUST)
- #define L_ADJUST_TRI (L_ADJUST|L_RAISE|L_LOWER)
+#define L_BASE 0
+#define L_LOWER (1<<_LOWER)
+#define L_RAISE (1<<_RAISE)
+#define L_ADJUST (1<<_ADJUST)
+#define L_ADJUST_TRI (L_ADJUST|L_RAISE|L_LOWER)
 
 char layer_state_str[24];
 


### PR DESCRIPTION
## Description

Change the layer values to be sequential.   This will reduce the firmware size, at it was using 16 layers, but now uses 4. 

Unfortunately, the requires changing both the default keymaps, but other keymaps using the `layer_state_reader` code. 

So this necesitate the changes of other keymaps. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
