### PR TITLE
Fix bug in `do_code16()`

### DIFF
--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -102,31 +102,11 @@ static void do_code16(uint16_t code, void (*f)(uint8_t)) {
     f(mods_to_send);
 }
 
-static inline void qk_register_weak_mods(uint8_t mods) {
-    add_weak_mods(mods);
-    send_keyboard_report();
-}
-
-static inline void qk_unregister_weak_mods(uint8_t mods) {
-    del_weak_mods(mods);
-    send_keyboard_report();
-}
-
-static inline void qk_register_mods(uint8_t mods) {
-    add_weak_mods(mods);
-    send_keyboard_report();
-}
-
-static inline void qk_unregister_mods(uint8_t mods) {
-    del_weak_mods(mods);
-    send_keyboard_report();
-}
-
 void register_code16(uint16_t code) {
     if (IS_MOD(code) || code == KC_NO) {
-        do_code16(code, qk_register_mods);
+        do_code16(code, register_mods);
     } else {
-        do_code16(code, qk_register_weak_mods);
+        do_code16(code, register_weak_mods);
     }
     register_code(code);
 }
@@ -134,9 +114,9 @@ void register_code16(uint16_t code) {
 void unregister_code16(uint16_t code) {
     unregister_code(code);
     if (IS_MOD(code) || code == KC_NO) {
-        do_code16(code, qk_unregister_mods);
+        do_code16(code, unregister_mods);
     } else {
-        do_code16(code, qk_unregister_weak_mods);
+        do_code16(code, unregister_weak_mods);
     }
 }
 

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -85,36 +85,40 @@ static void do_code16(uint16_t code, void (*f)(uint8_t)) {
             return;
     }
 
-    if (code & QK_LCTL) f(KC_LCTL);
-    if (code & QK_LSFT) f(KC_LSFT);
-    if (code & QK_LALT) f(KC_LALT);
-    if (code & QK_LGUI) f(KC_LGUI);
+    uint8_t mods_to_send = 0;
 
-    if (code < QK_RMODS_MIN) return;
+    if (code & QK_RMODS_MIN) { // Right mod flag is set
+        if (code & QK_LCTL) mods_to_send |= MOD_BIT(KC_RCTL);
+        if (code & QK_LSFT) mods_to_send |= MOD_BIT(KC_RSFT);
+        if (code & QK_LALT) mods_to_send |= MOD_BIT(KC_RALT);
+        if (code & QK_LGUI) mods_to_send |= MOD_BIT(KC_RGUI);
+    } else {
+        if (code & QK_LCTL) mods_to_send |= MOD_BIT(KC_LCTL);
+        if (code & QK_LSFT) mods_to_send |= MOD_BIT(KC_LSFT);
+        if (code & QK_LALT) mods_to_send |= MOD_BIT(KC_LALT);
+        if (code & QK_LGUI) mods_to_send |= MOD_BIT(KC_LGUI);
+    }
 
-    if (code & QK_RCTL) f(KC_RCTL);
-    if (code & QK_RSFT) f(KC_RSFT);
-    if (code & QK_RALT) f(KC_RALT);
-    if (code & QK_RGUI) f(KC_RGUI);
+    f(mods_to_send);
 }
 
-static inline void qk_register_weak_mods(uint8_t kc) {
-    add_weak_mods(MOD_BIT(kc));
+static inline void qk_register_weak_mods(uint8_t mods) {
+    add_weak_mods(mods);
     send_keyboard_report();
 }
 
-static inline void qk_unregister_weak_mods(uint8_t kc) {
-    del_weak_mods(MOD_BIT(kc));
+static inline void qk_unregister_weak_mods(uint8_t mods) {
+    del_weak_mods(mods);
     send_keyboard_report();
 }
 
-static inline void qk_register_mods(uint8_t kc) {
-    add_weak_mods(MOD_BIT(kc));
+static inline void qk_register_mods(uint8_t mods) {
+    add_weak_mods(mods);
     send_keyboard_report();
 }
 
-static inline void qk_unregister_mods(uint8_t kc) {
-    del_weak_mods(MOD_BIT(kc));
+static inline void qk_unregister_mods(uint8_t mods) {
+    del_weak_mods(mods);
     send_keyboard_report();
 }
 

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -868,9 +868,9 @@ void tap_code(uint8_t code) {
     unregister_code(code);
 }
 
-/** \brief Utilities for actions. (FIXME: Needs better description)
+/** \brief Adds the given physically pressed modifiers and sends a keyboard report immediately.
  *
- * FIXME: Needs documentation.
+ * \param mods A bitfield of modifiers to unregister.
  */
 void register_mods(uint8_t mods) {
     if (mods) {
@@ -879,13 +879,35 @@ void register_mods(uint8_t mods) {
     }
 }
 
-/** \brief Utilities for actions. (FIXME: Needs better description)
+/** \brief Removes the given physically pressed modifiers and sends a keyboard report immediately.
  *
- * FIXME: Needs documentation.
+ * \param mods A bitfield of modifiers to unregister.
  */
 void unregister_mods(uint8_t mods) {
     if (mods) {
         del_mods(mods);
+        send_keyboard_report();
+    }
+}
+
+/** \brief Adds the given weak modifiers and sends a keyboard report immediately.
+ *
+ * \param mods A bitfield of modifiers to register.
+ */
+void register_weak_mods(uint8_t mods) {
+    if (mods) {
+        add_weak_mods(mods);
+        send_keyboard_report();
+    }
+}
+
+/** \brief Removes the given weak modifiers and sends a keyboard report immediately.
+ *
+ * \param mods A bitfield of modifiers to unregister.
+ */
+void unregister_weak_mods(uint8_t mods) {
+    if (mods) {
+        del_weak_mods(mods);
         send_keyboard_report();
     }
 }

--- a/tmk_core/common/action.h
+++ b/tmk_core/common/action.h
@@ -90,6 +90,8 @@ void unregister_code(uint8_t code);
 void tap_code(uint8_t code);
 void register_mods(uint8_t mods);
 void unregister_mods(uint8_t mods);
+void register_weak_mods(uint8_t mods);
+void unregister_weak_mods(uint8_t mods);
 // void set_mods(uint8_t mods);
 void clear_keyboard(void);
 void clear_keyboard_but_mods(void);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This bug prevents you from calling the `_code16()` functions with a right modifier. Example:

```c
tap_code16(ALGR(KC_O));
```

On Windows, the above will emit `KC_O`, Left Alt and every right modifier. This is because the `QK_L/RCTL` etc. enum entries are *not* bitmasks; four of the bits represent the type of mod, and the fifth bit is the "left/right" flag. Thus, the mod checking `if`s will AND the keycode with `QK_R*`, and evaluate to true every time!

Instead, we should collect the mods we find in a variable, and look for the right flag separately. Then finally, we call `f()` with our mod bitmask.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
