### PR TITLE
Allow expanding from 8 to 32 RGB Lighting Layers

### DIFF
--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -194,6 +194,7 @@ If you define these options you will enable the associated feature, which may in
   * Lets you define [lighting layers](feature_rgblight.md?id=lighting-layers) that can be toggled on or off. Great for showing the current keyboard layer or caps lock state.
 * `#define RGBLIGHT_MAX_LAYERS`
   * Defaults to 8. Can be expanded up to 32 if more [lighting layers](feature_rgblight.md?id=lighting-layers) are needed.
+  * Note: Increasing the maximum will increase the firmware size.
 * `#define RGBLIGHT_LAYER_BLINK` 
   * Adds ability to [blink](feature_rgblight.md?id=lighting-layer-blink) a lighting layer for a specified number of milliseconds (e.g. to acknowledge an action).
 * `#define RGBLED_NUM 12`

--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -193,7 +193,7 @@ If you define these options you will enable the associated feature, which may in
 * `#define RGBLIGHT_LAYERS`
   * Lets you define [lighting layers](feature_rgblight.md?id=lighting-layers) that can be toggled on or off. Great for showing the current keyboard layer or caps lock state.
 * `#define RGBLIGHT_MAX_LAYERS`
-  * Defaults to 8. Can be expanded up to 16 if more [lighting layers](feature_rgblight.md?id=lighting-layers) are needed.
+  * Defaults to 8. Can be expanded up to 32 if more [lighting layers](feature_rgblight.md?id=lighting-layers) are needed.
 * `#define RGBLIGHT_LAYER_BLINK` 
   * Adds ability to [blink](feature_rgblight.md?id=lighting-layer-blink) a lighting layer for a specified number of milliseconds (e.g. to acknowledge an action).
 * `#define RGBLED_NUM 12`

--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -192,8 +192,8 @@ If you define these options you will enable the associated feature, which may in
   * run RGB animations
 * `#define RGBLIGHT_LAYERS`
   * Lets you define [lighting layers](feature_rgblight.md?id=lighting-layers) that can be toggled on or off. Great for showing the current keyboard layer or caps lock state.
-* `#define RGBLIGHT_LAYERS_16`
-  * Expands the number of [lighting layers](feature_rgblight.md?id=lighting-layers) possible from 8 to 16.
+* `#define RGBLIGHT_MAX_LAYERS`
+  * Defaults to 8. Can be expanded up to 16 if more [lighting layers](feature_rgblight.md?id=lighting-layers) are needed.
 * `#define RGBLIGHT_LAYER_BLINK` 
   * Adds ability to [blink](feature_rgblight.md?id=lighting-layer-blink) a lighting layer for a specified number of milliseconds (e.g. to acknowledge an action).
 * `#define RGBLED_NUM 12`

--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -192,6 +192,8 @@ If you define these options you will enable the associated feature, which may in
   * run RGB animations
 * `#define RGBLIGHT_LAYERS`
   * Lets you define [lighting layers](feature_rgblight.md?id=lighting-layers) that can be toggled on or off. Great for showing the current keyboard layer or caps lock state.
+* `#define RGBLIGHT_LAYERS_16`
+  * Expands the number of [lighting layers](feature_rgblight.md?id=lighting-layers) possible from 8 to 16.
 * `#define RGBLIGHT_LAYER_BLINK` 
   * Adds ability to [blink](feature_rgblight.md?id=lighting-layer-blink) a lighting layer for a specified number of milliseconds (e.g. to acknowledge an action).
 * `#define RGBLED_NUM 12`

--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -194,7 +194,7 @@ If you define these options you will enable the associated feature, which may in
   * Lets you define [lighting layers](feature_rgblight.md?id=lighting-layers) that can be toggled on or off. Great for showing the current keyboard layer or caps lock state.
 * `#define RGBLIGHT_MAX_LAYERS`
   * Defaults to 8. Can be expanded up to 32 if more [lighting layers](feature_rgblight.md?id=lighting-layers) are needed.
-  * Note: Increasing the maximum will increase the firmware size.
+  * Note: Increasing the maximum will increase the firmware size and slow sync on split keyboards.
 * `#define RGBLIGHT_LAYER_BLINK` 
   * Adds ability to [blink](feature_rgblight.md?id=lighting-layer-blink) a lighting layer for a specified number of milliseconds (e.g. to acknowledge an action).
 * `#define RGBLED_NUM 12`

--- a/docs/feature_rgblight.md
+++ b/docs/feature_rgblight.md
@@ -186,7 +186,7 @@ it easy to use your underglow LEDs as status indicators to show which keyboard l
 
 ### Defining Lighting Layers :id=defining-lighting-layers
 
-By default, 8 layers are possible. This can be expanded to as many as 16 by overriding the definition of `RGBLIGHT_MAX_LAYERS` in `config.h` (e.g. `#define RGBLIGHT_MAX_LAYERS 16`). Please note, if you use split keyboard, you will need to flash both sides of the split after changing this.
+By default, 8 layers are possible. This can be expanded to as many as 32 by overriding the definition of `RGBLIGHT_MAX_LAYERS` in `config.h` (e.g. `#define RGBLIGHT_MAX_LAYERS 32`). Please note, if you use a split keyboard, you will need to flash both sides of the split after changing this. Also, increasing the maximum will increase the firmware size.
 
 To define a layer, we modify `keymap.c` to list out LED ranges and the colors we want to overlay on them using an array of `rgblight_segment_t` using the `RGBLIGHT_LAYER_SEGMENTS` macro. We can define multiple layers and enable/disable them independently:
 

--- a/docs/feature_rgblight.md
+++ b/docs/feature_rgblight.md
@@ -186,7 +186,7 @@ it easy to use your underglow LEDs as status indicators to show which keyboard l
 
 ### Defining Lighting Layers :id=defining-lighting-layers
 
-By default, 8 layers are possible. This can be expanded to 16 by adding `#define RGBLIGHT_LAYERS_16` to `config.h`. Please note, if you use split keyboard, you will need to flash both sides of the split after changing this.
+By default, 8 layers are possible. This can be expanded to as many as 16 by overriding the definition of `RGBLIGHT_MAX_LAYERS` in `config.h` (e.g. `#define RGBLIGHT_MAX_LAYERS 16`). Please note, if you use split keyboard, you will need to flash both sides of the split after changing this.
 
 To define a layer, we modify `keymap.c` to list out LED ranges and the colors we want to overlay on them using an array of `rgblight_segment_t` using the `RGBLIGHT_LAYER_SEGMENTS` macro. We can define multiple layers and enable/disable them independently:
 

--- a/docs/feature_rgblight.md
+++ b/docs/feature_rgblight.md
@@ -186,6 +186,8 @@ it easy to use your underglow LEDs as status indicators to show which keyboard l
 
 ### Defining Lighting Layers :id=defining-lighting-layers
 
+By default, 8 layers are possible. This can be expanded to 16 by adding `#define RGBLIGHT_LAYERS_16` to `config.h`. Please note, if you use split keyboard, you will need to flash both sides of the split after changing this.
+
 To define a layer, we modify `keymap.c` to list out LED ranges and the colors we want to overlay on them using an array of `rgblight_segment_t` using the `RGBLIGHT_LAYER_SEGMENTS` macro. We can define multiple layers and enable/disable them independently:
 
 ```c

--- a/docs/feature_rgblight.md
+++ b/docs/feature_rgblight.md
@@ -186,7 +186,7 @@ it easy to use your underglow LEDs as status indicators to show which keyboard l
 
 ### Defining Lighting Layers :id=defining-lighting-layers
 
-By default, 8 layers are possible. This can be expanded to as many as 32 by overriding the definition of `RGBLIGHT_MAX_LAYERS` in `config.h` (e.g. `#define RGBLIGHT_MAX_LAYERS 32`). Please note, if you use a split keyboard, you will need to flash both sides of the split after changing this. Also, increasing the maximum will increase the firmware size.
+By default, 8 layers are possible. This can be expanded to as many as 32 by overriding the definition of `RGBLIGHT_MAX_LAYERS` in `config.h` (e.g. `#define RGBLIGHT_MAX_LAYERS 32`). Please note, if you use a split keyboard, you will need to flash both sides of the split after changing this. Also, increasing the maximum will increase the firmware size, and will slow sync on split keyboards.
 
 To define a layer, we modify `keymap.c` to list out LED ranges and the colors we want to overlay on them using an array of `rgblight_segment_t` using the `RGBLIGHT_LAYER_SEGMENTS` macro. We can define multiple layers and enable/disable them independently:
 

--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -613,7 +613,7 @@ void rgblight_sethsv_slave(uint8_t hue, uint8_t sat, uint8_t val) { rgblight_set
 
 #ifdef RGBLIGHT_LAYERS
 void rgblight_set_layer_state(uint8_t layer, bool enabled) {
-    uint8_t mask = 1 << layer;
+    uint16_t mask = 1 << layer;
     if (enabled) {
         rgblight_status.enabled_layer_mask |= mask;
     } else {
@@ -627,7 +627,7 @@ void rgblight_set_layer_state(uint8_t layer, bool enabled) {
 }
 
 bool rgblight_get_layer_state(uint8_t layer) {
-    uint8_t mask = 1 << layer;
+    uint16_t mask = 1 << layer;
     return (rgblight_status.enabled_layer_mask & mask) != 0;
 }
 

--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -613,7 +613,7 @@ void rgblight_sethsv_slave(uint8_t hue, uint8_t sat, uint8_t val) { rgblight_set
 
 #ifdef RGBLIGHT_LAYERS
 void rgblight_set_layer_state(uint8_t layer, bool enabled) {
-    uint16_t mask = 1 << layer;
+    rgblight_layer_mask_t mask = 1 << layer;
     if (enabled) {
         rgblight_status.enabled_layer_mask |= mask;
     } else {
@@ -627,7 +627,7 @@ void rgblight_set_layer_state(uint8_t layer, bool enabled) {
 }
 
 bool rgblight_get_layer_state(uint8_t layer) {
-    uint16_t mask = 1 << layer;
+    rgblight_layer_mask_t mask = 1 << layer;
     return (rgblight_status.enabled_layer_mask & mask) != 0;
 }
 

--- a/quantum/rgblight.h
+++ b/quantum/rgblight.h
@@ -205,8 +205,10 @@ typedef struct {
 typedef uint8_t rgblight_layer_mask_t;
 #        elif RGBLIGHT_MAX_LAYERS <= 16
 typedef uint16_t rgblight_layer_mask_t;
+#        elif RGBLIGHT_MAX_LAYERS <= 32
+typedef uint32_t rgblight_layer_mask_t;
 #        else
-#error invalid RGBLIGHT_MAX_LAYERS value (must be <= 16)
+#error invalid RGBLIGHT_MAX_LAYERS value (must be <= 32)
 #        endif
 #        define RGBLIGHT_LAYER_SEGMENTS(...) \
             { __VA_ARGS__, RGBLIGHT_END_SEGMENTS }
@@ -252,7 +254,6 @@ typedef union {
 } rgblight_config_t;
 
 // Need to maintain the old bit structure for the default case
-#if RGBLIGHT_MAX_LAYERS <= 8
 typedef struct _rgblight_status_t {
     uint8_t base_mode;
     bool    timer_enabled;
@@ -263,18 +264,6 @@ typedef struct _rgblight_status_t {
     rgblight_layer_mask_t enabled_layer_mask;
 #    endif
 } rgblight_status_t;
-#else
-typedef struct PACKED _rgblight_status_t {
-    uint8_t base_mode : 8;
-    bool    timer_enabled : 1;
-#    ifdef RGBLIGHT_SPLIT
-    uint8_t change_flags : 7;
-#    endif
-#    ifdef RGBLIGHT_LAYERS
-    rgblight_layer_mask_t enabled_layer_mask : RGBLIGHT_MAX_LAYERS;
-#    endif
-} rgblight_status_t;
-#endif
 
 /*
  * Structure for RGB Light clipping ranges

--- a/quantum/rgblight.h
+++ b/quantum/rgblight.h
@@ -253,7 +253,6 @@ typedef union {
     };
 } rgblight_config_t;
 
-// Need to maintain the old bit structure for the default case
 typedef struct _rgblight_status_t {
     uint8_t base_mode;
     bool    timer_enabled;

--- a/quantum/rgblight.h
+++ b/quantum/rgblight.h
@@ -196,7 +196,7 @@ typedef struct {
 #        define RGBLIGHT_END_SEGMENT_INDEX (255)
 #        define RGBLIGHT_END_SEGMENTS \
             { RGBLIGHT_END_SEGMENT_INDEX, 0, 0, 0 }
-#        define RGBLIGHT_MAX_LAYERS 8
+#        define RGBLIGHT_MAX_LAYERS 16
 #        define RGBLIGHT_LAYER_SEGMENTS(...) \
             { __VA_ARGS__, RGBLIGHT_END_SEGMENTS }
 #        define RGBLIGHT_LAYERS_LIST(...) \
@@ -247,7 +247,7 @@ typedef struct _rgblight_status_t {
     uint8_t change_flags;
 #    endif
 #    ifdef RGBLIGHT_LAYERS
-    uint8_t enabled_layer_mask;
+    uint16_t enabled_layer_mask;
 #    endif
 } rgblight_status_t;
 

--- a/quantum/rgblight.h
+++ b/quantum/rgblight.h
@@ -196,10 +196,15 @@ typedef struct {
 #        define RGBLIGHT_END_SEGMENT_INDEX (255)
 #        define RGBLIGHT_END_SEGMENTS \
             { RGBLIGHT_END_SEGMENT_INDEX, 0, 0, 0 }
-#        ifdef RGBLIGHT_LAYERS_16
-#          define RGBLIGHT_MAX_LAYERS 16
+#        ifndef RGBLIGHT_MAX_LAYERS
+#            define RGBLIGHT_MAX_LAYERS 8
+#        endif
+#        if RGBLIGHT_MAX_LAYERS <= 8
+typedef uint8_t rgblight_layer_mask_t;
+#        elif RGBLIGHT_MAX_LAYERS <= 16
+typedef uint16_t rgblight_layer_mask_t;
 #        else
-#          define RGBLIGHT_MAX_LAYERS 8
+#error invalid RGBLIGHT_MAX_LAYERS value (must be <= 16)
 #        endif
 #        define RGBLIGHT_LAYER_SEGMENTS(...) \
             { __VA_ARGS__, RGBLIGHT_END_SEGMENTS }
@@ -244,20 +249,8 @@ typedef union {
     };
 } rgblight_config_t;
 
-#ifdef RGBLIGHT_LAYERS_16
-typedef uint16_t rgblight_layer_mask_t;
-typedef struct PACKED _rgblight_status_t {
-    uint8_t base_mode : 8;
-    bool    timer_enabled : 1;
-#    ifdef RGBLIGHT_SPLIT
-    uint8_t change_flags : 7;
-#    endif
-#    ifdef RGBLIGHT_LAYERS
-    rgblight_layer_mask_t enabled_layer_mask : 16;
-#    endif
-} rgblight_status_t;
-#else
-typedef uint8_t rgblight_layer_mask_t;
+// Need to maintain the old bit structure for the default case
+#if RGBLIGHT_MAX_LAYERS <= 8
 typedef struct _rgblight_status_t {
     uint8_t base_mode;
     bool    timer_enabled;
@@ -266,6 +259,17 @@ typedef struct _rgblight_status_t {
 #    endif
 #    ifdef RGBLIGHT_LAYERS
     rgblight_layer_mask_t enabled_layer_mask;
+#    endif
+} rgblight_status_t;
+#else
+typedef struct PACKED _rgblight_status_t {
+    uint8_t base_mode : 8;
+    bool    timer_enabled : 1;
+#    ifdef RGBLIGHT_SPLIT
+    uint8_t change_flags : 7;
+#    endif
+#    ifdef RGBLIGHT_LAYERS
+    rgblight_layer_mask_t enabled_layer_mask : RGBLIGHT_MAX_LAYERS;
 #    endif
 } rgblight_status_t;
 #endif

--- a/quantum/rgblight.h
+++ b/quantum/rgblight.h
@@ -196,7 +196,11 @@ typedef struct {
 #        define RGBLIGHT_END_SEGMENT_INDEX (255)
 #        define RGBLIGHT_END_SEGMENTS \
             { RGBLIGHT_END_SEGMENT_INDEX, 0, 0, 0 }
-#        define RGBLIGHT_MAX_LAYERS 16
+#        ifdef RGBLIGHT_LAYERS_16
+#          define RGBLIGHT_MAX_LAYERS 16
+#        else
+#          define RGBLIGHT_MAX_LAYERS 8
+#        endif
 #        define RGBLIGHT_LAYER_SEGMENTS(...) \
             { __VA_ARGS__, RGBLIGHT_END_SEGMENTS }
 #        define RGBLIGHT_LAYERS_LIST(...) \
@@ -240,6 +244,20 @@ typedef union {
     };
 } rgblight_config_t;
 
+#ifdef RGBLIGHT_LAYERS_16
+typedef uint16_t rgblight_layer_mask_t;
+typedef struct PACKED _rgblight_status_t {
+    uint8_t base_mode : 8;
+    bool    timer_enabled : 1;
+#    ifdef RGBLIGHT_SPLIT
+    uint8_t change_flags : 7;
+#    endif
+#    ifdef RGBLIGHT_LAYERS
+    rgblight_layer_mask_t enabled_layer_mask : 16;
+#    endif
+} rgblight_status_t;
+#else
+typedef uint8_t rgblight_layer_mask_t;
 typedef struct _rgblight_status_t {
     uint8_t base_mode;
     bool    timer_enabled;
@@ -247,9 +265,10 @@ typedef struct _rgblight_status_t {
     uint8_t change_flags;
 #    endif
 #    ifdef RGBLIGHT_LAYERS
-    uint16_t enabled_layer_mask;
+    rgblight_layer_mask_t enabled_layer_mask;
 #    endif
 } rgblight_status_t;
+#endif
 
 /*
  * Structure for RGB Light clipping ranges

--- a/quantum/rgblight.h
+++ b/quantum/rgblight.h
@@ -200,7 +200,7 @@ typedef struct {
 #            define RGBLIGHT_MAX_LAYERS 8
 #        endif
 #        if RGBLIGHT_MAX_LAYERS <= 0
-#error invalid RGBLIGHT_MAX_LAYERS value (must be >= 1)
+#            error invalid RGBLIGHT_MAX_LAYERS value (must be >= 1)
 #        elif RGBLIGHT_MAX_LAYERS <= 8
 typedef uint8_t rgblight_layer_mask_t;
 #        elif RGBLIGHT_MAX_LAYERS <= 16
@@ -208,7 +208,7 @@ typedef uint16_t rgblight_layer_mask_t;
 #        elif RGBLIGHT_MAX_LAYERS <= 32
 typedef uint32_t rgblight_layer_mask_t;
 #        else
-#error invalid RGBLIGHT_MAX_LAYERS value (must be <= 32)
+#            error invalid RGBLIGHT_MAX_LAYERS value (must be <= 32)
 #        endif
 #        define RGBLIGHT_LAYER_SEGMENTS(...) \
             { __VA_ARGS__, RGBLIGHT_END_SEGMENTS }

--- a/quantum/rgblight.h
+++ b/quantum/rgblight.h
@@ -199,7 +199,7 @@ typedef struct {
 #        ifndef RGBLIGHT_MAX_LAYERS
 #            define RGBLIGHT_MAX_LAYERS 8
 #        endif
-#        if RGBLIGHT_MAX_LAYERS <= 8
+#        if RGBLIGHT_MAX_LAYERS > 0 && RGBLIGHT_MAX_LAYERS <= 8
 typedef uint8_t rgblight_layer_mask_t;
 #        elif RGBLIGHT_MAX_LAYERS <= 16
 typedef uint16_t rgblight_layer_mask_t;

--- a/quantum/rgblight.h
+++ b/quantum/rgblight.h
@@ -199,7 +199,9 @@ typedef struct {
 #        ifndef RGBLIGHT_MAX_LAYERS
 #            define RGBLIGHT_MAX_LAYERS 8
 #        endif
-#        if RGBLIGHT_MAX_LAYERS > 0 && RGBLIGHT_MAX_LAYERS <= 8
+#        if RGBLIGHT_MAX_LAYERS <= 0
+#error invalid RGBLIGHT_MAX_LAYERS value (must be >= 1)
+#        elif RGBLIGHT_MAX_LAYERS <= 8
 typedef uint8_t rgblight_layer_mask_t;
 #        elif RGBLIGHT_MAX_LAYERS <= 16
 typedef uint16_t rgblight_layer_mask_t;


### PR DESCRIPTION
## Description

This pull request increases the maximum number of RGB Lighting Layers from 8 to 16, if `RGBLIGHT_LAYERS_16` is defined. The default remains 8, since this impacts split transport. When enabled, the packing of the state transport is changed, so when enabling, it is necessary to flash both halves.

The reason for this change is to enable enough lighting layers to:

- use a different lighting layer for each keymap layer
- use a different lighting layer for each locking modifier (caps lock, scroll lock, num lock, compose, kana)
- use lighting layers to acknowledge events (yes/no/fail)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
