### PR TITLE
Remove unnecessary import of rgblight.h in tmk_core/protocol/*/*.c

### DIFF
--- a/tmk_core/protocol/chibios/main.c
+++ b/tmk_core/protocol/chibios/main.c
@@ -33,9 +33,6 @@
 #include "debug.h"
 #include "printf.h"
 
-#if defined(RGBLIGHT_ENABLE)
-#    include "rgblight.h"
-#endif
 #ifdef SLEEP_LED_ENABLE
 #    include "sleep_led.h"
 #endif

--- a/tmk_core/protocol/lufa/lufa.c
+++ b/tmk_core/protocol/lufa/lufa.c
@@ -77,10 +77,6 @@ extern keymap_config_t keymap_config;
 #    include "virtser.h"
 #endif
 
-#if defined(RGBLIGHT_ENABLE)
-#    include "rgblight.h"
-#endif
-
 #ifdef MIDI_ENABLE
 #    include "qmk_midi.h"
 #endif

--- a/tmk_core/protocol/vusb/main.c
+++ b/tmk_core/protocol/vusb/main.c
@@ -21,9 +21,6 @@
 #include "uart.h"
 #include "debug.h"
 
-#if defined(RGBLIGHT_ENABLE)
-#    include "rgblight.h"
-#endif
 
 #define UART_BAUD_RATE 115200
 


### PR DESCRIPTION
# Description

Remove `#Include "rgblight.h"` from the following files. Because the #7733 removed the call to `rgblight_task()`.

 * tmk_core/protocol/chibios/main.c
 * tmk_core/protocol/lufa/lufa.c
 *  tmk_core/protocol/vusb/main.c

~see #8380 for tmk_core/protocol/vusb/main.c.~


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
