### PR TITLE
Fixes #8541 by getting version from -dumpversion then --version as fa…

### DIFF
--- a/lib/python/qmk/cli/doctor.py
+++ b/lib/python/qmk/cli/doctor.py
@@ -16,8 +16,8 @@ ESSENTIAL_BINARIES = {
     'dfu-programmer': {},
     'avrdude': {},
     'dfu-util': {},
-    'avr-gcc': {},
-    'arm-none-eabi-gcc': {},
+    'avr-gcc': {'version_arg': '-dumpversion'},
+    'arm-none-eabi-gcc': {'version_arg': '-dumpversion'},
     'bin/qmk': {},
 }
 ESSENTIAL_SUBMODULES = ['lib/chibios', 'lib/lufa']
@@ -151,10 +151,8 @@ def is_executable(command):
         return False
 
     # Make sure the command can be executed
-    check = subprocess.run([command, '-dumpversion'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=5, universal_newlines=True)
-
-    if check.returncode > 1:  # if -dumpversion returns error check with --version instead
-        check = subprocess.run([command, '--version'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=5, universal_newlines=True)
+    version_arg = ESSENTIAL_BINARIES[command].get('version_arg', '--version')
+    check = subprocess.run([command, version_arg], stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=5, universal_newlines=True)
 
     ESSENTIAL_BINARIES[command]['output'] = check.stdout
 

--- a/lib/python/qmk/cli/doctor.py
+++ b/lib/python/qmk/cli/doctor.py
@@ -14,9 +14,7 @@ from qmk.commands import run
 
 ESSENTIAL_BINARIES = {
     'dfu-programmer': {},
-    'avrdude': {
-        'version_arg': '-\\?'
-    },
+    'avrdude': {},
     'dfu-util': {},
     'avr-gcc': {
         'version_arg': '-dumpversion'
@@ -166,7 +164,7 @@ def is_executable(command):
         cli.log.debug('Found {fg_cyan}%s', command)
         return True
 
-    cli.log.error("{fg_red}Can't get version number of `%s`", command)
+    cli.log.error("{fg_red}Can't run `%s %s`", (command, version_arg))
     return False
 
 

--- a/lib/python/qmk/cli/doctor.py
+++ b/lib/python/qmk/cli/doctor.py
@@ -36,9 +36,7 @@ def check_arm_gcc_version():
     """Returns True if the arm-none-eabi-gcc version is not known to cause problems.
     """
     if 'output' in ESSENTIAL_BINARIES['arm-none-eabi-gcc']:
-        first_line = ESSENTIAL_BINARIES['arm-none-eabi-gcc']['output'].split('\n')[0]
-        second_half = first_line.split(')', 1)[1].strip()
-        version_number = second_half.split()[0]
+        version_number = ESSENTIAL_BINARIES['arm-none-eabi-gcc']['output'].strip()
         cli.log.info('Found arm-none-eabi-gcc version %s', version_number)
 
     return True  # Right now all known arm versions are ok
@@ -48,8 +46,7 @@ def check_avr_gcc_version():
     """Returns True if the avr-gcc version is not known to cause problems.
     """
     if 'output' in ESSENTIAL_BINARIES['avr-gcc']:
-        first_line = ESSENTIAL_BINARIES['avr-gcc']['output'].split('\n')[0]
-        version_number = first_line.split()[2]
+        version_number = ESSENTIAL_BINARIES['avr-gcc']['output'].strip()
 
         major, minor, rest = version_number.split('.', 2)
         if int(major) > 8:
@@ -154,14 +151,18 @@ def is_executable(command):
         return False
 
     # Make sure the command can be executed
-    check = run([command, '--version'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=5, universal_newlines=True)
+    check = subprocess.run([command, '-dumpversion'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=5, universal_newlines=True)
+
+    if check.returncode > 1:  # if -dumpversion returns error check with --version instead
+        check = subprocess.run([command, '--version'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=5, universal_newlines=True)
+
     ESSENTIAL_BINARIES[command]['output'] = check.stdout
 
     if check.returncode in [0, 1]:  # Older versions of dfu-programmer exit 1
         cli.log.debug('Found {fg_cyan}%s', command)
         return True
 
-    cli.log.error("{fg_red}Can't run `%s --version`", command)
+    cli.log.error("{fg_red}Can't get version number of `%s`", command)
     return False
 
 

--- a/lib/python/qmk/cli/doctor.py
+++ b/lib/python/qmk/cli/doctor.py
@@ -14,10 +14,16 @@ from qmk.commands import run
 
 ESSENTIAL_BINARIES = {
     'dfu-programmer': {},
-    'avrdude': {},
+    'avrdude': {
+        'version_arg': '-\\?'
+    },
     'dfu-util': {},
-    'avr-gcc': {'version_arg': '-dumpversion'},
-    'arm-none-eabi-gcc': {'version_arg': '-dumpversion'},
+    'avr-gcc': {
+        'version_arg': '-dumpversion'
+    },
+    'arm-none-eabi-gcc': {
+        'version_arg': '-dumpversion'
+    },
     'bin/qmk': {},
 }
 ESSENTIAL_SUBMODULES = ['lib/chibios', 'lib/lufa']


### PR DESCRIPTION
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
When running `qmk setup` or `qmk doctor` would get error as referenced in #8541. The problem likely came from a change in the formatting of `avr-gcc --version`. Instead I used the flag `-dumpversion` and made it fallback to `--version` if it returned an error. Changed the cli.log string and the version checking to match the new output values.
 
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #8541 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
