### PR TITLE
Optimization for scanning less layers.

### DIFF
--- a/tmk_core/common/action_layer.c
+++ b/tmk_core/common/action_layer.c
@@ -257,7 +257,7 @@ uint8_t layer_switch_get_layer(keypos_t key) {
 
     layer_state_t layers = layer_state | default_layer_state;
     /* check top layer first */
-    for (int8_t i = NUM_LAYERS - 1; i >= 0; i--) {
+    for (int8_t i = MAX_LAYER - 1; i >= 0; i--) {
         if (layers & (1UL << i)) {
             action = action_for_key(i, key);
             if (action.code != ACTION_TRANSPARENT) {

--- a/tmk_core/common/action_layer.c
+++ b/tmk_core/common/action_layer.c
@@ -257,7 +257,7 @@ uint8_t layer_switch_get_layer(keypos_t key) {
 
     layer_state_t layers = layer_state | default_layer_state;
     /* check top layer first */
-    for (int8_t i = sizeof(layer_state_t) * 8 - 1; i >= 0; i--) {
+    for (int8_t i = NUM_LAYERS - 1; i >= 0; i--) {
         if (layers & (1UL << i)) {
             action = action_for_key(i, key);
             if (action.code != ACTION_TRANSPARENT) {

--- a/tmk_core/common/action_layer.h
+++ b/tmk_core/common/action_layer.h
@@ -23,12 +23,24 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #if defined(LAYER_STATE_8BIT)
 typedef uint8_t layer_state_t;
+#    define MAX_LAYER_BITS 3
+#    ifndef NUM_LAYERS
+#        define NUM_LAYERS 8
+#    endif
 #    define get_highest_layer(state) biton(state)
 #elif defined(LAYER_STATE_16BIT)
 typedef uint16_t layer_state_t;
+#    define MAX_LAYER_BITS 4
+#    ifndef NUM_LAYERS
+#        define NUM_LAYERS 16
+#    endif
 #    define get_highest_layer(state) biton16(state)
 #else
 typedef uint32_t layer_state_t;
+#    define MAX_LAYER_BITS 5
+#    ifndef NUM_LAYERS
+#        define NUM_LAYERS 32
+#    endif
 #    define get_highest_layer(state) biton32(state)
 #endif
 
@@ -96,8 +108,7 @@ layer_state_t layer_state_set_kb(layer_state_t state);
 
 /* pressed actions cache */
 #if !defined(NO_ACTION_LAYER) && !defined(STRICT_LAYER_RELEASE)
-/* The number of bits needed to represent the layer number: log2(32). */
-#    define MAX_LAYER_BITS 5
+
 void    update_source_layers_cache(keypos_t key, uint8_t layer);
 uint8_t read_source_layers_cache(keypos_t key);
 #endif

--- a/tmk_core/common/action_layer.h
+++ b/tmk_core/common/action_layer.h
@@ -24,22 +24,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #if defined(LAYER_STATE_8BIT)
 typedef uint8_t layer_state_t;
 #    define MAX_LAYER_BITS 3
-#    ifndef NUM_LAYERS
-#        define NUM_LAYERS 8
+#    ifndef MAX_LAYER
+#        define MAX_LAYER 8
 #    endif
 #    define get_highest_layer(state) biton(state)
 #elif defined(LAYER_STATE_16BIT)
 typedef uint16_t layer_state_t;
 #    define MAX_LAYER_BITS 4
-#    ifndef NUM_LAYERS
-#        define NUM_LAYERS 16
+#    ifndef MAX_LAYER
+#        define MAX_LAYER 16
 #    endif
 #    define get_highest_layer(state) biton16(state)
 #else
 typedef uint32_t layer_state_t;
 #    define MAX_LAYER_BITS 5
-#    ifndef NUM_LAYERS
-#        define NUM_LAYERS 32
+#    ifndef MAX_LAYER
+#        define MAX_LAYER 32
 #    endif
 #    define get_highest_layer(state) biton32(state)
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
This is a quick cleanup of layer_state_t that allows users to input their maximum layer number.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Generally, most users have 2-4 layers. Scanning from 31 down to 0 and checking KC_NO /KC_TRANS 32 times before hitting layer one takes quite a bit of time.
This speeds it up by scanning from NUM_LAYERS, which is automatically defined if you've used `#define LAYER_STATE_8BIT`, or you can define it in your config.h.

<!--- Describe your changes in detail here. -->
* Added auto define for NUM_LAYERS
* Changed scanning code from highest_layer (32) to NUM_LAYERS

I've tested with LAYER_STATE_8BIT + NUM_LAYERS = 2, on my 2 layer keyboard.
One caveat is you have to put in your maximum layer number + 1 (e.g. [0] and [1] will need NUM_LAYERS = 2.  [0] [1] [4] will require NUM_LAYERS = 5)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation



## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
