### PR TITLE
One-line build fix

### DIFF
--- a/quantum/rgb_matrix.c
+++ b/quantum/rgb_matrix.c
@@ -88,7 +88,7 @@
 #endif
 
 #if !defined(RGB_MATRIX_STARTUP_MODE)
-  #ifndef DISABLE_RGB_MATRIX_CYCLE_ALL
+  #ifndef DISABLE_RGB_MATRIX_CYCLE_LEFT_RIGHT
     #define RGB_MATRIX_STARTUP_MODE RGB_MATRIX_CYCLE_LEFT_RIGHT
   #else
     // fallback to solid colors if RGB_MATRIX_CYCLE_LEFT_RIGHT is disabled in userspace


### PR DESCRIPTION
One-line fix for a typo that could break build if DISABLE_RGB_MATRIX_CYCLE_LEFT_RIGHT was defined but not DISABLE_RGB_MATRIX_CYCLE_ALL

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Ran into this when customizing keymaps. Given the code structure + comment, I assume this was what the code was originally supposed to be, and current version was an oversight

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
