### PR TITLE
Minor link fix in Clueboard README

### DIFF
--- a/keyboards/clueboard/readme.md
+++ b/keyboards/clueboard/readme.md
@@ -8,6 +8,6 @@ Clueboard makes fully customizable custom keyboards in a variety of form-factors
   * [`2x1800`](2x1800/): Clueboard 2x1800 PCB
   * [`60`](60/): Clueboard 60% PCB
   * [`66`](66/): Clueboard 66% PCB
-  * [`66_hotswap`](66/): Clueboard 66% USB-C Hotswappable PCB
+  * [`66_hotswap`](66_hotswap/): Clueboard 66% USB-C Hotswappable PCB
   * [`card`](card/): Special Cluecard PCB
 * Hardware Availability: [clueboard.co](https://clueboard.co/)


### PR DESCRIPTION
Small change to fix the README link to go to the actual 66_hotswap instead of just the 66%.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The markdown link in the clueboard readme used to go to the 66 even if you clicked on the hotswap board, this is a small change and it has been corrected here.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
