### PR TITLE
Update docker util script and travis to use new base container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ env:
   - MAKEFLAGS="-j3 --output-sync"
 services:
   - docker
-before_install:
-  - docker build -t qmkfm/qmk_firmware .
 install:
   - npm install -g moxygen
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,4 @@
-FROM debian:9
-
-RUN apt-get update && apt-get install --no-install-recommends -y \
-    avr-libc \
-    avrdude \
-    binutils-arm-none-eabi \
-    binutils-avr \
-    build-essential \
-    dfu-programmer \
-    dfu-util \
-    gcc \
-    gcc-avr \
-    git \
-    libnewlib-arm-none-eabi \
-    software-properties-common \
-    unzip \
-    wget \
-    zip \
-    && rm -rf /var/lib/apt/lists/*
+FROM qmkfm/base_container
 
 # upgrade gcc-arm-none-eabi from the default 5.4.1 to 6.3.1 due to ARM runtime issues
 RUN wget -q https://developer.arm.com/-/media/Files/downloads/gnu-rm/6-2017q2/gcc-arm-none-eabi-6-2017-q2-update-linux.tar.bz2 -O - | \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,5 @@
 FROM qmkfm/base_container
 
-# upgrade gcc-arm-none-eabi from the default 5.4.1 to 6.3.1 due to ARM runtime issues
-RUN wget -q https://developer.arm.com/-/media/Files/downloads/gnu-rm/6-2017q2/gcc-arm-none-eabi-6-2017-q2-update-linux.tar.bz2 -O - | \
-    tar xj --strip-components=1 -C /
-
 VOLUME /qmk_firmware
 WORKDIR /qmk_firmware
 COPY . .

--- a/util/docker_build.sh
+++ b/util/docker_build.sh
@@ -46,5 +46,5 @@ fi
 dir=$(pwd -W 2>/dev/null) || dir=$PWD  # Use Windows path if on Windows
 
 # Run container and build firmware
-docker run --rm -it $usb_args -v "$dir":/qmk_firmware qmkfm/qmk_firmware \
+docker run --rm -it $usb_args -w /qmk_firmware/ -v "$dir":/qmk_firmware qmkfm/base_container \
 	make "$keyboard${keymap:+:$keymap}${target:+:$target}"

--- a/util/travis_build.sh
+++ b/util/travis_build.sh
@@ -3,7 +3,7 @@
 # if docker is installed - call make within the qmk docker image
 if command -v docker >/dev/null; then
   function make() {
-    docker run --rm -e MAKEFLAGS="$MAKEFLAGS" -w /qmk_firmware/ -v "$PWD":/qmk_firmware --user $(id -u):$(id -g) qmkfm/qmk_firmware make "$@"
+    docker run --rm -e MAKEFLAGS="$MAKEFLAGS" -w /qmk_firmware/ -v "$PWD":/qmk_firmware --user $(id -u):$(id -g) qmkfm/base_container make "$@"
   }
 fi
 

--- a/util/travis_test.sh
+++ b/util/travis_test.sh
@@ -22,7 +22,7 @@ fi
 # if docker is installed - call make within the qmk docker image
 if command -v docker >/dev/null; then
   function make() {
-    docker run --rm -e MAKEFLAGS="$MAKEFLAGS" -w /qmk_firmware/ -v "$PWD":/qmk_firmware --user $(id -u):$(id -g) qmkfm/qmk_firmware make "$@"
+    docker run --rm -e MAKEFLAGS="$MAKEFLAGS" -w /qmk_firmware/ -v "$PWD":/qmk_firmware --user $(id -u):$(id -g) qmkfm/base_container make "$@"
   }
 fi
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Now that <https://github.com/qmk/qmk_base_container> exists, we can update the travis build to use the new "slim" image, that does not bundle the qmk_firmware repo, and not build the image for every build. Should save a small amount of time (~100 seconds), and more importantly, increase the repeatability between builds.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
