### PR TITLE
[Keyboard] Update Lets Split Sockets to use LTO_ENABLE

### DIFF
--- a/keyboards/lets_split/sockets/config.h
+++ b/keyboards/lets_split/sockets/config.h
@@ -78,14 +78,3 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define NO_ACTION_LAYER
 //#define NO_ACTION_TAPPING
 //#define NO_ACTION_ONESHOT
-//#define NO_ACTION_MACRO
-//#define NO_ACTION_FUNCTION
-
-#ifdef USE_Link_Time_Optimization
-  // LTO has issues with macros (action_get_macro) and "functions" (fn_actions),
-  //  so just disable them
-  #define NO_ACTION_MACRO
-  #define NO_ACTION_FUNCTION
-
-  #define DISABLE_LEADER
-#endif // USE_Link_Time_Optimization

--- a/keyboards/lets_split/sockets/rules.mk
+++ b/keyboards/lets_split/sockets/rules.mk
@@ -2,4 +2,4 @@ BACKLIGHT_ENABLE = no
 AUDIO_ENABLE = yes
 RGBLIGHT_ENABLE = yes #Don't enable this along with I2C
 
-EXTRAFLAGS += -flto -DUSE_Link_Time_Optimization
+LTO_ENABLE = yes


### PR DESCRIPTION
This removes the `NO_ACTION_*` and `EXTRAFLAGS+=-flto` in favor of just `LTO_ENABLE = yes`, which accomplishes both.

Discovered when running `make all:drashna`

## Types of Changes
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)

## Checklist
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
