### PR TITLE
Fix breathing always on for soft PWM

### DIFF
--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -80,7 +80,7 @@ This is a C header file that is one of the first things included, and will persi
 * `#define BACKLIGHT_LEVELS 3`
   * number of levels your backlight will have (maximum 15 excluding off)
 * `#define BACKLIGHT_BREATHING`
-  * enables backlight breathing (only works with backlight pins B5, B6 and B7)
+  * enables backlight breathing
 * `#define BREATHING_PERIOD 6`
   * the length of one backlight "breath" in seconds
 * `#define DEBOUNCING_DELAY 5`

--- a/docs/feature_backlight.md
+++ b/docs/feature_backlight.md
@@ -63,11 +63,17 @@ To change the behaviour of the backlighting, `#define` these in your `config.h`:
 |Define               |Default      |Description                                                                                                  |
 |---------------------|-------------|-------------------------------------------------------------------------------------------------------------|
 |`BACKLIGHT_PIN`      |`B7`         |The pin that controls the LEDs. Unless you are designing your own keyboard, you shouldn't need to change this|
-|`BACKLIGHT_PINS`     |*Not defined*|experimental: see below for more information|
+|`BACKLIGHT_PINS`     |*Not defined*|experimental: see below for more information                                                                 |
 |`BACKLIGHT_LEVELS`   |`3`          |The number of brightness levels (maximum 15 excluding off)                                                   |
 |`BACKLIGHT_CAPS_LOCK`|*Not defined*|Enable Caps Lock indicator using backlight (for keyboards without dedicated LED)                             |
-|`BACKLIGHT_BREATHING`|*Not defined*|Enable backlight breathing, if supported                                                          |
+|`BACKLIGHT_BREATHING`|*Not defined*|Enable backlight breathing, if supported                                                                     |
 |`BREATHING_PERIOD`   |`6`          |The length of one backlight "breath" in seconds                                                              |
+|`BACKLIGHT_ON_STATE` |`0`          |The state of the backlight pin when the backlight is "on" - `1` for high, `0` for low                        |
+
+## Backlight On State
+
+Most backlight circuits are driven by an N-channel MOSFET or NPN transistor. This means that to turn the transistor *on* and light the LEDs, you must drive the backlight pin, connected to the gate or base, *low*.
+Sometimes, however, a P-channel MOSFET, or a PNP transistor is used. In this case you must `#define BACKLIGHT_ON_STATE 1`, so that when the transistor is on, the pin is driven *high* instead.
 
 ## Multiple backlight pins
 

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -707,8 +707,9 @@ bool process_record_quantum(keyrecord_t *record) {
 
 #if defined(BACKLIGHT_ENABLE) && defined(BACKLIGHT_BREATHING)
     case BL_BRTG: {
-      if (record->event.pressed)
+      if (record->event.pressed) {
         breathing_toggle();
+      }
       return false;
     }
 #endif
@@ -1138,13 +1139,13 @@ void backlight_off(uint8_t backlight_pin) {
 #define BACKLIGHT_PIN_INIT BACKLIGHT_PINS
 #endif
 
-#define FOR_EACH_LED(x)                             \
+#define FOR_EACH_LED(x) \
   for (uint8_t i = 0; i < BACKLIGHT_LED_COUNT; i++) \
-  {                                                 \
-    uint8_t backlight_pin = backlight_pins[i];      \
+  { \
+    uint8_t backlight_pin = backlight_pins[i]; \
     { \
-      x                         \
-    }                                             \
+      x \
+    } \
   }
 
 static const uint8_t backlight_pins[BACKLIGHT_LED_COUNT] = BACKLIGHT_PIN_INIT;
@@ -1223,7 +1224,9 @@ ISR(TIMERx_COMPA_vect) {
 // this one triggers at F_CPU/65536 =~ 244 Hz
 ISR(TIMERx_OVF_vect) {
 #ifdef BACKLIGHT_BREATHING
-  breathing_task();
+  if(is_breathing()) {
+    breathing_task();
+  }
 #endif
   // for very small values of OCRxx (or backlight level)
   // we can't guarantee this whole code won't execute


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

For backlight systems that don't use a hardware PWM-capable pin, `breathing_task()` is always running! This is because for hardware PWM, `breathing_interrupt_enable()` and `_disable()` modify the `TIMSK` register to control the ISR, whereas the software PWM versions of these macros (they're not functions) set the static bool `breathing`... which is never checked anywhere!

So, before we run `breathing_task()`, we get the green light from `is_breathing()`. I can now control software PWM backlight properly with my test setup - though it is quite flickery at low brightness levels, but I think that is a separate issue.

This *may* (partially) resolve some of the recent issues people have been having with soft backlighting doing weird things. Eg:

#5425, #5953

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
