### PR TITLE
Convert two handwired default keymaps to Dynamic Macro feature

### DIFF
--- a/keyboards/handwired/daishi/keymaps/default/keymap.c
+++ b/keyboards/handwired/daishi/keymaps/default/keymap.c
@@ -6,11 +6,8 @@
 
 enum custom_keycodes {
     M_EXAMPLE1 = SAFE_RANGE,
-	M_EXAMPLE2,
-	DYNAMIC_MACRO_RANGE,
+	M_EXAMPLE2
 };
-
-#include "dynamic_macro.h"
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
@@ -33,7 +30,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  */
 
  [_QW] = LAYOUT( /* QWERTY */
-  KC_ESC , _______, _______, _______, _______, _______, _______, _______, _______, _______,DYN_MACRO_PLAY1,DYN_MACRO_PLAY2,DYN_REC_STOP, KC_PSCR, KC_SLCK, KC_PAUS, MO(_FN), KC_MUTE,
+  KC_ESC , _______, _______, _______, _______, _______, _______, _______, _______, _______, DM_PLY1, DM_PLY2, DM_RSTP, KC_PSCR, KC_SLCK, KC_PAUS, MO(_FN), KC_MUTE,
   KC_F1  , KC_F2  , KC_F3  , KC_F4  , KC_F5  , KC_F6  , KC_F7  , KC_F8  , KC_F9  , KC_F10 , KC_F11 , KC_F12 , KC_DEL , KC_HOME, KC_PGUP, KC_END , KC_INS , KC_NLCK,
   KC_GRV , KC_1   , KC_2   , KC_3   , KC_4   , KC_5   , KC_6   , KC_7   , KC_8   , KC_9   , KC_0   , KC_MINS, KC_EQL , KC_BSPC, KC_PGDN, KC_PSLS, KC_PAST, KC_PMNS,
   KC_TAB , KC_Q   , KC_W   , KC_E   , KC_R   , KC_T   , KC_Y   , KC_U   , KC_I   , KC_O   , KC_P   , KC_LBRC, KC_RBRC, KC_BSLS, KC_P7  , KC_P8  , KC_P9  , KC_PPLS,
@@ -61,7 +58,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  */
  
  [_FN] = LAYOUT( /* Function */
-  RESET  , KC_F13 , KC_F14 , KC_F15 , KC_F16 , KC_F17 , KC_F18 , KC_F19 , KC_F20 , KC_F21 ,DYN_REC_START1,DYN_REC_START2,DYN_REC_STOP, _______, _______, _______, MO(_FN), DEBUG,
+  RESET  , KC_F13 , KC_F14 , KC_F15 , KC_F16 , KC_F17 , KC_F18 , KC_F19 , KC_F20 , KC_F21 , DM_REC1, DM_REC2, DM_RSTP, _______, _______, _______, MO(_FN), DEBUG,
   _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
   _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
   _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
@@ -72,9 +69,6 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 };
 
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
-	if (!process_record_dynamic_macro(keycode, record)) {
-        return false;
-    }
     if (record->event.pressed) {
         switch(keycode) {
             case M_EXAMPLE1:

--- a/keyboards/handwired/daishi/rules.mk
+++ b/keyboards/handwired/daishi/rules.mk
@@ -29,3 +29,4 @@ BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
 RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight.  Do not enable this with audio at the same time.
 SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
 ENCODER_ENABLE = yes		# Add rotary encoder support
+DYNAMIC_MACRO_ENABLE = yes

--- a/keyboards/handwired/space_oddity/keymaps/default/keymap.c
+++ b/keyboards/handwired/space_oddity/keymaps/default/keymap.c
@@ -24,9 +24,7 @@ enum custom_keycodes {
   PAIR_PR,
   PAIR_BR,
   PAIR_CB,
-  LAMBDA,
-  DYNAMIC_MACRO_RANGE,
-
+  LAMBDA
 };
 
 // Tap Dance initializer.
@@ -35,8 +33,6 @@ enum {
   SFT_CAPS = 0,
 
 };
-
-#include "dynamic_macro.h"
 
 // Tap dance actions - double tap for Caps Lock.
 qk_tap_dance_action_t tap_dance_actions[] = {
@@ -71,7 +67,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    */
 
   [0] = LAYOUT( \
-    PAIR_PR,       PAIR_BR,          PAIR_CB,          XXXXXXX,          XXXXXXX,                 DYN_MACRO_PLAY1,              DYN_MACRO_PLAY2, \
+    PAIR_PR,       PAIR_BR,          PAIR_CB,          XXXXXXX,          XXXXXXX,                 DM_PLY1,                      DM_PLY2,         \
     KC_GRV,        KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,           KC_9,           KC_0,         KC_BSPC,         \
     KC_TAB,        KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,           KC_O,           KC_P,         KC_MINS,         \
     CTL_T(KC_ESC), KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,           KC_L,           KC_SCLN,      KC_QUOT,         \
@@ -105,8 +101,8 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    */
 
   [1] = LAYOUT( \
-    LAMBDA,       _______,          _______,          _______,          _______,          DYN_REC_START1,   DYN_REC_START2, \
-    DYN_REC_STOP, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_LBRC, KC_P7,   KC_P8,   KC_P9,   KC_ASTR, KC_DEL,         \
+    LAMBDA,       _______,          _______,          _______,          _______,          DM_REC1,          DM_REC2,        \
+    DM_RSTP,      KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_LBRC, KC_P7,   KC_P8,   KC_P9,   KC_ASTR, KC_DEL,         \
     _______,      KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_RBRC, KC_P4,   KC_P5,   KC_P6,   KC_PLUS, KC_EQL,         \
     KC_BSLS,      KC_F11,  KC_F12,  KC_F13,  KC_F14,  KC_F15,  KC_LCBR, KC_P1,   KC_P2,   KC_P3,   KC_MINS, KC_PIPE,        \
     _______,      KC_F16,  KC_F17,  KC_F18,  KC_F19,  KC_F20,  KC_RCBR, KC_P0,   KC_COMM, KC_DOT,  KC_SLSH, _______,        \
@@ -160,11 +156,6 @@ void matrix_scan_user(void) {
 //
 // Customize to your heart's content!
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
-
-  if (!process_record_dynamic_macro(keycode, record)) {
-    return false;
-  }
-
   switch (keycode) {
 
     case PAIR_PR:

--- a/keyboards/handwired/space_oddity/rules.mk
+++ b/keyboards/handwired/space_oddity/rules.mk
@@ -25,3 +25,4 @@ BACKLIGHT_ENABLE = no      # Enable keyboard backlight functionality
 AUDIO_ENABLE = no
 RGBLIGHT_ENABLE = no
 TAP_DANCE_ENABLE = yes
+DYNAMIC_MACRO_ENABLE = yes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

When travis is building all default keymaps, it flags these two as using the old Dynamic Macro code. This updates them to the new feature.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
