### PR TITLE
Configurable VIA layout options default value

### DIFF
--- a/quantum/via.c
+++ b/quantum/via.c
@@ -111,7 +111,7 @@ void via_init(void) {
     if (via_eeprom_is_valid()) {
     } else {
         // This resets the layout options
-        via_set_layout_options(0);
+        via_set_layout_options(VIA_EEPROM_LAYOUT_OPTIONS_DEFAULT);
         // This resets the keymaps in EEPROM to what is in flash.
         dynamic_keymap_reset();
         // This resets the macros in EEPROM to nothing.

--- a/quantum/via.h
+++ b/quantum/via.h
@@ -37,6 +37,14 @@
 #    define VIA_EEPROM_LAYOUT_OPTIONS_SIZE 1
 #endif
 
+// Allow override of the layout options default value.
+// This requires advanced knowledge of how VIA stores layout options
+// and is only really useful for setting a boolean layout option
+// state to true by default.
+#ifndef VIA_EEPROM_LAYOUT_OPTIONS_DEFAULT
+#    define VIA_EEPROM_LAYOUT_OPTIONS_DEFAULT 0x00000000
+#endif
+
 // The end of the EEPROM memory used by VIA
 // By default, dynamic keymaps will start at this if there is no
 // custom config


### PR DESCRIPTION
## Description

Allow override of the layout options default value. This requires advanced knowledge of how VIA stores layout options and is only really useful for setting a boolean layout option state to true by default.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
