### PR TITLE
New keyboard variant (DMOTE)

### DIFF
--- a/keyboards/handwired/dactyl_manuform/4x5/config.h
+++ b/keyboards/handwired/dactyl_manuform/4x5/config.h
@@ -40,7 +40,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* define if matrix has ghost */
 //#define MATRIX_HAS_GHOST
 
+// WS2812 RGB LED strip input and number of LEDs
+#define RGB_DI_PIN D3
+#define RGBLED_NUM 12
+
 /* number of backlight levels */
 // #define BACKLIGHT_LEVELS 3
-
-

--- a/keyboards/handwired/dactyl_manuform/4x6/config.h
+++ b/keyboards/handwired/dactyl_manuform/4x6/config.h
@@ -38,3 +38,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* COL2ROW or ROW2COL */
 #define DIODE_DIRECTION COL2ROW
+
+// WS2812 RGB LED strip input and number of LEDs
+#define RGB_DI_PIN D3
+#define RGBLED_NUM 12

--- a/keyboards/handwired/dactyl_manuform/5x6/config.h
+++ b/keyboards/handwired/dactyl_manuform/5x6/config.h
@@ -32,10 +32,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MATRIX_COL_PINS { D4, C6, D7, E6, B4, B5 }
 #define MATRIX_ROW_PINS { F6, F7, B1, B3, B2, B6 }
 
+// WS2812 RGB LED strip input and number of LEDs
+#define RGB_DI_PIN D3
+#define RGBLED_NUM 12
 
 /* define if matrix has ghost */
 //#define MATRIX_HAS_GHOST
 
 /* number of backlight levels */
 // #define BACKLIGHT_LEVELS 3
-

--- a/keyboards/handwired/dactyl_manuform/5x7/config.h
+++ b/keyboards/handwired/dactyl_manuform/5x7/config.h
@@ -31,3 +31,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // wiring of each half
 #define MATRIX_ROW_PINS { D4, C6, D7, E6, B4, B5 }
 #define MATRIX_COL_PINS { F5, F6, F7, B1, B3, B2, B6 }
+
+// WS2812 RGB LED strip input and number of LEDs
+#define RGB_DI_PIN D3
+#define RGBLED_NUM 12

--- a/keyboards/handwired/dactyl_manuform/6x6/config.h
+++ b/keyboards/handwired/dactyl_manuform/6x6/config.h
@@ -31,3 +31,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // wiring of each half
 #define MATRIX_COL_PINS { D4, C6, D7, E6, B4, B5 }
 #define MATRIX_ROW_PINS { F5, F6, F7, B1, B3, B2, B6 }
+
+// WS2812 RGB LED strip input and number of LEDs
+#define RGB_DI_PIN D3
+#define RGBLED_NUM 12

--- a/keyboards/handwired/dactyl_manuform/config.h
+++ b/keyboards/handwired/dactyl_manuform/config.h
@@ -49,11 +49,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* Enables This makes it easier for fast typists to use dual-function keys */
 #define PERMISSIVE_HOLD
 
-/* ws2812 RGB LED */
-#define RGB_DI_PIN D3
-
-#define RGBLED_NUM 12    // Number of LEDs
-
 /*
  * Feature disable options
  *  These options are also useful to firmware size reduction.

--- a/keyboards/handwired/dactyl_manuform/dactyl_manuform.h
+++ b/keyboards/handwired/dactyl_manuform/dactyl_manuform.h
@@ -10,6 +10,8 @@
     #include "5x7.h"
 #elif KEYBOARD_handwired_dactyl_manuform_6x6
     #include "6x6.h"
+#elif KEYBOARD_handwired_dactyl_manuform_dmote_62key
+    #include "62key.h"
 #endif
 
 //void promicro_bootloader_jmp(bool program);
@@ -23,5 +25,3 @@
 	#include <avr/interrupt.h>
 #endif
 #endif
-
-

--- a/keyboards/handwired/dactyl_manuform/dmote/62key/62key.c
+++ b/keyboards/handwired/dactyl_manuform/dmote/62key/62key.c
@@ -1,0 +1,5 @@
+#include "62key.h"
+
+void matrix_init_kb(void) {
+	matrix_init_user();
+};

--- a/keyboards/handwired/dactyl_manuform/dmote/62key/62key.h
+++ b/keyboards/handwired/dactyl_manuform/dmote/62key/62key.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "dactyl_manuform.h"
+#include "quantum.h"
+
+#ifdef USE_I2C
+#include <stddef.h>
+#ifdef __AVR__
+  #include <avr/io.h>
+  #include <avr/interrupt.h>
+#endif
+#endif
+
+// This uses the same coordinate system as the program that defines
+// the case model, but not the same coordinates.
+// Numbers increase going to the right and away from the user on the
+// right-hand side of the keyboard. This is mirrored for the
+// left-hand side.
+// The matrix is constructed for ease of soldering, with the columns
+// of the thumb cluster extending along the sides of the finger
+// cluster so that everything can be contained in a 6x6 pattern.
+
+#define LAYOUT_62key( \
+    LA_20, LA_10, LF_35, LF_25, LF_15, LF_05,            \
+    LF_55, LF_45, LF_34, LF_24, LF_14, LF_04,            \
+    LF_54, LF_44, LF_33, LF_23, LF_13, LF_03,            \
+    LF_53, LF_43, LF_32, LF_22, LF_12,                   \
+                         LF_21,        LT_21, LT_22,     \
+                                    LT_10, LT_11, LT_12, \
+                                       LT_01, LT_02,     \
+                                                         \
+           RF_05, RF_15, RF_25, RF_35, RA_10, RA_20,     \
+           RF_04, RF_14, RF_24, RF_34, RF_45, RF_55,     \
+           RF_03, RF_13, RF_23, RF_33, RF_44, RF_54,     \
+                  RF_12, RF_22, RF_32, RF_43, RF_53,     \
+       RT_22, RT_21,     RF_21,                          \
+    RT_12, RT_11, RT_10,                                 \
+       RT_02, RT_01                                      \
+  ) \
+  { \
+    { LA_20, LA_10, LF_35, LF_25, LF_15, LF_05 }, \
+    { LF_55, LF_45, LF_34, LF_24, LF_14, LF_04 }, \
+    { LF_54, LF_44, LF_33, LF_23, LF_13, LF_03 }, \
+    { LF_53, LF_43, LF_32, LF_22, LF_12, LT_22 }, \
+    { KC_NO, KC_NO, LT_21, LF_21, LT_11, LT_12 }, \
+    { KC_NO, KC_NO, LT_10, KC_NO, LT_01, LT_02 }, \
+                                                  \
+    { RA_20, RA_10, RF_35, RF_25, RF_15, RF_05 }, \
+    { RF_55, RF_45, RF_34, RF_24, RF_14, RF_04 }, \
+    { RF_54, RF_44, RF_33, RF_23, RF_13, RF_03 }, \
+    { RF_53, RF_43, RF_32, RF_22, RF_12, RT_22 }, \
+    { KC_NO, KC_NO, RT_21, RF_21, RT_11, RT_12 }, \
+    { KC_NO, KC_NO, RT_10, KC_NO, RT_01, RT_02 }, \
+  }

--- a/keyboards/handwired/dactyl_manuform/dmote/62key/config.h
+++ b/keyboards/handwired/dactyl_manuform/dmote/62key/config.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "config_common.h"
+
+#define PRODUCT  DMOTE (62-key)
+#define MATRIX_ROWS 12
+#define MATRIX_COLS 6
+
+// MCUs are flipped on each side, relative to the shape of the case,
+// but for ease of mounting, the pinout is not flipped with the controller.
+// The same finger on each hand uses a column connected to the pin with the
+// same silk-screen label on each Pro Micro.
+
+// Pin use:
+//
+//  MCU | Silk | DMOTE
+// -----+------+----------
+//   D3 | TX0  |
+//   D2 | RX1  |
+//   D1 | 2    | LED strip input (dominant half only)
+//   D0 | 3    | Serial interface between halves
+//   D4 | 4    | Outermost pinky-finger column
+//   C6 | 5    | Column
+//   D7 | 6    | Column
+//   E6 | 7    | Column
+//   B4 | 8    | Column
+//   B5 | 9    | Outermost index-finger column
+// -----+------+----------
+//   F4 | A3   |
+//   F5 | A2   |
+//   F6 | A1   | Top row (furthest from user)
+//   F7 | A0   | Row
+//   B1 | 15   | Row
+//   B3 | 14   | Row
+//   B2 | 16   | Row
+//   B6 | 10   | Bottom row (closest to user)
+#define MATRIX_ROW_PINS { F6, F7, B1, B3, B2, B6 }
+#define MATRIX_COL_PINS { D4, C6, D7, E6, B4, B5 }
+
+// WS2812 RGB LED, normally used to indicate keyboard state:
+#define RGBLIGHT_EFFECT_KNIGHT
+#define RGBLIGHT_EFFECT_KNIGHT_LENGTH 2
+#define RGBLIGHT_EFFECT_CHRISTMAS
+#define RGBLIGHT_EFFECT_CHRISTMAS_STEP 1
+#define RGB_DI_PIN D1
+#define RGBLED_NUM 6           // Used when chaining strips
+#define RGBLED_SPLIT { 3, 3 }  // Used when not chaining strips
+#define ws2812_PORTREG  PORTD
+#define ws2812_DDRREG   DDRD

--- a/keyboards/handwired/dactyl_manuform/dmote/62key/keymaps/default/config.h
+++ b/keyboards/handwired/dactyl_manuform/dmote/62key/keymaps/default/config.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#define USE_SERIAL
+
+#define EE_HANDS

--- a/keyboards/handwired/dactyl_manuform/dmote/62key/keymaps/default/keymap.c
+++ b/keyboards/handwired/dactyl_manuform/dmote/62key/keymaps/default/keymap.c
@@ -1,0 +1,146 @@
+#include "62key.h"
+#include "rgblight.h"
+#include <keymap_colemak.h>
+#include <sendstring_colemak.h>
+
+extern keymap_config_t keymap_config;
+
+// Automatic Layer ID:
+enum layer_names {
+    _QWERTY,   // OS-side Colemak. Default.
+    _COLEMAK,  // Keyboard-side Colemak. Portability, emergency.
+    _NUMERIC
+};
+
+// Shorthand:
+#define LAYER_N MO(_NUMERIC)
+#define LAYER_C TG(_COLEMAK)
+#define PASTE LSFT(KC_INS)  // Terminal-compatible paste.
+#define SLQ RALT(KC_9)  // Single left-side quotation mark (in Colemak).
+#define SRQ RALT(KC_0)
+#define EMDASH RALT(LSFT(KC_MINUS))  // Em dash character (in Colemak).
+#define BK_LCTL CTL_T(KC_LBRACKET)
+#define BK_RCTL RCTL_T(KC_RBRACKET)
+// TODO: Mod-tap ALT with a curvilinear brace.
+// https://github.com/qmk/qmk_firmware/pull/2055
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+[_QWERTY] = LAYOUT_62key(
+    KC_VOLD, KC_VOLU, CM_W,    CM_F,    CM_P,    CM_G,
+    KC_TAB,  CM_Q,    CM_R,    CM_S,    CM_T,    CM_D,
+    KC_BSPC, CM_A,    CM_X,    CM_C,    CM_V,    CM_B,
+    SLQ,     CM_Z,    KC_HOME, KC_PGUP, KC_END,
+                               KC_PGDN,          KC_ENT,  KC_SPC,
+                                             KC_LSPO, KC_LGUI, KC_MINS,
+                                                 BK_LCTL, KC_LALT,
+
+                 CM_J,    CM_L,    CM_U,    CM_Y,    KC_MPLY, KC_MUTE,
+                 CM_H,    CM_N,    CM_E,    CM_I,    CM_SCLN, KC_BSLS,
+                 CM_K,    CM_M,    KC_COMM, KC_DOT,  CM_O,    KC_QUOT,
+                          KC_LEFT, KC_UP,   KC_RGHT, KC_SLSH, SRQ,
+        KC_DEL,  KC_ESC,           KC_DOWN,
+    KC_EQL,  LAYER_N, KC_RSPC,
+        KC_RALT, BK_RCTL
+),
+
+[_COLEMAK] = LAYOUT_62key(
+    _______, _______, KC_W,    KC_F,    KC_P,    KC_G,
+    _______, KC_Q,    KC_R,    KC_S,    KC_T,    KC_D,
+    _______, KC_A,    KC_X,    KC_C,    KC_V,    KC_B,
+    _______, KC_Z,    _______, _______, _______,
+                               _______,          _______, _______,
+                                             _______, _______, _______,
+                                                 _______, _______,
+
+                 KC_J,    KC_L,    KC_U,    KC_Y,    _______, _______,
+                 KC_H,    KC_N,    KC_E,    KC_I,    KC_SCLN, _______,
+                 KC_K,    KC_M,    _______, _______, KC_O,    _______,
+                          _______, _______, _______, _______, _______,
+        _______, _______,          _______,
+    _______, _______, _______,
+        _______, _______
+),
+
+[_NUMERIC] = LAYOUT_62key(
+    LAYER_C, KC_INS,  KC_F2,   KC_F3,   KC_F4,   KC_F5,
+    KC_F12,  KC_F1,   KC_2,    KC_3,    KC_4,    KC_5,
+    _______, KC_1,    KC_AT,   KC_HASH, KC_DLR,  KC_PERC,
+    KC_GRV,  KC_EXLM, KC_BTN1, KC_WH_U, KC_BTN2,
+                               KC_WH_D,          RGB_MOD, _______,
+                                             _______, _______, EMDASH,
+                                                 _______, _______,
+
+                 KC_F6,   KC_F7,   KC_F8,   KC_F9,   RESET,   KC_WAKE, // *
+                 KC_6,    KC_7,    KC_8,    KC_9,    KC_F10,  KC_F11,
+                 KC_CIRC, KC_AMPR, KC_ASTR, KC_APP,  KC_0,    PASTE,
+                          KC_MS_L, KC_MS_U, KC_MS_R, KC_PSCR, RGB_TOG,
+        KC_ACL1, KC_ACL2,          KC_MS_D,
+    KC_ACL0, _______, _______,
+        _______, _______
+)
+};
+// *KC_WAKE: Used in place of KC_SLEP because X11 with i3 on prerelease
+//  Debian 10 was seeing duplicate keypress and release events for sleep
+//  (regardless of i3 binding), which ruined the function.
+
+
+/*
+The rest is all about lighting control.
+The logic here represents a pretty poor compromise solution between the
+following concerns:
+
+- Feedback on active modifiers.
+- Flexibility: Both sides of the keyboard are interchangeable.
+- Regular QMK RBG lighting modes. Specifically, Knight and Xmas.
+
+Currently, the last item suffers, because the first two seem to require
+calling a function that implements the RGBLIGHT_SPLIT_SET_CHANGE_HSVS macro,
+which most of the rgblight.c functions do not. In particular, functions that
+target an individual LED do not do so correctly across the wire, so instead
+we let HSV vary without ever targeting LEDs.
+*/
+
+// How long to wait between animation steps for "Knight" animation:
+const uint8_t RGBLED_KNIGHT_INTERVALS[] PROGMEM = {255, 200, 100};
+
+bool _initialized = false;
+bool _leds_dirty = false;
+
+void modal_leds(void) {
+    uint8_t mods = get_mods();
+    uint16_t hue = 355;  // Rough match to printed case.
+    uint8_t saturation = 255;
+    uint8_t value = 0;
+    if (layer_state_is(_COLEMAK)) { hue -= 50; saturation -= 20; value += 20; };
+    if (layer_state_is(_NUMERIC)) { value += 30; };
+    if (mods & MOD_MASK_SHIFT) { saturation -= 20; value += 30; };
+    if (mods & MOD_MASK_ALT) { hue -= 100; saturation -= 20; value += 30; };
+    if (mods & MOD_MASK_CTRL) { hue -= 200; saturation -= 20; value += 30; };
+    // rgblight_sethsv_eeprom_helper is not a great API function but it does
+    // affect both halves of a split keyboard.
+    rgblight_sethsv_eeprom_helper(hue, saturation, value, false);
+    _leds_dirty = false;
+}
+
+void matrix_init_user(void) {
+}
+
+void matrix_scan_user(void) {
+    if (_leds_dirty) { modal_leds(); };
+}
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    if (!_initialized) {
+        // Static lighting is amenable to customization.
+        rgblight_mode(RGBLIGHT_MODE_STATIC_LIGHT);
+        _initialized = true;
+    };
+    if (keycode == KC_WAKE) {
+        // Turn the lights off before going to sleep.
+        rgblight_sethsv_eeprom_helper(0, 0, 0, false);
+    } else {
+        _leds_dirty = true;
+    };
+    return true;
+}

--- a/keyboards/handwired/dactyl_manuform/dmote/62key/rules.mk
+++ b/keyboards/handwired/dactyl_manuform/dmote/62key/rules.mk
@@ -1,0 +1,5 @@
+# Build-process overrides for the DMOTE.
+MOUSEKEY_ENABLE = yes       # Mouse keys(+4700)
+EXTRAKEY_ENABLE = yes       # Audio control and System control(+450)
+RGBLIGHT_ENABLE = yes       # Needed for the C linker with lighting control.
+COMMAND_ENABLE = no         # Not a good combo with Space Cadet shift.

--- a/keyboards/handwired/dactyl_manuform/dmote/config.h
+++ b/keyboards/handwired/dactyl_manuform/dmote/config.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "config_common.h"

--- a/keyboards/handwired/dactyl_manuform/dmote/readme.md
+++ b/keyboards/handwired/dactyl_manuform/dmote/readme.md
@@ -1,0 +1,16 @@
+DMOTE
+======
+
+The “Dactyl-ManuForm: Opposable Thumb Edition” is made from a Clojure
+application maintained [here](https://github.com/veikman/dactyl-keyboard).
+The application supports varied physical layouts and therefore matrices.
+This physical variability is its main feature; its QMK firmware is ordinary.
+
+Consult the general [Dactyl-ManuForm readme](../readme.md).
+
+## The `62key` layout
+
+This folder represents the default build target of the Clojure application
+as of its version 0.4.0. The default keymap for this layout has a QWERTY base
+layer but is intended for running Colemak on the OS side with the i3 tiling
+window manager. It’s also got a layer that forces Colemak from the QMK side.


### PR DESCRIPTION
## Description

Added [the DMOTE](https://github.com/veikman/dactyl-keyboard) as a variant of the hand-wired Dactyl-ManuForm, with slight changes to prior code organization to reflect differences.

Tom Short, the creator of the original Dactyl-ManuForm, has approved my publishing DMOTE firmware in this manner.

I hope my pushing straight from `master` is all right; I can branch out if it helps.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

None.

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
