### PR TITLE
Fix matrix column 10 and 11 swap in clueboard 60

### DIFF
--- a/keyboards/clueboard/60/60.h
+++ b/keyboards/clueboard/60/60.h
@@ -28,11 +28,11 @@
 /* The fully-featured LAYOUT_all() that has every single key available in the matrix.
  */
 #define LAYOUT_all(\
-    k00, k01, k02, k03, k04, k05, k06, k07, k08, k09, k0a, k0b, k0c, k0d, k0e, \
-     k10,   k11, k12, k13, k14, k15, k16, k17, k18, k19, k1a, k1b, k1c,   k1e, \
-     k20,    k21, k22, k23, k24, k25, k26, k27, k28, k29, k2a, k2b, k2c,  k2e, \
-    k30, k31,  k32, k33, k34, k35, k36, k37, k38, k39, k3a, k3b,     k3c, k3e, \
-    k40,  k41,  k42,               k47,                    k4a, k4b, k4c, k4e \
+     k00, k01, k02, k03, k04, k05, k06, k07, k08, k09, k0b, k0a, k0c, k0d, k0e, \
+     k10, k11, k12, k13, k14, k15, k16, k17, k18, k19, k1b, k1a, k1c, k1e, \
+     k20, k21, k22, k23, k24, k25, k26, k27, k28, k29, k2b, k2a, k2c, k2e, \
+     k30, k31, k32, k33, k34, k35, k36, k37, k38, k39, k3b, k3a, k3c, k3e, \
+     k40, k41, k42,                k47,                     k4a, k4b, k4c, k4e \
 ) { \
     { k00, k01, k02, k03, k04, k05, k06, k07, k08, k09, k0a, k0b, k0c, k0d, k0e, }, \
     { k10, k11, k12, k13, k14, k15, k16, k17, k18, k19, k1a, k1b, k1c, KC_NO, k1e, }, \

--- a/keyboards/clueboard/60/keymaps/yanfali/keymap.c
+++ b/keyboards/clueboard/60/keymaps/yanfali/keymap.c
@@ -46,14 +46,14 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
      * `-----------------------------------------------------------------'
      */
     [_BL] = LAYOUT_all(
-      KC_GESC,KC_1,   KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,   KC_0,   KC_MINS,KC_EQL, KC_GRV, KC_BSPC,\
-      KC_TAB,    KC_Q,   KC_W,   KC_E,   KC_R,   KC_T,   KC_Y,   KC_U,   KC_I,   KC_O,   KC_P,   KC_LBRC,KC_RBRC,KC_BSLS,     \
-      MT(MOD_LCTL, KC_ESC),     KC_A,   KC_S,   KC_D,   KC_F,   KC_G,   KC_H,   KC_J,   KC_K,   KC_L,   KC_SCLN,KC_QUOT,KC_NUHS,  KC_ENT,  \
-      KC_LSFT,  KC_NUBS,KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,   KC_N,   KC_M,   KC_COMM,KC_DOT, KC_SLSH,  KC_RSFT,   MO(_YF), \
-      KC_LCTL,  KC_LALT,  KC_LGUI,                        KC_SPC,                      KC_RALT,  KC_RGUI,  MO(_FL),   KC_RCTL),
+      KC_GRV,                  KC_1,   KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,   KC_0,   KC_MINS,  KC_EQL,   KC_GRV, KC_BSPC,\
+      KC_TAB,                   KC_Q,   KC_W,   KC_E,   KC_R,   KC_T,   KC_Y,   KC_U,   KC_I,   KC_O,   KC_P,   KC_LBRC,  KC_RBRC,  KC_BSLS,     \
+      MT(MOD_LCTL, KC_ESC),     KC_A,   KC_S,   KC_D,   KC_F,   KC_G,   KC_H,   KC_J,   KC_K,   KC_L,   KC_SCLN,KC_QUOT,  KC_NUHS,  KC_ENT,  \
+      KC_LSFT,                  KC_NUBS,KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,   KC_N,   KC_M,   KC_COMM,KC_DOT, KC_SLSH,  KC_RSFT,  MO(_YF), \
+      KC_LCTL,                  KC_LALT,  KC_LGUI,                        KC_SPC,                      KC_RALT,  KC_RGUI, MO(_FL),  KC_RCTL),
     [_FL] = LAYOUT_all(
       KC_ESC, KC_F1,  KC_F2,  KC_F3,  KC_F4,  KC_F5,  KC_F6,  KC_F7,  KC_F8,  KC_F9,  KC_F10, KC_F11, KC_F12, _______,_______,\
-      _______,   _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,     \
+      _______,   _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,RESET,     \
       _______,     _______,MO(_CL),_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,  _______, \
       _______,  _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,  _______,   MO(_YF), \
       _______,_______,_______,                        _______,                     _______,  _______,  MO(_FL),   _______),

--- a/keyboards/clueboard/60/keymaps/yanfali/rules.mk
+++ b/keyboards/clueboard/60/keymaps/yanfali/rules.mk
@@ -1,0 +1,2 @@
+BOOTMAGIC_ENABLE = lite
+COMMAND_ENABLE = yes     # Commands for debug and configuration


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Col 10 and 11 are swapped on the clueboard 60, this isn't reflected in the current matrix.
Personal keymap.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
