### PR TITLE
More community layout support for legacy KBD67 PCBs

### DIFF
--- a/keyboards/kbdfans/kbd67/hotswap/hotswap.h
+++ b/keyboards/kbdfans/kbd67/hotswap/hotswap.h
@@ -40,3 +40,5 @@
     { K30, K31, K32, K33, K34, K35, K36, K37, K38, K39, K3A, KC_NO, K3C, K3D, K3E},           \
     { K40, K41, K42, KC_NO, KC_NO, K45, KC_NO, KC_NO, KC_NO, K49, K4A, K4B, KC_NO, K4D, K4E}, \
 }
+
+#define LAYOUT_65_ansi_blocker_split_bs LAYOUT

--- a/keyboards/kbdfans/kbd67/hotswap/rules.mk
+++ b/keyboards/kbdfans/kbd67/hotswap/rules.mk
@@ -31,3 +31,5 @@ BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
 AUDIO_ENABLE = no           # Audio output on port C6
 FAUXCLICKY_ENABLE = no      # Use buzzer to emulate clicky switches
 HD44780_ENABLE = no 		# Enable support for HD44780 based LCDs
+
+LAYOUTS = 65_ansi_blocker_split_bs

--- a/keyboards/kbdfans/kbd67/rev1/rules.mk
+++ b/keyboards/kbdfans/kbd67/rev1/rules.mk
@@ -31,3 +31,5 @@ BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
 AUDIO_ENABLE = no           # Audio output on port C6
 FAUXCLICKY_ENABLE = no      # Use buzzer to emulate clicky switches
 HD44780_ENABLE = no 		# Enable support for HD44780 based LCDs
+
+LAYOUTS = 65_ansi

--- a/keyboards/kbdfans/kbd67/rev2/rev2.h
+++ b/keyboards/kbdfans/kbd67/rev2/rev2.h
@@ -85,6 +85,8 @@
     { K40, K41,   KC_NO, K43, KC_NO, KC_NO, K46, KC_NO, KC_NO, KC_NO, K4A, K4B, KC_NO, K4D,   K4E,   K4F }, \
 }
 
+#define LAYOUT_65_ansi_blocker_split_bs LAYOUT_65_ansi_blocker_splitbs
+
 #define LAYOUT_65_iso( \
     K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C,      K0E, K0F, \
     K10,      K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, K1C,      K1E, K1F, \

--- a/keyboards/kbdfans/kbd67/rev2/rules.mk
+++ b/keyboards/kbdfans/kbd67/rev2/rules.mk
@@ -32,4 +32,4 @@ AUDIO_ENABLE = no           # Audio output on port C6
 FAUXCLICKY_ENABLE = no      # Use buzzer to emulate clicky switches
 HD44780_ENABLE = no 		# Enable support for HD44780 based LCDs
 
-LAYOUTS = 65_ansi 65_iso 65_ansi_blocker
+LAYOUTS = 65_ansi 65_iso 65_ansi_blocker 65_ansi_blocker_split_bs

--- a/layouts/community/65_ansi_blocker_split_bs/bcat/keymap.c
+++ b/layouts/community/65_ansi_blocker_split_bs/bcat/keymap.c
@@ -9,7 +9,7 @@ enum layer {
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Default layer: http://www.keyboard-layout-editor.com/#/gists/dd675b40cc4df2c7bb78847ac29f5988 */
-    [LAYER_DEFAULT] = LAYOUT(
+    [LAYER_DEFAULT] = LAYOUT_65_ansi_blocker_split_bs(
         KC_ESC,   KC_1,     KC_2,     KC_3,     KC_4,     KC_5,     KC_6,     KC_7,     KC_8,     KC_9,     KC_0,     KC_MINS,  KC_EQL,   KC_BSLS,  KC_GRV,   KC_HOME,
         KC_TAB,   KC_Q,     KC_W,     KC_E,     KC_R,     KC_T,     KC_Y,     KC_U,     KC_I,     KC_O,     KC_P,     KC_LBRC,  KC_RBRC,  KC_BSPC,            KC_PGUP,
         KC_LCTL,  KC_A,     KC_S,     KC_D,     KC_F,     KC_G,     KC_H,     KC_J,     KC_K,     KC_L,     KC_SCLN,  KC_QUOT,            KC_ENT,             KC_PGDN,
@@ -18,7 +18,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     ),
 
     /* Function layer: http://www.keyboard-layout-editor.com/#/gists/f29128427f674c43777f045e363d1b44 */
-    [LAYER_FUNCTION] = LAYOUT(
+    [LAYER_FUNCTION] = LAYOUT_65_ansi_blocker_split_bs(
         _______,  KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   KC_INS,   KC_DEL,   _______,
         KC_CAPS,  _______,  KC_MPLY,  KC_VOLU,  KC_MSTP,  _______,  EEP_RST,  RESET,    KC_PSCR,  KC_SLCK,  KC_PAUS,  _______,  _______,  _______,            _______,
         _______,  _______,  KC_MPRV,  KC_VOLD,  KC_MNXT,  _______,  _______,  _______,  _______,  _______,  _______,  _______,            _______,            _______,

--- a/layouts/community/65_ansi_blocker_split_bs/bcat/readme.md
+++ b/layouts/community/65_ansi_blocker_split_bs/bcat/readme.md
@@ -1,7 +1,8 @@
-# bcat's KBD67 hotswap layout
+# bcat's 65% ANSI blocker split backspace layout
 
-This is a standard 65% keyboard layout, with an HHKB-style (split) backspace
-and media controls in the function layer (centered around the ESDF cluster).
+This is a standard 65% keyboard layout, with a blocker to the left of the arrow
+keys, an HHKB-style (split) backspace, and media controls in the function layer
+(centered around the ESDF cluster).
 
 ## Default layer
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Adding support for the new `65_ansi_blocker_split_bs` layout from #8793 to the old (pre-MKII) KBD67 PCBs, as well as a couple other layouts where appropriate:

* `rev1`: Adding `65_ansi` layout. (I'm pretty sure this PCB also supports at least `65_iso`, and probably `65_ansi_blocker` & `65_ansi_blocker_split_bs` too; however, I can't find a picture of the original KBD65 PCB to verify that.)
* `rev2`: Adding `65_ansi_blocker_split_bs`. (The layout is already here, just under a different name. Added an alias for backwards compatibility.)
* `hotswap`: Adding `65_ansi_blocker_split_bs`. (This is a fixed-layout hotswap keyboard, so `65_ansi_blocker_split_bs` is in fact the _only_ layout this particular PCB supports.)

I also moved my personal `kbd67/hotswap` keymap into the `65_ansi_blocker_split_bs` community layout directory. (Left other folks' keymaps alone, of course.) I can do that in a separate PR if you'd prefer.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [X] Keyboard (addition or update)
- [X] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
