### PR TITLE
Fix the modifier in ssd1306.c of some keyboards

### DIFF
--- a/keyboards/claw44/ssd1306.c
+++ b/keyboards/claw44/ssd1306.c
@@ -13,7 +13,7 @@
 #include "sendchar.h"
 #include "timer.h"
 
-static const unsigned char font[] PROGMEM;
+extern const unsigned char font[] PROGMEM;
 
 // Set this to 1 to help diagnose early startup problems
 // when testing power-on with ble.  Turn it off otherwise,

--- a/keyboards/comet46/ssd1306.c
+++ b/keyboards/comet46/ssd1306.c
@@ -13,7 +13,7 @@
 #include "sendchar.h"
 #include "timer.h"
 
-static const unsigned char font[] PROGMEM;
+extern const unsigned char font[] PROGMEM;
 
 // Set this to 1 to help diagnose early startup problems
 // when testing power-on with ble.  Turn it off otherwise,

--- a/keyboards/crkbd/ssd1306.c
+++ b/keyboards/crkbd/ssd1306.c
@@ -13,7 +13,7 @@
 #include "sendchar.h"
 #include "timer.h"
 
-static const unsigned char font[] PROGMEM;
+extern const unsigned char font[] PROGMEM;
 
 // Set this to 1 to help diagnose early startup problems
 // when testing power-on with ble.  Turn it off otherwise,

--- a/keyboards/lily58/ssd1306.c
+++ b/keyboards/lily58/ssd1306.c
@@ -13,7 +13,7 @@
 #include "sendchar.h"
 #include "timer.h"
 
-static const unsigned char font[] PROGMEM;
+extern const unsigned char font[] PROGMEM;
 
 // Set this to 1 to help diagnose early startup problems
 // when testing power-on with ble.  Turn it off otherwise,

--- a/keyboards/yosino58/ssd1306.c
+++ b/keyboards/yosino58/ssd1306.c
@@ -13,7 +13,7 @@
 #include "sendchar.h"
 #include "timer.h"
 
-static const unsigned char font[] PROGMEM;
+extern const unsigned char font[] PROGMEM;
 
 // Set this to 1 to help diagnose early startup problems
 // when testing power-on with ble.  Turn it off otherwise,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
I changed the font variable's modifier from **static** to **extern** in ssd1306.c of claw44, comet46, crkbd, lily58 and yosino58.
These modifiers had caused build error on my environment (avr-gcc 9.1.0).
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
