### PR TITLE
Disable Mousekey Command interface when Constant speed is enabled

### DIFF
--- a/tmk_core/common/command.c
+++ b/tmk_core/common/command.c
@@ -39,7 +39,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    include "backlight.h"
 #endif
 
-#ifdef MOUSEKEY_ENABLE
+#if defined(MOUSEKEY_ENABLE) && !defined(MK_3_SPEED)
 #    include "mousekey.h"
 #endif
 
@@ -57,7 +57,7 @@ static void print_version(void);
 static void print_status(void);
 static bool command_console(uint8_t code);
 static void command_console_help(void);
-#ifdef MOUSEKEY_ENABLE
+#if defined(MOUSEKEY_ENABLE) && !defined(MK_3_SPEED)
 static bool mousekey_console(uint8_t code);
 static void mousekey_console_help(void);
 #endif
@@ -78,7 +78,7 @@ bool command_proc(uint8_t code) {
             else
                 return (command_console_extra(code) || command_console(code));
             break;
-#ifdef MOUSEKEY_ENABLE
+#if defined(MOUSEKEY_ENABLE) && !defined(MK_3_SPEED)
         case MOUSEKEY:
             mousekey_console(code);
             break;
@@ -538,7 +538,7 @@ static bool command_console(uint8_t code) {
         case KC_ESC:
             command_state = ONESHOT;
             return false;
-#ifdef MOUSEKEY_ENABLE
+#if defined(MOUSEKEY_ENABLE) && !defined(MK_3_SPEED)
         case KC_M:
             mousekey_console_help();
             print("M> ");
@@ -553,7 +553,7 @@ static bool command_console(uint8_t code) {
     return true;
 }
 
-#ifdef MOUSEKEY_ENABLE
+#if defined(MOUSEKEY_ENABLE) && !defined(MK_3_SPEED)
 /***********************************************************
  * Mousekey console
  ***********************************************************/


### PR DESCRIPTION
This is kind of a brute force fix, but in "Constant Speed" mode, these values don't really change, for the ones that still exist.  

This disables the mousekey console/command code if this mode is deactivated, fixing the compiler errors that are generated. 

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* Fixes #6974

## Checklist
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
