### PR TITLE
Dimple: fix unintended LED behaviour

### DIFF
--- a/keyboards/lazydesigners/dimple/dimple.c
+++ b/keyboards/lazydesigners/dimple/dimple.c
@@ -22,3 +22,8 @@ void dimple_led_on() {
 void dimple_led_off() {
   DDRE &= ~(1 << 6); PORTE &= ~(1 << 6);
 }
+
+void keyboard_post_init_kb(void) {
+  dimple_led_off();
+  keyboard_post_init_user();
+}

--- a/keyboards/lazydesigners/dimple/dimple.c
+++ b/keyboards/lazydesigners/dimple/dimple.c
@@ -16,14 +16,15 @@
 #include "dimple.h"
 
 void dimple_led_on() {
-  DDRE |= (1 << 6); PORTE &= ~(1 << 6);
+  writePinHigh(E6);
 }
 
 void dimple_led_off() {
-  DDRE &= ~(1 << 6); PORTE &= ~(1 << 6);
+  writePinLow(E6);
 }
 
-void keyboard_post_init_kb(void) {
-  dimple_led_off();
-  keyboard_post_init_user();
+void keyboard_pre_init_kb(void) {
+  // Initialize Caps Lock LED
+  setPinOutput(E6);
+  keyboard_pre_init_user();
 }


### PR DESCRIPTION
The LED was always-on if the custom keymap did not call dimple_led_off()
at least once.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
