### PR TITLE
Update ps2avrgb readme template

### DIFF
--- a/quantum/template/ps2avrgb/readme.md
+++ b/quantum/template/ps2avrgb/readme.md
@@ -4,7 +4,7 @@
 
 A short description of the keyboard/project
 
-Keyboard Maintainer: [You](https://github.com/yourusername)  
+Keyboard Maintainer: [%YOUR_NAME%](https://github.com/yourusername)  
 Hardware Supported: The PCBs, controllers supported  
 Hardware Availability: links to where you can find this hardware
 
@@ -34,10 +34,10 @@ macOS:
     ```
 3. Install the following packages:
     ```
-    brew install python
-    brew install pyusb
-    brew install --HEAD`https://raw.githubusercontent.com/robertgzr/homebrew-tap/master/bootloadhid.rb
-
+    brew install python3
+    pip3 install pyusb
+    brew install --HEAD https://raw.githubusercontent.com/robertgzr/homebrew-tap/master/bootloadhid.rb
+    ```
 4. Place your keyboard into reset. 
 5. Flash the board by typing `bootloadHID -r` followed by the path to your `.hex` file. 
 


### PR DESCRIPTION
- fix markdown formatting on macOS instructions (close code block)
- update package install commands
  - set python3
  - use pip3 to install pyusb
  - fix typo (extra backtick on bootloadhid package install line)
- update Keyboard Maintainer line (now unified with AVR template)


Based on @mechmerlin's work of refactoring BMC boards to use QMK core functionality, though I'd guess he hopes to never again actually need this file.