### PR TITLE
Set backlight and RGB pins for AVR onekeys

### DIFF
--- a/keyboards/handwired/onekey/blackpill_f401/config.h
+++ b/keyboards/handwired/onekey/blackpill_f401/config.h
@@ -28,4 +28,4 @@
 
 #define RGB_DI_PIN A1
 
-#define ADC_PIN A1
+#define ADC_PIN A0

--- a/keyboards/handwired/onekey/blackpill_f401/config.h
+++ b/keyboards/handwired/onekey/blackpill_f401/config.h
@@ -27,3 +27,5 @@
 #define BACKLIGHT_PWM_CHANNEL   1
 
 #define RGB_DI_PIN A1
+
+#define ADC_PIN A1

--- a/keyboards/handwired/onekey/blackpill_f411/config.h
+++ b/keyboards/handwired/onekey/blackpill_f411/config.h
@@ -28,4 +28,4 @@
 
 #define RGB_DI_PIN A1
 
-#define ADC_PIN A1
+#define ADC_PIN A0

--- a/keyboards/handwired/onekey/blackpill_f411/config.h
+++ b/keyboards/handwired/onekey/blackpill_f411/config.h
@@ -27,3 +27,5 @@
 #define BACKLIGHT_PWM_CHANNEL   1
 
 #define RGB_DI_PIN A1
+
+#define ADC_PIN A1

--- a/keyboards/handwired/onekey/bluepill/config.h
+++ b/keyboards/handwired/onekey/bluepill/config.h
@@ -27,3 +27,5 @@
 #define BACKLIGHT_PWM_CHANNEL   1
 
 #define RGB_DI_PIN A1
+
+#define ADC_PIN A0

--- a/keyboards/handwired/onekey/elite_c/config.h
+++ b/keyboards/handwired/onekey/elite_c/config.h
@@ -25,3 +25,5 @@
 #define BACKLIGHT_PIN B6
 
 #define RGB_DI_PIN F6
+
+#define ADC_PIN F6

--- a/keyboards/handwired/onekey/elite_c/config.h
+++ b/keyboards/handwired/onekey/elite_c/config.h
@@ -21,3 +21,7 @@
 #define MATRIX_COL_PINS { F4 }
 #define MATRIX_ROW_PINS { F5 }
 #define UNUSED_PINS
+
+#define BACKLIGHT_PIN B6
+
+#define RGB_DI_PIN F6

--- a/keyboards/handwired/onekey/keymaps/adc/config.h
+++ b/keyboards/handwired/onekey/keymaps/adc/config.h
@@ -1,1 +1,0 @@
-#pragma once

--- a/keyboards/handwired/onekey/keymaps/adc/keymap.c
+++ b/keyboards/handwired/onekey/keymaps/adc/keymap.c
@@ -2,10 +2,6 @@
 #include "analog.h"
 #include <stdio.h>
 
-#ifndef ADC_PIN
-#    define ADC_PIN A0
-#endif
-
 enum custom_keycodes {
     ADC_SAMPLE = SAFE_RANGE,
 };

--- a/keyboards/handwired/onekey/promicro/config.h
+++ b/keyboards/handwired/onekey/promicro/config.h
@@ -25,3 +25,5 @@
 #define BACKLIGHT_PIN B6
 
 #define RGB_DI_PIN F6
+
+#define ADC_PIN F6

--- a/keyboards/handwired/onekey/promicro/config.h
+++ b/keyboards/handwired/onekey/promicro/config.h
@@ -21,3 +21,7 @@
 #define MATRIX_COL_PINS { F4 }
 #define MATRIX_ROW_PINS { F5 }
 #define UNUSED_PINS
+
+#define BACKLIGHT_PIN B6
+
+#define RGB_DI_PIN F6

--- a/keyboards/handwired/onekey/proton_c/config.h
+++ b/keyboards/handwired/onekey/proton_c/config.h
@@ -28,3 +28,5 @@
 #define BACKLIGHT_PAL_MODE      2
 
 #define RGB_DI_PIN A0
+
+#define ADC_PIN A0

--- a/keyboards/handwired/onekey/proton_c/config.h
+++ b/keyboards/handwired/onekey/proton_c/config.h
@@ -18,8 +18,8 @@
 
 #include "config_common.h"
 
-#define MATRIX_COL_PINS { A3 }
-#define MATRIX_ROW_PINS { A2 }
+#define MATRIX_COL_PINS { A2 }
+#define MATRIX_ROW_PINS { A1 }
 #define UNUSED_PINS
 
 #define BACKLIGHT_PIN           B8
@@ -27,4 +27,4 @@
 #define BACKLIGHT_PWM_CHANNEL   3
 #define BACKLIGHT_PAL_MODE      2
 
-#define RGB_DI_PIN A1
+#define RGB_DI_PIN A0

--- a/keyboards/handwired/onekey/stm32f0_disco/config.h
+++ b/keyboards/handwired/onekey/stm32f0_disco/config.h
@@ -28,3 +28,5 @@
 #define BACKLIGHT_PAL_MODE      0
 
 #define RGB_DI_PIN B15
+
+#define ADC_PIN A0

--- a/keyboards/handwired/onekey/teensy_2/config.h
+++ b/keyboards/handwired/onekey/teensy_2/config.h
@@ -25,3 +25,5 @@
 #define BACKLIGHT_PIN B6
 
 #define RGB_DI_PIN F6
+
+#define ADC_PIN F6

--- a/keyboards/handwired/onekey/teensy_2/config.h
+++ b/keyboards/handwired/onekey/teensy_2/config.h
@@ -21,3 +21,7 @@
 #define MATRIX_COL_PINS { F4 }
 #define MATRIX_ROW_PINS { F5 }
 #define UNUSED_PINS
+
+#define BACKLIGHT_PIN B6
+
+#define RGB_DI_PIN F6

--- a/keyboards/handwired/onekey/teensy_2pp/config.h
+++ b/keyboards/handwired/onekey/teensy_2pp/config.h
@@ -25,3 +25,5 @@
 #define BACKLIGHT_PIN B6
 
 #define RGB_DI_PIN F6
+
+#define ADC_PIN F6

--- a/keyboards/handwired/onekey/teensy_2pp/config.h
+++ b/keyboards/handwired/onekey/teensy_2pp/config.h
@@ -18,6 +18,10 @@
 
 #include "config_common.h"
 
-#define MATRIX_COL_PINS { B2 }
-#define MATRIX_ROW_PINS { B1 }
+#define MATRIX_COL_PINS { F4 }
+#define MATRIX_ROW_PINS { F5 }
 #define UNUSED_PINS
+
+#define BACKLIGHT_PIN B6
+
+#define RGB_DI_PIN F6


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

And corrected the matrix pinout for the Proton C onekey. A3 is one of the midboard pads.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
