### PR TITLE
Add DFU Suffix for ARM boards

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ env:
   - MAKEFLAGS="-j3 --output-sync"
 before_install:
   - wget http://ww1.microchip.com/downloads/en/DeviceDoc/avr8-gnu-toolchain-3.5.4.1709-linux.any.x86_64.tar.gz || wget http://qmk.fm/avr8-gnu-toolchain-3.5.4.1709-linux.any.x86_64.tar.gz
+  # Need DFU > .5 for dfu-suffix
+  - sudo add-apt-repository --yes ppa:tormodvolden/ppa
+  - sudo apt-get update -qq
 install:
   - tar -zxf avr8-gnu-toolchain-3.5.4.1709-linux.any.x86_64.tar.gz
   - export PATH="$PATH:$TRAVIS_BUILD_DIR/avr8-gnu-toolchain-linux_x86_64/bin"
@@ -29,7 +32,6 @@ addons:
     packages:
     - dfu-programmer
     - dfu-util
-    - dfu-suffix
     - pandoc
     - gcc-arm-none-eabi
     - binutils-arm-none-eabi

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ addons:
     packages:
     - dfu-programmer
     - dfu-util
+    - dfu-suffix
     - pandoc
     - gcc-arm-none-eabi
     - binutils-arm-none-eabi

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ install:
   - tar -zxf avr8-gnu-toolchain-3.5.4.1709-linux.any.x86_64.tar.gz
   - export PATH="$PATH:$TRAVIS_BUILD_DIR/avr8-gnu-toolchain-linux_x86_64/bin"
   - npm install -g moxygen
+  - sudo apt-get -y --force-yes install dfu-util
 before_script:
   - avr-gcc --version
 script:
@@ -31,7 +32,6 @@ addons:
   apt:
     packages:
     - dfu-programmer
-    - dfu-util
     - pandoc
     - gcc-arm-none-eabi
     - binutils-arm-none-eabi

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ addons:
   apt:
     packages:
     - dfu-programmer
+    - dfu-util
     - pandoc
     - gcc-arm-none-eabi
     - binutils-arm-none-eabi

--- a/keyboards/candybar/rules.mk
+++ b/keyboards/candybar/rules.mk
@@ -31,6 +31,7 @@ OPT_DEFS =
 
 # Options to pass to dfu-util when flashing
 DFU_ARGS = -d 0483:df11 -a 0 -s 0x08000000:leave
+DFU_SUFFIX_ARGS = -p DF11 -v 0483
 
 # Build Options
 #   comment out to disable the options.

--- a/keyboards/clueboard/60/rules.mk
+++ b/keyboards/clueboard/60/rules.mk
@@ -35,6 +35,7 @@ OPT_DEFS =
 
 # Options to pass to dfu-util when flashing
 DFU_ARGS = -d 0483:df11 -a 0 -s 0x08000000:leave
+DFU_SUFFIX_ARGS = -p DF11 -v 0483
 
 # Build Options
 #   comment out to disable the options.

--- a/keyboards/clueboard/66/rev4/rules.mk
+++ b/keyboards/clueboard/66/rev4/rules.mk
@@ -13,6 +13,7 @@ OPT_DEFS =
 
 # Options to pass to dfu-util when flashing
 DFU_ARGS = -d 0483:df11 -a 0 -s 0x08000000:leave
+DFU_SUFFIX_ARGS = -p DF11 -v 0483
 
 # Build Options
 #   comment out to disable the options.

--- a/keyboards/clueboard/66_hotswap/gen1/rules.mk
+++ b/keyboards/clueboard/66_hotswap/gen1/rules.mk
@@ -37,6 +37,7 @@ OPT_DEFS =
 
 # Options to pass to dfu-util when flashing
 DFU_ARGS = -d 0483:df11 -a 0 -s 0x08000000:leave
+DFU_SUFFIX_ARGS = -p DF11 -v 0483
 
 # LED Configuration
 LED_MATRIX_ENABLE = IS31FL3731

--- a/keyboards/dztech/dz40rgb/rules.mk
+++ b/keyboards/dztech/dz40rgb/rules.mk
@@ -40,6 +40,7 @@ OPT_DEFS += -DNO_SUSPEND_POWER_DOWN
 
 # Options to pass to dfu-util when flashing
 DFU_ARGS = -d 0483:df11 -a 0 -s 0x08000000:leave
+DFU_SUFFIX_ARGS = -p DF11 -v 0483
 
 # Build Options
 #   comment out to disable the options.

--- a/keyboards/dztech/dz60rgb/rules.mk
+++ b/keyboards/dztech/dz60rgb/rules.mk
@@ -35,6 +35,7 @@ OPT_DEFS =
 
 # Options to pass to dfu-util when flashing
 DFU_ARGS = -d 0483:df11 -a 0 -s 0x08000000:leave
+DFU_SUFFIX_ARGS = -p DF11 -v 0483
 
 
 BACKLIGHT_ENABLE = no

--- a/keyboards/ergodox_infinity/rules.mk
+++ b/keyboards/ergodox_infinity/rules.mk
@@ -59,6 +59,7 @@ OPT_DEFS += -DCORTEX_VTOR_INIT=0x00002000
 #
 
 DFU_ARGS = -d 1c11:b007
+DFU_SUFFIX_ARGS = -p b007 -v 1c11
 
 BOOTMAGIC_ENABLE = no  # Virtual DIP switch configuration(+1000)
 MOUSEKEY_ENABLE  = yes # Mouse keys(+4700)

--- a/keyboards/hs60/v2/keymaps/ansi_via/rules.mk
+++ b/keyboards/hs60/v2/keymaps/ansi_via/rules.mk
@@ -45,6 +45,7 @@ OPT_DEFS += -DNO_SUSPEND_POWER_DOWN
 
 # Options to pass to dfu-util when flashing
 DFU_ARGS = -d 0483:df11 -a 0 -s 0x08000000:leave
+DFU_SUFFIX_ARGS = -p DF11 -v 0483
 
 # Build Options
 #   comment out to disable the options.

--- a/keyboards/hs60/v2/keymaps/default_via/rules.mk
+++ b/keyboards/hs60/v2/keymaps/default_via/rules.mk
@@ -45,6 +45,7 @@ OPT_DEFS += -DNO_SUSPEND_POWER_DOWN
 
 # Options to pass to dfu-util when flashing
 DFU_ARGS = -d 0483:df11 -a 0 -s 0x08000000:leave
+DFU_SUFFIX_ARGS = -p DF11 -v 0483
 
 # Build Options
 #   comment out to disable the options.

--- a/keyboards/hs60/v2/keymaps/goatmaster/rules.mk
+++ b/keyboards/hs60/v2/keymaps/goatmaster/rules.mk
@@ -45,6 +45,7 @@ OPT_DEFS += -DNO_SUSPEND_POWER_DOWN
 
 # Options to pass to dfu-util when flashing
 DFU_ARGS = -d 0483:df11 -a 0 -s 0x08000000:leave
+DFU_SUFFIX_ARGS = -p DF11 -v 0483
 
 # Build Options
 #   comment out to disable the options.

--- a/keyboards/hs60/v2/keymaps/hhkb_via/rules.mk
+++ b/keyboards/hs60/v2/keymaps/hhkb_via/rules.mk
@@ -45,6 +45,7 @@ OPT_DEFS += -DNO_SUSPEND_POWER_DOWN
 
 # Options to pass to dfu-util when flashing
 DFU_ARGS = -d 0483:df11 -a 0 -s 0x08000000:leave
+DFU_SUFFIX_ARGS = -p DF11 -v 0483
 
 # Build Options
 #   comment out to disable the options.

--- a/keyboards/hs60/v2/keymaps/iso_andys8/rules.mk
+++ b/keyboards/hs60/v2/keymaps/iso_andys8/rules.mk
@@ -45,6 +45,7 @@ OPT_DEFS += -DNO_SUSPEND_POWER_DOWN
 
 # Options to pass to dfu-util when flashing
 DFU_ARGS = -d 0483:df11 -a 0 -s 0x08000000:leave
+DFU_SUFFIX_ARGS = -p DF11 -v 0483
 
 # Build Options
 #   comment out to disable the options.

--- a/keyboards/hs60/v2/keymaps/stanrc85/rules.mk
+++ b/keyboards/hs60/v2/keymaps/stanrc85/rules.mk
@@ -45,6 +45,7 @@ OPT_DEFS += -DNO_SUSPEND_POWER_DOWN
 
 # Options to pass to dfu-util when flashing
 DFU_ARGS = -d 0483:df11 -a 0 -s 0x08000000:leave
+DFU_SUFFIX_ARGS = -p DF11 -v 0483
 
 # Build Options
 #   comment out to disable the options.

--- a/keyboards/hs60/v2/keymaps/win_osx_dual/rules.mk
+++ b/keyboards/hs60/v2/keymaps/win_osx_dual/rules.mk
@@ -45,6 +45,7 @@ OPT_DEFS += -DNO_SUSPEND_POWER_DOWN
 
 # Options to pass to dfu-util when flashing
 DFU_ARGS = -d 0483:df11 -a 0 -s 0x08000000:leave
+DFU_SUFFIX_ARGS = -p DF11 -v 0483
 
 # Build Options
 #   comment out to disable the options.

--- a/keyboards/hs60/v2/rules.mk
+++ b/keyboards/hs60/v2/rules.mk
@@ -45,6 +45,7 @@ OPT_DEFS += -DNO_SUSPEND_POWER_DOWN
 
 # Options to pass to dfu-util when flashing
 DFU_ARGS = -d 0483:df11 -a 0 -s 0x08000000:leave
+DFU_SUFFIX_ARGS = -p DF11 -v 0483
 
 # Build Options
 #   comment out to disable the options.

--- a/keyboards/infinity60/rules.mk
+++ b/keyboards/infinity60/rules.mk
@@ -58,6 +58,7 @@ OPT_DEFS = -DCORTEX_VTOR_INIT=0x00001000
 #
 
 DFU_ARGS = -d 1c11:b007
+DFU_SUFFIX_ARGS = -p b007 -v 1c11
 
 BOOTMAGIC_ENABLE = no	# Virtual DIP switch configuration
 ## (Note that for BOOTMAGIC on Teensy LC you have to use a custom .ld script.)

--- a/keyboards/k_type/rules.mk
+++ b/keyboards/k_type/rules.mk
@@ -57,6 +57,7 @@ ARMV = 7
 OPT_DEFS =
 
 DFU_ARGS = -d 1c11:b007
+DFU_SUFFIX_ARGS = -p b007 -v 1c11
 
 # Build Options
 #   comment out to disable the options.

--- a/keyboards/vinta/rules.mk
+++ b/keyboards/vinta/rules.mk
@@ -33,6 +33,7 @@ OPT_DEFS =
 
 # Options to pass to dfu-util when flashing
 DFU_ARGS = -d 0483:df11 -a 0 -s 0x08000000:leave
+DFU_SUFFIX_ARGS = -p DF11 -v 0483
 
 # Build Options
 #   comment out to disable the options.

--- a/keyboards/whitefox/rules.mk
+++ b/keyboards/whitefox/rules.mk
@@ -55,6 +55,7 @@ ARMV = 7
 OPT_DEFS =
 
 DFU_ARGS = -d 1c11:b007
+DFU_SUFFIX_ARGS = -p b007 -v 1c11
 
 # Build Options
 #   comment out to disable the options.

--- a/quantum/mcu_selection.mk
+++ b/quantum/mcu_selection.mk
@@ -34,6 +34,7 @@ ifneq ($(findstring STM32F303, $(MCU)),)
 
   # Options to pass to dfu-util when flashing
   DFU_ARGS ?= -d 0483:df11 -a 0 -s 0x08000000:leave
+  DFU_SUFFIX_ARGS = -p DF11 -v 0483
 endif
 
 ifneq (,$(filter $(MCU),atmega32u4 at90usb1286))

--- a/quantum/stm32/proton_c.mk
+++ b/quantum/stm32/proton_c.mk
@@ -42,3 +42,4 @@ OPT_DEFS =
 
 # Options to pass to dfu-util when flashing
 DFU_ARGS = -d 0483:df11 -a 0 -s 0x08000000:leave
+DFU_SUFFIX_ARGS = -p df11 -v 0483

--- a/tmk_core/chibios.mk
+++ b/tmk_core/chibios.mk
@@ -262,6 +262,6 @@ st-link-cli: $(BUILD_DIR)/$(TARGET).hex sizeafter
 
 bin: $(BUILD_DIR)/$(TARGET).bin sizeafter
 	if [ ! -z "$(DFU_SUFFIX_ARGS)" ]; then \
-		$(DFU_SUFFIX) $(DFU_SUFFIX_ARGS) -a $(BUILD_DIR)/$(TARGET).bin ;\
+		$(DFU_SUFFIX) $(DFU_SUFFIX_ARGS) -a $(BUILD_DIR)/$(TARGET).bin 1>/dev/null ;\
 	fi
 	$(COPY) $(BUILD_DIR)/$(TARGET).bin $(TARGET).bin;

--- a/tmk_core/chibios.mk
+++ b/tmk_core/chibios.mk
@@ -201,6 +201,7 @@ DFU_ARGS ?=
 ifneq ("$(SERIAL)","")
 	DFU_ARGS += -S $(SERIAL)
 endif
+DFU_SUFFIX_ARGS ?=
 
 ST_LINK_ARGS ?=
 
@@ -208,6 +209,7 @@ ST_LINK_ARGS ?=
 EXTRALIBDIRS = $(RULESPATH)/ld
 
 DFU_UTIL ?= dfu-util
+DFU_SUFFIX ?= dfu-suffix
 ST_LINK_CLI ?= st-link_cli
 
 # Generate a .qmk for the QMK-FF
@@ -259,4 +261,8 @@ st-link-cli: $(BUILD_DIR)/$(TARGET).hex sizeafter
 	$(ST_LINK_CLI) $(ST_LINK_ARGS) -q -c SWD -p $(BUILD_DIR)/$(TARGET).hex -Rst
 
 bin: $(BUILD_DIR)/$(TARGET).bin sizeafter
+	ifneq ($(strip "$(DFU_SUFFIX_ARGS)","")
+		echo "$(DFU_SUFFIX_ARGS)"
+		# $(DFU_SUFFIX) $(DFU_SUFFIX_ARGS) -a $(BUILD_DIR)/$(TARGET).bin
+	endif
 	$(COPY) $(BUILD_DIR)/$(TARGET).bin $(TARGET).bin;

--- a/tmk_core/chibios.mk
+++ b/tmk_core/chibios.mk
@@ -261,8 +261,8 @@ st-link-cli: $(BUILD_DIR)/$(TARGET).hex sizeafter
 	$(ST_LINK_CLI) $(ST_LINK_ARGS) -q -c SWD -p $(BUILD_DIR)/$(TARGET).hex -Rst
 
 bin: $(BUILD_DIR)/$(TARGET).bin sizeafter
-	ifneq ($(strip "$(DFU_SUFFIX_ARGS)","")
-		echo "$(DFU_SUFFIX_ARGS)"
-		# $(DFU_SUFFIX) $(DFU_SUFFIX_ARGS) -a $(BUILD_DIR)/$(TARGET).bin
-	endif
+	# ifneq ($(strip "$(DFU_SUFFIX_ARGS)","")
+	#	echo "$(DFU_SUFFIX_ARGS)"
+	$(DFU_SUFFIX) $(DFU_SUFFIX_ARGS) -a $(BUILD_DIR)/$(TARGET).bin
+	#endif
 	$(COPY) $(BUILD_DIR)/$(TARGET).bin $(TARGET).bin;

--- a/tmk_core/chibios.mk
+++ b/tmk_core/chibios.mk
@@ -261,8 +261,8 @@ st-link-cli: $(BUILD_DIR)/$(TARGET).hex sizeafter
 	$(ST_LINK_CLI) $(ST_LINK_ARGS) -q -c SWD -p $(BUILD_DIR)/$(TARGET).hex -Rst
 
 bin: $(BUILD_DIR)/$(TARGET).bin sizeafter
-	# ifneq ($(strip "$(DFU_SUFFIX_ARGS)","")
-	#	echo "$(DFU_SUFFIX_ARGS)"
-	$(DFU_SUFFIX) $(DFU_SUFFIX_ARGS) -a $(BUILD_DIR)/$(TARGET).bin
-	#endif
+	# ifneq ($(strip "$(DFU_SUFFIX_ARGS)",""))
+	# 	echo "$(DFU_SUFFIX_ARGS)"
+	    $(DFU_SUFFIX) $(DFU_SUFFIX_ARGS) -a $(BUILD_DIR)/$(TARGET).bin
+	# endif
 	$(COPY) $(BUILD_DIR)/$(TARGET).bin $(TARGET).bin;

--- a/tmk_core/chibios.mk
+++ b/tmk_core/chibios.mk
@@ -261,8 +261,7 @@ st-link-cli: $(BUILD_DIR)/$(TARGET).hex sizeafter
 	$(ST_LINK_CLI) $(ST_LINK_ARGS) -q -c SWD -p $(BUILD_DIR)/$(TARGET).hex -Rst
 
 bin: $(BUILD_DIR)/$(TARGET).bin sizeafter
-	# ifneq ($(strip "$(DFU_SUFFIX_ARGS)",""))
-	# 	echo "$(DFU_SUFFIX_ARGS)"
-	    $(DFU_SUFFIX) $(DFU_SUFFIX_ARGS) -a $(BUILD_DIR)/$(TARGET).bin
-	# endif
+	if [ ! -z "$(DFU_SUFFIX_ARGS)" ]; then \
+		$(DFU_SUFFIX) $(DFU_SUFFIX_ARGS) -a $(BUILD_DIR)/$(TARGET).bin ;\
+	fi
 	$(COPY) $(BUILD_DIR)/$(TARGET).bin $(TARGET).bin;


### PR DESCRIPTION
## Description

This adds support for adding the DFU Signature to to the BIN files for ChibiOS based boards.   This gets rid of the "invalid signature" warning when flashing the boards. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bug
- [x] Enhancement/optimization

## Issues Fixed or Closed by This PR

* "invalid signature" warning in dfu-util

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
