### PR TITLE
Fix Georgi's RZ key in NKRO fake-steno mode

### DIFF
--- a/keyboards/georgi/sten.c
+++ b/keyboards/georgi/sten.c
@@ -253,7 +253,7 @@ uint32_t processFakeSteno(bool lookup) {
 	P( RB,				SEND(KC_K););
 	P( RG,				SEND(KC_L););
 	P( RS,				SEND(KC_SCLN););
-	P( RZ,				SEND(KC_COMM););
+	P( RZ,				SEND(KC_QUOT););
 	P( LNO,				SEND(KC_1););
 	P( RNO,				SEND(KC_1););
 


### PR DESCRIPTION
It was sending a comma keypress, while I believe that the targeted 
stenography software (at least on systems that generally use
US-International keyboard layout) expects a single-quote/apostrophe key.

@germ, the main author of this part of the code, has previously taken a brief
look at this patch in pull request [germ/qmk_firmware#8](https://github.com/germ/qmk_firmware/pull/8#issuecomment-529151901).

## Types of Changes

- [ ] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [X] My code follows the code style of this project. (NOTE: I have not read the project guidelines yet, but my code is consistent with the existing surrounding code)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
