### PR TITLE
Relocate some common backlight functionally

### DIFF
--- a/common_features.mk
+++ b/common_features.mk
@@ -257,13 +257,11 @@ ifeq ($(strip $(BACKLIGHT_ENABLE)), yes)
     SRC += $(QUANTUM_DIR)/backlight/backlight.c
     OPT_DEFS += -DBACKLIGHT_ENABLE
 
-    ifeq ($(strip $(BACKLIGHT_DRIVER)), software)
+    ifeq ($(strip $(BACKLIGHT_DRIVER)), custom)
+        OPT_DEFS += -DBACKLIGHT_CUSTOM_DRIVER
+    else ifeq ($(strip $(BACKLIGHT_DRIVER)), software)
         SRC += $(QUANTUM_DIR)/backlight/backlight_soft.c
     else
-        ifeq ($(strip $(BACKLIGHT_DRIVER)), custom)
-            OPT_DEFS += -DBACKLIGHT_CUSTOM_DRIVER
-        endif
-
         ifeq ($(PLATFORM),AVR)
             SRC += $(QUANTUM_DIR)/backlight/backlight_avr.c
         else

--- a/quantum/backlight/backlight.c
+++ b/quantum/backlight/backlight.c
@@ -21,6 +21,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 backlight_config_t backlight_config;
 
+// TODO: migrate to backlight_config_t
+static uint8_t breathing_period = BREATHING_PERIOD;
+
 /** \brief Backlight initialization
  *
  * FIXME: needs doc
@@ -191,3 +194,21 @@ void backlight_disable_breathing(void) {
  */
 bool is_backlight_breathing(void) { return backlight_config.breathing; }
 #endif
+
+// following are marked as weak purely for backwards compatibility
+__attribute__((weak)) void breathing_period_set(uint8_t value) { breathing_period = value ? value : 1; }
+
+__attribute__((weak)) uint8_t get_breathing_period(void) { return breathing_period; }
+
+__attribute__((weak)) void breathing_period_default(void) { breathing_period_set(BREATHING_PERIOD); }
+
+__attribute__((weak)) void breathing_period_inc(void) { breathing_period_set(breathing_period + 1); }
+
+__attribute__((weak)) void breathing_period_dec(void) { breathing_period_set(breathing_period - 1); }
+
+// defaults for backlight api
+__attribute__((weak)) void backlight_init_ports(void) {}
+
+__attribute__((weak)) void backlight_set(uint8_t level) {}
+
+__attribute__((weak)) void backlight_task(void) {}

--- a/quantum/backlight/backlight.h
+++ b/quantum/backlight/backlight.h
@@ -41,22 +41,39 @@ typedef union {
 } backlight_config_t;
 
 void    backlight_init(void);
-void    backlight_increase(void);
-void    backlight_decrease(void);
 void    backlight_toggle(void);
 void    backlight_enable(void);
 void    backlight_disable(void);
 bool    is_backlight_enabled(void);
 void    backlight_step(void);
-void    backlight_set(uint8_t level);
+void    backlight_increase(void);
+void    backlight_decrease(void);
 void    backlight_level(uint8_t level);
 uint8_t get_backlight_level(void);
 
+// implementation specific
+void backlight_init_ports(void);
+void backlight_set(uint8_t level);
+void backlight_task(void);
+
 #ifdef BACKLIGHT_BREATHING
+
 void backlight_toggle_breathing(void);
 void backlight_enable_breathing(void);
 void backlight_disable_breathing(void);
 bool is_backlight_breathing(void);
+
+void    breathing_period_set(uint8_t value);
+uint8_t get_breathing_period(void);
+void    breathing_period_default(void);
+void    breathing_period_inc(void);
+void    breathing_period_dec(void);
+
+// implementation specific
 void breathing_enable(void);
 void breathing_disable(void);
+void breathing_toggle(void);
+bool is_breathing(void);
+void breathing_pulse(void);
+void breathing_task(void);
 #endif

--- a/quantum/backlight/backlight_arm.c
+++ b/quantum/backlight/backlight_arm.c
@@ -106,7 +106,6 @@ void backlight_task(void) {}
 #    define BREATHING_HALT_ON 2
 #    define BREATHING_STEPS 128
 
-static uint8_t  breathing_period  = BREATHING_PERIOD;
 static uint8_t  breathing_halt    = BREATHING_NO_HALT;
 static uint16_t breathing_counter = 0;
 
@@ -114,7 +113,7 @@ bool is_breathing(void) { return BACKLIGHT_PWM_DRIVER.config == &pwmCFG_breathin
 
 static inline void breathing_min(void) { breathing_counter = 0; }
 
-static inline void breathing_max(void) { breathing_counter = breathing_period * 256 / 2; }
+static inline void breathing_max(void) { breathing_counter = get_breathing_period() * 256 / 2; }
 
 void breathing_interrupt_enable(void) {
     pwmStop(&BACKLIGHT_PWM_DRIVER);
@@ -166,17 +165,6 @@ void breathing_toggle(void) {
         breathing_enable();
 }
 
-void breathing_period_set(uint8_t value) {
-    if (!value) value = 1;
-    breathing_period = value;
-}
-
-void breathing_period_default(void) { breathing_period_set(BREATHING_PERIOD); }
-
-void breathing_period_inc(void) { breathing_period_set(breathing_period + 1); }
-
-void breathing_period_dec(void) { breathing_period_set(breathing_period - 1); }
-
 /* To generate breathing curve in python:
  * from math import sin, pi; [int(sin(x/128.0*pi)**4*255) for x in range(128)]
  */
@@ -187,7 +175,8 @@ static inline uint16_t scale_backlight(uint16_t v) { return v / BACKLIGHT_LEVELS
 
 static void breathing_callback(PWMDriver *pwmp) {
     (void)pwmp;
-    uint16_t interval = (uint16_t)breathing_period * 256 / BREATHING_STEPS;
+    uint8_t  breathing_period = get_breathing_period();
+    uint16_t interval         = (uint16_t)breathing_period * 256 / BREATHING_STEPS;
     // resetting after one period to prevent ugly reset at overflow.
     breathing_counter = (breathing_counter + 1) % (breathing_period * 256);
     uint8_t index     = breathing_counter / interval % BREATHING_STEPS;
@@ -202,13 +191,5 @@ static void breathing_callback(PWMDriver *pwmp) {
     pwmEnableChannelI(&BACKLIGHT_PWM_DRIVER, BACKLIGHT_PWM_CHANNEL - 1, PWM_FRACTION_TO_WIDTH(&BACKLIGHT_PWM_DRIVER, 0xFFFF, duty));
     chSysUnlockFromISR();
 }
-
-#else
-
-__attribute__((weak)) void backlight_init_ports(void) {}
-
-__attribute__((weak)) void backlight_set(uint8_t level) {}
-
-__attribute__((weak)) void backlight_task(void) {}
 
 #endif

--- a/quantum/backlight/backlight_avr.c
+++ b/quantum/backlight/backlight_avr.c
@@ -206,7 +206,7 @@ static const pin_t backlight_pin = BACKLIGHT_PIN;
 #    endif
 
 #    ifdef NO_HARDWARE_PWM
-__attribute__((weak)) void backlight_init_ports(void) {
+void backlight_init_ports(void) {
     // Setup backlight pin as output and output to on state.
     FOR_EACH_LED(setPinOutput(backlight_pin); backlight_on(backlight_pin);)
 
@@ -216,8 +216,6 @@ __attribute__((weak)) void backlight_init_ports(void) {
     }
 #        endif
 }
-
-__attribute__((weak)) void backlight_set(uint8_t level) {}
 
 uint8_t backlight_tick = 0;
 
@@ -303,7 +301,7 @@ static uint16_t cie_lightness(uint16_t v) {
 static inline void set_pwm(uint16_t val) { OCRxx = val; }
 
 #        ifndef BACKLIGHT_CUSTOM_DRIVER
-__attribute__((weak)) void backlight_set(uint8_t level) {
+void backlight_set(uint8_t level) {
     if (level > BACKLIGHT_LEVELS) level = BACKLIGHT_LEVELS;
 
     if (level == 0) {
@@ -342,7 +340,6 @@ void backlight_task(void) {}
 #            define BREATHING_HALT_ON 2
 #            define BREATHING_STEPS 128
 
-static uint8_t breathing_period = BREATHING_PERIOD;
 static uint8_t breathing_halt = BREATHING_NO_HALT;
 static uint16_t breathing_counter = 0;
 
@@ -377,9 +374,9 @@ bool is_breathing(void) { return !!(TIMSKx & _BV(TOIEx)); }
                 do {                       \
                     breathing_counter = 0; \
                 } while (0)
-#            define breathing_max()                                 \
-                do {                                                \
-                    breathing_counter = breathing_period * 244 / 2; \
+#            define breathing_max()                                       \
+                do {                                                      \
+                    breathing_counter = get_breathing_period() * 244 / 2; \
                 } while (0)
 
 void breathing_enable(void) {
@@ -417,17 +414,6 @@ void breathing_toggle(void) {
         breathing_enable();
 }
 
-void breathing_period_set(uint8_t value) {
-    if (!value) value = 1;
-    breathing_period = value;
-}
-
-void breathing_period_default(void) { breathing_period_set(BREATHING_PERIOD); }
-
-void breathing_period_inc(void) { breathing_period_set(breathing_period + 1); }
-
-void breathing_period_dec(void) { breathing_period_set(breathing_period - 1); }
-
 /* To generate breathing curve in python:
  * from math import sin, pi; [int(sin(x/128.0*pi)**4*255) for x in range(128)]
  */
@@ -445,6 +431,7 @@ void breathing_task(void)
 ISR(TIMERx_OVF_vect)
 #            endif
 {
+    uint8_t breathing_period = get_breathing_period();
     uint16_t interval = (uint16_t)breathing_period * 244 / BREATHING_STEPS;
     // resetting after one period to prevent ugly reset at overflow.
     breathing_counter = (breathing_counter + 1) % (breathing_period * 244);
@@ -459,7 +446,7 @@ ISR(TIMERx_OVF_vect)
 
 #        endif  // BACKLIGHT_BREATHING
 
-__attribute__((weak)) void backlight_init_ports(void) {
+void backlight_init_ports(void) {
     // Setup backlight pin as output and output to on state.
     FOR_EACH_LED(setPinOutput(backlight_pin); backlight_on(backlight_pin);)
 
@@ -499,11 +486,5 @@ __attribute__((weak)) void backlight_init_ports(void) {
 }
 
 #    endif  // hardware backlight
-
-#else  // no backlight
-
-__attribute__((weak)) void backlight_init_ports(void) {}
-
-__attribute__((weak)) void backlight_set(uint8_t level) {}
 
 #endif  // backlight

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -243,30 +243,6 @@ void register_code16(uint16_t code);
 void unregister_code16(uint16_t code);
 void tap_code16(uint16_t code);
 
-#ifdef BACKLIGHT_ENABLE
-void backlight_init_ports(void);
-void backlight_task(void);
-void backlight_task_internal(void);
-void backlight_on(pin_t backlight_pin);
-void backlight_off(pin_t backlight_pin);
-
-#    ifdef BACKLIGHT_BREATHING
-void breathing_task(void);
-void breathing_enable(void);
-void breathing_pulse(void);
-void breathing_disable(void);
-void breathing_self_disable(void);
-void breathing_toggle(void);
-bool is_breathing(void);
-
-void breathing_intensity_default(void);
-void breathing_period_default(void);
-void breathing_period_set(uint8_t value);
-void breathing_period_inc(void);
-void breathing_period_dec(void);
-#    endif
-#endif
-
 void     send_dword(uint32_t number);
 void     send_word(uint16_t number);
 void     send_byte(uint8_t number);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Part 1 of N: 
* Remove duplication of breathing config
  * Had to use weak as a bunch of boards are doing custom backlight without setting the rules.mk flag
* ~~Remove duplication of cie_lightness~~
  * ~~there might be a better location for this as it kind of fits in with the led_tables functionality~~
  * removed for now to avoid conflict with #7521
* Relocate backlight function definitions from quantum to backlight

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
