### PR TITLE
ARM split - detect USB to select master/slave

### DIFF
--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -264,6 +264,14 @@ There are a few different ways to set handedness for split keyboards (listed in 
     * 4: about 26kbps
     * 5: about 20kbps
 
+* `#define SPLIT_USB_DETECT`
+  * Detect (with timeout) USB connection when delegating master/slave
+  * Default behavior for ARM
+  * Required for AVR Teensy
+
+* `#define SPLIT_USB_TIMEOUT 2500`
+  * Maximum timeout when detecting master/slave when using `SPLIT_USB_DETECT`
+
 # The `rules.mk` File
 
 This is a [make](https://www.gnu.org/software/make/manual/make.html) file that is included by the top-level `Makefile`. It is used to set some information about the MCU that we will be compiling for as well as enabling and disabling certain features.

--- a/docs/feature_split_keyboard.md
+++ b/docs/feature_split_keyboard.md
@@ -188,6 +188,16 @@ This sets how many LEDs are directly connected to each controller.  The first nu
 ?> This setting implies that `RGBLIGHT_SPLIT` is enabled, and will forcibly enable it, if it's not.
 
 
+```c
+#define SPLIT_USB_DETECT
+```
+This option changes the startup behavior to detect a USB connection with a timeout when delegating master/slave. This is the default behavior for ARM, and required for AVR Teensy (due to hardware limitations).
+
+```c
+#define SPLIT_USB_TIMEOUT 2500
+```
+This sets the maximum timeout when detecting master/slave when using `SPLIT_USB_DETECT`.
+
 ## Additional Resources
 
 Nicinabox has a [very nice and detailed guide](https://github.com/nicinabox/lets-split-guide) for the Let's Split keyboard, that covers most everything you need to know, including troubleshooting information. 

--- a/docs/feature_split_keyboard.md
+++ b/docs/feature_split_keyboard.md
@@ -191,7 +191,9 @@ This sets how many LEDs are directly connected to each controller.  The first nu
 ```c
 #define SPLIT_USB_DETECT
 ```
-This option changes the startup behavior to detect a USB connection with a timeout when delegating master/slave. This is the default behavior for ARM, and required for AVR Teensy (due to hardware limitations).
+This option changes the startup behavior to detect an active USB connection when delegating master/slave. If this operation times out, then the half is assume to be a slave. This is the default behavior for ARM, and required for AVR Teensy boards (due to hardware limitations).
+
+?> This setting will stop the ability to demo using battery packs.
 
 ```c
 #define SPLIT_USB_TIMEOUT 2500

--- a/quantum/split_common/matrix.c
+++ b/quantum/split_common/matrix.c
@@ -250,6 +250,14 @@ void matrix_init(void) {
 
     // Set pinout for right half if pinout for that half is defined
     if (!isLeftHand) {
+#ifdef DIRECT_PINS_RIGHT
+        const pin_t direct_pins_right[MATRIX_ROWS][MATRIX_COLS] = DIRECT_PINS_RIGHT;
+        for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
+            for (uint8_t j = 0; j < MATRIX_COLS; j++) {
+                direct_pins[i][j] = direct_pins_right[i][j];
+            }
+        }
+#endif
 #ifdef MATRIX_ROW_PINS_RIGHT
         const pin_t row_pins_right[MATRIX_ROWS] = MATRIX_ROW_PINS_RIGHT;
         for (uint8_t i = 0; i < MATRIX_ROWS; i++) {

--- a/quantum/split_common/matrix.c
+++ b/quantum/split_common/matrix.c
@@ -246,20 +246,10 @@ static bool read_rows_on_col(matrix_row_t current_matrix[], uint8_t current_col)
 #endif
 
 void matrix_init(void) {
-    debug_enable = true;
-    debug_matrix = true;
-    debug_mouse  = true;
+    keyboard_split_setup();
 
     // Set pinout for right half if pinout for that half is defined
     if (!isLeftHand) {
-#ifdef DIRECT_PINS_RIGHT
-        const pin_t direct_pins_right[MATRIX_ROWS][MATRIX_COLS] = DIRECT_PINS_RIGHT;
-        for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-            for (uint8_t j = 0; j < MATRIX_COLS; j++) {
-                direct_pins[i][j] = direct_pins_right[i][j];
-            }
-        }
-#endif
 #ifdef MATRIX_ROW_PINS_RIGHT
         const pin_t row_pins_right[MATRIX_ROWS] = MATRIX_ROW_PINS_RIGHT;
         for (uint8_t i = 0; i < MATRIX_ROWS; i++) {

--- a/quantum/split_common/split_util.c
+++ b/quantum/split_common/split_util.c
@@ -16,7 +16,7 @@
 #endif
 
 #ifndef SPLIT_USB_TIMEOUT
-  #define SPLIT_USB_TIMEOUT 2500
+#    define SPLIT_USB_TIMEOUT 2500
 #endif
 
 volatile bool isLeftHand = true;
@@ -81,16 +81,9 @@ static void keyboard_master_setup(void) {
 
 static void keyboard_slave_setup(void) { transport_slave_init(); }
 
-<<<<<<< HEAD
-// this code runs before the usb and keyboard is initialized
-void matrix_setup(void) {
-    isLeftHand = is_keyboard_left();
-=======
 // this code runs before the keyboard is fully initialized
-void keyboard_split_setup(void)
-{
-  isLeftHand = is_keyboard_left();
->>>>>>> Initial split refactor to allow usb master detection
+void keyboard_split_setup(void) {
+    isLeftHand = is_keyboard_left();
 
 #if defined(RGBLIGHT_ENABLE) && defined(RGBLED_SPLIT)
     uint8_t num_rgb_leds_split[2] = RGBLED_SPLIT;

--- a/quantum/split_common/split_util.c
+++ b/quantum/split_common/split_util.c
@@ -22,7 +22,7 @@
 volatile bool isLeftHand = true;
 
 bool waitForUsb(void) {
-    for(uint8_t i = 0; i < (SPLIT_USB_TIMEOUT / 100); i++) {
+    for (uint8_t i = 0; i < (SPLIT_USB_TIMEOUT / 100); i++) {
         // This will return true of a USB connection has been established
 #if defined(__AVR__)
         if (UDADDR & _BV(ADDEN)) {

--- a/quantum/split_common/split_util.c
+++ b/quantum/split_common/split_util.c
@@ -15,7 +15,26 @@
 #    include "rgblight.h"
 #endif
 
+#ifndef SPLIT_USB_TIMEOUT
+  #define SPLIT_USB_TIMEOUT 2500
+#endif
+
 volatile bool isLeftHand = true;
+
+bool waitForUsb(void) {
+    for(uint8_t i = 0; i < (SPLIT_USB_TIMEOUT / 100); i++) {
+        // This will return true of a USB connection has been established
+#if defined(__AVR__)
+        if (UDADDR & _BV(ADDEN)) {
+#else
+        if (usbGetDriverStateI(&USBD1) == USB_ACTIVE) {
+#endif
+            return true;
+        }
+        wait_ms(100);
+    }
+    return false;
+}
 
 __attribute__((weak)) bool is_keyboard_left(void) {
 #if defined(SPLIT_HAND_PIN)
@@ -32,21 +51,23 @@ __attribute__((weak)) bool is_keyboard_left(void) {
 }
 
 __attribute__((weak)) bool is_keyboard_master(void) {
-#ifdef __AVR__
     static enum { UNKNOWN, MASTER, SLAVE } usbstate = UNKNOWN;
 
     // only check once, as this is called often
     if (usbstate == UNKNOWN) {
+#if defined(SPLIT_USB_DETECT) || defined(PROTOCOL_CHIBIOS)
+        usbstate = waitForUsb() ? MASTER : SLAVE;
+#elif defined(__AVR__)
         USBCON |= (1 << OTGPADE);  // enables VBUS pad
         wait_us(5);
 
         usbstate = (USBSTA & (1 << VBUS)) ? MASTER : SLAVE;  // checks state of VBUS
+#else
+        usbstate = MASTER;
+#endif
     }
 
     return (usbstate == MASTER);
-#else
-    return true;
-#endif
 }
 
 static void keyboard_master_setup(void) {
@@ -60,9 +81,16 @@ static void keyboard_master_setup(void) {
 
 static void keyboard_slave_setup(void) { transport_slave_init(); }
 
+<<<<<<< HEAD
 // this code runs before the usb and keyboard is initialized
 void matrix_setup(void) {
     isLeftHand = is_keyboard_left();
+=======
+// this code runs before the keyboard is fully initialized
+void keyboard_split_setup(void)
+{
+  isLeftHand = is_keyboard_left();
+>>>>>>> Initial split refactor to allow usb master detection
 
 #if defined(RGBLIGHT_ENABLE) && defined(RGBLED_SPLIT)
     uint8_t num_rgb_leds_split[2] = RGBLED_SPLIT;

--- a/quantum/split_common/split_util.h
+++ b/quantum/split_common/split_util.h
@@ -8,3 +8,4 @@
 extern volatile bool isLeftHand;
 
 void matrix_master_OLED_init(void);
+void keyboard_split_setup(void);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

<!--- Describe your changes in detail here. -->

## Current Issue
Master/slave detection is hard coded to always assume master

## TL;DR
This PR changes the startup behavior to detect an active USB connection when delegating master/slave. If this operation times out, then the half is assume to be a slave. This is the default behavior for ARM, and required for AVR Teensy boards (due to hardware limitations).

<details><summary>CLICK ME FOR INVESTIGATION INFO</summary>

## master/slave detection
Split code currently expects to run different routines on slave and master. The assumption is that devices cannot run both a requester and responder concurrently. The current process is that the master pulls the matrix and encoder data from the slave, and pushes rgb and backlight settings to the slave.

Current AVR init order:
```
lufa/lufa.c::main
    keyboard.c::keyboard_setup
        split_util.c::matrix_setup
            'usb check'
                init i2c/serial slave/master
    setup_usb
```

Current ARM init order:
```
chibios/main.c::main
    keyboard.c::keyboard_setup
        split_util.c::matrix_setup
            'usb check'
                init i2c/serial slave/master
    init_usb_driver
```

As shown above, 'usb check' cannot simply check "Do I currently have a USB connection". AVR assumes a hardware specific method of checking the usb power. **Note: This check fails on some hardware, as shown here <https://geekhack.org/index.php?topic=89674.0>**

### vitimins_included
Old split code modified to use a slightly different process. Both sides idle as slaves, then one is promoted to master. The main advantage here is that the transport init runs after usb has been configured. 
```
lufa/lufa.c::main
    keyboard.c::keyboard_setup
        vitamins_included::matrix_setup
            "nothing important"
    setup_usb
    keyboard.c::keyboard_init
        vitamins_included::matrix_init
            init i2c/serial slave
            "wait for usb"
                run slave tasks
            init i2c/serial master
```

### Potential Solutions


#### USB connected based
Wrapping up similar behavior to `WAIT_FOR_USB`

* adapt vitimins_included code into split_common
  * Maybe simplify with just a `wait_for_usb_with_timeout`
* init usb earlier
  * allows existing split code to be retained by pushing change elsewhere
* delay usb check check till after setup_usb
    * lazy init of transport to first matrix_scan
    * some processes might assume too much
        * rgblight clips to left and right hand and would need to handle it at a later point
        * pending support for split rgb matrix would need to handle left/right hand changing at a later point

#### Other
Find alternative "usb connected" methods, that allow "meetup RGB demo mode". The keyboard can be connected to a battery pack and thus have no usb connection but still maintain the master/slave connection.

* Using similar method to AVR VBUS detection
  * Fine for custom board where the additional circuitry can be added
  * Bad for Proton C as hardware has already shipped
* Using similar method to SPLIT_HAND_PIN
  * Would allow a `MASTER_LEFT` `MASTER_RIGHT` setup
  * Proton C is limited to bridging pins on the snap off section
    * Less flexible due to hard coded master/slave
    * Provides battery powered "demo mode"


</details>

## Description
Delaying split initialisation from `matrix_setup` to `matrix_init` was seen to be the most non intrusive change. As this has limitations for "battery demo mode", this may not be the full solution but gives us something to use while building up the remaining core split_common functionality.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
