### PR TITLE
[Keyboard] Fix calls in handwired/jotanck

### DIFF
--- a/keyboards/handwired/jotanck/jotanck.c
+++ b/keyboards/handwired/jotanck/jotanck.c
@@ -1,10 +1,12 @@
 #include "jotanck.h"
 
 void matrix_init_kb(void) {
-  matrix_init_user();
+    matrix_init_user();
 }
 
-void keyboard_pre_init_user() {
-  setPinOutput(JOTANCK_LED1);
-  setPinOutput(JOTANCK_LED2);
+void keyboard_pre_init_kb() {
+    setPinOutput(JOTANCK_LED1);
+    setPinOutput(JOTANCK_LED2);
+    
+    keyboard_pre_init_user();
 }


### PR DESCRIPTION
The C file for this keyboard was calling `keyboard_pre_init_user`.  Which is wrong.

This fixes that behavior. 

Discovered when running `make all:drashna`

## Types of Changes

- [x] Enhancement/optimization
- [x] Keyboard (addition or update)

## Checklist
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
