### PR TITLE
Audio enable corrections (Part 4)

### DIFF
--- a/docs/ChangeLog/20200530/PR8974.md
+++ b/docs/ChangeLog/20200530/PR8974.md
@@ -1,0 +1,2 @@
+## fixing wrong configuration of AUDIO feature
+add a compile-time error to alert the user to a missing pin-configuration (on AVR boards) when AUDIO_ENABLE=yes is set

--- a/quantum/audio/audio_avr.c
+++ b/quantum/audio/audio_avr.c
@@ -112,8 +112,7 @@
 #endif
 
 #if !defined(BPIN_AUDIO) && !defined(CPIN_AUDIO)
-#    error "Audio feature enabled, but no suitable pin selected - see docs/feature_audio.md under the AVR s
-ettings for available options."
+#    error "Audio feature enabled, but no suitable pin selected - see docs/feature_audio.md under the AVR settings for available options."
 #endif
 
 // -----------------------------------------------------------------------------

--- a/quantum/audio/audio_avr.c
+++ b/quantum/audio/audio_avr.c
@@ -110,6 +110,12 @@
 #    define TIMER_1_DUTY_CYCLE OCR1C
 #    define TIMER1_AUDIO_vect TIMER1_COMPC_vect
 #endif
+
+#if !defined(BPIN_AUDIO) && !defined(CPIN_AUDIO)
+#    error "Audio feature enabled, but no suitable pin selected - see docs/feature_audio.md under the AVR s
+ettings for available options."
+#endif
+
 // -----------------------------------------------------------------------------
 
 int   voices        = 0;


### PR DESCRIPTION
throw a compile error on mis-/un-configured AVR audio pins
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description


quantum/audio/audio_avr.c does not implicitly enable/use any pins, the proper defines have to be set for audio to actually work

-> this PR adds a compile error to alert the user to a wrong/missing configuration 

Note: this PR will break the build; build-fixes are in #8903

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
