### PR TITLE
Fix `pgm_read_ptr()` define for ARM

### DIFF
--- a/tmk_core/common/progmem.h
+++ b/tmk_core/common/progmem.h
@@ -8,7 +8,7 @@
 #    define pgm_read_byte(address_short) *((uint8_t*)(address_short))
 #    define pgm_read_word(address_short) *((uint16_t*)(address_short))
 #    define pgm_read_dword(address_short) *((uint32_t*)(address_short))
-#    define pgm_read_ptr(address_short) *((void*)(address_short))
+#    define pgm_read_ptr(address_short) *((void**)(address_short))
 #    define strcmp_P(s1, s2) strcmp(s1, s2)
 #    define strcpy_P(dest, src) strcpy(dest, src)
 #    define strlen_P(src) strlen(src)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Since we read a `void *` at `address_short`, and are dereferencing it, it must be a *pointer* to the void pointer.

Thanks to @sigprof for correcting my original attempt.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* RGB layer lighting reported not compiling by @stanrc85 on Discord - this appears to fix their problem

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
