### PR TITLE
Removed prescaler define from avr i2c, as it was impossible to use

### DIFF
--- a/docs/i2c_driver.md
+++ b/docs/i2c_driver.md
@@ -34,7 +34,6 @@ The following defines can be used to configure the I2C master driver.
 |Variable          |Description                                        |Default|
 |------------------|---------------------------------------------------|-------|
 |`F_SCL`           |Clock frequency in Hz                              |400KHz |
-|`Prescaler`       |Divides master clock to aid in I2C clock selection |1      |
 
 AVRs usually have set GPIO which turn into I2C pins, therefore no further configuration is required.
 

--- a/drivers/avr/i2c_master.c
+++ b/drivers/avr/i2c_master.c
@@ -27,8 +27,8 @@
 #ifndef F_SCL
 #  define F_SCL 400000UL  // SCL frequency
 #endif
-#define Prescaler 1
-#define TWBR_val ((((F_CPU / F_SCL) / Prescaler) - 16) / 2)
+
+#define TWBR_val (((F_CPU / F_SCL) - 16) / 2)
 
 void i2c_init(void) {
   TWSR = 0; /* no prescaler */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Looking at moving a keyboard of mine to the generic i2c driver, I noticed [the docs](https://beta.docs.qmk.fm/for-makers-and-modders/i2c_driver#configuration) mentioned that you could tune the frequency using the Prescaler for i2c, something I considered fairly niche, but it got me curious and I looked at the [implementation](https://github.com/qmk/qmk_firmware/blob/master/drivers/avr/i2c_master.c#L30-L34) 

As it turns out, this define isn't guarded by an ifndef, and isn't even used to set the prescaler, just to calculate the TWBR value.

discussing it with @zvecr in the discord it seemed not really useful, and I decided to open this PR removing it. This means it's still fixed at 1 as before, but docs don't mention it. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [X] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [X] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
