### PR TITLE
[kle2info] Trim the code in `kle2xy`

### DIFF
--- a/lib/python/kle2xy.py
+++ b/lib/python/kle2xy.py
@@ -14,7 +14,7 @@ class KLE2xy(list):
         self.name = name
         self.invert_y = invert_y
         self.key_width = Decimal('19.05')
-        self.key_skel = {'decal': False, 'border_color': 'none', 'keycap_profile': '', 'keycap_color': 'grey', 'label_color': 'black', 'label_size': 3, 'label_style': 4, 'width': Decimal('1'), 'height': Decimal('1'), 'x': Decimal('0'), 'y': Decimal('0')}
+        self.key_skel = {'decal': False, 'border_color': 'none', 'keycap_profile': '', 'keycap_color': 'grey', 'label_color': 'black', 'label_size': 3, 'label_style': 4, 'width': Decimal('1'), 'height': Decimal('1')}
         self.rows = Decimal(0)
         self.columns = Decimal(0)
 
@@ -55,8 +55,6 @@ class KLE2xy(list):
         current_key = self.key_skel.copy()
         current_row = Decimal(0)
         current_col = Decimal(0)
-        current_x = 0
-        current_y = self.key_width / 2
 
         if isinstance(layout[0], dict):
             self.attrs(layout[0])
@@ -92,10 +90,8 @@ class KLE2xy(list):
                         current_key['label_color'] = self.key_skel['label_color'] = key['t']
                     if 'x' in key:
                         current_col += Decimal(key['x'])
-                        current_x += Decimal(key['x']) * self.key_width
                     if 'y' in key:
                         current_row += Decimal(key['y'])
-                        current_y += Decimal(key['y']) * self.key_width
                     if 'd' in key:
                         current_key['decal'] = True
 
@@ -104,16 +100,11 @@ class KLE2xy(list):
                     current_key['row'] = round(current_row, 2)
                     current_key['column'] = round(current_col, 2)
 
-                    # Determine the X center
-                    x_center = (current_key['width'] * self.key_width) / 2
-                    current_x += x_center
-                    current_key['x'] = current_x
-                    current_x += x_center
-
-                    # Determine the Y center
-                    y_center = (current_key['height'] * self.key_width) / 2
-                    y_offset = y_center - (self.key_width / 2)
-                    current_key['y'] = (current_y + y_offset)
+                    # x,y (units mm) is the center of the key
+                    x_center = current_col + current_key['width'] / 2
+                    y_center = current_row + current_key['height'] / 2
+                    current_key['x'] = x_center * self.key_width
+                    current_key['y'] = y_center * self.key_width
 
                     # Tend to our row/col count
                     current_col += current_key['width']
@@ -129,8 +120,6 @@ class KLE2xy(list):
                     current_key = self.key_skel.copy()
 
             # Move to the next row
-            current_x = 0
-            current_y += self.key_width
             current_col = Decimal(0)
             current_row += Decimal(1)
             if current_row > self.rows:

--- a/lib/python/kle2xy.py
+++ b/lib/python/kle2xy.py
@@ -76,18 +76,9 @@ class KLE2xy(list):
                     if 'h' in key and key['h'] != Decimal(1):
                         current_key['height'] = Decimal(key['h'])
                     if 'a' in key:
-                        current_key['label_style'] = self.key_skel['label_style'] = int(key['a'])
-                        if current_key['label_style'] < 0:
-                            current_key['label_style'] = 0
-                        elif current_key['label_style'] > 9:
-                            current_key['label_style'] = 9
+                        current_key['label_style'] = self.key_skel['label_style'] = max(min(int(key['a']), 9), 0)
                     if 'f' in key:
-                        font_size = int(key['f'])
-                        if font_size > 9:
-                            font_size = 9
-                        elif font_size < 1:
-                            font_size = 1
-                        current_key['label_size'] = self.key_skel['label_size'] = font_size
+                        current_key['label_size'] = self.key_skel['label_size'] = max(min(int(key['f']), 9), 1)
                     if 'p' in key:
                         current_key['keycap_profile'] = self.key_skel['keycap_profile'] = key['p']
                     if 'c' in key:


### PR DESCRIPTION
This is not aimed to change functionality. Just trimming the code a little to hopefully be more understandable
## Description

2 commits:
- use min, max
- remove `current_x`, `current_y` 

#### Use Min, Max

the `label_style` can be between 0 and 9.

If a value is too high, it is set to 9.
The old code would put the correct value in `current_key`, but would put the incorrect value in `skel` (i.e. default values for the current key).

Simplifying the bounds checking to a single expression allowes both `skel` and `current_key` to be set with the correct value.

Same goes for `font_size`.

#### remove `current_{x,y}`

`row` and `column` are the location of a key in `u` units. `u` being the size of a key.
`x` and `y` are the location of the center of the key in `mm`.

`y = current_row * key_size + key_height * key_size /2`
you can have this value either by adding `key_size` every row, or by calculating this on the fly.

It seemed simpler to me to not have (and maintain) the 2 extra variables

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

I ran before and after with the test kle.txt and the larger alice keyboard layout.
The output was the same.

Since info does not output the `x, y` in `mm`, I also ran alice keyboard with print statements of the `row, col, x, y` values both before and after to ensure the calculated values were the same as the maintained values.