### PR TITLE
Fix wakeup function on ChibiOS

### DIFF
--- a/tmk_core/common/chibios/suspend.c
+++ b/tmk_core/common/chibios/suspend.c
@@ -82,7 +82,7 @@ void suspend_wakeup_init_user(void) { }
  */
 __attribute__ ((weak))
 void suspend_wakeup_init_kb(void) {
-  suspend_power_down_user();
+  suspend_wakeup_init_user();
 }
 
 /** \brief suspend wakeup condition


### PR DESCRIPTION
Somebody was a very, very bad boy, and did a poor job of copy-pasting

## Description

Added the wrong function when adding suspend functions.  

This fixes it, and allows proper wake trigger handling for ChibiOS boards. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

*  Mine

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
