### PR TITLE
Process leader mappings on key press

### DIFF
--- a/quantum/process_keycode/process_leader.c
+++ b/quantum/process_keycode/process_leader.c
@@ -52,11 +52,13 @@ void qk_leader_start(void) {
 }
 
 void matrix_scan_leader(void) {
+#    ifdef LEADER_ON_KEY_PROCESSING
     if (leading && timer_elapsed(leader_time) > LEADER_TIMEOUT) {
         leader_process_user(leader_sequence, true);
         leading = false;
         leader_end();
     }
+#    endif
 }
 
 bool process_leader(uint16_t keycode, keyrecord_t *record) {

--- a/quantum/process_keycode/process_leader.c
+++ b/quantum/process_keycode/process_leader.c
@@ -23,10 +23,6 @@
 #        define LEADER_TIMEOUT 300
 #    endif
 
-#    ifndef LEADER_ABORT
-#        define LEADER_ABORT KC_LEAD
-#    endif
-
 __attribute__((weak)) void leader_start(void) {}
 
 __attribute__((weak)) void leader_end(void) {}
@@ -71,11 +67,13 @@ bool process_leader(uint16_t keycode, keyrecord_t *record) {
                     keycode = keycode & 0xFF;
                 }
 #    endif  // LEADER_KEY_STRICT_KEY_PROCESSING
+#    ifdef LEADER_ABORT
                 if (keycode == LEADER_ABORT) {
                     leading = false;
                     leader_end();
                     return false;
                 }
+#    endif  // LEADER_ABORT
                 if (leader_sequence_size < (sizeof(leader_sequence) / sizeof(leader_sequence[0]))) {
                     leader_sequence[leader_sequence_size] = keycode;
                     leader_sequence_size++;
@@ -85,7 +83,7 @@ bool process_leader(uint16_t keycode, keyrecord_t *record) {
                         leader_end();
                         return false;
                     }
-#    endif // LEADER_ON_KEY_PROCESSING
+#    endif  // LEADER_ON_KEY_PROCESSING
                 } else {
                     leading = false;
                     leader_end();

--- a/quantum/process_keycode/process_leader.h
+++ b/quantum/process_keycode/process_leader.h
@@ -20,9 +20,12 @@
 #include "quantum.h"
 
 bool process_leader(uint16_t keycode, keyrecord_t *record);
+void matrix_scan_leader(void);
 
 void leader_start(void);
 void leader_end(void);
+bool leader_process_user(uint16_t *leader_sequence, bool is_timeout);
+
 void qk_leader_start(void);
 
 #define SEQ_ONE_KEY(key) if (leader_sequence[0] == (key) && leader_sequence[1] == 0 && leader_sequence[2] == 0 && leader_sequence[3] == 0 && leader_sequence[4] == 0)

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -982,6 +982,10 @@ void matrix_scan_quantum() {
     matrix_scan_combo();
 #endif
 
+#if defined(LEADER_ENABLE) && defined(LEADER_ON_KEY_PROCESSING)
+    matrix_scan_leader();
+#endif
+
 #if defined(BACKLIGHT_ENABLE)
 #    if defined(LED_MATRIX_ENABLE)
     led_matrix_task();

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -982,7 +982,7 @@ void matrix_scan_quantum() {
     matrix_scan_combo();
 #endif
 
-#if defined(LEADER_ENABLE) && defined(LEADER_ON_KEY_PROCESSING)
+#if defined(LEADER_ENABLE)
     matrix_scan_leader();
 #endif
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This PR has similar goals as https://github.com/qmk/qmk_firmware/pull/6580 but uses a different approach.

* Allows long timeouts and `LEADER_PER_KEY_TIMING` but you don't have to wait for the timeout to happen.
* Runs a user defined function on key press *and* after `LEADER_TIMEOUT`
* Allows cancellation of leader mode by key press, defaults to `KC_LEAD`
* No need for `LEADER_EXTERNS` and `LEADER_DICTIONARY` in user code
* Optional feature, should not interfere with the current behavior

Here's an example for a user function:

```c
// add some configuration
#ifdef LEADER_ENABLE
#   define LEADER_ON_KEY_PROCESSING

// per key timing and and 1s timeout are vim's defaults ;)
#   define LEADER_PER_KEY_TIMING
#   define LEADER_TIMEOUT 1000

// use escape (or five invalid keypresses) to abort leader mode
#   define LEADER_ABORT KC_ESC

bool leader_process_user(uint16_t *leader_sequence, bool is_timeout) {
    SEQ_ONE_KEY(KC_S) { SEND_STRING("Leader S"); return false; } // finish processing

    // KC_G is not unique, so this one is only valid after the timeout
    SEQ_ONE_KEY(KC_G) { if (is_timeout) { SEND_STRING("Leader with shared prefix G after timeout"); return false; } }

    SEQ_TWO_KEYS(KC_G, KC_G) { SEND_STRING("Leader GG"); return false; }

    return true; // continue processing
}
#endif
```


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Closes #6580 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
