### PR TITLE
Correct ARM STM32 I2C frequency.

### DIFF
--- a/drivers/arm/i2c_master.h
+++ b/drivers/arm/i2c_master.h
@@ -73,19 +73,19 @@
 // The default timing values below configures the I2C clock to 400khz assuming a 72Mhz clock
 // For more info : https://www.st.com/en/embedded-software/stsw-stm32126.html
 #    ifndef I2C1_TIMINGR_PRESC
-#        define I2C1_TIMINGR_PRESC 15U
+#        define I2C1_TIMINGR_PRESC 0U
 #    endif
 #    ifndef I2C1_TIMINGR_SCLDEL
-#        define I2C1_TIMINGR_SCLDEL 4U
+#        define I2C1_TIMINGR_SCLDEL 7U
 #    endif
 #    ifndef I2C1_TIMINGR_SDADEL
-#        define I2C1_TIMINGR_SDADEL 2U
+#        define I2C1_TIMINGR_SDADEL 0U
 #    endif
 #    ifndef I2C1_TIMINGR_SCLH
-#        define I2C1_TIMINGR_SCLH 15U
+#        define I2C1_TIMINGR_SCLH 38U
 #    endif
 #    ifndef I2C1_TIMINGR_SCLL
-#        define I2C1_TIMINGR_SCLL 21U
+#        define I2C1_TIMINGR_SCLL 129U
 #    endif
 #endif
 


### PR DESCRIPTION
It was beleaved that this setting result in a 400Khz I2C bus.

This was incorrect, actual frequency measure with a logic analyzer was around 150Khz.

This is derived from the excel sheet linked in the .h file.
Also confirmed with the ST IDE.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
