### PR TITLE
Correct the Num Lock LED state on YMDK NP21

### DIFF
--- a/keyboards/ymdk_np21/ymdk_np21.c
+++ b/keyboards/ymdk_np21/ymdk_np21.c
@@ -30,7 +30,7 @@ void led_init_ports(void) {
 
 bool led_update_kb(led_t led_state) {
     if (led_update_user(led_state)) {
-        writePin(D0, !led_state.num_lock);
+        writePin(D0, led_state.num_lock);
     }
     return true;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

#7775 appears to have inverted the Num Lock LED on the YMDK NP21, causing it to light up when Num Lock is off, and not light up when Num Lock is on. I removed a negation so that the LED properly reflects the state of Num Lock on the computer.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
