### PR TITLE
remove accidental characters in default preonic keymap

### DIFF
--- a/keyboards/preonic/keymaps/default/keymap.c
+++ b/keyboards/preonic/keymaps/default/keymap.c
@@ -274,7 +274,7 @@ void dip_switch_update_user(uint8_t index, bool active) {
             } else {
                 muse_mode = false;
             }
-    xs}
+    }
 }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Removes accidental text in default preonic keymap.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #6747

