### PR TITLE
[Keyboard] Flip the middle two keys when PCBDOWN is set.

### DIFF
--- a/keyboards/atreus/atreus.h
+++ b/keyboards/atreus/atreus.h
@@ -25,8 +25,23 @@
 #endif
 
 // This a shortcut to help you visually see your layout.
-// The first section contains all of the arguements
-// The second converts the arguments into a two-dimensional array
+// The first section contains all of the arguments.
+// The second converts the arguments into a two-dimensional array.
+// In the PCBDOWN case we need to swap the middle two keys: k35 and k36.
+#if defined(PCBDOWN)
+#define LAYOUT( \
+  k00, k01, k02, k03, k04,           k05, k06, k07, k08, k09, \
+  k10, k11, k12, k13, k14,           k15, k16, k17, k18, k19, \
+  k20, k21, k22, k23, k24,           k25, k26, k27, k28, k29, \
+  k30, k31, k32, k33, k34, k35, k36, k37, k38, k39, k3a, k3b \
+) \
+{ \
+	{ k00, k01, k02, k03, k04, KC_NO, k05, k06, k07, k08, k09 }, \
+	{ k10, k11, k12, k13, k14, KC_NO, k15, k16, k17, k18, k19 }, \
+	{ k20, k21, k22, k23, k24, k36,   k25, k26, k27, k28, k29 }, \
+	{ k30, k31, k32, k33, k34, k35,   k37, k38, k39, k3a, k3b } \
+}
+#else
 #define LAYOUT( \
   k00, k01, k02, k03, k04,           k05, k06, k07, k08, k09, \
   k10, k11, k12, k13, k14,           k15, k16, k17, k18, k19, \
@@ -39,3 +54,4 @@
 	{ k20, k21, k22, k23, k24, k35, k25, k26, k27, k28, k29 }, \
 	{ k30, k31, k32, k33, k34, k36, k37, k38, k39, k3a, k3b } \
 }
+#endif


### PR DESCRIPTION
## Description

I was wondering why the PCBDOWN=yes option had no effect on the two middle keys of my Atreus. As @technomancy, the maker of the keyboard [said](https://github.com/qmk/qmk_firmware/commit/79ae59c155c76394b09fb4286951a6ed5b71d82d#commitcomment-34836401):

> this is because these two keys are distinguished by row, not by column, and PCBDOWN only flips the columns.

This is basically his commit ab80f2fa79c1abdd9eda6e115ebeb724e302f105.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* My question in 79ae59c155c76394b09fb4286951a6ed5b71d82d
