### PR TITLE
"keymap already exists" no longer prints invalid path

### DIFF
--- a/util/new_keymap.sh
+++ b/util/new_keymap.sh
@@ -26,7 +26,7 @@ if [ ! -d "keyboards/$KB_PATH" ]; then
 fi
 
 if [ -d "keyboards/$KB_PATH/keymaps/$USERNAME" ]; then
-	printf "Error! keyboards/%s/keymaps/%s already exists!\n" "$KB_PATH" "$USERNAME"
+	printf "Error! keyboards/%skeymaps/%s already exists!\n" "$KB_PATH" "$USERNAME"
 	exit 1
 fi
 


### PR DESCRIPTION
When using `./util/new_keymap.sh` with the same keyboard/keymap name twice, an error with the path of the existing keymap. However, this path is invalid, as it includes `/` twice, i.e. `keyboards/planck//keymaps/olaven`. I have the second `/`.

## Description
Removing the additional `/` is the only change. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
