### PR TITLE
MILC: Use dashes instead of underscores for subcommands

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -125,14 +125,14 @@ This command examines your environment and alerts you to potential build or flas
 qmk doctor
 ```
 
-## `qmk list_keyboards`
+## `qmk list-keyboards`
 
 This command lists all the keyboards currently defined in `qmk_firmware`
 
 **Usage**:
 
 ```
-qmk list_keyboards
+qmk list-keyboards
 ```
 
 ## `qmk new-keymap`

--- a/lib/python/milc.py
+++ b/lib/python/milc.py
@@ -429,11 +429,12 @@ class MILC(object):
                 self.arg_only.append(arg_name)
                 del kwargs['arg_only']
 
+            name = handler.__name__.replace("_", "-")
             if handler is self._entrypoint:
                 self.add_argument(*args, **kwargs)
 
-            elif handler.__name__ in self.subcommands:
-                self.subcommands[handler.__name__].add_argument(*args, **kwargs)
+            elif name in self.subcommands:
+                self.subcommands[name].add_argument(*args, **kwargs)
 
             else:
                 raise RuntimeError('Decorated function is not entrypoint or subcommand!')
@@ -599,7 +600,7 @@ class MILC(object):
             self.add_subparsers()
 
         if not name:
-            name = handler.__name__
+            name = handler.__name__.replace("_", "-")
 
         self.acquire_lock()
         kwargs['help'] = description

--- a/lib/python/qmk/tests/test_cli_commands.py
+++ b/lib/python/qmk/tests/test_cli_commands.py
@@ -40,7 +40,7 @@ def test_pyformat():
 
 
 def test_list_keyboards():
-    result = check_subcommand('list_keyboards')
+    result = check_subcommand('list-keyboards')
     assert result.returncode == 0
     # check to see if a known keyboard is returned
     # this will fail if handwired/onekey/pytest is removed


### PR DESCRIPTION
The subcommand functions' name follows the Python convention of using
snake case, but looks odd on the command line.
Fix it by converting underscores to dashes, eg.: list_keyboards ->
list-keyboards.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [X] Core
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [X] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/qmk/qmk_cli/blob/master/qmk_cli/script_qmk.py#L6

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
