### PR TITLE
fix broken link in docs/newbs_best_practices.md

### DIFF
--- a/docs/newbs_best_practices.md
+++ b/docs/newbs_best_practices.md
@@ -7,7 +7,7 @@ This document aims to instruct novices in the best ways to have a smooth experie
 This document assumes a few things:
 
 1. You have a GitHub account, and have [forked the qmk_firmware repository](getting_started_github.md) to your account.
-2. You've [set up your build environment](newbs_getting_started.md?id=environment-setup).
+2. You've [set up your build environment](newbs_getting_started.md#set-up-your-environment).
 
 
 ## Your fork's master: Update Often, Commit Never


### PR DESCRIPTION
## Description

`docs/newbs_best_practices.md` has broken link:
```diff
-2. You've [set up your build environment](newbs_getting_started.md?id=environment-setup).
+2. You've [set up your build environment](newbs_getting_started.md#set-up-your-environment).
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
