### PR TITLE
Remove "ugly hack in usb_main.c" comments

### DIFF
--- a/keyboards/at_at/660m/config.h
+++ b/keyboards/at_at/660m/config.h
@@ -21,8 +21,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0xA22A
 #define PRODUCT_ID      0x6600
 #define DEVICE_VER      0x0001
-/* in python2: list(u"whatever".encode('utf-16-le')) */
-/*   at most 32 characters or the ugly hack in usb_main.c borks */
 #define MANUFACTURER    AT-AT
 #define PRODUCT         660M
 #define DESCRIPTION     660M Keyboard

--- a/keyboards/cannonkeys/an_c/config.h
+++ b/keyboards/cannonkeys/an_c/config.h
@@ -21,8 +21,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0xCA04
 #define PRODUCT_ID      0xA00C
 #define DEVICE_VER      0x0001
-/* in python2: list(u"whatever".encode('utf-16-le')) */
-/*   at most 32 characters or the ugly hack in usb_main.c borks */
 #define MANUFACTURER CannonKeys
 #define PRODUCT AN-C
 #define DESCRIPTION AN-C Keyboard

--- a/keyboards/cannonkeys/chimera65/config.h
+++ b/keyboards/cannonkeys/chimera65/config.h
@@ -21,8 +21,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0xCA04
 #define PRODUCT_ID      0xC024
 #define DEVICE_VER      0x0001
-/* in python2: list(u"whatever".encode('utf-16-le')) */
-/*   at most 32 characters or the ugly hack in usb_main.c borks */
 #define MANUFACTURER CannonKeys
 #define PRODUCT Chimera65
 #define DESCRIPTION Chimera65 Keyboard

--- a/keyboards/cannonkeys/instant60/config.h
+++ b/keyboards/cannonkeys/instant60/config.h
@@ -21,8 +21,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0xCA04
 #define PRODUCT_ID      0x1600
 #define DEVICE_VER      0x0001
-/* in python2: list(u"whatever".encode('utf-16-le')) */
-/*   at most 32 characters or the ugly hack in usb_main.c borks */
 #define MANUFACTURER CannonKeys
 #define PRODUCT Instant60
 #define DESCRIPTION Instant 60 Keyboard

--- a/keyboards/cannonkeys/iron165/config.h
+++ b/keyboards/cannonkeys/iron165/config.h
@@ -21,8 +21,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0x5A12
 #define PRODUCT_ID      0x5165
 #define DEVICE_VER      0x0001
-/* in python2: list(u"whatever".encode('utf-16-le')) */
-/*   at most 32 characters or the ugly hack in usb_main.c borks */
 #define MANUFACTURER SmithAndRune
 #define PRODUCT Iron165
 #define DESCRIPTION Iron165 Keyboard

--- a/keyboards/cannonkeys/ortho48/config.h
+++ b/keyboards/cannonkeys/ortho48/config.h
@@ -21,8 +21,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0xCA04
 #define PRODUCT_ID      0x0248
 #define DEVICE_VER      0x0001
-/* in python2: list(u"whatever".encode('utf-16-le')) */
-/*   at most 32 characters or the ugly hack in usb_main.c borks */
 #define MANUFACTURER QMK
 #define PRODUCT Ortho48
 #define DESCRIPTION Ortho48

--- a/keyboards/cannonkeys/ortho60/config.h
+++ b/keyboards/cannonkeys/ortho60/config.h
@@ -21,8 +21,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0xFEED
 #define PRODUCT_ID      0x6464
 #define DEVICE_VER      0x0001
-/* in python2: list(u"whatever".encode('utf-16-le')) */
-/*   at most 32 characters or the ugly hack in usb_main.c borks */
 #define MANUFACTURER QMK
 #define PRODUCT Ortho60
 #define DESCRIPTION Ortho60

--- a/keyboards/cannonkeys/ortho75/config.h
+++ b/keyboards/cannonkeys/ortho75/config.h
@@ -21,8 +21,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0xFEED
 #define PRODUCT_ID      0x6464
 #define DEVICE_VER      0x0001
-/* in python2: list(u"whatever".encode('utf-16-le')) */
-/*   at most 32 characters or the ugly hack in usb_main.c borks */
 #define MANUFACTURER CannonKeys
 #define PRODUCT Ortho75
 #define DESCRIPTION Ortho75

--- a/keyboards/cannonkeys/practice60/config.h
+++ b/keyboards/cannonkeys/practice60/config.h
@@ -21,8 +21,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0xFEED
 #define PRODUCT_ID      0x6464
 #define DEVICE_VER      0x0001
-/* in python2: list(u"whatever".encode('utf-16-le')) */
-/*   at most 32 characters or the ugly hack in usb_main.c borks */
 #define MANUFACTURER QMK
 #define PRODUCT Practice 60
 #define DESCRIPTION Practice 60

--- a/keyboards/cannonkeys/practice65/config.h
+++ b/keyboards/cannonkeys/practice65/config.h
@@ -21,8 +21,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0xCA04
 #define PRODUCT_ID      0x6565
 #define DEVICE_VER      0x0001
-/* in python2: list(u"whatever".encode('utf-16-le')) */
-/*   at most 32 characters or the ugly hack in usb_main.c borks */
 #define MANUFACTURER CannonKeys
 #define PRODUCT Practice 65
 #define DESCRIPTION Practice 65

--- a/keyboards/cannonkeys/satisfaction75/config.h
+++ b/keyboards/cannonkeys/satisfaction75/config.h
@@ -21,8 +21,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0xCA04
 #define PRODUCT_ID      0x57F5
 #define DEVICE_VER      0x0001
-/* in python2: list(u"whatever".encode('utf-16-le')) */
-/*   at most 32 characters or the ugly hack in usb_main.c borks */
 #define MANUFACTURER CannonKeys
 #define PRODUCT Satisfaction75
 #define DESCRIPTION Satisfaction 75 Keyboard

--- a/keyboards/cannonkeys/savage65/config.h
+++ b/keyboards/cannonkeys/savage65/config.h
@@ -21,8 +21,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0xCA04
 #define PRODUCT_ID      0x5A65
 #define DEVICE_VER      0x0001
-/* in python2: list(u"whatever".encode('utf-16-le')) */
-/*   at most 32 characters or the ugly hack in usb_main.c borks */
 #define MANUFACTURER CannonKeys
 #define PRODUCT Savage65
 #define DESCRIPTION Savage65 Keyboard

--- a/keyboards/cannonkeys/tmov2/config.h
+++ b/keyboards/cannonkeys/tmov2/config.h
@@ -21,8 +21,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0xCA04
 #define PRODUCT_ID      0x70F2
 #define DEVICE_VER      0x0001
-/* in python2: list(u"whatever".encode('utf-16-le')) */
-/*   at most 32 characters or the ugly hack in usb_main.c borks */
 #define MANUFACTURER CannonKeys
 #define PRODUCT TMOv2
 #define DESCRIPTION TMOv2 Keyboard

--- a/keyboards/handwired/bluepill/bluepill70/config.h
+++ b/keyboards/handwired/bluepill/bluepill70/config.h
@@ -4,14 +4,10 @@
 #define VENDOR_ID       0xFEED
 #define PRODUCT_ID      0x6464
 #define DEVICE_VER      0x0001
-/* in python2: list(u"whatever".encode('utf-16-le')) */
-/*   at most 32 characters or the ugly hack in usb_main.c works */
 
 //  Modified by Xydane
 #define MANUFACTURER "QMK"
-#define USBSTR_MANUFACTURER    'T', '\x00', 'M', '\x00', 'K', '\x00', ' ', '\x00', '\xc6', '\x00'
 #define PRODUCT "BluePill70"
-#define USBSTR_PRODUCT         'C', '\x00', 'h', '\x00', 'i', '\x00', 'b', '\x00', 'i', '\x00', 'O', '\x00', 'S', '\x00', ' ', '\x00', 'Q', '\x00', 'M', '\x00', 'K', '\x00'
 #define DESCRIPTION "QMK keyboard firmware with ChibiOS"
 
 /* key matrix size */

--- a/keyboards/handwired/ck4x4/config.h
+++ b/keyboards/handwired/ck4x4/config.h
@@ -21,8 +21,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0xFEED
 #define PRODUCT_ID      0x6464
 #define DEVICE_VER      0x0001
-/* in python2: list(u"whatever".encode('utf-16-le')) */
-/*   at most 32 characters or the ugly hack in usb_main.c borks */
 #define MANUFACTURER QMK
 #define PRODUCT CK4x4
 #define DESCRIPTION Cannon Keys 4x4 MacroPad

--- a/keyboards/hid_liber/config.h
+++ b/keyboards/hid_liber/config.h
@@ -25,9 +25,7 @@
 #define PRODUCT_ID      0xB919
 #define DEVICE_VER      0x0001
 #define MANUFACTURER    "bpiphany"
-#define USBSTR_MANUFACTURER 'b', '\x00', 'p', '\x00', 'i', '\x00', 'p', '\x00', 'h', '\x00', 'a', '\x00', 'n', '\x00', 'y', '\x00'
 #define PRODUCT         "HIDLiberation"
-#define USBSTR_PRODUCT 'H', '\x00', 'I', '\x00', 'D', '\x00', ' ', '\x00', 'L', '\x00', 'i', '\x00', 'b', '\x00', 'e', '\x00', 'r', '\x00', 'a', '\x00', 't', '\x00', 'i', '\x00', 'o', '\x00', 'n', '\x00'
 #define DESCRIPTION     "HID Liberation powered by QMK"
 
 /* key matrix size */

--- a/keyboards/jm60/config.h
+++ b/keyboards/jm60/config.h
@@ -22,8 +22,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0xFEED
 #define PRODUCT_ID      0x6464
 #define DEVICE_VER      0x0001
-/* in python2: list(u"whatever".encode('utf-16-le')) */
-/*   at most 32 characters or the ugly hack in usb_main.c borks */
 #define MANUFACTURER JMWS
 #define PRODUCT JM60 RGB Keyboard(QMK)
 #define DESCRIPTION QMK keyboard firmware for JM60 RGB Keyboard

--- a/keyboards/k_type/config.h
+++ b/keyboards/k_type/config.h
@@ -22,8 +22,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0x1c11
 #define PRODUCT_ID      0xb04d
 #define DEVICE_VER      0x0001
-/* in python2: list(u"whatever".encode('utf-16-le')) */
-/*   at most 32 characters or the ugly hack in usb_main.c borks */
 #define MANUFACTURER Input Club
 #define PRODUCT K-Type/QMK
 /* key matrix size */

--- a/keyboards/projectkb/alice/config.h
+++ b/keyboards/projectkb/alice/config.h
@@ -21,8 +21,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0x0159
 #define PRODUCT_ID      0xA71C
 #define DEVICE_VER      0x0001
-/* in python2: list(u"whatever".encode('utf-16-le')) */
-/*   at most 32 characters or the ugly hack in usb_main.c borks */
 #define MANUFACTURER ProjectKB
 #define PRODUCT Alice
 #define DESCRIPTION ProjectKB Alice

--- a/keyboards/wete/config.h
+++ b/keyboards/wete/config.h
@@ -21,8 +21,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0xB16B
 #define PRODUCT_ID      0x00B5
 #define DEVICE_VER      0x0012
-/* in python2: list(u"whatever".encode('utf-16-le')) */
-/*   at most 32 characters or the ugly hack in usb_main.c borks */
 #define MANUFACTURER Ramon Imbao
 #define PRODUCT Wete
 #define DESCRIPTION Southpaw Full-sized Keyboard

--- a/keyboards/xiaomi/mk02/config.h
+++ b/keyboards/xiaomi/mk02/config.h
@@ -21,8 +21,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0xFEED
 #define PRODUCT_ID      0x0B91
 #define DEVICE_VER      0x0001
-/* in python2: list(u"whatever".encode('utf-16-le')) */
-/*   at most 32 characters or the ugly hack in usb_main.c borks */
 #define MANUFACTURER Xiaomi
 #define PRODUCT MK02
 #define DESCRIPTION Yuemi Pro MK02


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Since ChibiOS now shares its descriptors with LUFA in usb_descriptor.c, this hack no longer exists, and these comments serve no purpose.

https://github.com/tmk/tmk_core/blob/437115bf1f623d19986f8375fe6c6aae52e1d406/protocol/chibios/usb_main.c#L562

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
