### PR TITLE
stm32f072: make sure userspace has chance to handle keycodes

### DIFF
--- a/keyboards/cannonkeys/stm32f072/keyboard.c
+++ b/keyboards/cannonkeys/stm32f072/keyboard.c
@@ -162,7 +162,7 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
 	}
     #endif //DYNAMIC_KEYMAP_ENABLE
 
-  return true;
+  return process_record_user(keycode, record);;
 }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The process_record_kb() function for cannonkeys/stm32f072 doesn't call process_record_user(), so any userspace keycode handling is ignored by boards using the stm32f072 support.  The fix is trivial - call process_record_user() at the end of process_record_kb() in the usual way.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
