### PR TITLE
Support for custom keys/custom shifted keys in Autoshift

### DIFF
--- a/docs/feature_auto_shift.md
+++ b/docs/feature_auto_shift.md
@@ -103,6 +103,41 @@ Do not Auto Shift numeric keys, zero through nine.
 
 Do not Auto Shift alpha characters, which include A through Z.
 
+### Custom Keys and Shifted Keycodes
+Often, with small keyboards (on which Auto Shift is most common), it is convenient to rearrange the shifted values of symbols due to many not being on the base layer. This lead to the creation of `autoshift_custom_shifts`. It is called when any key is pressed, and used to determine whether a key is included in Auto Shift and/or its shifted value.
+
+Here is an example `keymap.c`:
+
+```c
+int16_t autoshift_custom_shifts(uint16_t keycode, keyrecord_t *record) {
+  switch(keycode) {
+    case KC_TAB:
+    case KC_ENT:
+    case KC_QUOT:
+      return -1; // adds the key to Auto Shift with its default shifted action
+    case KC_COMM:
+      return KC_QUES; // send ? when , is held
+    case KC_DOT:
+      return KC_EXLM;
+    case KC_SLSH:
+      return KC_BSLASH;
+    case KC_AMPR:
+      return KC_PIPE;
+    case KC_LPRN:
+      return KC_LBRC;
+    case KC_RPRN:
+      return KC_RBRC;
+    case KC_A:
+      // note you can override the actions of already enabled keys, and KC_NO is supported
+      // which allows you to make keys do nothing when held for longer than the timeout
+      return KC_NO;
+  }
+  return -2; // default - not an Auto Shift key
+}
+```
+
+Returning `-2` indicates that the key press we just processed should continue to be processed as normal (not be included in Auto Shift). `-1` is used to add individual keys to Auto Shift, if there is not a relevant `#define` (or not everything from it is desired, such as `KC_TAB` in the above example). Returning anything else will make that the shifted value for the processed key.
+
 ## Using Auto Shift Setup
 
 This will enable you to define three keys temporarily to increase, decrease and report your `AUTO_SHIFT_TIMEOUT`.

--- a/quantum/process_keycode/process_auto_shift.c
+++ b/quantum/process_keycode/process_auto_shift.c
@@ -20,11 +20,11 @@
 
 #    include "process_auto_shift.h"
 
-static bool autoshift_enabled = true;
-static uint16_t autoshift_time = 0;
-static uint16_t autoshift_timeout = AUTO_SHIFT_TIMEOUT;
-static int16_t autoshift_lastkey = -1; // -1 is what KC_NO was before - 'not currently autoshifting'.
-static int16_t autoshift_lastkey_shifted = -2; // set in the top of process_auto_shift.
+static bool     autoshift_enabled         = true;
+static uint16_t autoshift_time            = 0;
+static uint16_t autoshift_timeout         = AUTO_SHIFT_TIMEOUT;
+static int16_t  autoshift_lastkey         = -1;  // -1 is what KC_NO was before - 'not currently autoshifting'.
+static int16_t  autoshift_lastkey_shifted = -2;  // set in the top of process_auto_shift.
 // process_custom_shifts return values:
 // -2 - not a custom autoshift key
 // -1 - custom key, use default shifted value
@@ -42,13 +42,15 @@ void autoshift_timer_report(void) {
 }
 
 bool autoshift_on(uint16_t keycode) {
-    if (!autoshift_enabled) { return true; }
+    if (!autoshift_enabled) {
+        return true;
+    }
 #    ifndef AUTO_SHIFT_MODIFIERS
     if (get_mods()) {
         return true;
     }
 #    endif
-    autoshift_time = timer_read();
+    autoshift_time    = timer_read();
     autoshift_lastkey = keycode;
 
     // We need some extra handling here for OSL edge cases
@@ -68,7 +70,7 @@ void autoshift_flush(void) {
             tap_code16(autoshift_lastkey);
         }
 
-        autoshift_time = 0;
+        autoshift_time    = 0;
         autoshift_lastkey = -1;
         // no need to reset shifted
     }

--- a/quantum/process_keycode/process_auto_shift.c
+++ b/quantum/process_keycode/process_auto_shift.c
@@ -21,7 +21,7 @@
 #    include "process_auto_shift.h"
 
 static bool autoshift_enabled = true;
-static uint16_t autoshift_time    = 0;
+static uint16_t autoshift_time = 0;
 static uint16_t autoshift_timeout = AUTO_SHIFT_TIMEOUT;
 static int16_t autoshift_lastkey = -1; // -1 is what KC_NO was before - 'not currently autoshifting'.
 static int16_t autoshift_lastkey_shifted = -2; // set in the top of process_auto_shift.
@@ -66,7 +66,7 @@ void autoshift_flush(void) {
             tap_code16((autoshift_lastkey_shifted == -1) ? LSFT(autoshift_lastkey) : autoshift_lastkey_shifted);
         }
         else {
-            tap_code(autoshift_lastkey);
+            tap_code16(autoshift_lastkey);
         }
 
         autoshift_time = 0;

--- a/quantum/process_keycode/process_auto_shift.c
+++ b/quantum/process_keycode/process_auto_shift.c
@@ -30,7 +30,6 @@ static int16_t autoshift_lastkey_shifted = -2; // set in the top of process_auto
 // -1 - custom key, use default shifted value
 // 0 = KC_NO, allowing for keys to not have an action when held.
 // other - the code to send when timeout exceeded.
-uint8_t permissive_mods;
 
 __attribute__((weak)) int16_t autoshift_custom_shifts(uint16_t keycode, keyrecord_t *record) { return -2; }
 
@@ -63,19 +62,11 @@ void autoshift_flush(void) {
     if (autoshift_lastkey != -1) {
         uint16_t elapsed = timer_elapsed(autoshift_time);
 
-#    ifdef PERMISSIVE_HOLD
-        uint8_t old_weak_mods = get_weak_mods();
-        set_weak_mods(permissive_mods);
-#    endif
         if (elapsed > autoshift_timeout) {
             tap_code16((autoshift_lastkey_shifted == -1) ? LSFT(autoshift_lastkey) : autoshift_lastkey_shifted);
-        }
-        else {
+        } else {
             tap_code16(autoshift_lastkey);
         }
-#    ifdef PERMISSIVE_HOLD
-        set_weak_mods(old_weak_mods);
-#    endif
 
         autoshift_time = 0;
         autoshift_lastkey = -1;
@@ -107,14 +98,10 @@ void set_autoshift_timeout(uint16_t timeout) { autoshift_timeout = timeout; }
 bool process_auto_shift(uint16_t keycode, keyrecord_t *record) {
     autoshift_flush();
     if (record->event.pressed) {
-#    ifdef PERMISSIVE_HOLD
-        permissive_mods = get_weak_mods() | get_mods();
-#    endif
         autoshift_lastkey_shifted = autoshift_custom_shifts(keycode, record);
         if (autoshift_lastkey_shifted > -2) {
             return autoshift_on(keycode);
-        }
-        else {
+        } else {
             autoshift_lastkey_shifted = LSFT(keycode);
         }
         switch (keycode) {


### PR DESCRIPTION
Allows keys to be added to AS without editing process_auto_shift.c
Custom keys can be set for when any key is held longer than the timout
Custom keys can override the action of a key already enabled in autoshift via #define or default (eg. one letter)
Support for KC_NO; one can make a key have no action when held
~~Permissive Hold-like behavior (see ced1019's commit message) for when accidentally releasing modifier before Auto Shift key.~~ Removed, actually the opposite of `IGNORE_MOD_TAP_INTERRUPT` which is by default 'enabled' (in behavior) for Auto Shift because modifiers are evaluated on release, not press. Breaking change and will be put in another pull once I work out the kinks and this is merged.

## Description

I've made a function definable in one's keymap to add and/or set shifted values of keys. The return value of the function, if it is a key, will be the shifted value. If it is -1, the key will have its default shifted value, but be added to AS. -2 is the default, and changes nothing.
This shouldn't be a breaking change, but it is a rather large refactor. One of the main things I'm not sure about is the return values. . . as I wanted support for KC_NO as a shifted key (and needed two extra return values anyway, default shifted value and not autoshifted), I just went with negative numbers as they seemed easiest for the user to type and couldn't cause conflicts.
Also, there's no way to remove a key from autoshift. Not a big deal, but if you want all but one letter enabled you'll need a case for KC_A ... KC_J and KC_L ... KC_Z and to disable AS_ALPHA. Would be nice to fix.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. ~~Planning on doing it tomorrow.~~ Done.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

Example custom function:
```
int16_t autoshift_custom_shifts(uint16_t keycode, keyrecord_t *record) {
  switch(keycode) {
    case KC_TAB:
    case KC_ENT:
    case KC_QUOT:
      return -1; // adds the key to Auto Shift with its default shifted action
    case KC_COMM:
      return KC_QUES; // send ? when , is held
    case KC_DOT:
      return KC_EXLM;
    case KC_SLSH:
      return KC_BSLASH;
    case KC_AMPR:
      return KC_PIPE;
    case KC_LPRN:
      return KC_LBRC;
    case KC_RPRN:
      return KC_RBRC;
    case KC_A:
      // note you can override the actions of already enabled keys, and KC_NO is supported
      // which allows you to make keys do nothing when held for longer than the timeout
      return KC_NO;
  }
  return -2; // default - not an Auto Shift key
}
```