### PR TITLE
Add support for early board init

### DIFF
--- a/tmk_core/common/keyboard.c
+++ b/tmk_core/common/keyboard.c
@@ -163,6 +163,13 @@ void disable_jtag(void) {
 #endif
 }
 
+/** \brief keyboard_early_init
+ *
+ * FIXME: needs doc
+ */
+
+__attribute__((weak)) void keyboard_early_init(void) {}
+
 /** \brief matrix_setup
  *
  * FIXME: needs doc
@@ -200,6 +207,13 @@ __attribute__((weak)) void keyboard_post_init_kb(void) { keyboard_post_init_user
  * FIXME: needs doc
  */
 void keyboard_setup(void) {
+#ifdef STM32_BOOTLOADER_ADDRESS
+    void enter_bootloader_mode_if_requested(void);
+    enter_bootloader_mode_if_requested();
+#endif
+
+    keyboard_early_init();
+
 #ifndef NO_JTAG_DISABLE
     disable_jtag();
 #endif


### PR DESCRIPTION
ChibiOS boards that require any extra processing at a very early time tend to end up duplicating the board definitions in order to override `boardInit()`.

Examples:
- anything that has a `enter_bootloader_mode_if_requested()` call
- cannonkeys/satisfaction75 and its RTC initialisation
- all the copypasted board definitions that do I2C1 DMA remapping (`SYSCFG_CFGR1_I2C1_DMA_RMP` etc.)

## Description

This is an attempt at spurring some discussion as to where/how we can put an early-enough init code that can be overridden without actually requiring duplication of the ChibiOS board definitions, thus minimising the subsequent maintenance overhead for the (hopefully) more frequent ChibiOS upgrades than what we're going through now.

Discussion-wise, I'd like to get some opinions where/how we'd like this feature implemented.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
