### PR TITLE
KBDfans/KBD75: Set "RGBLIGHT_SLEEP" as default value

### DIFF
--- a/keyboards/kbdfans/kbd75/config.h
+++ b/keyboards/kbdfans/kbd75/config.h
@@ -44,4 +44,6 @@
 #define RGBLIGHT_HUE_STEP 8
 #define RGBLIGHT_SAT_STEP 8
 #define RGBLIGHT_VAL_STEP 8
+/* If defined, the RGB lighting will be switched off when the host goes to sleep */
+#define RGBLIGHT_SLEEP
 #endif


### PR DESCRIPTION
Set "RGBLIGHT_SLEEP" as default value (RGB lighting will be switched off when the host goes to sleep)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation


