### PR TITLE
Add Guix manifest

### DIFF
--- a/docs/getting_started_build_tools.md
+++ b/docs/getting_started_build_tools.md
@@ -56,6 +56,14 @@ By default, this will download compilers for both AVR and ARM. If you don't need
 
     nix-shell --arg arm false
 
+## Guix
+
+If your're on [Guix](http://guix.gnu.org/) or have Guix installed in your Linux, you can use a guix environment in order to work in the project making use of the manifest file provided by the repository.
+
+```
+guix environment --manifest=guix-manifest.scm
+```
+
 ## macOS
 If you're using [Homebrew](http://brew.sh/), you can use the following commands:
 

--- a/guix-manifest.scm
+++ b/guix-manifest.scm
@@ -5,6 +5,7 @@
     "wget"
     "dfu-programmer"
     "dfu-util"
-    "avr-toolchain@4.9"
+    "avr-toolchain"
+    "glibc"
     "gcc-toolchain"
-    "arm-none-eabi-toolchain"))
+    "python"))

--- a/guix-manifest.scm
+++ b/guix-manifest.scm
@@ -1,0 +1,10 @@
+(specifications->manifest
+  '("unzip"
+    "zip"
+    "git"
+    "wget"
+    "dfu-programmer"
+    "dfu-util"
+    "avr-toolchain@4.9"
+    "gcc-toolchain"
+    "arm-none-eabi-toolchain"))


### PR DESCRIPTION
Add guix manifest to make guix environments like `guix environment --manifest=guix-manifest.scm`

- It's not configurable at the moment.
- AVR-Toolchain is 4.9 version because 5.5 package is broken, see [help-guix mailing list](https://lists.gnu.org/archive/html/help-guix/2020-02/msg00195.html)