### PR TITLE
Move RGBLIGHT_SLEEP block in AVR suspend.c

### DIFF
--- a/tmk_core/common/avr/suspend.c
+++ b/tmk_core/common/avr/suspend.c
@@ -98,6 +98,18 @@ static void power_down(uint8_t wdto) {
 #    ifdef PROTOCOL_LUFA
     if (USB_DeviceState == DEVICE_STATE_Configured) return;
 #    endif
+
+#    if defined(RGBLIGHT_SLEEP) && defined(RGBLIGHT_ENABLE)
+#        ifdef RGBLIGHT_ANIMATIONS
+    rgblight_timer_disable();
+#        endif
+    if (!is_suspended) {
+        is_suspended     = true;
+        rgblight_enabled = rgblight_config.enable;
+        rgblight_disable_noeeprom();
+    }
+#    endif
+
     wdt_timeout = wdto;
 
     // Watchdog Interrupt Mode
@@ -121,16 +133,6 @@ static void power_down(uint8_t wdto) {
     // This sometimes disables the start-up noise, so it's been disabled
     // stop_all_notes();
 #    endif /* AUDIO_ENABLE */
-#    if defined(RGBLIGHT_SLEEP) && defined(RGBLIGHT_ENABLE)
-#        ifdef RGBLIGHT_ANIMATIONS
-    rgblight_timer_disable();
-#        endif
-    if (!is_suspended) {
-        is_suspended     = true;
-        rgblight_enabled = rgblight_config.enable;
-        rgblight_disable_noeeprom();
-    }
-#    endif
     suspend_power_down_kb();
 
     // TODO: more power saving


### PR DESCRIPTION
For whatever reason, if both rgb matrix and rgb light are enabled, it will crash if sleeping happens after the watchdog timer is enabled

## Description

Specifically, when both RGB Matrix and RGB Light are enabled on the same board, and RGBLIGHT_SLEEP is enabled, it will crash when starting up.  

It looks like the issue is related with the watchdog interrupt  being enabled.  Moving the `RGBLIGHT_SLEEP` block to before the spot where the watchdog interrupt is enabled seems to fix this issue. 

To be honest, I'm not exactly sure why or what is going on here, but this is something that has been bugging me for quite a while now.  This code change seems to fix the issue, and I haven't seen any other ill effects from it. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix


## Checklist
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
