### PR TITLE
Unconditionally enable ChibiOS syscalls

### DIFF
--- a/tmk_core/chibios.mk
+++ b/tmk_core/chibios.mk
@@ -125,7 +125,7 @@ CHIBISRC = $(STARTUPSRC) \
        $(PLATFORMSRC_CONTRIB) \
        $(BOARDSRC) \
        $(STREAMSSRC) \
-	   $(CHIBIOS)/os/various/syscalls.c
+       $(CHIBIOS)/os/various/syscalls.c
 
 # Ensure the ASM files are not subjected to LTO -- it'll strip out interrupt handlers otherwise.
 QUANTUM_LIB_SRC += $(STARTUPASM) $(PORTASM) $(OSALASM)

--- a/tmk_core/chibios.mk
+++ b/tmk_core/chibios.mk
@@ -124,7 +124,8 @@ CHIBISRC = $(STARTUPSRC) \
        $(PLATFORMSRC) \
        $(PLATFORMSRC_CONTRIB) \
        $(BOARDSRC) \
-       $(STREAMSSRC)
+       $(STREAMSSRC) \
+	   $(CHIBIOS)/os/various/syscalls.c
 
 # Ensure the ASM files are not subjected to LTO -- it'll strip out interrupt handlers otherwise.
 QUANTUM_LIB_SRC += $(STARTUPASM) $(PORTASM) $(OSALASM)

--- a/tmk_core/common.mk
+++ b/tmk_core/common.mk
@@ -27,21 +27,11 @@ TMK_COMMON_SRC +=	$(COMMON_DIR)/host.c \
 
 ifeq ($(PLATFORM),AVR)
   TMK_COMMON_SRC += $(PLATFORM_COMMON_DIR)/xprintf.S
-endif
-
-ifeq ($(PLATFORM),CHIBIOS)
+else ifeq ($(PLATFORM),CHIBIOS)
   TMK_COMMON_SRC += $(PLATFORM_COMMON_DIR)/printf.c
-  ifeq ($(strip $(AUTO_SHIFT_ENABLE)), yes)
-    TMK_COMMON_SRC += $(CHIBIOS)/os/various/syscalls.c
-  else ifeq ($(strip $(TERMINAL_ENABLE)), yes)
-    TMK_COMMON_SRC += $(CHIBIOS)/os/various/syscalls.c
-  endif
-endif
-
-ifeq ($(PLATFORM),ARM_ATSAM)
+else ifeq ($(PLATFORM),ARM_ATSAM)
   TMK_COMMON_SRC += $(PLATFORM_COMMON_DIR)/printf.c
 endif
-
 
 # Option modules
 BOOTMAGIC_ENABLE ?= no


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
As ChibiOS syscalls is already used within in a few scenarios, this enables by default so that we avoid some of the issues within #7059.

Been using this for a while now and not seen issues :man_shrugging:, but then we only alloc in limited circumstances ( otherwise a lot more builds would be failing).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #7059
* Fixes `make 1upkeyboards/sweet16/v2/proton_c:switchtester`

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
