### PR TITLE
[keymap] use lowercase send_string for non-literals

### DIFF
--- a/keyboards/planck/keymaps/callum/keymap.c
+++ b/keyboards/planck/keymaps/callum/keymap.c
@@ -184,7 +184,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 bool send_string_if_keydown(keyrecord_t *record, const char *s) {
     if (record->event.pressed) {
-        SEND_STRING(s);
+        send_string(s);
     }
     return true;
 }


### PR DESCRIPTION
Sorry for another PR so soon after the last one, not sure why this worked for my v6 but it doesn't work for my v5... 😬

The lowercase `send_string` seems to do the trick though.