### PR TITLE
Improved default layout to match improved layout from configurator PR

### DIFF
--- a/keyboards/keebwerk/nano_slider/keymaps/default/keymap.c
+++ b/keyboards/keebwerk/nano_slider/keymaps/default/keymap.c
@@ -41,7 +41,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [_FN] = LAYOUT(
         TO(_DEMO),
         RGB_TOG, RGB_MOD,  RGB_VAI,
-        QMKURL, RGB_RMOD, RGB_VAD, QMKBEST
+        QMKURL,  RGB_RMOD, RGB_VAD, QMKBEST
     ),
     [_MEDIA] = LAYOUT(
         TO(_BASE),

--- a/keyboards/keebwerk/nano_slider/keymaps/default/keymap.c
+++ b/keyboards/keebwerk/nano_slider/keymaps/default/keymap.c
@@ -39,7 +39,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         KC_4,    KC_5,    KC_6,    KC_0
     ),
     [_FN] = LAYOUT(
-        TO(_DEMO),
+        TO(_MEDIA),
         RGB_TOG, RGB_MOD,  RGB_VAI,
         QMKURL,  RGB_RMOD, RGB_VAD, QMKBEST
     ),

--- a/keyboards/keebwerk/nano_slider/keymaps/default/keymap.c
+++ b/keyboards/keebwerk/nano_slider/keymaps/default/keymap.c
@@ -21,7 +21,7 @@
 enum layer_names {
     _BASE,
     _FN,
-    _DEMO
+    _MEDIA
 };
 
 // Defines the keycodes used by our macros in process_record_user
@@ -29,6 +29,7 @@ enum custom_keycodes {
     QMKBEST = SAFE_RANGE,
     QMKURL
 };
+
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Base */
@@ -39,13 +40,13 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     ),
     [_FN] = LAYOUT(
         TO(_DEMO),
-        RGB_TOG, RGB_MOD, RGB_VAI,
-        _______, _______, _______, _______
+        RGB_TOG, RGB_MOD,  RGB_VAI,
+        QMKURL, RGB_RMOD, RGB_VAD, QMKBEST
     ),
-    [_DEMO] = LAYOUT(
+    [_MEDIA] = LAYOUT(
         TO(_BASE),
-        QMKBEST, _______, _______,
-        _______, _______, _______, QMKURL
+        KC_VOLD, KC_VOLU, KC_F24,
+        KC_MRWD, KC_MFFD, KC_F23, KC_MPLY
     )
 };
 


### PR DESCRIPTION
As mentioned in https://github.com/qmk/qmk_configurator/pull/675 I wanted to update the default layout in qmk_firmware, such that the default layout had a bit more functionality. 

## Description
The change adds some media controls and high F-codes to the renamed media layer. 

The custom keycodes are retained, as I think they serve as a nice jumping off point for people to make their own custom keycodes

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
