### PR TITLE
Added defines for RAISE and LOWER

### DIFF
--- a/layouts/community/ortho_4x12/xyverz/keymap.c
+++ b/layouts/community/ortho_4x12/xyverz/keymap.c
@@ -2,13 +2,15 @@
 
 enum layer_names { _QWERTY, _COLEMAK, _DVORAK, _LOWER, _RAISE, _ADJUST };
 
-enum custom_keycodes { QWERTY = SAFE_RANGE, COLEMAK, DVORAK, LOWER, RAISE, ADJUST };
+enum custom_keycodes { QWERTY = SAFE_RANGE, COLEMAK, DVORAK, ADJUST };
 
 // Aliases to keep the keymap tidy
 #define GUIBSPC GUI_T(KC_BSPC)  // GUI when held, BSPC when tapped.
 #define RGB_SWR RGB_M_SW        // Swirl Animation alias
 #define RGB_SNK RGB_M_SN        // Snake Animation alias
 #define MACLOCK LGUI(LCTL(KC_Q)) // Lock my MacBook!
+#define RAISE MO(_RAISE)
+#define LOWER MO(_LOWER)
 
 // clang-format off
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {


### PR DESCRIPTION
I like being able to use layers. This fixes my screw-up from my last
code overhaul.

<!--- Provide a general summary of your changes in the title above. -->

Added defines for RAISE and LOWER, and removed RAISE  LOWER from the keycode enum. (Thanks @ridingqwerty!)

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
