### PR TITLE
Makes the docker build of layouts faster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,13 @@ endif
 override SILENT := false
 
 ifndef SUB_IS_SILENT
-QMK_VERSION := $(shell git describe --abbrev=0 --tags 2>/dev/null)
-ifneq ($(QMK_VERSION),)
-$(info QMK Firmware $(QMK_VERSION))
-endif
+    QMK_VERSION := $(shell git describe --abbrev=0 --tags 2>/dev/null)
+    ifeq ($(QMK_VERSION),)
+        QMK_VERSION := $(QUANTUM_VERSION)
+    endif
+    ifneq ($(QMK_VERSION),)
+        $(info QMK Firmware $(QMK_VERSION))
+    endif
 endif
 
 ON_ERROR := error_occurred=1

--- a/util/docker_build.sh
+++ b/util/docker_build.sh
@@ -45,6 +45,23 @@ if [ -n "$target" ]; then
 fi
 dir=$(pwd -W 2>/dev/null) || dir=$PWD  # Use Windows path if on Windows
 
+mk_mounts=""
+for f in *.mk
+do
+mk_mounts="$mk_mounts -v $dir/$f:/qmk_firmware/$f"
+done
+
+quantum_version="$(git describe --abbrev=0 --tags 2>/dev/null)"
+
 # Run container and build firmware
-docker run --rm -it $usb_args -v "$dir":/qmk_firmware qmkfm/qmk_firmware \
+docker run --rm -it $usb_args \
+    -v "$dir/keyboards/$keyboard":"/qmk_firmware/keyboards/$keyboard" \
+    -v "$dir/drivers":"/qmk_firmware/drivers" \
+    -v "$dir/quantum":"/qmk_firmware/quantum" \
+    -v "$dir/tmk_core":"/qmk_firmware/tmk_core" \
+    -v "$dir/lib":"/qmk_firmware/lib" \
+    -v "$dir/Makefile":"/qmk_firmware/Makefile" \
+    -e QUANTUM_VERSION="$quantum_version" \
+    $mk_mounts \
+    qmkfm/qmk_firmware \
 	make "$keyboard${keymap:+:$keymap}${target:+:$target}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

To compile the layouts we just need the following files:

- Desired keyboard files.
- Drivers.
- Quantum.
- TMK Core.
- Lib.
- Makefile.
- All the .mk files.

I also send the QMK version as an environment variable to the Docker
container and updated the Makefile to properly use it. This is needed
to be able to avoid copying the whole `.git` folder.

I ran this in my personal computer with such config: 
- Macbook Retina mid 2015, i7 2.2 GHz, 16 GB
- Docker for Mac Version 2.0.0.3 - 31259, configured with 4 cores and 2 GiB memory, 1 GiB swap) 

And got these results ⬇️

**Before changes:**

```sh
❯ time util/docker_build.sh ergodox_ez:default
QMK Firmware 0.5.132
Making ergodox_ez with keymap default

avr-gcc (GCC) 4.9.2
Copyright (C) 2014 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Compiling: keyboards/ergodox_ez/matrix.c                                                            [OK]
Compiling: drivers/avr/i2c_master.c                                                                 [OK]
Compiling: keyboards/ergodox_ez/ergodox_ez.c                                                        [OK]
Compiling: keyboards/ergodox_ez/keymaps/default/keymap.c                                            [OK]
Compiling: quantum/quantum.c                                                                        [OK]
Compiling: quantum/keymap_common.c                                                                  [OK]
Compiling: quantum/keycode_config.c                                                                 [OK]
Compiling: quantum/debounce/eager_pr.c                                                              [OK]
Compiling: quantum/process_keycode/process_unicode.c                                                [OK]
Compiling: quantum/process_keycode/process_unicode_common.c                                         [OK]
Compiling: quantum/color.c                                                                          [OK]
Compiling: quantum/rgblight.c                                                                       [OK]
Compiling: drivers/avr/ws2812.c                                                                     [OK]
Compiling: quantum/led_tables.c                                                                     [OK]
Compiling: quantum/process_keycode/process_space_cadet.c                                            [OK]
Compiling: tmk_core/common/host.c                                                                   [OK]
Compiling: tmk_core/common/keyboard.c                                                               [OK]
Compiling: tmk_core/common/action.c                                                                 [OK]
Compiling: tmk_core/common/action_tapping.c                                                         [OK]
Compiling: tmk_core/common/action_macro.c                                                           [OK]
Compiling: tmk_core/common/action_layer.c                                                           [OK]
Compiling: tmk_core/common/action_util.c                                                            [OK]
Compiling: tmk_core/common/print.c                                                                  [OK]
Compiling: tmk_core/common/debug.c                                                                  [OK]
Compiling: tmk_core/common/util.c                                                                   [OK]
Compiling: tmk_core/common/eeconfig.c                                                               [OK]
Compiling: tmk_core/common/report.c                                                                 [OK]
Compiling: tmk_core/common/avr/suspend.c                                                            [OK]
Compiling: tmk_core/common/avr/timer.c                                                              [OK]
Compiling: tmk_core/common/avr/bootloader.c                                                         [OK]
Assembling: tmk_core/common/avr/xprintf.S                                                           [OK]
Compiling: tmk_core/common/magic.c                                                                  [OK]
Compiling: tmk_core/common/mousekey.c                                                               [OK]
Compiling: tmk_core/common/command.c                                                                [OK]
Compiling: tmk_core/protocol/lufa/lufa.c                                                            [OK]
Compiling: tmk_core/protocol/usb_descriptor.c                                                       [OK]
Compiling: tmk_core/protocol/lufa/outputselect.c                                                    [OK]
Compiling: lib/lufa/LUFA/Drivers/USB/Class/Common/HIDParser.c                                       [OK]
Compiling: lib/lufa/LUFA/Drivers/USB/Core/AVR8/Device_AVR8.c                                        [OK]
Compiling: lib/lufa/LUFA/Drivers/USB/Core/AVR8/EndpointStream_AVR8.c                                [OK]
Compiling: lib/lufa/LUFA/Drivers/USB/Core/AVR8/Endpoint_AVR8.c                                      [OK]
Compiling: lib/lufa/LUFA/Drivers/USB/Core/AVR8/Host_AVR8.c                                          [OK]
Compiling: lib/lufa/LUFA/Drivers/USB/Core/AVR8/PipeStream_AVR8.c                                    [OK]
Compiling: lib/lufa/LUFA/Drivers/USB/Core/AVR8/Pipe_AVR8.c                                          [OK]
Compiling: lib/lufa/LUFA/Drivers/USB/Core/AVR8/USBController_AVR8.c                                 [OK]
Compiling: lib/lufa/LUFA/Drivers/USB/Core/AVR8/USBInterrupt_AVR8.c                                  [OK]
Compiling: lib/lufa/LUFA/Drivers/USB/Core/ConfigDescriptors.c                                       [OK]
Compiling: lib/lufa/LUFA/Drivers/USB/Core/DeviceStandardReq.c                                       [OK]
Compiling: lib/lufa/LUFA/Drivers/USB/Core/Events.c                                                  [OK]
Compiling: lib/lufa/LUFA/Drivers/USB/Core/HostStandardReq.c                                         [OK]
Compiling: lib/lufa/LUFA/Drivers/USB/Core/USBTask.c                                                 [OK]
Linking: .build/ergodox_ez_default.elf                                                              [OK]
Creating load file for flashing: .build/ergodox_ez_default.hex                                      [OK]
Copying ergodox_ez_default.hex to qmk_firmware folder                                               [OK]
Checking file size of ergodox_ez_default.hex                                                        [OK]
 * The firmware size is fine - 26330/32256 (5926 bytes free)
      149.63 real         0.04 user         0.02 sys
```

**After changes:**

```sh
$ time util/docker_build.sh ergodox_ez:default
QMK Firmware 0.5.132
Making ergodox_ez with keymap default

avr-gcc (GCC) 4.9.2
Copyright (C) 2014 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Compiling: keyboards/ergodox_ez/matrix.c                                                            [OK]
Compiling: drivers/avr/i2c_master.c                                                                 [OK]
Compiling: keyboards/ergodox_ez/ergodox_ez.c                                                        [OK]
Compiling: keyboards/ergodox_ez/keymaps/default/keymap.c                                            [OK]
Compiling: quantum/quantum.c                                                                        [OK]
Compiling: quantum/keymap_common.c                                                                  [OK]
Compiling: quantum/keycode_config.c                                                                 [OK]
Compiling: quantum/debounce/eager_pr.c                                                              [OK]
Compiling: quantum/process_keycode/process_unicode.c                                                [OK]
Compiling: quantum/process_keycode/process_unicode_common.c                                         [OK]
Compiling: quantum/color.c                                                                          [OK]
Compiling: quantum/rgblight.c                                                                       [OK]
Compiling: drivers/avr/ws2812.c                                                                     [OK]
Compiling: quantum/led_tables.c                                                                     [OK]
Compiling: quantum/process_keycode/process_space_cadet.c                                            [OK]
Compiling: tmk_core/common/host.c                                                                   [OK]
Compiling: tmk_core/common/keyboard.c                                                               [OK]
Compiling: tmk_core/common/action.c                                                                 [OK]
Compiling: tmk_core/common/action_tapping.c                                                         [OK]
Compiling: tmk_core/common/action_macro.c                                                           [OK]
Compiling: tmk_core/common/action_layer.c                                                           [OK]
Compiling: tmk_core/common/action_util.c                                                            [OK]
Compiling: tmk_core/common/print.c                                                                  [OK]
Compiling: tmk_core/common/debug.c                                                                  [OK]
Compiling: tmk_core/common/util.c                                                                   [OK]
Compiling: tmk_core/common/eeconfig.c                                                               [OK]
Compiling: tmk_core/common/report.c                                                                 [OK]
Compiling: tmk_core/common/avr/suspend.c                                                            [OK]
Compiling: tmk_core/common/avr/timer.c                                                              [OK]
Compiling: tmk_core/common/avr/bootloader.c                                                         [OK]
Assembling: tmk_core/common/avr/xprintf.S                                                           [OK]
Compiling: tmk_core/common/magic.c                                                                  [OK]
Compiling: tmk_core/common/mousekey.c                                                               [OK]
Compiling: tmk_core/common/command.c                                                                [OK]
Compiling: tmk_core/protocol/lufa/lufa.c                                                            [OK]
Compiling: tmk_core/protocol/usb_descriptor.c                                                       [OK]
Compiling: tmk_core/protocol/lufa/outputselect.c                                                    [OK]
Compiling: lib/lufa/LUFA/Drivers/USB/Class/Common/HIDParser.c                                       [OK]
Compiling: lib/lufa/LUFA/Drivers/USB/Core/AVR8/Device_AVR8.c                                        [OK]
Compiling: lib/lufa/LUFA/Drivers/USB/Core/AVR8/EndpointStream_AVR8.c                                [OK]
Compiling: lib/lufa/LUFA/Drivers/USB/Core/AVR8/Endpoint_AVR8.c                                      [OK]
Compiling: lib/lufa/LUFA/Drivers/USB/Core/AVR8/Host_AVR8.c                                          [OK]
Compiling: lib/lufa/LUFA/Drivers/USB/Core/AVR8/PipeStream_AVR8.c                                    [OK]
Compiling: lib/lufa/LUFA/Drivers/USB/Core/AVR8/Pipe_AVR8.c                                          [OK]
Compiling: lib/lufa/LUFA/Drivers/USB/Core/AVR8/USBController_AVR8.c                                 [OK]
Compiling: lib/lufa/LUFA/Drivers/USB/Core/AVR8/USBInterrupt_AVR8.c                                  [OK]
Compiling: lib/lufa/LUFA/Drivers/USB/Core/ConfigDescriptors.c                                       [OK]
Compiling: lib/lufa/LUFA/Drivers/USB/Core/DeviceStandardReq.c                                       [OK]
Compiling: lib/lufa/LUFA/Drivers/USB/Core/Events.c                                                  [OK]
Compiling: lib/lufa/LUFA/Drivers/USB/Core/HostStandardReq.c                                         [OK]
Compiling: lib/lufa/LUFA/Drivers/USB/Core/USBTask.c                                                 [OK]
Linking: .build/ergodox_ez_default.elf                                                              [OK]
Creating load file for flashing: .build/ergodox_ez_default.hex                                      [OK]
Copying ergodox_ez_default.hex to qmk_firmware folder                                               [OK]
Checking file size of ergodox_ez_default.hex                                                        [OK]
 * The firmware size is fine - 26322/32256 (5934 bytes free)
       42.32 real         0.08 user         0.04 sys
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code (hopefully) follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
