### PR TITLE
Chibios usbStartTransmitI null checks

### DIFF
--- a/tmk_core/protocol/chibios.mk
+++ b/tmk_core/protocol/chibios.mk
@@ -6,6 +6,7 @@ SRC += $(CHIBIOS_DIR)/usb_main.c
 SRC += $(CHIBIOS_DIR)/main.c
 SRC += usb_descriptor.c
 SRC += $(CHIBIOS_DIR)/usb_driver.c
+SRC += $(CHIBIOS_DIR)/usb_shim.c
 
 VPATH += $(TMK_PATH)/$(PROTOCOL_DIR)
 VPATH += $(TMK_PATH)/$(CHIBIOS_DIR)

--- a/tmk_core/protocol/chibios/usb_shim.c
+++ b/tmk_core/protocol/chibios/usb_shim.c
@@ -1,0 +1,9 @@
+#include <stddef.h>
+#include "hal.h"
+#include "usb_driver.h"
+
+void usbStartTransmitIGuard(USBDriver *usbp, usbep_t ep, const uint8_t *buf, size_t n) {
+  if (usbp->epc[ep] != NULL) {
+    usbStartTransmitI(usbp, ep, buf, n);
+  }
+}

--- a/tmk_core/protocol/chibios/usb_shim.c
+++ b/tmk_core/protocol/chibios/usb_shim.c
@@ -7,3 +7,9 @@ void usbStartTransmitIGuard(USBDriver *usbp, usbep_t ep, const uint8_t *buf, siz
     usbStartTransmitI(usbp, ep, buf, n);
   }
 }
+
+void usbStartReceiveIGuard(USBDriver *usbp, usbep_t ep, uint8_t *buf, size_t n) {
+  if (usbp->epc[ep] != NULL) {
+      usbStartReceiveI(usbp, ep, buf, n);
+  }
+}

--- a/tmk_core/protocol/chibios/usb_shim.h
+++ b/tmk_core/protocol/chibios/usb_shim.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void usbStartTransmitIGuard(USBDriver *usbp, usbep_t ep, const uint8_t *buf, size_t n);

--- a/tmk_core/protocol/chibios/usb_shim.h
+++ b/tmk_core/protocol/chibios/usb_shim.h
@@ -1,3 +1,4 @@
 #pragma once
 
 void usbStartTransmitIGuard(USBDriver *usbp, usbep_t ep, const uint8_t *buf, size_t n);
+void usbStartReceiveIGuard(USBDriver *usbp, usbep_t ep, const uint8_t *buf, size_t n);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Just testing ideas because of @xyz and @daagaak on how to prevent ARM from crashing on starting up from USB powerdown, all credit for debugging goes to them. This is just to confirm diagnosis.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
