### PR TITLE
Enable SLEEP_LED on ATmega32A 

### DIFF
--- a/tmk_core/common/avr/sleep_led.c
+++ b/tmk_core/common/avr/sleep_led.c
@@ -5,6 +5,16 @@
 #include "led.h"
 #include "sleep_led.h"
 
+#define TCCRxB TCCR1B
+#define TIMERx_COMPA_vect TIMER1_COMPA_vect
+#if defined(__AVR_ATmega32A__)  // This MCU has only one TIMSK register
+#    define TIMSKx TIMSK
+#else
+#    define TIMSKx TIMSK1
+#endif
+#define OCIExA OCIE1A
+#define OCRxx OCR1A
+
 /* Software PWM
  *  ______           ______           __
  * |  ON  |___OFF___|  ON  |___OFF___|   ....
@@ -25,14 +35,13 @@
 void sleep_led_init(void) {
     /* Timer1 setup */
     /* CTC mode */
-    TCCR1B |= _BV(WGM12);
+    TCCRxB |= _BV(WGM12);
     /* Clock selelct: clk/1 */
-    TCCR1B |= _BV(CS10);
+    TCCRxB |= _BV(CS10);
     /* Set TOP value */
     uint8_t sreg = SREG;
     cli();
-    OCR1AH = (SLEEP_LED_TIMER_TOP >> 8) & 0xff;
-    OCR1AL = SLEEP_LED_TIMER_TOP & 0xff;
+    OCRxx = SLEEP_LED_TIMER_TOP;
     SREG   = sreg;
 }
 
@@ -42,7 +51,7 @@ void sleep_led_init(void) {
  */
 void sleep_led_enable(void) {
     /* Enable Compare Match Interrupt */
-    TIMSK1 |= _BV(OCIE1A);
+    TIMSKx |= _BV(OCIExA);
 }
 
 /** \brief Sleep LED disable
@@ -51,7 +60,7 @@ void sleep_led_enable(void) {
  */
 void sleep_led_disable(void) {
     /* Disable Compare Match Interrupt */
-    TIMSK1 &= ~_BV(OCIE1A);
+    TIMSKx &= ~_BV(OCIExA);
 }
 
 /** \brief Sleep LED toggle
@@ -60,7 +69,7 @@ void sleep_led_disable(void) {
  */
 void sleep_led_toggle(void) {
     /* Disable Compare Match Interrupt */
-    TIMSK1 ^= _BV(OCIE1A);
+    TIMSKx ^= _BV(OCIExA);
 }
 
 /** \brief Breathing Sleep LED brighness(PWM On period) table
@@ -72,7 +81,7 @@ void sleep_led_toggle(void) {
  */
 static const uint8_t breathing_table[64] PROGMEM = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 4, 6, 10, 15, 23, 32, 44, 58, 74, 93, 113, 135, 157, 179, 199, 218, 233, 245, 252, 255, 252, 245, 233, 218, 199, 179, 157, 135, 113, 93, 74, 58, 44, 32, 23, 15, 10, 6, 4, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
-ISR(TIMER1_COMPA_vect) {
+ISR(TIMERx_COMPA_vect) {
     /* Software PWM
      * timer:1111 1111 1111 1111
      *       \_____/\/ \_______/____  count(0-255)

--- a/tmk_core/common/avr/sleep_led.c
+++ b/tmk_core/common/avr/sleep_led.c
@@ -56,7 +56,7 @@ void sleep_led_init(void) {
     uint8_t sreg = SREG;
     cli();
     OCRxx = SLEEP_LED_TIMER_TOP;
-    SREG   = sreg;
+    SREG  = sreg;
 }
 
 /** \brief Sleep LED enable

--- a/tmk_core/common/avr/sleep_led.c
+++ b/tmk_core/common/avr/sleep_led.c
@@ -5,15 +5,29 @@
 #include "led.h"
 #include "sleep_led.h"
 
-#define TCCRxB TCCR1B
-#define TIMERx_COMPA_vect TIMER1_COMPA_vect
-#if defined(__AVR_ATmega32A__)  // This MCU has only one TIMSK register
-#    define TIMSKx TIMSK
-#else
-#    define TIMSKx TIMSK1
+#ifndef SLEEP_LED_TIMER
+#    define SLEEP_LED_TIMER 1
 #endif
-#define OCIExA OCIE1A
-#define OCRxx OCR1A
+
+#if SLEEP_LED_TIMER == 1
+#    define TCCRxB TCCR1B
+#    define TIMERx_COMPA_vect TIMER1_COMPA_vect
+#    if defined(__AVR_ATmega32A__)  // This MCU has only one TIMSK register
+#        define TIMSKx TIMSK
+#    else
+#        define TIMSKx TIMSK1
+#    endif
+#    define OCIExA OCIE1A
+#    define OCRxx OCR1A
+#elif SLEEP_LED_TIMER == 3
+#    define TCCRxB TCCR3B
+#    define TIMERx_COMPA_vect TIMER3_COMPA_vect
+#    define TIMSKx TIMSK3
+#    define OCIExA OCIE3A
+#    define OCRxx OCR3A
+#else
+error("Invalid SLEEP_LED_TIMER config")
+#endif
 
 /* Software PWM
  *  ______           ______           __

--- a/tmk_core/protocol/vusb/main.c
+++ b/tmk_core/protocol/vusb/main.c
@@ -20,6 +20,9 @@
 #include "timer.h"
 #include "uart.h"
 #include "debug.h"
+#ifdef SLEEP_LED_ENABLE
+#    include "sleep_led.h"
+#endif
 
 #define UART_BAUD_RATE 115200
 
@@ -59,6 +62,9 @@ int main(void) {
     initForUsbConnectivity();
 
     keyboard_init();
+#ifdef SLEEP_LED_ENABLE
+    sleep_led_init();
+#endif
 
     debug("main loop\n");
     while (1) {
@@ -67,10 +73,16 @@ int main(void) {
             suspended   = false;
             usbSofCount = 0;
             last_timer  = timer_read();
+#    ifdef SLEEP_LED_ENABLE
+            sleep_led_disable();
+#    endif
         } else {
             // Suspend when no SOF in 3ms-10ms(7.1.7.4 Suspending of USB1.1)
             if (timer_elapsed(last_timer) > 5) {
                 suspended = true;
+#    ifdef SLEEP_LED_ENABLE
+                sleep_led_enable();
+#    endif
                 /*
                                 uart_putchar('S');
                                 _delay_ms(1);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Stole some logic from backlight code, compiles :man_shrugging:.

#### TODO
- [x] add timer 3 logic
    * this allows for fixing potential timer conflicts on platforms with more than 1 timer
- [ ] will there be conflicts when enabling both backlight and sleep led?

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
