### PR TITLE
Add encoder support to ta-65

### DIFF
--- a/keyboards/maartenwut/ta65/config.h
+++ b/keyboards/maartenwut/ta65/config.h
@@ -24,7 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define PRODUCT_ID      0x7465
 #define DEVICE_VER      0x0001
 #define MANUFACTURER    Maartenwut
-#define PRODUCT         TA-65
+#define PRODUCT         ta-65
 #define DESCRIPTION     A universal 65% PCB with underglow.
 
 /* key matrix size */
@@ -36,6 +36,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MATRIX_ROW_PINS {B4,D7,D6,D4,B3}
 #define MATRIX_COL_PINS {D2,D1,D0,D3,D5,C7,C6,B6,B5,F0,F1,F4,F5,F6,F7,B0}
 #define UNUSED_PINS
+
+#define ENCODERS_PAD_A { B2 }
+#define ENCODERS_PAD_B { B1 }
+
+/* Uncomment if your encoder doesn't react to every turn or skips */
+//#define ENCODER_RESOLUTION 2
 
 /* COL2ROW or ROW2COL */
 #define DIODE_DIRECTION COL2ROW

--- a/keyboards/maartenwut/ta65/keymaps/default/keymap.c
+++ b/keyboards/maartenwut/ta65/keymaps/default/keymap.c
@@ -20,7 +20,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 void encoder_update_user(uint8_t index, bool clockwise) {
   if (index == 0) { /* First encoder */
-    switch(biton32(layer_state)){
+    switch(get_highest_layer(layer_state)){
       case 0: //Layer 0
         if (!clockwise) { // Remove ! to reverse direction
           tap_code(KC_VOLU);

--- a/keyboards/maartenwut/ta65/keymaps/default/keymap.c
+++ b/keyboards/maartenwut/ta65/keymaps/default/keymap.c
@@ -1,17 +1,47 @@
 #include QMK_KEYBOARD_H
 
-// Each layer gets a name for readability, which is then used in the keymap matrix below.
-// The underscores don't mean anything - you can have a layer called STUFF or any other name.
-// Layer names don't all need to be of the same length, obviously, and you can also skip them
-// entirely and just use numbers.
-#define _MA 0
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
-[_MA] = LAYOUT_all(
-  KC_ESC,  KC_1,    KC_2,    KC_3, KC_4, KC_5, KC_6,   KC_7,   KC_8,   KC_9,    KC_0,    KC_MINS, KC_EQL,   KC_BSLS, KC_BSPC, KC_GRV,
-  KC_TAB,  KC_Q,    KC_W,    KC_E, KC_R, KC_T, KC_Y,   KC_U,   KC_I,   KC_O,    KC_P,    KC_LBRC, KC_RBRC,  KC_BSLS, KC_DEL,
-  KC_CAPS, KC_A,    KC_S,    KC_D, KC_F, KC_G, KC_H,   KC_J,   KC_K,   KC_L,    KC_SCLN, KC_QUOT, KC_BSLS,  KC_ENT,  KC_PGUP,
-  KC_LSFT, KC_NUBS, KC_Z,    KC_X, KC_C, KC_V, KC_B,   KC_N,   KC_M,   KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT,  KC_UP,   KC_PGDN,
-  KC_LCTL, KC_LGUI, KC_LALT,                   KC_SPC,                          KC_RALT, KC_APP,  KC_RCTRL, KC_LEFT, KC_DOWN, KC_RGHT)
+[0] = LAYOUT_all(
+  KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,   KC_9,     KC_0,    KC_MINS, KC_EQL,   KC_BSLS, KC_BSPC, KC_INS,
+  KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,   KC_O,     KC_P,    KC_LBRC, KC_RBRC,  KC_BSLS,          KC_DEL,
+  KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,   KC_L,     KC_SCLN, KC_QUOT, KC_BSLS,  KC_ENT,           KC_PGUP,
+  KC_LSFT, KC_NUBS, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,   KC_COMM,  KC_DOT,  KC_SLSH, KC_RSFT,  KC_UP,            KC_PGDN,
+  KC_LCTL, KC_LGUI, KC_LALT,                            KC_SPC,                             KC_RALT, MO(1),   KC_RCTRL, KC_LEFT, KC_DOWN, KC_RGHT),
+
+[1] = LAYOUT_all(
+  RESET,   _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,  _______, _______, _______,
+  _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,  _______,          _______,
+  _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,  _______,          _______,
+  _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,  _______,          _______,
+  _______, _______, _______,                            _______,                            _______, _______, _______,  _______, _______, _______),
+
 };
+
+void encoder_update_user(uint8_t index, bool clockwise) {
+  if (index == 0) { /* First encoder */
+    switch(biton32(layer_state)){
+      case 0: //Layer 0
+        if (!clockwise) { // Remove ! to reverse direction
+          tap_code(KC_VOLU);
+        } else {
+          tap_code(KC_VOLD);
+        }
+        break;
+      case 1: //Layer 1
+        if (!clockwise) {
+          tap_code(KC_WH_U);
+        } else {
+          tap_code(KC_WH_D);
+        }
+        break;
+      default:
+        if (!clockwise) {
+          tap_code(KC_VOLU);
+        } else {
+          tap_code(KC_VOLD);
+        }
+        break;
+    }
+  }
+}

--- a/keyboards/maartenwut/ta65/keymaps/default/keymap.c
+++ b/keyboards/maartenwut/ta65/keymaps/default/keymap.c
@@ -19,29 +19,20 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 };
 
 void encoder_update_user(uint8_t index, bool clockwise) {
-  if (index == 0) { /* First encoder */
-    switch(get_highest_layer(layer_state)){
-      case 0: //Layer 0
-        if (!clockwise) { // Remove ! to reverse direction
-          tap_code(KC_VOLU);
-        } else {
-          tap_code(KC_VOLD);
-        }
-        break;
-      case 1: //Layer 1
-        if (!clockwise) {
-          tap_code(KC_WH_U);
-        } else {
-          tap_code(KC_WH_D);
-        }
-        break;
-      default:
-        if (!clockwise) {
-          tap_code(KC_VOLU);
-        } else {
-          tap_code(KC_VOLD);
-        }
-        break;
-    }
+  switch(get_highest_layer(layer_state)){
+    case 1: //Layer 1
+      if (!clockwise) { // Remove ! to reverse direction
+        tap_code(KC_WH_U);
+      } else {
+        tap_code(KC_WH_D);
+      }
+      break;
+    default: //Layer 0
+      if (!clockwise) {
+        tap_code(KC_VOLU);
+      } else {
+        tap_code(KC_VOLD);
+      }
+      break;
   }
 }

--- a/keyboards/maartenwut/ta65/rules.mk
+++ b/keyboards/maartenwut/ta65/rules.mk
@@ -12,19 +12,24 @@ MCU = atmega32u4
 BOOTLOADER = qmk-dfu
 
 # Build Options
-#   comment out to disable the options.
+#   change yes to no to disable
 #
-BOOTMAGIC_ENABLE = lite	# Virtual DIP switch configuration
-MOUSEKEY_ENABLE = yes	# Mouse keys
-EXTRAKEY_ENABLE = yes	# Audio control and System control
-CONSOLE_ENABLE = no  	# Console for debug
-COMMAND_ENABLE = no     # Commands for debug and configuration
-NKRO_ENABLE = no		# USB Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
-RGBLIGHT_ENABLE = yes   # Enable keyboard underlight functionality
-BACKLIGHT_ENABLE = no  # Enable keyboard backlight functionality
-MIDI_ENABLE = no 		# MIDI controls
-AUDIO_ENABLE = no
-UNICODE_ENABLE = no 		# Unicode
-BLUETOOTH_ENABLE = no # Enable Bluetooth with the Adafruit EZ-Key HID
+BOOTMAGIC_ENABLE = lite     # Virtual DIP switch configuration
+MOUSEKEY_ENABLE = yes       # Mouse keys
+EXTRAKEY_ENABLE = yes       # Audio control and System control
+CONSOLE_ENABLE = yes        # Console for debug
+COMMAND_ENABLE = no         # Commands for debug and configuration
+# Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
+SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
+# if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+NKRO_ENABLE = no            # USB Nkey Rollover
+BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
+RGBLIGHT_ENABLE = yes       # Enable keyboard RGB underglow
+MIDI_ENABLE = no            # MIDI support
+BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
+AUDIO_ENABLE = no           # Audio output on port C6
+FAUXCLICKY_ENABLE = no      # Use buzzer to emulate clicky switches
+HD44780_ENABLE = no         # Enable support for HD44780 based LCDs
+ENCODER_ENABLE = yes
 
 LAYOUTS = 65_ansi 65_iso


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Adds support for a rotary encoder to the ta-65 and gives an example of how to use it in the default keymap. Also updated rules.mk to match the latest template.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
