### PR TITLE
add 'objs-size' target into tmk_core/rules.mk

### DIFF
--- a/build_keyboard.mk
+++ b/build_keyboard.mk
@@ -374,6 +374,7 @@ $(KEYBOARD_OUTPUT)_CONFIG := $(PROJECT_CONFIG)
 all: build check-size
 build: elf cpfirmware
 check-size: build
+objs-size: build
 
 include show_options.mk
 include $(TMK_PATH)/rules.mk

--- a/tmk_core/rules.mk
+++ b/tmk_core/rules.mk
@@ -382,6 +382,9 @@ show_path:
 	@echo SRC=$(SRC)
 	@echo OBJ=$(OBJ)
 
+objs-size:
+	for i in $(OBJ); do echo $$i; done | sort | xargs $(SIZE)
+
 ifeq ($(findstring avr-gcc,$(CC)),avr-gcc)
 check-size:
 	$(eval MAX_SIZE=$(shell n=`$(CC) -E -mmcu=$(MCU) $(CFLAGS) $(OPT_DEFS) tmk_core/common/avr/bootloader_size.c 2> /dev/null | sed -ne '/^#/n;/^AVR_SIZE:/,$${s/^AVR_SIZE: //;p;}'` && echo $$(($$n)) || echo 0))


### PR DESCRIPTION

## Description

Display the size of the created object files.

It is convenient to use as follows.

```
$ make crkbd:all
QMK Firmware 0.6.321
Making crkbd/rev1 with keymap default             [OK]
Making crkbd/rev1 with keymap drashna             [OK]
Making crkbd/rev1 with keymap edvorakjp           [OK]
Making crkbd/rev1 with keymap jarred              [OK]
Making crkbd/rev1 with keymap like_jis            [OK]
Making crkbd/rev1 with keymap omgvee              [OK]
Making crkbd/rev1 with keymap thefrey             [OK]

$ make crkbd:all:objs-size | grep keymap.o
   2558	      0	      0	   2558	    9fe	.build/obj_crkbd_rev1_default/keyboards/crkbd/keymaps/default/keymap.o
      0	      0	      0	      0	      0	.build/obj_crkbd_rev1_drashna/keyboards/crkbd/keymaps/drashna/keymap.o
    438	      0	      0	    438	    1b6	.build/obj_crkbd_rev1_edvorakjp/keyboards/crkbd/keymaps/edvorakjp/keymap.o
   1260	      0	      0	   1260	    4ec	.build/obj_crkbd_rev1_jarred/keyboards/crkbd/keymaps/jarred/keymap.o
      0	      0	      0	      0	      0	.build/obj_crkbd_rev1_like_jis/keyboards/crkbd/keymaps/like_jis/keymap.o
      0	      0	      0	      0	      0	.build/obj_crkbd_rev1_omgvee/keyboards/crkbd/keymaps/omgvee/keymap.o
   2532	      0	      0	   2532	    9e4	.build/obj_crkbd_rev1_thefrey/keyboards/crkbd/keymaps/thefrey/keymap.o

$ make crkbd:all:objs-size | grep rgblight.o
   4010	     14	     32	   4056	    fd8	.build/obj_crkbd_rev1_default/quantum/rgblight.o
      0	      0	      0	      0	      0	.build/obj_crkbd_rev1_drashna/quantum/rgblight.o
   2284	      1	      3	   2288	    8f0	.build/obj_crkbd_rev1_edvorakjp/quantum/rgblight.o
   4010	     14	     32	   4056	    fd8	.build/obj_crkbd_rev1_jarred/quantum/rgblight.o
      0	      0	      0	      0	      0	.build/obj_crkbd_rev1_like_jis/quantum/rgblight.o
      0	      0	      0	      0	      0	.build/obj_crkbd_rev1_omgvee/quantum/rgblight.o
   4010	     14	     32	   4056	    fd8	.build/obj_crkbd_rev1_thefrey/quantum/rgblight.o
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).