### PR TITLE
Noxary 280 Backwards LED Fix

### DIFF
--- a/keyboards/noxary/280/280.c
+++ b/keyboards/noxary/280/280.c
@@ -28,43 +28,10 @@ void matrix_init_kb(void) {
 	matrix_init_user();
 }
 
-/*
-void matrix_scan_kb(void) {
-  // put your looping keyboard code here
-  // runs every cycle (a lot)
-
-  matrix_scan_user();
-}
-
-bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
-  // put your per-action keyboard code here
-  // runs for every action, just before processing by the firmware
-
-  return process_record_user(keycode, record);
-}
-
-void led_set_kb(uint8_t usb_led) {
-  // put your keyboard LED indicator (ex: Caps Lock LED) toggling code here
-
-  led_set_user(usb_led);
-}
-
-*/
-
-
-void led_set_kb(uint8_t usb_led) {
-
-    if (IS_LED_ON(usb_led, USB_LED_CAPS_LOCK)) {
-      writePinLow(D5);
-    } else {
-      writePinHigh(D5);
+bool led_update_kb(led_t led_state) {
+    if(led_update_user(led_state)) {
+        writePin(D5, led_state.caps_lock);
+        writePin(D0, led_state.scroll_lock);
     }
-
-    if (IS_LED_ON(usb_led, USB_LED_SCROLL_LOCK)) {
-      writePinLow(D0);
-    } else {
-      writePinHigh(D0);
-    }
-     
-    led_set_user(usb_led);
+    return true;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Dead Encryption reached out to me stating that the led was backwards. He provided the following code which I have since updated to the new standards

void led_set_kb(uint8_t usb_led) {

    if (IS_LED_ON(usb_led, USB_LED_CAPS_LOCK)) {
      writePinHigh(D5);
    } else {
      writePinLow(D5);
    }

    if (IS_LED_ON(usb_led, USB_LED_SCROLL_LOCK)) {
      writePinHigh(D0);
    } else {
      writePinLow(D0);
    }
     
    led_set_user(usb_led);
}

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
