### PR TITLE
Use QUANTUM_LIB_SRC for i2c_master.c inclusion

### DIFF
--- a/common_features.mk
+++ b/common_features.mk
@@ -133,7 +133,7 @@ ifeq ($(strip $(LED_MATRIX_ENABLE)), IS31FL3731)
     OPT_DEFS += -DIS31FL3731
     COMMON_VPATH += $(DRIVER_PATH)/issi
     SRC += is31fl3731-simple.c
-    SRC += i2c_master.c
+    QUANTUM_LIB_SRC += i2c_master.c
 endif
 
 RGB_MATRIX_ENABLE ?= no
@@ -157,21 +157,21 @@ ifeq ($(strip $(RGB_MATRIX_ENABLE)), IS31FL3731)
     OPT_DEFS += -DIS31FL3731 -DSTM32_I2C -DHAL_USE_I2C=TRUE
     COMMON_VPATH += $(DRIVER_PATH)/issi
     SRC += is31fl3731.c
-    SRC += i2c_master.c
+    QUANTUM_LIB_SRC += i2c_master.c
 endif
 
 ifeq ($(strip $(RGB_MATRIX_ENABLE)), IS31FL3733)
     OPT_DEFS += -DIS31FL3733 -DSTM32_I2C -DHAL_USE_I2C=TRUE
     COMMON_VPATH += $(DRIVER_PATH)/issi
     SRC += is31fl3733.c
-    SRC += i2c_master.c
+    QUANTUM_LIB_SRC += i2c_master.c
 endif
 
 ifeq ($(strip $(RGB_MATRIX_ENABLE)), IS31FL3737)
     OPT_DEFS += -DIS31FL3737 -DSTM32_I2C -DHAL_USE_I2C=TRUE
     COMMON_VPATH += $(DRIVER_PATH)/issi
     SRC += is31fl3737.c
-    SRC += i2c_master.c
+    QUANTUM_LIB_SRC += i2c_master.c
 endif
 
 ifeq ($(strip $(RGB_MATRIX_ENABLE)), WS2812)
@@ -271,7 +271,7 @@ ifeq ($(strip $(HAPTIC_ENABLE)), DRV2605L)
     COMMON_VPATH += $(DRIVER_PATH)/haptic
     SRC += haptic.c
     SRC += DRV2605L.c
-    SRC += i2c_master.c
+    QUANTUM_LIB_SRC += i2c_master.c
     OPT_DEFS += -DHAPTIC_ENABLE
     OPT_DEFS += -DDRV2605L
 endif

--- a/drivers/qwiic/qwiic.mk
+++ b/drivers/qwiic/qwiic.mk
@@ -2,9 +2,7 @@ ifneq ($(strip $(QWIIC_ENABLE)),)
   COMMON_VPATH += $(DRIVER_PATH)/qwiic
   OPT_DEFS += -DQWIIC_ENABLE
   SRC += qwiic.c
-  ifeq ($(filter "i2c_master.c", $(SRC)),)
-    SRC += i2c_master.c
-  endif
+  QUANTUM_LIB_SRC += i2c_master.c
 endif
 
 ifneq ($(filter JOYSTIIC, $(QWIIC_ENABLE)),)

--- a/keyboards/ergodox_ez/rules.mk
+++ b/keyboards/ergodox_ez/rules.mk
@@ -16,6 +16,7 @@
 
 # # project specific files
 SRC += matrix.c
+QUANTUM_LIB_SRC += i2c_master.c
 
 # MCU name
 MCU = atmega32u4
@@ -84,10 +85,5 @@ API_SYSEX_ENABLE = no
 RGBLIGHT_ENABLE = yes
 RGB_MATRIX_ENABLE = no # enable later
 DEBOUNCE_TYPE = eager_pr
-
-ifeq ($(strip $(RGB_MATRIX_ENABLE)), no)
-  SRC += i2c_master.c
-endif
-
 
 LAYOUTS = ergodox

--- a/keyboards/model01/rules.mk
+++ b/keyboards/model01/rules.mk
@@ -1,5 +1,5 @@
-SRC += i2c_master.c \
-	   leds.c \
+QUANTUM_LIB_SRC += i2c_master.c
+SRC += leds.c \
 	   matrix.c
 
 # MCU name


### PR DESCRIPTION
Using QUANTUM_LIB_SRC prevents the warning when multiple sources add the i2c_master.c file. Boards such as the Ergodox EZ Glow see this warning every time they compile because the board uses the file in general, and because the RGB LED Matrix requires it, as well.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
   - [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
