### PR TITLE
Remove Atmel FLIP from install scripts and documentation

### DIFF
--- a/docs/faq_debug.md
+++ b/docs/faq_debug.md
@@ -160,10 +160,3 @@ As of now root of its cause is not clear but some build options seem to be relat
 
 https://github.com/tmk/tmk_keyboard/issues/266
 https://geekhack.org/index.php?topic=41989.msg1967778#msg1967778
-
-
-
-## FLIP Doesn't Work
-### `AtLibUsbDfu.dll` Not Found
-Remove current driver and reinstall one FLIP provides from DeviceManager.
-http://imgur.com/a/bnwzy

--- a/docs/flashing.md
+++ b/docs/flashing.md
@@ -26,7 +26,6 @@ Compatible flashers:
 
 * [QMK Toolbox](https://github.com/qmk/qmk_toolbox/releases) (recommended GUI)
 * [dfu-programmer](https://github.com/dfu-programmer/dfu-programmer) / `:dfu` in QMK (recommended command line)
-* [Atmel's Flip](http://www.microchip.com/developmenttools/productdetails.aspx?partno=flip) (not recommended)
 
 Flashing sequence:
 

--- a/docs/fr-fr/faq_debug.md
+++ b/docs/fr-fr/faq_debug.md
@@ -155,11 +155,3 @@ Pour le moment, l'origine du problème n'est pas comprise, mais certaines option
 
 https://github.com/tmk/tmk_keyboard/issues/266
 https://geekhack.org/index.php?topic=41989.msg1967778#msg1967778
-
-## FLIP ne marche pas
-
-### `AtLibUsbDfu.dll` Not Found
-
-Supprimez le pilote actuel et réinstallez celui donné par FLIP dans le gestionnaire de périphériques.
-
-http://imgur.com/a/bnwzy

--- a/docs/fr-fr/flashing.md
+++ b/docs/fr-fr/flashing.md
@@ -26,7 +26,6 @@ Méthodes de flash compatibles :
 
 * [QMK Toolbox](https://github.com/qmk/qmk_toolbox/releases) (interface graphique recommandé)
 * [dfu-programmer](https://github.com/dfu-programmer/dfu-programmer) / `:dfu` avec QMK (outil en ligne de commande recommandé)
-* [Atmel's Flip](http://www.microchip.com/developmenttools/productdetails.aspx?partno=flip) (non recommandé)
 
 Ordre des actions :
 

--- a/docs/getting_started_vagrant.md
+++ b/docs/getting_started_vagrant.md
@@ -20,7 +20,6 @@ The "easy" way to flash the firmware is using a tool from your host OS:
 
 * [QMK Toolbox](https://github.com/qmk/qmk_toolbox) (recommended)
 * [Teensy Loader](https://www.pjrc.com/teensy/loader.html)
-* [Atmel FLIP](http://www.atmel.com/tools/flip.aspx)
 
 If you want to program via the command line you can uncomment the ['modifyvm'] lines in the Vagrantfile to enable the USB passthrough into Linux and then program using the command line tools like dfu-util/dfu-programmer or you can install the Teensy CLI version.
 

--- a/docs/ja/faq_debug.md
+++ b/docs/ja/faq_debug.md
@@ -152,10 +152,3 @@ https://geekhack.org/index.php?topic=14290.msg1884034#msg1884034
 
 https://github.com/tmk/tmk_keyboard/issues/266
 https://geekhack.org/index.php?topic=41989.msg1967778#msg1967778
-
-
-
-## FLIP が動作しない
-### `AtLibUsbDfu.dll` が見つかりません
-デバイスマネージャから現在のドライバを削除し、FLIP が提供するものを再インストールします。
-http://imgur.com/a/bnwzy

--- a/docs/ja/flashing.md
+++ b/docs/ja/flashing.md
@@ -31,7 +31,6 @@ BOOTLOADER = atmel-dfu
 
 * [QMK Toolbox](https://github.com/qmk/qmk_toolbox/releases) (推奨の GUI)
 * QMK の [dfu-programmer](https://github.com/dfu-programmer/dfu-programmer) / `:dfu` (推奨のコマンドライン)
-* [Atmel の Flip](http://www.microchip.com/developmenttools/productdetails.aspx?partno=flip) (非推奨)
 
 書き込み手順:
 

--- a/docs/ja/getting_started_vagrant.md
+++ b/docs/ja/getting_started_vagrant.md
@@ -25,7 +25,6 @@ Vagrant 以外に、適切なプロバイダがインストールされ、その
 
 * [QMK Toolbox](https://github.com/qmk/qmk_toolbox) (推奨)
 * [Teensy ローダー](https://www.pjrc.com/teensy/loader.html)
-* [Atmel FLIP](http://www.atmel.com/tools/flip.aspx)
 
 コマンドラインでプログラムしたい場合は、Vagranfile の ['modifyvm'] 行のコメントを解除して Linux への USB パススルーを有効にし、dfu-util/dfu-programmer のようなコマンドラインツールを使ってプログラムすることができます。あるいは Teensy CLI バージョンをインストールすることができます。
 

--- a/docs/reference_glossary.md
+++ b/docs/reference_glossary.md
@@ -46,9 +46,6 @@ An IDE that is popular with many C developers.
 ## Firmware
 The software that controls your MCU.
 
-## FLIP
-Software provided by Atmel for flashing AVR devices. We generally recommend [QMK Flasher](https://github.com/qmk/qmk_flasher) instead, but for some advanced use cases FLIP is required.
-
 ## git
 Versioning software used at the command line
 

--- a/docs/zh-cn/faq_debug.md
+++ b/docs/zh-cn/faq_debug.md
@@ -139,10 +139,3 @@ https://geekhack.org/index.php?topic=14290.msg1884034#msg1884034
 
 https://github.com/tmk/tmk_keyboard/issues/266
 https://geekhack.org/index.php?topic=41989.msg1967778#msg1967778
-
-
-
-## FLIP 不工作
-### `AtLibUsbDfu.dll` 未找到
-从设备管理器中删除当前驱动程序并在设备管理器重新安装一个FLIP提供的程序。
-http://imgur.com/a/bnwzy

--- a/docs/zh-cn/reference_glossary.md
+++ b/docs/zh-cn/reference_glossary.md
@@ -46,9 +46,6 @@ Français (法国)标准键盘布局。用键盘的前六个字母命名。
 ## Firmware(固件)
 用来控制单片机的软件。
 
-## FLIP
-爱特梅尔(Atmel)提供的AVR器件刷写软件。我们一般推荐 [QMK刷写工具](https://github.com/qmk/qmk_flasher)，但是对于一些高级用例，需要FLIP。
-
 ## git
 命令行版本控制软件
 

--- a/tmk_core/avr.mk
+++ b/tmk_core/avr.mk
@@ -105,13 +105,6 @@ endef
 teensy: $(BUILD_DIR)/$(TARGET).hex check-size cpfirmware
 	$(call EXEC_TEENSY)
 
-BATCHISP ?= batchisp
-
-flip: $(BUILD_DIR)/$(TARGET).hex check-size
-	$(BATCHISP) -hardware usb -device $(MCU) -operation erase f
-	$(BATCHISP) -hardware usb -device $(MCU) -operation loadbuffer $(BUILD_DIR)/$(TARGET).hex program
-	$(BATCHISP) -hardware usb -device $(MCU) -operation start reset 0
-
 DFU_PROGRAMMER ?= dfu-programmer
 GREP ?= grep
 
@@ -145,13 +138,6 @@ dfu: $(BUILD_DIR)/$(TARGET).hex cpfirmware check-size
 dfu-start:
 	$(DFU_PROGRAMMER) $(MCU) reset
 	$(DFU_PROGRAMMER) $(MCU) start
-
-flip-ee: $(BUILD_DIR)/$(TARGET).hex $(BUILD_DIR)/$(TARGET).eep
-	$(COPY) $(BUILD_DIR)/$(TARGET).eep $(BUILD_DIR)/$(TARGET)eep.hex
-	$(BATCHISP) -hardware usb -device $(MCU) -operation memory EEPROM erase
-	$(BATCHISP) -hardware usb -device $(MCU) -operation memory EEPROM loadbuffer $(BUILD_DIR)/$(TARGET)eep.hex program
-	$(BATCHISP) -hardware usb -device $(MCU) -operation start reset 0
-	$(REMOVE) $(BUILD_DIR)/$(TARGET)eep.hex
 
 dfu-ee: $(BUILD_DIR)/$(TARGET).hex $(BUILD_DIR)/$(TARGET).eep
 	if $(DFU_PROGRAMMER) --version 2>&1 | $(GREP) -q 0.7 ; then\

--- a/tmk_core/rules.mk
+++ b/tmk_core/rules.mk
@@ -439,7 +439,7 @@ $(eval $(foreach OUTPUT,$(OUTPUTS),$(shell mkdir -p $(OUTPUT) 2>/dev/null)))
 .PHONY : all finish sizebefore sizeafter qmkversion \
 gccversion build elf hex eep lss sym coff extcoff \
 clean clean_list debug gdb-config show_path \
-program teensy dfu flip dfu-ee flip-ee dfu-start \
+program teensy dfu dfu-ee dfu-start \
 flash dfu-split-left dfu-split-right \
 avrdude-split-left avrdude-split-right \
 avrdude-loop usbasp

--- a/util/activate_msys2.sh
+++ b/util/activate_msys2.sh
@@ -6,7 +6,6 @@ function export_variables {
     export PATH=$PATH:$util_dir/dfu-programmer
     export PATH=$PATH:$util_dir/dfu-util-0.9-win64
     export PATH=$PATH:$util_dir/bootloadHID.2012-12-08/commandline
-    export PATH=$PATH:$util_dir/flip/bin
     export PATH=$PATH:$util_dir/avr8-gnu-toolchain/bin
     export PATH=$PATH:$util_dir/gcc-arm-none-eabi/bin
 }

--- a/util/activate_wsl.sh
+++ b/util/activate_wsl.sh
@@ -8,7 +8,6 @@ function export_variables {
     export DFU_UTIL=$download_dir/dfu-util-0.9-win64/dfu-util.exe
     export TEENSY_LOADER_CLI=$download_dir/teensy_loader_cli.exe
     export BOOTLOADHID_PROGRAMMER=$download_dir/bootloadHID.2012-12-08/commandline/bootloadHID.exe
-    export BATCHISP=batchisp.exe
 }
 
 export_variables

--- a/util/msys2_install.sh
+++ b/util/msys2_install.sh
@@ -4,11 +4,10 @@ dir=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 download_dir=~/qmk_utils
 avrtools=avr8-gnu-toolchain
 armtools=gcc-arm-none-eabi
-installflip=false
 util_dir=$(dirname "$0")
 
 echo "Installing dependencies needed for the installation (quazip)"
-pacman --needed --noconfirm --disable-download-timeout -Sy base-devel mingw-w64-x86_64-toolchain mingw-w64-x86_64-clang msys/git msys/p7zip mingw-w64-x86_64-python3-pip msys/unzip
+pacman --needed --noconfirm --disable-download-timeout -Sy base-devel mingw-w64-x86_64-toolchain mingw-w64-x86_64-clang git mingw-w64-x86_64-python3-pip unzip
 
 source "$dir/win_shared_install.sh"
 
@@ -31,18 +30,7 @@ function install_arm {
     rm gcc-arm-none-eabi-8-2019-q3-update-win32.zip
 }
 
-function extract_flip {
-    rm -f -r flip
-    7z -oflip x FlipInstaller.exe
-}
-
 pushd "$download_dir"
-
-if [ -f "FlipInstaller.exe" ]; then
-    echo
-    echo "Extracting flip"
-    extract_flip
-fi
 
 if [ ! -d "$avrtools" ]; then
     echo

--- a/util/win_shared_install.sh
+++ b/util/win_shared_install.sh
@@ -22,10 +22,6 @@ function install_utils {
     wget 'https://www.obdev.at/downloads/vusb/bootloadHID.2012-12-08.zip'
     unzip bootloadHID.2012-12-08.zip
 
-    echo "Installing Atmel Flip"
-    wget 'http://ww1.microchip.com/downloads/en/DeviceDoc/Flip%20Installer%20-%203.4.7.112.exe'
-    mv Flip\ Installer\ \-\ 3.4.7.112.exe FlipInstaller.exe
-
     echo "Downloading the QMK driver installer"
     wget -qO- https://api.github.com/repos/qmk/qmk_driver_installer/releases | grep browser_download_url | head -n 1 | cut -d '"' -f 4 | wget -i -
 

--- a/util/wsl_install.sh
+++ b/util/wsl_install.sh
@@ -31,21 +31,6 @@ source "$dir/win_shared_install.sh"
 
 pip3 install -r ${util_dir}/../requirements.txt
 
-pushd "$download_dir"
-while true; do
-    echo
-    echo "Flip need to be installed if you want to use that for programming."
-    echo "Please install it to the default location!"
-    read -p "Do you want to install it now? (Y/N) " res
-    case $res in
-        [Yy]* ) cmd.exe /c FlipInstaller.exe; break;;
-        [Nn]* ) break;;
-        * ) echo "Invalid answer";;
-    esac
-done
-popd
-
-
 echo 
 echo "Creating a softlink to the utils directory as ~/qmk_utils."
 echo "This is needed so that the the make system can find all utils it need."


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Since it's barely used, we already have the Toolbox, and Microchip are probably unlikely to maintain FLIP.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
