### PR TITLE
Turn off RGB Matrix LEDs when keyboard sleeps

### DIFF
--- a/quantum/rgb_matrix.c
+++ b/quantum/rgb_matrix.c
@@ -417,7 +417,12 @@ void rgb_matrix_init(void) {
     eeconfig_debug_rgb_matrix();  // display current eeprom values
 }
 
-void rgb_matrix_set_suspend_state(bool state) { g_suspend_state = state; }
+void rgb_matrix_set_suspend_state(bool state) { 
+    if (RGB_DISABLE_WHEN_USB_SUSPENDED && state) { 
+        rgb_matrix_set_color_all(0, 0, 0); // turn off all LEDs when suspending
+    }
+    g_suspend_state = state; 
+}
 
 void rgb_matrix_toggle(void) {
     rgb_matrix_config.enable ^= 1;


### PR DESCRIPTION
## Description

Currently, when suspend/sleep is enabled for the rgb matrix, it sets a boolean toggle, which prevents the animation from being updated.  This was fine when the entire animation was done each cycle, but because the animation is sliced up (and has been for a while), it can lead to a state where some of the LEDs are on, but the rest are not, as it's mid animation.  

This forcibly turns off (well, sets to black/blank) all of the LEDs when the keyboard goes to sleep (and only then), so that all the lights are off. 

## Types of Changes
- [x] Bugfix

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
