### PR TITLE
Remove QMK_KEYBOARD_CONFIG_H from boards

### DIFF
--- a/keyboards/7skb/rev1/config.h
+++ b/keyboards/7skb/rev1/config.h
@@ -18,8 +18,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
-#include QMK_KEYBOARD_CONFIG_H
-
 /* USB Device descriptor parameter */
 #define VENDOR_ID       0xFEED
 #define PRODUCT_ID      0x3060

--- a/keyboards/fortitude60/rev1/config.h
+++ b/keyboards/fortitude60/rev1/config.h
@@ -18,8 +18,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef REV1_CONFIG_H
 #define REV1_CONFIG_H
 
-#include QMK_KEYBOARD_CONFIG_H
-
 /* USB Device descriptor parameter */
 #define VENDOR_ID       0xCB10
 #define PRODUCT_ID      0x1156

--- a/keyboards/keebio/iris/rev1/config.h
+++ b/keyboards/keebio/iris/rev1/config.h
@@ -17,8 +17,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
-#include QMK_KEYBOARD_CONFIG_H
-
 /* USB Device descriptor parameter */
 #define VENDOR_ID       0xCB10
 #define PRODUCT_ID      0x1256

--- a/keyboards/keebio/iris/rev1_led/config.h
+++ b/keyboards/keebio/iris/rev1_led/config.h
@@ -17,8 +17,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
-#include QMK_KEYBOARD_CONFIG_H
-
 /* USB Device descriptor parameter */
 #define VENDOR_ID       0xCB10
 #define PRODUCT_ID      0x1256

--- a/keyboards/keebio/iris/rev2/config.h
+++ b/keyboards/keebio/iris/rev2/config.h
@@ -17,8 +17,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
-#include QMK_KEYBOARD_CONFIG_H
-
 /* USB Device descriptor parameter */
 #define VENDOR_ID       0xCB10
 #define PRODUCT_ID      0x1256

--- a/keyboards/keebio/iris/rev3/config.h
+++ b/keyboards/keebio/iris/rev3/config.h
@@ -17,8 +17,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
-#include QMK_KEYBOARD_CONFIG_H
-
 /* USB Device descriptor parameter */
 #define VENDOR_ID       0xCB10
 #define PRODUCT_ID      0x1256

--- a/keyboards/keebio/levinson/rev1/config.h
+++ b/keyboards/keebio/levinson/rev1/config.h
@@ -19,8 +19,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
-#include QMK_KEYBOARD_CONFIG_H
-
 /* USB Device descriptor parameter */
 #define VENDOR_ID       0xCB10
 #define PRODUCT_ID      0x1146

--- a/keyboards/keebio/levinson/rev2/config.h
+++ b/keyboards/keebio/levinson/rev2/config.h
@@ -19,8 +19,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
-#include QMK_KEYBOARD_CONFIG_H
-
 /* USB Device descriptor parameter */
 #define VENDOR_ID       0xCB10
 #define PRODUCT_ID      0x1146

--- a/keyboards/keebio/quefrency/rev1/config.h
+++ b/keyboards/keebio/quefrency/rev1/config.h
@@ -18,8 +18,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
-#include QMK_KEYBOARD_CONFIG_H
-
 /* USB Device descriptor parameter */
 #define VENDOR_ID       0xCB10
 #define PRODUCT_ID      0x1257

--- a/keyboards/keebio/rorschach/rev1/config.h
+++ b/keyboards/keebio/rorschach/rev1/config.h
@@ -17,8 +17,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
-#include QMK_KEYBOARD_CONFIG_H
-
 /* USB Device descriptor parameter */
 #define VENDOR_ID       0xCB10
 #define PRODUCT_ID      0x1246

--- a/keyboards/naked48/rev1/config.h
+++ b/keyboards/naked48/rev1/config.h
@@ -18,8 +18,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
-#include QMK_KEYBOARD_CONFIG_H
-
 /* USB Device descriptor parameter */
 #define VENDOR_ID       0xFEED
 #define PRODUCT_ID      0x3060


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes
Causes issues when building with CTPC:
```console
zvecr@zvecr-XPS-L322X:~/Desktop/qmk_firmware$ ./util/docker_build.sh keebio/levinson/rev2:default:flash
...
Compiling: tmk_core/protocol/chibios/main.c                                                         [OK]
Compiling: tmk_core/protocol/usb_descriptor.c                                                       [OK]
Compiling: tmk_core/protocol/chibios/usb_driver.c                                                   [OK]
Compiling: lib/chibios/os/common/startup/ARMCMx/compilers/GCC/crt1.c                               In file included from <command-line>:
./keyboards/keebio/levinson/rev2/config.h:22:10: error: #include expects "FILENAME" or <FILENAME>
 #include QMK_KEYBOARD_CONFIG_H
          ^~~~~~~~~~~~~~~~~~~~~
 [ERRORS]
 | 
 | 
 | 
tmk_core/rules.mk:377: recipe for target '.build/obj_keebio_levinson_rev2/lib/chibios/os/common/startup/ARMCMx/compilers/GCC/crt1.o' failed
make[1]: *** [.build/obj_keebio_levinson_rev2/lib/chibios/os/common/startup/ARMCMx/compilers/GCC/crt1.o] Error 1
Make finished with errors
Makefile:560: recipe for target 'keebio/levinson/rev2:default:flash' failed
make: *** [keebio/levinson/rev2:default:flash] Error 1
```

The next round will target breaking changes, and remove from user keymaps.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
