### PR TITLE
Update Dvorak, Colemak and Workman keycode aliases

### DIFF
--- a/quantum/keymap_extras/keymap_colemak.h
+++ b/quantum/keymap_extras/keymap_colemak.h
@@ -13,78 +13,145 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef KEYMAP_COLEMAK_H
-#define KEYMAP_COLEMAK_H
+
+#pragma once
 
 #include "keymap.h"
-// For software implementation of colemak
-#define CM_Q KC_Q
-#define CM_W KC_W
-#define CM_F KC_E
-#define CM_P KC_R
-#define CM_G KC_T
-#define CM_J KC_Y
-#define CM_L KC_U
-#define CM_U KC_I
-#define CM_Y KC_O
-#define CM_SCLN KC_P
 
-#define CM_A KC_A
-#define CM_R KC_S
-#define CM_S KC_D
-#define CM_T KC_F
-#define CM_D KC_G
-#define CM_H KC_H
-#define CM_N KC_J
-#define CM_E KC_K
-#define CM_I KC_L
-#define CM_O KC_SCLN
-#define CM_COLN LSFT(CM_SCLN)
+// clang-format off
 
-#define CM_Z KC_Z
-#define CM_X KC_X
-#define CM_C KC_C
-#define CM_V KC_V
-#define CM_B KC_B
-#define CM_K KC_N
-#define CM_M KC_M
-#define CM_COMM KC_COMM
-#define CM_DOT KC_DOT
-#define CM_SLSH KC_SLSH
+/*
+ * ┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───────┐
+ * │ ` │ 1 │ 2 │ 3 │ 4 │ 5 │ 6 │ 7 │ 8 │ 9 │ 0 │ - │ = │       │
+ * ├───┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─────┤
+ * │     │ Q │ W │ F │ P │ G │ J │ L │ U │ Y │ ; │ [ │ ] │  \  │
+ * ├─────┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴─────┤
+ * │      │ A │ R │ S │ T │ D │ H │ N │ E │ I │ O │ ' │        │
+ * ├──────┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴────────┤
+ * │        │ Z │ X │ C │ V │ B │ K │ M │ , │ . │ / │          │
+ * ├────┬───┴┬──┴─┬─┴───┴───┴───┴───┴───┴──┬┴───┼───┴┬────┬────┤
+ * │    │    │    │                        │    │    │    │    │
+ * └────┴────┴────┴────────────────────────┴────┴────┴────┴────┘
+ */
+// Row 1
+#define CM_GRV  KC_GRV  // `
+#define CM_1    KC_1    // 1
+#define CM_2    KC_2    // 2
+#define CM_3    KC_3    // 3
+#define CM_4    KC_4    // 4
+#define CM_5    KC_5    // 5
+#define CM_6    KC_6    // 6
+#define CM_7    KC_7    // 7
+#define CM_8    KC_8    // 8
+#define CM_9    KC_9    // 9
+#define CM_0    KC_0    // 0
+#define CM_MINS KC_MINS // -
+#define CM_EQL  KC_EQL  // =
+// Row 2
+#define CM_Q    KC_Q    // Q
+#define CM_W    KC_W    // W
+#define CM_F    KC_E    // F
+#define CM_P    KC_R    // P
+#define CM_G    KC_T    // G
+#define CM_J    KC_Y    // J
+#define CM_L    KC_U    // L
+#define CM_U    KC_I    // U
+#define CM_Y    KC_O    // Y
+#define CM_SCLN KC_P    // ;
+#define CM_LBRC KC_LBRC // [
+#define CM_RBRC KC_RBRC // ]
+#define CM_BSLS KC_BSLS // (backslash)
+// Row 3
+#define CM_A    KC_A    // A
+#define CM_R    KC_S    // R
+#define CM_S    KC_D    // S
+#define CM_T    KC_F    // T
+#define CM_D    KC_G    // D
+#define CM_H    KC_H    // H
+#define CM_N    KC_J    // N
+#define CM_E    KC_K    // E
+#define CM_I    KC_L    // I
+#define CM_O    KC_SCLN // O
+#define CM_QUOT KC_QUOT // '
+// Row 4
+#define CM_Z    KC_Z    // Z
+#define CM_X    KC_X    // X
+#define CM_C    KC_C    // C
+#define CM_V    KC_V    // V
+#define CM_B    KC_B    // B
+#define CM_K    KC_N    // K
+#define CM_M    KC_M    // M
+#define CM_COMM KC_COMM // ,
+#define CM_DOT  KC_DOT  // .
+#define CM_SLSH KC_SLSH // /
 
-// Make it easy to support these in macros
-// TODO: change macro implementation so these aren't needed
-#define KC_CM_Q CM_Q
-#define KC_CM_W CM_W
-#define KC_CM_F CM_F
-#define KC_CM_P CM_P
-#define KC_CM_G CM_G
-#define KC_CM_J CM_J
-#define KC_CM_L CM_L
-#define KC_CM_U CM_U
-#define KC_CM_Y CM_Y
+/* Shifted symbols
+ * ┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───────┐
+ * │ ~ │ ! │ @ │ # │ $ │ % │ ^ │ & │ * │ ( │ ) │ _ │ + │       │
+ * ├───┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─────┤
+ * │     │   │   │   │   │   │   │   │   │   │ : │ { │ } │  |  │
+ * ├─────┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴─────┤
+ * │      │   │   │   │   │   │   │   │   │   │   │ " │        │
+ * ├──────┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴────────┤
+ * │        │   │   │   │   │   │   │   │ < │ > │ ? │          │
+ * ├────┬───┴┬──┴─┬─┴───┴───┴───┴───┴───┴──┬┴───┼───┴┬────┬────┤
+ * │    │    │    │                        │    │    │    │    │
+ * └────┴────┴────┴────────────────────────┴────┴────┴────┴────┘
+ */
+// Row 1
+#define CM_TILD S(CM_GRV)  // ~
+#define CM_EXLM S(CM_1)    // !
+#define CM_AT   S(CM_2)    // @
+#define CM_HASH S(CM_3)    // #
+#define CM_DLR  S(CM_4)    // $
+#define CM_PERC S(CM_5)    // %
+#define CM_CIRC S(CM_6)    // ^
+#define CM_AMPR S(CM_7)    // &
+#define CM_ASTR S(CM_8)    // *
+#define CM_LPRN S(CM_9)    // (
+#define CM_RPRN S(CM_0)    // )
+#define CM_UNDS S(CM_MINS) // _
+#define CM_PLUS S(CM_EQL)  // +
+// Row 2
+#define CM_COLN S(CM_SCLN) // :
+#define CM_LCBR S(CM_LBRC) // {
+#define CM_RCBR S(CM_RBRC) // }
+#define CM_PIPE S(CM_BSLS) // |
+// Row 3
+#define CM_DQUO S(CM_QUOT) // "
+// Row 4
+#define CM_LABK S(CM_COMM) // <
+#define CM_RABK S(CM_DOT)  // >
+#define CM_QUES S(CM_SLSH) // /
+
+// DEPRECATED
+#define KC_CM_Q    CM_Q
+#define KC_CM_W    CM_W
+#define KC_CM_F    CM_F
+#define KC_CM_P    CM_P
+#define KC_CM_G    CM_G
+#define KC_CM_J    CM_J
+#define KC_CM_L    CM_L
+#define KC_CM_U    CM_U
+#define KC_CM_Y    CM_Y
 #define KC_CM_SCLN CM_SCLN
-
-#define KC_CM_A CM_A
-#define KC_CM_R CM_R
-#define KC_CM_S CM_S
-#define KC_CM_T CM_T
-#define KC_CM_D CM_D
-#define KC_CM_H CM_H
-#define KC_CM_N CM_N
-#define KC_CM_E CM_E
-#define KC_CM_I CM_I
-#define KC_CM_O CM_O
-
-#define KC_CM_Z CM_Z
-#define KC_CM_X CM_X
-#define KC_CM_C CM_C
-#define KC_CM_V CM_V
-#define KC_CM_B CM_B
-#define KC_CM_K CM_K
-#define KC_CM_M CM_M
+#define KC_CM_A    CM_A
+#define KC_CM_R    CM_R
+#define KC_CM_S    CM_S
+#define KC_CM_T    CM_T
+#define KC_CM_D    CM_D
+#define KC_CM_H    CM_H
+#define KC_CM_N    CM_N
+#define KC_CM_E    CM_E
+#define KC_CM_I    CM_I
+#define KC_CM_O    CM_O
+#define KC_CM_Z    CM_Z
+#define KC_CM_X    CM_X
+#define KC_CM_C    CM_C
+#define KC_CM_V    CM_V
+#define KC_CM_B    CM_B
+#define KC_CM_K    CM_K
+#define KC_CM_M    CM_M
 #define KC_CM_COMM CM_COMM
-#define KC_CM_DOT CM_DOT
+#define KC_CM_DOT  CM_DOT
 #define KC_CM_SLSH CM_SLSH
-
-#endif

--- a/quantum/keymap_extras/keymap_dvorak.h
+++ b/quantum/keymap_extras/keymap_dvorak.h
@@ -13,88 +13,113 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef KEYMAP_DVORAK_H
-#define KEYMAP_DVORAK_H
+
+#pragma once
 
 #include "keymap.h"
 
-// Normal characters
-#define DV_GRV KC_GRV
-#define DV_1 KC_1
-#define DV_2 KC_2
-#define DV_3 KC_3
-#define DV_4 KC_4
-#define DV_5 KC_5
-#define DV_6 KC_6
-#define DV_7 KC_7
-#define DV_8 KC_8
-#define DV_9 KC_9
-#define DV_0 KC_0
-#define DV_LBRC KC_MINS
-#define DV_RBRC KC_EQL
+// clang-format off
 
-#define DV_QUOT KC_Q
-#define DV_COMM KC_W
-#define DV_DOT KC_E
-#define DV_P KC_R
-#define DV_Y KC_T
-#define DV_F KC_Y
-#define DV_G KC_U
-#define DV_C KC_I
-#define DV_R KC_O
-#define DV_L KC_P
-#define DV_SLSH KC_LBRC
-#define DV_EQL KC_RBRC
-#define DV_BSLS KC_BSLS
+/*
+ * ┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───────┐
+ * │ ` │ 1 │ 2 │ 3 │ 4 │ 5 │ 6 │ 7 │ 8 │ 9 │ 0 │ [ │ ] │       │
+ * ├───┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─────┤
+ * │     │ ' │ , │ . │ P │ Y │ F │ G │ C │ R │ L │ / │ = │  \  │
+ * ├─────┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴─────┤
+ * │      │ A │ O │ E │ U │ I │ D │ H │ T │ N │ S │ - │        │
+ * ├──────┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴────────┤
+ * │        │ ; │ Q │ J │ K │ X │ B │ M │ W │ V │ Z │          │
+ * ├────┬───┴┬──┴─┬─┴───┴───┴───┴───┴───┴──┬┴───┼───┴┬────┬────┤
+ * │    │    │    │                        │    │    │    │    │
+ * └────┴────┴────┴────────────────────────┴────┴────┴────┴────┘
+ */
+// Row 1
+#define DV_GRV  KC_GRV  // `
+#define DV_1    KC_1    // 1
+#define DV_2    KC_2    // 2
+#define DV_3    KC_3    // 3
+#define DV_4    KC_4    // 4
+#define DV_5    KC_5    // 5
+#define DV_6    KC_6    // 6
+#define DV_7    KC_7    // 7
+#define DV_8    KC_8    // 8
+#define DV_9    KC_9    // 9
+#define DV_0    KC_0    // 0
+#define DV_LBRC KC_MINS // [
+#define DV_RBRC KC_EQL  // ]
+// Row 2
+#define DV_QUOT KC_Q    // '
+#define DV_COMM KC_W    // ,
+#define DV_DOT  KC_E    // .
+#define DV_P    KC_R    // P
+#define DV_Y    KC_T    // Y
+#define DV_F    KC_Y    // F
+#define DV_G    KC_U    // G
+#define DV_C    KC_I    // C
+#define DV_R    KC_O    // R
+#define DV_L    KC_P    // L
+#define DV_SLSH KC_LBRC // /
+#define DV_EQL  KC_RBRC // =
+#define DV_BSLS KC_BSLS // (backslash)
+// Row 3
+#define DV_A    KC_A    // A
+#define DV_O    KC_S    // O
+#define DV_E    KC_D    // E
+#define DV_U    KC_F    // U
+#define DV_I    KC_G    // I
+#define DV_D    KC_H    // D
+#define DV_H    KC_J    // H
+#define DV_T    KC_K    // T
+#define DV_N    KC_L    // N
+#define DV_S    KC_SCLN // S
+#define DV_MINS KC_QUOT // -
+// Row 4
+#define DV_SCLN KC_Z    // ;
+#define DV_Q    KC_X    // Q
+#define DV_J    KC_C    // J
+#define DV_K    KC_V    // K
+#define DV_X    KC_B    // X
+#define DV_B    KC_N    // B
+#define DV_M    KC_M    // M
+#define DV_W    KC_COMM // W
+#define DV_V    KC_DOT  // V
+#define DV_Z    KC_SLSH // Z
 
-#define DV_A KC_A
-#define DV_O KC_S
-#define DV_E KC_D
-#define DV_U KC_F
-#define DV_I KC_G
-#define DV_D KC_H
-#define DV_H KC_J
-#define DV_T KC_K
-#define DV_N KC_L
-#define DV_S KC_SCLN
-#define DV_MINS KC_QUOT
-
-#define DV_SCLN KC_Z
-#define DV_Q KC_X
-#define DV_J KC_C
-#define DV_K KC_V
-#define DV_X KC_B
-#define DV_B KC_N
-#define DV_M KC_M
-#define DV_W KC_COMM
-#define DV_V KC_DOT
-#define DV_Z KC_SLSH
-
-// Shifted characters
-#define DV_TILD LSFT(DV_GRV)
-#define DV_EXLM LSFT(DV_1)
-#define DV_AT LSFT(DV_2)
-#define DV_HASH LSFT(DV_3)
-#define DV_DLR LSFT(DV_4)
-#define DV_PERC LSFT(DV_5)
-#define DV_CIRC LSFT(DV_6)
-#define DV_AMPR LSFT(DV_7)
-#define DV_ASTR LSFT(DV_8)
-#define DV_LPRN LSFT(DV_9)
-#define DV_RPRN LSFT(DV_0)
-#define DV_LCBR LSFT(DV_LBRC)
-#define DV_RCBR LSFT(DV_RBRC)
-
-#define DV_DQUO LSFT(DV_QUOT)
-#define DV_LABK LSFT(DV_COMM)
-#define DV_RABK LSFT(DV_DOT)
-
-#define DV_QUES LSFT(DV_SLSH)
-#define DV_PLUS LSFT(DV_EQL)
-#define DV_PIPE LSFT(DV_BSLS)
-
-#define DV_UNDS LSFT(DV_MINS)
-
-#define DV_COLN LSFT(DV_SCLN)
-
-#endif
+/* Shifted symbols
+ * ┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───────┐
+ * │ ~ │ ! │ @ │ # │ $ │ % │ ^ │ & │ * │ ( │ ) │ { │ } │       │
+ * ├───┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─────┤
+ * │     │ " │ < │ > │   │   │   │   │   │   │   │ ? │ + │  |  │
+ * ├─────┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴─────┤
+ * │      │   │   │   │   │   │   │   │   │   │   │ _ │        │
+ * ├──────┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴────────┤
+ * │        │ : │   │   │   │   │   │   │   │   │   │          │
+ * ├────┬───┴┬──┴─┬─┴───┴───┴───┴───┴───┴──┬┴───┼───┴┬────┬────┤
+ * │    │    │    │                        │    │    │    │    │
+ * └────┴────┴────┴────────────────────────┴────┴────┴────┴────┘
+ */
+// Row 1
+#define DV_TILD S(DV_GRV)  // ~
+#define DV_EXLM S(DV_1)    // !
+#define DV_AT   S(DV_2)    // @
+#define DV_HASH S(DV_3)    // #
+#define DV_DLR  S(DV_4)    // $
+#define DV_PERC S(DV_5)    // %
+#define DV_CIRC S(DV_6)    // ^
+#define DV_AMPR S(DV_7)    // &
+#define DV_ASTR S(DV_8)    // *
+#define DV_LPRN S(DV_9)    // (
+#define DV_RPRN S(DV_0)    // )
+#define DV_LCBR S(DV_LBRC) // {
+#define DV_RCBR S(DV_RBRC) // }
+// Row 2
+#define DV_DQUO S(DV_QUOT) // "
+#define DV_LABK S(DV_COMM) // <
+#define DV_RABK S(DV_DOT)  // >
+#define DV_QUES S(DV_SLSH) // ?
+#define DV_PLUS S(DV_EQL)  // +
+#define DV_PIPE S(DV_BSLS) // |
+// Row 3
+#define DV_UNDS S(DV_MINS) // _
+// Row 4
+#define DV_COLN S(DV_SCLN) // :

--- a/quantum/keymap_extras/keymap_workman.h
+++ b/quantum/keymap_extras/keymap_workman.h
@@ -87,19 +87,42 @@
 
 /* Shifted symbols
  * ┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───────┐
- * │   │   │   │   │   │   │   │   │   │   │   │   │   │       │
+ * │ ~ │ ! │ @ │ # │ $ │ % │ ^ │ & │ * │ ( │ ) │ _ │ + │       │
  * ├───┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─────┤
- * │     │   │   │   │   │   │   │   │   │   │ : │   │   │     │
+ * │     │   │   │   │   │   │   │   │   │   │ : │ { │ } │  |  │
  * ├─────┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴─────┤
- * │      │   │   │   │   │   │   │   │   │   │   │   │        │
+ * │      │   │   │   │   │   │   │   │   │   │   │ " │        │
  * ├──────┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴────────┤
- * │        │   │   │   │   │   │   │   │   │   │   │          │
+ * │        │   │   │   │   │   │   │   │ < │ > │ ? │          │
  * ├────┬───┴┬──┴─┬─┴───┴───┴───┴───┴───┴──┬┴───┼───┴┬────┬────┤
  * │    │    │    │                        │    │    │    │    │
  * └────┴────┴────┴────────────────────────┴────┴────┴────┴────┘
  */
+// Row 1
+#define WK_TILD S(WK_GRV)  // ~
+#define WK_EXLM S(WK_1)    // !
+#define WK_AT   S(WK_2)    // @
+#define WK_HASH S(WK_3)    // #
+#define WK_DLR  S(WK_4)    // $
+#define WK_PERC S(WK_5)    // %
+#define WK_CIRC S(WK_6)    // ^
+#define WK_AMPR S(WK_7)    // &
+#define WK_ASTR S(WK_8)    // *
+#define WK_LPRN S(WK_9)    // (
+#define WK_RPRN S(WK_0)    // )
+#define WK_UNDS S(WK_MINS) // _
+#define WK_PLUS S(WK_EQL)  // +
 // Row 2
 #define WK_COLN S(WK_SCLN) // :
+#define WK_LCBR S(WK_LBRC) // {
+#define WK_RCBR S(WK_RBRC) // }
+#define WK_PIPE S(WK_BSLS) // |
+// Row 3
+#define WK_DQUO S(WK_QUOT) // "
+// Row 4
+#define WK_LABK S(WK_COMM) // <
+#define WK_RABK S(WK_DOT)  // >
+#define WK_QUES S(WK_SLSH) // ?
 
 // DEPRECATED
 #define KC_WK_Q    WK_Q

--- a/quantum/keymap_extras/keymap_workman.h
+++ b/quantum/keymap_extras/keymap_workman.h
@@ -13,71 +13,119 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef KEYMAP_WORKMAN_H
-#define KEYMAP_WORKMAN_H
+
+#pragma once
 
 #include "keymap.h"
-// For software implementation of workman
-#define WK_Q KC_Q
-#define WK_D KC_W
-#define WK_R KC_E
-#define WK_W KC_R
-#define WK_B KC_T
-#define WK_J KC_Y
-#define WK_F KC_U
-#define WK_U KC_I
-#define WK_P KC_O
-#define WK_SCLN KC_P
 
-#define WK_A KC_A
-#define WK_S KC_S
-#define WK_H KC_D
-#define WK_T KC_F
-#define WK_G KC_G
-#define WK_Y KC_H
-#define WK_N KC_J
-#define WK_E KC_K
-#define WK_O KC_L
-#define WK_I KC_SCLN
+// clang-format off
 
-#define WK_Z KC_Z
-#define WK_X KC_X
-#define WK_M KC_C
-#define WK_C KC_V
-#define WK_V KC_B
-#define WK_K KC_N
-#define WK_L KC_M
+/*
+ * ┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───────┐
+ * │ ` │ 1 │ 2 │ 3 │ 4 │ 5 │ 6 │ 7 │ 8 │ 9 │ 0 │ - │ = │       │
+ * ├───┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─────┤
+ * │     │ Q │ D │ R │ W │ B │ J │ F │ U │ P │ ; │ [ │ ] │  \  │
+ * ├─────┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴─────┤
+ * │      │ A │ S │ H │ T │ G │ Y │ N │ E │ O │ I │ ' │        │
+ * ├──────┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴────────┤
+ * │        │ Z │ X │ M │ C │ V │ K │ L │ , │ . │ / │          │
+ * ├────┬───┴┬──┴─┬─┴───┴───┴───┴───┴───┴──┬┴───┼───┴┬────┬────┤
+ * │    │    │    │                        │    │    │    │    │
+ * └────┴────┴────┴────────────────────────┴────┴────┴────┴────┘
+ */
+// Row 1
+#define WK_GRV  KC_GRV  // `
+#define WK_1    KC_1    // 1
+#define WK_2    KC_2    // 2
+#define WK_3    KC_3    // 3
+#define WK_4    KC_4    // 4
+#define WK_5    KC_5    // 5
+#define WK_6    KC_6    // 6
+#define WK_7    KC_7    // 7
+#define WK_8    KC_8    // 8
+#define WK_9    KC_9    // 9
+#define WK_0    KC_0    // 0
+#define WK_MINS KC_MINS // -
+#define WK_EQL  KC_EQL  // =
+// Row 2
+#define WK_Q    KC_Q    // Q
+#define WK_D    KC_W    // D
+#define WK_R    KC_E    // R
+#define WK_W    KC_R    // W
+#define WK_B    KC_T    // B
+#define WK_J    KC_Y    // J
+#define WK_F    KC_U    // F
+#define WK_U    KC_I    // U
+#define WK_P    KC_O    // P
+#define WK_SCLN KC_P    // ;
+#define WK_LBRC KC_LBRC // [
+#define WK_RBRC KC_RBRC // ]
+#define WK_BSLS KC_BSLS // (backslash)
+// Row 3
+#define WK_A    KC_A    // A
+#define WK_S    KC_S    // S
+#define WK_H    KC_D    // H
+#define WK_T    KC_F    // T
+#define WK_G    KC_G    // G
+#define WK_Y    KC_H    // Y
+#define WK_N    KC_J    // N
+#define WK_E    KC_K    // E
+#define WK_O    KC_L    // O
+#define WK_I    KC_SCLN // I
+#define WK_QUOT KC_QUOT // '
+// Row 4
+#define WK_Z    KC_Z    // Z
+#define WK_X    KC_X    // X
+#define WK_M    KC_C    // M
+#define WK_C    KC_V    // C
+#define WK_V    KC_B    // V
+#define WK_K    KC_N    // K
+#define WK_L    KC_M    // L
+#define WK_COMM KC_COMM // ,
+#define WK_DOT  KC_DOT  // .
+#define WK_SLSH KC_SLSH // /
 
-// Make it easy to support these in macros
-// TODO: change macro implementation so these aren't needed
-#define KC_WK_Q WK_Q
-#define KC_WK_D WK_D
-#define KC_WK_R WK_R
-#define KC_WK_W WK_W
-#define KC_WK_B WK_B
-#define KC_WK_J WK_J
-#define KC_WK_F WK_F
-#define KC_WK_U WK_U
-#define KC_WK_P WK_P
+/* Shifted symbols
+ * ┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───────┐
+ * │   │   │   │   │   │   │   │   │   │   │   │   │   │       │
+ * ├───┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─────┤
+ * │     │   │   │   │   │   │   │   │   │   │ : │   │   │     │
+ * ├─────┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴─────┤
+ * │      │   │   │   │   │   │   │   │   │   │   │   │        │
+ * ├──────┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴────────┤
+ * │        │   │   │   │   │   │   │   │   │   │   │          │
+ * ├────┬───┴┬──┴─┬─┴───┴───┴───┴───┴───┴──┬┴───┼───┴┬────┬────┤
+ * │    │    │    │                        │    │    │    │    │
+ * └────┴────┴────┴────────────────────────┴────┴────┴────┴────┘
+ */
+// Row 2
+#define WK_COLN S(WK_SCLN) // :
+
+// DEPRECATED
+#define KC_WK_Q    WK_Q
+#define KC_WK_D    WK_D
+#define KC_WK_R    WK_R
+#define KC_WK_W    WK_W
+#define KC_WK_B    WK_B
+#define KC_WK_J    WK_J
+#define KC_WK_F    WK_F
+#define KC_WK_U    WK_U
+#define KC_WK_P    WK_P
 #define KC_WK_SCLN WK_SCLN
-
-#define KC_WK_A WK_A
-#define KC_WK_S WK_S
-#define KC_WK_H WK_H
-#define KC_WK_T WK_T
-#define KC_WK_G WK_G
-#define KC_WK_Y WK_Y
-#define KC_WK_N WK_N
-#define KC_WK_E WK_E
-#define KC_WK_O WK_O
-#define KC_WK_I WK_I
-
-#define KC_WK_Z WK_Z
-#define KC_WK_X WK_X
-#define KC_WK_M WK_M
-#define KC_WK_C WK_C
-#define KC_WK_V WK_V
-#define KC_WK_K WK_K
-#define KC_WK_L WK_L
-
-#endif
+#define KC_WK_A    WK_A
+#define KC_WK_S    WK_S
+#define KC_WK_H    WK_H
+#define KC_WK_T    WK_T
+#define KC_WK_G    WK_G
+#define KC_WK_Y    WK_Y
+#define KC_WK_N    WK_N
+#define KC_WK_E    WK_E
+#define KC_WK_O    WK_O
+#define KC_WK_I    WK_I
+#define KC_WK_Z    WK_Z
+#define KC_WK_X    WK_X
+#define KC_WK_M    WK_M
+#define KC_WK_C    WK_C
+#define KC_WK_V    WK_V
+#define KC_WK_K    WK_K
+#define KC_WK_L    WK_L

--- a/quantum/keymap_extras/sendstring_colemak.h
+++ b/quantum/keymap_extras/sendstring_colemak.h
@@ -33,27 +33,27 @@ const uint8_t ascii_to_keycode_lut[128] PROGMEM = {
     XXXXXXX, XXXXXXX, XXXXXXX, KC_ESC,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
 
     //       !        "        #        $        %        &        '
-    KC_SPC,  KC_1,    KC_QUOT, KC_3,    KC_4,    KC_5,    KC_7,    KC_QUOT,
+    KC_SPC,  CM_1,    CM_QUOT, CM_3,    CM_4,    CM_5,    CM_7,    CM_QUOT,
     // (     )        *        +        ,        -        .        /
-    KC_9,    KC_0,    KC_8,    KC_EQL,  KC_COMM, KC_MINS, KC_DOT,  KC_SLSH,
+    CM_9,    CM_0,    CM_8,    CM_EQL,  CM_COMM, CM_MINS, CM_DOT,  CM_SLSH,
     // 0     1        2        3        4        5        6        7
-    KC_0,    KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,
+    CM_0,    CM_1,    CM_2,    CM_3,    CM_4,    CM_5,    CM_6,    CM_7,
     // 8     9        :        ;        <        =        >        ?
-    KC_8,    KC_9,    CM_SCLN, CM_SCLN, KC_COMM, KC_EQL,  KC_DOT,  KC_SLSH,
+    CM_8,    CM_9,    CM_SCLN, CM_SCLN, CM_COMM, CM_EQL,  CM_DOT,  CM_SLSH,
     // @     A        B        C        D        E        F        G
-    KC_2,    CM_A,    CM_B,    CM_C,    CM_D,    CM_E,    CM_F,    CM_G,
+    CM_2,    CM_A,    CM_B,    CM_C,    CM_D,    CM_E,    CM_F,    CM_G,
     // H     I        J        K        L        M        N        O
     CM_H,    CM_I,    CM_J,    CM_K,    CM_L,    CM_M,    CM_N,    CM_O,
     // P     Q        R        S        T        U        V        W
     CM_P,    CM_Q,    CM_R,    CM_S,    CM_T,    CM_U,    CM_V,    CM_W,
     // X     Y        Z        [        \        ]        ^        _
-    CM_X,    CM_Y,    CM_Z,    KC_LBRC, KC_BSLS, KC_RBRC, KC_6,    KC_MINS,
+    CM_X,    CM_Y,    CM_Z,    CM_LBRC, CM_BSLS, CM_RBRC, CM_6,    CM_MINS,
     // `     a        b        c        d        e        f        g
-    KC_GRV,  CM_A,    CM_B,    CM_C,    CM_D,    CM_E,    CM_F,    CM_G,
+    CM_GRV,  CM_A,    CM_B,    CM_C,    CM_D,    CM_E,    CM_F,    CM_G,
     // h     i        j        k        l        m        n        o
     CM_H,    CM_I,    CM_J,    CM_K,    CM_L,    CM_M,    CM_N,    CM_O,
     // p     q        r        s        t        u        v        w
     CM_P,    CM_Q,    CM_R,    CM_S,    CM_T,    CM_U,    CM_V,    CM_W,
     // x     y        z        {        |        }        ~        DEL
-    CM_X,    CM_Y,    CM_Z,    KC_LBRC, KC_BSLS, KC_RBRC, KC_GRV,  KC_DEL
+    CM_X,    CM_Y,    CM_Z,    CM_LBRC, CM_BSLS, CM_RBRC, CM_GRV,  KC_DEL
 };

--- a/quantum/keymap_extras/sendstring_workman.h
+++ b/quantum/keymap_extras/sendstring_workman.h
@@ -33,27 +33,27 @@ const uint8_t ascii_to_keycode_lut[128] PROGMEM = {
     XXXXXXX, XXXXXXX, XXXXXXX, KC_ESC,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
 
     //       !        "        #        $        %        &        '
-    KC_SPC,  KC_1,    KC_QUOT, KC_3,    KC_4,    KC_5,    KC_7,    KC_QUOT,
+    KC_SPC,  WK_1,    WK_QUOT, WK_3,    WK_4,    WK_5,    WK_7,    WK_QUOT,
     // (     )        *        +        ,        -        .        /
-    KC_9,    KC_0,    KC_8,    KC_EQL,  KC_COMM, KC_MINS, KC_DOT,  KC_SLSH,
+    WK_9,    WK_0,    WK_8,    WK_EQL,  WK_COMM, WK_MINS, WK_DOT,  WK_SLSH,
     // 0     1        2        3        4        5        6        7
-    KC_0,    KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,
+    WK_0,    WK_1,    WK_2,    WK_3,    WK_4,    WK_5,    WK_6,    WK_7,
     // 8     9        :        ;        <        =        >        ?
-    KC_8,    KC_9,    KC_SCLN, KC_SCLN, KC_COMM, KC_EQL,  KC_DOT,  KC_SLSH,
+    WK_8,    WK_9,    WK_SCLN, WK_SCLN, WK_COMM, WK_EQL,  WK_DOT,  WK_SLSH,
     // @     A        B        C        D        E        F        G
-    KC_2,    WK_A,    WK_B,    WK_C,    WK_D,    WK_E,    WK_F,    WK_G,
+    WK_2,    WK_A,    WK_B,    WK_C,    WK_D,    WK_E,    WK_F,    WK_G,
     // H     I        J        K        L        M        N        O
     WK_H,    WK_I,    WK_J,    WK_K,    WK_L,    WK_M,    WK_N,    WK_O,
     // P     Q        R        S        T        U        V        W
     WK_P,    WK_Q,    WK_R,    WK_S,    WK_T,    WK_U,    WK_V,    WK_W,
     // X     Y        Z        [        \        ]        ^        _
-    WK_X,    WK_Y,    WK_Z,    KC_LBRC, KC_BSLS, KC_RBRC, KC_6,    KC_MINS,
+    WK_X,    WK_Y,    WK_Z,    WK_LBRC, WK_BSLS, WK_RBRC, WK_6,    WK_MINS,
     // `     a        b        c        d        e        f        g
-    KC_GRV,  WK_A,    WK_B,    WK_C,    WK_D,    WK_E,    WK_F,    WK_G,
+    WK_GRV,  WK_A,    WK_B,    WK_C,    WK_D,    WK_E,    WK_F,    WK_G,
     // h     i        j        k        l        m        n        o
     WK_H,    WK_I,    WK_J,    WK_K,    WK_L,    WK_M,    WK_N,    WK_O,
     // p     q        r        s        t        u        v        w
     WK_P,    WK_Q,    WK_R,    WK_S,    WK_T,    WK_U,    WK_V,    WK_W,
     // x     y        z        {        |        }        ~        DEL
-    WK_X,    WK_Y,    WK_Z,    KC_LBRC, KC_BSLS, KC_RBRC, KC_GRV,  KC_DEL
+    WK_X,    WK_Y,    WK_Z,    WK_LBRC, WK_BSLS, WK_RBRC, WK_GRV,  KC_DEL
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Now on to some more keymap_extras stuff. The `KC_` prefixed aliases have been deprecated as they are an artifact of the old macro system and `_kc` layouts.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
