### PR TITLE
Generate PRODUCT if it wasn't defined in config.h

### DIFF
--- a/keyboards/clueboard/17/config.h
+++ b/keyboards/clueboard/17/config.h
@@ -25,7 +25,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define PRODUCT_ID      0x2312
 #define DEVICE_VER      0x0001
 #define MANUFACTURER    Clueboard
-#define PRODUCT         Cluepad with RGB Underlighting
 #define DESCRIPTION     QMK keyboard firmware for Cluepad
 
 /* key matrix size */

--- a/keyboards/clueboard/2x1800/2018/config.h
+++ b/keyboards/clueboard/2x1800/2018/config.h
@@ -25,7 +25,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define PRODUCT_ID      0x23A0
 #define DEVICE_VER      0x0001
 #define MANUFACTURER    Clueboard
-#define PRODUCT         2x1800 2018
 #define DESCRIPTION     What does it mean?
 
 /* key matrix size */

--- a/keyboards/clueboard/60/config.h
+++ b/keyboards/clueboard/60/config.h
@@ -24,7 +24,6 @@
 #define PRODUCT_ID      0x2350
 #define DEVICE_VER      0x0001
 #define MANUFACTURER    Clueboard
-#define PRODUCT         Clueboard 60%
 #define DESCRIPTION     Clueboard 60%
 
 /* Address for jumping to bootloader on STM32 chips. */

--- a/keyboards/clueboard/66/rev1/config.h
+++ b/keyboards/clueboard/66/rev1/config.h
@@ -7,7 +7,6 @@
 #define PRODUCT_ID      0x2301
 #define DEVICE_VER      0x0003
 #define MANUFACTURER    Clueboard
-#define PRODUCT         Clueboard
 #define DESCRIPTION     QMK keyboard firmware for Clueboard
 
 /* key matrix size

--- a/keyboards/clueboard/66/rev2/config.h
+++ b/keyboards/clueboard/66/rev2/config.h
@@ -7,7 +7,6 @@
 #define PRODUCT_ID      0x2320
 #define DEVICE_VER      0x0001
 #define MANUFACTURER    Clueboard
-#define PRODUCT         Clueboard
 #define DESCRIPTION     QMK keyboard firmware for Clueboard
 
 /* key matrix size */

--- a/keyboards/clueboard/66/rev3/config.h
+++ b/keyboards/clueboard/66/rev3/config.h
@@ -7,7 +7,6 @@
 #define PRODUCT_ID      0x2370
 #define DEVICE_VER      0x0001
 #define MANUFACTURER    Clueboard
-#define PRODUCT         Clueboard
 #define DESCRIPTION     QMK keyboard firmware for Clueboard
 
 /* key matrix size */

--- a/keyboards/clueboard/66/rev4/config.h
+++ b/keyboards/clueboard/66/rev4/config.h
@@ -7,7 +7,6 @@
 #define PRODUCT_ID      0x2390
 #define DEVICE_VER      0x0001
 #define MANUFACTURER    Clueboard
-#define PRODUCT         Clueboard 66% rev4
 #define DESCRIPTION     QMK keyboard firmware for Clueboard
 
 /* Address for jumping to bootloader on STM32 chips. */

--- a/keyboards/clueboard/66_hotswap/config.h
+++ b/keyboards/clueboard/66_hotswap/config.h
@@ -21,7 +21,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* USB Device descriptor parameter */
 #define VENDOR_ID       0xC1ED
 #define MANUFACTURER    Clueboard
-#define PRODUCT         Clueboard 66% HotSwap
 #define DESCRIPTION     QMK keyboard firmware for Clueboard 66%
 
 /* COL2ROW or ROW2COL */

--- a/keyboards/clueboard/california/config.h
+++ b/keyboards/clueboard/california/config.h
@@ -7,7 +7,6 @@
 #define PRODUCT_ID      0x23B0
 #define DEVICE_VER      0x0001
 #define MANUFACTURER    Clueboard
-#define PRODUCT         California Macropad
 #define DESCRIPTION     A 10-key macropad shaped like California
 
 /* key matrix pins */

--- a/keyboards/clueboard/card/config.h
+++ b/keyboards/clueboard/card/config.h
@@ -24,7 +24,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define PRODUCT_ID      0x2330
 #define DEVICE_VER      0x0001
 #define MANUFACTURER    Clueboard
-#define PRODUCT         ATMEGA32U4 Firmware Dev Kit
 #define DESCRIPTION     A small board to help you hack on QMK.
 
 /* key matrix size */

--- a/tmk_core/protocol/usb_descriptor.h
+++ b/tmk_core/protocol/usb_descriptor.h
@@ -49,6 +49,14 @@
 #    include "hal.h"
 #endif
 
+#ifndef PRODUCT
+#    ifdef SKIP_VERSION
+#        define PRODUCT BOARD_PATH (QMK __DATE__) (__DATE__ __TIME__)
+#    else
+#        define PRODUCT BOARD_PATH (QMK QMK_VERSION) (__DATE__ __TIME__)
+#    endif
+#endif
+
 /*
  * USB descriptor structure
  */


### PR DESCRIPTION
If a keyboard doesn't define PRODUCT we should generate a reasonable default. After this is in place and has received a bit of testing we should start to convert most boards to use it, and encourage people to let their PRODUCT strings be autogenerated.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Enhancement/optimization

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
