### PR TITLE
disable deprecated actions

### DIFF
--- a/quantum/template/avr/config.h
+++ b/quantum/template/avr/config.h
@@ -190,8 +190,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define NO_ACTION_LAYER
 //#define NO_ACTION_TAPPING
 //#define NO_ACTION_ONESHOT
-//#define NO_ACTION_MACRO
-//#define NO_ACTION_FUNCTION
+
+/* disable these deprecated features by default */
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
 
 /*
  * MIDI options

--- a/quantum/template/avr/config.h
+++ b/quantum/template/avr/config.h
@@ -192,8 +192,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define NO_ACTION_ONESHOT
 
 /* disable these deprecated features by default */
-#define NO_ACTION_MACRO
 #ifndef LINK_TIME_OPTIMIZATION_ENABLE
+  #define NO_ACTION_MACRO
   #define NO_ACTION_FUNCTION
 #endif
 /*

--- a/quantum/template/avr/config.h
+++ b/quantum/template/avr/config.h
@@ -193,8 +193,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* disable these deprecated features by default */
 #define NO_ACTION_MACRO
-#define NO_ACTION_FUNCTION
-
+#ifndef LINK_TIME_OPTIMIZATION_ENABLE
+  #define NO_ACTION_FUNCTION
+#endif
 /*
  * MIDI options
  */

--- a/quantum/template/ps2avrgb/config.h
+++ b/quantum/template/ps2avrgb/config.h
@@ -44,6 +44,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define NO_UART 1
 
+/* disable these deprecated features by default */
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
+
 /* key combination for magic key command */
 /* defined by default; to change, uncomment and set to the combination you want */
 // #define IS_COMMAND() (get_mods() == MOD_MASK_SHIFT)

--- a/quantum/template/ps2avrgb/config.h
+++ b/quantum/template/ps2avrgb/config.h
@@ -45,8 +45,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define NO_UART 1
 
 /* disable these deprecated features by default */
-#define NO_ACTION_MACRO
 #ifndef LINK_TIME_OPTIMIZATION_ENABLE
+  #define NO_ACTION_MACRO
   #define NO_ACTION_FUNCTION
 #endif
 

--- a/quantum/template/ps2avrgb/config.h
+++ b/quantum/template/ps2avrgb/config.h
@@ -46,7 +46,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* disable these deprecated features by default */
 #define NO_ACTION_MACRO
-#define NO_ACTION_FUNCTION
+#ifndef LINK_TIME_OPTIMIZATION_ENABLE
+  #define NO_ACTION_FUNCTION
+#endif
 
 /* key combination for magic key command */
 /* defined by default; to change, uncomment and set to the combination you want */


### PR DESCRIPTION
## Description
Set config templates to disable `action_get_macros` and `fn_actions` by default for [#3947](https://github.com/qmk/qmk_firmware/issues/3947)

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #3947 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
   - not sure, it may be worth mentioning the default under 'features that can be disabled'
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
