### PR TITLE
Fix some formatting, add blink on lock example

### DIFF
--- a/keyboards/primekb/prime_e/keymaps/jetpacktuxedo/keymap.c
+++ b/keyboards/primekb/prime_e/keymaps/jetpacktuxedo/keymap.c
@@ -15,6 +15,18 @@
  */
 #include QMK_KEYBOARD_H
 
+#define BLINK_DURATION 512
+#define CAPS_LED_PIN B1
+#define NUM_LED_PIN B2
+#define SCROLL_LED_PIN B3
+
+uint8_t CAPS;
+uint16_t BLINK_TIMER = 0;
+uint8_t CAPS_LED_STATE = 0;
+
+// Init togg_indicator so the compiler doesn't complain when I declare it last.
+static void togg_indicator(uint8_t *state, uint8_t pin);
+
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   [0] = LAYOUT(
     KC_ESC,        KC_Q,    KC_W, KC_E,     KC_R,    KC_T,    KC_Y,        KC_U,    KC_I,    KC_O,    KC_P,    KC_BSPC, KC_BSPC,
@@ -39,7 +51,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
   [3] = LAYOUT(
     KC_TRNS, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,       KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,
-    KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,     KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+    KC_CAPS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,     KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
     KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,     KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
     KC_TRNS, KC_TRNS,          KC_TRNS, KC_TRNS,              KC_TRNS,          KC_TRNS,          KC_TRNS, KC_TRNS
   )
@@ -47,33 +59,64 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 void matrix_init_user(void) {
   // set CapsLock LED to output and low
-  setPinOutput(B1);
-  writePinLow(B1);
+  setPinOutput(CAPS_LED_PIN);
+  writePinLow(CAPS_LED_PIN);
   // set NumLock LED to output and low
-  setPinOutput(B2);
-  writePinLow(B2);
+  setPinOutput(NUM_LED_PIN);
+  writePinLow(NUM_LED_PIN);
   // set ScrollLock LED to output and low
-  setPinOutput(B3);
-  writePinLow(B3);
+  setPinOutput(SCROLL_LED_PIN);
+  writePinLow(SCROLL_LED_PIN);
+}
+
+void matrix_scan_user(void) {
+    if (CAPS == 1) {
+        // Blink the first led when capslock is active
+        if (BLINK_TIMER >= BLINK_DURATION) {
+            togg_indicator(&CAPS_LED_STATE, CAPS_LED_PIN);
+            BLINK_TIMER = 0;
+        }
+        BLINK_TIMER++;
+    }
 }
 
 //function for layer indicator LED
-uint32_t layer_state_set_user(uint32_t state)
-{
+uint32_t layer_state_set_user(uint32_t state) {
     if (layer_state_cmp(state, 1)) {
-    writePinHigh(B1);
+        writePinHigh(CAPS_LED_PIN);
     } else {
-        writePinLow(B1);
+        writePinLow(CAPS_LED_PIN);
     }
     if (layer_state_cmp(state, 2)) {
-    writePinHigh(B2);
+        writePinHigh(NUM_LED_PIN);
     } else {
-        writePinLow(B2);
+        writePinLow(NUM_LED_PIN);
     }
     if (layer_state_cmp(state, 3)) {
-    writePinHigh(B3);
+        writePinHigh(SCROLL_LED_PIN);
     } else {
-        writePinLow(B3);
+        writePinLow(SCROLL_LED_PIN);
     }
     return state;
+}
+
+void led_set_user(uint8_t usb_led) {
+    if (IS_LED_ON(usb_led, USB_LED_CAPS_LOCK)) {
+        CAPS = 1;
+    }
+    else {
+        CAPS = 0;
+    }
+}
+
+void togg_indicator(uint8_t *state, uint8_t pin) {
+    // Toggles a pin based on the current state
+    if (*state == 0){
+        *state = 1;
+        writePinHigh(pin);
+    }
+    else if (*state == 1){
+        *state = 0;
+        writePinLow(pin);
+    }
 }

--- a/keyboards/primekb/prime_e/keymaps/jetpacktuxedo/keymap.c
+++ b/keyboards/primekb/prime_e/keymaps/jetpacktuxedo/keymap.c
@@ -81,7 +81,7 @@ void matrix_scan_user(void) {
 }
 
 //function for layer indicator LED
-uint32_t layer_state_set_user(uint32_t state) {
+layer_state_t layer_state_set_user(layer_state_t state) {
     if (layer_state_cmp(state, 1)) {
         writePinHigh(CAPS_LED_PIN);
     } else {

--- a/keyboards/primekb/prime_e/keymaps/jetpacktuxedo/keymap.c
+++ b/keyboards/primekb/prime_e/keymaps/jetpacktuxedo/keymap.c
@@ -17,14 +17,14 @@
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   [0] = LAYOUT(
-    KC_ESC,        KC_Q,    KC_W, KC_E,     KC_R,    KC_T,    KC_Y,        KC_U,    KC_I,    KC_O,    KC_P,    KC_BSPC, KC_DEL,
+    KC_ESC,        KC_Q,    KC_W, KC_E,     KC_R,    KC_T,    KC_Y,        KC_U,    KC_I,    KC_O,    KC_P,    KC_BSPC, KC_BSPC,
     LT(2, KC_TAB), KC_A,    KC_S, KC_D,     KC_F,    KC_G,    KC_H,        KC_J,    KC_K,    KC_L,    KC_SCLN, LT(2, KC_ENT),
     KC_LSFT,       KC_Z,    KC_X, KC_C,     KC_V,    KC_B,    LT(3, KC_B), KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT,
     KC_LCTL,       KC_LGUI,       KC_LALT,  LT(1, KC_SPC),    LT(1, KC_SPC),        KC_RALT,          KC_RGUI, KC_RCTL
   ),
 
   [1] = LAYOUT(
-    KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,        KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_DEL,  KC_TRNS,
+    KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,        KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_DEL,  KC_DEL,
     KC_TRNS, KC_MINS, KC_EQL,  KC_SCLN, KC_QUOT, KC_TRNS,     KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT, KC_QUOT, KC_TRNS,
     KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,     KC_TRNS, KC_TRNS, KC_TRNS, KC_LBRC, KC_RBRC, KC_BSLS, KC_TRNS,
     KC_TRNS, KC_TRNS,          KC_TRNS, KC_TRNS,              KC_TRNS,          KC_TRNS,          KC_TRNS, KC_TRNS
@@ -60,17 +60,17 @@ void matrix_init_user(void) {
 //function for layer indicator LED
 uint32_t layer_state_set_user(uint32_t state)
 {
-    if (state & (1<<1)) {
+    if (layer_state_cmp(state, 1)) {
     writePinHigh(B1);
     } else {
         writePinLow(B1);
     }
-    if (state & (1<<2)) {
+    if (layer_state_cmp(state, 2)) {
     writePinHigh(B2);
     } else {
         writePinLow(B2);
     }
-    if (state & (1<<3)) {
+    if (layer_state_cmp(state, 3)) {
     writePinHigh(B3);
     } else {
         writePinLow(B3);


### PR DESCRIPTION
## Description

Some formatting changes in `layer_state_set_user`, as well as switching the way that I am detecting layers to the (much more readable) `layer_state_cmp`. Also added example code to blink the indicator LED when capslock is on.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
