### PR TITLE
Fix IT_APOS backward compatibility define in keymap_italian.h

### DIFF
--- a/quantum/keymap_extras/keymap_italian.h
+++ b/quantum/keymap_extras/keymap_italian.h
@@ -166,7 +166,7 @@
 
 // DEPRECATED
 #define IT_BKSL IT_BSLS
-#define IT_QUOT IT_APOS
+//#define IT_QUOT IT_APOS
 #define IT_IACC IT_IGRV
 #define IT_EACC IT_EGRV
 #define IT_OACC IT_OGRV

--- a/quantum/keymap_extras/keymap_italian.h
+++ b/quantum/keymap_extras/keymap_italian.h
@@ -166,7 +166,7 @@
 
 // DEPRECATED
 #define IT_BKSL IT_BSLS
-//#define IT_QUOT IT_APOS
+#define IT_APOS IT_QUOT
 #define IT_IACC IT_IGRV
 #define IT_EACC IT_EGRV
 #define IT_OACC IT_OGRV


### PR DESCRIPTION
Found by ZSA.

This is defined on line 48 (as `KC_MINS`), and again, lower down. If this file is included, it will fail to compile.

## Types of Changes
- [x] Bugfix