### PR TITLE
Virtser disable

### DIFF
--- a/common_features.mk
+++ b/common_features.mk
@@ -61,7 +61,7 @@ endif
 
 ifeq ($(strip $(STENO_ENABLE)), yes)
     OPT_DEFS += -DSTENO_ENABLE
-    VIRTSER_ENABLE := yes
+    VIRTSER_ENABLE ?= yes
     SRC += $(QUANTUM_DIR)/process_keycode/process_steno.c
 endif
 

--- a/quantum/process_keycode/process_steno.c
+++ b/quantum/process_keycode/process_steno.c
@@ -73,7 +73,9 @@ static void steno_clear_state(void) {
 static void send_steno_state(uint8_t size, bool send_empty) {
     for (uint8_t i = 0; i < size; ++i) {
         if (chord[i] || send_empty) {
+#ifdef VIRTSER_ENABLE
             virtser_send(chord[i]);
+#endif
         }
     }
 }
@@ -105,7 +107,9 @@ static void send_steno_chord(void) {
         switch (mode) {
             case STENO_MODE_BOLT:
                 send_steno_state(BOLT_STATE_SIZE, false);
+#ifdef VIRTSER_ENABLE
                 virtser_send(0);  // terminating byte
+#endif
                 break;
             case STENO_MODE_GEMINI:
                 chord[0] |= 0x80;  // Indicate start of packet

--- a/quantum/process_keycode/process_steno.h
+++ b/quantum/process_keycode/process_steno.h
@@ -18,10 +18,6 @@
 
 #include "quantum.h"
 
-#if defined(STENO_ENABLE) && !defined(VIRTSER_ENABLE)
-#    error "must have virtser enabled to use steno"
-#endif
-
 typedef enum { STENO_MODE_BOLT, STENO_MODE_GEMINI } steno_mode_t;
 
 bool     process_steno(uint16_t keycode, keyrecord_t *record);


### PR DESCRIPTION
The general purpose chording engine that my boards use leverages the steno hooks. However some of them (Ginny, ButterStick, FaunchPad) don't use the serial interface typically used by a steno writer. This PR sticks in a option to stub out those serial calls in a way that only effects the steno subsystem. 

This saves about 1K of space that could be used for additional dictionary entries/words.

## Types of Changes
- [x] Core
- [x] New feature
- [x] Enhancement/optimization

## Checklist
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
