### PR TITLE
Implement kb function for rgb matrix to led lookup

### DIFF
--- a/keyboards/sol/sol.c
+++ b/keyboards/sol/sol.c
@@ -1,1 +1,20 @@
 #include "sol.h"
+
+#if defined(RGB_MATRIX_ENABLE)
+uint8_t rgb_matrix_map_row_column_to_led_kb(uint8_t row, uint8_t column, uint8_t *led_i) {
+  if (row == 4 && column == 5) {
+    led_i[0] = 33;
+    return 1;
+  } else if (row == 4 && column == 6) {
+    led_i[0] = 34;
+    return 1;
+  } else if (row == 10 && column == 5) {
+    led_i[0] = 68;
+    return 1;
+  } else if (row == 10 && column == 6) {
+    led_i[0] = 69;
+    return 1;
+  }
+  return 0;
+}
+#endif

--- a/quantum/rgb_matrix.c
+++ b/quantum/rgb_matrix.c
@@ -127,9 +127,14 @@ void eeconfig_debug_rgb_matrix(void) {
   dprintf("rgb_matrix_config.speed = %d\n", rgb_matrix_config.speed);
 }
 
+__attribute__ ((weak))
+uint8_t rgb_matrix_map_row_column_to_led_kb(uint8_t row, uint8_t column, uint8_t *led_i) {
+  return 0;
+}
+
 uint8_t rgb_matrix_map_row_column_to_led(uint8_t row, uint8_t column, uint8_t *led_i) {
   // TODO: This is kinda expensive, fix this soonish
-  uint8_t led_count = 0;
+  uint8_t led_count = rgb_matrix_map_row_column_to_led_kb(row, column, led_i);
   for (uint8_t i = 0; i < DRIVER_LED_TOTAL && led_count < LED_HITS_TO_REMEMBER; i++) {
     matrix_co_t matrix_co = g_rgb_leds[i].matrix_co;
     if (row == matrix_co.row && column == matrix_co.col) {


### PR DESCRIPTION
## Description

This PR adds a kb level weak function for for keyboard owners to implement special handling for rgb matrix key to led lookup code. This allows keyboards, such as the Sol in this example, handle 2 keys triggering 1 led which is not possible today. This makes Reactive mode work correctly for all possible key presses.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
