### PR TITLE
Add support for Bootmagic lite when using SPLIT_HAND_PIN

### DIFF
--- a/docs/feature_bootmagic.md
+++ b/docs/feature_bootmagic.md
@@ -123,7 +123,7 @@ If you would like to change the hotkey assignments for Bootmagic, `#define` thes
 
 # Bootmagic Lite :id=bootmagic-lite
 
-In addition to the full blown Bootmagic feature, is the Bootmagic Lite feature that only handles jumping into the bootloader.  This is great for boards that don't have a physical reset button but you need a way to jump into the bootloader, and don't want to deal with the headache that Bootmagic can cause.
+In addition to the full blown Bootmagic feature, is the Bootmagic Lite feature that only handles jumping into the bootloader. This is great for boards that don't have a physical reset button but you need a way to jump into the bootloader, and don't want to deal with the headache that Bootmagic can cause.
 
 To enable this version of Bootmagic, you need to enable it in your `rules.mk` with:
 
@@ -131,7 +131,7 @@ To enable this version of Bootmagic, you need to enable it in your `rules.mk` wi
 BOOTMAGIC_ENABLE = lite
 ```
 
-Additionally, you may want to specify which key to use.  This is especially useful for keyboards that have unusual matrices.  To do so, you need to specify the row and column of the key that you want to use. Add these entries to your `config.h` file:
+Additionally, you may want to specify which key to use. This is especially useful for keyboards that have unusual matrices. To do so, you need to specify the row and column of the key that you want to use. Add these entries to your `config.h` file:
 
 ```c
 #define BOOTMAGIC_LITE_ROW 0
@@ -144,9 +144,20 @@ And to trigger the bootloader, you hold this key down when plugging the keyboard
 
 !> Using bootmagic lite will **always reset** the EEPROM, so you will lose any settings that have been saved.
 
+## Split Keyboards
+
+When handedness is predetermined via an option like `SPLIT_HAND_PIN`, you might need to configure a different key between halves. This To do so, add these entries to your `config.h` file:
+
+```c
+#define BOOTMAGIC_LITE_ROW_RIGHT 4
+#define BOOTMAGIC_LITE_COLUMN_RIGHT 1
+```
+
+By default, these values are not set.
+
 ## Advanced Bootmagic Lite
 
-The `bootmagic_lite` function is defined weakly, so that you can replace this in your code, if you need.  A great example of this is the Zeal60 boards that have some additional handling needed.
+The `bootmagic_lite` function is defined weakly, so that you can replace this in your code, if you need. A great example of this is the Zeal60 boards that have some additional handling needed.
 
 To replace the function, all you need to do is add something like this to your code:
 
@@ -163,4 +174,4 @@ void bootmagic_lite(void) {
 }
 ```
 
-You can additional feature here. For instance, resetting the eeprom or requiring additional keys to be pressed to trigger bootmagic.  Keep in mind that `bootmagic_lite` is called before a majority of features are initialized in the firmware.
+You can additional feature here. For instance, resetting the eeprom or requiring additional keys to be pressed to trigger bootmagic. Keep in mind that `bootmagic_lite` is called before a majority of features are initialized in the firmware.

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -595,12 +595,21 @@ __attribute__((weak)) void bootmagic_lite(void) {
 #endif
     matrix_scan();
 
-    // If the Esc and space bar are held down on power up,
+    // If the configured key (commonly Esc) is held down on power up,
     // reset the EEPROM valid state and jump to bootloader.
-    // Assumes Esc is at [0,0].
     // This isn't very generalized, but we need something that doesn't
     // rely on user's keymaps in firmware or EEPROM.
-    if (matrix_get_row(BOOTMAGIC_LITE_ROW) & (1 << BOOTMAGIC_LITE_COLUMN)) {
+    uint8_t row = BOOTMAGIC_LITE_ROW;
+    uint8_t col = BOOTMAGIC_LITE_COLUMN;
+#if defined(BOOTMAGIC_LITE_ROW_RIGHT) && defined(BOOTMAGIC_LITE_COLUMN_RIGHT)
+    bool is_keyboard_left(void);
+    if (!is_keyboard_left()) {
+        row = BOOTMAGIC_LITE_ROW_RIGHT;
+        col = BOOTMAGIC_LITE_COLUMN_RIGHT;
+    }
+#endif
+
+    if (matrix_get_row(row) & (1 << col)) {
         eeconfig_disable();
         // Jump to bootloader.
         bootloader_jump();

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -581,41 +581,6 @@ void tap_random_base64(void) {
     }
 }
 
-__attribute__((weak)) void bootmagic_lite(void) {
-    // The lite version of TMK's bootmagic based on Wilba.
-    // 100% less potential for accidentally making the
-    // keyboard do stupid things.
-
-    // We need multiple scans because debouncing can't be turned off.
-    matrix_scan();
-#if defined(DEBOUNCE) && DEBOUNCE > 0
-    wait_ms(DEBOUNCE * 2);
-#else
-    wait_ms(30);
-#endif
-    matrix_scan();
-
-    // If the configured key (commonly Esc) is held down on power up,
-    // reset the EEPROM valid state and jump to bootloader.
-    // This isn't very generalized, but we need something that doesn't
-    // rely on user's keymaps in firmware or EEPROM.
-    uint8_t row = BOOTMAGIC_LITE_ROW;
-    uint8_t col = BOOTMAGIC_LITE_COLUMN;
-#if defined(BOOTMAGIC_LITE_ROW_RIGHT) && defined(BOOTMAGIC_LITE_COLUMN_RIGHT)
-    bool is_keyboard_left(void);
-    if (!is_keyboard_left()) {
-        row = BOOTMAGIC_LITE_ROW_RIGHT;
-        col = BOOTMAGIC_LITE_COLUMN_RIGHT;
-    }
-#endif
-
-    if (matrix_get_row(row) & (1 << col)) {
-        eeconfig_disable();
-        // Jump to bootloader.
-        bootloader_jump();
-    }
-}
-
 void matrix_init_quantum() {
 #ifdef BOOTMAGIC_LITE
     bootmagic_lite();

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -254,6 +254,13 @@ bool     process_action_kb(keyrecord_t *record);
 bool     process_record_kb(uint16_t keycode, keyrecord_t *record);
 bool     process_record_user(uint16_t keycode, keyrecord_t *record);
 
+#ifndef BOOTMAGIC_LITE_COLUMN
+#    define BOOTMAGIC_LITE_COLUMN 0
+#endif
+#ifndef BOOTMAGIC_LITE_ROW
+#    define BOOTMAGIC_LITE_ROW 0
+#endif
+
 void bootmagic_lite(void);
 
 void reset_keyboard(void);

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -254,13 +254,6 @@ bool     process_action_kb(keyrecord_t *record);
 bool     process_record_kb(uint16_t keycode, keyrecord_t *record);
 bool     process_record_user(uint16_t keycode, keyrecord_t *record);
 
-#ifndef BOOTMAGIC_LITE_COLUMN
-#    define BOOTMAGIC_LITE_COLUMN 0
-#endif
-#ifndef BOOTMAGIC_LITE_ROW
-#    define BOOTMAGIC_LITE_ROW 0
-#endif
-
 void bootmagic_lite(void);
 
 void reset_keyboard(void);

--- a/quantum/via.c
+++ b/quantum/via.c
@@ -92,36 +92,6 @@ void via_eeprom_reset(void) {
     eeconfig_disable();
 }
 
-// Override bootmagic_lite() so it can flag EEPROM as invalid
-// as well as jump to bootloader, thus performing a "factory reset"
-// of dynamic keymaps and optionally backlight/other settings.
-void bootmagic_lite(void) {
-    // The lite version of TMK's bootmagic based on Wilba.
-    // 100% less potential for accidentally making the
-    // keyboard do stupid things.
-
-    // We need multiple scans because debouncing can't be turned off.
-    matrix_scan();
-#if defined(DEBOUNCE) && DEBOUNCE > 0
-    wait_ms(DEBOUNCE * 2);
-#else
-    wait_ms(30);
-#endif
-    matrix_scan();
-
-    // If the Esc and space bar are held down on power up,
-    // reset the EEPROM valid state and jump to bootloader.
-    // Assumes Esc is at [0,0].
-    // This isn't very generalized, but we need something that doesn't
-    // rely on user's keymaps in firmware or EEPROM.
-    if (matrix_get_row(BOOTMAGIC_LITE_ROW) & (1 << BOOTMAGIC_LITE_COLUMN)) {
-        // This is the only difference from the default implementation.
-        via_eeprom_reset();
-        // Jump to bootloader.
-        bootloader_jump();
-    }
-}
-
 // Override this at the keyboard code level to check
 // VIA's EEPROM valid state and reset to defaults as needed.
 // Used by keyboards that store their own state in EEPROM,

--- a/tmk_core/common.mk
+++ b/tmk_core/common.mk
@@ -42,6 +42,8 @@ ifneq ($(strip $(BOOTMAGIC_ENABLE)), no)
   endif
   ifeq ($(strip $(BOOTMAGIC_ENABLE)), lite)
       TMK_COMMON_DEFS += -DBOOTMAGIC_LITE
+      TMK_COMMON_SRC += $(COMMON_DIR)/bootmagic_lite.c
+
       TMK_COMMON_DEFS += -DMAGIC_ENABLE
       TMK_COMMON_SRC += $(COMMON_DIR)/magic.c
   else

--- a/tmk_core/common/bootmagic_lite.c
+++ b/tmk_core/common/bootmagic_lite.c
@@ -1,12 +1,5 @@
 #include "quantum.h"
 
-#ifndef BOOTMAGIC_LITE_COLUMN
-#    define BOOTMAGIC_LITE_COLUMN 0
-#endif
-#ifndef BOOTMAGIC_LITE_ROW
-#    define BOOTMAGIC_LITE_ROW 0
-#endif
-
 bool is_keyboard_left(void);
 
 /** \brief The lite version of TMK's bootmagic based on Wilba.

--- a/tmk_core/common/bootmagic_lite.c
+++ b/tmk_core/common/bootmagic_lite.c
@@ -2,6 +2,18 @@
 
 bool is_keyboard_left(void);
 
+/** \brief Reset eeprom
+ * 
+ * ...just incase someone wants to only change the eeprom behaviour
+ */
+__attribute__((weak)) void bootmagic_lite_reset_eeprom(void) {
+#if defined(VIA_ENABLE)
+    via_eeprom_reset();
+#else
+    eeconfig_disable();
+#endif
+}
+
 /** \brief The lite version of TMK's bootmagic based on Wilba.
  *
  *  100% less potential for accidentally making the keyboard do stupid things.
@@ -31,11 +43,8 @@ __attribute__((weak)) void bootmagic_lite(void) {
 #endif
 
     if (matrix_get_row(row) & (1 << col)) {
-#if defined(VIA_ENABLE)
-        via_eeprom_reset();
-#else
-        eeconfig_disable();
-#endif
+        bootmagic_lite_reset_eeprom();
+
         // Jump to bootloader.
         bootloader_jump();
     }

--- a/tmk_core/common/bootmagic_lite.c
+++ b/tmk_core/common/bootmagic_lite.c
@@ -1,0 +1,49 @@
+#include "quantum.h"
+
+#ifndef BOOTMAGIC_LITE_COLUMN
+#    define BOOTMAGIC_LITE_COLUMN 0
+#endif
+#ifndef BOOTMAGIC_LITE_ROW
+#    define BOOTMAGIC_LITE_ROW 0
+#endif
+
+bool is_keyboard_left(void);
+
+/** \brief The lite version of TMK's bootmagic based on Wilba.
+ *
+ *  100% less potential for accidentally making the keyboard do stupid things.
+ */
+__attribute__((weak)) void bootmagic_lite(void) {
+    // We need multiple scans because debouncing can't be turned off.
+    matrix_scan();
+#if defined(DEBOUNCE) && DEBOUNCE > 0
+    wait_ms(DEBOUNCE * 2);
+#else
+    wait_ms(30);
+#endif
+    matrix_scan();
+
+    // If the configured key (commonly Esc) is held down on power up,
+    // reset the EEPROM valid state and jump to bootloader.
+    // This isn't very generalized, but we need something that doesn't
+    // rely on user's keymaps in firmware or EEPROM.
+    uint8_t row = BOOTMAGIC_LITE_ROW;
+    uint8_t col = BOOTMAGIC_LITE_COLUMN;
+
+#if defined(SPLIT_KEYBOARD) && defined(BOOTMAGIC_LITE_ROW_RIGHT) && defined(BOOTMAGIC_LITE_COLUMN_RIGHT)
+    if (!is_keyboard_left()) {
+        row = BOOTMAGIC_LITE_ROW_RIGHT;
+        col = BOOTMAGIC_LITE_COLUMN_RIGHT;
+    }
+#endif
+
+    if (matrix_get_row(row) & (1 << col)) {
+#if defined(VIA_ENABLE)
+        via_eeprom_reset();
+#else
+        eeconfig_disable();
+#endif
+        // Jump to bootloader.
+        bootloader_jump();
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Pulled the bootmagic logic into its own file. And to avoid implementing the logic in 2 places, I have merged the via override logic in.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
