### PR TITLE
Fix detection of rev number used to set bootloader

### DIFF
--- a/keyboards/keebio/iris/rules.mk
+++ b/keyboards/keebio/iris/rules.mk
@@ -7,7 +7,7 @@ F_USB = $(F_CPU)
 #     This definition is optional, and if your keyboard supports multiple bootloaders of
 #     different sizes, comment this out, and the correct address will be loaded
 #     automatically (+60). See bootloader.mk for all options.
-ifeq ($(strip $(KEYBOARD)), iris/rev3)
+ifneq (, $(findstring rev3, $(KEYBOARD)))
     BOOTLOADER = qmk-dfu
 else
     BOOTLOADER = caterina

--- a/keyboards/keebio/nyquist/rules.mk
+++ b/keyboards/keebio/nyquist/rules.mk
@@ -38,8 +38,8 @@ F_USB = $(F_CPU)
 #     This definition is optional, and if your keyboard supports multiple bootloaders of
 #     different sizes, comment this out, and the correct address will be loaded
 #     automatically (+60). See bootloader.mk for all options.
-ifeq ($(strip $(KEYBOARD)), nyquist/rev3)
-    BOOTLOADER = dfu
+ifneq (, $(findstring rev3, $(KEYBOARD)))
+    BOOTLOADER = qmk-dfu
 else
     BOOTLOADER = caterina
 endif


### PR DESCRIPTION
## Description

Revise method used to detect revision number so that the correct bootloader is used. This should fix issues with the RESET command not jumping to bootloader for Iris Rev. 3 and Nyquist Rev. 3.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
