### PR TITLE
Rollback #7967, ChibiOS thread safety

### DIFF
--- a/drivers/arm/i2c_master.c
+++ b/drivers/arm/i2c_master.c
@@ -29,6 +29,8 @@
 #include <string.h>
 #include <hal.h>
 
+static uint8_t i2c_address;
+
 static const I2CConfig i2cconfig = {
 #ifdef USE_I2CV1
     I2C1_OPMODE,
@@ -69,49 +71,27 @@ __attribute__((weak)) void i2c_init(void) {
 }
 
 i2c_status_t i2c_start(uint8_t address) {
-#if I2C_USE_MUTUAL_EXCLUSION
-    i2cAcquireBus(&I2C_DRIVER);
-#endif
-
+    i2c_address = address;
     i2cStart(&I2C_DRIVER, &i2cconfig);
     return I2C_STATUS_SUCCESS;
 }
 
 i2c_status_t i2c_transmit(uint8_t address, const uint8_t* data, uint16_t length, uint16_t timeout) {
-#if I2C_USE_MUTUAL_EXCLUSION
-    i2cAcquireBus(&I2C_DRIVER);
-#endif
-
+    i2c_address = address;
     i2cStart(&I2C_DRIVER, &i2cconfig);
-    msg_t status = i2cMasterTransmitTimeout(&I2C_DRIVER, (address >> 1), data, length, 0, 0, MS2ST(timeout));
-
-#if I2C_USE_MUTUAL_EXCLUSION
-    i2cReleaseBus(&I2C_DRIVER);
-#endif
-
+    msg_t status = i2cMasterTransmitTimeout(&I2C_DRIVER, (i2c_address >> 1), data, length, 0, 0, MS2ST(timeout));
     return chibios_to_qmk(&status);
 }
 
 i2c_status_t i2c_receive(uint8_t address, uint8_t* data, uint16_t length, uint16_t timeout) {
-#if I2C_USE_MUTUAL_EXCLUSION
-    i2cAcquireBus(&I2C_DRIVER);
-#endif
-
+    i2c_address = address;
     i2cStart(&I2C_DRIVER, &i2cconfig);
-    msg_t status = i2cMasterReceiveTimeout(&I2C_DRIVER, (address >> 1), data, length, MS2ST(timeout));
-
-#if I2C_USE_MUTUAL_EXCLUSION
-    i2cReleaseBus(&I2C_DRIVER);
-#endif
-
+    msg_t status = i2cMasterReceiveTimeout(&I2C_DRIVER, (i2c_address >> 1), data, length, MS2ST(timeout));
     return chibios_to_qmk(&status);
 }
 
 i2c_status_t i2c_writeReg(uint8_t devaddr, uint8_t regaddr, const uint8_t* data, uint16_t length, uint16_t timeout) {
-#if I2C_USE_MUTUAL_EXCLUSION
-    i2cAcquireBus(&I2C_DRIVER);
-#endif
-
+    i2c_address = devaddr;
     i2cStart(&I2C_DRIVER, &i2cconfig);
 
     uint8_t complete_packet[length + 1];
@@ -120,34 +100,15 @@ i2c_status_t i2c_writeReg(uint8_t devaddr, uint8_t regaddr, const uint8_t* data,
     }
     complete_packet[0] = regaddr;
 
-    msg_t status = i2cMasterTransmitTimeout(&I2C_DRIVER, (devaddr >> 1), complete_packet, length + 1, 0, 0, MS2ST(timeout));
-
-#if I2C_USE_MUTUAL_EXCLUSION
-    i2cReleaseBus(&I2C_DRIVER);
-#endif
-
+    msg_t status = i2cMasterTransmitTimeout(&I2C_DRIVER, (i2c_address >> 1), complete_packet, length + 1, 0, 0, MS2ST(timeout));
     return chibios_to_qmk(&status);
 }
 
 i2c_status_t i2c_readReg(uint8_t devaddr, uint8_t regaddr, uint8_t* data, uint16_t length, uint16_t timeout) {
-#if I2C_USE_MUTUAL_EXCLUSION
-    i2cAcquireBus(&I2C_DRIVER);
-#endif
-
+    i2c_address = devaddr;
     i2cStart(&I2C_DRIVER, &i2cconfig);
-    msg_t status = i2cMasterTransmitTimeout(&I2C_DRIVER, (devaddr >> 1), &regaddr, 1, data, length, MS2ST(timeout));
-
-#if I2C_USE_MUTUAL_EXCLUSION
-    i2cReleaseBus(&I2C_DRIVER);
-#endif
-
+    msg_t status = i2cMasterTransmitTimeout(&I2C_DRIVER, (i2c_address >> 1), &regaddr, 1, data, length, MS2ST(timeout));
     return chibios_to_qmk(&status);
 }
 
-void i2c_stop(void) {
-    i2cStop(&I2C_DRIVER);
-
-#if I2C_USE_MUTUAL_EXCLUSION
-    i2cReleaseBus(&I2C_DRIVER);
-#endif
-}
+void i2c_stop(void) { i2cStop(&I2C_DRIVER); }


### PR DESCRIPTION
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
~`i2c_start` and `i2c_stop` were actually only really useful for people who want to explicitly invoke ChibiOS i2c functions. With mutual exclusion enabled, there were instances of `i2c_start`->`i2c_transmit` which would deadlock as the mutexes are non-recursive.~

~This PR turns `i2c_start` and `i2c_stop` into no-ops in order to maintain the previous interface, and folds the `i2c_stop` functionality into the other transmission functions -- they were already effectively doing `i2c_start` anyway.~

Modified this PR to rollback #7967, specifically to fix the Qwiic OLED issue. Will do a new followup PR to fix all I2C usage across the platform to correctly invoke start/stop, and only perform lock acquisition in those functions.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
