### PR TITLE
Mars80 Bug: Physical/Electrical Matrix Mismatch

### DIFF
--- a/keyboards/ft/mars80/mars80.h
+++ b/keyboards/ft/mars80/mars80.h
@@ -37,7 +37,7 @@
 { \
    { k00,   KC_NO, k02, k03, KC_NO, k05, k06,   k07,   k08, k09, KC_NO, KC_NO, KC_NO, k0D   }, \
    { k10,   k11,   k12, k13, k14,   k15, k16,   KC_NO, k18, k19, k1A,   k1B,   k1C,   k1D   }, \
-   { k20,   k21,   k22, k23, k24,   k25, k26,   k27,   k28, k29, k2A,   k2B,   KC_NO, k2D   }, \
+   { k20,   k21,   k22, k23, k24,   k25, k26,   k27,   k28, k29, k2A,   k2B,   k2C,   k2D   }, \
    { k30,   k31,   k32, k33, k34,   k35, k36,   k37,   k38, k39, k3A,   k3B,   k3C,   k3D   }, \
    { k40,   k41,   k42, k43, k44,   k45, k46,   k47,   k48, k49, k4A,   k4B,   k4C,   k4D   }, \
    { KC_NO, k51,   k52, k53, k54,   k55, k56,   k57,   k58, k59, k5A,   k5B,   k5C,   k5D   }, \
@@ -55,7 +55,7 @@
 { \
    { k00,   KC_NO, k02, k03, KC_NO, k05, k06,   k07,   k08, k09, KC_NO, KC_NO, KC_NO, k0D   }, \
    { k10,   k11,   k12, k13, k14,   k15, k16,   KC_NO, k18, k19, k1A,   k1B,   k1C,   k1D   }, \
-   { k20,   k21,   k22, k23, k24,   k25, k26,   k27,   k28, k29, k2A,   k2B,   KC_NO, k2D   }, \
+   { k20,   k21,   k22, k23, k24,   k25, k26,   k27,   k28, k29, k2A,   k2B,   k2C,   k2D   }, \
    { k30,   k31,   k32, k33, k34,   k35, k36,   k37,   k38, k39, k3A,   k3B,   k3C,   k3D   }, \
    { k40,   k41,   k42, k43, k44,   k45, k46,   k47,   k48, k49, k4A,   k4B,   k4C,   KC_NO }, \
    { KC_NO, k51,   k52, k53, k54,   k55, k56,   k57,   k58, k59, k5A,   k5B,   k5C,   k5D   }, \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Fixed a bug in which k2c, while used in the physical matrix was set to KC_NO in the electrical matrix. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
