### PR TITLE
If nested macros are disabled, DYN_MACRO_PLAY could end an ongoing recording instead

### DIFF
--- a/quantum/process_keycode/process_dynamic_macro.c
+++ b/quantum/process_keycode/process_dynamic_macro.c
@@ -205,6 +205,10 @@ bool process_dynamic_macro(uint16_t keycode, keyrecord_t *record) {
                     dynamic_macro_record_start(&macro_pointer, r_macro_buffer);
                     macro_id = 2;
                     return false;
+            }
+        }
+        if (record->event.pressed) {
+            switch (keycode) {
                 case DYN_MACRO_PLAY1:
                     dynamic_macro_play(macro_buffer, macro_end, +1);
                     return false;

--- a/quantum/process_keycode/process_dynamic_macro.c
+++ b/quantum/process_keycode/process_dynamic_macro.c
@@ -205,10 +205,12 @@ bool process_dynamic_macro(uint16_t keycode, keyrecord_t *record) {
                     dynamic_macro_record_start(&macro_pointer, r_macro_buffer);
                     macro_id = 2;
                     return false;
+#ifdef DYNAMIC_MACRO_NO_NESTING
             }
         }
         if (record->event.pressed) {
             switch (keycode) {
+#endif
                 case DYN_MACRO_PLAY1:
                     dynamic_macro_play(macro_buffer, macro_end, +1);
                     return false;

--- a/quantum/process_keycode/process_dynamic_macro.c
+++ b/quantum/process_keycode/process_dynamic_macro.c
@@ -217,6 +217,11 @@ bool process_dynamic_macro(uint16_t keycode, keyrecord_t *record) {
         /* A macro is being recorded right now. */
         switch (keycode) {
             case DYN_REC_STOP:
+#ifdef DYNAMIC_MACRO_NO_NESTING
+            case DYN_MACRO_PLAY1:
+            case DYN_MACRO_PLAY2:
+                dprintln("dynamic macro: macro play key deteced while recording, but nesting disabled. Stopping macro recording.");
+#endif
                 /* Stop the macro recording. */
                 if (record->event.pressed) { /* Ignore the initial release
                                               * just after the recoding
@@ -232,12 +237,6 @@ bool process_dynamic_macro(uint16_t keycode, keyrecord_t *record) {
                     macro_id = 0;
                 }
                 return false;
-#ifdef DYNAMIC_MACRO_NO_NESTING
-            case DYN_MACRO_PLAY1:
-            case DYN_MACRO_PLAY2:
-                dprintln("dynamic macro: ignoring macro play key while recording");
-                return false;
-#endif
             default:
                 /* Store the key in the macro buffer and process it normally. */
                 switch (macro_id) {

--- a/quantum/process_keycode/process_dynamic_macro.c
+++ b/quantum/process_keycode/process_dynamic_macro.c
@@ -226,7 +226,7 @@ bool process_dynamic_macro(uint16_t keycode, keyrecord_t *record) {
 #ifdef DYNAMIC_MACRO_NO_NESTING
             case DYN_MACRO_PLAY1:
             case DYN_MACRO_PLAY2:
-                dprintln("dynamic macro: macro play key deteced while recording, but nesting disabled. Stopping macro recording.");
+                dprintln("dynamic macro: macro play key detected while recording, but nesting disabled. Stopping macro recording.");
 #endif
                 /* Stop the macro recording. */
                 if (record->event.pressed) { /* Ignore the initial release


### PR DESCRIPTION
I'm old so using dynamic macros is really complicated. I've been looking to make it more accessible for me. Specifically I want to avoid mapping a third key just for stopping recordings.

I found out when DYNAMIC_MACRO_NO_NESTING is set, the DYN_MACRO_PLAY keys do nothing.
This patch changes the behaviour of these keys to end ongoing recordings if DYNAMIC_MACRO_NO_NESTING is set.

## Description
In process_dynamic_macro.c, when DYNAMIC_MACRO_NO_NESTING is set, the DYN_MACRO_PLAY keycodes are handled in the same way as DYN_REC_STOP.

In addition, I've changed that when not recording, the DYN_MACRO_PLAY key behaviour triggers on event.pressed instead of !event.pressed, as otherwise stopping the recording with the _PLAY button will cause an immediate replay. I made it so that this behavior is only affected when DYNAMIC_MACRO_NO_NESTING is also set.

Note that I only did a basic functional testing, but did not write unit tests.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
