### PR TITLE
Bump up Instant60 custom EEPROM offsets to avoid conflict

### DIFF
--- a/keyboards/cannonkeys/instant60/config.h
+++ b/keyboards/cannonkeys/instant60/config.h
@@ -62,20 +62,20 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // EEPROM usage
 // TODO: refactor with new user EEPROM code (coming soon)
 #define EEPROM_MAGIC 0x451F
-#define EEPROM_MAGIC_ADDR 32
+#define EEPROM_MAGIC_ADDR 34
 // Bump this every time we change what we store
 // This will automatically reset the EEPROM with defaults
 // and avoid loading invalid data from the EEPROM
 #define EEPROM_VERSION 0x02
-#define EEPROM_VERSION_ADDR 34
+#define EEPROM_VERSION_ADDR 36
 
 
 #define DYNAMIC_KEYMAP_LAYER_COUNT 4
-// Dynamic macro starts after dynamic keymaps (35+(4*5*15*2)) = (35+600) = 635
+#define DYNAMIC_KEYMAP_EEPROM_ADDR 37
+// Backlight comes after dynamic keymaps (37+(4*5*15*2)) = (37+600) = 637
 // start + layer * rows * col * 2
-#define DYNAMIC_KEYMAP_EEPROM_ADDR 35
-#define EEPROM_CUSTOM_BACKLIGHT 636
-#define DYNAMIC_KEYMAP_MACRO_EEPROM_ADDR 637
+#define EEPROM_CUSTOM_BACKLIGHT 637
+#define DYNAMIC_KEYMAP_MACRO_EEPROM_ADDR 638
 #define DYNAMIC_KEYMAP_MACRO_EEPROM_SIZE 200
 #define DYNAMIC_KEYMAP_MACRO_COUNT 16
 

--- a/users/bcat/config.h
+++ b/users/bcat/config.h
@@ -46,21 +46,3 @@
   #define MOUSEKEY_WHEEL_MAX_SPEED 3
   #define MOUSEKEY_WHEEL_TIME_TO_MAX 150
 #endif
-
-#if defined(KEYBOARD_cannonkeys_instant60)
-  /*
-   * Work around EEPROM incompatibility with VIA:
-   * https://github.com/qmk/qmk_firmware/issues/6589#issuecomment-524042457.
-   */
-  #undef EEPROM_MAGIC_ADDR
-  #undef EEPROM_VERSION_ADDR
-  #undef DYNAMIC_KEYMAP_EEPROM_ADDR
-  #undef EEPROM_CUSTOM_BACKLIGHT
-  #undef DYNAMIC_KEYMAP_MACRO_EEPROM_ADDR
-
-  #define EEPROM_MAGIC_ADDR 34
-  #define EEPROM_VERSION_ADDR 36
-  #define DYNAMIC_KEYMAP_EEPROM_ADDR 37
-  #define EEPROM_CUSTOM_BACKLIGHT 637
-  #define DYNAMIC_KEYMAP_MACRO_EEPROM_ADDR 638
-#endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

<!--- Describe your changes in detail here. -->

* The Instant60 PCB supports Via (not sure if this is official, since it wasn't updated with the other Via PCBs), and it has the same address conflict that the other Via-supported PCBs did. This leads to weirdness with Ctrl and Super keys swapping. I'm bumping the EEPROM offsets to fix this issue.

* Tested on my Instant60 PCB with both non-Via and Via keymaps. No key swapping in either case. For Via keymap, I was able to edit in keycodes and they worked fine.

* @awkannan, it looks like the AN-C 60% PCB needs the same fix, but I don't have a physical one of these to test. I can send a PR for it (seems to be the same basic PCB, just not hotswap), but am a bit nervous making an untested change like that. Let me know if you'd like me to do this.

* **Questions:** Should I bump the `EEPROM_MAGIC` for this board (it has a custom value) to force an EEPROM reset after this change? And does this need to go out via the breaking changes process? It seems like maybe it should... but this keyboard is _already_ broken due to the Ctrl/Super swap, and it seems like the other EEPROM offset fixes were rolled out immediately, so maybe not?

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [X] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Issue #6589 for Instant60 PCB

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
