### PR TITLE
Wrap util.h functions in `extern "C"`

### DIFF
--- a/tmk_core/common/util.h
+++ b/tmk_core/common/util.h
@@ -27,6 +27,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define STR(s) XSTR(s)
 #define XSTR(s) #s
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 uint8_t bitpop(uint8_t bits);
 uint8_t bitpop16(uint16_t bits);
 uint8_t bitpop32(uint32_t bits);
@@ -38,5 +42,9 @@ uint8_t biton32(uint32_t bits);
 uint8_t  bitrev(uint8_t bits);
 uint16_t bitrev16(uint16_t bits);
 uint32_t bitrev32(uint32_t bits);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

`bitrev16()` in particular is [called](https://github.com/qmk/qmk_firmware/blob/37c29961379f39dd60f173b4b82df41a4f80b078/keyboards/converter/usb_usb/custom_matrix.cpp#L248) from the Hasu USB-USB converter's custom matrix, a C++ file. So, it needs this in order to compile with Console enabled.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
