### PR TITLE
fix LIB_SRC and QUANTUM_LIB_SRC for ARM(chibios)

### DIFF
--- a/tmk_core/arm_atsam.mk
+++ b/tmk_core/arm_atsam.mk
@@ -6,7 +6,7 @@ CC = arm-none-eabi-gcc
 OBJCOPY = arm-none-eabi-objcopy
 OBJDUMP = arm-none-eabi-objdump
 SIZE = arm-none-eabi-size
-AR = arm-none-eabi-ar rcs
+AR = arm-none-eabi-ar
 NM = arm-none-eabi-nm
 HEX = $(OBJCOPY) -O $(FORMAT) -R .eeprom -R .fuse -R .lock -R .signature
 EEP = $(OBJCOPY) -j .eeprom --set-section-flags=.eeprom="alloc,load" --change-section-lma .eeprom=0 --no-change-warnings -O $(FORMAT)

--- a/tmk_core/avr.mk
+++ b/tmk_core/avr.mk
@@ -6,13 +6,15 @@ CC = avr-gcc
 OBJCOPY = avr-objcopy
 OBJDUMP = avr-objdump
 SIZE = avr-size
-AR = avr-ar rcs
+AR = avr-ar
 NM = avr-nm
 HEX = $(OBJCOPY) -O $(FORMAT) -R .eeprom -R .fuse -R .lock -R .signature
 EEP = $(OBJCOPY) -j .eeprom --set-section-flags=.eeprom="alloc,load" --change-section-lma .eeprom=0 --no-change-warnings -O $(FORMAT)
 BIN =
 
 COMMON_VPATH += $(DRIVER_PATH)/avr
+
+ARFLAGS =  rcs
 
 COMPILEFLAGS += -funsigned-char
 COMPILEFLAGS += -funsigned-bitfields

--- a/tmk_core/avr.mk
+++ b/tmk_core/avr.mk
@@ -14,8 +14,6 @@ BIN =
 
 COMMON_VPATH += $(DRIVER_PATH)/avr
 
-ARFLAGS =  rcs
-
 COMPILEFLAGS += -funsigned-char
 COMPILEFLAGS += -funsigned-bitfields
 COMPILEFLAGS += -ffunction-sections

--- a/tmk_core/chibios.mk
+++ b/tmk_core/chibios.mk
@@ -151,8 +151,6 @@ BIN = $(OBJCOPY) -O binary
 
 COMMON_VPATH += $(DRIVER_PATH)/arm
 
-ARFLAGS =  rcs
-
 THUMBFLAGS = -DTHUMB_PRESENT -mno-thumb-interwork -DTHUMB_NO_INTERWORKING -mthumb -DTHUMB
 
 COMPILEFLAGS += -fomit-frame-pointer

--- a/tmk_core/chibios.mk
+++ b/tmk_core/chibios.mk
@@ -151,6 +151,8 @@ BIN = $(OBJCOPY) -O binary
 
 COMMON_VPATH += $(DRIVER_PATH)/arm
 
+ARFLAGS =  rcs
+
 THUMBFLAGS = -DTHUMB_PRESENT -mno-thumb-interwork -DTHUMB_NO_INTERWORKING -mthumb -DTHUMB
 
 COMPILEFLAGS += -fomit-frame-pointer

--- a/tmk_core/rules.mk
+++ b/tmk_core/rules.mk
@@ -331,7 +331,7 @@ $1/%.o : %.S $1/asflags.txt $1/compiler.txt | $(BEGIN)
 $1/%.a : $1/%.o
 	@mkdir -p $$(@D)
 	@$(SILENT) || printf "Archiving: $$<" | $$(AWK_CMD)
-	$$(eval CMD=$$(AR) $$@ $$<)
+	$$(eval CMD=$$(AR) $$(ARFLAGS) $$@ $$<)
 	@$$(BUILD_CMD)
 
 $1/force:

--- a/tmk_core/rules.mk
+++ b/tmk_core/rules.mk
@@ -331,7 +331,7 @@ $1/%.o : %.S $1/asflags.txt $1/compiler.txt | $(BEGIN)
 $1/%.a : $1/%.o
 	@mkdir -p $$(@D)
 	@$(SILENT) || printf "Archiving: $$<" | $$(AWK_CMD)
-	$$(eval CMD=$$(AR) $$(ARFLAGS) $$@ $$<)
+	$$(eval CMD=$$(AR) rcs $$@ $$<)
 	@$$(BUILD_CMD)
 
 $1/force:


### PR DESCRIPTION
## Description

On ARM targets, the LIB_SRC and QUANTUM_LIB_SRC macros have been corrected as they do not function properly.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #5617

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).