### PR TITLE
Use 75_ansi and community layout for xd84

### DIFF
--- a/layouts/community/75_ansi/yanfali/keymap.c
+++ b/layouts/community/75_ansi/yanfali/keymap.c
@@ -1,0 +1,25 @@
+#include QMK_KEYBOARD_H
+
+enum {
+    BASE,
+    FN
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+[BASE] = LAYOUT_75_ansi(\
+        KC_ESC,         KC_F1,   KC_F2,  KC_F3,  KC_F4,  KC_F5,  KC_F6,  KC_F7,  KC_F8,  KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_PSCR, KC_PAUS, KC_DEL,
+        KC_GRV,         KC_1,    KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_HOME,
+        KC_TAB,         KC_Q,    KC_W,   KC_E,   KC_R,   KC_T,   KC_Y,   KC_U,   KC_I,   KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS, KC_PGUP,
+        LCTL_T(KC_ESC), KC_A,    KC_S,   KC_D,   KC_F,   KC_G,   KC_H,   KC_J,   KC_K,   KC_L,    KC_SCLN, KC_QUOT, KC_ENT,  KC_PGDN,
+        KC_LSFT,        KC_Z,    KC_X,   KC_C,   KC_V,   KC_B,   KC_N,   KC_M,   KC_COMM, KC_DOT, KC_SLSH, KC_RSFT,          KC_UP,   KC_END,
+        KC_LCTL,        KC_LALT, KC_LGUI,                KC_SPC,                                  KC_RGUI, KC_NO,   MO(FN),  KC_LEFT, KC_DOWN, KC_RGHT),
+
+[FN] = LAYOUT_75_ansi(\
+        _______,   RGB_M_P,  RGB_M_B, RGB_M_R, RGB_M_SW, RGB_M_SN, RGB_M_K, RGB_M_X, RGB_M_G, _______, _______, _______, _______, _______, _______, _______,
+        _______, _______,  _______, _______, _______,  _______,  _______, _______, _______, _______, _______, _______, _______, _______, _______,
+        BL_TOGG, BL_INC,   BL_DEC,  BL_STEP, _______,  _______,  _______, _______, _______, _______, _______, _______, EEP_RST, RESET,   _______,
+        RGB_TOG, RGB_MOD,  RGB_HUI, RGB_SAI, RGB_VAI,  RGB_SPI,  _______, _______, _______, _______, _______, _______, _______, _______,
+        VLK_TOG, RGB_RMOD, RGB_HUD, RGB_SAD, RGB_VAD,  RGB_SPD,  _______, KC_MUTE, KC_VOLD, KC_VOLU, _______, _______, KC_PGUP, _______,
+        _______, _______,  _______,          _______,            _______, _______, _______, KC_HOME, KC_PGDN, KC_END)
+};

--- a/layouts/community/75_ansi/yanfali/rules.mk
+++ b/layouts/community/75_ansi/yanfali/rules.mk
@@ -1,0 +1,1 @@
+USER_NAME := yanfali

--- a/layouts/community/75_ansi/yanfali/rules.mk
+++ b/layouts/community/75_ansi/yanfali/rules.mk
@@ -1,1 +1,0 @@
-USER_NAME := yanfali

--- a/users/yanfali/config.h
+++ b/users/yanfali/config.h
@@ -8,3 +8,14 @@
 #endif
 
 #endif
+
+#ifdef KEYBOARD_xd84
+
+#undef RGBLED_NUM
+#define RGBLED_NUM 20
+
+#undef RGBLIGHT_ANIMATIONS
+#define RGBLIGHT_EFFECT_RAINBOW_MOOD
+#define RGBLIGHT_EFFECT_RAINBOW_SWIRL
+
+#endif


### PR DESCRIPTION
 - work around flash issues by disabling most of the animations
 - I use a 2 * 1.5u on right side of space bar, so ignore center 1.25 position right of space.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
