### PR TITLE
Added custom center point to rgb matrix

### DIFF
--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -144,14 +144,16 @@ const led_config_t g_led_config = { {
 } };
 ```
 
-The first part, `// Key Matrix to LED Index`, tells the system what key this LED represents by using the key's electrical matrix row & col. The second part, `// LED Index to Physical Position` represents the LED's physical position on the keyboard. The first value, `x`, is between 0-224 (inclusive), and the second value, `y`, is between 0-64 (inclusive). This range is due to effect that calculate the center or halves for their animations. The easiest way to calculate these positions is imagine your keyboard is a grid, and the top left of the keyboard represents x, y coordinate 0, 0 and the bottom right of your keyboard represents 224, 64. Using this as a basis, you can use the following formula to calculate the physical position:
+The first part, `// Key Matrix to LED Index`, tells the system what key this LED represents by using the key's electrical matrix row & col. The second part, `// LED Index to Physical Position` represents the LED's physical `{ x, y }` position on the keyboard. The default expected range of values for `{ x, y }` is the inclusive range `{ 0..224, 0..64 }`. This default expected range is due to effects that calculate the center of the keyboard for their animations. The easiest way to calculate these positions is imagine your keyboard is a grid, and the top left of the keyboard represents `{ x, y }` coordinate `{ 0, 0 }` and the bottom right of your keyboard represents `{ 224, 64 }`. Using this as a basis, you can use the following formula to calculate the physical position:
 
 ```C
 x = 224 / (NUMBER_OF_COLS - 1) * COL_POSITION
 y =  64 / (NUMBER_OF_ROWS - 1) * ROW_POSITION
 ```
 
-Where NUMBER_OF_COLS, NUMBER_OF_ROWS, COL_POSITION, & ROW_POSITION are all based on the physical layout of your keyboard, not the electrical layout.
+Where NUMBER_OF_COLS, NUMBER_OF_ROWS, COL_POSITION, & ROW_POSITION are all based on the physical layout of your keyboard, not the electrical layout. 
+
+As mentioned earlier, the center of the keyboard by default is expected to be `{ 112, 32 }`, but this can be changed if you want to more accurately calculate the LED's physical `{ x, y }` positions. Keyboard designers can implement `#define RGB_MATRIX_CENTER { 112, 32 }` in their config.h file with the new center point of the keyboard, or where they want it to be allowing more possibilities for the `{ x, y }` values. Do note that the maximum value for x or y is 255, and the recommended maximum is 224 as this gives animations runoff room before they reset.
 
 `// LED Index to Flag` is a bitmask, whether or not a certain LEDs is of a certain type. It is recommended that LEDs are set to only 1 type.
 

--- a/quantum/rgb_matrix.c
+++ b/quantum/rgb_matrix.c
@@ -26,6 +26,12 @@
 
 #include "lib/lib8tion/lib8tion.h"
 
+#ifndef RGB_MATRIX_CENTER
+  const point_t k_rgb_matrix_center = { 112, 32 };
+#else
+  const point_t k_rgb_matrix_center = RGB_MATRIX_CENTER;
+#endif
+
 // ------------------------------------------
 // -----Begin rgb effect includes macros-----
 #define RGB_MATRIX_EFFECT(name)

--- a/quantum/rgb_matrix_animations/cycle_out_in_anim.h
+++ b/quantum/rgb_matrix_animations/cycle_out_in_anim.h
@@ -9,8 +9,8 @@ bool CYCLE_OUT_IN(effect_params_t* params) {
   uint8_t time = scale16by8(g_rgb_counters.tick, rgb_matrix_config.speed / 4);
   for (uint8_t i = led_min; i < led_max; i++) {
     RGB_MATRIX_TEST_LED_FLAGS();
-    int16_t dx = g_led_config.point[i].x - 112;
-    int16_t dy = g_led_config.point[i].y - 32;
+    int16_t dx = g_led_config.point[i].x - k_rgb_matrix_center.x;
+    int16_t dy = g_led_config.point[i].y - k_rgb_matrix_center.y;
     uint8_t dist = sqrt16(dx * dx + dy * dy);
     hsv.h = 3 * dist / 2 + time;
     RGB rgb = hsv_to_rgb(hsv);

--- a/quantum/rgb_matrix_animations/cycle_out_in_dual_anim.h
+++ b/quantum/rgb_matrix_animations/cycle_out_in_dual_anim.h
@@ -9,8 +9,8 @@ bool CYCLE_OUT_IN_DUAL(effect_params_t* params) {
   uint8_t time = scale16by8(g_rgb_counters.tick, rgb_matrix_config.speed / 4);
   for (uint8_t i = led_min; i < led_max; i++) {
     RGB_MATRIX_TEST_LED_FLAGS();
-    int16_t dx = 56 - abs8(g_led_config.point[i].x - 112);
-    int16_t dy = g_led_config.point[i].y - 32;
+    int16_t dx = (k_rgb_matrix_center.x / 2) - abs8(g_led_config.point[i].x - k_rgb_matrix_center.x);
+    int16_t dy = g_led_config.point[i].y - k_rgb_matrix_center.y;
     uint8_t dist = sqrt16(dx * dx + dy * dy);
     hsv.h = 3 * dist + time;
     RGB rgb = hsv_to_rgb(hsv);

--- a/quantum/rgb_matrix_animations/dual_beacon_anim.h
+++ b/quantum/rgb_matrix_animations/dual_beacon_anim.h
@@ -11,7 +11,7 @@ bool DUAL_BEACON(effect_params_t* params) {
   int8_t sin_value = sin8(time) - 128;
   for (uint8_t i = led_min; i < led_max; i++) {
     RGB_MATRIX_TEST_LED_FLAGS();
-    hsv.h = ((g_led_config.point[i].y - 32) * cos_value + (g_led_config.point[i].x - 112) * sin_value) / 128 + rgb_matrix_config.hue;
+    hsv.h = ((g_led_config.point[i].y - k_rgb_matrix_center.y) * cos_value + (g_led_config.point[i].x - k_rgb_matrix_center.x) * sin_value) / 128 + rgb_matrix_config.hue;
     RGB rgb = hsv_to_rgb(hsv);
     rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
   }

--- a/quantum/rgb_matrix_animations/rainbow_beacon_anim.h
+++ b/quantum/rgb_matrix_animations/rainbow_beacon_anim.h
@@ -11,7 +11,7 @@ bool RAINBOW_BEACON(effect_params_t* params) {
   int16_t sin_value = 2 * (sin8(time) - 128);
   for (uint8_t i = led_min; i < led_max; i++) {
     RGB_MATRIX_TEST_LED_FLAGS();
-    hsv.h = ((g_led_config.point[i].y - 32) * cos_value + (g_led_config.point[i].x - 112) * sin_value) / 128 + rgb_matrix_config.hue;
+    hsv.h = ((g_led_config.point[i].y - k_rgb_matrix_center.y) * cos_value + (g_led_config.point[i].x - k_rgb_matrix_center.x) * sin_value) / 128 + rgb_matrix_config.hue;
     RGB rgb = hsv_to_rgb(hsv);
     rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
   }

--- a/quantum/rgb_matrix_animations/rainbow_pinwheels_anim.h
+++ b/quantum/rgb_matrix_animations/rainbow_pinwheels_anim.h
@@ -11,7 +11,7 @@ bool PINWHEELS(effect_params_t* params) {
   int16_t sin_value = 3 * (sin8(time) - 128);
   for (uint8_t i = led_min; i < led_max; i++) {
     RGB_MATRIX_TEST_LED_FLAGS();
-    hsv.h = ((g_led_config.point[i].y - 32) * cos_value + (56 - abs8(g_led_config.point[i].x - 112)) * sin_value) / 128 + rgb_matrix_config.hue;
+    hsv.h = ((g_led_config.point[i].y - k_rgb_matrix_center.y) * cos_value + (56 - abs8(g_led_config.point[i].x - k_rgb_matrix_center.x)) * sin_value) / 128 + rgb_matrix_config.hue;
     RGB rgb = hsv_to_rgb(hsv);
     rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
   }


### PR DESCRIPTION
## Description

Added a define for overriding rgb matrix effect's keyboard center point from the 112, 32 of today.  This allows users or keyboard makers to put the center point in the center of the qwerty keys instead of the center of the board. Or even more accurately provide x and y positions for leds on longer or narrower boards and still keeping those effects looking good!

As an example, the Massdrop CTRL should have range of 224, 84 to keep the physical x and y in proper ration to real world scale. So the center point should be 112, 42 instead. Minor change but updating the y point of the leds and defining the new center point makes effects look even better.

:exclamation: :exclamation: :exclamation: Should be merged after https://github.com/qmk/qmk_firmware/pull/5867 and https://github.com/qmk/qmk_firmware/pull/5877 and I have a chance to fix up those effects with this new center point code. :exclamation: :exclamation: :exclamation: 

❗️ #5919 contains this work, merge this first, or just merge that pr and close this one.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
