### PR TITLE
Fix breathing toggle when rgb is disabled

### DIFF
--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -303,6 +303,11 @@ bool process_record_quantum(keyrecord_t *record) {
                 set_output(OUTPUT_BLUETOOTH);
                 return false;
 #endif
+#if defined(BACKLIGHT_ENABLE) && defined(BACKLIGHT_BREATHING)
+        case BL_BRTG:
+                backlight_toggle_breathing();
+                return false;
+#endif
         }
     }
 
@@ -454,11 +459,6 @@ bool process_record_quantum(keyrecord_t *record) {
                 rgblight_mode(RGBLIGHT_MODE_RGB_TEST);
 #    endif
                 return false;
-#if defined(BACKLIGHT_ENABLE) && defined(BACKLIGHT_BREATHING)
-            case BL_BRTG:
-                backlight_toggle_breathing();
-                return false;
-#endif
         }
     }
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
`BL_BRTG` keycode handling was hidden within the rgb keycodes, and compiled out if you did not have rgblight or rgbmatrix enabled. Moved block to the other single state keycode handling,


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
