### PR TITLE
Fix FORCE_NKRO handling

### DIFF
--- a/quantum/process_keycode/process_magic.c
+++ b/quantum/process_keycode/process_magic.c
@@ -39,138 +39,140 @@ float cg_swap_song[][2] = CG_SWAP_SONG;
  */
 bool process_magic(uint16_t keycode, keyrecord_t *record) {
     // skip anything that isn't a keyup
-    if (!record->event.pressed) {
-        return true;
+    if (record->event.pressed) {
+        switch (keycode) {
+            case MAGIC_SWAP_CONTROL_CAPSLOCK ... MAGIC_TOGGLE_ALT_GUI:
+            case MAGIC_SWAP_LCTL_LGUI ... MAGIC_EE_HANDS_RIGHT:
+                /* keymap config */
+                keymap_config.raw = eeconfig_read_keymap();
+                switch (keycode) {
+                    case MAGIC_SWAP_CONTROL_CAPSLOCK:
+                        keymap_config.swap_control_capslock = true;
+                        break;
+                    case MAGIC_CAPSLOCK_TO_CONTROL:
+                        keymap_config.capslock_to_control = true;
+                        break;
+                    case MAGIC_SWAP_LALT_LGUI:
+                        keymap_config.swap_lalt_lgui = true;
+                        break;
+                    case MAGIC_SWAP_RALT_RGUI:
+                        keymap_config.swap_ralt_rgui = true;
+                        break;
+                    case MAGIC_SWAP_LCTL_LGUI:
+                        keymap_config.swap_lctl_lgui = true;
+                        break;
+                    case MAGIC_SWAP_RCTL_RGUI:
+                        keymap_config.swap_rctl_rgui = true;
+                        break;
+                    case MAGIC_NO_GUI:
+                        keymap_config.no_gui = true;
+                        break;
+                    case MAGIC_SWAP_GRAVE_ESC:
+                        keymap_config.swap_grave_esc = true;
+                        break;
+                    case MAGIC_SWAP_BACKSLASH_BACKSPACE:
+                        keymap_config.swap_backslash_backspace = true;
+                        break;
+                    case MAGIC_HOST_NKRO:
+                        clear_keyboard();  // clear first buffer to prevent stuck keys
+                        keymap_config.nkro = true;
+                        break;
+                    case MAGIC_SWAP_ALT_GUI:
+                        keymap_config.swap_lalt_lgui = keymap_config.swap_ralt_rgui = true;
+#ifdef AUDIO_ENABLE
+                        PLAY_SONG(ag_swap_song);
+#endif
+                        break;
+                    case MAGIC_SWAP_CTL_GUI:
+                        keymap_config.swap_lctl_lgui = keymap_config.swap_rctl_rgui = true;
+#ifdef AUDIO_ENABLE
+                        PLAY_SONG(cg_swap_song);
+#endif
+                        break;
+                    case MAGIC_UNSWAP_CONTROL_CAPSLOCK:
+                        keymap_config.swap_control_capslock = false;
+                        break;
+                    case MAGIC_UNCAPSLOCK_TO_CONTROL:
+                        keymap_config.capslock_to_control = false;
+                        break;
+                    case MAGIC_UNSWAP_LALT_LGUI:
+                        keymap_config.swap_lalt_lgui = false;
+                        break;
+                    case MAGIC_UNSWAP_RALT_RGUI:
+                        keymap_config.swap_ralt_rgui = false;
+                        break;
+                    case MAGIC_UNSWAP_LCTL_LGUI:
+                        keymap_config.swap_lctl_lgui = false;
+                        break;
+                    case MAGIC_UNSWAP_RCTL_RGUI:
+                        keymap_config.swap_rctl_rgui = false;
+                        break;
+                    case MAGIC_UNNO_GUI:
+                        keymap_config.no_gui = false;
+                        break;
+                    case MAGIC_UNSWAP_GRAVE_ESC:
+                        keymap_config.swap_grave_esc = false;
+                        break;
+                    case MAGIC_UNSWAP_BACKSLASH_BACKSPACE:
+                        keymap_config.swap_backslash_backspace = false;
+                        break;
+                    case MAGIC_UNHOST_NKRO:
+                        clear_keyboard();  // clear first buffer to prevent stuck keys
+                        keymap_config.nkro = false;
+                        break;
+                    case MAGIC_UNSWAP_ALT_GUI:
+                        keymap_config.swap_lalt_lgui = keymap_config.swap_ralt_rgui = false;
+#ifdef AUDIO_ENABLE
+                        PLAY_SONG(ag_norm_song);
+#endif
+                        break;
+                    case MAGIC_UNSWAP_CTL_GUI:
+                        keymap_config.swap_lctl_lgui = keymap_config.swap_rctl_rgui = false;
+#ifdef AUDIO_ENABLE
+                        PLAY_SONG(cg_norm_song);
+#endif
+                        break;
+                    case MAGIC_TOGGLE_ALT_GUI:
+                        keymap_config.swap_lalt_lgui = !keymap_config.swap_lalt_lgui;
+                        keymap_config.swap_ralt_rgui = keymap_config.swap_lalt_lgui;
+#ifdef AUDIO_ENABLE
+                        if (keymap_config.swap_ralt_rgui) {
+                            PLAY_SONG(ag_swap_song);
+                        } else {
+                            PLAY_SONG(ag_norm_song);
+                        }
+#endif
+                        break;
+                    case MAGIC_TOGGLE_CTL_GUI:
+                        keymap_config.swap_lctl_lgui = !keymap_config.swap_lctl_lgui;
+                        keymap_config.swap_rctl_rgui = keymap_config.swap_lctl_lgui;
+#ifdef AUDIO_ENABLE
+                        if (keymap_config.swap_rctl_rgui) {
+                            PLAY_SONG(cg_swap_song);
+                        } else {
+                            PLAY_SONG(cg_norm_song);
+                        }
+#endif
+                        break;
+                    case MAGIC_TOGGLE_NKRO:
+                        clear_keyboard();  // clear first buffer to prevent stuck keys
+                        keymap_config.nkro = !keymap_config.nkro;
+                        break;
+                    case MAGIC_EE_HANDS_LEFT:
+                        eeconfig_update_handedness(true);
+                        break;
+                    case MAGIC_EE_HANDS_RIGHT:
+                        eeconfig_update_handedness(false);
+                        break;
+                }
+
+                eeconfig_update_keymap(keymap_config.raw);
+                clear_keyboard();  // clear to prevent stuck keys
+
+                return false;
+        }
     }
 
-    /* keymap config */
-    keymap_config.raw = eeconfig_read_keymap();
-    switch (keycode) {
-        case MAGIC_SWAP_CONTROL_CAPSLOCK:
-            keymap_config.swap_control_capslock = true;
-            break;
-        case MAGIC_CAPSLOCK_TO_CONTROL:
-            keymap_config.capslock_to_control = true;
-            break;
-        case MAGIC_SWAP_LALT_LGUI:
-            keymap_config.swap_lalt_lgui = true;
-            break;
-        case MAGIC_SWAP_RALT_RGUI:
-            keymap_config.swap_ralt_rgui = true;
-            break;
-        case MAGIC_SWAP_LCTL_LGUI:
-            keymap_config.swap_lctl_lgui = true;
-            break;
-        case MAGIC_SWAP_RCTL_RGUI:
-            keymap_config.swap_rctl_rgui = true;
-            break;
-        case MAGIC_NO_GUI:
-            keymap_config.no_gui = true;
-            break;
-        case MAGIC_SWAP_GRAVE_ESC:
-            keymap_config.swap_grave_esc = true;
-            break;
-        case MAGIC_SWAP_BACKSLASH_BACKSPACE:
-            keymap_config.swap_backslash_backspace = true;
-            break;
-        case MAGIC_HOST_NKRO:
-            clear_keyboard();  // clear first buffer to prevent stuck keys
-            keymap_config.nkro = true;
-            break;
-        case MAGIC_SWAP_ALT_GUI:
-            keymap_config.swap_lalt_lgui = keymap_config.swap_ralt_rgui = true;
-#ifdef AUDIO_ENABLE
-            PLAY_SONG(ag_swap_song);
-#endif
-            break;
-        case MAGIC_SWAP_CTL_GUI:
-            keymap_config.swap_lctl_lgui = keymap_config.swap_rctl_rgui = true;
-#ifdef AUDIO_ENABLE
-            PLAY_SONG(cg_swap_song);
-#endif
-            break;
-        case MAGIC_UNSWAP_CONTROL_CAPSLOCK:
-            keymap_config.swap_control_capslock = false;
-            break;
-        case MAGIC_UNCAPSLOCK_TO_CONTROL:
-            keymap_config.capslock_to_control = false;
-            break;
-        case MAGIC_UNSWAP_LALT_LGUI:
-            keymap_config.swap_lalt_lgui = false;
-            break;
-        case MAGIC_UNSWAP_RALT_RGUI:
-            keymap_config.swap_ralt_rgui = false;
-            break;
-        case MAGIC_UNSWAP_LCTL_LGUI:
-            keymap_config.swap_lctl_lgui = false;
-            break;
-        case MAGIC_UNSWAP_RCTL_RGUI:
-            keymap_config.swap_rctl_rgui = false;
-            break;
-        case MAGIC_UNNO_GUI:
-            keymap_config.no_gui = false;
-            break;
-        case MAGIC_UNSWAP_GRAVE_ESC:
-            keymap_config.swap_grave_esc = false;
-            break;
-        case MAGIC_UNSWAP_BACKSLASH_BACKSPACE:
-            keymap_config.swap_backslash_backspace = false;
-            break;
-        case MAGIC_UNHOST_NKRO:
-            clear_keyboard();  // clear first buffer to prevent stuck keys
-            keymap_config.nkro = false;
-            break;
-        case MAGIC_UNSWAP_ALT_GUI:
-            keymap_config.swap_lalt_lgui = keymap_config.swap_ralt_rgui = false;
-#ifdef AUDIO_ENABLE
-            PLAY_SONG(ag_norm_song);
-#endif
-            break;
-        case MAGIC_UNSWAP_CTL_GUI:
-            keymap_config.swap_lctl_lgui = keymap_config.swap_rctl_rgui = false;
-#ifdef AUDIO_ENABLE
-            PLAY_SONG(cg_norm_song);
-#endif
-            break;
-        case MAGIC_TOGGLE_ALT_GUI:
-            keymap_config.swap_lalt_lgui = !keymap_config.swap_lalt_lgui;
-            keymap_config.swap_ralt_rgui = keymap_config.swap_lalt_lgui;
-#ifdef AUDIO_ENABLE
-            if (keymap_config.swap_ralt_rgui) {
-                PLAY_SONG(ag_swap_song);
-            } else {
-                PLAY_SONG(ag_norm_song);
-            }
-#endif
-            break;
-        case MAGIC_TOGGLE_CTL_GUI:
-            keymap_config.swap_lctl_lgui = !keymap_config.swap_lctl_lgui;
-            keymap_config.swap_rctl_rgui = keymap_config.swap_lctl_lgui;
-#ifdef AUDIO_ENABLE
-            if (keymap_config.swap_rctl_rgui) {
-                PLAY_SONG(cg_swap_song);
-            } else {
-                PLAY_SONG(cg_norm_song);
-            }
-#endif
-            break;
-        case MAGIC_TOGGLE_NKRO:
-            clear_keyboard();  // clear first buffer to prevent stuck keys
-            keymap_config.nkro = !keymap_config.nkro;
-            break;
-        case MAGIC_EE_HANDS_LEFT:
-            eeconfig_update_handedness(true);
-            break;
-        case MAGIC_EE_HANDS_RIGHT:
-            eeconfig_update_handedness(false);
-            break;
-        default:
-            // Not a magic keycode so continue processing
-            return true;
-    }
-
-    eeconfig_update_keymap(keymap_config.raw);
-    clear_keyboard(); // clear to prevent stuck keys
-
-    return false;
+    // Not a magic keycode so continue processing
+    return true;
 }

--- a/tmk_core/common/keyboard.c
+++ b/tmk_core/common/keyboard.c
@@ -254,6 +254,7 @@ void keyboard_init(void) {
 #endif
 #if defined(NKRO_ENABLE) && defined(FORCE_NKRO)
     keymap_config.nkro = 1;
+    eeconfig_update_keymap(keymap_config.raw);
 #endif
     keyboard_post_init_kb(); /* Always keep this last */
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Fixed Issues:
1. Fix force nkro overwriting on matrix scan
    * Introduced with #7512
    * `eeconfig_read_keymap()` is called on every keycode process, the previous nkro value in memory is lost.
    * could be fixed with just number 2 below
      * reverted code closer to what it was before #7512 to avoid any other behaviour changes from uncaptured logic

2. Fix first magic keycode overwriting force nkro
    * existing issue
    * when NKRO_FORCE, `tmk_core/common/keyboard.c` sets nkro value, which when the first magic keycode triggers `eeconfig_read_keymap()`, the previous nkro value in memory is lost.
    * changed to persist nkro config
      * this should be safe as eeprom will only write if value is different?
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
