### PR TITLE
Switch Quefrency keymap from I2C back to serial; factor common configs into userspace

### DIFF
--- a/keyboards/kbdfans/kbd67/hotswap/keymaps/bcat/keymap.c
+++ b/keyboards/kbdfans/kbd67/hotswap/keymaps/bcat/keymap.c
@@ -21,7 +21,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Function layer: http://www.keyboard-layout-editor.com/#/gists/f29128427f674c43777f045e363d1b44 */
     [LAYER_FUNCTION] = LAYOUT(
         _______,  KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   KC_INS,   KC_DEL,   _______,
-        _______,  KC_MPLY,  KC_VOLU,  KC_MSTP,  _______,  _______,  EEP_RST,  _______,  KC_PSCR,  KC_SLCK,  KC_PAUS,  _______,  _______,  _______,  _______,
+        _______,  KC_MPLY,  KC_VOLU,  KC_MSTP,  _______,  _______,  _______,  _______,  KC_PSCR,  KC_SLCK,  KC_PAUS,  _______,  _______,  _______,  _______,
         KC_CAPS,  KC_MPRV,  KC_VOLD,  KC_MNXT,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,
         _______,  _______,  KC_MUTE,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,
         _______,  _______,  _______,  _______,  KC_APP,   _______,  _______,  _______,  _______

--- a/keyboards/kbdfans/kbd67/hotswap/keymaps/bcat/readme.md
+++ b/keyboards/kbdfans/kbd67/hotswap/keymaps/bcat/readme.md
@@ -10,4 +10,4 @@ cluster.
 
 ## Function layer
 
-![Function layer layout](https://i.imgur.com/KScatX6.png)
+![Function layer layout](https://i.imgur.com/urDnuTC.png)

--- a/keyboards/keebio/quefrency/keymaps/bcat/config.h
+++ b/keyboards/keebio/quefrency/keymaps/bcat/config.h
@@ -14,22 +14,9 @@
  */
 #define USE_SERIAL
 
-/* Turn off RGB lighting when the host goes to sleep. */
-#define RGBLIGHT_SLEEP
-
 /* Use an extra LED on the right side since it's wider on the 65% PCB. */
 #undef RGBLED_NUM
 #define RGBLED_NUM 17
 
 /* Set up RGB lighting so it works with either side as master. */
 #define RGBLED_SPLIT { 8, 9 }
-
-/* Make mouse operation smoother. */
-#define MOUSEKEY_DELAY 0
-#define MOUSEKEY_INTERVAL 16
-
-/* Lower mouse speed to adjust for reduced MOUSEKEY_INTERVAL. */
-#define MOUSEKEY_MAX_SPEED 7
-#define MOUSEKEY_TIME_TO_MAX 150
-#define MOUSEKEY_WHEEL_MAX_SPEED 3
-#define MOUSEKEY_WHEEL_TIME_TO_MAX 150

--- a/keyboards/keebio/quefrency/keymaps/bcat/config.h
+++ b/keyboards/keebio/quefrency/keymaps/bcat/config.h
@@ -31,5 +31,5 @@
 /* Lower mouse speed to adjust for reduced MOUSEKEY_INTERVAL. */
 #define MOUSEKEY_MAX_SPEED 7
 #define MOUSEKEY_TIME_TO_MAX 150
-#define MOUSEKEY_WHEEL_MAX_SPEED 4
+#define MOUSEKEY_WHEEL_MAX_SPEED 3
 #define MOUSEKEY_WHEEL_TIME_TO_MAX 150

--- a/keyboards/keebio/quefrency/keymaps/bcat/config.h
+++ b/keyboards/keebio/quefrency/keymaps/bcat/config.h
@@ -1,7 +1,18 @@
 #pragma once
 
-/* Use I2C rather than serial communicaiton to reduce latency. */
-#define USE_I2C
+/*
+ * I2C seems to randomly drop keystrokes. Not sure why. It seems a bit like
+ * https://github.com/qmk/qmk_firmware/issues/5037, but that issue is closed,
+ * and our problems happen even with underglow disabled.
+ *
+ * This issue occurs with multiple TRRS cables of different lengths from
+ * different companies, so it's most likely not a cable issue.  It may be that
+ * we are running into issues with long I2C runs, in which case stronger
+ * pull-up resistors might help:
+ * https://hackaday.com/2017/02/08/taking-the-leap-off-board-an-introduction-to-i2c-over-long-wires/.
+ * For now, just don't use I2C.
+ */
+#define USE_SERIAL
 
 /* Turn off RGB lighting when the host goes to sleep. */
 #define RGBLIGHT_SLEEP

--- a/keyboards/keebio/quefrency/keymaps/bcat/keymap.c
+++ b/keyboards/keebio/quefrency/keymaps/bcat/keymap.c
@@ -25,7 +25,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Function layer: http://www.keyboard-layout-editor.com/#/gists/59636898946da51f91fb290f8e078b4d */
     [LAYER_FUNCTION] = LAYOUT_65(
         _______,  KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   KC_INS,   KC_DEL,   RGB_HUI,
-        _______,  KC_MPLY,  KC_VOLU,  KC_MSTP,  _______,  _______,  EEP_RST,  _______,  KC_PSCR,  KC_SLCK,  KC_PAUS,  _______,  _______,  _______,  RGB_SAI,
+        _______,  KC_MPLY,  KC_VOLU,  KC_MSTP,  _______,  _______,  _______,  _______,  KC_PSCR,  KC_SLCK,  KC_PAUS,  _______,  _______,  _______,  RGB_SAI,
         KC_CAPS,  KC_MPRV,  KC_VOLD,  KC_MNXT,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  RGB_TOG,  RGB_SAD,
         _______,  _______,  KC_MUTE,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  RGB_VAI,  RGB_HUD,
         _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  RGB_RMOD, RGB_VAD,  RGB_MOD

--- a/keyboards/keebio/quefrency/keymaps/bcat/readme.md
+++ b/keyboards/keebio/quefrency/keymaps/bcat/readme.md
@@ -10,7 +10,7 @@ cluster, and mouse keys on their own layer centered around the arrow cluster.
 
 ## Function layer
 
-![Function layer layout](https://i.imgur.com/ISklbfF.png)
+![Function layer layout](https://i.imgur.com/4R1F72M.png)
 
 ## Mouse layer
 

--- a/keyboards/keebio/quefrency/keymaps/bcat/rules.mk
+++ b/keyboards/keebio/quefrency/keymaps/bcat/rules.mk
@@ -1,3 +1,1 @@
 BOOTLOADER = atmel-dfu  # Elite-C
-
-MOUSEKEY_ENABLE = yes

--- a/users/bcat/config.h
+++ b/users/bcat/config.h
@@ -1,0 +1,31 @@
+/* Turn off RGB lighting when the host goes to sleep. */
+#define RGBLIGHT_SLEEP
+
+/* Keep backlight and RGB level increments consistent across keyboards. */
+#undef BACKLIGHT_LEVELS
+#undef RGBLIGHT_HUE_STEP
+#undef RGBLIGHT_SAT_STEP
+#undef RGBLIGHT_VAL_STEP
+
+#define BACKLIGHT_LEVELS 7
+#define RGVLIGHT_HUE_STEP 8
+#define RGVLIGHT_SAT_STEP 17
+#define RGVLIGHT_VAL_STEP 17
+
+/* Make mouse operation smoother. */
+#undef MOUSEKEY_DELAY
+#undef MOUSEKEY_INTERVAL
+
+#define MOUSEKEY_DELAY 0
+#define MOUSEKEY_INTERVAL 16
+
+/* Lower mouse speed to adjust for reduced MOUSEKEY_INTERVAL. */
+#undef MOUSEKEY_MAX_SPEED
+#undef MOUSEKEY_TIME_TO_MAX
+#undef MOUSEKEY_WHEEL_MAX_SPEED
+#undef MOUSEKEY_WHEEL_TIME_TO_MAX
+
+#define MOUSEKEY_MAX_SPEED 7
+#define MOUSEKEY_TIME_TO_MAX 150
+#define MOUSEKEY_WHEEL_MAX_SPEED 3
+#define MOUSEKEY_WHEEL_TIME_TO_MAX 150

--- a/users/bcat/rules.mk
+++ b/users/bcat/rules.mk
@@ -1,0 +1,11 @@
+# Enable Bootmagic Lite to consistently reset to bootloader and clear EEPROM.
+BOOTMAGIC_ENABLE = lite
+
+# Enable mouse and media keys on all keyboards.
+MOUSEKEY_ENABLE = yes
+EXTRAKEY_ENABLE = yes
+
+# Disable some unwanted features on all keyboards.
+CONSOLE_ENABLE = no
+COMMAND_ENABLE = no
+NKRO_ENABLE = no


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I've been having lots of trouble with I2C for my Quefrency. Thought it was a bad cable, but I've tried several and still get dropped/reordered characters. It could still be a hardware problem on my end, but from a quick glance at Reddit and the Keebio Discord, it seems several other folks have had the same issue. My Quefrency is my daily driver at work, so I don't have a ton of cycles to debug it right now. Therefore, I'm switching back to serial in the meantime. (Seems more than fast enough for me in practice, given my typing speed.)

I'm also factoring some common stuff into a userspace since I just found out that was a thing.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [X] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
