### PR TITLE
Plaid - Add compatibility for LAYOUTS = planck_mit planck_grid

### DIFF
--- a/keyboards/plaid/plaid.h
+++ b/keyboards/plaid/plaid.h
@@ -61,3 +61,7 @@
 #define KEYMAP LAYOUT_plaid_grid
 #define LAYOUT_ortho_4x12 LAYOUT_plaid_grid
 #define KC_LAYOUT_ortho_4x12 KC_KEYMAP
+
+// Compatibility for LAYOUTS = planck_mit planck_grid
+#define LAYOUT_planck_mit LAYOUT_plaid_mit
+#define LAYOUT_planck_grid LAYOUT_plaid_grid

--- a/keyboards/plaid/plaid.h
+++ b/keyboards/plaid/plaid.h
@@ -60,9 +60,6 @@
 
 #define KEYMAP LAYOUT_plaid_grid
 #define LAYOUT_ortho_4x12 LAYOUT_plaid_grid
-#define KC_LAYOUT_ortho_4x12 KC_KEYMAP
-#define LAYOUT_kc_ortho_4x12 KC_KEYMAP
-
-// Compatibility for LAYOUTS = planck_mit planck_grid
 #define LAYOUT_planck_mit LAYOUT_plaid_mit
-#define LAYOUT_planck_grid LAYOUT_plaid_grid
+#define LAYOUT_kc_ortho_4x12 KC_KEYMAP
+#define KC_LAYOUT_ortho_4x12 KC_KEYMAP

--- a/keyboards/plaid/plaid.h
+++ b/keyboards/plaid/plaid.h
@@ -61,6 +61,7 @@
 #define KEYMAP LAYOUT_plaid_grid
 #define LAYOUT_ortho_4x12 LAYOUT_plaid_grid
 #define KC_LAYOUT_ortho_4x12 KC_KEYMAP
+#define LAYOUT_kc_ortho_4x12 KC_KEYMAP
 
 // Compatibility for LAYOUTS = planck_mit planck_grid
 #define LAYOUT_planck_mit LAYOUT_plaid_mit

--- a/keyboards/plaid/rules.mk
+++ b/keyboards/plaid/rules.mk
@@ -97,5 +97,5 @@ NO_UART = yes
 NO_SUSPEND_POWER_DOWN = yes
 
 
-LAYOUTS = ortho_4x12 planck_mit planck_grid
+LAYOUTS = ortho_4x12 planck_mit
 LAYOUTS_HAS_RGB = no


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Spotted within the output of http://compile.qmk.fm/v1/keyboards/error_log.

Plaid defines `LAYOUTS = planck_mit planck_grid` however the LAYOUT macros are defined as `plaid_mit` and `plaid_grid`.

This PR allows the default community layout ` make plaid:default_planck_mit` to be built and also removes planck_grid as ortho_4x12 supersedes it. I have kept the existing macro and defined an alias, just incase any keymaps already exist. If required i can change the logic so the layouts are planck and the alias is plaid.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
