### PR TITLE
Use function for KEYCODE2 routines instead of macro.

### DIFF
--- a/tmk_core/common/report.h
+++ b/tmk_core/common/report.h
@@ -167,9 +167,6 @@ typedef struct {
 } __attribute__((packed)) report_mouse_t;
 
 /* keycode to system usage */
-#ifndef USE_KEYCODE2_FUNCTION
-#define KEYCODE2SYSTEM(key) (key == KC_SYSTEM_POWER ? SYSTEM_POWER_DOWN : (key == KC_SYSTEM_SLEEP ? SYSTEM_SLEEP : (key == KC_SYSTEM_WAKE ? SYSTEM_WAKE_UP : 0)))
-#else
 static inline uint16_t KEYCODE2SYSTEM(uint8_t key) {
     switch (key) {
         case KC_SYSTEM_POWER:  return SYSTEM_POWER_DOWN;
@@ -178,13 +175,8 @@ static inline uint16_t KEYCODE2SYSTEM(uint8_t key) {
         default:               return 0;
     }
 }
-#endif
 
 /* keycode to consumer usage */
-#ifndef USE_KEYCODE2_FUNCTION
-#define KEYCODE2CONSUMER(key) \
-    (key == KC_AUDIO_MUTE ? AUDIO_MUTE : (key == KC_AUDIO_VOL_UP ? AUDIO_VOL_UP : (key == KC_AUDIO_VOL_DOWN ? AUDIO_VOL_DOWN : (key == KC_MEDIA_NEXT_TRACK ? TRANSPORT_NEXT_TRACK : (key == KC_MEDIA_PREV_TRACK ? TRANSPORT_PREV_TRACK : (key == KC_MEDIA_FAST_FORWARD ? TRANSPORT_FAST_FORWARD : (key == KC_MEDIA_REWIND ? TRANSPORT_REWIND : (key == KC_MEDIA_STOP ? TRANSPORT_STOP : (key == KC_MEDIA_EJECT ? TRANSPORT_STOP_EJECT : (key == KC_MEDIA_PLAY_PAUSE ? TRANSPORT_PLAY_PAUSE : (key == KC_MEDIA_SELECT ? AL_CC_CONFIG : (key == KC_MAIL ? AL_EMAIL : (key == KC_CALCULATOR ? AL_CALCULATOR : (key == KC_MY_COMPUTER ? AL_LOCAL_BROWSER : (key == KC_WWW_SEARCH ? AC_SEARCH : (key == KC_WWW_HOME ? AC_HOME : (key == KC_WWW_BACK ? AC_BACK : (key == KC_WWW_FORWARD ? AC_FORWARD : (key == KC_WWW_STOP ? AC_STOP : (key == KC_WWW_REFRESH ? AC_REFRESH : (key == KC_BRIGHTNESS_UP ? BRIGHTNESS_UP : (key == KC_BRIGHTNESS_DOWN ? BRIGHTNESS_DOWN : (key == KC_WWW_FAVORITES ? AC_BOOKMARKS : 0)))))))))))))))))))))))
-#else
 static inline uint16_t KEYCODE2CONSUMER(uint8_t key) {
     switch (key) {
         case KC_AUDIO_MUTE:            return AUDIO_MUTE;
@@ -213,7 +205,6 @@ static inline uint16_t KEYCODE2CONSUMER(uint8_t key) {
         default:                       return 0;
     }
 }
-#endif
 
 uint8_t has_anykey(report_keyboard_t* keyboard_report);
 uint8_t get_first_key(report_keyboard_t* keyboard_report);

--- a/tmk_core/common/report.h
+++ b/tmk_core/common/report.h
@@ -169,40 +169,68 @@ typedef struct {
 /* keycode to system usage */
 static inline uint16_t KEYCODE2SYSTEM(uint8_t key) {
     switch (key) {
-        case KC_SYSTEM_POWER:  return SYSTEM_POWER_DOWN;
-        case KC_SYSTEM_SLEEP:  return SYSTEM_SLEEP;
-        case KC_SYSTEM_WAKE:   return SYSTEM_WAKE_UP;
-        default:               return 0;
+        case KC_SYSTEM_POWER:
+            return SYSTEM_POWER_DOWN;
+        case KC_SYSTEM_SLEEP:
+            return SYSTEM_SLEEP;
+        case KC_SYSTEM_WAKE:
+            return SYSTEM_WAKE_UP;
+        default:
+            return 0;
     }
 }
 
 /* keycode to consumer usage */
 static inline uint16_t KEYCODE2CONSUMER(uint8_t key) {
     switch (key) {
-        case KC_AUDIO_MUTE:            return AUDIO_MUTE;
-        case KC_AUDIO_VOL_UP:          return AUDIO_VOL_UP;
-        case KC_AUDIO_VOL_DOWN:        return AUDIO_VOL_DOWN;
-        case KC_MEDIA_NEXT_TRACK:      return TRANSPORT_NEXT_TRACK;
-        case KC_MEDIA_PREV_TRACK:      return TRANSPORT_PREV_TRACK;
-        case KC_MEDIA_FAST_FORWARD:    return TRANSPORT_FAST_FORWARD;
-        case KC_MEDIA_REWIND:          return TRANSPORT_REWIND;
-        case KC_MEDIA_STOP:            return TRANSPORT_STOP;
-        case KC_MEDIA_EJECT:           return TRANSPORT_STOP_EJECT;
-        case KC_MEDIA_PLAY_PAUSE:      return TRANSPORT_PLAY_PAUSE;
-        case KC_MEDIA_SELECT:          return AL_CC_CONFIG;
-        case KC_MAIL:                  return AL_EMAIL;
-        case KC_CALCULATOR:            return AL_CALCULATOR;
-        case KC_MY_COMPUTER:           return AL_LOCAL_BROWSER;
-        case KC_WWW_SEARCH:            return AC_SEARCH;
-        case KC_WWW_HOME:              return AC_HOME;
-        case KC_WWW_BACK:              return AC_BACK;
-        case KC_WWW_FORWARD:           return AC_FORWARD;
-        case KC_WWW_STOP:              return AC_STOP;
-        case KC_WWW_REFRESH:           return AC_REFRESH;
-        case KC_BRIGHTNESS_UP:         return BRIGHTNESS_UP;
-        case KC_BRIGHTNESS_DOWN:       return BRIGHTNESS_DOWN;
-        case KC_WWW_FAVORITES:         return AC_BOOKMARKS;
-        default:                       return 0;
+        case KC_AUDIO_MUTE:
+            return AUDIO_MUTE;
+        case KC_AUDIO_VOL_UP:
+            return AUDIO_VOL_UP;
+        case KC_AUDIO_VOL_DOWN:
+            return AUDIO_VOL_DOWN;
+        case KC_MEDIA_NEXT_TRACK:
+            return TRANSPORT_NEXT_TRACK;
+        case KC_MEDIA_PREV_TRACK:
+            return TRANSPORT_PREV_TRACK;
+        case KC_MEDIA_FAST_FORWARD:
+            return TRANSPORT_FAST_FORWARD;
+        case KC_MEDIA_REWIND:
+            return TRANSPORT_REWIND;
+        case KC_MEDIA_STOP:
+            return TRANSPORT_STOP;
+        case KC_MEDIA_EJECT:
+            return TRANSPORT_STOP_EJECT;
+        case KC_MEDIA_PLAY_PAUSE:
+            return TRANSPORT_PLAY_PAUSE;
+        case KC_MEDIA_SELECT:
+            return AL_CC_CONFIG;
+        case KC_MAIL:
+            return AL_EMAIL;
+        case KC_CALCULATOR:
+            return AL_CALCULATOR;
+        case KC_MY_COMPUTER:
+            return AL_LOCAL_BROWSER;
+        case KC_WWW_SEARCH:
+            return AC_SEARCH;
+        case KC_WWW_HOME:
+            return AC_HOME;
+        case KC_WWW_BACK:
+            return AC_BACK;
+        case KC_WWW_FORWARD:
+            return AC_FORWARD;
+        case KC_WWW_STOP:
+            return AC_STOP;
+        case KC_WWW_REFRESH:
+            return AC_REFRESH;
+        case KC_BRIGHTNESS_UP:
+            return BRIGHTNESS_UP;
+        case KC_BRIGHTNESS_DOWN:
+            return BRIGHTNESS_DOWN;
+        case KC_WWW_FAVORITES:
+            return AC_BOOKMARKS;
+        default:
+            return 0;
     }
 }
 

--- a/tmk_core/common/report.h
+++ b/tmk_core/common/report.h
@@ -167,11 +167,53 @@ typedef struct {
 } __attribute__((packed)) report_mouse_t;
 
 /* keycode to system usage */
+#ifndef USE_KEYCODE2_FUNCTION
 #define KEYCODE2SYSTEM(key) (key == KC_SYSTEM_POWER ? SYSTEM_POWER_DOWN : (key == KC_SYSTEM_SLEEP ? SYSTEM_SLEEP : (key == KC_SYSTEM_WAKE ? SYSTEM_WAKE_UP : 0)))
+#else
+static inline uint16_t KEYCODE2SYSTEM(uint8_t key) {
+    switch (key) {
+        case KC_SYSTEM_POWER:  return SYSTEM_POWER_DOWN;
+        case KC_SYSTEM_SLEEP:  return SYSTEM_SLEEP;
+        case KC_SYSTEM_WAKE:   return SYSTEM_WAKE_UP;
+        default:               return 0;
+    }
+}
+#endif
 
 /* keycode to consumer usage */
+#ifndef USE_KEYCODE2_FUNCTION
 #define KEYCODE2CONSUMER(key) \
     (key == KC_AUDIO_MUTE ? AUDIO_MUTE : (key == KC_AUDIO_VOL_UP ? AUDIO_VOL_UP : (key == KC_AUDIO_VOL_DOWN ? AUDIO_VOL_DOWN : (key == KC_MEDIA_NEXT_TRACK ? TRANSPORT_NEXT_TRACK : (key == KC_MEDIA_PREV_TRACK ? TRANSPORT_PREV_TRACK : (key == KC_MEDIA_FAST_FORWARD ? TRANSPORT_FAST_FORWARD : (key == KC_MEDIA_REWIND ? TRANSPORT_REWIND : (key == KC_MEDIA_STOP ? TRANSPORT_STOP : (key == KC_MEDIA_EJECT ? TRANSPORT_STOP_EJECT : (key == KC_MEDIA_PLAY_PAUSE ? TRANSPORT_PLAY_PAUSE : (key == KC_MEDIA_SELECT ? AL_CC_CONFIG : (key == KC_MAIL ? AL_EMAIL : (key == KC_CALCULATOR ? AL_CALCULATOR : (key == KC_MY_COMPUTER ? AL_LOCAL_BROWSER : (key == KC_WWW_SEARCH ? AC_SEARCH : (key == KC_WWW_HOME ? AC_HOME : (key == KC_WWW_BACK ? AC_BACK : (key == KC_WWW_FORWARD ? AC_FORWARD : (key == KC_WWW_STOP ? AC_STOP : (key == KC_WWW_REFRESH ? AC_REFRESH : (key == KC_BRIGHTNESS_UP ? BRIGHTNESS_UP : (key == KC_BRIGHTNESS_DOWN ? BRIGHTNESS_DOWN : (key == KC_WWW_FAVORITES ? AC_BOOKMARKS : 0)))))))))))))))))))))))
+#else
+static inline uint16_t KEYCODE2CONSUMER(uint8_t key) {
+    switch (key) {
+        case KC_AUDIO_MUTE:            return AUDIO_MUTE;
+        case KC_AUDIO_VOL_UP:          return AUDIO_VOL_UP;
+        case KC_AUDIO_VOL_DOWN:        return AUDIO_VOL_DOWN;
+        case KC_MEDIA_NEXT_TRACK:      return TRANSPORT_NEXT_TRACK;
+        case KC_MEDIA_PREV_TRACK:      return TRANSPORT_PREV_TRACK;
+        case KC_MEDIA_FAST_FORWARD:    return TRANSPORT_FAST_FORWARD;
+        case KC_MEDIA_REWIND:          return TRANSPORT_REWIND;
+        case KC_MEDIA_STOP:            return TRANSPORT_STOP;
+        case KC_MEDIA_EJECT:           return TRANSPORT_STOP_EJECT;
+        case KC_MEDIA_PLAY_PAUSE:      return TRANSPORT_PLAY_PAUSE;
+        case KC_MEDIA_SELECT:          return AL_CC_CONFIG;
+        case KC_MAIL:                  return AL_EMAIL;
+        case KC_CALCULATOR:            return AL_CALCULATOR;
+        case KC_MY_COMPUTER:           return AL_LOCAL_BROWSER;
+        case KC_WWW_SEARCH:            return AC_SEARCH;
+        case KC_WWW_HOME:              return AC_HOME;
+        case KC_WWW_BACK:              return AC_BACK;
+        case KC_WWW_FORWARD:           return AC_FORWARD;
+        case KC_WWW_STOP:              return AC_STOP;
+        case KC_WWW_REFRESH:           return AC_REFRESH;
+        case KC_BRIGHTNESS_UP:         return BRIGHTNESS_UP;
+        case KC_BRIGHTNESS_DOWN:       return BRIGHTNESS_DOWN;
+        case KC_WWW_FAVORITES:         return AC_BOOKMARKS;
+        default:                       return 0;
+    }
+}
+#endif
 
 uint8_t has_anykey(report_keyboard_t* keyboard_report);
 uint8_t get_first_key(report_keyboard_t* keyboard_report);


### PR DESCRIPTION
## Description

Convert the KEYCODE2SYSTEM and KEYCODE2CONSUMER macros to functions,
defaulting to using the macros.  The function form allows the compiler
to optimize the switch statement itself, over the macro nested
ternaries.

~~To enable this feature, #define USE_KEYCODE2_FUNCTION.~~

Testing against a random selection of avr-based keyboards, this
increased available flash by ~500 bytes. For arm-based keyboards,
the available flash increased by ~400 bytes.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
