### PR TITLE
Support flashing Instant60 from command line

### DIFF
--- a/keyboards/cannonkeys/instant60/rules.mk
+++ b/keyboards/cannonkeys/instant60/rules.mk
@@ -31,6 +31,10 @@ ARMV = 6
 #   <tmk_dir>/tmk_core/tool/chibios/ch-bootloader-jump.patch
 #STM32_BOOTLOADER_ADDRESS = 0x1FFFC800
 
+# Options to pass to dfu-util when flashing
+DFU_ARGS = -d 0483:df11 -a 0 -s 0x08000000:leave
+DFU_SUFFIX_ARGS = -p DF11 -v 0483
+
 # Build Options
 #   comment out to disable the options.
 #


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Support flashing Instant60 from the command line (via :flash or :dfu-util).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [X] New feature
- [ ] Enhancement/optimization
- [X] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

Before this change, flashing from the command line errors out with "More than one DFU capable USB device found! Try `--list' and specify the serial number or disconnect all but one device". (QMK toolbox works fine to flash, but it's annoying to have to use it for just this one board.) After this change, flashing finds the correct DFU device and works fine.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
