### PR TITLE
Fix the RGB_MATRIX_RAINBOW_PINWHEELS animation

### DIFF
--- a/quantum/rgb_matrix_animations/rainbow_pinwheels_anim.h
+++ b/quantum/rgb_matrix_animations/rainbow_pinwheels_anim.h
@@ -1,13 +1,13 @@
 #ifndef DISABLE_RGB_MATRIX_RAINBOW_PINWHEELS
-RGB_MATRIX_EFFECT(PINWHEELS)
+RGB_MATRIX_EFFECT(RAINBOW_PINWHEELS)
 #    ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static HSV PINWHEELS_math(HSV hsv, int8_t sin, int8_t cos, uint8_t i, uint8_t time) {
+static HSV RAINBOW_PINWHEELS_math(HSV hsv, int8_t sin, int8_t cos, uint8_t i, uint8_t time) {
     hsv.h += ((g_led_config.point[i].y - k_rgb_matrix_center.y) * 3 * cos + (56 - abs8(g_led_config.point[i].x - k_rgb_matrix_center.x)) * 3 * sin) / 128;
     return hsv;
 }
 
-bool PINWHEELS(effect_params_t* params) { return effect_runner_sin_cos_i(params, &PINWHEELS_math); }
+bool RAINBOW_PINWHEELS(effect_params_t* params) { return effect_runner_sin_cos_i(params, &RAINBOW_PINWHEELS_math); }
 
 #    endif  // RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 #endif      // DISABLE_RGB_MATRIX_RAINBOW_PINWHEELS


### PR DESCRIPTION
## Description

The internal naming was `PINWHEELS` instead of `RAINBOW_PINWHEELS` causing a mismatch between animation definition and the function.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

