### PR TITLE
Add Midi Endpoint task to ChibiOS main

### DIFF
--- a/tmk_core/protocol/chibios/main.c
+++ b/tmk_core/protocol/chibios/main.c
@@ -81,6 +81,9 @@ void raw_hid_task(void);
 #ifdef CONSOLE_ENABLE
 void console_task(void);
 #endif
+#ifdef MIDI_ENABLE
+void midi_ep_task(void);
+#endif
 
 /* TESTING
  * Amber LED blinker thread, times are in milliseconds.
@@ -213,6 +216,9 @@ int main(void) {
         keyboard_task();
 #ifdef CONSOLE_ENABLE
         console_task();
+#endif
+#ifdef MIDI_ENABLE
+        midi_ep_task();
 #endif
 #ifdef VIRTSER_ENABLE
         virtser_task();

--- a/tmk_core/protocol/chibios/usb_main.c
+++ b/tmk_core/protocol/chibios/usb_main.c
@@ -833,7 +833,17 @@ bool recv_midi_packet(MIDI_EventPacket_t *const event) {
     size_t size = chnReadTimeout(&drivers.midi_driver.driver, (uint8_t *)event, sizeof(MIDI_EventPacket_t), TIME_IMMEDIATE);
     return size == sizeof(MIDI_EventPacket_t);
 }
-
+void midi_ep_task(void) {
+    uint8_t buffer[MIDI_STREAM_EPSIZE];
+    size_t  size = 0;
+    do {
+        size_t size = chnReadTimeout(&drivers.midi_driver.driver, buffer, sizeof(buffer), TIME_IMMEDIATE);
+        if (size > 0) {
+            MIDI_EventPacket_t event;
+            recv_midi_packet(&event);
+        }
+    } while (size > 0);
+}
 #endif
 
 #ifdef VIRTSER_ENABLE


### PR DESCRIPTION
## Description

Add `midi_ep_task` so that the MIDI endpoint on ChibiOS is actually functional. 

Before, the feature would be enabled, but wouldn't actually do anything, since there was no actual communication.

I'm not 100% certain that this works, but alexfry#4975 on Discord has confirmed that it works (as well, as identified that it wasn't working)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

*  [Discord] MIDI wasn't working on ChibiOS

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
