### PR TITLE
i2c_init update to work with atmega32a boards

### DIFF
--- a/drivers/avr/i2c_master.c
+++ b/drivers/avr/i2c_master.c
@@ -16,9 +16,10 @@
 #define TWBR_val ((((F_CPU / F_SCL) / Prescaler) - 16) / 2)
 
 void i2c_init(void) {
-  // TWSR = 0; /* no prescaler */
+  TWSR = 0; /* no prescaler */
   TWBR = (uint8_t)TWBR_val;
 
+  #ifdef __AVR_ATmega32A__
   // set pull-up resistors on I2C bus pins
   PORTC |= 0b11;
 
@@ -28,6 +29,7 @@ void i2c_init(void) {
   // enable TWI interrupt and slave address ACK
   TWCR |= (1 << TWIE);
   TWCR |= (1 << TWEA);
+  #endif
 }
 
 i2c_status_t i2c_start(uint8_t address, uint16_t timeout) {

--- a/drivers/avr/i2c_master.c
+++ b/drivers/avr/i2c_master.c
@@ -16,8 +16,18 @@
 #define TWBR_val ((((F_CPU / F_SCL) / Prescaler) - 16) / 2)
 
 void i2c_init(void) {
-  TWSR = 0; /* no prescaler */
+  // TWSR = 0; /* no prescaler */
   TWBR = (uint8_t)TWBR_val;
+
+  // set pull-up resistors on I2C bus pins
+  PORTC |= 0b11;
+
+  // enable TWI (two-wire interface)
+  TWCR |= (1 << TWEN);
+
+  // enable TWI interrupt and slave address ACK
+  TWCR |= (1 << TWIE);
+  TWCR |= (1 << TWEA);
 }
 
 i2c_status_t i2c_start(uint8_t address, uint16_t timeout) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Bootmapper Client (BMC) boards have to use custom i2c instead of the QMK i2c_master driver. I would like to get rid of that dependency and modify i2c_master to support atmega32a boards. The difference actually lies in the `i2c_init` routine. 

In `i2c_init`, enable
1. Pull up resistors
2. Two Wire Interface
3. TWI Interrupts
4. Slave Address Ack

Tested working on 
1. Gray Studio HB85
2. Panc60
3. Donut Cables Budget96

I don't have any other non BMC boards that make use of i2c currently in my possession that I can think of, so I could use some help testing this =). 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
