### PR TITLE
Adjust Fn key and right arrow cluster of GH60/Satan keymap

### DIFF
--- a/keyboards/gh60/satan/keymaps/smt/keymap.c
+++ b/keyboards/gh60/satan/keymaps/smt/keymap.c
@@ -37,15 +37,15 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    * |-----------------------------------------------------------|
    * |Shift   |  Z|  X|  C|  V|  B|  N|  M|  ,|  .|  /|Shift     |
    * |-----------------------------------------------------------|
-   * |Ctrl|Gui |Alt |         Space         |Alt |Gui |Fn  |Ctrl |
+   * |Ctrl|Gui |Alt |         Space         |Alt |Fn |Gui  |Ctrl |
    * `-----------------------------------------------------------'
    */
   [_QWERTY] = LAYOUT_60_ansi(
-    KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,      KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,    KC_BSPC, \
-    HPR_TAB, KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,      KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC,   KC_BSLS, \
+    KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,      KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS,   KC_EQL,  KC_BSPC, \
+    HPR_TAB, KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,      KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC,   KC_RBRC, KC_BSLS, \
     CTL_ESC, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,      KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,            KC_ENT,  \
     KC_LSFT,          KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,      KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH,            SFT_ENT, \
-    KC_LCTL, KC_LGUI, KC_LALT,                   KC_SPC,                                        KC_RALT, KC_RGUI, MO(_FUNC), KC_RCTL
+    KC_LCTL, KC_LGUI, KC_LALT,                   KC_SPC,                                        KC_RALT, MO(_FUNC), KC_RGUI, KC_RCTL
   ),
 
   /* Keymap _COLEMAK: (Base Layer) Default Layer
@@ -58,15 +58,15 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    * |-----------------------------------------------------------|
    * |Shift   |  Z|  X|  C|  V|  B|  K|  M|  ,|  .|  /|Shift     |
    * |-----------------------------------------------------------|
-   * |Ctrl|Gui |Alt |         Space         |Alt |Gui |Fn  |Ctrl |
+   * |Ctrl|Gui |Alt |         Space         |Alt |Fn |Gui  |Ctrl |
    * `-----------------------------------------------------------'
    */
   [_COLEMAK] = LAYOUT_60_ansi(
-    KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,      KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,    KC_BSPC, \
-    HPR_TAB, KC_Q,    KC_W,    KC_F,    KC_P,    KC_G,    KC_J,      KC_L,    KC_U,    KC_Y,    KC_SCLN, KC_LBRC, KC_RBRC,   KC_BSLS, \
+    KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,      KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS,   KC_EQL,  KC_BSPC, \
+    HPR_TAB, KC_Q,    KC_W,    KC_F,    KC_P,    KC_G,    KC_J,      KC_L,    KC_U,    KC_Y,    KC_SCLN, KC_LBRC,   KC_RBRC, KC_BSLS, \
     CTL_ESC, KC_A,    KC_R,    KC_S,    KC_T,    KC_D,    KC_H,      KC_N,    KC_E,    KC_I,    KC_O,    KC_QUOT,            KC_ENT,  \
     KC_LSFT,          KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,      KC_K,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH,            SFT_ENT, \
-    KC_LCTL, KC_LGUI, KC_LALT,                   KC_SPC,                                        KC_RALT, KC_RGUI, MO(_FUNC), KC_RCTL
+    KC_LCTL, KC_LGUI, KC_LALT,                   KC_SPC,                                        KC_RALT, MO(_FUNC), KC_RGUI, KC_RCTL
   ),
 
   /* Keymap _DVORAK: (Base Layer) Default Layer
@@ -79,35 +79,35 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    * |-----------------------------------------------------------|
    * |Shift   |  ;|  Q|  J|  K|  X|  B|  M|  W|  V|  Z|ShiftEnter|
    * |-----------------------------------------------------------|
-   * |Ctrl|Gui |Alt |         Space         |Alt |Gui |Fn  |Ctrl |
+   * |Ctrl|Gui |Alt |         Space         |Alt |Fn |Gui  |Ctrl |
    * `-----------------------------------------------------------'
    */
   [_DVORAK] = LAYOUT_60_ansi(
-    KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,      KC_7,    KC_8,    KC_9,    KC_0,    KC_LBRC, KC_RBRC,   KC_BSPC, \
-    HPR_TAB, KC_QUOT, KC_COMM, KC_DOT,  KC_P,    KC_Y,    KC_F,      KC_G,    KC_C,    KC_R,    KC_L,    KC_SLSH, KC_EQL,    KC_BSLS, \
+    KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,      KC_7,    KC_8,    KC_9,    KC_0,    KC_LBRC,   KC_RBRC, KC_BSPC, \
+    HPR_TAB, KC_QUOT, KC_COMM, KC_DOT,  KC_P,    KC_Y,    KC_F,      KC_G,    KC_C,    KC_R,    KC_L,    KC_SLSH,   KC_EQL,  KC_BSLS, \
     CTL_ESC, KC_A,    KC_O,    KC_E,    KC_U,    KC_I,    KC_D,      KC_H,    KC_T,    KC_N,    KC_S,    KC_MINS,            KC_ENT,  \
     KC_LSFT,          KC_SCLN, KC_Q,    KC_J,    KC_K,    KC_X,      KC_B,    KC_M,    KC_W,    KC_V,    KC_Z,               SFT_ENT, \
-    KC_LCTL, KC_LGUI, KC_LALT,                   KC_SPC,                                        KC_RALT, KC_RGUI, MO(_FUNC), KC_RCTL
+    KC_LCTL, KC_LGUI, KC_LALT,                   KC_SPC,                                        KC_RALT, MO(_FUNC), KC_RGUI, KC_RCTL
   ),
 
   /* Keymap _FUNC: Function Layer
    * ,-----------------------------------------------------------.
-   * |   | F1| F2| F3| F4| F5| F6| F7| F8| F9|F10|F11|F12|Delete |
+   * |   | F1| F2| F3| F4| F5| F6| F7| F8| F9|F10|F11|F12|  BL   |
    * |-----------------------------------------------------------|
-   * |     |Hom| UP|End|   |   |   |Qwt|Cmk|Dvk|   |BL-|BL+|BL   |
+   * |     |Hom| UP|End|   |   |   |Qwt|Cmk|Dvk|   |UP |BL-| BL+ |
    * |-----------------------------------------------------------|
-   * |      |LFT| DN| RT|   |   |LFT| DN| UP| RT|Vo+|Pg+|        |
+   * |      |LFT| DN| RT|   |   |   |   |   |Pg+|LFT|RGT|        |
    * |-----------------------------------------------------------|
-   * |        |   |   |Prv|Ply|Nxt|   |   |   |Vo-|Pg-|          |
+   * |        |   |   |Prv|Ply|Nxt|   |   |   |Pg-|DN |          |
    * |-----------------------------------------------------------|
    * |RESET|    |    |                       |    |    |    |    |
    * `-----------------------------------------------------------'
    */
   [_FUNC] = LAYOUT_60_ansi(
-    _______, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_DEL,  \
-    _______, KC_HOME, KC_UP,   KC_END,  _______, _______, _______, QWERTY,  COLEMAK, DVORAK,  _______, BL_DEC,  BL_INC,  BL_TOGG, \
-    _______, KC_LEFT, KC_DOWN, KC_RGHT, _______, _______, KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT, KC_VOLU, KC_PGUP,          _______, \
-    _______,          _______, _______, KC_MPRV, KC_MPLY, KC_MNXT, _______, _______, _______, KC_VOLD, KC_PGDN,          _______, \
+    _______, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  BL_TOGG, \
+    _______, KC_HOME, KC_UP,   KC_END,  _______, _______, _______, QWERTY,  COLEMAK, DVORAK,  _______, KC_UP,   BL_DEC,  BL_INC,  \
+    _______, KC_LEFT, KC_DOWN, KC_RGHT, _______, _______, _______, _______, _______, KC_PGUP, KC_LEFT, KC_RGHT,          _______, \
+    _______,          _______, _______, KC_MPRV, KC_MPLY, KC_MNXT, _______, _______, _______, KC_PGDN, KC_DOWN,          _______, \
     RESET,   _______, _______,                   _______,                                     _______, _______, _______, _______
   )
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
User keymap change:
- Swap RGUI and FN keys for comfort
- Adjust layout to accommodate HHKB-style arrow cluster on the right-hand side

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
