### PR TITLE
Add more community layout support to Discipline

### DIFF
--- a/keyboards/coseyfannitutti/discipline/discipline.h
+++ b/keyboards/coseyfannitutti/discipline/discipline.h
@@ -34,7 +34,7 @@
 { K40, K41, K42, _x_, _x_, _x_, K46, _x_, _x_, K49, K4A, K4B, K4C, K4D, K4E} \
 }
 
-#define LAYOUT_65_ansi_2_right_mods( \
+#define LAYOUT_65_ansi_blocker( \
   K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C, K0D, K0E, \
   K10, K11, K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, K1C, K1D, K1E, \
   K20, K21, K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B,      K2D, K2E, \
@@ -48,7 +48,7 @@
 { K40, K41, K42, _x_, _x_, _x_, K46, _x_, _x_, K49, K4A, _x_, K4C, K4D, K4E} \
 }
 
-#define LAYOUT_65_ansi_blocker LAYOUT_65_ansi_2_right_mods
+#define LAYOUT_65_ansi_2_right_mods LAYOUT_65_ansi_blocker
 
 #define LAYOUT_wkl_ansi_2_right_mods( \
   K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C, K0D, K0E, \

--- a/keyboards/coseyfannitutti/discipline/discipline.h
+++ b/keyboards/coseyfannitutti/discipline/discipline.h
@@ -92,7 +92,7 @@
 { K40, K41, K42, _x_, _x_, _x_, K46, _x_, _x_, K49, K4A, K4B, K4C, K4D, K4E} \
 }
 
-#define LAYOUT_65_iso_2_right_mods( \
+#define LAYOUT_65_iso_blocker( \
   K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C, K0D, K0E, \
   K10, K11, K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, K1C,      K1E, \
   K20, K21, K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B, K2D, K1D, K2E, \
@@ -105,6 +105,8 @@
 { K30, K31, K32, K33, K34, K35, K36, K37, K38, K39, K3A, K3B, K3C, K3D, K3E }, \
 { K40, K41, K42, _x_, _x_, _x_, K46, _x_, _x_, K49, K4A, _x_, K4C, K4D, K4E} \
 }
+
+#define LAYOUT_65_iso_2_right_mods LAYOUT_65_iso_blocker
 
 #define LAYOUT_wkl_iso_2_right_mods( \
   K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C, K0D, K0E, \

--- a/keyboards/coseyfannitutti/discipline/discipline.h
+++ b/keyboards/coseyfannitutti/discipline/discipline.h
@@ -48,6 +48,8 @@
 { K40, K41, K42, _x_, _x_, _x_, K46, _x_, _x_, K49, K4A, _x_, K4C, K4D, K4E} \
 }
 
+#define LAYOUT_65_ansi_blocker LAYOUT_65_ansi_2_right_mods
+
 #define LAYOUT_wkl_ansi_2_right_mods( \
   K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C, K0D, K0E, \
   K10, K11, K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, K1C, K1D, K1E, \

--- a/keyboards/coseyfannitutti/discipline/rules.mk
+++ b/keyboards/coseyfannitutti/discipline/rules.mk
@@ -35,4 +35,4 @@ AUDIO_ENABLE = no           # Audio output on port C6
 FAUXCLICKY_ENABLE = no      # Use buzzer to emulate clicky switches
 HD44780_ENABLE = no 		# Enable support for HD44780 based LCDs
 
-LAYOUTS = 65_ansi 65_ansi_blocker 65_iso
+LAYOUTS = 65_ansi 65_ansi_blocker 65_iso 65_iso_blocker

--- a/keyboards/coseyfannitutti/discipline/rules.mk
+++ b/keyboards/coseyfannitutti/discipline/rules.mk
@@ -35,4 +35,4 @@ AUDIO_ENABLE = no           # Audio output on port C6
 FAUXCLICKY_ENABLE = no      # Use buzzer to emulate clicky switches
 HD44780_ENABLE = no 		# Enable support for HD44780 based LCDs
 
-LAYOUTS = 65_ansi 65_iso
+LAYOUTS = 65_ansi 65_ansi_blocker 65_iso


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

Adds support for 65_ansi_blocker community layouts to Discipline maintained by @coseyfannitutti. LAYOUT_65_ansi_blocker is aliased as the already implemented LAYOUT_65_ansi_2_right_mods. Although there is no physical blocker, it is the same layout with the same number of arguments, but with the 2 right mods being 1.5u keys and not 1.25u. Tested with layouts/default and layouts/community keymaps.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
