### PR TITLE
Banish some more magic numbers

### DIFF
--- a/tmk_core/common/avr/bootloader.c
+++ b/tmk_core/common/avr/bootloader.c
@@ -59,11 +59,6 @@
 uint16_t bootloader_start;
 #endif
 
-#define BOOT_SIZE_256 0b110
-#define BOOT_SIZE_512 0b100
-#define BOOT_SIZE_1024 0b010
-#define BOOT_SIZE_2048 0b000
-
 // compatibility between ATMega8 and ATMega88
 #if !defined(MCUCSR)
 #    if defined(MCUSR)
@@ -86,11 +81,11 @@ void bootloader_jump(void) {
 #if !defined(BOOTLOADER_SIZE)
     uint8_t high_fuse = boot_lock_fuse_bits_get(GET_HIGH_FUSE_BITS);
 
-    if (high_fuse & BOOT_SIZE_256) {
+    if (high_fuse & ~(FUSE_BOOTSZ0 & FUSE_BOOTSZ1)) {
         bootloader_start = (FLASH_SIZE - 512) >> 1;
-    } else if (high_fuse & BOOT_SIZE_512) {
+    } else if (high_fuse & ~(FUSE_BOOTSZ1)) {
         bootloader_start = (FLASH_SIZE - 1024) >> 1;
-    } else if (high_fuse & BOOT_SIZE_1024) {
+    } else if (high_fuse & ~(FUSE_BOOTSZ0)) {
         bootloader_start = (FLASH_SIZE - 2048) >> 1;
     } else {
         bootloader_start = (FLASH_SIZE - 4096) >> 1;

--- a/tmk_core/common/avr/timer.c
+++ b/tmk_core/common/avr/timer.c
@@ -32,33 +32,32 @@ volatile uint32_t timer_count;
  */
 void timer_init(void) {
 #if TIMER_PRESCALER == 1
-    uint8_t prescaler = 0x01;
+    uint8_t prescaler = _BV(CS00);
 #elif TIMER_PRESCALER == 8
-    uint8_t prescaler = 0x02;
+    uint8_t prescaler = _BV(CS01);
 #elif TIMER_PRESCALER == 64
-    uint8_t prescaler = 0x03;
+    uint8_t prescaler = _BV(CS00) | _BV(CS01);
 #elif TIMER_PRESCALER == 256
-    uint8_t prescaler = 0x04;
+    uint8_t prescaler = _BV(CS02);
 #elif TIMER_PRESCALER == 1024
-    uint8_t prescaler = 0x05;
+    uint8_t prescaler = _BV(CS00) | _BV(CS02);
 #else
-#    error "Timer prescaler value is NOT vaild."
+#    error "Timer prescaler value is not valid"
 #endif
 
 #ifndef __AVR_ATmega32A__
     // Timer0 CTC mode
-    TCCR0A = 0x02;
-
+    TCCR0A = _BV(WGM01);
     TCCR0B = prescaler;
 
     OCR0A  = TIMER_RAW_TOP;
-    TIMSK0 = (1 << OCIE0A);
+    TIMSK0 = _BV(OCIE0A);
 #else
     // Timer0 CTC mode
-    TCCR0 = (1 << WGM01) | prescaler;
+    TCCR0 = _BV(WGM01) | prescaler;
 
     OCR0  = TIMER_RAW_TOP;
-    TIMSK = (1 << OCIE0);
+    TIMSK = _BV(OCIE0);
 #endif
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Of note here is that `~(FUSE_BOOTSZ0 & FUSE_BOOTSZ1)` in particular for some reason adds an extra 4 bytes to the final binary. I don't see it as too much of an issue though, as that block of code is only compiled in if `BOOTLOADER_SIZE` is not defined, and pretty much every keyboard does either directly or through `BOOTLOADER`, in rules.mk.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
