### PR TITLE
[Docs] Replace Switch Hitter link with Wayback Machine link

### DIFF
--- a/docs/fr-FR/newbs_testing_debugging.md
+++ b/docs/fr-FR/newbs_testing_debugging.md
@@ -8,7 +8,7 @@ Tester votre clavier est normalement assez simple. Appuyez chaque touche de votr
 
 Note: ces programmes ne sont ni fournis ni approuvés par QMK.
 
-* [Switch Hitter](https://elitekeyboards.com/switchhitter.php) (Windows seulement)
+* [Switch Hitter](https://web.archive.org/web/20190413233743/https://elitekeyboards.com/switchhitter.php) (Windows seulement)
 * [Keyboard Viewer](https://www.imore.com/how-use-keyboard-viewer-your-mac) (Mac seulement)
 * [Keyboard Tester](http://www.keyboardtester.com) (Web)
 * [Keyboard Checker](http://keyboardchecker.com) (Web)

--- a/docs/fr-FR/newbs_testing_debugging.md
+++ b/docs/fr-FR/newbs_testing_debugging.md
@@ -8,6 +8,7 @@ Tester votre clavier est normalement assez simple. Appuyez chaque touche de votr
 
 Note: ces programmes ne sont ni fournis ni approuvés par QMK.
 
+* [QMK Configurator](https://config.qmk.fm/#/test/) (Web)
 * [Switch Hitter](https://web.archive.org/web/20190413233743/https://elitekeyboards.com/switchhitter.php) (Windows seulement)
 * [Keyboard Viewer](https://www.imore.com/how-use-keyboard-viewer-your-mac) (Mac seulement)
 * [Keyboard Tester](http://www.keyboardtester.com) (Web)

--- a/docs/newbs_testing_debugging.md
+++ b/docs/newbs_testing_debugging.md
@@ -8,7 +8,7 @@ Testing your keyboard is usually pretty straightforward. Press every single key 
 
 Note: These programs are not provided by or endorsed by QMK.
 
-* [Switch Hitter](https://elitekeyboards.com/switchhitter.php) (Windows Only)
+* [Switch Hitter](https://web.archive.org/web/20190413233743/https://elitekeyboards.com/switchhitter.php) (Windows Only)
 * [Keyboard Viewer](https://www.imore.com/how-use-keyboard-viewer-your-mac) (Mac Only)
 * [Keyboard Tester](http://www.keyboardtester.com) (Web Based)
 * [Keyboard Checker](http://keyboardchecker.com) (Web Based)

--- a/docs/newbs_testing_debugging.md
+++ b/docs/newbs_testing_debugging.md
@@ -8,6 +8,7 @@ Testing your keyboard is usually pretty straightforward. Press every single key 
 
 Note: These programs are not provided by or endorsed by QMK.
 
+* [QMK Configurator](https://config.qmk.fm/#/test/) (Web Based)
 * [Switch Hitter](https://web.archive.org/web/20190413233743/https://elitekeyboards.com/switchhitter.php) (Windows Only)
 * [Keyboard Viewer](https://www.imore.com/how-use-keyboard-viewer-your-mac) (Mac Only)
 * [Keyboard Tester](http://www.keyboardtester.com) (Web Based)

--- a/docs/zh-cn/newbs_testing_debugging.md
+++ b/docs/zh-cn/newbs_testing_debugging.md
@@ -8,7 +8,7 @@
 
 注意：这些程序不是由QMK提供或认可的。
 
-* [Switch Hitter](https://elitekeyboards.com/switchhitter.php) (仅Windows)
+* [Switch Hitter](https://web.archive.org/web/20190413233743/https://elitekeyboards.com/switchhitter.php) (仅Windows)
 * [Keyboard Viewer](https://www.imore.com/how-use-keyboard-viewer-your-mac) (仅Mac)
 * [Keyboard Tester](http://www.keyboardtester.com) (网页版)
 * [Keyboard Checker](http://keyboardchecker.com) (网页版)

--- a/docs/zh-cn/newbs_testing_debugging.md
+++ b/docs/zh-cn/newbs_testing_debugging.md
@@ -8,6 +8,7 @@
 
 注意：这些程序不是由QMK提供或认可的。
 
+* [QMK Configurator](https://config.qmk.fm/#/test/) (网页版)
 * [Switch Hitter](https://web.archive.org/web/20190413233743/https://elitekeyboards.com/switchhitter.php) (仅Windows)
 * [Keyboard Viewer](https://www.imore.com/how-use-keyboard-viewer-your-mac) (仅Mac)
 * [Keyboard Tester](http://www.keyboardtester.com) (网页版)


### PR DESCRIPTION
Since the switch hitter site is no longer up, and has shown no signs of returning, lets replace the links with the Wayback machines indexed version. 

This way, the files can be accessed and downloaded by users. 

## Types of Changes
- [x] Documentation


## Checklist
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
