### PR TITLE
Add idle/wakeup function calls to Ergodox EZ

### DIFF
--- a/keyboards/ergodox_ez/ergodox_ez.c
+++ b/keyboards/ergodox_ez/ergodox_ez.c
@@ -304,4 +304,14 @@ led_config_t g_led_config = { {
     4, 4, 1, 1, 1, 1
 } };
 
+void suspend_power_down_kb(void) {
+    rgb_matrix_set_suspend_state(true);
+    suspend_power_down_user();
+}
+
+ void suspend_wakeup_init_kb(void) {
+    rgb_matrix_set_suspend_state(false);
+    suspend_wakeup_init_user();
+}
+
 #endif


### PR DESCRIPTION
Adds the function calls for the idle/wakeup functionality, so that the board will "sleep" the LEDs  when enabled. 


## Types of Changes
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)

## Checklist
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
