### PR TITLE
Ignore VSCode's Precompiled Headers folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ util/Win_Check_Output.txt
 .vscode/tasks.json
 .vscode/last.sql
 .vscode/temp.sql
+.vscode/ipch/
 .stfolder
 .tags
 


### PR DESCRIPTION
## Description

VSCode has started to store precompiled headers in `/.vscode/ipch/`, so lets add this folder to gitignore, so we no longer see these from people's PRs. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Enhancement/optimization


## Checklist
- [X] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
