### PR TITLE
Cycle out to in rgb matrix effect

### DIFF
--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -197,6 +197,8 @@ enum rgb_matrix_effects {
     RGB_MATRIX_CYCLE_ALL,           // Full keyboard solid hue cycling through full gradient
     RGB_MATRIX_CYCLE_LEFT_RIGHT,    // Full gradient scrolling left to right
     RGB_MATRIX_CYCLE_UP_DOWN,       // Full gradient scrolling top to bottom
+    RGB_MATRIX_CYCLE_OUT_IN,        // Full gradient scrolling out to in
+    RGB_MATRIX_CYCLE_OUT_IN_DUAL,   // Full dual gradients scrolling out to in
     RGB_MATRIX_RAINBOW_MOVING_CHEVRON,  // Full gradent Chevron shapped scrolling left to right
     RGB_MATRIX_DUAL_BEACON,         // Full gradient spinning around center of keyboard
     RGB_MATRIX_RAINBOW_BEACON,      // Full tighter gradient spinning around center of keyboard
@@ -236,6 +238,8 @@ You can disable a single effect by defining `DISABLE_[EFFECT_NAME]` in your `con
 |`#define DISABLE_RGB_MATRIX_CYCLE_ALL`                 |Disables `RGB_MATRIX_CYCLE_ALL`                |
 |`#define DISABLE_RGB_MATRIX_CYCLE_LEFT_RIGHT`          |Disables `RGB_MATRIX_CYCLE_LEFT_RIGHT`         |
 |`#define DISABLE_RGB_MATRIX_CYCLE_UP_DOWN`             |Disables `RGB_MATRIX_CYCLE_UP_DOWN`            |
+|`#define DISABLE_RGB_MATRIX_CYCLE_OUT_IN`              |Disables `RGB_MATRIX_CYCLE_OUT_IN`             |
+|`#define DISABLE_RGB_MATRIX_CYCLE_OUT_IN_DUAL`         |Disables `RGB_MATRIX_CYCLE_OUT_IN_DUAL`        |
 |`#define DISABLE_RGB_MATRIX_RAINBOW_MOVING_CHEVRON`    |Disables `RGB_MATRIX_RAINBOW_MOVING_CHEVRON`   |
 |`#define DISABLE_RGB_MATRIX_DUAL_BEACON`               |Disables `RGB_MATRIX_DUAL_BEACON`              |
 |`#define DISABLE_RGB_MATRIX_RAINBOW_BEACON`            |Disables `RGB_MATRIX_RAINBOW_BEACON`           |

--- a/quantum/rgb_matrix_animations/cycle_out_in_anim.h
+++ b/quantum/rgb_matrix_animations/cycle_out_in_anim.h
@@ -1,0 +1,23 @@
+#ifndef DISABLE_RGB_MATRIX_CYCLE_OUT_IN
+RGB_MATRIX_EFFECT(CYCLE_OUT_IN)
+#ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
+
+bool CYCLE_OUT_IN(effect_params_t* params) {
+  RGB_MATRIX_USE_LIMITS(led_min, led_max);
+
+  HSV hsv = { 0, rgb_matrix_config.sat, rgb_matrix_config.val };
+  uint8_t time = scale16by8(g_rgb_counters.tick, rgb_matrix_config.speed / 4);
+  for (uint8_t i = led_min; i < led_max; i++) {
+    RGB_MATRIX_TEST_LED_FLAGS();
+    int16_t dx = g_led_config.point[i].x - 112;
+    int16_t dy = g_led_config.point[i].y - 32;
+    uint8_t dist = sqrt16(dx * dx + dy * dy);
+    hsv.h = 3 * dist / 2 + time;
+    RGB rgb = hsv_to_rgb(hsv);
+    rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
+  }
+  return led_max < DRIVER_LED_TOTAL;
+}
+
+#endif // RGB_MATRIX_CUSTOM_EFFECT_IMPLS
+#endif // DISABLE_RGB_MATRIX_CYCLE_OUT_IN

--- a/quantum/rgb_matrix_animations/cycle_out_in_dual_anim.h
+++ b/quantum/rgb_matrix_animations/cycle_out_in_dual_anim.h
@@ -1,0 +1,23 @@
+#ifndef DISABLE_RGB_MATRIX_CYCLE_OUT_IN_DUAL
+RGB_MATRIX_EFFECT(CYCLE_OUT_IN_DUAL)
+#ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
+
+bool CYCLE_OUT_IN_DUAL(effect_params_t* params) {
+  RGB_MATRIX_USE_LIMITS(led_min, led_max);
+
+  HSV hsv = { 0, rgb_matrix_config.sat, rgb_matrix_config.val };
+  uint8_t time = scale16by8(g_rgb_counters.tick, rgb_matrix_config.speed / 4);
+  for (uint8_t i = led_min; i < led_max; i++) {
+    RGB_MATRIX_TEST_LED_FLAGS();
+    int16_t dx = 56 - abs8(g_led_config.point[i].x - 112);
+    int16_t dy = g_led_config.point[i].y - 32;
+    uint8_t dist = sqrt16(dx * dx + dy * dy);
+    hsv.h = 3 * dist + time;
+    RGB rgb = hsv_to_rgb(hsv);
+    rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
+  }
+  return led_max < DRIVER_LED_TOTAL;
+}
+
+#endif // RGB_MATRIX_CUSTOM_EFFECT_IMPLS
+#endif // DISABLE_RGB_MATRIX_CYCLE_OUT_IN_DUAL

--- a/quantum/rgb_matrix_animations/rgb_matrix_effects.inc
+++ b/quantum/rgb_matrix_animations/rgb_matrix_effects.inc
@@ -7,6 +7,8 @@
 #include "rgb_matrix_animations/cycle_left_right_anim.h"
 #include "rgb_matrix_animations/cycle_up_down_anim.h"
 #include "rgb_matrix_animations/rainbow_moving_chevron_anim.h"
+#include "rgb_matrix_animations/cycle_out_in_anim.h"
+#include "rgb_matrix_animations/cycle_out_in_dual_anim.h"
 #include "rgb_matrix_animations/dual_beacon_anim.h"
 #include "rgb_matrix_animations/rainbow_beacon_anim.h"
 #include "rgb_matrix_animations/rainbow_pinwheels_anim.h"


### PR DESCRIPTION
## Description

New rgb matrix effects: Cycle Out to In & Cycle Out to In Dual
Effect Video: https://photos.app.goo.gl/5TdFdV3CyZFQ9XV37

Built on top of PR https://github.com/qmk/qmk_firmware/pull/5811 so merge that PR first.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
