### PR TITLE
Move Bootloader not found message to global variable

### DIFF
--- a/message.mk
+++ b/message.mk
@@ -87,4 +87,4 @@ MSG_PYTHON_MISSING = $(WARN_COLOR)WARNING:$(NO_COLOR)\n \
 	Please run $(BOLD)util/qmk_install.sh$(NO_COLOR) to install all the dependencies QMK requires.\n\n
 MSG_FLASH_BOOTLOADER = $(WARN_COLOR)WARNING:$(NO_COLOR) This board's bootloader is not specified or is not supported by the \":flash\" target at this time.\n\n
 MSG_FLASH_ARCH = $(WARN_COLOR)WARNING:$(NO_COLOR) This board's architecture is not supported by the \":flash\" target at this time.\n\n
-MSG_BOOTLOADER_NOT_FOUND = $(WARN_COLOR)ERROR:$(NO_COLOR) Bootloader not found. Trying again in 5s.\n
+MSG_BOOTLOADER_NOT_FOUND = $(ERROR_COLOR)ERROR:$(NO_COLOR) Bootloader not found. Trying again in 5s.\n

--- a/message.mk
+++ b/message.mk
@@ -87,3 +87,4 @@ MSG_PYTHON_MISSING = $(WARN_COLOR)WARNING:$(NO_COLOR)\n \
 	Please run $(BOLD)util/qmk_install.sh$(NO_COLOR) to install all the dependencies QMK requires.\n\n
 MSG_FLASH_BOOTLOADER = $(WARN_COLOR)WARNING:$(NO_COLOR) This board's bootloader is not specified or is not supported by the \":flash\" target at this time.\n\n
 MSG_FLASH_ARCH = $(WARN_COLOR)WARNING:$(NO_COLOR) This board's architecture is not supported by the \":flash\" target at this time.\n\n
+MSG_BOOTLOADER_NOT_FOUND = $(WARN_COLOR)ERROR:$(NO_COLOR) Bootloader not found. Trying again in 5s.\n

--- a/tmk_core/avr.mk
+++ b/tmk_core/avr.mk
@@ -147,7 +147,7 @@ define EXEC_DFU
 		echo "Flashing '$(1)' for EE_HANDS split keyboard support." ;\
 	fi; \
 	until $(DFU_PROGRAMMER) $(MCU) get bootloader-version; do\
-		echo "Error: Bootloader not found. Trying again in 5s." ;\
+		printf "$(MSG_FLASH_BOOTLOADER)"" ;\
 		sleep 5 ;\
 	done; \
 	if $(DFU_PROGRAMMER) --version 2>&1 | $(GREP) -q 0.7 ; then\
@@ -252,7 +252,7 @@ define EXEC_BOOTLOADHID
 	# bootloadHid executable has no cross platform detect methods
 	# so keep running bootloadHid if the output contains "The specified device was not found"
 	until $(BOOTLOADHID_PROGRAMMER) -r $(BUILD_DIR)/$(TARGET).hex 2>&1 | tee /dev/stderr | grep -v "device was not found"; do\
-		echo "Error: Bootloader not found. Trying again in 5s." ;\
+		printf "$(MSG_FLASH_BOOTLOADER)" ;\
 		sleep 5 ;\
 	done
 endef

--- a/tmk_core/avr.mk
+++ b/tmk_core/avr.mk
@@ -147,7 +147,7 @@ define EXEC_DFU
 		echo "Flashing '$(1)' for EE_HANDS split keyboard support." ;\
 	fi; \
 	until $(DFU_PROGRAMMER) $(MCU) get bootloader-version; do\
-		printf "$(MSG_FLASH_BOOTLOADER)"" ;\
+		printf "$(MSG_FLASH_BOOTLOADER)" ;\
 		sleep 5 ;\
 	done; \
 	if $(DFU_PROGRAMMER) --version 2>&1 | $(GREP) -q 0.7 ; then\

--- a/tmk_core/chibios.mk
+++ b/tmk_core/chibios.mk
@@ -236,7 +236,7 @@ qmk: $(BUILD_DIR)/$(TARGET).bin
 
 define EXEC_DFU_UTIL
 	until $(DFU_UTIL) -l | grep -q "Found DFU"; do\
-		echo "Error: Bootloader not found. Trying again in 5s." ;\
+		printf "$(MSG_FLASH_BOOTLOADER)" ;\
 		sleep 5 ;\
 	done
 	$(DFU_UTIL) $(DFU_ARGS) -D $(BUILD_DIR)/$(TARGET).bin


### PR DESCRIPTION
## Description

We have the same "bootloader not found" message in at least 3 spots.  This replaces them with a variable/thing, so that they can be more easily managed, in the future. 

## Types of Changes
- [x] Enhancement/optimization
