### PR TITLE
ARM - Fix missing debug_matrix output

### DIFF
--- a/tmk_core/common/chibios/printf.c
+++ b/tmk_core/common/chibios/printf.c
@@ -186,6 +186,15 @@ void tfp_format(void* putp, putcf putf, char* fmt, va_list va) {
                 case 's':
                     putchw(putp, putf, w, 0, va_arg(va, char*));
                     break;
+                case 'b':
+#ifdef PRINTF_LONG_SUPPORT
+                    if (lng)
+                        uli2a(va_arg(va, unsigned long int), 2, 0, bf);
+                    else
+#endif
+                        ui2a(va_arg(va, unsigned int), 2, 0, bf);
+                    putchw(putp, putf, w, lz, bf);
+                    break;
                 case '%':
                     putf(putp, ch);
                 default:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
When debugging debounced matrix keypresses on ARM, you get the following blank output:
```
r/c 01234567
00: 
01: 
02: 
03: 
04: 
05: 
06: 
07: 
```

Printing is done via `xprintf("%08b", i)`, digging into the tinyprintf lib that is used, it lacks binary support. This PR enables support and produces the expected output:
```
r/c 01234567
00: 00000000
01: 00001000
02: 00000000
03: 00000000
04: 00000000
05: 00000000
06: 00000000
07: 00000000
```


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
