### PR TITLE
Add config option for DIRECT_PINS_RIGHT

### DIFF
--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -248,6 +248,9 @@ There are a few different ways to set handedness for split keyboards (listed in 
 * `#define MATRIX_COL_PINS_RIGHT { <col pins> }`
   * If you want to specify a different pinout for the right half than the left half, you can define `MATRIX_ROW_PINS_RIGHT`/`MATRIX_COL_PINS_RIGHT`. Currently, the size of `MATRIX_ROW_PINS` must be the same as `MATRIX_ROW_PINS_RIGHT` and likewise for the definition of columns.
 
+* `#define DIRECT_PINS_RIGHT { { F1, F0, B0, C7 }, { F4, F5, F6, F7 } }`
+  * If you want to specify a different direct pinout for the right half than the left half, you can define `DIRECT_PINS_RIGHT`. Currently, the size of `DIRECT_PINS` must be the same as `DIRECT_PINS_RIGHT`.
+
 * `#define RGBLED_SPLIT { 6, 6 }`
   * See [RGB Light Configuration](#rgb-light-configuration)
 

--- a/docs/feature_split_keyboard.md
+++ b/docs/feature_split_keyboard.md
@@ -160,6 +160,11 @@ There are some settings that you may need to configure, based on how the hardwar
 
 This allows you to specify a different set of pins for the matrix on the right side.  This is useful if you have a board with differently-shaped halves that requires a different configuration (such as Keebio's Quefrency).
 
+```c
+#define DIRECT_PINS_RIGHT { { F1, F0, B0, C7 }, { F4, F5, F6, F7 } }
+```
+
+This allows you to specify a different set of direct pins for the right side.
 
 ```c
 #define RGBLIGHT_SPLIT

--- a/quantum/split_common/matrix.c
+++ b/quantum/split_common/matrix.c
@@ -252,6 +252,14 @@ void matrix_init(void) {
 
   // Set pinout for right half if pinout for that half is defined
   if (!isLeftHand) {
+#ifdef DIRECT_PINS_RIGHT
+    const pin_t direct_pins_right[MATRIX_ROWS][MATRIX_COLS] = DIRECT_PINS_RIGHT;
+    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
+      for (uint8_t j = 0; j < MATRIX_COLS; j++) {
+        direct_pins[i][j] = direct_pins_right[i][j];
+      }
+    }
+#endif
 #ifdef MATRIX_ROW_PINS_RIGHT
     const pin_t row_pins_right[MATRIX_ROWS] = MATRIX_ROW_PINS_RIGHT;
     for (uint8_t i = 0; i < MATRIX_ROWS; i++) {


### PR DESCRIPTION
Adds support for different direct pin mappings on the halves of a split keyboard.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [X] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* N/A 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project. (followed indentation of MATRIX_ROW_PINS_RIGHT and MATRIX_COLS_PINS_RIGHT blocks)
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage). (tested on one keyboard, have not tested much for regressions or otherwise) 
