### PR TITLE
Add short form LTO_ENABLE

### DIFF
--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -348,7 +348,8 @@ Use these to enable or disable building certain features. The more you have enab
 * `NO_USB_STARTUP_CHECK`
   * Disables usb suspend check after keyboard startup. Usually the keyboard waits for the host to wake it up before any tasks are performed. This is useful for split keyboards as one half will not get a wakeup call but must send commands to the master.
 * `LINK_TIME_OPTIMIZATION_ENABLE`
-  = Enables Link Time Optimization (`LTO`) when compiling the keyboard.  This makes the process take longer, but can significantly reduce the compiled size (and since the firmware is small, the added time is not noticable).  However, this will automatically disable the old Macros and Functions features automatically, as these break when `LTO` is enabled.  It does this by automatically defining `NO_ACTION_MACRO` and `NO_ACTION_FUNCTION`
+  * Enables Link Time Optimization (`LTO`) when compiling the keyboard.  This makes the process take longer, but can significantly reduce the compiled size (and since the firmware is small, the added time is not noticeable).  However, this will automatically disable the old Macros and Functions features automatically, as these break when `LTO` is enabled.  It does this by automatically defining `NO_ACTION_MACRO` and `NO_ACTION_FUNCTION`
+  * Alternatively, you can use `LTO_ENABLE` instead of `LINK_TIME_OPTIMIZATION_ENABLE`. 
 
 ## USB Endpoint Limitations
 

--- a/tmk_core/common.mk
+++ b/tmk_core/common.mk
@@ -203,6 +203,9 @@ ifeq ($(strip $(SHARED_EP_ENABLE)), yes)
     TMK_COMMON_DEFS += -DSHARED_EP_ENABLE
 endif
 
+ifeq ($(strip $(LTO_ENABLE)), yes)
+    LINK_TIME_OPTIMIZATION_ENABLE = yes
+endif
 
 ifeq ($(strip $(LINK_TIME_OPTIMIZATION_ENABLE)), yes)
     EXTRAFLAGS += -flto


### PR DESCRIPTION
## Description

This adds a shorter option for adding LTO, because it's awesome typing out `LINK_TIME_OPTIMIZATION_ENABLE=yes`....
Now, we can use `LTO_ENABLE=yes`

## Types of Changes
- [x] Core
- [x] Enhancement/optimization

## Issues Fixed or Closed by This PR

* Drashna's sanity 

