### PR TITLE
Fix Typo in :flash target for missing bootloader

### DIFF
--- a/tmk_core/avr.mk
+++ b/tmk_core/avr.mk
@@ -347,5 +347,5 @@ else ifeq ($(strip $(BOOTLOADER)), USBasp)
 else ifeq ($(strip $(BOOTLOADER)), bootloadHID)
 	$(call EXEC_BOOTLOADHID)
 else
-	$(PRINT_OK); $(SILENT) || printf "&(MSG_FLASH_BOOTLOADER)"
+	$(PRINT_OK); $(SILENT) || printf "$(MSG_FLASH_BOOTLOADER)"
 endif


### PR DESCRIPTION

Fixes typo in case for "no bootloader set" so that it actually prints the error message. 

## Types of Changes
- [x] Bugfix
