### PR TITLE
Fix issue with RGB Matrix Sleeping

### DIFF
--- a/quantum/rgb_matrix.c
+++ b/quantum/rgb_matrix.c
@@ -436,7 +436,14 @@ void rgb_matrix_init(void) {
 }
 
 void rgb_matrix_set_suspend_state(bool state) {
-  g_suspend_state = state;
+    if (state && RGB_DISABLE_WHEN_USB_SUSPENDED) {
+        /* For some reason, occasionally it renders some of 
+         * the lights still. This is most likely a timing issue
+         * so the simple solution is to clear all of them. 
+         */
+        rgb_matrix_set_color_all(0, 0, 0);
+    }
+    g_suspend_state = state;
 }
 
 void rgb_matrix_toggle(void) {


### PR DESCRIPTION
For some reason, occasionally it renders some of the lights still. This is most likely a timing issue since the matrix render is set up to do batch updates. It just doesn't stop in time, so the simple solution is to clear all of them.

## Types of Changes
- [x] Bugfix

## Checklist
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
