### PR TITLE
QMK Doctor: When checking program returncodes treat both 0 and 1 as installed

### DIFF
--- a/lib/python/qmk/cli/doctor.py
+++ b/lib/python/qmk/cli/doctor.py
@@ -24,8 +24,7 @@ def doctor(cli):
     cli.log.info('QMK Doctor is checking your environment.')
 
     # Make sure the basic CLI tools we need are available and can be executed.
-    binaries = ['dfu-programmer', 'avrdude', 'dfu-util', 'avr-gcc', 'arm-none-eabi-gcc']
-    binaries += glob('bin/qmk-*')
+    binaries = ['dfu-programmer', 'avrdude', 'dfu-util', 'avr-gcc', 'arm-none-eabi-gcc', 'bin/qmk']
     ok = True
 
     for binary in binaries:
@@ -34,10 +33,10 @@ def doctor(cli):
             cli.log.error("{fg_red}QMK can't find %s in your path.", binary)
             ok = False
         else:
-            try:
-                subprocess.run([binary, '--version'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=5, check=True)
+            check = subprocess.run([binary, '--version'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=5)
+            if check.returncode in [0, 1]:
                 cli.log.info('Found {fg_cyan}%s', binary)
-            except subprocess.CalledProcessError:
+            else:
                 cli.log.error("{fg_red}Can't run `%s --version`", binary)
                 ok = False
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

On older versions of `dfu-programmer` it exits with a returncode of 1 when run with `--help`. Newer versions exit with a returncode of 0. For the time being our test infrastructure is stuck on the older version, so for the purpose of this check we treat both 0 and 1 as working.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
