### PR TITLE
Fix qmk doctor 'bytes-like object is required' on linux

### DIFF
--- a/lib/python/qmk/cli/doctor.py
+++ b/lib/python/qmk/cli/doctor.py
@@ -50,7 +50,7 @@ def doctor(cli):
     elif OS == "Linux":
         cli.log.info("Detected {fg_cyan}Linux.")
         if shutil.which('systemctl'):
-            mm_check = subprocess.run(['systemctl', 'list-unit-files'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=10)
+            mm_check = subprocess.run(['systemctl', 'list-unit-files'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=10, universal_newlines=True)
             if mm_check.returncode == 0:
                 mm = True
                 for line in mm_check.stdout.split('\n'):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This fixes the following issue related to encoding on linux systems. The
solution is to use bytes formated new line character regardless of the
encoding.

<class 'TypeError'>
☒ a bytes-like object is required, not 'str'
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/milc.py", line 564, in __call__
    return self.__call__()
  File "/usr/local/lib/python3.7/site-packages/milc.py", line 569, in __call__
    return self._entrypoint(self)
  File "$HOME/qmk_firmware/lib/python/qmk/cli/doctor.py", line 56, in doctor
    for line in mm_check.stdout.split('\n'):
TypeError: a bytes-like object is required, not 'str'



## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

No opened issue.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).