### PR TITLE
Add tool to generate rgb matrix position data from KLE raw data.

### DIFF
--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -151,7 +151,37 @@ x = 224 / (NUMBER_OF_COLS - 1) * COL_POSITION
 y =  64 / (NUMBER_OF_ROWS - 1) * ROW_POSITION
 ```
 
-Where NUMBER_OF_COLS, NUMBER_OF_ROWS, COL_POSITION, & ROW_POSITION are all based on the physical layout of your keyboard, not the electrical layout. 
+Where NUMBER_OF_COLS, NUMBER_OF_ROWS, COL_POSITION, & ROW_POSITION are all based on the physical layout of your keyboard, not the electrical layout.
+
+For more complex layouts there is a tool ./utils/rgb_matrix_tool.py which can be used to generate the position matrix, though you'll have to reorder the elements if your LED's are not sequential.
+This uses the RAWDATA from the KeyboardLayoutEditor, to generate an accurate matrix from the key positions.
+
+```C
+./utils/rgb_matrix_tool.py keyboard.rawdata
+```
+e.g. if keyboard.rawdata contains:
+```C
+["F1","F2","F3","F4"],
+[{y:0.25},"Num Lock","/","*","-"],
+["7\nHome","8\n↑","9\nPgUp",{h:2},"+"],
+["4\n←","5","6\n→"],
+["1\nEnd","2\n↓","3\nPgDn",{h:2},"Enter"],
+[{w:2},"0\nIns",".\nDel"]
+```
+rgb_matrix_tool.py would generate:
+```C
+Keyboard dimension: 4.0 x 6.25
+Keyboard key count: 21
+
+         /*    0    */ /*    1    */ /*    2    */ /*    3    */
+/*  0 */ {   0,   0 }, {  75,   0 }, { 149,   0 }, { 224,   0 },
+/*  1 */ {   0,  15 }, {  75,  15 }, { 149,  15 }, { 224,  15 },
+/*  2 */ {   0,  27 }, {  75,  27 }, { 149,  27 }, { 224,  34 },
+/*  3 */ {   0,  40 }, {  75,  40 }, { 149,  40 },
+/*  4 */ {   0,  52 }, {  75,  52 }, { 149,  52 }, { 224,  58 },
+/*  5 */ {  37,  64 }, { 149,  64 },
+
+```
 
 As mentioned earlier, the center of the keyboard by default is expected to be `{ 112, 32 }`, but this can be changed if you want to more accurately calculate the LED's physical `{ x, y }` positions. Keyboard designers can implement `#define RGB_MATRIX_CENTER { 112, 32 }` in their config.h file with the new center point of the keyboard, or where they want it to be allowing more possibilities for the `{ x, y }` values. Do note that the maximum value for x or y is 255, and the recommended maximum is 224 as this gives animations runoff room before they reset.
 

--- a/util/rgb_matrix_tool.py
+++ b/util/rgb_matrix_tool.py
@@ -1,0 +1,245 @@
+#!/bin/env python
+"""Parse RawData from KeyboardLayoutGenerator and generate RGB position matrix."""
+
+import argparse
+import sys
+import json
+import re
+
+class Key:
+    """Define key class."""
+    ORIGIN_CENTER = 1
+    ORIGIN_TOP_LEFT = 2
+    ORIGIN_BOTTOM_RIGHT = 3
+
+    def __init__(self, label, x=0.0, y=0.0, w=1.0, h=1.0, origin=None):
+        """Init key."""
+        self.x = x
+        self.y = y
+        self.w = w
+        self.h = h
+        self.label = label
+        self.origin = origin if origin else self.ORIGIN_CENTER
+
+    @property
+    def origin_x(self):
+        """Calculate X origin ."""
+        if self.origin == self.ORIGIN_CENTER:
+            value = self.x + (self.w / 2.0)
+        elif self.origin == self.ORIGIN_TOP_LEFT:
+            value = self.x
+        elif self.origin == self.ORIGIN_BOTTOM_RIGHT:
+            value = self.x + self.w
+
+        return value
+
+    @property
+    def origin_y(self):
+        """Calculate Y origin ."""
+        if self.origin == self.ORIGIN_CENTER:
+            value = self.y + (self.h / 2.0)
+        elif self.origin == self.ORIGIN_TOP_LEFT:
+            value = self.y
+        elif self.origin == self.ORIGIN_BOTTOM_RIGHT:
+            value = self.y + self.h
+
+        return value
+
+    def __str__(self):
+        """.Dump out string"""
+        return u"{0.x}, {0.y}   {0.w}, {0.h}".format(self)
+
+    def get_matrix_position(self, width, height):
+        """Calculate x/y."""
+        return [self.origin_x * width, self.origin_y * height]
+
+def get_key(row, x=0.0, y=0.0, origin=Key.ORIGIN_CENTER):
+    """Column iterator for kle data."""
+    w = 1.0
+    h = 1.0
+
+    for i in row:
+        if isinstance(i, unicode):
+            k = Key(i, x, y, w, h, origin)
+            x += w
+            w = 1.0
+            h = 1.0
+            yield k
+        elif isinstance(i, dict):
+            if "w" in i:
+                w = i["w"]
+            if "h" in i:
+                h = i["h"]
+            if "y" in i:
+                y += i["y"]
+            if "x" in i:
+                x += i["x"]
+
+
+class Keyboard:
+    """Define keyboard."""
+    def __init__(self, data, origin=Key.ORIGIN_CENTER):
+        """Init keyboard."""
+        self.rows = []
+        self.width = 0.0
+        self.height = 0.0
+        self.origin = origin
+        self.columns = 0
+
+        y = 0.0
+        for row in data:
+            x = 0.0
+            key_row=[]
+            c = 0
+            for key in get_key(row, x=x, y=y, origin=self.origin):
+                c += 1
+                if (key.x + key.w) > self.width:
+                    self.width = key.x + key.w
+
+                if (key.y + key.h) > self.height:
+                    self.height = key.y + key.h
+
+                if key.y > y:
+                    y = key.y
+
+                key_row.append(key)
+            if c > self.columns:
+                self.columns = c
+            self.rows.append(key_row)
+            y += 1.0
+
+
+    def __len__(self):
+        """Count keys."""
+        return sum([len(x) for x in self.rows])
+
+    def get_matrix_positions(self, width, height):
+        """Generate list of lists."""
+        cellx = float(width) / (self.width - 1.0)
+        celly = float(height) / (self.height - 1.0)
+        rows = []
+        for r in self.rows:
+            row = []
+            for c in r:
+                x, y = c.get_matrix_position(cellx, celly)
+                if self.origin == Key.ORIGIN_CENTER:
+                    row.append([int((x-(cellx/2))+0.5), int((y-(celly/2))+0.5)])
+                elif self.origin == Key.ORIGIN_TOP_LEFT:
+                    row.append([int(x+0.5), int(y+0.5)])
+                elif self.origin == Key.ORIGIN_BOTTOM_RIGHT:
+                    row.append([int((x-cellx)+0.5), int((y-celly)+0.5)])
+            rows.append(row)
+
+        return rows
+
+def as_cpp(pos):
+    """Format as cpp header."""
+    return "{{ {0:3}, {1:3} }},".format(*pos)
+
+def main():# pylint: disable=R0914,R0915,R1260
+    """Do main function."""
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument(
+        "path",
+        type=str,
+        nargs="*",
+        default=[],
+        help="Path to rawdata, read stdin otherwise."
+    )
+
+    parser.add_argument(
+        "--width",
+        type=int,
+        default=224,
+        action="store",
+        help="Structure max X."
+    )
+
+    parser.add_argument(
+        "--height",
+        type=int,
+        default=64,
+        action="store",
+        help="Structure max Y."
+    )
+
+    parser.add_argument(
+        "--origin",
+        choices=[
+            "CENTER",
+            "TOP_LEFT",
+            "BOTTOM_RIGHT",
+        ],
+        help="Origin of key, for positioning",
+        default="CENTER"
+    )
+
+    parser.add_argument(
+        "-d", "--debug",
+        default=False,
+        action="store_true",
+        help="Debug mode."
+    )
+
+    args = parser.parse_args()
+
+    data = ""
+
+    if args.path:
+        with open(args.path[0], "r") as o:
+            data = o.read()
+    else:
+        # try stdin
+        while True:
+            try:
+                line = sys.stdin.readline()
+            except KeyboardInterrupt:
+                break
+
+            if not line:
+                break
+
+            line = line.strip()
+
+            if line:
+                data += line
+
+    # massage into JSON.. WHY doesn't KLE use JSON!
+    data = re.sub("([a-z0-9]+):", "\"\\1\":", data)
+
+    data = json.loads("[" + data + "]")
+    if args.debug:
+        for d in data:
+            print d
+
+    if args.origin == "CENTER":
+        origin = Key.ORIGIN_CENTER
+    elif args.origin == "TOP_LEFT":
+        origin = Key.ORIGIN_TOP_LEFT
+    elif args.origin == "BOTTOM_RIGHT":
+        origin = Key.ORIGIN_BOTTOM_RIGHT
+    kb = Keyboard(data, origin)
+
+    print "Keyboard dimension:", kb.width, "x", kb.height
+    print "Keyboard key count:", len(kb)
+    print
+    row_i = 0
+    print "        ",
+    for c in range(kb.columns):
+        print "/* {0:^7} */".format(c),
+    print
+    for r in kb.get_matrix_positions(args.width, args.height):
+        print "/* {0:2} */".format(row_i),
+        for c in r:
+            print as_cpp(c),
+        print
+        row_i += 1
+
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Description

New tool to allow generation of RGB matrix LED position data, from KLE RawData.
Had to do this manually for a TKL keyboard, it was painful, this should help others to not suffer the same fate.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
