### PR TITLE
Add dual-bank STM32 bootloader support

### DIFF
--- a/tmk_core/common/chibios/bootloader.c
+++ b/tmk_core/common/chibios/bootloader.c
@@ -3,28 +3,82 @@
 #include "ch.h"
 #include "hal.h"
 
-#ifdef STM32_BOOTLOADER_ADDRESS
-/* STM32 */
-
 /* This code should be checked whether it runs correctly on platforms */
-#    define SYMVAL(sym) (uint32_t)(((uint8_t *)&(sym)) - ((uint8_t *)0))
-extern uint32_t __ram0_end__;
-#    define BOOTLOADER_MAGIC 0xDEADBEEF
-#    define MAGIC_ADDR (unsigned long *)(SYMVAL(__ram0_end__) - 4)
+#define SYMVAL(sym) (uint32_t)(((uint8_t *)&(sym)) - ((uint8_t *)0))
+#define BOOTLOADER_MAGIC 0xDEADBEEF
+#define MAGIC_ADDR (unsigned long *)(SYMVAL(__ram0_end__) - 4)
 
-/** \brief Jump to the bootloader
- *
- * FIXME: needs doc
- */
+#ifndef STM32_BOOTLOADER_DUAL_BANK
+#    define STM32_BOOTLOADER_DUAL_BANK FALSE
+#endif
+
+#if STM32_BOOTLOADER_DUAL_BANK
+
+// Need pin definitions
+#    include "config_common.h"
+
+#    ifndef STM32_BOOTLOADER_DUAL_BANK_GPIO
+#        error "No STM32_BOOTLOADER_DUAL_BANK_GPIO defined, don't know which pin to toggle"
+#    endif
+
+#    ifndef STM32_BOOTLOADER_DUAL_BANK_POLARITY
+#        define STM32_BOOTLOADER_DUAL_BANK_POLARITY 0
+#    endif
+
+#    ifndef STM32_BOOTLOADER_DUAL_BANK_DELAY
+#        define STM32_BOOTLOADER_DUAL_BANK_DELAY 100000
+#    endif
+
+extern uint32_t __ram0_end__;
+
+#    define bootdelay(loopcount)                  \
+        do {                                      \
+            for (int i = 0; i < loopcount; ++i) { \
+                __asm__ volatile("nop\n\t"        \
+                                 "nop\n\t"        \
+                                 "nop\n\t");      \
+            }                                     \
+        } while (0)
+
 void bootloader_jump(void) {
     *MAGIC_ADDR = BOOTLOADER_MAGIC;  // set magic flag => reset handler will jump into boot loader
     NVIC_SystemReset();
 }
 
-/** \brief Enter bootloader mode if requested
- *
- * FIXME: needs doc
- */
+void enter_bootloader_mode_if_requested(void) {
+    unsigned long *check = MAGIC_ADDR;
+    if (*check == BOOTLOADER_MAGIC) {
+        *check = 0;
+
+        // For STM32 MCUs with dual-bank flash, and we're incapable of jumping to the bootloader. The first valid flash
+        // bank is executed unconditionally after a reset, so it doesn't enter DFU unless BOOT0 is high. Instead, we do
+        // it with hardware...in this case, we pull a GPIO high/low depending on the configuration, connects 3.3V to
+        // BOOT0's RC charging circuit, lets it charge the capacitor, and issue a system reset. See the QMK discord
+        // #hardware channel pins for an example circuit.
+        palSetPadMode(PAL_PORT(STM32_BOOTLOADER_DUAL_BANK_GPIO), PAL_PAD(STM32_BOOTLOADER_DUAL_BANK_GPIO), PAL_MODE_OUTPUT_PUSHPULL);
+#    if STM32_BOOTLOADER_DUAL_BANK_POLARITY
+        palSetPad(PAL_PORT(STM32_BOOTLOADER_DUAL_BANK_GPIO), PAL_PAD(STM32_BOOTLOADER_DUAL_BANK_GPIO));
+#    else
+        palClearPad(PAL_PORT(STM32_BOOTLOADER_DUAL_BANK_GPIO), PAL_PAD(STM32_BOOTLOADER_DUAL_BANK_GPIO));
+#    endif
+
+        // Wait for a while for the capacitor to charge
+        bootdelay(STM32_BOOTLOADER_DUAL_BANK_DELAY);
+
+        // Issue a system reset to get the ROM bootloader to execute, with BOOT0 high
+        NVIC_SystemReset();
+    }
+}
+
+#elif defined(STM32_BOOTLOADER_ADDRESS)  // STM32_BOOTLOADER_DUAL_BANK
+
+extern uint32_t __ram0_end__;
+
+void bootloader_jump(void) {
+    *MAGIC_ADDR = BOOTLOADER_MAGIC;  // set magic flag => reset handler will jump into boot loader
+    NVIC_SystemReset();
+}
+
 void enter_bootloader_mode_if_requested(void) {
     unsigned long *check = MAGIC_ADDR;
     if (*check == BOOTLOADER_MAGIC) {
@@ -41,7 +95,7 @@ void enter_bootloader_mode_if_requested(void) {
     }
 }
 
-#elif defined(KL2x) || defined(K20x) /* STM32_BOOTLOADER_ADDRESS */
+#elif defined(KL2x) || defined(K20x)  // STM32_BOOTLOADER_DUAL_BANK // STM32_BOOTLOADER_ADDRESS
 /* Kinetis */
 
 #    if defined(KIIBOHD_BOOTLOADER)

--- a/tmk_core/protocol/chibios/main.c
+++ b/tmk_core/protocol/chibios/main.c
@@ -35,6 +35,7 @@
 
 #ifndef EARLY_INIT_PERFORM_BOOTLOADER_JUMP
 // Change this to be TRUE once we've migrated keyboards to the new init system
+// Remember to change docs/platformdev_chibios_earlyinit.md as well.
 #    define EARLY_INIT_PERFORM_BOOTLOADER_JUMP FALSE
 #endif
 


### PR DESCRIPTION
## Description

Adds support for STM32 dual-bank flash bootloaders, by toggling a GPIO during early init in order to charge an RC circuit attached to `BOOT0`.

The main rationale behind this is that dual-bank STM32 devices unconditionally execute user-mode code, regardless of whether or not the user-mode code jumps to the bootloader. If either flash bank is valid (and `BOOT0` is low), then the built-in bootloader will skip any sort of DFU.

This PR allows for the initialisation sequencing to charge the RC circuit based on the example circuit posted on Discord, effectively pulling `BOOT0` high before issuing the system reset. As the RC circuit takes a while to discharge, the system reset executes the ROM bootloader which subsequently sees `BOOT0` high, and starts executing the DFU routines.

Tested with STM32L082 (with current QMK+current ChibiOS), and STM32G474 (against ChibiOS 20.x).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
