### PR TITLE
chibios/usb_main: re-check USB status in send_keyboard after sleeping the thread

### DIFF
--- a/tmk_core/protocol/chibios/usb_main.c
+++ b/tmk_core/protocol/chibios/usb_main.c
@@ -620,8 +620,7 @@ uint8_t keyboard_leds(void) { return (uint8_t)(keyboard_led_stats & 0xFF); }
 void send_keyboard(report_keyboard_t *report) {
     osalSysLock();
     if (usbGetDriverStateI(&USB_DRIVER) != USB_ACTIVE) {
-        osalSysUnlock();
-        return;
+        goto unlock;
     }
 
 #ifdef NKRO_ENABLE
@@ -640,8 +639,7 @@ void send_keyboard(report_keyboard_t *report) {
 
             /* after osalThreadSuspendS returns USB status might have changed */
             if (usbGetDriverStateI(&USB_DRIVER) != USB_ACTIVE) {
-                osalSysUnlock();
-                return;
+                goto unlock;
             }
         }
         usbStartTransmitI(&USB_DRIVER, SHARED_IN_EPNUM, (uint8_t *)report, sizeof(struct nkro_report));
@@ -659,8 +657,7 @@ void send_keyboard(report_keyboard_t *report) {
 
             /* after osalThreadSuspendS returns USB status might have changed */
             if (usbGetDriverStateI(&USB_DRIVER) != USB_ACTIVE) {
-                osalSysUnlock();
-                return;
+                goto unlock;
             }
         }
         uint8_t *data, size;
@@ -674,6 +671,8 @@ void send_keyboard(report_keyboard_t *report) {
         usbStartTransmitI(&USB_DRIVER, KEYBOARD_IN_EPNUM, data, size);
     }
     keyboard_report_sent = *report;
+
+unlock:
     osalSysUnlock();
 }
 


### PR DESCRIPTION
Fixes #5585 (attempt 2)

## Description

USB status might change from USB_ACTIVE while the thread is sleeping in `osalThreadSuspendS`. If the status is not USB_ACTIVE, we don't have any endpoints and attempting to send on them crashes. Discard these sends. Also fix a race condition in the same function. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #5585 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
