### PR TITLE
Add some usages needed for ChromeOS hosts

### DIFF
--- a/tmk_core/common/report.h
+++ b/tmk_core/common/report.h
@@ -69,6 +69,8 @@ enum consumer_usages {
     AL_CALCULATOR          = 0x192,
     AL_LOCAL_BROWSER       = 0x194,
     AL_LOCK                = 0x19E,
+    AL_CONTROL_PANEL       = 0x19F,
+    AL_ASSISTANT           = 0x1CB,
     // 15.16 Generic GUI Application Controls
     AC_MINIMIZE            = 0x206,
     AC_SEARCH              = 0x221,


### PR DESCRIPTION
## Description

This adds two Consumer Page usages that are used often in ChromeOS.

- `AL_CONTROL_PANEL` (`0x19F`) - On ChromeOS this opens the settings tray.
- `AL_ASSISTANT` (`0x1CB`) - On ChromeOS this starts the Google Assistant. 
 
Many Chromebooks have dedicated keys for these; this will allow them in QMK.

Note, owing the the shortage of available KC_ keycodes, there is no mapping to these now. To use them, you will need to implement your own custom keycode, and can call this to send the code:
```c
if (record->event.pressed) {
    host_consumer_send(AL_ASSISTANT);
} else {
    host_consumer_send(0);
}
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
