### PR TITLE
Palette1202 fix encoder rotate direction

### DIFF
--- a/keyboards/palette1202/config.h
+++ b/keyboards/palette1202/config.h
@@ -41,6 +41,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* Encoders */
 #define ENCODERS_PAD_A { F4, F6 }
 #define ENCODERS_PAD_B { F5, F7 }
+#define ENCODER_RESOLUTION 2
+// if you want to reverse encoder direction
+// #define ENCODER_DIRECTION_FLIP
 
 /* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
 #define DEBOUNCE 5

--- a/keyboards/palette1202/keymaps/default/keymap.c
+++ b/keyboards/palette1202/keymaps/default/keymap.c
@@ -116,55 +116,55 @@ void encoder_update_user(uint8_t index, bool clockwise) {
         if (currentLayer % 2 == 0) {
           // default layer
           // Zoom
-          tap_code16(!clockwise ? G(KC_EQL) : G(KC_MINS));
+          tap_code16(!clockwise ? G(KC_MINS) : G(KC_EQL));
         } else {
           // Fn Layer
           // rotate canvas
-          tap_code(!clockwise ? KC_QUOT : KC_MINS);
+          tap_code(!clockwise ? KC_MINS : KC_QUOT);
         }
         break;
       case MAC_PS_1:
         if (currentLayer % 2 == 0) {
           // default layer
           // Zoom
-          tap_code16(!clockwise ? G(KC_EQL) : G(KC_MINS));
+          tap_code16(!clockwise ? G(KC_MINS) : G(KC_EQL));
         } else {
           // Fn Layer
           // undo / redo
-          tap_code16(!clockwise ? S(G(KC_Z)) : G(KC_Z));
+          tap_code16(!clockwise ? G(KC_Z) : S(G(KC_Z)));
         }
         break;
       case WIN_CS_1:
         if (currentLayer % 2 == 0) {
           // default layer
           // Zoom
-          tap_code16(!clockwise ? C(KC_EQL) : C(KC_MINS));
+          tap_code16(!clockwise ? C(KC_MINS) : C(KC_EQL));
         } else {
           // Fn Layer
           // rotate canvas
-          tap_code(!clockwise ? KC_QUOT : KC_MINS);
+          tap_code(!clockwise ? KC_MINS : KC_QUOT);
         }
         break;
       case WIN_PS_1:
         if (currentLayer % 2 == 0) {
           // default layer
           // Zoom
-          tap_code16(!clockwise ? C(KC_SCLN) : C(KC_MINS));
+          tap_code16(!clockwise ? C(KC_MINS) : C(KC_SCLN));
         } else {
           // Fn Layer
           // undo / redo
-          tap_code16(!clockwise ? C(S(KC_Z)) : C(KC_Z));
+          tap_code16(!clockwise ? C(KC_Z) : C(S(KC_Z)));
         }
         break;
       case IOS_CS_1:
         if (currentLayer % 2 == 0) {
           // default layer
           // Zoom 
-          tap_code16(!clockwise ? G(KC_SCLN) : G(KC_MINS));
+          tap_code16(!clockwise ? G(KC_MINS) : G(KC_SCLN));
         } else {
           // Fn Layer
           // rotate canvas
-          tap_code(!clockwise ? KC_EQL : KC_MINS);
+          tap_code(!clockwise ? KC_MINS : KC_EQL);
         }
         break;
       default:
@@ -176,55 +176,55 @@ void encoder_update_user(uint8_t index, bool clockwise) {
         if (currentLayer % 2 == 0) {
           // default layer
           // size of brush
-          tap_code(!clockwise ? KC_RBRC : KC_LBRC);
+          tap_code(!clockwise ? KC_LBRC : KC_RBRC);
         } else {
           // Fn Layer
           // opacity of brush
-          tap_code16(!clockwise ? G(KC_RBRC) : G(KC_LBRC));
+          tap_code16(!clockwise ? G(KC_LBRC) : G(KC_RBRC));
         }
         break;
       case MAC_PS_1:
         if (currentLayer % 2 == 0) {
           // default layer
           // size of brush
-          tap_code(!clockwise ? KC_RBRC : KC_LBRC);
+          tap_code(!clockwise ? KC_LBRC : KC_RBRC);
         } else {
           // Fn Layer
           // opacity of brush
-          tap_code16(!clockwise ? KC_RCBR : KC_LCBR);
+          tap_code16(!clockwise ? KC_LCBR : KC_RCBR);
         }
         break;
       case WIN_CS_1:
         if (currentLayer % 2 == 0) {
           // default layer
           // rotate canvas
-          tap_code(!clockwise ? KC_RBRC : KC_LBRC);
+          tap_code(!clockwise ? KC_LBRC : KC_RBRC);
         } else {
           // Fn Layer
           // opacity of brush
-          tap_code16(!clockwise ? C(KC_RBRC) : C(KC_LBRC));
+          tap_code16(!clockwise ? C(KC_LBRC) : C(KC_RBRC));
         }
         break;
       case WIN_PS_1:
         if (currentLayer % 2 == 0) {
           // default layer
           // rotate canvas
-          tap_code(!clockwise ? KC_RBRC : KC_LBRC);
+          tap_code(!clockwise ? KC_LBRC : KC_RBRC);
         } else {
           // Fn Layer
           // opacity of brush
-          tap_code16(!clockwise ? KC_RCBR : KC_LCBR);
+          tap_code16(!clockwise ? KC_LCBR : KC_RCBR);
         }
         break;
       case IOS_CS_1:
         if (currentLayer % 2 == 0) {
           // default layer
           // size of brush
-          tap_code(!clockwise ? KC_BSLS : KC_RBRC);
+          tap_code(!clockwise ? KC_RBRC : KC_BSLS);
         } else {
           // Fn Layer
           // opacity of brush
-          tap_code16(!clockwise ? G(KC_BSLS) : G(KC_RBRC));
+          tap_code16(!clockwise ? G(KC_RBRC) : G(KC_BSLS));
         }
         break;
       default:

--- a/keyboards/palette1202/readme.md
+++ b/keyboards/palette1202/readme.md
@@ -6,7 +6,7 @@ A left hand device with rotary encoder, for artists.
 
 * Keyboard Maintainer: [niltea](https://github.com/niltea)
 * Hardware Supported: Palette1202
-* Hardware Availability: [Pixiv Booth](https://booth.pm/)
+* Hardware Availability: [Pixiv Booth](https://niltea.booth.pm/)
 * [PCB & Case](https://github.com/niltea/Palette1202)
 
 Make example for this keyboard (after setting up your build environment):


### PR DESCRIPTION
fixed keymap to fix encoder rotate direction.

## Description
Palette1202's encoder rotate direction was not correct (due to QMK Firmware's change of encoders support)
So that, fixed keymap to follow QMK's change.
(and changed readme in URL of hardware availability)

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
