### PR TITLE
Fix wrong key assigning in keymap for ISO layout

### DIFF
--- a/keyboards/westfoxtrot/aanzee/aanzee.h
+++ b/keyboards/westfoxtrot/aanzee/aanzee.h
@@ -46,14 +46,14 @@
 }
 #define LAYOUT_iso( \
   K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C, K0D, K0E, \
-  K10, K11, K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B,      K1D, K1E, \
+  K10, K11, K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, K1C,      K1E, \
   K20, K21, K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B, K2C, K2D, K2E, \
   K30, K31, K32, K33, K34, K35, K36, K37, K38, K39, K3A, K3B, K3C, K3D, K3E, \
   K40, K41, K42,                K46,           K49, K4A, K4B, K4C, K4D, K4E  \
 ) \
 { \
   {K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C, K0D, K0E, ___}, \
-  {K10, K11, K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, ___, K1D, K1E, ___}, \
+  {K10, K11, K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, K1C, ___, K1E, ___}, \
   {K20, K21, K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B, K2C, K2D, K2E, ___}, \
   {K30, K31, K32, K33, K34, K35, K36, K37, K38, K39, K3A, K3B, K3C, K3D, K3E, ___}, \
   {K40, K41, K42, ___, ___, ___, K46, ___, ___, K49, K4A, K4B, K4C, K4D, K4E, ___}  \


### PR DESCRIPTION
## Description

This PR fixes an issue for the ISO layout keymap on aanzee PCBs where the Backspace key has the wrong matrix assignment and is therefore not usable

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Backspace not usable when using LAYOUT_ISO on aanzee

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
