### PR TITLE
CLI: Invoke gmake on FreeBSD when using `qmk compile`.

### DIFF
--- a/lib/python/qmk/commands.py
+++ b/lib/python/qmk/commands.py
@@ -28,11 +28,16 @@ def create_make_command(keyboard, keymap, target=None):
         A command that can be run to make the specified keyboard and keymap
     """
     make_args = [keyboard, keymap]
+    make_cmd = 'make'
+
+    platform_id = platform.platform().lower()
+    if 'freebsd' in platform_id:
+        make_cmd = 'gmake'
 
     if target:
         make_args.append(target)
 
-    return ['make', ':'.join(make_args)]
+    return [make_cmd, ':'.join(make_args)]
 
 
 def compile_configurator_json(user_keymap, bootloader=None):

--- a/lib/python/qmk/commands.py
+++ b/lib/python/qmk/commands.py
@@ -5,6 +5,7 @@ import os
 import platform
 import subprocess
 import shlex
+import shutil
 
 import qmk.keymap
 
@@ -28,11 +29,7 @@ def create_make_command(keyboard, keymap, target=None):
         A command that can be run to make the specified keyboard and keymap
     """
     make_args = [keyboard, keymap]
-    make_cmd = 'make'
-
-    platform_id = platform.platform().lower()
-    if 'freebsd' in platform_id:
-        make_cmd = 'gmake'
+    make_cmd = 'gmake' if shutil.which('gmake') else 'make'
 
     if target:
         make_args.append(target)


### PR DESCRIPTION


## Description

Current makefiles aren't portable, so we should invoke gmake on FreeBSD. Arguable, this is likely the same scenario in other BSD variants, but I don't see any install scripts for this in `util/` so it seems safe to only check for FreeBSD here.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Running `qmk compile` on FreeBSD currently fails, lots of errors from "standard make" failing to load the non-portal makefiles.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
