### PR TITLE
Fix wake from suspend LED functionality for Massdrop CTRL and ALT

### DIFF
--- a/tmk_core/common/arm_atsam/suspend.c
+++ b/tmk_core/common/arm_atsam/suspend.c
@@ -78,7 +78,13 @@ void suspend_wakeup_init_kb(void) {
  */
 void suspend_wakeup_init(void) {
 #ifdef RGB_MATRIX_ENABLE
+#ifdef USE_MASSDROP_CONFIGURATOR
+    if (led_enabled) {
+        I2C3733_Control_Set(1);
+    }
+#else
     I2C3733_Control_Set(1);
+#endif
 #endif
 
     suspend_wakeup_init_kb();


### PR DESCRIPTION
When waking from suspend, only enable the LED drivers if they were not previously set to disabled by the user. This functionality was removed by the recent updates to adapt Massdrop keyboards to QMK RGB Matrix. Affects Massdrop CTRL and ALT keyboards compiled using Massdrop Configurator mode.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
