### PR TITLE
Add out of bound check for Leader Key sequence array

### DIFF
--- a/quantum/process_keycode/process_leader.c
+++ b/quantum/process_keycode/process_leader.c
@@ -33,19 +33,13 @@ bool leading = false;
 uint16_t leader_time = 0;
 
 uint16_t leader_sequence[5] = {0, 0, 0, 0, 0};
-uint8_t leader_sequence_size = 0;
 
 void qk_leader_start(void) {
   if (leading) { return; }
   leader_start();
   leading = true;
   leader_time = timer_read();
-  leader_sequence_size = 0;
-  leader_sequence[0] = 0;
-  leader_sequence[1] = 0;
-  leader_sequence[2] = 0;
-  leader_sequence[3] = 0;
-  leader_sequence[4] = 0;
+  memset(leader_sequence, 0, sizeof(leader_sequence));
 }
 
 bool process_leader(uint16_t keycode, keyrecord_t *record) {
@@ -58,9 +52,8 @@ bool process_leader(uint16_t keycode, keyrecord_t *record) {
           keycode = keycode & 0xFF;
         }
 #endif // LEADER_KEY_STRICT_KEY_PROCESSING
-        if (leader_sequence_size < 5) {
-          leader_sequence[leader_sequence_size] = keycode;
-          leader_sequence_size++;
+        if (sizeof(leader_sequence) < 5) {
+          leader_sequence[sizeof(leader_sequence)] = keycode;
         } else {
           leading = false;
           leader_end();

--- a/quantum/process_keycode/process_leader.c
+++ b/quantum/process_keycode/process_leader.c
@@ -58,8 +58,13 @@ bool process_leader(uint16_t keycode, keyrecord_t *record) {
           keycode = keycode & 0xFF;
         }
 #endif // LEADER_KEY_STRICT_KEY_PROCESSING
-        leader_sequence[leader_sequence_size] = keycode;
-        leader_sequence_size++;
+        if (leader_sequence_size < 5) {
+          leader_sequence[leader_sequence_size] = keycode;
+          leader_sequence_size++;
+        } else {
+          leading = false;
+          leader_end();
+        }
 #ifdef LEADER_PER_KEY_TIMING
         leader_time = timer_read();
 #endif

--- a/quantum/process_keycode/process_leader.c
+++ b/quantum/process_keycode/process_leader.c
@@ -57,7 +57,7 @@ bool process_leader(uint16_t keycode, keyrecord_t *record) {
           keycode = keycode & 0xFF;
         }
 #endif // LEADER_KEY_STRICT_KEY_PROCESSING
-        if (leader_sequence_size < 5) {
+        if ( leader_sequence_size < ( sizeof(leader_sequence) / sizeof(leader_sequence[0]) ) ) {
           leader_sequence[leader_sequence_size] = keycode;
           leader_sequence_size++;
         } else {

--- a/quantum/process_keycode/process_leader.c
+++ b/quantum/process_keycode/process_leader.c
@@ -17,6 +17,9 @@
 #ifdef LEADER_ENABLE
 
 #include "process_leader.h"
+#ifdef __arm__
+#   include <string.h>
+#endif
 
 #ifndef LEADER_TIMEOUT
   #define LEADER_TIMEOUT 300

--- a/quantum/process_keycode/process_leader.c
+++ b/quantum/process_keycode/process_leader.c
@@ -33,7 +33,7 @@ bool leading = false;
 uint16_t leader_time = 0;
 
 uint16_t leader_sequence[5] = {0, 0, 0, 0, 0};
-uint8_t leader_sequence_size;
+uint8_t leader_sequence_size = 0;
 
 void qk_leader_start(void) {
   if (leading) { return; }

--- a/quantum/process_keycode/process_leader.c
+++ b/quantum/process_keycode/process_leader.c
@@ -33,12 +33,14 @@ bool leading = false;
 uint16_t leader_time = 0;
 
 uint16_t leader_sequence[5] = {0, 0, 0, 0, 0};
+uint8_t leader_sequence_size;
 
 void qk_leader_start(void) {
   if (leading) { return; }
   leader_start();
   leading = true;
   leader_time = timer_read();
+  leader_sequence_size = 0;
   memset(leader_sequence, 0, sizeof(leader_sequence));
 }
 
@@ -52,8 +54,9 @@ bool process_leader(uint16_t keycode, keyrecord_t *record) {
           keycode = keycode & 0xFF;
         }
 #endif // LEADER_KEY_STRICT_KEY_PROCESSING
-        if (sizeof(leader_sequence) < 5) {
-          leader_sequence[sizeof(leader_sequence)] = keycode;
+        if (leader_sequence_size < 5) {
+          leader_sequence[leader_sequence_size] = keycode;
+          leader_sequence_size++;
         } else {
           leading = false;
           leader_end();

--- a/quantum/process_keycode/process_leader.h
+++ b/quantum/process_keycode/process_leader.h
@@ -32,7 +32,7 @@ void qk_leader_start(void);
 #define SEQ_FOUR_KEYS(key1, key2, key3, key4) if (leader_sequence[0] == (key1) && leader_sequence[1] == (key2) && leader_sequence[2] == (key3) && leader_sequence[3] == (key4) && leader_sequence[4] == 0)
 #define SEQ_FIVE_KEYS(key1, key2, key3, key4, key5) if (leader_sequence[0] == (key1) && leader_sequence[1] == (key2) && leader_sequence[2] == (key3) && leader_sequence[3] == (key4) && leader_sequence[4] == (key5))
 
-#define LEADER_EXTERNS() extern bool leading; extern uint16_t leader_time; extern uint16_t leader_sequence[5]; extern uint8_t leader_sequence_size
+#define LEADER_EXTERNS() extern bool leading; extern uint16_t leader_time; extern uint16_t leader_sequence[5]
 #define LEADER_DICTIONARY() if (leading && timer_elapsed(leader_time) > LEADER_TIMEOUT)
 
 #endif

--- a/quantum/process_keycode/process_leader.h
+++ b/quantum/process_keycode/process_leader.h
@@ -32,7 +32,7 @@ void qk_leader_start(void);
 #define SEQ_FOUR_KEYS(key1, key2, key3, key4) if (leader_sequence[0] == (key1) && leader_sequence[1] == (key2) && leader_sequence[2] == (key3) && leader_sequence[3] == (key4) && leader_sequence[4] == 0)
 #define SEQ_FIVE_KEYS(key1, key2, key3, key4, key5) if (leader_sequence[0] == (key1) && leader_sequence[1] == (key2) && leader_sequence[2] == (key3) && leader_sequence[3] == (key4) && leader_sequence[4] == (key5))
 
-#define LEADER_EXTERNS() extern bool leading; extern uint16_t leader_time; extern uint16_t leader_sequence[5]
+#define LEADER_EXTERNS() extern bool leading; extern uint16_t leader_time; extern uint16_t leader_sequence[5]; extern uint8_t leader_sequence_size
 #define LEADER_DICTIONARY() if (leading && timer_elapsed(leader_time) > LEADER_TIMEOUT)
 
 #endif


### PR DESCRIPTION
Leader keys is limited to 5 keypresses, even the array for is sets it to 5, but at no time does it check to make sure that it's hit the end of the array before adding more key sequences.... which appears to crash the controller. 

## Description

This adds a sanity check to make sure that once you've hit 5 keys, it doesn't add more.  However, it forcibly ends the lead sequence, and may not process it correctly. 


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* Fixes #5762

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
