### PR TITLE
[keymap] boy_314's satisfaction75 layout

### DIFF
--- a/keyboards/cannonkeys/satisfaction75/keymaps/boy_314/config.h
+++ b/keyboards/cannonkeys/satisfaction75/keymaps/boy_314/config.h
@@ -1,0 +1,1 @@
+#define ENCODER_RESOLUTION 2

--- a/keyboards/cannonkeys/satisfaction75/keymaps/boy_314/config.h
+++ b/keyboards/cannonkeys/satisfaction75/keymaps/boy_314/config.h
@@ -1,1 +1,3 @@
+#pragma once 
+
 #define ENCODER_RESOLUTION 2

--- a/keyboards/cannonkeys/satisfaction75/keymaps/boy_314/keymap.c
+++ b/keyboards/cannonkeys/satisfaction75/keymaps/boy_314/keymap.c
@@ -1,0 +1,51 @@
+/*
+Copyright 2019 Boy_314
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include QMK_KEYBOARD_H
+#define NKRO MAGIC_TOGGLE_NKRO
+
+const uint16_t keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  [0] = LAYOUT_2x2(
+    KC_ESC,   KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,
+    KC_GRV,   KC_1,     KC_2,     KC_3,     KC_4,     KC_5,     KC_6,     KC_7,     KC_8,     KC_9,     KC_0,     KC_MINS,  KC_EQL,   KC_BSPC,  KC_NO,   ENC_PRESS,
+    KC_TAB,   KC_Q,     KC_W,     KC_E,     KC_R,     KC_T,     KC_Y,     KC_U,     KC_I,     KC_O,     KC_P,     KC_LBRC,  KC_RBRC,  KC_BSLS,  KC_HOME,
+    KC_LCTL,  KC_A,     KC_S,     KC_D,     KC_F,     KC_G,     KC_H,     KC_J,     KC_K,     KC_L,     KC_SCLN,  KC_QUOT,  KC_ENTER, KC_END,
+    KC_LSFT,  KC_Z,     KC_X,     KC_C,     KC_V,     KC_B,     KC_N,     KC_M,     KC_COMM,  KC_DOT,   KC_SLSH,  KC_RSFT,            KC_UP,    KC_DEL,
+    KC_LCTL,  KC_LALT,                                KC_SPC,                                 KC_LGUI,            MO(1),    KC_LEFT,  KC_DOWN,  KC_RGHT
+  ),
+  [1] = LAYOUT_2x2(
+    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+    NKRO,    _______, _______, _______, _______, _______, _______, _______, KC_PSCR, KC_SLCK, KC_PAUS, _______, _______, _______, _______, OLED_TOGG,
+    _______, _______, _______, _______, _______, _______, _______, _______, KC_INS,  KC_HOME, KC_PGUP, _______, _______, RESET,   CLOCK_SET,
+    KC_CAPS, _______, _______, _______, _______, _______, _______, _______, KC_DEL,  KC_END,  KC_PGDN, _______, _______, _______,
+    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          KC_VOLU, _______,
+    _______, _______,                            _______,                            _______,          _______, KC_MPRV, KC_VOLD, KC_MNXT
+  )
+};
+
+
+void matrix_init_user(void) {
+  //user initialization
+}
+
+void matrix_scan_user(void) {
+  //user matrix
+}
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  return true;
+}

--- a/keyboards/cannonkeys/satisfaction75/keymaps/boy_314/keymap.c
+++ b/keyboards/cannonkeys/satisfaction75/keymaps/boy_314/keymap.c
@@ -16,7 +16,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include QMK_KEYBOARD_H
-#define NKRO MAGIC_TOGGLE_NKRO
 
 const uint16_t keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   [0] = LAYOUT_2x2(
@@ -29,23 +28,10 @@ const uint16_t keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   ),
   [1] = LAYOUT_2x2(
     _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
-    NKRO,    _______, _______, _______, _______, _______, _______, _______, KC_PSCR, KC_SLCK, KC_PAUS, _______, _______, _______, _______, OLED_TOGG,
+    NK_TOGG, _______, _______, _______, _______, _______, _______, _______, KC_PSCR, KC_SLCK, KC_PAUS, _______, _______, _______, _______, OLED_TOGG,
     _______, _______, _______, _______, _______, _______, _______, _______, KC_INS,  KC_HOME, KC_PGUP, _______, _______, RESET,   CLOCK_SET,
     KC_CAPS, _______, _______, _______, _______, _______, _______, _______, KC_DEL,  KC_END,  KC_PGDN, _______, _______, _______,
     _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          KC_VOLU, _______,
     _______, _______,                            _______,                            _______,          _______, KC_MPRV, KC_VOLD, KC_MNXT
   )
 };
-
-
-void matrix_init_user(void) {
-  //user initialization
-}
-
-void matrix_scan_user(void) {
-  //user matrix
-}
-
-bool process_record_user(uint16_t keycode, keyrecord_t *record) {
-  return true;
-}

--- a/keyboards/cannonkeys/satisfaction75/keymaps/boy_314/readme.md
+++ b/keyboards/cannonkeys/satisfaction75/keymaps/boy_314/readme.md
@@ -1,0 +1,3 @@
+# Boy_314's Satisfaction75 Layout
+
+This is Boy_314's Satisfaction75 Layout. It can be used on VIA. It features a QWERTY layout on the base, along with missing TKL keys on layer 1. Right side 3 keys from top down are: Home, End, Delete. The encoder resolution has been reduced from the default of 4 down to 2 so that it no longer needs to click twice, but now only once, before triggering an action.

--- a/keyboards/cannonkeys/satisfaction75/keymaps/boy_314/rules.mk
+++ b/keyboards/cannonkeys/satisfaction75/keymaps/boy_314/rules.mk
@@ -1,0 +1,4 @@
+# rules.mk overrides to enable VIA
+
+RAW_ENABLE = yes
+DYNAMIC_KEYMAP_ENABLE = yes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Added my custom satisfaction75 layout. Includes a default QWERTY keymap along with missing TKL keys on a second layer. also changes the encoder resolution from 4 (default) to 2 so that turning the knob once activates the knob instead of twice. See readme for some more details.
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
