### PR TITLE
Add decorators for determining keyboard and keymap based on current directory

### DIFF
--- a/lib/python/qmk/cli/__init__.py
+++ b/lib/python/qmk/cli/__init__.py
@@ -2,6 +2,8 @@
 
 We list each subcommand here explicitly because all the reliable ways of searching for modules are slow and delay startup.
 """
+from milc import cli
+
 from . import cformat
 from . import compile
 from . import config
@@ -15,3 +17,6 @@ from . import kle2json
 from . import new
 from . import pyformat
 from . import pytest
+
+if not hasattr(cli, 'config_source'):
+    cli.log.warning("Your QMK CLI is out of date. Please upgrade with `pip3 install --upgrade qmk` or by using your package manager.")

--- a/lib/python/qmk/cli/compile.py
+++ b/lib/python/qmk/cli/compile.py
@@ -4,7 +4,6 @@ You can compile a keymap already in the repo or using a QMK Configurator export.
 """
 import subprocess
 from argparse import FileType
-from pathlib import Path
 
 from milc import cli
 

--- a/lib/python/qmk/cli/compile.py
+++ b/lib/python/qmk/cli/compile.py
@@ -4,6 +4,7 @@ You can compile a keymap already in the repo or using a QMK Configurator export.
 """
 import subprocess
 from argparse import FileType
+from pathlib import Path
 
 from milc import cli
 

--- a/lib/python/qmk/cli/json/keymap.py
+++ b/lib/python/qmk/cli/json/keymap.py
@@ -11,7 +11,7 @@ import qmk.path
 
 @cli.argument('-o', '--output', arg_only=True, type=Path, help='File to write to')
 @cli.argument('-q', '--quiet', arg_only=True, action='store_true', help="Quiet mode, only output error messages")
-@cli.argument('filename', arg_only=True, type=Path, help='Configurator JSON file')
+@cli.argument('filename', arg_only=True, help='Configurator JSON file')
 @cli.subcommand('Creates a keymap.c from a QMK Configurator export.')
 def json_keymap(cli):
     """Generate a keymap.c from a configurator export.

--- a/lib/python/qmk/cli/json/keymap.py
+++ b/lib/python/qmk/cli/json/keymap.py
@@ -11,7 +11,7 @@ import qmk.path
 
 @cli.argument('-o', '--output', arg_only=True, type=Path, help='File to write to')
 @cli.argument('-q', '--quiet', arg_only=True, action='store_true', help="Quiet mode, only output error messages")
-@cli.argument('filename', arg_only=True, help='Configurator JSON file')
+@cli.argument('filename', arg_only=True, type=Path, help='Configurator JSON file')
 @cli.subcommand('Creates a keymap.c from a QMK Configurator export.')
 def json_keymap(cli):
     """Generate a keymap.c from a configurator export.

--- a/lib/python/qmk/cli/list/keymaps.py
+++ b/lib/python/qmk/cli/list/keymaps.py
@@ -1,12 +1,15 @@
 """List the keymaps for a specific keyboard
 """
 from milc import cli
+
 import qmk.keymap
+from qmk.decorators import automagic_keyboard
 from qmk.errors import NoSuchKeyboardError
 
 
 @cli.argument("-kb", "--keyboard", help="Specify keyboard name. Example: 1upkeyboards/1up60hse")
 @cli.subcommand("List the keymaps for a specific keyboard")
+@automagic_keyboard
 def list_keymaps(cli):
     """List the keymaps for a specific keyboard
     """

--- a/lib/python/qmk/cli/new/keymap.py
+++ b/lib/python/qmk/cli/new/keymap.py
@@ -4,12 +4,15 @@ import shutil
 from pathlib import Path
 
 import qmk.path
+from qmk.decorators import automagic_keyboard, automagic_keymap
 from milc import cli
 
 
 @cli.argument('-kb', '--keyboard', help='Specify keyboard name. Example: 1upkeyboards/1up60hse')
 @cli.argument('-km', '--keymap', help='Specify the name for the new keymap directory')
 @cli.subcommand('Creates a new keymap for the keyboard of your choosing')
+@automagic_keyboard
+@automagic_keymap
 def new_keymap(cli):
     """Creates a new keymap for the keyboard of your choosing.
     """

--- a/lib/python/qmk/commands.py
+++ b/lib/python/qmk/commands.py
@@ -1,12 +1,8 @@
 """Helper functions for commands.
 """
 import json
-from pathlib import Path
-
-from milc import cli
 
 import qmk.keymap
-from qmk.path import is_keyboard, is_keymap_dir, under_qmk_firmware
 
 
 def create_make_command(keyboard, keymap, target=None):
@@ -57,71 +53,6 @@ def compile_configurator_json(user_keymap, bootloader=None):
     if bootloader is None:
         return create_make_command(user_keymap['keyboard'], user_keymap['keymap'])
     return create_make_command(user_keymap['keyboard'], user_keymap['keymap'], bootloader)
-
-
-def find_keyboard_keymap():
-    """Returns `(keyboard_name, keymap_name)` based on the user's current environment.
-
-    This determines the keyboard and keymap name using the following precedence order:
-
-        * Command line flags (--keyboard and --keymap)
-        * Current working directory
-            * `keyboards/<keyboard_name>`
-            * `keyboards/<keyboard_name>/keymaps/<keymap_name>`
-            * `layouts/**/<keymap_name>`
-            * `users/<keymap_name>`
-        * Configuration
-            * cli.config.<subcommand>.keyboard
-            * cli.config.<subcommand>.keymap
-    """
-    # Check to make sure their copy of MILC supports config_source
-    if not hasattr(cli, 'config_source'):
-        cli.log.error("Your QMK CLI is out of date. Please upgrade using pip3 or your package manager.")
-        exit(1)
-
-    # State variables
-    relative_cwd = under_qmk_firmware()
-    keyboard_name = ""
-    keymap_name = ""
-
-    # If the keyboard or keymap are passed as arguments use that in preference to anything else
-    if cli.config_source[cli._entrypoint.__name__]['keyboard'] == 'argument':
-        keyboard_name = cli.config[cli._entrypoint.__name__]['keyboard']
-    if cli.config_source[cli._entrypoint.__name__]['keymap'] == 'argument':
-        keymap_name = cli.config[cli._entrypoint.__name__]['keymap']
-
-    if not keyboard_name or not keymap_name:
-        # If we don't have a keyboard_name and keymap_name from arguments try to derive one or both
-        if relative_cwd and relative_cwd.parts and relative_cwd.parts[0] == 'keyboards':
-            # Try to determine the keyboard and/or keymap name
-            current_path = Path('/'.join(relative_cwd.parts[1:]))
-
-            if current_path.parts[-2] == 'keymaps':
-                if not keymap_name:
-                    keymap_name = current_path.parts[-1]
-                if not keyboard_name:
-                    keyboard_name = '/'.join(current_path.parts[:-2])
-            elif not keyboard_name and is_keyboard(current_path):
-                keyboard_name = str(current_path)
-
-        elif relative_cwd and relative_cwd.parts and relative_cwd.parts[0] == 'layouts':
-            # Try to determine the keymap name from the community layout
-            if is_keymap_dir(relative_cwd) and not keymap_name:
-                keymap_name = relative_cwd.name
-
-        elif relative_cwd and relative_cwd.parts and relative_cwd.parts[0] == 'users':
-            # Try to determine the keymap name based on which userspace they're in
-            if not keymap_name and len(relative_cwd.parts) > 1:
-                keymap_name = relative_cwd.parts[1]
-
-    # If we still don't have a keyboard and keymap check the config
-    if not keyboard_name and cli.config[cli._entrypoint.__name__]['keyboard']:
-        keyboard_name = cli.config[cli._entrypoint.__name__]['keyboard']
-
-    if not keymap_name and cli.config[cli._entrypoint.__name__]['keymap']:
-        keymap_name = cli.config[cli._entrypoint.__name__]['keymap']
-
-    return (keyboard_name, keymap_name)
 
 
 def parse_configurator_json(configurator_file):

--- a/lib/python/qmk/commands.py
+++ b/lib/python/qmk/commands.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from milc import cli
 
 import qmk.keymap
-from qmk.path import is_keyboard, is_keymap_dir, keymap, under_qmk_firmware
+from qmk.path import is_keyboard, is_keymap_dir, under_qmk_firmware
 
 
 def create_make_command(keyboard, keymap, target=None):

--- a/lib/python/qmk/commands.py
+++ b/lib/python/qmk/commands.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from milc import cli
 
 import qmk.keymap
-from qmk.path import is_keyboard, is_keymap_dir, under_qmk_firmware
+from qmk.path import is_keyboard, is_keymap_dir, keymap, under_qmk_firmware
 
 
 def create_make_command(keyboard, keymap, target=None):
@@ -73,7 +73,6 @@ def find_keyboard_keymap():
         * Configuration
             * cli.config.<subcommand>.keyboard
             * cli.config.<subcommand>.keymap
-    """
     # Check to make sure their copy of MILC supports config_source
     if not hasattr(cli, 'config_source'):
         cli.log.error("Your QMK CLI is out of date. Please upgrade using pip3 or your package manager.")

--- a/lib/python/qmk/commands.py
+++ b/lib/python/qmk/commands.py
@@ -73,6 +73,7 @@ def find_keyboard_keymap():
         * Configuration
             * cli.config.<subcommand>.keyboard
             * cli.config.<subcommand>.keymap
+    """
     # Check to make sure their copy of MILC supports config_source
     if not hasattr(cli, 'config_source'):
         cli.log.error("Your QMK CLI is out of date. Please upgrade using pip3 or your package manager.")

--- a/lib/python/qmk/decorators.py
+++ b/lib/python/qmk/decorators.py
@@ -8,112 +8,34 @@ from milc import cli
 from qmk.path import is_keyboard, is_keymap_dir, under_qmk_firmware
 
 
-def context_sensitivity(func):
-    """Sets `cli.config.<subcommand>.keyboard` and `cli.config.<subcommand>.keymap` based on environment.
-
-    This determines the keyboard and keymap name using the following precedence order:
-
-        * Command line flags (--keyboard and --keymap)
-        * Current working directory
-            * `keyboards/<keyboard_name>`
-            * `keyboards/<keyboard_name>/keymaps/<keymap_name>`
-            * `layouts/**/<keymap_name>`
-            * `users/<keymap_name>`
-        * Configuration
-            * cli.config.<subcommand>.keyboard
-            * cli.config.<subcommand>.keymap
-    """
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        # Check to make sure their copy of MILC supports config_source
-        if not hasattr(cli, 'config_source'):
-            cli.log.error("Your QMK CLI is out of date. Please upgrade using pip3 or your package manager.")
-            exit(1)
-
-        # State variables
-        relative_cwd = under_qmk_firmware()
-        keyboard_name = ""
-        keymap_name = ""
-
-        # If the keyboard or keymap are passed as arguments use that in preference to anything else
-        if cli.config_source[cli._entrypoint.__name__]['keyboard'] == 'argument':
-            keyboard_name = cli.config[cli._entrypoint.__name__]['keyboard']
-
-        if cli.config_source[cli._entrypoint.__name__]['keymap'] == 'argument':
-            keymap_name = cli.config[cli._entrypoint.__name__]['keymap']
-
-        if not keyboard_name or not keymap_name:
-            # If we don't have a keyboard_name and keymap_name from arguments try to derive one or both
-            if relative_cwd and len(relative_cwd.parts) > 1:
-                # Try to determine based on being in `qmk_firmware/keyboards`
-                if relative_cwd.parts[0] == 'keyboards':
-                    current_path = Path('/'.join(relative_cwd.parts[1:]))  # Remove 'keyboards' from the front of the path
-
-                    if current_path.parts[-2] == 'keymaps':
-                        if not keymap_name:
-                            keymap_name = current_path.parts[-1]
-                        if not keyboard_name:
-                            keyboard_name = '/'.join(current_path.parts[:-2])
-                    elif not keyboard_name and is_keyboard(current_path):
-                        keyboard_name = str(current_path)
-
-                # Try to determine based on being in `qmk_firmware/layouts`
-                elif relative_cwd.parts[0] == 'layouts':
-                    if is_keymap_dir(relative_cwd) and not keymap_name:
-                        keymap_name = relative_cwd.name
-
-                # Try to determine based on being in `qmk_firmware/users`
-                elif relative_cwd.parts[0] == 'users':
-                    if not keymap_name and len(relative_cwd.parts) > 1:
-                        keymap_name = relative_cwd.parts[1]
-
-        # If we have a keyboard/keymap name overwrite the config
-        if keyboard_name:
-            cli.config[cli._entrypoint.__name__]['keyboard'] = keyboard_name
-
-        if keymap_name:
-            cli.config[cli._entrypoint.__name__]['keymap'] = keymap_name
-
-        return func(*args, **kwargs)
-
-    return wrapper
-
-
 def automagic_keyboard(func):
     """Sets `cli.config.<subcommand>.keyboard` based on environment.
 
-    This determines the keyboard name using the following precedence order:
-
-        * Command line flags (--keyboard)
-        * Current working directory
-            * `keyboards/<keyboard_name>`
-        * Configuration
-            * cli.config.<subcommand>.keyboard
+    This will rewrite cli.config.<subcommand>.keyboard if the user did not pass `--keyboard` and the directory they are currently in is a keyboard or keymap directory.
     """
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         # Check to make sure their copy of MILC supports config_source
         if not hasattr(cli, 'config_source'):
-            cli.log.error("Your QMK CLI is out of date. Please upgrade using pip3 or your package manager.")
+            cli.log.error("This subcommand requires a newer version of the QMK CLI. Please upgrade using `pip3 install --upgrade qmk` or your package manager.")
             exit(1)
 
-        # If the keyboard or keymap are passed as arguments use that in preference to anything else
-        if cli.config_source[cli._entrypoint.__name__]['keyboard'] == 'argument':
-            return func(*args, **kwargs)
+        # Ensure that `--keyboard` was not passed and CWD is under `qmk_firmware/keyboards`
+        if cli.config_source[cli._entrypoint.__name__]['keyboard'] != 'argument':
+            relative_cwd = under_qmk_firmware()
 
-        # If the user is in `qmk_firmware/keyboards` try to determine the keyboard name that way
-        relative_cwd = under_qmk_firmware()
+            if relative_cwd and len(relative_cwd.parts) > 1 and relative_cwd.parts[0] == 'keyboards':
+                # Attempt to extract the keyboard name from the current directory
+                current_path = Path('/'.join(relative_cwd.parts[1:]))
 
-        if relative_cwd and len(relative_cwd.parts) > 1 and relative_cwd.parts[0] == 'keyboards':
-            current_path = Path('/'.join(relative_cwd.parts[1:]))
+                if 'keymaps' in current_path.parts:
+                    # Strip current_path of anything after `keymaps`
+                    keymap_index = len(current_path.parts) - current_path.parts.index('keymaps') - 1
+                    current_path = current_path.parents[keymap_index]
 
-            if 'keymaps' in current_path.parts:
-                # Strip current_path of anything after `keymaps`
-                keymap_index = len(current_path.parts) - current_path.parts.index('keymaps') - 1
-                current_path = current_path.parents[keymap_index]
-
-            if is_keyboard(current_path):
-                cli.config[cli._entrypoint.__name__]['keyboard'] = str(current_path)
+                if is_keyboard(current_path):
+                    cli.config[cli._entrypoint.__name__]['keyboard'] = str(current_path)
+                    cli.config_source[cli._entrypoint.__name__]['keyboard'] = 'keyboard_directory'
 
         return func(*args, **kwargs)
 
@@ -123,47 +45,40 @@ def automagic_keyboard(func):
 def automagic_keymap(func):
     """Sets `cli.config.<subcommand>.keymap` based on environment.
 
-    This determines the keymap name using the following precedence order:
-
-        * Command line flags (--keymap)
-        * Current working directory
-            * `keyboards/<keyboard_name>/keymaps/<keymap_name>`
-            * `layouts/**/<keymap_name>`
-            * `users/<keymap_name>`
-        * Configuration
-            * cli.config.<subcommand>.keymap
+    This will rewrite cli.config.<subcommand>.keymap if the user did not pass `--keymap` and the directory they are currently in is a keymap, layout, or user directory.
     """
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         # Check to make sure their copy of MILC supports config_source
         if not hasattr(cli, 'config_source'):
-            cli.log.error("Your QMK CLI is out of date. Please upgrade using pip3 or your package manager.")
+            cli.log.error("This subcommand requires a newer version of the QMK CLI. Please upgrade using `pip3 install --upgrade qmk` or your package manager.")
             exit(1)
 
-        # If the keyboard or keymap are passed as arguments use that in preference to anything else
-        if cli.config_source[cli._entrypoint.__name__]['keymap'] == 'argument':
-            return func(*args, **kwargs)
+        # Ensure that `--keymap` was not passed and that we're under `qmk_firmware`
+        if cli.config_source[cli._entrypoint.__name__]['keymap'] != 'argument':
+            relative_cwd = under_qmk_firmware()
 
-        # Check our current directory for a keymap name
-        relative_cwd = under_qmk_firmware()
+            if relative_cwd and len(relative_cwd.parts) > 1:
+                # If we're in `qmk_firmware/keyboards` and `keymaps` is in our path, try to find the keyboard name.
+                if relative_cwd.parts[0] == 'keyboards' and 'keymaps' in relative_cwd.parts:
+                    current_path = Path('/'.join(relative_cwd.parts[1:]))  # Strip 'keyboards' from the front
 
-        if relative_cwd and len(relative_cwd.parts) > 1:
-            # If we're in `qmk_firmware/keyboards` and `keymaps` is in our path, try to find the keyboard name.
-            if relative_cwd.parts[0] == 'keyboards' and 'keymaps' in relative_cwd.parts:
-                current_path = Path('/'.join(relative_cwd.parts[1:]))  # Strip 'keyboards' from the front
+                    if 'keymaps' in current_path.parts and current_path.name != 'keymaps':
+                        while current_path.parent.name != 'keymaps':
+                            current_path = current_path.parent
+                        cli.config[cli._entrypoint.__name__]['keymap'] = current_path.name
+                        cli.config_source[cli._entrypoint.__name__]['keyboard'] = 'keymap_directory'
 
-                if 'keymaps' in current_path.parts and current_path.name != 'keymaps':
-                    while current_path.parent.name != 'keymaps':
-                        current_path = current_path.parent
-                    cli.config[cli._entrypoint.__name__]['keymap'] = current_path.name
+                # If we're in `qmk_firmware/layouts` guess the name from the community keymap they're in
+                elif relative_cwd.parts[0] == 'layouts' and is_keymap_dir(relative_cwd):
+                    cli.config[cli._entrypoint.__name__]['keymap'] = relative_cwd.name
+                    cli.config_source[cli._entrypoint.__name__]['keyboard'] = 'layouts_directory'
 
-            elif relative_cwd.parts[0] == 'layouts' and is_keymap_dir(relative_cwd):
-                # Guess the keymap name from the community keymap they're in
-                cli.config[cli._entrypoint.__name__]['keymap'] = relative_cwd.name
-
-            elif relative_cwd.parts[0] == 'users':
-                # Guess the keymap name based on which userspace they're in
-                cli.config[cli._entrypoint.__name__]['keymap'] = relative_cwd.parts[1]
+                # If we're in `qmk_firmware/users` guess the name from the userspace they're in
+                elif relative_cwd.parts[0] == 'users':
+                    # Guess the keymap name based on which userspace they're in
+                    cli.config[cli._entrypoint.__name__]['keymap'] = relative_cwd.parts[1]
+                    cli.config_source[cli._entrypoint.__name__]['keyboard'] = 'users_directory'
 
         return func(*args, **kwargs)
 

--- a/lib/python/qmk/decorators.py
+++ b/lib/python/qmk/decorators.py
@@ -1,0 +1,170 @@
+"""Helpful decorators that subcommands can use.
+"""
+import functools
+from pathlib import Path
+
+from milc import cli
+
+from qmk.path import is_keyboard, is_keymap_dir, under_qmk_firmware
+
+
+def context_sensitivity(func):
+    """Sets `cli.config.<subcommand>.keyboard` and `cli.config.<subcommand>.keymap` based on environment.
+
+    This determines the keyboard and keymap name using the following precedence order:
+
+        * Command line flags (--keyboard and --keymap)
+        * Current working directory
+            * `keyboards/<keyboard_name>`
+            * `keyboards/<keyboard_name>/keymaps/<keymap_name>`
+            * `layouts/**/<keymap_name>`
+            * `users/<keymap_name>`
+        * Configuration
+            * cli.config.<subcommand>.keyboard
+            * cli.config.<subcommand>.keymap
+    """
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        # Check to make sure their copy of MILC supports config_source
+        if not hasattr(cli, 'config_source'):
+            cli.log.error("Your QMK CLI is out of date. Please upgrade using pip3 or your package manager.")
+            exit(1)
+
+        # State variables
+        relative_cwd = under_qmk_firmware()
+        keyboard_name = ""
+        keymap_name = ""
+
+        # If the keyboard or keymap are passed as arguments use that in preference to anything else
+        if cli.config_source[cli._entrypoint.__name__]['keyboard'] == 'argument':
+            keyboard_name = cli.config[cli._entrypoint.__name__]['keyboard']
+
+        if cli.config_source[cli._entrypoint.__name__]['keymap'] == 'argument':
+            keymap_name = cli.config[cli._entrypoint.__name__]['keymap']
+
+        if not keyboard_name or not keymap_name:
+            # If we don't have a keyboard_name and keymap_name from arguments try to derive one or both
+            if relative_cwd and len(relative_cwd.parts) > 1:
+                # Try to determine based on being in `qmk_firmware/keyboards`
+                if relative_cwd.parts[0] == 'keyboards':
+                    current_path = Path('/'.join(relative_cwd.parts[1:]))  # Remove 'keyboards' from the front of the path
+
+                    if current_path.parts[-2] == 'keymaps':
+                        if not keymap_name:
+                            keymap_name = current_path.parts[-1]
+                        if not keyboard_name:
+                            keyboard_name = '/'.join(current_path.parts[:-2])
+                    elif not keyboard_name and is_keyboard(current_path):
+                        keyboard_name = str(current_path)
+
+                # Try to determine based on being in `qmk_firmware/layouts`
+                elif relative_cwd.parts[0] == 'layouts':
+                    if is_keymap_dir(relative_cwd) and not keymap_name:
+                        keymap_name = relative_cwd.name
+
+                # Try to determine based on being in `qmk_firmware/users`
+                elif relative_cwd.parts[0] == 'users':
+                    if not keymap_name and len(relative_cwd.parts) > 1:
+                        keymap_name = relative_cwd.parts[1]
+
+        # If we have a keyboard/keymap name overwrite the config
+        if keyboard_name:
+            cli.config[cli._entrypoint.__name__]['keyboard'] = keyboard_name
+
+        if keymap_name:
+            cli.config[cli._entrypoint.__name__]['keymap'] = keymap_name
+
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+def automagic_keyboard(func):
+    """Sets `cli.config.<subcommand>.keyboard` based on environment.
+
+    This determines the keyboard name using the following precedence order:
+
+        * Command line flags (--keyboard)
+        * Current working directory
+            * `keyboards/<keyboard_name>`
+        * Configuration
+            * cli.config.<subcommand>.keyboard
+    """
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        # Check to make sure their copy of MILC supports config_source
+        if not hasattr(cli, 'config_source'):
+            cli.log.error("Your QMK CLI is out of date. Please upgrade using pip3 or your package manager.")
+            exit(1)
+
+        # If the keyboard or keymap are passed as arguments use that in preference to anything else
+        if cli.config_source[cli._entrypoint.__name__]['keyboard'] == 'argument':
+            return func(*args, **kwargs)
+
+        # If the user is in `qmk_firmware/keyboards` try to determine the keyboard name that way
+        relative_cwd = under_qmk_firmware()
+
+        if relative_cwd and len(relative_cwd.parts) > 1 and relative_cwd.parts[0] == 'keyboards':
+            current_path = Path('/'.join(relative_cwd.parts[1:]))
+
+            if 'keymaps' in current_path.parts:
+                # Strip current_path of anything after `keymaps`
+                keymap_index = len(current_path.parts) - current_path.parts.index('keymaps') - 1
+                current_path = current_path.parents[keymap_index]
+
+            if is_keyboard(current_path):
+                cli.config[cli._entrypoint.__name__]['keyboard'] = str(current_path)
+
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+def automagic_keymap(func):
+    """Sets `cli.config.<subcommand>.keymap` based on environment.
+
+    This determines the keymap name using the following precedence order:
+
+        * Command line flags (--keymap)
+        * Current working directory
+            * `keyboards/<keyboard_name>/keymaps/<keymap_name>`
+            * `layouts/**/<keymap_name>`
+            * `users/<keymap_name>`
+        * Configuration
+            * cli.config.<subcommand>.keymap
+    """
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        # Check to make sure their copy of MILC supports config_source
+        if not hasattr(cli, 'config_source'):
+            cli.log.error("Your QMK CLI is out of date. Please upgrade using pip3 or your package manager.")
+            exit(1)
+
+        # If the keyboard or keymap are passed as arguments use that in preference to anything else
+        if cli.config_source[cli._entrypoint.__name__]['keymap'] == 'argument':
+            return func(*args, **kwargs)
+
+        # Check our current directory for a keymap name
+        relative_cwd = under_qmk_firmware()
+
+        if relative_cwd and len(relative_cwd.parts) > 1:
+            # If we're in `qmk_firmware/keyboards` and `keymaps` is in our path, try to find the keyboard name.
+            if relative_cwd.parts[0] == 'keyboards' and 'keymaps' in relative_cwd.parts:
+                current_path = Path('/'.join(relative_cwd.parts[1:]))  # Strip 'keyboards' from the front
+
+                if 'keymaps' in current_path.parts and current_path.name != 'keymaps':
+                    while current_path.parent.name != 'keymaps':
+                        current_path = current_path.parent
+                    cli.config[cli._entrypoint.__name__]['keymap'] = current_path.name
+
+            elif relative_cwd.parts[0] == 'layouts' and is_keymap_dir(relative_cwd):
+                # Guess the keymap name from the community keymap they're in
+                cli.config[cli._entrypoint.__name__]['keymap'] = relative_cwd.name
+
+            elif relative_cwd.parts[0] == 'users':
+                # Guess the keymap name based on which userspace they're in
+                cli.config[cli._entrypoint.__name__]['keymap'] = relative_cwd.parts[1]
+
+        return func(*args, **kwargs)
+
+    return wrapper

--- a/lib/python/qmk/path.py
+++ b/lib/python/qmk/path.py
@@ -65,6 +65,6 @@ def normpath(path):
     path = Path(path)
 
     if path.is_absolute():
-        return Path(path)
+        return path
 
     return Path(os.environ['ORIG_CWD']) / path


### PR DESCRIPTION
Based on @Erovia's brilliant POC I've created two decorators that can be used to determine keyboard or keymap names from the user's current working directory.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Enhancement/optimization

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
