### PR TITLE
Fix Redefinition of OLED_TIMEOUT

### DIFF
--- a/drivers/oled/oled_driver.c
+++ b/drivers/oled/oled_driver.c
@@ -83,7 +83,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define CHARGE_PUMP             0x8D
 
 // Misc defines
-#define OLED_TIMEOUT 60000
 #define OLED_BLOCK_COUNT (sizeof(OLED_BLOCK_TYPE) * 8)
 #define OLED_BLOCK_SIZE (OLED_MATRIX_SIZE / OLED_BLOCK_COUNT)
 


### PR DESCRIPTION

## Description

`OLED_TIMEOUT` is defined in `oled_driver.c` and `oled_driver.h`, but not in the same way.   This is redundant and can cause compiler errors if the timeout is disabled or set. 

This removes the define from `oled_driver.c`, fixing the issue. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bugfix

