### PR TITLE
Keyboard/ergodox debounce

### DIFF
--- a/keyboards/ergodox_ez/config.h
+++ b/keyboards/ergodox_ez/config.h
@@ -40,6 +40,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MOUSEKEY_MAX_SPEED      7
 #define MOUSEKEY_WHEEL_DELAY 0
 
+#define DEBOUNCE 30
+
 #define TAPPING_TOGGLE  1
 
 /* define if matrix has ghost */

--- a/keyboards/ergodox_ez/matrix.c
+++ b/keyboards/ergodox_ez/matrix.c
@@ -31,6 +31,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "matrix.h"
 #include "debounce.h"
 #include QMK_KEYBOARD_H
+
+// Only enable this if console is enabled to print to
+#if defined(DEBUG_MATRIX_SCAN_RATE) && !defined(CONSOLE_ENABLE)
+#    undef DEBUG_MATRIX_SCAN_RATE
+#endif
+
 #ifdef DEBUG_MATRIX_SCAN_RATE
 #  include "timer.h"
 #endif
@@ -46,10 +52,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  * something else might be wrong. (Also, the scan speed has improved since
  * that comment was written.)
  */
-
-#ifndef DEBOUNCE
-#  define DEBOUNCE 5
-#endif
 
 /* matrix state(1:on, 0:off) */
 static matrix_row_t raw_matrix[MATRIX_ROWS];  // raw values


### PR DESCRIPTION
## Description

Increases the default debounce of the ergodox ez to 30(ms).  This should prevent any nasty debouncing issues from occurring, and keep in line with what ZSA is using for the default. 

Additionally, this cleans up some code in the matrix.c file (removes the debounce define since it's not used there, and only enableds matrix scan debug printing if it can be printed out). 

## Types of Changes
- [x] Keyboard (addition or update)

## Issues Fixed or Closed by This PR

* Addresses and hopefully fixes the issue in #6269 

