### PR TITLE
Update and cleanup of Tap Dance Documentation

### DIFF
--- a/docs/feature_tap_dance.md
+++ b/docs/feature_tap_dance.md
@@ -422,7 +422,7 @@ Tap Dance can be used to mimic MO(layer) and TG(layer) functionality. For this e
 
 The first step is to include the following code towards the beginning of your `keymap.c`:
 
-```
+```c
 typedef struct {
   bool is_press_action;
   int state;
@@ -452,36 +452,20 @@ void ql_reset (qk_tap_dance_state_t *state, void *user_data);
 int active_layer;
 ```
 
-The above code is similar to that used in previous examples. The one point to note is that you need to declare a variable to keep track of what layer is currently the active layer. We'll see why shortly.
-
 Towards the bottom of your `keymap.c`, include the following code:
 
-```
-//Update active_layer
-uint32_t layer_state_set_user(uint32_t state) {
-  switch (biton32(state)) {
-    case 1:
-      active_layer = 1;
-      break;
-    case 2:
-      active_layer = 2;
-      break;
-    case 3:
-      active_layer = 3;
-      break;
-    default:
-      active_layer = 0;
-      break;
-  }
-  return state;
-}
-
+```c
 //Determine the current tap dance state
 int cur_dance (qk_tap_dance_state_t *state) {
   if (state->count == 1) {
-    if (!state->pressed) {return SINGLE_TAP;}
-    else return SINGLE_HOLD;
-  } else if (state->count == 2) {return DOUBLE_TAP;}
+    if (!state->pressed) {
+      return SINGLE_TAP;
+    } else {
+      return SINGLE_HOLD;
+    }
+  } else if (state->count == 2) {
+    return DOUBLE_TAP;
+  }
   else return 8;
 }
 
@@ -495,16 +479,30 @@ static tap ql_tap_state = {
 void ql_finished (qk_tap_dance_state_t *state, void *user_data) {
   ql_tap_state.state = cur_dance(state);
   switch (ql_tap_state.state) {
-    case SINGLE_TAP: tap_code(KC_QUOT); break;
-    case SINGLE_HOLD: layer_on(_MY_LAYER); break;
+    case SINGLE_TAP: 
+      tap_code(KC_QUOT); 
+      break;
+    case SINGLE_HOLD: 
+      layer_on(_MY_LAYER); 
+      break;
     case DOUBLE_TAP: 
-      if (active_layer==_MY_LAYER) {layer_off(_MY_LAYER);}
-      else layer_on(_MY_LAYER);
+      //check to see if the layer is already set
+      if (layer_state_is(_MY_LAYER)) {
+        //if already set, then switch it off
+        layer_off(_MY_LAYER);
+      } else { 
+        //if not already set, then switch the layer on
+        layer_on(_MY_LAYER);
+      }
+      break;
   }
 }
 
 void ql_reset (qk_tap_dance_state_t *state, void *user_data) {
-  if (ql_tap_state.state==SINGLE_HOLD) {layer_off(_MY_LAYER);}
+  //if the key was held down and now is released then switch off the layer
+  if (ql_tap_state.state==SINGLE_HOLD) {
+    layer_off(_MY_LAYER);
+  }
   ql_tap_state.state = 0;
 }
 
@@ -514,7 +512,7 @@ qk_tap_dance_action_t tap_dance_actions[] = {
 };
 ```
 
-The is where the real logic of our tap dance key gets worked out. Since `layer_state_set_user()` is called on any layer switch, we use it to update `active_layer`. Our example is assuming that your `keymap.c` includes 4 layers, so adjust the switch statement here to fit your actual number of layers.
+The above code is similar to that used in previous examples. The one point to note is that we need to be able to check which layers are active at any time so we can toggle them if needed. To do this we use the `layer_state_is( layer )` function which returns `true` if the given `layer` is active.
 
 The use of `cur_dance()` and `ql_tap_state` mirrors the above examples.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Cleaned up and updated Tap Dance code examples in the documentation.
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Under Example 6 in the Tap Dance Documentation, the code created a variable called `active_layer` to track which layer was active using a switch statement in `layer_state_set_user()`.  This is no longer needed as one can use the built in `layer_state_is( layer )` function to check whether a layer is active. This function also works better in this case as it will not only work for the current top active layer, but will also check for other active layers that aren't currently on top.
In addition, the code was not formatted according to the coding conventions of the other examples in the document, so I changed it to match.
Edited the markdown so it will format the C code with syntax highlighting.
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
