### PR TITLE
Added workaround for serial.c issue when LTO_ENABLE=yes for the Helix.

### DIFF
--- a/keyboards/helix/pico/rules.mk
+++ b/keyboards/helix/pico/rules.mk
@@ -5,6 +5,11 @@ SRC += local_drivers/serial.c
 SRC += local_drivers/ssd1306.c
 KEYBOARD_PATHS += $(HELIX_TOP_DIR)/local_drivers
 
+# A workaround until #7089 is merged.
+#   serial.c must not be compiled with the -lto option.
+#   The current LIB_SRC has a side effect with the -fno-lto option, so use it.
+LIB_SRC += local_drivers/serial.c
+
 CUSTOM_MATRIX = yes
 
 SRC += pico/matrix.c

--- a/keyboards/helix/rev2/rules.mk
+++ b/keyboards/helix/rev2/rules.mk
@@ -5,6 +5,11 @@ SRC += local_drivers/serial.c
 SRC += local_drivers/ssd1306.c
 KEYBOARD_PATHS += $(HELIX_TOP_DIR)/local_drivers
 
+# A workaround until #7089 is merged.
+#   serial.c must not be compiled with the -lto option.
+#   The current LIB_SRC has a side effect with the -fno-lto option, so use it.
+LIB_SRC += local_drivers/serial.c
+
 CUSTOM_MATRIX = yes
 
 SRC += rev2/matrix.c


### PR DESCRIPTION
## Description

helix-serial.c is sensitive to execution timing and will not work as expected when compiled with the -flto option. As a result, if Helix is compiled with LTO_ENABLE = yes, the key input on the slave side will not be performed correctly.

In particular, `helix:xulkal` is always set to LTO_ENABLE = yes, so key input on the slave side is not possible.

To solve this problem, #7089 suggests a general way to specify the `-fno-lto` option, but it still doesn't merge after a month and a half.

This PR adds a temporary workaround to helix/rev2 and helix/pico until #7089 is merged.

What happens with this PR:
* When LTO_ENABLE = no. 
  All helix/rev2 and helix/pico keymap compilation results will not change. Therefore, there is no adverse effect.
* When LTO_ENABLE = yes. 
  This PR ensures that all `helix/rev2` and` helix/pico` keymaps work correctly. All keymaps have been checked for operation.
  
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/qmk/qmk_firmware/pull/6952#discussion_r332658968

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
