### PR TITLE
Initialize Layer State on startup

### DIFF
--- a/tmk_core/common/action_layer.h
+++ b/tmk_core/common/action_layer.h
@@ -85,6 +85,8 @@ void layer_invert(uint8_t layer);
 void layer_or(layer_state_t state);
 void layer_and(layer_state_t state);
 void layer_xor(layer_state_t state);
+layer_state_t layer_state_set_user(layer_state_t state);
+layer_state_t layer_state_set_kb(layer_state_t state);
 #else
 #    define layer_state 0
 
@@ -101,10 +103,10 @@ void layer_xor(layer_state_t state);
 #    define layer_or(state) (void)state
 #    define layer_and(state) (void)state
 #    define layer_xor(state) (void)state
+#    define layer_state_set_kb(state) (void)state
+#    define layer_state_set_user(state) (void)state
 #endif
 
-layer_state_t layer_state_set_user(layer_state_t state);
-layer_state_t layer_state_set_kb(layer_state_t state);
 
 /* pressed actions cache */
 #if !defined(NO_ACTION_LAYER) && !defined(STRICT_LAYER_RELEASE)

--- a/tmk_core/common/bootmagic.c
+++ b/tmk_core/common/bootmagic.c
@@ -123,7 +123,7 @@ void bootmagic(void) {
         default_layer_set((layer_state_t)default_layer);
     }
     /* Also initialize layer state to trigger callback functions for layer_state */
-    layer_clear();
+    layer_state_set_kb(layer_state);
 
     /* EE_HANDS handedness */
     if (bootmagic_scan_keycode(BOOTMAGIC_KEY_EE_HANDS_LEFT)) {

--- a/tmk_core/common/bootmagic.c
+++ b/tmk_core/common/bootmagic.c
@@ -122,6 +122,8 @@ void bootmagic(void) {
         default_layer = eeconfig_read_default_layer();
         default_layer_set((layer_state_t)default_layer);
     }
+    /* Also initialize layer state to trigger callback functions for layer_state */
+    layer_clear();
 
     /* EE_HANDS handedness */
     if (bootmagic_scan_keycode(BOOTMAGIC_KEY_EE_HANDS_LEFT)) {

--- a/tmk_core/common/bootmagic.c
+++ b/tmk_core/common/bootmagic.c
@@ -123,7 +123,7 @@ void bootmagic(void) {
         default_layer_set((layer_state_t)default_layer);
     }
     /* Also initialize layer state to trigger callback functions for layer_state */
-    layer_state_set_kb(layer_state);
+    layer_state_set_kb((layer_state_t)layer_state);
 
     /* EE_HANDS handedness */
     if (bootmagic_scan_keycode(BOOTMAGIC_KEY_EE_HANDS_LEFT)) {

--- a/tmk_core/common/magic.c
+++ b/tmk_core/common/magic.c
@@ -35,5 +35,5 @@ void magic(void) {
     default_layer_set((layer_state_t)default_layer);
 
     /* Also initialize layer state to trigger callback functions for layer_state */
-    layer_clear();
+    layer_state_set_kb(layer_state);
 }

--- a/tmk_core/common/magic.c
+++ b/tmk_core/common/magic.c
@@ -33,4 +33,7 @@ void magic(void) {
     uint8_t default_layer = 0;
     default_layer         = eeconfig_read_default_layer();
     default_layer_set((layer_state_t)default_layer);
+
+    /* Also initialize layer state to trigger callback functions for layer_state */
+    layer_clear();
 }

--- a/tmk_core/common/magic.c
+++ b/tmk_core/common/magic.c
@@ -35,5 +35,5 @@ void magic(void) {
     default_layer_set((layer_state_t)default_layer);
 
     /* Also initialize layer state to trigger callback functions for layer_state */
-    layer_state_set_kb(layer_state);
+    layer_state_set_kb((layer_state_t)layer_state);
 }


### PR DESCRIPTION
Right now, on startup, the default layer state gets called and set, triggering the callback functions for the default layer state. However, the normal layer state never actually gets initialized.  It's set to 0 directly, by default, but the callback functions are never actually called.  This creates some inconsistency in the behavior for end users.  This adds a simple "clear" that triggers the callback on startup.  This should produce more consistent behavior between the two functions and layer masks.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
