### PR TITLE
Add 16U2, 16U4 and USB646 to mcu_selection.mk

### DIFF
--- a/keyboards/lfkeyboards/lfk78/rules.mk
+++ b/keyboards/lfkeyboards/lfk78/rules.mk
@@ -21,18 +21,6 @@ OPT_DEFS += -DLFK_REV_STRING=\"Rev$(LFK_REV)\"
 # Extra source files for IS3731 lighting
 SRC = TWIlib.c issi.c lighting.c
 
-# Processor frequency.
-F_CPU = 16000000
-
-# Target architecture (see library "Board Types" documentation).
-ARCH = AVR8
-
-# Input clock frequency.
-F_USB = $(F_CPU)
-
-# Interrupt driven control endpoint task(+60)
-OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
-
 BOOTMAGIC_ENABLE = no           # Virtual DIP switch configuration(+1000)
 MOUSEKEY_ENABLE = no            # Mouse keys(+4700)
 EXTRAKEY_ENABLE = yes           # Audio control and System control(+450)

--- a/keyboards/lfkeyboards/lfk87/rules.mk
+++ b/keyboards/lfkeyboards/lfk87/rules.mk
@@ -18,18 +18,6 @@ OPT_DEFS += -DLFK_TKL_REV_$(LFK_REV)
 # Extra source files for IS3731 lighting
 SRC = TWIlib.c issi.c lighting.c
 
-# Processor frequency.
-F_CPU = 16000000
-
-# Target architecture (see library "Board Types" documentation).
-ARCH = AVR8
-
-# Input clock frequency.
-F_USB = $(F_CPU)
-
-# Interrupt driven control endpoint task(+60)
-OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
-
 LAYOUTS = tkl_ansi tkl_iso
 
 # Build Options

--- a/keyboards/lfkeyboards/mini1800/rules.mk
+++ b/keyboards/lfkeyboards/mini1800/rules.mk
@@ -16,42 +16,6 @@ else
 endif
 OPT_DEFS += -DLFK_TKL_REV_$(LFK_REV)
 
-# Processor frequency.
-#     This will define a symbol, F_CPU, in all source code files equal to the
-#     processor frequency in Hz. You can then use this symbol in your source code to
-#     calculate timings. Do NOT tack on a 'UL' at the end, this will be done
-#     automatically to create a 32-bit value in your source code.
-#
-#     This will be an integer division of F_USB below, as it is sourced by
-#     F_USB after it has run through any CPU prescalers. Note that this value
-#     does not *change* the processor frequency - it should merely be updated to
-#     reflect the processor speed set externally so that the code can use accurate
-#     software delays.
-F_CPU = 16000000
-
-
-#
-# LUFA specific
-#
-# Target architecture (see library "Board Types" documentation).
-ARCH = AVR8
-
-# Input clock frequency.
-#     This will define a symbol, F_USB, in all source code files equal to the
-#     input clock frequency (before any prescaling is performed) in Hz. This value may
-#     differ from F_CPU if prescaling is used on the latter, and is required as the
-#     raw input clock is fed directly to the PLL sections of the AVR for high speed
-#     clock generation for the USB and other AVR subsections. Do NOT tack on a 'UL'
-#     at the end, this will be done automatically to create a 32-bit value in your
-#     source code.
-#
-#     If no clock division is performed on the input clock inside the AVR (via the
-#     CPU clock adjust registers or the clock division fuses), this will be equal to F_CPU.
-F_USB = $(F_CPU)
-
-# Interrupt driven control endpoint task(+60)
-OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
-
 # Extra source files for IS3731 lighting
 SRC = TWIlib.c issi.c lighting.c
 

--- a/keyboards/lfkeyboards/smk65/rules.mk
+++ b/keyboards/lfkeyboards/smk65/rules.mk
@@ -3,15 +3,3 @@ OPT_DEFS += -DBOOTLOADER_SIZE=4096
 
 # Extra source files for IS3731 lighting
 SRC = TWIlib.c issi.c lighting.c
-
-# Processor frequency.
-F_CPU = 16000000
-
-# Target architecture (see library "Board Types" documentation).
-ARCH = AVR8
-
-# Input clock frequency.
-F_USB = $(F_CPU)
-
-# Interrupt driven control endpoint task(+60)
-OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT

--- a/keyboards/naked48/rules.mk
+++ b/keyboards/naked48/rules.mk
@@ -3,7 +3,6 @@ QUANTUM_LIB_SRC += serial.c
 # SRC += ssd1306.c
 
 # MCU name
-#MCU = at90usb1287
 MCU = atmega32u4
 
 # Processor frequency.

--- a/keyboards/sixkeyboard/rules.mk
+++ b/keyboards/sixkeyboard/rules.mk
@@ -3,42 +3,6 @@ SRC = matrix.c
 # MCU name
 MCU = atmega16u2
 
-# Processor frequency.
-#     This will define a symbol, F_CPU, in all source code files equal to the
-#     processor frequency in Hz. You can then use this symbol in your source code to
-#     calculate timings. Do NOT tack on a 'UL' at the end, this will be done
-#     automatically to create a 32-bit value in your source code.
-#
-#     This will be an integer division of F_USB below, as it is sourced by
-#     F_USB after it has run through any CPU prescalers. Note that this value
-#     does not *change* the processor frequency - it should merely be updated to
-#     reflect the processor speed set externally so that the code can use accurate
-#     software delays.
-F_CPU = 16000000
-
-
-#
-# LUFA specific
-#
-# Target architecture (see library "Board Types" documentation).
-ARCH = AVR8
-
-# Input clock frequency.
-#     This will define a symbol, F_USB, in all source code files equal to the
-#     input clock frequency (before any prescaling is performed) in Hz. This value may
-#     differ from F_CPU if prescaling is used on the latter, and is required as the
-#     raw input clock is fed directly to the PLL sections of the AVR for high speed
-#     clock generation for the USB and other AVR subsections. Do NOT tack on a 'UL'
-#     at the end, this will be done automatically to create a 32-bit value in your
-#     source code.
-#
-#     If no clock division is performed on the input clock inside the AVR (via the
-#     CPU clock adjust registers or the clock division fuses), this will be equal to F_CPU.
-F_USB = $(F_CPU)
-
-# Interrupt driven control endpoint task(+60)
-OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
-
 
 # Boot Section Size in *bytes*
 #   Teensy halfKay   512

--- a/keyboards/xd004/v1/rules.mk
+++ b/keyboards/xd004/v1/rules.mk
@@ -2,43 +2,6 @@
 MCU = atmega16u2
 
 
-# Processor frequency.
-#     This will define a symbol, F_CPU, in all source code files equal to the
-#     processor frequency in Hz. You can then use this symbol in your source code to
-#     calculate timings. Do NOT tack on a 'UL' at the end, this will be done
-#     automatically to create a 32-bit value in your source code.
-#
-#     This will be an integer division of F_USB below, as it is sourced by
-#     F_USB after it has run through any CPU prescalers. Note that this value
-#     does not *change* the processor frequency - it should merely be updated to
-#     reflect the processor speed set externally so that the code can use accurate
-#     software delays.
-F_CPU = 16000000
-
-
-# LUFA specific
-# Target architecture (see library "Board Types" documentation).
-ARCH = AVR8
-
-
-# Input clock frequency.
-#     This will define a symbol, F_USB, in all source code files equal to the
-#     input clock frequency (before any prescaling is performed) in Hz. This value may
-#     differ from F_CPU if prescaling is used on the latter, and is required as the
-#     raw input clock is fed directly to the PLL sections of the AVR for high speed
-#     clock generation for the USB and other AVR subsections. Do NOT tack on a 'UL'
-#     at the end, this will be done automatically to create a 32-bit value in your
-#     source code.
-#
-#     If no clock division is performed on the input clock inside the AVR (via the
-#     CPU clock adjust registers or the clock division fuses), this will be equal to F_CPU.
-F_USB = $(F_CPU)
-
-
-# Interrupt driven control endpoint task(+60)
-OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
-
-
 # Boot Section Size in *bytes*
 #   Teensy halfKay   512
 #   Teensy++ halfKay 2048

--- a/quantum/mcu_selection.mk
+++ b/quantum/mcu_selection.mk
@@ -36,7 +36,7 @@ ifneq ($(findstring STM32F303, $(MCU)),)
   DFU_SUFFIX_ARGS = -p DF11 -v 0483
 endif
 
-ifneq (,$(filter $(MCU),atmega32u2 atmega32u4 at90usb1286))
+ifneq (,$(filter $(MCU),atmega16u2 atmega32u2 atmega16u4 atmega32u4 at90usb646 at90usb1286))
   # Processor frequency.
   #     This will define a symbol, F_CPU, in all source code files equal to the
   #     processor frequency in Hz. You can then use this symbol in your source code to


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This is pretty much the last of the MCUs currently in the repo, apart from the 328P, and since there's only a handful of them I removed the relevant stuff in their `rules.mk`s too. No 16U4s at all actually, but I threw it in there just in case.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
