### PR TITLE
Use os.chdir for `qmk docs` instead of a custom HTTP request handler

### DIFF
--- a/lib/python/qmk/cli/docs.py
+++ b/lib/python/qmk/cli/docs.py
@@ -1,13 +1,9 @@
 """Serve QMK documentation locally
 """
 import http.server
+import os
 
 from milc import cli
-
-
-class DocsHandler(http.server.SimpleHTTPRequestHandler):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, directory='docs', **kwargs)
 
 
 @cli.argument('-p', '--port', default=8936, type=int, help='Port number to use.')
@@ -15,7 +11,9 @@ class DocsHandler(http.server.SimpleHTTPRequestHandler):
 def docs(cli):
     """Spin up a local HTTPServer instance for the QMK docs.
     """
-    with http.server.HTTPServer(('', cli.config.docs.port), DocsHandler) as httpd:
+    os.chdir('docs')
+
+    with http.server.HTTPServer(('', cli.config.docs.port), http.server.SimpleHTTPRequestHandler) as httpd:
         cli.log.info("Serving QMK docs at http://localhost:%d/", cli.config.docs.port)
         cli.log.info("Press Control+C to exit.")
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I tried to be clever here, but `directory` isn't a thing below 3.7...

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
