### PR TITLE
Have clang ignore the code in bootloader_size.c

### DIFF
--- a/tmk_core/common/avr/bootloader_size.c
+++ b/tmk_core/common/avr/bootloader_size.c
@@ -16,5 +16,6 @@
 #include <avr/io.h>
 #include <avr/boot.h>
 
+// clang-format off
 // this is not valid C - it's for computing the size available on the chip
 AVR_SIZE: FLASHEND + 1 - BOOTLOADER_SIZE


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The code in bootloader_size.c is a hack to determine the available firmware size limits. Clang format breaks it.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
