### PR TITLE
add 'KEYBOARD_LOCAL_FEATURES_MK' into build_keyboard.mk

### DIFF
--- a/build_keyboard.mk
+++ b/build_keyboard.mk
@@ -343,6 +343,9 @@ VPATH += $(USER_PATH)
 VPATH += $(KEYBOARD_PATHS)
 VPATH += $(COMMON_VPATH)
 
+ifneq ($(strip $(KEYBOARD_LOCAL_FEATURES_MK)),)
+    include $(strip $(KEYBOARD_LOCAL_FEATURES_MK))
+endif
 include common_features.mk
 include $(TMK_PATH)/protocol.mk
 include $(TMK_PATH)/common.mk


### PR DESCRIPTION
## Description

KEYBOARD_LOCAL_FEATURES_MK has the file name of the file that contains
the keyboard post-processing rules.

Post-processing rules convert keyboard-specific shortcuts that represent
combinations of standard options into QMK standard options.

Usage:
```c
// file: keyboards/helix/rev2/rules.mk
KEYBOARD_LOCAL_FEATURES_MK := $(dir $(lastword $(MAKEFILE_LIST)))local_features.mk

HELIX_ROWS = 5              # Helix Rows is 4 or 5
LED_BACK_ENABLE = no        # LED as backlight (Enable WS2812 RGB backlight.)
LED_UNDERGLOW_ENABLE = no   # LED as underglow (Enable WS2812 RGB underlight.)
IOS_DEVICE_ENABLE = no      # connect to IOS device (iPad,iPhone)

```
```c
// file: keyboards/helix/rev2/keymaps/a_keymap/rules.mk
LED_BACK_ENABLE = yes        # LED as backlight (Enable WS2812 RGB backlight.)
```
```c
// file: keyboards/helix/rev2/local_features.mk
ifneq ($(strip $(HELIX_ROWS)), 4)
  ifneq ($(strip $(HELIX_ROWS)), 5)
    $(error HELIX_ROWS = $(strip $(HELIX_ROWS)) is unexpected value)
  endif
endif
OPT_DEFS += -DHELIX_ROWS=$(strip $(HELIX_ROWS))

ifeq ($(strip $(LED_BACK_ENABLE)), yes)
  RGBLIGHT_ENABLE = yes
  OPT_DEFS += -DRGBLED_BACK
else ifeq ($(strip $(LED_UNDERGLOW_ENABLE)), yes)
  RGBLIGHT_ENABLE = yes
endif

ifeq ($(strip $(IOS_DEVICE_ENABLE)), yes)
    OPT_DEFS += -DIOS_DEVICE_ENABLE
endif
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
