### PR TITLE
[Planck/EZ] Add an option to disable LEDs located under the space bar

### DIFF
--- a/keyboards/planck/ez/ez.c
+++ b/keyboards/planck/ez/ez.c
@@ -126,11 +126,13 @@ void matrix_scan_kb(void) {
   matrix_scan_user();
 }
 
+#ifndef PLANCK_EZ_CUSTOM_LEDS
 uint32_t layer_state_set_kb(uint32_t state) {
-
   palClearPad(GPIOB, 8);
   palClearPad(GPIOB, 9);
+
   state = layer_state_set_user(state);
+
   uint8_t layer = biton32(state);
   switch (layer) {
       case 3:
@@ -148,3 +150,4 @@ uint32_t layer_state_set_kb(uint32_t state) {
     }
     return state;
 }
+#endif

--- a/keyboards/planck/ez/readme.md
+++ b/keyboards/planck/ez/readme.md
@@ -13,3 +13,38 @@ Make example for this keyboard (after setting up your build environment):
     make planck/ez:default
 
 See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
+
+## Spacebar LEDs
+
+If you don't want to use the default behavior for the 2 LEDs under the spacebar, you can disable the normal handling, and implement your own.  This allows for better customization, or disabling of the LEDs.
+
+To do so, add `#define PLANCK_EZ_CUSTOM_LEDS` in your keymap's `config.h` file.
+
+If you want them disabled, this is all you need to do!  Nothing more.
+
+However, if you want to customize the behavior, you will want to add something like this to your `keymap.c` file:
+
+    layer_state_t layer_state_set_user(layer_state_t state) {
+        // clear LEDs
+        palClearPad(GPIOB, 8);
+        palClearPad(GPIOB, 9);
+
+        switch (biton32(state)) {
+            case _LOWER:
+                palSetPad(GPIOB, 9);
+                break;
+            case _RAISE:
+                palSetPad(GPIOB, 8);
+                break;
+            case _ADJUST:
+                palSetPad(GPIOB, 9);
+                palSetPad(GPIOB, 8);
+                break;
+            default:
+                break;
+        }
+        return state;
+    }
+
+
+This will allow you to customize the LED state based on your needs.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I've created a custom set of layers for my Planck EZ and it annoyingly blinks with the LEDs when I select a layer number that overlaps with one of the default ones.

Now it's possible to disable that using a single line in a custom `config.h`:

```
#undef PLANCK_EZ_CUSTOM_LEDS
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).