### PR TITLE
Remove stub backlight functions from clueboard/66/rev4

### DIFF
--- a/keyboards/clueboard/66/rev4/rev4.c
+++ b/keyboards/clueboard/66/rev4/rev4.c
@@ -8,39 +8,6 @@ void matrix_init_kb(void) {
     led_init_ports();
 }
 
-void matrix_scan_kb(void) {
-    matrix_scan_user();
-}
-
-void backlight_init_ports(void) {
-    print("init_backlight_pin()\n");
-    // Set our LED pins as output
-    //DDRD |= (1<<6); // Esc
-    //DDRB |= (1<<7); // Page Up
-    //DDRD |= (1<<4); // Arrows
-
-    // Set our LED pins low
-    //PORTD &= ~(1<<6); // Esc
-    //PORTB &= ~(1<<7); // Page Up
-    //PORTD &= ~(1<<4); // Arrows
-}
-
-void backlight_set(uint8_t level) {
-/*
-    if ( level == 0 ) {
-        // Turn off light
-        PORTD |= (1<<6); // Esc
-        PORTB |= (1<<7); // Page Up
-        PORTD |= (1<<4); // Arrows
-    } else {
-        // Turn on light
-        PORTD &= ~(1<<6); // Esc
-        PORTB &= ~(1<<7); // Page Up
-        PORTD &= ~(1<<4); // Arrows
-    }
-*/
-}
-
 void led_init_ports() {
     // Set our LED pins as output
     palSetPadMode(GPIOB, 13, PAL_MODE_OUTPUT_PUSHPULL); // LED1

--- a/keyboards/clueboard/66/rev4/rules.mk
+++ b/keyboards/clueboard/66/rev4/rules.mk
@@ -4,7 +4,6 @@ MCU = STM32F303
 # Build Options
 #   comment out to disable the options.
 #
-BACKLIGHT_ENABLE = yes
 BOOTMAGIC_ENABLE = no   # Virtual DIP switch configuration
 MOUSEKEY_ENABLE = yes   # Mouse keys
 EXTRAKEY_ENABLE = yes   # Audio control and System control
@@ -12,7 +11,8 @@ CONSOLE_ENABLE = yes    # Console for debug
 COMMAND_ENABLE = no     # Commands for debug and configuration
 NKRO_ENABLE = yes       # USB Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
 AUDIO_ENABLE = no
-RGBLIGHT_ENABLE = no    # Enable keyboard underlight functionality
+BACKLIGHT_ENABLE = no   # Enable keyboard backlight functionality
+RGBLIGHT_ENABLE = no    # Enable keyboard RGB underglow
 MIDI_ENABLE = no        # MIDI controls
 UNICODE_ENABLE = no     # Unicode
 BLUETOOTH_ENABLE = no   # Enable Bluetooth with the Adafruit EZ-Key HID


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Issue found within #7959 and #8292.
Another instance of backlight code existing without custom driver being used. Given the functions are just comments, I figured it best to just remove.

Tagging @skullydazed.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
