### PR TITLE
Added idle rgblight timeout feature

### DIFF
--- a/common_features.mk
+++ b/common_features.mk
@@ -271,6 +271,11 @@ ifeq ($(strip $(VELOCIKEY_ENABLE)), yes)
     SRC += $(QUANTUM_DIR)/velocikey.c
 endif
 
+ifeq ($(strip $(IDLE_RGBLIGHT_ENABLE)), yes)
+    OPT_DEFS += -DIDLE_RGBLIGHT_ENABLE
+    SRC += $(QUANTUM_DIR)/idle_rgblight.c
+endif
+
 ifeq ($(strip $(DYNAMIC_KEYMAP_ENABLE)), yes)
     OPT_DEFS += -DDYNAMIC_KEYMAP_ENABLE
     SRC += $(QUANTUM_DIR)/dynamic_keymap.c

--- a/docs/feature_idle_rgblight_timeout.md
+++ b/docs/feature_idle_rgblight_timeout.md
@@ -1,0 +1,18 @@
+# Idle RGB Lighting Timeout
+
+Idle RGB Lighting Timeout is a feature that allows you to turn your keyboard underglow off after a fifteen minutes. This is independent of the your PC's power settings.
+
+## Usage
+For the idle timeout to take effect, you need to set `IDLE_RGBLIGHT_ENABLE = yes` in your `rules.mk`, eg.:
+```
+IDLE_RGBLIGHT_ENABLE = yes
+```
+
+Now when using your keyboard, the underglow will turn off after 15 minutes. This works with all existing lighting effects.
+
+## Configuration
+You may change the timeout (in minutes) by setting `#define IDLE_RGBLIGHT_TIMEOUT 15` in your `config.h` fil, eg.:
+
+```
+#define IDLE_RGBLIGHT_TIMEOUT 15
+```

--- a/quantum/idle_rgblight.c
+++ b/quantum/idle_rgblight.c
@@ -1,0 +1,37 @@
+#include "quantum.h"
+#include "rgblight.h"
+#include "timer.h"
+#include "idle_rgblight.h"
+
+bool idle_rgblight_timeout = false;
+uint16_t idle_timer;
+uint8_t minute_counter = 0;
+extern rgblight_config_t rgblight_config;
+
+void idle_rgblight_init(void) {
+  idle_timer = timer_read();
+}
+
+void idle_rgblight_press(void) {
+  if (idle_rgblight_timeout) {
+    idle_rgblight_timeout = false;
+    rgblight_enable();
+  }
+  idle_timer = timer_read();
+  minute_counter = 0;
+}
+
+void idle_rgblight_matrix_scan(void) {
+  if (!idle_rgblight_timeout && rgblight_config.enable) {
+    if (timer_elapsed(idle_timer) >= 60000) {
+      minute_counter++;
+      idle_timer = timer_read();
+    }
+    if (minute_counter >= IDLE_RGBLIGHT_TIMEOUT) {
+      idle_rgblight_timeout = true;
+      rgblight_disable();
+      minute_counter = 0;
+      idle_timer = 0;
+    }
+  }
+}

--- a/quantum/idle_rgblight.h
+++ b/quantum/idle_rgblight.h
@@ -1,0 +1,16 @@
+#ifndef IDLE_RGBLIGHT_H
+#define IDLE_RGBLIGHT_H
+
+#ifndef IDLE_RGBLIGHT_TIMEOUT
+  #define IDLE_RGBLIGHT_TIMEOUT 15 // in minutes
+#endif
+
+#include <stdint.h>
+#include <stdbool.h>
+
+void idle_rgblight_init(void);
+void idle_rgblight_press(void);
+void idle_rgblight_matrix_scan(void);
+bool idle_rgblight_timeout;
+
+#endif

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -51,6 +51,10 @@ extern backlight_config_t backlight_config;
 #include "velocikey.h"
 #endif
 
+#ifdef IDLE_RGBLIGHT_ENABLE
+#include "idle_rgblight.h"
+#endif
+
 #ifdef HAPTIC_ENABLE
     #include "haptic.h"
 #endif
@@ -257,6 +261,10 @@ bool process_record_quantum(keyrecord_t *record) {
 
   #ifdef VELOCIKEY_ENABLE
     if (velocikey_enabled() && record->event.pressed) { velocikey_accelerate(); }
+  #endif
+
+  #ifdef IDLE_RGBLIGHT_ENABLE
+    if (record->event.pressed) { idle_rgblight_press(); }
   #endif
 
   #ifdef TAP_DANCE_ENABLE
@@ -1046,6 +1054,9 @@ void matrix_init_quantum() {
   #ifdef HAPTIC_ENABLE
     haptic_init();
   #endif
+  #ifdef IDLE_RGBLIGHT_ENABLE
+    idle_rgblight_init();
+  #endif
   matrix_init_kb();
 }
 
@@ -1090,6 +1101,10 @@ void matrix_scan_quantum() {
 
   #ifdef HAPTIC_ENABLE
     haptic_task();
+  #endif
+
+  #ifdef IDLE_RGBLIGHT_ENABLE
+    idle_rgblight_matrix_scan();
   #endif
 
   matrix_scan_kb();


### PR DESCRIPTION
## Description

This adds an idle timeout features (independent of your PC's sleep settings). In simple terms: if there are no keystrokes after X minutes, turn off the underglow.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).