### PR TITLE
Disable NKRO on V-USB controllers

### DIFF
--- a/tmk_core/common.mk
+++ b/tmk_core/common.mk
@@ -92,8 +92,12 @@ ifeq ($(strip $(COMMAND_ENABLE)), yes)
 endif
 
 ifeq ($(strip $(NKRO_ENABLE)), yes)
-    TMK_COMMON_DEFS += -DNKRO_ENABLE
-    SHARED_EP_ENABLE = yes
+    ifneq ($(PROTOCOL),VUSB)
+        TMK_COMMON_DEFS += -DNKRO_ENABLE
+        SHARED_EP_ENABLE = yes
+    else
+        $(info NKRO is not supported on V-USB, and has been disabled.)
+    endif
 endif
 
 ifeq ($(strip $(USB_6KRO_ENABLE)), yes)

--- a/tmk_core/common.mk
+++ b/tmk_core/common.mk
@@ -96,7 +96,7 @@ ifeq ($(strip $(NKRO_ENABLE)), yes)
         TMK_COMMON_DEFS += -DNKRO_ENABLE
         SHARED_EP_ENABLE = yes
     else
-        $(info NKRO is not supported on V-USB, and has been disabled.)
+        $(info NKRO is not currently supported on V-USB, and has been disabled.)
     endif
 endif
 


### PR DESCRIPTION
## Description

NKRO isn't available on on V-USB.  Instead of erroring out and failing to compile, just forcibly disable NKRO on V-USB controllers. 


## Types of Changes

- [x] Core
- [x] Enhancement/optimization

## Checklist

- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
