### PR TITLE
Made AVR backlight pwm resolution configurable

### DIFF
--- a/quantum/backlight/backlight_avr.c
+++ b/quantum/backlight/backlight_avr.c
@@ -280,9 +280,9 @@ void backlight_set(uint8_t level) {
     set_pwm(cie_lightness(ICRx * (uint32_t)level / BACKLIGHT_LEVELS));
 }
 
-#ifdef BACKLIGHT_BREATHING
+#            ifdef BACKLIGHT_BREATHING
 static uint16_t pwm_frequency = 244;
-#endif
+#            endif
 
 void backlight_task(void) {}
 
@@ -327,8 +327,8 @@ bool is_breathing(void) { return !!(TIMSKx & _BV(TOIEx)); }
                 do {                       \
                     breathing_counter = 0; \
                 } while (0)
-#            define breathing_max()                                 \
-                do {                                                \
+#            define breathing_max()                                           \
+                do {                                                          \
                     breathing_counter = breathing_period * pwm_frequency / 2; \
                 } while (0)
 
@@ -427,9 +427,9 @@ void backlight_init_ports(void) {
 #            elif (BACKLIGHT_CUSTOM_RESOLUTION < 0xFF)
 #                warning "Resolution lower than 0xFF isn't recommended"
 #            endif
-#        ifdef BACKLIGHT_BREATHING
-            pwm_frequency = F_CPU / BACKLIGHT_CUSTOM_RESOLUTION;
-            #endif
+#            ifdef BACKLIGHT_BREATHING
+    pwm_frequency = F_CPU / BACKLIGHT_CUSTOM_RESOLUTION;
+#            endif
     ICRx = BACKLIGHT_CUSTOM_RESOLUTION;
 #        else
     ICRx   = TIMER_TOP;

--- a/quantum/backlight/backlight_avr.c
+++ b/quantum/backlight/backlight_avr.c
@@ -220,8 +220,8 @@ ISR(TIMERx_OVF_vect) {
     // artifacts (especially while breathing, because breathing_task
     // takes many computation cycles).
     // so better not turn them on while the counter TOP is very low.
-    if (OCRxx > 256) {
-        backlight_pins_on();
+    if (OCRxx > ICRx / 250 + 5) {
+        FOR_EACH_LED(backlight_on(backlight_pin);)
     }
 }
 

--- a/quantum/backlight/backlight_avr.c
+++ b/quantum/backlight/backlight_avr.c
@@ -230,11 +230,11 @@ ISR(TIMERx_OVF_vect) {
 #define TIMER_TOP 0xFFFFU
 
 // See http://jared.geek.nz/2013/feb/linear-led-pwm
-static uint16_t cie_lightness(uint16_t v, uint16_t max = TIMER_TOP) {
-    if (v <= max / 12)  // if below ~8% of max
+static uint16_t cie_lightness(uint16_t v) {
+    if (v <= ICRx / 12)  // if below ~8% of max
         return v / 9;  // same as dividing by 900%
     else {
-        uint32_t y = (((uint32_t)v + max/6) << 8) / (max/6 + 0xFFFFUL);  // add ~16% of max and compare
+        uint32_t y = (((uint32_t)v + ICRx/6) << 8) / (ICRx/6 + 0xFFFFUL);  // add ~16% of max and compare
         // to get a useful result with integer division, we shift left in the expression above
         // and revert what we've done again after squaring.
         y = y * y * y >> 8;
@@ -380,7 +380,8 @@ ISR(TIMERx_OVF_vect)
         breathing_interrupt_disable();
     }
 
-    set_pwm(cie_lightness(rescale_limit_val(scale_backlight((uint16_t)pgm_read_byte(&breathing_table[index]) * 0x0101U))));
+    // Set PWM to a brightnessvalue scaled to the configured resolution
+    set_pwm(cie_lightness(scale_backlight((uint16_t)pgm_read_byte(&breathing_table[index]) * ICRx/255)));
 }
 
 #endif  // BACKLIGHT_BREATHING

--- a/quantum/backlight/backlight_avr.c
+++ b/quantum/backlight/backlight_avr.c
@@ -280,7 +280,9 @@ void backlight_set(uint8_t level) {
     set_pwm(cie_lightness(ICRx * (uint32_t)level / BACKLIGHT_LEVELS));
 }
 
+#ifdef BACKLIGHT_BREATHING
 static uint16_t pwm_frequency = 244;
+#endif
 
 void backlight_task(void) {}
 
@@ -425,8 +427,9 @@ void backlight_init_ports(void) {
 #            elif (BACKLIGHT_CUSTOM_RESOLUTION < 0xFF)
 #                warning "Resolution lower than 0xFF isn't recommended"
 #            endif
-
-    pwm_frequency = F_CPU / BACKLIGHT_CUSTOM_RESOLUTION;
+#        ifdef BACKLIGHT_BREATHING
+            pwm_frequency = F_CPU / BACKLIGHT_CUSTOM_RESOLUTION;
+            #endif
     ICRx = BACKLIGHT_CUSTOM_RESOLUTION;
 #        else
     ICRx   = TIMER_TOP;

--- a/quantum/backlight/backlight_avr.c
+++ b/quantum/backlight/backlight_avr.c
@@ -248,6 +248,9 @@ static uint16_t cie_lightness(uint16_t v) {
     }
 }
 
+// rescale the supplied backlight value to be in terms of the value limit	// range for val is [0..ICRx]. PWM pin is high while the timer count is below val.
+static uint32_t rescale_limit_val(uint32_t val) { return (val * (BACKLIGHT_LIMIT_VAL + 1)) / 256; }
+
 // range for val is [0..ICRx]. PWM pin is high while the timer count is below val.
 static inline void set_pwm(uint16_t val) { OCRxx = val; }
 
@@ -277,7 +280,7 @@ void backlight_set(uint8_t level) {
 #endif
     }
     // Set the brightness
-    set_pwm(cie_lightness(ICRx * (uint32_t)level / BACKLIGHT_LEVELS));
+    set_pwm(cie_lightness(rescale_limit_val(ICRx * (uint32_t)level / BACKLIGHT_LEVELS)));
 }
 
 void backlight_task(void) {}
@@ -400,7 +403,7 @@ ISR(TIMERx_OVF_vect)
     }
 
     // Set PWM to a brightnessvalue scaled to the configured resolution
-    set_pwm(cie_lightness(scale_backlight((uint16_t)pgm_read_byte(&breathing_table[index]) * ICRx / 255)));
+    set_pwm(cie_lightness(rescale_limit_val(scale_backlight((uint16_t)pgm_read_byte(&breathing_table[index]) * ICRx / 255))));
 }
 
 #endif  // BACKLIGHT_BREATHING

--- a/quantum/backlight/backlight_avr.c
+++ b/quantum/backlight/backlight_avr.c
@@ -291,8 +291,10 @@ void backlight_task(void) {}
 
 static uint8_t  breathing_halt    = BREATHING_NO_HALT;
 static uint16_t breathing_counter = 0;
-static uint16_t pwm_frequency = 244;
+
+static uint8_t breath_scale_counter = 1;
 /* Run the breathing loop at ~120Hz*/
+const uint8_t breathing_ISR_frequency = 120;
 static uint16_t breathing_freq_scale_factor = 2;
 
 #    ifdef BACKLIGHT_PWM_TIMER
@@ -328,7 +330,7 @@ bool is_breathing(void) { return !!(TIMSKx & _BV(TOIEx)); }
                 } while (0)
 #            define breathing_max()                                           \
                 do {                                                          \
-                    breathing_counter = breathing_period * pwm_frequency / 2; \
+                    breathing_counter = breathing_period * breathing_ISR_frequency / 2; \
                 } while (0)
 
 void breathing_enable(void) {
@@ -375,8 +377,6 @@ void breathing_task(void)
  *
  * The following ISR runs at F_CPU/ISRx. With a 16MHz clock and default pwm resolution, that means 244Hz
  */
-static uint8_t breath_scale_counter = 1;
-const uint8_t breathing_ISR_frequency = 120;
 ISR(TIMERx_OVF_vect)
 #    endif
 {
@@ -441,7 +441,6 @@ void backlight_init_ports(void) {
 #                warning "Resolution lower than 0xFF isn't recommended"
 #            endif
 #            ifdef BACKLIGHT_BREATHING
-    pwm_frequency = F_CPU / BACKLIGHT_CUSTOM_RESOLUTION;
     breathing_freq_scale_factor = F_CPU / BACKLIGHT_CUSTOM_RESOLUTION / 120;
 #            endif
     ICRx = BACKLIGHT_CUSTOM_RESOLUTION;

--- a/quantum/backlight/backlight_avr.c
+++ b/quantum/backlight/backlight_avr.c
@@ -199,7 +199,8 @@ static inline void disable_pwm(void) {
 // reaches the backlight level, where we turn off the LEDs,
 // but also an overflow interrupt when the counter rolls back to 0,
 // in which we're going to turn on the LEDs.
-// The LED will then be on for OCRxx/0xFFFF time, adjusted every 244Hz.
+// The LED will then be on for OCRxx/0xFFFF time, adjusted every 244Hz,
+// or F_CPU/BACKLIGHT_CUSTOM_RESOLUTION if used.
 
 // Triggered when the counter reaches the OCRx value
 ISR(TIMERx_COMPA_vect) { backlight_pins_off(); }
@@ -279,6 +280,8 @@ void backlight_set(uint8_t level) {
     set_pwm(cie_lightness(ICRx * (uint32_t)level / BACKLIGHT_LEVELS));
 }
 
+static uint16_t pwm_frequency = 244;
+
 void backlight_task(void) {}
 
 #ifdef BACKLIGHT_BREATHING
@@ -290,7 +293,6 @@ void backlight_task(void) {}
 
 static uint8_t  breathing_halt    = BREATHING_NO_HALT;
 static uint16_t breathing_counter = 0;
-static uint16_t pwm_frequency = 244;
 
 #    ifdef BACKLIGHT_PWM_TIMER
 static bool breathing = false;

--- a/quantum/backlight/backlight_avr.c
+++ b/quantum/backlight/backlight_avr.c
@@ -458,13 +458,3 @@ void backlight_init_ports(void) {
     }
 #endif
 }
-
-#    endif  // hardware backlight
-
-#else  // no backlight
-
-__attribute__((weak)) void backlight_init_ports(void) {}
-
-__attribute__((weak)) void backlight_set(uint8_t level) {}
-
-#endif  // backlight

--- a/quantum/backlight/backlight_avr.c
+++ b/quantum/backlight/backlight_avr.c
@@ -420,10 +420,11 @@ void backlight_init_ports(void) {
     TCCRxB = _BV(WGM13) | _BV(WGM12) | _BV(CS10);
 #endif
     // Use full 16-bit resolution. Counter counts to ICR1 before reset to 0.
-    #ifdef BACKLIGHT_CUSTOM_SPEED
-
+    #ifdef BACKLIGHT_CUSTOM_RESOLUTION
+        ICRx = BACKLIGHT_CUSTOM_RESOLUTION
     #else
         ICRx = TIMER_TOP;
+    #endif
 
     backlight_init();
 #ifdef BACKLIGHT_BREATHING

--- a/quantum/backlight/backlight_avr.c
+++ b/quantum/backlight/backlight_avr.c
@@ -416,7 +416,7 @@ void backlight_init_ports(void) {
 #        endif
 
 #        ifdef BACKLIGHT_CUSTOM_RESOLUTION  // Use full 16-bit resolution. Counter counts to ICR1 before reset to 0.
-    ICRx = BACKLIGHT_CUSTOM_RESOLUTION
+    ICRx = BACKLIGHT_CUSTOM_RESOLUTION;
 #        else
     ICRx   = TIMER_TOP;
 #        endif

--- a/quantum/backlight/backlight_avr.c
+++ b/quantum/backlight/backlight_avr.c
@@ -232,9 +232,9 @@ ISR(TIMERx_OVF_vect) {
 // See http://jared.geek.nz/2013/feb/linear-led-pwm
 static uint16_t cie_lightness(uint16_t v) {
     if (v <= ICRx / 12)  // if below ~8% of max
-        return v / 9;  // same as dividing by 900%
+        return v / 9;    // same as dividing by 900%
     else {
-        uint32_t y = (((uint32_t)v + ICRx/6) << 8) / (ICRx/6 + 0xFFFFUL);  // add ~16% of max and compare
+        uint32_t y = (((uint32_t)v + ICRx / 6) << 8) / (ICRx / 6 + 0xFFFFUL);  // add ~16% of max and compare
         // to get a useful result with integer division, we shift left in the expression above
         // and revert what we've done again after squaring.
         y = y * y * y >> 8;
@@ -381,7 +381,7 @@ ISR(TIMERx_OVF_vect)
     }
 
     // Set PWM to a brightnessvalue scaled to the configured resolution
-    set_pwm(cie_lightness(scale_backlight((uint16_t)pgm_read_byte(&breathing_table[index]) * ICRx/255)));
+    set_pwm(cie_lightness(scale_backlight((uint16_t)pgm_read_byte(&breathing_table[index]) * ICRx / 255)));
 }
 
 #endif  // BACKLIGHT_BREATHING
@@ -411,20 +411,15 @@ void backlight_init_ports(void) {
     "In fast PWM mode, the compare units allow generation of PWM waveforms on the OCnx pins. Setting the COMnx1:0 bits to two will produce a non-inverted PWM [..]."
     "In fast PWM mode the counter is incremented until the counter value matches either one of the fixed values 0x00FF, 0x01FF, or 0x03FF (WGMn3:0 = 5, 6, or 7), the value in ICRn (WGMn3:0 = 14), or the value in OCRnA (WGMn3:0 = 15)."
     */
-#    if BACKLIGHT_ON_STATE == 1
-    TCCRxA = _BV(COMxx1) | _BV(WGM11);
-#    else
-    TCCRxA = _BV(COMxx1) | _BV(COMxx0) | _BV(WGM11);
-#    endif
+    TCCRxA = _BV(COMxx1) | _BV(WGM11);             // = 0b00001010;
+    TCCRxB = _BV(WGM13) | _BV(WGM12) | _BV(CS10);  // = 0b00011001;
+#        endif
 
-    TCCRxB = _BV(WGM13) | _BV(WGM12) | _BV(CS10);
-#endif
-    // Use full 16-bit resolution. Counter counts to ICR1 before reset to 0.
-    #ifdef BACKLIGHT_CUSTOM_RESOLUTION
-        ICRx = BACKLIGHT_CUSTOM_RESOLUTION
-    #else
-        ICRx = TIMER_TOP;
-    #endif
+#        ifdef BACKLIGHT_CUSTOM_RESOLUTION  // Use full 16-bit resolution. Counter counts to ICR1 before reset to 0.
+    ICRx = BACKLIGHT_CUSTOM_RESOLUTION
+#        else
+    ICRx   = TIMER_TOP;
+#        endif
 
     backlight_init();
 #ifdef BACKLIGHT_BREATHING


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
## Description
This PR aims to make hardware PWM resolution configurable, allowing higher PWM frequencies at lower resolutions.

Currently, 16bit timers use the full 16bit resolution, resulting in a ~244Hz frequency for the backlight PWM. This would be noticeable in the peripheral vision if moving quickly / turning your head quickly. Additionally, with most keyboards having very few brightness levels, this resolution is wasted.

For now, making the top of the counter optionally configurable using `#define BACKLIGHT_CUSTOM_RESOLUTION = <custom resolution>` should offer configurability for users that find 244Hz too slow.

In order to achieve this, some things have been changed slightly. 

The cie_lightness function was hard-coded to assume the max value was 65535.
In order to avoid floating point arithmetic, I replaced the hard-coded 8% and 16% values of that with division with the nearest integer to the reciprocal of the respective percentages. x/12 for ~8% (8.333...%) and x/6 for ~16% (16.666...%)

No change default behavior should be as it was, except for the minor differences in percentages.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->



<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
