### PR TITLE
Fix LT() crashing some ARM keyboards

### DIFF
--- a/tmk_core/common/wait.h
+++ b/tmk_core/common/wait.h
@@ -13,8 +13,8 @@ extern "C" {
 #   define wait_us(us)  _delay_us(us)
 #elif defined PROTOCOL_CHIBIOS
 #   include "ch.h"
-#   define wait_ms(ms) chThdSleepMilliseconds(ms)
-#   define wait_us(us) chThdSleepMicroseconds(us)
+#   define wait_ms(ms) do { if (ms != 0) { chThdSleepMilliseconds(ms); } else { chThdSleepMicroseconds(1); } } while (0)
+#   define wait_us(us) do { if (us != 0) { chThdSleepMicroseconds(us); } else { chThdSleepMicroseconds(1); } } while (0)
 #elif defined PROTOCOL_ARM_ATSAM
 #   include "clks.h"
 #   define wait_ms(ms) CLK_delay_ms(ms)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Using LT() causes some ARM keyboards to apparently crash.

Issue was tracked down to commit https://github.com/qmk/qmk_firmware/commit/3261c408e454dbc3cc2a1591ba62575036af19ad.

The code change is innocent looking, but the `TAP_CODE_DELAY` macro defaults to 0 and in theory, would not optimise out the sleep call. The ChibiOS docs have the following:

>#define chThdSleepMilliseconds    (         msec    )       chThdSleep(TIME_MS2I(msec))
Delays the invoking thread for the specified number of milliseconds.

>Note
The specified time is rounded up to a value allowed by the real system tick clock.
The maximum specifiable value is implementation dependent.
Use of this macro for large values is not secure because integer overflows, make sure your value can be correctly converted.
Parameters
[in]    msec    time in milliseconds, must be different from zero
Function Class:
Normal API, this function can be invoked by regular system threads but not from within a lock zone.
Definition at line 197 of file chthreads.h.

The important part being `must be different from zero`. Its odd that some boards break while sleeping zero, maybe `wait_ms` has different behaviour when running tickless.

Given that PR targets wait_ms, instead of `action.c`, i figured it best to sleep something in all cases.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
