### PR TITLE
[Keymap] New Massdrop ALT keymap for emptyflask

### DIFF
--- a/keyboards/massdrop/alt/keymaps/emptyflask/README.md
+++ b/keyboards/massdrop/alt/keymaps/emptyflask/README.md
@@ -1,0 +1,14 @@
+### Drop (Massdrop) ALT Layout
+
+This layout is for the [Drop ALT Keyboard](https://drop.com/buy/massdrop-alt-high-profile-mechanical-keyboard).
+
+Features:
+
+* Tap caps lock for ESC, hold for CTRL
+* Prefer grave/tilde to dedicated ESC key
+* Swap home and delete. It's more compatible with my keycaps, and closer to a traditional layout.
+* Numpad layer (FN-\ to enable)
+* Method for clearing all stuck-down mods (taken from favorable-mutation, for tapped modifiers)
+
+To do:
+* Customize RGB: solid colors by default, highlight numpad keys when using that layer.

--- a/keyboards/massdrop/alt/keymaps/emptyflask/config.h
+++ b/keyboards/massdrop/alt/keymaps/emptyflask/config.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#define ONESHOT_TIMEOUT 3000

--- a/keyboards/massdrop/alt/keymaps/emptyflask/keymap.c
+++ b/keyboards/massdrop/alt/keymaps/emptyflask/keymap.c
@@ -1,0 +1,292 @@
+#include QMK_KEYBOARD_H
+
+enum my_keycodes {
+    U_T_AUTO = SAFE_RANGE, // USB Extra Port Toggle Auto Detect / Always Active
+    U_T_AGCR,              // USB Toggle Automatic GCR control
+    DBG_TOG,               // DEBUG Toggle On / Off
+    DBG_MTRX,              // DEBUG Toggle Matrix Prints
+    DBG_KBD,               // DEBUG Toggle Keyboard Prints
+    DBG_MOU,               // DEBUG Toggle Mouse Prints
+    MD_BOOT,               // Restart into bootloader after hold timeout
+    HK_COSL,               // Clear held-down keys
+    QWERTY,                // Switch to QWERTY layout
+    COLEMAK,               // Switch to Colemak layout
+    DVORAK,                // Switch to Dvorak layout
+    WORKMAN,               // Switch to Workman layout
+};
+
+enum my_layers {
+    _QWERTY = 0,
+    _COLEMAK,
+    _DVORAK,
+    _WORKMAN,
+    _FUNCTION,
+    _NUMPAD,
+    _LAYOUTS,
+};
+
+#define CTL_ESC  LCTL_T(KC_ESC)    // Tap for ESC, hold for CTRL
+#define MD_LOCK  LCTL(LGUI(KC_Q))  // MacOS lock screen shortcut
+#define MO_FUNC  MO(_FUNCTION)     // Hold for function layer
+#define TG_NUMP  TG(_NUMPAD)       // Toggle numpad layer
+#define OSL_LAY  OSL(_LAYOUTS)     // One-shot layer to change layout
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    /* QWERTY
+     * ┌───────┬───────┬───────┬───────┬───────┬───────┬───────┬───────┬───────┬───────┬───────┬───────┬───────┬────────────┬───────┐
+     * │       │       │       │       │       │       │       │       │       │       │       │       │       │            │       │
+     * │   `   │   1   │   2   │   3   │   4   │   5   │   6   │   7   │   8   │   9   │   0   │   -   │   =   │ BackSpace  │ Home  │
+     * │       │       │       │       │       │       │       │       │       │       │       │       │       │            │       │
+     * ├───────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬─────────┼───────┤
+     * │          │       │       │       │       │       │       │       │       │       │       │       │       │         │       │
+     * │    Tab   │   Q   │   W   │   E   │   R   │   T   │   Y   │   U   │   I   │   O   │   P   │   [   │   ]   │    \    │  Del  │
+     * │          │       │       │       │       │       │       │       │       │       │       │       │       │         │       │
+     * ├──────────┴─┬─────┴─┬─────┴─┬─────┴─┬─────┴─┬─────┴─┬─────┴─┬─────┴─┬─────┴─┬─────┴─┬─────┴─┬─────┴─┬─────┴─────────┼───────┤
+     * │            │       │       │       │       │       │       │       │       │       │       │       │               │       │
+     * │  Ctrl/Esc  │   A   │   S   │   D   │   F   │   G   │   H   │   J   │   K   │   L   │   ;   │   '   │    Return     │ PgUp  │
+     * │            │       │       │       │       │       │       │       │       │       │       │       │               │       │
+     * ├────────────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴───────┬───────┼───────┤
+     * │               │       │       │       │       │       │       │       │       │       │       │            │       │       │
+     * │     Shift     │   Z   │   X   │   C   │   V   │   B   │   N   │   M   │   ,   │   .   │   /   │   Shift    │  Up   │ PgDn  │
+     * │               │       │       │       │       │       │       │       │       │       │       │            │       │       │
+     * ├─────────┬─────┴───┬───┴─────┬─┴───────┴───────┴───────┴───────┴───────┴─────┬─┴───────┼───────┴─┬──┬───────┼───────┼───────┤
+     * │         │         │         │                                               │         │         │▒▒│       │       │       │
+     * │  Ctrl   │   GUI   │   Alt   │                     Space                     │   Alt   │  Func   │▒▒│ Left  │ Down  │ Right │
+     * │         │         │         │                                               │         │         │▒▒│       │       │       │
+     * └─────────┴─────────┴─────────┴───────────────────────────────────────────────┴─────────┴─────────┴──┴───────┴───────┴───────┘
+     */
+    [_QWERTY] = LAYOUT_65_ansi_blocker(
+        KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_HOME,
+        KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS, KC_DEL,
+        CTL_ESC, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,          KC_ENT,  KC_PGUP,
+        KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT,          KC_UP,   KC_PGDN,
+        KC_LCTL, KC_LGUI, KC_LALT,                            KC_SPC,                             KC_RALT, MO_FUNC, KC_LEFT, KC_DOWN, KC_RGHT
+    ),
+
+    [_COLEMAK] = LAYOUT_65_ansi_blocker(
+        KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_HOME,
+        KC_TAB,  KC_Q,    KC_W,    KC_F,    KC_P,    KC_G,    KC_J,    KC_L,    KC_U,    KC_Y,    KC_SCLN, KC_LBRC, KC_RBRC, KC_BSLS, KC_DEL,
+        CTL_ESC, KC_A,    KC_R,    KC_S,    KC_T,    KC_D,    KC_H,    KC_N,    KC_E,    KC_I,    KC_O,    KC_QUOT,          KC_ENT,  KC_PGUP,
+        KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_K,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT,          KC_UP,   KC_PGDN,
+        KC_LCTL, KC_LGUI, KC_LALT,                            KC_SPC,                             KC_RALT, MO_FUNC, KC_LEFT, KC_DOWN, KC_RGHT
+    ),
+
+    [_DVORAK] = LAYOUT_65_ansi_blocker(
+        KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_LBRC, KC_RBRC, KC_BSPC, KC_HOME,
+        KC_TAB,  KC_QUOT, KC_COMM, KC_DOT,  KC_P,    KC_Y,    KC_F,    KC_G,    KC_C,    KC_R,    KC_L,    KC_SLSH, KC_EQL,  KC_BSLS, KC_DEL,
+        CTL_ESC, KC_A,    KC_O,    KC_E,    KC_U,    KC_I,    KC_D,    KC_H,    KC_T,    KC_N,    KC_S,    KC_MINS,          KC_ENT,  KC_PGUP,
+        KC_LSFT, KC_SCLN, KC_Q,    KC_J,    KC_K,    KC_X,    KC_B,    KC_M,    KC_W,    KC_V,    KC_Z,    KC_RSFT,          KC_UP,   KC_PGDN,
+        KC_LCTL, KC_LGUI, KC_LALT,                            KC_SPC,                             KC_RALT, MO_FUNC, KC_LEFT, KC_DOWN, KC_RGHT
+    ),
+
+    [_WORKMAN] = LAYOUT_65_ansi_blocker(
+        KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_HOME,
+        KC_TAB,  KC_Q,    KC_D,    KC_R,    KC_W,    KC_B,    KC_J,    KC_F,    KC_U,    KC_P,    KC_SCLN, KC_LBRC, KC_RBRC, KC_BSLS, KC_DEL,
+        CTL_ESC, KC_A,    KC_S,    KC_H,    KC_T,    KC_G,    KC_Y,    KC_N,    KC_E,    KC_O,    KC_I,    KC_QUOT,          KC_ENT,  KC_PGUP,
+        KC_LSFT, KC_Z,    KC_X,    KC_M,    KC_C,    KC_V,    KC_K,    KC_L,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT,          KC_UP,   KC_PGDN,
+        KC_LCTL, KC_LGUI, KC_LALT,                            KC_SPC,                             KC_RALT, MO_FUNC, KC_LEFT, KC_DOWN, KC_RGHT
+    ),
+
+    /* Function layer
+     * ┌───────┬───────┬───────┬───────┬───────┬───────┬───────┬───────┬───────┬───────┬───────┬───────┬───────┬────────────┬───────┐
+     * │       │       │       │       │       │       │       │       │       │       │       │       │       │            │       │
+     * │  Esc  │  F1   │  F2   │  F3   │  F4   │  F5   │  F6   │  F7   │  F8   │  F9   │  F10  │  F11  │  F12  │    Del     │  End  │
+     * │       │       │       │       │       │       │       │       │       │       │       │       │       │            │       │
+     * ├───────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬─────────┼───────┤
+     * │          │  RGB  │  RGB  │  RGB  │  RGB  │  RGB  │       │  USB  │  USB  │       │       │       │       │         │       │
+     * │          │ Speed │  Val  │ Speed │  Hue  │  Sat  │       │  Port │  GCR  │       │ PrtSc │ ScrLk │ Pause │ NumPad  │ Mute  │
+     * │          │   -   │   +   │   +   │   +   │   +   │       │       │       │       │       │       │       │         │       │
+     * ├──────────┴─┬─────┴─┬─────┴─┬─────┴─┬─────┴─┬─────┴─┬─────┴─┬─────┴─┬─────┴─┬─────┴─┬─────┴─┬─────┴─┬─────┴─────────┼───────┤
+     * │            │  RGB  │  RGB  │  RGB  │  RGB  │  RGB  │       │       │       │ (Mac) │       │       │               │       │
+     * │  CapsLock  │  Mode │  Val  │  Mode │  Hue  │  Sat  │       │       │       │ Lock  │       │       │               │ Vol+  │
+     * │            │   -   │   -   │   +   │   -   │   -   │       │       │       │       │       │       │               │       │
+     * ├────────────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴───────┬───────┼───────┤
+     * │               │  RGB  │       │       │       │       │ 6KRO/ │       │       │       │       │            │       │       │
+     * │               │ On/Off│       │       │       │Restart│ NKRO  │ Debug │       │       │ Layout│            │ PgUp  │ Vol-  │
+     * │               │       │       │       │       │       │       │       │       │       │       │            │       │       │
+     * ├─────────┬─────┴───┬───┴─────┬─┴───────┴───────┴───────┴───────┴───────┴─────┬─┴───────┼───────┴─┬──┬───────┼───────┼───────┤
+     * │         │         │         │                                               │         │         │▒▒│       │       │       │
+     * │         │         │         │               Clear modifiers                 │         │         │▒▒│ Home  │ PgDn  │  End  │
+     * │         │         │         │                                               │         │         │▒▒│       │       │       │
+     * └─────────┴─────────┴─────────┴───────────────────────────────────────────────┴─────────┴─────────┴──┴───────┴───────┴───────┘
+     */
+    [_FUNCTION] = LAYOUT_65_ansi_blocker(
+        KC_ESC,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_DEL,  KC_END,
+        _______, RGB_SPD, RGB_VAI, RGB_SPI, RGB_HUI, RGB_SAI, _______, U_T_AUTO,U_T_AGCR,_______, KC_PSCR, KC_SLCK, KC_PAUS, TG_NUMP, KC_MUTE,
+        KC_CAPS, RGB_RMOD,RGB_VAD, RGB_MOD, RGB_HUD, RGB_SAD, _______, _______, _______, MD_LOCK, _______, _______,          _______, KC_VOLU,
+        _______, RGB_TOG, _______, _______, _______, MD_BOOT, NK_TOGG, DBG_TOG, _______, _______, OSL_LAY, _______,          KC_PGUP, KC_VOLD,
+        _______, _______, _______,                            HK_COSL,                            _______, _______, KC_HOME, KC_PGDN, KC_END
+    ),
+
+    /* Number pad (FN-\ to toggle)
+     * ┌───────┬───────┬───────┬───────┬───────┬───────┬───────┬───────┬───────┬───────┬───────┬───────┬───────┬────────────┬───────┐
+     * │       │       │       │       │       │       │       │       │       │       │       │       │       │            │       │
+     * │       │       │       │       │       │       │       │       │   /   │   *   │   -   │       │       │            │       │
+     * │       │       │       │       │       │       │       │       │       │       │       │       │       │            │       │
+     * ├───────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬─────────┼───────┤
+     * │          │       │       │       │       │       │       │       │       │       │       │       │       │         │       │
+     * │          │       │       │       │       │       │       │   7   │   8   │   9   │   +   │       │       │         │       │
+     * │          │       │       │       │       │       │       │       │       │       │       │       │       │         │       │
+     * ├──────────┴─┬─────┴─┬─────┴─┬─────┴─┬─────┴─┬─────┴─┬─────┴─┬─────┴─┬─────┴─┬─────┴─┬─────┴─┬─────┴─┬─────┴─────────┼───────┤
+     * │            │       │       │       │       │       │       │       │       │       │       │       │               │       │
+     * │            │       │       │       │       │       │       │   4   │   5   │   6   │   +   │       │               │       │
+     * │            │       │       │       │       │       │       │       │       │       │       │       │               │       │
+     * ├────────────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴───────┬───────┼───────┤
+     * │               │       │       │       │       │       │       │       │       │       │       │            │       │       │
+     * │               │       │       │       │       │       │       │   1   │   2   │   3   │   =   │            │       │       │
+     * │               │       │       │       │       │       │       │       │       │       │       │            │       │       │
+     * ├─────────┬─────┴───┬───┴─────┬─┴───────┴───────┴───────┴───────┴───────┴─────┬─┴───────┼───────┴─┬──┬───────┼───────┼───────┤
+     * │         │         │         │                                               │         │         │▒▒│       │       │       │
+     * │         │         │         │                                     0         │    .    │         │▒▒│       │       │       │
+     * │         │         │         │                                               │         │         │▒▒│       │       │       │
+     * └─────────┴─────────┴─────────┴───────────────────────────────────────────────┴─────────┴─────────┴──┴───────┴───────┴───────┘
+     */
+    [_NUMPAD] = LAYOUT_65_ansi_blocker(
+        _______, _______, _______, _______, _______, _______, _______, _______, KC_PSLS, KC_PAST, KC_PMNS, _______, _______, _______, _______,
+        _______, _______, _______, _______, _______, _______, _______, KC_P7,   KC_P8,   KC_P9,   KC_PPLS, _______, _______, _______, _______,
+        _______, _______, _______, _______, _______, _______, _______, KC_P4,   KC_P5,   KC_P6,   KC_PPLS, _______,          _______, _______,
+        _______, _______, _______, _______, _______, _______, _______, KC_P1,   KC_P2,   KC_P3,   KC_PEQL, _______,          _______, _______,
+        _______, _______, _______,                                     KC_P0,                     KC_PDOT, _______, _______, _______, _______
+    ),
+
+    /* Alternate layouts (FN-/ then one of [Q,C,D,W]) */
+    [_LAYOUTS] = LAYOUT_65_ansi_blocker(
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+        _______, QWERTY,  WORKMAN, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+        _______, _______, _______, DVORAK,  _______, _______, _______, _______, _______, _______, _______, _______,          _______, _______,
+        _______, _______, _______, COLEMAK, _______, _______, _______, _______, _______, _______, _______, _______,          _______, _______,
+        _______, _______, _______,                            _______,                            _______, _______, _______, _______, _______
+    ),
+
+    /* Template
+     * ┌───────┬───────┬───────┬───────┬───────┬───────┬───────┬───────┬───────┬───────┬───────┬───────┬───────┬────────────┬───────┐
+     * │       │       │       │       │       │       │       │       │       │       │       │       │       │            │       │
+     * │       │       │       │       │       │       │       │       │       │       │       │       │       │            │       │
+     * │       │       │       │       │       │       │       │       │       │       │       │       │       │            │       │
+     * ├───────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬─────────┼───────┤
+     * │          │       │       │       │       │       │       │       │       │       │       │       │       │         │       │
+     * │          │       │       │       │       │       │       │       │       │       │       │       │       │         │       │
+     * │          │       │       │       │       │       │       │       │       │       │       │       │       │         │       │
+     * ├──────────┴─┬─────┴─┬─────┴─┬─────┴─┬─────┴─┬─────┴─┬─────┴─┬─────┴─┬─────┴─┬─────┴─┬─────┴─┬─────┴─┬─────┴─────────┼───────┤
+     * │            │       │       │       │       │       │       │       │       │       │       │       │               │       │
+     * │            │       │       │       │       │       │       │       │       │       │       │       │               │       │
+     * │            │       │       │       │       │       │       │       │       │       │       │       │               │       │
+     * ├────────────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴──┬────┴───────┬───────┼───────┤
+     * │               │       │       │       │       │       │       │       │       │       │       │            │       │       │
+     * │               │       │       │       │       │       │       │       │       │       │       │            │       │       │
+     * │               │       │       │       │       │       │       │       │       │       │       │            │       │       │
+     * ├─────────┬─────┴───┬───┴─────┬─┴───────┴───────┴───────┴───────┴───────┴─────┬─┴───────┼───────┴─┬──┬───────┼───────┼───────┤
+     * │         │         │         │                                               │         │         │▒▒│       │       │       │
+     * │         │         │         │                                               │         │         │▒▒│       │       │       │
+     * │         │         │         │                                               │         │         │▒▒│       │       │       │
+     * └─────────┴─────────┴─────────┴───────────────────────────────────────────────┴─────────┴─────────┴──┴───────┴───────┴───────┘
+    [X] = LAYOUT_65_ansi_blocker(
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          _______, _______,
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          _______, _______,
+        _______, _______, _______,                            _______,                            _______, _______, _______, _______, _______
+    ),
+    */
+};
+
+#define MODS_SHIFT  (get_mods() & MOD_MASK_SHIFT)
+#define MODS_CTRL  (get_mods() & MOD_MASK_CTRL)
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    static uint32_t key_timer;
+
+    switch (keycode) {
+        case QWERTY:
+            if (record->event.pressed) {
+                set_single_persistent_default_layer(_QWERTY);
+            }
+            return true;
+        case COLEMAK:
+            if (record->event.pressed) {
+                set_single_persistent_default_layer(_COLEMAK);
+            }
+            return true;
+        case DVORAK:
+            if (record->event.pressed) {
+                set_single_persistent_default_layer(_DVORAK);
+            }
+            return true;
+        case WORKMAN:
+            if (record->event.pressed) {
+                set_single_persistent_default_layer(_WORKMAN);
+            }
+            return true;
+        case HK_COSL:
+            clear_keyboard();
+            reset_oneshot_layer();
+            return true;
+        case U_T_AUTO:
+            if (record->event.pressed && MODS_SHIFT && MODS_CTRL) {
+                TOGGLE_FLAG_AND_PRINT(usb_extra_manual, "USB extra port manual mode");
+            }
+            return false;
+        case U_T_AGCR:
+            if (record->event.pressed && MODS_SHIFT && MODS_CTRL) {
+                TOGGLE_FLAG_AND_PRINT(usb_gcr_auto, "USB GCR auto mode");
+            }
+            return false;
+        case DBG_TOG:
+            if (record->event.pressed) {
+                TOGGLE_FLAG_AND_PRINT(debug_enable, "Debug mode");
+            }
+            return false;
+        case DBG_MTRX:
+            if (record->event.pressed) {
+                TOGGLE_FLAG_AND_PRINT(debug_matrix, "Debug matrix");
+            }
+            return false;
+        case DBG_KBD:
+            if (record->event.pressed) {
+                TOGGLE_FLAG_AND_PRINT(debug_keyboard, "Debug keyboard");
+            }
+            return false;
+        case DBG_MOU:
+            if (record->event.pressed) {
+                TOGGLE_FLAG_AND_PRINT(debug_mouse, "Debug mouse");
+            }
+            return false;
+        case MD_BOOT:
+            if (record->event.pressed) {
+                key_timer = timer_read32();
+            } else {
+                if (timer_elapsed32(key_timer) >= 500) {
+                    reset_keyboard();
+                }
+            }
+            return false;
+        case RGB_TOG:
+            if (record->event.pressed) {
+              switch (rgb_matrix_get_flags()) {
+                case LED_FLAG_ALL: {
+                    rgb_matrix_set_flags(LED_FLAG_KEYLIGHT);
+                    rgb_matrix_set_color_all(0, 0, 0);
+                  }
+                  break;
+                case LED_FLAG_KEYLIGHT: {
+                    rgb_matrix_set_flags(LED_FLAG_UNDERGLOW);
+                    rgb_matrix_set_color_all(0, 0, 0);
+                  }
+                  break;
+                case LED_FLAG_UNDERGLOW: {
+                    rgb_matrix_set_flags(LED_FLAG_NONE);
+                    rgb_matrix_disable_noeeprom();
+                  }
+                  break;
+                default: {
+                    rgb_matrix_set_flags(LED_FLAG_ALL);
+                    rgb_matrix_enable_noeeprom();
+                  }
+                  break;
+              }
+            }
+            return false;
+        default:
+            return true; //Process all other keycodes normally
+    }
+}


### PR DESCRIPTION
## Description

Customized Drop ALT config:

* Tap caps lock for ESC, hold for CTRL
* Prefer grave/tilde to dedicated ESC key
* Swap home and delete. It's more compatible with my keycaps, and closer to a traditional layout.
* Numpad layer (FN-\ to enable)
* Method for clearing all stuck-down mods (taken from favorable-mutation, for tapped modifiers)
* Switch between QWERTY, Colemak, Dvorak, Workman layouts using FN-/ plus one of [Q,C,D,W]

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
