### PR TITLE
[Keyboard] Use DIRECT_PINS instead of empty MATRIX_ROW_PINS: sixshooter

### DIFF
--- a/keyboards/bpiphany/sixshooter/config.h
+++ b/keyboards/bpiphany/sixshooter/config.h
@@ -11,11 +11,14 @@
 #define DESCRIPTION     A PCB for the CM Storm switch tester utilizing a Teensy 2.0.
 
 /* key matrix size */
-#define MATRIX_ROWS 1
-#define MATRIX_COLS 6
+#define MATRIX_ROWS 2
+#define MATRIX_COLS 3
 
 /* Keyboard Matrix Assignments */
-#define DIRECT_PINS { { F7, F6, F1, F5, F4, F0 } }
+#define DIRECT_PINS { \
+    { F7, F6, F1 }, \
+    { F5, F4, F0 } \
+}
 #define UNUSED_PINS
 
 /* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */

--- a/keyboards/bpiphany/sixshooter/config.h
+++ b/keyboards/bpiphany/sixshooter/config.h
@@ -14,22 +14,9 @@
 #define MATRIX_ROWS 1
 #define MATRIX_COLS 6
 
-/*
- * Keyboard Matrix Assignments
- *
- * Change this to how you wired your keyboard
- * COLS: AVR pins used for columns, left to right
- * ROWS: AVR pins used for rows, top to bottom
- * DIODE_DIRECTION: COL2ROW = COL = Anode (+), ROW = Cathode (-, marked on diode)
- *                  ROW2COL = ROW = Anode (+), COL = Cathode (-, marked on diode)
- *
-*/
-#define MATRIX_ROW_PINS {  }
-#define MATRIX_COL_PINS { F7, F6, F1, F5, F4, F0 }
+/* Keyboard Matrix Assignments */
+#define DIRECT_PINS { { F7, F6, F1, F5, F4, F0 } }
 #define UNUSED_PINS
-
-/* COL2ROW, ROW2COL*/
-#define DIODE_DIRECTION COL2ROW
 
 /* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
 #define DEBOUNCE 5

--- a/keyboards/bpiphany/sixshooter/sixshooter.h
+++ b/keyboards/bpiphany/sixshooter/sixshooter.h
@@ -4,10 +4,12 @@
 #include "quantum.h"
 
 #define LAYOUT( \
-	K00, K01, K02, \
-	K03, K04, K05 \
-) { \
-	{ K00, K01, K02, K03, K04, K05 }, \
+    K00, K01, K02, \
+    K03, K04, K05 \
+) \
+{ \
+    { K00, K01, K02 }, \
+    { K03, K04, K05 } \
 }
 
 inline void sixshooter_led_0_on(void)    { DDRB |=  (1<<6); PORTB |=  (1<<6); }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

In the config.h of sixshooter, it has been defined as following.
#define MATRIX_ROWS 1
#define MATRIX_ROW_PINS {  }
This is a potential bug because by definition row_pins will get assigned undefined value.

In this case use of DIRECT_PINS is appropriate. 

Similar to https://github.com/qmk/qmk_firmware/pull/8115, I need this consistency for my next PR.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
