### PR TITLE
Minor fix to the Doro67 regular layout.

### DIFF
--- a/keyboards/doro67/regular/regular.h
+++ b/keyboards/doro67/regular/regular.h
@@ -36,6 +36,5 @@
   {   K10,   K11,   K12,   K13,   K14,   K15,   K16,   K17,   K18,   K19,   K1A,   K1B,   K1C,   K1D,   K1E   }, \
   {   K20,   K21,   K22,   K23,   K24,   K25,   K26,   K27,   K28,   K29,   K2A,   K2B,   KC_NO, K2D,   K2E   }, \
   {   K30,   KC_NO, K32,   K33,   K34,   K35,   K36,   K37,   K38,   K39,   K3A,   K3B,   K3C,   K3D,   K3E   }, \
-  {   K40,   K41,   K42,   K43,   KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, K49,   K4A,   KC_NO, K4C,   K4D,   K4E   }, \
+  {   K40,   K41,   K42,   KC_NO, K43,   KC_NO, KC_NO, KC_NO, KC_NO, K49,   K4A,   KC_NO, K4C,   K4D,   K4E   }, \
 }
-

--- a/keyboards/doro67/regular/regular.h
+++ b/keyboards/doro67/regular/regular.h
@@ -38,3 +38,4 @@
   {   K30,   KC_NO, K32,   K33,   K34,   K35,   K36,   K37,   K38,   K39,   K3A,   K3B,   K3C,   K3D,   K3E   }, \
   {   K40,   K41,   K42,   KC_NO, K43,   KC_NO, KC_NO, KC_NO, KC_NO, K49,   K4A,   KC_NO, K4C,   K4D,   K4E   }, \
 }
+


### PR DESCRIPTION
## Description

The position for space was off by one in the layout. It also seems to use dfu for flashing, so perhaps we should add that to the instructions for building/flashing?

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation