### PR TITLE
fix unselect_rows() in quantum/matrix.c

### DIFF
--- a/quantum/matrix.c
+++ b/quantum/matrix.c
@@ -183,7 +183,7 @@ static void unselect_row(uint8_t row)
 static void unselect_rows(void)
 {
     for(uint8_t x = 0; x < MATRIX_ROWS; x++) {
-        setPinInput(row_pins[x]);
+        setPinInputHigh(row_pins[x]);
     }
 }
 


### PR DESCRIPTION
## Description

unselect_row() uses setPinInputHigh(), but unselect_rows() uses setPinInput().
This is not correct. unselect_rows() should also use setPinInputHigh().

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
