### PR TITLE
Decrement EECONFIG magic number

### DIFF
--- a/tmk_core/common/eeconfig.h
+++ b/tmk_core/common/eeconfig.h
@@ -22,7 +22,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <stdbool.h>
 
 
-#define EECONFIG_MAGIC_NUMBER                       (uint16_t)0xFEED
+#ifndef EECONFIG_MAGIC_NUMBER
+#     define EECONFIG_MAGIC_NUMBER                       (uint16_t)0xFEEC
+#endif
 #define EECONFIG_MAGIC_NUMBER_OFF                   (uint16_t)0xFFFF
 
 /* EEPROM parameter address */


### PR DESCRIPTION
This will manually wipe the EEPROM. This is a hacky solution for when new ranges are added or moved around. 

A better (more complicated) solution would be to zero out everything, not just known ranges.  But for now, this is a hacky solution that will work.

## Types of Changes

- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* Fixes #6589

