### PR TITLE
Upgrade gcc version/tweak package installs in Gentoo installation

### DIFF
--- a/util/linux_install.sh
+++ b/util/linux_install.sh
@@ -105,17 +105,17 @@ elif grep ID /etc/os-release | grep -q gentoo; then
 		sudo touch /etc/portage/package.use/qmkfirmware
 		# tee is used here since sudo doesn't apply to >>
 		echo "sys-devel/gcc multilib" | sudo tee --append /etc/portage/package.use/qmkfirmware >/dev/null
-		sudo emerge -auN \
+		sudo emerge -auN sys-devel/gcc
+		sudo emerge -au --noreplace \
 			app-arch/unzip \
 			app-arch/zip \
 			app-mobilephone/dfu-util \
 			dev-embedded/avrdude \
-			dev-lang/python:3.5 \
 			net-misc/wget \
 			sys-devel/clang \
-			sys-devel/gcc \
 			sys-devel/crossdev
-		sudo crossdev -s4 --stable --g =4.9.4 --portage --verbose --target avr
+		sudo crossdev -s4 --stable --g \<9 --portage --verbose --target avr
+		sudo crossdev -s4 --stable --g \<9 --portage --verbose --target arm-none-eabi
 		echo "Done!"
 	else
 		echo "Quitting..."
@@ -132,7 +132,8 @@ elif grep ID /etc/os-release | grep -q sabayon; then
 		sys-devel/clang \
 		sys-devel/gcc \
 		sys-devel/crossdev
-	sudo crossdev -s4 --stable --g =4.9.4 --portage --verbose --target avr
+	sudo crossdev -s4 --stable --g \<9 --portage --verbose --target avr
+	sudo crossdev -s4 --stable --g \<9 --portage --verbose --target arm-none-eabi
 	echo "Done!"
 
 elif grep ID /etc/os-release | grep -qE "opensuse|tumbleweed"; then


### PR DESCRIPTION
## Description

GCC 4.9.4 is no longer available on Gentoo (or Sabayon), which causes
problems when attempting to install on either of these platforms. Since
QMK is not particularly sensitive to its GCC version, modify the version
restriction to <9 so newer versions of GCC may be installed.

Additionally, drop the Python installation as part of the Gentoo
installation process. Python is a core system package on Gentoo and can
therefore be assumed to be present; in addition, the slot restriction of
3.5 which was present is also no longer available in Gentoo.

Finally, separate the gcc rebuild invocation of `emerge` from the new
packages that may need to be installed, and apply the `--noreplace` flag
to new packages so that they are not rebuilt if already present.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

None

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
