### PR TITLE
Corrected Tanuki keymap to match physical appearance

### DIFF
--- a/keyboards/tanuki/config.h
+++ b/keyboards/tanuki/config.h
@@ -48,11 +48,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define LOCKING_RESYNC_ENABLE
 
 #define RGB_DI_PIN D1
+#ifdef RGB_DI_PIN
 #define RGBLIGHT_ANIMATIONS
 #define RGBLED_NUM 5
 #define RGBLIGHT_HUE_STEP 10
 #define RGBLIGHT_SAT_STEP 17
 #define RGBLIGHT_VAL_STEP 17
+#define RGBLIGHT_SLEEP
+#endif
 
 #define TAPPING_TERM 200
 /*

--- a/keyboards/tanuki/keymaps/default/keymap.c
+++ b/keyboards/tanuki/keymaps/default/keymap.c
@@ -16,34 +16,34 @@ bool lRGB = true;
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 [_BL] = LAYOUT(
-  KC_Q,     KC_W,     KC_E,     KC_R,    KC_T,     KC_Y,           KC_U,           KC_I,    KC_O,    KC_P,    KC_BSPC, \
-  KC_A,     KC_S,     KC_D,     KC_F,    KC_G,     KC_H,           KC_J,           KC_K,    KC_L,    KC_SCLN, TG(_GL), \
+  KC_ESC,   KC_Q,     KC_W,     KC_E,     KC_R,    KC_T,     KC_Y,           KC_U,           KC_I,    KC_O,    KC_P,    KC_BSPC, \
+  KC_TAB,   KC_A,     KC_S,     KC_D,     KC_F,    KC_G,     KC_H,           KC_J,           KC_K,    KC_L,    KC_SCLN, TG(_GL), \
   KC_LSFT,  KC_Z,     KC_X,     KC_C,    KC_V,     KC_B,           KC_N,           KC_M,    KC_QUOT, KC_SLSH, KC_ENT,  \
-  KC_TAB,   KC_ESC,   KC_LCTL,  KC_LALT, KC_COMMA, LT(_DL,KC_SPC), LT(_UL,KC_SPC),          KC_DOT,  KC_LGUI),
+  KC_LCTL,  KC_LALT, KC_COMMA, LT(_DL,KC_SPC), LT(_UL,KC_SPC),          KC_DOT,  KC_LGUI),
 
 [_DL] = LAYOUT(
-  KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,  KC_F12,\
-  KC_1,     KC_2,     KC_3,     KC_4,     KC_5,     KC_6,     KC_7,     KC_8,     KC_9,     KC_0,    KC_TRNS,\
+  KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,  KC_F12,\
+  KC_TRNS,  KC_1,     KC_2,     KC_3,     KC_4,     KC_5,     KC_6,     KC_7,     KC_8,     KC_9,     KC_0,    KC_TRNS,\
   KC_TRNS,  KC_PSCR,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  \
-  KC_TRNS,  KC_F1,    KC_TRNS,  RESET,    KC_TRNS,  KC_TRNS,  KC_TRNS,            KC_TRNS,  KC_TRNS),
+  KC_TRNS,  RESET,    KC_TRNS,  KC_TRNS,  KC_TRNS,            KC_TRNS,  KC_TRNS),
 
 [_UL] = LAYOUT(
-  KC_LBRC,  KC_RBRC,  KC_LCBR,  KC_RCBR,  KC_PIPE,  KC_BSLS,  KC_PLUS,  KC_UNDS,  KC_MINS,  KC_EQL,  KC_DEL,\
-  KC_EXLM,  KC_AT,    KC_HASH,  KC_DLR,   KC_PERC,  KC_CIRC,  KC_AMPR,  KC_ASTR,  KC_LPRN,  KC_RPRN, KC_TRNS, \
+  KC_GRV,   KC_LBRC,  KC_RBRC,  KC_LCBR,  KC_RCBR,  KC_PIPE,  KC_BSLS,  KC_PLUS,  KC_UNDS,  KC_MINS,  KC_EQL,  KC_DEL,\
+  KC_TRNS,  KC_EXLM,  KC_AT,    KC_HASH,  KC_DLR,   KC_PERC,  KC_CIRC,  KC_AMPR,  KC_ASTR,  KC_LPRN,  KC_RPRN, KC_TRNS, \
   KC_TRNS,  KC_FN0,   RGB_TOG,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  RGB_SAD,  RGB_VAD,  KC_TRNS,  KC_TRNS,  \
-  KC_TRNS,  KC_GRV,   KC_TRNS,  RGB_MOD,  RGB_HUI,  KC_TRNS,  KC_TRNS,            RGB_SAI,  RGB_VAI),
+  KC_TRNS,  RGB_MOD,  RGB_HUI,  KC_TRNS,  KC_TRNS,            RGB_SAI,  RGB_VAI),
 
 [_GL] = LAYOUT(
-  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_UP,    KC_TRNS,  KC_TRNS, \
-  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_LEFT,  KC_DOWN,  KC_RGHT,  KC_TRNS, \
+  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_UP,    KC_TRNS,  KC_TRNS, \
+  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_LEFT,  KC_DOWN,  KC_RGHT,  KC_TRNS, \
   KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  \
-  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_SPC,   KC_SPC,             KC_TRNS,  KC_TRNS),
+  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_SPC,   KC_SPC,             KC_TRNS,  KC_TRNS),
 
 [_BK] = LAYOUT(
-  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,\
-  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,\
+  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,\
+  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,\
   KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_NO,    KC_NO,    KC_TRNS,  KC_TRNS,  \
-  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_NO,    KC_NO,    KC_TRNS,  KC_FN1,  KC_NO,    KC_NO),
+  KC_TRNS,  KC_NO,    KC_NO,    KC_TRNS,  KC_FN1,  KC_NO,    KC_NO),
 
 };
 

--- a/keyboards/tanuki/tanuki.h
+++ b/keyboards/tanuki/tanuki.h
@@ -7,10 +7,10 @@
 // The first section contains all of the arguments
 // The second converts the arguments into a two-dimensional array
 #define LAYOUT( \
-	k00, k01, k02, k03, k04, k05, k06, k07, k08, k09, k0a, \
-	k10, k11, k12, k13, k14, k15, k16, k17, k18, k19, k1a, \
+	k31, k00, k01, k02, k03, k04, k05, k06, k07, k08, k09, k0a, \
+	k30, k10, k11, k12, k13, k14, k15, k16, k17, k18, k19, k1a, \
 	k20, k21, k22, k23, k24, k25, k26, k27, k28, k29, k2a, \
-	k30, k31, k32, k33, k34, k35, k36,      k38, k39 \
+	k32, k33, k34, k35, k36, k38, k39 \
 ) \
 { \
 		{k00, k01, k02, k03, k04, k05, k06, k07, k08, k09, k0a}, \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
The Tanuki keyboard uses different wiring layout from how it appears physically. It has 11 wired columns but 12 physical columns, the leftmost column keys are stacked in the following ones on the bottom row. See here to understand what I mean: 
![dfxcb](https://user-images.githubusercontent.com/24601129/60374280-f7886000-9a03-11e9-8ef3-2e6eb41c1de3.png)

This PR fixes that by modifying the default layout in tanuki.h and the default keymap to follow the physical appearance and don't confuse people. Since nobody else submitted their keymaps, it shouldn't break anything.

Also added support for RGB sleep.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
