### PR TITLE
Align cformat rules with current CI implementation

### DIFF
--- a/lib/python/qmk/cli/cformat.py
+++ b/lib/python/qmk/cli/cformat.py
@@ -24,14 +24,14 @@ def cformat(cli):
     if cli.args.files:
         cli.args.files = [os.path.join(os.environ['ORIG_CWD'], file) for file in cli.args.files]
     else:
+        ignores = ['tmk_core/protocol/usb_hid', 'quantum/template']
         for dir in ['drivers', 'quantum', 'tests', 'tmk_core']:
             for dirpath, dirnames, filenames in os.walk(dir):
-                ignores = ['tmk_core/protocol/usb_hid', 'quantum/template']
                 if any(i in dirpath for i in ignores):
-                    continue
+                    dirnames.clear()
 
                 for name in filenames:
-                    if name.endswith('.c') or name.endswith('.h') or name.endswith('.cpp'):
+                    if name.endswith(('.c', '.h', '.cpp')):
                         cli.args.files.append(os.path.join(dirpath, name))
 
     # Run clang-format on the files we've found

--- a/lib/python/qmk/cli/cformat.py
+++ b/lib/python/qmk/cli/cformat.py
@@ -26,7 +26,8 @@ def cformat(cli):
     else:
         for dir in ['drivers', 'quantum', 'tests', 'tmk_core']:
             for dirpath, dirnames, filenames in os.walk(dir):
-                if 'tmk_core/protocol/usb_hid' in dirpath:
+                ignores = ['tmk_core/protocol/usb_hid', 'quantum/template']
+                if any(i in dirpath for i in ignores):
                     continue
 
                 for name in filenames:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Noticed while fixing #7934, `quantum/template/*` gets included in clang-format, which breaks the tokens `#define MANUFACTURER % YOUR_NAME %`.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
