### PR TITLE
Add Keebio lighting defaults

### DIFF
--- a/keyboards/keebio/bdn9/bdn9.c
+++ b/keyboards/keebio/bdn9/bdn9.c
@@ -1,1 +1,18 @@
 #include "bdn9.h"
+
+void eeconfig_init_kb(void) {
+#ifdef BACKLIGHT_ENABLE
+    backlight_enable();
+    backlight_level(5);
+#endif
+#ifdef RGBLIGHT_ENABLE
+    rgblight_enable(); // Enable RGB by default
+    rgblight_sethsv(0, 255, 255);  // Set default HSV - red hue, full saturation, full brightness
+#ifdef RGBLIGHT_ANIMATIONS
+    rgblight_mode(RGBLIGHT_MODE_RAINBOW_SWIRL + 2); // set to RGB_RAINBOW_SWIRL by default
+#endif
+#endif
+
+    eeconfig_update_kb(0);
+    eeconfig_init_user();
+}

--- a/keyboards/keebio/chocopad/chocopad.c
+++ b/keyboards/keebio/chocopad/chocopad.c
@@ -1,1 +1,18 @@
 #include "chocopad.h"
+
+void eeconfig_init_kb(void) {
+#ifdef BACKLIGHT_ENABLE
+    backlight_enable();
+    backlight_level(5);
+#endif
+#ifdef RGBLIGHT_ENABLE
+    rgblight_enable(); // Enable RGB by default
+    rgblight_sethsv(0, 255, 255);  // Set default HSV - red hue, full saturation, full brightness
+#ifdef RGBLIGHT_ANIMATIONS
+    rgblight_mode(RGBLIGHT_MODE_RAINBOW_SWIRL + 2); // set to RGB_RAINBOW_SWIRL by default
+#endif
+#endif
+
+    eeconfig_update_kb(0);
+    eeconfig_init_user();
+}

--- a/keyboards/keebio/dilly/dilly.c
+++ b/keyboards/keebio/dilly/dilly.c
@@ -1,1 +1,18 @@
 #include "dilly.h"
+
+void eeconfig_init_kb(void) {
+#ifdef BACKLIGHT_ENABLE
+    backlight_enable();
+    backlight_level(3);
+#endif
+#ifdef RGBLIGHT_ENABLE
+    rgblight_enable(); // Enable RGB by default
+    rgblight_sethsv(0, 255, 255);  // Set default HSV - red hue, full saturation, full brightness
+#ifdef RGBLIGHT_ANIMATIONS
+    rgblight_mode(RGBLIGHT_MODE_RAINBOW_SWIRL + 2); // set to RGB_RAINBOW_SWIRL by default
+#endif
+#endif
+
+    eeconfig_update_kb(0);
+    eeconfig_init_user();
+}

--- a/keyboards/keebio/ergodicity/ergodicity.c
+++ b/keyboards/keebio/ergodicity/ergodicity.c
@@ -1,51 +1,18 @@
-/* Copyright 2019 Keebio
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
 #include "ergodicity.h"
 
-// Optional override functions below.
-// You can leave any or all of these undefined.
-// These are only required if you want to perform custom actions.
+void eeconfig_init_kb(void) {
+#ifdef BACKLIGHT_ENABLE
+    backlight_enable();
+    backlight_level(5);
+#endif
+#ifdef RGBLIGHT_ENABLE
+    rgblight_enable(); // Enable RGB by default
+    rgblight_sethsv(0, 255, 255);  // Set default HSV - red hue, full saturation, full brightness
+#ifdef RGBLIGHT_ANIMATIONS
+    rgblight_mode(RGBLIGHT_MODE_RAINBOW_SWIRL + 2); // set to RGB_RAINBOW_SWIRL by default
+#endif
+#endif
 
-/*
-
-void matrix_init_kb(void) {
-  // put your keyboard start-up code here
-  // runs once when the firmware starts up
-
-  matrix_init_user();
+    eeconfig_update_kb(0);
+    eeconfig_init_user();
 }
-
-void matrix_scan_kb(void) {
-  // put your looping keyboard code here
-  // runs every cycle (a lot)
-
-  matrix_scan_user();
-}
-
-bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
-  // put your per-action keyboard code here
-  // runs for every action, just before processing by the firmware
-
-  return process_record_user(keycode, record);
-}
-
-void led_set_kb(uint8_t usb_led) {
-  // put your keyboard LED indicator (ex: Caps Lock LED) toggling code here
-
-  led_set_user(usb_led);
-}
-
-*/

--- a/keyboards/keebio/iris/rev2/rev2.c
+++ b/keyboards/keebio/iris/rev2/rev2.c
@@ -1,12 +1,5 @@
 #include "rev2.h"
 
-#ifdef SSD1306OLED
-void led_set_kb(uint8_t usb_led) {
-    // put your keyboard LED indicator (ex: Caps Lock LED) toggling code here
-    led_set_user(usb_led);
-}
-#endif
-
 #ifdef SWAP_HANDS_ENABLE
 __attribute__ ((weak))
 // swap-hands action needs a matrix to define the swap
@@ -26,3 +19,19 @@ const keypos_t hand_swap_config[MATRIX_ROWS][MATRIX_COLS] = {
 };
 #endif
 
+void eeconfig_init_kb(void) {
+#ifdef BACKLIGHT_ENABLE
+    backlight_enable();
+    backlight_level(3);
+#endif
+#ifdef RGBLIGHT_ENABLE
+    rgblight_enable(); // Enable RGB by default
+    rgblight_sethsv(0, 255, 255);  // Set default HSV - red hue, full saturation, full brightness
+#ifdef RGBLIGHT_ANIMATIONS
+    rgblight_mode(RGBLIGHT_MODE_RAINBOW_SWIRL + 2); // set to RGB_RAINBOW_SWIRL by default
+#endif
+#endif
+
+    eeconfig_update_kb(0);
+    eeconfig_init_user();
+}

--- a/keyboards/keebio/iris/rev3/rev3.c
+++ b/keyboards/keebio/iris/rev3/rev3.c
@@ -1,12 +1,5 @@
 #include "rev3.h"
 
-#ifdef SSD1306OLED
-void led_set_kb(uint8_t usb_led) {
-    // put your keyboard LED indicator (ex: Caps Lock LED) toggling code here
-    led_set_user(usb_led);
-}
-#endif
-
 #ifdef SWAP_HANDS_ENABLE
 __attribute__ ((weak))
 // swap-hands action needs a matrix to define the swap
@@ -25,3 +18,20 @@ const keypos_t hand_swap_config[MATRIX_ROWS][MATRIX_COLS] = {
     {{0,4}, {1,4}, {2,4}, {3,4}, {4,4}, {5,4}},
 };
 #endif
+
+void eeconfig_init_kb(void) {
+#ifdef BACKLIGHT_ENABLE
+    backlight_enable();
+    backlight_level(3);
+#endif
+#ifdef RGBLIGHT_ENABLE
+    rgblight_enable(); // Enable RGB by default
+    rgblight_sethsv(0, 255, 255);  // Set default HSV - red hue, full saturation, full brightness
+#ifdef RGBLIGHT_ANIMATIONS
+    rgblight_mode(RGBLIGHT_MODE_RAINBOW_SWIRL + 2); // set to RGB_RAINBOW_SWIRL by default
+#endif
+#endif
+
+    eeconfig_update_kb(0);
+    eeconfig_init_user();
+}

--- a/keyboards/keebio/iris/rev4/rev4.c
+++ b/keyboards/keebio/iris/rev4/rev4.c
@@ -1,1 +1,18 @@
 #include "rev4.h"
+
+void eeconfig_init_kb(void) {
+#ifdef BACKLIGHT_ENABLE
+    backlight_enable();
+    backlight_level(3);
+#endif
+#ifdef RGBLIGHT_ENABLE
+    rgblight_enable(); // Enable RGB by default
+    rgblight_sethsv(0, 255, 255);  // Set default HSV - red hue, full saturation, full brightness
+#ifdef RGBLIGHT_ANIMATIONS
+    rgblight_mode(RGBLIGHT_MODE_RAINBOW_SWIRL + 2); // set to RGB_RAINBOW_SWIRL by default
+#endif
+#endif
+
+    eeconfig_update_kb(0);
+    eeconfig_init_user();
+}

--- a/keyboards/keebio/levinson/rev2/rev2.c
+++ b/keyboards/keebio/levinson/rev2/rev2.c
@@ -1,22 +1,18 @@
 #include "levinson.h"
 
-#ifdef SSD1306OLED
-void led_set_kb(uint8_t usb_led) {
-    // put your keyboard LED indicator (ex: Caps Lock LED) toggling code here
-    led_set_user(usb_led);
-}
+void eeconfig_init_kb(void) {
+#ifdef BACKLIGHT_ENABLE
+    backlight_enable();
+    backlight_level(5);
+#endif
+#ifdef RGBLIGHT_ENABLE
+    rgblight_enable(); // Enable RGB by default
+    rgblight_sethsv(0, 255, 255);  // Set default HSV - red hue, full saturation, full brightness
+#ifdef RGBLIGHT_ANIMATIONS
+    rgblight_mode(RGBLIGHT_MODE_RAINBOW_SWIRL + 2); // set to RGB_RAINBOW_SWIRL by default
+#endif
 #endif
 
-void matrix_init_kb(void) {
-
-    // // green led on
-    // DDRD |= (1<<5);
-    // PORTD &= ~(1<<5);
-
-    // // orange led on
-    // DDRB |= (1<<0);
-    // PORTB &= ~(1<<0);
-
-	matrix_init_user();
-};
-
+    eeconfig_update_kb(0);
+    eeconfig_init_user();
+}

--- a/keyboards/keebio/levinson/rev3/rev3.c
+++ b/keyboards/keebio/levinson/rev3/rev3.c
@@ -1,22 +1,18 @@
 #include "levinson.h"
 
-#ifdef SSD1306OLED
-void led_set_kb(uint8_t usb_led) {
-    // put your keyboard LED indicator (ex: Caps Lock LED) toggling code here
-    led_set_user(usb_led);
-}
+void eeconfig_init_kb(void) {
+#ifdef BACKLIGHT_ENABLE
+    backlight_enable();
+    backlight_level(5);
+#endif
+#ifdef RGBLIGHT_ENABLE
+    rgblight_enable(); // Enable RGB by default
+    rgblight_sethsv(0, 255, 255);  // Set default HSV - red hue, full saturation, full brightness
+#ifdef RGBLIGHT_ANIMATIONS
+    rgblight_mode(RGBLIGHT_MODE_RAINBOW_SWIRL + 2); // set to RGB_RAINBOW_SWIRL by default
+#endif
 #endif
 
-void matrix_init_kb(void) {
-
-    // // green led on
-    // DDRD |= (1<<5);
-    // PORTD &= ~(1<<5);
-
-    // // orange led on
-    // DDRB |= (1<<0);
-    // PORTB &= ~(1<<0);
-
-	matrix_init_user();
-};
-
+    eeconfig_update_kb(0);
+    eeconfig_init_user();
+}

--- a/keyboards/keebio/nyquist/rev2/rev2.c
+++ b/keyboards/keebio/nyquist/rev2/rev2.c
@@ -1,21 +1,18 @@
 #include "rev2.h"
 
-#ifdef SSD1306OLED
-void led_set_kb(uint8_t usb_led) {
-    // put your keyboard LED indicator (ex: Caps Lock LED) toggling code here
-    led_set_user(usb_led);
-}
+void eeconfig_init_kb(void) {
+#ifdef BACKLIGHT_ENABLE
+    backlight_enable();
+    backlight_level(5);
+#endif
+#ifdef RGBLIGHT_ENABLE
+    rgblight_enable(); // Enable RGB by default
+    rgblight_sethsv(0, 255, 255);  // Set default HSV - red hue, full saturation, full brightness
+#ifdef RGBLIGHT_ANIMATIONS
+    rgblight_mode(RGBLIGHT_MODE_RAINBOW_SWIRL + 2); // set to RGB_RAINBOW_SWIRL by default
+#endif
 #endif
 
-void matrix_init_kb(void) {
-
-    // // green led on
-    // DDRD |= (1<<5);
-    // PORTD &= ~(1<<5);
-
-    // // orange led on
-    // DDRB |= (1<<0);
-    // PORTB &= ~(1<<0);
-
-	matrix_init_user();
-};
+    eeconfig_update_kb(0);
+    eeconfig_init_user();
+}

--- a/keyboards/keebio/nyquist/rev3/rev3.c
+++ b/keyboards/keebio/nyquist/rev3/rev3.c
@@ -1,21 +1,18 @@
 #include "rev3.h"
 
-#ifdef SSD1306OLED
-void led_set_kb(uint8_t usb_led) {
-    // put your keyboard LED indicator (ex: Caps Lock LED) toggling code here
-    led_set_user(usb_led);
-}
+void eeconfig_init_kb(void) {
+#ifdef BACKLIGHT_ENABLE
+    backlight_enable();
+    backlight_level(5);
+#endif
+#ifdef RGBLIGHT_ENABLE
+    rgblight_enable(); // Enable RGB by default
+    rgblight_sethsv(0, 255, 255);  // Set default HSV - red hue, full saturation, full brightness
+#ifdef RGBLIGHT_ANIMATIONS
+    rgblight_mode(RGBLIGHT_MODE_RAINBOW_SWIRL + 2); // set to RGB_RAINBOW_SWIRL by default
+#endif
 #endif
 
-void matrix_init_kb(void) {
-
-    // // green led on
-    // DDRD |= (1<<5);
-    // PORTD &= ~(1<<5);
-
-    // // orange led on
-    // DDRB |= (1<<0);
-    // PORTB &= ~(1<<0);
-
-	matrix_init_user();
-};
+    eeconfig_update_kb(0);
+    eeconfig_init_user();
+}

--- a/keyboards/keebio/quefrency/rev1/rev1.c
+++ b/keyboards/keebio/quefrency/rev1/rev1.c
@@ -1,5 +1,14 @@
 #include "quefrency.h"
 
-void matrix_init_kb(void) {
-	matrix_init_user();
-};
+void eeconfig_init_kb(void) {
+#ifdef RGBLIGHT_ENABLE
+    rgblight_enable(); // Enable RGB by default
+    rgblight_sethsv(0, 255, 255);  // Set default HSV - red hue, full saturation, full brightness
+#ifdef RGBLIGHT_ANIMATIONS
+    rgblight_mode(RGBLIGHT_MODE_RAINBOW_SWIRL + 2); // set to RGB_RAINBOW_SWIRL by default
+#endif
+#endif
+
+    eeconfig_update_kb(0);
+    eeconfig_init_user();
+}

--- a/keyboards/keebio/viterbi/rev2/rev2.c
+++ b/keyboards/keebio/viterbi/rev2/rev2.c
@@ -1,1 +1,18 @@
 #include "viterbi.h"
+
+void eeconfig_init_kb(void) {
+#ifdef BACKLIGHT_ENABLE
+    backlight_enable();
+    backlight_level(5);
+#endif
+#ifdef RGBLIGHT_ENABLE
+    rgblight_enable(); // Enable RGB by default
+    rgblight_sethsv(0, 255, 255);  // Set default HSV - red hue, full saturation, full brightness
+#ifdef RGBLIGHT_ANIMATIONS
+    rgblight_mode(RGBLIGHT_MODE_RAINBOW_SWIRL + 2); // set to RGB_RAINBOW_SWIRL by default
+#endif
+#endif
+
+    eeconfig_update_kb(0);
+    eeconfig_init_user();
+}


### PR DESCRIPTION
## Description

Adds lighting defaults for Keebio boards, so users aren't confused that their lighting isn't working.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
