### PR TITLE
Support RGBLIGHT_SLEEP when ChibiOS boards suspend

### DIFF
--- a/tmk_core/common/chibios/suspend.c
+++ b/tmk_core/common/chibios/suspend.c
@@ -15,6 +15,13 @@
 #    include "backlight.h"
 #endif
 
+#if defined(RGBLIGHT_SLEEP) && defined(RGBLIGHT_ENABLE)
+#    include "rgblight.h"
+extern rgblight_config_t rgblight_config;
+static bool              rgblight_enabled;
+static bool              is_suspended;
+#endif
+
 /** \brief suspend idle
  *
  * FIXME: needs doc
@@ -43,6 +50,16 @@ void suspend_power_down(void) {
     // TODO: figure out what to power down and how
     // shouldn't power down TPM/FTM if we want a breathing LED
     // also shouldn't power down USB
+#if defined(RGBLIGHT_SLEEP) && defined(RGBLIGHT_ENABLE)
+#    ifdef RGBLIGHT_ANIMATIONS
+    rgblight_timer_disable();
+#    endif
+    if (!is_suspended) {
+        is_suspended     = true;
+        rgblight_enabled = rgblight_config.enable;
+        rgblight_disable_noeeprom();
+    }
+#endif
 
     suspend_power_down_kb();
     // on AVR, this enables the watchdog for 15ms (max), and goes to
@@ -104,5 +121,14 @@ void suspend_wakeup_init(void) {
 #ifdef BACKLIGHT_ENABLE
     backlight_init();
 #endif /* BACKLIGHT_ENABLE */
+#if defined(RGBLIGHT_SLEEP) && defined(RGBLIGHT_ENABLE)
+    is_suspended = false;
+    if (rgblight_enabled) {
+        rgblight_enable_noeeprom();
+    }
+#    ifdef RGBLIGHT_ANIMATIONS
+    rgblight_timer_enable();
+#    endif
+#endif
     suspend_wakeup_init_kb();
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I know ARM boards don't have a general WS2812 implementation yet, but some specific boards do, like the CannonKeys ARM boards. For these boards, it'd be nice if `RGBLIGHT_SLEEP` just worked. I copied over the implementation from `tmk_core/common/avr/suspend.c` and it seems to work fine with ChibiOS.

I verified on my Instant60 that with `RGBLIGHT_SLEEP` the RGB now turns off when the host PC goes to sleep and turns back on (including animations) when the host PC wakes. Normal keyboard stuff seems fine after wake as well.

**Open question:** Should I guard this code behind `NO_SUSPEND_POWER_DOWN` like the equivalent AVR code? It's honestly not clear to me what that define is for, exactly....

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [X] Core
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* ARM boards keeping their RGB underglow on at all times, even if `RGBLIGHT_SLEEP` was defined.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
