### PR TITLE
Add ARM I2Cv1 support to i2c_master

### DIFF
--- a/docs/i2c_driver.md
+++ b/docs/i2c_driver.md
@@ -73,7 +73,22 @@ STM32 MCUs allows a variety of pins to be configured as I2C pins depending on th
 | `I2C1_SDA`               | The pin number for the SDA pin (0-9)                                                         | `7`     |
 | `I2C1_BANK` (deprecated) | The bank of pins (`GPIOA`, `GPIOB`, `GPIOC`), superceded by `I2C1_SCL_BANK`, `I2C1_SDA_BANK` | `GPIOB` |
 
-STM32 MCUs allow for different timing parameters when configuring I2C. These can be modified using the following parameters, using https://www.st.com/en/embedded-software/stsw-stm32126.html as a reference:
+The ChibiOS I2C driver configuration depends on STM32 MCU:
+
+    STM32F1xx, STM32F2xx, STM32F4xx, STM32L0xx and STM32L1xx use I2Cv1;
+    STM32F0xx, STM32F3xx, STM32F7xx and STM32L4xx use I2Cv2;
+
+#### I2Cv1
+STM32 MCUs allow for different clock and duty parameters when configuring I2Cv1. These can be modified using the following parameters, using <https://www.playembedded.org/blog/stm32-i2c-chibios/#I2Cv1_configuration_structure> as a reference:
+
+| Variable           | Default          |
+|--------------------|------------------|
+| `I2C1_OPMODE`      | `OPMODE_I2C`     |
+| `I2C1_CLOCK_SPEED` | `100000`         |
+| `I2C1_DUTY_CYCLE`  | `STD_DUTY_CYCLE` |
+
+#### I2Cv2
+STM32 MCUs allow for different timing parameters when configuring I2Cv2. These can be modified using the following parameters, using <https://www.st.com/en/embedded-software/stsw-stm32126.html> as a reference:
 
 | Variable              | Default |
 |-----------------------|---------|
@@ -83,13 +98,14 @@ STM32 MCUs allow for different timing parameters when configuring I2C. These can
 | `I2C1_TIMINGR_SCLH`   | `15U`   |
 | `I2C1_TIMINGR_SCLL`   | `21U`   |
 
-STM32 MCUs allow for different "alternate function" modes when configuring GPIO pins. These are required to switch the pins used to I2C mode. See the respective datasheet for the appropriate values for your MCU.
+STM32 MCUs allow for different "alternate function" modes when configuring GPIO pins. These are required to switch the pins used to I2Cv2 mode. See the respective datasheet for the appropriate values for your MCU.
 
 | Variable            | Default |
 |---------------------|---------|
 | `I2C1_SCL_PAL_MODE` | `4`     |
 | `I2C1_SDA_PAL_MODE` | `4`     |
 
+#### Other
 You can also overload the `void i2c_init(void)` function, which has a weak attribute. If you do this the configuration variables above will not be used. Please consult the datasheet of your MCU for the available GPIO configurations. The following is an example initialization function:
 
 ```C

--- a/drivers/arm/i2c_master.c
+++ b/drivers/arm/i2c_master.c
@@ -33,11 +33,17 @@
 static uint8_t i2c_address;
 
 static const I2CConfig i2cconfig = {
+#ifdef USE_I2CV1
+  I2C1_OPMODE,
+  I2C1_CLOCK_SPEED,
+  I2C1_DUTY_CYCLE,
+#else
   STM32_TIMINGR_PRESC(I2C1_TIMINGR_PRESC) |
   STM32_TIMINGR_SCLDEL(I2C1_TIMINGR_SCLDEL) | STM32_TIMINGR_SDADEL(I2C1_TIMINGR_SDADEL) |
   STM32_TIMINGR_SCLH(I2C1_TIMINGR_SCLH)  | STM32_TIMINGR_SCLL(I2C1_TIMINGR_SCLL),
   0,
   0
+#endif
 };
 
 static i2c_status_t chibios_to_qmk(const msg_t* status) {
@@ -61,8 +67,13 @@ void i2c_init(void)
 
   chThdSleepMilliseconds(10);
 
+#ifdef USE_I2CV1
+  palSetPadMode(I2C1_SCL_BANK, I2C1_SCL, PAL_MODE_STM32_ALTERNATE_OPENDRAIN);
+  palSetPadMode(I2C1_SDA_BANK, I2C1_SDA, PAL_MODE_STM32_ALTERNATE_OPENDRAIN);
+#else
   palSetPadMode(I2C1_SCL_BANK, I2C1_SCL, PAL_MODE_ALTERNATE(I2C1_SCL_PAL_MODE) | PAL_STM32_OTYPE_OPENDRAIN);
   palSetPadMode(I2C1_SDA_BANK, I2C1_SDA, PAL_MODE_ALTERNATE(I2C1_SDA_PAL_MODE) | PAL_STM32_OTYPE_OPENDRAIN);
+#endif
 
   //i2cInit(); //This is invoked by halInit() so no need to redo it.
 }

--- a/drivers/arm/i2c_master.h
+++ b/drivers/arm/i2c_master.h
@@ -22,9 +22,15 @@
  * Please ensure that HAL_USE_I2C is TRUE in the halconf.h file and that
  * STM32_I2C_USE_I2C1 is TRUE in the mcuconf.h file.
  */
+#pragma once
 
 #include "ch.h"
 #include <hal.h>
+
+
+#if defined(STM32F1XX) || defined(STM32F1xx) || defined(STM32F2xx) || defined(STM32F4xx) || defined(STM32L0xx) || defined(STM32L1xx)
+    #define USE_I2CV1
+#endif
 
 #ifdef I2C1_BANK
     #define I2C1_SCL_BANK I2C1_BANK
@@ -46,30 +52,42 @@
     #define I2C1_SDA 7
 #endif
 
-// The default PAL alternate modes are used to signal that the pins are used for I2C
-#ifndef I2C1_SCL_PAL_MODE
-    #define I2C1_SCL_PAL_MODE 4
-#endif
-#ifndef I2C1_SDA_PAL_MODE
-    #define I2C1_SDA_PAL_MODE 4
-#endif
+#ifdef USE_I2CV1
+    #ifndef I2C1_OPMODE
+        #define I2C1_OPMODE OPMODE_I2C
+    #endif
+    #ifndef I2C1_CLOCK_SPEED
+        #define I2C1_CLOCK_SPEED 100000 /* 400000 */
+    #endif
+    #ifndef I2C1_DUTY_CYCLE
+        #define I2C1_DUTY_CYCLE STD_DUTY_CYCLE /* FAST_DUTY_CYCLE_2 */
+    #endif
+#else
+    // The default PAL alternate modes are used to signal that the pins are used for I2C
+    #ifndef I2C1_SCL_PAL_MODE
+        #define I2C1_SCL_PAL_MODE 4
+    #endif
+    #ifndef I2C1_SDA_PAL_MODE
+        #define I2C1_SDA_PAL_MODE 4
+    #endif
 
-// The default timing values below configures the I2C clock to 400khz assuming a 72Mhz clock
-// For more info : https://www.st.com/en/embedded-software/stsw-stm32126.html
-#ifndef I2C1_TIMINGR_PRESC
-    #define I2C1_TIMINGR_PRESC 15U
-#endif
-#ifndef I2C1_TIMINGR_SCLDEL
-    #define I2C1_TIMINGR_SCLDEL 4U
-#endif
-#ifndef I2C1_TIMINGR_SDADEL
-    #define I2C1_TIMINGR_SDADEL 2U
-#endif
-#ifndef I2C1_TIMINGR_SCLH
-    #define I2C1_TIMINGR_SCLH 15U
-#endif
-#ifndef I2C1_TIMINGR_SCLL
-    #define I2C1_TIMINGR_SCLL 21U
+    // The default timing values below configures the I2C clock to 400khz assuming a 72Mhz clock
+    // For more info : https://www.st.com/en/embedded-software/stsw-stm32126.html
+    #ifndef I2C1_TIMINGR_PRESC
+        #define I2C1_TIMINGR_PRESC 15U
+    #endif
+    #ifndef I2C1_TIMINGR_SCLDEL
+        #define I2C1_TIMINGR_SCLDEL 4U
+    #endif
+    #ifndef I2C1_TIMINGR_SDADEL
+        #define I2C1_TIMINGR_SDADEL 2U
+    #endif
+    #ifndef I2C1_TIMINGR_SCLH
+        #define I2C1_TIMINGR_SCLH 15U
+    #endif
+    #ifndef I2C1_TIMINGR_SCLL
+        #define I2C1_TIMINGR_SCLL 21U
+    #endif
 #endif
 
 #ifndef I2C_DRIVER


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Currently the i2c_master driver assumes I2Cv2, which is fine for STM32 f3 boards but not f1. The changes required are quite minimal, and revolve around the config object and port init.

This allows the oled driver to work on bluepill boards, as can be seen https://github.com/zvecr/qmk_firmware/commit/f509a19fd06d1f84bba146de72d9da895d26345f

For the version configuration option, should we attempt to detect the MCU family and use the correct I2CvX automatically? (note, that is what is currently implemented here)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
