### PR TITLE
Adding ortho_4x12 & planck_mit layouts for KBD4X.

### DIFF
--- a/keyboards/kbdfans/kbd4x/kbd4x.h
+++ b/keyboards/kbdfans/kbd4x/kbd4x.h
@@ -21,13 +21,13 @@
 	k00, k01, k02, k03, k04, k05, k06, k07, k08, k09, k0a, k0b, \
 	k10, k11, k12, k13, k14, k15, k16, k17, k18, k19, k1a, k1b, \
 	k20, k21, k22, k23, k24, k25, k26, k27, k28, k29, k2a, k2b, \
-	k30, k31, k32, k33, k34,    k35,   k37, k38, k39, k3a, k3b \
+	k30, k31, k32, k33, k34,    k35,   k37, k38, k39, k3a, k3b  \
 ) \
 { \
 	{ k00, k01, k02, k03, k04, k05, k06,   k07, k08, k09, k0a, k0b }, \
 	{ k10, k11, k12, k13, k14, k15, k16,   k17, k18, k19, k1a, k1b }, \
 	{ k20, k21, k22, k23, k24, k25, k26,   k27, k28, k29, k2a, k2b }, \
-	{ k30, k31, k32, k33, k34, k35, KC_NO, k37, k38, k39, k3a, k3b } \
+	{ k30, k31, k32, k33, k34, k35, KC_NO, k37, k38, k39, k3a, k3b }  \
 }
 
 // The PCB does support a grid layout, but the case does not.
@@ -35,11 +35,24 @@
 	k00, k01, k02, k03, k04, k05, k06, k07, k08, k09, k0a, k0b, \
 	k10, k11, k12, k13, k14, k15, k16, k17, k18, k19, k1a, k1b, \
 	k20, k21, k22, k23, k24, k25, k26, k27, k28, k29, k2a, k2b, \
-	k30, k31, k32, k33, k34, k35, k36, k37, k38, k39, k3a, k3b \
+	k30, k31, k32, k33, k34, k35, k36, k37, k38, k39, k3a, k3b  \
 ) \
 { \
 	{ k00, k01, k02, k03, k04, k05, k06, k07, k08, k09, k0a, k0b }, \
 	{ k10, k11, k12, k13, k14, k15, k16, k17, k18, k19, k1a, k1b }, \
 	{ k20, k21, k22, k23, k24, k25, k26, k27, k28, k29, k2a, k2b }, \
-	{ k30, k31, k32, k33, k34, k35, k36, k37, k38, k39, k3a, k3b } \
+	{ k30, k31, k32, k33, k34, k35, k36, k37, k38, k39, k3a, k3b }  \
+}
+
+#define LAYOUT_kc_ortho_4x12( \
+	k00, k01, k02, k03, k04, k05, k06, k07, k08, k09, k0a, k0b, \
+	k10, k11, k12, k13, k14, k15, k16, k17, k18, k19, k1a, k1b, \
+	k20, k21, k22, k23, k24, k25, k26, k27, k28, k29, k2a, k2b, \
+	k30, k31, k32, k33, k34, k35, k36, k37, k38, k39, k3a, k3b  \
+) \
+{ \
+	{ KC_##k00, KC_##k01, KC_##k02, KC_##k03, KC_##k04, KC_##k05, KC_##k06, KC_##k07, KC_##k08, KC_##k09, KC_##k0a, KC_##k0b }, \
+	{ KC_##k10, KC_##k11, KC_##k12, KC_##k13, KC_##k14, KC_##k15, KC_##k16, KC_##k17, KC_##k18, KC_##k19, KC_##k1a, KC_##k1b }, \
+	{ KC_##k20, KC_##k21, KC_##k22, KC_##k23, KC_##k24, KC_##k25, KC_##k26, KC_##k27, KC_##k28, KC_##k29, KC_##k2a, KC_##k2b }, \
+	{ KC_##k30, KC_##k31, KC_##k32, KC_##k33, KC_##k34, KC_##k35, KC_##k36, KC_##k37, KC_##k38, KC_##k39, KC_##k3a, KC_##k3b }  \
 }

--- a/keyboards/kbdfans/kbd4x/rules.mk
+++ b/keyboards/kbdfans/kbd4x/rules.mk
@@ -79,3 +79,5 @@ BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
 AUDIO_ENABLE = no           # Audio output on port C6
 FAUXCLICKY_ENABLE = no      # Use buzzer to emulate clicky switches
 HD44780_ENABLE = no 		# Enable support for HD44780 based LCDs (+400)
+
+LAYOUTS = ortho_4x12 planck_mit

--- a/keyboards/kbdfans/kbd4x/rules.mk
+++ b/keyboards/kbdfans/kbd4x/rules.mk
@@ -65,7 +65,7 @@ BOOTLOADER = atmel-dfu
 BOOTMAGIC_ENABLE = lite     # Virtual DIP switch configuration(+1000)
 MOUSEKEY_ENABLE = no        # Mouse keys(+4700)
 EXTRAKEY_ENABLE = yes       # Audio control and System control(+450)
-CONSOLE_ENABLE = yes        # Console for debug(+400)
+CONSOLE_ENABLE = no        # Console for debug(+400)
 COMMAND_ENABLE = yes        # Commands for debug and configuration
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
 SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend


### PR DESCRIPTION
Enabling ortho_4x12 & planck_mit layouts for KBD4X.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ x] Keymap/layout/userspace (addition or update)
- [ ] Documentation
