### PR TITLE
Define backlight pin for Quefrency Rev2

### DIFF
--- a/keyboards/keebio/quefrency/rev2/config.h
+++ b/keyboards/keebio/quefrency/rev2/config.h
@@ -46,6 +46,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* Set 0 if debouncing isn't needed */
 #define DEBOUNCE 5
 
+#define BACKLIGHT_PIN B5
+
 /* serial.c configuration for split keyboard */
 #define SOFT_SERIAL_PIN D0
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Per @nooges' comment in #8041. I would have also added `led_update_kb()` for B6 as the caps lock LED, but that pin seems to already be included in `MATRIX_ROW_PINS_RIGHT`, and I'm not quite sure whether we should be checking which half we're on (or if the split code even understands what to do with lock LEDs).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
