### PR TITLE
Cannonkeys Instant60 Configurator updates

### DIFF
--- a/keyboards/cannonkeys/instant60/instant60.h
+++ b/keyboards/cannonkeys/instant60/instant60.h
@@ -4,7 +4,7 @@
 
 #define KNO KC_NO
 
-#define LAYOUT_ansi( \
+#define LAYOUT_60_ansi( \
   K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C, K0D, \
   K10, K11, K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, K1C,      K1E, \
   K20, K21, K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B,           K2E, \
@@ -18,7 +18,7 @@
   {  K40,  K41,  K42,  KNO,  KNO,    K45,    KNO,    KNO,    KNO,    K49,  K4A,  K4B,  KNO,  KNO,  K4E  }  \
 }
 
-#define LAYOUT_tsangan( \
+#define LAYOUT_60_tsangan_hhkb( \
   K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C, K0D, K0E, \
   K10, K11, K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, K1C,      K1E, \
   K20, K21, K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B,           K2E, \

--- a/keyboards/cannonkeys/instant60/keymaps/default/keymap.c
+++ b/keyboards/cannonkeys/instant60/keymaps/default/keymap.c
@@ -30,7 +30,7 @@ enum custom_keycodes {
 };
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-  [_BASE] = LAYOUT_ansi(
+  [_BASE] = LAYOUT_60_ansi(
     KC_GESC, KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,                 KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,   KC_BSPC, \
     KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,   KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC,  KC_BSLS, \
     KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,                 KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,           KC_ENT,  \
@@ -38,7 +38,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     KC_LCTL, KC_LGUI, KC_LALT,                            KC_SPC,                                          KC_RALT, KC_RGUI, MO(_FN1), KC_RCTL
   ),
 
-  [_FN1] = LAYOUT_ansi(
+  [_FN1] = LAYOUT_60_ansi(
     KC_GESC, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_DEL, \
     RGB_TOG, RGB_MOD, KC_UP,   _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, \
     BL_BRTG, KC_LEFT, KC_DOWN, KC_RGHT, _______, _______, _______, _______, _______, _______, _______, _______,          _______, \

--- a/keyboards/cannonkeys/instant60/keymaps/tsangan/keymap.c
+++ b/keyboards/cannonkeys/instant60/keymaps/tsangan/keymap.c
@@ -30,7 +30,7 @@ enum custom_keycodes {
 };
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-  [_BASE] = LAYOUT_tsangan(
+  [_BASE] = LAYOUT_60_tsangan_hhkb(
     KC_GESC, KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,                 KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,   KC_BSLS, KC_DEL, \
     KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,   KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC,  KC_BSPC, \
     KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,                 KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,           KC_ENT,  \
@@ -38,7 +38,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     KC_LCTL, KC_LGUI, KC_LALT,                            KC_SPC,                                          KC_RALT, KC_RGUI, KC_RCTL
   ),
 
-  [_FN1] = LAYOUT_tsangan(
+  [_FN1] = LAYOUT_60_tsangan_hhkb(
     KC_GRV, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_DEL, _______,\
     RGB_TOG, RGB_MOD, KC_UP,   _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, \
     BL_BRTG, KC_LEFT, KC_DOWN, KC_RGHT, _______, _______, _______, _______, _______, _______, _______, _______,          _______, \

--- a/keyboards/cannonkeys/instant60/rules.mk
+++ b/keyboards/cannonkeys/instant60/rules.mk
@@ -54,3 +54,4 @@ RGBLIGHT_ENABLE = yes
 # RAW_ENABLE = yes
 # DYNAMIC_KEYMAP_ENABLE = yes
 
+LAYOUTS = 60_ansi 60_tsangan_hhkb


### PR DESCRIPTION
## Description

Provides QMK Configurator support for both ANSI and Tsangan variants of the Instant60.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)

## Notes

- Instant60 layouts are currently blocks of 1u keys in QMK Configurator.
  - flagged by @yanfali 
- `LAYOUT_all` macro is unchanged, per @awkannan's request. There are some ideas to deal with this moving forward.
- Also, as @awkannan is the keyboard maintainer, I'd like to have his "OK" on the record before these changes are merged.
- @skullydazed would probably call this a `breaking change` because of the layout macro renaming, which could break unmerged user keymaps. I'm willing to alias the layout macros to maintain backwards compatibility, but I would prefer not to do so.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
