### PR TITLE
fix mint60 with qmk_configurator 

### DIFF
--- a/keyboards/mint60/config.h
+++ b/keyboards/mint60/config.h
@@ -31,6 +31,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define TAPPING_FORCE_HOLD
 #define TAPPING_TERM 100
 
+#define USE_SERIAL
+
 /* key matrix size */
 #define MATRIX_ROWS 10
 #define MATRIX_COLS 8

--- a/keyboards/mint60/keymaps/default/config.h
+++ b/keyboards/mint60/keymaps/default/config.h
@@ -17,7 +17,7 @@
 #pragma once
 
 /* Use I2C or Serial, not both */
-#define USE_SERIAL
+// #define USE_SERIAL
 // #define USE_I2C
 
 // #define MASTER_RIGHT

--- a/keyboards/mint60/keymaps/eucalyn/config.h
+++ b/keyboards/mint60/keymaps/eucalyn/config.h
@@ -17,7 +17,7 @@
 #pragma once
 
 /* Use I2C or Serial, not both */
-#define USE_SERIAL
+// #define USE_SERIAL
 // #define USE_I2C
 
 // #define MASTER_RIGHT


### PR DESCRIPTION
add '#define USE_SERIAL' to keyboards/mint60/config.h.

If there is no '#define USE_SERIAL', qmk configurator will give an error, so add '#define USE_SERIAL' to `mint60/config.h`。

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).