### PR TITLE
linux_install.sh fix for openSUSE Leap 15.1

### DIFF
--- a/util/linux_install.sh
+++ b/util/linux_install.sh
@@ -118,7 +118,7 @@ elif grep ID /etc/os-release | grep -q sabayon; then
 elif grep ID /etc/os-release | grep -qE "opensuse|tumbleweed"; then
 	CROSS_AVR_GCC=cross-avr-gcc8
 	CROSS_ARM_GCC=cross-arm-none-gcc8
-	if grep ID /etc/os-release | grep -q "15.0"; then
+	if grep ID /etc/os-release | grep -q "15."; then
 		CROSS_AVR_GCC=cross-avr-gcc7
 		CROSS_ARM_GCC=cross-arm-none-gcc7
 	fi


### PR DESCRIPTION
## Description

linux_install.sh checked openSUSE for v 15.0 (exactly), and doesn't work for the recently released v 15.1.

Change is pretty trivial.

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
