### PR TITLE
[kle2json] Add key_count, width, height

### DIFF
--- a/lib/python/kle2xy.py
+++ b/lib/python/kle2xy.py
@@ -17,6 +17,7 @@ class KLE2xy(list):
         self.key_skel = {'decal': False, 'border_color': 'none', 'keycap_profile': '', 'keycap_color': 'grey', 'label_color': 'black', 'label_size': 3, 'label_style': 4, 'width': Decimal('1'), 'height': Decimal('1'), 'x': Decimal('0'), 'y': Decimal('0')}
         self.rows = Decimal(0)
         self.columns = Decimal(0)
+        self.key_count = 0
 
         if layout:
             self.parse_layout(layout)
@@ -136,6 +137,7 @@ class KLE2xy(list):
                     # Store this key
                     self[-1].append(current_key)
                     current_key = self.key_skel.copy()
+                    self.key_count += 1
 
             # Move to the next row
             current_x = 0

--- a/lib/python/qmk/cli/kle2json.py
+++ b/lib/python/qmk/cli/kle2json.py
@@ -60,6 +60,8 @@ def kle2json(cli):
         height=kle.rows,
         layouts={'LAYOUT': {
             'key_count': kle.key_count,
+            'width': kle.columns,
+            'height': kle.rows,
             'layout': 'LAYOUT_JSON_HERE'
         }},
     )

--- a/lib/python/qmk/cli/kle2json.py
+++ b/lib/python/qmk/cli/kle2json.py
@@ -59,6 +59,7 @@ def kle2json(cli):
         width=kle.columns,
         height=kle.rows,
         layouts={'LAYOUT': {
+            'key_count': kle.key_count,
             'layout': 'LAYOUT_JSON_HERE'
         }},
     )


### PR DESCRIPTION
## Description

The `kle2json` tool converts keyboard layout editor's json to an `info.json` file.

The [info.json spec] allows for some fields that are not being populated in the `info.json` file:

- `key_count`
- `width`
- `height`

These are part of the [info.json spec], with `key_count` being required.
The width and height are already calculated by the tool.
This adds calculation of `key_count`

Not sure if these fields were left out of the file for a reason.

[info.json spec]: https://beta.docs.qmk.fm/developing-qmk/qmk-reference/reference_info_json#layout-format


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
