### PR TITLE
Fix minor differences in docs/newbs_git_resynchronize_a_branch.md

### DIFF
--- a/docs/newbs_git_resynchronize_a_branch.md
+++ b/docs/newbs_git_resynchronize_a_branch.md
@@ -1,6 +1,6 @@
 # Resynchronizing an Out-of-Sync Git Branch
 
-Suppose you have committed to your `master` branch, and now need to update your QMK repository. You could `git pull` QMK's `master` branch into your own, but GitHub will tell you that your commit is a number of commits ahead of `qmk:master`, which can create issues if you want to make a pull request to QMK.
+Suppose you have committed to your `master` branch, and now need to update your QMK repository. You could `git pull` QMK's `master` branch into your own, but GitHub will tell you that your branch is a number of commits ahead of `qmk:master`, which can create issues if you want to make a pull request to QMK.
 
 ?> This document builds upon the concepts detailed in [Your Fork's Master: Update Often, Commit Never](newbs_git_using_your_master_branch.md). If you are not familiar with that document, please read it first, then return here.
 


### PR DESCRIPTION
## Description

In first paragraph
`GitHub will tell you that your commit is a number of commits ahead of qmk:master`
change to
`GitHub will tell you that your branch is a number of commits ahead of qmk:master`

Because, GitHub displays as follows.
<img src="https://user-images.githubusercontent.com/2170248/71514265-39299300-28e1-11ea-8074-79853a4cabba.png" width="50%">


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
