### PR TITLE
[Keyboard] Enable RGB Light on ARM OLKB Keyboards

### DIFF
--- a/keyboards/planck/rev6/config.h
+++ b/keyboards/planck/rev6/config.h
@@ -125,14 +125,17 @@
 /* override number of MIDI tone keycodes (each octave adds 12 keycodes and allocates 12 bytes) */
 //#define MIDI_TONE_KEYCODE_OCTAVES 1
 
-#define WS2812_LED_N 2
-#define RGBLED_NUM WS2812_LED_N
-#define WS2812_TIM_N 2
-#define WS2812_TIM_CH 2
-#define PORT_WS2812     GPIOA
-#define PIN_WS2812      1
-#define WS2812_DMA_STREAM STM32_DMA1_STREAM2  // DMA stream for TIMx_UP (look up in reference manual under DMA Channel selection)
+// #define WS2812_LED_N 2
+// #define RGBLED_NUM WS2812_LED_N
+// #define WS2812_TIM_N 2
+// #define WS2812_TIM_CH 2
+// #define PORT_WS2812     GPIOA
+// #define PIN_WS2812      1
+// #define WS2812_DMA_STREAM STM32_DMA1_STREAM2  // DMA stream for TIMx_UP (look up in reference manual under DMA Channel selection)
 //#define WS2812_DMA_CHANNEL 7                  // DMA channel for TIMx_UP
 //#define WS2812_EXTERNAL_PULLUP
+#define RGB_DI_PIN A1
+#define RGBLED_NUM 9
+#define RGBLIGHT_ANIMATIONS
 
 #endif

--- a/keyboards/planck/rev6/rules.mk
+++ b/keyboards/planck/rev6/rules.mk
@@ -20,7 +20,8 @@ MIDI_ENABLE = no            # MIDI controls
 AUDIO_ENABLE = yes           # Audio output on port C6
 UNICODE_ENABLE = no         # Unicode
 BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
-RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight.
+RGBLIGHT_ENABLE = yes        # Enable WS2812 RGB underlight.
+WS2812_DRIVER = bitbang
 API_SYSEX_ENABLE = no
 
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
@@ -29,7 +30,7 @@ SLEEP_LED_ENABLE = no    # Breathing sleep LED during USB suspend
 
 # SERIAL_LINK_ENABLE = yes
 ENCODER_ENABLE = yes
-DIP_SWITCH_ENABLE = yes 
+DIP_SWITCH_ENABLE = yes
 
 LAYOUTS = ortho_4x12 planck_mit
 LAYOUTS_HAS_RGB = no

--- a/keyboards/preonic/rev3/config.h
+++ b/keyboards/preonic/rev3/config.h
@@ -112,14 +112,18 @@
 /* override number of MIDI tone keycodes (each octave adds 12 keycodes and allocates 12 bytes) */
 //#define MIDI_TONE_KEYCODE_OCTAVES 1
 
-#define WS2812_LED_N 2
-#define RGBLED_NUM WS2812_LED_N
-#define WS2812_TIM_N 2
-#define WS2812_TIM_CH 2
-#define PORT_WS2812     GPIOA
-#define PIN_WS2812      1
-#define WS2812_DMA_STREAM STM32_DMA1_STREAM2  // DMA stream for TIMx_UP (look up in reference manual under DMA Channel selection)
+// #define WS2812_LED_N 2
+// #define RGBLED_NUM WS2812_LED_N
+// #define WS2812_TIM_N 2
+// #define WS2812_TIM_CH 2
+// #define PORT_WS2812     GPIOA
+// #define PIN_WS2812      1
+// #define WS2812_DMA_STREAM STM32_DMA1_STREAM2  // DMA stream for TIMx_UP (look up in reference manual under DMA Channel selection)
 //#define WS2812_DMA_CHANNEL 7                  // DMA channel for TIMx_UP
 //#define WS2812_EXTERNAL_PULLUP
+#define RGB_DI_PIN A1
+#define RGBLED_NUM 9
+#define RGBLIGHT_ANIMATIONS
+
 
 #endif

--- a/keyboards/preonic/rev3/rules.mk
+++ b/keyboards/preonic/rev3/rules.mk
@@ -17,7 +17,8 @@ MIDI_ENABLE = no            # MIDI controls
 AUDIO_ENABLE = yes           # Audio output on port C6
 UNICODE_ENABLE = no         # Unicode
 BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
-RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight.
+RGBLIGHT_ENABLE = yes        # Enable WS2812 RGB underlight.
+WS2812_DRIVER = bitbang
 API_SYSEX_ENABLE = no
 
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE


### PR DESCRIPTION

## Description

This enables the bitbang WS2812 support for the ARM OLKB keyboards (Planck Rev6, and Preonic Rev3).

Defaulted to "enabled", since size really isn't a consideration, and you won't see if the LEDs are not soldered on. 

## Types of Changes
- [x] Keyboard (addition or update)

## Checklist
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
