### PR TITLE
Add SH1106 OLED support

### DIFF
--- a/docs/feature_oled_driver.md
+++ b/docs/feature_oled_driver.md
@@ -2,7 +2,16 @@
 
 ## OLED Supported Hardware
 
-128x32 OLED modules using SSD1306 driver IC over I2C. Supported on AVR based keyboards. Possible but untested hardware includes ARM based keyboards and other sized OLED modules using SSD1306 over I2C, such as 128x64. 
+OLED modules using SSD1306 or SH1106 driver ICs, communicating over I2C.
+Tested combinations:
+
+| IC driver |   Size | Keyboard Platform | Notes                    |
+|-----------|--------|-------------------|--------------------------|
+| SSD1306   | 128x32 | AVR               | Primary support          |
+| SSD1306   | 128x32 | ARM               |                          |
+| SH1106    | 128x64 | AVR               | No rotation or scrolling |
+
+Hardware configurations using ARM-based microcontrollers or different sizes of OLED modules may be compatible, but are untested.
 
 !> Warning: This OLED Driver currently uses the new i2c_master driver from split common code. If your split keyboard uses i2c to communication between sides this driver could cause an address conflict (serial is fine). Please contact your keyboard vendor and ask them to migrate to the latest split common code to fix this. 
 
@@ -86,17 +95,17 @@ void oled_task_user(void) {
 
  ## Basic Configuration
 
-|Define                 |Default        |Description                                     |
-|-----------------------|---------------|------------------------------------------------|
-|`OLED_DISPLAY_ADDRESS` |`0x3C`         |The i2c address of the OLED Display             |
-|`OLED_FONT_H`          |`"glcdfont.c"` |The font code file to use for custom fonts      |
-|`OLED_FONT_START`      |`0`            |The starting characer index for custom fonts    |
-|`OLED_FONT_END`        |`224`          |The ending characer index for custom fonts      |
-|`OLED_FONT_WIDTH`      |`6`            |The font width                                  |
-|`OLED_FONT_HEIGHT`     |`8`            |The font height (untested)                      |
-|`OLED_DISABLE_TIMEOUT` |*Not defined*  |Disables the built in OLED timeout feature. Useful when implementing custom timeout rules.|
-
-
+| Define                 | Default           | Description                                                                                                                |
+|------------------------|-------------------|----------------------------------------------------------------------------------------------------------------------------|
+| `OLED_DISPLAY_ADDRESS` | `0x3C`            | The i2c address of the OLED Display                                                                                        |
+| `OLED_FONT_H`          | `"glcdfont.c"`    | The font code file to use for custom fonts                                                                                 |
+| `OLED_FONT_START`      | `0`               | The starting characer index for custom fonts                                                                               |
+| `OLED_FONT_END`        | `224`             | The ending characer index for custom fonts                                                                                 |
+| `OLED_FONT_WIDTH`      | `6`               | The font width                                                                                                             |
+| `OLED_FONT_HEIGHT`     | `8`               | The font height (untested)                                                                                                 |
+| `OLED_DISABLE_TIMEOUT` | *Not defined*     | Disables the built in OLED timeout feature. Useful when implementing custom timeout rules.                                 |
+| `OLED_IC`              | `OLED_IC_SSD1306` | Set to `OLED_IC_SH1106` if you're using the SH1106 OLED controller.                                                        |
+| `OLED_COLUMN_OFFSET`   | `0`               | (SH1106 only.) Shift output to the right this many pixels.<br />Useful for 128x64 displays centered on a 132x64 SH1106 IC. |
 
  ## 128x64 & Custom sized OLED Displays
 
@@ -118,6 +127,8 @@ void oled_task_user(void) {
 
 
 ### 90 Degree Rotation - Technical Mumbo Jumbo 
+
+!> Rotation is unsupported on the SH1106.
 
 ```C
 // OLED Rotation enum values are flags
@@ -249,6 +260,8 @@ uint8_t oled_max_chars(void);
 // Returns the maximum number of lines that will fit on the OLED
 uint8_t oled_max_lines(void);
 ```
+
+!> Scrolling and rotation are unsupported on the SH1106.
 
 ## SSD1306.h driver conversion guide
 

--- a/docs/feature_oled_driver.md
+++ b/docs/feature_oled_driver.md
@@ -8,6 +8,7 @@ Tested combinations:
 | IC driver |   Size | Keyboard Platform | Notes                    |
 |-----------|--------|-------------------|--------------------------|
 | SSD1306   | 128x32 | AVR               | Primary support          |
+| SSD1306   | 128x64 | AVR               | Verified working         |
 | SSD1306   | 128x32 | ARM               |                          |
 | SH1106    | 128x64 | AVR               | No rotation or scrolling |
 

--- a/drivers/oled/oled_driver.h
+++ b/drivers/oled/oled_driver.h
@@ -19,6 +19,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <stdint.h>
 #include <stdbool.h>
 
+// an enumeration of the chips this driver supports
+#define OLED_IC_SSD1306 0
+#define OLED_IC_SH1106  1
 
 #if defined(OLED_DISPLAY_CUSTOM)
   // Expected user to implement the necessary defines
@@ -100,7 +103,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   // #define OLED_TARGET_MAP { 48, 32, 16, 0, 56, 40, 24, 8 }
 #endif // defined(OLED_DISPLAY_CUSTOM)
 
-// Address to use for tthe i2d oled communication
+#if !defined(OLED_IC)
+  #define OLED_IC OLED_IC_SSD1306
+#endif
+
+// the column address corresponding to the first column in the display hardware
+#if !defined(OLED_COLUMN_OFFSET)
+  #define OLED_COLUMN_OFFSET 0
+#endif
+
+// Address to use for the i2c oled communication
 #if !defined(OLED_DISPLAY_ADDRESS)
   #define OLED_DISPLAY_ADDRESS 0x3C
 #endif


### PR DESCRIPTION
## Description

This patch adds rudimentary support for the SH1106 OLED driver IC, and some minor enhancements to better support my particular OLED module.

The SH1106 chip is quite similar to but not the same as the SSD1306 that `drivers/oled/oled_driver.c` was written to support. In particular:

- Its internal ram for the display is 132x64 bits, compared to 128x64 for the SSD1306.
- It supports only Page Addressing Mode, while the SSD1306 also supports Horizontal Addressing and Vertical Addressing. (`oled_driver.c` assumes Horizontal Addressing.)
- It does not support hardware scrolling.

Regarding my particular OLED module:

I purchased a cheap 128x64 I2C OLED module claiming to use SSD1306, but it turned out to have an SH1106 instead. Recall that the SH1106 at 132x64 has a wider buffer than the physical display at 128x64. The vendor of my OLED module elected to connect the display such that the first two columns of display ram are not mapped to the display hardware. To accommodate this, I added `#define OLED_COLUMN_OFFSET`.

Since other full-featured graphics libraries exist that support many different chips, my goal for this patch was only to add basic support to QMK's `oled_driver.c` with a minimum of code changes.

It does not yet support 90 degree rotation (because I don't yet understand the algorithm implementing it), and it will probably never support scrolling (since that feature is missing from SH1106 hardware.)

[This discussion in the Arduino forums](https://forum.arduino.cc/index.php?topic=256374.msg3832639#msg3832639) helped me troubleshoot my OLED module enough to make these changes.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
