### PR TITLE
Adding bdn9 keymap examples for company event

### DIFF
--- a/keyboards/keebio/bdn9/keymaps/vosechu-browser/keymap.c
+++ b/keyboards/keebio/bdn9/keymaps/vosechu-browser/keymap.c
@@ -1,0 +1,72 @@
+#include QMK_KEYBOARD_H
+
+// Fillers to make layering more clear
+#define _______ KC_TRNS
+#define _LAYER_ KC_TRNS
+#define XXXXXXX KC_NO
+
+// Macro keys for some apps
+#define SLACKUP LALT(LSFT(KC_UP))
+#define SLACKDN LALT(LSFT(KC_DOWN))
+#define RELOAD  LGUI(KC_R)
+
+enum {
+  PAWFIVE = SAFE_RANGE
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  [0] = LAYOUT(
+    RESET  , PAWFIVE, RELOAD , \
+    SLACKUP, KC_UP  , KC_PGUP, \
+    SLACKDN, KC_DOWN, KC_PGDN \
+  ),
+};
+
+void keyboard_post_init_user(void) {
+    // Call the post init code.
+    rgblight_enable_noeeprom(); // enables Rgb, without saving settings
+    rgblight_mode_noeeprom(RGBLIGHT_MODE_RAINBOW_SWIRL); // sets mode to Slow breathing without saving
+}
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  switch (keycode) {
+    case PAWFIVE:
+      if (record->event.pressed) {
+        SEND_STRING("+:pawfive:");
+        return false;
+      }
+  }
+
+  return true;
+}
+
+void encoder_update_user(uint8_t index, bool clockwise) {
+  if (index == 0) {
+    if (clockwise) {
+      // Tab right
+      register_code(KC_LGUI);
+      register_code(KC_LSFT);
+      tap_code(KC_RBRC);
+      clear_keyboard();
+    } else {
+      // Tab left
+      register_code(KC_LGUI);
+      register_code(KC_LSFT);
+      tap_code(KC_LBRC);
+      clear_keyboard();
+    }
+  }
+  else if (index == 1) {
+    if (clockwise) {
+      // History forward
+      register_code(KC_LGUI);
+      tap_code(KC_RBRC);
+      clear_keyboard();
+    } else {
+      // History back
+      register_code(KC_LGUI);
+      tap_code(KC_LBRC);
+      clear_keyboard();
+    }
+  }
+}

--- a/keyboards/keebio/bdn9/keymaps/vosechu-browser/keymap.c
+++ b/keyboards/keebio/bdn9/keymaps/vosechu-browser/keymap.c
@@ -1,24 +1,19 @@
 #include QMK_KEYBOARD_H
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define _LAYER_ KC_TRNS
-#define XXXXXXX KC_NO
-
 // Macro keys for some apps
 #define SLACKUP LALT(LSFT(KC_UP))
 #define SLACKDN LALT(LSFT(KC_DOWN))
 #define RELOAD  LGUI(KC_R)
 
-enum {
+enum custom_keycodes {
   PAWFIVE = SAFE_RANGE
 };
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   [0] = LAYOUT(
-    RESET  , PAWFIVE, RELOAD , \
-    SLACKUP, KC_UP  , KC_PGUP, \
-    SLACKDN, KC_DOWN, KC_PGDN \
+    RESET  , PAWFIVE, RELOAD ,
+    SLACKUP, KC_UP  , KC_PGUP,
+    SLACKDN, KC_DOWN, KC_PGDN
   ),
 };
 
@@ -32,7 +27,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
   switch (keycode) {
     case PAWFIVE:
       if (record->event.pressed) {
-        SEND_STRING("+:pawfive:");
+        SEND_STRING("+:pawfive:\n");
         return false;
       }
   }
@@ -44,29 +39,19 @@ void encoder_update_user(uint8_t index, bool clockwise) {
   if (index == 0) {
     if (clockwise) {
       // Tab right
-      register_code(KC_LGUI);
-      register_code(KC_LSFT);
-      tap_code(KC_RBRC);
-      clear_keyboard();
+      tap_code16(LSFT(LGUI(KC_RBRC)));
     } else {
       // Tab left
-      register_code(KC_LGUI);
-      register_code(KC_LSFT);
-      tap_code(KC_LBRC);
-      clear_keyboard();
+      tap_code16(LSFT(LGUI(KC_LBRC)));
     }
   }
   else if (index == 1) {
     if (clockwise) {
       // History forward
-      register_code(KC_LGUI);
-      tap_code(KC_RBRC);
-      clear_keyboard();
+      tap_code16(LGUI(KC_RBRC));
     } else {
       // History back
-      register_code(KC_LGUI);
-      tap_code(KC_LBRC);
-      clear_keyboard();
+      tap_code16(LGUI(KC_LBRC));
     }
   }
 }

--- a/keyboards/keebio/bdn9/keymaps/vosechu-ksp/keymap.c
+++ b/keyboards/keebio/bdn9/keymaps/vosechu-ksp/keymap.c
@@ -18,11 +18,6 @@
 // // Debugging
 // #include <print.h>
 
-// Fillers to make layering more clear
-#define _______ KC_TRNS
-#define _LAYER_ KC_TRNS
-#define XXXXXXX KC_NO
-
 #define BASE   TO(_BASE)
 #define PANIC  TO(_PANIC)
 #define FLIGHT TO(_FLIGHT)
@@ -37,24 +32,24 @@ enum my_layers {
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [_BASE] = LAYOUT(
-        KC_MUTE, PANIC  , XXXXXXX, \
-        FLIGHT , XXXXXXX, RCS    , \
-        XXXXXXX, XXXXXXX, XXXXXXX \
+        KC_MUTE, PANIC  , XXXXXXX,
+        FLIGHT , XXXXXXX, RCS    ,
+        XXXXXXX, XXXXXXX, XXXXXXX
     ),
     [_PANIC] = LAYOUT(
-        RESET  , BASE   , XXXXXXX, \
-        _______, XXXXXXX, _______, \
-        KC_F2  , KC_F5  , KC_F9 \
+        RESET  , BASE   , XXXXXXX,
+        _______, XXXXXXX, _______,
+        KC_F2  , KC_F5  , KC_F9
     ),
     [_FLIGHT] = LAYOUT(
-        XXXXXXX, _______, KC_M   , \
-        BASE   , KC_W   , _______, \
-        KC_A   , KC_S   , KC_D \
+        XXXXXXX, _______, KC_M   ,
+        BASE   , KC_W   , _______,
+        KC_A   , KC_S   , KC_D
     ),
     [_RCS] = LAYOUT(
-        XXXXXXX, _______, XXXXXXX, \
-        _______, KC_I   , BASE   , \
-        KC_J   , KC_K   , KC_L \
+        XXXXXXX, _______, XXXXXXX,
+        _______, KC_I   , BASE   ,
+        KC_J   , KC_K   , KC_L
     )
 };
 
@@ -167,14 +162,10 @@ void encoder_update_user(uint8_t index, bool clockwise) {
         else if (index == 1) {
             if (clockwise) {
                 // Trim left
-                register_code(KC_LALT);
-                tap_code(KC_A);
-                unregister_code(KC_LALT);
+                tap_code16(LALT(KC_A));
             } else {
                 // Trim right
-                register_code(KC_LALT);
-                tap_code(KC_D);
-                unregister_code(KC_LALT);
+                tap_code16(LALT(KC_D));
             }
         }
     }

--- a/keyboards/keebio/bdn9/keymaps/vosechu-ksp/keymap.c
+++ b/keyboards/keebio/bdn9/keymaps/vosechu-ksp/keymap.c
@@ -1,0 +1,181 @@
+/* Copyright 2019 Chuck Lauer Vose <vosechu@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include QMK_KEYBOARD_H
+
+// // Debugging
+// #include <print.h>
+
+// Fillers to make layering more clear
+#define _______ KC_TRNS
+#define _LAYER_ KC_TRNS
+#define XXXXXXX KC_NO
+
+#define BASE   TO(_BASE)
+#define PANIC  TO(_PANIC)
+#define FLIGHT TO(_FLIGHT)
+#define RCS    TO(_RCS)
+
+enum my_layers {
+    _BASE = 0,
+    _PANIC,
+    _FLIGHT,
+    _RCS
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [_BASE] = LAYOUT(
+        KC_MUTE, PANIC  , XXXXXXX, \
+        FLIGHT , XXXXXXX, RCS    , \
+        XXXXXXX, XXXXXXX, XXXXXXX \
+    ),
+    [_PANIC] = LAYOUT(
+        RESET  , BASE   , XXXXXXX, \
+        _______, XXXXXXX, _______, \
+        KC_F2  , KC_F5  , KC_F9 \
+    ),
+    [_FLIGHT] = LAYOUT(
+        XXXXXXX, _______, KC_M   , \
+        BASE   , KC_W   , _______, \
+        KC_A   , KC_S   , KC_D \
+    ),
+    [_RCS] = LAYOUT(
+        XXXXXXX, _______, XXXXXXX, \
+        _______, KC_I   , BASE   , \
+        KC_J   , KC_K   , KC_L \
+    )
+};
+
+bool base_mode = false;
+bool panic_mode = false;
+bool flight_mode = false;
+bool rcs_mode = false;
+
+uint32_t layer_state_set_user(uint32_t state) {
+    base_mode = false;
+    panic_mode = false;
+    flight_mode = false;
+    rcs_mode = false;
+
+    switch (biton32(state)) {
+    case _PANIC:
+        panic_mode = true; // For use in encoder evaluation
+        rgblight_sethsv_noeeprom(HSV_RED);
+        break;
+    case _FLIGHT:
+        flight_mode = true; // For use in encoder evaluation
+        rgblight_sethsv_noeeprom(HSV_CYAN);
+        break;
+    case _RCS:
+        rcs_mode = true; // For use in encoder evaluation
+        rgblight_sethsv_noeeprom(HSV_BLUE);
+        break;
+    default: //  for any other layers, or the default layer
+        base_mode = true;
+        rgblight_sethsv_noeeprom(HSV_SPRINGGREEN);
+        break;
+    }
+    return state;
+}
+
+void keyboard_post_init_user(void) {
+    // Call the post init code.
+    rgblight_enable_noeeprom(); // enables Rgb, without saving settings
+    rgblight_mode_noeeprom(RGBLIGHT_MODE_BREATHING + 1); // sets mode to Slow breathing without saving
+    rgblight_sethsv_noeeprom(HSV_SPRINGGREEN);
+}
+
+// bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+//     switch (keycode) {
+//         uprintf("Keycode: %s\n", keycode);
+//         if (record->event.pressed) {
+//           print("pressed");
+//           // Do something when pressed
+//         } else {
+//           print("unpressed");
+//           // Do something else when release
+//         }
+//     }
+//     return true;
+// }
+
+void encoder_update_user(uint8_t index, bool clockwise) {
+    if(base_mode == true) {
+        if (index == 0) {
+            if (clockwise) {
+                // Volume up
+                tap_code(KC_VOLU);
+            } else {
+                // Volume down
+                tap_code(KC_VOLD);
+            }
+        }
+        else if (index == 1) {
+            if (clockwise) {
+                // Time warp faster
+                tap_code(KC_DOT);
+            } else {
+                // Time warp slower
+                tap_code(KC_COMM);
+            }
+        }
+    }
+
+    if(rcs_mode == true) {
+        if (index == 0) {
+            if (clockwise) {
+                // RCS Forward
+                tap_code(KC_H);
+            } else {
+                // RCS Backward
+                tap_code(KC_N);
+            }
+        }
+        else if (index == 1) {
+            if (clockwise) {
+                // RCS Rotate Left
+                tap_code(KC_Q);
+            } else {
+                // RCS Rotate Right
+                tap_code(KC_E);
+            }
+        }
+    }
+
+    if(flight_mode == true) {
+        if (index == 0) {
+            if (clockwise) {
+                // Throttle up
+                tap_code(KC_LSFT);
+            } else {
+                // Throttle down
+                tap_code(KC_LCTL);
+            }
+        }
+        else if (index == 1) {
+            if (clockwise) {
+                // Trim left
+                register_code(KC_LALT);
+                tap_code(KC_A);
+                unregister_code(KC_LALT);
+            } else {
+                // Trim right
+                register_code(KC_LALT);
+                tap_code(KC_D);
+                unregister_code(KC_LALT);
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

Add several examples for use in our company keyboard building activity!

## Description

This adds a simple layout which has examples of different encoder options, slack reactions, default lights, and some macro definitions
Also adds a much more complex gaming example for use with KSP which demonstrates per-layer colors, multiple layers, and debugging examples

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
