### PR TITLE
Clean up my ergo keymaps and userspace

### DIFF
--- a/keyboards/crkbd/keymaps/bcat/readme.md
+++ b/keyboards/crkbd/keymaps/bcat/readme.md
@@ -17,8 +17,8 @@ at the same time.
 
 * Other than Right Shift (which I seldom use), mods aren't rebound on layers.
 
-* Backspace is bound in the same place on every layer to avoid having to let go
-of layer-switch keys to correct mistakes.
+* Likewise, Backspace is not rebound on layers to avoid having to let go of
+layer-switch keys to correct mistakes.
 
 ## Default layer
 
@@ -28,13 +28,13 @@ of layer-switch keys to correct mistakes.
 
 * The alpha keys are a standard QWERTY layout, no funny business there.
 
-* Tab and Backspace in familiar locations from my row-staggered boards (almost
-all of which use HHKB-style split backspace).
+* Tab and Backspace are in familiar locations from my row-staggered boards
+(almost all of which use HHKB-style split backspace).
 
 * Likewise, the Ctrl key is in the same place as on my row-staggered boards
 (where I've been remapping Caps Lock as Ctrl since before even using QMK).
 
-* There are two shift keys, because I do use Right Shift on occasion (even
+* There are two Shift keys, because I do use Right Shift on occasion (even
 though I'm predominately a Left Shift-er).
 
 * Lower and Raise layer-switch keys are below the left and right thumb,
@@ -43,8 +43,8 @@ respectively, when resting my fingers on the home row.
 * Space and Enter are on the big thumb keys so they're easy to press.
 
 * Alt is on the left so I can navigate back (Alt+Raise+H) and forward
-(Alt+Raise+L) having to uncomfortably hit two thumb keys on the same half. This
-puts Super on the right by the process of elimination.
+(Alt+Raise+L) without having to uncomfortably hit two thumb keys on the same
+half. This puts Super on the right by the process of elimination.
 
 * Escape shares a mod-tap key with Ctrl, which is convenient for Vim, but not
 something I'm totally in love with, as even after tweaking `TAPPING_TERM` I
@@ -61,7 +61,7 @@ on a layer, but that'd take some getting used to....)
 
 * Shifted numbers are bound in their usual positions on the top row.
 
-* Hyphen/Underscore and Equals/Plus are in the right index and middle finger
+* Hyphen/Underscore and Equals/Plus are in the right index- and middle-finger
 columns for easy reach. They share the same relative position as on a
 row-staggered keyboard, and the shifted versions are physically above the
 unshifted versions as a mnemonic device.
@@ -72,6 +72,7 @@ bottom row.
 
 * Forward Slash/Pipe and Backtick/Tilde fill out the remaining positions on the
 right half, with the same relative positions as on a row-staggered HHKB layout.
+And yup, the shifted versions are above the unshifted versions.
 
 * Caps Lock is bound in the same position as on an HHKB, for lack of an obvious
 better location.
@@ -112,10 +113,10 @@ be a better place to put them.
 ([KLE](http://www.keyboard-layout-editor.com/#/gists/77e7572e077b36a23eb2086017e16fee))
 
 * Media keys are centered around the ESDF cluster, just like I arrange them on
-row-staggered keyboards. (It's even more sensible on with columnar stagger.)
+row-staggered keyboards. (It's even more sensible with columnar stagger.)
 
-* The navigation and Enter keys are replaced by RGB controls. Again, this
-mirrors the positioning I use on my row-staggered keyboards.
+* The navigation keys are replaced by RGB controls. Again, this mirrors the
+positioning I use on my row-staggered keyboards.
 
 * Finally, reset keys live at the top-left corner of the right half where it's
 reasonably hard to press them by accident.

--- a/keyboards/crkbd/keymaps/bcat/readme.md
+++ b/keyboards/crkbd/keymaps/bcat/readme.md
@@ -1,9 +1,24 @@
 # bcat's Corne layout
 
-This split ergo layout mirrors
-[my Lily58 layout](https://github.com/qmk/qmk_firmware/tree/master/keyboards/lily58/keymaps/bcat)
-with the number row removed and RGB controls added. See that layout's docs for
-more details on the principles that went into the layout.
+This is my favorite split ergo layout for typing, featuring the traditional
+four ortho/ergo layers (Default, Lower, Raise, Adjust). It is loosely inspired
+by the default Planck (numbers on Lower, symbols on Raise) and Crkbd (Space on
+left, Enter on right) layouts, but has since been redesigned heavily according
+to the principles described below:
+
+* Since most of the modifiers are on the left half, keys frequently pressed
+together with mods (e.g., numbers, function keys, etc.) are on the Raise layer
+activated by the right thumb.
+
+* Navigation can be done on the right half alone, to enable simultaneous
+left-handed mousing. Additionally, Web pages can be scrolled with Space or
+Shift+Space on the left half alone, to enable taking notes with the right hand
+at the same time.
+
+* Other than Right Shift (which I seldom use), mods aren't rebound on layers.
+
+* Backspace is bound in the same place on every layer to avoid having to let go
+of layer-switch keys to correct mistakes.
 
 ## Default layer
 
@@ -11,11 +26,60 @@ more details on the principles that went into the layout.
 
 ([KLE](http://www.keyboard-layout-editor.com/#/gists/08d9827d916662a9414f48805aa895a5))
 
+* The alpha keys are a standard QWERTY layout, no funny business there.
+
+* Tab and Backspace in familiar locations from my row-staggered boards (almost
+all of which use HHKB-style split backspace).
+
+* Likewise, the Ctrl key is in the same place as on my row-staggered boards
+(where I've been remapping Caps Lock as Ctrl since before even using QMK).
+
+* There are two shift keys, because I do use Right Shift on occasion (even
+though I'm predominately a Left Shift-er).
+
+* Lower and Raise layer-switch keys are below the left and right thumb,
+respectively, when resting my fingers on the home row.
+
+* Space and Enter are on the big thumb keys so they're easy to press.
+
+* Alt is on the left so I can navigate back (Alt+Raise+H) and forward
+(Alt+Raise+L) having to uncomfortably hit two thumb keys on the same half. This
+puts Super on the right by the process of elimination.
+
+* Escape shares a mod-tap key with Ctrl, which is convenient for Vim, but not
+something I'm totally in love with, as even after tweaking `TAPPING_TERM` I
+still get occasional spurious Esc taps. (I might move Esc up a key and put Tab
+on a layer, but that'd take some getting used to....)
+
 ## Lower layer
 
 ![Lower layer layout](https://i.imgur.com/rDlSmrA.png)
 
 ([KLE](http://www.keyboard-layout-editor.com/#/gists/c3fba5eaa2cd70fdfbdbc0f9e34d3bc0))
+
+* This could also be called the "symbol layer".
+
+* Shifted numbers are bound in their usual positions on the top row.
+
+* Hyphen/Underscore and Equals/Plus are in the right index and middle finger
+columns for easy reach. They share the same relative position as on a
+row-staggered keyboard, and the shifted versions are physically above the
+unshifted versions as a mnemonic device.
+
+* Brackets and braces are placed below the parens for easy recall. Once again,
+the shifted versions are on the home row and the unshifted versions are on the
+bottom row.
+
+* Forward Slash/Pipe and Backtick/Tilde fill out the remaining positions on the
+right half, with the same relative positions as on a row-staggered HHKB layout.
+
+* Caps Lock is bound in the same position as on an HHKB, for lack of an obvious
+better location.
+
+* Some extra keys are placed on the bottom row of the left half, ensuring every
+key on a TKL has a binding.
+
+* The left-half home row is reversed for future use. (It's free real estate.)
 
 ## Raise layer
 
@@ -23,8 +87,35 @@ more details on the principles that went into the layout.
 
 ([KLE](http://www.keyboard-layout-editor.com/#/gists/08b44355d4ca85d294bad9e2821f91d7))
 
+* This could also be called the "number layer".
+
+* Unshifted numbers are bound in their usual positions on the top row.
+
+* Arrow keys are on VIM-style HJKL keys.
+
+* Home/End and Page Up/Page Down are in the same column as the arrow keys, but
+translated down one row. (This means that the comma and period keys are not
+bound on the number layer, which makes data entry a bit funky. I might add a
+dedicated numpad layer to compensate.)
+
+* Function keys F1–F10 take up most of remaining space on the left half, with
+F11 and F12 spilling over to the right half. (This puts the most used function
+keys (F1–F5) on the home row.)
+
+* Insert and Delete are on the rightmost column, because there didn't seem to
+be a better place to put them.
+
 ## Adjust layer
 
 ![Adjust layer layout](https://i.imgur.com/LEHM4DU.png)
 
 ([KLE](http://www.keyboard-layout-editor.com/#/gists/77e7572e077b36a23eb2086017e16fee))
+
+* Media keys are centered around the ESDF cluster, just like I arrange them on
+row-staggered keyboards. (It's even more sensible on with columnar stagger.)
+
+* The navigation and Enter keys are replaced by RGB controls. Again, this
+mirrors the positioning I use on my row-staggered keyboards.
+
+* Finally, reset keys live at the top-left corner of the right half where it's
+reasonably hard to press them by accident.

--- a/keyboards/lily58/keymaps/bcat/config.h
+++ b/keyboards/lily58/keymaps/bcat/config.h
@@ -1,3 +1,6 @@
 #pragma once
 
 #define EE_HANDS
+
+/* Work around Elite-C v3 with broken VBUS detection. */
+#define SPLIT_USB_DETECT

--- a/keyboards/lily58/keymaps/bcat/readme.md
+++ b/keyboards/lily58/keymaps/bcat/readme.md
@@ -1,49 +1,18 @@
 # bcat's Lily58 layout
 
-This split ergo layout is standard QWERTY on the default layer, with symbols on
-the lower layer, numbers/navigation on the raise layer, and media keys centered
-around the ESDF cluster in the adjust (raise + lower) layer. A few general
-principles went into this layout:
+This split ergo layout follows my preferred [Crkbd
+layout](https://github.com/qmk/qmk_firmware/tree/master/keyboards/crkbd/keymaps/bcat)
+with the following changes:
 
-* The number row is optional, as are the outermost bottom row keys and the
-"extra" keys on the innnermost columns below the controllers. This allows me to
-switch between this keyboard and a 40% like the
-[Crkbd](https://github.com/qmk/qmk_firmware/tree/master/keyboards/lily58/keymaps/bcat)
-without breaking muscle memory.
+* There's an optional number row at the top of the keyboard. I am quite used to
+using layers for numbers and symbols, so in practice this goes unused.
 
-* Space and Enter are on the big thumb keys so they're easy to press.
+* The dedicated Hyphen/Underscore and Equals/Plus keys on the number row are
+placed in the same positions as on the ErgoDox EZ. (There's no real reason for
+this; I just had to do _something_ with those keys.)
 
-* There are two shift keys because Right Shift is all that important, but just
-because I don't have any better ideas for what to put there.
-
-* Arrow keys are on VIM-style HJKL keys.
-
-* Home/End and Page Up/Page Down are equivalent to the arrow keys, but
-translated down one row.
-
-* Navigation is usable with just the right hand, to enable left-handed mousing
-at the same time. Additionally, Web page scrolling (Space, Shift+Space) is
-possible with just the left hand, for writing at the same time as scrolling.
-
-* Escape is easy to reach because Vim is life.
-
-* Since most of the modifiers are on the left half, keys frequently pressed
-together with mods (e.g., numbers, function keys, etc.) are on the Raise layer
-activated by the right thumb.
-
-* Every key on a TKL has a binding.
-
-* Backspace is bound in the same place on every layer to avoid having to let go
-of layer-shift keys to fix a mistake.
-
-* Likewise, the comma and period keys are not rebound on the raise layer to
-allow typing numbers with thousand separators and decimal points without
-releasing the layer key.
-
-* Brackets and braces are on or near the home row for quick access when coding.
-They're positioned below the parens on the Raise layer for easy recall.
-
-* For consistency, mods aren't rebound on layers (except for the Tab key).
+* The extra thumb keys are used for dedicated Ctrl/Menu keys (not super useful)
+and browser back/forward navigation keys (actually more useful than expected).
 
 ## Default layer
 

--- a/users/bcat/bcat.c
+++ b/users/bcat/bcat.c
@@ -1,6 +1,6 @@
 #include "quantum.h"
 
 #if defined(RGBLIGHT_ENABLE)
-    /* Adjust RGB static hue ranges for shorter gradients than default. */
-    const uint8_t RGBLED_GRADIENT_RANGES[] PROGMEM = {255, 127, 63, 31, 15};
+/* Adjust RGB static hue ranges for shorter gradients than default. */
+const uint8_t RGBLED_GRADIENT_RANGES[] PROGMEM = {255, 127, 63, 31, 15};
 #endif

--- a/users/bcat/config.h
+++ b/users/bcat/config.h
@@ -26,45 +26,45 @@
 #define TAPPING_FORCE_HOLD
 
 #if defined(RGB_MATRIX_ENABLE)
-    /* Turn off per-key RGB when the host goes to sleep. */
-    #define RGB_DISABLE_WHEN_USB_SUSPENDED true
+/* Turn off per-key RGB when the host goes to sleep. */
+#    define RGB_DISABLE_WHEN_USB_SUSPENDED true
 
-    /* Keep per-key RGB increments consistent across keyboards. */
-    #undef RGB_MATRIX_HUE_STEP
-    #undef RGB_MATRIX_SAT_STEP
-    #undef RGB_MATRIX_VAL_STEP
-    #undef RGB_MATRIX_SPD_STEP
+/* Keep per-key RGB increments consistent across keyboards. */
+#    undef RGB_MATRIX_HUE_STEP
+#    undef RGB_MATRIX_SAT_STEP
+#    undef RGB_MATRIX_VAL_STEP
+#    undef RGB_MATRIX_SPD_STEP
 
-    #define RGB_MATRIX_HUE_STEP 8
-    #define RGB_MATRIX_SAT_STEP 17
-    #define RGB_MATRIX_VAL_STEP 17
-    #define RGB_MATRIX_SPD_STEP 17
+#    define RGB_MATRIX_HUE_STEP 8
+#    define RGB_MATRIX_SAT_STEP 17
+#    define RGB_MATRIX_VAL_STEP 17
+#    define RGB_MATRIX_SPD_STEP 17
 
-    /* Turn on additional RGB animations. */
-    #define RGB_MATRIX_FRAMEBUFFER_EFFECTS
-    #define RGB_MATRIX_KEYPRESSES
+/* Turn on additional RGB animations. */
+#    define RGB_MATRIX_FRAMEBUFFER_EFFECTS
+#    define RGB_MATRIX_KEYPRESSES
 #endif
 
 #if defined(RGBLIGHT_ENABLE)
-    /* Turn off RGB underglow when the host goes to sleep. */
-    #define RGBLIGHT_SLEEP
+/* Turn off RGB underglow when the host goes to sleep. */
+#    define RGBLIGHT_SLEEP
 
-    /* Keep RGB underglow level increments consistent across keyboards. */
-    #undef RGBLIGHT_HUE_STEP
-    #undef RGBLIGHT_SAT_STEP
-    #undef RGBLIGHT_VAL_STEP
+/* Keep RGB underglow level increments consistent across keyboards. */
+#    undef RGBLIGHT_HUE_STEP
+#    undef RGBLIGHT_SAT_STEP
+#    undef RGBLIGHT_VAL_STEP
 
-    #define RGBLIGHT_HUE_STEP 8
-    #define RGBLIGHT_SAT_STEP 17
-    #define RGBLIGHT_VAL_STEP 17
+#    define RGBLIGHT_HUE_STEP 8
+#    define RGBLIGHT_SAT_STEP 17
+#    define RGBLIGHT_VAL_STEP 17
 #endif
 
 #if defined(BACKLIGHT_ENABLE)
-    /* Enable backlight breathing across the board. */
-    #define BACKLIGHT_BREATHING
+/* Enable backlight breathing across the board. */
+#    define BACKLIGHT_BREATHING
 
-    /* Keep backlight level increments consistent across keyboards. */
-    #undef BACKLIGHT_LEVELS
+/* Keep backlight level increments consistent across keyboards. */
+#    undef BACKLIGHT_LEVELS
 
-    #define BACKLIGHT_LEVELS 7
+#    define BACKLIGHT_LEVELS 7
 #endif

--- a/users/bcat/config.h
+++ b/users/bcat/config.h
@@ -68,23 +68,3 @@
 
     #define BACKLIGHT_LEVELS 7
 #endif
-
-#if defined(MOUSEKEY_ENABLE)
-    /* Make mouse operation smoother. */
-    #undef MOUSEKEY_DELAY
-    #undef MOUSEKEY_INTERVAL
-
-    #define MOUSEKEY_DELAY 0
-    #define MOUSEKEY_INTERVAL 16
-
-    /* Lower mouse speed to adjust for reduced MOUSEKEY_INTERVAL. */
-    #undef MOUSEKEY_MAX_SPEED
-    #undef MOUSEKEY_TIME_TO_MAX
-    #undef MOUSEKEY_WHEEL_MAX_SPEED
-    #undef MOUSEKEY_WHEEL_TIME_TO_MAX
-
-    #define MOUSEKEY_MAX_SPEED 7
-    #define MOUSEKEY_TIME_TO_MAX 150
-    #define MOUSEKEY_WHEEL_MAX_SPEED 3
-    #define MOUSEKEY_WHEEL_TIME_TO_MAX 150
-#endif

--- a/users/bcat/readme.md
+++ b/users/bcat/readme.md
@@ -1,0 +1,13 @@
+# bcat's userspace
+
+This is some code and config shared by all of [my](https://github.com/bcat)
+keyboards. I have a few different keymaps spread throughout the repo; however,
+they are all derived from two "canonical" keymaps for my preferred layouts:
+
+* For typing, my canonical layout is my
+[Crkbd](https://github.com/qmk/qmk_firmware/tree/master/keyboards/crkbd/keymaps/bcat)
+(split ergo, columnar-staggered) layout.
+
+* For gaming, my canonical layout is my
+[Tsangan](https://github.com/qmk/qmk_firmware/tree/master/layouts/community/60_tsangan_hhkb/bcat)
+(row-staggered) layout.

--- a/users/bcat/rules.mk
+++ b/users/bcat/rules.mk
@@ -6,18 +6,30 @@ BOOTMAGIC_ENABLE = lite
 # Enable media keys on all keyboards.
 EXTRAKEY_ENABLE = yes
 
-# Disable some unwanted features on all keyboards.
-API_SYSEX_ENABLE = no
-COMMAND_ENABLE = no
-CONSOLE_ENABLE = no
-FAUXCLICKY_ENABLE = no
-MIDI_ENABLE = no
-MOUSEKEY_ENABLE = no
-NKRO_ENABLE = no
-SLEEP_LED_ENABLE = no
-UCIS_ENABLE = no
-UNICODE_ENABLE = no
-UNICODEMAP_ENABLE = no
-
 # Enable link-time optimization to reduce binary size.
 LINK_TIME_OPTIMIZATION_ENABLE = yes
+
+# Disable unused build options on all keyboards.
+COMMAND_ENABLE = no
+CONSOLE_ENABLE = no
+MOUSEKEY_ENABLE = no
+NKRO_ENABLE = no
+TERMINAL_ENABLE = no
+
+# Disable unused hardware options on all keyboards.
+FAUXCLICKY_ENABLE = no
+MIDI_ENABLE = no
+SLEEP_LED_ENABLE = no
+
+# Disable unused other options.
+API_SYSEX_ENABLE = no
+AUTO_SHIFT_ENABLE = no
+COMBO_ENABLE = no
+KEYBOARD_LOCK_ENABLE = no
+KEY_LOCK_ENABLE = no
+LEADER_ENABLE = no
+SWAP_HANDS_ENABLE = no
+TAP_DANCE_ENABLE = no
+UCIS_ENABLE = no
+UNICODEMAP_ENABLE = no
+UNICODE_ENABLE = no


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

* Turned on `SPLIT_USB_DETECT` in my Lily58 keymap since I'm rebuilding it with buggy Elite-C v3 controllers.
* Turned off a few more unused features in my userspace's `rules.mk` file.
* Ran `clang-format` on my userspace.
* Updated my Crkbd and Lily58 keymap readme files to make the Crkbd the "canonical" layout, as that's my daily driver. Now the Crkbd readme lists a bunch of reasons why things are laid out the way they are, and the Lily58 readme just lists the delta from the canonical Crkbd keymap.
* Added a readme to my userspace pointing at my "canonical" keymaps.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [X] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
