### PR TITLE
Percent Studio Booster: Configurator fix

### DIFF
--- a/keyboards/percent/booster/info.json
+++ b/keyboards/percent/booster/info.json
@@ -5,7 +5,7 @@
     "width": 4,
     "height": 5,
     "layouts": {
-        "LAYOUT": {
+        "LAYOUT_numpad_5x4": {
             "key_count": 17,
             "layout": [
                 {"label":"K00 (D1,C7)", "x":0, "y":0},


### PR DESCRIPTION
## Description

Fixing something I missed in a PR review a while back.

(info.json/keyboard.h macro name mismatch)

## Types of Changes

- [x] Bugfix
- [x] Keyboard (addition or update)

## Issues Fixed or Closed by This PR

![image](https://user-images.githubusercontent.com/18669334/64928086-0a6f2d00-d7c8-11e9-9fbb-e06c8162f5b7.png)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
