### PR TITLE
Fix OLKB layout macro aliases

### DIFF
--- a/keyboards/planck/light/light.h
+++ b/keyboards/planck/light/light.h
@@ -61,7 +61,7 @@ LAYOUT_ortho_4x12( \
 )
 
 #define KEYMAP LAYOUT_ortho_4x12
-#define LAYOUT_planck_mit  LAYOUT_planck_1x2uC
+#define LAYOUT_planck_mit LAYOUT_planck_1x2uC
 #define LAYOUT_planck_grid LAYOUT_ortho_4x12
 #define LAYOUT_kc_ortho_4x12 LAYOUT_kc
 #define KC_KEYMAP LAYOUT_kc

--- a/keyboards/planck/rev1/rev1.h
+++ b/keyboards/planck/rev1/rev1.h
@@ -43,7 +43,7 @@ LAYOUT_ortho_4x12( \
 )
 
 #define KEYMAP LAYOUT_ortho_4x12
-#define LAYOUT_planck_mit  LAYOUT_planck_1x2uC
+#define LAYOUT_planck_mit LAYOUT_planck_1x2uC
 #define LAYOUT_planck_grid LAYOUT_ortho_4x12
 #define LAYOUT_kc_ortho_4x12 LAYOUT_kc
 #define KC_KEYMAP LAYOUT_kc

--- a/keyboards/planck/rev2/rev2.h
+++ b/keyboards/planck/rev2/rev2.h
@@ -43,7 +43,7 @@ LAYOUT_ortho_4x12( \
 )
 
 #define KEYMAP LAYOUT_ortho_4x12
-#define LAYOUT_planck_mit  LAYOUT_planck_1x2uC
+#define LAYOUT_planck_mit LAYOUT_planck_1x2uC
 #define LAYOUT_planck_grid LAYOUT_ortho_4x12
 #define LAYOUT_kc_ortho_4x12 LAYOUT_kc
 #define KC_KEYMAP LAYOUT_kc

--- a/keyboards/planck/rev3/rev3.h
+++ b/keyboards/planck/rev3/rev3.h
@@ -43,7 +43,7 @@ LAYOUT_ortho_4x12( \
 )
 
 #define KEYMAP LAYOUT_ortho_4x12
-#define LAYOUT_planck_mit  LAYOUT_planck_1x2uC
+#define LAYOUT_planck_mit LAYOUT_planck_1x2uC
 #define LAYOUT_planck_grid LAYOUT_ortho_4x12
 #define LAYOUT_kc_ortho_4x12 LAYOUT_kc
 #define KC_KEYMAP LAYOUT_kc

--- a/keyboards/planck/rev4/rev4.h
+++ b/keyboards/planck/rev4/rev4.h
@@ -43,7 +43,7 @@ LAYOUT_ortho_4x12( \
 )
 
 #define KEYMAP LAYOUT_ortho_4x12
-#define LAYOUT_planck_mit  LAYOUT_planck_1x2uC
+#define LAYOUT_planck_mit LAYOUT_planck_1x2uC
 #define LAYOUT_planck_grid LAYOUT_ortho_4x12
 #define LAYOUT_kc_ortho_4x12 LAYOUT_kc
 #define KC_KEYMAP LAYOUT_kc

--- a/keyboards/planck/rev5/rev5.h
+++ b/keyboards/planck/rev5/rev5.h
@@ -43,7 +43,7 @@ LAYOUT_ortho_4x12( \
 )
 
 #define KEYMAP LAYOUT_ortho_4x12
-#define LAYOUT_planck_mit  LAYOUT_planck_1x2uC
+#define LAYOUT_planck_mit LAYOUT_planck_1x2uC
 #define LAYOUT_planck_grid LAYOUT_ortho_4x12
 #define LAYOUT_kc_ortho_4x12 LAYOUT_kc
 #define KC_KEYMAP LAYOUT_kc

--- a/keyboards/planck/rev6/rev6.h
+++ b/keyboards/planck/rev6/rev6.h
@@ -119,7 +119,7 @@ LAYOUT_ortho_4x12( \
 )
 
 #define KEYMAP LAYOUT_ortho_4x12
-#define LAYOUT_planck_mit  LAYOUT_planck_1x2uC
+#define LAYOUT_planck_mit LAYOUT_planck_1x2uC
 #define LAYOUT_planck_grid LAYOUT_ortho_4x12
 #define LAYOUT_kc_ortho_4x12 LAYOUT_kc
 #define KC_KEYMAP LAYOUT_kc

--- a/keyboards/preonic/preonic.h
+++ b/keyboards/preonic/preonic.h
@@ -4,7 +4,7 @@
 
 /**************************************************
 ** Include headers specific to keyboard revision **
-***************************************************/
+**************************************************/
 #ifdef KEYBOARD_preonic_rev1
   #include "rev1.h"
 #endif
@@ -20,7 +20,7 @@
 
 /**************************************************
 ** Layout macros aliases common to all revisions **
-
-        Name of Alias      Matrix Name:
-        -----------------  ------------------- ****/
-#define LAYOUT_ortho_5x12  LAYOUT_preonic_grid
+**                                               **
+**      Name of Alias     Matrix Name:           **
+******* ----------------- ------------------- ****/
+#define LAYOUT_ortho_5x12 LAYOUT_preonic_grid


### PR DESCRIPTION
## Description

Apparently QMK API can't parse layout macro aliases if you use more than one space character between the alias name and the macro name, which messes up their discoverability in QMK Configurator.


## Types of Changes

- [x] Bugfix
- [x] Keyboard (addition or update)


## Issues Fixed or Closed by This PR

### http://api.qmk.fm/v1/keyboards/error_log:

```
  {
    "message": "Error: planck/light: Missing layout pp macro for ['planck_mit']",
    "severity": "error"
  },
  {
    "message": "Error: planck/rev1: Missing layout pp macro for ['planck_mit']",
    "severity": "error"
  },
  {
    "message": "Error: planck/rev2: Missing layout pp macro for ['planck_mit']",
    "severity": "error"
  },
  {
    "message": "Error: planck/rev3: Missing layout pp macro for ['planck_mit']",
    "severity": "error"
  },
  {
    "message": "Error: planck/rev4: Missing layout pp macro for ['planck_mit']",
    "severity": "error"
  },
  {
    "message": "Error: planck/rev5: Missing layout pp macro for ['planck_mit']",
    "severity": "error"
  },
  {
    "message": "Error: planck/rev6: Missing layout pp macro for ['planck_mit']",
    "severity": "error"
  },
  {
    "message": "Error: preonic/rev1: Missing layout pp macro for ['ortho_5x12']",
    "severity": "error"
  },
  {
    "message": "Error: preonic/rev2: Missing layout pp macro for ['ortho_5x12']",
    "severity": "error"
  },
  {
    "message": "Error: preonic/rev3: Missing layout pp macro for ['ortho_5x12']",
    "severity": "error"
  },
```


## Checklist

- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
