### PR TITLE
Added oled_write_raw and oled_write_raw_P functions to the OLED driver

### DIFF
--- a/docs/feature_oled_driver.md
+++ b/docs/feature_oled_driver.md
@@ -229,6 +229,12 @@ void oled_write_P(const char *data, bool invert);
 // Remapped to call 'void oled_write_ln(const char *data, bool invert);' on ARM
 void oled_write_ln_P(const char *data, bool invert);
 
+// Writes a string to the buffer at current cursor position
+void oled_write_raw(const char *data, uint16_t size);
+
+// Writes a PROGMEM string to the buffer at current cursor position
+void oled_write_raw_P(const char *data, uint16_t size);
+
 // Can be used to manually turn on the screen if it is off
 // Returns true if the screen was on or turns on
 bool oled_on(void);

--- a/drivers/oled/oled_driver.c
+++ b/drivers/oled/oled_driver.c
@@ -431,6 +431,15 @@ void oled_write_ln(const char *data, bool invert) {
     oled_advance_page(true);
 }
 
+void oled_write_raw(const char *data, uint16_t size) {
+    if (size > OLED_MATRIX_SIZE) size = OLED_MATRIX_SIZE;
+    for (uint16_t i = 0; i < size; i++) {
+        if (oled_buffer[i] == data[i]) continue;
+        oled_buffer[i] = data[i];
+        oled_dirty |= (1 << (i / OLED_BLOCK_SIZE));
+    }
+}
+
 #if defined(__AVR__)
 void oled_write_P(const char *data, bool invert) {
     uint8_t c = pgm_read_byte(data);
@@ -443,6 +452,16 @@ void oled_write_P(const char *data, bool invert) {
 void oled_write_ln_P(const char *data, bool invert) {
     oled_write_P(data, invert);
     oled_advance_page(true);
+}
+
+void oled_write_raw_P(const char *data, uint16_t size) {
+    if (size > OLED_MATRIX_SIZE) size = OLED_MATRIX_SIZE;
+    for (uint16_t i = 0; i < size; i++) {
+        uint8_t c = pgm_read_byte(++data);
+        if (oled_buffer[i] == c) continue;
+        oled_buffer[i] = c;
+        oled_dirty |= (1 << (i / OLED_BLOCK_SIZE));
+    }
 }
 #endif  // defined(__AVR__)
 

--- a/drivers/oled/oled_driver.h
+++ b/drivers/oled/oled_driver.h
@@ -200,6 +200,8 @@ void oled_write(const char *data, bool invert);
 // Advances the cursor to the next page, wiring ' ' to the remainder of the current page
 void oled_write_ln(const char *data, bool invert);
 
+void oled_write_raw(const char *data, uint16_t size);
+
 #if defined(__AVR__)
 // Writes a PROGMEM string to the buffer at current cursor position
 // Advances the cursor while writing, inverts the pixels if true
@@ -211,6 +213,8 @@ void oled_write_P(const char *data, bool invert);
 // Advances the cursor to the next page, wiring ' ' to the remainder of the current page
 // Remapped to call 'void oled_write_ln(const char *data, bool invert);' on ARM
 void oled_write_ln_P(const char *data, bool invert);
+
+void oled_write_raw_P(const char *data, uint16_t size);
 #else
 // Writes a string to the buffer at current cursor position
 // Advances the cursor while writing, inverts the pixels if true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
The current way to write images to OLED displays is by making use of the font functionality. This has several limitations:

- The way to serialize images into the font format isn't obvious;
- The font format limits the image size to a maximum of 128x32, while 128x64 OLED displays are too supported by QMK.

This pull request, code written by @XScorpion2, intends to introduce an easier way to write custom images to OLED displays within QMK.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [X] Core
- [ ] Bugfix
- [X] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
