### PR TITLE
Wonderland keymap for black cases, disable underglow

### DIFF
--- a/keyboards/maartenwut/wonderland/keymaps/black/keymap.c
+++ b/keyboards/maartenwut/wonderland/keymaps/black/keymap.c
@@ -1,0 +1,23 @@
+#include QMK_KEYBOARD_H
+
+enum layers {
+  _BASE,
+  _FUNC
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+[_BASE] = LAYOUT(
+  KC_ESC, KC_GRV,  KC_1, KC_2, KC_3, KC_4, KC_5, KC_6,  KC_7, KC_8, KC_9,    KC_0,    KC_MINS, KC_EQL,  XXXXXXX,  KC_BSPC, \
+ KC_PGUP, KC_TAB,  KC_Q, KC_W, KC_E, KC_R, KC_T, KC_Y,  KC_U, KC_I, KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS, \
+ KC_PGDN, KC_CAPS, KC_A, KC_S, KC_D, KC_F, KC_G, KC_H,  KC_J, KC_K, KC_L,    KC_SCLN, KC_QUOT,          KC_ENT, \
+          KC_LSFT, KC_Z, KC_X, KC_C, KC_V, KC_B, MO(1), KC_N, KC_M, KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT, KC_APP, \
+          KC_LCTL,    KC_LAPO, KC_BSPC, KC_LGUI,        KC_SPC,     KC_RAPC,                   KC_RCTRL \
+   ),
+[_FUNC] = LAYOUT(
+ LCA(KC_DEL), VLK_TOG,   KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,  KC_F10,  KC_F11,  KC_F12, XXXXXXX, RESET, \
+ KC_HOME,     XXXXXXX, XXXXXXX,   KC_UP, XXXXXXX,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, \
+ KC_END,      XXXXXXX, KC_LEFT, KC_DOWN, KC_RIGHT, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, \
+              KC_LSFT, XXXXXXX, XXXXXXX, XXXXXXX,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, \
+              _______,          KC_LALT, _______,  _______,          _______,                   KC_RALT,                            _______ \
+   )
+};

--- a/keyboards/maartenwut/wonderland/keymaps/black/rules.mk
+++ b/keyboards/maartenwut/wonderland/keymaps/black/rules.mk
@@ -1,0 +1,1 @@
+RGBLIGHT_ENABLE = no   # Underglow will not show through the black case


### PR DESCRIPTION
## Description

Underglow in Lubrigante/Wonderland keyboards with black cases is useless, because the LEDs will not show through the black case. This keymap disables underglow, and removes the RGB controls from the function layer.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [X] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
