### PR TITLE
Fix for One Shot Layer not being cleaned up after some actions

### DIFF
--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -231,7 +231,7 @@ void process_action(keyrecord_t *record, action_t action) {
 #ifndef NO_ACTION_ONESHOT
     bool do_release_oneshot = false;
     // notice we only clear the one shot layer if the pressed key is not a modifier.
-    if (is_oneshot_layer_active() && event.pressed && !IS_MOD(action.key.code)
+    if (is_oneshot_layer_active() && event.pressed && (action.kind.id == ACT_USAGE || !IS_MOD(action.key.code))
 #    ifdef SWAP_HANDS_ENABLE
         && !(action.kind.id == ACT_SWAP_HANDS && action.swap.code == OP_SH_ONESHOT)
 #    endif

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -192,7 +192,14 @@ void process_record(keyrecord_t *record) {
         return;
     }
 
-    if (!process_record_quantum(record)) return;
+    if (!process_record_quantum(record)) {
+#ifndef NO_ACTION_ONESHOT
+        if (is_oneshot_layer_active() && record->event.pressed) {
+            clear_oneshot_layer_state(ONESHOT_OTHER_KEY_PRESSED);
+        }
+#endif
+        return;
+    }
 
     process_record_handler(record);
     post_process_record_quantum(record);


### PR DESCRIPTION
## Description

This provides a fix for two cases of One Shot Layers not being cleaned up after the next key has been pressed:

1. KC_MUTE does not trigger cleanup action for One Shot Layers (Issue #7599)
2. QMK functions (implemented in `process_record_quantum()` or its constituents) will never reach [this code](https://github.com/qmk/qmk_firmware/blob/58a9c84d6bb22c7544231f60acace4a85d6f8dd2/tmk_core/common/action.c#L227), leaving the OSL active.

To solve these problems I have:

-  added a check for `ACT_USAGE` to prevent that case from allowing the action to erroneously be interpreted as a modifier (@fauxpark suggested).  
- added code to `process_record()` so that when an QMK function is processed, the OSL is still cleaned up even though `process_action()` is never called in that case.

Note: 
This code does _not_ fix a separate (and thornier) issue that exists, which is that One Shot Layers are currently incompatible with layer toggling. If a layer is activated using OSL, then `TG(layer)` in that layer does not work.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #7599 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
