### PR TITLE
Add gcc version detection to qmk doctor

### DIFF
--- a/lib/python/qmk/cli/doctor.py
+++ b/lib/python/qmk/cli/doctor.py
@@ -31,6 +31,36 @@ def _udev_rule(vid, pid=None):
         return 'SUBSYSTEMS=="usb", ATTRS{idVendor}=="%s", MODE:="0666"' % vid
 
 
+def check_arm_gcc_version():
+    """Returns True if the arm-none-eabi-gcc version is not known to cause problems.
+    """
+    if 'output' in ESSENTIAL_BINARIES['arm-none-eabi-gcc']:
+        first_line = ESSENTIAL_BINARIES['arm-none-eabi-gcc']['output'].split('\n')[0]
+        second_half = first_line.split(')', 1)[1].strip()
+        version_number = second_half.split()[0]
+        cli.log.info('Found arm-none-eabi-gcc version %s', version_number)
+
+    return True  # Right now all known arm versions are ok
+
+
+def check_avr_gcc_version():
+    """Returns True if the avr-gcc version is not known to cause problems.
+    """
+    if 'output' in ESSENTIAL_BINARIES['avr-gcc']:
+        first_line = ESSENTIAL_BINARIES['avr-gcc']['output'].split('\n')[0]
+        version_number = first_line.split()[2]
+
+        major, minor, rest = version_number.split('.', 2)
+        if int(major) > 8:
+            cli.log.error('We do not recommend avr-gcc newer than 8. Downgrading to 8.x is recommended.')
+            return False
+
+        cli.log.info('Found avr-gcc version %s', version_number)
+        return True
+
+    return False
+
+
 def check_binaries():
     """Iterates through ESSENTIAL_BINARIES and tests them.
     """
@@ -160,36 +190,6 @@ def os_test_windows():
     cli.log.info("Detected {fg_cyan}Windows.")
 
     return True
-
-
-def check_avr_gcc_version():
-    """Returns True if the avr-gcc version is not known to cause problems.
-    """
-    if 'output' in ESSENTIAL_BINARIES['avr-gcc']:
-        first_line = ESSENTIAL_BINARIES['avr-gcc']['output'].split('\n')[0]
-        version_number = first_line.split()[2]
-
-        major, minor, rest = version_number.split('.', 2)
-        if int(major) > 8:
-            cli.log.error('We do not recommend avr-gcc newer than 8. Recommend you downgrade.')
-            return False
-
-        cli.log.info('Found avr-gcc version %s', version_number)
-        return True
-
-    return False
-
-
-def check_arm_gcc_version():
-    """Returns True if the arm-none-eabi-gcc version is not known to cause problems.
-    """
-    if 'output' in ESSENTIAL_BINARIES['arm-none-eabi-gcc']:
-        first_line = ESSENTIAL_BINARIES['arm-none-eabi-gcc']['output'].split('\n')[0]
-        second_half = first_line.split(')', 1)[1].strip()
-        version_number = second_half.split()[0]
-        cli.log.info('Found arm-none-eabi-gcc version %s', version_number)
-
-    return True  # Right now all known arm versions are ok
 
 
 @cli.argument('-y', '--yes', action='store_true', arg_only=True, help='Answer yes to all questions.')


### PR DESCRIPTION
Per title, basic version detection so we can warn users with gcc 9. Also outputs the version number of both to aid troubleshooting.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Enhancement/optimization

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
