### PR TITLE
Remove i2c logic for STM32F103xB in favour of USE_I2CV1 

### DIFF
--- a/drivers/arm/i2c_master.c
+++ b/drivers/arm/i2c_master.c
@@ -32,27 +32,17 @@
 
 static uint8_t i2c_address;
 
-// ChibiOS uses two initialization structure for v1 and v2/v3 i2c APIs.
-// The F1 series uses the v1 api, which have to initialized this way.
-#ifdef STM32F103xB
-static const I2CConfig i2cconfig = {
-  OPMODE_I2C,
-  400000,
-  FAST_DUTY_CYCLE_2,
-};
-#else
-// This configures the I2C clock to 400khz assuming a 72Mhz clock
-// For more info : https://www.st.com/en/embedded-software/stsw-stm32126.html
 static const I2CConfig i2cconfig = {
 #ifdef USE_I2CV1
     I2C1_OPMODE,
     I2C1_CLOCK_SPEED,
     I2C1_DUTY_CYCLE,
 #else
+    // This configures the I2C clock to 400khz assuming a 72Mhz clock
+    // For more info : https://www.st.com/en/embedded-software/stsw-stm32126.html
     STM32_TIMINGR_PRESC(I2C1_TIMINGR_PRESC) | STM32_TIMINGR_SCLDEL(I2C1_TIMINGR_SCLDEL) | STM32_TIMINGR_SDADEL(I2C1_TIMINGR_SDADEL) | STM32_TIMINGR_SCLH(I2C1_TIMINGR_SCLH) | STM32_TIMINGR_SCLL(I2C1_TIMINGR_SCLL), 0, 0
 #endif
 };
-#endif
 
 static i2c_status_t chibios_to_qmk(const msg_t* status) {
     switch (*status) {

--- a/keyboards/ergodox_stm32/config.h
+++ b/keyboards/ergodox_stm32/config.h
@@ -33,3 +33,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     keyboard_report->mods == (MOD_BIT(KC_LCTL) | MOD_BIT(KC_RCTL)) || \
     keyboard_report->mods == (MOD_BIT(KC_LSFT) | MOD_BIT(KC_RSFT)) \
 )
+
+// i2c_master driver config
+#define I2C1_CLOCK_SPEED 400000
+#define I2C1_DUTY_CYCLE FAST_DUTY_CYCLE_2


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Introduced in #5398, duplicate I2CV1 configuration has been removed, and migrated via existing config values.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
