### PR TITLE
Fix RGB_MATRIX_ENABLE check in users/konstantin/rules.mk

### DIFF
--- a/users/konstantin/rules.mk
+++ b/users/konstantin/rules.mk
@@ -2,6 +2,7 @@ SRC += konstantin.c
 ifeq ($(strip $(RGBLIGHT_ENABLE)), yes)
     SRC += rgb.c
 endif
+RGB_MATRIX_ENABLE ?= no
 ifneq ($(strip $(RGB_MATRIX_ENABLE)), no)
     SRC += rgb.c
 endif


### PR DESCRIPTION
Fixes a bug introduced by #5774 

The `ifneq ($(strip $(RGB_MATRIX_ENABLE)), no)` check didn't work on its own because `RGB_MATRIX_ENABLE` is undefined rather than `no` when the userspace makefile is processed. This is because `common_features.mk` hasn't yet been included at that point, and so this line (which is supposed to set the default value to `no`) hasn't been executed:

https://github.com/qmk/qmk_firmware/blob/2ea7c597f8d66db332ab569d4e67df46e1af7cbe/common_features.mk#L139

See [here](https://github.com/qmk/qmk_firmware/pull/5774#discussion_r281043110) for some related discussion.