### PR TITLE
Fix matrix_scan_user is not called at stm32 env(projectkb/alice etc.)

### DIFF
--- a/keyboards/cannonkeys/stm32f072/keyboard.c
+++ b/keyboards/cannonkeys/stm32f072/keyboard.c
@@ -74,6 +74,7 @@ void matrix_scan_kb(void)
   #ifdef RGBLIGHT_ENABLE
     rgblight_task();
   #endif
+    matrix_scan_user();
 }
 
 bool process_record_kb(uint16_t keycode, keyrecord_t *record) {


### PR DESCRIPTION
Fix matrix_scan_user is not called at stm32 env(projectkb/alice etc.) which using cannonkeys/stm32f072

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
just added matrix_scan_user() into cannonkeys/stm32f072/keyboard.c : matrix_scan_kb()

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
