### PR TITLE
Updated split encoders so indexes are based on left hand encoders first.

### DIFF
--- a/quantum/encoder.c
+++ b/quantum/encoder.c
@@ -23,6 +23,10 @@
 // for memcpy
 #include <string.h>
 
+#ifdef SPLIT_KEYBOARD
+#    include "split_util.h"
+#endif
+
 #ifndef ENCODER_RESOLUTION
 #    define ENCODER_RESOLUTION 4
 #endif
@@ -40,8 +44,10 @@ static int8_t encoder_LUT[] = {0, -1, 1, 0, 1, 0, 0, -1, -1, 0, 0, 1, 0, 1, -1, 
 static uint8_t encoder_state[NUMBER_OF_ENCODERS] = {0};
 
 #ifdef SPLIT_KEYBOARD
-// slave half encoders come over as second set of encoders
+// right half encoders come over as second set of encoders
 static int8_t encoder_value[NUMBER_OF_ENCODERS * 2] = {0};
+// row offsets for each hand
+static uint8_t thisHand, thatHand;
 #else
 static int8_t encoder_value[NUMBER_OF_ENCODERS] = {0};
 #endif
@@ -68,20 +74,33 @@ void encoder_init(void) {
 
         encoder_state[i] = (readPin(encoders_pad_a[i]) << 0) | (readPin(encoders_pad_b[i]) << 1);
     }
+
+#ifdef SPLIT_KEYBOARD
+    thisHand = isLeftHand ? 0 : NUMBER_OF_ENCODERS;
+    thatHand = NUMBER_OF_ENCODERS - thisHand;
+#endif
+}
+
+static void encoder_update(int8_t index, uint8_t state) {
+    encoder_value[index] += encoder_LUT[state & 0xF];
+    if (encoder_value[index] >= ENCODER_RESOLUTION) {
+        encoder_update_kb(index, false);
+    }
+    if (encoder_value[index] <= -ENCODER_RESOLUTION) { // direction is arbitrary here, but this clockwise
+        encoder_update_kb(index, true);
+    }
+    encoder_value[index] %= ENCODER_RESOLUTION;
 }
 
 void encoder_read(void) {
     for (int i = 0; i < NUMBER_OF_ENCODERS; i++) {
         encoder_state[i] <<= 2;
         encoder_state[i] |= (readPin(encoders_pad_a[i]) << 0) | (readPin(encoders_pad_b[i]) << 1);
-        encoder_value[i] += encoder_LUT[encoder_state[i] & 0xF];
-        if (encoder_value[i] >= ENCODER_RESOLUTION) {
-            encoder_update_kb(i, false);
-        }
-        if (encoder_value[i] <= -ENCODER_RESOLUTION) {  // direction is arbitrary here, but this clockwise
-            encoder_update_kb(i, true);
-        }
-        encoder_value[i] %= ENCODER_RESOLUTION;
+#if SPLIT_KEYBOARD
+        encoder_update(i + thisHand, encoder_state[i]);
+#else
+        encoder_update(i, encoder_state[i]);
+#endif
     }
 }
 
@@ -90,14 +109,7 @@ void encoder_state_raw(uint8_t* slave_state) { memcpy(slave_state, encoder_state
 
 void encoder_update_raw(uint8_t* slave_state) {
     for (int i = 0; i < NUMBER_OF_ENCODERS; i++) {
-        encoder_value[NUMBER_OF_ENCODERS + i] += encoder_LUT[slave_state[i] & 0xF];
-        if (encoder_value[NUMBER_OF_ENCODERS + i] >= ENCODER_RESOLUTION) {
-            encoder_update_kb(NUMBER_OF_ENCODERS + i, false);
-        }
-        if (encoder_value[NUMBER_OF_ENCODERS + i] <= -ENCODER_RESOLUTION) {  // direction is arbitrary here, but this clockwise
-            encoder_update_kb(NUMBER_OF_ENCODERS + i, true);
-        }
-        encoder_value[NUMBER_OF_ENCODERS + i] %= ENCODER_RESOLUTION;
+        encoder_update(i + thatHand, slave_state[i]);
     }
 }
 #endif

--- a/quantum/encoder.c
+++ b/quantum/encoder.c
@@ -23,10 +23,6 @@
 // for memcpy
 #include <string.h>
 
-#ifdef SPLIT_KEYBOARD
-#    include "split_util.h"
-#endif
-
 #ifndef ENCODER_RESOLUTION
 #    define ENCODER_RESOLUTION 4
 #endif


### PR DESCRIPTION
## Description

Updated split encoders so indexes are based on left hand encoders first.
This ensures when swapping master sides that code logic based on encoder index doesn't change.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
