### PR TITLE
Set up language fallback for docs, and update translation guidelines

### DIFF
--- a/docs/_summary.md
+++ b/docs/_summary.md
@@ -111,7 +111,7 @@
   * [Using Eclipse with QMK](other_eclipse.md)
   * [Using VSCode with QMK](other_vscode.md)
   * [Support](support.md)
-  * [How to add translations](translating.md)
+  * [Translating the QMK Docs](translating.md)
 
 * QMK Internals (In Progress)
   * [Defines](internals_defines.md)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -101,6 +101,18 @@ enum my_keycodes {
 };
 ```
 
+### Previewing the Documentation
+
+Before opening a pull request, you can preview your changes if you have set up the development environment by running this command from the `qmk_firmware/` folder:
+
+    ./bin/qmk docs
+
+or if you only have Python 3 installed:
+
+    python3 -m http.server 8936
+
+and navigating to `http://localhost:8936/`.
+
 ## Keymaps
 
 Most first-time QMK contributors start with their personal keymaps. We try to keep keymap standards pretty casual (keymaps, after all, reflect the personality of their creators) but we do ask that you follow these guidelines to make it easier for others to discover and learn from your keymap.

--- a/docs/index.html
+++ b/docs/index.html
@@ -35,6 +35,15 @@
       loadNavbar: '_langs.md',
       mergeNavbar: true,
       auto2top: true,
+      fallbackLanguages: [
+        'de',
+        'es',
+        'fr-fr',
+        'he-il',
+        'ja',
+        'ru-ru',
+        'zh-cn'
+      ],
       formatUpdated: '{YYYY}/{MM}/{DD} {HH}:{mm}',
       search: {
         paths: 'auto',

--- a/docs/translating.md
+++ b/docs/translating.md
@@ -8,7 +8,13 @@ A `_summary.md` file should exist in this folder with a list of links to each fi
  * [QMK简介](zh-cn/getting_started_introduction.md)
 ```
 
-All links to other docs pages must also be prefixed with the language folder.
+All links to other docs pages must also be prefixed with the language folder. If the link is to a specific part of the page (ie. a certain heading), you must use the English ID for the heading, like so:
+
+```markdown
+[建立你的环境](zh-cn/newbs-getting-started.md#set-up-your-environment)
+
+## 建立你的环境 :id=set-up-your-environment
+```
 
 Once you've finished translating a new language, you'll also need to modify the following files:
 
@@ -26,7 +32,7 @@ Once you've finished translating a new language, you'll also need to modify the 
   '/zh-cn/': '没有结果!',
   ```
 
-  And make sure to add the language folder in the `fallbackLanguages` list, so it will properly fall back to English:
+  And make sure to add the language folder in the `fallbackLanguages` list, so it will properly fall back to English instead of 404ing:
 
   ```js
   fallbackLanguages: [

--- a/docs/translating.md
+++ b/docs/translating.md
@@ -44,10 +44,6 @@ Once you've finished translating a new language, you'll also need to modify the 
 
 ## Previewing the Translations
 
-Before opening a pull request, you can preview your additions if you have Python 3 installed by running this command in the `qmk_firmware/` folder:
-
-    ./bin/qmk docs
-
-and navigating to `http://localhost:8936/` - you should be able to select your new language from the "Translations" menu at the top-right.
+See (Previewing the Documentation)[contributing.md#previewing-the-documentation] for how to set up a local instance of the docs - you should be able to select your new language from the "Translations" menu at the top-right.
 
 Once you're happy with your work, feel free to open a pull request!

--- a/docs/translating.md
+++ b/docs/translating.md
@@ -19,7 +19,7 @@ All links to other docs pages must also be prefixed with the language folder. If
 Once you've finished translating a new language, you'll also need to modify the following files:
 
 * [`docs/_langs.md`](https://github.com/qmk/qmk_firmware/blob/master/docs/_langs.md)  
-  Each line should contain a country flag in the format `:us:` followed by the name represented in its own language:
+  Each line should contain a country flag as a [GitHub emoji shortcode](https://github.com/ikatyang/emoji-cheat-sheet/blob/master/README.md#country-flag) followed by the name represented in its own language:
 
   ```markdown
    - [:cn: 中文](/zh-cn/)

--- a/docs/translating.md
+++ b/docs/translating.md
@@ -36,7 +36,7 @@ Once you've finished translating a new language, you'll also need to modify the 
   ],
   ```
 
-## Previewing the translations
+## Previewing the Translations
 
 Before opening a pull request, you can preview your additions if you have Python 3 installed by running this command in the `qmk_firmware/` folder:
 

--- a/docs/translating.md
+++ b/docs/translating.md
@@ -1,29 +1,47 @@
-# How to translate the QMK docs into different languages
+# Translating the QMK Docs
 
 All files in the root folder (`docs/`) should be in English - all other languages should be in subfolders with the ISO 639-1 language codes, followed by `-` and the country code where relevant. [A list of common ones can be found here](https://www.andiamo.co.uk/resources/iso-language-codes/). If this folder doesn't exist, you may create it. Each of the translated files should have the same name as the English version, so things can fall back successfully.
 
 A `_summary.md` file should exist in this folder with a list of links to each file, with a translated name, and link preceded by the language folder:
 
-    * [QMK简介](zh-cn/getting_started_introduction.md)
+```markdown
+ * [QMK简介](zh-cn/getting_started_introduction.md)
+```
+
+All links to other docs pages must also be prefixed with the language folder.
 
 Once you've finished translating a new language, you'll also need to modify the following files:
 
 * [`docs/_langs.md`](https://github.com/qmk/qmk_firmware/blob/master/docs/_langs.md)  
-  Each line should contain a country flag in the format `:us:` followed by the name represented in its own language:  
-  
-      - [:cn: 中文](/zh-cn/)
+  Each line should contain a country flag in the format `:us:` followed by the name represented in its own language:
+
+  ```markdown
+   - [:cn: 中文](/zh-cn/)
+  ```
 
 * [`docs/index.html`](https://github.com/qmk/qmk_firmware/blob/master/docs/index.html)  
-  Both `placeholder` and `noData` objects should have a dictionary entry for the language folder in a string:  
-  
-      '/zh-cn/': '没有结果!',
+  Both `placeholder` and `noData` objects should have a dictionary entry for the language folder in a string:
+
+  ```js
+  '/zh-cn/': '没有结果!',
+  ```
+
+  And make sure to add the language folder in the `fallbackLanguages` list, so it will properly fall back to English:
+
+  ```js
+  fallbackLanguages: [
+    // ...
+    'zh-cn',
+    // ...
+  ],
+  ```
 
 ## Previewing the translations
 
-Before opening a pull request, you can preview your additions if you have Python 3 installed by running this command in the `docs/` folder:
+Before opening a pull request, you can preview your additions if you have Python 3 installed by running this command in the `qmk_firmware/` folder:
 
-    python -m http.server 9000
+    ./bin/qmk docs
 
-and navigating to http://localhost:9000/ - you should be able to select your new language from the "Translations" menu at the top-right.
+and navigating to `http://localhost:8936/` - you should be able to select your new language from the "Translations" menu at the top-right.
 
 Once you're happy with your work, feel free to open a pull request!

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,9 @@ This is a keyboard firmware based on the [tmk\_keyboard firmware](https://github
 
 * [See the official documentation on docs.qmk.fm](https://docs.qmk.fm)
 
-The docs are powered by [Docsify](https://docsify.js.org/) and hosted on [GitHub](/docs/). You can request changes by making a fork and [pull request](https://github.com/qmk/qmk_firmware/pulls), or by clicking the "Edit Document" link at the bottom of any page.
+The docs are powered by [Docsify](https://docsify.js.org/) and hosted on [GitHub](/docs/). They are also viewable offline; see [Previewing the Documentation](https://docs.qmk.fm/#/contributing?id=previewing-the-documentation) for more details.
+
+You can request changes by making a fork and opening a [pull request](https://github.com/qmk/qmk_firmware/pulls), or by clicking the "Edit Document" link at the bottom of any page.
 
 ## Supported Keyboards
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Without this `fallbackLanguages` array, pages that don't exist in the selected language will 404. All links must also be prefixed with the language code, or it will revert back to English.

Additionally, pointed users towards using the `qmk docs` CLI command, and used fenced code blocks in translating.md, for syntax highlighting.

Also I think the country flags should be the actual emoji characters, instead of eg. `:ja:`, as some of them appear to be unsupported currently.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
