### PR TITLE
Remove no-longer-necessary LTO checks from keyboards' config.h files

### DIFF
--- a/keyboards/abacus/config.h
+++ b/keyboards/abacus/config.h
@@ -105,10 +105,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define NO_ACTION_ONESHOT
 
 /* disable these deprecated features by default */
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-  #define NO_ACTION_MACRO
-  #define NO_ACTION_FUNCTION
-#endif
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
+
 /*
  * MIDI options
  */

--- a/keyboards/ai03/orbit_x/config.h
+++ b/keyboards/ai03/orbit_x/config.h
@@ -165,10 +165,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define NO_ACTION_ONESHOT
 
 /* disable these deprecated features by default */
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-  #define NO_ACTION_MACRO
-  #define NO_ACTION_FUNCTION
-#endif
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
 
 /* Bootmagic Lite key configuration */
 // #define BOOTMAGIC_LITE_ROW 0

--- a/keyboards/allison/config.h
+++ b/keyboards/allison/config.h
@@ -192,10 +192,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define NO_ACTION_ONESHOT
 
 /* disable these deprecated features by default */
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-  #define NO_ACTION_MACRO
-  #define NO_ACTION_FUNCTION
-#endif
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
+
 /*
  * MIDI options
  */

--- a/keyboards/allison_numpad/config.h
+++ b/keyboards/allison_numpad/config.h
@@ -192,10 +192,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define NO_ACTION_ONESHOT
 
 /* disable these deprecated features by default */
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-  #define NO_ACTION_MACRO
-  #define NO_ACTION_FUNCTION
-#endif
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
+
 /*
  * MIDI options
  */

--- a/keyboards/bat43/config.h
+++ b/keyboards/bat43/config.h
@@ -192,10 +192,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define NO_ACTION_ONESHOT
 
 /* disable these deprecated features by default */
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-  #define NO_ACTION_MACRO
-  #define NO_ACTION_FUNCTION
-#endif
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
+
 /*
  * MIDI options
  */

--- a/keyboards/ckeys/washington/config.h
+++ b/keyboards/ckeys/washington/config.h
@@ -193,10 +193,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define NO_ACTION_ONESHOT
 
 /* disable these deprecated features by default */
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-  #define NO_ACTION_MACRO
-  #define NO_ACTION_FUNCTION
-#endif
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
+
 /*
  * MIDI options
  */

--- a/keyboards/cospad/config.h
+++ b/keyboards/cospad/config.h
@@ -193,10 +193,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define NO_ACTION_ONESHOT
 
 /* disable these deprecated features by default */
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-  #define NO_ACTION_MACRO
-  #define NO_ACTION_FUNCTION
-#endif
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
+
 /*
  * MIDI options
  */

--- a/keyboards/crkbd/config.h
+++ b/keyboards/crkbd/config.h
@@ -24,11 +24,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define USE_I2C
 #define USE_SERIAL
 
-#ifdef USE_Link_Time_Optimization
-  // LTO has issues with macros (action_get_macro) and "functions" (fn_actions),
-  //  so just disable them
-  #define NO_ACTION_MACRO
-  #define NO_ACTION_FUNCTION
-
-  #define DISABLE_LEADER
-#endif // USE_Link_Time_Optimization
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION

--- a/keyboards/daisy/config.h
+++ b/keyboards/daisy/config.h
@@ -192,10 +192,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define NO_ACTION_ONESHOT
 
 /* disable these deprecated features by default */
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-  #define NO_ACTION_MACRO
-  #define NO_ACTION_FUNCTION
-#endif
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
+
 /*
  * MIDI options
  */

--- a/keyboards/dztech/dz60rgb/v1/config.h
+++ b/keyboards/dztech/dz60rgb/v1/config.h
@@ -33,10 +33,8 @@
 #define DEBOUNCE 3
 
 /* disable these deprecated features by default */
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-#    define NO_ACTION_MACRO
-#    define NO_ACTION_FUNCTION
-#endif
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
 
 #ifdef RGB_MATRIX_ENABLE
 #    define RGB_DISABLE_AFTER_TIMEOUT 0 // number of ticks to wait until disabling effects

--- a/keyboards/dztech/dz60rgb/v2/config.h
+++ b/keyboards/dztech/dz60rgb/v2/config.h
@@ -33,10 +33,8 @@
 #define DEBOUNCE 3
 
 /* disable these deprecated features by default */
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-#    define NO_ACTION_MACRO
-#    define NO_ACTION_FUNCTION
-#endif
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
 
 #ifdef RGB_MATRIX_ENABLE
 #    define RGB_DISABLE_AFTER_TIMEOUT 0 // number of ticks to wait until disabling effects

--- a/keyboards/dztech/dz60rgb_ansi/v1/config.h
+++ b/keyboards/dztech/dz60rgb_ansi/v1/config.h
@@ -33,10 +33,8 @@
 #define DEBOUNCE 3
 
 /* disable these deprecated features by default */
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-#    define NO_ACTION_MACRO
-#    define NO_ACTION_FUNCTION
-#endif
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
 
 #ifdef RGB_MATRIX_ENABLE
 #    define RGB_DISABLE_AFTER_TIMEOUT 0 // number of ticks to wait until disabling effects

--- a/keyboards/dztech/dz60rgb_ansi/v2/config.h
+++ b/keyboards/dztech/dz60rgb_ansi/v2/config.h
@@ -33,10 +33,8 @@
 #define DEBOUNCE 3
 
 /* disable these deprecated features by default */
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-#    define NO_ACTION_MACRO
-#    define NO_ACTION_FUNCTION
-#endif
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
 
 #ifdef RGB_MATRIX_ENABLE
 #    define RGB_DISABLE_AFTER_TIMEOUT 0 // number of ticks to wait until disabling effects

--- a/keyboards/dztech/dz60rgb_wkl/v1/config.h
+++ b/keyboards/dztech/dz60rgb_wkl/v1/config.h
@@ -33,10 +33,8 @@
 #define DEBOUNCE 3
 
 /* disable these deprecated features by default */
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-#    define NO_ACTION_MACRO
-#    define NO_ACTION_FUNCTION
-#endif
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
 
 #ifdef RGB_MATRIX_ENABLE
 #    define RGB_DISABLE_AFTER_TIMEOUT 0 // number of ticks to wait until disabling effects

--- a/keyboards/dztech/dz60rgb_wkl/v2/config.h
+++ b/keyboards/dztech/dz60rgb_wkl/v2/config.h
@@ -33,10 +33,8 @@
 #define DEBOUNCE 3
 
 /* disable these deprecated features by default */
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-#    define NO_ACTION_MACRO
-#    define NO_ACTION_FUNCTION
-#endif
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
 
 #ifdef RGB_MATRIX_ENABLE
 #    define RGB_DISABLE_AFTER_TIMEOUT 0 // number of ticks to wait until disabling effects

--- a/keyboards/dztech/dz65rgb/v1/config.h
+++ b/keyboards/dztech/dz65rgb/v1/config.h
@@ -29,10 +29,8 @@
 #define DIODE_DIRECTION COL2ROW
 
 /* disable these deprecated features by default */
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-#    define NO_ACTION_MACRO
-#    define NO_ACTION_FUNCTION
-#endif
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
 
 #ifdef RGB_MATRIX_ENABLE
 #    define RGB_MATRIX_LED_PROCESS_LIMIT 4

--- a/keyboards/dztech/dz65rgb/v2/config.h
+++ b/keyboards/dztech/dz65rgb/v2/config.h
@@ -29,10 +29,8 @@
 #define DIODE_DIRECTION COL2ROW
 
 /* disable these deprecated features by default */
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-#    define NO_ACTION_MACRO
-#    define NO_ACTION_FUNCTION
-#endif
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
 
 #ifdef RGB_MATRIX_ENABLE
 #    define RGB_MATRIX_LED_PROCESS_LIMIT 4

--- a/keyboards/ergodox_ez/keymaps/danielo515/config.h
+++ b/keyboards/ergodox_ez/keymaps/danielo515/config.h
@@ -25,9 +25,7 @@
 #    define NO_PRINT
 #endif
 
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-#    define NO_ACTION_MACRO
-#    define NO_ACTION_FUNCTION
-#endif
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
 
 #undef RGBLIGHT_ANIMATIONS

--- a/keyboards/exclusive/e7v1se/config.h
+++ b/keyboards/exclusive/e7v1se/config.h
@@ -192,10 +192,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define NO_ACTION_ONESHOT
 
 /* disable these deprecated features by default */
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-  #define NO_ACTION_MACRO
-  #define NO_ACTION_FUNCTION
-#endif
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
+
 /*
  * MIDI options
  */

--- a/keyboards/handwired/fc200rt_qmk/config.h
+++ b/keyboards/handwired/fc200rt_qmk/config.h
@@ -31,14 +31,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MATRIX_ROWS 8
 #define MATRIX_COLS 16
 
-
 #define MATRIX_ROW_PINS { B0, B1, B2, B3, E6, B7, D0, D1 }
 #define MATRIX_COL_PINS { D2, D3, C6, C7, D5, D4, D6, D7, B4, B5, B6, F7, F6, F5, F4, F1 }
 #define UNUSED_PINS
 
 /* COL2ROW, ROW2COL*/
 #define DIODE_DIRECTION ROW2COL
-
 
 /* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
 #define DEBOUNCE 5
@@ -130,7 +128,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define MAGIC_KEY_NKRO           N
 //#define MAGIC_KEY_SLEEP_LED      Z
 
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-  #define NO_ACTION_MACRO
-  #define NO_ACTION_FUNCTION
-#endif
+/* disable these deprecated features by default */
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION

--- a/keyboards/handwired/floorboard/config.h
+++ b/keyboards/handwired/floorboard/config.h
@@ -192,10 +192,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define NO_ACTION_ONESHOT
 
 /* disable these deprecated features by default */
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-  #define NO_ACTION_MACRO
-  #define NO_ACTION_FUNCTION
-#endif
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
+
 /*
  * MIDI options
  */

--- a/keyboards/handwired/jtallbean/split_65/config.h
+++ b/keyboards/handwired/jtallbean/split_65/config.h
@@ -195,10 +195,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define NO_ACTION_ONESHOT
 
 /* disable these deprecated features by default */
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-  #define NO_ACTION_MACRO
-  #define NO_ACTION_FUNCTION
-#endif
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
+
 /*
  * MIDI options
  */

--- a/keyboards/handwired/sick68/config.h
+++ b/keyboards/handwired/sick68/config.h
@@ -194,10 +194,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define NO_ACTION_ONESHOT
 
 /* disable these deprecated features by default */
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-#    define NO_ACTION_MACRO
-#    define NO_ACTION_FUNCTION
-#endif
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
+
 /*
  * MIDI options
  */

--- a/keyboards/handwired/videowriter/config.h
+++ b/keyboards/handwired/videowriter/config.h
@@ -130,10 +130,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define NO_ACTION_ONESHOT
 
 /* disable these deprecated features by default */
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-  #define NO_ACTION_MACRO
-  #define NO_ACTION_FUNCTION
-#endif
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
 
 /* Bootmagic Lite key configuration */
 // #define BOOTMAGIC_LITE_ROW 0

--- a/keyboards/hineybush/physix/config.h
+++ b/keyboards/hineybush/physix/config.h
@@ -192,10 +192,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define NO_ACTION_ONESHOT
 
 /* disable these deprecated features by default */
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-  #define NO_ACTION_MACRO
-  #define NO_ACTION_FUNCTION
-#endif
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
+
 /*
  * MIDI options
  */

--- a/keyboards/j80/config.h
+++ b/keyboards/j80/config.h
@@ -39,10 +39,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define BACKLIGHT_PIN D4
 
 /* disable these deprecated features by default */
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-  #define NO_ACTION_MACRO
-  #define NO_ACTION_FUNCTION
-#endif
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
 
 /* key combination for magic key command */
 /* defined by default; to change, uncomment and set to the combination you want */

--- a/keyboards/jae/j01/config.h
+++ b/keyboards/jae/j01/config.h
@@ -165,10 +165,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define NO_ACTION_ONESHOT
 
 /* disable these deprecated features by default */
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-  #define NO_ACTION_MACRO
-  #define NO_ACTION_FUNCTION
-#endif
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
+
 /*
  * MIDI options
  */

--- a/keyboards/just60/config.h
+++ b/keyboards/just60/config.h
@@ -48,7 +48,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define LOCKING_RESYNC_ENABLE
 
 /* disable these deprecated features by default */
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-  #define NO_ACTION_MACRO
-  #define NO_ACTION_FUNCTION
-#endif
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION

--- a/keyboards/keebio/choconum/config.h
+++ b/keyboards/keebio/choconum/config.h
@@ -147,10 +147,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define NO_ACTION_ONESHOT
 
 /* disable these deprecated features by default */
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-  #define NO_ACTION_MACRO
-  #define NO_ACTION_FUNCTION
-#endif
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
+
 /*
  * MIDI options
  */

--- a/keyboards/keebwerk/nano_slider/config.h
+++ b/keyboards/keebwerk/nano_slider/config.h
@@ -161,10 +161,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define NO_ACTION_ONESHOT
 
 /* disable these deprecated features by default */
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-#    define NO_ACTION_MACRO
-#    define NO_ACTION_FUNCTION
-#endif
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
+
 /*
  * MIDI options
  */

--- a/keyboards/lattice60/config.h
+++ b/keyboards/lattice60/config.h
@@ -99,7 +99,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define NO_ACTION_ONESHOT
 
 /* disable these deprecated features by default */
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-  #define NO_ACTION_MACRO
-  #define NO_ACTION_FUNCTION
-#endif
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION

--- a/keyboards/lfkeyboards/lfk78/config.h
+++ b/keyboards/lfkeyboards/lfk78/config.h
@@ -158,10 +158,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define NO_ACTION_ONESHOT
 
 /* disable these deprecated features by default */
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-  #define NO_ACTION_MACRO
-  #define NO_ACTION_FUNCTION
-#endif
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
+
 /*
  * MIDI options
  */

--- a/keyboards/lfkeyboards/lfkpad/config.h
+++ b/keyboards/lfkeyboards/lfkpad/config.h
@@ -175,10 +175,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define NO_ACTION_ONESHOT
 
 /* disable these deprecated features by default */
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-  #define NO_ACTION_MACRO
-  #define NO_ACTION_FUNCTION
-#endif
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
+
 /*
  * MIDI options
  */

--- a/keyboards/mc_76k/config.h
+++ b/keyboards/mc_76k/config.h
@@ -98,7 +98,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 /* disable these deprecated features by default */
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-  #define NO_ACTION_MACRO
-  #define NO_ACTION_FUNCTION
-#endif
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION

--- a/keyboards/miller/gm862/config.h
+++ b/keyboards/miller/gm862/config.h
@@ -28,11 +28,11 @@
 #define UNUSED_PINS
 /* COL2ROW, ROW2COL*/
 #define DIODE_DIRECTION COL2ROW
+
 /* disable these deprecated features by default */
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-#    define NO_ACTION_MACRO
-#    define NO_ACTION_FUNCTION
-#endif
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
+
 /* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
 #define DEBOUNCE 3
 #ifdef RGB_MATRIX_ENABLE

--- a/keyboards/mountainblocks/mb17/config.h
+++ b/keyboards/mountainblocks/mb17/config.h
@@ -147,12 +147,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
 /* disable these deprecated features by default */
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-  #define NO_ACTION_MACRO
-  #define NO_ACTION_FUNCTION
-#endif
-
-
-
-
-
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION

--- a/keyboards/oddball/config.h
+++ b/keyboards/oddball/config.h
@@ -195,10 +195,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define NO_ACTION_ONESHOT
 
 /* disable these deprecated features by default */
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-  #define NO_ACTION_MACRO
-  #define NO_ACTION_FUNCTION
-#endif
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
+
 /*
  * MIDI options
  */

--- a/keyboards/silverbullet44/config.h
+++ b/keyboards/silverbullet44/config.h
@@ -233,10 +233,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define NO_ACTION_LAYER
 //#define NO_ACTION_TAPPING
 //#define NO_ACTION_ONESHOT
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-#    define NO_ACTION_MACRO
-#    define NO_ACTION_FUNCTION
-#endif
+
+/* disable these deprecated features by default */
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
 
 /*
  * MIDI options

--- a/keyboards/switchplate/southpaw_fullsize/config.h
+++ b/keyboards/switchplate/southpaw_fullsize/config.h
@@ -133,10 +133,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define NO_ACTION_ONESHOT
 
 /* disable these deprecated features by default */
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-  #define NO_ACTION_MACRO
-  #define NO_ACTION_FUNCTION
-#endif
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
 
 /* Bootmagic Lite key configuration */
 // #define BOOTMAGIC_LITE_ROW 0

--- a/keyboards/treadstone48/rev1/config.h
+++ b/keyboards/treadstone48/rev1/config.h
@@ -198,10 +198,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define NO_ACTION_ONESHOT
 
 /* disable these deprecated features by default */
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-  #define NO_ACTION_MACRO
-  #define NO_ACTION_FUNCTION
-#endif
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
+
 /*
  * MIDI options
  */

--- a/keyboards/wallaby/config.h
+++ b/keyboards/wallaby/config.h
@@ -192,10 +192,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define NO_ACTION_ONESHOT
 
 /* disable these deprecated features by default */
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-  #define NO_ACTION_MACRO
-  #define NO_ACTION_FUNCTION
-#endif
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
+
 /*
  * MIDI options
  */

--- a/keyboards/ymdk/ymd09/config.h
+++ b/keyboards/ymdk/ymd09/config.h
@@ -60,7 +60,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define LOCKING_RESYNC_ENABLE
 
 /* disable these deprecated features by default */
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-  #define NO_ACTION_MACRO
-  #define NO_ACTION_FUNCTION
-#endif
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION

--- a/keyboards/yosino58/config.h
+++ b/keyboards/yosino58/config.h
@@ -24,11 +24,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define USE_I2C
 #define USE_SERIAL
 
-#ifdef USE_Link_Time_Optimization
-  // LTO has issues with macros (action_get_macro) and "functions" (fn_actions),
-  //  so just disable them
-  #define NO_ACTION_MACRO
-  #define NO_ACTION_FUNCTION
-
-  #define DISABLE_LEADER
-#endif // USE_Link_Time_Optimization
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION

--- a/keyboards/yurei/config.h
+++ b/keyboards/yurei/config.h
@@ -192,10 +192,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define NO_ACTION_ONESHOT
 
 /* disable these deprecated features by default */
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-  #define NO_ACTION_MACRO
-  #define NO_ACTION_FUNCTION
-#endif
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
+
 /*
  * MIDI options
  */

--- a/keyboards/zinc/config.h
+++ b/keyboards/zinc/config.h
@@ -40,11 +40,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //     ./tmk_core
 //     ......
 
-#ifdef USE_Link_Time_Optimization
-  // LTO has issues with macros (action_get_macro) and "functions" (fn_actions),
-  //  so just disable them
-  #define NO_ACTION_MACRO
-  #define NO_ACTION_FUNCTION
-#endif // USE_Link_Time_Optimization
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
 
 //#endif /* CONFIG_H */


### PR DESCRIPTION
## Description

As of #8663, checking for `LINK_TIME_OPTIMIZATION_ENABLE` before defining `NO_ACTION_MACRO`, `NO_ACTION_FUNCTION` is no longer required. This PR removes the now unnecessary checks from keyboards' `config.h` files that were based on the old version of the template.

While I was at it, I thought I might as well update the single user `config.h` that had the check, which is @danielo515's. Could you please check and confirm if you're okay with the change?

Note on `crkbd` and `yosino58`: the `DISABLE_LEADER` flag doesn't seem to exist anymore, so I've removed that as well since it doesn't do anything.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
