### PR TITLE
Fix recent clang-format breaking quantum.c

### DIFF
--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -642,8 +642,8 @@ void matrix_scan_quantum() {
 // Functions for spitting out values
 //
 
-void send_dword(uint32_t number) {  // this might not actually work
-    uint16_tword = (number >> 16);
+void send_dword(uint32_t number) {
+    uint16_t word = (number >> 16);
     send_word(word);
     send_word(number & 0xFFFFUL);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

* doesnt happen with clang-format-8
  * not easy to get into the environment
* doesnt happen on 7 if i remove a comment...
  * fragile so something to keep an eye on
  * maybe need to change the process to catch this sort of error in the future


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
