### PR TITLE
Fixing effects to respect user sat and val levels

### DIFF
--- a/quantum/rgb_matrix_animations/colorband_pinwheel_sat_anim.h
+++ b/quantum/rgb_matrix_animations/colorband_pinwheel_sat_anim.h
@@ -3,7 +3,7 @@ RGB_MATRIX_EFFECT(BAND_PINWHEEL_SAT)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
 static void BAND_PINWHEEL_SAT_math(HSV* hsv, int16_t dx, int16_t dy, uint8_t time) {
-    hsv->s = rgb_matrix_config.sat - time - atan2_8(dy, dx) * 3;
+    hsv->s = scale8(rgb_matrix_config.sat - time - atan2_8(dy, dx) * 3, rgb_matrix_config.sat);
 }
 
 bool BAND_PINWHEEL_SAT(effect_params_t* params) {

--- a/quantum/rgb_matrix_animations/colorband_pinwheel_val_anim.h
+++ b/quantum/rgb_matrix_animations/colorband_pinwheel_val_anim.h
@@ -3,7 +3,7 @@ RGB_MATRIX_EFFECT(BAND_PINWHEEL_VAL)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
 static void BAND_PINWHEEL_VAL_math(HSV* hsv, int16_t dx, int16_t dy, uint8_t time) {
-    hsv->v = rgb_matrix_config.val - time - atan2_8(dy, dx) * 3;
+    hsv->v = scale8(rgb_matrix_config.val - time - atan2_8(dy, dx) * 3, rgb_matrix_config.val);
 }
 
 bool BAND_PINWHEEL_VAL(effect_params_t* params) {

--- a/quantum/rgb_matrix_animations/colorband_sat_anim.h
+++ b/quantum/rgb_matrix_animations/colorband_sat_anim.h
@@ -4,7 +4,7 @@ RGB_MATRIX_EFFECT(BAND_SAT)
 
 static void BAND_SAT_math(HSV* hsv, uint8_t i, uint8_t time) {
     int16_t s = rgb_matrix_config.sat - abs(scale8(g_led_config.point[i].x, 228) + 28 - time) * 8;
-    hsv->s = s < 0 ? 0 : s;
+    hsv->s = scale8(s < 0 ? 0 : s, rgb_matrix_config.sat);
 }
 
 bool BAND_SAT(effect_params_t* params) {

--- a/quantum/rgb_matrix_animations/colorband_spiral_sat_anim.h
+++ b/quantum/rgb_matrix_animations/colorband_spiral_sat_anim.h
@@ -3,7 +3,7 @@ RGB_MATRIX_EFFECT(BAND_SPIRAL_SAT)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
 static void BAND_SPIRAL_SAT_math(HSV* hsv, int16_t dx, int16_t dy, uint8_t dist, uint8_t time) {
-    hsv->s = rgb_matrix_config.sat + dist - time - atan2_8(dy, dx);
+    hsv->s = scale8(rgb_matrix_config.sat + dist - time - atan2_8(dy, dx), rgb_matrix_config.sat);
 }
 
 bool BAND_SPIRAL_SAT(effect_params_t* params) {

--- a/quantum/rgb_matrix_animations/colorband_spiral_val_anim.h
+++ b/quantum/rgb_matrix_animations/colorband_spiral_val_anim.h
@@ -3,7 +3,7 @@ RGB_MATRIX_EFFECT(BAND_SPIRAL_VAL)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
 static void BAND_SPIRAL_VAL_math(HSV* hsv, int16_t dx, int16_t dy, uint8_t dist, uint8_t time) {
-    hsv->v = rgb_matrix_config.val + dist - time - atan2_8(dy, dx);
+    hsv->v = scale8(rgb_matrix_config.val + dist - time - atan2_8(dy, dx), rgb_matrix_config.val);
 }
 
 bool BAND_SPIRAL_VAL(effect_params_t* params) {

--- a/quantum/rgb_matrix_animations/colorband_val_anim.h
+++ b/quantum/rgb_matrix_animations/colorband_val_anim.h
@@ -4,7 +4,7 @@ RGB_MATRIX_EFFECT(BAND_VAL)
 
 static void BAND_VAL_math(HSV* hsv, uint8_t i, uint8_t time) {
     int16_t v = rgb_matrix_config.val - abs(scale8(g_led_config.point[i].x, 228) + 28 - time) * 8;
-    hsv->v = v < 0 ? 0 : v;
+    hsv->v = scale8(v < 0 ? 0 : v, rgb_matrix_config.val);
 }
 
 bool BAND_VAL(effect_params_t* params) {


### PR DESCRIPTION
## Description

Fixes color band rgb matrix effects that were not respecting the current saturation and value levels from the config.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
