### PR TITLE
Fix compile failures when enabling only some matrix animations.

### DIFF
--- a/quantum/rgb_matrix.c
+++ b/quantum/rgb_matrix.c
@@ -101,7 +101,7 @@ void eeconfig_update_rgb_matrix(uint32_t val) {
 void eeconfig_update_rgb_matrix_default(void) {
   dprintf("eeconfig_update_rgb_matrix_default\n");
   rgb_matrix_config.enable = 1;
-#ifndef DISABLE_RGB_MATRIX_CYCLE_ALL
+#ifndef DISABLE_RGB_MATRIX_CYCLE_LEFT_RIGHT
   rgb_matrix_config.mode = RGB_MATRIX_CYCLE_LEFT_RIGHT;
 #else
   // fallback to solid colors if RGB_MATRIX_CYCLE_LEFT_RIGHT is disabled in userspace

--- a/quantum/rgb_matrix_animations/breathing_anim.h
+++ b/quantum/rgb_matrix_animations/breathing_anim.h
@@ -1,6 +1,7 @@
 #pragma once
 #ifndef DISABLE_RGB_MATRIX_BREATHING
 
+extern rgb_counters_t g_rgb_counters;
 extern rgb_config_t rgb_matrix_config;
 
 bool rgb_matrix_breathing(effect_params_t* params) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
AI found a couple of compile failures while running with various RGB Matrix animations disabled.

`#define DISABLE_RGB_MATRIX_CYCLE_LEFT_RIGHT`

Causes explosion due to incorrect check at https://github.com/qmk/qmk_firmware/blob/cb33643f0209202e5d195613ad685e3cdae4ef2d/quantum/rgb_matrix.c#L104

Enabling breathing but disabling most others, causes explosion due to lack of extern declaration for `g_rgb_counters` at:

https://github.com/qmk/qmk_firmware/blob/cb33643f0209202e5d195613ad685e3cdae4ef2d/quantum/rgb_matrix_animations/breathing_anim.h#L9


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
