### PR TITLE
Remove i2c write command when reading columns on Ergodox EZ

### DIFF
--- a/keyboards/ergodox_ez/matrix.c
+++ b/keyboards/ergodox_ez/matrix.c
@@ -208,10 +208,6 @@ static matrix_row_t read_cols(uint8_t row) {
       return 0;
     } else {
       uint8_t data    = 0;
-      mcp23018_status = i2c_start(I2C_ADDR_WRITE, ERGODOX_EZ_I2C_TIMEOUT);
-      if (mcp23018_status) goto out;
-      mcp23018_status = i2c_write(GPIOB, ERGODOX_EZ_I2C_TIMEOUT);
-      if (mcp23018_status) goto out;
       mcp23018_status = i2c_start(I2C_ADDR_READ, ERGODOX_EZ_I2C_TIMEOUT);
       if (mcp23018_status) goto out;
       mcp23018_status = i2c_read_nack(ERGODOX_EZ_I2C_TIMEOUT);

--- a/keyboards/ergodox_ez/matrix.c
+++ b/keyboards/ergodox_ez/matrix.c
@@ -208,6 +208,8 @@ static matrix_row_t read_cols(uint8_t row) {
       return 0;
     } else {
       uint8_t data    = 0;
+      // reading GPIOB (column port) since in mcp23018's sequential mode
+      // it is addressed directly after writing to GPIOA in select_row()
       mcp23018_status = i2c_start(I2C_ADDR_READ, ERGODOX_EZ_I2C_TIMEOUT);
       if (mcp23018_status) goto out;
       mcp23018_status = i2c_read_nack(ERGODOX_EZ_I2C_TIMEOUT);


### PR DESCRIPTION
## Description

Since the IO expander is sequential mode (IOCON.SEQOP = 0),  the address pointer is set to GPIOB (columns to be read) register after the row selection write operation on GPIOA so this write-restart to set address to GPIOB is unnecessary.

I also looked into special byte mode (IOCON.SEQOP = 1, IOCON.BANK = 0) that should cause the address pointer to toggle between GPIOA and GPIOB, but it doesn't look like you should write without sending the register address from the MCP23018 datasheet Figure 1-1 so  there were no other savings.

This improves scan rate from 590 to 790.

@seebs 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).