### PR TITLE
Streamline the macos install process

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -13,18 +13,17 @@ QMK requires Python 3.6 or greater. We try to keep the number of requirements sm
 If you have installed [Homebrew](https://brew.sh) you can tap and install QMK:
 
 ```
-brew tap qmk/qmk
-brew install qmk
+brew install qmk/qmk/qmk
 export QMK_HOME='~/qmk_firmware' # Optional, set the location for `qmk_firmware`
 qmk setup  # This will clone `qmk/qmk_firmware` and optionally set up your build environment
 ```
 
-### Install Using easy_install or pip :id=install-using-easy_install-or-pip
+### Install Using pip :id=install-using-easy_install-or-pip
 
-If your system is not listed above you can install QMK manually. First ensure that you have python 3.6 (or later) installed and have installed pip. Then install QMK with this command:
+If your system is not listed above you can install QMK manually. First ensure that you have Python 3.6 (or later) installed and have installed pip. Then install QMK with this command:
 
 ```
-pip3 install qmk
+python3 -m pip install qmk
 export QMK_HOME='~/qmk_firmware' # Optional, set the location for `qmk_firmware`
 qmk setup  # This will clone `qmk/qmk_firmware` and optionally set up your build environment
 ```

--- a/docs/faq_build.md
+++ b/docs/faq_build.md
@@ -113,26 +113,16 @@ OPT_DEFS += -DBOOTLOADER_SIZE=2048
 ```
 
 ## `avr-gcc: internal compiler error: Abort trap: 6 (program cc1)` on MacOS
+
 This is an issue with updating on brew, causing symlinks that avr-gcc depend on getting mangled.
 
 The solution is to remove and reinstall all affected modules.
 
 ```
-brew rm avr-gcc
-brew rm avr-gcc@8
-brew rm dfu-programmer
-brew rm dfu-util
-brew rm gcc-arm-none-eabi
-brew rm arm-gcc-bin@8
-brew rm avrdude
-brew install avr-gcc@8
-brew install dfu-programmer
-brew install dfu-util
-brew install arm-gcc-bin@8
-brew install avrdude
+brew rm avr-gcc avr-gcc@8 dfu-programmer dfu-util gcc-arm-none-eabi arm-gcc-bin@8 avrdude qmk
+brew install qmk/qmk/qmk
 brew link --force avr-gcc@8
 brew link --force arm-gcc-bin@8
-
 ```
 
 ### `avr-gcc` and LUFA

--- a/docs/newbs_getting_started.md
+++ b/docs/newbs_getting_started.md
@@ -57,10 +57,9 @@ You may be asked to close and reopen the window. Do this and keep running the ab
 
 You will need to install Homebrew. Follow the instructions on the [Homebrew homepage](https://brew.sh).
 
-After Homebrew is installed run these commands:
+After Homebrew is installed run this command:
 
-    brew tap qmk/qmk
-    brew install qmk
+    brew install qmk/qmk/qmk
 
 ### Linux
 

--- a/util/macos_install.sh
+++ b/util/macos_install.sh
@@ -21,11 +21,10 @@ if ! brew --version >/dev/null 2>&1; then
 	done
 fi
 
-brew tap osx-cross/avr
-brew tap osx-cross/arm
+# All macOS dependencies are managed in the homebrew package:
+#     https://github.com/qmk/homebrew-qmk
 brew update
-brew install avr-gcc@8 arm-gcc-bin@8 dfu-programmer avrdude clang-format dfu-util python3
-brew install --HEAD https://raw.githubusercontent.com/robertgzr/homebrew-tap/master/bootloadhid.rb
+brew install qmk/qmk/qmk
 brew link --force avr-gcc@8
 brew link --force arm-gcc-bin@8
 


### PR DESCRIPTION
# Description

The Homebrew formula was recently changed to included all the dependencies needed for QMK. This PR makes a few tweaks to streamline the installation process on macOS based on that change.

After this is merged there is only one step needed to setup a fully functional build environment: `brew install qmk/qmk/qmk`

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Enhancement/optimization
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
