### PR TITLE
Forgot to omit k05 from the electrical matrix in hhkb layout

### DIFF
--- a/keyboards/exclusive/e6v2/bmc/bmc.h
+++ b/keyboards/exclusive/e6v2/bmc/bmc.h
@@ -72,7 +72,7 @@
     k01, k02, k75, k08, k09                                                    \
 ) \
 { \
-    { KC_NO, k01,   k02,   KC_NO, KC_NO, k05,   KC_NO, KC_NO, k08,   k09,   KC_NO }, \
+    { KC_NO, k01,   k02,   KC_NO, KC_NO, KC_NO,   KC_NO, KC_NO, k08,   k09,   KC_NO }, \
     { k10,   k11,   k12,   k13,   k14,   k15,   KC_NO, KC_NO, k18,   k19,   KC_NO }, \
     { k20,   k21,   k22,   k23,   k24,   k25,   k26,   KC_NO, k28,   k29,   KC_NO }, \
     { k30,   k31,   k32,   k33,   k34,   k35,   k36,   k37,   k38,   k39,   KC_NO }, \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
