### PR TITLE
XT converter: add config_common.h include and fix E0 collision

### DIFF
--- a/keyboards/converter/xt_usb/config.h
+++ b/keyboards/converter/xt_usb/config.h
@@ -17,6 +17,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
+#include "config_common.h"
+
 #define VENDOR_ID       0xFEED
 #define PRODUCT_ID      0x6512
 #define DEVICE_VER      0x0001

--- a/keyboards/converter/xt_usb/matrix.c
+++ b/keyboards/converter/xt_usb/matrix.c
@@ -99,25 +99,25 @@ static uint8_t move_e0code(uint8_t code) {
 uint8_t matrix_scan(void)
 {
     static enum {
-        INIT,
-        E0,
+        XT_STATE_INIT,
+        XT_STATE_E0,
         // Pause: E1 1D 45, E1 9D C5
-        E1,
-        E1_1D,
-        E1_9D,
-    } state = INIT;
+        XT_STATE_E1,
+        XT_STATE_E1_1D,
+        XT_STATE_E1_9D,
+    } state = XT_STATE_INIT;
 
     uint8_t code = xt_host_recv();
     if (!code) return 0;
     xprintf("%02X ", code);
     switch (state) {
-        case INIT:
+        case XT_STATE_INIT:
             switch (code) {
                 case 0xE0:
-                    state = E0;
+                    state = XT_STATE_E0;
                     break;
                 case 0xE1:
-                    state = E1;
+                    state = XT_STATE_E1;
                     break;
                 default:
                     if (code < 0x80)
@@ -127,59 +127,59 @@ uint8_t matrix_scan(void)
                     break;
             }
             break;
-        case E0:
+        case XT_STATE_E0:
             switch (code) {
                 case 0x2A:
                 case 0xAA:
                 case 0x36:
                 case 0xB6:
                     //ignore fake shift
-                    state = INIT;
+                    state = XT_STATE_INIT;
                     break;
                 default:
                     if (code < 0x80)
                         matrix_make(move_e0code(code));
                     else
                         matrix_break(move_e0code(code & 0x7F));
-                    state = INIT;
+                    state = XT_STATE_INIT;
                     break;
             }
             break;
-        case E1:
+        case XT_STATE_E1:
             switch (code) {
                 case 0x1D:
-                    state = E1_1D;
+                    state = XT_STATE_E1_1D;
                     break;
                 case 0x9D:
-                    state = E1_9D;
+                    state = XT_STATE_E1_9D;
                     break;
                 default:
-                    state = INIT;
+                    state = XT_STATE_INIT;
                     break;
             }
             break;
-        case E1_1D:
+        case XT_STATE_E1_1D:
             switch (code) {
                 case 0x45:
                     matrix_make(0x55);
                     break;
                 default:
-                    state = INIT;
+                    state = XT_STATE_INIT;
                     break;
             }
             break;
-        case E1_9D:
+        case XT_STATE_E1_9D:
             switch (code) {
                 case 0x45:
                     matrix_break(0x55);
                     break;
                 default:
-                    state = INIT;
+                    state = XT_STATE_INIT;
                     break;
             }
             break;
         default:
-            state = INIT;
+            state = XT_STATE_INIT;
     }
     matrix_scan_quantum();
     return 1;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The XT converter didn't have `#include "config_common.h"` which is necessary for defining `RGB_DI_PIN`, among other things. Since the custom matrix already defines `E0` as one of the states (even though this is not an actual pin on the 32U4), they had to be prefixed to avoid this collision.

Thanks to @acid2000 for reporting.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #7324

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
