### PR TITLE
[Keymap] fix OLED display on Helix keyboard keymaps default and five_rows

### DIFF
--- a/keyboards/helix/rev2/keymaps/default/keymap.c
+++ b/keyboards/helix/rev2/keymaps/default/keymap.c
@@ -536,9 +536,9 @@ static void render_logo(struct CharacterMatrix *matrix) {
 }
 
 static void render_rgbled_status(bool full, struct CharacterMatrix *matrix) {
-#if defined(RGBLIGHT_ENABLE) && defined(RGBLIGHT_ANIMATIONS)
+#ifdef RGBLIGHT_ENABLE
   char buf[30];
-  if(rgblight_config.enable) {
+  if (RGBLIGHT_MODES > 1 && rgblight_config.enable) {
       if (full) {
           snprintf(buf, sizeof(buf), " LED %2d: %d,%d,%d ",
                    rgblight_config.mode,

--- a/keyboards/helix/rev2/keymaps/five_rows/keymap.c
+++ b/keyboards/helix/rev2/keymaps/five_rows/keymap.c
@@ -496,9 +496,9 @@ static void render_logo(struct CharacterMatrix *matrix) {
     0xc0,0xc1,0xc2,0xc3,0xc4,0xc5,0xc6,0xc7,0xc8,0xc9,0xca,0xcb,0xcc,0xcd,0xce,0xcf,0xd0,0xd1,0xd2,0xd3,0xd4,
     0};
   matrix_write(matrix, logo);
-#if defined(RGBLIGHT_ENABLE) && defined(RGBLIGHT_ANIMATIONS)
+#ifdef RGBLIGHT_ENABLE
   char buf[30];
-  if(rgblight_config.enable) {
+  if (RGBLIGHT_MODES > 1 && rgblight_config.enable) {
       snprintf(buf, sizeof(buf), " LED %2d: %d,%d,%d ",
                rgblight_config.mode,
                rgblight_config.hue/RGBLIGHT_HUE_STEP,


### PR DESCRIPTION
## Description

Since #7773, the mode number of RGBlight is no longer displayed on the Helix OLEDs. I fixed this.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
