### PR TITLE
Add a via compatible keymap

### DIFF
--- a/keyboards/maartenwut/plain60/keymaps/via/keymap.c
+++ b/keyboards/maartenwut/plain60/keymaps/via/keymap.c
@@ -1,0 +1,17 @@
+#include QMK_KEYBOARD_H
+
+// Each layer gets a name for readability, which is then used in the keymap matrix below.
+// The underscores don't mean anything - you can have a layer called STUFF or any other name.
+// Layer names don't all need to be of the same length, obviously, and you can also skip them
+// entirely and just use numbers.
+#define _MA 0
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+[_MA] = LAYOUT(
+  KC_ESC,  KC_1,    KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSLS, KC_BSPC, \
+  KC_TAB,  KC_Q,    KC_W,   KC_E,   KC_R,   KC_T,   KC_Y,   KC_U,   KC_I,   KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS,          \
+  KC_CAPS, KC_A,    KC_S,   KC_D,   KC_F,   KC_G,   KC_H,   KC_J,   KC_K,   KC_L,    KC_SCLN, KC_QUOT, KC_BSLS, KC_ENT,           \
+  KC_LSFT, KC_NUBS, KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,   KC_N,   KC_M,   KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT, KC_UP,            \
+  KC_LCTL, KC_LGUI, KC_LALT,                        KC_SPC,                          KC_RALT, KC_RGUI, KC_APP,  KC_RCTRL)
+};

--- a/keyboards/maartenwut/plain60/keymaps/via/rules.mk
+++ b/keyboards/maartenwut/plain60/keymaps/via/rules.mk
@@ -1,0 +1,5 @@
+# rules.mk overrides to enable VIA
+
+RAW_ENABLE = yes
+DYNAMIC_KEYMAP_ENABLE = yes
+

--- a/keyboards/maartenwut/plain60/keymaps/via/rules.mk
+++ b/keyboards/maartenwut/plain60/keymaps/via/rules.mk
@@ -1,4 +1,5 @@
 # rules.mk overrides to enable VIA
+SRC += keyboards/wilba_tech/wt_main.c
 
 RAW_ENABLE = yes
 DYNAMIC_KEYMAP_ENABLE = yes

--- a/keyboards/maartenwut/plain60/rules.mk
+++ b/keyboards/maartenwut/plain60/rules.mk
@@ -62,7 +62,7 @@ MIDI_ENABLE = no 		# MIDI controls
 AUDIO_ENABLE = no
 UNICODE_ENABLE = no 		# Unicode
 BLUETOOTH_ENABLE = no # Enable Bluetooth with the Adafruit EZ-Key HID
-RAW_ENABLE = yes
-DYNAMIC_KEYMAP_ENABLE = yes
+RAW_ENABLE = no
+DYNAMIC_KEYMAP_ENABLE = no
 
 LAYOUTS = 60_ansi 60_ansi_split_bs_rshift 60_hhkb 60_iso 60_tsangan_hhkb

--- a/keyboards/maartenwut/plain60/rules.mk
+++ b/keyboards/maartenwut/plain60/rules.mk
@@ -1,4 +1,3 @@
-SRC += keyboards/wilba_tech/wt_main.c
 # MCU name
 MCU = atmega32u4
 
@@ -62,7 +61,6 @@ MIDI_ENABLE = no 		# MIDI controls
 AUDIO_ENABLE = no
 UNICODE_ENABLE = no 		# Unicode
 BLUETOOTH_ENABLE = no # Enable Bluetooth with the Adafruit EZ-Key HID
-RAW_ENABLE = no
-DYNAMIC_KEYMAP_ENABLE = no
 
 LAYOUTS = 60_ansi 60_ansi_split_bs_rshift 60_hhkb 60_iso 60_tsangan_hhkb
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Adds a VIA keymap target to plain60. Tested on plain60-c with VIA 0.5.4 macOS

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
