### PR TITLE
Add support for different encoder pinout for right half of split keyboard

### DIFF
--- a/docs/feature_encoders.md
+++ b/docs/feature_encoders.md
@@ -20,6 +20,15 @@ Additionally, the resolution can be specified in the same file (the default & su
 
     #define ENCODER_RESOLUTION 4
 
+## Split Keyboards
+
+If you are using different pinouts for the encoders on each half of a split keyboard, you can define the pinout for the right half like this:
+
+```c
+#define ENCODERS_PAD_A_RIGHT { encoder1a, encoder2a }
+#define ENCODERS_PAD_B_RIGHT { encoder1b, encoder2b }
+```
+
 ## Callbacks
 
 The callback functions can be inserted into your `<keyboard>.c`:

--- a/docs/feature_split_keyboard.md
+++ b/docs/feature_split_keyboard.md
@@ -167,6 +167,13 @@ This allows you to specify a different set of pins for the matrix on the right s
 This allows you to specify a different set of direct pins for the right side.
 
 ```c
+#define ENCODERS_PAD_A_RIGHT { encoder1a, encoder2a }
+#define ENCODERS_PAD_B_RIGHT { encoder1b, encoder2b }
+```
+
+This allows you to specify a different set of encoder pins for the right side.
+
+```c
 #define RGBLIGHT_SPLIT
 ```
 

--- a/quantum/encoder.c
+++ b/quantum/encoder.c
@@ -16,6 +16,9 @@
  */
 
 #include "encoder.h"
+#ifdef SPLIT_KEYBOARD
+  #include "split_util.h"
+#endif
 
 // for memcpy
 #include <string.h>
@@ -54,6 +57,17 @@ void encoder_update_kb(int8_t index, bool clockwise) {
 }
 
 void encoder_init(void) {
+#if defined(SPLIT_KEYBOARD) && defined(ENCODERS_PAD_A_RIGHT) && defined(ENCODERS_PAD_B_RIGHT)
+  if (!isLeftHand) {
+    const pin_t encoders_pad_a_right[] = ENCODERS_PAD_A_RIGHT;
+    const pin_t encoders_pad_b_right[] = ENCODERS_PAD_B_RIGHT;
+    for (uint8_t i = 0; i < NUMBER_OF_ENCODERS; i++) {
+      encoders_pad_a[i] = encoders_pad_a_right[i];
+      encoders_pad_b[i] = encoders_pad_b_right[i];
+    }
+  }
+#endif
+
   for (int i = 0; i < NUMBER_OF_ENCODERS; i++) {
     setPinInputHigh(encoders_pad_a[i]);
     setPinInputHigh(encoders_pad_b[i]);


### PR DESCRIPTION
## Description

Adds option to define `ENCODERS_PAD_A_RIGHT` and `ENCODERS_PAD_B_RIGHT` to allow right half of split keyboard to have a different encoder pinout than the left half. Needed for upcoming Iris Rev. 4.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
