### PR TITLE
Fix up Debouncing in AVR Templates

### DIFF
--- a/quantum/template/avr/config.h
+++ b/quantum/template/avr/config.h
@@ -86,7 +86,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // #endif
 
 /* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
-#define DEBOUNCING_DELAY 5
+#define DEBOUNCE 5
 
 /* define if matrix has ghost (lacks anti-ghosting diodes) */
 //#define MATRIX_HAS_GHOST

--- a/quantum/template/ps2avrgb/config.h
+++ b/quantum/template/ps2avrgb/config.h
@@ -37,7 +37,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define UNUSED_PINS     {}
 
 #define DIODE_DIRECTION COL2ROW
-#define DEBOUNCING_DELAY 5
+#define DEBOUNCE 5
 
 #define NO_BACKLIGHT_CLOCK
 #define BACKLIGHT_LEVELS 1


### PR DESCRIPTION
## Description

`DEBOUNCING_DELAY ` no longer exists, and instead, `DEBOUNCE` is what is used. 

This changes the template to properly reflect this. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Enhancement/optimization
