### PR TITLE
Update default keymaps to use `layer_state_t`

### DIFF
--- a/keyboards/40percentclub/nori/keymaps/default/keymap.c
+++ b/keyboards/40percentclub/nori/keymaps/default/keymap.c
@@ -133,7 +133,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 };
 
-uint32_t layer_state_set_user(uint32_t state) {
+layer_state_t layer_state_set_user(layer_state_t state) {
   return update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
 }
 

--- a/keyboards/aeboards/ext65/keymaps/default/keymap.c
+++ b/keyboards/aeboards/ext65/keymaps/default/keymap.c
@@ -90,7 +90,7 @@ void led_set_user(uint8_t usb_led) {
     }
 }
 
-uint32_t layer_state_set_user(uint32_t state) {
+layer_state_t layer_state_set_user(layer_state_t state) {
     switch (biton32(state)) {
       case 1:
         writePinHigh(D1);

--- a/keyboards/aeboards/ext65/keymaps/default/keymap.c
+++ b/keyboards/aeboards/ext65/keymaps/default/keymap.c
@@ -91,7 +91,7 @@ void led_set_user(uint8_t usb_led) {
 }
 
 layer_state_t layer_state_set_user(layer_state_t state) {
-    switch (biton32(state)) {
+    switch (get_highest_layer(state)) {
       case 1:
         writePinHigh(D1);
         break;

--- a/keyboards/ai03/orbit/keymaps/default/keymap.c
+++ b/keyboards/ai03/orbit/keymaps/default/keymap.c
@@ -85,7 +85,7 @@ void led_set_user(uint8_t usb_led) {
 
 }
 
-uint32_t layer_state_set_user(uint32_t state) {
+layer_state_t layer_state_set_user(layer_state_t state) {
 		
 	return state;
 }

--- a/keyboards/boston_meetup/2019/keymaps/default/keymap.c
+++ b/keyboards/boston_meetup/2019/keymaps/default/keymap.c
@@ -108,7 +108,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 };
 
-uint32_t layer_state_set_user(uint32_t state) {
+layer_state_t layer_state_set_user(layer_state_t state) {
   return update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
 }
 
@@ -163,4 +163,3 @@ void matrix_init_user(void) {
 
 void matrix_scan_user(void) {
 }
-

--- a/keyboards/comet46/keymaps/default/keymap.c
+++ b/keyboards/comet46/keymaps/default/keymap.c
@@ -144,7 +144,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 };
 
 
-uint32_t layer_state_set_user(uint32_t state) {
+layer_state_t layer_state_set_user(layer_state_t state) {
   return update_tri_layer_state(state, _RAISE, _LOWER, _ADJUST);
 }
 

--- a/keyboards/divergetm2/keymaps/default/keymap.c
+++ b/keyboards/divergetm2/keymaps/default/keymap.c
@@ -194,6 +194,6 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
   return true;
 }
 
-uint32_t layer_state_set_user(uint32_t state) {
+layer_state_t layer_state_set_user(layer_state_t state) {
   return update_tri_layer_state(state, _RAISE, _LOWER, _ADJUST);
 }

--- a/keyboards/ergodox_ez/keymaps/default/keymap.c
+++ b/keyboards/ergodox_ez/keymaps/default/keymap.c
@@ -174,7 +174,7 @@ layer_state_t layer_state_set_user(layer_state_t state) {
   ergodox_right_led_2_off();
   ergodox_right_led_3_off();
 
-  uint8_t layer = biton32(state);
+  uint8_t layer = get_highest_layer(state);
   switch (layer) {
       case 0:
         #ifdef RGBLIGHT_COLOR_LAYER_0

--- a/keyboards/ergodox_stm32/keymaps/default/keymap.c
+++ b/keyboards/ergodox_stm32/keymaps/default/keymap.c
@@ -15,7 +15,7 @@ const uint16_t PROGMEM fn_actions[] = {
 
 layer_state_t layer_state_set_user(layer_state_t state) {
 
-    uint8_t layer = biton32(state);
+    uint8_t layer = get_highest_layer(state);
 
     ergodox_led_all_off();
     ergodox_board_led_1_off();

--- a/keyboards/ergodox_stm32/keymaps/default/keymap.c
+++ b/keyboards/ergodox_stm32/keymaps/default/keymap.c
@@ -13,7 +13,7 @@ const uint16_t PROGMEM fn_actions[] = {
   [1] = TT(1)
 };
 
-uint32_t layer_state_set_user(uint32_t state) {
+layer_state_t layer_state_set_user(layer_state_t state) {
 
     uint8_t layer = biton32(state);
 

--- a/keyboards/fortitude60/keymaps/default/keymap.c
+++ b/keyboards/fortitude60/keymaps/default/keymap.c
@@ -155,7 +155,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 };
 
-uint32_t layer_state_set_user(uint32_t state) {
+layer_state_t layer_state_set_user(layer_state_t state) {
   return update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
 }
 

--- a/keyboards/hadron/ver3/keymaps/default/keymap.c
+++ b/keyboards/hadron/ver3/keymaps/default/keymap.c
@@ -193,7 +193,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 };
 
-uint32_t layer_state_set_user(uint32_t state) {
+layer_state_t layer_state_set_user(layer_state_t state) {
   return update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
 }
 
@@ -267,4 +267,3 @@ void matrix_init_user(void) {
 
 void matrix_scan_user(void) {
 }
-

--- a/keyboards/handwired/2x5keypad/keymaps/default/keymap.c
+++ b/keyboards/handwired/2x5keypad/keymaps/default/keymap.c
@@ -143,7 +143,7 @@ layer_state_t layer_state_set_user(layer_state_t state)
 {
     turn_off_leds();
 
-    switch (biton32(state))
+    switch (get_highest_layer(state))
     {
     case NORMAL_LAYER:
 	break;

--- a/keyboards/handwired/bluepill/keymaps/default/keymap.c
+++ b/keyboards/handwired/bluepill/keymaps/default/keymap.c
@@ -51,7 +51,7 @@ KC_GRAVE, KC_1,   KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9, 
 
 /* Layer based ilumination, just binary */
 layer_state_t layer_state_set_user(layer_state_t state) {
-  switch (biton32(state)) {
+  switch (get_highest_layer(state)) {
   case _FNONE:
     palSetPad(GPIOA, 0);  //OFF Color A
     palClearPad(GPIOA, 1); //ON Color B

--- a/keyboards/handwired/bluepill/keymaps/default/keymap.c
+++ b/keyboards/handwired/bluepill/keymaps/default/keymap.c
@@ -50,7 +50,7 @@ KC_GRAVE, KC_1,   KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9, 
 };
 
 /* Layer based ilumination, just binary */
-uint32_t layer_state_set_user(uint32_t state) {
+layer_state_t layer_state_set_user(layer_state_t state) {
   switch (biton32(state)) {
   case _FNONE:
     palSetPad(GPIOA, 0);  //OFF Color A

--- a/keyboards/handwired/jot50/keymaps/default/keymap.c
+++ b/keyboards/handwired/jot50/keymaps/default/keymap.c
@@ -74,7 +74,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 ),
 };
 
-uint32_t layer_state_set_user(uint32_t state) {
+layer_state_t layer_state_set_user(layer_state_t state) {
   return update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
 }
 

--- a/keyboards/handwired/jotanck/keymaps/default/keymap.c
+++ b/keyboards/handwired/jotanck/keymaps/default/keymap.c
@@ -80,7 +80,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 layer_state_t layer_state_set_user(layer_state_t state) {
   #ifdef JOTANCK_LEDS
-  switch (biton32(state)) {
+  switch (get_highest_layer(state)) {
   case _LOWER:
     writePinHigh(JOTANCK_LED1);
     writePinLow(JOTANCK_LED2);

--- a/keyboards/handwired/jotanck/keymaps/default/keymap.c
+++ b/keyboards/handwired/jotanck/keymaps/default/keymap.c
@@ -78,7 +78,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     
 };
 
-uint32_t layer_state_set_user(uint32_t state) {
+layer_state_t layer_state_set_user(layer_state_t state) {
   #ifdef JOTANCK_LEDS
   switch (biton32(state)) {
   case _LOWER:

--- a/keyboards/handwired/prime_exl/keymaps/default/keymap.c
+++ b/keyboards/handwired/prime_exl/keymaps/default/keymap.c
@@ -134,7 +134,7 @@ void led_set_user(uint8_t usb_led) {
 //function for layer indicator LED
 layer_state_t layer_state_set_user(layer_state_t state)
 {
-    if (biton32(state) == 2) {
+    if (get_highest_layer(state) == 2) {
     writePinHigh(C6);
 	} else {
 		writePinLow(C6);

--- a/keyboards/handwired/prime_exl/keymaps/default/keymap.c
+++ b/keyboards/handwired/prime_exl/keymaps/default/keymap.c
@@ -132,7 +132,7 @@ void led_set_user(uint8_t usb_led) {
 }
 
 //function for layer indicator LED
-uint32_t layer_state_set_user(uint32_t state)
+layer_state_t layer_state_set_user(layer_state_t state)
 {
     if (biton32(state) == 2) {
     writePinHigh(C6);

--- a/keyboards/handwired/promethium/keymaps/default/keymap.c
+++ b/keyboards/handwired/promethium/keymaps/default/keymap.c
@@ -986,7 +986,7 @@ void process_doublespace(bool pressed, bool *isactive, bool *otheractive, bool *
 }
 #endif
 
-uint32_t layer_state_set_kb(uint32_t state)
+layer_state_t layer_state_set_user(layer_state_t state)
 {
   // turn on punc layer if both fun & num are on
   if ((state & ((1UL<<_NUM) | (1UL<<_FUN))) == ((1UL<<_NUM) | (1UL<<_FUN))) {

--- a/keyboards/handwired/pteron/keymaps/default/keymap.c
+++ b/keyboards/handwired/pteron/keymaps/default/keymap.c
@@ -99,6 +99,6 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 };
 
-uint32_t layer_state_set_user(uint32_t state) {
+layer_state_t layer_state_set_user(layer_state_t state) {
   return update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
 }

--- a/keyboards/handwired/wulkan/keymaps/default/keymap.c
+++ b/keyboards/handwired/wulkan/keymaps/default/keymap.c
@@ -102,7 +102,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 )
 };
 
-uint32_t layer_state_set_user(uint32_t state) {
+layer_state_t layer_state_set_user(layer_state_t state) {
   return update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
 }
 

--- a/keyboards/handwired/xealous/keymaps/default/keymap.c
+++ b/keyboards/handwired/xealous/keymaps/default/keymap.c
@@ -87,7 +87,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 float tone_qwerty[][2]     = TONE_QWERTY;
 float tone_numpad[][2]     = TONE_NUMPAD;
 
-uint32_t default_layer_state_set_kb(uint32_t state) {
+layer_state_t default_layer_state_set_kb(layer_state_t state) {
     if (state == 1UL<<_QWERTY) {
       PLAY_SONG(tone_qwerty);
     } else if (state == 1UL<<_NUMPAD) {

--- a/keyboards/hecomi/keymaps/default/keymap.c
+++ b/keyboards/hecomi/keymaps/default/keymap.c
@@ -75,7 +75,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
   return true;
 }
 
-uint32_t layer_state_set_user(uint32_t state)
+layer_state_t layer_state_set_user(layer_state_t state)
 {
 	uint8_t layer=biton32(state);
 	switch(layer)

--- a/keyboards/hecomi/keymaps/default/keymap.c
+++ b/keyboards/hecomi/keymaps/default/keymap.c
@@ -77,7 +77,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 
 layer_state_t layer_state_set_user(layer_state_t state)
 {
-	uint8_t layer=biton32(state);
+	uint8_t layer=get_highest_layer(state);
 	switch(layer)
 	{
 		case DF:

--- a/keyboards/jj40/keymaps/default/keymap.c
+++ b/keyboards/jj40/keymaps/default/keymap.c
@@ -99,6 +99,6 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 )
 };
 
-uint32_t layer_state_set_user(uint32_t state) {
+layer_state_t layer_state_set_user(layer_state_t state) {
   return update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
 }

--- a/keyboards/lazydesigners/dimple/keymaps/default/keymap.c
+++ b/keyboards/lazydesigners/dimple/keymaps/default/keymap.c
@@ -118,7 +118,7 @@ if (IS_LED_ON(usb_led, USB_LED_CAPS_LOCK)) {
 
 layer_state_t layer_state_set_user(layer_state_t state) {
 	state = update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
-	switch (biton32(state)) {
+	switch (get_highest_layer(state)) {
 		case _LOWER:
 			rgblight_sethsv_noeeprom(HSV_GREEN);
 			break;

--- a/keyboards/lazydesigners/dimple/keymaps/default/keymap.c
+++ b/keyboards/lazydesigners/dimple/keymaps/default/keymap.c
@@ -116,7 +116,7 @@ if (IS_LED_ON(usb_led, USB_LED_CAPS_LOCK)) {
 	}
 }
 
-uint32_t layer_state_set_user(uint32_t state) {
+layer_state_t layer_state_set_user(layer_state_t state) {
 	state = update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
 	switch (biton32(state)) {
 		case _LOWER:

--- a/keyboards/lets_split/keymaps/default/keymap.c
+++ b/keyboards/lets_split/keymaps/default/keymap.c
@@ -133,7 +133,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 };
 
-uint32_t layer_state_set_user(uint32_t state) {
+layer_state_t layer_state_set_user(layer_state_t state) {
   return update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
 }
 

--- a/keyboards/lets_split_eh/keymaps/default/keymap.c
+++ b/keyboards/lets_split_eh/keymaps/default/keymap.c
@@ -115,6 +115,6 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 };
 
-uint32_t layer_state_set_user(uint32_t state) {
+layer_state_t layer_state_set_user(layer_state_t state) {
   return update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
 }

--- a/keyboards/model01/keymaps/default/keymap.c
+++ b/keyboards/model01/keymaps/default/keymap.c
@@ -110,7 +110,7 @@ void rgb_matrix_indicators_user(void) {
 }
 #else   /* no RGB matrix support */
 
-uint32_t layer_state_set_user(uint32_t state) {
+layer_state_t layer_state_set_user(layer_state_t state) {
   if (state & (1<<NUM)) {
     set_numpad_colours(1, &set_led_to);
   } else {

--- a/keyboards/newgame40/keymaps/default/keymap.c
+++ b/keyboards/newgame40/keymaps/default/keymap.c
@@ -171,7 +171,7 @@ enum layers {
 
  };
 
- uint32_t layer_state_set_user(uint32_t state) {
+ layer_state_t layer_state_set_user(layer_state_t state) {
    return update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
  }
 

--- a/keyboards/orthodox/keymaps/default/keymap.c
+++ b/keyboards/orthodox/keymaps/default/keymap.c
@@ -83,7 +83,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 };
 
-uint32_t layer_state_set_user(uint32_t state) {
+layer_state_t layer_state_set_user(layer_state_t state) {
   return update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
 }
 

--- a/keyboards/plaid/keymaps/default/keymap.c
+++ b/keyboards/plaid/keymaps/default/keymap.c
@@ -234,7 +234,7 @@ void eeconfig_init_user(void) {  // EEPROM is getting reset!
   eeconfig_update_user(led_config.raw);
 }
 
-uint32_t layer_state_set_user(uint32_t state) {
+layer_state_t layer_state_set_user(layer_state_t state) {
   return update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
 }
 

--- a/keyboards/primekb/prime_e/keymaps/default/keymap.c
+++ b/keyboards/primekb/prime_e/keymaps/default/keymap.c
@@ -83,7 +83,7 @@ void led_set_user(uint8_t usb_led) {
 }
 
 //function for layer indicator LED
-uint32_t layer_state_set_user(uint32_t state)
+layer_state_t layer_state_set_user(layer_state_t state)
 {
     if (biton32(state) == 1) {
     writePinHigh(B3);

--- a/keyboards/primekb/prime_e/keymaps/default/keymap.c
+++ b/keyboards/primekb/prime_e/keymaps/default/keymap.c
@@ -85,7 +85,7 @@ void led_set_user(uint8_t usb_led) {
 //function for layer indicator LED
 layer_state_t layer_state_set_user(layer_state_t state)
 {
-    if (biton32(state) == 1) {
+    if (get_highest_layer(state) == 1) {
     writePinHigh(B3);
 	} else {
 		writePinLow(B3);

--- a/keyboards/reviung34/keymaps/default/keymap.c
+++ b/keyboards/reviung34/keymaps/default/keymap.c
@@ -61,7 +61,6 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   ),
 };
 
-uint32_t layer_state_set_user(uint32_t state) {
+layer_state_t layer_state_set_user(layer_state_t state) {
   return update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
 }
-

--- a/keyboards/reviung39/keymaps/default/keymap.c
+++ b/keyboards/reviung39/keymaps/default/keymap.c
@@ -56,6 +56,6 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   ),
 };
 
-uint32_t layer_state_set_user(uint32_t state) {
+layer_state_t layer_state_set_user(layer_state_t state) {
   return update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
 }

--- a/keyboards/spacetime/keymaps/default/keymap.c
+++ b/keyboards/spacetime/keymaps/default/keymap.c
@@ -64,7 +64,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   )
 };
 
-uint32_t layer_state_set_user(uint32_t state) {
+layer_state_t layer_state_set_user(layer_state_t state) {
   return update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
 }
 

--- a/keyboards/staryu/keymaps/default/keymap.c
+++ b/keyboards/staryu/keymaps/default/keymap.c
@@ -81,7 +81,7 @@ void keyboard_post_init_user(void) {
   rgblight_sethsv_noeeprom_white();
 }
 
-uint32_t layer_state_set_user(uint32_t state) {
+layer_state_t layer_state_set_user(layer_state_t state) {
   switch (biton32(state)) {
     case _LAYER1:
         rgblight_sethsv_noeeprom_cyan();

--- a/keyboards/staryu/keymaps/default/keymap.c
+++ b/keyboards/staryu/keymaps/default/keymap.c
@@ -82,7 +82,7 @@ void keyboard_post_init_user(void) {
 }
 
 layer_state_t layer_state_set_user(layer_state_t state) {
-  switch (biton32(state)) {
+  switch (get_highest_layer(state)) {
     case _LAYER1:
         rgblight_sethsv_noeeprom_cyan();
         break;

--- a/keyboards/tanuki/keymaps/default/keymap.c
+++ b/keyboards/tanuki/keymaps/default/keymap.c
@@ -59,7 +59,7 @@ void keyboard_post_init_user(void) {
     }
 }
 
-uint32_t layer_state_set_user(uint32_t state) {
+layer_state_t layer_state_set_user(layer_state_t state) {
     // This code switches underglow color by active layer, if the user has enabled the feature
     if(user_config.layer_rgb) {
         switch (biton32(state)) {

--- a/keyboards/tanuki/keymaps/default/keymap.c
+++ b/keyboards/tanuki/keymaps/default/keymap.c
@@ -62,7 +62,7 @@ void keyboard_post_init_user(void) {
 layer_state_t layer_state_set_user(layer_state_t state) {
     // This code switches underglow color by active layer, if the user has enabled the feature
     if(user_config.layer_rgb) {
-        switch (biton32(state)) {
+        switch (get_highest_layer(state)) {
             case _BL:
                 rgblight_sethsv_noeeprom(0,10,255);
                 rgblight_mode_noeeprom(1);


### PR DESCRIPTION
## Description

This replaces the `uint32_t` that a number of the default keymaps are using for the layer_state_* stuff with the proper typedef'ed `layer_state_t`
And it replaces `biton32` with `get_highest_layer` when dealing with layer state.

This only touches the default keymaps and none of the user keymaps. 

## Types of Changes
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)


## Checklist
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
