### PR TITLE
Made windows driver installation accept y as All to allow CI

### DIFF
--- a/util/win_shared_install.sh
+++ b/util/win_shared_install.sh
@@ -69,12 +69,12 @@ while true; do
     echo "           keyboards"
     echo "(N)one - No drivers will be installed,"
     echo "         flashing your keyboard will most likely not work"
-    read -p "(A/C/F/N)? " res
+    read -p "(a/c/f/N)? " res
     case $res in
         [AaYy]* ) install_drivers --all; break;;
         [Cc]* ) install_drivers; break;;
         [Ff]* ) install_drivers --all --force; break;;
-        [Nn]* ) break;;
+        [Nn]* | "" ) break;;
         * ) echo "Invalid answer";;
     esac
 done

--- a/util/win_shared_install.sh
+++ b/util/win_shared_install.sh
@@ -37,7 +37,7 @@ function install_utils {
 function install_drivers {
     pushd "$download_dir"
     cp -f "$dir/drivers.txt" .
-    echo 
+    echo
     cmd.exe //c "qmk_driver_installer.exe $1 $2 drivers.txt"
     popd > /dev/null
 }
@@ -71,7 +71,7 @@ while true; do
     echo "         flashing your keyboard will most likely not work"
     read -p "(A/C/F/N)? " res
     case $res in
-        [Aa]* ) install_drivers --all; break;;
+        [AaYy]* ) install_drivers --all; break;;
         [Cc]* ) install_drivers; break;;
         [Ff]* ) install_drivers --all --force; break;;
         [Nn]* ) break;;

--- a/util/win_shared_install.sh
+++ b/util/win_shared_install.sh
@@ -62,10 +62,10 @@ fi
 while true; do
     echo
     echo "Which USB drivers do you want to install?"
-    echo "(A)all - All supported drivers will be installed"
+    echo "(A)ll - All supported drivers will be installed"
     echo "(C)onnected - Only drivers for connected keyboards (in bootloader/flashing mode)"
     echo "              will be installed"
-    echo "(F)force - Like all, but will also override existing drivers for connected"
+    echo "(F)orce - Like all, but will also override existing drivers for connected"
     echo "           keyboards"
     echo "(N)one - No drivers will be installed,"
     echo "         flashing your keyboard will most likely not work"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This is to allow CI to run `qmk setup -y` on windows runners. Without it it'll loop in "invalid answer" when it reaches [the driver installation step](https://github.com/Duckle29/qmk_cli/runs/451126266?check_suite_focus=true#step:7:906)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
