### PR TITLE
Make generating keymap.c from JSON more reliable

### DIFF
--- a/build_json.mk
+++ b/build_json.mk
@@ -22,6 +22,5 @@ else ifneq ("$(wildcard $(MAIN_KEYMAP_PATH_1)/keymap.json)","")
 endif
 
 # Generate the keymap.c
-ifneq ("$(KEYMAP_JSON)","")
-    _ = $(shell test -e $(KEYMAP_C) || bin/qmk json-keymap $(KEYMAP_JSON) -o $(KEYMAP_C))
-endif
+$(KEYBOARD_OUTPUT)/src/keymap.c:
+	bin/qmk json-keymap --quiet --output $(KEYMAP_C) $(KEYMAP_JSON)

--- a/lib/python/qmk/cli/json/keymap.py
+++ b/lib/python/qmk/cli/json/keymap.py
@@ -10,6 +10,7 @@ import qmk.keymap
 
 
 @cli.argument('-o', '--output', arg_only=True, help='File to write to')
+@cli.argument('-q', '--quiet', arg_only=True, action='store_true', help="Quiet mode, only output error messages")
 @cli.argument('filename', arg_only=True, help='Configurator JSON file')
 @cli.subcommand('Creates a keymap.c from a QMK Configurator export.')
 def json_keymap(cli):
@@ -48,7 +49,8 @@ def json_keymap(cli):
         with open(output_file, 'w') as keymap_fd:
             keymap_fd.write(keymap_c)
 
-        cli.log.info('Wrote keymap to %s.', cli.args.output)
+        if not cli.args.quiet:
+            cli.log.info('Wrote keymap to %s.', cli.args.output)
 
     else:
         print(keymap_c)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

When compiling `keymap.json` we used to generate the `keymap.c` in a kludgy way. This makes the `keymap.c` a proper make target, so it can be generated in a straightforward way.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
