### PR TITLE
Fix arch installs as avr-gcc 8.1 is now unavailable

### DIFF
--- a/util/linux_install.sh
+++ b/util/linux_install.sh
@@ -54,8 +54,7 @@ elif grep ID /etc/os-release | grep -qE 'debian|ubuntu'; then
 		zip
 
 elif grep ID /etc/os-release | grep -q 'arch\|manjaro'; then
-	# install avr-gcc 8.1 until 8.3 is available. See #3657 for details of the bug.
-	sudo pacman -U https://archive.archlinux.org/packages/a/avr-gcc/avr-gcc-8.1.0-1-x86_64.pkg.tar.xz
+	sudo pacman -U https://archive.archlinux.org/packages/a/avr-gcc/avr-gcc-8.3.0-1-x86_64.pkg.tar.xz
 	sudo pacman -S \
 		arm-none-eabi-binutils \
 		arm-none-eabi-gcc \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
The old url <https://archive.archlinux.org/packages/a/avr-gcc/avr-gcc-8.1.0-1-x86_64.pkg.tar.xz> returns 404, only the following files are now available:
```
avr-gcc-8.2.0-1-x86_64.pkg.tar.xz                  26-Jul-2018 22:26     21M
avr-gcc-8.2.0-1-x86_64.pkg.tar.xz.sig              26-Jul-2018 22:26     566
avr-gcc-8.3.0-1-x86_64.pkg.tar.xz                  26-Feb-2019 01:40     21M
avr-gcc-8.3.0-1-x86_64.pkg.tar.xz.sig              26-Feb-2019 01:40     566
avr-gcc-9.1.0-1-x86_64.pkg.tar.xz                  04-May-2019 07:31     22M
avr-gcc-9.1.0-1-x86_64.pkg.tar.xz.sig              04-May-2019 07:31     566
```
#5456 has been merged so it should be safe to use 8.3. I have flashed a hex produced from this PR and it functions as expected.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
