### PR TITLE
Change from avr-gcc@7 to @8 for Mac

### DIFF
--- a/docs/faq_build.md
+++ b/docs/faq_build.md
@@ -140,8 +140,8 @@ For now, you need to rollback avr-gcc to 7 in brew.
 
 ```
 brew uninstall --force avr-gcc
-brew install avr-gcc@7
-brew link --force avr-gcc@7
+brew install avr-gcc@8
+brew link --force avr-gcc@8
 ```
 
 ### I just flashed my keyboard and it does nothing/keypresses don't register - it's also ARM (rev6 planck, clueboard 60, hs60v2, etc...) (Feb 2019)

--- a/docs/getting_started_build_tools.md
+++ b/docs/getting_started_build_tools.md
@@ -62,14 +62,14 @@ If you're using [homebrew,](http://brew.sh/) you can use the following commands:
     brew tap osx-cross/avr
     brew tap PX4/homebrew-px4
     brew update
-    brew install avr-gcc@7
-    brew link --force avr-gcc@7
+    brew install avr-gcc@8
+    brew link --force avr-gcc@8
     brew install dfu-programmer
     brew install dfu-util
     brew install gcc-arm-none-eabi
     brew install avrdude
 
-This is the recommended method. If you don't have homebrew, [install it!](http://brew.sh/) It's very much worth it for anyone who works in the command line. Note that the `make` and `make install` portion during the homebrew installation of `avr-gcc@7` can take over 20 minutes and exhibit high CPU usage.
+This is the recommended method. If you don't have homebrew, [install it!](http://brew.sh/) It's very much worth it for anyone who works in the command line. Note that the `make` and `make install` portion during the homebrew installation of `avr-gcc@8` can take over 20 minutes and exhibit high CPU usage.
 
 ## Windows with msys2 (recommended)
 

--- a/docs/zh-cn/faq_build.md
+++ b/docs/zh-cn/faq_build.md
@@ -137,8 +137,8 @@ brew install avrdude
 
 ```
 brew uninstall --force avr-gcc
-brew install avr-gcc@7
-brew link --force avr-gcc@7
+brew install avr-gcc@8
+brew link --force avr-gcc@8
 ```
 
 ### 我刷新了我的键盘但是键盘不工作/按键没有注册 - 而且还是ARM的 (rev6 planck, clueboard 60, hs60v2, etc...) (Feb 2019)

--- a/util/macos_install.sh
+++ b/util/macos_install.sh
@@ -22,5 +22,5 @@ fi
 brew tap osx-cross/avr
 brew tap PX4/homebrew-px4
 brew update
-brew install avr-gcc@7 gcc-arm-none-eabi dfu-programmer avrdude dfu-util python3
-brew link --force avr-gcc@7
+brew install avr-gcc@8 gcc-arm-none-eabi dfu-programmer avrdude dfu-util python3
+brew link --force avr-gcc@8


### PR DESCRIPTION
## Description

Change default install of avr-gcc from 7.x to 8.x (8.3.0) for Mac installs.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
