### PR TITLE
Fix docker script and document

### DIFF
--- a/docs/getting_started_build_tools.md
+++ b/docs/getting_started_build_tools.md
@@ -120,12 +120,12 @@ If this is a bit complex for you, Docker might be the turnkey solution you need.
 util/docker_build.sh keyboard:keymap
 # For example: util/docker_build.sh ergodox_ez:steno
 ```
-This will compile the desired keyboard/keymap and leave the resulting `.hex` or `.bin` file in the QMK directory for you to flash. If `:keymap` is omitted, the `default` keymap is used. Note that the parameter format is the same as when building with `make`.
+This will compile the desired keyboard/keymap and leave the resulting `.hex` or `.bin` file in the QMK directory for you to flash. If `:keymap` is omitted, all keymaps are used. Note that the parameter format is the same as when building with `make`.
 
 You can also start the script without any parameters, in which case it will ask you to input the build parameters one by one, which you may find easier to use:
 ```bash
 util/docker_build.sh
-# Reads parameters as input (leave blank for defaults)
+# Reads parameters as input (leave blank for all keyboards/keymaps)
 ```
 
 There is also support for building _and_ flashing the keyboard straight from Docker by specifying the `target` as well:

--- a/util/docker_build.sh
+++ b/util/docker_build.sh
@@ -37,6 +37,9 @@ else
 		exit 1
 	fi
 fi
+if [ -z "$keyboard" ]; then
+	keyboard=all
+fi
 if [ -n "$target" ]; then
 	if [ "$(uname)" = "Linux" ] || docker-machine active >/dev/null 2>&1; then
 		usb_args="--privileged -v /dev:/dev"


### PR DESCRIPTION
## Description

Fixed error when keyboard parameter is omitted in interactive mode.

```
util/docker_build.sh
keyboard=
make: *** empty string invalid as file name.  Stop.
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
