### PR TITLE
Added ALT_TAB macro example

### DIFF
--- a/docs/feature_macros.md
+++ b/docs/feature_macros.md
@@ -297,7 +297,7 @@ const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt) {
 
 #### Super ALT/TAB
 
-This marco will register `KC_LALT` and tap `KC_TAB` and wait for 1000ms. If the key is taped again it will send another `KC_TAP`, if there is no tap then unregister `KC_LALT`. Thus allowing you to cycle through windows. 
+This macro will register `KC_LALT` and tap `KC_TAB`, then wait for 1000ms. If the key is tapped again, it will send another `KC_TAB`; if there is no tap, `KC_LALT` will be unregistered, thus allowing you to cycle through windows. 
 
 ```c
 bool is_alt_tab_active = false;    # ADD this near the begining of keymap.c

--- a/docs/feature_macros.md
+++ b/docs/feature_macros.md
@@ -299,7 +299,7 @@ const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt) {
 
 This marco will register `KC_LALT` and tap `KC_TAB` and wait for 1000ms. If the key is taped again it will send another `KC_TAP`, if there is no tap then unregister `KC_LALT`. Thus allowing you to cycle through windows. 
 
-```
+```c
 bool is_alt_tab_active = false;    # ADD this near the begining of keymap.c
 uint16_t alt_tab_timer = 0;        # we will be using them soon.
 

--- a/docs/feature_macros.md
+++ b/docs/feature_macros.md
@@ -195,6 +195,49 @@ This will clear all mods currently pressed.
 
 This will clear all keys besides the mods currently pressed.
 
+### Advanced Example: 
+
+#### Super ALT/TAB
+
+This macro will register `KC_LALT` and tap `KC_TAB`, then wait for 1000ms. If the key is tapped again, it will send another `KC_TAB`; if there is no tap, `KC_LALT` will be unregistered, thus allowing you to cycle through windows. 
+
+```c
+bool is_alt_tab_active = false;    # ADD this near the begining of keymap.c
+uint16_t alt_tab_timer = 0;        # we will be using them soon.
+
+enum custom_keycodes {             # Make sure have the awesome keycode ready
+  ALT_TAB = SAFE_RANGE,
+};
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  switch (keycode) {               # This will do most of the grunt work with the keycodes.
+    case ALT_TAB:
+      if (record->event.pressed) {
+        if (!is_alt_tab_active) {
+          is_alt_tab_active = true;
+          register_code(KC_LALT);
+        } 
+        alt_tab_timer = timer_read();
+        register_code(KC_TAB);
+      } else {
+        unregister_code(KC_TAB);
+      }
+      break;
+  }
+  return true;
+}
+
+void matrix_scan_user(void) {     # The very important timer. 
+  if (is_alt_tab_active) {
+    if (timer_elapsed(alt_tab_timer) > 1000) {
+      unregister_code16(LALT(KC_TAB));
+      is_alt_tab_active = false;
+    }
+  }
+}
+```
+
+---
 
 ##  **(DEPRECATED)** The Old Way: `MACRO()` & `action_get_macro`
 
@@ -273,7 +316,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 ```
 
 
-### Advanced Examples: 
+### Advanced Example: 
 
 #### Single-Key Copy/Paste
 
@@ -293,44 +336,4 @@ const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt) {
     }
     return MACRO_NONE;
 };
-```
-
-#### Super ALT/TAB
-
-This macro will register `KC_LALT` and tap `KC_TAB`, then wait for 1000ms. If the key is tapped again, it will send another `KC_TAB`; if there is no tap, `KC_LALT` will be unregistered, thus allowing you to cycle through windows. 
-
-```c
-bool is_alt_tab_active = false;    # ADD this near the begining of keymap.c
-uint16_t alt_tab_timer = 0;        # we will be using them soon.
-
-enum custom_keycodes {             # Make sure have the awesome keycode ready
-  ALT_TAB = SAFE_RANGE,
-};
-
-bool process_record_user(uint16_t keycode, keyrecord_t *record) {
-  switch (keycode) {               # This will do most of the grunt work with the keycodes.
-    case ALT_TAB:
-      if (record->event.pressed) {
-        if (!is_alt_tab_active) {
-          is_alt_tab_active = true;
-          register_code(KC_LALT);
-        } 
-        alt_tab_timer = timer_read();
-        register_code(KC_TAB);
-      } else {
-        unregister_code(KC_TAB);
-      }
-      break;
-  }
-  return true;
-}
-
-void matrix_scan_user(void) {     # The very important timer. 
-  if (is_alt_tab_active) {
-    if (timer_elapsed(alt_tab_timer) > 1000) {
-      unregister_code16(LALT(KC_TAB));
-      is_alt_tab_active = false;
-    }
-  }
-}
 ```


### PR DESCRIPTION
This adds an example of Super ALT_TAB macro for easily switching windows.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
ALT_TAB macro has be requested before. This example will help with anyone else who wants to have a single key way to alt tab
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [X] Documentation

## Issues Fixed or Closed by This PR

* None that aware of. 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
