### PR TITLE
Fix typo for building Ergodox EZ keyboards

### DIFF
--- a/docs/newbs_flashing.md
+++ b/docs/newbs_flashing.md
@@ -223,7 +223,7 @@ For the PJRC devices (Teensy's), when you're ready to compile and flash your fir
 
 For example, if your keymap is named "xyverz" and you're building a keymap for an Ergodox or Ergodox EZ, you'll use this command:
 
-    make erdogox_ez:xyverz:teensy
+    make ergodox_ez:xyverz:teensy
 
 Once the firmware finishes compiling, it will output something like this: 
 


### PR DESCRIPTION
Fixed a minor typo where ergodox is misspelled. It made me scratch my head for a while, because I couldn't build my keyboard.

## Types of Changes
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [X] Documentation

## Checklist
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
