### PR TITLE
Add default layouts for 2u spacebar to Clueboard 2x1800 2019

### DIFF
--- a/keyboards/clueboard/2x1800/2019/2019.h
+++ b/keyboards/clueboard/2x1800/2019/2019.h
@@ -103,6 +103,54 @@ enum TWOx1800_keycodes {
     { KC_NO, KC_NO, KC_NO, e00, e01, KC_NO, KC_NO, KC_NO, KC_NO, e02, e03 } \
 }
 
+#define LAYOUT_2u_ansi( \
+                     e00, e01,                                                                   e02, e03,                 \
+      k00, k01, k02, k03,    k04,   k06, k07, k08, k09,   k0a, k60, k61, k62,   k63, k64, k65, k66,    k67, k68, k69, k6a, \
+      k10, k11, k12, k13,   k14, k15, k16, k17, k18, k19, k1a, k70, k71, k72, k73, k74, k75,    k76,   k77, k78, k79, k7a, \
+      k20, k21, k22, k23,    k24,  k25, k26, k27, k28, k29, k2a, k80, k81, k82, k83, k84, k85,   k86,  k87, k88, k89, k8a, \
+           k31, k32, k33,   k34,   k35, k36, k37, k38, k39, k3a, k90, k91, k92, k93, k94,      k95,    k97, k98, k99,      \
+      k40, k41, k42, k43,  k44,  k45, k46, k47, k48, k49, k4a, ka0, ka1, ka2, ka3, ka4,  ka5,  k96,    ka7, ka8, ka9, kaa, \
+           k51, k52,  k53, k54, k55,  k56, k57, k58, k59,   kb0,    kb1, kb2, kb3, kb4, kb5, ka6, kb6, kb7, kb8, kb9       \
+) { \
+    { k00, k01, k02, k03, k04, KC_NO, k06, k07, k08, k09, k0a }, \
+    { k10, k11, k12, k13, k14, k15, k16, k17, k18, k19, k1a }, \
+    { k20, k21, k22, k23, k24, k25, k26, k27, k28, k29, k2a }, \
+    { KC_NO, k31, k32, k33, k34, k35, k36, k37, k38, k39, k3a }, \
+    { k40, k41, k42, k43, k44, k45, k46, k47, k48, k49, k4a }, \
+    { KC_NO, k51, k52, k53, k54, k55, k56, k57, k58, k59, KC_NO }, \
+    { k60, k61, k62, k63, k64, k65, k66, k67, k68, k69, k6a }, \
+    { k70, k71, k72, k73, k74, k75, k76, k77, k78, k79, k7a }, \
+    { k80, k81, k82, k83, k84, k85, k86, k87, k88, k89, k8a }, \
+    { k90, k91, k92, k93, k94, k95, k96, k97, k98, k99, KC_NO }, \
+    { ka0, ka1, ka2, ka3, ka4, ka5, ka6, ka7, ka8, ka9, kaa }, \
+    { kb0, kb1, kb2, kb3, kb4, kb5, kb6, kb7, kb8, kb9, KC_NO }, \
+    { KC_NO, KC_NO, KC_NO, e00, e01, KC_NO, KC_NO, KC_NO, KC_NO, e02, e03 } \
+}
+
+#define LAYOUT_2u_iso( \
+                     e00, e01,                                                                   e02, e03,                 \
+      k00, k01, k02, k03,    k04,   k06, k07, k08, k09,   k0a, k60, k61, k62,   k63, k64, k65, k66,    k67, k68, k69, k6a, \
+      k10, k11, k12, k13,   k14, k15, k16, k17, k18, k19, k1a, k70, k71, k72, k73, k74, k75,    k76,   k77, k78, k79, k7a, \
+      k20, k21, k22, k23,    k24,  k25, k26, k27, k28, k29, k2a, k80, k81, k82, k83, k84, k85,         k87, k88, k89, k8a, \
+           k31, k32, k33,   k34,   k35, k36, k37, k38, k39, k3a, k90, k91, k92, k93, k94, k9a, k95,    k97, k98, k99,      \
+      k40, k41, k42, k43,  k44,  k45, k46, k47, k48, k49, k4a, ka0, ka1, ka2, ka3, ka4,  ka5,  k96,    ka7, ka8, ka9, kaa, \
+           k51, k52,  k53, k54, k55,  k56, k57, k58, k59,   kb0,    kb1, kb2, kb3, kb4, kb5, ka6, kb6, kb7, kb8, kb9       \
+) { \
+    { k00, k01, k02, k03, k04, KC_NO, k06, k07, k08, k09, k0a }, \
+    { k10, k11, k12, k13, k14, k15, k16, k17, k18, k19, k1a }, \
+    { k20, k21, k22, k23, k24, k25, k26, k27, k28, k29, k2a }, \
+    { KC_NO, k31, k32, k33, k34, k35, k36, k37, k38, k39, k3a }, \
+    { k40, k41, k42, k43, k44, k45, k46, k47, k48, k49, k4a }, \
+    { KC_NO, k51, k52, k53, k54, k55, k56, k57, k58, k59, KC_NO }, \
+    { k60, k61, k62, k63, k64, k65, k66, k67, k68, k69, k6a }, \
+    { k70, k71, k72, k73, k74, k75, k76, k77, k78, k79, k7a }, \
+    { k80, k81, k82, k83, k84, k85, KC_NO, k87, k88, k89, k8a }, \
+    { k90, k91, k92, k93, k94, k95, k96, k97, k98, k99, k9a }, \
+    { ka0, ka1, ka2, ka3, ka4, ka5, ka6, ka7, ka8, ka9, kaa }, \
+    { kb0, kb1, kb2, kb3, kb4, kb5, kb6, kb7, kb8, kb9, KC_NO }, \
+    { KC_NO, KC_NO, KC_NO, e00, e01, KC_NO, KC_NO, KC_NO, KC_NO, e02, e03 } \
+}
+
 #define LAYOUT_4u_ansi( \
                      e00, e01,                                                                   e02, e03,                 \
       k00, k01, k02, k03,    k04,   k06, k07, k08, k09,   k0a, k60, k61, k62,   k63, k64, k65, k66,    k67, k68, k69, k6a, \

--- a/keyboards/clueboard/2x1800/2019/keymaps/default_2u_ansi/config.h
+++ b/keyboards/clueboard/2x1800/2019/keymaps/default_2u_ansi/config.h
@@ -1,0 +1,19 @@
+/* Copyright 2017 Zach White <skullydazed@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// place overrides here

--- a/keyboards/clueboard/2x1800/2019/keymaps/default_2u_ansi/keymap.c
+++ b/keyboards/clueboard/2x1800/2019/keymaps/default_2u_ansi/keymap.c
@@ -1,0 +1,29 @@
+/* Copyright 2017 Zach White <skullydazed@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+[0] = LAYOUT_2u_ansi( \
+                                 KC_BTN1, KC_BTN2,                                                                                                                 KC_BTN3, KC_BTN4,                                  \
+      KC_HOME, KC_END,  KC_PGUP, KC_PGDN,       KC_ESC,    KC_F1,   KC_F2,   KC_F3,   KC_F4,     KC_F5,   KC_F6,   KC_F7,   KC_F8,     KC_F9,   KC_F10,   KC_F11,  KC_F12,        KC_PSCR, KC_SLCK, KC_PAUS, KC_INS,  \
+                                                                                                                                                                                                                      \
+      KC_PMNS, KC_NLCK, KC_PSLS, KC_PAST,      KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,   KC_BSPC,     KC_NLCK, KC_PSLS, KC_PAST, KC_PMNS, \
+      KC_PPLS, KC_P7,   KC_P8,   KC_P9,        KC_TAB,    KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P, KC_LBRC, KC_RBRC, KC_BSLS,       KC_P7, KC_P8, KC_P9, KC_PSLS,       \
+               KC_P4,   KC_P5,   KC_P6,        KC_CAPS,     KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,          KC_ENT,   KC_P4, KC_P5, KC_P6,                \
+      KC_PENT, KC_P1,   KC_P2,   KC_P3,     KC_UP,  KC_LSFT,    KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M, KC_COMM, KC_DOT, KC_SLSH,   KC_RSFT,      KC_UP,      KC_P1, KC_P2, KC_P3, KC_PENT,       \
+               KC_P0,   KC_PDOT,  KC_LEFT, KC_DOWN, KC_RGHT,  KC_LCTL, KC_LGUI, KC_LALT, KC_SPC,     KC_SPC,     KC_SPC, KC_RALT, KC_RGUI, KC_APP, KC_RCTL,  KC_LEFT, KC_DOWN, KC_RGHT,  KC_P0, KC_PDOT               \
+)
+};

--- a/keyboards/clueboard/2x1800/2019/keymaps/default_2u_ansi/readme.md
+++ b/keyboards/clueboard/2x1800/2019/keymaps/default_2u_ansi/readme.md
@@ -1,0 +1,1 @@
+# The default keymap for 2x1800 with 2u spacebar

--- a/keyboards/clueboard/2x1800/2019/keymaps/default_2u_iso/config.h
+++ b/keyboards/clueboard/2x1800/2019/keymaps/default_2u_iso/config.h
@@ -1,0 +1,19 @@
+/* Copyright 2017 Zach White <skullydazed@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// place overrides here

--- a/keyboards/clueboard/2x1800/2019/keymaps/default_2u_iso/keymap.c
+++ b/keyboards/clueboard/2x1800/2019/keymaps/default_2u_iso/keymap.c
@@ -1,0 +1,29 @@
+/* Copyright 2017 Zach White <skullydazed@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+[0] = LAYOUT_2u_iso( \
+                                 KC_BTN1, KC_BTN2,                                                                                                                 KC_BTN3, KC_BTN4,                                  \
+      KC_HOME, KC_END,  KC_PGUP, KC_PGDN,       KC_ESC,    KC_F1,   KC_F2,   KC_F3,   KC_F4,     KC_F5,   KC_F6,   KC_F7,   KC_F8,     KC_F9,   KC_F10,   KC_F11,  KC_F12,        KC_PSCR, KC_SLCK, KC_PAUS, KC_INS,  \
+                                                                                                                                                                                                                      \
+      KC_PMNS, KC_NLCK, KC_PSLS, KC_PAST,      KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,   KC_BSPC,     KC_NLCK, KC_PSLS, KC_PAST, KC_PMNS, \
+      KC_PPLS, KC_P7,   KC_P8,   KC_P9,        KC_TAB,    KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P, KC_LBRC, KC_RBRC,                KC_P7, KC_P8, KC_P9, KC_PSLS,       \
+               KC_P4,   KC_P5,   KC_P6,        KC_CAPS,     KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_NUHS, KC_ENT,   KC_P4, KC_P5, KC_P6,                \
+      KC_PENT, KC_P1,   KC_P2,   KC_P3,     KC_UP,  KC_LSFT,    KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M, KC_COMM, KC_DOT, KC_SLSH,   KC_RSFT,      KC_UP,      KC_P1, KC_P2, KC_P3, KC_PENT,       \
+               KC_P0,   KC_PDOT,  KC_LEFT, KC_DOWN, KC_RGHT,  KC_LCTL, KC_LGUI, KC_LALT, KC_SPC,     KC_SPC,     KC_SPC, KC_RALT, KC_RGUI, KC_APP, KC_RCTL,  KC_LEFT, KC_DOWN, KC_RGHT,  KC_P0, KC_PDOT               \
+)
+};

--- a/keyboards/clueboard/2x1800/2019/keymaps/default_2u_iso/readme.md
+++ b/keyboards/clueboard/2x1800/2019/keymaps/default_2u_iso/readme.md
@@ -1,0 +1,1 @@
+# The default keymap for 2x1800 with 2u spacebar


### PR DESCRIPTION
Add default ANSI and ISO layouts for 2u spacebar option. @skullydazed may want to review.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
