### PR TITLE
Add kwer keymap and RGB mod description to cypher

### DIFF
--- a/keyboards/westfoxtrot/cypher/keymaps/kwer/config.h
+++ b/keyboards/westfoxtrot/cypher/keymaps/kwer/config.h
@@ -1,0 +1,33 @@
+/* Copyright 2018 westfoxtrot
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define RGB_DI_PIN F7
+#ifdef  RGB_DI_PIN
+  #define RGBLED_NUM 15
+  #define RGBLIGHT_HUE_STEP 8
+  #define RGBLIGHT_SAT_STEP 8
+  #define RGBLIGHT_VAL_STEP 15
+  #define RGBLIGHT_LIMIT_VAL 255 /* The maximum brightness level */
+  #define RGBLIGHT_EFFECT_RAINBOW_MOOD
+  #define RGBLIGHT_EFFECT_RAINBOW_SWIRL
+  #define RGBLIGHT_EFFECT_KNIGHT
+  #define RGBLIGHT_EFFECT_KNIGHT_LENGTH 5
+  #define RGBLIGHT_EFFECT_STATIC_GRADIENT
+ #endif
+
+// place overrides here

--- a/keyboards/westfoxtrot/cypher/keymaps/kwer/keymap.c
+++ b/keyboards/westfoxtrot/cypher/keymaps/kwer/keymap.c
@@ -1,0 +1,66 @@
+/* Copyright 2018 westfoxtrot
+ * Copyright 2019 kwerdenker
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include QMK_KEYBOARD_H
+#include "keymap_extras/keymap_german.h"
+
+#define _DL 0
+#define _FN 1
+#define _LE 2
+
+#define SPECIAL LT(_FN, DE_CIRC)    //capslock layer switch + stargate key on tap
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+  [_DL] = LAYOUT_iso (
+      KC_ESC,  KC_1,    KC_2,  KC_3,  KC_4,  KC_5,  KC_6,  KC_7,  KC_8,  KC_9,    KC_0,   DE_SS,   DE_ACUT, KC_BSPC, _______,     KC_NLCK, KC_PSCR,KC_PSLS,KC_PAST,
+      KC_TAB,  KC_Q,    KC_W,  KC_E,  KC_R,  KC_T,  DE_Z,  KC_U,  KC_I,  KC_O,    KC_P,   DE_UE,   DE_PLUS,                       KC_P7,   KC_P8,  KC_P9,  KC_PMNS,
+      SPECIAL, KC_A,    KC_S,  KC_D,  KC_F,  KC_G,  KC_H,  KC_J,  KC_K,  KC_L,    DE_OE,  DE_AE,   DE_HASH, KC_ENT,               KC_P4,   KC_P5,  KC_P6,  KC_PPLS,
+      KC_LSFT, DE_LESS, DE_Y,  KC_X,  KC_C,  KC_V,  KC_B,  KC_N,  KC_M,  KC_COMM, KC_DOT, DE_MINS, KC_RSFT,        KC_UP,         KC_P1,   KC_P2,  KC_P3,  KC_PENT,
+      KC_LCTL, _______, KC_LALT,             KC_SPC,                     _______, KC_RALT, TG(_LE),       KC_LEFT, KC_DOWN, KC_RGHT,        KC_P0,  KC_PDOT, KC_NO
+  ),
+
+  [_FN] = LAYOUT_iso (
+      DE_RING, KC_F1,   KC_F2,   KC_F3,   KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,  KC_F11,  KC_F12,  KC_DEL, _______,      _______, _______, _______, _______,
+      _______, _______, KC_UP,   _______, _______,  _______,  _______,  _______,  _______,  _______,  _______, _______, _______,                        _______, _______, _______, _______,
+      _______, KC_LEFT, KC_DOWN, KC_RGHT, _______,  _______,  _______,  _______,  _______,  _______,  _______, _______, _______, _______,               _______, _______, _______, _______,
+      _______, _______, _______, _______, _______,  _______,  _______,  _______,  _______,  _______,  _______, _______, _______, _______,               _______, _______, _______, _______,
+      _______, _______, _______,             KC_LGUI,                _______, _______, _______,                         _______, _______, _______,               _______, _______, _______
+  ),
+
+  [_LE] = LAYOUT_iso (
+      _______, _______, _______, _______, _______,  _______,  _______,  _______,  _______,  _______,  _______, _______, _______, _______, _______,      _______, _______, _______, RESET,
+      _______, _______, _______, _______, _______,  _______,  _______,  _______,  _______,  _______,  _______, _______, _______,                        RGB_TOG, RGB_MOD, RGB_RMOD,_______,
+      _______, _______, _______, _______, _______,  _______,  _______,  _______,  _______,  _______,  _______, _______, _______, _______,               RGB_HUI, RGB_SAI, RGB_VAI, _______,
+      _______, _______, _______, _______, _______,  _______,  _______,  _______,  _______,  _______,  _______, _______, _______, _______,               RGB_HUD, RGB_SAD, RGB_VAD, _______,
+      _______, _______, _______,             _______,                _______, _______, _______,                         _______, _______, _______,               _______, _______, _______
+  ),
+};
+
+
+
+void matrix_init_user(void) {
+  //user initialization
+}
+
+void matrix_scan_user(void) {
+  //user matrix
+}
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  return true;
+}

--- a/keyboards/westfoxtrot/cypher/keymaps/kwer/keymap.c
+++ b/keyboards/westfoxtrot/cypher/keymaps/kwer/keymap.c
@@ -16,7 +16,7 @@
  */
 
 #include QMK_KEYBOARD_H
-#include "keymap_extras/keymap_german.h"
+#include "keymap_german.h"
 
 #define _DL 0
 #define _FN 1

--- a/keyboards/westfoxtrot/cypher/keymaps/kwer/keymap.c
+++ b/keyboards/westfoxtrot/cypher/keymaps/kwer/keymap.c
@@ -64,3 +64,16 @@ void matrix_scan_user(void) {
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
   return true;
 }
+
+void led_set_user(uint8_t usb_led) {
+  // Insert custom handling for CAPS_LOCK, NUM_LOCK, SCROLL_LOCK here
+      if (IS_LED_ON(usb_led, USB_LED_NUM_LOCK)) {
+        writePinHigh(F4);
+        writePinHigh(F1);
+        writePinHigh(F5);
+    } else {
+        writePinLow(F4);
+        writePinLow(F1);
+        writePinLow(F5);
+    }
+}

--- a/keyboards/westfoxtrot/cypher/keymaps/kwer/readme.md
+++ b/keyboards/westfoxtrot/cypher/keymaps/kwer/readme.md
@@ -1,0 +1,39 @@
+# The kwer keymap and RGB MOD for cypher
+
+![](https://i.imgur.com/b7snIju.jpg)
+
+## Hardware
+To make this mod, all you need a piece of WS2812b RGB strip (I used one with 144 LEDs per meter, so it's rather dense), some wiring (I used 0.6mm solid core wire) and steady hands for soldering to the MCU pin.
+
+**Installed mod**
+![](https://i.imgur.com/IKcFd0k.jpg)
+
+As you can see, the wiring is relatively simple. VCC and GND can be easily accessed through the ISP header on the right side of the spacebar while the DATA line can be routed relatively easy through one of the stabilizer holes. While it isn't important where exactly you solder the VCC/GND wires to their respective lines on the strip, you have to keep the direction of the data line in mind. Most strip have arrows printed on them to show you in which direction the data is shifted through the LEDs and your should always solder your DATA line on the _from_ side, as seen in the above picture.
+
+**Close-up for the VCC/GND connections**
+![](https://i.imgur.com/K0OibwW.jpg)
+
+Since there is no pinout availble for the pin we're gonna use to control the strip, the line has to be soldered to the MCU directly. While this is not a very complex process, you should have a fine tipped soldering irong and a steady hand. Make sure you do not bridge any of the neighboring pins when soldering the wire to the MCU pin. As shown in the picture below, you want to connect the DATA line to the third pin from the right on the top of the controller chip.
+
+**Close-up for the DATA connection**
+![](https://i.imgur.com/zkD3RjF.jpg)
+
+## Software
+To enable your RGB strip in QMK, you have to add change/add the following lines
+
+**rules.&#8203;mk**
+```
+[...]
+RGBLIGHT_ENABLE = yes        # Enable keyboard RGB underglow
+[...]
+```
+
+**config.h**
+```
+[...]
+#define RGB_DI_PIN F7
+#define RGBLED_NUM 15        // Change this number to the amount of LEDs on the strip you soldered
+#define RGBLIGHT_ANIMATIONS
+[...]
+```
+To control the RGB color, animation, etc. you need to add the appropriate keycodes to your keymap. Either see [my keymap](./keymap.c) or the [official QMK documentation](https://docs.qmk.fm/#/feature_rgblight?id=keycodes) for references.

--- a/keyboards/westfoxtrot/cypher/keymaps/kwer/rules.mk
+++ b/keyboards/westfoxtrot/cypher/keymaps/kwer/rules.mk
@@ -1,0 +1,2 @@
+# Build options override
+RGBLIGHT_ENABLE = yes        # Enable keyboard RGB underglow


### PR DESCRIPTION
Add new keymap and documentation on how to add/configure an RGB strip to the cypher keyboard PCB

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
