### PR TITLE
Improvements to extrakey HID descriptors

### DIFF
--- a/tmk_core/protocol/arm_atsam/main_arm_atsam.c
+++ b/tmk_core/protocol/arm_atsam/main_arm_atsam.c
@@ -130,7 +130,6 @@ void send_extra(uint8_t report_id, uint16_t data) {
 
 void send_system(uint16_t data) {
 #ifdef EXTRAKEY_ENABLE
-    if (data != 0) data = data - SYSTEM_POWER_DOWN + 1;
     send_extra(REPORT_ID_SYSTEM, data);
 #endif  // EXTRAKEY_ENABLE
 }

--- a/tmk_core/protocol/arm_atsam/usb/udi_device_conf.h
+++ b/tmk_core/protocol/arm_atsam/usb/udi_device_conf.h
@@ -327,7 +327,7 @@ typedef struct {
 } udi_hid_exk_desc_t;
 
 typedef struct {
-    uint8_t array[54];
+    uint8_t array[50];
 } udi_hid_exk_report_desc_t;
 
 #    define UDI_HID_EXK_DESC \
@@ -429,7 +429,7 @@ typedef struct {
 } udi_hid_raw_desc_t;
 
 typedef struct {
-    uint8_t array[27];
+    uint8_t array[26];
 } udi_hid_raw_report_desc_t;
 
 #    define UDI_HID_RAW_DESC                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           \

--- a/tmk_core/protocol/arm_atsam/usb/udi_hid_kbd.c
+++ b/tmk_core/protocol/arm_atsam/usb/udi_hid_kbd.c
@@ -377,39 +377,33 @@ static uint8_t udi_hid_exk_report_trans[UDI_HID_EXK_REPORT_SIZE];
 
 COMPILER_WORD_ALIGNED
 UDC_DESC_STORAGE udi_hid_exk_report_desc_t udi_hid_exk_report_desc = {{
+    // clang-format off
     0x05, 0x01,              // Usage Page (Generic Desktop)
     0x09, 0x80,              // Usage (System Control)
     0xA1, 0x01,              // Collection (Application)
     0x85, REPORT_ID_SYSTEM,  //   Report ID
-    0x1A, 0x81,
-    0x00,  //   Usage Minimum (81) (System Power Down)
-    0x2A, 0x83,
-    0x00,  //   Usage Maximum (83) (System Wake Up)
-    0x16, 0x01,
-    0x00,  //   Logical Minimum (1)
-    0x26, 0x03,
-    0x00,        //   Logical Maximum (3)
-    0x95, 0x01,  //   Report Count (1)
-    0x75, 0x10,  //   Report Size (16)
-    0x81, 0x00,  //   Input (Data, Array, Absolute)
-    0xC0,        // End Collection
+    0x19, 0x01,              //   Usage Minimum (Pointer)
+    0x2A, 0xB7, 0x00,        //   Usage Maximum (System Display LCD Autoscale)
+    0x15, 0x01,              //   Logical Minimum
+    0x26, 0xB7, 0x00,        //   Logical Maximum
+    0x95, 0x01,              //   Report Count (1)
+    0x75, 0x10,              //   Report Size (16)
+    0x81, 0x00,              //   Input (Data, Array, Absolute)
+    0xC0,                    // End Collection
 
     0x05, 0x0C,                // Usage Page (Consumer)
     0x09, 0x01,                // Usage (Consumer Control)
     0xA1, 0x01,                // Collection (Application)
     0x85, REPORT_ID_CONSUMER,  //   Report ID
-    0x1A, 0x01,
-    0x00,  //   Usage Minimum (Consumer Control)
-    0x2A, 0x9C,
-    0x02,  //   Usage Maximum (AC Distribute Vertically)
-    0x16, 0x01,
-    0x00,  //   Logical Minimum
-    0x26, 0x9C,
-    0x02,        //   Logical Maximum
-    0x95, 0x01,  //   Report Count (1)
-    0x75, 0x10,  //   Report Size (16)
-    0x81, 0x00,  //   Input (Data, Array, Absolute)
-    0xC0         // End Collection
+    0x19, 0x01,                //   Usage Minimum (Consumer Control)
+    0x2A, 0xA0, 0x02,          //   Usage Maximum (AC Desktop Show All Applications)
+    0x15, 0x01,                //   Logical Minimum
+    0x26, 0xA0, 0x02,          //   Logical Maximum
+    0x95, 0x01,                //   Report Count (1)
+    0x75, 0x10,                //   Report Size (16)
+    0x81, 0x00,                //   Input (Data, Array, Absolute)
+    0xC0                       // End Collection
+    //clang-format on
 }};
 
 static bool udi_hid_exk_setreport(void);

--- a/tmk_core/protocol/chibios/usb_main.c
+++ b/tmk_core/protocol/chibios/usb_main.c
@@ -732,7 +732,7 @@ void shared_in_cb(USBDriver *usbp, usbep_t ep) {
  */
 
 #ifdef EXTRAKEY_ENABLE
-static void send_extra_report(uint8_t report_id, uint16_t data) {
+static void send_extra(uint8_t report_id, uint16_t data) {
     osalSysLock();
     if (usbGetDriverStateI(&USB_DRIVER) != USB_ACTIVE) {
         osalSysUnlock();
@@ -744,15 +744,19 @@ static void send_extra_report(uint8_t report_id, uint16_t data) {
     usbStartTransmitI(&USB_DRIVER, SHARED_IN_EPNUM, (uint8_t *)&report, sizeof(report_extra_t));
     osalSysUnlock();
 }
+#endif
 
-void send_system(uint16_t data) { send_extra_report(REPORT_ID_SYSTEM, data); }
+void send_system(uint16_t data) {
+#ifdef EXTRAKEY_ENABLE
+    send_extra(REPORT_ID_SYSTEM, data);
+#endif
+}
 
-void send_consumer(uint16_t data) { send_extra_report(REPORT_ID_CONSUMER, data); }
-
-#else  /* EXTRAKEY_ENABLE */
-void send_system(uint16_t data) { (void)data; }
-void send_consumer(uint16_t data) { (void)data; }
-#endif /* EXTRAKEY_ENABLE */
+void send_consumer(uint16_t data) {
+#ifdef EXTRAKEY_ENABLE
+    send_extra(REPORT_ID_CONSUMER, data);
+#endif
+}
 
 /* ---------------------------------------------------------
  *                   Console functions

--- a/tmk_core/protocol/lufa/lufa.c
+++ b/tmk_core/protocol/lufa/lufa.c
@@ -690,7 +690,7 @@ static void send_extra(uint8_t report_id, uint16_t data) {
  */
 static void send_system(uint16_t data) {
 #ifdef EXTRAKEY_ENABLE
-    send_extra(REPORT_ID_SYSTEM, data - SYSTEM_POWER_DOWN + 1);
+    send_extra(REPORT_ID_SYSTEM, data);
 #endif
 }
 

--- a/tmk_core/protocol/usb_descriptor.c
+++ b/tmk_core/protocol/usb_descriptor.c
@@ -166,10 +166,10 @@ const USB_Descriptor_HIDReport_Datatype_t PROGMEM SharedReport[] = {
     HID_RI_USAGE(8, 0x80),                // System Control
     HID_RI_COLLECTION(8, 0x01),           // Application
         HID_RI_REPORT_ID(8, REPORT_ID_SYSTEM),
-        HID_RI_USAGE_MINIMUM(16, 0x0081), // System Power Down
-        HID_RI_USAGE_MAXIMUM(16, 0x0083), // System Wake Up
-        HID_RI_LOGICAL_MINIMUM(16, 0x0001),
-        HID_RI_LOGICAL_MAXIMUM(16, 0x0003),
+        HID_RI_USAGE_MINIMUM(8, 0x01),    // Pointer
+        HID_RI_USAGE_MAXIMUM(16, 0x00B7), // System Display LCD Autoscale
+        HID_RI_LOGICAL_MINIMUM(8, 0x01),
+        HID_RI_LOGICAL_MAXIMUM(16, 0x00B7),
         HID_RI_REPORT_COUNT(8, 1),
         HID_RI_REPORT_SIZE(8, 16),
         HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_ARRAY | HID_IOF_ABSOLUTE),
@@ -179,10 +179,10 @@ const USB_Descriptor_HIDReport_Datatype_t PROGMEM SharedReport[] = {
     HID_RI_USAGE(8, 0x01),                // Consumer Control
     HID_RI_COLLECTION(8, 0x01),           // Application
         HID_RI_REPORT_ID(8, REPORT_ID_CONSUMER),
-        HID_RI_USAGE_MINIMUM(16, 0x0001), // Consumer Control
-        HID_RI_USAGE_MAXIMUM(16, 0x029C), // AC Distribute Vertically
-        HID_RI_LOGICAL_MINIMUM(16, 0x0001),
-        HID_RI_LOGICAL_MAXIMUM(16, 0x029C),
+        HID_RI_USAGE_MINIMUM(8, 0x01),    // Consumer Control
+        HID_RI_USAGE_MAXIMUM(16, 0x02A0), // AC Desktop Show All Applications
+        HID_RI_LOGICAL_MINIMUM(8, 0x01),
+        HID_RI_LOGICAL_MAXIMUM(16, 0x02A0),
         HID_RI_REPORT_COUNT(8, 1),
         HID_RI_REPORT_SIZE(8, 16),
         HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_ARRAY | HID_IOF_ABSOLUTE),

--- a/tmk_core/protocol/vusb/vusb.c
+++ b/tmk_core/protocol/vusb/vusb.c
@@ -129,7 +129,7 @@ static void send_extra(uint8_t report_id, uint16_t data) {
 
 static void send_system(uint16_t data) {
 #ifdef EXTRAKEY_ENABLE
-    send_extra(REPORT_ID_SYSTEM, data - SYSTEM_POWER_DOWN + 1);
+    send_extra(REPORT_ID_SYSTEM, data);
 #endif
 }
 
@@ -251,7 +251,9 @@ const PROGMEM uchar keyboard_hid_report[] = {
     0xC0         // End Collection
 };
 
-const PROGMEM uchar mouse_hid_report[] = {
+#if defined(MOUSE_ENABLE) || defined(EXTRAKEY_ENABLE)
+const PROGMEM uchar mouse_extra_hid_report[] = {
+#    ifdef MOUSE_ENABLE
     // Mouse report descriptor
     0x05, 0x01,             // Usage Page (Generic Desktop)
     0x09, 0x02,             // Usage (Mouse)
@@ -300,17 +302,18 @@ const PROGMEM uchar mouse_hid_report[] = {
     0x81, 0x06,        //     Input (Data, Variable, Relative)
     0xC0,              //   End Collection
     0xC0,              // End Collection
+#    endif
 
-#ifdef EXTRAKEY_ENABLE
+#    ifdef EXTRAKEY_ENABLE
     // Extrakeys report descriptor
     0x05, 0x01,              // Usage Page (Generic Desktop)
     0x09, 0x80,              // Usage (System Control)
     0xA1, 0x01,              // Collection (Application)
     0x85, REPORT_ID_SYSTEM,  //   Report ID
-    0x1A, 0x81, 0x00,        //   Usage Minimum (System Power Down)
-    0x2A, 0x83, 0x00,        //   Usage Maximum (System Wake Up)
-    0x16, 0x01, 0x00,        //   Logical Minimum
-    0x26, 0x03, 0x00,        //   Logical Maximum
+    0x19, 0x01,              //   Usage Minimum (Pointer)
+    0x2A, 0xB7, 0x00,        //   Usage Maximum (System Display LCD Autoscale)
+    0x15, 0x01,              //   Logical Minimum
+    0x26, 0xB7, 0x00,        //   Logical Maximum
     0x95, 0x01,              //   Report Count (1)
     0x75, 0x10,              //   Report Size (16)
     0x81, 0x00,              //   Input (Data, Array, Absolute)
@@ -320,16 +323,17 @@ const PROGMEM uchar mouse_hid_report[] = {
     0x09, 0x01,                // Usage (Consumer Control)
     0xA1, 0x01,                // Collection (Application)
     0x85, REPORT_ID_CONSUMER,  //   Report ID
-    0x1A, 0x01, 0x00,          //   Usage Minimum (Consumer Control)
-    0x2A, 0x9C, 0x02,          //   Usage Maximum (AC Distribute Vertically)
-    0x16, 0x01, 0x00,          //   Logical Minimum
-    0x26, 0x9C, 0x02,          //   Logical Maximum
+    0x19, 0x01,                //   Usage Minimum (Consumer Control)
+    0x2A, 0xA0, 0x02,          //   Usage Maximum (AC Desktop Show All Applications)
+    0x15, 0x01,                //   Logical Minimum
+    0x26, 0xA0, 0x02,          //   Logical Maximum
     0x95, 0x01,                //   Report Count (1)
     0x75, 0x10,                //   Report Size (16)
     0x81, 0x00,                //   Input (Data, Array, Absolute)
     0xC0                       // End Collection
-#endif
+#    endif
 };
+#endif
 
 #ifndef USB_MAX_POWER_CONSUMPTION
 #    define USB_MAX_POWER_CONSUMPTION 500
@@ -350,10 +354,19 @@ const PROGMEM char usbDescriptorConfiguration[] = {
     /* USB configuration descriptor */
     9,               /* sizeof(usbDescriptorConfiguration): length of descriptor in bytes */
     USBDESCR_CONFIG, /* descriptor type */
-    9 + (9 + 9 + 7) + (9 + 9 + 7), 0,
+#    if defined (MOUSE_ENABLE) || defined(EXTRAKEY_ENABLE)
+    59, // 9 + (9 + 9 + 7) + (9 + 9 + 7)
+#else
+    34, // 9 + (9 + 9 + 7)
+#    endif
+    0,
     // 18 + 7 * USB_CFG_HAVE_INTRIN_ENDPOINT + 7 * USB_CFG_HAVE_INTRIN_ENDPOINT3 + 9, 0,
     /* total length of data returned (including inlined descriptors) */
+#    if defined(MOUSE_ENABLE) || defined(EXTRAKEY_ENABLE)
     2, /* number of interfaces in this configuration */
+#    else
+    1,
+#endif
     1, /* index of this configuration */
     0, /* configuration name string index */
 #    if USB_CFG_IS_SELF_POWERED
@@ -391,8 +404,9 @@ const PROGMEM char usbDescriptorConfiguration[] = {
     USB_POLLING_INTERVAL_MS,         /* in ms */
 #    endif
 
+#    if defined(MOUSE_ENABLE) || defined(EXTRAKEY_ENABLE)
     /*
-     * Mouse interface
+     * Mouse/extrakeys interface
      */
     /* Interface descriptor */
     9,                             /* sizeof(usbDescrInterface): length of descriptor in bytes */
@@ -411,8 +425,8 @@ const PROGMEM char usbDescriptorConfiguration[] = {
     0x00,                             /* target country code */
     0x01,                             /* number of HID Report (or other HID class) Descriptor infos to follow */
     0x22,                             /* descriptor type: report */
-    sizeof(mouse_hid_report), 0,      /* total length of report descriptor */
-#    if USB_CFG_HAVE_INTRIN_ENDPOINT3 /* endpoint descriptor for endpoint 3 */
+    sizeof(mouse_extra_hid_report), 0,      /* total length of report descriptor */
+#        if USB_CFG_HAVE_INTRIN_ENDPOINT3 /* endpoint descriptor for endpoint 3 */
     /* Endpoint descriptor */
     7,                                 /* sizeof(usbDescrEndpoint) */
     USBDESCR_ENDPOINT,                 /* descriptor type = endpoint */
@@ -420,6 +434,7 @@ const PROGMEM char usbDescriptorConfiguration[] = {
     0x03,                              /* attrib: Interrupt endpoint */
     8, 0,                              /* maximum packet size */
     USB_POLLING_INTERVAL_MS,           /* in ms */
+#        endif
 #    endif
 };
 #endif
@@ -448,10 +463,12 @@ USB_PUBLIC usbMsgLen_t usbFunctionDescriptor(struct usbRequest *rq) {
                     usbMsgPtr = (unsigned char *)(usbDescriptorConfiguration + 9 + 9);
                     len       = 9;
                     break;
+#if defined(MOUSE_ENABLE) || defined(EXTRAKEY_ENABLE)
                 case 1:
                     usbMsgPtr = (unsigned char *)(usbDescriptorConfiguration + 9 + (9 + 9 + 7) + 9);
                     len       = 9;
                     break;
+#endif
             }
             break;
         case USBDESCR_HID_REPORT:
@@ -461,10 +478,12 @@ USB_PUBLIC usbMsgLen_t usbFunctionDescriptor(struct usbRequest *rq) {
                     usbMsgPtr = (unsigned char *)keyboard_hid_report;
                     len       = sizeof(keyboard_hid_report);
                     break;
+#if defined(MOUSE_ENABLE) || defined(EXTRAKEY_ENABLE)
                 case 1:
-                    usbMsgPtr = (unsigned char *)mouse_hid_report;
-                    len       = sizeof(mouse_hid_report);
+                    usbMsgPtr = (unsigned char *)mouse_extra_hid_report;
+                    len       = sizeof(mouse_extra_hid_report);
                     break;
+#endif
             }
             break;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

As mentioned in #963, these descriptors are declared as Array, so the logical value sent over the wire is the 1-based index of the usage between Usage Minimum and Usage Maximum. Only one value can be asserted at a time, and a value of 0 means nothing pressed.

I've reverted the range of the System usages from just the three power keycodes to the entire thing so that one can send arbitrary usages with `host_system_send()`. Now we don't need to do the whole `data - SYSTEM_POWER_DOWN + 1` first, as usage 1 == index 1.

Similarly I increased the range of the Consumer usages slightly, to allow for some of the newer additions to the page such as the macOS Launchpad and Mission Control usages (#4762). They still don't have their own keycodes yet, but you can now at least DIY.

I couldn't reproduce the issue with macOS seeing QMK as a mouse/tablet (#510) on Catalina... except for with V-USB, until I realised that the extrakey descriptor is part of the mousekey descriptor's array, and the latter is *always* present even if `MOUSE_ENABLE` is not defined. So I chucked a bunch of ifdefs in vusb.c to handle the cases of either extrakeys or mouse being disabled, and both at the same time. Should save some bytes!

Tested and working on LUFA, ChibiOS and V-USB. Again, I can't test ATSAM, but the changes to the descriptors are much the same as the other stacks, and the CTRL and ALT both compile 😄

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
