### PR TITLE
Allow 30us matrix delay to be keyboard/user overridable 

### DIFF
--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -53,6 +53,8 @@ This is a C header file that is one of the first things included, and will persi
   * pins of the rows, from top to bottom
 * `#define MATRIX_COL_PINS { F1, F0, B0, C7, F4, F5, F6, F7, D4, D6, B4, D7 }`
   * pins of the columns, from left to right
+* `#define MATRIX_IO_DELAY 30`
+  * the delay in microseconds when between changing matrix pin state and reading values
 * `#define UNUSED_PINS { D1, D2, D3, B1, B2, B3 }`
   * pins unused by the keyboard for reference
 * `#define MATRIX_HAS_GHOST`

--- a/quantum/matrix.c
+++ b/quantum/matrix.c
@@ -16,7 +16,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include <stdint.h>
 #include <stdbool.h>
-#include "wait.h"
 #include "util.h"
 #include "matrix.h"
 #include "debounce.h"

--- a/quantum/matrix.c
+++ b/quantum/matrix.c
@@ -94,7 +94,7 @@ static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
 
     // Select row and wait for row selecton to stabilize
     select_row(current_row);
-    wait_us(30);
+    wait_us(MATRIX_IO_DELAY);
 
     // For each col...
     for (uint8_t col_index = 0; col_index < MATRIX_COLS; col_index++) {
@@ -138,7 +138,7 @@ static bool read_rows_on_col(matrix_row_t current_matrix[], uint8_t current_col)
 
     // Select col and wait for col selecton to stabilize
     select_col(current_col);
-    wait_us(30);
+    wait_us(MATRIX_IO_DELAY);
 
     // For each row...
     for (uint8_t row_index = 0; row_index < MATRIX_ROWS; row_index++) {

--- a/quantum/matrix.c
+++ b/quantum/matrix.c
@@ -94,7 +94,7 @@ static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
 
     // Select row and wait for row selecton to stabilize
     select_row(current_row);
-    wait_us(MATRIX_IO_DELAY);
+    matrix_io_delay();
 
     // For each col...
     for (uint8_t col_index = 0; col_index < MATRIX_COLS; col_index++) {
@@ -138,7 +138,7 @@ static bool read_rows_on_col(matrix_row_t current_matrix[], uint8_t current_col)
 
     // Select col and wait for col selecton to stabilize
     select_col(current_col);
-    wait_us(MATRIX_IO_DELAY);
+    matrix_io_delay();
 
     // For each row...
     for (uint8_t row_index = 0; row_index < MATRIX_ROWS; row_index++) {

--- a/quantum/matrix_common.c
+++ b/quantum/matrix_common.c
@@ -1,5 +1,6 @@
 #include "matrix.h"
 #include "debounce.h"
+#include "wait.h"
 #include "print.h"
 #include "debug.h"
 

--- a/quantum/matrix_common.c
+++ b/quantum/matrix_common.c
@@ -3,6 +3,10 @@
 #include "print.h"
 #include "debug.h"
 
+#ifndef MATRIX_IO_DELAY
+#    define MATRIX_IO_DELAY 30
+#endif
+
 /* matrix state(1:on, 0:off) */
 matrix_row_t raw_matrix[MATRIX_ROWS];
 matrix_row_t matrix[MATRIX_ROWS];
@@ -77,6 +81,8 @@ uint8_t matrix_key_count(void) {
     }
     return count;
 }
+
+__attribute__((weak)) void matrix_io_delay(void) { wait_us(MATRIX_IO_DELAY); }
 
 // CUSTOM MATRIX 'LITE'
 __attribute__((weak)) void matrix_init_custom(void) {}

--- a/quantum/split_common/matrix.c
+++ b/quantum/split_common/matrix.c
@@ -16,7 +16,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include <stdint.h>
 #include <stdbool.h>
-#include "wait.h"
 #include "util.h"
 #include "matrix.h"
 #include "debounce.h"

--- a/quantum/split_common/matrix.c
+++ b/quantum/split_common/matrix.c
@@ -111,7 +111,7 @@ static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
 
     // Select row and wait for row selecton to stabilize
     select_row(current_row);
-    wait_us(30);
+    wait_us(MATRIX_IO_DELAY);
 
     // For each col...
     for (uint8_t col_index = 0; col_index < MATRIX_COLS; col_index++) {
@@ -155,7 +155,7 @@ static bool read_rows_on_col(matrix_row_t current_matrix[], uint8_t current_col)
 
     // Select col and wait for col selecton to stabilize
     select_col(current_col);
-    wait_us(30);
+    wait_us(MATRIX_IO_DELAY);
 
     // For each row...
     for (uint8_t row_index = 0; row_index < ROWS_PER_HAND; row_index++) {

--- a/quantum/split_common/matrix.c
+++ b/quantum/split_common/matrix.c
@@ -111,7 +111,7 @@ static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
 
     // Select row and wait for row selecton to stabilize
     select_row(current_row);
-    wait_us(MATRIX_IO_DELAY);
+    matrix_io_delay();
 
     // For each col...
     for (uint8_t col_index = 0; col_index < MATRIX_COLS; col_index++) {
@@ -155,7 +155,7 @@ static bool read_rows_on_col(matrix_row_t current_matrix[], uint8_t current_col)
 
     // Select col and wait for col selecton to stabilize
     select_col(current_col);
-    wait_us(MATRIX_IO_DELAY);
+    matrix_io_delay();
 
     // For each row...
     for (uint8_t row_index = 0; row_index < ROWS_PER_HAND; row_index++) {

--- a/tmk_core/common/matrix.h
+++ b/tmk_core/common/matrix.h
@@ -40,6 +40,10 @@ typedef uint32_t matrix_col_t;
 #    error "MATRIX_ROWS: invalid value"
 #endif
 
+#ifndef MATRIX_IO_DELAY
+#    define MATRIX_IO_DELAY 30
+#endif
+
 #define MATRIX_ROW_SHIFTER ((matrix_row_t)1)
 
 #define MATRIX_IS_ON(row, col) (matrix_get_row(row) && (1 << col))

--- a/tmk_core/common/matrix.h
+++ b/tmk_core/common/matrix.h
@@ -40,10 +40,6 @@ typedef uint32_t matrix_col_t;
 #    error "MATRIX_ROWS: invalid value"
 #endif
 
-#ifndef MATRIX_IO_DELAY
-#    define MATRIX_IO_DELAY 30
-#endif
-
 #define MATRIX_ROW_SHIFTER ((matrix_row_t)1)
 
 #define MATRIX_IS_ON(row, col) (matrix_get_row(row) && (1 << col))
@@ -70,6 +66,8 @@ bool matrix_is_on(uint8_t row, uint8_t col);
 matrix_row_t matrix_get_row(uint8_t row);
 /* print matrix for debug */
 void matrix_print(void);
+/* delay between changing matrix pin state and reading values */
+void matrix_io_delay(void);
 
 /* power control */
 void matrix_power_up(void);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Hitting some limits when testing the arm uart serial code, this allows the delay while waiting for IO to settle to be configurable.

Ive tested as low as 5us with success.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
