### PR TITLE
K-Nunmpad17 

### DIFF
--- a/keyboards/handwired/k_numpad17/config.h
+++ b/keyboards/handwired/k_numpad17/config.h
@@ -1,0 +1,53 @@
+/*
+Copyright 2012 Jun Wako <wakojun@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "config_common.h"
+/* USB Device descriptor parameter */
+#define VENDOR_ID       0xFEED
+#define PRODUCT_ID      0x6060
+#define DEVICE_VER      0x0001
+#define MANUFACTURER    Handwired
+#define PRODUCT         K-Numpad17
+#define DESCRIPTION     QMK keyboard firmware for handwired numpad with 17 keys
+
+#define TAPPING_TERM 400
+
+/* key matrix size */
+#define MATRIX_ROWS 5
+#define MATRIX_COLS 4
+
+// ROWS: Top to bottom, COLS: Left to right
+
+#define MATRIX_ROW_PINS { D1, D4, C6, D7, E6 }
+#define MATRIX_COL_PINS { B2, B1, F6 , F4 }
+#define UNUSED_PINS
+
+/* COL2ROW or ROW2COL */
+#define DIODE_DIRECTION COL2ROW
+
+
+/* Set 0 if debouncing isn't needed */
+#define DEBOUNCE 5
+
+/* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
+#define LOCKING_SUPPORT_ENABLE
+/* Locking resynchronize hack */
+#define LOCKING_RESYNC_ENABLE
+
+

--- a/keyboards/handwired/k_numpad17/k_numpad17.c
+++ b/keyboards/handwired/k_numpad17/k_numpad17.c
@@ -1,0 +1,1 @@
+#include "k_numpad17.h"

--- a/keyboards/handwired/k_numpad17/k_numpad17.h
+++ b/keyboards/handwired/k_numpad17/k_numpad17.h
@@ -1,10 +1,9 @@
 #pragma once
-
 #include "quantum.h"
 
 // The first section contains all of the arguments
 // The second converts the arguments into a two-dimensional array
-#define layout_5x4( \
+#define LAYOUT_numpad_5x4( \
   k00, k01, k02, k03, \
   k10, k11, k12,      \
   k20, k21, k22, k13,  \
@@ -33,7 +32,4 @@
    * `-------------------'
  */
 
-
-void keyboard_pre_init_user(void);
-void matrix_scan_user(void);
 

--- a/keyboards/handwired/k_numpad17/k_numpad17.h
+++ b/keyboards/handwired/k_numpad17/k_numpad17.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "quantum.h"
+
+// The first section contains all of the arguments
+// The second converts the arguments into a two-dimensional array
+#define layout_5x4( \
+  k00, k01, k02, k03, \
+  k10, k11, k12,      \
+  k20, k21, k22, k13,  \
+  k30, k31, k32,      \
+    k40,    k41, k33  \
+) \
+{ \
+  {k00, k01, k02, k03}, \
+  {k10, k11, k12, k13}, \
+  {k20, k21, k22, KC_NO}, \
+  {k30, k31, k32, k33}, \
+  {k40, KC_NO, k41, KC_NO} \
+}
+
+/*  matrix layout
+   * ,-------------------.
+   * | 00 | 01 | 02 | 03 |
+   * |----|----|----|----|
+   * | 10 | 11 | 12 |    |
+   * |----|----|----| 13 |
+   * | 20 | 21 | 22 |    |
+   * |----|----|----|----|
+   * | 30 | 31 | 32 |    |
+   * |----|----|----| 33 |
+   * |   40    | 41 |    |
+   * `-------------------'
+ */
+
+
+void keyboard_pre_init_user(void);
+void matrix_scan_user(void);
+

--- a/keyboards/handwired/k_numpad17/keymaps/default/keymap.c
+++ b/keyboards/handwired/k_numpad17/keymaps/default/keymap.c
@@ -1,0 +1,24 @@
+#include QMK_KEYBOARD_H
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  /*
+   * ,-------------------.
+   * | NL | /  | *  | -  |
+   * |----|----|----|----|
+   * | 7  | 8  | 9  |    |
+   * |----|----|----| +  |
+   * | 4  | 5  | 6  |    |
+   * |----|----|----|----|
+   * | 1  | 2  | 3  |    |
+   * |----|----|----| En |
+   * |    0    | .  |    |
+   * `-------------------'
+   */
+
+  [0] = layout_5x4(
+    KC_NLCK, KC_PSLS, KC_PAST, KC_PMNS, 
+    KC_P7,   KC_P8,   KC_P9,   
+    KC_P4,   KC_P5,   KC_P6,   KC_PPLS, 
+    KC_P1,   KC_P2,   KC_P3,   
+    KC_P0, KC_PDOT,  KC_PENT  
+  ),
+};

--- a/keyboards/handwired/k_numpad17/keymaps/default/keymap.c
+++ b/keyboards/handwired/k_numpad17/keymaps/default/keymap.c
@@ -14,7 +14,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    * `-------------------'
    */
 
-  [0] = layout_5x4(
+  [0] = LAYOUT_numpad_5x4(
     KC_NLCK, KC_PSLS, KC_PAST, KC_PMNS, 
     KC_P7,   KC_P8,   KC_P9,   
     KC_P4,   KC_P5,   KC_P6,   KC_PPLS, 

--- a/keyboards/handwired/k_numpad17/keymaps/default/rules.mk
+++ b/keyboards/handwired/k_numpad17/keymaps/default/rules.mk
@@ -1,1 +1,0 @@
-TAP_DANCE_ENABLE = no

--- a/keyboards/handwired/k_numpad17/keymaps/default/rules.mk
+++ b/keyboards/handwired/k_numpad17/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+TAP_DANCE_ENABLE = no

--- a/keyboards/handwired/k_numpad17/keymaps/karlssn/keymap.c
+++ b/keyboards/handwired/k_numpad17/keymaps/karlssn/keymap.c
@@ -1,0 +1,61 @@
+#include QMK_KEYBOARD_H
+
+//Tap Dance Declarations
+enum {
+  TD_DOT_COMMAS = 0
+};
+
+//Tap Dance Definitions
+qk_tap_dance_action_t tap_dance_actions[] = {
+  //Tap once for Esc, twice for Caps Lock
+  [TD_DOT_COMMAS]  = ACTION_TAP_DANCE_DOUBLE(KC_DOT, KC_COMMA)
+// Other declarations would go here, separated by commas, if you have them
+};
+
+//In Layer declaration, add tap dance item in place of a key code
+
+
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  /*
+   * ,-------------------.
+   * |bcsp| /  | *  | -  |
+   * |----|----|----|----|
+   * | 7  | 8  | 9  |    |
+   * |----|----|----| +  |
+   * | 4  | 5  | 6  |    |
+   * |----|----|----|----|
+   * | 1  | 2  | 3  |    |
+   * |----|----|----| En |
+   * |   FN/0  | .  |    |
+   * `-------------------'
+   */
+
+  [0] = layout_5x4(
+    KC_BSPC, KC_PSLS, KC_PAST, KC_PMNS, 
+    KC_P7,   KC_P8,   KC_P9,   
+    KC_P4,   KC_P5,   KC_P6,   KC_PPLS, 
+    KC_P1,   KC_P2,   KC_P3,   
+    LT(1, KC_P0), TD(TD_DOT_COMMAS),  KC_PENT  
+  ),
+  /*
+   * ,-------------------.
+   * | F10| F11| F12| -  |
+   * |----|----|----|----|
+   * | F7 | F8 | F9 |    |
+   * |----|----|----| vol|
+   * | F4 | F5 | F6 |  + |
+   * |----|----|----|----|
+   * | F1 | F2 | F3 | vol|
+   * |----|----|----|  - |
+   * |    FN   | .  |    |
+   * `-------------------'
+   */
+  [1] = layout_5x4(
+    KC_F10, KC_F11, KC_F12, KC_NO, 
+    KC_F7,   KC_F8,   KC_F9,   
+    KC_F4,   KC_F5,   KC_F6, KC_VOLU, 
+    KC_F1,   KC_F2,   KC_F3,   
+    KC_NO, KC_PDOT,  KC_VOLD  
+  )
+};

--- a/keyboards/handwired/k_numpad17/keymaps/karlssn/keymap.c
+++ b/keyboards/handwired/k_numpad17/keymaps/karlssn/keymap.c
@@ -31,7 +31,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    * `-------------------'
    */
 
-  [0] = layout_5x4(
+  [0] = LAYOUT_numpad_5x4(
     KC_BSPC, KC_PSLS, KC_PAST, KC_PMNS, 
     KC_P7,   KC_P8,   KC_P9,   
     KC_P4,   KC_P5,   KC_P6,   KC_PPLS, 
@@ -51,7 +51,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    * |    FN   | .  |    |
    * `-------------------'
    */
-  [1] = layout_5x4(
+  [1] = LAYOUT_numpad_5x4(
     KC_F10, KC_F11, KC_F12, KC_NO, 
     KC_F7,   KC_F8,   KC_F9,   
     KC_F4,   KC_F5,   KC_F6, KC_VOLU, 

--- a/keyboards/handwired/k_numpad17/keymaps/karlssn/rules.mk
+++ b/keyboards/handwired/k_numpad17/keymaps/karlssn/rules.mk
@@ -1,0 +1,1 @@
+TAP_DANCE_ENABLE = yes

--- a/keyboards/handwired/k_numpad17/readme.md
+++ b/keyboards/handwired/k_numpad17/readme.md
@@ -1,5 +1,4 @@
-K-Numpad17 
-===
+# K-Numpad17 
 <img src="https://i.imgur.com/MasSa71.jpg" alt="k-numpad" width="400"/>
 
 ### Arduino Pro Micro Pinout
@@ -20,7 +19,7 @@ Make example for this keyboard (after setting up your build environment):
 
 Bootmagic is enabled.  Press the key at (0,0) while plugging the keyboard in to jump to bootloader. This is numlock in the default keymap.
 
-Keyboard Maintainer: [Karlssn](https://github.com/Karlssn)
-Hardware: [Casefile](https://www.thingiverse.com/thing:4062409)
+* Keyboard Maintainer: [Karlssn](https://github.com/Karlssn)
+* Hardware Availability: [Casefile](https://www.thingiverse.com/thing:4062409)
 
 See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).

--- a/keyboards/handwired/k_numpad17/readme.md
+++ b/keyboards/handwired/k_numpad17/readme.md
@@ -1,0 +1,26 @@
+K-Numpad17 
+===
+<img src="https://i.imgur.com/MasSa71.jpg" alt="k-numpad" width="400"/>
+
+### Arduino Pro Micro Pinout
+| rows        | 0   | 1   | 2   | 3   | 4   |
+| ----------- | --- | --- | --- | --- | --- |
+| arduino pin | 2   | 4   | 5   | 6   | 7   |
+| qmk pin     | D1  | D4  | C6  | D7  | E6  |
+
+| columns     | 0   | 1   | 2   | 3   |
+| ----------- | --- | --- | --- | --- |
+| arduino pin | 16  | 15  | A1  | A3  |
+| qmk pin     | B5  | B4  | B3  | C3  |
+
+
+Make example for this keyboard (after setting up your build environment):
+
+    make handwired/k_numpad17:default
+
+Bootmagic is enabled.  Press the key at (0,0) while plugging the keyboard in to jump to bootloader. This is numlock in the default keymap.
+
+Keyboard Maintainer: [Karlssn](https://github.com/Karlssn)
+Hardware: [Casefile](https://www.thingiverse.com/thing:4062409)
+
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).

--- a/keyboards/handwired/k_numpad17/rules.mk
+++ b/keyboards/handwired/k_numpad17/rules.mk
@@ -26,6 +26,6 @@ MIDI_ENABLE = no 		# MIDI controls
 AUDIO_ENABLE = no
 UNICODE_ENABLE = no 		# Unicode
 BLUETOOTH_ENABLE = no # Enable Bluetooth with the Adafruit EZ-Key HID
-TAP_DANCE_ENABLE = yes
+TAP_DANCE_ENABLE = no
 
 LAYOUTS = numpad_5x4

--- a/keyboards/handwired/k_numpad17/rules.mk
+++ b/keyboards/handwired/k_numpad17/rules.mk
@@ -15,13 +15,13 @@ BOOTLOADER = caterina
 #   comment out to disable the options.
 #
 BOOTMAGIC_ENABLE = lite	# Key at 0,0 makes the keyboard go into bootloader
-MOUSEKEY_ENABLE = no	# Mouse keys(+4700)
-EXTRAKEY_ENABLE = yes	# Audio control and System control(+450)
-CONSOLE_ENABLE = yes	# Console for debug(+400)
+MOUSEKEY_ENABLE = no	# Mouse keys
+EXTRAKEY_ENABLE = yes	# Audio control and System control
+CONSOLE_ENABLE = yes	# Console for debug
 COMMAND_ENABLE = yes    # Commands for debug and configuration
 NKRO_ENABLE = yes		# USB Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
-RGBLIGHT_ENABLE = no   # Enable keyboard underlight functionality (+4870)
-BACKLIGHT_ENABLE = no  # Enable keyboard backlight functionality (+1150)
+RGBLIGHT_ENABLE = no   # Enable keyboard underlight functionality 
+BACKLIGHT_ENABLE = no  # Enable keyboard backlight functionality 
 MIDI_ENABLE = no 		# MIDI controls
 AUDIO_ENABLE = no
 UNICODE_ENABLE = no 		# Unicode

--- a/keyboards/handwired/k_numpad17/rules.mk
+++ b/keyboards/handwired/k_numpad17/rules.mk
@@ -28,4 +28,4 @@ UNICODE_ENABLE = no 		# Unicode
 BLUETOOTH_ENABLE = no # Enable Bluetooth with the Adafruit EZ-Key HID
 TAP_DANCE_ENABLE = yes
 
-LAYOUTS = layout_5x4
+LAYOUTS = numpad_5x4

--- a/keyboards/handwired/k_numpad17/rules.mk
+++ b/keyboards/handwired/k_numpad17/rules.mk
@@ -1,0 +1,31 @@
+# MCU name
+MCU = atmega32u4
+
+# Bootloader selection
+#   Teensy       halfkay
+#   Pro Micro    caterina
+#   Atmel DFU    atmel-dfu
+#   LUFA DFU     lufa-dfu
+#   QMK DFU      qmk-dfu
+#   ATmega32A    bootloadHID
+#   ATmega328P   USBasp
+BOOTLOADER = caterina
+
+# Build Options
+#   comment out to disable the options.
+#
+BOOTMAGIC_ENABLE = lite	# Key at 0,0 makes the keyboard go into bootloader
+MOUSEKEY_ENABLE = no	# Mouse keys(+4700)
+EXTRAKEY_ENABLE = yes	# Audio control and System control(+450)
+CONSOLE_ENABLE = yes	# Console for debug(+400)
+COMMAND_ENABLE = yes    # Commands for debug and configuration
+NKRO_ENABLE = yes		# USB Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+RGBLIGHT_ENABLE = no   # Enable keyboard underlight functionality (+4870)
+BACKLIGHT_ENABLE = no  # Enable keyboard backlight functionality (+1150)
+MIDI_ENABLE = no 		# MIDI controls
+AUDIO_ENABLE = no
+UNICODE_ENABLE = no 		# Unicode
+BLUETOOTH_ENABLE = no # Enable Bluetooth with the Adafruit EZ-Key HID
+TAP_DANCE_ENABLE = yes
+
+LAYOUTS = layout_5x4


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
I created a new handwired keyboard and added it under keyboards/handwired/ 
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
So I recently created a numpad and handwired it on my own but found that qmk didnt have a numpad with 17 keys under the handwired tab. Therefore I created my own based of Tritium Numpad which is a 21 key numpad.
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
