### PR TITLE
Fix unknown key 'IndentPPDirectives' on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,18 @@ env:
   - MAKEFLAGS="-j3 --output-sync"
 services:
   - docker
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+      - llvm-toolchain-trusty-7
+    packages:
+    - pandoc
+    - diffutils
+    - dos2unix
+    - doxygen
+    - clang-format-7
+    - libstdc++-7-dev
 install:
   - npm install -g moxygen
 script:
@@ -20,13 +32,6 @@ script:
   - bash util/travis_test.sh
   - bash util/travis_build.sh
   - bash util/travis_docs.sh
-addons:
-  apt:
-    packages:
-    - pandoc
-    - diffutils
-    - dos2unix
-    - doxygen
 after_script:
   bash util/travis_compiled_push.sh
 notifications:

--- a/util/travis_compiled_push.sh
+++ b/util/travis_compiled_push.sh
@@ -13,7 +13,7 @@ if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == "false" ]] ; the
 # fix formatting
 git checkout master
 git diff --diff-filter=AM --name-only -n 1 -z ${TRAVIS_COMMIT_RANGE} | xargs -0 dos2unix
-git diff --diff-filter=AM --name-only -n 1 -z ${TRAVIS_COMMIT_RANGE} '*.c' '*.h' '*.cpp' | grep -z -e '^drivers' -e '^quantum' -e '^tests' -e '^tmk_core' | grep -zv -e 'quantum/template' -e 'tmk_core/protocol/usb_hid' | xargs -0 clang-format -i
+git diff --diff-filter=AM --name-only -n 1 -z ${TRAVIS_COMMIT_RANGE} '*.c' '*.h' '*.cpp' | grep -z -e '^drivers' -e '^quantum' -e '^tests' -e '^tmk_core' | grep -zv -e 'quantum/template' -e 'tmk_core/protocol/usb_hid' | xargs -0 clang-format-7 -i
 git diff --diff-filter=AM --name-only -n 1 -z ${TRAVIS_COMMIT_RANGE} | xargs -0 git add
 git commit -m "format code according to conventions [skip ci]" && git push git@github.com:qmk/qmk_firmware.git master
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
clang-format is not currently being run on core files. From <https://travis-ci.org/qmk/qmk_firmware/builds/622207692?utm_source=github_status&utm_medium=notification>,

```console
0.21s$ bash util/travis_compiled_push.sh
id_rsa_qmk_firmware
id_rsa_qmk.fm
Agent pid 16033
Identity added: id_rsa_qmk_firmware (id_rsa_qmk_firmware)
Using git hash 201c5bf
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
dos2unix: converting file quantum/encoder.c to Unix format ...
YAML:15:21: error: unknown key 'IndentPPDirectives'
IndentPPDirectives: AfterHash
                    ^~~~~~~~~
Error reading /home/travis/build/qmk/qmk_firmware/.clang-format: Invalid argument
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
