### PR TITLE
SPLIT - Remove NO_USB_STARTUP_CHECK requirement for usb detection

### DIFF
--- a/keyboards/handwired/splittest/teensy_2/config.h
+++ b/keyboards/handwired/splittest/teensy_2/config.h
@@ -29,5 +29,3 @@
 
 // teensy has vbus detection issues - use usb detection instead
 #define SPLIT_USB_DETECT
-// required for teensy slave otherwise it "locks up" during startup
-#define NO_USB_STARTUP_CHECK

--- a/keyboards/vitamins_included/rev1/config.h
+++ b/keyboards/vitamins_included/rev1/config.h
@@ -21,7 +21,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "config_common.h"
 
 #define SPLIT_USB_DETECT
-#define NO_USB_STARTUP_CHECK
 
 #define EE_HANDS
 #define SOFT_SERIAL_PIN D0

--- a/quantum/split_common/split_util.c
+++ b/quantum/split_common/split_util.c
@@ -35,7 +35,7 @@ bool waitForUsb(void) {
 
 #if defined(__AVR__)
     // Avoid NO_USB_STARTUP_CHECK - Disable USB as the previous checks seem to enable it somehow
-    (USBCON &= ~((1 << USBE) | (1 << OTGPADE)));
+    (USBCON &= ~(_BV(USBE) | _BV(OTGPADE)));
 #endif
 
     return false;

--- a/quantum/split_common/split_util.c
+++ b/quantum/split_common/split_util.c
@@ -32,6 +32,12 @@ bool waitForUsb(void) {
         }
         wait_ms(100);
     }
+
+#if defined(__AVR__)
+    // Avoid NO_USB_STARTUP_CHECK - Disable USB as the previous checks seem to enable it somehow
+    (USBCON &= ~((1 << USBE) | (1 << OTGPADE)));
+#endif
+
     return false;
 }
 


### PR DESCRIPTION
Disable USB after we become slave, as checks seem to partially enable it somehow.

Now when using `#define SPLIT_USB_DETECT` on avr, you no longer need to also use `#define NO_USB_STARTUP_CHECK` to avoid slave "locks up" during startup.

Tagging @Duckle29 as I have also refactored vit inc rev 1.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
