### PR TITLE
[Keymap] foxx1337 for Massdrop CTRL with raw HID

### DIFF
--- a/keyboards/massdrop/ctrl/keymaps/foxx1337/README.md
+++ b/keyboards/massdrop/ctrl/keymaps/foxx1337/README.md
@@ -1,0 +1,18 @@
+# Massdrop CTRL default layout with raw HID protocol
+
+This represents my current layout, with filtered out effects, personal defaults,
+added inactivity timeout (for rgbmatrix) and a HID protocol example.
+
+To test that this is working, there's a user application I'm using to help with
+development on [my GitHub](https://github.com/foxx1337/rawhid_io).
+
+Currently all the HID operations defined in the protocol are callable from the
+user application:
+
+- hello: gets the string "CTRLHID 1.0.0"
+- lights: toggles the rgbmatrix on/off
+- led n #RRGGBB: colors the specified led. Valid n from 0 to 117 (87-117 are on
+    the edge)
+- leds start #RRGGBB #RRGGBB #RRGGBB ...: colors the range of leds from start
+- mode n: switches to the specific rgbmatrix mode. Use the last one, 11, to test
+    the led operations listed above

--- a/keyboards/massdrop/ctrl/keymaps/foxx1337/config.h
+++ b/keyboards/massdrop/ctrl/keymaps/foxx1337/config.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#define FORCE_NKRO                  // NKRO by default requires to be turned on, this forces it on during keyboard startup regardless of EEPROM setting. NKRO can still be turned off but will be turned on again if the keyboard reboots.
+
+#define RGB_MATRIX_FRAMEBUFFER_EFFECTS
+#define RGB_MATRIX_KEYPRESSES         // reacts to keypresses
+
+#define RGB_MATRIX_FRAMEBUFFER_EFFECTS
+#define RGB_MATRIX_KEYPRESSES         // reacts to keypresses
+// #define RGB_MATRIX_KEYRELEASES        // reacts to keyreleases (instead of keypresses)
+#define RGB_MATRIX_STARTUP_MODE RGB_MATRIX_SOLID_REACTIVE // Sets the default mode, if none has been set
+#define RGB_MATRIX_STARTUP_HUE 12
+#define RGB_MATRIX_STARTUP_SPD (UINT8_MAX / 2 + 32)
+#define RGB_MATRIX_STARTUP_VAL 96
+// #define RGBLIGHT_HUE_STEP 12        // Units to step when in/decreasing hue
+// #define RGBLIGHT_SAT_STEP 25        // Units to step when in/decreasing saturation
+// #define RGBLIGHT_VAL_STEP 12        // Units to step when in/decreasing value (brightness)
+// #define RGB_DISABLE_AFTER_TIMEOUT 0   // number of ticks to wait until disabling effects
+// #define RGB_DISABLE_WHEN_USB_SUSPENDED false // turn off effects when suspended
+// #define RGB_MATRIX_LED_PROCESS_LIMIT (DRIVER_LED_TOTAL + 4) / 5 // limits the number of LEDs to process in an animation per task run (increases keyboard responsiveness)
+// #define RGB_MATRIX_LED_FLUSH_LIMIT 16 // limits in milliseconds how frequently an animation will update the LEDs. 16 (16ms) is equivalent to limiting to 60fps (increases keyboard responsiveness)
+// #define RGBLIGHT_ANIMATIONS             // Run RGB animations
+// #define RGBLIGHT_ANIMATIONS             // Enable all additional animation modes.
+// #define RGBLIGHT_EFFECT_ALTERNATING     // Enable alternating animation mode.
+// #define RGBLIGHT_EFFECT_BREATHING       // Enable breathing animation mode.
+// #define RGBLIGHT_EFFECT_CHRISTMAS       // Enable christmas animation mode.
+// #define RGBLIGHT_EFFECT_KNIGHT          // Enable knight animation mode.
+// #define RGBLIGHT_EFFECT_RAINBOW_MOOD    // Enable rainbow mood animation mode.
+// #define RGBLIGHT_EFFECT_RAINBOW_SWIRL   // Enable rainbow swirl animation mode.
+// #define RGBLIGHT_EFFECT_RGB_TEST        // Enable RGB test animation mode.
+// #define RGBLIGHT_EFFECT_SNAKE           // Enable snake animation mode.
+// #define RGBLIGHT_EFFECT_STATIC_GRADIENT // Enable static gradient mode.
+
+// #define RGBLIGHT_EFFECT_BREATHE_CENTER              // If defined, used to calculate the curve for the breathing animation. Valid values are 1.0 to 2.7
+// #define RGBLIGHT_EFFECT_BREATHE_MAX 255             // The maximum brightness for the breathing mode. Valid values are 1 to 255
+// #define RGBLIGHT_EFFECT_CHRISTMAS_INTERVAL 1000     // How long to wait between light changes for the "Christmas" animation, in milliseconds
+// #define RGBLIGHT_EFFECT_CHRISTMAS_STEP 2            // The number of LEDs to group the red/green colors by for the "Christmas" animation
+// #define RGBLIGHT_EFFECT_KNIGHT_LED_NUM RGBLED_NUM   // The number of LEDs to have the "Knight" animation travel
+// #define RGBLIGHT_EFFECT_KNIGHT_LENGTH 3             // The number of LEDs to light up for the "Knight" animation
+// #define RGBLIGHT_EFFECT_KNIGHT_OFFSET 0             // The number of LEDs to start the "Knight" animation from the start of the strip by
+// #define RGBLIGHT_RAINBOW_SWIRL_RANGE 255            // Range adjustment for the rainbow swirl effect to get different swirls
+// #define RGBLIGHT_EFFECT_SNAKE_LENGTH 4              // The number of LEDs to light up for the "Snake" animation
+
+// This list in in the correct mode order. Next mode is the following line, previous mode is previous line. Loops around.
+// #define DISABLE_RGB_MATRIX_SOLID_COLOR                   // Static single hue, no speed support
+// #define DISABLE_RGB_MATRIX_ALPHAS_MODS                   // Static dual hue, speed is hue for secondary hue
+#define DISABLE_RGB_MATRIX_GRADIENT_UP_DOWN              // Static gradient top to bottom, speed controls how much gradient changes
+#define DISABLE_RGB_MATRIX_BREATHING                     // Single hue brightness cycling animation
+#define DISABLE_RGB_MATRIX_BAND_SAT                      // Single hue band fading saturation scrolling left to right
+#define DISABLE_RGB_MATRIX_BAND_VAL                      // Single hue band fading brightness scrolling left to right
+#define DISABLE_RGB_MATRIX_BAND_PINWHEEL_SAT             // Single hue 3 blade spinning pinwheel fades saturation
+#define DISABLE_RGB_MATRIX_BAND_PINWHEEL_VAL             // Single hue 3 blade spinning pinwheel fades brightness
+#define DISABLE_RGB_MATRIX_BAND_SPIRAL_SAT               // Single hue spinning spiral fades saturation
+#define DISABLE_RGB_MATRIX_BAND_SPIRAL_VAL               // Single hue spinning spiral fades brightness
+#define DISABLE_RGB_MATRIX_CYCLE_ALL                     // Full keyboard solid hue cycling through full gradient
+#define DISABLE_RGB_MATRIX_CYCLE_LEFT_RIGHT              // Full gradient scrolling left to right
+#define DISABLE_RGB_MATRIX_CYCLE_UP_DOWN                 // Full gradient scrolling top to bottom
+#define DISABLE_RGB_MATRIX_CYCLE_OUT_IN                  // Full gradient scrolling out to in
+#define DISABLE_RGB_MATRIX_CYCLE_OUT_IN_DUAL             // Full dual gradients scrolling out to in
+#define DISABLE_RGB_MATRIX_RAINBOW_MOVING_CHEVRON        // Full gradent Chevron shapped scrolling left to right
+#define DISABLE_RGB_MATRIX_CYCLE_PINWHEEL                // Full gradient spinning pinwheel around center of keyboard
+#define DISABLE_RGB_MATRIX_CYCLE_SPIRAL                  // Full gradient spinning spiral around center of keyboard
+#define DISABLE_RGB_MATRIX_DUAL_BEACON                   // Full gradient spinning around center of keyboard
+#define DISABLE_RGB_MATRIX_RAINBOW_BEACON                // Full tighter gradient spinning around center of keyboard
+#define DISABLE_RGB_MATRIX_RAINBOW_PINWHEELS             // Full dual gradients spinning two halfs of keyboard
+// #define DISABLE_RGB_MATRIX_RAINDROPS                     // Randomly changes a single key's hue
+// #define DISABLE_RGB_MATRIX_JELLYBEAN_RAINDROPS           // Randomly changes a single key's hue and saturation
+// =================================================== Requires RGB_MATRIX_FRAMEBUFFER_EFFECTS =============================================================
+#define DISABLE_RGB_MATRIX_TYPING_HEATMAP                // How hot is your WPM!
+#define DISABLE_RGB_MATRIX_DIGITAL_RAIN                  // That famous computer simulation
+// =================================================== RGB_MATRIX_KEYPRESSES OR RGB_MATRIX_KEYRELEASES =====================================================
+// #define DISABLE_RGB_MATRIX_SOLID_REACTIVE                // Static single hue, pulses keys hit to shifted hue then fades to current hue
+//#define DISABLE_RGB_MATRIX_SOLID_REACTIVE_SIMPLE         // Pulses keys hit to hue & value then fades value out
+#define DISABLE_RGB_MATRIX_SOLID_REACTIVE_WIDE           // Hue & value pulse near a single key hit then fades value out
+//#define DISABLE_RGB_MATRIX_SOLID_REACTIVE_MULTIWIDE      // Hue & value pulse near multiple key hits then fades value out
+//#define DISABLE_RGB_MATRIX_SOLID_REACTIVE_CROSS          // Hue & value pulse the same column and row of a single key hit then fades value out
+#define DISABLE_RGB_MATRIX_SOLID_REACTIVE_MULTICROSS     // Hue & value pulse the same column and row of multiple key hits then fades value out
+//#define DISABLE_RGB_MATRIX_SOLID_REACTIVE_NEXUS          // Hue & value pulse away on the same column and row of a single key hit then fades value out
+#define DISABLE_RGB_MATRIX_SOLID_REACTIVE_MULTINEXUS     // Hue & value pulse away on the same column and row of multiple key hits then fades value out
+#define DISABLE_RGB_MATRIX_SPLASH                        // Full gradient & value pulse away from a single key hit then fades value out
+#define DISABLE_RGB_MATRIX_MULTISPLASH                   // Full gradient & value pulse away from multiple key hits then fades value out
+#define DISABLE_RGB_MATRIX_SOLID_SPLASH                  // Hue & value pulse away from a single key hit then fades value out
+#define DISABLE_RGB_MATRIX_SOLID_MULTISPLASH             // Hue & value pulse away from multiple key hits then fades value out

--- a/keyboards/massdrop/ctrl/keymaps/foxx1337/config.h
+++ b/keyboards/massdrop/ctrl/keymaps/foxx1337/config.h
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2021 foxx1337 at yahoo dot com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #define FORCE_NKRO                  // NKRO by default requires to be turned on, this forces it on during keyboard startup regardless of EEPROM setting. NKRO can still be turned off but will be turned on again if the keyboard reboots.

--- a/keyboards/massdrop/ctrl/keymaps/foxx1337/hid_protocol.c
+++ b/keyboards/massdrop/ctrl/keymaps/foxx1337/hid_protocol.c
@@ -1,0 +1,8 @@
+#include QMK_KEYBOARD_H
+#include "hid_protocol.h"
+
+uint8_t raw_hid_buffer[RAW_EPSIZE];
+
+void raw_hid_perform_send(void) {
+    raw_hid_send(raw_hid_buffer, RAW_EPSIZE);
+}

--- a/keyboards/massdrop/ctrl/keymaps/foxx1337/hid_protocol.c
+++ b/keyboards/massdrop/ctrl/keymaps/foxx1337/hid_protocol.c
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2021 foxx1337 at yahoo dot com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include QMK_KEYBOARD_H
 #include "hid_protocol.h"
 

--- a/keyboards/massdrop/ctrl/keymaps/foxx1337/hid_protocol.h
+++ b/keyboards/massdrop/ctrl/keymaps/foxx1337/hid_protocol.h
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2021 foxx1337 at yahoo dot com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <color.h>

--- a/keyboards/massdrop/ctrl/keymaps/foxx1337/hid_protocol.h
+++ b/keyboards/massdrop/ctrl/keymaps/foxx1337/hid_protocol.h
@@ -1,13 +1,63 @@
 #pragma once
 
+#include <color.h>
 #include <raw_hid.h>
 
+#define CTRL_HID_GREETING_VERSION "CTRLHID 1.0.0"
+
 enum ctrl_hid_codes {
+    // Signals end of message. Not really that useful.
     CTRL_HID_EOM = 0x00,
+    CTRL_HID_OK,
+    CTRL_HID_NOK,
+
+    /**
+     * to hid: CTRL_HID_HELLO
+     * from hid: CTRL_HID_HELLO, "CTRLHID 1.0.0", CTRL_HID_EOM
+     **/
     CTRL_HID_HELLO,
-    CTRL_HID_LIGHTS_TOGGLE
+
+    /**
+     * to hid: CTRL_HID_LIGHTS_TOGGLE
+     * from hid: CTRL_HID_LIGHTS_TOGGLE, CTRL_HID_OK, is_led_timeout, CTRL_HID_EOM
+     *
+     * Toggles all the leds on the keyboard. is_led_timeout will be 1 if the new
+     * state is off, 0 if leds are on.
+     **/
+    CTRL_HID_LIGHTS_TOGGLE,
+
+    /**
+     * to hid: CTRL_HID_LED, led_id, r, g, b
+     * from hid: CTRL_HID_LED, CTRL_HID_OK, CTRL_HID_EOM
+     * on error: CTRL_HID_LED, CTRL_HID_NOK, num_leds, CTRL_HID_EOM
+     *
+     * Sets the specific led to r, g, b. It's only visible when the hid_effect mode is active.
+     **/
+    CTRL_HID_LED,
+
+    /**
+     * to hid: CTRL_HID_LEDS, start, count, r0, g0, b0, ..., r[count-1], g[count-1], b[count-1]
+     * from hid: CTRL_HID_LEDS, CTRL_HID_OK, affected_leds, CTRL_HID_EOM
+     *
+     * Sets affected_leds leds following start to the corresponding r, g, b value.
+     * It's only visible when the hid_effect mode is active.
+     **/
+    CTRL_HID_LEDS,
+
+    /**
+     * to hid: CTRL_HID_RGBMATRIX_MODE, mode
+     * from hid: CTRL_HID_RGBMATRIX_MODE, CTRL_HID_OK, CTRL_HID_EOM
+     * on error: CTRL_HID_RGBMATRIX_MODE, CTRL_HID_NOK, mode_max, CTRL_HID_EOM
+     *
+     * Changes light mode. mode_max is hid_effect for CTRL_HID_LED and CTRL_HID_LEDS.
+     */
+    CTRL_HID_RGBMATRIX_MODE
 };
 
 extern uint8_t raw_hid_buffer[RAW_EPSIZE];
+
+// Defined in rgb_matrix_user.inc
+// It's 119 for Massdrop CTRL, 0 - 118.
+extern RGB rgb_matrix_led_state[DRIVER_LED_TOTAL];
 
 void raw_hid_perform_send(void);

--- a/keyboards/massdrop/ctrl/keymaps/foxx1337/hid_protocol.h
+++ b/keyboards/massdrop/ctrl/keymaps/foxx1337/hid_protocol.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <raw_hid.h>
+
+enum ctrl_hid_codes {
+    CTRL_HID_EOM = 0x00,
+    CTRL_HID_HELLO,
+    CTRL_HID_LIGHTS_TOGGLE
+};
+
+extern uint8_t raw_hid_buffer[RAW_EPSIZE];
+
+void raw_hid_perform_send(void);

--- a/keyboards/massdrop/ctrl/keymaps/foxx1337/keymap.c
+++ b/keyboards/massdrop/ctrl/keymaps/foxx1337/keymap.c
@@ -77,9 +77,9 @@ void matrix_scan_user(void) {
     }
 };
 
-#define MODS_SHIFT  (get_mods() & MOD_BIT(KC_LSHIFT) || get_mods() & MOD_BIT(KC_RSHIFT))
-#define MODS_CTRL  (get_mods() & MOD_BIT(KC_LCTL) || get_mods() & MOD_BIT(KC_RCTRL))
-#define MODS_ALT  (get_mods() & MOD_BIT(KC_LALT) || get_mods() & MOD_BIT(KC_RALT))
+#define MODS_SHIFT  (get_mods() & MOD_MASK_SHIFT)
+#define MODS_CTRL   (get_mods() & MOD_MASK_CTRL)
+#define MODS_ALT    (get_mods() & MOD_MASK_ALT)
 
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     static uint32_t key_timer;

--- a/keyboards/massdrop/ctrl/keymaps/foxx1337/keymap.c
+++ b/keyboards/massdrop/ctrl/keymaps/foxx1337/keymap.c
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2021 foxx1337 at yahoo dot com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include QMK_KEYBOARD_H
 #include "hid_protocol.h"
 

--- a/keyboards/massdrop/ctrl/keymaps/foxx1337/keymap.c
+++ b/keyboards/massdrop/ctrl/keymaps/foxx1337/keymap.c
@@ -161,24 +161,71 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 }
 
 void raw_hid_say_hello(void) {
-    raw_hid_buffer[0] = CTRL_HID_HELLO;
-    raw_hid_buffer[1] = 'C';
-    raw_hid_buffer[2] = 'T';
-    raw_hid_buffer[3] = 'R';
-    raw_hid_buffer[4] = 'L';
-    raw_hid_buffer[5] = CTRL_HID_EOM;
-
-    raw_hid_perform_send();
+    const char *ctrl = CTRL_HID_GREETING_VERSION;
+    uint8_t i = 0;
+    while (ctrl[i] != 0 && i + 2 < RAW_EPSIZE) {
+        raw_hid_buffer[1 + i] = ctrl[i];
+        i++;
+    }
+    raw_hid_buffer[i] = CTRL_HID_EOM;
 }
 
 void raw_hid_lights_toggle(void) {
     change_led_state(!is_led_timeout);
 
-    raw_hid_buffer[0] = CTRL_HID_LIGHTS_TOGGLE;
-    raw_hid_buffer[1] = (uint8_t) is_led_timeout;
-    raw_hid_buffer[2] = CTRL_HID_EOM;
+    raw_hid_buffer[1] = CTRL_HID_OK;
+    raw_hid_buffer[2] = (uint8_t) is_led_timeout;
+    raw_hid_buffer[3] = CTRL_HID_EOM;
+}
 
-    raw_hid_perform_send();
+void raw_hid_led(uint8_t *data) {
+    //rgb_matrix_set_color(data[1], data[2], data[3], data[4]);
+    const uint8_t led = data[1];
+
+    if (led >= DRIVER_LED_TOTAL) {
+        raw_hid_buffer[1] = CTRL_HID_NOK;
+        raw_hid_buffer[2] = DRIVER_LED_TOTAL;
+        raw_hid_buffer[3] = CTRL_HID_EOM;
+        return;
+    }
+
+    rgb_matrix_led_state[led].r = data[2];
+    rgb_matrix_led_state[led].g = data[3];
+    rgb_matrix_led_state[led].b = data[4];
+
+    raw_hid_buffer[1] = CTRL_HID_OK;
+    raw_hid_buffer[2] = CTRL_HID_EOM;
+}
+
+void raw_hid_leds(uint8_t *data) {
+    const uint8_t first_led = data[1];
+    const uint8_t number_leds = data[2];
+
+    uint8_t i = 0;
+    while (i < number_leds && first_led + i < DRIVER_LED_TOTAL && i * 3 + 5 < RAW_EPSIZE) {
+        rgb_matrix_led_state[first_led + i].r = data[3 + i * 3 + 0];
+        rgb_matrix_led_state[first_led + i].g = data[3 + i * 3 + 1];
+        rgb_matrix_led_state[first_led + i].b = data[3 + i * 3 + 2];
+        i++;
+    }
+
+    raw_hid_buffer[1] = CTRL_HID_OK;
+    raw_hid_buffer[2] = i;
+    raw_hid_buffer[3] = CTRL_HID_EOM;
+}
+
+void raw_hid_rgbmatrix_mode(uint8_t *data) {
+    const uint8_t mode = data[1];
+    if (mode >= RGB_MATRIX_EFFECT_MAX) {
+        raw_hid_buffer[1] = CTRL_HID_NOK;
+        raw_hid_buffer[2] = RGB_MATRIX_EFFECT_MAX - 1;
+        raw_hid_buffer[3] = CTRL_HID_EOM;
+        return;
+    }
+    rgb_matrix_mode_noeeprom(mode);
+
+    raw_hid_buffer[1] = CTRL_HID_OK;
+    raw_hid_buffer[2] = CTRL_HID_EOM;
 }
 
 void raw_hid_receive(uint8_t *data, uint8_t length) {
@@ -189,5 +236,16 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
         case CTRL_HID_LIGHTS_TOGGLE:
             raw_hid_lights_toggle();
             break;
+        case CTRL_HID_LED:
+            raw_hid_led(data);
+            break;
+        case CTRL_HID_LEDS:
+            raw_hid_leds(data);
+            break;
+        case CTRL_HID_RGBMATRIX_MODE:
+            raw_hid_rgbmatrix_mode(data);
+            break;
     }
+
+    raw_hid_perform_send();
 }

--- a/keyboards/massdrop/ctrl/keymaps/foxx1337/keymap.c
+++ b/keyboards/massdrop/ctrl/keymaps/foxx1337/keymap.c
@@ -1,0 +1,160 @@
+#include QMK_KEYBOARD_H
+
+enum ctrl_keycodes {
+    U_T_AUTO = SAFE_RANGE, //USB Extra Port Toggle Auto Detect / Always Active
+    U_T_AGCR,              //USB Toggle Automatic GCR control
+    DBG_TOG,               //DEBUG Toggle On / Off
+    DBG_MTRX,              //DEBUG Toggle Matrix Prints
+    DBG_KBD,               //DEBUG Toggle Keyboard Prints
+    DBG_MOU,               //DEBUG Toggle Mouse Prints
+    MD_BOOT,               //Restart into bootloader after hold timeout
+};
+
+#define TIMEOUT_ACTIVITY 300000 // 300 seconds before lights go off
+
+uint32_t time_last_activity;
+bool is_led_timeout;
+led_flags_t led_state;
+
+keymap_config_t keymap_config;
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [0] = LAYOUT(
+        KC_ESC,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,             KC_PSCR, KC_SLCK, KC_PAUS, \
+        KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC,   KC_INS,  KC_HOME, KC_PGUP, \
+        KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS,   KC_DEL,  KC_END,  KC_PGDN, \
+        KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_ENT, \
+        KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT,                              KC_UP, \
+        KC_LCTL, KC_LGUI, KC_LALT,                   KC_SPC,                             KC_RALT, MO(1),   KC_APP,  KC_RCTL,            KC_LEFT, KC_DOWN, KC_RGHT \
+    ),
+    [1] = LAYOUT(
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,            KC_MUTE, _______, _______, \
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,   KC_MPLY, KC_MSTP, KC_VOLU, \
+        _______, RGB_SPD, RGB_VAI, RGB_SPI, RGB_HUI, RGB_SAI, _______, U_T_AUTO,U_T_AGCR,_______, _______, _______, _______, _______,   KC_MPRV, KC_MNXT, KC_VOLD, \
+        _______, RGB_RMOD,RGB_VAD, RGB_MOD, RGB_HUD, RGB_SAD, _______, _______, _______, _______, _______, _______, _______, \
+        _______, RGB_TOG, _______, _______, _______, MD_BOOT, NK_TOGG, _______, _______, _______, _______, _______,                              _______, \
+        _______, _______, _______,                   _______,                            _______, _______, _______, _______,            _______, _______, _______ \
+    ),
+    /*
+    [X] = LAYOUT(
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,            _______, _______, _______, \
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,   _______, _______, _______, \
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,   _______, _______, _______, \
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, \
+        _______, _______, _______, _______, _______, _______, NK_TOGG, _______, _______, _______, _______, _______,                              _______, \
+        _______, _______, _______,                   _______,                            _______, _______, _______, _______,            _______, _______, _______ \
+    ),
+    */
+};
+
+void change_led_state(bool is_off) {
+    is_led_timeout = is_off;
+
+    if (is_led_timeout) {
+        led_state = rgb_matrix_get_flags();
+        if (led_state != LED_FLAG_NONE) {
+            rgb_matrix_set_flags(LED_FLAG_NONE);
+            rgb_matrix_disable_noeeprom();
+        }
+    } else {
+        if (led_state != LED_FLAG_NONE) {
+            rgb_matrix_set_flags(led_state);
+            rgb_matrix_enable_noeeprom();
+        }
+    }
+}
+
+// Runs just one time when the keyboard initializes.
+void matrix_init_user(void) {
+    time_last_activity = timer_read32();
+};
+
+// Runs constantly in the background, in a loop.
+void matrix_scan_user(void) {
+    if (!is_led_timeout && timer_elapsed32(time_last_activity) > TIMEOUT_ACTIVITY) {
+        change_led_state(true);
+    }
+};
+
+#define MODS_SHIFT  (get_mods() & MOD_BIT(KC_LSHIFT) || get_mods() & MOD_BIT(KC_RSHIFT))
+#define MODS_CTRL  (get_mods() & MOD_BIT(KC_LCTL) || get_mods() & MOD_BIT(KC_RCTRL))
+#define MODS_ALT  (get_mods() & MOD_BIT(KC_LALT) || get_mods() & MOD_BIT(KC_RALT))
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    static uint32_t key_timer;
+
+    time_last_activity = timer_read32();
+    if (is_led_timeout) {
+        change_led_state(false);
+    }
+
+    switch (keycode) {
+        case U_T_AUTO:
+            if (record->event.pressed && MODS_SHIFT && MODS_CTRL) {
+                TOGGLE_FLAG_AND_PRINT(usb_extra_manual, "USB extra port manual mode");
+            }
+            return false;
+        case U_T_AGCR:
+            if (record->event.pressed && MODS_SHIFT && MODS_CTRL) {
+                TOGGLE_FLAG_AND_PRINT(usb_gcr_auto, "USB GCR auto mode");
+            }
+            return false;
+        case DBG_TOG:
+            if (record->event.pressed) {
+                TOGGLE_FLAG_AND_PRINT(debug_enable, "Debug mode");
+            }
+            return false;
+        case DBG_MTRX:
+            if (record->event.pressed) {
+                TOGGLE_FLAG_AND_PRINT(debug_matrix, "Debug matrix");
+            }
+            return false;
+        case DBG_KBD:
+            if (record->event.pressed) {
+                TOGGLE_FLAG_AND_PRINT(debug_keyboard, "Debug keyboard");
+            }
+            return false;
+        case DBG_MOU:
+            if (record->event.pressed) {
+                TOGGLE_FLAG_AND_PRINT(debug_mouse, "Debug mouse");
+            }
+            return false;
+        case MD_BOOT:
+            if (record->event.pressed) {
+                key_timer = timer_read32();
+            } else {
+                if (timer_elapsed32(key_timer) >= 500) {
+                    reset_keyboard();
+                }
+            }
+            return false;
+        case RGB_TOG:
+            if (record->event.pressed) {
+              switch (rgb_matrix_get_flags()) {
+                case LED_FLAG_ALL: {
+                    rgb_matrix_set_flags(LED_FLAG_KEYLIGHT | LED_FLAG_MODIFIER);
+                    rgb_matrix_set_color_all(0, 0, 0);
+                  }
+                  break;
+                case LED_FLAG_KEYLIGHT | LED_FLAG_MODIFIER: {
+                    rgb_matrix_set_flags(LED_FLAG_UNDERGLOW);
+                    rgb_matrix_set_color_all(0, 0, 0);
+                  }
+                  break;
+                case LED_FLAG_UNDERGLOW: {
+                    rgb_matrix_set_flags(LED_FLAG_NONE);
+                    rgb_matrix_disable_noeeprom();
+                  }
+                  break;
+                default: {
+                    rgb_matrix_set_flags(LED_FLAG_ALL);
+                    rgb_matrix_enable_noeeprom();
+                  }
+                  break;
+              }
+            }
+            return false;
+        default:
+            return true; //Process all other keycodes normally
+    }
+}

--- a/keyboards/massdrop/ctrl/keymaps/foxx1337/rgb_matrix_user.inc
+++ b/keyboards/massdrop/ctrl/keymaps/foxx1337/rgb_matrix_user.inc
@@ -1,0 +1,27 @@
+// !!! DO NOT ADD #pragma once !!! //
+
+// Step 1.
+// Declare custom effects using the RGB_MATRIX_EFFECT macro
+// (note the lack of semicolon after the macro!)
+RGB_MATRIX_EFFECT(hid_effect)
+
+// Step 2.
+// Define effects inside the `RGB_MATRIX_CUSTOM_EFFECT_IMPLS` ifdef block
+#ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
+
+RGB rgb_matrix_led_state[DRIVER_LED_TOTAL];
+
+// e.g: A simple effect, self-contained within a single method
+static bool hid_effect(effect_params_t* params) {
+    RGB_MATRIX_USE_LIMITS(led_min, led_max);
+
+    for (uint8_t i = led_min; i < led_max; i++) {
+        rgb_matrix_set_color(i,
+            rgb_matrix_led_state[i].r,
+            rgb_matrix_led_state[i].g,
+            rgb_matrix_led_state[i].b);
+    }
+    return led_max < DRIVER_LED_TOTAL;
+}
+
+#endif // RGB_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/keyboards/massdrop/ctrl/keymaps/foxx1337/rgb_matrix_user.inc
+++ b/keyboards/massdrop/ctrl/keymaps/foxx1337/rgb_matrix_user.inc
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2021 foxx1337 at yahoo dot com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 // !!! DO NOT ADD #pragma once !!! //
 
 // Step 1.

--- a/keyboards/massdrop/ctrl/keymaps/foxx1337/rules.mk
+++ b/keyboards/massdrop/ctrl/keymaps/foxx1337/rules.mk
@@ -1,0 +1,3 @@
+# Build Options
+CONSOLE_ENABLE = no         # Console for debug
+RAW_ENABLE = no            # Raw device

--- a/keyboards/massdrop/ctrl/keymaps/foxx1337/rules.mk
+++ b/keyboards/massdrop/ctrl/keymaps/foxx1337/rules.mk
@@ -1,3 +1,5 @@
 # Build Options
 CONSOLE_ENABLE = no         # Console for debug
-RAW_ENABLE = no            # Raw device
+RAW_ENABLE = yes            # Raw device
+
+SRC += hid_protocol.c

--- a/keyboards/massdrop/ctrl/keymaps/foxx1337/rules.mk
+++ b/keyboards/massdrop/ctrl/keymaps/foxx1337/rules.mk
@@ -1,5 +1,6 @@
 # Build Options
-CONSOLE_ENABLE = no         # Console for debug
-RAW_ENABLE = yes            # Raw device
+CONSOLE_ENABLE = no          	# Console for debug
+RAW_ENABLE = yes             	# Raw device
+RGB_MATRIX_CUSTOM_USER = yes	# Custom rgb matrix effect
 
 SRC += hid_protocol.c


### PR DESCRIPTION
This keymap is not too different from the default.

I introduced defaults according to my taste and stripped away some effects. The biggest change is the addition of a raw HID communication protocol, which opens the way for a configurator a la VIA or Logitech Gaming Software, etc.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

* Added inactivity timeout for the rgb matrix; after 5 minutes of idleness the matrix turns off.
* Added a raw HID protocol based on 96bfce70009ac15 that exposes the rgbmatrix functionality to clients

[This YouTube video](https://www.youtube.com/watch?v=2SEVsAaa3tA) showcases the layout in action.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
