### PR TITLE
Clean up the blocks in the second section so that macOS & Windows are…

### DIFF
--- a/docs/newbs_building_firmware.md
+++ b/docs/newbs_building_firmware.md
@@ -8,14 +8,12 @@ If you have closed and reopened your terminal window since following the first p
 
 Start by navigating to the `keymaps` folder for your keyboard.
 
-?> If you are on macOS or Windows there are commands you can use to easily open the keymaps folder.
+If you are on macOS or Windows there are commands you can use to easily open the keymaps folder.
 
-?> macOS:
-
+?> macOS:<br>
     open keyboards/<keyboard_folder>/keymaps
 
-?> Windows:
-
+?> Windows:<br>
     start .\\keyboards\\<keyboard_folder>\\keymaps
 
 ## Create a Copy Of The `default` Keymap

--- a/docs/newbs_building_firmware.md
+++ b/docs/newbs_building_firmware.md
@@ -10,11 +10,13 @@ Start by navigating to the `keymaps` folder for your keyboard.
 
 If you are on macOS or Windows there are commands you can use to easily open the keymaps folder.
 
-?> macOS:<br>
-    open keyboards/<keyboard_folder>/keymaps
+### macOS:
 
-?> Windows:<br>
-    start .\\keyboards\\<keyboard_folder>\\keymaps
+``` open keyboards/<keyboard_folder>/keymaps ```
+
+### Windows:
+
+``` start .\\keyboards\\<keyboard_folder>\\keymaps ```
 
 ## Create a Copy Of The `default` Keymap
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
In the second section there is a bunch of blocks separating a description, then the operating system and then a commands. I noticed that earlier in the documentation things are grouped in the same block by separating it with a <br> tag and would like to suggest this here as well. This way the OS and the command are grouped together. The first block with the description seems a bit unnecessary so I removed it.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
