### PR TITLE
New feature: PERMISSIVE_HOLD_PER_KEY

### DIFF
--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -140,6 +140,8 @@ If you define these options you will enable the associated feature, which may in
 * `#define PERMISSIVE_HOLD`
   * makes tap and hold keys trigger the hold if another key is pressed before releasing, even if it hasn't hit the `TAPPING_TERM`
   * See [Permissive Hold](feature_advanced_keycodes.md#permissive-hold) for details
+* `#define PERMISSIVE_HOLD_PER_KEY`
+  * enabled handling for per key `PERMISSIVE_HOLD` settings
 * `#define IGNORE_MOD_TAP_INTERRUPT`
   * makes it possible to do rolling combos (zx) with keys that convert to other keys on hold, by enforcing the `TAPPING_TERM` for both keys.
   * See [Mod tap interrupt](feature_advanced_keycodes.md#ignore-mod-tap-interrupt) for details

--- a/docs/feature_advanced_keycodes.md
+++ b/docs/feature_advanced_keycodes.md
@@ -265,6 +265,25 @@ Normally, if you do all this within the `TAPPING_TERM` (default: 200ms) this wil
 
 ?> If you have `Ignore Mod Tap Interrupt` enabled, as well, this will modify how both work. The regular key has the modifier added if the first key is released first or if both keys are held longer than the `TAPPING_TERM`.
 
+For more granular control of this feature, you can add the following to your `config.h`:
+
+```c
+#define PERMISSIVE_HOLD_PER_KEY
+```
+
+You can then add the following function to your keymap:
+
+```c
+bool get_permissive_hold(uint16_t keycode, keyrecord_t *record) {
+  switch (keycode) {
+    case SFT_T(KC_A):
+      return true;
+    default:
+      return false;
+  }
+}
+```
+
 ## Ignore Mod Tap Interrupt
 
 To enable this setting, add this to your `config.h`:

--- a/tmk_core/common/action_tapping.c
+++ b/tmk_core/common/action_tapping.c
@@ -31,6 +31,10 @@ __attribute__((weak)) uint16_t get_tapping_term(uint16_t keycode) { return TAPPI
 __attribute__((weak)) bool get_tapping_force_hold(uint16_t keycode, keyrecord_t *record) { return false; }
 #    endif
 
+#    ifdef PERMISSIVE_HOLD_PER_KEY
+__attribute__((weak)) bool get_permissive_hold(uint16_t keycode, keyrecord_t *record) { return false; }
+#    endif
+
 static keyrecord_t tapping_key                         = {};
 static keyrecord_t waiting_buffer[WAITING_BUFFER_SIZE] = {};
 static uint8_t     waiting_buffer_head                 = 0;
@@ -115,12 +119,15 @@ bool process_tapping(keyrecord_t *keyp) {
                  * This can register the key before settlement of tapping,
                  * useful for long TAPPING_TERM but may prevent fast typing.
                  */
-#    if defined(TAPPING_TERM_PER_KEY) || (TAPPING_TERM >= 500) || defined(PERMISSIVE_HOLD)
+#    if defined(TAPPING_TERM_PER_KEY) || (TAPPING_TERM >= 500) || defined(PERMISSIVE_HOLD) || defined(PERMISSIVE_HOLD_PER_KEY)
+                else if (
 #        ifdef TAPPING_TERM_PER_KEY
-                else if ((get_tapping_term(get_event_keycode(tapping_key.event)) >= 500) && IS_RELEASED(event) && waiting_buffer_typed(event))
-#        else
-                else if (IS_RELEASED(event) && waiting_buffer_typed(event))
+                         (get_tapping_term(get_event_keycode(tapping_key.event)) >= 500) &&
 #        endif
+#        ifdef PERMISSIVE_HOLD_PER_KEY
+                         !get_permissive_hold(get_event_keycode(tapping_key.event), keyp) &&
+#        endif
+                         IS_RELEASED(event) && waiting_buffer_typed(event))
                 {
                     debug("Tapping: End. No tap. Interfered by typing key\n");
                     process_record(&tapping_key);


### PR DESCRIPTION
## Description

Expands on the per-key tap-hold configuration options, allowing for fine-tuned control of exactly which keys are affected by `PERMISSIVE_HOLD`.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
