### PR TITLE
Add an alternative method for keyboard discovery to speed up build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,10 @@ endif
 override SILENT := false
 
 ifndef SUB_IS_SILENT
-QMK_VERSION := $(shell git describe --abbrev=0 --tags 2>/dev/null)
+ifndef SKIP_GIT
+    QMK_VERSION := $(shell git describe --abbrev=0 --tags 2>/dev/null)
+endif
+
 ifneq ($(QMK_VERSION),)
 $(info QMK Firmware $(QMK_VERSION))
 endif
@@ -94,6 +97,7 @@ $(eval $(call NEXT_PATH_ELEMENT))
 # endif
 
 define GET_KEYBOARDS
+ifndef ALT_GET_KEYBOARDS
     All_RULES_MK := $$(patsubst $(ROOT_DIR)/keyboards/%/rules.mk,%,$$(wildcard $(ROOT_DIR)/keyboards/*/rules.mk))
     All_RULES_MK += $$(patsubst $(ROOT_DIR)/keyboards/%/rules.mk,%,$$(wildcard $(ROOT_DIR)/keyboards/*/*/rules.mk))
     All_RULES_MK += $$(patsubst $(ROOT_DIR)/keyboards/%/rules.mk,%,$$(wildcard $(ROOT_DIR)/keyboards/*/*/*/rules.mk))
@@ -105,6 +109,10 @@ define GET_KEYBOARDS
     KEYMAPS_MK += $$(patsubst $(ROOT_DIR)/keyboards/%/rules.mk,%,$$(wildcard $(ROOT_DIR)/keyboards/*/*/*/*/keymaps/*/rules.mk))
 
     KEYBOARDS := $$(sort $$(filter-out $$(KEYMAPS_MK), $$(All_RULES_MK)))
+else
+    $(info USING ALT FIND)
+    KEYBOARDS := $(shell find keyboards/ -type f -iname "rules.mk" | sed 's!keyboards/\(.*\)/rules.mk!\1!' | sed 's!/keymaps.*!!' | sort | uniq)
+endif
 endef
 
 $(eval $(call GET_KEYBOARDS))

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,6 @@ ifndef ALT_GET_KEYBOARDS
 
     KEYBOARDS := $$(sort $$(filter-out $$(KEYMAPS_MK), $$(All_RULES_MK)))
 else
-    $(info USING ALT FIND)
     KEYBOARDS := $(shell find keyboards/ -type f -iname "rules.mk" | grep -v keymaps | sed 's!keyboards/\(.*\)/rules.mk!\1!' | sort | uniq)
 endif
 endef

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ ifndef ALT_GET_KEYBOARDS
     KEYBOARDS := $$(sort $$(filter-out $$(KEYMAPS_MK), $$(All_RULES_MK)))
 else
     $(info USING ALT FIND)
-    KEYBOARDS := $(shell find keyboards/ -type f -iname "rules.mk" | sed 's!keyboards/\(.*\)/rules.mk!\1!' | sed 's!/keymaps.*!!' | sort | uniq)
+    KEYBOARDS := $(shell find keyboards/ -type f -iname "rules.mk" | grep -v keymaps | sed 's!keyboards/\(.*\)/rules.mk!\1!' | sort | uniq)
 endif
 endef
 

--- a/util/docker_build.sh
+++ b/util/docker_build.sh
@@ -50,7 +50,7 @@ docker run --rm -it $usb_args \
     -w /qmk_firmware/
 	-v "$dir":/qmk_firmware \
 	-e ALT_GET_KEYBOARDS=true \
-	-e SKIP_GIT=$SKIP_GIT \
-	-e MAKEFLAGS=$MAKEFLAGS \
+	-e SKIP_GIT="$SKIP_GIT" \
+	-e MAKEFLAGS="$MAKEFLAGS" \
 	qmkfm/base_container \
 	make "$keyboard${keymap:+:$keymap}${target:+:$target}"

--- a/util/docker_build.sh
+++ b/util/docker_build.sh
@@ -46,5 +46,11 @@ fi
 dir=$(pwd -W 2>/dev/null) || dir=$PWD  # Use Windows path if on Windows
 
 # Run container and build firmware
-docker run --rm -it $usb_args -w /qmk_firmware/ -v "$dir":/qmk_firmware qmkfm/base_container \
+docker run --rm -it $usb_args \
+    -w /qmk_firmware/
+	-v "$dir":/qmk_firmware \
+	-e ALT_GET_KEYBOARDS=true \
+	-e SKIP_GIT=$SKIP_GIT \
+	-e MAKEFLAGS=$MAKEFLAGS \
+	qmkfm/base_container \
 	make "$keyboard${keymap:+:$keymap}${target:+:$target}"

--- a/util/docker_build.sh
+++ b/util/docker_build.sh
@@ -47,7 +47,7 @@ dir=$(pwd -W 2>/dev/null) || dir=$PWD  # Use Windows path if on Windows
 
 # Run container and build firmware
 docker run --rm -it $usb_args \
-    -w /qmk_firmware/
+    -w /qmk_firmware/ \
 	-v "$dir":/qmk_firmware \
 	-e ALT_GET_KEYBOARDS=true \
 	-e SKIP_GIT="$SKIP_GIT" \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Discussed within #6065.

The main take-away is that windows vagrant and macos docker can have poor filesystem performance. This PR attempts to work around that issue by providing a method of keyboard discovery that seems to be faster, up to a factor of 3x.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
