### PR TITLE
Fix 9key macropad keymap

### DIFF
--- a/keyboards/9key/keymaps/default/keymap.c
+++ b/keyboards/9key/keymaps/default/keymap.c
@@ -1,16 +1,5 @@
 #include QMK_KEYBOARD_H
 
-// Tap Dance Declarations
-enum {
-  ENT_5 = 0,
-  ZERO_7
-};
-
-// Macro Declarations
-enum {
-  DBL_0 = 0
-};
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 /* LAYER 0
@@ -24,8 +13,8 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  */
 [0] = LAYOUT( \
   KC_1,       KC_2,      KC_3,       \
-  KC_4,       TD(ENT_5), KC_6,       \
-  TD(ZERO_7), KC_8,      LT(1, KC_9) \
+  KC_4,       KC_5,      KC_6,       \
+  KC_7,       KC_8,      LT(1, KC_9) \
 ),
 
 /* LAYER 1
@@ -39,27 +28,8 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  */
 [1] = LAYOUT( \
   KC_ESC,   KC_PLUS, KC_MINS, \
-  KC_BSPC,  KC_ASTR, KC_SLSH, \
-  M(DBL_0), KC_DOT,  KC_TRNS  \
+  KC_ENTER, KC_ASTR, KC_SLSH, \
+  KC_0,     KC_DOT,  KC_TRNS  \
 )
 
 };
-
-qk_tap_dance_action_t tap_dance_actions[] = {
-  [ENT_5] = ACTION_TAP_DANCE_DOUBLE(KC_5, KC_ENT),
-  [ZERO_7] = ACTION_TAP_DANCE_DOUBLE(KC_7, KC_0)
-};
-
-const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt) {
-  if (record->event.pressed) {
-      switch(id) {
-          case DBL_0:
-              SEND_STRING("00");
-              return false;
-      }
-  }
-  return MACRO_NONE;
-};
-
-void matrix_init_user(void) {
-}

--- a/keyboards/9key/keymaps/tap_dance/keymap.c
+++ b/keyboards/9key/keymaps/tap_dance/keymap.c
@@ -1,0 +1,69 @@
+#include QMK_KEYBOARD_H
+
+// Tap Dance Declarations
+enum tap_dances {
+  ENT_5 = 0,
+  ZERO_7,
+};
+
+// Macro Declarations
+enum custom_keycodes {
+  DBL_0 = SAFE_RANGE,
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+/* LAYER 0
+ * ,-----------------------.
+ * |   1   |   2   |   3   |
+ * |-------+-------+-------|
+ * |   4   | 5/ENT |   6   | Dbl Tap 5 for Enter
+ * |-------+-------+-------|
+ * |  7/0  |   8   | 9/FN  | 7/0 = Dbl Tap 7 for 0  -  9/FN = Hold 9 for FN
+ * `-----------------------'
+ */
+[0] = LAYOUT( \
+  KC_1,       KC_2,      KC_3,       \
+  KC_4,       TD(ENT_5), KC_6,       \
+  TD(ZERO_7), KC_8,      LT(1, KC_9) \
+),
+
+/* LAYER 1
+ * ,-----------------------.
+ * |  ESC  |   +   |   -   |
+ * |-------+-------+-------|
+ * |  BSPC |   *   |   /   |
+ * |-------+-------+-------|
+ * |  00   |   .   |       |
+ * `-----------------------'
+ */
+[1] = LAYOUT( \
+  KC_ESC,   KC_PLUS, KC_MINS, \
+  KC_BSPC,  KC_ASTR, KC_SLSH, \
+  DBL_0,    KC_DOT,  KC_TRNS  \
+)
+
+};
+
+qk_tap_dance_action_t tap_dance_actions[] = {
+  [ENT_5] = ACTION_TAP_DANCE_DOUBLE(KC_5, KC_ENT),
+  [ZERO_7] = ACTION_TAP_DANCE_DOUBLE(KC_7, KC_0)
+};
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  switch (keycode) {
+    case DBL_0:
+      if (record->event.pressed) {
+        // when keycode QMKBEST is pressed
+        tap_code(KC_P0);
+        tap_code(KC_P0);
+      }
+      break;
+
+  }
+  return true;
+};
+
+
+void matrix_init_user(void) {
+}

--- a/keyboards/9key/keymaps/tap_dance/rules.mk
+++ b/keyboards/9key/keymaps/tap_dance/rules.mk
@@ -1,0 +1,1 @@
+TAP_DANCE_ENABLE = yes

--- a/keyboards/9key/rules.mk
+++ b/keyboards/9key/rules.mk
@@ -47,7 +47,7 @@ OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
 OPT_DEFS += -DBOOTLOADER_SIZE=4096
 
 # Build Options
-#   change to "no" to disable the options, or define them in the Makefile in 
+#   change to "no" to disable the options, or define them in the Makefile in
 #   the appropriate keymap folder that will get included automatically
 #
 BOOTMAGIC_ENABLE = no       # Virtual DIP switch configuration(+1000)
@@ -63,7 +63,7 @@ UNICODE_ENABLE = yes         # Unicode
 BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
 RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight.
 API_SYSEX_ENABLE = yes
-TAP_DANCE_ENABLE = yes
+TAP_DANCE_ENABLE = no
 
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
 SLEEP_LED_ENABLE = no    # Breathing sleep LED during USB suspend


### PR DESCRIPTION
Fails to compile on the configurator because tapdance is enabled for the entire keyboard

## Types of Changes

- [x] Bugfix
- [x] Keyboard (addition or update)

## Issues Fixed or Closed by This PR

* Configurator

## Checklist

- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
