### PR TITLE
Fix Lily58 build with link-time optimization

### DIFF
--- a/keyboards/lily58/config.h
+++ b/keyboards/lily58/config.h
@@ -24,5 +24,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define USE_I2C
 #define USE_SERIAL
 
-#define NO_ACTION_MACRO
-#define NO_ACTION_FUNCTION
+#if !defined(NO_ACTION_MACRO)
+    #define NO_ACTION_MACRO
+#endif
+#if !defined(NO_ACTION_FUNCTION)
+    #define NO_ACTION_FUNCTION
+#endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Currently the Lily58 keyboard doesn't build with `LINK_TIME_OPTIMIZATON_ENABLE = yes` due to multiple definition of a couple macros. This PR fixes that.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [X] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

Before this PR,

    $ LINK_TIME_OPTIMIZATION_ENABLE=yes make lily58:default

fails with this error:

    Compiling: keyboards/lily58/i2c.c                                                                  In file included from 
    <command-line>:0:0:
    ./keyboards/lily58/config.h:27:0: error: "NO_ACTION_MACRO" redefined [-Werror]
     #define NO_ACTION_MACRO
     ^
    <command-line>:0:0: note: this is the location of the previous definition
    In file included from <command-line>:0:0:
    ./keyboards/lily58/config.h:28:0: error: "NO_ACTION_FUNCTION" redefined [-Werror]
     #define NO_ACTION_FUNCTION
     ^
    <command-line>:0:0: note: this is the location of the previous definition

After this PR, it compiles successfully.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
