### PR TITLE
QMK Configurator support for the emptystring studio NQG

### DIFF
--- a/keyboards/emptystring/NQG/info.json
+++ b/keyboards/emptystring/NQG/info.json
@@ -1,0 +1,50 @@
+{
+    "keyboard_name": "NQG (Not Quite Gherkin)",
+    "url": "",
+    "maintainer": "culturalsnow",
+    "width": 11,
+    "height": 4,
+    "layouts": {
+        "LAYOUT": {
+            "layout": [
+                {"label":"Q", "x":1, "y":0},
+                {"label":"W", "x":2, "y":0},
+                {"label":"E", "x":3, "y":0},
+                {"label":"R", "x":4, "y":0},
+                {"label":"T", "x":5, "y":0},
+                {"label":"Y", "x":6, "y":0},
+                {"label":"U", "x":7, "y":0},
+                {"label":"I", "x":8, "y":0},
+                {"label":"O", "x":9, "y":0},
+                {"label":"P", "x":10, "y":0},
+                {"label":"A", "x":1, "y":1},
+                {"label":"S", "x":2, "y":1},
+                {"label":"D", "x":3, "y":1},
+                {"label":"F", "x":4, "y":1},
+                {"label":"G", "x":5, "y":1},
+                {"label":"H", "x":6, "y":1},
+                {"label":"J", "x":7, "y":1},
+                {"label":"K", "x":8, "y":1},
+                {"label":"L", "x":9, "y":1},
+                {"label":"; '", "x":10, "y":1},
+                {"label":"Z", "x":1, "y":2},
+                {"label":"X", "x":2, "y":2},
+                {"label":"C", "x":3, "y":2},
+                {"label":"V", "x":4, "y":2},
+                {"label":"B", "x":5, "y":2},
+                {"label":"N", "x":6, "y":2},
+                {"label":"M", "x":7, "y":2},
+                {"label":",", "x":8, "y":2},
+                {"label":".", "x":9, "y":2},
+                {"label":"/ Enter", "x":10, "y":2},
+                {"label":"Shift / Tab", "x":0, "y":2},
+                {"label":"LT(_LOWER, KC_ESC)", "x":3, "y":3},
+                {"label":"Ctrl / Backspace", "x":4, "y":3},
+                {"label":"Ctrl / Backspace", "x":5, "y":3},
+                {"label":"Space", "x":6, "y":3},
+                {"label":"Space", "x":7, "y":3},
+                {"label":"MO(_RAISE)", "x":8, "y":3}
+            ]
+        }
+    }
+}

--- a/keyboards/emptystring/NQG/readme.md
+++ b/keyboards/emptystring/NQG/readme.md
@@ -4,7 +4,7 @@
 
 NQG (Not Quite Gherkin) is a 30% ortholinear keyboard with a macro key and dedicated row for thumb keys, made by emptystring studio.
 
-Keyboard Maintainer: [Culturalsnow](http://github.com/culturalsnow)
+Keyboard Maintainer: [Culturalsnow](http://github.com/culturalsnow)  
 Hardware Supported: NQG PCB, Pro Micro  
 Hardware Availability: Kits are available from [SA_EndlessGame](http://twitter.com/SA_EndlessGame)  
 


### PR DESCRIPTION
## Description

Adds QMK Configurator support for the NQG by emptystring studio.

Spotted this while looking into something else.


## Notes

The layout visually in Configurator won't match the way the layout macro is in the source files, but I chose to do it this way because it doesn't require changing any of @culturalsnow's source code.


## Commit Log

### NQG Configurator support (b96c898)

### Fix line break in readme file (67527cb)
