### PR TITLE
quantum/debounce: Added sym_pk debounce algorithm

### DIFF
--- a/docs/feature_debounce_type.md
+++ b/docs/feature_debounce_type.md
@@ -38,5 +38,6 @@ For use in keyboards where refreshing ```NUM_KEYS``` 8-bit counters is computati
 appropriate for the ErgoDox models; the matrix is rotated 90°, and hence its "rows" are really columns, and each finger only hits a single "row" at a time in normal use.
 * eager_pk - debouncing per key. On any state change, response is immediate, followed by ```DEBOUNCE``` milliseconds of no further input for that key
 * sym_g - debouncing per keyboard. On any state change, a global timer is set. When ```DEBOUNCE``` milliseconds of no changes has occured, all input changes are pushed.
+* sym_pk - debouncing per key. On any state change, a per-key timer is set. When ```DEBOUNCE``` milliseconds of no changes have occured on that key, the key status change is pushed.
 
 

--- a/quantum/debounce/eager_pk.c
+++ b/quantum/debounce/eager_pk.c
@@ -27,13 +27,7 @@ No further inputs are accepted until DEBOUNCE milliseconds have occurred.
 #    define DEBOUNCE 5
 #endif
 
-#if (MATRIX_COLS <= 8)
-#    define ROW_SHIFTER ((uint8_t)1)
-#elif (MATRIX_COLS <= 16)
-#    define ROW_SHIFTER ((uint16_t)1)
-#elif (MATRIX_COLS <= 32)
-#    define ROW_SHIFTER ((uint32_t)1)
-#endif
+#define ROW_SHIFTER ((matrix_row_t)1)
 
 #define debounce_counter_t uint8_t
 

--- a/quantum/debounce/sym_pk.c
+++ b/quantum/debounce/sym_pk.c
@@ -43,7 +43,7 @@ static bool                counters_need_update;
 #define DEBOUNCE_ELAPSED 251
 #define MAX_DEBOUNCE (DEBOUNCE_ELAPSED - 1)
 
-static uint8_t wrap_timer_read(void) {
+static uint8_t wrapping_timer_read(void) {
     static uint16_t time = 0;
     static uint8_t  last_result = 0;
     uint16_t new_time = timer_read();
@@ -68,7 +68,7 @@ void debounce_init(uint8_t num_rows) {
 }
 
 void debounce(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, bool changed) {
-    uint8_t current_time = wrap_timer_read();
+    uint8_t current_time = wrapping_timer_read();
     if (counters_need_update) {
         update_debounce_counters_and_transfer_if_expired(raw, cooked, num_rows, current_time);
     }

--- a/quantum/debounce/sym_pk.c
+++ b/quantum/debounce/sym_pk.c
@@ -43,14 +43,14 @@ static bool                counters_need_update;
 #define DEBOUNCE_ELAPSED 251
 #define MAX_DEBOUNCE (DEBOUNCE_ELAPSED - 1)
 
-static uint16_t custom_wrap_timer_reference = 0;
-static uint8_t custom_wrap_timer_last_value = 0;
+static uint16_t custom_wrap_timer_reference  = 0;
+static uint8_t  custom_wrap_timer_last_value = 0;
 
 static uint8_t custom_wrap_timer_read(void) {
     uint16_t custom_wrap_timer_new_reference = timer_read();
-    uint16_t diff = custom_wrap_timer_new_reference - custom_wrap_timer_reference;
-    custom_wrap_timer_reference = custom_wrap_timer_new_reference;
-    custom_wrap_timer_last_value = (custom_wrap_timer_last_value + diff) % (MAX_DEBOUNCE + 1);
+    uint16_t diff                            = custom_wrap_timer_new_reference - custom_wrap_timer_reference;
+    custom_wrap_timer_reference              = custom_wrap_timer_new_reference;
+    custom_wrap_timer_last_value             = (custom_wrap_timer_last_value + diff) % (MAX_DEBOUNCE + 1);
     return custom_wrap_timer_last_value;
 }
 
@@ -88,7 +88,7 @@ void update_debounce_counters(matrix_row_t raw[], matrix_row_t cooked[], uint8_t
             if (*debounce_pointer != DEBOUNCE_ELAPSED) {
                 if (TIMER_DIFF(current_time, *debounce_pointer, MAX_DEBOUNCE) >= DEBOUNCE) {
                     *debounce_pointer = DEBOUNCE_ELAPSED;
-                    cooked[row] = (cooked[row] & ~(ROW_SHIFTER << col)) | (raw[row] & (ROW_SHIFTER << col));
+                    cooked[row]       = (cooked[row] & ~(ROW_SHIFTER << col)) | (raw[row] & (ROW_SHIFTER << col));
                 } else {
                     counters_need_update = true;
                 }
@@ -102,7 +102,7 @@ void update_debounce_counters(matrix_row_t raw[], matrix_row_t cooked[], uint8_t
 void transfer_matrix_values(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, uint8_t current_time) {
     debounce_counter_t *debounce_pointer = debounce_counters;
     for (uint8_t row = 0; row < num_rows; row++) {
-        matrix_row_t delta        = raw[row] ^ cooked[row];
+        matrix_row_t delta = raw[row] ^ cooked[row];
         for (uint8_t col = 0; col < MATRIX_COLS; col++) {
             if (delta & (ROW_SHIFTER << col)) {
                 if (*debounce_pointer == DEBOUNCE_ELAPSED) {

--- a/quantum/debounce/sym_pk.c
+++ b/quantum/debounce/sym_pk.c
@@ -27,13 +27,7 @@ When no state changes have occured for DEBOUNCE milliseconds, we push the state.
 #    define DEBOUNCE 5
 #endif
 
-#if (MATRIX_COLS <= 8)
-#    define ROW_SHIFTER ((uint8_t)1)
-#elif (MATRIX_COLS <= 16)
-#    define ROW_SHIFTER ((uint16_t)1)
-#elif (MATRIX_COLS <= 32)
-#    define ROW_SHIFTER ((uint32_t)1)
-#endif
+#define ROW_SHIFTER ((matrix_row_t)1)
 
 #define debounce_counter_t uint8_t
 

--- a/quantum/debounce/sym_pk.c
+++ b/quantum/debounce/sym_pk.c
@@ -43,15 +43,14 @@ static bool                counters_need_update;
 #define DEBOUNCE_ELAPSED 251
 #define MAX_DEBOUNCE (DEBOUNCE_ELAPSED - 1)
 
-static uint16_t custom_wrap_timer_reference  = 0;
-static uint8_t  custom_wrap_timer_last_value = 0;
-
-static uint8_t custom_wrap_timer_read(void) {
-    uint16_t custom_wrap_timer_new_reference = timer_read();
-    uint16_t diff                            = custom_wrap_timer_new_reference - custom_wrap_timer_reference;
-    custom_wrap_timer_reference              = custom_wrap_timer_new_reference;
-    custom_wrap_timer_last_value             = (custom_wrap_timer_last_value + diff) % (MAX_DEBOUNCE + 1);
-    return custom_wrap_timer_last_value;
+static uint8_t wrap_timer_read(void) {
+    static uint16_t time = 0;
+    static uint8_t  last_result = 0;
+    uint16_t new_time = timer_read();
+    uint16_t diff = new_time - time;
+    time = new_time;
+    last_result = (last_result + diff) % (MAX_DEBOUNCE + 1);
+    return last_result;
 }
 
 void update_debounce_counters_and_transfer_if_expired(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, uint8_t current_time);
@@ -69,7 +68,7 @@ void debounce_init(uint8_t num_rows) {
 }
 
 void debounce(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, bool changed) {
-    uint8_t current_time = custom_wrap_timer_read();
+    uint8_t current_time = wrap_timer_read();
     if (counters_need_update) {
         update_debounce_counters_and_transfer_if_expired(raw, cooked, num_rows, current_time);
     }

--- a/quantum/debounce/sym_pk.c
+++ b/quantum/debounce/sym_pk.c
@@ -54,8 +54,8 @@ static uint8_t custom_wrap_timer_read(void) {
     return custom_wrap_timer_last_value;
 }
 
-void update_debounce_counters(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, uint8_t current_time);
-void transfer_matrix_values(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, uint8_t current_time);
+void update_debounce_counters_and_transfer_if_expired(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, uint8_t current_time);
+void start_debounce_counters(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, uint8_t current_time);
 
 // we use num_rows rather than MATRIX_ROWS to support split keyboards
 void debounce_init(uint8_t num_rows) {
@@ -71,16 +71,15 @@ void debounce_init(uint8_t num_rows) {
 void debounce(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, bool changed) {
     uint8_t current_time = custom_wrap_timer_read();
     if (counters_need_update) {
-        update_debounce_counters(raw, cooked, num_rows, current_time);
+        update_debounce_counters_and_transfer_if_expired(raw, cooked, num_rows, current_time);
     }
 
     if (changed) {
-        transfer_matrix_values(raw, cooked, num_rows, current_time);
+        start_debounce_counters(raw, cooked, num_rows, current_time);
     }
 }
 
-// If the current time is > debounce counter, set the counter to enable input.
-void update_debounce_counters(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, uint8_t current_time) {
+void update_debounce_counters_and_transfer_if_expired(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, uint8_t current_time) {
     counters_need_update                 = false;
     debounce_counter_t *debounce_pointer = debounce_counters;
     for (uint8_t row = 0; row < num_rows; row++) {
@@ -98,8 +97,7 @@ void update_debounce_counters(matrix_row_t raw[], matrix_row_t cooked[], uint8_t
     }
 }
 
-// upload from raw_matrix to final matrix;
-void transfer_matrix_values(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, uint8_t current_time) {
+void start_debounce_counters(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, uint8_t current_time) {
     debounce_counter_t *debounce_pointer = debounce_counters;
     for (uint8_t row = 0; row < num_rows; row++) {
         matrix_row_t delta = raw[row] ^ cooked[row];

--- a/quantum/debounce/sym_pk.c
+++ b/quantum/debounce/sym_pk.c
@@ -1,0 +1,120 @@
+/*
+Copyright 2017 Alex Ong<the.onga@gmail.com>
+Copyright 2020 Andrei Purdea<andrei@purdea.ro>
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*
+Basic symmetric per-key algorithm. Uses an 8-bit counter per key.
+When no state changes have occured for DEBOUNCE milliseconds, we push the state.
+*/
+
+#include "matrix.h"
+#include "timer.h"
+#include "quantum.h"
+#include <stdlib.h>
+
+#ifndef DEBOUNCE
+#    define DEBOUNCE 5
+#endif
+
+#if (MATRIX_COLS <= 8)
+#    define ROW_SHIFTER ((uint8_t)1)
+#elif (MATRIX_COLS <= 16)
+#    define ROW_SHIFTER ((uint16_t)1)
+#elif (MATRIX_COLS <= 32)
+#    define ROW_SHIFTER ((uint32_t)1)
+#endif
+
+#define debounce_counter_t uint8_t
+
+static debounce_counter_t *debounce_counters;
+static bool                counters_need_update;
+
+#define DEBOUNCE_ELAPSED 251
+#define MAX_DEBOUNCE (DEBOUNCE_ELAPSED - 1)
+
+static uint16_t custom_wrap_timer_reference = 0;
+static uint8_t custom_wrap_timer_last_value = 0;
+
+static uint8_t custom_wrap_timer_read(void) {
+    uint16_t custom_wrap_timer_new_reference = timer_read();
+    uint16_t diff = custom_wrap_timer_new_reference - custom_wrap_timer_reference;
+    custom_wrap_timer_reference = custom_wrap_timer_new_reference;
+    custom_wrap_timer_last_value = (custom_wrap_timer_last_value + diff) % (MAX_DEBOUNCE + 1);
+    return custom_wrap_timer_last_value;
+}
+
+void update_debounce_counters(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, uint8_t current_time);
+void transfer_matrix_values(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, uint8_t current_time);
+
+// we use num_rows rather than MATRIX_ROWS to support split keyboards
+void debounce_init(uint8_t num_rows) {
+    debounce_counters = (debounce_counter_t *)malloc(num_rows * MATRIX_COLS * sizeof(debounce_counter_t));
+    int i             = 0;
+    for (uint8_t r = 0; r < num_rows; r++) {
+        for (uint8_t c = 0; c < MATRIX_COLS; c++) {
+            debounce_counters[i++] = DEBOUNCE_ELAPSED;
+        }
+    }
+}
+
+void debounce(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, bool changed) {
+    uint8_t current_time = custom_wrap_timer_read();
+    if (counters_need_update) {
+        update_debounce_counters(raw, cooked, num_rows, current_time);
+    }
+
+    if (changed) {
+        transfer_matrix_values(raw, cooked, num_rows, current_time);
+    }
+}
+
+// If the current time is > debounce counter, set the counter to enable input.
+void update_debounce_counters(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, uint8_t current_time) {
+    counters_need_update                 = false;
+    debounce_counter_t *debounce_pointer = debounce_counters;
+    for (uint8_t row = 0; row < num_rows; row++) {
+        for (uint8_t col = 0; col < MATRIX_COLS; col++) {
+            if (*debounce_pointer != DEBOUNCE_ELAPSED) {
+                if (TIMER_DIFF(current_time, *debounce_pointer, MAX_DEBOUNCE) >= DEBOUNCE) {
+                    *debounce_pointer = DEBOUNCE_ELAPSED;
+                    cooked[row] = (cooked[row] & ~(ROW_SHIFTER << col)) | (raw[row] & (ROW_SHIFTER << col));
+                } else {
+                    counters_need_update = true;
+                }
+            }
+            debounce_pointer++;
+        }
+    }
+}
+
+// upload from raw_matrix to final matrix;
+void transfer_matrix_values(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, uint8_t current_time) {
+    debounce_counter_t *debounce_pointer = debounce_counters;
+    for (uint8_t row = 0; row < num_rows; row++) {
+        matrix_row_t delta        = raw[row] ^ cooked[row];
+        for (uint8_t col = 0; col < MATRIX_COLS; col++) {
+            if (delta & (ROW_SHIFTER << col)) {
+                if (*debounce_pointer == DEBOUNCE_ELAPSED) {
+                    *debounce_pointer    = current_time;
+                    counters_need_update = true;
+                }
+            } else {
+                *debounce_pointer = DEBOUNCE_ELAPSED;
+            }
+            debounce_pointer++;
+        }
+    }
+}
+
+bool debounce_active(void) { return true; }


### PR DESCRIPTION
## Description

Added sym_pk debounce algorithm
sym_pk is debouncing per key. On any state change, a per-key timer is set. When DEBOUNCE milliseconds of no changes have occured on that key, the key status change is pushed.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

NOTE: I have only tested this on a pro micro devboard, by touching some exposed pins, and having it pick up noise. I have not tested this on a real keyboard.