### PR TITLE
Get creating build environment with Nix working on macOS when tracking latest stable channel

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,8 +1,17 @@
-# dfu-programmer doesn't have darwin on it's list of supported platforms
-{ pkgs ? import <nixpkgs> { config = { allowUnsupportedSystem = true; }; }
-, avr ? true, arm ? true, teensy ? true }:
+# Compatibility note:
+# This nix expression is designed to work on systems tracking the latest stable channel or unstable.
+# (Currently 19.03)
+{ pkgs ? import <nixpkgs> {}, avr ? true, arm ? true, teensy ? true }:
 
-with pkgs;
+# Required because gcc-arm-embeded fails to build on macOS when tracking nixpkgs-19.03-darwin.
+with if pkgs.stdenv.isDarwin && arm then
+   (import (pkgs.fetchFromGitHub {
+      owner  = "NixOS";
+      repo   = "nixpkgs-channels";
+      rev    = "9ebc6ad";
+      sha256 = "1hv53kw8nwg9k3kim19ykbmn3yksgmlw1gjbd6d5midhmjjc6mhv";
+    }) { config.allowUnsupportedSystem = true; }).pkgs
+    else pkgs;
 let
   avrbinutils = pkgsCross.avr.buildPackages.binutils;
   avrlibc = pkgsCross.avr.libcCross;


### PR DESCRIPTION
## Description
Creating the build environment for QMK using `nix-shell` failed on my Mac running macOS 10.14.4 with the following error, which is a result of `gcc-arm-embedded` failing to build:
```
gold-threads.cc:288:13: error: expected expression
    : once_(PTHREAD_ONCE_INIT)
            ^
/nix/store/mkfq1a1i6n66fahlcjvw890xj32zvlqp-Libsystem-osx-10.11.6/include/pthread.h:245:27: note: expanded from macro 'PTHREAD_ONCE_INIT'
#define PTHREAD_ONCE_INIT {_PTHREAD_ONCE_SIG_init, {0}}
                          ^
1 error generated.
make[4]: *** [Makefile:1123: gold-threads.o] Error 1
make[4]: Leaving directory '/private/tmp/nix-build-arm-none-eabi-binutils-2.31.1.drv-0/binutils-2.31.1/gold'
make[3]: *** [Makefile:1146: all-recursive] Error 1
make[3]: Leaving directory '/private/tmp/nix-build-arm-none-eabi-binutils-2.31.1.drv-0/binutils-2.31.1/gold'
make[2]: *** [Makefile:886: all] Error 2
make[2]: Leaving directory '/private/tmp/nix-build-arm-none-eabi-binutils-2.31.1.drv-0/binutils-2.31.1/gold'
make[1]: *** [Makefile:6072: all-gold] Error 2
make[1]: Leaving directory '/private/tmp/nix-build-arm-none-eabi-binutils-2.31.1.drv-0/binutils-2.31.1'
make: *** [Makefile:878: all] Error 2
builder for '/nix/store/8cw63ya5y4klxgyh7j79kj8y3ynlc2zz-arm-none-eabi-binutils-2.31.1.drv' failed with exit code 2
cannot build derivation '/nix/store/hvn0hvx4y55nzq39dlssssvgzl3y2xdc-arm-none-eabi-binutils-wrapper-2.31.1.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/iq121vzd93z4krm2p08frdl90kqsrfcw-arm-none-eabi-binutils-wrapper-2.31.1.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/qjh8wwrgsc3zwsjma1wmsr62dy6s4kg7-arm-none-eabi-stage-final-gcc-debug-wrapper-7.4.0.drv': 1 dependencies couldn't be built
error: build of '/nix/store/qjh8wwrgsc3zwsjma1wmsr62dy6s4kg7-arm-none-eabi-stage-final-gcc-debug-wrapper-7.4.0.drv' failed
```

 A recent pull request in the `nixpkgs` repository added support for darwin, https://github.com/NixOS/nixpkgs/pull/58972. Unfortunately this isn't in any stable channel yet.

To resolve the issue, I've added the `nixpkgs-unstable` channel to the `nix-shell` environment, and then used the unstable version of the `gcc-arm-embedded` package if `stdenv.isDarwin` is `true`.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation
- [x] Other

## Checklist
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).