### PR TITLE
Updated V-USB template to allow usbFunctionWriteOut

### DIFF
--- a/tmk_core/protocol/vusb/usbconfig.h
+++ b/tmk_core/protocol/vusb/usbconfig.h
@@ -123,7 +123,7 @@ section at the end of this file).
  * data from a static buffer, set it to 0 and return the data from
  * usbFunctionSetup(). This saves a couple of bytes.
  */
-#define USB_CFG_IMPLEMENT_FN_WRITEOUT   0
+#define USB_CFG_IMPLEMENT_FN_WRITEOUT   1
 /* Define this to 1 if you want to use interrupt-out (or bulk out) endpoints.
  * You must implement the function usbFunctionWriteOut() which receives all
  * interrupt/bulk data sent to any endpoint other than 0. The endpoint number

--- a/tmk_core/protocol/vusb/vusb.c
+++ b/tmk_core/protocol/vusb/vusb.c
@@ -106,8 +106,6 @@ void raw_hid_send(uint8_t *data, uint8_t length) {
         usbPoll();
     }
     usbSetInterrupt3(0, 0);
-    usbPoll();
-    _delay_ms(1);
 }
 
 __attribute__((weak)) void raw_hid_receive(uint8_t *data, uint8_t length) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Currently the general template has `usbFunctionWriteOut()` disabled which is necessary for raw_hid. It looks like one cannot easily overwrite usbconfig.h. I suggest enabling it in general as it does no harm. If raw_hid is not defined it is an empty function.

Also while I am here, `usbFunctionWriteOut()` has a delay and a usbPoll which are unnecessary. there is no need to Poll after you have set a usb interrupt.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
