### PR TITLE
Downgrade gcc-arm-embedded in shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -6,7 +6,10 @@ with pkgs;
 let
   avrbinutils = pkgsCross.avr.buildPackages.binutils;
   avrlibc = pkgsCross.avr.libcCross;
-  gcc-arm-embedded = pkgsCross.arm-embedded.buildPackages.gcc;
+  gcc-arm-embedded = (import (builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs-channels/archive/87f146a41c463a64c93022b11cf19716b3a22037.tar.gz";
+    sha256 = "0rk8haf19plw6vyvq0am99rik0hrrysknjw0f2vs7985awngy3q2";
+  }) {}).gcc-arm-embedded;
 
   avr_incflags = [
     "-isystem ${avrlibc}/avr/include"


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Temporary fix for https://github.com/qmk/qmk_firmware/issues/5868
Tried gcc versions `7.4` as well as `8.3`(the versions in the channels corresponding to the latest NixOS release - 19.03), both compile firmware, which does not work on Planck rev6. See issue for more details.

Fix the issue by pinning the "known-good" gcc ARM version from `18.09` channel.

Once the firmware is fixed to work on versions `7.4` and `8.3`, this change should be reverted.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Temporary fix for #5868 (does not close the issue, but merely is a workaround on systems using `nix` package manager)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
