### PR TITLE
Additional changes for Layer State typedef compatibility

### DIFF
--- a/docs/custom_quantum_functions.md
+++ b/docs/custom_quantum_functions.md
@@ -298,7 +298,7 @@ This example shows how to set the [RGB Underglow](feature_rgblight.md) lights ba
 
 ```c
 layer_state_t layer_state_set_user(layer_state_t state) {
-    switch (biton32(state)) {
+    switch (get_highest_layer(state)) {
     case _RAISE:
         rgblight_setrgb (0x00,  0x00, 0xFF);
         break;
@@ -378,7 +378,7 @@ The above function will use the EEPROM config immediately after reading it, to s
 
 ```c
 layer_state_t layer_state_set_user(layer_state_t state) {
-    switch (biton32(state)) {
+    switch (get_highest_layer(state)) {
     case _RAISE:
         if (user_config.rgb_layer_change) { rgblight_sethsv_noeeprom_magenta(); rgblight_mode_noeeprom(1); }
         break;

--- a/docs/custom_quantum_functions.md
+++ b/docs/custom_quantum_functions.md
@@ -297,7 +297,7 @@ This runs code every time that the layers get changed.  This can be useful for l
 This example shows how to set the [RGB Underglow](feature_rgblight.md) lights based on the layer, using the Planck as an example
 
 ```c
-uint32_t layer_state_set_user(uint32_t state) {
+layer_state_t layer_state_set_user(layer_state_t state) {
     switch (biton32(state)) {
     case _RAISE:
         rgblight_setrgb (0x00,  0x00, 0xFF);
@@ -320,8 +320,8 @@ uint32_t layer_state_set_user(uint32_t state) {
 ```
 ### `layer_state_set_*` Function Documentation
 
-* Keyboard/Revision: `uint32_t layer_state_set_kb(uint32_t state)`
-* Keymap: `uint32_t layer_state_set_user(uint32_t state)`
+* Keyboard/Revision: `layer_state_t layer_state_set_kb(layer_state_t state)`
+* Keymap: `layer_state_t layer_state_set_user(layer_state_t state)`
 
 
 The `state` is the bitmask of the active layers, as explained in the [Keymap Overview](keymap.md#keymap-layer-status)
@@ -377,7 +377,7 @@ void keyboard_post_init_user(void) {
 The above function will use the EEPROM config immediately after reading it, to set the default layer's RGB color. The "raw" value of it is converted in a usable structure based on the "union" that you created above. 
 
 ```c
-uint32_t layer_state_set_user(uint32_t state) {
+layer_state_t layer_state_set_user(layer_state_t state) {
     switch (biton32(state)) {
     case _RAISE:
         if (user_config.rgb_layer_change) { rgblight_sethsv_noeeprom_magenta(); rgblight_mode_noeeprom(1); }

--- a/docs/feature_oled_driver.md
+++ b/docs/feature_oled_driver.md
@@ -31,7 +31,7 @@ This enables the feature and the `OLED_DRIVER_ENABLE` define. Then in your `keym
 void oled_task_user(void) {
   // Host Keyboard Layer Status
   oled_write_P(PSTR("Layer: "), false);
-  switch (biton32(layer_state)) {
+  switch (get_highest_layer(layer_state)) {
     case _QWERTY:
       oled_write_P(PSTR("Default\n"), false);
       break;

--- a/docs/feature_userspace.md
+++ b/docs/feature_userspace.md
@@ -115,11 +115,11 @@ For instance, let's look at the `layer_state_set_user()` function.  You can enab
 In your `<name.c>` file, you'd want to add this: 
 ```c
 __attribute__ ((weak))
-uint32_t layer_state_set_keymap (uint32_t state) {
+layer_state_t layer_state_set_keymap (layer_state_t state) {
   return state;
 }
 
-uint32_t layer_state_set_user (uint32_t state) {
+layer_state_t layer_state_set_user (layer_state_t state) {
   state = update_tri_layer_state(state, 2, 3, 5);
   return layer_state_set_keymap (state);
 }

--- a/docs/ref_functions.md
+++ b/docs/ref_functions.md
@@ -50,7 +50,7 @@ The caveat to this method is that you cannot access the `z` layer without having
 #### Example
 
 ```c
-uint32_t layer_state_set_user(uint32_t state) {
+layer_state_t layer_state_set_user(layer_state_t state) {
   return update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
 }
 ```
@@ -58,7 +58,7 @@ uint32_t layer_state_set_user(uint32_t state) {
 Alternatively, you don't have to immediately "return" the value.  This is useful if you want to add multiple tri layers, or if you want to add additional effects.
 
 ```c
-uint32_t layer_state_set_user(uint32_t state) {
+layer_state_t layer_state_set_user(layer_state_t state) {
   state = update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
   state = update_tri_layer_state(state, _RAISE, _SYMB, _SPECIAL);
   return state;

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -866,9 +866,9 @@ void set_single_persistent_default_layer(uint8_t default_layer) {
   default_layer_set(1U<<default_layer);
 }
 
-uint32_t update_tri_layer_state(uint32_t state, uint8_t layer1, uint8_t layer2, uint8_t layer3) {
-  uint32_t mask12 = (1UL << layer1) | (1UL << layer2);
-  uint32_t mask3 = 1UL << layer3;
+layer_state_t  update_tri_layer_state(layer_state_t  state, uint8_t layer1, uint8_t layer2, uint8_t layer3) {
+  layer_state_t  mask12 = (1UL << layer1) | (1UL << layer2);
+  layer_state_t  mask3 = 1UL << layer3;
   return (state & mask12) == mask12 ? (state | mask3) : (state & ~mask3);
 }
 

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -866,9 +866,9 @@ void set_single_persistent_default_layer(uint8_t default_layer) {
   default_layer_set(1U<<default_layer);
 }
 
-layer_state_t  update_tri_layer_state(layer_state_t  state, uint8_t layer1, uint8_t layer2, uint8_t layer3) {
-  layer_state_t  mask12 = (1UL << layer1) | (1UL << layer2);
-  layer_state_t  mask3 = 1UL << layer3;
+layer_state_t update_tri_layer_state(layer_state_t state, uint8_t layer1, uint8_t layer2, uint8_t layer3) {
+  layer_state_t mask12 = (1UL << layer1) | (1UL << layer2);
+  layer_state_t mask3 = 1UL << layer3;
   return (state & mask12) == mask12 ? (state | mask3) : (state & ~mask3);
 }
 

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -224,7 +224,7 @@ void send_char(char ascii_code);
 
 // For tri-layer
 void update_tri_layer(uint8_t layer1, uint8_t layer2, uint8_t layer3);
-layer_state_t  update_tri_layer_state(layer_state_t  state, uint8_t layer1, uint8_t layer2, uint8_t layer3);
+layer_state_t update_tri_layer_state(layer_state_t state, uint8_t layer1, uint8_t layer2, uint8_t layer3);
 
 void set_single_persistent_default_layer(uint8_t default_layer);
 

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -224,7 +224,7 @@ void send_char(char ascii_code);
 
 // For tri-layer
 void update_tri_layer(uint8_t layer1, uint8_t layer2, uint8_t layer3);
-uint32_t update_tri_layer_state(uint32_t state, uint8_t layer1, uint8_t layer2, uint8_t layer3);
+layer_state_t  update_tri_layer_state(layer_state_t  state, uint8_t layer1, uint8_t layer2, uint8_t layer3);
 
 void set_single_persistent_default_layer(uint8_t default_layer);
 

--- a/quantum/visualizer/visualizer.c
+++ b/quantum/visualizer/visualizer.c
@@ -437,7 +437,7 @@ uint8_t visualizer_get_mods() {
   if (!has_oneshot_mods_timed_out()) {
     mods |= get_oneshot_mods();
   }
-#endif  
+#endif
   return mods;
 }
 
@@ -447,7 +447,7 @@ void visualizer_set_user_data(void* u) {
 }
 #endif
 
-void visualizer_update(uint32_t default_state, uint32_t state, uint8_t mods, uint32_t leds) {
+void visualizer_update(layer_state_t default_state, layer_state_t state, uint8_t mods, uint32_t leds) {
     // Note that there's a small race condition here, the thread could read
     // a state where one of these are set but not the other. But this should
     // not really matter as it will be fixed during the next loop step.

--- a/quantum/visualizer/visualizer.h
+++ b/quantum/visualizer/visualizer.h
@@ -45,7 +45,7 @@ uint8_t visualizer_get_mods(void);
 // This need to be called once at the start
 void visualizer_init(void);
 // This should be called at every matrix scan
-void visualizer_update(uint32_t default_state, uint32_t state, uint8_t mods, uint32_t leds);
+void visualizer_update(layer_state_t default_state, layer_state_t state, uint8_t mods, uint32_t leds);
 
 // This should be called when the keyboard goes to suspend state
 void visualizer_suspend(void);
@@ -68,8 +68,8 @@ void draw_emulator(void);
 struct keyframe_animation_t;
 
 typedef struct {
-    uint32_t layer;
-    uint32_t default_layer;
+    layer_state_t layer;
+    layer_state_t default_layer;
     uint32_t leds; // See led.h for available statuses
     uint8_t mods;
     bool suspended;

--- a/quantum/visualizer/visualizer.h
+++ b/quantum/visualizer/visualizer.h
@@ -30,6 +30,7 @@ SOFTWARE.
 
 #include "config.h"
 #include "gfx.h"
+#include "action_layer.h"
 
 #ifdef LCD_BACKLIGHT_ENABLE
 #include "lcd_backlight.h"

--- a/tmk_core/common/action_layer.h
+++ b/tmk_core/common/action_layer.h
@@ -21,7 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "keyboard.h"
 #include "action.h"
 
-#if defined(LAYER_STATE_8BIT) || ( defined(DYNAMIC_KEYMAP_ENABLE) && DYNAMIC_KEYMAP_LAYER_COUNT >= 8 )
+#if defined(LAYER_STATE_8BIT)
 typedef uint8_t layer_state_t;
 #define get_highest_layer(state) biton8(state)
 #elif defined(LAYER_STATE_16BIT)

--- a/tmk_core/common/action_layer.h
+++ b/tmk_core/common/action_layer.h
@@ -23,10 +23,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #if defined(LAYER_STATE_8BIT) || ( defined(DYNAMIC_KEYMAP_ENABLE) && DYNAMIC_KEYMAP_LAYER_COUNT >= 8 )
 typedef uint8_t layer_state_t;
+#define get_highest_layer(state) biton8(state)
 #elif defined(LAYER_STATE_16BIT)
 typedef uint16_t layer_state_t;
+#define get_highest_layer(state) biton16(state)
 #else
 typedef uint32_t layer_state_t;
+#define get_highest_layer(state) biton32(state)
 #endif
 
 

--- a/tmk_core/common/eeconfig.c
+++ b/tmk_core/common/eeconfig.c
@@ -8,7 +8,7 @@
 #include "eeprom_stm32.h"
 #endif
 
-extern uint32_t  default_layer_state;
+extern uint32_t default_layer_state;
 /** \brief eeconfig enable
  *
  * FIXME: needs doc

--- a/tmk_core/common/eeconfig.c
+++ b/tmk_core/common/eeconfig.c
@@ -8,7 +8,7 @@
 #include "eeprom_stm32.h"
 #endif
 
-extern uint32_t default_layer_state;
+extern uint32_t  default_layer_state;
 /** \brief eeconfig enable
  *
  * FIXME: needs doc


### PR DESCRIPTION
## Description

This updates the documents, and the tri-layer functions to use the correct code. 

Additionally, it adds `get_highest_layer(state)` (subject to renaming) to replace the `biton32` function with the correct version of the function. 
 
## Types of Changes
- [x] Core
- [x] Enhancement/optimization
- [x] Documentation


## Checklist
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
