### PR TITLE
Properly reset default layer when resetting EEPROM

### DIFF
--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -293,6 +293,7 @@ bool process_record_quantum(keyrecord_t *record) {
         case EEPROM_RESET:
             if (record->event.pressed) {
                 eeconfig_init();
+                keyboard_init();
             }
             return false;
 #ifdef FAUXCLICKY_ENABLE
@@ -1121,6 +1122,4 @@ void eeconfig_init_kb(void) {
 
 void eeconfig_init_quantum(void) {
     eeconfig_init_kb();
-    // re-initialize everything
-    keyboard_init();
 }

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -1103,3 +1103,24 @@ __attribute__((weak)) void startup_user() {}
 __attribute__((weak)) void shutdown_user() {}
 
 //------------------------------------------------------------------------------
+
+
+__attribute__ ((weak))
+void eeconfig_init_user(void) {
+    // Reset user EEPROM value to blank, rather than to a set value
+    eeconfig_update_user(0);
+}
+
+__attribute__ ((weak))
+void eeconfig_init_kb(void) {
+    // Reset Keyboard EEPROM value to blank, rather than to a set value
+    eeconfig_update_kb(0);
+
+    eeconfig_init_user();
+}
+
+void eeconfig_init_quantum(void) {
+    eeconfig_init_kb();
+    // re-initialize everything
+    keyboard_init();
+}

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -287,3 +287,7 @@ void led_set_user(uint8_t usb_led);
 void led_set_kb(uint8_t usb_led);
 
 void api_send_unicode(uint32_t unicode);
+
+void eeconfig_init_quantum(void);
+void eeconfig_init_kb(void);
+void eeconfig_init_user(void);

--- a/tests/test_common/test_fixture.cpp
+++ b/tests/test_common/test_fixture.cpp
@@ -22,7 +22,7 @@ using testing::Return;
 
 void TestFixture::SetUpTestCase() {
     TestDriver driver;
-    EXPECT_CALL(driver, send_keyboard_mock(_)).Times(AnyNumber());
+    EXPECT_CALL(driver, send_keyboard_mock(_));
     keyboard_init();
 }
 

--- a/tests/test_common/test_fixture.cpp
+++ b/tests/test_common/test_fixture.cpp
@@ -22,7 +22,7 @@ using testing::Return;
 
 void TestFixture::SetUpTestCase() {
     TestDriver driver;
-    EXPECT_CALL(driver, send_keyboard_mock(_));
+    EXPECT_CALL(driver, send_keyboard_mock(_)).Times(AnyNumber());
     keyboard_init();
 }
 

--- a/tmk_core/common/bootmagic.c
+++ b/tmk_core/common/bootmagic.c
@@ -39,6 +39,7 @@ void bootmagic(void) {
     /* eeconfig clear */
     if (bootmagic_scan_keycode(BOOTMAGIC_KEY_EEPROM_CLEAR)) {
         eeconfig_init();
+        matrix_init();
     }
 
     /* bootloader */

--- a/tmk_core/common/eeconfig.c
+++ b/tmk_core/common/eeconfig.c
@@ -2,13 +2,13 @@
 #include <stdbool.h>
 #include "eeprom.h"
 #include "eeconfig.h"
+#include "action_layer.h"
 
 #ifdef STM32_EEPROM_ENABLE
 #    include "hal.h"
 #    include "eeprom_stm32.h"
 #endif
 
-extern uint32_t default_layer_state;
 /** \brief eeconfig enable
  *
  * FIXME: needs doc

--- a/tmk_core/common/eeconfig.c
+++ b/tmk_core/common/eeconfig.c
@@ -49,12 +49,6 @@ void eeconfig_init(void) {
     keyboard_init();
 }
 
-/** \brief eeconfig initialization
- *
- * FIXME: needs doc
- */
-void eeconfig_init(void) { eeconfig_init_quantum(); }
-
 /** \brief eeconfig enable
  *
  * FIXME: needs doc

--- a/tmk_core/common/eeconfig.c
+++ b/tmk_core/common/eeconfig.c
@@ -8,28 +8,13 @@
 #    include "eeprom_stm32.h"
 #endif
 
-void keyboard_init(void);
 
-/** \brief eeconfig enable
- *
- * FIXME: needs doc
- */
-__attribute__((weak)) void eeconfig_init_user(void) {
-    // Reset user EEPROM value to blank, rather than to a set value
-    eeconfig_update_user(0);
-}
-
-__attribute__((weak)) void eeconfig_init_kb(void) {
-    // Reset Keyboard EEPROM value to blank, rather than to a set value
-    eeconfig_update_kb(0);
-
-    eeconfig_init_user();
-}
-
+__attribute__ ((weak))
+void eeconfig_init_quantum(void) {}
 /*
  * FIXME: needs doc
  */
-void eeconfig_init_quantum(void) {
+void eeconfig_init(void) {
 #ifdef STM32_EEPROM_ENABLE
     EEPROM_Erase();
 #endif
@@ -58,7 +43,7 @@ void eeconfig_init_quantum(void) {
     eeprom_update_byte(EECONFIG_HANDEDNESS, 0);
 #endif
 
-    eeconfig_init_kb();
+    eeconfig_init_quantum();
 
     // re-initialize everything
     keyboard_init();

--- a/tmk_core/common/eeconfig.c
+++ b/tmk_core/common/eeconfig.c
@@ -44,9 +44,6 @@ void eeconfig_init(void) {
 #endif
 
     eeconfig_init_quantum();
-
-    // re-initialize everything
-    keyboard_init();
 }
 
 /** \brief eeconfig enable

--- a/tmk_core/common/eeconfig.c
+++ b/tmk_core/common/eeconfig.c
@@ -2,12 +2,13 @@
 #include <stdbool.h>
 #include "eeprom.h"
 #include "eeconfig.h"
-#include "action_layer.h"
 
 #ifdef STM32_EEPROM_ENABLE
 #    include "hal.h"
 #    include "eeprom_stm32.h"
 #endif
+
+void keyboard_init(void);
 
 /** \brief eeconfig enable
  *
@@ -35,7 +36,6 @@ void eeconfig_init_quantum(void) {
     eeprom_update_word(EECONFIG_MAGIC, EECONFIG_MAGIC_NUMBER);
     eeprom_update_byte(EECONFIG_DEBUG, 0);
     eeprom_update_byte(EECONFIG_DEFAULT_LAYER, 0);
-    default_layer_state = 0;
     eeprom_update_byte(EECONFIG_KEYMAP_LOWER_BYTE, 0);
     eeprom_update_byte(EECONFIG_KEYMAP_UPPER_BYTE, 0);
     eeprom_update_byte(EECONFIG_MOUSEKEY_ACCEL, 0);
@@ -59,6 +59,9 @@ void eeconfig_init_quantum(void) {
 #endif
 
     eeconfig_init_kb();
+
+    // re-initialize everything
+    keyboard_init();
 }
 
 /** \brief eeconfig initialization


### PR DESCRIPTION
## Description

When resetting the EEPROM, it should forcibly set the default layer. 

We were doing that by setting it to zero, but that doesn't trigger any of the normal checks.   This fixes that, and calls the proper function

## Types of Changes
- [x] Core
- [x] Bugfix
- [x] Enhancement/optimization

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
