### PR TITLE
Remove backlight_init_ports from duck/orion/v3

### DIFF
--- a/keyboards/duck/orion/v3/matrix.c
+++ b/keyboards/duck/orion/v3/matrix.c
@@ -46,11 +46,6 @@ __attribute__ ((weak))
 void matrix_scan_user(void) {
 }
 
-void backlight_init_ports(void)
-{
-  
-}
-
 void indicator_init_ports(void) {
 
   // Num LED


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Broken with #7273, empty function without the correct custom driver stuff now produces:
```console
Linking: .build/duck_orion_v3_default.elf                                                           [ERRORS]
 | 
 | .build/obj_duck_orion_v3_default/quantum/backlight/backlight_avr.o: In function `backlight_init_ports':
 | /home/zvecr/Desktop/qmk_firmware/quantum/backlight/backlight_avr.c:449: multiple definition of `backlight_init_ports'
 | .build/obj_duck_orion_v3_default/matrix.o:matrix.c:(.text.backlight_init_ports+0x0): first defined here
 | collect2: error: ld returned 1 exit status
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
