### PR TITLE
Fix layout comment

### DIFF
--- a/keyboards/tada68/keymaps/iso-nor/keymap.c
+++ b/keyboards/tada68/keymaps/iso-nor/keymap.c
@@ -14,7 +14,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    * |----------------------------------------------------------------|
    * |Shif| <>|  Z|  X|  C|  V|  B|  N|  M|  ,|  .|  -| Shift| Up|PgDn|
    * |----------------------------------------------------------------|
-   * |Ctrl|Alt |Cmd |        Space          |Alt| FN|Ctrl|Lef|Dow|Rig |
+   * |Ctrl|Win |Alt |        Space          |Alt| FN|Ctrl|Lef|Dow|Rig |
    * `----------------------------------------------------------------'
    */
   [_BL] = LAYOUT_iso(


### PR DESCRIPTION
Swap the "Cmd" and "Alt" keys in the comment to reflect the actual layout.

Also change "Cmd" to "Win" for consistency with the default keymap.