### PR TITLE
Switching rgb_config_t to use the HSV struct

### DIFF
--- a/keyboards/dztech/dz60rgb/keymaps/matthewrobo/keymap.c
+++ b/keyboards/dztech/dz60rgb/keymaps/matthewrobo/keymap.c
@@ -146,7 +146,7 @@ void rgb_matrix_indicators_user(void)
 			break;
 
 		case _RGB: {
-			HSV hsv = { rgb_matrix_config.hue, rgb_matrix_config.sat, rgb_matrix_config.val };
+			HSV hsv = { rgb_matrix_config.hsv.h, rgb_matrix_config.hsv.s, rgb_matrix_config.hsv.v };
 			HSV hui = hsv;
 			HSV hud = hsv;
 			HSV sai = hsv;

--- a/keyboards/massdrop/ctrl/keymaps/matthewrobo/keymap.c
+++ b/keyboards/massdrop/ctrl/keymaps/matthewrobo/keymap.c
@@ -135,7 +135,7 @@ void rgb_matrix_indicators_user(void)
 			break;
 
 		case _FNC: {
-			HSV hsv = { rgb_matrix_config.hue, rgb_matrix_config.sat, rgb_matrix_config.val };
+			HSV hsv = { rgb_matrix_config.hsv.h, rgb_matrix_config.hsv.s, rgb_matrix_config.hsv.v };
 			HSV hui = hsv;
 			HSV hud = hsv;
 			HSV sai = hsv;

--- a/quantum/rgb_matrix.c
+++ b/quantum/rgb_matrix.c
@@ -128,9 +128,7 @@ void eeconfig_update_rgb_matrix_default(void) {
   dprintf("eeconfig_update_rgb_matrix_default\n");
   rgb_matrix_config.enable = 1;
   rgb_matrix_config.mode = RGB_MATRIX_STARTUP_MODE;
-  rgb_matrix_config.hue = 0;
-  rgb_matrix_config.sat = UINT8_MAX;
-  rgb_matrix_config.val = RGB_MATRIX_MAXIMUM_BRIGHTNESS;
+  rgb_matrix_config.hsv = (HSV){ 0,  UINT8_MAX, RGB_MATRIX_MAXIMUM_BRIGHTNESS };
   rgb_matrix_config.speed = UINT8_MAX / 2;
   eeconfig_update_rgb_matrix(rgb_matrix_config.raw);
 }
@@ -139,9 +137,9 @@ void eeconfig_debug_rgb_matrix(void) {
   dprintf("rgb_matrix_config eprom\n");
   dprintf("rgb_matrix_config.enable = %d\n", rgb_matrix_config.enable);
   dprintf("rgb_matrix_config.mode = %d\n", rgb_matrix_config.mode);
-  dprintf("rgb_matrix_config.hue = %d\n", rgb_matrix_config.hue);
-  dprintf("rgb_matrix_config.sat = %d\n", rgb_matrix_config.sat);
-  dprintf("rgb_matrix_config.val = %d\n", rgb_matrix_config.val);
+  dprintf("rgb_matrix_config.hsv.h = %d\n", rgb_matrix_config.hsv.h);
+  dprintf("rgb_matrix_config.hsv.s = %d\n", rgb_matrix_config.hsv.s);
+  dprintf("rgb_matrix_config.hsv.v = %d\n", rgb_matrix_config.hsv.v);
   dprintf("rgb_matrix_config.speed = %d\n", rgb_matrix_config.speed);
 }
 
@@ -492,34 +490,34 @@ void rgb_matrix_step_reverse(void) {
 }
 
 void rgb_matrix_increase_hue(void) {
-  rgb_matrix_config.hue += RGB_MATRIX_HUE_STEP;
+  rgb_matrix_config.hsv.h += RGB_MATRIX_HUE_STEP;
   eeconfig_update_rgb_matrix(rgb_matrix_config.raw);
 }
 
 void rgb_matrix_decrease_hue(void) {
-  rgb_matrix_config.hue -= RGB_MATRIX_HUE_STEP;
+  rgb_matrix_config.hsv.h -= RGB_MATRIX_HUE_STEP;
   eeconfig_update_rgb_matrix(rgb_matrix_config.raw);
 }
 
 void rgb_matrix_increase_sat(void) {
-  rgb_matrix_config.sat = qadd8(rgb_matrix_config.sat, RGB_MATRIX_SAT_STEP);
+  rgb_matrix_config.hsv.s = qadd8(rgb_matrix_config.hsv.s, RGB_MATRIX_SAT_STEP);
   eeconfig_update_rgb_matrix(rgb_matrix_config.raw);
 }
 
 void rgb_matrix_decrease_sat(void) {
-  rgb_matrix_config.sat = qsub8(rgb_matrix_config.sat, RGB_MATRIX_SAT_STEP);
+  rgb_matrix_config.hsv.s = qsub8(rgb_matrix_config.hsv.s, RGB_MATRIX_SAT_STEP);
   eeconfig_update_rgb_matrix(rgb_matrix_config.raw);
 }
 
 void rgb_matrix_increase_val(void) {
-  rgb_matrix_config.val = qadd8(rgb_matrix_config.val, RGB_MATRIX_VAL_STEP);
-  if (rgb_matrix_config.val > RGB_MATRIX_MAXIMUM_BRIGHTNESS)
-    rgb_matrix_config.val = RGB_MATRIX_MAXIMUM_BRIGHTNESS;
+  rgb_matrix_config.hsv.v = qadd8(rgb_matrix_config.hsv.v, RGB_MATRIX_VAL_STEP);
+  if (rgb_matrix_config.hsv.v > RGB_MATRIX_MAXIMUM_BRIGHTNESS)
+    rgb_matrix_config.hsv.v = RGB_MATRIX_MAXIMUM_BRIGHTNESS;
   eeconfig_update_rgb_matrix(rgb_matrix_config.raw);
 }
 
 void rgb_matrix_decrease_val(void) {
-  rgb_matrix_config.val = qsub8(rgb_matrix_config.val, RGB_MATRIX_VAL_STEP);
+  rgb_matrix_config.hsv.v = qsub8(rgb_matrix_config.hsv.v, RGB_MATRIX_VAL_STEP);
   eeconfig_update_rgb_matrix(rgb_matrix_config.raw);
 }
 
@@ -561,9 +559,9 @@ void rgb_matrix_sethsv(uint16_t hue, uint8_t sat, uint8_t val) {
 }
 
 void rgb_matrix_sethsv_noeeprom(uint16_t hue, uint8_t sat, uint8_t val) {
-  rgb_matrix_config.hue = hue;
-  rgb_matrix_config.sat = sat;
-  rgb_matrix_config.val = val;
-  if (rgb_matrix_config.val > RGB_MATRIX_MAXIMUM_BRIGHTNESS)
-    rgb_matrix_config.val = RGB_MATRIX_MAXIMUM_BRIGHTNESS;
+  rgb_matrix_config.hsv.h = hue;
+  rgb_matrix_config.hsv.s = sat;
+  rgb_matrix_config.hsv.v = val;
+  if (rgb_matrix_config.hsv.v > RGB_MATRIX_MAXIMUM_BRIGHTNESS)
+    rgb_matrix_config.hsv.v = RGB_MATRIX_MAXIMUM_BRIGHTNESS;
 }

--- a/quantum/rgb_matrix_animations/alpha_mods_anim.h
+++ b/quantum/rgb_matrix_animations/alpha_mods_anim.h
@@ -6,7 +6,7 @@ RGB_MATRIX_EFFECT(ALPHAS_MODS)
 bool ALPHAS_MODS(effect_params_t* params) {
   RGB_MATRIX_USE_LIMITS(led_min, led_max);
 
-  HSV hsv = { rgb_matrix_config.hue, rgb_matrix_config.sat, rgb_matrix_config.val };
+  HSV hsv = rgb_matrix_config.hsv;
   RGB rgb1 = hsv_to_rgb(hsv);
   hsv.h += rgb_matrix_config.speed;
   RGB rgb2 = hsv_to_rgb(hsv);

--- a/quantum/rgb_matrix_animations/breathing_anim.h
+++ b/quantum/rgb_matrix_animations/breathing_anim.h
@@ -5,9 +5,9 @@ RGB_MATRIX_EFFECT(BREATHING)
 bool BREATHING(effect_params_t* params) {
   RGB_MATRIX_USE_LIMITS(led_min, led_max);
 
+  HSV hsv = rgb_matrix_config.hsv;
   uint16_t time = scale16by8(g_rgb_counters.tick, rgb_matrix_config.speed / 8);
-  uint8_t val = scale8(abs8(sin8(time) - 128) * 2, rgb_matrix_config.val);
-  HSV hsv = { rgb_matrix_config.hue, rgb_matrix_config.sat, val };
+  hsv.v = scale8(abs8(sin8(time) - 128) * 2, hsv.v);
   RGB rgb = hsv_to_rgb(hsv);
   for (uint8_t i = led_min; i < led_max; i++) {
     RGB_MATRIX_TEST_LED_FLAGS();

--- a/quantum/rgb_matrix_animations/colorband_pinwheel_sat_anim.h
+++ b/quantum/rgb_matrix_animations/colorband_pinwheel_sat_anim.h
@@ -2,8 +2,9 @@
 RGB_MATRIX_EFFECT(BAND_PINWHEEL_SAT)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static void BAND_PINWHEEL_SAT_math(HSV* hsv, int16_t dx, int16_t dy, uint8_t time) {
-    hsv->s = scale8(rgb_matrix_config.sat - time - atan2_8(dy, dx) * 3, rgb_matrix_config.sat);
+static HSV BAND_PINWHEEL_SAT_math(HSV hsv, int16_t dx, int16_t dy, uint8_t time) {
+    hsv.s = scale8(hsv.s - time - atan2_8(dy, dx) * 3, hsv.s);
+    return hsv;
 }
 
 bool BAND_PINWHEEL_SAT(effect_params_t* params) {

--- a/quantum/rgb_matrix_animations/colorband_pinwheel_val_anim.h
+++ b/quantum/rgb_matrix_animations/colorband_pinwheel_val_anim.h
@@ -2,8 +2,9 @@
 RGB_MATRIX_EFFECT(BAND_PINWHEEL_VAL)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static void BAND_PINWHEEL_VAL_math(HSV* hsv, int16_t dx, int16_t dy, uint8_t time) {
-    hsv->v = scale8(rgb_matrix_config.val - time - atan2_8(dy, dx) * 3, rgb_matrix_config.val);
+static HSV BAND_PINWHEEL_VAL_math(HSV hsv, int16_t dx, int16_t dy, uint8_t time) {
+    hsv.v = scale8(hsv.v - time - atan2_8(dy, dx) * 3, hsv.v);
+    return hsv;
 }
 
 bool BAND_PINWHEEL_VAL(effect_params_t* params) {

--- a/quantum/rgb_matrix_animations/colorband_sat_anim.h
+++ b/quantum/rgb_matrix_animations/colorband_sat_anim.h
@@ -2,9 +2,10 @@
 RGB_MATRIX_EFFECT(BAND_SAT)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static void BAND_SAT_math(HSV* hsv, uint8_t i, uint8_t time) {
-    int16_t s = rgb_matrix_config.sat - abs(scale8(g_led_config.point[i].x, 228) + 28 - time) * 8;
-    hsv->s = scale8(s < 0 ? 0 : s, rgb_matrix_config.sat);
+static HSV BAND_SAT_math(HSV hsv, uint8_t i, uint8_t time) {
+    int16_t s = hsv.s - abs(scale8(g_led_config.point[i].x, 228) + 28 - time) * 8;
+    hsv.s = scale8(s < 0 ? 0 : s, hsv.s);
+    return hsv;
 }
 
 bool BAND_SAT(effect_params_t* params) {

--- a/quantum/rgb_matrix_animations/colorband_spiral_sat_anim.h
+++ b/quantum/rgb_matrix_animations/colorband_spiral_sat_anim.h
@@ -2,8 +2,9 @@
 RGB_MATRIX_EFFECT(BAND_SPIRAL_SAT)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static void BAND_SPIRAL_SAT_math(HSV* hsv, int16_t dx, int16_t dy, uint8_t dist, uint8_t time) {
-    hsv->s = scale8(rgb_matrix_config.sat + dist - time - atan2_8(dy, dx), rgb_matrix_config.sat);
+static HSV BAND_SPIRAL_SAT_math(HSV hsv, int16_t dx, int16_t dy, uint8_t dist, uint8_t time) {
+    hsv.s = scale8(hsv.s + dist - time - atan2_8(dy, dx), hsv.s);
+    return hsv;
 }
 
 bool BAND_SPIRAL_SAT(effect_params_t* params) {

--- a/quantum/rgb_matrix_animations/colorband_spiral_val_anim.h
+++ b/quantum/rgb_matrix_animations/colorband_spiral_val_anim.h
@@ -2,8 +2,9 @@
 RGB_MATRIX_EFFECT(BAND_SPIRAL_VAL)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static void BAND_SPIRAL_VAL_math(HSV* hsv, int16_t dx, int16_t dy, uint8_t dist, uint8_t time) {
-    hsv->v = scale8(rgb_matrix_config.val + dist - time - atan2_8(dy, dx), rgb_matrix_config.val);
+static HSV BAND_SPIRAL_VAL_math(HSV hsv, int16_t dx, int16_t dy, uint8_t dist, uint8_t time) {
+    hsv.v = scale8(hsv.v + dist - time - atan2_8(dy, dx), hsv.v);
+    return hsv;
 }
 
 bool BAND_SPIRAL_VAL(effect_params_t* params) {

--- a/quantum/rgb_matrix_animations/colorband_val_anim.h
+++ b/quantum/rgb_matrix_animations/colorband_val_anim.h
@@ -2,9 +2,10 @@
 RGB_MATRIX_EFFECT(BAND_VAL)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static void BAND_VAL_math(HSV* hsv, uint8_t i, uint8_t time) {
-    int16_t v = rgb_matrix_config.val - abs(scale8(g_led_config.point[i].x, 228) + 28 - time) * 8;
-    hsv->v = scale8(v < 0 ? 0 : v, rgb_matrix_config.val);
+static HSV BAND_VAL_math(HSV hsv, uint8_t i, uint8_t time) {
+    int16_t v = hsv.v - abs(scale8(g_led_config.point[i].x, 228) + 28 - time) * 8;
+    hsv.v = scale8(v < 0 ? 0 : v, hsv.v);
+    return hsv;
 }
 
 bool BAND_VAL(effect_params_t* params) {

--- a/quantum/rgb_matrix_animations/cycle_all_anim.h
+++ b/quantum/rgb_matrix_animations/cycle_all_anim.h
@@ -2,9 +2,9 @@
 RGB_MATRIX_EFFECT(CYCLE_ALL)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static void CYCLE_ALL_math(HSV* hsv, uint8_t i, uint8_t time)
-{
-    hsv->h = time;
+static HSV CYCLE_ALL_math(HSV hsv,  uint8_t i, uint8_t time){
+    hsv.h = time;
+    return hsv;
 }
 
 bool CYCLE_ALL(effect_params_t* params) {

--- a/quantum/rgb_matrix_animations/cycle_left_right_anim.h
+++ b/quantum/rgb_matrix_animations/cycle_left_right_anim.h
@@ -2,8 +2,9 @@
 RGB_MATRIX_EFFECT(CYCLE_LEFT_RIGHT)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static void CYCLE_LEFT_RIGHT_math(HSV* hsv, uint8_t i, uint8_t time) {
-    hsv->h = g_led_config.point[i].x - time;
+static HSV CYCLE_LEFT_RIGHT_math(HSV hsv,  uint8_t i, uint8_t time) {
+    hsv.h = g_led_config.point[i].x - time;
+    return hsv;
 }
 
 bool CYCLE_LEFT_RIGHT(effect_params_t* params) {

--- a/quantum/rgb_matrix_animations/cycle_out_in_anim.h
+++ b/quantum/rgb_matrix_animations/cycle_out_in_anim.h
@@ -2,8 +2,9 @@
 RGB_MATRIX_EFFECT(CYCLE_OUT_IN)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static void CYCLE_OUT_IN_math(HSV* hsv, int16_t dx, int16_t dy, uint8_t dist, uint8_t time) {
-    hsv->h = 3 * dist / 2 + time;
+static HSV CYCLE_OUT_IN_math(HSV hsv,  int16_t dx, int16_t dy, uint8_t dist, uint8_t time) {
+    hsv.h = 3 * dist / 2 + time;
+    return hsv;
 }
 
 bool CYCLE_OUT_IN(effect_params_t* params) {

--- a/quantum/rgb_matrix_animations/cycle_out_in_dual_anim.h
+++ b/quantum/rgb_matrix_animations/cycle_out_in_dual_anim.h
@@ -2,10 +2,11 @@
 RGB_MATRIX_EFFECT(CYCLE_OUT_IN_DUAL)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static void CYCLE_OUT_IN_DUAL_math(HSV* hsv, int16_t dx, int16_t dy, uint8_t time) {
+static HSV CYCLE_OUT_IN_DUAL_math(HSV hsv,  int16_t dx, int16_t dy, uint8_t time) {
     dx = (k_rgb_matrix_center.x / 2) - abs8(dx);
     uint8_t dist = sqrt16(dx * dx + dy * dy);
-    hsv->h = 3 * dist + time;
+    hsv.h = 3 * dist + time;
+    return hsv;
 }
 
 bool CYCLE_OUT_IN_DUAL(effect_params_t* params) {

--- a/quantum/rgb_matrix_animations/cycle_pinwheel_anim.h
+++ b/quantum/rgb_matrix_animations/cycle_pinwheel_anim.h
@@ -2,8 +2,9 @@
 RGB_MATRIX_EFFECT(CYCLE_PINWHEEL)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static void CYCLE_PINWHEEL_math(HSV* hsv, int16_t dx, int16_t dy, uint8_t time) {
-    hsv->h = atan2_8(dy, dx) + time;
+static HSV CYCLE_PINWHEEL_math(HSV hsv,  int16_t dx, int16_t dy, uint8_t time) {
+    hsv.h = atan2_8(dy, dx) + time;
+    return hsv;
 }
 
 bool CYCLE_PINWHEEL(effect_params_t* params) {

--- a/quantum/rgb_matrix_animations/cycle_spiral_anim.h
+++ b/quantum/rgb_matrix_animations/cycle_spiral_anim.h
@@ -2,8 +2,9 @@
 RGB_MATRIX_EFFECT(CYCLE_SPIRAL)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static void CYCLE_SPIRAL_math(HSV* hsv, int16_t dx, int16_t dy, uint8_t dist, uint8_t time) {
-    hsv->h = dist - time - atan2_8(dy, dx);
+static HSV CYCLE_SPIRAL_math(HSV hsv,  int16_t dx, int16_t dy, uint8_t dist, uint8_t time) {
+    hsv.h = dist - time - atan2_8(dy, dx);
+    return hsv;
 }
 
 bool CYCLE_SPIRAL(effect_params_t* params) {

--- a/quantum/rgb_matrix_animations/cycle_up_down_anim.h
+++ b/quantum/rgb_matrix_animations/cycle_up_down_anim.h
@@ -2,8 +2,9 @@
 RGB_MATRIX_EFFECT(CYCLE_UP_DOWN)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static void CYCLE_UP_DOWN_math(HSV* hsv, uint8_t i, uint8_t time) {
-    hsv->h = g_led_config.point[i].y - time;
+static HSV CYCLE_UP_DOWN_math(HSV hsv,  uint8_t i, uint8_t time) {
+    hsv.h = g_led_config.point[i].y - time;
+    return hsv;
 }
 
 bool CYCLE_UP_DOWN(effect_params_t* params) {

--- a/quantum/rgb_matrix_animations/dual_beacon_anim.h
+++ b/quantum/rgb_matrix_animations/dual_beacon_anim.h
@@ -2,8 +2,9 @@
 RGB_MATRIX_EFFECT(DUAL_BEACON)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static void DUAL_BEACON_math(HSV* hsv, int8_t sin, int8_t cos, uint8_t i, uint8_t time) {
-    hsv->h = ((g_led_config.point[i].y - k_rgb_matrix_center.y) * cos + (g_led_config.point[i].x - k_rgb_matrix_center.x) * sin) / 128 + rgb_matrix_config.hue;
+static HSV DUAL_BEACON_math(HSV hsv,  int8_t sin, int8_t cos, uint8_t i, uint8_t time) {
+    hsv.h += ((g_led_config.point[i].y - k_rgb_matrix_center.y) * cos + (g_led_config.point[i].x - k_rgb_matrix_center.x) * sin) / 128;
+    return hsv;
 }
 
 bool DUAL_BEACON(effect_params_t* params) {

--- a/quantum/rgb_matrix_animations/gradient_up_down_anim.h
+++ b/quantum/rgb_matrix_animations/gradient_up_down_anim.h
@@ -5,13 +5,13 @@ RGB_MATRIX_EFFECT(GRADIENT_UP_DOWN)
 bool GRADIENT_UP_DOWN(effect_params_t* params) {
   RGB_MATRIX_USE_LIMITS(led_min, led_max);
 
-  HSV hsv = { 0, rgb_matrix_config.sat, rgb_matrix_config.val };
+  HSV hsv = rgb_matrix_config.hsv;
   uint8_t scale = scale8(64, rgb_matrix_config.speed);
   for (uint8_t i = led_min; i < led_max; i++) {
     RGB_MATRIX_TEST_LED_FLAGS();
     // The y range will be 0..64, map this to 0..4
     // Relies on hue being 8-bit and wrapping
-    hsv.h = rgb_matrix_config.hue + scale * (g_led_config.point[i].y >> 4);
+    hsv.h = rgb_matrix_config.hsv.h + scale * (g_led_config.point[i].y >> 4);
     RGB rgb = hsv_to_rgb(hsv);
     rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
   }

--- a/quantum/rgb_matrix_animations/jellybean_raindrops_anim.h
+++ b/quantum/rgb_matrix_animations/jellybean_raindrops_anim.h
@@ -4,7 +4,7 @@ RGB_MATRIX_EFFECT(JELLYBEAN_RAINDROPS)
 
 static void jellybean_raindrops_set_color(int i, effect_params_t* params) {
   if (!HAS_ANY_FLAGS(g_led_config.flags[i], params->flags)) return;
-  HSV hsv = { rand() & 0xFF , rand() & 0xFF, rgb_matrix_config.val };
+  HSV hsv = { rand() & 0xFF , rand() & 0xFF, rgb_matrix_config.hsv.v };
   RGB rgb = hsv_to_rgb(hsv);
   rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
 }

--- a/quantum/rgb_matrix_animations/rainbow_beacon_anim.h
+++ b/quantum/rgb_matrix_animations/rainbow_beacon_anim.h
@@ -2,8 +2,9 @@
 RGB_MATRIX_EFFECT(RAINBOW_BEACON)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static void RAINBOW_BEACON_math(HSV* hsv, int8_t sin, int8_t cos, uint8_t i, uint8_t time) {
-    hsv->h = ((g_led_config.point[i].y - k_rgb_matrix_center.y) * 2 * cos + (g_led_config.point[i].x - k_rgb_matrix_center.x) * 2 * sin) / 128 + rgb_matrix_config.hue;
+static HSV RAINBOW_BEACON_math(HSV hsv,  int8_t sin, int8_t cos, uint8_t i, uint8_t time) {
+    hsv.h += ((g_led_config.point[i].y - k_rgb_matrix_center.y) * 2 * cos + (g_led_config.point[i].x - k_rgb_matrix_center.x) * 2 * sin) / 128;
+    return hsv;
 }
 
 bool RAINBOW_BEACON(effect_params_t* params) {

--- a/quantum/rgb_matrix_animations/rainbow_moving_chevron_anim.h
+++ b/quantum/rgb_matrix_animations/rainbow_moving_chevron_anim.h
@@ -2,8 +2,9 @@
 RGB_MATRIX_EFFECT(RAINBOW_MOVING_CHEVRON)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static void RAINBOW_MOVING_CHEVRON_math(HSV* hsv, uint8_t i, uint8_t time) {
-    hsv->h = abs8(g_led_config.point[i].y - k_rgb_matrix_center.y) + (g_led_config.point[i].x - time) + rgb_matrix_config.hue;
+static HSV RAINBOW_MOVING_CHEVRON_math(HSV hsv,  uint8_t i, uint8_t time) {
+    hsv.h += abs8(g_led_config.point[i].y - k_rgb_matrix_center.y) + (g_led_config.point[i].x - time);
+    return hsv;
 }
 
 bool RAINBOW_MOVING_CHEVRON(effect_params_t* params) {

--- a/quantum/rgb_matrix_animations/rainbow_pinwheels_anim.h
+++ b/quantum/rgb_matrix_animations/rainbow_pinwheels_anim.h
@@ -2,8 +2,9 @@
 RGB_MATRIX_EFFECT(PINWHEELS)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static void PINWHEELS_math(HSV* hsv, int8_t sin, int8_t cos, uint8_t i, uint8_t time) {
-    hsv->h = ((g_led_config.point[i].y - k_rgb_matrix_center.y) * 3 * cos + (56 - abs8(g_led_config.point[i].x - k_rgb_matrix_center.x)) * 3 * sin) / 128 + rgb_matrix_config.hue;
+static HSV PINWHEELS_math(HSV hsv,  int8_t sin, int8_t cos, uint8_t i, uint8_t time) {
+    hsv.h += ((g_led_config.point[i].y - k_rgb_matrix_center.y) * 3 * cos + (56 - abs8(g_led_config.point[i].x - k_rgb_matrix_center.x)) * 3 * sin) / 128;
+    return hsv;
 }
 
 bool PINWHEELS(effect_params_t* params) {

--- a/quantum/rgb_matrix_animations/raindrops_anim.h
+++ b/quantum/rgb_matrix_animations/raindrops_anim.h
@@ -4,17 +4,17 @@ RGB_MATRIX_EFFECT(RAINDROPS)
 
 static void raindrops_set_color(int i, effect_params_t* params) {
   if (!HAS_ANY_FLAGS(g_led_config.flags[i], params->flags)) return;
-  HSV hsv = { 0 , rgb_matrix_config.sat, rgb_matrix_config.val };
+  HSV hsv = { 0 , rgb_matrix_config.hsv.s, rgb_matrix_config.hsv.v };
 
   // Take the shortest path between hues
-  int16_t deltaH = ((rgb_matrix_config.hue + 180) % 360 - rgb_matrix_config.hue) / 4;
+  int16_t deltaH = ((rgb_matrix_config.hsv.h + 180) % 360 - rgb_matrix_config.hsv.h) / 4;
   if (deltaH > 127) {
     deltaH -= 256;
   } else if (deltaH < -127) {
     deltaH += 256;
   }
 
-  hsv.h = rgb_matrix_config.hue + (deltaH * (rand() & 0x03));
+  hsv.h = rgb_matrix_config.hsv.h + (deltaH * (rand() & 0x03));
   RGB rgb = hsv_to_rgb(hsv);
   rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
 }

--- a/quantum/rgb_matrix_animations/solid_color_anim.h
+++ b/quantum/rgb_matrix_animations/solid_color_anim.h
@@ -4,8 +4,7 @@ RGB_MATRIX_EFFECT(SOLID_COLOR)
 bool SOLID_COLOR(effect_params_t* params) {
   RGB_MATRIX_USE_LIMITS(led_min, led_max);
 
-  HSV hsv = { rgb_matrix_config.hue, rgb_matrix_config.sat, rgb_matrix_config.val };
-  RGB rgb = hsv_to_rgb(hsv);
+  RGB rgb = hsv_to_rgb(rgb_matrix_config.hsv);
   for (uint8_t i = led_min; i < led_max; i++) {
     RGB_MATRIX_TEST_LED_FLAGS();
     rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);

--- a/quantum/rgb_matrix_animations/solid_reactive_anim.h
+++ b/quantum/rgb_matrix_animations/solid_reactive_anim.h
@@ -3,8 +3,9 @@
 RGB_MATRIX_EFFECT(SOLID_REACTIVE)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static void SOLID_REACTIVE_math(HSV* hsv, uint16_t offset) {
-    hsv->h = rgb_matrix_config.hue + qsub8(130, offset);
+static HSV SOLID_REACTIVE_math(HSV hsv,  uint16_t offset) {
+    hsv.h += qsub8(130, offset);
+    return hsv;
 }
 
 bool SOLID_REACTIVE(effect_params_t* params) {

--- a/quantum/rgb_matrix_animations/solid_reactive_cross.h
+++ b/quantum/rgb_matrix_animations/solid_reactive_cross.h
@@ -11,7 +11,7 @@ RGB_MATRIX_EFFECT(SOLID_REACTIVE_MULTICROSS)
 
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static void SOLID_REACTIVE_CROSS_math(HSV* hsv, int16_t dx, int16_t dy, uint8_t dist, uint16_t tick) {
+static HSV SOLID_REACTIVE_CROSS_math(HSV hsv,  int16_t dx, int16_t dy, uint8_t dist, uint16_t tick) {
     uint16_t effect = tick + dist;
     dx = dx < 0 ? dx * -1 : dx;
     dy = dy < 0 ? dy * -1 : dy;
@@ -20,7 +20,8 @@ static void SOLID_REACTIVE_CROSS_math(HSV* hsv, int16_t dx, int16_t dy, uint8_t 
     effect += dx > dy ? dy : dx;
     if (effect > 255)
         effect = 255;
-    hsv->v = qadd8(hsv->v, 255 - effect);
+    hsv.v = qadd8(hsv.v, 255 - effect);
+    return hsv;
 }
 
 #ifndef DISABLE_RGB_MATRIX_SOLID_REACTIVE_CROSS

--- a/quantum/rgb_matrix_animations/solid_reactive_nexus.h
+++ b/quantum/rgb_matrix_animations/solid_reactive_nexus.h
@@ -11,7 +11,7 @@ RGB_MATRIX_EFFECT(SOLID_REACTIVE_MULTINEXUS)
 
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static void SOLID_REACTIVE_NEXUS_math(HSV* hsv, int16_t dx, int16_t dy, uint8_t dist, uint16_t tick) {
+static HSV SOLID_REACTIVE_NEXUS_math(HSV hsv,  int16_t dx, int16_t dy, uint8_t dist, uint16_t tick) {
     uint16_t effect = tick - dist;
     if (effect > 255)
         effect = 255;
@@ -19,8 +19,9 @@ static void SOLID_REACTIVE_NEXUS_math(HSV* hsv, int16_t dx, int16_t dy, uint8_t 
         effect = 255;
     if ((dx > 8 || dx < -8) && (dy > 8 || dy < -8))
         effect = 255;
-    hsv->v = qadd8(hsv->v, 255 - effect);
-    hsv->h = rgb_matrix_config.hue + dy / 4;
+    hsv.v = qadd8(hsv.v, 255 - effect);
+    hsv.h = rgb_matrix_config.hsv.h + dy / 4;
+    return hsv;
 }
 
 #ifndef DISABLE_RGB_MATRIX_SOLID_REACTIVE_NEXUS

--- a/quantum/rgb_matrix_animations/solid_reactive_simple_anim.h
+++ b/quantum/rgb_matrix_animations/solid_reactive_simple_anim.h
@@ -3,8 +3,9 @@
 RGB_MATRIX_EFFECT(SOLID_REACTIVE_SIMPLE)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static void SOLID_REACTIVE_SIMPLE_math(HSV* hsv, uint16_t offset) {
-    hsv->v = scale8(255 - offset, rgb_matrix_config.val);
+static HSV SOLID_REACTIVE_SIMPLE_math(HSV hsv,  uint16_t offset) {
+    hsv.v = scale8(255 - offset, hsv.v);
+    return hsv;
 }
 
 bool SOLID_REACTIVE_SIMPLE(effect_params_t* params) {

--- a/quantum/rgb_matrix_animations/solid_reactive_wide.h
+++ b/quantum/rgb_matrix_animations/solid_reactive_wide.h
@@ -11,11 +11,12 @@ RGB_MATRIX_EFFECT(SOLID_REACTIVE_MULTIWIDE)
 
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static void SOLID_REACTIVE_WIDE_math(HSV* hsv, int16_t dx, int16_t dy, uint8_t dist, uint16_t tick) {
+static HSV SOLID_REACTIVE_WIDE_math(HSV hsv,  int16_t dx, int16_t dy, uint8_t dist, uint16_t tick) {
     uint16_t effect = tick + dist * 5;
     if (effect > 255)
         effect = 255;
-    hsv->v = qadd8(hsv->v, 255 - effect);
+    hsv.v = qadd8(hsv.v, 255 - effect);
+    return hsv;
 }
 
 #ifndef DISABLE_RGB_MATRIX_SOLID_REACTIVE_WIDE

--- a/quantum/rgb_matrix_animations/solid_splash_anim.h
+++ b/quantum/rgb_matrix_animations/solid_splash_anim.h
@@ -11,11 +11,12 @@ RGB_MATRIX_EFFECT(SOLID_MULTISPLASH)
 
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-void SOLID_SPLASH_math(HSV* hsv, int16_t dx, int16_t dy, uint8_t dist, uint16_t tick) {
+HSV SOLID_SPLASH_math(HSV hsv,  int16_t dx, int16_t dy, uint8_t dist, uint16_t tick) {
     uint16_t effect = tick - dist;
     if (effect > 255)
         effect = 255;
-    hsv->v = qadd8(hsv->v, 255 - effect);
+    hsv.v = qadd8(hsv.v, 255 - effect);
+    return hsv;
 }
 
 #ifndef DISABLE_RGB_MATRIX_SOLID_SPLASH

--- a/quantum/rgb_matrix_animations/splash_anim.h
+++ b/quantum/rgb_matrix_animations/splash_anim.h
@@ -11,12 +11,13 @@ RGB_MATRIX_EFFECT(MULTISPLASH)
 
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-void SPLASH_math(HSV* hsv, int16_t dx, int16_t dy, uint8_t dist, uint16_t tick) {
+HSV SPLASH_math(HSV hsv,  int16_t dx, int16_t dy, uint8_t dist, uint16_t tick) {
     uint16_t effect = tick - dist;
-      if (effect > 255)
+    if (effect > 255)
         effect = 255;
-      hsv->h += effect;
-      hsv->v = qadd8(hsv->v, 255 - effect);
+    hsv.h += effect;
+    hsv.v = qadd8(hsv.v, 255 - effect);
+    return hsv;
 }
 
 #ifndef DISABLE_RGB_MATRIX_SPLASH

--- a/quantum/rgb_matrix_animations/typing_heatmap_anim.h
+++ b/quantum/rgb_matrix_animations/typing_heatmap_anim.h
@@ -59,7 +59,7 @@ bool TYPING_HEATMAP(effect_params_t* params) {
       if (!HAS_ANY_FLAGS(g_led_config.flags[led[j]], params->flags))
         continue;
 
-      HSV hsv = { 170 - qsub8(val, 85), rgb_matrix_config.sat, scale8((qadd8(170, val) - 170) * 3, rgb_matrix_config.val) };
+      HSV hsv = { 170 - qsub8(val, 85), rgb_matrix_config.hsv.s, scale8((qadd8(170, val) - 170) * 3, rgb_matrix_config.hsv.v) };
       RGB rgb = hsv_to_rgb(hsv);
       rgb_matrix_set_color(led[j], rgb.r, rgb.g, rgb.b);
     }

--- a/quantum/rgb_matrix_runners/effect_runner_dx_dy.h
+++ b/quantum/rgb_matrix_runners/effect_runner_dx_dy.h
@@ -1,18 +1,16 @@
 #pragma once
 
-typedef void (*dx_dy_f)(HSV* hsv, int16_t dx, int16_t dy, uint8_t time);
+typedef HSV (*dx_dy_f)(HSV hsv, int16_t dx, int16_t dy, uint8_t time);
 
 bool effect_runner_dx_dy(effect_params_t* params, dx_dy_f effect_func) {
   RGB_MATRIX_USE_LIMITS(led_min, led_max);
 
-  HSV hsv = { rgb_matrix_config.hue, rgb_matrix_config.sat, rgb_matrix_config.val };
   uint8_t time = scale16by8(g_rgb_counters.tick, rgb_matrix_config.speed / 2);
   for (uint8_t i = led_min; i < led_max; i++) {
     RGB_MATRIX_TEST_LED_FLAGS();
     int16_t dx = g_led_config.point[i].x - k_rgb_matrix_center.x;
     int16_t dy = g_led_config.point[i].y - k_rgb_matrix_center.y;
-    effect_func(&hsv, dx, dy, time);
-    RGB rgb = hsv_to_rgb(hsv);
+    RGB rgb = hsv_to_rgb(effect_func(rgb_matrix_config.hsv, dx, dy, time));
     rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
   }
   return led_max < DRIVER_LED_TOTAL;

--- a/quantum/rgb_matrix_runners/effect_runner_dx_dy_dist.h
+++ b/quantum/rgb_matrix_runners/effect_runner_dx_dy_dist.h
@@ -1,19 +1,17 @@
 #pragma once
 
-typedef void (*dx_dy_dist_f)(HSV* hsv, int16_t dx, int16_t dy, uint8_t dist, uint8_t time);
+typedef HSV (*dx_dy_dist_f)(HSV hsv, int16_t dx, int16_t dy, uint8_t dist, uint8_t time);
 
 bool effect_runner_dx_dy_dist(effect_params_t* params, dx_dy_dist_f effect_func) {
   RGB_MATRIX_USE_LIMITS(led_min, led_max);
 
-  HSV hsv = { rgb_matrix_config.hue, rgb_matrix_config.sat, rgb_matrix_config.val };
   uint8_t time = scale16by8(g_rgb_counters.tick, rgb_matrix_config.speed / 2);
   for (uint8_t i = led_min; i < led_max; i++) {
     RGB_MATRIX_TEST_LED_FLAGS();
     int16_t dx = g_led_config.point[i].x - k_rgb_matrix_center.x;
     int16_t dy = g_led_config.point[i].y - k_rgb_matrix_center.y;
     uint8_t dist = sqrt16(dx * dx + dy * dy);
-    effect_func(&hsv, dx, dy, dist, time);
-    RGB rgb = hsv_to_rgb(hsv);
+    RGB rgb = hsv_to_rgb(effect_func(rgb_matrix_config.hsv, dx, dy, dist, time));
     rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
   }
   return led_max < DRIVER_LED_TOTAL;

--- a/quantum/rgb_matrix_runners/effect_runner_i.h
+++ b/quantum/rgb_matrix_runners/effect_runner_i.h
@@ -1,16 +1,14 @@
 #pragma once
 
-typedef void (*i_f)(HSV* hsv, uint8_t i, uint8_t time);
+typedef HSV (*i_f)(HSV hsv, uint8_t i, uint8_t time);
 
 bool effect_runner_i(effect_params_t* params, i_f effect_func) {
   RGB_MATRIX_USE_LIMITS(led_min, led_max);
 
-  HSV hsv = { rgb_matrix_config.hue, rgb_matrix_config.sat, rgb_matrix_config.val };
   uint8_t time = scale16by8(g_rgb_counters.tick, rgb_matrix_config.speed / 4);
   for (uint8_t i = led_min; i < led_max; i++) {
     RGB_MATRIX_TEST_LED_FLAGS();
-    effect_func(&hsv, i, time);
-    RGB rgb = hsv_to_rgb(hsv);
+    RGB rgb = hsv_to_rgb(effect_func(rgb_matrix_config.hsv, i, time));
     rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
   }
   return led_max < DRIVER_LED_TOTAL;

--- a/quantum/rgb_matrix_runners/effect_runner_reactive.h
+++ b/quantum/rgb_matrix_runners/effect_runner_reactive.h
@@ -2,12 +2,11 @@
 
 #ifdef RGB_MATRIX_KEYREACTIVE_ENABLED
 
-typedef void (*reactive_f)(HSV* hsv, uint16_t offset);
+typedef HSV (*reactive_f)(HSV hsv, uint16_t offset);
 
 bool effect_runner_reactive(effect_params_t* params, reactive_f effect_func) {
     RGB_MATRIX_USE_LIMITS(led_min, led_max);
 
-  HSV hsv = { rgb_matrix_config.hue, rgb_matrix_config.sat, rgb_matrix_config.val };
   uint16_t max_tick = 65535 / rgb_matrix_config.speed;
   for (uint8_t i = led_min; i < led_max; i++) {
     RGB_MATRIX_TEST_LED_FLAGS();
@@ -21,8 +20,7 @@ bool effect_runner_reactive(effect_params_t* params, reactive_f effect_func) {
     }
 
     uint16_t  offset = scale16by8(tick, rgb_matrix_config.speed);
-    effect_func(&hsv, offset);
-    RGB rgb = hsv_to_rgb(hsv);
+    RGB rgb = hsv_to_rgb(effect_func(rgb_matrix_config.hsv, offset));
     rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
   }
   return led_max < DRIVER_LED_TOTAL;

--- a/quantum/rgb_matrix_runners/effect_runner_reactive_splash.h
+++ b/quantum/rgb_matrix_runners/effect_runner_reactive_splash.h
@@ -2,25 +2,24 @@
 
 #ifdef RGB_MATRIX_KEYREACTIVE_ENABLED
 
-typedef void (*reactive_splash_f)(HSV* hsv, int16_t dx, int16_t dy, uint8_t dist, uint16_t tick);
+typedef HSV (*reactive_splash_f)(HSV hsv, int16_t dx, int16_t dy, uint8_t dist, uint16_t tick);
 
 bool effect_runner_reactive_splash(uint8_t start, effect_params_t* params, reactive_splash_f effect_func) {
   RGB_MATRIX_USE_LIMITS(led_min, led_max);
 
-  HSV hsv = { 0, rgb_matrix_config.sat, 0 };
   uint8_t count = g_last_hit_tracker.count;
   for (uint8_t i = led_min; i < led_max; i++) {
     RGB_MATRIX_TEST_LED_FLAGS();
-    hsv.h = rgb_matrix_config.hue;
+    HSV hsv = rgb_matrix_config.hsv;
     hsv.v = 0;
     for (uint8_t j = start; j < count; j++) {
       int16_t dx = g_led_config.point[i].x - g_last_hit_tracker.x[j];
       int16_t dy = g_led_config.point[i].y - g_last_hit_tracker.y[j];
       uint8_t dist = sqrt16(dx * dx + dy * dy);
       uint16_t tick = scale16by8(g_last_hit_tracker.tick[j], rgb_matrix_config.speed);
-      effect_func(&hsv, dx, dy, dist, tick);
+      hsv = effect_func(hsv, dx, dy, dist, tick);
     }
-    hsv.v = scale8(hsv.v, rgb_matrix_config.val);
+    hsv.v = scale8(hsv.v, rgb_matrix_config.hsv.v);
     RGB rgb = hsv_to_rgb(hsv);
     rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
   }

--- a/quantum/rgb_matrix_runners/effect_runner_sin_cos_i.h
+++ b/quantum/rgb_matrix_runners/effect_runner_sin_cos_i.h
@@ -1,18 +1,16 @@
 #pragma once
 
-typedef void (*sin_cos_i_f)(HSV* hsv, int8_t sin, int8_t cos, uint8_t i, uint8_t time);
+typedef HSV (*sin_cos_i_f)(HSV hsv, int8_t sin, int8_t cos, uint8_t i, uint8_t time);
 
 bool effect_runner_sin_cos_i(effect_params_t* params, sin_cos_i_f effect_func) {
   RGB_MATRIX_USE_LIMITS(led_min, led_max);
 
-  HSV hsv = { rgb_matrix_config.hue, rgb_matrix_config.sat, rgb_matrix_config.val };
   uint16_t time = scale16by8(g_rgb_counters.tick, rgb_matrix_config.speed / 4);
   int8_t cos_value = cos8(time) - 128;
   int8_t sin_value = sin8(time) - 128;
   for (uint8_t i = led_min; i < led_max; i++) {
     RGB_MATRIX_TEST_LED_FLAGS();
-    effect_func(&hsv, cos_value, sin_value, i, time);
-    RGB rgb = hsv_to_rgb(hsv);
+    RGB rgb = hsv_to_rgb(effect_func(rgb_matrix_config.hsv, cos_value, sin_value, i, time));
     rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
   }
   return led_max < DRIVER_LED_TOTAL;

--- a/quantum/rgb_matrix_types.h
+++ b/quantum/rgb_matrix_types.h
@@ -2,6 +2,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "color.h"
 
 #if defined(__GNUC__)
 #define PACKED __attribute__ ((__packed__))
@@ -81,10 +82,8 @@ typedef union {
   struct PACKED {
     uint8_t  enable  :2;
     uint8_t  mode    :6;
-    uint8_t  hue     :8;
-    uint8_t  sat     :8;
-    uint8_t  val     :8;
-    uint8_t  speed   :8;//EECONFIG needs to be increased to support this
+    HSV      hsv;
+    uint8_t  speed;  //EECONFIG needs to be increased to support this
   };
 } rgb_config_t;
 

--- a/users/xulkal/custom_oled.c
+++ b/users/xulkal/custom_oled.c
@@ -80,7 +80,7 @@ static void render_status(void)
     oled_set_cursor(0, oled_max_lines() - 7);
     oled_write_P(PSTR("-----"), false);
     static char buffer[26] = {0};
-    snprintf(buffer, sizeof(buffer), "h%3d s%3d v%3d s%3d m%3d\n", rgb_matrix_config.hue, rgb_matrix_config.sat, rgb_matrix_config.val, rgb_matrix_config.speed, rgb_matrix_config.mode);
+    snprintf(buffer, sizeof(buffer), "h%3d s%3d v%3d s%3d m%3d\n", rgb_matrix_config.hsv.h, rgb_matrix_config.hsv.s, rgb_matrix_config.hsv.v, rgb_matrix_config.speed, rgb_matrix_config.mode);
     oled_write(buffer, false);
 #elif defined(RGBLIGHT_ENABLE)
     oled_set_cursor(0, oled_max_lines() - 7);
@@ -137,7 +137,7 @@ static void render_status(void)
 
 #if defined(RGB_MATRIX_ENABLE)
     static char buffer[20] = {0};
-    snprintf(buffer, sizeof(buffer), "    h%3d s%3d v%3d\n", rgb_matrix_config.hue, rgb_matrix_config.sat, rgb_matrix_config.val);
+    snprintf(buffer, sizeof(buffer), "    h%3d s%3d v%3d\n", rgb_matrix_config.hsv.h, rgb_matrix_config.hsv.s, rgb_matrix_config.hsv.v);
     oled_write(buffer, false);
 #elif defined(RGBLIGHT_ENABLE)
     static char buffer[20] = {0};


### PR DESCRIPTION
## Description

This update saves another ~190 bytes with LTO enabled.  In addition this was planned with the multiple effects pr in mind making the rebase / transition of that pr easier. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
