### PR TITLE
Remove check for EH define

### DIFF
--- a/keyboards/ai03/orbit/split_util.c
+++ b/keyboards/ai03/orbit/split_util.c
@@ -54,7 +54,7 @@ bool is_keyboard_master(void)
 }
 
 static void keyboard_master_setup(void) {
-#if defined(USE_I2C) || defined(EH)
+#if defined(USE_I2C)
   #ifdef SSD1306OLED
     matrix_master_OLED_init ();
   #endif

--- a/keyboards/ai03/orbit/transport.c
+++ b/keyboards/ai03/orbit/transport.c
@@ -18,7 +18,7 @@
   extern backlight_config_t backlight_config;
 #endif
 
-#if defined(USE_I2C) || defined(EH)
+#if defined(USE_I2C)
 
 #include "i2c.h"
 

--- a/quantum/split_common/post_config.h
+++ b/quantum/split_common/post_config.h
@@ -1,4 +1,4 @@
-#if defined(USE_I2C) || defined(EH)
+#if defined(USE_I2C)
 // When using I2C, using rgblight implicitly involves split support.
 #    if defined(RGBLIGHT_ENABLE) && !defined(RGBLIGHT_SPLIT)
 #        define RGBLIGHT_SPLIT

--- a/quantum/split_common/split_util.c
+++ b/quantum/split_common/split_util.c
@@ -76,7 +76,7 @@ __attribute__((weak)) bool is_keyboard_master(void) {
 }
 
 static void keyboard_master_setup(void) {
-#if defined(USE_I2C) || defined(EH)
+#if defined(USE_I2C)
 #    ifdef SSD1306OLED
     matrix_master_OLED_init();
 #    endif

--- a/quantum/split_common/transport.c
+++ b/quantum/split_common/transport.c
@@ -21,7 +21,7 @@ static pin_t encoders_pad[] = ENCODERS_PAD_A;
 #    define NUMBER_OF_ENCODERS (sizeof(encoders_pad) / sizeof(pin_t))
 #endif
 
-#if defined(USE_I2C) || defined(EH)
+#if defined(USE_I2C)
 
 #    include "i2c_master.h"
 #    include "i2c_slave.h"


### PR DESCRIPTION
`#define EH` and its checks were a temporary solution in the early days of `split_common`. Its use in lets_split_eh was factored out in https://github.com/qmk/qmk_firmware/pull/6411, so the checks are no longer needed.

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
