### PR TITLE
revert back to the old custom i2c code for bmc

### DIFF
--- a/keyboards/exclusive/e6v2/bmc/bmc.c
+++ b/keyboards/exclusive/e6v2/bmc/bmc.c
@@ -15,7 +15,7 @@
  */
 #include "bmc.h"
 #include "rgblight.h"
-#include "i2c_master.h"
+#include "i2c.h"
 
 void matrix_init_kb(void) {
 	// put your keyboard start-up code here
@@ -57,7 +57,7 @@ void rgblight_set(void) {
     }
 
     i2c_init();
-    i2c_transmit(0xb0, (uint8_t*)led, 3 * RGBLED_NUM, 100);
+    i2c_send(0xb0, (uint8_t*)led, 3 * RGBLED_NUM);
 }
 #endif
 

--- a/keyboards/exclusive/e6v2/bmc/i2c.c
+++ b/keyboards/exclusive/e6v2/bmc/i2c.c
@@ -1,0 +1,106 @@
+/*
+Copyright 2016 Luiz Ribeiro <luizribeiro@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// Please do not modify this file 
+
+#include <avr/io.h>
+#include <util/twi.h>
+
+#include "i2c.h"
+
+void i2c_set_bitrate(uint16_t bitrate_khz) {
+    uint8_t bitrate_div = ((F_CPU / 1000l) / bitrate_khz);
+    if (bitrate_div >= 16) {
+        bitrate_div = (bitrate_div - 16) / 2;
+    }
+    TWBR = bitrate_div;
+}
+
+void i2c_init(void) {
+    // set pull-up resistors on I2C bus pins
+    PORTC |= 0b11;
+
+    i2c_set_bitrate(400);
+
+    // enable TWI (two-wire interface)
+    TWCR |= (1 << TWEN);
+
+    // enable TWI interrupt and slave address ACK
+    TWCR |= (1 << TWIE);
+    TWCR |= (1 << TWEA);
+}
+
+uint8_t i2c_start(uint8_t address) {
+    // reset TWI control register
+    TWCR = 0;
+
+    // begin transmission and wait for it to end
+    TWCR = (1<<TWINT) | (1<<TWSTA) | (1<<TWEN);
+    while (!(TWCR & (1<<TWINT)));
+
+    // check if the start condition was successfully transmitted
+    if ((TWSR & 0xF8) != TW_START) {
+        return 1;
+    }
+
+    // transmit address and wait
+    TWDR = address;
+    TWCR = (1<<TWINT) | (1<<TWEN);
+    while (!(TWCR & (1<<TWINT)));
+
+    // check if the device has acknowledged the READ / WRITE mode
+    uint8_t twst = TW_STATUS & 0xF8;
+    if ((twst != TW_MT_SLA_ACK) && (twst != TW_MR_SLA_ACK)) {
+        return 1;
+    }
+
+    return 0;
+}
+
+void i2c_stop(void) {
+    TWCR = (1<<TWINT) | (1<<TWEN) | (1<<TWSTO);
+}
+
+uint8_t i2c_write(uint8_t data) {
+    TWDR = data;
+
+    // transmit data and wait
+    TWCR = (1<<TWINT) | (1<<TWEN);
+    while (!(TWCR & (1<<TWINT)));
+
+    if ((TWSR & 0xF8) != TW_MT_DATA_ACK) {
+        return 1;
+    }
+
+    return 0;
+}
+
+uint8_t i2c_send(uint8_t address, uint8_t *data, uint16_t length) {
+    if (i2c_start(address)) {
+        return 1;
+    }
+
+    for (uint16_t i = 0; i < length; i++) {
+        if (i2c_write(data[i])) {
+            return 1;
+        }
+    }
+
+    i2c_stop();
+
+    return 0;
+}

--- a/keyboards/exclusive/e6v2/bmc/i2c.h
+++ b/keyboards/exclusive/e6v2/bmc/i2c.h
@@ -1,0 +1,24 @@
+/*
+Copyright 2016 Luiz Ribeiro <luizribeiro@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// Please do not modify this file 
+
+#pragma once
+
+void i2c_init(void);
+void i2c_set_bitrate(uint16_t bitrate_khz);
+uint8_t i2c_send(uint8_t address, uint8_t *data, uint16_t length);

--- a/keyboards/exclusive/e6v2/bmc/rules.mk
+++ b/keyboards/exclusive/e6v2/bmc/rules.mk
@@ -85,6 +85,6 @@ AUDIO_ENABLE = no           # Audio output on port C6
 FAUXCLICKY_ENABLE = no      # Use buzzer to emulate clicky switches
 HD44780_ENABLE = no 		# Enable support for HD44780 based LCDs (+400)
 
-SRC += i2c_master.c
+SRC += i2c.c
 
 PROGRAM_CMD = ./util/atmega32a_program.py $(TARGET).hex


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
@drashna deceived me and I willingly obeyed his lies regarding the usage of i2c_master over the custom i2c code needed for ps2avrgb. I suspect it was all part of his ploy to discredit and undermine my BMC ambitions. 

In all seriousness, I'll have to take another look at i2c_master and see what exactly is causing it to mess up BMC boards making it not type ANYTHING. For the time being, reverting the change he requested. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
