### PR TITLE
Update Italian keymap and add sendstring LUT

### DIFF
--- a/quantum/keymap_extras/keymap_italian.h
+++ b/quantum/keymap_extras/keymap_italian.h
@@ -14,100 +14,171 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef KEYMAP_ITALIAN
-#define KEYMAP_ITALIAN
+#pragma once
 
 #include "keymap.h"
 
-// normal characters
-#define IT_A KC_A
-#define IT_B KC_B
-#define IT_C KC_C
-#define IT_D KC_D
-#define IT_E KC_E
-#define IT_F KC_F
-#define IT_G KC_G
-#define IT_H KC_H
-#define IT_I KC_I
-#define IT_J KC_J
-#define IT_K KC_K
-#define IT_L KC_L
-#define IT_M KC_M
-#define IT_N KC_N
-#define IT_O KC_O
-#define IT_P KC_P
-#define IT_Q KC_Q
-#define IT_R KC_R
-#define IT_S KC_S
-#define IT_T KC_T
-#define IT_U KC_U
-#define IT_V KC_V
-#define IT_W KC_W
-#define IT_X KC_X
-#define IT_Y KC_Y
-#define IT_Z KC_Z
+// clang-format off
 
-#define IT_0 KC_0
-#define IT_1 KC_1
-#define IT_2 KC_2
-#define IT_3 KC_3
-#define IT_4 KC_4
-#define IT_5 KC_5
-#define IT_6 KC_6
-#define IT_7 KC_7
-#define IT_8 KC_8
-#define IT_9 KC_9
+/*
+ * ┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───────┐
+ * │ \ │ 1 │ 2 │ 3 │ 4 │ 5 │ 6 │ 7 │ 8 │ 9 │ 0 │ ' │ ì │       │
+ * ├───┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─────┤
+ * │     │ Q │ W │ E │ R │ T │ Y │ U │ I │ O │ P │ è │ + │     │
+ * ├─────┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┐    │
+ * │      │ A │ S │ D │ F │ G │ H │ J │ K │ L │ ò │ à │ ù │    │
+ * ├────┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴───┴────┤
+ * │    │ < │ Z │ X │ C │ V │ B │ N │ M │ , │ . │ - │          │
+ * ├────┼───┴┬──┴─┬─┴───┴───┴───┴───┴───┴──┬┴───┼───┴┬────┬────┤
+ * │    │    │    │                        │    │    │    │    │
+ * └────┴────┴────┴────────────────────────┴────┴────┴────┴────┘
+ */
+// Row 1
+#define IT_BSLS KC_GRV  // (backslash)
+#define IT_1    KC_1    // 1
+#define IT_2    KC_2    // 2
+#define IT_3    KC_3    // 3
+#define IT_4    KC_4    // 4
+#define IT_5    KC_5    // 5
+#define IT_6    KC_6    // 6
+#define IT_7    KC_7    // 7
+#define IT_8    KC_8    // 8
+#define IT_9    KC_9    // 9
+#define IT_0    KC_0    // 0
+#define IT_QUOT KC_MINS // '
+#define IT_IGRV KC_EQL  // ì
+// Row 2
+#define IT_Q    KC_Q    // Q
+#define IT_W    KC_W    // W
+#define IT_E    KC_E    // E
+#define IT_R    KC_R    // R
+#define IT_T    KC_T    // T
+#define IT_Y    KC_Y    // Y
+#define IT_U    KC_U    // U
+#define IT_I    KC_I    // I
+#define IT_O    KC_O    // O
+#define IT_P    KC_P    // P
+#define IT_EGRV KC_LBRC // è
+#define IT_PLUS KC_RBRC // +
+// Row 3
+#define IT_A    KC_A    // A
+#define IT_S    KC_S    // S
+#define IT_D    KC_D    // D
+#define IT_F    KC_F    // F
+#define IT_G    KC_G    // G
+#define IT_H    KC_H    // H
+#define IT_J    KC_J    // J
+#define IT_K    KC_K    // K
+#define IT_L    KC_L    // L
+#define IT_OGRV KC_SCLN // ò
+#define IT_AGRV KC_QUOT // à
+#define IT_UGRV KC_NUHS // ù
+// Row 4
+#define IT_LABK KC_NUBS // <
+#define IT_Z    KC_Z    // Z
+#define IT_X    KC_X    // X
+#define IT_C    KC_C    // C
+#define IT_B    KC_B    // B
+#define IT_V    KC_V    // V
+#define IT_N    KC_N    // N
+#define IT_M    KC_M    // M
+#define IT_COMM KC_COMM // ,
+#define IT_DOT  KC_DOT  // .
+#define IT_MINS KC_SLSH // -
 
-#define IT_DOT KC_DOT
-#define IT_COMM KC_COMM
+/* Shifted symbols
+ * ┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───────┐
+ * │ | │ ! │ " │ £ │ $ │ % │ & │ / │ ( │ ) │ = │ ? │ ^ │       │
+ * ├───┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─────┤
+ * │     │   │   │   │   │   │   │   │   │   │   │ é │ * │     │
+ * ├─────┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┐    │
+ * │      │   │   │   │   │   │   │   │   │   │ ç │ ° │ § │    │
+ * ├────┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴───┴────┤
+ * │    │ > │   │   │   │   │   │   │   │ ; │ : │ _ │          │
+ * ├────┼───┴┬──┴─┬─┴───┴───┴───┴───┴───┴──┬┴───┼───┴┬────┬────┤
+ * │    │    │    │                        │    │    │    │    │
+ * └────┴────┴────┴────────────────────────┴────┴────┴────┴────┘
+ */
+// Row 1
+#define IT_PIPE S(IT_BSLS) // |
+#define IT_EXLM S(IT_1)    // !
+#define IT_DQUO S(IT_2)    // "
+#define IT_PND  S(IT_3)    // £
+#define IT_DLR  S(IT_4)    // $
+#define IT_PERC S(IT_5)    // %
+#define IT_AMPR S(IT_6)    // &
+#define IT_SLSH S(IT_7)    // /
+#define IT_LPRN S(IT_8)    // (
+#define IT_RPRN S(IT_9)    // )
+#define IT_EQL  S(IT_0)    // =
+#define IT_QUES S(IT_QUOT) // ?
+#define IT_CIRC S(IT_IGRV) // ^
+// Row 2
+#define IT_EACU S(IT_EGRV) // é
+#define IT_ASTR S(IT_PLUS) // *
+// Row 3
+#define IT_CCED S(IT_OGRV) // ç
+#define IT_DEG  S(IT_AGRV) // °
+#define IT_SECT S(IT_UGRV) // §
+// Row 4
+#define IT_RABK S(IT_LABK) // >
+#define IT_COLN S(IT_DOT)  // :
+#define IT_SCLN S(IT_COMM) // ;
+#define IT_UNDS S(IT_MINS) // _
 
-#define IT_EACC KC_LBRC  // è, é, [, {
-#define IT_PLUS KC_RBRC  // +, *, ], }
-#define IT_OACC KC_SCLN  // ò, ç, @,
-#define IT_AACC KC_QUOT  // à, °, #,
-#define IT_UACC KC_BSLS  // ù, §,  ,
-#define IT_IACC KC_EQL   // ì, ^,  ,
+/* AltGr symbols
+ * ┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───────┐
+ * │   │   │   │   │   │   │   │   │   │   │   │   │   │       │
+ * ├───┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─────┤
+ * │     │   │   │ € │   │   │   │   │   │   │   │ [ │ ] │     │
+ * ├─────┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┐    │
+ * │      │   │   │   │   │   │   │   │   │   │ @ │ # │   │    │
+ * ├────┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴───┴────┤
+ * │    │   │   │   │   │   │   │   │   │   │   │   │          │
+ * ├────┼───┴┬──┴─┬─┴───┴───┴───┴───┴───┴──┬┴───┼───┴┬────┬────┤
+ * │    │    │    │                        │    │    │    │    │
+ * └────┴────┴────┴────────────────────────┴────┴────┴────┴────┘
+ */
+// Row 2
+#define IT_EURO ALGR(IT_E)       // €
+#define IT_LBRC ALGR(IT_EGRV)    // [
+#define IT_RBRC ALGR(IT_PLUS)    // ]
+// Row 3
+#define IT_AT   ALGR(IT_OGRV)    // @
+#define IT_HASH ALGR(IT_AGRV)    // #
 
-#define IT_APOS KC_MINS  // ', ?,  ,
+/* Shift+AltGr symbols
+ * ┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───────┐
+ * │   │   │   │   │   │   │   │   │   │   │   │   │   │       │
+ * ├───┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─────┤
+ * │     │   │   │   │   │   │   │   │   │   │   │ { │ } │     │
+ * ├─────┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┐    │
+ * │      │   │   │   │   │   │   │   │   │   │   │   │   │    │
+ * ├────┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴───┴────┤
+ * │    │   │   │   │   │   │   │   │   │   │   │   │          │
+ * ├────┼───┴┬──┴─┬─┴───┴───┴───┴───┴───┴──┬┴───┼───┴┬────┬────┤
+ * │    │    │    │                        │    │    │    │    │
+ * └────┴────┴────┴────────────────────────┴────┴────┴────┴────┘
+ */
+// Row 2
+#define IT_LCBR S(ALGR(IT_EGRV)) // {
+#define IT_RCBR S(ALGR(IT_PLUS)) // }
 
-#define IT_BKSL KC_GRAVE  // backslash \, |
+// DEPRECATED
+#define IT_BKSL IT_BSLS
+#define IT_QUOT IT_APOS
+#define IT_IACC IT_IGRV
+#define IT_EACC IT_EGRV
+#define IT_OACC IT_OGRV
+#define IT_AACC IT_AGRV
+#define IT_UACC IT_UGRV
+#define IT_LESS IT_LABK
+#define IT_DQOT IT_DQUO
+#define IT_STRL IT_PND
+#define IT_QST  IT_QUES
+#define IT_CRC  IT_CIRC
+#define IT_MORE IT_RABK
+#define IT_SHRP IT_HASH
 
-#define IT_ACUT  // accent acute ´ and grave `
-
-#define IT_LESS KC_NUBS  // < and > and |
-#define IT_MINS KC_SLSH  // - and _
-
-// shifted characters
-#define IT_DEGR LSFT(IT_AACC)  // °
-#define IT_EXLM LSFT(KC_1)     // !
-#define IT_DQOT LSFT(KC_2)     // "
-#define IT_STRL LSFT(KC_3)     // £
-#define IT_DLR LSFT(KC_4)      // $
-#define IT_PERC LSFT(KC_5)     // %
-#define IT_AMPR LSFT(KC_6)     // &
-#define IT_SLSH LSFT(KC_7)     // /
-#define IT_LPRN LSFT(KC_8)     // (
-#define IT_RPRN LSFT(KC_9)     // )
-#define IT_EQL LSFT(KC_0)      // =
-#define IT_QST LSFT(IT_APOS)   // ?
-#define IT_CRC LSFT(IT_IACC)   // ^
-#define IT_ASTR LSFT(IT_PLUS)  // *
-#define IT_MORE LSFT(IT_LESS)  // >
-#define IT_COLN LSFT(IT_DOT)   // :
-#define IT_SCLN LSFT(IT_COMM)  // ;
-#define IT_UNDS LSFT(IT_MINS)  // _
-
-// Alt Gr-ed characters
-#define IT_LCBR ALGR(KC_7)     // {
-#define IT_LBRC ALGR(IT_EACC)  // [
-#define IT_RBRC ALGR(IT_PLUS)  // ]
-#define IT_RCBR ALGR(KC_0)     // }
-#define IT_AT ALGR(IT_OACC)    // @
-#define IT_EURO ALGR(KC_E)     // €
-#define IT_PIPE LSFT(IT_BSLS)  // |
-#define IT_SHRP ALGR(IT_AACC)  // #
-
-// Deprecated
-#define IT_X_PLUS X_RBRACKET  // #
-
-#endif
+#define IT_X_PLUS X_RBRACKET
+#define IT_ACUT

--- a/quantum/keymap_extras/sendstring_italian.h
+++ b/quantum/keymap_extras/sendstring_italian.h
@@ -1,0 +1,100 @@
+/* Copyright 2019
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Sendstring lookup tables for Italian layouts
+
+#pragma once
+
+#include "keymap_italian.h"
+#include "quantum.h"
+
+// clang-format off
+
+const uint8_t ascii_to_shift_lut[16] PROGMEM = {
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+
+    KCLUT_ENTRY(0, 1, 1, 0, 1, 1, 1, 0),
+    KCLUT_ENTRY(1, 1, 1, 0, 0, 0, 0, 1),
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+    KCLUT_ENTRY(0, 0, 1, 1, 0, 1, 1, 1),
+    KCLUT_ENTRY(0, 1, 1, 1, 1, 1, 1, 1),
+    KCLUT_ENTRY(1, 1, 1, 1, 1, 1, 1, 1),
+    KCLUT_ENTRY(1, 1, 1, 1, 1, 1, 1, 1),
+    KCLUT_ENTRY(1, 1, 1, 0, 0, 0, 1, 1),
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+    KCLUT_ENTRY(0, 0, 0, 1, 1, 1, 0, 0)
+};
+
+const uint8_t ascii_to_altgr_lut[16] PROGMEM = {
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+
+    KCLUT_ENTRY(0, 0, 0, 1, 0, 0, 0, 0),
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+    KCLUT_ENTRY(1, 0, 0, 0, 0, 0, 0, 0),
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+    KCLUT_ENTRY(0, 0, 0, 1, 0, 1, 0, 0),
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+    KCLUT_ENTRY(0, 0, 0, 1, 0, 1, 0, 0)
+};
+
+const uint8_t ascii_to_keycode_lut[128] PROGMEM = {
+    // NUL   SOH      STX      ETX      EOT      ENQ      ACK      BEL
+    XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+    // BS    TAB      LF       VT       FF       CR       SO       SI
+    KC_BSPC, KC_TAB,  KC_ENT,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+    // DLE   DC1      DC2      DC3      DC4      NAK      SYN      ETB
+    XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+    // CAN   EM       SUB      ESC      FS       GS       RS       US
+    XXXXXXX, XXXXXXX, XXXXXXX, KC_ESC,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+
+    //       !        "        #        $        %        &        '
+    KC_SPC,  IT_1,    IT_2,    IT_AGRV, IT_4,    IT_5,    IT_6,    IT_QUOT,
+    // (     )        *        +        ,        -        .        /
+    IT_8,    IT_9,    IT_PLUS, IT_PLUS, IT_COMM, IT_MINS, IT_DOT,  IT_7,
+    // 0     1        2        3        4        5        6        7
+    IT_0,    IT_1,    IT_2,    IT_3,    IT_4,    IT_5,    IT_6,    IT_7,
+    // 8     9        :        ;        <        =        >        ?
+    IT_8,    IT_9,    IT_DOT,  IT_COMM, IT_LABK, IT_0,    IT_LABK, IT_QUOT,
+    // @     A        B        C        D        E        F        G
+    IT_OGRV, IT_A,    IT_B,    IT_C,    IT_D,    IT_E,    IT_F,    IT_G,
+    // H     I        J        K        L        M        N        O
+    IT_H,    IT_I,    IT_J,    IT_K,    IT_L,    IT_M,    IT_N,    IT_O,
+    // P     Q        R        S        T        U        V        W
+    IT_P,    IT_Q,    IT_R,    IT_S,    IT_T,    IT_U,    IT_V,    IT_W,
+    // X     Y        Z        [        \        ]        ^        _
+    IT_X,    IT_Y,    IT_Z,    IT_EGRV, IT_BSLS, IT_PLUS, IT_IGRV, IT_MINS,
+    // `     a        b        c        d        e        f        g
+    XXXXXXX, IT_A,    IT_B,    IT_C,    IT_D,    IT_E,    IT_F,    IT_G,
+    // h     i        j        k        l        m        n        o
+    IT_H,    IT_I,    IT_J,    IT_K,    IT_L,    IT_M,    IT_N,    IT_O,
+    // p     q        r        s        t        u        v        w
+    IT_P,    IT_Q,    IT_R,    IT_S,    IT_T,    IT_U,    IT_V,    IT_W,
+    // x     y        z        {        |        }        ~        DEL
+    IT_X,    IT_Y,    IT_Z,    IT_EGRV, IT_BSLS, IT_PLUS, XXXXXXX, KC_DEL
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

🇮🇹
Amazingly, there is no way to input <code>&#96;</code> or `~` with this layout, at least on Windows. Thus they have been marked as `KC_NO` in the LUT.

https://superuser.com/questions/667622/italian-keyboard-entering-the-tilde-and-backtick-characters-without-cha

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
