### PR TITLE
Update C coding conventions to match .clang-format config for indenting PP directives

### DIFF
--- a/docs/coding_conventions_c.md
+++ b/docs/coding_conventions_c.md
@@ -23,7 +23,7 @@ Most of our style is pretty easy to pick up on, but right now it's not entirely 
 * When deciding how (or if) to indent preprocessor directives, keep these points in mind:
   * Readability is more important than consistency.
   * Follow the file's existing style. If the file is mixed, follow the style that makes sense for the section you are modifying.
-  * When indenting, keep the hash at the start of the line and add whitespace between `#` and `if`, in increments of 4, starting at the first column after `#`.
+  * When indenting, keep the hash at the start of the line and add whitespace between `#` and `if`, starting with 4 spaces after the `#`.
   * You can follow the indention level of the surrounding C code, or preprocessor directives can have their own indentation levels. Choose the style that best communicates the intent of your code.
 
 Here is an example for easy reference:

--- a/docs/coding_conventions_c.md
+++ b/docs/coding_conventions_c.md
@@ -20,11 +20,11 @@ Most of our style is pretty easy to pick up on, but right now it's not entirely 
 * We accept both forms of preprocessor if's: `#ifdef DEFINED` and `#if defined(DEFINED)`
   * If you are not sure which to prefer use the `#if defined(DEFINED)` form.
   * Do not change existing code from one style to the other, except when moving to a multiple condition `#if`.
-  * Do not put whitespace between `#` and `if`.
-  * When deciding how (or if) to indent directives keep these points in mind:
-    * Readability is more important than consistency.
-    * Follow the file's existing style. If the file is mixed follow the style that makes sense for the section you are modifying.
-    * When choosing to indent you can follow the indention level of the surrounding C code, or preprocessor directives can have their own indent level. Choose the style that best communicates the intent of your code.
+* When deciding how (or if) to indent preprocessor directives, keep these points in mind:
+  * Readability is more important than consistency.
+  * Follow the file's existing style. If the file is mixed, follow the style that makes sense for the section you are modifying.
+  * When indenting, keep the hash at the start of the line and add whitespace between `#` and `if`, in increments of 4, starting at the first column after `#`.
+  * You can follow the indention level of the surrounding C code, or preprocessor directives can have their own indentation levels. Choose the style that best communicates the intent of your code.
 
 Here is an example for easy reference:
 


### PR DESCRIPTION
## Description

In #6316 we agreed that, in the long term, preprocessor directives should be indented using the `BeforeHash` style. However, we are using `AfterHash` for the time being until versions of clang-format that support the former option are more widely available.

As mentioned in #8664, there is a discrepancy between the coding conventions doc and the current `.clang-format` configuration, which is causing some confusion. This updates the conventions to match that configuration for the time being.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* resolves #8664 

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
