### PR TITLE
Add am layout for Corne (crkbd)

### DIFF
--- a/keyboards/crkbd/keymaps/am/config.h
+++ b/keyboards/crkbd/keymaps/am/config.h
@@ -1,0 +1,36 @@
+/*
+This is the c configuration file for the keymap
+
+Copyright 2012 Jun Wako <wakojun@gmail.com>
+Copyright 2015 Jack Humbert
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+//#define USE_MATRIX_I2C
+
+/* Select hand configuration */
+
+#define MASTER_LEFT
+
+// https://medium.com/@keebio/the-case-of-the-wayward-elite-c-73f0fd691f88
+#define SPLIT_USB_DETECT
+
+#define SSD1306OLED
+
+#define USE_SERIAL_PD2
+
+#define TAPPING_FORCE_HOLD

--- a/keyboards/crkbd/keymaps/am/keymap.c
+++ b/keyboards/crkbd/keymaps/am/keymap.c
@@ -1,0 +1,223 @@
+#include QMK_KEYBOARD_H
+
+extern uint8_t is_master;
+
+// Each layer gets a name for readability, which is then used in the keymap matrix below.
+// The underscores don't mean anything - you can have a layer called STUFF or any other name.
+// Layer names don't all need to be of the same length, obviously, and you can also skip them
+// entirely and just use numbers.
+#define _QWERTY 0
+#define _LOWER 1
+#define _RAISE 2
+#define _ADJUST 3
+#define _TOUCHCURSOR 4
+
+enum custom_keycodes {
+  QWERTY = SAFE_RANGE,
+  LOWER,
+  RAISE,
+  ADJUST,
+  BACKLIT
+};
+
+enum macro_keycodes {
+  KC_SAMPLEMACRO,
+};
+
+// Tap-dance
+enum {
+    TD_GUI_ALT = 0
+};
+
+// Tap Dance Definitions
+qk_tap_dance_action_t tap_dance_actions[] = {
+    // Tap once for Gui, twice for Alt
+    [TD_GUI_ALT] = ACTION_TAP_DANCE_DOUBLE(KC_LGUI, KC_LALT)
+};
+
+#define KC_LOWER LOWER
+#define KC_RAISE RAISE
+#define KC_RESET RESET
+#define KC_VUP KC__VOLUP
+#define KC_VDW KC__VOLDOWN
+#define KC_LT_TC LT(_TOUCHCURSOR, KC_SPC) // L-ayer T-ap T-ouch C-ursor
+#define KC_CT_ESC CTL_T(KC_ESC)
+#define KC_SF_EN RSFT_T(KC_ENTER)
+// GUI on tap/hold | ALT on double-tap/hold
+#define KC_GUI_ALT TD(TD_GUI_ALT)
+// GUI + ALT
+#define KC_GUIAL OSM(MOD_LGUI | MOD_LALT)
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  [_QWERTY] = LAYOUT_kc( \
+  //,-----------------------------------------.                ,-----------------------------------------.
+        TAB,     Q,     W,     E,     R,     T,                      Y,     U,     I,     O,     P,  BSPC, \
+  //|------+------+------+------+------+------|                |------+------+------+------+------+------|
+     CT_ESC,     A,     S,     D,     F,     G,                      H,     J,     K,     L,  SCLN,  QUOT, \
+  //|------+------+------+------+------+------|                |------+------+------+------+------+------|
+       LSFT,     Z,     X,     C,     V,     B,                      N,     M,  COMM,   DOT,  SLSH, SF_EN, \
+  //|------+------+------+------+------+------+------|  |------+------+------+------+------+------+------|
+                                GUI_ALT, LOWER, GUIAL,    LT_TC, RAISE, ENTER \
+                              //`--------------------'  `--------------------'
+  ),
+
+  [_LOWER] = LAYOUT_kc( \
+  //,-----------------------------------------.                ,-----------------------------------------.
+       TILD,  EXLM,    AT,  HASH,   DLR,  PERC,                   CIRC,  AMPR,  ASTR,  LPRN,  RPRN,  TRNS, \
+  //|------+------+------+------+------+------|                |------+------+------+------+------+------|
+       PIPE,    F1,    F2,    F3,    F4,    F5,                     F6,  MINS,  PLUS,  LCBR,  RCBR,   GRV, \
+  //|------+------+------+------+------+------|                |------+------+------+------+------+------|
+       BSLS,    F7,    F8,    F9,   F10,   F11,                    F12,  UNDS,   EQL,  LBRC,  RBRC,  SLSH, \
+  //|------+------+------+------+------+------+------|  |------+------+------+------+------+------+------|
+                                GUI_ALT, LOWER, GUIAL,    LT_TC, RAISE, ENTER \
+                              //`--------------------'  `--------------------'
+  ),
+
+  [_RAISE] = LAYOUT_kc( \
+  //,-----------------------------------------.                ,-----------------------------------------.
+          0,     1,     2,     3,     4,     5,                      6,     7,     8,     9,     0,  TRNS, \
+  //|------+------+------+------+------+------|                |------+------+------+------+------+------|
+         NO,     4,     5,     6,    NO,    NO,                   PPLS,     4,     5,     6,    NO,   DLR, \
+  //|------+------+------+------+------+------|                |------+------+------+------+------+------|
+         NO,     7,     8,     9,     0,    NO,                   PMNS,     1,     2,     3,    NO,  PENT, \
+  //|------+------+------+------+------+------+------|  |------+------+------+------+------+------+------|
+                                GUI_ALT, LOWER, GUIAL,    LT_TC, RAISE, ENTER \
+                              //`--------------------'  `--------------------'
+  ),
+
+  [_ADJUST] = LAYOUT_kc( \
+  //,-----------------------------------------.                ,-----------------------------------------.
+      RESET, POWER,    NO,    NO,    NO,    NO,                     NO,    NO,    NO,    NO,    NO,    NO, \
+  //|------+------+------+------+------+------|                |------+------+------+------+------+------|
+         NO,    NO,    NO,    NO,    NO,    NO,                   MPRV,  MPLY,  MNXT,    NO,    NO,    NO, \
+  //|------+------+------+------+------+------|                |------+------+------+------+------+------|
+         NO,    NO,    NO,    NO,    NO,    NO,                  _MUTE,   VDW,   VUP,    NO,    NO,    NO, \
+  //|------+------+------+------+------+------+------|  |------+------+------+------+------+------+------|
+                                     NO,    NO,    NO,       NO,    NO,    NO \
+                              //`--------------------'  `--------------------'
+  ),
+
+  [_TOUCHCURSOR] = LAYOUT_kc( \
+  //,-----------------------------------------.                ,-----------------------------------------.
+       TRNS,    NO,    NO,    NO,    NO,    NO,                     NO,    NO,    NO,    NO,    NO,  TRNS, \
+  //|------+------+------+------+------+------|                |------+------+------+------+------+------|
+       TRNS,    NO,    NO,    NO,    NO,    NO,                   LEFT,  DOWN,    UP,  RGHT,    NO,  TRNS, \
+  //|------+------+------+------+------+------|                |------+------+------+------+------+------|
+       TRNS,    NO,    NO,    NO,    NO,    NO,                   MS_L,  MS_D,  MS_U,  MS_R,    NO,  TRNS,\
+  //|------+------+------+------+------+------+------|  |------+------+------+------+------+------+------|
+                                GUI_ALT, LOWER, GUIAL,    LT_TC, RAISE, ENTER \
+                              //`--------------------'  `--------------------'
+  )
+};
+
+void persistent_default_layer_set(uint16_t default_layer) {
+  eeconfig_update_default_layer(default_layer);
+  default_layer_set(default_layer);
+}
+
+// Setting ADJUST layer RGB back to default
+void update_tri_layer_RGB(uint8_t layer1, uint8_t layer2, uint8_t layer3) {
+  if (IS_LAYER_ON(layer1) && IS_LAYER_ON(layer2)) {
+    layer_on(layer3);
+  } else {
+    layer_off(layer3);
+  }
+}
+
+void matrix_init_user(void) {
+    //SSD1306 OLED init, make sure to add #define SSD1306OLED in config.h
+    #ifdef SSD1306OLED
+        iota_gfx_init(!has_usb());   // turns on the display
+    #endif
+}
+
+//SSD1306 OLED update loop, make sure to add #define SSD1306OLED in config.h
+#ifdef SSD1306OLED
+
+// When add source files to SRC in rules.mk, you can use functions.
+const char *read_layer_state(void);
+const char *read_logo(void);
+void set_keylog(uint16_t keycode, keyrecord_t *record);
+const char *read_keylog(void);
+const char *read_keylogs(void);
+
+// const char *read_mode_icon(bool swap);
+// const char *read_host_led_state(void);
+// void set_timelog(void);
+// const char *read_timelog(void);
+
+void matrix_scan_user(void) {
+   iota_gfx_task();
+}
+
+void matrix_render_user(struct CharacterMatrix *matrix) {
+  if (is_master) {
+    // If you want to change the display of OLED, you need to change here
+    matrix_write_ln(matrix, read_layer_state());
+    matrix_write_ln(matrix, read_keylog());
+    //matrix_write_ln(matrix, read_keylogs());
+    //matrix_write_ln(matrix, read_mode_icon(keymap_config.swap_lalt_lgui));
+    //matrix_write_ln(matrix, read_host_led_state());
+    //matrix_write_ln(matrix, read_timelog());
+  } else {
+    matrix_write(matrix, read_logo());
+  }
+}
+
+void matrix_update(struct CharacterMatrix *dest, const struct CharacterMatrix *source) {
+  if (memcmp(dest->display, source->display, sizeof(dest->display))) {
+    memcpy(dest->display, source->display, sizeof(dest->display));
+    dest->dirty = true;
+  }
+}
+
+void iota_gfx_task_user(void) {
+  struct CharacterMatrix matrix;
+  matrix_clear(&matrix);
+  matrix_render_user(&matrix);
+  matrix_update(&display, &matrix);
+}
+#endif//SSD1306OLED
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  if (record->event.pressed) {
+#ifdef SSD1306OLED
+    set_keylog(keycode, record);
+#endif
+    // set_timelog();
+  }
+
+  switch (keycode) {
+    case QWERTY:
+      if (record->event.pressed) {
+        persistent_default_layer_set(1UL<<_QWERTY);
+      }
+      return false;
+    case LOWER:
+      if (record->event.pressed) {
+        layer_on(_LOWER);
+        update_tri_layer_RGB(_LOWER, _RAISE, _ADJUST);
+      } else {
+        layer_off(_LOWER);
+        update_tri_layer_RGB(_LOWER, _RAISE, _ADJUST);
+      }
+      return false;
+    case RAISE:
+      if (record->event.pressed) {
+        layer_on(_RAISE);
+        update_tri_layer_RGB(_LOWER, _RAISE, _ADJUST);
+      } else {
+        layer_off(_RAISE);
+        update_tri_layer_RGB(_LOWER, _RAISE, _ADJUST);
+      }
+      return false;
+    case ADJUST:
+        if (record->event.pressed) {
+          layer_on(_ADJUST);
+        } else {
+          layer_off(_ADJUST);
+        }
+      break;
+  }
+  return true;
+}

--- a/keyboards/crkbd/keymaps/am/rules.mk
+++ b/keyboards/crkbd/keymaps/am/rules.mk
@@ -1,0 +1,10 @@
+BOOTLOADER = atmel-dfu  # Elite-C
+NKRO_ENABLE = yes
+TAP_DANCE_ENABLE = yes
+EXTRAKEY_ENABLE = yes
+
+# If you want to change the display of OLED, you need to change here
+SRC +=  ./lib/glcdfont.c \
+        ./lib/layer_state_reader.c \
+        ./lib/logo_reader.c \
+        ./lib/keylogger.c


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Adding the layout I use for a Corne keyboard. A few features that can be found:
- QWERTY
- Number layer: with row and pads(normal and inverted)
- Symbols + Fns layer
- Adjust layer: Reset power and media keys (OSX)
- Touchcursor layer: VIM style for cursos keys and mouse

- Some tapdance for cmd / alt on a single key + cmd + alt on another

![IMG_4431](https://user-images.githubusercontent.com/33835/77963358-86047780-72dd-11ea-971d-2e47ea3db809.jpg)

😺 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
