### PR TITLE
Fixed a bug caused by "split_common" in Fortitude 60.

### DIFF
--- a/keyboards/fortitude60/keymaps/default/config.h
+++ b/keyboards/fortitude60/keymaps/default/config.h
@@ -18,16 +18,3 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #pragma once
 
 #define USE_SERIAL
-
-/* Select hand configuration */
-
-// #define MASTER_LEFT
-// #define MASTER_RIGHT
-#define EE_HANDS
-
-/* #undef RGBLED_NUM */
-/* #define RGBLIGHT_ANIMATIONS */
-/* #define RGBLED_NUM 12 */
-/* #define RGBLIGHT_HUE_STEP 8 */
-/* #define RGBLIGHT_SAT_STEP 8 */
-/* #define RGBLIGHT_VAL_STEP 8 */

--- a/keyboards/fortitude60/rev1/config.h
+++ b/keyboards/fortitude60/rev1/config.h
@@ -44,6 +44,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #define SOFT_SERIAL_PIN D2
 
+#define EE_HANDS
+
+#define SPLIT_USB_DETECT
+#define SPLIT_USB_TIMEOUT 1000
+
 /* define if matrix has ghost */
 //#define MATRIX_HAS_GHOST
 
@@ -65,7 +70,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* ws2812 RGB LED */
 #ifdef RGBLIGHT_ENABLE
   #define RGB_DI_PIN B5
-  
   #define RGBLED_NUM 18    // Number of LEDs */
 #endif
 /*


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
When "split_common" was introduced in Fortitude 60, it did not work perfectly because it did not have the option to detect USB connections.
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
