### PR TITLE
Further changes to HHKB keymap

### DIFF
--- a/keyboards/hhkb/keymaps/xyverz/keymap.c
+++ b/keyboards/hhkb/keymaps/xyverz/keymap.c
@@ -19,6 +19,8 @@ enum layer_names {
 
 enum planck_keycodes { DVORAK = SAFE_RANGE, QWERTY, COLEMAK };
 
+#define FN_TAB  LT(_FL, KC_TAB) 
+
 // clang-format off
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
@@ -27,9 +29,9 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    * ,-----------------------------------------------------------.
    * |ESC | 1|  2|  3|  4|  5|  6|  7|  8|  9|  0|  -|  =| \ |Del|
    * |-----------------------------------------------------------|
-   * |Tab  |  Q|  W|  E|  R|  T|  Y|  U|  I|  O|  P|  [|  ]|BkSpc|
+   * |Fn/Tb|  Q|  W|  E|  R|  T|  Y|  U|  I|  O|  P|  [|  ]|BkSpc|
    * |-----------------------------------------------------------|
-   * |Fn     |  A|  S|  D|  F|  G|  H|  J|  K|  L|  ;|  '| Return|
+   * |Control|  A|  S|  D|  F|  G|  H|  J|  K|  L|  ;|  '| Return|
    * |-----------------------------------------------------------|
    * |Shift   |  Z|  X|  C|  V|  B|  N|  M|  ,|  .|  /| Shift |Fn|
    * |-----------------------------------------------------------|
@@ -38,8 +40,8 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    */
   /* Layer 0: Qwerty */
   [_QW] = LAYOUT(
-    KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSLS, KC_DEL ,
-    KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSPC,
+    KC_GESC, KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSLS, KC_DEL ,
+    FN_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSPC,
     KC_LCTL, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,          KC_ENT ,
     KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH,          KC_RSFT, MO(_FL),
              KC_LALT, KC_LGUI,                   KC_SPC,                                      KC_RGUI, KC_RALT
@@ -50,9 +52,9 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    * ,-----------------------------------------------------------.
    * |ESC | 1|  2|  3|  4|  5|  6|  7|  8|  9|  0|  [|  ]| \ |Del|
    * |-----------------------------------------------------------|
-   * |Tab  |  '|  ,|  .|  P|  Y|  F|  G|  C|  R|  L|  /|  =|BkSpc|
+   * |Fn/Tb|  '|  ,|  .|  P|  Y|  F|  G|  C|  R|  L|  /|  =|BkSpc|
    * |-----------------------------------------------------------|
-   * |Fn     |  A|  O|  E|  U|  I|  D|  H|  T|  N|  S|  -| Return|
+   * |Control|  A|  O|  E|  U|  I|  D|  H|  T|  N|  S|  -| Return|
    * |-----------------------------------------------------------|
    * |Shift   |  ;|  Q|  J|  K|  X|  B|  M|  W|  V|  Z| Shift |Fn|
    * |-----------------------------------------------------------|
@@ -61,8 +63,8 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    */
   /* Layer 1: Dvorak */
   [_DV] = LAYOUT(
-    KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_LBRC, KC_RBRC, KC_BSLS, KC_DEL ,
-    KC_TAB,  KC_QUOT, KC_COMM, KC_DOT,  KC_P,    KC_Y,    KC_F,    KC_G,    KC_C,    KC_R,    KC_L,    KC_SLSH, KC_EQL,  KC_BSPC,
+    KC_GESC, KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_LBRC, KC_RBRC, KC_BSLS, KC_DEL ,
+    FN_TAB,  KC_QUOT, KC_COMM, KC_DOT,  KC_P,    KC_Y,    KC_F,    KC_G,    KC_C,    KC_R,    KC_L,    KC_SLSH, KC_EQL,  KC_BSPC,
     KC_LCTL, KC_A,    KC_O,    KC_E,    KC_U,    KC_I,    KC_D,    KC_H,    KC_T,    KC_N,    KC_S,    KC_MINS,          KC_ENT,
     KC_LSFT, KC_SCLN, KC_Q,    KC_J,    KC_K,    KC_X,    KC_B,    KC_M,    KC_W,    KC_V,    KC_Z,             KC_RSFT, MO(_FL),
              KC_LALT, KC_LGUI,                   KC_SPC,                                      KC_RGUI, KC_RALT
@@ -73,9 +75,9 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    * ,-----------------------------------------------------------.
    * |ESC | 1|  2|  3|  4|  5|  6|  7|  8|  9|  0|  -|  =| \ |Del|
    * |-----------------------------------------------------------|
-   * |Tab  |  Q|  W|  F|  P|  G|  J|  L|  U|  Y|  ;|  [|  ]|BkSpc|
+   * |Fn/Tb|  Q|  W|  F|  P|  G|  J|  L|  U|  Y|  ;|  [|  ]|BkSpc|
    * |-----------------------------------------------------------|
-   * |Fn     |  A|  R|  S|  T|  D|  H|  N|  E|  I|  O|  '| Return|
+   * |Control|  A|  R|  S|  T|  D|  H|  N|  E|  I|  O|  '| Return|
    * |-----------------------------------------------------------|
    * |Shift   |  Z|  X|  C|  V|  B|  K|  M|  ,|  .|  /| Shift |Fn|
    * |-----------------------------------------------------------|
@@ -84,8 +86,8 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    */
   /* Layer 2: Colemak */
   [_CM] = LAYOUT(
-    KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSLS, KC_DEL ,
-    KC_TAB,  KC_Q,    KC_W,    KC_F,    KC_P,    KC_G,    KC_J,    KC_L,    KC_U,    KC_Y,    KC_SCLN, KC_LBRC, KC_RBRC, KC_BSPC,
+    KC_GESC, KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSLS, KC_DEL ,
+    FN_TAB,  KC_Q,    KC_W,    KC_F,    KC_P,    KC_G,    KC_J,    KC_L,    KC_U,    KC_Y,    KC_SCLN, KC_LBRC, KC_RBRC, KC_BSPC,
     KC_LCTL, KC_A,    KC_R,    KC_S,    KC_T,    KC_D,    KC_H,    KC_N,    KC_E,    KC_I,    KC_O,    KC_QUOT,          KC_ENT,
     KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_K,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH,          KC_RSFT, MO(_FL),
              KC_LALT, KC_LGUI,                   KC_SPC,                                      KC_RGUI, KC_RALT

--- a/keyboards/hhkb/keymaps/xyverz/keymap.c
+++ b/keyboards/hhkb/keymaps/xyverz/keymap.c
@@ -96,7 +96,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   /*
    *  _FL: Function Layer
    * ,-----------------------------------------------------------.
-   * |    |F1| F2| F3| F4| F5| F6| F7| F8| F9|F10|F11|F12|   |RST|
+   * |Grv |F1| F2| F3| F4| F5| F6| F7| F8| F9|F10|F11|F12|   |RST|
    * |-----------------------------------------------------------|
    * |     |   |_QW|_DV|_CM|   |   |PgU| Up|PgD|PSc|SLk|Pau|     |
    * |-----------------------------------------------------------|
@@ -109,7 +109,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    */
   /* Layer 3: Functions */
   [_FL] = LAYOUT(
-    _______, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  _______, RESET  ,
+    KC_GRV,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  _______, RESET  ,
     _______, _______, QWERTY,  DVORAK,  COLEMAK, _______, _______, KC_PGUP, KC_UP,   KC_PGDN, KC_PSCR, KC_SLCK, KC_PAUS, _______,
     KC_CAPS, _______, KC_MPRV, KC_MPLY, KC_MNXT, _______, KC_HOME, KC_LEFT, KC_DOWN, KC_RGHT, _______, _______,          _______,
     _______, _______, KC_MUTE, KC_VOLD, KC_VOLU, _______, KC_END,  _______, _______, _______, _______,          _______, _______,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Usability changes: added `KC_GRV` and `KC_GESC` to keymap as well as `FN_TAB` for `LT(_FL, KC_TAB)`.
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
