### PR TITLE
Fix issue with Encoder support over Split i2c

### DIFF
--- a/quantum/split_common/transport.c
+++ b/quantum/split_common/transport.c
@@ -74,7 +74,7 @@ bool transport_master(matrix_row_t matrix[]) {
 #  endif
 
 #  ifdef ENCODER_ENABLE
-  i2c_readReg(SLAVE_I2C_ADDRESS, I2C_ENCODER_START, (void *)i2c_buffer->encoder_state, sizeof(I2C_slave_buffer_t.encoder_state), TIMEOUT);
+  i2c_readReg(SLAVE_I2C_ADDRESS, I2C_ENCODER_START, (void *)i2c_buffer->encoder_state, sizeof(i2c_buffer->encoder_state), TIMEOUT);
   encoder_update_raw(i2c_buffer->encoder_state);
 #  endif
 


### PR DESCRIPTION
# Description

As the title. 

Specifically, it seems that you can't get the size of a structure's typedef, but have to use an actual data structure. 

Bug was introduced by @mtei (and appears to be 100% accidental). 

## Types of Changes
- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* Travis CI

## Checklist
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
