### PR TITLE
IS31FL3733 Dirty page fix

### DIFF
--- a/drivers/issi/is31fl3733.c
+++ b/drivers/issi/is31fl3733.c
@@ -248,6 +248,5 @@ void IS31FL3733_update_led_control_registers(uint8_t addr, uint8_t index) {
             IS31FL3733_write_register(addr, i, g_led_control_registers[index][i]);
         }
     }
-    // This seems counter intuitive but sometimes this page can get corrupted. So update it every time.
     g_led_control_registers_update_required[index] = false;
 }

--- a/drivers/issi/is31fl3733.c
+++ b/drivers/issi/is31fl3733.c
@@ -93,7 +93,7 @@ uint8_t IS31FL3733_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
         output = 1;
     }
 #else
-    if (!i2c_transmit(addr << 1, g_twi_transfer_buffer, 2, ISSI_TIMEOUT)) {
+    if (i2c_transmit(addr << 1, g_twi_transfer_buffer, 2, ISSI_TIMEOUT)) {
         output = 1;
     }
 #endif
@@ -124,7 +124,7 @@ uint8_t IS31FL3733_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
             output = 1;
         }
 #else
-        if (!i2c_transmit(addr << 1, g_twi_transfer_buffer, 17, ISSI_TIMEOUT)) {
+        if (i2c_transmit(addr << 1, g_twi_transfer_buffer, 17, ISSI_TIMEOUT)) {
             output = 1;
         }
 #endif

--- a/drivers/issi/is31fl3733.c
+++ b/drivers/issi/is31fl3733.c
@@ -24,10 +24,10 @@
 #    include "wait.h"
 #endif
 
-#include "is31fl3733.h"
 #include <string.h>
 #include "i2c_master.h"
 #include "progmem.h"
+#include "is31fl3733.h"
 
 // This is a 7-bit address, that gets left-shifted and bit 0
 // set to 0 for write, 1 for read (as per I2C protocol)
@@ -80,31 +80,39 @@ bool    g_pwm_buffer_update_required[DRIVER_COUNT] = {false};
 uint8_t g_led_control_registers[DRIVER_COUNT][24]             = {{0}, {0}};
 bool    g_led_control_registers_update_required[DRIVER_COUNT] = {false};
 
-void IS31FL3733_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
+uint8_t IS31FL3733_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
+    // If the transaction fails function returns 1.
+    uint8_t output = 0;
     g_twi_transfer_buffer[0] = reg;
     g_twi_transfer_buffer[1] = data;
 
 #if ISSI_PERSISTENCE > 0
     for (uint8_t i = 0; i < ISSI_PERSISTENCE; i++) {
         if (i2c_transmit(addr << 1, g_twi_transfer_buffer, 2, ISSI_TIMEOUT) == 0) break;
+    } else {
+        output = 1;
     }
 #else
-    i2c_transmit(addr << 1, g_twi_transfer_buffer, 2, ISSI_TIMEOUT);
+    if (!i2c_transmit(addr << 1, g_twi_transfer_buffer, 2, ISSI_TIMEOUT)) {
+        output = 1;
+    }
 #endif
+    return output;
 }
 
-void IS31FL3733_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
-    // assumes PG1 is already selected
-
-    // transmit PWM registers in 12 transfers of 16 bytes
+uint8_t IS31FL3733_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
+    // Assumes PG1 is already selected.
+    // If any of the transactions fails function returns 1.
+    uint8_t output = 0;
+    // Transmit PWM registers in 12 transfers of 16 bytes.
     // g_twi_transfer_buffer[] is 20 bytes
 
-    // iterate over the pwm_buffer contents at 16 byte intervals
+    // Iterate over the pwm_buffer contents at 16 byte intervals.
     for (int i = 0; i < 192; i += 16) {
         g_twi_transfer_buffer[0] = i;
-        // copy the data from i to i+15
-        // device will auto-increment register for data after the first byte
-        // thus this sets registers 0x00-0x0F, 0x10-0x1F, etc. in one transfer
+        // Copy the data from i to i+15.
+        // Device will auto-increment register for data after the first byte
+        // Thus this sets registers 0x00-0x0F, 0x10-0x1F, etc. in one transfer.
         for (int j = 0; j < 16; j++) {
             g_twi_transfer_buffer[1 + j] = pwm_buffer[i + j];
         }
@@ -112,11 +120,16 @@ void IS31FL3733_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
 #if ISSI_PERSISTENCE > 0
         for (uint8_t i = 0; i < ISSI_PERSISTENCE; i++) {
             if (i2c_transmit(addr << 1, g_twi_transfer_buffer, 17, ISSI_TIMEOUT) == 0) break;
+        } else {
+            output = 1;
         }
 #else
-        i2c_transmit(addr << 1, g_twi_transfer_buffer, 17, ISSI_TIMEOUT);
+        if (!i2c_transmit(addr << 1, g_twi_transfer_buffer, 17, ISSI_TIMEOUT)) {
+            output = 1;
+        }
 #endif
     }
+    return output;
 }
 
 void IS31FL3733_init(uint8_t addr, uint8_t sync) {
@@ -213,11 +226,15 @@ void IS31FL3733_set_led_control_register(uint8_t index, bool red, bool green, bo
 
 void IS31FL3733_update_pwm_buffers(uint8_t addr, uint8_t index) {
     if (g_pwm_buffer_update_required[index]) {
-        // Firstly we need to unlock the command register and select PG1
+        // Firstly we need to unlock the command register and select PG1.
         IS31FL3733_write_register(addr, ISSI_COMMANDREGISTER_WRITELOCK, 0xC5);
         IS31FL3733_write_register(addr, ISSI_COMMANDREGISTER, ISSI_PAGE_PWM);
 
-        IS31FL3733_write_pwm_buffer(addr, g_pwm_buffer[index]);
+        // If any of the transactions fail we risk writing dirty PG0,
+        // refresh page 0 just in case.
+        if (IS31FL3733_write_pwm_buffer(addr, g_pwm_buffer[index])){
+            g_led_control_registers_update_required[index] = true;
+        }
     }
     g_pwm_buffer_update_required[index] = false;
 }
@@ -232,5 +249,5 @@ void IS31FL3733_update_led_control_registers(uint8_t addr, uint8_t index) {
         }
     }
     // This seems counter intuitive but sometimes this page can get corrupted. So update it every time.
-    // g_led_control_registers_update_required[index] = false;
+    g_led_control_registers_update_required[index] = false;
 }

--- a/drivers/issi/is31fl3733.c
+++ b/drivers/issi/is31fl3733.c
@@ -88,9 +88,11 @@ uint8_t IS31FL3733_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
 
 #if ISSI_PERSISTENCE > 0
     for (uint8_t i = 0; i < ISSI_PERSISTENCE; i++) {
-        if (i2c_transmit(addr << 1, g_twi_transfer_buffer, 2, ISSI_TIMEOUT) == 0) break;
-    } else {
-        output = 1;
+        if (i2c_transmit(addr << 1, g_twi_transfer_buffer, 2, ISSI_TIMEOUT) == 0) {
+            break;
+        } else {
+            output = 1;
+        }
     }
 #else
     if (i2c_transmit(addr << 1, g_twi_transfer_buffer, 2, ISSI_TIMEOUT)) {
@@ -119,9 +121,11 @@ uint8_t IS31FL3733_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
 
 #if ISSI_PERSISTENCE > 0
         for (uint8_t i = 0; i < ISSI_PERSISTENCE; i++) {
-            if (i2c_transmit(addr << 1, g_twi_transfer_buffer, 17, ISSI_TIMEOUT) == 0) break;
-        } else {
-            output = 1;
+            if (i2c_transmit(addr << 1, g_twi_transfer_buffer, 17, ISSI_TIMEOUT) == 0) {
+                break;
+            } else {
+                output = 1;
+            }
         }
 #else
         if (i2c_transmit(addr << 1, g_twi_transfer_buffer, 17, ISSI_TIMEOUT)) {

--- a/drivers/issi/is31fl3733.c
+++ b/drivers/issi/is31fl3733.c
@@ -87,13 +87,12 @@ uint8_t IS31FL3733_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
 
 #if ISSI_PERSISTENCE > 0
     for (uint8_t i = 0; i < ISSI_PERSISTENCE; i++) {
-        if (!(i2c_transmit(addr << 1, g_twi_transfer_buffer, 2, ISSI_TIMEOUT) == 0)) {
+        if (i2c_transmit(addr << 1, g_twi_transfer_buffer, 2, ISSI_TIMEOUT) != 0) {
             return 1;
-            break;
         }
     }
 #else
-    if (i2c_transmit(addr << 1, g_twi_transfer_buffer, 2, ISSI_TIMEOUT)) {
+    if (i2c_transmit(addr << 1, g_twi_transfer_buffer, 2, ISSI_TIMEOUT) != 0) {
         return 1;
     }
 #endif
@@ -103,7 +102,6 @@ uint8_t IS31FL3733_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
 uint8_t IS31FL3733_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     // Assumes PG1 is already selected.
     // If any of the transactions fails function returns 1.
-    uint8_t output = 0;
     // Transmit PWM registers in 12 transfers of 16 bytes.
     // g_twi_transfer_buffer[] is 20 bytes
 
@@ -119,19 +117,17 @@ uint8_t IS31FL3733_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
 
 #if ISSI_PERSISTENCE > 0
         for (uint8_t i = 0; i < ISSI_PERSISTENCE; i++) {
-            if (i2c_transmit(addr << 1, g_twi_transfer_buffer, 17, ISSI_TIMEOUT) == 0) {
-                break;
-            } else {
-                output = 1;
+            if (i2c_transmit(addr << 1, g_twi_transfer_buffer, 17, ISSI_TIMEOUT) != 0) {
+                return 1;
             }
         }
 #else
-        if (i2c_transmit(addr << 1, g_twi_transfer_buffer, 17, ISSI_TIMEOUT)) {
-            output = 1;
+        if (i2c_transmit(addr << 1, g_twi_transfer_buffer, 17, ISSI_TIMEOUT) != 0) {
+            return 1;
         }
 #endif
     }
-    return output;
+    return 0;
 }
 
 void IS31FL3733_init(uint8_t addr, uint8_t sync) {

--- a/drivers/issi/is31fl3733.c
+++ b/drivers/issi/is31fl3733.c
@@ -80,28 +80,28 @@ bool    g_pwm_buffer_update_required[DRIVER_COUNT] = {false};
 uint8_t g_led_control_registers[DRIVER_COUNT][24]             = {{0}, {0}};
 bool    g_led_control_registers_update_required[DRIVER_COUNT] = {false};
 
-uint8_t IS31FL3733_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
-    // If the transaction fails function returns 1.
+bool IS31FL3733_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
+    // If the transaction fails function returns true.
     g_twi_transfer_buffer[0] = reg;
     g_twi_transfer_buffer[1] = data;
 
 #if ISSI_PERSISTENCE > 0
     for (uint8_t i = 0; i < ISSI_PERSISTENCE; i++) {
         if (i2c_transmit(addr << 1, g_twi_transfer_buffer, 2, ISSI_TIMEOUT) != 0) {
-            return 1;
+            return true;
         }
     }
 #else
     if (i2c_transmit(addr << 1, g_twi_transfer_buffer, 2, ISSI_TIMEOUT) != 0) {
-        return 1;
+        return true;
     }
 #endif
-    return 0;
+    return false;
 }
 
-uint8_t IS31FL3733_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
+bool IS31FL3733_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     // Assumes PG1 is already selected.
-    // If any of the transactions fails function returns 1.
+    // If any of the transactions fails function returns true.
     // Transmit PWM registers in 12 transfers of 16 bytes.
     // g_twi_transfer_buffer[] is 20 bytes
 
@@ -118,16 +118,16 @@ uint8_t IS31FL3733_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
 #if ISSI_PERSISTENCE > 0
         for (uint8_t i = 0; i < ISSI_PERSISTENCE; i++) {
             if (i2c_transmit(addr << 1, g_twi_transfer_buffer, 17, ISSI_TIMEOUT) != 0) {
-                return 1;
+                return true;
             }
         }
 #else
         if (i2c_transmit(addr << 1, g_twi_transfer_buffer, 17, ISSI_TIMEOUT) != 0) {
-            return 1;
+            return true;
         }
 #endif
     }
-    return 0;
+    return false;
 }
 
 void IS31FL3733_init(uint8_t addr, uint8_t sync) {

--- a/drivers/issi/is31fl3733.c
+++ b/drivers/issi/is31fl3733.c
@@ -82,24 +82,22 @@ bool    g_led_control_registers_update_required[DRIVER_COUNT] = {false};
 
 uint8_t IS31FL3733_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
     // If the transaction fails function returns 1.
-    uint8_t output = 0;
     g_twi_transfer_buffer[0] = reg;
     g_twi_transfer_buffer[1] = data;
 
 #if ISSI_PERSISTENCE > 0
     for (uint8_t i = 0; i < ISSI_PERSISTENCE; i++) {
-        if (i2c_transmit(addr << 1, g_twi_transfer_buffer, 2, ISSI_TIMEOUT) == 0) {
+        if (!(i2c_transmit(addr << 1, g_twi_transfer_buffer, 2, ISSI_TIMEOUT) == 0)) {
+            return 1;
             break;
-        } else {
-            output = 1;
         }
     }
 #else
     if (i2c_transmit(addr << 1, g_twi_transfer_buffer, 2, ISSI_TIMEOUT)) {
-        output = 1;
+        return 1;
     }
 #endif
-    return output;
+    return 0;
 }
 
 uint8_t IS31FL3733_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {

--- a/drivers/issi/is31fl3733.h
+++ b/drivers/issi/is31fl3733.h
@@ -32,8 +32,8 @@ typedef struct is31_led {
 extern const is31_led g_is31_leds[DRIVER_LED_TOTAL];
 
 void IS31FL3733_init(uint8_t addr, uint8_t sync);
-void IS31FL3733_write_register(uint8_t addr, uint8_t reg, uint8_t data);
-void IS31FL3733_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer);
+uint8_t IS31FL3733_write_register(uint8_t addr, uint8_t reg, uint8_t data);
+uint8_t IS31FL3733_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer);
 
 void IS31FL3733_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
 void IS31FL3733_set_color_all(uint8_t red, uint8_t green, uint8_t blue);

--- a/drivers/issi/is31fl3733.h
+++ b/drivers/issi/is31fl3733.h
@@ -32,8 +32,8 @@ typedef struct is31_led {
 extern const is31_led g_is31_leds[DRIVER_LED_TOTAL];
 
 void IS31FL3733_init(uint8_t addr, uint8_t sync);
-uint8_t IS31FL3733_write_register(uint8_t addr, uint8_t reg, uint8_t data);
-uint8_t IS31FL3733_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer);
+bool IS31FL3733_write_register(uint8_t addr, uint8_t reg, uint8_t data);
+bool IS31FL3733_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer);
 
 void IS31FL3733_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
 void IS31FL3733_set_color_all(uint8_t red, uint8_t green, uint8_t blue);


### PR DESCRIPTION
Function IS31FL3733_update_led_control_registers was never setting update register to false. As a result the led on/off page was being written every transaction even when it was not modified. This is ineficient and causes lots of bandwidth use.

-> Fix the IS31FL3733_update_led_control_registers.
-> After testing it was evident that failed I2C transactions could corrupt the Led on/off register.
-> Update IS31FL3733_write_pwm_buffer and IS31FL3733_write_register functions to return 0 upon succesful tranmission and 1 if any of the transmitions within the function fail.
-> Modify IS31FL3733_update_pwm_buffers function so if any of the IS31FL3733_write_pwm_buffer transuction fails, the g_led_control_registers_update_required register is set to true forcing a rewrite of the led on/off register in case it was corrupted.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
