### PR TITLE
Added Space Cadet modifer carry over

### DIFF
--- a/docs/feature_space_cadet.md
+++ b/docs/feature_space_cadet.md
@@ -43,6 +43,7 @@ By default Space Cadet assumes a US ANSI layout, but if your layout uses differe
 |`LAPO_KEYS`     |`KC_LALT, KC_LSFT, KC_9`       |Send `KC_LALT` when held, the mod `KC_LSFT` with the key `KC_9` when tapped.     |
 |`RAPC_KEYS`     |`KC_RALT, KC_RSFT, KC_0`       |Send `KC_RALT` when held, the mod `KC_RSFT` with the key `KC_0` when tapped.     |
 |`SFTENT_KEYS`   |`KC_RSFT, KC_TRNS, SFTENT_KEY` |Send `KC_RSFT` when held, no mod with the key `SFTENT_KEY` when tapped.          |
+|`SPACE_CADET_MODIFIER_CARRYOVER`   |*Not defined* |Store current modifiers before the hold mod is pressed and use them with the tap mod and keycode. Useful for when you frequently release a modifier before triggering Space Cadet.  |
 
 
 ## Obsolete Configuration

--- a/quantum/process_keycode/process_space_cadet.c
+++ b/quantum/process_keycode/process_space_cadet.c
@@ -81,11 +81,17 @@
 
 static uint8_t sc_last = 0;
 static uint16_t sc_timer = 0;
+#ifdef SPACE_CADET_MODIFIER_CARRYOVER
+static uint8_t sc_mods = 0;
+#endif
 
 void perform_space_cadet(keyrecord_t *record, uint8_t holdMod, uint8_t tapMod, uint8_t keycode) {
   if (record->event.pressed) {
     sc_last = holdMod;
     sc_timer = timer_read ();
+#ifdef SPACE_CADET_MODIFIER_CARRYOVER
+    sc_mods = get_mods();
+#endif
     if (IS_MOD(holdMod)) {
       register_mods(MOD_BIT(holdMod));
     }
@@ -100,7 +106,13 @@ void perform_space_cadet(keyrecord_t *record, uint8_t holdMod, uint8_t tapMod, u
           register_mods(MOD_BIT(tapMod));
         }
       }
+#ifdef SPACE_CADET_MODIFIER_CARRYOVER
+    set_weak_mods(sc_mods);
+#endif
       tap_code(keycode);
+#ifdef SPACE_CADET_MODIFIER_CARRYOVER
+    clear_weak_mods();
+#endif
       if (IS_MOD(tapMod)) {
         unregister_mods(MOD_BIT(tapMod));
       }


### PR DESCRIPTION
## Description

This is an option for those fast typing folks that carry over the mods from when you pressed the space cadet key to the release. For example: Press Shift > Press KC_LSPO > Release Shift > Release KC_LSPO. In this example, since KC_LSPO tap triggers on release, it will not contain the Shift modifier from when it was pressed. This define will carry over the modifiers from when it was pressed and use them on tap trigger release. This is super useful when using a setup like this and fast typing to get both { & [ based on if the other shift is held down or not.

```
#define LSPO_KEYS KC_LSFT, KC_TRNS, KC_LBRC
#define RSPC_KEYS KC_RSFT, KC_TRNS, KC_RBRC
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
