### PR TITLE
Fix 2U backspace key in ansi_blocker layout for GrayStudio Space65 keyboard

### DIFF
--- a/keyboards/gray_studio/space65/keymaps/default/keymap.c
+++ b/keyboards/gray_studio/space65/keymaps/default/keymap.c
@@ -22,20 +22,20 @@ enum custom_keycodes {
 };
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-[0] = LAYOUT( \
-        KC_ESC,  KC_1,    KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_BSPC, KC_DEL, \
-        KC_TAB,  KC_Q,    KC_W,   KC_E,   KC_R,   KC_T,   KC_Y,   KC_U,   KC_I,   KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS, KC_INS,          \
-        KC_CAPS, KC_A,    KC_S,   KC_D,   KC_F,   KC_G,   KC_H,   KC_J,   KC_K,   KC_L,    KC_SCLN, KC_QUOT, KC_ENT,  KC_PGUP,                  \
-        KC_LSFT, KC_LSFT, KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,   KC_N,   KC_M,   KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT, KC_UP,   KC_PGDN,         \
-        KC_LCTL, KC_LGUI, KC_LALT,                KC_SPC, KC_SPC, KC_SPC,         KC_RALT, MO(1),   KC_LEFT, KC_DOWN, KC_RGHT                   \
-    ),
-[1] = LAYOUT( \
-        KC_TRNS, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_TRNS, KC_TRNS, KC_MUTE, \
-        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_PSCR, KC_SLCK, KC_PAUS, KC_TRNS, KC_TRNS,          \
-        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_VOLU,                   \
-        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_PGUP, KC_VOLD,          \
-        KC_TRNS, KC_TRNS, KC_TRNS,                   KC_TRNS, KC_TRNS, KC_TRNS,          KC_TRNS, KC_TRNS, KC_HOME, KC_PGDN, KC_END                     \
-    ),
+  [0] = LAYOUT( \
+      KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_BSPC, KC_DEL,  \
+      KC_TAB,           KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS, KC_INS,  \
+      KC_CAPS,          KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_ENT,           KC_PGUP, \
+      KC_LSFT, KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT,          KC_UP,   KC_PGDN, \
+      KC_LCTL, KC_LGUI, KC_LALT,                   KC_SPC,  KC_SPC,  KC_SPC,           KC_RALT, MO(1),                     KC_LEFT, KC_DOWN, KC_RGHT  \
+  ),
+  [1] = LAYOUT( \
+      KC_TRNS, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_TRNS, KC_TRNS, KC_MUTE, \
+      KC_TRNS,          KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_PSCR, KC_SLCK, KC_PAUS, KC_TRNS, KC_TRNS, \
+      KC_TRNS,          KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,          KC_VOLU, \
+      KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,          KC_PGUP, KC_VOLD, \
+      KC_TRNS, KC_TRNS, KC_TRNS,                   KC_TRNS, KC_TRNS, KC_TRNS,          KC_TRNS, KC_TRNS,                   KC_HOME, KC_PGDN, KC_END   \
+  ),
 };
 
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {

--- a/keyboards/gray_studio/space65/space65.h
+++ b/keyboards/gray_studio/space65/space65.h
@@ -48,7 +48,7 @@
     k40, k41,      k43,                 k47,          k4A, k4B, k4D, k4E, k4F       \
 ) \
 { \
-    { k00, k01,   k02,   k03, k04,   k05,   k06,   k07, k08,   k09,   k0A, k0B, k0C,   KC_NO, k0E,   k0F }, \
+    { k00, k01,   k02,   k03, k04,   k05,   k06,   k07, k08,   k09,   k0A, k0B, k0C,   k0E,   KC_NO, k0F }, \
     { k10, KC_NO, k12,   k13, k14,   k15,   k16,   k17, k18,   k19,   k1A, k1B, k1C,   k1D,   k1E,   k1F }, \
     { k20, KC_NO, k22,   k23, k24,   k25,   k26,   k27, k28,   k29,   k2A, k2B, k2C,   k2D,   KC_NO, k2F }, \
     { k30, KC_NO, k32,   k33, k34,   k35,   k36,   k37, k38,   k39,   k3A, k3B, KC_NO, k3D,   k3E,   k3F }, \

--- a/keyboards/gray_studio/space65/space65.h
+++ b/keyboards/gray_studio/space65/space65.h
@@ -27,10 +27,10 @@
  */
 #define LAYOUT( \
     k00, k01, k02, k03, k04, k05, k06, k07, k08, k09, k0A, k0B, k0C, k0D, k0E, k0F, \
-    k10, k12, k13, k14, k15, k16, k17, k18, k19, k1A, k1B, k1C, k1D, k1E, k1F,      \
-    k20, k22, k23, k24, k25, k26, k27, k28, k29, k2A, k2B, k2C, k2D, k2F,           \
-    k30, k31, k32, k33, k34, k35, k36, k37, k38, k39, k3A, k3B, k3D, k3E, k3F,      \
-    k40, k41,      k43,      k45,      k47, k48,      k4A, k4B, k4D, k4E, k4F       \
+    k10,      k12, k13, k14, k15, k16, k17, k18, k19, k1A, k1B, k1C, k1D, k1E, k1F, \
+    k20,      k22, k23, k24, k25, k26, k27, k28, k29, k2A, k2B, k2C, k2D,      k2F, \
+    k30, k31, k32, k33, k34, k35, k36, k37, k38, k39, k3A, k3B, k3D,      k3E, k3F, \
+    k40, k41,      k43,      k45,      k47, k48,      k4A, k4B,      k4D, k4E, k4F  \
 ) \
 { \
     { k00, k01,   k02,   k03, k04,   k05, k06,   k07, k08, k09,   k0A, k0B, k0C,   k0D, k0E,   k0F }, \
@@ -41,14 +41,14 @@
 }
 
 #define LAYOUT_65_ansi_blocker( \
-    k00, k01, k02, k03, k04, k05, k06, k07, k08, k09, k0A, k0B, k0C,      k0E, k0F, \
-    k10, k12, k13, k14, k15, k16, k17, k18, k19, k1A, k1B, k1C, k1D, k1E, k1F,      \
-    k20, k22, k23, k24, k25, k26, k27, k28, k29, k2A, k2B, k2C, k2D, k2F,           \
-    k30,      k32, k33, k34, k35, k36, k37, k38, k39, k3A, k3B, k3D, k3E, k3F,      \
-    k40, k41,      k43,                 k47,          k4A, k4B, k4D, k4E, k4F       \
+    k00, k01, k02, k03, k04, k05, k06, k07, k08, k09, k0A, k0B, k0C, k0D,      k0F, \
+    k10,      k12, k13, k14, k15, k16, k17, k18, k19, k1A, k1B, k1C, k1D, k1E, k1F, \
+    k20,      k22, k23, k24, k25, k26, k27, k28, k29, k2A, k2B, k2C, k2D,      k2F, \
+    k30,      k32, k33, k34, k35, k36, k37, k38, k39, k3A, k3B, k3D,      k3E, k3F, \
+    k40, k41,      k43,                k47,           k4A, k4B,      k4D, k4E, k4F  \
 ) \
 { \
-    { k00, k01,   k02,   k03, k04,   k05,   k06,   k07, k08,   k09,   k0A, k0B, k0C,   k0E,   KC_NO, k0F }, \
+    { k00, k01,   k02,   k03, k04,   k05,   k06,   k07, k08,   k09,   k0A, k0B, k0C,   k0D,   KC_NO, k0F }, \
     { k10, KC_NO, k12,   k13, k14,   k15,   k16,   k17, k18,   k19,   k1A, k1B, k1C,   k1D,   k1E,   k1F }, \
     { k20, KC_NO, k22,   k23, k24,   k25,   k26,   k27, k28,   k29,   k2A, k2B, k2C,   k2D,   KC_NO, k2F }, \
     { k30, KC_NO, k32,   k33, k34,   k35,   k36,   k37, k38,   k39,   k3A, k3B, KC_NO, k3D,   k3E,   k3F }, \


### PR DESCRIPTION
When building firmware for the GrayStudio Space65 keyboard using the `LAYOUT_65_ansi_blocker` layout, in both the online configurator, as well as building the firmware locally, the key in the backspace position does not work.

## Description

Swap the location of the blank layout position.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
