### PR TITLE
add hid_raw feature to VUSB

### DIFF
--- a/tmk_core/protocol/vusb/main.c
+++ b/tmk_core/protocol/vusb/main.c
@@ -108,6 +108,13 @@ int main(void) {
                 keyboard_task();
             }
             vusb_transfer_keyboard();
+#ifdef RAW_ENABLE
+            usbPoll();
+
+            if (usbConfiguration && usbInterruptIsReady3()) {
+                raw_hid_task();
+            }
+#endif
         }
     }
 }

--- a/tmk_core/protocol/vusb/vusb.c
+++ b/tmk_core/protocol/vusb/vusb.c
@@ -83,14 +83,14 @@ void vusb_transfer_keyboard(void) {
  * RAW HID
  *------------------------------------------------------------------*/
 #ifdef RAW_ENABLE
-#    define RAW_INPUT_SIZE (32)
-#    define RAW_OUTPUT_SIZE (32)
+#    define RAW_BUFFER_SIZE 32
+#    define RAW_EPSIZE 8
 
-static uint8_t raw_output_buffer[RAW_OUTPUT_SIZE];
+static uint8_t raw_output_buffer[RAW_BUFFER_SIZE];
 static uint8_t raw_output_received_bytes = 0;
 
 void raw_hid_send(uint8_t *data, uint8_t length) {
-    if (length != RAW_INPUT_SIZE) {
+    if (length != RAW_BUFFER_SIZE) {
         return;
     }
 
@@ -117,8 +117,8 @@ __attribute__((weak)) void raw_hid_receive(uint8_t *data, uint8_t length) {
 }
 
 void raw_hid_task(void) {
-    if (raw_output_received_bytes == RAW_OUTPUT_SIZE) {
-        raw_hid_receive(raw_output_buffer, RAW_OUTPUT_SIZE);
+    if (raw_output_received_bytes == RAW_BUFFER_SIZE) {
+        raw_hid_receive(raw_output_buffer, RAW_BUFFER_SIZE);
         raw_output_received_bytes = 0;
     }
 }
@@ -269,7 +269,7 @@ void usbFunctionWriteOut(uchar *data, uchar len) {
         return;
     }
 
-    if (raw_output_received_bytes + len > RAW_OUTPUT_SIZE) {
+    if (raw_output_received_bytes + len > RAW_BUFFER_SIZE) {
         debug("RAW: buffer full");
         raw_output_received_bytes = 0;
     } else {
@@ -416,17 +416,17 @@ const PROGMEM uchar raw_hid_report[] = {
     0x09, 0x61,        // Usage (Vendor Defined)
     0xA1, 0x01,        // Collection (Application)
     // Data to host
-    0x09, 0x62,            //   Usage (Vendor Defined)
-    0x15, 0x00,            //   Logical Minimum (0)
-    0x26, 0xFF, 0x00,      //   Logical Maximum (255)
-    0x95, RAW_INPUT_SIZE,  //   Report Count
-    0x75, 0x08,            //   Report Size (8)
-    0x81, 0x02,            //   Input (Data, Variable, Absolute)
+    0x09, 0x62,             //   Usage (Vendor Defined)
+    0x15, 0x00,             //   Logical Minimum (0)
+    0x26, 0xFF, 0x00,       //   Logical Maximum (255)
+    0x95, RAW_BUFFER_SIZE,  //   Report Count
+    0x75, 0x08,             //   Report Size (8)
+    0x81, 0x02,             //   Input (Data, Variable, Absolute)
     // Data from host
     0x09, 0x63,             //   Usage (Vendor Defined)
     0x15, 0x00,             //   Logical Minimum (0)
     0x26, 0xFF, 0x00,       //   Logical Maximum (255)
-    0x95, RAW_OUTPUT_SIZE,  //   Report Count
+    0x95, RAW_BUFFER_SIZE,  //   Report Count
     0x75, 0x08,             //   Report Size (8)
     0x91, 0x02,             //   Output (Data, Variable, Absolute)
     0xC0,                   // End Collection
@@ -642,7 +642,7 @@ const PROGMEM usbConfigurationDescriptor_t usbConfigurationDescriptor = {
         },
         .bEndpointAddress    = (USBRQ_DIR_DEVICE_TO_HOST | USB_CFG_EP3_NUMBER),
         .bmAttributes        = 0x03,
-        .wMaxPacketSize      = 8,
+        .wMaxPacketSize      = RAW_EPSIZE,
         .bInterval           = USB_POLLING_INTERVAL_MS
     },
     .rawOUTEndpoint = {
@@ -652,7 +652,7 @@ const PROGMEM usbConfigurationDescriptor_t usbConfigurationDescriptor = {
         },
         .bEndpointAddress    = (USBRQ_DIR_HOST_TO_DEVICE | USB_CFG_EP3_NUMBER),
         .bmAttributes        = 0x03,
-        .wMaxPacketSize      = 8,
+        .wMaxPacketSize      = RAW_EPSIZE,
         .bInterval           = USB_POLLING_INTERVAL_MS
     }
 #        endif

--- a/tmk_core/protocol/vusb/vusb.c
+++ b/tmk_core/protocol/vusb/vusb.c
@@ -87,7 +87,7 @@ void vusb_transfer_keyboard(void) {
 #    define RAW_OUTPUT_SIZE (32)
 
 static uint8_t raw_output_buffer[RAW_OUTPUT_SIZE];
-static uint8_t raw_output_received_bytes = 0;
+static uint8_t raw_output_recieved_bytes = 0;
 
 void raw_hid_send(uint8_t *data, uint8_t length) {
     if (length != RAW_INPUT_SIZE) {

--- a/tmk_core/protocol/vusb/vusb.c
+++ b/tmk_core/protocol/vusb/vusb.c
@@ -33,7 +33,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #endif
 
 #if (defined(MOUSE_ENABLE) || defined(EXTRAKEY_ENABLE)) && defined(RAW_ENABLE)
-#    error "can't use mouse/extra key and hid raw at same time on VUSB"
+#    error "Enabling Mousekeys/Extrakeys and Raw HID at the same time is not currently supported on V-USB."
 #endif
 
 static uint8_t vusb_keyboard_leds = 0;

--- a/tmk_core/protocol/vusb/vusb.c
+++ b/tmk_core/protocol/vusb/vusb.c
@@ -87,7 +87,7 @@ void vusb_transfer_keyboard(void) {
 #    define RAW_OUTPUT_SIZE (32)
 
 static uint8_t raw_output_buffer[RAW_OUTPUT_SIZE];
-static uint8_t raw_output_recieved_bytes = 0;
+static uint8_t raw_output_received_bytes = 0;
 
 void raw_hid_send(uint8_t *data, uint8_t length) {
     if (length != RAW_INPUT_SIZE) {
@@ -117,9 +117,9 @@ __attribute__((weak)) void raw_hid_receive(uint8_t *data, uint8_t length) {
 }
 
 void raw_hid_task(void) {
-    if (raw_output_recieved_bytes == RAW_OUTPUT_SIZE) {
+    if (raw_output_received_bytes == RAW_OUTPUT_SIZE) {
         raw_hid_receive(raw_output_buffer, RAW_OUTPUT_SIZE);
-        raw_output_recieved_bytes = 0;
+        raw_output_received_bytes = 0;
     }
 }
 
@@ -265,18 +265,18 @@ void usbFunctionWriteOut(uchar *data, uchar len) {
     // Data from host must be divided every 8bytes
     if (len != 8) {
         debug("RAW: invalid length");
-        raw_output_recieved_bytes = 0;
+        raw_output_received_bytes = 0;
         return;
     }
 
-    if (raw_output_recieved_bytes + len > RAW_OUTPUT_SIZE) {
+    if (raw_output_received_bytes + len > RAW_OUTPUT_SIZE) {
         debug("RAW: buffer full");
-        raw_output_recieved_bytes = 0;
+        raw_output_received_bytes = 0;
     } else {
         for (uint8_t i = 0; i < 8; i++) {
-            raw_output_buffer[raw_output_recieved_bytes + i] = data[i];
+            raw_output_buffer[raw_output_received_bytes + i] = data[i];
         }
-        raw_output_recieved_bytes += len;
+        raw_output_received_bytes += len;
     }
 #endif
 }

--- a/tmk_core/protocol/vusb/vusb.h
+++ b/tmk_core/protocol/vusb/vusb.h
@@ -97,9 +97,7 @@ typedef struct usbConfigurationDescriptor {
 #    ifdef USB_CFG_HAVE_INTRIN_ENDPOINT3
     usbEndpointDescriptor_t mouseExtraINEndpoint;
 #    endif
-#endif
-
-#if defined(RAW_ENABLE)
+#elif defined(RAW_ENABLE)
     usbInterfaceDescriptor_t rawInterface;
     usbHIDDescriptor_t       rawHID;
 #    ifdef USB_CFG_HAVE_INTRIN_ENDPOINT3

--- a/tmk_core/protocol/vusb/vusb.h
+++ b/tmk_core/protocol/vusb/vusb.h
@@ -98,9 +98,22 @@ typedef struct usbConfigurationDescriptor {
     usbEndpointDescriptor_t mouseExtraINEndpoint;
 #    endif
 #endif
+
+#if defined(RAW_ENABLE)
+    usbInterfaceDescriptor_t rawInterface;
+    usbHIDDescriptor_t       rawHID;
+#    ifdef USB_CFG_HAVE_INTRIN_ENDPOINT3
+    usbEndpointDescriptor_t rawINEndpoint;
+    usbEndpointDescriptor_t rawOUTEndpoint;
+#    endif
+#endif
 } __attribute__((packed)) usbConfigurationDescriptor_t;
 
 #define USB_STRING_LEN(s) (sizeof(usbDescriptorHeader_t) + ((s) << 1))
 
 host_driver_t *vusb_driver(void);
 void           vusb_transfer_keyboard(void);
+
+#if defined(RAW_ENABLE)
+void raw_hid_task(void);
+#endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Add hid_raw feature to keyboard with USB. 

Currently,  I had tested on atmega328p.   
Would anyone test on other VUSB MCU?
Test method is here.  https://github.com/qmk/qmk_firmware/issues/8320#issuecomment-597762268

### Limitation
This feature is not available with  mousekey / extrakey.

## TODO
- [ ] Add documentation for setting in `usbconfig.h`

~I will remove draft flag after #8321 merged.~

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #8320

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
