### PR TITLE
Fix timer_elapsed() overflow issue for STM32F103 and other ChibiOS boards

### DIFF
--- a/quantum/process_keycode/process_space_cadet.c
+++ b/quantum/process_keycode/process_space_cadet.c
@@ -96,7 +96,7 @@ void perform_space_cadet(keyrecord_t *record, uint8_t holdMod, uint8_t tapMod, u
             register_mods(MOD_BIT(holdMod));
         }
     } else {
-        if (sc_last == holdMod && TIMER_DIFF_16(timer_read(), sc_timer) < TAPPING_TERM) {
+        if (sc_last == holdMod && timer_elapsed(sc_timer) < TAPPING_TERM) {
             if (holdMod != tapMod) {
                 if (IS_MOD(holdMod)) {
                     unregister_mods(MOD_BIT(holdMod));

--- a/quantum/process_keycode/process_space_cadet.c
+++ b/quantum/process_keycode/process_space_cadet.c
@@ -96,7 +96,7 @@ void perform_space_cadet(keyrecord_t *record, uint8_t holdMod, uint8_t tapMod, u
             register_mods(MOD_BIT(holdMod));
         }
     } else {
-        if (sc_last == holdMod && timer_elapsed(sc_timer) < TAPPING_TERM) {
+        if (sc_last == holdMod && TIMER_DIFF_16(timer_read(), sc_timer) < TAPPING_TERM) {
             if (holdMod != tapMod) {
                 if (IS_MOD(holdMod)) {
                     unregister_mods(MOD_BIT(holdMod));

--- a/tmk_core/common/chibios/timer.c
+++ b/tmk_core/common/chibios/timer.c
@@ -28,6 +28,10 @@ uint32_t timer_read32(void) {
     return current_time_ms;
 }
 
-uint16_t timer_elapsed(uint16_t last) { return timer_read() - last; }
+uint16_t timer_elapsed(uint16_t last) {
+    return TIMER_DIFF_16(timer_read(), last);
+}
 
-uint32_t timer_elapsed32(uint32_t last) { return timer_read32() - last; }
+uint32_t timer_elapsed32(uint32_t last) {
+    return TIMER_DIFF_32(timer_read32(), last);
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Space Cadet does not work on STM32F103 (BluePill). Specifically it works a couple of times, then it stops. There may be a deeper problem in timeout computation that I'm not able to fix (being a Java programmer). Basically after a couple of any key presses the timer_elapsed() starts returning large increments (the overflow variable in chibios/timer.c) gets stuck at 65535.
<!--- Describe your changes in detail here. -->
Adding TIMER_DIFF_16() to the comparison in perform_space_cadet() fixed the problem. I'm aware that it is probably not the "right" solution but it works for this case.

It is a simple change but I'm a little worried that I was not able to test the fix on any other architecture.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
