### PR TITLE
Make personal keymaps a bit more consistent

### DIFF
--- a/keyboards/crkbd/keymaps/bcat/keymap.c
+++ b/keyboards/crkbd/keymaps/bcat/keymap.c
@@ -25,7 +25,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [LAYER_LOWER] = LAYOUT(
         KC_CAPS,  KC_EXLM,  KC_AT,    KC_HASH,  KC_DLR,   KC_PERC,                      KC_CIRC,  KC_AMPR,  KC_ASTR,  KC_LPRN,  KC_RPRN,  _______,
         _______,  _______,  _______,  _______,  _______,  _______,                      KC_PIPE,  KC_UNDS,  KC_PLUS,  KC_LCBR,  KC_RCBR,  KC_TILD,
-        _______,  _______,  KC_PSCR,  KC_SLCK,  KC_PAUS,  KC_APP,                       KC_BSLS,  KC_MINS,  KC_EQL,   KC_LBRC,  KC_RBRC,  KC_GRV,
+        _______,  KC_APP,   KC_PSCR,  KC_SLCK,  KC_PAUS,  _______,                      KC_BSLS,  KC_MINS,  KC_EQL,   KC_LBRC,  KC_RBRC,  KC_GRV,
                                                 _______,  _______,  _______,  _______,  _______,  _______
     ),
 

--- a/keyboards/crkbd/keymaps/bcat/readme.md
+++ b/keyboards/crkbd/keymaps/bcat/readme.md
@@ -53,7 +53,7 @@ on a layer, but that'd take some getting used to....)
 
 ## Lower layer
 
-![Lower layer layout](https://i.imgur.com/rDlSmrA.png)
+![Lower layer layout](https://i.imgur.com/SsxvCgy.png)
 
 ([KLE](http://www.keyboard-layout-editor.com/#/gists/c3fba5eaa2cd70fdfbdbc0f9e34d3bc0))
 

--- a/keyboards/kbdfans/kbd67/hotswap/keymaps/bcat/keymap.c
+++ b/keyboards/kbdfans/kbd67/hotswap/keymaps/bcat/keymap.c
@@ -5,7 +5,7 @@ enum layer {
     LAYER_FUNCTION,
 };
 
-#define LY_FUNC LT(LAYER_FUNCTION, KC_APP)
+#define LY_FN MO(LAYER_FUNCTION)
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Default layer: http://www.keyboard-layout-editor.com/#/gists/dd675b40cc4df2c7bb78847ac29f5988 */
@@ -14,7 +14,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         KC_TAB,   KC_Q,     KC_W,     KC_E,     KC_R,     KC_T,     KC_Y,     KC_U,     KC_I,     KC_O,     KC_P,     KC_LBRC,  KC_RBRC,  KC_BSPC,            KC_PGUP,
         KC_LCTL,  KC_A,     KC_S,     KC_D,     KC_F,     KC_G,     KC_H,     KC_J,     KC_K,     KC_L,     KC_SCLN,  KC_QUOT,            KC_ENT,             KC_PGDN,
         KC_LSFT,  KC_Z,     KC_X,     KC_C,     KC_V,     KC_B,     KC_N,     KC_M,     KC_COMM,  KC_DOT,   KC_SLSH,  KC_RSFT,                      KC_UP,    KC_END,
-        KC_LCTL,  KC_LGUI,  KC_LALT,                      KC_SPC,                                 KC_RALT,  LY_FUNC,                      KC_LEFT,  KC_DOWN,  KC_RGHT
+        KC_LCTL,  KC_LGUI,  KC_LALT,                      KC_SPC,                                 KC_RALT,  LY_FN,                        KC_LEFT,  KC_DOWN,  KC_RGHT
     ),
 
     /* Function layer: http://www.keyboard-layout-editor.com/#/gists/f29128427f674c43777f045e363d1b44 */
@@ -22,7 +22,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         _______,  KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   KC_INS,   KC_DEL,   _______,
         KC_CAPS,  _______,  KC_MPLY,  KC_VOLU,  KC_MSTP,  _______,  EEP_RST,  RESET,    KC_PSCR,  KC_SLCK,  KC_PAUS,  _______,  _______,  _______,            _______,
         _______,  _______,  KC_MPRV,  KC_VOLD,  KC_MNXT,  _______,  _______,  _______,  _______,  _______,  _______,  _______,            _______,            _______,
-        _______,  _______,  _______,  KC_MUTE,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,                      _______,  _______,
+        _______,  KC_APP,   _______,  KC_MUTE,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,                      _______,  _______,
         _______,  _______,  _______,                      _______,                                _______,  _______,                      _______,  _______,  _______
     ),
 };

--- a/keyboards/kbdfans/kbd67/hotswap/keymaps/bcat/readme.md
+++ b/keyboards/kbdfans/kbd67/hotswap/keymaps/bcat/readme.md
@@ -1,17 +1,16 @@
 # bcat's KBD67 hotswap layout
 
-This is pretty much a stock 65% split keyboard layout, with an HHKB-style
-(split) backspace and media keys in the function layer centered around the ESDF
-cluster.
+This is a standard 65% keyboard layout, with an HHKB-style (split) backspace
+and media controls in the function layer (centered around the ESDF cluster).
 
 ## Default layer
 
-![Default layer layout](https://i.imgur.com/QNJ0HhY.png)
+![Default layer layout](https://i.imgur.com/Vdnw2mp.png)
 
 ([KLE](http://www.keyboard-layout-editor.com/#/gists/dd675b40cc4df2c7bb78847ac29f5988))
 
 ## Function layer
 
-![Function layer layout](https://i.imgur.com/E7Pf1gS.png)
+![Function layer layout](https://i.imgur.com/Q304GlI.png)
 
 ([KLE](http://www.keyboard-layout-editor.com/#/gists/f29128427f674c43777f045e363d1b44))

--- a/keyboards/keebio/quefrency/keymaps/bcat/keymap.c
+++ b/keyboards/keebio/quefrency/keymaps/bcat/keymap.c
@@ -5,7 +5,7 @@ enum layer {
     LAYER_FUNCTION,
 };
 
-#define LY_FUNC MO(LAYER_FUNCTION)
+#define LY_FN MO(LAYER_FUNCTION)
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Default layer: http://www.keyboard-layout-editor.com/#/gists/60a262432bb340b37d364a4424f3037b */
@@ -14,7 +14,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         KC_TAB,   KC_Q,     KC_W,     KC_E,     KC_R,     KC_T,     KC_Y,     KC_U,     KC_I,     KC_O,     KC_P,     KC_LBRC,  KC_RBRC,  KC_BSPC,            KC_PGUP,
         KC_LCTL,  KC_A,     KC_S,     KC_D,     KC_F,     KC_G,     KC_H,     KC_J,     KC_K,     KC_L,     KC_SCLN,  KC_QUOT,            KC_ENT,             KC_PGDN,
         KC_LSFT,  KC_Z,     KC_X,     KC_C,     KC_V,     KC_B,     KC_N,     KC_M,     KC_COMM,  KC_DOT,   KC_SLSH,  KC_RSFT,                      KC_UP,    KC_END,
-        KC_LCTL,  KC_LGUI,  KC_LALT,  LY_FUNC,  KC_SPC,                       KC_SPC,   XXXXXXX,  KC_RALT,  LY_FUNC,  KC_APP,             KC_LEFT,  KC_DOWN,  KC_RGHT
+        KC_LCTL,  KC_LGUI,  KC_LALT,  LY_FN,    KC_SPC,                       KC_SPC,   XXXXXXX,  KC_RALT,  LY_FN,    KC_RCTL,            KC_LEFT,  KC_DOWN,  KC_RGHT
     ),
 
     /* Function layer: http://www.keyboard-layout-editor.com/#/gists/59636898946da51f91fb290f8e078b4d */
@@ -22,7 +22,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         _______,  KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   KC_INS,   KC_DEL,   RGB_HUI,
         KC_CAPS,  _______,  KC_MPLY,  KC_VOLU,  KC_MSTP,  _______,  EEP_RST,  RESET,    KC_PSCR,  KC_SLCK,  KC_PAUS,  _______,  _______,  _______,            RGB_SAI,
         _______,  _______,  KC_MPRV,  KC_VOLD,  KC_MNXT,  _______,  _______,  _______,  _______,  _______,  _______,  _______,            RGB_TOG,            RGB_SAD,
-        _______,  _______,  _______,  KC_MUTE,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,                      RGB_VAI,  RGB_HUD,
+        _______,  KC_APP,   _______,  KC_MUTE,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,                      RGB_VAI,  RGB_HUD,
         _______,  _______,  _______,  _______,  _______,                      _______,  _______,  _______,  _______,  _______,            RGB_RMOD, RGB_VAD,  RGB_MOD
     ),
 };

--- a/keyboards/keebio/quefrency/keymaps/bcat/readme.md
+++ b/keyboards/keebio/quefrency/keymaps/bcat/readme.md
@@ -1,17 +1,17 @@
 # bcat's Quefrency 65% layout
 
-This is pretty much a stock 65% split keyboard layout, with an HHKB-style
-(split) backspace, media keys in the function layer centered around the ESDF
-cluster, and RGB controls in the function layer on the arrow/nav keys.
+This is a standard 65% keyboard layout, with a split spacebar, an HHKB-style
+(split) backspace, media controls in the function layer (centered around the
+ESDF cluster), and RGB controls in the function layer (on the arrow/nav keys).
 
 ## Default layer
 
-![Default layer layout](https://i.imgur.com/CU2fxDg.png)
+![Default layer layout](https://i.imgur.com/gfVTuPO.png)
 
 ([KLE](http://www.keyboard-layout-editor.com/#/gists/60a262432bb340b37d364a4424f3037b))
 
 ## Function layer
 
-![Function layer layout](https://i.imgur.com/xE4CuH0.png)
+![Function layer layout](https://i.imgur.com/Wmx1hfx.png)
 
 ([KLE](http://www.keyboard-layout-editor.com/#/gists/59636898946da51f91fb290f8e078b4d))

--- a/keyboards/lily58/keymaps/bcat/keymap.c
+++ b/keyboards/lily58/keymaps/bcat/keymap.c
@@ -27,7 +27,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         _______,  _______,  _______,  _______,  _______,  _______,                      _______,  _______,  _______,  _______,  _______,  _______,
         KC_CAPS,  KC_EXLM,  KC_AT,    KC_HASH,  KC_DLR,   KC_PERC,                      KC_CIRC,  KC_AMPR,  KC_ASTR,  KC_LPRN,  KC_RPRN,  _______,
         _______,  _______,  _______,  _______,  _______,  _______,                      KC_PIPE,  KC_UNDS,  KC_PLUS,  KC_LCBR,  KC_RCBR,  KC_TILD,
-        _______,  _______,  KC_PSCR,  KC_SLCK,  KC_PAUS,  KC_APP,   _______,  _______,  KC_BSLS,  KC_MINS,  KC_EQL,   KC_LBRC,  KC_RBRC,  KC_GRV,
+        _______,  KC_APP,   KC_PSCR,  KC_SLCK,  KC_PAUS,  _______,  _______,  _______,  KC_BSLS,  KC_MINS,  KC_EQL,   KC_LBRC,  KC_RBRC,  KC_GRV,
                                       _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______
     ),
 

--- a/keyboards/lily58/keymaps/bcat/readme.md
+++ b/keyboards/lily58/keymaps/bcat/readme.md
@@ -22,7 +22,7 @@ and browser back/forward navigation keys (actually more useful than expected).
 
 ## Lower layer
 
-![Lower layer layout](https://i.imgur.com/d0J2lum.png)
+![Lower layer layout](https://i.imgur.com/9JlbNAd.png)
 
 ([KLE](http://www.keyboard-layout-editor.com/#/gists/19ad0d3b5d745fbb2818db09740f5a11))
 

--- a/layouts/community/60_ansi_split_bs_rshift/bcat/keymap.c
+++ b/layouts/community/60_ansi_split_bs_rshift/bcat/keymap.c
@@ -2,12 +2,12 @@
 
 enum layer {
     LAYER_DEFAULT,
-    LAYER_FUNCTION,
-    LAYER_ADJUST,
+    LAYER_FUNCTION_1,
+    LAYER_FUNCTION_2,
 };
 
-#define LY_FUNC MO(LAYER_FUNCTION)
-#define LY_ADJST MO(LAYER_ADJUST)
+#define LY_FN1 MO(LAYER_FUNCTION_1)
+#define LY_FN2 MO(LAYER_FUNCTION_2)
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Default layer: http://www.keyboard-layout-editor.com/#/gists/327b41b5a933b3d44bf60ca9822e85dc */
@@ -15,25 +15,25 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         KC_ESC,   KC_1,     KC_2,     KC_3,     KC_4,     KC_5,     KC_6,     KC_7,     KC_8,     KC_9,     KC_0,     KC_MINS,  KC_EQL,   KC_BSLS,  KC_GRV,
         KC_TAB,   KC_Q,     KC_W,     KC_E,     KC_R,     KC_T,     KC_Y,     KC_U,     KC_I,     KC_O,     KC_P,     KC_LBRC,  KC_RBRC,  KC_BSPC,
         KC_LCTL,  KC_A,     KC_S,     KC_D,     KC_F,     KC_G,     KC_H,     KC_J,     KC_K,     KC_L,     KC_SCLN,  KC_QUOT,            KC_ENT,
-        KC_LSFT,  KC_Z,     KC_X,     KC_C,     KC_V,     KC_B,     KC_N,     KC_M,     KC_COMM,  KC_DOT,   KC_SLSH,  KC_RSFT,                      LY_FUNC,
-        KC_LCTL,  KC_LGUI,  KC_LALT,                                KC_SPC,                                           KC_RALT,  LY_ADJST, KC_APP,   KC_RCTL
+        KC_LSFT,  KC_Z,     KC_X,     KC_C,     KC_V,     KC_B,     KC_N,     KC_M,     KC_COMM,  KC_DOT,   KC_SLSH,  KC_RSFT,                      LY_FN1,
+        KC_LCTL,  KC_LGUI,  KC_LALT,                                KC_SPC,                                           KC_RALT,  LY_FN2,   KC_APP,   KC_RCTL
     ),
 
-    /* Function layer: http://www.keyboard-layout-editor.com/#/gists/c7a55e75285d474b6301140eaf53f915 */
-    [LAYER_FUNCTION] = LAYOUT_60_ansi_split_bs_rshift(
+    /* Function 1 layer: http://www.keyboard-layout-editor.com/#/gists/c7a55e75285d474b6301140eaf53f915 */
+    [LAYER_FUNCTION_1] = LAYOUT_60_ansi_split_bs_rshift(
         _______,  KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   KC_INS,   KC_DEL,
         KC_CAPS,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  KC_PSCR,  KC_SLCK,  KC_PAUS,  KC_UP,    _______,  _______,
         _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  KC_HOME,  KC_PGUP,  KC_LEFT,  KC_RGHT,            _______,
-        _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  KC_END,   KC_PGDN,  KC_DOWN,  _______,                      _______,
+        _______,  KC_APP,   _______,  _______,  _______,  _______,  _______,  _______,  KC_END,   KC_PGDN,  KC_DOWN,  _______,                      _______,
         _______,  _______,  _______,                                _______,                                          _______,  _______,  _______,  _______
     ),
 
-    /* Adjust layer: http://www.keyboard-layout-editor.com/#/gists/6e1068e4f91bbacccaf5ac0acbeec79c */
-    [LAYER_ADJUST] = LAYOUT_60_ansi_split_bs_rshift(
-        _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,
-        _______,  BL_BRTG,  KC_MPLY,  KC_VOLU,  KC_MSTP,  _______,  EEP_RST,  RESET,    _______,  _______,  _______,  RGB_VAI,  _______,  _______,
-        _______,  BL_INC,   KC_MPRV,  KC_VOLD,  KC_MNXT,  _______,  _______,  RGB_SPI,  RGB_HUI,  RGB_SAI,  RGB_RMOD, RGB_MOD,            RGB_TOG,
-        _______,  BL_DEC,   _______,  KC_MUTE,  _______,  _______,  _______,  RGB_SPD,  RGB_HUD,  RGB_SAD,  RGB_VAD,  _______,                      _______,
+    /* Function 2 layer: http://www.keyboard-layout-editor.com/#/gists/6e1068e4f91bbacccaf5ac0acbeec79c */
+    [LAYER_FUNCTION_2] = LAYOUT_60_ansi_split_bs_rshift(
+        _______,  KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   KC_INS,   KC_DEL,
+        _______,  _______,  KC_MPLY,  KC_VOLU,  KC_MSTP,  BL_BRTG,  EEP_RST,  RESET,    _______,  _______,  _______,  RGB_VAI,  _______,  _______,
+        _______,  _______,  KC_MPRV,  KC_VOLD,  KC_MNXT,  BL_INC,   _______,  RGB_SPI,  RGB_HUI,  RGB_SAI,  RGB_RMOD, RGB_MOD,            RGB_TOG,
+        _______,  _______,  _______,  KC_MUTE,  _______,  BL_DEC,   _______,  RGB_SPD,  RGB_HUD,  RGB_SAD,  RGB_VAD,  _______,                      _______,
         _______,  _______,  _______,                                _______,                                          _______,  _______,  _______,  _______
     ),
 };

--- a/layouts/community/60_ansi_split_bs_rshift/bcat/readme.md
+++ b/layouts/community/60_ansi_split_bs_rshift/bcat/readme.md
@@ -1,26 +1,24 @@
 # bcat's 60% ANSI split backspace/right-shift layout
 
-This is a hybrid of an HHKB layout and a standard ANSI bottom row. It's nice if
-you want to fill out a 60% case with no blockers, or just really want a 6.25U
-spacebar. The arrow and navigation keys match a standard HHKB layout using the
-Fn key next to the right shift key. Additionally, the redundant Fn key on the
-bottom row activates an adjust layer with controls for RGB underglow and
-backlight, as well as media keys centered around the ESDF cluster.
+This is a hybrid of a Tsangan/HHKB layout and a standard ANSI bottom row. It's
+not my favorite layout, but it's nice enough if you only have a 6.25u spacebar.
+Other than the bottom row, this is identical to my regular [Tsangan
+layout](https://github.com/qmk/qmk_firmware/tree/master/layouts/community/60_tsangan_hhkb/bcat).
 
 ## Default layer
 
-![Default layer layout](https://i.imgur.com/HM0115k.png)
+![Default layer layout](https://i.imgur.com/auP2mWT.png)
 
 ([KLE](http://www.keyboard-layout-editor.com/#/gists/327b41b5a933b3d44bf60ca9822e85dc))
 
-## Function layer
+## Function 1 layer
 
-![Function layer layout](https://i.imgur.com/3swWxPn.png)
+![Function 1 layer layout](https://i.imgur.com/iRNy6Zy.png)
 
 ([KLE](http://www.keyboard-layout-editor.com/#/gists/c7a55e75285d474b6301140eaf53f915))
 
-## Adjust layer
+## Function 2 layer
 
-![Adjust layer layout](https://i.imgur.com/lQfcnQV.png)
+![Function 2 layer layout](https://i.imgur.com/WRvsEuZ.png)
 
 ([KLE](http://www.keyboard-layout-editor.com/#/gists/6e1068e4f91bbacccaf5ac0acbeec79c))

--- a/layouts/community/60_tsangan_hhkb/bcat/keymap.c
+++ b/layouts/community/60_tsangan_hhkb/bcat/keymap.c
@@ -30,10 +30,10 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
     /* Function 2 layer: http://www.keyboard-layout-editor.com/#/gists/65ac939caec878401603bc36290852d4 */
     [LAYER_FUNCTION_2] = LAYOUT_60_tsangan_hhkb(
-        _______,  KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   _______,  _______,
-        _______,  BL_BRTG,  KC_MPLY,  KC_VOLU,  KC_MSTP,  _______,  EEP_RST,  RESET,    _______,  _______,  _______,  RGB_VAI,  _______,  _______,
-        _______,  BL_INC,   KC_MPRV,  KC_VOLD,  KC_MNXT,  _______,  _______,  RGB_SPI,  RGB_HUI,  RGB_SAI,  RGB_RMOD, RGB_MOD,            RGB_TOG,
-        _______,  BL_DEC,   _______,  KC_MUTE,  _______,  _______,  _______,  RGB_SPD,  RGB_HUD,  RGB_SAD,  RGB_VAD,  _______,                      _______,
+        _______,  KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   KC_INS,   KC_DEL,
+        _______,  _______,  KC_MPLY,  KC_VOLU,  KC_MSTP,  BL_BRTG,  EEP_RST,  RESET,    _______,  _______,  _______,  RGB_VAI,  _______,  _______,
+        _______,  _______,  KC_MPRV,  KC_VOLD,  KC_MNXT,  BL_INC,   _______,  RGB_SPI,  RGB_HUI,  RGB_SAI,  RGB_RMOD, RGB_MOD,            RGB_TOG,
+        _______,  _______,  _______,  KC_MUTE,  _______,  BL_DEC,   _______,  RGB_SPD,  RGB_HUD,  RGB_SAD,  RGB_VAD,  _______,                      _______,
         _______,  _______,  _______,                                _______,                                          _______,  _______,            _______
     ),
 };

--- a/layouts/community/60_tsangan_hhkb/bcat/readme.md
+++ b/layouts/community/60_tsangan_hhkb/bcat/readme.md
@@ -39,6 +39,6 @@ and/or blockers, so there aren't switches installed in those positions.
 
 ## Function 2 layer
 
-![Function 2layer layout](https://i.imgur.com/tQBIR1m.png)
+![Function 2 layer layout](https://i.imgur.com/37APm7c.png)
 
 ([KLE](http://www.keyboard-layout-editor.com/#/gists/65ac939caec878401603bc36290852d4))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Just tidying up some inconsistencies across my less-frequently-used keyboard layouts after #8836 and #8857 reworked my preferred (Crkbd, Tsangan) layouts to reflect current preferences.

* Put Menu key binding in a uniform location across keyboards.
* Move backlight controls to a conflict-free location across keyboards.
* Standardize labeling of layers on row-staggered keyboards.
* Tweak non-Tsangan bottom rows so they make a little more sense to me.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [X] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
