### PR TITLE
Qmk doctor os check to support newer msys2/w10 installations

### DIFF
--- a/lib/python/qmk/cli/doctor.py
+++ b/lib/python/qmk/cli/doctor.py
@@ -168,15 +168,15 @@ def doctor(cli):
     ok = True
 
     # Determine our OS and run platform specific tests
-    OS = platform.system()  # noqa (N806), uppercase name is ok in this instance
+    OS = platform.platform()  # noqa (N806), uppercase name is ok in this instance
 
-    if OS == 'Darwin':
+    if 'Darwin' in OS:
         if not os_test_macos():
             ok = False
-    elif OS == 'Linux':
+    elif 'Linux' in OS:
         if not os_test_linux():
             ok = False
-    elif OS == 'Windows':
+    elif 'Windows' in OS:
         if not os_test_windows():
             ok = False
     else:

--- a/lib/python/qmk/cli/doctor.py
+++ b/lib/python/qmk/cli/doctor.py
@@ -168,15 +168,15 @@ def doctor(cli):
     ok = True
 
     # Determine our OS and run platform specific tests
-    OS = platform.platform()  # noqa (N806), uppercase name is ok in this instance
+    OS = platform.platform().lower()  # noqa (N806), uppercase name is ok in this instance
 
-    if 'Darwin' in OS:
+    if 'darwin' in OS:
         if not os_test_macos():
             ok = False
-    elif 'Linux' in OS:
+    elif 'linux' in OS:
         if not os_test_linux():
             ok = False
-    elif 'Windows' in OS:
+    elif 'windows' in OS:
         if not os_test_windows():
             ok = False
     else:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I noticed in a fresh MSYS2 installation on a fresh W10 (home and pro) installation didn't work with qmk doctor anymore, as the platform string has changed to indicate that it's msys

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
