### PR TITLE
Install avrdude in Arch or Manjaro Linux

### DIFF
--- a/util/linux_install.sh
+++ b/util/linux_install.sh
@@ -61,6 +61,7 @@ elif grep ID /etc/os-release | grep -q 'arch\|manjaro'; then
 		arm-none-eabi-binutils \
 		arm-none-eabi-gcc \
 		arm-none-eabi-newlib \
+		avrdude \
 		avr-binutils \
 		avr-libc \
 		avr-gcc \


### PR DESCRIPTION
avrdude is require package but not installed by script when arch linux.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Here is steps to reproduce.

```shell
% pacman --remove avrdude
% ./util/qmk_install.sh

# ...snip...

% sudo make meishi:default:avrdude
QMK Firmware 0.6.400
WARNING:
 Some git sub-modules are out of date or modified, please consider running:
 make git-submodule
 You can ignore this warning if you are not compiling any ChibiOS keyboards,
 or if you have modified the ChibiOS libraries yourself.

Making meishi with keymap default and target avrdude

avr-gcc (GCC) 9.1.0
Copyright (C) 2019 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Size before:
   text    data     bss     dec     hex filename
      0   22116       0   22116    5664 .build/meishi_default.hex

Compiling: tmk_core/common/command.c                                                                [OK]
Linking: .build/meishi_default.elf                                                                  [OK]
Creating load file for flashing: .build/meishi_default.hex                                          [OK]
Copying meishi_default.hex to qmk_firmware folder                                                   [OK]
Checking file size of meishi_default.hex                                                            [OK]
 * The firmware size is fine - 22116/28672 (6556 bytes free)
Detecting USB port, reset your controller now.......
Device /dev/ttyACM0 has appeared; assuming it is the controller.
Waiting for /dev/ttyACM0 to become writable.
sh: avrdude: command not found
make[1]: *** [tmk_core/avr.mk:235: avrdude] Error 127
Make finished with errors
make: *** [Makefile:553: meishi:default:avrdude] Error 1

%
```

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
