### PR TITLE
Convert clipping variables in rgblight.c to a structure

### DIFF
--- a/keyboards/ergodox_ez/led_i2c.c
+++ b/keyboards/ergodox_ez/led_i2c.c
@@ -22,31 +22,11 @@
  */
 #ifdef RGBLIGHT_ENABLE
 
-#    include "ws2812.c"
 #    include "ergodox_ez.h"
 
 extern rgblight_config_t rgblight_config;
 
-void rgblight_set(void) {
-    if (!rgblight_config.enable) {
-        for (uint8_t i = 0; i < RGBLED_NUM; i++) {
-            led[i].r = 0;
-            led[i].g = 0;
-            led[i].b = 0;
-#ifdef RGBW
-            led[i].w = 0;
-#endif
-        }
-    }
-#ifdef RGBW
-    else {
-        for (uint8_t i = 0; i < RGBLED_NUM; i++) {
-            convert_rgb_to_rgbw(&led[i]);
-        }
-    }
-#endif
-
-    uint8_t led_num = RGBLED_NUM;
+void rgblight_call_driver(LED_TYPE *led, uint8_t led_num) {
     i2c_init();
     i2c_start(0x84, ERGODOX_EZ_I2C_TIMEOUT);
     int i = 0;
@@ -54,8 +34,8 @@ void rgblight_set(void) {
     // prevent right-half code from trying to bitbang all 30
     // so with 30 LEDs, we count from 29 to 15 here, and the
     // other half does 0 to 14.
-    led_num = RGBLED_NUM / 2;
-    for (i = led_num + led_num - 1; i >= led_num; --i)
+    uint8_t half_led_num = RGBLED_NUM / 2;
+    for (i = half_led_num + half_led_num - 1; i >= half_led_num; --i)
 #    elif defined(ERGODOX_LED_15_MIRROR)
     for (i = 0; i < led_num; ++i)
 #    else  // ERGDOX_LED_15 non-mirrored
@@ -72,7 +52,7 @@ void rgblight_set(void) {
     }
     i2c_stop();
 
-    ws2812_setleds(led, RGBLED_NUM);
+    ws2812_setleds(led, led_num);
 }
 
 

--- a/keyboards/ergodox_ez/rules.mk
+++ b/keyboards/ergodox_ez/rules.mk
@@ -31,7 +31,6 @@ SWAP_HANDS_ENABLE= yes # Allow swapping hands of keyboard
 SLEEP_LED_ENABLE = no
 API_SYSEX_ENABLE = no
 RGBLIGHT_ENABLE = yes
-RGBLIGHT_CUSTOM_DRIVER = yes
 
 RGB_MATRIX_ENABLE = no # enable later
 DEBOUNCE_TYPE = eager_pr

--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -107,23 +107,19 @@ LED_TYPE led[RGBLED_NUM];
 rgblight_segment_t const *const *rgblight_layers = NULL;
 #endif
 
-uint8_t clipping_start_pos = 0;
-uint8_t clipping_num_leds  = RGBLED_NUM;
-uint8_t effect_start_pos   = 0;
-uint8_t effect_end_pos     = RGBLED_NUM;
-uint8_t effect_num_leds    = RGBLED_NUM;
+rgblight_ranges_t rgblight_ranges = { 0, RGBLED_NUM,  0, RGBLED_NUM, RGBLED_NUM };
 
 void rgblight_set_clipping_range(uint8_t start_pos, uint8_t num_leds) {
-    clipping_start_pos = start_pos;
-    clipping_num_leds  = num_leds;
+    rgblight_ranges.clipping_start_pos = start_pos;
+    rgblight_ranges.clipping_num_leds  = num_leds;
 }
 
 void rgblight_set_effect_range(uint8_t start_pos, uint8_t num_leds) {
     if (start_pos >= RGBLED_NUM) return;
     if (start_pos + num_leds > RGBLED_NUM) return;
-    effect_start_pos = start_pos;
-    effect_end_pos   = start_pos + num_leds;
-    effect_num_leds  = num_leds;
+    rgblight_ranges.effect_start_pos = start_pos;
+    rgblight_ranges.effect_end_pos   = start_pos + num_leds;
+    rgblight_ranges.effect_num_leds  = num_leds;
 }
 
 void sethsv_raw(uint8_t hue, uint8_t sat, uint8_t val, LED_TYPE *led1) {
@@ -468,15 +464,15 @@ void rgblight_sethsv_eeprom_helper(uint8_t hue, uint8_t sat, uint8_t val, bool w
 #    else
                 uint8_t range = RGBLED_GRADIENT_RANGES[delta / 2];
 #    endif
-                for (uint8_t i = 0; i < effect_num_leds; i++) {
-                    uint8_t _hue = ((uint16_t)i * (uint16_t)range) / effect_num_leds;
+                for (uint8_t i = 0; i < rgblight_ranges.effect_num_leds; i++) {
+                    uint8_t _hue = ((uint16_t)i * (uint16_t)range) / rgblight_ranges.effect_num_leds;
                     if (direction) {
                         _hue = hue + _hue;
                     } else {
                         _hue = hue - _hue;
                     }
                     dprintf("rgblight rainbow set hsv: %d,%d,%d,%u\n", i, _hue, direction, range);
-                    sethsv(_hue, sat, val, (LED_TYPE *)&led[i + effect_start_pos]);
+                    sethsv(_hue, sat, val, (LED_TYPE *)&led[i + rgblight_ranges.effect_start_pos]);
                 }
                 rgblight_set();
             }
@@ -530,7 +526,7 @@ void rgblight_setrgb(uint8_t r, uint8_t g, uint8_t b) {
         return;
     }
 
-    for (uint8_t i = effect_start_pos; i < effect_end_pos; i++) {
+    for (uint8_t i = rgblight_ranges.effect_start_pos; i < rgblight_ranges.effect_end_pos; i++) {
         led[i].r = r;
         led[i].g = g;
         led[i].b = b;
@@ -667,7 +663,7 @@ static void rgblight_layers_write(void) {
 #ifndef RGBLIGHT_CUSTOM_DRIVER
 void rgblight_set(void) {
     LED_TYPE *start_led;
-    uint16_t  num_leds = clipping_num_leds;
+    uint16_t  num_leds = rgblight_ranges.clipping_num_leds;
 
 #    ifdef RGBLIGHT_LAYERS
     if (rgblight_layers != NULL) {
@@ -676,7 +672,7 @@ void rgblight_set(void) {
 #    endif
 
     if (!rgblight_config.enable) {
-        for (uint8_t i = effect_start_pos; i < effect_end_pos; i++) {
+        for (uint8_t i = rgblight_ranges.effect_start_pos; i < rgblight_ranges.effect_end_pos; i++) {
             led[i].r = 0;
             led[i].g = 0;
             led[i].b = 0;
@@ -691,9 +687,9 @@ void rgblight_set(void) {
     for (uint8_t i = 0; i < RGBLED_NUM; i++) {
         led0[i] = led[pgm_read_byte(&led_map[i])];
     }
-    start_led = led0 + clipping_start_pos;
+    start_led = led0 + rgblight_ranges.clipping_start_pos;
 #    else
-    start_led = led + clipping_start_pos;
+    start_led = led + rgblight_ranges.clipping_start_pos;
 #    endif
 
 #    ifdef RGBW
@@ -961,9 +957,9 @@ void rgblight_effect_rainbow_swirl(animation_status_t *anim) {
     uint8_t hue;
     uint8_t i;
 
-    for (i = 0; i < effect_num_leds; i++) {
-        hue = (RGBLIGHT_RAINBOW_SWIRL_RANGE / effect_num_leds * i + anim->current_hue);
-        sethsv(hue, rgblight_config.sat, rgblight_config.val, (LED_TYPE *)&led[i + effect_start_pos]);
+    for (i = 0; i < rgblight_ranges.effect_num_leds; i++) {
+        hue = (RGBLIGHT_RAINBOW_SWIRL_RANGE / rgblight_ranges.effect_num_leds * i + anim->current_hue);
+        sethsv(hue, rgblight_config.sat, rgblight_config.val, (LED_TYPE *)&led[i + rgblight_ranges.effect_start_pos]);
     }
     rgblight_set();
 
@@ -991,7 +987,7 @@ void rgblight_effect_snake(animation_status_t *anim) {
 #    if defined(RGBLIGHT_SPLIT) && !defined(RGBLIGHT_SPLIT_NO_ANIMATION_SYNC)
     if (anim->pos == 0) {  // restart signal
         if (increment == 1) {
-            pos = effect_num_leds - 1;
+            pos = rgblight_ranges.effect_num_leds - 1;
         } else {
             pos = 0;
         }
@@ -999,8 +995,8 @@ void rgblight_effect_snake(animation_status_t *anim) {
     }
 #    endif
 
-    for (i = 0; i < effect_num_leds; i++) {
-        LED_TYPE *ledp = led + i + effect_start_pos;
+    for (i = 0; i < rgblight_ranges.effect_num_leds; i++) {
+        LED_TYPE *ledp = led + i + rgblight_ranges.effect_start_pos;
         ledp->r        = 0;
         ledp->g        = 0;
         ledp->b        = 0;
@@ -1013,7 +1009,7 @@ void rgblight_effect_snake(animation_status_t *anim) {
                 k = k % RGBLED_NUM;
             }
             if (k < 0) {
-                k = k + effect_num_leds;
+                k = k + rgblight_ranges.effect_num_leds;
             }
             if (i == k) {
                 sethsv(rgblight_config.hue, rgblight_config.sat, (uint8_t)(rgblight_config.val * (RGBLIGHT_EFFECT_SNAKE_LENGTH - j) / RGBLIGHT_EFFECT_SNAKE_LENGTH), ledp);
@@ -1023,7 +1019,7 @@ void rgblight_effect_snake(animation_status_t *anim) {
     rgblight_set();
     if (increment == 1) {
         if (pos - 1 < 0) {
-            pos = effect_num_leds - 1;
+            pos = rgblight_ranges.effect_num_leds - 1;
 #    if defined(RGBLIGHT_SPLIT) && !defined(RGBLIGHT_SPLIT_NO_ANIMATION_SYNC)
             anim->pos = 0;
 #    endif
@@ -1034,7 +1030,7 @@ void rgblight_effect_snake(animation_status_t *anim) {
 #    endif
         }
     } else {
-        pos = (pos + 1) % effect_num_leds;
+        pos = (pos + 1) % rgblight_ranges.effect_num_leds;
 #    if defined(RGBLIGHT_SPLIT) && !defined(RGBLIGHT_SPLIT_NO_ANIMATION_SYNC)
         anim->pos = pos;
 #    endif
@@ -1060,7 +1056,7 @@ void rgblight_effect_knight(animation_status_t *anim) {
     }
 #    endif
     // Set all the LEDs to 0
-    for (i = effect_start_pos; i < effect_end_pos; i++) {
+    for (i = rgblight_ranges.effect_start_pos; i < rgblight_ranges.effect_end_pos; i++) {
         led[i].r = 0;
         led[i].g = 0;
         led[i].b = 0;
@@ -1070,7 +1066,7 @@ void rgblight_effect_knight(animation_status_t *anim) {
     }
     // Determine which LEDs should be lit up
     for (i = 0; i < RGBLIGHT_EFFECT_KNIGHT_LED_NUM; i++) {
-        cur = (i + RGBLIGHT_EFFECT_KNIGHT_OFFSET) % effect_num_leds + effect_start_pos;
+        cur = (i + RGBLIGHT_EFFECT_KNIGHT_OFFSET) % rgblight_ranges.effect_num_leds + rgblight_ranges.effect_start_pos;
 
         if (i >= low_bound && i <= high_bound) {
             sethsv(rgblight_config.hue, rgblight_config.sat, rgblight_config.val, (LED_TYPE *)&led[cur]);
@@ -1107,9 +1103,9 @@ void rgblight_effect_christmas(animation_status_t *anim) {
     uint8_t i;
 
     anim->current_offset = (anim->current_offset + 1) % 2;
-    for (i = 0; i < effect_num_leds; i++) {
+    for (i = 0; i < rgblight_ranges.effect_num_leds; i++) {
         hue = 0 + ((i / RGBLIGHT_EFFECT_CHRISTMAS_STEP + anim->current_offset) % 2) * 85;
-        sethsv(hue, rgblight_config.sat, rgblight_config.val, (LED_TYPE *)&led[i + effect_start_pos]);
+        sethsv(hue, rgblight_config.sat, rgblight_config.val, (LED_TYPE *)&led[i + rgblight_ranges.effect_start_pos]);
     }
     rgblight_set();
 }
@@ -1148,11 +1144,11 @@ void rgblight_effect_rgbtest(animation_status_t *anim) {
 
 #ifdef RGBLIGHT_EFFECT_ALTERNATING
 void rgblight_effect_alternating(animation_status_t *anim) {
-    for (int i = 0; i < effect_num_leds; i++) {
-        LED_TYPE *ledp = led + i + effect_start_pos;
-        if (i < effect_num_leds / 2 && anim->pos) {
+    for (int i = 0; i < rgblight_ranges.effect_num_leds; i++) {
+        LED_TYPE *ledp = led + i + rgblight_ranges.effect_start_pos;
+        if (i < rgblight_ranges.effect_num_leds / 2 && anim->pos) {
             sethsv(rgblight_config.hue, rgblight_config.sat, rgblight_config.val, ledp);
-        } else if (i >= effect_num_leds / 2 && !anim->pos) {
+        } else if (i >= rgblight_ranges.effect_num_leds / 2 && !anim->pos) {
             sethsv(rgblight_config.hue, rgblight_config.sat, rgblight_config.val, ledp);
         } else {
             sethsv(rgblight_config.hue, rgblight_config.sat, 0, ledp);

--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -107,11 +107,11 @@ LED_TYPE led[RGBLED_NUM];
 rgblight_segment_t const *const *rgblight_layers = NULL;
 #endif
 
-static uint8_t clipping_start_pos = 0;
-static uint8_t clipping_num_leds  = RGBLED_NUM;
-static uint8_t effect_start_pos   = 0;
-static uint8_t effect_end_pos     = RGBLED_NUM;
-static uint8_t effect_num_leds    = RGBLED_NUM;
+uint8_t clipping_start_pos = 0;
+uint8_t clipping_num_leds  = RGBLED_NUM;
+uint8_t effect_start_pos   = 0;
+uint8_t effect_end_pos     = RGBLED_NUM;
+uint8_t effect_num_leds    = RGBLED_NUM;
 
 void rgblight_set_clipping_range(uint8_t start_pos, uint8_t num_leds) {
     clipping_start_pos = start_pos;

--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -660,10 +660,15 @@ static void rgblight_layers_write(void) {
 }
 #endif
 
+__attribute__((weak))
+void rgblight_call_driver(LED_TYPE *start_led, uint8_t num_leds) {
+    ws2812_setleds(start_led, num_leds);
+}
+
 #ifndef RGBLIGHT_CUSTOM_DRIVER
 void rgblight_set(void) {
     LED_TYPE *start_led;
-    uint16_t  num_leds = rgblight_ranges.clipping_num_leds;
+    uint8_t  num_leds = rgblight_ranges.clipping_num_leds;
 
 #    ifdef RGBLIGHT_LAYERS
     if (rgblight_layers != NULL) {
@@ -697,7 +702,7 @@ void rgblight_set(void) {
         convert_rgb_to_rgbw(&start_led[i]);
     }
 #    endif
-    ws2812_setleds(start_led, num_leds);
+    rgblight_call_driver(start_led, num_leds);
 }
 #endif
 

--- a/quantum/rgblight.h
+++ b/quantum/rgblight.h
@@ -241,9 +241,7 @@ typedef struct _rgblight_ranges_t {
     uint8_t effect_num_leds;
 } rgblight_ranges_t;
 
-#    ifdef RGBLIGHT_CUSTOM_DRIVER
 extern rgblight_ranges_t rgblight_ranges;
-#    endif
 
 /* === Utility Functions ===*/
 void sethsv(uint8_t hue, uint8_t sat, uint8_t val, LED_TYPE *led1);

--- a/quantum/rgblight.h
+++ b/quantum/rgblight.h
@@ -130,7 +130,7 @@ enum RGBLIGHT_EFFECT_MODE {
 #    endif
 
 #    ifndef RGBLIGHT_EFFECT_KNIGHT_LED_NUM
-#        define RGBLIGHT_EFFECT_KNIGHT_LED_NUM (effect_num_leds)
+#        define RGBLIGHT_EFFECT_KNIGHT_LED_NUM (rgblight_ranges.effect_num_leds)
 #    endif
 
 #    ifndef RGBLIGHT_EFFECT_CHRISTMAS_INTERVAL
@@ -229,6 +229,21 @@ typedef struct _rgblight_status_t {
     uint8_t enabled_layer_mask;
 #    endif
 } rgblight_status_t;
+
+/*
+ * Structure for RGB Light clipping ranges
+ */
+typedef struct _rgblight_ranges_t {
+    uint8_t clipping_start_pos;
+    uint8_t clipping_num_leds;
+    uint8_t effect_start_pos;
+    uint8_t effect_end_pos;
+    uint8_t effect_num_leds;
+} rgblight_ranges_t;
+
+#    ifdef RGBLIGHT_CUSTOM_DRIVER
+extern rgblight_ranges_t rgblight_ranges;
+#    endif
 
 /* === Utility Functions ===*/
 void sethsv(uint8_t hue, uint8_t sat, uint8_t val, LED_TYPE *led1);

--- a/quantum/rgblight.h
+++ b/quantum/rgblight.h
@@ -160,9 +160,7 @@ enum RGBLIGHT_EFFECT_MODE {
 #    include <stdint.h>
 #    include <stdbool.h>
 #    include "eeconfig.h"
-#    ifndef RGBLIGHT_CUSTOM_DRIVER
-#        include "ws2812.h"
-#    endif
+#    include "ws2812.h"
 #    include "color.h"
 #    include "rgblight_list.h"
 


### PR DESCRIPTION
This allows these variables to be called by keyboard code that uses the custom rgb driver.

Right now, any keyboard using a custom rgblight driver cannot access these settings, so any benefit from using them is lost for those boards.  Such as the Ergodox EZ.  This allows them to be externed, so they can be used by those boards. 



## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
