### PR TITLE
[keymap]kbdfans/kbd8x_mk2 add ISO 88keys

### DIFF
--- a/keyboards/kbdfans/kbd8x_mk2/keymaps/iso_88keys/keymap.c
+++ b/keyboards/kbdfans/kbd8x_mk2/keymaps/iso_88keys/keymap.c
@@ -1,0 +1,47 @@
+/* Copyright 2019 Ryota Goto
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  [0] = LAYOUT( /* Base */
+	KC_ESC,           KC_F1,   KC_F2,   KC_F3,   KC_F4,        KC_F5,   KC_F6,   KC_F7,   KC_F8,       KC_F9,   KC_F10,  KC_F11,  KC_F12,           KC_PSCR, KC_SLCK, KC_PAUS, \
+	KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_NO,            KC_INS,  KC_HOME, KC_PGUP, \
+	KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC,          KC_NUHS,          KC_DEL,  KC_END,  KC_PGDN, \
+	KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,                   KC_ENT,                                      \
+	KC_LSFT, KC_NUBS, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH,          KC_RSFT, KC_NO,                      KC_UP,           \
+	KC_LCTL, KC_LGUI, KC_LALT,                           KC_SPC,                                       KC_RALT, KC_RGUI, KC_APP,  KC_RCTL,          KC_LEFT, KC_DOWN, KC_RGHT  \
+  ),
+};
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  return true;
+}
+
+void matrix_init_user(void) {
+
+}
+
+void matrix_scan_user(void) {
+
+}
+
+void led_set_user(uint8_t usb_led) {
+
+}
+
+void keyboard_post_init_user(void) {
+  // Call the post init code.
+}

--- a/keyboards/kbdfans/kbd8x_mk2/keymaps/iso_88keys/readme.md
+++ b/keyboards/kbdfans/kbd8x_mk2/keymaps/iso_88keys/readme.md
@@ -1,0 +1,4 @@
+# The default keymap for KBD8X MKII
+
+A typical setup. Nothing special.  
+A nice starting point for customizing.

--- a/keyboards/kbdfans/kbd8x_mk2/keymaps/iso_88keys/readme.md
+++ b/keyboards/kbdfans/kbd8x_mk2/keymaps/iso_88keys/readme.md
@@ -1,4 +1,4 @@
-# The default keymap for KBD8X MKII
+# iso_88keys keymap for KBD8X MKII
 
 A typical setup. Nothing special.  
 A nice starting point for customizing.


### PR DESCRIPTION
## Description

Added kbdfans/kbd8x_mk2 keymap for ISO layout with 88keys.
Tested with swiss french keyboard

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
