### PR TITLE
Adafruit BLE: Set SPI2X bit only when F_CPU is 8MHz

### DIFF
--- a/tmk_core/protocol/lufa/adafruit_ble.cpp
+++ b/tmk_core/protocol/lufa/adafruit_ble.cpp
@@ -151,9 +151,10 @@ static struct SPI_Settings spi;
 // Initialize 4Mhz MSBFIRST MODE0
 void SPI_init(struct SPI_Settings *spi) {
     spi->spcr = _BV(SPE) | _BV(MSTR);
+#if F_CPU == 8000000
+    // For MCUs running at 8MHz (such as Feather 32U4, or 3.3V Pro Micros) we set the SPI doublespeed bit
     spi->spsr = _BV(SPI2X);
-
-    static_assert(SpiBusSpeed == F_CPU / 2, "hard coded at 4Mhz");
+#endif
 
     ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
         // Ensure that SS is OUTPUT High


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Requested by dohmain#0566 on Discord (who reports that this works). Apparently, you can get the [BLE modules](https://www.adafruit.com/product/2633) used in the Feather by themselves. This should allow them to be used by things like Teensys and 5V Pro Micros which have 16MHz crystals.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
