### PR TITLE
V-USB: Use manufacturer and product strings from config.h

### DIFF
--- a/keyboards/ares/config.h
+++ b/keyboards/ares/config.h
@@ -23,7 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define PRODUCT_ID      0x422D
 #define DEVICE_VER      0x0200
 #define MANUFACTURER    LSJ
-#define PRODUCT         QMK Firmware for Ares
+#define PRODUCT         Ares
 
 #define RGBLED_NUM 16
 

--- a/keyboards/ares/usbconfig.h
+++ b/keyboards/ares/usbconfig.h
@@ -231,31 +231,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'L', 'S', 'J'
-#define USB_CFG_VENDOR_NAME_LEN 3
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'A', 'r', 'e', 's'
-#define USB_CFG_DEVICE_NAME_LEN 4
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -337,11 +312,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/bfake/config.h
+++ b/keyboards/bfake/config.h
@@ -22,8 +22,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0x20A0
 #define PRODUCT_ID      0x422D
 #define DEVICE_VER      0x0200
-#define MANUFACTURER    NotActuallyWinkeyless
-#define PRODUCT         b.fake
+#define MANUFACTURER    NotWinkeyless
+#define PRODUCT         B.fake
 
 #define RGBLED_NUM 16
 

--- a/keyboards/bfake/usbconfig.h
+++ b/keyboards/bfake/usbconfig.h
@@ -231,31 +231,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'w', 'i', 'n', 'k', 'e', 'y', 'l', 'e', 's', 's', '.', 'k', 'r'
-#define USB_CFG_VENDOR_NAME_LEN 13
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'p', 's', '2', 'a', 'v', 'r', 'G', 'B'
-#define USB_CFG_DEVICE_NAME_LEN 8
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -337,11 +312,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/chidori/usbconfig.h
+++ b/keyboards/chidori/usbconfig.h
@@ -231,31 +231,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'K','a','g','i','z','a','r','a','y','a'
-#define USB_CFG_VENDOR_NAME_LEN 10
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'C', 'h', 'i', 'd', 'o', 'r', 'i'
-#define USB_CFG_DEVICE_NAME_LEN 7
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -337,11 +312,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/coseyfannitutti/discipad/usbconfig.h
+++ b/keyboards/coseyfannitutti/discipad/usbconfig.h
@@ -231,31 +231,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'c','o','s','e','y','f','a','n','n','i','t','u','t','t','i'
-#define USB_CFG_VENDOR_NAME_LEN 15
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'D','I','S','C','I','P','A','D'
-#define USB_CFG_DEVICE_NAME_LEN 8
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-#define USB_CFG_SERIAL_NUMBER   '0'
-#define USB_CFG_SERIAL_NUMBER_LEN   1
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -337,11 +312,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/coseyfannitutti/discipline/usbconfig.h
+++ b/keyboards/coseyfannitutti/discipline/usbconfig.h
@@ -231,31 +231,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'c','o','s','e','y','f','a','n','n','i','t','u','t','t','i'
-#define USB_CFG_VENDOR_NAME_LEN 15
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'D','I','S','C','I','P','L','I','N','E'
-#define USB_CFG_DEVICE_NAME_LEN 10
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-#define USB_CFG_SERIAL_NUMBER   '0'
-#define USB_CFG_SERIAL_NUMBER_LEN   1
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -337,11 +312,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/coseyfannitutti/mysterium/usbconfig.h
+++ b/keyboards/coseyfannitutti/mysterium/usbconfig.h
@@ -231,31 +231,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'c','o','s','e','y','f','a','n','n','i','t','u','t','t','i'
-#define USB_CFG_VENDOR_NAME_LEN 15
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'M','Y','S','T','E','R','I','U','M'
-#define USB_CFG_DEVICE_NAME_LEN 9
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-#define USB_CFG_SERIAL_NUMBER   '0'
-#define USB_CFG_SERIAL_NUMBER_LEN   1
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -337,11 +312,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/coseyfannitutti/romeo/usbconfig.h
+++ b/keyboards/coseyfannitutti/romeo/usbconfig.h
@@ -231,31 +231,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'c','o','s','e','y','f','a','n','n','i','t','u','t','t','i'
-#define USB_CFG_VENDOR_NAME_LEN 15
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'R','O','M','E','O'
-#define USB_CFG_DEVICE_NAME_LEN 5
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-#define USB_CFG_SERIAL_NUMBER   '0'
-#define USB_CFG_SERIAL_NUMBER_LEN   1
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -337,11 +312,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/db/db63/config.h
+++ b/keyboards/db/db63/config.h
@@ -20,8 +20,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0xFAAD
 #define PRODUCT_ID      0x422D
 #define DEVICE_VER      0x0200
-// You can edit those at usbconfig.h about line 250. These values will
-// unforunatly be ignored so far
 #define MANUFACTURER    HNB
 #define PRODUCT         DB63v1 Hotswap
 

--- a/keyboards/db/db63/usbconfig.h
+++ b/keyboards/db/db63/usbconfig.h
@@ -230,31 +230,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'H', 'N', 'B'
-#define USB_CFG_VENDOR_NAME_LEN 3
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'D', 'B', '6', '3', 'H', 'S'
-#define USB_CFG_DEVICE_NAME_LEN 6
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -336,11 +311,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/donutcables/budget96/usbconfig.h
+++ b/keyboards/donutcables/budget96/usbconfig.h
@@ -230,31 +230,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'D', 'o', 'n', 'u', 't', 'C', 'a', 'b', 'l', 'e', 's'
-#define USB_CFG_VENDOR_NAME_LEN 11
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'b', 'u', 'd', 'g', 'e', 't', '9', '6'
-#define USB_CFG_DEVICE_NAME_LEN 8
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -336,11 +311,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/eve/meteor/usbconfig.h
+++ b/keyboards/eve/meteor/usbconfig.h
@@ -220,31 +220,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'w', 'i', 'n', 'k', 'e', 'y', 'l', 'e', 's', 's', '.', 'k', 'r'
-#define USB_CFG_VENDOR_NAME_LEN 13
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'p', 's', '2', 'a', 'v', 'r', 'G', 'B'
-#define USB_CFG_DEVICE_NAME_LEN 8
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -326,11 +301,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/exclusive/e6v2/le_bmc/config.h
+++ b/keyboards/exclusive/e6v2/le_bmc/config.h
@@ -21,8 +21,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0xFEED
 #define PRODUCT_ID      0x0000
 #define DEVICE_VER      0x0001
-#define MANUFACTURER    exclusive
-#define PRODUCT         e6v2 le bmc
+#define MANUFACTURER    Exclusive / E-Team
+#define PRODUCT         E6-V2 LE BMC
 #define DESCRIPTION     A custom 60% keyboard
 
 /* key matrix size */

--- a/keyboards/exclusive/e6v2/le_bmc/usbconfig.h
+++ b/keyboards/exclusive/e6v2/le_bmc/usbconfig.h
@@ -230,31 +230,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'E', 'x', 'c', 'l', 'u', 's', 'i', 'v', 'e'
-#define USB_CFG_VENDOR_NAME_LEN 9
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'E', '6', 'V', '2'
-#define USB_CFG_DEVICE_NAME_LEN 4
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -336,11 +311,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/exclusive/e6v2/oe_bmc/config.h
+++ b/keyboards/exclusive/e6v2/oe_bmc/config.h
@@ -21,8 +21,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0xFEED
 #define PRODUCT_ID      0x0000
 #define DEVICE_VER      0x0001
-#define MANUFACTURER    exclusive
-#define PRODUCT         e6v2 oe bmc
+#define MANUFACTURER    Exclusive / E-Team
+#define PRODUCT         E6-V2 OE BMC
 #define DESCRIPTION     A custom 60% keyboard
 
 /* key matrix size */

--- a/keyboards/exclusive/e6v2/oe_bmc/usbconfig.h
+++ b/keyboards/exclusive/e6v2/oe_bmc/usbconfig.h
@@ -230,31 +230,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'E', 'x', 'c', 'l', 'u', 's', 'i', 'v', 'e'
-#define USB_CFG_VENDOR_NAME_LEN 9
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'E', '6', 'V', '2'
-#define USB_CFG_DEVICE_NAME_LEN 4
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -336,11 +311,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/exent/usbconfig.h
+++ b/keyboards/exent/usbconfig.h
@@ -220,31 +220,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME 'w', 'i', 'n', 'k', 'e', 'y', 'l', 'e', 's', 's', '.', 'k', 'r'
-#define USB_CFG_VENDOR_NAME_LEN 13
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME 'p', 's', '2', 'a', 'v', 'r', 'G', 'B'
-#define USB_CFG_DEVICE_NAME_LEN 8
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS 0
 #define USB_CFG_DEVICE_SUBCLASS 0
 /* See USB specification if you want to conform to an existing device class.
@@ -326,11 +301,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE 0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS 0
-#define USB_CFG_DESCR_PROPS_STRING_0 0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR 0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT 0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER 0
+#define USB_CFG_DESCR_PROPS_STRINGS USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT USB_PROP_IS_DYNAMIC

--- a/keyboards/facew/config.h
+++ b/keyboards/facew/config.h
@@ -22,8 +22,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0x20A0
 #define PRODUCT_ID      0x422D
 #define DEVICE_VER      0x0200
-#define MANUFACTURER    NotActuallyWinkeyless
-#define PRODUCT         facew
+#define MANUFACTURER    SPRiT
+#define PRODUCT         FaceW
 
 #define RGBLED_NUM 16
 

--- a/keyboards/facew/usbconfig.h
+++ b/keyboards/facew/usbconfig.h
@@ -230,31 +230,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'S', 'p', 'r', 'i', 't'
-#define USB_CFG_VENDOR_NAME_LEN 5
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'F', 'a', 'c', 'e', 'W'
-#define USB_CFG_DEVICE_NAME_LEN 5
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -336,11 +311,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/ft/mars80/usbconfig.h
+++ b/keyboards/ft/mars80/usbconfig.h
@@ -230,31 +230,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'f', 't'
-#define USB_CFG_VENDOR_NAME_LEN 2
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'm', 'a', 'r', 's', '8', '0'
-#define USB_CFG_DEVICE_NAME_LEN 6
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -336,11 +311,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/gingham/usbconfig.h
+++ b/keyboards/gingham/usbconfig.h
@@ -231,31 +231,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'Y','i','a','n','c','a','r','-','D','e', 's', 'i', 'g', 'n', 's'
-#define USB_CFG_VENDOR_NAME_LEN 15
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'G', 'i', 'n', 'g', 'h', 'a', 'm'
-#define USB_CFG_DEVICE_NAME_LEN 7
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-#define USB_CFG_SERIAL_NUMBER   '0'
-#define USB_CFG_SERIAL_NUMBER_LEN   1
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -337,11 +312,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/gray_studio/hb85/usbconfig.h
+++ b/keyboards/gray_studio/hb85/usbconfig.h
@@ -230,31 +230,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'G', 'r', 'a', 'y', ' ', 'S', 't', 'u', 'd', 'i', 'o'
-#define USB_CFG_VENDOR_NAME_LEN 11
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'H', 'B', '8', '5'
-#define USB_CFG_DEVICE_NAME_LEN 4
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -336,11 +311,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/handwired/hnah40/config.h
+++ b/keyboards/handwired/hnah40/config.h
@@ -23,7 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define PRODUCT_ID      0x0000
 #define DEVICE_VER      0x0002
 #define MANUFACTURER    HnahKB
-#define PRODUCT         hnah40
+#define PRODUCT         Hnah40
 #define DESCRIPTION     Custom 40% PCB
 
 /* key matrix size */

--- a/keyboards/handwired/hnah40/usbconfig.h
+++ b/keyboards/handwired/hnah40/usbconfig.h
@@ -231,31 +231,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'H','n','a','h','K','B'
-#define USB_CFG_VENDOR_NAME_LEN 6
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'H', 'n', 'a', 'h', '4', '0'
-#define USB_CFG_DEVICE_NAME_LEN 6
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-#define USB_CFG_SERIAL_NUMBER   'H','n','a','h','K','B'
-#define USB_CFG_SERIAL_NUMBER_LEN   6
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -337,11 +312,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/j80/usbconfig.h
+++ b/keyboards/j80/usbconfig.h
@@ -220,31 +220,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME 'J', 'E', 'R'
-#define USB_CFG_VENDOR_NAME_LEN 3
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME 'J', '8', '0'
-#define USB_CFG_DEVICE_NAME_LEN 3
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS 0
 #define USB_CFG_DEVICE_SUBCLASS 0
 /* See USB specification if you want to conform to an existing device class.
@@ -326,11 +301,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE 0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS 0
-#define USB_CFG_DESCR_PROPS_STRING_0 0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR 0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT 0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER 0
+#define USB_CFG_DESCR_PROPS_STRINGS USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT USB_PROP_IS_DYNAMIC

--- a/keyboards/jc65/v32a/config.h
+++ b/keyboards/jc65/v32a/config.h
@@ -22,8 +22,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0x1234
 #define PRODUCT_ID      0x5679
 #define DEVICE_VER      0x0200
-#define MANUFACTURER    winkeyless.kr
-#define PRODUCT         JC65 PS2AVRGB
+#define MANUFACTURER    RAMA
+#define PRODUCT         JC65 BMC
 
 /* matrix size */
 #define MATRIX_ROWS 7

--- a/keyboards/jc65/v32a/usbconfig.h
+++ b/keyboards/jc65/v32a/usbconfig.h
@@ -231,31 +231,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'w', 'i', 'n', 'k', 'e', 'y', 'l', 'e', 's', 's', '.', 'k', 'r'
-#define USB_CFG_VENDOR_NAME_LEN 13
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'p', 's', '2', 'a', 'v', 'r', 'G', 'B'
-#define USB_CFG_DEVICE_NAME_LEN 8
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -337,11 +312,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/jj40/config.h
+++ b/keyboards/jj40/config.h
@@ -19,10 +19,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0x20A0
 #define PRODUCT_ID      0x422D
 #define DEVICE_VER      0x0200
-// TODO: share these strings with usbconfig.h
-// Edit usbconfig.h to change these.
-#define MANUFACTURER    Kprepublic
-#define PRODUCT         jj40
+#define MANUFACTURER    KPrepublic
+#define PRODUCT         JJ40
 
 /* matrix size */
 #define MATRIX_ROWS 4

--- a/keyboards/jj40/usbconfig.h
+++ b/keyboards/jj40/usbconfig.h
@@ -231,31 +231,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'w', 'i', 'n', 'k', 'e', 'y', 'l', 'e', 's', 's', '.', 'k', 'r'
-#define USB_CFG_VENDOR_NAME_LEN 13
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'j', 'j', '4', '0'
-#define USB_CFG_DEVICE_NAME_LEN 4
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -337,11 +312,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/jj4x4/config.h
+++ b/keyboards/jj4x4/config.h
@@ -22,10 +22,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0x20A0
 #define PRODUCT_ID      0x422D
 #define DEVICE_VER      0x0200
-// TODO: share these strings with usbconfig.h
-// Edit usbconfig.h to change these.
-#define MANUFACTURER    Kprepublic
-#define PRODUCT         jj4x4
+#define MANUFACTURER    KPrepublic
+#define PRODUCT         JJ4x4
 
 /* matrix size */
 #define MATRIX_ROWS 4

--- a/keyboards/jj4x4/usbconfig.h
+++ b/keyboards/jj4x4/usbconfig.h
@@ -231,31 +231,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'w', 'i', 'n', 'k', 'e', 'y', 'l', 'e', 's', 's', '.', 'k', 'r'
-#define USB_CFG_VENDOR_NAME_LEN 13
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'j', 'j', '4', 'x', '4'
-#define USB_CFG_DEVICE_NAME_LEN 5
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -337,11 +312,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/jj50/config.h
+++ b/keyboards/jj50/config.h
@@ -25,10 +25,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0x20A0
 #define PRODUCT_ID      0x422D
 #define DEVICE_VER      0x0200
-// TODO: share these strings with usbconfig.h
-// Edit usbconfig.h to change these.
-#define MANUFACTURER    kprepublic
-#define PRODUCT         jj50
+#define MANUFACTURER    KPrepublic
+#define PRODUCT         JJ50
 #define DESCRIPTION     Preonic-like clone
 
 /* matrix size */

--- a/keyboards/jj50/usbconfig.h
+++ b/keyboards/jj50/usbconfig.h
@@ -231,31 +231,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'K', 'P', 'R', 'e', 'p', 'u', 'b', 'l', 'i', 'c'
-#define USB_CFG_VENDOR_NAME_LEN 10
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'J','J','5','0',' ','K','e','y','b','o','a','r','d'
-#define USB_CFG_DEVICE_NAME_LEN 13
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -337,11 +312,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/kbdfans/kbdpad/mk1/config.h
+++ b/keyboards/kbdfans/kbdpad/mk1/config.h
@@ -23,7 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define PRODUCT_ID      0x422D
 #define DEVICE_VER      0x0200
 #define MANUFACTURER    KBDfans
-#define PRODUCT         KBDPAD-MKI
+#define PRODUCT         KBDPAD Mk. I
 
 #define MATRIX_ROWS 6
 #define MATRIX_COLS 4

--- a/keyboards/kbdfans/kbdpad/mk1/usbconfig.h
+++ b/keyboards/kbdfans/kbdpad/mk1/usbconfig.h
@@ -230,31 +230,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'w', 'i', 'n', 'k', 'e', 'y', 'l', 'e', 's', 's', '.', 'k', 'r'
-#define USB_CFG_VENDOR_NAME_LEN 13
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'p', 's', '2', 'a', 'v', 'r', 'G', 'B'
-#define USB_CFG_DEVICE_NAME_LEN 8
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -336,11 +311,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/keycapsss/plaid_pad/usbconfig.h
+++ b/keyboards/keycapsss/plaid_pad/usbconfig.h
@@ -230,31 +230,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'K','e','y','c','a','p','s','s','s'
-#define USB_CFG_VENDOR_NAME_LEN 9
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'P', 'l', 'a', 'i', 'd', '-', 'P', 'a', 'd'
-#define USB_CFG_DEVICE_NAME_LEN 9
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -336,11 +311,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/kira80/usbconfig.h
+++ b/keyboards/kira80/usbconfig.h
@@ -231,31 +231,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'E', 'V', 'E'
-#define USB_CFG_VENDOR_NAME_LEN 3
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'K', 'i', 'r', 'a', '8', '0'
-#define USB_CFG_DEVICE_NAME_LEN 6
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -337,11 +312,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/leeku/finger65/config.h
+++ b/keyboards/leeku/finger65/config.h
@@ -24,7 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define PRODUCT_ID      0x6050
 #define DEVICE_VER      0x0100
 #define MANUFACTURER    LeeKu
-#define PRODUCT         L3
+#define PRODUCT         Finger65
 #define DESCRIPTION     QMK keyboard firmware for L3
 
 #define RGBLED_NUM 12

--- a/keyboards/leeku/finger65/usbconfig.h
+++ b/keyboards/leeku/finger65/usbconfig.h
@@ -230,31 +230,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'L', 'e', 'e', 'k', 'u'
-#define USB_CFG_VENDOR_NAME_LEN 5
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'F', 'i', 'n', 'g', 'e', 'r', '6', '5'
-#define USB_CFG_DEVICE_NAME_LEN 8
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -335,11 +310,11 @@ section at the end of this file).
 
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0

--- a/keyboards/mechmini/v1/config.h
+++ b/keyboards/mechmini/v1/config.h
@@ -22,8 +22,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0xFEED
 #define PRODUCT_ID      0xCA40
 #define DEVICE_VER      0x0001
-// TODO: share these strings with usbconfig.h
-// Edit usbconfig.h to change these.
 #define MANUFACTURER    MECHKEYS
 #define PRODUCT         Mechmini
 #define DESCRIPTION     40% modular keyboard

--- a/keyboards/mechmini/v1/usbconfig.h
+++ b/keyboards/mechmini/v1/usbconfig.h
@@ -231,31 +231,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'w', 'i', 'n', 'k', 'e', 'y', 'l', 'e', 's', 's', '.', 'k', 'r'
-#define USB_CFG_VENDOR_NAME_LEN 13
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'p', 's', '2', 'a', 'v', 'r', 'G', 'B'
-#define USB_CFG_DEVICE_NAME_LEN 8
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -337,11 +312,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/mehkee96/config.h
+++ b/keyboards/mehkee96/config.h
@@ -6,8 +6,8 @@
 #define VENDOR_ID       0x20A0
 #define PRODUCT_ID      0x422D
 #define DEVICE_VER      0x0200
-#define MANUFACTURER    mehkee
-#define PRODUCT         96kee
+#define MANUFACTURER    Mehkee
+#define PRODUCT         96KEE
 
 /* matrix size */
 #define MATRIX_ROWS 8

--- a/keyboards/mehkee96/usbconfig.h
+++ b/keyboards/mehkee96/usbconfig.h
@@ -231,31 +231,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'w', 'i', 'n', 'k', 'e', 'y', 'l', 'e', 's', 's', '.', 'k', 'r'
-#define USB_CFG_VENDOR_NAME_LEN 13
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'p', 's', '2', 'a', 'v', 'r', 'G', 'B'
-#define USB_CFG_DEVICE_NAME_LEN 8
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -337,11 +312,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/mt40/config.h
+++ b/keyboards/mt40/config.h
@@ -27,7 +27,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define DEVICE_VER      0x0001
 
 #define MANUFACTURER    ThomasDehaeze
-#define PRODUCT         mt40
+#define PRODUCT         MT40
 
 #define DESCRIPTION     A Planck clone
 

--- a/keyboards/mt40/usbconfig.h
+++ b/keyboards/mt40/usbconfig.h
@@ -231,31 +231,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'T', 'h', 'o', 'm', 'a', 's', 'D', 'e', 'h', 'a', 'e', 'z', 'e'
-#define USB_CFG_VENDOR_NAME_LEN 13
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'c', 'u', 's', 't', 'o', 'm', '4', '8'
-#define USB_CFG_DEVICE_NAME_LEN 8
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -337,11 +312,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/panc60/config.h
+++ b/keyboards/panc60/config.h
@@ -23,7 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define PRODUCT_ID      0x422D
 #define DEVICE_VER      0x0200
 #define MANUFACTURER    Panc Interactive
-#define PRODUCT         panc60
+#define PRODUCT         Panc60
 
 #define RGBLED_NUM 12
 

--- a/keyboards/panc60/usbconfig.h
+++ b/keyboards/panc60/usbconfig.h
@@ -230,31 +230,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'w', 'i', 'n', 'k', 'e', 'y', 'l', 'e', 's', 's', '.', 'k', 'r'
-#define USB_CFG_VENDOR_NAME_LEN 13
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'p', 's', '2', 'a', 'v', 'r', 'G', 'B'
-#define USB_CFG_DEVICE_NAME_LEN 8
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -336,11 +311,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/pearl/usbconfig.h
+++ b/keyboards/pearl/usbconfig.h
@@ -230,31 +230,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'w', 'i', 'n', 'k', 'e', 'y', 'l', 'e', 's', 's', '.', 'k', 'r'
-#define USB_CFG_VENDOR_NAME_LEN 13
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'p', 's', '2', 'a', 'v', 'r', 'G', 'B'
-#define USB_CFG_DEVICE_NAME_LEN 8
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -336,11 +311,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/percent/canoe/config.h
+++ b/keyboards/percent/canoe/config.h
@@ -23,7 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0x20A0
 #define PRODUCT_ID      0x422D
 #define DEVICE_VER      0x0200
-#define MANUFACTURER    NotActuallyPercent
+#define MANUFACTURER    Percent Studios
 #define PRODUCT         CANOE
 
 #define RGBLED_NUM 2

--- a/keyboards/percent/canoe/usbconfig.h
+++ b/keyboards/percent/canoe/usbconfig.h
@@ -231,31 +231,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'w', 'i', 'n', 'k', 'e', 'y', 'l', 'e', 's', 's', '.', 'k', 'r'
-#define USB_CFG_VENDOR_NAME_LEN 13
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'p', 's', '2', 'a', 'v', 'r', 'G', 'B'
-#define USB_CFG_DEVICE_NAME_LEN 8
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -337,11 +312,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/percent/skog/config.h
+++ b/keyboards/percent/skog/config.h
@@ -21,7 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define PRODUCT_ID      0x422D
 #define DEVICE_VER      0x0200
 
-#define MANUFACTURER    Percent
+#define MANUFACTURER    Percent Studios
 #define PRODUCT         Skog TKL
 
 /* matrix size */

--- a/keyboards/percent/skog/usbconfig.h
+++ b/keyboards/percent/skog/usbconfig.h
@@ -231,31 +231,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'P','e','r','c','e','n','t'
-#define USB_CFG_VENDOR_NAME_LEN 7
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'S','k','o','g',' ','T','K','L'
-#define USB_CFG_DEVICE_NAME_LEN 8
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -337,11 +312,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/percent/skog_lite/config.h
+++ b/keyboards/percent/skog_lite/config.h
@@ -22,7 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0x20A0
 #define PRODUCT_ID      0x422D
 #define DEVICE_VER      0x0200
-#define MANUFACTURER    Percent
+#define MANUFACTURER    Percent Studios
 #define PRODUCT         Skog Lite
 
 #define RGBLED_NUM 18

--- a/keyboards/percent/skog_lite/usbconfig.h
+++ b/keyboards/percent/skog_lite/usbconfig.h
@@ -230,31 +230,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'w', 'i', 'n', 'k', 'e', 'y', 'l', 'e', 's', 's', '.', 'k', 'r'
-#define USB_CFG_VENDOR_NAME_LEN 13
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'p', 's', '2', 'a', 'v', 'r', 'G', 'B'
-#define USB_CFG_DEVICE_NAME_LEN 8
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -336,11 +311,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/plaid/config.h
+++ b/keyboards/plaid/config.h
@@ -25,7 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define PRODUCT_ID 0x27db
 #define DEVICE_VER 0x0002
 #define MANUFACTURER dm9records
-#define PRODUCT plaid
+#define PRODUCT Plaid
 #define DESCRIPTION 12x4 ortholinear keyboard with through hole components
 
 /* key matrix size */

--- a/keyboards/plaid/usbconfig.h
+++ b/keyboards/plaid/usbconfig.h
@@ -231,31 +231,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'd','m','9','r','e','c','o','r','d','s'
-#define USB_CFG_VENDOR_NAME_LEN 10
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'P', 'l', 'a', 'i', 'd'
-#define USB_CFG_DEVICE_NAME_LEN 5
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-#define USB_CFG_SERIAL_NUMBER   'd','m','9','r','e','c','o','r','d','s','.','c','o','m',':','p','1'
-#define USB_CFG_SERIAL_NUMBER_LEN   17
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -337,11 +312,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/singa/usbconfig.h
+++ b/keyboards/singa/usbconfig.h
@@ -230,31 +230,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'w', 'i', 'n', 'k', 'e', 'y', 'l', 'e', 's', 's', '.', 'k', 'r'
-#define USB_CFG_VENDOR_NAME_LEN 13
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'p', 's', '2', 'a', 'v', 'r', 'G', 'B'
-#define USB_CFG_DEVICE_NAME_LEN 8
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -336,11 +311,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/tartan/usbconfig.h
+++ b/keyboards/tartan/usbconfig.h
@@ -230,31 +230,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'd','m','9','r','e','c','o','r','d','s'
-#define USB_CFG_VENDOR_NAME_LEN 10
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'T', 'a', 'r', 't', 'a', 'n'
-#define USB_CFG_DEVICE_NAME_LEN 6
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-#define USB_CFG_SERIAL_NUMBER   'd','m','9','r','e','c','o','r','d','s','.','c','o','m',':','t','1'
-#define USB_CFG_SERIAL_NUMBER_LEN   17
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -336,11 +311,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/tgr/alice/config.h
+++ b/keyboards/tgr/alice/config.h
@@ -20,10 +20,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0x20A0
 #define PRODUCT_ID      0x422E
 #define DEVICE_VER      0x0200
-// TODO: share these strings with usbconfig.h
-// Edit usbconfig.h to change these.
 #define MANUFACTURER    TGR
-#define PRODUCT         TGR Alice
+#define PRODUCT         Alice
 
 /* matrix size */
 #define MATRIX_ROWS 6

--- a/keyboards/tgr/alice/usbconfig.h
+++ b/keyboards/tgr/alice/usbconfig.h
@@ -231,31 +231,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'T', 'G', 'R'
-#define USB_CFG_VENDOR_NAME_LEN 3
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'T', 'G', 'R', ' ', 'A', 'l', 'i', 'c', 'e'
-#define USB_CFG_DEVICE_NAME_LEN 9
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -337,11 +312,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/tgr/jane/usbconfig.h
+++ b/keyboards/tgr/jane/usbconfig.h
@@ -230,31 +230,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'w', 'i', 'n', 'k', 'e', 'y', 'l', 'e', 's', 's', '.', 'k', 'r'
-#define USB_CFG_VENDOR_NAME_LEN 13
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'p', 's', '2', 'a', 'v', 'r', 'G', 'B'
-#define USB_CFG_DEVICE_NAME_LEN 8
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -336,11 +311,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/unikorn/config.h
+++ b/keyboards/unikorn/config.h
@@ -22,8 +22,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0x20A0
 #define PRODUCT_ID      0x422D
 #define DEVICE_VER      0x0200
-#define MANUFACTURER    Singa and TGR
-#define PRODUCT         Unikorn 60
+#define MANUFACTURER    Singa x TGR
+#define PRODUCT         Unikorn60
 
 #define MATRIX_ROWS 5
 #define MATRIX_COLS 15

--- a/keyboards/unikorn/usbconfig.h
+++ b/keyboards/unikorn/usbconfig.h
@@ -230,31 +230,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     's', 'i', 'n', 'g', 'a', 't', 'g', 'r'
-#define USB_CFG_VENDOR_NAME_LEN 8
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'u', 'n', 'i', 'k', 'o', 'r', 'n'
-#define USB_CFG_DEVICE_NAME_LEN 7
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -336,11 +311,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/winkeyless/bface/config.h
+++ b/keyboards/winkeyless/bface/config.h
@@ -21,10 +21,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0x20A0
 #define PRODUCT_ID      0x422D
 #define DEVICE_VER      0x0200
-// You can edit those at usbconfig.h about line 250. These values will
-// unforunatly be ignored so far
-#define MANUFACTURER    winkeyless.kr
-#define PRODUCT         b.face
+#define MANUFACTURER    Winkeyless
+#define PRODUCT         B.face
 
 /* matrix size */
 #define MATRIX_ROWS 8

--- a/keyboards/winkeyless/bface/usbconfig.h
+++ b/keyboards/winkeyless/bface/usbconfig.h
@@ -230,31 +230,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'w', 'i', 'n', 'k', 'e', 'y', 'l', 'e', 's', 's', '.', 'k', 'r'
-#define USB_CFG_VENDOR_NAME_LEN 13
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'b', '.', 'f', 'a', 'c', 'e'
-#define USB_CFG_DEVICE_NAME_LEN 6
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -336,11 +311,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/winkeyless/bmini/config.h
+++ b/keyboards/winkeyless/bmini/config.h
@@ -22,7 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0x20A0
 #define PRODUCT_ID      0x422D
 #define DEVICE_VER      0x0200
-#define MANUFACTURER    winkeyless.kr
+#define MANUFACTURER    Winkeyless
 #define PRODUCT         B.mini
 
 #define RGBLED_NUM 16

--- a/keyboards/winkeyless/bmini/usbconfig.h
+++ b/keyboards/winkeyless/bmini/usbconfig.h
@@ -231,31 +231,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'w', 'i', 'n', 'k', 'e', 'y', 'l', 'e', 's', 's', '.', 'k', 'r'
-#define USB_CFG_VENDOR_NAME_LEN 13
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'p', 's', '2', 'a', 'v', 'r', 'G', 'B'
-#define USB_CFG_DEVICE_NAME_LEN 8
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -337,11 +312,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/winkeyless/bminiex/config.h
+++ b/keyboards/winkeyless/bminiex/config.h
@@ -22,8 +22,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0x20A0
 #define PRODUCT_ID      0x422E
 #define DEVICE_VER      0x0200
-#define MANUFACTURER    winkeyless.kr
-#define PRODUCT         B.mini Ex
+#define MANUFACTURER    Winkeyless
+#define PRODUCT         B.mini EX
 
 #define RGBLED_NUM 20
 

--- a/keyboards/winkeyless/bminiex/usbconfig.h
+++ b/keyboards/winkeyless/bminiex/usbconfig.h
@@ -231,31 +231,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'w', 'i', 'n', 'k', 'e', 'y', 'l', 'e', 's', 's', '.', 'k', 'r'
-#define USB_CFG_VENDOR_NAME_LEN 13
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'p', 's', '2', 'a', 'v', 'r', 'G', 'B'
-#define USB_CFG_DEVICE_NAME_LEN 8
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -337,11 +312,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/ymd75/config.h
+++ b/keyboards/ymd75/config.h
@@ -24,11 +24,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0x20A0
 #define PRODUCT_ID      0x422D
 #define DEVICE_VER      0x0200
-
-// TODO: share these strings with usbconfig.h
-// Edit usbconfig.h to change these.
 #define MANUFACTURER    YMDK
-#define PRODUCT         ymd75 / mt84
+#define PRODUCT         YMD75 / MT84
 #define DESCRIPTION     75% Keyboard
 
 /* matrix size */

--- a/keyboards/ymd75/usbconfig.h
+++ b/keyboards/ymd75/usbconfig.h
@@ -231,31 +231,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'Y', 'M', 'D', 'K'
-#define USB_CFG_VENDOR_NAME_LEN 4
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'Y','M','D','7','5',' ','K','e','y','b','o','a','r','d'
-#define USB_CFG_DEVICE_NAME_LEN 14
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -337,11 +312,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/ymd96/config.h
+++ b/keyboards/ymd96/config.h
@@ -23,9 +23,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0x20A0
 #define PRODUCT_ID      0x422D
 #define DEVICE_VER      0x0200
-// Edit usbconfig.h to change these.
-#define MANUFACTURER    ymdkey
-#define PRODUCT         ymd96
+#define MANUFACTURER    YMDK
+#define PRODUCT         YMD96
 
 /* matrix size */
 #define MATRIX_ROWS 8

--- a/keyboards/ymd96/usbconfig.h
+++ b/keyboards/ymd96/usbconfig.h
@@ -231,31 +231,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'y','m','d','k','e','y'
-#define USB_CFG_VENDOR_NAME_LEN 6
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'y','m','d','9','6'
-#define USB_CFG_DEVICE_NAME_LEN 5
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -337,11 +312,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/ymdk/bface/config.h
+++ b/keyboards/ymdk/bface/config.h
@@ -20,10 +20,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0x20A0
 #define PRODUCT_ID      0x422D
 #define DEVICE_VER      0x0200
-// You can edit those at usbconfig.h about line 250. These values will
-// unforunatly be ignored so far
 #define MANUFACTURER    YMDK
-#define PRODUCT         bface
+#define PRODUCT         B.face
 
 /* matrix size */
 #define MATRIX_ROWS 5

--- a/keyboards/ymdk/bface/usbconfig.h
+++ b/keyboards/ymdk/bface/usbconfig.h
@@ -230,31 +230,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'Y', 'M', 'D', 'K'
-#define USB_CFG_VENDOR_NAME_LEN 4
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'b', 'f', 'a', 'c', 'e'
-#define USB_CFG_DEVICE_NAME_LEN 5
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -336,11 +311,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/keyboards/ymdk_np21/config.h
+++ b/keyboards/ymdk_np21/config.h
@@ -22,10 +22,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0x20A0
 #define PRODUCT_ID      0x422D
 #define DEVICE_VER      0x0200
-// TODO: share these strings with usbconfig.h
-// Edit usbconfig.h to change these.
-#define MANUFACTURER    ymdk
-#define PRODUCT         np21
+#define MANUFACTURER    YMDK
+#define PRODUCT         NP21
 
 /* matrix size */
 #define MATRIX_ROWS 4

--- a/keyboards/ymdk_np21/usbconfig.h
+++ b/keyboards/ymdk_np21/usbconfig.h
@@ -231,31 +231,6 @@ section at the end of this file).
 #define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
 /* Version number of the device: Minor number first, then major number.
  */
-#define USB_CFG_VENDOR_NAME     'w', 'i', 'n', 'k', 'e', 'y', 'l', 'e', 's', 's', '.', 'k', 'r'
-#define USB_CFG_VENDOR_NAME_LEN 13
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME     'j', 'j', '4', '0'
-#define USB_CFG_DEVICE_NAME_LEN 4
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
- */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
 /* See USB specification if you want to conform to an existing device class.
@@ -337,11 +312,11 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
-#define USB_CFG_DESCR_PROPS_STRING_0                0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
 //#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC

--- a/tmk_core/protocol/vusb/vusb.c
+++ b/tmk_core/protocol/vusb/vusb.c
@@ -335,6 +335,10 @@ const PROGMEM uchar mouse_extra_hid_report[] = {
 };
 #endif
 
+#ifndef SERIAL_NUMBER
+#    define SERIAL_NUMBER 0
+#endif
+
 #ifndef USB_MAX_POWER_CONSUMPTION
 #    define USB_MAX_POWER_CONSUMPTION 500
 #endif
@@ -343,6 +347,40 @@ const PROGMEM uchar mouse_extra_hid_report[] = {
 #ifndef USB_POLLING_INTERVAL_MS
 #    define USB_POLLING_INTERVAL_MS 1
 #endif
+
+// clang-format off
+const PROGMEM usbStringDescriptor_t usbDescriptorStringZero = {
+    .header = {
+        .bLength = USB_STRING_LEN(1),
+        .bDescriptorType = USBDESCR_STRING
+    },
+    .bString = {0x0409} // US English
+};
+
+const PROGMEM usbStringDescriptor_t usbDescriptorStringManufacturer = {
+    .header = {
+        .bLength = USB_STRING_LEN(sizeof(STR(MANUFACTURER)) - 1),
+        .bDescriptorType = USBDESCR_STRING
+    },
+    .bString = LSTR(MANUFACTURER)
+};
+
+const PROGMEM usbStringDescriptor_t usbDescriptorStringProduct = {
+    .header = {
+        .bLength = USB_STRING_LEN(sizeof(STR(PRODUCT)) - 1),
+        .bDescriptorType = USBDESCR_STRING
+    },
+    .bString = LSTR(PRODUCT)
+};
+
+const PROGMEM usbStringDescriptor_t usbDescriptorStringSerial = {
+    .header = {
+        .bLength = USB_STRING_LEN(sizeof(STR(SERIAL_NUMBER)) - 1),
+        .bDescriptorType = USBDESCR_STRING
+    },
+    .bString = LSTR(SERIAL_NUMBER)
+};
+// clang-format on
 
 /*
  * Descriptor for compite device: Keyboard + Mouse
@@ -457,6 +495,26 @@ USB_PUBLIC usbMsgLen_t usbFunctionDescriptor(struct usbRequest *rq) {
             len       = sizeof(usbDescriptorConfiguration);
             break;
 #endif
+        case USBDESCR_STRING:
+            switch (rq->wValue.bytes[0]) {
+                case 0:
+                    usbMsgPtr = (unsigned char *)&usbDescriptorStringZero;
+                    len       = usbDescriptorStringZero.header.bLength;
+                    break;
+                case 1:  // iManufacturer
+                    usbMsgPtr = (unsigned char *)&usbDescriptorStringManufacturer;
+                    len       = usbDescriptorStringManufacturer.header.bLength;
+                    break;
+                case 2:  // iProduct
+                    usbMsgPtr = (unsigned char *)&usbDescriptorStringProduct;
+                    len       = usbDescriptorStringProduct.header.bLength;
+                    break;
+                case 3:  // iSerialNumber
+                    usbMsgPtr = (unsigned char *)&usbDescriptorStringSerial;
+                    len       = usbDescriptorStringSerial.header.bLength;
+                    break;
+            }
+            break;
         case USBDESCR_HID:
             switch (rq->wValue.bytes[0]) {
                 case 0:

--- a/tmk_core/protocol/vusb/vusb.h
+++ b/tmk_core/protocol/vusb/vusb.h
@@ -20,6 +20,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "host_driver.h"
 
+typedef struct usbDescriptorHeader {
+    uchar bLength;
+    uchar bDescriptorType;
+} __attribute__((packed)) usbDescriptorHeader_t;
+
+typedef struct usbStringDescriptor {
+    usbDescriptorHeader_t header;
+    int                   bString[];
+} __attribute__((packed)) usbStringDescriptor_t;
+
+#define USB_STRING_LEN(s) (sizeof(usbDescriptorHeader_t) + ((s) << 1))
+
 host_driver_t *vusb_driver(void);
 void           vusb_transfer_keyboard(void);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This removes the need to go messing around in usbconfig.h to set the manufacturer and product strings for V-USB boards 🎉 and is one more step towards eradicating it completely from keyboard folders.
~~As I don't have one myself (yet), please test if you can! It compiles for me, at the very least, and doing a binary diff shows nothing drastic.~~

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
