### PR TITLE
Docs: Make Code Examples Consistent On Combo Page

### DIFF
--- a/docs/feature_combo.md
+++ b/docs/feature_combo.md
@@ -29,6 +29,7 @@ enum combos {
   AB_ESC,
   JK_TAB
 };
+
 const uint16_t PROGMEM ab_combo[] = {KC_A, KC_B, COMBO_END};
 const uint16_t PROGMEM jk_combo[] = {KC_J, KC_K, COMBO_END};
 
@@ -44,7 +45,7 @@ For a more complicated implementation, you can use the `process_combo_event` fun
 enum combo_events {
   ZC_COPY,
   XV_PASTE
-  };
+};
 
 const uint16_t PROGMEM copy_combo[] = {KC_Z, KC_C, COMBO_END};
 const uint16_t PROGMEM paste_combo[] = {KC_X, KC_V, COMBO_END};


### PR DESCRIPTION
## Description

Fix indentation and whitespace in code examples for the Combo features page.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation