### PR TITLE
Configure Vagrant to use qmk_base_container

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -74,15 +74,15 @@ Vagrant.configure(2) do |config|
       end
 
       override.vm.provision "shell", inline: <<-SHELL
-        echo 'exec docker exec -it qmkfm-base_container /bin/bash -l' >> ~vagrant/.bashrc
+        echo 'docker restart qmkfm-base_container && exec docker exec -it qmkfm-base_container /bin/bash -l' >> ~vagrant/.bashrc
       SHELL
     end
   end
 
   config.vm.post_up_message = <<-EOT
 
-  Log into the VM using 'vagrant ssh'. QMK directory synchronized with host is
-  located at /vagrant
+  Log into the environment using 'vagrant ssh'. QMK directory synchronized with
+  host is located at /vagrant
   To compile the .hex files use make command inside this directory, e.g.
      cd /vagrant
      make <keyboard>:default

--- a/docs/getting_started_vagrant.md
+++ b/docs/getting_started_vagrant.md
@@ -1,16 +1,20 @@
 # Vagrant Quick Start
 
-This project includes a Vagrantfile that will allow you to build a new firmware for your keyboard very easily without major changes to your primary operating system. This also ensures that when you clone the project and perform a build, you have the exact same environment as anyone else using the Vagrantfile to build. This makes it much easier for people to help you troubleshoot any issues you encounter.
+This project includes a `Vagrantfile` that will allow you to build a new firmware for your keyboard very easily without major changes to your primary operating system. This also ensures that when you clone the project and perform a build, you have the exact same environment as anyone else using the Vagrantfile to build. This makes it much easier for people to help you troubleshoot any issues you encounter.
 
 ## Requirements
 
-Using the `/Vagrantfile` in this repository requires you have [Vagrant](http://www.vagrantup.com/) as well as [VirtualBox](https://www.virtualbox.org/) (or [VMware Workstation](https://www.vmware.com/products/workstation) and [Vagrant VMware plugin](http://www.vagrantup.com/vmware) but the (paid) VMware plugin requires a licensed copy of VMware Workstation/Fusion).
+Using the `Vagrantfile` in this repository requires you have [Vagrant](http://www.vagrantup.com/) as well as a supported provider installed:
 
-*COMPATIBILITY NOTICE* Certain versions of Virtualbox 5 appear to have an incompatibility with the Virtualbox extensions installed in the boxes in this Vagrantfile. If you encounter any issues with the /vagrant mount not succeeding, please upgrade your version of Virtualbox to at least 5.0.12. **Alternately, you can try running the following command:** `vagrant plugin install vagrant-vbguest`
+* [VirtualBox](https://www.virtualbox.org/) (Version at least 5.0.12)
+  * Sold as 'the most accessible platform to use Vagrant'
+* [VMware Workstation](https://www.vmware.com/products/workstation) and [Vagrant VMware plugin](http://www.vagrantup.com/vmware)
+  * The (paid) VMware plugin requires a licensed copy of VMware Workstation/Fusion
+* [Docker](https://www.docker.com/)
 
-Other than having Vagrant and Virtualbox installed and possibly a restart of your computer afterwards, you can simple run a 'vagrant up' anywhere inside the folder where you checked out this project and it will start a Linux virtual machine that contains all the tools required to build this project. There is a post Vagrant startup hint that will get you off on the right foot, otherwise you can also reference the build documentation below.
+Other than having Vagrant, a suitable provider installed and possibly a restart of your computer afterwards, you can simple run a 'vagrant up' anywhere inside the folder where you checked out this project and it will start an environment (either a virtual machine or container) that contains all the tools required to build this project. There is a post Vagrant startup hint that will get you off on the right foot, otherwise you can also reference the build documentation below.
 
-# Flashing the Firmware
+## Flashing the Firmware
 
 The "easy" way to flash the firmware is using a tool from your host OS:
 
@@ -19,3 +23,35 @@ The "easy" way to flash the firmware is using a tool from your host OS:
 * [Atmel FLIP](http://www.atmel.com/tools/flip.aspx)
 
 If you want to program via the command line you can uncomment the ['modifyvm'] lines in the Vagrantfile to enable the USB passthrough into Linux and then program using the command line tools like dfu-util/dfu-programmer or you can install the Teensy CLI version.
+
+## Vagrantfile Overview
+The development environment is configured to run the QMK Docker image, `qmkfm/base_container`. This not only ensures predictability between systems, it also mirrors the CI environment.
+
+## FAQ
+
+### Why am I seeing issues under Virtualbox?
+Certain versions of Virtualbox 5 appear to have an incompatibility with the Virtualbox extensions installed in the boxes in this Vagrantfile. If you encounter any issues with the /vagrant mount not succeeding, please upgrade your version of Virtualbox to at least 5.0.12. **Alternately, you can try running the following command:**
+
+```console
+vagrant plugin install vagrant-vbguest
+```
+
+### How do I remove an existing environment?
+Finished with your environment? From anywhere inside the folder where you checked out this project, Execute:
+
+```console
+vagrant destory
+```
+
+### What if I want to use Docker directly?
+Want to benefit from the Vagrant workflow without a virtual machine? The Vagrantfile is configured to bypass running a virtual machine, and run the container directly. Execute the following when bringing up the environment to force the use of Docker:
+```console
+vagrant up --provider=docker
+```
+
+### How do I access the virtual machine instead of the Docker container?
+Execute the following to bypass the `vagrant` user booting directly to the official qmk builder image:
+
+```console
+vagrant ssh -c 'sudo -i'
+```

--- a/util/vagrant/Dockerfile
+++ b/util/vagrant/Dockerfile
@@ -1,0 +1,33 @@
+FROM qmkfm/base_container
+
+# Basic upgrades; install sudo and SSH.
+RUN apt-get update && apt-get install --no-install-recommends -y \
+        sudo \
+        openssh-server \
+    && rm -rf /var/lib/apt/lists/*
+RUN mkdir /var/run/sshd
+RUN sed -i 's/PermitRootLogin yes/PermitRootLogin no/' /etc/ssh/sshd_config
+RUN echo 'UseDNS no' >> /etc/ssh/sshd_config
+
+# Remove the policy file once we're finished installing software.
+# This allows invoke-rc.d and friends to work as expected.
+RUN rm /usr/sbin/policy-rc.d
+
+# Add the Vagrant user and necessary passwords.
+RUN groupadd vagrant
+RUN useradd -c "Vagrant" -g vagrant -d /home/vagrant -m -s /bin/bash vagrant
+RUN echo 'root:vagrant' | chpasswd
+RUN echo 'vagrant:vagrant' | chpasswd
+
+# Allow the vagrant user to use sudo without a password.
+RUN echo 'vagrant ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/vagrant
+
+# Install Vagrant's insecure public key so provisioning and 'vagrant ssh' work.
+RUN mkdir /home/vagrant/.ssh
+ADD https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub /home/vagrant/.ssh/authorized_keys
+RUN chmod 0600 /home/vagrant/.ssh/authorized_keys
+RUN chown -R vagrant:vagrant /home/vagrant/.ssh
+RUN chmod 0700 /home/vagrant/.ssh
+
+EXPOSE 22
+CMD ["/usr/sbin/sshd", "-D"]

--- a/util/vagrant/readme.md
+++ b/util/vagrant/readme.md
@@ -1,0 +1,12 @@
+# QMK Vagrant Utilities
+
+## Dockerfile
+Vagrant-friendly `qmkfm/base_container`.
+
+In order for the Docker provider and `vagrant ssh` to function the container has a few extra requirements.
+
+* vagrant user
+* ssh server
+  * configured with expected public key
+* sudo
+  * passwordless for vagrant user


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
To help with environment predictability, this PR configures Vagrant to use qmk_base_container.

The process is as follows:

vagrant up
```
if using docker directly
  build a slightly modified qmk_base_container with ssh
  run container
else
  build Debian vm
  install docker
  pull qmk_base_container
  run container
  patch so that we jump directly to container instead of to vm
```

vagrant ssh
```
  Running inside qmk_base_container with the predicable toolchain
```

To an new/existing vagrant user, the change is transparent, and should not change the workflow.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
