### PR TITLE
Add one-handed Viterbi layout for gaming

### DIFF
--- a/keyboards/keebio/viterbi/keymaps/vosechu/config.h
+++ b/keyboards/keebio/viterbi/keymaps/vosechu/config.h
@@ -1,0 +1,54 @@
+/*
+Copyright 2017 Chuck Lauer Vose <vosechu@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+// #define USE_I2C
+
+/* Select hand configuration */
+
+// #define MASTER_RIGHT
+// #define EE_HANDS
+
+#undef RGBLED_NUM
+#define RGBLIGHT_ANIMATIONS
+#define RGBLED_NUM 12
+#define RGBLIGHT_HUE_STEP 8
+#define RGBLIGHT_SAT_STEP 8
+#define RGBLIGHT_VAL_STEP 8
+
+#define RGBLIGHT_LAYERS
+
+#define LAYOUT_ortho_half_5x7( \
+		L00, L01, L02, L03, L04, L05, L06, \
+		L10, L11, L12, L13, L14, L15, L16, \
+		L20, L21, L22, L23, L24, L25, L26, \
+		L30, L31, L32, L33, L34, L35, L36, \
+		L40, L41, L42, L43, L44, L45, L46\
+) \
+{ \
+	{ L00, L01, L02, L03, L04, L05, L06 }, \
+	{ L10, L11, L12, L13, L14, L15, L16 }, \
+	{ L20, L21, L22, L23, L24, L25, L26 }, \
+	{ L30, L31, L32, L33, L34, L35, L36 }, \
+	{ L40, L41, L42, L43, L44, L45, L46 }, \
+	{ KC_NO , KC_NO , KC_NO , KC_NO , KC_NO , KC_NO , KC_NO  }, \
+	{ KC_NO , KC_NO , KC_NO , KC_NO , KC_NO , KC_NO , KC_NO  }, \
+	{ KC_NO , KC_NO , KC_NO , KC_NO , KC_NO , KC_NO , KC_NO  }, \
+	{ KC_NO , KC_NO , KC_NO , KC_NO , KC_NO , KC_NO , KC_NO  }, \
+	{ KC_NO , KC_NO , KC_NO , KC_NO , KC_NO , KC_NO , KC_NO  } \
+}

--- a/keyboards/keebio/viterbi/keymaps/vosechu/config.h
+++ b/keyboards/keebio/viterbi/keymaps/vosechu/config.h
@@ -17,21 +17,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
-// #define USE_I2C
-
-/* Select hand configuration */
-
-// #define MASTER_RIGHT
-// #define EE_HANDS
-
 #undef RGBLED_NUM
 #define RGBLIGHT_ANIMATIONS
-#define RGBLED_NUM 12
+#define RGBLED_NUM 3
 #define RGBLIGHT_HUE_STEP 8
 #define RGBLIGHT_SAT_STEP 8
-#define RGBLIGHT_VAL_STEP 8
 
-#define RGBLIGHT_LAYERS
+#define RGBLIGHT_SLEEP // Put the keyboard to sleep when USB goes dark
 
 #define LAYOUT_ortho_half_5x7( \
 		L00, L01, L02, L03, L04, L05, L06, \

--- a/keyboards/keebio/viterbi/keymaps/vosechu/config.h
+++ b/keyboards/keebio/viterbi/keymaps/vosechu/config.h
@@ -26,21 +26,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGBLIGHT_SLEEP // Put the keyboard to sleep when USB goes dark
 
 #define LAYOUT_ortho_half_5x7( \
-		L00, L01, L02, L03, L04, L05, L06, \
-		L10, L11, L12, L13, L14, L15, L16, \
-		L20, L21, L22, L23, L24, L25, L26, \
-		L30, L31, L32, L33, L34, L35, L36, \
-		L40, L41, L42, L43, L44, L45, L46\
-) \
-{ \
-	{ L00, L01, L02, L03, L04, L05, L06 }, \
-	{ L10, L11, L12, L13, L14, L15, L16 }, \
-	{ L20, L21, L22, L23, L24, L25, L26 }, \
-	{ L30, L31, L32, L33, L34, L35, L36 }, \
-	{ L40, L41, L42, L43, L44, L45, L46 }, \
-	{ KC_NO , KC_NO , KC_NO , KC_NO , KC_NO , KC_NO , KC_NO  }, \
-	{ KC_NO , KC_NO , KC_NO , KC_NO , KC_NO , KC_NO , KC_NO  }, \
-	{ KC_NO , KC_NO , KC_NO , KC_NO , KC_NO , KC_NO , KC_NO  }, \
-	{ KC_NO , KC_NO , KC_NO , KC_NO , KC_NO , KC_NO , KC_NO  }, \
-	{ KC_NO , KC_NO , KC_NO , KC_NO , KC_NO , KC_NO , KC_NO  } \
-}
+    L00, L01, L02, L03, L04, L05, L06, \
+    L10, L11, L12, L13, L14, L15, L16, \
+    L20, L21, L22, L23, L24, L25, L26, \
+    L30, L31, L32, L33, L34, L35, L36, \
+    L40, L41, L42, L43, L44, L45, L46 \
+    ) \
+    LAYOUT_ortho_5x14( \
+        L00, L01, L02, L03, L04, L05, L06, KC_NO , KC_NO , KC_NO , KC_NO , KC_NO , KC_NO , KC_NO, \
+        L10, L11, L12, L13, L14, L15, L16, KC_NO , KC_NO , KC_NO , KC_NO , KC_NO , KC_NO , KC_NO, \
+        L20, L21, L22, L23, L24, L25, L26, KC_NO , KC_NO , KC_NO , KC_NO , KC_NO , KC_NO , KC_NO, \
+        L30, L31, L32, L33, L34, L35, L36, KC_NO , KC_NO , KC_NO , KC_NO , KC_NO , KC_NO , KC_NO, \
+        L40, L41, L42, L43, L44, L45, L46, KC_NO , KC_NO , KC_NO , KC_NO , KC_NO , KC_NO , KC_NO  \
+    )

--- a/keyboards/keebio/viterbi/keymaps/vosechu/keymap.c
+++ b/keyboards/keebio/viterbi/keymaps/vosechu/keymap.c
@@ -1,0 +1,116 @@
+#include QMK_KEYBOARD_H
+#include "vosechu.h"
+
+extern keymap_config_t keymap_config;
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+[BASE] = LAYOUT_ortho_half_5x7( // Base layer
+  KC_GRV  , KC_1    , KC_2    , KC_3    , KC_4    , KC_5    , KC_9    ,
+  ALT_TAB , KC_Q    , KC_W    , KC_E    , KC_R    , KC_T    , TT(TT1) ,
+  CTL_ESC , KC_A    , KC_S    , KC_D    , KC_F    , KC_G    , TT(TT2) ,
+  KC_F13  , KC_Z    , KC_X    , KC_C    , KC_V    , KC_B    , TT(TT3) ,
+  KC_MEH  , CTL_GRV , ALT_TAB , KC_LALT , MO(LWR) , LFT_BK  , SFT_SPC
+),
+[LWR] = LAYOUT_ortho_half_5x7( // EVE layer
+  _______   , _______ , _______ , _______ , _______ , _______ , _______ ,
+  A(KC_LEFT), KC_F1   , KC_F2   , KC_F3   , KC_F4   , KC_F5   , KC_F9   ,
+  SFT_SPC   , A(KC_F1), A(KC_F2), A(KC_F3), A(KC_F4), _______ , _______ ,
+  A(KC_RGHT), C(KC_F1), C(KC_F2), C(KC_F3), C(KC_F4), _______ , _______ ,
+  _______   , RESET   , _______ , _______ , _LAYER_ , KC_DEL  , KC_ENT
+),
+[LFT] = LAYOUT_ortho_half_5x7( // Media
+  _______ , KC_F10  , KC_F11  , KC_F12  , KC_PSCR , KC_SLCK , KC_PAUS ,
+  _______ , KC_F7   , KC_F8   , KC_F9   , KC_INS  , KC_HOME , KC_PGUP ,
+  RGB_TOG , KC_F4   , KC_F5   , KC_F6   , KC_DEL  , KC_END  , KC_PGDN ,
+  _______ , KC_F1   , KC_F2   , KC_F3   , KC_VOLU , KC_VOLD , KC_MUTE ,
+  _______ , _______ , _______ , _______ , PSWD    , _LAYER_ , PSWD_ALT
+),
+[TT1] = LAYOUT_ortho_half_5x7( // Override WASD with arrows
+  _______ , _______ , _______ , _______ , _______ , _______ , _______ ,
+  _______ , _______ , KC_UP   , _______ , _______ , _______ , _______ ,
+  _______ , KC_LEFT , KC_DOWN , KC_RGHT , _______ , _______ , _______ ,
+  _______ , _______ , _______ , _______ , _______ , _______ , _______ ,
+  _______ , _______ , _______ , _______ , _______ , _______ , _______
+),
+[TT2] = LAYOUT_ortho_half_5x7( // Browser layer
+  C(KC_W) , C(KC_1) , C(KC_T) , C(KC_9) , _______ , _______ , _______ ,
+  WBWSRBK , WTABLFT , KC_UP   , WTABRGT , WBWSRFW , _______ , _______ ,
+  KC_ESC  , KC_LEFT , KC_DOWN , KC_RGHT , C(KC_R) , _______ , _______ ,
+  _______ , _______ , _______ , _______ , _______ , _______ , TT(T23X),
+  _______ , _______ , _______ , _______ , _______ , _______ , _______
+),
+[TT3] = LAYOUT_ortho_half_5x7( // OS X override layer
+  _______ , _______ , _______ , _______ , _______ , _______ , _______ ,
+  _______ , _______ , _______ , _______ , _______ , _______ , _______ ,
+  _______ , _______ , _______ , _______ , _______ , _______ , TT(T23X),
+  _______ , _______ , _______ , _______ , _______ , _______ , _______ ,
+  _______ , _______ , _______ , KC_LGUI , _______ , _______ , _______
+),
+[T23X] = LAYOUT_ortho_half_5x7( // Browser layer
+  G(KC_W) , G(KC_1) , G(KC_T) , G(KC_9) , _______ , SLACKTB , _______ ,
+  BWSR_BK , TAB_LFT , KC_UP   , TAB_RGT , BWSR_FW , SLACKUP , _______ ,
+  KC_ESC  , KC_LEFT , KC_DOWN , KC_RGHT , G(KC_R) , SLACKDN , _______ ,
+  _______ , _______ , KC_Q    , KC_J    , KC_K    , _______ , _______ ,
+  _______ , _______ , _______ , KC_LGUI , _______ , _______ , _______
+),
+// [_EMPTY] = LAYOUT(
+//   _______ , _______ , _______ , _______ , _______ , _______ , _______ ,
+//   _______ , _______ , _______ , _______ , _______ , _______ , _______ ,
+//   _______ , _______ , _______ , _______ , _______ , _______ , _______ ,
+//   _______ , _______ , _______ , _______ , _______ , _______ , _______ ,
+//   _______ , _______ , _______ , _______ , _______ , _______ , _______
+// ),
+};
+
+void keyboard_post_init_user(void) {
+    // Call the post init code.
+    rgblight_enable_noeeprom(); // enables Rgb, without saving settings
+    rgblight_mode_noeeprom(0);
+    rgblight_sethsv_noeeprom(0, 0, 0);
+}
+
+layer_state_t layer_state_set_user(layer_state_t state) {
+  switch (get_highest_layer(state)) {
+  case TT1:
+    rgblight_sethsv_noeeprom(HSV_BLUE);
+    break;
+  case TT2:
+    rgblight_sethsv_noeeprom(HSV_PURPLE);
+    break;
+  case T23X:
+    rgblight_sethsv_noeeprom(HSV_GOLD);
+    break;
+  case TT3:
+    rgblight_sethsv_noeeprom(HSV_GREEN);
+    break;
+  default: //  for any other layers, or the default layer
+    rgblight_sethsv_noeeprom(0, 0, 0);
+    break;
+  }
+
+  return state;
+}
+
+void suspend_power_down_user(void) {
+    rgblight_disable();
+}
+
+void suspend_wakeup_init_user(void) {
+    rgblight_enable();
+}
+
+
+// bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+//   switch (keycode) {
+//     case TT1:
+//       if (record->event.pressed) {
+
+//       } else {
+
+//       }
+//       return false;
+//       break;
+//   }
+//   return true;
+// }

--- a/keyboards/keebio/viterbi/keymaps/vosechu/keymap.c
+++ b/keyboards/keebio/viterbi/keymaps/vosechu/keymap.c
@@ -1,8 +1,6 @@
 #include QMK_KEYBOARD_H
 #include "vosechu.h"
 
-extern keymap_config_t keymap_config;
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 [BASE] = LAYOUT_ortho_half_5x7( // Base layer
@@ -91,26 +89,3 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 
   return state;
 }
-
-void suspend_power_down_user(void) {
-    rgblight_disable();
-}
-
-void suspend_wakeup_init_user(void) {
-    rgblight_enable();
-}
-
-
-// bool process_record_user(uint16_t keycode, keyrecord_t *record) {
-//   switch (keycode) {
-//     case TT1:
-//       if (record->event.pressed) {
-
-//       } else {
-
-//       }
-//       return false;
-//       break;
-//   }
-//   return true;
-// }

--- a/keyboards/keebio/viterbi/keymaps/vosechu/rules.mk
+++ b/keyboards/keebio/viterbi/keymaps/vosechu/rules.mk
@@ -1,0 +1,1 @@
+RGBLIGHT_ENABLE = yes

--- a/users/vosechu/vosechu.h
+++ b/users/vosechu/vosechu.h
@@ -10,8 +10,13 @@ enum userspace_custom_layers {
   RSE,
   LWR,
   LFT,
-  MOUSE
+  MOUSE,
+  TT1,
+  TT2,
+  TT3,
+  T23X
 };
+#define BASE DV
 
 enum userspace_custom_keycodes {
   PAWFIVE = SAFE_RANGE,
@@ -34,8 +39,13 @@ enum userspace_custom_keycodes {
 // == Macro keys for commonly used apps
 // -- Slack
 // Move one conversation up/down
+#define SLACKTB LGUI(LSFT(KC_T))
 #define SLACKUP LALT(LSFT(KC_UP))
 #define SLACKDN LALT(LSFT(KC_DOWN))
+
+// -- 1password
+#define PSWD LCTL(KC_BSLS)
+#define PSWD_ALT LCTL(LALT(KC_BSLS))
 
 // -- Browser and OS X
 // Activate one tab left/right
@@ -51,6 +61,14 @@ enum userspace_custom_keycodes {
 #define SCR_RGT HYPR(KC_RGHT)
 // Make window fill the whole monitor
 #define SCR_FUL HYPR(KC_F)
+
+// -- Windows variants of browser commanads
+// Activate one tab left/right
+#define WTABLFT LCTL(LSFT(KC_TAB))
+#define WTABRGT LCTL(KC_TAB)
+// Go back/forward in history
+#define WBWSRBK LALT(KC_LEFT)
+#define WBWSRFW LALT(KC_RGHT)
 
 // == Extended alpha layer toggles
 // -- Dvorak


### PR DESCRIPTION
Adds a layout for my one-handed viterbi that I use for playing EVE and other games. 

Any and all feedback would be greatly appreciated!!

## Description

- Adds gaming layout
- Adds half-sized macro

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
