### PR TITLE
Fix missing item in Ergodicity macro

### DIFF
--- a/keyboards/keebio/ergodicity/ergodicity.h
+++ b/keyboards/keebio/ergodicity/ergodicity.h
@@ -37,5 +37,5 @@
     { kB1, kB2, kB3, kB4, kB5, kB6, kB7, kB8, kB9, kB10, kB11, kB12, kB13, kB14, kB15 }, \
     { kC1, kC2, kC3, kC4, kC5, kC6, kC7, kC8, kC9, kC10, kC11, kC12, kC13, KC_NO, kC15 }, \
     { KC_NO, kD2, kD3, kD4, kD5, kD6, kD7, kD8, kD9, kD10, kD11, kD12, kD13, kD14, kD15 }, \
-    { KC_NO, kE2, kE3, kE4, KC_NO, kE6, kE7, KC_NO, kE9, KC_NO, kE11, KC_NO, KC_NO, kE15 } \
+    { KC_NO, kE2, kE3, kE4, KC_NO, kE6, kE7, KC_NO, kE9, KC_NO, kE11, KC_NO, KC_NO, KC_NO, kE15 } \
 }


### PR DESCRIPTION

## Description

Fixes missing KC_NO in last line of macro of the Ergodicity layout macro.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
