### PR TITLE
Allow CI to build all board revisions when not using DEFAULT_FOLDER

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -281,6 +281,12 @@ define PARSE_RULE
     else ifeq ($$(call TRY_TO_MATCH_RULE_FROM_LIST,$$(KEYBOARDS)),true)
         KEYBOARD_RULE=$$(MATCHED_ITEM)
         $$(eval $$(call PARSE_KEYBOARD,$$(MATCHED_ITEM)))
+    # ONLY ON CI - build all revisions for boards without DEFAULT_FOLDER set
+    else ifeq ($${CI}, true)
+        FILTER := $$(firstword $$(subst :, ,$${RULE}))
+        KEYBOARDS := $$(filter $${FILTER}%,$$(KEYBOARDS))
+        RULE := $$(subst $${FILTER}:,,$${RULE})
+        $$(eval $$(call PARSE_ALL_KEYBOARDS))
     # Otherwise use the KEYBOARD variable, which is determined either by
     # the current directory you run make from, or passed in as an argument
     else ifneq ($$(KEYBOARD),)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Currently if a planck or keebio/iris keymap is added or modified, CI will fail as those boards do not use a `DEFAULT_FOLDER`.
```console
$ make keebio/iris:drashna
QMK Firmware 0.7.92
make: *** No rule to make target 'keebio/iris:drashna'. Stop.
```
This allows compilation issues to slip through the PR process.

Another potential problem is these boards have top level code files, for example `keyboards/planck/planck.h`. If these change, the same issue arises. CI has no way to key the changes against what to build.

`DEFAULT_FOLDER` was removed from some of these boards, as people were trying to build/flash the wrong firmware. To maintain this contract, but allow CI to have a sane behaviour, this PR adds in logic to support partial matching within the travis environment.

```console
$ make keebio/iris:drashna
QMK Firmware 0.7.92
Making keebio/iris/rev1 with keymap drashna                                                            [OK]
Making keebio/iris/rev1_led with keymap drashna                                                        [OK]
Making keebio/iris/rev2 with keymap drashna                                                            [OK]
...
```

### Alternative solutions
1. configure a `CI_DEFAULT_FOLDER` option within the top level rules.mk, which will behave like `DEFAULT_FOLDER` would, but only within CI. 
2. configure  `NO_USER_DEFAULT_FOLDER` that disables `DEFAULT_FOLDER` when not in CI. 

The downside to this, is the reliance on keyboards to be configured correctly.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
