### PR TITLE
Fix small hiccup in snake animation

### DIFF
--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -910,6 +910,9 @@ void rgblight_effect_snake(animation_status_t *anim) {
         ledp->b        = 0;
         for (j = 0; j < RGBLIGHT_EFFECT_SNAKE_LENGTH; j++) {
             k = pos + j * increment;
+            if (k > RGBLED_NUM) {
+                k = k % RGBLED_NUM;
+            }
             if (k < 0) {
                 k = k + effect_num_leds;
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

There's an occasional 'lag' frame of animation or two when using the 'snake' RGB animation when the 'snake' reaches the last LEDs. This small fix just corrects that issue (it will no longer try to set LEDs that don't exist).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
