### PR TITLE
Standardize how unicode is processed (fixes #6220)

### DIFF
--- a/docs/feature_unicode.md
+++ b/docs/feature_unicode.md
@@ -46,7 +46,8 @@ For instance, you could define a table like this in your keymap file:
 const qk_ucis_symbol_t ucis_symbol_table[] = UCIS_TABLE(
   UCIS_SYM("poop", 0x1F4A9), // 💩
   UCIS_SYM("rofl", 0x1F923), // 🤣
-  UCIS_SYM("kiss", 0x1F619)  // 😙
+  UCIS_SYM("kiss", 0x1F619), // 😙
+  UCIS_SYM("poops", 0x1F4A9, 0x1F4A9) // 💩💩 
 );
 ```
 
@@ -68,7 +69,7 @@ Unicode input in QMK works by inputting a sequence of characters to the OS, sort
 
 The following input modes are available:
 
-* **`UC_OSX`**: macOS built-in Unicode hex input. Supports code points up to `0xFFFF` (`0x10FFFF` with `UNICODEMAP`).
+* **`UC_OSX`**: macOS built-in Unicode hex input. Supports code points up to `0x10FFFF` (all possible code points).
 
   To enable, go to _System Preferences > Keyboard > Input Sources_, add _Unicode Hex Input_ to the list (it's under _Other_), then activate it from the input dropdown in the Menu Bar.
   By default, this mode uses the left Option key (`KC_LALT`) for Unicode input, but this can be changed by defining [`UNICODE_KEY_OSX`](#input-key-configuration) with another keycode.

--- a/quantum/process_keycode/process_ucis.c
+++ b/quantum/process_keycode/process_ucis.c
@@ -66,7 +66,7 @@ void qk_ucis_symbol_fallback (void) {
 
 void register_ucis(const uint32_t *codes) {
   uint8_t input_mode = get_unicode_input_mode();
-  for(int i = 0; i < UCIS_MAX_SYMBOL_LENGTH && codes[i]; i++) {
+  for(int i = 0; i < UCIS_MAX_CODE_LENGTH && codes[i]; i++) {
     uint32_t code = codes[i];
     register_unicode(code, input_mode);
     wait_ms (UNICODE_TYPE_DELAY);

--- a/quantum/process_keycode/process_ucis.c
+++ b/quantum/process_keycode/process_ucis.c
@@ -64,31 +64,12 @@ void qk_ucis_symbol_fallback (void) {
   }
 }
 
-void register_ucis(const char *hex) {
-  for(int i = 0; hex[i]; i++) {
-    uint8_t kc = 0;
-    char c = hex[i];
-
-    switch (c) {
-    case '0':
-      kc = KC_0;
-      break;
-    case '1' ... '9':
-      kc = c - '1' + KC_1;
-      break;
-    case 'a' ... 'f':
-      kc = c - 'a' + KC_A;
-      break;
-    case 'A' ... 'F':
-      kc = c - 'A' + KC_A;
-      break;
-    }
-
-    if (kc) {
-      register_code (kc);
-      unregister_code (kc);
-      wait_ms (UNICODE_TYPE_DELAY);
-    }
+void register_ucis(const uint32_t *codes) {
+  uint8_t input_mode = get_unicode_input_mode();
+  for(int i = 0; i < UCIS_MAX_SYMBOL_LENGTH && codes[i]; i++) {
+    uint32_t code = codes[i];
+    register_unicode(code, input_mode);
+    wait_ms (UNICODE_TYPE_DELAY);
   }
 }
 
@@ -133,18 +114,16 @@ bool process_ucis (uint16_t keycode, keyrecord_t *record) {
       return false;
     }
 
-    unicode_input_start();
     for (i = 0; ucis_symbol_table[i].symbol; i++) {
       if (is_uni_seq (ucis_symbol_table[i].symbol)) {
         symbol_found = true;
-        register_ucis(ucis_symbol_table[i].code + 2);
+        register_ucis(ucis_symbol_table[i].code);
         break;
       }
     }
     if (!symbol_found) {
       qk_ucis_symbol_fallback();
     }
-    unicode_input_finish();
 
     if (symbol_found) {
       qk_ucis_success(i);

--- a/quantum/process_keycode/process_ucis.h
+++ b/quantum/process_keycode/process_ucis.h
@@ -23,9 +23,13 @@
 #define UCIS_MAX_SYMBOL_LENGTH 32
 #endif
 
+#ifndef UCIS_MAX_CODE_LENGTH
+#define UCIS_MAX_CODE_LENGTH 3
+#endif
+
 typedef struct {
   char *symbol;
-  uint32_t code[UCIS_MAX_SYMBOL_LENGTH];
+  uint32_t code[UCIS_MAX_CODE_LENGTH];
 } qk_ucis_symbol_t;
 
 typedef struct {

--- a/quantum/process_keycode/process_ucis.h
+++ b/quantum/process_keycode/process_ucis.h
@@ -25,7 +25,7 @@
 
 typedef struct {
   char *symbol;
-  char *code;
+  uint32_t code[UCIS_MAX_SYMBOL_LENGTH];
 } qk_ucis_symbol_t;
 
 typedef struct {
@@ -36,8 +36,8 @@ typedef struct {
 
 extern qk_ucis_state_t qk_ucis_state;
 
-#define UCIS_TABLE(...) {__VA_ARGS__, {NULL, NULL}}
-#define UCIS_SYM(name, code) {name, #code}
+#define UCIS_TABLE(...) {__VA_ARGS__, {NULL, {}}}
+#define UCIS_SYM(name, ...) {name, {__VA_ARGS__}}
 
 extern const qk_ucis_symbol_t ucis_symbol_table[];
 
@@ -45,5 +45,5 @@ void qk_ucis_start(void);
 void qk_ucis_start_user(void);
 void qk_ucis_symbol_fallback (void);
 void qk_ucis_success(uint8_t symbol_index);
-void register_ucis(const char *hex);
+void register_ucis(const uint32_t *codes);
 bool process_ucis (uint16_t keycode, keyrecord_t *record);

--- a/quantum/process_keycode/process_unicode_common.h
+++ b/quantum/process_keycode/process_unicode_common.h
@@ -79,7 +79,10 @@ void unicode_input_finish(void);
 void unicode_input_cancel(void);
 
 void register_hex(uint16_t hex);
+void register_hex32(uint32_t hex);
 void send_unicode_hex_string(const char *str);
+
+void register_unicode(uint32_t code, uint8_t input_mode);
 
 bool process_unicode_common(uint16_t keycode, keyrecord_t *record);
 

--- a/quantum/process_keycode/process_unicodemap.c
+++ b/quantum/process_keycode/process_unicodemap.c
@@ -16,26 +16,6 @@
 
 #include "process_unicodemap.h"
 
-void register_hex32(uint32_t hex) {
-  bool onzerostart = true;
-  for(int i = 7; i >= 0; i--) {
-    if (i <= 3) {
-      onzerostart = false;
-    }
-    uint8_t digit = ((hex >> (i*4)) & 0xF);
-    if (digit == 0) {
-      if (!onzerostart) {
-        register_code(hex_to_keycode(digit));
-        unregister_code(hex_to_keycode(digit));
-      }
-    } else {
-      register_code(hex_to_keycode(digit));
-      unregister_code(hex_to_keycode(digit));
-      onzerostart = false;
-    }
-  }
-}
-
 __attribute__((weak))
 uint16_t unicodemap_index(uint16_t keycode) {
   if (keycode >= QK_UNICODEMAP_PAIR) {
@@ -54,25 +34,11 @@ uint16_t unicodemap_index(uint16_t keycode) {
 
 bool process_unicodemap(uint16_t keycode, keyrecord_t *record) {
   if (keycode >= QK_UNICODEMAP && keycode <= QK_UNICODEMAP_PAIR_MAX && record->event.pressed) {
-    unicode_input_start();
 
     uint32_t code = pgm_read_dword(unicode_map + unicodemap_index(keycode));
     uint8_t input_mode = get_unicode_input_mode();
 
-    if (code > 0x10FFFF || (code > 0xFFFF && input_mode == UC_WIN)) {
-      // Character is out of range supported by the platform
-      unicode_input_cancel();
-    } else if (code > 0xFFFF && input_mode == UC_OSX) {
-      // Convert to UTF-16 surrogate pair on Mac
-      code -= 0x10000;
-      uint32_t lo = code & 0x3FF, hi = (code & 0xFFC00) >> 10;
-      register_hex32(hi + 0xD800);
-      register_hex32(lo + 0xDC00);
-      unicode_input_finish();
-    } else {
-      register_hex32(code);
-      unicode_input_finish();
-    }
+    register_unicode(code, input_mode);
   }
   return true;
 }

--- a/quantum/process_keycode/process_unicodemap.h
+++ b/quantum/process_keycode/process_unicodemap.h
@@ -20,6 +20,5 @@
 
 extern const uint32_t PROGMEM unicode_map[];
 
-void register_hex32(uint32_t hex);
 uint16_t unicodemap_index(uint16_t keycode);
 bool process_unicodemap(uint16_t keycode, keyrecord_t *record);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
- Standardize how unicode is processed by utilizing how unicodemap converts it for OS X and move that to process_unicode_common.
- Add the ability to have multiple characters sent with UCIS
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* fixes #6220 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (The contributing document says 4 spaces but everywhere I've seen it as 2 so I went with that)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
