### PR TITLE
Improvements to Solenoid feature 

### DIFF
--- a/docs/feature_haptic_feedback.md
+++ b/docs/feature_haptic_feedback.md
@@ -41,11 +41,15 @@ First you will need a build a circuit to drive the solenoid through a mosfet as 
 
 [Wiring diagram provided by Adafruit](https://playground.arduino.cc/uploads/Learning/solenoid_driver.pdf)
 
-Select a pin that has PWM for the signal pin
 
-```
-#define SOLENOID_PIN *pin*
-```
+| Settings                 | Default       | Description                                           |
+|--------------------------|---------------|-------------------------------------------------------|
+|`SOLENOID_PIN`            | *Not defined* |Configures the pin that the Solenoid is connected to.  |
+|`SOLENOID_DEFAULT_DWELL`  | `12` ms       |Configures the default dwell time for the solenoid.    |
+|`SOLENOID_MIN_DWELL`      | `4` ms        |Sets the lower limit for the dwell.                    |
+|`SOLENOID_MAX_DWELL`      | `100` ms      |Sets the upper limit for the dwell.                    |
+
+?> Dwell time is how long the "plunger" stays activated.  The dwell time changes how the solenoid sounds.
 
 Beware that some pins may be powered during bootloader (ie. A13 on the STM32F303 chip) and will result in the solenoid kept in the on state through the whole flashing process. This may overheat and damage the solenoid. If you find that the pin the solenoid is connected to is triggering the solenoid during bootloader/DFU, select another pin.
 

--- a/drivers/haptic/solenoid.h
+++ b/drivers/haptic/solenoid.h
@@ -29,10 +29,6 @@
 #    define SOLENOID_MIN_DWELL 4
 #endif
 
-#ifndef SOLENOID_ACTIVE
-#    define SOLENOID_ACTIVE false
-#endif
-
 #ifndef SOLENOID_PIN
 #    error SOLENOID_PIN not defined
 #endif

--- a/drivers/haptic/solenoid.h
+++ b/drivers/haptic/solenoid.h
@@ -34,7 +34,7 @@
 #endif
 
 #ifndef SOLENOID_PIN
-#    define SOLENOID_PIN F6
+#    error SOLENOID_PIN not defined
 #endif
 
 void solenoid_buzz_on(void);


### PR DESCRIPTION
## Description

* Removes `SOLENOID_ACTIVE` since this is stored in eeprom. No need for it
* Remove default pin define to prevent unexpected/unwanted behavior. Instead, explicitly require a define for it. 
* Actually add solenoid settings to documentation. 

## Types of Changes

- [x] Core
- [x] Bugfix
- [x] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

* if solenoid is enabled, but pin not defined, can cause keys to not work. 

## Checklist
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
