### PR TITLE
Remove entries for Minidox eep files from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,9 +63,6 @@ util/Win_Check_Output.txt
 *.gif
 *.jpg
 
-# Do not ignore MiniDox left/right hand eeprom files
-!keyboards/minidox/*.eep
-
 # things travis sees
 secrets.tar
 id_rsa_*


### PR DESCRIPTION
No longer necessary due to #7924.
