### PR TITLE
Buffer based OLED panning, write byte to buffer at arbitrary index

### DIFF
--- a/docs/feature_oled_driver.md
+++ b/docs/feature_oled_driver.md
@@ -221,6 +221,9 @@ void oled_write(const char *data, bool invert);
 // Advances the cursor to the next page, wiring ' ' to the remainder of the current page
 void oled_write_ln(const char *data, bool invert);
 
+// Pans the buffer to the right (or left by passing true) by moving contents of the buffer
+void oled_pan(bool left);
+
 // Writes a PROGMEM string to the buffer at current cursor position
 // Advances the cursor while writing, inverts the pixels if true
 // Remapped to call 'void oled_write(const char *data, bool invert);' on ARM
@@ -234,6 +237,9 @@ void oled_write_ln_P(const char *data, bool invert);
 
 // Writes a string to the buffer at current cursor position
 void oled_write_raw(const char *data, uint16_t size);
+
+// Writes a single byte into the buffer at the specified index
+void oled_write_raw_byte(const char data, uint16_t index);
 
 // Writes a PROGMEM string to the buffer at current cursor position
 void oled_write_raw_P(const char *data, uint16_t size);

--- a/docs/feature_oled_driver.md
+++ b/docs/feature_oled_driver.md
@@ -222,6 +222,9 @@ void oled_write(const char *data, bool invert);
 void oled_write_ln(const char *data, bool invert);
 
 // Pans the buffer to the right (or left by passing true) by moving contents of the buffer
+// Useful for moving the screen in preparation for new drawing 
+// oled_scroll_left or oled_scroll_right should be preferred for all cases of moving a static
+// image such as a logo or to avoid burn-in as it's much, much less cpu intensive
 void oled_pan(bool left);
 
 // Writes a PROGMEM string to the buffer at current cursor position

--- a/drivers/oled/oled_driver.c
+++ b/drivers/oled/oled_driver.c
@@ -446,7 +446,7 @@ void oled_pan(bool left) {
             }
         }
     }
-    oled_dirty = 65535;
+    oled_dirty = ~((OLED_BLOCK_TYPE)0);
 }
 
 void oled_write_raw_byte(const char data, uint16_t index) {

--- a/drivers/oled/oled_driver.c
+++ b/drivers/oled/oled_driver.c
@@ -431,6 +431,31 @@ void oled_write_ln(const char *data, bool invert) {
     oled_advance_page(true);
 }
 
+void oled_pan(bool left) {
+    uint16_t i = 0;
+    for (uint16_t y = 0; y < OLED_DISPLAY_HEIGHT/8; y++) {
+        if(left) {
+            for (uint16_t x = 0; x < OLED_DISPLAY_WIDTH - 1; x++) {
+                i = y * OLED_DISPLAY_WIDTH + x;
+                oled_buffer[i] = oled_buffer[i+1];
+            }
+        } else {
+            for (uint16_t x = OLED_DISPLAY_WIDTH -1; x > 0; x--) {
+                i = y * OLED_DISPLAY_WIDTH + x;
+                oled_buffer[i] = oled_buffer[i-1];
+            }
+        }
+    }
+    oled_dirty = 65535;
+}
+
+void oled_write_raw_byte(const char data, uint16_t index) {
+    if (index > OLED_MATRIX_SIZE) index = OLED_MATRIX_SIZE;
+    if (oled_buffer[index] == data) return;
+    oled_buffer[index] = data;
+    oled_dirty |= (1 << (index / OLED_BLOCK_SIZE));
+}
+
 void oled_write_raw(const char *data, uint16_t size) {
     if (size > OLED_MATRIX_SIZE) size = OLED_MATRIX_SIZE;
     for (uint16_t i = 0; i < size; i++) {

--- a/drivers/oled/oled_driver.h
+++ b/drivers/oled/oled_driver.h
@@ -200,7 +200,11 @@ void oled_write(const char *data, bool invert);
 // Advances the cursor to the next page, wiring ' ' to the remainder of the current page
 void oled_write_ln(const char *data, bool invert);
 
+// Pans the buffer to the right (or left by passing true) by moving contents of the buffer
+void oled_pan(bool left);
+
 void oled_write_raw(const char *data, uint16_t size);
+void oled_write_raw_byte(const char data, uint16_t index);
 
 #if defined(__AVR__)
 // Writes a PROGMEM string to the buffer at current cursor position


### PR DESCRIPTION
A duet of functions to facilitate sophisticated graphical displays such as time series graphing using the OLED library.
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

A function to pan the contents of an OLED display left or right by manipulating the buffer. This is distinct from the scrolling features provided by the driver in that the program can control speed by panning the display column by column.

A function to write a byte at an arbitrary index of the OLED display buffer to allow for modifying discreet areas of the display.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
