### PR TITLE
Added terminal lock/screensaver key.

### DIFF
--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -207,6 +207,7 @@ See also: [Basic Keycodes](keycodes_basic.md)
 |`KC_MEDIA_REWIND`      |`KC_MRWD`                     |Previous Track (macOS)                         |
 |`KC_BRIGHTNESS_UP`     |`KC_BRIU`                     |Brightness Up                                  |
 |`KC_BRIGHTNESS_DOWN`   |`KC_BRID`                     |Brightness Down                                |
+|`KC_SCREENSAVER`       |`KC_SCSV`                     |Terminal Lock/Screensaver                      |
 
 ## Quantum Keycodes :id=quantum-keycodes
 

--- a/docs/keycodes_basic.md
+++ b/docs/keycodes_basic.md
@@ -221,6 +221,7 @@ These keycodes are not part of the Keyboard/Keypad usage page. The `SYSTEM_` key
 |`KC_MEDIA_REWIND`      |`KC_MRWD`|Previous Track (macOS)       |
 |`KC_BRIGHTNESS_UP`     |`KC_BRIU`|Brightness Up                |
 |`KC_BRIGHTNESS_DOWN`   |`KC_BRID`|Brightness Down              |
+|`KC_SCREENSAVER`       |`KC_SCSV`|Terminal Lock/Screensaver    |
 
 ## Number Pad
 

--- a/quantum/keymap_common.c
+++ b/quantum/keymap_common.c
@@ -64,7 +64,7 @@ action_t action_for_key(uint8_t layer, keypos_t key) {
         case KC_SYSTEM_POWER ... KC_SYSTEM_WAKE:
             action.code = ACTION_USAGE_SYSTEM(KEYCODE2SYSTEM(keycode));
             break;
-        case KC_AUDIO_MUTE ... KC_BRIGHTNESS_DOWN:
+        case KC_AUDIO_MUTE ... KC_SCREENSAVER:
             action.code = ACTION_USAGE_CONSUMER(KEYCODE2CONSUMER(keycode));
             break;
 #endif

--- a/tmk_core/common/keycode.h
+++ b/tmk_core/common/keycode.h
@@ -33,7 +33,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define IS_SPECIAL(code) ((0xA5 <= (code) && (code) <= 0xDF) || (0xE8 <= (code) && (code) <= 0xFF))
 #define IS_SYSTEM(code) (KC_PWR <= (code) && (code) <= KC_WAKE)
-#define IS_CONSUMER(code) (KC_MUTE <= (code) && (code) <= KC_BRID)
+#define IS_CONSUMER(code) (KC_MUTE <= (code) && (code) <= KC_SCSV)
 
 #define IS_FN(code) (KC_FN0 <= (code) && (code) <= KC_FN31)
 
@@ -190,6 +190,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define KC_MRWD KC_MEDIA_REWIND
 #define KC_BRIU KC_BRIGHTNESS_UP
 #define KC_BRID KC_BRIGHTNESS_DOWN
+#define KC_SCSV KC_SCREENSAVER
 
 /* System Specific */
 #define KC_BRMU KC_PAUSE
@@ -483,6 +484,7 @@ enum internal_special_keycodes {
     KC_MEDIA_REWIND,
     KC_BRIGHTNESS_UP,
     KC_BRIGHTNESS_DOWN,
+    KC_SCREENSAVER,
 
     /* Fn keys */
     KC_FN0 = 0xC0,

--- a/tmk_core/common/report.h
+++ b/tmk_core/common/report.h
@@ -247,6 +247,8 @@ static inline uint16_t KEYCODE2CONSUMER(uint8_t key) {
             return BRIGHTNESS_DOWN;
         case KC_WWW_FAVORITES:
             return AC_BOOKMARKS;
+        case KC_SCREENSAVER:
+            return AL_LOCK;
         default:
             return 0;
     }


### PR DESCRIPTION
Added AL Terminal Lock/Screensaver key to QMK keycodes
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This PR adds "AL Terminal Lock/Screensaver" aka KEY_COFFEE/XF86ScreenSaver in Linux kernel and X11.
It seems to only work in Linux (although I haven't tested with MacOS). It just adds a simple keycode at
the end of the QMK keycode table, so it shouldn't break anything, and I tried to update all boundary checks
in necessary places. It doesn't seem to break compilation either. 

<!--- Describe your changes in detail here. -->

## Types of Changes

Not exactly sure whether adding keycode is a change to keymap or to the core, but it seems to be
a minor change, so I'll go for keymap change.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).