### PR TITLE
Fixes compile errors for massdrop keyboards

### DIFF
--- a/tmk_core/protocol/arm_atsam/md_bootloader.h
+++ b/tmk_core/protocol/arm_atsam/md_bootloader.h
@@ -11,7 +11,7 @@ extern uint32_t _erom;
 //WARNING: These are only for CTRL bootloader release "v2.18Jun 22 2018 17:28:08" for bootloader_jump support
 extern uint32_t _eram;
 #define BOOTLOADER_MAGIC 0x3B9ACA00
-#define MAGIC_ADDR (uint32_t *)(&_eram - 4)
+#define MAGIC_ADDR (uint32_t *)((intptr_t)(&_eram) - 4)
 #endif
 
 #ifdef MD_BOOTLOADER
@@ -22,4 +22,3 @@ extern uint32_t _eram;
 #endif //MD_BOOTLOADER
 
 #endif //_MD_BOOTLOADER_H_
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The latest version of arm-none-eabi-gcc fails to compile firmware for massdrop keyboards. This is the fixes suggested in #5958.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #5958

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
