### PR TITLE
V-USB interrupt enable fix

### DIFF
--- a/tmk_core/protocol/vusb/main.c
+++ b/tmk_core/protocol/vusb/main.c
@@ -59,11 +59,11 @@ int main(void) {
 #endif
     keyboard_setup();
 
-    keyboard_init();
     host_set_driver(vusb_driver());
-
     debug("initForUsbConnectivity()\n");
     initForUsbConnectivity();
+
+    keyboard_init();
 
     debug("main loop\n");
     while (1) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
As discussed here: https://github.com/qmk/qmk_firmware/issues/8193

In vusb main, the interrupt enable was after `keyboard_init();`. As a result, the debouncing was not working correctly to capture the first press of the bootmagic lite key.

Now the USB stack is initialized, then the usb connection is initialized, interrupt is enabled and finally `keyboard_init();`.

Thanks to @fauxpark for his help.

Tested on gingham with 328p

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/qmk/qmk_firmware/issues/8193

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
