### PR TITLE
fix keyboards/mxss/rgblight.h

### DIFF
--- a/keyboards/mxss/rgblight.h
+++ b/keyboards/mxss/rgblight.h
@@ -16,8 +16,6 @@
 #ifndef RGBLIGHT_H
 #define RGBLIGHT_H
 
-#include "rgblight_reconfig.h"
-
 /***** rgblight_mode(mode)/rgblight_mode_noeeprom(mode) ****
 
  old mode number (before 0.6.117) to new mode name table
@@ -63,6 +61,39 @@
 |       36        | RGBLIGHT_MODE_ALTERNATING         |
 |-----------------|-----------------------------------|
  *****/
+
+#ifdef RGBLIGHT_ANIMATIONS
+// for backward compatibility
+#    define RGBLIGHT_EFFECT_BREATHING
+#    define RGBLIGHT_EFFECT_RAINBOW_MOOD
+#    define RGBLIGHT_EFFECT_RAINBOW_SWIRL
+#    define RGBLIGHT_EFFECT_SNAKE
+#    define RGBLIGHT_EFFECT_KNIGHT
+#    define RGBLIGHT_EFFECT_CHRISTMAS
+#    define RGBLIGHT_EFFECT_STATIC_GRADIENT
+#    define RGBLIGHT_EFFECT_RGB_TEST
+#    define RGBLIGHT_EFFECT_ALTERNATING
+#endif
+
+#ifdef RGBLIGHT_STATIC_PATTERNS
+#    define RGBLIGHT_EFFECT_STATIC_GRADIENT
+#endif
+
+// clang-format off
+
+// check dynamic animation effects chose ?
+#if  defined(RGBLIGHT_EFFECT_BREATHING)     \
+  || defined(RGBLIGHT_EFFECT_RAINBOW_MOOD)  \
+  || defined(RGBLIGHT_EFFECT_RAINBOW_SWIRL) \
+  || defined(RGBLIGHT_EFFECT_SNAKE)         \
+  || defined(RGBLIGHT_EFFECT_KNIGHT)        \
+  || defined(RGBLIGHT_EFFECT_CHRISTMAS)     \
+  || defined(RGBLIGHT_EFFECT_RGB_TEST)      \
+  || defined(RGBLIGHT_EFFECT_ALTERNATING)
+#    define RGBLIGHT_USE_TIMER
+#endif
+
+// clang-format on
 
 #define _RGBM_SINGLE_STATIC(sym) RGBLIGHT_MODE_##sym,
 #define _RGBM_SINGLE_DYNAMIC(sym) RGBLIGHT_MODE_##sym,
@@ -263,12 +294,19 @@ void rgblight_mode_eeprom_helper(uint8_t mode, bool write_to_eeprom);
 #    define EZ_RGB(val) rgblight_show_solid_color((val >> 16) & 0xFF, (val >> 8) & 0xFF, val & 0xFF)
 void rgblight_show_solid_color(uint8_t r, uint8_t g, uint8_t b);
 
+#    ifdef RGBLIGHT_USE_TIMER
 void rgblight_task(void);
-
 void rgblight_timer_init(void);
 void rgblight_timer_enable(void);
 void rgblight_timer_disable(void);
 void rgblight_timer_toggle(void);
+#    else
+#        define rgblight_task()
+#        define rgblight_timer_init()
+#        define rgblight_timer_enable()
+#        define rgblight_timer_disable()
+#        define rgblight_timer_toggle()
+#    endif
 
 #    ifdef RGBLIGHT_SPLIT
 #        define RGBLIGHT_STATUS_CHANGE_MODE (1 << 0)


### PR DESCRIPTION
## Description

PR #7773 caused a build error for `mxss:default`, I made similar changes to 'keyboards/mxss/rgblight.h' as #7773 did to 'quantum/rgblight.h'.

**This commit does not change the build result.**

Testing script
```shell
 # build on versions earlier than PR #7773
 git checkout 0.8.24
 echo master > /tmp/master_md5.txt

 make mxss:default:clean
 make mxss:default
 md5 mxss_default.hex >> /tmp/master_md5.txt

 # build on this commit
 git checkout fix-keyboards-mxss-rgblight.h
 echo fix-keyboards-mxss-rgblight.h > /tmp/branch_md5.txt

 make mxss:default:clean
 make mxss:default
 md5 mxss_default.hex >> /tmp/branch_md5.txt

 diff -u /tmp/master_md5.txt /tmp/branch_md5.txt
```

Test result:
```
--- /tmp/master_md5.txt 2020-03-12 05:51:39.000000000 +0900
+++ /tmp/branch_md5.txt 2020-03-12 05:51:49.000000000 +0900
@@ -1,2 +1,2 @@
-master
+fix-keyboards-mxss-rgblight.h
MD5 (mxss_default.hex) = 3034b2504d0c7fc6bd8bf1dffb6b8486
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/qmk/qmk_firmware/pull/7773#issuecomment-597734754

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
