### PR TITLE
Synchronize with HHKB keymap

### DIFF
--- a/keyboards/choco60/keymaps/default/keymap.c
+++ b/keyboards/choco60/keymaps/default/keymap.c
@@ -33,9 +33,9 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   ),
   [_FN] = LAYOUT(
     _______, KC_F1, KC_F2, KC_F3, KC_F4, KC_F5, KC_F6, KC_F7, KC_F8, KC_F9, KC_F10, KC_F11, KC_F12, KC_INSERT, KC_DELETE,
-    _______, _______, _______, _______, _______, _______, _______, _______, KC_PSCREEN, KC_SCROLLLOCK, KC_PAUSE, KC_UP, KC_RBRACKET, KC_BSPACE,
-    _______, _______, _______, _______, _______, _______, _______, _______, KC_HOME, KC_PGUP, KC_LEFT, KC_RIGHT, KC_ENTER,
-    RESET, _______, _______, _______, _______, _______, _______, _______, KC_END, KC_PGDOWN, KC_DOWN, KC_RSHIFT, KC_FN,
+    KC_CAPS, _______, _______, _______, _______, _______, _______, _______, KC_PSCREEN, KC_SCROLLLOCK, KC_PAUSE, KC_UP, KC_RBRACKET, KC_BSPACE,
+    _______, _______, _______, _______, _______, _______, KC_ASTR, KC_SLSH, KC_HOME, KC_PGUP, KC_LEFT, KC_RIGHT, KC_ENTER,
+    RESET, _______, _______, _______, _______, _______, KC_PLUS, KC_MINS, KC_END, KC_PGDOWN, KC_DOWN, KC_RSHIFT, KC_FN,
     _______, _______, _______, _______, _______, KC_STOP, _______
   )
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The key layout has been adjusted to the HHKB key map (Lite extension mode).

![image](https://user-images.githubusercontent.com/24952964/76762496-bd026580-67d4-11ea-8380-ac54b40be9b9.png)
ref: https://www.pfu.fujitsu.com/hhkeyboard/leaflet/hairetu.html

Enter was assigned to the `FN + Enter` key ,and BACKSPACE was assigned to `FN + BACKSPACE` , so it was determined that it was in Lite extended mode.
In that case, the `CAPSLOCK` key and `numeric keypad` were not assigned, so they were fixed.


<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
