### PR TITLE
[Keymap] Rework my Tsangan layout; turn off mousekeys

### DIFF
--- a/layouts/community/60_tsangan_hhkb/bcat/keymap.c
+++ b/layouts/community/60_tsangan_hhkb/bcat/keymap.c
@@ -2,12 +2,12 @@
 
 enum layer {
     LAYER_DEFAULT,
-    LAYER_FUNCTION,
-    LAYER_ADJUST,
+    LAYER_FUNCTION_1,
+    LAYER_FUNCTION_2,
 };
 
-#define LY_FUNC MO(LAYER_FUNCTION)
-#define LY_ADJST LT(LAYER_ADJUST, KC_APP)
+#define LY_FN1 MO(LAYER_FUNCTION_1)
+#define LY_FN2 MO(LAYER_FUNCTION_2)
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Default layer: http://www.keyboard-layout-editor.com/#/gists/86b33d75aa6f56d8781ab3d8475f4e77 */
@@ -15,22 +15,22 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         KC_ESC,   KC_1,     KC_2,     KC_3,     KC_4,     KC_5,     KC_6,     KC_7,     KC_8,     KC_9,     KC_0,     KC_MINS,  KC_EQL,   KC_BSLS,  KC_GRV,
         KC_TAB,   KC_Q,     KC_W,     KC_E,     KC_R,     KC_T,     KC_Y,     KC_U,     KC_I,     KC_O,     KC_P,     KC_LBRC,  KC_RBRC,  KC_BSPC,
         KC_LCTL,  KC_A,     KC_S,     KC_D,     KC_F,     KC_G,     KC_H,     KC_J,     KC_K,     KC_L,     KC_SCLN,  KC_QUOT,            KC_ENT,
-        KC_LSFT,  KC_Z,     KC_X,     KC_C,     KC_V,     KC_B,     KC_N,     KC_M,     KC_COMM,  KC_DOT,   KC_SLSH,  KC_RSFT,                      LY_FUNC,
-        KC_LCTL,  KC_LGUI,  KC_LALT,                                KC_SPC,                                           KC_RALT,  LY_ADJST,           KC_RCTL
+        KC_LSFT,  KC_Z,     KC_X,     KC_C,     KC_V,     KC_B,     KC_N,     KC_M,     KC_COMM,  KC_DOT,   KC_SLSH,  KC_RSFT,                      LY_FN1,
+        KC_LCTL,  LY_FN2,   KC_LALT,                                KC_SPC,                                           KC_RALT,  KC_RGUI,            KC_RCTL
     ),
 
-    /* Function layer: http://www.keyboard-layout-editor.com/#/gists/f6311fd7e315de781143b80eb040a551 */
-    [LAYER_FUNCTION] = LAYOUT_60_tsangan_hhkb(
+    /* Function 1 layer: http://www.keyboard-layout-editor.com/#/gists/f6311fd7e315de781143b80eb040a551 */
+    [LAYER_FUNCTION_1] = LAYOUT_60_tsangan_hhkb(
         _______,  KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   KC_INS,   KC_DEL,
         KC_CAPS,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  KC_PSCR,  KC_SLCK,  KC_PAUS,  KC_UP,    _______,  _______,
         _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  KC_HOME,  KC_PGUP,  KC_LEFT,  KC_RGHT,            _______,
-        _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  KC_END,   KC_PGDN,  KC_DOWN,  _______,                      _______,
+        _______,  KC_APP,   _______,  _______,  _______,  _______,  _______,  _______,  KC_END,   KC_PGDN,  KC_DOWN,  _______,                      _______,
         _______,  _______,  _______,                                _______,                                          _______,  _______,            _______
     ),
 
-    /* Adjust layer: http://www.keyboard-layout-editor.com/#/gists/65ac939caec878401603bc36290852d4 */
-    [LAYER_ADJUST] = LAYOUT_60_tsangan_hhkb(
-        _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,
+    /* Function 2 layer: http://www.keyboard-layout-editor.com/#/gists/65ac939caec878401603bc36290852d4 */
+    [LAYER_FUNCTION_2] = LAYOUT_60_tsangan_hhkb(
+        _______,  KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   _______,  _______,
         _______,  BL_BRTG,  KC_MPLY,  KC_VOLU,  KC_MSTP,  _______,  EEP_RST,  RESET,    _______,  _______,  _______,  RGB_VAI,  _______,  _______,
         _______,  BL_INC,   KC_MPRV,  KC_VOLD,  KC_MNXT,  _______,  _______,  RGB_SPI,  RGB_HUI,  RGB_SAI,  RGB_RMOD, RGB_MOD,            RGB_TOG,
         _______,  BL_DEC,   _______,  KC_MUTE,  _______,  _______,  _______,  RGB_SPD,  RGB_HUD,  RGB_SAD,  RGB_VAD,  _______,                      _______,

--- a/layouts/community/60_tsangan_hhkb/bcat/readme.md
+++ b/layouts/community/60_tsangan_hhkb/bcat/readme.md
@@ -1,25 +1,44 @@
 # bcat's 60% Tsangan HHKB layout
 
-This is a normal Tsangan/HHKB (split backspace, split right shift) layout with
-arrow and navigation keys that match a standard HHKB layout. Additionally, the
-redundant right Super key on the bottom row actives an adjust layer with
-controls for RGB underglow and backlight, as well as media keys centered around
-the ESDF cluster.
+This is a Tsangan/HHKB (split backspace, split right shift) layout following
+the [traditional HHKB layout](https://deskthority.net/wiki/HHKB_Professional2)
+with a few changes:
+
+* The Delete key is mapped as Backspace (HHKB DIP switch 3).
+
+* The Alt and Super keys are swapped to put Alt directly adjacent to the
+spacebar (HHKB DIP switch 5).
+
+* The left Super key is replaced with another Function key (HHKB DIP switch 2).
+Unlike on the real HHKB, this key triggers a different Function 2 layer. (This
+also helps prevent accidental Super key presses while gaming.)
+
+* The Function 2 layer contains reset keys, RGB underglow and backlight
+controls (in place of the arrow and navigation keys), and media controls
+(centered around the ESDF cluster).
+
+* The Function 2 layer also has the F1-F12 keys mapped just like the Function 1
+layer. This is a concession to gaming because it enables these keys to be
+easily typed with the left hand, without taking the right hand off the mouse.
+
+* The leftmost and rightmost bottom row keys are mapped to Ctrl rather than
+anything more useful because most of my Tsangan PCBs actually have HHKB plates
+and/or blockers, so there aren't switches installed in those positions.
 
 ## Default layer
 
-![Default layer layout](https://i.imgur.com/et26km2.png)
+![Default layer layout](https://i.imgur.com/3tBxms8.png)
 
 ([KLE](http://www.keyboard-layout-editor.com/#/gists/86b33d75aa6f56d8781ab3d8475f4e77))
 
-## Function layer
+## Function 1 layer
 
-![Function layer layout](https://i.imgur.com/NdJTW9f.png)
+![Function l 1ayer layout](https://i.imgur.com/jn4HtA5.png)
 
 ([KLE](http://www.keyboard-layout-editor.com/#/gists/f6311fd7e315de781143b80eb040a551))
 
-## Adjust layer
+## Function 2 layer
 
-![Adjust layer layout](https://i.imgur.com/XQR4AEf.png)
+![Function 2layer layout](https://i.imgur.com/tQBIR1m.png)
 
 ([KLE](http://www.keyboard-layout-editor.com/#/gists/65ac939caec878401603bc36290852d4))

--- a/users/bcat/rules.mk
+++ b/users/bcat/rules.mk
@@ -3,9 +3,8 @@ SRC += bcat.c
 # Enable Bootmagic Lite to consistently reset to bootloader and clear EEPROM.
 BOOTMAGIC_ENABLE = lite
 
-# Enable mouse and media keys on all keyboards.
+# Enable media keys on all keyboards.
 EXTRAKEY_ENABLE = yes
-MOUSEKEY_ENABLE = yes
 
 # Disable some unwanted features on all keyboards.
 API_SYSEX_ENABLE = no
@@ -13,6 +12,7 @@ COMMAND_ENABLE = no
 CONSOLE_ENABLE = no
 FAUXCLICKY_ENABLE = no
 MIDI_ENABLE = no
+MOUSEKEY_ENABLE = no
 NKRO_ENABLE = no
 SLEEP_LED_ENABLE = no
 UCIS_ENABLE = no


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Reworks my Tsangan layout's two function layers to make more sense for gaming (including F1-F6 keys accessible with the left hand alone).

Also turns off mouse keys for all my keyboards since I don't actually use them in any keymaps, and they interfere with sleep on Windows.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [X] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

None.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
