### PR TITLE
[Keyboard] Sol r2: Fix default layer oled display

### DIFF
--- a/keyboards/rgbkb/sol/keymaps/default/keymap.c
+++ b/keyboards/rgbkb/sol/keymaps/default/keymap.c
@@ -324,7 +324,8 @@ static void render_status(void) {
 
   // Define layers here
   oled_write_P(PSTR("Layer"), false);
-  switch (biton32(layer_state)) {
+  uint8_t layer = layer_state ? biton(layer_state) : biton32(default_layer_state);
+  switch (layer) {
     case _QWERTY:
       oled_write_P(PSTR("BASE "), false);
       break;


### PR DESCRIPTION
## Description

Small fix to display the correct default layer.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
