### PR TITLE
Plain60C layout that is KBP-V60 like

### DIFF
--- a/keyboards/maartenwut/plain60/keymaps/kbp-v60/keymap.c
+++ b/keyboards/maartenwut/plain60/keymaps/kbp-v60/keymap.c
@@ -1,0 +1,27 @@
+#include QMK_KEYBOARD_H
+
+// Each layer gets a name for readability, which is then used in the keymap matrix below.
+// The underscores don't mean anything - you can have a layer called STUFF or any other name.
+// Layer names don't all need to be of the same length, obviously, and you can also skip them
+// entirely and just use numbers.
+enum _layer {
+  _MA,
+  _FN
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+[_MA] = LAYOUT(
+  KC_ESC,  KC_1,    KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSLS, KC_BSPC, \
+  KC_TAB,  KC_Q,    KC_W,   KC_E,   KC_R,   KC_T,   KC_Y,   KC_U,   KC_I,   KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS,          \
+  MO(_FN), KC_A,    KC_S,   KC_D,   KC_F,   KC_G,   KC_H,   KC_J,   KC_K,   KC_L,    KC_SCLN, KC_QUOT, KC_BSLS, KC_ENT,           \
+  KC_LSFT, KC_NUBS, KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,   KC_N,   KC_M,   KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT, LT(_FN, KC_UP),   \
+  KC_LCTL, KC_LGUI, KC_LALT,                        KC_SPC,                          MO(_FN), KC_ALGR , LT(_FN, KC_APP),  KC_RCTRL),
+
+[_FN] = LAYOUT(
+  KC_GRV,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  _______, KC_DEL, \
+  KC_CAPS, _______, KC_UP,   _______, KC_BSPC, KC_PSCR, KC_PGUP, KC_HOME, KC_END,  KC_HOME, KC_UP,   KC_END,  _______, KC_PGUP,\
+  _______, KC_LEFT, KC_DOWN, KC_RIGHT,KC_DEL,  KC_SLCK, KC_PGDN, KC_TILD, KC_INS,  KC_LEFT, KC_DOWN, KC_RIGHT,         KC_PGDN,\
+  _______, _______, _______, _______, _______, _______, _______, _______, KC_VOLD, KC_VOLU, KC_MUTE, _______, KC_BTN1, KC_MS_U,\
+  _______, _______, _______,                   _______,                            _______, _______, _______, KC_MS_L, KC_MS_D),
+};

--- a/keyboards/maartenwut/plain60/keymaps/kbp-v60/readme.md
+++ b/keyboards/maartenwut/plain60/keymaps/kbp-v60/readme.md
@@ -1,0 +1,3 @@
+# KBP V60 like TADA68 layout
+
+This layout resembles the KBParadise V60 FN layer and moves around some keys.

--- a/keyboards/maartenwut/plain60/keymaps/kbp-v60/rules.mk
+++ b/keyboards/maartenwut/plain60/keymaps/kbp-v60/rules.mk
@@ -1,0 +1,5 @@
+# Build Options
+#   comment out to disable the options.
+#
+BOOTMAGIC_ENABLE = lite	# Virtual DIP switch configuration(+1000)
+NKRO_ENABLE = yes	# USB Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Keymap for Plain-60C PCB that mimics KBP V60 keyboards.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Added a keymap for Plain-60C PCB that mimics KBP V60 keyboards.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
