### PR TITLE
Fix MATRIX_ROW_PINS_RIGHT and MATRIX_COL_PINS_RIGHT compilation on ARM

### DIFF
--- a/quantum/split_common/matrix.c
+++ b/quantum/split_common/matrix.c
@@ -253,13 +253,13 @@ void matrix_init(void) {
   // Set pinout for right half if pinout for that half is defined
   if (!isLeftHand) {
 #ifdef MATRIX_ROW_PINS_RIGHT
-    const uint8_t row_pins_right[MATRIX_ROWS] = MATRIX_ROW_PINS_RIGHT;
+    const pin_t row_pins_right[MATRIX_ROWS] = MATRIX_ROW_PINS_RIGHT;
     for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
       row_pins[i] = row_pins_right[i];
     }
 #endif
 #ifdef MATRIX_COL_PINS_RIGHT
-    const uint8_t col_pins_right[MATRIX_COLS] = MATRIX_COL_PINS_RIGHT;
+    const pin_t col_pins_right[MATRIX_COLS] = MATRIX_COL_PINS_RIGHT;
     for (uint8_t i = 0; i < MATRIX_COLS; i++) {
       col_pins[i] = col_pins_right[i];
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Storing `MATRIX_ROW_PINS_RIGHT` in a uint8_t array fails due to uint32_t being involved in the pin defs, and instead `pin_t` should be used to match the rest of the file. It currently produces the following error
```console
./lib/chibios/os/hal/ports/STM32/LLD/GPIOv1/hal_pal_lld.h:81:3: error: large integer implicitly truncated to unsigned type [-Werror=overflow]
   ((ioline_t)((uint32_t)(port)) | ((uint32_t)(pad)))
```

<details>
  <summary>Click for full log</summary>

```console
quantum/split_common/matrix.c: In function 'matrix_init':
./lib/chibios/os/hal/ports/STM32/LLD/GPIOv1/hal_pal_lld.h:81:3: error: large integer implicitly truncated to unsigned type [-Werror=overflow]
   ((ioline_t)((uint32_t)(port)) | ((uint32_t)(pad)))
   ^
quantum/config_common.h:202:17: note: in expansion of macro 'PAL_LINE'
     #define B11 PAL_LINE(GPIOB, 11)
                 ^~~~~~~~
./keyboards/handwired/split_blackpill/config.h:35:33: note: in expansion of macro 'B11'
 #define MATRIX_ROW_PINS_RIGHT { B11, B10, B1, B0 }
                                 ^~~
quantum/split_common/matrix.c:260:49: note: in expansion of macro 'MATRIX_ROW_PINS_RIGHT'
     const uint8_t row_pins_right[MATRIX_ROWS] = MATRIX_ROW_PINS_RIGHT;
                                                 ^~~~~~~~~~~~~~~~~~~~~
./lib/chibios/os/hal/ports/STM32/LLD/GPIOv1/hal_pal_lld.h:81:3: error: large integer implicitly truncated to unsigned type [-Werror=overflow]
   ((ioline_t)((uint32_t)(port)) | ((uint32_t)(pad)))
   ^
quantum/config_common.h:201:17: note: in expansion of macro 'PAL_LINE'
     #define B10 PAL_LINE(GPIOB, 10)
                 ^~~~~~~~
./keyboards/handwired/split_blackpill/config.h:35:38: note: in expansion of macro 'B10'
 #define MATRIX_ROW_PINS_RIGHT { B11, B10, B1, B0 }
                                      ^~~
quantum/split_common/matrix.c:260:49: note: in expansion of macro 'MATRIX_ROW_PINS_RIGHT'
     const uint8_t row_pins_right[MATRIX_ROWS] = MATRIX_ROW_PINS_RIGHT;
                                                 ^~~~~~~~~~~~~~~~~~~~~
./lib/chibios/os/hal/ports/STM32/LLD/GPIOv1/hal_pal_lld.h:81:3: error: large integer implicitly truncated to unsigned type [-Werror=overflow]
   ((ioline_t)((uint32_t)(port)) | ((uint32_t)(pad)))
   ^
quantum/config_common.h:192:17: note: in expansion of macro 'PAL_LINE'
     #define B1  PAL_LINE(GPIOB, 1)
                 ^~~~~~~~
./keyboards/handwired/split_blackpill/config.h:35:43: note: in expansion of macro 'B1'
 #define MATRIX_ROW_PINS_RIGHT { B11, B10, B1, B0 }
                                           ^~
quantum/split_common/matrix.c:260:49: note: in expansion of macro 'MATRIX_ROW_PINS_RIGHT'
     const uint8_t row_pins_right[MATRIX_ROWS] = MATRIX_ROW_PINS_RIGHT;
                                                 ^~~~~~~~~~~~~~~~~~~~~
./lib/chibios/os/hal/ports/STM32/LLD/GPIOv1/hal_pal_lld.h:81:3: error: large integer implicitly truncated to unsigned type [-Werror=overflow]
   ((ioline_t)((uint32_t)(port)) | ((uint32_t)(pad)))
   ^
quantum/config_common.h:191:17: note: in expansion of macro 'PAL_LINE'
     #define B0  PAL_LINE(GPIOB, 0)
                 ^~~~~~~~
./keyboards/handwired/split_blackpill/config.h:35:47: note: in expansion of macro 'B0'
 #define MATRIX_ROW_PINS_RIGHT { B11, B10, B1, B0 }
                                               ^~
quantum/split_common/matrix.c:260:49: note: in expansion of macro 'MATRIX_ROW_PINS_RIGHT'
     const uint8_t row_pins_right[MATRIX_ROWS] = MATRIX_ROW_PINS_RIGHT;
                                                 ^~~~~~~~~~~~~~~~~~~~~
./lib/chibios/os/hal/ports/STM32/LLD/GPIOv1/hal_pal_lld.h:81:3: error: large integer implicitly truncated to unsigned type [-Werror=overflow]
   ((ioline_t)((uint32_t)(port)) | ((uint32_t)(pad)))
   ^
quantum/config_common.h:203:17: note: in expansion of macro 'PAL_LINE'
     #define B12 PAL_LINE(GPIOB, 12)
                 ^~~~~~~~
./keyboards/handwired/split_blackpill/config.h:34:33: note: in expansion of macro 'B12'
 #define MATRIX_COL_PINS_RIGHT { B12, B13, B14, B15, A8, A9 }
                                 ^~~
quantum/split_common/matrix.c:266:49: note: in expansion of macro 'MATRIX_COL_PINS_RIGHT'
     const uint8_t col_pins_right[MATRIX_COLS] = MATRIX_COL_PINS_RIGHT;
                                                 ^~~~~~~~~~~~~~~~~~~~~
./lib/chibios/os/hal/ports/STM32/LLD/GPIOv1/hal_pal_lld.h:81:3: error: large integer implicitly truncated to unsigned type [-Werror=overflow]
   ((ioline_t)((uint32_t)(port)) | ((uint32_t)(pad)))
   ^
quantum/config_common.h:204:17: note: in expansion of macro 'PAL_LINE'
     #define B13 PAL_LINE(GPIOB, 13)
                 ^~~~~~~~
./keyboards/handwired/split_blackpill/config.h:34:38: note: in expansion of macro 'B13'
 #define MATRIX_COL_PINS_RIGHT { B12, B13, B14, B15, A8, A9 }
                                      ^~~
quantum/split_common/matrix.c:266:49: note: in expansion of macro 'MATRIX_COL_PINS_RIGHT'
     const uint8_t col_pins_right[MATRIX_COLS] = MATRIX_COL_PINS_RIGHT;
                                                 ^~~~~~~~~~~~~~~~~~~~~
./lib/chibios/os/hal/ports/STM32/LLD/GPIOv1/hal_pal_lld.h:81:3: error: large integer implicitly truncated to unsigned type [-Werror=overflow]
   ((ioline_t)((uint32_t)(port)) | ((uint32_t)(pad)))
   ^
quantum/config_common.h:205:17: note: in expansion of macro 'PAL_LINE'
     #define B14 PAL_LINE(GPIOB, 14)
                 ^~~~~~~~
./keyboards/handwired/split_blackpill/config.h:34:43: note: in expansion of macro 'B14'
 #define MATRIX_COL_PINS_RIGHT { B12, B13, B14, B15, A8, A9 }
                                           ^~~
quantum/split_common/matrix.c:266:49: note: in expansion of macro 'MATRIX_COL_PINS_RIGHT'
     const uint8_t col_pins_right[MATRIX_COLS] = MATRIX_COL_PINS_RIGHT;
                                                 ^~~~~~~~~~~~~~~~~~~~~
./lib/chibios/os/hal/ports/STM32/LLD/GPIOv1/hal_pal_lld.h:81:3: error: large integer implicitly truncated to unsigned type [-Werror=overflow]
   ((ioline_t)((uint32_t)(port)) | ((uint32_t)(pad)))
   ^
quantum/config_common.h:206:17: note: in expansion of macro 'PAL_LINE'
     #define B15 PAL_LINE(GPIOB, 15)
                 ^~~~~~~~
./keyboards/handwired/split_blackpill/config.h:34:48: note: in expansion of macro 'B15'
 #define MATRIX_COL_PINS_RIGHT { B12, B13, B14, B15, A8, A9 }
                                                ^~~
quantum/split_common/matrix.c:266:49: note: in expansion of macro 'MATRIX_COL_PINS_RIGHT'
     const uint8_t col_pins_right[MATRIX_COLS] = MATRIX_COL_PINS_RIGHT;
                                                 ^~~~~~~~~~~~~~~~~~~~~
./lib/chibios/os/hal/ports/STM32/LLD/GPIOv1/hal_pal_lld.h:81:3: error: large integer implicitly truncated to unsigned type [-Werror=overflow]
   ((ioline_t)((uint32_t)(port)) | ((uint32_t)(pad)))
   ^
quantum/config_common.h:183:17: note: in expansion of macro 'PAL_LINE'
     #define A8  PAL_LINE(GPIOA, 8)
                 ^~~~~~~~
./keyboards/handwired/split_blackpill/config.h:34:53: note: in expansion of macro 'A8'
 #define MATRIX_COL_PINS_RIGHT { B12, B13, B14, B15, A8, A9 }
                                                     ^~
quantum/split_common/matrix.c:266:49: note: in expansion of macro 'MATRIX_COL_PINS_RIGHT'
     const uint8_t col_pins_right[MATRIX_COLS] = MATRIX_COL_PINS_RIGHT;
                                                 ^~~~~~~~~~~~~~~~~~~~~
./lib/chibios/os/hal/ports/STM32/LLD/GPIOv1/hal_pal_lld.h:81:3: error: large integer implicitly truncated to unsigned type [-Werror=overflow]
   ((ioline_t)((uint32_t)(port)) | ((uint32_t)(pad)))
   ^
quantum/config_common.h:184:17: note: in expansion of macro 'PAL_LINE'
     #define A9  PAL_LINE(GPIOA, 9)
                 ^~~~~~~~
./keyboards/handwired/split_blackpill/config.h:34:57: note: in expansion of macro 'A9'
 #define MATRIX_COL_PINS_RIGHT { B12, B13, B14, B15, A8, A9 }
                                                         ^~
quantum/split_common/matrix.c:266:49: note: in expansion of macro 'MATRIX_COL_PINS_RIGHT'
     const uint8_t col_pins_right[MATRIX_COLS] = MATRIX_COL_PINS_RIGHT;
                                                 ^~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
 [ERRORS]
 | 
 | 
 | 
```

</details>

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
