### PR TITLE
Use `keymap` instead of `username` variable for `qmk new_keymap`

### DIFF
--- a/lib/python/qmk/cli/new/keymap.py
+++ b/lib/python/qmk/cli/new/keymap.py
@@ -12,14 +12,14 @@ from milc import cli
 def new_keymap(cli):
     """Creates a new keymap for the keyboard of your choosing.
     """
-    # ask for user input if keyboard or username was not provided in the command line
+    # ask for user input if keyboard or keymap was not provided in the command line
     keyboard = cli.config.new_keymap.keyboard if cli.config.new_keymap.keyboard else input("Keyboard Name: ")
     keymap = cli.config.new_keymap.keymap if cli.config.new_keymap.keymap else input("Keymap Name: ")
 
     # generate keymap paths
     kb_path = os.path.join(os.getcwd(), "keyboards", keyboard)
     keymap_path_default = os.path.join(kb_path, "keymaps/default")
-    keymap_path = os.path.join(kb_path, "keymaps/%s" % username)
+    keymap_path = os.path.join(kb_path, "keymaps/%s" % keymap)
 
     # check directories
     if not os.path.exists(kb_path):
@@ -36,5 +36,5 @@ def new_keymap(cli):
     shutil.copytree(keymap_path_default, keymap_path, symlinks=True)
 
     # end message to user
-    cli.log.info("%s keymap directory created in: %s", username, keymap_path)
-    cli.log.info("Compile a firmware with your new keymap by typing: \n" + "qmk compile -kb %s -km %s", keyboard, username)
+    cli.log.info("%s keymap directory created in: %s", keymap, keymap_path)
+    cli.log.info("Compile a firmware with your new keymap by typing: \n" + "qmk compile -kb %s -km %s", keyboard, keymap)


### PR DESCRIPTION
## Description

The command `gmk new_keymap` is not working due to an undefined variable:
```
$ ./bin/qmk new_keymap
Keyboard Name: ergodox_ez
Keymap Name: testing-123
<class 'NameError'>
☒ name 'username' is not defined
Traceback (most recent call last):
  File "/tmp/qmk_firmware/lib/python/milc.py", line 564, in __call__
    return self.__call__()
  File "/tmp/qmk_firmware/lib/python/milc.py", line 569, in __call__
    return self._entrypoint(self)
  File "/tmp/qmk_firmware/lib/python/qmk/cli/new/keymap.py", line 22, in new_keymap
    keymap_path = os.path.join(kb_path, "keymaps/%s" % username)
NameError: name 'username' is not defined
```

This feature was added and working in #6066 but appears to have broken during the refactoring in #6708.  See https://github.com/qmk/qmk_firmware/pull/6708/files#diff-d5208bcbc79aa428556a743b6ff41086 for more info.  

This change completes the migration from `username` to `keymap`.

After the fix, `qmk new_keymap` works as expected:
```
$ ./bin/qmk new_keymap
Keyboard Name: ergodox_ez
Keymap Name: testing-123
Ψ testing-123 keymap directory created in: /tmp/qmk_firmware/keyboards/ergodox_ez/keymaps/testing-123
Ψ Compile a firmware with your new keymap by typing:
qmk compile -kb ergodox_ez -km testing-123
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
