### PR TITLE
Add a universal flash command for cli

### DIFF
--- a/keyboards/ergodox_infinity/keymaps/halfkeyboard/rules.mk
+++ b/keyboards/ergodox_infinity/keymaps/halfkeyboard/rules.mk
@@ -54,6 +54,8 @@ ARMV = 7
 # The CORTEX_VTOR... is needed only for MCHCK/Infinity KB
 OPT_DEFS += -DCORTEX_VTOR_INIT=0x00002000
 
+BOOTLOADER = dfu
+
 # Build Options
 #   comment out to disable the options.
 #

--- a/keyboards/ergodox_infinity/rules.mk
+++ b/keyboards/ergodox_infinity/rules.mk
@@ -54,6 +54,8 @@ ARMV = 7
 # The CORTEX_VTOR... is needed only for MCHCK/Infinity KB
 OPT_DEFS += -DCORTEX_VTOR_INIT=0x00002000
 
+BOOTLOADER = dfu
+
 # Build Options
 #   comment out to disable the options.
 #

--- a/keyboards/infinity60/rules.mk
+++ b/keyboards/infinity60/rules.mk
@@ -53,6 +53,8 @@ ARMV = 7
 # The CORTEX_VTOR... is needed only for MCHCK/Infinity KB
 OPT_DEFS = -DCORTEX_VTOR_INIT=0x00001000
 
+BOOTLOADER = dfu
+
 # Build Options
 #   comment out to disable the options.
 #

--- a/keyboards/k_type/rules.mk
+++ b/keyboards/k_type/rules.mk
@@ -59,6 +59,8 @@ OPT_DEFS =
 DFU_ARGS = -d 1c11:b007
 DFU_SUFFIX_ARGS = -p b007 -v 1c11
 
+BOOTLOADER = dfu
+
 # Build Options
 #   comment out to disable the options.
 #

--- a/keyboards/whitefox/rules.mk
+++ b/keyboards/whitefox/rules.mk
@@ -57,6 +57,8 @@ OPT_DEFS =
 DFU_ARGS = -d 1c11:b007
 DFU_SUFFIX_ARGS = -p b007 -v 1c11
 
+BOOTLOADER = dfu
+
 # Build Options
 #   comment out to disable the options.
 #

--- a/message.mk
+++ b/message.mk
@@ -85,5 +85,5 @@ MSG_PYTHON_MISSING = $(WARN_COLOR)WARNING:$(NO_COLOR)\n \
 	Python 3 is not installed. It will be required by a future version\n\
 	of qmk_firmware.\n\n\
 	Please run $(BOLD)util/qmk_install.sh$(NO_COLOR) to install all the dependencies QMK requires.\n\n
-MSG_FLASH_BOOTLOADER = $(WARN_COLOR)WARNING:$(NO_COLOR) This board's bootloader is not supported by the \":flash\" target at this time.\n\n
+MSG_FLASH_BOOTLOADER = $(WARN_COLOR)WARNING:$(NO_COLOR) This board's bootloader is not specified or is not supported by the \":flash\" target at this time.\n\n
 MSG_FLASH_ARCH = $(WARN_COLOR)WARNING:$(NO_COLOR) This board's architecture is not supported by the \":flash\" target at this time.\n\n

--- a/message.mk
+++ b/message.mk
@@ -85,3 +85,4 @@ MSG_PYTHON_MISSING = $(WARN_COLOR)WARNING:$(NO_COLOR)\n \
 	Python 3 is not installed. It will be required by a future version\n\
 	of qmk_firmware.\n\n\
 	Please run $(BOLD)util/qmk_install.sh$(NO_COLOR) to install all the dependencies QMK requires.\n\n
+MSG_FLASH_BOOTLOADER = This board's bootloader is not supported by the 'flash' target at this time.

--- a/message.mk
+++ b/message.mk
@@ -85,4 +85,5 @@ MSG_PYTHON_MISSING = $(WARN_COLOR)WARNING:$(NO_COLOR)\n \
 	Python 3 is not installed. It will be required by a future version\n\
 	of qmk_firmware.\n\n\
 	Please run $(BOLD)util/qmk_install.sh$(NO_COLOR) to install all the dependencies QMK requires.\n\n
-MSG_FLASH_BOOTLOADER = This board's bootloader is not supported by the 'flash' target at this time.
+MSG_FLASH_BOOTLOADER = $(WARN_COLOR)WARNING:$(NO_COLOR) This board's bootloader is not supported by the \":flash\" target at this time.\n\n
+MSG_FLASH_ARCH = $(WARN_COLOR)WARNING:$(NO_COLOR) This board's architecture is not supported by the \":flash\" target at this time.\n\n

--- a/tmk_core/arm_atsam.mk
+++ b/tmk_core/arm_atsam.mk
@@ -54,3 +54,6 @@ EXTRALIBDIRS =
 bin: $(BUILD_DIR)/$(TARGET).hex
 	$(OBJCOPY) -Iihex -Obinary $(BUILD_DIR)/$(TARGET).hex $(BUILD_DIR)/$(TARGET).bin
 	$(COPY) $(BUILD_DIR)/$(TARGET).bin $(TARGET).bin;
+
+flash: bin
+	$(PRINT_OK); $(SILENT) || printf "$(MSG_FLASH_ARCH)"

--- a/tmk_core/avr.mk
+++ b/tmk_core/avr.mk
@@ -239,8 +239,12 @@ avrdude-split-left: $(BUILD_DIR)/$(TARGET).hex check-size cpfirmware
 avrdude-split-right: $(BUILD_DIR)/$(TARGET).hex check-size cpfirmware
 	$(call EXEC_AVRDUDE,eeprom-righthand.eep)
 
-usbasp: $(BUILD_DIR)/$(TARGET).hex check-size cpfirmware
+define EXEC_USBASP
 	avrdude -p $(MCU) -c usbasp -U flash:w:$(BUILD_DIR)/$(TARGET).hex
+endef
+
+usbasp: $(BUILD_DIR)/$(TARGET).hex check-size cpfirmware
+	$(call EXEC_USBASP)
 
 
 # Convert hex to bin.
@@ -326,7 +330,7 @@ else ifeq ($(strip $(BOOTLOADER)), halfkay)
 else ifeq (dfu,$(findstring dfu,$(BOOTLOADER)))
 	$(call EXEC_DFU)
 else ifeq ($(strip $(BOOTLOADER)), USBasp)
-	avrdude -p $(MCU) -c usbasp -U flash:w:$(BUILD_DIR)/$(TARGET).hex
+	$(call EXEC_USBASP)
 else
 	$(PRINT_OK); $(SILENT) || printf "&(MSG_FLASH_BOOTLOADER)"
 endif

--- a/tmk_core/avr.mk
+++ b/tmk_core/avr.mk
@@ -326,5 +326,5 @@ else ifeq ($(strip $(BOOTLOADER)), halfkay)
 else ifeq (dfu,$(findstring dfu,$(BOOTLOADER)))
 	$(call EXEC_DFU)
 else
-	echo "&(MSG_FLASH_BOOTLOADER)"
+	$(PRINT_OK); $(SILENT) || printf "&(MSG_FLASH_BOOTLOADER)"
 endif

--- a/tmk_core/avr.mk
+++ b/tmk_core/avr.mk
@@ -89,11 +89,11 @@ DEBUG_HOST = localhost
 #============================================================================
 # Autodetect teensy loader
 ifndef TEENSY_LOADER_CLI
-    ifneq (, $(shell which teensy-loader-cli 2>/dev/null))
-        TEENSY_LOADER_CLI ?= teensy-loader-cli
-    else
-        TEENSY_LOADER_CLI ?= teensy_loader_cli
-    endif
+	ifneq (, $(shell which teensy-loader-cli 2>/dev/null))
+		TEENSY_LOADER_CLI ?= teensy-loader-cli
+	else
+		TEENSY_LOADER_CLI ?= teensy_loader_cli
+	endif
 endif
 
 # Generate a .qmk for the QMK-FF
@@ -124,8 +124,12 @@ qmk: $(BUILD_DIR)/$(TARGET).hex
 program: $(BUILD_DIR)/$(TARGET).hex $(BUILD_DIR)/$(TARGET).eep check-size
 	$(PROGRAM_CMD)
 
-teensy: $(BUILD_DIR)/$(TARGET).hex check-size cpfirmware
+define EXEC_TEENSY
 	$(TEENSY_LOADER_CLI) -mmcu=$(MCU) -w -v $(BUILD_DIR)/$(TARGET).hex
+endef
+
+teensy: $(BUILD_DIR)/$(TARGET).hex check-size cpfirmware
+	$(call EXEC_TEENSY)
 
 BATCHISP ?= batchisp
 
@@ -137,18 +141,32 @@ flip: $(BUILD_DIR)/$(TARGET).hex check-size
 DFU_PROGRAMMER ?= dfu-programmer
 GREP ?= grep
 
-dfu: $(BUILD_DIR)/$(TARGET).hex cpfirmware check-size
+
+define EXEC_DFU
+	if [ "$(1)" ]; then \
+		echo "Flashing '$(1)' for EE_HANDS split keyboard support." ;\
+	fi; \
 	until $(DFU_PROGRAMMER) $(MCU) get bootloader-version; do\
 		echo "Error: Bootloader not found. Trying again in 5s." ;\
 		sleep 5 ;\
-	done
+	done; \
 	if $(DFU_PROGRAMMER) --version 2>&1 | $(GREP) -q 0.7 ; then\
-		$(DFU_PROGRAMMER) $(MCU) erase --force;\
-	else\
-		$(DFU_PROGRAMMER) $(MCU) erase;\
-	fi
-	$(DFU_PROGRAMMER) $(MCU) flash $(BUILD_DIR)/$(TARGET).hex
+		$(DFU_PROGRAMMER) $(MCU) erase --force; \
+		if [ "$(1)" ]; then \
+			$(DFU_PROGRAMMER) $(MCU) flash --eeprom $(QUANTUM_PATH)/split_common/$(1);\
+		fi; \
+	else \
+		$(DFU_PROGRAMMER) $(MCU) erase; \
+		if [ "$(1)" ]; then \
+			$(DFU_PROGRAMMER) $(MCU) flash-eeprom $(QUANTUM_PATH)/split_common/$(1);\
+		fi; \
+	fi; \
+	$(DFU_PROGRAMMER) $(MCU) flash $(BUILD_DIR)/$(TARGET).hex;\
 	$(DFU_PROGRAMMER) $(MCU) reset
+endef
+
+dfu: $(BUILD_DIR)/$(TARGET).hex cpfirmware check-size
+	$(call EXEC_DFU)
 
 dfu-start:
 	$(DFU_PROGRAMMER) $(MCU) reset
@@ -170,34 +188,10 @@ dfu-ee: $(BUILD_DIR)/$(TARGET).hex $(BUILD_DIR)/$(TARGET).eep
 	$(DFU_PROGRAMMER) $(MCU) reset
 
 dfu-split-left: $(BUILD_DIR)/$(TARGET).hex cpfirmware check-size
-	until $(DFU_PROGRAMMER) $(MCU) get bootloader-version; do\
-		echo "Error: Bootloader not found. Trying again in 5s." ;\
-		sleep 5 ;\
-	done
-	if $(DFU_PROGRAMMER) --version 2>&1 | $(GREP) -q 0.7 ; then\
-		$(DFU_PROGRAMMER) $(MCU) erase --force;\
-		$(DFU_PROGRAMMER) $(MCU) flash --eeprom $(QUANTUM_PATH)/split_common/eeprom-lefthand.eep;\
-	else\
-		$(DFU_PROGRAMMER) $(MCU) erase;\
-		$(DFU_PROGRAMMER) $(MCU) flash-eeprom $(QUANTUM_PATH)/split_common/eeprom-lefthand.eep;\
-	fi
-	$(DFU_PROGRAMMER) $(MCU) flash $(BUILD_DIR)/$(TARGET).hex
-	$(DFU_PROGRAMMER) $(MCU) reset
+	$(call EXEC_DFU,eeprom-lefthand.eep)
 
 dfu-split-right: $(BUILD_DIR)/$(TARGET).hex cpfirmware check-size
-	until $(DFU_PROGRAMMER) $(MCU) get bootloader-version; do\
-		echo "Error: Bootloader not found. Trying again in 5s." ;\
-		sleep 5 ;\
-	done
-	if $(DFU_PROGRAMMER) --version 2>&1 | $(GREP) -q 0.7 ; then\
-		$(DFU_PROGRAMMER) $(MCU) erase --force;\
-		$(DFU_PROGRAMMER) $(MCU) flash --eeprom $(QUANTUM_PATH)/split_common/eeprom-righthand.eep;\
-	else\
-		$(DFU_PROGRAMMER) $(MCU) erase;\
-		$(DFU_PROGRAMMER) $(MCU) flash-eeprom $(QUANTUM_PATH)/split_common/eeprom-righthand.eep;\
-	fi
-	$(DFU_PROGRAMMER) $(MCU) flash $(BUILD_DIR)/$(TARGET).hex
-	$(DFU_PROGRAMMER) $(MCU) reset
+	$(call EXEC_DFU,eeprom-righthand.eep)
 
 define EXEC_AVRDUDE
 	USB= ;\
@@ -323,3 +317,14 @@ production: $(BUILD_DIR)/$(TARGET).hex bootloader cpfirmware
 	@cat $(TARGET)_bootloader.hex >> $(TARGET)_production.hex
 	echo "File sizes:"
 	$(SIZE) $(TARGET).hex $(TARGET)_bootloader.hex $(TARGET)_production.hex
+
+flash:  $(BUILD_DIR)/$(TARGET).hex check-size cpfirmware
+ifeq ($(strip $(BOOTLOADER)), caterina)
+	$(call EXEC_AVRDUDE)
+else ifeq ($(strip $(BOOTLOADER)), halfkay)
+	$(call EXEC_TEENSY)
+else ifeq (dfu,$(findstring dfu,$(BOOTLOADER)))
+	$(call EXEC_DFU)
+else
+	echo "&(MSG_FLASH_BOOTLOADER)"
+endif

--- a/tmk_core/avr.mk
+++ b/tmk_core/avr.mk
@@ -325,6 +325,8 @@ else ifeq ($(strip $(BOOTLOADER)), halfkay)
 	$(call EXEC_TEENSY)
 else ifeq (dfu,$(findstring dfu,$(BOOTLOADER)))
 	$(call EXEC_DFU)
+else ifeq ($(strip $(BOOTLOADER)), USBasp)
+	avrdude -p $(MCU) -c usbasp -U flash:w:$(BUILD_DIR)/$(TARGET).hex
 else
 	$(PRINT_OK); $(SILENT) || printf "&(MSG_FLASH_BOOTLOADER)"
 endif

--- a/tmk_core/chibios.mk
+++ b/tmk_core/chibios.mk
@@ -290,5 +290,5 @@ else ifeq ($(strip $(MCU_FAMILY)),KINETIS)
 else ifeq ($(strip $(MCU_FAMILY)),STM32)
 	$(call EXEC_DFU_UTIL)
 else
-	echo "$(MSG_FLASH_BOOTLOADER)"
+	$(PRINT_OK); $(SILENT) || printf "$(MSG_FLASH_BOOTLOADER)"
 endif

--- a/tmk_core/chibios.mk
+++ b/tmk_core/chibios.mk
@@ -234,9 +234,12 @@ qmk: $(BUILD_DIR)/$(TARGET).bin
 	zip $(TARGET).qmk -urj $(BUILD_DIR)/$(TARGET).json
 	printf "@ $(TARGET).json\n@=info.json\n" | zipnote -w $(TARGET).qmk
 
-dfu-util: $(BUILD_DIR)/$(TARGET).bin cpfirmware sizeafter
+define EXEC_DFU_UTIL
 	$(DFU_UTIL) $(DFU_ARGS) -D $(BUILD_DIR)/$(TARGET).bin
+endef
 
+dfu-util: $(BUILD_DIR)/$(TARGET).bin cpfirmware sizeafter
+	$(call EXEC_DFU_UTIL)
 
 ifneq ($(strip $(TIME_DELAY)),)
   TIME_DELAY = $(strip $(TIME_DELAY))
@@ -253,7 +256,7 @@ dfu-util-wait: $(BUILD_DIR)/$(TARGET).bin cpfirmware sizeafter
   done; \
   echo "Flashing $(TARGET).bin" ;\
   sleep 1 ;\
-  $(DFU_UTIL) $(DFU_ARGS) -D $(BUILD_DIR)/$(TARGET).bin
+  $(call EXEC_DFU_UTIL)
 
 st-link-cli: $(BUILD_DIR)/$(TARGET).hex sizeafter
 	$(ST_LINK_CLI) $(ST_LINK_ARGS) -q -c SWD -p $(BUILD_DIR)/$(TARGET).hex -Rst
@@ -268,7 +271,24 @@ ifndef TEENSY_LOADER_CLI
     endif
 endif
 
-teensy: $(BUILD_DIR)/$(TARGET).hex cpfirmware sizeafter
+define EXEC_TEENSY
 	$(TEENSY_LOADER_CLI) -mmcu=$(MCU_LDSCRIPT) -w -v $(BUILD_DIR)/$(TARGET).hex
+endef
+
+teensy: $(BUILD_DIR)/$(TARGET).hex cpfirmware sizeafter
+	$(call EXEC_TEENSY)
 
 bin: $(BUILD_DIR)/$(TARGET).bin sizeafter
+	$(COPY) $(BUILD_DIR)/$(TARGET).bin $(TARGET).bin;
+
+
+flash: $(BUILD_DIR)/$(TARGET).bin cpfirmware sizeafter
+ifeq ($(strip $(BOOTLOADER)),dfu)
+	$(call EXEC_DFU_UTIL)
+else ifeq ($(strip $(MCU_FAMILY)),KINETIS)
+	$(call EXEC_TEENSY)
+else ifeq ($(strip $(MCU_FAMILY)),STM32)
+	$(call EXEC_DFU_UTIL)
+else
+	echo "$(MSG_FLASH_BOOTLOADER)"
+endif

--- a/tmk_core/rules.mk
+++ b/tmk_core/rules.mk
@@ -436,4 +436,4 @@ clean clean_list debug gdb-config show_path \
 program teensy dfu flip dfu-ee flip-ee dfu-start \
 flash dfu-split-left dfu-split-right \
 avrdude-split-left avrdude-split-right \
-avrdude-loop
+avrdude-loop usbasp

--- a/tmk_core/rules.mk
+++ b/tmk_core/rules.mk
@@ -433,4 +433,7 @@ $(eval $(foreach OUTPUT,$(OUTPUTS),$(shell mkdir -p $(OUTPUT) 2>/dev/null)))
 .PHONY : all finish sizebefore sizeafter qmkversion \
 gccversion build elf hex eep lss sym coff extcoff \
 clean clean_list debug gdb-config show_path \
-program teensy dfu flip dfu-ee flip-ee dfu-start
+program teensy dfu flip dfu-ee flip-ee dfu-start \
+flash dfu-split-left dfu-split-right \
+avrdude-split-left avrdude-split-right \
+avrdude-loop


### PR DESCRIPTION
## Description

This adds a `:flash` target that detects the board and bootloader type, and runs the correct flashing command, based on that information.

This supports AVR, and ChibiOS based ARM boards, as ATSAM has no flash command in QMK, currently.

This also cleans up the `:dfu` target to make it more modular, the way the `:avrdude` target is.

## Types of Changes
- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation


## Checklist
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
