### PR TITLE
massdrop alt/ctrl: support saving into nvm

### DIFF
--- a/tmk_core/common/arm_atsam/eeprom.c
+++ b/tmk_core/common/arm_atsam/eeprom.c
@@ -29,7 +29,7 @@ volatile uint8_t *SmartEEPROM8 = (uint8_t *) SEEPROM_ADDR;
 uint8_t eeprom_read_byte(const uint8_t *addr) {
     uintptr_t offset = (uintptr_t)addr;
     if (offset >= EEPROM_SIZE)
-        return 0xff;
+        return 0x0;
 
     if (NVMCTRL->SEESTAT.bit.PSZ == 0 || NVMCTRL->SEESTAT.bit.SBLK == 0)
         return buffer[offset];
@@ -40,7 +40,7 @@ uint8_t eeprom_read_byte(const uint8_t *addr) {
     if (!NVMCTRL->SEESTAT.bit.BUSY)
         return SmartEEPROM8[offset];
 
-    return 0xff;
+    return 0;
 }
 
 void eeprom_write_byte(uint8_t *addr, uint8_t value) {

--- a/tmk_core/common/arm_atsam/eeprom.c
+++ b/tmk_core/common/arm_atsam/eeprom.c
@@ -24,10 +24,12 @@
 #endif
 
 __attribute__((aligned(4))) static uint8_t buffer[EEPROM_SIZE];
-volatile uint8_t *SmartEEPROM8 = (uint8_t *) 0x44000000;
+volatile uint8_t *SmartEEPROM8 = (uint8_t *) SEEPROM_ADDR;
 
 uint8_t eeprom_read_byte(const uint8_t *addr) {
     uintptr_t offset = (uintptr_t)addr;
+    if (offset >= EEPROM_SIZE)
+        return 0xff;
 
     if (NVMCTRL->SEESTAT.bit.PSZ == 0 || NVMCTRL->SEESTAT.bit.SBLK == 0)
         return buffer[offset];
@@ -35,11 +37,16 @@ uint8_t eeprom_read_byte(const uint8_t *addr) {
     int timeout = 10000;
     while (NVMCTRL->SEESTAT.bit.BUSY && timeout-- > 0)
         ;
-    return SmartEEPROM8[offset];
+    if (!NVMCTRL->SEESTAT.bit.BUSY)
+        return SmartEEPROM8[offset];
+
+    return 0xff;
 }
 
 void eeprom_write_byte(uint8_t *addr, uint8_t value) {
     uintptr_t offset = (uintptr_t)addr;
+    if (offset >= EEPROM_SIZE)
+        return;
 
     if (NVMCTRL->SEESTAT.bit.PSZ == 0 || NVMCTRL->SEESTAT.bit.SBLK == 0) {
         buffer[offset] = value;
@@ -49,8 +56,8 @@ void eeprom_write_byte(uint8_t *addr, uint8_t value) {
     int timeout = 10000;
     while (NVMCTRL->SEESTAT.bit.BUSY && timeout-- > 0)
         ;
-
-    SmartEEPROM8[offset] = value;
+    if (!NVMCTRL->SEESTAT.bit.BUSY)
+        SmartEEPROM8[offset] = value;
 }
 
 uint16_t eeprom_read_word(const uint16_t *addr) {

--- a/tmk_core/common/arm_atsam/eeprom.c
+++ b/tmk_core/common/arm_atsam/eeprom.c
@@ -13,8 +13,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include "samd51j18a.h"
 #include "eeprom.h"
+#include "debug.h"
+#include "samd51j18a.h"
 #include "core_cm4.h"
 #include "component/nvmctrl.h"
 
@@ -23,52 +24,99 @@
 #    define EEPROM_SIZE (((EECONFIG_SIZE + 3) / 4) * 4)  // based off eeconfig's current usage, aligned to 4-byte sizes, to deal with LTO
 #endif
 
+#ifndef MAX
+#    define MAX(X, Y) ((X) > (Y) ? (X) : (Y))
+#endif
+
 #ifndef BUSY_RETRIES
 #    define BUSY_RETRIES 10000
 #endif
 
-__attribute__((aligned(4))) static uint8_t buffer[EEPROM_SIZE];
-volatile uint8_t *                         SmartEEPROM8 = (uint8_t *)SEEPROM_ADDR;
+// #define DEBUG_EEPROM_OUTPUT
 
-uint8_t eeprom_read_byte(const uint8_t *addr) {
-    uintptr_t offset = (uintptr_t)addr;
-    if (offset >= EEPROM_SIZE) {
-        return 0x0;
-    }
+/*
+ * Debug print utils
+ */
+#if defined(DEBUG_EEPROM_OUTPUT)
+#    define eeprom_printf(fmt, ...) xprintf(fmt, ##__VA_ARGS__);
+#else /* NO_DEBUG */
+#    define eeprom_printf(fmt, ...)
+#endif /* NO_DEBUG */
 
-    if (NVMCTRL->SEESTAT.bit.PSZ == 0 || NVMCTRL->SEESTAT.bit.SBLK == 0) {
-        return buffer[offset];
-    }
+__attribute__((aligned(4))) static uint8_t buffer[EEPROM_SIZE] = {0};
+volatile uint8_t *                         SmartEEPROM8        = (uint8_t *)SEEPROM_ADDR;
 
+static inline bool eeprom_is_busy(void) {
     int timeout = BUSY_RETRIES;
     while (NVMCTRL->SEESTAT.bit.BUSY && timeout-- > 0)
         ;
 
-    if (!NVMCTRL->SEESTAT.bit.BUSY) {
-        return SmartEEPROM8[offset];
+    return NVMCTRL->SEESTAT.bit.BUSY;
+}
+
+static uint32_t get_virtual_eeprom_size(void) {
+    // clang-format off
+    static const uint32_t VIRTUAL_EEPROM_MAP[11][8] = {
+    /*          4    8    16    32    64    128    256    512 */
+    /* 0*/ {   0,    0,    0,    0,    0,     0,     0,     0 },
+    /* 1*/ { 512, 1024, 2048, 4096, 4096,  4096,  4096,  4096 },
+    /* 2*/ { 512, 1024, 2048, 4096, 8192,  8192,  8192,  8192 },
+    /* 3*/ { 512, 1024, 2048, 4096, 8192, 16384, 16384, 16384 },
+    /* 4*/ { 512, 1024, 2048, 4096, 8192, 16384, 16384, 16384 },
+    /* 5*/ { 512, 1024, 2048, 4096, 8192, 16384, 32768, 32768 },
+    /* 6*/ { 512, 1024, 2048, 4096, 8192, 16384, 32768, 32768 },
+    /* 7*/ { 512, 1024, 2048, 4096, 8192, 16384, 32768, 32768 },
+    /* 8*/ { 512, 1024, 2048, 4096, 8192, 16384, 32768, 32768 },
+    /* 9*/ { 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536 },
+    /*10*/ { 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536 },
+    };
+    // clang-format on
+
+    static uint32_t virtual_eeprom_size = UINT32_MAX;
+    if (virtual_eeprom_size == UINT32_MAX) {
+        virtual_eeprom_size = VIRTUAL_EEPROM_MAP[NVMCTRL->SEESTAT.bit.PSZ][NVMCTRL->SEESTAT.bit.SBLK];
+    }
+    // eeprom_printf("get_virtual_eeprom_size:: %d:%d:%d\n", NVMCTRL->SEESTAT.bit.PSZ, NVMCTRL->SEESTAT.bit.SBLK, virtual_eeprom_size);
+    return virtual_eeprom_size;
+}
+
+uint8_t eeprom_read_byte(const uint8_t *addr) {
+    uintptr_t offset = (uintptr_t)addr;
+    if (offset >= MAX(EEPROM_SIZE, get_virtual_eeprom_size())) {
+        eeprom_printf("eeprom_read_byte:: out of bounds\n");
+        return 0x0;
     }
 
-    return 0x0;
+    if (get_virtual_eeprom_size() == 0) {
+        return buffer[offset];
+    }
+
+    if (eeprom_is_busy()) {
+        eeprom_printf("eeprom_write_byte:: timeout\n");
+        return 0x0;
+    }
+
+    return SmartEEPROM8[offset];
 }
 
 void eeprom_write_byte(uint8_t *addr, uint8_t value) {
     uintptr_t offset = (uintptr_t)addr;
-    if (offset >= EEPROM_SIZE) {
-        return 0x0;
+    if (offset >= MAX(EEPROM_SIZE, get_virtual_eeprom_size())) {
+        eeprom_printf("eeprom_write_byte:: out of bounds\n");
+        return;
     }
 
-    if (NVMCTRL->SEESTAT.bit.PSZ == 0 || NVMCTRL->SEESTAT.bit.SBLK == 0) {
+    if (get_virtual_eeprom_size() == 0) {
         buffer[offset] = value;
         return;
     }
 
-    int timeout = BUSY_RETRIES;
-    while (NVMCTRL->SEESTAT.bit.BUSY && timeout-- > 0)
-        ;
-
-    if (!NVMCTRL->SEESTAT.bit.BUSY) {
-        SmartEEPROM8[offset] = value;
+    if (eeprom_is_busy()) {
+        eeprom_printf("eeprom_write_byte:: timeout\n");
+        return;
     }
+
+    SmartEEPROM8[offset] = value;
 }
 
 uint16_t eeprom_read_word(const uint16_t *addr) {


### PR DESCRIPTION
Use SAMD51 virtual eeprom to store eeprom in nvm instead of ram buffer so it is persistent accross reboots.
In order to have this working it is required to set PSZ and SBLK values in the NVM user row, I believe that can be done with the mdloader, but not having the source code, I am not able to implement this, I would be happy to do so.
I've tested by manualy updating the NVM user row connecting a JLINK probe on my keyboard.

Signed-off-by: Alexandre d Alton <alex@alexdalton.org>
