### PR TITLE
Updates to noroadsleft keymap for KC60 (2019-04-07)

### DIFF
--- a/keyboards/kc60/keymaps/noroadsleft/keymap.c
+++ b/keyboards/kc60/keymaps/noroadsleft/keymap.c
@@ -9,24 +9,24 @@
 ** LAYER DEFINITIONS **
 **********************/
 enum layers_keymap {
-  // BASE LAYERS
-  _QWERTY = 0,
-  _DVORAK,
-  _COLEMAK,
-  _MAC,
-  _QUAKE2,
-  _QUAKE2_DVORAK,
-  _QUAKE2_CONSOLE,
+    // BASE LAYERS
+    _QWERTY = 0,
+    _DVORAK,
+    _COLEMAK,
+    _MAC,
+    _QUAKE2,
+    _QUAKE2_DVORAK,
+    _QUAKE2_CONSOLE,
 
-  // FUNCTION LAYERS
-  _FUNCWIN,
-  _FUNCMAC,
-  _FUNCQ2,
+    // FUNCTION LAYERS
+    _FUNCWIN,
+    _FUNCMAC,
+    _FUNCQ2,
 
-  // OTHER LAYERS
-  _NUMPAD,
-  _MACROS,
-  _SYSTEM
+    // OTHER LAYERS
+    _NUMPAD,
+    _MACROS,
+    _SYSTEM
 };
 
 // LAYER SHORT CODES
@@ -70,24 +70,24 @@ enum layers_keymap {
 
 // MACRO DEFINITIONS
 enum custom_keycodes {
-  F_CAPS = SAFE_RANGE,
-  T_L3DED,
-  G_PUSH,
-  G_FTCH,
-  G_COMM,
-  G_RST,
-  G_C10R,
-  G_BRCH,
-  SIGNA,
-  GO_Q2,
-  Q2_ON,
-  Q2_OFF,
-  Q2_ESC,
-  Q2_GRV,
-  MC_UNDO,
-  MC_PSTE,
-  NUBS_Z,
-  VRSN
+    F_CAPS = SAFE_RANGE,
+    T_L3DED,
+    G_PUSH,
+    G_FTCH,
+    G_COMM,
+    G_RST,
+    G_C10R,
+    G_BRCH,
+    SIGNA,
+    GO_Q2,
+    Q2_ON,
+    Q2_OFF,
+    Q2_ESC,
+    Q2_GRV,
+    MC_UNDO,
+    MC_PSTE,
+    NUBS_Z,
+    VRSN
 };
 
 
@@ -98,293 +98,314 @@ enum custom_keycodes {
 
 
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
-  switch(keycode) {
-    // these are our macros!
-    case F_CAPS:
-      /*
-        Objective: write a macro that checks the current layers that are
-        enabled, and activates the appropriate function layer.
-      */
-      if ( biton32(layer_state) == _MAC ) {
-        if (record->event.pressed) {
-          layer_on(_FUNCMAC);
-        } else {
-          layer_off(_FUNCMAC);
-        }
-      } else {
-        if (record->event.pressed) {
-          layer_on(_FUNCWIN);
-        } else {
-          layer_off(_FUNCWIN);
-        }
-      };
-      return false;
-    case T_L3DED:
-      if (record->event.pressed) {
-        SEND_STRING("lavak3DED ");
-      };
-      return false;
-    case G_PUSH:
-      if (record->event.pressed) {
-        SEND_STRING("git push origin ");
-      };
-      return false;
-    case G_FTCH:
-      if (record->event.pressed) {
-        if ( get_mods() & MOD_MASK_SHIFT ) {
-          clear_mods();
-          SEND_STRING("git pull upstream ");
-        } else {
-          SEND_STRING("git fetch upstream ");
-        }
-      };
-      return false;
-    case G_COMM:
-      if (record->event.pressed) {
-        SEND_STRING("git commit -m \"\"" SS_TAP(X_LEFT));
-        layer_off(_MACROS);
-      };
-      return false;
-    case G_BRCH:
-      if (record->event.pressed) {
-        if ( get_mods() & MOD_MASK_SHIFT ) {
-          clear_mods();
-          SEND_STRING("master");
-        } else {
-          SEND_STRING("$(git branch-name)");
-        }
-        layer_off(_MACROS);
-      };
-      return false;
-    case SIGNA:
-      if (record->event.pressed) {
-        SEND_STRING("\\- @noroadsleft" SS_TAP(X_ENTER));
-        layer_off(_MACROS);
-      };
-      return false;
-    case GO_Q2:
-      if (record->event.pressed) {
-        //default_layer_set(_QWERTY);
-        layer_move(_QWERTY); // TO(_QWERTY);
-        layer_on(_QUAKE2);
-        //layer_off(_SYSTEM);
-      };
-      return false;
-    case Q2_ON:
-      if (record->event.pressed) {
-        SEND_STRING(SS_TAP(X_ENTER));
-        layer_on(_DVORAK);
-        layer_on(_QUAKE2_DVORAK);
-      };
-      return false;
-    case Q2_OFF:
-      if (record->event.pressed) {
-        SEND_STRING(SS_TAP(X_ENTER));
-        layer_move(_QWERTY); // TO(_QWERTY);
-        layer_on(_QUAKE2);
-      };
-      return false;
-    case Q2_ESC:
-      if (record->event.pressed) {
-        SEND_STRING(SS_TAP(X_ESCAPE));
-        layer_move(_QWERTY); // TO(_QWERTY);
-        layer_on(_QUAKE2);
-      };
-      return false;
-    case Q2_GRV:
-      if (record->event.pressed) {
-        SEND_STRING(SS_TAP(X_GRAVE));
-        layer_on(_DVORAK);
-        layer_on(_QUAKE2_DVORAK);
-        layer_on(_QUAKE2_CONSOLE);
-      };
-      return false;
-    case MC_UNDO:
-      if (record->event.pressed) {
-        if ( get_mods() & MOD_MASK_SHIFT ) {
-          SEND_STRING( SS_DOWN(X_LSHIFT) SS_DOWN(X_LGUI) SS_TAP(X_Z) SS_UP(X_LGUI) SS_UP(X_LSHIFT) );
-        } else {
-          SEND_STRING( SS_DOWN(X_LGUI) SS_TAP(X_Z) SS_UP(X_LGUI) );
-        }
-      };
-      return false;
-    case MC_PSTE:
-      if (record->event.pressed) {
-        if ( get_mods() & MOD_MASK_SHIFT ) {
-          SEND_STRING( SS_DOWN(X_LSHIFT) SS_DOWN(X_LGUI) SS_DOWN(X_LALT) SS_TAP(X_V) SS_UP(X_LALT) SS_UP(X_LGUI) SS_UP(X_LSHIFT) );
-        } else {
-          SEND_STRING( SS_DOWN(X_LGUI) SS_TAP(X_V) SS_UP(X_LGUI) );
-        }
-      };
-      return false;
-    case NUBS_Z:
-      if (record->event.pressed) {
-        if ( get_mods() & MOD_MASK_RALT ) {
-          SEND_STRING( SS_TAP(X_NONUS_BSLASH) );
-        } else {
-          SEND_STRING( SS_TAP(X_Z) );
-        }
-      };
-      return false;
-    case VRSN:
-      if (record->event.pressed) {
-        SEND_STRING( QMK_KEYBOARD "/" QMK_KEYMAP " @ " QMK_VERSION );
-      }
-      return false;
-  } // switch()
-  return true;
+    switch(keycode) {
+        // these are our macros!
+        case F_CAPS:
+            /*
+             * Objective: write a macro that checks the current layers that are
+             * enabled, and activates the appropriate function layer.
+             */
+            if ( biton32(layer_state) == _MAC ) {
+                if (record->event.pressed) {
+                    layer_on(_FUNCMAC);
+                } else {
+                    layer_off(_FUNCMAC);
+                }
+            } else {
+                if (record->event.pressed) {
+                    layer_on(_FUNCWIN);
+                } else {
+                    layer_off(_FUNCWIN);
+                }
+            };
+            return false;
+        case T_L3DED:
+            if (record->event.pressed) {
+                SEND_STRING("lavak3DED ");
+            };
+            return false;
+        case G_PUSH:
+            if (record->event.pressed) {
+                SEND_STRING("git push origin ");
+            };
+            return false;
+        case G_FTCH:
+            if (record->event.pressed) {
+                if ( get_mods() & MOD_MASK_SHIFT ) {
+                    clear_mods();
+                    SEND_STRING("git pull upstream ");
+                } else {
+                    SEND_STRING("git fetch upstream ");
+                }
+            };
+            return false;
+        case G_COMM:
+            if (record->event.pressed) {
+                SEND_STRING("git commit -m \"\"" SS_TAP(X_LEFT));
+                layer_off(_MACROS);
+            };
+            return false;
+        case G_BRCH:
+            if (record->event.pressed) {
+                if ( get_mods() & MOD_MASK_SHIFT ) {
+                    clear_mods();
+                    SEND_STRING("master");
+                } else {
+                    SEND_STRING("$(git branch-name)");
+                }
+                layer_off(_MACROS);
+            };
+            return false;
+        case SIGNA:
+            if (record->event.pressed) {
+                SEND_STRING("\\- @noroadsleft" SS_TAP(X_ENTER));
+                layer_off(_MACROS);
+            };
+            return false;
+        case GO_Q2:
+            if (record->event.pressed) {
+                //default_layer_set(_QWERTY);
+                layer_move(_QWERTY); // TO(_QWERTY);
+                layer_on(_QUAKE2);
+                //layer_off(_SYSTEM);
+            };
+            return false;
+        case Q2_ON:
+            if (record->event.pressed) {
+                SEND_STRING(SS_TAP(X_ENTER));
+                layer_on(_DVORAK);
+                layer_on(_QUAKE2_DVORAK);
+            };
+            return false;
+        case Q2_OFF:
+            if (record->event.pressed) {
+                SEND_STRING(SS_TAP(X_ENTER));
+                layer_move(_QWERTY); // TO(_QWERTY);
+                layer_on(_QUAKE2);
+            };
+            return false;
+        case Q2_ESC:
+            if (record->event.pressed) {
+                SEND_STRING(SS_TAP(X_ESCAPE));
+                layer_move(_QWERTY); // TO(_QWERTY);
+                layer_on(_QUAKE2);
+            };
+            return false;
+        case Q2_GRV:
+            if (record->event.pressed) {
+                SEND_STRING(SS_TAP(X_GRAVE));
+                layer_on(_DVORAK);
+                layer_on(_QUAKE2_DVORAK);
+                layer_on(_QUAKE2_CONSOLE);
+            };
+            return false;
+        case MC_UNDO:
+            if (record->event.pressed) {
+                if ( get_mods() & MOD_MASK_SHIFT ) {
+                    SEND_STRING( SS_DOWN(X_LSHIFT) SS_DOWN(X_LGUI) SS_TAP(X_Z) SS_UP(X_LGUI) SS_UP(X_LSHIFT) );
+                } else {
+                    SEND_STRING( SS_DOWN(X_LGUI) SS_TAP(X_Z) SS_UP(X_LGUI) );
+                }
+            };
+            return false;
+        case MC_PSTE:
+            if (record->event.pressed) {
+                if ( get_mods() & MOD_MASK_SHIFT ) {
+                    SEND_STRING( SS_DOWN(X_LSHIFT) SS_DOWN(X_LGUI) SS_DOWN(X_LALT) SS_TAP(X_V) SS_UP(X_LALT) SS_UP(X_LGUI) SS_UP(X_LSHIFT) );
+                } else {
+                    SEND_STRING( SS_DOWN(X_LGUI) SS_TAP(X_V) SS_UP(X_LGUI) );
+                }
+            };
+            return false;
+        case NUBS_Z:
+            if (record->event.pressed) {
+                if ( get_mods() & MOD_MASK_RALT ) {
+                    SEND_STRING( SS_DOWN(X_NONUS_BSLASH) );
+                } else {
+                    SEND_STRING( SS_DOWN(X_Z) );
+                }
+            } else {
+                if ( get_mods() & MOD_MASK_RALT ) {
+                    SEND_STRING( SS_UP(X_NONUS_BSLASH) );
+                } else {
+                    SEND_STRING( SS_UP(X_Z) );
+                }
+            };
+            return false;
+        case VRSN:
+            if (record->event.pressed) {
+                SEND_STRING( QMK_KEYBOARD "/" QMK_KEYMAP " @ " QMK_VERSION );
+            }
+            return false;
+        case KC_1 ... KC_0:
+            if (record->event.pressed) {
+                if ( get_mods() & MOD_MASK_RALT ) {
+                    register_code( keycode + 0x3b );
+                } else {
+                    register_code( keycode );
+                }
+            } else {
+                if ( get_mods() & MOD_MASK_RALT ) {
+                    unregister_code( keycode + 0x3b );
+                } else {
+                    unregister_code( keycode );
+                }
+            }
+            return false;
+    } // switch()
+    return true;
 };
 
 
 // KEYMAPS
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
-  /****************
-  ** BASE LAYERS **
-  ****************/
+    /****************
+    ** BASE LAYERS **
+    ****************/
 
-  /* QWERTY */
-  [_QWERTY] = LAYOUT_60_ansi(
-    //       2        3        4        5        6        7        8        9        10       11       12       13       14       15       16
-    KC_GESC, KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, \
-    KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS, \
-    FW_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_ENT,           \
-    KC_LSFT, NUBS_Z,  KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT,                   \
-    KC_LCTL, KC_LGUI, KC_LALT,                   KC_SPC,                                      KC_RALT, KC_RGUI, MO(_FW), KC_RCTL  \
-  ),
+    /* QWERTY */
+    [_QWERTY] = LAYOUT_60_ansi(
+        //       2        3        4        5        6        7        8        9        10       11       12       13       14       15       16
+        KC_GESC, KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, \
+        KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS, \
+        FW_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_ENT,           \
+        KC_LSFT, NUBS_Z,  KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT,                   \
+        KC_LCTL, KC_LGUI, KC_LALT,                   KC_SPC,                                      KC_RALT, KC_RGUI, MO(_FW), KC_RCTL  \
+    ),
 
-  /* Dvorak */
-  [_DVORAK] = LAYOUT_60_ansi(
-    //       2        3        4        5        6        7        8        9        10       11       12       13       14       15       16
-    KC_GESC, KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_LBRC, KC_RBRC, KC_BSPC, \
-    KC_TAB,  KC_QUOT, KC_COMM, KC_DOT,  KC_P,    KC_Y,    KC_F,    KC_G,    KC_C,    KC_R,    KC_L,    KC_SLSH, KC_EQL,  KC_BSLS, \
-    FW_CAPS, KC_A,    KC_O,    KC_E,    KC_U,    KC_I,    KC_D,    KC_H,    KC_T,    KC_N,    KC_S,    KC_MINS, KC_ENT,           \
-    KC_LSFT, KC_SCLN, KC_Q,    KC_J,    KC_K,    KC_X,    KC_B,    KC_M,    KC_W,    KC_V,    KC_Z,    KC_RSFT,                   \
-    KC_LCTL, KC_LGUI, KC_LALT,                   KC_SPC,                                      KC_RALT, KC_RGUI, MO(_FW), KC_RCTL  \
-  ),
+    /* Dvorak */
+    [_DVORAK] = LAYOUT_60_ansi(
+        //       2        3        4        5        6        7        8        9        10       11       12       13       14       15       16
+        KC_GESC, KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_LBRC, KC_RBRC, KC_BSPC, \
+        KC_TAB,  KC_QUOT, KC_COMM, KC_DOT,  KC_P,    KC_Y,    KC_F,    KC_G,    KC_C,    KC_R,    KC_L,    KC_SLSH, KC_EQL,  KC_BSLS, \
+        FW_CAPS, KC_A,    KC_O,    KC_E,    KC_U,    KC_I,    KC_D,    KC_H,    KC_T,    KC_N,    KC_S,    KC_MINS, KC_ENT,           \
+        KC_LSFT, KC_SCLN, KC_Q,    KC_J,    KC_K,    KC_X,    KC_B,    KC_M,    KC_W,    KC_V,    KC_Z,    KC_RSFT,                   \
+        KC_LCTL, KC_LGUI, KC_LALT,                   KC_SPC,                                      KC_RALT, KC_RGUI, MO(_FW), KC_RCTL  \
+    ),
 
-  /* Colemak */
-  [_COLEMAK] = LAYOUT_60_ansi(
-    //       2        3        4        5        6        7        8        9        10       11       12       13       14       15       16
-    KC_GESC, KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, \
-    KC_TAB,  KC_Q,    KC_W,    KC_F,    KC_P,    KC_G,    KC_J,    KC_L,    KC_U,    KC_Y,    KC_SCLN, KC_LBRC, KC_RBRC, KC_BSLS, \
-    FW_CAPS, KC_A,    KC_R,    KC_S,    KC_T,    KC_D,    KC_H,    KC_N,    KC_E,    KC_I,    KC_O,    KC_QUOT, KC_ENT,           \
-    KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_K,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT,                   \
-    KC_LCTL, KC_LGUI, KC_LALT,                   KC_SPC,                                      KC_RALT, KC_RGUI, MO(_FW), KC_RCTL  \
-  ),
+    /* Colemak */
+    [_COLEMAK] = LAYOUT_60_ansi(
+        //       2        3        4        5        6        7        8        9        10       11       12       13       14       15       16
+        KC_GESC, KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, \
+        KC_TAB,  KC_Q,    KC_W,    KC_F,    KC_P,    KC_G,    KC_J,    KC_L,    KC_U,    KC_Y,    KC_SCLN, KC_LBRC, KC_RBRC, KC_BSLS, \
+        FW_CAPS, KC_A,    KC_R,    KC_S,    KC_T,    KC_D,    KC_H,    KC_N,    KC_E,    KC_I,    KC_O,    KC_QUOT, KC_ENT,           \
+        KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_K,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT,                   \
+        KC_LCTL, KC_LGUI, KC_LALT,                   KC_SPC,                                      KC_RALT, KC_RGUI, MO(_FW), KC_RCTL  \
+    ),
 
-  /****************
-  ** OS OVERLAYS **
-  ****************/
+    /****************
+    ** OS OVERLAYS **
+    ****************/
 
-  /* Mac */
-  [_MAC] = LAYOUT_60_ansi(
-    //       2        3        4        5        6        7        8        9        10       11       12       13       14       15       16
-    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, \
-    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, \
-    FM_CAPS, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          \
-    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,                   \
-    _______, _______, _______,                   _______,                                     _______, _______, MO(_FM), _______  \
-  ),
+    /* Mac */
+    [_MAC] = LAYOUT_60_ansi(
+        //       2        3        4        5        6        7        8        9        10       11       12       13       14       15       16
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, \
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, \
+        FM_CAPS, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          \
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,                   \
+        _______, _______, _______,                   _______,                                     _______, _______, MO(_FM), _______  \
+    ),
 
-  /*********************
-  ** QUAKE 2 OVERLAYS **
-  *********************/
+    /*********************
+    ** QUAKE 2 OVERLAYS **
+    *********************/
 
-  /* Quake 2 */
-  [_QUAKE2] = LAYOUT_60_ansi(
-    //       2        3        4        5        6        7        8        9        10       11       12       13       14       15       16
-    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, \
-    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, \
-    Q2_CAPS, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, Q2_ON,            \
-    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,                   \
-    _______, _______, _______,                   _______,                                     _______, _______, MO(_FQ), _______  \
-  ),
+    /* Quake 2 */
+    [_QUAKE2] = LAYOUT_60_ansi(
+        //       2        3        4        5        6        7        8        9        10       11       12       13       14       15       16
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, \
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, \
+        Q2_CAPS, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, Q2_ON,            \
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,                   \
+        _______, _______, _______,                   _______,                                     _______, _______, MO(_FQ), _______  \
+    ),
 
-  [_QUAKE2_DVORAK] = LAYOUT_60_ansi(
-    //       2        3        4        5        6        7        8        9        10       11       12       13       14       15       16
-    Q2_ESC,  _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, \
-    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, \
-    Q2_CAPS, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, Q2_OFF,           \
-    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,                   \
-    _______, _______, _______,                   _______,                                     _______, _______, MO(_FQ), _______  \
-  ),
+    [_QUAKE2_DVORAK] = LAYOUT_60_ansi(
+        //       2        3        4        5        6        7        8        9        10       11       12       13       14       15       16
+        Q2_ESC,  _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, \
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, \
+        Q2_CAPS, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, Q2_OFF,           \
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,                   \
+        _______, _______, _______,                   _______,                                     _______, _______, MO(_FQ), _______  \
+    ),
 
-  [_QUAKE2_CONSOLE] = LAYOUT_60_ansi(
-    //       2        3        4        5        6        7        8        9        10       11       12       13       14       15       16
-    Q2_ESC,  _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, \
-    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, \
-    Q2_CAPS, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, KC_ENT,           \
-    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,                   \
-    _______, _______, _______,                   _______,                                     _______, _______, MO(_FQ), _______  \
-  ),
+    [_QUAKE2_CONSOLE] = LAYOUT_60_ansi(
+        //       2        3        4        5        6        7        8        9        10       11       12       13       14       15       16
+        Q2_ESC,  _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, \
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, \
+        Q2_CAPS, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, KC_ENT,           \
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,                   \
+        _______, _______, _______,                   _______,                                     _______, _______, MO(_FQ), _______  \
+    ),
 
-  /********************
-  ** FUNCTION LAYERS **
-  ********************/
+    /********************
+    ** FUNCTION LAYERS **
+    ********************/
 
-  /* Windows Fn layer */
-  [_FUNCWIN] = LAYOUT_60_ansi(
-    //       2        3        4        5        6        7        8        9        10       11       12       13       14       15       16
-    KC_GRV,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_DEL,  \
-    _______, KC_CALC, KC_APP,  _______, _______, _______, KC_INS,  KC_HOME, KC_UP,   KC_END,  KC_PGUP, KC_PSCR, KC_SLCK, KC_PAUS, \
-    NO_CHNG, WN_SALL, _______, _______, _______, _______, KC_DEL,  KC_LEFT, KC_DOWN, KC_RGHT, KC_PGDN, _______, KC_PENT,          \
-    _______, WN_UNDO, WN_CUT,  WN_COPY, WN_PSTE, _______, _______, KC_MUTE, KC_VOLD, KC_VOLU, TG(_SY), _______,                   \
-    _______, _______, _______,                   TG(_NP),                                     _______, TG(_MA), NO_CHNG, _______  \
-  ),
+    /* Windows Fn layer */
+    [_FUNCWIN] = LAYOUT_60_ansi(
+        //       2        3        4        5        6        7        8        9        10       11       12       13       14       15       16
+        KC_GRV,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_DEL,  \
+        _______, KC_CALC, KC_APP,  _______, _______, _______, KC_INS,  KC_HOME, KC_UP,   KC_END,  KC_PGUP, KC_PSCR, KC_SLCK, KC_PAUS, \
+        NO_CHNG, WN_SALL, _______, _______, _______, _______, KC_DEL,  KC_LEFT, KC_DOWN, KC_RGHT, KC_PGDN, _______, KC_PENT,          \
+        _______, WN_UNDO, WN_CUT,  WN_COPY, WN_PSTE, _______, _______, KC_MUTE, KC_VOLD, KC_VOLU, TG(_SY), _______,                   \
+        _______, _______, _______,                   TG(_NP),                                     _______, TG(_MA), NO_CHNG, _______  \
+    ),
 
-  /* MacOS Fn layer */
-  [_FUNCMAC] = LAYOUT_60_ansi(
-    //       2        3        4        5        6        7        8        9        10       11       12       13       14       15       16
-    KC_GRV,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_DEL,  \
-    _______, _______, _______, _______, _______, _______, KC_INS,  MC_HOME, KC_UP,   MC_END,  KC_PGUP, MC_PSCR, _______, _______, \
-    NO_CHNG, MC_SALL, _______, _______, _______, _______, KC_DEL,  KC_LEFT, KC_DOWN, KC_RGHT, KC_PGDN, _______, _______,          \
-    _______, MC_UNDO, MC_CUT,  MC_COPY, MC_PSTE, _______, _______, _______, _______, _______, TG(_SY), _______,                   \
-    _______, _______, _______,                   TG(_NP),                                     _______, _______, NO_CHNG, _______  \
-  ),
+    /* MacOS Fn layer */
+    [_FUNCMAC] = LAYOUT_60_ansi(
+        //       2        3        4        5        6        7        8        9        10       11       12       13       14       15       16
+        KC_GRV,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_DEL,  \
+        _______, _______, _______, _______, _______, _______, KC_INS,  MC_HOME, KC_UP,   MC_END,  KC_PGUP, MC_PSCR, _______, _______, \
+        NO_CHNG, MC_SALL, _______, _______, _______, _______, KC_DEL,  KC_LEFT, KC_DOWN, KC_RGHT, KC_PGDN, _______, _______,          \
+        _______, MC_UNDO, MC_CUT,  MC_COPY, MC_PSTE, _______, _______, _______, _______, _______, TG(_SY), _______,                   \
+        _______, _______, _______,                   TG(_NP),                                     _______, _______, NO_CHNG, _______  \
+    ),
 
-  /* Quake 2 Fn layer */
-  [_FUNCQ2] = LAYOUT_60_ansi(
-    //       2        3        4        5        6        7        8        9        10       11       12       13       14       15       16
-    Q2_GRV,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_DEL,  \
-    _______, _______, _______, _______, _______, _______, KC_INS,  KC_HOME, KC_UP,   KC_END,  KC_PGUP, KC_PSCR, KC_SLCK, KC_PAUS, \
-    NO_CHNG, _______, _______, _______, _______, _______, KC_DEL,  KC_LEFT, KC_DOWN, KC_RGHT, KC_PGDN, _______, KC_ENT,           \
-    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, TG(_SY), _______,                   \
-    _______, _______, _______,                   _______,                                     _______, _______, NO_CHNG, _______  \
-  ),
+    /* Quake 2 Fn layer */
+    [_FUNCQ2] = LAYOUT_60_ansi(
+        //       2        3        4        5        6        7        8        9        10       11       12       13       14       15       16
+        Q2_GRV,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_DEL,  \
+        _______, _______, _______, _______, _______, _______, KC_INS,  KC_HOME, KC_UP,   KC_END,  KC_PGUP, KC_PSCR, KC_SLCK, KC_PAUS, \
+        NO_CHNG, _______, _______, _______, _______, _______, KC_DEL,  KC_LEFT, KC_DOWN, KC_RGHT, KC_PGDN, _______, KC_ENT,           \
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, TG(_SY), _______,                   \
+        _______, _______, _______,                   _______,                                     _______, _______, NO_CHNG, _______  \
+    ),
 
-  /*****************
-  ** OTHER LAYERS **
-  *****************/
+    /*****************
+    ** OTHER LAYERS **
+    *****************/
 
-  /* Numpad layer */
-  [_NUMPAD] = LAYOUT_60_ansi(
-    //       2        3        4        5        6        7        8        9        10       11       12       13       14       15       16
-    _______, _______, _______, _______, _______, _______, _______, KC_P7,   KC_P8,   KC_P9,   _______, _______, _______, _______, \
-    _______, _______, _______, _______, KC_E,    KC_F,    _______, KC_P4,   KC_P5,   KC_P6,   KC_PAST, KC_PSLS, KC_PEQL, _______, \
-    _______, _______, _______, _______, KC_C,    KC_D,    _______, KC_P1,   KC_P2,   KC_P3,   KC_PPLS, KC_PMNS, KC_PENT,          \
-    _______, _______, _______, _______, KC_A,    KC_B,    _______, KC_P0,   _______, KC_PDOT, _______, _______,                   \
-    _______, _______, _______,                   TG(_NP),                                     _______, _______, NO_CHNG, _______  \
-  ),
+    /* Numpad layer */
+    [_NUMPAD] = LAYOUT_60_ansi(
+        //       2        3        4        5        6        7        8        9        10       11       12       13       14       15       16
+        _______, _______, _______, _______, _______, _______, _______, KC_P7,   KC_P8,   KC_P9,   _______, _______, _______, _______, \
+        _______, _______, _______, _______, KC_E,    KC_F,    _______, KC_P4,   KC_P5,   KC_P6,   KC_PAST, KC_PSLS, KC_PEQL, _______, \
+        _______, _______, _______, _______, KC_C,    KC_D,    _______, KC_P1,   KC_P2,   KC_P3,   KC_PPLS, KC_PMNS, KC_PENT,          \
+        _______, _______, _______, _______, KC_A,    KC_B,    _______, KC_P0,   _______, KC_PDOT, _______, _______,                   \
+        _______, _______, _______,                   TG(_NP),                                     _______, _______, NO_CHNG, _______  \
+    ),
 
-  /* Macro layer */
-  [_MACROS] = LAYOUT_60_ansi(
-    //       2        3        4        5        6        7        8        9        10       11       12       13       14       15       16
-    TG(_MA), _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, \
-    _______, _______, _______, G_PUSH,  _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, \
-    _______, _______, _______, G_FTCH,  G_COMM,  _______, _______, _______, _______, T_L3DED, _______, _______, _______,          \
-    _______, _______, _______, _______, _______, G_BRCH,  SIGNA,   _______, _______, _______, _______, _______,                   \
-    _______, _______, _______,                   _______,                                     _______, _______, NO_CHNG, _______  \
-  ),
+    /* Macro layer */
+    [_MACROS] = LAYOUT_60_ansi(
+        //       2        3        4        5        6        7        8        9        10       11       12       13       14       15       16
+        TG(_MA), _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, \
+        _______, _______, _______, G_PUSH,  _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, \
+        _______, _______, _______, G_FTCH,  G_COMM,  _______, _______, _______, _______, T_L3DED, _______, _______, _______,          \
+        _______, _______, _______, _______, _______, G_BRCH,  SIGNA,   _______, _______, _______, _______, _______,                   \
+        _______, _______, _______,                   _______,                                     _______, _______, NO_CHNG, _______  \
+    ),
 
-  /* System layer */
-  [_SYSTEM] = LAYOUT_60_ansi(
-    //       2        3        4        5        6        7        8        9        10       11       12       13       14       15       16
-    TG(_SY), TO(_QW), TO(_DV), TO(_CM), GO_Q2,   XXXXXXX, XXXXXXX, XXXXXXX, RESET,   XXXXXXX, DEBUG,   XXXXXXX, VRSN,    XXXXXXX, \
-    XXXXXXX, XXXXXXX, TG(_MC), XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, \
-    XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,          \
-    XXXXXXX, XXXXXXX, XXXXXXX, BL_DEC,  BL_TOGG, BL_INC,  BL_BRTG, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,                   \
-    XXXXXXX, XXXXXXX, XXXXXXX,                   XXXXXXX,                                     XXXXXXX, XXXXXXX, NO_CHNG, XXXXXXX  \
-  ),
+    /* System layer */
+    [_SYSTEM] = LAYOUT_60_ansi(
+        //       2        3        4        5        6        7        8        9        10       11       12       13       14       15       16
+        TG(_SY), TO(_QW), TO(_DV), TO(_CM), GO_Q2,   XXXXXXX, XXXXXXX, XXXXXXX, RESET,   XXXXXXX, DEBUG,   XXXXXXX, VRSN,    XXXXXXX, \
+        XXXXXXX, XXXXXXX, TG(_MC), XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, \
+        XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,          \
+        XXXXXXX, XXXXXXX, XXXXXXX, BL_DEC,  BL_TOGG, BL_INC,  BL_BRTG, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,                   \
+        XXXXXXX, XXXXXXX, XXXXXXX,                   XXXXXXX,                                     XXXXXXX, XXXXXXX, NO_CHNG, XXXXXXX  \
+    ),
 
 };

--- a/keyboards/kc60/keymaps/noroadsleft/readme.md
+++ b/keyboards/kc60/keymaps/noroadsleft/readme.md
@@ -1,6 +1,6 @@
 # @noroadsleft's KC60 keymap
 
-### Last updated: February 14, 2019, 3:50 AM UTC-0800
+### Last updated: April 7, 2019, 2:26 AM UTC-0700
 
 ![](https://i.imgur.com/tzhXQYI.jpg)
 

--- a/keyboards/kc60/keymaps/noroadsleft/readme_ch3.md
+++ b/keyboards/kc60/keymaps/noroadsleft/readme_ch3.md
@@ -16,7 +16,7 @@
 
 These layers were born out of the confusion I have had trying to use the in-game chat and the console in [Quake 2](https://en.wikipedia.org/wiki/Quake_II). When Quake 2 came out, alternate keyboard layouts weren't really a thing. As a result, all in-game text input is hard-locked to US QWERTY, regardless of what the operating system is using for its input method.
 
-I'm attempting to solve this by some creative use of QMK's macro feature. The keycode in the System layer that enables these layers, [`GO_Q2`](./keymap.c#L383), is a [macro](./keymap.c#L165-172) that sets the default layer to the QWERTY layer, then turns the Quake 2 layer `_Q2` on. The result is a partially-overwritten QWERTY layer, that has some keycodes with some creative layer switching.
+I'm attempting to solve this by some creative use of QMK's macro feature. The keycode in the System layer that enables these layers, [`GO_Q2`](./keymap.c#L404), is a [macro](./keymap.c#L165-L172) that sets the default layer to the QWERTY layer, then turns the Quake 2 layer `_Q2` on. The result is a partially-overwritten QWERTY layer, that has some keycodes with some creative layer switching.
 
 When I hit the `Enter` key (bound in-game to text chat), the [macro keycode](./keymap.c#L173-L179) I've created sends the keycode for `Enter`, then follows with enabling the Hardware Dvorak layer and its corresponding overlay. Now the game is in text chat mode, and my keyboard is in Dvorak. When I hit `Enter` again, another `Enter` [keycode macro](./keymap.c#L180-L186) is sent, which sends the message, then the macro brings me back to the standard QWERTY+Quake 2 setup. Hitting `Escape` instead runs a [macro](./keymap.c#L187-L193) that cancels the sending of the message, and undoes the layers.
 

--- a/keyboards/kc60/keymaps/noroadsleft/readme_ch5.md
+++ b/keyboards/kc60/keymaps/noroadsleft/readme_ch5.md
@@ -60,7 +60,7 @@ Output: `git commit -m ""` <kbd>Left</kbd>
 
 Readies a `git commit` command, moves the cursor between the quotation marks, then disables the Macro layer.
 
-#### [G_BRCH](./keymap.c#L148-158)
+#### [G_BRCH](./keymap.c#L148-L158)
 
 | Condition | Output |
 | :-------- | :----- |
@@ -93,7 +93,7 @@ An Undo shortcut that turns to Redo if <kbd>Shift</kbd> is being held. I'm not s
 
 The program I use this in uses <kbd>Shift</kbd> + <kbd>Command</kbd> + <kbd>Option</kbd> + <kbd>V</kbd> to paste while maintaining formatting (typeface, text size, etc.). Sometimes I want this and sometimes I don't. Using <kbd>Shift</kbd> changes the behavior.
 
-#### [NUBS_Z](./keymap.c#L220-L228)
+#### [NUBS_Z](./keymap.c#L220-L234)
 
 | Condition | Output |
 | :-------- | :----- |
@@ -102,11 +102,15 @@ The program I use this in uses <kbd>Shift</kbd> + <kbd>Command</kbd> + <kbd>Opti
 
 Sometimes I type in languages from countries that use ISO layout, but my keyboard is ANSI, so I have one key fewer. This macro simulates the Non-US Backslash key if I use Right Alt + Z.
 
-#### [VRSN](./keymap.c#L229-L233)
+#### [VRSN](./keymap.c#L235-L239)
 
 Outputs a string that tells me the Git commit from which my flashed firmware was built. Looks something like:
 
-    kc60/noroadsleft @ 0.6.240-20-ge91549-dirty
+    kc60/noroadsleft @ 0.6.326-6-gae6d7b-dirty
+
+#### [Emulated Numeric Keypad](./keymap.c#L240-L254)
+
+If I hold the Right Alt key, the number row (`KC_1` through `KC_0`) will output numpad keycodes instead of number row keycodes, enabling quicker access to characters like ™ and °.
 
 ----
 


### PR DESCRIPTION
## Commit Log

### Update macros and keycode handling (fed4f25)

- Update NUBS_Z macro so it repeats when held down
- Number row now uses numpad keycodes if Right Alt is being held
- coding conventions and formatting update
  - switched to four-space indent
  - reformatted a block comment

### Update readme files (dd55f7d)
