### PR TITLE
Remove unused _BOOTLOADER defines

### DIFF
--- a/keyboards/alice/config.h
+++ b/keyboards/alice/config.h
@@ -36,4 +36,3 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGBLIGHT_ANIMATIONS
 
 #define NO_UART 1
-#define BOOTLOADHID_BOOTLOADER 1

--- a/keyboards/ergo42/rev1/config.h
+++ b/keyboards/ergo42/rev1/config.h
@@ -40,8 +40,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MATRIX_COL_PINS { F5, F6, F7, B1, B3, B2, B6 }
 // #define MATRIX_COL_PINS { B6, B2, B3, B1, F7, F6 } //uncomment this line and comment line above if you need to reverse left-to-right key order
 
-#define CATERINA_BOOTLOADER
-
 /* define tapping term */
 #define TAPPING_TERM 100
 

--- a/keyboards/ergo42/rules.mk
+++ b/keyboards/ergo42/rules.mk
@@ -43,13 +43,15 @@ F_USB = $(F_CPU)
 OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
 
 
-# Boot Section Size in *bytes*
-#   Teensy halfKay   512
-#   Teensy++ halfKay 1024
-#   Atmel DFU loader 4096
-#   LUFA bootloader  4096
-#   USBaspLoader     2048
-OPT_DEFS += -DBOOTLOADER_SIZE=4096
+# Bootloader selection
+#   Teensy       halfkay
+#   Pro Micro    caterina
+#   Atmel DFU    atmel-dfu
+#   LUFA DFU     lufa-dfu
+#   QMK DFU      qmk-dfu
+#   atmega32a    bootloadHID
+BOOTLOADER = caterina
+
 
 # Build Options
 #   change to "no" to disable the options, or define them in the Makefile in

--- a/keyboards/helix/rev1/config.h
+++ b/keyboards/helix/rev1/config.h
@@ -51,8 +51,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MATRIX_COL_PINS { F6, F7, B1, B3, B2, B6 }
 // #define MATRIX_COL_PINS { B6, B2, B3, B1, F7, F6 } //uncomment this line and comment line above if you need to reverse left-to-right key order
 
-#define CATERINA_BOOTLOADER
-
 /* define if matrix has ghost */
 //#define MATRIX_HAS_GHOST
 

--- a/keyboards/helix/rules.mk
+++ b/keyboards/helix/rules.mk
@@ -37,10 +37,13 @@ ARCH = AVR8
 #     CPU clock adjust registers or the clock division fuses), this will be equal to F_CPU.
 F_USB = $(F_CPU)
 
-# Bootloader
-#     This definition is optional, and if your keyboard supports multiple bootloaders of
-#     different sizes, comment this out, and the correct address will be loaded
-#     automatically (+60). See bootloader.mk for all options.
+# Bootloader selection
+#   Teensy       halfkay
+#   Pro Micro    caterina
+#   Atmel DFU    atmel-dfu
+#   LUFA DFU     lufa-dfu
+#   QMK DFU      qmk-dfu
+#   atmega32a    bootloadHID
 BOOTLOADER = caterina
 
 # Interrupt driven control endpoint task(+60)

--- a/keyboards/jj50/config.h
+++ b/keyboards/jj50/config.h
@@ -46,6 +46,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGBLIGHT_VAL_STEP 18
 
 #define NO_UART 1
-#define BOOTLOADHID_BOOTLOADER 1
 
 #endif

--- a/keyboards/jj50/rules.mk
+++ b/keyboards/jj50/rules.mk
@@ -25,10 +25,13 @@ NO_SUSPEND_POWER_DOWN = yes
 # processor frequency
 F_CPU = 12000000
 
-# Bootloader
-#     This definition is optional, and if your keyboard supports multiple bootloaders of
-#     different sizes, comment this out, and the correct address will be loaded
-#     automatically (+60). See bootloader.mk for all options.
+# Bootloader selection
+#   Teensy       halfkay
+#   Pro Micro    caterina
+#   Atmel DFU    atmel-dfu
+#   LUFA DFU     lufa-dfu
+#   QMK DFU      qmk-dfu
+#   atmega32a    bootloadHID
 BOOTLOADER = bootloadHID
 
 # build options

--- a/keyboards/lets_split/keymaps/zer09/config.h
+++ b/keyboards/lets_split/keymaps/zer09/config.h
@@ -35,7 +35,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MATRIX_ROW_PINS { C6, D7, E6, B4, B5 }
 #define MATRIX_COL_PINS { F7, B1, B3, B2, B6 }
 
-#define CATERINA_BOOTLOADER
 #define USB_MAX_POWER_CONSUMPTION 50
 
 /* Use I2C or Serial, not both */

--- a/keyboards/lets_split/rules.mk
+++ b/keyboards/lets_split/rules.mk
@@ -33,10 +33,13 @@ ARCH = AVR8
 #     CPU clock adjust registers or the clock division fuses), this will be equal to F_CPU.
 F_USB = $(F_CPU)
 
-# Bootloader
-#     This definition is optional, and if your keyboard supports multiple bootloaders of
-#     different sizes, comment this out, and the correct address will be loaded
-#     automatically (+60). See bootloader.mk for all options.
+# Bootloader selection
+#   Teensy       halfkay
+#   Pro Micro    caterina
+#   Atmel DFU    atmel-dfu
+#   LUFA DFU     lufa-dfu
+#   QMK DFU      qmk-dfu
+#   atmega32a    bootloadHID
 BOOTLOADER = caterina
 
 # Interrupt driven control endpoint task(+60)

--- a/keyboards/lily58/rev1/config.h
+++ b/keyboards/lily58/rev1/config.h
@@ -36,8 +36,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MATRIX_ROW_PINS { C6, D7, E6, B4, B5 }
 #define MATRIX_COL_PINS { F6, F7, B1, B3, B2, B6 }
 
-#define CATERINA_BOOTLOADER
-
 /* define tapping term */
 #define TAPPING_TERM 100
 

--- a/keyboards/lily58/rules.mk
+++ b/keyboards/lily58/rules.mk
@@ -40,10 +40,13 @@ ARCH = AVR8
 #     CPU clock adjust registers or the clock division fuses), this will be equal to F_CPU.
 F_USB = $(F_CPU)
 
-# Bootloader
-#     This definition is optional, and if your keyboard supports multiple bootloaders of
-#     different sizes, comment this out, and the correct address will be loaded
-#     automatically (+60). See bootloader.mk for all options.
+# Bootloader selection
+#   Teensy       halfkay
+#   Pro Micro    caterina
+#   Atmel DFU    atmel-dfu
+#   LUFA DFU     lufa-dfu
+#   QMK DFU      qmk-dfu
+#   atmega32a    bootloadHID
 BOOTLOADER = caterina
 
 # Interrupt driven control endpoint task(+60)

--- a/keyboards/meira/featherble/config.h
+++ b/keyboards/meira/featherble/config.h
@@ -40,9 +40,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define B5_AUDIO
 #define AUDIO_VOICES
 
-#define CATERINA_BOOTLOADER
-
- 
 // #define BACKLIGHT_PIN B7
 // #define BACKLIGHT_BREATHING
 //#define BACKLIGHT_LEVELS 3

--- a/keyboards/meira/promicro/config.h
+++ b/keyboards/meira/promicro/config.h
@@ -36,8 +36,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define LED_EN_PIN D2
 #define UNUSED_PINS
 
-#define CATERINA_BOOTLOADER
-
 /* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
 #define DEBOUNCE 5
 

--- a/keyboards/meira/rules.mk
+++ b/keyboards/meira/rules.mk
@@ -32,15 +32,14 @@ BOOTLOADER = caterina
 # Interrupt driven control endpoint task(+60)
 OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
 
-
-# Boot Section Size in *bytes*
-#   Teensy halfKay   512
-#   Teensy++ halfKay 1024
-#   Atmel DFU loader 4096
-#   LUFA bootloader  4096
-#   USBaspLoader     2048
-OPT_DEFS += -DBOOTLOADER_SIZE=4096
-
+# Bootloader selection
+#   Teensy       halfkay
+#   Pro Micro    caterina
+#   Atmel DFU    atmel-dfu
+#   LUFA DFU     lufa-dfu
+#   QMK DFU      qmk-dfu
+#   atmega32a    bootloadHID
+BOOTLOADER = caterina
 
 # Build Options
 #   change yes to no to disable

--- a/keyboards/orthodox/rev3/config.h
+++ b/keyboards/orthodox/rev3/config.h
@@ -48,8 +48,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MATRIX_COL_PINS { D2, F5, F6, D6, D7, B4, B5, B6, F7 }
 /*/
 
-#define CATERINA_BOOTLOADER
-
 /* COL2ROW or ROW2COL */
 #define DIODE_DIRECTION COL2ROW
 

--- a/keyboards/skog/config.h
+++ b/keyboards/skog/config.h
@@ -34,6 +34,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define BACKLIGHT_LEVELS 5
 
 #define NO_UART 1
-#define BOOTLOADHID_BOOTLOADER 1
 
 #endif

--- a/keyboards/winkeyless/bface/config.h
+++ b/keyboards/winkeyless/bface/config.h
@@ -38,7 +38,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGBLIGHT_ANIMATIONS
 
 #define NO_UART 1
-#define BOOTLOADHID_BOOTLOADER 1
 
 #ifdef BACKLIGHT_ENABLE
 	// the backlight PWM does not work (yet). Therefore, we only have two backlight levels (on/off)

--- a/keyboards/winkeyless/bface/rules.mk
+++ b/keyboards/winkeyless/bface/rules.mk
@@ -37,7 +37,7 @@ RGBLIGHT_ENABLE = yes
 RGBLIGHT_CUSTOM_DRIVER = yes
 
 OPT_DEFS = -DDEBUG_LEVEL=0
-OPT_DEFS += -DBOOTLOADER_SIZE=2048
+BOOTLOADER = bootloadHID
 
 # custom matrix setup
 SRC = i2c_master.c

--- a/keyboards/ymd75/config.h
+++ b/keyboards/ymd75/config.h
@@ -46,6 +46,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGBLIGHT_VAL_STEP 18
 
 #define NO_UART 1
-#define BOOTLOADHID_BOOTLOADER 1
 
 #endif

--- a/keyboards/ymd96/config.h
+++ b/keyboards/ymd96/config.h
@@ -51,7 +51,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGBLIGHT_ANIMATIONS
 /*#define RGBLIGHT_VAL_STEP 20
 
-#define NO_UART 1
-#define BOOTLOADHID_BOOTLOADER 1*/
+#define NO_UART 1*/
 
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Another round of dead code removal. `CATERINA_BOOTLOADER` and `BOOTLOADHID_BOOTLOADER` are never used anywhere, and they duplicate the `BOOTLOADER_*` defines set in bootloader.mk.

Also made sure `BOOTLOADER` was correctly set for all of the touched boards.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
