### PR TITLE
Add LUFA mass storage `BOOTLOADER` "support"

### DIFF
--- a/bootloader.mk
+++ b/bootloader.mk
@@ -82,6 +82,13 @@ ifeq ($(strip $(BOOTLOADER)), USBasp)
     OPT_DEFS += -DBOOTLOADER_USBASP
     BOOTLOADER_SIZE = 4096
 endif
+ifeq ($(strip $(BOOTLOADER)), lufa-ms)
+    # DO NOT USE THIS BOOTLOADER IN NEW PROJECTS!
+    # It is extremely prone to bricking, and is only included to support existing boards.
+    OPT_DEFS += -DBOOTLOADER_MS
+    BOOTLOADER_SIZE = 6144
+    FIRMWARE_FORMAT = bin
+endif
 
 ifdef BOOTLOADER_SIZE
     OPT_DEFS += -DBOOTLOADER_SIZE=$(strip $(BOOTLOADER_SIZE))

--- a/keyboards/gray_studio/cod67/rules.mk
+++ b/keyboards/gray_studio/cod67/rules.mk
@@ -9,10 +9,7 @@ MCU = atmega32u4
 #   QMK DFU      qmk-dfu
 #   ATmega32A    bootloadHID
 #   ATmega328P   USBasp
-BOOTLOADER = atmel-dfu # actually lufa-ms
-
-# Mass storage bootloader on the COD67 uses bin files
-FIRMWARE_FORMAT = bin
+BOOTLOADER = lufa-ms
 
 # Build Options
 #   change yes to no to disable

--- a/keyboards/tada68/rules.mk
+++ b/keyboards/tada68/rules.mk
@@ -9,10 +9,7 @@ MCU = atmega32u4
 #   QMK DFU      qmk-dfu
 #   ATmega32A    bootloadHID
 #   ATmega328P   USBasp
-BOOTLOADER = atmel-dfu # actually lufa-ms
-
-# Mass storage bootloader on the tada68 uses bin files
-FIRMWARE_FORMAT = bin
+BOOTLOADER = lufa-ms
 
 # Build Options
 #   comment out to disable the options.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Tested with a Pro Micro and the MassStorage bootloader from current submodule LUFA. Mainly interested in the behaviour of the `RESET` keycode as it was reportedly not working (possibly `BOOTLOADER_SIZE` was wrong, since `atmel-dfu` specifies 4kB instead of 6). It seems to work fine.

I purposely did not document this, nor add it to the list in the templates. I will not be QMK-ifying the bootloader in our fork a la QMK-DFU. For anyone stumbling across this wanting to have a mass storage bootloader: I _strongly_ advise against it 😄

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
