### PR TITLE
Add alternate bépo layout for Ergodox EZ

### DIFF
--- a/layouts/community/ergodox/bepo_alt/keymap.c
+++ b/layouts/community/ergodox/bepo_alt/keymap.c
@@ -1,0 +1,127 @@
+/* Bepo layout for ergodox EZ by Nicolas CARPi (deltablot.com) */
+#include QMK_KEYBOARD_H
+#include "keymap_bepo.h"
+#include "keymap_french.h"
+
+#define BEPO 0  // default layer, for bepo compatible systems
+#define FNAV 1  // function / navigation / mouse layer
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+/* Keymap 0: default layer
+ *
+ * ,--------------------------------------------------.                                  ,--------------------------------------------------.
+ * |   $    |   "  |   <  |   >  |   (  |   )  |  @   |                                  |  +   |   -  |   -  |   /  |   *  |   =  |   %    |
+ * |--------+------+------+------+------+-------------|                                  |------+------+------+------+------+------+--------|
+ * |   TAB  |   B  |E_ACUT|   P  |   O  |E_GRAV|Backsp|                                  |CapsLo|   ^  |   V  |   D  |   L  |   J  |   Z    |
+ * |--------+------+------+------+------+------|  ace |                                  |      |------+------+------+------+------+--------|
+ * |   W    |   A  |   U  |   I  |   E  |   ,  |------|                                  |------|   C  |   T  |   S  |   R  |   N  |   M    |
+ * |--------+------+------+------+------+------|      |                                  | ESCAP------+------+------+------+------+--------|
+ * | SHIFT |E_CIRC |  A_GRAV   | Y | X |    .  |  K   |                                  |      |   '  |   Q  |   G  |   H  |   F  | C_CEDIL|
+ * `--------+------+------+------+------+-------------,-------------.      ,-------------`-------------+------+------+------+------+--------'
+ *   |Ctrl|LSuper|LSuper| LSuper|  LAlt|             | PgUp  | PgDwn|      |BEPO| Delete |             | AltGr| RSuper|RSuper|RCtrl| Enter|
+ *   `----------------------------------'      ,------|------|------|      |------+------+------.      `----------------------------------'
+ *                                             |      |      |Insert|      |L_Fnav|      |      |
+ *                                             | Space|Shift |------|      |------|RShift|Enter |
+ *                                             |      |      |Mouse |      |  Fn  |       |      |
+ *                                             `--------------------'      `--------------------'
+ * df is for temporary stuff and mo is for toggle (momentary)
+ * so mouse is to toggle the mouse mode
+ */
+[BEPO] = LAYOUT_ergodox(
+
+/* Left hand */
+BP_DOLLAR,  BP_DQOT,  BP_LGIL,  BP_RGIL,  BP_LPRN,  BP_RPRN,  BP_AT,
+KC_TAB, BP_B,   BP_E_ACUTE, BP_P,   BP_O,   BP_E_GRAVE, KC_BSPC,
+BP_W,   BP_A,   BP_U,   BP_I,   BP_E,   BP_COMMA,
+KC_LSHIFT,  BP_ECRC,  BP_A_GRAVE,   BP_Y,   BP_X,   BP_DOT,   BP_K,
+KC_LCTL,    KC_LGUI,    KC_LGUI,  KC_LGUI,  KC_LALT,
+                            KC_PGUP,  KC_PGDOWN,
+                                KC_INS,
+                        KC_SPC,   KC_LSHIFT,  DF(FNAV),
+
+/* Right hand */
+                BP_PLUS, BP_MINUS,    BP_MINUS, BP_SLASH, BP_ASTR,  BP_EQUAL, BP_PERCENT,
+        KC_CAPSLOCK,  BP_DCRC,  BP_V,   BP_D,   BP_L,   BP_J,   BP_Z,
+            BP_C,   BP_T,   BP_S,   BP_R,   BP_N,   BP_M,
+        KC_ESC, BP_APOS,  BP_Q,   BP_G,   BP_H,   BP_F,   BP_CCED,
+                KC_ALGR,  KC_RGUI,  KC_RGUI,  KC_RCTL,  KC_ENTER,
+DF(BEPO), KC_DEL,
+DF(FNAV),
+MO(FNAV), KC_RSHIFT,  KC_ENTER),
+
+/* Keymap 1: function / navigation / mouse layer
+ *
+ * ,--------------------------------------------------.                                  ,--------------------------------------------------.
+ * |        |  F1  |  F2  |  F3  |  F4  |  F5  |  F6  |                                  | F7   |  F8  |  F9  |  F10  |  F11  |  F12 |  F12 |
+ * |--------+------+------+------+------+-------------|                                  |------+------+------+------+------+------+--------|
+ * |        | Next |LClick|  Up  |RClick| WhUp |Backspace|                               |      | PgUp | Home |  Up  |  End |  F11 |        |
+ * |--------+------+------+------+------+------|      |                                  |      |------+------+------+------+------+--------|
+ * |        | Prev | Left | Down | Right|WhDown|------|                                  |------| Left | Down | Up  | Right |  F12 |        |
+ * |--------+------+------+------+------+------| VolUp|                                  |      |------+------+------+------+------+--------|
+ * |  Shift  | Undo |  Cut | Copy | Paste|      |      |                                 |      |      |      |      |      |      |        |
+ * `--------+------+------+------+------+-------------,-------------.      ,-------------`-------------+------+------+------+------+--------'
+ *   |  ctrl  | super  | super | alt    |      |        Home | End  |      |      |      |      |      | Alt  |      |      |Ctrl  |      |
+ *   `----------------------------------'      ,------|------|------|      |------+------+------.      `----------------------------------'
+ *                                             |      |      |      |      |      |      |      |
+ *                                             |      |      |------|      |------|      |      |
+ *                                             |      |      |      |      |      |      |      |
+ *                                             `--------------------'      `--------------------'
+ */
+[FNAV] = LAYOUT_ergodox(
+
+/* Left hand */
+KC_NO,    KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,
+KC_NO,    KC_MS_BTN5, KC_MS_BTN1, KC_MS_UP, KC_MS_BTN2, KC_MS_WH_UP,  KC_BSPC,
+KC_NO,    KC_MS_BTN4, KC_MS_LEFT, KC_MS_DOWN, KC_MS_RIGHT,  KC_MS_WH_DOWN,
+KC_LSHIFT,    KC_UNDO,  KC_CUT,   KC_COPY,  KC_PASTE, KC_NO,    KC_VOLD,
+KC_LCTL,    KC_INS,   KC_LGUI,  KC_LGUI,  KC_LALT,
+                            KC_HOME,  KC_END,
+                                KC_TRNS,
+                        KC_NO,    KC_TRNS,  KC_TRNS,
+
+/* Right hand */
+        KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   KC_F12,
+        KC_NO,    KC_PGUP,  KC_HOME,  KC_UP,    KC_END,   KC_F11,   KC_NO,
+            KC_LEFT,  KC_DOWN,  KC_UP,  KC_RIGHT, KC_F12,   KC_NO,
+        KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,
+                KC_RALT,  KC_TRNS,  KC_TRNS,  KC_RCTL,    KC_NO,
+KC_TRNS,  KC_TRNS,
+KC_TRNS,
+KC_TRNS,  KC_TRNS,  KC_NO),
+};
+
+/* helper function to switch on of the right LED ON/OFF */
+static void indicate_using_led(const uint8_t led, const bool enabled) {
+  if (enabled) {
+    ergodox_right_led_on(led);
+  } else {
+    ergodox_right_led_off(led);
+  }
+}
+
+/* Runs constantly in the background, in a loop */
+void matrix_scan_user(void) {
+
+  /* red led for shift */
+  if (keyboard_report->mods & MOD_BIT(KC_LSFT) ||
+    ((get_oneshot_mods() & MOD_BIT(KC_LSFT)) && !has_oneshot_mods_timed_out())) {
+    indicate_using_led(1, true);
+  } else {
+    indicate_using_led(1, false);
+  }
+
+  /* green led for alt */
+  if (keyboard_report->mods & MOD_BIT(KC_LALT) ||
+    ((get_oneshot_mods() & MOD_BIT(KC_LALT)) && !has_oneshot_mods_timed_out())) {
+    indicate_using_led(2, true);
+  } else {
+    indicate_using_led(2, false);
+  }
+
+  /* blue led for function mode */
+  if (IS_LAYER_ON(FNAV)) {
+    indicate_using_led(3, true);
+  } else {
+    indicate_using_led(3, false);
+  }
+};

--- a/layouts/community/ergodox/bepo_alt/readme.md
+++ b/layouts/community/ergodox/bepo_alt/readme.md
@@ -1,0 +1,66 @@
+![layer0](https://i.imgur.com/vd4QLBf.png)
+
+![layer1](https://i.imgur.com/eo101eD.png)
+
+# BEPO keymap for the ErgoDox (alternate version)
+
+This keymap has been made for the BEPO layout (https://bepo.fr), which is an ergonomic french keyboard layout based on Dvorak rules. As it's made for french people, the following of this readme will be in french.
+
+Keyboard Maintainer: [Nicolas CARPi](https://github.com/NicolasCARPi)
+
+Hardware Supported: Ergodox EZ
+
+## Disposition BÉPO pour l'ErgoDox
+
+Cette keymap a été adaptée de la keymap "bepo_csa" présente dans le dossier parent.
+
+Certaines modifications ont été apportées pour ressembler un peu plus à une clavier traditionel:
+
+* entrée sur la touche tout en bas à droite (comme la touche entrée du pavé numérique sur un clavier traditionnel)
+* plusieurs touches "Super" pour faciliter son accès
+
+Il y a deux layers, celui de base, et celui avec les flèches, les touches fonction et la souris (main gauche).
+
+## Particularités
+
+* Touches de repos des pouces : "espace" à gauche et "entrée" à droite.
+* Touche Ctrl gauche accessible avec la paume de la main.
+* Touche "w" placée sur la main gauche (j'ai toujours trouvé le "w" difficle d'accès sur un clavier bépo classique.
+* Plusieurs touches F12.
+* Les flèches sont disposées avec un déplacement à la VIM.
+* Un mode souris permet d'utiliser la souris avec le clavier.
+* Possibilité de changer de mode de manière temporaire ou permanente.
+* Les leds s'allument avec SHIFT, ALT ou la touche function.
+
+J'ai fait cette disposition pour mes besoins, à vous de la modifier pour les vôtres ;)
+
+## Utilisation
+
+### Pré-requis
+
+Pour Archlinux, il est nécessaire d'installer ces paquets au préalable:
+
+~~~bash
+sudo pacman -S avr-gcc avr-libc teensy-loader-cli
+~~~
+
+Les paquets "avr" permettent de compiler le firmware, et teensy-loader permet de le charger sur le clavier.
+
+### Compilation
+
+~~~bash
+# clone the repo
+git clone https://github.com/qmk/qmk_firmware
+# install submodules
+make git-submodule
+# compile this layout
+make ergodox_ez:bepo_alt
+~~~
+
+### Chargement
+
+~~~bash
+teensy-loader-cli -w -mmcu=atmega32u4 -v ergodox_ez_bepo_alt.hex && sleep 6 && setxkbmap fr bepo
+~~~
+
+J'ai ajouté un sleep avant la commande pour remettre en bépo afin de laisser au clavier le temps de rebooter.

--- a/layouts/community/ergodox/bepo_alt/rules.mk
+++ b/layouts/community/ergodox/bepo_alt/rules.mk
@@ -1,0 +1,5 @@
+# Having a file like this allows you to override Makefile definitions
+# for your own particular keymap
+
+SLEEP_LED_ENABLE = no  # Breathing sleep LED during USB suspend
+COMMAND_ENABLE   = no  # Commands for debug and configuration


### PR DESCRIPTION
Hello,

Please find my contribution to this repository as a new layout for the ergodox keyboard.

## Description

The other bépo layouts were a bit too complex/weird or without LED code
and hard to transition to for new users. This config is a good base for
bépo users. Also, it removes the AZERTY compatibility layers found in other keymaps, thus liberating some keys for the user.

I think it's best to have as much examples as possible, so I'm hoping my layout could be included in this repository so french bépo users can start from a good base.

You can see the [README.md here](https://github.com/NicolasCARPi/qmk_firmware/blob/pr/layouts/community/ergodox/bepo_alt/readme.md).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [X] Keymap/layout/userspace (addition)
- [ ] Documentation

## Issues Fixed or Closed by This PR

None.

## Checklist

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
