### PR TITLE
Complete info.json for Sticc14 handwired

### DIFF
--- a/keyboards/handwired/sticc14/info.json
+++ b/keyboards/handwired/sticc14/info.json
@@ -1,0 +1,27 @@
+{
+    "keyboard_name": "Sticc14",
+    "url": "",
+    "maintainer": "erkhal",
+    "width": 3,
+    "height": 5,
+    "layouts": {
+        "LAYOUT": {
+            "layout": [
+                {"label":"K00", "x":0, "y":0},
+                {"label":"K01", "x":1, "y":0},
+                {"label":"K02", "x":2, "y":0},
+                {"label":"K10", "x":0, "y":1},
+                {"label":"K11", "x":1, "y":1},
+                {"label":"K12", "x":2, "y":1},
+                {"label":"K20", "x":0, "y":2},
+                {"label":"K21", "x":1, "y":2},
+                {"label":"K22", "x":2, "y":2},
+                {"label":"K30", "x":0, "y":3},
+                {"label":"K31", "x":1, "y":3},
+                {"label":"K32", "x":2, "y":3},
+                {"label":"K40", "x":0, "y":4, "w":2},
+                {"label":"K41", "x":2, "y":4}
+            ]
+        }
+    }
+}


### PR DESCRIPTION
## Description

Completes the `info.json` data, which was previously blank.

Tagging @erkhal (keyboard maintainer).

## Issues Fixed or Closed by This PR

http://api.qmk.fm/v1/keyboards/error_log:

```json
{
  "message": "Error: Could not parse qmk_firmware/keyboards/handwired/sticc14/info.json as JSON: Expecting value: line 1 column 1 (char 0)",
  "severity": "error"
},
```

## Types of Changes

- [x] Enhancement/optimization
- [x] Keyboard (addition or update)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
