### PR TITLE
Readded lost pgm_read_word code to encoder array lookups

### DIFF
--- a/keyboards/rgbkb/sol/keymaps/default/keymap.c
+++ b/keyboards/rgbkb/sol/keymaps/default/keymap.c
@@ -234,12 +234,12 @@ void encoder_update_user(uint8_t index, bool clockwise) {
 #endif
   {
     uint8_t layer = biton32(layer_state);
-    uint16_t keycode = encoders[layer][index][clockwise];
+    uint16_t keycode = pgm_read_word(&encoders[layer][index][clockwise]);
     while (keycode == KC_TRANSPARENT && layer > 0)
     {
       layer--;
       if ((layer_state & (1 << layer)) != 0)
-          keycode = encoders[layer][index][clockwise];
+          keycode = pgm_read_word(&encoders[layer][index][clockwise]);
     }
     if (keycode != KC_TRANSPARENT)
       tap_code16(keycode);


### PR DESCRIPTION
## Description

Adding code that was lost at some point to the Sol Rev2 Encoder keymaps.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
