### PR TITLE
Fix dztech/dz60rgb_ansi/v1 firmware by turning off NKey rollover. 

### DIFF
--- a/keyboards/dztech/dz60rgb_ansi/v1/rules.mk
+++ b/keyboards/dztech/dz60rgb_ansi/v1/rules.mk
@@ -12,7 +12,7 @@ COMMAND_ENABLE = no            # Commands for debug and configuration
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
 SLEEP_LED_ENABLE = no          # Breathing sleep LED during USB suspend
 # if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
-NKRO_ENABLE = yes              # USB Nkey Rollover
+NKRO_ENABLE = no               # USB Nkey Rollover
 BACKLIGHT_ENABLE = no          # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no           # Enable keyboard RGB underglow
 MIDI_ENABLE = no               # MIDI support


### PR DESCRIPTION
The default layout for `dztech/dz60rgb_ansi/v1` will render most modifier keys & some of the right hand side symbols useless on V1 of dz60rgb_ansi PCB (STM32). Disabling Nkey Rollover seems to have fixed the problem.  

Note that I don't have V2 of the PCB to test, so I cannot confirm if `NKRO_ENABLE = yes` is affecting V2 as well.  I did, however, test `dztech/dz60rgb/v1` and it was working fine with NKey rollover on.

## Types of Changes
- [x] Bugfix

