### PR TITLE
Fix dz60 LAYOUT_60_iso_split_space_bs_rshift api errors

### DIFF
--- a/keyboards/dz60/dz60.h
+++ b/keyboards/dz60/dz60.h
@@ -410,7 +410,7 @@
     { k10,  KC_NO, k12,   k13,  k14,  k15,   k16,  k17,   k18,  k19,   k1a,  k1b,   k1c,  k1d,  k1e   }, \
     { k20,  KC_NO, k22,   k23,  k24,  k25,   k26,  k27,   k28,  k29,   k2a,  k2b,   k2c,  k2d,  KC_NO }, \
     { k30,  k31,   k32,   k33,  k34,  k35,   k36,  k37,   k38,  k39,   k3a,  k3b,   KC_NO,k3d,  k3e   }, \
-    { k40,  k41,   KC_NO, k43,  k44,  KC_NO, k46,  KC_NO, k48,  KC_NO, k4a,  k4b,   k4c,  k4d,  k4e   }  \
+    { k40,  k41,   KC_NO, k43,  k44,  KC_NO, k46,  KC_NO, k48,  KC_NO, k4a,  k4b,   KC_NO,k4d,  k4e   }  \
 }
 
 #endif

--- a/keyboards/dz60/dz60.h
+++ b/keyboards/dz60/dz60.h
@@ -404,7 +404,7 @@
     k10,      k12, k13, k14, k15, k16, k17, k18, k19, k1a, k1b, k1c, k1d,      \
     k20,      k22, k23, k24, k25, k26, k27, k28, k29, k2a, k2b, k2c, k1e, k2d, \
     k30, k31, k32, k33, k34, k35, k36, k37, k38, k39, k3a, k3b,      k3d, k3e, \
-    k40, k41,      k43, k44,      k46,      k48,      k4a, k4b, k4c, k4d, k4e  \
+    k40, k41,      k43, k44,      k46,      k48,      k4a, k4b,      k4d, k4e  \
 ) { \
     { k00,  k01,   k02,   k03,  k04,  k05,   k06,  k07,   k08,  k09,   k0a,  k0b,   k0c,  k0d,  k0e   }, \
     { k10,  KC_NO, k12,   k13,  k14,  k15,   k16,  k17,   k18,  k19,   k1a,  k1b,   k1c,  k1d,  k1e   }, \

--- a/keyboards/dz60/keymaps/olligranlund_iso/keymap.c
+++ b/keyboards/dz60/keymaps/olligranlund_iso/keymap.c
@@ -26,13 +26,13 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 		KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,     KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC,
 		MO(1),   KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,     KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_BSLS, KC_ENT,
 		KC_LSFT, KC_NUBS, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,     KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT, KC_PSCR,
-		KC_LCTL, KC_LGUI, KC_LALT, KC_SPC,  KC_SPC,  KC_SPC,  KC_RALT, MO(1),    KC_NO,   KC_APP,   KC_RCTL),
+		KC_LCTL, KC_LGUI, KC_LALT, KC_SPC,  KC_SPC,  KC_SPC,  KC_RALT, MO(1),    KC_APP,  KC_RCTL),
 
 	LAYOUT_60_iso_split_space_bs_rshift(
 		KC_GRV,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,    KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_DEL,  KC_DEL,
 		KC_NO,   KC_MPRV, KC_MPLY, KC_MNXT, KC_NO,   KC_NO,   KC_NO,   KC_PGDOWN,KC_UP,   KC_PGUP, KC_NO,   KC_NO,   KC_NO,
 		KC_NO,   KC_VOLD, KC_MUTE, KC_VOLU, KC_NO,   KC_NO,   KC_HOME,  KC_LEFT, KC_DOWN, KC_RGHT, KC_NO,   KC_NO,   KC_NO,   KC_NO,
 		KC_LSFT, KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_END,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_RSFT, KC_CAPS,
-		KC_LCTL, KC_LGUI, KC_LALT, KC_SPC,  KC_SPC,  KC_SPC,  KC_RALT, MO(1),    KC_NO,   KC_APP,  KC_RCTL),
+		KC_LCTL, KC_LGUI, KC_LALT, KC_SPC,  KC_SPC,  KC_SPC,  KC_RALT, MO(1),    KC_APP,  KC_RCTL),
 
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
QMK api error log (http://compile.qmk.fm/v1/keyboards/error_log) contains:
```json
{
  "message": "Error: dz60: LAYOUT_60_iso_split_space_bs_rshift: Number of elements in info.json does not match! info.json:66 != LAYOUT_60_iso_split_space_bs_rshift:67",
  "severity": "error"
}
``` 

Fixed up the layout macro to match the `info.json` and code comments (however it could go the other way with a 5x1u bottom corner). Flagging @OlliGranlund as the keymap owner.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
