### PR TITLE
Removed forced in lining for lib8tion functions

### DIFF
--- a/lib/lib8tion/lib8tion.h
+++ b/lib/lib8tion/lib8tion.h
@@ -167,8 +167,8 @@ Lib8tion is pronounced like 'libation': lie-BAY-shun
 
 #include <stdint.h>
 
-#define LIB8STATIC __attribute__ ((unused)) static inline
-#define LIB8STATIC_ALWAYS_INLINE __attribute__ ((always_inline)) static inline
+#define LIB8STATIC static inline
+#define LIB8STATIC_ALWAYS_INLINE static inline
 
 #if !defined(__AVR__)
 #include <string.h>


### PR DESCRIPTION
Reduces firmware size at a slight cost for performance.

## Description

Using the SOL keyboard, atmega32u4 mcu and lto enabled

Firmware size:
`make sol:xulkal`
Before: 2948 bytes free
After: 3118 bytes free
Savings: 170 bytes

Performance:
rgb_matrix_multisplash max 8 presses
Before Worse Case: 10ms
After Worse Case: 10ms
Sub MS performance change, cannot measure.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
