### PR TITLE
[Keyboard] Fix inconsistent MATRIX_COLS: basekeys/slice

### DIFF
--- a/keyboards/basekeys/slice/rev1/config.h
+++ b/keyboards/basekeys/slice/rev1/config.h
@@ -28,7 +28,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* key matrix size */
 #define MATRIX_ROWS 10
-#define MATRIX_COLS 18
+#define MATRIX_COLS 9
 
 // wiring of each half
 #define MATRIX_ROW_PINS { D4, C6, D7, E6, B4 }

--- a/keyboards/basekeys/slice/rev1_rgb/config.h
+++ b/keyboards/basekeys/slice/rev1_rgb/config.h
@@ -28,7 +28,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* key matrix size */
 #define MATRIX_ROWS 10
-#define MATRIX_COLS 18
+#define MATRIX_COLS 9
 
 // wiring of each half
 #define MATRIX_ROW_PINS { D4, C6, D7, E6, B4 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->


<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Similar to #8115  #8150

MATRIX_COLS is wrongly defined larger than it should be.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
