### PR TITLE
Adding LED support to the plaid default keycap

### DIFF
--- a/keyboards/plaid/keymaps/default/keymap.c
+++ b/keyboards/plaid/keymaps/default/keymap.c
@@ -33,11 +33,43 @@ enum plaid_keycodes {
   COLEMAK,
   DVORAK,
   PLOVER,
-  EXT_PLV
+  EXT_PLV,
+  LED_1,
+  LED_2,
+  LED_3,
+  LED_4,
+  LED_5,
+  LED_6,
+  LED_7,
+  LED_8,
+  LED_9,
+  LED_0
 };
 
 #define LOWER MO(_LOWER)
 #define RAISE MO(_RAISE)
+
+// array of keys considered modifiers for led purposes
+const uint16_t modifiers[] = {
+    KC_LCTL,
+    KC_RCTL,
+    KC_LALT,
+    KC_RALT,
+    KC_LSFT,
+    KC_RSFT,
+    KC_LGUI,
+    KC_RGUI,
+    LOWER,
+    RAISE
+};
+
+//Setup consts for LED modes
+#define LEDMODE_ON 1 //always on
+#define LEDMODE_OFF 0 //always off
+#define LEDMODE_MODS 2 //On with modifiers
+#define LEDMODE_BLINKIN 3 //blinkinlights - % chance toggle on keypress
+#define LEDMODE_KEY 4 //On with any keypress, off with key release
+#define LEDMODE_ENTER 5 // On with enter key
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
@@ -152,7 +184,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 /* Adjust (Lower + Raise)
  * ,-----------------------------------------------------------------------------------.
- * |      | Reset|      |      |      |      |      |      |      |      |      |  Del |
+ * |Reset |      |      |      |      |      |      |      |      |      |      |  Del |
  * |------+------+------+------+------+-------------+------+------+------+------+------|
  * |      |      |      |Aud on|Audoff|AGnorm|AGswap|Qwerty|Colemk|Dvorak|Plover|      |
  * |------+------+------+------+------+------|------+------+------+------+------+------|
@@ -162,7 +194,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * `-----------------------------------------------------------------------------------'
  */
 [_ADJUST] = LAYOUT_plaid_grid(
-    _______, RESET,   DEBUG,    RGB_TOG, RGB_MOD, RGB_HUI, RGB_HUD, RGB_SAI, RGB_SAD, RGB_VAI, RGB_VAD, KC_DEL ,
+    RESET,LED_1, LED_2, LED_3, LED_4, LED_5,LED_6, LED_7, LED_8, LED_9, LED_0,KC_DEL ,
     _______, _______, MU_MOD,  AU_ON,   AU_OFF,  AG_NORM, AG_SWAP, QWERTY,  COLEMAK, DVORAK,  PLOVER,  _______,
     _______, MUV_DE,  MUV_IN,  MU_ON,   MU_OFF,  MI_ON,   MI_OFF,  TERM_ON, TERM_OFF, _______, _______, _______,
     _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______
@@ -171,11 +203,100 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 };
 
+//Setup config struct for LED
+typedef union {
+  uint32_t raw;
+  struct {
+    uint8_t  red_mode :8;
+    uint8_t  green_mode :8;
+  };
+} led_config_t;
+led_config_t led_config;
+
+//Set leds to saved state during powerup
+void keyboard_post_init_user(void) {
+  // Call the post init code.
+  led_config.raw = eeconfig_read_user();
+
+  if(led_config.red_mode == LEDMODE_ON) {
+      writePinHigh(LED_RED);
+  }
+
+  if(led_config.green_mode == LEDMODE_ON) {
+      writePinHigh(LED_GREEN);
+  }
+}
+
+void eeconfig_init_user(void) {  // EEPROM is getting reset! 
+  led_config.raw = 0;
+  led_config.red_mode = LEDMODE_ON;
+  led_config.green_mode = LEDMODE_MODS;
+      eeconfig_update_user(led_config.raw);
+  eeconfig_update_user(led_config.raw);
+}
+
 uint32_t layer_state_set_user(uint32_t state) {
   return update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
 }
 
+void led_keypress_update(uint8_t led, uint8_t led_mode, uint16_t keycode, keyrecord_t *record) {
+    switch (led_mode) {
+      case LEDMODE_MODS:
+        for (int i=0;i<sizeof(modifiers) / sizeof(modifiers[0]);i++) {
+          if(keycode==modifiers[i]) {
+            if (record->event.pressed) {
+              writePinHigh(led);
+            }
+            else {
+              writePinLow(led);
+            }
+          }
+        }
+        break;
+      case LEDMODE_BLINKIN:
+        if (record->event.pressed) {
+          if(rand() % 2 == 1) {
+            if(rand() % 2 == 0) {
+              writePinLow(led);
+            }
+            else {
+              writePinHigh(led);
+            }
+          }
+        }
+        break;
+      case LEDMODE_KEY:
+        if (record->event.pressed) {
+          writePinHigh(led);
+          return;
+        }
+        else {
+          writePinLow(led);
+          return;
+        }
+        break;
+      case LEDMODE_ENTER:
+        if (keycode==KC_ENT) {
+          writePinHigh(led);
+        }
+        else {
+          writePinLow(led);
+        }
+        break;
+
+    }
+}
+
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  /* If the either led mode is keypressed based, call the led updater
+     then let it fall through the keypress handlers. Just to keep 
+     the logic out of this procedure */
+  if (led_config.red_mode >= LEDMODE_MODS && led_config.red_mode <= LEDMODE_ENTER) {
+      led_keypress_update(LED_RED, led_config.red_mode, keycode, record);
+  }
+  if (led_config.green_mode >= LEDMODE_MODS && led_config.green_mode <= LEDMODE_ENTER) {
+      led_keypress_update(LED_GREEN, led_config.green_mode, keycode, record);
+  }
   switch (keycode) {
     case QWERTY:
       if (record->event.pressed) {
@@ -215,6 +336,74 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
       if (record->event.pressed) {
         layer_off(_PLOVER);
       }
+      return false;
+      break;
+    case LED_1:
+      if (record->event.pressed) {
+        if (led_config.red_mode==LEDMODE_ON) {
+            led_config.red_mode=LEDMODE_OFF;
+            writePinLow(LED_RED);
+        }
+        else {
+            led_config.red_mode=LEDMODE_ON;
+            writePinHigh(LED_RED);
+        }
+      }
+      eeconfig_update_user(led_config.raw);
+      return false;
+      break;
+    case LED_2:
+      if (record->event.pressed) {
+        if (led_config.green_mode==LEDMODE_ON) {
+            led_config.green_mode=LEDMODE_OFF;
+            writePinLow(LED_GREEN);
+        }
+        else {
+            led_config.green_mode=LEDMODE_ON;
+            writePinHigh(LED_GREEN);
+        }
+      }
+      eeconfig_update_user(led_config.raw);
+      return false;
+      break;
+    case LED_3:
+      led_config.red_mode=LEDMODE_MODS;
+      eeconfig_update_user(led_config.raw);
+      return false;
+      break;
+    case LED_4:
+      led_config.green_mode=LEDMODE_MODS;
+      eeconfig_update_user(led_config.raw);
+      return false;
+      break;
+    case LED_5:
+      led_config.red_mode=LEDMODE_BLINKIN;
+      eeconfig_update_user(led_config.raw);
+      return false;
+      break;
+    case LED_6:
+      led_config.green_mode=LEDMODE_BLINKIN;
+      eeconfig_update_user(led_config.raw);
+      return false;
+      break;
+    case LED_7:
+      led_config.red_mode=LEDMODE_KEY;
+      eeconfig_update_user(led_config.raw);
+      return false;
+      break;
+    case LED_8:
+      led_config.green_mode=LEDMODE_KEY;
+      eeconfig_update_user(led_config.raw);
+      return false;
+      break;
+    case LED_9:
+      led_config.red_mode=LEDMODE_ENTER;
+      eeconfig_update_user(led_config.raw);
+      return false;
+      break;
+    case LED_0:
+      led_config.green_mode=LEDMODE_ENTER;
+      eeconfig_update_user(led_config.raw);
       return false;
       break;
   }

--- a/keyboards/plaid/keymaps/default/readme.md
+++ b/keyboards/plaid/keymaps/default/readme.md
@@ -1,2 +1,32 @@
 # The default keymap for plaid
-folk from planck
+Original copyright 2019 Takuya Urakawa (dm9records.com)
+LED Support added  by Richard Sutherland (rich@brickbots.com)
+
+This layout is based on the Planck layout, and includes an adjust layer (6)
+accessible by holding the lower and raise modifiers (MO3 and MO4) together.
+The adjustment layer is used to set the behavior of the two LEDs:
+
+Modifier Mode: 
+
+Activates when any modifier (shift, alt, os, MO) key is held
+down.  LED turns off when key is release
+
+Blinkinlights Mode:
+Random chance of state change on each keystroke.
+
+Keypress Mode:
+On for any keypress as long as the key is pressed
+
+Carriage Mode:
+Turns on when enter is pressed, turns off when any next key is pressed
+
+q = Toggle Red LED state, deactivates any other modes
+w = Toggle Green LED state, deactivates any other modes
+e = Set RED LED to modifier mode
+r = Set GREEN LED to modifier mode
+t = Set RED LED to Blinkinlights mode
+y = set GREEN LED to Blinkinlights mode
+u = set RED LED to Keypress mode
+i = set GREEN LED to Keypress mode
+o = set RED LED to Carriage mode
+p = set GREEN LED to Carriage mode

--- a/keyboards/plaid/plaid.h
+++ b/keyboards/plaid/plaid.h
@@ -63,3 +63,6 @@
 #define LAYOUT_planck_mit LAYOUT_plaid_mit
 #define LAYOUT_kc_ortho_4x12 KC_KEYMAP
 #define KC_LAYOUT_ortho_4x12 KC_KEYMAP
+
+#define LED_RED C5
+#define LED_GREEN C4


### PR DESCRIPTION
## Description

The plaid keyboard has two LEDs installed, but there was no functionality in the code to activate them.  I've added some, hopefully, interesting and fun modes for these little guys.

plaid/plaid.h - Added two constants for the LED pins to ease any keymap dev to add functionality
plaid/keymaps/default/readme.md - Added documentation on how to set various LED modes
plaid/keymaps/default/keymap.c -
* Altered keymap to include 10 led mode keys on the adjust layer
* Added code to handle new led mode keys, save to eeprom
* Added handler for changing state of LEDs as appropriate for each mode

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [X ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* None

## Checklist

- [X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).