### PR TITLE
Fix v60_type_r compile failures

### DIFF
--- a/keyboards/v60_type_r/config.h
+++ b/keyboards/v60_type_r/config.h
@@ -53,14 +53,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define BACKLIGHT_LEVELS 3
 #define BACKLIGHT_ON_STATE 0
 
-#define RGBLIGHT_CUSTOM_DRIVER
-#define RGBLIGHT_ANIMATIONS
+//#define RGB_DI_PIN 0
 #define RGBLED_NUM 1
+#define RGBLIGHT_ANIMATIONS
+#define RGB_STEP 16
+
 #define RGB_RED_PIN PF6
 #define RGB_GREEN_PIN PF5
 #define RGB_BLUE_PIN PF4
-#define RGB_DI_PIN 0
-#define RGB_STEP 16
 
 /* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
 #define DEBOUNCE 5

--- a/keyboards/v60_type_r/rules.mk
+++ b/keyboards/v60_type_r/rules.mk
@@ -17,18 +17,21 @@ BOOTLOADER = atmel-dfu
 BOOTMAGIC_ENABLE = no       # Virtual DIP switch configuration(+1000)
 MOUSEKEY_ENABLE = yes       # Mouse keys(+4700)
 EXTRAKEY_ENABLE = yes       # Audio control and System control(+450)
-CONSOLE_ENABLE = yes        # Console for debug(+400)
+CONSOLE_ENABLE = no         # Console for debug(+400)
 COMMAND_ENABLE = yes        # Commands for debug and configuration
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
 SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
 # if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
 NKRO_ENABLE = no            # USB Nkey Rollover
-BACKLIGHT_ENABLE = yes       # Enable keyboard backlight functionality on B7 by default
-RGBLIGHT_ENABLE = yes        # Enable the RGB Underglow
+BACKLIGHT_ENABLE = yes      # Enable keyboard backlight functionality on B7 by default
+RGBLIGHT_ENABLE = yes       # Enable the RGB Underglow
+RGBLIGHT_CUSTOM_DRIVER = yes
 MIDI_ENABLE = no            # MIDI support (+2400 to 4200, depending on config)
 UNICODE_ENABLE = no         # Unicode
 BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
 AUDIO_ENABLE = no           # Audio output on port C6
 FAUXCLICKY_ENABLE = no      # Use buzzer to emulate clicky switches
+
+LINK_TIME_OPTIMIZATION_ENABLE = yes
 
 LAYOUTS = 60_ansi 60_iso

--- a/keyboards/v60_type_r/v60_type_r.c
+++ b/keyboards/v60_type_r/v60_type_r.c
@@ -18,13 +18,7 @@
 #include "quantum.h"
 
 // if we've got an RGB underglow!
-#ifdef V60_POLESTAR
-
-#include "rgblight.h"
-
-#include <avr/pgmspace.h>
-
-#include "action_layer.h"
+#ifdef RGBLIGHT_ENABLE
 
 #define SOFTPWM_LED_TIMER_TOP F_CPU/(256*64)
 
@@ -191,4 +185,4 @@ ISR(TIMER3_COMPA_vect)
     	softpwm_buff[2] = led[0].b;
   	}
 }
-#endif // V60_POLESTAR
+#endif // RGBLIGHT_ENABLE

--- a/keyboards/v60_type_r/v60_type_r.h
+++ b/keyboards/v60_type_r/v60_type_r.h
@@ -17,7 +17,7 @@
 
 #include "quantum.h"
 
-#ifdef V60_POLESTAR
+#ifdef RGBLIGHT_ENABLE
 
 #include "rgblight.h"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
```console
Making v60_type_r with keymap default                                                                  [ERRORS]
quantum/backlight/backlight_avr.c:116:25: note: #pragma message: Using hardware timer 1 with software PWM
 #                pragma message "Using hardware timer 1 with software PWM"
                         ^
 | 
 | .build/obj_v60_type_r_default/quantum/rgblight.o: In function `rgblight_effect_alternating':
 | /qmk_firmware/quantum/rgblight.c:709: undefined reference to `rgblight_set'
 | .build/obj_v60_type_r_default/quantum/rgblight.o: In function `rgblight_effect_christmas':
 | /qmk_firmware/quantum/rgblight.c:709: undefined reference to `rgblight_set'
 | .build/obj_v60_type_r_default/quantum/rgblight.o: In function `rgblight_effect_knight':
 | /qmk_firmware/quantum/rgblight.c:709: undefined reference to `rgblight_set'
 | .build/obj_v60_type_r_default/quantum/rgblight.o: In function `rgblight_effect_snake':
 | /qmk_firmware/quantum/rgblight.c:709: undefined reference to `rgblight_set'
 | .build/obj_v60_type_r_default/quantum/rgblight.o: In function `rgblight_effect_rainbow_swirl':
 | /qmk_firmware/quantum/rgblight.c:709: undefined reference to `rgblight_set'
 | .build/obj_v60_type_r_default/quantum/rgblight.o:/qmk_firmware/quantum/rgblight.c:709: more undefined references to `rgblight_set' follow
 | collect2: error: ld returned 1 exit status
 | 
tmk_core/rules.mk:298: recipe for target '.build/v60_type_r_default.elf' failed
```

Also had to cut the firmware size down a bit (removed console +lto) as now it compiles, its oversized.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
