### PR TITLE
Fix AVR SPI parameter configuration, remove timeouts

### DIFF
--- a/docs/spi_driver.md
+++ b/docs/spi_driver.md
@@ -16,7 +16,7 @@ No special setup is required - just connect the `SS`, `SCK`, `MOSI` and `MISO` p
 You may use more than one slave select pin, not just the `SS` pin. This is useful when you have multiple devices connected and need to communicate with them individually.
 `SPI_SS_PIN` can be passed to `spi_start()` to refer to `SS`.
 
-## ARM Configuration
+## ChibiOS/ARM Configuration
 
 ARM support for this driver is not ready yet. Check back later!
 
@@ -28,7 +28,7 @@ Initialize the SPI driver. This function must be called only once, before any of
 
 ---
 
-### `void spi_start(pin_t slavePin, bool lsbFirst, uint8_t mode, uint8_t divisor)`
+### `bool spi_start(pin_t slavePin, bool lsbFirst, uint8_t mode, uint16_t divisor)`
 
 Start an SPI transaction.
 
@@ -48,12 +48,16 @@ Start an SPI transaction.
    |`2` |Leading edge falling|Sample on leading edge |
    |`3` |Leading edge falling|Sample on trailing edge|
 
- - `uint8_t divisor`  
+ - `uint16_t divisor`  
    The SPI clock divisor, will be rounded up to the nearest power of two. This number can be calculated by dividing the MCU's clock speed by the desired SPI clock speed. For example, an MCU running at 8 MHz wanting to talk to an SPI device at 4 MHz would set the divisor to `2`.
+
+#### Return Value
+
+`false` if the supplied parameters are invalid or the SPI peripheral is already in use, or `true`.
 
 ---
 
-### `spi_status_t spi_write(uint8_t data, uint16_t timeout)`
+### `spi_status_t spi_write(uint8_t data)`
 
 Write a byte to the selected SPI device.
 
@@ -61,8 +65,6 @@ Write a byte to the selected SPI device.
 
  - `uint8_t data`  
    The byte to write.
- - `uint16_t timeout`  
-   The amount of time to wait, in milliseconds, before timing out.
 
 #### Return Value
 
@@ -70,14 +72,9 @@ Write a byte to the selected SPI device.
 
 ---
 
-### `spi_status_t spi_read(uint16_t timeout)`
+### `spi_status_t spi_read(void)`
 
 Read a byte from the selected SPI device.
-
-#### Arguments
-
- - `uint16_t timeout`  
-   The amount of time to wait, in milliseconds, before timing out.
 
 #### Return Value
 
@@ -85,7 +82,7 @@ Read a byte from the selected SPI device.
 
 ---
 
-### `spi_status_t spi_transmit(const uint8_t *data, uint16_t length, uint16_t timeout)`
+### `spi_status_t spi_transmit(const uint8_t *data, uint16_t length)`
 
 Send multiple bytes to the selected SPI device.
 
@@ -95,8 +92,6 @@ Send multiple bytes to the selected SPI device.
    A pointer to the data to write from.
  - `uint16_t length`  
    The number of bytes to write. Take care not to overrun the length of `data`.
- - `uint16_t timeout`  
-   The amount of time to wait, in milliseconds, before timing out.
 
 #### Return Value
 
@@ -104,7 +99,7 @@ Send multiple bytes to the selected SPI device.
 
 ---
 
-### `spi_status_t spi_receive(uint8_t *data, uint16_t length, uint16_t timeout)`
+### `spi_status_t spi_receive(uint8_t *data, uint16_t length)`
 
 Receive multiple bytes from the selected SPI device.
 
@@ -114,12 +109,10 @@ Receive multiple bytes from the selected SPI device.
    A pointer to the buffer to read into.
  - `uint16_t length`  
    The number of bytes to read. Take care not to overrun the length of `data`.
- - `uint16_t timeout`  
-   The amount of time to wait, in milliseconds, before timing out.
 
 #### Return Value
 
-`SPI_STATUS_TIMEOUT` if the timeout period elapses, `SPI_STATUS_SUCCESS` on success, or `SPI_STATUS_ERROR` otherwise.
+`SPI_STATUS_TIMEOUT` if the internal transmission timeout period elapses, `SPI_STATUS_SUCCESS` on success, or `SPI_STATUS_ERROR` otherwise.
 
 ---
 

--- a/drivers/avr/spi_master.h
+++ b/drivers/avr/spi_master.h
@@ -41,15 +41,15 @@ extern "C" {
 #endif
 void spi_init(void);
 
-void spi_start(pin_t slavePin, bool lsbFirst, uint8_t mode, uint8_t divisor);
+bool spi_start(pin_t slavePin, bool lsbFirst, uint8_t mode, uint16_t divisor);
 
-spi_status_t spi_write(uint8_t data, uint16_t timeout);
+spi_status_t spi_write(uint8_t data);
 
-spi_status_t spi_read(uint16_t timeout);
+spi_status_t spi_read(void);
 
-spi_status_t spi_transmit(const uint8_t *data, uint16_t length, uint16_t timeout);
+spi_status_t spi_transmit(const uint8_t *data, uint16_t length);
 
-spi_status_t spi_receive(uint8_t *data, uint16_t length, uint16_t timeout);
+spi_status_t spi_receive(uint8_t *data, uint16_t length);
 
 void spi_stop(void);
 #ifdef __cplusplus

--- a/tmk_core/protocol/lufa/adafruit_ble.cpp
+++ b/tmk_core/protocol/lufa/adafruit_ble.cpp
@@ -152,7 +152,7 @@ static bool sdep_send_pkt(const struct sdep_msg *msg, uint16_t timeout) {
     bool     ready      = false;
 
     do {
-        ready = spi_write(msg->type, 100) != SdepSlaveNotReady;
+        ready = spi_write(msg->type) != SdepSlaveNotReady;
         if (ready) {
             break;
         }
@@ -165,7 +165,7 @@ static bool sdep_send_pkt(const struct sdep_msg *msg, uint16_t timeout) {
 
     if (ready) {
         // Slave is ready; send the rest of the packet
-        spi_transmit(&msg->cmd_low, sizeof(*msg) - (1 + sizeof(msg->payload)) + msg->len, 100);
+        spi_transmit(&msg->cmd_low, sizeof(*msg) - (1 + sizeof(msg->payload)) + msg->len);
         success = true;
     }
 
@@ -205,7 +205,7 @@ static bool sdep_recv_pkt(struct sdep_msg *msg, uint16_t timeout) {
 
         do {
             // Read the command type, waiting for the data to be ready
-            msg->type = spi_read(100);
+            msg->type = spi_read();
             if (msg->type == SdepSlaveNotReady || msg->type == SdepSlaveOverflow) {
                 // Release it and let it initialize
                 spi_stop();
@@ -215,11 +215,11 @@ static bool sdep_recv_pkt(struct sdep_msg *msg, uint16_t timeout) {
             }
 
             // Read the rest of the header
-            spi_receive(&msg->cmd_low, sizeof(*msg) - (1 + sizeof(msg->payload)), 100);
+            spi_receive(&msg->cmd_low, sizeof(*msg) - (1 + sizeof(msg->payload)));
 
             // and get the payload if there is any
             if (msg->len <= SdepMaxPayload) {
-                spi_receive(msg->payload, msg->len, 100);
+                spi_receive(msg->payload, msg->len);
             }
             success = true;
             break;


### PR DESCRIPTION
## Description

There were a few issues with the SPI configuration on AVR, with wrong registers being written.
This fixes those, but also removes the external timeout parameters as it's a synchronous protocol.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
