### PR TITLE
Rename Polaris Tsangan layout to 60_tsangan_hhkb and enable community layout support

### DIFF
--- a/keyboards/ai03/polaris/info.json
+++ b/keyboards/ai03/polaris/info.json
@@ -75,7 +75,7 @@
                 {"label":"Ctrl", "x":13.75, "y":4, "w":1.25}
             ]
         },
-        "LAYOUT_60_ansi_tsangan_split_rshift": {
+        "LAYOUT_60_tsangan_hhkb": {
             "layout": [
                 {"label":"~", "x":0, "y":0},
                 {"label":"!", "x":1, "y":0},

--- a/keyboards/ai03/polaris/keymaps/default_ansi_tsangan/keymap.c
+++ b/keyboards/ai03/polaris/keymaps/default_ansi_tsangan/keymap.c
@@ -21,14 +21,14 @@ enum layer_names {
 };
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-  [_BASE] = LAYOUT_60_ansi_tsangan_split_rshift( /* Base */
+  [_BASE] = LAYOUT_60_tsangan_hhkb( /* Base */
     KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_DEL,
     KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC,          KC_BSLS,
     MO(1),   KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,                   KC_ENT,
     KC_LSFT,          KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH,          KC_RSFT, KC_DEL,
     KC_LCTL, KC_LGUI, KC_LALT,                                     KC_SPC,                                      KC_RALT, KC_RGUI, KC_RCTL
   ),
-  [_FN] = LAYOUT_60_ansi_tsangan_split_rshift( /* FN */
+  [_FN] = LAYOUT_60_tsangan_hhkb( /* FN */
     RESET,   KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_DEL,  KC_BSPC,
     _______, _______, KC_PGUP, _______, _______, _______, _______, _______, KC_UP,   _______, KC_MPRV, KC_MPLY, KC_MNXT,          BL_STEP,
     _______, KC_HOME, KC_PGDN, KC_END,  _______, KC_VOLD, KC_VOLU, KC_LEFT, KC_DOWN, KC_RGHT, _______, _______,                   _______,

--- a/keyboards/ai03/polaris/polaris.h
+++ b/keyboards/ai03/polaris/polaris.h
@@ -40,7 +40,7 @@
 	{ K400,  K401,  K402,  KC_NO, K404,  KC_NO, K406,  KC_NO, K408,  KC_NO, K410,  K411,  K412,  K413 }  \
 }
 
-#define LAYOUT_60_ansi_tsangan_split_rshift( \
+#define LAYOUT_60_tsangan_hhkb( \
 	K000, K001, K002, K003, K004, K005, K006, K007, K008, K009, K010, K011, K012, K013, K212, \
 	K100, K101, K102, K103, K104, K105, K106, K107, K108, K109, K110, K111, K112,       K113, \
 	K200, K201, K202, K203, K204, K205, K206, K207, K208, K209, K210, K211,             K213, \

--- a/keyboards/ai03/polaris/rules.mk
+++ b/keyboards/ai03/polaris/rules.mk
@@ -30,3 +30,5 @@ BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
 AUDIO_ENABLE = no           # Audio output on port C6
 FAUXCLICKY_ENABLE = no      # Use buzzer to emulate clicky switches
 HD44780_ENABLE = no         # Enable support for HD44780 based LCDs
+
+LAYOUTS = 60_tsangan_hhkb


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The Polaris PCB has a Tsangan layout macro that matches the existing [`60_tsangan_hhkb`](https://github.com/qmk/qmk_firmware/tree/master/layouts/default/60_tsangan_hhkb) layout. I'm just renaming the layout macro to use that name so existing community layouts work. AFAIK these boards haven't shipped to anyone yet, so I don't think this is a breaking change since there is no hardware in the wild to break.

I ran `make ai03/polaris` and everything seems happy, except that yanfali's community layout firmware is too big (unrelated to this change).

@ai03-2725, are you okay with this change?

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [X] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

None.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
