### PR TITLE
Fix unaligned access with LTO

### DIFF
--- a/tmk_core/protocol/chibios/usb_main.c
+++ b/tmk_core/protocol/chibios/usb_main.c
@@ -227,8 +227,8 @@ typedef struct {
             .in_size     = stream##_EPSIZE,                                                     \
             .out_size    = stream##_EPSIZE,                                                     \
             .fixed_size  = fixedsize,                                                           \
-            .ib          = (uint8_t[BQ_BUFFER_SIZE(stream##_IN_CAPACITY, stream##_EPSIZE)]){},  \
-            .ob          = (uint8_t[BQ_BUFFER_SIZE(stream##_OUT_CAPACITY, stream##_EPSIZE)]){}, \
+            .ib          = (__attribute__((aligned(4))) uint8_t[BQ_BUFFER_SIZE(stream##_IN_CAPACITY, stream##_EPSIZE)]){},  \
+            .ob          = (__attribute__((aligned(4))) uint8_t[BQ_BUFFER_SIZE(stream##_OUT_CAPACITY, stream##_EPSIZE)]){}, \
         }                                                                                       \
     }
 


### PR DESCRIPTION
Force 4 byte alignment on USB buffers. Chibios casts these buffers to `size_t*` before dereferencing them (`os/hal/src/hal_buffers.c:633`, among other locations); in some cases this can result in an unaligned access if LTO decides to shift things around. Ideally the chibios API would express this alignment precondition, but this will ensure that all accesses to these buffers are aligned.

There are several more APIs in which chibios performs an unsafe cast, but as far as I can tell this is the only one that might result in an unaligned access to QMK data. 

I've been able to reliably reproduce this crash in the following configuration:
- docker build on `tzarc/qmk_firmware:chibios-upgrade`
- target `onekey/stm32f0_disco:rgb` 
- disable NKRO
- enable RGBLIGHT
- enable UNICODE
- enable LTO

This fix works for the same configuration and a few permutations (enable/disable NKRO & UNICODE). Also tested with `:default` as configured on `tzarc/chibios-upgrade`.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
