### PR TITLE
Add rules.mk defaults for f103,f072,f042

### DIFF
--- a/quantum/mcu_selection.mk
+++ b/quantum/mcu_selection.mk
@@ -23,7 +23,6 @@ ifneq ($(findstring STM32F303, $(MCU)),)
 
   # ARM version, CORTEX-M0/M1 are 6, CORTEX-M3/M4/M7 are 7
   ARMV ?= 7
-
   USE_FPU ?= yes
 
   # Options to pass to dfu-util when flashing
@@ -56,6 +55,7 @@ ifneq ($(findstring STM32F072, $(MCU)),)
 
   # ARM version, CORTEX-M0/M1 are 6, CORTEX-M3/M4/M7 are 7
   ARMV ?= 6
+  USE_FPU ?= no
 
   # Options to pass to dfu-util when flashing
   DFU_ARGS ?= -d 0483:df11 -a 0 -s 0x08000000:leave
@@ -87,6 +87,7 @@ ifneq ($(findstring STM32F042, $(MCU)),)
 
   # ARM version, CORTEX-M0/M1 are 6, CORTEX-M3/M4/M7 are 7
   ARMV ?= 6
+  USE_FPU ?= no
 
   # Options to pass to dfu-util when flashing
   DFU_ARGS ?= -d 0483:df11 -a 0 -s 0x08000000:leave
@@ -118,7 +119,6 @@ ifneq ($(findstring STM32F103, $(MCU)),)
 
   # ARM version, CORTEX-M0/M1 are 6, CORTEX-M3/M4/M7 are 7
   ARMV ?= 7
-
   USE_FPU ?= no
 
   # Options to pass to dfu-util when flashing

--- a/quantum/mcu_selection.mk
+++ b/quantum/mcu_selection.mk
@@ -1,9 +1,15 @@
 ifneq ($(findstring STM32F303, $(MCU)),)
+  # Cortex version
+  MCU = cortex-m4
+
+  # ARM version, CORTEX-M0/M1 are 6, CORTEX-M3/M4/M7 are 7
+  ARMV = 7
+
   ## chip/board settings
   # - the next two should match the directories in
   #   <chibios>/os/hal/ports/$(MCU_FAMILY)/$(MCU_SERIES)
-  MCU_FAMILY ?= STM32
-  MCU_SERIES ?= STM32F3xx
+  MCU_FAMILY = STM32
+  MCU_SERIES = STM32F3xx
 
   # Linker script to use
   # - it should exist either in <chibios>/os/common/ports/ARMCMx/compilers/GCC/ld/
@@ -18,11 +24,6 @@ ifneq ($(findstring STM32F303, $(MCU)),)
   # <keyboard_dir>/boards/, or drivers/boards/
   BOARD ?= GENERIC_STM32_F303XC
 
-  # Cortex version
-  MCU = cortex-m4
-
-  # ARM version, CORTEX-M0/M1 are 6, CORTEX-M3/M4/M7 are 7
-  ARMV ?= 7
   USE_FPU ?= yes
 
   # Options to pass to dfu-util when flashing
@@ -31,11 +32,17 @@ ifneq ($(findstring STM32F303, $(MCU)),)
 endif
 
 ifneq ($(findstring STM32F072, $(MCU)),)
+  # Cortex version
+  MCU = cortex-m0
+
+  # ARM version, CORTEX-M0/M1 are 6, CORTEX-M3/M4/M7 are 7
+  ARMV = 6
+
   ## chip/board settings
   # - the next two should match the directories in
   #   <chibios>/os/hal/ports/$(MCU_FAMILY)/$(MCU_SERIES)
-  MCU_FAMILY ?= STM32
-  MCU_SERIES ?= STM32F0xx
+  MCU_FAMILY = STM32
+  MCU_SERIES = STM32F0xx
 
   # Linker script to use
   # - it should exist either in <chibios>/os/common/ports/ARMCMx/compilers/GCC/ld/
@@ -50,11 +57,6 @@ ifneq ($(findstring STM32F072, $(MCU)),)
   # <keyboard_dir>/boards/, or drivers/boards/
   BOARD ?= ST_STM32F072B_DISCOVERY
 
-  # Cortex version
-  MCU = cortex-m0
-
-  # ARM version, CORTEX-M0/M1 are 6, CORTEX-M3/M4/M7 are 7
-  ARMV ?= 6
   USE_FPU ?= no
 
   # Options to pass to dfu-util when flashing
@@ -63,11 +65,17 @@ ifneq ($(findstring STM32F072, $(MCU)),)
 endif
 
 ifneq ($(findstring STM32F042, $(MCU)),)
+  # Cortex version
+  MCU = cortex-m0
+
+  # ARM version, CORTEX-M0/M1 are 6, CORTEX-M3/M4/M7 are 7
+  ARMV = 6
+
   ## chip/board settings
   # - the next two should match the directories in
   #   <chibios>/os/hal/ports/$(MCU_FAMILY)/$(MCU_SERIES)
-  MCU_FAMILY ?= STM32
-  MCU_SERIES ?= STM32F0xx
+  MCU_FAMILY = STM32
+  MCU_SERIES = STM32F0xx
 
   # Linker script to use
   # - it should exist either in <chibios>/os/common/ports/ARMCMx/compilers/GCC/ld/
@@ -82,11 +90,6 @@ ifneq ($(findstring STM32F042, $(MCU)),)
   # <keyboard_dir>/boards/, or drivers/boards/
   BOARD ?= GENERIC_STM32_F042X6
 
-  # Cortex version
-  MCU = cortex-m0
-
-  # ARM version, CORTEX-M0/M1 are 6, CORTEX-M3/M4/M7 are 7
-  ARMV ?= 6
   USE_FPU ?= no
 
   # Options to pass to dfu-util when flashing
@@ -95,11 +98,17 @@ ifneq ($(findstring STM32F042, $(MCU)),)
 endif
 
 ifneq ($(findstring STM32F103, $(MCU)),)
+  # Cortex version
+  MCU = cortex-m3
+
+  # ARM version, CORTEX-M0/M1 are 6, CORTEX-M3/M4/M7 are 7
+  ARMV = 7
+
   ## chip/board settings
   # - the next two should match the directories in
   #   <chibios>/os/hal/ports/$(MCU_FAMILY)/$(MCU_SERIES)
-  MCU_FAMILY ?= STM32
-  MCU_SERIES ?= STM32F1xx
+  MCU_FAMILY = STM32
+  MCU_SERIES = STM32F1xx
 
   # Linker script to use
   # - it should exist either in <chibios>/os/common/ports/ARMCMx/compilers/GCC/ld/
@@ -114,11 +123,6 @@ ifneq ($(findstring STM32F103, $(MCU)),)
   # <keyboard_dir>/boards/, or drivers/boards/
   BOARD ?= GENERIC_STM32_F103
 
-  # Cortex version
-  MCU = cortex-m3
-
-  # ARM version, CORTEX-M0/M1 are 6, CORTEX-M3/M4/M7 are 7
-  ARMV ?= 7
   USE_FPU ?= no
 
   # Options to pass to dfu-util when flashing

--- a/quantum/mcu_selection.mk
+++ b/quantum/mcu_selection.mk
@@ -28,7 +28,7 @@ ifneq ($(findstring STM32F303, $(MCU)),)
 
   # Options to pass to dfu-util when flashing
   DFU_ARGS ?= -d 0483:df11 -a 0 -s 0x08000000:leave
-  DFU_SUFFIX_ARGS ?= -p DF11 -v 0483
+  DFU_SUFFIX_ARGS ?= -v 0483 -p df11
 endif
 
 ifneq ($(findstring STM32F072, $(MCU)),)
@@ -61,7 +61,7 @@ ifneq ($(findstring STM32F072, $(MCU)),)
 
   # Options to pass to dfu-util when flashing
   DFU_ARGS ?= -d 0483:df11 -a 0 -s 0x08000000:leave
-  DFU_SUFFIX_ARGS ?= -p DF11 -v 0483
+  DFU_SUFFIX_ARGS ?= -v 0483 -p df11
 endif
 
 ifneq ($(findstring STM32F042, $(MCU)),)
@@ -94,7 +94,7 @@ ifneq ($(findstring STM32F042, $(MCU)),)
 
   # Options to pass to dfu-util when flashing
   DFU_ARGS ?= -d 0483:df11 -a 0 -s 0x08000000:leave
-  DFU_SUFFIX_ARGS ?= -p DF11 -v 0483
+  DFU_SUFFIX_ARGS ?= -v 0483 -p df11
 endif
 
 ifneq ($(findstring STM32F103, $(MCU)),)
@@ -127,7 +127,7 @@ ifneq ($(findstring STM32F103, $(MCU)),)
 
   # Options to pass to dfu-util when flashing
   DFU_ARGS ?= -d 0483:df11 -a 0 -s 0x08000000:leave
-  DFU_SUFFIX_ARGS ?= -p DF11 -v 0483
+  DFU_SUFFIX_ARGS ?= -v 0483 -p df11
 endif
 
 ifneq (,$(filter $(MCU),atmega16u2 atmega32u2 atmega16u4 atmega32u4 at90usb646 at90usb1286))

--- a/quantum/mcu_selection.mk
+++ b/quantum/mcu_selection.mk
@@ -121,11 +121,6 @@ ifneq ($(findstring STM32F103, $(MCU)),)
 
   USE_FPU ?= no
 
-  # Vector table for application
-  # 0x00000000-0x00001000 area is occupied by bootloader.*/
-  # The CORTEX_VTOR... is needed only for MCHCK/Infinity KB
-  # OPT_DEFS = -DCORTEX_VTOR_INIT=0x08005000
-
   # Options to pass to dfu-util when flashing
   DFU_ARGS ?= -d 0483:df11 -a 0 -s 0x08000000:leave
   DFU_SUFFIX_ARGS ?= -p DF11 -v 0483

--- a/quantum/mcu_selection.mk
+++ b/quantum/mcu_selection.mk
@@ -19,12 +19,107 @@ ifneq ($(findstring STM32F303, $(MCU)),)
   BOARD ?= GENERIC_STM32_F303XC
 
   # Cortex version
-  MCU = cortex-m4
+  MCU ?= cortex-m4
 
   # ARM version, CORTEX-M0/M1 are 6, CORTEX-M3/M4/M7 are 7
   ARMV ?= 7
 
-  USE_FPU = yes
+  USE_FPU ?= yes
+
+  # Options to pass to dfu-util when flashing
+  DFU_ARGS ?= -d 0483:df11 -a 0 -s 0x08000000:leave
+  DFU_SUFFIX_ARGS ?= -p DF11 -v 0483
+endif
+
+ifneq ($(findstring STM32F072, $(MCU)),)
+  ## chip/board settings
+  # - the next two should match the directories in
+  #   <chibios>/os/hal/ports/$(MCU_FAMILY)/$(MCU_SERIES)
+  MCU_FAMILY ?= STM32
+  MCU_SERIES ?= STM32F0xx
+
+  # Linker script to use
+  # - it should exist either in <chibios>/os/common/ports/ARMCMx/compilers/GCC/ld/
+  #   or <keyboard_dir>/ld/
+  MCU_LDSCRIPT ?= STM32F072xB
+
+  # Startup code to use
+  #  - it should exist in <chibios>/os/common/startup/ARMCMx/compilers/GCC/mk/
+  MCU_STARTUP ?= stm32f0xx
+
+  # Board: it should exist either in <chibios>/os/hal/boards/,
+  # <keyboard_dir>/boards/, or drivers/boards/
+  BOARD ?= ST_STM32F072B_DISCOVERY
+
+  # Cortex version
+  MCU ?= cortex-m0
+
+  # ARM version, CORTEX-M0/M1 are 6, CORTEX-M3/M4/M7 are 7
+  ARMV ?= 6
+
+  # Options to pass to dfu-util when flashing
+  DFU_ARGS ?= -d 0483:df11 -a 0 -s 0x08000000:leave
+  DFU_SUFFIX_ARGS ?= -p DF11 -v 0483
+endif
+
+ifneq ($(findstring STM32F042, $(MCU)),)
+  ## chip/board settings
+  # - the next two should match the directories in
+  #   <chibios>/os/hal/ports/$(MCU_FAMILY)/$(MCU_SERIES)
+  MCU_FAMILY ?= STM32
+  MCU_SERIES ?= STM32F0xx
+
+  # Linker script to use
+  # - it should exist either in <chibios>/os/common/ports/ARMCMx/compilers/GCC/ld/
+  #   or <keyboard_dir>/ld/
+  MCU_LDSCRIPT ?= STM32F042x6
+
+  # Startup code to use
+  #  - it should exist in <chibios>/os/common/startup/ARMCMx/compilers/GCC/mk/
+  MCU_STARTUP ?= stm32f0xx
+
+  # Board: it should exist either in <chibios>/os/hal/boards/,
+  # <keyboard_dir>/boards/, or drivers/boards/
+  BOARD ?= GENERIC_STM32_F042X6
+
+  # Cortex version
+  MCU ?= cortex-m0
+
+  # ARM version, CORTEX-M0/M1 are 6, CORTEX-M3/M4/M7 are 7
+  ARMV ?= 6
+
+  # Options to pass to dfu-util when flashing
+  DFU_ARGS ?= -d 0483:df11 -a 0 -s 0x08000000:leave
+  DFU_SUFFIX_ARGS ?= -p DF11 -v 0483
+endif
+
+ifneq ($(findstring STM32F103, $(MCU)),)
+  ## chip/board settings
+  # - the next two should match the directories in
+  #   <chibios>/os/hal/ports/$(MCU_FAMILY)/$(MCU_SERIES)
+  MCU_FAMILY ?= STM32
+  MCU_SERIES ?= STM32F1xx
+
+  # Linker script to use
+  # - it should exist either in <chibios>/os/common/ports/ARMCMx/compilers/GCC/ld/
+  #   or <keyboard_dir>/ld/
+  MCU_LDSCRIPT ?= STM32F103x8
+
+  # Startup code to use
+  #  - it should exist in <chibios>/os/common/startup/ARMCMx/compilers/GCC/mk/
+  MCU_STARTUP ?= stm32f1xx
+
+  # Board: it should exist either in <chibios>/os/hal/boards/,
+  # <keyboard_dir>/boards/, or drivers/boards/
+  BOARD ?= GENERIC_STM32_F103
+
+  # Cortex version
+  MCU ?= cortex-m3
+
+  # ARM version, CORTEX-M0/M1 are 6, CORTEX-M3/M4/M7 are 7
+  ARMV ?= 7
+
+  USE_FPU ?= no
 
   # Vector table for application
   # 0x00000000-0x00001000 area is occupied by bootloader.*/
@@ -33,7 +128,7 @@ ifneq ($(findstring STM32F303, $(MCU)),)
 
   # Options to pass to dfu-util when flashing
   DFU_ARGS ?= -d 0483:df11 -a 0 -s 0x08000000:leave
-  DFU_SUFFIX_ARGS = -p DF11 -v 0483
+  DFU_SUFFIX_ARGS ?= -p DF11 -v 0483
 endif
 
 ifneq (,$(filter $(MCU),atmega16u2 atmega32u2 atmega16u4 atmega32u4 at90usb646 at90usb1286))

--- a/quantum/mcu_selection.mk
+++ b/quantum/mcu_selection.mk
@@ -19,7 +19,7 @@ ifneq ($(findstring STM32F303, $(MCU)),)
   BOARD ?= GENERIC_STM32_F303XC
 
   # Cortex version
-  MCU ?= cortex-m4
+  MCU = cortex-m4
 
   # ARM version, CORTEX-M0/M1 are 6, CORTEX-M3/M4/M7 are 7
   ARMV ?= 7
@@ -51,7 +51,7 @@ ifneq ($(findstring STM32F072, $(MCU)),)
   BOARD ?= ST_STM32F072B_DISCOVERY
 
   # Cortex version
-  MCU ?= cortex-m0
+  MCU = cortex-m0
 
   # ARM version, CORTEX-M0/M1 are 6, CORTEX-M3/M4/M7 are 7
   ARMV ?= 6
@@ -83,7 +83,7 @@ ifneq ($(findstring STM32F042, $(MCU)),)
   BOARD ?= GENERIC_STM32_F042X6
 
   # Cortex version
-  MCU ?= cortex-m0
+  MCU = cortex-m0
 
   # ARM version, CORTEX-M0/M1 are 6, CORTEX-M3/M4/M7 are 7
   ARMV ?= 6
@@ -115,7 +115,7 @@ ifneq ($(findstring STM32F103, $(MCU)),)
   BOARD ?= GENERIC_STM32_F103
 
   # Cortex version
-  MCU ?= cortex-m3
+  MCU = cortex-m3
 
   # ARM version, CORTEX-M0/M1 are 6, CORTEX-M3/M4/M7 are 7
   ARMV ?= 7


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
As an attempt to resurrect parts of #5669, this PR aims to add defaults for a few of the more popular STM32 chips.

2nd pass will be to refactor boards to use these new defaults where possible
 
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
