### PR TITLE
Reset source detection

### DIFF
--- a/docs/flashing.md
+++ b/docs/flashing.md
@@ -49,6 +49,20 @@ To generate this bootloader, use the `bootloader` target, eg `make planck/rev4:d
 
 To generate a production-ready .hex file (containing the application and the bootloader), use the `production` target, eg `make planck/rev4:default:production`.
 
+Once you have a .hex file, flash them to your board with AVRDUDE with the following command:
+
+    avrdude -c <your programmer id> -p m32u4 -U flash:w:"your_production.hex":a
+
+Where \<your programmer id\> is the name of your programmer from the list available [here](https://www.nongnu.org/avrdude/user-manual/avrdude_4.html)
+
+You also need to set the correct fuses. If your board uses reset source detection, (CHECK_RESET_SOURCE = yes in your rules.mk), then flash the following fuses:
+
+    avrdude -c <your programmer id> -p m32u4 -U lfuse:w:0xDE:m -U hfuse:w:0x98:m -U efuse:w:0xCB:m
+
+Otherwise, your board has to tie PE2 to GND. This is the case with the sparkfun pro micro. In that case you would need the following fuses:
+
+    avrdude -c <your programmer id> -p m32u4 -U lfuse:w:0xDE:m -U hfuse:w:0x99:m -U efuse:w:0xC3:m
+
 ### DFU commands
 
 There are a number of DFU commands that you can use to flash firmware to a DFU device:

--- a/tmk_core/avr.mk
+++ b/tmk_core/avr.mk
@@ -325,7 +325,7 @@ bootloader:
 	$(eval PROGRAM_SIZE_KB=$(shell n=`expr $(MAX_SIZE) / 1024` && echo $$(($$n)) || echo 0))
 	$(eval BOOT_SECTION_SIZE_KB=$(shell n=`expr  $(BOOTLOADER_SIZE) / 1024` && echo $$(($$n)) || echo 0))
 	$(eval FLASH_SIZE_KB=$(shell n=`expr $(PROGRAM_SIZE_KB) + $(BOOT_SECTION_SIZE_KB)` && echo $$(($$n)) || echo 0))
-	make -C lib/lufa/Bootloaders/DFU/ MCU=$(MCU) ARCH=$(ARCH) F_CPU=$(F_CPU) FLASH_SIZE_KB=$(FLASH_SIZE_KB) BOOT_SECTION_SIZE_KB=$(BOOT_SECTION_SIZE_KB)
+	make -C lib/lufa/Bootloaders/DFU/ MCU=$(MCU) ARCH=$(ARCH) F_CPU=$(F_CPU) FLASH_SIZE_KB=$(FLASH_SIZE_KB) BOOT_SECTION_SIZE_KB=$(BOOT_SECTION_SIZE_KB) CHECK_RESET_SOURCE=$(CHECK_RESET_SOURCE)
 	printf "BootloaderDFU.hex copied to $(TARGET)_bootloader.hex\n"
 	cp lib/lufa/Bootloaders/DFU/BootloaderDFU.hex $(TARGET)_bootloader.hex
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This PR adds an option to allow the keyboard to use a bootloader that checks if the reset source was by pulling the reset pin low, or if it wasn't. This allows the use of PE2 as a normal GPIO pin, as it doesn't have to be pulled low to enter bootloader.

Currently HWBE fuse bit is required. The HWBE fuse bit makes the ATMega32U4 enter the bootloader section if a reset occurs, and PE2 is low. Instead, with this change, one can use PE2 and then set the BOOTRST fuse bit, which makes the ATMega32U4 always boot into the bootloader, and then allowing the bootloader to check the source of the reset, and decide if it should jump straight to the main application, or if it should run the bootloader.

This shouldn't be merged before https://github.com/qmk/lufa/pull/5, as it relies on that. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
