### PR TITLE
Allow Combo feature to be enabled/disabled live

### DIFF
--- a/docs/feature_combo.md
+++ b/docs/feature_combo.md
@@ -87,9 +87,9 @@ You can enable, disable and toggle the Combo feature on the fly.  This is useful
 
 
 ```
-* `COMBO_ON` - Turn combo Feature on
-* `COMBO_OFF` - Turn Combo Feature off
-* `COMBO_TOG` - Toggles Combo Feature state
+* `CMB_ON` - Turn combo Feature on
+* `CMB_OFF` - Turn Combo Feature off
+* `CMB_TOG` - Toggles Combo Feature state
 ```
 
 ## User callbacks

--- a/docs/feature_combo.md
+++ b/docs/feature_combo.md
@@ -107,5 +107,5 @@ void combo_disable(void);
 void combo_toggle(void);
 
 /* Gets Combo feature enabled state */
-bool get_combo_enable(void);
+bool is_combo_enabled(void);
 ```

--- a/docs/feature_combo.md
+++ b/docs/feature_combo.md
@@ -59,19 +59,12 @@ void process_combo_event(uint8_t combo_index, bool pressed) {
   switch(combo_index) {
     case ZC_COPY:
       if (pressed) {
-        register_code(KC_LCTL);
-        register_code(KC_C);
-        unregister_code(KC_C);
-        unregister_code(KC_LCTL);
+        tap_code16(LCTL(KC_C));
       }
       break;
-
     case XV_PASTE:
       if (pressed) {
-        register_code(KC_LCTL);
-        register_code(KC_V);
-        unregister_code(KC_V);
-        unregister_code(KC_LCTL);
+        tap_code16(LCTL(KC_V));
       }
       break;
   }
@@ -87,3 +80,32 @@ If you're using long combos, or even longer combos, you may run into issues with
 In this case, you can add either `#define EXTRA_LONG_COMBOS` or `#define EXTRA_EXTRA_LONG_COMBOS` in your `config.h` file.
 
 You may also be able to enable action keys by defining `COMBO_ALLOW_ACTION_KEYS`.
+
+## Keycodes 
+
+You can enable, disable and toggle the Combo feature on the fly.  This is useful if you need to disable them temporarily, such as for a game. 
+
+
+```
+* `COMBO_ON` - Turn combo Feature on
+* `COMBO_OFF` - Turn Combo Feature off
+* `COMBO_TOG` - Toggles Combo Feature state
+```
+
+## User callbacks
+
+In addition to the keycodes, there are a few functions that you can use to set the status, or check it:
+
+```c 
+/* Enables Combos */
+void combo_enable(void);
+
+/* Disables Combos */
+void combo_disable(void);
+
+/* Toggles Combo feature state */
+void combo_toggle(void);
+
+/* Gets Combo feature enabled state */
+bool get_combo_enable(void);
+```

--- a/docs/feature_combo.md
+++ b/docs/feature_combo.md
@@ -85,27 +85,19 @@ You may also be able to enable action keys by defining `COMBO_ALLOW_ACTION_KEYS`
 
 You can enable, disable and toggle the Combo feature on the fly.  This is useful if you need to disable them temporarily, such as for a game. 
 
-
-```
-* `CMB_ON` - Turn combo Feature on
-* `CMB_OFF` - Turn Combo Feature off
-* `CMB_TOG` - Toggles Combo Feature state
-```
+|Keycode   |Description                      |
+|----------|---------------------------------|
+|`CMB_ON`  |Turns on Combo feature           |
+|`CMB_OFF` |Turns off Combo feature          |
+|`CMB_TOG` |Toggles Combo feature on and off |
 
 ## User callbacks
 
 In addition to the keycodes, there are a few functions that you can use to set the status, or check it:
 
-```c 
-/* Enables Combos */
-void combo_enable(void);
-
-/* Disables Combos */
-void combo_disable(void);
-
-/* Toggles Combo feature state */
-void combo_toggle(void);
-
-/* Gets Combo feature enabled state */
-bool is_combo_enabled(void);
-```
+|Function   |Description                                                         |
+|-----------|--------------------------------------------------------------------|
+| `combo_enable()`     | Enables the combo feature                               |
+| `combo_disable()`    | Disables the combo feature, and clears the combo buffer |
+| `combo_toggle()`     | Toggles the state of the combo feature                  |
+| `is_combo_enabled()` | Returns the status of the combo feature state (true or false) |

--- a/quantum/process_keycode/process_combo.c
+++ b/quantum/process_keycode/process_combo.c
@@ -129,17 +129,17 @@ bool process_combo(uint16_t keycode, keyrecord_t *record) {
   drop_buffer = false;
   bool no_combo_keys_pressed = true;
 
-  if (keycode == COMBO_ON && record->event.pressed) {
+  if (keycode == CMB_ON && record->event.pressed) {
     combo_enable();
     return true;
   }
 
-  if (keycode == COMBO_OFF && record->event.pressed) {
+  if (keycode == CMB_OFF && record->event.pressed) {
     combo_disable();
     return true;
   }
 
-  if (keycode == COMBO_TOG && record->event.pressed) {
+  if (keycode == CMB_TOG && record->event.pressed) {
     combo_toggle();
     return true;
   }

--- a/quantum/process_keycode/process_combo.c
+++ b/quantum/process_keycode/process_combo.c
@@ -28,7 +28,7 @@ static uint16_t timer = 0;
 static uint8_t current_combo_index = 0;
 static bool drop_buffer = false;
 static bool is_active = false;
-static bool is_combo_enable = true; // defaults to enabled
+static bool b_combo_enable = true; // defaults to enabled
 
 static uint8_t buffer_size = 0;
 #ifdef COMBO_ALLOW_ACTION_KEYS
@@ -144,7 +144,7 @@ bool process_combo(uint16_t keycode, keyrecord_t *record) {
     return true;
   }
 
-  if (!get_combo_enable()) { return true; }
+  if (!is_combo_enabled()) { return true; }
 
   for (current_combo_index = 0; current_combo_index < COMBO_COUNT;
        ++current_combo_index) {
@@ -184,7 +184,7 @@ bool process_combo(uint16_t keycode, keyrecord_t *record) {
 }
 
 void matrix_scan_combo(void) {
-  if (is_combo_enable && is_active && timer && timer_elapsed(timer) > COMBO_TERM) {
+  if (b_combo_enable && is_active && timer && timer_elapsed(timer) > COMBO_TERM) {
 
     /* This disables the combo, meaning key events for this
      * combo will be handled by the next processors in the chain
@@ -195,24 +195,24 @@ void matrix_scan_combo(void) {
 }
 
 void combo_enable(void) {
-    is_combo_enable = true;
+    b_combo_enable = true;
 }
 
 void combo_disable(void) {
-    is_combo_enable = is_active = false;
+    b_combo_enable = is_active = false;
     timer = 0;
     dump_key_buffer(true);
 
 }
 
 void combo_toggle(void) {
-    if (is_combo_enable) {
+    if (b_combo_enable) {
         combo_disable();
     } else {
         combo_enable();
     }
 }
 
-bool get_combo_enable(void) {
-    return is_combo_enable;
+bool is_combo_enabled(void) {
+    return b_combo_enable;
 }

--- a/quantum/process_keycode/process_combo.c
+++ b/quantum/process_keycode/process_combo.c
@@ -199,19 +199,17 @@ void combo_enable(void) {
 }
 
 void combo_disable(void) {
-    is_combo_enable = false;
-    is_active = false;
+    is_combo_enable = is_active = false;
     timer = 0;
     dump_key_buffer(true);
 
 }
 
 void combo_toggle(void) {
-    is_combo_enable ^= true;
-    if (!is_combo_enable) {
-        is_active = false;
-        timer = 0;
-        dump_key_buffer(true);
+    if (is_combo_enable) {
+        combo_disable();
+    } else {
+        combo_enable();
     }
 }
 

--- a/quantum/process_keycode/process_combo.h
+++ b/quantum/process_keycode/process_combo.h
@@ -58,4 +58,9 @@ bool process_combo(uint16_t keycode, keyrecord_t *record);
 void matrix_scan_combo(void);
 void process_combo_event(uint8_t combo_index, bool pressed);
 
+void combo_enable(void);
+void combo_disable(void);
+void combo_toggle(void);
+bool get_combo_enable(void);
+
 #endif

--- a/quantum/process_keycode/process_combo.h
+++ b/quantum/process_keycode/process_combo.h
@@ -61,6 +61,6 @@ void process_combo_event(uint8_t combo_index, bool pressed);
 void combo_enable(void);
 void combo_disable(void);
 void combo_toggle(void);
-bool get_combo_enable(void);
+bool is_combo_enabled(void);
 
 #endif

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -489,9 +489,9 @@ enum quantum_keycodes {
     // Right control, close paren
     KC_RAPC,
 
-    COMBO_ON,
-    COMBO_OFF,
-    COMBO_TOG,
+    CMB_ON,
+    CMB_OFF,
+    CMB_TOG,
     // always leave at the end
     SAFE_RANGE
 };

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -489,6 +489,9 @@ enum quantum_keycodes {
     // Right control, close paren
     KC_RAPC,
 
+    COMBO_ON,
+    COMBO_OFF,
+    COMBO_TOG,
     // always leave at the end
     SAFE_RANGE
 };


### PR DESCRIPTION
 ## Description

This adds the ability to enable, disable and toggle the state of the Combo feature without having to recompile if want to disable the feature.

This makes it useful, if you have modes where combos are actually in the way (such as when gaming).

## Types of Changes
- [x] Enhancement/optimization
- [x] Documentation
## Issues Fixed or Closed by This PR
* thread on reddit
## Checklist
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).