### PR TITLE
Fix printf buffer overflow when cols>16

### DIFF
--- a/tmk_core/common/chibios/printf.c
+++ b/tmk_core/common/chibios/printf.c
@@ -120,7 +120,8 @@ static void putchw(void* putp, putcf putf, int n, char z, char* bf) {
 }
 
 void tfp_format(void* putp, putcf putf, char* fmt, va_list va) {
-    char bf[12];
+    // This used to handle max of 12, but binary support jumps this to at least 32
+    char bf[36];
 
     char ch;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
When implementing matrix printing on ChibiOS, binary support was added to the printf lib. This was only tested on a "small" board, however recent investigation within #7946 has shown that the original buffer used is not large enough... :man_facepalming: 
 
Credit goes to @wiml for the awesome investigation work!

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #7946

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
