### PR TITLE
Add support for STM32L0/L1 onboard EEPROM.

### DIFF
--- a/common_features.mk
+++ b/common_features.mk
@@ -141,6 +141,10 @@ else
         SRC += $(PLATFORM_COMMON_DIR)/flash_stm32.c
         OPT_DEFS += -DEEPROM_EMU_STM32F072xB
         OPT_DEFS += -DSTM32_EEPROM_ENABLE
+      else ifneq ($(filter $(MCU_SERIES),STM32L0xx STM32L1xx),)
+        OPT_DEFS += -DEEPROM_DRIVER
+        COMMON_VPATH += $(DRIVER_PATH)/eeprom
+        SRC += eeprom_driver.c eeprom_stm32_L0_L1.c
       else
         # This will effectively work the same as "transient" if not supported by the chip
         SRC += $(PLATFORM_COMMON_DIR)/eeprom_teensy.c

--- a/docs/eeprom_driver.md
+++ b/docs/eeprom_driver.md
@@ -2,11 +2,11 @@
 
 The EEPROM driver can be swapped out depending on the needs of the keyboard, or whether extra hardware is present.
 
-Driver                      | Description
---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-`EEPROM_DRIVER = vendor`    | Uses the on-chip driver provided by the chip manufacturer. For AVR, this is provided by avr-libc. This is supported on ARM for a subset of chips -- STM32F3xx, STM32F1xx, and STM32F072xB will be emulated by writing to flash. Other chips will generally act as "transient" below.
-`EEPROM_DRIVER = i2c`       | Supports writing to I2C-based 24xx EEPROM chips. See the driver section below.
-`EEPROM_DRIVER = transient` | Fake EEPROM driver -- supports reading/writing to RAM, and will be discarded when power is lost.
+Driver                             | Description
+-----------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+`EEPROM_DRIVER = vendor` (default) | Uses the on-chip driver provided by the chip manufacturer. For AVR, this is provided by avr-libc. This is supported on ARM for a subset of chips -- STM32F3xx, STM32F1xx, and STM32F072xB will be emulated by writing to flash. STM32L0xx and STM32L1xx will use the onboard dedicated true EEPROM. Other chips will generally act as "transient" below.
+`EEPROM_DRIVER = i2c`              | Supports writing to I2C-based 24xx EEPROM chips. See the driver section below.
+`EEPROM_DRIVER = transient`        | Fake EEPROM driver -- supports reading/writing to RAM, and will be discarded when power is lost.
 
 ## Vendor Driver Configuration
 

--- a/docs/eeprom_driver.md
+++ b/docs/eeprom_driver.md
@@ -10,6 +10,8 @@ Driver                             | Description
 
 ## Vendor Driver Configuration
 
+!> Resetting EEPROM using an STM32L0/L1 device takes up to 1 second for every 1kB of internal EEPROM used.
+
 No configurable options are available.
 
 ## I2C Driver Configuration

--- a/drivers/eeprom/eeprom_stm32_L0_L1.c
+++ b/drivers/eeprom/eeprom_stm32_L0_L1.c
@@ -1,0 +1,96 @@
+/* Copyright 2020 Nick Brassel (tzarc)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+#include <string.h>
+
+#include "hal.h"
+#include "eeprom_driver.h"
+#include "eeprom_stm32_L0_L1.h"
+
+#define EEPROM_BASE_ADDR 0x08080000
+#define EEPROM_ADDR(offset) (EEPROM_BASE_ADDR + (offset))
+#define EEPROM_PTR(offset) ((__IO uint8_t *)EEPROM_ADDR(offset))
+#define EEPROM_BYTE(location, offset) (*(EEPROM_PTR(((uint32_t)location) + ((uint32_t)offset))))
+
+#define BUFFER_BYTE(buffer, offset) (*(((uint8_t *)buffer) + offset))
+
+#define FLASH_PEKEY1 0x89ABCDEF
+#define FLASH_PEKEY2 0x02030405
+
+static inline void STM32_L0_L1_EEPROM_WaitNotBusy(void) {
+    while (FLASH->SR & FLASH_SR_BSY) {
+        __WFI();
+    }
+}
+
+static inline void STM32_L0_L1_EEPROM_Unlock(void) {
+    STM32_L0_L1_EEPROM_WaitNotBusy();
+    if (FLASH->PECR & FLASH_PECR_PELOCK) {
+        FLASH->PEKEYR = FLASH_PEKEY1;
+        FLASH->PEKEYR = FLASH_PEKEY2;
+    }
+}
+
+static inline void STM32_L0_L1_EEPROM_Lock(void) {
+    STM32_L0_L1_EEPROM_WaitNotBusy();
+    FLASH->PECR |= FLASH_PECR_PELOCK;
+}
+
+void eeprom_driver_init(void) {}
+
+void eeprom_driver_erase(void) {
+    STM32_L0_L1_EEPROM_Unlock();
+
+    for (size_t offset = 0; offset < STM32_ONBOARD_EEPROM_SIZE; offset += sizeof(uint32_t)) {
+        FLASH->PECR |= FLASH_PECR_ERASE | FLASH_PECR_DATA;
+
+        *(__IO uint32_t *)EEPROM_ADDR(offset) = (uint32_t)0;
+
+        STM32_L0_L1_EEPROM_WaitNotBusy();
+        FLASH->PECR &= ~(FLASH_PECR_ERASE | FLASH_PECR_DATA);
+    }
+
+    STM32_L0_L1_EEPROM_Lock();
+}
+
+void eeprom_read_block(void *buf, const void *addr, size_t len) {
+    for (size_t offset = 0; offset < len; ++offset) {
+        // Drop out if we've hit the limit of the EEPROM
+        if ((((uint32_t)addr) + offset) >= STM32_ONBOARD_EEPROM_SIZE) {
+            break;
+        }
+
+        STM32_L0_L1_EEPROM_WaitNotBusy();
+        BUFFER_BYTE(buf, offset) = EEPROM_BYTE(addr, offset);
+    }
+}
+
+void eeprom_write_block(const void *buf, void *addr, size_t len) {
+    STM32_L0_L1_EEPROM_Unlock();
+
+    for (size_t offset = 0; offset < len; ++offset) {
+        // Drop out if we've hit the limit of the EEPROM
+        if ((((uint32_t)addr) + offset) >= STM32_ONBOARD_EEPROM_SIZE) {
+            break;
+        }
+
+        STM32_L0_L1_EEPROM_WaitNotBusy();
+        EEPROM_BYTE(addr, offset) = BUFFER_BYTE(buf, offset);
+    }
+
+    STM32_L0_L1_EEPROM_Lock();
+}

--- a/drivers/eeprom/eeprom_stm32_L0_L1.h
+++ b/drivers/eeprom/eeprom_stm32_L0_L1.h
@@ -1,0 +1,33 @@
+/* Copyright 2020 Nick Brassel (tzarc)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+/*
+    The size used by the STM32 L0/L1 EEPROM driver.
+*/
+#ifndef STM32_ONBOARD_EEPROM_SIZE
+#    ifdef VIA_ENABLE
+#        define STM32_ONBOARD_EEPROM_SIZE 1024
+#    else
+#        include "eeconfig.h"
+#        define STM32_ONBOARD_EEPROM_SIZE (((EECONFIG_SIZE + 3) / 4) * 4)  // based off eeconfig's current usage, aligned to 4-byte sizes, to deal with LTO and EEPROM page sizing
+#    endif
+#endif
+
+#if STM32_ONBOARD_EEPROM_SIZE > 128
+#    pragma message("Please note: resetting EEPROM using an STM32L0/L1 device takes up to 1 second for every 1kB of internal EEPROM used.")
+#endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Adds support for chip-based EEPROM for STM32L0 and L1, using the default "vendor" driver.

Tested with STM Nucleo boards, both L0xx and L1xx function as intended.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
