### PR TITLE
Update e65.c to fix Caps Lock indicator

### DIFF
--- a/keyboards/exclusive/e65/e65.c
+++ b/keyboards/exclusive/e65/e65.c
@@ -17,16 +17,22 @@
 #include "e65.h"
 
 void matrix_init_kb(void) {
-    setPinOutput(B6);
+    // put your keyboard start-up code here
+    // runs once when the firmware starts up
+
     matrix_init_user();
+    led_init_ports();
 }
 
-void led_set_kb(uint8_t usb_led) {
-    if (IS_LED_ON(usb_led, USB_LED_CAPS_LOCK)) {
-        writePinLow(B6);
-    } else {
-        writePinHigh(B6);
+void led_init_ports(void) {
+    setPinOutput(B6);
+    writePinHigh(B6);
+}
+
+bool led_update_kb(led_t led_state) {
+    if(led_update_user(led_state)) {
+        writePin(B6, !led_state.caps_lock);
     }
 
-    led_set_user(usb_led);
+    return true;
 }

--- a/keyboards/exclusive/e65/e65.c
+++ b/keyboards/exclusive/e65/e65.c
@@ -23,9 +23,9 @@ void matrix_init_kb(void) {
 
 void led_set_kb(uint8_t usb_led) {
     if (IS_LED_ON(usb_led, USB_LED_CAPS_LOCK)) {
-        writePinHigh(B6);
-    } else {
         writePinLow(B6);
+    } else {
+        writePinHigh(B6);
     }
 
     led_set_user(usb_led);


### PR DESCRIPTION
Caps lock LED indicator is reverse.  Light comes on if Caps Lock is not on and turns off when it is on.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Fixed the lines to reverse the Caps Lock LED indicator to turn on when Caps Lock is pressed.

## Types of Changes
Swapped writePinLow/writePinHigh

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixed Caps Lock LED

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
