### PR TITLE
Add 60_tsangan_hhkb layout to gh60

### DIFF
--- a/keyboards/gh60/revc/revc.h
+++ b/keyboards/gh60/revc/revc.h
@@ -142,3 +142,17 @@ inline void gh60_wasd_leds_off(void)    { setPinInput(F7); }
     { K30, K31, K32, K33,   K34,   K35, K36,   K37,   K38,   K39,   K3A, K3B, K3C,   K3D   }, \
     { K40, K41, K42, KC_NO, KC_NO, K45, KC_NO, KC_NO, KC_NO, KC_NO, K4A, K4B, K4C,   K4D   }  \
 }
+
+#define LAYOUT_60_tsangan_hhkb( \
+    K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C, K0D, K49,\
+    K10, K11, K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, K1C, K1D, \
+    K20, K21, K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B,      K2D, \
+    K30, K32, K33, K34, K35, K36, K37, K38, K39, K3A, K3B,      K3D, K3C, \
+    K40, K41, K42,           K45,                          K4B, K4C, K4D  \
+) { \
+    { K00, K01,   K02, K03,   K04,   K05, K06,   K07,   K08,   K09, K0A,   K0B, K0C,   K0D }, \
+    { K10, K11,   K12, K13,   K14,   K15, K16,   K17,   K18,   K19, K1A,   K1B, K1C,   K1D }, \
+    { K20, K21,   K22, K23,   K24,   K25, K26,   K27,   K28,   K29, K2A,   K2B, KC_NO, K2D }, \
+    { K30, KC_NO, K32, K33,   K34,   K35, K36,   K37,   K38,   K39, K3A,   K3B, K3C,   K3D }, \
+    { K40, K41,   K42, KC_NO, KC_NO, K45, KC_NO, KC_NO, KC_NO, K49, KC_NO, K4B, K4C,   K4D }  \
+}

--- a/keyboards/gh60/revc/rules.mk
+++ b/keyboards/gh60/revc/rules.mk
@@ -28,4 +28,4 @@ NKRO_ENABLE = yes			# USB Nkey Rollover - if this doesn't work, see here: https:
 # UNICODE_ENABLE = YES		# Unicode
 # BLUETOOTH_ENABLE = yes	# Enable Bluetooth with the Adafruit EZ-Key HID
 
-LAYOUTS = 60_ansi 60_iso 60_ansi_split_bs_rshift
+LAYOUTS = 60_ansi 60_iso 60_ansi_split_bs_rshift 60_tsangan_hhkb


### PR DESCRIPTION
## Description

This adds the 60_tsangan_hhkb layout to the rules file and implements it in the keyboard's header file.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
