### PR TITLE
Update LUFA submodule

### DIFF
--- a/docs/ChangeLog/20200229/PR6825.md
+++ b/docs/ChangeLog/20200229/PR6825.md
@@ -1,0 +1,4 @@
+# Update LUFA submodule
+
+* Updates the LUFA submodule to include updates from upstream (abcminiuser/lufa)
+* Includes some cleanup for QMK DFU generation


### PR DESCRIPTION
This updates the LUFA submodule to the latest version, which includes a number of changes, including setting LTO for the bootloader generation. 

~~There are two outstanding PRs for LUFA right now qmk/lufa#5 and qmk/lufa#6 that should be merged into this, as well (and will be updated when they are)~~
This shouldn't wait on these PRs. 

This should also have fewer/no issues with updating, since LUFA is already a submodule. 