### PR TITLE
Pti jc65 v32 a fix rgb backlight disable

### DIFF
--- a/keyboards/jc65/v32a/v32a.c
+++ b/keyboards/jc65/v32a/v32a.c
@@ -29,6 +29,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "i2c.h"
 #include "quantum.h"
 
+#ifdef RGBLIGHT_ENABLE
 extern rgblight_config_t rgblight_config;
 
 void rgblight_set(void) {
@@ -43,12 +44,16 @@ void rgblight_set(void) {
     i2c_init();
     i2c_send(0xb0, (uint8_t*)led, 3 * RGBLED_NUM);
 }
+#endif
 
 __attribute__ ((weak))
 void matrix_scan_user(void) {
-    rgblight_task();
+#ifdef RGBLIGHT_ENABLE
+  rgblight_task();
+#endif
 }
 
+#ifdef BACKLIGHT_ENABLE
 void backlight_init_ports(void) {
 	DDRD |= (1<<0 | 1<<1 | 1<<4 | 1<<6);
 	PORTD &= ~(1<<0 | 1<<1 | 1<<4 | 1<<6);
@@ -63,3 +68,4 @@ void backlight_set(uint8_t level) {
 		PORTD |= (1<<0 | 1<<1 | 1<<4 | 1<<6);
 	}
 }
+#endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

When building a firmware with RGB and Backlight disabled there were compile errors
because the headers are not imported but the code which calls its methods are still
called.

This change adds additional #ifdefs to remove the problematic pieces.


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR



## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
