### PR TITLE
Use qmk.path.normpath to locate the output file for json2c

### DIFF
--- a/lib/python/qmk/cli/json2c.py
+++ b/lib/python/qmk/cli/json2c.py
@@ -1,7 +1,6 @@
 """Generate a keymap.c from a configurator export.
 """
 import json
-from pathlib import Path
 
 from milc import cli
 
@@ -9,7 +8,7 @@ import qmk.keymap
 import qmk.path
 
 
-@cli.argument('-o', '--output', arg_only=True, type=Path, help='File to write to')
+@cli.argument('-o', '--output', arg_only=True, type=qmk.path.normpath, help='File to write to')
 @cli.argument('-q', '--quiet', arg_only=True, action='store_true', help="Quiet mode, only output error messages")
 @cli.argument('filename', arg_only=True, help='Configurator JSON file')
 @cli.subcommand('Creates a keymap.c from a QMK Configurator export.')


### PR DESCRIPTION
Currently the `qmk json2c -o <file>` command outputs relative to `qmk_firmware`. It should output relative to the current directory instead.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
