### PR TITLE
adds spacetime keyboard

### DIFF
--- a/keyboards/spacetime/config.h
+++ b/keyboards/spacetime/config.h
@@ -81,7 +81,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // #endif
 
 /* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
-#define DEBOUNCING_DELAY 5
+#define DEBOUNCE 5
 
 /* define if matrix has ghost (lacks anti-ghosting diodes) */
 //#define MATRIX_HAS_GHOST

--- a/keyboards/spacetime/config.h
+++ b/keyboards/spacetime/config.h
@@ -1,0 +1,245 @@
+/*
+Copyright 2019 Kyle Terry
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "config_common.h"
+
+/* USB Device descriptor parameter */
+#define VENDOR_ID       0xFEED
+#define PRODUCT_ID      0x0A0C
+#define DEVICE_VER      0x4A1F
+#define MANUFACTURER    Kyle Terry
+#define PRODUCT         spacetime
+#define DESCRIPTION     A split ortho keyboard with a 30 degree thumb cluster and support for oled
+
+/* key matrix size */
+#define MATRIX_ROWS 4*2
+#define MATRIX_COLS 7
+
+/*
+ * Keyboard Matrix Assignments
+ *
+ * Change this to how you wired your keyboard
+ * COLS: AVR pins used for columns, left to right
+ * ROWS: AVR pins used for rows, top to bottom
+ * DIODE_DIRECTION: COL2ROW = COL = Anode (+), ROW = Cathode (-, marked on diode)
+ *                  ROW2COL = ROW = Anode (+), COL = Cathode (-, marked on diode)
+ *
+*/
+#define MATRIX_ROW_PINS { D4, C6, D7, E6 }
+#define MATRIX_COL_PINS { F4, F5, F6, F7, B1, B3, B2 }
+#define UNUSED_PINS
+
+/* COL2ROW, ROW2COL*/
+#define DIODE_DIRECTION COL2ROW
+
+/*
+ * Split Keyboard specific options, make sure you have 'SPLIT_KEYBOARD = yes' in your rules.mk, and define SOFT_SERIAL_PIN.
+ */
+#define SOFT_SERIAL_PIN D0 // or D1, D2, D3, E6
+#define USE_SERIAL
+
+// #define BACKLIGHT_PIN B7
+// #define BACKLIGHT_BREATHING
+// #define BACKLIGHT_LEVELS 3
+
+// #define RGB_DI_PIN E2
+// #ifdef RGB_DI_PIN
+//   #define RGBLED_NUM 16
+//   #define RGBLIGHT_HUE_STEP 8
+//   #define RGBLIGHT_SAT_STEP 8
+//   #define RGBLIGHT_VAL_STEP 8
+//   #define RGBLIGHT_LIMIT_VAL 255 /* The maximum brightness level */
+//   #define RGBLIGHT_SLEEP  /* If defined, the RGB lighting will be switched off when the host goes to sleep */
+// /*== all animations enable ==*/
+//   #define RGBLIGHT_ANIMATIONS
+// /*== or choose animations ==*/
+//   #define RGBLIGHT_EFFECT_BREATHING
+//   #define RGBLIGHT_EFFECT_RAINBOW_MOOD
+//   #define RGBLIGHT_EFFECT_RAINBOW_SWIRL
+//   #define RGBLIGHT_EFFECT_SNAKE
+//   #define RGBLIGHT_EFFECT_KNIGHT
+//   #define RGBLIGHT_EFFECT_CHRISTMAS
+//   #define RGBLIGHT_EFFECT_STATIC_GRADIENT
+//   #define RGBLIGHT_EFFECT_RGB_TEST
+//   #define RGBLIGHT_EFFECT_ALTERNATING
+// #endif
+
+/* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
+#define DEBOUNCING_DELAY 5
+
+/* define if matrix has ghost (lacks anti-ghosting diodes) */
+//#define MATRIX_HAS_GHOST
+
+/* number of backlight levels */
+
+/* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
+#define LOCKING_SUPPORT_ENABLE
+/* Locking resynchronize hack */
+#define LOCKING_RESYNC_ENABLE
+
+/* If defined, GRAVE_ESC will always act as ESC when CTRL is held.
+ * This is userful for the Windows task manager shortcut (ctrl+shift+esc).
+ */
+// #define GRAVE_ESC_CTRL_OVERRIDE
+
+/*
+ * Force NKRO
+ *
+ * Force NKRO (nKey Rollover) to be enabled by default, regardless of the saved
+ * state in the bootmagic EEPROM settings. (Note that NKRO must be enabled in the
+ * makefile for this to work.)
+ *
+ * If forced on, NKRO can be disabled via magic key (default = LShift+RShift+N)
+ * until the next keyboard reset.
+ *
+ * NKRO may prevent your keystrokes from being detected in the BIOS, but it is
+ * fully operational during normal computer usage.
+ *
+ * For a less heavy-handed approach, enable NKRO via magic key (LShift+RShift+N)
+ * or via bootmagic (hold SPACE+N while plugging in the keyboard). Once set by
+ * bootmagic, NKRO mode will always be enabled until it is toggled again during a
+ * power-up.
+ *
+ */
+//#define FORCE_NKRO
+
+/*
+ * Magic Key Options
+ *
+ * Magic keys are hotkey commands that allow control over firmware functions of
+ * the keyboard. They are best used in combination with the HID Listen program,
+ * found here: https://www.pjrc.com/teensy/hid_listen.html
+ *
+ * The options below allow the magic key functionality to be changed. This is
+ * useful if your keyboard/keypad is missing keys and you want magic key support.
+ *
+ */
+
+/* key combination for magic key command */
+/* defined by default; to change, uncomment and set to the combination you want */
+// #define IS_COMMAND() (get_mods() == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT)))
+
+/* control how magic key switches layers */
+//#define MAGIC_KEY_SWITCH_LAYER_WITH_FKEYS  true
+//#define MAGIC_KEY_SWITCH_LAYER_WITH_NKEYS  true
+//#define MAGIC_KEY_SWITCH_LAYER_WITH_CUSTOM false
+
+/* override magic key keymap */
+//#define MAGIC_KEY_SWITCH_LAYER_WITH_FKEYS
+//#define MAGIC_KEY_SWITCH_LAYER_WITH_NKEYS
+//#define MAGIC_KEY_SWITCH_LAYER_WITH_CUSTOM
+//#define MAGIC_KEY_HELP1          H
+//#define MAGIC_KEY_HELP2          SLASH
+//#define MAGIC_KEY_DEBUG          D
+//#define MAGIC_KEY_DEBUG_MATRIX   X
+//#define MAGIC_KEY_DEBUG_KBD      K
+//#define MAGIC_KEY_DEBUG_MOUSE    M
+//#define MAGIC_KEY_VERSION        V
+//#define MAGIC_KEY_STATUS         S
+//#define MAGIC_KEY_CONSOLE        C
+//#define MAGIC_KEY_LAYER0_ALT1    ESC
+//#define MAGIC_KEY_LAYER0_ALT2    GRAVE
+//#define MAGIC_KEY_LAYER0         0
+//#define MAGIC_KEY_LAYER1         1
+//#define MAGIC_KEY_LAYER2         2
+//#define MAGIC_KEY_LAYER3         3
+//#define MAGIC_KEY_LAYER4         4
+//#define MAGIC_KEY_LAYER5         5
+//#define MAGIC_KEY_LAYER6         6
+//#define MAGIC_KEY_LAYER7         7
+//#define MAGIC_KEY_LAYER8         8
+//#define MAGIC_KEY_LAYER9         9
+//#define MAGIC_KEY_BOOTLOADER     PAUSE
+//#define MAGIC_KEY_LOCK           CAPS
+//#define MAGIC_KEY_EEPROM         E
+//#define MAGIC_KEY_NKRO           N
+//#define MAGIC_KEY_SLEEP_LED      Z
+
+/*
+ * Feature disable options
+ *  These options are also useful to firmware size reduction.
+ */
+
+/* disable debug print */
+//#define NO_DEBUG
+
+/* disable print */
+//#define NO_PRINT
+
+/* disable action features */
+//#define NO_ACTION_LAYER
+//#define NO_ACTION_TAPPING
+//#define NO_ACTION_ONESHOT
+//#define NO_ACTION_MACRO
+//#define NO_ACTION_FUNCTION
+
+/*
+ * MIDI options
+ */
+
+/* Prevent use of disabled MIDI features in the keymap */
+//#define MIDI_ENABLE_STRICT 1
+
+/* enable basic MIDI features:
+   - MIDI notes can be sent when in Music mode is on
+*/
+//#define MIDI_BASIC
+
+/* enable advanced MIDI features:
+   - MIDI notes can be added to the keymap
+   - Octave shift and transpose
+   - Virtual sustain, portamento, and modulation wheel
+   - etc.
+*/
+//#define MIDI_ADVANCED
+
+/* override number of MIDI tone keycodes (each octave adds 12 keycodes and allocates 12 bytes) */
+//#define MIDI_TONE_KEYCODE_OCTAVES 1
+
+/*
+ * HD44780 LCD Display Configuration
+ */
+/*
+#define LCD_LINES           2     //< number of visible lines of the display
+#define LCD_DISP_LENGTH    16     //< visibles characters per line of the display
+
+#define LCD_IO_MODE      1            //< 0: memory mapped mode, 1: IO port mode
+
+#if LCD_IO_MODE
+#define LCD_PORT         PORTB        //< port for the LCD lines
+#define LCD_DATA0_PORT   LCD_PORT     //< port for 4bit data bit 0
+#define LCD_DATA1_PORT   LCD_PORT     //< port for 4bit data bit 1
+#define LCD_DATA2_PORT   LCD_PORT     //< port for 4bit data bit 2
+#define LCD_DATA3_PORT   LCD_PORT     //< port for 4bit data bit 3
+#define LCD_DATA0_PIN    4            //< pin for 4bit data bit 0
+#define LCD_DATA1_PIN    5            //< pin for 4bit data bit 1
+#define LCD_DATA2_PIN    6            //< pin for 4bit data bit 2
+#define LCD_DATA3_PIN    7            //< pin for 4bit data bit 3
+#define LCD_RS_PORT      LCD_PORT     //< port for RS line
+#define LCD_RS_PIN       3            //< pin  for RS line
+#define LCD_RW_PORT      LCD_PORT     //< port for RW line
+#define LCD_RW_PIN       2            //< pin  for RW line
+#define LCD_E_PORT       LCD_PORT     //< port for Enable line
+#define LCD_E_PIN        1            //< pin  for Enable line
+#endif
+*/
+
+/* Bootmagic Lite key configuration */
+// #define BOOTMAGIC_LITE_ROW 0
+// #define BOOTMAGIC_LITE_COLUMN 0

--- a/keyboards/spacetime/info.json
+++ b/keyboards/spacetime/info.json
@@ -1,0 +1,68 @@
+{
+  "keyboard_name": "spacetime",
+  "url": "https://github.com/kyleterry/spacetime-keyboard",
+  "maintainer": "qmk",
+  "width": 14,
+  "height": 4,
+  "layouts": {
+    "LAYOUT": {
+      "key_count": 50,
+      "layout": [
+          {"label":"L00", "x":0, "y":0},
+          {"label":"L01", "x":1, "y":0},
+          {"label":"L02", "x":2, "y":0},
+          {"label":"L03", "x":3, "y":0},
+          {"label":"L04", "x":4, "y":0},
+          {"label":"L05", "x":5, "y":0},
+          {"label":"L06", "x":6, "y":0},
+          {"label":"R00", "x":7, "y":0},
+          {"label":"R01", "x":8, "y":0},
+          {"label":"R02", "x":9, "y":0},
+          {"label":"R03", "x":10, "y":0},
+          {"label":"R04", "x":11, "y":0},
+          {"label":"R05", "x":12, "y":0},
+          {"label":"R06", "x":13, "y":0},
+
+          {"label":"L10", "x":0, "y":1},
+          {"label":"L11", "x":1, "y":1},
+          {"label":"L12", "x":2, "y":1},
+          {"label":"L13", "x":3, "y":1},
+          {"label":"L14", "x":4, "y":1},
+          {"label":"L15", "x":5, "y":1},
+          {"label":"L16", "x":6, "y":1},
+          {"label":"R10", "x":7, "y":1},
+          {"label":"R11", "x":8, "y":1},
+          {"label":"R12", "x":9, "y":1},
+          {"label":"R13", "x":10, "y":1},
+          {"label":"R14", "x":11, "y":1},
+          {"label":"R15", "x":12, "y":1},
+          {"label":"R16", "x":13, "y":1},
+
+          {"label":"L20", "x":0, "y":2},
+          {"label":"L21", "x":1, "y":2},
+          {"label":"L22", "x":2, "y":2},
+          {"label":"L23", "x":3, "y":2},
+          {"label":"L24", "x":4, "y":2},
+          {"label":"L25", "x":5, "y":2},
+          {"label":"L26", "x":6, "y":2},
+          {"label":"R20", "x":7, "y":2},
+          {"label":"R21", "x":8, "y":2},
+          {"label":"R22", "x":9, "y":2},
+          {"label":"R23", "x":10, "y":2},
+          {"label":"R24", "x":11, "y":2},
+          {"label":"R25", "x":12, "y":2},
+          {"label":"R26", "x":13, "y":2},
+ 
+          {"label":"L30", "x":0, "y":3, "w":1},
+          {"label":"L34", "x":4, "y":3, "w":1},
+          {"label":"L35", "x":5, "y":3, "w":2},
+          {"label":"L36", "x":6, "y":3, "w":2},
+          {"label":"R30", "x":7, "y":3, "w":2},
+          {"label":"R31", "x":8, "y":3, "w":2},
+          {"label":"R32", "x":9, "y":3, "w":1},
+          {"label":"R36", "x":13, "y":3, "w":1}
+      ]
+    }
+  }
+}
+  

--- a/keyboards/spacetime/keymaps/default/config.h
+++ b/keyboards/spacetime/keymaps/default/config.h
@@ -1,0 +1,19 @@
+/* Copyright 2019 Kyle Terry
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// place overrides here

--- a/keyboards/spacetime/keymaps/default/keymap.c
+++ b/keyboards/spacetime/keymaps/default/keymap.c
@@ -1,0 +1,85 @@
+/* Copyright 2019 Kyle Terry
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include QMK_KEYBOARD_H
+
+#define LOWER MO(_LOWER)
+#define RAISE MO(_RAISE)
+
+enum layers {
+  _QWERTY,
+  _LOWER,
+  _RAISE,
+  _ADJUST
+};
+
+/*  layer template:
+ *  [_LAYER] = LAYOUT(
+ *    _______, _______, _______, _______, _______, _______, _______,   _______, _______, _______, _______, _______, _______, _______, \
+ *    _______, _______, _______, _______, _______, _______, _______,   _______, _______, _______, _______, _______, _______, _______, \
+ *    _______, _______, _______, _______, _______, _______, _______,   _______, _______, _______, _______, _______, _______, _______, \
+ *        _______,                        _______, _______, _______,   _______, _______, _______,                        _______
+ *  ),
+ */
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  [_QWERTY] = LAYOUT(
+    KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,   KC_LCTL,    KC_RCTL, KC_Y,    KC_U,   KC_I,    KC_O,     KC_P,    KC_BSPC,
+    KC_ESC,  KC_A,    KC_S,    KC_D,    KC_F,    KC_G,   KC_LALT,    KC_RALT, KC_H,    KC_J,   KC_K,    KC_L,     KC_SCLN, KC_QUOT,
+    KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,   KC_LGUI,    KC_APP,  KC_N,    KC_M,   KC_COMM, KC_DOT,   KC_SLSH, KC_ENT,
+        KC_LCTL,                        KC_LGUI, KC_SPC, LOWER,      RAISE,   KC_SPC,  KC_RGUI,                        KC_RCTL
+  ),
+
+  [_LOWER] = LAYOUT(
+    KC_TILD, KC_EXLM, KC_AT,   KC_HASH, KC_DLR,  KC_PERC, _______,   _______, KC_CIRC, KC_AMPR, KC_ASTR, KC_LPRN, KC_RPRN, KC_DEL,
+    _______, _______, _______, _______, _______, _______, _______,   _______, _______, KC_UNDS, KC_PLUS, KC_LCBR, KC_RCBR, KC_PIPE,
+    _______, _______, _______, _______, _______, _______, _______,   _______, _______, _______, _______, _______, KC_MPLY, KC_MNXT,
+        _______,                        _______, _______, _______,   _______, _______, _______,                        _______
+  ),
+
+  [_RAISE] = LAYOUT(
+    KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    _______,   _______, KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_DEL,
+    _______, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,     _______, _______, KC_MINS, KC_EQL,  KC_LBRC, KC_RBRC, KC_BSLS,
+    _______, KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,    _______, _______, _______, _______, _______, KC_VOLD, KC_VOLU,
+        _______,                        _______, _______, _______,   _______, _______, _______,                        _______
+  ),
+
+  [_ADJUST] = LAYOUT(
+    _______, _______, KC_PGUP, _______, _______, _______, _______,   _______, _______, _______, KC_INS,  _______, KC_PSCR, _______,
+    _______, KC_HOME, KC_PGDN, KC_END,  _______, _______, _______,   _______, KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT, _______, _______,
+    _______, _______, _______, _______, _______, _______, _______,   _______, _______, _______, _______, _______, _______, _______,
+        _______,                        _______, _______, _______,   _______, _______, _______,                        _______
+  )
+};
+
+uint32_t layer_state_set_user(uint32_t state) {
+  return update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
+}
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  return true;
+}
+
+void matrix_init_user(void) {
+
+}
+
+void matrix_scan_user(void) {
+
+}
+
+void led_set_user(uint8_t usb_led) {
+
+}

--- a/keyboards/spacetime/keymaps/default/readme.md
+++ b/keyboards/spacetime/keymaps/default/readme.md
@@ -1,0 +1,1 @@
+# Spacetime Default Keymap

--- a/keyboards/spacetime/keymaps/kyleterry/keymap.c
+++ b/keyboards/spacetime/keymaps/kyleterry/keymap.c
@@ -55,14 +55,14 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,   KC_LCTL,    TD(TD_C),KC_Y,    KC_U,   KC_I,    KC_O,     KC_P,    KC_BSPC,
     CTL_ESC, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,   KC_LALT,    KC_ENT,  KC_H,    KC_J,   KC_K,    KC_L,     KC_SCLN, KC_QUOT,
     KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,   NUM,        OS_LGUI, KC_N,    KC_M,   KC_COMM, KC_DOT,   KC_SLSH, KC_RSFT,
-        KC_LCTL,                        OS_LGUI, KC_SPC, LOWER,      RAISE,   KC_SPC,  OS_LGUI,                        KC_RCTL
+        KC_LCTL,                        OS_LGUI, KC_SPC, LOWER,      RAISE,   KC_SPC,  OS_LGUI,                        KC_RALT
   ),
 
   [_GAMING] = LAYOUT(
     KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,   KC_LCTL,    TD(TD_C),KC_Y,    KC_U,   KC_I,    KC_O,     KC_P,    KC_BSPC,
     KC_LCTL, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,   KC_ESC,     KC_ENT,  KC_H,    KC_J,   KC_K,    KC_L,     KC_SCLN, KC_QUOT,
     KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,   NUM,        OS_LGUI, KC_N,    KC_M,   KC_COMM, KC_DOT,   KC_SLSH, KC_RSFT,
-        KC_LALT,                        KC_V,    KC_SPC, LOWER,      RAISE,   KC_SPC,  OS_LGUI,                        KC_RCTL
+        KC_LALT,                        KC_V,    KC_SPC, LOWER,      RAISE,   KC_SPC,  OS_LGUI,                        KC_RALT
   ),
 
   [_LOWER] = LAYOUT(
@@ -89,7 +89,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   [_NUM] = LAYOUT(
     _______, _______, _______, _______, _______, _______, _______,   _______, _______, _______, KC_7,    KC_8,    KC_9,    KC_ASTR,
     _______, _______, _______, _______, _______, _______, _______,   _______, _______, _______, KC_4,    KC_5,    KC_6,    KC_MINS,
-    _______, _______, _______, _______, _______, _______, _______,   _______, _______, _______, KC_1,    KC_2,    KC_3,    KC_PLUS,
+    _______, _______, _______, _______, _______, _______, _______,   _______, _______, KC_DOT,  KC_1,    KC_2,    KC_3,    KC_PLUS,
         _______,                        _______, _______, _______,   _______, _______, _______,                        KC_0
   )
 };

--- a/keyboards/spacetime/keymaps/kyleterry/keymap.c
+++ b/keyboards/spacetime/keymaps/kyleterry/keymap.c
@@ -1,0 +1,168 @@
+/* Copyright 2019 Kyle Terry
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include QMK_KEYBOARD_H
+
+#define LOWER       MO(_LOWER)
+#define RAISE       MO(_RAISE)
+#define NUM         MO(_NUM)
+#define CTL_ESC     CTL_T(KC_ESC)
+#define OS_LGUI     OSM (MOD_LGUI)
+#define SGAME       TO(_GAMING)
+#define SQWER       TO(_QWERTY)
+
+enum layers {
+  _QWERTY,
+  _GAMING,
+  _LOWER,
+  _RAISE,
+  _ADJUST,
+  _NUM
+};
+
+enum {
+  /* tap dance for raise and lower layer switching */
+  TD_RL = 0,
+  /* tap dance for common cording */
+  TD_C  = 1,
+  /* tap dance for media keys */
+  TD_MD = 2,
+};
+
+/*  layer template:
+ *  [_LAYER] = LAYOUT(
+ *    _______, _______, _______, _______, _______, _______, _______,   _______, _______, _______, _______, _______, _______, _______,
+ *    _______, _______, _______, _______, _______, _______, _______,   _______, _______, _______, _______, _______, _______, _______,
+ *    _______, _______, _______, _______, _______, _______, _______,   _______, _______, _______, _______, _______, _______, _______,
+ *        _______,                        _______, _______, _______,   _______, _______, _______,                        _______
+ *  ),
+ */
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  [_QWERTY] = LAYOUT(
+    KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,   KC_LCTL,    TD(TD_C),KC_Y,    KC_U,   KC_I,    KC_O,     KC_P,    KC_BSPC,
+    CTL_ESC, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,   KC_LALT,    KC_ENT,  KC_H,    KC_J,   KC_K,    KC_L,     KC_SCLN, KC_QUOT,
+    KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,   NUM,        OS_LGUI, KC_N,    KC_M,   KC_COMM, KC_DOT,   KC_SLSH, KC_RSFT,
+        KC_LCTL,                        OS_LGUI, KC_SPC, LOWER,      RAISE,   KC_SPC,  OS_LGUI,                        KC_RCTL
+  ),
+
+  [_GAMING] = LAYOUT(
+    KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,   KC_LCTL,    TD(TD_C),KC_Y,    KC_U,   KC_I,    KC_O,     KC_P,    KC_BSPC,
+    KC_LCTL, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,   KC_ESC,     KC_ENT,  KC_H,    KC_J,   KC_K,    KC_L,     KC_SCLN, KC_QUOT,
+    KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,   NUM,        OS_LGUI, KC_N,    KC_M,   KC_COMM, KC_DOT,   KC_SLSH, KC_RSFT,
+        KC_LALT,                        KC_V,    KC_SPC, LOWER,      RAISE,   KC_SPC,  OS_LGUI,                        KC_RCTL
+  ),
+
+  [_LOWER] = LAYOUT(
+    KC_TILD, KC_EXLM, KC_AT,   KC_HASH, KC_DLR,  KC_PERC, KC_LPRN,   KC_RPRN, KC_CIRC, KC_AMPR, KC_ASTR, KC_LPRN, KC_RPRN, KC_DEL,
+    _______, _______, _______, _______, _______, _______, KC_LBRC,   KC_RBRC, _______, KC_UNDS, KC_PLUS, KC_LCBR, KC_RCBR, KC_PIPE,
+    _______, _______, _______, _______, _______, _______, KC_LCBR,   KC_RCBR, _______, _______, _______, _______, TD(TD_MD), KC_MNXT,
+        _______,                        _______, _______, _______,   _______, _______, _______,                        _______
+  ),
+
+  [_RAISE] = LAYOUT(
+    KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    _______,   _______, KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_DEL,
+    _______, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,     _______, _______, KC_MINS, KC_EQL,  KC_LBRC, KC_RBRC, KC_BSLS,
+    _______, KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,    _______, _______, _______, _______, _______, KC_VOLD, KC_VOLU,
+        _______,                        _______, _______, _______,   _______, _______, _______,                        _______
+  ),
+
+  [_ADJUST] = LAYOUT(
+    _______, _______, KC_PGUP, _______, _______, _______, SQWER,     _______, _______, _______, KC_INS,  _______, KC_PSCR, _______,
+    _______, KC_HOME, KC_PGDN, KC_END,  _______, _______, SGAME,     _______, KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT, _______, _______,
+    _______, _______, _______, _______, _______, _______, _______,   _______, _______, _______, _______, _______, _______, _______,
+        _______,                        _______, _______, _______,   _______, _______, _______,                        _______
+  ),
+
+  [_NUM] = LAYOUT(
+    _______, _______, _______, _______, _______, _______, _______,   _______, _______, _______, KC_7,    KC_8,    KC_9,    KC_ASTR,
+    _______, _______, _______, _______, _______, _______, _______,   _______, _______, _______, KC_4,    KC_5,    KC_6,    KC_MINS,
+    _______, _______, _______, _______, _______, _______, _______,   _______, _______, _______, KC_1,    KC_2,    KC_3,    KC_PLUS,
+        _______,                        _______, _______, _______,   _______, _______, _______,                        KC_0
+  )
+};
+
+uint32_t layer_state_set_user(uint32_t state) {
+  return update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
+}
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  return true;
+}
+
+void matrix_init_user(void) {
+
+}
+
+void matrix_scan_user(void) {
+
+}
+
+void led_set_user(uint8_t usb_led) {
+
+}
+
+void tap_key(uint16_t keycode) {
+  register_code  (keycode);
+  unregister_code(keycode);
+}
+
+void shift_key(uint16_t keycode) {
+  register_code  (KC_LSFT);
+  tap_key        (keycode);
+  unregister_code(KC_LSFT);
+}
+
+void control_key(uint16_t keycode) {
+  register_code  (KC_LCTL);
+  tap_key        (keycode);
+  unregister_code(KC_LCTL);
+}
+
+void td_common(qk_tap_dance_state_t *state, void *user_data) {
+  switch (state->count) {
+    case 1:
+      /* this case handles ctrl+o which is my tmux prefix
+       */
+      control_key(KC_O);
+      reset_tap_dance(state);
+      break;
+    case 2:
+      /* this case handles shift+insert which is a common way
+       * for me to paste text in linux
+       */
+      shift_key(KC_INS);
+      reset_tap_dance(state);
+      break;
+  }
+}
+
+void td_media(qk_tap_dance_state_t *state, void *user_data) {
+  switch (state->count) {
+    case 1:
+      tap_key(KC_MPLY);
+      reset_tap_dance(state);
+      break;
+    case 2:
+      tap_key(KC_MUTE);
+      reset_tap_dance(state);
+      break;
+  }
+}
+
+qk_tap_dance_action_t tap_dance_actions[] = {
+  [TD_C]  = ACTION_TAP_DANCE_FN(td_common),
+  [TD_MD] = ACTION_TAP_DANCE_FN(td_media),
+};

--- a/keyboards/spacetime/keymaps/kyleterry/keymap.c
+++ b/keyboards/spacetime/keymaps/kyleterry/keymap.c
@@ -114,36 +114,19 @@ void led_set_user(uint8_t usb_led) {
 
 }
 
-void tap_key(uint16_t keycode) {
-  register_code  (keycode);
-  unregister_code(keycode);
-}
-
-void shift_key(uint16_t keycode) {
-  register_code  (KC_LSFT);
-  tap_key        (keycode);
-  unregister_code(KC_LSFT);
-}
-
-void control_key(uint16_t keycode) {
-  register_code  (KC_LCTL);
-  tap_key        (keycode);
-  unregister_code(KC_LCTL);
-}
-
 void td_common(qk_tap_dance_state_t *state, void *user_data) {
   switch (state->count) {
     case 1:
       /* this case handles ctrl+o which is my tmux prefix
        */
-      control_key(KC_O);
+      tap_code16(C(KC_O));
       reset_tap_dance(state);
       break;
     case 2:
       /* this case handles shift+insert which is a common way
        * for me to paste text in linux
        */
-      shift_key(KC_INS);
+      tap_code16(S(KC_INS));
       reset_tap_dance(state);
       break;
   }
@@ -152,11 +135,11 @@ void td_common(qk_tap_dance_state_t *state, void *user_data) {
 void td_media(qk_tap_dance_state_t *state, void *user_data) {
   switch (state->count) {
     case 1:
-      tap_key(KC_MPLY);
+      tap_code16(KC_MPLY);
       reset_tap_dance(state);
       break;
     case 2:
-      tap_key(KC_MUTE);
+      tap_code16(KC_MUTE);
       reset_tap_dance(state);
       break;
   }

--- a/keyboards/spacetime/keymaps/kyleterry/rules.mk
+++ b/keyboards/spacetime/keymaps/kyleterry/rules.mk
@@ -1,0 +1,1 @@
+TAP_DANCE_ENABLE=yes

--- a/keyboards/spacetime/readme.md
+++ b/keyboards/spacetime/readme.md
@@ -1,0 +1,6 @@
+# Spacetime Keyboard
+
+A small split-design ortholinear board with a 30 degree thumb cluster and
+a breakaway palm key on each side.
+
+PCB can be found on [GitHub](https://github.com/kyleterry/spacetime-keyboard)

--- a/keyboards/spacetime/rev1/rev1.c
+++ b/keyboards/spacetime/rev1/rev1.c
@@ -1,0 +1,40 @@
+/* Copyright 2019 Kyle Terry
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "rev1.h"
+
+bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
+  return process_record_user(keycode, record);
+}
+
+void matrix_init_kb(void) {
+	// put your keyboard start-up code here
+	// runs once when the firmware starts up
+
+	matrix_init_user();
+}
+
+void matrix_scan_kb(void) {
+	// put your looping keyboard code here
+	// runs every cycle (a lot)
+
+	matrix_scan_user();
+}
+
+void led_set_kb(uint8_t usb_led) {
+	// put your keyboard LED indicator (ex: Caps Lock LED) toggling code here
+
+	led_set_user(usb_led);
+}

--- a/keyboards/spacetime/rev1/rev1.h
+++ b/keyboards/spacetime/rev1/rev1.h
@@ -1,0 +1,48 @@
+/* Copyright 2019 Kyle Terry
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "quantum.h"
+#define ___ KC_NO
+
+/* This a shortcut to help you visually see your layout.
+ *
+ * The first section contains all of the arguments representing the physical
+ * layout of the board and position of the keys.
+ *
+ * The second converts the arguments into a two-dimensional array which
+ * represents the switch matrix.
+ */
+#define LAYOUT( \
+    L00, L01, L02, L03, L04, L05, L06,     R00, R01, R02, R03, R04, R05, R06, \
+    L10, L11, L12, L13, L14, L15, L16,     R10, R11, R12, R13, R14, R15, R16, \
+    L20, L21, L22, L23, L24, L25, L26,     R20, R21, R22, R23, R24, R25, R26, \
+    L30,                L34, L35, L36,     R30, R31, R32,                R36  \
+) { \
+    { L00, L01, L02, L03, L04, L05, L06 }, \
+    { L10, L11, L12, L13, L14, L15, L16 }, \
+    { L20, L21, L22, L23, L24, L25, L26 }, \
+    { L30, ___, ___, ___, L34, L35, L36 }, \
+\
+    { R06, R05, R04, R03, R02, R01, R00 }, \
+    { R16, R15, R14, R13, R12, R11, R10 }, \
+    { R26, R25, R24, R23, R22, R21, R20 }, \
+    { R36, ___, ___, ___, R32, R31, R30 }  \
+}
+
+#ifdef USE_I2C
+  #error "I2C not Supported"
+#endif

--- a/keyboards/spacetime/rev1/rules.mk
+++ b/keyboards/spacetime/rev1/rules.mk
@@ -1,0 +1,1 @@
+OLED_DRIVER_ENABLE = no

--- a/keyboards/spacetime/rev2/rev2.c
+++ b/keyboards/spacetime/rev2/rev2.c
@@ -1,0 +1,44 @@
+/* Copyright 2019 Kyle Terry
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "rev2.h"
+
+bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
+#ifdef SSD1306OLED
+  return process_record_gfx(keycode,record) && process_record_user(keycode, record);
+#else
+  return process_record_user(keycode, record);
+#endif
+}
+
+void matrix_init_kb(void) {
+	// put your keyboard start-up code here
+	// runs once when the firmware starts up
+
+	matrix_init_user();
+}
+
+void matrix_scan_kb(void) {
+	// put your looping keyboard code here
+	// runs every cycle (a lot)
+
+	matrix_scan_user();
+}
+
+void led_set_kb(uint8_t usb_led) {
+	// put your keyboard LED indicator (ex: Caps Lock LED) toggling code here
+
+	led_set_user(usb_led);
+}

--- a/keyboards/spacetime/rev2/rev2.h
+++ b/keyboards/spacetime/rev2/rev2.h
@@ -1,0 +1,48 @@
+/* Copyright 2019 Kyle Terry
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "quantum.h"
+#define ___ KC_NO
+
+/* This a shortcut to help you visually see your layout.
+ *
+ * The first section contains all of the arguments representing the physical
+ * layout of the board and position of the keys.
+ *
+ * The second converts the arguments into a two-dimensional array which
+ * represents the switch matrix.
+ */
+#define LAYOUT( \
+    L00, L01, L02, L03, L04, L05, L06,     R00, R01, R02, R03, R04, R05, R06, \
+    L10, L11, L12, L13, L14, L15, L16,     R10, R11, R12, R13, R14, R15, R16, \
+    L20, L21, L22, L23, L24, L25, L26,     R20, R21, R22, R23, R24, R25, R26, \
+    L30,                L34, L35, L36,     R30, R31, R32,                R36  \
+) { \
+    { L00, L01, L02, L03, L04, L05, L06 }, \
+    { L10, L11, L12, L13, L14, L15, L16 }, \
+    { L20, L21, L22, L23, L24, L25, L26 }, \
+    { L30, ___, ___, ___, L34, L35, L36 }, \
+\
+    { R06, R05, R04, R03, R02, R01, R00 }, \
+    { R16, R15, R14, R13, R12, R11, R10 }, \
+    { R26, R25, R24, R23, R22, R21, R20 }, \
+    { R36, ___, ___, ___, R32, R31, R30 }  \
+}
+
+#ifdef USE_I2C
+  #error "I2C not Supported"
+#endif

--- a/keyboards/spacetime/rev2/rules.mk
+++ b/keyboards/spacetime/rev2/rules.mk
@@ -1,0 +1,1 @@
+OLED_DRIVER_ENABLE = yes

--- a/keyboards/spacetime/rules.mk
+++ b/keyboards/spacetime/rules.mk
@@ -1,5 +1,4 @@
 # MCU name
-#MCU = at90usb1286
 MCU = atmega32u4
 
 # Processor frequency.

--- a/keyboards/spacetime/rules.mk
+++ b/keyboards/spacetime/rules.mk
@@ -1,0 +1,87 @@
+# MCU name
+#MCU = at90usb1286
+MCU = atmega32u4
+
+# Processor frequency.
+#     This will define a symbol, F_CPU, in all source code files equal to the
+#     processor frequency in Hz. You can then use this symbol in your source code to
+#     calculate timings. Do NOT tack on a 'UL' at the end, this will be done
+#     automatically to create a 32-bit value in your source code.
+#
+#     This will be an integer division of F_USB below, as it is sourced by
+#     F_USB after it has run through any CPU prescalers. Note that this value
+#     does not *change* the processor frequency - it should merely be updated to
+#     reflect the processor speed set externally so that the code can use accurate
+#     software delays.
+F_CPU = 16000000
+
+
+#
+# LUFA specific
+#
+# Target architecture (see library "Board Types" documentation).
+ARCH = AVR8
+
+# Input clock frequency.
+#     This will define a symbol, F_USB, in all source code files equal to the
+#     input clock frequency (before any prescaling is performed) in Hz. This value may
+#     differ from F_CPU if prescaling is used on the latter, and is required as the
+#     raw input clock is fed directly to the PLL sections of the AVR for high speed
+#     clock generation for the USB and other AVR subsections. Do NOT tack on a 'UL'
+#     at the end, this will be done automatically to create a 32-bit value in your
+#     source code.
+#
+#     If no clock division is performed on the input clock inside the AVR (via the
+#     CPU clock adjust registers or the clock division fuses), this will be equal to F_CPU.
+F_USB = $(F_CPU)
+
+# Interrupt driven control endpoint task(+60)
+OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
+
+
+# Bootloader selection
+#   Teensy       halfkay
+#   Pro Micro    caterina
+#   Atmel DFU    atmel-dfu
+#   LUFA DFU     lufa-dfu
+#   QMK DFU      qmk-dfu
+#   atmega32a    bootloadHID
+BOOTLOADER = caterina
+
+
+# If you don't know the bootloader type, then you can specify the
+# Boot Section Size in *bytes* by uncommenting out the OPT_DEFS line
+#   Teensy halfKay      512
+#   Teensy++ halfKay    1024
+#   Atmel DFU loader    4096
+#   LUFA bootloader     4096
+#   USBaspLoader        2048
+# OPT_DEFS += -DBOOTLOADER_SIZE=4096
+
+
+# Build Options
+#   change yes to no to disable
+#
+BOOTMAGIC_ENABLE = no      # Virtual DIP switch configuration(+1000)
+MOUSEKEY_ENABLE = yes       # Mouse keys(+4700)
+EXTRAKEY_ENABLE = yes       # Audio control and System control(+450)
+CONSOLE_ENABLE = yes        # Console for debug(+400)
+COMMAND_ENABLE = no        # Commands for debug and configuration
+# Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
+SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
+# if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+NKRO_ENABLE = no            # USB Nkey Rollover
+BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality on B7 by default
+RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
+MIDI_ENABLE = no            # MIDI support (+2400 to 4200, depending on config)
+UNICODE_ENABLE = no         # Unicode
+BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
+AUDIO_ENABLE = no           # Audio output on port C6
+FAUXCLICKY_ENABLE = no      # Use buzzer to emulate clicky switches
+HD44780_ENABLE = no 		# Enable support for HD44780 based LCDs (+400)
+OLED_DRIVER_ENABLE = no
+
+# Enable generic behavior for split boards
+SPLIT_KEYBOARD = yes
+
+DEFAULT_FOLDER = spacetime/rev1

--- a/keyboards/spacetime/spacetime.c
+++ b/keyboards/spacetime/spacetime.c
@@ -1,0 +1,1 @@
+#include "spacetime.h"

--- a/keyboards/spacetime/spacetime.h
+++ b/keyboards/spacetime/spacetime.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#ifdef KEYBOARD_spacetime_rev1
+    #include "rev1.h"
+#endif
+
+#ifdef KEYBOARD_spacetime_rev2
+    #include "rev2.h"
+#endif
+
+#include "quantum.h"


### PR DESCRIPTION
Adds a split design keyboard called the Spacetime Keyboard

## Description

Includes matrix, rev1, rev2 and 2 layouts.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
