### PR TITLE
ARM split - Disable USB on slave half to resolve random 'lockup'

### DIFF
--- a/quantum/split_common/split_util.c
+++ b/quantum/split_common/split_util.c
@@ -33,9 +33,11 @@ bool waitForUsb(void) {
         wait_ms(100);
     }
 
-#if defined(__AVR__)
     // Avoid NO_USB_STARTUP_CHECK - Disable USB as the previous checks seem to enable it somehow
+#if defined(__AVR__)
     (USBCON &= ~(_BV(USBE) | _BV(OTGPADE)));
+#else
+    usbStop(&USBD1);
 #endif
 
     return false;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

When using serial transport, the slave side still runs the ISR and sends the previous data, but from an end user perspective the slave doesnt respond.

Similar to the elite-c v3/teensy2/vit_inc issue, the slave side gets stuck in the sleep loop. However on ARM, its less consistent and happens at random.

A bit of a "when you only have a hammer everything looks like a nail." solution, but for now I just want things to work.....and can try to tackle *better* once things are working.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
