### PR TITLE
Fix MCU rule for Wete

### DIFF
--- a/keyboards/wete/rules.mk
+++ b/keyboards/wete/rules.mk
@@ -1,5 +1,5 @@
 # MCU name
-MCU = STM32F072xB
+MCU = STM32F072
 
 # Build Options
 #   comment out to disable the options.


### PR DESCRIPTION
## Description

Including the `xB` suffix prevents qmk_compiler (and thus QMK Configurator) from compiling firmware for the Wete.

Rolling this change back until we work out a long-term solution for the suffixes.

@ramonimbao This is why Configurator can't compile your board.

## Types of Changes

- [x] Bugfix
- [x] Keyboard (addition or update)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
