### PR TITLE
[Keyboard] Switch to RGB Matrix for Super16

### DIFF
--- a/keyboards/1upkeyboards/super16/config.h
+++ b/keyboards/1upkeyboards/super16/config.h
@@ -40,9 +40,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  * DIODE_DIRECTION: COL2ROW = COL = Anode (+), ROW = Cathode (-, marked on diode)
  *                  ROW2COL = ROW = Anode (+), COL = Cathode (-, marked on diode)
  *
-*/
-#define MATRIX_ROW_PINS { D1, D0, F4, F5 }
-#define MATRIX_COL_PINS { D4, C6, F6, F7 }
+ */
+#define MATRIX_ROW_PINS \
+    { D1, D0, F4, F5 }
+#define MATRIX_COL_PINS \
+    { D4, C6, F6, F7 }
 #define UNUSED_PINS
 
 /* COL2ROW, ROW2COL*/
@@ -51,7 +53,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /*
  * Split Keyboard specific options, make sure you have 'SPLIT_KEYBOARD = yes' in your rules.mk, and define SOFT_SERIAL_PIN.
  */
-#define SOFT_SERIAL_PIN D0 // or D1, D2, D3, E6
+#define SOFT_SERIAL_PIN D0  // or D1, D2, D3, E6
 
 // #define BACKLIGHT_PIN B7
 // #define BACKLIGHT_BREATHING
@@ -59,15 +61,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define RGB_DI_PIN D3
 #ifdef RGB_DI_PIN
-  #define RGBLED_NUM 16 // Add 12 if attaching the RGB LED ring
-  #define RGBLIGHT_HUE_STEP 8
-  #define RGBLIGHT_SAT_STEP 8
-  #define RGBLIGHT_VAL_STEP 8
-  #define RGBLIGHT_LIMIT_VAL 255 /* The maximum brightness level */
-  #define RGBLIGHT_SLEEP  /* If defined, the RGB lighting will be switched off when the host goes to sleep */
-  /*== all animations enable ==*/
-  #define RGBLIGHT_ANIMATIONS
-  /*== or choose animations ==*/
+#    define RGBLED_NUM 16  // Add 12 if attaching the RGB LED ring
+#    define DRIVER_LED_TOTAL RGBLED_NUM
+#    ifdef RGBLIGHT_ENABLE
+#        define RGBLIGHT_HUE_STEP 8
+#        define RGBLIGHT_SAT_STEP 8
+#        define RGBLIGHT_VAL_STEP 8
+#        define RGBLIGHT_LIMIT_VAL 255 /* The maximum brightness level */
+#        define RGBLIGHT_SLEEP         /* If defined, the RGB lighting will be switched off when the host goes to sleep */
+/*== all animations enable ==*/
+#        define RGBLIGHT_ANIMATIONS
+/*== or choose animations ==*/
 //   #define RGBLIGHT_EFFECT_BREATHING
 //   #define RGBLIGHT_EFFECT_RAINBOW_MOOD
 //   #define RGBLIGHT_EFFECT_RAINBOW_SWIRL
@@ -77,6 +81,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //   #define RGBLIGHT_EFFECT_STATIC_GRADIENT
 //   #define RGBLIGHT_EFFECT_RGB_TEST
 //   #define RGBLIGHT_EFFECT_ALTERNATING
+#    elif defined RGB_MATRIX_ENABLE
+#        define RGB_MATRIX_KEYPRESSES   // reacts to keypresses
+#        define RGB_MATRIX_FRAMEBUFFER_EFFECTS  // reacts to keyreleases (instead of keypresses)
+
+#    endif
 #endif
 
 /* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */

--- a/keyboards/1upkeyboards/super16/rules.mk
+++ b/keyboards/1upkeyboards/super16/rules.mk
@@ -24,7 +24,8 @@ SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
 # if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
 NKRO_ENABLE = no            # USB Nkey Rollover
 BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality on B7 by default
-RGBLIGHT_ENABLE = yes       # Enable keyboard RGB underglow
+RGBLIGHT_ENABLE = no       # Enable keyboard RGB underglow
+RGB_MATRIX_ENABLE = WS2812
 MIDI_ENABLE = no            # MIDI support
 UNICODE_ENABLE = no         # Unicode
 BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID

--- a/keyboards/1upkeyboards/super16/super16.c
+++ b/keyboards/1upkeyboards/super16/super16.c
@@ -15,29 +15,23 @@
  */
 #include "super16.h"
 
-void matrix_init_kb(void) {
-  // put your keyboard start-up code here
-  // runs once when the firmware starts up
+led_config_t g_led_config = { {
+  // Key Matrix to LED Index
+  {   0,  1,  2,  3 },
+  {   7,  6,  5,  4 },
+  {   8,  9, 10, 11 },
+  {  15, 14, 13, 12 }
+}, {
+  // LED Index to Physical Position
+  { 0,  0 }, { 75,  0 }, { 150,  0 }, { 224,  0 },
+  { 224,  21 }, { 150,  21 }, { 75,  21 }, { 0,  21 },
+  { 0,  43 }, { 75,  43 }, { 150,  43 }, { 224,  43 },
+  { 224,  64 }, { 150,  64 }, { 75,  64 }, { 0,  64 },
 
-  matrix_init_user();
-}
-
-void matrix_scan_kb(void) {
-  // put your looping keyboard code here
-  // runs every cycle (a lot)
-
-  matrix_scan_user();
-}
-
-bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
-  // put your per-action keyboard code here
-  // runs for every action, just before processing by the firmware
-
-  return process_record_user(keycode, record);
-}
-
-void led_set_kb(uint8_t usb_led) {
-  // put your keyboard LED indicator (ex: Caps Lock LED) toggling code here
-
-  led_set_user(usb_led);
-}
+}, {
+  // LED Index to Flag
+  4, 4, 4, 4,
+  4, 4, 4, 4,
+  4, 4, 4, 4,
+  4, 4, 4, 4
+} };


### PR DESCRIPTION
 ## Description

The Super16 keyboard from 1upkeyboards appears to have per key RGB via "helix style mounted" WS2812 LEDs.  So it makes more sense to use the RGB matrix, as this allows for better animations on the macropad. 

Tested by sirknighting on discord. 

## Types of Changes
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Documentation


## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
