### PR TITLE
Compile out some keycode processing when features are disabled

### DIFF
--- a/quantum/keymap_common.c
+++ b/quantum/keymap_common.c
@@ -52,9 +52,6 @@ action_t action_for_key(uint8_t layer, keypos_t key) {
     uint8_t  action_layer, when, mod;
 
     switch (keycode) {
-        case KC_FN0 ... KC_FN31:
-            action.code = keymap_function_id_to_action(FN_INDEX(keycode));
-            break;
         case KC_A ... KC_EXSEL:
         case KC_LCTRL ... KC_RGUI:
             action.code = ACTION_KEY(keycode);
@@ -65,9 +62,11 @@ action_t action_for_key(uint8_t layer, keypos_t key) {
         case KC_AUDIO_MUTE ... KC_BRIGHTNESS_DOWN:
             action.code = ACTION_USAGE_CONSUMER(KEYCODE2CONSUMER(keycode));
             break;
+#ifdef MOUSEKEY_ENABLE
         case KC_MS_UP ... KC_MS_ACCEL2:
             action.code = ACTION_MOUSEKEY(keycode);
             break;
+#endif
         case KC_TRNS:
             action.code = ACTION_TRANSPARENT;
             break;
@@ -76,17 +75,24 @@ action_t action_for_key(uint8_t layer, keypos_t key) {
             // Split it up
             action.code = ACTION_MODS_KEY(keycode >> 8, keycode & 0xFF);  // adds modifier to key
             break;
+#ifndef NO_ACTION_FUNCTION
+        case KC_FN0 ... KC_FN31:
+            action.code = keymap_function_id_to_action(FN_INDEX(keycode));
+            break;
         case QK_FUNCTION ... QK_FUNCTION_MAX:;
             // Is a shortcut for function action_layer, pull last 12bits
             // This means we have 4,096 FN macros at our disposal
             action.code = keymap_function_id_to_action((int)keycode & 0xFFF);
             break;
+#endif
+#ifndef NO_ACTION_MACRO
         case QK_MACRO ... QK_MACRO_MAX:
             if (keycode & 0x800)  // tap macros have upper bit set
                 action.code = ACTION_MACRO_TAP(keycode & 0xFF);
             else
                 action.code = ACTION_MACRO(keycode & 0xFF);
             break;
+#endif
         case QK_LAYER_TAP ... QK_LAYER_TAP_MAX:
             action.code = ACTION_LAYER_TAP_KEY((keycode >> 0x8) & 0xF, keycode & 0xFF);
             break;

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -164,11 +164,6 @@ void reset_keyboard(void) {
     bootloader_jump();
 }
 
-/* true if the last press of GRAVE_ESC was shifted (i.e. GUI or SHIFT were pressed), false otherwise.
- * Used to ensure that the correct keycode is released if the key is released.
- */
-static bool grave_esc_was_shifted = false;
-
 /* Convert record into usable keycode via the contained event. */
 uint16_t get_record_keycode(keyrecord_t *record) { return get_event_keycode(record->event); }
 
@@ -281,6 +276,7 @@ bool process_record_quantum(keyrecord_t *record) {
             case RESET:
                 reset_keyboard();
                 return false;
+#ifndef NO_DEBUG
             case DEBUG:
                 debug_enable ^= 1;
                 if (debug_enable) {
@@ -288,6 +284,7 @@ bool process_record_quantum(keyrecord_t *record) {
                 } else {
                     print("DEBUG: disabled.\n");
                 }
+#endif
                 return false;
             case EEPROM_RESET:
                 eeconfig_init();
@@ -308,18 +305,16 @@ bool process_record_quantum(keyrecord_t *record) {
                 velocikey_toggle();
                 return false;
 #endif
-#ifdef PROTOCOL_LUFA
+#ifdef BLUETOOTH_ENABLE
         case OUT_AUTO:
                 set_output(OUTPUT_AUTO);
                 return false;
         case OUT_USB:
                 set_output(OUTPUT_USB);
                 return false;
-#    ifdef BLUETOOTH_ENABLE
         case OUT_BT:
                 set_output(OUTPUT_BLUETOOTH);
                 return false;
-#    endif
 #endif
         }
     }
@@ -590,6 +585,11 @@ bool process_record_quantum(keyrecord_t *record) {
             break;
 
         case GRAVE_ESC: {
+            /* true if the last press of GRAVE_ESC was shifted (i.e. GUI or SHIFT were pressed), false otherwise.
+            * Used to ensure that the correct keycode is released if the key is released.
+            */
+            static bool grave_esc_was_shifted = false;
+
             uint8_t shifted = get_mods() & ((MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT) | MOD_BIT(KC_LGUI) | MOD_BIT(KC_RGUI)));
 
 #ifdef GRAVE_ESC_ALT_OVERRIDE


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

This PR attempts to save some bytes (and potentially bringing #7484 back under size). Mimicking travis by running `./util/docker_build.sh helix/pico/back:default`:

before
`* The firmware size is approaching the maximum - 28320/28672 (98%, 352 bytes free)`

after
 `* The firmware size is approaching the maximum - 28120/28672 (98%, 552 bytes free)`

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
