### PR TITLE
Fix boards being skipped during make all

### DIFF
--- a/keyboards/maartenwut/atom47/rules.mk
+++ b/keyboards/maartenwut/atom47/rules.mk
@@ -61,5 +61,5 @@ AUDIO_ENABLE = no
 UNICODE_ENABLE = no 		# Unicode
 BLUETOOTH_ENABLE = no # Enable Bluetooth with the Adafruit EZ-Key HID
 
-DEFAULT_FOLDER = atom47/rev3
+DEFAULT_FOLDER = maartenwut/atom47/rev3
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
When travis decides to make all keyboards, the output currently contains the following:
```console
Making default keymaps for all keyboards
QMK Firmware 0.7.13
Makefile:542: keyboards/adkb96/rev1/rules.mk: No such file or directory
Makefile:542: keyboards/atom47/rev3/rules.mk: No such file or directory
```

This PR allows the boards to be built so that we get the expected coverage.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
