### PR TITLE
Fixed the dynamic macro layer for m10a:gam3cat

### DIFF
--- a/keyboards/m10a/keymaps/gam3cat/keymap.c
+++ b/keyboards/m10a/keymaps/gam3cat/keymap.c
@@ -17,10 +17,10 @@ enum layers {
 };
 
 enum custom_keycodes {
-    DYNAMIC_MACRO_RANGE = SAFE_RANGE,
-    QMK_REV,
+    QMK_REV = SAFE_RANGE,
     KC_WEB,
-    KC_WCLS
+    KC_WCLS,
+    DYNAMIC_MACRO_RANGE
 };
 
 extern backlight_config_t backlight_config;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

m10a:gam3cat keymap used quantum's `DYNAMIC_MACRO_RANGE` at the beginning of the `custom_keycodes` enum, which goes against the notes in `dynamic_macros.h`:

```c
/* DYNAMIC_MACRO_RANGE must be set as the last element of user's
 * "planck_keycodes" enum prior to including this header. This allows
 * us to 'extend' it.
 */
``` 

The fix is simple, just move that line to the bottom of the enum, as per note in the quantum lib.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Prior to this fix, the L7 layout would not perform the dynamic macros. With this fix, the L7 behaves as intended.

I tested this several times going back and forth my change VS the original gam3cat's and am now happy that my m10a behaves as it should!

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
