### PR TITLE
Option to allow lighting layers when RGB Lighting is off

### DIFF
--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -197,6 +197,8 @@ If you define these options you will enable the associated feature, which may in
   * Note: Increasing the maximum will increase the firmware size and slow sync on split keyboards.
 * `#define RGBLIGHT_LAYER_BLINK` 
   * Adds ability to [blink](feature_rgblight.md?id=lighting-layer-blink) a lighting layer for a specified number of milliseconds (e.g. to acknowledge an action).
+* `#define RGBLIGHT_LAYERS_OVERRIDE_RGB_OFF`
+  * If defined, then [lighting layers](feature_rgblight.md?id=lighting-layers) will be shown even if RGB Light is off.
 * `#define RGBLED_NUM 12`
   * number of LEDs
 * `#define RGBLIGHT_SPLIT`

--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -198,7 +198,7 @@ If you define these options you will enable the associated feature, which may in
 * `#define RGBLIGHT_LAYER_BLINK` 
   * Adds ability to [blink](feature_rgblight.md?id=lighting-layer-blink) a lighting layer for a specified number of milliseconds (e.g. to acknowledge an action).
 * `#define RGBLIGHT_LAYERS_OVERRIDE_RGB_OFF`
-  * If defined, then [lighting layers](feature_rgblight.md?id=lighting-layers) will be shown even if RGB Light is off.
+  * If defined, then [lighting layers](feature_rgblight?id=overriding-rgb-lighting-onoff-status) will be shown even if RGB Light is off.
 * `#define RGBLED_NUM 12`
   * number of LEDs
 * `#define RGBLIGHT_SPLIT`

--- a/docs/feature_rgblight.md
+++ b/docs/feature_rgblight.md
@@ -278,6 +278,8 @@ void post_process_record_user(uint16_t keycode, keyrecord_t *record) {
 }
 ```
 
+### Overriding RGB Lighting on/off status
+
 Normally lighting layers are not shown when RGB Lighting is disabled (e.g. with `RGB_TOG` keycode). If you would like lighting layers to work even when the RGB Lighting is otherwise off, add `#define RGBLIGHT_LAYERS_OVERRIDE_RGB_OFF` to your `config.h`.
 
 ## Functions

--- a/docs/feature_rgblight.md
+++ b/docs/feature_rgblight.md
@@ -278,6 +278,8 @@ void post_process_record_user(uint16_t keycode, keyrecord_t *record) {
 }
 ```
 
+Normally lighting layers are not shown when RGB Lighting is disabled (e.g. with `RGB_TOG` keycode). If you would like lighting layers to work even when the RGB Lighting is otherwise off, add `#define RGBLIGHT_LAYERS_OVERRIDE_RGB_OFF` to your `config.h`.
+
 ## Functions
 
 If you need to change your RGB lighting in code, for example in a macro to change the color whenever you switch layers, QMK provides a set of functions to assist you. See [`rgblight.h`](https://github.com/qmk/qmk_firmware/blob/master/quantum/rgblight.h) for the full list, but the most commonly used functions include:

--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -628,6 +628,13 @@ void rgblight_set_layer_state(uint8_t layer, bool enabled) {
     if (rgblight_status.timer_enabled == false) {
         rgblight_mode_noeeprom(rgblight_config.mode);
     }
+
+#    ifdef RGBLIGHT_LAYERS_OVERRIDE_RGB_OFF
+    // If not enabled, then nothing else will actually set the LEDs...
+    if (!rgblight_config.enable) {
+        rgblight_set();
+    }
+#    endif
 }
 
 bool rgblight_get_layer_state(uint8_t layer) {
@@ -693,15 +700,10 @@ void rgblight_unblink_layers(void) {
 __attribute__((weak)) void rgblight_call_driver(LED_TYPE *start_led, uint8_t num_leds) { ws2812_setleds(start_led, num_leds); }
 
 #ifndef RGBLIGHT_CUSTOM_DRIVER
+
 void rgblight_set(void) {
     LED_TYPE *start_led;
     uint8_t   num_leds = rgblight_ranges.clipping_num_leds;
-
-#    ifdef RGBLIGHT_LAYERS
-    if (rgblight_layers != NULL) {
-        rgblight_layers_write();
-    }
-#    endif
 
     if (!rgblight_config.enable) {
         for (uint8_t i = rgblight_ranges.effect_start_pos; i < rgblight_ranges.effect_end_pos; i++) {
@@ -713,6 +715,16 @@ void rgblight_set(void) {
 #    endif
         }
     }
+
+#    ifdef RGBLIGHT_LAYERS
+    if (rgblight_layers != NULL
+#        ifndef RGBLIGHT_LAYERS_OVERRIDE_RGB_OFF
+        && rgblight_config.enable
+#        endif
+    ) {
+        rgblight_layers_write();
+    }
+#    endif
 
 #    ifdef RGBLIGHT_LED_MAP
     LED_TYPE led0[RGBLED_NUM];


### PR DESCRIPTION
## Description

At present, if RGB Lighting is disabled (e.g. using `RGB_TOG` keycode) then enabling the lighting layer has no effect. 

With this change, if RGBLIGHT_LAYERS_OVERRIDE_RGB_OFF is defined, then lighting layers will work even when RGB Lighting is otherwise turned off.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
