### PR TITLE
Fix advanced keymap readme and macro function

### DIFF
--- a/keyboards/xd004/keymaps/system_and_media/keymap.c
+++ b/keyboards/xd004/keymaps/system_and_media/keymap.c
@@ -41,12 +41,10 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             if (record->event.pressed) {
                 if (!is_alt_f4_active) {
                     is_alt_f4_active = true;
-                    tap_code_16(LALT(KC_F4);  // Alt-F4
+                    tap_code16(LALT(KC_F4));  // Alt-F4
                 } else {
                     tap_code(KC_ENTER);  // Tap enter
                 }
-            } else {
-                unregister_code(KC_TAB);
             }
             alt_f4_timer = timer_read();
             break;

--- a/keyboards/xd004/keymaps/system_and_media/readme.md
+++ b/keyboards/xd004/keymaps/system_and_media/readme.md
@@ -1,4 +1,4 @@
-# Default Keymap for XD004 PCB
+# Slightly more advanced keymap for XD004 PCB
 
 A somehow more useful keymap, allowing one to move across virtual desktops on Windows, etc.
 


### PR DESCRIPTION
Guys I am sorry, there was useless code left over in my previous PR, plus `tap_code16` was spelled wrong. The thing was not compiling! Weird that Travis didn't warn us. Anyway, here's the fix.