### PR TITLE
Fix compiling json files

### DIFF
--- a/lib/python/qmk/cli/compile.py
+++ b/lib/python/qmk/cli/compile.py
@@ -37,7 +37,7 @@ def compile(cli):
         cli.log.info('Creating {fg_cyan}%s{style_reset_all} keymap in {fg_cyan}%s', user_keymap['keymap'], keymap_path)
 
         # Compile the keymap
-        command = compile_configurator_json(cli.args.filename)
+        command = compile_configurator_json(user_keymap)
 
         cli.log.info('Wrote keymap to {fg_cyan}%s/%s/keymap.c', keymap_path, user_keymap['keymap'])
 

--- a/lib/python/qmk/cli/flash.py
+++ b/lib/python/qmk/cli/flash.py
@@ -4,6 +4,7 @@ You can compile a keymap already in the repo or using a QMK Configurator export.
 A bootloader must be specified.
 """
 import subprocess
+from argparse import FileType
 
 import qmk.path
 from milc import cli
@@ -28,7 +29,7 @@ def print_bootloader_help():
 
 
 @cli.argument('-bl', '--bootloader', default='flash', help='The flash command, corresponding to qmk\'s make options of bootloaders.')
-@cli.argument('filename', nargs='?', arg_only=True, help='The configurator export JSON to compile. Use this if you dont want to specify a keymap and keyboard.')
+@cli.argument('filename', nargs='?', arg_only=True, type=FileType('r'), help='The configurator export JSON to compile.')
 @cli.argument('-km', '--keymap', help='The keymap to build a firmware for. Use this if you dont have a configurator file. Ignored when a configurator file is supplied.')
 @cli.argument('-kb', '--keyboard', help='The keyboard to build a firmware for. Use this if you dont have a configurator file. Ignored when a configurator file is supplied.')
 @cli.argument('-b', '--bootloaders', action='store_true', help='List the available bootloaders.')
@@ -65,7 +66,7 @@ def flash(cli):
         cli.log.info('Creating {fg_cyan}%s{style_reset_all} keymap in {fg_cyan}%s', user_keymap['keymap'], keymap_path)
 
         # Convert the JSON into a C file and write it to disk.
-        command = compile_configurator_json(cli.args.filename, cli.args.bootloader)
+        command = compile_configurator_json(user_keymap, cli.args.bootloader)
 
         cli.log.info('Wrote keymap to {fg_cyan}%s/%s/keymap.c', keymap_path, user_keymap['keymap'])
 

--- a/lib/python/qmk/commands.py
+++ b/lib/python/qmk/commands.py
@@ -25,16 +25,14 @@ def create_make_command(keyboard, keymap, target=None):
     return ['make', ':'.join((keyboard, keymap, target))]
 
 
-def parse_configurator_json(configurator_filename):
+def parse_configurator_json(configurator_file):
     """Open and parse a configurator json export
     """
-    file = open(configurator_filename)
-    user_keymap = json.load(file)
-    file.close()
+    user_keymap = json.load(configurator_file)
     return user_keymap
 
 
-def compile_configurator_json(configurator_filename, bootloader=None):
+def compile_configurator_json(user_keymap, bootloader=None):
     """Convert a configurator export JSON file into a C file
 
     Args:
@@ -47,9 +45,6 @@ def compile_configurator_json(configurator_filename, bootloader=None):
     Returns:
         A command to run to compile and flash the C file.
     """
-    # Parse the configurator json
-    user_keymap = parse_configurator_json(configurator_filename)
-
     # Write the keymap C file
     qmk.keymap.write(user_keymap['keyboard'], user_keymap['keymap'], user_keymap['layout'], user_keymap['layers'])
 


### PR DESCRIPTION
Compiling JSON files by passing them into `qmk compile` was broken. This fixes it.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
