### PR TITLE
ARM split - Add support for dfu-util EE_HANDS flashing

### DIFF
--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -222,6 +222,7 @@ There are a few different ways to set handedness for split keyboards (listed in 
 2. Set `EE_HANDS` and flash `eeprom-lefthand.eep`/`eeprom-righthand.eep` to each half
    * For boards with DFU bootloader you can use `:dfu-split-left`/`:dfu-split-right` to flash these EEPROM files
    * For boards with Caterina bootloader (like stock Pro Micros), use `:avrdude-split-left`/`:avrdude-split-right`
+   * For boards with ARM DFU bootloader (like Proton C), use `:dfu-util-split-left`/`:dfu-util-split-right`
 3. Set `MASTER_RIGHT`: Half that is plugged into the USB port is determined to be the master and right half (inverse of the default)
 4. Default: The side that is plugged into the USB port is the master half and is assumed to be the left half. The slave side is the right half
 

--- a/docs/feature_split_keyboard.md
+++ b/docs/feature_split_keyboard.md
@@ -96,6 +96,8 @@ However, you'll have to flash the EEPROM files for the correct hand to each cont
 * `:avrdude-split-right`
 * `:dfu-split-left`
 * `:dfu-split-right`
+* `:dfu-util-split-left`
+* `:dfu-util-split-right`
 
 This setting is not changed when re-initializing the EEPROM using the `EEP_RST` key, or using the `eeconfig_init()` function.  However, if you reset the EEPROM outside of the firmware's built in options (such as flashing a file that overwrites the `EEPROM`, like how the [QMK Toolbox]()'s "Reset EEPROM" button works), you'll need to re-flash the controller with the `EEPROM` files. 
 

--- a/docs/flashing.md
+++ b/docs/flashing.md
@@ -202,6 +202,6 @@ Flashing sequence:
 There are a number of DFU commands that you can use to flash firmware to a STM32 device:
 
 * `:dfu-util` - The default command for flashing to STM32 devices.
-* `:dfu-utilsplit-left` - This flashes the normal firmware, just like the default option (`:dfu-util`). However, this also configures the "Left Side" EEPROM setting for split keyboards.
-* `:dfu-utilsplit-right` - This flashes the normal firmware, just like the default option (`:dfu-util`). However, this also configures the "Right Side" EEPROM setting for split keyboards.
+* `:dfu-util-split-left` - This flashes the normal firmware, just like the default option (`:dfu-util`). However, this also configures the "Left Side" EEPROM setting for split keyboards.
+* `:dfu-util-split-right` - This flashes the normal firmware, just like the default option (`:dfu-util`). However, this also configures the "Right Side" EEPROM setting for split keyboards.
 * `:st-link-cli` - This allows you to flash the firmware via ST-LINK's CLI utility, rather than dfu-util. 

--- a/docs/flashing.md
+++ b/docs/flashing.md
@@ -202,4 +202,6 @@ Flashing sequence:
 There are a number of DFU commands that you can use to flash firmware to a STM32 device:
 
 * `:dfu-util` - The default command for flashing to STM32 devices.
-* `:st-link-cli` - This allows you to flash the firmware via ST-LINK's CLI utility, rather than dfu-util.
+* `:dfu-utilsplit-left` - This flashes the normal firmware, just like the default option (`:dfu-util`). However, this also configures the "Left Side" EEPROM setting for split keyboards.
+* `:dfu-utilsplit-right` - This flashes the normal firmware, just like the default option (`:dfu-util`). However, this also configures the "Right Side" EEPROM setting for split keyboards.
+* `:st-link-cli` - This allows you to flash the firmware via ST-LINK's CLI utility, rather than dfu-util. 

--- a/docs/newbs_flashing.md
+++ b/docs/newbs_flashing.md
@@ -341,8 +341,8 @@ There are a number of DFU commands that you can use to flash firmware to a STM32
 * `:dfu-util` - The default command for flashing to STM32 devices. 
 * `:dfu-util-wait` - This works like the default command, but it gives you a (configurable) 10 second timeout before it attempts to flash the firmware.  You can use `TIME_DELAY=20` from the command line to change the timeout.
    * Eg: `make <keyboard>:<keymap>:dfu-util TIME_DELAY=5`
-* `:dfu-utilsplit-left` - This flashes the normal firmware, just like the default option (`:dfu-util`). However, this also configures the "Left Side" EEPROM setting for split keyboards.
-* `:dfu-utilsplit-right` - This flashes the normal firmware, just like the default option (`:dfu-util`). However, this also configures the "Right Side" EEPROM setting for split keyboards.
+* `:dfu-util-split-left` - This flashes the normal firmware, just like the default option (`:dfu-util`). However, this also configures the "Left Side" EEPROM setting for split keyboards.
+* `:dfu-util-split-right` - This flashes the normal firmware, just like the default option (`:dfu-util`). However, this also configures the "Right Side" EEPROM setting for split keyboards.
 
 ## Test It Out!
 

--- a/docs/newbs_flashing.md
+++ b/docs/newbs_flashing.md
@@ -215,7 +215,7 @@ Additionally, if you want to flash multiple boards, use the following command:
 When you're done flashing boards, you'll need to hit Ctrl + C or whatever the correct keystroke is for your operating system to break the loop.
 
 
-## HalfKay
+### HalfKay
 
 For the PJRC devices (Teensy's), when you're ready to compile and flash your firmware, open up your terminal window and run the build command: 
 
@@ -248,7 +248,7 @@ Programming.....................................................................
 Booting
 ```
 
-## BootloadHID
+### BootloadHID
 
 For Bootmapper Client(BMC)/bootloadHID/ATmega32A based boards, when you're ready to compile and flash your firmware, open up your terminal window and run the build command: 
 
@@ -284,7 +284,7 @@ Uploading 22016 (0x5600) bytes starting at 0 (0x0)
 0x05580 ... 0x05600
 ```
 
-## STM32 (ARM)
+### STM32 (ARM)
 
 For a majority of ARM boards (including the Proton C, Planck Rev 6, and Preonic Rev 3), when you're ready to compile and flash your firmware, open up your terminal window and run the build command: 
 
@@ -333,6 +333,16 @@ Download done.
 File downloaded successfully
 Transitioning to dfuMANIFEST state
 ```
+
+#### STM32 Commands
+
+There are a number of DFU commands that you can use to flash firmware to a STM32 device:
+
+* `:dfu-util` - The default command for flashing to STM32 devices. 
+* `:dfu-util-wait` - This works like the default command, but it gives you a (configurable) 10 second timeout before it attempts to flash the firmware.  You can use `TIME_DELAY=20` from the command line to change the timeout.
+   * Eg: `make <keyboard>:<keymap>:dfu-util TIME_DELAY=5`
+* `:dfu-utilsplit-left` - This flashes the normal firmware, just like the default option (`:dfu-util`). However, this also configures the "Left Side" EEPROM setting for split keyboards.
+* `:dfu-utilsplit-right` - This flashes the normal firmware, just like the default option (`:dfu-util`). However, this also configures the "Right Side" EEPROM setting for split keyboards.
 
 ## Test It Out!
 

--- a/tmk_core/chibios.mk
+++ b/tmk_core/chibios.mk
@@ -254,6 +254,10 @@ ifneq (,$(filter $(MAKECMDGOALS),dfu-util-split-left))
     OPT_DEFS += -DINIT_EE_HANDS_LEFT
 endif
 
+ifneq (,$(filter $(MAKECMDGOALS),dfu-util-split-right))
+    OPT_DEFS += -DINIT_EE_HANDS_RIGHT
+endif
+
 dfu-util-split-left: dfu-util
 
 dfu-util-split-right: dfu-util

--- a/tmk_core/chibios.mk
+++ b/tmk_core/chibios.mk
@@ -248,6 +248,17 @@ dfu-util: $(BUILD_DIR)/$(TARGET).bin cpfirmware sizeafter
 # Legacy alias
 dfu-util-wait: dfu-util
 
+# TODO: Remove once ARM has a way to configure EECONFIG_HANDEDNESS
+#       within the emulated eeprom via dfu-util or another tool
+ifneq (,$(filter $(MAKECMDGOALS),dfu-util-split-left))
+    OPT_DEFS += -DINIT_EE_HANDS_LEFT
+endif
+
+dfu-util-split-left: dfu-util
+
+dfu-util-split-right: dfu-util
+
+
 st-link-cli: $(BUILD_DIR)/$(TARGET).hex sizeafter
 	$(ST_LINK_CLI) $(ST_LINK_ARGS) -q -c SWD -p $(BUILD_DIR)/$(TARGET).hex -Rst
 

--- a/tmk_core/common/eeconfig.c
+++ b/tmk_core/common/eeconfig.c
@@ -48,6 +48,13 @@ void eeconfig_init_quantum(void) {
     eeprom_update_dword(EECONFIG_RGB_MATRIX, 0);
     eeprom_update_byte(EECONFIG_RGB_MATRIX_SPEED, 0);
 
+    // TODO: Remove once ARM has a way to configure EECONFIG_HANDEDNESS
+    //        within the emulated eeprom via dfu-util or another tool
+#ifdef INIT_EE_HANDS_LEFT
+    #pragma message "Faking EE_HANDS for left hand"
+    eeprom_update_byte(EECONFIG_HANDEDNESS,        1);
+#endif
+
     eeconfig_init_kb();
 }
 

--- a/tmk_core/common/eeconfig.c
+++ b/tmk_core/common/eeconfig.c
@@ -52,7 +52,7 @@ void eeconfig_init_quantum(void) {
     //        within the emulated eeprom via dfu-util or another tool
 #ifdef INIT_EE_HANDS_LEFT
     #pragma message "Faking EE_HANDS for left hand"
-    eeprom_update_byte(EECONFIG_HANDEDNESS,        1);
+    eeprom_update_byte(EECONFIG_HANDEDNESS, 1);
 #endif
 
     eeconfig_init_kb();

--- a/tmk_core/common/eeconfig.c
+++ b/tmk_core/common/eeconfig.c
@@ -50,9 +50,12 @@ void eeconfig_init_quantum(void) {
 
     // TODO: Remove once ARM has a way to configure EECONFIG_HANDEDNESS
     //        within the emulated eeprom via dfu-util or another tool
-#ifdef INIT_EE_HANDS_LEFT
+#if defined INIT_EE_HANDS_LEFT
     #pragma message "Faking EE_HANDS for left hand"
     eeprom_update_byte(EECONFIG_HANDEDNESS, 1);
+#elif defined INIT_EE_HANDS_RIGHT
+    #pragma message "Faking EE_HANDS for right hand"
+    eeprom_update_byte(EECONFIG_HANDEDNESS, 0);
 #endif
 
     eeconfig_init_kb();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->
## Current Issue
No method to set eeprom handedness

## Description
Existing AVR implementations rely on flashing another file to set a particular eeprom byte.

ARM currently looks like it has no way to configure EECONFIG_HANDEDNESS within the emulated eeprom via dfu-util or another tool.

Until a solution is found, this PR emulates the behaviour with the limitation that produces different binaries for the left and right sides.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
