### PR TITLE
ergodox_ez: Matrix changes now used for debounce()

### DIFF
--- a/keyboards/ergodox_ez/matrix.c
+++ b/keyboards/ergodox_ez/matrix.c
@@ -123,6 +123,17 @@ void matrix_power_up(void) {
 #endif
 }
 
+// Reads and stores a row, returning
+// whether a change occurred.
+static inline bool store_raw_matrix_row(uint8_t index) {
+  matrix_row_t temp = read_cols(index);
+  if (raw_matrix[index] != temp) {
+    raw_matrix[index] = temp;
+    return true;
+  }
+  return false;
+}
+
 uint8_t matrix_scan(void) {
   if (mcp23018_status) {  // if there was an error
     if (++mcp23018_reset_loop == 0) {
@@ -157,22 +168,24 @@ uint8_t matrix_scan(void) {
 #ifdef LEFT_LEDS
   mcp23018_status = ergodox_left_leds_update();
 #endif  // LEFT_LEDS
+  bool changed = false;  
   for (uint8_t i = 0; i < MATRIX_ROWS_PER_SIDE; i++) {
     // select rows from left and right hands
-    select_row(i);
-    select_row(i + MATRIX_ROWS_PER_SIDE);
+    uint8_t left_index = i;
+    uint8_t right_index = i + MATRIX_ROWS_PER_SIDE;
+    select_row(left_index);
+    select_row(right_index);
 
     // we don't need a 30us delay anymore, because selecting a
     // left-hand row requires more than 30us for i2c.
-
-    // grab left + right cols.
-    raw_matrix[i] = read_cols(i);    
-    raw_matrix[i+MATRIX_ROWS_PER_SIDE] = read_cols(i+MATRIX_ROWS_PER_SIDE);
     
+    changed |= store_raw_matrix_row(left_index);
+    changed |= store_raw_matrix_row(right_index);
+
     unselect_rows();
   }
   
-  debounce(raw_matrix, matrix, MATRIX_ROWS, true);
+  debounce(raw_matrix, matrix, MATRIX_ROWS, changed);
   matrix_scan_quantum();
 
   return 1;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Ergodox_ez now calculates whether the matrix changed during scanning.

## Description
Ergodox_ez previously did not calculate if the matrix changed while scanning it.
This is required to make sym_g debounce work correctly.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

I have only compiled it - @drashna (lol) to test.