### PR TITLE
Call led_set_user at the end of led_set_kb for Clueboard 2x1800 2019

### DIFF
--- a/keyboards/clueboard/2x1800/2019/2019.c
+++ b/keyboards/clueboard/2x1800/2019/2019.c
@@ -94,6 +94,8 @@ void led_set_kb(uint8_t usb_led) {
     } else {
         writePinLow(B6);
     }
+
+    led_set_user(usb_led);
 }
 
 bool encoder_update_keymap(int8_t index, bool clockwise) {


### PR DESCRIPTION
Call led_set_user at the end of led_set_kb so that customizations can be made in keymaps.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
