### PR TITLE
Fix TO() and DF() calling layer_state_set_[kb,user] twice

### DIFF
--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -412,7 +412,7 @@ void process_action(keyrecord_t *record, action_t action)
                         case OP_BIT_AND: default_layer_and(bits | mask); break;
                         case OP_BIT_OR:  default_layer_or(bits | mask);  break;
                         case OP_BIT_XOR: default_layer_xor(bits | mask); break;
-                        case OP_BIT_SET: default_layer_and(mask); default_layer_or(bits); break;
+                        case OP_BIT_SET: default_layer_set(bits | mask); break;
                     }
                 }
             } else {
@@ -426,7 +426,7 @@ void process_action(keyrecord_t *record, action_t action)
                         case OP_BIT_AND: layer_and(bits | mask); break;
                         case OP_BIT_OR:  layer_or(bits | mask);  break;
                         case OP_BIT_XOR: layer_xor(bits | mask); break;
-                        case OP_BIT_SET: layer_and(mask); layer_or(bits); break;
+                        case OP_BIT_SET: layer_state_set(bits | mask); break;
                     }
                 }
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

When using `TO()` and `DF()`, `layer_state_set_user()` was observed to be called twice. This was not a keydown/keyup thing - the code first does an `AND`, then an `OR`, which both call `layer_state_set()`, which in turn calls `layer_state_set_kb()`... Instead of doing that, we can directly set the layer state here.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
