### PR TITLE
Allow 'make all:<user>' to not build EVERYTHING

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -272,12 +272,14 @@ define PARSE_RULE
     # If the rule starts with all, then continue the parsing from
     # PARSE_ALL_KEYBOARDS
     ifeq ($$(call COMPARE_AND_REMOVE_FROM_RULE,all),true)
+        KEYBOARD_RULE=all
         $$(eval $$(call PARSE_ALL_KEYBOARDS))
     else ifeq ($$(call COMPARE_AND_REMOVE_FROM_RULE,test),true)
         $$(eval $$(call PARSE_TEST))
     # If the rule starts with the name of a known keyboard, then continue
     # the parsing from PARSE_KEYBOARD
     else ifeq ($$(call TRY_TO_MATCH_RULE_FROM_LIST,$$(KEYBOARDS)),true)
+        KEYBOARD_RULE=$$(MATCHED_ITEM)
         $$(eval $$(call PARSE_KEYBOARD,$$(MATCHED_ITEM)))
     # Otherwise use the KEYBOARD variable, which is determined either by
     # the current directory you run make from, or passed in as an argument
@@ -380,6 +382,9 @@ define PARSE_KEYBOARD
     # Otherwise try to match the keymap from the current folder, or arguments to the make command
     else ifneq ($$(KEYMAP),)
         $$(eval $$(call PARSE_KEYMAP,$$(KEYMAP)))
+    # Otherwise if we are running make all:<user> just skip
+    else ifeq ($$(KEYBOARD_RULE),all)
+        # $$(info Skipping: No user keymap for $$(CURRENT_KB))
     # Otherwise, make all keymaps, again this is consistent with how it works without
     # any arguments
     else


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Currently if you run something like `make all:zvecr` it produces the following output...

```console
$ make all:zvecr
QMK Firmware 0.7.79
Making 1upkeyboards/1up60hse with keymap default and target zvecr                              [ERRORS]
make[1]: *** No rule to make target 'zvecr'. Stop.
Making 1upkeyboards/1up60hse with keymap default_60_ansi and target zvecr                      [ERRORS]
make[1]: *** No rule to make target 'zvecr'. Stop.
Making 1upkeyboards/1up60hse with keymap mechmerlin-ansi and target zvecr                      [ERRORS]
make[1]: *** No rule to make target 'zvecr'. Stop.
Making 1upkeyboards/1up60hse with keymap stanrc85-ansi and target zvecr                        [ERRORS]
make[1]: *** No rule to make target 'zvecr'. Stop.
Making 1upkeyboards/1up60hse with keymap talljoe-ansi and target zvecr                         [ERRORS]
make[1]: *** No rule to make target 'zvecr'. Stop.
Making 1upkeyboards/1up60hse with keymap vosechu and target zvecr                              [ERRORS]
make[1]: *** No rule to make target 'zvecr'. Stop.
Making 1upkeyboards/1up60hse with keymap xyverz and target zvecr                               [ERRORS]
make[1]: *** No rule to make target 'zvecr'. Stop.
Making 1upkeyboards/1up60hte with keymap default and target zvecr                              [ERRORS]
make[1]: *** No rule to make target 'zvecr'. Stop.
Making 1upkeyboards/1up60hte with keymap default_60_hhkb and target zvecr                      [ERRORS]
make[1]: *** No rule to make target 'zvecr'. Stop.
Making 1upkeyboards/1up60hte with keymap hhkb and target zvecr                                 [ERRORS]
make[1]: *** No rule to make target 'zvecr'. Stop.
Making 1upkeyboards/1up60hte with keymap talljoe-hhkb and target zvecr                         [ERRORS]
make[1]: *** No rule to make target 'zvecr'. Stop.
Making 1upkeyboards/1up60hte with keymap yanfali and target zvecr                              [ERRORS]
make[1]: *** No rule to make target 'zvecr'. Stop.
```

**Note:** The above output shows it trying to build *all* keymaps against *all* keymaps for that board

This PR updates the makefile logic to skip boards when a user keymap does not exist and now when running `make all:zvecr` only builds my dz60 keymap.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
