### PR TITLE
Update ChibiOS Contrib module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,8 +3,7 @@
 	url = https://github.com/qmk/ChibiOS
 [submodule "lib/chibios-contrib"]
 	path = lib/chibios-contrib
-	url = https://github.com/qmk/ChibiOS-Contrib
-	branch = k-type-fix
+	url = https://github.com/drashna/ChibiOS-Contrib
 [submodule "lib/ugfx"]
 	path = lib/ugfx
 	url = https://github.com/qmk/uGFX


### PR DESCRIPTION
This updates the ChibiOS Contrib submodule to the latest version.  This contains the k type fix, as that was merged upstream. 


This should be reset back to the qmk fork, once it's updated.  
Additionally, we may want to wait on https://github.com/qmk/ChibiOS-Contrib/pull/10 getting merged (to upstream, even). 