### PR TITLE
Fix up Arm builds with nix-shell.

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -45,6 +45,6 @@ stdenv.mkDerivation {
     ++ lib.optional arm [ gcc-arm-embedded ]
     ++ lib.optional teensy [ teensy-loader-cli ];
 
-  CFLAGS = lib.optional avr avr_incflags;
-  ASFLAGS = lib.optional avr avr_incflags;
+  AVR_CFLAGS = lib.optional avr avr_incflags;
+  AVR_ASFLAGS = lib.optional avr avr_incflags;
 }

--- a/tmk_core/avr.mk
+++ b/tmk_core/avr.mk
@@ -21,7 +21,9 @@ COMPILEFLAGS += -fdata-sections
 COMPILEFLAGS += -fpack-struct
 COMPILEFLAGS += -fshort-enums
 
-CFLAGS += $(COMPILEFLAGS)
+ASFLAGS += $(AVR_ASFLAGS)
+
+CFLAGS += $(COMPILEFLAGS) $(AVR_CFLAGS)
 CFLAGS += -fno-inline-small-functions
 CFLAGS += -fno-strict-aliasing
 


### PR DESCRIPTION
## Description

AVR `CFLAGS`/`ASFLAGS` were unconditionally used for all targets, even if they were targeting Arm. This limits the scope to those variables to AVR-specific, as the normal Arm compiler included in Nix actually has these set correctly.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #8241 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
