### PR TITLE
Turn on internal pullups on I2C pins on right half

### DIFF
--- a/docs/feature_split_keyboard.md
+++ b/docs/feature_split_keyboard.md
@@ -128,7 +128,7 @@ Because not every split keyboard is identical, there are a number of additional 
 #define USE_I2C
 ```
 
-This enables I<sup>2</sup>C support for split keyboards. This isn't strictly for communication, but can be used for OLED or other I<sup>2</sup>C-based devices. Also add the `NO_RIGHT_HALF_EXT_I2C_PULLUPS` define (described below) if the right half of the board does not have I2C pullup resistors on it.
+This enables I<sup>2</sup>C support for split keyboards. This isn't strictly for communication, but can be used for OLED or other I<sup>2</sup>C-based devices.
 
 ```c
 #define SOFT_SERIAL_PIN D0
@@ -203,10 +203,16 @@ This option changes the startup behavior to detect an active USB connection when
 This sets the maximum timeout when detecting master/slave when using `SPLIT_USB_DETECT`.
 
 ```c
-#define NO_RIGHT_HALF_EXT_I2C_PULLUPS
+#define RIGHT_HALF_INT_I2C_PULLUPS_OFF
 ```
 
-This turns on the internal pullup resistors on the I2C pins if the right half does not have external pullup resistors, so that the right half can operate on its own without delays. Most boards will need this option to be enabled. Leave this define out if the right half does have pullup resistors on the I2C pins.
+By default, it is assumed that the right half of a board does not have I2C pullup resistors installed on it, so the internal pullups are turned on for the 2 I2C pins. If the right half of the board does have physical I2C pullup resistors on the PCB, then `RIGHT_HALF_INT_I2C_PULLUPS_OFF` can be set to disable the internal pullups, but this is optional, as using both internal and external pullups at the same time will be okay.
+
+```c
+#define LEFT_HALF_INT_I2C_PULLUPS_ON
+```
+
+This turns on the internal pullup resistors on the I2C pins if the left half does not have external pullup resistors, so that the left half can operate on its own without delays. Most boards will not need this option, as the I2C pullup resistors are usually placed on this half. Leave this define out if the left half does have pullup resistors on the I2C pins.
 
 ## Additional Resources
 

--- a/docs/feature_split_keyboard.md
+++ b/docs/feature_split_keyboard.md
@@ -128,7 +128,7 @@ Because not every split keyboard is identical, there are a number of additional 
 #define USE_I2C
 ```
 
-This enables I<sup>2</sup>C support for split keyboards. This isn't strictly for communication, but can be used for OLED or other I<sup>2</sup>C-based devices. 
+This enables I<sup>2</sup>C support for split keyboards. This isn't strictly for communication, but can be used for OLED or other I<sup>2</sup>C-based devices. Also add the `NO_RIGHT_HALF_EXT_I2C_PULLUPS` define (described below) if the right half of the board does not have I2C pullup resistors on it.
 
 ```c
 #define SOFT_SERIAL_PIN D0
@@ -201,6 +201,12 @@ This option changes the startup behavior to detect an active USB connection when
 #define SPLIT_USB_TIMEOUT 2500
 ```
 This sets the maximum timeout when detecting master/slave when using `SPLIT_USB_DETECT`.
+
+```c
+#define NO_RIGHT_HALF_EXT_I2C_PULLUPS
+```
+
+This turns on the internal pullup resistors on the I2C pins if the right half does not have external pullup resistors, so that the right half can operate on its own without delays. Most boards will need this option to be enabled. Leave this define out if the right half does have pullup resistors on the I2C pins.
 
 ## Additional Resources
 

--- a/quantum/split_common/split_util.c
+++ b/quantum/split_common/split_util.c
@@ -80,6 +80,15 @@ static void keyboard_master_setup(void) {
 #    ifdef SSD1306OLED
     matrix_master_OLED_init();
 #    endif
+#    if defined(NO_RIGHT_HALF_EXT_I2C_PULLUPS)
+    // Set internal pullups on I2C pins
+    if (!isLeftHand) {
+#        if defined(__AVR__)
+        setPinInputHigh(D0);
+        setPinInputHigh(D1);
+#        endif
+    }
+#    endif
 #endif
     transport_master_init();
 }

--- a/quantum/split_common/split_util.c
+++ b/quantum/split_common/split_util.c
@@ -80,17 +80,28 @@ static void keyboard_master_setup(void) {
 #    ifdef SSD1306OLED
     matrix_master_OLED_init();
 #    endif
-#    if defined(NO_RIGHT_HALF_EXT_I2C_PULLUPS)
-    // Set internal pullups on I2C pins
-    if (!isLeftHand) {
-#        if defined(__AVR__)
-        setPinInputHigh(D0);
-        setPinInputHigh(D1);
-#        endif
+
+    // Set internal pullups on I2C pins if needed
+#    if defined(LEFT_HALF_INT_I2C_PULLUPS_ON)
+    if (isLeftHand) {
+        set_internal_I2C_pullups();
     }
 #    endif
+#    if defined(RIGHT_HALF_INT_I2C_PULLUPS_OFF)
+    if (!isLeftHand) {
+        set_internal_I2C_pullups();
+    }
+#    endif
+
 #endif
     transport_master_init();
+}
+
+void set_internal_I2C_pullups(void) {
+#if defined(__AVR__)
+    setPinInputHigh(D0);
+    setPinInputHigh(D1);
+#endif
 }
 
 static void keyboard_slave_setup(void) { transport_slave_init(); }

--- a/quantum/split_common/split_util.h
+++ b/quantum/split_common/split_util.h
@@ -8,4 +8,5 @@
 extern volatile bool isLeftHand;
 
 void matrix_master_OLED_init(void);
+void set_internal_I2C_pullups(void);
 void keyboard_split_setup(void);


### PR DESCRIPTION
## Description

Fixes issue raised in https://github.com/qmk/qmk_firmware/issues/7522, where the right half of a split keyboard operates slowly due to lack of external I2C pullup resistors. This PR turns on the internal pullup resistors on the I2C pins if `NO_RIGHT_HALF_EXT_I2C_PULLUPS` is defined, and if it is the right half. This allows the `i2c_readReg` call in `transport_master` of `transport.c` to return immediately, instead of waiting for the timeout length of 100ms for each call.

Tested change on Levinson Rev. 3 and Iris Rev. 3 & 4.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/qmk/qmk_firmware/issues/7522

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
