### PR TITLE
Update features to use Custom Tapping Term when appropriate

### DIFF
--- a/docs/feature_tap_dance.md
+++ b/docs/feature_tap_dance.md
@@ -29,7 +29,7 @@ After this, you'll want to use the `tap_dance_actions` array to specify what act
 * `ACTION_TAP_DANCE_FN(fn)`: Calls the specified function - defined in the user keymap - with the final tap count of the tap dance action.
 * `ACTION_TAP_DANCE_FN_ADVANCED(on_each_tap_fn, on_dance_finished_fn, on_dance_reset_fn)`: Calls the first specified function - defined in the user keymap - on every tap, the second function when the dance action finishes (like the previous option), and the last function when the tap dance action resets.
 * ~~`ACTION_TAP_DANCE_FN_ADVANCED_TIME(on_each_tap_fn, on_dance_finished_fn, on_dance_reset_fn, tap_specific_tapping_term)`~~: This functions identically to the `ACTION_TAP_DANCE_FN_ADVANCED` function, but uses a custom tapping term for it, instead of the predefined `TAPPING_TERM`.
-    * This is deprecated in favor of the Per Key Tapping Term functionality, as outlined [here](custom_quantum_functions.md#Custom_Tapping_Term). You'd want to check for the specific `TD()` macro that you want to use (such as `TD(TD_ESC_CAPS)`) instead of using this specific.
+    * This is deprecated in favor of the Per Key Tapping Term functionality, as outlined [here](custom_quantum_functions.md#Custom_Tapping_Term). You'd want to check for the specific `TD()` macro that you want to use (such as `TD(TD_ESC_CAPS)`) instead of using this specific Tap Dance function.
 
 
 The first option is enough for a lot of cases, that just want dual roles. For example, `ACTION_TAP_DANCE_DOUBLE(KC_SPC, KC_ENT)` will result in `Space` being sent on single-tap, `Enter` otherwise. 

--- a/docs/feature_tap_dance.md
+++ b/docs/feature_tap_dance.md
@@ -28,7 +28,9 @@ After this, you'll want to use the `tap_dance_actions` array to specify what act
 * `ACTION_TAP_DANCE_LAYER_TOGGLE(kc, layer)`: Sends the `kc` keycode when tapped once, or toggles the state of `layer`. (this functions like the `TG` layer keycode).
 * `ACTION_TAP_DANCE_FN(fn)`: Calls the specified function - defined in the user keymap - with the final tap count of the tap dance action.
 * `ACTION_TAP_DANCE_FN_ADVANCED(on_each_tap_fn, on_dance_finished_fn, on_dance_reset_fn)`: Calls the first specified function - defined in the user keymap - on every tap, the second function when the dance action finishes (like the previous option), and the last function when the tap dance action resets.
-* `ACTION_TAP_DANCE_FN_ADVANCED_TIME(on_each_tap_fn, on_dance_finished_fn, on_dance_reset_fn, tap_specific_tapping_term)`: This functions identically to the `ACTION_TAP_DANCE_FN_ADVANCED` function, but uses a custom tapping term for it, instead of the predefined `TAPPING_TERM`.
+* ~~`ACTION_TAP_DANCE_FN_ADVANCED_TIME(on_each_tap_fn, on_dance_finished_fn, on_dance_reset_fn, tap_specific_tapping_term)`~~: This functions identically to the `ACTION_TAP_DANCE_FN_ADVANCED` function, but uses a custom tapping term for it, instead of the predefined `TAPPING_TERM`.
+    * This is deprecated in favor of the Per Key Tapping Term functionality, as outlined [here](custom_quantum_functions.md#Custom_Tapping_Term). You'd want to check for the specific `TD()` macro that you want to use (such as `TD(TD_ESC_CAPS)`) instead of using this specific.
+
 
 The first option is enough for a lot of cases, that just want dual roles. For example, `ACTION_TAP_DANCE_DOUBLE(KC_SPC, KC_ENT)` will result in `Space` being sent on single-tap, `Enter` otherwise. 
 

--- a/keyboards/converter/usb_usb/keymaps/narze/keymap.c
+++ b/keyboards/converter/usb_usb/keymaps/narze/keymap.c
@@ -130,17 +130,17 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 
         // 1. Hold for LGUI, tap for Underscore
         case GUI_UNDS:
-            perform_space_cadet(record, KC_LGUI, KC_LSFT, KC_MINS);
+            perform_space_cadet(record, keycode, KC_LGUI, KC_LSFT, KC_MINS);
             return false;
 
         // 2. Hold for LSHIFT, tap for Parens open
         case LSFT_LPRN:
-            perform_space_cadet(record, KC_LSFT, KC_LSFT, KC_9);
+            perform_space_cadet(record, keycode, KC_LSFT, KC_LSFT, KC_9);
             return false;
 
         // 3. Hold for RSHIFT, tap for Parens close
         case RSFT_RPRN:
-            perform_space_cadet(record, KC_RSFT, KC_RSFT, KC_0);
+            perform_space_cadet(record, keycode, KC_RSFT, KC_RSFT, KC_0);
             return false;
 
         default:

--- a/keyboards/ergodox_infinity/keymaps/narze/keymap.c
+++ b/keyboards/ergodox_infinity/keymaps/narze/keymap.c
@@ -635,17 +635,17 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 
         // 1. Hold for LGUI, tap for Underscore
         case GUI_UNDS:
-            perform_space_cadet(record, KC_LGUI, KC_LSFT, KC_MINS);
+            perform_space_cadet(record, keycode, KC_LGUI, KC_LSFT, KC_MINS);
             return false;
 
         // 2. Hold for LSHIFT, tap for Parens open
         case LSFT_LPRN:
-            perform_space_cadet(record, KC_LSFT, KC_LSFT, KC_9);
+            perform_space_cadet(record, keycode, KC_LSFT, KC_LSFT, KC_9);
             return false;
 
         // 3. Hold for RSHIFT, tap for Parens close
         case RSFT_RPRN:
-            perform_space_cadet(record, KC_RSFT, KC_RSFT, KC_0);
+            perform_space_cadet(record, keycode, KC_RSFT, KC_RSFT, KC_0);
             return false;
 
     }

--- a/keyboards/planck/keymaps/narze/keymap.c
+++ b/keyboards/planck/keymaps/narze/keymap.c
@@ -330,12 +330,12 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 
         // 1. Hold for LGUI, tap for Underscore
         case GUI_UNDS:
-            perform_space_cadet(record, KC_LGUI, KC_LSFT, KC_MINS);
+            perform_space_cadet(record, keycode, KC_LGUI, KC_LSFT, KC_MINS);
             return false;
 
         // 2. Hold for LSHIFT, tap for Parens open
         case LSFT_LPRN:
-            perform_space_cadet(record, KC_LSFT, KC_LSFT, KC_9);
+            perform_space_cadet(record, keycode, KC_LSFT, KC_LSFT, KC_9);
             return false;
 
         default:

--- a/quantum/process_keycode/process_space_cadet.c
+++ b/quantum/process_keycode/process_space_cadet.c
@@ -88,7 +88,7 @@ static uint16_t sc_timer = 0;
 static uint8_t sc_mods = 0;
 #endif
 
-void perform_space_cadet(keyrecord_t *record, uint16_t og_keycode, uint8_t holdMod, uint8_t tapMod, uint8_t keycode) {
+void perform_space_cadet(keyrecord_t *record, uint16_t sc_keycode, uint8_t holdMod, uint8_t tapMod, uint8_t keycode) {
     if (record->event.pressed) {
         sc_last  = holdMod;
         sc_timer = timer_read();
@@ -97,7 +97,7 @@ void perform_space_cadet(keyrecord_t *record, uint16_t og_keycode, uint8_t holdM
         }
     } else {
 #ifdef TAPPING_TERM_PER_KEY
-        if (sc_last == holdMod && timer_elapsed(sc_timer) < get_tapping_term(og_keycode))
+        if (sc_last == holdMod && timer_elapsed(sc_timer) < get_tapping_term(sc_keycode))
 #else
         if (sc_last == holdMod && timer_elapsed(sc_timer) < TAPPING_TERM)
 #endif

--- a/quantum/process_keycode/process_space_cadet.c
+++ b/quantum/process_keycode/process_space_cadet.c
@@ -15,7 +15,7 @@
  */
 #include "process_space_cadet.h"
 #ifdef TAPPING_TERM_PER_KEY
-#   include "action_tapping.h"
+#    include "action_tapping.h"
 #endif
 
 #ifndef TAPPING_TERM
@@ -88,16 +88,14 @@ static uint16_t sc_timer = 0;
 static uint8_t sc_mods = 0;
 #endif
 
-
 void perform_space_cadet(keyrecord_t *record, uint16_t og_keycode, uint8_t holdMod, uint8_t tapMod, uint8_t keycode) {
-  if (record->event.pressed) {
-    sc_last = holdMod;
-    sc_timer = timer_read ();
-    if (IS_MOD(holdMod)) {
-      register_mods(MOD_BIT(holdMod));
-    }
-  }
-  else {
+    if (record->event.pressed) {
+        sc_last  = holdMod;
+        sc_timer = timer_read();
+        if (IS_MOD(holdMod)) {
+            register_mods(MOD_BIT(holdMod));
+        }
+    } else {
 #ifdef TAPPING_TERM_PER_KEY
         if (sc_last == holdMod && timer_elapsed(sc_timer) < get_tapping_term(og_keycode))
 #else
@@ -131,8 +129,7 @@ void perform_space_cadet(keyrecord_t *record, uint16_t og_keycode, uint8_t holdM
 }
 
 bool process_space_cadet(uint16_t keycode, keyrecord_t *record) {
-
-  switch(keycode) {
+    switch (keycode) {
         case KC_LSPO: {
             perform_space_cadet(record, keycode, LSPO_KEYS);
             return false;

--- a/quantum/process_keycode/process_space_cadet.c
+++ b/quantum/process_keycode/process_space_cadet.c
@@ -14,6 +14,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "process_space_cadet.h"
+#ifdef TAPPING_TERM_PER_KEY
+#   include "action_tapping.h"
+#endif
 
 #ifndef TAPPING_TERM
 #    define TAPPING_TERM 200
@@ -89,14 +92,17 @@ void perform_space_cadet(keyrecord_t *record, uint8_t holdMod, uint8_t tapMod, u
     if (record->event.pressed) {
         sc_last  = holdMod;
         sc_timer = timer_read();
-#ifdef SPACE_CADET_MODIFIER_CARRYOVER
-        sc_mods = get_mods();
-#endif
+        
         if (IS_MOD(holdMod)) {
             register_mods(MOD_BIT(holdMod));
         }
     } else {
-        if (sc_last == holdMod && timer_elapsed(sc_timer) < TAPPING_TERM) {
+#ifdef TAPPING_TERM_PER_KEY
+        if (sc_last == holdMod && timer_elapsed(sc_timer) < get_tapping_term(keycode))
+#else
+        if (sc_last == holdMod && timer_elapsed(sc_timer) < TAPPING_TERM)
+#endif
+        {
             if (holdMod != tapMod) {
                 if (IS_MOD(holdMod)) {
                     unregister_mods(MOD_BIT(holdMod));

--- a/quantum/process_keycode/process_space_cadet.c
+++ b/quantum/process_keycode/process_space_cadet.c
@@ -92,12 +92,15 @@ void perform_space_cadet(keyrecord_t *record, uint16_t sc_keycode, uint8_t holdM
     if (record->event.pressed) {
         sc_last  = holdMod;
         sc_timer = timer_read();
+#ifdef SPACE_CADET_MODIFIER_CARRYOVER
+        sc_mods = get_mods();
+#endif
         if (IS_MOD(holdMod)) {
             register_mods(MOD_BIT(holdMod));
         }
     } else {
 #ifdef TAPPING_TERM_PER_KEY
-        if (sc_last == holdMod && timer_elapsed(sc_timer) < get_tapping_term(sc_keycode))
+        if (sc_last == holdMod && timer_elapsed(sc_timer) < get_tapping_term(sc_keycode record->event))
 #else
         if (sc_last == holdMod && timer_elapsed(sc_timer) < TAPPING_TERM)
 #endif

--- a/quantum/process_keycode/process_space_cadet.c
+++ b/quantum/process_keycode/process_space_cadet.c
@@ -88,17 +88,18 @@ static uint16_t sc_timer = 0;
 static uint8_t sc_mods = 0;
 #endif
 
-void perform_space_cadet(keyrecord_t *record, uint8_t holdMod, uint8_t tapMod, uint8_t keycode) {
-    if (record->event.pressed) {
-        sc_last  = holdMod;
-        sc_timer = timer_read();
-        
-        if (IS_MOD(holdMod)) {
-            register_mods(MOD_BIT(holdMod));
-        }
-    } else {
+
+void perform_space_cadet(keyrecord_t *record, uint16_t og_keycode, uint8_t holdMod, uint8_t tapMod, uint8_t keycode) {
+  if (record->event.pressed) {
+    sc_last = holdMod;
+    sc_timer = timer_read ();
+    if (IS_MOD(holdMod)) {
+      register_mods(MOD_BIT(holdMod));
+    }
+  }
+  else {
 #ifdef TAPPING_TERM_PER_KEY
-        if (sc_last == holdMod && timer_elapsed(sc_timer) < get_tapping_term(keycode))
+        if (sc_last == holdMod && timer_elapsed(sc_timer) < get_tapping_term(og_keycode))
 #else
         if (sc_last == holdMod && timer_elapsed(sc_timer) < TAPPING_TERM)
 #endif
@@ -130,33 +131,34 @@ void perform_space_cadet(keyrecord_t *record, uint8_t holdMod, uint8_t tapMod, u
 }
 
 bool process_space_cadet(uint16_t keycode, keyrecord_t *record) {
-    switch (keycode) {
+
+  switch(keycode) {
         case KC_LSPO: {
-            perform_space_cadet(record, LSPO_KEYS);
+            perform_space_cadet(record, keycode, LSPO_KEYS);
             return false;
         }
         case KC_RSPC: {
-            perform_space_cadet(record, RSPC_KEYS);
+            perform_space_cadet(record, keycode, RSPC_KEYS);
             return false;
         }
         case KC_LCPO: {
-            perform_space_cadet(record, LCPO_KEYS);
+            perform_space_cadet(record, keycode, LCPO_KEYS);
             return false;
         }
         case KC_RCPC: {
-            perform_space_cadet(record, RCPC_KEYS);
+            perform_space_cadet(record, keycode, RCPC_KEYS);
             return false;
         }
         case KC_LAPO: {
-            perform_space_cadet(record, LAPO_KEYS);
+            perform_space_cadet(record, keycode, LAPO_KEYS);
             return false;
         }
         case KC_RAPC: {
-            perform_space_cadet(record, RAPC_KEYS);
+            perform_space_cadet(record, keycode, RAPC_KEYS);
             return false;
         }
         case KC_SFTENT: {
-            perform_space_cadet(record, SFTENT_KEYS);
+            perform_space_cadet(record, keycode, SFTENT_KEYS);
             return false;
         }
         default: {

--- a/quantum/process_keycode/process_space_cadet.c
+++ b/quantum/process_keycode/process_space_cadet.c
@@ -100,7 +100,7 @@ void perform_space_cadet(keyrecord_t *record, uint16_t sc_keycode, uint8_t holdM
         }
     } else {
 #ifdef TAPPING_TERM_PER_KEY
-        if (sc_last == holdMod && timer_elapsed(sc_timer) < get_tapping_term(sc_keycode record->event))
+        if (sc_last == holdMod && timer_elapsed(sc_timer) < get_tapping_term(sc_keycode, record))
 #else
         if (sc_last == holdMod && timer_elapsed(sc_timer) < TAPPING_TERM)
 #endif

--- a/quantum/process_keycode/process_space_cadet.c
+++ b/quantum/process_keycode/process_space_cadet.c
@@ -16,6 +16,9 @@
 #include "process_space_cadet.h"
 #include "action_tapping.h"
 
+#ifdef NO_ACTION_TAPPING
+__attribute__((weak)) uint16_t get_tapping_term(uint16_t keycode, keyrecord_t *record) { return TAPPING_TERM; };
+#endif
 
 // ********** OBSOLETE DEFINES, STOP USING! (pls?) **********
 // Shift / paren setup

--- a/quantum/process_keycode/process_space_cadet.c
+++ b/quantum/process_keycode/process_space_cadet.c
@@ -14,13 +14,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "process_space_cadet.h"
-#ifdef TAPPING_TERM_PER_KEY
-#    include "action_tapping.h"
-#endif
+#include "action_tapping.h"
 
-#ifndef TAPPING_TERM
-#    define TAPPING_TERM 200
-#endif
 
 // ********** OBSOLETE DEFINES, STOP USING! (pls?) **********
 // Shift / paren setup
@@ -99,12 +94,7 @@ void perform_space_cadet(keyrecord_t *record, uint16_t sc_keycode, uint8_t holdM
             register_mods(MOD_BIT(holdMod));
         }
     } else {
-#ifdef TAPPING_TERM_PER_KEY
-        if (sc_last == holdMod && timer_elapsed(sc_timer) < get_tapping_term(sc_keycode, record))
-#else
-        if (sc_last == holdMod && timer_elapsed(sc_timer) < TAPPING_TERM)
-#endif
-        {
+        if (sc_last == holdMod && timer_elapsed(sc_timer) < get_tapping_term(sc_keycode, record)) {
             if (holdMod != tapMod) {
                 if (IS_MOD(holdMod)) {
                     unregister_mods(MOD_BIT(holdMod));

--- a/quantum/process_keycode/process_space_cadet.h
+++ b/quantum/process_keycode/process_space_cadet.h
@@ -17,5 +17,5 @@
 
 #include "quantum.h"
 
-void perform_space_cadet(keyrecord_t *record, uint8_t holdMod, uint8_t tapMod, uint8_t keycode);
+void perform_space_cadet(keyrecord_t *record, uint16_t og_keycode, uint8_t holdMod, uint8_t tapMod, uint8_t keycode);
 bool process_space_cadet(uint16_t keycode, keyrecord_t *record);

--- a/quantum/process_keycode/process_space_cadet.h
+++ b/quantum/process_keycode/process_space_cadet.h
@@ -19,3 +19,6 @@
 
 void perform_space_cadet(keyrecord_t *record, uint16_t sc_keycode, uint8_t holdMod, uint8_t tapMod, uint8_t keycode);
 bool process_space_cadet(uint16_t keycode, keyrecord_t *record);
+#ifdef NO_ACTION_TAPPING
+uint16_t get_tapping_term(uint16_t keycode, keyrecord_t *record);
+#endif

--- a/quantum/process_keycode/process_space_cadet.h
+++ b/quantum/process_keycode/process_space_cadet.h
@@ -17,5 +17,5 @@
 
 #include "quantum.h"
 
-void perform_space_cadet(keyrecord_t *record, uint16_t og_keycode, uint8_t holdMod, uint8_t tapMod, uint8_t keycode);
+void perform_space_cadet(keyrecord_t *record, uint16_t sc_keycode, uint8_t holdMod, uint8_t tapMod, uint8_t keycode);
 bool process_space_cadet(uint16_t keycode, keyrecord_t *record);

--- a/quantum/process_keycode/process_tap_dance.c
+++ b/quantum/process_keycode/process_tap_dance.c
@@ -171,7 +171,11 @@ void matrix_scan_tap_dance() {
         if (action->custom_tapping_term > 0) {
             tap_user_defined = action->custom_tapping_term;
         } else {
+#ifdef TAPPING_TERM_PER_KEY
+            tap_user_defined = get_tapping_term(action->state.keycode - QK_TAP_DANCE);
+#else
             tap_user_defined = TAPPING_TERM;
+#endif
         }
         if (action->state.count && timer_elapsed(action->state.timer) > tap_user_defined) {
             process_tap_dance_action_on_dance_finished(action);

--- a/quantum/process_keycode/process_tap_dance.c
+++ b/quantum/process_keycode/process_tap_dance.c
@@ -172,7 +172,7 @@ void matrix_scan_tap_dance() {
             tap_user_defined = action->custom_tapping_term;
         } else {
 #ifdef TAPPING_TERM_PER_KEY
-            tap_user_defined = get_tapping_term(action->state.keycode - QK_TAP_DANCE);
+            tap_user_defined = get_tapping_term(action->state.keycode - QK_TAP_DANCE, NULL);
 #else
             tap_user_defined = TAPPING_TERM;
 #endif

--- a/quantum/process_keycode/process_tap_dance.c
+++ b/quantum/process_keycode/process_tap_dance.c
@@ -16,10 +16,6 @@
 #include "quantum.h"
 #include "action_tapping.h"
 
-#ifndef TAPPING_TERM
-#    define TAPPING_TERM 200
-#endif
-
 #ifndef NO_ACTION_ONESHOT
 uint8_t get_oneshot_mods(void);
 #endif
@@ -171,11 +167,7 @@ void matrix_scan_tap_dance() {
         if (action->custom_tapping_term > 0) {
             tap_user_defined = action->custom_tapping_term;
         } else {
-#ifdef TAPPING_TERM_PER_KEY
-            tap_user_defined = get_tapping_term(action->state.keycode - QK_TAP_DANCE, NULL);
-#else
-            tap_user_defined = TAPPING_TERM;
-#endif
+            tap_user_defined = get_tapping_term(action->state.keycode, NULL);
         }
         if (action->state.count && timer_elapsed(action->state.timer) > tap_user_defined) {
             process_tap_dance_action_on_dance_finished(action);


### PR DESCRIPTION
This updates both the Space Cadet feature, and Tap Dances to use the Custom Tapping Term functionality, so that you can check them as well.

For the Tap Dance feature, this completely removes the need for the `ACTION_TAP_DANCE_FN_ADVANCED_TIME` dance, but I didn't want to remove it, as a few keymaps do rely on this function. 

## Types of Changes
- [x] Enhancement/optimization
- [x] Documentation

## Checklist
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).