### PR TITLE
Add QMK Compile Context Sensitivity

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -142,7 +142,7 @@ $ qmk compile -kb dz60
 ...
 ```
 
-## `qmk cformat`
+## `qmk flash`
 
 This command is similar to `qmk compile`, but can also target a bootloader. The bootloader is optional, and is set to `:flash` by default.
 To specify a different bootloader, use `-bl <bootloader>`. Visit <https://docs.qmk.fm/#/flashing>

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -104,6 +104,7 @@ qmk compile
 
 **Example**:
 ```
+$ qmk config compile.keymap=default
 $ cd ~/qmk_firmware/keyboards/planck/rev6
 $ qmk compile
 Ψ Compiling keymap with make planck/rev6:default

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -81,7 +81,7 @@ qmk cformat [file1] [file2] [...] [fileN]
 
 ## `qmk compile`
 
-This command allows you to compile firmware from any directory. You can compile JSON exports from <https://config.qmk.fm> or compile keymaps in the repo.
+This command allows you to compile firmware from any directory. You can compile JSON exports from <https://config.qmk.fm>, compile keymaps in the repo, or compile the keyboard in the current working directory.
 
 **Usage for Configurator Exports**:
 
@@ -95,7 +95,30 @@ qmk compile <configuratorExport.json>
 qmk compile -kb <keyboard_name> -km <keymap_name>
 ```
 
-## `qmk flash`
+**Usage in Keyboard Directory**:  
+
+Must be in keyboard directory with a default keymap, or supply one with `--keymap <keymap_name>`
+```
+qmk compile
+```
+
+**Example**:
+```
+$ cd ~/qmk_firmware/keyboards/planck/rev6
+$ qmk compile
+Ψ Compiling keymap with make planck/rev6:default
+...
+```
+or
+
+```
+$ cd ~/qmk_firmware/keyboards/clueboard/66/rev4 
+$ qmk compile --keymap 66_iso
+Ψ Compiling keymap with make clueboard/66/rev4:66_iso
+...
+```
+
+## `qmk cformat`
 
 This command is similar to `qmk compile`, but can also target a bootloader. The bootloader is optional, and is set to `:flash` by default.
 To specify a different bootloader, use `-bl <bootloader>`. Visit <https://docs.qmk.fm/#/flashing>

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -113,7 +113,7 @@ or with optional keymap argument
 
 ```
 $ cd ~/qmk_firmware/keyboards/clueboard/66/rev4 
-$ qmk compile --km 66_iso
+$ qmk compile -km 66_iso
 Ψ Compiling keymap with make clueboard/66/rev4:66_iso
 ...
 ```
@@ -130,13 +130,13 @@ $ qmk compile
 
 Must be under `qmk_firmware/layouts/`, and in a keymap folder.
 ```
-qmk compile --kb <keyboard_name>
+qmk compile -kb <keyboard_name>
 ```
 
 **Example**:
 ```
 $ cd ~/qmk_firmware/layouts/community/60_ansi/mechmerlin-ansi
-$ qmk compile --kb dz60
+$ qmk compile -kb dz60
 Ψ Compiling keymap with make dz60:mechmerlin-ansi
 ...
 ```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -97,7 +97,7 @@ qmk compile -kb <keyboard_name> -km <keymap_name>
 
 **Usage in Keyboard Directory**:  
 
-Must be in keyboard directory with a default keymap, or supply one with `--keymap <keymap_name>`
+Must be in keyboard directory with a default keymap, or in keymap directory for keyboard, or supply one with `--keymap <keymap_name>`
 ```
 qmk compile
 ```
@@ -109,12 +109,35 @@ $ qmk compile
 Ψ Compiling keymap with make planck/rev6:default
 ...
 ```
-or
+or with optional keymap argument
 
 ```
 $ cd ~/qmk_firmware/keyboards/clueboard/66/rev4 
 $ qmk compile --keymap 66_iso
 Ψ Compiling keymap with make clueboard/66/rev4:66_iso
+...
+```
+or in keymap directory
+
+```
+$ cd ~/qmk_firmware/keyboards/gh60/satan/keymaps/colemak
+$ qmk compile
+Ψ Compiling keymap with make make gh60/satan:colemak
+...
+```
+
+**Usage in Layout Directory**:  
+
+Must be under `qmk_firmware/layouts/`, and in a keymap folder.
+```
+qmk compile --keyboard <keyboard_name>
+```
+
+**Example**:
+```
+$ cd ~/qmk_firmware/layouts/community/60_ansi/mechmerlin-ansi
+$ qmk compile --keyboard dz60
+Ψ Compiling keymap with make dz60:mechmerlin-ansi
 ...
 ```
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -113,7 +113,7 @@ or with optional keymap argument
 
 ```
 $ cd ~/qmk_firmware/keyboards/clueboard/66/rev4 
-$ qmk compile --keymap 66_iso
+$ qmk compile --km 66_iso
 Ψ Compiling keymap with make clueboard/66/rev4:66_iso
 ...
 ```
@@ -130,13 +130,13 @@ $ qmk compile
 
 Must be under `qmk_firmware/layouts/`, and in a keymap folder.
 ```
-qmk compile --keyboard <keyboard_name>
+qmk compile --kb <keyboard_name>
 ```
 
 **Example**:
 ```
 $ cd ~/qmk_firmware/layouts/community/60_ansi/mechmerlin-ansi
-$ qmk compile --keyboard dz60
+$ qmk compile --kb dz60
 Ψ Compiling keymap with make dz60:mechmerlin-ansi
 ...
 ```

--- a/lib/python/qmk/cli/compile.py
+++ b/lib/python/qmk/cli/compile.py
@@ -64,11 +64,10 @@ def compile(cli):
             in_layout = True
 
     # If user keyboard/keymap or compile keyboard/keymap are supplied, assign those
-    if cli.config.compile.keyboard or cli.config.user.keyboard:
+    if cli.config.compile.keyboard:
         user_keyboard = cli.config.user.keyboard if cli.config.user.keyboard else cli.config.compile.keyboard
-    if cli.config.compile.keymap or cli.config.user.keymap:
-        if not in_layout:
-            user_keymap = cli.config.user.keymap if cli.config.user.keymap else cli.config.compile.keymap
+    if cli.config.compile.keymap and not in_layout:
+        user_keymap = cli.config.user.keymap if cli.config.user.keymap else cli.config.compile.keymap
 
     if cli.args.filename:
         # Parse the configurator json

--- a/lib/python/qmk/cli/compile.py
+++ b/lib/python/qmk/cli/compile.py
@@ -65,9 +65,9 @@ def compile(cli):
 
     # If user keyboard/keymap or compile keyboard/keymap are supplied, assign those
     if cli.config.compile.keyboard:
-        user_keyboard = cli.config.user.keyboard if cli.config.user.keyboard else cli.config.compile.keyboard
+        user_keyboard = cli.config.compile.keyboard
     if cli.config.compile.keymap and not in_layout:
-        user_keymap = cli.config.user.keymap if cli.config.user.keymap else cli.config.compile.keymap
+        user_keymap = cli.config.compile.keymap
 
     if cli.args.filename:
         # Parse the configurator json

--- a/lib/python/qmk/cli/compile.py
+++ b/lib/python/qmk/cli/compile.py
@@ -30,22 +30,20 @@ def compile(cli):
 
     """
     # Set CWD as directory command was issued from
-    cwd = os.path.normpath(os.path.join(os.environ['ORIG_CWD']))
-
+    cwd = os.environ['ORIG_CWD']
+    qmk_path = os.getcwd()
     # Initialize boolean to check for being in a keyboard directory and initialize keyboard string
     in_keyboard = False
     keyboard = ""
 
-    # Loop through three levels up to check for keyboards root directory
-    for index, directory in enumerate(['..', '../..', '../../..']):
-        above_basename = os.path.basename(os.path.normpath(os.path.join(cwd, directory)))
+    # Set path for '/keyboards/' directory
+    keyboards_path = os.path.join(qmk_path , "keyboards")
 
-        # If the folder above is "/keyboards/"
-        if above_basename == "keyboards":
-            # Get back the full keyboard name
-            keyboard += str(Path(cwd).relative_to(os.path.join(os.getcwd() , "keyboards")))
-            in_keyboard = True
-            break
+    # if below 'keyboards' and not in 'keyboards', get current keyboard name
+    if cwd.startswith(keyboards_path):
+        if os.path.basename(cwd) != "keyboards":
+            keyboard = str(cwd[len(keyboards_path):])[1:]
+            in_keyboard= True
 
     if cli.args.filename:
         # Parse the configurator json

--- a/lib/python/qmk/cli/compile.py
+++ b/lib/python/qmk/cli/compile.py
@@ -90,7 +90,6 @@ def compile(cli):
     elif in_keyboard:
         keyboard = user_keyboard if user_keyboard else keyboard
         keymap = user_keymap if user_keymap else keymap
-        
         if not os.path.exists(os.path.join(keyboards_path, keyboard, "rules.mk")):
             cli.log.error('This directory does not contain a rules.mk file. Change directory or supply --keyboard with optional --keymap')
             return False

--- a/lib/python/qmk/cli/compile.py
+++ b/lib/python/qmk/cli/compile.py
@@ -34,11 +34,11 @@ def compile(cli):
     current_folder = os.path.basename(cwd)
     # Initialize boolean to check for being in a keyboard directory and initialize keyboard string
     in_keyboard = False
+    in_layout = False
     keyboard = ""
     keymap = "default"
     user_keymap = ""
     user_keyboard = ""
-
 
     # Set path for '/keyboards/' directory
     keyboards_path = os.path.join(qmk_path , "keyboards")
@@ -109,6 +109,9 @@ def compile(cli):
         if user_keyboard:
             keymap = current_folder
             command = ['make', ':'.join((user_keyboard, keymap))]
+        else:
+            cli.log.error('You must supply a keyboard to compile a layout keymap. Set one with `qmk config` or supply `--keyboard` ')
+            return False
 
 
     else:

--- a/lib/python/qmk/cli/compile.py
+++ b/lib/python/qmk/cli/compile.py
@@ -98,15 +98,9 @@ def compile(cli):
         if user_keymap:
             command = ['make', ':'.join((keyboard, user_keymap))]
 
-        # Check if keyboard has default layout
-        elif os.path.exists(keymap_path + "/default"):
-
-            # Generate the make command for the current directories keyboard
-            command = ['make', ':'.join((keyboard, keymap))]
-
         else:
             # If no default keymap exists and none provided
-            cli.log.error('This directory does not contain a default keymap. Set one with `qmk config` or supply `--keymap` ')
+            cli.log.error('This directory does not contain a keymap. Set one with `qmk config` or supply `--keymap` ')
             return False
 
     elif in_layout:

--- a/lib/python/qmk/cli/compile.py
+++ b/lib/python/qmk/cli/compile.py
@@ -43,7 +43,7 @@ def compile(cli):
         # If the folder above is "/keyboards/"
         if above_basename == "keyboards":
             # Get back the full keyboard name
-            keyboard += str(Path(cwd).relative_to(os.getcwd() + "/keyboards"))
+            keyboard += str(Path(cwd).relative_to(os.path.join(os.getcwd() , "keyboards")))
             in_keyboard = True
             break
 

--- a/lib/python/qmk/cli/compile.py
+++ b/lib/python/qmk/cli/compile.py
@@ -90,11 +90,14 @@ def compile(cli):
     elif in_keyboard:
         keyboard = user_keyboard if user_keyboard else keyboard
         keymap = user_keymap if user_keymap else keymap
+
         if not os.path.exists(os.path.join(keyboards_path, keyboard, "rules.mk")):
             cli.log.error('This directory does not contain a rules.mk file. Change directory or supply --keyboard with optional --keymap')
             return False
+
         # Get path for keyboard directory
         keymap_path = qmk.path.keymap(keyboard)
+
         # Check for global keymap config first
         if keymap:
             command = create_make_command(keyboard, keymap)

--- a/lib/python/qmk/cli/compile.py
+++ b/lib/python/qmk/cli/compile.py
@@ -41,10 +41,11 @@ def compile(cli):
     keyboards_path = os.path.join(qmk_path , "keyboards")
     layouts_path = os.path.join(qmk_path, "layouts")
 
-    # If below 'keyboards' and not in 'keyboards', get current keyboard name
+    # If below 'keyboards' and not in 'keyboards' or 'keymaps', get current keyboard name
     if cwd.startswith(keyboards_path):
         if current_folder != "keyboards" and current_folder != "keymaps":
             if os.path.basename(os.path.abspath(os.path.join(cwd, ".."))) == "keymaps":
+                # If in a keymap folder, set relative path, get everything before /keymaps, and the keymap name
                 relative_path = cwd[len(keyboards_path):][1:]
                 keyboard = str(relative_path).split("/keymaps", 1)[0]
                 keymap = str(relative_path.rsplit("/", 1)[-1])

--- a/lib/python/qmk/cli/compile.py
+++ b/lib/python/qmk/cli/compile.py
@@ -42,9 +42,8 @@ def compile(cli):
 
         # If the folder above is "/keyboards/"
         if above_basename == "keyboards":
-            # Set the full path name and get back the full keyboard name
-            path = Path(os.path.normpath(os.path.join(cwd, directory[index-1])))
-            keyboard += str(path.relative_to(os.getcwd() + "/keyboards"))
+            # Get back the full keyboard name
+            keyboard += str(Path(cwd).relative_to(os.getcwd() + "/keyboards"))
             in_keyboard = True
             break
 

--- a/lib/python/qmk/cli/compile.py
+++ b/lib/python/qmk/cli/compile.py
@@ -4,7 +4,6 @@ You can compile a keymap already in the repo or using a QMK Configurator export.
 """
 import subprocess
 from argparse import FileType
-from pathlib import Path
 
 from milc import cli
 from qmk.commands import create_make_command
@@ -32,18 +31,31 @@ def compile(cli):
     # Set CWD as directory command was issued from
     cwd = os.environ['ORIG_CWD']
     qmk_path = os.getcwd()
+    current_folder = os.path.basename(cwd)
     # Initialize boolean to check for being in a keyboard directory and initialize keyboard string
     in_keyboard = False
     keyboard = ""
+    keymap = "default"
 
     # Set path for '/keyboards/' directory
     keyboards_path = os.path.join(qmk_path , "keyboards")
+    layouts_path = os.path.join(qmk_path, "layouts")
 
     # if below 'keyboards' and not in 'keyboards', get current keyboard name
     if cwd.startswith(keyboards_path):
-        if os.path.basename(cwd) != "keyboards":
-            keyboard = str(cwd[len(keyboards_path):])[1:]
+        if current_folder != "keyboards" and current_folder != "keymaps":
+            if os.path.basename(os.path.abspath(os.path.join(cwd, ".."))) == "keymaps":
+                relative_path = cwd[len(keyboards_path):][1:]
+                keyboard = str(relative_path).split("/keymaps", 1)[0]
+                keymap = str(relative_path.rsplit("/", 1)[-1])
+            else:
+                keyboard = str(cwd[len(keyboards_path):])[1:]
+
             in_keyboard= True
+    if cwd.startswith(layouts_path):
+        if os.path.basename(cwd != "layouts"):
+            layout = str(cwd[len(keyboards_path):])[1:]
+            in_layout=True
 
     if cli.args.filename:
         # Parse the configurator json
@@ -72,7 +84,7 @@ def compile(cli):
 
         # Check if keyboard has default layout
         elif os.path.exists(keymap_path + "/default"):
-            keymap = "default"
+            
             # Generate the make command for the current directories keyboard
             command = ['make', ':'.join((keyboard, keymap))]
 

--- a/lib/python/qmk/cli/compile.py
+++ b/lib/python/qmk/cli/compile.py
@@ -89,14 +89,15 @@ def compile(cli):
 
     elif in_keyboard:
         keyboard = user_keyboard if user_keyboard else keyboard
+        keymap = user_keymap if user_keymap else keymap
         if not os.path.exists(os.path.join(keyboards_path, keyboard, "rules.mk")):
             cli.log.error('This directory does not contain a rules.mk file. Change directory or supply --keyboard with optional --keymap')
             return False
         # Get path for keyboard directory
         keymap_path = qmk.path.keymap(keyboard)
         # Check for global keymap config first
-        if user_keymap:
-            command = ['make', ':'.join((keyboard, user_keymap))]
+        if keymap:
+            command = ['make', ':'.join((keyboard, keymap))]
 
         else:
             # If no default keymap exists and none provided

--- a/lib/python/qmk/cli/compile.py
+++ b/lib/python/qmk/cli/compile.py
@@ -54,7 +54,6 @@ def compile(cli):
                 keymap = str(relative_path.rsplit("/", 1)[-1])
             else:
                 keyboard = str(cwd[len(keyboards_path):])[1:]
-                
 
             in_keyboard= True
 
@@ -85,7 +84,7 @@ def compile(cli):
 
     elif user_keyboard and user_keymap:
         # Generate the make command for a specific keyboard/keymap.
-        command = ['make', ':'.join((keyboard, keymap))]
+        command = ['make', ':'.join((user_keyboard, user_keymap))]
     
     elif in_keyboard: 
         keyboard = user_keyboard if user_keyboard else keyboard

--- a/lib/python/qmk/cli/compile.py
+++ b/lib/python/qmk/cli/compile.py
@@ -41,7 +41,7 @@ def compile(cli):
     keyboards_path = os.path.join(qmk_path , "keyboards")
     layouts_path = os.path.join(qmk_path, "layouts")
 
-    # if below 'keyboards' and not in 'keyboards', get current keyboard name
+    # If below 'keyboards' and not in 'keyboards', get current keyboard name
     if cwd.startswith(keyboards_path):
         if current_folder != "keyboards" and current_folder != "keymaps":
             if os.path.basename(os.path.abspath(os.path.join(cwd, ".."))) == "keymaps":
@@ -52,8 +52,10 @@ def compile(cli):
                 keyboard = str(cwd[len(keyboards_path):])[1:]
 
             in_keyboard= True
+
+    # If in layouts dir
     if cwd.startswith(layouts_path):
-        if os.path.basename(cwd != "layouts"):
+        if current_folder != "layouts":
             layout = str(cwd[len(keyboards_path):])[1:]
             in_layout=True
 
@@ -92,8 +94,15 @@ def compile(cli):
             # If no default keymap exists and none provided
             cli.log.error('This directory does not contain a default keymap. Set one with `qmk config` or supply `--keymap` ')
             return False
+
+    elif in_layout:
+        if cli.config.compile.keyboard:
+            keymap = current_folder
+            command = ['make', ':'.join((cli.config.compile.keyboard, keymap))]
+
+
     else:
-        cli.log.error('You must supply a configurator export or both `--keyboard` and `--keymap`, or be in the root directory for a keyboard.')
+        cli.log.error('You must supply a configurator export or both `--keyboard` and `--keymap`, or be a directory for a keyboard or keymap.')
         return False
 
     cli.log.info('Compiling keymap with {fg_cyan}%s\n\n', ' '.join(command))

--- a/lib/python/qmk/cli/compile.py
+++ b/lib/python/qmk/cli/compile.py
@@ -86,7 +86,7 @@ def compile(cli):
 
     elif user_keyboard and user_keymap:
         # Generate the make command for a specific keyboard/keymap.
-        command = ['make', ':'.join((user_keyboard, user_keymap))]
+        command = create_make_command(user_keyboard, user_keymap)
 
     elif in_keyboard:
         keyboard = user_keyboard if user_keyboard else keyboard
@@ -99,7 +99,7 @@ def compile(cli):
         keymap_path = qmk.path.keymap(keyboard)
         # Check for global keymap config first
         if keymap:
-            command = ['make', ':'.join((keyboard, keymap))]
+            command = create_make_command(keyboard, keymap)
 
         else:
             # If no default keymap exists and none provided
@@ -109,8 +109,7 @@ def compile(cli):
     elif in_layout:
         if user_keyboard:
             keymap = current_folder
-            print(keymap)
-            command = ['make', ':'.join((user_keyboard, keymap))]
+            command = create_make_command(user_keyboard, keymap)
         else:
             cli.log.error('You must supply a keyboard to compile a layout keymap. Set one with `qmk config` or supply `--keyboard` ')
             return False

--- a/lib/python/qmk/cli/compile.py
+++ b/lib/python/qmk/cli/compile.py
@@ -54,6 +54,7 @@ def compile(cli):
                 keymap = str(relative_path.rsplit("/", 1)[-1])
             else:
                 keyboard = str(cwd[len(keyboards_path):])[1:]
+                
 
             in_keyboard= True
 
@@ -88,6 +89,9 @@ def compile(cli):
     
     elif in_keyboard: 
         keyboard = user_keyboard if user_keyboard else keyboard
+        if not os.path.exists(os.path.join(keyboards_path, keyboard, "rules.mk")):
+            cli.log.error('This directory does not contain a rules.mk file. Change directory or supply --keyboard with optional --keymap')
+            return False
         # Get path for keyboard directory
         keymap_path = qmk.path.keymap(keyboard) 
         # Check for global keymap config first

--- a/lib/python/qmk/cli/compile.py
+++ b/lib/python/qmk/cli/compile.py
@@ -3,6 +3,7 @@
 You can compile a keymap already in the repo or using a QMK Configurator export.
 """
 import subprocess
+import os
 from argparse import FileType
 
 from milc import cli

--- a/lib/python/qmk/cli/compile.py
+++ b/lib/python/qmk/cli/compile.py
@@ -29,21 +29,24 @@ def compile(cli):
     If --keyboard and --keymap are provided this command will build a firmware based on that.
 
     """
-    #set string to define CWD
+    # Set CWD as directory command was issued from
     cwd = os.path.normpath(os.path.join(os.environ['ORIG_CWD']))
+
+    # Initialize boolean to check for being in a keyboard directory and initialize keyboard string
     in_keyboard = False
     keyboard = ""
+
+    # Loop through three levels up to check for keyboards root directory
     for index, directory in enumerate(['..', '../..', '../../..']):
         above_basename = os.path.basename(os.path.normpath(os.path.join(cwd, directory)))
+
+        # If the folder above is "/keyboards/"
         if above_basename == "keyboards":
+            # Set the full path name and get back the full keyboard name
             path = Path(os.path.normpath(os.path.join(cwd, directory[index-1])))
-            if path.parts[-2] == "keyboards":
-                keyboard = path.parts[-1]
-            elif path.parts[-3] == "keyboards":
-                keyboard = "/".join(path.parts[-2:])
-            else:
-                keyboard = "/".join(path.parts[-3:])
+            keyboard += str(path.relative_to(os.getcwd() + "/keyboards"))
             in_keyboard = True
+            break
 
     if cli.args.filename:
         # Parse the configurator json

--- a/lib/python/qmk/cli/compile.py
+++ b/lib/python/qmk/cli/compile.py
@@ -42,7 +42,7 @@ def compile(cli):
     user_keyboard = ""
 
     # Set path for '/keyboards/' directory
-    keyboards_path = os.path.join(qmk_path , "keyboards")
+    keyboards_path = os.path.join(qmk_path, "keyboards")
     layouts_path = os.path.join(qmk_path, "layouts")
 
     # If below 'keyboards' and not in 'keyboards' or 'keymaps', get current keyboard name
@@ -56,20 +56,19 @@ def compile(cli):
             else:
                 keyboard = str(cwd[len(keyboards_path):])[1:]
 
-            in_keyboard= True
+            in_keyboard = True
 
     # If in layouts dir
     if cwd.startswith(layouts_path):
         if current_folder != "layouts":
-            layout = str(cwd[len(layouts_path):])[1:]
-            in_layout=True
+            in_layout = True
 
     # If user keyboard/keymap or compile keyboard/keymap are supplied, assign those
     if cli.config.compile.keyboard or cli.config.user.keyboard:
         user_keyboard = cli.config.user.keyboard if cli.config.user.keyboard else cli.config.compile.keyboard
     if cli.config.compile.keymap or cli.config.user.keymap:
         if not in_layout:
-            user_keymap = cli.config.user.keymap if cli.config.user.keymap else cli.config.compile.keymap 
+            user_keymap = cli.config.user.keymap if cli.config.user.keymap else cli.config.compile.keymap
 
     if cli.args.filename:
         # Parse the configurator json
@@ -113,7 +112,6 @@ def compile(cli):
         else:
             cli.log.error('You must supply a keyboard to compile a layout keymap. Set one with `qmk config` or supply `--keyboard` ')
             return False
-
 
     else:
         cli.log.error('You must supply a configurator export, both `--keyboard` and `--keymap`, or be in a directory for a keyboard or keymap.')

--- a/lib/python/qmk/cli/compile.py
+++ b/lib/python/qmk/cli/compile.py
@@ -28,6 +28,10 @@ def compile(cli):
     If --keyboard and --keymap are provided this command will build a firmware based on that.
 
     """
+    #set string to define keymaps directory
+    cwd = os.path.normpath(os.path.join(os.environ['ORIG_CWD']))
+    keymaps = cwd + "/keymaps"
+
     if cli.args.filename:
         # Parse the configurator json
         user_keymap = parse_configurator_json(cli.args.filename)
@@ -43,8 +47,15 @@ def compile(cli):
 
     elif cli.config.compile.keyboard and cli.config.compile.keymap:
         # Generate the make command for a specific keyboard/keymap.
-        command = create_make_command(cli.config.compile.keyboard, cli.config.compile.keymap)
-
+        command = ['make', ':'.join((cli.config.compile.keyboard, cli.config.compile.keymap))]
+    
+    elif os.path.exists(keymaps):
+        keyboard = os.path.basename(cwd)
+        if os.path.exists(keymaps + "/default"):
+            command = ['make', ':'.join((keyboard, "default"))]
+        else:
+            cli.log.error('You must supply a configurator export or both `--keyboard` and `--keymap`.')
+            return False
     else:
         cli.log.error('You must supply a configurator export or both `--keyboard` and `--keymap`.')
         return False

--- a/lib/python/qmk/cli/compile.py
+++ b/lib/python/qmk/cli/compile.py
@@ -90,6 +90,7 @@ def compile(cli):
     elif in_keyboard:
         keyboard = user_keyboard if user_keyboard else keyboard
         keymap = user_keymap if user_keymap else keymap
+        
         if not os.path.exists(os.path.join(keyboards_path, keyboard, "rules.mk")):
             cli.log.error('This directory does not contain a rules.mk file. Change directory or supply --keyboard with optional --keymap')
             return False

--- a/lib/python/qmk/cli/compile.py
+++ b/lib/python/qmk/cli/compile.py
@@ -103,7 +103,7 @@ def compile(cli):
 
 
     else:
-        cli.log.error('You must supply a configurator export or both `--keyboard` and `--keymap`, or be a directory for a keyboard or keymap.')
+        cli.log.error('You must supply a configurator export, both `--keyboard` and `--keymap`, or be in a directory for a keyboard or keymap.')
         return False
 
     cli.log.info('Compiling keymap with {fg_cyan}%s\n\n', ' '.join(command))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Adds context sensitivity to `qmk compile`. Allows the command to be run within a keyboard directory, given no other CLI arguments, and will compile the default keymap for the given keyboard.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR
 
* Closes #6824 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
