### PR TITLE
Fixed RGB_DISABLE_AFTER_TIMEOUT to be seconds based & small internals cleanup

### DIFF
--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -374,7 +374,8 @@ These are defined in [`rgblight_list.h`](https://github.com/qmk/qmk_firmware/blo
 ```c
 #define RGB_MATRIX_KEYPRESSES // reacts to keypresses
 #define RGB_MATRIX_KEYRELEASES // reacts to keyreleases (instead of keypresses)
-#define RGB_DISABLE_AFTER_TIMEOUT 0 // number of ticks to wait until disabling effects
+#define RGB_DISABLE_TIMEOUT 0 // number of milliseconds to wait until rgb automatically turns off
+#define RGB_DISABLE_AFTER_TIMEOUT 0 // OBSOLETE: number of ticks to wait until disabling effects
 #define RGB_DISABLE_WHEN_USB_SUSPENDED false // turn off effects when suspended
 #define RGB_MATRIX_LED_PROCESS_LIMIT (DRIVER_LED_TOTAL + 4) / 5 // limits the number of LEDs to process in an animation per task run (increases keyboard responsiveness)
 #define RGB_MATRIX_LED_FLUSH_LIMIT 16 // limits in milliseconds how frequently an animation will update the LEDs. 16 (16ms) is equivalent to limiting to 60fps (increases keyboard responsiveness)

--- a/quantum/rgb_matrix.c
+++ b/quantum/rgb_matrix.c
@@ -57,8 +57,12 @@ const point_t k_rgb_matrix_center = RGB_MATRIX_CENTER;
 // -----End rgb effect includes macros-------
 // ------------------------------------------
 
-#ifndef RGB_DISABLE_AFTER_TIMEOUT
-#    define RGB_DISABLE_AFTER_TIMEOUT 0
+#if defined(RGB_DISABLE_AFTER_TIMEOUT) && !defined(RGB_DISABLE_TIMEOUT)
+#    define RGB_DISABLE_TIMEOUT (RGB_DISABLE_AFTER_TIMEOUT * 1200)
+#endif
+
+#ifndef RGB_DISABLE_TIMEOUT
+#    define RGB_DISABLE_TIMEOUT 0
 #endif
 
 #ifndef RGB_DISABLE_WHEN_USB_SUSPENDED
@@ -111,19 +115,29 @@ const point_t k_rgb_matrix_center = RGB_MATRIX_CENTER;
 #    define RGB_MATRIX_STARTUP_SPD UINT8_MAX / 2
 #endif
 
-bool g_suspend_state = false;
-
-rgb_config_t rgb_matrix_config;
-
-rgb_counters_t  g_rgb_counters;
-static uint32_t rgb_counters_buffer;
-
+// globals
+bool         g_suspend_state = false;
+rgb_config_t rgb_matrix_config;  // TODO: would like to prefix this with g_ for global consistancy, do this in another pr
+uint32_t     g_rgb_timer;
 #ifdef RGB_MATRIX_FRAMEBUFFER_EFFECTS
-uint8_t rgb_frame_buffer[MATRIX_ROWS][MATRIX_COLS] = {{0}};
-#endif
-
+uint8_t g_rgb_frame_buffer[MATRIX_ROWS][MATRIX_COLS] = {{0}};
+#endif  // RGB_MATRIX_FRAMEBUFFER_EFFECTS
 #ifdef RGB_MATRIX_KEYREACTIVE_ENABLED
-last_hit_t        g_last_hit_tracker;
+last_hit_t g_last_hit_tracker;
+#endif  // RGB_MATRIX_KEYREACTIVE_ENABLED
+
+// internals
+static uint8_t         rgb_last_enable   = UINT8_MAX;
+static uint8_t         rgb_last_effect   = UINT8_MAX;
+static effect_params_t rgb_effect_params = {0, 0xFF};
+static rgb_task_states rgb_task_state    = SYNCING;
+#if RGB_DISABLE_TIMEOUT > 0
+static uint32_t rgb_anykey_timer;
+#endif  // RGB_DISABLE_TIMEOUT > 0
+
+// double buffers
+static uint32_t rgb_timer_buffer;
+#ifdef RGB_MATRIX_KEYREACTIVE_ENABLED
 static last_hit_t last_hit_buffer;
 #endif  // RGB_MATRIX_KEYREACTIVE_ENABLED
 
@@ -169,21 +183,24 @@ void rgb_matrix_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
 void rgb_matrix_set_color_all(uint8_t red, uint8_t green, uint8_t blue) { rgb_matrix_driver.set_color_all(red, green, blue); }
 
 bool process_rgb_matrix(uint16_t keycode, keyrecord_t *record) {
+#if RGB_DISABLE_TIMEOUT > 0
+    if (record->event.pressed) {
+        rgb_anykey_timer = 0;
+    }
+#endif  // RGB_DISABLE_TIMEOUT > 0
+
 #ifdef RGB_MATRIX_KEYREACTIVE_ENABLED
     uint8_t led[LED_HITS_TO_REMEMBER];
     uint8_t led_count = 0;
 
 #    if defined(RGB_MATRIX_KEYRELEASES)
-    if (!record->event.pressed) {
-        led_count                  = rgb_matrix_map_row_column_to_led(record->event.key.row, record->event.key.col, led);
-        g_rgb_counters.any_key_hit = 0;
-    }
+    if (!record->event.pressed)
 #    elif defined(RGB_MATRIX_KEYPRESSES)
-    if (record->event.pressed) {
-        led_count                  = rgb_matrix_map_row_column_to_led(record->event.key.row, record->event.key.col, led);
-        g_rgb_counters.any_key_hit = 0;
-    }
+    if (record->event.pressed)
 #    endif  // defined(RGB_MATRIX_KEYRELEASES)
+    {
+        led_count = rgb_matrix_map_row_column_to_led(record->event.key.row, record->event.key.col, led);
+    }
 
     if (last_hit_buffer.count + led_count > LED_HITS_TO_REMEMBER) {
         memcpy(&last_hit_buffer.x[0], &last_hit_buffer.x[led_count], LED_HITS_TO_REMEMBER - led_count);
@@ -216,7 +233,7 @@ void rgb_matrix_test(void) {
     // Mask out bits 4 and 5
     // Increase the factor to make the test animation slower (and reduce to make it faster)
     uint8_t factor = 10;
-    switch ((g_rgb_counters.tick & (0b11 << factor)) >> factor) {
+    switch ((g_rgb_timer & (0b11 << factor)) >> factor) {
         case 0: {
             rgb_matrix_set_color_all(20, 0, 0);
             break;
@@ -241,29 +258,26 @@ static bool rgb_matrix_none(effect_params_t *params) {
         return false;
     }
 
-    RGB_MATRIX_USE_LIMITS(led_min, led_max);
-    for (uint8_t i = led_min; i < led_max; i++) {
-        rgb_matrix_set_color(i, 0, 0, 0);
-    }
-    return led_max < DRIVER_LED_TOTAL;
+    rgb_matrix_set_color_all(0, 0, 0);
+    return false;
 }
 
-static uint8_t         rgb_last_enable   = UINT8_MAX;
-static uint8_t         rgb_last_effect   = UINT8_MAX;
-static effect_params_t rgb_effect_params = {0, 0xFF};
-static rgb_task_states rgb_task_state    = SYNCING;
-
 static void rgb_task_timers(void) {
+#if defined(RGB_MATRIX_KEYREACTIVE_ENABLED) || RGB_DISABLE_TIMEOUT > 0
+    uint32_t deltaTime = timer_elapsed32(rgb_timer_buffer);
+#endif  // defined(RGB_MATRIX_KEYREACTIVE_ENABLED) || RGB_DISABLE_TIMEOUT > 0
+    rgb_timer_buffer = timer_read32();
+
     // Update double buffer timers
-    uint16_t deltaTime  = timer_elapsed32(rgb_counters_buffer);
-    rgb_counters_buffer = timer_read32();
-    if (g_rgb_counters.any_key_hit < UINT32_MAX) {
-        if (UINT32_MAX - deltaTime < g_rgb_counters.any_key_hit) {
-            g_rgb_counters.any_key_hit = UINT32_MAX;
+#if RGB_DISABLE_TIMEOUT > 0
+    if (rgb_anykey_timer < UINT32_MAX) {
+        if (UINT32_MAX - deltaTime < rgb_anykey_timer) {
+            rgb_anykey_timer = UINT32_MAX;
         } else {
-            g_rgb_counters.any_key_hit += deltaTime;
+            rgb_anykey_timer += deltaTime;
         }
     }
+#endif  // RGB_DISABLE_TIMEOUT > 0
 
     // Update double buffer last hit timers
 #ifdef RGB_MATRIX_KEYREACTIVE_ENABLED
@@ -280,7 +294,7 @@ static void rgb_task_timers(void) {
 
 static void rgb_task_sync(void) {
     // next task
-    if (timer_elapsed32(g_rgb_counters.tick) >= RGB_MATRIX_LED_FLUSH_LIMIT) rgb_task_state = STARTING;
+    if (timer_elapsed32(g_rgb_timer) >= RGB_MATRIX_LED_FLUSH_LIMIT) rgb_task_state = STARTING;
 }
 
 static void rgb_task_start(void) {
@@ -288,7 +302,7 @@ static void rgb_task_start(void) {
     rgb_effect_params.iter = 0;
 
     // update double buffers
-    g_rgb_counters.tick = rgb_counters_buffer;
+    g_rgb_timer = rgb_timer_buffer;
 #ifdef RGB_MATRIX_KEYREACTIVE_ENABLED
     g_last_hit_tracker = last_hit_buffer;
 #endif  // RGB_MATRIX_KEYREACTIVE_ENABLED
@@ -370,8 +384,16 @@ void rgb_matrix_task(void) {
 
     // Ideally we would also stop sending zeros to the LED driver PWM buffers
     // while suspended and just do a software shutdown. This is a cheap hack for now.
-    bool    suspend_backlight = ((g_suspend_state && RGB_DISABLE_WHEN_USB_SUSPENDED) || (RGB_DISABLE_AFTER_TIMEOUT > 0 && g_rgb_counters.any_key_hit > RGB_DISABLE_AFTER_TIMEOUT * 60 * 20));
-    uint8_t effect            = suspend_backlight || !rgb_matrix_config.enable ? 0 : rgb_matrix_config.mode;
+    bool suspend_backlight =
+#if RGB_DISABLE_WHEN_USB_SUSPENDED == true
+        g_suspend_state ||
+#endif  // RGB_DISABLE_WHEN_USB_SUSPENDED == true
+#if RGB_DISABLE_TIMEOUT > 0
+        (rgb_anykey_timer > (uint32_t)RGB_DISABLE_TIMEOUT) ||
+#endif  // RGB_DISABLE_TIMEOUT > 0
+        false;
+
+    uint8_t effect = suspend_backlight || !rgb_matrix_config.enable ? 0 : rgb_matrix_config.mode;
 
     switch (rgb_task_state) {
         case STARTING:
@@ -404,8 +426,6 @@ __attribute__((weak)) void rgb_matrix_indicators_user(void) {}
 
 void rgb_matrix_init(void) {
     rgb_matrix_driver.init();
-
-    // TODO: put the 1 second startup delay here?
 
 #ifdef RGB_MATRIX_KEYREACTIVE_ENABLED
     g_last_hit_tracker.count = 0;

--- a/quantum/rgb_matrix.h
+++ b/quantum/rgb_matrix.h
@@ -165,14 +165,14 @@ extern const rgb_matrix_driver_t rgb_matrix_driver;
 
 extern rgb_config_t rgb_matrix_config;
 
-extern bool           g_suspend_state;
-extern rgb_counters_t g_rgb_counters;
-extern led_config_t   g_led_config;
+extern bool         g_suspend_state;
+extern uint32_t     g_rgb_timer;
+extern led_config_t g_led_config;
 #ifdef RGB_MATRIX_KEYREACTIVE_ENABLED
 extern last_hit_t g_last_hit_tracker;
 #endif
 #ifdef RGB_MATRIX_FRAMEBUFFER_EFFECTS
-extern uint8_t rgb_frame_buffer[MATRIX_ROWS][MATRIX_COLS];
+extern uint8_t g_rgb_frame_buffer[MATRIX_ROWS][MATRIX_COLS];
 #endif
 
 #endif

--- a/quantum/rgb_matrix_animations/breathing_anim.h
+++ b/quantum/rgb_matrix_animations/breathing_anim.h
@@ -6,7 +6,7 @@ bool BREATHING(effect_params_t* params) {
     RGB_MATRIX_USE_LIMITS(led_min, led_max);
 
     HSV      hsv  = rgb_matrix_config.hsv;
-    uint16_t time = scale16by8(g_rgb_counters.tick, rgb_matrix_config.speed / 8);
+    uint16_t time = scale16by8(g_rgb_timer, rgb_matrix_config.speed / 8);
     hsv.v         = scale8(abs8(sin8(time) - 128) * 2, hsv.v);
     RGB rgb       = hsv_to_rgb(hsv);
     for (uint8_t i = led_min; i < led_max; i++) {

--- a/quantum/rgb_matrix_animations/digital_rain_anim.h
+++ b/quantum/rgb_matrix_animations/digital_rain_anim.h
@@ -18,7 +18,7 @@ bool DIGITAL_RAIN(effect_params_t* params) {
 
     if (params->init) {
         rgb_matrix_set_color_all(0, 0, 0);
-        memset(rgb_frame_buffer, 0, sizeof(rgb_frame_buffer));
+        memset(g_rgb_frame_buffer, 0, sizeof(g_rgb_frame_buffer));
         drop = 0;
     }
 
@@ -27,10 +27,10 @@ bool DIGITAL_RAIN(effect_params_t* params) {
             if (row == 0 && drop == 0 && rand() < RAND_MAX / RGB_DIGITAL_RAIN_DROPS) {
                 // top row, pixels have just fallen and we're
                 // making a new rain drop in this column
-                rgb_frame_buffer[row][col] = max_intensity;
-            } else if (rgb_frame_buffer[row][col] > 0 && rgb_frame_buffer[row][col] < max_intensity) {
+                g_rgb_frame_buffer[row][col] = max_intensity;
+            } else if (g_rgb_frame_buffer[row][col] > 0 && g_rgb_frame_buffer[row][col] < max_intensity) {
                 // neither fully bright nor dark, decay it
-                rgb_frame_buffer[row][col]--;
+                g_rgb_frame_buffer[row][col]--;
             }
             // set the pixel colour
             uint8_t led[LED_HITS_TO_REMEMBER];
@@ -38,11 +38,11 @@ bool DIGITAL_RAIN(effect_params_t* params) {
 
             // TODO: multiple leds are supported mapped to the same row/column
             if (led_count > 0) {
-                if (rgb_frame_buffer[row][col] > pure_green_intensity) {
-                    const uint8_t boost = (uint8_t)((uint16_t)max_brightness_boost * (rgb_frame_buffer[row][col] - pure_green_intensity) / (max_intensity - pure_green_intensity));
+                if (g_rgb_frame_buffer[row][col] > pure_green_intensity) {
+                    const uint8_t boost = (uint8_t)((uint16_t)max_brightness_boost * (g_rgb_frame_buffer[row][col] - pure_green_intensity) / (max_intensity - pure_green_intensity));
                     rgb_matrix_set_color(led[0], boost, max_intensity, boost);
                 } else {
-                    const uint8_t green = (uint8_t)((uint16_t)max_intensity * rgb_frame_buffer[row][col] / pure_green_intensity);
+                    const uint8_t green = (uint8_t)((uint16_t)max_intensity * g_rgb_frame_buffer[row][col] / pure_green_intensity);
                     rgb_matrix_set_color(led[0], 0, green, 0);
                 }
             }
@@ -55,15 +55,15 @@ bool DIGITAL_RAIN(effect_params_t* params) {
         for (uint8_t row = MATRIX_ROWS - 1; row > 0; row--) {
             for (uint8_t col = 0; col < MATRIX_COLS; col++) {
                 // if ths is on the bottom row and bright allow decay
-                if (row == MATRIX_ROWS - 1 && rgb_frame_buffer[row][col] == max_intensity) {
-                    rgb_frame_buffer[row][col]--;
+                if (row == MATRIX_ROWS - 1 && g_rgb_frame_buffer[row][col] == max_intensity) {
+                    g_rgb_frame_buffer[row][col]--;
                 }
                 // check if the pixel above is bright
-                if (rgb_frame_buffer[row - 1][col] == max_intensity) {
+                if (g_rgb_frame_buffer[row - 1][col] == max_intensity) {
                     // allow old bright pixel to decay
-                    rgb_frame_buffer[row - 1][col]--;
+                    g_rgb_frame_buffer[row - 1][col]--;
                     // make this pixel bright
-                    rgb_frame_buffer[row][col] = max_intensity;
+                    g_rgb_frame_buffer[row][col] = max_intensity;
                 }
             }
         }

--- a/quantum/rgb_matrix_animations/jellybean_raindrops_anim.h
+++ b/quantum/rgb_matrix_animations/jellybean_raindrops_anim.h
@@ -12,7 +12,7 @@ static void jellybean_raindrops_set_color(int i, effect_params_t* params) {
 bool JELLYBEAN_RAINDROPS(effect_params_t* params) {
     if (!params->init) {
         // Change one LED every tick, make sure speed is not 0
-        if (scale16by8(g_rgb_counters.tick, qadd8(rgb_matrix_config.speed, 16)) % 5 == 0) {
+        if (scale16by8(g_rgb_timer, qadd8(rgb_matrix_config.speed, 16)) % 5 == 0) {
             jellybean_raindrops_set_color(rand() % DRIVER_LED_TOTAL, params);
         }
         return false;

--- a/quantum/rgb_matrix_animations/raindrops_anim.h
+++ b/quantum/rgb_matrix_animations/raindrops_anim.h
@@ -22,7 +22,7 @@ static void raindrops_set_color(int i, effect_params_t* params) {
 bool RAINDROPS(effect_params_t* params) {
     if (!params->init) {
         // Change one LED every tick, make sure speed is not 0
-        if (scale16by8(g_rgb_counters.tick, qadd8(rgb_matrix_config.speed, 16)) % 10 == 0) {
+        if (scale16by8(g_rgb_timer, qadd8(rgb_matrix_config.speed, 16)) % 10 == 0) {
             raindrops_set_color(rand() % DRIVER_LED_TOTAL, params);
         }
         return false;

--- a/quantum/rgb_matrix_animations/typing_heatmap_anim.h
+++ b/quantum/rgb_matrix_animations/typing_heatmap_anim.h
@@ -10,20 +10,20 @@ void process_rgb_matrix_typing_heatmap(keyrecord_t* record) {
     uint8_t m_col = col - 1;
     uint8_t p_col = col + 1;
 
-    if (m_col < col) rgb_frame_buffer[row][m_col] = qadd8(rgb_frame_buffer[row][m_col], 16);
-    rgb_frame_buffer[row][col] = qadd8(rgb_frame_buffer[row][col], 32);
-    if (p_col < MATRIX_COLS) rgb_frame_buffer[row][p_col] = qadd8(rgb_frame_buffer[row][p_col], 16);
+    if (m_col < col) g_rgb_frame_buffer[row][m_col] = qadd8(g_rgb_frame_buffer[row][m_col], 16);
+    g_rgb_frame_buffer[row][col] = qadd8(g_rgb_frame_buffer[row][col], 32);
+    if (p_col < MATRIX_COLS) g_rgb_frame_buffer[row][p_col] = qadd8(g_rgb_frame_buffer[row][p_col], 16);
 
     if (p_row < MATRIX_ROWS) {
-        if (m_col < col) rgb_frame_buffer[p_row][m_col] = qadd8(rgb_frame_buffer[p_row][m_col], 13);
-        rgb_frame_buffer[p_row][col] = qadd8(rgb_frame_buffer[p_row][col], 16);
-        if (p_col < MATRIX_COLS) rgb_frame_buffer[p_row][p_col] = qadd8(rgb_frame_buffer[p_row][p_col], 13);
+        if (m_col < col) g_rgb_frame_buffer[p_row][m_col] = qadd8(g_rgb_frame_buffer[p_row][m_col], 13);
+        g_rgb_frame_buffer[p_row][col] = qadd8(g_rgb_frame_buffer[p_row][col], 16);
+        if (p_col < MATRIX_COLS) g_rgb_frame_buffer[p_row][p_col] = qadd8(g_rgb_frame_buffer[p_row][p_col], 13);
     }
 
     if (m_row < row) {
-        if (m_col < col) rgb_frame_buffer[m_row][m_col] = qadd8(rgb_frame_buffer[m_row][m_col], 13);
-        rgb_frame_buffer[m_row][col] = qadd8(rgb_frame_buffer[m_row][col], 16);
-        if (p_col < MATRIX_COLS) rgb_frame_buffer[m_row][p_col] = qadd8(rgb_frame_buffer[m_row][p_col], 13);
+        if (m_col < col) g_rgb_frame_buffer[m_row][m_col] = qadd8(g_rgb_frame_buffer[m_row][m_col], 13);
+        g_rgb_frame_buffer[m_row][col] = qadd8(g_rgb_frame_buffer[m_row][col], 16);
+        if (p_col < MATRIX_COLS) g_rgb_frame_buffer[m_row][p_col] = qadd8(g_rgb_frame_buffer[m_row][p_col], 13);
     }
 }
 
@@ -31,18 +31,18 @@ bool TYPING_HEATMAP(effect_params_t* params) {
     // Modified version of RGB_MATRIX_USE_LIMITS to work off of matrix row / col size
     uint8_t led_min = RGB_MATRIX_LED_PROCESS_LIMIT * params->iter;
     uint8_t led_max = led_min + RGB_MATRIX_LED_PROCESS_LIMIT;
-    if (led_max > sizeof(rgb_frame_buffer)) led_max = sizeof(rgb_frame_buffer);
+    if (led_max > sizeof(g_rgb_frame_buffer)) led_max = sizeof(g_rgb_frame_buffer);
 
     if (params->init) {
         rgb_matrix_set_color_all(0, 0, 0);
-        memset(rgb_frame_buffer, 0, sizeof rgb_frame_buffer);
+        memset(g_rgb_frame_buffer, 0, sizeof g_rgb_frame_buffer);
     }
 
     // Render heatmap & decrease
     for (int i = led_min; i < led_max; i++) {
         uint8_t row = i % MATRIX_ROWS;
         uint8_t col = i / MATRIX_ROWS;
-        uint8_t val = rgb_frame_buffer[row][col];
+        uint8_t val = g_rgb_frame_buffer[row][col];
 
         // set the pixel colour
         uint8_t led[LED_HITS_TO_REMEMBER];
@@ -55,10 +55,10 @@ bool TYPING_HEATMAP(effect_params_t* params) {
             rgb_matrix_set_color(led[j], rgb.r, rgb.g, rgb.b);
         }
 
-        rgb_frame_buffer[row][col] = qsub8(val, 1);
+        g_rgb_frame_buffer[row][col] = qsub8(val, 1);
     }
 
-    return led_max < sizeof(rgb_frame_buffer);
+    return led_max < sizeof(g_rgb_frame_buffer);
 }
 
 #    endif  // RGB_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/quantum/rgb_matrix_runners/effect_runner_dx_dy.h
+++ b/quantum/rgb_matrix_runners/effect_runner_dx_dy.h
@@ -5,7 +5,7 @@ typedef HSV (*dx_dy_f)(HSV hsv, int16_t dx, int16_t dy, uint8_t time);
 bool effect_runner_dx_dy(effect_params_t* params, dx_dy_f effect_func) {
     RGB_MATRIX_USE_LIMITS(led_min, led_max);
 
-    uint8_t time = scale16by8(g_rgb_counters.tick, rgb_matrix_config.speed / 2);
+    uint8_t time = scale16by8(g_rgb_timer, rgb_matrix_config.speed / 2);
     for (uint8_t i = led_min; i < led_max; i++) {
         RGB_MATRIX_TEST_LED_FLAGS();
         int16_t dx  = g_led_config.point[i].x - k_rgb_matrix_center.x;

--- a/quantum/rgb_matrix_runners/effect_runner_dx_dy_dist.h
+++ b/quantum/rgb_matrix_runners/effect_runner_dx_dy_dist.h
@@ -5,7 +5,7 @@ typedef HSV (*dx_dy_dist_f)(HSV hsv, int16_t dx, int16_t dy, uint8_t dist, uint8
 bool effect_runner_dx_dy_dist(effect_params_t* params, dx_dy_dist_f effect_func) {
     RGB_MATRIX_USE_LIMITS(led_min, led_max);
 
-    uint8_t time = scale16by8(g_rgb_counters.tick, rgb_matrix_config.speed / 2);
+    uint8_t time = scale16by8(g_rgb_timer, rgb_matrix_config.speed / 2);
     for (uint8_t i = led_min; i < led_max; i++) {
         RGB_MATRIX_TEST_LED_FLAGS();
         int16_t dx   = g_led_config.point[i].x - k_rgb_matrix_center.x;

--- a/quantum/rgb_matrix_runners/effect_runner_i.h
+++ b/quantum/rgb_matrix_runners/effect_runner_i.h
@@ -5,7 +5,7 @@ typedef HSV (*i_f)(HSV hsv, uint8_t i, uint8_t time);
 bool effect_runner_i(effect_params_t* params, i_f effect_func) {
     RGB_MATRIX_USE_LIMITS(led_min, led_max);
 
-    uint8_t time = scale16by8(g_rgb_counters.tick, rgb_matrix_config.speed / 4);
+    uint8_t time = scale16by8(g_rgb_timer, rgb_matrix_config.speed / 4);
     for (uint8_t i = led_min; i < led_max; i++) {
         RGB_MATRIX_TEST_LED_FLAGS();
         RGB rgb = hsv_to_rgb(effect_func(rgb_matrix_config.hsv, i, time));

--- a/quantum/rgb_matrix_runners/effect_runner_sin_cos_i.h
+++ b/quantum/rgb_matrix_runners/effect_runner_sin_cos_i.h
@@ -5,7 +5,7 @@ typedef HSV (*sin_cos_i_f)(HSV hsv, int8_t sin, int8_t cos, uint8_t i, uint8_t t
 bool effect_runner_sin_cos_i(effect_params_t* params, sin_cos_i_f effect_func) {
     RGB_MATRIX_USE_LIMITS(led_min, led_max);
 
-    uint16_t time      = scale16by8(g_rgb_counters.tick, rgb_matrix_config.speed / 4);
+    uint16_t time      = scale16by8(g_rgb_timer, rgb_matrix_config.speed / 4);
     int8_t   cos_value = cos8(time) - 128;
     int8_t   sin_value = sin8(time) - 128;
     for (uint8_t i = led_min; i < led_max; i++) {

--- a/quantum/rgb_matrix_types.h
+++ b/quantum/rgb_matrix_types.h
@@ -44,13 +44,6 @@ typedef struct PACKED {
 } effect_params_t;
 
 typedef struct PACKED {
-    // Global tick at 20 Hz
-    uint32_t tick;
-    // Ticks since this key was last hit.
-    uint32_t any_key_hit;
-} rgb_counters_t;
-
-typedef struct PACKED {
     uint8_t x;
     uint8_t y;
 } point_t;

--- a/tmk_core/protocol/arm_atsam/led_matrix.c
+++ b/tmk_core/protocol/arm_atsam/led_matrix.c
@@ -270,7 +270,7 @@ void flush(void) {
     }
 
     // This should only be performed once per frame
-    pomod = (float)((g_rgb_counters.tick / 10) % (uint32_t)(1000.0f / led_animation_speed)) / 10.0f * led_animation_speed;
+    pomod = (float)((g_rgb_timer / 10) % (uint32_t)(1000.0f / led_animation_speed)) / 10.0f * led_animation_speed;
     pomod *= 100.0f;
     pomod = (uint32_t)pomod % 10000;
     pomod /= 100.0f;

--- a/users/xulkal/config.h
+++ b/users/xulkal/config.h
@@ -13,13 +13,13 @@
 
 // Running out of firmware space
 #if defined(__AVR__)
-#undef RGB_MATRIX_KEYPRESSES
-#undef RGB_MATRIX_KEYRELEASES
-#undef RGB_MATRIX_FRAMEBUFFER_EFFECTS
+#    undef RGB_MATRIX_KEYPRESSES
+#    undef RGB_MATRIX_KEYRELEASES
+#    undef RGB_MATRIX_FRAMEBUFFER_EFFECTS
 #else
-#define RGB_MATRIX_KEYPRESSES
-#undef RGB_MATRIX_KEYRELEASES
-#define RGB_MATRIX_FRAMEBUFFER_EFFECTS
+#    define RGB_MATRIX_KEYPRESSES
+#    undef RGB_MATRIX_KEYRELEASES
+#    define RGB_MATRIX_FRAMEBUFFER_EFFECTS
 #endif
 
 // No need for the single versions when multi performance isn't a problem =D

--- a/users/xulkal/config.h
+++ b/users/xulkal/config.h
@@ -13,13 +13,13 @@
 
 // Running out of firmware space
 #if defined(__AVR__)
-#    undef RGB_MATRIX_KEYPRESSES
-#    undef RGB_MATRIX_KEYRELEASES
-#    undef RGB_MATRIX_FRAMEBUFFER_EFFECTS
+#undef RGB_MATRIX_KEYPRESSES
+#undef RGB_MATRIX_KEYRELEASES
+#undef RGB_MATRIX_FRAMEBUFFER_EFFECTS
 #else
-#    define RGB_MATRIX_KEYPRESSES
-#    undef RGB_MATRIX_KEYRELEASES
-#    define RGB_MATRIX_FRAMEBUFFER_EFFECTS
+#define RGB_MATRIX_KEYPRESSES
+#undef RGB_MATRIX_KEYRELEASES
+#define RGB_MATRIX_FRAMEBUFFER_EFFECTS
 #endif
 
 // No need for the single versions when multi performance isn't a problem =D


### PR DESCRIPTION
## Description

This PR changes RGB_DISABLE_AFTER_TIMEOUT to be based on seconds, instead of some odd previous 1.2s per unit from before all the rgb matrix work. In addition this did a bit of code cleanup saving another 100 bytes depending on features used. Also fixed issues with timeouts / suspending at the wrong time not turning off all LEDs in some cases.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
