### PR TITLE
build size-check enhancement

### DIFF
--- a/message.mk
+++ b/message.mk
@@ -80,3 +80,4 @@ MSG_CHECK_FILESIZE = Checking file size of $(TARGET).hex
 MSG_FILE_TOO_BIG = $(ERROR_COLOR)The firmware is too large!$(NO_COLOR) $(CURRENT_SIZE)/$(MAX_SIZE) ($(OVER_SIZE) bytes over)\n
 MSG_FILE_TOO_SMALL = The firmware is too small! $(CURRENT_SIZE)/$(MAX_SIZE)\n
 MSG_FILE_JUST_RIGHT = The firmware size is fine - $(CURRENT_SIZE)/$(MAX_SIZE) ($(FREE_SIZE) bytes free)\n
+MSG_FILE_NEAR_LIMIT = The firmware size is the limit soon - $(CURRENT_SIZE)/$(MAX_SIZE) ($(FREE_SIZE) bytes free)\n

--- a/message.mk
+++ b/message.mk
@@ -80,4 +80,4 @@ MSG_CHECK_FILESIZE = Checking file size of $(TARGET).hex
 MSG_FILE_TOO_BIG = $(ERROR_COLOR)The firmware is too large!$(NO_COLOR) $(CURRENT_SIZE)/$(MAX_SIZE) ($(OVER_SIZE) bytes over)\n
 MSG_FILE_TOO_SMALL = The firmware is too small! $(CURRENT_SIZE)/$(MAX_SIZE)\n
 MSG_FILE_JUST_RIGHT = The firmware size is fine - $(CURRENT_SIZE)/$(MAX_SIZE) ($(FREE_SIZE) bytes free)\n
-MSG_FILE_NEAR_LIMIT = The firmware size is nearly too large - $(CURRENT_SIZE)/$(MAX_SIZE) ($(FREE_SIZE) bytes free)\n
+MSG_FILE_NEAR_LIMIT = The firmware size is approaching the maximum - $(CURRENT_SIZE)/$(MAX_SIZE) ($(FREE_SIZE) bytes free)\n

--- a/message.mk
+++ b/message.mk
@@ -80,4 +80,4 @@ MSG_CHECK_FILESIZE = Checking file size of $(TARGET).hex
 MSG_FILE_TOO_BIG = $(ERROR_COLOR)The firmware is too large!$(NO_COLOR) $(CURRENT_SIZE)/$(MAX_SIZE) ($(OVER_SIZE) bytes over)\n
 MSG_FILE_TOO_SMALL = The firmware is too small! $(CURRENT_SIZE)/$(MAX_SIZE)\n
 MSG_FILE_JUST_RIGHT = The firmware size is fine - $(CURRENT_SIZE)/$(MAX_SIZE) ($(FREE_SIZE) bytes free)\n
-MSG_FILE_NEAR_LIMIT = The firmware size is the limit soon - $(CURRENT_SIZE)/$(MAX_SIZE) ($(FREE_SIZE) bytes free)\n
+MSG_FILE_NEAR_LIMIT = The firmware size is nearly too large - $(CURRENT_SIZE)/$(MAX_SIZE) ($(FREE_SIZE) bytes free)\n

--- a/tmk_core/rules.mk
+++ b/tmk_core/rules.mk
@@ -390,7 +390,15 @@ check-size:
 	$(eval OVER_SIZE=$(shell expr $(CURRENT_SIZE) - $(MAX_SIZE)))
 	if [ $(MAX_SIZE) -gt 0 ] && [ $(CURRENT_SIZE) -gt 0 ]; then \
 		$(SILENT) || printf "$(MSG_CHECK_FILESIZE)" | $(AWK_CMD); \
-		if [ $(CURRENT_SIZE) -gt $(MAX_SIZE) ]; then printf "\n * $(MSG_FILE_TOO_BIG)"; $(PRINT_ERROR_PLAIN); else $(PRINT_OK); $(SILENT) || printf " * $(MSG_FILE_JUST_RIGHT)";  fi \
+		if [ $(CURRENT_SIZE) -gt $(MAX_SIZE) ]; then \
+		    printf "\n * $(MSG_FILE_TOO_BIG)"; $(PRINT_ERROR_PLAIN); \
+		else \
+		    if [ $(FREE_SIZE) -lt 512 ]; then \
+			$(PRINT_WARNING_PLAIN); printf " * $(MSG_FILE_NEAR_LIMIT)"; \
+		    else \
+			$(PRINT_OK); $(SILENT) || printf " * $(MSG_FILE_JUST_RIGHT)"; \
+		    fi \
+		fi \
 	fi
 else
 check-size:

--- a/tmk_core/rules.mk
+++ b/tmk_core/rules.mk
@@ -383,6 +383,8 @@ show_path:
 	@echo OBJ=$(OBJ)
 
 ifeq ($(findstring avr-gcc,$(CC)),avr-gcc)
+SIZE_MARGIN = 1024
+
 check-size:
 	$(eval MAX_SIZE=$(shell n=`$(CC) -E -mmcu=$(MCU) $(CFLAGS) $(OPT_DEFS) tmk_core/common/avr/bootloader_size.c 2> /dev/null | sed -ne '/^#/n;/^AVR_SIZE:/,$${s/^AVR_SIZE: //;p;}'` && echo $$(($$n)) || echo 0))
 	$(eval CURRENT_SIZE=$(shell if [ -f $(BUILD_DIR)/$(TARGET).hex ]; then $(SIZE) --target=$(FORMAT) $(BUILD_DIR)/$(TARGET).hex | $(AWK) 'NR==2 {print $$4}'; else printf 0; fi))
@@ -393,7 +395,7 @@ check-size:
 		if [ $(CURRENT_SIZE) -gt $(MAX_SIZE) ]; then \
 		    printf "\n * $(MSG_FILE_TOO_BIG)"; $(PRINT_ERROR_PLAIN); \
 		else \
-		    if [ $(FREE_SIZE) -lt 512 ]; then \
+		    if [ $(FREE_SIZE) -lt $(SIZE_MARGIN) ]; then \
 			$(PRINT_WARNING_PLAIN); printf " * $(MSG_FILE_NEAR_LIMIT)"; \
 		    else \
 			$(PRINT_OK); $(SILENT) || printf " * $(MSG_FILE_JUST_RIGHT)"; \


### PR DESCRIPTION
## Description

Changed to display a warning when the free size of compilation result is less than 512 bytes. :-)

Example:
```
$ make crkbd:default
.....
Copying crkbd_rev1_default.hex to qmk_firmware folder                        [OK]
Checking file size of crkbd_rev1_default.hex                                 [WARNINGS]

 * The firmware size is the limit soon - 28388/28672 (284 bytes free)
```

```
$ make crkbd:all
QMK Firmware 0.6.321
Making crkbd/rev1 with keymap default                                        [WARNINGS]

 * The firmware size is the limit soon - 28388/28672 (284 bytes free)
Making crkbd/rev1 with keymap drashna                                        [OK]
Making crkbd/rev1 with keymap edvorakjp                                      [OK]
Making crkbd/rev1 with keymap jarred                                         [OK]
Making crkbd/rev1 with keymap like_jis                                       [OK]
Making crkbd/rev1 with keymap omgvee                                         [OK]
Making crkbd/rev1 with keymap thefrey                                        [WARNINGS]

 * The firmware size is the limit soon - 28400/28672 (272 bytes free)
```

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
