### PR TITLE
Reduce duplication for ARM/AVR ws2812 RGB Matrix driver

### DIFF
--- a/drivers/avr/ws2812.c
+++ b/drivers/avr/ws2812.c
@@ -25,13 +25,17 @@
 #include <avr/interrupt.h>
 #include <avr/io.h>
 #include <util/delay.h>
-#include "debug.h"
 
-#if !defined(LED_ARRAY) && defined(RGB_MATRIX_ENABLE)
-// LED color buffer
-LED_TYPE led[DRIVER_LED_TOTAL];
-#    define LED_ARRAY led
-#endif
+/*
+ * Forward declare internal functions
+ *
+ * The functions take a byte-array and send to the data output as WS2812 bitstream.
+ * The length is the number of bytes to send - three per LED.
+ */
+
+void ws2812_sendarray(uint8_t *array, uint16_t length);
+void ws2812_sendarray_mask(uint8_t *array, uint16_t length, uint8_t pinmask);
+
 
 #ifdef RGBW_BB_TWI
 
@@ -133,23 +137,6 @@ unsigned char I2C_Write(unsigned char c) {
     return 0;
 }
 
-#endif
-
-#ifdef RGB_MATRIX_ENABLE
-// Set an led in the buffer to a color
-void inline ws2812_setled(int i, uint8_t r, uint8_t g, uint8_t b) {
-    led[i].r = r;
-    led[i].g = g;
-    led[i].b = b;
-}
-
-void ws2812_setled_all(uint8_t r, uint8_t g, uint8_t b) {
-    for (int i = 0; i < sizeof(led) / sizeof(led[0]); i++) {
-        led[i].r = r;
-        led[i].g = g;
-        led[i].b = b;
-    }
-}
 #endif
 
 // Setleds for standard RGB

--- a/drivers/avr/ws2812.h
+++ b/drivers/avr/ws2812.h
@@ -20,13 +20,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIGHT_WS2812_H_
-#define LIGHT_WS2812_H_
-
-#include <avr/io.h>
-#include <avr/interrupt.h>
-//#include "ws2812_config.h"
-//#include "i2cmaster.h"
+#pragma once
 
 #include "quantum/color.h"
 
@@ -42,33 +36,6 @@
  *         - Send out the LED data
  *         - Wait 50�s to reset the LEDs
  */
-#ifdef RGB_MATRIX_ENABLE
-void ws2812_setled(int index, uint8_t r, uint8_t g, uint8_t b);
-void ws2812_setled_all(uint8_t r, uint8_t g, uint8_t b);
-#endif
-
 void ws2812_setleds(LED_TYPE *ledarray, uint16_t number_of_leds);
 void ws2812_setleds_pin(LED_TYPE *ledarray, uint16_t number_of_leds, uint8_t pinmask);
 void ws2812_setleds_rgbw(LED_TYPE *ledarray, uint16_t number_of_leds);
-
-/*
- * Old interface / Internal functions
- *
- * The functions take a byte-array and send to the data output as WS2812 bitstream.
- * The length is the number of bytes to send - three per LED.
- */
-
-void ws2812_sendarray(uint8_t *array, uint16_t length);
-void ws2812_sendarray_mask(uint8_t *array, uint16_t length, uint8_t pinmask);
-
-/*
- * Internal defines
- */
-#ifndef CONCAT
-#    define CONCAT(a, b) a##b
-#endif
-#ifndef CONCAT_EXP
-#    define CONCAT_EXP(a, b) CONCAT(a, b)
-#endif
-
-#endif /* LIGHT_WS2812_H_ */

--- a/quantum/rgb_matrix_drivers.c
+++ b/quantum/rgb_matrix_drivers.c
@@ -116,7 +116,7 @@ static inline void setled(int i, uint8_t r, uint8_t g, uint8_t b) {
 
 static void setled_all(uint8_t r, uint8_t g, uint8_t b) {
     for (int i = 0; i < sizeof(led) / sizeof(led[0]); i++) {
-        setled(i, r, b, b);
+        setled(i, r, g, b);
     }
 }
 

--- a/quantum/rgb_matrix_drivers.c
+++ b/quantum/rgb_matrix_drivers.c
@@ -97,19 +97,33 @@ const rgb_matrix_driver_t rgb_matrix_driver = {
 
 #elif defined(WS2812)
 
-extern LED_TYPE led[DRIVER_LED_TOTAL];
+// LED color buffer
+LED_TYPE led[DRIVER_LED_TOTAL];
+
+static void init(void) {}
 
 static void flush(void) {
     // Assumes use of RGB_DI_PIN
     ws2812_setleds(led, DRIVER_LED_TOTAL);
 }
 
-static void init(void) {}
+// Set an led in the buffer to a color
+static inline void setled(int i, uint8_t r, uint8_t g, uint8_t b) {
+    led[i].r = r;
+    led[i].g = g;
+    led[i].b = b;
+}
+
+static void setled_all(uint8_t r, uint8_t g, uint8_t b) {
+    for (int i = 0; i < sizeof(led) / sizeof(led[0]); i++) {
+        setled(i, r, b, b);
+    }
+}
 
 const rgb_matrix_driver_t rgb_matrix_driver = {
     .init          = init,
     .flush         = flush,
-    .set_color     = ws2812_setled,
-    .set_color_all = ws2812_setled_all,
+    .set_color     = setled,
+    .set_color_all = setled_all,
 };
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
When producing a ARM ws2812 driver (#7173), it has been noted that the rgb matrix specific code ends up duplicated. This worsens when we pursue adding pwm, spi, and attiny85 based i2c implementations to core. 

As the required shim is quite small, Ive chosen to add it to `rgb_matrix_drivers.c`, quick checks show no overall impact to compiled firmware.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
