### PR TITLE
Move CORTEX_ENABLE_WFI_IDLE=TRUE to rules.mk files

### DIFF
--- a/keyboards/at_at/660m/chconf.h
+++ b/keyboards/at_at/660m/chconf.h
@@ -105,10 +105,6 @@
  */
 #define CH_CFG_NO_IDLE_THREAD               FALSE
 
-/* Use __WFI in the idle thread for waiting. Does lower the power
- * consumption. */
-#define CORTEX_ENABLE_WFI_IDLE              TRUE
-
 /** @} */
 
 /*===========================================================================*/

--- a/keyboards/at_at/660m/rules.mk
+++ b/keyboards/at_at/660m/rules.mk
@@ -17,3 +17,6 @@ CUSTOM_MATRIX = no # Custom matrix file
 # RGBLIGHT_ENABLE = yes
 NO_USB_STARTUP_CHECK = yes # Workaround for issue 6369
 
+
+# Enter lower-power sleep mode when on the ChibiOS idle thread
+OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/candybar/chconf.h
+++ b/keyboards/candybar/chconf.h
@@ -105,10 +105,6 @@
  */
 #define CH_CFG_NO_IDLE_THREAD               FALSE
 
-/* Use __WFI in the idle thread for waiting. Does lower the power
- * consumption. */
-#define CORTEX_ENABLE_WFI_IDLE              TRUE
-
 /** @} */
 
 /*===========================================================================*/

--- a/keyboards/candybar/rules.mk
+++ b/keyboards/candybar/rules.mk
@@ -18,3 +18,7 @@ NKRO_ENABLE = yes     # USB Nkey Rollover
 AUDIO_ENABLE = no
 RGBLIGHT_ENABLE = no
 SERIAL_LINK_ENABLE = no
+
+
+# Enter lower-power sleep mode when on the ChibiOS idle thread
+OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/cannonkeys/an_c/chconf.h
+++ b/keyboards/cannonkeys/an_c/chconf.h
@@ -105,10 +105,6 @@
  */
 #define CH_CFG_NO_IDLE_THREAD               FALSE
 
-/* Use __WFI in the idle thread for waiting. Does lower the power
- * consumption. */
-#define CORTEX_ENABLE_WFI_IDLE              TRUE
-
 /** @} */
 
 /*===========================================================================*/

--- a/keyboards/cannonkeys/an_c/rules.mk
+++ b/keyboards/cannonkeys/an_c/rules.mk
@@ -22,3 +22,7 @@ CUSTOM_MATRIX = no # Custom matrix file
 RGBLIGHT_ENABLE = yes
 
 LAYOUTS = 60_ansi 60_tsangan_hhkb
+
+
+# Enter lower-power sleep mode when on the ChibiOS idle thread
+OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/cannonkeys/chimera65/chconf.h
+++ b/keyboards/cannonkeys/chimera65/chconf.h
@@ -105,10 +105,6 @@
  */
 #define CH_CFG_NO_IDLE_THREAD               FALSE
 
-/* Use __WFI in the idle thread for waiting. Does lower the power
- * consumption. */
-#define CORTEX_ENABLE_WFI_IDLE              TRUE
-
 /** @} */
 
 /*===========================================================================*/

--- a/keyboards/cannonkeys/chimera65/rules.mk
+++ b/keyboards/cannonkeys/chimera65/rules.mk
@@ -20,3 +20,7 @@ NKRO_ENABLE = yes	    # USB Nkey Rollover
 CUSTOM_MATRIX = no # Custom matrix file
 # BACKLIGHT_ENABLE = yes # This is broken on 072 for some reason
 RGBLIGHT_ENABLE = no
+
+
+# Enter lower-power sleep mode when on the ChibiOS idle thread
+OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/cannonkeys/instant60/chconf.h
+++ b/keyboards/cannonkeys/instant60/chconf.h
@@ -105,10 +105,6 @@
  */
 #define CH_CFG_NO_IDLE_THREAD               FALSE
 
-/* Use __WFI in the idle thread for waiting. Does lower the power
- * consumption. */
-#define CORTEX_ENABLE_WFI_IDLE              TRUE
-
 /** @} */
 
 /*===========================================================================*/

--- a/keyboards/cannonkeys/instant60/rules.mk
+++ b/keyboards/cannonkeys/instant60/rules.mk
@@ -22,3 +22,7 @@ CUSTOM_MATRIX = no # Custom matrix file
 RGBLIGHT_ENABLE = yes
 
 LAYOUTS = 60_ansi 60_tsangan_hhkb
+
+
+# Enter lower-power sleep mode when on the ChibiOS idle thread
+OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/cannonkeys/iron165/chconf.h
+++ b/keyboards/cannonkeys/iron165/chconf.h
@@ -105,10 +105,6 @@
  */
 #define CH_CFG_NO_IDLE_THREAD               FALSE
 
-/* Use __WFI in the idle thread for waiting. Does lower the power
- * consumption. */
-#define CORTEX_ENABLE_WFI_IDLE              TRUE
-
 /** @} */
 
 /*===========================================================================*/

--- a/keyboards/cannonkeys/iron165/rules.mk
+++ b/keyboards/cannonkeys/iron165/rules.mk
@@ -20,3 +20,7 @@ NKRO_ENABLE = yes	    # USB Nkey Rollover
 CUSTOM_MATRIX = no # Custom matrix file
 # BACKLIGHT_ENABLE = yes # This is broken on 072 for some reason
 RGBLIGHT_ENABLE = no
+
+
+# Enter lower-power sleep mode when on the ChibiOS idle thread
+OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/cannonkeys/ortho48/chconf.h
+++ b/keyboards/cannonkeys/ortho48/chconf.h
@@ -105,10 +105,6 @@
  */
 #define CH_CFG_NO_IDLE_THREAD               FALSE
 
-/* Use __WFI in the idle thread for waiting. Does lower the power
- * consumption. */
-#define CORTEX_ENABLE_WFI_IDLE              TRUE
-
 /** @} */
 
 /*===========================================================================*/

--- a/keyboards/cannonkeys/ortho48/rules.mk
+++ b/keyboards/cannonkeys/ortho48/rules.mk
@@ -25,3 +25,7 @@ BACKLIGHT_ENABLE = yes
 RGBLIGHT_ENABLE = yes
 
 LAYOUTS = ortho_4x12
+
+
+# Enter lower-power sleep mode when on the ChibiOS idle thread
+OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/cannonkeys/ortho60/chconf.h
+++ b/keyboards/cannonkeys/ortho60/chconf.h
@@ -105,10 +105,6 @@
  */
 #define CH_CFG_NO_IDLE_THREAD               FALSE
 
-/* Use __WFI in the idle thread for waiting. Does lower the power
- * consumption. */
-#define CORTEX_ENABLE_WFI_IDLE              TRUE
-
 /** @} */
 
 /*===========================================================================*/

--- a/keyboards/cannonkeys/ortho60/rules.mk
+++ b/keyboards/cannonkeys/ortho60/rules.mk
@@ -25,3 +25,7 @@ BACKLIGHT_ENABLE = yes
 RGBLIGHT_ENABLE = yes
 
 LAYOUTS = ortho_5x12
+
+
+# Enter lower-power sleep mode when on the ChibiOS idle thread
+OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/cannonkeys/ortho75/chconf.h
+++ b/keyboards/cannonkeys/ortho75/chconf.h
@@ -105,10 +105,6 @@
  */
 #define CH_CFG_NO_IDLE_THREAD               FALSE
 
-/* Use __WFI in the idle thread for waiting. Does lower the power
- * consumption. */
-#define CORTEX_ENABLE_WFI_IDLE              TRUE
-
 /** @} */
 
 /*===========================================================================*/

--- a/keyboards/cannonkeys/ortho75/rules.mk
+++ b/keyboards/cannonkeys/ortho75/rules.mk
@@ -26,3 +26,7 @@ RGBLIGHT_ENABLE = yes
 ENCODER_ENABLE = yes
 
 LAYOUTS = ortho_5x15
+
+
+# Enter lower-power sleep mode when on the ChibiOS idle thread
+OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/cannonkeys/practice60/chconf.h
+++ b/keyboards/cannonkeys/practice60/chconf.h
@@ -105,10 +105,6 @@
  */
 #define CH_CFG_NO_IDLE_THREAD               FALSE
 
-/* Use __WFI in the idle thread for waiting. Does lower the power
- * consumption. */
-#define CORTEX_ENABLE_WFI_IDLE              TRUE
-
 /** @} */
 
 /*===========================================================================*/

--- a/keyboards/cannonkeys/practice60/rules.mk
+++ b/keyboards/cannonkeys/practice60/rules.mk
@@ -27,3 +27,7 @@ RGBLIGHT_ENABLE = yes
 LAYOUTS = 60_ansi
 
 DEFAULT_FOLDER = cannonkeys/practice60
+
+
+# Enter lower-power sleep mode when on the ChibiOS idle thread
+OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/cannonkeys/practice65/chconf.h
+++ b/keyboards/cannonkeys/practice65/chconf.h
@@ -105,10 +105,6 @@
  */
 #define CH_CFG_NO_IDLE_THREAD               FALSE
 
-/* Use __WFI in the idle thread for waiting. Does lower the power
- * consumption. */
-#define CORTEX_ENABLE_WFI_IDLE              TRUE
-
 /** @} */
 
 /*===========================================================================*/

--- a/keyboards/cannonkeys/practice65/rules.mk
+++ b/keyboards/cannonkeys/practice65/rules.mk
@@ -23,3 +23,7 @@ SLEEP_LED_ENABLE = yes  # Breathing sleep LED during USB suspend
 NKRO_ENABLE = yes	    # USB Nkey Rollover
 BACKLIGHT_ENABLE = yes
 RGBLIGHT_ENABLE = yes
+
+
+# Enter lower-power sleep mode when on the ChibiOS idle thread
+OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/cannonkeys/satisfaction75/chconf.h
+++ b/keyboards/cannonkeys/satisfaction75/chconf.h
@@ -105,10 +105,6 @@
  */
 #define CH_CFG_NO_IDLE_THREAD               FALSE
 
-/* Use __WFI in the idle thread for waiting. Does lower the power
- * consumption. */
-#define CORTEX_ENABLE_WFI_IDLE              TRUE
-
 /** @} */
 
 /*===========================================================================*/

--- a/keyboards/cannonkeys/satisfaction75/rules.mk
+++ b/keyboards/cannonkeys/satisfaction75/rules.mk
@@ -22,3 +22,7 @@ QWIIC_ENABLE += MICRO_OLED
 #BACKLIGHT_ENABLE = yes
 
 DEFAULT_FOLDER = cannonkeys/satisfaction75/rev1
+
+
+# Enter lower-power sleep mode when on the ChibiOS idle thread
+OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/cannonkeys/savage65/chconf.h
+++ b/keyboards/cannonkeys/savage65/chconf.h
@@ -105,10 +105,6 @@
  */
 #define CH_CFG_NO_IDLE_THREAD               FALSE
 
-/* Use __WFI in the idle thread for waiting. Does lower the power
- * consumption. */
-#define CORTEX_ENABLE_WFI_IDLE              TRUE
-
 /** @} */
 
 /*===========================================================================*/

--- a/keyboards/cannonkeys/savage65/rules.mk
+++ b/keyboards/cannonkeys/savage65/rules.mk
@@ -21,3 +21,6 @@ CUSTOM_MATRIX = no # Custom matrix file
 # BACKLIGHT_ENABLE = yes # This is broken on 072 for some reason
 RGBLIGHT_ENABLE = yes
 
+
+# Enter lower-power sleep mode when on the ChibiOS idle thread
+OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/cannonkeys/tmov2/chconf.h
+++ b/keyboards/cannonkeys/tmov2/chconf.h
@@ -105,10 +105,6 @@
  */
 #define CH_CFG_NO_IDLE_THREAD               FALSE
 
-/* Use __WFI in the idle thread for waiting. Does lower the power
- * consumption. */
-#define CORTEX_ENABLE_WFI_IDLE              TRUE
-
 /** @} */
 
 /*===========================================================================*/

--- a/keyboards/cannonkeys/tmov2/rules.mk
+++ b/keyboards/cannonkeys/tmov2/rules.mk
@@ -21,3 +21,6 @@ CUSTOM_MATRIX = no # Custom matrix file
 # BACKLIGHT_ENABLE = yes # This is broken on 072 right now
 RGBLIGHT_ENABLE = yes
 
+
+# Enter lower-power sleep mode when on the ChibiOS idle thread
+OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/converter/siemens_tastatur/chconf.h
+++ b/keyboards/converter/siemens_tastatur/chconf.h
@@ -105,10 +105,6 @@
  */
 #define CH_CFG_NO_IDLE_THREAD               FALSE
 
-/* Use __WFI in the idle thread for waiting. Does lower the power
- * consumption. */
-#define CORTEX_ENABLE_WFI_IDLE              TRUE
-
 /** @} */
 
 /*===========================================================================*/

--- a/keyboards/converter/siemens_tastatur/rules.mk
+++ b/keyboards/converter/siemens_tastatur/rules.mk
@@ -22,3 +22,6 @@ BACKLIGHT_ENABLE = no
 RGBLIGHT_ENABLE = no
 CUSTOM_MATRIX = yes
 
+
+# Enter lower-power sleep mode when on the ChibiOS idle thread
+OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/ergodox_stm32/chconf.h
+++ b/keyboards/ergodox_stm32/chconf.h
@@ -105,10 +105,6 @@
  */
 #define CH_CFG_NO_IDLE_THREAD               FALSE
 
-/* Use __WFI in the idle thread for waiting. Does lower the power
- * consumption. */
-#define CORTEX_ENABLE_WFI_IDLE              TRUE
-
 /** @} */
 
 /*===========================================================================*/

--- a/keyboards/ergodox_stm32/rules.mk
+++ b/keyboards/ergodox_stm32/rules.mk
@@ -30,3 +30,7 @@ NKRO_ENABLE = yes	    # USB Nkey Rollover
 CUSTOM_MATRIX = yes # Custom matrix file
 NKRO_ENABLE      = yes # USB Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
 UNICODE_ENABLE   = yes # Unicode
+
+
+# Enter lower-power sleep mode when on the ChibiOS idle thread
+OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/handwired/bluepill/bluepill70/chconf.h
+++ b/keyboards/handwired/bluepill/bluepill70/chconf.h
@@ -105,10 +105,6 @@
  */
 #define CH_CFG_NO_IDLE_THREAD               FALSE
 
-/* Use __WFI in the idle thread for waiting. Does lower the power
- * consumption. */
-#define CORTEX_ENABLE_WFI_IDLE              TRUE
-
 /** @} */
 
 /*===========================================================================*/

--- a/keyboards/handwired/bluepill/bluepill70/rules.mk
+++ b/keyboards/handwired/bluepill/bluepill70/rules.mk
@@ -45,3 +45,7 @@ ARMV = 7
 # This also requires a patch to chibios:
 #   <tmk_dir>/tmk_core/tool/chibios/ch-bootloader-jump.patch
 #STM32_BOOTLOADER_ADDRESS = 0x1FFFC800
+
+
+# Enter lower-power sleep mode when on the ChibiOS idle thread
+OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/handwired/ck4x4/chconf.h
+++ b/keyboards/handwired/ck4x4/chconf.h
@@ -105,10 +105,6 @@
  */
 #define CH_CFG_NO_IDLE_THREAD               FALSE
 
-/* Use __WFI in the idle thread for waiting. Does lower the power
- * consumption. */
-#define CORTEX_ENABLE_WFI_IDLE              TRUE
-
 /** @} */
 
 /*===========================================================================*/

--- a/keyboards/handwired/ck4x4/rules.mk
+++ b/keyboards/handwired/ck4x4/rules.mk
@@ -15,3 +15,7 @@ NKRO_ENABLE = yes	    # USB Nkey Rollover
 CUSTOM_MATRIX = no # Custom matrix file
 
 DEFAULT_FOLDER = handwired/ck4x4
+
+
+# Enter lower-power sleep mode when on the ChibiOS idle thread
+OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/handwired/onekey/bluepill/chconf.h
+++ b/keyboards/handwired/onekey/bluepill/chconf.h
@@ -105,10 +105,6 @@
  */
 #define CH_CFG_NO_IDLE_THREAD               FALSE
 
-/* Use __WFI in the idle thread for waiting. Does lower the power
- * consumption. */
-#define CORTEX_ENABLE_WFI_IDLE              TRUE
-
 /** @} */
 
 /*===========================================================================*/

--- a/keyboards/handwired/onekey/bluepill/rules.mk
+++ b/keyboards/handwired/onekey/bluepill/rules.mk
@@ -8,3 +8,7 @@ BOARD = GENERIC_STM32_F103
 
 DFU_ARGS = -d 1eaf:0003 -a2 -R
 DFU_SUFFIX_ARGS = -v 1eaf -p 0003
+
+
+# Enter lower-power sleep mode when on the ChibiOS idle thread
+OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/handwired/onekey/stm32f0_disco/chconf.h
+++ b/keyboards/handwired/onekey/stm32f0_disco/chconf.h
@@ -105,10 +105,6 @@
  */
 #define CH_CFG_NO_IDLE_THREAD               FALSE
 
-/* Use __WFI in the idle thread for waiting. Does lower the power
- * consumption. */
-#define CORTEX_ENABLE_WFI_IDLE              TRUE
-
 /** @} */
 
 /*===========================================================================*/

--- a/keyboards/handwired/onekey/stm32f0_disco/rules.mk
+++ b/keyboards/handwired/onekey/stm32f0_disco/rules.mk
@@ -1,2 +1,6 @@
 # MCU name
 MCU = STM32F072
+
+
+# Enter lower-power sleep mode when on the ChibiOS idle thread
+OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/handwired/onekey/teensy_32/chconf.h
+++ b/keyboards/handwired/onekey/teensy_32/chconf.h
@@ -105,10 +105,6 @@
  */
 #define CH_CFG_NO_IDLE_THREAD               FALSE
 
-/* Use __WFI in the idle thread for waiting. Does lower the power
- * consumption. */
-#define CORTEX_ENABLE_WFI_IDLE              TRUE
-
 /** @} */
 
 /*===========================================================================*/

--- a/keyboards/handwired/onekey/teensy_32/rules.mk
+++ b/keyboards/handwired/onekey/teensy_32/rules.mk
@@ -39,3 +39,7 @@ MCU  = cortex-m4
 # ARM version, CORTEX-M0/M1 are 6, CORTEX-M3/M4/M7 are 7
 # I.e. 6 for Teensy LC; 7 for Teensy 3.x
 ARMV = 7
+
+
+# Enter lower-power sleep mode when on the ChibiOS idle thread
+OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/handwired/onekey/teensy_lc/chconf.h
+++ b/keyboards/handwired/onekey/teensy_lc/chconf.h
@@ -105,10 +105,6 @@
  */
 #define CH_CFG_NO_IDLE_THREAD               FALSE
 
-/* Use __WFI in the idle thread for waiting. Does lower the power
- * consumption. */
-#define CORTEX_ENABLE_WFI_IDLE              TRUE
-
 /** @} */
 
 /*===========================================================================*/

--- a/keyboards/handwired/onekey/teensy_lc/rules.mk
+++ b/keyboards/handwired/onekey/teensy_lc/rules.mk
@@ -39,3 +39,7 @@ MCU  = cortex-m0plus
 # ARM version, CORTEX-M0/M1 are 6, CORTEX-M3/M4/M7 are 7
 # I.e. 6 for Teensy LC; 7 for Teensy 3.x
 ARMV = 6
+
+
+# Enter lower-power sleep mode when on the ChibiOS idle thread
+OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/infinity60/chconf.h
+++ b/keyboards/infinity60/chconf.h
@@ -105,10 +105,6 @@
  */
 #define CH_CFG_NO_IDLE_THREAD               FALSE
 
-/* Use __WFI in the idle thread for waiting. Does lower the power
- * consumption. */
-#define CORTEX_ENABLE_WFI_IDLE              TRUE
-
 /** @} */
 
 /*===========================================================================*/

--- a/keyboards/infinity60/rules.mk
+++ b/keyboards/infinity60/rules.mk
@@ -73,3 +73,7 @@ NKRO_ENABLE = yes	    # USB Nkey Rollover
 CUSTOM_MATRIX = yes # Custom matrix file
 
 LAYOUTS = 60_ansi_split_bs_rshift
+
+
+# Enter lower-power sleep mode when on the ChibiOS idle thread
+OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/jm60/chconf.h
+++ b/keyboards/jm60/chconf.h
@@ -105,10 +105,6 @@
  */
 #define CH_CFG_NO_IDLE_THREAD               FALSE
 
-/* Use __WFI in the idle thread for waiting. Does lower the power
- * consumption. */
-#define CORTEX_ENABLE_WFI_IDLE              TRUE
-
 /** @} */
 
 /*===========================================================================*/

--- a/keyboards/jm60/rules.mk
+++ b/keyboards/jm60/rules.mk
@@ -34,7 +34,7 @@ ARMV = 7
 # 0x00000000-0x00001000 area is occupied by bootlaoder.*/
 # The CORTEX_VTOR... is needed only for MCHCK/Infinity KB
 #OPT_DEFS = -DCORTEX_VTOR_INIT=0x00001000
-OPT_DEFS = 
+OPT_DEFS =
 
 # Build Options
 #   comment out to disable the options.
@@ -52,5 +52,9 @@ BACKLIGHT_ENABLE = no
 VISUALIZER_ENABLE = no
 
 #LED_DRIVER = is31fl3731c
-#LED_WIDTH = 16 
+#LED_WIDTH = 16
 #LED_HEIGHT = 5
+
+
+# Enter lower-power sleep mode when on the ChibiOS idle thread
+OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/k_type/chconf.h
+++ b/keyboards/k_type/chconf.h
@@ -105,10 +105,6 @@
  */
 #define CH_CFG_NO_IDLE_THREAD               FALSE
 
-/* Use __WFI in the idle thread for waiting. Does lower the power
- * consumption. */
-#define CORTEX_ENABLE_WFI_IDLE              TRUE
-
 /** @} */
 
 /*===========================================================================*/

--- a/keyboards/k_type/rules.mk
+++ b/keyboards/k_type/rules.mk
@@ -74,3 +74,7 @@ SLEEP_LED_ENABLE = yes  # Breathing sleep LED during USB suspend
 NKRO_ENABLE = yes	    # USB Nkey Rollover
 CUSTOM_MATRIX = yes # Custom matrix file
 DEBUG_ENABLE = yes
+
+
+# Enter lower-power sleep mode when on the ChibiOS idle thread
+OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/peiorisboards/ixora/chconf.h
+++ b/keyboards/peiorisboards/ixora/chconf.h
@@ -102,10 +102,6 @@
  */
 #define CH_CFG_NO_IDLE_THREAD               FALSE
 
-/* Use __WFI in the idle thread for waiting. Does lower the power
- * consumption. */
-#define CORTEX_ENABLE_WFI_IDLE              TRUE
-
 /** @} */
 
 /*===========================================================================*/

--- a/keyboards/peiorisboards/ixora/rules.mk
+++ b/keyboards/peiorisboards/ixora/rules.mk
@@ -12,3 +12,7 @@ CONSOLE_ENABLE = no					# Console for debug
 COMMAND_ENABLE = no    				# Commands for debug and configuration
 NKRO_ENABLE = yes					# USB Nkey Rollover
 NO_USB_STARTUP_CHECK = no         	# Disable initialization only when usb is plugged in
+
+
+# Enter lower-power sleep mode when on the ChibiOS idle thread
+OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/projectkb/alice/chconf.h
+++ b/keyboards/projectkb/alice/chconf.h
@@ -105,10 +105,6 @@
  */
 #define CH_CFG_NO_IDLE_THREAD               FALSE
 
-/* Use __WFI in the idle thread for waiting. Does lower the power
- * consumption. */
-#define CORTEX_ENABLE_WFI_IDLE              TRUE
-
 /** @} */
 
 /*===========================================================================*/

--- a/keyboards/projectkb/alice/rules.mk
+++ b/keyboards/projectkb/alice/rules.mk
@@ -23,3 +23,7 @@ RGBLIGHT_ENABLE = yes
 
 # RAW_ENABLE = yes
 # DYNAMIC_KEYMAP_ENABLE = yes
+
+
+# Enter lower-power sleep mode when on the ChibiOS idle thread
+OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/vinta/chconf.h
+++ b/keyboards/vinta/chconf.h
@@ -102,10 +102,6 @@
  */
 #define CH_CFG_NO_IDLE_THREAD               FALSE
 
-/* Use __WFI in the idle thread for waiting. Does lower the power
- * consumption. */
-#define CORTEX_ENABLE_WFI_IDLE              TRUE
-
 /** @} */
 
 /*===========================================================================*/

--- a/keyboards/vinta/rules.mk
+++ b/keyboards/vinta/rules.mk
@@ -14,3 +14,7 @@ NKRO_ENABLE = yes					# USB Nkey Rollover
 NO_USB_STARTUP_CHECK = no         	# Disable initialization only when usb is plugged in
 
 LAYOUTS = 65_ansi_blocker
+
+
+# Enter lower-power sleep mode when on the ChibiOS idle thread
+OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/whitefox/chconf.h
+++ b/keyboards/whitefox/chconf.h
@@ -105,10 +105,6 @@
  */
 #define CH_CFG_NO_IDLE_THREAD               FALSE
 
-/* Use __WFI in the idle thread for waiting. Does lower the power
- * consumption. */
-#define CORTEX_ENABLE_WFI_IDLE              TRUE
-
 /** @} */
 
 /*===========================================================================*/

--- a/keyboards/whitefox/rules.mk
+++ b/keyboards/whitefox/rules.mk
@@ -77,3 +77,7 @@ VISUALIZER_ENABLE = yes
 LED_DRIVER = is31fl3731c
 LED_WIDTH = 16
 LED_HEIGHT = 5
+
+
+# Enter lower-power sleep mode when on the ChibiOS idle thread
+OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The ChibiOS upgrade branch utilises scripts provided in their repo for updating the respective conf.h files.
It seems as if there's been a fair bit of copy/paste going on with respect to configurations, and the flag `CORTEX_ENABLE_WFI_IDLE=TRUE` has been replicated in a lot of places.
Unfortunately executing the upgrade scripts nukes this definition in the conf files. After discussion on Discord with @zvecr it seemed like splitting this out into rules.mk would make the upgrade review process smoother.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
