### PR TITLE
Fix wrong python-pip package for MSYS setup instructions

### DIFF
--- a/docs/newbs_getting_started.md
+++ b/docs/newbs_getting_started.md
@@ -50,7 +50,7 @@ After opening a new MSYS2 MinGW 64-bit terminal, make sure `pacman` is up to dat
 
 You may be asked to close and reopen the window. Do this and keep running the above command until it says `there is nothing to do`. Then run the following:
 
-    pacman -S git python3-pip
+    pacman -S git mingw-w64-x86_64-toolchain mingw-w64-x86_64-python3-pip
     python3 -m pip install qmk
 
 ### macOS


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

`python3-pip` drags in the MSYS Python 3.7, and the CLI gets installed to the wrong place. After `qmk_install.sh` completes, MinGW64 Python 3.8 and its pip (`mingw-w64-x86_64-python3-pip`) will be the default.

However it seems to be not enough to only install the latter package instead; `mingw-w64-x86_64-toolchain` is also necessary, otherwise pip will fail trying to install `coverage`. This is because it contains some C extensions that must be compiled.
![](https://media.discordapp.net/attachments/616725666842411032/692692572006776963/unknown.png)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
