### PR TITLE
Fix inverted backlight for XD60

### DIFF
--- a/keyboards/xd60/rev2/config.h
+++ b/keyboards/xd60/rev2/config.h
@@ -48,6 +48,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 /* Backlight Setup */
 #define BACKLIGHT_PIN F5
 #define BACKLIGHT_LEVELS 6
+#define BACKLIGHT_ON_STATE 0
 
 /* COL2ROW or ROW2COL */
 #define DIODE_DIRECTION COL2ROW

--- a/keyboards/xd60/rev3/config.h
+++ b/keyboards/xd60/rev3/config.h
@@ -48,6 +48,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 /* Backlight Setup */
 #define BACKLIGHT_PIN F5
 #define BACKLIGHT_LEVELS 6
+#define BACKLIGHT_ON_STATE 0
 
 /* COL2ROW or ROW2COL */
 #define DIODE_DIRECTION COL2ROW


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The XD60's backlight is on a non-hardware PWM pin, so the recent breaking change to the default value of `BACKLIGHT_ON_STATE`... has broken it.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #8573 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
