### PR TITLE
Remove empty led_set_kb() from crkbd/rev1

### DIFF
--- a/keyboards/crkbd/rev1/rev1.c
+++ b/keyboards/crkbd/rev1/rev1.c
@@ -6,13 +6,6 @@
     float tone_goodbye[][2] = SONG(GOODBYE_SOUND);
 #endif
 
-#ifdef SSD1306OLED
-void led_set_kb(uint8_t usb_led) {
-    // put your keyboard LED indicator (ex: Caps Lock LED) toggling code here
-    //led_set_user(usb_led);
-}
-#endif
-
 #ifdef RGB_MATRIX_ENABLE
 
   // Logical Layout


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Because the default `led_set_kb()` simply calls `led_set_user()`, this actually prevents the use of lock LED processing in keymap-level code (eg. RGB indicators) when the OLED feature is enabled.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
