### PR TITLE
Fix buffer sizes for sprintf overflows.

### DIFF
--- a/keyboards/cannonkeys/satisfaction75/satisfaction_oled.c
+++ b/keyboards/cannonkeys/satisfaction75/satisfaction_oled.c
@@ -91,8 +91,8 @@ void draw_default(){
   if (hour == 0){
     hour = 12;
   }
-  char hour_str[2] = "";
-  char min_str[2] = "";
+  char hour_str[3] = "";
+  char min_str[3] = "";
 
   sprintf(hour_str, "%02d", hour);
   sprintf(min_str, "%02d", minute);
@@ -199,11 +199,11 @@ void draw_clock(){
   if (hour == 0){
     hour = 12;
   }
-  char hour_str[2] = "";
-  char min_str[2] = "";
-  char year_str[4] = "";
-  char month_str[2] = "";
-  char day_str[2] = "";
+  char hour_str[3] = "";
+  char min_str[3] = "";
+  char year_str[5] = "";
+  char month_str[3] = "";
+  char day_str[3] = "";
 
   sprintf(hour_str, "%02d", hour);
   sprintf(min_str, "%02d", minute);


### PR DESCRIPTION
## Description

Some `sprintf` calls in the `satisfaction75` driver were being used to fill buffers with an exact number of characters for date and time, but the buffers didn't account for the `NULL` terminator `sprintf` always adds, thus writing beyond the provided buffer.

So this simply increases the size of those buffers by 1.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
