### PR TITLE
New keymap for KBD67 hotswap

### DIFF
--- a/keyboards/kbdfans/kbd67/hotswap/keymaps/bcat/keymap.c
+++ b/keyboards/kbdfans/kbd67/hotswap/keymaps/bcat/keymap.c
@@ -1,0 +1,29 @@
+#include QMK_KEYBOARD_H
+
+enum layer {
+    LAYER_DEFAULT,
+    LAYER_FUNCTION,
+};
+
+/* Switch to function layer when held. */
+#define LY_FUNC MO(LAYER_FUNCTION)
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    /* Default layer: http://www.keyboard-layout-editor.com/#/gists/dd675b40cc4df2c7bb78847ac29f5988 */
+    [LAYER_DEFAULT] = LAYOUT(
+        KC_ESC,   KC_1,     KC_2,     KC_3,     KC_4,     KC_5,     KC_6,     KC_7,     KC_8,     KC_9,     KC_0,     KC_MINS,  KC_EQL,   KC_BSLS,  KC_GRV,   KC_HOME,  \
+        KC_TAB,   KC_Q,     KC_W,     KC_E,     KC_R,     KC_T,     KC_Y,     KC_U,     KC_I,     KC_O,     KC_P,     KC_LBRC,  KC_RBRC,  KC_BSPC,  KC_PGUP,            \
+        KC_LCTL,  KC_A,     KC_S,     KC_D,     KC_F,     KC_G,     KC_H,     KC_J,     KC_K,     KC_L,     KC_SCLN,  KC_QUOT,  KC_ENT,   KC_PGDN,                      \
+        KC_LSFT,  KC_Z,     KC_X,     KC_C,     KC_V,     KC_B,     KC_N,     KC_M,     KC_COMM,  KC_DOT,   KC_SLSH,  KC_RSFT,  KC_UP,    KC_END,                       \
+        KC_LCTL,  KC_LGUI,  KC_LALT,  KC_SPC,   KC_RALT,  LY_FUNC,  KC_LEFT,  KC_DOWN,  KC_RGHT                                                                         \
+    ),
+
+    /* Function layer: http://www.keyboard-layout-editor.com/#/gists/f29128427f674c43777f045e363d1b44 */
+    [LAYER_FUNCTION] = LAYOUT(
+        _______,  KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   _______,  _______,  _______,  \
+        _______,  KC_MPLY,  KC_VOLU,  KC_MSTP,  _______,  _______,  EEP_RST,  _______,  _______,  KC_INS,   KC_PSCR,  KC_SLCK,  KC_PAUS,  KC_DEL,   _______,            \
+        KC_CAPS,  KC_MPRV,  KC_VOLD,  KC_MNXT,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,                      \
+        _______,  _______,  KC_MUTE,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,                      \
+        _______,  _______,  _______,  _______,  KC_APP,   _______,  _______,  _______,  _______                                                                         \
+    ),
+};

--- a/keyboards/kbdfans/kbd67/hotswap/keymaps/bcat/readme.md
+++ b/keyboards/kbdfans/kbd67/hotswap/keymaps/bcat/readme.md
@@ -1,0 +1,13 @@
+# bcat's Quefrency 65% layout
+
+This is pretty much a stock 65% split keyboard layout, with an HHKB-style
+(split) backspace and media keys in the function layer centered around the WASD
+cluster.
+
+## Default layer
+
+![Default layer layout](https://i.imgur.com/stwELz3.png)
+
+## Function layer
+
+![Function layer layout](https://i.imgur.com/K5Z5qbw.png)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This is pretty much a stock 65% split keyboard layout, with an HHKB-style (split) backspace and media keys in the function layer centered around the WASD cluster.

Basically the same as [my Quefrency keymap](https://github.com/qmk/qmk_firmware/tree/master/keyboards/keebio/quefrency/keymaps/bcat), just without mouse keys, since I don't have a use for those on this keeb, and without RGB keys since this keeb has no underglow. :)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [X] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
