### PR TITLE
Added encoder support to split common code

### DIFF
--- a/quantum/encoder.c
+++ b/quantum/encoder.c
@@ -17,6 +17,12 @@
 
 #include "encoder.h"
 
+#ifdef SPLIT_KEYBOARD
+  // for memcpy
+  #include <string.h>
+#endif
+
+
 #ifndef ENCODER_RESOLUTION
   #define ENCODER_RESOLUTION 4
 #endif
@@ -35,7 +41,13 @@ static pin_t encoders_pad_b[NUMBER_OF_ENCODERS] = ENCODERS_PAD_B;
 static int8_t encoder_LUT[] = { 0, -1, 1, 0, 1, 0, 0, -1, -1, 0, 0, 1, 0, 1, -1, 0 };
 
 static uint8_t encoder_state[NUMBER_OF_ENCODERS] = {0};
+
+#ifdef SPLIT_KEYBOARD
+// slave half encoders come over as second set of encoders
+static int8_t encoder_value[NUMBER_OF_ENCODERS * 2] = {0};
+#else
 static int8_t encoder_value[NUMBER_OF_ENCODERS] = {0};
+#endif
 
 __attribute__ ((weak))
 void encoder_update_user(int8_t index, bool clockwise) { }
@@ -60,11 +72,30 @@ void encoder_read(void) {
     encoder_state[i] |= (readPin(encoders_pad_a[i]) << 0) | (readPin(encoders_pad_b[i]) << 1);
     encoder_value[i] += encoder_LUT[encoder_state[i] & 0xF];
     if (encoder_value[i] >= ENCODER_RESOLUTION) {
-        encoder_update_kb(i, COUNTRECLOCKWISE);
+        encoder_update_kb(i, false);
     }
     if (encoder_value[i] <= -ENCODER_RESOLUTION) { // direction is arbitrary here, but this clockwise
-        encoder_update_kb(i, CLOCKWISE);
+        encoder_update_kb(i, true);
     }
     encoder_value[i] %= ENCODER_RESOLUTION;
   }
 }
+
+#ifdef SPLIT_KEYBOARD
+void encoder_state_raw(uint8_t* slave_state) {
+  memcpy(slave_state, encoder_state, sizeof(encoder_state));
+}
+
+void encoder_update_raw(uint8_t* slave_state) {
+  for (int i = 0; i < NUMBER_OF_ENCODERS; i++) {
+    encoder_value[NUMBER_OF_ENCODERS + i] += encoder_LUT[slave_state[i] & 0xF];
+    if (encoder_value[NUMBER_OF_ENCODERS + i] >= ENCODER_RESOLUTION) {
+        encoder_update_kb(NUMBER_OF_ENCODERS + i, false);
+    }
+    if (encoder_value[NUMBER_OF_ENCODERS + i] <= -ENCODER_RESOLUTION) { // direction is arbitrary here, but this clockwise
+        encoder_update_kb(NUMBER_OF_ENCODERS + i, true);
+    }
+    encoder_value[NUMBER_OF_ENCODERS + i] %= ENCODER_RESOLUTION;
+  }
+}
+#endif

--- a/quantum/encoder.c
+++ b/quantum/encoder.c
@@ -17,10 +17,8 @@
 
 #include "encoder.h"
 
-#ifdef SPLIT_KEYBOARD
-  // for memcpy
-  #include <string.h>
-#endif
+// for memcpy
+#include <string.h>
 
 
 #ifndef ENCODER_RESOLUTION

--- a/quantum/encoder.h
+++ b/quantum/encoder.h
@@ -19,11 +19,13 @@
 
 #include "quantum.h"
 
-#define COUNTRECLOCKWISE 0
-#define CLOCKWISE 1
-
 void encoder_init(void);
 void encoder_read(void);
 
 void encoder_update_kb(int8_t index, bool clockwise);
 void encoder_update_user(int8_t index, bool clockwise);
+
+#ifdef SPLIT_KEYBOARD
+void encoder_state_raw(uint8_t* slave_state);
+void encoder_update_raw(uint8_t* slave_state);
+#endif

--- a/quantum/split_common/matrix.c
+++ b/quantum/split_common/matrix.c
@@ -29,6 +29,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "debounce.h"
 #include "transport.h"
 
+#ifdef ENCODER_ENABLE
+  #include "encoder.h"
+#endif
+
 #if (MATRIX_COLS <= 8)
 #  define print_matrix_header() print("\nr/c 01234567\n")
 #  define print_matrix_row(row) print_bin_reverse8(matrix_get_row(row))
@@ -320,6 +324,9 @@ uint8_t matrix_scan(void) {
     matrix_scan_quantum();
   } else {
     transport_slave(matrix + thisHand);
+#ifdef ENCODER_ENABLE
+    encoder_read();
+#endif
     matrix_slave_scan_user();
   }
 

--- a/quantum/split_common/transport.c
+++ b/quantum/split_common/transport.c
@@ -39,6 +39,7 @@ typedef struct __attribute__ ((__packed__)) {
   uint8_t matrix_start[0];
 } transport_values_t;
 
+__attribute__ ((unused))
 static transport_values_t transport_values;
 
 #ifdef BACKLIGHT_ENABLE

--- a/quantum/split_common/transport.c
+++ b/quantum/split_common/transport.c
@@ -1,4 +1,5 @@
 #include <string.h>
+#include <stddef.h>
 
 #include "config.h"
 #include "matrix.h"
@@ -15,15 +16,44 @@
 extern backlight_config_t backlight_config;
 #endif
 
+#ifdef ENCODER_ENABLE
+#  include "encoder.h"
+#endif
+
 #if defined(USE_I2C) || defined(EH)
 
 #  include "i2c_master.h"
 #  include "i2c_slave.h"
 
-#  define I2C_BACKLIT_START 0x00
-// Need 4 bytes for RGB (32 bit)
-#  define I2C_RGB_START 0x01
-#  define I2C_KEYMAP_START 0x05
+typedef struct __attribute__ ((__packed__)) {
+#ifdef BACKLIGHT_ENABLE
+  uint8_t backlight_level;
+#endif
+#ifdef RGBLIGHT_ENABLE
+  uint32_t rgb_settings;
+#endif
+#ifdef ENCODER_ENABLE
+  uint8_t encoder_state[NUMBER_OF_ENCODERS];
+#endif
+  // Keep matrix last, we are only using this for it's offset
+  uint8_t matrix_start[0];
+} transport_values_t;
+
+static transport_values_t transport_values;
+
+#ifdef BACKLIGHT_ENABLE
+#  define I2C_BACKLIT_START (uint8_t)offsetof(transport_values_t, backlight_level)
+#endif
+
+#ifdef RGBLIGHT_ENABLE
+#  define I2C_RGB_START (uint8_t)offsetof(transport_values_t, rgb_settings)
+#endif
+
+#ifdef ENCODER_ENABLE
+#  define I2C_ENCODER_START (uint8_t)offsetof(transport_values_t, encoder_state)
+#endif
+
+#define I2C_KEYMAP_START (uint8_t)offsetof(transport_values_t, matrix_start)
 
 #  define TIMEOUT 100
 
@@ -37,23 +67,26 @@ bool transport_master(matrix_row_t matrix[]) {
 
   // write backlight info
 #  ifdef BACKLIGHT_ENABLE
-  static uint8_t prev_level = ~0;
-  uint8_t        level      = get_backlight_level();
-  if (level != prev_level) {
+  uint8_t level = get_backlight_level();
+  if (level != transport_values.backlight_level) {
     if (i2c_writeReg(SLAVE_I2C_ADDRESS, I2C_BACKLIT_START, (void *)&level, sizeof(level), TIMEOUT) >= 0) {
-      prev_level = level;
+      transport_values.backlight_level = level;
     }
   }
 #  endif
 
 #  ifdef RGBLIGHT_ENABLE
-  static uint32_t prev_rgb = ~0;
-  uint32_t        rgb      = rgblight_read_dword();
-  if (rgb != prev_rgb) {
+  uint32_t rgb = rgblight_read_dword();
+  if (rgb != transport_values.rgb_settings) {
     if (i2c_writeReg(SLAVE_I2C_ADDRESS, I2C_RGB_START, (void *)&rgb, sizeof(rgb), TIMEOUT) >= 0) {
-      prev_rgb = rgb;
+      transport_values.rgb_settings = rgb;
     }
   }
+#  endif
+
+#  ifdef ENCODER_ENABLE
+  i2c_readReg(SLAVE_I2C_ADDRESS, I2C_ENCODER_START, (void *)transport_values.encoder_state, sizeof(transport_values.encoder_state), TIMEOUT);
+  encoder_update_raw(&transport_values.encoder_state[0]);
 #  endif
 
   return true;
@@ -73,6 +106,10 @@ void transport_slave(matrix_row_t matrix[]) {
   // Update the RGB with the new data
   rgblight_update_dword(rgb);
 #  endif
+
+#  ifdef ENCODER_ENABLE
+  encoder_state_raw((uint8_t*)(i2c_slave_reg + I2C_ENCODER_START));
+#  endif
 }
 
 void transport_master_init(void) { i2c_init(); }
@@ -83,12 +120,15 @@ void transport_slave_init(void) { i2c_slave_init(SLAVE_I2C_ADDRESS); }
 
 #  include "serial.h"
 
-typedef struct _Serial_s2m_buffer_t {
+typedef struct __attribute__ ((__packed__)) {
+#  ifdef ENCODER_ENABLE
+  uint8_t encoder_state[NUMBER_OF_ENCODERS];
+#  endif
   // TODO: if MATRIX_COLS > 8 change to uint8_t packed_matrix[] for pack/unpack
   matrix_row_t smatrix[ROWS_PER_HAND];
 } Serial_s2m_buffer_t;
 
-typedef struct _Serial_m2s_buffer_t {
+typedef struct __attribute__ ((__packed__)) {
 #  ifdef BACKLIGHT_ENABLE
   uint8_t           backlight_level;
 #  endif
@@ -147,6 +187,10 @@ bool transport_master(matrix_row_t matrix[]) {
   }
 #  endif
 
+#  ifdef ENCODER_ENABLE
+  encoder_update_raw((uint8_t*)&serial_s2m_buffer.encoder_state);
+#  endif
+
   return true;
 }
 
@@ -161,6 +205,10 @@ void transport_slave(matrix_row_t matrix[]) {
 #  if defined(RGBLIGHT_ENABLE) && defined(RGBLED_SPLIT)
   // Update RGB config with the new data
   rgblight_update_dword(serial_m2s_buffer.rgblight_config.raw);
+#  endif
+
+#  ifdef ENCODER_ENABLE
+  encoder_state_raw((uint8_t*)&serial_s2m_buffer.encoder_state);
 #  endif
 }
 


### PR DESCRIPTION
Added encoder support to split common code. 

## Description

Added functionality to split common code to send encoder data from slave to master. Updated I2C communication in transport.c to be more robust for address shifting based on features turned on and off.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
