### PR TITLE
clueboard 60 fix col 11 12 mixup

### DIFF
--- a/keyboards/clueboard/60/config.h
+++ b/keyboards/clueboard/60/config.h
@@ -47,7 +47,7 @@
  *
 */
 #define MATRIX_ROW_PINS { B0, B1, B2, A15, A10 }
-#define MATRIX_COL_PINS { A2, A3, A6, B14, B15, A8, A9, A7, B3, B4, C14, C15, C13, B5, B6 }
+#define MATRIX_COL_PINS { A2, A3, A6, B14, B15, A8, A9, A7, B3, B4, C15, C14, C13, B5, B6 }
 #define UNUSED_PINS { A0, A1, A9, B7, B8, B9, B10, B11, B12, B13 }
 #define DIODE_DIRECTION COL2ROW
 

--- a/layouts/community/60_ansi_split_bs_rshift/yanfali/keymap.c
+++ b/layouts/community/60_ansi_split_bs_rshift/yanfali/keymap.c
@@ -13,7 +13,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     KC_TAB,         KC_Q,    KC_W, KC_E, KC_R, KC_T, KC_Y, KC_U,  KC_I,    KC_O,    KC_P,    KC_LBRC,  KC_RBRC, KC_BSLS,         \
     LCTL_T(KC_ESC), KC_A,    KC_S, KC_D, KC_F, KC_G, KC_H, KC_J,  KC_K,    KC_L,    KC_SCLN, KC_QUOT,  KC_ENT,                   \
     KC_LSFT,        KC_Z,    KC_X, KC_C, KC_V, KC_B, KC_N, KC_M,  KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT,  MO(YFL),                  \
-    KC_LCTL,        KC_LGUI, KC_LALT,       KC_SPACE,             KC_RGUI, KC_RALT, MO(FN),  KC_RCTL),
+    KC_LCTL,        KC_LALT, KC_LGUI,       KC_SPACE,             KC_RGUI, KC_RALT, MO(FN),  KC_RCTL),
 
 [FN] = LAYOUT_60_ansi_split_bs_rshift(
     KC_GRV,  KC_F1,    KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_DEL, KC_DEL, \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Swaps columns 12 and 11 so they are in the correct positions for the matrix
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
This is a bug fix, this has been broken for quite a while.
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
