### PR TITLE
Allow board to override split keyboard master check

### DIFF
--- a/quantum/split_common/split_util.c
+++ b/quantum/split_common/split_util.c
@@ -32,6 +32,7 @@ bool is_keyboard_left(void) {
   return is_keyboard_master();
 }
 
+__attribute__((weak))
 bool is_keyboard_master(void)
 {
 #ifdef __AVR__


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Just like `is_keyboard_left`, this allows a board to use a alternative logic (maybe pin high/low), rather AVR vusb pad, to determine slave/master. This allows something like handwired AVR Teensy 2.0 to also have a way to force slave/master without hacking the split_common code.

<details>
  <summary>Passing notes....</summary>
The current default for ARM is `true`, which causes issues if you want a ARM slave.
When using `SPLIT_TRANSPORT` within split common to tinker with available options, slave/master identification gets in the way.

I do not intend for this to be a long term solution, but it does align a few things for implementers.
</details>

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
