### PR TITLE
* MIDI: Fix basic noteon: send correct velocity

### DIFF
--- a/quantum/process_keycode/process_midi.c
+++ b/quantum/process_keycode/process_midi.c
@@ -24,7 +24,7 @@
 
 void process_midi_basic_noteon(uint8_t note)
 {
-    midi_send_noteon(&midi_device, 0, note, 128);
+    midi_send_noteon(&midi_device, 0, note, 127);
 }
 
 void process_midi_basic_noteoff(uint8_t note)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

MIDI noteon events accept velocity from 0-127. Basic MIDI mode was sending 128 velocity, which does not work. This fix allows midi to work.

If you `#define MIDI_BASIC` and then press your `MI_ON` key, then it will actually send proper MIDI note ons.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
