### PR TITLE
Fix ChibiOS USB config for chips which support OTGv1

### DIFF
--- a/tmk_core/protocol/chibios/usb_main.c
+++ b/tmk_core/protocol/chibios/usb_main.c
@@ -164,58 +164,61 @@ typedef struct {
     QMKUSBDriver        driver;
 } usb_driver_config_t;
 
-#define QMK_USB_DRIVER_CONFIG(stream, notification, fixedsize)                                                       \
-    {                                                                                                                \
-        .queue_capacity_in = stream##_IN_CAPACITY, .queue_capacity_out = stream##_OUT_CAPACITY,                      \
-        .in_ep_config = {.ep_mode     = stream##_IN_MODE,                                                            \
-                         .setup_cb    = NULL,                                                                        \
-                         .in_cb       = qmkusbDataTransmitted,                                                       \
-                         .out_cb      = NULL,                                                                        \
-                         .in_maxsize  = stream##_EPSIZE,                                                             \
-                         .out_maxsize = 0, /* The pointer to the states will be filled during initialization */      \
-                         .in_state    = NULL,                                                                        \
-                         .out_state   = NULL,                                                                        \
-                         .ep_buffers  = 2,                                                                           \
-                         .setup_buf   = NULL},                                                                         \
-        .out_ep_config =                                                                                             \
-            {                                                                                                        \
-                .ep_mode     = stream##_OUT_MODE,                                                                    \
-                .setup_cb    = NULL,                                                                                 \
-                .in_cb       = NULL,                                                                                 \
-                .out_cb      = qmkusbDataReceived,                                                                   \
-                .in_maxsize  = 0,                                                                                    \
-                .out_maxsize = stream##_EPSIZE, /* The pointer to the states will be filled during initialization */ \
-                .in_state    = NULL,                                                                                 \
-                .out_state   = NULL,                                                                                 \
-                .ep_buffers  = 2,                                                                                    \
-                .setup_buf   = NULL,                                                                                 \
-            },                                                                                                       \
-        .int_ep_config =                                                                                             \
-            {                                                                                                        \
-                .ep_mode     = USB_EP_MODE_TYPE_INTR,                                                                \
-                .setup_cb    = NULL,                                                                                 \
-                .in_cb       = qmkusbInterruptTransmitted,                                                           \
-                .out_cb      = NULL,                                                                                 \
-                .in_maxsize  = CDC_NOTIFICATION_EPSIZE,                                                              \
-                .out_maxsize = 0, /* The pointer to the states will be filled during initialization */               \
-                .in_state    = NULL,                                                                                 \
-                .out_state   = NULL,                                                                                 \
-                .ep_buffers  = 2,                                                                                    \
-                .setup_buf   = NULL,                                                                                 \
-            },                                                                                                       \
-        .config = {                                                                                                  \
-            .usbp        = &USB_DRIVER,                                                                              \
-            .bulk_in     = stream##_IN_EPNUM,                                                                        \
-            .bulk_out    = stream##_OUT_EPNUM,                                                                       \
-            .int_in      = notification,                                                                             \
-            .in_buffers  = stream##_IN_CAPACITY,                                                                     \
-            .out_buffers = stream##_OUT_CAPACITY,                                                                    \
-            .in_size     = stream##_EPSIZE,                                                                          \
-            .out_size    = stream##_EPSIZE,                                                                          \
-            .fixed_size  = fixedsize,                                                                                \
-            .ib          = (uint8_t[BQ_BUFFER_SIZE(stream##_IN_CAPACITY, stream##_EPSIZE)]){},                       \
-            .ob          = (uint8_t[BQ_BUFFER_SIZE(stream##_OUT_CAPACITY, stream##_EPSIZE)]){},                      \
-        }                                                                                                            \
+#define QMK_USB_DRIVER_CONFIG(stream, notification, fixedsize)                                  \
+    {                                                                                           \
+        .queue_capacity_in = stream##_IN_CAPACITY, .queue_capacity_out = stream##_OUT_CAPACITY, \
+        .in_ep_config =                                                                         \
+            {                                                                                   \
+                stream##_IN_MODE,      /* Interrupt EP */                                       \
+                NULL,                  /* SETUP packet notification callback */                 \
+                qmkusbDataTransmitted, /* IN notification callback */                           \
+                NULL,                  /* OUT notification callback */                          \
+                stream##_EPSIZE,       /* IN maximum packet size */                             \
+                0,                     /* OUT maximum packet size */                            \
+                NULL,                  /* IN Endpoint state */                                  \
+                NULL,                  /* OUT endpoint state */                                 \
+                2,                     /* IN multiplier */                                      \
+                NULL                   /* SETUP buffer (not a SETUP endpoint) */                \
+            },                                                                                  \
+        .out_ep_config =                                                                        \
+            {                                                                                   \
+                stream##_OUT_MODE,  /* Interrupt EP */                                          \
+                NULL,               /* SETUP packet notification callback */                    \
+                NULL,               /* IN notification callback */                              \
+                qmkusbDataReceived, /* OUT notification callback */                             \
+                0,                  /* IN maximum packet size */                                \
+                stream##_EPSIZE,    /* OUT maximum packet size */                               \
+                NULL,               /* IN Endpoint state */                                     \
+                NULL,               /* OUT endpoint state */                                    \
+                2,                  /* IN multiplier */                                         \
+                NULL,               /* SETUP buffer (not a SETUP endpoint) */                   \
+            },                                                                                  \
+        .int_ep_config =                                                                        \
+            {                                                                                   \
+                USB_EP_MODE_TYPE_INTR,      /* Interrupt EP */                                  \
+                NULL,                       /* SETUP packet notification callback */            \
+                qmkusbInterruptTransmitted, /* IN notification callback */                      \
+                NULL,                       /* OUT notification callback */                     \
+                CDC_NOTIFICATION_EPSIZE,    /* IN maximum packet size */                        \
+                0,                          /* OUT maximum packet size */                       \
+                NULL,                       /* IN Endpoint state */                             \
+                NULL,                       /* OUT endpoint state */                            \
+                2,                          /* IN multiplier */                                 \
+                NULL,                       /* SETUP buffer (not a SETUP endpoint) */           \
+            },                                                                                  \
+        .config = {                                                                             \
+            .usbp        = &USB_DRIVER,                                                         \
+            .bulk_in     = stream##_IN_EPNUM,                                                   \
+            .bulk_out    = stream##_OUT_EPNUM,                                                  \
+            .int_in      = notification,                                                        \
+            .in_buffers  = stream##_IN_CAPACITY,                                                \
+            .out_buffers = stream##_OUT_CAPACITY,                                               \
+            .in_size     = stream##_EPSIZE,                                                     \
+            .out_size    = stream##_EPSIZE,                                                     \
+            .fixed_size  = fixedsize,                                                           \
+            .ib          = (uint8_t[BQ_BUFFER_SIZE(stream##_IN_CAPACITY, stream##_EPSIZE)]){},  \
+            .ob          = (uint8_t[BQ_BUFFER_SIZE(stream##_OUT_CAPACITY, stream##_EPSIZE)]){}, \
+        }                                                                                       \
     }
 
 typedef struct {

--- a/tmk_core/protocol/chibios/usb_main.c
+++ b/tmk_core/protocol/chibios/usb_main.c
@@ -15,6 +15,16 @@
  * GPL v2 or later.
  */
 
+/*
+ * Implementation notes:
+ *
+ * USBEndpointConfig - Configured using explicit order instead of struct member name.
+ *   This is due to ChibiOS hal LDD differences, which is dependent on hardware,
+ *   "USBv1" devices have `ep_buffers` and "OTGv1" have `in_multiplier`.
+ *   Given `USBv1/hal_usb_lld.h` marks the field as "not currently used" this code file
+ *   makes the assumption this is safe to avoid littering with preprocessor directives.
+ */
+
 #include "ch.h"
 #include "hal.h"
 
@@ -98,7 +108,7 @@ static const USBDescriptor *usb_get_descriptor_cb(USBDriver *usbp, uint8_t dtype
 #ifndef KEYBOARD_SHARED_EP
 /* keyboard endpoint state structure */
 static USBInEndpointState kbd_ep_state;
-/* keyboard endpoint initialization structure (IN) */
+/* keyboard endpoint initialization structure (IN) - see USBEndpointConfig comment at top of file */
 static const USBEndpointConfig kbd_ep_config = {
     USB_EP_MODE_TYPE_INTR, /* Interrupt EP */
     NULL,                  /* SETUP packet notification callback */
@@ -117,7 +127,7 @@ static const USBEndpointConfig kbd_ep_config = {
 /* mouse endpoint state structure */
 static USBInEndpointState mouse_ep_state;
 
-/* mouse endpoint initialization structure (IN) */
+/* mouse endpoint initialization structure (IN) - see USBEndpointConfig comment at top of file */
 static const USBEndpointConfig mouse_ep_config = {
     USB_EP_MODE_TYPE_INTR, /* Interrupt EP */
     NULL,                  /* SETUP packet notification callback */
@@ -136,7 +146,7 @@ static const USBEndpointConfig mouse_ep_config = {
 /* shared endpoint state structure */
 static USBInEndpointState shared_ep_state;
 
-/* shared endpoint initialization structure (IN) */
+/* shared endpoint initialization structure (IN) - see USBEndpointConfig comment at top of file */
 static const USBEndpointConfig shared_ep_config = {
     USB_EP_MODE_TYPE_INTR, /* Interrupt EP */
     NULL,                  /* SETUP packet notification callback */
@@ -164,6 +174,7 @@ typedef struct {
     QMKUSBDriver        driver;
 } usb_driver_config_t;
 
+/* Reusable initialization structure - see USBEndpointConfig comment at top of file */
 #define QMK_USB_DRIVER_CONFIG(stream, notification, fixedsize)                                  \
     {                                                                                           \
         .queue_capacity_in = stream##_IN_CAPACITY, .queue_capacity_out = stream##_OUT_CAPACITY, \

--- a/tmk_core/protocol/chibios/usb_main.c
+++ b/tmk_core/protocol/chibios/usb_main.c
@@ -19,7 +19,7 @@
  * Implementation notes:
  *
  * USBEndpointConfig - Configured using explicit order instead of struct member name.
- *   This is due to ChibiOS hal LDD differences, which is dependent on hardware,
+ *   This is due to ChibiOS hal LLD differences, which is dependent on hardware,
  *   "USBv1" devices have `ep_buffers` and "OTGv1" have `in_multiplier`.
  *   Given `USBv1/hal_usb_lld.h` marks the field as "not currently used" this code file
  *   makes the assumption this is safe to avoid littering with preprocessor directives.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
As per #4783 USBv1 devices have `ep_buffers` and OTGv1 have `in_multiplier`.

This PR aligns usb endpoint config as per rest of file, using explicit order instead of struct member name.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #4783

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
