### PR TITLE
Add query functions for RGB Light and RGB Matrix

### DIFF
--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -437,12 +437,15 @@ Where `28` is an unused index from `eeconfig.h`.
 |`rgb_matrix_sethsv_noeeprom(h, s, v)`       |Set LEDs to the given HSV value where `h`/`s`/`v` are between 0 and 255 (not written to EEPROM) |
 
 ### Query Current Status :id=query-current-status
-|Function               |Description      |
-|-----------------------|-----------------|
-|`rgb_matrix_get_mode()`  |Get current mode |
-|`rgb_matrix_get_hue()`   |Get current hue  |
-|`rgb_matrix_get_sat()`   |Get current sat  |
-|`rgb_matrix_get_val()`   |Get current val  |
+|Function                         |Description                |
+|---------------------------------|---------------------------|
+|`rgb_matrix_get_enable()`        |Gets current on/off status |
+|`rgb_matrix_get_mode()`          |Gets current mode          |
+|`rgb_matrix_get_hue()`           |Gets current hue           |
+|`rgb_matrix_get_sat()`           |Gets current sat           |
+|`rgb_matrix_get_val()`           |Gets current val           |
+|`rgb_matrix_get_speed()`         |Gets current speed         |
+|`rgb_matrix_get_suspend_state()` |Gets current suspend state |
 
 ## Callbacks :id=callbacks
 

--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -444,6 +444,7 @@ Where `28` is an unused index from `eeconfig.h`.
 |`rgb_matrix_get_hue()`           |Gets current hue           |
 |`rgb_matrix_get_sat()`           |Gets current sat           |
 |`rgb_matrix_get_val()`           |Gets current val           |
+|`rgb_matrix_get_hsv()`           |Gets hue, sat, and val and returns a [`HSV` structure](https://github.com/qmk/qmk_firmware/blob/7ba6456c0b2e041bb9f97dbed265c5b8b4b12192/quantum/color.h#L56-L61)|
 |`rgb_matrix_get_speed()`         |Gets current speed         |
 |`rgb_matrix_get_suspend_state()` |Gets current suspend state |
 

--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -439,7 +439,7 @@ Where `28` is an unused index from `eeconfig.h`.
 ### Query Current Status :id=query-current-status
 |Function                         |Description                |
 |---------------------------------|---------------------------|
-|`rgb_matrix_get_enable()`        |Gets current on/off status |
+|`rgb_matrix_is_enabled()`        |Gets current on/off status |
 |`rgb_matrix_get_mode()`          |Gets current mode          |
 |`rgb_matrix_get_hue()`           |Gets current hue           |
 |`rgb_matrix_get_sat()`           |Gets current sat           |

--- a/docs/feature_rgblight.md
+++ b/docs/feature_rgblight.md
@@ -328,12 +328,14 @@ rgblight_sethsv(HSV_GREEN, 2); // led 2
 |`rgblight_set_layer_state(i, is_on)`        |Enable or disable lighting layer `i` based on value of `bool is_on` |
 
 #### query
-|Function               |Description      |
-|-----------------------|-----------------|
-|`rgblight_get_mode()`  |Get current mode |
-|`rgblight_get_hue()`   |Get current hue  |
-|`rgblight_get_sat()`   |Get current sat  |
-|`rgblight_get_val()`   |Get current val  |
+|Function               |Description                |
+|-----------------------|---------------------------|
+|`rgblight_get_enable()`|Gets current on/off status |
+|`rgblight_get_mode()`  |Gets current mode          |
+|`rgblight_get_hue()`   |Gets current hue           |
+|`rgblight_get_sat()`   |Gets current sat           |
+|`rgblight_get_val()`   |Gets current val           |
+|`rgblight_get_speed()` |Gets current speed         |
 
 ## Colors
 

--- a/docs/feature_rgblight.md
+++ b/docs/feature_rgblight.md
@@ -330,7 +330,7 @@ rgblight_sethsv(HSV_GREEN, 2); // led 2
 #### query
 |Function               |Description                |
 |-----------------------|---------------------------|
-|`rgblight_get_enable()`|Gets current on/off status |
+|`rgblight_is_enabled()`|Gets current on/off status |
 |`rgblight_get_mode()`  |Gets current mode          |
 |`rgblight_get_hue()`   |Gets current hue           |
 |`rgblight_get_sat()`   |Gets current sat           |

--- a/quantum/rgb_matrix.c
+++ b/quantum/rgb_matrix.c
@@ -440,6 +440,8 @@ void rgb_matrix_set_suspend_state(bool state) {
     g_suspend_state = state;
 }
 
+bool rgb_matrix_get_suspend_state(void) { return g_suspend_state; }
+
 void rgb_matrix_toggle(void) {
     rgb_matrix_config.enable ^= 1;
     rgb_task_state = STARTING;
@@ -465,6 +467,8 @@ void rgb_matrix_disable_noeeprom(void) {
     if (rgb_matrix_config.enable) rgb_task_state = STARTING;
     rgb_matrix_config.enable = 0;
 }
+
+uint8_t rgb_matrix_get_enable(void) { return rgb_matrix_config.enable; }
 
 void rgb_matrix_step(void) {
     rgb_matrix_config.mode++;
@@ -521,6 +525,8 @@ void rgb_matrix_decrease_speed(void) {
     eeconfig_update_rgb_matrix();
 }
 
+uint8_t rgb_matrix_get_speed(void) { return rgb_matrix_config.speed; }
+
 led_flags_t rgb_matrix_get_flags(void) { return rgb_effect_params.flags; }
 
 void rgb_matrix_set_flags(led_flags_t flags) { rgb_effect_params.flags = flags; }
@@ -546,3 +552,8 @@ void rgb_matrix_sethsv_noeeprom(uint16_t hue, uint8_t sat, uint8_t val) {
     rgb_matrix_config.hsv.v = val;
     if (rgb_matrix_config.hsv.v > RGB_MATRIX_MAXIMUM_BRIGHTNESS) rgb_matrix_config.hsv.v = RGB_MATRIX_MAXIMUM_BRIGHTNESS;
 }
+
+HSV     rgb_matrix_get_hsv(void) { return rgb_matrix_config.hsv; }
+uint8_t rgb_matrix_get_hue(void) { return rgb_matrix_config.hsv.h; }
+uint8_t rgb_matrix_get_sat(void) { return rgb_matrix_config.hsv.s; }
+uint8_t rgb_matrix_get_val(void) { return rgb_matrix_config.hsv.v; }

--- a/quantum/rgb_matrix.c
+++ b/quantum/rgb_matrix.c
@@ -468,7 +468,7 @@ void rgb_matrix_disable_noeeprom(void) {
     rgb_matrix_config.enable = 0;
 }
 
-uint8_t rgb_matrix_get_enable(void) { return rgb_matrix_config.enable; }
+uint8_t rgb_matrix_is_enabled(void) { return rgb_matrix_config.enable; }
 
 void rgb_matrix_step(void) {
     rgb_matrix_config.mode++;

--- a/quantum/rgb_matrix.h
+++ b/quantum/rgb_matrix.h
@@ -110,7 +110,7 @@ void        rgb_matrix_enable(void);
 void        rgb_matrix_enable_noeeprom(void);
 void        rgb_matrix_disable(void);
 void        rgb_matrix_disable_noeeprom(void);
-uint8_t     rgb_matrix_get_enable(void);
+uint8_t     rgb_matrix_is_enabled(void);
 void        rgb_matrix_step(void);
 void        rgb_matrix_step_reverse(void);
 void        rgb_matrix_increase_hue(void);

--- a/quantum/rgb_matrix.h
+++ b/quantum/rgb_matrix.h
@@ -140,7 +140,7 @@ uint8_t     rgb_matrix_get_val(void);
 #    define rgblight_enable_noeeprom rgb_matrix_enable_noeeprom
 #    define rgblight_disable rgb_matrix_disable
 #    define rgblight_disable_noeeprom rgb_matrix_disable_noeeprom
-#    define rgblight_get_enable rgb_matrix_get_enable
+#    define rgblight_is_enabled rgb_matrix_is_enabled
 #    define rgblight_step rgb_matrix_step
 #    define rgblight_sethsv rgb_matrix_sethsv
 #    define rgblight_sethsv_noeeprom rgb_matrix_sethsv_noeeprom

--- a/quantum/rgb_matrix.h
+++ b/quantum/rgb_matrix.h
@@ -104,11 +104,13 @@ void rgb_matrix_indicators_user(void);
 void rgb_matrix_init(void);
 
 void        rgb_matrix_set_suspend_state(bool state);
+bool        rgb_matrix_get_suspend_state(void);
 void        rgb_matrix_toggle(void);
 void        rgb_matrix_enable(void);
 void        rgb_matrix_enable_noeeprom(void);
 void        rgb_matrix_disable(void);
 void        rgb_matrix_disable_noeeprom(void);
+uint8_t     rgb_matrix_get_enable(void);
 void        rgb_matrix_step(void);
 void        rgb_matrix_step_reverse(void);
 void        rgb_matrix_increase_hue(void);
@@ -119,6 +121,7 @@ void        rgb_matrix_increase_val(void);
 void        rgb_matrix_decrease_val(void);
 void        rgb_matrix_increase_speed(void);
 void        rgb_matrix_decrease_speed(void);
+uint8_t     rgb_matrix_get_speed(void);
 led_flags_t rgb_matrix_get_flags(void);
 void        rgb_matrix_set_flags(led_flags_t flags);
 void        rgb_matrix_mode(uint8_t mode);
@@ -126,6 +129,10 @@ void        rgb_matrix_mode_noeeprom(uint8_t mode);
 uint8_t     rgb_matrix_get_mode(void);
 void        rgb_matrix_sethsv(uint16_t hue, uint8_t sat, uint8_t val);
 void        rgb_matrix_sethsv_noeeprom(uint16_t hue, uint8_t sat, uint8_t val);
+HSV         rgb_matrix_get_hsv(void);
+uint8_t     rgb_matrix_get_hue(void);
+uint8_t     rgb_matrix_get_sat(void);
+uint8_t     rgb_matrix_get_val(void);
 
 #ifndef RGBLIGHT_ENABLE
 #    define rgblight_toggle rgb_matrix_toggle
@@ -133,6 +140,7 @@ void        rgb_matrix_sethsv_noeeprom(uint16_t hue, uint8_t sat, uint8_t val);
 #    define rgblight_enable_noeeprom rgb_matrix_enable_noeeprom
 #    define rgblight_disable rgb_matrix_disable
 #    define rgblight_disable_noeeprom rgb_matrix_disable_noeeprom
+#    define rgblight_get_enable rgb_matrix_get_enable
 #    define rgblight_step rgb_matrix_step
 #    define rgblight_sethsv rgb_matrix_sethsv
 #    define rgblight_sethsv_noeeprom rgb_matrix_sethsv_noeeprom
@@ -145,9 +153,13 @@ void        rgb_matrix_sethsv_noeeprom(uint16_t hue, uint8_t sat, uint8_t val);
 #    define rgblight_decrease_val rgb_matrix_decrease_val
 #    define rgblight_increase_speed rgb_matrix_increase_speed
 #    define rgblight_decrease_speed rgb_matrix_decrease_speed
+#    define rgblight_get_speed rgb_matrix_get_speed
 #    define rgblight_mode rgb_matrix_mode
 #    define rgblight_mode_noeeprom rgb_matrix_mode_noeeprom
 #    define rgblight_get_mode rgb_matrix_get_mode
+#    define rgblight_get_hue rgb_matrix_get_hue
+#    define rgblight_get_sat rgb_matrix_get_sat
+#    define rgblight_get_val rgb_matrix_get_val
 #endif
 
 typedef struct {

--- a/quantum/rgb_matrix.h
+++ b/quantum/rgb_matrix.h
@@ -160,6 +160,7 @@ uint8_t     rgb_matrix_get_val(void);
 #    define rgblight_get_hue rgb_matrix_get_hue
 #    define rgblight_get_sat rgb_matrix_get_sat
 #    define rgblight_get_val rgb_matrix_get_val
+#    define rgblight_get_hsv rgb_matrix_get_hsv
 #endif
 
 typedef struct {

--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -371,7 +371,7 @@ void rgblight_disable_noeeprom(void) {
     rgblight_set();
 }
 
-bool rgblight_get_enable(void) { return rgblight_config.enable; }
+bool rgblight_is_enabled(void) { return rgblight_config.enable; }
 
 void rgblight_increase_hue_helper(bool write_to_eeprom) {
     uint8_t hue = rgblight_config.hue + RGBLIGHT_HUE_STEP;

--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -371,6 +371,8 @@ void rgblight_disable_noeeprom(void) {
     rgblight_set();
 }
 
+bool rgblight_get_enable(void) { return rgblight_config.enable; }
+
 void rgblight_increase_hue_helper(bool write_to_eeprom) {
     uint8_t hue = rgblight_config.hue + RGBLIGHT_HUE_STEP;
     rgblight_sethsv_eeprom_helper(hue, rgblight_config.sat, rgblight_config.val, write_to_eeprom);

--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -527,6 +527,10 @@ uint8_t rgblight_get_sat(void) { return rgblight_config.sat; }
 
 uint8_t rgblight_get_val(void) { return rgblight_config.val; }
 
+HSV rgblight_get_hsv(void) {
+    return (HSV){ rgblight_config.hue, rgblight_config.sat, rgblight_config.val };
+}
+
 void rgblight_setrgb(uint8_t r, uint8_t g, uint8_t b) {
     if (!rgblight_config.enable) {
         return;

--- a/quantum/rgblight.h
+++ b/quantum/rgblight.h
@@ -303,7 +303,7 @@ uint8_t rgblight_get_mode(void);
 uint8_t rgblight_get_hue(void);
 uint8_t rgblight_get_sat(void);
 uint8_t rgblight_get_val(void);
-bool    rgblight_get_enable(void);
+bool    rgblight_is_enabled(void);
 
 /* === qmk_firmware (core)internal Functions === */
 void     rgblight_init(void);

--- a/quantum/rgblight.h
+++ b/quantum/rgblight.h
@@ -303,6 +303,7 @@ uint8_t rgblight_get_mode(void);
 uint8_t rgblight_get_hue(void);
 uint8_t rgblight_get_sat(void);
 uint8_t rgblight_get_val(void);
+bool    rgblight_get_enable(void);
 
 /* === qmk_firmware (core)internal Functions === */
 void     rgblight_init(void);

--- a/quantum/rgblight.h
+++ b/quantum/rgblight.h
@@ -304,6 +304,7 @@ uint8_t rgblight_get_hue(void);
 uint8_t rgblight_get_sat(void);
 uint8_t rgblight_get_val(void);
 bool    rgblight_is_enabled(void);
+HSV     rgblight_get_hsv(void);
 
 /* === qmk_firmware (core)internal Functions === */
 void     rgblight_init(void);


### PR DESCRIPTION
## Description

Adds additional `rgblight_get_*` and `rgb_matrix_get_*` functions for querying RGB status, rather than referencing the rgblight or rgb matrix config directly. 

## Types of Changes

- [x] Core
- [x] Documentation

## Checklist
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
