### PR TITLE
Add new 60% Tsangan HHKB layout

### DIFF
--- a/layouts/community/60_tsangan_hhkb/bcat/keymap.c
+++ b/layouts/community/60_tsangan_hhkb/bcat/keymap.c
@@ -1,0 +1,42 @@
+#include QMK_KEYBOARD_H
+
+enum layer {
+    LAYER_DEFAULT,
+    LAYER_FUNCTION,
+    LAYER_ADJUST,
+};
+
+/* Switch to function layer when held. */
+#define LY_FUNC MO(LAYER_FUNCTION)
+
+/* Switch to adjust layer when held; send menu key when tapped. */
+#define LY_ADJST LT(LAYER_ADJUST, KC_APP)
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    /* Default layer: http://www.keyboard-layout-editor.com/#/gists/86b33d75aa6f56d8781ab3d8475f4e77 */
+    [LAYER_DEFAULT] = LAYOUT_60_tsangan_hhkb(
+        KC_ESC,   KC_1,     KC_2,     KC_3,     KC_4,     KC_5,     KC_6,     KC_7,     KC_8,     KC_9,     KC_0,     KC_MINS,  KC_EQL,   KC_BSLS,  KC_GRV,
+        KC_TAB,   KC_Q,     KC_W,     KC_E,     KC_R,     KC_T,     KC_Y,     KC_U,     KC_I,     KC_O,     KC_P,     KC_LBRC,  KC_RBRC,  KC_BSPC,
+        KC_LCTL,  KC_A,     KC_S,     KC_D,     KC_F,     KC_G,     KC_H,     KC_J,     KC_K,     KC_L,     KC_SCLN,  KC_QUOT,  KC_ENT,
+        KC_LSFT,  KC_Z,     KC_X,     KC_C,     KC_V,     KC_B,     KC_N,     KC_M,     KC_COMM,  KC_DOT,   KC_SLSH,  KC_RSFT,  LY_FUNC,
+        KC_LCTL,  KC_LGUI,  KC_LALT,  KC_SPC,   KC_RALT,  LY_ADJST, KC_RCTL
+    ),
+
+    /* Function layer: http://www.keyboard-layout-editor.com/#/gists/f6311fd7e315de781143b80eb040a551 */
+    [LAYER_FUNCTION] = LAYOUT_60_tsangan_hhkb(
+        _______,  KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   KC_INS,   KC_DEL,
+        _______,  KC_MPLY,  KC_VOLU,  KC_MSTP,  _______,  _______,  _______,  _______,  KC_PSCR,  KC_SLCK,  KC_PAUS,  KC_UP,    _______,  _______,
+        KC_CAPS,  KC_MPRV,  KC_VOLD,  KC_MNXT,  _______,  _______,  _______,  _______,  KC_HOME,  KC_PGUP,  KC_LEFT,  KC_RGHT,  _______,
+        _______,  _______,  KC_MUTE,  _______,  _______,  _______,  _______,  _______,  KC_END,   KC_PGDN,  KC_DOWN,  _______,  _______,
+        _______,  _______,  _______,  _______,  _______,  _______,  _______
+    ),
+
+    /* Adjust layer: http://www.keyboard-layout-editor.com/#/gists/65ac939caec878401603bc36290852d4 */
+    [LAYER_ADJUST] = LAYOUT_60_tsangan_hhkb(
+        _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,
+        _______,  _______,  _______,  _______,  _______,  _______,  EEP_RST,  RESET,    _______,  _______,  _______,  RGB_VAI,  _______,  _______,
+        _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  RGB_HUI,  RGB_SAI,  RGB_RMOD, RGB_MOD,  RGB_TOG,
+        _______,  _______,  _______,  _______,  _______,  BL_BRTG,  BL_DEC,   BL_INC,   RGB_HUD,  RGB_SAD,  RGB_VAD,  _______,  _______,
+        _______,  _______,  _______,  _______,  _______,  _______,  _______
+    ),
+};

--- a/layouts/community/60_tsangan_hhkb/bcat/readme.md
+++ b/layouts/community/60_tsangan_hhkb/bcat/readme.md
@@ -1,0 +1,18 @@
+# bcat's 60% Tsangan HHKB layout
+
+This is a normal Tsangan/HHKB (split backspace, split right shift) layout with
+arrow and navigation keys that match a standard HHKB layout, as well as media
+keys centered around the WASD cluster. Additionally, the redundant right Super
+key on the bottom row actives an adjust layer to control RGB underglow.
+
+## Default layer
+
+![Default layer layout](https://i.imgur.com/cBYvCOh.png)
+
+## Function layer
+
+![Function layer layout](https://i.imgur.com/ut9PvhF.png)
+
+## Adjust layer
+
+![Adjust layer layout](https://i.imgur.com/Z6YIxdP.png)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Basically a straightforward port of my existing `60_ansi_split_bs_rshift` layout to a Tsangan bottom row (for use with CanonKeys Instant60 PCB, right now).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [X] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
