### PR TITLE
[keyboard] mitosis:datagrok: use non-copyrighted songs, add workman ditty

### DIFF
--- a/keyboards/mitosis/keymaps/datagrok/config.h
+++ b/keyboards/mitosis/keymaps/datagrok/config.h
@@ -27,13 +27,13 @@
 //#define NO_ACTION_FUNCTION
 
 #ifdef AUDIO_ENABLE
-#define STARTUP_SONG SONG(MARIO_MUSHROOM)
-#define DEFAULT_LAYER_SONGS {                   \
-    SONG(QWERTY_SOUND),                         \
-    SONG(COLEMAK_SOUND),                        \
-    SONG(DVORAK_SOUND),                         \
-    SONG(ZELDA_TREASURE),                       \
-  }
+#define STARTUP_SONG SONG(STARTUP_SOUND)
+#define DEFAULT_LAYER_SONGS { \
+        SONG(QWERTY_SOUND),   \
+        SONG(COLEMAK_SOUND),  \
+        SONG(DVORAK_SOUND),   \
+        SONG(WORKMAN_SOUND),  \
+        }
 #define AUDIO_VOICES
 #define AUDIO_CLICKY
 #define C6_AUDIO

--- a/quantum/audio/song_list.h
+++ b/quantum/audio/song_list.h
@@ -108,6 +108,17 @@
     S__NOTE(_REST),  \
     E__NOTE(_E7  ),
 
+#define WORKMAN_SOUND \
+    E__NOTE(_GS6 ), \
+    E__NOTE(_A6  ), \
+    S__NOTE(_REST), \
+    E__NOTE(_GS6 ), \
+    E__NOTE(_A6  ), \
+    S__NOTE(_REST), \
+    ED_NOTE(_FS7  ), \
+    S__NOTE(_REST), \
+    ED_NOTE(_A7 ),
+
 #define PLOVER_SOUND \
     E__NOTE(_GS6 ),  \
     E__NOTE(_A6  ),  \


### PR DESCRIPTION
## Description

Tiny changes in config.h for my keymap to refer to only the available (non-copyright-restricted) songs.

Adds a new variant of the layout-types mini-songs to `quantum/audio/song_list.h`, that I use for workman.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
