### PR TITLE
Add RawHID support to ATSAM (Massdrop boards)

### DIFF
--- a/tmk_core/protocol/arm_atsam/main_arm_atsam.c
+++ b/tmk_core/protocol/arm_atsam/main_arm_atsam.c
@@ -207,14 +207,12 @@ void main_subtask_usb_extra_device(void) {
 }
 
 #ifdef RAW_ENABLE
-void main_subtask_raw(void)
-{
+void main_subtask_raw(void) {
     udi_hid_raw_receive_report();
 }
 #endif
 
-void main_subtasks(void)
-{
+void main_subtasks(void) {
     main_subtask_usb_state();
     main_subtask_power_check();
     main_subtask_usb_extra_device();

--- a/tmk_core/protocol/arm_atsam/main_arm_atsam.c
+++ b/tmk_core/protocol/arm_atsam/main_arm_atsam.c
@@ -206,10 +206,21 @@ void main_subtask_usb_extra_device(void) {
     }
 }
 
-void main_subtasks(void) {
+#ifdef RAW_ENABLE
+void main_subtask_raw(void)
+{
+    udi_hid_raw_receive_report();
+}
+#endif
+
+void main_subtasks(void)
+{
     main_subtask_usb_state();
     main_subtask_power_check();
     main_subtask_usb_extra_device();
+#ifdef RAW_ENABLE
+    main_subtask_raw();
+#endif
 }
 
 int main(void) {

--- a/tmk_core/protocol/arm_atsam/usb/conf_usb.h
+++ b/tmk_core/protocol/arm_atsam/usb/conf_usb.h
@@ -146,7 +146,7 @@
 #ifdef RAW
 #    define UDI_HID_RAW_ENABLE_EXT() main_raw_enable()
 #    define UDI_HID_RAW_DISABLE_EXT() main_raw_disable()
-#define  UDI_HID_RAW_RECEIVE(buffer, len) main_raw_receive(buffer, len)
+#    define UDI_HID_RAW_RECEIVE(buffer, len) main_raw_receive(buffer, len)
 #endif
 
 //@}

--- a/tmk_core/protocol/arm_atsam/usb/conf_usb.h
+++ b/tmk_core/protocol/arm_atsam/usb/conf_usb.h
@@ -146,6 +146,7 @@
 #ifdef RAW
 #    define UDI_HID_RAW_ENABLE_EXT() main_raw_enable()
 #    define UDI_HID_RAW_DISABLE_EXT() main_raw_disable()
+#define  UDI_HID_RAW_RECEIVE(buffer, len) main_raw_receive(buffer, len)
 #endif
 
 //@}

--- a/tmk_core/protocol/arm_atsam/usb/main_usb.c
+++ b/tmk_core/protocol/arm_atsam/usb/main_usb.c
@@ -93,8 +93,7 @@ bool          main_raw_enable(void) {
 
 void main_raw_disable(void) { main_b_raw_enable = false; }
 
-void main_raw_receive(uint8_t *buffer, uint8_t len)
-{
-  raw_hid_receive(buffer, len);
+void main_raw_receive(uint8_t *buffer, uint8_t len) {
+    raw_hid_receive(buffer, len);
 }
 #endif

--- a/tmk_core/protocol/arm_atsam/usb/main_usb.c
+++ b/tmk_core/protocol/arm_atsam/usb/main_usb.c
@@ -18,6 +18,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "samd51j18a.h"
 #include "conf_usb.h"
 #include "udd.h"
+#ifdef RAW
+#include "raw_hid.h"
+#endif
 
 uint8_t keyboard_protocol = 1;
 
@@ -89,4 +92,9 @@ bool          main_raw_enable(void) {
 }
 
 void main_raw_disable(void) { main_b_raw_enable = false; }
+
+void main_raw_receive(uint8_t *buffer, uint8_t len)
+{
+  raw_hid_receive(buffer, len);
+}
 #endif

--- a/tmk_core/protocol/arm_atsam/usb/udi_hid_kbd.c
+++ b/tmk_core/protocol/arm_atsam/usb/udi_hid_kbd.c
@@ -641,6 +641,9 @@ COMPILER_WORD_ALIGNED
 static uint8_t udi_hid_raw_report_trans[UDI_HID_RAW_REPORT_SIZE];
 
 COMPILER_WORD_ALIGNED
+static uint8_t udi_hid_raw_report_recv[UDI_HID_RAW_REPORT_SIZE];
+
+COMPILER_WORD_ALIGNED
 UDC_DESC_STORAGE udi_hid_raw_report_desc_t udi_hid_raw_report_desc = {{
     0x06, 0x60, 0xFF,  // Usage Page (Vendor Defined)
     0x09, 0x61,        // Usage (Vendor Defined)
@@ -663,6 +666,7 @@ static bool udi_hid_raw_setreport(void);
 static void udi_hid_raw_setreport_valid(void);
 
 static void udi_hid_raw_report_sent(udd_ep_status_t status, iram_size_t nb_sent, udd_ep_id_t ep);
+static void udi_hid_raw_report_rcvd(udd_ep_status_t status, iram_size_t nb_rcvd, udd_ep_id_t ep);
 
 bool udi_hid_raw_enable(void) {
     // Initialize internal values
@@ -719,7 +723,35 @@ static void udi_hid_raw_report_sent(udd_ep_status_t status, iram_size_t nb_sent,
 
 static void udi_hid_raw_setreport_valid(void) {}
 
-#endif  // RAW
+void raw_hid_send(uint8_t *data, uint8_t length)
+{
+  if (main_b_raw_enable && !udi_hid_raw_b_report_trans_ongoing && length == UDI_HID_RAW_REPORT_SIZE) {
+    memcpy(udi_hid_raw_report, data, UDI_HID_RAW_REPORT_SIZE);
+    udi_hid_raw_send_report();
+  }
+}
+
+bool udi_hid_raw_receive_report(void)
+{
+  if (!main_b_raw_enable)
+  {
+    return false;
+  }
+
+  return udd_ep_run(UDI_HID_RAW_EP_OUT | USB_EP_DIR_OUT, false, udi_hid_raw_report_recv, UDI_HID_RAW_REPORT_SIZE, udi_hid_raw_report_rcvd);
+}
+
+static void udi_hid_raw_report_rcvd(udd_ep_status_t status, iram_size_t nb_rcvd, udd_ep_id_t ep)
+{
+  UNUSED(ep);
+
+  if (status == UDD_EP_TRANSFER_OK && nb_rcvd == UDI_HID_RAW_REPORT_SIZE)
+  {
+    UDI_HID_RAW_RECEIVE(udi_hid_raw_report_recv, UDI_HID_RAW_REPORT_SIZE);
+  }
+}
+
+#endif //RAW
 
 //********************************************************************************************
 // CON

--- a/tmk_core/protocol/arm_atsam/usb/udi_hid_kbd.c
+++ b/tmk_core/protocol/arm_atsam/usb/udi_hid_kbd.c
@@ -723,32 +723,27 @@ static void udi_hid_raw_report_sent(udd_ep_status_t status, iram_size_t nb_sent,
 
 static void udi_hid_raw_setreport_valid(void) {}
 
-void raw_hid_send(uint8_t *data, uint8_t length)
-{
-  if (main_b_raw_enable && !udi_hid_raw_b_report_trans_ongoing && length == UDI_HID_RAW_REPORT_SIZE) {
-    memcpy(udi_hid_raw_report, data, UDI_HID_RAW_REPORT_SIZE);
-    udi_hid_raw_send_report();
-  }
+void raw_hid_send(uint8_t *data, uint8_t length) {
+    if (main_b_raw_enable && !udi_hid_raw_b_report_trans_ongoing && length == UDI_HID_RAW_REPORT_SIZE) {
+        memcpy(udi_hid_raw_report, data, UDI_HID_RAW_REPORT_SIZE);
+        udi_hid_raw_send_report();
+    }
 }
 
-bool udi_hid_raw_receive_report(void)
-{
-  if (!main_b_raw_enable)
-  {
-    return false;
-  }
+bool udi_hid_raw_receive_report(void) {
+    if (!main_b_raw_enable) {
+        return false;
+    }
 
-  return udd_ep_run(UDI_HID_RAW_EP_OUT | USB_EP_DIR_OUT, false, udi_hid_raw_report_recv, UDI_HID_RAW_REPORT_SIZE, udi_hid_raw_report_rcvd);
+    return udd_ep_run(UDI_HID_RAW_EP_OUT | USB_EP_DIR_OUT, false, udi_hid_raw_report_recv, UDI_HID_RAW_REPORT_SIZE, udi_hid_raw_report_rcvd);
 }
 
-static void udi_hid_raw_report_rcvd(udd_ep_status_t status, iram_size_t nb_rcvd, udd_ep_id_t ep)
-{
-  UNUSED(ep);
+static void udi_hid_raw_report_rcvd(udd_ep_status_t status, iram_size_t nb_rcvd, udd_ep_id_t ep) {
+    UNUSED(ep);
 
-  if (status == UDD_EP_TRANSFER_OK && nb_rcvd == UDI_HID_RAW_REPORT_SIZE)
-  {
-    UDI_HID_RAW_RECEIVE(udi_hid_raw_report_recv, UDI_HID_RAW_REPORT_SIZE);
-  }
+    if (status == UDD_EP_TRANSFER_OK && nb_rcvd == UDI_HID_RAW_REPORT_SIZE) {
+        UDI_HID_RAW_RECEIVE(udi_hid_raw_report_recv, UDI_HID_RAW_REPORT_SIZE);
+    }
 }
 
 #endif //RAW

--- a/tmk_core/protocol/arm_atsam/usb/udi_hid_kbd.h
+++ b/tmk_core/protocol/arm_atsam/usb/udi_hid_kbd.h
@@ -111,6 +111,7 @@ bool                              udi_hid_mou_send_report(void);
 #ifdef RAW
 extern UDC_DESC_STORAGE udi_api_t udi_api_hid_raw;
 bool                              udi_hid_raw_send_report(void);
+bool                              udi_hid_raw_receive_report(void);
 #endif  // RAW
 
 //@}

--- a/tmk_core/protocol/arm_atsam/usb/usb_main.h
+++ b/tmk_core/protocol/arm_atsam/usb/usb_main.h
@@ -97,6 +97,7 @@ void                 main_mou_disable(void);
 extern volatile bool main_b_raw_enable;
 bool                 main_raw_enable(void);
 void                 main_raw_disable(void);
+void                 main_raw_receive(uint8_t *buffer, uint8_t len);
 #endif  // RAW
 
 #endif  // _MAIN_H_


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Default Massdrop CTRL layout with led timeout and  arm_atsam raw HID r/w


<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or ~~update~~)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Added 300 ms timeout for the led indicators for Massdrop CTRL
* Added raw HID support together with a very stupid test program linked in the readme. My plan is to write a proper configurator a la VIA, but this is a good starting point as CTRL (and ALT) lacked this arm_atsam functionality.
    The code is originally authored by @helluvamatt and I saw that @ash0x0 also has interest in these things.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
