### PR TITLE
Small corrections to Belgian, Serbian and Slovenian keymaps

### DIFF
--- a/quantum/keymap_extras/keymap_belgian.h
+++ b/quantum/keymap_extras/keymap_belgian.h
@@ -111,7 +111,7 @@
 #define BE_8    S(BE_EXLM) // 8
 #define BE_9    S(BE_CCED) // 9
 #define BE_0    S(BE_AGRV) // 0
-#define BE_RNGA S(BE_RPRN) // °
+#define BE_DEG  S(BE_RPRN) // °
 #define BE_UNDS S(BE_MINS) // _
 // Row 2
 #define BE_DIAE S(BE_DCIR) // ¨ (dead)
@@ -163,7 +163,7 @@
 #define BE_PARA BE_SECT
 #define BE_MU   BE_MICR
 #define BE_LESS BE_LABK
-#define BE_OVRR BE_RNGA
+#define BE_OVRR BE_DEG
 #define BE_UMLT BE_DIAE
 #define BE_GRTR BE_RABK
 #define BE_LSBR BE_LBRC

--- a/quantum/keymap_extras/keymap_greek.h
+++ b/quantum/keymap_extras/keymap_greek.h
@@ -114,7 +114,7 @@
 #define GR_PLUS S(GR_EQL)  // +
 // Row 2
 #define GR_COLN S(GR_SCLN) // :
-#define GR_DTON S(GR_FSIG) // ΅ (dead)
+#define GR_DIAT S(GR_FSIG) // ΅ (dead)
 #define GR_LCBR S(GR_LBRC) // {
 #define GR_RCBR S(GR_RBRC) // }
 // Row 3

--- a/quantum/keymap_extras/keymap_serbian.h
+++ b/quantum/keymap_extras/keymap_serbian.h
@@ -111,8 +111,8 @@
 #define RS_LPRN S(RS_8)    // (
 #define RS_RPRN S(RS_9)    // )
 #define RS_EQL  S(RS_0)    // =
-#define RS_DEG  S(RS_QUOT) // ?
-#define RS_UNDS S(RS_PLUS) // *
+#define RS_QUES S(RS_QUOT) // ?
+#define RS_ASTR S(RS_PLUS) // *
 // Row 4
 #define RS_RABK S(RS_LABK) // >
 #define RS_SCLN S(RS_COMM) // ;

--- a/quantum/keymap_extras/keymap_serbian_latin.h
+++ b/quantum/keymap_extras/keymap_serbian_latin.h
@@ -111,8 +111,8 @@
 #define RS_LPRN S(RS_8)    // (
 #define RS_RPRN S(RS_9)    // )
 #define RS_EQL  S(RS_0)    // =
-#define RS_DEG  S(RS_QUOT) // ?
-#define RS_UNDS S(RS_PLUS) // *
+#define RS_QUES S(RS_QUOT) // ?
+#define RS_ASTR S(RS_PLUS) // *
 // Row 4
 #define RS_RABK S(RS_LABK) // >
 #define RS_SCLN S(RS_COMM) // ;

--- a/quantum/keymap_extras/keymap_slovenian.h
+++ b/quantum/keymap_extras/keymap_slovenian.h
@@ -137,11 +137,11 @@
 #define SI_CARN ALGR(SI_2)    // ˇ (dead)
 #define SI_CIRC ALGR(SI_3)    // ^ (dead)
 #define SI_BREV ALGR(SI_4)    // ˘ (dead)
-#define SI_DEG  ALGR(SI_5)    // ° (dead)
+#define SI_RNGA ALGR(SI_5)    // ° (dead)
 #define SI_OGON ALGR(SI_6)    // ˛ (dead)
 #define SI_GRV  ALGR(SI_7)    // `
 #define SI_DOTA ALGR(SI_8)    // ˙ (dead)
-#define SI_ACCU ALGR(SI_9)    // ´ (dead)
+#define SI_ACUT ALGR(SI_9)    // ´ (dead)
 #define SI_DACU ALGR(SI_0)    // ˝ (dead)
 // Row 2
 #define SI_BSLS ALGR(SI_Q)    // (backslash)

--- a/quantum/keymap_extras/keymap_swedish.h
+++ b/quantum/keymap_extras/keymap_swedish.h
@@ -162,6 +162,7 @@
 #define SE_BULT SE_CURR
 #define SE_GRTR SE_RABK
 #define SE_AA   SE_ARNG
+#define SE_AE   SE_ADIA
 #define SE_AM   SE_ARNG
 #define SE_MU   SE_MICR
 // Swedish macOS symbols (not vetted)


### PR DESCRIPTION
## Description

Small corrections to Belgian (#8349), Serbian (#8560) and Slovenian (#8350) keymaps.

Namely, the Belgian keymap calls the non-dead-key degree sign `RNGA` instead of `DEG`, the Slovenian keymap does the opposite for the ring accent dead key, and the Serbian keymaps have a couple of wrong names altogether (one of them causes a multiple definition error).

/request_review @fauxpark 

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
