### PR TITLE
Fix unselect_rows() for Wasdat custom matrix

### DIFF
--- a/keyboards/wasdat/matrix.c
+++ b/keyboards/wasdat/matrix.c
@@ -183,7 +183,7 @@ static void unselect_row(uint8_t row)
 static void unselect_rows(void)
 {
     for(uint8_t x = 0; x < MATRIX_ROWS; x++) {
-        setPinInput(row_pins[x]);
+        setPinInputHigh(row_pins[x]);
     }
 }
 

--- a/keyboards/wasdat/matrix.c
+++ b/keyboards/wasdat/matrix.c
@@ -480,5 +480,5 @@ uint8_t matrix_scan(void)
   debounce(raw_matrix, matrix, MATRIX_ROWS, changed);
 
   matrix_scan_quantum();
-  return 1;
+  return (uint8_t)changed;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Porting #6243 (and #5984) to the Wasdat. The diode direction on this board is actually `ROW2COL` so it will not end up in the compiled firmware - this is just to keep the custom matrix aligned with the default implementation :)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
