### PR TITLE
Make delay for Capslock in Hold-Tap functions configurable 

### DIFF
--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -167,6 +167,8 @@ If you define these options you will enable the associated feature, which may in
   * how long for the Combo keys to be detected. Defaults to `TAPPING_TERM` if not defined.
 * `#define TAP_CODE_DELAY 100`
   * Sets the delay between `register_code` and `unregister_code`, if you're having issues with it registering properly (common on VUSB boards). The value is in milliseconds.
+* `#define TAP_HOLD_CAPS_DELAY 200`
+  * Sets the delay for Tap Hold keys (`LT`, `MT`) when using `KC_CAPSLOCK` keycode, as this has some special handling on MacOS.  The value is in milliseconds, and defaults to 200ms if not defined. 
 
 ## RGB Light Configuration
 

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -518,7 +518,7 @@ void process_action(keyrecord_t *record, action_t action)
                         if (tap_count > 0) {
                             dprint("KEYMAP_TAP_KEY: Tap: unregister_code\n");
                             if (action.layer_tap.code == KC_CAPS) {
-                                wait_ms(80);
+                                wait_ms(200);
                             }
                             unregister_code(action.layer_tap.code);
                         } else {

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -44,6 +44,9 @@ int retro_tapping_counter = 0;
 #include <fauxclicky.h>
 #endif
 
+#ifndef TAP_HOLD_CAPS_DELAY
+#  define TAP_HOLD_CAPS_DELAY 200
+#endif
 /** \brief Called to execute an action.
  *
  * FIXME: Needs documentation.
@@ -518,7 +521,7 @@ void process_action(keyrecord_t *record, action_t action)
                         if (tap_count > 0) {
                             dprint("KEYMAP_TAP_KEY: Tap: unregister_code\n");
                             if (action.layer_tap.code == KC_CAPS) {
-                                wait_ms(200);
+                                wait_ms(TAP_HOLD_CAPS_DELAY);
                             }
                             unregister_code(action.layer_tap.code);
                         } else {
@@ -853,8 +856,13 @@ void unregister_code(uint8_t code)
  */
 void tap_code(uint8_t code) {
   register_code(code);
+  if (code == KC_CAPS) {
+    wait_ms(TAP_HOLD_CAPS_DELAY);
+  }
   #if TAP_CODE_DELAY > 0
+  else {
     wait_ms(TAP_CODE_DELAY);
+  }
   #endif
   unregister_code(code);
 }


### PR DESCRIPTION
## Description

Increases the delay to 200ms, since it seems to have issues registering on MacOS.
Also, made the delay configurable, for those that want to change this. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* On Discord

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
