### PR TITLE
Realign dynamic macros with recent SEND_STRING changes

### DIFF
--- a/quantum/dynamic_keymap.c
+++ b/quantum/dynamic_keymap.c
@@ -210,9 +210,9 @@ void dynamic_keymap_macro_send(uint8_t id) {
         ++p;
     }
 
-    // Send the macro string one or two chars at a time
-    // by making temporary 1 or 2 char strings
-    char data[3] = {0, 0, 0};
+    // Send the macro string one or three chars at a time
+    // by making temporary 1 or 3 char strings
+    char data[4] = {0, 0, 0, 0};
     // We already checked there was a null at the end of
     // the buffer, so this cannot go past the end
     while (1) {
@@ -223,10 +223,12 @@ void dynamic_keymap_macro_send(uint8_t id) {
             break;
         }
         // If the char is magic (tap, down, up),
-        // add the next char (key to use) and send a 2 char string.
+        // add the next char (key to use) and send a 3 char string.
         if (data[0] == SS_TAP_CODE || data[0] == SS_DOWN_CODE || data[0] == SS_UP_CODE) {
-            data[1] = eeprom_read_byte(p++);
-            if (data[1] == 0) {
+            data[1] = data[0];
+            data[0] = SS_QMK_PREFIX;
+            data[2] = eeprom_read_byte(p++);
+            if (data[2] == 0) {
                 break;
             }
         }


### PR DESCRIPTION
## Description

#8244 broke VIA macro handling by changing the protocol of `send_string()`

This PR fixes it by maintaining the original protocol and translating to the new protocol, so we can defer VIA and existing firmware getting out of sync until a major version upgrade of VIA and VIA protocol.
 
## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
