### PR TITLE
Refactor handwired/splittest to support multiple boards

### DIFF
--- a/keyboards/handwired/splittest/config.h
+++ b/keyboards/handwired/splittest/config.h
@@ -33,12 +33,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MATRIX_ROWS 2
 #define MATRIX_COLS 1
 
-// wiring of each half
-#define MATRIX_ROW_PINS { B3 }
-#define MATRIX_COL_PINS { B6 }
-#define SPLIT_HAND_PIN F6
-#define SOFT_SERIAL_PIN D1
-
 /* define if matrix has ghost */
 //#define MATRIX_HAS_GHOST
 
@@ -51,10 +45,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define LOCKING_RESYNC_ENABLE
 
 /* ws2812 RGB LED */
-#define RGB_DI_PIN D3
 #define RGBLIGHT_ANIMATIONS
-#define RGBLED_NUM 12
-#define RGBLED_SPLIT { 6, 6 }
+#define RGBLED_NUM 10
+#define RGBLED_SPLIT { 5, 5 }
 
 /*
  * Feature disable options

--- a/keyboards/handwired/splittest/config.h
+++ b/keyboards/handwired/splittest/config.h
@@ -46,8 +46,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGBLIGHT_ANIMATIONS
-#define RGBLED_NUM 10
-#define RGBLED_SPLIT { 5, 5 }
+#define RGBLED_NUM 12
+#define RGBLED_SPLIT { 6, 6 }
 
 /*
  * Feature disable options

--- a/keyboards/handwired/splittest/promicro/config.h
+++ b/keyboards/handwired/splittest/promicro/config.h
@@ -1,0 +1,28 @@
+/* Copyright 2019
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "config_common.h"
+
+// wiring of each half
+#define MATRIX_ROW_PINS { B3 }
+#define MATRIX_COL_PINS { B6 }
+#define SPLIT_HAND_PIN F6
+#define SOFT_SERIAL_PIN D1
+
+/* ws2812 RGB LED */
+#define RGB_DI_PIN D3

--- a/keyboards/handwired/splittest/promicro/readme.md
+++ b/keyboards/handwired/splittest/promicro/readme.md
@@ -1,0 +1,3 @@
+# Pro Micro onekey
+
+To trigger keypress, short together pins *F4* and *F5* (marked on the PCB as *A3* and *A2*).

--- a/keyboards/handwired/splittest/promicro/readme.md
+++ b/keyboards/handwired/splittest/promicro/readme.md
@@ -1,3 +1,11 @@
-# Pro Micro onekey
+# Pro Micro splittest
 
-To trigger keypress, short together pins *F4* and *F5* (marked on the PCB as *A3* and *A2*).
+To trigger keypress, short together pins *B3* and *B6* (marked on the PCB as *14* and *10*).
+
+## Wiring
+- Add switches to both Pro Micros across B3 and B6 pins
+- Add pull-up resistor to left side between VCC and F6
+- Add pull-down resistors to right side between GND and F6
+- Connect the following pins on both sides together: D0, D1, GND, VCC
+- Add I2C 4.7kOhm resistors between D0 and VCC, and D1 and VCC
+- Wire Di of RGB strip for each half to D3

--- a/keyboards/handwired/splittest/promicro/rules.mk
+++ b/keyboards/handwired/splittest/promicro/rules.mk
@@ -1,0 +1,58 @@
+# MCU name
+MCU = atmega32u4
+
+# Processor frequency.
+#     This will define a symbol, F_CPU, in all source code files equal to the
+#     processor frequency in Hz. You can then use this symbol in your source code to
+#     calculate timings. Do NOT tack on a 'UL' at the end, this will be done
+#     automatically to create a 32-bit value in your source code.
+#
+#     This will be an integer division of F_USB below, as it is sourced by
+#     F_USB after it has run through any CPU prescalers. Note that this value
+#     does not *change* the processor frequency - it should merely be updated to
+#     reflect the processor speed set externally so that the code can use accurate
+#     software delays.
+F_CPU = 16000000
+
+
+#
+# LUFA specific
+#
+# Target architecture (see library "Board Types" documentation).
+ARCH = AVR8
+
+# Input clock frequency.
+#     This will define a symbol, F_USB, in all source code files equal to the
+#     input clock frequency (before any prescaling is performed) in Hz. This value may
+#     differ from F_CPU if prescaling is used on the latter, and is required as the
+#     raw input clock is fed directly to the PLL sections of the AVR for high speed
+#     clock generation for the USB and other AVR subsections. Do NOT tack on a 'UL'
+#     at the end, this will be done automatically to create a 32-bit value in your
+#     source code.
+#
+#     If no clock division is performed on the input clock inside the AVR (via the
+#     CPU clock adjust registers or the clock division fuses), this will be equal to F_CPU.
+F_USB = $(F_CPU)
+
+# Interrupt driven control endpoint task(+60)
+OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
+
+
+# Bootloader selection
+#   Teensy       halfkay
+#   Pro Micro    caterina
+#   Atmel DFU    atmel-dfu
+#   LUFA DFU     lufa-dfu
+#   QMK DFU      qmk-dfu
+#   atmega32a    bootloadHID
+BOOTLOADER = caterina
+
+
+# If you don't know the bootloader type, then you can specify the
+# Boot Section Size in *bytes* by uncommenting out the OPT_DEFS line
+#   Teensy halfKay      512
+#   Teensy++ halfKay    1024
+#   Atmel DFU loader    4096
+#   LUFA bootloader     4096
+#   USBaspLoader        2048
+# OPT_DEFS += -DBOOTLOADER_SIZE=4096

--- a/keyboards/handwired/splittest/readme.md
+++ b/keyboards/handwired/splittest/readme.md
@@ -4,7 +4,10 @@ Split Tester
 A two-switch tester built using two Pro Micros, mainly intended to test RGB on split keyboards. Seen here: https://www.instagram.com/p/BvCPNzynwrV/
 
 Keyboard Maintainer: [Bakingpy/nooges](https://github.com/nooges)  
-Hardware Supported: Pro Micro   
+Hardware Supported: Pro Micro, Teensy 2.0  
+Hardware Availability: 
+
+**See each individual board for pin infomation**
 
 Make example for this keyboard (after setting up your build environment):
 
@@ -15,12 +18,3 @@ Example of flashing this keyboard:
     make handwired/splittest:default:avrdude
 
 See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
-
-Wiring
-------
-- Add switches to both Pro Micros across B3 and B6 pins
-- Add pull-up resistor to left side between VCC and F6
-- Add pull-down resistors to right side between GND and F6
-- Connect the following pins on both sides together: D0, D1, GND, VCC
-- Add I2C 4.7kOhm resistors between D0 and VCC, and D1 and VCC
-- Wire Di of RGB strip for each half to D2

--- a/keyboards/handwired/splittest/rules.mk
+++ b/keyboards/handwired/splittest/rules.mk
@@ -1,47 +1,3 @@
-# MCU name
-MCU = atmega32u4
-
-# Processor frequency.
-#     This will define a symbol, F_CPU, in all source code files equal to the
-#     processor frequency in Hz. You can then use this symbol in your source code to
-#     calculate timings. Do NOT tack on a 'UL' at the end, this will be done
-#     automatically to create a 32-bit value in your source code.
-#
-#     This will be an integer division of F_USB below, as it is sourced by
-#     F_USB after it has run through any CPU prescalers. Note that this value
-#     does not *change* the processor frequency - it should merely be updated to
-#     reflect the processor speed set externally so that the code can use accurate
-#     software delays.
-F_CPU = 16000000
-
-#
-# LUFA specific
-#
-# Target architecture (see library "Board Types" documentation).
-ARCH = AVR8
-
-# Input clock frequency.
-#     This will define a symbol, F_USB, in all source code files equal to the
-#     input clock frequency (before any prescaling is performed) in Hz. This value may
-#     differ from F_CPU if prescaling is used on the latter, and is required as the
-#     raw input clock is fed directly to the PLL sections of the AVR for high speed
-#     clock generation for the USB and other AVR subsections. Do NOT tack on a 'UL'
-#     at the end, this will be done automatically to create a 32-bit value in your
-#     source code.
-#
-#     If no clock division is performed on the input clock inside the AVR (via the
-#     CPU clock adjust registers or the clock division fuses), this will be equal to F_CPU.
-F_USB = $(F_CPU)
-
-# Bootloader
-#     This definition is optional, and if your keyboard supports multiple bootloaders of
-#     different sizes, comment this out, and the correct address will be loaded
-#     automatically (+60). See bootloader.mk for all options.
-BOOTLOADER = caterina
-
-# Interrupt driven control endpoint task(+60)
-OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
-
 # Build Options
 #   change to "no" to disable the options, or define them in the Makefile in
 #   the appropriate keymap folder that will get included automatically
@@ -63,3 +19,5 @@ RGBLIGHT_ENABLE = yes        # Enable WS2812 RGB underlight.
 SLEEP_LED_ENABLE = no    # Breathing sleep LED during USB suspend
 
 SPLIT_KEYBOARD = yes
+
+DEFAULT_FOLDER = handwired/splittest/promicro

--- a/keyboards/handwired/splittest/teensy_2/config.h
+++ b/keyboards/handwired/splittest/teensy_2/config.h
@@ -19,7 +19,7 @@
 #include "config_common.h"
 
 // wiring of each half
-#define MATRIX_ROW_PINS { F6 }
+#define MATRIX_ROW_PINS { F5 }
 #define MATRIX_COL_PINS { F7 }
 #define SPLIT_HAND_PIN F0
 #define SOFT_SERIAL_PIN D1

--- a/keyboards/handwired/splittest/teensy_2/config.h
+++ b/keyboards/handwired/splittest/teensy_2/config.h
@@ -1,0 +1,31 @@
+/* Copyright 2019
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "config_common.h"
+
+// wiring of each half
+#define MATRIX_ROW_PINS { F6 }
+#define MATRIX_COL_PINS { F7 }
+#define SPLIT_HAND_PIN F0
+#define SOFT_SERIAL_PIN D1
+
+/* ws2812 RGB LED */
+#define RGB_DI_PIN D3
+
+// required for teensy slave otherwise it "locks up" during startup
+#define NO_USB_STARTUP_CHECK

--- a/keyboards/handwired/splittest/teensy_2/readme.md
+++ b/keyboards/handwired/splittest/teensy_2/readme.md
@@ -1,0 +1,3 @@
+# Teensy 2.0 onekey
+
+To trigger keypress, short together pins *F4* and *F5*

--- a/keyboards/handwired/splittest/teensy_2/readme.md
+++ b/keyboards/handwired/splittest/teensy_2/readme.md
@@ -1,3 +1,11 @@
-# Teensy 2.0 onekey
+# Teensy 2.0 splittest
 
-To trigger keypress, short together pins *F4* and *F5*
+To trigger keypress, short together pins *F5* and *F7*
+
+## Wiring
+- Add switches to both Pro Micros across F5 and F7 pins
+- Add pull-up resistor to left side between VCC and F0
+- Add pull-down resistors to right side between GND and F0
+- Connect the following pins on both sides together: D0, D1, GND, VCC
+- Add I2C 4.7kOhm resistors between D0 and VCC, and D1 and VCC
+- Wire Di of RGB strip for each half to D3

--- a/keyboards/handwired/splittest/teensy_2/readme.md
+++ b/keyboards/handwired/splittest/teensy_2/readme.md
@@ -3,7 +3,7 @@
 To trigger keypress, short together pins *F5* and *F7*
 
 ## Wiring
-- Add switches to both Pro Micros across F5 and F7 pins
+- Add switches to both Teensy 2s across F5 and F7 pins
 - Add pull-up resistor to left side between VCC and F0
 - Add pull-down resistors to right side between GND and F0
 - Connect the following pins on both sides together: D0, D1, GND, VCC

--- a/keyboards/handwired/splittest/teensy_2/rules.mk
+++ b/keyboards/handwired/splittest/teensy_2/rules.mk
@@ -1,0 +1,58 @@
+# MCU name
+MCU = atmega32u4
+
+# Processor frequency.
+#     This will define a symbol, F_CPU, in all source code files equal to the
+#     processor frequency in Hz. You can then use this symbol in your source code to
+#     calculate timings. Do NOT tack on a 'UL' at the end, this will be done
+#     automatically to create a 32-bit value in your source code.
+#
+#     This will be an integer division of F_USB below, as it is sourced by
+#     F_USB after it has run through any CPU prescalers. Note that this value
+#     does not *change* the processor frequency - it should merely be updated to
+#     reflect the processor speed set externally so that the code can use accurate
+#     software delays.
+F_CPU = 16000000
+
+
+#
+# LUFA specific
+#
+# Target architecture (see library "Board Types" documentation).
+ARCH = AVR8
+
+# Input clock frequency.
+#     This will define a symbol, F_USB, in all source code files equal to the
+#     input clock frequency (before any prescaling is performed) in Hz. This value may
+#     differ from F_CPU if prescaling is used on the latter, and is required as the
+#     raw input clock is fed directly to the PLL sections of the AVR for high speed
+#     clock generation for the USB and other AVR subsections. Do NOT tack on a 'UL'
+#     at the end, this will be done automatically to create a 32-bit value in your
+#     source code.
+#
+#     If no clock division is performed on the input clock inside the AVR (via the
+#     CPU clock adjust registers or the clock division fuses), this will be equal to F_CPU.
+F_USB = $(F_CPU)
+
+# Interrupt driven control endpoint task(+60)
+OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
+
+
+# Bootloader selection
+#   Teensy       halfkay
+#   Pro Micro    caterina
+#   Atmel DFU    atmel-dfu
+#   LUFA DFU     lufa-dfu
+#   QMK DFU      qmk-dfu
+#   atmega32a    bootloadHID
+BOOTLOADER = halfkay
+
+
+# If you don't know the bootloader type, then you can specify the
+# Boot Section Size in *bytes* by uncommenting out the OPT_DEFS line
+#   Teensy halfKay      512
+#   Teensy++ halfKay    1024
+#   Atmel DFU loader    4096
+#   LUFA bootloader     4096
+#   USBaspLoader        2048
+# OPT_DEFS += -DBOOTLOADER_SIZE=4096

--- a/keyboards/handwired/splittest/teensy_2/teensy_2.c
+++ b/keyboards/handwired/splittest/teensy_2/teensy_2.c
@@ -1,0 +1,9 @@
+#include QMK_KEYBOARD_H
+
+bool is_keyboard_master(void) {
+    // TODO: replace this override once USB host detection is implemented
+    // SPLIT_HAND_PIN Combined with MASTER_LEFT or MASTER_RIGHT, it gives a crude
+    // way to force teensy to run as slave/master
+    setPinInput(SPLIT_HAND_PIN);
+    return readPin(SPLIT_HAND_PIN);
+}

--- a/keyboards/handwired/splittest/teensy_2/teensy_2.c
+++ b/keyboards/handwired/splittest/teensy_2/teensy_2.c
@@ -2,8 +2,13 @@
 
 bool is_keyboard_master(void) {
     // TODO: replace this override once USB host detection is implemented
-    // SPLIT_HAND_PIN Combined with MASTER_LEFT or MASTER_RIGHT, it gives a crude
+    // SPLIT_HAND_PIN Combined with MASTER_LEFT or MASTER_RIGHT, gives a crude
     // way to force teensy to run as slave/master
     setPinInput(SPLIT_HAND_PIN);
+
+#if defined(MASTER_RIGHT)
+    return !readPin(SPLIT_HAND_PIN);
+#else
     return readPin(SPLIT_HAND_PIN);
+#endif
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Add a collection of boards to enable split testing, as preparation for future ARM split work.

The idea is to have something that testers can easily breadboard to verify the various stages of split development. One area being master/slave detection, which the teensy2 also suffers from. The advantage of solving this issue on teensy, is that is removes the dependency on having a working ARM split transport.
 
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
