### PR TITLE
Fix Layer-Tap and Layer Mod overlap issues

### DIFF
--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -254,7 +254,7 @@ void process_action(keyrecord_t *record, action_t action)
             {
                 uint8_t mods = (action.kind.id == ACT_LMODS_TAP) ?  action.key.mods :
                                                                     action.key.mods<<4;
-                switch (action.layer_tap.code) {
+                switch (action.key.code) {
     #ifndef NO_ACTION_ONESHOT
                     case MODS_ONESHOT:
                         // Oneshot modifier
@@ -435,14 +435,18 @@ void process_action(keyrecord_t *record, action_t action)
         case ACT_LAYER_TAP:
         case ACT_LAYER_TAP_EXT:
             switch (action.layer_tap.code) {
-                case 0xe0 ... 0xef:
+                case 0xc0 ... 0xdf:
                     /* layer On/Off with modifiers(left only) */
                     if (event.pressed) {
                         layer_on(action.layer_tap.val);
-                        register_mods(action.layer_tap.code & 0x0f);
+                        register_mods((action.layer_tap.code & 0x10) ?
+                            (action.layer_tap.code & 0x0f) << 4 :
+                            (action.layer_tap.code & 0x0f));
                     } else {
                         layer_off(action.layer_tap.val);
-                        unregister_mods(action.layer_tap.code & 0x0f);
+                        unregister_mods((action.layer_tap.code & 0x10) ?
+                            (action.layer_tap.code & 0x0f) << 4 :
+                            (action.layer_tap.code & 0x0f));
                     }
                     break;
                 case OP_TAP_TOGGLE:
@@ -949,10 +953,20 @@ bool is_tap_action(action_t action)
     switch (action.kind.id) {
         case ACT_LMODS_TAP:
         case ACT_RMODS_TAP:
+            switch (action.key.code) {
+                case MODS_ONESHOT:
+                case MODS_TAP_TOGGLE:
+                case KC_A ... KC_EXSEL:                 // tap key
+                case KC_LCTRL ... KC_RGUI:              // tap key
+                    return true;
+            }
         case ACT_LAYER_TAP:
         case ACT_LAYER_TAP_EXT:
             switch (action.layer_tap.code) {
-                case 0x00 ... 0xdf:
+                case 0xc0 ... 0xdf:         // with modifiers
+                    return false;
+                case KC_A ... KC_EXSEL:     // tap key
+                case KC_LCTRL ... KC_RGUI:  // tap key
                 case OP_TAP_TOGGLE:
                 case OP_ONESHOT:
                     return true;

--- a/tmk_core/common/action_code.h
+++ b/tmk_core/common/action_code.h
@@ -202,6 +202,7 @@ typedef union {
  *   bit 4      +----- LR flag(Left:0, Right:1)
  */
 enum mods_bit {
+    MOD_NONE = 0x00,
     MOD_LCTL = 0x01,
     MOD_LSFT = 0x02,
     MOD_LALT = 0x04,
@@ -277,7 +278,7 @@ enum layer_param_tap_op {
 #define ACTION_LAYER_OFF_ON(layer)                  ACTION_LAYER_TAP((layer), OP_OFF_ON)
 #define ACTION_LAYER_SET_CLEAR(layer)               ACTION_LAYER_TAP((layer), OP_SET_CLEAR)
 #define ACTION_LAYER_ONESHOT(layer)                 ACTION_LAYER_TAP((layer), OP_ONESHOT)
-#define ACTION_LAYER_MODS(layer, mods)              ACTION_LAYER_TAP((layer), 0xe0 | ((mods)&0x0f))
+#define ACTION_LAYER_MODS(layer, mods)              ACTION_LAYER_TAP((layer), 0xc0 | ((mods)&0x1f))
 /* With Tapping */
 #define ACTION_LAYER_TAP_KEY(layer, key)            ACTION_LAYER_TAP((layer), (key))
 #define ACTION_LAYER_TAP_TOGGLE(layer)              ACTION_LAYER_TAP((layer), OP_TAP_TOGGLE)


### PR DESCRIPTION
Specifically, if you try to use a mode for LT, it causes issues, it's expecting mod bits.
Fixing this is trivial, but it breaks LM, since the fix is adding a conversation to mod bits, since it expects these to be mod bits and not a keycode.

The solution is backported from TMK, and basically shifts the mods into an unused section. This is actually used, but by the "KC_FN#" keycode section.  However, this should be okay, as these will be filtered out prior to being passed on to the correct functions.

This is not ideal, but shouldn't break anything (quick testing shows it to be okay). It doesn't seem to break anything. (eg shifted keys, and other keycodes work).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [x] Enhancement/optimization

## Issues Fixed or Closed by This PR

* https://www.reddit.com/r/olkb/comments/c4vemf/qmkbug_lt_fn1_kc_lgui_sends_lctrl_and_lshft/

## Checklist
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
