### PR TITLE
Enable RGBLIGHT_ANIMATIONS by default on the Zen rev2

### DIFF
--- a/keyboards/zen/rev2/config.h
+++ b/keyboards/zen/rev2/config.h
@@ -65,6 +65,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGBLED_NUM 34    // Number of LEDs
+#define RGBLIGHT_ANIMATIONS
 
 /*
  * Feature disable options

--- a/keyboards/zen/rev2/rev2.c
+++ b/keyboards/zen/rev2/rev2.c
@@ -24,7 +24,7 @@ const char* layer_name_user(uint32_t layer) {
 
 __attribute__((weak))
 void render_status(void) {
-  // Setup for 90 degree rendering because it's awesome!
+  // Setup for 270 degree rendering because it's awesome!
   // It can house 16 lines of text, with 5 letters each line
   // Render to mode icon
   static const char PROGMEM mode_logo[2][4] = {
@@ -49,7 +49,7 @@ void render_status(void) {
 
 oled_rotation_t oled_init_user(oled_rotation_t rotation) {
   if (is_keyboard_master())
-    return OLED_ROTATION_90;  // flips the display 90 degrees if mainhand
+    return OLED_ROTATION_270;  // flips the display 270 degrees if mainhand
   return rotation;
 }
 


### PR DESCRIPTION
## Description

I forgot to enable this by default and lots of sad users told me I was bad and I should feel bad.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
