### PR TITLE
Remove the need to specify NUM_OF_ENCODERS for the Encoder feature

### DIFF
--- a/docs/feature_encoders.md
+++ b/docs/feature_encoders.md
@@ -6,7 +6,6 @@ Basic encoders are supported by adding this to your `rules.mk`:
 
 and this to your `config.h`:
 
-    #define NUMBER_OF_ENCODERS 1
     #define ENCODERS_PAD_A { B12 }
     #define ENCODERS_PAD_B { B13 }
 

--- a/keyboards/abstract/ellipse/rev1/config.h
+++ b/keyboards/abstract/ellipse/rev1/config.h
@@ -239,7 +239,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // #define BOOTMAGIC_LITE_ROW 0
 // #define BOOTMAGIC_LITE_COLUMN 0
 
-#define NUMBER_OF_ENCODERS 3
 #define ENCODERS_PAD_A { B2, B3, D5 }
 #define ENCODERS_PAD_B { B1, B7, B4 }
 #define ENCODER_RESOLUTION 2

--- a/keyboards/boston_meetup/2019/config.h
+++ b/keyboards/boston_meetup/2019/config.h
@@ -26,7 +26,6 @@
 #define MATRIX_ROW_PINS { A3, B8, B9, B1 }
 #define MATRIX_COL_PINS { A7, A8, B2, B10 }
 
-#define NUMBER_OF_ENCODERS 1
 #define ENCODERS_PAD_A { B13 }
 #define ENCODERS_PAD_B { B14 }
 
@@ -142,7 +141,7 @@
 #define FB_LOOPGAIN 1 /* For  Low:0, Medium:1, High:2, Very High:3 */
 
 /* default 3V ERM vibration motor voltage and library*/
-#if FB_ERM_LRA == 0 
+#if FB_ERM_LRA == 0
 #define RATED_VOLTAGE 3
 #define V_RMS 2.3
 #define V_PEAK 3.30
@@ -193,4 +192,3 @@
 #define RGB_MATRIX_KEYPRESSES
 
 #define SOLENOID_PIN A14
-

--- a/keyboards/cannonkeys/ortho75/config.h
+++ b/keyboards/cannonkeys/ortho75/config.h
@@ -39,7 +39,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define BACKLIGHT_BREATHING
 #define BREATHING_PERIOD 6
 
-#define NUMBER_OF_ENCODERS 1
 #define ENCODERS_PAD_A { B9 }
 #define ENCODERS_PAD_B { B8 }
 

--- a/keyboards/cannonkeys/satisfaction75/config.h
+++ b/keyboards/cannonkeys/satisfaction75/config.h
@@ -35,7 +35,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MATRIX_ROW_PINS { B3, B4, A0, A2, A4, A3 }
 #define DIODE_DIRECTION COL2ROW
 
-#define NUMBER_OF_ENCODERS 1
 #define ENCODERS_PAD_A { B9 }
 #define ENCODERS_PAD_B { B8 }
 

--- a/keyboards/hadron/ver3/config.h
+++ b/keyboards/hadron/ver3/config.h
@@ -44,7 +44,6 @@
 #define MATRIX_COL_PINS { B8,  B2,  B10, A0, A1, A2, B0, A3, B1, A6, A7, B12, C13, B11, B9 }
 #define UNUSED_PINS
 
-#define NUMBER_OF_ENCODERS 1
 #define ENCODERS_PAD_A { B13 }
 #define ENCODERS_PAD_B { B14 }
 

--- a/keyboards/handwired/daishi/config.h
+++ b/keyboards/handwired/daishi/config.h
@@ -52,7 +52,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define DEBOUNCE 5
 
 /* Set up rotary encoder */
-#define NUMBER_OF_ENCODERS 1
 #define ENCODERS_PAD_A { F1 }
 #define ENCODERS_PAD_B { F0 }
 #define ENCODER_RESOLUTION 2

--- a/keyboards/keebio/bdn9/config.h
+++ b/keyboards/keebio/bdn9/config.h
@@ -38,7 +38,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     { E6, B4, B2 } \
 }
 
-#define NUMBER_OF_ENCODERS 2
 #define ENCODERS_PAD_A { D1, F5 }
 #define ENCODERS_PAD_B { D0, F6 }
 

--- a/keyboards/keebio/iris/rev3/config.h
+++ b/keyboards/keebio/iris/rev3/config.h
@@ -41,7 +41,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define QMK_LED B0
 #define QMK_SPEAKER C6
 
-#define NUMBER_OF_ENCODERS 1
 #define ENCODERS_PAD_A { B5 }
 #define ENCODERS_PAD_B { B7 }
 

--- a/keyboards/maxr1998/pulse4k/config.h
+++ b/keyboards/maxr1998/pulse4k/config.h
@@ -43,7 +43,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define DEBOUNCE 5
 
 /* Rotary encoders */
-#define NUMBER_OF_ENCODERS 2
 #define ENCODERS_PAD_A { D2, F6 }
 #define ENCODERS_PAD_B { D3, F5 }
 #define ENCODER_RESOLUTION 4

--- a/keyboards/planck/ez/config.h
+++ b/keyboards/planck/ez/config.h
@@ -43,7 +43,6 @@
 #define MATRIX_ROW_PINS { A10, A9, A8, B15, C13, C14, C15, A2 }
 #define MATRIX_COL_PINS { B11, B10, B2, B1, A7, B0 }
 
-#define NUMBER_OF_ENCODERS 1
 #define ENCODERS_PAD_A { B12 }
 #define ENCODERS_PAD_B { B13 }
 

--- a/keyboards/planck/rev6/config.h
+++ b/keyboards/planck/rev6/config.h
@@ -43,7 +43,6 @@
  * #define UNUSED_PINS
  */
 
-#define NUMBER_OF_ENCODERS 1
 #define ENCODERS_PAD_A { B12 }
 #define ENCODERS_PAD_B { B13 }
 

--- a/keyboards/preonic/rev3/config.h
+++ b/keyboards/preonic/rev3/config.h
@@ -43,7 +43,6 @@
  * #define UNUSED_PINS
  */
 
-#define NUMBER_OF_ENCODERS 1
 #define ENCODERS_PAD_A { B12 }
 #define ENCODERS_PAD_B { B13 }
 

--- a/keyboards/rgbkb/sol/config.h
+++ b/keyboards/rgbkb/sol/config.h
@@ -36,7 +36,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MATRIX_COL_PINS { F0, F1, F4, F5, F6, F7, C7 }
 
 // Encoder support
-#define NUMBER_OF_ENCODERS 1
 #define ENCODERS_PAD_A { D2 }
 #define ENCODERS_PAD_B { D6 }
 

--- a/keyboards/rgbkb/zen/rev2/config.h
+++ b/keyboards/rgbkb/zen/rev2/config.h
@@ -41,8 +41,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MATRIX_ROW_PINS { C6, E6, B5, D7, B4 }
 #define MATRIX_COL_PINS { F4, F5, F6, F7, B3, B1, B2 }
 
-#define NUMBER_OF_ENCODERS 1
-
 #define ENCODERS_PAD_A  { D4 }
 #define ENCODERS_PAD_B  { D2 }
 

--- a/keyboards/rgbkb/zygomorph/rev1/config.h
+++ b/keyboards/rgbkb/zygomorph/rev1/config.h
@@ -40,7 +40,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define SOFT_SERIAL_PIN D3
 
-#define NUMBER_OF_ENCODERS 1
 #define ENCODERS_PAD_A  { D2 }
 #define ENCODERS_PAD_B  { D7 }
 

--- a/keyboards/ropro/config.h
+++ b/keyboards/ropro/config.h
@@ -1,4 +1,4 @@
-#pragma once 
+#pragma once
 
 /* Copyright 2019 Garret G. (TheRoyalSweatshirt)
  *
@@ -13,10 +13,10 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.#pragma once 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.#pragma once
  */
 
-#include "config_common.h" 
+#include "config_common.h"
 
 /* USB Device descriptor parameter */
 #define VENDOR_ID       0xFEED
@@ -30,7 +30,6 @@
 #define MATRIX_ROWS 7
 #define MATRIX_COLS 14
 
-#define NUMBER_OF_ENCODERS 1
 #define ENCODERS_PAD_A { B7 }
 #define ENCODERS_PAD_B { D5 }
 

--- a/keyboards/tetris/config.h
+++ b/keyboards/tetris/config.h
@@ -40,7 +40,6 @@
   #define NO_MUSIC_MODE
 #endif
 
-#define NUMBER_OF_ENCODERS 2
 #define ENCODERS_PAD_A { D1,F1 }
 #define ENCODERS_PAD_B { D0,F0 }
 

--- a/quantum/encoder.c
+++ b/quantum/encoder.c
@@ -25,16 +25,14 @@
   #define ENCODER_RESOLUTION 4
 #endif
 
-#ifndef NUMBER_OF_ENCODERS
-  #error "Number of encoders not defined by NUMBER_OF_ENCODERS"
-#endif
-
 #if !defined(ENCODERS_PAD_A) || !defined(ENCODERS_PAD_B)
   #error "No encoder pads defined by ENCODERS_PAD_A and ENCODERS_PAD_B"
 #endif
 
-static pin_t encoders_pad_a[NUMBER_OF_ENCODERS] = ENCODERS_PAD_A;
-static pin_t encoders_pad_b[NUMBER_OF_ENCODERS] = ENCODERS_PAD_B;
+
+#define NUMBER_OF_ENCODERS (sizeof(encoders_pad_a)/sizeof(pin_t))
+static pin_t encoders_pad_a[] = ENCODERS_PAD_A;
+static pin_t encoders_pad_b[] = ENCODERS_PAD_B;
 
 static int8_t encoder_LUT[] = { 0, -1, 1, 0, 1, 0, 0, -1, -1, 0, 0, 1, 0, 1, -1, 0 };
 

--- a/quantum/split_common/transport.c
+++ b/quantum/split_common/transport.c
@@ -17,6 +17,8 @@
 
 #ifdef ENCODER_ENABLE
 #  include "encoder.h"
+static pin_t encoders_pad[] = ENCODERS_PAD_A;
+#  define NUMBER_OF_ENCODERS (sizeof(encoders_pad)/sizeof(pin_t))
 #endif
 
 #if defined(USE_I2C) || defined(EH)


### PR DESCRIPTION
## Description
Instead, this calculates the number from the array of pins used. 

Thanks mtei for this, on the dip switch PR.

## Types of Changes
- [x] Core
- [x] Enhancement/optimization
- [x] Documentation
## Checklist
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).