### PR TITLE
Changing Dockerfile to use CLI as entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,6 @@ VOLUME /qmk_firmware
 WORKDIR /qmk_firmware
 COPY . .
 
-CMD make all:default
+RUN ["pip3", "install", "-r", "requirements.txt"]
+ENTRYPOINT [ "bin/qmk" ]
+CMD [ "compile", "-kb", "all", "-km", "default"]


### PR DESCRIPTION
## Description

Using the CLI as the entrypoint allows us to get all the benefits of the CLI self-contained in a Docker image.

_This should be a non-impacting change as the default CMD will still be `make all:default`._

Also, I did not update the `build_tools` documentation as that is still using the `docker_build` script which uses the `qmk/base_container` container under the hood instead of the `qmk/qmk_firmware` container (the one I changed).

Example:
```
$ docker run --rm -it qmk_firmware:latest
INFO Compiling keymap with make all:default


QMK Firmware 0.7.29
Making 1upkeyboards/1up60hse with keymap default         [OK]
...

$ docker run --rm -it qmk_firmware:latest hello
INFO Hello, World!
```

## Types of Changes

- [X] Enhancement/optimization

## Checklist

- [X] My code follows the code style of this project.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
