### PR TITLE
add SPLIT_HAND_PIN_WITH_PULLUP into quantum/split_common/split_util.c

### DIFF
--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -232,7 +232,7 @@ There are a few different ways to set handedness for split keyboards (listed in 
   * For using high/low pin to determine handedness, low = right hand, high = left hand. Replace `B7` with the pin you are using. This is optional, and if you leave `SPLIT_HAND_PIN` undefined, then you can still use the EE_HANDS method or MASTER_LEFT / MASTER_RIGHT defines like the stock Let's Split uses.
 
 * `#define SPLIT_HAND_PIN_WITH_PULLUP B7`
-  * For using high/low pin to determine handedness, low = right hand, open = left hand. Replace `B7` with the pin you are using. This is optional, and if you leave `SPLIT_HAND_PIN` undefined, then you can still use the EE_HANDS method or MASTER_LEFT / MASTER_RIGHT defines like the stock Let's Split uses.
+  * For using open/low pin to determine handedness, low = right hand, open = left hand. Replace `B7` with the pin you are using. This is optional, and if you leave `SPLIT_HAND_PIN` undefined, then you can still use the EE_HANDS method or MASTER_LEFT / MASTER_RIGHT defines like the stock Let's Split uses.
 
 * `#define EE_HANDS` (only works if `SPLIT_HAND_PIN` is not defined)
   * Reads the handedness value stored in the EEPROM after `eeprom-lefthand.eep`/`eeprom-righthand.eep` has been flashed to their respective halves.

--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -219,16 +219,20 @@ One thing to remember, the side that the USB port is plugged into is always the 
 There are a few different ways to set handedness for split keyboards (listed in order of precedence):
 
 1. Set `SPLIT_HAND_PIN`: Reads a pin to determine handedness. If pin is high, it's the left side, if low, the half is determined to be the right side
-2. Set `EE_HANDS` and flash `eeprom-lefthand.eep`/`eeprom-righthand.eep` to each half
+2. Set `SPLIT_HAND_PIN_WITH_PULLUP`: Reads a pin to determine handedness. If pin is open, it's the left side, if low, the half is determined to be the right side
+3. Set `EE_HANDS` and flash `eeprom-lefthand.eep`/`eeprom-righthand.eep` to each half
    * For boards with DFU bootloader you can use `:dfu-split-left`/`:dfu-split-right` to flash these EEPROM files
    * For boards with Caterina bootloader (like stock Pro Micros), use `:avrdude-split-left`/`:avrdude-split-right`
-3. Set `MASTER_RIGHT`: Half that is plugged into the USB port is determined to be the master and right half (inverse of the default)
-4. Default: The side that is plugged into the USB port is the master half and is assumed to be the left half. The slave side is the right half
+4. Set `MASTER_RIGHT`: Half that is plugged into the USB port is determined to be the master and right half (inverse of the default)
+5. Default: The side that is plugged into the USB port is the master half and is assumed to be the left half. The slave side is the right half
 
 #### Defines for handedness
 
 * `#define SPLIT_HAND_PIN B7`
   * For using high/low pin to determine handedness, low = right hand, high = left hand. Replace `B7` with the pin you are using. This is optional, and if you leave `SPLIT_HAND_PIN` undefined, then you can still use the EE_HANDS method or MASTER_LEFT / MASTER_RIGHT defines like the stock Let's Split uses.
+
+* `#define SPLIT_HAND_PIN_WITH_PULLUP B7`
+  * For using high/low pin to determine handedness, low = right hand, open = left hand. Replace `B7` with the pin you are using. This is optional, and if you leave `SPLIT_HAND_PIN` undefined, then you can still use the EE_HANDS method or MASTER_LEFT / MASTER_RIGHT defines like the stock Let's Split uses.
 
 * `#define EE_HANDS` (only works if `SPLIT_HAND_PIN` is not defined)
   * Reads the handedness value stored in the EEPROM after `eeprom-lefthand.eep`/`eeprom-righthand.eep` has been flashed to their respective halves.

--- a/quantum/split_common/split_util.c
+++ b/quantum/split_common/split_util.c
@@ -23,6 +23,10 @@ bool is_keyboard_left(void) {
     // Test pin SPLIT_HAND_PIN for High/Low, if low it's right hand
     setPinInput(SPLIT_HAND_PIN);
     return readPin(SPLIT_HAND_PIN);
+  #elif defined(SPLIT_HAND_PIN_WITH_PULLUP)
+    // Test pin SPLIT_HAND_PIN_WITH_PULLUP for Open/Low, if low it's right hand
+    setPinInputHigh(SPLIT_HAND_PIN_WITH_PULLUP);
+    return readPin(SPLIT_HAND_PIN_WITH_PULLUP);
   #elif defined(EE_HANDS)
     return eeprom_read_byte(EECONFIG_HANDEDNESS);
   #elif defined(MASTER_RIGHT)

--- a/quantum/split_common/split_util.c
+++ b/quantum/split_common/split_util.c
@@ -15,6 +15,9 @@
 #include "rgblight.h"
 #endif
 
+#define AVR_GPIO_INPUT_PULLUP_CHARGE_TIME  10 // micro sec
+#define WAIT_GPIO_PULLUP_CHARGE(ratio)  wait_us((ratio)*AVR_GPIO_INPUT_PULLUP_CHARGE_TIME)
+
 volatile bool isLeftHand = true;
 
 __attribute__((weak))
@@ -26,6 +29,7 @@ bool is_keyboard_left(void) {
   #elif defined(SPLIT_HAND_PIN_WITH_PULLUP)
     // Test pin SPLIT_HAND_PIN_WITH_PULLUP for Open/Low, if low it's right hand
     setPinInputHigh(SPLIT_HAND_PIN_WITH_PULLUP);
+    WAIT_GPIO_PULLUP_CHARGE(1);
     return readPin(SPLIT_HAND_PIN_WITH_PULLUP);
   #elif defined(EE_HANDS)
     return eeprom_read_byte(EECONFIG_HANDEDNESS);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Added SPLIT_HAND_PIN_WITH_PULLUP similar to SPLIT_HAND_PIN.

With SPLIT_HAND_PIN_WITH_PULLUP, the left half does not need to connect the pin to Vcc.
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).