### PR TITLE
Add advanced/efficient RGB Matrix Indicators

### DIFF
--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -482,6 +482,14 @@ void rgb_matrix_indicators_kb(void) {
 }
 ```
 
+In addition, there are the advanced indicator functions.  These are aimed at those with heavily customized displays, where rendering every LED per cycle is expensive.  Such as some of the "drashna" layouts.  This includes a special macro to help make this easier to use: `RGB_MATRIX_INDICATOR_SET_COLOR(i, r, g, b)`.
+
+```c
+void rgb_matrix_indicators_advanced_user(uint8_t led_min, uint8_t led_max) {
+    RGB_MATRIX_INDICATOR_SET_COLOR(index, red, green, blue);
+}
+```
+
 ### Suspended state :id=suspended-state
 To use the suspend feature, make sure that `#define RGB_DISABLE_WHEN_USB_SUSPENDED true` is added to the `config.h` file. 
 

--- a/quantum/rgb_matrix.c
+++ b/quantum/rgb_matrix.c
@@ -401,6 +401,10 @@ void rgb_matrix_task(void) {
             break;
         case RENDERING:
             rgb_task_render(effect);
+            if (!suspend_backlight) {
+                rgb_matrix_indicators();
+                rgb_matrix_indicators_advanced(&rgb_effect_params);
+            }
             break;
         case FLUSHING:
             rgb_task_flush(effect);
@@ -410,9 +414,6 @@ void rgb_matrix_task(void) {
             break;
     }
 
-    if (!suspend_backlight) {
-        rgb_matrix_indicators();
-    }
 }
 
 void rgb_matrix_indicators(void) {
@@ -423,6 +424,15 @@ void rgb_matrix_indicators(void) {
 __attribute__((weak)) void rgb_matrix_indicators_kb(void) {}
 
 __attribute__((weak)) void rgb_matrix_indicators_user(void) {}
+
+void rgb_matrix_indicators_advanced(effect_params_t* params) {
+    rgb_matrix_indicators_advanced_kb(params);
+    rgb_matrix_indicators_advanced_user(params);
+}
+
+__attribute__((weak)) void rgb_matrix_indicators_advanced_kb(effect_params_t* params) {}
+
+__attribute__((weak)) void rgb_matrix_indicators_advanced_user(effect_params_t* params) {}
 
 void rgb_matrix_init(void) {
     rgb_matrix_driver.init();

--- a/quantum/rgb_matrix.c
+++ b/quantum/rgb_matrix.c
@@ -413,7 +413,6 @@ void rgb_matrix_task(void) {
             rgb_task_sync();
             break;
     }
-
 }
 
 void rgb_matrix_indicators(void) {
@@ -425,14 +424,21 @@ __attribute__((weak)) void rgb_matrix_indicators_kb(void) {}
 
 __attribute__((weak)) void rgb_matrix_indicators_user(void) {}
 
-void rgb_matrix_indicators_advanced(effect_params_t* params) {
-    rgb_matrix_indicators_advanced_kb(params);
-    rgb_matrix_indicators_advanced_user(params);
+void rgb_matrix_indicators_advanced(effect_params_t *params) {
+#if defined(RGB_MATRIX_LED_PROCESS_LIMIT) && RGB_MATRIX_LED_PROCESS_LIMIT > 0 && RGB_MATRIX_LED_PROCESS_LIMIT < DRIVER_LED_TOTAL
+    uint8_t min = RGB_MATRIX_LED_PROCESS_LIMIT * (params->iter - 1);
+    uint8_t max = min + RGB_MATRIX_LED_PROCESS_LIMIT;
+    if (max > DRIVER_LED_TOTAL) max = DRIVER_LED_TOTAL;
+#else
+    uint8_t min = 0 uint8_t max = DRIVER_LED_TOTAL;
+#endif
+    rgb_matrix_indicators_advanced_kb(min, max);
+    rgb_matrix_indicators_advanced_user(min, max);
 }
 
-__attribute__((weak)) void rgb_matrix_indicators_advanced_kb(effect_params_t* params) {}
+__attribute__((weak)) void rgb_matrix_indicators_advanced_kb(uint8_t led_min, uint8_t led_max) {}
 
-__attribute__((weak)) void rgb_matrix_indicators_advanced_user(effect_params_t* params) {}
+__attribute__((weak)) void rgb_matrix_indicators_advanced_user(uint8_t led_min, uint8_t led_max) {}
 
 void rgb_matrix_init(void) {
     rgb_matrix_driver.init();

--- a/quantum/rgb_matrix.c
+++ b/quantum/rgb_matrix.c
@@ -425,12 +425,18 @@ __attribute__((weak)) void rgb_matrix_indicators_kb(void) {}
 __attribute__((weak)) void rgb_matrix_indicators_user(void) {}
 
 void rgb_matrix_indicators_advanced(effect_params_t *params) {
+    /* special handling is need "params->iter", since it's already been incremented.
+     * Could move the invocations to rgb_task_render, but then it's missing a few checks
+     * and not sure which would be better. Otherwise, this should be called from
+     * rgb_task_render, right before the iter++ line.
+     */
 #if defined(RGB_MATRIX_LED_PROCESS_LIMIT) && RGB_MATRIX_LED_PROCESS_LIMIT > 0 && RGB_MATRIX_LED_PROCESS_LIMIT < DRIVER_LED_TOTAL
     uint8_t min = RGB_MATRIX_LED_PROCESS_LIMIT * (params->iter - 1);
     uint8_t max = min + RGB_MATRIX_LED_PROCESS_LIMIT;
     if (max > DRIVER_LED_TOTAL) max = DRIVER_LED_TOTAL;
 #else
-    uint8_t min = 0 uint8_t max = DRIVER_LED_TOTAL;
+    uint8_t min = 0;
+    uint8_t max = DRIVER_LED_TOTAL;
 #endif
     rgb_matrix_indicators_advanced_kb(min, max);
     rgb_matrix_indicators_advanced_user(min, max);

--- a/quantum/rgb_matrix.c
+++ b/quantum/rgb_matrix.c
@@ -425,7 +425,7 @@ __attribute__((weak)) void rgb_matrix_indicators_kb(void) {}
 __attribute__((weak)) void rgb_matrix_indicators_user(void) {}
 
 void rgb_matrix_indicators_advanced(effect_params_t *params) {
-    /* special handling is need "params->iter", since it's already been incremented.
+    /* special handling is needed for "params->iter", since it's already been incremented.
      * Could move the invocations to rgb_task_render, but then it's missing a few checks
      * and not sure which would be better. Otherwise, this should be called from
      * rgb_task_render, right before the iter++ line.

--- a/quantum/rgb_matrix.h
+++ b/quantum/rgb_matrix.h
@@ -103,6 +103,10 @@ void rgb_matrix_indicators(void);
 void rgb_matrix_indicators_kb(void);
 void rgb_matrix_indicators_user(void);
 
+void rgb_matrix_indicators_advanced(effect_params_t* params);
+void rgb_matrix_indicators_advanced_kb(effect_params_t* params);
+void rgb_matrix_indicators_advanced_user(effect_params_t* params);
+
 void rgb_matrix_init(void);
 
 void        rgb_matrix_set_suspend_state(bool state);

--- a/quantum/rgb_matrix.h
+++ b/quantum/rgb_matrix.h
@@ -57,6 +57,11 @@
         uint8_t max = DRIVER_LED_TOTAL;
 #endif
 
+#define rgb_matrix_indicator_set_color(i, r, g, b) \
+    if (index >= led_min && index <= led_max) {    \
+        rgb_matrix_set_color(i, r, g, b);          \
+    }
+
 #define RGB_MATRIX_TEST_LED_FLAGS() \
     if (!HAS_ANY_FLAGS(g_led_config.flags[i], params->flags)) continue
 

--- a/quantum/rgb_matrix.h
+++ b/quantum/rgb_matrix.h
@@ -58,7 +58,7 @@
 #endif
 
 #define RGB_MATRIX_INDICATOR_SET_COLOR(i, r, g, b) \
-    if (i >= led_min && i <= led_max) {    \
+    if (i >= led_min && i <= led_max) {            \
         rgb_matrix_set_color(i, r, g, b);          \
     }
 
@@ -108,7 +108,7 @@ void rgb_matrix_indicators(void);
 void rgb_matrix_indicators_kb(void);
 void rgb_matrix_indicators_user(void);
 
-void rgb_matrix_indicators_advanced(effect_params_t* params);
+void rgb_matrix_indicators_advanced(effect_params_t *params);
 void rgb_matrix_indicators_advanced_kb(uint8_t led_min, uint8_t led_max);
 void rgb_matrix_indicators_advanced_user(uint8_t led_min, uint8_t led_max);
 

--- a/quantum/rgb_matrix.h
+++ b/quantum/rgb_matrix.h
@@ -57,7 +57,7 @@
         uint8_t max = DRIVER_LED_TOTAL;
 #endif
 
-#define rgb_matrix_indicator_set_color(i, r, g, b) \
+#define RGB_MATRIX_INDICATOR_SET_COLOR(i, r, g, b) \
     if (index >= led_min && index <= led_max) {    \
         rgb_matrix_set_color(i, r, g, b);          \
     }

--- a/quantum/rgb_matrix.h
+++ b/quantum/rgb_matrix.h
@@ -58,7 +58,7 @@
 #endif
 
 #define RGB_MATRIX_INDICATOR_SET_COLOR(i, r, g, b) \
-    if (index >= led_min && index <= led_max) {    \
+    if (i >= led_min && i <= led_max) {    \
         rgb_matrix_set_color(i, r, g, b);          \
     }
 

--- a/quantum/rgb_matrix.h
+++ b/quantum/rgb_matrix.h
@@ -104,8 +104,8 @@ void rgb_matrix_indicators_kb(void);
 void rgb_matrix_indicators_user(void);
 
 void rgb_matrix_indicators_advanced(effect_params_t* params);
-void rgb_matrix_indicators_advanced_kb(effect_params_t* params);
-void rgb_matrix_indicators_advanced_user(effect_params_t* params);
+void rgb_matrix_indicators_advanced_kb(uint8_t led_min, uint8_t led_max);
+void rgb_matrix_indicators_advanced_user(uint8_t led_min, uint8_t led_max);
 
 void rgb_matrix_init(void);
 


### PR DESCRIPTION
## Description

The RGB Matrix indicators is currently getting called on every task cycle, regardless of the type of cycle. 
Additionally, it calls the entire code, which could be every LED in the matrix, which may be costly.  

This adds an "advanced" function that passes the min and max LEDs, and adds a function (a C macro), that will check to see if a specific LED is in the specified range and only set it if it is.  

This should reduce the number of LEDs set each cycle and make the indicators less costly/more efficient. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Enhancement/optimization
- [x] Documentation

## Checklist
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
   * This is RGB we're talking about, you know I tested it :D
