### PR TITLE
Remove unnecessary IS_COMMAND definition in treadstone48

### DIFF
--- a/keyboards/treadstone48/rev1/config.h
+++ b/keyboards/treadstone48/rev1/config.h
@@ -70,11 +70,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* Locking resynchronize hack */
 //#define LOCKING_RESYNC_ENABLE
 
-/* key combination for command */
-#define IS_COMMAND() ( \
-    keyboard_report->mods == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT)) \
-)
-
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D3
 #define RGBLIGHT_TIMER


### PR DESCRIPTION
Found another one of these. See #4301 #5065 #5269 for more details.