### PR TITLE
adds support for the atmega328

### DIFF
--- a/quantum/config_common.h
+++ b/quantum/config_common.h
@@ -58,7 +58,7 @@
 #        define PINC_ADDRESS 0x3
 #        define PINB_ADDRESS 0x6
 #        define PINA_ADDRESS 0x9
-#    elif defined(__AVR_ATmega328P__)
+#    elif defined(__AVR_ATmega328P__) || defined(__AVR_ATmega328__)
 #        define ADDRESS_BASE 0x00
 #        define PINB_ADDRESS 0x3
 #        define PINC_ADDRESS 0x6

--- a/tmk_core/common/avr/bootloader.c
+++ b/tmk_core/common/avr/bootloader.c
@@ -247,7 +247,7 @@ void bootloader_jump(void) {
 
 #else  // Assume remaining boards are DFU, even if the flag isn't set
 
-#    if !(defined(__AVR_ATmega32A__) || defined(__AVR_ATmega328P__) || defined(__AVR_ATtiny85__))  // no USB - maybe BOOTLOADER_BOOTLOADHID instead though?
+#    if !(defined(__AVR_ATmega32A__) || defined(__AVR_ATmega328P__) || defined(__AVR_ATmega328__) || defined(__AVR_ATtiny85__))  // no USB - maybe BOOTLOADER_BOOTLOADHID instead though?
     UDCON  = 1;
     USBCON = (1 << FRZCLK);  // disable USB
     UCSR1B = 0;


### PR DESCRIPTION
## Description

I ordered some atmega328-pu chips by mistake not realising they weren't supported in qmk. with money scarce and the coronavirus delaying postage i decided it was worth adapting qmk to work with it. I compile the atmega328 USBaspLoader bootloader separately on my machine, I don't know how to integrate a custom bootloader in qmk, but this much works for me and it shouldn't break anything. I want to avoid making a keyboard that I don't know how to program in 5 years time. that's why i submitted the change.  

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
