### PR TITLE
Switch my Quefrency (back) to serial so halves work independently

### DIFF
--- a/keyboards/keebio/quefrency/keymaps/bcat/config.h
+++ b/keyboards/keebio/quefrency/keymaps/bcat/config.h
@@ -1,6 +1,12 @@
 #pragma once
 
-#define USE_I2C
+/*
+ * Quefrency lacks I2C resistors on the right PCB, so the right half doesn't
+ * work independently. (Presumably the floating I2C lines cause a problem.)
+ * Using serial seems sufficiently fast in practice and allows both halves to
+ * be used independently.
+ */
+#define USE_SERIAL
 
 /* Use an extra LED on the right side since it's wider on the 65% PCB. */
 #undef RGBLED_NUM


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Turns out the right half of my Quefrency doesn't work independently with I2C, but it does with serial. I think this is because there are only pull-up resistors for the I2C lines on the left PCB, not the right PCB, and so the lines float when only the right half is connected.

I could add pull ups to the right side too, but meh. There's no PCB footprints for them, and honestly serial seems to work perfectly fine. :)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [X] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

None.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
