### PR TITLE
[WIP] chibios/main: after USB resume, wait for endpoints to appear

### DIFF
--- a/tmk_core/protocol/chibios/main.c
+++ b/tmk_core/protocol/chibios/main.c
@@ -197,6 +197,12 @@ int main(void) {
                     usbWakeupHost(&USB_DRIVER);
                 }
             }
+
+            /* Wait for USB to configure, otherwise we have no endpoints */
+            while (!usb_configured()) {
+                wait_ms(50);
+            }
+
             /* Woken up */
             // variables has been already cleared by the wakeup hook
             send_keyboard_report();

--- a/tmk_core/protocol/chibios/usb_main.c
+++ b/tmk_core/protocol/chibios/usb_main.c
@@ -292,6 +292,12 @@ static usb_driver_configs_t drivers = {
  * ---------------------------------------------------------
  */
 
+static volatile bool is_usb_configured;
+
+bool usb_configured(void) {
+    return is_usb_configured;
+}
+
 /* Handles the USB driver global events
  * TODO: maybe disable some things when connection is lost? */
 static void usb_event_cb(USBDriver *usbp, usbevent_t event) {
@@ -319,6 +325,7 @@ static void usb_event_cb(USBDriver *usbp, usbevent_t event) {
                 }
                 qmkusbConfigureHookI(&drivers.array[i].driver);
             }
+            is_usb_configured = TRUE;
             osalSysUnlockFromISR();
             return;
         case USB_EVENT_SUSPEND:
@@ -329,6 +336,8 @@ static void usb_event_cb(USBDriver *usbp, usbevent_t event) {
         case USB_EVENT_UNCONFIGURED:
             /* Falls into.*/
         case USB_EVENT_RESET:
+            is_usb_configured = FALSE;
+
             for (int i = 0; i < NUM_USB_DRIVERS; i++) {
                 chSysLockFromISR();
                 /* Disconnection event on suspend.*/

--- a/tmk_core/protocol/chibios/usb_main.h
+++ b/tmk_core/protocol/chibios/usb_main.h
@@ -35,6 +35,9 @@
 /* Initialize the USB driver and bus */
 void init_usb_driver(USBDriver *usbp);
 
+/* Whether USB is currently configured */
+bool usb_configured(void);
+
 /* ---------------
  * Keyboard header
  * ---------------


### PR DESCRIPTION
Fixes #5585

## Description

When we resume from suspend we have no endpoints and must wait for them to appear.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #5585 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
