### PR TITLE
Fix bit count calculation for iterating layers

### DIFF
--- a/tmk_core/common/action_layer.c
+++ b/tmk_core/common/action_layer.c
@@ -303,7 +303,7 @@ uint8_t layer_switch_get_layer(keypos_t key) {
 
   layer_state_t layers = layer_state | default_layer_state;
   /* check top layer first */
-  for (int8_t i = sizeof(layer_state_t)-1; i >= 0; i--) {
+  for (int8_t i = sizeof(layer_state_t) * 8 - 1; i >= 0; i--) {
     if (layers & (1UL << i)) {
       action = action_for_key(i, key);
       if (action.code != ACTION_TRANSPARENT) {


### PR DESCRIPTION
## Description

Fix for bug introduced in https://github.com/qmk/qmk_firmware/pull/3637
sizeof returns size of the data structure in bytes, and this logic needs size in bits.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
