### PR TITLE
Fix i2c split encoder

### DIFF
--- a/keyboards/keebio/iris/keymaps/hexwire/config.h
+++ b/keyboards/keebio/iris/keymaps/hexwire/config.h
@@ -20,14 +20,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "config_common.h"
 
-/* Use I2C or Serial, not both */
-
-#define USE_SERIAL
-// #define USE_I2C
+#define USE_I2C
 
 /* Select hand configuration */
-
-#define MASTER_LEFT
 // #define MASTER_RIGHT
 // #define EE_HANDS
 

--- a/quantum/split_common/transport.c
+++ b/quantum/split_common/transport.c
@@ -74,7 +74,7 @@ bool transport_master(matrix_row_t matrix[]) {
 #  endif
 
 #  ifdef ENCODER_ENABLE
-  i2c_readReg(SLAVE_I2C_ADDRESS, I2C_ENCODER_START, (void *)i2c_buffer->encoder_state, sizeof(I2C_slave_buffer_t.encoder_state), TIMEOUT);
+  i2c_readReg(SLAVE_I2C_ADDRESS, I2C_ENCODER_START, (void *)i2c_buffer->encoder_state, sizeof(i2c_buffer->encoder_state), TIMEOUT);
   encoder_update_raw(i2c_buffer->encoder_state);
 #  endif
 


### PR DESCRIPTION
## Description

Fixes I2C split keyboard encoder usage.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Closes #6058 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
