### PR TITLE
Add missing repository name to qmk setup w/ github

### DIFF
--- a/docs/newbs_getting_started.md
+++ b/docs/newbs_getting_started.md
@@ -78,7 +78,7 @@ After installing QMK you can set it up with this command:
 
 In most situations you will want to answer Yes to all of the prompts.
 
-?> If you already know [how to use GitHub](getting_started_github.md), we recommend that you create your own fork and use `qmk setup <github_username>` to clone your personal fork. If you don't know what that means you can safely ignore this message.
+?> If you already know [how to use GitHub](getting_started_github.md), we recommend that you create your own fork and use `qmk setup <github_username>/qmk_firmware` to clone your personal fork. If you don't know what that means you can safely ignore this message.
 
 ## 4. Test Your Build Environment
 


### PR DESCRIPTION
Using just qmk setup <github_username> would fail w/ "Could not find repo github.com/<username>, whereas the repo is actually after another slash after the user name. Can consider changing code to add the default forked repo name if slash is not detected in the arg.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

