### PR TITLE
Use task driven PWM for CTPC until ARM can provide automatic configuration

### DIFF
--- a/docs/proton_c_conversion.md
+++ b/docs/proton_c_conversion.md
@@ -19,3 +19,13 @@ Before being able to compile, you may get some errors about `PORTB/DDRB`, etc no
 The Proton C only has one on-board LED (C13), and by default, the TXLED (D5) is mapped to it. If you want the RXLED (B0) mapped to it instead, add this like to your `config.h`:
 
     #define CONVERT_TO_PROTON_C_RXLED
+
+## Feature Conversion
+
+These are defaults based on what has been implemented for ARM boards.
+
+| Feature                             | Notes                                                                                                            |
+|-------------------------------------|------------------------------------------------------------------------------------------------------------------|
+| [Audio](feature_audio.md)           | Enabled                                                                                                          |  
+| [RGB Lighting](feature_rgblight.md) | Disabled                                                                                                         |
+| [Backlight](feature_backlight.md)   | Forces [task driven PWM](feature_backlight.md#software-pwm-driver) until ARM can provide automatic configuration |

--- a/quantum/stm32/proton_c.mk
+++ b/quantum/stm32/proton_c.mk
@@ -3,7 +3,11 @@
 # These are defaults based on what has been implemented for ARM boards
 AUDIO_ENABLE = yes
 RGBLIGHT_ENABLE = no
-BACKLIGHT_ENABLE = no
+
+# Force task driven PWM until ARM can provide automatic configuration
+ifneq ($(strip $(BACKLIGHT_ENABLE)), no)
+	BACKLIGHT_ENABLE = software
+endif
 
 # The rest of these settings shouldn't change
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Requires #6709.

As an attempt at a "works everywhere" CTPC upgrade, in the short term ARM backlight can use the task driven software PWM.

### Future Work
* Add hardware PWM auto configuration

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
