### PR TITLE
ARM split - Add serial transport support

### DIFF
--- a/drivers/chibios/serial.c
+++ b/drivers/chibios/serial.c
@@ -1,0 +1,290 @@
+/*
+ * WARNING: be careful changing this code, it is very timing dependent
+ */
+
+#include "quantum.h"
+#include "serial.h"
+#include "wait.h"
+
+#include "hal.h"
+
+// TODO: resolve/remove build warnings
+#if defined(RGBLIGHT_ENABLE) && defined(RGBLED_SPLIT) && defined(PROTOCOL_CHIBIOS) && defined(WS2812_DRIVER_BITBANG)
+#    warning "RGBLED_SPLIT not supported with bitbang WS2812 driver"
+#endif
+
+// default wait implementation cannot be called within interrupt
+//   this method seems to be more accurate than GPT timers
+#if PORT_SUPPORTS_RT == FALSE
+#    error "chSysPolledDelayX method not supported on this platform"
+#else
+#    undef wait_us
+#    define wait_us(x) chSysPolledDelayX(US2RTC(STM32_SYSCLK, x))
+#endif
+
+#ifndef SELECT_SOFT_SERIAL_SPEED
+#    define SELECT_SOFT_SERIAL_SPEED 1
+// TODO: correct speeds...
+//  0: about 189kbps (Experimental only)
+//  1: about 137kbps (default)
+//  2: about 75kbps
+//  3: about 39kbps
+//  4: about 26kbps
+//  5: about 20kbps
+#endif
+
+// Serial pulse period in microseconds. At the moment, going lower than 12 causes communication failure
+#if SELECT_SOFT_SERIAL_SPEED == 0
+#    define SERIAL_DELAY 12
+#elif SELECT_SOFT_SERIAL_SPEED == 1
+#    define SERIAL_DELAY 16
+#elif SELECT_SOFT_SERIAL_SPEED == 2
+#    define SERIAL_DELAY 24
+#elif SELECT_SOFT_SERIAL_SPEED == 3
+#    define SERIAL_DELAY 32
+#elif SELECT_SOFT_SERIAL_SPEED == 4
+#    define SERIAL_DELAY 48
+#elif SELECT_SOFT_SERIAL_SPEED == 5
+#    define SERIAL_DELAY 64
+#else
+#    error invalid SELECT_SOFT_SERIAL_SPEED value
+#endif
+
+inline static void serial_delay(void) { wait_us(SERIAL_DELAY); }
+inline static void serial_delay_half(void) { wait_us(SERIAL_DELAY / 2); }
+inline static void serial_delay_blip(void) { wait_us(1); }
+inline static void serial_output(void) { setPinOutput(SOFT_SERIAL_PIN); }
+inline static void serial_input(void) { setPinInputHigh(SOFT_SERIAL_PIN); }
+inline static bool serial_read_pin(void) { return !!readPin(SOFT_SERIAL_PIN); }
+inline static void serial_low(void) { writePinLow(SOFT_SERIAL_PIN); }
+inline static void serial_high(void) { writePinHigh(SOFT_SERIAL_PIN); }
+
+void interrupt_handler(void *arg);
+
+// Use thread + palWaitLineTimeout instead of palSetLineCallback
+//  - Methods like setPinOutput and palEnableLineEvent/palDisableLineEvent
+//    cause the interrupt to lock up, which would limit to only receiving data...
+static THD_WORKING_AREA(waThread1, 128);
+static THD_FUNCTION(Thread1, arg) {
+    (void)arg;
+    chRegSetThreadName("blinker");
+    while (true) {
+        palWaitLineTimeout(SOFT_SERIAL_PIN, TIME_INFINITE);
+        interrupt_handler(NULL);
+    }
+}
+
+static SSTD_t *Transaction_table      = NULL;
+static uint8_t Transaction_table_size = 0;
+
+void soft_serial_initiator_init(SSTD_t *sstd_table, int sstd_table_size) {
+    Transaction_table      = sstd_table;
+    Transaction_table_size = (uint8_t)sstd_table_size;
+
+    serial_output();
+    serial_high();
+}
+
+void soft_serial_target_init(SSTD_t *sstd_table, int sstd_table_size) {
+    Transaction_table      = sstd_table;
+    Transaction_table_size = (uint8_t)sstd_table_size;
+
+    serial_input();
+
+    palEnablePadEvent(PAL_PORT(SOFT_SERIAL_PIN), PAL_PAD(SOFT_SERIAL_PIN), PAL_EVENT_MODE_FALLING_EDGE);
+    chThdCreateStatic(waThread1, sizeof(waThread1), HIGHPRIO, Thread1, NULL);
+}
+
+// Used by the master to synchronize timing with the slave.
+static void __attribute__((noinline)) sync_recv(void) {
+    serial_input();
+    // This shouldn't hang if the slave disconnects because the
+    // serial line will float to high if the slave does disconnect.
+    while (!serial_read_pin()) {
+    }
+
+    serial_delay();
+}
+
+// Used by the slave to send a synchronization signal to the master.
+static void __attribute__((noinline)) sync_send(void) {
+    serial_output();
+
+    serial_low();
+    serial_delay();
+
+    serial_high();
+}
+
+// Reads a byte from the serial line
+static uint8_t __attribute__((noinline)) serial_read_byte(void) {
+    uint8_t byte = 0;
+    serial_input();
+    for (uint8_t i = 0; i < 8; ++i) {
+        byte = (byte << 1) | serial_read_pin();
+        serial_delay();
+    }
+
+    return byte;
+}
+
+// Sends a byte with MSB ordering
+static void __attribute__((noinline)) serial_write_byte(uint8_t data) {
+    uint8_t b = 8;
+    serial_output();
+    while (b--) {
+        if (data & (1 << b)) {
+            serial_high();
+        } else {
+            serial_low();
+        }
+        serial_delay();
+    }
+}
+
+// interrupt handle to be used by the slave device
+void interrupt_handler(void *arg) {
+    chSysLockFromISR();
+
+    sync_send();
+
+    // read mid pulses
+    serial_delay_blip();
+
+    uint8_t checksum_computed = 0;
+    int     sstd_index        = 0;
+
+#ifdef SERIAL_USE_MULTI_TRANSACTION
+    sstd_index = serial_read_byte();
+    sync_send();
+#endif
+
+    SSTD_t *trans = &Transaction_table[sstd_index];
+    for (int i = 0; i < trans->initiator2target_buffer_size; ++i) {
+        trans->initiator2target_buffer[i] = serial_read_byte();
+        sync_send();
+        checksum_computed += trans->initiator2target_buffer[i];
+    }
+    checksum_computed ^= 7;
+    uint8_t checksum_received = serial_read_byte();
+    sync_send();
+
+    // wait for the sync to finish sending
+    serial_delay();
+
+    uint8_t checksum = 0;
+    for (int i = 0; i < trans->target2initiator_buffer_size; ++i) {
+        serial_write_byte(trans->target2initiator_buffer[i]);
+        sync_send();
+        serial_delay_half();
+        checksum += trans->target2initiator_buffer[i];
+    }
+    serial_write_byte(checksum ^ 7);
+    sync_send();
+
+    // wait for the sync to finish sending
+    serial_delay();
+
+    *trans->status = (checksum_computed == checksum_received) ? TRANSACTION_ACCEPTED : TRANSACTION_DATA_ERROR;
+
+    // end transaction
+    serial_input();
+
+    // TODO: remove extra delay between transactions
+    serial_delay();
+
+    chSysUnlockFromISR();
+}
+
+/////////
+//  start transaction by initiator
+//
+// int  soft_serial_transaction(int sstd_index)
+//
+// Returns:
+//    TRANSACTION_END
+//    TRANSACTION_NO_RESPONSE
+//    TRANSACTION_DATA_ERROR
+// this code is very time dependent, so we need to disable interrupts
+#ifndef SERIAL_USE_MULTI_TRANSACTION
+int soft_serial_transaction(void) {
+    int sstd_index = 0;
+#else
+int soft_serial_transaction(int sstd_index) {
+#endif
+
+    if (sstd_index > Transaction_table_size) return TRANSACTION_TYPE_ERROR;
+    SSTD_t *trans = &Transaction_table[sstd_index];
+
+    // TODO: remove extra delay between transactions
+    serial_delay();
+
+    // this code is very time dependent, so we need to disable interrupts
+    chSysLock();
+
+    // signal to the slave that we want to start a transaction
+    serial_output();
+    serial_low();
+    serial_delay_blip();
+
+    // wait for the slaves response
+    serial_input();
+    serial_high();
+    serial_delay();
+
+    // check if the slave is present
+    if (serial_read_pin()) {
+        // slave failed to pull the line low, assume not present
+        dprintf("serial::NO_RESPONSE\n");
+        chSysUnlock();
+        return TRANSACTION_NO_RESPONSE;
+    }
+
+    // if the slave is present syncronize with it
+
+    uint8_t checksum = 0;
+    // send data to the slave
+#ifdef SERIAL_USE_MULTI_TRANSACTION
+    serial_write_byte(sstd_index);  // first chunk is transaction id
+    sync_recv();
+#endif
+    for (int i = 0; i < trans->initiator2target_buffer_size; ++i) {
+        serial_write_byte(trans->initiator2target_buffer[i]);
+        sync_recv();
+        checksum += trans->initiator2target_buffer[i];
+    }
+    serial_write_byte(checksum ^ 7);
+    sync_recv();
+
+    serial_delay();
+    serial_delay();  // read mid pulses
+
+    // receive data from the slave
+    uint8_t checksum_computed = 0;
+    for (int i = 0; i < trans->target2initiator_buffer_size; ++i) {
+        trans->target2initiator_buffer[i] = serial_read_byte();
+        sync_recv();
+        checksum_computed += trans->target2initiator_buffer[i];
+    }
+    checksum_computed ^= 7;
+    uint8_t checksum_received = serial_read_byte();
+
+    sync_recv();
+    serial_delay();
+
+    if ((checksum_computed) != (checksum_received)) {
+        dprintf("serial::FAIL[%u,%u,%u]\n", checksum_computed, checksum_received, sstd_index);
+        serial_output();
+        serial_high();
+
+        chSysUnlock();
+        return TRANSACTION_DATA_ERROR;
+    }
+
+    // always, release the line when not in use
+    serial_high();
+    serial_output();
+
+    chSysUnlock();
+    return TRANSACTION_END;
+}

--- a/quantum/stm32/halconf.h
+++ b/quantum/stm32/halconf.h
@@ -203,7 +203,7 @@
  * @note    Disabling this option saves both code and data space.
  */
 #    if !defined(PAL_USE_CALLBACKS) || defined(__DOXYGEN__)
-#        define PAL_USE_CALLBACKS FALSE
+#        define PAL_USE_CALLBACKS TRUE
 #    endif
 
 /**
@@ -211,7 +211,7 @@
  * @note    Disabling this option saves both code and data space.
  */
 #    if !defined(PAL_USE_WAIT) || defined(__DOXYGEN__)
-#        define PAL_USE_WAIT FALSE
+#        define PAL_USE_WAIT TRUE
 #    endif
 
 /*===========================================================================*/


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Current Issue
Transport does not exist

## TL;DR
This PR partially ports some of the old lets_split serial code, with slightly different timings.

<details><summary>CLICK ME FOR INVESTIGATION INFO</summary>

## Transport

Current issues include
* drivers/arm/i2c_serial.[ch] not implemented
  * ChibiOS patch has at least been verified against current QMK fork
      * needs verification against latest release
      * self contained master/slave example might help testing
* split_common/serial.[ch] does not compile for ARM

Requirements
* 1 wire protocol
  * Serial
    * complete implementation required
* 2 wire protocol
  * I2C
    * boards may have wired the I2C bus to both a split slave and device like OLED

Upgrading ChibiOS, maintain patch - could break
Potential to lock in to current version if patch cannot be applied going forward

> Think of the current I2C slave code like a patch file, if the code changes the patch might not apply. Or the surrounding code could change behavior, patch applies fine but fails somehow at runtime.

Requires more in-depth knowledge of ChibiOS than "Contributors/Members" have?

### I2C
Pulling the muon code as a intial example, I2C slave support is reasonably self contained. The current implementation manages one block of memory, and reads/writes at offsets. Each offset is handled as a I2C register. The currently exposed API poses an issue due to ChibiOS not providing a mechninism to know the requested number of bytes. When an I2C callback fires, the amount of data to send is unknown.

Potential Solutions
* Stash offsets -> size, sniff register and map to size
* Refactor api to use a structure which can map data with size
    * Each I2C register can then map 
* Refactor to one block, one register
    * Simple
    * No more offsets, transmit/receive all data in one go
    * More overhead
        * chunking based X bytes

### Serial
Currently coded to only support atmega32u4, and contains timings and various settings which are both compiler. Uses AVR specific interrupts and register configuration. Porting it in its current form would be extremely unlikely. Extracting the existing serial.[ch] into a master/slave under `drivers/avr`, with an exposed API. This can then be implemented for ARM, using the relevant ChibiOS calls.

### Alternatives
While outside of current AVR support, anything that is either simple enough to implement, or bundled as part of ChibiOS could be considered. If it can help bootstrap the project, then its on the table.

* RS232/RS485
  * No ChibiOS support
* SPI
  * Untested patch exists on ChibiOS forum

</details>

## Description
Provides a method of transport that does not require a patch or upgrade to ChibiOS. The downside is due to the legacy version of ChibiOS, the code will need to change when we update as interrupts were moved from ext to pal. Stubs have been added for I2C support, to reduce the code changes while #6494 is in progress. Scan rate is reporting as `matrix scan frequency: 692` which is less than ideal but workable for not fast typists (I type ~75wpm and havent seen issues).

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
