### PR TITLE
Keebio RGB wiring update

### DIFF
--- a/keyboards/keebio/bfo9000/config.h
+++ b/keyboards/keebio/bfo9000/config.h
@@ -53,6 +53,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* ws2812 RGB LED */
 #define RGB_DI_PIN B4
 #define RGBLED_NUM 20    // Number of LEDs
+#define RGBLED_SPLIT { 10, 10 }
 
 /*
  * Feature disable options

--- a/keyboards/keebio/fourier/config.h
+++ b/keyboards/keebio/fourier/config.h
@@ -65,6 +65,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGB_DI_PIN D3
 #define RGBLIGHT_ANIMATIONS
 #define RGBLED_NUM 14    // Number of LEDs
+#define RGBLED_SPLIT { 7, 7 }
 
 /*
  * Feature disable options

--- a/keyboards/keebio/iris/rev2/config.h
+++ b/keyboards/keebio/iris/rev2/config.h
@@ -60,4 +60,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D3
 #define RGBLED_NUM 12    // Number of LEDs
+#define RGBLED_SPLIT { 6, 6 }
 #define RGBLIGHT_ANIMATIONS

--- a/keyboards/keebio/levinson/rev1/config.h
+++ b/keyboards/keebio/levinson/rev1/config.h
@@ -51,8 +51,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D3
-
 #define RGBLED_NUM 12    // Number of LEDs
+#define RGBLED_SPLIT { 6, 6 }
 
 /* Backlight LEDs */
 #define BACKLIGHT_PIN C6

--- a/keyboards/keebio/levinson/rev2/config.h
+++ b/keyboards/keebio/levinson/rev2/config.h
@@ -51,8 +51,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D3
-
 #define RGBLED_NUM 12    // Number of LEDs
+#define RGBLED_SPLIT { 6, 6 }
 
 /* Backlight LEDs */
 #define BACKLIGHT_PIN B5

--- a/keyboards/keebio/nyquist/rev1/config.h
+++ b/keyboards/keebio/nyquist/rev1/config.h
@@ -56,8 +56,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D3
-
-#define RGBLED_NUM 16    // Number of LEDs
+#define RGBLED_NUM 12
+#define RGBLED_SPLIT { 6, 6 }
 
 /*
  * Feature disable options

--- a/keyboards/keebio/nyquist/rev2/config.h
+++ b/keyboards/keebio/nyquist/rev2/config.h
@@ -53,8 +53,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D3
-
-#define RGBLED_NUM 16    // Number of LEDs
+#define RGBLED_NUM 12
+#define RGBLED_SPLIT { 6, 6 }
 
 /* Backlight LEDs */
 #define BACKLIGHT_PIN B6

--- a/keyboards/keebio/quefrency/keymaps/drashna_ms/config.h
+++ b/keyboards/keebio/quefrency/keymaps/drashna_ms/config.h
@@ -29,6 +29,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     #define RGBLIGHT_SPLIT
     #undef  RGBLED_NUM
     #define RGBLED_NUM 17
+    #undef RGBLED_SPLIT
     #define RGBLED_SPLIT { 9, 8 }
     #define RGBLIGHT_SLEEP
 #endif

--- a/keyboards/keebio/quefrency/rev1/config.h
+++ b/keyboards/keebio/quefrency/rev1/config.h
@@ -55,6 +55,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGB_DI_PIN D3
 #define RGBLIGHT_ANIMATIONS
 #define RGBLED_NUM 16    // Number of LEDs
+#define RGBLED_SPLIT { 8, 8 }
 
 // Set 65% column (option 1) and Macro (option 2) on by default
 #define VIA_EEPROM_LAYOUT_OPTIONS_DEFAULT 0x60

--- a/keyboards/keebio/viterbi/rev1/config.h
+++ b/keyboards/keebio/viterbi/rev1/config.h
@@ -51,3 +51,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D3
 #define RGBLED_NUM 14
+#define RGBLED_SPLIT { 7, 7 }

--- a/keyboards/keebio/viterbi/rev2/config.h
+++ b/keyboards/keebio/viterbi/rev2/config.h
@@ -50,6 +50,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D3
 #define RGBLED_NUM 14
+#define RGBLED_SPLIT { 7, 7 }
 
 /* Backlight LEDs */
 #define BACKLIGHT_PIN B6


### PR DESCRIPTION
## Description

Change configuration for Keebio split boards to use the same RGB strip wiring for each half, which provides the following improvements:

1. Easier wiring due to one fewer wire needed (the wire between left DOut to extra data pin) and the fact that wiring is the same for both halves.
2. RGB LEDs can be controlled by each half now instead of just master half.
3. Extra data line is freed up to allow for I2C usage instead of serial.

Keebio docs have also been updated already to reflect new wiring setup.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
