### PR TITLE
Fix shell.nix by pinning nixpkgs

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,17 +1,33 @@
-# dfu-programmer doesn't have darwin on it's list of supported platforms
-{ pkgs ? import <nixpkgs> { config = { allowUnsupportedSystem = true; }; }
-, avr ? true, arm ? true, teensy ? true }:
+{ avr ? true, arm ? true, teensy ? true }:
+
+let
+  overlay = self: super:
+    let addDarwinSupport = pkg: pkg.overrideAttrs (oldAttrs: {
+      meta.platforms = (oldAttrs.meta.platforms or []) ++ self.lib.platforms.darwin;
+    });
+    in {
+      dfu-programmer = addDarwinSupport super.dfu-programmer;
+      teensy-loader-cli = addDarwinSupport super.teensy-loader-cli;
+
+      avrgcc = super.avrgcc.overrideAttrs (oldAttrs: rec {
+        name = "avr-gcc-8.1.0";
+        src = super.fetchurl {
+          url = "mirror://gcc/releases/gcc-8.1.0/gcc-8.1.0.tar.xz";
+          sha256 = "0lxil8x0jjx7zbf90cy1rli650akaa6hpk8wk8s62vk2jbwnc60x";
+        };
+      });
+    };
+
+  nixpkgs = builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/0260747427737b980f0.tar.gz";
+    sha256 = "1p2yc6b40xvvxvmlqd9wb440pkrimnlc2wsbpa5rddlpx1dn8qmf";
+  };
+
+  pkgs = import nixpkgs { overlays = [ overlay ]; };
+in
 
 with pkgs;
-let
-  avrbinutils = pkgsCross.avr.buildPackages.binutils;
-  avrlibc = pkgsCross.avr.libcCross;
-  gcc-arm-embedded = (import (builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs-channels/archive/87f146a41c463a64c93022b11cf19716b3a22037.tar.gz";
-    sha256 = "0rk8haf19plw6vyvq0am99rik0hrrysknjw0f2vs7985awngy3q2";
-  }) {}).gcc-arm-embedded;
-
-  avr_incflags = [
+let avr_incflags = [
     "-isystem ${avrlibc}/avr/include"
     "-B${avrlibc}/avr/lib/avr5"
     "-L${avrlibc}/avr/lib/avr5"
@@ -20,15 +36,7 @@ let
     "-B${avrlibc}/avr/lib/avr51"
     "-L${avrlibc}/avr/lib/avr51"
   ];
-  avrgcc = pkgsCross.avr.buildPackages.gcc.overrideAttrs (oldAttrs: rec {
-    name = "avr-gcc-8.1.0";
-    src = fetchurl {
-      url = "mirror://gcc/releases/gcc-8.1.0/gcc-8.1.0.tar.xz";
-      sha256 = "0lxil8x0jjx7zbf90cy1rli650akaa6hpk8wk8s62vk2jbwnc60x";
-    };
-  });
 in
-
 stdenv.mkDerivation {
   name = "qmk-firmware";
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I tried to use `shell.nix`, but I ran into a build issue. To fix it, I found a commit in `nixpkgs` from around the time the file was made, and modified `shell.nix` to always use the version of `nixpkgs` at that commit. That way even as `nixpkgs` changes, this `shell.nix` file should always work.

I also tweaked the way we get around the fact that `dfu-programmer` and `teensy-loader-cli` are erroneously marked as unsupported on darwin, so that it only affects those two packages. I'm not sure what the status of theses packages is for the current version of `nixpkgs`, but maybe someone should submit a PR to nixpkgs to fix this upstream?

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
