### PR TITLE
Reword confusing description of `TO(layer)`

### DIFF
--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -298,7 +298,7 @@ This is a reference only. Each group of keys links to the page documenting their
 |`LM(layer, mod)`|Momentarily turn on `layer` (like MO) with `mod` active as well.  Where `mod` is a mods_bit.  Mods can be viewed [here](https://docs.qmk.fm/#/feature_advanced_keycodes?id=mod-tap).  Example Implementation: `LM(LAYER_1, MOD_LALT)`|
 |`LT(layer, kc)` |Turn on `layer` when held, `kc` when tapped                                       |
 |`TG(layer)`     |Toggle `layer` on or off                                                          |
-|`TO(layer)`     |Replace active layer stack with only `layer` and the default layer                |
+|`TO(layer)`     |Turns on `layer` and turns off all other layers, except the default layer |
 |`TT(layer)`     |Normally acts like MO unless it's tapped multiple times, which toggles `layer` on |
 
 ## [Mouse Keys](feature_mouse_keys.md)

--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -298,7 +298,7 @@ This is a reference only. Each group of keys links to the page documenting their
 |`LM(layer, mod)`|Momentarily turn on `layer` (like MO) with `mod` active as well.  Where `mod` is a mods_bit.  Mods can be viewed [here](https://docs.qmk.fm/#/feature_advanced_keycodes?id=mod-tap).  Example Implementation: `LM(LAYER_1, MOD_LALT)`|
 |`LT(layer, kc)` |Turn on `layer` when held, `kc` when tapped                                       |
 |`TG(layer)`     |Toggle `layer` on or off                                                          |
-|`TO(layer)`     |Turn on `layer` when pressed                                                      |
+|`TO(layer)`     |Replace active layer stack with only `layer` and the default layer                |
 |`TT(layer)`     |Normally acts like MO unless it's tapped multiple times, which toggles `layer` on |
 
 ## [Mouse Keys](feature_mouse_keys.md)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Current docs suggest that a key which is mapped to `TO(n+1)` where `n` is the current layer, except on layer 4 where the key is mapped to `TO(0)`, will result in the following sequence as it is pressed:

```
1
1+2
1+2+3
1+2+3+4
1+2+3+4
1+2+3+4
...
```

This is not actually what `TO(layer)` does, so this pull request makes it clearer on the summary page.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation