### PR TITLE
mitosis: rewrite led #defines to make pins configurable

### DIFF
--- a/keyboards/mitosis/keymaps/datagrok/config.h
+++ b/keyboards/mitosis/keymaps/datagrok/config.h
@@ -1,5 +1,8 @@
-#ifndef CONFIG_USER_H
-#define CONFIG_USER_H
+#pragma once
+
+#ifdef MITOSIS_DATAGROK_I2CHACK
+#define LED_PIN_GREEN D4
+#endif
 
 #ifdef MITOSIS_DATAGROK_SLOWUART
 // This is the highest possible baud rate that a pro micro clocked at 8Mhz can
@@ -37,8 +40,6 @@
 #define AUDIO_VOICES
 #define AUDIO_CLICKY
 #define C6_AUDIO
-#endif
-
 #endif
 
 #define LAYOUT_bottomspace(                                           \

--- a/keyboards/mitosis/mitosis.c
+++ b/keyboards/mitosis/mitosis.c
@@ -5,11 +5,11 @@ void uart_init(void) {
 }
 
 void led_init(void) {
-  led_init_pin(red); led(red, off);
-  led_init_pin(green); led(green, off);
-  led_init_pin(blue); led(blue, off);
-  led_init_pin(tx); led(tx, off);
-  led_init_pin(rx); led(rx, off);
+  LED_INIT_PIN(RED); LED(RED, OFF);
+  LED_INIT_PIN(GREEN); LED(GREEN, OFF);
+  LED_INIT_PIN(BLUE); LED(BLUE, OFF);
+  LED_INIT_PIN(TX); LED(TX, OFF);
+  LED_INIT_PIN(RX); LED(RX, OFF);
 }
 
 void matrix_init_kb(void) {

--- a/keyboards/mitosis/mitosis.c
+++ b/keyboards/mitosis/mitosis.c
@@ -5,10 +5,11 @@ void uart_init(void) {
 }
 
 void led_init(void) {
-	DDRD  |= (1<<1); // Pin to green, set as output
-	PORTD |= (1<<1); // Turn it off
-	DDRF  |= (1<<4) | (1<<5); // Pins to red and blue, set as output
-	PORTF |= (1<<4) | (1<<5); // Turn them off
+  led_init_pin(red); led(red, off);
+  led_init_pin(green); led(green, off);
+  led_init_pin(blue); led(blue, off);
+  led_init_pin(tx); led(tx, off);
+  led_init_pin(rx); led(rx, off);
 }
 
 void matrix_init_kb(void) {

--- a/keyboards/mitosis/mitosis.h
+++ b/keyboards/mitosis/mitosis.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "quantum.h"
 
-// port,pin assignments for LED indicators
+/* port,pin assignments for LED indicators */
 #define led_red   F5
 #ifdef MITOSIS_DATAGROK_I2CHACK
 #define led_green D4
@@ -12,16 +12,16 @@
 #define led_tx    D5
 #define led_rx    B0
 
-// led_init_pin(name): sets the pin for the named LED to output mode
+/* led_init_pin(name): sets the pin for the named LED to output mode */
 #define _led_init_pin(pin) setPinOutput(pin)
 #define led_init_pin(name) _led_init_pin(led_ ## name)
 
-// led(name, state): sets the named LED to state, where state is on or off
+/* led(name, state): sets the named LED to state, where state is on or off */
 #define _led_off(pin) writePinHigh(pin)
 #define _led_on(pin) writePinLow(pin)
 #define led(name, state) _led_ ## state (led_ ## name)
 
-// convenience macros to set the RGB LED to a specific color
+/* convenience macros to set the RGB LED to a specific color */
 #define set_led_off     led(red, off); led(green, off); led(blue, off)
 #define set_led_red     led(red, on);  led(green, off); led(blue, off)
 #define set_led_blue    led(red, off); led(green, off); led(blue, on)
@@ -31,9 +31,11 @@
 #define set_led_cyan    led(red, off); led(green, on);  led(blue, on)
 #define set_led_white   led(red, on);  led(green, on);  led(blue, on)
 
-// This a shortcut to help you visually see your layout.
-// The first section contains all of the arguments
-// The second converts the arguments into a two-dimensional array
+/*
+  This a shortcut to help you visually see your layout.
+  The first section contains all of the arguments
+  The second converts the arguments into a two-dimensional array
+*/
 #define LAYOUT( \
   k00, k01, k02, k03, k04,      k05, k06, k07, k08, k09, \
   k10, k11, k12, k13, k14,      k15, k16, k17, k18, k19, \

--- a/keyboards/mitosis/mitosis.h
+++ b/keyboards/mitosis/mitosis.h
@@ -1,29 +1,25 @@
-#ifndef MITOSIS_H
-#define MITOSIS_H
-
+#pragma once
 #include "quantum.h"
 
 // port,pin assignments for LED indicators
-#define led_red   F, 5
+#define led_red   F5
 #ifdef MITOSIS_DATAGROK_I2CHACK
-#define led_green D, 4
+#define led_green D4
 #else
-#define led_green D, 1
+#define led_green D1
 #endif
-#define led_blue  F, 4
-#define led_tx    D, 5
-#define led_rx    B, 0
+#define led_blue  F4
+#define led_tx    D5
+#define led_rx    B0
 
 // led_init_pin(name): sets the pin for the named LED to output mode
-#define __led_init_pin(port, pin) DDR ## port |= (1<<pin)
-#define _led_init_pin(portpin) __led_init_pin(portpin)
+#define _led_init_pin(pin) setPinOutput(pin)
 #define led_init_pin(name) _led_init_pin(led_ ## name)
 
 // led(name, state): sets the named LED to state, where state is on or off
-#define _led_off(port, pin) PORT ## port |= (1<<pin)
-#define _led_on(port, pin) PORT ## port &= ~(1<<pin)
-#define _led(portpin, state) _led_ ## state (portpin)
-#define led(name, state) _led(led_ ## name, state)
+#define _led_off(pin) writePinHigh(pin)
+#define _led_on(pin) writePinLow(pin)
+#define led(name, state) _led_ ## state (led_ ## name)
 
 // convenience macros to set the RGB LED to a specific color
 #define set_led_off     led(red, off); led(green, off); led(blue, off)
@@ -52,4 +48,3 @@
     { KC_NO, k31, k32, k33, k34, k35, k36, k37, k38, KC_NO }, \
     { KC_NO, k41, k42, k43, k44, k45, k46, k47, k48, KC_NO }  \
   }
-#endif

--- a/keyboards/mitosis/mitosis.h
+++ b/keyboards/mitosis/mitosis.h
@@ -3,45 +3,37 @@
 
 #include "quantum.h"
 
-#define red_led_off   PORTF |= (1<<5)
-#define red_led_on    PORTF &= ~(1<<5)
-#define blu_led_off   PORTF |= (1<<4)
-#define blu_led_on    PORTF &= ~(1<<4)
-#define grn_led_off   PORTD |= (1<<1)
-#define grn_led_on    PORTD &= ~(1<<1)
+// port,pin assignments for LED indicators
+#define led_red   F, 5
+#ifdef MITOSIS_DATAGROK_I2CHACK
+#define led_green D, 4
+#else
+#define led_green D, 1
+#endif
+#define led_blue  F, 4
+#define led_tx    D, 5
+#define led_rx    B, 0
 
-#define set_led_off     red_led_off; grn_led_off; blu_led_off
-#define set_led_red     red_led_on;  grn_led_off; blu_led_off
-#define set_led_blue    red_led_off; grn_led_off; blu_led_on
-#define set_led_green   red_led_off; grn_led_on;  blu_led_off
-#define set_led_yellow  red_led_on;  grn_led_on;  blu_led_off
-#define set_led_magenta red_led_on;  grn_led_off; blu_led_on
-#define set_led_cyan    red_led_off; grn_led_on;  blu_led_on
-#define set_led_white   red_led_on;  grn_led_on;  blu_led_on
+// led_init_pin(name): sets the pin for the named LED to output mode
+#define __led_init_pin(port, pin) DDR ## port |= (1<<pin)
+#define _led_init_pin(portpin) __led_init_pin(portpin)
+#define led_init_pin(name) _led_init_pin(led_ ## name)
 
-/*
-#define LED_B 5
-#define LED_R 6
-#define LED_G 7
+// led(name, state): sets the named LED to state, where state is on or off
+#define _led_off(port, pin) PORT ## port |= (1<<pin)
+#define _led_on(port, pin) PORT ## port &= ~(1<<pin)
+#define _led(portpin, state) _led_ ## state (portpin)
+#define led(name, state) _led(led_ ## name, state)
 
-#define all_leds_off PORTF &= ~(1<<LED_B) & ~(1<<LED_R) & ~(1<<LED_G)
-
-#define red_led_on   PORTF |= (1<<LED_R)
-#define red_led_off  PORTF &= ~(1<<LED_R)
-#define grn_led_on   PORTF |= (1<<LED_G)
-#define grn_led_off  PORTF &= ~(1<<LED_G)
-#define blu_led_on   PORTF |= (1<<LED_B)
-#define blu_led_off  PORTF &= ~(1<<LED_B)
-
-#define set_led_off     PORTF &= ~(1<<LED_B) & ~(1<<LED_R) & ~(1<<LED_G)
-#define set_led_red     PORTF = PORTF & ~(1<<LED_B) & ~(1<<LED_G) | (1<<LED_R)
-#define set_led_blue    PORTF = PORTF & ~(1<<LED_G) & ~(1<<LED_R) | (1<<LED_B)
-#define set_led_green   PORTF = PORTF & ~(1<<LED_B) & ~(1<<LED_R) | (1<<LED_G)
-#define set_led_yellow  PORTF = PORTF & ~(1<<LED_B) | (1<<LED_R) | (1<<LED_G)
-#define set_led_magenta PORTF = PORTF & ~(1<<LED_G) | (1<<LED_R) | (1<<LED_B)
-#define set_led_cyan    PORTF = PORTF & ~(1<<LED_R) | (1<<LED_B) | (1<<LED_G)
-#define set_led_white   PORTF |= (1<<LED_B) | (1<<LED_R) | (1<<LED_G)
-*/
+// convenience macros to set the RGB LED to a specific color
+#define set_led_off     led(red, off); led(green, off); led(blue, off)
+#define set_led_red     led(red, on);  led(green, off); led(blue, off)
+#define set_led_blue    led(red, off); led(green, off); led(blue, on)
+#define set_led_green   led(red, off); led(green, on);  led(blue, off)
+#define set_led_yellow  led(red, on);  led(green, on);  led(blue, off)
+#define set_led_magenta led(red, on);  led(green, off); led(blue, on)
+#define set_led_cyan    led(red, off); led(green, on);  led(blue, on)
+#define set_led_white   led(red, on);  led(green, on);  led(blue, on)
 
 // This a shortcut to help you visually see your layout.
 // The first section contains all of the arguments

--- a/keyboards/mitosis/mitosis.h
+++ b/keyboards/mitosis/mitosis.h
@@ -1,35 +1,45 @@
 #pragma once
 #include "quantum.h"
 
-/* port,pin assignments for LED indicators */
-#define led_red   F5
-#ifdef MITOSIS_DATAGROK_I2CHACK
-#define led_green D4
-#else
-#define led_green D1
+/*
+  port and pin assignments for LED indicators. if you modify your hardware to
+  reroute some pins (for example, to allow use of the i2c pins) then you can
+  override these assignments in your own keymap.
+*/
+#ifndef LED_PIN_RED
+#    define LED_PIN_RED   F5
 #endif
-#define led_blue  F4
-#define led_tx    D5
-#define led_rx    B0
+#ifndef LED_PIN_GREEN
+#    define LED_PIN_GREEN D1
+#endif
+#ifndef LED_PIN_BLUE
+#    define LED_PIN_BLUE  F4
+#endif
+#ifndef LED_PIN_TX
+#    define LED_PIN_TX    D5
+#endif
+#ifndef LED_PIN_RX
+#    define LED_PIN_RX    B0
+#endif
 
-/* led_init_pin(name): sets the pin for the named LED to output mode */
-#define _led_init_pin(pin) setPinOutput(pin)
-#define led_init_pin(name) _led_init_pin(led_ ## name)
+/* LED_INIT_PIN(name): sets the pin for the named LED to output mode */
+#define _LED_INIT_PIN(pin) setPinOutput(pin)
+#define LED_INIT_PIN(name) _LED_INIT_PIN(LED_PIN_ ## name)
 
-/* led(name, state): sets the named LED to state, where state is on or off */
-#define _led_off(pin) writePinHigh(pin)
-#define _led_on(pin) writePinLow(pin)
-#define led(name, state) _led_ ## state (led_ ## name)
+/* LED(name, state): sets the named LED to state, where state is on or off */
+#define _LED_OFF(pin) writePinHigh(pin)
+#define _LED_ON(pin) writePinLow(pin)
+#define LED(name, state) _LED_ ## state (LED_PIN_ ## name)
 
 /* convenience macros to set the RGB LED to a specific color */
-#define set_led_off     led(red, off); led(green, off); led(blue, off)
-#define set_led_red     led(red, on);  led(green, off); led(blue, off)
-#define set_led_blue    led(red, off); led(green, off); led(blue, on)
-#define set_led_green   led(red, off); led(green, on);  led(blue, off)
-#define set_led_yellow  led(red, on);  led(green, on);  led(blue, off)
-#define set_led_magenta led(red, on);  led(green, off); led(blue, on)
-#define set_led_cyan    led(red, off); led(green, on);  led(blue, on)
-#define set_led_white   led(red, on);  led(green, on);  led(blue, on)
+#define set_led_off     LED(RED, OFF); LED(GREEN, OFF); LED(BLUE, OFF)
+#define set_led_red     LED(RED, ON);  LED(GREEN, OFF); LED(BLUE, OFF)
+#define set_led_blue    LED(RED, OFF); LED(GREEN, OFF); LED(BLUE, ON)
+#define set_led_green   LED(RED, OFF); LED(GREEN, ON);  LED(BLUE, OFF)
+#define set_led_yellow  LED(RED, ON);  LED(GREEN, ON);  LED(BLUE, OFF)
+#define set_led_magenta LED(RED, ON);  LED(GREEN, OFF); LED(BLUE, ON)
+#define set_led_cyan    LED(RED, OFF); LED(GREEN, ON);  LED(BLUE, ON)
+#define set_led_white   LED(RED, ON);  LED(GREEN, ON);  LED(BLUE, ON)
 
 /*
   This a shortcut to help you visually see your layout.


### PR DESCRIPTION


## Description

I rewrote the LED convenience macros such that they could be configured by an initial set of macros that define the port/pin configuration for the LEDs. This makes it easier to use my hardware where I have rerouted one of the pins.

The resulting macros have the same names and effects as before my rewrite, so all the keymaps that rely on them should continue to work unmodified. They compile but I have not tested each one on actual hardware.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
