### PR TITLE
QMK CLI quality of life improvements

### DIFF
--- a/build_json.mk
+++ b/build_json.mk
@@ -23,4 +23,4 @@ endif
 
 # Generate the keymap.c
 $(KEYBOARD_OUTPUT)/src/keymap.c:
-	bin/qmk json-keymap $(KEYMAP_JSON) -o $(KEYMAP_C)
+	bin/qmk json-keymap --quiet --output $(KEYMAP_C) $(KEYMAP_JSON)

--- a/build_json.mk
+++ b/build_json.mk
@@ -22,6 +22,5 @@ else ifneq ("$(wildcard $(MAIN_KEYMAP_PATH_1)/keymap.json)","")
 endif
 
 # Generate the keymap.c
-ifneq ("$(KEYMAP_JSON)","")
-    _ = $(shell test -e $(KEYMAP_C) || bin/qmk json-keymap $(KEYMAP_JSON) -o $(KEYMAP_C))
-endif
+$(KEYBOARD_OUTPUT)/src/keymap.c:
+	bin/qmk json-keymap $(KEYMAP_JSON) -o $(KEYMAP_C)

--- a/lib/python/milc.py
+++ b/lib/python/milc.py
@@ -20,6 +20,7 @@ import re
 import shlex
 import sys
 from decimal import Decimal
+from pathlib import Path
 from tempfile import NamedTemporaryFile
 from time import sleep
 
@@ -39,7 +40,7 @@ import colorama
 from appdirs import user_config_dir
 
 # Disable logging until we can configure it how the user wants
-logging.basicConfig(filename='/dev/null')
+logging.basicConfig(stream=os.devnull)
 
 # Log Level Representations
 EMOJI_LOGLEVELS = {
@@ -96,7 +97,6 @@ def format_ansi(text):
 class ANSIFormatter(logging.Formatter):
     """A log formatter that inserts ANSI color.
     """
-
     def format(self, record):
         msg = super(ANSIFormatter, self).format(record)
         return format_ansi(msg)
@@ -105,7 +105,6 @@ class ANSIFormatter(logging.Formatter):
 class ANSIEmojiLoglevelFormatter(ANSIFormatter):
     """A log formatter that makes the loglevel an emoji on UTF capable terminals.
     """
-
     def format(self, record):
         if UNICODE_SUPPORT:
             record.levelname = EMOJI_LOGLEVELS[record.levelname].format(**ansi_colors)
@@ -115,7 +114,6 @@ class ANSIEmojiLoglevelFormatter(ANSIFormatter):
 class ANSIStrippingFormatter(ANSIFormatter):
     """A log formatter that strips ANSI.
     """
-
     def format(self, record):
         msg = super(ANSIStrippingFormatter, self).format(record)
         return ansi_escape.sub('', msg)
@@ -127,7 +125,6 @@ class Configuration(object):
     This class never raises IndexError, instead it will return None if a
     section or option does not yet exist.
     """
-
     def __contains__(self, key):
         return self._config.__contains__(key)
 
@@ -214,9 +211,8 @@ def handle_store_boolean(self, *args, **kwargs):
 
 
 class SubparserWrapper(object):
-    """Wrap subparsers so we can populate the normal and the shadow parser.
+    """Wrap subparsers so we can track what options the user passed.
     """
-
     def __init__(self, cli, submodule, subparser):
         self.cli = cli
         self.submodule = submodule
@@ -232,24 +228,25 @@ class SubparserWrapper(object):
         self.subparser.completer = completer
 
     def add_argument(self, *args, **kwargs):
+        """Add an argument for this subcommand.
+        
+        This also stores the default for the argument in `self.cli.default_arguments`.
+        """
         if 'action' in kwargs and kwargs['action'] == 'store_boolean':
+            # Store boolean will call us again with the enable/disable flag arguments
             return handle_store_boolean(self, *args, **kwargs)
 
         self.cli.acquire_lock()
         self.subparser.add_argument(*args, **kwargs)
-
-        if 'default' in kwargs:
-            del kwargs['default']
-        if 'action' in kwargs and kwargs['action'] == 'store_false':
-            kwargs['action'] == 'store_true'
-        self.cli.subcommands_default[self.submodule].add_argument(*args, **kwargs)
+        if self.submodule not in self.cli.default_arguments:
+            self.cli.default_arguments[self.submodule] = {}
+        self.cli.default_arguments[self.submodule][self.cli.get_argument_name(*args, **kwargs)] = kwargs.get('default')
         self.cli.release_lock()
 
 
 class MILC(object):
     """MILC - An Opinionated Batteries Included Framework
     """
-
     def __init__(self):
         """Initialize the MILC object.
         """
@@ -263,8 +260,9 @@ class MILC(object):
         self._inside_context_manager = False
         self.ansi = ansi_colors
         self.arg_only = []
-        self.config = Configuration()
+        self.config = None
         self.config_file = None
+        self.default_arguments = {}
         self.version = os.environ.get('QMK_VERSION', 'unknown')
         self.release_lock()
 
@@ -273,6 +271,7 @@ class MILC(object):
         self.prog_name = self.prog_name.split('/')[-1]
 
         # Initialize all the things
+        self.read_config_file()
         self.initialize_argparse()
         self.initialize_logging()
 
@@ -282,7 +281,7 @@ class MILC(object):
 
     @description.setter
     def description(self, value):
-        self._description = self._arg_parser.description = self._arg_defaults.description = value
+        self._description = self._arg_parser.description = value
 
     def echo(self, text, *args, **kwargs):
         """Print colorized text to stdout.
@@ -311,12 +310,9 @@ class MILC(object):
 
         self.acquire_lock()
         self.subcommands = {}
-        self.subcommands_default = {}
         self._subparsers = None
-        self._subparsers_default = None
         self.argwarn = argcomplete.warn
         self.args = None
-        self._arg_defaults = argparse.ArgumentParser(**kwargs)
         self._arg_parser = argparse.ArgumentParser(**kwargs)
         self.set_defaults = self._arg_parser.set_defaults
         self.print_usage = self._arg_parser.print_usage
@@ -329,25 +325,18 @@ class MILC(object):
         self._arg_parser.completer = completer
 
     def add_argument(self, *args, **kwargs):
-        """Wrapper to add arguments to both the main and the shadow argparser.
+        """Wrapper to add arguments and track whether they were passed on the command line.
         """
         if 'action' in kwargs and kwargs['action'] == 'store_boolean':
             return handle_store_boolean(self, *args, **kwargs)
 
-        if kwargs.get('add_dest', True) and args[0][0] == '-':
-            kwargs['dest'] = 'general_' + self.get_argument_name(*args, **kwargs)
-        if 'add_dest' in kwargs:
-            del kwargs['add_dest']
-
         self.acquire_lock()
-        self._arg_parser.add_argument(*args, **kwargs)
 
-        # Populate the shadow parser
-        if 'default' in kwargs:
-            del kwargs['default']
-        if 'action' in kwargs and kwargs['action'] == 'store_false':
-            kwargs['action'] == 'store_true'
-        self._arg_defaults.add_argument(*args, **kwargs)
+        self._arg_parser.add_argument(*args, **kwargs)
+        if 'general' not in self.default_arguments:
+            self.default_arguments['general'] = {}
+        self.default_arguments['general'][self.get_argument_name(*args, **kwargs)] = kwargs.get('default')
+
         self.release_lock()
 
     def initialize_logging(self):
@@ -374,15 +363,13 @@ class MILC(object):
         self.add_argument('--log-file-fmt', default='[%(levelname)s] [%(asctime)s] [file:%(pathname)s] [line:%(lineno)d] %(message)s', help='Format string for log file.')
         self.add_argument('--log-file', help='File to write log messages to')
         self.add_argument('--color', action='store_boolean', default=True, help='color in output')
-        self.add_argument('-c', '--config-file', help='The config file to read and/or write')
-        self.add_argument('--save-config', action='store_true', help='Save the running configuration to the config file')
+        self.add_argument('--config-file', help='The location for the configuration file')
 
     def add_subparsers(self, title='Sub-commands', **kwargs):
         if self._inside_context_manager:
             raise RuntimeError('You must run this before the with statement!')
 
         self.acquire_lock()
-        self._subparsers_default = self._arg_defaults.add_subparsers(title=title, dest='subparsers', **kwargs)
         self._subparsers = self._arg_parser.add_subparsers(title=title, dest='subparsers', **kwargs)
         self.release_lock()
 
@@ -404,10 +391,12 @@ class MILC(object):
         if self.config_file:
             return self.config_file
 
-        if self.args and self.args.general_config_file:
-            return self.args.general_config_file
+        if '--config-file' in sys.argv:
+            return Path(sys.argv[sys.argv.index('--config-file') + 1]).expanduser().resolve()
 
-        return os.path.join(user_config_dir(appname='qmk', appauthor='QMK'), '%s.ini' % self.prog_name)
+        filedir = user_config_dir(appname='qmk', appauthor='QMK')
+        filename = '%s.ini' % self.prog_name
+        return Path(filedir) / filename
 
     def get_argument_name(self, *args, **kwargs):
         """Takes argparse arguments and returns the dest name.
@@ -446,7 +435,7 @@ class MILC(object):
     def arg_passed(self, arg):
         """Returns True if arg was passed on the command line.
         """
-        return self.args_passed[arg] in (None, False)
+        return self.default_arguments.get(arg) != self.args[arg]
 
     def parse_args(self):
         """Parse the CLI args.
@@ -459,25 +448,22 @@ class MILC(object):
 
         self.acquire_lock()
         self.args = self._arg_parser.parse_args()
-        self.args_passed = self._arg_defaults.parse_args()
 
         if 'entrypoint' in self.args:
             self._entrypoint = self.args.entrypoint
 
-        if self.args.general_config_file:
-            self.config_file = self.args.general_config_file
-
         self.release_lock()
 
-    def read_config(self):
-        """Parse the configuration file and determine the runtime configuration.
+    def read_config_file(self):
+        """Read in the configuration file and store it in self.config.
         """
         self.acquire_lock()
+        self.config = Configuration()
         self.config_file = self.find_config_file()
 
-        if self.config_file and os.path.exists(self.config_file):
+        if self.config_file and self.config_file.exists():
             config = RawConfigParser(self.config)
-            config.read(self.config_file)
+            config.read(str(self.config_file))
 
             # Iterate over the config file options and write them into self.config
             for section in config.sections():
@@ -497,32 +483,44 @@ class MILC(object):
 
                     self.config[section][option] = value
 
-        # Fold the CLI args into self.config
+        self.release_lock()
+
+    def merge_args_into_config(self):
+        """Merge CLI arguments into self.config to create the runtime configuration.
+        """
+        self.acquire_lock()
         for argument in vars(self.args):
             if argument in ('subparsers', 'entrypoint'):
                 continue
 
-            if '_' in argument:
-                section, option = argument.split('_', 1)
-            else:
-                section = self._entrypoint.__name__
-                option = argument
+            if argument not in self.arg_only:
+                # Find the argument's section
+                argument_found = True
+                for group in self.default_arguments:
+                    if argument in self.default_arguments[group]:
+                        argument_found = True
+                        section = group
+                        break
 
-            if option not in self.arg_only:
-                if hasattr(self.args_passed, argument):
+                if not argument_found:
+                    raise RuntimeError('Could not find argument in `self.default_arguments`. This should be impossible!')
+                    exit(1)
+
+                # Merge this argument into self.config
+                if argument in self.default_arguments:
                     arg_value = getattr(self.args, argument)
                     if arg_value:
-                        self.config[section][option] = arg_value
+                        self.config[section][argument] = arg_value
                 else:
-                    if option not in self.config[section]:
-                        self.config[section][option] = getattr(self.args, argument)
+                    if argument not in self.config[section]:
+                        self.config[section][argument] = getattr(self.args, argument)
 
         self.release_lock()
 
     def save_config(self):
         """Save the current configuration to the config file.
         """
-        self.log.debug("Saving config file to '%s'", self.config_file)
+        self.log.debug("Saving config file to '%s'", str(self.config_file))
 
         if not self.config_file:
             self.log.warning('%s.config_file file not set, not saving config!', self.__class__.__name__)
@@ -530,31 +528,33 @@ class MILC(object):
 
         self.acquire_lock()
 
+        # Generate a sanitized version of our running configuration
         config = RawConfigParser()
-        config_dir = os.path.dirname(self.config_file)
-
         for section_name, section in self.config._config.items():
             config.add_section(section_name)
             for option_name, value in section.items():
                 if section_name == 'general':
-                    if option_name in ['save_config']:
+                    if option_name in ['config_file']:
                         continue
                 config.set(section_name, option_name, str(value))
 
-        if not os.path.exists(config_dir):
-            os.makedirs(config_dir)
+        # Write out the config file
+        config_dir = self.config_file.parent
+        if not config_dir.exists():
+            config_dir.mkdir(parents=True, exist_ok=True)
 
-        with NamedTemporaryFile(mode='w', dir=config_dir, delete=False) as tmpfile:
+        with NamedTemporaryFile(mode='w', dir=str(config_dir), delete=False) as tmpfile:
             config.write(tmpfile)
 
         # Move the new config file into place atomically
         if os.path.getsize(tmpfile.name) > 0:
-            os.rename(tmpfile.name, self.config_file)
+            os.rename(tmpfile.name, str(self.config_file))
         else:
-            self.log.warning('Config file saving failed, not replacing %s with %s.', self.config_file, tmpfile.name)
+            self.log.warning('Config file saving failed, not replacing %s with %s.', str(self.config_file), tmpfile.name)
 
+        # Housekeeping
         self.release_lock()
-        cli.log.info('Wrote configuration to %s', shlex.quote(self.config_file))
+        cli.log.info('Wrote configuration to %s', shlex.quote(str(self.config_file)))
 
     def __call__(self):
         """Execute the entrypoint function.
@@ -603,15 +603,10 @@ class MILC(object):
             name = handler.__name__.replace("_", "-")
 
         self.acquire_lock()
+
         kwargs['help'] = description
-        self.subcommands_default[name] = self._subparsers_default.add_parser(name, **kwargs)
         self.subcommands[name] = SubparserWrapper(self, name, self._subparsers.add_parser(name, **kwargs))
         self.subcommands[name].set_defaults(entrypoint=handler)
-
-        if name not in self.__dict__:
-            self.__dict__[name] = self.subcommands[name]
-        else:
-            self.log.debug("Could not add subcommand '%s' to attributes, key already exists!", name)
 
         self.release_lock()
 
@@ -620,7 +615,6 @@ class MILC(object):
     def subcommand(self, description, **kwargs):
         """Decorator to register a subcommand.
         """
-
         def subcommand_function(handler):
             return self.add_subcommand(handler, description, **kwargs)
 
@@ -644,9 +638,9 @@ class MILC(object):
         self.log_format = self.config['general']['log_fmt']
 
         if self.config.general.color:
-            self.log_format = ANSIEmojiLoglevelFormatter(self.args.general_log_fmt, self.config.general.datetime_fmt)
+            self.log_format = ANSIEmojiLoglevelFormatter(self.args.log_fmt, self.config.general.datetime_fmt)
         else:
-            self.log_format = ANSIStrippingFormatter(self.args.general_log_fmt, self.config.general.datetime_fmt)
+            self.log_format = ANSIStrippingFormatter(self.args.log_fmt, self.config.general.datetime_fmt)
 
         if self.log_file:
             self.log_file_handler = logging.FileHandler(self.log_file, self.log_file_mode)
@@ -673,12 +667,8 @@ class MILC(object):
 
         colorama.init()
         self.parse_args()
-        self.read_config()
+        self.merge_args_into_config()
         self.setup_logging()
-
-        if 'save_config' in self.config.general and self.config.general.save_config:
-            self.save_config()
-            exit(0)
 
         return self
 

--- a/lib/python/qmk/cli/cformat.py
+++ b/lib/python/qmk/cli/cformat.py
@@ -2,6 +2,7 @@
 """
 import os
 import subprocess
+from shutil import which
 
 from milc import cli
 
@@ -11,7 +12,13 @@ from milc import cli
 def cformat(cli):
     """Format C code according to QMK's style.
     """
+    # Determine which version of clang-format to use
     clang_format = ['clang-format', '-i']
+    for clang_version in [10, 9, 8, 7]:
+        binary = 'clang-format-%d' % clang_version
+        if which(binary):
+            clang_format[0] = binary
+            break
 
     # Find the list of files to format
     if not cli.args.files:

--- a/lib/python/qmk/cli/cformat.py
+++ b/lib/python/qmk/cli/cformat.py
@@ -22,7 +22,7 @@ def cformat(cli):
 
     # Find the list of files to format
     if cli.args.files:
-        cli.args.files = [os.path.join(os.environ['ORIG_DIR'], file) for file in cli.args.files]
+        cli.args.files = [os.path.join(os.environ['ORIG_CWD'], file) for file in cli.args.files]
     else:
         for dir in ['drivers', 'quantum', 'tests', 'tmk_core']:
             for dirpath, dirnames, filenames in os.walk(dir):

--- a/lib/python/qmk/cli/cformat.py
+++ b/lib/python/qmk/cli/cformat.py
@@ -21,7 +21,9 @@ def cformat(cli):
             break
 
     # Find the list of files to format
-    if not cli.args.files:
+    if cli.args.files:
+        cli.args.files = [os.path.join(os.environ['ORIG_DIR'], file) for file in cli.args.files]
+    else:
         for dir in ['drivers', 'quantum', 'tests', 'tmk_core']:
             for dirpath, dirnames, filenames in os.walk(dir):
                 if 'tmk_core/protocol/usb_hid' in dirpath:

--- a/lib/python/qmk/cli/config.py
+++ b/lib/python/qmk/cli/config.py
@@ -12,7 +12,7 @@ def print_config(section, key):
     cli.echo('%s.%s{fg_cyan}={fg_reset}%s', section, key, cli.config[section][key])
 
 
-@cli.argument('-ro', '--read-only', action='store_true', help='Operate in read-only mode.')
+@cli.argument('-ro', '--read-only', arg_only=True, action='store_true', help='Operate in read-only mode.')
 @cli.argument('configs', nargs='*', arg_only=True, help='Configuration options to read or write.')
 @cli.subcommand("Read and write configuration settings.")
 def config(cli):

--- a/lib/python/qmk/cli/doctor.py
+++ b/lib/python/qmk/cli/doctor.py
@@ -24,8 +24,7 @@ def doctor(cli):
     cli.log.info('QMK Doctor is checking your environment.')
 
     # Make sure the basic CLI tools we need are available and can be executed.
-    binaries = ['dfu-programmer', 'avrdude', 'dfu-util', 'avr-gcc', 'arm-none-eabi-gcc']
-    binaries += glob('bin/qmk-*')
+    binaries = ['dfu-programmer', 'avrdude', 'dfu-util', 'avr-gcc', 'arm-none-eabi-gcc', 'bin/qmk']
     ok = True
 
     for binary in binaries:
@@ -34,10 +33,10 @@ def doctor(cli):
             cli.log.error("{fg_red}QMK can't find %s in your path.", binary)
             ok = False
         else:
-            try:
-                subprocess.run([binary, '--version'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=5, check=True)
+            check = subprocess.run([binary, '--version'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=5)
+            if check.returncode in [0, 1]:
                 cli.log.info('Found {fg_cyan}%s', binary)
-            except subprocess.CalledProcessError:
+            else:
                 cli.log.error("{fg_red}Can't run `%s --version`", binary)
                 ok = False
 

--- a/lib/python/qmk/cli/json/keymap.py
+++ b/lib/python/qmk/cli/json/keymap.py
@@ -10,6 +10,7 @@ import qmk.keymap
 
 
 @cli.argument('-o', '--output', arg_only=True, help='File to write to')
+@cli.argument('-q', '--quiet', arg_only=True, action='store_true', help="Quiet mode, only output error messages")
 @cli.argument('filename', arg_only=True, help='Configurator JSON file')
 @cli.subcommand('Creates a keymap.c from a QMK Configurator export.')
 def json_keymap(cli):
@@ -48,7 +49,8 @@ def json_keymap(cli):
         with open(output_file, 'w') as keymap_fd:
             keymap_fd.write(keymap_c)
 
-        cli.log.info('Wrote keymap to %s.', cli.args.output)
+        if not cli.args.quiet:
+            cli.log.info('Wrote keymap to %s.', cli.args.output)
 
     else:
         print(keymap_c)

--- a/lib/python/qmk/cli/list/keyboards.py
+++ b/lib/python/qmk/cli/list/keyboards.py
@@ -6,6 +6,7 @@ import glob
 
 from milc import cli
 
+
 @cli.subcommand("List the keyboards currently defined within QMK")
 def list_keyboards(cli):
     """List the keyboards currently defined within QMK

--- a/lib/python/qmk/errors.py
+++ b/lib/python/qmk/errors.py
@@ -1,6 +1,5 @@
 class NoSuchKeyboardError(Exception):
     """Raised when we can't find a keyboard/keymap directory.
     """
-
     def __init__(self, message):
         self.message = message

--- a/lib/python/qmk/tests/attrdict.py
+++ b/lib/python/qmk/tests/attrdict.py
@@ -3,7 +3,6 @@ class AttrDict(dict):
 
     This should only be used to mock objects for unit testing. Please do not use this outside of qmk.tests.
     """
-
     def __init__(self, *args, **kwargs):
         super(AttrDict, self).__init__(*args, **kwargs)
         self.__dict__ = self

--- a/lib/python/qmk/tests/test_cli_commands.py
+++ b/lib/python/qmk/tests/test_cli_commands.py
@@ -7,7 +7,7 @@ def check_subcommand(command, *args):
 
 
 def test_cformat():
-    assert check_subcommand('cformat', 'tmk_core/common/backlight.c').returncode == 0
+    assert check_subcommand('cformat', 'tmk_core/common/keyboard.c').returncode == 0
 
 
 def test_compile():

--- a/lib/python/qmk/tests/test_qmk_path.py
+++ b/lib/python/qmk/tests/test_qmk_path.py
@@ -10,4 +10,4 @@ def test_keymap_onekey_pytest():
 
 def test_normpath():
     path = qmk.path.normpath('lib/python')
-    assert path == os.environ['ORIG_CWD'] + '/lib/python'
+    assert path == os.path.join(os.environ['ORIG_CWD'], 'lib/python')

--- a/util/travis_build.sh
+++ b/util/travis_build.sh
@@ -9,11 +9,11 @@ if [[ "$TRAVIS_COMMIT_MESSAGE" == *"[skip build]"* ]]; then
     exit 0
 fi
 
-if [ "$LOCAL_BRANCH" == "master" ] || [ "$NUM_CORE_CHANGES" != "0" ]; then
+#if [ "$LOCAL_BRANCH" == "milc_improvements" ] || [ "$NUM_CORE_CHANGES" != "0" ]; then
     echo "Making default keymaps for all keyboards"
     make all:default
     exit $?
-fi
+#fi
 
 exit_code=0
 

--- a/util/travis_build.sh
+++ b/util/travis_build.sh
@@ -9,11 +9,11 @@ if [[ "$TRAVIS_COMMIT_MESSAGE" == *"[skip build]"* ]]; then
     exit 0
 fi
 
-#if [ "$LOCAL_BRANCH" == "milc_improvements" ] || [ "$NUM_CORE_CHANGES" != "0" ]; then
+if [ "$LOCAL_BRANCH" == "milc_improvements" ] || [ "$NUM_CORE_CHANGES" != "0" ]; then
     echo "Making default keymaps for all keyboards"
     make all:default
     exit $?
-#fi
+fi
 
 exit_code=0
 

--- a/util/travis_utils.sh
+++ b/util/travis_utils.sh
@@ -16,9 +16,27 @@ QMK_CHANGES=$(git diff --name-only HEAD ${TRAVIS_BRANCH})
 # if docker is installed - patch calls to within the qmk docker image
 if command -v docker >/dev/null; then
     function make() {
+        echo DEBUG DEBUG DEBUG DEBUG DEBUG
+        echo DEBUG DEBUG DEBUG DEBUG DEBUG
+        echo DEBUG DEBUG DEBUG DEBUG DEBUG
+        set
+        echo
+        echo docker run --rm -e MAKEFLAGS="$MAKEFLAGS" -w /qmk_firmware/ -v "$PWD":/qmk_firmware --user $(id -u):$(id -g) qmkfm/base_container make "$@"
+        echo DEBUG DEBUG DEBUG DEBUG DEBUG
+        echo DEBUG DEBUG DEBUG DEBUG DEBUG
+        echo DEBUG DEBUG DEBUG DEBUG DEBUG
         docker run --rm -e MAKEFLAGS="$MAKEFLAGS" -w /qmk_firmware/ -v "$PWD":/qmk_firmware --user $(id -u):$(id -g) qmkfm/base_container make "$@"
     }
     function qmk() {
+        echo DEBUG DEBUG DEBUG DEBUG DEBUG
+        echo DEBUG DEBUG DEBUG DEBUG DEBUG
+        echo DEBUG DEBUG DEBUG DEBUG DEBUG
+        set
+        echo
+        echo docker run --rm -w /qmk_firmware/ -v "$PWD":/qmk_firmware --user $(id -u):$(id -g) qmkfm/base_container bin/qmk "$@"
+        echo DEBUG DEBUG DEBUG DEBUG DEBUG
+        echo DEBUG DEBUG DEBUG DEBUG DEBUG
+        echo DEBUG DEBUG DEBUG DEBUG DEBUG
         docker run --rm -w /qmk_firmware/ -v "$PWD":/qmk_firmware --user $(id -u):$(id -g) qmkfm/base_container bin/qmk "$@"
     }
 fi

--- a/util/travis_utils.sh
+++ b/util/travis_utils.sh
@@ -16,27 +16,9 @@ QMK_CHANGES=$(git diff --name-only HEAD ${TRAVIS_BRANCH})
 # if docker is installed - patch calls to within the qmk docker image
 if command -v docker >/dev/null; then
     function make() {
-        echo DEBUG DEBUG DEBUG DEBUG DEBUG
-        echo DEBUG DEBUG DEBUG DEBUG DEBUG
-        echo DEBUG DEBUG DEBUG DEBUG DEBUG
-        set
-        echo
-        echo docker run --rm -e MAKEFLAGS="$MAKEFLAGS" -w /qmk_firmware/ -v "$PWD":/qmk_firmware --user $(id -u):$(id -g) qmkfm/base_container make "$@"
-        echo DEBUG DEBUG DEBUG DEBUG DEBUG
-        echo DEBUG DEBUG DEBUG DEBUG DEBUG
-        echo DEBUG DEBUG DEBUG DEBUG DEBUG
         docker run --rm -e MAKEFLAGS="$MAKEFLAGS" -w /qmk_firmware/ -v "$PWD":/qmk_firmware --user $(id -u):$(id -g) qmkfm/base_container make "$@"
     }
     function qmk() {
-        echo DEBUG DEBUG DEBUG DEBUG DEBUG
-        echo DEBUG DEBUG DEBUG DEBUG DEBUG
-        echo DEBUG DEBUG DEBUG DEBUG DEBUG
-        set
-        echo
-        echo docker run --rm -w /qmk_firmware/ -v "$PWD":/qmk_firmware --user $(id -u):$(id -g) qmkfm/base_container bin/qmk "$@"
-        echo DEBUG DEBUG DEBUG DEBUG DEBUG
-        echo DEBUG DEBUG DEBUG DEBUG DEBUG
-        echo DEBUG DEBUG DEBUG DEBUG DEBUG
         docker run --rm -w /qmk_firmware/ -v "$PWD":/qmk_firmware --user $(id -u):$(id -g) qmkfm/base_container bin/qmk "$@"
     }
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Various quality of life improvements within.
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

* Add/remove some whitespace to make yapf happy
* Fix the failing test
* Mark `qmk config --read-only` as `arg_only`
* MILC improvements-
    * Remove the shadow argparser
    * Make it easier to reason about arguments and how they're translated into the config tree
    * Populate `self.config` during init to support setting `user.qmk_home` for the global CLI
    * Remove the short argument `-c` so that we can unambiguously determine the config file location without doing full argument processing
    * Remove the `--save-config` option as it's a little confusing anyway
    * Use Pathlib for path manipulation

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [x] Enhancement/optimization

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
