### PR TITLE
Hineybush h87a lock indicators

### DIFF
--- a/keyboards/hineybush/h87a/h87a.c
+++ b/keyboards/hineybush/h87a/h87a.c
@@ -18,7 +18,8 @@
 void matrix_init_kb(void) {
 	// put your keyboard start-up code here
 	// runs once when the firmware starts up
-
+   	setPinOutput(D5);
+    setPinOutput(E6);
 	matrix_init_user();
 }
 
@@ -40,6 +41,14 @@ void led_set_kb(uint8_t usb_led) {
 	// put your keyboard LED indicator (ex: Caps Lock LED) toggling code here
 
 	led_set_user(usb_led);
+}
+
+bool led_update_kb(led_t led_state) {
+    if(led_update_user(led_state)) {
+        writePin(D5, !led_state.caps_lock);
+        writePin(E6, !led_state.scroll_lock);
+    }
+    return true;
 }
 
 void eeconfig_init_kb(void) {  // EEPROM is getting reset!

--- a/keyboards/hineybush/h87a/keymaps/default/keymap.c
+++ b/keyboards/hineybush/h87a/keymaps/default/keymap.c
@@ -46,24 +46,3 @@ void matrix_scan_user(void) {
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
   return true;
 }
-
-void led_init_ports(void) {
-  DDRD |= (1<<5); // OUT
-  DDRE |= (1<<6); // OUT
-}
-
-void led_set_user(uint8_t usb_led) {
-
-  if (usb_led & (1 << USB_LED_CAPS_LOCK)) {
-    DDRD |= (1 << 5); PORTD &= ~(1 << 5);
-  } else {
-    DDRD &= ~(1 << 5); PORTD &= ~(1 << 5);
-  }
-
-  if (usb_led & (1 << USB_LED_SCROLL_LOCK)) {
-    DDRE |= (1 << 6); PORTE &= ~(1 << 6);
-  } else {
-    DDRE &= ~(1 << 6); PORTE &= ~(1 << 6);
-  }
-
-}

--- a/keyboards/hineybush/h87a/keymaps/via/keymap.c
+++ b/keyboards/hineybush/h87a/keymaps/via/keymap.c
@@ -51,13 +51,22 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 };
 
-void led_init_ports(void) {
-    setPinOutput(D5);
-    setPinOutput(E6);
-}
+// void led_init_ports(void) {
+//     setPinOutput(D5);
+//     setPinOutput(E6);
+// }
 
-bool led_update_user(led_t led_state) {
-    writePin(D5, !led_state.caps_lock);
-    writePin(E6, !led_state.scroll_lock);
-    return true;
-}
+// bool led_update_user(led_t led_state) {
+//     writePin(D5, !led_state.caps_lock);
+//     writePin(E6, !led_state.scroll_lock);
+//     return true;
+// }
+
+
+// bool led_update_kb(led_t led_state) {
+//     if(led_update_user(led_state)) {
+//         writePin(E6, !led_state.caps_lock);
+//         writePin(B2, !led_state.scroll_lock);
+//     }
+//     return true;
+// }

--- a/keyboards/hineybush/h87a/keymaps/via/keymap.c
+++ b/keyboards/hineybush/h87a/keymaps/via/keymap.c
@@ -50,23 +50,3 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS),
 
 };
-
-// void led_init_ports(void) {
-//     setPinOutput(D5);
-//     setPinOutput(E6);
-// }
-
-// bool led_update_user(led_t led_state) {
-//     writePin(D5, !led_state.caps_lock);
-//     writePin(E6, !led_state.scroll_lock);
-//     return true;
-// }
-
-
-// bool led_update_kb(led_t led_state) {
-//     if(led_update_user(led_state)) {
-//         writePin(E6, !led_state.caps_lock);
-//         writePin(B2, !led_state.scroll_lock);
-//     }
-//     return true;
-// }

--- a/keyboards/hineybush/h87a/keymaps/wkl/keymap.c
+++ b/keyboards/hineybush/h87a/keymaps/wkl/keymap.c
@@ -46,26 +46,3 @@ void matrix_scan_user(void) {
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
   return true;
 }
-
-void led_init_ports(void) {
-  setPinOutput(D5);
-  setPinOutput(E6);
-}
-
-void led_set_user(uint8_t usb_led) {
-
-  if (IS_LED_ON(usb_led, USB_LED_CAPS_LOCK)) {
-    setPinOutput(D5);
-    writePinLow(D5);
-  } else {
-    setPinInput(D5);
-  }
-
-  if (IS_LED_ON(usb_led, USB_LED_SCROLL_LOCK)) {
-    setPinOutput(E6);
-    writePinLow(E6);
-  } else {
-    setPinInput(E6);
-  }
-
-}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Reported to me by wholesomeducky on discord. When using the VIA enabled firmware, his locking indicators were not working as expected. Tagging @hineybush for visibility. 

To fix this I updated the led code used in the VIA keymap and moved it to h87a.c so that all keymaps can make use of this. Wholesomeducky has confirmed that my changes work. 

I also had to speak with both default and wkl about changing their user keymaps. They weren't too happy, but after a few beers and some arm wrestling matches, they conceded. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
