### PR TITLE
Allow overriding of all functions in wonderland.c

### DIFF
--- a/docs/custom_quantum_functions.md
+++ b/docs/custom_quantum_functions.md
@@ -167,11 +167,16 @@ bool led_update_kb(led_t led_state) {
 This incomplete example, would play a sound if capslock was turned on or off. It returns true, because you also want the LEDs to maintain their state.
 
 ```c
+#ifdef AUDIO_ENABLE
+  float caps_on[][2] = SONG(CAPS_LOCK_ON_SOUND);
+  float caps_off[][2] = SONG(CAPS_LOCK_OFF_SOUND);
+#endif
+
 bool led_update_user(led_t led_state) {
     #ifdef AUDIO_ENABLE
     static uint8_t caps_state = 0;
     if (caps_state != led_state.caps_lock) {
-        led_state.caps_lock ? PLAY_SONG(SONG(CAPS_LOCK_ON_SOUND)) : PLAY_SONG(SONG(CAPS_LOCK_OFF_SOUND));
+        led_state.caps_lock ? PLAY_SONG(caps_on) : PLAY_SONG(caps_off);
         caps_state = led_state.caps_lock;
     }
     #endif

--- a/docs/custom_quantum_functions.md
+++ b/docs/custom_quantum_functions.md
@@ -164,33 +164,17 @@ bool led_update_kb(led_t led_state) {
 
 ### Example `led_update_user()` Implementation
 
+This incomplete example, would play a sound if capslock was turned on or off. It returns true, because you also want the LEDs to maintain their state.
+
 ```c
 bool led_update_user(led_t led_state) {
-    if (led_state.num_lock) {
-        writePinLow(B0);
-    } else {
-        writePinHigh(B0);
+    #ifdef AUDIO_ENABLE
+    static uint8_t caps_state = 0;
+    if (caps_state != led_state.caps_lock) {
+        led_state.caps_lock ? PLAY_SONG(SONG(CAPS_LOCK_ON_SOUND)) : PLAY_SONG(SONG(CAPS_LOCK_OFF_SOUND));
+        caps_state = led_state.caps_lock;
     }
-    if (led_state.caps_lock) {
-        writePinLow(B1);
-    } else {
-        writePinHigh(B1);
-    }
-    if (led_state.scroll_lock) {
-        writePinLow(B2);
-    } else {
-        writePinHigh(B2);
-    }
-    if (led_state.compose) {
-        writePinLow(B3);
-    } else {
-        writePinHigh(B3);
-    }
-    if (led_state.kana) {
-        writePinLow(B4);
-    } else {
-        writePinHigh(B4);
-    }
+    #endif
     return true;
 }
 ```

--- a/docs/custom_quantum_functions.md
+++ b/docs/custom_quantum_functions.md
@@ -504,7 +504,7 @@ The `val` is the value of the data that you want to write to EEPROM.  And the `e
 
 # Custom Tapping Term
 
-By default, the tapping term is defined globally, and is not configurable by key.  For most users, this is perfectly fine.  But in come cases, dual function keys would be greatly improved by different timeouts than `LT` keys, or because some keys may be easier to hold than others.  Instead of using custom key codes for each, this allows for per key configurable `TAPPING_TERM`. 
+By default, the tapping term is defined globally, and is not configurable by key.  For most users, this is perfectly fine.  But in come cases, dual function keys would be greatly improved by different timeouts than `LT` keys, or because some keys may be easier to hold than others.  Instead of using custom key codes for each, this allows for per key configurable `TAPPING_TERM`.
 
 To enable this functionality, you need to add `#define TAPPING_TERM_PER_KEY` to your `config.h`, first. 
 

--- a/docs/custom_quantum_functions.md
+++ b/docs/custom_quantum_functions.md
@@ -164,7 +164,7 @@ bool led_update_kb(led_t led_state) {
 
 ### Example `led_update_user()` Implementation
 
-This incomplete example, would play a sound if capslock was turned on or off. It returns true, because you also want the LEDs to maintain their state.
+This incomplete example would play a sound if Caps Lock is turned on or off. It returns `true`, because you also want the LEDs to maintain their state.
 
 ```c
 #ifdef AUDIO_ENABLE

--- a/docs/custom_quantum_functions.md
+++ b/docs/custom_quantum_functions.md
@@ -219,11 +219,11 @@ These are the three main initialization functions, listed in the order that they
 
 ## Keyboard Pre Initialization code
 
-This runs very early during startup, even before the USB has been started.
+This runs very early during startup, even before the USB has been started.  
 
 Shortly after this, the matrix is initialized.
 
-For most users, this shouldn't be used, as it's primarily for hardware oriented initialization.
+For most users, this shouldn't be used, as it's primarily for hardware oriented initialization.  
 
 However, if you have hardware stuff that you need initialized, this is the best place for it (such as initializing LED pins).
 
@@ -251,9 +251,9 @@ void keyboard_pre_init_user(void) {
 
 ## Matrix Initialization Code
 
-This is called when the matrix is initialized, and after some of the hardware has been set up, but before many of the features have been initialized.
+This is called when the matrix is initialized, and after some of the hardware has been set up, but before many of the features have been initialized.  
 
-This is useful for setting up stuff that you may need elsewhere, but isn't hardware related nor is dependant on where it's started.
+This is useful for setting up stuff that you may need elsewhere, but isn't hardware related nor is dependant on where it's started.  
 
 
 ### `matrix_init_*` Function Documentation
@@ -369,17 +369,17 @@ The `state` is the bitmask of the active layers, as explained in the [Keymap Ove
 
 # Persistent Configuration (EEPROM)
 
-This allows you to configure persistent settings for your keyboard.  These settings are stored in the EEPROM of your controller, and are retained even after power loss. The settings can be read with `eeconfig_read_kb` and `eeconfig_read_user`, and can be written to using `eeconfig_update_kb` and `eeconfig_update_user`. This is useful for features that you want to be able to toggle (like toggling rgb layer indication).  Additionally, you can use `eeconfig_init_kb` and `eeconfig_init_user` to set the default values for the EEPROM.
+This allows you to configure persistent settings for your keyboard.  These settings are stored in the EEPROM of your controller, and are retained even after power loss. The settings can be read with `eeconfig_read_kb` and `eeconfig_read_user`, and can be written to using `eeconfig_update_kb` and `eeconfig_update_user`. This is useful for features that you want to be able to toggle (like toggling rgb layer indication).  Additionally, you can use `eeconfig_init_kb` and `eeconfig_init_user` to set the default values for the EEPROM.  
 
 The complicated part here, is that there are a bunch of ways that you can store and access data via EEPROM, and there is no "correct" way to do this.  However, you only have a DWORD (4 bytes) for each function.
 
 Keep in mind that EEPROM has a limited number of writes. While this is very high, it's not the only thing writing to the EEPROM, and if you write too often, you can potentially drastically shorten the life of your MCU.
 
-* If you don't understand the example, then you may want to avoid using this feature, as it is rather complicated.
+* If you don't understand the example, then you may want to avoid using this feature, as it is rather complicated.  
 
 ### Example Implementation
 
-This is an example of how to add settings, and read and write it. We're using the user keymap for the example here.  This is a complex function, and has a lot going on.  In fact, it uses a lot of the above functions to work!
+This is an example of how to add settings, and read and write it. We're using the user keymap for the example here.  This is a complex function, and has a lot going on.  In fact, it uses a lot of the above functions to work!  
 
 
 In your keymap.c file, add this to the top:
@@ -394,11 +394,11 @@ typedef union {
 user_config_t user_config;
 ```
 
-This sets up a 32 bit structure that we can store settings with in memory, and write to the EEPROM. Using this removes the need to define variables, since they're defined in this structure. Remember that `bool` (boolean) values use 1 bit, `uint8_t` uses 8 bits, `uint16_t` uses up 16 bits.  You can mix and match, but changing the order can cause issues, as it will change the values that are read and written.
+This sets up a 32 bit structure that we can store settings with in memory, and write to the EEPROM. Using this removes the need to define variables, since they're defined in this structure. Remember that `bool` (boolean) values use 1 bit, `uint8_t` uses 8 bits, `uint16_t` uses up 16 bits.  You can mix and match, but changing the order can cause issues, as it will change the values that are read and written.  
 
-We're using `rgb_layer_change`, for the `layer_state_set_*` function, and use `keyboard_post_init_user` and `process_record_user` to configure everything.
+We're using `rgb_layer_change`, for the `layer_state_set_*` function, and use `keyboard_post_init_user` and `process_record_user` to configure everything.  
 
-Now, using the `keyboard_post_init_user` code above, you want to add `eeconfig_read_user()` to it, to populate the structure you've just created. And you can then immediately use this structure to control functionality in your keymap.  And It should look like:
+Now, using the `keyboard_post_init_user` code above, you want to add `eeconfig_read_user()` to it, to populate the structure you've just created. And you can then immediately use this structure to control functionality in your keymap.  And It should look like:  
 ```c
 void keyboard_post_init_user(void) {
   // Call the keymap level matrix init.

--- a/docs/custom_quantum_functions.md
+++ b/docs/custom_quantum_functions.md
@@ -493,7 +493,7 @@ void eeconfig_init_user(void) {  // EEPROM is getting reset!
 }
 ```
 
-And you're done.  The RGB layer indication will only work if you want it to. And it will be saved, even after unplugging the board. And if you use any of the RGB codes, it will disable the layer indication, so that it stays on the mode and color that you set it to.
+And you're done.  The RGB layer indication will only work if you want it to. And it will be saved, even after unplugging the board. And if you use any of the RGB codes, it will disable the layer indication, so that it stays on the mode and color that you set it to. 
 
 ### 'EECONFIG' Function Documentation
 
@@ -504,7 +504,7 @@ The `val` is the value of the data that you want to write to EEPROM.  And the `e
 
 # Custom Tapping Term
 
-By default, the tapping term is defined globally, and is not configurable by key.  For most users, this is perfectly fine.  But in come cases, dual function keys would be greatly improved by different timeouts than `LT` keys, or because some keys may be easier to hold than others.  Instead of using custom key codes for each, this allows for per key configurable `TAPPING_TERM`.
+By default, the tapping term is defined globally, and is not configurable by key.  For most users, this is perfectly fine.  But in come cases, dual function keys would be greatly improved by different timeouts than `LT` keys, or because some keys may be easier to hold than others.  Instead of using custom key codes for each, this allows for per key configurable `TAPPING_TERM`. 
 
 To enable this functionality, you need to add `#define TAPPING_TERM_PER_KEY` to your `config.h`, first. 
 

--- a/docs/custom_quantum_functions.md
+++ b/docs/custom_quantum_functions.md
@@ -117,7 +117,7 @@ This function will be called when the state of one of those 5 LEDs changes. It r
 By convention, return `true` from `led_update_user()` to get the `led_update_kb()` hook to run its code, and
 return `false` when you would prefer not to run the code in `led_update_kb()`.
 
-Some example include:
+Some examples include:
 
   - overriding the LEDs to use them for something else like layer indication
     - return false as you do not want the `_kb` functions to run as they would override your layer behavior.

--- a/docs/custom_quantum_functions.md
+++ b/docs/custom_quantum_functions.md
@@ -115,7 +115,7 @@ Two more deprecated functions exist that provide the LED state as a `uint8_t`:
 This function will be called when the state of one of those 5 LEDs changes. It receives the LED state as a struct parameter.
 
 By convention, return `true` from `led_update_user()` to get the `led_update_kb()` hook to run its code, and
-return false when you would prefer not to run the code in `led_update_kb()`.
+return `false` when you would prefer not to run the code in `led_update_kb()`.
 
 Some example include:
 

--- a/docs/custom_quantum_functions.md
+++ b/docs/custom_quantum_functions.md
@@ -219,11 +219,11 @@ These are the three main initialization functions, listed in the order that they
 
 ## Keyboard Pre Initialization code
 
-This runs very early during startup, even before the USB has been started.  
+This runs very early during startup, even before the USB has been started. 
 
 Shortly after this, the matrix is initialized.
 
-For most users, this shouldn't be used, as it's primarily for hardware oriented initialization.  
+For most users, this shouldn't be used, as it's primarily for hardware oriented initialization. 
 
 However, if you have hardware stuff that you need initialized, this is the best place for it (such as initializing LED pins).
 
@@ -251,9 +251,9 @@ void keyboard_pre_init_user(void) {
 
 ## Matrix Initialization Code
 
-This is called when the matrix is initialized, and after some of the hardware has been set up, but before many of the features have been initialized.  
+This is called when the matrix is initialized, and after some of the hardware has been set up, but before many of the features have been initialized. 
 
-This is useful for setting up stuff that you may need elsewhere, but isn't hardware related nor is dependant on where it's started.  
+This is useful for setting up stuff that you may need elsewhere, but isn't hardware related nor is dependant on where it's started. 
 
 
 ### `matrix_init_*` Function Documentation
@@ -369,17 +369,17 @@ The `state` is the bitmask of the active layers, as explained in the [Keymap Ove
 
 # Persistent Configuration (EEPROM)
 
-This allows you to configure persistent settings for your keyboard.  These settings are stored in the EEPROM of your controller, and are retained even after power loss. The settings can be read with `eeconfig_read_kb` and `eeconfig_read_user`, and can be written to using `eeconfig_update_kb` and `eeconfig_update_user`. This is useful for features that you want to be able to toggle (like toggling rgb layer indication).  Additionally, you can use `eeconfig_init_kb` and `eeconfig_init_user` to set the default values for the EEPROM.  
+This allows you to configure persistent settings for your keyboard.  These settings are stored in the EEPROM of your controller, and are retained even after power loss. The settings can be read with `eeconfig_read_kb` and `eeconfig_read_user`, and can be written to using `eeconfig_update_kb` and `eeconfig_update_user`. This is useful for features that you want to be able to toggle (like toggling rgb layer indication).  Additionally, you can use `eeconfig_init_kb` and `eeconfig_init_user` to set the default values for the EEPROM. 
 
 The complicated part here, is that there are a bunch of ways that you can store and access data via EEPROM, and there is no "correct" way to do this.  However, you only have a DWORD (4 bytes) for each function.
 
 Keep in mind that EEPROM has a limited number of writes. While this is very high, it's not the only thing writing to the EEPROM, and if you write too often, you can potentially drastically shorten the life of your MCU.
 
-* If you don't understand the example, then you may want to avoid using this feature, as it is rather complicated.  
+* If you don't understand the example, then you may want to avoid using this feature, as it is rather complicated. 
 
 ### Example Implementation
 
-This is an example of how to add settings, and read and write it. We're using the user keymap for the example here.  This is a complex function, and has a lot going on.  In fact, it uses a lot of the above functions to work!  
+This is an example of how to add settings, and read and write it. We're using the user keymap for the example here.  This is a complex function, and has a lot going on.  In fact, it uses a lot of the above functions to work! 
 
 
 In your keymap.c file, add this to the top:
@@ -394,11 +394,11 @@ typedef union {
 user_config_t user_config;
 ```
 
-This sets up a 32 bit structure that we can store settings with in memory, and write to the EEPROM. Using this removes the need to define variables, since they're defined in this structure. Remember that `bool` (boolean) values use 1 bit, `uint8_t` uses 8 bits, `uint16_t` uses up 16 bits.  You can mix and match, but changing the order can cause issues, as it will change the values that are read and written.  
+This sets up a 32 bit structure that we can store settings with in memory, and write to the EEPROM. Using this removes the need to define variables, since they're defined in this structure. Remember that `bool` (boolean) values use 1 bit, `uint8_t` uses 8 bits, `uint16_t` uses up 16 bits.  You can mix and match, but changing the order can cause issues, as it will change the values that are read and written. 
 
-We're using `rgb_layer_change`, for the `layer_state_set_*` function, and use `keyboard_post_init_user` and `process_record_user` to configure everything.  
+We're using `rgb_layer_change`, for the `layer_state_set_*` function, and use `keyboard_post_init_user` and `process_record_user` to configure everything. 
 
-Now, using the `keyboard_post_init_user` code above, you want to add `eeconfig_read_user()` to it, to populate the structure you've just created. And you can then immediately use this structure to control functionality in your keymap.  And It should look like:  
+Now, using the `keyboard_post_init_user` code above, you want to add `eeconfig_read_user()` to it, to populate the structure you've just created. And you can then immediately use this structure to control functionality in your keymap.  And It should look like: 
 ```c
 void keyboard_post_init_user(void) {
   // Call the keymap level matrix init.
@@ -414,7 +414,7 @@ void keyboard_post_init_user(void) {
   }
 }
 ```
-The above function will use the EEPROM config immediately after reading it, to set the default layer's RGB color. The "raw" value of it is converted in a usable structure based on the "union" that you created above.
+The above function will use the EEPROM config immediately after reading it, to set the default layer's RGB color. The "raw" value of it is converted in a usable structure based on the "union" that you created above. 
 
 ```c
 layer_state_t layer_state_set_user(layer_state_t state) {
@@ -478,7 +478,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
   }
 }
 ```
-And lastly, you want to add the `eeconfig_init_user` function, so that when the EEPROM is reset, you can specify default values, and even custom actions. To force an EEPROM reset, use the `EEP_RST` keycode or [Bootmagic](feature_bootmagic.md) functionallity. For example, if you want to set rgb layer indication by default, and save the default valued.
+And lastly, you want to add the `eeconfig_init_user` function, so that when the EEPROM is reset, you can specify default values, and even custom actions. To force an EEPROM reset, use the `EEP_RST` keycode or [Bootmagic](feature_bootmagic.md) functionallity. For example, if you want to set rgb layer indication by default, and save the default valued. 
 
 ```c
 void eeconfig_init_user(void) {  // EEPROM is getting reset!
@@ -500,18 +500,18 @@ And you're done.  The RGB layer indication will only work if you want it to. And
 * Keyboard/Revision: `void eeconfig_init_kb(void)`, `uint32_t eeconfig_read_kb(void)` and `void eeconfig_update_kb(uint32_t val)`
 * Keymap: `void eeconfig_init_user(void)`, `uint32_t eeconfig_read_user(void)` and `void eeconfig_update_user(uint32_t val)`
 
-The `val` is the value of the data that you want to write to EEPROM.  And the `eeconfig_read_*` function return a 32 bit (DWORD) value from the EEPROM.
+The `val` is the value of the data that you want to write to EEPROM.  And the `eeconfig_read_*` function return a 32 bit (DWORD) value from the EEPROM. 
 
 # Custom Tapping Term
 
 By default, the tapping term is defined globally, and is not configurable by key.  For most users, this is perfectly fine.  But in come cases, dual function keys would be greatly improved by different timeouts than `LT` keys, or because some keys may be easier to hold than others.  Instead of using custom key codes for each, this allows for per key configurable `TAPPING_TERM`.
 
-To enable this functionality, you need to add `#define TAPPING_TERM_PER_KEY` to your `config.h`, first.
+To enable this functionality, you need to add `#define TAPPING_TERM_PER_KEY` to your `config.h`, first. 
 
 
 ## Example `get_tapping_term` Implementation
 
-To change the `TAPPING TERM` based on the keycode, you'd want to add something like the following to your `keymap.c` file:
+To change the `TAPPING TERM` based on the keycode, you'd want to add something like the following to your `keymap.c` file: 
 
 ```c
 uint16_t get_tapping_term(uint16_t keycode) {

--- a/docs/custom_quantum_functions.md
+++ b/docs/custom_quantum_functions.md
@@ -114,7 +114,7 @@ Two more deprecated functions exist that provide the LED state as a `uint8_t`:
 
 This function will be called when the state of one of those 5 LEDs changes. It receives the LED state as a struct parameter.
 
-By convention, return true from `led_update_user()` to get the `led_update_kb()` hook to run it's code, and
+By convention, return `true` from `led_update_user()` to get the `led_update_kb()` hook to run its code, and
 return false when you would prefer not to run the code in `led_update_kb()`.
 
 Some example include:

--- a/docs/custom_quantum_functions.md
+++ b/docs/custom_quantum_functions.md
@@ -122,7 +122,7 @@ Some examples include:
   - overriding the LEDs to use them for something else like layer indication
     - return `false` because you do not want the `_kb()` function to run, as it would override your layer behavior.
   - play a sound when an LED turns on or off.
-    - return true because you want the `_kb` function to run and this is in addition to the default LED behavior.
+    - return `true` because you want the `_kb` function to run, and this is in addition to the default LED behavior.
 
 ?> Because the `led_set_*` functions return `void` instead of `bool`, they do not allow for overriding the keyboard LED control, and thus it's recommended to use `led_update_*` instead.
 

--- a/docs/custom_quantum_functions.md
+++ b/docs/custom_quantum_functions.md
@@ -114,7 +114,15 @@ Two more deprecated functions exist that provide the LED state as a `uint8_t`:
 
 This function will be called when the state of one of those 5 LEDs changes. It receives the LED state as a struct parameter.
 
-You must return either `true` or `false` from this function, depending on whether you want to override the keyboard-level implementation.
+By convention, return true from `led_update_user()` to get the `led_update_kb()` hook to run it's code, and
+return false when you would prefer not to run the code in `led_update_kb()`.
+
+Some example include:
+
+  - overriding the LEDs to use them for something else like layer indication
+    - return false as you do not want the `_kb` functions to run as they would override your layer behavior.
+  - play a sound when an LED turns on or off.
+    - return true because you want the `_kb` function to run and this is in addition to the default LED behavior.
 
 ?> Because the `led_set_*` functions return `void` instead of `bool`, they do not allow for overriding the keyboard LED control, and thus it's recommended to use `led_update_*` instead.
 
@@ -122,7 +130,8 @@ You must return either `true` or `false` from this function, depending on whethe
 
 ```c
 bool led_update_kb(led_t led_state) {
-    if(led_update_user(led_state)) {
+    bool res = led_update_user(led_state);
+    if(res) {
         if (led_state.num_lock) {
             writePinLow(B0);
         } else {
@@ -148,8 +157,8 @@ bool led_update_kb(led_t led_state) {
         } else {
             writePinHigh(B4);
         }
-        return true;
     }
+    return res;
 }
 ```
 
@@ -221,11 +230,11 @@ These are the three main initialization functions, listed in the order that they
 
 ## Keyboard Pre Initialization code
 
-This runs very early during startup, even before the USB has been started. 
+This runs very early during startup, even before the USB has been started.
 
 Shortly after this, the matrix is initialized.
 
-For most users, this shouldn't be used, as it's primarily for hardware oriented initialization. 
+For most users, this shouldn't be used, as it's primarily for hardware oriented initialization.
 
 However, if you have hardware stuff that you need initialized, this is the best place for it (such as initializing LED pins).
 
@@ -253,9 +262,9 @@ void keyboard_pre_init_user(void) {
 
 ## Matrix Initialization Code
 
-This is called when the matrix is initialized, and after some of the hardware has been set up, but before many of the features have been initialized. 
+This is called when the matrix is initialized, and after some of the hardware has been set up, but before many of the features have been initialized.
 
-This is useful for setting up stuff that you may need elsewhere, but isn't hardware related nor is dependant on where it's started. 
+This is useful for setting up stuff that you may need elsewhere, but isn't hardware related nor is dependant on where it's started.
 
 
 ### `matrix_init_*` Function Documentation
@@ -371,17 +380,17 @@ The `state` is the bitmask of the active layers, as explained in the [Keymap Ove
 
 # Persistent Configuration (EEPROM)
 
-This allows you to configure persistent settings for your keyboard.  These settings are stored in the EEPROM of your controller, and are retained even after power loss. The settings can be read with `eeconfig_read_kb` and `eeconfig_read_user`, and can be written to using `eeconfig_update_kb` and `eeconfig_update_user`. This is useful for features that you want to be able to toggle (like toggling rgb layer indication).  Additionally, you can use `eeconfig_init_kb` and `eeconfig_init_user` to set the default values for the EEPROM. 
+This allows you to configure persistent settings for your keyboard.  These settings are stored in the EEPROM of your controller, and are retained even after power loss. The settings can be read with `eeconfig_read_kb` and `eeconfig_read_user`, and can be written to using `eeconfig_update_kb` and `eeconfig_update_user`. This is useful for features that you want to be able to toggle (like toggling rgb layer indication).  Additionally, you can use `eeconfig_init_kb` and `eeconfig_init_user` to set the default values for the EEPROM.
 
 The complicated part here, is that there are a bunch of ways that you can store and access data via EEPROM, and there is no "correct" way to do this.  However, you only have a DWORD (4 bytes) for each function.
 
 Keep in mind that EEPROM has a limited number of writes. While this is very high, it's not the only thing writing to the EEPROM, and if you write too often, you can potentially drastically shorten the life of your MCU.
 
-* If you don't understand the example, then you may want to avoid using this feature, as it is rather complicated. 
+* If you don't understand the example, then you may want to avoid using this feature, as it is rather complicated.
 
 ### Example Implementation
 
-This is an example of how to add settings, and read and write it. We're using the user keymap for the example here.  This is a complex function, and has a lot going on.  In fact, it uses a lot of the above functions to work! 
+This is an example of how to add settings, and read and write it. We're using the user keymap for the example here.  This is a complex function, and has a lot going on.  In fact, it uses a lot of the above functions to work!
 
 
 In your keymap.c file, add this to the top:
@@ -396,11 +405,11 @@ typedef union {
 user_config_t user_config;
 ```
 
-This sets up a 32 bit structure that we can store settings with in memory, and write to the EEPROM. Using this removes the need to define variables, since they're defined in this structure. Remember that `bool` (boolean) values use 1 bit, `uint8_t` uses 8 bits, `uint16_t` uses up 16 bits.  You can mix and match, but changing the order can cause issues, as it will change the values that are read and written. 
+This sets up a 32 bit structure that we can store settings with in memory, and write to the EEPROM. Using this removes the need to define variables, since they're defined in this structure. Remember that `bool` (boolean) values use 1 bit, `uint8_t` uses 8 bits, `uint16_t` uses up 16 bits.  You can mix and match, but changing the order can cause issues, as it will change the values that are read and written.
 
-We're using `rgb_layer_change`, for the `layer_state_set_*` function, and use `keyboard_post_init_user` and `process_record_user` to configure everything. 
+We're using `rgb_layer_change`, for the `layer_state_set_*` function, and use `keyboard_post_init_user` and `process_record_user` to configure everything.
 
-Now, using the `keyboard_post_init_user` code above, you want to add `eeconfig_read_user()` to it, to populate the structure you've just created. And you can then immediately use this structure to control functionality in your keymap.  And It should look like: 
+Now, using the `keyboard_post_init_user` code above, you want to add `eeconfig_read_user()` to it, to populate the structure you've just created. And you can then immediately use this structure to control functionality in your keymap.  And It should look like:
 ```c
 void keyboard_post_init_user(void) {
   // Call the keymap level matrix init.
@@ -411,12 +420,12 @@ void keyboard_post_init_user(void) {
   // Set default layer, if enabled
   if (user_config.rgb_layer_change) {
     rgblight_enable_noeeprom();
-    rgblight_sethsv_noeeprom_cyan(); 
+    rgblight_sethsv_noeeprom_cyan();
     rgblight_mode_noeeprom(1);
   }
 }
 ```
-The above function will use the EEPROM config immediately after reading it, to set the default layer's RGB color. The "raw" value of it is converted in a usable structure based on the "union" that you created above. 
+The above function will use the EEPROM config immediately after reading it, to set the default layer's RGB color. The "raw" value of it is converted in a usable structure based on the "union" that you created above.
 
 ```c
 layer_state_t layer_state_set_user(layer_state_t state) {
@@ -459,18 +468,18 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         }
         return true; // Let QMK send the enter press/release events
     case RGB_LYR:  // This allows me to use underglow as layer indication, or as normal
-        if (record->event.pressed) { 
+        if (record->event.pressed) {
             user_config.rgb_layer_change ^= 1; // Toggles the status
             eeconfig_update_user(user_config.raw); // Writes the new status to EEPROM
-            if (user_config.rgb_layer_change) { // if layer state indication is enabled, 
+            if (user_config.rgb_layer_change) { // if layer state indication is enabled,
                 layer_state_set(layer_state);   // then immediately update the layer color
             }
         }
         return false; break;
     case RGB_MODE_FORWARD ... RGB_MODE_GRADIENT: // For any of the RGB codes (see quantum_keycodes.h, L400 for reference)
         if (record->event.pressed) { //This disables layer indication, as it's assumed that if you're changing this ... you want that disabled
-            if (user_config.rgb_layer_change) {        // only if this is enabled 
-                user_config.rgb_layer_change = false;  // disable it, and 
+            if (user_config.rgb_layer_change) {        // only if this is enabled
+                user_config.rgb_layer_change = false;  // disable it, and
                 eeconfig_update_user(user_config.raw); // write the setings to EEPROM
             }
         }
@@ -480,10 +489,10 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
   }
 }
 ```
-And lastly, you want to add the `eeconfig_init_user` function, so that when the EEPROM is reset, you can specify default values, and even custom actions. To force an EEPROM reset, use the `EEP_RST` keycode or [Bootmagic](feature_bootmagic.md) functionallity. For example, if you want to set rgb layer indication by default, and save the default valued. 
+And lastly, you want to add the `eeconfig_init_user` function, so that when the EEPROM is reset, you can specify default values, and even custom actions. To force an EEPROM reset, use the `EEP_RST` keycode or [Bootmagic](feature_bootmagic.md) functionallity. For example, if you want to set rgb layer indication by default, and save the default valued.
 
 ```c
-void eeconfig_init_user(void) {  // EEPROM is getting reset! 
+void eeconfig_init_user(void) {  // EEPROM is getting reset!
   user_config.raw = 0;
   user_config.rgb_layer_change = true; // We want this enabled by default
   eeconfig_update_user(user_config.raw); // Write default value to EEPROM now
@@ -495,25 +504,25 @@ void eeconfig_init_user(void) {  // EEPROM is getting reset!
 }
 ```
 
-And you're done.  The RGB layer indication will only work if you want it to. And it will be saved, even after unplugging the board. And if you use any of the RGB codes, it will disable the layer indication, so that it stays on the mode and color that you set it to. 
+And you're done.  The RGB layer indication will only work if you want it to. And it will be saved, even after unplugging the board. And if you use any of the RGB codes, it will disable the layer indication, so that it stays on the mode and color that you set it to.
 
 ### 'EECONFIG' Function Documentation
 
 * Keyboard/Revision: `void eeconfig_init_kb(void)`, `uint32_t eeconfig_read_kb(void)` and `void eeconfig_update_kb(uint32_t val)`
 * Keymap: `void eeconfig_init_user(void)`, `uint32_t eeconfig_read_user(void)` and `void eeconfig_update_user(uint32_t val)`
 
-The `val` is the value of the data that you want to write to EEPROM.  And the `eeconfig_read_*` function return a 32 bit (DWORD) value from the EEPROM. 
+The `val` is the value of the data that you want to write to EEPROM.  And the `eeconfig_read_*` function return a 32 bit (DWORD) value from the EEPROM.
 
 # Custom Tapping Term
 
 By default, the tapping term is defined globally, and is not configurable by key.  For most users, this is perfectly fine.  But in come cases, dual function keys would be greatly improved by different timeouts than `LT` keys, or because some keys may be easier to hold than others.  Instead of using custom key codes for each, this allows for per key configurable `TAPPING_TERM`.
 
-To enable this functionality, you need to add `#define TAPPING_TERM_PER_KEY` to your `config.h`, first.  
+To enable this functionality, you need to add `#define TAPPING_TERM_PER_KEY` to your `config.h`, first.
 
 
 ## Example `get_tapping_term` Implementation
 
-To change the `TAPPING TERM` based on the keycode, you'd want to add something like the following to your `keymap.c` file: 
+To change the `TAPPING TERM` based on the keycode, you'd want to add something like the following to your `keymap.c` file:
 
 ```c
 uint16_t get_tapping_term(uint16_t keycode) {

--- a/docs/custom_quantum_functions.md
+++ b/docs/custom_quantum_functions.md
@@ -120,7 +120,7 @@ return `false` when you would prefer not to run the code in `led_update_kb()`.
 Some examples include:
 
   - overriding the LEDs to use them for something else like layer indication
-    - return false as you do not want the `_kb` functions to run as they would override your layer behavior.
+    - return `false` because you do not want the `_kb()` function to run, as it would override your layer behavior.
   - play a sound when an LED turns on or off.
     - return true because you want the `_kb` function to run and this is in addition to the default LED behavior.
 

--- a/keyboards/maartenwut/wonderland/keymaps/default/keymap.c
+++ b/keyboards/maartenwut/wonderland/keymaps/default/keymap.c
@@ -22,3 +22,33 @@ RGB_RMOD, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX
           _______,          KC_LALT, _______, _______,          _______,                   KC_RALT,                            _______ \
    )
 };
+
+#ifdef USE_LEDS_FOR_LAYERS
+// example of how to use LEDs as layer indicators
+static uint8_t top = 1;
+static uint8_t middle = 0;
+static uint8_t bottom = 0;
+
+layer_state_t layer_state_set_user(layer_state_t state) {
+    top = middle = bottom = 0;
+    switch (get_highest_layer(state)) {
+    case _BASE:
+        top = 1;
+        break;
+    case _FUNC:
+        middle = 1;
+        break;
+    default: //  for any other layers, or the default layer
+        break;
+    }
+  return state;
+}
+
+// override kb level function
+void led_set_kb(uint8_t usb_led) {
+    top ?  writePinLow(B1) : writePinHigh(B1);
+    middle ? writePinLow(B2): writePinHigh(B2);
+    bottom ? writePinLow(B3) : writePinHigh(B3);
+    led_set_user(usb_led);
+}
+#endif

--- a/keyboards/maartenwut/wonderland/keymaps/default/keymap.c
+++ b/keyboards/maartenwut/wonderland/keymaps/default/keymap.c
@@ -45,10 +45,10 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 }
 
 // override kb level function
-void led_set_kb(uint8_t usb_led) {
+bool led_update_user(led_t usb_led) {
     top ?  writePinLow(B1) : writePinHigh(B1);
     middle ? writePinLow(B2): writePinHigh(B2);
     bottom ? writePinLow(B3) : writePinHigh(B3);
-    led_set_user(usb_led);
+    return false; // we are using LEDs for something else override kb
 }
 #endif

--- a/keyboards/maartenwut/wonderland/keymaps/default/keymap.c
+++ b/keyboards/maartenwut/wonderland/keymaps/default/keymap.c
@@ -46,9 +46,9 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 
 // override kb level function
 bool led_update_user(led_t usb_led) {
-    top ?  writePinLow(B1) : writePinHigh(B1);
-    middle ? writePinLow(B2): writePinHigh(B2);
-    bottom ? writePinLow(B3) : writePinHigh(B3);
+    writePin(B1, !top);
+    writePin(B2, !middle);
+    writePin(B3, !bottom);
     return false; // we are using LEDs for something else override kb
 }
 #endif

--- a/keyboards/maartenwut/wonderland/wonderland.c
+++ b/keyboards/maartenwut/wonderland/wonderland.c
@@ -1,5 +1,6 @@
 #include "wonderland.h"
 
+__attribute__ ((weak))
 void matrix_init_kb(void) {
 	// put your keyboard start-up code here
 	// runs once when the firmware starts up
@@ -7,12 +8,14 @@ void matrix_init_kb(void) {
 	led_init_ports();
 };
 
+__attribute__ ((weak))
 void matrix_scan_kb(void) {
 	// put your looping keyboard code here
 	// runs every cycle (a lot)
 	matrix_scan_user();
 };
 
+__attribute__ ((weak))
 void led_init_ports(void) {
     // * Set our LED pins as output
     setPinOutput(B1);
@@ -20,6 +23,7 @@ void led_init_ports(void) {
     setPinOutput(B3);
 }
 
+__attribute__ ((weak))
 void led_set_kb(uint8_t usb_led) {
 	if (IS_LED_ON(usb_led, USB_LED_NUM_LOCK)) {
         writePinLow(B1);

--- a/keyboards/maartenwut/wonderland/wonderland.c
+++ b/keyboards/maartenwut/wonderland/wonderland.c
@@ -23,24 +23,12 @@ void led_init_ports(void) {
     setPinOutput(B3);
 }
 
-__attribute__ ((weak))
-void led_set_kb(uint8_t usb_led) {
-	if (IS_LED_ON(usb_led, USB_LED_NUM_LOCK)) {
-        writePinLow(B1);
-    } else {
-        writePinHigh(B1);
+bool led_update_kb(led_t led_state) {
+    bool runDefault = led_update_user(led_state);
+    if (runDefault) {
+      led_state.num_lock ? writePinLow(B1) : writePinHigh(B1);
+      led_state.caps_lock ? writePinLow(B2) : writePinHigh(B2);
+      led_state.scroll_lock ? writePinLow(B3) : writePinHigh(B3);
     }
-
-    if (IS_LED_ON(usb_led, USB_LED_CAPS_LOCK)) {
-        writePinLow(B2);
-    } else {
-        writePinHigh(B2);
-    }
-
-    if (IS_LED_ON(usb_led, USB_LED_SCROLL_LOCK)) {
-        writePinLow(B3);
-    } else {
-        writePinHigh(B3);
-    }
-	led_set_user(usb_led);
+    return runDefault;
 }

--- a/keyboards/maartenwut/wonderland/wonderland.c
+++ b/keyboards/maartenwut/wonderland/wonderland.c
@@ -26,9 +26,9 @@ void led_init_ports(void) {
 bool led_update_kb(led_t led_state) {
     bool runDefault = led_update_user(led_state);
     if (runDefault) {
-      led_state.num_lock ? writePinLow(B1) : writePinHigh(B1);
-      led_state.caps_lock ? writePinLow(B2) : writePinHigh(B2);
-      led_state.scroll_lock ? writePinLow(B3) : writePinHigh(B3);
+      writePin(B1, !led_state.num_lock);
+      writePin(B2, !led_state.caps_lock);
+      writePin(B3, !led_state.scroll_lock);
     }
     return runDefault;
 }

--- a/layouts/community/60_hhkb/yanfali/keymap.c
+++ b/layouts/community/60_hhkb/yanfali/keymap.c
@@ -42,8 +42,8 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
      */
 [FN]= LAYOUT_60_hhkb(
        KC_PWR,   KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,  KC_F10,  KC_F11,  KC_F12,  KC_INS,  KC_DEL, \
-       _______,  RGB_TOG, KC_UP,   RGB_RMOD, BL_TOGG, BL_STEP, KC_TRNS, KC_TRNS, KC_PSCR, KC_SLCK, KC_PAUS,   KC_UP, KC_TRNS, RESET,  \
-       KC_CAPS,  KC_LEFT, KC_DOWN, KC_RIGHT, KC_EJCT, KC_TRNS, KC_PAST, KC_PSLS, KC_HOME, KC_PGUP, KC_LEFT, KC_RGHT,       KC_PENT,       \
+       _______,  RGB_TOG, KC_UP,   RGB_RMOD, BL_TOGG, BL_STEP, KC_TRNS, KC_TRNS, KC_PSCR, KC_SLCK, KC_PAUS,   KC_VOLU, KC_TRNS, RESET,  \
+       KC_CAPS,  KC_LEFT, KC_DOWN, KC_RIGHT, KC_EJCT, KC_TRNS, KC_PAST, KC_PSLS, KC_HOME, KC_PGUP, KC_LEFT, KC_VOLD,       KC_PENT,       \
        KC_TRNS,  RGB_TOG, RGB_MOD, KC_TRNS, KC_TRNS, KC_TRNS, KC_PPLS, KC_PMNS,  KC_END, KC_PGDN, KC_DOWN,       KC_TRNS, KC_TRNS, \
                  KC_TRNS, KC_TRNS,                   KC_TRNS,                         KC_TRNS, KC_TRNS ),
 };

--- a/layouts/community/60_hhkb/yanfali/keymap.c
+++ b/layouts/community/60_hhkb/yanfali/keymap.c
@@ -42,8 +42,8 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
      */
 [FN]= LAYOUT_60_hhkb(
        KC_PWR,   KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,  KC_F10,  KC_F11,  KC_F12,  KC_INS,  KC_DEL, \
-       _______,  RGB_TOG, KC_UP,   RGB_RMOD, BL_TOGG, BL_STEP, KC_TRNS, KC_TRNS, KC_PSCR, KC_SLCK, KC_PAUS,   KC_VOLU, KC_TRNS, RESET,  \
-       KC_CAPS,  KC_LEFT, KC_DOWN, KC_RIGHT, KC_EJCT, KC_TRNS, KC_PAST, KC_PSLS, KC_HOME, KC_PGUP, KC_LEFT, KC_VOLD,       KC_PENT,       \
+       _______,  RGB_TOG, KC_UP,   RGB_RMOD, BL_TOGG, BL_STEP, KC_TRNS, KC_TRNS, KC_PSCR, KC_SLCK, KC_PAUS,   KC_UP, KC_TRNS, RESET,  \
+       KC_CAPS,  KC_LEFT, KC_DOWN, KC_RIGHT, KC_EJCT, KC_TRNS, KC_PAST, KC_PSLS, KC_HOME, KC_PGUP, KC_LEFT, KC_RGHT,       KC_PENT,       \
        KC_TRNS,  RGB_TOG, RGB_MOD, KC_TRNS, KC_TRNS, KC_TRNS, KC_PPLS, KC_PMNS,  KC_END, KC_PGDN, KC_DOWN,       KC_TRNS, KC_TRNS, \
                  KC_TRNS, KC_TRNS,                   KC_TRNS,                         KC_TRNS, KC_TRNS ),
 };


### PR DESCRIPTION
 - needed for custom LED functions in keymap.c
 - adds an example in code on how to override the LEDs and use them as layer indicators
<!--- Provide a general summary of your changes in the title above. -->
Allow end-user to override functions again in keymap.c

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
If you want to use the LEDs for custom stuff, it's good to allow users to override these functions defined in wonderland.c

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
