### PR TITLE
[keymap] miryoku: Add RGB keycodes, enable RGB_MATRIX on crkbd

### DIFF
--- a/keyboards/crkbd/keymaps/manna-harbour_miryoku/config.h
+++ b/keyboards/crkbd/keymaps/manna-harbour_miryoku/config.h
@@ -1,0 +1,17 @@
+
+// generated from users/manna-harbour_miryoku/miryoku.org
+
+#pragma once
+
+#define EE_HANDS
+
+#ifdef RGB_MATRIX_ENABLE
+#define RGB_MATRIX_KEYPRESSES  // reacts to keypresses
+#define RGB_DISABLE_WHEN_USB_SUSPENDED true  // turn off effects when suspended
+#define RGB_MATRIX_FRAMEBUFFER_EFFECTS
+#define RGB_MATRIX_MAXIMUM_BRIGHTNESS 150 // limits maximum brightness of LEDs to 150 out of 255. Higher may cause the controller to crash.
+#define RGB_MATRIX_HUE_STEP 8
+#define RGB_MATRIX_SAT_STEP 8
+#define RGB_MATRIX_VAL_STEP 8
+#define RGB_MATRIX_SPD_STEP 10
+#endif

--- a/keyboards/crkbd/keymaps/manna-harbour_miryoku/rules.mk
+++ b/keyboards/crkbd/keymaps/manna-harbour_miryoku/rules.mk
@@ -1,0 +1,4 @@
+
+# generated from users/manna-harbour_miryoku/miryoku.org
+
+RGB_MATRIX_ENABLE = WS2812

--- a/users/manna-harbour_miryoku/manna-harbour_miryoku.c
+++ b/users/manna-harbour_miryoku/manna-harbour_miryoku.c
@@ -6,7 +6,14 @@
 #define KC_NP KC_NO // key is not present
 #define KC_NA KC_NO // present but not available for use
 #define KC_NU KC_NO // available but not used
+
+// non-KC_ keycodes
 #define KC_RST RESET
+#define KC_TOG RGB_TOG
+#define KC_MOD RGB_MOD
+#define KC_HUI RGB_HUI
+#define KC_SAI RGB_SAI
+#define KC_VAI RGB_VAI
 
 enum layers { BASE, MEDR, NAVR, MOUR, NSSL, NSL, FUNL };
 
@@ -30,7 +37,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     KC_NP,   KC_NP,   KC_NA,   KC_NA,   KC_NA,   KC_BTN3, KC_BTN1, KC_BTN2, KC_NP,   KC_NP
   ),
   [MEDR] = LAYOUT_miryoku(
-    KC_RST,  KC_NA,   KC_NA,   KC_NA,   KC_NA,   KC_NU,   KC_NU,   KC_NU,   KC_NU,   KC_NU,
+    KC_RST,  KC_NA,   KC_NA,   KC_NA,   KC_NA,   KC_TOG,  KC_MOD,  KC_HUI,  KC_SAI,  KC_VAI,
     KC_LGUI, KC_LALT, KC_LCTL, KC_LSFT, KC_NA,   KC_NU,   KC_MPRV, KC_VOLD, KC_VOLU, KC_MNXT,
     KC_NA,   KC_ALGR, KC_NA,   KC_NA,   KC_NA,   KC_NU,   KC_NU,   KC_NU,   KC_NU,   KC_NU,
     KC_NP,   KC_NP,   KC_NA,   KC_NA,   KC_NA,   KC_MSTP, KC_MPLY, KC_MUTE, KC_NP,   KC_NP

--- a/users/manna-harbour_miryoku/miryoku.org
+++ b/users/manna-harbour_miryoku/miryoku.org
@@ -134,11 +134,12 @@ the home position.  Unused keys are available for other related functions.
 *** Media (MEDR)
 
 Tertiary RH layer is media control, with volume up / down and next / prev
-mirroring the navigation keys.  Pause, stop and mute are on thumbs.  Unused keys
-are available for other related functions.
+mirroring the navigation keys.  Pause, stop and mute are on thumbs.  RGB control
+is on the top row (combine with shift to invert). Unused keys are available for
+other related functions.
 
 #+NAME: medr
-|      |      |      |      |      |
+| TOG  | MOD  | HUI  | SAI  | VAI  |
 |      | MPRV | VOLD | VOLU | MNXT |
 |      |      |      |      |      |
 | MSTP | MPLY | MUTE | NP   | NP   |
@@ -413,7 +414,14 @@ Contains the keymap.  Included from keymap.c
 #define KC_NP KC_NO // key is not present
 #define KC_NA KC_NO // present but not available for use
 #define KC_NU KC_NO // available but not used
+
+// non-KC_ keycodes
 #define KC_RST RESET
+#define KC_TOG RGB_TOG
+#define KC_MOD RGB_MOD
+#define KC_HUI RGB_HUI
+#define KC_SAI RGB_SAI
+#define KC_VAI RGB_VAI
 
 <<table-enums()>>
 
@@ -463,6 +471,7 @@ Build options.  Automatically included.
 
 MOUSEKEY_ENABLE = yes        # Mouse keys(+4700)
 EXTRAKEY_ENABLE = yes        # Audio control and System control(+450)
+
 
 #+END_SRC
 
@@ -561,10 +570,11 @@ To use the keymap on a keyboard which does not support the layouts feature,
 LAYOUT_miryoku is defined as a macro mapping onto the keyboard's own LAYOUT
 macro, leaving the unused keys as KC_NO.  The userspace keymap is then included.
 
-
 *** crkbd
 
 The outer columns are unused.
+
+**** keymap.c
 
 [[../../keyboards/crkbd/keymaps/manna-harbour_miryoku/keymap.c][keyboards/crkbd/keymaps/manna-harbour_miryoku/keymap.c]]
 #+BEGIN_SRC C :noweb yes :tangle ../../keyboards/crkbd/keymaps/manna-harbour_miryoku/keymap.c
@@ -588,10 +598,48 @@ KC_NO, K20,   K21,   K22,   K23,   K24,   K25,   K26,   K27,   K28,   K29,   KC_
 
 #+END_SRC
 
+
+**** config.h
+
+[[../../keyboards/crkbd/keymaps/manna-harbour_miryoku/config.h][keyboards/crkbd/keymaps/manna-harbour_miryoku/config.h]]
+#+BEGIN_SRC C :noweb yes :tangle ../../keyboards/crkbd/keymaps/manna-harbour_miryoku/config.h
+
+// <<header>>
+
+#pragma once
+
+#define EE_HANDS
+
+#ifdef RGB_MATRIX_ENABLE
+#define RGB_MATRIX_KEYPRESSES  // reacts to keypresses
+#define RGB_DISABLE_WHEN_USB_SUSPENDED true  // turn off effects when suspended
+#define RGB_MATRIX_FRAMEBUFFER_EFFECTS
+#define RGB_MATRIX_MAXIMUM_BRIGHTNESS 150 // limits maximum brightness of LEDs to 150 out of 255. Higher may cause the controller to crash.
+#define RGB_MATRIX_HUE_STEP 8
+#define RGB_MATRIX_SAT_STEP 8
+#define RGB_MATRIX_VAL_STEP 8
+#define RGB_MATRIX_SPD_STEP 10
+#endif
+
+#+END_SRC
+
+
+**** rules.mk
+
+[[../../keyboards/crkbd/keymaps/manna-harbour_miryoku/rules.mk][keyboards/crkbd/keymaps/manna-harbour_miryoku/rules.mk]]
+#+BEGIN_SRC C :noweb yes :tangle ../../keyboards/crkbd/keymaps/manna-harbour_miryoku/rules.mk
+
+# <<header>>
+
+RGB_MATRIX_ENABLE = WS2812
+
+#+END_SRC
+
+
 To build for this keyboard,
 
 #+BEGIN_SRC sh :tangle no
-cd ../.. && make crkbd:manna-harbour_miryoku:avrdude
+cd ../.. && make crkbd:manna-harbour_miryoku:flash
 #+END_SRC
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
