### PR TITLE
Clean up ATSAM ifdefs

### DIFF
--- a/tmk_core/protocol/arm_atsam/usb/conf_usb.h
+++ b/tmk_core/protocol/arm_atsam/usb/conf_usb.h
@@ -116,34 +116,32 @@
  * @{
  */
 //! Interface callback definition
-#ifdef KBD
-#    define UDI_HID_KBD_ENABLE_EXT() main_kbd_enable()
-#    define UDI_HID_KBD_DISABLE_EXT() main_kbd_disable()
-//#define  UDI_HID_KBD_CHANGE_LED(value)  ui_kbd_led(value)
-#endif
+#define UDI_HID_KBD_ENABLE_EXT() main_kbd_enable()
+#define UDI_HID_KBD_DISABLE_EXT() main_kbd_disable()
+//#define UDI_HID_KBD_CHANGE_LED(value) ui_kbd_led(value)
 
-#ifdef NKRO
+#ifdef NKRO_ENABLE
 #    define UDI_HID_NKRO_ENABLE_EXT() main_nkro_enable()
 #    define UDI_HID_NKRO_DISABLE_EXT() main_nkro_disable()
-//#define  UDI_HID_NKRO_CHANGE_LED(value)   ui_kbd_led(value)
+//#define UDI_HID_NKRO_CHANGE_LED(value) ui_kbd_led(value)
 #endif
 
-#ifdef EXK
+#ifdef EXTRAKEY_ENABLE
 #    define UDI_HID_EXK_ENABLE_EXT() main_exk_enable()
 #    define UDI_HID_EXK_DISABLE_EXT() main_exk_disable()
 #endif
 
-#ifdef CON
+#ifdef CONSOLE_ENABLE
 #    define UDI_HID_CON_ENABLE_EXT() main_con_enable()
 #    define UDI_HID_CON_DISABLE_EXT() main_con_disable()
 #endif
 
-#ifdef MOU
+#ifdef MOUSE_ENABLE
 #    define UDI_HID_MOU_ENABLE_EXT() main_mou_enable()
 #    define UDI_HID_MOU_DISABLE_EXT() main_mou_disable()
 #endif
 
-#ifdef RAW
+#ifdef RAW_ENABLE
 #    define UDI_HID_RAW_ENABLE_EXT() main_raw_enable()
 #    define UDI_HID_RAW_DISABLE_EXT() main_raw_disable()
 #    define UDI_HID_RAW_RECEIVE(buffer, len) main_raw_receive(buffer, len)

--- a/tmk_core/protocol/arm_atsam/usb/main_usb.c
+++ b/tmk_core/protocol/arm_atsam/usb/main_usb.c
@@ -18,7 +18,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "samd51j18a.h"
 #include "conf_usb.h"
 #include "udd.h"
-#ifdef RAW
+
+#ifdef RAW_ENABLE
 #    include "raw_hid.h"
 #endif
 
@@ -34,7 +35,6 @@ void main_remotewakeup_enable(void) { ui_wakeup_enable(); }
 
 void main_remotewakeup_disable(void) { ui_wakeup_disable(); }
 
-#ifdef KBD
 volatile bool main_b_kbd_enable = false;
 bool          main_kbd_enable(void) {
     main_b_kbd_enable = true;
@@ -42,9 +42,8 @@ bool          main_kbd_enable(void) {
 }
 
 void main_kbd_disable(void) { main_b_kbd_enable = false; }
-#endif
 
-#ifdef NKRO
+#ifdef NKRO_ENABLE
 volatile bool main_b_nkro_enable = false;
 bool          main_nkro_enable(void) {
     main_b_nkro_enable = true;
@@ -54,7 +53,7 @@ bool          main_nkro_enable(void) {
 void main_nkro_disable(void) { main_b_nkro_enable = false; }
 #endif
 
-#ifdef EXK
+#ifdef EXTRAKEY_ENABLE
 volatile bool main_b_exk_enable = false;
 bool          main_exk_enable(void) {
     main_b_exk_enable = true;
@@ -64,7 +63,7 @@ bool          main_exk_enable(void) {
 void main_exk_disable(void) { main_b_exk_enable = false; }
 #endif
 
-#ifdef CON
+#ifdef CONSOLE_ENABLE
 volatile bool main_b_con_enable = false;
 bool          main_con_enable(void) {
     main_b_con_enable = true;
@@ -74,7 +73,7 @@ bool          main_con_enable(void) {
 void main_con_disable(void) { main_b_con_enable = false; }
 #endif
 
-#ifdef MOU
+#ifdef MOUSE_ENABLE
 volatile bool main_b_mou_enable = false;
 bool          main_mou_enable(void) {
     main_b_mou_enable = true;
@@ -84,7 +83,7 @@ bool          main_mou_enable(void) {
 void main_mou_disable(void) { main_b_mou_enable = false; }
 #endif
 
-#ifdef RAW
+#ifdef RAW_ENABLE
 volatile bool main_b_raw_enable = false;
 bool          main_raw_enable(void) {
     main_b_raw_enable = true;

--- a/tmk_core/protocol/arm_atsam/usb/udi_cdc.c
+++ b/tmk_core/protocol/arm_atsam/usb/udi_cdc.c
@@ -57,7 +57,7 @@
 #include "stdarg.h"
 #include "tmk_core/protocol/arm_atsam/clks.h"
 
-#ifdef CDC
+#ifdef VIRTSER_ENABLE
 
 #    ifdef UDI_CDC_LOW_RATE
 #        ifdef USB_DEVICE_HS_SUPPORT

--- a/tmk_core/protocol/arm_atsam/usb/udi_cdc.h
+++ b/tmk_core/protocol/arm_atsam/usb/udi_cdc.h
@@ -47,7 +47,7 @@
 #ifndef _UDI_CDC_H_
 #define _UDI_CDC_H_
 
-#ifdef CDC
+#ifdef VIRTSER_ENABLE
 
 #    include "conf_usb.h"
 #    include "usb_protocol.h"
@@ -346,7 +346,7 @@ typedef struct {
     char     buf[CDC_INBUF_SIZE];
 } inbuf_t;
 
-#else  // CDC
+#else  // VIRTSER_ENABLE
 
 // keep these to accommodate calls if remaining
 #    define CDC_PRINTBUF_SIZE 1
@@ -362,7 +362,7 @@ typedef struct {
 
 extern inbuf_t inbuf;
 
-#endif  // CDC
+#endif  // VIRTSER_ENABLE
 
 uint32_t CDC_print(char* printbuf);
 int      CDC_printf(const char* _Format, ...);

--- a/tmk_core/protocol/arm_atsam/usb/udi_device_conf.h
+++ b/tmk_core/protocol/arm_atsam/usb/udi_device_conf.h
@@ -23,77 +23,36 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "compiler.h"
 #include "usb_protocol_hid.h"
 
-#define DEVICE_CLASS 0
-#define DEVICE_SUBCLASS 0
-#define DEVICE_PROTOCOL 0
-
-#define KBD
-
-//#define MOUSE_ENABLE //rules.mk
-#ifdef MOUSE_ENABLE
-#    define MOU
-#endif
-
-//#define EXTRAKEY_ENABLE //rules.mk
-#ifdef EXTRAKEY_ENABLE
-#    define EXK
-#endif
-
-//#define RAW_ENABLE //rules.mk
-#ifdef RAW_ENABLE
-#    define RAW
-#endif
-
-//#define CONSOLE_ENABLE //rules.mk
-#ifdef CONSOLE_ENABLE
-#    define CON
-#endif
-
-//#define NKRO_ENABLE //rules.mk
-#ifdef NKRO_ENABLE
-#    define NKRO
-#endif
-
-//#define MIDI_ENABLE //deferred implementation
-//#ifdef MIDI_ENABLE
-//#define MIDI
-//#endif
-
-//#define VIRTSER_ENABLE //rules.mk
 #ifdef VIRTSER_ENABLE
-#    define CDC
 // because CDC uses IAD (interface association descriptor
 // per USB Interface Association Descriptor Device Class Code and Use Model 7/23/2003 Rev 1.0)
-#    undef DEVICE_CLASS
 #    define DEVICE_CLASS 0xEF
-#    undef DEVICE_SUBCLASS
 #    define DEVICE_SUBCLASS 0x02
-#    undef DEVICE_PROTOCOL
 #    define DEVICE_PROTOCOL 0x01
+#else
+#    define DEVICE_CLASS 0x00
+#    define DEVICE_SUBCLASS 0x00
+#    define DEVICE_PROTOCOL 0x00
 #endif
 
 /* number of interfaces */
 #define NEXT_INTERFACE_0 0
 
-#ifdef KBD
-#    define KEYBOARD_INTERFACE NEXT_INTERFACE_0
-#    define NEXT_INTERFACE_1 (KEYBOARD_INTERFACE + 1)
-#    define UDI_HID_KBD_IFACE_NUMBER KEYBOARD_INTERFACE
-#else
-#    define NEXT_INTERFACE_1 NEXT_INTERFACE_0
-#endif
+#define KEYBOARD_INTERFACE NEXT_INTERFACE_0
+#define NEXT_INTERFACE_1 (KEYBOARD_INTERFACE + 1)
+#define UDI_HID_KBD_IFACE_NUMBER KEYBOARD_INTERFACE
 
 // It is important that the Raw HID interface is at a constant
 // interface number, to support Linux/OSX platforms and chrome.hid
 // If Raw HID is enabled, let it be always 1.
-#ifdef RAW
+#ifdef RAW_ENABLE
 #    define RAW_INTERFACE NEXT_INTERFACE_1
 #    define NEXT_INTERFACE_2 (RAW_INTERFACE + 1)
 #else
 #    define NEXT_INTERFACE_2 NEXT_INTERFACE_1
 #endif
 
-#ifdef MOU
+#ifdef MOUSE_ENABLE
 #    define MOUSE_INTERFACE NEXT_INTERFACE_2
 #    define UDI_HID_MOU_IFACE_NUMBER MOUSE_INTERFACE
 #    define NEXT_INTERFACE_3 (MOUSE_INTERFACE + 1)
@@ -101,7 +60,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    define NEXT_INTERFACE_3 NEXT_INTERFACE_2
 #endif
 
-#ifdef EXK
+#ifdef EXTRAKEY_ENABLE
 #    define EXTRAKEY_INTERFACE NEXT_INTERFACE_3
 #    define NEXT_INTERFACE_4 (EXTRAKEY_INTERFACE + 1)
 #    define UDI_HID_EXK_IFACE_NUMBER EXTRAKEY_INTERFACE
@@ -109,7 +68,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    define NEXT_INTERFACE_4 NEXT_INTERFACE_3
 #endif
 
-#ifdef CON
+#ifdef CONSOLE_ENABLE
 #    define CON_INTERFACE NEXT_INTERFACE_4
 #    define NEXT_INTERFACE_5 (CON_INTERFACE + 1)
 #    define UDI_HID_CON_IFACE_NUMBER CON_INTERFACE
@@ -117,7 +76,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    define NEXT_INTERFACE_5 NEXT_INTERFACE_4
 #endif
 
-#ifdef NKRO
+#ifdef NKRO_ENABLE
 #    define NKRO_INTERFACE NEXT_INTERFACE_5
 #    define NEXT_INTERFACE_6 (NKRO_INTERFACE + 1)
 #    define UDI_HID_NKRO_IFACE_NUMBER NKRO_INTERFACE
@@ -125,7 +84,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    define NEXT_INTERFACE_6 NEXT_INTERFACE_5
 #endif
 
-#ifdef MIDI
+#ifdef MIDI_ENABLE
 #    define AC_INTERFACE NEXT_INTERFACE_6
 #    define AS_INTERFACE (AC_INTERFACE + 1)
 #    define NEXT_INTERFACE_7 (AS_INTERFACE + 1)
@@ -133,7 +92,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    define NEXT_INTERFACE_7 NEXT_INTERFACE_6
 #endif
 
-#ifdef CDC
+#ifdef VIRTSER_ENABLE
 #    define CCI_INTERFACE NEXT_INTERFACE_7
 #    define CDI_INTERFACE (CCI_INTERFACE + 1)
 #    define NEXT_INTERFACE_8 (CDI_INTERFACE + 1)
@@ -155,20 +114,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define NEXT_IN_EPNUM_0 1
 #define NEXT_OUT_EPNUM_0 1
 
-#ifdef KBD
-#    define KEYBOARD_IN_EPNUM NEXT_IN_EPNUM_0
-#    define UDI_HID_KBD_EP_IN KEYBOARD_IN_EPNUM
-#    define NEXT_IN_EPNUM_1 (KEYBOARD_IN_EPNUM + 1)
-#    define UDI_HID_KBD_EP_SIZE KEYBOARD_EPSIZE
-#    define KBD_POLLING_INTERVAL 10
-#    ifndef UDI_HID_KBD_STRING_ID
-#        define UDI_HID_KBD_STRING_ID 0
-#    endif
-#else
-#    define NEXT_IN_EPNUM_1 NEXT_IN_EPNUM_0
+#define KEYBOARD_IN_EPNUM NEXT_IN_EPNUM_0
+#define UDI_HID_KBD_EP_IN KEYBOARD_IN_EPNUM
+#define NEXT_IN_EPNUM_1 (KEYBOARD_IN_EPNUM + 1)
+#define UDI_HID_KBD_EP_SIZE KEYBOARD_EPSIZE
+#define KBD_POLLING_INTERVAL 10
+#ifndef UDI_HID_KBD_STRING_ID
+#    define UDI_HID_KBD_STRING_ID 0
 #endif
 
-#ifdef MOU
+#ifdef MOUSE_ENABLE
 #    define MOUSE_IN_EPNUM NEXT_IN_EPNUM_1
 #    define NEXT_IN_EPNUM_2 (MOUSE_IN_EPNUM + 1)
 #    define UDI_HID_MOU_EP_IN MOUSE_IN_EPNUM
@@ -181,7 +136,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    define NEXT_IN_EPNUM_2 NEXT_IN_EPNUM_1
 #endif
 
-#ifdef EXK
+#ifdef EXTRAKEY_ENABLE
 #    define EXTRAKEY_IN_EPNUM NEXT_IN_EPNUM_2
 #    define UDI_HID_EXK_EP_IN EXTRAKEY_IN_EPNUM
 #    define NEXT_IN_EPNUM_3 (EXTRAKEY_IN_EPNUM + 1)
@@ -194,7 +149,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    define NEXT_IN_EPNUM_3 NEXT_IN_EPNUM_2
 #endif
 
-#ifdef RAW
+#ifdef RAW_ENABLE
 #    define RAW_IN_EPNUM NEXT_IN_EPNUM_3
 #    define UDI_HID_RAW_EP_IN RAW_IN_EPNUM
 #    define NEXT_IN_EPNUM_4 (RAW_IN_EPNUM + 1)
@@ -210,7 +165,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    define NEXT_OUT_EPNUM_1 NEXT_OUT_EPNUM_0
 #endif
 
-#ifdef CON
+#ifdef CONSOLE_ENABLE
 #    define CON_IN_EPNUM NEXT_IN_EPNUM_4
 #    define UDI_HID_CON_EP_IN CON_IN_EPNUM
 #    define NEXT_IN_EPNUM_5 (CON_IN_EPNUM + 1)
@@ -226,7 +181,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    define NEXT_OUT_EPNUM_2 NEXT_OUT_EPNUM_1
 #endif
 
-#ifdef NKRO
+#ifdef NKRO_ENABLE
 #    define NKRO_IN_EPNUM NEXT_IN_EPNUM_5
 #    define UDI_HID_NKRO_EP_IN NKRO_IN_EPNUM
 #    define NEXT_IN_EPNUM_6 (NKRO_IN_EPNUM + 1)
@@ -239,7 +194,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    define NEXT_IN_EPNUM_6 NEXT_IN_EPNUM_5
 #endif
 
-#ifdef MIDI
+#ifdef MIDI_ENABLE
 #    define MIDI_STREAM_IN_EPNUM NEXT_IN_EPNUM_6
 #    define NEXT_IN_EPNUM_7 (MIDI_STREAM_IN_EPNUM + 1)
 #    define MIDI_STREAM_OUT_EPNUM NEXT_OUT_EPNUM_2
@@ -250,7 +205,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    define NEXT_OUT_EPNUM_3 NEXT_OUT_EPNUM_2
 #endif
 
-#ifdef CDC
+#ifdef VIRTSER_ENABLE
 #    define CDC_NOTIFICATION_EPNUM NEXT_IN_EPNUM_7
 #    define CDC_ACM_ENDPOINT CDC_NOTIFICATION_EPNUM
 #    define CDC_TX_ENDPOINT (CDC_NOTIFICATION_EPNUM + 1)
@@ -285,8 +240,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // **********************************************************************
 // KBD Descriptor structure and content
 // **********************************************************************
-#ifdef KBD
-
 COMPILER_PACK_SET(1)
 
 typedef struct {
@@ -299,8 +252,40 @@ typedef struct {
     uint8_t array[59];
 } udi_hid_kbd_report_desc_t;
 
-#    define UDI_HID_KBD_DESC \
-        { .iface.bLength = sizeof(usb_iface_desc_t), .iface.bDescriptorType = USB_DT_INTERFACE, .iface.bInterfaceNumber = UDI_HID_KBD_IFACE_NUMBER, .iface.bAlternateSetting = 0, .iface.bNumEndpoints = 1, .iface.bInterfaceClass = HID_CLASS, .iface.bInterfaceSubClass = HID_SUB_CLASS_BOOT, .iface.bInterfaceProtocol = HID_PROTOCOL_KEYBOARD, .iface.iInterface = UDI_HID_KBD_STRING_ID, .hid.bLength = sizeof(usb_hid_descriptor_t), .hid.bDescriptorType = USB_DT_HID, .hid.bcdHID = LE16(USB_HID_BDC_V1_11), .hid.bCountryCode = USB_HID_NO_COUNTRY_CODE, .hid.bNumDescriptors = USB_HID_NUM_DESC, .hid.bRDescriptorType = USB_DT_HID_REPORT, .hid.wDescriptorLength = LE16(sizeof(udi_hid_kbd_report_desc_t)), .ep.bLength = sizeof(usb_ep_desc_t), .ep.bDescriptorType = USB_DT_ENDPOINT, .ep.bEndpointAddress = UDI_HID_KBD_EP_IN | USB_EP_DIR_IN, .ep.bmAttributes = USB_EP_TYPE_INTERRUPT, .ep.wMaxPacketSize = LE16(UDI_HID_KBD_EP_SIZE), .ep.bInterval = KBD_POLLING_INTERVAL, }
+// clang-format off
+
+#    define UDI_HID_KBD_DESC { \
+    .iface = { \
+        .bLength = sizeof(usb_iface_desc_t), \
+        .bDescriptorType = USB_DT_INTERFACE, \
+        .bInterfaceNumber = UDI_HID_KBD_IFACE_NUMBER, \
+        .bAlternateSetting = 0, \
+        .bNumEndpoints = 1, \
+        .bInterfaceClass = HID_CLASS, \
+        .bInterfaceSubClass = HID_SUB_CLASS_BOOT, \
+        .bInterfaceProtocol = HID_PROTOCOL_KEYBOARD, \
+        .iInterface = UDI_HID_KBD_STRING_ID, \
+    }, \
+    .hid = { \
+        .bLength = sizeof(usb_hid_descriptor_t), \
+        .bDescriptorType = USB_DT_HID, \
+        .bcdHID = LE16(USB_HID_BDC_V1_11), \
+        .bCountryCode = USB_HID_NO_COUNTRY_CODE, \
+        .bNumDescriptors = USB_HID_NUM_DESC, \
+        .bRDescriptorType = USB_DT_HID_REPORT, \
+        .wDescriptorLength = LE16(sizeof(udi_hid_kbd_report_desc_t)), \
+    }, \
+    .ep = { \
+        .bLength = sizeof(usb_ep_desc_t), \
+        .bDescriptorType = USB_DT_ENDPOINT, \
+        .bEndpointAddress = UDI_HID_KBD_EP_IN | USB_EP_DIR_IN, \
+        .bmAttributes = USB_EP_TYPE_INTERRUPT, \
+        .wMaxPacketSize = LE16(UDI_HID_KBD_EP_SIZE), \
+        .bInterval = KBD_POLLING_INTERVAL \
+    } \
+}
+
+// clang-format on
 
 // set report buffer (from host)
 extern uint8_t udi_hid_kbd_report_set;
@@ -311,12 +296,10 @@ extern uint8_t udi_hid_kbd_report[UDI_HID_KBD_REPORT_SIZE];
 
 COMPILER_PACK_RESET()
 
-#endif  // KBD
-
 // **********************************************************************
 // EXK Descriptor structure and content
 // **********************************************************************
-#ifdef EXK
+#ifdef EXTRAKEY_ENABLE
 
 COMPILER_PACK_SET(1)
 
@@ -330,8 +313,40 @@ typedef struct {
     uint8_t array[50];
 } udi_hid_exk_report_desc_t;
 
-#    define UDI_HID_EXK_DESC \
-        { .iface.bLength = sizeof(usb_iface_desc_t), .iface.bDescriptorType = USB_DT_INTERFACE, .iface.bInterfaceNumber = UDI_HID_EXK_IFACE_NUMBER, .iface.bAlternateSetting = 0, .iface.bNumEndpoints = 1, .iface.bInterfaceClass = HID_CLASS, .iface.bInterfaceSubClass = HID_SUB_CLASS_BOOT, .iface.bInterfaceProtocol = HID_PROTOCOL_GENERIC, .iface.iInterface = UDI_HID_EXK_STRING_ID, .hid.bLength = sizeof(usb_hid_descriptor_t), .hid.bDescriptorType = USB_DT_HID, .hid.bcdHID = LE16(USB_HID_BDC_V1_11), .hid.bCountryCode = USB_HID_NO_COUNTRY_CODE, .hid.bNumDescriptors = USB_HID_NUM_DESC, .hid.bRDescriptorType = USB_DT_HID_REPORT, .hid.wDescriptorLength = LE16(sizeof(udi_hid_exk_report_desc_t)), .ep.bLength = sizeof(usb_ep_desc_t), .ep.bDescriptorType = USB_DT_ENDPOINT, .ep.bEndpointAddress = UDI_HID_EXK_EP_IN | USB_EP_DIR_IN, .ep.bmAttributes = USB_EP_TYPE_INTERRUPT, .ep.wMaxPacketSize = LE16(UDI_HID_EXK_EP_SIZE), .ep.bInterval = EXTRAKEY_POLLING_INTERVAL, }
+// clang-format off
+
+#    define UDI_HID_EXK_DESC { \
+    .iface = { \
+        .bLength = sizeof(usb_iface_desc_t), \
+        .bDescriptorType = USB_DT_INTERFACE, \
+        .bInterfaceNumber = UDI_HID_EXK_IFACE_NUMBER, \
+        .bAlternateSetting = 0, \
+        .bNumEndpoints = 1, \
+        .bInterfaceClass = HID_CLASS, \
+        .bInterfaceSubClass = HID_SUB_CLASS_BOOT, \
+        .bInterfaceProtocol = HID_PROTOCOL_GENERIC, \
+        .iInterface = UDI_HID_EXK_STRING_ID \
+    }, \
+    .hid = { \
+        .bLength = sizeof(usb_hid_descriptor_t), \
+        .bDescriptorType = USB_DT_HID, \
+        .bcdHID = LE16(USB_HID_BDC_V1_11), \
+        .bCountryCode = USB_HID_NO_COUNTRY_CODE, \
+        .bNumDescriptors = USB_HID_NUM_DESC, \
+        .bRDescriptorType = USB_DT_HID_REPORT, \
+        .wDescriptorLength = LE16(sizeof(udi_hid_exk_report_desc_t)) \
+    }, \
+    .ep = { \
+        .bLength = sizeof(usb_ep_desc_t), \
+        .bDescriptorType = USB_DT_ENDPOINT, \
+        .bEndpointAddress = UDI_HID_EXK_EP_IN | USB_EP_DIR_IN, \
+        .bmAttributes = USB_EP_TYPE_INTERRUPT, \
+        .wMaxPacketSize = LE16(UDI_HID_EXK_EP_SIZE), \
+        .bInterval = EXTRAKEY_POLLING_INTERVAL \
+    } \
+}
+
+// clang-format on
 
 // set report buffer (from host)
 extern uint8_t udi_hid_exk_report_set;
@@ -351,12 +366,12 @@ extern udi_hid_exk_report_t udi_hid_exk_report;
 
 COMPILER_PACK_RESET()
 
-#endif  // EXK
+#endif  // EXTRAKEY_ENABLE
 
 // **********************************************************************
 // NKRO Descriptor structure and content
 // **********************************************************************
-#ifdef NKRO
+#ifdef NKRO_ENABLE
 
 COMPILER_PACK_SET(1)
 
@@ -370,8 +385,40 @@ typedef struct {
     uint8_t array[57];
 } udi_hid_nkro_report_desc_t;
 
-#    define UDI_HID_NKRO_DESC \
-        { .iface.bLength = sizeof(usb_iface_desc_t), .iface.bDescriptorType = USB_DT_INTERFACE, .iface.bInterfaceNumber = UDI_HID_NKRO_IFACE_NUMBER, .iface.bAlternateSetting = 0, .iface.bNumEndpoints = 1, .iface.bInterfaceClass = HID_CLASS, .iface.bInterfaceSubClass = HID_SUB_CLASS_NOBOOT, .iface.bInterfaceProtocol = HID_PROTOCOL_KEYBOARD, .iface.iInterface = UDI_HID_NKRO_STRING_ID, .hid.bLength = sizeof(usb_hid_descriptor_t), .hid.bDescriptorType = USB_DT_HID, .hid.bcdHID = LE16(USB_HID_BDC_V1_11), .hid.bCountryCode = USB_HID_NO_COUNTRY_CODE, .hid.bNumDescriptors = USB_HID_NUM_DESC, .hid.bRDescriptorType = USB_DT_HID_REPORT, .hid.wDescriptorLength = LE16(sizeof(udi_hid_nkro_report_desc_t)), .ep.bLength = sizeof(usb_ep_desc_t), .ep.bDescriptorType = USB_DT_ENDPOINT, .ep.bEndpointAddress = UDI_HID_NKRO_EP_IN | USB_EP_DIR_IN, .ep.bmAttributes = USB_EP_TYPE_INTERRUPT, .ep.wMaxPacketSize = LE16(UDI_HID_NKRO_EP_SIZE), .ep.bInterval = NKRO_POLLING_INTERVAL, }
+// clang-format off
+
+#    define UDI_HID_NKRO_DESC { \
+    .iface = { \
+        .bLength = sizeof(usb_iface_desc_t), \
+        .bDescriptorType = USB_DT_INTERFACE, \
+        .bInterfaceNumber = UDI_HID_NKRO_IFACE_NUMBER, \
+        .bAlternateSetting = 0, \
+        .bNumEndpoints = 1, \
+        .bInterfaceClass = HID_CLASS, \
+        .bInterfaceSubClass = HID_SUB_CLASS_NOBOOT, \
+        .bInterfaceProtocol = HID_PROTOCOL_KEYBOARD, \
+        .iInterface = UDI_HID_NKRO_STRING_ID \
+    }, \
+    .hid = { \
+        .bLength = sizeof(usb_hid_descriptor_t), \
+        .bDescriptorType = USB_DT_HID, \
+        .bcdHID = LE16(USB_HID_BDC_V1_11), \
+        .bCountryCode = USB_HID_NO_COUNTRY_CODE, \
+        .bNumDescriptors = USB_HID_NUM_DESC, \
+        .bRDescriptorType = USB_DT_HID_REPORT, \
+        .wDescriptorLength = LE16(sizeof(udi_hid_nkro_report_desc_t)) \
+    }, \
+    .ep = { \
+        .bLength = sizeof(usb_ep_desc_t), \
+        .bDescriptorType = USB_DT_ENDPOINT, \
+        .bEndpointAddress = UDI_HID_NKRO_EP_IN | USB_EP_DIR_IN, \
+        .bmAttributes = USB_EP_TYPE_INTERRUPT, \
+        .wMaxPacketSize = LE16(UDI_HID_NKRO_EP_SIZE), \
+        .bInterval = NKRO_POLLING_INTERVAL \
+    } \
+}
+
+// clang-format on
 
 // set report buffer
 extern uint8_t udi_hid_nkro_report_set;
@@ -382,12 +429,12 @@ extern uint8_t udi_hid_nkro_report[UDI_HID_NKRO_REPORT_SIZE];
 
 COMPILER_PACK_RESET()
 
-#endif  // NKRO
+#endif  // NKRO_ENABLE
 
 // **********************************************************************
 // MOU Descriptor structure and content
 // **********************************************************************
-#ifdef MOU
+#ifdef MOUSE_ENABLE
 
 COMPILER_PACK_SET(1)
 
@@ -401,10 +448,40 @@ typedef struct {
     uint8_t array[77];  // MOU PDS
 } udi_hid_mou_report_desc_t;
 
-#    define UDI_HID_MOU_DESC \
-        { .iface.bLength = sizeof(usb_iface_desc_t), .iface.bDescriptorType = USB_DT_INTERFACE, .iface.bInterfaceNumber = MOUSE_INTERFACE, .iface.bAlternateSetting = 0, .iface.bNumEndpoints = 1, .iface.bInterfaceClass = HID_CLASS, .iface.bInterfaceSubClass = HID_SUB_CLASS_BOOT, .iface.bInterfaceProtocol = HID_PROTOCOL_MOUSE, .iface.iInterface = UDI_HID_MOU_STRING_ID, .hid.bLength = sizeof(usb_hid_descriptor_t), .hid.bDescriptorType = USB_DT_HID, .hid.bcdHID = LE16(USB_HID_BDC_V1_11), .hid.bCountryCode = USB_HID_NO_COUNTRY_CODE, .hid.bNumDescriptors = USB_HID_NUM_DESC, .hid.bRDescriptorType = USB_DT_HID_REPORT, .hid.wDescriptorLength = LE16(sizeof(udi_hid_mou_report_desc_t)), .ep.bLength = sizeof(usb_ep_desc_t), .ep.bDescriptorType = USB_DT_ENDPOINT, .ep.bEndpointAddress = UDI_HID_MOU_EP_IN | USB_EP_DIR_IN, .ep.bmAttributes = USB_EP_TYPE_INTERRUPT, .ep.wMaxPacketSize = LE16(UDI_HID_MOU_EP_SIZE), .ep.bInterval = MOU_POLLING_INTERVAL, }
+// clang-format off
 
-// no set report buffer
+#    define UDI_HID_MOU_DESC { \
+    .iface = { \
+        .bLength = sizeof(usb_iface_desc_t), \
+        .bDescriptorType = USB_DT_INTERFACE, \
+        .bInterfaceNumber = MOUSE_INTERFACE, \
+        .bAlternateSetting = 0, \
+        .bNumEndpoints = 1, \
+        .bInterfaceClass = HID_CLASS, \
+        .bInterfaceSubClass = HID_SUB_CLASS_BOOT, \
+        .bInterfaceProtocol = HID_PROTOCOL_MOUSE, \
+        .iInterface = UDI_HID_MOU_STRING_ID \
+    }, \
+    .hid = { \
+        .bLength = sizeof(usb_hid_descriptor_t), \
+        .bDescriptorType = USB_DT_HID, \
+        .bcdHID = LE16(USB_HID_BDC_V1_11), \
+        .bCountryCode = USB_HID_NO_COUNTRY_CODE, \
+        .bNumDescriptors = USB_HID_NUM_DESC, \
+        .bRDescriptorType = USB_DT_HID_REPORT, \
+        .wDescriptorLength = LE16(sizeof(udi_hid_mou_report_desc_t)) \
+    }, \
+    .ep = { \
+        .bLength = sizeof(usb_ep_desc_t), \
+        .bDescriptorType = USB_DT_ENDPOINT, \
+        .bEndpointAddress = UDI_HID_MOU_EP_IN | USB_EP_DIR_IN, \
+        .bmAttributes = USB_EP_TYPE_INTERRUPT, \
+        .wMaxPacketSize = LE16(UDI_HID_MOU_EP_SIZE), \
+        .bInterval = MOU_POLLING_INTERVAL \
+    } \
+}
+
+// clang-format on
 
 // report buffer
 #    define UDI_HID_MOU_REPORT_SIZE 5  // MOU PDS
@@ -412,12 +489,12 @@ extern uint8_t udi_hid_mou_report[UDI_HID_MOU_REPORT_SIZE];
 
 COMPILER_PACK_RESET()
 
-#endif  // MOU
+#endif  // MOUSE_ENABLE
 
 // **********************************************************************
 // RAW Descriptor structure and content
 // **********************************************************************
-#ifdef RAW
+#ifdef RAW_ENABLE
 
 COMPILER_PACK_SET(1)
 
@@ -432,11 +509,48 @@ typedef struct {
     uint8_t array[26];
 } udi_hid_raw_report_desc_t;
 
-#    define UDI_HID_RAW_DESC                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           \
-        {                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              \
-            .iface.bLength = sizeof(usb_iface_desc_t), .iface.bDescriptorType = USB_DT_INTERFACE, .iface.bInterfaceNumber = RAW_INTERFACE, .iface.bAlternateSetting = 0, .iface.bNumEndpoints = 2, .iface.bInterfaceClass = HID_CLASS, .iface.bInterfaceSubClass = HID_SUB_CLASS_NOBOOT, .iface.bInterfaceProtocol = HID_SUB_CLASS_NOBOOT, .iface.iInterface = UDI_HID_RAW_STRING_ID, .hid.bLength = sizeof(usb_hid_descriptor_t), .hid.bDescriptorType = USB_DT_HID, .hid.bcdHID = LE16(USB_HID_BDC_V1_11), .hid.bCountryCode = USB_HID_NO_COUNTRY_CODE, .hid.bNumDescriptors = USB_HID_NUM_DESC, .hid.bRDescriptorType = USB_DT_HID_REPORT, .hid.wDescriptorLength = LE16(sizeof(udi_hid_raw_report_desc_t)), .ep_out.bLength = sizeof(usb_ep_desc_t), .ep_out.bDescriptorType = USB_DT_ENDPOINT, .ep_out.bEndpointAddress = UDI_HID_RAW_EP_OUT | USB_EP_DIR_OUT, .ep_out.bmAttributes = USB_EP_TYPE_INTERRUPT, .ep_out.wMaxPacketSize = LE16(RAW_EPSIZE), .ep_out.bInterval = RAW_POLLING_INTERVAL, \
-            .ep_in.bLength = sizeof(usb_ep_desc_t), .ep_in.bDescriptorType = USB_DT_ENDPOINT, .ep_in.bEndpointAddress = UDI_HID_RAW_EP_IN | USB_EP_DIR_IN, .ep_in.bmAttributes = USB_EP_TYPE_INTERRUPT, .ep_in.wMaxPacketSize = LE16(RAW_EPSIZE), .ep_in.bInterval = RAW_POLLING_INTERVAL,                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             \
-        }
+// clang-format off
+
+#    define UDI_HID_RAW_DESC { \
+    .iface = { \
+        .bLength = sizeof(usb_iface_desc_t), \
+        .bDescriptorType = USB_DT_INTERFACE, \
+        .bInterfaceNumber = RAW_INTERFACE, \
+        .bAlternateSetting = 0, \
+        .bNumEndpoints = 2, \
+        .bInterfaceClass = HID_CLASS, \
+        .bInterfaceSubClass = HID_SUB_CLASS_NOBOOT, \
+        .bInterfaceProtocol = HID_SUB_CLASS_NOBOOT, \
+        .iInterface = UDI_HID_RAW_STRING_ID \
+    }, \
+    .hid = { \
+        .bLength = sizeof(usb_hid_descriptor_t), \
+        .bDescriptorType = USB_DT_HID, \
+        .bcdHID = LE16(USB_HID_BDC_V1_11), \
+        .bCountryCode = USB_HID_NO_COUNTRY_CODE, \
+        .bNumDescriptors = USB_HID_NUM_DESC, \
+        .bRDescriptorType = USB_DT_HID_REPORT, \
+        .wDescriptorLength = LE16(sizeof(udi_hid_raw_report_desc_t)) \
+    }, \
+    .ep_out = { \
+        .bLength = sizeof(usb_ep_desc_t), \
+        .bDescriptorType = USB_DT_ENDPOINT, \
+        .bEndpointAddress = UDI_HID_RAW_EP_OUT | USB_EP_DIR_OUT, \
+        .bmAttributes = USB_EP_TYPE_INTERRUPT, \
+        .wMaxPacketSize = LE16(RAW_EPSIZE), \
+        .bInterval = RAW_POLLING_INTERVAL \
+    }, \
+    .ep_in = { \
+        .bLength = sizeof(usb_ep_desc_t), \
+        .bDescriptorType = USB_DT_ENDPOINT, \
+        .bEndpointAddress = UDI_HID_RAW_EP_IN | USB_EP_DIR_IN, \
+        .bmAttributes = USB_EP_TYPE_INTERRUPT, \
+        .wMaxPacketSize = LE16(RAW_EPSIZE), \
+        .bInterval = RAW_POLLING_INTERVAL \
+    } \
+}
+
+// clang-format on
 
 #    define UDI_HID_RAW_REPORT_SIZE RAW_EPSIZE
 
@@ -447,12 +561,12 @@ extern uint8_t udi_hid_raw_report[UDI_HID_RAW_REPORT_SIZE];
 
 COMPILER_PACK_RESET()
 
-#endif  // RAW
+#endif  // RAW_ENABLE
 
 // **********************************************************************
 // CON Descriptor structure and content
 // **********************************************************************
-#ifdef CON
+#ifdef CONSOLE_ENABLE
 
 COMPILER_PACK_SET(1)
 
@@ -467,11 +581,48 @@ typedef struct {
     uint8_t array[34];
 } udi_hid_con_report_desc_t;
 
-#    define UDI_HID_CON_DESC                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          \
-        {                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             \
-            .iface.bLength = sizeof(usb_iface_desc_t), .iface.bDescriptorType = USB_DT_INTERFACE, .iface.bInterfaceNumber = UDI_HID_CON_IFACE_NUMBER, .iface.bAlternateSetting = 0, .iface.bNumEndpoints = 2, .iface.bInterfaceClass = HID_CLASS, .iface.bInterfaceSubClass = HID_SUB_CLASS_NOBOOT, .iface.bInterfaceProtocol = HID_SUB_CLASS_NOBOOT, .iface.iInterface = UDI_HID_CON_STRING_ID, .hid.bLength = sizeof(usb_hid_descriptor_t), .hid.bDescriptorType = USB_DT_HID, .hid.bcdHID = LE16(USB_HID_BDC_V1_11), .hid.bCountryCode = USB_HID_NO_COUNTRY_CODE, .hid.bNumDescriptors = USB_HID_NUM_DESC, .hid.bRDescriptorType = USB_DT_HID_REPORT, .hid.wDescriptorLength = LE16(sizeof(udi_hid_con_report_desc_t)), .ep_out.bLength = sizeof(usb_ep_desc_t), .ep_out.bDescriptorType = USB_DT_ENDPOINT, .ep_out.bEndpointAddress = UDI_HID_CON_EP_OUT | USB_EP_DIR_OUT, .ep_out.bmAttributes = USB_EP_TYPE_INTERRUPT, .ep_out.wMaxPacketSize = LE16(CONSOLE_EPSIZE), .ep_out.bInterval = CON_POLLING_INTERVAL, \
-            .ep_in.bLength = sizeof(usb_ep_desc_t), .ep_in.bDescriptorType = USB_DT_ENDPOINT, .ep_in.bEndpointAddress = UDI_HID_CON_EP_IN | USB_EP_DIR_IN, .ep_in.bmAttributes = USB_EP_TYPE_INTERRUPT, .ep_in.wMaxPacketSize = LE16(CONSOLE_EPSIZE), .ep_in.bInterval = CON_POLLING_INTERVAL,                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        \
-        }
+// clang-format off
+
+#    define UDI_HID_CON_DESC { \
+    .iface = { \
+        .bLength = sizeof(usb_iface_desc_t), \
+        .bDescriptorType = USB_DT_INTERFACE, \
+        .bInterfaceNumber = UDI_HID_CON_IFACE_NUMBER, \
+        .bAlternateSetting = 0, \
+        .bNumEndpoints = 2, \
+        .bInterfaceClass = HID_CLASS, \
+        .bInterfaceSubClass = HID_SUB_CLASS_NOBOOT, \
+        .bInterfaceProtocol = HID_SUB_CLASS_NOBOOT, \
+        .iInterface = UDI_HID_CON_STRING_ID \
+    }, \
+    .hid = { \
+        .bLength = sizeof(usb_hid_descriptor_t), \
+        .bDescriptorType = USB_DT_HID, \
+        .bcdHID = LE16(USB_HID_BDC_V1_11), \
+        .bCountryCode = USB_HID_NO_COUNTRY_CODE, \
+        .bNumDescriptors = USB_HID_NUM_DESC, \
+        .bRDescriptorType = USB_DT_HID_REPORT, \
+        .wDescriptorLength = LE16(sizeof(udi_hid_con_report_desc_t)) \
+    }, \
+    .ep_out = { \
+        .bLength = sizeof(usb_ep_desc_t), \
+        .bDescriptorType = USB_DT_ENDPOINT, \
+        .bEndpointAddress = UDI_HID_CON_EP_OUT | USB_EP_DIR_OUT, \
+        .bmAttributes = USB_EP_TYPE_INTERRUPT, \
+        .wMaxPacketSize = LE16(CONSOLE_EPSIZE), \
+        .bInterval = CON_POLLING_INTERVAL \
+    }, \
+    .ep_in = { \
+        .bLength = sizeof(usb_ep_desc_t), \
+        .bDescriptorType = USB_DT_ENDPOINT, \
+        .bEndpointAddress = UDI_HID_CON_EP_IN | USB_EP_DIR_IN, \
+        .bmAttributes = USB_EP_TYPE_INTERRUPT, \
+        .wMaxPacketSize = LE16(CONSOLE_EPSIZE), \
+        .bInterval = CON_POLLING_INTERVAL \
+    } \
+}
+
+// clang-format on
 
 #    define UDI_HID_CON_REPORT_SIZE CONSOLE_EPSIZE
 
@@ -482,12 +633,12 @@ extern uint8_t udi_hid_con_report[UDI_HID_CON_REPORT_SIZE];
 
 COMPILER_PACK_RESET()
 
-#endif  // CON
+#endif  // CONSOLE_ENABLE
 
 // **********************************************************************
 // CDC Descriptor structure and content
 // **********************************************************************
-#ifdef CDC
+#ifdef VIRTSER_ENABLE
 
 COMPILER_PACK_SET(1)
 
@@ -534,16 +685,98 @@ typedef struct {
     usb_ep_desc_t            ep_rx;
 } udi_cdc_desc_t;
 
-#    define CDC_DESCRIPTOR                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          \
-        {                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           \
-            .iaface.bLength = sizeof(usb_association_desc_t), .iaface.bDescriptorType = USB_DT_IAD, .iaface.bFirstInterface = CDC_STATUS_INTERFACE, .iaface.bInterfaceCount = 2, .iaface.bFunctionClass = CDC_CLASS_DEVICE, .iaface.bFunctionSubClass = CDC_SUBCLASS_ACM, .iaface.bFunctionProtocol = CDC_PROTOCOL_V25TER, .iaface.iFunction = 0, .iface_c.bLength = sizeof(usb_iface_desc_t), .iface_c.bDescriptorType = USB_DT_INTERFACE, .iface_c.bInterfaceNumber = CDC_STATUS_INTERFACE, .iface_c.bAlternateSetting = 0, .iface_c.bNumEndpoints = 1, .iface_c.bInterfaceClass = 0x02, .iface_c.bInterfaceSubClass = 0x02, .iface_c.bInterfaceProtocol = CDC_PROTOCOL_V25TER, .iface_c.iInterface = 0, .fd.bFunctionLength = sizeof(usb_cdc_hdr_desc_t), .fd.bDescriptorType = CDC_CS_INTERFACE, .fd.bDescriptorSubtype = CDC_SCS_HEADER, .fd.bcdCDC = 0x0110, .mfd.bFunctionLength = sizeof(usb_cdc_call_mgmt_desc_t), .mfd.bDescriptorType = CDC_CS_INTERFACE, .mfd.bDescriptorSubtype = CDC_SCS_CALL_MGMT,   \
-            .mfd.bmCapabilities = CDC_CALL_MGMT_SUPPORTED, .mfd.bDataInterface = CDC_DATA_INTERFACE, .acmd.bFunctionLength = sizeof(usb_cdc_acm_desc_t), .acmd.bDescriptorType = CDC_CS_INTERFACE, .acmd.bDescriptorSubtype = CDC_SCS_ACM, .acmd.bmCapabilities = CDC_ACM_SUPPORT_LINE_REQUESTS, .ufd.bFunctionLength = sizeof(usb_cdc_union_desc_t), .ufd.bDescriptorType = CDC_CS_INTERFACE, .ufd.bDescriptorSubtype = CDC_SCS_UNION, .ufd.bMasterInterface = CDC_STATUS_INTERFACE, .ufd.bSlaveInterface0 = CDC_DATA_INTERFACE, .ep_c.bLength = sizeof(usb_ep_desc_t), .ep_c.bDescriptorType = USB_DT_ENDPOINT, .ep_c.bEndpointAddress = CDC_ACM_ENDPOINT | USB_EP_DIR_IN, .ep_c.bmAttributes = USB_EP_TYPE_INTERRUPT, .ep_c.wMaxPacketSize = LE16(CDC_ACM_SIZE), .ep_c.bInterval = CDC_EP_INTERVAL_STATUS, .iface_d.bLength = sizeof(usb_iface_desc_t), .iface_d.bDescriptorType = USB_DT_INTERFACE, .iface_d.bInterfaceNumber = CDC_DATA_INTERFACE, .iface_d.bAlternateSetting = 0, .iface_d.bNumEndpoints = 2, \
-            .iface_d.bInterfaceClass = CDC_CLASS_DATA, .iface_d.bInterfaceSubClass = 0, .iface_d.bInterfaceProtocol = 0, .iface_d.iInterface = 0, .ep_rx.bLength = sizeof(usb_ep_desc_t), .ep_rx.bDescriptorType = USB_DT_ENDPOINT, .ep_rx.bEndpointAddress = CDC_RX_ENDPOINT | USB_EP_DIR_OUT, .ep_rx.bmAttributes = USB_EP_TYPE_BULK, .ep_rx.wMaxPacketSize = LE16(CDC_RX_SIZE), .ep_rx.bInterval = CDC_EP_INTERVAL_DATA, .ep_tx.bLength = sizeof(usb_ep_desc_t), .ep_tx.bDescriptorType = USB_DT_ENDPOINT, .ep_tx.bEndpointAddress = CDC_TX_ENDPOINT | USB_EP_DIR_IN, .ep_tx.bmAttributes = USB_EP_TYPE_BULK, .ep_tx.wMaxPacketSize = LE16(CDC_TX_SIZE), .ep_tx.bInterval = CDC_EP_INTERVAL_DATA,                                                                                                                                                                                                                                                                                                                \
-        }
+// clang-format off
+
+#    define CDC_DESCRIPTOR { \
+    .iaface = { \
+        .bLength = sizeof(usb_association_desc_t), \
+        .bDescriptorType = USB_DT_IAD, \
+        .bFirstInterface = CDC_STATUS_INTERFACE, \
+        .bInterfaceCount = 2, \
+        .bFunctionClass = CDC_CLASS_DEVICE, \
+        .bFunctionSubClass = CDC_SUBCLASS_ACM, \
+        .bFunctionProtocol = CDC_PROTOCOL_V25TER, \
+        .iFunction = 0 \
+    }, \
+    .iface_c = { \
+        .bLength = sizeof(usb_iface_desc_t), \
+        .bDescriptorType = USB_DT_INTERFACE, \
+        .bInterfaceNumber = CDC_STATUS_INTERFACE, \
+        .bAlternateSetting = 0, \
+        .bNumEndpoints = 1, \
+        .bInterfaceClass = 0x02, \
+        .bInterfaceSubClass = 0x02, \
+        .bInterfaceProtocol = CDC_PROTOCOL_V25TER, \
+        .iInterface = 0 \
+    }, \
+    .fd = { \
+        .bFunctionLength = sizeof(usb_cdc_hdr_desc_t), \
+        .bDescriptorType = CDC_CS_INTERFACE, \
+        .bDescriptorSubtype = CDC_SCS_HEADER, \
+        .bcdCDC = 0x0110 \
+    }, \
+    .mfd = { \
+        .bFunctionLength = sizeof(usb_cdc_call_mgmt_desc_t), \
+        .bDescriptorType = CDC_CS_INTERFACE, \
+        .bDescriptorSubtype = CDC_SCS_CALL_MGMT, \
+        .bmCapabilities = CDC_CALL_MGMT_SUPPORTED, \
+        .bDataInterface = CDC_DATA_INTERFACE \
+    }, \
+    .acmd = { \
+        .bFunctionLength = sizeof(usb_cdc_acm_desc_t), \
+        .bDescriptorType = CDC_CS_INTERFACE, \
+        .bDescriptorSubtype = CDC_SCS_ACM, \
+        .bmCapabilities = CDC_ACM_SUPPORT_LINE_REQUESTS \
+    }, \
+    .ufd = { \
+        .bFunctionLength = sizeof(usb_cdc_union_desc_t), \
+        .bDescriptorType = CDC_CS_INTERFACE, \
+        .bDescriptorSubtype = CDC_SCS_UNION, \
+        .bMasterInterface = CDC_STATUS_INTERFACE, \
+        .bSlaveInterface0 = CDC_DATA_INTERFACE \
+    }, \
+    .ep_c = { \
+        .bLength = sizeof(usb_ep_desc_t), \
+        .bDescriptorType = USB_DT_ENDPOINT, \
+        .bEndpointAddress = CDC_ACM_ENDPOINT | USB_EP_DIR_IN, \
+        .bmAttributes = USB_EP_TYPE_INTERRUPT, \
+        .wMaxPacketSize = LE16(CDC_ACM_SIZE), \
+        .bInterval = CDC_EP_INTERVAL_STATUS \
+    }, \
+    .iface_d = { \
+        .bLength = sizeof(usb_iface_desc_t), \
+        .bDescriptorType = USB_DT_INTERFACE, \
+        .bInterfaceNumber = CDC_DATA_INTERFACE, \
+        .bAlternateSetting = 0, \
+        .bNumEndpoints = 2, \
+        .bInterfaceClass = CDC_CLASS_DATA, \
+        .bInterfaceSubClass = 0, \
+        .bInterfaceProtocol = 0, \
+        .iInterface = 0 \
+    }, \
+    .ep_rx = { \
+        .bLength = sizeof(usb_ep_desc_t), \
+        .bDescriptorType = USB_DT_ENDPOINT, \
+        .bEndpointAddress = CDC_RX_ENDPOINT | USB_EP_DIR_OUT, \
+        .bmAttributes = USB_EP_TYPE_BULK, \
+        .wMaxPacketSize = LE16(CDC_RX_SIZE), \
+        .bInterval = CDC_EP_INTERVAL_DATA \
+    }, \
+    .ep_tx = { \
+        .bLength = sizeof(usb_ep_desc_t), \
+        .bDescriptorType = USB_DT_ENDPOINT, \
+        .bEndpointAddress = CDC_TX_ENDPOINT | USB_EP_DIR_IN, \
+        .bmAttributes = USB_EP_TYPE_BULK, \
+        .wMaxPacketSize = LE16(CDC_TX_SIZE), \
+        .bInterval = CDC_EP_INTERVAL_DATA \
+    } \
+}
+
+// clang-format on
 
 COMPILER_PACK_RESET()
 
-#endif  // CDC
+#endif  // VIRTSER_ENABLE
 
 // **********************************************************************
 // CONFIGURATION Descriptor structure and content
@@ -552,28 +785,26 @@ COMPILER_PACK_SET(1)
 
 typedef struct {
     usb_conf_desc_t conf;
-#ifdef KBD
     udi_hid_kbd_desc_t hid_kbd;
-#endif
-#ifdef MOU
+#ifdef MOUSE_ENABLE
     udi_hid_mou_desc_t hid_mou;
 #endif
-#ifdef EXK
+#ifdef EXTRAKEY_ENABLE
     udi_hid_exk_desc_t hid_exk;
 #endif
-#ifdef RAW
+#ifdef RAW_ENABLE
     udi_hid_raw_desc_t hid_raw;
 #endif
-#ifdef CON
+#ifdef CONSOLE_ENABLE
     udi_hid_con_desc_t hid_con;
 #endif
-#ifdef NKRO
+#ifdef NKRO_ENABLE
     udi_hid_nkro_desc_t hid_nkro;
 #endif
-#ifdef MIDI
+#ifdef MIDI_ENABLE
     udi_hid_midi_desc_t hid_midi;
 #endif
-#ifdef CDC
+#ifdef VIRTSER_ENABLE
     udi_cdc_desc_t cdc_serial;
 #endif
 } udc_desc_t;

--- a/tmk_core/protocol/arm_atsam/usb/udi_hid_kbd.c
+++ b/tmk_core/protocol/arm_atsam/usb/udi_hid_kbd.c
@@ -59,8 +59,6 @@
 //***************************************************************************
 // KBD
 //***************************************************************************
-#ifdef KBD
-
 bool    udi_hid_kbd_enable(void);
 void    udi_hid_kbd_disable(void);
 bool    udi_hid_kbd_setup(void);
@@ -196,12 +194,10 @@ static void udi_hid_kbd_setreport_valid(void) {
     // UDI_HID_KBD_CHANGE_LED(udi_hid_kbd_report_set);
 }
 
-#endif  // KBD
-
 //********************************************************************************************
 // NKRO Keyboard
 //********************************************************************************************
-#ifdef NKRO
+#ifdef NKRO_ENABLE
 
 bool    udi_hid_nkro_enable(void);
 void    udi_hid_nkro_disable(void);
@@ -336,12 +332,12 @@ static void udi_hid_nkro_setreport_valid(void) {
     // UDI_HID_NKRO_CHANGE_LED(udi_hid_nkro_report_set);
 }
 
-#endif  // NKRO
+#endif  // NKRO_ENABLE
 
 //********************************************************************************************
 // EXK (extra-keys) SYS-CTRL  Keyboard
 //********************************************************************************************
-#ifdef EXK
+#ifdef EXTRAKEY_ENABLE
 
 bool    udi_hid_exk_enable(void);
 void    udi_hid_exk_disable(void);
@@ -467,12 +463,12 @@ static void udi_hid_exk_report_sent(udd_ep_status_t status, iram_size_t nb_sent,
 
 static void udi_hid_exk_setreport_valid(void) {}
 
-#endif  // EXK
+#endif  // EXTRAKEY_ENABLE
 
 //********************************************************************************************
 // MOU Mouse
 //********************************************************************************************
-#ifdef MOU
+#ifdef MOUSE_ENABLE
 
 bool    udi_hid_mou_enable(void);
 void    udi_hid_mou_disable(void);
@@ -601,12 +597,12 @@ static void udi_hid_mou_report_sent(udd_ep_status_t status, iram_size_t nb_sent,
     }
 }
 
-#endif  // MOU
+#endif  // MOUSE_ENABLE
 
 //********************************************************************************************
 // RAW
 //********************************************************************************************
-#ifdef RAW
+#ifdef RAW_ENABLE
 
 bool    udi_hid_raw_enable(void);
 void    udi_hid_raw_disable(void);
@@ -746,12 +742,12 @@ static void udi_hid_raw_report_rcvd(udd_ep_status_t status, iram_size_t nb_rcvd,
     }
 }
 
-#endif //RAW
+#endif // RAW_ENABLE
 
 //********************************************************************************************
 // CON
 //********************************************************************************************
-#ifdef CON
+#ifdef CONSOLE_ENABLE
 
 bool    udi_hid_con_enable(void);
 void    udi_hid_con_disable(void);
@@ -866,4 +862,4 @@ static void udi_hid_con_report_sent(udd_ep_status_t status, iram_size_t nb_sent,
 
 static void udi_hid_con_setreport_valid(void) {}
 
-#endif  // CON
+#endif  // CONSOLE_ENABLE

--- a/tmk_core/protocol/arm_atsam/usb/udi_hid_kbd.h
+++ b/tmk_core/protocol/arm_atsam/usb/udi_hid_kbd.h
@@ -57,62 +57,60 @@ extern "C" {
 //******************************************************************************
 // Keyboard interface definitions
 //******************************************************************************
-#ifdef KBD
 extern UDC_DESC_STORAGE udi_api_t udi_api_hid_kbd;
 extern bool                       udi_hid_kbd_b_report_valid;
 extern volatile bool              udi_hid_kbd_b_report_trans_ongoing;
 extern uint8_t                    udi_hid_kbd_report_set;
 bool                              udi_hid_kbd_send_report(void);
-#endif  // KBD
 
 //********************************************************************************************
 // NKRO Keyboard
 //********************************************************************************************
-#ifdef NKRO
+#ifdef NKRO_ENABLE
 extern UDC_DESC_STORAGE udi_api_t udi_api_hid_nkro;
 extern bool                       udi_hid_nkro_b_report_valid;
 extern volatile bool              udi_hid_nkro_b_report_trans_ongoing;
 bool                              udi_hid_nkro_send_report(void);
-#endif  // NKRO
+#endif  // NKRO_ENABLE
 
 //********************************************************************************************
 // SYS-CTRL interface
 //********************************************************************************************
-#ifdef EXK
+#ifdef EXTRAKEY_ENABLE
 extern UDC_DESC_STORAGE udi_api_t udi_api_hid_exk;
 extern bool                       udi_hid_exk_b_report_valid;
 extern uint8_t                    udi_hid_exk_report_set;
 bool                              udi_hid_exk_send_report(void);
-#endif  // EXK
+#endif  // EXTRAKEY_ENABLE
 
 //********************************************************************************************
 // CON Console
 //********************************************************************************************
-#ifdef CON
+#ifdef CONSOLE_ENABLE
 extern UDC_DESC_STORAGE udi_api_t udi_api_hid_con;
 extern bool                       udi_hid_con_b_report_valid;
 extern uint8_t                    udi_hid_con_report_set[UDI_HID_CON_REPORT_SIZE];
 extern volatile bool              udi_hid_con_b_report_trans_ongoing;
 bool                              udi_hid_con_send_report(void);
-#endif  // CON
+#endif  // CONSOLE_ENABLE
 
 //********************************************************************************************
 // MOU Mouse
 //********************************************************************************************
-#ifdef MOU
+#ifdef MOUSE_ENABLE
 extern UDC_DESC_STORAGE udi_api_t udi_api_hid_mou;
 extern bool                       udi_hid_mou_b_report_valid;
 bool                              udi_hid_mou_send_report(void);
-#endif  // MOU
+#endif  // MOUSE_ENABLE
 
 //********************************************************************************************
 // RAW Raw
 //********************************************************************************************
-#ifdef RAW
+#ifdef RAW_ENABLE
 extern UDC_DESC_STORAGE udi_api_t udi_api_hid_raw;
 bool                              udi_hid_raw_send_report(void);
 bool                              udi_hid_raw_receive_report(void);
-#endif  // RAW
+#endif  // RAW_ENABLE
 
 //@}
 

--- a/tmk_core/protocol/arm_atsam/usb/udi_hid_kbd_desc.c
+++ b/tmk_core/protocol/arm_atsam/usb/udi_hid_kbd_desc.c
@@ -120,49 +120,45 @@ UDC_DESC_STORAGE udc_desc_t udc_desc = {
     .conf.iConfiguration      = 0,
     .conf.bmAttributes        = /* USB_CONFIG_ATTR_MUST_SET | */ USB_DEVICE_ATTR,
     .conf.bMaxPower           = USB_CONFIG_MAX_POWER(USB_DEVICE_POWER),
-#ifdef KBD
     .hid_kbd = UDI_HID_KBD_DESC,
-#endif
-#ifdef RAW
+#ifdef RAW_ENABLE
     .hid_raw = UDI_HID_RAW_DESC,
 #endif
-#ifdef MOU
+#ifdef MOUSE_ENABLE
     .hid_mou = UDI_HID_MOU_DESC,
 #endif
-#ifdef EXK
+#ifdef EXTRAKEY_ENABLE
     .hid_exk = UDI_HID_EXK_DESC,
 #endif
-#ifdef CON
+#ifdef CONSOLE_ENABLE
     .hid_con = UDI_HID_CON_DESC,
 #endif
-#ifdef NKRO
+#ifdef NKRO_ENABLE
     .hid_nkro = UDI_HID_NKRO_DESC,
 #endif
-#ifdef CDC
+#ifdef VIRTSER_ENABLE
     .cdc_serial = CDC_DESCRIPTOR,
 #endif
 };
 
 UDC_DESC_STORAGE udi_api_t *udi_apis[USB_DEVICE_NB_INTERFACE] = {
-#ifdef KBD
     &udi_api_hid_kbd,
-#endif
-#ifdef RAW
+#ifdef RAW_ENABLE
     &udi_api_hid_raw,
 #endif
-#ifdef MOU
+#ifdef MOUSE_ENABLE
     &udi_api_hid_mou,
 #endif
-#ifdef EXK
+#ifdef EXTRAKEY_ENABLE
     &udi_api_hid_exk,
 #endif
-#ifdef CON
+#ifdef CONSOLE_ENABLE
     &udi_api_hid_con,
 #endif
-#ifdef NKRO
+#ifdef NKRO_ENABLE
     &udi_api_hid_nkro,
 #endif
-#ifdef CDC
+#ifdef VIRTSER_ENABLE
     &udi_api_cdc_comm, &udi_api_cdc_data,
 #endif
 };

--- a/tmk_core/protocol/arm_atsam/usb/usb_main.h
+++ b/tmk_core/protocol/arm_atsam/usb/usb_main.h
@@ -63,41 +63,39 @@ void main_remotewakeup_enable(void);
 // Called by UDC when USB Host request to disable remote wakeup
 void main_remotewakeup_disable(void);
 
-#ifdef KBD
 extern volatile bool main_b_kbd_enable;
 bool                 main_kbd_enable(void);
 void                 main_kbd_disable(void);
-#endif  // KBD
 
-#ifdef NKRO
+#ifdef NKRO_ENABLE
 extern volatile bool main_b_nkro_enable;
 bool                 main_nkro_enable(void);
 void                 main_nkro_disable(void);
-#endif  // NKRO
+#endif  // NKRO_ENABLE
 
-#ifdef EXK
+#ifdef EXTRAKEY_ENABLE
 extern volatile bool main_b_exk_enable;
 bool                 main_exk_enable(void);
 void                 main_exk_disable(void);
-#endif  // EXK
+#endif  // EXTRAKEY_ENABLE
 
-#ifdef CON
+#ifdef CONSOLE_ENABLE
 extern volatile bool main_b_con_enable;
 bool                 main_con_enable(void);
 void                 main_con_disable(void);
-#endif  // CON
+#endif  // CONSOLE_ENABLE
 
-#ifdef MOU
+#ifdef MOUSE_ENABLE
 extern volatile bool main_b_mou_enable;
 bool                 main_mou_enable(void);
 void                 main_mou_disable(void);
-#endif  // MOU
+#endif  // MOUSE_ENABLE
 
-#ifdef RAW
+#ifdef RAW_ENABLE
 extern volatile bool main_b_raw_enable;
 bool                 main_raw_enable(void);
 void                 main_raw_disable(void);
 void                 main_raw_receive(uint8_t *buffer, uint8_t len);
-#endif  // RAW
+#endif  // RAW_ENABLE
 
 #endif  // _MAIN_H_

--- a/tmk_core/protocol/arm_atsam/usb/usb_protocol_cdc.h
+++ b/tmk_core/protocol/arm_atsam/usb/usb_protocol_cdc.h
@@ -48,7 +48,7 @@
 
 #include "compiler.h"
 
-#ifdef CDC
+#ifdef VIRTSER_ENABLE
 
 #    define CDC_CLASS_DEVICE 0x02  //!< USB Communication Device Class
 #    define CDC_CLASS_COMM 0x02    //!< CDC Communication Class Interface


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

For some reason the ATSAM code uses these three-letter defines for NKRO/mousekeys/extrakeys/console/raw/virtser/etc, when it really doesn't need to. I also reformatted the descriptors to be more readable.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
