### PR TITLE
CLI: Rework ModemManager check and add udev check

### DIFF
--- a/lib/python/qmk/cli/doctor.py
+++ b/lib/python/qmk/cli/doctor.py
@@ -57,7 +57,7 @@ def doctor(cli):
                          "input-club": {'SUBSYSTEMS=="usb", ATTRS{idVendor}=="1c11", MODE:="0666"'},
                          "stm32": {'SUBSYSTEMS=="usb", ATTRS{idVendor}=="1eaf", ATTRS{idProduct}=="0003", MODE:="0666"',
                                    'SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", MODE:="0666"'},
-                         "catalina": {'ATTRS{idVendor}=="2a03", ENV{ID_MM_DEVICE_IGNORE}="1"',
+                         "caterina": {'ATTRS{idVendor}=="2a03", ENV{ID_MM_DEVICE_IGNORE}="1"',
                                       'ATTRS{idVendor}=="2341", ENV{ID_MM_DEVICE_IGNORE}="1"'}}
         if os.path.exists(udev_dir):
             udev_rules = [rule for rule in glob.iglob(os.path.join(udev_dir, "*.rules")) if os.path.isfile(rule)]
@@ -74,12 +74,12 @@ def doctor(cli):
             for bootloader, rules in desired_rules.items():
                 if not rules.issubset(current_rules):
                     # If the rules for catalina are not present, check if ModemManager is running
-                    if bootloader == "catalina":
+                    if bootloader == "caterina":
                         if shutil.which("systemctl"):
                             mm_check = subprocess.run(["systemctl", "--quiet", "is-active", "ModemManager.service"], timeout=10)
                             if mm_check.returncode == 0:
                                 ok = False
-                                cli.log.warn("{bg_yellow}Detected ModemManager without udev rules. Please either disable it or set the appropriate udev rules if you are using a Pro-Micro.")
+                                cli.log.warn("{bg_yellow}Detected ModemManager without udev rules. Please either disable it or set the appropriate udev rules if you are using a Pro Micro.")
                         else:
                             cli.log.warn("Can't find systemctl to check for ModemManager.")
                     else:

--- a/lib/python/qmk/cli/doctor.py
+++ b/lib/python/qmk/cli/doctor.py
@@ -10,13 +10,15 @@ import glob
 
 from milc import cli
 
-def _udev_rule(vid, pid = None):
+
+def _udev_rule(vid, pid=None):
     """ Helper function that return udev rules
     """
     if pid:
         return 'SUBSYSTEMS=="usb", ATTRS{idVendor}=="%s", ATTRS{idProduct}=="%s", MODE:="0666"' % (vid, pid)
     else:
         return 'SUBSYSTEMS=="usb", ATTRS{idVendor}=="%s", MODE:="0666"' % vid
+
 
 @cli.subcommand('Basic QMK environment checks')
 def doctor(cli):
@@ -57,17 +59,14 @@ def doctor(cli):
         # Checking for udev rules
         udev_dir = "/etc/udev/rules.d/"
         # These are the recommended udev rules
-        desired_rules = dict(dfu = {_udev_rule("03eb", "2ff4"),_udev_rule("03eb", "2ffb"), _udev_rule("03eb", "2ff0")},
+        desired_rules = {
+            'dfu': {_udev_rule("03eb", "2ff4"), _udev_rule("03eb", "2ffb"), _udev_rule("03eb", "2ff0")},
+            'tmk': {_udev_rule("feed")},
+            'input_club': {_udev_rule("1c11")},
+            'stm32': {_udev_rule("1eaf", "0003"), _udev_rule("0483", "df11")},
+            'caterina': {'ATTRS{idVendor}=="2a03", ENV{ID_MM_DEVICE_IGNORE}="1"', 'ATTRS{idVendor}=="2341", ENV{ID_MM_DEVICE_IGNORE}="1"'},
+        }
 
-                             tmk = {_udev_rule("feed")},
-
-                             input_club = {_udev_rule("1c11")},
-
-                             stm32 = {_udev_rule("1eaf", "0003"),_udev_rule("0483", "df11")},
-
-                             caterina = {'ATTRS{idVendor}=="2a03", ENV{ID_MM_DEVICE_IGNORE}="1"',
-                                         'ATTRS{idVendor}=="2341", ENV{ID_MM_DEVICE_IGNORE}="1"'}
-                             )
         if os.path.exists(udev_dir):
             udev_rules = [rule for rule in glob.iglob(os.path.join(udev_dir, "*.rules")) if os.path.isfile(rule)]
             # Collect all rules from the config files


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Check the udev rules on the system for the recommended rules. Print warning if not found.
If the udev rules for catalina bootloader are not present, check if ModemManager is running, because that could cause troubles with flashing. In this scenario the `doctor` strongly advices fixing the problem.

**Note**: I tested it the best I could, but most likely need some work before merging. I'm opening this PR in order to get early feedback and help with testing.
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
