### PR TITLE
Fix NK65 indicator code after refactoring

### DIFF
--- a/keyboards/wilba_tech/wt_rgb_backlight.c
+++ b/keyboards/wilba_tech/wt_rgb_backlight.c
@@ -1238,7 +1238,10 @@ void backlight_set_color_all( uint8_t red, uint8_t green, uint8_t blue )
 #if defined(RGB_BACKLIGHT_M6_B)
     IS31FL3218_set_color_all( red, green, blue );
 #elif defined(RGB_BACKLIGHT_HS60) || defined(RGB_BACKLIGHT_NK65)
-    IS31FL3733_set_color_all( red, green, blue );
+    // This is done to avoid indicator LEDs being set
+    for (int i = 0; i < BACKLIGHT_LED_COUNT; i++) {
+        IS31FL3733_set_color(i, red, green, blue);
+    }
 #elif defined(RGB_BACKLIGHT_DAWN60)
     IS31FL3731_set_color_all( red, green, blue );
     for (uint8_t i = 0; i < WS2812_LED_TOTAL; i++) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

This is done to fix https://github.com/qmk/qmk_firmware/issues/7899

The `backlight_set_color_all` function was using the `IS31FL3733_set_color_all` function which sets **ALL** the leds of the drivers. As the indicators are driven by the drivers this means they were getting overwritten.

Before the NK65 refactoring, after `backlight_set_color_all` was called, `backlight_effect_indicators` was called fixing the wrong state of the indicators.

Now as the indicator code is not synchronous with the backlight effects we need to avoid putting "dirty" values in the indicator registers.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
