### PR TITLE
Added workaround for serial.c issue when LTO_ENABLE=yes for the Lily58

### DIFF
--- a/keyboards/lily58/rules.mk
+++ b/keyboards/lily58/rules.mk
@@ -36,6 +36,11 @@ SRC += i2c.c
 SRC += serial.c
 SRC += ssd1306.c
 
+# A workaround until #7089 is merged.
+#   serial.c must not be compiled with the -lto option.
+#   The current LIB_SRC has a side effect with the -fno-lto option, so use it.
+LIB_SRC += serial.c
+
 # if firmware size over limit, try this option
 # CFLAGS += -flto
 


### PR DESCRIPTION
This is the same workaround as #7558 applied for the Helix.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This code is timing sensitive and seems to break with LTO enabled (at
least on avr-gcc 8.3.0... it worked on older gcc versions). Without this PR applied, Lily58 slave side is totally nonfunctional (no keystrokes register) when using LTO.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [X] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* I believe this addresses #7857, though it's possible they're having an unrelated issue.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
