### PR TITLE
[Docs] Add dedicated page for Split Keyboard information

### DIFF
--- a/docs/_summary.md
+++ b/docs/_summary.md
@@ -73,6 +73,7 @@
   * [RGB Lighting](feature_rgblight.md)
   * [RGB Matrix](feature_rgb_matrix.md)
   * [Space Cadet](feature_space_cadet.md)
+  * [Split Keyboard](feature_split_keyboard.md)
   * [Stenography](feature_stenography.md)
   * [Swap Hands](feature_swap_hands.md)
   * [Tap Dance](feature_tap_dance.md)

--- a/docs/feature_split_keyboard.md
+++ b/docs/feature_split_keyboard.md
@@ -132,7 +132,9 @@ This enables I<sup>2</sup>C support for split keyboards. This isn't strictly for
 #define SOFT_SERIAL_PIN D0
 ```
 
-This sets the pin to be used for serial communication. If you're not using serial, you shouldn't need to define this. 
+This sets the pin to be used for serial communication. If you're not using serial, you shouldn't need to define this.  
+
+However, if you are using serial and i2c on the board, you will need to set this, and to something other than D0 and D1 (as these are used for I<sup>2</sup>C communication).
 
 ```c
 #define SELECT_SOFT_SERIAL_SPEED {#}`

--- a/docs/feature_split_keyboard.md
+++ b/docs/feature_split_keyboard.md
@@ -132,12 +132,12 @@ This sets the pin to be used for serial communication. If you're not using seria
 
 If you're having issues with serial communication, you can change this value, as it controls the communication speed for serial.  The default is 1, and the possible values are:
 
-    * **0**: about 189kbps (Experimental only)
-    * **1**: about 137kbps (default)
-    * **2**: about 75kbps
-    * **3**: about 39kbps
-    * **4**: about 26kbps
-    * **5**: about 20kbps
+* **`0`**: about 189kbps (Experimental only)
+* **`1`**: about 137kbps (default)
+* **`2`**: about 75kbps
+* **`3`**: about 39kbps
+* **`4`**: about 26kbps
+* **`5`**: about 20kbps
 
 ###  Hardware Configuration Options
 

--- a/docs/feature_split_keyboard.md
+++ b/docs/feature_split_keyboard.md
@@ -107,7 +107,7 @@ or
 #define MASTER_LEFT
 ```
 
-Or by not defining any of these options (which defaults to `MASTER_LEFT`, in this case. 
+If neither are defined, the handedness defaults to `MASTER_LEFT`.
 
 
 ### Communication Options
@@ -118,7 +118,7 @@ Because not every split keyboard is identical, there are a number of additional 
 #define USE_I2C
 ```
 
-This enables I<sup>2</sup>C support for split keyboards. This isn't strictly for communication, but can be used for OLED or other I<sup>2</sup>C based devices. 
+This enables I<sup>2</sup>C support for split keyboards. This isn't strictly for communication, but can be used for OLED or other I<sup>2</sup>C-based devices. 
 
 ```c
 #define SOFT_SERIAL_PIN D0
@@ -155,7 +155,7 @@ This allows you to specify a different set of pins for the matrix on the right s
 #define RGBLIGHT_SPLIT
 ```
 
-This option enables synchronization of the RGB Light modes between the controllers of the split Keyboard.  This is for keyboards that have RGB LEDs that are directly wired to the controller (aka, that are not using the "extra data" option on the TRRS cable)
+This option enables synchronization of the RGB Light modes between the controllers of the split keyboard.  This is for keyboards that have RGB LEDs that are directly wired to the controller (that is, they are not using the "extra data" option on the TRRS cable).
 
 ```c
 #define RGBLED_SPLIT { 6, 6 }

--- a/docs/feature_split_keyboard.md
+++ b/docs/feature_split_keyboard.md
@@ -1,25 +1,25 @@
 # Split Keyboard 
 
-Many keyboards in QMK Firmware's repo are "split" keyboards. Meaning, they use two controllers, one plugging into USB, and the second connected by a serial or an I<sup>2</sup>C connection over a TRRS or similar cable. 
+Many keyboards in the QMK Firmware repo are "split" keyboards. They use two controllers—one plugging into USB, and the second connected by a serial or an I<sup>2</sup>C connection over a TRRS or similar cable. 
 
-Split keyboards can have a lot of benefits, but there are some additional work to get them enabled.  
+Split keyboards can have a lot of benefits, but there is some additional work needed to get them enabled.  
 
 QMK Firmware has a generic implementation that is usable by any board, as well as numerous board specific implementations. 
 
-For this, we will mostly be talking about the generic implementation used by the Lets Split and other keyboards. 
+For this, we will mostly be talking about the generic implementation used by the Let's Split and other keyboards. 
 
 
 ## Hardware Configuration
 
-This assumes that you're using two Pro Micro compatible controllers, and are using TRRS jacks to connect to two halves. 
+This assumes that you're using two Pro Micro-compatible controllers, and are using TRRS jacks to connect to two halves. 
 
 ### Required Hardware
 
-Apart from diodes and key switches for the keyboard matrix in each half, you will need 2x TRRS sockets and 1x TRRS cable
+Apart from diodes and key switches for the keyboard matrix in each half, you will need 2x TRRS sockets and 1x TRRS cable.
 
 Alternatively, you can use any sort of cable and socket that has at least 3 wires. 
 
-If you want to use I2C to communicate between halves, you will need a cable with at least 4 wires and 2x 4.7kΩ pull-up resistors.
+If you want to use I<sup>2</sup>C to communicate between halves, you will need a cable with at least 4 wires and 2x 4.7kΩ pull-up resistors.
 
 
 
@@ -27,13 +27,13 @@ If you want to use I2C to communicate between halves, you will need a cable with
 
 The 3 wires of the TRS/TRRS cable need to connect GND, VCC, and D0 (aka PDO or pin 3) between the two Pro Micros. 
 
-?> Note that pin used here is actually set by `SOFT_SERIAL_PIN` below.
+?> Note that the pin used here is actually set by `SOFT_SERIAL_PIN` below.
 
 ![serial wiring](https://i.imgur.com/C3D1GAQ.png)
 
-### I2C Wiring
+### I<sup>2</sup>C Wiring
 
-The 4 wires of the TRRS cable need to connect GND, VCC, and SLC and SDA (aka PD0/pin 3 and PD1/pin 2, respectively) between the two Pro Micros. 
+The 4 wires of the TRRS cable need to connect GND, VCC, and SCL and SDA (aka PD0/pin 3 and PD1/pin 2, respectively) between the two Pro Micros. 
 
 The pull-up resistors may be placed on either half. It is also possible
 to use 4 resistors and have the pull-ups in both halves, but this is
@@ -57,7 +57,7 @@ SPLIT_TRANSPORT = custom
 
 ### Setting Handedness
 
-By default, the firmware does not know what side is which.  It needs some help to determine that. And there are several ways to do this.  And they are listed in order of precedence. 
+By default, the firmware does not know which side is which; it needs some help to determine that. There are several ways to do this, listed in order of precedence.
 
 #### Handedness by Pin
 
@@ -73,24 +73,24 @@ This will read the specified pin. If it's high, then the controller assumes it i
 
 This method sets the and reads the handedness by using the EEPROM (persistent storage of the controller). 
 
-To set enable this method, add the following to your `config.h` file: 
+To enable this method, add the following to your `config.h` file: 
 
 ```c
 #define EE_HANDS
 ```
 
-However, you'll have to flash the eeprom files for the correct hand to each controller.  You can do this manually, or there are targets for avrdude and dfu to do this, while flashing the firmware: 
+However, you'll have to flash the EEPROM files for the correct hand to each controller.  You can do this manually, or there are targets for avrdude and dfu to do this, while flashing the firmware: 
 
 * `:avrdude-split-left`
 * `:avrdude-split-right`
 * `:dfu-split-left`
 * `:dfu-split-right`
 
-If you reset the eeprom outside of the firmeware's built in options (such as using the QMK Toolbox's "reset EEPROM" option), you'll need to re-flash the EEPROM files. 
+If you reset the EEPROM outside of the firmeware's built in options (such as using the QMK Toolbox's "Reset EEPROM" option), you'll need to re-flash the EEPROM files. 
 
 You can find the EEPROM files in the QMK firmware repo, [here](https://github.com/qmk/qmk_firmware/tree/master/quantum/split_common). 
 
-#### Handedness by define
+#### Handedness by `#define`
 
 You can set the handedness at compile time.  This is done by adding the following to your `config.h` file:
 
@@ -107,7 +107,7 @@ or
 Or by not defining any of these options (which defaults to `MASTER_LEFT`, in this case. 
 
 
-### Communication options
+### Communication Options
 
 Because not every split keyboard is identical, there are a number of additional options that can be configured in your `config.h` file.
 
@@ -127,7 +127,7 @@ This sets the pin to be used for serial communication. If you're not using seria
 #define SELECT_SOFT_SERIAL_SPEED {#}` 
 ```
 
-If you're having issues with serial communication, you can change this value, as it controls the communication speed for serial.  It defaults to 1, but the possible values are: 
+If you're having issues with serial communication, you can change this value, as it controls the communication speed for serial.  The default is 1, and the possible values are:
 
     * __0__: about 189kbps (Experimental only)
     * __1__: about 137kbps (default)
@@ -145,10 +145,10 @@ There are some settings that you may need to configure, based on how the hardwar
 #define MATRIX_COL_PINS_RIGHT { <col pins> }
 ```
 
-This allows you to specify a different set of pins for the matrix on the right side.  This is useful, if you have a board that the halves are very differently shaped, and need different configurations (such as Keebio's Quefrency keyboard).
+This allows you to specify a different set of pins for the matrix on the right side.  This is useful if you have a board with differently-shaped halves that requires a different configuration (such as Keebio's Quefrency).
 
 ```c
 #define RGBLED_SPLIT { 6, 6 }
 ```
 
-This lets set how many LEDs are connected to each controller. 
+This sets how many LEDs are connected to each controller.

--- a/docs/feature_split_keyboard.md
+++ b/docs/feature_split_keyboard.md
@@ -49,7 +49,7 @@ The 4 wires of the TRRS cable need to connect GND, VCC, and SCL and SDA (aka PD0
 
 The pull-up resistors may be placed on either half. It is also possible to use 4 resistors and have the pull-ups in both halves, but this is unnecessary in simple use cases.
 
-![I<sup>2</sup>C wiring](https://i.imgur.com/Hbzhc6E.png)
+![I2C wiring](https://i.imgur.com/Hbzhc6E.png)
 
 ## Firmware Configuration
 

--- a/docs/feature_split_keyboard.md
+++ b/docs/feature_split_keyboard.md
@@ -37,9 +37,7 @@ The 3 wires of the TRS/TRRS cable need to connect GND, VCC, and D0 (aka PDO or p
 
 The 4 wires of the TRRS cable need to connect GND, VCC, and SCL and SDA (aka PD0/pin 3 and PD1/pin 2, respectively) between the two Pro Micros. 
 
-The pull-up resistors may be placed on either half. It is also possible
-to use 4 resistors and have the pull-ups in both halves, but this is
-unnecessary in simple use cases.
+The pull-up resistors may be placed on either half. It is also possible to use 4 resistors and have the pull-ups in both halves, but this is unnecessary in simple use cases.
 
 ![i2c wiring](https://i.imgur.com/Hbzhc6E.png)
 

--- a/docs/feature_split_keyboard.md
+++ b/docs/feature_split_keyboard.md
@@ -49,7 +49,7 @@ The 4 wires of the TRRS cable need to connect GND, VCC, and SCL and SDA (aka PD0
 
 The pull-up resistors may be placed on either half. It is also possible to use 4 resistors and have the pull-ups in both halves, but this is unnecessary in simple use cases.
 
-![i2c wiring](https://i.imgur.com/Hbzhc6E.png)
+![I<sup>2</sup>C wiring](https://i.imgur.com/Hbzhc6E.png)
 
 ## Firmware Configuration
 
@@ -134,7 +134,7 @@ This enables I<sup>2</sup>C support for split keyboards. This isn't strictly for
 
 This sets the pin to be used for serial communication. If you're not using serial, you shouldn't need to define this.  
 
-However, if you are using serial and i2c on the board, you will need to set this, and to something other than D0 and D1 (as these are used for I<sup>2</sup>C communication).
+However, if you are using serial and I<sup>2</sup>C on the board, you will need to set this, and to something other than D0 and D1 (as these are used for I<sup>2</sup>C communication).
 
 ```c
 #define SELECT_SOFT_SERIAL_SPEED {#}`

--- a/docs/feature_split_keyboard.md
+++ b/docs/feature_split_keyboard.md
@@ -73,7 +73,8 @@ This will read the specified pin. If it's high, then the controller assumes it i
 
 #### Handedness by EEPROM
 
-This method sets the and reads the handedness by using the EEPROM (persistent storage of the controller). 
+This method sets the keyboard's handedness by setting a flag in the persistent storage (`EEPROM`).  This is checked when the controller first starts up, and determines what half the keyboard is, and how to orient the keyboard layout. 
+
 
 To enable this method, add the following to your `config.h` file: 
 
@@ -88,9 +89,9 @@ However, you'll have to flash the EEPROM files for the correct hand to each cont
 * `:dfu-split-left`
 * `:dfu-split-right`
 
-If you reset the EEPROM outside of the firmware's built in options (such as using the QMK Toolbox's "Reset EEPROM" option), you'll need to re-flash the EEPROM files. 
+This setting is not changed when re-initializing the EEPROM using the `EEP_RST` key, or using the `eeconfig_init()` function.  However, if you reset the EEPROM outside of the firmware's built in options (such as flashing a file that overwrites the `EEPROM`, like how the [QMK Toolbox]()'s "Reset EEPROM" button works), you'll need to re-flash the controller with the `EEPROM` files. 
 
-You can find the EEPROM files in the QMK firmware repo, [here](https://github.com/qmk/qmk_firmware/tree/master/quantum/split_common). 
+You can find the `EEPROM` files in the QMK firmware repo, [here](https://github.com/qmk/qmk_firmware/tree/master/quantum/split_common). 
 
 #### Handedness by `#define`
 
@@ -149,8 +150,26 @@ There are some settings that you may need to configure, based on how the hardwar
 
 This allows you to specify a different set of pins for the matrix on the right side.  This is useful if you have a board with differently-shaped halves that requires a different configuration (such as Keebio's Quefrency).
 
+
+```c
+#define RGBLIGHT_SPLIT
+```
+
+This option enables synchronization of the RGB Light modes between the controllers of the split Keyboard.  This is for keyboards that have RGB LEDs that are directly wired to the controller (aka, that are not using the "extra data" option on the TRRS cable)
+
 ```c
 #define RGBLED_SPLIT { 6, 6 }
 ```
 
-This sets how many LEDs are connected to each controller.
+This sets how many LEDs are directly connected to each controller.  The first number is the left side, and the second number is the right side.  
+
+?> This setting implies that `RGBLIGHT_SPLIT` is enabled, and will forcibly enable it, if it's not.
+
+
+## Additional Resources
+
+Nicinabox has a [very nice and detailed guide](https://github.com/nicinabox/lets-split-guide) for the Let's Split keyboard, that covers most everything you need to know, including troubleshooting information. 
+
+However, the RGB Light section is out of date, as it was written long before the RGB Split code was added to QMK Firmware. Instead, wire each strip up directly to the controller.
+
+<!-- I may port this information later, but for now ... it's very nice, and covers everything -->

--- a/docs/feature_split_keyboard.md
+++ b/docs/feature_split_keyboard.md
@@ -1,0 +1,154 @@
+# Split Keyboard 
+
+Many keyboards in QMK Firmware's repo are "split" keyboards. Meaning, they use two controllers, one plugging into USB, and the second connected by a serial or an I<sup>2</sup>C connection over a TRRS or similar cable. 
+
+Split keyboards can have a lot of benefits, but there are some additional work to get them enabled.  
+
+QMK Firmware has a generic implementation that is usable by any board, as well as numerous board specific implementations. 
+
+For this, we will mostly be talking about the generic implementation used by the Lets Split and other keyboards. 
+
+
+## Hardware Configuration
+
+This assumes that you're using two Pro Micro compatible controllers, and are using TRRS jacks to connect to two halves. 
+
+### Required Hardware
+
+Apart from diodes and key switches for the keyboard matrix in each half, you will need 2x TRRS sockets and 1x TRRS cable
+
+Alternatively, you can use any sort of cable and socket that has at least 3 wires. 
+
+If you want to use I2C to communicate between halves, you will need a cable with at least 4 wires and 2x 4.7kΩ pull-up resistors.
+
+
+
+### Serial Wiring
+
+The 3 wires of the TRS/TRRS cable need to connect GND, VCC, and D0 (aka PDO or pin 3) between the two Pro Micros. 
+
+?> Note that pin used here is actually set by `SOFT_SERIAL_PIN` below.
+
+![serial wiring](https://i.imgur.com/C3D1GAQ.png)
+
+### I2C Wiring
+
+The 4 wires of the TRRS cable need to connect GND, VCC, and SLC and SDA (aka PD0/pin 3 and PD1/pin 2, respectively) between the two Pro Micros. 
+
+The pull-up resistors may be placed on either half. It is also possible
+to use 4 resistors and have the pull-ups in both halves, but this is
+unnecessary in simple use cases.
+
+![i2c wiring](https://i.imgur.com/Hbzhc6E.png)
+
+## Firmware Configuration
+
+To enable the split keyboard feature, add the following to your `rules.mk`: 
+
+```make
+SPLIT_KEYBOARD = yes
+```
+
+If you're using a custom transport (communication method), then you will also need to add: 
+
+```make
+SPLIT_TRANSPORT = custom
+```
+
+### Setting Handedness
+
+By default, the firmware does not know what side is which.  It needs some help to determine that. And there are several ways to do this.  And they are listed in order of precedence. 
+
+#### Handedness by Pin
+
+You can configure the firmware to read a pin on the controller to determine handedness.  To do this, add the following to your `config.h` file:
+
+```c
+#define SPLIT_HAND_PIN B7
+```
+
+This will read the specified pin. If it's high, then the controller assumes it is the left hand, and if it's low, it's assumed to be the right side. 
+
+#### Handedness by EEPROM
+
+This method sets the and reads the handedness by using the EEPROM (persistent storage of the controller). 
+
+To set enable this method, add the following to your `config.h` file: 
+
+```c
+#define EE_HANDS
+```
+
+However, you'll have to flash the eeprom files for the correct hand to each controller.  You can do this manually, or there are targets for avrdude and dfu to do this, while flashing the firmware: 
+
+* `:avrdude-split-left`
+* `:avrdude-split-right`
+* `:dfu-split-left`
+* `:dfu-split-right`
+
+If you reset the eeprom outside of the firmeware's built in options (such as using the QMK Toolbox's "reset EEPROM" option), you'll need to re-flash the EEPROM files. 
+
+You can find the EEPROM files in the QMK firmware repo, [here](https://github.com/qmk/qmk_firmware/tree/master/quantum/split_common). 
+
+#### Handedness by define
+
+You can set the handedness at compile time.  This is done by adding the following to your `config.h` file:
+
+```c
+#define MASTER_RIGHT
+```
+
+or 
+
+```c
+#define MASTER_LEFT
+```
+
+Or by not defining any of these options (which defaults to `MASTER_LEFT`, in this case. 
+
+
+### Communication options
+
+Because not every split keyboard is identical, there are a number of additional options that can be configured in your `config.h` file.
+
+```c
+#define USE_I2C
+```
+
+This enables I<sup>2</sup>C support for split keyboards. This isn't strictly for communication, but can be used for OLED or other I<sup>2</sup>C based devices. 
+
+```c
+#define SOFT_SERIAL_PIN D0
+```
+
+This sets the pin to be used for serial communication. If you're not using serial, you shouldn't need to define this. 
+
+```c
+#define SELECT_SOFT_SERIAL_SPEED {#}` 
+```
+
+If you're having issues with serial communication, you can change this value, as it controls the communication speed for serial.  It defaults to 1, but the possible values are: 
+
+    * __0__: about 189kbps (Experimental only)
+    * __1__: about 137kbps (default)
+    * __2__: about 75kbps
+    * __3__: about 39kbps
+    * __4__: about 26kbps
+    * __5__: about 20kbps
+
+###  Hardware Configuration Options
+
+There are some settings that you may need to configure, based on how the hardware is set up. 
+
+```c
+#define MATRIX_ROW_PINS_RIGHT { <row pins> }
+#define MATRIX_COL_PINS_RIGHT { <col pins> }
+```
+
+This allows you to specify a different set of pins for the matrix on the right side.  This is useful, if you have a board that the halves are very differently shaped, and need different configurations (such as Keebio's Quefrency keyboard).
+
+```c
+#define RGBLED_SPLIT { 6, 6 }
+```
+
+This lets set how many LEDs are connected to each controller. 

--- a/docs/feature_split_keyboard.md
+++ b/docs/feature_split_keyboard.md
@@ -33,7 +33,7 @@ Another option is to use phone cables (as in, old school RJ-11/RJ-14 cables). Ma
 
 However, USB cables, SATA cables, and even just 4 wires have been known to be used for communication between the controllers. 
 
-!> Using USB Cables for communication between the controllers works just fine. But you could plug in a normal USB cable here and short out the keyboard, depending on how it's wired.  We would not recommend using USB cables for communication, for this reason. 
+!> Using USB cables for communication between the controllers works just fine, but the connector could be mistaken for a normal USB connection and potentially short out the keyboard, depending on how it's wired.  For this reason, they are not recommended for connecting split keyboards.  
 
 ### Serial Wiring
 

--- a/docs/feature_split_keyboard.md
+++ b/docs/feature_split_keyboard.md
@@ -86,7 +86,7 @@ However, you'll have to flash the EEPROM files for the correct hand to each cont
 * `:dfu-split-left`
 * `:dfu-split-right`
 
-If you reset the EEPROM outside of the firmeware's built in options (such as using the QMK Toolbox's "Reset EEPROM" option), you'll need to re-flash the EEPROM files. 
+If you reset the EEPROM outside of the firmware's built in options (such as using the QMK Toolbox's "Reset EEPROM" option), you'll need to re-flash the EEPROM files. 
 
 You can find the EEPROM files in the QMK firmware repo, [here](https://github.com/qmk/qmk_firmware/tree/master/quantum/split_common). 
 

--- a/docs/feature_split_keyboard.md
+++ b/docs/feature_split_keyboard.md
@@ -8,6 +8,8 @@ QMK Firmware has a generic implementation that is usable by any board, as well a
 
 For this, we will mostly be talking about the generic implementation used by the Let's Split and other keyboards. 
 
+!> ARM is not yet supported for Split Keyboards.  Progress is being made, but we are not quite there, yet. 
+
 
 ## Hardware Configuration
 
@@ -124,17 +126,17 @@ This enables I<sup>2</sup>C support for split keyboards. This isn't strictly for
 This sets the pin to be used for serial communication. If you're not using serial, you shouldn't need to define this. 
 
 ```c
-#define SELECT_SOFT_SERIAL_SPEED {#}` 
+#define SELECT_SOFT_SERIAL_SPEED {#}`
 ```
 
 If you're having issues with serial communication, you can change this value, as it controls the communication speed for serial.  The default is 1, and the possible values are:
 
-    * __0__: about 189kbps (Experimental only)
-    * __1__: about 137kbps (default)
-    * __2__: about 75kbps
-    * __3__: about 39kbps
-    * __4__: about 26kbps
-    * __5__: about 20kbps
+    * **0**: about 189kbps (Experimental only)
+    * **1**: about 137kbps (default)
+    * **2**: about 75kbps
+    * **3**: about 39kbps
+    * **4**: about 26kbps
+    * **5**: about 20kbps
 
 ###  Hardware Configuration Options
 

--- a/docs/feature_split_keyboard.md
+++ b/docs/feature_split_keyboard.md
@@ -23,7 +23,17 @@ Alternatively, you can use any sort of cable and socket that has at least 3 wire
 
 If you want to use I<sup>2</sup>C to communicate between halves, you will need a cable with at least 4 wires and 2x 4.7kΩ pull-up resistors.
 
+#### Considerations 
 
+The most commonly used connection is a TRRS cable and jacks.  These provide 4 wires, making them very useful for split keyboards, and are easy to find. 
+
+However, since one of the wires carries VCC, this means that the boards are not hot pluggable. You should always disconnect the board from USB before unplugging and plugging in TRRS cables, or you can short the controller, or worse. 
+
+Another option is to use phone cables (as in, old school RJ-11/RJ-14 cables). Make sure that you use one that actually supports 4 wires/lanes.  
+
+However, USB cables, SATA cables, and even just 4 wires have been known to be used for communication between the controllers. 
+
+!> Using USB Cables for communication between the controllers works just fine. But you could plug in a normal USB cable here and short out the keyboard, depending on how it's wired.  We would not recommend using USB cables for communication, for this reason. 
 
 ### Serial Wiring
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -30,6 +30,7 @@ QMK has a staggering number of features for building your keyboard. It can take 
 * [RGB Light](feature_rgblight.md) - RGB lighting for your keyboard.
 * [RGB Matrix](feature_rgb_matrix.md) - RGB Matrix lights for per key lighting.
 * [Space Cadet](feature_space_cadet.md) - Use your left/right shift keys to type parenthesis and brackets.
+* [Split Keyboard](feature_split_keyboard.md) 
 * [Stenography](feature_stenography.md) - Put your keyboard into Plover mode for stenography use.
 * [Swap Hands](feature_swap_hands.md) - Mirror your keyboard for one handed usage.
 * [Tap Dance](feature_tap_dance.md) - Make a single key do as many things as you want.


### PR DESCRIPTION
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).


## To Do

- [ ] Include more information about hardware, and wiring 
- [ ] Add Troubleshooting info
- [ ] Add RGB Underglow information
