### PR TITLE
V-USB: Use structs for USB descriptors

### DIFF
--- a/keyboards/ares/usbconfig.h
+++ b/keyboards/ares/usbconfig.h
@@ -208,7 +208,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -217,7 +217,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -227,9 +227,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -309,18 +306,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/bfake/usbconfig.h
+++ b/keyboards/bfake/usbconfig.h
@@ -208,7 +208,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -217,7 +217,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -227,9 +227,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -309,18 +306,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/chidori/usbconfig.h
+++ b/keyboards/chidori/usbconfig.h
@@ -208,7 +208,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -217,7 +217,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -227,9 +227,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -309,18 +306,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/coseyfannitutti/discipad/usbconfig.h
+++ b/keyboards/coseyfannitutti/discipad/usbconfig.h
@@ -208,7 +208,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -217,7 +217,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -227,9 +227,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -309,18 +306,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/coseyfannitutti/discipline/usbconfig.h
+++ b/keyboards/coseyfannitutti/discipline/usbconfig.h
@@ -208,7 +208,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -217,7 +217,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -227,9 +227,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -309,18 +306,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/coseyfannitutti/mysterium/usbconfig.h
+++ b/keyboards/coseyfannitutti/mysterium/usbconfig.h
@@ -208,7 +208,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -217,7 +217,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -227,9 +227,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -309,18 +306,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/coseyfannitutti/romeo/usbconfig.h
+++ b/keyboards/coseyfannitutti/romeo/usbconfig.h
@@ -208,7 +208,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -217,7 +217,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -227,9 +227,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -309,18 +306,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/db/db63/usbconfig.h
+++ b/keyboards/db/db63/usbconfig.h
@@ -207,7 +207,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -216,7 +216,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -226,9 +226,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -308,18 +305,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/donutcables/budget96/usbconfig.h
+++ b/keyboards/donutcables/budget96/usbconfig.h
@@ -207,7 +207,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -216,7 +216,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -226,9 +226,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -308,18 +305,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/eve/meteor/usbconfig.h
+++ b/keyboards/eve/meteor/usbconfig.h
@@ -197,7 +197,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -206,7 +206,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -216,9 +216,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -298,18 +295,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/exclusive/e6v2/le_bmc/usbconfig.h
+++ b/keyboards/exclusive/e6v2/le_bmc/usbconfig.h
@@ -207,7 +207,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -216,7 +216,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -226,9 +226,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -308,18 +305,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/exclusive/e6v2/oe_bmc/usbconfig.h
+++ b/keyboards/exclusive/e6v2/oe_bmc/usbconfig.h
@@ -207,7 +207,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -216,7 +216,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -226,9 +226,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -308,18 +305,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/exent/usbconfig.h
+++ b/keyboards/exent/usbconfig.h
@@ -197,7 +197,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -206,7 +206,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -216,9 +216,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS 0
 #define USB_CFG_DEVICE_SUBCLASS 0
@@ -298,18 +295,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE 0
+#define USB_CFG_DESCR_PROPS_DEVICE USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/facew/usbconfig.h
+++ b/keyboards/facew/usbconfig.h
@@ -207,7 +207,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -216,7 +216,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -226,9 +226,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -308,18 +305,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/ft/mars80/usbconfig.h
+++ b/keyboards/ft/mars80/usbconfig.h
@@ -207,7 +207,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -216,7 +216,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -226,9 +226,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -308,18 +305,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/gingham/usbconfig.h
+++ b/keyboards/gingham/usbconfig.h
@@ -208,7 +208,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -217,7 +217,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -227,9 +227,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -309,18 +306,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/gray_studio/hb85/usbconfig.h
+++ b/keyboards/gray_studio/hb85/usbconfig.h
@@ -207,7 +207,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -216,7 +216,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -226,9 +226,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -308,18 +305,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/handwired/hnah40/usbconfig.h
+++ b/keyboards/handwired/hnah40/usbconfig.h
@@ -208,7 +208,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -217,7 +217,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -227,9 +227,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -309,18 +306,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/j80/usbconfig.h
+++ b/keyboards/j80/usbconfig.h
@@ -197,7 +197,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -206,7 +206,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -216,9 +216,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS 0
 #define USB_CFG_DEVICE_SUBCLASS 0
@@ -298,18 +295,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE 0
+#define USB_CFG_DESCR_PROPS_DEVICE USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/jc65/v32a/usbconfig.h
+++ b/keyboards/jc65/v32a/usbconfig.h
@@ -208,7 +208,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -217,7 +217,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -227,9 +227,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -309,18 +306,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/jj40/usbconfig.h
+++ b/keyboards/jj40/usbconfig.h
@@ -208,7 +208,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -217,7 +217,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -227,9 +227,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -309,18 +306,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/jj4x4/usbconfig.h
+++ b/keyboards/jj4x4/usbconfig.h
@@ -208,7 +208,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -217,7 +217,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -227,9 +227,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -309,18 +306,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/jj50/usbconfig.h
+++ b/keyboards/jj50/usbconfig.h
@@ -208,7 +208,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -217,7 +217,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -227,9 +227,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -309,18 +306,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/kbdfans/kbdpad/mk1/usbconfig.h
+++ b/keyboards/kbdfans/kbdpad/mk1/usbconfig.h
@@ -207,7 +207,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -216,7 +216,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -226,9 +226,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -308,18 +305,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/keycapsss/plaid_pad/usbconfig.h
+++ b/keyboards/keycapsss/plaid_pad/usbconfig.h
@@ -207,7 +207,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -216,7 +216,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -226,9 +226,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -308,18 +305,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/kira80/usbconfig.h
+++ b/keyboards/kira80/usbconfig.h
@@ -208,7 +208,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -217,7 +217,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -227,9 +227,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -309,18 +306,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/leeku/finger65/usbconfig.h
+++ b/keyboards/leeku/finger65/usbconfig.h
@@ -207,7 +207,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -216,7 +216,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -226,9 +226,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -308,7 +305,7 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC

--- a/keyboards/mechmini/v1/usbconfig.h
+++ b/keyboards/mechmini/v1/usbconfig.h
@@ -208,7 +208,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -217,7 +217,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -227,9 +227,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -309,18 +306,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/mehkee96/usbconfig.h
+++ b/keyboards/mehkee96/usbconfig.h
@@ -208,7 +208,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -217,7 +217,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -227,9 +227,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -309,18 +306,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/mt40/usbconfig.h
+++ b/keyboards/mt40/usbconfig.h
@@ -208,7 +208,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -217,7 +217,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -227,9 +227,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -309,18 +306,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/panc60/usbconfig.h
+++ b/keyboards/panc60/usbconfig.h
@@ -207,7 +207,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -216,7 +216,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -226,9 +226,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -308,18 +305,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/pearl/usbconfig.h
+++ b/keyboards/pearl/usbconfig.h
@@ -207,7 +207,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -216,7 +216,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -226,9 +226,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -308,18 +305,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/percent/canoe/usbconfig.h
+++ b/keyboards/percent/canoe/usbconfig.h
@@ -208,7 +208,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -217,7 +217,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -227,9 +227,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -309,18 +306,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/percent/skog/usbconfig.h
+++ b/keyboards/percent/skog/usbconfig.h
@@ -208,7 +208,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -217,7 +217,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -227,9 +227,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -309,18 +306,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/percent/skog_lite/usbconfig.h
+++ b/keyboards/percent/skog_lite/usbconfig.h
@@ -207,7 +207,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -216,7 +216,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -226,9 +226,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -308,18 +305,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/plaid/usbconfig.h
+++ b/keyboards/plaid/usbconfig.h
@@ -208,7 +208,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -217,7 +217,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -227,9 +227,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -309,18 +306,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/singa/usbconfig.h
+++ b/keyboards/singa/usbconfig.h
@@ -207,7 +207,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -216,7 +216,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -226,9 +226,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -308,18 +305,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/tartan/usbconfig.h
+++ b/keyboards/tartan/usbconfig.h
@@ -207,7 +207,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -216,7 +216,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -226,9 +226,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -308,18 +305,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/tgr/alice/usbconfig.h
+++ b/keyboards/tgr/alice/usbconfig.h
@@ -208,7 +208,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -217,7 +217,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -227,9 +227,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -309,18 +306,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/tgr/jane/usbconfig.h
+++ b/keyboards/tgr/jane/usbconfig.h
@@ -207,7 +207,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -216,7 +216,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -226,9 +226,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -308,18 +305,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/unikorn/usbconfig.h
+++ b/keyboards/unikorn/usbconfig.h
@@ -207,7 +207,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -216,7 +216,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -226,9 +226,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -308,18 +305,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/winkeyless/bface/usbconfig.h
+++ b/keyboards/winkeyless/bface/usbconfig.h
@@ -207,7 +207,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -216,7 +216,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -226,9 +226,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -308,18 +305,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/winkeyless/bmini/usbconfig.h
+++ b/keyboards/winkeyless/bmini/usbconfig.h
@@ -208,7 +208,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -217,7 +217,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -227,9 +227,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -309,18 +306,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/winkeyless/bminiex/usbconfig.h
+++ b/keyboards/winkeyless/bminiex/usbconfig.h
@@ -208,7 +208,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -217,7 +217,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -227,9 +227,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -309,18 +306,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/ymd75/usbconfig.h
+++ b/keyboards/ymd75/usbconfig.h
@@ -208,7 +208,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -217,7 +217,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -227,9 +227,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -309,18 +306,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/ymd96/usbconfig.h
+++ b/keyboards/ymd96/usbconfig.h
@@ -208,7 +208,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -217,7 +217,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -227,9 +227,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -309,18 +306,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/ymdk/bface/usbconfig.h
+++ b/keyboards/ymdk/bface/usbconfig.h
@@ -207,7 +207,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -216,7 +216,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -226,9 +226,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -308,18 +305,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/keyboards/ymdk_np21/usbconfig.h
+++ b/keyboards/ymdk_np21/usbconfig.h
@@ -208,7 +208,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -217,7 +217,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -227,9 +227,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION  (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
  */
 #define USB_CFG_DEVICE_CLASS        0
 #define USB_CFG_DEVICE_SUBCLASS     0
@@ -309,18 +306,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_DEVICE                  USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
 #define USB_CFG_DESCR_PROPS_STRINGS                 USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_0                USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #define usbMsgPtr_t unsigned short

--- a/quantum/template/ps2avrgb/usbconfig.h
+++ b/quantum/template/ps2avrgb/usbconfig.h
@@ -197,7 +197,7 @@ section at the end of this file).
 
 /* -------------------------- Device Description --------------------------- */
 
-#define USB_CFG_VENDOR_ID (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+#define USB_CFG_VENDOR_ID
 /* USB vendor ID for the device, low byte first. If you have registered your
  * own Vendor ID, define it here. Otherwise you may use one of obdev's free
  * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
@@ -206,7 +206,7 @@ section at the end of this file).
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
  */
-#define USB_CFG_DEVICE_ID (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+#define USB_CFG_DEVICE_ID
 /* This is the ID of the product, low byte first. It is interpreted in the
  * scope of the vendor ID. If you have registered your own VID with usb.org
  * or if you have licensed a PID from somebody else, define it here. Otherwise
@@ -216,34 +216,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_VERSION (DEVICE_VER & 0xFF), ((DEVICE_VER >> 8) & 0xFF)
-/* Version number of the device: Minor number first, then major number.
- */
-#define USB_CFG_VENDOR_NAME 'w', 'i', 'n', 'k', 'e', 'y', 'l', 'e', 's', 's', '.', 'k', 'r'
-#define USB_CFG_VENDOR_NAME_LEN 13
-/* These two values define the vendor name returned by the USB device. The name
- * must be given as a list of characters under single quotes. The characters
- * are interpreted as Unicode (UTF-16) entities.
- * If you don't want a vendor name string, undefine these macros.
- * ALWAYS define a vendor name containing your Internet domain name if you use
- * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
- * details.
- */
-#define USB_CFG_DEVICE_NAME 'p', 's', '2', 'a', 'v', 'r', 'G', 'B'
-#define USB_CFG_DEVICE_NAME_LEN 8
-/* Same as above for the device name. If you don't want a device name, undefine
- * the macros. See the file USB-IDs-for-free.txt before you assign a name if
- * you use a shared VID/PID.
- */
-/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
-/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
-/* Same as above for the serial number. If you don't want a serial number,
- * undefine the macros.
- * It may be useful to provide the serial number through other means than at
- * compile time. See the section about descriptor properties below for how
- * to fine tune control over USB descriptors such as the string descriptor
- * for the serial number.
  */
 #define USB_CFG_DEVICE_CLASS 0
 #define USB_CFG_DEVICE_SUBCLASS 0
@@ -323,18 +295,15 @@ section at the end of this file).
  * };
  */
 
-#define USB_CFG_DESCR_PROPS_DEVICE 0
+#define USB_CFG_DESCR_PROPS_DEVICE USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_CONFIGURATION USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS 0
-#define USB_CFG_DESCR_PROPS_STRING_0 0
-#define USB_CFG_DESCR_PROPS_STRING_VENDOR 0
-#define USB_CFG_DESCR_PROPS_STRING_PRODUCT 0
-#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER 0
+#define USB_CFG_DESCR_PROPS_STRINGS USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_0 USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT USB_PROP_IS_DYNAMIC
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER USB_PROP_IS_DYNAMIC
 #define USB_CFG_DESCR_PROPS_HID USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT USB_PROP_IS_DYNAMIC
-//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN 0
 
 #define usbMsgPtr_t unsigned short

--- a/tmk_core/protocol/vusb/vusb.c
+++ b/tmk_core/protocol/vusb/vusb.c
@@ -349,133 +349,173 @@ const PROGMEM uchar mouse_extra_hid_report[] = {
 #endif
 
 // clang-format off
-const PROGMEM usbStringDescriptor_t usbDescriptorStringZero = {
+const PROGMEM usbStringDescriptor_t usbStringDescriptorZero = {
     .header = {
-        .bLength = USB_STRING_LEN(1),
+        .bLength         = USB_STRING_LEN(1),
         .bDescriptorType = USBDESCR_STRING
     },
-    .bString = {0x0409} // US English
+    .bString             = {0x0409} // US English
 };
 
-const PROGMEM usbStringDescriptor_t usbDescriptorStringManufacturer = {
+const PROGMEM usbStringDescriptor_t usbStringDescriptorManufacturer = {
     .header = {
-        .bLength = USB_STRING_LEN(sizeof(STR(MANUFACTURER)) - 1),
+        .bLength         = USB_STRING_LEN(sizeof(STR(MANUFACTURER)) - 1),
         .bDescriptorType = USBDESCR_STRING
     },
-    .bString = LSTR(MANUFACTURER)
+    .bString             = LSTR(MANUFACTURER)
 };
 
-const PROGMEM usbStringDescriptor_t usbDescriptorStringProduct = {
+const PROGMEM usbStringDescriptor_t usbStringDescriptorProduct = {
     .header = {
-        .bLength = USB_STRING_LEN(sizeof(STR(PRODUCT)) - 1),
+        .bLength         = USB_STRING_LEN(sizeof(STR(PRODUCT)) - 1),
         .bDescriptorType = USBDESCR_STRING
     },
-    .bString = LSTR(PRODUCT)
+    .bString             = LSTR(PRODUCT)
 };
 
-const PROGMEM usbStringDescriptor_t usbDescriptorStringSerial = {
+const PROGMEM usbStringDescriptor_t usbStringDescriptorSerial = {
     .header = {
-        .bLength = USB_STRING_LEN(sizeof(STR(SERIAL_NUMBER)) - 1),
+        .bLength         = USB_STRING_LEN(sizeof(STR(SERIAL_NUMBER)) - 1),
         .bDescriptorType = USBDESCR_STRING
     },
-    .bString = LSTR(SERIAL_NUMBER)
+    .bString             = LSTR(SERIAL_NUMBER)
 };
-// clang-format on
 
+#if USB_CFG_DESCR_PROPS_DEVICE
 /*
- * Descriptor for compite device: Keyboard + Mouse
- *
- * contains: device, interface, HID and endpoint descriptors
+ * Device descriptor
  */
+const PROGMEM usbDeviceDescriptor_t usbDeviceDescriptor = {
+    .header = {
+        .bLength         = sizeof(usbDeviceDescriptor_t),
+        .bDescriptorType = USBDESCR_DEVICE
+    },
+    .bcdUSB              = 0x0110,
+    .bDeviceClass        = USB_CFG_DEVICE_CLASS,
+    .bDeviceSubClass     = USB_CFG_DEVICE_SUBCLASS,
+    .bDeviceProtocol     = 0x00,
+    .bMaxPacketSize0     = 8,
+    .idVendor            = VENDOR_ID,
+    .idProduct           = PRODUCT_ID,
+    .bcdDevice           = DEVICE_VER,
+    .iManufacturer       = 0x01,
+    .iProduct            = 0x02,
+    .iSerialNumber       = 0x03,
+    .bNumConfigurations  = 1
+};
+#endif
+
 #if USB_CFG_DESCR_PROPS_CONFIGURATION
-const PROGMEM char usbDescriptorConfiguration[] = {
-    /* USB configuration descriptor */
-    9,               /* sizeof(usbDescriptorConfiguration): length of descriptor in bytes */
-    USBDESCR_CONFIG, /* descriptor type */
+/*
+ * Configuration descriptors
+ */
+const PROGMEM usbConfigurationDescriptor_t usbConfigurationDescriptor = {
+    .header = {
+        .header = {
+            .bLength         = sizeof(usbConfigurationDescriptorHeader_t),
+            .bDescriptorType = USBDESCR_CONFIG
+        },
+        .wTotalLength        = sizeof(usbConfigurationDescriptor_t),
 #    if defined(MOUSE_ENABLE) || defined(EXTRAKEY_ENABLE)
-    59,  // 9 + (9 + 9 + 7) + (9 + 9 + 7)
+        .bNumInterfaces      = 2,
 #    else
-    34,  // 9 + (9 + 9 + 7)
+        .bNumInterfaces      = 1,
 #    endif
-    0,
-// 18 + 7 * USB_CFG_HAVE_INTRIN_ENDPOINT + 7 * USB_CFG_HAVE_INTRIN_ENDPOINT3 + 9, 0,
-/* total length of data returned (including inlined descriptors) */
-#    if defined(MOUSE_ENABLE) || defined(EXTRAKEY_ENABLE)
-    2, /* number of interfaces in this configuration */
-#    else
-    1,
-#    endif
-    1, /* index of this configuration */
-    0, /* configuration name string index */
+        .bConfigurationValue = 0x01,
+        .iConfiguration      = 0x00,
 #    if USB_CFG_IS_SELF_POWERED
-    (1 << 7) | USBATTR_SELFPOWER, /* attributes */
+        .bmAttributes        = (1 << 7) | USBATTR_SELFPOWER,
 #    else
-    (1 << 7), /* attributes */
+        .bmAttributes        = (1 << 7),
 #    endif
-    USB_MAX_POWER_CONSUMPTION / 2, /* max USB current in 2mA units */
+        .bMaxPower           = USB_MAX_POWER_CONSUMPTION / 2
+    },
 
     /*
-     * Keyboard interface
+     * Keyboard
      */
-    /* Interface descriptor */
-    9,                                                                                  /* sizeof(usbDescrInterface): length of descriptor in bytes */
-    USBDESCR_INTERFACE,                                                                 /* descriptor type */
-    0,                                                                                  /* index of this interface */
-    0,                                                                                  /* alternate setting for this interface */
-    USB_CFG_HAVE_INTRIN_ENDPOINT,                                                       /* endpoints excl 0: number of endpoint descriptors to follow */
-    USB_CFG_INTERFACE_CLASS, USB_CFG_INTERFACE_SUBCLASS, USB_CFG_INTERFACE_PROTOCOL, 0, /* string index for interface */
-    /* HID descriptor */
-    9,                              /* sizeof(usbDescrHID): length of descriptor in bytes */
-    USBDESCR_HID,                   /* descriptor type: HID */
-    0x01, 0x01,                     /* BCD representation of HID version */
-    0x00,                           /* target country code */
-    0x01,                           /* number of HID Report (or other HID class) Descriptor infos to follow */
-    0x22,                           /* descriptor type: report */
-    sizeof(keyboard_hid_report), 0, /* total length of report descriptor */
-/* Endpoint descriptor */
-#    if USB_CFG_HAVE_INTRIN_ENDPOINT /* endpoint descriptor for endpoint 1 */
-    7,                               /* sizeof(usbDescrEndpoint) */
-    USBDESCR_ENDPOINT,               /* descriptor type = endpoint */
-    (char)0x81,                      /* IN endpoint number 1 */
-    0x03,                            /* attrib: Interrupt endpoint */
-    8, 0,                            /* maximum packet size */
-    USB_POLLING_INTERVAL_MS,         /* in ms */
+    .keyboardInterface = {
+        .header = {
+            .bLength         = sizeof(usbInterfaceDescriptor_t),
+            .bDescriptorType = USBDESCR_INTERFACE
+        },
+        .bInterfaceNumber    = 0,
+        .bAlternateSetting   = 0x00,
+        .bNumEndpoints       = USB_CFG_HAVE_INTRIN_ENDPOINT,
+        .bInterfaceClass     = USB_CFG_INTERFACE_CLASS,
+        .bInterfaceSubClass  = USB_CFG_INTERFACE_SUBCLASS,
+        .bInterfaceProtocol  = USB_CFG_INTERFACE_PROTOCOL,
+        .iInterface          = 0x00
+    },
+    .keyboardHID = {
+        .header = {
+            .bLength         = sizeof(usbHIDDescriptor_t),
+            .bDescriptorType = USBDESCR_HID
+        },
+        .bcdHID              = 0x0101,
+        .bCountryCode        = 0x00,
+        .bNumDescriptors     = 1,
+        .bDescriptorType     = USBDESCR_HID_REPORT,
+        .wDescriptorLength   = sizeof(keyboard_hid_report)
+    },
+#    ifdef USB_CFG_HAVE_INTRIN_ENDPOINT
+    .keyboardINEndpoint = {
+        .header = {
+            .bLength         = sizeof(usbEndpointDescriptor_t),
+            .bDescriptorType = USBDESCR_ENDPOINT
+        },
+        .bEndpointAddress    = (USBRQ_DIR_DEVICE_TO_HOST | 1),
+        .bmAttributes        = 0x03,
+        .wMaxPacketSize      = 8,
+        .bInterval           = USB_POLLING_INTERVAL_MS
+    },
 #    endif
 
 #    if defined(MOUSE_ENABLE) || defined(EXTRAKEY_ENABLE)
     /*
-     * Mouse/extrakeys interface
+     * Mouse/Extrakeys
      */
-    /* Interface descriptor */
-    9,                             /* sizeof(usbDescrInterface): length of descriptor in bytes */
-    USBDESCR_INTERFACE,            /* descriptor type */
-    1,                             /* index of this interface */
-    0,                             /* alternate setting for this interface */
-    USB_CFG_HAVE_INTRIN_ENDPOINT3, /* endpoints excl 0: number of endpoint descriptors to follow */
-    0x03,                          /* CLASS: HID */
-    0,                             /* SUBCLASS: none */
-    0,                             /* PROTOCOL: none */
-    0,                             /* string index for interface */
-    /* HID descriptor */
-    9,                                    /* sizeof(usbDescrHID): length of descriptor in bytes */
-    USBDESCR_HID,                         /* descriptor type: HID */
-    0x01, 0x01,                           /* BCD representation of HID version */
-    0x00,                                 /* target country code */
-    0x01,                                 /* number of HID Report (or other HID class) Descriptor infos to follow */
-    0x22,                                 /* descriptor type: report */
-    sizeof(mouse_extra_hid_report), 0,    /* total length of report descriptor */
-#        if USB_CFG_HAVE_INTRIN_ENDPOINT3 /* endpoint descriptor for endpoint 3 */
-    /* Endpoint descriptor */
-    7,                                 /* sizeof(usbDescrEndpoint) */
-    USBDESCR_ENDPOINT,                 /* descriptor type = endpoint */
-    (char)(0x80 | USB_CFG_EP3_NUMBER), /* IN endpoint number 3 */
-    0x03,                              /* attrib: Interrupt endpoint */
-    8, 0,                              /* maximum packet size */
-    USB_POLLING_INTERVAL_MS,           /* in ms */
+    .mouseExtraInterface = {
+        .header = {
+            .bLength         = sizeof(usbInterfaceDescriptor_t),
+            .bDescriptorType = USBDESCR_INTERFACE
+        },
+        .bInterfaceNumber    = 1,
+        .bAlternateSetting   = 0x00,
+        .bNumEndpoints       = USB_CFG_HAVE_INTRIN_ENDPOINT3,
+        .bInterfaceClass     = 0x03,
+        .bInterfaceSubClass  = 0x00,
+        .bInterfaceProtocol  = 0x00,
+        .iInterface          = 0x00
+    },
+    .mouseExtraHID = {
+        .header = {
+            .bLength         = sizeof(usbHIDDescriptor_t),
+            .bDescriptorType = USBDESCR_HID
+        },
+        .bcdHID              = 0x0101,
+        .bCountryCode        = 0x00,
+        .bNumDescriptors     = 1,
+        .bDescriptorType     = USBDESCR_HID_REPORT,
+        .wDescriptorLength   = sizeof(mouse_extra_hid_report)
+    },
+#        if USB_CFG_HAVE_INTRIN_ENDPOINT3
+    .mouseExtraINEndpoint = {
+        .header = {
+            .bLength         = sizeof(usbEndpointDescriptor_t),
+            .bDescriptorType = USBDESCR_ENDPOINT
+        },
+        .bEndpointAddress    = (USBRQ_DIR_DEVICE_TO_HOST | USB_CFG_EP3_NUMBER),
+        .bmAttributes        = 0x03,
+        .wMaxPacketSize      = 8,
+        .bInterval           = USB_POLLING_INTERVAL_MS
+    }
 #        endif
 #    endif
 };
 #endif
+
+// clang-format on
 
 USB_PUBLIC usbMsgLen_t usbFunctionDescriptor(struct usbRequest *rq) {
     usbMsgLen_t len = 0;
@@ -489,42 +529,48 @@ USB_PUBLIC usbMsgLen_t usbFunctionDescriptor(struct usbRequest *rq) {
         debug_hex16(rq->wLength.word); debug("\n");
     */
     switch (rq->wValue.bytes[1]) {
+#if USB_CFG_DESCR_PROPS_DEVICE
+        case USBDESCR_DEVICE:
+            usbMsgPtr = (unsigned char *)&usbDeviceDescriptor;
+            len       = sizeof(usbDeviceDescriptor_t);
+            break;
+#endif
 #if USB_CFG_DESCR_PROPS_CONFIGURATION
         case USBDESCR_CONFIG:
-            usbMsgPtr = (unsigned char *)usbDescriptorConfiguration;
-            len       = sizeof(usbDescriptorConfiguration);
+            usbMsgPtr = (unsigned char *)&usbConfigurationDescriptor;
+            len       = sizeof(usbConfigurationDescriptor_t);
             break;
 #endif
         case USBDESCR_STRING:
             switch (rq->wValue.bytes[0]) {
                 case 0:
-                    usbMsgPtr = (unsigned char *)&usbDescriptorStringZero;
-                    len       = usbDescriptorStringZero.header.bLength;
+                    usbMsgPtr = (unsigned char *)&usbStringDescriptorZero;
+                    len       = usbStringDescriptorZero.header.bLength;
                     break;
                 case 1:  // iManufacturer
-                    usbMsgPtr = (unsigned char *)&usbDescriptorStringManufacturer;
-                    len       = usbDescriptorStringManufacturer.header.bLength;
+                    usbMsgPtr = (unsigned char *)&usbStringDescriptorManufacturer;
+                    len       = usbStringDescriptorManufacturer.header.bLength;
                     break;
                 case 2:  // iProduct
-                    usbMsgPtr = (unsigned char *)&usbDescriptorStringProduct;
-                    len       = usbDescriptorStringProduct.header.bLength;
+                    usbMsgPtr = (unsigned char *)&usbStringDescriptorProduct;
+                    len       = usbStringDescriptorProduct.header.bLength;
                     break;
                 case 3:  // iSerialNumber
-                    usbMsgPtr = (unsigned char *)&usbDescriptorStringSerial;
-                    len       = usbDescriptorStringSerial.header.bLength;
+                    usbMsgPtr = (unsigned char *)&usbStringDescriptorSerial;
+                    len       = usbStringDescriptorSerial.header.bLength;
                     break;
             }
             break;
         case USBDESCR_HID:
             switch (rq->wValue.bytes[0]) {
                 case 0:
-                    usbMsgPtr = (unsigned char *)(usbDescriptorConfiguration + 9 + 9);
-                    len       = 9;
+                    usbMsgPtr = (unsigned char *)&usbConfigurationDescriptor.keyboardHID;
+                    len       = sizeof(usbHIDDescriptor_t);
                     break;
 #if defined(MOUSE_ENABLE) || defined(EXTRAKEY_ENABLE)
                 case 1:
-                    usbMsgPtr = (unsigned char *)(usbDescriptorConfiguration + 9 + (9 + 9 + 7) + 9);
-                    len       = 9;
+                    usbMsgPtr = (unsigned char *)&usbConfigurationDescriptor.mouseExtraHID;
+                    len       = sizeof(usbHIDDescriptor_t);
                     break;
 #endif
             }

--- a/tmk_core/protocol/vusb/vusb.h
+++ b/tmk_core/protocol/vusb/vusb.h
@@ -15,8 +15,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef VUSB_H
-#define VUSB_H
+#pragma once
 
 #include "host_driver.h"
 
@@ -25,14 +24,83 @@ typedef struct usbDescriptorHeader {
     uchar bDescriptorType;
 } __attribute__((packed)) usbDescriptorHeader_t;
 
+typedef struct usbDeviceDescriptor {
+    usbDescriptorHeader_t header;
+    unsigned              bcdUSB;
+    uchar                 bDeviceClass;
+    uchar                 bDeviceSubClass;
+    uchar                 bDeviceProtocol;
+    uchar                 bMaxPacketSize0;
+    unsigned              idVendor;
+    unsigned              idProduct;
+    unsigned              bcdDevice;
+    uchar                 iManufacturer;
+    uchar                 iProduct;
+    uchar                 iSerialNumber;
+    uchar                 bNumConfigurations;
+} __attribute__((packed)) usbDeviceDescriptor_t;
+
+typedef struct usbConfigurationDescriptorHeader {
+    usbDescriptorHeader_t    header;
+    unsigned                 wTotalLength;
+    uchar                    bNumInterfaces;
+    uchar                    bConfigurationValue;
+    uchar                    iConfiguration;
+    uchar                    bmAttributes;
+    uchar                    bMaxPower;
+} __attribute__((packed)) usbConfigurationDescriptorHeader_t;
+
 typedef struct usbStringDescriptor {
     usbDescriptorHeader_t header;
     int                   bString[];
 } __attribute__((packed)) usbStringDescriptor_t;
 
+typedef struct usbInterfaceDescriptor {
+    usbDescriptorHeader_t header;
+    uchar                 bInterfaceNumber;
+    uchar                 bAlternateSetting;
+    uchar                 bNumEndpoints;
+    uchar                 bInterfaceClass;
+    uchar                 bInterfaceSubClass;
+    uchar                 bInterfaceProtocol;
+    uchar                 iInterface;
+} __attribute__((packed)) usbInterfaceDescriptor_t;
+
+typedef struct usbEndpointDescriptor {
+    usbDescriptorHeader_t header;
+    uchar                 bEndpointAddress;
+    uchar                 bmAttributes;
+    unsigned              wMaxPacketSize;
+    uchar                 bInterval;
+} __attribute__((packed)) usbEndpointDescriptor_t;
+
+typedef struct usbHIDDescriptor {
+    usbDescriptorHeader_t header;
+    unsigned              bcdHID;
+    uchar                 bCountryCode;
+    uchar                 bNumDescriptors;
+    uchar                 bDescriptorType;
+    unsigned              wDescriptorLength;
+} __attribute__((packed)) usbHIDDescriptor_t;
+
+typedef struct usbConfigurationDescriptor {
+    usbConfigurationDescriptorHeader_t header;
+    usbInterfaceDescriptor_t           keyboardInterface;
+    usbHIDDescriptor_t                 keyboardHID;
+#ifdef USB_CFG_HAVE_INTRIN_ENDPOINT
+    usbEndpointDescriptor_t            keyboardINEndpoint;
+#endif
+
+#if defined(MOUSE_ENABLE) || defined(EXTRAKEY_ENABLE)
+    usbInterfaceDescriptor_t           mouseExtraInterface;
+    usbHIDDescriptor_t                 mouseExtraHID;
+#    ifdef USB_CFG_HAVE_INTRIN_ENDPOINT3
+    usbEndpointDescriptor_t            mouseExtraINEndpoint;
+#    endif
+#endif
+} __attribute__((packed)) usbConfigurationDescriptor_t;
+
 #define USB_STRING_LEN(s) (sizeof(usbDescriptorHeader_t) + ((s) << 1))
 
 host_driver_t *vusb_driver(void);
 void           vusb_transfer_keyboard(void);
-
-#endif

--- a/tmk_core/protocol/vusb/vusb.h
+++ b/tmk_core/protocol/vusb/vusb.h
@@ -41,13 +41,13 @@ typedef struct usbDeviceDescriptor {
 } __attribute__((packed)) usbDeviceDescriptor_t;
 
 typedef struct usbConfigurationDescriptorHeader {
-    usbDescriptorHeader_t    header;
-    unsigned                 wTotalLength;
-    uchar                    bNumInterfaces;
-    uchar                    bConfigurationValue;
-    uchar                    iConfiguration;
-    uchar                    bmAttributes;
-    uchar                    bMaxPower;
+    usbDescriptorHeader_t header;
+    unsigned              wTotalLength;
+    uchar                 bNumInterfaces;
+    uchar                 bConfigurationValue;
+    uchar                 iConfiguration;
+    uchar                 bmAttributes;
+    uchar                 bMaxPower;
 } __attribute__((packed)) usbConfigurationDescriptorHeader_t;
 
 typedef struct usbStringDescriptor {
@@ -88,14 +88,14 @@ typedef struct usbConfigurationDescriptor {
     usbInterfaceDescriptor_t           keyboardInterface;
     usbHIDDescriptor_t                 keyboardHID;
 #ifdef USB_CFG_HAVE_INTRIN_ENDPOINT
-    usbEndpointDescriptor_t            keyboardINEndpoint;
+    usbEndpointDescriptor_t keyboardINEndpoint;
 #endif
 
 #if defined(MOUSE_ENABLE) || defined(EXTRAKEY_ENABLE)
-    usbInterfaceDescriptor_t           mouseExtraInterface;
-    usbHIDDescriptor_t                 mouseExtraHID;
+    usbInterfaceDescriptor_t mouseExtraInterface;
+    usbHIDDescriptor_t       mouseExtraHID;
 #    ifdef USB_CFG_HAVE_INTRIN_ENDPOINT3
-    usbEndpointDescriptor_t            mouseExtraINEndpoint;
+    usbEndpointDescriptor_t mouseExtraINEndpoint;
 #    endif
 #endif
 } __attribute__((packed)) usbConfigurationDescriptor_t;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Much better than an array of bytes. It's starting to look much more like the LUFA/ChibiOS descriptors.

`USB_CFG_VENDOR_ID` and `USB_CFG_DEVICE_ID` are unused now but not completely removed from usbconfig.h, because the usbdrv code contains a warning if they're not defined (it defaults to the obdev VID/PID). By setting `USB_CFG_DESCR_PROPS_DEVICE` to `USB_PROP_IS_DYNAMIC`, the device descriptor request is sent to `usbFunctionDescriptor()` instead of being handled by usbdrv's default device descriptor.

Tested and working on Plaid-Pad and JJ4x4. After this, I think it's time to consolidate all the usbconfig.h's into a single one under tmk_core/protocol/vusb...

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
