### PR TITLE
Fix LAYER_STATE_8BIT compile issues

### DIFF
--- a/tmk_core/common/action_layer.c
+++ b/tmk_core/common/action_layer.c
@@ -268,7 +268,7 @@ uint8_t layer_switch_get_layer(keypos_t key) {
     /* fall back to layer 0 */
     return 0;
 #else
-    return biton32(default_layer_state);
+    return get_highest_layer(default_layer_state);
 #endif
 }
 

--- a/tmk_core/common/action_layer.h
+++ b/tmk_core/common/action_layer.h
@@ -23,7 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #if defined(LAYER_STATE_8BIT)
 typedef uint8_t layer_state_t;
-#    define get_highest_layer(state) biton8(state)
+#    define get_highest_layer(state) biton(state)
 #elif defined(LAYER_STATE_16BIT)
 typedef uint16_t layer_state_t;
 #    define get_highest_layer(state) biton16(state)

--- a/tmk_core/common/eeconfig.c
+++ b/tmk_core/common/eeconfig.c
@@ -2,13 +2,13 @@
 #include <stdbool.h>
 #include "eeprom.h"
 #include "eeconfig.h"
+#include "action_layer.h"
 
 #ifdef STM32_EEPROM_ENABLE
 #    include "hal.h"
 #    include "eeprom_stm32.h"
 #endif
 
-extern uint32_t default_layer_state;
 /** \brief eeconfig enable
  *
  * FIXME: needs doc


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
When on a mission to cut down firmware size, the following settings were added
```
#define LAYER_STATE_8BIT
#define NO_ACTION_LAYER
```
Which produces the following error:
```
tmk_core/common/action_layer.h:26:38: error: implicit declaration of function ‘biton8’ [-Werror=implicit-function-declaration]
```

This PR fixes a few scenarios where a u32 is still being used.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
