### PR TITLE
Use led_set_kb instead of led_set_user in melody96.c

### DIFF
--- a/keyboards/melody96/melody96.c
+++ b/keyboards/melody96/melody96.c
@@ -1,7 +1,6 @@
 #include "melody96.h"
 
-void led_set_user(uint8_t usb_led) {
-
+void led_set_kb(uint8_t usb_led) {
 	if (usb_led & (1 << USB_LED_NUM_LOCK)) {
 		DDRC |= (1 << 6); PORTC &= ~(1 << 6);
 	} else {
@@ -19,4 +18,6 @@ void led_set_user(uint8_t usb_led) {
 	} else {
 		DDRB &= ~(1 << 5); PORTB &= ~(1 << 5);
 	}
+
+    led_set_user(usb_led);
 }


### PR DESCRIPTION
## Description

The Melody96 keyboard file should define `led_set_kb()` rather than `led_set_user()`, as the latter makes it impossible to mix in a user-defined implementation of `led_set_user()` (it fails at link time). This PR fixes that.

Tested on my Melody96.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
