### PR TITLE
Make DEBUG keycode disable as well as enable

### DIFF
--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -312,12 +312,11 @@ bool process_record_quantum(keyrecord_t *record) {
     return false;
     case DEBUG:
       if (record->event.pressed) {
+        debug_enable ^= 1;
         if (debug_enable) {
-          print("DEBUG: disabled.\n");
-          debug_enable = false;
-        } else {
-          debug_enable = true;
           print("DEBUG: enabled.\n");
+        } else {
+          print("DEBUG: disabled.\n");
         }
       }
     return false;

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -312,8 +312,13 @@ bool process_record_quantum(keyrecord_t *record) {
     return false;
     case DEBUG:
       if (record->event.pressed) {
+        if (debug_enable) {
+          print("DEBUG: disabled.\n");
+          debug_enable = false;
+        } else {
           debug_enable = true;
           print("DEBUG: enabled.\n");
+        }
       }
     return false;
     case EEPROM_RESET:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I just thought it was slightly annoying that the `DEBUG` keycode only enables debugging. It should be able to turn it off too.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
