### PR TITLE
audio refactor: replace deprecated PLAY_NOTE_ARRAY

### DIFF
--- a/docs/ChangeLog/20200530/PR8484.md
+++ b/docs/ChangeLog/20200530/PR8484.md
@@ -1,0 +1,1 @@
+code cleanup regarding deprecated macro PLAY_NOTE_ARRAY by replacing it with PLAY_SONG

--- a/docs/custom_quantum_functions.md
+++ b/docs/custom_quantum_functions.md
@@ -57,7 +57,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case KC_ENTER:
       // Play a tone when enter is pressed
       if (record->event.pressed) {
-        PLAY_NOTE_ARRAY(tone_qwerty);
+        PLAY_SONG(tone_qwerty);
       }
       return true; // Let QMK send the enter press/release events
     default:
@@ -438,7 +438,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case KC_ENTER:
         // Play a tone when enter is pressed
         if (record->event.pressed) {
-            PLAY_NOTE_ARRAY(tone_qwerty);
+            PLAY_SONG(tone_qwerty);
         }
         return true; // Let QMK send the enter press/release events
     case RGB_LYR:  // This allows me to use underglow as layer indication, or as normal

--- a/docs/ja/custom_quantum_functions.md
+++ b/docs/ja/custom_quantum_functions.md
@@ -62,7 +62,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case KC_ENTER:
       // enter が押された時に音を再生します
       if (record->event.pressed) {
-        PLAY_NOTE_ARRAY(tone_qwerty);
+        PLAY_SONG(tone_qwerty);
       }
       return true; // QMK に enter のプレスまたはリリースイベントを送信させます
     default:
@@ -440,7 +440,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case KC_ENTER:
         // enter が押された時に音を再生します
         if (record->event.pressed) {
-            PLAY_NOTE_ARRAY(tone_qwerty);
+            PLAY_SONG(tone_qwerty);
         }
         return true; // QMK に enter のプレスまたはリリースイベントを送信させます
     case RGB_LYR:  // これにより、アンダーグローをレイヤー表示として、あるいは通常通りに使うことができます。

--- a/docs/zh-cn/custom_quantum_functions.md
+++ b/docs/zh-cn/custom_quantum_functions.md
@@ -57,7 +57,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case KC_ENTER:
       // 当按下回车时播放音符
       if (record->event.pressed) {
-        PLAY_NOTE_ARRAY(tone_qwerty);
+        PLAY_SONG(tone_qwerty);
       }
       return true; // 让QMK触发回车按下/释放事件
     default:
@@ -413,7 +413,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case KC_ENTER:
         // 在按下回车时播放音符
         if (record->event.pressed) {
-            PLAY_NOTE_ARRAY(tone_qwerty);
+            PLAY_SONG(tone_qwerty);
         }
         return true; // 让QMK产生回车按下/释放事件
     case RGB_LYR:  // 本句让underglow作为层指示，或正常使用。

--- a/keyboards/cu75/cu75.c
+++ b/keyboards/cu75/cu75.c
@@ -26,7 +26,7 @@ void matrix_init_kb(void)
 
 #ifdef AUDIO_ENABLE
     audio_init();
-    PLAY_NOTE_ARRAY(test_sound, false, STACCATO);
+    PLAY_SONG(test_sound);
     // Fix port B5
     cbi(DDRB, 5);
     sbi(PORTB, 5);

--- a/keyboards/jd45/keymaps/mjt6u/keymap.c
+++ b/keyboards/jd45/keymaps/mjt6u/keymap.c
@@ -119,7 +119,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record)
         {
             persistent_default_layer_set(1UL << _QWERTY);
 #ifdef AUDIO_ENABLE
-            PLAY_NOTE_ARRAY(tone_fnpc, false, 0);
+            PLAY_SONG(tone_fnpc);
 #endif
             print("Space-FN");
         }
@@ -130,7 +130,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record)
         {
             persistent_default_layer_set(1UL << _QWERTYNUMMODS);
 #ifdef AUDIO_ENABLE
-            PLAY_NOTE_ARRAY(tone_fnmac, false, 0);
+            PLAY_SONG(tone_fnmac);
 #endif
             print("Space-Numpad");
         }

--- a/keyboards/keebio/viterbi/keymaps/bakingpy/keymap.c
+++ b/keyboards/keebio/viterbi/keymaps/bakingpy/keymap.c
@@ -158,7 +158,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case QWERTY:
       if (record->event.pressed) {
         #ifdef AUDIO_ENABLE
-          PLAY_NOTE_ARRAY(tone_qwerty, false, 0);
+          PLAY_SONG(tone_qwerty);
         #endif
         persistent_default_layer_set(1UL<<_QWERTY);
       }
@@ -167,7 +167,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case COLEMAK:
       if (record->event.pressed) {
         #ifdef AUDIO_ENABLE
-          PLAY_NOTE_ARRAY(tone_colemak, false, 0);
+          PLAY_SONG(tone_colemak);
         #endif
         persistent_default_layer_set(1UL<<_COLEMAK);
       }
@@ -176,7 +176,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case DVORAK:
       if (record->event.pressed) {
         #ifdef AUDIO_ENABLE
-          PLAY_NOTE_ARRAY(tone_dvorak, false, 0);
+          PLAY_SONG(tone_dvorak);
         #endif
         persistent_default_layer_set(1UL<<_DVORAK);
       }

--- a/keyboards/keebio/viterbi/keymaps/dwallace/keymap.c
+++ b/keyboards/keebio/viterbi/keymaps/dwallace/keymap.c
@@ -155,7 +155,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case QWERTY:
       if (record->event.pressed) {
         #ifdef AUDIO_ENABLE
-          PLAY_NOTE_ARRAY(tone_qwerty, false, 0);
+          PLAY_SONG(tone_qwerty);
         #endif
         persistent_default_layer_set(1UL<<_QWERTY);
       }

--- a/keyboards/keebio/viterbi/keymaps/mike808/keymap.c
+++ b/keyboards/keebio/viterbi/keymaps/mike808/keymap.c
@@ -128,7 +128,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case QWERTY:
       if (record->event.pressed) {
         #ifdef AUDIO_ENABLE
-          PLAY_NOTE_ARRAY(tone_qwerty, false, 0);
+          PLAY_SONG(tone_qwerty);
         #endif
         persistent_default_layer_set(1UL << _QWERTY);
       }
@@ -137,7 +137,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case DVORAK:
       if (record->event.pressed) {
         #ifdef AUDIO_ENABLE
-          PLAY_NOTE_ARRAY(tone_dvorak, false, 0);
+          PLAY_SONG(tone_dvorak);
         #endif
         persistent_default_layer_set(1UL << _DVORAK);
       }

--- a/keyboards/lets_split/keymaps/mjt/keymap.c
+++ b/keyboards/lets_split/keymaps/mjt/keymap.c
@@ -152,7 +152,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case QWERTY:
       if (record->event.pressed) {
         #ifdef AUDIO_ENABLE
-          PLAY_NOTE_ARRAY(tone_qwerty, false, 0);
+          PLAY_SONG(tone_qwerty);
         #endif
         persistent_default_layer_set(1UL<<_QWERTY);
       }
@@ -161,7 +161,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case COLEMAK:
       if (record->event.pressed) {
         #ifdef AUDIO_ENABLE
-          PLAY_NOTE_ARRAY(tone_colemak, false, 0);
+          PLAY_SONG(tone_colemak);
         #endif
         persistent_default_layer_set(1UL<<_COLEMAK);
       }
@@ -170,7 +170,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case DVORAK:
       if (record->event.pressed) {
         #ifdef AUDIO_ENABLE
-          PLAY_NOTE_ARRAY(tone_dvorak, false, 0);
+          PLAY_SONG(tone_dvorak);
         #endif
         persistent_default_layer_set(1UL<<_DVORAK);
       }

--- a/keyboards/meira/keymaps/default/keymap.c
+++ b/keyboards/meira/keymaps/default/keymap.c
@@ -187,7 +187,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case QWERTY:
       if (record->event.pressed) {
         #ifdef AUDIO_ENABLE
-          PLAY_NOTE_ARRAY(tone_qwerty, false, 0);
+          PLAY_SONG(tone_qwerty);
         #endif
 //        persistent_default_layer_set(1UL<<_QWERTY);
       }
@@ -196,7 +196,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case COLEMAK:
       if (record->event.pressed) {
         #ifdef AUDIO_ENABLE
-          PLAY_NOTE_ARRAY(tone_colemak, false, 0);
+          PLAY_SONG(tone_colemak);
         #endif
 //        persistent_default_layer_set(1UL<<_COLEMAK);
       }
@@ -205,7 +205,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case DVORAK:
       if (record->event.pressed) {
         #ifdef AUDIO_ENABLE
-          PLAY_NOTE_ARRAY(tone_dvorak, false, 0);
+          PLAY_SONG(tone_dvorak);
         #endif
 //        persistent_default_layer_set(1UL<<_DVORAK);
       }

--- a/keyboards/meira/keymaps/grahampheath/keymap.c
+++ b/keyboards/meira/keymaps/grahampheath/keymap.c
@@ -243,7 +243,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case QWERTY:
       if (record->event.pressed) {
         #ifdef AUDIO_ENABLE
-          PLAY_NOTE_ARRAY(tone_qwerty, false, 0);
+          PLAY_SONG(tone_qwerty);
         #endif
       }
       return false;
@@ -251,7 +251,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case COLEMAK:
       if (record->event.pressed) {
         #ifdef AUDIO_ENABLE
-          PLAY_NOTE_ARRAY(tone_colemak, false, 0);
+          PLAY_SONG(tone_colemak);
         #endif
       }
       return false;
@@ -259,7 +259,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case DVORAK:
       if (record->event.pressed) {
         #ifdef AUDIO_ENABLE
-          PLAY_NOTE_ARRAY(tone_dvorak, false, 0);
+          PLAY_SONG(tone_dvorak);
         #endif
       }
       return false;

--- a/keyboards/meira/keymaps/takmiya/keymap.c
+++ b/keyboards/meira/keymaps/takmiya/keymap.c
@@ -153,7 +153,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case QWERTY:
       if (record->event.pressed) {
         #ifdef AUDIO_ENABLE
-          PLAY_NOTE_ARRAY(tone_qwerty, false, 0);
+          PLAY_SONG(tone_qwerty);
         #endif
 //        persistent_default_layer_set(1UL<<_QWERTY);
       }

--- a/keyboards/planck/keymaps/emilyh/keymap.c
+++ b/keyboards/planck/keymaps/emilyh/keymap.c
@@ -187,7 +187,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case QWERTY:
       if (record->event.pressed) {
         #ifdef AUDIO_ENABLE
-          PLAY_NOTE_ARRAY(tone_qwerty, false, 0);
+          PLAY_SONG(tone_qwerty);
         #endif
         persistant_default_layer_set(1UL<<_QWERTY);
       }
@@ -196,7 +196,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case COLEMAK:
       if (record->event.pressed) {
         #ifdef AUDIO_ENABLE
-          PLAY_NOTE_ARRAY(tone_colemak, false, 0);
+          PLAY_SONG(tone_colemak);
         #endif
         persistant_default_layer_set(1UL<<_COLEMAK);
       }
@@ -205,7 +205,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case DVORAK:
       if (record->event.pressed) {
         #ifdef AUDIO_ENABLE
-          PLAY_NOTE_ARRAY(tone_dvorak, false, 0);
+          PLAY_SONG(tone_dvorak);
         #endif
         persistant_default_layer_set(1UL<<_DVORAK);
       }
@@ -246,7 +246,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
       if (record->event.pressed) {
         #ifdef AUDIO_ENABLE
           stop_all_notes();
-          PLAY_NOTE_ARRAY(tone_plover, false, 0);
+          PLAY_SONG(tone_plover);
         #endif
         layer_off(_RAISE);
         layer_off(_LOWER);
@@ -264,7 +264,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case EXT_PLV:
       if (record->event.pressed) {
         #ifdef AUDIO_ENABLE
-          PLAY_NOTE_ARRAY(tone_plover_gb, false, 0);
+          PLAY_SONG(tone_plover_gb);
         #endif
         layer_off(_PLOVER);
       }
@@ -285,12 +285,12 @@ void matrix_init_user(void) {
 void startup_user()
 {
     _delay_ms(20); // gets rid of tick
-    PLAY_NOTE_ARRAY(tone_startup, false, 0);
+    PLAY_SONG(tone_startup);
 }
 
 void shutdown_user()
 {
-    PLAY_NOTE_ARRAY(tone_goodbye, false, 0);
+    PLAY_SONG(tone_goodbye);
     _delay_ms(150);
     stop_all_notes();
 }
@@ -302,7 +302,7 @@ void music_on_user(void)
 
 void music_scale_user(void)
 {
-    PLAY_NOTE_ARRAY(music_scale, false, 0);
+    PLAY_SONG(music_scale);
 }
 
 #endif

--- a/keyboards/planck/keymaps/ishtob/keymap.c
+++ b/keyboards/planck/keymaps/ishtob/keymap.c
@@ -226,7 +226,7 @@ bool process_record_keymap(uint16_t keycode, keyrecord_t *record) {
     case QWERTY:
       if (record->event.pressed) {
         #ifdef AUDIO_ENABLE
-          PLAY_NOTE_ARRAY(tone_qwerty, false, 0);
+          PLAY_SONG(tone_qwerty);
         #endif
         persistant_default_layer_set(1UL<<_QWERTY);
       }
@@ -235,7 +235,7 @@ bool process_record_keymap(uint16_t keycode, keyrecord_t *record) {
     case COLEMAK:
       if (record->event.pressed) {
         #ifdef AUDIO_ENABLE
-          PLAY_NOTE_ARRAY(tone_colemak, false, 0);
+          PLAY_SONG(tone_colemak);
         #endif
         persistant_default_layer_set(1UL<<_COLEMAK);
       }
@@ -244,7 +244,7 @@ bool process_record_keymap(uint16_t keycode, keyrecord_t *record) {
     case DVORAK:
       if (record->event.pressed) {
         #ifdef AUDIO_ENABLE
-          PLAY_NOTE_ARRAY(tone_dvorak, false, 0);
+          PLAY_SONG(tone_dvorak);
         #endif
         persistant_default_layer_set(1UL<<_DVORAK);
       }
@@ -285,7 +285,7 @@ bool process_record_keymap(uint16_t keycode, keyrecord_t *record) {
       if (record->event.pressed) {
         #ifdef AUDIO_ENABLE
           stop_all_notes();
-          PLAY_NOTE_ARRAY(tone_plover, false, 0);
+          PLAY_SONG(tone_plover);
         #endif
         layer_off(_RAISE);
         layer_off(_LOWER);
@@ -303,7 +303,7 @@ bool process_record_keymap(uint16_t keycode, keyrecord_t *record) {
     case EXT_PLV:
       if (record->event.pressed) {
         #ifdef AUDIO_ENABLE
-          PLAY_NOTE_ARRAY(tone_plover_gb, false, 0);
+          PLAY_SONG(tone_plover_gb);
         #endif
         layer_off(_PLOVER);
       }
@@ -327,12 +327,12 @@ void startup_user()
     rgblight_mode(RGB_MATRIX_CYCLE_ALL);
     #endif //RGB_matrix
     wait_ms(20); // gets rid of tick
-    PLAY_NOTE_ARRAY(tone_startup, false, 0);
+    PLAY_SONG(tone_startup);
 }
 
 void shutdown_user()
 {
-    PLAY_NOTE_ARRAY(tone_goodbye, false, 0);
+    PLAY_SONG(tone_goodbye);
     wait_ms(150);
     stop_all_notes();
 }
@@ -344,7 +344,7 @@ void music_on_user(void)
 
 void music_scale_user(void)
 {
-    PLAY_NOTE_ARRAY(music_scale, false, 0);
+    PLAY_SONG(music_scale);
 }
 
 #endif

--- a/keyboards/planck/keymaps/that_canadian/keymap.c
+++ b/keyboards/planck/keymaps/that_canadian/keymap.c
@@ -144,7 +144,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case QWERTY:
       if (record->event.pressed) {
         #ifdef AUDIO_ENABLE
-          PLAY_NOTE_ARRAY(tone_qwerty, false, 0);
+          PLAY_SONG(tone_qwerty);
         #endif
         persistant_default_layer_set(1UL<<_QWERTY);
       }
@@ -185,12 +185,12 @@ void matrix_init_user(void) {
 void startup_user()
 {
     _delay_ms(20); // gets rid of tick
-    PLAY_NOTE_ARRAY(tone_startup, false, 0);
+    PLAY_SONG(tone_startup);
 }
 
 void shutdown_user()
 {
-    PLAY_NOTE_ARRAY(tone_goodbye, false, 0);
+    PLAY_SONG(tone_goodbye);
     _delay_ms(150);
     stop_all_notes();
 }
@@ -202,7 +202,7 @@ void music_on_user(void)
 
 void music_scale_user(void)
 {
-    PLAY_NOTE_ARRAY(music_scale, false, 0);
+    PLAY_SONG(music_scale);
 }
 
 #endif

--- a/keyboards/preonic/keymaps/that_canadian/keymap.c
+++ b/keyboards/preonic/keymaps/that_canadian/keymap.c
@@ -161,7 +161,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         case QWERTY:
           if (record->event.pressed) {
             #ifdef AUDIO_ENABLE
-              PLAY_NOTE_ARRAY(tone_qwerty, false, 0);
+              PLAY_SONG(tone_qwerty);
             #endif
             persistant_default_layer_set(1UL<<_QWERTY);
           }
@@ -213,12 +213,12 @@ void matrix_init_user(void) {
 void startup_user()
 {
     _delay_ms(20); // gets rid of tick
-    PLAY_NOTE_ARRAY(tone_startup, false, 0);
+    PLAY_SONG(tone_startup);
 }
 
 void shutdown_user()
 {
-    PLAY_NOTE_ARRAY(tone_goodbye, false, 0);
+    PLAY_SONG(tone_goodbye);
     _delay_ms(150);
     stop_all_notes();
 }
@@ -230,7 +230,7 @@ void music_on_user(void)
 
 void music_scale_user(void)
 {
-    PLAY_NOTE_ARRAY(music_scale, false, 0);
+    PLAY_SONG(music_scale);
 }
 
 #endif

--- a/keyboards/rgbkb/zen/rev1/keymaps/default/keymap.c
+++ b/keyboards/rgbkb/zen/rev1/keymaps/default/keymap.c
@@ -78,7 +78,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case QWERTY:
       if (record->event.pressed) {
         #ifdef AUDIO_ENABLE
-          PLAY_NOTE_ARRAY(tone_qwerty, false, 0);
+          PLAY_SONG(tone_qwerty);
         #endif
         persistant_default_layer_set(1UL<<_QWERTY);
       }
@@ -87,7 +87,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     //case COLEMAK:
       //if (record->event.pressed) {
         //#ifdef AUDIO_ENABLE
-          //PLAY_NOTE_ARRAY(tone_colemak, false, 0);
+          //PLAY_SONG(tone_colemak);
         //#endif
         //persistant_default_layer_set(1UL<<_COLEMAK);
       //}

--- a/keyboards/rgbkb/zen/rev1/keymaps/jwlawrence/keymap.c
+++ b/keyboards/rgbkb/zen/rev1/keymaps/jwlawrence/keymap.c
@@ -77,7 +77,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case QWERTY:
       if (record->event.pressed) {
         #ifdef AUDIO_ENABLE
-          PLAY_NOTE_ARRAY(tone_qwerty, false, 0);
+          PLAY_SONG(tone_qwerty);
         #endif
         persistant_default_layer_set(1UL<<_QWERTY);
       }
@@ -86,7 +86,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     //case COLEMAK:
       //if (record->event.pressed) {
         //#ifdef AUDIO_ENABLE
-          //PLAY_NOTE_ARRAY(tone_colemak, false, 0);
+          //PLAY_SONG(tone_colemak);
         //#endif
         //persistant_default_layer_set(1UL<<_COLEMAK);
       //}

--- a/keyboards/thevankeyboards/minivan/keymaps/mjt/keymap.c
+++ b/keyboards/thevankeyboards/minivan/keymaps/mjt/keymap.c
@@ -99,7 +99,7 @@ const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
               if (record->event.pressed) {
               #ifdef AUDIO_ENABLE
                 stop_all_notes();
-                PLAY_NOTE_ARRAY(tone_plover, false, 0);
+                PLAY_SONG(tone_plover);
               #endif
               layer_off(_NUMSYM);
               layer_off(_FKEYS);
@@ -110,7 +110,7 @@ const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
         case 7: // LAYERRESET
               if (record->event.pressed) {
               #ifdef AUDIO_ENABLE
-                PLAY_NOTE_ARRAY(tone_qwerty, false, 0);
+                PLAY_SONG(tone_qwerty);
               #endif
               layer_off(_NUMSYM);
               layer_off(_FKEYS);
@@ -132,7 +132,7 @@ const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
           if(record->event.pressed) {
             #ifdef AUDIO_ENABLE
               stop_all_notes();
-              PLAY_NOTE_ARRAY(tone_adjust, false, 0);
+              PLAY_SONG(tone_adjust);
             #endif
             layer_off(_NUMSYM);
             layer_off(_FKEYS);
@@ -166,12 +166,12 @@ void matrix_init_user(void) {
 void startup_user()
 {
     _delay_ms(20); // gets rid of tick
-    PLAY_NOTE_ARRAY(tone_startup, false, 0);
+    PLAY_SONG(tone_startup);
 }
 
 void shutdown_user()
 {
-    PLAY_NOTE_ARRAY(tone_goodbye, false, 0);
+    PLAY_SONG(tone_goodbye);
     _delay_ms(150);
     stop_all_notes();
 }
@@ -183,6 +183,6 @@ void music_on_user(void)
 
 void music_scale_user(void)
 {
-    PLAY_NOTE_ARRAY(music_scale, false, 0);
+    PLAY_SONG(music_scale);
 }
 #endif

--- a/keyboards/thevankeyboards/roadkit/keymaps/mjt/keymap.c
+++ b/keyboards/thevankeyboards/roadkit/keymaps/mjt/keymap.c
@@ -145,7 +145,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case NUMPAD_LOCK:
       if (record->event.pressed) {
         #ifdef AUDIO_ENABLE
-          PLAY_NOTE_ARRAY(tone_numpad, false, 0);
+          PLAY_SONG(tone_numpad);
         #endif
         persistant_default_layer_set(1UL<<_NUMPAD);
       }
@@ -154,7 +154,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case NAVIGATION_LOCK:
       if (record->event.pressed) {
         #ifdef AUDIO_ENABLE
-          PLAY_NOTE_ARRAY(tone_navigation, false, 0);
+          PLAY_SONG(tone_navigation);
         #endif
         persistant_default_layer_set(1UL<<_NAVIGATION);
       }
@@ -163,7 +163,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case EXCEL_LOCK:
       if (record->event.pressed) {
         #ifdef AUDIO_ENABLE
-          PLAY_NOTE_ARRAY(tone_excel, false, 0);
+          PLAY_SONG(tone_excel);
         #endif
         persistant_default_layer_set(1UL<<_EXCEL);
       }

--- a/quantum/audio/audio.h
+++ b/quantum/audio/audio.h
@@ -99,9 +99,6 @@ void play_notes(float (*np)[][2], uint16_t n_count, bool n_repeat);
 // length. This works around the limitation of C's sizeof operation on pointers.
 // The global float array for the song must be used here.
 #define NOTE_ARRAY_SIZE(x) ((int16_t)(sizeof(x) / (sizeof(x[0]))))
-#define PLAY_NOTE_ARRAY(note_array, note_repeat, deprecated_arg)           \
-    play_notes(&note_array, NOTE_ARRAY_SIZE((note_array)), (note_repeat)); \
-    _Pragma("message \"'PLAY_NOTE_ARRAY' macro is deprecated\"")
 #define PLAY_SONG(note_array) play_notes(&note_array, NOTE_ARRAY_SIZE((note_array)), false)
 #define PLAY_LOOP(note_array) play_notes(&note_array, NOTE_ARRAY_SIZE((note_array)), true)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
remove the deprecated PLAY_NOTE_ARRAY macro throughout the code, and replace it with PLAY_SONG
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR
code cleanup :-)
* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
