### PR TITLE
MILC: Fix setting config values for store_true and store_false

### DIFF
--- a/lib/python/milc.py
+++ b/lib/python/milc.py
@@ -438,19 +438,20 @@ class MILC(object):
             raise RuntimeError('You must run this before the with statement!')
 
         def argument_function(handler):
+            subcommand_name = handler.__name__.replace("_", "-")
+
             if kwargs.get('arg_only'):
                 arg_name = self.get_argument_name(*args, **kwargs)
                 if arg_name not in self.arg_only:
                     self.arg_only[arg_name] = []
-                self.arg_only[arg_name].append(handler.__name__)
+                self.arg_only[arg_name].append(subcommand_name)
                 del kwargs['arg_only']
 
-            name = handler.__name__.replace("_", "-")
             if handler is self._entrypoint:
                 self.add_argument(*args, **kwargs)
 
-            elif name in self.subcommands:
-                self.subcommands[name].add_argument(*args, **kwargs)
+            elif subcommand_name in self.subcommands:
+                self.subcommands[subcommand_name].add_argument(*args, **kwargs)
 
             else:
                 raise RuntimeError('Decorated function is not entrypoint or subcommand!')


### PR DESCRIPTION
Fixes the following bugs:

* Using `action='store_true'` and `action='store_false'` did not populate the config
* Setting `args_only=True` for one subcommand would set it for all subcommands that used the same flag.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
