### PR TITLE
Fix clang-format logic within CI

### DIFF
--- a/util/travis_compiled_push.sh
+++ b/util/travis_compiled_push.sh
@@ -13,7 +13,7 @@ if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == "false" ]] ; the
 # fix formatting
 git checkout master
 git diff --diff-filter=AM --name-only -n 1 -z ${TRAVIS_COMMIT_RANGE} | xargs -0 dos2unix
-git diff --diff-filter=AM --name-only -n 1 -z ${TRAVIS_COMMIT_RANGE} | grep -e '^drivers' -e '^quantum' -e '^tests' -e '^tmk_core' | grep -v 'quantum/template' | xargs -0 clang-format
+git diff --diff-filter=AM --name-only -n 1 -z ${TRAVIS_COMMIT_RANGE} '*.c' '*.h' '*.cpp' | grep -z -e '^drivers' -e '^quantum' -e '^tests' -e '^tmk_core' | grep -zv -e 'quantum/template' -e 'tmk_core/protocol/usb_hid' | xargs -0 clang-format -i
 git diff --diff-filter=AM --name-only -n 1 -z ${TRAVIS_COMMIT_RANGE} | xargs -0 git add
 git commit -m "format code according to conventions [skip ci]" && git push git@github.com:qmk/qmk_firmware.git master
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Issues:
1. grep needs `-z` to correctly handle the null instead of newlines from previous `git diff -z` output
2. clang-format needs `-i` otherwise it prints all the newly formatted code to stdout
3. changed files can be outside of the original format pass
    * this leads to clang-format targeting makefiles and markdown

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
