### PR TITLE
buildfix for Travis failing on mxss:default because of custom rgblight

### DIFF
--- a/keyboards/mxss/rgblight.h
+++ b/keyboards/mxss/rgblight.h
@@ -16,8 +16,6 @@
 #ifndef RGBLIGHT_H
 #define RGBLIGHT_H
 
-#include "rgblight_reconfig.h"
-
 /***** rgblight_mode(mode)/rgblight_mode_noeeprom(mode) ****
 
  old mode number (before 0.6.117) to new mode name table

--- a/keyboards/mxss/rules.mk
+++ b/keyboards/mxss/rules.mk
@@ -32,10 +32,11 @@ FAUXCLICKY_ENABLE = no      # Use buzzer to emulate clicky switches
 
 SRC += mxss_frontled.c
 
+RGBLIGHT_ENABLE = yes
 # Remove the common RGB light code and use my iteration instead
-OPT_DEFS += -DRGBLIGHT_ENABLE
-SRC += $(QUANTUM_DIR)/process_keycode/process_rgb.c
-SRC += rgblight.c
-SRC += color.c
-SRC += ws2812.c
-CIE1931_CURVE = yes
+#OPT_DEFS += -DRGBLIGHT_ENABLE
+#SRC += $(QUANTUM_DIR)/process_keycode/process_rgb.c
+#SRC += rgblight.c
+#SRC += color.c
+#SRC += ws2812.c
+#CIE1931_CURVE = yes


### PR DESCRIPTION
Travis fails on mxss:default because it uses a custom rgblight implementation instead of the qmk/quantum one, which was refactored in #7773

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Travis build failing with:
[ERRORS]
In file included from keyboards/mxss/rgblight.c:30:0:
keyboards/mxss/rgblight.h:19:31: fatal error: rgblight_reconfig.h: No such file or directory
compilation terminated.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
