### PR TITLE
use replace() over rename() to have cross-platform overwriting

### DIFF
--- a/lib/python/milc.py
+++ b/lib/python/milc.py
@@ -571,7 +571,7 @@ class MILC(object):
 
         # Move the new config file into place atomically
         if os.path.getsize(tmpfile.name) > 0:
-            os.rename(tmpfile.name, str(self.config_file))
+            os.replace(tmpfile.name, str(self.config_file))
         else:
             self.log.warning('Config file saving failed, not replacing %s with %s.', str(self.config_file), tmpfile.name)
 


### PR DESCRIPTION
## Description

`os.rename()` doesn't support cross-platform overwriting of files (windows, yay) `os.replace()` does

https://docs.python.org/3.5/library/os.html#os.rename

> If you want cross-platform overwriting of the destination, use replace().
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
