### PR TITLE
Add auto-handling of stale PRs/Issues

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,56 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# General configuration
+
+# Pull request specific configuration
+pulls:
+  staleLabel: awaiting changes
+  # Number of days of inactivity before an Issue or Pull Request becomes stale
+  daysUntilStale: 45
+  # Number of days of inactivity before a stale Issue or Pull Request is closed.
+  # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+  daysUntilClose: 30
+  # Comment to post when marking as stale. Set to `false` to disable
+  markComment: >
+    This pull request has been automatically marked as stale because it has not had
+    activity in the last 45 days. It will be closed in 30 days if no further activity occurs.
+    Please feel free to give a status update now, or re-open when it's ready.
+
+    Thank you for your contributions!
+  # Comment to post when closing a stale Issue or Pull Request.
+  closeComment: >
+     This pull request has been automatically closed because it has not had activity in the last 30 days.
+     Please feel free to give a status update now, ping for review, or re-open when it's ready.
+
+     Thank you for your contributions!
+  # Limit the number of actions per hour, from 1-30. Default is 30
+  limitPerRun: 30
+  exemptLabels:
+    - awaiting review
+    - breaking_change
+    - in progress
+    - on hold
+
+# Issue specific configuration
+issues:
+  staleLabel: solved
+  limitPerRun: 10
+  daysUntilStale: 90
+  daysUntilClose: 30
+  markComment: >
+    This issue has been automatically marked as resolved because it has not had activity in the
+    last 90 days. It will be closed in the next 30 days unless it is tagged properly or other activity
+    occurs.
+
+    Thank you for your contributions!
+  closeComment: >
+    This issue has been automatically closed because it has not had activity in the last 30 days.
+    If this issue is still valid, please ping a maintainer.
+
+    Thank you for your contributions!
+  exemptLabels:
+    - bug
+    - in progress
+    - on hold
+    - discussion
+    - to do

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -12,17 +12,17 @@ pulls:
   daysUntilClose: 30
   # Comment to post when marking as stale. Set to `false` to disable
   markComment: >
+    Thank you for your contribution!
+
     This pull request has been automatically marked as stale because it has not had
     activity in the last 45 days. It will be closed in 30 days if no further activity occurs.
     Please feel free to give a status update now, or re-open when it's ready.
-
-    Thank you for your contributions!
   # Comment to post when closing a stale Issue or Pull Request.
   closeComment: >
-     This pull request has been automatically closed because it has not had activity in the last 30 days.
-     Please feel free to give a status update now, ping for review, or re-open when it's ready.
+    Thank you for your contribution!
 
-     Thank you for your contributions!
+    This pull request has been automatically closed because it has not had activity in the last 30 days.
+    Please feel free to give a status update now, ping for review, or re-open when it's ready.
   # Limit the number of actions per hour, from 1-30. Default is 30
   limitPerRun: 30
   exemptLabels:
@@ -41,13 +41,9 @@ issues:
     This issue has been automatically marked as resolved because it has not had activity in the
     last 90 days. It will be closed in the next 30 days unless it is tagged properly or other activity
     occurs.
-
-    Thank you for your contributions!
   closeComment: >
     This issue has been automatically closed because it has not had activity in the last 30 days.
-    If this issue is still valid, please ping a maintainer.
-
-    Thank you for your contributions!
+    If this issue is still valid, re-open the issue and let us know..
   exemptLabels:
     - bug
     - in progress

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -43,7 +43,7 @@ issues:
     occurs.
   closeComment: >
     This issue has been automatically closed because it has not had activity in the last 30 days.
-    If this issue is still valid, re-open the issue and let us know..
+    If this issue is still valid, re-open the issue and let us know.
   exemptLabels:
     - bug
     - in progress


### PR DESCRIPTION
This adds the configuration for probot-stale, so that PRs and Issues can be automatically pruned without intervention by collaborators.

This marks PRs with `awaiting changes` label after 45 days, and then closes any PR with "Awaiting changes" after 30 days.  Unless they have `awaiting review`, `breaking_changes`, `in progress` or `on hold` labels.

This marks issues as `solved` after 90 days, and then closes them 30 days afterwards. Unless they have `bug`, `discussion`, `to do`, `in progress` or `on hold` labels.


This does require the installation of the ProBot Stale bot.
https://github.com/probot/stale

~~Alternatively, there is: 
https://github.com/actions/stale~~

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
