### PR TITLE
Reduce compiled size of handwired Promethium keyboard

### DIFF
--- a/keyboards/handwired/promethium/rules.mk
+++ b/keyboards/handwired/promethium/rules.mk
@@ -47,7 +47,7 @@ OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
 OPT_DEFS += -DBOOTLOADER_SIZE=4096
 
 # Build Options
-#   change to "no" to disable the options, or define them in the Makefile in 
+#   change to "no" to disable the options, or define them in the Makefile in
 #   the appropriate keymap folder that will get included automatically
 #
 BOOTMAGIC_ENABLE = no       # Virtual DIP switch configuration(+1000)
@@ -62,7 +62,7 @@ AUDIO_ENABLE = no           # Audio output on port C6
 UNICODE_ENABLE = no         # Unicode
 UNICODEMAP_ENABLE = yes
 BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
-RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight. 
+RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight.
 PS2_MOUSE_ENABLE = yes
 PS2_USE_INT = yes
 API_SYSEX_ENABLE = no
@@ -76,3 +76,5 @@ SRC += ws2812.c
 SRC += rgbsps.c
 SRC += analog.c
 SRC += matrix.c
+
+LINK_TIME_OPTIMIZATION_ENABLE = yes


### PR DESCRIPTION
Mostly, this just enables LTO on the board, since there isn't a lot left that we can actually disable to save space 

## Types of Changes
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Travis CI pitching a fit

## Checklist
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).