### PR TITLE
Fix processing of RGB keycodes on crkbd slave half

### DIFF
--- a/keyboards/crkbd/rev1/split_util.c
+++ b/keyboards/crkbd/rev1/split_util.c
@@ -48,13 +48,13 @@ __attribute__((weak)) bool is_keyboard_left(void) {
 #elif defined(EE_HANDS)
     return eeconfig_read_handedness();
 #elif defined(MASTER_RIGHT)
-    return !is_keyboard_master();
+    return !has_usb();
 #endif
 
-    return is_keyboard_master();
+    return has_usb();
 }
 
-__attribute__((weak)) bool is_keyboard_master(void) {
+__attribute__((weak)) bool has_usb(void) {
     static enum { UNKNOWN, MASTER, SLAVE } usbstate = UNKNOWN;
 
     // only check once, as this is called often
@@ -102,9 +102,4 @@ void split_keyboard_setup(void) {
       keyboard_slave_setup();
    }
    sei();
-}
-
-// backwards compat
-bool has_usb(void) {
-   return is_keyboard_master();
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Currently `is_keyboard_master` has a default implementation of `return true`, where keycodes are processed on the slave half by
https://github.com/qmk/qmk_firmware/blob/46d0fe44f357f0435d3335cbe5e361324d4236f6/tmk_core/common/keyboard.c#L288-L316

Porting over usb detection added an implementation to this function, which with its effective false on the slave half, stops keycode processing.

For now, this behaviour will need to fixed, as its the only method that currently works across rgb light and matrix.

Symptoms also found within #7385.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* RGB matrix issue raised on Discord by @tominabox1 
* fixes 7492

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
