### PR TITLE
Add CLI command to generate new keyboard (resolves #6872)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -191,6 +191,16 @@ This command lists all the keyboards currently defined in `qmk_firmware`
 qmk list-keyboards
 ```
 
+## `qmk new-keyboard`
+
+This command creates a new keyboard.
+
+**Usage**:
+
+```
+qmk new-keyboard [-kb KEYBOARD] [-kbt TYPE] [-un USERNAME]
+```
+
 ## `qmk new-keymap`
 
 This command creates a new keymap based on a keyboard's existing default keymap.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -191,14 +191,14 @@ This command lists all the keyboards currently defined in `qmk_firmware`
 qmk list-keyboards
 ```
 
-## `qmk new-keyboard`
+## `qmk new_keyboard`
 
 This command creates a new keyboard.
 
 **Usage**:
 
 ```
-qmk new-keyboard [-kb KEYBOARD] [-kbt TYPE] [-un USERNAME]
+qmk new_keyboard [-kb KEYBOARD] [-t TYPE] [-u USERNAME]
 ```
 
 ## `qmk new-keymap`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -198,7 +198,7 @@ This command creates a new keyboard.
 **Usage**:
 
 ```
-qmk new_keyboard [-kb KEYBOARD] [-t TYPE] [-u USERNAME]
+qmk new-keyboard [-kb KEYBOARD] [-t TYPE] [-u USERNAME]
 ```
 
 ## `qmk new-keymap`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -191,7 +191,7 @@ This command lists all the keyboards currently defined in `qmk_firmware`
 qmk list-keyboards
 ```
 
-## `qmk new_keyboard`
+## `qmk new-keyboard`
 
 This command creates a new keyboard.
 

--- a/lib/python/qmk/cli/new/__init__.py
+++ b/lib/python/qmk/cli/new/__init__.py
@@ -1,1 +1,2 @@
-from . import keymap, keyboard
+from . import keymap
+from . import keyboard

--- a/lib/python/qmk/cli/new/__init__.py
+++ b/lib/python/qmk/cli/new/__init__.py
@@ -1,1 +1,1 @@
-from . import keymap
+from . import keymap, keyboard

--- a/lib/python/qmk/cli/new/keyboard.py
+++ b/lib/python/qmk/cli/new/keyboard.py
@@ -22,8 +22,8 @@ def replace_files(filenames, search, replace):
 
 
 @cli.argument('-kb', '--keyboard', help='Specify keyboard name. Example: 1upkeyboards/1up60hse')
-@cli.argument('-kbt', '--type', help='Specify keyboard type. Valid Options: avr or ps2avrgb')
-@cli.argument('-un', '--username', help='Specify username. Example: skullydazed')
+@cli.argument('-t', '--type', help='Specify keyboard type. Valid Options: avr or ps2avrgb')
+@cli.argument('-u', '--username', help='Specify username. Example: skullydazed')
 @cli.subcommand('Creates a new keyboard of your choosing')
 def new_keyboard(cli):
     """Creates a new keyboard of your choosing.

--- a/lib/python/qmk/cli/new/keyboard.py
+++ b/lib/python/qmk/cli/new/keyboard.py
@@ -1,0 +1,96 @@
+"""This script automates the generation of a new keyboard directory.
+"""
+import os
+import shutil
+
+from distutils.dir_util import copy_tree
+from datetime import datetime
+from milc import cli
+
+
+def replace_files(filenames, search, replace):
+    """Replaces keywords across multiple files
+    """
+    for filename in filenames:
+        with open(filename, 'r') as file:
+            contents = file.read()
+
+        contents = contents.replace(search, replace)
+
+        with open(filename, 'w') as file:
+            file.write(contents)
+
+
+@cli.argument('-kb', '--keyboard', help='Specify keyboard name. Example: 1upkeyboards/1up60hse')
+@cli.argument('-kbt', '--type', help='Specify keyboard type. Valid Options: avr or ps2avrgb')
+@cli.argument('-un', '--username', help='Specify username. Example: skullydazed')
+@cli.subcommand('Creates a new keyboard of your choosing')
+def new_keyboard(cli):
+    """Creates a new keyboard of your choosing.
+    """
+    # ask for user input if keyboard, type, or username was not provided in the command line
+    keyboard = cli.config.new_keyboard.keyboard if cli.config.new_keyboard.keyboard else input("Keyboard Name: ")
+    keyboard_type = cli.config.new_keyboard.type if cli.config.new_keyboard.type else input("Keyboard Type: ")
+    username = cli.config.new_keyboard.username if cli.config.new_keyboard.username else input("Username: ")
+
+    # generate keyboard paths
+    kb_path = os.path.join(os.getcwd(), "keyboards", keyboard)
+    kb_path_base = os.path.join(os.getcwd(), "quantum/template/base")
+    kb_path_type = os.path.join(os.getcwd(), "quantum/template", keyboard_type)
+
+    # check keyboard type
+    valid_types = ["avr", "ps2avrgb"]
+    if keyboard_type not in valid_types:
+        cli.log.error('Keyboard type %s must be one of %s!', keyboard_type, valid_types)
+        exit(1)
+
+    # check directories
+    if os.path.exists(kb_path):
+        cli.log.error('Keyboard %s already exists!', kb_path)
+        exit(1)
+    if not os.path.exists(kb_path_base):
+        cli.log.error('Keyboard default %s does not exist!', kb_path_base)
+        exit(1)
+    if not os.path.exists(kb_path_type):
+        cli.log.error('Keyboard type %s does not exist!', kb_path_type)
+        exit(1)
+
+    # create user directory with mix of keyboard base and keyboard type
+    copy_tree(kb_path_base, kb_path, preserve_symlinks=1)
+    copy_tree(kb_path_type, kb_path, preserve_symlinks=1)
+
+    # rename template files to keyboard
+    shutil.move(os.path.join(kb_path, "template.c"), os.path.join(kb_path, "%s.c" % keyboard))
+    shutil.move(os.path.join(kb_path, "template.h"), os.path.join(kb_path, "%s.h" % keyboard))
+
+    # replace year placeholders
+    replace_files([
+        os.path.join(kb_path, "config.h"),
+        os.path.join(kb_path, "%s.c" % keyboard),
+        os.path.join(kb_path, "%s.h" % keyboard),
+        os.path.join(kb_path, "keymaps/default/config.h"),
+        os.path.join(kb_path, "keymaps/default/keymap.c"),
+    ], "%YEAR%", str(datetime.now().year))
+
+    # replace keyboard name placeholders
+    replace_files([
+        os.path.join(kb_path, "config.h"),
+        os.path.join(kb_path, "readme.md"),
+        os.path.join(kb_path, "%s.c" % keyboard),
+        os.path.join(kb_path, "keymaps/default/readme.md"),
+    ], "%KEYBOARD%", keyboard)
+
+    # replace username placeholders
+    replace_files([
+        os.path.join(kb_path, "config.h"),
+        os.path.join(kb_path, "readme.md"),
+        os.path.join(kb_path, "%s.c" % keyboard),
+        os.path.join(kb_path, "%s.h" % keyboard),
+        os.path.join(kb_path, "keymaps/default/config.h"),
+        os.path.join(kb_path, "keymaps/default/keymap.c"),
+    ], "%YOUR_NAME%", username)
+
+    # end message to user
+    cli.log.info("Created a new keyboard called %s\n", keyboard)
+    cli.log.info("To start working on things, cd into keyboards/%s,", keyboard)
+    cli.log.info("or open the directory in your favourite text editor.")

--- a/lib/python/qmk/cli/new/keyboard.py
+++ b/lib/python/qmk/cli/new/keyboard.py
@@ -12,17 +12,14 @@ def replace_files(filenames, search, replace):
     """Replaces keywords across multiple files
     """
     for filename in filenames:
-        with open(filename, 'r') as file:
+        with open(filename, 'r+') as file:
             contents = file.read()
-
-        contents = contents.replace(search, replace)
-
-        with open(filename, 'w') as file:
-            file.write(contents)
-
+            file.seek(0)
+            file.write(contents.replace(search, replace))
+            file.truncate()
 
 @cli.argument('-kb', '--keyboard', help='Specify keyboard name. Example: 1upkeyboards/1up60hse')
-@cli.argument('-t', '--type', help='Specify keyboard type. Valid Options: avr or ps2avrgb')
+@cli.argument('-t', '--type', help='Specify keyboard type. [avr|ps2avrgb]')
 @cli.argument('-u', '--username', help='Specify username. Example: skullydazed')
 @cli.subcommand('Creates a new keyboard of your choosing')
 def new_keyboard(cli):
@@ -33,16 +30,26 @@ def new_keyboard(cli):
     keyboard_type = cli.config.new_keyboard.type if cli.config.new_keyboard.type else input("Keyboard Type: ")
     username = cli.config.new_keyboard.username if cli.config.new_keyboard.username else input("Username: ")
 
+    # check inputs
+    valid = True
+    if not keyboard:
+        cli.log.error('Keyboard is a required argument')
+        valid = False
+    if not username:
+        cli.log.error('Username is a required argument')
+        valid = False
+    valid_keyboard_types = ["avr", "ps2avrgb"]
+    if keyboard_type not in valid_keyboard_types:
+        cli.log.error('Keyboard type %s must be one of %s!', keyboard_type, valid_keyboard_types)
+        valid = False
+    
+    if not valid:
+        exit(1)
+
     # generate keyboard paths
     kb_path = os.path.join(os.getcwd(), "keyboards", keyboard)
     kb_path_base = os.path.join(os.getcwd(), "quantum/template/base")
     kb_path_type = os.path.join(os.getcwd(), "quantum/template", keyboard_type)
-
-    # check keyboard type
-    valid_types = ["avr", "ps2avrgb"]
-    if keyboard_type not in valid_types:
-        cli.log.error('Keyboard type %s must be one of %s!', keyboard_type, valid_types)
-        exit(1)
 
     # check directories
     if os.path.exists(kb_path):

--- a/lib/python/qmk/cli/new/keyboard.py
+++ b/lib/python/qmk/cli/new/keyboard.py
@@ -74,6 +74,7 @@ def new_keyboard(cli):
 
     # replace keyboard name placeholders
     replace_files([
+        os.path.join(kb_path, "info.json"),
         os.path.join(kb_path, "config.h"),
         os.path.join(kb_path, "readme.md"),
         os.path.join(kb_path, "%s.c" % keyboard),
@@ -82,6 +83,7 @@ def new_keyboard(cli):
 
     # replace username placeholders
     replace_files([
+        os.path.join(kb_path, "info.json"),
         os.path.join(kb_path, "config.h"),
         os.path.join(kb_path, "readme.md"),
         os.path.join(kb_path, "%s.c" % keyboard),

--- a/lib/python/qmk/cli/new/keyboard.py
+++ b/lib/python/qmk/cli/new/keyboard.py
@@ -66,9 +66,9 @@ def new_keyboard(cli):
     copy_tree(kb_path_base, kb_path, preserve_symlinks=1)
     copy_tree(kb_path_type, kb_path, preserve_symlinks=1)
 
-    # rename template files to keyboard
-    shutil.move(os.path.join(kb_path, "template.c"), os.path.join(kb_path, "%s.c" % keyboard))
-    shutil.move(os.path.join(kb_path, "template.h"), os.path.join(kb_path, "%s.h" % keyboard))
+    # rename header/c files to keyboard
+    shutil.move(os.path.join(kb_path, "keyboard.c"), os.path.join(kb_path, "%s.c" % keyboard))
+    shutil.move(os.path.join(kb_path, "keyboard.h"), os.path.join(kb_path, "%s.h" % keyboard))
 
     # replace year placeholders
     replace_files([

--- a/lib/python/qmk/cli/new/keyboard.py
+++ b/lib/python/qmk/cli/new/keyboard.py
@@ -2,9 +2,9 @@
 """
 import os
 import shutil
-
 from distutils.dir_util import copy_tree
 from datetime import datetime
+
 from milc import cli
 
 
@@ -52,14 +52,17 @@ def new_keyboard(cli):
     kb_path_type = os.path.join(os.getcwd(), "quantum/template", keyboard_type)
 
     # check directories
+    valid = True
     if os.path.exists(kb_path):
         cli.log.error('Keyboard %s already exists!', kb_path)
-        exit(1)
+        valid = False
     if not os.path.exists(kb_path_base):
         cli.log.error('Keyboard default %s does not exist!', kb_path_base)
-        exit(1)
+        valid = False
     if not os.path.exists(kb_path_type):
         cli.log.error('Keyboard type %s does not exist!', kb_path_type)
+        valid = False
+    if not valid:
         exit(1)
 
     # create user directory with mix of keyboard base and keyboard type


### PR DESCRIPTION
## Description

Per request in #6872, this adds a new CLI command `qmk new_keyboard`
that mirrors the existing functionality in `util/new_keyboard.sh`.

 - Accepts keyboard, type, and username from arg or input
 - Validates type against `avr` and `ps2avrgb`
 - Copies base and $type into new directory
 - Replaces %YEAR%, %KEYBOARD%, and %YOUR_NAME% across specific files

Note, had to use `distutils.dir_util.copy_tree` instead of
`shutil.copytree` as the `shutil` version does not support copying into
an existing folder.

```
$ qmk new_keyboard --help
usage: qmk new_keyboard [-h] [-un USERNAME] [-kbt TYPE] [-kb KEYBOARD]

optional arguments:
  -h, --help            show this help message and exit
  -un USERNAME, --username USERNAME
                        Specify username. Example: skullydazed
  -kbt TYPE, --type TYPE
                        Specify keyboard type. Valid Options: avr or ps2avrgb
  -kb KEYBOARD, --keyboard KEYBOARD
                        Specify keyboard name. Example: 1upkeyboards/1up60hse
```

```
$ qmk new_keyboard --type=ps2avrgb --keyboard=baz --username=asdf
Ψ Created a new keyboard called baz

Ψ To start working on things, cd into keyboards/baz,
Ψ or open the directory in your favourite text editor.
$ tree keyboards/baz
keyboards/baz
├── baz.c
├── baz.h
├── config.h
├── info.json
├── keymaps
│   └── default
│       ├── config.h
│       ├── keymap.c
│       └── readme.md
├── readme.md
├── rules.mk
└── usbconfig.h

2 directories, 10 files
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* Fixes #6872 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
