### PR TITLE
[Keyboard] Ergodox EZ - Re-init ISSI driver on reconnect

### DIFF
--- a/keyboards/ergodox_ez/matrix.c
+++ b/keyboards/ergodox_ez/matrix.c
@@ -122,6 +122,9 @@ uint8_t matrix_scan(void) {
       } else {
         print("left side attached\n");
         ergodox_blink_all_leds();
+#ifdef RGB_MATRIX_ENABLE
+        rgb_matrix_init(); // re-init driver on reconnect
+#endif
       }
     }
   }


### PR DESCRIPTION

## Description

When reconnecting the left half of the Ergodox EZ Glow, the RGB matrix doesn't work until it's re-init'ed.   And since the matrix code already handles this detection, we can use that to re-initialize the driver, so that the per key RGB will work immediately. 

I would prefer to use `rgb_matrix_driver.init();`, but in testing, this would error out, even though, it looks to be externed and included properly. 
However, this does work, and should be fine. 
## Types of Changes
- [x] Bugfix
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)

## Issues Fixed or Closed by This PR

* Left half Ergdox EZ Glow doesn't re-init driver on reconnect. 

## Checklist
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
