### PR TITLE
TravisCI - Fix docker permission issues when pushing firmware files to qmk/qmk.fm

### DIFF
--- a/util/travis_build.sh
+++ b/util/travis_build.sh
@@ -3,7 +3,7 @@
 # if docker is installed - call make within the qmk docker image
 if command -v docker >/dev/null; then
   function make() {
-    docker run --rm -e MAKEFLAGS="$MAKEFLAGS" -w /qmk_firmware/ -v "$PWD":/qmk_firmware qmkfm/qmk_firmware make "$@"
+    docker run --rm -e MAKEFLAGS="$MAKEFLAGS" -w /qmk_firmware/ -v "$PWD":/qmk_firmware --user $(id -u):$(id -g) qmkfm/qmk_firmware make "$@"
   }
 fi
 

--- a/util/travis_test.sh
+++ b/util/travis_test.sh
@@ -22,7 +22,7 @@ fi
 # if docker is installed - call make within the qmk docker image
 if command -v docker >/dev/null; then
   function make() {
-    docker run --rm -e MAKEFLAGS="$MAKEFLAGS" -w /qmk_firmware/ -v "$PWD":/qmk_firmware qmkfm/qmk_firmware make "$@"
+    docker run --rm -e MAKEFLAGS="$MAKEFLAGS" -w /qmk_firmware/ -v "$PWD":/qmk_firmware --user $(id -u):$(id -g) qmkfm/qmk_firmware make "$@"
   }
 fi
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Recent builds contain the following failures, after the recent "travis use docker" PR:
```
Warning: Permanently added the RSA host key for IP address '192.30.253.112' to the list of known hosts.
To github.com:qmk/qmk_firmware.git
 * [new tag]             0.6.393 -> 0.6.393
/bin/sh: 1: cannot create .//quantum/version.h: Permission denied
/bin/sh: 1: cannot create .//quantum/version.h: Permission denied
Cloning into 'qmk.fm'...
All identities removed.
Agent pid 1147
Identity added: id_rsa_qmk.fm (id_rsa_qmk.fm)
Removing deprecated binary: ./compiled/adkb96_rev1_default.hex
rm: remove write-protected regular file ‘./compiled/adkb96_rev1_default.hex’? 
```

This is due to running as root within the container. This PR makes it so the travis user is used, it should mimic the old behaviour better.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
