### PR TITLE
Added check for event pressed to clear space cadet

### DIFF
--- a/docs/feature_space_cadet.md
+++ b/docs/feature_space_cadet.md
@@ -20,7 +20,7 @@ Firstly, in your keymap, do one of the following:
 |`KC_RCPC`  |Right Control when held, `)` when tapped   |
 |`KC_LAPO`  |Left Alt when held, `(` when tapped        |
 |`KC_RAPC`  |Right Alt when held, `)` when tapped       |
-|`KC_SFTENT`|Right Shift when held, `Enter` when tapped |
+|`KC_SFTENT`|Right Shift when held, Enter when tapped   |
 
 ## Caveats
 
@@ -38,10 +38,10 @@ By default Space Cadet assumes a US ANSI layout, but if your layout uses differe
 |----------------|-------------------------------|---------------------------------------------------------------------------------|
 |`LSPO_KEYS`     |`KC_LSFT, LSPO_MOD, LSPO_KEY`  |Send `KC_LSFT` when held, the mod and  key defined by `LSPO_MOD` and `LSPO_KEY`. |
 |`RSPC_KEYS`     |`KC_RSFT, RSPC_MOD, RSPC_KEY`  |Send `KC_RSFT` when held, the mod and  key defined by `RSPC_MOD` and `RSPC_KEY`. |
-|`LCPO_KEYS`     |`KC_LCTL, KC_LCTL, KC_9`       |Send `KC_LCTL` when held, the mod `KC_LCTL` with the key `KC_9` when tapped.     |
-|`RCPC_KEYS`     |`KC_RCTL, KC_RCTL, KC_0`       |Send `KC_RCTL` when held, the mod `KC_RCTL` with the key `KC_0` when tapped.     |
-|`LAPO_KEYS`     |`KC_LALT, KC_LALT, KC_9`       |Send `KC_LALT` when held, the mod `KC_LALT` with the key `KC_9` when tapped.     |
-|`RAPC_KEYS`     |`KC_RALT, KC_RALT, KC_0`       |Send `KC_RALT` when held, the mod `KC_RALT` with the key `KC_0` when tapped.     |
+|`LCPO_KEYS`     |`KC_LCTL, KC_LSFT, KC_9`       |Send `KC_LCTL` when held, the mod `KC_LSFT` with the key `KC_9` when tapped.     |
+|`RCPC_KEYS`     |`KC_RCTL, KC_RSFT, KC_0`       |Send `KC_RCTL` when held, the mod `KC_RSFT` with the key `KC_0` when tapped.     |
+|`LAPO_KEYS`     |`KC_LALT, KC_LSFT, KC_9`       |Send `KC_LALT` when held, the mod `KC_LSFT` with the key `KC_9` when tapped.     |
+|`RAPC_KEYS`     |`KC_RALT, KC_RSFT, KC_0`       |Send `KC_RALT` when held, the mod `KC_RSFT` with the key `KC_0` when tapped.     |
 |`SFTENT_KEYS`   |`KC_RSFT, KC_TRNS, SFTENT_KEY` |Send `KC_RSFT` when held, no mod with the key `SFTENT_KEY` when tapped.          |
 
 

--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -220,7 +220,7 @@ This is a reference only. Each group of keys links to the page documenting their
 |`KC_RCPC`      |           |Right Control when held, `)` when tapped                             |
 |`KC_LAPO`      |           |Left Alt when held, `(` when tapped                                  |
 |`KC_RAPC`      |           |Right Alt when held, `)` when tapped                                 |
-|`KC_SFTENT`    |           |Right Shift when held, `Enter` when tapped                           |
+|`KC_SFTENT`    |           |Right Shift when held, Enter when tapped                             |
 |`KC_LEAD`      |           |The [Leader key](feature_leader_key.md)                              |
 |`KC_LOCK`      |           |The [Lock key](feature_key_lock.md)                                  |
 |`FUNC(n)`      |`F(n)`     |Call `fn_action(n)` (deprecated)                                     |

--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -216,6 +216,11 @@ This is a reference only. Each group of keys links to the page documenting their
 |`KC_GESC`      |`GRAVE_ESC`|Escape when tapped, <code>&#96;</code> when pressed with Shift or GUI|
 |`KC_LSPO`      |           |Left Shift when held, `(` when tapped                                |
 |`KC_RSPC`      |           |Right Shift when held, `)` when tapped                               |
+|`KC_LCPO`      |           |Left Control when held, `(` when tapped                              |
+|`KC_RCPC`      |           |Right Control when held, `)` when tapped                             |
+|`KC_LAPO`      |           |Left Alt when held, `(` when tapped                                  |
+|`KC_RAPC`      |           |Right Alt when held, `)` when tapped                                 |
+|`KC_SFTENT`    |           |Right Shift when held, `Enter` when tapped                           |
 |`KC_LEAD`      |           |The [Leader key](feature_leader_key.md)                              |
 |`KC_LOCK`      |           |The [Lock key](feature_key_lock.md)                                  |
 |`FUNC(n)`      |`F(n)`     |Call `fn_action(n)` (deprecated)                                     |

--- a/docs/quantum_keycodes.md
+++ b/docs/quantum_keycodes.md
@@ -1,6 +1,6 @@
 # Quantum Keycodes
 
-Quantum keycodes allow for easier customisation of your keymap than the basic ones provide, without having to define custom actions.
+Quantum keycodes allow for easier customization of your keymap than the basic ones provide, without having to define custom actions.
 
 All keycodes within quantum are numbers between `0x0000` and `0xFFFF`. Within your `keymap.c` it may look like you have functions and other special cases, but ultimately the C preprocessor will translate those into a single 4 byte integer. QMK has reserved `0x0000` through `0x00FF` for standard keycodes. These are keycodes such as `KC_A`, `KC_1`, and `KC_LCTL`, which are basic keys defined in the USB HID specification.
 
@@ -16,6 +16,11 @@ On this page we have documented keycodes between `0x00FF` and `0xFFFF` which are
 |`KC_GESC`      |`GRAVE_ESC`|Escape when tapped, <code>&#96;</code> when pressed with Shift or GUI|
 |`KC_LSPO`      |           |Left Shift when held, `(` when tapped                                |
 |`KC_RSPC`      |           |Right Shift when held, `)` when tapped                               |
+|`KC_LCPO`      |           |Left Control when held, `(` when tapped                              |
+|`KC_RCPC`      |           |Right Control when held, `)` when tapped                             |
+|`KC_LAPO`      |           |Left Alt when held, `(` when tapped                                  |
+|`KC_RAPC`      |           |Right Alt when held, `)` when tapped                                 |
+|`KC_SFTENT`    |           |Right Shift when held, `Enter` when tapped                           |
 |`KC_LEAD`      |           |The [Leader key](feature_leader_key.md)                              |
 |`KC_LOCK`      |           |The [Lock key](feature_key_lock.md)                                  |
 |`FUNC(n)`      |`F(n)`     |Call `fn_action(n)` (deprecated)                                     |

--- a/docs/quantum_keycodes.md
+++ b/docs/quantum_keycodes.md
@@ -20,7 +20,7 @@ On this page we have documented keycodes between `0x00FF` and `0xFFFF` which are
 |`KC_RCPC`      |           |Right Control when held, `)` when tapped                             |
 |`KC_LAPO`      |           |Left Alt when held, `(` when tapped                                  |
 |`KC_RAPC`      |           |Right Alt when held, `)` when tapped                                 |
-|`KC_SFTENT`    |           |Right Shift when held, `Enter` when tapped                           |
+|`KC_SFTENT`    |           |Right Shift when held, Enter when tapped                             |
 |`KC_LEAD`      |           |The [Leader key](feature_leader_key.md)                              |
 |`KC_LOCK`      |           |The [Lock key](feature_key_lock.md)                                  |
 |`FUNC(n)`      |`F(n)`     |Call `fn_action(n)` (deprecated)                                     |

--- a/quantum/process_keycode/process_space_cadet.c
+++ b/quantum/process_keycode/process_space_cadet.c
@@ -60,18 +60,18 @@
 
 // Control / paren setup
 #ifndef LCPO_KEYS
-  #define LCPO_KEYS KC_LCTL, KC_LCTL, KC_9
+  #define LCPO_KEYS KC_LCTL, KC_LSFT, KC_9
 #endif
 #ifndef RCPC_KEYS
-  #define RCPC_KEYS KC_RCTL, KC_RCTL, KC_0
+  #define RCPC_KEYS KC_RCTL, KC_RSFT, KC_0
 #endif
 
 // Alt / paren setup
 #ifndef LAPO_KEYS
-  #define LAPO_KEYS KC_LALT, KC_LALT, KC_9
+  #define LAPO_KEYS KC_LALT, KC_LSFT, KC_9
 #endif
 #ifndef RAPC_KEYS
-  #define RAPC_KEYS KC_RALT, KC_RALT, KC_0
+  #define RAPC_KEYS KC_RALT, KC_RSFT, KC_0
 #endif
 
 // Shift / Enter setup

--- a/quantum/process_keycode/process_space_cadet.c
+++ b/quantum/process_keycode/process_space_cadet.c
@@ -143,7 +143,9 @@ bool process_space_cadet(uint16_t keycode, keyrecord_t *record) {
       return false;
     }
     default: {
-      sc_last = 0;
+      if (record->event.pressed) {
+        sc_last = 0;
+      }
       break;
     }
   }


### PR DESCRIPTION
## Description

Small usability bugfix. When typing fast, you could press down A, then press LSPO, releasing A, then releasing LSPO. The releasing of A would cause space cadet to be cleared and not trigger when in reality it should still trigger in this case. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
