### PR TITLE
Reduce rgb matrix firmware size

### DIFF
--- a/quantum/rgb_matrix.c
+++ b/quantum/rgb_matrix.c
@@ -32,6 +32,14 @@
   const point_t k_rgb_matrix_center = RGB_MATRIX_CENTER;
 #endif
 
+// Generic effect runners
+#include "rgb_matrix_runners/effect_runner_dx_dy_dist.h"
+#include "rgb_matrix_runners/effect_runner_dx_dy.h"
+#include "rgb_matrix_runners/effect_runner_i.h"
+#include "rgb_matrix_runners/effect_runner_sin_cos_i.h"
+#include "rgb_matrix_runners/effect_runner_reactive.h"
+#include "rgb_matrix_runners/effect_runner_reactive_splash.h"
+
 // ------------------------------------------
 // -----Begin rgb effect includes macros-----
 #define RGB_MATRIX_EFFECT(name)

--- a/quantum/rgb_matrix_animations/colorband_pinwheel_sat_anim.h
+++ b/quantum/rgb_matrix_animations/colorband_pinwheel_sat_anim.h
@@ -2,20 +2,12 @@
 RGB_MATRIX_EFFECT(BAND_PINWHEEL_SAT)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-bool BAND_PINWHEEL_SAT(effect_params_t* params) {
-  RGB_MATRIX_USE_LIMITS(led_min, led_max);
+static void BAND_PINWHEEL_SAT_math(HSV* hsv, int16_t dx, int16_t dy, uint8_t time) {
+    hsv->s = rgb_matrix_config.sat - time - atan2_8(dy, dx) * 3;
+}
 
-  HSV hsv = { rgb_matrix_config.hue, 0, rgb_matrix_config.val };
-  uint8_t time = scale16by8(g_rgb_counters.tick, rgb_matrix_config.speed / 2);
-  for (uint8_t i = led_min; i < led_max; i++) {
-    RGB_MATRIX_TEST_LED_FLAGS();
-    int16_t dx = g_led_config.point[i].x - 112;
-    int16_t dy = g_led_config.point[i].y - 32;
-    hsv.s = rgb_matrix_config.sat - time - atan2_8(dy, dx) * 3;
-    RGB rgb = hsv_to_rgb(hsv);
-    rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
-  }
-  return led_max < DRIVER_LED_TOTAL;
+bool BAND_PINWHEEL_SAT(effect_params_t* params) {
+    return effect_runner_dx_dy(params, &BAND_PINWHEEL_SAT_math);
 }
 
 #endif // RGB_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/quantum/rgb_matrix_animations/colorband_pinwheel_val_anim.h
+++ b/quantum/rgb_matrix_animations/colorband_pinwheel_val_anim.h
@@ -2,20 +2,12 @@
 RGB_MATRIX_EFFECT(BAND_PINWHEEL_VAL)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-bool BAND_PINWHEEL_VAL(effect_params_t* params) {
-  RGB_MATRIX_USE_LIMITS(led_min, led_max);
+static void BAND_PINWHEEL_VAL_math(HSV* hsv, int16_t dx, int16_t dy, uint8_t time) {
+    hsv->v = rgb_matrix_config.val - time - atan2_8(dy, dx) * 3;
+}
 
-  HSV hsv = { rgb_matrix_config.hue, rgb_matrix_config.sat, 0 };
-  uint8_t time = scale16by8(g_rgb_counters.tick, rgb_matrix_config.speed / 2);
-  for (uint8_t i = led_min; i < led_max; i++) {
-    RGB_MATRIX_TEST_LED_FLAGS();
-    int16_t dx = g_led_config.point[i].x - 112;
-    int16_t dy = g_led_config.point[i].y - 32;
-    hsv.v = rgb_matrix_config.val - time - atan2_8(dy, dx) * 3;
-    RGB rgb = hsv_to_rgb(hsv);
-    rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
-  }
-  return led_max < DRIVER_LED_TOTAL;
+bool BAND_PINWHEEL_VAL(effect_params_t* params) {
+    return effect_runner_dx_dy(params, &BAND_PINWHEEL_VAL_math);
 }
 
 #endif // RGB_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/quantum/rgb_matrix_animations/colorband_sat_anim.h
+++ b/quantum/rgb_matrix_animations/colorband_sat_anim.h
@@ -2,19 +2,13 @@
 RGB_MATRIX_EFFECT(BAND_SAT)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-bool BAND_SAT(effect_params_t* params) {
-  RGB_MATRIX_USE_LIMITS(led_min, led_max);
-
-  HSV hsv = { rgb_matrix_config.hue, 0, rgb_matrix_config.val };
-  uint8_t time = scale16by8(g_rgb_counters.tick, rgb_matrix_config.speed / 4);
-  for (uint8_t i = led_min; i < led_max; i++) {
-    RGB_MATRIX_TEST_LED_FLAGS();
+static void BAND_SAT_math(HSV* hsv, uint8_t i, uint8_t time) {
     int16_t s = rgb_matrix_config.sat - abs(scale8(g_led_config.point[i].x, 228) + 28 - time) * 8;
-    hsv.s = s < 0 ? 0 : s;
-    RGB rgb = hsv_to_rgb(hsv);
-    rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
-  }
-  return led_max < DRIVER_LED_TOTAL;
+    hsv->s = s < 0 ? 0 : s;
+}
+
+bool BAND_SAT(effect_params_t* params) {
+    return effect_runner_i(params, &BAND_SAT_math);
 }
 
 #endif // RGB_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/quantum/rgb_matrix_animations/colorband_spiral_sat_anim.h
+++ b/quantum/rgb_matrix_animations/colorband_spiral_sat_anim.h
@@ -2,21 +2,12 @@
 RGB_MATRIX_EFFECT(BAND_SPIRAL_SAT)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-bool BAND_SPIRAL_SAT(effect_params_t* params) {
-  RGB_MATRIX_USE_LIMITS(led_min, led_max);
+static void BAND_SPIRAL_SAT_math(HSV* hsv, int16_t dx, int16_t dy, uint8_t dist, uint8_t time) {
+    hsv->s = rgb_matrix_config.sat + dist - time - atan2_8(dy, dx);
+}
 
-  HSV hsv = { rgb_matrix_config.hue, 0, rgb_matrix_config.val };
-  uint8_t time = scale16by8(g_rgb_counters.tick, rgb_matrix_config.speed / 2);
-  for (uint8_t i = led_min; i < led_max; i++) {
-    RGB_MATRIX_TEST_LED_FLAGS();
-    int16_t dx = g_led_config.point[i].x - 112;
-    int16_t dy = g_led_config.point[i].y - 32;
-    uint8_t dist = sqrt16(dx * dx + dy * dy);
-    hsv.s = rgb_matrix_config.sat + dist - time - atan2_8(dy, dx);
-    RGB rgb = hsv_to_rgb(hsv);
-    rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
-  }
-  return led_max < DRIVER_LED_TOTAL;
+bool BAND_SPIRAL_SAT(effect_params_t* params) {
+    return effect_runner_dx_dy_dist(params, &BAND_SPIRAL_SAT_math);
 }
 
 #endif // RGB_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/quantum/rgb_matrix_animations/colorband_spiral_val_anim.h
+++ b/quantum/rgb_matrix_animations/colorband_spiral_val_anim.h
@@ -2,21 +2,12 @@
 RGB_MATRIX_EFFECT(BAND_SPIRAL_VAL)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-bool BAND_SPIRAL_VAL(effect_params_t* params) {
-  RGB_MATRIX_USE_LIMITS(led_min, led_max);
+static void BAND_SPIRAL_VAL_math(HSV* hsv, int16_t dx, int16_t dy, uint8_t dist, uint8_t time) {
+    hsv->v = rgb_matrix_config.val + dist - time - atan2_8(dy, dx);
+}
 
-  HSV hsv = { rgb_matrix_config.hue, rgb_matrix_config.sat, 0 };
-  uint8_t time = scale16by8(g_rgb_counters.tick, rgb_matrix_config.speed / 2);
-  for (uint8_t i = led_min; i < led_max; i++) {
-    RGB_MATRIX_TEST_LED_FLAGS();
-    int16_t dx = g_led_config.point[i].x - 112;
-    int16_t dy = g_led_config.point[i].y - 32;
-    uint8_t dist = sqrt16(dx * dx + dy * dy);
-    hsv.v = rgb_matrix_config.val + dist - time - atan2_8(dy, dx);
-    RGB rgb = hsv_to_rgb(hsv);
-    rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
-  }
-  return led_max < DRIVER_LED_TOTAL;
+bool BAND_SPIRAL_VAL(effect_params_t* params) {
+    return effect_runner_dx_dy_dist(params, &BAND_SPIRAL_VAL_math);
 }
 
 #endif // RGB_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/quantum/rgb_matrix_animations/colorband_val_anim.h
+++ b/quantum/rgb_matrix_animations/colorband_val_anim.h
@@ -2,19 +2,13 @@
 RGB_MATRIX_EFFECT(BAND_VAL)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-bool BAND_VAL(effect_params_t* params) {
-  RGB_MATRIX_USE_LIMITS(led_min, led_max);
-
-  HSV hsv = { rgb_matrix_config.hue, rgb_matrix_config.sat, 0 };
-  uint8_t time = scale16by8(g_rgb_counters.tick, rgb_matrix_config.speed / 4);
-  for (uint8_t i = led_min; i < led_max; i++) {
-    RGB_MATRIX_TEST_LED_FLAGS();
+static void BAND_VAL_math(HSV* hsv, uint8_t i, uint8_t time) {
     int16_t v = rgb_matrix_config.val - abs(scale8(g_led_config.point[i].x, 228) + 28 - time) * 8;
-    hsv.v = v < 0 ? 0 : v;
-    RGB rgb = hsv_to_rgb(hsv);
-    rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
-  }
-  return led_max < DRIVER_LED_TOTAL;
+    hsv->v = v < 0 ? 0 : v;
+}
+
+bool BAND_VAL(effect_params_t* params) {
+    return effect_runner_i(params, &BAND_VAL_math);
 }
 
 #endif // RGB_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/quantum/rgb_matrix_animations/cycle_all_anim.h
+++ b/quantum/rgb_matrix_animations/cycle_all_anim.h
@@ -2,17 +2,13 @@
 RGB_MATRIX_EFFECT(CYCLE_ALL)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-bool CYCLE_ALL(effect_params_t* params) {
-  RGB_MATRIX_USE_LIMITS(led_min, led_max);
+static void CYCLE_ALL_math(HSV* hsv, uint8_t i, uint8_t time)
+{
+    hsv->h = time;
+}
 
-  HSV hsv = { 0, rgb_matrix_config.sat, rgb_matrix_config.val };
-  hsv.h = scale16by8(g_rgb_counters.tick, rgb_matrix_config.speed / 4);
-  for (uint8_t i = led_min; i < led_max; i++) {
-    RGB_MATRIX_TEST_LED_FLAGS();
-    RGB rgb = hsv_to_rgb(hsv);
-    rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
-  }
-  return led_max < DRIVER_LED_TOTAL;
+bool CYCLE_ALL(effect_params_t* params) {
+    return effect_runner_i(params, &CYCLE_ALL_math);
 }
 
 #endif // RGB_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/quantum/rgb_matrix_animations/cycle_left_right_anim.h
+++ b/quantum/rgb_matrix_animations/cycle_left_right_anim.h
@@ -2,18 +2,12 @@
 RGB_MATRIX_EFFECT(CYCLE_LEFT_RIGHT)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-bool CYCLE_LEFT_RIGHT(effect_params_t* params) {
-  RGB_MATRIX_USE_LIMITS(led_min, led_max);
+static void CYCLE_LEFT_RIGHT_math(HSV* hsv, uint8_t i, uint8_t time) {
+    hsv->h = g_led_config.point[i].x - time;
+}
 
-  HSV hsv = { 0, rgb_matrix_config.sat, rgb_matrix_config.val };
-  uint8_t time = scale16by8(g_rgb_counters.tick, rgb_matrix_config.speed / 4);
-  for (uint8_t i = led_min; i < led_max; i++) {
-    RGB_MATRIX_TEST_LED_FLAGS();
-    hsv.h = g_led_config.point[i].x - time;
-    RGB rgb = hsv_to_rgb(hsv);
-    rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
-  }
-  return led_max < DRIVER_LED_TOTAL;
+bool CYCLE_LEFT_RIGHT(effect_params_t* params) {
+    return effect_runner_i(params, &CYCLE_LEFT_RIGHT_math);
 }
 
 #endif // RGB_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/quantum/rgb_matrix_animations/cycle_out_in_anim.h
+++ b/quantum/rgb_matrix_animations/cycle_out_in_anim.h
@@ -2,21 +2,12 @@
 RGB_MATRIX_EFFECT(CYCLE_OUT_IN)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-bool CYCLE_OUT_IN(effect_params_t* params) {
-  RGB_MATRIX_USE_LIMITS(led_min, led_max);
+static void CYCLE_OUT_IN_math(HSV* hsv, int16_t dx, int16_t dy, uint8_t dist, uint8_t time) {
+    hsv->h = 3 * dist / 2 + time;
+}
 
-  HSV hsv = { 0, rgb_matrix_config.sat, rgb_matrix_config.val };
-  uint8_t time = scale16by8(g_rgb_counters.tick, rgb_matrix_config.speed / 4);
-  for (uint8_t i = led_min; i < led_max; i++) {
-    RGB_MATRIX_TEST_LED_FLAGS();
-    int16_t dx = g_led_config.point[i].x - k_rgb_matrix_center.x;
-    int16_t dy = g_led_config.point[i].y - k_rgb_matrix_center.y;
-    uint8_t dist = sqrt16(dx * dx + dy * dy);
-    hsv.h = 3 * dist / 2 + time;
-    RGB rgb = hsv_to_rgb(hsv);
-    rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
-  }
-  return led_max < DRIVER_LED_TOTAL;
+bool CYCLE_OUT_IN(effect_params_t* params) {
+    return effect_runner_dx_dy_dist(params, &CYCLE_OUT_IN_math);
 }
 
 #endif // RGB_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/quantum/rgb_matrix_animations/cycle_out_in_dual_anim.h
+++ b/quantum/rgb_matrix_animations/cycle_out_in_dual_anim.h
@@ -2,21 +2,14 @@
 RGB_MATRIX_EFFECT(CYCLE_OUT_IN_DUAL)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-bool CYCLE_OUT_IN_DUAL(effect_params_t* params) {
-  RGB_MATRIX_USE_LIMITS(led_min, led_max);
-
-  HSV hsv = { 0, rgb_matrix_config.sat, rgb_matrix_config.val };
-  uint8_t time = scale16by8(g_rgb_counters.tick, rgb_matrix_config.speed / 4);
-  for (uint8_t i = led_min; i < led_max; i++) {
-    RGB_MATRIX_TEST_LED_FLAGS();
-    int16_t dx = (k_rgb_matrix_center.x / 2) - abs8(g_led_config.point[i].x - k_rgb_matrix_center.x);
-    int16_t dy = g_led_config.point[i].y - k_rgb_matrix_center.y;
+static void CYCLE_OUT_IN_DUAL_math(HSV* hsv, int16_t dx, int16_t dy, uint8_t time) {
+    dx = (k_rgb_matrix_center.x / 2) - abs8(dx);
     uint8_t dist = sqrt16(dx * dx + dy * dy);
-    hsv.h = 3 * dist + time;
-    RGB rgb = hsv_to_rgb(hsv);
-    rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
-  }
-  return led_max < DRIVER_LED_TOTAL;
+    hsv->h = 3 * dist + time;
+}
+
+bool CYCLE_OUT_IN_DUAL(effect_params_t* params) {
+    return effect_runner_dx_dy(params, &CYCLE_OUT_IN_DUAL_math);
 }
 
 #endif // RGB_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/quantum/rgb_matrix_animations/cycle_pinwheel_anim.h
+++ b/quantum/rgb_matrix_animations/cycle_pinwheel_anim.h
@@ -2,20 +2,12 @@
 RGB_MATRIX_EFFECT(CYCLE_PINWHEEL)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-bool CYCLE_PINWHEEL(effect_params_t* params) {
-  RGB_MATRIX_USE_LIMITS(led_min, led_max);
+static void CYCLE_PINWHEEL_math(HSV* hsv, int16_t dx, int16_t dy, uint8_t time) {
+    hsv->h = atan2_8(dy, dx) + time;
+}
 
-  HSV hsv = { 0, rgb_matrix_config.sat, rgb_matrix_config.val };
-  uint8_t time = scale16by8(g_rgb_counters.tick, rgb_matrix_config.speed / 4);
-  for (uint8_t i = led_min; i < led_max; i++) {
-    RGB_MATRIX_TEST_LED_FLAGS();
-    int16_t dx = g_led_config.point[i].x - 112;
-    int16_t dy = g_led_config.point[i].y - 32;
-    hsv.h = atan2_8(dy, dx) + time;
-    RGB rgb = hsv_to_rgb(hsv);
-    rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
-  }
-  return led_max < DRIVER_LED_TOTAL;
+bool CYCLE_PINWHEEL(effect_params_t* params) {
+    return effect_runner_dx_dy(params, &CYCLE_PINWHEEL_math);
 }
 
 #endif // RGB_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/quantum/rgb_matrix_animations/cycle_spiral_anim.h
+++ b/quantum/rgb_matrix_animations/cycle_spiral_anim.h
@@ -2,21 +2,12 @@
 RGB_MATRIX_EFFECT(CYCLE_SPIRAL)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-bool CYCLE_SPIRAL(effect_params_t* params) {
-  RGB_MATRIX_USE_LIMITS(led_min, led_max);
+static void CYCLE_SPIRAL_math(HSV* hsv, int16_t dx, int16_t dy, uint8_t dist, uint8_t time) {
+    hsv->h = dist - time - atan2_8(dy, dx);
+}
 
-  HSV hsv = { 0, rgb_matrix_config.sat, rgb_matrix_config.val };
-  uint8_t time = scale16by8(g_rgb_counters.tick, rgb_matrix_config.speed / 2);
-  for (uint8_t i = led_min; i < led_max; i++) {
-    RGB_MATRIX_TEST_LED_FLAGS();
-    int16_t dx = g_led_config.point[i].x - 112;
-    int16_t dy = g_led_config.point[i].y - 32;
-    uint8_t dist = sqrt16(dx * dx + dy * dy);
-    hsv.h = dist - time - atan2_8(dy, dx);
-    RGB rgb = hsv_to_rgb(hsv);
-    rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
-  }
-  return led_max < DRIVER_LED_TOTAL;
+bool CYCLE_SPIRAL(effect_params_t* params) {
+    return effect_runner_dx_dy_dist(params, &CYCLE_SPIRAL_math);
 }
 
 #endif // RGB_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/quantum/rgb_matrix_animations/cycle_up_down_anim.h
+++ b/quantum/rgb_matrix_animations/cycle_up_down_anim.h
@@ -2,18 +2,12 @@
 RGB_MATRIX_EFFECT(CYCLE_UP_DOWN)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-bool CYCLE_UP_DOWN(effect_params_t* params) {
-  RGB_MATRIX_USE_LIMITS(led_min, led_max);
+static void CYCLE_UP_DOWN_math(HSV* hsv, uint8_t i, uint8_t time) {
+    hsv->h = g_led_config.point[i].y - time;
+}
 
-  HSV hsv = { 0, rgb_matrix_config.sat, rgb_matrix_config.val };
-  uint8_t time = scale16by8(g_rgb_counters.tick, rgb_matrix_config.speed / 4);
-  for (uint8_t i = led_min; i < led_max; i++) {
-    RGB_MATRIX_TEST_LED_FLAGS();
-    hsv.h = g_led_config.point[i].y - time;
-    RGB rgb = hsv_to_rgb(hsv);
-    rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
-  }
-  return led_max < DRIVER_LED_TOTAL;
+bool CYCLE_UP_DOWN(effect_params_t* params) {
+    return effect_runner_i(params, &CYCLE_UP_DOWN_math);
 }
 
 #endif // RGB_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/quantum/rgb_matrix_animations/dual_beacon_anim.h
+++ b/quantum/rgb_matrix_animations/dual_beacon_anim.h
@@ -2,20 +2,12 @@
 RGB_MATRIX_EFFECT(DUAL_BEACON)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-bool DUAL_BEACON(effect_params_t* params) {
-  RGB_MATRIX_USE_LIMITS(led_min, led_max);
+static void DUAL_BEACON_math(HSV* hsv, int8_t sin, int8_t cos, uint8_t i, uint8_t time) {
+    hsv->h = ((g_led_config.point[i].y - k_rgb_matrix_center.y) * cos + (g_led_config.point[i].x - k_rgb_matrix_center.x) * sin) / 128 + rgb_matrix_config.hue;
+}
 
-  HSV hsv = { 0, rgb_matrix_config.sat, rgb_matrix_config.val };
-  uint16_t time = scale16by8(g_rgb_counters.tick, rgb_matrix_config.speed / 4);
-  int8_t cos_value = cos8(time) - 128;
-  int8_t sin_value = sin8(time) - 128;
-  for (uint8_t i = led_min; i < led_max; i++) {
-    RGB_MATRIX_TEST_LED_FLAGS();
-    hsv.h = ((g_led_config.point[i].y - k_rgb_matrix_center.y) * cos_value + (g_led_config.point[i].x - k_rgb_matrix_center.x) * sin_value) / 128 + rgb_matrix_config.hue;
-    RGB rgb = hsv_to_rgb(hsv);
-    rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
-  }
-  return led_max < DRIVER_LED_TOTAL;
+bool DUAL_BEACON(effect_params_t* params) {
+    return effect_runner_sin_cos_i(params, &DUAL_BEACON_math);
 }
 
 #endif // RGB_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/quantum/rgb_matrix_animations/rainbow_beacon_anim.h
+++ b/quantum/rgb_matrix_animations/rainbow_beacon_anim.h
@@ -2,20 +2,12 @@
 RGB_MATRIX_EFFECT(RAINBOW_BEACON)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-bool RAINBOW_BEACON(effect_params_t* params) {
-  RGB_MATRIX_USE_LIMITS(led_min, led_max);
+static void RAINBOW_BEACON_math(HSV* hsv, int8_t sin, int8_t cos, uint8_t i, uint8_t time) {
+    hsv->h = ((g_led_config.point[i].y - k_rgb_matrix_center.y) * 2 * cos + (g_led_config.point[i].x - k_rgb_matrix_center.x) * 2 * sin) / 128 + rgb_matrix_config.hue;
+}
 
-  HSV hsv = { 0, rgb_matrix_config.sat, rgb_matrix_config.val };
-  uint16_t time = scale16by8(g_rgb_counters.tick, rgb_matrix_config.speed / 4);
-  int16_t cos_value = 2 * (cos8(time) - 128);
-  int16_t sin_value = 2 * (sin8(time) - 128);
-  for (uint8_t i = led_min; i < led_max; i++) {
-    RGB_MATRIX_TEST_LED_FLAGS();
-    hsv.h = ((g_led_config.point[i].y - k_rgb_matrix_center.y) * cos_value + (g_led_config.point[i].x - k_rgb_matrix_center.x) * sin_value) / 128 + rgb_matrix_config.hue;
-    RGB rgb = hsv_to_rgb(hsv);
-    rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
-  }
-  return led_max < DRIVER_LED_TOTAL;
+bool RAINBOW_BEACON(effect_params_t* params) {
+    return effect_runner_sin_cos_i(params, &RAINBOW_BEACON_math);
 }
 
 #endif // RGB_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/quantum/rgb_matrix_animations/rainbow_moving_chevron_anim.h
+++ b/quantum/rgb_matrix_animations/rainbow_moving_chevron_anim.h
@@ -2,18 +2,12 @@
 RGB_MATRIX_EFFECT(RAINBOW_MOVING_CHEVRON)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-bool RAINBOW_MOVING_CHEVRON(effect_params_t* params) {
-  RGB_MATRIX_USE_LIMITS(led_min, led_max);
+static void RAINBOW_MOVING_CHEVRON_math(HSV* hsv, uint8_t i, uint8_t time) {
+    hsv->h = abs8(g_led_config.point[i].y - k_rgb_matrix_center.y) + (g_led_config.point[i].x - time) + rgb_matrix_config.hue;
+}
 
-  HSV hsv = { 0, rgb_matrix_config.sat, rgb_matrix_config.val };
-  uint8_t time = scale16by8(g_rgb_counters.tick, rgb_matrix_config.speed / 4);
-  for (uint8_t i = led_min; i < led_max; i++) {
-    RGB_MATRIX_TEST_LED_FLAGS();
-    hsv.h = abs8(g_led_config.point[i].y - 32) + (g_led_config.point[i].x - time) + rgb_matrix_config.hue;
-    RGB rgb = hsv_to_rgb(hsv);
-    rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
-  }
-  return led_max < DRIVER_LED_TOTAL;
+bool RAINBOW_MOVING_CHEVRON(effect_params_t* params) {
+    return effect_runner_i(params, &RAINBOW_MOVING_CHEVRON_math);
 }
 
 #endif // RGB_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/quantum/rgb_matrix_animations/rainbow_pinwheels_anim.h
+++ b/quantum/rgb_matrix_animations/rainbow_pinwheels_anim.h
@@ -2,20 +2,12 @@
 RGB_MATRIX_EFFECT(PINWHEELS)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-bool PINWHEELS(effect_params_t* params) {
-  RGB_MATRIX_USE_LIMITS(led_min, led_max);
+static void PINWHEELS_math(HSV* hsv, int8_t sin, int8_t cos, uint8_t i, uint8_t time) {
+    hsv->h = ((g_led_config.point[i].y - k_rgb_matrix_center.y) * 3 * cos + (56 - abs8(g_led_config.point[i].x - k_rgb_matrix_center.x)) * 3 * sin) / 128 + rgb_matrix_config.hue;
+}
 
-  HSV hsv = { 0, rgb_matrix_config.sat, rgb_matrix_config.val };
-  uint16_t time = scale16by8(g_rgb_counters.tick, rgb_matrix_config.speed / 4);
-  int16_t cos_value = 3 * (cos8(time) - 128);
-  int16_t sin_value = 3 * (sin8(time) - 128);
-  for (uint8_t i = led_min; i < led_max; i++) {
-    RGB_MATRIX_TEST_LED_FLAGS();
-    hsv.h = ((g_led_config.point[i].y - k_rgb_matrix_center.y) * cos_value + (56 - abs8(g_led_config.point[i].x - k_rgb_matrix_center.x)) * sin_value) / 128 + rgb_matrix_config.hue;
-    RGB rgb = hsv_to_rgb(hsv);
-    rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
-  }
-  return led_max < DRIVER_LED_TOTAL;
+bool PINWHEELS(effect_params_t* params) {
+    return effect_runner_sin_cos_i(params, &PINWHEELS_math);
 }
 
 #endif // RGB_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/quantum/rgb_matrix_animations/solid_reactive_anim.h
+++ b/quantum/rgb_matrix_animations/solid_reactive_anim.h
@@ -3,30 +3,12 @@
 RGB_MATRIX_EFFECT(SOLID_REACTIVE)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
+static void SOLID_REACTIVE_math(HSV* hsv, uint16_t offset) {
+    hsv->h = rgb_matrix_config.hue + qsub8(130, offset);
+}
+
 bool SOLID_REACTIVE(effect_params_t* params) {
-  RGB_MATRIX_USE_LIMITS(led_min, led_max);
-
-  HSV hsv = { rgb_matrix_config.hue, 255, rgb_matrix_config.val };
-  // Max tick based on speed scale ensures results from scale16by8 with rgb_matrix_config.speed are no greater than 255
-  uint16_t max_tick = 65535 / rgb_matrix_config.speed;
-  // Relies on hue being 8-bit and wrapping
-  for (uint8_t i = led_min; i < led_max; i++) {
-    RGB_MATRIX_TEST_LED_FLAGS();
-    uint16_t tick = max_tick;
-    // Reverse search to find most recent key hit
-    for (int8_t j = g_last_hit_tracker.count - 1; j >= 0; j--) {
-      if (g_last_hit_tracker.index[j] == i && g_last_hit_tracker.tick[j] < tick) {
-        tick = g_last_hit_tracker.tick[j];
-        break;
-      }
-    }
-
-    uint16_t  offset = scale16by8(tick, rgb_matrix_config.speed);
-    hsv.h = rgb_matrix_config.hue + qsub8(130, offset);
-    RGB rgb = hsv_to_rgb(hsv);
-    rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
-  }
-  return led_max < DRIVER_LED_TOTAL;
+    return effect_runner_reactive(params, &SOLID_REACTIVE_math);
 }
 
 #endif // RGB_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/quantum/rgb_matrix_animations/solid_reactive_cross.h
+++ b/quantum/rgb_matrix_animations/solid_reactive_cross.h
@@ -11,45 +11,29 @@ RGB_MATRIX_EFFECT(SOLID_REACTIVE_MULTICROSS)
 
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static bool rgb_matrix_solid_reactive_multicross_range(uint8_t start, effect_params_t* params) {
-  RGB_MATRIX_USE_LIMITS(led_min, led_max);
-
-  HSV hsv = { rgb_matrix_config.hue, rgb_matrix_config.sat, 0 };
-  uint8_t count = g_last_hit_tracker.count;
-  for (uint8_t i = led_min; i < led_max; i++) {
-    hsv.v = 0;
-    for (uint8_t j = start; j < count; j++) {
-      RGB_MATRIX_TEST_LED_FLAGS();
-      int16_t dx = g_led_config.point[i].x - g_last_hit_tracker.x[j];
-      int16_t dy = g_led_config.point[i].y - g_last_hit_tracker.y[j];
-      uint8_t dist = sqrt16(dx * dx + dy * dy);
-      int16_t dist2 = 16;
-      uint8_t dist3;
-      uint16_t effect = scale16by8(g_last_hit_tracker.tick[j], rgb_matrix_config.speed) + dist;
-      dx = dx < 0 ? dx * -1 : dx;
-      dy = dy < 0 ? dy * -1 : dy;
-      dx = dx * dist2 > 255 ? 255 : dx * dist2;
-      dy = dy * dist2 > 255 ? 255 : dy * dist2;
-      dist3 = dx > dy ? dy : dx;
-      effect += dist3;
-      if (effect > 255)
+static void SOLID_REACTIVE_CROSS_math(HSV* hsv, int16_t dx, int16_t dy, uint8_t dist, uint16_t tick) {
+    uint16_t effect = tick + dist;
+    dx = dx < 0 ? dx * -1 : dx;
+    dy = dy < 0 ? dy * -1 : dy;
+    dx = dx * 16 > 255 ? 255 : dx * 16;
+    dy = dy * 16 > 255 ? 255 : dy * 16;
+    effect += dx > dy ? dy : dx;
+    if (effect > 255)
         effect = 255;
-      hsv.v = qadd8(hsv.v, 255 - effect);
-    }
-    hsv.v = scale8(hsv.v, rgb_matrix_config.val);
-    RGB rgb = hsv_to_rgb(hsv);
-    rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
-  }
-  return led_max < DRIVER_LED_TOTAL;
+    hsv->v = qadd8(hsv->v, 255 - effect);
 }
 
-bool SOLID_REACTIVE_MULTICROSS(effect_params_t* params) {
-  return rgb_matrix_solid_reactive_multicross_range(0, params);
-}
-
+#ifndef DISABLE_RGB_MATRIX_SOLID_REACTIVE_CROSS
 bool SOLID_REACTIVE_CROSS(effect_params_t* params) {
-  return rgb_matrix_solid_reactive_multicross_range(qsub8(g_last_hit_tracker.count, 1), params);
+    return effect_runner_reactive_splash(qsub8(g_last_hit_tracker.count, 1), params, &SOLID_REACTIVE_CROSS_math);
 }
+#endif
+
+#ifndef DISABLE_RGB_MATRIX_SOLID_REACTIVE_MULTICROSS
+bool SOLID_REACTIVE_MULTICROSS(effect_params_t* params) {
+    return effect_runner_reactive_splash(0, params, &SOLID_REACTIVE_CROSS_math);
+}
+#endif
 
 #endif // RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 #endif // !defined(DISABLE_RGB_MATRIX_SOLID_REACTIVE_CROSS) || !defined(DISABLE_RGB_MATRIX_SOLID_REACTIVE_MULTICROSS)

--- a/quantum/rgb_matrix_animations/solid_reactive_nexus.h
+++ b/quantum/rgb_matrix_animations/solid_reactive_nexus.h
@@ -11,43 +11,29 @@ RGB_MATRIX_EFFECT(SOLID_REACTIVE_MULTINEXUS)
 
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static bool rgb_matrix_solid_reactive_multinexus_range(uint8_t start, effect_params_t* params) {
-  RGB_MATRIX_USE_LIMITS(led_min, led_max);
-
-  HSV hsv = { rgb_matrix_config.hue, rgb_matrix_config.sat, 0 };
-  uint8_t count = g_last_hit_tracker.count;
-  for (uint8_t i = led_min; i < led_max; i++) {
-    hsv.v = 0;
-    for (uint8_t j = start; j < count; j++) {
-      RGB_MATRIX_TEST_LED_FLAGS();
-      int16_t dx = g_led_config.point[i].x - g_last_hit_tracker.x[j];
-      int16_t dy = g_led_config.point[i].y - g_last_hit_tracker.y[j];
-      uint8_t dist = sqrt16(dx * dx + dy * dy);
-      int16_t dist2 = 8;
-      uint16_t effect = scale16by8(g_last_hit_tracker.tick[j], rgb_matrix_config.speed) - dist;
-      if (effect > 255)
+static void SOLID_REACTIVE_NEXUS_math(HSV* hsv, int16_t dx, int16_t dy, uint8_t dist, uint16_t tick) {
+    uint16_t effect = tick - dist;
+    if (effect > 255)
         effect = 255;
-      if (dist > 72)
+    if (dist > 72)
         effect = 255;
-      if ((dx > dist2 || dx < -dist2) && (dy > dist2 || dy < -dist2))
+    if ((dx > 8 || dx < -8) && (dy > 8 || dy < -8))
         effect = 255;
-      hsv.v = qadd8(hsv.v, 255 - effect);
-      hsv.h = rgb_matrix_config.hue + dy / 4;
-    }
-    hsv.v = scale8(hsv.v, rgb_matrix_config.val);
-    RGB rgb = hsv_to_rgb(hsv);
-    rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
-  }
-  return led_max < DRIVER_LED_TOTAL;
+    hsv->v = qadd8(hsv->v, 255 - effect);
+    hsv->h = rgb_matrix_config.hue + dy / 4;
 }
 
-bool SOLID_REACTIVE_MULTINEXUS(effect_params_t* params) {
-  return rgb_matrix_solid_reactive_multinexus_range(0, params);
-}
-
+#ifndef DISABLE_RGB_MATRIX_SOLID_REACTIVE_NEXUS
 bool SOLID_REACTIVE_NEXUS(effect_params_t* params) {
-  return rgb_matrix_solid_reactive_multinexus_range(qsub8(g_last_hit_tracker.count, 1), params);
+    return effect_runner_reactive_splash(qsub8(g_last_hit_tracker.count, 1), params, &SOLID_REACTIVE_NEXUS_math);
 }
+#endif
+
+#ifndef DISABLE_RGB_MATRIX_SOLID_REACTIVE_MULTINEXUS
+bool SOLID_REACTIVE_MULTINEXUS(effect_params_t* params) {
+    return effect_runner_reactive_splash(0, params, &SOLID_REACTIVE_NEXUS_math);
+}
+#endif
 
 #endif // RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 #endif // !defined(DISABLE_RGB_MATRIX_SOLID_REACTIVE_NEXUS) || !defined(DISABLE_RGB_MATRIX_SOLID_REACTIVE_MULTINEXUS)

--- a/quantum/rgb_matrix_animations/solid_reactive_simple_anim.h
+++ b/quantum/rgb_matrix_animations/solid_reactive_simple_anim.h
@@ -3,29 +3,12 @@
 RGB_MATRIX_EFFECT(SOLID_REACTIVE_SIMPLE)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
+static void SOLID_REACTIVE_SIMPLE_math(HSV* hsv, uint16_t offset) {
+    hsv->v = scale8(255 - offset, rgb_matrix_config.val);
+}
+
 bool SOLID_REACTIVE_SIMPLE(effect_params_t* params) {
-  RGB_MATRIX_USE_LIMITS(led_min, led_max);
-
-  HSV hsv = { rgb_matrix_config.hue, rgb_matrix_config.sat, 0 };
-  // Max tick based on speed scale ensures results from scale16by8 with rgb_matrix_config.speed are no greater than 255
-  uint16_t max_tick = 65535 / rgb_matrix_config.speed;
-  for (uint8_t i = led_min; i < led_max; i++) {
-    RGB_MATRIX_TEST_LED_FLAGS();
-    uint16_t tick = max_tick;
-    // Reverse search to find most recent key hit
-    for (int8_t j = g_last_hit_tracker.count - 1; j >= 0; j--) {
-      if (g_last_hit_tracker.index[j] == i && g_last_hit_tracker.tick[j] < tick) {
-        tick = g_last_hit_tracker.tick[j];
-        break;
-      }
-    }
-
-    uint16_t  offset = scale16by8(tick, rgb_matrix_config.speed);
-    hsv.v = scale8(255 - offset, rgb_matrix_config.val);
-    RGB rgb = hsv_to_rgb(hsv);
-    rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
-  }
-  return led_max < DRIVER_LED_TOTAL;
+    return effect_runner_reactive(params, &SOLID_REACTIVE_SIMPLE_math);
 }
 
 #endif // RGB_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/quantum/rgb_matrix_animations/solid_reactive_wide.h
+++ b/quantum/rgb_matrix_animations/solid_reactive_wide.h
@@ -11,37 +11,24 @@ RGB_MATRIX_EFFECT(SOLID_REACTIVE_MULTIWIDE)
 
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static bool rgb_matrix_solid_reactive_multiwide_range(uint8_t start, effect_params_t* params) {
-  RGB_MATRIX_USE_LIMITS(led_min, led_max);
-
-  HSV hsv = { rgb_matrix_config.hue, rgb_matrix_config.sat, 0 };
-  uint8_t count = g_last_hit_tracker.count;
-  for (uint8_t i = led_min; i < led_max; i++) {
-    hsv.v = 0;
-    for (uint8_t j = start; j < count; j++) {
-      RGB_MATRIX_TEST_LED_FLAGS();
-      int16_t dx = g_led_config.point[i].x - g_last_hit_tracker.x[j];
-      int16_t dy = g_led_config.point[i].y - g_last_hit_tracker.y[j];
-      uint8_t dist = sqrt16(dx * dx + dy * dy);
-      uint16_t effect = scale16by8(g_last_hit_tracker.tick[j], rgb_matrix_config.speed) + dist * 5;
-      if (effect > 255)
+static void SOLID_REACTIVE_WIDE_math(HSV* hsv, int16_t dx, int16_t dy, uint8_t dist, uint16_t tick) {
+    uint16_t effect = tick + dist * 5;
+    if (effect > 255)
         effect = 255;
-      hsv.v = qadd8(hsv.v, 255 - effect);
-    }
-    hsv.v = scale8(hsv.v, rgb_matrix_config.val);
-    RGB rgb = hsv_to_rgb(hsv);
-    rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
-  }
-  return led_max < DRIVER_LED_TOTAL;
+    hsv->v = qadd8(hsv->v, 255 - effect);
 }
 
-bool SOLID_REACTIVE_MULTIWIDE(effect_params_t* params) {
-  return rgb_matrix_solid_reactive_multiwide_range(0, params);
-}
-
+#ifndef DISABLE_RGB_MATRIX_SOLID_REACTIVE_WIDE
 bool SOLID_REACTIVE_WIDE(effect_params_t* params) {
-  return rgb_matrix_solid_reactive_multiwide_range(qsub8(g_last_hit_tracker.count, 1), params);
+    return effect_runner_reactive_splash(qsub8(g_last_hit_tracker.count, 1), params, &SOLID_REACTIVE_WIDE_math);
 }
+#endif
+
+#ifndef DISABLE_RGB_MATRIX_SOLID_REACTIVE_MULTIWIDE
+bool SOLID_REACTIVE_MULTIWIDE(effect_params_t* params) {
+    return effect_runner_reactive_splash(0, params, &SOLID_REACTIVE_WIDE_math);
+}
+#endif
 
 #endif // RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 #endif // !defined(DISABLE_RGB_MATRIX_SOLID_REACTIVE_WIDE) || !defined(DISABLE_RGB_MATRIX_SOLID_REACTIVE_MULTIWIDE)

--- a/quantum/rgb_matrix_animations/solid_splash_anim.h
+++ b/quantum/rgb_matrix_animations/solid_splash_anim.h
@@ -11,37 +11,24 @@ RGB_MATRIX_EFFECT(SOLID_MULTISPLASH)
 
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static bool rgb_matrix_solid_multisplash_range(uint8_t start, effect_params_t* params) {
-  RGB_MATRIX_USE_LIMITS(led_min, led_max);
-
-  HSV hsv = { rgb_matrix_config.hue, rgb_matrix_config.sat, 0 };
-  uint8_t count = g_last_hit_tracker.count;
-  for (uint8_t i = led_min; i < led_max; i++) {
-    RGB_MATRIX_TEST_LED_FLAGS();
-    hsv.v = 0;
-    for (uint8_t j = start; j < count; j++) {
-      int16_t dx = g_led_config.point[i].x - g_last_hit_tracker.x[j];
-      int16_t dy = g_led_config.point[i].y - g_last_hit_tracker.y[j];
-      uint8_t dist = sqrt16(dx * dx + dy * dy);
-      uint16_t effect = scale16by8(g_last_hit_tracker.tick[j], rgb_matrix_config.speed) - dist;
-      if (effect > 255)
+void SOLID_SPLASH_math(HSV* hsv, int16_t dx, int16_t dy, uint8_t dist, uint16_t tick) {
+    uint16_t effect = tick - dist;
+    if (effect > 255)
         effect = 255;
-      hsv.v = qadd8(hsv.v, 255 - effect);
-    }
-    hsv.v = scale8(hsv.v, rgb_matrix_config.val);
-    RGB rgb = hsv_to_rgb(hsv);
-    rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
-  }
-  return led_max < DRIVER_LED_TOTAL;
+    hsv->v = qadd8(hsv->v, 255 - effect);
 }
 
-bool SOLID_MULTISPLASH(effect_params_t* params) {
-  return rgb_matrix_solid_multisplash_range(0, params);
-}
-
+#ifndef DISABLE_RGB_MATRIX_SOLID_SPLASH
 bool SOLID_SPLASH(effect_params_t* params) {
-  return rgb_matrix_solid_multisplash_range(qsub8(g_last_hit_tracker.count, 1), params);
+    return effect_runner_reactive_splash(qsub8(g_last_hit_tracker.count, 1), params, &SOLID_SPLASH_math);
 }
+#endif
+
+#ifndef DISABLE_RGB_MATRIX_SOLID_MULTISPLASH
+bool SOLID_MULTISPLASH(effect_params_t* params) {
+    return effect_runner_reactive_splash(0, params, &SOLID_SPLASH_math);
+}
+#endif
 
 #endif // RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 #endif // !defined(DISABLE_RGB_MATRIX_SPLASH) && !defined(DISABLE_RGB_MATRIX_MULTISPLASH)

--- a/quantum/rgb_matrix_animations/splash_anim.h
+++ b/quantum/rgb_matrix_animations/splash_anim.h
@@ -11,40 +11,25 @@ RGB_MATRIX_EFFECT(MULTISPLASH)
 
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-
-static bool rgb_matrix_multisplash_range(uint8_t start, effect_params_t* params) {
-  RGB_MATRIX_USE_LIMITS(led_min, led_max);
-
-  HSV hsv = { 0, rgb_matrix_config.sat, 0 };
-  uint8_t count = g_last_hit_tracker.count;
-  for (uint8_t i = led_min; i < led_max; i++) {
-    RGB_MATRIX_TEST_LED_FLAGS();
-    hsv.h = rgb_matrix_config.hue;
-    hsv.v = 0;
-    for (uint8_t j = start; j < count; j++) {
-      int16_t dx = g_led_config.point[i].x - g_last_hit_tracker.x[j];
-      int16_t dy = g_led_config.point[i].y - g_last_hit_tracker.y[j];
-      uint8_t dist = sqrt16(dx * dx + dy * dy);
-      uint16_t effect = scale16by8(g_last_hit_tracker.tick[j], rgb_matrix_config.speed) - dist;
+void SPLASH_math(HSV* hsv, int16_t dx, int16_t dy, uint8_t dist, uint16_t tick) {
+    uint16_t effect = tick - dist;
       if (effect > 255)
         effect = 255;
-      hsv.h += effect;
-      hsv.v = qadd8(hsv.v, 255 - effect);
-    }
-    hsv.v = scale8(hsv.v, rgb_matrix_config.val);
-    RGB rgb = hsv_to_rgb(hsv);
-    rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
-  }
-  return led_max < DRIVER_LED_TOTAL;
+      hsv->h += effect;
+      hsv->v = qadd8(hsv->v, 255 - effect);
 }
 
-bool MULTISPLASH(effect_params_t* params) {
-  return rgb_matrix_multisplash_range(0, params);
-}
-
+#ifndef DISABLE_RGB_MATRIX_SPLASH
 bool SPLASH(effect_params_t* params) {
-  return rgb_matrix_multisplash_range(qsub8(g_last_hit_tracker.count, 1), params);
+    return effect_runner_reactive_splash(qsub8(g_last_hit_tracker.count, 1), params, &SPLASH_math);
 }
+#endif
+
+#ifndef DISABLE_RGB_MATRIX_MULTISPLASH
+bool MULTISPLASH(effect_params_t* params) {
+    return effect_runner_reactive_splash(0, params, &SPLASH_math);
+}
+#endif
 
 #endif // RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 #endif // !defined(DISABLE_RGB_MATRIX_SPLASH) || !defined(DISABLE_RGB_MATRIX_MULTISPLASH)

--- a/quantum/rgb_matrix_runners/effect_runner_dx_dy.h
+++ b/quantum/rgb_matrix_runners/effect_runner_dx_dy.h
@@ -1,0 +1,19 @@
+#pragma once
+
+typedef void (*dx_dy_f)(HSV* hsv, int16_t dx, int16_t dy, uint8_t time);
+
+bool effect_runner_dx_dy(effect_params_t* params, dx_dy_f effect_func) {
+  RGB_MATRIX_USE_LIMITS(led_min, led_max);
+
+  HSV hsv = { rgb_matrix_config.hue, rgb_matrix_config.sat, rgb_matrix_config.val };
+  uint8_t time = scale16by8(g_rgb_counters.tick, rgb_matrix_config.speed / 2);
+  for (uint8_t i = led_min; i < led_max; i++) {
+    RGB_MATRIX_TEST_LED_FLAGS();
+    int16_t dx = g_led_config.point[i].x - k_rgb_matrix_center.x;
+    int16_t dy = g_led_config.point[i].y - k_rgb_matrix_center.y;
+    effect_func(&hsv, dx, dy, time);
+    RGB rgb = hsv_to_rgb(hsv);
+    rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
+  }
+  return led_max < DRIVER_LED_TOTAL;
+}

--- a/quantum/rgb_matrix_runners/effect_runner_dx_dy_dist.h
+++ b/quantum/rgb_matrix_runners/effect_runner_dx_dy_dist.h
@@ -1,0 +1,20 @@
+#pragma once
+
+typedef void (*dx_dy_dist_f)(HSV* hsv, int16_t dx, int16_t dy, uint8_t dist, uint8_t time);
+
+bool effect_runner_dx_dy_dist(effect_params_t* params, dx_dy_dist_f effect_func) {
+  RGB_MATRIX_USE_LIMITS(led_min, led_max);
+
+  HSV hsv = { rgb_matrix_config.hue, rgb_matrix_config.sat, rgb_matrix_config.val };
+  uint8_t time = scale16by8(g_rgb_counters.tick, rgb_matrix_config.speed / 2);
+  for (uint8_t i = led_min; i < led_max; i++) {
+    RGB_MATRIX_TEST_LED_FLAGS();
+    int16_t dx = g_led_config.point[i].x - k_rgb_matrix_center.x;
+    int16_t dy = g_led_config.point[i].y - k_rgb_matrix_center.y;
+    uint8_t dist = sqrt16(dx * dx + dy * dy);
+    effect_func(&hsv, dx, dy, dist, time);
+    RGB rgb = hsv_to_rgb(hsv);
+    rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
+  }
+  return led_max < DRIVER_LED_TOTAL;
+}

--- a/quantum/rgb_matrix_runners/effect_runner_i.h
+++ b/quantum/rgb_matrix_runners/effect_runner_i.h
@@ -1,0 +1,17 @@
+#pragma once
+
+typedef void (*i_f)(HSV* hsv, uint8_t i, uint8_t time);
+
+bool effect_runner_i(effect_params_t* params, i_f effect_func) {
+  RGB_MATRIX_USE_LIMITS(led_min, led_max);
+
+  HSV hsv = { rgb_matrix_config.hue, rgb_matrix_config.sat, rgb_matrix_config.val };
+  uint8_t time = scale16by8(g_rgb_counters.tick, rgb_matrix_config.speed / 4);
+  for (uint8_t i = led_min; i < led_max; i++) {
+    RGB_MATRIX_TEST_LED_FLAGS();
+    effect_func(&hsv, i, time);
+    RGB rgb = hsv_to_rgb(hsv);
+    rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
+  }
+  return led_max < DRIVER_LED_TOTAL;
+}

--- a/quantum/rgb_matrix_runners/effect_runner_reactive.h
+++ b/quantum/rgb_matrix_runners/effect_runner_reactive.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#ifdef RGB_MATRIX_KEYREACTIVE_ENABLED
+
+typedef void (*reactive_f)(HSV* hsv, uint16_t offset);
+
+bool effect_runner_reactive(effect_params_t* params, reactive_f effect_func) {
+    RGB_MATRIX_USE_LIMITS(led_min, led_max);
+
+  HSV hsv = { rgb_matrix_config.hue, rgb_matrix_config.sat, rgb_matrix_config.val };
+  uint16_t max_tick = 65535 / rgb_matrix_config.speed;
+  for (uint8_t i = led_min; i < led_max; i++) {
+    RGB_MATRIX_TEST_LED_FLAGS();
+    uint16_t tick = max_tick;
+    // Reverse search to find most recent key hit
+    for (int8_t j = g_last_hit_tracker.count - 1; j >= 0; j--) {
+      if (g_last_hit_tracker.index[j] == i && g_last_hit_tracker.tick[j] < tick) {
+        tick = g_last_hit_tracker.tick[j];
+        break;
+      }
+    }
+
+    uint16_t  offset = scale16by8(tick, rgb_matrix_config.speed);
+    effect_func(&hsv, offset);
+    RGB rgb = hsv_to_rgb(hsv);
+    rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
+  }
+  return led_max < DRIVER_LED_TOTAL;
+}
+
+#endif // RGB_MATRIX_KEYREACTIVE_ENABLED

--- a/quantum/rgb_matrix_runners/effect_runner_reactive_splash.h
+++ b/quantum/rgb_matrix_runners/effect_runner_reactive_splash.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#ifdef RGB_MATRIX_KEYREACTIVE_ENABLED
+
+typedef void (*reactive_splash_f)(HSV* hsv, int16_t dx, int16_t dy, uint8_t dist, uint16_t tick);
+
+bool effect_runner_reactive_splash(uint8_t start, effect_params_t* params, reactive_splash_f effect_func) {
+  RGB_MATRIX_USE_LIMITS(led_min, led_max);
+
+  HSV hsv = { 0, rgb_matrix_config.sat, 0 };
+  uint8_t count = g_last_hit_tracker.count;
+  for (uint8_t i = led_min; i < led_max; i++) {
+    RGB_MATRIX_TEST_LED_FLAGS();
+    hsv.h = rgb_matrix_config.hue;
+    hsv.v = 0;
+    for (uint8_t j = start; j < count; j++) {
+      int16_t dx = g_led_config.point[i].x - g_last_hit_tracker.x[j];
+      int16_t dy = g_led_config.point[i].y - g_last_hit_tracker.y[j];
+      uint8_t dist = sqrt16(dx * dx + dy * dy);
+      uint16_t tick = scale16by8(g_last_hit_tracker.tick[j], rgb_matrix_config.speed);
+      effect_func(&hsv, dx, dy, dist, tick);
+    }
+    hsv.v = scale8(hsv.v, rgb_matrix_config.val);
+    RGB rgb = hsv_to_rgb(hsv);
+    rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
+  }
+  return led_max < DRIVER_LED_TOTAL;
+}
+
+#endif // RGB_MATRIX_KEYREACTIVE_ENABLED

--- a/quantum/rgb_matrix_runners/effect_runner_sin_cos_i.h
+++ b/quantum/rgb_matrix_runners/effect_runner_sin_cos_i.h
@@ -1,0 +1,19 @@
+#pragma once
+
+typedef void (*sin_cos_i_f)(HSV* hsv, int8_t sin, int8_t cos, uint8_t i, uint8_t time);
+
+bool effect_runner_sin_cos_i(effect_params_t* params, sin_cos_i_f effect_func) {
+  RGB_MATRIX_USE_LIMITS(led_min, led_max);
+
+  HSV hsv = { rgb_matrix_config.hue, rgb_matrix_config.sat, rgb_matrix_config.val };
+  uint16_t time = scale16by8(g_rgb_counters.tick, rgb_matrix_config.speed / 4);
+  int8_t cos_value = cos8(time) - 128;
+  int8_t sin_value = sin8(time) - 128;
+  for (uint8_t i = led_min; i < led_max; i++) {
+    RGB_MATRIX_TEST_LED_FLAGS();
+    effect_func(&hsv, cos_value, sin_value, i, time);
+    RGB rgb = hsv_to_rgb(hsv);
+    rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
+  }
+  return led_max < DRIVER_LED_TOTAL;
+}


### PR DESCRIPTION
## Description

This reduces the firmware size of rgb matrix effects. With LTO enabled, the basic suite of effects were reduced by ~1000 bytes, and the reactive suite of effects were reduced by ~1400 bytes.

❗️ Either merge #5867, #5877, and #5886 first, and give me time to fix up merge conflicts, or just merge this pr as it wraps up those 3 prs and improves the firmware size.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
