### PR TITLE
Remove apostrophe from various abbreviations' plural forms

### DIFF
--- a/docs/hardware_avr.md
+++ b/docs/hardware_avr.md
@@ -1,6 +1,6 @@
 # Keyboards with AVR Processors
 
-This page describes the support for for AVR processors in QMK. AVR processors include the atmega32u4, atmega32u2, at90usb1286, and other processors from Atmel Corporation. AVR processors are 8-bit MCU's that are designed to be easy to work with. The most common AVR processors in keyboards have on-board USB and plenty of GPIO for supporting large keyboard matrices. They are the most popular MCU for use in keyboards today.
+This page describes the support for for AVR processors in QMK. AVR processors include the atmega32u4, atmega32u2, at90usb1286, and other processors from Atmel Corporation. AVR processors are 8-bit MCUs that are designed to be easy to work with. The most common AVR processors in keyboards have on-board USB and plenty of GPIO for supporting large keyboard matrices. They are the most popular MCU for use in keyboards today.
 
 If you have not yet you should read the [Keyboard Guidelines](hardware_keyboard_guidelines.md) to get a sense of how keyboards fit into QMK.
 

--- a/docs/hardware_drivers.md
+++ b/docs/hardware_drivers.md
@@ -20,7 +20,7 @@ Support for SSD1306 based OLED displays. For more information see the [OLED Driv
 
 ## uGFX
 
-You can make use of uGFX within QMK to drive character and graphic LCD's, LED arrays, OLED, TFT, and other display technologies. This needs to be better documented, if you are trying to do this and reading the code doesn't help please [open an issue](https://github.com/qmk/qmk_firmware/issues/new) and we can help you through the process.
+You can make use of uGFX within QMK to drive character and graphic LCDs, LED arrays, OLED, TFT, and other display technologies. This needs to be better documented, if you are trying to do this and reading the code doesn't help please [open an issue](https://github.com/qmk/qmk_firmware/issues/new) and we can help you through the process.
 
 ## WS2812 (AVR Only)
 

--- a/docs/reference_glossary.md
+++ b/docs/reference_glossary.md
@@ -1,16 +1,16 @@
 # Glossary of QMK Terms
 
 ## ARM
-A line of 32-bit MCU's produced by a number of companies, such as Atmel, Cypress, Kinetis, NXP, ST, and TI.
+A line of 32-bit MCUs produced by a number of companies, such as Atmel, Cypress, Kinetis, NXP, ST, and TI.
 
 ## AVR
-A line of 8-bit MCU's produced by [Atmel](http://www.microchip.com/). AVR was the original platform that TMK supported.
+A line of 8-bit MCUs produced by [Atmel](http://www.microchip.com/). AVR was the original platform that TMK supported.
 
 ## AZERTY
 The standard Français (French) keyboard layout. Named for the first 6 keys on the keyboard.
 
 ## Backlight
-A generic term for lighting on a keyboard. The backlight is typically, but not always, an array of LED's that shine through keycaps and/or switches.
+A generic term for lighting on a keyboard. The backlight is typically, but not always, an array of LEDs that shine through keycaps and/or switches.
 
 ## Bluetooth
 A short range peer to peer wireless protocol. Most common wireless protocol for a keyboard.
@@ -147,7 +147,7 @@ A feature that lets you assign multiple keycodes to the same key based on how ma
 A low-cost AVR development board that is commonly used for hand-wired builds. A teensy is often chosen despite costing a few dollars more due to its halfkay bootloader, which makes flashing very simple.
 
 ## Underlight
-A generic term for LEDs that light the underside of the board. These LED's typically shine away from the bottom of the PCB and towards the surface the keyboard rests on.
+A generic term for LEDs that light the underside of the board. These LEDs typically shine away from the bottom of the PCB and towards the surface the keyboard rests on.
 
 ## Unicode
 In the larger computer world Unicode is a set of encoding schemes for representing characters in any language. As it relates to QMK it means using various OS schemes to send unicode codepoints instead of scancodes.

--- a/docs/understanding_qmk.md
+++ b/docs/understanding_qmk.md
@@ -22,7 +22,7 @@ This section of code is called "The Main Loop" because it's responsible for loop
     keyboard_task();
 ```
 
-This is where all the keyboard specific functionality is dispatched. The source code for `keyboard_task()` can be found in [tmk_core/common/keyboard.c](https://github.com/qmk/qmk_firmware/blob/e1203a222bb12ab9733916164a000ef3ac48da93/tmk_core/common/keyboard.c#L216), and it is responsible for detecting changes in the matrix and turning status LED's on and off.
+This is where all the keyboard specific functionality is dispatched. The source code for `keyboard_task()` can be found in [tmk_core/common/keyboard.c](https://github.com/qmk/qmk_firmware/blob/e1203a222bb12ab9733916164a000ef3ac48da93/tmk_core/common/keyboard.c#L216), and it is responsible for detecting changes in the matrix and turning status LEDs on and off.
 
 Within `keyboard_task()` you'll find code to handle:
 
@@ -30,7 +30,7 @@ Within `keyboard_task()` you'll find code to handle:
 * Mouse Handling
 * Serial Link(s)
 * Visualizer
-* Keyboard status LED's (Caps Lock, Num Lock, Scroll Lock)
+* Keyboard status LEDs (Caps Lock, Num Lock, Scroll Lock)
 
 #### Matrix Scanning
 
@@ -175,7 +175,7 @@ FIXME: This needs to be written
 
 FIXME: This needs to be written
 
-#### Keyboard state LED's (Caps Lock, Num Lock, Scroll Lock)
+#### Keyboard state LEDs (Caps Lock, Num Lock, Scroll Lock)
 
 FIXME: This needs to be written
 


### PR DESCRIPTION
## Description
While this was historically a valid possibility, nowadays, it reads
kinda weird, and the [Oxford Dictionaries Online suggests to avoid it](https://english.stackexchange.com/a/56010).

Thus, I removed it everywhere I found it.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
