### PR TITLE
CLI: Improve experience when running `qmk setup` on FreeBSD.

### DIFF
--- a/docs/newbs_getting_started.md
+++ b/docs/newbs_getting_started.md
@@ -75,6 +75,18 @@ Install the global CLI to bootstrap your system:
 
   `python3 -m pip install --user qmk` (on Arch-based distros you can also try the `qmk` package from AUR (**note**: it's maintained by a community member): `yay -S qmk`)
 
+### FreeBSD
+
+You will need to install Git and Python. It's possible that you already have both, but if not, run the following commands to install them:
+
+    pkg install git python3
+
+Make sure that `$HOME/.local/bin` is added to your `$PATH` so that locally install Python packages are available.
+
+Once installed, you can install QMK CLI:
+
+    python3 -m pip install --user qmk
+
 ## 3. Run QMK Setup :id=set-up-qmk
 
 After installing QMK you can set it up with this command:
@@ -90,6 +102,16 @@ Sadly, Ubuntu reitroduced this bug and is [yet to fix it](https://bugs.launchpad
 Luckily, the fix is easy. Run this as your user: `echo "PATH=$HOME/.local/bin:$PATH" >> $HOME/.bashrc && source $HOME/.bashrc`
 
 ?> If you already know [how to use GitHub](getting_started_github.md), we recommend that you create your own fork and use `qmk setup <github_username>/qmk_firmware` to clone your personal fork. If you don't know what that means you can safely ignore this message.
+
+### Note on FreeBSD Permissions
+
+It is suggested to run `qmk setup` as a non-`root` user to start with, but this will likely identify that packages need to be isntalled to your
+base system using `pkg`. Although you maybe be prompted to install dependencies, this will likely fail due to running as an unprivileged user. To
+manually install the base dependencies, run the following either as `root`, or with `sudo`:
+
+    ./util/qmk_install.sh
+
+Once that completes, re-run `qmk setup` to complete the setup and checks.
 
 ## 4. Test Your Build Environment
 

--- a/docs/newbs_getting_started.md
+++ b/docs/newbs_getting_started.md
@@ -20,8 +20,8 @@ QMK Toolbox is an optional graphical program for Windows and macOS that allows y
 
 [Download the latest release here.](https://github.com/qmk/qmk_toolbox/releases/latest)
 
--   For Windows: `qmk_toolbox.exe` (portable) or `qmk_toolbox_install.exe` (installer)
--   For macOS: `QMK.Toolbox.app.zip` (portable) or `QMK.Toolbox.pkg` (installer)
+* For Windows: `qmk_toolbox.exe` (portable) or `qmk_toolbox_install.exe` (installer)
+* For macOS: `QMK.Toolbox.app.zip` (portable) or `QMK.Toolbox.pkg` (installer)
 
 ### A Unix-like Environment
 
@@ -41,8 +41,8 @@ We've tried to make QMK as easy to set up as possible. You only have to prepare 
 
 You will need to install MSYS2, Git, and the QMK CLI.
 
--   Follow the installation instructions on the [MSYS2 homepage](http://www.msys2.org).
--   Close any open MSYS2 terminals and open a new MSYS2 MinGW 64-bit terminal. NOTE: This is **not** the same as the MSYS terminal that opens when installation is completed.
+* Follow the installation instructions on the [MSYS2 homepage](http://www.msys2.org).
+* Close any open MSYS2 terminals and open a new MSYS2 MinGW 64-bit terminal. NOTE: This is **not** the same as the MSYS terminal that opens when installation is completed.
 
 After opening a new MSYS2 MinGW 64-bit terminal, make sure `pacman` is up to date with:
 
@@ -66,9 +66,9 @@ After Homebrew is installed run these commands:
 
 You will need to install Git and Python. It's very likely that you already have both, but if not, one of the following commands should install them:
 
--   Debian / Ubuntu / Devuan: `sudo apt install git python3 python3-pip`
--   Fedora / Red Hat / CentOS: `sudo yum install git python3 python3-pip`
--   Arch / Manjaro: `sudo pacman -S git python python-pip python-setuptools libffi`
+* Debian / Ubuntu / Devuan: `sudo apt install git python3 python3-pip`
+* Fedora / Red Hat / CentOS: `sudo yum install git python3 python3-pip`
+* Arch / Manjaro: `sudo pacman -S git python python-pip python-setuptools libffi`
 
 Install the global CLI to bootstrap your system:
 

--- a/docs/newbs_getting_started.md
+++ b/docs/newbs_getting_started.md
@@ -103,7 +103,7 @@ Luckily, the fix is easy. Run this as your user: `echo "PATH=$HOME/.local/bin:$P
 
 ?> If you already know [how to use GitHub](getting_started_github.md), we recommend that you create your own fork and use `qmk setup <github_username>/qmk_firmware` to clone your personal fork. If you don't know what that means you can safely ignore this message.
 
-### Note on FreeBSD Permissions
+### Note on FreeBSD Permissions :id=note-on-freebsd-permissions
 
 It is suggested to run `qmk setup` as a non-`root` user to start with, but this will likely identify that packages need to be isntalled to your
 base system using `pkg`. Although you maybe be prompted to install dependencies, this will likely fail due to running as an unprivileged user. To

--- a/docs/newbs_getting_started.md
+++ b/docs/newbs_getting_started.md
@@ -75,7 +75,7 @@ Install the global CLI to bootstrap your system:
 
   `python3 -m pip install --user qmk` (on Arch-based distros you can also try the `qmk` package from AUR (**note**: it's maintained by a community member): `yay -S qmk`)
 
-### FreeBSD
+### FreeBSD :id=freebsd
 
 You will need to install Git and Python. It's possible that you already have both, but if not, run the following commands to install them:
 

--- a/docs/newbs_getting_started.md
+++ b/docs/newbs_getting_started.md
@@ -20,8 +20,8 @@ QMK Toolbox is an optional graphical program for Windows and macOS that allows y
 
 [Download the latest release here.](https://github.com/qmk/qmk_toolbox/releases/latest)
 
-* For Windows: `qmk_toolbox.exe` (portable) or `qmk_toolbox_install.exe` (installer)
-* For macOS: `QMK.Toolbox.app.zip` (portable) or `QMK.Toolbox.pkg` (installer)
+-   For Windows: `qmk_toolbox.exe` (portable) or `qmk_toolbox_install.exe` (installer)
+-   For macOS: `QMK.Toolbox.app.zip` (portable) or `QMK.Toolbox.pkg` (installer)
 
 ### A Unix-like Environment
 
@@ -41,8 +41,8 @@ We've tried to make QMK as easy to set up as possible. You only have to prepare 
 
 You will need to install MSYS2, Git, and the QMK CLI.
 
-* Follow the installation instructions on the [MSYS2 homepage](http://www.msys2.org).
-* Close any open MSYS2 terminals and open a new MSYS2 MinGW 64-bit terminal. NOTE: This is **not** the same as the MSYS terminal that opens when installation is completed.
+-   Follow the installation instructions on the [MSYS2 homepage](http://www.msys2.org).
+-   Close any open MSYS2 terminals and open a new MSYS2 MinGW 64-bit terminal. NOTE: This is **not** the same as the MSYS terminal that opens when installation is completed.
 
 After opening a new MSYS2 MinGW 64-bit terminal, make sure `pacman` is up to date with:
 
@@ -66,16 +66,15 @@ After Homebrew is installed run these commands:
 
 You will need to install Git and Python. It's very likely that you already have both, but if not, one of the following commands should install them:
 
-* Debian / Ubuntu / Devuan: `sudo apt install git python3 python3-pip`
-* Fedora / Red Hat / CentOS: `sudo yum install git python3 python3-pip`
-* Arch / Manjaro: `sudo pacman -S git python python-pip python-setuptools libffi`
-
+-   Debian / Ubuntu / Devuan: `sudo apt install git python3 python3-pip`
+-   Fedora / Red Hat / CentOS: `sudo yum install git python3 python3-pip`
+-   Arch / Manjaro: `sudo pacman -S git python python-pip python-setuptools libffi`
 
 Install the global CLI to bootstrap your system:
 
-  `python3 -m pip install --user qmk` (on Arch-based distros you can also try the `qmk` package from AUR (**note**: it's maintained by a community member): `yay -S qmk`)
+`python3 -m pip install --user qmk` (on Arch-based distros you can also try the `qmk` package from AUR (**note**: it's maintained by a community member): `yay -S qmk`)
 
-### FreeBSD :id=freebsd
+### FreeBSD
 
 You will need to install Git and Python. It's possible that you already have both, but if not, run the following commands to install them:
 
@@ -101,17 +100,13 @@ This is due to a [bug](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=839155)
 Sadly, Ubuntu reitroduced this bug and is [yet to fix it](https://bugs.launchpad.net/ubuntu/+source/bash/+bug/1588562).
 Luckily, the fix is easy. Run this as your user: `echo "PATH=$HOME/.local/bin:$PATH" >> $HOME/.bashrc && source $HOME/.bashrc`
 
-?> If you already know [how to use GitHub](getting_started_github.md), we recommend that you create your own fork and use `qmk setup <github_username>/qmk_firmware` to clone your personal fork. If you don't know what that means you can safely ignore this message.
-
-### Note on FreeBSD Permissions :id=note-on-freebsd-permissions
-
+?>**Note on FreeBSD**:
 It is suggested to run `qmk setup` as a non-`root` user to start with, but this will likely identify packages that need to be installed to your
-base system using `pkg`. However the installation will probably fail when run as an unprivileged user. To
-manually install the base dependencies, run the following either as `root`, or with `sudo`:
-
-    ./util/qmk_install.sh
-
+base system using `pkg`. However the installation will probably fail when run as an unprivileged user.
+To manually install the base dependencies, run `./util/qmk_install.sh` either as `root`, or with `sudo`.
 Once that completes, re-run `qmk setup` to complete the setup and checks.
+
+?> If you already know [how to use GitHub](getting_started_github.md), we recommend that you create your own fork and use `qmk setup <github_username>/qmk_firmware` to clone your personal fork. If you don't know what that means you can safely ignore this message.
 
 ## 4. Test Your Build Environment
 

--- a/docs/newbs_getting_started.md
+++ b/docs/newbs_getting_started.md
@@ -105,8 +105,8 @@ Luckily, the fix is easy. Run this as your user: `echo "PATH=$HOME/.local/bin:$P
 
 ### Note on FreeBSD Permissions :id=note-on-freebsd-permissions
 
-It is suggested to run `qmk setup` as a non-`root` user to start with, but this will likely identify that packages need to be isntalled to your
-base system using `pkg`. Although you maybe be prompted to install dependencies, this will likely fail due to running as an unprivileged user. To
+It is suggested to run `qmk setup` as a non-`root` user to start with, but this will likely identify packages that need to be installed to your
+base system using `pkg`. However the installation will probably fail when run as an unprivileged user. To
 manually install the base dependencies, run the following either as `root`, or with `sudo`:
 
     ./util/qmk_install.sh

--- a/util/freebsd_install.sh
+++ b/util/freebsd_install.sh
@@ -1,31 +1,39 @@
 #!/bin/sh
+packages=$(cat <<EOF
+	git \
+	wget \
+	gmake \
+	gcc \
+	zip \
+	unzip \
+	avr-binutils \
+	avr-gcc \
+	avr-libc \
+	dfu-programmer \
+	dfu-util \
+	avrdude \
+	arm-none-eabi-gcc \
+	arm-none-eabi-binutils \
+	arm-none-eabi-newlib \
+	diffutils \
+	python3
+EOF
+)
 util_dir=$(dirname "$0")
 if [ $(id -u) = 0 ]; then
 	pkg update
-	pkg install -y \
-		git \
-		wget \
-		gmake \
-		gcc \
-		zip \
-		unzip \
-		avr-binutils \
-		avr-gcc \
-		avr-libc \
-		dfu-programmer \
-		dfu-util \
-		avrdude \
-		arm-none-eabi-gcc \
-		arm-none-eabi-binutils \
-		arm-none-eabi-newlib \
-		diffutils \
-		python3
+	pkg install -y ${packages}
 	echo ""
 	echo "Re-run the setup as your normal user to install the qmk python dependencies"
 	exit 1
 else
-	echo "Make sure you run setup as root first to install base OS dependencies..."
-	echo ""
+	if command -v sudo > /dev/null 2>&1; then
+		sudo pkg update
+		sudp pkg install -y ${packages}
+	else
+		echo "Make sure you run setup as root first to install base OS dependencies..."
+		echo ""
+	fi
 
 	python3 -m pip install --user -r ${util_dir}/../requirements.txt
 fi

--- a/util/freebsd_install.sh
+++ b/util/freebsd_install.sh
@@ -1,21 +1,32 @@
 #!/bin/sh
 util_dir=$(dirname "$0")
-pkg update
-pkg install -y \
-	git \
-	wget \
-	gmake \
-	gcc \
-	zip \
-	unzip \
-	avr-binutils \
-	avr-gcc \
-	avr-libc \
-	dfu-programmer \
-	dfu-util \
-	arm-none-eabi-gcc \
-	arm-none-eabi-binutils \
-	arm-none-eabi-newlib \
-	diffutils \
-	python3
-pip3 install -r ${util_dir}/../requirements.txt
+if [ $(id -u) = 0 ]
+then
+	pkg update
+	pkg install -y \
+		git \
+		wget \
+		gmake \
+		gcc \
+		zip \
+		unzip \
+		avr-binutils \
+		avr-gcc \
+		avr-libc \
+		dfu-programmer \
+		dfu-util \
+		avrdude \
+		arm-none-eabi-gcc \
+		arm-none-eabi-binutils \
+		arm-none-eabi-newlib \
+		diffutils \
+		python3
+	echo ""
+	echo "Re-run the setup as your normal user to install the qmk python dependencies"
+	exit 1
+else
+	echo "Make sure you run setup as root first to install base OS dependencies..."
+	echo ""
+
+	python3 -m pip install --user -r ${util_dir}/../requirements.txt
+fi

--- a/util/freebsd_install.sh
+++ b/util/freebsd_install.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 util_dir=$(dirname "$0")
-if [ $(id -u) = 0 ]
-then
+if [ $(id -u) = 0 ]; then
 	pkg update
 	pkg install -y \
 		git \


### PR DESCRIPTION

## Description

* Install the `avrdude` package as well.
* Switch to installing python packages w/ `--user` flag.
* Basic getting started sections for FreeBSD.
* Update `util/freebsd_install.sh` for root/non-root branches.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [X] Documentation

## Issues Fixed or Closed by This PR

* Currently, after installing QMK with pip, running `qmk setup` does not work properly as a normal user. This MR aims to address most of that pain, while adhering to best practices for FreeBSD, such as using `pip install` with the `--user` flag.
* Install avrdude as well from the FreeBSD install script.
* Missing docs on basic setup w/ FreeBSD.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
