### PR TITLE
Partially port GET_SLAVE_STATUS from helix to split_common

### DIFF
--- a/quantum/split_common/transport.c
+++ b/quantum/split_common/transport.c
@@ -145,9 +145,9 @@ volatile Serial_rgblight_t serial_rgblight = {};
 uint8_t volatile status_rgblight           = 0;
 #    endif
 
-uint8_t volatile slave_buffer_change_count = 0;
 volatile Serial_s2m_buffer_t serial_s2m_buffer = {};
 volatile Serial_m2s_buffer_t serial_m2s_buffer = {};
+uint8_t volatile slave_buffer_change_count     = 0;
 uint8_t volatile status0                       = 0;
 
 enum serial_transaction_id {
@@ -169,11 +169,13 @@ SSTD_t transactions[] = {
         },
     [GET_SLAVE_STATUS] =
         /* master buffer not changed, only receive slave_buffer_change_count */
-        {
-            (uint8_t *)&status0,
-            0, NULL,
-            sizeof(slave_buffer_change_count), (uint8_t *)&slave_buffer_change_count,
-        },
+    {
+        (uint8_t *)&status0,
+        0,
+        NULL,
+        sizeof(slave_buffer_change_count),
+        (uint8_t *)&slave_buffer_change_count,
+    },
 #    if defined(RGBLIGHT_ENABLE) && defined(RGBLIGHT_SPLIT)
     [PUT_RGBLIGHT] =
         {
@@ -245,7 +247,7 @@ bool transport_master(matrix_row_t matrix[]) {
 void transport_slave(matrix_row_t matrix[]) {
     transport_rgblight_slave();
 
-    slave_buffer_change_count=0;
+    slave_buffer_change_count = 0;
     // TODO: if MATRIX_COLS > 8 change to pack()
     for (int i = 0; i < ROWS_PER_HAND; ++i) {
         slave_buffer_change_count += (serial_s2m_buffer.smatrix[i] != matrix[i]);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
To help with the slower scan rates on the current arm_split branch, this PR partially ports some of the helix code to split_common. GET_SLAVE_STATUS aims to quickly query the slave side if anything has changed, before requesting the full slave side matrix. My limited testing gives about a +50% increase to scan rate.

### Current scan rates
#### before
32u4 -> 1435
f303 -> 859

#### after
32u4 -> 2066
f303 -> 1321

In my limited testing with mashing keys, I have been unable to get f303 with GET_SLAVE_STATUS to slow down below what it was before. (Speedup might change for boards not ortho_4x12) 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
