### PR TITLE
Tweak my TAPPING_TERM and be more futureproof

### DIFF
--- a/keyboards/crkbd/keymaps/bcat/config.h
+++ b/keyboards/crkbd/keymaps/bcat/config.h
@@ -3,4 +3,5 @@
 #define EE_HANDS
 
 /* Limit max RGB LED current to avoid tripping controller fuse. */
+#undef RGB_MATRIX_MAXIMUM_BRIGHTNESS
 #define RGB_MATRIX_MAXIMUM_BRIGHTNESS 150

--- a/keyboards/keebio/quefrency/keymaps/bcat/config.h
+++ b/keyboards/keebio/quefrency/keymaps/bcat/config.h
@@ -13,4 +13,5 @@
 #define RGBLED_NUM 17
 
 /* Set up RGB lighting so it works with either side as master. */
+#undef RGBLED_SPLIT
 #define RGBLED_SPLIT { 8, 9 }

--- a/users/bcat/config.h
+++ b/users/bcat/config.h
@@ -3,10 +3,13 @@
 
 #define TAP_CODE_DELAY 20
 
-/* Extend default tap timeout because I'm too slow. :) */
+/*
+ * Force the default tapping term since some keyboards make it way too short
+ * (*cough*Lily58*cough*).
+ */
 #undef TAPPING_TERM
 
-#define TAPPING_TERM 250
+#define TAPPING_TERM 200
 
 /*
  * Treat mod-tap keys as holds even if the mod-tap key and the key being


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I'm reducing my `TAPPING_TERM` back to the default (200 ms) to try and combat spurious Esc keypresses on an Esc (tap)/Ctrl (hold) key. It turns out my real issue before was the Lily58 keyboard sets it to _super short_ (100 ms) by default. :) I'm also explicitly `#undef`ing some symbols I redefine in keymap configs so I don't cause problems if the keyboards start defining those things in the future (e.g., #7754).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [X] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
