### PR TITLE
Add user-overridable callback for cancelling UCIS input

### DIFF
--- a/quantum/process_keycode/process_ucis.c
+++ b/quantum/process_keycode/process_ucis.c
@@ -64,6 +64,10 @@ void qk_ucis_symbol_fallback (void) {
   }
 }
 
+__attribute__((weak))
+void qk_ucis_cancel(void) {
+}
+
 void register_ucis(const char *hex) {
   for(int i = 0; hex[i]; i++) {
     uint8_t kc = 0;
@@ -118,7 +122,6 @@ bool process_ucis (uint16_t keycode, keyrecord_t *record) {
       return false;
     }
   }
-
   if (keycode == KC_ENT || keycode == KC_SPC || keycode == KC_ESC) {
     bool symbol_found = false;
 
@@ -130,6 +133,7 @@ bool process_ucis (uint16_t keycode, keyrecord_t *record) {
 
     if (keycode == KC_ESC) {
       qk_ucis_state.in_progress = false;
+      qk_ucis_cancel();
       return false;
     }
 

--- a/quantum/process_keycode/process_ucis.c
+++ b/quantum/process_keycode/process_ucis.c
@@ -122,6 +122,7 @@ bool process_ucis (uint16_t keycode, keyrecord_t *record) {
       return false;
     }
   }
+
   if (keycode == KC_ENT || keycode == KC_SPC || keycode == KC_ESC) {
     bool symbol_found = false;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Add a callback style function qk_ucis_cancel to quantum/process_keycode/process_ucis.c, similar to qk_ucis_start_user and qk_ucis_success, that will be called in case the user cancels by sending KC_ESC during UCIS input.
Useful for cleaning up changes set up in qk_ucis_start_user, since neither qk_ucis_symbol_fallback nor qk_ucis_success will get called when input is cancelled.

Personally I use it for a workaround to UCIS not interpreting LT(_LAYER, KC_SPC) as KC_SPACE and thus not being able to finish UCIS input from my default layer. I layer_on() a UCIS specific layer in qk_ucis_start_user that then needs to be turned off after UCIS is finished.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
