### PR TITLE
Set default I2C clock speed to 100kHz for split_common

### DIFF
--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -93,8 +93,8 @@ This is a C header file that is one of the first things included, and will persi
   * key combination that allows the use of magic commands (useful for debugging)
 * `#define USB_MAX_POWER_CONSUMPTION`
   * sets the maximum power (in mA) over USB for the device (default: 500)
-* `#define SCL_CLOCK 100000L`
-  * sets the SCL_CLOCK speed for split keyboards. The default is `100000L` but some boards can be set to `400000L`.
+* `#define F_SCL 100000L`
+  * sets the I2C clock rate speed for keyboards using I2C. The default is `400000L`, except for keyboards using `split_common`, where the default is `100000L`.
 
 ## Features That Can Be Disabled
 

--- a/quantum/split_common/post_config.h
+++ b/quantum/split_common/post_config.h
@@ -4,6 +4,10 @@
     #define RGBLIGHT_SPLIT
   #endif
 
+  #ifndef F_SCL
+    #define F_SCL 100000UL  // SCL frequency
+  #endif
+
 #else  // use serial
   // When using serial, the user must define RGBLIGHT_SPLIT explicitly
   //  in config.h as needed.


### PR DESCRIPTION
## Description

Restores default I2C clock speed to 100kHz, after it was switched to 400kHz during refactor to use core I2C driver instead of split_common specific one.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/qmk/qmk_firmware/issues/5569

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
