### PR TITLE
40percent/gherkin Midi Layout

### DIFF
--- a/keyboards/40percentclub/gherkin/keymaps/midi/config.h
+++ b/keyboards/40percentclub/gherkin/keymaps/midi/config.h
@@ -1,0 +1,30 @@
+/*
+Copyright 2012 Jun Wako <wakojun@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef CONFIG_USER_H
+#define CONFIG_USER_H
+
+#include "../../config.h"
+
+
+#undef TAPPING_TERM
+#define TAPPING_TERM 190
+
+#define MUSIC_MASK (keycode != KC_NO)
+#define MIDI_ADVANCED
+
+#endif

--- a/keyboards/40percentclub/gherkin/keymaps/midi/config.h
+++ b/keyboards/40percentclub/gherkin/keymaps/midi/config.h
@@ -15,16 +15,10 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
-
-#include "../../config.h"
-
+#pragma once
 
 #undef TAPPING_TERM
 #define TAPPING_TERM 190
 
 #define MUSIC_MASK (keycode != KC_NO)
 #define MIDI_ADVANCED
-
-#endif

--- a/keyboards/40percentclub/gherkin/keymaps/midi/keymap.c
+++ b/keyboards/40percentclub/gherkin/keymaps/midi/keymap.c
@@ -1,10 +1,7 @@
 #include QMK_KEYBOARD_H
 
-extern keymap_config_t keymap_config;
-
 enum layer_number {
-  _BASE = 0,
-  _IONIAN,
+  _IONIAN = 0,
   _DORIAN,
   _PHRYGIAN,
   _LYDIAN,
@@ -15,8 +12,7 @@ enum layer_number {
 };
 
 enum custom_keycodes {
-  BASE = SAFE_RANGE,
-  IONIAN,
+  IONIAN = SAFE_RANGE,
   DORIAN,
   PHRYGIAN,
   LYDIAN,
@@ -28,17 +24,10 @@ enum custom_keycodes {
 #define MENU MO(_MENU)
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-  // Basic controls like octave and transpose
-  [_BASE] = LAYOUT_ortho_3x10(
-    _______, _______, _______, _______, _______, _______, _______, _______, MI_OCTD,  MI_OCTU,
-    _______, _______, _______, _______, _______, _______, _______, _______, MI_TRNSD, MI_TRNSU,
-    _______, _______, _______, _______, _______, _______, _______, _______, MI_SUS,   MENU
-  ),
-
   [_IONIAN] = LAYOUT_ortho_3x10(
-    MI_C_1,  MI_F_1,  MI_B_1,  MI_E_2,  MI_A_2,  MI_D_3,  MI_G_3,  MI_C_4,  _______, _______,
-    MI_D_1,  MI_G_1,  MI_C_2,  MI_F_2,  MI_B_2,  MI_E_3,  MI_A_3,  MI_D_4,  _______, _______,
-    MI_E_1,  MI_A_1,  MI_D_2,  MI_G_2,  MI_C_3,  MI_F_3,  MI_B_3,  MI_E_4,  _______, _______
+    MI_C_1,  MI_F_1,  MI_B_1,  MI_E_2,  MI_A_2,  MI_D_3,  MI_G_3,  MI_C_4,  MI_OCTD,  MI_OCTU,
+    MI_D_1,  MI_G_1,  MI_C_2,  MI_F_2,  MI_B_2,  MI_E_3,  MI_A_3,  MI_D_4,  MI_TRNSD, MI_TRNSU,
+    MI_E_1,  MI_A_1,  MI_D_2,  MI_G_2,  MI_C_3,  MI_F_3,  MI_B_3,  MI_E_4,  MI_SUS, MENU
   ),
 
   [_DORIAN] = LAYOUT_ortho_3x10(
@@ -84,54 +73,42 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   )
 };
 
-void persistent_default_layer_set(uint16_t default_layer){
-    eeconfig_update_default_layer(default_layer);
-    default_layer_set(default_layer);
-};
-
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
   switch (keycode) {
     case IONIAN:
       if (record->event.pressed) {
-        persistent_default_layer_set(1UL<<_IONIAN);
+        set_single_persistent_default_layer(_IONIAN);
       }
-      return false;
       break;
     case DORIAN:
       if (record->event.pressed) {
-        persistent_default_layer_set(1UL<<_DORIAN);
+        set_single_persistent_default_layer(_DORIAN);
       }
-      return false;
       break;
     case PHRYGIAN:
       if (record->event.pressed) {
-        persistent_default_layer_set(1UL<<_PHRYGIAN);
+        set_single_persistent_default_layer(_PHRYGIAN);
       }
-      return false;
       break;
     case LYDIAN:
       if (record->event.pressed) {
-        persistent_default_layer_set(1UL<<_LYDIAN);
+        set_single_persistent_default_layer(_LYDIAN);
       }
-      return false;
       break;
     case MIXOLYDIAN:
       if (record->event.pressed) {
-        persistent_default_layer_set(1UL<<_MIXOLYDIAN);
+        set_single_persistent_default_layer(_MIXOLYDIAN);
       }
-      return false;
       break;
     case AEOLIAN:
       if (record->event.pressed) {
-        persistent_default_layer_set(1UL<<_AEOLIAN);
+        set_single_persistent_default_layer(_AEOLIAN);
       }
-      return false;
       break;
     case LOCRIAN:
       if (record->event.pressed) {
-        persistent_default_layer_set(1UL<<_LOCRIAN);
+        set_single_persistent_default_layer(_LOCRIAN);
       }
-      return false;
       break;
   }
   return true;

--- a/keyboards/40percentclub/gherkin/keymaps/midi/keymap.c
+++ b/keyboards/40percentclub/gherkin/keymaps/midi/keymap.c
@@ -1,0 +1,138 @@
+#include QMK_KEYBOARD_H
+
+extern keymap_config_t keymap_config;
+
+enum layer_number {
+  _BASE = 0,
+  _IONIAN,
+  _DORIAN,
+  _PHRYGIAN,
+  _LYDIAN,
+  _MIXOLYDIAN,
+  _AEOLIAN,
+  _LOCRIAN,
+  _MENU
+};
+
+enum custom_keycodes {
+  BASE = SAFE_RANGE,
+  IONIAN,
+  DORIAN,
+  PHRYGIAN,
+  LYDIAN,
+  MIXOLYDIAN,
+  AEOLIAN,
+  LOCRIAN,
+};
+
+#define MENU MO(_MENU)
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  // Basic controls like octave and transpose
+  [_BASE] = LAYOUT_ortho_3x10(
+    _______, _______, _______, _______, _______, _______, _______, _______, MI_OCTD,  MI_OCTU,
+    _______, _______, _______, _______, _______, _______, _______, _______, MI_TRNSD, MI_TRNSU,
+    _______, _______, _______, _______, _______, _______, _______, _______, MI_SUS,   MENU
+  ),
+
+  [_IONIAN] = LAYOUT_ortho_3x10(
+    MI_C_1,  MI_F_1,  MI_B_1,  MI_E_2,  MI_A_2,  MI_D_3,  MI_G_3,  MI_C_4,  _______, _______,
+    MI_D_1,  MI_G_1,  MI_C_2,  MI_F_2,  MI_B_2,  MI_E_3,  MI_A_3,  MI_D_4,  _______, _______,
+    MI_E_1,  MI_A_1,  MI_D_2,  MI_G_2,  MI_C_3,  MI_F_3,  MI_B_3,  MI_E_4,  _______, _______
+  ),
+
+  [_DORIAN] = LAYOUT_ortho_3x10(
+    MI_C_1,  MI_F_1,  MI_As_1, MI_Ds_2, MI_A_2,  MI_D_3,  MI_G_3,  MI_C_4,  _______, _______,
+    MI_D_1,  MI_G_1,  MI_C_2,  MI_F_2,  MI_As_2, MI_Ds_3, MI_A_3,  MI_D_4,  _______, _______,
+    MI_Ds_1, MI_A_1,  MI_D_2,  MI_G_2,  MI_C_3,  MI_F_3,  MI_As_3, MI_Ds_4, _______, _______
+  ),
+
+  [_PHRYGIAN] = LAYOUT_ortho_3x10(
+    MI_C_1,  MI_F_1,  MI_As_1, MI_Ds_2, MI_Gs_2, MI_Cs_3, MI_G_3,  MI_C_4,  _______, _______,
+    MI_Cs_1, MI_G_1,  MI_C_2,  MI_F_2,  MI_As_2, MI_Ds_3, MI_Gs_3, MI_Cs_4, _______, _______,
+    MI_Ds_1, MI_Gs_1, MI_Cs_2, MI_G_2,  MI_C_3,  MI_F_3,  MI_As_3, MI_Ds_4, _______, _______
+  ),
+
+  [_LYDIAN] = LAYOUT_ortho_3x10(
+    MI_C_1,  MI_Fs_1, MI_B_1,  MI_E_2,  MI_A_2,  MI_D_3,  MI_G_3,  MI_C_4,  _______, _______,
+    MI_D_1,  MI_G_1,  MI_C_2,  MI_Fs_2, MI_B_2,  MI_E_3,  MI_A_3,  MI_D_4,  _______, _______,
+    MI_E_1,  MI_A_1,  MI_D_2,  MI_G_2,  MI_C_3,  MI_Fs_3, MI_B_3,  MI_E_4,  _______, _______
+  ),
+
+  [_MIXOLYDIAN] = LAYOUT_ortho_3x10(
+    MI_C_1,  MI_F_1,  MI_As_1, MI_E_2,  MI_A_2,  MI_D_3,  MI_G_3,  MI_C_4,  _______, _______,
+    MI_D_1,  MI_G_1,  MI_C_2,  MI_F_2,  MI_As_2, MI_E_3,  MI_A_3,  MI_D_4,  _______, _______,
+    MI_E_1,  MI_A_1,  MI_D_2,  MI_G_2,  MI_C_3,  MI_F_3,  MI_As_3, MI_E_4,  _______, _______
+  ),
+
+  [_AEOLIAN] = LAYOUT_ortho_3x10(
+    MI_C_1,  MI_F_1,  MI_As_1, MI_Ds_2, MI_Gs_2, MI_D_3,  MI_G_3,  MI_C_4,  _______, _______,
+    MI_D_1,  MI_G_1,  MI_C_2,  MI_F_2,  MI_As_2, MI_Ds_3, MI_Gs_3, MI_D_4,  _______, _______,
+    MI_Ds_1, MI_Gs_1, MI_D_2,  MI_G_2,  MI_C_3,  MI_F_3,  MI_As_3, MI_Ds_4, _______, _______
+  ),
+
+  [_LOCRIAN] = LAYOUT_ortho_3x10(
+    MI_C_1,  MI_F_1,  MI_As_1, MI_Ds_2, MI_Gs_2, MI_Cs_3, MI_Fs_3, MI_C_4,  _______, _______,
+    MI_Cs_1, MI_Fs_1, MI_C_2,  MI_F_2,  MI_As_2, MI_Ds_3, MI_Gs_3, MI_Cs_4, _______, _______,
+    MI_Ds_1, MI_Gs_1, MI_Cs_2, MI_Fs_2, MI_C_3,  MI_F_3,  MI_As_3, MI_Ds_4, _______, _______
+  ),
+
+  [_MENU] = LAYOUT_ortho_3x10(
+    IONIAN,   LYDIAN,     LOCRIAN, _______, _______, _______, _______, _______, _______, _______,
+    DORIAN,   MIXOLYDIAN, _______, _______, _______, _______, _______, _______, _______, _______,
+    PHRYGIAN, AEOLIAN,    _______, _______, _______, _______, _______, _______, RESET,   _______
+  )
+};
+
+void persistent_default_layer_set(uint16_t default_layer){
+    eeconfig_update_default_layer(default_layer);
+    default_layer_set(default_layer);
+};
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  switch (keycode) {
+    case IONIAN:
+      if (record->event.pressed) {
+        persistent_default_layer_set(1UL<<_IONIAN);
+      }
+      return false;
+      break;
+    case DORIAN:
+      if (record->event.pressed) {
+        persistent_default_layer_set(1UL<<_DORIAN);
+      }
+      return false;
+      break;
+    case PHRYGIAN:
+      if (record->event.pressed) {
+        persistent_default_layer_set(1UL<<_PHRYGIAN);
+      }
+      return false;
+      break;
+    case LYDIAN:
+      if (record->event.pressed) {
+        persistent_default_layer_set(1UL<<_LYDIAN);
+      }
+      return false;
+      break;
+    case MIXOLYDIAN:
+      if (record->event.pressed) {
+        persistent_default_layer_set(1UL<<_MIXOLYDIAN);
+      }
+      return false;
+      break;
+    case AEOLIAN:
+      if (record->event.pressed) {
+        persistent_default_layer_set(1UL<<_AEOLIAN);
+      }
+      return false;
+      break;
+    case LOCRIAN:
+      if (record->event.pressed) {
+        persistent_default_layer_set(1UL<<_LOCRIAN);
+      }
+      return false;
+      break;
+  }
+  return true;
+}

--- a/keyboards/40percentclub/gherkin/keymaps/midi/readme.md
+++ b/keyboards/40percentclub/gherkin/keymaps/midi/readme.md
@@ -1,0 +1,14 @@
+### Gherkin Midi
+A gherkin midi layout that should cover most midi note playing needs.
+
+A 3x8 grid of notes written bottom left to right upwards as notes for the selected mode, with octave and transpose note controls at the top. Menu accesses other mode layouts, persisted to keyboard settings, and a reset for firmware programming.
+
+Modes are set by pressing Menu and their corresponding note from the C Ionian layout. That is, for Aeolian, press Menu and A 1. For Phrygian, press Menu and E 1.
+
+#### Keyboard Default Layout
+![](https://i.imgur.com/VNc0GsI.jpg)
+
+Keyboard Editor Gist [link](https://gist.github.com/scottsheffield/c57859fe1a85d703f5387bf8ce41028c)
+
+#### Glamour Shot
+![](https://i.imgur.com/B3Q4JoU.jpg)

--- a/keyboards/40percentclub/gherkin/keymaps/midi/rules.mk
+++ b/keyboards/40percentclub/gherkin/keymaps/midi/rules.mk
@@ -1,0 +1,75 @@
+# MCU name
+MCU = atmega32u4
+
+# Processor frequency.
+#     This will define a symbol, F_CPU, in all source code files equal to the
+#     processor frequency in Hz. You can then use this symbol in your source code to
+#     calculate timings. Do NOT tack on a 'UL' at the end, this will be done
+#     automatically to create a 32-bit value in your source code.
+#
+#     This will be an integer division of F_USB below, as it is sourced by
+#     F_USB after it has run through any CPU prescalers. Note that this value
+#     does not *change* the processor frequency - it should merely be updated to
+#     reflect the processor speed set externally so that the code can use accurate
+#     software delays.
+F_CPU = 16000000
+
+#
+# LUFA specific
+#
+# Target architecture (see library "Board Types" documentation).
+ARCH = AVR8
+
+# Input clock frequency.
+#     This will define a symbol, F_USB, in all source code files equal to the
+#     input clock frequency (before any prescaling is performed) in Hz. This value may
+#     differ from F_CPU if prescaling is used on the latter, and is required as the
+#     raw input clock is fed directly to the PLL sections of the AVR for high speed
+#     clock generation for the USB and other AVR subsections. Do NOT tack on a 'UL'
+#     at the end, this will be done automatically to create a 32-bit value in your
+#     source code.
+#
+#     If no clock division is performed on the input clock inside the AVR (via the
+#     CPU clock adjust registers or the clock division fuses), this will be equal to F_CPU.
+F_USB = $(F_CPU)
+
+# Interrupt driven control endpoint task(+60)
+OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
+
+
+# Bootloader selection
+#   Teensy       halfkay
+#   Pro Micro    caterina
+#   Atmel DFU    atmel-dfu
+#   LUFA DFU     lufa-dfu
+#   QMK DFU      qmk-dfu
+#   atmega32a    bootloadHID
+BOOTLOADER = caterina
+
+
+# If you don't know the bootloader type, then you can specify the
+# Boot Section Size in *bytes* by uncommenting out the OPT_DEFS line
+#   Teensy halfKay      512
+#   Teensy++ halfKay    1024
+#   Atmel DFU loader    4096
+#   LUFA bootloader     4096
+#   USBaspLoader        2048
+# OPT_DEFS += -DBOOTLOADER_SIZE=4096
+
+
+# Build Options
+#   comment out to disable the options.
+#
+BOOTMAGIC_ENABLE = no	# Virtual DIP switch configuration(+1000)
+MOUSEKEY_ENABLE = no	  # Mouse keys(+4700)
+EXTRAKEY_ENABLE = no	  # Audio control and System control(+450)
+CONSOLE_ENABLE = no	    # Console for debug(+400)
+COMMAND_ENABLE = no     # Commands for debug and configuration
+SLEEP_LED_ENABLE = no   # Breathing sleep LED during USB suspend
+NKRO_ENABLE = yes		    # USB Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+BACKLIGHT_ENABLE = no  # Enable keyboard backlight functionality
+AUDIO_ENABLE = no
+RGBLIGHT_ENABLE = no
+MIDI_ENABLE = yes
+
+LAYOUTS = ortho_3x10

--- a/keyboards/40percentclub/gherkin/keymaps/midi/rules.mk
+++ b/keyboards/40percentclub/gherkin/keymaps/midi/rules.mk
@@ -1,75 +1,8 @@
-# MCU name
-MCU = atmega32u4
-
-# Processor frequency.
-#     This will define a symbol, F_CPU, in all source code files equal to the
-#     processor frequency in Hz. You can then use this symbol in your source code to
-#     calculate timings. Do NOT tack on a 'UL' at the end, this will be done
-#     automatically to create a 32-bit value in your source code.
-#
-#     This will be an integer division of F_USB below, as it is sourced by
-#     F_USB after it has run through any CPU prescalers. Note that this value
-#     does not *change* the processor frequency - it should merely be updated to
-#     reflect the processor speed set externally so that the code can use accurate
-#     software delays.
-F_CPU = 16000000
-
-#
-# LUFA specific
-#
-# Target architecture (see library "Board Types" documentation).
-ARCH = AVR8
-
-# Input clock frequency.
-#     This will define a symbol, F_USB, in all source code files equal to the
-#     input clock frequency (before any prescaling is performed) in Hz. This value may
-#     differ from F_CPU if prescaling is used on the latter, and is required as the
-#     raw input clock is fed directly to the PLL sections of the AVR for high speed
-#     clock generation for the USB and other AVR subsections. Do NOT tack on a 'UL'
-#     at the end, this will be done automatically to create a 32-bit value in your
-#     source code.
-#
-#     If no clock division is performed on the input clock inside the AVR (via the
-#     CPU clock adjust registers or the clock division fuses), this will be equal to F_CPU.
-F_USB = $(F_CPU)
-
-# Interrupt driven control endpoint task(+60)
-OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
-
-
-# Bootloader selection
-#   Teensy       halfkay
-#   Pro Micro    caterina
-#   Atmel DFU    atmel-dfu
-#   LUFA DFU     lufa-dfu
-#   QMK DFU      qmk-dfu
-#   atmega32a    bootloadHID
-BOOTLOADER = caterina
-
-
-# If you don't know the bootloader type, then you can specify the
-# Boot Section Size in *bytes* by uncommenting out the OPT_DEFS line
-#   Teensy halfKay      512
-#   Teensy++ halfKay    1024
-#   Atmel DFU loader    4096
-#   LUFA bootloader     4096
-#   USBaspLoader        2048
-# OPT_DEFS += -DBOOTLOADER_SIZE=4096
-
-
-# Build Options
-#   comment out to disable the options.
-#
 BOOTMAGIC_ENABLE = no	# Virtual DIP switch configuration(+1000)
 MOUSEKEY_ENABLE = no	  # Mouse keys(+4700)
 EXTRAKEY_ENABLE = no	  # Audio control and System control(+450)
 CONSOLE_ENABLE = no	    # Console for debug(+400)
 COMMAND_ENABLE = no     # Commands for debug and configuration
-SLEEP_LED_ENABLE = no   # Breathing sleep LED during USB suspend
-NKRO_ENABLE = yes		    # USB Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
 BACKLIGHT_ENABLE = no  # Enable keyboard backlight functionality
-AUDIO_ENABLE = no
 RGBLIGHT_ENABLE = no
 MIDI_ENABLE = yes
-
-LAYOUTS = ortho_3x10


### PR DESCRIPTION
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Added a midi layout for gherkin, assuming vertical layout with USB port at the top.

Mod layer used to set and persist Modal change, includes keys for octave and transposition changes on base layer off of which modal note layers inherit.

I would mention here that I'm very open to help setting a default layer other than 0 (ideally all layers could fallback to 0 but default would start on 1 / Ionian), but also generally open to any suggestions on how to make this better.

Similarly, while I based my layout on code I've read on other keyboard layouts, I'm not entirely certain whether I'm strictly adhering to the code style of this project.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Keymap/layout/userspace (addition or update)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).

Necessary glamour shot:
![00100dPORTRAIT_00100_BURST20190614195358909_COVER](https://user-images.githubusercontent.com/1342826/59544532-69c75380-8ee0-11e9-9b2f-40783f234056.jpg)

