### PR TITLE
Extend maximum number of backlight levels to 31

### DIFF
--- a/docs/feature_backlight.md
+++ b/docs/feature_backlight.md
@@ -65,7 +65,7 @@ To change the behaviour of the backlighting, `#define` these in your `config.h`:
 |---------------------|-------------|-------------------------------------------------------------------------------------------------------------|
 |`BACKLIGHT_PIN`      |`B7`         |The pin that controls the LEDs. Unless you are designing your own keyboard, you shouldn't need to change this|
 |`BACKLIGHT_PINS`     |*Not defined*|experimental: see below for more information                                                                 |
-|`BACKLIGHT_LEVELS`   |`3`          |The number of brightness levels (maximum 15 excluding off)                                                   |
+|`BACKLIGHT_LEVELS`   |`3`          |The number of brightness levels (maximum 31 excluding off)                                                   |
 |`BACKLIGHT_CAPS_LOCK`|*Not defined*|Enable Caps Lock indicator using backlight (for keyboards without dedicated LED)                             |
 |`BACKLIGHT_BREATHING`|*Not defined*|Enable backlight breathing, if supported                                                                     |
 |`BREATHING_PERIOD`   |`6`          |The length of one backlight "breath" in seconds                                                              |

--- a/tmk_core/common/backlight.h
+++ b/tmk_core/common/backlight.h
@@ -22,8 +22,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #ifndef BACKLIGHT_LEVELS
   #define BACKLIGHT_LEVELS 3
-#elif BACKLIGHT_LEVELS > 15
-  #error "Maximum value of BACKLIGHT_LEVELS is 15"
+#elif BACKLIGHT_LEVELS > 31
+  #error "Maximum value of BACKLIGHT_LEVELS is 31"
 #endif
 
 typedef union {
@@ -31,7 +31,8 @@ typedef union {
     struct {
         bool    enable    :1;
         bool    breathing :1;
-        uint8_t level     :4;
+        uint8_t reserved  :1; // Reserved for possible future backlight modes
+        uint8_t level     :5;
     };
 } backlight_config_t;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Turns out 15 levels wasn't enough for some people 😁 so it's increased to 5 bits.

Also, nudged the level bits over again and added a reserved bit, which could be eventually merged into the breathing bit, for a tiny (4) mode selector.

Once again there will be a further dimming of the backlight after flashing, which is solved by just hitting `BL_INC` until it's back where you want it.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* Supersedes #6343

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
