### PR TITLE
rgblight idle timeout feature

### DIFF
--- a/docs/feature_rgblight.md
+++ b/docs/feature_rgblight.md
@@ -76,6 +76,7 @@ Your RGB lighting can be configured by placing these `#define`s in your `config.
 |`RGBLIGHT_LIMIT_VAL` |`255`        |The maximum brightness level                                                 |
 |`RGBLIGHT_SLEEP`     |*Not defined*|If defined, the RGB lighting will be switched off when the host goes to sleep|
 |`RGBLIGHT_SPLIT`     |*Not defined*|If defined, synchronization functionality for split keyboards is added|
+|`RGBLIGHT_IDLE_TIMEOUT`|*Not defined*|If defined, turn the backlight off after this number in minutes of inactivity.|
 
 ## Effects and Animations
 

--- a/docs/feature_rgblight.md
+++ b/docs/feature_rgblight.md
@@ -76,7 +76,7 @@ Your RGB lighting can be configured by placing these `#define`s in your `config.
 |`RGBLIGHT_LIMIT_VAL` |`255`        |The maximum brightness level                                                 |
 |`RGBLIGHT_SLEEP`     |*Not defined*|If defined, the RGB lighting will be switched off when the host goes to sleep|
 |`RGBLIGHT_SPLIT`     |*Not defined*|If defined, synchronization functionality for split keyboards is added|
-|`RGBLIGHT_IDLE_TIMEOUT`|*Not defined*|If defined, turn the backlight off after this number in minutes of inactivity.|
+|`RGBLIGHT_IDLE_TIMEOUT`|*Not defined*|If defined, turn the backlight off after this many minutes of inactivity.|
 
 ## Effects and Animations
 

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -298,6 +298,9 @@ bool process_record_quantum(keyrecord_t *record) {
   #ifdef SPACE_CADET_ENABLE
     process_space_cadet(keycode, record) &&
   #endif
+  #ifdef RGBLIGHT_USE_PROCESS
+    process_rgblight(keycode, record) &&
+  #endif
       true)) {
     return false;
   }

--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -809,10 +809,9 @@ void rgblight_task(void) {
     // exit early if we are timedout
     else if (rgblight_idle_timedout) {
         return;
-    } else if (timer_elapsed32(rgblight_idle_timer) >= (RGBLIGHT_IDLE_TIMEOUT * 60000)) {
+    } else if (timer_elapsed32(rgblight_idle_timer) >= (RGBLIGHT_IDLE_TIMEOUT * RGBLIGHT_IDLE_MULTIPLIER)) {
         rgblight_idle_timedout = true;
         rgblight_disable_noeeprom();
-        rgblight_idle_timer = timer_read32();
     }
 #endif
 #ifdef RGBLIGHT_EFFECT_BREATHING

--- a/quantum/rgblight.h
+++ b/quantum/rgblight.h
@@ -264,6 +264,14 @@ void rgblight_timer_enable(void);
 void rgblight_timer_disable(void);
 void rgblight_timer_toggle(void);
 
+// if timeout is set, enable the rgblight idle feature
+#ifdef RGBLIGHT_IDLE_TIMEOUT
+  #define RGBLIGHT_IDLE_ENABLE
+#endif
+
+#include "quantum.h"
+bool process_rgblight(uint16_t keycode, keyrecord_t *record);
+
 #ifdef RGBLIGHT_SPLIT
   #define RGBLIGHT_STATUS_CHANGE_MODE (1<<0)
   #define RGBLIGHT_STATUS_CHANGE_HSVS (1<<1)

--- a/quantum/rgblight.h
+++ b/quantum/rgblight.h
@@ -267,6 +267,7 @@ void rgblight_timer_toggle(void);
 // if timeout is set, enable the rgblight idle feature
 #ifdef RGBLIGHT_IDLE_TIMEOUT
   #define RGBLIGHT_IDLE_ENABLE
+  #define RGBLIGHT_IDLE_MULTIPLIER 60000
 #endif
 
 #include "quantum.h"

--- a/quantum/rgblight_reconfig.h
+++ b/quantum/rgblight_reconfig.h
@@ -18,6 +18,10 @@
    #define RGBLIGHT_EFFECT_STATIC_GRADIENT
 #endif
 
+#if defined(RGBLIGHT_IDLE_TIMEOUT)
+  #define RGBLIGHT_USE_PROCESS
+#endif
+
 // check dynamic animation effects chose ?
 #if defined(RGBLIGHT_EFFECT_BREATHING) || \
     defined(RGBLIGHT_EFFECT_RAINBOW_MOOD) || \
@@ -26,7 +30,8 @@
     defined(RGBLIGHT_EFFECT_KNIGHT) ||		\
     defined(RGBLIGHT_EFFECT_CHRISTMAS) ||	\
     defined(RGBLIGHT_EFFECT_RGB_TEST) ||	\
-    defined(RGBLIGHT_EFFECT_ALTERNATING)
+    defined(RGBLIGHT_EFFECT_ALTERNATING) ||	\
+    defined(RGBLIGHT_IDLE_ENABLE)
   #define RGBLIGHT_USE_TIMER
   #ifndef RGBLIGHT_ANIMATIONS
     #define RGBLIGHT_ANIMATIONS  // for backward compatibility


### PR DESCRIPTION
## Description

This adds an idle timeout features (independent of your PC's sleep settings). In simple terms: if there are no keystrokes after X minutes, turn off the underglow. All you need to do is add `#define RGBLIGHT_IDLE_TIMEOUT 10` (any number in minutes) in `config.h` to enable the feature.

A couple notable things were added as side effects:
1. Including `quantum.h` in `rgblight.h`.
2. Adding a `process_rgblight` function to `process_record_quantum` in `quantum.c`. Could also be useful if other future features need to hook into this loop. I couldn't find anywhere in rgblight.c where it was already being called.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
