### PR TITLE
FIX rgblight.c split sync bug

### DIFF
--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -38,11 +38,13 @@
   /* for split keyboard */
   #define RGBLIGHT_SPLIT_SET_CHANGE_MODE         rgblight_status.change_flags |= RGBLIGHT_STATUS_CHANGE_MODE
   #define RGBLIGHT_SPLIT_SET_CHANGE_HSVS         rgblight_status.change_flags |= RGBLIGHT_STATUS_CHANGE_HSVS
+  #define RGBLIGHT_SPLIT_SET_CHANGE_MODEHSVS     rgblight_status.change_flags |= (RGBLIGHT_STATUS_CHANGE_MODE|RGBLIGHT_STATUS_CHANGE_HSVS)
   #define RGBLIGHT_SPLIT_SET_CHANGE_TIMER_ENABLE rgblight_status.change_flags |= RGBLIGHT_STATUS_CHANGE_TIMER
   #define RGBLIGHT_SPLIT_ANIMATION_TICK          rgblight_status.change_flags |= RGBLIGHT_STATUS_ANIMATION_TICK
 #else
   #define RGBLIGHT_SPLIT_SET_CHANGE_MODE
   #define RGBLIGHT_SPLIT_SET_CHANGE_HSVS
+  #define RGBLIGHT_SPLIT_SET_CHANGE_MODEHSVS
   #define RGBLIGHT_SPLIT_SET_CHANGE_TIMER_ENABLE
   #define RGBLIGHT_SPLIT_ANIMATION_TICK
 #endif
@@ -221,6 +223,7 @@ void eeconfig_update_rgblight_default(void) {
   rgblight_config.sat = 255;
   rgblight_config.val = RGBLIGHT_LIMIT_VAL;
   rgblight_config.speed = 0;
+  RGBLIGHT_SPLIT_SET_CHANGE_MODEHSVS;
   eeconfig_update_rgblight(rgblight_config.raw);
 }
 
@@ -249,7 +252,7 @@ void rgblight_init(void) {
     eeconfig_update_rgblight_default();
   }
   rgblight_config.raw = eeconfig_read_rgblight();
-  RGBLIGHT_SPLIT_SET_CHANGE_HSVS;
+  RGBLIGHT_SPLIT_SET_CHANGE_MODEHSVS;
   if (!rgblight_config.mode) {
     dprintf("rgblight_init rgblight_config.mode = 0. Write default values to EEPROM.\n");
     eeconfig_update_rgblight_default();

--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -279,6 +279,7 @@ uint32_t rgblight_read_dword(void) {
 }
 
 void rgblight_update_dword(uint32_t dword) {
+  RGBLIGHT_SPLIT_SET_CHANGE_MODEHSVS;
   rgblight_config.raw = dword;
   if (rgblight_config.enable)
     rgblight_mode_noeeprom(rgblight_config.mode);


### PR DESCRIPTION
## Description

Fixed that sync information was not notified to slave when `rgblight_update_dword()` and `eeconfig_update_rgblight_default()` were executed.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).