### PR TITLE
Rename qmk json-keymap to qmk json2c

### DIFF
--- a/build_json.mk
+++ b/build_json.mk
@@ -23,4 +23,4 @@ endif
 
 # Generate the keymap.c
 $(KEYBOARD_OUTPUT)/src/keymap.c: $(KEYMAP_JSON)
-	bin/qmk json-keymap --quiet --output $(KEYMAP_C) $(KEYMAP_JSON)
+	bin/qmk json2c --quiet --output $(KEYMAP_C) $(KEYMAP_JSON)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -231,14 +231,14 @@ Check your environment and report problems only:
 
     qmk doctor -n
 
-## `qmk json-keymap`
+## `qmk json2c`
 
 Creates a keymap.c from a QMK Configurator export.
 
 **Usage**:
 
 ```
-qmk json-keymap [-o OUTPUT] filename
+qmk json2c [-o OUTPUT] filename
 ```
 
 ## `qmk kle2json`

--- a/docs/ja/cli.md
+++ b/docs/ja/cli.md
@@ -215,14 +215,14 @@ qmk doctor [-y] [-n]
 
     qmk doctor -n
 
-## `qmk json-keymap`
+## `qmk json2c`
 
 QMK Configurator からエクスポートしたものから keymap.c を生成します。
 
 **使用法**:
 
 ```
-qmk json-keymap [-o OUTPUT] filename
+qmk json2c [-o OUTPUT] filename
 ```
 
 ## `qmk kle2json`

--- a/lib/python/qmk/cli/__init__.py
+++ b/lib/python/qmk/cli/__init__.py
@@ -10,6 +10,7 @@ from . import doctor
 from . import flash
 from . import hello
 from . import json
+from . import json2c
 from . import list
 from . import kle2json
 from . import new

--- a/lib/python/qmk/cli/json/keymap.py
+++ b/lib/python/qmk/cli/json/keymap.py
@@ -18,39 +18,5 @@ def json_keymap(cli):
 
     This command uses the `qmk.keymap` module to generate a keymap.c from a configurator export. The generated keymap is written to stdout, or to a file if -o is provided.
     """
-    cli.args.filename = qmk.path.normpath(cli.args.filename)
-
-    # Error checking
-    if not cli.args.filename.exists():
-        cli.log.error('JSON file does not exist!')
-        cli.print_usage()
-        exit(1)
-
-    if str(cli.args.filename) == '-':
-        # TODO(skullydazed/anyone): Read file contents from STDIN
-        cli.log.error('Reading from STDIN is not (yet) supported.')
-        cli.print_usage()
-        exit(1)
-
-    # Environment processing
-    if cli.args.output == ('-'):
-        cli.args.output = None
-
-    # Parse the configurator json
-    with cli.args.filename.open('r') as fd:
-        user_keymap = json.load(fd)
-
-    # Generate the keymap
-    keymap_c = qmk.keymap.generate(user_keymap['keyboard'], user_keymap['layout'], user_keymap['layers'])
-
-    if cli.args.output:
-        cli.args.output.parent.mkdir(parents=True, exist_ok=True)
-        if cli.args.output.exists():
-            cli.args.output.replace(cli.args.output.name + '.bak')
-        cli.args.output.write_text(keymap_c)
-
-        if not cli.args.quiet:
-            cli.log.info('Wrote keymap to %s.', cli.args.output)
-
-    else:
-        print(keymap_c)
+    cli.log.error('This command has been renamed to `qmk json2c`.')
+    exit(1)

--- a/lib/python/qmk/cli/json/keymap.py
+++ b/lib/python/qmk/cli/json/keymap.py
@@ -1,22 +1,15 @@
 """Generate a keymap.c from a configurator export.
 """
-import json
 from pathlib import Path
 
 from milc import cli
-
-import qmk.keymap
-import qmk.path
-
 
 @cli.argument('-o', '--output', arg_only=True, type=Path, help='File to write to')
 @cli.argument('-q', '--quiet', arg_only=True, action='store_true', help="Quiet mode, only output error messages")
 @cli.argument('filename', arg_only=True, help='Configurator JSON file')
 @cli.subcommand('Creates a keymap.c from a QMK Configurator export.')
 def json_keymap(cli):
-    """Generate a keymap.c from a configurator export.
-
-    This command uses the `qmk.keymap` module to generate a keymap.c from a configurator export. The generated keymap is written to stdout, or to a file if -o is provided.
+    """Renamed to `qmk json2c`.
     """
     cli.log.error('This command has been renamed to `qmk json2c`.')
     exit(1)

--- a/lib/python/qmk/cli/json/keymap.py
+++ b/lib/python/qmk/cli/json/keymap.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from milc import cli
 
+
 @cli.argument('-o', '--output', arg_only=True, type=Path, help='File to write to')
 @cli.argument('-q', '--quiet', arg_only=True, action='store_true', help="Quiet mode, only output error messages")
 @cli.argument('filename', arg_only=True, help='Configurator JSON file')

--- a/lib/python/qmk/cli/json2c.py
+++ b/lib/python/qmk/cli/json2c.py
@@ -1,0 +1,56 @@
+"""Generate a keymap.c from a configurator export.
+"""
+import json
+from pathlib import Path
+
+from milc import cli
+
+import qmk.keymap
+import qmk.path
+
+
+@cli.argument('-o', '--output', arg_only=True, type=Path, help='File to write to')
+@cli.argument('-q', '--quiet', arg_only=True, action='store_true', help="Quiet mode, only output error messages")
+@cli.argument('filename', arg_only=True, help='Configurator JSON file')
+@cli.subcommand('Creates a keymap.c from a QMK Configurator export.')
+def json2c(cli):
+    """Generate a keymap.c from a configurator export.
+
+    This command uses the `qmk.keymap` module to generate a keymap.c from a configurator export. The generated keymap is written to stdout, or to a file if -o is provided.
+    """
+    cli.args.filename = qmk.path.normpath(cli.args.filename)
+
+    # Error checking
+    if not cli.args.filename.exists():
+        cli.log.error('JSON file does not exist!')
+        cli.print_usage()
+        exit(1)
+
+    if str(cli.args.filename) == '-':
+        # TODO(skullydazed/anyone): Read file contents from STDIN
+        cli.log.error('Reading from STDIN is not (yet) supported.')
+        cli.print_usage()
+        exit(1)
+
+    # Environment processing
+    if cli.args.output == ('-'):
+        cli.args.output = None
+
+    # Parse the configurator json
+    with cli.args.filename.open('r') as fd:
+        user_keymap = json.load(fd)
+
+    # Generate the keymap
+    keymap_c = qmk.keymap.generate(user_keymap['keyboard'], user_keymap['layout'], user_keymap['layers'])
+
+    if cli.args.output:
+        cli.args.output.parent.mkdir(parents=True, exist_ok=True)
+        if cli.args.output.exists():
+            cli.args.output.replace(cli.args.output.name + '.bak')
+        cli.args.output.write_text(keymap_c)
+
+        if not cli.args.quiet:
+            cli.log.info('Wrote keymap to %s.', cli.args.output)
+
+    else:
+        print(keymap_c)


### PR DESCRIPTION
Per title, rename for consistency with other and future commands. Should also make this functionality easier to find for people who want to use configurator to generate `keymap.c` files.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Enhancement/optimization
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
