### PR TITLE
MILC: Fix/complete attribute heritance

### DIFF
--- a/lib/python/milc.py
+++ b/lib/python/milc.py
@@ -180,7 +180,7 @@ class ConfigurationSection(Configuration):
         """Returns a config value, pulling from the `user` section as a fallback.
         This is called when the attribute is accessed either via the get method or through [ ] index.
         """
-        if key in self._config and self._config[key]:
+        if key in self._config and self._config.get(key) is not None:
             return self._config[key]
 
         elif key in self.parent.user:
@@ -523,7 +523,7 @@ class MILC(object):
                     exit(1)
 
                 # Merge this argument into self.config
-                if argument in self.default_arguments:
+                if argument in self.default_arguments[section]:
                     arg_value = getattr(self.args, argument)
                     if arg_value:
                         self.config[section][argument] = arg_value
@@ -531,7 +531,7 @@ class MILC(object):
                     if argument not in self.config[section]:
                         # Check if the argument exist for this section
                         arg = getattr(self.args, argument)
-                        if arg:
+                        if arg is not None:
                             self.config[section][argument] = arg
 
         self.release_lock()

--- a/lib/python/milc.py
+++ b/lib/python/milc.py
@@ -178,11 +178,21 @@ class ConfigurationSection(Configuration):
 
     def __getitem__(self, key):
         """Returns a config value, pulling from the `user` section as a fallback.
+        This is called when the attribute is accessed either via the get method or through [ ] index.
         """
-        if key in self._config:
+        if key in self._config and self._config[key]:
             return self._config[key]
 
         elif key in self.parent.user:
+            return self.parent.user[key]
+
+        return None
+
+    def __getattr__(self, key):
+        """Returns the config value from the `user` section.
+        This is called when the attribute is accessed via dot notation but does not exists.
+        """
+        if key in self.parent.user:
             return self.parent.user[key]
 
         return None
@@ -519,7 +529,10 @@ class MILC(object):
                         self.config[section][argument] = arg_value
                 else:
                     if argument not in self.config[section]:
-                        self.config[section][argument] = getattr(self.args, argument)
+                        # Check if the argument exist for this section
+                        arg = getattr(self.args, argument)
+                        if arg:
+                            self.config[section][argument] = arg
 
         self.release_lock()
 

--- a/lib/python/milc.py
+++ b/lib/python/milc.py
@@ -511,7 +511,10 @@ class MILC(object):
 
             if argument not in self.arg_only:
                 # Find the argument's section
-                if self._entrypoint.__name__ in self.default_arguments and argument in self.default_arguments[self._entrypoint.__name__]:
+                # Underscores in command's names are converted to dashes during initialization.
+                # TODO(Erovia) Find a better solution
+                entrypoint_name = self._entrypoint.__name__.replace("_", "-")
+                if entrypoint_name in self.default_arguments and argument in self.default_arguments[entrypoint_name]:
                     argument_found = True
                     section = self._entrypoint.__name__
                 if argument in self.default_arguments['general']:
@@ -523,12 +526,12 @@ class MILC(object):
                     exit(1)
 
                 # Merge this argument into self.config
-                if argument in self.default_arguments[section]:
+                if argument in self.default_arguments['general'] or argument in self.default_arguments[entrypoint_name]:
                     arg_value = getattr(self.args, argument)
-                    if arg_value:
+                    if arg_value is not None:
                         self.config[section][argument] = arg_value
                 else:
-                    if argument not in self.config[section]:
+                    if argument not in self.config[entrypoint_name]:
                         # Check if the argument exist for this section
                         arg = getattr(self.args, argument)
                         if arg is not None:


### PR DESCRIPTION
If an undefined attribute of a submodule is accessed, fall back to
same attribute of the submodule's parent.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Example:

QMK CLI submodules try to access their respective configs, for example: `qmk compile` will read from `cli.config.compile.*`.
If we try to access an attribute that's not defined on the submodule level, fall back to the submodules' parent level (`cli.config.user.*`) before erroring out.

This was the intended behaviour before, but it was kind of broken.
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
