### PR TITLE
Avoid 'Entering|Leaving directory' messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ $(info QMK Firmware $(QMK_VERSION))
 endif
 endif
 
+# avoid 'Entering|Leaving directory' messages
+MAKEFLAGS += --no-print-directory
+
 ON_ERROR := error_occurred=1
 
 BREAK_ON_ERRORS = no


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Recent arch install produces:
```console
$ make handwired/onekey:all LTO_ENABLE=yes
QMK Firmware 0.8.144
Making handwired/onekey/promicro with keymap adc                                                       [WARNINGS]
make[1]: Entering directory '/home/zvecr/qmk_firmware'
make[1]: Leaving directory '/home/zvecr/qmk_firmware'
Making handwired/onekey/promicro with keymap backlight                                                 [WARNINGS]
make[1]: Entering directory '/home/zvecr/qmk_firmware'
make[1]: Leaving directory '/home/zvecr/qmk_firmware'
Making handwired/onekey/promicro with keymap default                                                   [WARNINGS]
make[1]: Entering directory '/home/zvecr/qmk_firmware'
make[1]: Leaving directory '/home/zvecr/qmk_firmware'
Making handwired/onekey/promicro with keymap i2c_scanner                                               [WARNINGS]
make[1]: Entering directory '/home/zvecr/qmk_firmware'
make[1]: Leaving directory '/home/zvecr/qmk_firmware'
Making handwired/onekey/promicro with keymap reset                                                     [WARNINGS]
make[1]: Entering directory '/home/zvecr/qmk_firmware'
make[1]: Leaving directory '/home/zvecr/qmk_firmware'
Making handwired/onekey/promicro with keymap rgb                                                       [WARNINGS]
make[1]: Entering directory '/home/zvecr/qmk_firmware'
make[1]: Leaving directory '/home/zvecr/qmk_firmware'
Making handwired/onekey/promicro with keymap test                                                      [WARNINGS]
make[1]: Entering directory '/home/zvecr/qmk_firmware'
make[1]: Leaving directory '/home/zvecr/qmk_firmware'

```
Without something like `make -s` or the change in this PR, the above "Entering|Leaving directory" logic triggers erroneous build warnings.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
