### PR TITLE
fix combo enabling logic

### DIFF
--- a/quantum/process_keycode/process_combo.c
+++ b/quantum/process_keycode/process_combo.c
@@ -126,13 +126,13 @@ static bool process_single_combo(combo_t *combo, uint16_t keycode,
 bool process_combo(uint16_t keycode, keyrecord_t *record) {
   bool is_combo_key = false;
   drop_buffer = false;
-  bool no_combo_keys_pressed = false;
+  bool no_combo_keys_pressed = true;
 
   for (current_combo_index = 0; current_combo_index < COMBO_COUNT;
        ++current_combo_index) {
     combo_t *combo = &key_combos[current_combo_index];
     is_combo_key |= process_single_combo(combo, keycode, record);
-    no_combo_keys_pressed |= NO_COMBO_KEYS_ARE_DOWN;
+    no_combo_keys_pressed = no_combo_keys_pressed && NO_COMBO_KEYS_ARE_DOWN;
   }
 
   if (drop_buffer) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I botched the merge conflict resolution in #2561 , inverting the logic for when combos should be re-enabled. This PR fixes #5595 that came as a result; on master with combos I can reproduce stuck keys and swallowed keypresses when using `SEND_KEYS()` but with these changes I cannot. It'd be great if @noahfrederick could confirm!

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #5595

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
