### PR TITLE
Upgrade gcc-arm-none-eabi from the default 5.4.1 to 6.3.1 due to ARM runtime issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     dfu-programmer \
     dfu-util \
     gcc \
-    gcc-arm-none-eabi \
     gcc-avr \
     git \
     libnewlib-arm-none-eabi \
@@ -18,6 +17,10 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     wget \
     zip \
     && rm -rf /var/lib/apt/lists/*
+
+# upgrade gcc-arm-none-eabi from the default 5.4.1 to 6.3.1 due to ARM runtime issues
+RUN wget -q https://developer.arm.com/-/media/Files/downloads/gnu-rm/6-2017q2/gcc-arm-none-eabi-6-2017-q2-update-linux.tar.bz2 -O - | \
+    tar xj --strip-components=1 -C /
 
 VOLUME /qmk_firmware
 WORKDIR /qmk_firmware


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Instant60 is currently having runtime issues with firmware built from both the configurator, and travis (the default firmware published to <https://qmk.fm/keyboards>) .

From Discord, the error was sumarised as:
> Binary doesn't seem to work
> Keyboard doesn't respond to input
> Flashing 6.3.1 built on did

This PR updates the Docker container to use gcc-arm-none-eabi from the default 5.4.1 to 6.3.1, which in turn will be used for travis builds.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
