### PR TITLE
[kle2json] fix rounding in output

### DIFF
--- a/lib/python/kle2xy.py
+++ b/lib/python/kle2xy.py
@@ -110,8 +110,8 @@ class KLE2xy(list):
 
                 else:
                     current_key['name'] = key
-                    current_key['row'] = current_row
-                    current_key['column'] = current_col
+                    current_key['row'] = round(current_row, 2)
+                    current_key['column'] = round(current_col, 2)
 
                     # Determine the X center
                     x_center = (current_key['width'] * self.key_width) / 2

--- a/lib/python/qmk/cli/kle2json.py
+++ b/lib/python/qmk/cli/kle2json.py
@@ -69,7 +69,7 @@ def kle2json(cli):
     # Replace layout in keyboard json
     keyboard = keyboard.replace('"LAYOUT_JSON_HERE"', layout)
     # Write our info.json
-    file = open(out_path + "/info.json", "w")
+    file = open(out_path / "info.json", "w")
     file.write(keyboard)
     file.close()
     cli.log.info('Wrote out {fg_cyan}%s/info.json', out_path)


### PR DESCRIPTION
## Description

Two tweaks to the code that converts from keyboard layout editor json to qmk info json files:

- Remove error on command line execution
- Round x and y output


### Remove error on command line execution

Remove an error thrown in python 3.7.7 (more recent than the targeted 3.6):

```
./bin/qmk kle2json -f file.json
[...]
TypeError: unsupported operand type(s) for +: 'PosixPath' and 'str'
```

### Round x and y output

```diff
  [...]
      "layouts": {
          "LAYOUT": {  
-             "layout": [{"label":"Esc", "x":0.66, "y":1.45}, {"label":"!", "x":1.6600000000000001, "y":1.45},
+             "layout": [{"label":"Esc", "x":0.66, "y":1.45}, {"label":"!", "x":1.66, "y":1.45},
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

### PS

Starting small as I'm starting to understand python and qmk in general.
