### PR TITLE
Automatically rebuild C keymap when JSON keymap is changed

### DIFF
--- a/build_json.mk
+++ b/build_json.mk
@@ -22,5 +22,5 @@ else ifneq ("$(wildcard $(MAIN_KEYMAP_PATH_1)/keymap.json)","")
 endif
 
 # Generate the keymap.c
-$(KEYBOARD_OUTPUT)/src/keymap.c:
+$(KEYBOARD_OUTPUT)/src/keymap.c: $(KEYMAP_JSON)
 	bin/qmk json-keymap --quiet --output $(KEYMAP_C) $(KEYMAP_JSON)


### PR DESCRIPTION
# Description

Without this change, you have to remove the generated C keymap if you want your updated JSON keymap to take effect. I'd consider that a bug, since the whole point of `make` is to do that work for you.

I tested this on my personal lily58 keymap and it worked---the keymap.c file was regenerated when my keymap.json file changed, and it left keymap.c alone when keymap.json wasn't changed. I also watched `make all` run for a few minutes and didn't see any errors that would have been caused by this change.

## Types of Changes

(I'm not sure what kind of change this is. Sorry if I filled this out wrong.)

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).