### PR TITLE
Add support for out-of-tree keymap.json compilation

### DIFF
--- a/lib/python/qmk/commands.py
+++ b/lib/python/qmk/commands.py
@@ -7,6 +7,8 @@ import subprocess
 import shlex
 import shutil
 
+from milc import cli
+
 import qmk.keymap
 
 
@@ -65,6 +67,13 @@ def parse_configurator_json(configurator_file):
     """Open and parse a configurator json export
     """
     user_keymap = json.load(configurator_file)
+
+    # If the json file does not contain a name for the keymap
+    # try to figure one out of the environment
+    if not user_keymap.get('keymap', False):
+        user_keymap['keymap'] = cli.config.user.name
+        if not user_keymap['keymap']:
+            user_keymap['keymap'] = os.environ['USER']
 
     return user_keymap
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
A small modification to allow users to store their `keymap.json` outside the `qmk_firmware` repo, yet be ablo to compile it with `qmk compile /path/to/keymap.json`.
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
