### PR TITLE
Simple fix for selecting which tracked key press to work off of for simple reactive effects

### DIFF
--- a/quantum/rgb_matrix_animations/solid_reactive_anim.h
+++ b/quantum/rgb_matrix_animations/solid_reactive_anim.h
@@ -15,7 +15,8 @@ bool rgb_matrix_solid_reactive(effect_params_t* params) {
   for (uint8_t i = led_min; i < led_max; i++) {
     RGB_MATRIX_TEST_LED_FLAGS();
     uint16_t tick = max_tick;
-    for(uint8_t j = 0; j < g_last_hit_tracker.count; j++) {
+    // Reverse search to find most recent key hit
+    for (int8_t j = g_last_hit_tracker.count - 1; j >= 0; j--) {
       if (g_last_hit_tracker.index[j] == i && g_last_hit_tracker.tick[j] < tick) {
         tick = g_last_hit_tracker.tick[j];
         break;

--- a/quantum/rgb_matrix_animations/solid_reactive_simple_anim.h
+++ b/quantum/rgb_matrix_animations/solid_reactive_simple_anim.h
@@ -14,7 +14,8 @@ bool rgb_matrix_solid_reactive_simple(effect_params_t* params) {
   for (uint8_t i = led_min; i < led_max; i++) {
     RGB_MATRIX_TEST_LED_FLAGS();
     uint16_t tick = max_tick;
-    for(uint8_t j = 0; j < g_last_hit_tracker.count; j++) {
+    // Reverse search to find most recent key hit
+    for (int8_t j = g_last_hit_tracker.count - 1; j >= 0; j--) {
       if (g_last_hit_tracker.index[j] == i && g_last_hit_tracker.tick[j] < tick) {
         tick = g_last_hit_tracker.tick[j];
         break;


### PR DESCRIPTION
## Description

Changed the simple reactive effects to grab the most recent keypress for a given key instead of the oldest. 

Here's a rough image of the effect of this change. The before change behavior (actual) vs the after change behavior (expected)
![Image of the difference](https://cdn.discordapp.com/attachments/473506116718952450/572974149765562368/unknown.png)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
