### PR TITLE
Add Wally flasher support to QMK Firmware

### DIFF
--- a/keyboards/ergodox_ez/readme.md
+++ b/keyboards/ergodox_ez/readme.md
@@ -28,12 +28,18 @@ See also [video demonstration](https://www.youtube.com/watch?v=9PyiGUO9_KQ) usin
 
 To flash with ´teensy-loader-cli´:
 
-  - Build the firmware with `make keymapname`, for example `make default`
-
-  - Run ´<path/to/>teensy_loader_cli -mmcu=atmega32u4 -w ergodox_ez_<keymap>.hex´
+  - Build the firmware with `make <keyboardname>:<keymapname>:teensy`, for example `make ergodox_ez:default:teensy`
 
   - Press the Reset button by inserting a paperclip gently into the reset hole
-    in the top right corder.
+    in the top right corner.
+
+
+To flash with [`Wally-cli`](https://github.com/zsa/wally/releases):
+
+  - Build the firmware with `make <keyboardname>:<keymapname>:wally`, for example `make ergodox_ez:default:wally`
+
+  - Press the Reset button by inserting a paperclip gently into the reset hole
+    in the top right corner.
 
 ## Settings
 

--- a/tmk_core/avr.mk
+++ b/tmk_core/avr.mk
@@ -96,6 +96,8 @@ ifndef TEENSY_LOADER_CLI
     endif
 endif
 
+WALLY_CLI ?= wally-cli
+
 # Generate a .qmk for the QMK-FF
 qmk: $(BUILD_DIR)/$(TARGET).hex
 	zip $(TARGET).qmk -FSrj $(KEYMAP_PATH)/*
@@ -126,6 +128,10 @@ program: $(BUILD_DIR)/$(TARGET).hex $(BUILD_DIR)/$(TARGET).eep check-size
 
 teensy: $(BUILD_DIR)/$(TARGET).hex check-size cpfirmware
 	$(TEENSY_LOADER_CLI) -mmcu=$(MCU) -w -v $(BUILD_DIR)/$(TARGET).hex
+
+
+wally: $(BUILD_DIR)/$(TARGET).hex check-size cpfirmware
+	$(WALLY_CLI) $(BUILD_DIR)/$(TARGET).hex
 
 BATCHISP ?= batchisp
 

--- a/tmk_core/chibios.mk
+++ b/tmk_core/chibios.mk
@@ -211,6 +211,7 @@ EXTRALIBDIRS = $(RULESPATH)/ld
 DFU_UTIL ?= dfu-util
 DFU_SUFFIX ?= dfu-suffix
 ST_LINK_CLI ?= st-link_cli
+WALLY_CLI ?= wally-cli
 
 # Generate a .qmk for the QMK-FF
 qmk: $(BUILD_DIR)/$(TARGET).bin
@@ -238,6 +239,9 @@ qmk: $(BUILD_DIR)/$(TARGET).bin
 
 dfu-util: $(BUILD_DIR)/$(TARGET).bin cpfirmware sizeafter
 	$(DFU_UTIL) $(DFU_ARGS) -D $(BUILD_DIR)/$(TARGET).bin
+
+wally: $(BUILD_DIR)/$(TARGET).bin cpfirmware sizeafter
+	$(WALLY_CLI) $(BUILD_DIR)/$(TARGET).bin
 
 
 ifneq ($(strip $(TIME_DELAY)),)

--- a/util/linux_install.sh
+++ b/util/linux_install.sh
@@ -35,9 +35,10 @@ if grep ID /etc/os-release | grep -qE "fedora"; then
 		wget \
 		zip
     wget `https://github.com/zsa/wally/releases/download/1.0.0/wally-linux.zip`
-    unzip wally-linux.zip -d ~/bin/
+    unzip wally-linux.zip -d /tmp/wally/
     rm -f wally-linux.zip
-    chmod -x ~/bin/wally ~/wally-cli
+    sudo mv /tmp/wally/* /usr/bin/
+    sudo chmod +x /usr/bin/wally /usr/bin/wally-cli
 
 elif grep ID /etc/os-release | grep -qE 'debian|ubuntu'; then
 	DEBIAN_FRONTEND=noninteractive
@@ -64,10 +65,11 @@ elif grep ID /etc/os-release | grep -qE 'debian|ubuntu'; then
 		webkit2gtk-4.0 \
         wget \
 		zip
-    wget `https://github.com/zsa/wally/releases/download/1.0.0/wally-linux.zip`
-    unzip wally-linux.zip -d ~/bin/
+    wget https://github.com/zsa/wally/releases/download/1.0.0/wally-linux.zip
+    unzip wally-linux.zip -d /tmp/wally/
     rm -f wally-linux.zip
-    chmod -x ~/bin/wally ~/wally-cli
+    sudo mv /tmp/wally/* /usr/bin/
+    sudo chmod +x /usr/bin/wally /usr/bin/wally-cli
 
 elif grep ID /etc/os-release | grep -q 'arch\|manjaro'; then
 	sudo pacman -U https://archive.archlinux.org/packages/a/avr-gcc/avr-gcc-8.3.0-1-x86_64.pkg.tar.xz
@@ -95,9 +97,10 @@ elif grep ID /etc/os-release | grep -q 'arch\|manjaro'; then
 	makepkg -sic
 	rm -rf /tmp/dfu-programmer/
     wget `https://github.com/zsa/wally/releases/download/1.0.0/wally-linux.zip`
-    unzip wally-linux.zip -d ~/bin/
+    unzip wally-linux.zip -d /tmp/wally/
     rm -f wally-linux.zip
-    chmod -x ~/bin/wally ~/wally-cli
+    sudo mv /tmp/wally/* /usr/bin/
+    sudo chmod +x /usr/bin/wally /usr/bin/wally-cli
 
 
 elif grep ID /etc/os-release | grep -q gentoo; then
@@ -119,9 +122,10 @@ elif grep ID /etc/os-release | grep -q gentoo; then
 			sys-devel/crossdev
 		sudo crossdev -s4 --stable --g =4.9.4 --portage --verbose --target avr
         wget `https://github.com/zsa/wally/releases/download/1.0.0/wally-linux.zip`
-        unzip wally-linux.zip -d ~/bin/
+        unzip wally-linux.zip -d /tmp/wally/
         rm -f wally-linux.zip
-        chmod -x ~/bin/wally ~/wally-cli
+        sudo mv /tmp/wally/* /usr/bin/
+        sudo chmod +x /usr/bin/wally /usr/bin/wally-cli
 		echo "Done!"
 	else
 		echo "Quitting..."

--- a/util/linux_install.sh
+++ b/util/linux_install.sh
@@ -23,14 +23,21 @@ if grep ID /etc/os-release | grep -qE "fedora"; then
 		git \
 		gcc \
 		glibc-headers \
+        gtk3 \
 		kernel-devel \
 		kernel-headers \
+        libusb \
 		make \
 		perl \
 		python3 \
 		unzip \
+        webkit2gtk3 \
 		wget \
 		zip
+    wget `https://github.com/zsa/wally/releases/download/1.0.0/wally-linux.zip`
+    unzip wally-linux.zip -d ~/bin/
+    rm -f wally-linux.zip
+    chmod -x ~/bin/wally ~/wally-cli
 
 elif grep ID /etc/os-release | grep -qE 'debian|ubuntu'; then
 	DEBIAN_FRONTEND=noninteractive
@@ -49,11 +56,18 @@ elif grep ID /etc/os-release | grep -qE 'debian|ubuntu'; then
 		gcc-arm-none-eabi \
 		gcc-avr \
 		git \
+        gtk+3.0 \
 		libnewlib-arm-none-eabi \
+        libusb-dev \
 		python3 \
 		unzip \
-		wget \
+		webkit2gtk-4.0 \
+        wget \
 		zip
+    wget `https://github.com/zsa/wally/releases/download/1.0.0/wally-linux.zip`
+    unzip wally-linux.zip -d ~/bin/
+    rm -f wally-linux.zip
+    chmod -x ~/bin/wally ~/wally-cli
 
 elif grep ID /etc/os-release | grep -q 'arch\|manjaro'; then
 	sudo pacman -U https://archive.archlinux.org/packages/a/avr-gcc/avr-gcc-8.3.0-1-x86_64.pkg.tar.xz
@@ -69,14 +83,22 @@ elif grep ID /etc/os-release | grep -q 'arch\|manjaro'; then
 		diffutils \
 		gcc \
 		git \
+        gtk3 \
+        libusb \
 		python \
 		unzip \
-		wget \
+		webkit2gtk \
+        wget \
 		zip
 	git clone https://aur.archlinux.org/dfu-programmer.git /tmp/dfu-programmer
 	cd /tmp/dfu-programmer || exit 1
 	makepkg -sic
 	rm -rf /tmp/dfu-programmer/
+    wget `https://github.com/zsa/wally/releases/download/1.0.0/wally-linux.zip`
+    unzip wally-linux.zip -d ~/bin/
+    rm -f wally-linux.zip
+    chmod -x ~/bin/wally ~/wally-cli
+
 
 elif grep ID /etc/os-release | grep -q gentoo; then
 	echo "$GENTOO_WARNING" | fmt
@@ -96,6 +118,10 @@ elif grep ID /etc/os-release | grep -q gentoo; then
 			sys-devel/gcc \
 			sys-devel/crossdev
 		sudo crossdev -s4 --stable --g =4.9.4 --portage --verbose --target avr
+        wget `https://github.com/zsa/wally/releases/download/1.0.0/wally-linux.zip`
+        unzip wally-linux.zip -d ~/bin/
+        rm -f wally-linux.zip
+        chmod -x ~/bin/wally ~/wally-cli
 		echo "Done!"
 	else
 		echo "Quitting..."

--- a/util/macos_install.sh
+++ b/util/macos_install.sh
@@ -26,8 +26,10 @@ brew install avr-gcc@8 gcc-arm-none-eabi dfu-programmer avrdude dfu-util python3
 brew link --force avr-gcc@8
 
 # curl -fsLS https://github.com/zsa/wally/releases/download/1.0.0/wally-osx.dmg
-wget -O /tmp/wally.dmg https://github.com/zsa/wally/releases/download/1.0.0/wally-osx.dmg
-open /tmp/wally.dmg
-sleep 5
+wget -O /tmp/wally.dmg https://github.com/zsa/wally/releases/download/1.0.1-osx/wally-osx-1.0.1.dmg
+hdiutil attach /tmp/wally.dmg
+sleep 3
 cp -R /Volumes/Wally/Wally.app /Volumes/Wally/Applications
-cp /Volumes/Wally/wally-cli /usr/bin/local/
+cp /Volumes/Wally/wally-cli /usr/local/bin/
+hdiutil detach /Volumes/Wally
+rm /tmp/wally.dmg

--- a/util/macos_install.sh
+++ b/util/macos_install.sh
@@ -24,3 +24,10 @@ brew tap PX4/homebrew-px4
 brew update
 brew install avr-gcc@8 gcc-arm-none-eabi dfu-programmer avrdude dfu-util python3
 brew link --force avr-gcc@8
+
+# curl -fsLS https://github.com/zsa/wally/releases/download/1.0.0/wally-osx.dmg
+wget -O /tmp/wally.dmg https://github.com/zsa/wally/releases/download/1.0.0/wally-osx.dmg
+open /tmp/wally.dmg
+sleep 5
+cp -R /Volumes/Wally/Wally.app /Volumes/Wally/Applications
+cp /Volumes/Wally/wally-cli /usr/bin/local/

--- a/util/win_shared_install.sh
+++ b/util/win_shared_install.sh
@@ -18,6 +18,10 @@ function install_utils {
     wget 'https://www.pjrc.com/teensy/teensy_loader_cli_windows.zip'
     unzip teensy_loader_cli_windows.zip
 
+    echo "Extracting Wally...."
+    wget 'https://github.com/zsa/wally/releases/download/1.0.0/wally-win.zip'
+    unzip wally-win.zip
+
     echo "Installing Atmel Flip"
     wget 'http://ww1.microchip.com/downloads/en/DeviceDoc/Flip%20Installer%20-%203.4.7.112.exe'
     mv Flip\ Installer\ \-\ 3.4.7.112.exe FlipInstaller.exe
@@ -33,7 +37,7 @@ function install_utils {
 function install_drivers {
     pushd "$download_dir"
     cp -f "$dir/drivers.txt" .
-    echo 
+    echo
     cmd.exe /c "qmk_driver_installer.exe $1 $2 drivers.txt"
     popd > /dev/null
 }
@@ -77,4 +81,3 @@ done
 
 
 popd > /dev/null
-


### PR DESCRIPTION
## Description

This adds support for ZSA's [`Wally` flashing program](https://github.com/zsa/wally), which allows you to flash the firmware for the Ergodox EZ and Planck EZ. 

## Types of Changes
- [x] New feature
- [x] Enhancement/optimization

## Issues 

- [x] Script for Windows  
- [ ] Script for Linux
   - [x] Ubuntu/Debian Tested
   - [ ] Fedora
   - [ ] Arch/manjaro
   - [ ] gentoo
   - [ ] openSuse
   - [ ] etc 
- [ ] Script for MacOS

Also, the method for installing the binaries is not great on linux, but that's because I'm not very familiar with the OS... but the ubuntu stuff is tested, and does work.

As for the MacOS, I have NO idea how to install that, via script or otherwise.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
