### PR TITLE
Update how_keyboards_work.md

### DIFF
--- a/docs/how_keyboards_work.md
+++ b/docs/how_keyboards_work.md
@@ -35,7 +35,7 @@ USB for a given key.
 
 ## 3. What the Event Input/Kernel Does
 
-The *scancode* is mapped to a *keycode* dependant on the keyboard [60-keyboard.hwdb at Master](example: https://github.com/systemd/systemd/blob/master/hwdb/60-keyboard.hwdb ). Without this mapping, the operating system will not receive a valid keycode and will be unable to do anything useful with that key press.
+The *scancode* is mapped to a *keycode* dependant on the keyboard [60-keyboard.hwdb at Master](https://github.com/systemd/systemd/blob/master/hwdb/60-keyboard.hwdb). Without this mapping, the operating system will not receive a valid keycode and will be unable to do anything useful with that key press.
 
 ## 4. What the Operating System Does
 

--- a/docs/how_keyboards_work.md
+++ b/docs/how_keyboards_work.md
@@ -35,7 +35,7 @@ USB for a given key.
 
 ## 3. What the Event Input/Kernel Does
 
-The *scancode* is mapped to a *keycode* dependant on the keyboard [60-keyboard.hwdb at Master](https://github.com/systemd/systemd/blob/master/hwdb/60-keyboard.hwdb). Without this mapping, the operating system will not receive a valid keycode and will be unable to do anything useful with that key press.
+The *scancode* is mapped to a *keycode* dependent on the keyboard [60-keyboard.hwdb at Master](https://github.com/systemd/systemd/blob/master/hwdb/60-keyboard.hwdb). Without this mapping, the operating system will not receive a valid keycode and will be unable to do anything useful with that key press.
 
 ## 4. What the Operating System Does
 

--- a/docs/how_keyboards_work.md
+++ b/docs/how_keyboards_work.md
@@ -33,7 +33,11 @@ The firmware does not send actual letters or characters, but only scancodes.
 Thus, by modifying the firmware, you can only modify what scancode is sent over
 USB for a given key.
 
-## 3. What the Operating System Does
+## 3. What the Event Input/Kernel Does
+
+The *scancode* is mapped to a *keycode* dependant on the keyboard [60-keyboard.hwdb at Master](example: https://github.com/systemd/systemd/blob/master/hwdb/60-keyboard.hwdb ). Without this mapping, the operating system will not receive a valid keycode and will be unable to do anything useful with that key press.
+
+## 4. What the Operating System Does
 
 Once the keycode reaches the operating system, a piece of software has to have
 it match an actual character thanks to a keyboard layout. For example, if your


### PR DESCRIPTION
bridged the gap between scancodes and keycodes, the doc didn't make the distinction and was ambiguous.
