### PR TITLE
Fix my userspace RGB bug

### DIFF
--- a/users/mechmerlin/changelog.md
+++ b/users/mechmerlin/changelog.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to my userspace will be documented in this file.
 
+## [0.2.2] - 2019-04-22
+### Fixed
+- `config.h` usage of turning on `RGBLIGHT_ENABLE` when it is not enabled on boards other than my two clueboards were causing issues with boards that didn't have RGB underglow on it. 
+
 ## [0.2.1] - 2019-03-01
 ### Fixed
 - `config.h` usage of `#ifdef RGBLIGHT_ENABLE` caused problems for other of my boards that had `RGBLIGHT_ENABLE`.  

--- a/users/mechmerlin/config.h
+++ b/users/mechmerlin/config.h
@@ -21,17 +21,11 @@
     #ifndef RGBLIGHT_ENABLE
         #define RGBLIGHT_ENABLE
     #endif
-
     #ifndef AUDIO_CLICKY
         #define AUDIO_CLICKY
     #endif
-
 #elif defined(KEYBOARD_clueboard_66_hotswap_gen1)
     #ifndef AUDIO_CLICKY
         #define AUDIO_CLICKY
-    #endif
-#else
-    #ifndef RGBLIGHT_ENABLE
-        #define RGBLIGHT_ENABLE
     #endif
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Turns out I was enabling RGBLIGHT_ENABLE on my boards regardless if there was a pin defined or not. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
