### PR TITLE
Fix typo in getting_started_vagrant.md

### DIFF
--- a/docs/getting_started_vagrant.md
+++ b/docs/getting_started_vagrant.md
@@ -40,7 +40,7 @@ vagrant plugin install vagrant-vbguest
 Finished with your environment? From anywhere inside the folder where you checked out this project, Execute:
 
 ```console
-vagrant destory
+vagrant destroy
 ```
 
 ### What if I want to use Docker directly?


### PR DESCRIPTION
Fixes a typo in the `vagrant destroy` line.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
