### PR TITLE
Update docker_build.sh: indentation fix, error echo function

### DIFF
--- a/util/docker_build.sh
+++ b/util/docker_build.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 # NOTE: This script uses tabs for indentation
 
+errcho() {
+	echo "$@" >&2
+}
+
 USAGE="Usage: $0 [keyboard[:keymap[:target]]]"
 
 # Check preconditions
@@ -11,11 +15,11 @@ for arg; do
 	fi
 done
 if [ $# -gt 1 ]; then
-	echo "$USAGE" >&2
+	errcho "$USAGE"
 	exit 1
 elif ! command -v docker >/dev/null 2>&1; then
-	echo "Error: docker not found" >&2
-	echo "See https://docs.docker.com/install/#supported-platforms for installation instructions" >&2
+	errcho "Error: docker not found"
+	errcho "See https://docs.docker.com/install/#supported-platforms for installation instructions"
 	exit 2
 fi
 
@@ -29,7 +33,7 @@ else
 	$1
 	EOF
 	if [ -n "$x" ]; then
-		echo "$USAGE" >&2
+		errcho "$USAGE"
 		exit 1
 	fi
 fi
@@ -37,9 +41,9 @@ if [ -n "$target" ]; then
 	if [ "$(uname)" = "Linux" ] || docker-machine active >/dev/null 2>&1; then
 		usb_args="--privileged -v /dev:/dev"
 	else
-		echo "Error: target requires docker-machine to work on your platform" >&2
-		echo "See http://gw.tnode.com/docker/docker-machine-with-usb-support-on-windows-macos" >&2
-		echo "Consider flashing with QMK Toolbox (https://github.com/qmk/qmk_toolbox) instead" >&2
+		errcho "Error: target requires docker-machine to work on your platform"
+		errcho "See http://gw.tnode.com/docker/docker-machine-with-usb-support-on-windows-macos"
+		errcho "Consider flashing with QMK Toolbox (https://github.com/qmk/qmk_toolbox) instead"
 		exit 3
 	fi
 fi

--- a/util/docker_build.sh
+++ b/util/docker_build.sh
@@ -47,7 +47,7 @@ dir=$(pwd -W 2>/dev/null) || dir=$PWD  # Use Windows path if on Windows
 
 # Run container and build firmware
 docker run --rm -it $usb_args \
-    -w /qmk_firmware/ \
+	-w /qmk_firmware \
 	-v "$dir":/qmk_firmware \
 	-e ALT_GET_KEYBOARDS=true \
 	-e SKIP_GIT="$SKIP_GIT" \


### PR DESCRIPTION
Two minor changes to the Docker build script: replace stray space indentation with tab, and add `errcho` function to replace repeated `echo >&2` output redirections.
