### PR TITLE
BACKLIGHT_ON_STATE config.h fixes

### DIFF
--- a/keyboards/amjkeyboard/amj66/config.h
+++ b/keyboards/amjkeyboard/amj66/config.h
@@ -43,7 +43,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define BACKLIGHT_LEVELS 3
 #define BACKLIGHT_BREATHING
 #define BREATHING_PERIOD 6
-#define BACKLIGHT_ON_STATE 1
 
 /* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
 #define DEBOUNCE 5

--- a/keyboards/duck/orion/v3/config.h
+++ b/keyboards/duck/orion/v3/config.h
@@ -43,7 +43,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define BACKLIGHT_PINS { B1, B2, B3, E6 }
 #define BACKLIGHT_LED_COUNT 4
 #define BACKLIGHT_LEVELS 10
-#define BACKLIGHT_ON_STATE 1
 
 #define RGBLIGHT_ANIMATIONS
 #define RGB_DI_PIN D6

--- a/keyboards/gray_studio/cod67/config.h
+++ b/keyboards/gray_studio/cod67/config.h
@@ -52,6 +52,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  * https://docs.qmk.fm/#/feature_backlight?id=timer-assisted-pwm-implementation
  */
 #define BACKLIGHT_PIN D4
+#define BACKLIGHT_ON_STATE 0
 
 #define RGB_DI_PIN B2
 #ifdef RGB_DI_PIN

--- a/keyboards/gray_studio/cod67/readme.md
+++ b/keyboards/gray_studio/cod67/readme.md
@@ -39,7 +39,3 @@ After putting your COD67 in bootloader mode, it will show up as a drive.
 * Drag and drop your new `COD67.BIN` to the drive.
 * Wait a few seconds for it to write. The caps lock LED flashes rapidly while writing.
 * Press the `Esc` key or eject the drive in Finder to reset the board. You are now ready to type!
-
-## Notes
-
-The backlight pin is attached to a non PWM pin `D4` so the backlight is only on/off.

--- a/keyboards/handwired/aek64/config.h
+++ b/keyboards/handwired/aek64/config.h
@@ -27,9 +27,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define PRODUCT         AEK64
 #define DESCRIPTION     QMK keyboard firmware for AEK64 handwired
 
-/* Define the backlight */
-/*#define BACKLIGHT_ON_STATE 1*/
-
 /* key matrix size */
 #define MATRIX_ROWS 5
 #define MATRIX_COLS 14

--- a/keyboards/handwired/bdn9_ble/config.h
+++ b/keyboards/handwired/bdn9_ble/config.h
@@ -41,7 +41,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define BACKLIGHT_PIN F6
 // #define BACKLIGHT_BREATHING
 #define BACKLIGHT_LEVELS 5
-#define BACKLIGHT_ON_STATE 1
 
 /* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
 #define DEBOUNCE 5

--- a/keyboards/staryu/config.h
+++ b/keyboards/staryu/config.h
@@ -65,7 +65,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define BACKLIGHT_PINS { C2, C7, D5, D6, B0 }
 #define BACKLIGHT_LED_COUNT 5
 #define BACKLIGHT_LEVELS 10
-#define BACKLIGHT_ON_STATE 1
 
 /* Set 0 if debouncing isn't needed */
 #define DEBOUNCE 5

--- a/keyboards/tokyo60/config.h
+++ b/keyboards/tokyo60/config.h
@@ -18,7 +18,6 @@
 #define BACKLIGHT_PIN B7
 #ifdef BACKLIGHT_PIN
 #define BACKLIGHT_LEVELS 6
-//#define BACKLIGHT_ON_STATE 1
 #endif
 
 /* COL2ROW or ROW2COL */

--- a/keyboards/xd68/config.h
+++ b/keyboards/xd68/config.h
@@ -52,6 +52,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define BACKLIGHT_LEVELS 6
 #define BACKLIGHT_BREATHING
 #define BREATHING_PERIOD 6
+#define BACKLIGHT_ON_STATE 0
 
 /* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
 #define DEBOUNCE 5

--- a/keyboards/xd75/config.h
+++ b/keyboards/xd75/config.h
@@ -51,6 +51,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define BACKLIGHT_PIN F5
 #define BACKLIGHT_LEVELS 6
+#define BACKLIGHT_ON_STATE 0
 
 /* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
 #define DEBOUNCE 5


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Removing instances of `BACKLIGHT_ON_STATE 1` since it is now the default for both hardware and software PWM, and added some `BACKLIGHT_ON_STATE 0`s for some other boards. The only one I'm not sure of is the COD67 -- @rys you appear to have one; could you confirm whether the inswitch backlight LEDs function properly with this change?

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
