### PR TITLE
Fix Tap Dance name for consistency and to match docs

### DIFF
--- a/quantum/process_keycode/process_tap_dance.h
+++ b/quantum/process_keycode/process_tap_dance.h
@@ -65,7 +65,7 @@ typedef struct {
 #    define ACTION_TAP_DANCE_DUAL_ROLE(kc, layer) \
         { .fn = { qk_tap_dance_dual_role_on_each_tap, qk_tap_dance_dual_role_finished, qk_tap_dance_dual_role_reset }, .user_data = (void *)&((qk_tap_dance_dual_role_t) { kc, layer, layer_move }),  }
 
-#    define ACTION_TAP_DANCE_TOGGLE_LAYER(kc, layer) \
+#    define ACTION_TAP_DANCE_LAYER_TOGGLE(kc, layer) \
         { .fn = { NULL, qk_tap_dance_dual_role_finished, qk_tap_dance_dual_role_reset }, .user_data = (void *)&((qk_tap_dance_dual_role_t) { kc, layer, layer_invert }), }
 
 #    define ACTION_TAP_DANCE_LAYER_MOVE(kc, layer) ACTION_TAP_DANCE_DUAL_ROLE(kc, layer)


### PR DESCRIPTION
## Description

Tap Dance name is wrong.   Docs and function don't actually match.  

This corrects the name in the code to match what the documentation lists, and to be more consistent with the naming.
## Types of Changes
- [ ] Core
- [x] Bugfix


## Checklist

- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
