### PR TITLE
Add ws2812 driver type define

### DIFF
--- a/common_features.mk
+++ b/common_features.mk
@@ -278,6 +278,8 @@ ifeq ($(strip $(WS2812_DRIVER_REQUIRED)), yes)
         $(error WS2812_DRIVER="$(WS2812_DRIVER)" is not a valid WS2812 driver)
     endif
 
+    OPT_DEFS += -DWS2812_DRIVER_$(strip $(shell echo $(WS2812_DRIVER) | tr '[:lower:]' '[:upper:]'))
+
     ifeq ($(strip $(WS2812_DRIVER)), bitbang)
         SRC += ws2812.c
     else


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Bitbang ws2812 currently causes issues on ARM split with both "serial" and potential uart transport code, mainly due to the need to chSysLock to get accurate timings.

In order to add build errors/warnings for `if(ARM && ws2812_driver == bitbang, && RGBLIGHT_SPLIT)`, this PR adds the `WS2812_DRIVER_BITBANG/WS2812_DRIVER_SPI/WS2812_DRIVER_I2C/WS2812_DRIVER_PWM` defines. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
