### PR TITLE
Fixing hsv_to_rgb where s = 0 and v < 255

### DIFF
--- a/quantum/color.c
+++ b/quantum/color.c
@@ -27,14 +27,12 @@ RGB hsv_to_rgb( HSV hsv )
 
 	if ( hsv.s == 0 )
 	{
+#ifdef USE_CIE1931_CURVE
+		rgb.r = rgb.g = rgb.b = pgm_read_byte( &CIE1931_CURVE[hsv.v] );
+#else
 		rgb.r = hsv.v;
 		rgb.g = hsv.v;
 		rgb.b = hsv.v;
-
-#ifdef USE_CIE1931_CURVE
-		rgb.r = pgm_read_byte( &CIE1931_CURVE[rgb.r] );
-		rgb.g = pgm_read_byte( &CIE1931_CURVE[rgb.g] );
-		rgb.b = pgm_read_byte( &CIE1931_CURVE[rgb.b] );
 #endif
 		return rgb;
 	}

--- a/quantum/color.c
+++ b/quantum/color.c
@@ -30,6 +30,12 @@ RGB hsv_to_rgb( HSV hsv )
 		rgb.r = hsv.v;
 		rgb.g = hsv.v;
 		rgb.b = hsv.v;
+
+#ifdef USE_CIE1931_CURVE
+		rgb.r = pgm_read_byte( &CIE1931_CURVE[rgb.r] );
+		rgb.g = pgm_read_byte( &CIE1931_CURVE[rgb.g] );
+		rgb.b = pgm_read_byte( &CIE1931_CURVE[rgb.b] );
+#endif
 		return rgb;
 	}
 


### PR DESCRIPTION
## Description

hsv to rgb was ignoring the linear lookup table when saturation was 0. This causes visibly larger brightness if your value was also less than maxed compared when saturation was > 0.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
