### PR TITLE
Adding Backlight on the handwired AEK64 keyboard

### DIFF
--- a/keyboards/handwired/aek64/config.h
+++ b/keyboards/handwired/aek64/config.h
@@ -27,26 +27,20 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define PRODUCT         AEK64
 #define DESCRIPTION     QMK keyboard firmware for AEK64 handwired
 
+/* Define the backlight */
+/*#define BACKLIGHT_ON_STATE 1*/
+
 /* key matrix size */
 #define MATRIX_ROWS 5
 #define MATRIX_COLS 14
 
 // Originally made for a Teensy 2++
-#define MATRIX_COL_PINS { F0, E6, E7, B0, B1, B2, B3, B4, B5, B6, B7, D0, D1, D2 }
+#define MATRIX_COL_PINS { F0, E6, E7, B0, B1, B2, B3, B4, B5, B6, D3, D0, D1, D2 }
 #define MATRIX_ROW_PINS { E0, E1, C0, C1, C2 }
 #define UNUSED_PINS
 
-/* define if matrix has ghost */
-//#define MATRIX_HAS_GHOST
-
 /* Set 0 if debouncing isn't needed */
 #define DEBOUNCE    5
-
-/* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
-// #define LOCKING_SUPPORT_ENABLE
-
-/* Locking resynchronize hack */
-//#define LOCKING_RESYNC_ENABLE
 
 /* Enable the space-cadet options */
 #define RSPC_KEYS KC_RSFT, KC_TRNS, KC_PGUP
@@ -59,20 +53,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define COMBO_COUNT 1
 
-/*
- * Feature disable options
- *  These options are also useful to firmware size reduction.
- */
-
-/* disable debug print */
-//#define NO_DEBUG
-
-/* disable print */
-//#define NO_PRINT
-
-/* disable action features */
-//#define NO_ACTION_LAYER
-//#define NO_ACTION_TAPPING
-//#define NO_ACTION_ONESHOT
-//#define NO_ACTION_MACRO
-//#define NO_ACTION_FUNCTION
+#define BACKLIGHT_PIN B7
+#define BACKLIGHT_BREATHING
+#define BACKLIGHT_LEVELS 5

--- a/keyboards/handwired/aek64/keymaps/4sstylz/keycodes.h
+++ b/keyboards/handwired/aek64/keymaps/4sstylz/keycodes.h
@@ -1,0 +1,85 @@
+/*
+ *           DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+ *                    Version 2, December 2004
+ *
+ * Copyright (C) 2019 4sStylZ <4sstylz@protonmail.ch>
+ *
+ * Everyone is permitted to copy and distribute verbatim or modified
+ * copies of this license document, and changing it is allowed as long
+ * as the name is changed.
+ *
+ *            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+ *   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+ *
+ *  0. You just DO WHAT THE FUCK YOU WANT TO.
+ */
+#include QMK_KEYBOARD_H
+
+/**
+ * Macro for selecting all the text in the document.
+ * Usual shortcut : Ctrl+A.
+ *
+ * @param keyrecord_t *record
+ *
+ * @return void
+ */
+void select_all(keyrecord_t *record) {
+    if (record->event.pressed) {
+        register_code(KC_LCTL);
+        tap_code(KC_A);
+        unregister_code(KC_LCTL);
+    }
+}
+
+/**
+ * Macro for selecting the current row.
+ *
+ * @param keyrecord_t *record
+ *
+ * @return void
+ */
+void select_row(keyrecord_t *record) {
+    if (record->event.pressed) {
+        tap_code(KC_HOME);
+        register_code(KC_LSFT);
+        tap_code(KC_END);
+        unregister_code(KC_LSFT);
+    }
+}
+
+/**
+ * Macro for selecting the current word.
+ * Usage : You need to have the cursor into the word or directly at the right.
+ *
+ *
+ * Usual shortcut : Ctrl+A.
+ *
+ * @param keyrecord_t *record
+ *
+ * @return void
+ */
+void select_word(keyrecord_t *record) {
+    if (record->event.pressed) {
+        register_code(KC_LCTL);
+        tap_code(KC_LEFT);
+        register_code(KC_LSFT);
+        tap_code(KC_RIGHT);
+        unregister_code(KC_LSFT);
+        unregister_code(KC_LCTL);
+    }
+}
+
+/**
+ * Macro for inserting two 0 with keypad.
+ * Be carefull to have the keypad lock enabled
+ *
+ * @param keyrecord_t *record
+ *
+ * @return void
+ */
+void insert_00(keyrecord_t *record) {
+    if (record->event.pressed) {
+        tap_code(KC_P0);
+        tap_code(KC_P0);
+    }
+}

--- a/keyboards/handwired/aek64/keymaps/4sstylz/keymap.c
+++ b/keyboards/handwired/aek64/keymaps/4sstylz/keymap.c
@@ -18,7 +18,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   /* 0: qwerty
    * ┌──────┬──────┬──────┬──────┬──────┬──────┬──────┬──────┬──────┬──────┬──────┬──────┬──────┬─────────────┐
    * │ ` Esc│   1  │   2  │   3  │   4  │   5  │   6  │   7  │   8  │   9  │   0  │  -   │  =   │ Bksp        │
-   * ├─────────────┼──────┼──────┼──────┼──────┼──────┼──────┼──────┼──────┼──────┼──────┼──────┼─────┬───────┤
+   * ├──────┴──────┼──────┼──────┼──────┼──────┼──────┼──────┼──────┼──────┼──────┼──────┼──────┼─────┬───────┤
    * │ Tab         │   Q  │   W  │   E  │   R  │   T  │   Y  │   U  │   I  │   O  │   P  │  [   │  ]  │       │
    * ├─────────────┼──────┼──────┼──────┼──────┼──────┼──────┼──────┼──────┼──────┼──────┼──────┼─────┴┐ Enter│
    * │ Layer 2     │   A  │   S  │   D  │   F  │   G  │   H  │   J  │   K  │   L  │   ;  │   '  │   #  │      │
@@ -40,14 +40,14 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     KC_TAB         , KC_Q   , KC_W   , KC_E , KC_R , KC_T , KC_Y  , KC_U , KC_I , KC_O   , KC_P   , KC_LBRC, KC_RBRC,
     MO(1)          , KC_A   , KC_S   , KC_D , KC_F , KC_G , KC_H  , KC_J , KC_K , KC_L   , KC_SCLN, KC_QUOT, KC_NUHS, KC_ENT ,
     KC_LSPO        , KC_NUBS, KC_Z   , KC_X , KC_C , KC_V , KC_B  , KC_N , KC_M , KC_COMM, KC_DOT , KC_SLSH, KC_RSPC         ,
-    KC_LCPO        , KC_LALT, ALT_TAB,                      KC_SPC,                                 KC_LGUI, KC_RALT, KC_RCPC
+    KC_LCPO        , KC_LGUI, KC_LALT,                      KC_SPC,                                 KC_APP , KC_RALT, KC_RCPC
   ),
 
   /* 1: second layer for media keys and many advanced features ç
    * ┌──────┬──────┬──────┬──────┬──────┬──────┬──────┬──────┬──────┬──────┬──────┬──────┬──────┬─────────────┐
    * │Alt F4│  F1  │  F2  │  F3  │  F4  │  F5  │  F6  │  F7  │  F8  │  F9  │  F10 │  F11 │  F12 │             │
-   * ├──────┼──────┼──────┼──────┼──────┼──────┼──────┼──────┼──────┼──────┼──────┼──────┼──────┼─────┬───────┤
-   * │      │      │      │PrtScn│ Brt+ │ Brt- │Ctrl A│ Home │  Up  │  End │   ‽   │  ↑      │  ⸮    │     │       │
+   * ├──────┴──────┼──────┼──────┼──────┼──────┼──────┼──────┼──────┼──────┼──────┼──────┼──────┼─────┬───────┤
+   * │             │      │PrtScn│ Brt+ │ Brt- │Ctrl A│ Home │  Up  │  End │   ‽   │  ↑      │  ⸮    │     │       │
    * ├─────────────┼──────┼──────┼──────┼──────┼──────┼──────┼──────┼──────┼──────┼──────┼──────┼─────┴┐      │
    * │             │ Cut  │ Copy │Paste │ Del  │ Del  │ Left │ Down │Right │  ←   │  ↓   │  →   │      │      │
    * ├──────┬──────┼──────┼──────┼──────┼──────┼──────┼──────┼──────┼──────┼──────┼──────┼──────┴──────┴──────┤
@@ -57,10 +57,10 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    * └──────┴──────┴──────┴──────────────────────────────────────────────────────────────┴──────┴──────┴──────┘
    */
   [1] = LAYOUT( \
-    LALT(KC_F4), KC_F1     , KC_F2       , KC_F3       , KC_F4       , KC_F5  , KC_F6     , KC_F7  , KC_F8  , KC_F9   , KC_F10     , KC_F11    , KC_F12    , _______,
+    LALT(KC_F4), KC_F1     , KC_F2       , KC_F3       , KC_F4       , KC_F5  , KC_F6     , KC_F7  , KC_F8  , KC_F9   , KC_F10     , KC_F11    , KC_F12    , KC_DEL ,
     _______    , _______   , _______     , KC_PSCR     , KC_BRIU     , KC_BRID, LCTL(KC_A), KC_HOME, KC_UP  , KC_END  , UC(0x203D) , UC(0x8593), UC(0x2E2E),
     _______    , _______   , LSFT(KC_DEL), LCTL(KC_INS), LSFT(KC_INS), KC_DEL , KC_DEL    , KC_LEFT, KC_DOWN, KC_RIGHT, UC(0x8592) , UC(0x8595), UC(0x8594), _______,
-    _______    , _______   , KC_MUTE     , KC_VOLD     , KC_VOLU     , _______, _______   , _______, _______, _______ , _______    , RESET     , _______            ,
+    _______    , _______   , KC_MUTE     , KC_VOLD     , KC_VOLU     , BL_TOGG, BL_STEP   , BL_BRTG, _______, _______ , _______    , RESET     , _______            ,
     _______    , _______   , _______     ,                             _______,                                                      _______   , _______   , _______
   )
 };

--- a/keyboards/handwired/aek64/keymaps/4sstylz/keymap.c
+++ b/keyboards/handwired/aek64/keymaps/4sstylz/keymap.c
@@ -1,4 +1,5 @@
 #include QMK_KEYBOARD_H
+#include <keycodes.h>
 
 // Implement Super-alt↯tab
 // See https://docs.qmk.fm/#/feature_macros?id=super-alt↯tab
@@ -7,7 +8,10 @@ uint16_t alt_tab_timer = 0;
 
 // Defining all the custom keycodes.
 enum custom_keycodes {
-  ALT_TAB = SAFE_RANGE
+  ALT_TAB = SAFE_RANGE,
+  SLC_ROW,
+  SLC_ALL,
+  SLC_WRD
 };
 
 const uint16_t PROGMEM lock_combo[] = {KC_J, KC_K, KC_L, KC_SCLN, COMBO_END};
@@ -57,11 +61,11 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    * └──────┴──────┴──────┴──────────────────────────────────────────────────────────────┴──────┴──────┴──────┘
    */
   [1] = LAYOUT( \
-    LALT(KC_F4), KC_F1     , KC_F2       , KC_F3       , KC_F4       , KC_F5  , KC_F6     , KC_F7  , KC_F8  , KC_F9   , KC_F10     , KC_F11    , KC_F12    , KC_DEL ,
-    _______    , _______   , _______     , KC_PSCR     , KC_BRIU     , KC_BRID, LCTL(KC_A), KC_HOME, KC_UP  , KC_END  , UC(0x203D) , UC(0x8593), UC(0x2E2E),
-    _______    , _______   , LSFT(KC_DEL), LCTL(KC_INS), LSFT(KC_INS), KC_DEL , KC_DEL    , KC_LEFT, KC_DOWN, KC_RIGHT, UC(0x8592) , UC(0x8595), UC(0x8594), _______,
-    _______    , _______   , KC_MUTE     , KC_VOLD     , KC_VOLU     , BL_TOGG, BL_STEP   , BL_BRTG, _______, _______ , _______    , RESET     , _______            ,
-    _______    , _______   , _______     ,                             _______,                                                      _______   , _______   , _______
+    LALT(KC_F4), KC_F1     , KC_F2       , KC_F3       , KC_F4       , KC_F5  , KC_F6  , KC_F7  , KC_F8  , KC_F9   , KC_F10 , KC_F11    , KC_F12 , KC_DEL ,
+    _______    , _______   , SLC_ALL     , SLC_ROW     , SLC_WRD     , _______, KC_BSPC, KC_HOME, KC_UP  , KC_END  , KC_BRIU, KC_BRID   , KC_PSCR,
+    _______    , _______   , LSFT(KC_DEL), LCTL(KC_INS), LSFT(KC_INS), KC_DEL , KC_ENT , KC_LEFT, KC_DOWN, KC_RIGHT, BL_TOGG, BL_STEP   , BL_BRTG, _______,
+    _______    , _______   , KC_MUTE     , KC_VOLD     , KC_VOLU     , ALT_TAB, _______, _______, _______, _______ , _______, RESET     , _______         ,
+    _______    , _______   , _______     ,                             _______,                                               _______   , _______, _______
   )
 };
 
@@ -87,6 +91,15 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
       } else {
         unregister_code(KC_TAB);
       }
+      break;
+    case SLC_ALL:
+      select_all(record);
+      break;
+    case SLC_ROW:
+      select_row(record);
+      break;
+    case SLC_WRD:
+      select_word(record);
       break;
   }
   return true;

--- a/keyboards/handwired/aek64/rules.mk
+++ b/keyboards/handwired/aek64/rules.mk
@@ -25,3 +25,4 @@ UNICODE_ENABLE   = yes # Enable support for arrow keys icon on the second layer.
 COMBO_ENABLE     = yes # Enable combo for special function when using multiple keys at once.
 TAP_DANCE_ENABLE = no  # Enable use multiple tap
 NKRO_ENABLE      = yes
+BACKLIGHT_ENABLE = yes


### PR DESCRIPTION
## Description

* Rework of my personal keymap for the AEK64 handwired keyboard.
* Adding backlight effects on the keyboard.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
