### PR TITLE
fixed typo for clear lcd screen function in hd44780 docs

### DIFF
--- a/docs/feature_hd44780.md
+++ b/docs/feature_hd44780.md
@@ -50,7 +50,7 @@ LCD_DISP_ON_CURSOR_BLINK : display on, cursor on flashing
 ````
 This is best done in your keyboards `matrix_init_kb` or your keymaps `matrix_init_user`.  
 It is advised to clear the display before use.  
-To do so call `lcd_clrsrc()`.
+To do so call `lcd_clrscr()`.
 
 To now print something to your Display you first call `lcd_gotoxy(column, line)`. To go to the start of the first line you would call `lcd_gotoxy(0, 0)` and then print a string with `lcd_puts("example string")`.
 

--- a/docs/ja/feature_hd44780.md
+++ b/docs/ja/feature_hd44780.md
@@ -55,7 +55,7 @@ LCD_DISP_ON_CURSOR_BLINK : ディスプレイオン、点滅カーソル
 ````
 これはキーボードの `matrix_init_kb` またはキーマップの `matrix_init_user` で行うのが最適です。
 使用前にディスプレイをクリアすることをお勧めします。
-そのためには、`lcd_clrsrc()` を呼びます。
+そのためには、`lcd_clrscr()` を呼びます。
 
 ディスプレイに何かを表示するには、最初に `lcd_gotoxy(column, line)` を呼びます。最初の行の先頭に移動するには、`lcd_gotoxy(0, 0)` を呼び出し、その後 `lcd_puts("example string")` を使って文字列を出力します。
 


### PR DESCRIPTION
brought to attention by RichardMiruGeorge and fauxpark in #9085

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* fixes #9085

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
