### PR TITLE
Revert "Update build instructions and docker file to download submodules"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ VOLUME /qmk_firmware
 WORKDIR /qmk_firmware
 COPY . .
 
-CMD make clean ; make git-submodule ; make $KEYBOARD:$KEYMAP
+CMD make $KEYBOARD:$KEYMAP

--- a/docs/getting_started_build_tools.md
+++ b/docs/getting_started_build_tools.md
@@ -2,8 +2,6 @@
 
 This page describes setting up the build environment for QMK. These instructions cover AVR processors (such as the atmega32u4).
 
-After cloning the repo of QMK run `make git-submodule` once to download 3rd party libraries like ChibiOS.
-
 <!-- FIXME: We should have ARM instructions somewhere. -->
 
 Note: If it is your first time here, Check out the "Complete Newbs guide" instead

--- a/docs/getting_started_build_tools.md
+++ b/docs/getting_started_build_tools.md
@@ -4,7 +4,7 @@ This page describes setting up the build environment for QMK. These instructions
 
 <!-- FIXME: We should have ARM instructions somewhere. -->
 
-**Note:** If this is your first time here, check out the [Complete Newbs Guide](newbs) page.
+**Note:** If this is your first time here, check out the [Complete Newbs Guide](newbs.md) page.
 
 Before continuing, double check that your submodules (third-party libraries) are up to date by running `make git-submodule`.
 

--- a/docs/getting_started_build_tools.md
+++ b/docs/getting_started_build_tools.md
@@ -4,7 +4,9 @@ This page describes setting up the build environment for QMK. These instructions
 
 <!-- FIXME: We should have ARM instructions somewhere. -->
 
-Note: If it is your first time here, Check out the "Complete Newbs guide" instead
+**Note:** If this is your first time here, check out the [Complete Newbs Guide](newbs) page.
+
+Before continuing, double check that your submodules (third-party libraries) are up to date by running `make git-submodule`.
 
 ## Linux
 

--- a/util/docker_build.sh
+++ b/util/docker_build.sh
@@ -47,4 +47,4 @@ dir=$(pwd -W 2>/dev/null) || dir=$PWD  # Use Windows path if on Windows
 
 # Run container and build firmware
 docker run --rm -it $usb_args -v "$dir":/qmk_firmware qmkfm/qmk_firmware \
-	/bin/bash -c "make git-submodule; make \"$keyboard${keymap:+:$keymap}${target:+:$target}\""
+	make "$keyboard${keymap:+:$keymap}${target:+:$target}"


### PR DESCRIPTION
Reverts qmk/qmk_firmware#2724

The changes that PR made to the dockerfile and build script are not correct. `make clean` and `make git-submodule` should not be executed every time the container is run, as this can slow down keymap build times significantly. Submodules should already be present in the directory when the image is built. CI enforces this for [official images](https://hub.docker.com/r/qmkfm/qmk_firmware), and you're supposed to have the submodules cloned ahead of time if you're building a custom image locally.

Furthermore, the change to the docs is unnecessary as well, since the guide instructs the user to use `git clone --recurse-submodules` to clone the repo (as can be seen [here](https://github.com/qmk/qmk_firmware/blob/master/docs/newbs_getting_started.md#set-up-qmk) and [here](https://github.com/qmk/qmk_firmware/blob/master/docs/getting_started_build_tools.md#git)), which also clones the submodules.

However, after discussing this with the original PR's author, I've decided that it's a good idea to keep a reminder to run `make git-submodule` in the build tools docs.

For more details, see the [discussion](https://github.com/qmk/qmk_firmware/pull/2724#issuecomment-478907078) in the original PR.