### PR TITLE
Relocate magic keycode processing

### DIFF
--- a/common_features.mk
+++ b/common_features.mk
@@ -410,7 +410,7 @@ endif
 MAGIC_ENABLE ?= yes
 ifeq ($(strip $(MAGIC_ENABLE)), yes)
     SRC += $(QUANTUM_DIR)/process_keycode/process_magic.c
-  OPT_DEFS += -DMAGIC_ENABLE
+    OPT_DEFS += -DMAGIC_KEYCODE_ENABLE
 endif
 
 ifeq ($(strip $(DYNAMIC_MACRO_ENABLE)), yes)

--- a/common_features.mk
+++ b/common_features.mk
@@ -407,12 +407,18 @@ ifeq ($(strip $(SPACE_CADET_ENABLE)), yes)
   OPT_DEFS += -DSPACE_CADET_ENABLE
 endif
 
-ifeq ($(strip $(DIP_SWITCH_ENABLE)), yes)
-  SRC += $(QUANTUM_DIR)/dip_switch.c
-  OPT_DEFS += -DDIP_SWITCH_ENABLE
+MAGIC_ENABLE ?= yes
+ifeq ($(strip $(MAGIC_ENABLE)), yes)
+    SRC += $(QUANTUM_DIR)/process_keycode/process_magic.c
+  OPT_DEFS += -DMAGIC_ENABLE
 endif
 
 ifeq ($(strip $(DYNAMIC_MACRO_ENABLE)), yes)
     SRC += $(QUANTUM_DIR)/process_keycode/process_dynamic_macro.c
     OPT_DEFS += -DDYNAMIC_MACRO_ENABLE
+endif
+
+ifeq ($(strip $(DIP_SWITCH_ENABLE)), yes)
+  SRC += $(QUANTUM_DIR)/dip_switch.c
+  OPT_DEFS += -DDIP_SWITCH_ENABLE
 endif

--- a/quantum/process_keycode/process_magic.c
+++ b/quantum/process_keycode/process_magic.c
@@ -1,0 +1,161 @@
+/* Copyright 2019 Jack Humbert
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "process_magic.h"
+
+bool process_magic(uint16_t keycode, keyrecord_t *record) {
+    // keycodes that depend on both pressed and non-pressed state
+    switch (keycode) {
+        case MAGIC_SWAP_CONTROL_CAPSLOCK ... MAGIC_TOGGLE_ALT_GUI:
+        case MAGIC_SWAP_LCTL_LGUI ... MAGIC_EE_HANDS_RIGHT:
+            if (record->event.pressed) {
+                // MAGIC actions (BOOTMAGIC without the boot)
+                if (!eeconfig_is_enabled()) {
+                    eeconfig_init();
+                }
+                /* keymap config */
+                keymap_config.raw = eeconfig_read_keymap();
+                switch (keycode) {
+                    case MAGIC_SWAP_CONTROL_CAPSLOCK:
+                        keymap_config.swap_control_capslock = true;
+                        break;
+                    case MAGIC_CAPSLOCK_TO_CONTROL:
+                        keymap_config.capslock_to_control = true;
+                        break;
+                    case MAGIC_SWAP_LALT_LGUI:
+                        keymap_config.swap_lalt_lgui = true;
+                        break;
+                    case MAGIC_SWAP_RALT_RGUI:
+                        keymap_config.swap_ralt_rgui = true;
+                        break;
+                    case MAGIC_SWAP_LCTL_LGUI:
+                        keymap_config.swap_lctl_lgui = true;
+                        break;
+                    case MAGIC_SWAP_RCTL_RGUI:
+                        keymap_config.swap_rctl_rgui = true;
+                        break;
+                    case MAGIC_NO_GUI:
+                        keymap_config.no_gui = true;
+                        break;
+                    case MAGIC_SWAP_GRAVE_ESC:
+                        keymap_config.swap_grave_esc = true;
+                        break;
+                    case MAGIC_SWAP_BACKSLASH_BACKSPACE:
+                        keymap_config.swap_backslash_backspace = true;
+                        break;
+                    case MAGIC_HOST_NKRO:
+                        clear_keyboard();  // clear first buffer to prevent stuck keys
+                        keymap_config.nkro = true;
+                        break;
+                    case MAGIC_SWAP_ALT_GUI:
+                        keymap_config.swap_lalt_lgui = keymap_config.swap_ralt_rgui = true;
+#ifdef AUDIO_ENABLE
+                        PLAY_SONG(ag_swap_song);
+#endif
+                        break;
+                    case MAGIC_SWAP_CTL_GUI:
+                        keymap_config.swap_lctl_lgui = keymap_config.swap_rctl_rgui = true;
+#ifdef AUDIO_ENABLE
+                        PLAY_SONG(cg_swap_song);
+#endif
+                        break;
+                    case MAGIC_UNSWAP_CONTROL_CAPSLOCK:
+                        keymap_config.swap_control_capslock = false;
+                        break;
+                    case MAGIC_UNCAPSLOCK_TO_CONTROL:
+                        keymap_config.capslock_to_control = false;
+                        break;
+                    case MAGIC_UNSWAP_LALT_LGUI:
+                        keymap_config.swap_lalt_lgui = false;
+                        break;
+                    case MAGIC_UNSWAP_RALT_RGUI:
+                        keymap_config.swap_ralt_rgui = false;
+                        break;
+                    case MAGIC_UNSWAP_LCTL_LGUI:
+                        keymap_config.swap_lctl_lgui = false;
+                        break;
+                    case MAGIC_UNSWAP_RCTL_RGUI:
+                        keymap_config.swap_rctl_rgui = false;
+                        break;
+                    case MAGIC_UNNO_GUI:
+                        keymap_config.no_gui = false;
+                        break;
+                    case MAGIC_UNSWAP_GRAVE_ESC:
+                        keymap_config.swap_grave_esc = false;
+                        break;
+                    case MAGIC_UNSWAP_BACKSLASH_BACKSPACE:
+                        keymap_config.swap_backslash_backspace = false;
+                        break;
+                    case MAGIC_UNHOST_NKRO:
+                        clear_keyboard();  // clear first buffer to prevent stuck keys
+                        keymap_config.nkro = false;
+                        break;
+                    case MAGIC_UNSWAP_ALT_GUI:
+                        keymap_config.swap_lalt_lgui = keymap_config.swap_ralt_rgui = false;
+#ifdef AUDIO_ENABLE
+                        PLAY_SONG(ag_norm_song);
+#endif
+                        break;
+                    case MAGIC_UNSWAP_CTL_GUI:
+                        keymap_config.swap_lctl_lgui = keymap_config.swap_rctl_rgui = false;
+#ifdef AUDIO_ENABLE
+                        PLAY_SONG(cg_norm_song);
+#endif
+                        break;
+                    case MAGIC_TOGGLE_ALT_GUI:
+                        keymap_config.swap_lalt_lgui = !keymap_config.swap_lalt_lgui;
+                        keymap_config.swap_ralt_rgui = keymap_config.swap_lalt_lgui;
+#ifdef AUDIO_ENABLE
+                        if (keymap_config.swap_ralt_rgui) {
+                            PLAY_SONG(ag_swap_song);
+                        } else {
+                            PLAY_SONG(ag_norm_song);
+                        }
+#endif
+                        break;
+                    case MAGIC_TOGGLE_CTL_GUI:
+                        keymap_config.swap_lctl_lgui = !keymap_config.swap_lctl_lgui;
+                        keymap_config.swap_rctl_rgui = keymap_config.swap_lctl_lgui;
+#ifdef AUDIO_ENABLE
+                        if (keymap_config.swap_rctl_rgui) {
+                            PLAY_SONG(cg_swap_song);
+                        } else {
+                            PLAY_SONG(cg_norm_song);
+                        }
+#endif
+                        break;
+                    case MAGIC_TOGGLE_NKRO:
+                        clear_keyboard();  // clear first buffer to prevent stuck keys
+                        keymap_config.nkro = !keymap_config.nkro;
+                        break;
+                    case MAGIC_EE_HANDS_LEFT:
+                        eeconfig_update_handedness(true);
+                        break;
+                    case MAGIC_EE_HANDS_RIGHT:
+                        eeconfig_update_handedness(false);
+                        break;
+                    default:
+                        break;
+                }
+                eeconfig_update_keymap(keymap_config.raw);
+                clear_keyboard();  // clear to prevent stuck keys
+
+                return false;
+            }
+            break;
+    }
+
+    return true;
+}

--- a/quantum/process_keycode/process_magic.c
+++ b/quantum/process_keycode/process_magic.c
@@ -15,8 +15,11 @@
  */
 #include "process_magic.h"
 
-// MAGIC actions (BOOTMAGIC without the boot)
+/**
+ * MAGIC actions (BOOTMAGIC without the boot)
+ */
 bool process_magic(uint16_t keycode, keyrecord_t *record) {
+    // skip anything that isn't a keyup
     if (!record->event.pressed) {
         return true;
     }
@@ -143,11 +146,12 @@ bool process_magic(uint16_t keycode, keyrecord_t *record) {
             eeconfig_update_handedness(false);
             break;
         default:
+            // Not a magic keycode so continue processing
             return true;
     }
 
     eeconfig_update_keymap(keymap_config.raw);
-    clear_keyboard();  // clear to prevent stuck keys
+    clear_keyboard(); // clear to prevent stuck keys
 
     return false;
 }

--- a/quantum/process_keycode/process_magic.c
+++ b/quantum/process_keycode/process_magic.c
@@ -15,6 +15,25 @@
  */
 #include "process_magic.h"
 
+#ifdef AUDIO_ENABLE
+#    ifndef AG_NORM_SONG
+#        define AG_NORM_SONG SONG(AG_NORM_SOUND)
+#    endif
+#    ifndef AG_SWAP_SONG
+#        define AG_SWAP_SONG SONG(AG_SWAP_SOUND)
+#    endif
+#    ifndef CG_NORM_SONG
+#        define CG_NORM_SONG SONG(AG_NORM_SOUND)
+#    endif
+#    ifndef CG_SWAP_SONG
+#        define CG_SWAP_SONG SONG(AG_SWAP_SOUND)
+#    endif
+float ag_norm_song[][2] = AG_NORM_SONG;
+float ag_swap_song[][2] = AG_SWAP_SONG;
+float cg_norm_song[][2] = CG_NORM_SONG;
+float cg_swap_song[][2] = CG_SWAP_SONG;
+#endif
+
 /**
  * MAGIC actions (BOOTMAGIC without the boot)
  */

--- a/quantum/process_keycode/process_magic.c
+++ b/quantum/process_keycode/process_magic.c
@@ -15,147 +15,139 @@
  */
 #include "process_magic.h"
 
+// MAGIC actions (BOOTMAGIC without the boot)
 bool process_magic(uint16_t keycode, keyrecord_t *record) {
-    // keycodes that depend on both pressed and non-pressed state
-    switch (keycode) {
-        case MAGIC_SWAP_CONTROL_CAPSLOCK ... MAGIC_TOGGLE_ALT_GUI:
-        case MAGIC_SWAP_LCTL_LGUI ... MAGIC_EE_HANDS_RIGHT:
-            if (record->event.pressed) {
-                // MAGIC actions (BOOTMAGIC without the boot)
-                if (!eeconfig_is_enabled()) {
-                    eeconfig_init();
-                }
-                /* keymap config */
-                keymap_config.raw = eeconfig_read_keymap();
-                switch (keycode) {
-                    case MAGIC_SWAP_CONTROL_CAPSLOCK:
-                        keymap_config.swap_control_capslock = true;
-                        break;
-                    case MAGIC_CAPSLOCK_TO_CONTROL:
-                        keymap_config.capslock_to_control = true;
-                        break;
-                    case MAGIC_SWAP_LALT_LGUI:
-                        keymap_config.swap_lalt_lgui = true;
-                        break;
-                    case MAGIC_SWAP_RALT_RGUI:
-                        keymap_config.swap_ralt_rgui = true;
-                        break;
-                    case MAGIC_SWAP_LCTL_LGUI:
-                        keymap_config.swap_lctl_lgui = true;
-                        break;
-                    case MAGIC_SWAP_RCTL_RGUI:
-                        keymap_config.swap_rctl_rgui = true;
-                        break;
-                    case MAGIC_NO_GUI:
-                        keymap_config.no_gui = true;
-                        break;
-                    case MAGIC_SWAP_GRAVE_ESC:
-                        keymap_config.swap_grave_esc = true;
-                        break;
-                    case MAGIC_SWAP_BACKSLASH_BACKSPACE:
-                        keymap_config.swap_backslash_backspace = true;
-                        break;
-                    case MAGIC_HOST_NKRO:
-                        clear_keyboard();  // clear first buffer to prevent stuck keys
-                        keymap_config.nkro = true;
-                        break;
-                    case MAGIC_SWAP_ALT_GUI:
-                        keymap_config.swap_lalt_lgui = keymap_config.swap_ralt_rgui = true;
-#ifdef AUDIO_ENABLE
-                        PLAY_SONG(ag_swap_song);
-#endif
-                        break;
-                    case MAGIC_SWAP_CTL_GUI:
-                        keymap_config.swap_lctl_lgui = keymap_config.swap_rctl_rgui = true;
-#ifdef AUDIO_ENABLE
-                        PLAY_SONG(cg_swap_song);
-#endif
-                        break;
-                    case MAGIC_UNSWAP_CONTROL_CAPSLOCK:
-                        keymap_config.swap_control_capslock = false;
-                        break;
-                    case MAGIC_UNCAPSLOCK_TO_CONTROL:
-                        keymap_config.capslock_to_control = false;
-                        break;
-                    case MAGIC_UNSWAP_LALT_LGUI:
-                        keymap_config.swap_lalt_lgui = false;
-                        break;
-                    case MAGIC_UNSWAP_RALT_RGUI:
-                        keymap_config.swap_ralt_rgui = false;
-                        break;
-                    case MAGIC_UNSWAP_LCTL_LGUI:
-                        keymap_config.swap_lctl_lgui = false;
-                        break;
-                    case MAGIC_UNSWAP_RCTL_RGUI:
-                        keymap_config.swap_rctl_rgui = false;
-                        break;
-                    case MAGIC_UNNO_GUI:
-                        keymap_config.no_gui = false;
-                        break;
-                    case MAGIC_UNSWAP_GRAVE_ESC:
-                        keymap_config.swap_grave_esc = false;
-                        break;
-                    case MAGIC_UNSWAP_BACKSLASH_BACKSPACE:
-                        keymap_config.swap_backslash_backspace = false;
-                        break;
-                    case MAGIC_UNHOST_NKRO:
-                        clear_keyboard();  // clear first buffer to prevent stuck keys
-                        keymap_config.nkro = false;
-                        break;
-                    case MAGIC_UNSWAP_ALT_GUI:
-                        keymap_config.swap_lalt_lgui = keymap_config.swap_ralt_rgui = false;
-#ifdef AUDIO_ENABLE
-                        PLAY_SONG(ag_norm_song);
-#endif
-                        break;
-                    case MAGIC_UNSWAP_CTL_GUI:
-                        keymap_config.swap_lctl_lgui = keymap_config.swap_rctl_rgui = false;
-#ifdef AUDIO_ENABLE
-                        PLAY_SONG(cg_norm_song);
-#endif
-                        break;
-                    case MAGIC_TOGGLE_ALT_GUI:
-                        keymap_config.swap_lalt_lgui = !keymap_config.swap_lalt_lgui;
-                        keymap_config.swap_ralt_rgui = keymap_config.swap_lalt_lgui;
-#ifdef AUDIO_ENABLE
-                        if (keymap_config.swap_ralt_rgui) {
-                            PLAY_SONG(ag_swap_song);
-                        } else {
-                            PLAY_SONG(ag_norm_song);
-                        }
-#endif
-                        break;
-                    case MAGIC_TOGGLE_CTL_GUI:
-                        keymap_config.swap_lctl_lgui = !keymap_config.swap_lctl_lgui;
-                        keymap_config.swap_rctl_rgui = keymap_config.swap_lctl_lgui;
-#ifdef AUDIO_ENABLE
-                        if (keymap_config.swap_rctl_rgui) {
-                            PLAY_SONG(cg_swap_song);
-                        } else {
-                            PLAY_SONG(cg_norm_song);
-                        }
-#endif
-                        break;
-                    case MAGIC_TOGGLE_NKRO:
-                        clear_keyboard();  // clear first buffer to prevent stuck keys
-                        keymap_config.nkro = !keymap_config.nkro;
-                        break;
-                    case MAGIC_EE_HANDS_LEFT:
-                        eeconfig_update_handedness(true);
-                        break;
-                    case MAGIC_EE_HANDS_RIGHT:
-                        eeconfig_update_handedness(false);
-                        break;
-                    default:
-                        break;
-                }
-                eeconfig_update_keymap(keymap_config.raw);
-                clear_keyboard();  // clear to prevent stuck keys
-
-                return false;
-            }
-            break;
+    if (!record->event.pressed) {
+        return true;
     }
 
-    return true;
+    /* keymap config */
+    keymap_config.raw = eeconfig_read_keymap();
+    switch (keycode) {
+        case MAGIC_SWAP_CONTROL_CAPSLOCK:
+            keymap_config.swap_control_capslock = true;
+            break;
+        case MAGIC_CAPSLOCK_TO_CONTROL:
+            keymap_config.capslock_to_control = true;
+            break;
+        case MAGIC_SWAP_LALT_LGUI:
+            keymap_config.swap_lalt_lgui = true;
+            break;
+        case MAGIC_SWAP_RALT_RGUI:
+            keymap_config.swap_ralt_rgui = true;
+            break;
+        case MAGIC_SWAP_LCTL_LGUI:
+            keymap_config.swap_lctl_lgui = true;
+            break;
+        case MAGIC_SWAP_RCTL_RGUI:
+            keymap_config.swap_rctl_rgui = true;
+            break;
+        case MAGIC_NO_GUI:
+            keymap_config.no_gui = true;
+            break;
+        case MAGIC_SWAP_GRAVE_ESC:
+            keymap_config.swap_grave_esc = true;
+            break;
+        case MAGIC_SWAP_BACKSLASH_BACKSPACE:
+            keymap_config.swap_backslash_backspace = true;
+            break;
+        case MAGIC_HOST_NKRO:
+            clear_keyboard();  // clear first buffer to prevent stuck keys
+            keymap_config.nkro = true;
+            break;
+        case MAGIC_SWAP_ALT_GUI:
+            keymap_config.swap_lalt_lgui = keymap_config.swap_ralt_rgui = true;
+#ifdef AUDIO_ENABLE
+            PLAY_SONG(ag_swap_song);
+#endif
+            break;
+        case MAGIC_SWAP_CTL_GUI:
+            keymap_config.swap_lctl_lgui = keymap_config.swap_rctl_rgui = true;
+#ifdef AUDIO_ENABLE
+            PLAY_SONG(cg_swap_song);
+#endif
+            break;
+        case MAGIC_UNSWAP_CONTROL_CAPSLOCK:
+            keymap_config.swap_control_capslock = false;
+            break;
+        case MAGIC_UNCAPSLOCK_TO_CONTROL:
+            keymap_config.capslock_to_control = false;
+            break;
+        case MAGIC_UNSWAP_LALT_LGUI:
+            keymap_config.swap_lalt_lgui = false;
+            break;
+        case MAGIC_UNSWAP_RALT_RGUI:
+            keymap_config.swap_ralt_rgui = false;
+            break;
+        case MAGIC_UNSWAP_LCTL_LGUI:
+            keymap_config.swap_lctl_lgui = false;
+            break;
+        case MAGIC_UNSWAP_RCTL_RGUI:
+            keymap_config.swap_rctl_rgui = false;
+            break;
+        case MAGIC_UNNO_GUI:
+            keymap_config.no_gui = false;
+            break;
+        case MAGIC_UNSWAP_GRAVE_ESC:
+            keymap_config.swap_grave_esc = false;
+            break;
+        case MAGIC_UNSWAP_BACKSLASH_BACKSPACE:
+            keymap_config.swap_backslash_backspace = false;
+            break;
+        case MAGIC_UNHOST_NKRO:
+            clear_keyboard();  // clear first buffer to prevent stuck keys
+            keymap_config.nkro = false;
+            break;
+        case MAGIC_UNSWAP_ALT_GUI:
+            keymap_config.swap_lalt_lgui = keymap_config.swap_ralt_rgui = false;
+#ifdef AUDIO_ENABLE
+            PLAY_SONG(ag_norm_song);
+#endif
+            break;
+        case MAGIC_UNSWAP_CTL_GUI:
+            keymap_config.swap_lctl_lgui = keymap_config.swap_rctl_rgui = false;
+#ifdef AUDIO_ENABLE
+            PLAY_SONG(cg_norm_song);
+#endif
+            break;
+        case MAGIC_TOGGLE_ALT_GUI:
+            keymap_config.swap_lalt_lgui = !keymap_config.swap_lalt_lgui;
+            keymap_config.swap_ralt_rgui = keymap_config.swap_lalt_lgui;
+#ifdef AUDIO_ENABLE
+            if (keymap_config.swap_ralt_rgui) {
+                PLAY_SONG(ag_swap_song);
+            } else {
+                PLAY_SONG(ag_norm_song);
+            }
+#endif
+            break;
+        case MAGIC_TOGGLE_CTL_GUI:
+            keymap_config.swap_lctl_lgui = !keymap_config.swap_lctl_lgui;
+            keymap_config.swap_rctl_rgui = keymap_config.swap_lctl_lgui;
+#ifdef AUDIO_ENABLE
+            if (keymap_config.swap_rctl_rgui) {
+                PLAY_SONG(cg_swap_song);
+            } else {
+                PLAY_SONG(cg_norm_song);
+            }
+#endif
+            break;
+        case MAGIC_TOGGLE_NKRO:
+            clear_keyboard();  // clear first buffer to prevent stuck keys
+            keymap_config.nkro = !keymap_config.nkro;
+            break;
+        case MAGIC_EE_HANDS_LEFT:
+            eeconfig_update_handedness(true);
+            break;
+        case MAGIC_EE_HANDS_RIGHT:
+            eeconfig_update_handedness(false);
+            break;
+        default:
+            return true;
+    }
+
+    eeconfig_update_keymap(keymap_config.raw);
+    clear_keyboard();  // clear to prevent stuck keys
+
+    return false;
 }

--- a/quantum/process_keycode/process_magic.h
+++ b/quantum/process_keycode/process_magic.h
@@ -1,0 +1,20 @@
+/* Copyright 2019
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "quantum.h"
+
+bool process_magic(uint16_t keycode, keyrecord_t *record);

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -57,23 +57,7 @@ extern backlight_config_t backlight_config;
 #    ifndef GOODBYE_SONG
 #        define GOODBYE_SONG SONG(GOODBYE_SOUND)
 #    endif
-#    ifndef AG_NORM_SONG
-#        define AG_NORM_SONG SONG(AG_NORM_SOUND)
-#    endif
-#    ifndef AG_SWAP_SONG
-#        define AG_SWAP_SONG SONG(AG_SWAP_SOUND)
-#    endif
-#    ifndef CG_NORM_SONG
-#        define CG_NORM_SONG SONG(AG_NORM_SOUND)
-#    endif
-#    ifndef CG_SWAP_SONG
-#        define CG_SWAP_SONG SONG(AG_SWAP_SOUND)
-#    endif
 float goodbye_song[][2] = GOODBYE_SONG;
-float ag_norm_song[][2] = AG_NORM_SONG;
-float ag_swap_song[][2] = AG_SWAP_SONG;
-float cg_norm_song[][2] = CG_NORM_SONG;
-float cg_swap_song[][2] = CG_SWAP_SONG;
 #    ifdef DEFAULT_LAYER_SONGS
 float default_layer_songs[][16][2] = DEFAULT_LAYER_SONGS;
 #    endif

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -267,6 +267,9 @@ bool process_record_quantum(keyrecord_t *record) {
 #ifdef SPACE_CADET_ENABLE
             process_space_cadet(keycode, record) &&
 #endif
+#ifdef MAGIC_ENABLE
+            process_magic(keycode, record) &&
+#endif
             true)) {
         return false;
     }
@@ -478,144 +481,6 @@ bool process_record_quantum(keyrecord_t *record) {
 
     // keycodes that depend on both pressed and non-pressed state
     switch (keycode) {
-        case MAGIC_SWAP_CONTROL_CAPSLOCK ... MAGIC_TOGGLE_ALT_GUI:
-        case MAGIC_SWAP_LCTL_LGUI ... MAGIC_EE_HANDS_RIGHT:
-            if (record->event.pressed) {
-                // MAGIC actions (BOOTMAGIC without the boot)
-                if (!eeconfig_is_enabled()) {
-                    eeconfig_init();
-                }
-                /* keymap config */
-                keymap_config.raw = eeconfig_read_keymap();
-                switch (keycode) {
-                    case MAGIC_SWAP_CONTROL_CAPSLOCK:
-                        keymap_config.swap_control_capslock = true;
-                        break;
-                    case MAGIC_CAPSLOCK_TO_CONTROL:
-                        keymap_config.capslock_to_control = true;
-                        break;
-                    case MAGIC_SWAP_LALT_LGUI:
-                        keymap_config.swap_lalt_lgui = true;
-                        break;
-                    case MAGIC_SWAP_RALT_RGUI:
-                        keymap_config.swap_ralt_rgui = true;
-                        break;
-                    case MAGIC_SWAP_LCTL_LGUI:
-                        keymap_config.swap_lctl_lgui = true;
-                        break;
-                    case MAGIC_SWAP_RCTL_RGUI:
-                        keymap_config.swap_rctl_rgui = true;
-                        break;
-                    case MAGIC_NO_GUI:
-                        keymap_config.no_gui = true;
-                        break;
-                    case MAGIC_SWAP_GRAVE_ESC:
-                        keymap_config.swap_grave_esc = true;
-                        break;
-                    case MAGIC_SWAP_BACKSLASH_BACKSPACE:
-                        keymap_config.swap_backslash_backspace = true;
-                        break;
-                    case MAGIC_HOST_NKRO:
-                        clear_keyboard();  // clear first buffer to prevent stuck keys
-                        keymap_config.nkro = true;
-                        break;
-                    case MAGIC_SWAP_ALT_GUI:
-                        keymap_config.swap_lalt_lgui = keymap_config.swap_ralt_rgui = true;
-#ifdef AUDIO_ENABLE
-                        PLAY_SONG(ag_swap_song);
-#endif
-                        break;
-                    case MAGIC_SWAP_CTL_GUI:
-                        keymap_config.swap_lctl_lgui = keymap_config.swap_rctl_rgui = true;
-#ifdef AUDIO_ENABLE
-                        PLAY_SONG(cg_swap_song);
-#endif
-                        break;
-                    case MAGIC_UNSWAP_CONTROL_CAPSLOCK:
-                        keymap_config.swap_control_capslock = false;
-                        break;
-                    case MAGIC_UNCAPSLOCK_TO_CONTROL:
-                        keymap_config.capslock_to_control = false;
-                        break;
-                    case MAGIC_UNSWAP_LALT_LGUI:
-                        keymap_config.swap_lalt_lgui = false;
-                        break;
-                    case MAGIC_UNSWAP_RALT_RGUI:
-                        keymap_config.swap_ralt_rgui = false;
-                        break;
-                    case MAGIC_UNSWAP_LCTL_LGUI:
-                        keymap_config.swap_lctl_lgui = false;
-                        break;
-                    case MAGIC_UNSWAP_RCTL_RGUI:
-                        keymap_config.swap_rctl_rgui = false;
-                        break;
-                    case MAGIC_UNNO_GUI:
-                        keymap_config.no_gui = false;
-                        break;
-                    case MAGIC_UNSWAP_GRAVE_ESC:
-                        keymap_config.swap_grave_esc = false;
-                        break;
-                    case MAGIC_UNSWAP_BACKSLASH_BACKSPACE:
-                        keymap_config.swap_backslash_backspace = false;
-                        break;
-                    case MAGIC_UNHOST_NKRO:
-                        clear_keyboard();  // clear first buffer to prevent stuck keys
-                        keymap_config.nkro = false;
-                        break;
-                    case MAGIC_UNSWAP_ALT_GUI:
-                        keymap_config.swap_lalt_lgui = keymap_config.swap_ralt_rgui = false;
-#ifdef AUDIO_ENABLE
-                        PLAY_SONG(ag_norm_song);
-#endif
-                        break;
-                    case MAGIC_UNSWAP_CTL_GUI:
-                        keymap_config.swap_lctl_lgui = keymap_config.swap_rctl_rgui = false;
-#ifdef AUDIO_ENABLE
-                        PLAY_SONG(cg_norm_song);
-#endif
-                        break;
-                    case MAGIC_TOGGLE_ALT_GUI:
-                        keymap_config.swap_lalt_lgui = !keymap_config.swap_lalt_lgui;
-                        keymap_config.swap_ralt_rgui = keymap_config.swap_lalt_lgui;
-#ifdef AUDIO_ENABLE
-                        if (keymap_config.swap_ralt_rgui) {
-                            PLAY_SONG(ag_swap_song);
-                        } else {
-                            PLAY_SONG(ag_norm_song);
-                        }
-#endif
-                        break;
-                    case MAGIC_TOGGLE_CTL_GUI:
-                        keymap_config.swap_lctl_lgui = !keymap_config.swap_lctl_lgui;
-                        keymap_config.swap_rctl_rgui = keymap_config.swap_lctl_lgui;
-#ifdef AUDIO_ENABLE
-                        if (keymap_config.swap_rctl_rgui) {
-                            PLAY_SONG(cg_swap_song);
-                        } else {
-                            PLAY_SONG(cg_norm_song);
-                        }
-#endif
-                        break;
-                    case MAGIC_TOGGLE_NKRO:
-                        clear_keyboard();  // clear first buffer to prevent stuck keys
-                        keymap_config.nkro = !keymap_config.nkro;
-                        break;
-                    case MAGIC_EE_HANDS_LEFT:
-                        eeconfig_update_handedness(true);
-                        break;
-                    case MAGIC_EE_HANDS_RIGHT:
-                        eeconfig_update_handedness(false);
-                        break;
-                    default:
-                        break;
-                }
-                eeconfig_update_keymap(keymap_config.raw);
-                clear_keyboard();  // clear to prevent stuck keys
-
-                return false;
-            }
-            break;
-
         case GRAVE_ESC: {
             /* true if the last press of GRAVE_ESC was shifted (i.e. GUI or SHIFT were pressed), false otherwise.
             * Used to ensure that the correct keycode is released if the key is released.

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -267,7 +267,7 @@ bool process_record_quantum(keyrecord_t *record) {
 #ifdef SPACE_CADET_ENABLE
             process_space_cadet(keycode, record) &&
 #endif
-#ifdef MAGIC_ENABLE
+#ifdef MAGIC_KEYCODE_ENABLE
             process_magic(keycode, record) &&
 #endif
             true)) {

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -133,7 +133,7 @@ extern layer_state_t layer_state;
 #    include "process_space_cadet.h"
 #endif
 
-#ifdef MAGIC_ENABLE
+#ifdef MAGIC_KEYCODE_ENABLE
 #    include "process_magic.h"
 #endif
 

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -133,6 +133,10 @@ extern layer_state_t layer_state;
 #    include "process_space_cadet.h"
 #endif
 
+#ifdef MAGIC_ENABLE
+#    include "process_magic.h"
+#endif
+
 #ifdef HD44780_ENABLE
 #    include "hd44780.h"
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
This PR relocates a block of keycode handling to its own file for readability. I've ditched a few redundant checks to save a few bytes in firmware size, the net saving is about 10 bytes, so basically the same as before.

The main functional change, is the removal of:
```c
if (!eeconfig_is_enabled()) {
    eeconfig_init();
}
```
Which seems to be handled within `magic.c` and `bootmagic.c` on keyboard startup, so should be initialised by first magic keypress.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
