### PR TITLE
[core] Fix for eager_pr #5643

### DIFF
--- a/quantum/debounce/eager_pr.c
+++ b/quantum/debounce/eager_pr.c
@@ -48,11 +48,12 @@ void debounce_init(uint8_t num_rows) {
 
 void debounce(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, bool changed) {
   uint8_t current_time = timer_read() % MAX_DEBOUNCE;
+  bool needed_update = counters_need_update;
   if (counters_need_update) {
     update_debounce_counters(num_rows, current_time);
   }
 
-  if (changed) {
+  if (changed || (needed_update && !counters_need_update)) {
     transfer_matrix_values(raw, cooked, num_rows, current_time);
   }
 }


### PR DESCRIPTION
Added extra transfer_matrix_values() call whenever counters don't need updating

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
My theory is that due to shared counter usage, we also need to `transfer_matrix_values()` whenever the we change from a state of `counters_need_update` to `!counters_need_update`. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #5643 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
