### PR TITLE
core: Fix variable init in keymap_common.c

### DIFF
--- a/quantum/keymap_common.c
+++ b/quantum/keymap_common.c
@@ -48,7 +48,7 @@ action_t action_for_key(uint8_t layer, keypos_t key) {
     // keycode remapping
     keycode = keycode_config(keycode);
 
-    action_t action;
+    action_t action = {};
     uint8_t  action_layer, when, mod;
 
     switch (keycode) {


### PR DESCRIPTION
tmk backport from tmk/tmk_keyboard@325a99acd9c81f60519b6e594b2bf5d1e478ac56

## Types of Changes
- [x] Core
