### PR TITLE
[OLED] Added support for CR

### DIFF
--- a/drivers/oled/oled_driver.c
+++ b/drivers/oled/oled_driver.c
@@ -321,7 +321,7 @@ void oled_render(void) {
 
     // Send render data chunk after rotating
     if (I2C_WRITE_REG(I2C_DATA, &temp_buffer[0], OLED_BLOCK_SIZE) != I2C_STATUS_SUCCESS) {
-      print("oled_render data failed\n");
+      print("oled_render90 data failed\n");
       return;
     }
   }
@@ -390,6 +390,11 @@ void oled_write_char(const char data, bool invert) {
   if (data == '\n') {
     // Old source wrote ' ' until end of line...
     oled_advance_page(true);
+    return;
+  }
+
+  if (data == '\r') {
+    oled_advance_page(false);
     return;
   }
 


### PR DESCRIPTION
## Description

Currently OLED Dirver only supports LF (\n) character in a string to clear out the rest of the current line and advance to the next line for writing. This PR adds support for CR (\r) character as well to advance to the next line, however not clear out the rest of the current line. This is extremely useful when you want to display a multi-line logo using a single array without wiping out exiting lines and flagging the OLED as dirty unnecessarily. 

```
LF (\n):
"EX BUFFER L1"
"EX BUFFER L2"

oled_write("E1\nE2");

Result:
"E1          "
"E2 BUFFER L2"

CR (\r):
"EX BUFFER L1"
"EX BUFFER L2"

oled_write("E1\rE2");

Result:
"E1 BUFFER L1"
"E2 BUFFER L2"
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
