### PR TITLE
Fix qmk_install.sh on Windows dropping to command prompt

### DIFF
--- a/util/win_shared_install.sh
+++ b/util/win_shared_install.sh
@@ -34,7 +34,7 @@ function install_drivers {
     pushd "$download_dir"
     cp -f "$dir/drivers.txt" .
     echo 
-    cmd.exe /c "qmk_driver_installer.exe $1 $2 drivers.txt"
+    cmd.exe //c "qmk_driver_installer.exe $1 $2 drivers.txt"
     popd > /dev/null
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

When running qmk_install.sh on a fresh Windows install, the script gets as far as prompting to run qmk_driver_installer.exe, and then sits at a command prompt until you type `exit` - it continues on its way but the driver installer never gets run.

Turns out on Msys2, you need to pass `//c` (double slashes) to cmd.exe, otherwise it will think you mean the C:\ drive.

I don't know if this is an issue on WSL too, and if not, whether this extra character will break it in turn. Please test :)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
