### PR TITLE
Fix lock LEDs for ChibiOS when using shared endpoints

### DIFF
--- a/tmk_core/protocol/chibios/usb_main.c
+++ b/tmk_core/protocol/chibios/usb_main.c
@@ -383,7 +383,7 @@ static uint16_t get_hword(uint8_t *p) {
 
 static uint8_t set_report_buf[2] __attribute__((aligned(2)));
 static void    set_led_transfer_cb(USBDriver *usbp) {
-    if (usbp->setup[6] == 2) { // LSB(wLength)
+    if (usbp->setup[6] == 2) { /* LSB(wLength) */
         uint8_t report_id = set_report_buf[0];
         if ((report_id == REPORT_ID_KEYBOARD) || (report_id == REPORT_ID_NKRO)) {
             keyboard_led_stats = set_report_buf[1];
@@ -447,7 +447,7 @@ static bool usb_request_hook_cb(USBDriver *usbp) {
             case USB_RTYPE_DIR_HOST2DEV:
                 switch (usbp->setup[1]) { /* bRequest */
                     case HID_SET_REPORT:
-                        switch (usbp->setup[4]) { /* LSB(wIndex) (check MSB==0 and wLength==1?) */
+                        switch (usbp->setup[4]) { /* LSB(wIndex) (check MSB==0?) */
                             case KEYBOARD_INTERFACE:
 #if defined(SHARED_EP_ENABLE) && !defined(KEYBOARD_SHARED_EP)
                             case SHARED_INTERFACE:

--- a/tmk_core/protocol/chibios/usb_main.c
+++ b/tmk_core/protocol/chibios/usb_main.c
@@ -62,7 +62,7 @@ extern keymap_config_t keymap_config;
 
 uint8_t                keyboard_idle __attribute__((aligned(2)))      = 0;
 uint8_t                keyboard_protocol __attribute__((aligned(2)))  = 1;
-uint16_t               keyboard_led_stats __attribute__((aligned(2))) = 0;
+uint8_t                keyboard_led_stats                             = 0;
 volatile uint16_t      keyboard_idle_count                            = 0;
 static virtual_timer_t keyboard_idle_timer;
 static void            keyboard_idle_timer_cb(void *arg);
@@ -610,7 +610,7 @@ static void keyboard_idle_timer_cb(void *arg) {
 }
 
 /* LED status */
-uint8_t keyboard_leds(void) { return (uint8_t)(keyboard_led_stats & 0xFF); }
+uint8_t keyboard_leds(void) { return keyboard_led_stats; }
 
 /* prepare and start sending a report IN
  * not callable from ISR or locked state */

--- a/tmk_core/protocol/chibios/usb_main.c
+++ b/tmk_core/protocol/chibios/usb_main.c
@@ -381,14 +381,17 @@ static uint16_t get_hword(uint8_t *p) {
  * Other Device    Required    Optional    Optional    Optional    Optional    Optional
  */
 
-#if defined(SHARED_EP_ENABLE) && !defined(KEYBOARD_SHARED_EP)
 static uint8_t set_report_buf[2] __attribute__((aligned(2)));
 static void    set_led_transfer_cb(USBDriver *usbp) {
-    if ((set_report_buf[0] == REPORT_ID_KEYBOARD) || (set_report_buf[0] == REPORT_ID_NKRO)) {
-        keyboard_led_stats = set_report_buf[1];
+    if (usbp->setup[6] == 2) { // LSB(wLength)
+        uint8_t report_id = set_report_buf[0];
+        if ((report_id == REPORT_ID_KEYBOARD) || (report_id == REPORT_ID_NKRO)) {
+            keyboard_led_stats = set_report_buf[1];
+        }
+    } else {
+        keyboard_led_stats = set_report_buf[0];
     }
 }
-#endif
 
 /* Callback for SETUP request on the endpoint 0 (control) */
 static bool usb_request_hook_cb(USBDriver *usbp) {
@@ -445,17 +448,11 @@ static bool usb_request_hook_cb(USBDriver *usbp) {
                 switch (usbp->setup[1]) { /* bRequest */
                     case HID_SET_REPORT:
                         switch (usbp->setup[4]) { /* LSB(wIndex) (check MSB==0 and wLength==1?) */
+                            case KEYBOARD_INTERFACE:
 #if defined(SHARED_EP_ENABLE) && !defined(KEYBOARD_SHARED_EP)
                             case SHARED_INTERFACE:
-                                usbSetupTransfer(usbp, set_report_buf, sizeof(set_report_buf), set_led_transfer_cb);
-                                return TRUE;
-                                break;
 #endif
-
-                            case KEYBOARD_INTERFACE:
-                                /* keyboard_led_stats = <read byte from next OUT report>
-                                 * keyboard_led_stats needs be word (or dword), otherwise we get an exception on F0 */
-                                usbSetupTransfer(usbp, (uint8_t *)&keyboard_led_stats, 1, NULL);
+                                usbSetupTransfer(usbp, set_report_buf, sizeof(set_report_buf), set_led_transfer_cb);
                                 return TRUE;
                                 break;
                         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Following on from #7860, porting my fix from #4824. Now we always use `set_led_transfer_cb`, so the ifdef surrounding it has been removed altogether.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
