### PR TITLE
fix typo

### DIFF
--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -643,7 +643,7 @@ void matrix_scan_quantum() {
 //
 
 void send_dword(uint32_t number) {  // this might not actually work
-    uint16_tword = (number >> 16);
+    uint16_t word = (number >> 16);
     send_word(word);
     send_word(number & 0xFFFFUL);
 }


### PR DESCRIPTION

## Description

I can't build on current master. 1ec8a7205f1719496e043776edcc972125fc57e3 

```
Compiling: quantum/quantum.c                                                                       quantum/quantum.c: In function 'send_dword':
quantum/quantum.c:646:5: error: 'uint16_tword' undeclared (first use in this function); did you mean 'uint16_t'?
     uint16_tword = (number >> 16);
     ^~~~~~~~~~~~
     uint16_t
```

So, I think `uint16_tword`  is typo.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

No Issues

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
