### PR TITLE
[WIP] util/new_keyboard.sh: Create nested keyboard directories as needed

### DIFF
--- a/util/new_keyboard.sh
+++ b/util/new_keyboard.sh
@@ -147,6 +147,9 @@ username=$prompt_return
 
 echo
 
+# Create new keyboard directory and any intermediate directories.
+mkdir -p "$keyboard_dir"
+
 copy_templates
 set_sed_i
 replace_keyboard_placeholders


### PR DESCRIPTION
## Description

Say a user wants to create a parent directory to group the keyboards they plan on adding. For example: `keyboards/mycompany/mykb1`, `keyboards/mycompany/mykb2` etc. Currently, the `new_keyboard.sh` script doesn't allow them to do this if the parent directory doesn't already exist. In other words, they have to `mkdir keyboards/mycompany` manually before running the script and inputting `mycompany/mykb1` on the keyboard name prompt.

This PR fixes that by running `mkdir -p "$keyboard_dir"` (`-p` = no error if existing, make parent directories as needed) before `cp` and other commands are executed.

Based on #5191.

/request_review @fauxpark et al.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
