### PR TITLE
Space Cadet: Reducing unnecessary reported keypresses

### DIFF
--- a/docs/feature_space_cadet.md
+++ b/docs/feature_space_cadet.md
@@ -47,7 +47,7 @@ By default Space Cadet assumes a US ANSI layout, but if your layout uses differe
 
 ## Obsolete Configuration
 
-These defines are used in the above defines internally to support backwards compatibility, so you may continue to use them, however the above defines open up a larger range of flexibility than before. As an example, say you want to not send any modifier when you tap just `KC_LSPO`, with the old defines you had an all or nothing choice of using the `DISABLE_SPACE_CADET_MODIFIER` define. Now you can define that key as: `#define LSPO_KEYS KC_LSFT, KC_TRNS, KC_9`. This tells the system to set Left Shift if held or used with other keys, then on tap send no modifier (transparent) with the `KC_9`
+These defines are used in the above defines internally to support backwards compatibility, so you may continue to use them, however the above defines open up a larger range of flexibility than before. As an example, say you want to not send any modifier when you tap just `KC_LSPO`, with the old defines you had an all or nothing choice of using the `DISABLE_SPACE_CADET_MODIFIER` define. Now you can define that key as: `#define LSPO_KEYS KC_LSFT, KC_TRNS, KC_9`. This tells the system to set Left Shift if held or used with other keys, then on tap send no modifier (transparent) with the `KC_9`.
 
 |Define                        |Default      |Description                                                       |
 |------------------------------|-------------|------------------------------------------------------------------|

--- a/docs/feature_space_cadet.md
+++ b/docs/feature_space_cadet.md
@@ -39,15 +39,15 @@ By default Space Cadet assumes a US ANSI layout, but if your layout uses differe
 |`LSPO_KEYS`     |`KC_LSFT, LSPO_MOD, LSPO_KEY`  |Send `KC_LSFT` when held, the mod and  key defined by `LSPO_MOD` and `LSPO_KEY`. |
 |`RSPC_KEYS`     |`KC_RSFT, RSPC_MOD, RSPC_KEY`  |Send `KC_RSFT` when held, the mod and  key defined by `RSPC_MOD` and `RSPC_KEY`. |
 |`LCPO_KEYS`     |`KC_LCTL, KC_LCTL, KC_9`       |Send `KC_LCTL` when held, the mod `KC_LCTL` with the key `KC_9` when tapped.     |
-|`RCPO_KEYS`     |`KC_RCTL, KC_RCTL, KC_0`       |Send `KC_RCTL` when held, the mod `KC_RCTL` with the key `KC_0` when tapped.     |
+|`RCPC_KEYS`     |`KC_RCTL, KC_RCTL, KC_0`       |Send `KC_RCTL` when held, the mod `KC_RCTL` with the key `KC_0` when tapped.     |
 |`LAPO_KEYS`     |`KC_LALT, KC_LALT, KC_9`       |Send `KC_LALT` when held, the mod `KC_LALT` with the key `KC_9` when tapped.     |
-|`RAPO_KEYS`     |`KC_RALT, KC_RALT, KC_0`       |Send `KC_RALT` when held, the mod `KC_RALT` with the key `KC_0` when tapped.     |
+|`RAPC_KEYS`     |`KC_RALT, KC_RALT, KC_0`       |Send `KC_RALT` when held, the mod `KC_RALT` with the key `KC_0` when tapped.     |
 |`SFTENT_KEYS`   |`KC_RSFT, KC_TRNS, SFTENT_KEY` |Send `KC_RSFT` when held, no mod with the key `SFTENT_KEY` when tapped.          |
 
 
 ## Obsolete Configuration
 
-These defines are used in the above defines internally to support backwards compatibility, so you may continue to use them, however the above defines open up a larger range of flexibility than before. As an example, say you want to not send any modifier when you tap just `KC_LSPO`, with the old defines you had an all or nothing choice of using the `DISABLE_SPACE_CADET_MODIFIER` define. Now you can define that key as: `#define KC_LSPO_KEYS KC_LSFT, KC_TRNS, KC_9`. This tells the system to set Left Shift if held or used with other keys, then on tap send no modifier (transparent) with the `KC_9`
+These defines are used in the above defines internally to support backwards compatibility, so you may continue to use them, however the above defines open up a larger range of flexibility than before. As an example, say you want to not send any modifier when you tap just `KC_LSPO`, with the old defines you had an all or nothing choice of using the `DISABLE_SPACE_CADET_MODIFIER` define. Now you can define that key as: `#define LSPO_KEYS KC_LSFT, KC_TRNS, KC_9`. This tells the system to set Left Shift if held or used with other keys, then on tap send no modifier (transparent) with the `KC_9`
 
 |Define                        |Default      |Description                                                       |
 |------------------------------|-------------|------------------------------------------------------------------|

--- a/quantum/process_keycode/process_space_cadet.c
+++ b/quantum/process_keycode/process_space_cadet.c
@@ -62,16 +62,16 @@
 #ifndef LCPO_KEYS
   #define LCPO_KEYS KC_LCTL, KC_LCTL, KC_9
 #endif
-#ifndef RCPO_KEYS
-  #define RCPO_KEYS KC_RCTL, KC_RCTL, KC_0
+#ifndef RCPC_KEYS
+  #define RCPC_KEYS KC_RCTL, KC_RCTL, KC_0
 #endif
 
 // Alt / paren setup
 #ifndef LAPO_KEYS
   #define LAPO_KEYS KC_LALT, KC_LALT, KC_9
 #endif
-#ifndef RAPO_KEYS
-  #define RAPO_KEYS KC_RALT, KC_RALT, KC_0
+#ifndef RAPC_KEYS
+  #define RAPC_KEYS KC_RALT, KC_RALT, KC_0
 #endif
 
 // Shift / Enter setup
@@ -82,26 +82,31 @@
 static uint8_t sc_last = 0;
 static uint16_t sc_timer = 0;
 
-void perform_space_cadet(keyrecord_t *record, uint8_t normalMod, uint8_t tapMod, uint8_t keycode) {
+void perform_space_cadet(keyrecord_t *record, uint8_t holdMod, uint8_t tapMod, uint8_t keycode) {
   if (record->event.pressed) {
-    sc_last = normalMod;
+    sc_last = holdMod;
     sc_timer = timer_read ();
-    if (IS_MOD(normalMod)) {
-      register_mods(MOD_BIT(normalMod));
+    if (IS_MOD(holdMod)) {
+      register_mods(MOD_BIT(holdMod));
     }
   }
   else {
-    if (IS_MOD(normalMod)) {
-      unregister_mods(MOD_BIT(normalMod));
-    }
-
-    if (sc_last == normalMod && timer_elapsed(sc_timer) < TAPPING_TERM) {
-      if (IS_MOD(tapMod)) {
-        register_mods(MOD_BIT(tapMod));
+    if (sc_last == holdMod && timer_elapsed(sc_timer) < TAPPING_TERM) {
+      if (holdMod != tapMod) {
+        if (IS_MOD(holdMod)) {
+          unregister_mods(MOD_BIT(holdMod));
+        }
+        if (IS_MOD(tapMod)) {
+          register_mods(MOD_BIT(tapMod));
+        }
       }
       tap_code(keycode);
       if (IS_MOD(tapMod)) {
         unregister_mods(MOD_BIT(tapMod));
+      }
+    } else {
+      if (IS_MOD(holdMod)) {
+        unregister_mods(MOD_BIT(holdMod));
       }
     }
   }
@@ -122,7 +127,7 @@ bool process_space_cadet(uint16_t keycode, keyrecord_t *record) {
       return false;
     }
     case KC_RCPC: {
-      perform_space_cadet(record, RCPO_KEYS);
+      perform_space_cadet(record, RCPC_KEYS);
       return false;
     }
     case KC_LAPO: {
@@ -130,7 +135,7 @@ bool process_space_cadet(uint16_t keycode, keyrecord_t *record) {
       return false;
     }
     case KC_RAPC: {
-      perform_space_cadet(record, RAPO_KEYS);
+      perform_space_cadet(record, RAPC_KEYS);
       return false;
     }
     case KC_SFTENT: {

--- a/quantum/process_keycode/process_space_cadet.h
+++ b/quantum/process_keycode/process_space_cadet.h
@@ -17,5 +17,5 @@
 
 #include "quantum.h"
 
-void perform_space_cadet(keyrecord_t *record, uint8_t normalMod, uint8_t tapMod, uint8_t keycode);
+void perform_space_cadet(keyrecord_t *record, uint8_t holdMod, uint8_t tapMod, uint8_t keycode);
 bool process_space_cadet(uint16_t keycode, keyrecord_t *record);

--- a/users/xulkal/config.h
+++ b/users/xulkal/config.h
@@ -10,7 +10,7 @@
 #define LSPO_KEYS KC_LSFT, KC_TRNS, KC_LBRC
 #define RSPC_KEYS KC_RSFT, KC_TRNS, KC_RBRC
 #define LCPO_KEYS KC_LCTL, KC_TRNS, KC_MINS
-#define RCPO_KEYS KC_RCTL, KC_TRNS, KC_EQL
+#define RCPC_KEYS KC_RCTL, KC_TRNS, KC_EQL
 
 // No need for the single versions when multi performance isn't a problem =D
 #define DISABLE_RGB_MATRIX_SOLID_REACTIVE_WIDE


### PR DESCRIPTION
 and minor docs / variable name changes

## Description

Added a check to remove unnecessary keypresses in the event that the hold mod is the same as the tap mod.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/qmk/qmk_firmware/issues/5780
* https://github.com/qmk/qmk_firmware/issues/5793

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
