### PR TITLE
CLI: Fix doctor error when can't run `bin/qmk --version`.

### DIFF
--- a/lib/python/qmk/cli/doctor.py
+++ b/lib/python/qmk/cli/doctor.py
@@ -191,7 +191,7 @@ def is_executable(command):
         cli.log.debug('Found {fg_cyan}%s', command)
         return True
 
-    cli.log.error("{fg_red}Can't run `%s %s`", (command, version_arg))
+    cli.log.error("{fg_red}Can't run `%s %s`", command, version_arg)
     return False
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Running `qmk setup` on a fresh FreeBSD system results in an error trying to log one of the error messages to the console after failing to run `bin/qmk --version`. It looks like it is attempting to pass a tuple for the arguments, instead of individual arguments to the `error` method for logging.

Stacktrace:

```
--- Logging error ---                                                      
Traceback (most recent call last):                                         
  File "/usr/local/lib/python3.7/logging/__init__.py", line 1025, in emit  
    msg = self.format(record)                                              
  File "/usr/local/lib/python3.7/logging/__init__.py", line 869, in format                                                                            
    return fmt.format(record)                                              
  File "/home/peter/.local/lib/python3.7/site-packages/milc.py", line 111, in format  
    return super(ANSIEmojiLoglevelFormatter, self).format(record)          
  File "/home/peter/.local/lib/python3.7/site-packages/milc.py", line 101, in format   
    msg = super(ANSIFormatter, self).format(record)                        
  File "/usr/local/lib/python3.7/logging/__init__.py", line 608, in format                                                                            
    record.message = record.getMessage()                                   
  File "/usr/local/lib/python3.7/logging/__init__.py", line 369, in getMessage
    msg = msg % self.args                                                  
TypeError: not enough arguments for format string                          
Call stack:                          
  File "/home/peter/qmk_firmware/bin/qmk", line 97, in <module>
    main()                           
  File "/home/peter/qmk_firmware/bin/qmk", line 81, in main
    return_code = milc.cli()                                               
  File "/home/peter/.local/lib/python3.7/site-packages/milc.py", line 592, in __call__
    return self.__call__()           
  File "/home/peter/.local/lib/python3.7/site-packages/milc.py", line 597, in __call__
    return self._entrypoint(self)                                          
  File "/usr/home/peter/qmk_firmware/lib/python/qmk/cli/doctor.py", line 257, in doctor
    bin_ok = check_binaries()                                              
  File "/usr/home/peter/qmk_firmware/lib/python/qmk/cli/doctor.py", line 99, in check_binaries
    if not is_executable(binary):                                          
  File "/usr/home/peter/qmk_firmware/lib/python/qmk/cli/doctor.py", line 194, in is_executable
    cli.log.error("{fg_red}Can't run `%s %s`", (command, version_arg))
Message: "{fg_red}Can't run `%s %s`"                                       
Arguments: (('bin/qmk', '--version'),)
```

One line fix that makes this work as expected:

```
➜  git qmk setup                     
Ψ Found qmk_firmware at /home/peter/qmk_firmware.                                                                                                     
Ψ QMK Doctor is checking your environment.                                 
☒ Unsupported OS detected: freebsd-12.1-release-p3-amd64-64bit-elf                                                                                    
☒ Can't find arm-none-eabi-gcc in your path.                               
☒ Can't find avr-gcc in your path.                                                                                                                    
☒ Can't find avrdude in your path.                                         
☒ Can't run `bin/qmk --version`                                                                                                                       
☒ Can't find dfu-programmer in your path.                                  
☒ Can't find dfu-util in your path.                                                                                                                   
                                                                           
Would you like to install dependencies? [Y/n] n
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fix stacktrace on `qmk setup`

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ x I have tested the changes and verified that they work and don't break anything (as well as I can manage).
