### PR TITLE
Compile error if ONESHOT_TIMEOUT defined but oneshot disabled

### DIFF
--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -90,6 +90,7 @@ void action_exec(keyevent_t event) {
 
     keyrecord_t record = {.event = event};
 
+#ifndef NO_ACTION_ONESHOT
 #if (defined(ONESHOT_TIMEOUT) && (ONESHOT_TIMEOUT > 0))
     if (has_oneshot_layer_timed_out()) {
         clear_oneshot_layer_state(ONESHOT_OTHER_KEY_PRESSED);
@@ -97,6 +98,7 @@ void action_exec(keyevent_t event) {
     if (has_oneshot_mods_timed_out()) {
         clear_oneshot_mods();
     }
+#endif
 #endif
 
 #ifndef NO_ACTION_TAPPING

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -91,14 +91,14 @@ void action_exec(keyevent_t event) {
     keyrecord_t record = {.event = event};
 
 #ifndef NO_ACTION_ONESHOT
-#if (defined(ONESHOT_TIMEOUT) && (ONESHOT_TIMEOUT > 0))
+#    if (defined(ONESHOT_TIMEOUT) && (ONESHOT_TIMEOUT > 0))
     if (has_oneshot_layer_timed_out()) {
         clear_oneshot_layer_state(ONESHOT_OTHER_KEY_PRESSED);
     }
     if (has_oneshot_mods_timed_out()) {
         clear_oneshot_mods();
     }
-#endif
+#    endif
 #endif
 
 #ifndef NO_ACTION_TAPPING


### PR DESCRIPTION
## Description

When ONESHOT_TIMEOUT and NO_ACTION_ONESHOT are both defined, this code
fails to compile.

Wrap the one usage of ONESHOT_TIMEOUT that is inconsistent with the
rest so all usages are properly wrapped by a check of NO_ACTION_ONESHOT.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
