### PR TITLE
Split - Avoid race condition during matrix_init_quantum

### DIFF
--- a/quantum/split_common/matrix.c
+++ b/quantum/split_common/matrix.c
@@ -191,7 +191,7 @@ static bool read_rows_on_col(matrix_row_t current_matrix[], uint8_t current_col)
 #endif
 
 void matrix_init(void) {
-    keyboard_split_setup();
+    split_pre_init();
 
     // Set pinout for right half if pinout for that half is defined
     if (!isLeftHand) {
@@ -232,6 +232,8 @@ void matrix_init(void) {
     debounce_init(ROWS_PER_HAND);
 
     matrix_init_quantum();
+
+    split_post_init();
 }
 
 void matrix_post_scan(void) {

--- a/quantum/split_common/split_util.c
+++ b/quantum/split_common/split_util.c
@@ -103,7 +103,7 @@ void split_pre_init(void) {
 }
 
 // this code runs after the keyboard is fully initialized
-//   - avoids race condidion during matrix_init_quantum where slave can start
+//   - avoids race condition during matrix_init_quantum where slave can start
 //     receiving before the init process has completed
 void split_post_init(void) {
     if (!is_keyboard_master()) {

--- a/quantum/split_common/split_util.c
+++ b/quantum/split_common/split_util.c
@@ -81,19 +81,8 @@ __attribute__((weak)) bool is_keyboard_master(void) {
     return (usbstate == MASTER);
 }
 
-static void keyboard_master_setup(void) {
-#if defined(USE_I2C)
-#    ifdef SSD1306OLED
-    matrix_master_OLED_init();
-#    endif
-#endif
-    transport_master_init();
-}
-
-static void keyboard_slave_setup(void) { transport_slave_init(); }
-
 // this code runs before the keyboard is fully initialized
-void keyboard_split_setup(void) {
+void split_pre_init(void) {
     isLeftHand = is_keyboard_left();
 
 #if defined(RGBLIGHT_ENABLE) && defined(RGBLED_SPLIT)
@@ -106,8 +95,18 @@ void keyboard_split_setup(void) {
 #endif
 
     if (is_keyboard_master()) {
-        keyboard_master_setup();
-    } else {
-        keyboard_slave_setup();
+#if defined(USE_I2C) && defined(SSD1306OLED)
+        matrix_master_OLED_init();
+#endif
+        transport_master_init();
+    }
+}
+
+// this code runs after the keyboard is fully initialized
+//   - avoids race condidion during matrix_init_quantum where slave can start
+//     receiving before the init process has completed
+void split_post_init(void) {
+    if (!is_keyboard_master()) {
+        transport_slave_init();
     }
 }

--- a/quantum/split_common/split_util.h
+++ b/quantum/split_common/split_util.h
@@ -8,4 +8,5 @@
 extern volatile bool isLeftHand;
 
 void matrix_master_OLED_init(void);
-void keyboard_split_setup(void);
+void split_pre_init(void);
+void split_post_init(void);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Made much worse by the `SPLIT_USB_DETECT` mode, there is a window where the slave side has is interrupt handler registered before its init process has finished. Given this interrupt can jump in at any point, it breaks some single threaded assumptions within the codebase.

Order of events:
1. master powers on - begin init
2. slave powers on - begin init
3. master detects USB quickly - finish init
    * as part of init finish, RGB is set to eeprom values
4. master runs `post_init` which triggers RGB sync
5. slave receives sync and sets RGB
6. slave times out on USB detect - finishes init
    * as part of init finish, RGB is set to eeprom values

What you expect is that both halves share the same RGB config, however what actually happens is the slave side has the eeprom values set till the next animation tick (30 seconds).

While difficult, i have managed to reproduce this without the `SPLIT_USB_DETECT` mode.

With this change, interrupt handlers are registered after init. Any rgb syncs will then fail, and be retried till the slave starts to respond (after its init process has completed).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
