### PR TITLE
Fix chibios so the dfu-suffix is only applied once.

### DIFF
--- a/tmk_core/chibios.mk
+++ b/tmk_core/chibios.mk
@@ -201,7 +201,6 @@ DFU_ARGS ?=
 ifneq ("$(SERIAL)","")
 	DFU_ARGS += -S $(SERIAL)
 endif
-DFU_SUFFIX_ARGS ?=
 
 ST_LINK_ARGS ?=
 
@@ -209,7 +208,6 @@ ST_LINK_ARGS ?=
 EXTRALIBDIRS = $(RULESPATH)/ld
 
 DFU_UTIL ?= dfu-util
-DFU_SUFFIX ?= dfu-suffix
 ST_LINK_CLI ?= st-link_cli
 
 # Generate a .qmk for the QMK-FF
@@ -274,7 +272,3 @@ teensy: $(BUILD_DIR)/$(TARGET).hex cpfirmware sizeafter
 	$(TEENSY_LOADER_CLI) -mmcu=$(MCU_LDSCRIPT) -w -v $(BUILD_DIR)/$(TARGET).hex
 
 bin: $(BUILD_DIR)/$(TARGET).bin sizeafter
-	if [ ! -z "$(DFU_SUFFIX_ARGS)" ]; then \
-		$(DFU_SUFFIX) $(DFU_SUFFIX_ARGS) -a $(BUILD_DIR)/$(TARGET).bin 1>/dev/null ;\
-	fi
-	$(COPY) $(BUILD_DIR)/$(TARGET).bin $(TARGET).bin;

--- a/tmk_core/rules.mk
+++ b/tmk_core/rules.mk
@@ -223,6 +223,10 @@ $(foreach LOBJ, $(NO_LTO_OBJ), $(eval $(call NO_LTO,$(LOBJ))))
 
 MOVE_DEP = mv -f $(patsubst %.o,%.td,$@) $(patsubst %.o,%.d,$@)
 
+# Add QMK specific flags
+DFU_SUFFIX ?= dfu-suffix
+DFU_SUFFIX_ARGS ?=
+
 
 elf: $(BUILD_DIR)/$(TARGET).elf
 hex: $(BUILD_DIR)/$(TARGET).hex
@@ -279,6 +283,10 @@ gccversion :
 	@$(SILENT) || printf "$(MSG_BIN) $@" | $(AWK_CMD)
 	$(eval CMD=$(BIN) $< $@ || exit 0)
 	@$(BUILD_CMD)
+	if [ ! -z "$(DFU_SUFFIX_ARGS)" ]; then \
+		$(DFU_SUFFIX) $(DFU_SUFFIX_ARGS) -a $(BUILD_DIR)/$(TARGET).bin 1>/dev/null ;\
+	fi
+	$(COPY) $(BUILD_DIR)/$(TARGET).bin $(TARGET).bin;
 
 BEGIN = gccversion sizebefore
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
If you build your firmware and then run the same make command with `:dfu-util` appended you will get an error message because we attempt to add a dfu-suffix when one already exists. This changes that process to only add the suffix at bin creation time.

Thanks to @fauxpark for helping to identify and fix this issue.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
