### PR TITLE
Fix ChibiOS compile error when mouse and nkro disabled

### DIFF
--- a/tmk_core/protocol/chibios/usb_main.c
+++ b/tmk_core/protocol/chibios/usb_main.c
@@ -379,7 +379,6 @@ static void    set_led_transfer_cb(USBDriver *usbp) {
 /* Callback for SETUP request on the endpoint 0 (control) */
 static bool usb_request_hook_cb(USBDriver *usbp) {
     const USBDescriptor *dp;
-    int                  has_report_id;
 
     /* usbp->setup fields:
      *  0:   bmRequestType (bitmask)
@@ -432,26 +431,17 @@ static bool usb_request_hook_cb(USBDriver *usbp) {
                 switch (usbp->setup[1]) { /* bRequest */
                     case HID_SET_REPORT:
                         switch (usbp->setup[4]) { /* LSB(wIndex) (check MSB==0 and wLength==1?) */
-                            case KEYBOARD_INTERFACE:
 #if defined(SHARED_EP_ENABLE) && !defined(KEYBOARD_SHARED_EP)
                             case SHARED_INTERFACE:
+                                usbSetupTransfer(usbp, set_report_buf, sizeof(set_report_buf), set_led_transfer_cb);
+                                return TRUE;
+                                break;
 #endif
+
+                            case KEYBOARD_INTERFACE:
                                 /* keyboard_led_stats = <read byte from next OUT report>
                                  * keyboard_led_stats needs be word (or dword), otherwise we get an exception on F0 */
-                                has_report_id = 0;
-#if defined(SHARED_EP_ENABLE)
-                                if (usbp->setup[4] == SHARED_INTERFACE) {
-                                    has_report_id = 1;
-                                }
-#endif
-                                if (usbp->setup[4] == KEYBOARD_INTERFACE && !keyboard_protocol) {
-                                    has_report_id = 0;
-                                }
-                                if (has_report_id) {
-                                    usbSetupTransfer(usbp, set_report_buf, sizeof(set_report_buf), set_led_transfer_cb);
-                                } else {
-                                    usbSetupTransfer(usbp, (uint8_t *)&keyboard_led_stats, 1, NULL);
-                                }
+                                usbSetupTransfer(usbp, (uint8_t *)&keyboard_led_stats, 1, NULL);
                                 return TRUE;
                                 break;
                         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
When disabling basically all the features on `handwired/onekey/proton_c:default`, including mouse and nkro, the following error is produced:
```console
Compiling: tmk_core/protocol/chibios/usb_main.c                                                    In file included from ./lib/chibios/os/hal/include/hal.h:141:0,
                 from tmk_core/protocol/chibios/usb_main.c:19:
tmk_core/protocol/chibios/usb_main.c: In function 'usb_request_hook_cb':
tmk_core/protocol/chibios/usb_main.c:451:60: error: 'set_report_buf' undeclared (first use in this function); did you mean 'has_report_id'?
                                     usbSetupTransfer(usbp, set_report_buf, sizeof(set_report_buf), set_led_transfer_cb);
                                                            ^
./lib/chibios/os/hal/include/hal_usb.h:477:23: note: in definition of macro 'usbSetupTransfer'
   (usbp)->ep0next  = (buf);                                                 \
                       ^~~
tmk_core/protocol/chibios/usb_main.c:451:60: note: each undeclared identifier is reported only once for each function it appears in
                                     usbSetupTransfer(usbp, set_report_buf, sizeof(set_report_buf), set_led_transfer_cb);
                                                            ^
./lib/chibios/os/hal/include/hal_usb.h:477:23: note: in definition of macro 'usbSetupTransfer'
   (usbp)->ep0next  = (buf);                                                 \
                       ^~~
tmk_core/protocol/chibios/usb_main.c:451:100: error: 'set_led_transfer_cb' undeclared (first use in this function)
                                     usbSetupTransfer(usbp, set_report_buf, sizeof(set_report_buf), set_led_transfer_cb);
                                                                                                    ^
./lib/chibios/os/hal/include/hal_usb.h:479:23: note: in definition of macro 'usbSetupTransfer'
   (usbp)->ep0endcb = (endcb);                                               \
                       ^~~~~
 [ERRORS]
```



This PR fixes the logic so that `set_report_buf` is correctly guarded when `SHARED_EP_ENABLE` is not defined, reducing the logic down so the code isnt littered with ifdefs.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
