### PR TITLE
Always run `util/travis_compiled_push.sh`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ addons:
     - diffutils
     - dos2unix
     - doxygen
-after_success:
+after_script:
   bash util/travis_compiled_push.sh
 notifications:
   webhooks:


### PR DESCRIPTION
Specifically, the `util/travis_compiled_push.sh` runs a number of cleanup and deployment routines. This includes `dos2unix` that fixes the line endings for sanity's sake.   However, it only runs on successful builds.  That would be fine, except some builds WILL fail (community layouts, yay), which is a problem. 

This should change the behavior to always run the post compile checks. 

However, in the long run, we should break up this script into more parts.

## Types of Changes
- [x] Bugfix
- [x] Core

## Details.

* https://docs.travis-ci.com/user/job-lifecycle/
* https://docs.travis-ci.com/user/uploading-artifacts/