### PR TITLE
Convert `CONSUMER2BLUEFRUIT()` and `CONSUMER2RN42()` macros to static inline functions

### DIFF
--- a/tmk_core/common/report.h
+++ b/tmk_core/common/report.h
@@ -46,8 +46,9 @@ enum mouse_buttons {
  * See https://www.usb.org/sites/default/files/documents/hut1_12v2.pdf#page=75
  */
 enum consumer_usages {
-    // 15.5 Display Controls (https://www.usb.org/sites/default/files/hutrr41_0.pdf)
-    BRIGHTNESS_UP          = 0x06F,
+    // 15.5 Display Controls
+    SNAPSHOT               = 0x065,
+    BRIGHTNESS_UP          = 0x06F, // https://www.usb.org/sites/default/files/hutrr41_0.pdf
     BRIGHTNESS_DOWN        = 0x070,
     // 15.7 Transport Controls
     TRANSPORT_RECORD       = 0x0B2,
@@ -57,6 +58,7 @@ enum consumer_usages {
     TRANSPORT_PREV_TRACK   = 0x0B6,
     TRANSPORT_STOP         = 0x0B7,
     TRANSPORT_EJECT        = 0x0B8,
+    TRANSPORT_RANDOM_PLAY  = 0x0B9,
     TRANSPORT_STOP_EJECT   = 0x0CC,
     TRANSPORT_PLAY_PAUSE   = 0x0CD,
     // 15.9.1 Audio Controls - Volume
@@ -71,6 +73,7 @@ enum consumer_usages {
     AL_LOCK                = 0x19E,
     AL_CONTROL_PANEL       = 0x19F,
     AL_ASSISTANT           = 0x1CB,
+    AL_KEYBOARD_LAYOUT     = 0x1AE,
     // 15.16 Generic GUI Application Controls
     AC_MINIMIZE            = 0x206,
     AC_SEARCH              = 0x221,

--- a/tmk_core/protocol/lufa/bluetooth.h
+++ b/tmk_core/protocol/lufa/bluetooth.h
@@ -15,34 +15,82 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef BLUETOOTH_H
-#define BLUETOOTH_H
+#pragma once
 
 #include "../serial.h"
 
 void bluefruit_serial_send(uint8_t data);
 
-/*
-+-----------------+-------------------+-------+
-| Consumer Key    | Bit Map           | Hex   |
-+-----------------+-------------------+-------+
-| Home            | 00000001 00000000 | 01 00 |
-| KeyboardLayout  | 00000010 00000000 | 02 00 |
-| Search          | 00000100 00000000 | 04 00 |
-| Snapshot        | 00001000 00000000 | 08 00 |
-| VolumeUp        | 00010000 00000000 | 10 00 |
-| VolumeDown      | 00100000 00000000 | 20 00 |
-| Play/Pause      | 01000000 00000000 | 40 00 |
-| Fast Forward    | 10000000 00000000 | 80 00 |
-| Rewind          | 00000000 00000001 | 00 01 |
-| Scan Next Track | 00000000 00000010 | 00 02 |
-| Scan Prev Track | 00000000 00000100 | 00 04 |
-| Random Play     | 00000000 00001000 | 00 08 |
-| Stop            | 00000000 00010000 | 00 10 |
-+-------------------------------------+-------+
-*/
-#define CONSUMER2BLUEFRUIT(usage) (usage == AUDIO_MUTE ? 0x0000 : (usage == AUDIO_VOL_UP ? 0x1000 : (usage == AUDIO_VOL_DOWN ? 0x2000 : (usage == TRANSPORT_NEXT_TRACK ? 0x0002 : (usage == TRANSPORT_PREV_TRACK ? 0x0004 : (usage == TRANSPORT_STOP ? 0x0010 : (usage == TRANSPORT_STOP_EJECT ? 0x0000 : (usage == TRANSPORT_PLAY_PAUSE ? 0x4000 : (usage == AL_CC_CONFIG ? 0x0000 : (usage == AL_EMAIL ? 0x0000 : (usage == AL_CALCULATOR ? 0x0000 : (usage == AL_LOCAL_BROWSER ? 0x0000 : (usage == AC_SEARCH ? 0x0400 : (usage == AC_HOME ? 0x0100 : (usage == AC_BACK ? 0x0000 : (usage == AC_FORWARD ? 0x0000 : (usage == AC_STOP ? 0x0000 : (usage == AC_REFRESH ? 0x0000 : (usage == AC_BOOKMARKS ? 0x0000 : 0)))))))))))))))))))
+// https://learn.adafruit.com/introducing-bluefruit-ez-key-diy-bluetooth-hid-keyboard/sending-keys-via-serial#raw-hid-consumer-reports-8-14
+static inline uint16_t CONSUMER2BLUEFRUIT(uint16_t usage) {
+    switch (usage) {
+        case AC_HOME:
+            return 0x0001;
+        case AL_KEYBOARD_LAYOUT:
+            return 0x0002;
+        case AC_SEARCH:
+            return 0x0004;
+        case SNAPSHOT:
+            return 0x0008;
+        case AUDIO_VOL_UP:
+            return 0x0010;
+        case AUDIO_VOL_DOWN:
+            return 0x0020;
+        case TRANSPORT_PLAY_PAUSE:
+            return 0x0040;
+        case TRANSPORT_FAST_FORWARD:
+            return 0x0080;
+        case TRANSPORT_REWIND:
+            return 0x0100;
+        case TRANSPORT_NEXT_TRACK:
+            return 0x0200;
+        case TRANSPORT_PREV_TRACK:
+            return 0x0400;
+        case TRANSPORT_RANDOM_PLAY:
+            return 0x0800;
+        case TRANSPORT_STOP:
+            return 0x1000;
+        default:
+            return 0;
+    }
+}
 
-#define CONSUMER2RN42(usage) (usage == AUDIO_MUTE ? 0x0040 : (usage == AUDIO_VOL_UP ? 0x0010 : (usage == AUDIO_VOL_DOWN ? 0x0020 : (usage == TRANSPORT_NEXT_TRACK ? 0x0100 : (usage == TRANSPORT_PREV_TRACK ? 0x0200 : (usage == TRANSPORT_STOP ? 0x0400 : (usage == TRANSPORT_STOP_EJECT ? 0x0800 : (usage == TRANSPORT_PLAY_PAUSE ? 0x0080 : (usage == AL_EMAIL ? 0x0200 : (usage == AL_LOCAL_BROWSER ? 0x8000 : (usage == AC_SEARCH ? 0x0400 : (usage == AC_HOME ? 0x0100 : 0))))))))))))
-
-#endif
+// https://cdn.sparkfun.com/datasheets/Wireless/Bluetooth/bluetooth_cr_UG-v1.0r.pdf#G7.663734
+static inline uint16_t CONSUMER2RN42(uint16_t usage) {
+    switch (usage) {
+        case AC_HOME:
+            return 0x0001;
+        case AL_EMAIL:
+            return 0x0002;
+        case AC_SEARCH:
+            return 0x0004;
+        case AL_KEYBOARD_LAYOUT:
+            return 0x0008;
+        case AUDIO_VOL_UP:
+            return 0x0010;
+        case AUDIO_VOL_DOWN:
+            return 0x0020;
+        case AUDIO_MUTE:
+            return 0x0040;
+        case TRANSPORT_PLAY_PAUSE:
+            return 0x0080;
+        case TRANSPORT_NEXT_TRACK:
+            return 0x0100;
+        case TRANSPORT_PREV_TRACK:
+            return 0x0200;
+        case TRANSPORT_STOP:
+            return 0x0400;
+        case TRANSPORT_EJECT:
+            return 0x0800;
+        case TRANSPORT_FAST_FORWARD:
+            return 0x1000;
+        case TRANSPORT_REWIND:
+            return 0x2000;
+        case TRANSPORT_STOP_EJECT:
+            return 0x4000;
+        case AL_LOCAL_BROWSER:
+            return 0x8000;
+        default:
+            return 0;
+    }
+}

--- a/tmk_core/protocol/lufa/lufa.c
+++ b/tmk_core/protocol/lufa/lufa.c
@@ -719,8 +719,8 @@ static void send_consumer(uint16_t data) {
         bluefruit_serial_send(0xFD);
         bluefruit_serial_send(0x00);
         bluefruit_serial_send(0x02);
-        bluefruit_serial_send((bitmap >> 8) & 0xFF);
         bluefruit_serial_send(bitmap & 0xFF);
+        bluefruit_serial_send((bitmap >> 8) & 0xFF);
         bluefruit_serial_send(0x00);
         bluefruit_serial_send(0x00);
         bluefruit_serial_send(0x00);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

A la #8101.
`AL Keyboard Layout` apparently toggles the virtual keyboard on iOS, and *only* iOS. Nothing seems to happen on Windows, Android or macOS, though I didn't have a touch-capable Windows device nor an iPhone/iPad to test.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
