### PR TITLE
Only increment Enable status for RGB Matrix if it supports it

### DIFF
--- a/quantum/rgb_matrix.c
+++ b/quantum/rgb_matrix.c
@@ -515,7 +515,9 @@ void rgb_matrix_toggle(void) {
   rgb_matrix_config.enable++;
 #else
   rgb_matrix_config.enable ^= 1;
-  if (rgb_matrix_config.enable > 1) { rgb_matrix_config.enable = 0; } // make sure that if we are treating this as a bool, that it is only 1 or 0.
+  if (rgb_matrix_config.enable > 1) {  // make sure that if we are treating this  as a bool, that it is only 1 or 0.
+    rgb_matrix_config.enable = 0; 
+  }
 #endif
   if (!rgb_matrix_config.enable) {
     rgb_task_state = STARTING;

--- a/quantum/rgb_matrix.c
+++ b/quantum/rgb_matrix.c
@@ -511,7 +511,11 @@ void rgb_matrix_set_suspend_state(bool state) {
 }
 
 void rgb_matrix_toggle(void) {
+#ifdef RGB_MATRIX_EXTRA_TOG
   rgb_matrix_config.enable++;
+#else
+  rgb_matrix_config.enable ^= 1;
+#endif
   if (!rgb_matrix_config.enable) {
     rgb_task_state = STARTING;
   }

--- a/quantum/rgb_matrix.c
+++ b/quantum/rgb_matrix.c
@@ -515,6 +515,7 @@ void rgb_matrix_toggle(void) {
   rgb_matrix_config.enable++;
 #else
   rgb_matrix_config.enable ^= 1;
+  if (rgb_matrix_config.enable > 1) { rgb_matrix_config.enable = 0; } // make sure that if we are treating this as a bool, that it is only 1 or 0.
 #endif
   if (!rgb_matrix_config.enable) {
     rgb_task_state = STARTING;


### PR DESCRIPTION
## Description

Right now, the RGB Matrix toggle code increments the variable. That's fine, if `RGB_MATRIX_EXTRA_TOG` is defined.  But it's not normally.  So, on non-massdrop boards, it's creating an issue where you have to hit the toggle multiple times. 

This should fix the issue.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation



## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
   - [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
