### PR TITLE
Restore ability use RGBLIGHT_CUSTOM_DRIVER (fixes issue #8889)

### DIFF
--- a/docs/feature_rgblight.md
+++ b/docs/feature_rgblight.md
@@ -23,11 +23,12 @@ RGBLIGHT_ENABLE = yes
 
 At minimum you must define the data pin your LED strip is connected to, and the number of LEDs in the strip, in your `config.h`. If your keyboard has onboard RGB LEDs, and you are simply creating a keymap, you usually won't need to modify these.
 
-|Define         |Description                                                                                              |
-|---------------|---------------------------------------------------------------------------------------------------------|
-|`RGB_DI_PIN`   |The pin connected to the data pin of the LEDs                                                            |
-|`RGBLED_NUM`   |The number of LEDs connected                                                                             |
-|`RGBLED_SPLIT` |(Optional) For split keyboards, the number of LEDs connected on each half directly wired to `RGB_DI_PIN` |
+|Define                   |Description                                                                                                 |
+|-------------------------|------------------------------------------------------------------------------------------------------------|
+|`RGB_DI_PIN`             |The pin connected to the data pin of the LEDs                                                               |
+|`RGBLED_NUM`             |The number of LEDs connected                                                                                |
+|`RGBLED_SPLIT`           |(Optional) For split keyboards, the number of LEDs connected on each half directly wired to `RGB_DI_PIN`    |
+|`RGBLIGHT_CUSTOM_DRIVER` |(Optional) If defined, allows custom implementation of `rgblight_set_driver()` to handle unusual LED setups |
 
 Then you should be able to use the keycodes below to change the RGB lighting to your liking.
 
@@ -245,6 +246,7 @@ If you need to change your RGB lighting in code, for example in a macro to chang
 |Function                                    |Description                                |
 |--------------------------------------------|-------------------------------------------|
 |`rgblight_set()`                            |Flash out led buffers to LEDs              |
+|`rgblight_set_driver()`                     |Should not be called directly. Implements the LED setting. Can be overriden by defining `RGBLIGHT_CUSTOM_DRIVER` (see below) |
 |`rgblight_set_clipping_range(pos, num)`     |Set clipping Range. see [Clipping Range](#clipping-range) |
 
 Example:
@@ -254,6 +256,8 @@ sethsv(HSV_RED,   (LED_TYPE *)&led[1]); // led 1
 sethsv(HSV_GREEN, (LED_TYPE *)&led[2]); // led 2
 rgblight_set(); // Utility functions do not call rgblight_set() automatically, so they need to be called explicitly.
 ```
+
+If your keyboard has an unusal LED hardware setup that is not supported by QMK core code, you can `#define RGBLIGHT_CUSTOM_DRIVER` and implement your own `rgblight_set_driver()` so that when `rgblight_set()` is called, your custom logic will be used.
 
 ### Effects and Animations Functions
 #### effect range setting

--- a/keyboards/ergodox_ez/led_i2c.c
+++ b/keyboards/ergodox_ez/led_i2c.c
@@ -27,7 +27,7 @@
 
 extern rgblight_config_t rgblight_config;
 
-void rgblight_set(void) {
+void rgblight_set_driver(void) {
     if (!rgblight_config.enable) {
         for (uint8_t i = 0; i < RGBLED_NUM; i++) {
             led[i].r = 0;

--- a/keyboards/lfkeyboards/lighting.c
+++ b/keyboards/lfkeyboards/lighting.c
@@ -87,7 +87,7 @@ void set_underglow(uint8_t red, uint8_t green, uint8_t blue){
 }
 
 
-void rgblight_set(void) {
+void rgblight_set_driver(void) {
 #ifdef RGBLIGHT_ENABLE
     for(uint8_t i = 0; (i < sizeof(rgb_sequence)) && (i < RGBLED_NUM); i++){
         if(rgblight_config.enable){

--- a/keyboards/matrix/noah/noah.c
+++ b/keyboards/matrix/noah/noah.c
@@ -17,7 +17,7 @@ extern rgblight_config_t rgblight_config;
 #endif
 LED_TYPE noah_leds[RGBLED_NUM];
 static bool noah_led_mode = false;
-void rgblight_set(void) {
+void rgblight_set_driver(void) {
     memset(&noah_leds[0], 0, sizeof(noah_leds));
     if (!rgblight_config.enable) {
         for (uint8_t i = 0; i < RGBLED_NUM; i++) {

--- a/keyboards/v60_type_r/v60_type_r.c
+++ b/keyboards/v60_type_r/v60_type_r.c
@@ -131,7 +131,7 @@ void set_rgb_pin_off(uint8_t pin) {
 	PORTF |= _BV(pin);
 }
 
-void rgblight_set(void) {
+void rgblight_set_driver(void) {
 	  // xprintf("Setting RGB underglow\n");
     if (!rgblight_config.enable) {
           led[0].r = 0;

--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -664,16 +664,19 @@ static void rgblight_layers_write(void) {
 }
 #endif
 
-#ifndef RGBLIGHT_CUSTOM_DRIVER
 void rgblight_set(void) {
-    LED_TYPE *start_led;
-    uint16_t  num_leds = clipping_num_leds;
-
-#    ifdef RGBLIGHT_LAYERS
+#ifdef RGBLIGHT_LAYERS
     if (rgblight_layers != NULL) {
         rgblight_layers_write();
     }
-#    endif
+#endif
+    rgblight_set_driver();
+}
+
+#ifndef RGBLIGHT_CUSTOM_DRIVER
+void rgblight_set_driver(void) {
+    LED_TYPE *start_led;
+    uint16_t  num_leds = clipping_num_leds;
 
     if (!rgblight_config.enable) {
         for (uint8_t i = effect_start_pos; i < effect_end_pos; i++) {

--- a/quantum/rgblight.h
+++ b/quantum/rgblight.h
@@ -237,6 +237,7 @@ void setrgb(uint8_t r, uint8_t g, uint8_t b, LED_TYPE *led1);
 
 /* === Low level Functions === */
 void rgblight_set(void);
+void rgblight_set_driver(void);
 void rgblight_set_clipping_range(uint8_t start_pos, uint8_t num_leds);
 
 /* === Effects and Animations Functions === */


### PR DESCRIPTION
## Description

Issue #8889 observes that since `RGBLIGHT_LAYERS` was implemented, it is no longer possible to implement an override of `rgblight_set()` using `RGBLIGHT_CUSTOM_DRIVER` in a way that maintains the correct operation of lighting layers, because `rgblight_layers_write()` is static and thus cannot be called from user code.

See #8889 for more detail, but in short, it's probably not right to just expose `rgblight_layers_write()`, as that just requires each person overriding `rgblight_set()` to remember to call it, resulting in code duplication, potential errors, etc.

I have instead resolved the issue by splitting `rgblight_set()` into:
* `rgblight_set_driver()` – does _only_ what `rgblight_set()` used to do before lighting layers were added. Can be overridden if necessary by defining `RGBLIGHT_CUSTOM_DRIVER`.  
* `rgblight_set()` – calls `rgblight_layers_write()` and then calls `rgblight_set_driver()`.

By doing this:
* Only the < 10 custom implementations of `rgblight_set()` needed to be changed to instead be named `rgblight_set_driver()`
* There in no need for those who override to call `rgblight_layers_write()`.
* No change is needed to the > 60 places where `rgblight_set()` is called.
* Current functionality is maintained, and now those kb's where `rgblight_set()` was overridden can now use lighting layers.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* Issue #8889 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
