### PR TITLE
Fixing incorrect usage of RGBLED_NUM in ws2812 driver when used with RGB Matrix

### DIFF
--- a/drivers/avr/ws2812.c
+++ b/drivers/avr/ws2812.c
@@ -158,7 +158,7 @@ void inline ws2812_setled(int i, uint8_t r, uint8_t g, uint8_t b)
 
 void ws2812_setled_all  (uint8_t r, uint8_t g, uint8_t b)
 {
-  for (int i = 0; i < RGBLED_NUM; i++) {
+  for (int i = 0; i < sizeof(led)/sizeof(led[0]); i++) {
     led[i].r = r;
     led[i].g = g;
     led[i].b = b;

--- a/quantum/rgb_matrix_drivers.c
+++ b/quantum/rgb_matrix_drivers.c
@@ -99,12 +99,12 @@ const rgb_matrix_driver_t rgb_matrix_driver = {
 
 #elif defined(WS2812)
 
-extern LED_TYPE led[RGBLED_NUM];
+extern LED_TYPE led[DRIVER_LED_TOTAL];
 
   static void flush( void )
   {
     // Assumes use of RGB_DI_PIN
-    ws2812_setleds(led, RGBLED_NUM);
+    ws2812_setleds(led, DRIVER_LED_TOTAL);
   }
 
   static void init( void )


### PR DESCRIPTION
## Description

There were two usages of RGBLED_NUM in the ws2812 driver that would cause an issue if it was used only in the RGB Matrix feature where it was not defined. Switched it to correctly calculate it using sizeof or the RGB Matrix specific DRIVER_LED_TOTAL define where necessary.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
