### PR TITLE
Phoebe/Maxr1998 keymap: enable space cadet with curly braces

### DIFF
--- a/keyboards/maxr1998/phoebe/keymaps/default/config.h
+++ b/keyboards/maxr1998/phoebe/keymaps/default/config.h
@@ -1,4 +1,3 @@
 #pragma once
 
-#define LSPO_KEYS KC_LSFT, KC_RALT, KC_7
-#define RSPC_KEYS KC_RSFT, KC_RALT, KC_0
+#define RSPC_KEYS KC_RSFT, KC_RALT, KC_7

--- a/keyboards/maxr1998/phoebe/keymaps/default/config.h
+++ b/keyboards/maxr1998/phoebe/keymaps/default/config.h
@@ -1,0 +1,4 @@
+#pragma once
+
+#define LSPO_KEYS KC_LSFT, KC_RALT, KC_7
+#define RSPC_KEYS KC_RSFT, KC_RALT, KC_0

--- a/keyboards/maxr1998/phoebe/keymaps/default/keymap.c
+++ b/keyboards/maxr1998/phoebe/keymaps/default/keymap.c
@@ -33,7 +33,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   KC_ESC,  DE_1,    DE_2,    DE_3,    DE_4,    DE_5,    DE_6,    DE_7,    DE_8,    DE_9,    DE_0,    DE_QST,
   KC_GRV,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_BSPC,
   KC_TAB,  KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    DE_PLUS, KC_ENT,
-  KC_LSPO, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_UP,   KC_RSPC,
+  KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_UP,   KC_RSPC,
   KC_LCTL, KC_LGUI, KC_LALT, KC_LALT, KC_SC,       KC_SPC,       KC_ALGR, KC_FN,   KC_LEFT, KC_DOWN, KC_RGHT
 ),
 

--- a/keyboards/maxr1998/phoebe/keymaps/default/keymap.c
+++ b/keyboards/maxr1998/phoebe/keymaps/default/keymap.c
@@ -33,7 +33,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   KC_ESC,  DE_1,    DE_2,    DE_3,    DE_4,    DE_5,    DE_6,    DE_7,    DE_8,    DE_9,    DE_0,    DE_QST,
   KC_GRV,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_BSPC,
   KC_TAB,  KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    DE_PLUS, KC_ENT,
-  KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_UP,   KC_RSFT,
+  KC_LSPO, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_UP,   KC_RSPC,
   KC_LCTL, KC_LGUI, KC_LALT, KC_LALT, KC_SC,       KC_SPC,       KC_ALGR, KC_FN,   KC_LEFT, KC_DOWN, KC_RGHT
 ),
 


### PR DESCRIPTION
## Description
As stated in the title ;)
I wondered, could I also just put the defines directly into the `keymap.c`?

## Types of Changes
- [X] Keymap/layout/~~userspace~~ (~~addition or~~ update)