### PR TITLE
Add support for hardware and board initialisation overrides.

### DIFF
--- a/docs/_summary.md
+++ b/docs/_summary.md
@@ -136,6 +136,10 @@
       * [Development Environment](api_development_environment.md)
       * [Architecture Overview](api_development_overview.md)
 
+  * Hardware Platform Development
+    * Arm/ChibiOS
+      * [Early initialization](platformdev_chibios_earlyinit.md)
+
   * QMK Reference
     * [Contributing to QMK](contributing.md)
     * [Translating the QMK Docs](translating.md)

--- a/docs/platformdev_chibios_earlyinit.md
+++ b/docs/platformdev_chibios_earlyinit.md
@@ -1,20 +1,20 @@
 # Arm/ChibiOS Early Initialization
 
-This page describes a part of QMK that is a somewhat advanced concept, and is only relevant to board designers.
+This page describes a part of QMK that is a somewhat advanced concept, and is only relevant to keyboard designers.
 
-QMK uses ChibiOS as the underlying layer to support a multitude of Arm-based devices. Each ChibiOS-supported board has a low-level board definition which is responsible for initializing hardware peripherals such as the clocks, and GPIOs.
+QMK uses ChibiOS as the underlying layer to support a multitude of Arm-based devices. Each ChibiOS-supported keyboard has a low-level board definition which is responsible for initializing hardware peripherals such as the clocks, and GPIOs.
 
-Older QMK revisions required duplication of these board definitions inside your keyboard's directory in order to override such early initialization points; this is now abstracted into the following APIs, and allows usage of the board definitions supplied with ChibiOS itself. Check `<qmk_firmware>/lib/chibios/os/hal/boards` for the list of official definitions. If your board needs extra initialization at a very early stage, consider providing board-level overrides of the following APIs:
+Older QMK revisions required duplication of these board definitions inside your keyboard's directory in order to override such early initialization points; this is now abstracted into the following APIs, and allows usage of the board definitions supplied with ChibiOS itself. Check `<qmk_firmware>/lib/chibios/os/hal/boards` for the list of official definitions. If your keyboard needs extra initialization at a very early stage, consider providing keyboard-level overrides of the following APIs:
 
 ## `early_hardware_init_pre()`
 
-The function `early_hardware_init_pre` is the earliest possible code that can be executed by a board firmware. This is intended as a replacement for the ChibiOS board definition's `__early_init` function, and is the equivalent of executing at the start of the function.
+The function `early_hardware_init_pre` is the earliest possible code that can be executed by a keyboard firmware. This is intended as a replacement for the ChibiOS board definition's `__early_init` function, and is the equivalent of executing at the start of the function.
 
 This is executed before RAM gets cleared, and before clocks or GPIOs are configured; any delays or preparation using GPIOs is not likely to work at this point. After executing this function, RAM on the MCU may be zero'ed. Assigning values to variables during execution of this function may be overwritten.
 
 As such, if you wish to override this API consider limiting use to writing to low-level registers. The default implementation of this function is to do nothing.
 
-To implement your own version of this function, in your board's source files:
+To implement your own version of this function, in your keyboard's source files:
 
     void early_hardware_init_pre(void) {
         // do things with registers
@@ -22,13 +22,13 @@ To implement your own version of this function, in your board's source files:
 
 ## `early_hardware_init_post()`
 
-The function `early_hardware_init_post` is the next earliest possible code that can be executed by a board firmware. This is executed after RAM has been cleared, and clocks and GPIOs are configured. This is intended as a replacement for the ChibiOS board definition's `__early_init` function, and is the equivalent of executing at the end of the function.
+The function `early_hardware_init_post` is the next earliest possible code that can be executed by a keyboard firmware. This is executed after RAM has been cleared, and clocks and GPIOs are configured. This is intended as a replacement for the ChibiOS board definition's `__early_init` function, and is the equivalent of executing at the end of the function.
 
 Much like `early_hardware_init_pre`, ChibiOS has not yet been initialized either, so the same restrictions on delays and timing apply.
 
 If you wish to override this API, consider limiting functionality to register writes, variable initialization, and GPIO toggling. The default implementation of this function is to do nothing.
 
-To implement your own version of this function, in your board's source files:
+To implement your own version of this function, in your keyboard's source files:
 
     void early_hardware_init_post(void) {
         // toggle GPIO pins and write to variables
@@ -40,7 +40,7 @@ The function `board_init` is executed directly after the ChibiOS initialization 
 
 The default implementation of this function is to do nothing.
 
-To implement your own version of this function, in your board's source files:
+To implement your own version of this function, in your keyboard's source files:
 
     void board_init(void) {
         // initialize anything that requires ChibiOS

--- a/docs/platformdev_chibios_earlyinit.md
+++ b/docs/platformdev_chibios_earlyinit.md
@@ -1,4 +1,4 @@
-# Arm/ChibiOS Early Initialization
+# Arm/ChibiOS Early Initialization :id=chibios-early-init
 
 This page describes a part of QMK that is a somewhat advanced concept, and is only relevant to keyboard designers.
 
@@ -6,7 +6,7 @@ QMK uses ChibiOS as the underlying layer to support a multitude of Arm-based dev
 
 Older QMK revisions required duplication of these board definitions inside your keyboard's directory in order to override such early initialization points; this is now abstracted into the following APIs, and allows usage of the board definitions supplied with ChibiOS itself. Check `<qmk_firmware>/lib/chibios/os/hal/boards` for the list of official definitions. If your keyboard needs extra initialization at a very early stage, consider providing keyboard-level overrides of the following APIs:
 
-## `early_hardware_init_pre()`
+## `early_hardware_init_pre()` :id=early-hardware-init-pre
 
 The function `early_hardware_init_pre` is the earliest possible code that can be executed by a keyboard firmware. This is intended as a replacement for the ChibiOS board definition's `__early_init` function, and is the equivalent of executing at the start of the function.
 
@@ -16,11 +16,13 @@ As such, if you wish to override this API consider limiting use to writing to lo
 
 To implement your own version of this function, in your keyboard's source files:
 
-    void early_hardware_init_pre(void) {
-        // do things with registers
-    }
+```c
+void early_hardware_init_pre(void) {
+    // do things with registers
+}
+```
 
-## `early_hardware_init_post()`
+## `early_hardware_init_post()` :id=early-hardware-init-post
 
 The function `early_hardware_init_post` is the next earliest possible code that can be executed by a keyboard firmware. This is executed after RAM has been cleared, and clocks and GPIOs are configured. This is intended as a replacement for the ChibiOS board definition's `__early_init` function, and is the equivalent of executing at the end of the function.
 
@@ -30,11 +32,13 @@ If you wish to override this API, consider limiting functionality to register wr
 
 To implement your own version of this function, in your keyboard's source files:
 
-    void early_hardware_init_post(void) {
-        // toggle GPIO pins and write to variables
-    }
+```c
+void early_hardware_init_post(void) {
+    // toggle GPIO pins and write to variables
+}
+```
 
-## `board_init()`
+## `board_init()` :id=board-init
 
 The function `board_init` is executed directly after the ChibiOS initialization routines have completed. At this stage, all normal low-level functionality should be available for use (including timers and delays), with the restriction that USB is not yet connected. This is intended as a replacement for the ChibiOS board definition's `boardInit` function.
 
@@ -42,6 +46,8 @@ The default implementation of this function is to do nothing.
 
 To implement your own version of this function, in your keyboard's source files:
 
-    void board_init(void) {
-        // initialize anything that requires ChibiOS
-    }
+```c
+void board_init(void) {
+    // initialize anything that requires ChibiOS
+}
+```

--- a/docs/platformdev_chibios_earlyinit.md
+++ b/docs/platformdev_chibios_earlyinit.md
@@ -8,7 +8,7 @@ If your board needs extra initialisation at a very early stage, consider overrid
 
 The function `early_hardware_init_pre` is the earliest possible code that can be executed by a board firmware. This is executed before clocks or GPIOs are configured, so any preparation using GPIOs is not likely to work at this point.
 
-ChibiOS has not yet been initialised either, so functionality such as delays are unlikely to work.
+ChibiOS has not yet been initialized either, so functionality such as delays are unlikely to work.
 
 If you wish to override this API, consider limiting use to writing to low-level registers and/or initialising variables.
 
@@ -22,9 +22,9 @@ To implement your own version of this function, in your board's source files:
 
 ## `early_hardware_init_post()`
 
-The function `early_hardware_init_post` is the next earliest possible code that can be executed by a board firmware. This is executed after clocks or GPIOs are configured, so any preparation using GPIOs is not likely to work at this point.
+The function `early_hardware_init_post` is the next earliest possible code that can be executed by a board firmware. This is executed after clocks and GPIOs are configured.
 
-Much like `early_hardware_init_pre`, ChibiOS has not yet been initialised either, so the same restrictions apply.
+Much like `early_hardware_init_pre`, ChibiOS has not yet been initialized either, so the same restrictions apply.
 
 If you wish to override this API, the same recommendation above applies, with the exception of modifying GPIOs.
 
@@ -45,5 +45,5 @@ The default implementation of this function is to do nothing.
 To implement your own version of this function, in your board's source files:
 
     void board_init(void) {
-        // initialise low-level ChibiOS devices
+        // initialize low-level ChibiOS devices
     }

--- a/docs/platformdev_chibios_earlyinit.md
+++ b/docs/platformdev_chibios_earlyinit.md
@@ -1,0 +1,49 @@
+# Arm/ChibiOS Early Initialization
+
+QMK uses ChibiOS as the underlying layer to support a multitude of Arm-based devices. Each ChibiOS-supported board has a low-level board layer, which is responsible for initialising hardware peripherals such as the clocks, and GPIOs.
+
+If your board needs extra initialisation at a very early stage, consider overriding the following APIs.
+
+## `early_hardware_init_pre()`
+
+The function `early_hardware_init_pre` is the earliest possible code that can be executed by a board firmware. This is executed before clocks or GPIOs are configured, so any preparation using GPIOs is not likely to work at this point.
+
+ChibiOS has not yet been initialised either, so functionality such as delays are unlikely to work.
+
+If you wish to override this API, consider limiting use to writing to low-level registers and/or initialising variables.
+
+The default implementation of this function is to jump to bootloader, if the bootloader address has been specified in your board's `rules.mk`.
+
+To implement your own version of this function, in your board's source files:
+
+    void early_hardware_init_pre(void) {
+        // do things with registers and variables
+    }
+
+## `early_hardware_init_post()`
+
+The function `early_hardware_init_post` is the next earliest possible code that can be executed by a board firmware. This is executed after clocks or GPIOs are configured, so any preparation using GPIOs is not likely to work at this point.
+
+Much like `early_hardware_init_pre`, ChibiOS has not yet been initialised either, so the same restrictions apply.
+
+If you wish to override this API, the same recommendation above applies, with the exception of modifying GPIOs.
+
+The default implementation of this function is to do nothing.
+
+To implement your own version of this function, in your board's source files:
+
+    void early_hardware_init_post(void) {
+        // toggle GPIO pins and things
+    }
+
+## `board_init()`
+
+The function `board_init` is executed directly after the ChibiOS initialisation routines have completed. At this stage, all normal low-level functionality should be available for use, with the assumption that USB is not yet connected.
+
+The default implementation of this function is to do nothing.
+
+To implement your own version of this function, in your board's source files:
+
+    void board_init(void) {
+        // initialise low-level ChibiOS devices
+    }

--- a/docs/platformdev_chibios_earlyinit.md
+++ b/docs/platformdev_chibios_earlyinit.md
@@ -12,7 +12,7 @@ The function `early_hardware_init_pre` is the earliest possible code that can be
 
 This is executed before RAM gets cleared, and before clocks or GPIOs are configured; any delays or preparation using GPIOs is not likely to work at this point. After executing this function, RAM on the MCU may be zero'ed. Assigning values to variables during execution of this function may be overwritten.
 
-As such, if you wish to override this API consider limiting use to writing to low-level registers. The default implementation of this function is to do nothing.
+As such, if you wish to override this API consider limiting use to writing to low-level registers. The default implementation of this function can be configured to jump to bootloader if a `RESET` key was pressed, by ensuring `#define EARLY_INIT_PERFORM_BOOTLOADER_JUMP TRUE` is in the keyboard's `config.h` file.
 
 To implement your own version of this function, in your keyboard's source files:
 

--- a/tmk_core/protocol/chibios/init_hooks.h
+++ b/tmk_core/protocol/chibios/init_hooks.h
@@ -1,0 +1,5 @@
+#pragma once
+
+// Override the initialisation functions inside the ChibiOS board.c files
+#define __early_init __chibios_override___early_init
+#define boardInit __chibios_override_boardInit

--- a/tmk_core/protocol/chibios/main.c
+++ b/tmk_core/protocol/chibios/main.c
@@ -101,6 +101,40 @@ void midi_ep_task(void);
 //   }
 // }
 
+/* Early initialisation
+ */
+__attribute__((weak)) void early_hardware_init_pre(void) {}
+
+__attribute__((weak)) void early_hardware_init_post(void) {
+#ifdef STM32_BOOTLOADER_ADDRESS
+    void enter_bootloader_mode_if_requested(void);
+    enter_bootloader_mode_if_requested();
+#endif
+}
+
+__attribute__((weak)) void board_init(void) {
+}
+
+// This overrides what's normally in ChibiOS board definitions
+void __early_init(void) {
+    early_hardware_init_pre();
+
+    // This is the renamed equivalent of __early_init in the board.c file
+    void __chibios_override___early_init(void);
+    __chibios_override___early_init();
+
+    early_hardware_init_post();
+}
+
+// This overrides what's normally in ChibiOS board definitions
+void boardInit(void) {
+    // This is the renamed equivalent of boardInit in the board.c file
+    void __chibios_override_boardInit(void);
+    __chibios_override_boardInit();
+
+    board_init();
+}
+
 /* Main thread
  */
 int main(void) {

--- a/tmk_core/protocol/chibios/main.c
+++ b/tmk_core/protocol/chibios/main.c
@@ -103,14 +103,14 @@ void midi_ep_task(void);
 
 /* Early initialisation
  */
-__attribute__((weak)) void early_hardware_init_pre(void) {}
-
-__attribute__((weak)) void early_hardware_init_post(void) {
+__attribute__((weak)) void early_hardware_init_pre(void) {
 #ifdef STM32_BOOTLOADER_ADDRESS
     void enter_bootloader_mode_if_requested(void);
     enter_bootloader_mode_if_requested();
 #endif
 }
+
+__attribute__((weak)) void early_hardware_init_post(void) {}
 
 __attribute__((weak)) void board_init(void) {}
 

--- a/tmk_core/protocol/chibios/main.c
+++ b/tmk_core/protocol/chibios/main.c
@@ -33,6 +33,11 @@
 #include "debug.h"
 #include "printf.h"
 
+#ifndef EARLY_INIT_PERFORM_BOOTLOADER_JUMP
+// Change this to be TRUE once we've migrated keyboards to the new init system
+#    define EARLY_INIT_PERFORM_BOOTLOADER_JUMP FALSE
+#endif
+
 #ifdef SLEEP_LED_ENABLE
 #    include "sleep_led.h"
 #endif
@@ -104,10 +109,10 @@ void midi_ep_task(void);
 /* Early initialisation
  */
 __attribute__((weak)) void early_hardware_init_pre(void) {
-#if defined(ENABLE_STM32_BOOTLOADER_ADDRESS) && defined(STM32_BOOTLOADER_ADDRESS) // remove the FALSE when we've migrated all existing __early_init invocations
+#if EARLY_INIT_PERFORM_BOOTLOADER_JUMP
     void enter_bootloader_mode_if_requested(void);
     enter_bootloader_mode_if_requested();
-#endif
+#endif  // EARLY_INIT_PERFORM_BOOTLOADER_JUMP
 }
 
 __attribute__((weak)) void early_hardware_init_post(void) {}

--- a/tmk_core/protocol/chibios/main.c
+++ b/tmk_core/protocol/chibios/main.c
@@ -104,7 +104,7 @@ void midi_ep_task(void);
 /* Early initialisation
  */
 __attribute__((weak)) void early_hardware_init_pre(void) {
-#if FALSE && defined(STM32_BOOTLOADER_ADDRESS) // remove the FALSE when we've migrated all existing __early_init invocations
+#if defined(ENABLE_STM32_BOOTLOADER_ADDRESS) && defined(STM32_BOOTLOADER_ADDRESS) // remove the FALSE when we've migrated all existing __early_init invocations
     void enter_bootloader_mode_if_requested(void);
     enter_bootloader_mode_if_requested();
 #endif

--- a/tmk_core/protocol/chibios/main.c
+++ b/tmk_core/protocol/chibios/main.c
@@ -104,7 +104,7 @@ void midi_ep_task(void);
 /* Early initialisation
  */
 __attribute__((weak)) void early_hardware_init_pre(void) {
-#ifdef STM32_BOOTLOADER_ADDRESS
+#if FALSE && defined(STM32_BOOTLOADER_ADDRESS) // remove the FALSE when we've migrated all existing __early_init invocations
     void enter_bootloader_mode_if_requested(void);
     enter_bootloader_mode_if_requested();
 #endif

--- a/tmk_core/protocol/chibios/main.c
+++ b/tmk_core/protocol/chibios/main.c
@@ -112,8 +112,7 @@ __attribute__((weak)) void early_hardware_init_post(void) {
 #endif
 }
 
-__attribute__((weak)) void board_init(void) {
-}
+__attribute__((weak)) void board_init(void) {}
 
 // This overrides what's normally in ChibiOS board definitions
 void __early_init(void) {

--- a/tmk_core/rules.mk
+++ b/tmk_core/rules.mk
@@ -223,6 +223,12 @@ $(foreach LOBJ, $(NO_LTO_OBJ), $(eval $(call NO_LTO,$(LOBJ))))
 
 MOVE_DEP = mv -f $(patsubst %.o,%.td,$@) $(patsubst %.o,%.d,$@)
 
+# For a ChibiOS build, ensure that the board files have the hook overrides injected
+define BOARDSRC_INJECT_HOOKS
+$(KEYBOARD_OUTPUT)/$(patsubst %.c,%.o,$(patsubst ./%,%,$1)): INIT_HOOK_CFLAGS += -include $(TOP_DIR)/tmk_core/protocol/chibios/init_hooks.h
+endef
+$(foreach LOBJ, $(BOARDSRC), $(eval $(call BOARDSRC_INJECT_HOOKS,$(LOBJ))))
+
 # Add QMK specific flags
 DFU_SUFFIX ?= dfu-suffix
 DFU_SUFFIX_ARGS ?=
@@ -306,27 +312,27 @@ ifdef $1_CONFIG
 $1_CONFIG_FLAGS += $$(patsubst %,-include %,$$($1_CONFIG))
 endif
 $1_CFLAGS = $$(ALL_CFLAGS) $$($1_DEFS) $$($1_INCFLAGS) $$($1_CONFIG_FLAGS) $$(NOLTO_CFLAGS)
-$1_CXXFLAGS= $$(ALL_CXXFLAGS) $$($1_DEFS) $$($1_INCFLAGS) $$($1_CONFIG_FLAGS) $$(NOLTO_CFLAGS)
-$1_ASFLAGS= $$(ALL_ASFLAGS) $$($1_DEFS) $$($1_INCFLAGS) $$($1_CONFIG_FLAGS)
+$1_CXXFLAGS = $$(ALL_CXXFLAGS) $$($1_DEFS) $$($1_INCFLAGS) $$($1_CONFIG_FLAGS) $$(NOLTO_CFLAGS)
+$1_ASFLAGS = $$(ALL_ASFLAGS) $$($1_DEFS) $$($1_INCFLAGS) $$($1_CONFIG_FLAGS)
 
 # Compile: create object files from C source files.
 $1/%.o : %.c $1/%.d $1/cflags.txt $1/compiler.txt | $(BEGIN)
 	@mkdir -p $$(@D)
 	@$$(SILENT) || printf "$$(MSG_COMPILING) $$<" | $$(AWK_CMD)
-	$$(eval CMD := $$(CC) -c $$($1_CFLAGS) $$(GENDEPFLAGS) $$< -o $$@ && $$(MOVE_DEP))
+	$$(eval CMD := $$(CC) -c $$($1_CFLAGS) $$(INIT_HOOK_CFLAGS) $$(GENDEPFLAGS) $$< -o $$@ && $$(MOVE_DEP))
 	@$$(BUILD_CMD)
 
 # Compile: create object files from C++ source files.
 $1/%.o : %.cpp $1/%.d $1/cxxflags.txt $1/compiler.txt | $(BEGIN)
 	@mkdir -p $$(@D)
 	@$$(SILENT) || printf "$$(MSG_COMPILING_CXX) $$<" | $$(AWK_CMD)
-	$$(eval CMD=$$(CC) -c $$($1_CXXFLAGS) $$(GENDEPFLAGS) $$< -o $$@ && $$(MOVE_DEP))
+	$$(eval CMD=$$(CC) -c $$($1_CXXFLAGS) $$(INIT_HOOK_CFLAGS) $$(GENDEPFLAGS) $$< -o $$@ && $$(MOVE_DEP))
 	@$$(BUILD_CMD)
 
 $1/%.o : %.cc $1/%.d $1/cxxflags.txt $1/compiler.txt | $(BEGIN)
 	@mkdir -p $$(@D)
 	@$$(SILENT) || printf "$$(MSG_COMPILING_CXX) $$<" | $$(AWK_CMD)
-	$$(eval CMD=$$(CC) -c $$($1_CXXFLAGS) $$(GENDEPFLAGS) $$< -o $$@ && $$(MOVE_DEP))
+	$$(eval CMD=$$(CC) -c $$($1_CXXFLAGS) $$(INIT_HOOK_CFLAGS) $$(GENDEPFLAGS) $$< -o $$@ && $$(MOVE_DEP))
 	@$$(BUILD_CMD)
 
 # Assemble: create object files from assembler source files.


### PR DESCRIPTION
## Description

ChibiOS board files aren't normally able to be overridden without making duplicates of the definitions, and modding them.

This PR introduces some new API methods and provides a way to override the initialisation files such that hooking the early bootup sequence can be achieved whilst retaining the original ChibiOS board definitions.

Effective changes, replacing modifications for each board definition's `board.c`:
 - `__early_init` has been overridden, and now has qmk api equivalents `early_hardware_init_pre` and `early_hardware_init_post`
 - `boardInit` has been overridden, and now has qmk api equivalent `board_init`

See documentation for notes on the constraints for usage -- any board developer that has previously overridden these will likely know the constraints already.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
