### PR TITLE
Fixing wrapping math logic for timer_expired functions

### DIFF
--- a/tmk_core/common/timer.h
+++ b/tmk_core/common/timer.h
@@ -45,9 +45,9 @@ uint16_t timer_elapsed(uint16_t last);
 uint32_t timer_elapsed32(uint32_t last);
 
 // Utility functions to check if a future time has expired & autmatically handle time wrapping if checked / reset frequently (half of max value)
-inline bool timer_expired(uint16_t current, uint16_t last) { return current - last < 0x8000; }
+inline bool timer_expired(uint16_t current, uint16_t future) { return (uint16_t)(current - future) < 0x8000; }
 
-inline bool timer_expired32(uint32_t current, uint32_t future) { return current - future < 0x80000000; }
+inline bool timer_expired32(uint32_t current, uint32_t future) { return (uint32_t)(current - future) < 0x80000000; }
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Description

I did not cast the result back to unsigned for the timer_expired functions to properly handle wrapping. So this bugfix fixes that issue by adding the correct cast. The timer will now properly handle checking against wrapped values easily and correctly.

```
uint16_t whenToTrigger = timer_read() + SOME_FUTURE_TIME;
If (timer_expired(timer_read(), whenToTrigger))
    // Future time has been reached, no worrying about time wrapping!
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
