### PR TITLE
Revert "Switch to nano specs on ChibiOS builds"

### DIFF
--- a/tmk_core/chibios.mk
+++ b/tmk_core/chibios.mk
@@ -233,7 +233,6 @@ LDFLAGS += -mno-thumb-interwork -mthumb
 LDSYMBOLS =,--defsym=__process_stack_size__=$(USE_PROCESS_STACKSIZE)
 LDSYMBOLS :=$(LDSYMBOLS),--defsym=__main_stack_size__=$(USE_EXCEPTIONS_STACKSIZE)
 LDFLAGS += -Wl,--script=$(LDSCRIPT)$(LDSYMBOLS)
-LDFLAGS += --specs=nano.specs
 
 OPT_DEFS += -DPROTOCOL_CHIBIOS
 


### PR DESCRIPTION
Reverts qmk/qmk_firmware#8270

Fixes #8809

`syscalls_cpp.cpp` contains some of the required stub functions, however on this arch environment it produces:
* ```multiple definition of `__dso_handle'```
* +2k firmware size over nosys

For the most part, ARM users are not strapped for space. So I put the case that it is better to have working builds across the board in the short term, while a potential longer term solution is worked on.