### PR TITLE
Remove force of debug on within rgblight - causes lockups waiting for hid_listen

### DIFF
--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -189,7 +189,6 @@ void rgblight_init(void) {
         return;
     }
 
-    debug_enable = 1;  // Debug ON!
     dprintf("rgblight_init called.\n");
     dprintf("rgblight_init start!\n");
     if (!eeconfig_is_enabled()) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Reports have started slowly filtering in about the recent RGB changes on ChibiOS, mostly within the context of the Planck v6.

I have reproduced locally, with the default keymap. However if i run hid_listen, then the board works.
Disabling console and the board responds fine. A guess at the core issue, is its like it tries to log, and blocks waiting for someone host side to read. When you disable console, those log functions are compiled out.

Tracking down the logging theme, resulting in chopping out code till the board worked again, resulting in the following line being the culprit:
```diff
diff --git a/quantum/rgblight.c b/quantum/rgblight.c
index a4cbe513e..ea54a349f 100644
--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -189,7 +189,7 @@ void rgblight_init(void) {
         return;
     }
 
-    debug_enable = 1;  // Debug ON!
+    //debug_enable = 1;  // Debug ON!
     dprintf("rgblight_init called.\n");
     dprintf("rgblight_init start!\n");
     if (!eeconfig_is_enabled()) {
```

Seems to resolve the reported Chibios + RGBLIGHT sleep issues too.

#### Future work
* figure out why early logging causes issues

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #7329

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
