### PR TITLE
unneeded line of code removed in Tap Dance documentation

### DIFF
--- a/docs/feature_tap_dance.md
+++ b/docs/feature_tap_dance.md
@@ -447,9 +447,6 @@ int cur_dance (qk_tap_dance_state_t *state);
 //Functions associated with individual tap dances
 void ql_finished (qk_tap_dance_state_t *state, void *user_data);
 void ql_reset (qk_tap_dance_state_t *state, void *user_data);
-
-//Declare variable to track which layer is active
-int active_layer;
 ```
 
 Towards the bottom of your `keymap.c`, include the following code:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Just noticed that I forgot to remove in my previous Pull Request the line that declares the `active_layer` variable that is not needed any more. 
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Removed the line declaring the unneeded variable `active_layer`. I should have caught this on the first PR which rendered this unneeded, but missed it.
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
