### PR TITLE
V-USB: Remove some stuff from usbconfig.h that should not be configurable

### DIFF
--- a/tmk_core/protocol/vusb/usbconfig.h
+++ b/tmk_core/protocol/vusb/usbconfig.h
@@ -41,15 +41,6 @@ section at the end of this file).
  * interrupt, the USB interrupt will also be triggered at Start-Of-Frame
  * markers every millisecond.]
  */
-#define USB_CFG_CLOCK_KHZ       (F_CPU/1000)
-/* Clock rate of the AVR in kHz. Legal values are 12000, 12800, 15000, 16000,
- * 16500, 18000 and 20000. The 12.8 MHz and 16.5 MHz versions of the code
- * require no crystal, they tolerate +/- 1% deviation from the nominal
- * frequency. All other rates require a precision of 2000 ppm and thus a
- * crystal!
- * Since F_CPU should be defined to your actual clock rate anyway, you should
- * not need to modify this setting.
- */
 #define USB_CFG_CHECK_CRC       0
 /* Define this to 1 if you want that the driver checks integrity of incoming
  * data packets (CRC checks). CRC checks cost quite a bit of code size and are
@@ -226,19 +217,6 @@ section at the end of this file).
  * This template uses obdev's shared VID/PID pair for Vendor Class devices
  * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
  * the implications!
- */
-#define USB_CFG_DEVICE_CLASS        0
-#define USB_CFG_DEVICE_SUBCLASS     0
-/* See USB specification if you want to conform to an existing device class.
- * Class 0xff is "vendor specific".
- */
-#define USB_CFG_INTERFACE_CLASS     3   /* HID */
-#define USB_CFG_INTERFACE_SUBCLASS  1   /* Boot */
-#define USB_CFG_INTERFACE_PROTOCOL  1   /* Keyboard */
-/* See USB specification if you want to conform to an existing device class or
- * protocol. The following classes must be set at interface level:
- * HID class is 3, no subclass and protocol required (but may be useful!)
- * CDC class is 2, use subclass 2 and protocol 1 for ACM
  */
 #define USB_CFG_HID_REPORT_DESCRIPTOR_LENGTH    0
 /* Define this to the length of the HID report descriptor, if you implement

--- a/tmk_core/protocol/vusb/vusb.c
+++ b/tmk_core/protocol/vusb/vusb.c
@@ -489,8 +489,8 @@ const PROGMEM usbDeviceDescriptor_t usbDeviceDescriptor = {
         .bDescriptorType = USBDESCR_DEVICE
     },
     .bcdUSB              = 0x0110,
-    .bDeviceClass        = USB_CFG_DEVICE_CLASS,
-    .bDeviceSubClass     = USB_CFG_DEVICE_SUBCLASS,
+    .bDeviceClass        = 0x00,
+    .bDeviceSubClass     = 0x00,
     .bDeviceProtocol     = 0x00,
     .bMaxPacketSize0     = 8,
     .idVendor            = VENDOR_ID,
@@ -540,9 +540,9 @@ const PROGMEM usbConfigurationDescriptor_t usbConfigurationDescriptor = {
         .bInterfaceNumber    = 0,
         .bAlternateSetting   = 0x00,
         .bNumEndpoints       = USB_CFG_HAVE_INTRIN_ENDPOINT,
-        .bInterfaceClass     = USB_CFG_INTERFACE_CLASS,
-        .bInterfaceSubClass  = USB_CFG_INTERFACE_SUBCLASS,
-        .bInterfaceProtocol  = USB_CFG_INTERFACE_PROTOCOL,
+        .bInterfaceClass     = 0x03,
+        .bInterfaceSubClass  = 0x01,
+        .bInterfaceProtocol  = 0x01,
         .iInterface          = 0x00
     },
     .keyboardHID = {

--- a/tmk_core/protocol/vusb/vusb.c
+++ b/tmk_core/protocol/vusb/vusb.c
@@ -536,7 +536,7 @@ const PROGMEM usbConfigurationDescriptor_t usbConfigurationDescriptor = {
         },
         .bInterfaceNumber    = 0,
         .bAlternateSetting   = 0x00,
-        .bNumEndpoints       = USB_CFG_HAVE_INTRIN_ENDPOINT,
+        .bNumEndpoints       = 1,
         .bInterfaceClass     = 0x03,
         .bInterfaceSubClass  = 0x01,
         .bInterfaceProtocol  = 0x01,
@@ -575,7 +575,7 @@ const PROGMEM usbConfigurationDescriptor_t usbConfigurationDescriptor = {
         },
         .bInterfaceNumber    = 1,
         .bAlternateSetting   = 0x00,
-        .bNumEndpoints       = USB_CFG_HAVE_INTRIN_ENDPOINT3,
+        .bNumEndpoints       = 1,
         .bInterfaceClass     = 0x03,
         .bInterfaceSubClass  = 0x00,
         .bInterfaceProtocol  = 0x00,
@@ -627,7 +627,6 @@ const PROGMEM usbConfigurationDescriptor_t usbConfigurationDescriptor = {
         .bDescriptorType     = USBDESCR_HID_REPORT,
         .wDescriptorLength   = sizeof(raw_hid_report)
     },
-#        if USB_CFG_HAVE_INTRIN_ENDPOINT3
     .rawINEndpoint = {
         .header = {
             .bLength         = sizeof(usbEndpointDescriptor_t),
@@ -648,7 +647,6 @@ const PROGMEM usbConfigurationDescriptor_t usbConfigurationDescriptor = {
         .wMaxPacketSize      = RAW_EPSIZE,
         .bInterval           = USB_POLLING_INTERVAL_MS
     }
-#        endif
 #    endif
 };
 

--- a/tmk_core/protocol/vusb/vusb.c
+++ b/tmk_core/protocol/vusb/vusb.c
@@ -28,7 +28,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "vusb.h"
 #include <util/delay.h>
 
-#if defined(RAW_ENABLE)
+#ifdef RAW_ENABLE
 #    include "raw_hid.h"
 #endif
 
@@ -158,7 +158,7 @@ typedef struct {
 } __attribute__((packed)) vusb_mouse_report_t;
 
 static void send_mouse(report_mouse_t *report) {
-#if defined(MOUSE_ENABLE)
+#ifdef MOUSE_ENABLE
     vusb_mouse_report_t r = {.report_id = REPORT_ID_MOUSE, .report = *report};
     if (usbInterruptIsReady3()) {
         usbSetInterrupt3((void *)&r, sizeof(vusb_mouse_report_t));
@@ -410,7 +410,7 @@ const PROGMEM uchar mouse_extra_hid_report[] = {
 };
 #endif
 
-#if defined(RAW_ENABLE)
+#ifdef RAW_ENABLE
 const PROGMEM uchar raw_hid_report[] = {
     0x06, 0x60, 0xFF,  // Usage Page (Vendor Defined)
     0x09, 0x61,        // Usage (Vendor Defined)
@@ -479,7 +479,6 @@ const PROGMEM usbStringDescriptor_t usbStringDescriptorSerial = {
     .bString             = LSTR(SERIAL_NUMBER)
 };
 
-#if USB_CFG_DESCR_PROPS_DEVICE
 /*
  * Device descriptor
  */
@@ -501,9 +500,7 @@ const PROGMEM usbDeviceDescriptor_t usbDeviceDescriptor = {
     .iSerialNumber       = 0x03,
     .bNumConfigurations  = 1
 };
-#endif
 
-#if USB_CFG_DESCR_PROPS_CONFIGURATION
 /*
  * Configuration descriptors
  */
@@ -556,7 +553,6 @@ const PROGMEM usbConfigurationDescriptor_t usbConfigurationDescriptor = {
         .bDescriptorType     = USBDESCR_HID_REPORT,
         .wDescriptorLength   = sizeof(keyboard_hid_report)
     },
-#    ifdef USB_CFG_HAVE_INTRIN_ENDPOINT
     .keyboardINEndpoint = {
         .header = {
             .bLength         = sizeof(usbEndpointDescriptor_t),
@@ -567,7 +563,6 @@ const PROGMEM usbConfigurationDescriptor_t usbConfigurationDescriptor = {
         .wMaxPacketSize      = 8,
         .bInterval           = USB_POLLING_INTERVAL_MS
     },
-#    endif
 
 #    if defined(MOUSE_ENABLE) || defined(EXTRAKEY_ENABLE)
     /*
@@ -597,7 +592,6 @@ const PROGMEM usbConfigurationDescriptor_t usbConfigurationDescriptor = {
         .bDescriptorType     = USBDESCR_HID_REPORT,
         .wDescriptorLength   = sizeof(mouse_extra_hid_report)
     },
-#        if USB_CFG_HAVE_INTRIN_ENDPOINT3
     .mouseExtraINEndpoint = {
         .header = {
             .bLength         = sizeof(usbEndpointDescriptor_t),
@@ -608,7 +602,6 @@ const PROGMEM usbConfigurationDescriptor_t usbConfigurationDescriptor = {
         .wMaxPacketSize      = 8,
         .bInterval           = USB_POLLING_INTERVAL_MS
     }
-#        endif
 #    elif defined(RAW_ENABLE)
     .rawInterface = {
         .header = {
@@ -658,7 +651,6 @@ const PROGMEM usbConfigurationDescriptor_t usbConfigurationDescriptor = {
 #        endif
 #    endif
 };
-#endif
 
 // clang-format on
 
@@ -674,18 +666,14 @@ USB_PUBLIC usbMsgLen_t usbFunctionDescriptor(struct usbRequest *rq) {
         debug_hex16(rq->wLength.word); debug("\n");
     */
     switch (rq->wValue.bytes[1]) {
-#if USB_CFG_DESCR_PROPS_DEVICE
         case USBDESCR_DEVICE:
             usbMsgPtr = (unsigned char *)&usbDeviceDescriptor;
             len       = sizeof(usbDeviceDescriptor_t);
             break;
-#endif
-#if USB_CFG_DESCR_PROPS_CONFIGURATION
         case USBDESCR_CONFIG:
             usbMsgPtr = (unsigned char *)&usbConfigurationDescriptor;
             len       = sizeof(usbConfigurationDescriptor_t);
             break;
-#endif
         case USBDESCR_STRING:
             switch (rq->wValue.bytes[0]) {
                 case 0:

--- a/tmk_core/protocol/vusb/vusb.h
+++ b/tmk_core/protocol/vusb/vusb.h
@@ -87,23 +87,17 @@ typedef struct usbConfigurationDescriptor {
     usbConfigurationDescriptorHeader_t header;
     usbInterfaceDescriptor_t           keyboardInterface;
     usbHIDDescriptor_t                 keyboardHID;
-#ifdef USB_CFG_HAVE_INTRIN_ENDPOINT
     usbEndpointDescriptor_t keyboardINEndpoint;
-#endif
 
 #if defined(MOUSE_ENABLE) || defined(EXTRAKEY_ENABLE)
     usbInterfaceDescriptor_t mouseExtraInterface;
     usbHIDDescriptor_t       mouseExtraHID;
-#    ifdef USB_CFG_HAVE_INTRIN_ENDPOINT3
     usbEndpointDescriptor_t mouseExtraINEndpoint;
-#    endif
 #elif defined(RAW_ENABLE)
     usbInterfaceDescriptor_t rawInterface;
     usbHIDDescriptor_t       rawHID;
-#    ifdef USB_CFG_HAVE_INTRIN_ENDPOINT3
     usbEndpointDescriptor_t rawINEndpoint;
     usbEndpointDescriptor_t rawOUTEndpoint;
-#    endif
 #endif
 } __attribute__((packed)) usbConfigurationDescriptor_t;
 
@@ -112,6 +106,6 @@ typedef struct usbConfigurationDescriptor {
 host_driver_t *vusb_driver(void);
 void           vusb_transfer_keyboard(void);
 
-#if defined(RAW_ENABLE)
+#ifdef RAW_ENABLE
 void raw_hid_task(void);
 #endif


### PR DESCRIPTION
…able

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

As with the LUFA/ChibiOS descriptors, the device/interface class/subclass/protocol does not need to be configurable, so we can safely hardcode it in the descriptors. V-USB is also aware of `F_CPU` and so `USB_CFG_CLOCK_KHZ` is not necessary either.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
