### PR TITLE
Add `ENCODER_DIRECTION_FLIP` setting 

### DIFF
--- a/docs/feature_encoders.md
+++ b/docs/feature_encoders.md
@@ -2,23 +2,35 @@
 
 Basic encoders are supported by adding this to your `rules.mk`:
 
-    ENCODER_ENABLE = yes
+```make
+ENCODER_ENABLE = yes
+```
 
 and this to your `config.h`:
 
-    #define ENCODERS_PAD_A { B12 }
-    #define ENCODERS_PAD_B { B13 }
+```c
+#define ENCODERS_PAD_A { B12 }
+#define ENCODERS_PAD_B { B13 }
+```
 
 Each PAD_A/B variable defines an array so multiple encoders can be defined, e.g.:
 
-    #define ENCODERS_PAD_A { encoder1a, encoder2a }
-    #define ENCODERS_PAD_B { encoder1b, encoder2b }
+```c
+#define ENCODERS_PAD_A { encoder1a, encoder2a }
+#define ENCODERS_PAD_B { encoder1b, encoder2b }
+```
 
-If your encoder's clockwise directions are incorrect, you can swap the A & B pad definitions.
+If your encoder's clockwise directions are incorrect, you can swap the A & B pad definitions.  Additionally, they can be flipped with a define:
+
+```c
+#define ENCODER_DIRECTION_FLIP
+```
 
 Additionally, the resolution can be specified in the same file (the default & suggested is 4):
 
-    #define ENCODER_RESOLUTION 4
+```c
+#define ENCODER_RESOLUTION 4
+```
 
 ## Split Keyboards
 
@@ -33,27 +45,31 @@ If you are using different pinouts for the encoders on each half of a split keyb
 
 The callback functions can be inserted into your `<keyboard>.c`:
 
-    void encoder_update_kb(uint8_t index, bool clockwise) {
-        encoder_update_user(index, clockwise);
-    }
+```c
+void encoder_update_kb(uint8_t index, bool clockwise) {
+    encoder_update_user(index, clockwise);
+}
+```
 
 or `keymap.c`:
 
-    void encoder_update_user(uint8_t index, bool clockwise) {
-      if (index == 0) { /* First encoder */
-        if (clockwise) {
-          tap_code(KC_PGDN);
-        } else {
-          tap_code(KC_PGUP);
-        }
-      } else if (index == 1) { /* Second encoder */  
-        if (clockwise) {
-          tap_code(KC_UP);
-        } else {
-          tap_code(KC_DOWN);
-        }
-      }
+```c
+void encoder_update_user(uint8_t index, bool clockwise) {
+    if (index == 0) { /* First encoder */
+    if (clockwise) {
+        tap_code(KC_PGDN);
+    } else {
+        tap_code(KC_PGUP);
     }
+    } else if (index == 1) { /* Second encoder */  
+    if (clockwise) {
+        tap_code(KC_UP);
+    } else {
+        tap_code(KC_DOWN);
+    }
+    }
+}
+```
 
 ## Hardware
 

--- a/quantum/encoder.c
+++ b/quantum/encoder.c
@@ -32,7 +32,7 @@
 #endif
 
 #define NUMBER_OF_ENCODERS (sizeof(encoders_pad_a) / sizeof(pin_t))
-#ifndef ENCODER_DIRECTION_FLIP
+#ifdef ENCODER_DIRECTION_FLIP
 static pin_t encoders_pad_a[] = ENCODERS_PAD_A;
 static pin_t encoders_pad_b[] = ENCODERS_PAD_B;
 #else
@@ -60,7 +60,7 @@ __attribute__((weak)) void encoder_update_kb(int8_t index, bool clockwise) { enc
 void encoder_init(void) {
 #if defined(SPLIT_KEYBOARD) && defined(ENCODERS_PAD_A_RIGHT) && defined(ENCODERS_PAD_B_RIGHT)
     if (!isLeftHand) {
-#ifndef ENCODER_DIRECTION_FLIP
+#ifdef ENCODER_DIRECTION_FLIP
         const pin_t encoders_pad_a_right[] = ENCODERS_PAD_A_RIGHT;
         const pin_t encoders_pad_b_right[] = ENCODERS_PAD_B_RIGHT;
 #else

--- a/quantum/encoder.c
+++ b/quantum/encoder.c
@@ -32,9 +32,13 @@
 #endif
 
 #define NUMBER_OF_ENCODERS (sizeof(encoders_pad_a) / sizeof(pin_t))
+#ifndef ENCODER_DIRECTION_FLIP
 static pin_t encoders_pad_a[] = ENCODERS_PAD_A;
 static pin_t encoders_pad_b[] = ENCODERS_PAD_B;
-
+#else
+static pin_t encoders_pad_a[] = ENCODERS_PAD_B;
+static pin_t encoders_pad_b[] = ENCODERS_PAD_A;
+#endif
 static int8_t encoder_LUT[] = {0, -1, 1, 0, 1, 0, 0, -1, -1, 0, 0, 1, 0, 1, -1, 0};
 
 static uint8_t encoder_state[NUMBER_OF_ENCODERS]  = {0};
@@ -56,8 +60,13 @@ __attribute__((weak)) void encoder_update_kb(int8_t index, bool clockwise) { enc
 void encoder_init(void) {
 #if defined(SPLIT_KEYBOARD) && defined(ENCODERS_PAD_A_RIGHT) && defined(ENCODERS_PAD_B_RIGHT)
     if (!isLeftHand) {
+#ifndef ENCODER_DIRECTION_FLIP
         const pin_t encoders_pad_a_right[] = ENCODERS_PAD_A_RIGHT;
         const pin_t encoders_pad_b_right[] = ENCODERS_PAD_B_RIGHT;
+#else
+        const pin_t encoders_pad_a_right[] = ENCODERS_PAD_B_RIGHT;
+        const pin_t encoders_pad_b_right[] = ENCODERS_PAD_A_RIGHT;
+#endif
         for (uint8_t i = 0; i < NUMBER_OF_ENCODERS; i++) {
             encoders_pad_a[i] = encoders_pad_a_right[i];
             encoders_pad_b[i] = encoders_pad_b_right[i];


### PR DESCRIPTION
To allow simple flip of direction. 

In fixing the Split Encoder issues in #7325, the direction was flipped for all encoders.

However, this flip actually corrects the direction to be correct, but this was an unintended change in behavior.
Rather than reverting the direction (because, now it's actually correctly processing CW vs CCW), lets add an option to flip this, so that users can revert to the older behavior if they want, without having to redefine the pins/pads.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/qmk/qmk_firmware/pull/7325/files#r347210609

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
