### PR TITLE
Think 6.5 Soldered Matrix Fix

### DIFF
--- a/keyboards/gray_studio/think65/solder/readme.md
+++ b/keyboards/gray_studio/think65/solder/readme.md
@@ -6,8 +6,6 @@ Keyboard Maintainer: [MechMerlin](https://github.com/mechmerlin)
 Hardware Supported: Think6.5 Compatible PCB  
 Hardware Availability: [Geekhack GB](https://geekhack.org/index.php?topic=100166.0)
 
-**Note:** The `LAYOUT_65_ansi_blocker` LAYOUT macro utilizes the same pins and switch matrix as the hotswap version. Any firmware made with this LAYOUT macro can be flashed on both the Solder (Compatible) version and the Hotswap version of the Think6.5.  
-
 **Indicator LEDs:** The solder PCB ONLY supports Caps Lock LEDs unlike the Hotswap version that supports Num Lock, Caps Lock, and Scroll Lock.  
 
 Make example for this keyboard (after setting up your build environment):

--- a/keyboards/gray_studio/think65/solder/solder.c
+++ b/keyboards/gray_studio/think65/solder/solder.c
@@ -25,15 +25,7 @@ void matrix_init_kb(void) {
   // runs once when the firmware starts up
 
   setPinOutput(C7);
-  
   matrix_init_user();
-}
-
-void matrix_scan_kb(void) {
-  // put your looping keyboard code here
-  // runs every cycle (a lot)
-
-  matrix_scan_user();
 }
 
 bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
@@ -43,15 +35,10 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
   return process_record_user(keycode, record);
 }
 
-void led_set_kb(uint8_t usb_led) {
-  // put your keyboard LED indicator (ex: Caps Lock LED) toggling code here
-
-  if (IS_LED_ON(usb_led, USB_LED_CAPS_LOCK)) {
-    writePinLow(C7);
-  } else {
-    writePinHigh(C7);
+bool led_update_kb(led_t led_state) {
+  if(led_update_user(led_state)) {
+    writePin(C7, led_state.caps_lock);
   }
-
-  led_set_user(usb_led);
+  return true;
 }
 

--- a/keyboards/gray_studio/think65/solder/solder.c
+++ b/keyboards/gray_studio/think65/solder/solder.c
@@ -37,8 +37,7 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
 
 bool led_update_kb(led_t led_state) {
   if(led_update_user(led_state)) {
-    writePin(C7, led_state.caps_lock);
+    writePin(C7, !led_state.caps_lock);
   }
   return true;
 }
-

--- a/keyboards/gray_studio/think65/solder/solder.h
+++ b/keyboards/gray_studio/think65/solder/solder.h
@@ -32,16 +32,16 @@
 }
 
 #define LAYOUT_65_ansi_blocker( \
-    K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C, K0E,      K0F,   \
+    K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C, K0D,      K0F,   \
     K10,   K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, K1C, K1D, K1E,    K1F,   \
     K20,    K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B, K2C, K2D,        K2F,   \
-    K31,       K32, K33, K34, K35, K36, K37, K38, K39, K3A, K3B, K3D,     K3E, K3F,   \
+    K30,       K32, K33, K34, K35, K36, K37, K38, K39, K3A, K3B, K3D,     K3E, K3F,   \
     K40,  K41,  K43,              K46,                K4A,  K4B,     K4D, K4E, K4F    \
 ) { \
-    { K00,   K01,   K02,   K03,   K04,   K05,   K06,   K07,   K08,   K09,   K0A,   K0B,   K0C,   KC_NO, K0E,   K0F   }, \
+    { K00,   K01,   K02,   K03,   K04,   K05,   K06,   K07,   K08,   K09,   K0A,   K0B,   K0C,   K0D,   KC_NO, K0F   }, \
     { K10,   KC_NO, K12,   K13,   K14,   K15,   K16,   K17,   K18,   K19,   K1A,   K1B,   K1C,   K1D,   K1E,   K1F   }, \
     { K20,   KC_NO, K22,   K23,   K24,   K25,   K26,   K27,   K28,   K29,   K2A,   K2B,   K2C,   K2D,   KC_NO, K2F   }, \
-    { KC_NO, K31,   K32,   K33,   K34,   K35,   K36,   K37,   K38,   K39,   K3A,   K3B,   KC_NO, K3D,   K3E,   K3F   }, \
+    { K30,   KC_NO, K32,   K33,   K34,   K35,   K36,   K37,   K38,   K39,   K3A,   K3B,   KC_NO, K3D,   K3E,   K3F   }, \
     { K40,   K41,   KC_NO, K43,   KC_NO, KC_NO, K46,   KC_NO, KC_NO, KC_NO, K4A,   K4B,   KC_NO, K4D,   K4E,   K4F   }, \
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

It was reported to me by mwb that on the soldered PCB, both the backspace and left shift keys were not correct on the LAYOUT_65_ansi LAYOUT. 

Also took the opportunity to do some minor clean ups. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
