### PR TITLE
shell.nix: keep Nixpkgs pinned, but allow override

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,11 @@
-{ avr ? true, arm ? true, teensy ? true }:
+let
+  nixpkgs-pinned = builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/0260747427737b980f0.tar.gz";
+    sha256 = "1p2yc6b40xvvxvmlqd9wb440pkrimnlc2wsbpa5rddlpx1dn8qmf";
+  };
+in
+
+{ avr ? true, arm ? true, teensy ? true, nixpkgs ? nixpkgs-pinned }:
 
 let
   overlay = self: super:
@@ -17,11 +24,6 @@ let
         };
       });
     };
-
-  nixpkgs = builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/0260747427737b980f0.tar.gz";
-    sha256 = "1p2yc6b40xvvxvmlqd9wb440pkrimnlc2wsbpa5rddlpx1dn8qmf";
-  };
 
   pkgs = import nixpkgs { overlays = [ overlay ]; };
 in


### PR DESCRIPTION
This refines PR #6213 (commit 8dc9764f), which pinned Nixpkgs.

In general, pinning Nixpkgs is a good idea.  But there's some problems with
pinning it so hard.  It makes it harder to experiment with more modern Nixpkgs
without forking the codebase.  In general it's nicer to be current if we can,
because it decreases the likelihood of cache misses and having to pull a ton of
stuff down from Hydra.

So this commit tries to get the best of both worlds.  The pinned version is
still there as a default.  But I can easily override it to test out later
versions (which we'll want to do periodically anyway to not be perpetually stuck
on an ancient version of Nixpkgs).

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
