### PR TITLE
Remove NO_UART defines from config.h for V-USB boards

### DIFF
--- a/keyboards/ares/config.h
+++ b/keyboards/ares/config.h
@@ -42,8 +42,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define RGBLIGHT_ANIMATIONS
 
-#define NO_UART 1
-
 /* key combination for magic key command */
 /* defined by default; to change, uncomment and set to the combination you want */
 // #define IS_COMMAND() (get_mods() == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT)))

--- a/keyboards/bfake/config.h
+++ b/keyboards/bfake/config.h
@@ -41,5 +41,3 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define BACKLIGHT_LEVELS 3
 
 #define RGBLIGHT_ANIMATIONS
-
-#define NO_UART 1

--- a/keyboards/coseyfannitutti/discipad/config.h
+++ b/keyboards/coseyfannitutti/discipad/config.h
@@ -49,7 +49,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* COL2ROW, ROW2COL*/
 #define DIODE_DIRECTION COL2ROW
 
-#define NO_UART 1
 #define USB_MAX_POWER_CONSUMPTION 100
 
 /*

--- a/keyboards/coseyfannitutti/discipline/config.h
+++ b/keyboards/coseyfannitutti/discipline/config.h
@@ -47,7 +47,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* COL2ROW, ROW2COL*/
 #define DIODE_DIRECTION COL2ROW
 
-#define NO_UART 1
 #define USB_MAX_POWER_CONSUMPTION 100
 
 /*

--- a/keyboards/coseyfannitutti/mysterium/config.h
+++ b/keyboards/coseyfannitutti/mysterium/config.h
@@ -47,8 +47,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* COL2ROW, ROW2COL*/
 #define DIODE_DIRECTION COL2ROW
 
-#define NO_UART 1
-
 /*
  * Split Keyboard specific options, make sure you have 'SPLIT_KEYBOARD = yes' in your rules.mk, and define SOFT_SERIAL_PIN.
  */

--- a/keyboards/db/db63/config.h
+++ b/keyboards/db/db63/config.h
@@ -37,7 +37,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGBLED_NUM 18
 #define RGBLIGHT_ANIMATIONS
 
-#define NO_UART 1
-
 #define BACKLIGHT_PIN D4
 #define BACKLIGHT_LEVELS 3

--- a/keyboards/exent/config.h
+++ b/keyboards/exent/config.h
@@ -44,8 +44,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define RGBLIGHT_ANIMATIONS
 
-#define NO_UART 1
-
 /* key combination for magic key command */
 /* defined by default; to change, uncomment and set to the combination you want */
 // #define IS_COMMAND() (get_mods() == MOD_MASK_SHIFT)

--- a/keyboards/ft/mars80/config.h
+++ b/keyboards/ft/mars80/config.h
@@ -43,8 +43,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define RGBLIGHT_ANIMATIONS
 
-#define NO_UART 1
-
 /* key combination for magic key command */
 /* defined by default; to change, uncomment and set to the combination you want */
 // #define IS_COMMAND() (get_mods() == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT)))

--- a/keyboards/gingham/config.h
+++ b/keyboards/gingham/config.h
@@ -50,7 +50,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* COL2ROW, ROW2COL*/
 #define DIODE_DIRECTION COL2ROW
 
-#define NO_UART 1
 #define USB_MAX_POWER_CONSUMPTION 100
 
 /*

--- a/keyboards/j80/config.h
+++ b/keyboards/j80/config.h
@@ -38,8 +38,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define BACKLIGHT_LEVELS 3
 #define BACKLIGHT_PIN D4
 
-#define NO_UART 1
-
 /* disable these deprecated features by default */
 #ifndef LINK_TIME_OPTIMIZATION_ENABLE
   #define NO_ACTION_MACRO

--- a/keyboards/jc65/v32a/config.h
+++ b/keyboards/jc65/v32a/config.h
@@ -42,7 +42,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGBLIGHT_VAL_STEP 8
 #define RGBLIGHT_EFFECT_KNIGHT_LED_NUM 8
 
-#define NO_UART 1
-
 #define NO_ACTION_MACRO
 #define NO_ACTION_FUNCTION

--- a/keyboards/jj40/config.h
+++ b/keyboards/jj40/config.h
@@ -45,7 +45,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
 #define DEBOUNCE 5
 
-#define NO_UART 1
 #define USB_MAX_POWER_CONSUMPTION 100
 
 /* key combination for magic key command */

--- a/keyboards/jj4x4/config.h
+++ b/keyboards/jj4x4/config.h
@@ -48,7 +48,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
 #define DEBOUNCE 5
 
-#define NO_UART 1
 #define USB_MAX_POWER_CONSUMPTION 100
 
 /* key combination for magic key command */

--- a/keyboards/jj50/config.h
+++ b/keyboards/jj50/config.h
@@ -48,6 +48,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGBLIGHT_SAT_STEP 15
 #define RGBLIGHT_VAL_STEP 18
 
-#define NO_UART 1
-
 #endif

--- a/keyboards/keycapsss/plaid_pad/config.h
+++ b/keyboards/keycapsss/plaid_pad/config.h
@@ -25,7 +25,6 @@
 /* COL2ROW, ROW2COL*/
 #define DIODE_DIRECTION COL2ROW
 
-#define NO_UART 1
 #define USB_MAX_POWER_CONSUMPTION 100
 
 /* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */

--- a/keyboards/mechmini/v1/config.h
+++ b/keyboards/mechmini/v1/config.h
@@ -35,8 +35,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MATRIX_COL_PINS { A0, A1, A2, A3, A4, A5, A6, A7, C7, C6, C5, C4 }
 #define DIODE_DIRECTION COL2ROW
 
-#define NO_UART 1
-
 #define BACKLIGHT_PIN D4
 #define BACKLIGHT_LEVELS 3
 

--- a/keyboards/mt40/config.h
+++ b/keyboards/mt40/config.h
@@ -35,8 +35,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MATRIX_ROWS 7
 #define MATRIX_COLS 15
 
-#define NO_UART 1
-
 #define RGB_DI_PIN C0
 #define RGBLED_NUM 12
 #define RGBLIGHT_ANIMATIONS

--- a/keyboards/pearl/config.h
+++ b/keyboards/pearl/config.h
@@ -26,8 +26,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define PRODUCT      Pearl
 #define DESCRIPTION  40% keyboard
 
-#define NO_UART 1
-
 #define RGBLIGHT_ANIMATIONS
 #define RGBLED_NUM 12
 

--- a/keyboards/percent/canoe/config.h
+++ b/keyboards/percent/canoe/config.h
@@ -43,6 +43,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define RGBLIGHT_ANIMATIONS
 
-#define NO_UART 1
-
 #endif

--- a/keyboards/percent/skog/config.h
+++ b/keyboards/percent/skog/config.h
@@ -37,5 +37,3 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define BACKLIGHT_PIN D4
 #define BACKLIGHT_LEVELS 5
-
-#define NO_UART 1

--- a/keyboards/plaid/config.h
+++ b/keyboards/plaid/config.h
@@ -49,7 +49,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* COL2ROW, ROW2COL*/
 #define DIODE_DIRECTION COL2ROW
 
-#define NO_UART 1
 #define USB_MAX_POWER_CONSUMPTION 100
 
 /*

--- a/keyboards/tartan/config.h
+++ b/keyboards/tartan/config.h
@@ -49,8 +49,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* COL2ROW, ROW2COL*/
 #define DIODE_DIRECTION COL2ROW
 
-#define NO_UART 1
-
 /*
  * Split Keyboard specific options, make sure you have 'SPLIT_KEYBOARD = yes' in your rules.mk, and define SOFT_SERIAL_PIN.
  */

--- a/keyboards/tgr/alice/config.h
+++ b/keyboards/tgr/alice/config.h
@@ -38,5 +38,3 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define RGBLED_NUM 18
 #define RGBLIGHT_ANIMATIONS
-
-#define NO_UART 1

--- a/keyboards/winkeyless/bface/config.h
+++ b/keyboards/winkeyless/bface/config.h
@@ -40,7 +40,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGBLED_NUM 16
 #define RGBLIGHT_ANIMATIONS
 
-#define NO_UART 1
-
 #define BACKLIGHT_PIN D4
 #define BACKLIGHT_LEVELS 3

--- a/keyboards/winkeyless/bmini/config.h
+++ b/keyboards/winkeyless/bmini/config.h
@@ -38,5 +38,3 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define BACKLIGHT_PIN D4
 #define BACKLIGHT_LEVELS 3
-
-#define NO_UART 1

--- a/keyboards/winkeyless/bminiex/config.h
+++ b/keyboards/winkeyless/bminiex/config.h
@@ -38,5 +38,3 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define BACKLIGHT_PIN D4
 #define BACKLIGHT_LEVELS 5
-
-#define NO_UART 1

--- a/keyboards/ymd75/config.h
+++ b/keyboards/ymd75/config.h
@@ -47,5 +47,3 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGBLIGHT_HUE_STEP 12
 #define RGBLIGHT_SAT_STEP 15
 #define RGBLIGHT_VAL_STEP 18
-
-#define NO_UART 1

--- a/keyboards/ymd96/config.h
+++ b/keyboards/ymd96/config.h
@@ -33,7 +33,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MATRIX_ROW_PINS { B0, B1, B2, B3, B4, B5, B6, B7 }
 #define MATRIX_COL_PINS { A0, A1, A2, A3, A4, A5, A6, A7, C7, C6, C5, C4, C3, C2, D7 }
 
-//#define RGB_DI_PIN C4
 /* COL2ROW or ROW2COL */
 #define DIODE_DIRECTION COL2ROW
 
@@ -43,7 +42,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define TAPPING_TOGGLE 3
 
-#define NO_UART 1
 #define USB_MAX_POWER_CONSUMPTION 100
 
 /* RGB underglow */
@@ -52,6 +50,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGBLED_NUM 18
 #define RGB_DI_PIN E2 // NOTE: for PS2AVRGB boards, underglow commands are sent via I2C to 0xB0.
 #define RGBLIGHT_ANIMATIONS
-/*#define RGBLIGHT_VAL_STEP 20
-
-#define NO_UART 1*/
+/*#define RGBLIGHT_VAL_STEP 20*/

--- a/keyboards/ymdk/bface/config.h
+++ b/keyboards/ymdk/bface/config.h
@@ -36,7 +36,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define DIODE_DIRECTION COL2ROW
 
-#define NO_UART 1
-
 #define BACKLIGHT_PIN       D4
 #define BACKLIGHT_LEVELS    6

--- a/keyboards/ymdk_np21/config.h
+++ b/keyboards/ymdk_np21/config.h
@@ -42,8 +42,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define TAPPING_TOGGLE 3
 
-#define NO_UART 1
-
 #define USB_MAX_POWER_CONSUMPTION 100
 
 /* RGB underglow */

--- a/quantum/template/ps2avrgb/config.h
+++ b/quantum/template/ps2avrgb/config.h
@@ -42,8 +42,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define BACKLIGHT_LEVELS 1
 #define RGBLIGHT_ANIMATIONS
 
-#define NO_UART 1
-
 /* disable these deprecated features by default */
 #ifndef LINK_TIME_OPTIMIZATION_ENABLE
   #define NO_ACTION_MACRO


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This is already defined by default, in tmk_core/common.mk, due to the `NO_UART ?= yes` in mcu_selection.mk.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
