### PR TITLE
Fix formatting for sendstring LUTs

### DIFF
--- a/quantum/keymap_extras/sendstring_belgian.h
+++ b/quantum/keymap_extras/sendstring_belgian.h
@@ -20,45 +20,80 @@
 
 #include "keymap_belgian.h"
 
-const bool ascii_to_shift_lut[128] PROGMEM = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+// clang-format off
 
-                                              0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+const bool ascii_to_shift_lut[128] PROGMEM = {
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
 
-const bool ascii_to_altgr_lut[128] PROGMEM = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 1, 0, 0,
+    0, 0, 1, 1, 0, 0, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 0, 0, 0, 0, 1, 1,
+    0, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 0, 0, 0, 0, 1,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0
+};
 
-                                              0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0};
+const bool ascii_to_altgr_lut[128] PROGMEM = {
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+
+    0, 0, 0, 1, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    1, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 1, 1, 1, 1, 0,
+    1, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 1, 1, 1, 1, 0
+};
 
 const uint8_t ascii_to_keycode_lut[128] PROGMEM = {
     // NUL   SOH      STX      ETX      EOT      ENQ      ACK      BEL
     XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
     // BS    TAB      LF       VT       FF       CR       SO       SI
-    KC_BSPC, KC_TAB, KC_ENT, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+    KC_BSPC, KC_TAB,  KC_ENT,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
     // DLE   DC1      DC2      DC3      DC4      NAK      SYN      ETB
     XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
     // CAN   EM       SUB      ESC      FS       GS       RS       US
-    XXXXXXX, XXXXXXX, XXXXXXX, KC_ESC, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+    XXXXXXX, XXXXXXX, XXXXXXX, KC_ESC,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
 
     //       !        "        #        $        %        &        '
-    KC_SPC, BE_EXLM, BE_QUOT, BE_QUOT, BE_DLR, BE_UGRV, BE_AMP, BE_APOS,
+    KC_SPC,  BE_EXLM, BE_QUOT, BE_QUOT, BE_DLR,  BE_UGRV, BE_AMP,  BE_APOS,
     // (     )        *        +        ,        -        .        /
-    BE_LPRN, BE_RPRN, BE_DLR, BE_EQL, BE_COMM, BE_MINS, BE_SCLN, BE_COLN,
+    BE_LPRN, BE_RPRN, BE_DLR,  BE_EQL,  BE_COMM, BE_MINS, BE_SCLN, BE_COLN,
     // 0     1        2        3        4        5        6        7
-    BE_AGRV, BE_AMP, BE_EACU, BE_QUOT, BE_APOS, BE_LPRN, BE_PARA, BE_EGRV,
+    BE_AGRV, BE_AMP,  BE_EACU, BE_QUOT, BE_APOS, BE_LPRN, BE_PARA, BE_EGRV,
     // 8     9        :        ;        <        =        >        ?
-    BE_EXLM, BE_CCED, BE_COLN, BE_SCLN, BE_LESS, BE_EQL, BE_LESS, BE_COMM,
+    BE_EXLM, BE_CCED, BE_COLN, BE_SCLN, BE_LESS, BE_EQL,  BE_LESS, BE_COMM,
     // @     A        B        C        D        E        F        G
-    BE_EACU, BE_A, KC_B, KC_C, KC_D, KC_E, KC_F, KC_G,
+    BE_EACU, BE_A,    KC_B,    KC_C,    KC_D,    KC_E,    KC_F,    KC_G,
     // H     I        J        K        L        M        N        O
-    KC_H, KC_I, KC_J, KC_K, KC_L, BE_M, KC_N, KC_O,
+    KC_H,    KC_I,    KC_J,    KC_K,    KC_L,    BE_M,    KC_N,    KC_O,
     // P     Q        R        S        T        U        V        W
-    KC_P, BE_Q, KC_R, KC_S, KC_T, KC_U, KC_V, BE_W,
+    KC_P,    BE_Q,    KC_R,    KC_S,    KC_T,    KC_U,    KC_V,    BE_W,
     // X     Y        Z        [        \        ]        ^        _
-    KC_X, KC_Y, BE_Z, BE_CIRC, BE_LESS, BE_DLR, BE_PARA, BE_MINS,
+    KC_X,    KC_Y,    BE_Z,    BE_CIRC, BE_LESS, BE_DLR,  BE_PARA, BE_MINS,
     // `     a        b        c        d        e        f        g
-    BE_MU, BE_A, KC_B, KC_C, KC_D, KC_E, KC_F, KC_G,
+    BE_MU,   BE_A,    KC_B,    KC_C,    KC_D,    KC_E,    KC_F,    KC_G,
     // h     i        j        k        l        m        n        o
-    KC_H, KC_I, KC_J, KC_K, KC_L, BE_M, KC_N, KC_O,
+    KC_H,    KC_I,    KC_J,    KC_K,    KC_L,    BE_M,    KC_N,    KC_O,
     // p     q        r        s        t        u        v        w
-    KC_P, BE_Q, KC_R, KC_S, KC_T, KC_U, KC_V, BE_W,
+    KC_P,    BE_Q,    KC_R,    KC_S,    KC_T,    KC_U,    KC_V,    BE_W,
     // x     y        z        {        |        }        ~        DEL
-    KC_X, KC_Y, BE_Z, BE_CCED, BE_AMP, BE_AGRV, BE_EQL, KC_DEL};
+    KC_X,    KC_Y,    BE_Z,    BE_CCED, BE_AMP,  BE_AGRV, BE_EQL,  KC_DEL
+};

--- a/quantum/keymap_extras/sendstring_bepo.h
+++ b/quantum/keymap_extras/sendstring_bepo.h
@@ -20,45 +20,80 @@
 
 #include "keymap_bepo.h"
 
-const bool ascii_to_shift_lut[128] PROGMEM = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+// clang-format off
 
-                                              0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+const bool ascii_to_shift_lut[128] PROGMEM = {
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
 
-const bool ascii_to_altgr_lut[128] PROGMEM = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 1, 0, 1, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 0, 0, 0, 1,
+    0, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 0, 0, 0, 0, 0,
+    1, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0
+};
 
-                                              0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0};
+const bool ascii_to_altgr_lut[128] PROGMEM = {
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+
+    0, 0, 0, 0, 0, 0, 1, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 1, 0, 1, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 1, 1, 1, 1, 1,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 1, 1, 1, 1, 0
+};
 
 const uint8_t ascii_to_keycode_lut[128] PROGMEM = {
     // NUL   SOH      STX      ETX      EOT      ENQ      ACK      BEL
     XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
     // BS    TAB      LF       VT       FF       CR       SO       SI
-    KC_BSPC, KC_TAB, KC_ENT, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+    KC_BSPC, KC_TAB,  KC_ENT,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
     // DLE   DC1      DC2      DC3      DC4      NAK      SYN      ETB
     XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
     // CAN   EM       SUB      ESC      FS       GS       RS       US
-    XXXXXXX, XXXXXXX, XXXXXXX, KC_ESC, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+    XXXXXXX, XXXXXXX, XXXXXXX, KC_ESC,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
 
     //       !        "        #        $        %        &        '
-    KC_SPC, BP_DCRC, BP_DQOT, BP_DLR, BP_DLR, BP_PERC, BP_P, BP_APOS,
+    KC_SPC,  BP_DCRC, BP_DQOT, BP_DLR,  BP_DLR,  BP_PERC, BP_P,    BP_APOS,
     // (     )        *        +        ,        -        .        /
-    BP_LPRN, BP_RPRN, BP_ASTR, BP_PLUS, BP_COMM, BP_MINS, BP_DOT, BP_SLSH,
+    BP_LPRN, BP_RPRN, BP_ASTR, BP_PLUS, BP_COMM, BP_MINS, BP_DOT,  BP_SLSH,
     // 0     1        2        3        4        5        6        7
-    BP_ASTR, BP_DQOT, BP_LGIL, BP_RGIL, BP_LPRN, BP_RPRN, BP_AT, BP_PLUS,
+    BP_ASTR, BP_DQOT, BP_LGIL, BP_RGIL, BP_LPRN, BP_RPRN, BP_AT,   BP_PLUS,
     // 8     9        :        ;        <        =        >        ?
-    BP_MINS, BP_SLSH, BP_DOT, BP_COMM, BP_LGIL, BP_EQL, BP_RGIL, BP_APOS,
+    BP_MINS, BP_SLSH, BP_DOT,  BP_COMM, BP_LGIL, BP_EQL,  BP_RGIL, BP_APOS,
     // @     A        B        C        D        E        F        G
-    BP_AT, BP_A, BP_B, BP_C, BP_D, BP_E, BP_F, BP_G,
+    BP_AT,   BP_A,    BP_B,    BP_C,    BP_D,    BP_E,    BP_F,    BP_G,
     // H     I        J        K        L        M        N        O
-    BP_H, BP_I, BP_J, BP_K, BP_L, BP_M, BP_N, BP_O,
+    BP_H,    BP_I,    BP_J,    BP_K,    BP_L,    BP_M,    BP_N,    BP_O,
     // P     Q        R        S        T        U        V        W
-    BP_P, BP_Q, BP_R, BP_S, BP_T, BP_U, BP_V, BP_W,
+    BP_P,    BP_Q,    BP_R,    BP_S,    BP_T,    BP_U,    BP_V,    BP_W,
     // X     Y        Z        [        \        ]        ^        _
-    BP_X, BP_Y, BP_Z, BP_LPRN, BP_AGRV, BP_RPRN, BP_AT, KC_SPC,
+    BP_X,    BP_Y,    BP_Z,    BP_LPRN, BP_AGRV, BP_RPRN, BP_AT,   KC_SPC,
     // `     a        b        c        d        e        f        g
-    BP_PERC, BP_A, BP_B, BP_C, BP_D, BP_E, BP_F, BP_G,
+    BP_PERC, BP_A,    BP_B,    BP_C,    BP_D,    BP_E,    BP_F,    BP_G,
     // h     i        j        k        l        m        n        o
-    BP_H, BP_I, BP_J, BP_K, BP_L, BP_M, BP_N, BP_O,
+    BP_H,    BP_I,    BP_J,    BP_K,    BP_L,    BP_M,    BP_N,    BP_O,
     // p     q        r        s        t        u        v        w
-    BP_P, BP_Q, BP_R, BP_S, BP_T, BP_U, BP_V, BP_W,
+    BP_P,    BP_Q,    BP_R,    BP_S,    BP_T,    BP_U,    BP_V,    BP_W,
     // x     y        z        {        |        }        ~        DEL
-    BP_X, BP_Y, BP_Z, BP_Y, BP_B, BP_X, BP_K, KC_DEL};
+    BP_X,    BP_Y,    BP_Z,    BP_Y,    BP_B,    BP_X,    BP_K,    KC_DEL
+};

--- a/quantum/keymap_extras/sendstring_colemak.h
+++ b/quantum/keymap_extras/sendstring_colemak.h
@@ -20,37 +20,40 @@
 
 #include "keymap_colemak.h"
 
+// clang-format off
+
 const uint8_t ascii_to_keycode_lut[128] PROGMEM = {
     // NUL   SOH      STX      ETX      EOT      ENQ      ACK      BEL
     XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
     // BS    TAB      LF       VT       FF       CR       SO       SI
-    KC_BSPC, KC_TAB, KC_ENT, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+    KC_BSPC, KC_TAB,  KC_ENT,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
     // DLE   DC1      DC2      DC3      DC4      NAK      SYN      ETB
     XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
     // CAN   EM       SUB      ESC      FS       GS       RS       US
-    XXXXXXX, XXXXXXX, XXXXXXX, KC_ESC, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+    XXXXXXX, XXXXXXX, XXXXXXX, KC_ESC,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
 
     //       !        "        #        $        %        &        '
-    KC_SPC, KC_1, KC_QUOT, KC_3, KC_4, KC_5, KC_7, KC_QUOT,
+    KC_SPC,  KC_1,    KC_QUOT, KC_3,    KC_4,    KC_5,    KC_7,    KC_QUOT,
     // (     )        *        +        ,        -        .        /
-    KC_9, KC_0, KC_8, KC_EQL, KC_COMM, KC_MINS, KC_DOT, KC_SLSH,
+    KC_9,    KC_0,    KC_8,    KC_EQL,  KC_COMM, KC_MINS, KC_DOT,  KC_SLSH,
     // 0     1        2        3        4        5        6        7
-    KC_0, KC_1, KC_2, KC_3, KC_4, KC_5, KC_6, KC_7,
+    KC_0,    KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,
     // 8     9        :        ;        <        =        >        ?
-    KC_8, KC_9, CM_SCLN, CM_SCLN, KC_COMM, KC_EQL, KC_DOT, KC_SLSH,
+    KC_8,    KC_9,    CM_SCLN, CM_SCLN, KC_COMM, KC_EQL,  KC_DOT,  KC_SLSH,
     // @     A        B        C        D        E        F        G
-    KC_2, CM_A, CM_B, CM_C, CM_D, CM_E, CM_F, CM_G,
+    KC_2,    CM_A,    CM_B,    CM_C,    CM_D,    CM_E,    CM_F,    CM_G,
     // H     I        J        K        L        M        N        O
-    CM_H, CM_I, CM_J, CM_K, CM_L, CM_M, CM_N, CM_O,
+    CM_H,    CM_I,    CM_J,    CM_K,    CM_L,    CM_M,    CM_N,    CM_O,
     // P     Q        R        S        T        U        V        W
-    CM_P, CM_Q, CM_R, CM_S, CM_T, CM_U, CM_V, CM_W,
+    CM_P,    CM_Q,    CM_R,    CM_S,    CM_T,    CM_U,    CM_V,    CM_W,
     // X     Y        Z        [        \        ]        ^        _
-    CM_X, CM_Y, CM_Z, KC_LBRC, KC_BSLS, KC_RBRC, KC_6, KC_MINS,
+    CM_X,    CM_Y,    CM_Z,    KC_LBRC, KC_BSLS, KC_RBRC, KC_6,    KC_MINS,
     // `     a        b        c        d        e        f        g
-    KC_GRV, CM_A, CM_B, CM_C, CM_D, CM_E, CM_F, CM_G,
+    KC_GRV,  CM_A,    CM_B,    CM_C,    CM_D,    CM_E,    CM_F,    CM_G,
     // h     i        j        k        l        m        n        o
-    CM_H, CM_I, CM_J, CM_K, CM_L, CM_M, CM_N, CM_O,
+    CM_H,    CM_I,    CM_J,    CM_K,    CM_L,    CM_M,    CM_N,    CM_O,
     // p     q        r        s        t        u        v        w
-    CM_P, CM_Q, CM_R, CM_S, CM_T, CM_U, CM_V, CM_W,
+    CM_P,    CM_Q,    CM_R,    CM_S,    CM_T,    CM_U,    CM_V,    CM_W,
     // x     y        z        {        |        }        ~        DEL
-    CM_X, CM_Y, CM_Z, KC_LBRC, KC_BSLS, KC_RBRC, KC_GRV, KC_DEL};
+    CM_X,    CM_Y,    CM_Z,    KC_LBRC, KC_BSLS, KC_RBRC, KC_GRV,  KC_DEL
+};

--- a/quantum/keymap_extras/sendstring_dvorak.h
+++ b/quantum/keymap_extras/sendstring_dvorak.h
@@ -20,37 +20,40 @@
 
 #include "keymap_dvorak.h"
 
+// clang-format off
+
 const uint8_t ascii_to_keycode_lut[128] PROGMEM = {
     // NUL   SOH      STX      ETX      EOT      ENQ      ACK      BEL
     XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
     // BS    TAB      LF       VT       FF       CR       SO       SI
-    KC_BSPC, KC_TAB, KC_ENT, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+    KC_BSPC, KC_TAB,  KC_ENT,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
     // DLE   DC1      DC2      DC3      DC4      NAK      SYN      ETB
     XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
     // CAN   EM       SUB      ESC      FS       GS       RS       US
-    XXXXXXX, XXXXXXX, XXXXXXX, KC_ESC, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+    XXXXXXX, XXXXXXX, XXXXXXX, KC_ESC,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
 
     //       !        "        #        $        %        &        '
-    KC_SPC, DV_1, DV_QUOT, DV_3, DV_4, DV_5, DV_7, DV_QUOT,
+    KC_SPC,  DV_1,    DV_QUOT, DV_3,    DV_4,    DV_5,    DV_7,    DV_QUOT,
     // (     )        *        +        ,        -        .        /
-    DV_9, DV_0, DV_8, DV_EQL, DV_COMM, DV_MINS, DV_DOT, DV_SLSH,
+    DV_9,    DV_0,    DV_8,    DV_EQL,  DV_COMM, DV_MINS, DV_DOT,  DV_SLSH,
     // 0     1        2        3        4        5        6        7
-    DV_0, DV_1, DV_2, DV_3, DV_4, DV_5, DV_6, DV_7,
+    DV_0,    DV_1,    DV_2,    DV_3,    DV_4,    DV_5,    DV_6,    DV_7,
     // 8     9        :        ;        <        =        >        ?
-    DV_8, DV_9, DV_SCLN, DV_SCLN, DV_COMM, DV_EQL, DV_DOT, DV_SLSH,
+    DV_8,    DV_9,    DV_SCLN, DV_SCLN, DV_COMM, DV_EQL,  DV_DOT,  DV_SLSH,
     // @     A        B        C        D        E        F        G
-    DV_2, DV_A, DV_B, DV_C, DV_D, DV_E, DV_F, DV_G,
+    DV_2,    DV_A,    DV_B,    DV_C,    DV_D,    DV_E,    DV_F,    DV_G,
     // H     I        J        K        L        M        N        O
-    DV_H, DV_I, DV_J, DV_K, DV_L, DV_M, DV_N, DV_O,
+    DV_H,    DV_I,    DV_J,    DV_K,    DV_L,    DV_M,    DV_N,    DV_O,
     // P     Q        R        S        T        U        V        W
-    DV_P, DV_Q, DV_R, DV_S, DV_T, DV_U, DV_V, DV_W,
+    DV_P,    DV_Q,    DV_R,    DV_S,    DV_T,    DV_U,    DV_V,    DV_W,
     // X     Y        Z        [        \        ]        ^        _
-    DV_X, DV_Y, DV_Z, DV_LBRC, DV_BSLS, DV_RBRC, DV_6, DV_MINS,
+    DV_X,    DV_Y,    DV_Z,    DV_LBRC, DV_BSLS, DV_RBRC, DV_6,    DV_MINS,
     // `     a        b        c        d        e        f        g
-    DV_GRV, DV_A, DV_B, DV_C, DV_D, DV_E, DV_F, DV_G,
+    DV_GRV,  DV_A,    DV_B,    DV_C,    DV_D,    DV_E,    DV_F,    DV_G,
     // h     i        j        k        l        m        n        o
-    DV_H, DV_I, DV_J, DV_K, DV_L, DV_M, DV_N, DV_O,
+    DV_H,    DV_I,    DV_J,    DV_K,    DV_L,    DV_M,    DV_N,    DV_O,
     // p     q        r        s        t        u        v        w
-    DV_P, DV_Q, DV_R, DV_S, DV_T, DV_U, DV_V, DV_W,
+    DV_P,    DV_Q,    DV_R,    DV_S,    DV_T,    DV_U,    DV_V,    DV_W,
     // x     y        z        {        |        }        ~        DEL
-    DV_X, DV_Y, DV_Z, DV_LBRC, DV_BSLS, DV_RBRC, DV_GRV, KC_DEL};
+    DV_X,    DV_Y,    DV_Z,    DV_LBRC, DV_BSLS, DV_RBRC, DV_GRV,  KC_DEL
+};

--- a/quantum/keymap_extras/sendstring_french.h
+++ b/quantum/keymap_extras/sendstring_french.h
@@ -20,45 +20,80 @@
 
 #include "keymap_french.h"
 
-const bool ascii_to_shift_lut[128] PROGMEM = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+// clang-format off
 
-                                              0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+const bool ascii_to_shift_lut[128] PROGMEM = {
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
 
-const bool ascii_to_altgr_lut[128] PROGMEM = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 1, 0, 0,
+    0, 0, 0, 1, 0, 0, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 0, 0, 0, 0, 1, 1,
+    0, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0
+};
 
-                                              0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0};
+const bool ascii_to_altgr_lut[128] PROGMEM = {
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+
+    0, 0, 0, 1, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    1, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 1, 1, 1, 1, 0,
+    1, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 1, 1, 1, 1, 0
+};
 
 const uint8_t ascii_to_keycode_lut[128] PROGMEM = {
     // NUL   SOH      STX      ETX      EOT      ENQ      ACK      BEL
     XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
     // BS    TAB      LF       VT       FF       CR       SO       SI
-    KC_BSPC, KC_TAB, KC_ENT, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+    KC_BSPC, KC_TAB,  KC_ENT,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
     // DLE   DC1      DC2      DC3      DC4      NAK      SYN      ETB
     XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
     // CAN   EM       SUB      ESC      FS       GS       RS       US
-    XXXXXXX, XXXXXXX, XXXXXXX, KC_ESC, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+    XXXXXXX, XXXXXXX, XXXXXXX, KC_ESC,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
 
     //       !        "        #        $        %        &        '
-    KC_SPC, FR_EXLM, FR_QUOT, FR_QUOT, FR_DLR, FR_UGRV, FR_AMP, FR_APOS,
+    KC_SPC,  FR_EXLM, FR_QUOT, FR_QUOT, FR_DLR, FR_UGRV,  FR_AMP,  FR_APOS,
     // (     )        *        +        ,        -        .        /
-    FR_LPRN, FR_RPRN, FR_ASTR, FR_EQL, FR_COMM, FR_MINS, FR_SCLN, FR_COLN,
+    FR_LPRN, FR_RPRN, FR_ASTR, FR_EQL,  FR_COMM, FR_MINS, FR_SCLN, FR_COLN,
     // 0     1        2        3        4        5        6        7
-    FR_AGRV, FR_AMP, FR_EACU, FR_QUOT, FR_APOS, FR_LPRN, FR_MINS, FR_EGRV,
+    FR_AGRV, FR_AMP,  FR_EACU, FR_QUOT, FR_APOS, FR_LPRN, FR_MINS, FR_EGRV,
     // 8     9        :        ;        <        =        >        ?
-    FR_CCED, FR_AGRV, FR_COLN, FR_SCLN, FR_LESS, FR_EQL, FR_LESS, FR_COMM,
+    FR_CCED, FR_AGRV, FR_COLN, FR_SCLN, FR_LESS, FR_EQL,  FR_LESS, FR_COMM,
     // @     A        B        C        D        E        F        G
-    FR_AGRV, FR_A, KC_B, KC_C, KC_D, KC_E, KC_F, KC_G,
+    FR_AGRV, FR_A,    KC_B,    KC_C,    KC_D,    KC_E,    KC_F,    KC_G,
     // H     I        J        K        L        M        N        O
-    KC_H, KC_I, KC_J, KC_K, KC_L, FR_M, KC_N, KC_O,
+    KC_H,    KC_I,    KC_J,    KC_K,    KC_L,    FR_M,    KC_N,    KC_O,
     // P     Q        R        S        T        U        V        W
-    KC_P, FR_Q, KC_R, KC_S, KC_T, KC_U, KC_V, FR_W,
+    KC_P,    FR_Q,    KC_R,    KC_S,    KC_T,    KC_U,    KC_V,    FR_W,
     // X     Y        Z        [        \        ]        ^        _
-    KC_X, KC_Y, FR_Z, FR_LPRN, FR_UNDS, FR_RPRN, FR_CCED, FR_UNDS,
+    KC_X,    KC_Y,    FR_Z,    FR_LPRN, FR_UNDS, FR_RPRN, FR_CCED, FR_UNDS,
     // `     a        b        c        d        e        f        g
-    FR_EGRV, FR_A, KC_B, KC_C, KC_D, KC_E, KC_F, KC_G,
+    FR_EGRV, FR_A,    KC_B,    KC_C,    KC_D,    KC_E,    KC_F,    KC_G,
     // h     i        j        k        l        m        n        o
-    KC_H, KC_I, KC_J, KC_K, KC_L, FR_M, KC_N, KC_O,
+    KC_H,    KC_I,    KC_J,    KC_K,    KC_L,    FR_M,    KC_N,    KC_O,
     // p     q        r        s        t        u        v        w
-    KC_P, FR_Q, KC_R, KC_S, KC_T, KC_U, KC_V, FR_W,
+    KC_P,    FR_Q,    KC_R,    KC_S,    KC_T,    KC_U,    KC_V,    FR_W,
     // x     y        z        {        |        }        ~        DEL
-    KC_X, KC_Y, FR_Z, FR_APOS, FR_MINS, FR_EQL, FR_EACU, KC_DEL};
+    KC_X,    KC_Y,    FR_Z,    FR_APOS, FR_MINS, FR_EQL,  FR_EACU, KC_DEL
+};

--- a/quantum/keymap_extras/sendstring_german.h
+++ b/quantum/keymap_extras/sendstring_german.h
@@ -20,45 +20,80 @@
 
 #include "keymap_german.h"
 
-const bool ascii_to_shift_lut[128] PROGMEM = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+// clang-format off
 
-                                              0, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+const bool ascii_to_shift_lut[128] PROGMEM = {
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
 
-const bool ascii_to_altgr_lut[128] PROGMEM = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 1, 1, 0, 1, 1, 1, 1,
+    1, 1, 1, 0, 0, 0, 0, 1,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 1, 1, 0, 1, 1, 1,
+    0, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 0, 0, 0, 0, 1,
+    1, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0
+};
 
-                                              0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0};
+const bool ascii_to_altgr_lut[128] PROGMEM = {
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    1, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 1, 1, 1, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 1, 1, 1, 1, 0
+};
 
 const uint8_t ascii_to_keycode_lut[128] PROGMEM = {
     // NUL   SOH      STX      ETX      EOT      ENQ      ACK      BEL
     XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
     // BS    TAB      LF       VT       FF       CR       SO       SI
-    KC_BSPC, KC_TAB, KC_ENT, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+    KC_BSPC, KC_TAB,  KC_ENT,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
     // DLE   DC1      DC2      DC3      DC4      NAK      SYN      ETB
     XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
     // CAN   EM       SUB      ESC      FS       GS       RS       US
-    XXXXXXX, XXXXXXX, XXXXXXX, KC_ESC, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+    XXXXXXX, XXXXXXX, XXXXXXX, KC_ESC,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
 
     //       !        "        #        $        %        &        '
-    KC_SPC, DE_1, DE_2, DE_HASH, DE_4, DE_5, DE_6, DE_HASH,
+    KC_SPC,  DE_1,    DE_2,    DE_HASH, DE_4,    DE_5,    DE_6,    DE_HASH,
     // (     )        *        +        ,        -        .        /
-    DE_8, DE_9, DE_PLUS, DE_PLUS, DE_COMM, DE_MINS, DE_DOT, DE_7,
+    DE_8,    DE_9,    DE_PLUS, DE_PLUS, DE_COMM, DE_MINS, DE_DOT,  DE_7,
     // 0     1        2        3        4        5        6        7
-    DE_0, DE_1, DE_2, DE_3, DE_4, DE_5, DE_6, DE_7,
+    DE_0,    DE_1,    DE_2,    DE_3,    DE_4,    DE_5,    DE_6,    DE_7,
     // 8     9        :        ;        <        =        >        ?
-    DE_8, DE_9, DE_DOT, DE_COMM, DE_LESS, DE_0, DE_LESS, DE_SS,
+    DE_8,    DE_9,    DE_DOT,  DE_COMM, DE_LESS, DE_0,    DE_LESS, DE_SS,
     // @     A        B        C        D        E        F        G
-    DE_Q, DE_A, DE_B, DE_C, DE_D, DE_E, DE_F, DE_G,
+    DE_Q,    DE_A,    DE_B,    DE_C,    DE_D,    DE_E,    DE_F,    DE_G,
     // H     I        J        K        L        M        N        O
-    DE_H, DE_I, DE_J, DE_K, DE_L, DE_M, DE_N, DE_O,
+    DE_H,    DE_I,    DE_J,    DE_K,    DE_L,    DE_M,    DE_N,    DE_O,
     // P     Q        R        S        T        U        V        W
-    DE_P, DE_Q, DE_R, DE_S, DE_T, DE_U, DE_V, DE_W,
+    DE_P,    DE_Q,    DE_R,    DE_S,    DE_T,    DE_U,    DE_V,    DE_W,
     // X     Y        Z        [        \        ]        ^        _
-    DE_X, DE_Y, DE_Z, DE_8, DE_SS, DE_9, DE_CIRC, DE_MINS,
+    DE_X,    DE_Y,    DE_Z,    DE_8,    DE_SS,   DE_9,    DE_CIRC, DE_MINS,
     // `     a        b        c        d        e        f        g
-    DE_ACUT, DE_A, DE_B, DE_C, DE_D, DE_E, DE_F, DE_G,
+    DE_ACUT, DE_A,    DE_B,    DE_C,    DE_D,    DE_E,    DE_F,    DE_G,
     // h     i        j        k        l        m        n        o
-    DE_H, DE_I, DE_J, DE_K, DE_L, DE_M, DE_N, DE_O,
+    DE_H,    DE_I,    DE_J,    DE_K,    DE_L,    DE_M,    DE_N,    DE_O,
     // p     q        r        s        t        u        v        w
-    DE_P, DE_Q, DE_R, DE_S, DE_T, DE_U, DE_V, DE_W,
+    DE_P,    DE_Q,    DE_R,    DE_S,    DE_T,    DE_U,    DE_V,    DE_W,
     // x     y        z        {        |        }        ~        DEL
-    DE_X, DE_Y, DE_Z, DE_7, DE_LESS, DE_0, DE_PLUS, KC_DEL};
+    DE_X,    DE_Y,    DE_Z,    DE_7,    DE_LESS, DE_0,    DE_PLUS, KC_DEL
+};

--- a/quantum/keymap_extras/sendstring_jis.h
+++ b/quantum/keymap_extras/sendstring_jis.h
@@ -20,41 +20,60 @@
 
 #include "keymap_jp.h"
 
-const bool ascii_to_shift_lut[128] PROGMEM = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+// clang-format off
 
-                                              0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0};
+const bool ascii_to_shift_lut[128] PROGMEM = {
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+
+    0, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 1, 1, 1, 1,
+    0, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 0, 0, 0, 0, 1,
+    1, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 1, 1, 1, 1, 0
+};
 
 const uint8_t ascii_to_keycode_lut[128] PROGMEM = {
     // NUL   SOH      STX      ETX      EOT      ENQ      ACK      BEL
     XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
     // BS    TAB      LF       VT       FF       CR       SO       SI
-    KC_BSPC, KC_TAB, KC_ENT, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+    KC_BSPC, KC_TAB,  KC_ENT,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
     // DLE   DC1      DC2      DC3      DC4      NAK      SYN      ETB
     XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
     // CAN   EM       SUB      ESC      FS       GS       RS       US
-    XXXXXXX, XXXXXXX, XXXXXXX, KC_ESC, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+    XXXXXXX, XXXXXXX, XXXXXXX, KC_ESC,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
 
     //       !        "        #        $        %        &        '
-    KC_SPC, KC_1, KC_2, KC_3, KC_4, KC_5, KC_6, KC_7,
+    KC_SPC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,
     // (     )        *        +        ,        -        .        /
-    KC_8, KC_9, JP_COLN, JP_SCLN, JP_COMM, JP_MINS, JP_DOT, JP_SLSH,
+    KC_8,    KC_9,    JP_COLN, JP_SCLN, JP_COMM, JP_MINS, JP_DOT,  JP_SLSH,
     // 0     1        2        3        4        5        6        7
-    KC_0, KC_1, KC_2, KC_3, KC_4, KC_5, KC_6, KC_7,
+    KC_0,    KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,
     // 8     9        :        ;        <        =        >        ?
-    KC_8, KC_9, JP_COLN, JP_SCLN, JP_COMM, JP_MINS, JP_DOT, JP_SLSH,
+    KC_8,    KC_9,    JP_COLN, JP_SCLN, JP_COMM, JP_MINS, JP_DOT,  JP_SLSH,
     // @     A        B        C        D        E        F        G
-    JP_AT, KC_A, KC_B, KC_C, KC_D, KC_E, KC_F, KC_G,
+    JP_AT,   KC_A,    KC_B,    KC_C,    KC_D,    KC_E,    KC_F,    KC_G,
     // H     I        J        K        L        M        N        O
-    KC_H, KC_I, KC_J, KC_K, KC_L, KC_M, KC_N, KC_O,
+    KC_H,    KC_I,    KC_J,    KC_K,    KC_L,    KC_M,    KC_N,    KC_O,
     // P     Q        R        S        T        U        V        W
-    KC_P, KC_Q, KC_R, KC_S, KC_T, KC_U, KC_V, KC_W,
+    KC_P,    KC_Q,    KC_R,    KC_S,    KC_T,    KC_U,    KC_V,    KC_W,
     // X     Y        Z        [        \        ]        ^        _
-    KC_X, KC_Y, KC_Z, JP_LBRC, JP_BSLS, JP_RBRC, JP_CIRC, JP_BSLS,
+    KC_X,    KC_Y,    KC_Z,    JP_LBRC, JP_BSLS, JP_RBRC, JP_CIRC, JP_BSLS,
     // `     a        b        c        d        e        f        g
-    JP_AT, KC_A, KC_B, KC_C, KC_D, KC_E, KC_F, KC_G,
+    JP_AT,   KC_A,    KC_B,    KC_C,    KC_D,    KC_E,    KC_F,    KC_G,
     // h     i        j        k        l        m        n        o
-    KC_H, KC_I, KC_J, KC_K, KC_L, KC_M, KC_N, KC_O,
+    KC_H,    KC_I,    KC_J,    KC_K,    KC_L,    KC_M,    KC_N,    KC_O,
     // p     q        r        s        t        u        v        w
-    KC_P, KC_Q, KC_R, KC_S, KC_T, KC_U, KC_V, KC_W,
+    KC_P,    KC_Q,    KC_R,    KC_S,    KC_T,    KC_U,    KC_V,    KC_W,
     // x     y        z        {        |        }        ~        DEL
-    KC_X, KC_Y, KC_Z, JP_LBRC, JP_YEN, JP_RBRC, JP_CIRC, KC_DEL};
+    KC_X,    KC_Y,    KC_Z,    JP_LBRC, JP_YEN,  JP_RBRC, JP_CIRC, KC_DEL
+};

--- a/quantum/keymap_extras/sendstring_norman.h
+++ b/quantum/keymap_extras/sendstring_norman.h
@@ -20,37 +20,40 @@
 
 #include "keymap_norman.h"
 
+// clang-format off
+
 const uint8_t ascii_to_keycode_lut[128] PROGMEM = {
     // NUL   SOH      STX      ETX      EOT      ENQ      ACK      BEL
     XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
     // BS    TAB      LF       VT       FF       CR       SO       SI
-    KC_BSPC, KC_TAB, KC_ENT, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+    KC_BSPC, KC_TAB,  KC_ENT,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
     // DLE   DC1      DC2      DC3      DC4      NAK      SYN      ETB
     XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
     // CAN   EM       SUB      ESC      FS       GS       RS       US
-    XXXXXXX, XXXXXXX, XXXXXXX, KC_ESC, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+    XXXXXXX, XXXXXXX, XXXXXXX, KC_ESC,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
 
     //       !        "        #        $        %        &        '
-    KC_SPC, KC_1, KC_QUOT, KC_3, KC_4, KC_5, KC_7, KC_QUOT,
+    KC_SPC,  KC_1,    KC_QUOT, KC_3,    KC_4,    KC_5,    KC_7,    KC_QUOT,
     // (     )        *        +        ,        -        .        /
-    KC_9, KC_0, KC_8, KC_EQL, KC_COMM, KC_MINS, KC_DOT, KC_SLSH,
+    KC_9,    KC_0,    KC_8,    KC_EQL,  KC_COMM, KC_MINS, KC_DOT,  KC_SLSH,
     // 0     1        2        3        4        5        6        7
-    KC_0, KC_1, KC_2, KC_3, KC_4, KC_5, KC_6, KC_7,
+    KC_0,    KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,
     // 8     9        :        ;        <        =        >        ?
-    KC_8, KC_9, NM_SCLN, NM_SCLN, KC_COMM, KC_EQL, KC_DOT, KC_SLSH,
+    KC_8,    KC_9,    NM_SCLN, NM_SCLN, KC_COMM, KC_EQL,  KC_DOT,  KC_SLSH,
     // @     A        B        C        D        E        F        G
-    KC_2, NM_A, NM_B, NM_C, NM_D, NM_E, NM_F, NM_G,
+    KC_2,    NM_A,    NM_B,    NM_C,    NM_D,    NM_E,    NM_F,    NM_G,
     // H     I        J        K        L        M        N        O
-    NM_H, NM_I, NM_J, NM_K, NM_L, NM_M, NM_N, NM_O,
+    NM_H,    NM_I,    NM_J,    NM_K,    NM_L,    NM_M,    NM_N,    NM_O,
     // P     Q        R        S        T        U        V        W
-    NM_P, NM_Q, NM_R, NM_S, NM_T, NM_U, NM_V, NM_W,
+    NM_P,    NM_Q,    NM_R,    NM_S,    NM_T,    NM_U,    NM_V,    NM_W,
     // X     Y        Z        [        \        ]        ^        _
-    NM_X, NM_Y, NM_Z, KC_LBRC, KC_BSLS, KC_RBRC, KC_6, KC_MINS,
+    NM_X,    NM_Y,    NM_Z,    KC_LBRC, KC_BSLS, KC_RBRC, KC_6,    KC_MINS,
     // `     a        b        c        d        e        f        g
-    KC_GRV, NM_A, NM_B, NM_C, NM_D, NM_E, NM_F, NM_G,
+    KC_GRV,  NM_A,    NM_B,    NM_C,    NM_D,    NM_E,    NM_F,    NM_G,
     // h     i        j        k        l        m        n        o
-    NM_H, NM_I, NM_J, NM_K, NM_L, NM_M, NM_N, NM_O,
+    NM_H,    NM_I,    NM_J,    NM_K,    NM_L,    NM_M,    NM_N,    NM_O,
     // p     q        r        s        t        u        v        w
-    NM_P, NM_Q, NM_R, NM_S, NM_T, NM_U, NM_V, NM_W,
+    NM_P,    NM_Q,    NM_R,    NM_S,    NM_T,    NM_U,    NM_V,    NM_W,
     // x     y        z        {        |        }        ~        DEL
-    NM_X, NM_Y, NM_Z, KC_LBRC, KC_BSLS, KC_RBRC, KC_GRV, KC_DEL};
+    NM_X,    NM_Y,    NM_Z,    KC_LBRC, KC_BSLS, KC_RBRC, KC_GRV,  KC_DEL
+};

--- a/quantum/keymap_extras/sendstring_spanish.h
+++ b/quantum/keymap_extras/sendstring_spanish.h
@@ -20,45 +20,80 @@
 
 #include "keymap_spanish.h"
 
-const bool ascii_to_shift_lut[128] PROGMEM = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+// clang-format off
 
-                                              0, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+const bool ascii_to_shift_lut[128] PROGMEM = {
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
 
-const bool ascii_to_altgr_lut[128] PROGMEM = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 1, 1, 0, 1, 1, 1, 0,
+    1, 1, 1, 0, 0, 0, 0, 1,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 1, 1, 0, 1, 1, 1,
+    0, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 0, 0, 0, 1, 1,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0
+};
 
-                                              0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0};
+const bool ascii_to_altgr_lut[128] PROGMEM = {
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+
+    0, 0, 0, 1, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    1, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 1, 1, 1, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 1, 1, 1, 1, 0
+};
 
 const uint8_t ascii_to_keycode_lut[128] PROGMEM = {
     // NUL   SOH      STX      ETX      EOT      ENQ      ACK      BEL
     XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
     // BS    TAB      LF       VT       FF       CR       SO       SI
-    KC_BSPC, KC_TAB, KC_ENT, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+    KC_BSPC, KC_TAB,  KC_ENT,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
     // DLE   DC1      DC2      DC3      DC4      NAK      SYN      ETB
     XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
     // CAN   EM       SUB      ESC      FS       GS       RS       US
-    XXXXXXX, XXXXXXX, XXXXXXX, KC_ESC, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+    XXXXXXX, XXXXXXX, XXXXXXX, KC_ESC,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
 
     //       !        "        #        $        %        &        '
-    KC_SPC, KC_1, KC_2, KC_3, KC_4, KC_5, KC_6, ES_APOS,
+    KC_SPC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    ES_APOS,
     // (     )        *        +        ,        -        .        /
-    KC_8, KC_9, ES_PLUS, ES_PLUS, KC_COMM, ES_MINS, KC_DOT, KC_7,
+    KC_8,    KC_9,    ES_PLUS, ES_PLUS, KC_COMM, ES_MINS, KC_DOT,  KC_7,
     // 0     1        2        3        4        5        6        7
-    KC_0, KC_1, KC_2, KC_3, KC_4, KC_5, KC_6, KC_7,
+    KC_0,    KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,
     // 8     9        :        ;        <        =        >        ?
-    KC_8, KC_9, KC_DOT, KC_COMM, ES_LESS, KC_0, ES_LESS, ES_APOS,
+    KC_8,    KC_9,    KC_DOT,  KC_COMM, ES_LESS, KC_0,    ES_LESS, ES_APOS,
     // @     A        B        C        D        E        F        G
-    KC_2, KC_A, KC_B, KC_C, KC_D, KC_E, KC_F, KC_G,
+    KC_2,    KC_A,    KC_B,    KC_C,    KC_D,    KC_E,    KC_F,    KC_G,
     // H     I        J        K        L        M        N        O
-    KC_H, KC_I, KC_J, KC_K, KC_L, KC_M, KC_N, KC_O,
+    KC_H,    KC_I,    KC_J,    KC_K,    KC_L,    KC_M,    KC_N,    KC_O,
     // P     Q        R        S        T        U        V        W
-    KC_P, KC_Q, KC_R, KC_S, KC_T, KC_U, KC_V, KC_W,
+    KC_P,    KC_Q,    KC_R,    KC_S,    KC_T,    KC_U,    KC_V,    KC_W,
     // X     Y        Z        [        \        ]        ^        _
-    KC_X, KC_Y, KC_Z, ES_GRV, ES_OVRR, ES_PLUS, ES_GRV, ES_MINS,
+    KC_X,    KC_Y,    KC_Z,    ES_GRV,  ES_OVRR, ES_PLUS, ES_GRV,  ES_MINS,
     // `     a        b        c        d        e        f        g
-    ES_GRV, KC_A, KC_B, KC_C, KC_D, KC_E, KC_F, KC_G,
+    ES_GRV,  KC_A,    KC_B,    KC_C,    KC_D,    KC_E,    KC_F,    KC_G,
     // h     i        j        k        l        m        n        o
-    KC_H, KC_I, KC_J, KC_K, KC_L, KC_M, KC_N, KC_O,
+    KC_H,    KC_I,    KC_J,    KC_K,    KC_L,    KC_M,    KC_N,    KC_O,
     // p     q        r        s        t        u        v        w
-    KC_P, KC_Q, KC_R, KC_S, KC_T, KC_U, KC_V, KC_W,
+    KC_P,    KC_Q,    KC_R,    KC_S,    KC_T,    KC_U,    KC_V,    KC_W,
     // x     y        z        {        |        }        ~        DEL
-    KC_X, KC_Y, KC_Z, ES_ACUT, KC_1, ES_CCED, ES_NTIL, KC_DEL};
+    KC_X,    KC_Y,    KC_Z,    ES_ACUT, KC_1,    ES_CCED, ES_NTIL, KC_DEL
+};

--- a/quantum/keymap_extras/sendstring_uk.h
+++ b/quantum/keymap_extras/sendstring_uk.h
@@ -20,41 +20,60 @@
 
 #include "keymap_uk.h"
 
-const bool ascii_to_shift_lut[128] PROGMEM = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+// clang-format off
 
-                                              0, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0};
+const bool ascii_to_shift_lut[128] PROGMEM = {
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+
+    0, 1, 1, 0, 1, 1, 1, 0,
+    1, 1, 1, 1, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 1, 0, 1, 0, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 0, 0, 0, 1, 1,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 1, 1, 1, 1, 0
+};
 
 const uint8_t ascii_to_keycode_lut[128] PROGMEM = {
     // NUL   SOH      STX      ETX      EOT      ENQ      ACK      BEL
     XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
     // BS    TAB      LF       VT       FF       CR       SO       SI
-    KC_BSPC, KC_TAB, KC_ENT, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+    KC_BSPC, KC_TAB,  KC_ENT,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
     // DLE   DC1      DC2      DC3      DC4      NAK      SYN      ETB
     XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
     // CAN   EM       SUB      ESC      FS       GS       RS       US
-    XXXXXXX, XXXXXXX, XXXXXXX, KC_ESC, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+    XXXXXXX, XXXXXXX, XXXXXXX, KC_ESC,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
 
     //       !        "        #        $        %        &        '
-    UK_SPC, UK_1, UK_2, UK_HASH, UK_4, UK_5, UK_7, UK_QUOT,
+    UK_SPC,  UK_1,    UK_2,    UK_HASH, UK_4,    UK_5,    UK_7,    UK_QUOT,
     // (     )        *        +        ,        -        .        /
-    UK_9, UK_0, UK_8, UK_EQL, UK_COMM, UK_MINS, UK_DOT, UK_SLSH,
+    UK_9,    UK_0,    UK_8,    UK_EQL,  UK_COMM, UK_MINS, UK_DOT,  UK_SLSH,
     // 0     1        2        3        4        5        6        7
-    UK_0, UK_1, UK_2, UK_3, UK_4, UK_5, UK_6, UK_7,
+    UK_0,    UK_1,    UK_2,    UK_3,    UK_4,    UK_5,    UK_6,    UK_7,
     // 8     9        :        ;        <        =        >        ?
-    UK_8, UK_9, UK_SCLN, UK_SCLN, UK_COMM, UK_EQL, UK_DOT, UK_SLSH,
+    UK_8,    UK_9,    UK_SCLN, UK_SCLN, UK_COMM, UK_EQL,  UK_DOT,  UK_SLSH,
     // @     A        B        C        D        E        F        G
-    UK_QUOT, UK_A, UK_B, UK_C, UK_D, UK_E, UK_F, UK_G,
+    UK_QUOT, UK_A,    UK_B,    UK_C,    UK_D,    UK_E,    UK_F,    UK_G,
     // H     I        J        K        L        M        N        O
-    UK_H, UK_I, UK_J, UK_K, UK_L, UK_M, UK_N, UK_O,
+    UK_H,    UK_I,    UK_J,    UK_K,    UK_L,    UK_M,    UK_N,    UK_O,
     // P     Q        R        S        T        U        V        W
-    UK_P, UK_Q, UK_R, UK_S, UK_T, UK_U, UK_V, UK_W,
+    UK_P,    UK_Q,    UK_R,    UK_S,    UK_T,    UK_U,    UK_V,    UK_W,
     // X     Y        Z        [        \        ]        ^        _
-    UK_X, UK_Y, UK_Z, UK_LBRC, UK_BSLS, UK_RBRC, UK_6, UK_MINS,
+    UK_X,    UK_Y,    UK_Z,    UK_LBRC, UK_BSLS, UK_RBRC, UK_6,    UK_MINS,
     // `     a        b        c        d        e        f        g
-    UK_GRV, UK_A, UK_B, UK_C, UK_D, UK_E, UK_F, UK_G,
+    UK_GRV,  UK_A,    UK_B,    UK_C,    UK_D,    UK_E,    UK_F,    UK_G,
     // h     i        j        k        l        m        n        o
-    UK_H, UK_I, UK_J, UK_K, UK_L, UK_M, UK_N, UK_O,
+    UK_H,    UK_I,    UK_J,    UK_K,    UK_L,    UK_M,    UK_N,    UK_O,
     // p     q        r        s        t        u        v        w
-    UK_P, UK_Q, UK_R, UK_S, UK_T, UK_U, UK_V, UK_W,
+    UK_P,    UK_Q,    UK_R,    UK_S,    UK_T,    UK_U,    UK_V,    UK_W,
     // x     y        z        {        |        }        ~        DEL
-    UK_X, UK_Y, UK_Z, UK_LBRC, UK_BSLS, UK_RBRC, UK_HASH, KC_DEL};
+    UK_X,    UK_Y,    UK_Z,    UK_LBRC, UK_BSLS, UK_RBRC, UK_HASH, KC_DEL
+};

--- a/quantum/keymap_extras/sendstring_workman.h
+++ b/quantum/keymap_extras/sendstring_workman.h
@@ -20,37 +20,40 @@
 
 #include "keymap_workman.h"
 
+// clang-format off
+
 const uint8_t ascii_to_keycode_lut[128] PROGMEM = {
     // NUL   SOH      STX      ETX      EOT      ENQ      ACK      BEL
     XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
     // BS    TAB      LF       VT       FF       CR       SO       SI
-    KC_BSPC, KC_TAB, KC_ENT, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+    KC_BSPC, KC_TAB,  KC_ENT,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
     // DLE   DC1      DC2      DC3      DC4      NAK      SYN      ETB
     XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
     // CAN   EM       SUB      ESC      FS       GS       RS       US
-    XXXXXXX, XXXXXXX, XXXXXXX, KC_ESC, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+    XXXXXXX, XXXXXXX, XXXXXXX, KC_ESC,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
 
     //       !        "        #        $        %        &        '
-    KC_SPC, KC_1, KC_QUOT, KC_3, KC_4, KC_5, KC_7, KC_QUOT,
+    KC_SPC,  KC_1,    KC_QUOT, KC_3,    KC_4,    KC_5,    KC_7,    KC_QUOT,
     // (     )        *        +        ,        -        .        /
-    KC_9, KC_0, KC_8, KC_EQL, KC_COMM, KC_MINS, KC_DOT, KC_SLSH,
+    KC_9,    KC_0,    KC_8,    KC_EQL,  KC_COMM, KC_MINS, KC_DOT,  KC_SLSH,
     // 0     1        2        3        4        5        6        7
-    KC_0, KC_1, KC_2, KC_3, KC_4, KC_5, KC_6, KC_7,
+    KC_0,    KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,
     // 8     9        :        ;        <        =        >        ?
-    KC_8, KC_9, KC_SCLN, KC_SCLN, KC_COMM, KC_EQL, KC_DOT, KC_SLSH,
+    KC_8,    KC_9,    KC_SCLN, KC_SCLN, KC_COMM, KC_EQL,  KC_DOT,  KC_SLSH,
     // @     A        B        C        D        E        F        G
-    KC_2, WK_A, WK_B, WK_C, WK_D, WK_E, WK_F, WK_G,
+    KC_2,    WK_A,    WK_B,    WK_C,    WK_D,    WK_E,    WK_F,    WK_G,
     // H     I        J        K        L        M        N        O
-    WK_H, WK_I, WK_J, WK_K, WK_L, WK_M, WK_N, WK_O,
+    WK_H,    WK_I,    WK_J,    WK_K,    WK_L,    WK_M,    WK_N,    WK_O,
     // P     Q        R        S        T        U        V        W
-    WK_P, WK_Q, WK_R, WK_S, WK_T, WK_U, WK_V, WK_W,
+    WK_P,    WK_Q,    WK_R,    WK_S,    WK_T,    WK_U,    WK_V,    WK_W,
     // X     Y        Z        [        \        ]        ^        _
-    WK_X, WK_Y, WK_Z, KC_LBRC, KC_BSLS, KC_RBRC, KC_6, KC_MINS,
+    WK_X,    WK_Y,    WK_Z,    KC_LBRC, KC_BSLS, KC_RBRC, KC_6,    KC_MINS,
     // `     a        b        c        d        e        f        g
-    KC_GRV, WK_A, WK_B, WK_C, WK_D, WK_E, WK_F, WK_G,
+    KC_GRV,  WK_A,    WK_B,    WK_C,    WK_D,    WK_E,    WK_F,    WK_G,
     // h     i        j        k        l        m        n        o
-    WK_H, WK_I, WK_J, WK_K, WK_L, WK_M, WK_N, WK_O,
+    WK_H,    WK_I,    WK_J,    WK_K,    WK_L,    WK_M,    WK_N,    WK_O,
     // p     q        r        s        t        u        v        w
-    WK_P, WK_Q, WK_R, WK_S, WK_T, WK_U, WK_V, WK_W,
+    WK_P,    WK_Q,    WK_R,    WK_S,    WK_T,    WK_U,    WK_V,    WK_W,
     // x     y        z        {        |        }        ~        DEL
-    WK_X, WK_Y, WK_Z, KC_LBRC, KC_BSLS, KC_RBRC, KC_GRV, KC_DEL};
+    WK_X,    WK_Y,    WK_Z,    KC_LBRC, KC_BSLS, KC_RBRC, KC_GRV,  KC_DEL
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Setting `clang-format off` and un-clang-formatting the `sendstring_*.h` files to make them align again.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
