### PR TITLE
1up60hte cleanup + bugfix

### DIFF
--- a/keyboards/1upkeyboards/1up60hte/1up60hte.c
+++ b/keyboards/1upkeyboards/1up60hte/1up60hte.c
@@ -16,3 +16,19 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include "1up60hte.h"
+
+void keyboard_pre_init_kb(void) {
+	// put your keyboard start-up code here
+	// runs once when the firmware starts up
+    setPinOutput(B6);
+    keyboard_pre_init_user();
+}
+
+void led_set_kb(uint8_t usb_led) {
+	if (IS_LED_ON(usb_led, USB_LED_CAPS_LOCK)) {
+		writePinLow(B6);
+	} else {
+		writePinHigh(B6);
+	}
+    led_set_user(usb_led);
+}

--- a/keyboards/1upkeyboards/1up60hte/keymaps/default/keymap.c
+++ b/keyboards/1upkeyboards/1up60hte/keymaps/default/keymap.c
@@ -31,22 +31,3 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 		KC_TRNS, RGB_TOG, RGB_MOD, RGB_HUI, RGB_HUD, RGB_SAI, RGB_SAD, RGB_VAI, KC_END, KC_PGDN,   KC_DOWN, KC_TRNS, KC_TRNS,
 		KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS)
 };
-
-void matrix_init_user(void) {
-  setPinOutput(B6);
-}
-
-void matrix_scan_user(void) {
-}
-
-bool process_record_user(uint16_t keycode, keyrecord_t *record) {
-	return true;
-}
-
-void led_set_user(uint8_t usb_led) {
-	if (IS_LED_ON(usb_led, USB_LED_CAPS_LOCK)) {
-		writePinLow(B6);
-	} else {
-		writePinHigh(B6);
-	}
-}

--- a/keyboards/1upkeyboards/1up60hte/keymaps/hhkb/keymap.c
+++ b/keyboards/1upkeyboards/1up60hte/keymaps/hhkb/keymap.c
@@ -31,22 +31,3 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 		KC_TRNS, RGB_TOG, RGB_MOD, RGB_HUI, RGB_HUD, RGB_SAI, RGB_SAD, RGB_VAI, KC_END, KC_PGDN,   KC_DOWN, KC_TRNS, KC_TRNS,
 		KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS)
 };
-
-void matrix_init_user(void) {
-  setPinOutput(B6);
-}
-
-void matrix_scan_user(void) {
-}
-
-bool process_record_user(uint16_t keycode, keyrecord_t *record) {
-	return true;
-}
-
-void led_set_user(uint8_t usb_led) {
-	if (IS_LED_ON(usb_led, USB_LED_CAPS_LOCK)) {
-		writePinLow(B6);
-	} else {
-		writePinHigh(B6);
-	}
-}

--- a/keyboards/1upkeyboards/1up60hte/readme.md
+++ b/keyboards/1upkeyboards/1up60hte/readme.md
@@ -8,7 +8,6 @@ A 60% PCB with USB C, RGB underglow, backlighting, hotswappable switches, and a 
 
 Keyboard Maintainer: [Bubnick](https://github.com/bubnick)  
 Hardware Supported: 1up60hte 60% PCB  
-
 Hardware Availability: [1upkeyboards.com](https://www.1upkeyboards.com/shop/controllers/1up-rgb-60-pcb-hte/)
 
 Make example for this keyboard (after setting up your build environment):

--- a/keyboards/1upkeyboards/1up60hte/rules.mk
+++ b/keyboards/1upkeyboards/1up60hte/rules.mk
@@ -1,50 +1,12 @@
 # MCU name
 MCU = atmega32u4
 
-# Processor frequency.
-#     This will define a symbol, F_CPU, in all source code files equal to the
-#     processor frequency in Hz. You can then use this symbol in your source code to
-#     calculate timings. Do NOT tack on a 'UL' at the end, this will be done
-#     automatically to create a 32-bit value in your source code.
-#
-#     This will be an integer division of F_USB below, as it is sourced by
-#     F_USB after it has run through any CPU prescalers. Note that this value
-#     does not *change* the processor frequency - it should merely be updated to
-#     reflect the processor speed set externally so that the code can use accurate
-#     software delays.
-F_CPU = 16000000
-
-#
-# LUFA specific
-#
-# Target architecture (see library "Board Types" documentation).
-ARCH = AVR8
-
-# Input clock frequency.
-#     This will define a symbol, F_USB, in all source code files equal to the
-#     input clock frequency (before any prescaling is performed) in Hz. This value may
-#     differ from F_CPU if prescaling is used on the latter, and is required as the
-#     raw input clock is fed directly to the PLL sections of the AVR for high speed
-#     clock generation for the USB and other AVR subsections. Do NOT tack on a 'UL'
-#     at the end, this will be done automatically to create a 32-bit value in your
-#     source code.
-#
-#     If no clock division is performed on the input clock inside the AVR (via the
-#     CPU clock adjust registers or the clock division fuses), this will be equal to F_CPU.
-F_USB = $(F_CPU)
-
-# Interrupt driven control endpoint task(+60)
-OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
-
-
-# Boot Section Size in *bytes*
-OPT_DEFS += -DBOOTLOADER_SIZE=4096
-
+BOOTLOADER = atmel-dfu
 
 # Build Options
 #   comment out to disable the options.
 #
-BOOTMAGIC_ENABLE = yes	# Virtual DIP switch configuration(+1000)
+BOOTMAGIC_ENABLE = lite	# Virtual DIP switch configuration(+1000)
 MOUSEKEY_ENABLE = yes	# Mouse keys(+4700)
 EXTRAKEY_ENABLE = yes	# Audio control and System control(+450)
 CONSOLE_ENABLE = no	# Console for debug(+400)
@@ -54,6 +16,5 @@ NKRO_ENABLE = yes		# USB Nkey Rollover - if this doesn't work, see here: https:/
 BACKLIGHT_ENABLE = yes  # Enable keyboard backlight functionality
 AUDIO_ENABLE = no
 RGBLIGHT_ENABLE = yes
-EXTRAFLAGS += -flto
 
 LAYOUTS = 60_hhkb


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
It was reported to me that using QMK Configurator for the 1up60hte would result in the caps lock LED failing to illuminate. Turns out the functionality was only available on the default and hhkb keymaps. I've moved said code to keyboard level to accomodate this. 

In addition, I set the bootloader to atmel-dfu. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
