### PR TITLE
Document an annoyance with Grave Escape and macOS Terminal

### DIFF
--- a/docs/feature_grave_esc.md
+++ b/docs/feature_grave_esc.md
@@ -18,7 +18,7 @@ If Mary presses GESC on her keyboard, the OS will see an KC_ESC character. Now i
 
 ### Caveats
 
- * On macOS CMD/GUI + KC_GRV is actually mapped to a hot key so it will not output a backtick.
+On macOS, Command+<code>&#96;</code> is by default mapped to "Move focus to next window" so it will not output a backtick. Additionally, Terminal always recognises this shortcut to cycle between windows, even if the shortcut is changed in the Keyboard preferences.
 
 ## Configuration
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

It appears Terminal doesn't respect the assigned Command+<code>&#96;</code> shortcut in Keyboard preferences:
![keyboard-prefs](https://user-images.githubusercontent.com/4781841/54887653-bd319300-4ee9-11e9-97f4-8dcf6cd5ac3e.png)
![terminal-menu](https://user-images.githubusercontent.com/4781841/54887647-a723d280-4ee9-11e9-9792-f1ff261dc4ca.png)
There is apparently no way to change this within the Terminal preferences, so this should be noted in the Grave Escape Caveats section.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
