### PR TITLE
Improve and streamline MSYS2 installation

### DIFF
--- a/util/msys2_install.sh
+++ b/util/msys2_install.sh
@@ -8,7 +8,7 @@ installflip=false
 util_dir=$(dirname "$0")
 
 echo "Installing dependencies needed for the installation (quazip)"
-pacman --needed -Sy base-devel mingw-w64-x86_64-toolchain mingw-w64-x86_64-clang msys/git msys/p7zip msys/python3 msys/unzip
+pacman --needed --noconfirm -Sy base-devel mingw-w64-x86_64-toolchain mingw-w64-x86_64-clang msys/git msys/p7zip msys/python3 msys/unzip
 
 source "$dir/win_shared_install.sh"
 

--- a/util/msys2_install.sh
+++ b/util/msys2_install.sh
@@ -25,7 +25,7 @@ function install_avr {
 
 function install_arm {
     rm -f -r "$armtools"
-    wget -O gcc-arm-none-eabi-8-2019-q3-update-win32.zip "https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2019q3/RC1.1/gcc-arm-none-eabi-8-2019-q3-update-win32.zip?revision=2f0fd855-d015-423c-9c76-c953ae7e730b?product=GNU%20Arm%20Embedded%20Toolchain,ZIP,,Windows,8-2019-q3-update"
+    wget -O gcc-arm-none-eabi-8-2019-q3-update-win32.zip "https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2019q3/RC1.1/gcc-arm-none-eabi-8-2019-q3-update-win32.zip"
     echo "Extracting ARM toolchain..."
     unzip -q -d gcc-arm-none-eabi gcc-arm-none-eabi-8-2019-q3-update-win32.zip
     rm gcc-arm-none-eabi-8-2019-q3-update-win32.zip

--- a/util/msys2_install.sh
+++ b/util/msys2_install.sh
@@ -14,19 +14,19 @@ source "$dir/win_shared_install.sh"
 
 function install_avr {
     rm -f -r "$avrtools"
-    wget "http://ww1.microchip.com/downloads/en/DeviceDoc/avr8-gnu-toolchain-3.6.1.1752-win32.any.x86.zip"
+    wget -O avr8-gnu-toolchain.zip "https://blog.zakkemble.net/download/avr-gcc-8.3.0-x86-mingw.zip"
     echo "Extracting AVR toolchain..."
-	unzip -q avr8-gnu-toolchain-3.6.1.1752-win32.any.x86.zip
-	mv avr8-gnu-toolchain-win32_x86/ avr8-gnu-toolchain
-    rm __MACOSX -R
-    rm avr8-gnu-toolchain-3.6.1.1752-win32.any.x86.zip
+	unzip -q -d avr8-gnu-toolchain avr8-gnu-toolchain.zip
+    rm avr8-gnu-toolchain.zip
     pacman --needed -S mingw-w64-x86_64-avrdude
 }
 
 function install_arm {
-    wget -O gcc-arm-none-eabi.zip "https://developer.arm.com/-/media/Files/downloads/gnu-rm/6-2017q2/gcc-arm-none-eabi-6-2017-q2-update-win32.zip?product=GNU%20ARM%20Embedded%20Toolchain,ZIP,,Windows,6-2017-q2-update"
-    unzip -d gcc-arm-none-eabi gcc-arm-none-eabi.zip
-    rm gcc-arm-none-eabi.zip
+    rm -f -r "$armtools"
+    wget -O gcc-arm-none-eabi.tar.xz "https://developer.arm.com/-/media/Files/downloads/gnu-a/8.3-2019.03/binrel/gcc-arm-8.3-2019.03-i686-mingw32-arm-eabi.tar.xz?revision=ee19688c-d795-49c3-9937-f9b2e5a49b6b&la=en"
+    echo "Extracting ARM toolchain..."
+    tar -xf gcc-arm-none-eabi.tar.xz
+    rm gcc-arm-none-eabi.tar.xz
 }
 
 function extract_flip {

--- a/util/msys2_install.sh
+++ b/util/msys2_install.sh
@@ -8,7 +8,7 @@ installflip=false
 util_dir=$(dirname "$0")
 
 echo "Installing dependencies needed for the installation (quazip)"
-pacman --needed --noconfirm --disable-download-timeout -Sy base-devel mingw-w64-x86_64-toolchain mingw-w64-x86_64-clang msys/git msys/p7zip msys/python3 msys/unzip
+pacman --needed --noconfirm --disable-download-timeout -Sy base-devel mingw-w64-x86_64-toolchain mingw-w64-x86_64-clang msys/git msys/p7zip mingw-w64-x86_64-python3-pip msys/unzip
 
 source "$dir/win_shared_install.sh"
 

--- a/util/msys2_install.sh
+++ b/util/msys2_install.sh
@@ -89,18 +89,10 @@ then
     echo "The line source ~/qmk_utils/activate_msys2.sh is already added to your /.bashrc"
     echo "Not adding it twice!"
 else
-    while true; do
         echo
-        echo "Do you want to add 'source ~/qmk_utils/activate_msys2.sh' to the end of your"
-        echo ".bashrc file? Without this make won't find the needed utils, so if you don't"
-        echo "want to do it automatically, then you have to do it manually later."
-        read -p "(Y/N)? " res
-        case $res in
-            [Yy]* ) echo "source ~/qmk_utils/activate_msys2.sh" >> ~/.bashrc; break;;
-            [Nn]* ) break;;
-            * ) echo "Invalid answer";;
-        esac
-    done
+        echo "Adding 'source ~/qmk_utils/activate_msys2.sh' to the end of your"
+        echo ".bashrc file? Without this make won't find the needed utils."
+        echo "source ~/qmk_utils/activate_msys2.sh" >> ~/.bashrc;
 fi
 
 echo

--- a/util/msys2_install.sh
+++ b/util/msys2_install.sh
@@ -24,11 +24,11 @@ function install_avr {
 
 function install_arm {
     rm -f -r "$armtools"
-    wget -O gcc-arm-8.3-2019.03-i686-mingw32-arm-eabi.tar.xz "https://developer.arm.com/-/media/Files/downloads/gnu-a/8.3-2019.03/binrel/gcc-arm-8.3-2019.03-i686-mingw32-arm-eabi.tar.xz?revision=ee19688c-d795-49c3-9937-f9b2e5a49b6b&la=en"
+    wget -O gcc-arm-none-eabi-8-2019-q3-update-win32.zip "https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2019q3/RC1.1/gcc-arm-none-eabi-8-2019-q3-update-win32.zip?revision=2f0fd855-d015-423c-9c76-c953ae7e730b?product=GNU%20Arm%20Embedded%20Toolchain,ZIP,,Windows,8-2019-q3-update"
     echo "Extracting ARM toolchain..."
-    tar -xf gcc-arm-8.3-2019.03-i686-mingw32-arm-eabi.tar.xz -C .
-    mv gcc-arm-8.3-2019.03-i686-mingw32-arm-eabi gcc-arm-none-eabi
-    rm gcc-arm-8.3-2019.03-i686-mingw32-arm-eabi.tar.xz
+	unzip -q -d . gcc-arm-none-eabi-8-2019-q3-update-win32.zip
+    mv gcc-arm-none-eabi-8-2019-q3-update-win32 gcc-arm-none-eabi
+    rm gcc-arm-none-eabi-8-2019-q3-update-win32.zip
 }
 
 function extract_flip {

--- a/util/msys2_install.sh
+++ b/util/msys2_install.sh
@@ -26,8 +26,7 @@ function install_arm {
     rm -f -r "$armtools"
     wget -O gcc-arm-none-eabi-8-2019-q3-update-win32.zip "https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2019q3/RC1.1/gcc-arm-none-eabi-8-2019-q3-update-win32.zip?revision=2f0fd855-d015-423c-9c76-c953ae7e730b?product=GNU%20Arm%20Embedded%20Toolchain,ZIP,,Windows,8-2019-q3-update"
     echo "Extracting ARM toolchain..."
-	unzip -q -d . gcc-arm-none-eabi-8-2019-q3-update-win32.zip
-    mv gcc-arm-none-eabi-8-2019-q3-update-win32 gcc-arm-none-eabi
+	unzip -q -d gcc-arm-none-eabi gcc-arm-none-eabi-8-2019-q3-update-win32.zip
     rm gcc-arm-none-eabi-8-2019-q3-update-win32.zip
 }
 

--- a/util/msys2_install.sh
+++ b/util/msys2_install.sh
@@ -16,7 +16,7 @@ function install_avr {
     rm -f -r "$avrtools"
     wget "https://blog.zakkemble.net/download/avr-gcc-8.3.0-x86-mingw.zip"
     echo "Extracting AVR toolchain..."
-	unzip -q -d . avr-gcc-8.3.0-x86-mingw.zip
+    unzip -q -d . avr-gcc-8.3.0-x86-mingw.zip
     mv avr-gcc-8.3.0-x86-mingw avr8-gnu-toolchain
     rm avr-gcc-8.3.0-x86-mingw.zip
     pacman --needed -S mingw-w64-x86_64-avrdude
@@ -26,7 +26,7 @@ function install_arm {
     rm -f -r "$armtools"
     wget -O gcc-arm-none-eabi-8-2019-q3-update-win32.zip "https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2019q3/RC1.1/gcc-arm-none-eabi-8-2019-q3-update-win32.zip?revision=2f0fd855-d015-423c-9c76-c953ae7e730b?product=GNU%20Arm%20Embedded%20Toolchain,ZIP,,Windows,8-2019-q3-update"
     echo "Extracting ARM toolchain..."
-	unzip -q -d gcc-arm-none-eabi gcc-arm-none-eabi-8-2019-q3-update-win32.zip
+    unzip -q -d gcc-arm-none-eabi gcc-arm-none-eabi-8-2019-q3-update-win32.zip
     rm gcc-arm-none-eabi-8-2019-q3-update-win32.zip
 }
 
@@ -46,7 +46,7 @@ fi
 if [ ! -d "$avrtools" ]; then
     echo
     echo "The AVR toolchain is not installed."
-    echo "This is needed for building AVR based keboards."
+    echo "This is needed for building AVR based keyboards."
     install_avr
 else
     while true; do

--- a/util/msys2_install.sh
+++ b/util/msys2_install.sh
@@ -8,7 +8,7 @@ installflip=false
 util_dir=$(dirname "$0")
 
 echo "Installing dependencies needed for the installation (quazip)"
-pacman --needed -S base-devel mingw-w64-x86_64-toolchain mingw-w64-x86_64-clang msys/git msys/p7zip msys/python3 msys/unzip
+pacman --needed -Sy base-devel mingw-w64-x86_64-toolchain mingw-w64-x86_64-clang msys/git msys/p7zip msys/python3 msys/unzip
 
 source "$dir/win_shared_install.sh"
 
@@ -43,17 +43,10 @@ if [ -f "FlipInstaller.exe" ]; then
 fi
 
 if [ ! -d "$avrtools" ]; then
-    while true; do
-        echo
-        echo "The AVR toolchain is not installed."
-        echo "This is needed for building AVR based keboards."
-        read -p "Do you want to install it? (Y/N) " res
-        case $res in
-            [Yy]* ) install_avr; break;;
-            [Nn]* ) break;;
-            * ) echo "Invalid answer";;
-        esac
-    done
+    echo
+    echo "The AVR toolchain is not installed."
+    echo "This is needed for building AVR based keboards."
+    install_avr
 else
     while true; do
         echo
@@ -68,17 +61,10 @@ else
 fi
 
 if [ ! -d "$armtools" ]; then
-    while true; do
-        echo
-        echo "The ARM toolchain is not installed."
-        echo "This is needed for building ARM based keyboards."
-        read -p "Do you want to install it? (Y/N) " res
-        case $res in
-            [Yy]* ) install_arm; break;;
-            [Nn]* ) break;;
-            * ) echo "Invalid answer";;
-        esac
-    done
+    echo
+    echo "The ARM toolchain is not installed."
+    echo "This is needed for building ARM based keyboards."
+    install_arm
 else
     while true; do
         echo

--- a/util/msys2_install.sh
+++ b/util/msys2_install.sh
@@ -93,7 +93,7 @@ then
 else
         echo
         echo "Adding 'source ~/qmk_utils/activate_msys2.sh' to the end of your"
-        echo ".bashrc file? Without this make won't find the needed utils."
+        echo ".bashrc file. Without this make won't find the needed utils."
         echo "source ~/qmk_utils/activate_msys2.sh" >> ~/.bashrc;
 fi
 

--- a/util/msys2_install.sh
+++ b/util/msys2_install.sh
@@ -14,19 +14,21 @@ source "$dir/win_shared_install.sh"
 
 function install_avr {
     rm -f -r "$avrtools"
-    wget -O avr8-gnu-toolchain.zip "https://blog.zakkemble.net/download/avr-gcc-8.3.0-x86-mingw.zip"
+    wget "https://blog.zakkemble.net/download/avr-gcc-8.3.0-x86-mingw.zip"
     echo "Extracting AVR toolchain..."
-	unzip -q -d avr8-gnu-toolchain avr8-gnu-toolchain.zip
-    rm avr8-gnu-toolchain.zip
+	unzip -q -d . avr-gcc-8.3.0-x86-mingw.zip
+    mv avr-gcc-8.3.0-x86-mingw avr8-gnu-toolchain
+    rm avr-gcc-8.3.0-x86-mingw.zip
     pacman --needed -S mingw-w64-x86_64-avrdude
 }
 
 function install_arm {
     rm -f -r "$armtools"
-    wget -O gcc-arm-none-eabi.tar.xz "https://developer.arm.com/-/media/Files/downloads/gnu-a/8.3-2019.03/binrel/gcc-arm-8.3-2019.03-i686-mingw32-arm-eabi.tar.xz?revision=ee19688c-d795-49c3-9937-f9b2e5a49b6b&la=en"
+    wget -O gcc-arm-8.3-2019.03-i686-mingw32-arm-eabi.tar.xz "https://developer.arm.com/-/media/Files/downloads/gnu-a/8.3-2019.03/binrel/gcc-arm-8.3-2019.03-i686-mingw32-arm-eabi.tar.xz?revision=ee19688c-d795-49c3-9937-f9b2e5a49b6b&la=en"
     echo "Extracting ARM toolchain..."
-    tar -xf gcc-arm-none-eabi.tar.xz
-    rm gcc-arm-none-eabi.tar.xz
+    tar -xf gcc-arm-8.3-2019.03-i686-mingw32-arm-eabi.tar.xz -C .
+    mv gcc-arm-8.3-2019.03-i686-mingw32-arm-eabi gcc-arm-none-eabi
+    rm gcc-arm-8.3-2019.03-i686-mingw32-arm-eabi.tar.xz
 }
 
 function extract_flip {

--- a/util/msys2_install.sh
+++ b/util/msys2_install.sh
@@ -8,7 +8,7 @@ installflip=false
 util_dir=$(dirname "$0")
 
 echo "Installing dependencies needed for the installation (quazip)"
-pacman --needed --noconfirm -Sy base-devel mingw-w64-x86_64-toolchain mingw-w64-x86_64-clang msys/git msys/p7zip msys/python3 msys/unzip
+pacman --needed --noconfirm --disable-download-timeout -Sy base-devel mingw-w64-x86_64-toolchain mingw-w64-x86_64-clang msys/git msys/p7zip msys/python3 msys/unzip
 
 source "$dir/win_shared_install.sh"
 
@@ -20,7 +20,7 @@ function install_avr {
     mv avr-gcc-8.3.0-x86-mingw avr8-gnu-toolchain
     rm avr8-gnu-toolchain/bin/make.exe
     rm avr-gcc-8.3.0-x86-mingw.zip
-    pacman --needed -S mingw-w64-x86_64-avrdude
+    pacman --needed --disable-download-timeout -S mingw-w64-x86_64-avrdude
 }
 
 function install_arm {

--- a/util/msys2_install.sh
+++ b/util/msys2_install.sh
@@ -18,6 +18,7 @@ function install_avr {
     echo "Extracting AVR toolchain..."
     unzip -q -d . avr-gcc-8.3.0-x86-mingw.zip
     mv avr-gcc-8.3.0-x86-mingw avr8-gnu-toolchain
+    rm avr8-gnu-toolchain/bin/make.exe
     rm avr-gcc-8.3.0-x86-mingw.zip
     pacman --needed -S mingw-w64-x86_64-avrdude
 }


### PR DESCRIPTION
## Description

* Update AVR GCC and ARM GCC to 8.3.x (and don't prompt unless it exists)
* Install packages via pacman without prompting user
* Remove prompts for installing stuff unless it already exists

This doesn't touch the win_shared_install.sh  stuff, since that prompts only if utils have already been installed already, and for drivers (since that's long and requires a UAC prompt .... lets not change that). 

## Types of Changes
- [x] Core
- [x] Enhancement/optimization

## Checklist

- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
