### PR TITLE
Set a short TAP_CODE_DELAY so media keys work

### DIFF
--- a/users/bcat/config.h
+++ b/users/bcat/config.h
@@ -1,3 +1,8 @@
+/* Delay between tap_code register and unregister to fix flaky media keys. */
+#undef TAP_CODE_DELAY
+
+#define TAP_CODE_DELAY 10
+
 /* Turn off RGB lighting when the host goes to sleep. */
 #define RGBLIGHT_SLEEP
 


### PR DESCRIPTION
A delay of 10ms seems sufficient. Otherwise, media keys tapped from the
encoder of my BDN9 macropad only seem to get picked up by the OS
(Windows 10) some of the time.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [X] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
