### PR TITLE
Remove caveat about combos with shared keys

### DIFF
--- a/docs/feature_combo.md
+++ b/docs/feature_combo.md
@@ -19,7 +19,6 @@ combo_t key_combos[COMBO_COUNT] = {COMBO(test_combo, KC_ESC)};
 This will send "Escape" if you hit the A and B keys.
 
 !> This method only supports [basic keycodes](keycodes_basic.md). See the examples for more control.
-!> You cannot reuse (share) keys in combos. Each key should only belong to a single combo.  
 
 ## Examples
 


### PR DESCRIPTION
## Description

Combos with shared keys are supported as of https://github.com/qmk/qmk_firmware/pull/2561. Therefore, this caveat no longer applies and should be removed.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
