### PR TITLE
Highlight .inc files as .c files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,7 @@
     "files.associations": {
       "*.h": "c",
       "*.c": "c",
+      "*.inc": "c",
       "*.cpp": "cpp",
       "*.hpp": "cpp",
       "xstddef": "c",


### PR DESCRIPTION
This makes highlighting work in Visual Studio Code when adding custom RGB matrix effects by following these instructions: https://beta.docs.qmk.fm/using-qmk/hardware-features/lighting/feature_rgb_matrix#custom-rgb-matrix-effects-id-custom-rgb-matrix-effects