### PR TITLE
Ergosaurus Configurator support bugfix

### DIFF
--- a/keyboards/ergosaurus/info.json
+++ b/keyboards/ergosaurus/info.json
@@ -4,7 +4,7 @@
     "width": 19.75,
     "height": 5.25,
     "layouts": {
-        "LAYOUT_default": {
+        "LAYOUT": {
             "layout": [
                 {"label":"`", "x":0.5, "y":0},
                 {"label":"Esc", "x":1.75, "y":0.25},


### PR DESCRIPTION
## Description

Corrected the layout macro name in `info.json`.

@cfbender kindly opened a PR to add a default keymap for this board in QMK Configurator, and when I went to check it I discovered the layout rendering wasn't working. Cause was the `info.json` file referencing a layout macro that doesn't exist.


## Types of Changes

- [x] Enhancement/optimization
- [x] Keyboard (addition or update)

## Issues Fixed or Closed by This PR

![image](https://user-images.githubusercontent.com/18669334/73920374-1f815100-487a-11ea-864d-3bd669bfea67.png)


## Checklist

- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
