### PR TITLE
Fix BACKLIGHT_LEVELS for broken keyboards

### DIFF
--- a/keyboards/cannonkeys/satisfaction75/config.h
+++ b/keyboards/cannonkeys/satisfaction75/config.h
@@ -39,7 +39,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define ENCODERS_PAD_B { B8 }
 
 //LEDS A6, RGB B15
-#define BACKLIGHT_LEVELS 24
+#define BACKLIGHT_LEVELS 15
 #define BACKLIGHT_BREATHING
 #define BREATHING_PERIOD 6
 

--- a/keyboards/handwired/co60/rev6/config.h
+++ b/keyboards/handwired/co60/rev6/config.h
@@ -55,6 +55,6 @@
 /* Backlight configuration
  * Backlight LEDs on B8
  */
-#define BACKLIGHT_LEVELS 24
+#define BACKLIGHT_LEVELS 15
 #define BACKLIGHT_BREATHING
 #define BREATHING_PERIOD 6

--- a/keyboards/handwired/co60/rev7/config.h
+++ b/keyboards/handwired/co60/rev7/config.h
@@ -57,7 +57,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* Backlight configuration
  * Backlight LEDs on B8
  */
-#define BACKLIGHT_LEVELS 24
+#define BACKLIGHT_LEVELS 15
 #define BACKLIGHT_BREATHING
 #define BREATHING_PERIOD 6
 


### PR DESCRIPTION
## Description

The following keyboards were broken by the merging of #6105, because they had their BACKLIGHT_LEVELS set above QMK's (now-enforced) limit of 15:

- CannonKeys Satisfaction75
- CO60 handwired (revs. 6 and 7)

### Tagging

- @awkannan (CannonKeys maintainer)
- @jmdaly (CO60 handwired maintainer)


## Types of Changes

- [x] Bugfix
- [x] Keyboard (addition or update)


## Checklist

- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
