### PR TITLE
Add some defaults for ATmega32A to mcu_selection.mk

### DIFF
--- a/quantum/mcu_selection.mk
+++ b/quantum/mcu_selection.mk
@@ -85,8 +85,8 @@ ifneq (,$(filter $(MCU),atmega32a))
   F_CPU ?= 12000000
 
   # unsupported features for now
-  NO_UART = yes
-  NO_SUSPEND_POWER_DOWN = yes
+  NO_UART ?= yes
+  NO_SUSPEND_POWER_DOWN ?= yes
 
   # Programming options
   PROGRAM_CMD ?= ./util/atmega32a_program.py $(TARGET).hex

--- a/quantum/mcu_selection.mk
+++ b/quantum/mcu_selection.mk
@@ -54,7 +54,7 @@ ifneq (,$(filter $(MCU),atmega32u4 at90usb1286))
   # LUFA specific
   #
   # Target architecture (see library "Board Types" documentation).
-  ARCH ?= AVR8
+  ARCH = AVR8
 
   # Input clock frequency.
   #     This will define a symbol, F_USB, in all source code files equal to the
@@ -68,4 +68,31 @@ ifneq (,$(filter $(MCU),atmega32u4 at90usb1286))
   #     If no clock division is performed on the input clock inside the AVR (via the
   #     CPU clock adjust registers or the clock division fuses), this will be equal to F_CPU.
   F_USB ?= $(F_CPU)
+
+  # Interrupt driven control endpoint task
+  OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
+endif
+
+ifneq (,$(filter $(MCU),atmega32a))
+  PROTOCOL = VUSB
+
+  # Processor frequency.
+  #     This will define a symbol, F_CPU, in all source code files equal to the
+  #     processor frequency in Hz. You can then use this symbol in your source code to
+  #     calculate timings. Do NOT tack on a 'UL' at the end, this will be done
+  #     automatically to create a 32-bit value in your source code.
+  #
+  #     This will be an integer division of F_USB below, as it is sourced by
+  #     F_USB after it has run through any CPU prescalers. Note that this value
+  #     does not *change* the processor frequency - it should merely be updated to
+  #     reflect the processor speed set externally so that the code can use accurate
+  #     software delays.
+  F_CPU ?= 12000000
+
+  # unsupported features for now
+  NO_UART = yes
+  NO_SUSPEND_POWER_DOWN = yes
+
+  # Programming options
+  PROGRAM_CMD = ./util/atmega32a_program.py $(TARGET).hex
 endif

--- a/quantum/mcu_selection.mk
+++ b/quantum/mcu_selection.mk
@@ -1,4 +1,3 @@
-
 ifneq ($(findstring STM32F303, $(MCU)),)
   ## chip/board settings
   # - the next two should match the directories in
@@ -70,7 +69,9 @@ ifneq (,$(filter $(MCU),atmega32u4 at90usb1286))
   F_USB ?= $(F_CPU)
 
   # Interrupt driven control endpoint task
-  OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
+  ifeq (,$(filter $(NO_INTERRUPT_CONTROL_ENDPOINT),yes))
+    OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
+  endif
 endif
 
 ifneq (,$(filter $(MCU),atmega32a))
@@ -81,12 +82,6 @@ ifneq (,$(filter $(MCU),atmega32a))
   #     processor frequency in Hz. You can then use this symbol in your source code to
   #     calculate timings. Do NOT tack on a 'UL' at the end, this will be done
   #     automatically to create a 32-bit value in your source code.
-  #
-  #     This will be an integer division of F_USB below, as it is sourced by
-  #     F_USB after it has run through any CPU prescalers. Note that this value
-  #     does not *change* the processor frequency - it should merely be updated to
-  #     reflect the processor speed set externally so that the code can use accurate
-  #     software delays.
   F_CPU ?= 12000000
 
   # unsupported features for now
@@ -94,5 +89,5 @@ ifneq (,$(filter $(MCU),atmega32a))
   NO_SUSPEND_POWER_DOWN = yes
 
   # Programming options
-  PROGRAM_CMD = ./util/atmega32a_program.py $(TARGET).hex
+  PROGRAM_CMD ?= ./util/atmega32a_program.py $(TARGET).hex
 endif

--- a/quantum/template/avr/rules.mk
+++ b/quantum/template/avr/rules.mk
@@ -2,42 +2,6 @@
 #MCU = at90usb1286
 MCU = atmega32u4
 
-# Processor frequency.
-#     This will define a symbol, F_CPU, in all source code files equal to the
-#     processor frequency in Hz. You can then use this symbol in your source code to
-#     calculate timings. Do NOT tack on a 'UL' at the end, this will be done
-#     automatically to create a 32-bit value in your source code.
-#
-#     This will be an integer division of F_USB below, as it is sourced by
-#     F_USB after it has run through any CPU prescalers. Note that this value
-#     does not *change* the processor frequency - it should merely be updated to
-#     reflect the processor speed set externally so that the code can use accurate
-#     software delays.
-F_CPU = 16000000
-
-
-#
-# LUFA specific
-#
-# Target architecture (see library "Board Types" documentation).
-ARCH = AVR8
-
-# Input clock frequency.
-#     This will define a symbol, F_USB, in all source code files equal to the
-#     input clock frequency (before any prescaling is performed) in Hz. This value may
-#     differ from F_CPU if prescaling is used on the latter, and is required as the
-#     raw input clock is fed directly to the PLL sections of the AVR for high speed
-#     clock generation for the USB and other AVR subsections. Do NOT tack on a 'UL'
-#     at the end, this will be done automatically to create a 32-bit value in your
-#     source code.
-#
-#     If no clock division is performed on the input clock inside the AVR (via the
-#     CPU clock adjust registers or the clock division fuses), this will be equal to F_CPU.
-F_USB = $(F_CPU)
-
-# Interrupt driven control endpoint task(+60)
-OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
-
 
 # Bootloader selection
 #   Teensy       halfkay

--- a/quantum/template/ps2avrgb/rules.mk
+++ b/quantum/template/ps2avrgb/rules.mk
@@ -15,14 +15,6 @@
 
 # MCU name
 MCU = atmega32a
-PROTOCOL = VUSB
-
-# unsupported features for now
-NO_UART = yes
-NO_SUSPEND_POWER_DOWN = yes
-
-# processor frequency
-F_CPU = 12000000
 
 # Bootloader
 #     This definition is optional, and if your keyboard supports multiple bootloaders of
@@ -43,6 +35,3 @@ RGBLIGHT_CUSTOM_DRIVER = yes
 OPT_DEFS = -DDEBUG_LEVEL=0
 
 SRC += i2c_master.c
-
-# programming options
-PROGRAM_CMD = ./util/atmega32a_program.py $(TARGET).hex


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

For about 80% of the boards in QMK right now, we actually only need specify `MCU`, `BOOTLOADER` and the feature options.

Should I remove this stuff from the templates too?

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
