### PR TITLE
[Keyboard] [bface] Make RGB actually optional

### DIFF
--- a/keyboards/winkeyless/bface/bface.c
+++ b/keyboards/winkeyless/bface/bface.c
@@ -25,6 +25,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "i2c.h"
 #include "quantum.h"
 
+#ifdef RGBLIGHT_ENABLE
+
 extern rgblight_config_t rgblight_config;
 
 void rgblight_set(void) {
@@ -44,3 +46,5 @@ __attribute__ ((weak))
 void matrix_scan_user(void) {
     rgblight_task();
 }
+
+#endif

--- a/keyboards/winkeyless/bface/matrix.c
+++ b/keyboards/winkeyless/bface/matrix.c
@@ -99,8 +99,9 @@ uint8_t matrix_scan(void) {
             }
         }
     }
-
+#ifdef RGBLIGHT_ENABLE
     matrix_scan_user();
+#endif
 
     return 1;
 }


### PR DESCRIPTION
## Description

With the `RGBLIGHT_ENABLE` rule set to "no", compiling errors follow.
This makes the option possible to disable.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
