### PR TITLE
Fix dunder names being accidentally bolded

### DIFF
--- a/docs/coding_conventions_python.md
+++ b/docs/coding_conventions_python.md
@@ -79,7 +79,7 @@ Always use a .py filename extension. Never use dashes.
 
 * single character names except for counters or iterators. You may use "e" as an exception identifier in try/except statements.
 * dashes (-) in any package/module name
-* \_\_double_leading_and_trailing_underscore\_\_ names (reserved by Python)
+* `__double_leading_and_trailing_underscore__` names (reserved by Python)
 
 # Docstrings
 

--- a/docs/coding_conventions_python.md
+++ b/docs/coding_conventions_python.md
@@ -79,7 +79,7 @@ Always use a .py filename extension. Never use dashes.
 
 * single character names except for counters or iterators. You may use "e" as an exception identifier in try/except statements.
 * dashes (-) in any package/module name
-* __double_leading_and_trailing_underscore__ names (reserved by Python)
+* \_\_double_leading_and_trailing_underscore\_\_ names (reserved by Python)
 
 # Docstrings
 

--- a/docs/coding_conventions_python.md
+++ b/docs/coding_conventions_python.md
@@ -77,8 +77,8 @@ Always use a .py filename extension. Never use dashes.
 
 ## Names to Avoid
 
-* single character names except for counters or iterators. You may use "e" as an exception identifier in try/except statements.
-* dashes (-) in any package/module name
+* single character names except for counters or iterators. You may use `e` as an exception identifier in try/except statements.
+* dashes (`-`) in any package/module name
 * `__double_leading_and_trailing_underscore__` names (reserved by Python)
 
 # Docstrings


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
The Python coding conventions docs have the `__names__` ban part accidentally seen as a bold directive by Markdown. I escaped it.
