### PR TITLE
Conform Gherkin defaults to original TMK keymap

### DIFF
--- a/keyboards/40percentclub/gherkin/keymaps/default/keymap.c
+++ b/keyboards/40percentclub/gherkin/keymaps/default/keymap.c
@@ -40,7 +40,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   [4] = LAYOUT_ortho_3x10(
     _______, _______, _______, _______, _______, KC_UNDS, KC_PLUS, KC_LCBR, KC_RCBR, KC_PIPE,
     KC_TAB,  _______, _______, _______, _______, KC_LABK, KC_RABK, KC_QUES, KC_COLN, KC_DQUO,
-    _______, _______, _______, _______, _______, _______, KC_HOME, KC_PGUP, KC_PGDN, KC_END
+    _______, _______, _______, _______, _______, _______, KC_HOME, KC_PGDN, KC_PGUP, KC_END
   ),
 
   [5] = LAYOUT_ortho_3x10(

--- a/keyboards/40percentclub/gherkin/keymaps/default/keymap.c
+++ b/keyboards/40percentclub/gherkin/keymaps/default/keymap.c
@@ -1,20 +1,53 @@
 #include QMK_KEYBOARD_H
 
-#define FN1_Q LT(1, KC_Q)
+#define FN1_SPC     LT(1, KC_SPC)
+#define FN2_BSPC    LT(2, KC_BSPC)
+#define FN3_C       LT(3, KC_C)
+#define FN4_V       LT(4, KC_V)
+#define FN5_B       LT(5, KC_B)
+#define CTL_Z       CTL_T(KC_Z)
+#define ALT_X       ALT_T(KC_X)
+#define ALT_N       ALGR_T(KC_N)
+#define CTL_M       RCTL_T(KC_Z)
+#define SFT_ENT     RSFT_T(KC_ENT)
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
   [0] = LAYOUT_ortho_3x10(
-    FN1_Q,   KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,
+    KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,
     KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_ESC,
-    KC_Z,    KC_X,    KC_C,    KC_V,    KC_BSPC, KC_SPC,  KC_B,    KC_N,    KC_M,    KC_ENT
+    CTL_Z,   ALT_X,   FN3_C,   FN4_V,   FN2_BSPC,FN1_SPC, FN5_B,   ALT_N,   CTL_M,   SFT_ENT
   ),
 
   [1] = LAYOUT_ortho_3x10(
-    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
-    _______, _______, _______, _______, _______, _______, _______, _______, _______, BL_INC,
-    _______, _______, _______, _______, _______, _______, RESET,   _______, _______, BL_DEC
+    KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,
+    KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,
+    _______, _______, _______, _______, KC_DEL,  _______, _______, _______, _______, _______
   ),
+
+  [2] = LAYOUT_ortho_3x10(
+    KC_EXLM, KC_AT,   KC_HASH, KC_DLR,  KC_PERC, KC_CIRC, KC_AMPR, KC_ASTR, KC_LPRN, KC_RPRN,
+    KC_F11,  KC_F12,  _______, _______, _______, _______, _______, _______, _______, KC_GRV,
+    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______
+  ),
+
+  [3] = LAYOUT_ortho_3x10(
+    _______, _______, _______, _______, _______, KC_MINS, KC_EQL,  KC_LBRC, KC_RBRC, KC_BSLS,
+    KC_TAB,  _______, _______, _______, _______, KC_COMM, KC_DOT,  KC_SLSH, KC_SCLN, KC_QUOT,
+    _______, _______, _______, _______, _______, _______, KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT
+  ),
+
+  [4] = LAYOUT_ortho_3x10(
+    _______, _______, _______, _______, _______, KC_UNDS, KC_PLUS, KC_LCBR, KC_RCBR, KC_PIPE,
+    KC_TAB,  _______, _______, _______, _______, KC_LABK, KC_RABK, KC_QUES, KC_COLN, KC_DQUO,
+    _______, _______, _______, _______, _______, _______, KC_HOME, KC_PGUP, KC_PGDN, KC_END
+  ),
+
+  [5] = LAYOUT_ortho_3x10(
+    KC_CALC, KC_WHOM, KC_MAIL, KC_MYCM, _______, _______, _______, _______, _______, KC_PSCR,
+    _______, _______, _______, _______, _______, _______, _______, _______, BL_DEC,  BL_INC,
+    _______, _______, _______, _______, RESET,   _______, _______, _______, _______, _______
+  )
 
 };
 

--- a/keyboards/40percentclub/gherkin/keymaps/default/keymap.c
+++ b/keyboards/40percentclub/gherkin/keymaps/default/keymap.c
@@ -8,7 +8,7 @@
 #define CTL_Z       CTL_T(KC_Z)
 #define ALT_X       ALT_T(KC_X)
 #define ALT_N       ALGR_T(KC_N)
-#define CTL_M       RCTL_T(KC_Z)
+#define CTL_M       RCTL_T(KC_M)
 #define SFT_ENT     RSFT_T(KC_ENT)
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {


### PR DESCRIPTION
Updates the default QMK keymap for Gherkin to [the same one](http://www.keyboard-layout-editor.com/#/gists/7eac308ec268b36b0621bfca7500d20c) that's in [the original TMK repository](https://git.40percent.club/di0ib/tmk_keyboard/src/branch/master/keyboard/gherkin/actionmap_gherkin.c). This will let new Gherkin builders flash the default QMK firmware and get the same experience that they would if they built and flashed from di0ib's TMK repository.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [X] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
