### PR TITLE
WIP: Refactor DZ60RGB's RGB LED layer indication

### DIFF
--- a/keyboards/dztech/dz60rgb/keymaps/ansi/keymap.c
+++ b/keyboards/dztech/dz60rgb/keymaps/ansi/keymap.c
@@ -4,38 +4,39 @@
 #define _LAYER2 2
 #define _LAYER3 3
 #define _LAYER4 4
+
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-		[_LAYER0] = LAYOUT_ANSI( /* Base */
-			KC_GESC,         KC_1,     KC_2,     KC_3,  KC_4,  KC_5,  KC_6,    KC_7,  KC_8,    KC_9,     KC_0,      KC_MINS,  KC_EQL,  KC_BSPC,\
-		    KC_TAB,          KC_Q,     KC_W,     KC_E,  KC_R,  KC_T,  KC_Y,    KC_U,  KC_I,    KC_O,     KC_P,      KC_LBRC,  KC_RBRC, KC_BSLASH,\
-			CTL_T(KC_CAPS),  KC_A,     KC_S,     KC_D,  KC_F,  KC_G,  KC_H,    KC_J,  KC_K,    KC_L,     KC_SCLN,   KC_QUOT,           KC_ENT, \
-		    KC_LSFT,         KC_Z,     KC_X,     KC_C,  KC_V,  KC_B,  KC_N,    KC_M,  KC_COMM, KC_DOT,   KC_SLSH,   KC_RSFT, \
-		    KC_LCTL,         KC_LGUI,  KC_LALT,                KC_SPC,                         KC_RALT,  MO(1),     MO(2),             KC_RCTL),
-		[_LAYER1] = LAYOUT_ANSI( /* FN */
-				KC_GESC,  KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   KC_DEL ,\
-			    KC_TRNS,  KC_TRNS,  KC_UP,    KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_CALC,  KC_TRNS,  KC_INS,   KC_TRNS,  KC_PSCR,  KC_SLCK,  KC_PAUS,  RESET  ,\
-			    KC_TRNS,  KC_LEFT,  KC_DOWN,  KC_RIGHT, KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_HOME,  KC_PGUP,            KC_TRNS,\
-				KC_MPRV,  KC_VOLD,  KC_VOLU,  KC_MUTE,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_END,   KC_PGDOWN,KC_MNXT, \
-				KC_TRNS,  KC_TRNS,  KC_TRNS,                      TO(3),                                  KC_TRNS,  KC_TRNS,  KC_TRNS,            KC_TRNS),
-		[_LAYER2] = LAYOUT_ANSI( /* FN2 */
-				KC_TRNS,  KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   KC_DEL ,\
-				KC_TRNS,  RGB_TOG,  KC_TRNS,  RGB_HUI,  RGB_HUD,  RGB_SAI,  RGB_SAD,  RGB_VAI,  RGB_VAD,  RGB_MOD,  KC_TRNS,  KC_TRNS,  KC_TRNS,  RESET  ,\
-				KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  RGB_SPI,  RGB_SPD,  KC_TRNS,  KC_TRNS,            KC_TRNS,\
-				KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS, \
-				KC_TRNS,  KC_TRNS,  KC_TRNS,                      KC_TRNS,                                KC_TRNS,  KC_TRNS,  KC_TRNS,            KC_TRNS),
-		[_LAYER3] = LAYOUT_ANSI( /* FN3 */
-				KC_GESC,       KC_1,     KC_2,     KC_3,  KC_4,  KC_5,  KC_6,    KC_7,    KC_8,    KC_9,   KC_0,    KC_MINS,  KC_EQL,  KC_BSPC,\
-			    KC_TAB,        KC_Q,     KC_W,     KC_E,  KC_R,  KC_T,  KC_Y,    KC_U,    KC_I,    KC_O,   KC_P,    KC_LBRC,  KC_RBRC, KC_BSLASH,\
-				CTL_T(KC_CAPS),KC_A,     KC_S,     KC_D,  KC_F,  KC_G,  KC_H,    KC_J,    KC_K,    KC_L,   KC_SCLN, KC_QUOT,           KC_ENT, \
-			    KC_LSFT,       KC_Z,     KC_X,     KC_C,  KC_V,  KC_B,  KC_N,    KC_M,    KC_COMM, KC_DOT, KC_SLSH, KC_RSFT,  \
-				KC_LCTL,       KC_LALT,  KC_LGUI,                KC_SPC,                           KC_TRNS,MO(4),   KC_RALT,           KC_RCTL),
-		[_LAYER4] = LAYOUT_ANSI( /* FN4 */
-				KC_GESC,  KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   KC_DEL ,\
-			    KC_TRNS,  RGB_TOG,  KC_TRNS,  RGB_HUI,  RGB_HUD,  RGB_SAI,  RGB_SAD,  RGB_VAI,  RGB_VAD,  RGB_MOD,  KC_PSCR,  KC_SLCK,  KC_PAUS,  RESET  ,\
-			    KC_TRNS,  KC_LEFT,  KC_DOWN,  KC_UP,    KC_RIGHT, KC_TRNS,  KC_TRNS,  KC_TRNS,  RGB_SPI,  RGB_SPD,  KC_HOME,  KC_PGUP,            KC_TRNS,\
-				KC_MPRV,  KC_VOLD,  KC_VOLU,  KC_MUTE,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_END,   KC_PGDOWN,KC_MNXT, \
-				KC_TRNS,  KC_TRNS,  KC_TRNS,                      TO(0),                                  KC_TRNS,  KC_TRNS,  KC_TRNS,            KC_TRNS),
-		};
+    [_LAYER0] = LAYOUT_ANSI( /* Base */
+        KC_GESC,         KC_1,     KC_2,     KC_3,  KC_4,  KC_5,  KC_6,    KC_7,  KC_8,    KC_9,     KC_0,      KC_MINS,  KC_EQL,  KC_BSPC,\
+        KC_TAB,          KC_Q,     KC_W,     KC_E,  KC_R,  KC_T,  KC_Y,    KC_U,  KC_I,    KC_O,     KC_P,      KC_LBRC,  KC_RBRC, KC_BSLASH,\
+        CTL_T(KC_CAPS),  KC_A,     KC_S,     KC_D,  KC_F,  KC_G,  KC_H,    KC_J,  KC_K,    KC_L,     KC_SCLN,   KC_QUOT,           KC_ENT, \
+        KC_LSFT,         KC_Z,     KC_X,     KC_C,  KC_V,  KC_B,  KC_N,    KC_M,  KC_COMM, KC_DOT,   KC_SLSH,   KC_RSFT, \
+        KC_LCTL,         KC_LGUI,  KC_LALT,                KC_SPC,                         KC_RALT,  MO(1),     MO(2),             KC_RCTL),
+    [_LAYER1] = LAYOUT_ANSI( /* FN */
+        KC_GESC,  KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   KC_DEL ,\
+        KC_TRNS,  KC_TRNS,  KC_UP,    KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_CALC,  KC_TRNS,  KC_INS,   KC_TRNS,  KC_PSCR,  KC_SLCK,  KC_PAUS,  RESET  ,\
+        KC_TRNS,  KC_LEFT,  KC_DOWN,  KC_RIGHT, KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_HOME,  KC_PGUP,            KC_TRNS,\
+        KC_MPRV,  KC_VOLD,  KC_VOLU,  KC_MUTE,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_END,   KC_PGDOWN,KC_MNXT, \
+        KC_TRNS,  KC_TRNS,  KC_TRNS,                      TO(3),                                  KC_TRNS,  KC_TRNS,  KC_TRNS,            KC_TRNS),
+    [_LAYER2] = LAYOUT_ANSI( /* FN2 */
+        KC_TRNS,  KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   KC_DEL ,\
+        KC_TRNS,  RGB_TOG,  KC_TRNS,  RGB_HUI,  RGB_HUD,  RGB_SAI,  RGB_SAD,  RGB_VAI,  RGB_VAD,  RGB_MOD,  KC_TRNS,  KC_TRNS,  KC_TRNS,  RESET  ,\
+        KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  RGB_SPI,  RGB_SPD,  KC_TRNS,  KC_TRNS,            KC_TRNS,\
+        KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS, \
+        KC_TRNS,  KC_TRNS,  KC_TRNS,                      KC_TRNS,                                KC_TRNS,  KC_TRNS,  KC_TRNS,            KC_TRNS),
+    [_LAYER3] = LAYOUT_ANSI( /* FN3 */
+        KC_GESC,       KC_1,     KC_2,     KC_3,  KC_4,  KC_5,  KC_6,    KC_7,    KC_8,    KC_9,   KC_0,    KC_MINS,  KC_EQL,  KC_BSPC,\
+        KC_TAB,        KC_Q,     KC_W,     KC_E,  KC_R,  KC_T,  KC_Y,    KC_U,    KC_I,    KC_O,   KC_P,    KC_LBRC,  KC_RBRC, KC_BSLASH,\
+        CTL_T(KC_CAPS),KC_A,     KC_S,     KC_D,  KC_F,  KC_G,  KC_H,    KC_J,    KC_K,    KC_L,   KC_SCLN, KC_QUOT,           KC_ENT, \
+        KC_LSFT,       KC_Z,     KC_X,     KC_C,  KC_V,  KC_B,  KC_N,    KC_M,    KC_COMM, KC_DOT, KC_SLSH, KC_RSFT,  \
+        KC_LCTL,       KC_LALT,  KC_LGUI,                KC_SPC,                           KC_TRNS,MO(4),   KC_RALT,           KC_RCTL),
+    [_LAYER4] = LAYOUT_ANSI( /* FN4 */
+        KC_GESC,  KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   KC_DEL ,\
+        KC_TRNS,  RGB_TOG,  KC_TRNS,  RGB_HUI,  RGB_HUD,  RGB_SAI,  RGB_SAD,  RGB_VAI,  RGB_VAD,  RGB_MOD,  KC_PSCR,  KC_SLCK,  KC_PAUS,  RESET  ,\
+        KC_TRNS,  KC_LEFT,  KC_DOWN,  KC_UP,    KC_RIGHT, KC_TRNS,  KC_TRNS,  KC_TRNS,  RGB_SPI,  RGB_SPD,  KC_HOME,  KC_PGUP,            KC_TRNS,\
+        KC_MPRV,  KC_VOLD,  KC_VOLU,  KC_MUTE,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_END,   KC_PGDOWN,KC_MNXT, \
+        KC_TRNS,  KC_TRNS,  KC_TRNS,                      TO(0),                                  KC_TRNS,  KC_TRNS,  KC_TRNS,            KC_TRNS),
+};
 
 void matrix_init_user(void) {
   //user initialization

--- a/keyboards/dztech/dz60rgb/keymaps/ansi/keymap.c
+++ b/keyboards/dztech/dz60rgb/keymaps/ansi/keymap.c
@@ -37,34 +37,6 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 				KC_TRNS,  KC_TRNS,  KC_TRNS,                      TO(0),                                  KC_TRNS,  KC_TRNS,  KC_TRNS,            KC_TRNS),
 		};
 
-void rgb_matrix_layer_helper (uint8_t red, uint8_t green, uint8_t blue, bool default_layer) {
-  for (int i = 0; i < DRIVER_LED_TOTAL; i++) {
-    if (HAS_FLAGS(g_led_config.flags[i], LED_FLAG_MODIFIER)) {
-        rgb_matrix_set_color( i, red, green, blue );
-    }
-  }
-}
-
-void rgb_matrix_indicators_user(void) {
-	  uint8_t this_led = host_keyboard_leds();
-	  if (!g_suspend_state) {
-	    switch (biton32(layer_state)) {
-	      case _LAYER1:
-		    rgb_matrix_layer_helper(0xFF, 0x00, 0x00, false); break;
-	      case _LAYER2:
-	        rgb_matrix_layer_helper(0x00, 0xFF, 0x00, false); break;
-	      case _LAYER3:
-	        rgb_matrix_layer_helper(0x00, 0x00, 0xFF, false); break;
-	      case _LAYER4:
-	        rgb_matrix_layer_helper(0xFF, 0xFF, 0x00, false); break;
-	    							  }
-	                        }
-	  if ( this_led & (1<<USB_LED_CAPS_LOCK)) {
-	        rgb_matrix_set_color(40, 0xFF, 0xFF, 0xFF);
-	  }
-
-}
-
 void matrix_init_user(void) {
   //user initialization
 }

--- a/keyboards/dztech/dz60rgb/keymaps/ansi/keymap.c
+++ b/keyboards/dztech/dz60rgb/keymaps/ansi/keymap.c
@@ -45,6 +45,6 @@ void matrix_scan_user(void) {
   //user matrix
 }
 
-	bool process_record_user(uint16_t keycode, keyrecord_t *record) {
-	  return true;
-	}
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    return true;
+}

--- a/keyboards/dztech/dz60rgb/rgbmatrix_layers.c
+++ b/keyboards/dztech/dz60rgb/rgbmatrix_layers.c
@@ -1,0 +1,26 @@
+void rgb_matrix_layer_helper (uint8_t red, uint8_t green, uint8_t blue, bool default_layer) {
+  for (int i = 0; i < DRIVER_LED_TOTAL; i++) {
+    if (HAS_FLAGS(g_led_config.flags[i], LED_FLAG_MODIFIER)) {
+        rgb_matrix_set_color( i, red, green, blue );
+    }
+  }
+}
+
+void rgb_matrix_indicators_user(void) {
+      uint8_t this_led = host_keyboard_leds();
+      if (!g_suspend_state) {
+        switch (biton32(layer_state)) {
+          case _LAYER1:
+            rgb_matrix_layer_helper(0xFF, 0x00, 0x00, false); break;
+          case _LAYER2:
+            rgb_matrix_layer_helper(0x00, 0xFF, 0x00, false); break;
+          case _LAYER3:
+            rgb_matrix_layer_helper(0x00, 0x00, 0xFF, false); break;
+          case _LAYER4:
+            rgb_matrix_layer_helper(0xFF, 0xFF, 0x00, false); break;
+                                      }
+                            }
+      if ( this_led & (1<<USB_LED_CAPS_LOCK)) {
+            rgb_matrix_set_color(40, 0xFF, 0xFF, 0xFF);
+      }
+}

--- a/keyboards/dztech/dz60rgb/rgbmatrix_layers.c
+++ b/keyboards/dztech/dz60rgb/rgbmatrix_layers.c
@@ -7,20 +7,20 @@ void rgb_matrix_layer_helper (uint8_t red, uint8_t green, uint8_t blue, bool def
 }
 
 void rgb_matrix_indicators_user(void) {
-      uint8_t this_led = host_keyboard_leds();
-      if (!g_suspend_state) {
-        switch (biton32(layer_state)) {
-          case _LAYER1:
-            rgb_matrix_layer_helper(0xFF, 0x00, 0x00, false); break;
-          case _LAYER2:
-            rgb_matrix_layer_helper(0x00, 0xFF, 0x00, false); break;
-          case _LAYER3:
-            rgb_matrix_layer_helper(0x00, 0x00, 0xFF, false); break;
-          case _LAYER4:
-            rgb_matrix_layer_helper(0xFF, 0xFF, 0x00, false); break;
-                                      }
-                            }
-      if ( this_led & (1<<USB_LED_CAPS_LOCK)) {
-            rgb_matrix_set_color(40, 0xFF, 0xFF, 0xFF);
-      }
+    uint8_t this_led = host_keyboard_leds();
+    if (!g_suspend_state) {
+    switch (biton32(layer_state)) {
+        case _LAYER1:
+        rgb_matrix_layer_helper(0xFF, 0x00, 0x00, false); break;
+        case _LAYER2:
+        rgb_matrix_layer_helper(0x00, 0xFF, 0x00, false); break;
+        case _LAYER3:
+        rgb_matrix_layer_helper(0x00, 0x00, 0xFF, false); break;
+        case _LAYER4:
+        rgb_matrix_layer_helper(0xFF, 0xFF, 0x00, false); break;
+                                    }
+                        }
+    if ( this_led & (1<<USB_LED_CAPS_LOCK)) {
+        rgb_matrix_set_color(40, 0xFF, 0xFF, 0xFF);
+    }
 }

--- a/keyboards/dztech/dz60rgb/rgbmatrix_layers.c
+++ b/keyboards/dztech/dz60rgb/rgbmatrix_layers.c
@@ -1,5 +1,12 @@
 #include QMK_KEYBOARD_H
-#include rgblight_list.h
+#include <rgblight_list.h>
+#include "dz60rgb.h"
+
+#define _LAYER0 0
+#define _LAYER1 1
+#define _LAYER2 2
+#define _LAYER3 3
+#define _LAYER4 4
 
 #define RGB_OFF 0x00, 0x00, 0x00
 

--- a/keyboards/dztech/dz60rgb/rgbmatrix_layers.c
+++ b/keyboards/dztech/dz60rgb/rgbmatrix_layers.c
@@ -1,3 +1,8 @@
+#include QMK_KEYBOARD_H
+#include rgblight_list.h
+
+#define RGB_OFF 0x00, 0x00, 0x00
+
 void rgb_matrix_layer_helper (uint8_t red, uint8_t green, uint8_t blue, bool default_layer) {
     for (int i = 0; i < DRIVER_LED_TOTAL; i++) {
         if (HAS_FLAGS(g_led_config.flags[i], LED_FLAG_MODIFIER)) {

--- a/keyboards/dztech/dz60rgb/rgbmatrix_layers.c
+++ b/keyboards/dztech/dz60rgb/rgbmatrix_layers.c
@@ -1,25 +1,25 @@
 void rgb_matrix_layer_helper (uint8_t red, uint8_t green, uint8_t blue, bool default_layer) {
-  for (int i = 0; i < DRIVER_LED_TOTAL; i++) {
-    if (HAS_FLAGS(g_led_config.flags[i], LED_FLAG_MODIFIER)) {
-        rgb_matrix_set_color( i, red, green, blue );
+    for (int i = 0; i < DRIVER_LED_TOTAL; i++) {
+        if (HAS_FLAGS(g_led_config.flags[i], LED_FLAG_MODIFIER)) {
+            rgb_matrix_set_color( i, red, green, blue );
+        }
     }
-  }
 }
 
 void rgb_matrix_indicators_user(void) {
     uint8_t this_led = host_keyboard_leds();
     if (!g_suspend_state) {
-    switch (biton32(layer_state)) {
-        case _LAYER1:
-        rgb_matrix_layer_helper(0xFF, 0x00, 0x00, false); break;
-        case _LAYER2:
-        rgb_matrix_layer_helper(0x00, 0xFF, 0x00, false); break;
-        case _LAYER3:
-        rgb_matrix_layer_helper(0x00, 0x00, 0xFF, false); break;
-        case _LAYER4:
-        rgb_matrix_layer_helper(0xFF, 0xFF, 0x00, false); break;
-                                    }
-                        }
+        switch (biton32(layer_state)) {
+            case _LAYER1:
+            rgb_matrix_layer_helper(0xFF, 0x00, 0x00, false); break;
+            case _LAYER2:
+            rgb_matrix_layer_helper(0x00, 0xFF, 0x00, false); break;
+            case _LAYER3:
+            rgb_matrix_layer_helper(0x00, 0x00, 0xFF, false); break;
+            case _LAYER4:
+            rgb_matrix_layer_helper(0xFF, 0xFF, 0x00, false); break;
+        }
+    }
     if ( this_led & (1<<USB_LED_CAPS_LOCK)) {
         rgb_matrix_set_color(40, 0xFF, 0xFF, 0xFF);
     }

--- a/keyboards/dztech/dz60rgb/rgbmatrix_layers.c
+++ b/keyboards/dztech/dz60rgb/rgbmatrix_layers.c
@@ -10,6 +10,13 @@
 
 #define RGB_OFF 0x00, 0x00, 0x00
 
+// TODO: possibly change _LAYER defines to an enum, in keymap.c
+// TODO: determine how to get access to that enum from keymap.c
+
+// TODO: change out color RGB values for their constants to aid readability
+// TODO: add proper defines so people can turn this all on and off
+// TODO: find a way to allow the user to customize colors (another enum?)
+
 void rgb_matrix_layer_helper (uint8_t red, uint8_t green, uint8_t blue, bool default_layer) {
     for (int i = 0; i < DRIVER_LED_TOTAL; i++) {
         if (HAS_FLAGS(g_led_config.flags[i], LED_FLAG_MODIFIER)) {

--- a/keyboards/dztech/dz60rgb/rules.mk
+++ b/keyboards/dztech/dz60rgb/rules.mk
@@ -12,3 +12,5 @@ NKRO_ENABLE = no                 # USB Nkey Rollover
 AUDIO_ENABLE = no
 RGB_MATRIX_ENABLE = IS31FL3733     # Use RGB matrix
 NO_USB_STARTUP_CHECK = no          # Disable initialization only when usb is plugged in
+
+SRC += rgbmatrix_layers.c


### PR DESCRIPTION
## Description
The purpose of this is to move RGB layer indication out of the keymaps in `keymap.c`, and up into the keyboard level.  This will ensure all the folks that use the configurator to build a custom keymap retain the same layer indication behavior as the default keymaps.

* pull rgb layer indication functions out of keymaps and up to the keyboard level
* enable by default, but allow easy disable
* optional: make layer enumeration more flexible
* optional: make colors adjustable without modifying keyboard-level code

* clean up tab-based formatting along the way

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
