### PR TITLE
Add 60_tsangan_hhkb layout to dz60

### DIFF
--- a/keyboards/dz60/rules.mk
+++ b/keyboards/dz60/rules.mk
@@ -25,4 +25,4 @@ BACKLIGHT_ENABLE = yes  # Enable per-key backlight LEDs
 AUDIO_ENABLE = no    # There is no speaker on this PCB
 RGBLIGHT_ENABLE = yes # Enable the RGB underglow LEDs
 
-LAYOUTS = 60_ansi 60_ansi_split_bs_rshift 60_hhkb 60_iso 60_abnt2
+LAYOUTS = 60_ansi 60_ansi_split_bs_rshift 60_hhkb 60_iso 60_abnt2 60_tsangan_hhkb


### PR DESCRIPTION
## Description

Simply adds the 60_tsangan_hhkb layout to the dz60 rules file. The actual layout implementation was already there.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).