### PR TITLE
Convert backlight to follow driver rules pattern

### DIFF
--- a/common_features.mk
+++ b/common_features.mk
@@ -231,15 +231,16 @@ endif
 
 # backward compat
 ifeq ($(strip $(BACKLIGHT_CUSTOM_DRIVER)), yes)
-    BACKLIGHT_ENABLE = custom
+    BACKLIGHT_DRIVER = custom
 endif
 
-VALID_BACKLIGHT_TYPES := yes software custom
+VALID_BACKLIGHT_TYPES := pwm software custom
 
 BACKLIGHT_ENABLE ?= no
-ifneq ($(strip $(BACKLIGHT_ENABLE)), no)
-    ifeq ($(filter $(BACKLIGHT_ENABLE),$(VALID_BACKLIGHT_TYPES)),)
-        $(error BACKLIGHT_ENABLE="$(BACKLIGHT_ENABLE)" is not a valid backlight type)
+BACKLIGHT_DRIVER ?= pwm
+ifeq ($(strip $(BACKLIGHT_ENABLE)), yes)
+    ifeq ($(filter $(BACKLIGHT_DRIVER),$(VALID_BACKLIGHT_TYPES)),)
+        $(error BACKLIGHT_DRIVER="$(BACKLIGHT_DRIVER)" is not a valid backlight type)
     endif
 
     ifeq ($(strip $(VISUALIZER_ENABLE)), yes)
@@ -250,10 +251,10 @@ ifneq ($(strip $(BACKLIGHT_ENABLE)), no)
     SRC += $(QUANTUM_DIR)/backlight/backlight.c
     OPT_DEFS += -DBACKLIGHT_ENABLE
 
-    ifeq ($(strip $(BACKLIGHT_ENABLE)), software)
+    ifeq ($(strip $(BACKLIGHT_DRIVER)), software)
         SRC += $(QUANTUM_DIR)/backlight/backlight_soft.c
     else
-        ifeq ($(strip $(BACKLIGHT_ENABLE)), custom)
+        ifeq ($(strip $(BACKLIGHT_DRIVER)), custom)
             OPT_DEFS += -DBACKLIGHT_CUSTOM_DRIVER
         endif
 

--- a/docs/feature_backlight.md
+++ b/docs/feature_backlight.md
@@ -6,15 +6,13 @@ QMK is able to control the brightness of these LEDs by switching them on and off
 
 The MCU can only supply so much current to its GPIO pins. Instead of powering the backlight directly from the MCU, the backlight pin is connected to a transistor or MOSFET that switches the power to the LEDs.
 
-## Driver configuration
+## Feature Configuration
 
 Most keyboards have backlighting enabled by default if they support it, but if it is not working for you, check that your `rules.mk` includes the following:
 
 ```makefile
-BACKLIGHT_ENABLE = software # Valid driver values are 'yes,software,no'
+BACKLIGHT_ENABLE = yes
 ```
-
-See below for help on individual drivers.
 
 ## Keycodes
 Once enabled the following keycodes below can be used to change the backlight level.
@@ -51,6 +49,16 @@ Once enabled the following keycodes below can be used to change the backlight le
 |`breathing_enable()`  |Turns on backlight breathing           |
 |`breathing_disable()` |Turns off backlight breathing          |
 
+## Driver Configuration
+
+To select which driver to use, configure your `rules.mk` with the following:
+
+```makefile
+BACKLIGHT_DRIVER = software # Valid driver values are 'pwm,software,no'
+```
+
+See below for help on individual drivers.
+
 ## Common Driver Configuration
 
 To change the behavior of the backlighting, `#define` these in your `config.h`:
@@ -72,9 +80,9 @@ This functionality is configured at the keyboard level with the `BACKLIGHT_ON_ST
 
 ## AVR driver
 
-On AVR boards, the default driver currently sniffs the configuration to pick the best scenario. To enable it, add this to your rules.mk:
+On AVR boards, the default driver currently sniffs the configuration to pick the best scenario. The driver is configured by default, however the equivalent setting within rules.mk would be:
 ```makefile
-BACKLIGHT_ENABLE = yes
+BACKLIGHT_DRIVER = pwm
 ```
 
 ### Caveats
@@ -150,9 +158,9 @@ The breathing effect is the same as in the hardware PWM implementation.
 
 ## ARM Driver
 
-While still in its early stages, ARM backlight support aims to eventually have feature parity with AVR. To enable it, add this to your rules.mk:
+While still in its early stages, ARM backlight support aims to eventually have feature parity with AVR. The driver is configured by default, however the equivalent setting within rules.mk would be:
 ```makefile
-BACKLIGHT_ENABLE = yes
+BACKLIGHT_DRIVER = pwm
 ```
 
 ### Caveats
@@ -176,7 +184,7 @@ To change the behavior of the backlighting, `#define` these in your `config.h`:
 
 Emulation of PWM while running other keyboard tasks, it offers maximum hardware compatibility without extra platform configuration. The tradeoff is the backlight might jitter when the keyboard is busy. To enable, add this to your rules.mk:
 ```makefile
-BACKLIGHT_ENABLE = software
+BACKLIGHT_DRIVER = software
 ```
 
 ### Software PWM Configuration
@@ -199,4 +207,30 @@ To activate multiple backlight pins, you need to add something like this to your
 ```c
 #undef BACKLIGHT_PIN
 #define BACKLIGHT_PINS { F5, B2 }
+```
+
+## Custom Driver
+
+To enable, add this to your rules.mk:
+
+```makefile
+BACKLIGHT_DRIVER = custom
+```
+
+When implementing the custom driver API, the provided keyboard hooks are as follows:
+
+```c
+void backlight_init_ports(void) {
+    // Optional - Run on startup
+    //          - usually you want to configure pins here
+}
+void backlight_set(uint8_t level) {
+    // Optional - Run on level change
+    //          - usually you want to respond to the new value
+}
+
+void backlight_task(void) {
+    // Optional - Run periodically
+    //          - long running actions here can cause performance issues
+}
 ```

--- a/quantum/stm32/proton_c.mk
+++ b/quantum/stm32/proton_c.mk
@@ -5,9 +5,7 @@ AUDIO_ENABLE = yes
 WS2812_DRIVER = bitbang
 
 # Force task driven PWM until ARM can provide automatic configuration
-ifneq ($(strip $(BACKLIGHT_ENABLE)), no)
-	BACKLIGHT_ENABLE = software
-endif
+BACKLIGHT_DRIVER = software
 
 # The rest of these settings shouldn't change
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Kind of an oversight on my part, but `BACKLIGHT_ENABLE = software` or `BACKLIGHT_ENABLE = custom` makes life a little difficult. Having a clear option for what method to use, and then a master on/off, provides users with just a toggle and removes overhead of them finding context on stuff like pwm/timer/software emulation for a particular keyboard. Another example with issues is, userspace where a board has backlight off by default to save space.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
