### PR TITLE
Remove obsolete note about media keys in MacOS

### DIFF
--- a/docs/faq_keymap.md
+++ b/docs/faq_keymap.md
@@ -95,13 +95,6 @@ Even worse, it is not recognized unless the keyboard's VID and PID match that of
 
 See [this issue](https://github.com/qmk/qmk_firmware/issues/2179) for detailed information.
 
-
-## Media Control Keys in Mac OSX
-#### KC_MNXT and KC_MPRV Does Not Work on Mac
-Use `KC_MFFD`(`KC_MEDIA_FAST_FORWARD`) and `KC_MRWD`(`KC_MEDIA_REWIND`) instead of `KC_MNXT` and `KC_MPRV`.
-See https://github.com/tmk/tmk_keyboard/issues/195
-
-
 ## Keys Supported in Mac OSX?
 You can know which keycodes are supported in OSX from this source code.
 

--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -185,8 +185,8 @@ This is a reference only. Each group of keys links to the page documenting their
 |`KC_AUDIO_MUTE`        |`KC_MUTE`                     |Mute                                           |
 |`KC_AUDIO_VOL_UP`      |`KC_VOLU`                     |Volume Up                                      |
 |`KC_AUDIO_VOL_DOWN`    |`KC_VOLD`                     |Volume Down                                    |
-|`KC_MEDIA_NEXT_TRACK`  |`KC_MNXT`                     |Next Track (Windows)                           |
-|`KC_MEDIA_PREV_TRACK`  |`KC_MPRV`                     |Previous Track (Windows)                       |
+|`KC_MEDIA_NEXT_TRACK`  |`KC_MNXT`                     |Next Track                                     |
+|`KC_MEDIA_PREV_TRACK`  |`KC_MPRV`                     |Previous Track                                 |
 |`KC_MEDIA_STOP`        |`KC_MSTP`                     |Stop Track (Windows)                           |
 |`KC_MEDIA_PLAY_PAUSE`  |`KC_MPLY`                     |Play/Pause Track                               |
 |`KC_MEDIA_SELECT`      |`KC_MSEL`                     |Launch Media Player (Windows)                  |

--- a/docs/keycodes_basic.md
+++ b/docs/keycodes_basic.md
@@ -191,7 +191,7 @@ The basic set of keycodes are based on the [HID Keyboard/Keypad Usage Page (0x07
 
 These keycodes are not part of the Keyboard/Keypad usage page. The `SYSTEM_` keycodes are found in the Generic Desktop page, and the rest are located in the Consumer page.
 
-Note that some of these keycodes are OS-dependent.
+Note that some of these keycodes are OS-dependent. For example, on MacOS supports the keycodes `KC_MEDIA_FAST_FORWARD` and `KC_MEDIA_REWIND` in addition to `KC_MEDIA_NEXT_TRACK` and `KC_MEDIA_PREV_TRACK`: those extra keycodes skip within the current track when held, but skip the entire track like the latter keycodes when tapped.
 
 |Key                    |Aliases  |Description                  |
 |-----------------------|---------|-----------------------------|

--- a/docs/keycodes_basic.md
+++ b/docs/keycodes_basic.md
@@ -191,7 +191,7 @@ The basic set of keycodes are based on the [HID Keyboard/Keypad Usage Page (0x07
 
 These keycodes are not part of the Keyboard/Keypad usage page. The `SYSTEM_` keycodes are found in the Generic Desktop page, and the rest are located in the Consumer page.
 
-Windows and macOS use different keycodes for "next track" and "previous track". Make sure you choose the keycode that corresponds to your OS.
+Note that some of these keycodes are OS-dependent.
 
 |Key                    |Aliases  |Description                  |
 |-----------------------|---------|-----------------------------|
@@ -201,8 +201,8 @@ Windows and macOS use different keycodes for "next track" and "previous track". 
 |`KC_AUDIO_MUTE`        |`KC_MUTE`|Mute                         |
 |`KC_AUDIO_VOL_UP`      |`KC_VOLU`|Volume Up                    |
 |`KC_AUDIO_VOL_DOWN`    |`KC_VOLD`|Volume Down                  |
-|`KC_MEDIA_NEXT_TRACK`  |`KC_MNXT`|Next Track (Windows)         |
-|`KC_MEDIA_PREV_TRACK`  |`KC_MPRV`|Previous Track (Windows)     |
+|`KC_MEDIA_NEXT_TRACK`  |`KC_MNXT`|Next Track                   |
+|`KC_MEDIA_PREV_TRACK`  |`KC_MPRV`|Previous Track               |
 |`KC_MEDIA_STOP`        |`KC_MSTP`|Stop Track (Windows)         |
 |`KC_MEDIA_PLAY_PAUSE`  |`KC_MPLY`|Play/Pause Track             |
 |`KC_MEDIA_SELECT`      |`KC_MSEL`|Launch Media Player (Windows)|

--- a/docs/keycodes_basic.md
+++ b/docs/keycodes_basic.md
@@ -191,7 +191,7 @@ The basic set of keycodes are based on the [HID Keyboard/Keypad Usage Page (0x07
 
 These keycodes are not part of the Keyboard/Keypad usage page. The `SYSTEM_` keycodes are found in the Generic Desktop page, and the rest are located in the Consumer page.
 
-Note that some of these keycodes are OS-dependent. For example, on MacOS supports the keycodes `KC_MEDIA_FAST_FORWARD` and `KC_MEDIA_REWIND` in addition to `KC_MEDIA_NEXT_TRACK` and `KC_MEDIA_PREV_TRACK`: those extra keycodes skip within the current track when held, but skip the entire track like the latter keycodes when tapped.
+Note that some of these keycodes may be OS-dependent. For example, MacOS supports the keycodes `KC_MEDIA_FAST_FORWARD` and `KC_MEDIA_REWIND` in addition to `KC_MEDIA_NEXT_TRACK` and `KC_MEDIA_PREV_TRACK`: those extra keycodes skip within the current track when held, but skip the entire track like the latter keycodes when tapped.
 
 |Key                    |Aliases  |Description                  |
 |-----------------------|---------|-----------------------------|

--- a/docs/keycodes_basic.md
+++ b/docs/keycodes_basic.md
@@ -191,7 +191,7 @@ The basic set of keycodes are based on the [HID Keyboard/Keypad Usage Page (0x07
 
 These keycodes are not part of the Keyboard/Keypad usage page. The `SYSTEM_` keycodes are found in the Generic Desktop page, and the rest are located in the Consumer page.
 
-Note that some of these keycodes may be OS-dependent. For example, MacOS supports the keycodes `KC_MEDIA_FAST_FORWARD` and `KC_MEDIA_REWIND` in addition to `KC_MEDIA_NEXT_TRACK` and `KC_MEDIA_PREV_TRACK`: those extra keycodes skip within the current track when held, but skip the entire track like the latter keycodes when tapped.
+?> Some of these keycodes may behave differently depending on the OS. For example, on macOS, the keycodes `KC_MEDIA_FAST_FORWARD`, `KC_MEDIA_REWIND`, `KC_MEDIA_NEXT_TRACK` and `KC_MEDIA_PREV_TRACK` skip within the current track when held, but skip the entire track when tapped.
 
 |Key                    |Aliases  |Description                  |
 |-----------------------|---------|-----------------------------|


### PR DESCRIPTION
KC_MNXT and KC_MPRV work fine on MacOS, so this note is obsolete.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation
