### PR TITLE
[Keyboard] Fix compile issues for OLKB Default keymaps

### DIFF
--- a/keyboards/planck/keymaps/default/keymap.c
+++ b/keyboards/planck/keymaps/default/keymap.c
@@ -292,7 +292,9 @@ void encoder_update(bool clockwise) {
 void dip_switch_update_user(uint8_t index, bool active) {
     switch (index) {
         case 0: {
+#ifdef AUDIO_ENABLE
             static bool play_sound = false;
+#endif
             if (active) {
 #ifdef AUDIO_ENABLE
                 if (play_sound) { PLAY_SONG(plover_song); }
@@ -304,7 +306,9 @@ void dip_switch_update_user(uint8_t index, bool active) {
 #endif
                 layer_off(_ADJUST);
             }
+#ifdef AUDIO_ENABLE
             play_sound = true;
+#endif
             break;
         }
         case 1:


### PR DESCRIPTION

## Description

This should fix the compile issues that I introduced by not properly testing out the boards. 

This time, they've been more thoroughly tested to ensure that they don't break anything. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bugfix
- [x] Keymap/layout/userspace (addition or update)

## Issues Fixed or Closed by This PR

* Travis, and flagged issue.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
