### PR TITLE
[Keyboard] Add 60_hhkb layout to hhkb

### DIFF
--- a/keyboards/hhkb/hhkb.h
+++ b/keyboards/hhkb/hhkb.h
@@ -21,6 +21,7 @@
     { K70, K71, K72, K73, K74, K75, K76, KC_NO }                               \
 }
 
+#define LAYOUT_60_hhkb LAYOUT
 
 #define LAYOUT_JP(                                                             \
     K02, K32, K62, K22, K12, K52, K72, KA2, K92, K82, KB2, KE2, KF2, KD2, KC2, \

--- a/keyboards/hhkb/rules.mk
+++ b/keyboards/hhkb/rules.mk
@@ -67,3 +67,5 @@ endif
 # debug-off: EXTRAFLAGS += -DNO_DEBUG -DNO_PRINT
 # debug-off: OPT_DEFS := $(filter-out -DCONSOLE_ENABLE,$(OPT_DEFS))
 # debug-off: all
+
+LAYOUTS = 60_hhkb


### PR DESCRIPTION
## Description

This updates the hhkb keyboard such that it satisfies the `60_hhkb` layout. I implemented this in the most minimal way possible with a simple `#define LAYOUT_60_hhkb LAYOUT`, though if this is frowned on, I can update all instances of `LAYOUT` to be `LAYOUT_60_hhkb` instead.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
