### PR TITLE
instant60: Enable bootmagic lite to make eeprom reset easier

### DIFF
--- a/keyboards/cannonkeys/instant60/rules.mk
+++ b/keyboards/cannonkeys/instant60/rules.mk
@@ -44,7 +44,7 @@ VPATH += keyboards/cannonkeys/stm32f072
 SRC =	keyboard.c \
       led.c
 
-#BOOTMAGIC_ENABLE = yes	# Virtual DIP switch configuration
+BOOTMAGIC_ENABLE = lite	# Virtual DIP switch configuration
 MOUSEKEY_ENABLE = yes	# Mouse keys
 EXTRAKEY_ENABLE = yes	# Audio control and System control
 CONSOLE_ENABLE = yes	# Console for debug


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Add bootmagic lite to instant60 to make resetting eeprom easier
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
User was not able to reset their eeprom easily. Enable bootmagic lite to facilitate that.
@awkannan this seems to be a harmless and helpful change.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
