### PR TITLE
Add central location for ChibiOS defines

### DIFF
--- a/drivers/arm/i2c_master.c
+++ b/drivers/arm/i2c_master.c
@@ -24,9 +24,8 @@
  * STM32_I2C_USE_I2C1 is TRUE in the mcuconf.h file. Pins B6 and B7 are used
  * but using any other I2C pins should be trivial.
  */
-
-#include "i2c_master.h"
 #include "quantum.h"
+#include "i2c_master.h"
 #include <string.h>
 #include <hal.h>
 

--- a/drivers/arm/i2c_master.h
+++ b/drivers/arm/i2c_master.h
@@ -27,10 +27,6 @@
 #include "ch.h"
 #include <hal.h>
 
-#if defined(STM32F1XX) || defined(STM32F1xx) || defined(STM32F2xx) || defined(STM32F4xx) || defined(STM32F4XX) || defined(STM32L0xx) || defined(STM32L1xx)
-#    define USE_I2CV1
-#endif
-
 #ifdef I2C1_BANK
 #    define I2C1_SCL_BANK I2C1_BANK
 #    define I2C1_SDA_BANK I2C1_BANK
@@ -49,20 +45,6 @@
 #endif
 #ifndef I2C1_SDA
 #    define I2C1_SDA 7
-#endif
-
-#if defined(STM32F1XX) || defined(STM32F1xx)
-#    define USE_GPIOV1
-#endif
-
-#ifndef USE_GPIOV1
-// The default PAL alternate modes are used to signal that the pins are used for I2C
-#    ifndef I2C1_SCL_PAL_MODE
-#        define I2C1_SCL_PAL_MODE 4
-#    endif
-#    ifndef I2C1_SDA_PAL_MODE
-#        define I2C1_SDA_PAL_MODE 4
-#    endif
 #endif
 
 #ifdef USE_I2CV1
@@ -97,6 +79,16 @@
 
 #ifndef I2C_DRIVER
 #    define I2C_DRIVER I2CD1
+#endif
+
+#ifndef USE_GPIOV1
+// The default PAL alternate modes are used to signal that the pins are used for I2C
+#    ifndef I2C1_SCL_PAL_MODE
+#        define I2C1_SCL_PAL_MODE 4
+#    endif
+#    ifndef I2C1_SDA_PAL_MODE
+#        define I2C1_SDA_PAL_MODE 4
+#    endif
 #endif
 
 typedef int16_t i2c_status_t;

--- a/quantum/backlight/backlight_arm.c
+++ b/quantum/backlight/backlight_arm.c
@@ -10,10 +10,6 @@
 #        error "Backlight support for STMF072 is not available. Please disable."
 #    endif
 
-#    if defined(STM32F1XX) || defined(STM32F1xx)
-#        define USE_GPIOV1
-#    endif
-
 // GPIOV2 && GPIOV3
 #    ifndef BACKLIGHT_PAL_MODE
 #        define BACKLIGHT_PAL_MODE 2

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -22,6 +22,7 @@
 #endif
 #if defined(PROTOCOL_CHIBIOS)
 #    include "hal.h"
+#    include "chibios_config.h"
 #endif
 
 #include "wait.h"

--- a/tmk_core/common/chibios/chibios_config.h
+++ b/tmk_core/common/chibios/chibios_config.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#if defined(STM32F1XX)
+#    define USE_GPIOV1
+#endif
+
+#if defined(STM32F1XX) || defined(STM32F2XX) || defined(STM32F4XX) || defined(STM32L1XX)
+#    define USE_I2CV1
+#endif

--- a/tmk_core/common/chibios/chibios_config.h
+++ b/tmk_core/common/chibios/chibios_config.h
@@ -1,3 +1,18 @@
+/* Copyright 2019
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 #pragma once
 
 #if defined(STM32F1XX)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Given the ChibiOS HAL doesnt have a unified API, we end up in a HAL of HAL's situation where various code areas have to sniff config options and compile in different blocks of code. Unfortunately it doesn't look like there are internal "this board is using gpiov2" defines we can leverage.

Rather than have these defines duplicated, this PR aims to add a central location to manage the mcu logic.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
