### PR TITLE
Fix `led_init_ports()` for Wasdat

### DIFF
--- a/keyboards/maartenwut/wasdat/wasdat.c
+++ b/keyboards/maartenwut/wasdat/wasdat.c
@@ -29,8 +29,11 @@ void matrix_init_kb(void) {
 
 void led_init_ports(void) {
     setPinOutput(B0);
+    writePinHigh(B0);
     setPinOutput(B1);
+    writePinHigh(B1);
     setPinOutput(B2);
+    writePinHigh(B2);
 }
 
 bool led_update_kb(led_t led_state) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

With the following code in my keymap to repurpose the Scroll Lock LED as a layer indicator:

```c
bool led_update_user(led_t led_state) {
    writePin(B0, !led_state.caps_lock);

    return false;
}

layer_state_t layer_state_set_user(layer_state_t state) {
    writePin(B1, IS_LAYER_ON(_FN));

    return state;
}
```

The LED turns on upon reset. Because the pins are in current sink configuration (VCC -> LED -> pin), output low lights up the LEDs. So we need to explicitly initially set them to output high.

As a side note this also basically fixes the brief flickering on powerup, due to the reliance on the first call to `led_update_kb()` to turn them back off, which obviously has to wait for USB enumeration.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
