### PR TITLE
Update vusb to match 3rd endpoint.

### DIFF
--- a/tmk_core/protocol/vusb/usbconfig.h
+++ b/tmk_core/protocol/vusb/usbconfig.h
@@ -31,7 +31,7 @@ section at the end of this file).
  * "B", the registers PORTB, PINB and DDRB will be used.
  */
 #ifndef USB_CFG_DMINUS_BIT
-#define USB_CFG_DMINUS_BIT              3
+#define USB_CFG_DMINUS_BIT      3
 #endif
 /* This is the bit number in USB_CFG_IOPORT where the USB D- line is connected.
  * This may be any bit in the port.

--- a/tmk_core/protocol/vusb/usbconfig.h
+++ b/tmk_core/protocol/vusb/usbconfig.h
@@ -25,19 +25,19 @@ section at the end of this file).
 /* ---------------------------- Hardware Config ---------------------------- */
 
 #ifndef USB_CFG_IOPORTNAME
-#define USB_CFG_IOPORTNAME      D
+#define USB_CFG_IOPORTNAME              D
 #endif
 /* This is the port where the USB bus is connected. When you configure it to
  * "B", the registers PORTB, PINB and DDRB will be used.
  */
 #ifndef USB_CFG_DMINUS_BIT
-#define USB_CFG_DMINUS_BIT      3
+#define USB_CFG_DMINUS_BIT              3
 #endif
 /* This is the bit number in USB_CFG_IOPORT where the USB D- line is connected.
  * This may be any bit in the port.
  */
 #ifndef USB_CFG_DPLUS_BIT
-#define USB_CFG_DPLUS_BIT       2
+#define USB_CFG_DPLUS_BIT               2
 #endif
 /* This is the bit number in USB_CFG_IOPORT where the USB D+ line is connected.
  * This may be any bit in the port. Please note that D+ must also be connected
@@ -47,7 +47,7 @@ section at the end of this file).
  * interrupt, the USB interrupt will also be triggered at Start-Of-Frame
  * markers every millisecond.]
  */
-#define USB_CFG_CHECK_CRC       0
+#define USB_CFG_CHECK_CRC               0
 /* Define this to 1 if you want that the driver checks integrity of incoming
  * data packets (CRC checks). CRC checks cost quite a bit of code size and are
  * currently only available for 18 MHz crystal clock. You must choose
@@ -85,13 +85,13 @@ section at the end of this file).
 /* If the so-called endpoint 3 is used, it can now be configured to any other
  * endpoint number (except 0) with this macro. Default if undefined is 3.
  */
-#define USB_CFG_HAVE_INTRIN_ENDPOINT4 1
+#define USB_CFG_HAVE_INTRIN_ENDPOINT4   1
 /* Define this to 1 if you want to compile a version with three endpoints: The
  * default control endpoint 0, an interrupt-in endpoint 4 (or the number
  * configured below) and a catch-all default interrupt-in endpoint as above.
  * You must also define USB_CFG_HAVE_INTRIN_ENDPOINT to 1 for this feature.
  */
-#define USB_CFG_EP4_NUMBER 4
+#define USB_CFG_EP4_NUMBER              4
 /* If the so-called endpoint 4 is used, it can now be configured to any other
  * endpoint number (except 0) with this macro. Default if undefined is 4.
  */

--- a/tmk_core/protocol/vusb/usbconfig.h
+++ b/tmk_core/protocol/vusb/usbconfig.h
@@ -85,9 +85,19 @@ section at the end of this file).
 /* If the so-called endpoint 3 is used, it can now be configured to any other
  * endpoint number (except 0) with this macro. Default if undefined is 3.
  */
+#define USB_CFG_HAVE_INTRIN_ENDPOINT4 1
+/* Define this to 1 if you want to compile a version with three endpoints: The
+ * default control endpoint 0, an interrupt-in endpoint 4 (or the number
+ * configured below) and a catch-all default interrupt-in endpoint as above.
+ * You must also define USB_CFG_HAVE_INTRIN_ENDPOINT to 1 for this feature.
+ */
+#define USB_CFG_EP4_NUMBER 4
+/* If the so-called endpoint 4 is used, it can now be configured to any other
+ * endpoint number (except 0) with this macro. Default if undefined is 4.
+ */
 /* #define USB_INITIAL_DATATOKEN           USBPID_DATA1 */
 /* The above macro defines the startup condition for data toggling on the
- * interrupt/bulk endpoints 1 and 3. Defaults to USBPID_DATA1.
+ * interrupt/bulk endpoints 1, 3 and 4. Defaults to USBPID_DATA1.
  * Since the token is toggled BEFORE sending any data, the first packet is
  * sent with the oposite value of this configuration!
  */
@@ -100,10 +110,10 @@ section at the end of this file).
 #define USB_CFG_SUPPRESS_INTR_CODE      0
 /* Define this to 1 if you want to declare interrupt-in endpoints, but don't
  * want to send any data over them. If this macro is defined to 1, functions
- * usbSetInterrupt() and usbSetInterrupt3() are omitted. This is useful if
- * you need the interrupt-in endpoints in order to comply to an interface
- * (e.g. HID), but never want to send any data. This option saves a couple
- * of bytes in flash memory and the transmit buffers in RAM.
+ * usbSetInterrupt(), usbSetInterrupt3() and usbSetInterrupt4() are omitted.
+ * This is useful if you need the interrupt-in endpoints in order to comply
+ * to an interface (e.g. HID), but never want to send any data. This option
+ * saves a couple of bytes in flash memory and the transmit buffers in RAM.
  */
 #define USB_CFG_IS_SELF_POWERED         0
 /* Define this to 1 if the device has its own power supply. Set it to 0 if the

--- a/tmk_core/protocol/vusb/usbconfig.h
+++ b/tmk_core/protocol/vusb/usbconfig.h
@@ -37,7 +37,7 @@ section at the end of this file).
  * This may be any bit in the port.
  */
 #ifndef USB_CFG_DPLUS_BIT
-#define USB_CFG_DPLUS_BIT               2
+#define USB_CFG_DPLUS_BIT       2
 #endif
 /* This is the bit number in USB_CFG_IOPORT where the USB D+ line is connected.
  * This may be any bit in the port. Please note that D+ must also be connected

--- a/tmk_core/protocol/vusb/usbconfig.h
+++ b/tmk_core/protocol/vusb/usbconfig.h
@@ -25,7 +25,7 @@ section at the end of this file).
 /* ---------------------------- Hardware Config ---------------------------- */
 
 #ifndef USB_CFG_IOPORTNAME
-#define USB_CFG_IOPORTNAME              D
+#define USB_CFG_IOPORTNAME      D
 #endif
 /* This is the port where the USB bus is connected. When you configure it to
  * "B", the registers PORTB, PINB and DDRB will be used.

--- a/tmk_core/protocol/vusb/usbconfig.h
+++ b/tmk_core/protocol/vusb/usbconfig.h
@@ -47,7 +47,7 @@ section at the end of this file).
  * interrupt, the USB interrupt will also be triggered at Start-Of-Frame
  * markers every millisecond.]
  */
-#define USB_CFG_CHECK_CRC               0
+#define USB_CFG_CHECK_CRC       0
 /* Define this to 1 if you want that the driver checks integrity of incoming
  * data packets (CRC checks). CRC checks cost quite a bit of code size and are
  * currently only available for 18 MHz crystal clock. You must choose

--- a/tmk_core/protocol/vusb/vusb.c
+++ b/tmk_core/protocol/vusb/vusb.c
@@ -72,7 +72,7 @@ enum usb_interfaces {
 #    error Mouse/Extra Keys share an endpoint with Console. Please disable one of the two.
 #endif
 
-static uint8_t vusb_keyboard_leds = 0;
+static uint8_t keyboard_led_state = 0;
 static uint8_t vusb_idle_rate     = 0;
 
 /* Keyboard report send buffer */

--- a/tmk_core/protocol/vusb/vusb.c
+++ b/tmk_core/protocol/vusb/vusb.c
@@ -234,8 +234,8 @@ typedef struct {
 static void send_mouse(report_mouse_t *report) {
 #ifdef MOUSE_ENABLE
     vusb_mouse_report_t r = {.report_id = REPORT_ID_MOUSE, .report = *report};
-    if (usbInterruptIsReady3()) {
-        usbSetInterrupt3((void *)&r, sizeof(vusb_mouse_report_t));
+    if (usbInterruptIsReady4()) {
+        usbSetInterrupt4((void *)&r, sizeof(vusb_mouse_report_t));
     }
 #endif
 }
@@ -249,8 +249,8 @@ static void send_extra(uint8_t report_id, uint16_t data) {
     last_data = data;
 
     report_extra_t report = {.report_id = report_id, .usage = data};
-    if (usbInterruptIsReady3()) {
-        usbSetInterrupt3((void *)&report, sizeof(report));
+    if (usbInterruptIsReady4()) {
+        usbSetInterrupt4((void *)&report, sizeof(report));
     }
 }
 #endif
@@ -732,7 +732,7 @@ const PROGMEM usbConfigurationDescriptor_t usbConfigurationDescriptor = {
             .bLength         = sizeof(usbEndpointDescriptor_t),
             .bDescriptorType = USBDESCR_ENDPOINT
         },
-        .bEndpointAddress    = (USBRQ_DIR_DEVICE_TO_HOST | USB_CFG_EP3_NUMBER),
+        .bEndpointAddress    = (USBRQ_DIR_DEVICE_TO_HOST | USB_CFG_EP4_NUMBER),
         .bmAttributes        = 0x03,
         .wMaxPacketSize      = 8,
         .bInterval           = USB_POLLING_INTERVAL_MS

--- a/tmk_core/protocol/vusb/vusb.c
+++ b/tmk_core/protocol/vusb/vusb.c
@@ -69,7 +69,7 @@ enum usb_interfaces {
 #endif
 
 #if (defined(MOUSE_ENABLE) || defined(EXTRAKEY_ENABLE)) && CONSOLE_ENABLE
-#    error Mouse/Extra Keys share an endpoing with Console. Please disable one of the two.
+#    error Mouse/Extra Keys share an endpoint with Console. Please disable one of the two.
 #endif
 
 static uint8_t vusb_keyboard_leds = 0;


### PR DESCRIPTION
- With the addition of https://github.com/qmk/v-usb/pull/1 a 3rd endpoint (endpoint4) becomes available.
- We can assign mouse/extrakeys to that endpoint as its a desirable feature and leave rawhid and console to compete for the 2nd endpoint.

NOTE: The version of vusb.c in future branch is older than master. Just remember that it will need a #error if both raw_hid and console are enabled at the same time.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
