### PR TITLE
Fix macro keycode for alpha keyboard

### DIFF
--- a/keyboards/alpha/keymaps/default/keymap.c
+++ b/keyboards/alpha/keymaps/default/keymap.c
@@ -6,7 +6,7 @@
 #define OTHER 3
 
 enum custom_keycodes {
-	MACRO1
+	MACRO1 = SAFE_RANGE
 };
 
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

Set custom key codes  for alpha to start at SAFE_RANGE

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Set the custom keycode to start at SAFE_RANGE.
This will change Layer 3 KC_NO to not behave like the custom key code.

@PyrooL If all keys on layer 3 should behave like your custom key code, I can change all KC_NO to MACRO1.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
