### PR TITLE
[Keymap] kifinnsson's dz60 keymap

### DIFF
--- a/keyboards/dz60/keymaps/kifinnsson/keymap.c
+++ b/keyboards/dz60/keymaps/kifinnsson/keymap.c
@@ -1,0 +1,210 @@
+#include QMK_KEYBOARD_H
+
+bool is_lgui_active = false;
+uint16_t lgui_timer = 0;
+
+
+//Macro Declarations
+enum my_keycodes {
+  KI_NO = SAFE_RANGE,
+    KI_1,
+    KI_2,
+    KI_3,
+    KI_4,
+    KI_5,
+    KI_6,
+    KI_7,
+    KI_8,
+    KI_9,
+    KI_10,
+    KI_11,
+    KI_12,
+    KI_ESC,
+    KI_BKSP,
+    KI_BSLS,
+    KI_WLFT,
+    KI_WRGT,
+    };
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+	LAYOUT_all(
+		KC_GESC, KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,   KC_8,     KC_9,    KC_0,    KC_MINS, KC_EQL,  XXXXXXX, KC_BSPC,
+		KC_TAB,  KC_Q,    KC_W,    KC_F,    KC_P,    KC_G,    KC_J,    KC_L,   KC_U,     KC_Y,    KC_SCLN, KC_LBRC, KC_RBRC, KC_BSLS,
+		MO(1),   KC_A,    KC_R,    KC_S,    KC_T,    KC_D,    KC_H,    KC_N,   KC_E,     KC_I,    KC_O,    KC_QUOT, KC_ENT,
+		KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    MO(2),   KC_K,   KC_M,     KC_COMM, KC_DOT,  KC_SLSH, XXXXXXX, KC_RSFT, XXXXXXX,
+		KC_LCTL, KC_LGUI, KC_LALT, KC_SPC,  KC_SPC,  KC_SPC,  KC_RALT, MO(1),  XXXXXXX,  MO(3),   KC_RCTL),
+
+	LAYOUT_all(
+		KC_GRV,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_DEL,
+		_______, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, KC_PGUP, KC_HOME, KC_UP,   KC_END,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+		_______, XXXXXXX, KC_TAB,  KC_LSFT, KC_LCTL, XXXXXXX, KC_PGDN, KC_LEFT, KC_DOWN, KC_RGHT, KC_DEL,  KC_CAPS, XXXXXXX,
+		_______, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, _______, KC_BSPC, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,,
+		_______, _______, XXXXXXX, KC_ENT,  KC_ENT,  KC_ENT,  _______, _______, _______, _______, RESET),
+
+	LAYOUT_all(
+		KI_ESC,  _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, XXXXXXX, KI_BKSP,
+		_______, KI_1,    KI_2,    KI_3,    KI_4,    KI_5,    KI_6,    KI_7,    KI_8,    KI_9,    KI_10,   KI_11,   KI_12,   KI_BSLS,
+		_______, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+		_______, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, _______, XXXXXXX, XXXXXXX, KI_WLFT, KI_WRGT, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+		_______, _______, _______, _______, _______, _______, _______, _______, XXXXXXX, _______, XXXXXXX),
+
+	LAYOUT_all(
+		_______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+		_______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+		_______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+		_______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+		_______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______),
+};
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  switch (keycode) {
+    // Keycodes Starting with KI_ are place holders for my personal macros. They are set below. Most are simple SEND_STRINGS().
+    case KI_ESC:
+      if (record->event.pressed) {
+        SEND_STRING("");
+      } else {
+        
+      }
+      return false; // Skip all further processing of this key
+    case KI_1:
+      if (record->event.pressed) {
+        SEND_STRING("");
+      } else {
+        
+      }
+      return false; // Skip all further processing of this key
+    case KI_2:
+      if (record->event.pressed) {
+        SEND_STRING("");
+      } else {
+        
+      }
+      return false; // Skip all further processing of this key
+    case KI_3:
+      if (record->event.pressed) {
+        SEND_STRING("");
+      } else {
+        
+      }
+      return false; // Skip all further processing of this key
+    case KI_4:
+      if (record->event.pressed) {
+        SEND_STRING("");
+      } else {
+        
+      }
+      return false; // Skip all further processing of this key
+    case KI_5:
+      if (record->event.pressed) {
+        SEND_STRING("");
+      } else {
+        
+      }
+      return false; // Skip all further processing of this key
+    case KI_6:
+      if (record->event.pressed) {
+        SEND_STRING("");
+      } else {
+        
+      }
+      return false; // Skip all further processing of this key
+    case KI_7:
+      if (record->event.pressed) {
+        SEND_STRING("");
+      } else {
+        
+      }
+      return false; // Skip all further processing of this key
+    case KI_8:
+      if (record->event.pressed) {
+        SEND_STRING("");
+      } else {
+        
+      }
+      return false; // Skip all further processing of this key
+    case KI_9:
+      if (record->event.pressed) {
+        SEND_STRING("");
+      } else {
+        
+      }
+      return false; // Skip all further processing of this key
+    case KI_10:
+      if (record->event.pressed) {
+        SEND_STRING("");
+      } else {
+        
+      }
+      return false; // Skip all further processing of this key
+    case KI_11:
+      if (record->event.pressed) {
+        SEND_STRING("");
+      } else {
+        
+      }
+      return false; // Skip all further processing of this key
+    case KI_12:
+      if (record->event.pressed) {
+        SEND_STRING("");
+      } else {
+        
+      }
+      return false; // Skip all further processing of this key
+    case KI_BKSP:
+      if (record->event.pressed) {
+        SEND_STRING("");
+      } else {
+        
+      }
+      return false; // Skip all further processing of this key
+    case KI_BSLS:
+      if (record->event.pressed) {
+        SEND_STRING("");
+      } else {
+        
+      }
+      return false; // Skip all further processing of this key
+
+    //Windows Win+Left tap to move window without resetting KC_LGUI
+    //Additional code is in matrix_scan_user()
+    case KI_WLFT:
+      if (record->event.pressed) {
+        if (!is_lgui_active) {
+          is_lgui_active = true;
+          register_code(KC_LGUI);
+        } 
+        lgui_timer = timer_read();
+        tap_code(KC_LEFT);
+      } else {
+        
+      }
+      return false; // Skip all further processing of this key
+    //Windows Win+Right tap to move window without resetting KC_LGUI
+    //Additional code is in matrix_scan_user()
+    case KI_WRGT:
+      if (record->event.pressed) {
+        if (!is_lgui_active) {
+          is_lgui_active = true;
+          register_code(KC_LGUI);
+        } 
+        lgui_timer = timer_read();
+        tap_code(KC_RIGHT);
+      } else {
+        
+      }
+      return false; // Skip all further processing of this key
+    default:
+      return true; // Process all other keycodes normally
+  }
+}
+
+//Check if KC_LGUI is active in KI_WLFT and KI_WRGT
+void matrix_scan_user(void) { 
+  if (is_lgui_active) {
+    if (timer_elapsed(lgui_timer) > 1000) {
+      unregister_code(KC_LGUI);
+      is_lgui_active = false;
+    }
+  }
+}

--- a/keyboards/dz60/keymaps/kifinnsson/readme.md
+++ b/keyboards/dz60/keymaps/kifinnsson/readme.md
@@ -1,0 +1,19 @@
+# DZ60:kifinnsson
+
+kifinnsson's Colemak angle mod ansi layout
+-----------------
+This is built as an ISO layout on the left and an ANSI layout on the right. This creates an [Angle Mod](https://colemakmods.github.io/ergonomic-mods/angle.html) ANSI Colemak layout however row 4 has an extra key which I place between "B" and "K" and is used for my macros on layer 2. If you build one with my wonkyness feel free to use it as a template. If you didn't build as I did you are not going to have a good time. This a cleaned up / sanitized version for pubilshing upstream. 
+
+![dz60](https://cdn.shopify.com/s/files/1/1473/3902/files/1_6525343b-ee62-47e8-882a-05e316136a3f.jpg?v=1501657073)
+
+A customizable 60% keyboard.
+
+Keyboard Maintainer: QMK Community  
+Hardware Supported: DZ60
+Hardware Availability: [kbdfans](https://kbdfans.myshopify.com/collections/pcb/products/dz60-60-pcb?variant=40971616717)
+
+Make example for this keyboard (after setting up your build environment):
+
+    make dz60:kifinnson
+
+See [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) then the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information.

--- a/keyboards/dz60/keymaps/kifinnsson/readme.md
+++ b/keyboards/dz60/keymaps/kifinnsson/readme.md
@@ -9,7 +9,7 @@ This is built as an ISO layout on the left and an ANSI layout on the right. This
 A customizable 60% keyboard.
 
 Keyboard Maintainer: QMK Community  
-Hardware Supported: DZ60
+Hardware Supported: DZ60  
 Hardware Availability: [kbdfans](https://kbdfans.myshopify.com/collections/pcb/products/dz60-60-pcb?variant=40971616717)
 
 Make example for this keyboard (after setting up your build environment):

--- a/keyboards/dz60/keymaps/kifinnsson/rules.mk
+++ b/keyboards/dz60/keymaps/kifinnsson/rules.mk
@@ -1,0 +1,6 @@
+# Build Options
+#   comment out to disable the options.
+#
+BOOTMAGIC_ENABLE = no	# Virtual DIP switch configuration(+1000)
+MOUSEKEY_ENABLE = no	# Mouse keys(+4700)
+EXTRAKEY_ENABLE = no	# Audio control and System control(+450)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## kifinnsson's keymap for the DZ60 Keyboard
Keymap for my non-standard DZ60 layout. It is an ansi layout on the right and iso on the left (ie 1.25x left shift). This is to implement the angle mod on for Colemak which is the base layer. A side effect of this is that I have an extra key on row 4, which sits between the "b" and "k" keys in Colemak. I use this key as a switch to layer 2 which is my macro layer.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
