### PR TITLE
Fix community support for hs60

### DIFF
--- a/keyboards/hs60/v1/rules.mk
+++ b/keyboards/hs60/v1/rules.mk
@@ -69,7 +69,7 @@ FAUXCLICKY_ENABLE = no      # Use buzzer to emulate clicky switches
 RGB_MATRIX_ENABLE = yes     # Use RGB matrix
 RAW_ENABLE = yes
 
-LAYOUTS = 60_ansi_split_bs_rshift
+LAYOUTS = 60_ansi 60_iso
 
 # Experimental features for zealcmd please do no enable
 #RAW_ENABLE = yes

--- a/keyboards/hs60/v2/rules.mk
+++ b/keyboards/hs60/v2/rules.mk
@@ -65,3 +65,5 @@ NO_USB_STARTUP_CHECK = no          # Disable initialization only when usb is plu
 RAW_ENABLE = no
 DYNAMIC_KEYMAP_ENABLE = no
 CIE1931_CURVE = yes
+
+LAYOUTS = 60_ansi 60_iso


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
QMK api error log (http://compile.qmk.fm/v1/keyboards/error_log) contains:
```json
{
  "severity":"error",
  "message":"Error: hs60/v1: Missing layout pp macro for ['60_ansi_split_bs_rshift']"
}
```

`60_ansi_split_bs_rshift` support does not exist in the header files, but `60_ansi` and `60_iso` do. I have left off `60_hhkb` from v2 as the current macro is incompatible.  

Tagging @yiancar as maintainer.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
