### PR TITLE
Convert Dynamic Macro to a Core Feature

### DIFF
--- a/common_features.mk
+++ b/common_features.mk
@@ -404,8 +404,12 @@ ifeq ($(strip $(SPACE_CADET_ENABLE)), yes)
   OPT_DEFS += -DSPACE_CADET_ENABLE
 endif
 
-
 ifeq ($(strip $(DIP_SWITCH_ENABLE)), yes)
   SRC += $(QUANTUM_DIR)/dip_switch.c
   OPT_DEFS += -DDIP_SWITCH_ENABLE
+endif
+
+ifeq ($(strip $(DYNAMIC_MACRO_ENABLE)), yes)
+    SRC += $(QUANTUM_DIR)/process_keycode/process_dynamic_macro.c
+    OPT_DEFS += -DDYNAMIC_MACRO_ENABLE
 endif

--- a/docs/feature_dynamic_macros.md
+++ b/docs/feature_dynamic_macros.md
@@ -37,7 +37,7 @@ There are a number of options added that should allow some additional degree of 
 |`DYNAMIC_MACRO_NO_NESTING`  |*Not Defined*   |Defining this disables the ability to call a macro from another macro (nested macros).                           | 
 
 
-If the LEDs start blinking during the recording with each keypress, it means there is no more space for the macro in the macro buffer. To fit the macro in, either make the other macro shorter (they share the same buffer) or increase the buffer size by adding the `DYNAMIC_MACRO_SIZE` define in your `config.h (default value: 128; please read the comments for it in the header).
+If the LEDs start blinking during the recording with each keypress, it means there is no more space for the macro in the macro buffer. To fit the macro in, either make the other macro shorter (they share the same buffer) or increase the buffer size by adding the `DYNAMIC_MACRO_SIZE` define in your `config.h` (default value: 128; please read the comments for it in the header).
 
 
 ### DYNAMIC_MACRO_USER_CALL

--- a/docs/feature_dynamic_macros.md
+++ b/docs/feature_dynamic_macros.md
@@ -6,11 +6,13 @@ You can store one or two macros and they may have a combined total of 128 keypre
 
 To enable them, first include `DYNAMIC_MACRO_ENABLE = yes` in your `rules.mk`. Then, add the following keys to your keymap:
 
-* `DYN_REC_START1` — start recording the macro 1,
-* `DYN_REC_START2` — start recording the macro 2,
-* `DYN_MACRO_PLAY1` — replay the macro 1,
-* `DYN_MACRO_PLAY2` — replay the macro 2,
-* `DYN_REC_STOP` — finish the macro that is currently being recorded.
+|Key               |Alias     |Description                                        |
+|------------------|----------|---------------------------------------------------|
+|`DYN_REC_START1`  |`DM_REC1` |Start recording Macro 1                            |
+|`DYN_REC_START2`  |`DM_REC2` |Start recording Macro 2                            |
+|`DYN_MACRO_PLAY1` |`DM_PLY1` |Replay Macro 1                                     |
+|`DYN_MACRO_PLAY2` |`DM_PLY2` |Replay Macro 2                                     |
+|`DYN_REC_STOP`    |`DM_RSTP` |Finish the macro that is currently being recorded. |
 
 That should be everything necessary. 
 

--- a/docs/feature_dynamic_macros.md
+++ b/docs/feature_dynamic_macros.md
@@ -22,7 +22,7 @@ To finish the recording, press the `DYN_REC_STOP` layer button.
 
 To replay the macro, press either `DYN_MACRO_PLAY1` or `DYN_MACRO_PLAY2`.
 
-!> It is possible to replay a macro as part of a macro. It's ok to replay macro 2 while recording macro 1 and vice versa but never create recursive macros i.e. macro 1 that replays macro 1. If you do so and the keyboard will get unresponsive, unplug the keyboard and plug it again.
+It is possible to replay a macro as part of a macro. It's ok to replay macro 2 while recording macro 1 and vice versa but never create recursive macros i.e. macro 1 that replays macro 1. If you do so and the keyboard will get unresponsive, unplug the keyboard and plug it again.  You can disable this completly by defining `DYNAMIC_MACRO_NO_NESTING`  in your `config.h` file.
 
 ?> For the details about the internals of the dynamic macros, please read the comments in the `process_dynamic_macro.h` and `process_dynamic_macro.c` files.
 
@@ -32,8 +32,9 @@ There are a number of options added that should allow some additional degree of 
 
 |Define                      |Default         |Description                                                                                                      |
 |----------------------------|----------------|-----------------------------------------------------------------------------------------------------------------|
-|`DYNAMIC_MACRO_SIZE         |128             |Sets the amount of memory that Dynamic Macros can use. This is a limited resource, dependent on the controller.  |
+|`DYNAMIC_MACRO_SIZE`        |128             |Sets the amount of memory that Dynamic Macros can use. This is a limited resource, dependent on the controller.  |
 |`DYNAMIC_MACRO_USER_CALL`   |*Not defined*   |Defining this falls back to using the user `keymap.c` file to trigger the macro behavior.                        |
+|`DYNAMIC_MACRO_NO_NESTING`  |*Not Defined*   |Defining this disables the ability to call a macro from another macro (nested macros).                           | 
 
 
 If the LEDs start blinking during the recording with each keypress, it means there is no more space for the macro in the macro buffer. To fit the macro in, either make the other macro shorter (they share the same buffer) or increase the buffer size by adding the `DYNAMIC_MACRO_SIZE` define in your `config.h (default value: 128; please read the comments for it in the header).

--- a/docs/feature_dynamic_macros.md
+++ b/docs/feature_dynamic_macros.md
@@ -4,31 +4,7 @@ QMK supports temporary macros created on the fly. We call these Dynamic Macros. 
 
 You can store one or two macros and they may have a combined total of 128 keypresses. You can increase this size at the cost of RAM.
 
-To enable them, first add a new element to the end of your `keycodes` enum — `DYNAMIC_MACRO_RANGE`:
-
-```c
-enum keycodes {
-	QWERTY = SAFE_RANGE,
-	COLEMAK,
-	DVORAK,
-	PLOVER,
-	LOWER,
-	RAISE,
-	BACKLIT,
-	EXT_PLV,
-	DYNAMIC_MACRO_RANGE,
-};
-```
-
-Your `keycodes` enum may have a slightly different name. You must add `DYNAMIC_MACRO_RANGE` as the last element because `dynamic_macros.h` will add some more keycodes after it.
-
-Below it, include the `dynamic_macro.h` header:
-
-```c
-	#include "dynamic_macro.h"`
-```
-
-Add the following keys to your keymap:
+To enable them, first include `DYNAMIC_MACRO_ENABLE = yes` in your Makefile. Then, add the following keys to your keymap:
 
 * `DYN_REC_START1` — start recording the macro 1,
 * `DYN_REC_START2` — start recording the macro 2,
@@ -36,19 +12,34 @@ Add the following keys to your keymap:
 * `DYN_MACRO_PLAY2` — replay the macro 2,
 * `DYN_REC_STOP` — finish the macro that is currently being recorded.
 
-Add the following code to the very beginning of your `process_record_user()` function:
+That should be everything necessary. 
 
-```c
-	if (!process_record_dynamic_macro(keycode, record)) {
-		return false;
-	}
-```
+To start recording the macro, press either `DYN_REC_START1` or `DYN_REC_START2`. 
 
-That should be everything necessary. To start recording the macro, press either `DYN_REC_START1` or `DYN_REC_START2`. To finish the recording, press the `DYN_REC_STOP` layer button. To replay the macro, press either `DYN_MACRO_PLAY1` or `DYN_MACRO_PLAY2`.
+To finish the recording, press the `DYN_REC_STOP` layer button. 
 
-Note that it's possible to replay a macro as part of a macro. It's ok to replay macro 2 while recording macro 1 and vice versa but never create recursive macros i.e. macro 1 that replays macro 1. If you do so and the keyboard will get unresponsive, unplug the keyboard and plug it again.
+To replay the macro, press either `DYN_MACRO_PLAY1` or `DYN_MACRO_PLAY2`.
 
-For users of the earlier versions of dynamic macros: It is still possible to finish the macro recording using just the layer modifier used to access the dynamic macro keys, without a dedicated `DYN_REC_STOP` key. If you want this behavior back, use the following snippet instead of the one above:
+!> It is possible to replay a macro as part of a macro. It's ok to replay macro 2 while recording macro 1 and vice versa but never create recursive macros i.e. macro 1 that replays macro 1. If you do so and the keyboard will get unresponsive, unplug the keyboard and plug it again.
+
+?> For the details about the internals of the dynamic macros, please read the comments in the `process_dynamic_macro.h` and `process_dynamic_macro.c` files.
+
+## Customization 
+
+There are a number of options added that should allow some additional degree of customization
+
+|Define                      |Default         |Description                                                                                                      |
+|----------------------------|----------------|-----------------------------------------------------------------------------------------------------------------|
+|`DYNAMIC_MACRO_SIZE         |128             |Sets the amount of memory that Dynamic Macros can use. This is a limited resource, dependent on the controller.  |
+|`DYNAMIC_MACRO_USER_CALL`   |*Not defined*   |Defining this falls back to using the user `keymap.c` file to trigger the macro behavior.                        |
+
+
+If the LEDs start blinking during the recording with each keypress, it means there is no more space for the macro in the macro buffer. To fit the macro in, either make the other macro shorter (they share the same buffer) or increase the buffer size by adding the `DYNAMIC_MACRO_SIZE` define in your `config.h (default value: 128; please read the comments for it in the header).
+
+
+### DYNAMIC_MACRO_USER_CALL
+
+For users of the earlier versions of dynamic macros: It is still possible to finish the macro recording using just the layer modifier used to access the dynamic macro keys, without a dedicated `DYN_REC_STOP` key. If you want this behavior back, add `#define DYNAMIC_MACRO_USER_CALL` to your `config.h` and insert the following snippet at the beginning of your `process_record_user()` function:
 
 ```c
 	uint16_t macro_kc = (keycode == MO(_DYN) ? DYN_REC_STOP : keycode);
@@ -58,6 +49,15 @@ For users of the earlier versions of dynamic macros: It is still possible to fin
 	}
 ```
 
-If the LEDs start blinking during the recording with each keypress, it means there is no more space for the macro in the macro buffer. To fit the macro in, either make the other macro shorter (they share the same buffer) or increase the buffer size by setting the `DYNAMIC_MACRO_SIZE` preprocessor macro (default value: 128; please read the comments for it in the header).
+### User Hooks
 
-For the details about the internals of the dynamic macros, please read the comments in the `dynamic_macro.h` header.
+There are a number of hooks that you can use to add custom functionality and feedback options to Dynamic Macro feature.  This allows for some additional degree of customization. 
+
+Note, that direction indicates which macro it is, with `1` being Macro 1, `-1` being Macro 2, and 0 being no macro. 
+
+* `dynamic_macro_record_start_user(void)` - Triggered when you start recording a macro.
+* `dynamic_macro_play_user(int8_t direction)` - Triggered when you play back a macro.
+* `dynamic_macro_record_key_user(int8_t direction, keyrecord_t *record)` - Triggered on each keypress while recording a macro.
+* `dynamic_macro_record_end_user(int8_t direction)` - Triggered when the macro recording is stopped. 
+
+Additionally, you can call `dynamic_macro_led_blink()` to flash the backlights if that feature is enabled. 

--- a/docs/feature_dynamic_macros.md
+++ b/docs/feature_dynamic_macros.md
@@ -4,7 +4,7 @@ QMK supports temporary macros created on the fly. We call these Dynamic Macros. 
 
 You can store one or two macros and they may have a combined total of 128 keypresses. You can increase this size at the cost of RAM.
 
-To enable them, first include `DYNAMIC_MACRO_ENABLE = yes` in your Makefile. Then, add the following keys to your keymap:
+To enable them, first include `DYNAMIC_MACRO_ENABLE = yes` in your `rules.mk`. Then, add the following keys to your keymap:
 
 * `DYN_REC_START1` — start recording the macro 1,
 * `DYN_REC_START2` — start recording the macro 2,

--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -297,6 +297,16 @@ This is a reference only. Each group of keys links to the page documenting their
 |`OUT_USB` |USB only                                      |
 |`OUT_BT`  |Bluetooth only                                |
 
+## [Dynamic Macros](feature_dynamic_macros.md)
+
+|Key              |Alias    |Description                                       |
+|-----------------|---------|--------------------------------------------------|
+|`DYN_REC_START1` |`DM_REC1`|Start recording Macro 1                           |
+|`DYN_REC_START2` |`DM_REC2`|Start recording Macro 2                           |
+|`DYN_MACRO_PLAY1`|`DM_PLY1`|Replay Macro 1                                    |
+|`DYN_MACRO_PLAY2`|`DM_PLY2`|Replay Macro 2                                    |
+|`DYN_REC_STOP`   |`DM_RSTP`|Finish the macro that is currently being recorded.|
+
 ## [Layer Switching](feature_advanced_keycodes.md#switching-and-toggling-layers)
 
 |Key             |Description                                                                       |

--- a/quantum/dynamic_macro.h
+++ b/quantum/dynamic_macro.h
@@ -35,17 +35,12 @@
 #    define DYNAMIC_MACRO_SIZE 128
 #endif
 
-/* DYNAMIC_MACRO_RANGE must be set as the last element of user's
- * "planck_keycodes" enum prior to including this header. This allows
- * us to 'extend' it.
+/* DYNAMIC_MACRO_RANGE was the last entry in the enum for custom keycodes.
+ * However, because they are in the system core now, it will cause errors.
+ * So to avoid potential issues, just set it to something past  SAFE_RANGE
  */
-enum dynamic_macro_keycodes {
-    DYN_REC_START1 = DYNAMIC_MACRO_RANGE,
-    DYN_REC_START2,
-    DYN_REC_STOP,
-    DYN_MACRO_PLAY1,
-    DYN_MACRO_PLAY2,
-};
+
+#define DYNAMIC_MACRO_RANGE (SAFE_RANGE + 20)
 
 /* Blink the LEDs to notify the user about some event. */
 void dynamic_macro_led_blink(void) {

--- a/quantum/dynamic_macro.h
+++ b/quantum/dynamic_macro.h
@@ -35,13 +35,6 @@
 #    define DYNAMIC_MACRO_SIZE 128
 #endif
 
-/* DYNAMIC_MACRO_RANGE was the last entry in the enum for custom keycodes.
- * However, because they are in the system core now, it will cause errors.
- * So to avoid potential issues, just set it to something past  SAFE_RANGE
- */
-
-#define DYNAMIC_MACRO_RANGE (SAFE_RANGE + 20)
-
 /* Blink the LEDs to notify the user about some event. */
 void dynamic_macro_led_blink(void) {
 #ifdef BACKLIGHT_ENABLE

--- a/quantum/dynamic_macro.h
+++ b/quantum/dynamic_macro.h
@@ -18,7 +18,7 @@
 #pragma once
 
 /* Warn users that this is now deprecated and they should use the core feature instead. */
-#pragma message "Dyanmic Macros is now a core feature. See updated documentation to see how to configure it: https://docs.qmk.fm/#/feature_dynamic_macros"
+#pragma message "Dynamic Macros is now a core feature. See updated documentation to see how to configure it: https://docs.qmk.fm/#/feature_dynamic_macros"
 
 #include "action_layer.h"
 

--- a/quantum/process_keycode/process_dynamic_macro.c
+++ b/quantum/process_keycode/process_dynamic_macro.c
@@ -1,5 +1,5 @@
 /* Copyright 2016 Jack Humbert
- * Copyright 2019 Drashna Jael're (Christopher Courtney, @drashna)
+ * Copyright 2019 Drashna Jael're (@drashna, aka Christopher Courtney)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -214,57 +214,57 @@ bool process_dynamic_macro(uint16_t keycode, keyrecord_t *record) {
         /* No macro recording in progress. */
         if (!record->event.pressed) {
             switch (keycode) {
-            case DYN_REC_START1:
-                dynamic_macro_record_start(&macro_pointer, macro_buffer);
-                macro_id = 1;
-                return false;
-            case DYN_REC_START2:
-                dynamic_macro_record_start(&macro_pointer, r_macro_buffer);
-                macro_id = 2;
-                return false;
-            case DYN_MACRO_PLAY1:
-                dynamic_macro_play(macro_buffer, macro_end, +1);
-                return false;
-            case DYN_MACRO_PLAY2:
-                dynamic_macro_play(r_macro_buffer, r_macro_end, -1);
-                return false;
+                case DYN_REC_START1:
+                    dynamic_macro_record_start(&macro_pointer, macro_buffer);
+                    macro_id = 1;
+                    return false;
+                case DYN_REC_START2:
+                    dynamic_macro_record_start(&macro_pointer, r_macro_buffer);
+                    macro_id = 2;
+                    return false;
+                case DYN_MACRO_PLAY1:
+                    dynamic_macro_play(macro_buffer, macro_end, +1);
+                    return false;
+                case DYN_MACRO_PLAY2:
+                    dynamic_macro_play(r_macro_buffer, r_macro_end, -1);
+                    return false;
             }
         }
     } else {
         /* A macro is being recorded right now. */
         switch (keycode) {
-        case DYN_REC_STOP:
-            /* Stop the macro recording. */
-            if (record->event.pressed) { /* Ignore the initial release
-                                          * just after the recoding
-                                          * starts. */
-                switch (macro_id) {
-                case 1:
-                    dynamic_macro_record_end(macro_buffer, macro_pointer, +1, &macro_end);
-                    break;
-                case 2:
-                    dynamic_macro_record_end(r_macro_buffer, macro_pointer, -1, &r_macro_end);
-                    break;
+            case DYN_REC_STOP:
+                /* Stop the macro recording. */
+                if (record->event.pressed) { /* Ignore the initial release
+                                            * just after the recoding
+                                            * starts. */
+                    switch (macro_id) {
+                        case 1:
+                            dynamic_macro_record_end(macro_buffer, macro_pointer, +1, &macro_end);
+                            break;
+                        case 2:
+                            dynamic_macro_record_end(r_macro_buffer, macro_pointer, -1, &r_macro_end);
+                            break;
+                    }
+                    macro_id = 0;
                 }
-                macro_id = 0;
-            }
-            return false;
-        case DYN_MACRO_PLAY1:
-        case DYN_MACRO_PLAY2:
-            dprintln("dynamic macro: ignoring macro play key while recording");
-            return false;
-        default:
-            /* Store the key in the macro buffer and process it normally. */
-            switch (macro_id) {
-            case 1:
-                dynamic_macro_record_key(macro_buffer, &macro_pointer, r_macro_end, +1, record);
+                return false;
+            case DYN_MACRO_PLAY1:
+            case DYN_MACRO_PLAY2:
+                dprintln("dynamic macro: ignoring macro play key while recording");
+                return false;
+            default:
+                /* Store the key in the macro buffer and process it normally. */
+                switch (macro_id) {
+                    case 1:
+                        dynamic_macro_record_key(macro_buffer, &macro_pointer, r_macro_end, +1, record);
+                        break;
+                    case 2:
+                        dynamic_macro_record_key(r_macro_buffer, &macro_pointer, macro_end, -1, record);
+                        break;
+                }
+                return true;
                 break;
-            case 2:
-                dynamic_macro_record_key(r_macro_buffer, &macro_pointer, macro_end, -1, record);
-                break;
-            }
-            return true;
-            break;
         }
     }
 

--- a/quantum/process_keycode/process_dynamic_macro.c
+++ b/quantum/process_keycode/process_dynamic_macro.c
@@ -1,4 +1,5 @@
 /* Copyright 2016 Jack Humbert
+ * Copyright 2019 Drashna Jael're (Christopher Courtney, @drashna)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,39 +16,9 @@
  */
 
 /* Author: Wojciech Siewierski < wojciech dot siewierski at onet dot pl > */
-#pragma once
+#include "quantum.h"
 
-/* Warn users that this is now deprecated and they should use the core feature instead. */
-#pragma message "Dyanmic Macros is now a core feature. See updated documentation to see how to configure it: https://docs.qmk.fm/#/feature_dynamic_macros"
-
-#include "action_layer.h"
-
-#ifndef DYNAMIC_MACRO_SIZE
-/* May be overridden with a custom value. Be aware that the effective
- * macro length is half of this value: each keypress is recorded twice
- * because of the down-event and up-event. This is not a bug, it's the
- * intended behavior.
- *
- * Usually it should be fine to set the macro size to at least 256 but
- * there have been reports of it being too much in some users' cases,
- * so 128 is considered a safe default.
- */
-#    define DYNAMIC_MACRO_SIZE 128
-#endif
-
-/* DYNAMIC_MACRO_RANGE must be set as the last element of user's
- * "planck_keycodes" enum prior to including this header. This allows
- * us to 'extend' it.
- */
-enum dynamic_macro_keycodes {
-    DYN_REC_START1 = DYNAMIC_MACRO_RANGE,
-    DYN_REC_START2,
-    DYN_REC_STOP,
-    DYN_MACRO_PLAY1,
-    DYN_MACRO_PLAY2,
-};
-
-/* Blink the LEDs to notify the user about some event. */
+// default feedback method
 void dynamic_macro_led_blink(void) {
 #ifdef BACKLIGHT_ENABLE
     backlight_toggle();
@@ -56,12 +27,28 @@ void dynamic_macro_led_blink(void) {
 #endif
 }
 
+/* User hooks for Dynamic Macros */
+
+__attribute__((weak))
+void dynamic_macro_record_start_user(void) { dynamic_macro_led_blink(); }
+
+__attribute__((weak))
+void dynamic_macro_play_user(int8_t direction) { dynamic_macro_led_blink(); }
+
+__attribute__((weak))
+void dynamic_macro_record_key_user(int8_t direction, keyrecord_t *record) { dynamic_macro_led_blink(); }
+
+__attribute__((weak))
+void dynamic_macro_record_end_user(int8_t direction) { dynamic_macro_led_blink(); }
+
 /* Convenience macros used for retrieving the debug info. All of them
  * need a `direction` variable accessible at the call site.
  */
 #define DYNAMIC_MACRO_CURRENT_SLOT() (direction > 0 ? 1 : 2)
-#define DYNAMIC_MACRO_CURRENT_LENGTH(BEGIN, POINTER) ((int)(direction * ((POINTER) - (BEGIN))))
-#define DYNAMIC_MACRO_CURRENT_CAPACITY(BEGIN, END2) ((int)(direction * ((END2) - (BEGIN)) + 1))
+#define DYNAMIC_MACRO_CURRENT_LENGTH(BEGIN, POINTER) \
+    ((int)(direction * ((POINTER) - (BEGIN))))
+#define DYNAMIC_MACRO_CURRENT_CAPACITY(BEGIN, END2) \
+    ((int)(direction * ((END2) - (BEGIN)) + 1))
 
 /**
  * Start recording of the dynamic macro.
@@ -72,7 +59,7 @@ void dynamic_macro_led_blink(void) {
 void dynamic_macro_record_start(keyrecord_t **macro_pointer, keyrecord_t *macro_buffer) {
     dprintln("dynamic macro recording: started");
 
-    dynamic_macro_led_blink();
+    dynamic_macro_record_start_user();
 
     clear_keyboard();
     layer_clear();
@@ -102,6 +89,8 @@ void dynamic_macro_play(keyrecord_t *macro_buffer, keyrecord_t *macro_end, int8_
     clear_keyboard();
 
     layer_state = saved_layer_state;
+
+    dynamic_macro_play_user(direction);
 }
 
 /**
@@ -127,10 +116,15 @@ void dynamic_macro_record_key(keyrecord_t *macro_buffer, keyrecord_t **macro_poi
         **macro_pointer = *record;
         *macro_pointer += direction;
     } else {
-        dynamic_macro_led_blink();
+        dynamic_macro_record_key_user(direction, record);
     }
 
-    dprintf("dynamic macro: slot %d length: %d/%d\n", DYNAMIC_MACRO_CURRENT_SLOT(), DYNAMIC_MACRO_CURRENT_LENGTH(macro_buffer, *macro_pointer), DYNAMIC_MACRO_CURRENT_CAPACITY(macro_buffer, macro2_end));
+    dprintf(
+        "dynamic macro: slot %d length: %d/%d\n",
+        DYNAMIC_MACRO_CURRENT_SLOT(),
+        DYNAMIC_MACRO_CURRENT_LENGTH(macro_buffer, *macro_pointer),
+        DYNAMIC_MACRO_CURRENT_CAPACITY(macro_buffer, macro2_end)
+        );
 }
 
 /**
@@ -138,7 +132,7 @@ void dynamic_macro_record_key(keyrecord_t *macro_buffer, keyrecord_t **macro_poi
  * pointer to the end of the macro.
  */
 void dynamic_macro_record_end(keyrecord_t *macro_buffer, keyrecord_t *macro_pointer, int8_t direction, keyrecord_t **macro_end) {
-    dynamic_macro_led_blink();
+    dynamic_macro_record_end_user(direction);
 
     /* Do not save the keys being held when stopping the recording,
      * i.e. the keys used to access the layer DYN_REC_STOP is on.
@@ -148,9 +142,14 @@ void dynamic_macro_record_end(keyrecord_t *macro_buffer, keyrecord_t *macro_poin
         macro_pointer -= direction;
     }
 
-    dprintf("dynamic macro: slot %d saved, length: %d\n", DYNAMIC_MACRO_CURRENT_SLOT(), DYNAMIC_MACRO_CURRENT_LENGTH(macro_buffer, macro_pointer));
+    dprintf(
+        "dynamic macro: slot %d saved, length: %d\n",
+        DYNAMIC_MACRO_CURRENT_SLOT(),
+        DYNAMIC_MACRO_CURRENT_LENGTH(macro_buffer, macro_pointer)
+        );
 
     *macro_end = macro_pointer;
+
 }
 
 /* Handle the key events related to the dynamic macros. Should be
@@ -163,7 +162,7 @@ void dynamic_macro_record_end(keyrecord_t *macro_buffer, keyrecord_t *macro_poin
  *       <...THE REST OF THE FUNCTION...>
  *   }
  */
-bool process_record_dynamic_macro(uint16_t keycode, keyrecord_t *record) {
+bool process_dynamic_macro(uint16_t keycode, keyrecord_t *record) {
     /* Both macros use the same buffer but read/write on different
      * ends of it.
      *
@@ -210,67 +209,64 @@ bool process_record_dynamic_macro(uint16_t keycode, keyrecord_t *record) {
      * 1,2 - either macro 1 or 2 is being recorded */
     static uint8_t macro_id = 0;
 
+
     if (macro_id == 0) {
         /* No macro recording in progress. */
         if (!record->event.pressed) {
             switch (keycode) {
-                case DYN_REC_START1:
-                    dynamic_macro_record_start(&macro_pointer, macro_buffer);
-                    macro_id = 1;
-                    return false;
-                case DYN_REC_START2:
-                    dynamic_macro_record_start(&macro_pointer, r_macro_buffer);
-                    macro_id = 2;
-                    return false;
-                case DYN_MACRO_PLAY1:
-                    dynamic_macro_play(macro_buffer, macro_end, +1);
-                    return false;
-                case DYN_MACRO_PLAY2:
-                    dynamic_macro_play(r_macro_buffer, r_macro_end, -1);
-                    return false;
+            case DYN_REC_START1:
+                dynamic_macro_record_start(&macro_pointer, macro_buffer);
+                macro_id = 1;
+                return false;
+            case DYN_REC_START2:
+                dynamic_macro_record_start(&macro_pointer, r_macro_buffer);
+                macro_id = 2;
+                return false;
+            case DYN_MACRO_PLAY1:
+                dynamic_macro_play(macro_buffer, macro_end, +1);
+                return false;
+            case DYN_MACRO_PLAY2:
+                dynamic_macro_play(r_macro_buffer, r_macro_end, -1);
+                return false;
             }
         }
     } else {
         /* A macro is being recorded right now. */
         switch (keycode) {
-            case DYN_REC_STOP:
-                /* Stop the macro recording. */
-                if (record->event.pressed) { /* Ignore the initial release
-                                              * just after the recoding
-                                              * starts. */
-                    switch (macro_id) {
-                        case 1:
-                            dynamic_macro_record_end(macro_buffer, macro_pointer, +1, &macro_end);
-                            break;
-                        case 2:
-                            dynamic_macro_record_end(r_macro_buffer, macro_pointer, -1, &r_macro_end);
-                            break;
-                    }
-                    macro_id = 0;
-                }
-                return false;
-            case DYN_MACRO_PLAY1:
-            case DYN_MACRO_PLAY2:
-                dprintln("dynamic macro: ignoring macro play key while recording");
-                return false;
-            default:
-                /* Store the key in the macro buffer and process it normally. */
+        case DYN_REC_STOP:
+            /* Stop the macro recording. */
+            if (record->event.pressed) { /* Ignore the initial release
+                                          * just after the recoding
+                                          * starts. */
                 switch (macro_id) {
-                    case 1:
-                        dynamic_macro_record_key(macro_buffer, &macro_pointer, r_macro_end, +1, record);
-                        break;
-                    case 2:
-                        dynamic_macro_record_key(r_macro_buffer, &macro_pointer, macro_end, -1, record);
-                        break;
+                case 1:
+                    dynamic_macro_record_end(macro_buffer, macro_pointer, +1, &macro_end);
+                    break;
+                case 2:
+                    dynamic_macro_record_end(r_macro_buffer, macro_pointer, -1, &r_macro_end);
+                    break;
                 }
-                return true;
+                macro_id = 0;
+            }
+            return false;
+        case DYN_MACRO_PLAY1:
+        case DYN_MACRO_PLAY2:
+            dprintln("dynamic macro: ignoring macro play key while recording");
+            return false;
+        default:
+            /* Store the key in the macro buffer and process it normally. */
+            switch (macro_id) {
+            case 1:
+                dynamic_macro_record_key(macro_buffer, &macro_pointer, r_macro_end, +1, record);
                 break;
+            case 2:
+                dynamic_macro_record_key(r_macro_buffer, &macro_pointer, macro_end, -1, record);
+                break;
+            }
+            return true;
+            break;
         }
     }
 
     return true;
 }
-
-#undef DYNAMIC_MACRO_CURRENT_SLOT
-#undef DYNAMIC_MACRO_CURRENT_LENGTH
-#undef DYNAMIC_MACRO_CURRENT_CAPACITY

--- a/quantum/process_keycode/process_dynamic_macro.c
+++ b/quantum/process_keycode/process_dynamic_macro.c
@@ -29,26 +29,20 @@ void dynamic_macro_led_blink(void) {
 
 /* User hooks for Dynamic Macros */
 
-__attribute__((weak))
-void dynamic_macro_record_start_user(void) { dynamic_macro_led_blink(); }
+__attribute__((weak)) void dynamic_macro_record_start_user(void) { dynamic_macro_led_blink(); }
 
-__attribute__((weak))
-void dynamic_macro_play_user(int8_t direction) { dynamic_macro_led_blink(); }
+__attribute__((weak)) void dynamic_macro_play_user(int8_t direction) { dynamic_macro_led_blink(); }
 
-__attribute__((weak))
-void dynamic_macro_record_key_user(int8_t direction, keyrecord_t *record) { dynamic_macro_led_blink(); }
+__attribute__((weak)) void dynamic_macro_record_key_user(int8_t direction, keyrecord_t *record) { dynamic_macro_led_blink(); }
 
-__attribute__((weak))
-void dynamic_macro_record_end_user(int8_t direction) { dynamic_macro_led_blink(); }
+__attribute__((weak)) void dynamic_macro_record_end_user(int8_t direction) { dynamic_macro_led_blink(); }
 
 /* Convenience macros used for retrieving the debug info. All of them
  * need a `direction` variable accessible at the call site.
  */
 #define DYNAMIC_MACRO_CURRENT_SLOT() (direction > 0 ? 1 : 2)
-#define DYNAMIC_MACRO_CURRENT_LENGTH(BEGIN, POINTER) \
-    ((int)(direction * ((POINTER) - (BEGIN))))
-#define DYNAMIC_MACRO_CURRENT_CAPACITY(BEGIN, END2) \
-    ((int)(direction * ((END2) - (BEGIN)) + 1))
+#define DYNAMIC_MACRO_CURRENT_LENGTH(BEGIN, POINTER) ((int)(direction * ((POINTER) - (BEGIN))))
+#define DYNAMIC_MACRO_CURRENT_CAPACITY(BEGIN, END2) ((int)(direction * ((END2) - (BEGIN)) + 1))
 
 /**
  * Start recording of the dynamic macro.
@@ -119,12 +113,7 @@ void dynamic_macro_record_key(keyrecord_t *macro_buffer, keyrecord_t **macro_poi
         dynamic_macro_record_key_user(direction, record);
     }
 
-    dprintf(
-        "dynamic macro: slot %d length: %d/%d\n",
-        DYNAMIC_MACRO_CURRENT_SLOT(),
-        DYNAMIC_MACRO_CURRENT_LENGTH(macro_buffer, *macro_pointer),
-        DYNAMIC_MACRO_CURRENT_CAPACITY(macro_buffer, macro2_end)
-    );
+    dprintf("dynamic macro: slot %d length: %d/%d\n", DYNAMIC_MACRO_CURRENT_SLOT(), DYNAMIC_MACRO_CURRENT_LENGTH(macro_buffer, *macro_pointer), DYNAMIC_MACRO_CURRENT_CAPACITY(macro_buffer, macro2_end));
 }
 
 /**
@@ -142,14 +131,9 @@ void dynamic_macro_record_end(keyrecord_t *macro_buffer, keyrecord_t *macro_poin
         macro_pointer -= direction;
     }
 
-    dprintf(
-        "dynamic macro: slot %d saved, length: %d\n",
-        DYNAMIC_MACRO_CURRENT_SLOT(),
-        DYNAMIC_MACRO_CURRENT_LENGTH(macro_buffer, macro_pointer)
-    );
+    dprintf("dynamic macro: slot %d saved, length: %d\n", DYNAMIC_MACRO_CURRENT_SLOT(), DYNAMIC_MACRO_CURRENT_LENGTH(macro_buffer, macro_pointer));
 
     *macro_end = macro_pointer;
-
 }
 
 /* Handle the key events related to the dynamic macros. Should be
@@ -209,7 +193,6 @@ bool process_dynamic_macro(uint16_t keycode, keyrecord_t *record) {
      * 1,2 - either macro 1 or 2 is being recorded */
     static uint8_t macro_id = 0;
 
-
     if (macro_id == 0) {
         /* No macro recording in progress. */
         if (!record->event.pressed) {
@@ -236,8 +219,8 @@ bool process_dynamic_macro(uint16_t keycode, keyrecord_t *record) {
             case DYN_REC_STOP:
                 /* Stop the macro recording. */
                 if (record->event.pressed) { /* Ignore the initial release
-                                            * just after the recoding
-                                            * starts. */
+                                              * just after the recoding
+                                              * starts. */
                     switch (macro_id) {
                         case 1:
                             dynamic_macro_record_end(macro_buffer, macro_pointer, +1, &macro_end);

--- a/quantum/process_keycode/process_dynamic_macro.c
+++ b/quantum/process_keycode/process_dynamic_macro.c
@@ -16,7 +16,7 @@
  */
 
 /* Author: Wojciech Siewierski < wojciech dot siewierski at onet dot pl > */
-#include "quantum.h"
+#include "process_dynamic_macro.h"
 
 // default feedback method
 void dynamic_macro_led_blink(void) {
@@ -70,7 +70,7 @@ void dynamic_macro_record_start(keyrecord_t **macro_pointer, keyrecord_t *macro_
 void dynamic_macro_play(keyrecord_t *macro_buffer, keyrecord_t *macro_end, int8_t direction) {
     dprintf("dynamic macro: slot %d playback\n", DYNAMIC_MACRO_CURRENT_SLOT());
 
-    uint32_t saved_layer_state = layer_state;
+    layer_state_t saved_layer_state = layer_state;
 
     clear_keyboard();
     layer_clear();

--- a/quantum/process_keycode/process_dynamic_macro.c
+++ b/quantum/process_keycode/process_dynamic_macro.c
@@ -249,10 +249,12 @@ bool process_dynamic_macro(uint16_t keycode, keyrecord_t *record) {
                     macro_id = 0;
                 }
                 return false;
+#ifdef DYNAMIC_MACRO_NO_NESTING
             case DYN_MACRO_PLAY1:
             case DYN_MACRO_PLAY2:
                 dprintln("dynamic macro: ignoring macro play key while recording");
                 return false;
+#endif
             default:
                 /* Store the key in the macro buffer and process it normally. */
                 switch (macro_id) {

--- a/quantum/process_keycode/process_dynamic_macro.c
+++ b/quantum/process_keycode/process_dynamic_macro.c
@@ -124,7 +124,7 @@ void dynamic_macro_record_key(keyrecord_t *macro_buffer, keyrecord_t **macro_poi
         DYNAMIC_MACRO_CURRENT_SLOT(),
         DYNAMIC_MACRO_CURRENT_LENGTH(macro_buffer, *macro_pointer),
         DYNAMIC_MACRO_CURRENT_CAPACITY(macro_buffer, macro2_end)
-        );
+    );
 }
 
 /**
@@ -146,7 +146,7 @@ void dynamic_macro_record_end(keyrecord_t *macro_buffer, keyrecord_t *macro_poin
         "dynamic macro: slot %d saved, length: %d\n",
         DYNAMIC_MACRO_CURRENT_SLOT(),
         DYNAMIC_MACRO_CURRENT_LENGTH(macro_buffer, macro_pointer)
-        );
+    );
 
     *macro_end = macro_pointer;
 

--- a/quantum/process_keycode/process_dynamic_macro.h
+++ b/quantum/process_keycode/process_dynamic_macro.h
@@ -1,0 +1,48 @@
+/* Copyright 2016 Jack Humbert
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Author: Wojciech Siewierski < wojciech dot siewierski at onet dot pl > */
+#pragma once
+
+#ifndef DYNAMIC_MACRO_SIZE
+/* May be overridden with a custom value. Be aware that the effective
+ * macro length is half of this value: each keypress is recorded twice
+ * because of the down-event and up-event. This is not a bug, it's the
+ * intended behavior.
+ *
+ * Usually it should be fine to set the macro size to at least 256 but
+ * there have been reports of it being too much in some users' cases,
+ * so 128 is considered a safe default.
+ */
+#define DYNAMIC_MACRO_SIZE 128
+#endif
+
+/* Handle the key events related to the dynamic macros. Should be
+ * called from process_record_user() like this:
+ *
+ *   bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+ *       if (!process_record_dynamic_macro(keycode, record)) {
+ *           return false;
+ *       }
+ *       <...THE REST OF THE FUNCTION...>
+ *   }
+ */
+void dynamic_macro_led_blink(void);
+bool process_dynamic_macro(uint16_t keycode, keyrecord_t *record);
+void dynamic_macro_record_start_user(void);
+void dynamic_macro_play_user(int8_t direction);
+void dynamic_macro_record_key_user(int8_t direction, keyrecord_t *record);
+void dynamic_macro_record_end_user(int8_t direction);

--- a/quantum/process_keycode/process_dynamic_macro.h
+++ b/quantum/process_keycode/process_dynamic_macro.h
@@ -18,6 +18,8 @@
 /* Author: Wojciech Siewierski < wojciech dot siewierski at onet dot pl > */
 #pragma once
 
+#include "quantum.h"
+
 /* May be overridden with a custom value. Be aware that the effective
  * macro length is half of this value: each keypress is recorded twice
  * because of the down-event and up-event. This is not a bug, it's the

--- a/quantum/process_keycode/process_dynamic_macro.h
+++ b/quantum/process_keycode/process_dynamic_macro.h
@@ -28,7 +28,7 @@
  * so 128 is considered a safe default.
  */
 #ifndef DYNAMIC_MACRO_SIZE
-#   define DYNAMIC_MACRO_SIZE 128
+#    define DYNAMIC_MACRO_SIZE 128
 #endif
 
 void dynamic_macro_led_blink(void);

--- a/quantum/process_keycode/process_dynamic_macro.h
+++ b/quantum/process_keycode/process_dynamic_macro.h
@@ -1,4 +1,5 @@
 /* Copyright 2016 Jack Humbert
+ * Copyright 2019 Drashna Jael're (@drashna, aka Christopher Courtney)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,7 +18,6 @@
 /* Author: Wojciech Siewierski < wojciech dot siewierski at onet dot pl > */
 #pragma once
 
-#ifndef DYNAMIC_MACRO_SIZE
 /* May be overridden with a custom value. Be aware that the effective
  * macro length is half of this value: each keypress is recorded twice
  * because of the down-event and up-event. This is not a bug, it's the
@@ -27,19 +27,10 @@
  * there have been reports of it being too much in some users' cases,
  * so 128 is considered a safe default.
  */
-#define DYNAMIC_MACRO_SIZE 128
+#ifndef DYNAMIC_MACRO_SIZE
+#   define DYNAMIC_MACRO_SIZE 128
 #endif
 
-/* Handle the key events related to the dynamic macros. Should be
- * called from process_record_user() like this:
- *
- *   bool process_record_user(uint16_t keycode, keyrecord_t *record) {
- *       if (!process_record_dynamic_macro(keycode, record)) {
- *           return false;
- *       }
- *       <...THE REST OF THE FUNCTION...>
- *   }
- */
 void dynamic_macro_led_blink(void);
 bool process_dynamic_macro(uint16_t keycode, keyrecord_t *record);
 void dynamic_macro_record_start_user(void);

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -26,7 +26,7 @@
 
 #ifdef BACKLIGHT_ENABLE
 #    include "backlight.h"
-    extern backlight_config_t backlight_config;
+extern backlight_config_t backlight_config;
 #endif
 
 #ifdef FAUXCLICKY_ENABLE
@@ -89,7 +89,7 @@ static void do_code16(uint16_t code, void (*f)(uint8_t)) {
 
     uint8_t mods_to_send = 0;
 
-    if (code & QK_RMODS_MIN) { // Right mod flag is set
+    if (code & QK_RMODS_MIN) {  // Right mod flag is set
         if (code & QK_LCTL) mods_to_send |= MOD_BIT(KC_RCTL);
         if (code & QK_LSFT) mods_to_send |= MOD_BIT(KC_RSFT);
         if (code & QK_LALT) mods_to_send |= MOD_BIT(KC_RALT);
@@ -567,7 +567,7 @@ bool process_record_quantum(keyrecord_t *record) {
                         keymap_config.swap_backslash_backspace = true;
                         break;
                     case MAGIC_HOST_NKRO:
-                        clear_keyboard(); // clear first buffer to prevent stuck keys
+                        clear_keyboard();  // clear first buffer to prevent stuck keys
                         keymap_config.nkro = true;
                         break;
                     case MAGIC_SWAP_ALT_GUI:
@@ -610,7 +610,7 @@ bool process_record_quantum(keyrecord_t *record) {
                         keymap_config.swap_backslash_backspace = false;
                         break;
                     case MAGIC_UNHOST_NKRO:
-                        clear_keyboard(); // clear first buffer to prevent stuck keys
+                        clear_keyboard();  // clear first buffer to prevent stuck keys
                         keymap_config.nkro = false;
                         break;
                     case MAGIC_UNSWAP_ALT_GUI:
@@ -648,7 +648,7 @@ bool process_record_quantum(keyrecord_t *record) {
 #endif
                         break;
                     case MAGIC_TOGGLE_NKRO:
-                        clear_keyboard(); // clear first buffer to prevent stuck keys
+                        clear_keyboard();  // clear first buffer to prevent stuck keys
                         keymap_config.nkro = !keymap_config.nkro;
                         break;
                     case MAGIC_EE_HANDS_LEFT:

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -222,6 +222,10 @@ bool process_record_quantum(keyrecord_t *record) {
             // Must run first to be able to mask key_up events.
             process_key_lock(&keycode, record) &&
 #endif
+#if defined(DYNAMIC_MACRO_ENABLE) && !defined(DYNAMIC_MACRO_USER_CALL)
+            // Must run asap to ensure all keypresses are recorded.
+            process_dynamic_macro(keycode, record) &&
+#endif
 #if defined(AUDIO_ENABLE) && defined(AUDIO_CLICKY)
             process_clicky(keycode, record) &&
 #endif  // AUDIO_CLICKY

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -149,6 +149,10 @@ extern layer_state_t layer_state;
     #include "dip_switch.h"
 #endif
 
+#ifdef DYNAMIC_MACRO_ENABLE
+    #include "process_dynamic_macro.h"
+#endif
+
 
 // Function substitutions to ease GPIO manipulation
 #if defined(__AVR__)

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -505,6 +505,13 @@ enum quantum_keycodes {
     MAGIC_EE_HANDS_LEFT,
     MAGIC_EE_HANDS_RIGHT,
 
+    // Dynamic Macros
+    DYN_REC_START1,
+    DYN_REC_START2,
+    DYN_REC_STOP,
+    DYN_MACRO_PLAY1,
+    DYN_MACRO_PLAY2,
+
     // always leave at the end
     SAFE_RANGE
 };

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -764,4 +764,11 @@ enum quantum_keycodes {
 #    define SH_OFF (QK_SWAP_HANDS | OP_SH_OFF)
 #endif
 
-#endif  // QUANTUM_KEYCODES_H
+// Dynamic Macros aliases
+#define DM_REC1 DYN_REC_START1
+#define DM_REC2 DYN_REC_START2
+#define DM_RSTP DYN_REC_STOP
+#define DM_PLY1 DYN_MACRO_PLAY1
+#define DM_PLY2 DYN_MACRO_PLAY2
+
+#endif // QUANTUM_KEYCODES_H


### PR DESCRIPTION
This imports the code from Dynamic Macro into the core code, and handles it, as such.

This deprecates the old method but does not remove it, for legacy support. This way, no existing user files need to be touched.

Additionally, this reorganizes the documentation to better reflect the changes.

Also, it adds user hooks to the feature so users can customize the existing functionality.

Based heavily on and closes #2976

## Types of Changes
- [x] Core
- [x] Enhancement/optimization
- [x] Documentation

## Checklist
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
