### PR TITLE
Move some common matrix code to a common location

### DIFF
--- a/common_features.mk
+++ b/common_features.mk
@@ -368,10 +368,16 @@ QUANTUM_SRC:= \
 
 # Include the standard or split matrix code if needed
 ifneq ($(strip $(CUSTOM_MATRIX)), yes)
-    ifeq ($(strip $(SPLIT_KEYBOARD)), yes)
-        QUANTUM_SRC += $(QUANTUM_DIR)/split_common/matrix.c
-    else
-        QUANTUM_SRC += $(QUANTUM_DIR)/matrix.c
+    # Include common stuff for all non custom matrix users
+    QUANTUM_SRC += $(QUANTUM_DIR)/matrix_common.c
+
+    # if 'lite' then skip the actual matrix implementation
+    ifneq ($(strip $(CUSTOM_MATRIX)), lite)
+        ifeq ($(strip $(SPLIT_KEYBOARD)), yes)
+            QUANTUM_SRC += $(QUANTUM_DIR)/split_common/matrix.c
+        else
+            QUANTUM_SRC += $(QUANTUM_DIR)/matrix.c
+        endif
     endif
 endif
 

--- a/common_features.mk
+++ b/common_features.mk
@@ -366,13 +366,23 @@ QUANTUM_SRC:= \
     $(QUANTUM_DIR)/keymap_common.c \
     $(QUANTUM_DIR)/keycode_config.c
 
-# Include the standard or split matrix code if needed
+
+
+VALID_CUSTOM_MATRIX_TYPES:= yes lite no
+
+CUSTOM_MATRIX ?= no
+
 ifneq ($(strip $(CUSTOM_MATRIX)), yes)
+    ifeq ($(filter $(CUSTOM_MATRIX),$(VALID_CUSTOM_MATRIX_TYPES)),)
+        $(error CUSTOM_MATRIX="$(CUSTOM_MATRIX)" is not a valid custom matrix type)
+    endif
+
     # Include common stuff for all non custom matrix users
     QUANTUM_SRC += $(QUANTUM_DIR)/matrix_common.c
 
     # if 'lite' then skip the actual matrix implementation
     ifneq ($(strip $(CUSTOM_MATRIX)), lite)
+        # Include the standard or split matrix code if needed
         ifeq ($(strip $(SPLIT_KEYBOARD)), yes)
             QUANTUM_SRC += $(QUANTUM_DIR)/split_common/matrix.c
         else

--- a/keyboards/kinesis/alvicstep/rules.mk
+++ b/keyboards/kinesis/alvicstep/rules.mk
@@ -1,0 +1,4 @@
+CUSTOM_MATRIX = yes # need to do our own thing with the matrix
+
+# Project specific files
+SRC += matrix.c

--- a/keyboards/kinesis/rules.mk
+++ b/keyboards/kinesis/rules.mk
@@ -28,9 +28,5 @@ MIDI_ENABLE = no            # MIDI controls
 UNICODE_ENABLE = no         # Unicode
 BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
 AUDIO_ENABLE = no # Audio output should be port E6, current quantum library hardcodes C6, which we use for programming
-CUSTOM_MATRIX=yes # need to do our own thing with the matrix
 
 DEFAULT_FOLDER = kinesis/alvicstep
-
-# Project specific files
-SRC = matrix.c

--- a/keyboards/xd84/custom_matrix_helper.c
+++ b/keyboards/xd84/custom_matrix_helper.c
@@ -23,71 +23,15 @@
 #include "debounce.h"
 #include "quantum.h"
 
-//_____COMMON__________________________________________________________________
-// user-defined overridable functions
-__attribute__((weak)) void matrix_init_kb(void) { matrix_init_user(); }
-__attribute__((weak)) void matrix_scan_kb(void) { matrix_scan_user(); }
-__attribute__((weak)) void matrix_init_user(void) {}
-__attribute__((weak)) void matrix_scan_user(void) {}
-
-
 //_____COULD BE COMMON_________________________________________________________
 /* matrix state(1:on, 0:off) */
 /*static*/ matrix_row_t raw_matrix[MATRIX_ROWS];
 /*static*/ matrix_row_t matrix[MATRIX_ROWS];
 
-#if (MATRIX_COLS <= 8)
-#    define print_matrix_header()  print("\nr/c 01234567\n")
-#    define print_matrix_row(row)  print_bin_reverse8(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop(matrix[i])
-#    define ROW_SHIFTER ((uint8_t)1)
-#elif (MATRIX_COLS <= 16)
-#    define print_matrix_header()  print("\nr/c 0123456789ABCDEF\n")
-#    define print_matrix_row(row)  print_bin_reverse16(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop16(matrix[i])
-#    define ROW_SHIFTER ((uint16_t)1)
-#elif (MATRIX_COLS <= 32)
-#    define print_matrix_header()  print("\nr/c 0123456789ABCDEF0123456789ABCDEF\n")
-#    define print_matrix_row(row)  print_bin_reverse32(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop32(matrix[i])
-#    define ROW_SHIFTER  ((uint32_t)1)
-#endif
-
-__attribute__ ((weak))
-uint8_t matrix_rows(void) {
-  return MATRIX_ROWS;
-}
-
-__attribute__ ((weak))
-uint8_t matrix_cols(void) {
-  return MATRIX_COLS;
-}
-
 __attribute__ ((weak))
 matrix_row_t matrix_get_row(uint8_t row) {
   return matrix[row];
 }
-
-__attribute__ ((weak))
-uint8_t matrix_key_count(void) {
-  uint8_t count = 0;
-  for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-    count += matrix_bitpop(i);
-  }
-  return count;
-}
-
-__attribute__ ((weak))
-void matrix_print(void) {
-  print_matrix_header();
-
-  for (uint8_t row = 0; row < MATRIX_ROWS; row++) {
-    phex(row); print(": ");
-    print_matrix_row(row);
-    print("\n");
-  }
-}
-
 
 //_____CUSTOM MATRIX 'LITE'____________________________________________________
 __attribute__ ((weak))

--- a/keyboards/xd84/rules.mk
+++ b/keyboards/xd84/rules.mk
@@ -34,7 +34,7 @@ HD44780_ENABLE = no         # Enable support for HD44780 based LCDs (+400)
 LINK_TIME_OPTIMIZATION_ENABLE = yes
 
 # custom matrix setup
-CUSTOM_MATRIX = yes
+CUSTOM_MATRIX = lite
 
 VPATH += drivers/gpio
 SRC += custom_matrix_helper.c pca9555.c matrix.c

--- a/keyboards/xd96/custom_matrix_helper.c
+++ b/keyboards/xd96/custom_matrix_helper.c
@@ -23,71 +23,15 @@
 #include "debounce.h"
 #include "quantum.h"
 
-//_____COMMON__________________________________________________________________
-// user-defined overridable functions
-__attribute__((weak)) void matrix_init_kb(void) { matrix_init_user(); }
-__attribute__((weak)) void matrix_scan_kb(void) { matrix_scan_user(); }
-__attribute__((weak)) void matrix_init_user(void) {}
-__attribute__((weak)) void matrix_scan_user(void) {}
-
-
 //_____COULD BE COMMON_________________________________________________________
 /* matrix state(1:on, 0:off) */
 /*static*/ matrix_row_t raw_matrix[MATRIX_ROWS];
 /*static*/ matrix_row_t matrix[MATRIX_ROWS];
 
-#if (MATRIX_COLS <= 8)
-#    define print_matrix_header()  print("\nr/c 01234567\n")
-#    define print_matrix_row(row)  print_bin_reverse8(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop(matrix[i])
-#    define ROW_SHIFTER ((uint8_t)1)
-#elif (MATRIX_COLS <= 16)
-#    define print_matrix_header()  print("\nr/c 0123456789ABCDEF\n")
-#    define print_matrix_row(row)  print_bin_reverse16(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop16(matrix[i])
-#    define ROW_SHIFTER ((uint16_t)1)
-#elif (MATRIX_COLS <= 32)
-#    define print_matrix_header()  print("\nr/c 0123456789ABCDEF0123456789ABCDEF\n")
-#    define print_matrix_row(row)  print_bin_reverse32(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop32(matrix[i])
-#    define ROW_SHIFTER  ((uint32_t)1)
-#endif
-
-__attribute__ ((weak))
-uint8_t matrix_rows(void) {
-  return MATRIX_ROWS;
-}
-
-__attribute__ ((weak))
-uint8_t matrix_cols(void) {
-  return MATRIX_COLS;
-}
-
 __attribute__ ((weak))
 matrix_row_t matrix_get_row(uint8_t row) {
   return matrix[row];
 }
-
-__attribute__ ((weak))
-uint8_t matrix_key_count(void) {
-  uint8_t count = 0;
-  for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-    count += matrix_bitpop(i);
-  }
-  return count;
-}
-
-__attribute__ ((weak))
-void matrix_print(void) {
-  print_matrix_header();
-
-  for (uint8_t row = 0; row < MATRIX_ROWS; row++) {
-    phex(row); print(": ");
-    print_matrix_row(row);
-    print("\n");
-  }
-}
-
 
 //_____CUSTOM MATRIX 'LITE'____________________________________________________
 __attribute__ ((weak))

--- a/keyboards/xd96/rules.mk
+++ b/keyboards/xd96/rules.mk
@@ -34,7 +34,7 @@ HD44780_ENABLE = no         # Enable support for HD44780 based LCDs (+400)
 LINK_TIME_OPTIMIZATION_ENABLE = yes
 
 # custom matrix setup
-CUSTOM_MATRIX = yes
+CUSTOM_MATRIX = lite
 
 VPATH += drivers/gpio
 SRC += custom_matrix_helper.c pca9555.c matrix.c

--- a/quantum/matrix_common.c
+++ b/quantum/matrix_common.c
@@ -1,0 +1,59 @@
+#include "matrix.h"
+#include "debounce.h"
+#include "print.h"
+#include "debug.h"
+
+// user-defined overridable functions
+
+__attribute__((weak)) void matrix_init_kb(void) { matrix_init_user(); }
+
+__attribute__((weak)) void matrix_scan_kb(void) { matrix_scan_user(); }
+
+__attribute__((weak)) void matrix_init_user(void) {}
+
+__attribute__((weak)) void matrix_scan_user(void) {}
+
+// helper functions
+
+inline uint8_t matrix_rows(void) { return MATRIX_ROWS; }
+
+inline uint8_t matrix_cols(void) { return MATRIX_COLS; }
+
+// Deprecated.
+bool matrix_is_modified(void) {
+    if (debounce_active()) return false;
+    return true;
+}
+
+#if (MATRIX_COLS <= 8)
+#    define print_matrix_header() print("\nr/c 01234567\n")
+#    define print_matrix_row(row) print_bin_reverse8(matrix_get_row(row))
+#    define matrix_bitpop(row) bitpop(matrix_get_row(row))
+#elif (MATRIX_COLS <= 16)
+#    define print_matrix_header() print("\nr/c 0123456789ABCDEF\n")
+#    define print_matrix_row(row) print_bin_reverse16(matrix_get_row(row))
+#    define matrix_bitpop(row) bitpop16(matrix_get_row(row))
+#elif (MATRIX_COLS <= 32)
+#    define print_matrix_header() print("\nr/c 0123456789ABCDEF0123456789ABCDEF\n")
+#    define print_matrix_row(row) print_bin_reverse32(matrix_get_row(row))
+#    define matrix_bitpop(row) bitpop32(matrix_get_row(row))
+#endif
+
+void matrix_print(void) {
+    print_matrix_header();
+
+    for (uint8_t row = 0; row < MATRIX_ROWS; row++) {
+        phex(row);
+        print(": ");
+        print_matrix_row(row);
+        print("\n");
+    }
+}
+
+uint8_t matrix_key_count(void) {
+    uint8_t count = 0;
+    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
+        count += matrix_bitpop(i);
+    }
+    return count;
+}

--- a/quantum/split_common/matrix.c
+++ b/quantum/split_common/matrix.c
@@ -14,10 +14,6 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-
-/*
- * scan matrix
- */
 #include <stdint.h>
 #include <stdbool.h>
 #include "wait.h"
@@ -33,23 +29,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    include "encoder.h"
 #endif
 
-#if (MATRIX_COLS <= 8)
-#    define print_matrix_header() print("\nr/c 01234567\n")
-#    define print_matrix_row(row) print_bin_reverse8(matrix_get_row(row))
-#    define matrix_bitpop(i) bitpop(matrix[i])
-#    define ROW_SHIFTER ((uint8_t)1)
-#elif (MATRIX_COLS <= 16)
-#    define print_matrix_header() print("\nr/c 0123456789ABCDEF\n")
-#    define print_matrix_row(row) print_bin_reverse16(matrix_get_row(row))
-#    define matrix_bitpop(i) bitpop16(matrix[i])
-#    define ROW_SHIFTER ((uint16_t)1)
-#elif (MATRIX_COLS <= 32)
-#    define print_matrix_header() print("\nr/c 0123456789ABCDEF0123456789ABCDEF\n")
-#    define print_matrix_row(row) print_bin_reverse32(matrix_get_row(row))
-#    define matrix_bitpop(i) bitpop32(matrix[i])
-#    define ROW_SHIFTER ((uint32_t)1)
-#endif
-
 #define ERROR_DISCONNECT_COUNT 5
 
 #define ROWS_PER_HAND (MATRIX_ROWS / 2)
@@ -62,57 +41,20 @@ static pin_t col_pins[MATRIX_COLS] = MATRIX_COL_PINS;
 #endif
 
 /* matrix state(1:on, 0:off) */
-static matrix_row_t matrix[MATRIX_ROWS];
-static matrix_row_t raw_matrix[ROWS_PER_HAND];
+static matrix_row_t raw_matrix[MATRIX_ROWS];  // raw values
+static matrix_row_t matrix[MATRIX_ROWS];      // debounced values
 
 // row offsets for each hand
 uint8_t thisHand, thatHand;
 
 // user-defined overridable functions
-
-__attribute__((weak)) void matrix_init_kb(void) { matrix_init_user(); }
-
-__attribute__((weak)) void matrix_scan_kb(void) { matrix_scan_user(); }
-
-__attribute__((weak)) void matrix_init_user(void) {}
-
-__attribute__((weak)) void matrix_scan_user(void) {}
-
 __attribute__((weak)) void matrix_slave_scan_user(void) {}
 
 // helper functions
 
-inline uint8_t matrix_rows(void) { return MATRIX_ROWS; }
-
-inline uint8_t matrix_cols(void) { return MATRIX_COLS; }
-
-bool matrix_is_modified(void) {
-    if (debounce_active()) return false;
-    return true;
-}
-
 inline bool matrix_is_on(uint8_t row, uint8_t col) { return (matrix[row] & ((matrix_row_t)1 << col)); }
 
 inline matrix_row_t matrix_get_row(uint8_t row) { return matrix[row]; }
-
-void matrix_print(void) {
-    print_matrix_header();
-
-    for (uint8_t row = 0; row < MATRIX_ROWS; row++) {
-        phex(row);
-        print(": ");
-        print_matrix_row(row);
-        print("\n");
-    }
-}
-
-uint8_t matrix_key_count(void) {
-    uint8_t count = 0;
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        count += matrix_bitpop(i);
-    }
-    return count;
-}
 
 // matrix code
 
@@ -136,7 +78,7 @@ static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
     for (uint8_t col_index = 0; col_index < MATRIX_COLS; col_index++) {
         pin_t pin = direct_pins[current_row][col_index];
         if (pin != NO_PIN) {
-            current_matrix[current_row] |= readPin(pin) ? 0 : (ROW_SHIFTER << col_index);
+            current_matrix[current_row] |= readPin(pin) ? 0 : (MATRIX_ROW_SHIFTER << col_index);
         }
     }
 
@@ -179,7 +121,7 @@ static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
     // For each col...
     for (uint8_t col_index = 0; col_index < MATRIX_COLS; col_index++) {
         // Populate the matrix row with the state of the col pin
-        current_matrix[current_row] |= readPin(col_pins[col_index]) ? 0 : (ROW_SHIFTER << col_index);
+        current_matrix[current_row] |= readPin(col_pins[col_index]) ? 0 : (MATRIX_ROW_SHIFTER << col_index);
     }
 
     // Unselect row
@@ -225,10 +167,10 @@ static bool read_rows_on_col(matrix_row_t current_matrix[], uint8_t current_col)
         // Check row pin state
         if (readPin(row_pins[row_index])) {
             // Pin HI, clear col bit
-            current_matrix[row_index] &= ~(ROW_SHIFTER << current_col);
+            current_matrix[row_index] &= ~(MATRIX_ROW_SHIFTER << current_col);
         } else {
             // Pin LO, set col bit
-            current_matrix[row_index] |= (ROW_SHIFTER << current_col);
+            current_matrix[row_index] |= (MATRIX_ROW_SHIFTER << current_col);
         }
 
         // Determine if the matrix changed state
@@ -280,7 +222,8 @@ void matrix_init(void) {
 
     // initialize matrix state: all keys off
     for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        matrix[i] = 0;
+        raw_matrix[i] = 0;
+        matrix[i]     = 0;
     }
 
     debounce_init(ROWS_PER_HAND);
@@ -288,29 +231,7 @@ void matrix_init(void) {
     matrix_init_quantum();
 }
 
-uint8_t _matrix_scan(void) {
-    bool changed = false;
-
-#if defined(DIRECT_PINS) || (DIODE_DIRECTION == COL2ROW)
-    // Set row, read cols
-    for (uint8_t current_row = 0; current_row < ROWS_PER_HAND; current_row++) {
-        changed |= read_cols_on_row(raw_matrix, current_row);
-    }
-#elif (DIODE_DIRECTION == ROW2COL)
-    // Set col, read rows
-    for (uint8_t current_col = 0; current_col < MATRIX_COLS; current_col++) {
-        changed |= read_rows_on_col(raw_matrix, current_col);
-    }
-#endif
-
-    debounce(raw_matrix, matrix + thisHand, ROWS_PER_HAND, changed);
-
-    return (uint8_t)changed;
-}
-
-uint8_t matrix_scan(void) {
-    uint8_t ret = _matrix_scan();
-
+void matrix_post_scan(void) {
     if (is_keyboard_master()) {
         static uint8_t error_count;
 
@@ -335,6 +256,25 @@ uint8_t matrix_scan(void) {
 #endif
         matrix_slave_scan_user();
     }
+}
 
-    return ret;
+uint8_t matrix_scan(void) {
+    bool changed = false;
+
+#if defined(DIRECT_PINS) || (DIODE_DIRECTION == COL2ROW)
+    // Set row, read cols
+    for (uint8_t current_row = 0; current_row < ROWS_PER_HAND; current_row++) {
+        changed |= read_cols_on_row(raw_matrix, current_row);
+    }
+#elif (DIODE_DIRECTION == ROW2COL)
+    // Set col, read rows
+    for (uint8_t current_col = 0; current_col < MATRIX_COLS; current_col++) {
+        changed |= read_rows_on_col(raw_matrix, current_col);
+    }
+#endif
+
+    debounce(raw_matrix, matrix + thisHand, ROWS_PER_HAND, changed);
+
+    matrix_post_scan();
+    return (uint8_t)changed;
 }

--- a/quantum/split_common/matrix.h
+++ b/quantum/split_common/matrix.h
@@ -1,3 +1,0 @@
-#pragma once
-
-#include <common/matrix.h>

--- a/tmk_core/common/matrix.h
+++ b/tmk_core/common/matrix.h
@@ -40,6 +40,8 @@ typedef uint32_t matrix_col_t;
 #    error "MATRIX_ROWS: invalid value"
 #endif
 
+#define MATRIX_ROW_SHIFTER ((matrix_row_t)1)
+
 #define MATRIX_IS_ON(row, col) (matrix_get_row(row) && (1 << col))
 
 #ifdef __cplusplus
@@ -78,11 +80,6 @@ void matrix_scan_kb(void);
 
 void matrix_init_user(void);
 void matrix_scan_user(void);
-
-#ifdef I2C_SPLIT
-void    slave_matrix_init(void);
-uint8_t slave_matrix_scan(void);
-#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
It started with the xd84/xd96 ports, where implementing custom matrix felt like reimplementing a bunch of boiler plate over and over again. And again when trying to unify behaviour between split and non split keyboards.

As part of this i have touched a few things in `quantum/split_common/matrix.c` so that it diffs better with `quantum/matrix.c`.

This PR aims to add a common location to remove duplication, as well as this new location to be optionally leveraged when implementing custom matrix.

### Notes
* For `CUSTOM_MATRIX=no` boards, the aim is to have zero impact. 
* Round 2 will migrate `keyboards/xd84/custom_matrix_helper.c` to core as 'lite' mode, and in the process remove more duplication from the other matrix implementations.
  * Personally I would be keen to add docs once this extra phase is complete, rather than right now, but I'm open to suggestions.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
