### PR TITLE
Added Atreus Pro Micro variant

### DIFF
--- a/keyboards/atreus/atreus.h
+++ b/keyboards/atreus/atreus.h
@@ -24,6 +24,8 @@
     #include "astar_mirrored.h"
 #elif KEYBOARD_atreus_teensy2
     #include "teensy2.h"
+#elif KEYBOARD_atreus_promicro
+    #include "promicro.h"
 #endif
 
 // This a shortcut to help you visually see your layout.

--- a/keyboards/atreus/keymaps/ibnuda/config.h
+++ b/keyboards/atreus/keymaps/ibnuda/config.h
@@ -1,7 +1,5 @@
 #pragma once
 
-// #include "config_common.h"
-
 #define TAPPING_TERM 200
 #define IGNORE_MOD_TAP_INTERRUPT
 #define COMBO_COUNT 15

--- a/keyboards/atreus/keymaps/ibnuda/config.h
+++ b/keyboards/atreus/keymaps/ibnuda/config.h
@@ -1,0 +1,7 @@
+#pragma once
+
+// #include "config_common.h"
+
+#define TAPPING_TERM 200
+#define IGNORE_MOD_TAP_INTERRUPT
+#define COMBO_COUNT 15

--- a/keyboards/atreus/keymaps/ibnuda/keymap.c
+++ b/keyboards/atreus/keymaps/ibnuda/keymap.c
@@ -1,0 +1,281 @@
+#include QMK_KEYBOARD_H
+
+typedef enum {
+    SINGLE_TAP,
+    SINGLE_HOLD,
+    DOUBLE_TAP,
+} td_state_t;
+
+static td_state_t td_state;
+
+int current_dance(qk_tap_dance_state_t *state);
+
+void dance_tmb_finished(qk_tap_dance_state_t *state, void *user_data);
+void dance_tmb_reset(qk_tap_dance_state_t *state, void *user_data);
+
+// enum for tap dances.
+enum {
+    TD_DLT_CTLDLT = 0,
+    TD_SCLN_CLN,
+    TD_LEFT_THUMB,
+};
+
+// enum for combos.
+enum combos {
+    // left hand combinations.
+    COLON_COMMA,
+    COMMA_DOT,
+    DOT_P,
+    Q_J,
+    J_K,
+
+    // right hand combinations.
+    L_R,
+    R_C,
+    C_G,
+    V_W,
+    W_M,
+
+    // both hands combinations.
+    DOT_C,
+    J_W,
+    P_G,
+    U_H,
+    K_M,
+};
+
+#define _BASE    0
+#define _LOWER   1
+#define _RAISE   2
+#define _ADJUST  3
+#define _MUIS    4
+
+#define ____ KC_TRNS
+
+// short.
+#define KC_QUES LSFT(KC_SLSH)
+#define KC_UNDR LSFT(KC_MINS)
+#define MU_UP   KC_MS_UP
+#define MU_DN   KC_MS_DOWN
+#define MU_LFT  KC_MS_LEFT
+#define MU_RGHT KC_MS_RIGHT
+#define MU_BTN1 KC_MS_BTN1
+#define MU_BTN2 KC_MS_BTN2
+#define MU_WD   KC_MS_WH_DOWN
+#define MU_WU   KC_MS_WH_UP
+
+// thumb keys.
+#define ALT_ENT   ALT_T(KC_ENT)
+#define SFT_ESC   SFT_T(KC_ESC)
+
+// home row mods.
+#define CT_O RCTL_T(KC_O)
+#define CT_N RCTL_T(KC_N)
+#define SH_A RSFT_T(KC_A)
+#define SH_S RSFT_T(KC_S)
+#define AL_E RALT_T(KC_E)
+#define AL_T RALT_T(KC_T)
+#define GU_I RGUI_T(KC_I)
+#define GU_D RGUI_T(KC_D)
+
+// layer toggle.
+#define LW_BSPC  LT(_LOWER, KC_BSPC)
+#define RS_SPC   LT(_RAISE, KC_SPC)
+#define RS_D     LT(_RAISE, KC_D)
+#define LW_I     LT(_LOWER, KC_I)
+#define MU_QUOT  LT(_MUIS, KC_QUOT)
+#define MU_Z     LT(_MUIS, KC_Z)
+
+// idk, man. not used, i guess.
+#define RAISE    MO(_RAISE)
+#define LOWER    MO(_LOWER)
+#define ADDDD    MO(_ADJUST)
+#define MUIS     MO(_MUIS)
+
+// common shortcuts for windows and linux that i use.
+#define NXTTAB LCTL(KC_PGDN)
+#define PRVTAB LCTL(KC_PGUP)
+#define UPTAB  LCTL(LSFT(KC_PGUP))
+#define DNTAB  LCTL(LSFT(KC_PGDN))
+#define NXTWIN LALT(KC_TAB)
+#define PRVWIN LALT(LSFT(KC_TAB))
+#define CALDL  LCTL(LALT(KC_DELT))
+#define TSKMGR LCTL(LSFT(KC_ESC))
+#define EXPLR  LGUI(KC_E)
+#define LCKGUI LGUI(KC_L)
+#define CONPST LSFT(KC_INS)
+#define CLSGUI LALT(KC_F4)
+
+// tap dances
+#define CTL_DLT TD(TD_DLT_CTLDLT)
+#define SM_CLN  TD(TD_SCLN_CLN)
+#define LFT_TMB TD(TD_LEFT_THUMB)
+
+// left hand combinations.
+const uint16_t PROGMEM colon_comma_combo[] = {KC_SCLN, KC_COMM, COMBO_END};
+const uint16_t PROGMEM comma_dot_combo[]   = {KC_COMM, KC_DOT, COMBO_END};
+const uint16_t PROGMEM dot_p_combo[]       = {KC_DOT, KC_P, COMBO_END};
+const uint16_t PROGMEM q_j_combo[]         = {KC_Q, KC_J, COMBO_END};
+const uint16_t PROGMEM j_k_combo[]         = {KC_J, KC_K, COMBO_END};
+
+// right hand combinations.
+const uint16_t PROGMEM l_r_combo[]         = {KC_L, KC_R, COMBO_END};
+const uint16_t PROGMEM r_c_combo[]         = {KC_R, KC_C, COMBO_END};
+const uint16_t PROGMEM c_g_combo[]         = {KC_C, KC_G, COMBO_END};
+const uint16_t PROGMEM v_w_combo[]         = {KC_V, KC_W, COMBO_END};
+const uint16_t PROGMEM w_m_combo[]         = {KC_W, KC_M, COMBO_END};
+
+// both hand combinations.
+const uint16_t PROGMEM dot_c_combo[]       = {KC_DOT, KC_C, COMBO_END};
+const uint16_t PROGMEM j_w_combo[]         = {KC_J, KC_W, COMBO_END};
+const uint16_t PROGMEM u_h_combo[]         = {KC_U, KC_H, COMBO_END};
+const uint16_t PROGMEM p_g_combo[]         = {KC_P, KC_G, COMBO_END};
+const uint16_t PROGMEM k_m_combo[]         = {KC_K, KC_M, COMBO_END};
+
+combo_t key_combos[COMBO_COUNT] = {
+    // left hand combinations.
+    [COLON_COMMA]   = COMBO(colon_comma_combo,  KC_TAB),
+    [COMMA_DOT]     = COMBO(comma_dot_combo,    KC_QUES),
+    [DOT_P]         = COMBO(dot_p_combo,        KC_UNDR),
+    [Q_J]           = COMBO(q_j_combo,          LCTL(KC_W)),
+    [J_K]           = COMBO(j_k_combo,          KC_DELT),
+
+    // right hand combinations.
+    [L_R]           = COMBO(l_r_combo,          KC_BSPC),
+    [R_C]           = COMBO(r_c_combo,          KC_SLSH),
+    [C_G]           = COMBO(c_g_combo,          KC_MINS),
+    [V_W]           = COMBO(v_w_combo,          KC_APP),
+    [W_M]           = COMBO(w_m_combo,          KC_DELT),
+
+    // both hand combinations.
+    [DOT_C]         = COMBO(dot_c_combo,        KC_PGUP),
+    [J_W]           = COMBO(j_w_combo,          KC_PGDN),
+    [U_H]           = COMBO(u_h_combo,          KC_ENT),
+    [P_G]           = COMBO(p_g_combo,          KC_HOME),
+    [K_M]           = COMBO(k_m_combo,          KC_END),
+};
+
+void dance_dlt_finished(qk_tap_dance_state_t *state, void *user_data) {
+    if (state->count == 1) {
+        register_code(KC_DELT);
+    } else {
+        register_code(KC_LCTL);
+        register_code(KC_DELT);
+    }
+}
+
+void dance_dlt_reset(qk_tap_dance_state_t *state, void *user_data) {
+    if (state->count == 1) {
+        unregister_code(KC_DELT);
+    } else {
+        unregister_code(KC_LCTL);
+        unregister_code(KC_DELT);
+    }
+}
+
+void dance_cln_finished(qk_tap_dance_state_t *state, void *user_data) {
+    if (state->count == 1) {
+        register_code(KC_SCLN);
+    } else {
+        register_code(KC_LSFT);
+        register_code(KC_SCLN);
+    }
+}
+
+void dance_cln_reset(qk_tap_dance_state_t *state, void *user_data) {
+    if (state->count == 1) {
+        unregister_code(KC_SCLN);
+    } else {
+        unregister_code(KC_LSFT);
+        unregister_code(KC_SCLN);
+    }
+}
+
+int current_dance(qk_tap_dance_state_t *state) {
+    if (state->count == 1) {
+        if (state->interrupted || !state->pressed) {
+            return SINGLE_TAP;
+        } else {
+            return SINGLE_HOLD;
+        }
+    }
+    if (state->count == 2) {
+        return DOUBLE_TAP;
+    } else {
+        return 3;
+    }
+}
+
+void dance_tmb_finished(qk_tap_dance_state_t *state, void *user_data) {
+    td_state = current_dance(state);
+    switch (td_state) {
+        case SINGLE_TAP:
+            register_code16(KC_ESC);
+            break;
+        case SINGLE_HOLD:
+            register_mods(MOD_BIT(KC_LSFT));
+            break;
+        case DOUBLE_TAP:
+            register_code16(KC_DELT);
+            break;
+    }
+}
+
+void dance_tmb_reset(qk_tap_dance_state_t *state, void *user_data) {
+    switch (td_state) {
+        case SINGLE_TAP:
+            unregister_code16(KC_ESC);
+            break;
+        case SINGLE_HOLD:
+            unregister_mods(MOD_BIT(KC_LSFT));
+            break;
+        case DOUBLE_TAP:
+            unregister_code16(KC_DELT);
+            break;
+    }
+}
+
+qk_tap_dance_action_t tap_dance_actions[] = {
+    [TD_DLT_CTLDLT] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, dance_dlt_finished, dance_dlt_reset),
+    [TD_SCLN_CLN]   = ACTION_TAP_DANCE_FN_ADVANCED(NULL, dance_cln_finished, dance_cln_reset),
+    [TD_LEFT_THUMB] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, dance_tmb_finished, dance_tmb_reset),
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+[_BASE] = LAYOUT(
+    SM_CLN, KC_COMM,KC_DOT, KC_P,   KC_Y,                       KC_F,   KC_G,   KC_C,   KC_R,   KC_L,
+    SH_A,   CT_O,   AL_E,   KC_U,   GU_I,                       GU_D,   KC_H,   AL_T,   CT_N,   SH_S,
+    MU_QUOT,KC_Q,   KC_J,   KC_K,   KC_X,                       KC_B,   KC_M,   KC_W,   KC_V,   MU_Z,
+    ____,   ____,   ____,   ____,   LW_BSPC,SFT_ESC,    ALT_ENT,RS_SPC, ____,   ____,   ____,   ____
+),
+
+[_RAISE] = LAYOUT(
+    KC_EXLM,KC_AT,  KC_UP,  KC_LCBR,KC_RCBR,                    KC_BSLS,KC_7,   KC_8,   KC_9,   KC_ASTR ,
+    KC_HASH,KC_LEFT,KC_DOWN,KC_RGHT,KC_DLR,                     KC_EQL, KC_4,   KC_5,   KC_6,   KC_TILD ,
+    KC_LBRC,KC_RBRC,KC_LPRN,KC_RPRN,KC_AMPR,                    KC_GRV, KC_1,   KC_2,   KC_3,   KC_PLUS ,
+    ____,   ____,   ____,   ____,   ADDDD,  ____,       ALT_ENT,RS_SPC, ____,   ____,   ____,   ____
+),
+[_LOWER] = LAYOUT(
+    KC_ESC, KC_QUES,KC_UNDR,KC_F1,  KC_F2,                      KC_F3,  KC_F4,  KC_MINS,KC_SLSH,KC_BSPC ,
+    KC_LSFT,KC_TAB, KC_PGUP,KC_F5,  KC_F6,                      KC_F7,  KC_F8,  KC_HOME,KC_LALT,KC_ENT  ,
+    KC_CLCK,KC_SLCK,KC_PGDN,KC_F9,  KC_F10,                     KC_F11, KC_F12, KC_END, KC_INS, KC_SLSH ,
+    ____,   ____,   ____,   ____,   ADDDD,  ____,       KC_DELT,ADDDD,  ____,   ____,   ____,   ____
+),
+[_ADJUST] = LAYOUT(
+    ____,   EXPLR,  KC_UP,  PRVTAB, PRVWIN,                     NXTWIN, NXTTAB, ____,   ____,   LCKGUI,
+    TSKMGR, KC_LEFT,KC_DOWN,KC_RGHT,UPTAB,                      DNTAB,  KC_ENT, KC_LGUI,____,   CALDL,
+    ____,   CLSGUI, ____,   CONPST, RESET,                      ____,   ____,   ____,   ____,   ____,
+    ____,   ____,   ____,   ____,   ____,   ____,       ____,   ____,   ____,   ____,   ____,   ____
+),
+[_MUIS] = LAYOUT(
+    ____,   MU_BTN2,MU_UP,  MU_BTN1,____,                       ____,   MU_BTN1,MU_UP,  MU_BTN2,____,
+    ____,   MU_LFT, MU_DN,  MU_RGHT,____,                       ____,   MU_LFT, MU_DN,  MU_RGHT,____,
+    ____,   ____,   MU_WD,  MU_WU,  ____,                       ____,   MU_WU,  MU_WD,  ____,   ____,
+    ____,   ____,   ____,   ____,   ____,   ____,       ____,   ____,   ____,   ____,   ____,   ____
+),
+};
+
+void persistent_default_layer_set(uint16_t default_layer) {
+  eeconfig_update_default_layer(default_layer);
+  default_layer_set(default_layer);
+}

--- a/keyboards/atreus/keymaps/ibnuda/keymap.c
+++ b/keyboards/atreus/keymaps/ibnuda/keymap.c
@@ -52,16 +52,6 @@ enum {
     _MUIS
 };
 
-// short.
-#define MU_UP   KC_MS_UP
-#define MU_DN   KC_MS_DOWN
-#define MU_LFT  KC_MS_LEFT
-#define MU_RGHT KC_MS_RIGHT
-#define MU_BTN1 KC_MS_BTN1
-#define MU_BTN2 KC_MS_BTN2
-#define MU_WD   KC_MS_WH_DOWN
-#define MU_WU   KC_MS_WH_UP
-
 // thumb keys.
 #define ALT_ENT   ALT_T(KC_ENT)
 #define SFT_ESC   SFT_T(KC_ESC)

--- a/keyboards/atreus/keymaps/ibnuda/keymap.c
+++ b/keyboards/atreus/keymaps/ibnuda/keymap.c
@@ -44,17 +44,15 @@ enum combos {
     K_M,
 };
 
-#define _BASE    0
-#define _LOWER   1
-#define _RAISE   2
-#define _ADJUST  3
-#define _MUIS    4
-
-#define ____ KC_TRNS
+enum {
+    _BASE,
+    _LOWER,
+    _RAISE,
+    _ADJUST,
+    _MUIS
+};
 
 // short.
-#define KC_QUES LSFT(KC_SLSH)
-#define KC_UNDR LSFT(KC_MINS)
 #define MU_UP   KC_MS_UP
 #define MU_DN   KC_MS_DOWN
 #define MU_LFT  KC_MS_LEFT
@@ -246,36 +244,31 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     SM_CLN, KC_COMM,KC_DOT, KC_P,   KC_Y,                       KC_F,   KC_G,   KC_C,   KC_R,   KC_L,
     SH_A,   CT_O,   AL_E,   KC_U,   GU_I,                       GU_D,   KC_H,   AL_T,   CT_N,   SH_S,
     MU_QUOT,KC_Q,   KC_J,   KC_K,   KC_X,                       KC_B,   KC_M,   KC_W,   KC_V,   MU_Z,
-    ____,   ____,   ____,   ____,   LW_BSPC,SFT_ESC,    ALT_ENT,RS_SPC, ____,   ____,   ____,   ____
+    _______,_______,_______,_______,LW_BSPC,SFT_ESC,    ALT_ENT,RS_SPC, _______,_______,_______,____
 ),
 
 [_RAISE] = LAYOUT(
     KC_EXLM,KC_AT,  KC_UP,  KC_LCBR,KC_RCBR,                    KC_BSLS,KC_7,   KC_8,   KC_9,   KC_ASTR ,
     KC_HASH,KC_LEFT,KC_DOWN,KC_RGHT,KC_DLR,                     KC_EQL, KC_4,   KC_5,   KC_6,   KC_TILD ,
     KC_LBRC,KC_RBRC,KC_LPRN,KC_RPRN,KC_AMPR,                    KC_GRV, KC_1,   KC_2,   KC_3,   KC_PLUS ,
-    ____,   ____,   ____,   ____,   ADDDD,  ____,       ALT_ENT,RS_SPC, ____,   ____,   ____,   ____
+    _______,_______,_______,_______,ADDDD,  _______,    ALT_ENT,RS_SPC, _______,_______,_______,____
 ),
 [_LOWER] = LAYOUT(
-    KC_ESC, KC_QUES,KC_UNDR,KC_F1,  KC_F2,                      KC_F3,  KC_F4,  KC_MINS,KC_SLSH,KC_BSPC ,
+    KC_ESC, KC_QUES,KC_UNDS,KC_F1,  KC_F2,                      KC_F3,  KC_F4,  KC_MINS,KC_SLSH,KC_BSPC ,
     KC_LSFT,KC_TAB, KC_PGUP,KC_F5,  KC_F6,                      KC_F7,  KC_F8,  KC_HOME,KC_LALT,KC_ENT  ,
     KC_CLCK,KC_SLCK,KC_PGDN,KC_F9,  KC_F10,                     KC_F11, KC_F12, KC_END, KC_INS, KC_SLSH ,
-    ____,   ____,   ____,   ____,   ADDDD,  ____,       KC_DELT,ADDDD,  ____,   ____,   ____,   ____
+    _______,_______,_______,_______,ADDDD,  _______,    KC_DELT,ADDDD,  _______,_______,_______,____
 ),
 [_ADJUST] = LAYOUT(
-    ____,   EXPLR,  KC_UP,  PRVTAB, PRVWIN,                     NXTWIN, NXTTAB, ____,   ____,   LCKGUI,
-    TSKMGR, KC_LEFT,KC_DOWN,KC_RGHT,UPTAB,                      DNTAB,  KC_ENT, KC_LGUI,____,   CALDL,
-    ____,   CLSGUI, ____,   CONPST, RESET,                      ____,   ____,   ____,   ____,   ____,
-    ____,   ____,   ____,   ____,   ____,   ____,       ____,   ____,   ____,   ____,   ____,   ____
+    _______,EXPLR,  KC_UP,  PRVTAB, PRVWIN,                     NXTWIN, NXTTAB, _______,_______,LCKGUI,
+    TSKMGR, KC_LEFT,KC_DOWN,KC_RGHT,UPTAB,                      DNTAB,  KC_ENT, KC_LGUI,_______,CALDL,
+    _______,CLSGUI, _______,CONPST, RESET,                      _______,_______,_______,_______,____,
+    _______,_______,_______,_______,_______,_______,    _______,_______,_______,_______,_______,____
 ),
 [_MUIS] = LAYOUT(
-    ____,   MU_BTN2,MU_UP,  MU_BTN1,____,                       ____,   MU_BTN1,MU_UP,  MU_BTN2,____,
-    ____,   MU_LFT, MU_DN,  MU_RGHT,____,                       ____,   MU_LFT, MU_DN,  MU_RGHT,____,
-    ____,   ____,   MU_WD,  MU_WU,  ____,                       ____,   MU_WU,  MU_WD,  ____,   ____,
-    ____,   ____,   ____,   ____,   ____,   ____,       ____,   ____,   ____,   ____,   ____,   ____
+    _______,KC_BTN2,KC_MS_U,KC_BTN1,_______,                    _______,KC_BTN1,KC_MS_U,KC_BTN2,____,
+    _______,KC_MS_L,KC_MS_D,KC_MS_R,_______,                    _______,KC_MS_L,KC_MS_D,KC_MS_R,____,
+    _______,_______,KC_WH_D,KC_WH_U,_______,                    _______,KC_WH_U,KC_WH_D,_______,____,
+    _______,_______,_______,_______,_______,_______,    _______,_______,_______,_______,_______,____
 ),
 };
-
-void persistent_default_layer_set(uint16_t default_layer) {
-  eeconfig_update_default_layer(default_layer);
-  default_layer_set(default_layer);
-}

--- a/keyboards/atreus/keymaps/ibnuda/keymap.c
+++ b/keyboards/atreus/keymaps/ibnuda/keymap.c
@@ -134,7 +134,7 @@ combo_t key_combos[COMBO_COUNT] = {
     // left hand combinations.
     [COLON_COMMA]   = COMBO(colon_comma_combo,  KC_TAB),
     [COMMA_DOT]     = COMBO(comma_dot_combo,    KC_QUES),
-    [DOT_P]         = COMBO(dot_p_combo,        KC_UNDR),
+    [DOT_P]         = COMBO(dot_p_combo,        KC_UNDS),
     [Q_J]           = COMBO(q_j_combo,          LCTL(KC_W)),
     [J_K]           = COMBO(j_k_combo,          KC_DELT),
 
@@ -244,31 +244,31 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     SM_CLN, KC_COMM,KC_DOT, KC_P,   KC_Y,                       KC_F,   KC_G,   KC_C,   KC_R,   KC_L,
     SH_A,   CT_O,   AL_E,   KC_U,   GU_I,                       GU_D,   KC_H,   AL_T,   CT_N,   SH_S,
     MU_QUOT,KC_Q,   KC_J,   KC_K,   KC_X,                       KC_B,   KC_M,   KC_W,   KC_V,   MU_Z,
-    _______,_______,_______,_______,LW_BSPC,SFT_ESC,    ALT_ENT,RS_SPC, _______,_______,_______,____
+    _______,_______,_______,_______,LW_BSPC,SFT_ESC,    ALT_ENT,RS_SPC, _______,_______,_______,_______
 ),
 
 [_RAISE] = LAYOUT(
     KC_EXLM,KC_AT,  KC_UP,  KC_LCBR,KC_RCBR,                    KC_BSLS,KC_7,   KC_8,   KC_9,   KC_ASTR ,
     KC_HASH,KC_LEFT,KC_DOWN,KC_RGHT,KC_DLR,                     KC_EQL, KC_4,   KC_5,   KC_6,   KC_TILD ,
     KC_LBRC,KC_RBRC,KC_LPRN,KC_RPRN,KC_AMPR,                    KC_GRV, KC_1,   KC_2,   KC_3,   KC_PLUS ,
-    _______,_______,_______,_______,ADDDD,  _______,    ALT_ENT,RS_SPC, _______,_______,_______,____
+    _______,_______,_______,_______,ADDDD,  _______,    ALT_ENT,RS_SPC, _______,_______,_______,_______
 ),
 [_LOWER] = LAYOUT(
     KC_ESC, KC_QUES,KC_UNDS,KC_F1,  KC_F2,                      KC_F3,  KC_F4,  KC_MINS,KC_SLSH,KC_BSPC ,
     KC_LSFT,KC_TAB, KC_PGUP,KC_F5,  KC_F6,                      KC_F7,  KC_F8,  KC_HOME,KC_LALT,KC_ENT  ,
     KC_CLCK,KC_SLCK,KC_PGDN,KC_F9,  KC_F10,                     KC_F11, KC_F12, KC_END, KC_INS, KC_SLSH ,
-    _______,_______,_______,_______,ADDDD,  _______,    KC_DELT,ADDDD,  _______,_______,_______,____
+    _______,_______,_______,_______,ADDDD,  _______,    KC_DELT,ADDDD,  _______,_______,_______,_______
 ),
 [_ADJUST] = LAYOUT(
     _______,EXPLR,  KC_UP,  PRVTAB, PRVWIN,                     NXTWIN, NXTTAB, _______,_______,LCKGUI,
     TSKMGR, KC_LEFT,KC_DOWN,KC_RGHT,UPTAB,                      DNTAB,  KC_ENT, KC_LGUI,_______,CALDL,
-    _______,CLSGUI, _______,CONPST, RESET,                      _______,_______,_______,_______,____,
-    _______,_______,_______,_______,_______,_______,    _______,_______,_______,_______,_______,____
+    _______,CLSGUI, _______,CONPST, RESET,                      _______,_______,_______,_______,_______,
+    _______,_______,_______,_______,_______,_______,    _______,_______,_______,_______,_______,_______
 ),
 [_MUIS] = LAYOUT(
-    _______,KC_BTN2,KC_MS_U,KC_BTN1,_______,                    _______,KC_BTN1,KC_MS_U,KC_BTN2,____,
-    _______,KC_MS_L,KC_MS_D,KC_MS_R,_______,                    _______,KC_MS_L,KC_MS_D,KC_MS_R,____,
-    _______,_______,KC_WH_D,KC_WH_U,_______,                    _______,KC_WH_U,KC_WH_D,_______,____,
-    _______,_______,_______,_______,_______,_______,    _______,_______,_______,_______,_______,____
+    _______,KC_BTN2,KC_MS_U,KC_BTN1,_______,                    _______,KC_BTN1,KC_MS_U,KC_BTN2,_______,
+    _______,KC_MS_L,KC_MS_D,KC_MS_R,_______,                    _______,KC_MS_L,KC_MS_D,KC_MS_R,_______,
+    _______,_______,KC_WH_D,KC_WH_U,_______,                    _______,KC_WH_U,KC_WH_D,_______,_______,
+    _______,_______,_______,_______,_______,_______,    _______,_______,_______,_______,_______,_______
 ),
 };

--- a/keyboards/atreus/keymaps/ibnuda/keymap.c
+++ b/keyboards/atreus/keymaps/ibnuda/keymap.c
@@ -155,38 +155,32 @@ combo_t key_combos[COMBO_COUNT] = {
 
 void dance_dlt_finished(qk_tap_dance_state_t *state, void *user_data) {
     if (state->count == 1) {
-        register_code(KC_DELT);
+        register_code16(KC_DELT);
     } else {
-        register_code(KC_LCTL);
-        register_code(KC_DELT);
+        register_code16(C(KC_DELT));
     }
 }
 
 void dance_dlt_reset(qk_tap_dance_state_t *state, void *user_data) {
     if (state->count == 1) {
-        unregister_code(KC_DELT);
+        unregister_code16(KC_DELT);
     } else {
-        unregister_code(KC_LCTL);
-        unregister_code(KC_DELT);
+        unregister_code16(C(KC_DELT));
     }
 }
 
 void dance_cln_finished(qk_tap_dance_state_t *state, void *user_data) {
     if (state->count == 1) {
-        register_code(KC_SCLN);
-    } else {
         register_code(KC_LSFT);
-        register_code(KC_SCLN);
     }
+    register_code(KC_SCLN);
 }
 
 void dance_cln_reset(qk_tap_dance_state_t *state, void *user_data) {
     if (state->count == 1) {
-        unregister_code(KC_SCLN);
-    } else {
         unregister_code(KC_LSFT);
-        unregister_code(KC_SCLN);
     }
+    unregister_code(KC_SCLN);
 }
 
 int current_dance(qk_tap_dance_state_t *state) {
@@ -251,7 +245,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     KC_EXLM,KC_AT,  KC_UP,  KC_LCBR,KC_RCBR,                    KC_BSLS,KC_7,   KC_8,   KC_9,   KC_ASTR ,
     KC_HASH,KC_LEFT,KC_DOWN,KC_RGHT,KC_DLR,                     KC_EQL, KC_4,   KC_5,   KC_6,   KC_TILD ,
     KC_LBRC,KC_RBRC,KC_LPRN,KC_RPRN,KC_AMPR,                    KC_GRV, KC_1,   KC_2,   KC_3,   KC_PLUS ,
-    _______,_______,_______,_______,ADDDD,  _______,    ALT_ENT,RS_SPC, _______,_______,_______,_______
+    _______,_______,_______,_______,ADDDD,  _______,    ALT_ENT,RS_SPC, _______,KC_0,   _______,_______
 ),
 [_LOWER] = LAYOUT(
     KC_ESC, KC_QUES,KC_UNDS,KC_F1,  KC_F2,                      KC_F3,  KC_F4,  KC_MINS,KC_SLSH,KC_BSPC ,

--- a/keyboards/atreus/keymaps/ibnuda/rules.mk
+++ b/keyboards/atreus/keymaps/ibnuda/rules.mk
@@ -1,0 +1,9 @@
+# Build Options
+#   change yes to no to disable
+#
+
+MOUSEKEY_ENABLE  = yes     # Mouse keys(+4700)
+COMBO_ENABLE	 = yes
+TAP_DANCE_ENABLE = yes
+
+DEFAULT_FOLDER = atreus/greasy-promicro

--- a/keyboards/atreus/keymaps/ibnuda/rules.mk
+++ b/keyboards/atreus/keymaps/ibnuda/rules.mk
@@ -5,5 +5,3 @@
 MOUSEKEY_ENABLE  = yes
 COMBO_ENABLE	 = yes
 TAP_DANCE_ENABLE = yes
-
-DEFAULT_FOLDER = atreus/promicro

--- a/keyboards/atreus/keymaps/ibnuda/rules.mk
+++ b/keyboards/atreus/keymaps/ibnuda/rules.mk
@@ -2,8 +2,8 @@
 #   change yes to no to disable
 #
 
-MOUSEKEY_ENABLE  = yes     # Mouse keys(+4700)
+MOUSEKEY_ENABLE  = yes
 COMBO_ENABLE	 = yes
 TAP_DANCE_ENABLE = yes
 
-DEFAULT_FOLDER = atreus/greasy-promicro
+DEFAULT_FOLDER = atreus/promicro

--- a/keyboards/atreus/promicro/config.h
+++ b/keyboards/atreus/promicro/config.h
@@ -1,0 +1,40 @@
+/* Copyright 2019
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "config_common.h"
+
+/*
+ * Keyboard Matrix Assignments
+ *
+ * Change this to how you wired your keyboard
+ * COLS: AVR pins used for columns, left to right
+ * ROWS: AVR pins used for rows, top to bottom
+ * DIODE_DIRECTION: COL2ROW = COL = Anode (+), ROW = Cathode (-, marked on diode)
+ *                  ROW2COL = ROW = Anode (+), COL = Cathode (-, marked on diode)
+ *
+*/
+#define MATRIX_ROW_PINS { F4, B2, B4, B5 }
+#if defined(PCBDOWN)
+  #define MATRIX_COL_PINS { D0, D4, C6, D7, E6, B6, B3, B1, F7, F6, F5 }
+#else
+  #define MATRIX_COL_PINS { F5, F6, F7, B1, B3, B6, E6, D7, C6, D4, D0 }
+#endif
+#define UNUSED_PINS
+
+/* COL2ROW, ROW2COL*/
+#define DIODE_DIRECTION COL2ROW

--- a/keyboards/atreus/promicro/config.h
+++ b/keyboards/atreus/promicro/config.h
@@ -16,8 +16,6 @@
 
 #pragma once
 
-#include "config_common.h"
-
 /*
  * Keyboard Matrix Assignments
  *

--- a/keyboards/atreus/promicro/config.h
+++ b/keyboards/atreus/promicro/config.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include "config_common.h"
+
 /*
  * Keyboard Matrix Assignments
  *

--- a/keyboards/atreus/promicro/promicro.c
+++ b/keyboards/atreus/promicro/promicro.c
@@ -13,4 +13,4 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include "atreus.h"
+#include "promicro.h"

--- a/keyboards/atreus/promicro/promicro.c
+++ b/keyboards/atreus/promicro/promicro.c
@@ -1,0 +1,16 @@
+/* Copyright 2020
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "atreus.h"

--- a/keyboards/atreus/promicro/promicro.h
+++ b/keyboards/atreus/promicro/promicro.h
@@ -1,0 +1,17 @@
+/* Copyright 2019
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once

--- a/keyboards/atreus/promicro/rules.mk
+++ b/keyboards/atreus/promicro/rules.mk
@@ -1,0 +1,12 @@
+# MCU name
+MCU = atmega32u4
+
+# Bootloader selection
+#   Teensy       halfkay
+#   Pro Micro    caterina
+#   Atmel DFU    atmel-dfu
+#   LUFA DFU     lufa-dfu
+#   QMK DFU      qmk-dfu
+#   ATmega32A    bootloadHID
+#   ATmega328P   USBasp
+BOOTLOADER = caterina

--- a/keyboards/atreus/readme.md
+++ b/keyboards/atreus/readme.md
@@ -18,6 +18,7 @@ If you would like to use one of the alternative controllers:
 
     make atreus/astar:default:avrdude
     make atreus/teensy2:default:teensy
+    make atreus/promicro:default:avrdude
 
 If your keyboard layout is a mirror image of what you expected (i.e. you do not get QWERTY on the left but YTREWQ on the right), then you have an A-Star powered Atreus (older than March 2016) with PCB labels facing *down* instead of up. Specify that by adding `PCBDOWN=yes` to your `make` commands, e.g.
 

--- a/keyboards/atreus/readme.md
+++ b/keyboards/atreus/readme.md
@@ -16,9 +16,9 @@ Make example for this keyboard (after setting up your build environment):
 
 If you would like to use one of the alternative controllers:
 
-    make atreus/astar:default:avrdude
-    make atreus/teensy2:default:teensy
-    make atreus/promicro:default:avrdude
+    make atreus/astar:default:flash
+    make atreus/teensy2:default:flash
+    make atreus/promicro:default:flash
 
 If your keyboard layout is a mirror image of what you expected (i.e. you do not get QWERTY on the left but YTREWQ on the right), then you have an A-Star powered Atreus (older than March 2016) with PCB labels facing *down* instead of up. Specify that by adding `PCBDOWN=yes` to your `make` commands, e.g.
 


### PR DESCRIPTION
## Description

- Added cheap promicro clone as one of the alternative controllers, intended to be used with [this fork](https://github.com/ibnuda/atreus/tree/promicro).
- Added my personal keymap.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
