### PR TITLE
Dedupe extrakey report struct, and send functions in V-USB & LUFA

### DIFF
--- a/tmk_core/common/report.h
+++ b/tmk_core/common/report.h
@@ -151,6 +151,11 @@ typedef union {
 } __attribute__((packed)) report_keyboard_t;
 
 typedef struct {
+    uint8_t  report_id;
+    uint16_t usage;
+} __attribute__((packed)) report_extra_t;
+
+typedef struct {
 #ifdef MOUSE_SHARED_EP
     uint8_t report_id;
 #endif

--- a/tmk_core/protocol/arm_atsam/main_arm_atsam.c
+++ b/tmk_core/protocol/arm_atsam/main_arm_atsam.c
@@ -110,40 +110,34 @@ void send_mouse(report_mouse_t *report) {
 #endif  // MOUSEKEY_ENABLE
 }
 
-void send_system(uint16_t data) {
 #ifdef EXTRAKEY_ENABLE
+void send_extra(uint8_t report_id, uint16_t data) {
     uint32_t irqflags;
 
     irqflags = __get_PRIMASK();
     __disable_irq();
     __DMB();
 
-    udi_hid_exk_report.desc.report_id = REPORT_ID_SYSTEM;
-    if (data != 0) data = data - SYSTEM_POWER_DOWN + 1;
+    udi_hid_exk_report.desc.report_id   = report_id;
     udi_hid_exk_report.desc.report_data = data;
     udi_hid_exk_b_report_valid          = 1;
     udi_hid_exk_send_report();
 
     __DMB();
     __set_PRIMASK(irqflags);
+}
+#endif  // EXTRAKEY_ENABLE
+
+void send_system(uint16_t data) {
+#ifdef EXTRAKEY_ENABLE
+    if (data != 0) data = data - SYSTEM_POWER_DOWN + 1;
+    send_extra(REPORT_ID_SYSTEM,  data);
 #endif  // EXTRAKEY_ENABLE
 }
 
 void send_consumer(uint16_t data) {
 #ifdef EXTRAKEY_ENABLE
-    uint32_t irqflags;
-
-    irqflags = __get_PRIMASK();
-    __disable_irq();
-    __DMB();
-
-    udi_hid_exk_report.desc.report_id   = REPORT_ID_CONSUMER;
-    udi_hid_exk_report.desc.report_data = data;
-    udi_hid_exk_b_report_valid          = 1;
-    udi_hid_exk_send_report();
-
-    __DMB();
-    __set_PRIMASK(irqflags);
+    send_extra(REPORT_ID_CONSUMER, data);
 #endif  // EXTRAKEY_ENABLE
 }
 

--- a/tmk_core/protocol/chibios/usb_main.h
+++ b/tmk_core/protocol/chibios/usb_main.h
@@ -72,20 +72,6 @@ void mouse_in_cb(USBDriver *usbp, usbep_t ep);
 /* shared IN request callback handler */
 void shared_in_cb(USBDriver *usbp, usbep_t ep);
 
-/* ---------------
- * Extrakey header
- * ---------------
- */
-
-#ifdef EXTRAKEY_ENABLE
-
-/* extra report structure */
-typedef struct {
-    uint8_t  report_id;
-    uint16_t usage;
-} __attribute__((packed)) report_extra_t;
-#endif /* EXTRAKEY_ENABLE */
-
 /* --------------
  * Console header
  * --------------

--- a/tmk_core/protocol/lufa/lufa.c
+++ b/tmk_core/protocol/lufa/lufa.c
@@ -666,6 +666,7 @@ static void send_mouse(report_mouse_t *report) {
  *
  * FIXME: Needs doc
  */
+#ifdef EXTRAKEY_ENABLE
 static void send_extra(uint8_t report_id, uint16_t data) {
     uint8_t timeout = 255;
 
@@ -681,6 +682,7 @@ static void send_extra(uint8_t report_id, uint16_t data) {
     Endpoint_Write_Stream_LE(&r, sizeof(report_extra_t), NULL);
     Endpoint_ClearIN();
 }
+#endif
 
 /** \brief Send System
  *

--- a/tmk_core/protocol/lufa/lufa.c
+++ b/tmk_core/protocol/lufa/lufa.c
@@ -662,17 +662,12 @@ static void send_mouse(report_mouse_t *report) {
 #endif
 }
 
-/** \brief Send System
- *
- * FIXME: Needs doc
- */
-static void send_system(uint16_t data) {
-#ifdef EXTRAKEY_ENABLE
+static void send_extra(uint8_t report_id, uint16_t data) {
     uint8_t timeout = 255;
 
     if (USB_DeviceState != DEVICE_STATE_Configured) return;
 
-    report_extra_t r = {.report_id = REPORT_ID_SYSTEM, .usage = data - SYSTEM_POWER_DOWN + 1};
+    report_extra_t r = {.report_id = report_id, .usage = data};
     Endpoint_SelectEndpoint(SHARED_IN_EPNUM);
 
     /* Check if write ready for a polling interval around 10ms */
@@ -681,6 +676,15 @@ static void send_system(uint16_t data) {
 
     Endpoint_Write_Stream_LE(&r, sizeof(report_extra_t), NULL);
     Endpoint_ClearIN();
+}
+
+/** \brief Send System
+ *
+ * FIXME: Needs doc
+ */
+static void send_system(uint16_t data) {
+#ifdef EXTRAKEY_ENABLE
+    send_extra(REPORT_ID_SYSTEM, data - SYSTEM_POWER_DOWN + 1);
 #endif
 }
 
@@ -690,7 +694,6 @@ static void send_system(uint16_t data) {
  */
 static void send_consumer(uint16_t data) {
 #ifdef EXTRAKEY_ENABLE
-    uint8_t timeout = 255;
     uint8_t where   = where_to_send();
 
 #    ifdef BLUETOOTH_ENABLE
@@ -729,15 +732,7 @@ static void send_consumer(uint16_t data) {
         return;
     }
 
-    report_extra_t r = {.report_id = REPORT_ID_CONSUMER, .usage = data};
-    Endpoint_SelectEndpoint(SHARED_IN_EPNUM);
-
-    /* Check if write ready for a polling interval around 10ms */
-    while (timeout-- && !Endpoint_IsReadWriteAllowed()) _delay_us(40);
-    if (!Endpoint_IsReadWriteAllowed()) return;
-
-    Endpoint_Write_Stream_LE(&r, sizeof(report_extra_t), NULL);
-    Endpoint_ClearIN();
+    send_extra(REPORT_ID_CONSUMER, data);
 #endif
 }
 

--- a/tmk_core/protocol/lufa/lufa.c
+++ b/tmk_core/protocol/lufa/lufa.c
@@ -662,6 +662,10 @@ static void send_mouse(report_mouse_t *report) {
 #endif
 }
 
+/** \brief Send Extra
+ *
+ * FIXME: Needs doc
+ */
 static void send_extra(uint8_t report_id, uint16_t data) {
     uint8_t timeout = 255;
 

--- a/tmk_core/protocol/lufa/lufa.h
+++ b/tmk_core/protocol/lufa/lufa.h
@@ -58,12 +58,6 @@ extern host_driver_t lufa_driver;
 }
 #endif
 
-/* extra report structure */
-typedef struct {
-    uint8_t  report_id;
-    uint16_t usage;
-} __attribute__((packed)) report_extra_t;
-
 #ifdef API_ENABLE
 #    include "api.h"
 #endif

--- a/tmk_core/protocol/vusb/vusb.c
+++ b/tmk_core/protocol/vusb/vusb.c
@@ -112,31 +112,25 @@ static void send_mouse(report_mouse_t *report) {
     }
 }
 
-typedef struct {
-    uint8_t  report_id;
-    uint16_t usage;
-} __attribute__((packed)) report_extra_t;
-
-static void send_system(uint16_t data) {
+static void send_extra(uint8_t report_id, uint16_t data) {
+    static uint8_t last_id    = 0;
     static uint16_t last_data = 0;
-    if (data == last_data) return;
+    if ((report_id == last_id) && (data == last_data)) return;
+    last_id = report_id;
     last_data = data;
 
-    report_extra_t report = {.report_id = REPORT_ID_SYSTEM, .usage = data};
+    report_extra_t report = {.report_id = report_id, .usage = data};
     if (usbInterruptIsReady3()) {
         usbSetInterrupt3((void *)&report, sizeof(report));
     }
 }
 
-static void send_consumer(uint16_t data) {
-    static uint16_t last_data = 0;
-    if (data == last_data) return;
-    last_data = data;
+static void send_system(uint16_t data) {
+    send_extra(REPORT_ID_SYSTEM, data);
+}
 
-    report_extra_t report = {.report_id = REPORT_ID_CONSUMER, .usage = data};
-    if (usbInterruptIsReady3()) {
-        usbSetInterrupt3((void *)&report, sizeof(report));
-    }
+static void send_consumer(uint16_t data) {
+    send_extra(REPORT_ID_CONSUMER, data);
 }
 
 /*------------------------------------------------------------------*


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The changes here are twofold: the report struct for the extrakeys (media keys) interface was defined in multiple places, so I pulled them up into report.h, where the rest of the report structs are.

Also, the system and consumer send functions have a good amount of common code that can be refactored into a single `send_extra()` function that takes the report ID and the usage.

```
make gh60/satan:default
	before: 18618/28672 (64%, 10054 bytes free)
	after: 18542/28672 (64%, 10130 bytes free)

make jj4x4:default
	before: 19106/28672 (66%, 9566 bytes free)
	after: 19060/28672 (66%, 9612 bytes free)
```

So on avr-gcc 8.3.0/avr-binutils 2.33.1, that's about a 76 byte decrease in filesize for LUFA with extrakeys on, and around 46 bytes for V-USB 👍

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
