### PR TITLE
Relocate rgblight and backlight task

### DIFF
--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -634,12 +634,8 @@ void matrix_scan_quantum() {
     matrix_scan_combo();
 #endif
 
-#if defined(BACKLIGHT_ENABLE)
-#    if defined(LED_MATRIX_ENABLE)
+#ifdef LED_MATRIX_ENABLE
     led_matrix_task();
-#    elif defined(BACKLIGHT_PIN) || defined(BACKLIGHT_PINS)
-    backlight_task();
-#    endif
 #endif
 
 #ifdef RGB_MATRIX_ENABLE

--- a/tmk_core/common/keyboard.c
+++ b/tmk_core/common/keyboard.c
@@ -335,6 +335,16 @@ MATRIX_LOOP_END:
     matrix_scan_perf_task();
 #endif
 
+#if defined(RGBLIGHT_ANIMATIONS) && defined(RGBLIGHT_ENABLE)
+    rgblight_task();
+#endif
+
+#if defined(BACKLIGHT_ENABLE)
+#    if defined(BACKLIGHT_PIN) || defined(BACKLIGHT_PINS)
+    backlight_task();
+#    endif
+#endif
+
 #ifdef QWIIC_ENABLE
     qwiic_task();
 #endif

--- a/tmk_core/protocol/chibios/main.c
+++ b/tmk_core/protocol/chibios/main.c
@@ -220,8 +220,5 @@ int main(void) {
 #ifdef RAW_ENABLE
         raw_hid_task();
 #endif
-#if defined(RGBLIGHT_ANIMATIONS) && defined(RGBLIGHT_ENABLE)
-        rgblight_task();
-#endif
     }
 }

--- a/tmk_core/protocol/lufa/lufa.c
+++ b/tmk_core/protocol/lufa/lufa.c
@@ -998,10 +998,6 @@ int main(void) {
         MIDI_Device_USBTask(&USB_MIDI_Interface);
 #endif
 
-#if defined(RGBLIGHT_ANIMATIONS) && defined(RGBLIGHT_ENABLE)
-        rgblight_task();
-#endif
-
 #ifdef MODULE_ADAFRUIT_BLE
         adafruit_ble_task();
 #endif

--- a/tmk_core/protocol/vusb/main.c
+++ b/tmk_core/protocol/vusb/main.c
@@ -99,10 +99,6 @@ int main(void) {
             // To prevent failing to configure NOT scan keyboard during configuration
             if (usbConfiguration && usbInterruptIsReady()) {
                 keyboard_task();
-
-#if defined(RGBLIGHT_ANIMATIONS) && defined(RGBLIGHT_ENABLE)
-                rgblight_task();
-#endif
             }
             vusb_transfer_keyboard();
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->
## Description

<!--- Describe your changes in detail here. -->
Backlight with CTPC wasnt happy on arm_split, where it would only function on the master slide. While moving backlight_task, rgblight_task also looked out of place at the protocol level so that was moved too.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
