### PR TITLE
Various fixes to how timer differences are calculated

### DIFF
--- a/quantum/debounce/eager_pk.c
+++ b/quantum/debounce/eager_pk.c
@@ -44,6 +44,17 @@ static bool                matrix_need_update;
 #define DEBOUNCE_ELAPSED 251
 #define MAX_DEBOUNCE (DEBOUNCE_ELAPSED - 1)
 
+static uint16_t custom_wrap_timer_reference = 0;
+static uint8_t custom_wrap_timer_last_value = 0;
+
+static uint8_t custom_wrap_timer_read(void) {
+    uint16_t custom_wrap_timer_new_reference = timer_read();
+    uint16_t diff = custom_wrap_timer_new_reference - custom_wrap_timer_reference;
+    custom_wrap_timer_reference = custom_wrap_timer_new_reference;
+    custom_wrap_timer_last_value = (custom_wrap_timer_last_value + diff) % (MAX_DEBOUNCE + 1);
+    return custom_wrap_timer_last_value;
+}
+
 void update_debounce_counters(uint8_t num_rows, uint8_t current_time);
 void transfer_matrix_values(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, uint8_t current_time);
 
@@ -59,7 +70,7 @@ void debounce_init(uint8_t num_rows) {
 }
 
 void debounce(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, bool changed) {
-    uint8_t current_time = timer_read() % MAX_DEBOUNCE;
+    uint8_t current_time = custom_wrap_timer_read();
     if (counters_need_update) {
         update_debounce_counters(num_rows, current_time);
     }

--- a/quantum/debounce/eager_pk.c
+++ b/quantum/debounce/eager_pk.c
@@ -44,15 +44,14 @@ static bool                matrix_need_update;
 #define DEBOUNCE_ELAPSED 251
 #define MAX_DEBOUNCE (DEBOUNCE_ELAPSED - 1)
 
-static uint16_t custom_wrap_timer_reference = 0;
-static uint8_t custom_wrap_timer_last_value = 0;
-
-static uint8_t custom_wrap_timer_read(void) {
-    uint16_t custom_wrap_timer_new_reference = timer_read();
-    uint16_t diff = custom_wrap_timer_new_reference - custom_wrap_timer_reference;
-    custom_wrap_timer_reference = custom_wrap_timer_new_reference;
-    custom_wrap_timer_last_value = (custom_wrap_timer_last_value + diff) % (MAX_DEBOUNCE + 1);
-    return custom_wrap_timer_last_value;
+static uint8_t wrap_timer_read(void) {
+    static uint16_t time = 0;
+    static uint8_t  last_result = 0;
+    uint16_t new_time = timer_read();
+    uint16_t diff = new_time - time;
+    time = new_time;
+    last_result = (last_result + diff) % (MAX_DEBOUNCE + 1);
+    return last_result;
 }
 
 void update_debounce_counters(uint8_t num_rows, uint8_t current_time);
@@ -70,7 +69,7 @@ void debounce_init(uint8_t num_rows) {
 }
 
 void debounce(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, bool changed) {
-    uint8_t current_time = custom_wrap_timer_read();
+    uint8_t current_time = wrap_timer_read();
     if (counters_need_update) {
         update_debounce_counters(num_rows, current_time);
     }

--- a/quantum/debounce/eager_pk.c
+++ b/quantum/debounce/eager_pk.c
@@ -44,7 +44,7 @@ static bool                matrix_need_update;
 #define DEBOUNCE_ELAPSED 251
 #define MAX_DEBOUNCE (DEBOUNCE_ELAPSED - 1)
 
-static uint8_t wrap_timer_read(void) {
+static uint8_t wrapping_timer_read(void) {
     static uint16_t time = 0;
     static uint8_t  last_result = 0;
     uint16_t new_time = timer_read();
@@ -69,7 +69,7 @@ void debounce_init(uint8_t num_rows) {
 }
 
 void debounce(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, bool changed) {
-    uint8_t current_time = wrap_timer_read();
+    uint8_t current_time = wrapping_timer_read();
     if (counters_need_update) {
         update_debounce_counters(num_rows, current_time);
     }

--- a/quantum/debounce/eager_pr.c
+++ b/quantum/debounce/eager_pr.c
@@ -36,15 +36,14 @@ static bool                counters_need_update;
 #define DEBOUNCE_ELAPSED 251
 #define MAX_DEBOUNCE (DEBOUNCE_ELAPSED - 1)
 
-static uint16_t custom_wrap_timer_reference = 0;
-static uint8_t custom_wrap_timer_last_value = 0;
-
-static uint8_t custom_wrap_timer_read(void) {
-    uint16_t custom_wrap_timer_new_reference = timer_read();
-    uint16_t diff = custom_wrap_timer_new_reference - custom_wrap_timer_reference;
-    custom_wrap_timer_reference = custom_wrap_timer_new_reference;
-    custom_wrap_timer_last_value = (custom_wrap_timer_last_value + diff) % (MAX_DEBOUNCE + 1);
-    return custom_wrap_timer_last_value;
+static uint8_t wrap_timer_read(void) {
+    static uint16_t time = 0;
+    static uint8_t  last_result = 0;
+    uint16_t new_time = timer_read();
+    uint16_t diff = new_time - time;
+    time = new_time;
+    last_result = (last_result + diff) % (MAX_DEBOUNCE + 1);
+    return last_result;
 }
 
 void update_debounce_counters(uint8_t num_rows, uint8_t current_time);
@@ -59,7 +58,7 @@ void debounce_init(uint8_t num_rows) {
 }
 
 void debounce(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, bool changed) {
-    uint8_t current_time  = custom_wrap_timer_read();
+    uint8_t current_time  = wrap_timer_read();
     bool    needed_update = counters_need_update;
     if (counters_need_update) {
         update_debounce_counters(num_rows, current_time);

--- a/quantum/debounce/eager_pr.c
+++ b/quantum/debounce/eager_pr.c
@@ -36,6 +36,17 @@ static bool                counters_need_update;
 #define DEBOUNCE_ELAPSED 251
 #define MAX_DEBOUNCE (DEBOUNCE_ELAPSED - 1)
 
+static uint16_t custom_wrap_timer_reference = 0;
+static uint8_t custom_wrap_timer_last_value = 0;
+
+static uint8_t custom_wrap_timer_read(void) {
+    uint16_t custom_wrap_timer_new_reference = timer_read();
+    uint16_t diff = custom_wrap_timer_new_reference - custom_wrap_timer_reference;
+    custom_wrap_timer_reference = custom_wrap_timer_new_reference;
+    custom_wrap_timer_last_value = (custom_wrap_timer_last_value + diff) % (MAX_DEBOUNCE + 1);
+    return custom_wrap_timer_last_value;
+}
+
 void update_debounce_counters(uint8_t num_rows, uint8_t current_time);
 void transfer_matrix_values(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, uint8_t current_time);
 
@@ -48,7 +59,7 @@ void debounce_init(uint8_t num_rows) {
 }
 
 void debounce(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, bool changed) {
-    uint8_t current_time  = timer_read() % MAX_DEBOUNCE;
+    uint8_t current_time  = custom_wrap_timer_read();
     bool    needed_update = counters_need_update;
     if (counters_need_update) {
         update_debounce_counters(num_rows, current_time);

--- a/quantum/debounce/eager_pr.c
+++ b/quantum/debounce/eager_pr.c
@@ -36,7 +36,7 @@ static bool                counters_need_update;
 #define DEBOUNCE_ELAPSED 251
 #define MAX_DEBOUNCE (DEBOUNCE_ELAPSED - 1)
 
-static uint8_t wrap_timer_read(void) {
+static uint8_t wrapping_timer_read(void) {
     static uint16_t time = 0;
     static uint8_t  last_result = 0;
     uint16_t new_time = timer_read();
@@ -58,7 +58,7 @@ void debounce_init(uint8_t num_rows) {
 }
 
 void debounce(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, bool changed) {
-    uint8_t current_time  = wrap_timer_read();
+    uint8_t current_time  = wrapping_timer_read();
     bool    needed_update = counters_need_update;
     if (counters_need_update) {
         update_debounce_counters(num_rows, current_time);

--- a/tmk_core/common/timer.h
+++ b/tmk_core/common/timer.h
@@ -25,7 +25,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    include "avr/timer_avr.h"
 #endif
 
-#define TIMER_DIFF(a, b, max) ((a) >= (b) ? (a) - (b) : (max) + 1 - (b) + (a))
+#define TIMER_DIFF(a, b, max) ((max == UINT8_MAX) ? ((uint8_t)((a)-(b))) : ( \
+                               (max == UINT16_MAX) ? ((uint16_t)((a)-(b))) : ( \
+                               (max == UINT32_MAX) ? ((uint32_t)((a)-(b))) : ( \
+                               (a) >= (b) ? (a) - (b) : (max) + 1 - (b) + (a) ))))
 #define TIMER_DIFF_8(a, b) TIMER_DIFF(a, b, UINT8_MAX)
 #define TIMER_DIFF_16(a, b) TIMER_DIFF(a, b, UINT16_MAX)
 #define TIMER_DIFF_32(a, b) TIMER_DIFF(a, b, UINT32_MAX)

--- a/tmk_core/common/timer.h
+++ b/tmk_core/common/timer.h
@@ -25,7 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    include "avr/timer_avr.h"
 #endif
 
-#define TIMER_DIFF(a, b, max) ((a) >= (b) ? (a) - (b) : (max) - (b) + (a))
+#define TIMER_DIFF(a, b, max) ((a) >= (b) ? (a) - (b) : (max) + 1 - (b) + (a))
 #define TIMER_DIFF_8(a, b) TIMER_DIFF(a, b, UINT8_MAX)
 #define TIMER_DIFF_16(a, b) TIMER_DIFF(a, b, UINT16_MAX)
 #define TIMER_DIFF_32(a, b) TIMER_DIFF(a, b, UINT32_MAX)


### PR DESCRIPTION
## Description

This PR makes 3 main changes
1) The TIMER_DIFF* macros calculated wrong values after timer overflow (1 less)
2) Improves code generation efficiency for TIMER_DIFF* macros (smaller, faster code)
3) The eager_pr, and eager_pk debounce algorithms had a serious problem with how they tracked time.

For details please see each commit message in turn.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

NOTE: I have tested the changes using a atmega32u4 devboard, with some synthetic tests. I have not tested with an actual keyboard.
