### PR TITLE
Add remaining RGB underglow logic to Singa.

### DIFF
--- a/keyboards/singa/singa.c
+++ b/keyboards/singa/singa.c
@@ -34,6 +34,25 @@ void rgblight_set(void) {
 }
 #endif
 
+void matrix_init_kb(void) {
+#ifdef RGBLIGHT_ENABLE
+    if (rgblight_config.enable) {
+        i2c_init();
+        i2c_transmit(0xb0, (uint8_t*)led, 3 * RGBLED_NUM, 100);
+    }
+#endif
+    // call user level keymaps, if any
+    matrix_init_user();
+}
+
+void matrix_scan_kb(void) {
+#ifdef RGBLIGHT_ENABLE
+    rgblight_task();
+#endif
+    matrix_scan_user();
+    /* Nothing else for now. */
+}
+
 __attribute__ ((weak))
 void matrix_scan_user(void) {
 }
@@ -45,7 +64,7 @@ void backlight_init_ports(void) {
     setPinOutput(D4);
     setPinOutput(D6);
 
-    // turn RGB LEDs on
+    // turn backlight LEDs on
     writePinHigh(D0);
     writePinHigh(D1);
     writePinHigh(D4);
@@ -54,13 +73,13 @@ void backlight_init_ports(void) {
 
 void backlight_set(uint8_t level) {
 	if (level == 0) {
-        // turn RGB LEDs off
+        // turn backlight LEDs off
         writePinLow(D0);
         writePinLow(D1);
         writePinLow(D4);
         writePinLow(D6);
 	} else {
-        // turn RGB LEDs on
+        // turn backlight LEDs on
         writePinHigh(D0);
         writePinHigh(D1);
         writePinHigh(D4);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The refactor in #5579 partially works, but:
- RGB underglow does not render to the LEDs on startup (so firmware thinks RGB is on and if static color is set, displaying the selected color, but it is not)
- Animations do not work

This deficiency potentially also affects:
- HB85
- Budget96
- E6V2

If it makes sense, I can expand this PR to address those three boards.

cc: @mechmerlin 
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
