### PR TITLE
Correct backlight on state docs

### DIFF
--- a/docs/feature_backlight.md
+++ b/docs/feature_backlight.md
@@ -74,7 +74,9 @@ To change the behaviour of the backlighting, `#define` these in your `config.h`:
 ## Backlight On State
 
 Most backlight circuits are driven by an N-channel MOSFET or NPN transistor. This means that to turn the transistor *on* and light the LEDs, you must drive the backlight pin, connected to the gate or base, *high*.
-Sometimes, however, a P-channel MOSFET, or a PNP transistor is used. In this case you must `#define BACKLIGHT_ON_STATE 0`, so that when the transistor is on, the pin is driven *low* instead.
+Sometimes, however, a P-channel MOSFET, or a PNP transistor is used. In this case, when the transistor is on, the pin is driven *low* instead.
+
+This functionality is configured at the keyboard level with the `BACKLIGHT_ON_STATE` define.
 
 ## Multiple backlight pins
 

--- a/docs/feature_backlight.md
+++ b/docs/feature_backlight.md
@@ -73,8 +73,8 @@ To change the behaviour of the backlighting, `#define` these in your `config.h`:
 
 ## Backlight On State
 
-Most backlight circuits are driven by an N-channel MOSFET or NPN transistor. This means that to turn the transistor *on* and light the LEDs, you must drive the backlight pin, connected to the gate or base, *low*.
-Sometimes, however, a P-channel MOSFET, or a PNP transistor is used. In this case you must `#define BACKLIGHT_ON_STATE 1`, so that when the transistor is on, the pin is driven *high* instead.
+Most backlight circuits are driven by an N-channel MOSFET or NPN transistor. This means that to turn the transistor *on* and light the LEDs, you must drive the backlight pin, connected to the gate or base, *high*.
+Sometimes, however, a P-channel MOSFET, or a PNP transistor is used. In this case you must `#define BACKLIGHT_ON_STATE 0`, so that when the transistor is on, the pin is driven *low* instead.
 
 ## Multiple backlight pins
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Arghhh... This section is all kinds of wrong - my bad. I confirmed with some test circuits that PNP transistors are in fact the ones which are active low.

But, this presents another problem: `BACKLIGHT_ON_STATE` is only respected for software PWM, *and* it defaults to 0, which is at odds with hardware PWM; it currently assumes an NPN. ~So this paragraph is still confusing as it appears to imply the default is `1`, since it's more common and is inherently true for hardware PWM~ **Reworded to reduce the confusion**.

I'm still experimenting to get this define working for hardware PWM, and I seem to be on the right track as the addition and usage of `COMxx0` in #2661 is pretty much what I came up with. `COMxx1` == clear on compare match, `COMxx1 | COMxx0` == set on compare match.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
