### PR TITLE
Ensure setPinInput actually sets input high-Z

### DIFF
--- a/keyboards/40percentclub/mf68/keymaps/emdarcher/keymap.c
+++ b/keyboards/40percentclub/mf68/keymaps/emdarcher/keymap.c
@@ -48,8 +48,6 @@ void led_set_user(uint8_t usb_led){
     } else {
         //set to Hi-Z
         setPinInput(B0);
-        writePinLow(B0);
-        setPinInput(D5);
-        writePinLow(D5);
+        setPinInput(B5);
     }
 }

--- a/keyboards/40percentclub/mf68/keymaps/emdarcher/keymap.c
+++ b/keyboards/40percentclub/mf68/keymaps/emdarcher/keymap.c
@@ -48,6 +48,6 @@ void led_set_user(uint8_t usb_led){
     } else {
         //set to Hi-Z
         setPinInput(B0);
-        setPinInput(B5);
+        setPinInput(D5);
     }
 }

--- a/keyboards/atreus62/keymaps/xyverz/keymap.c
+++ b/keyboards/atreus62/keymaps/xyverz/keymap.c
@@ -30,6 +30,7 @@ CHANGELOG:
  0.6 - Swapped ESC and GRV in all layers.
  0.7 - Brought code up to current standards.
  0.8 - Added MACLOCK macro.
+ 0.9 - Updated code to correspond to new setPinInput behaviour
 
 TODO:
 
@@ -124,9 +125,7 @@ void matrix_init_user(void) {
 #ifdef BOOTLOADER_CATERINA
    // This will disable the red LEDs on the ProMicros
    setPinInput(D5);
-   writePinLow(D5);
    setPinInput(B0);
-   writePinLow(B0);
 #endif
 };
 

--- a/keyboards/atreus62/keymaps/xyverz/readme.md
+++ b/keyboards/atreus62/keymaps/xyverz/readme.md
@@ -30,6 +30,10 @@ The bottom row is fairly Kinesis-ish since the Contour and Advantage keyboards h
 ### 0.7
  * Brought code up to new standards (as of 27 June 2019).
  * Updated this readme file.
+### 0.8
+ * Added MACLOCK macro.
+### 0.9
+ * Updated code to correspond to new setPinInput behaviour.
 
 ### TODO:
 

--- a/keyboards/eco/keymaps/xyverz/keymap.c
+++ b/keyboards/eco/keymaps/xyverz/keymap.c
@@ -132,9 +132,7 @@ void matrix_init_user(void) {
 #ifdef BOOTLOADER_CATERINA
     // This will disable the red LEDs on the ProMicros
     setPinInput(D5);
-    writePinLow(D5);
     setPinInput(B0);
-    writePinLow(B0);
 #endif
 };
 

--- a/keyboards/gh60/revc/revc.h
+++ b/keyboards/gh60/revc/revc.h
@@ -12,17 +12,17 @@
  *   B2 Capslock LED
  *   B0 not connected
  */
-inline void gh60_caps_led_on(void)      { setPinOutput(B2); writePinLow(B2); }
+inline void gh60_caps_led_on(void)      { setPinOutput(B2); writePinLow(B2); 
 inline void gh60_poker_leds_on(void)    { setPinOutput(F4); writePinLow(F4); }
 inline void gh60_fn_led_on(void)        { setPinOutput(F5); writePinLow(F5); }
 inline void gh60_esc_led_on(void)       { setPinOutput(F6); writePinLow(F6); }
 inline void gh60_wasd_leds_on(void)     { setPinOutput(F7); writePinLow(F7); }
 
-inline void gh60_caps_led_off(void)     { setPinInput(B2); writePinLow(B2); }
-inline void gh60_poker_leds_off(void)   { setPinInput(F4); writePinLow(F4); }
-inline void gh60_fn_led_off(void)       { setPinInput(F5); writePinLow(F5); }
-inline void gh60_esc_led_off(void)      { setPinInput(F6); writePinLow(F6); }
-inline void gh60_wasd_leds_off(void)    { setPinInput(F7); writePinLow(F7); }
+inline void gh60_caps_led_off(void)     { setPinInput(B2); }
+inline void gh60_poker_leds_off(void)   { setPinInput(F4); }
+inline void gh60_fn_led_off(void)       { setPinInput(F5); }
+inline void gh60_esc_led_off(void)      { setPinInput(F6); }
+inline void gh60_wasd_leds_off(void)    { setPinInput(F7); }
 
 /* GH60 keymap definition macro
  * K2C, K31 and  K3C are extra keys for ISO

--- a/keyboards/gh60/revc/revc.h
+++ b/keyboards/gh60/revc/revc.h
@@ -12,7 +12,7 @@
  *   B2 Capslock LED
  *   B0 not connected
  */
-inline void gh60_caps_led_on(void)      { setPinOutput(B2); writePinLow(B2); 
+inline void gh60_caps_led_on(void)      { setPinOutput(B2); writePinLow(B2); }
 inline void gh60_poker_leds_on(void)    { setPinOutput(F4); writePinLow(F4); }
 inline void gh60_fn_led_on(void)        { setPinOutput(F5); writePinLow(F5); }
 inline void gh60_esc_led_on(void)       { setPinOutput(F6); writePinLow(F6); }

--- a/keyboards/gingham/matrix.c
+++ b/keyboards/gingham/matrix.c
@@ -150,7 +150,7 @@ static void unselect_row(uint8_t row)
 static void unselect_rows(void)
 {
     for(uint8_t x = 0; x < MATRIX_ROWS; x++) {
-        setPinInput(row_pins[x]);
+        setPinInputHigh(row_pins[x]);
     }
 }
 

--- a/keyboards/handwired/owlet60/matrix.c
+++ b/keyboards/handwired/owlet60/matrix.c
@@ -215,10 +215,7 @@ void matrix_init(void) {
     matrix_init_quantum();
 
     setPinInput(D5);
-   writePinLow(D5);
-
-   setPinInput(B0);
-   writePinLow(B0);
+    setPinInput(B0);
 }
 
 // modified for per col read matrix scan

--- a/keyboards/hineybush/h87a/keymaps/wkl/keymap.c
+++ b/keyboards/hineybush/h87a/keymaps/wkl/keymap.c
@@ -59,7 +59,6 @@ void led_set_user(uint8_t usb_led) {
     writePinLow(D5);
   } else {
     setPinInput(D5);
-    writePinLow(D5);
   }
 
   if (IS_LED_ON(usb_led, USB_LED_SCROLL_LOCK)) {
@@ -67,7 +66,6 @@ void led_set_user(uint8_t usb_led) {
     writePinLow(E6);
   } else {
     setPinInput(E6);
-    writePinLow(E6);
   }
 
 }

--- a/keyboards/hineybush/h88/h88.c
+++ b/keyboards/hineybush/h88/h88.c
@@ -54,7 +54,6 @@ void led_set_user(uint8_t usb_led) {
     writePinLow(D5);
   } else {
     setPinInput(D5);
-    writePinLow(D5);
   }
 
   if (IS_LED_ON(usb_led, USB_LED_SCROLL_LOCK)) {
@@ -62,7 +61,6 @@ void led_set_user(uint8_t usb_led) {
     writePinLow(E6);
   } else {
     setPinInput(E6);
-    writePinLow(E6);
   }
 
 }

--- a/keyboards/kbdfans/kbd75/keymaps/tucznak/keymap.c
+++ b/keyboards/kbdfans/kbd75/keymaps/tucznak/keymap.c
@@ -85,6 +85,5 @@ void led_set_user(uint8_t usb_led) {
         writePinLow(B2);
     } else {
         setPinInput(B2);
-        writePinLow(B2);
     }
 }

--- a/keyboards/kmac/matrix.c
+++ b/keyboards/kmac/matrix.c
@@ -140,7 +140,7 @@ static void select_col(uint8_t col) {
 static void init_pins(void) {
     unselect_cols();
     for (uint8_t x = 0; x < MATRIX_ROWS; x++) {
-        setPinInput(row_pins[x]);
+        setPinInputHigh(row_pins[x]);
     }
 
     setPinInputHigh(E2);

--- a/keyboards/minidox/keymaps/xyverz/keymap.c
+++ b/keyboards/minidox/keymaps/xyverz/keymap.c
@@ -169,9 +169,7 @@ void matrix_init_user(void) {
 #ifdef BOOTLOADER_CATERINA
     // This will disable the red LEDs on the ProMicros
     setPinInput(D5);
-    writePinLow(D5);
     setPinInput(B0);
-    writePinLow(B0);
 #endif
 };
 

--- a/keyboards/noxary/268_2/268_2.c
+++ b/keyboards/noxary/268_2/268_2.c
@@ -21,7 +21,6 @@ void led_set_kb(uint8_t usb_led) {
         writePinHigh(B0);
     } else {
         setPinInput(B0);
-        writePinLow(B0);
     }
 
     led_set_user(usb_led);

--- a/keyboards/orthodox/keymaps/xyverz/keymap.c
+++ b/keyboards/orthodox/keymaps/xyverz/keymap.c
@@ -63,9 +63,7 @@ void matrix_init_user(void) {
 #ifdef BOOTLOADER_CATERINA
     // This will disable the red LEDs on the ProMicros
     setPinInput(D5);
-    writePinLow(D5);
     setPinInput(B0);
-    writePinLow(B0);
 #endif
 };
 

--- a/keyboards/yd60mq/yd60mq.c
+++ b/keyboards/yd60mq/yd60mq.c
@@ -6,7 +6,6 @@ void led_set_kb(uint8_t usb_led) {
         writePinLow(F4);
     } else {
         setPinInput(F4);
-        writePinLow(F4);
 	}
 
     led_set_user(usb_led);

--- a/layouts/community/ortho_4x12/xyverz/keymap.c
+++ b/layouts/community/ortho_4x12/xyverz/keymap.c
@@ -132,9 +132,7 @@ void matrix_init_user(void) {
 #ifdef BOOTLOADER_CATERINA
     // This will disable the red LEDs on the ProMicros
     setPinInput(D5);
-    writePinLow(D5);
     setPinInput(B0);
-    writePinLow(B0);
 #endif
 };
 

--- a/layouts/community/ortho_5x12/xyverz/keymap.c
+++ b/layouts/community/ortho_5x12/xyverz/keymap.c
@@ -151,9 +151,7 @@ void matrix_init_user(void) {
 #ifdef BOOTLOADER_CATERINA
     // This will disable the red LEDs on the ProMicros
     setPinInput(D5);
-    writePinLow(D5);
     setPinInput(B0);
-    writePinLow(B0);
 #endif
 };
 

--- a/quantum/config_common.h
+++ b/quantum/config_common.h
@@ -133,7 +133,7 @@
 #    endif
 
 #    ifndef __ASSEMBLER__
-#        define _PIN_ADDRESS(p, offset) _SFR_IO8(ADDRESS_BASE + (p >> PORT_SHIFTER) + offset)
+#        define _PIN_ADDRESS(p, offset) _SFR_IO8(ADDRESS_BASE + ((p) >> PORT_SHIFTER) + (offset))
 // Port X Input Pins Address
 #        define PINx_ADDRESS(p) _PIN_ADDRESS(p, 0)
 // Port X Data Direction Register,  0:input 1:output

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -157,7 +157,7 @@ extern layer_state_t layer_state;
 #if defined(__AVR__)
 typedef uint8_t pin_t;
 
-#    define setPinInput(pin) (DDRx_ADDRESS(pin) &= ~_BV((pin)&0xF))
+#    define setPinInput(pin) (DDRx_ADDRESS(pin) &= ~_BV((pin)&0xF), PORTx_ADDRESS(pin) &= ~_BV((pin)&0xF))
 #    define setPinInputHigh(pin) (DDRx_ADDRESS(pin) &= ~_BV((pin)&0xF), PORTx_ADDRESS(pin) |= _BV((pin)&0xF))
 #    define setPinInputLow(pin) _Static_assert(0, "AVR processors cannot implement an input as pull low")
 #    define setPinOutput(pin) (DDRx_ADDRESS(pin) |= _BV((pin)&0xF))
@@ -167,6 +167,7 @@ typedef uint8_t pin_t;
 #    define writePin(pin, level) ((level) ? writePinHigh(pin) : writePinLow(pin))
 
 #    define readPin(pin) ((bool)(PINx_ADDRESS(pin) & _BV((pin)&0xF)))
+
 #elif defined(PROTOCOL_CHIBIOS)
 typedef ioline_t pin_t;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

[The documentation](https://github.com/qmk/qmk_firmware/blob/master/docs/internals_gpio_control.md) here says that setPinInput() sets the pin to a high-z input. This is true only if the PORTx register is 0, meaning you have to use writePinLow() to go from setPinInputHigh to input high-z again. This fixes that.