### PR TITLE
V-USB Interface reorder

### DIFF
--- a/tmk_core/protocol/vusb/vusb.c
+++ b/tmk_core/protocol/vusb/vusb.c
@@ -43,11 +43,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 enum usb_interfaces {
     KEYBOARD_INTERFACE = NEXT_INTERFACE,
-#if (defined(MOUSE_ENABLE) || defined(EXTRAKEY_ENABLE))
-    MOUSE_EXTRA_INTERFACE = NEXT_INTERFACE,
-#endif
 #ifdef RAW_ENABLE
     RAW_INTERFACE = NEXT_INTERFACE,
+#endif
+#if (defined(MOUSE_ENABLE) || defined(EXTRAKEY_ENABLE))
+    MOUSE_EXTRA_INTERFACE = NEXT_INTERFACE,
 #endif
 #ifdef CONSOLE_ENABLE
     CONSOLE_INTERFACE = NEXT_INTERFACE,

--- a/tmk_core/protocol/vusb/vusb.c
+++ b/tmk_core/protocol/vusb/vusb.c
@@ -43,6 +43,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 enum usb_interfaces {
     KEYBOARD_INTERFACE = NEXT_INTERFACE,
+// It is important that the Raw HID interface is at a constant
+// interface number, to support Linux/OSX platforms and chrome.hid
+// If Raw HID is enabled, let it be always 1.
 #ifdef RAW_ENABLE
     RAW_INTERFACE = NEXT_INTERFACE,
 #endif

--- a/tmk_core/protocol/vusb/vusb.c
+++ b/tmk_core/protocol/vusb/vusb.c
@@ -407,6 +407,29 @@ const PROGMEM uchar keyboard_hid_report[] = {
     0xC0         // End Collection
 };
 
+#ifdef RAW_ENABLE
+const PROGMEM uchar raw_hid_report[] = {
+    0x06, 0x60, 0xFF,  // Usage Page (Vendor Defined)
+    0x09, 0x61,        // Usage (Vendor Defined)
+    0xA1, 0x01,        // Collection (Application)
+    // Data to host
+    0x09, 0x62,             //   Usage (Vendor Defined)
+    0x15, 0x00,             //   Logical Minimum (0)
+    0x26, 0xFF, 0x00,       //   Logical Maximum (255)
+    0x95, RAW_BUFFER_SIZE,  //   Report Count
+    0x75, 0x08,             //   Report Size (8)
+    0x81, 0x02,             //   Input (Data, Variable, Absolute)
+    // Data from host
+    0x09, 0x63,             //   Usage (Vendor Defined)
+    0x15, 0x00,             //   Logical Minimum (0)
+    0x26, 0xFF, 0x00,       //   Logical Maximum (255)
+    0x95, RAW_BUFFER_SIZE,  //   Report Count
+    0x75, 0x08,             //   Report Size (8)
+    0x91, 0x02,             //   Output (Data, Variable, Absolute)
+    0xC0                    // End Collection
+};
+#endif
+
 #if defined(MOUSE_ENABLE) || defined(EXTRAKEY_ENABLE)
 const PROGMEM uchar mouse_extra_hid_report[] = {
 #    ifdef MOUSE_ENABLE
@@ -488,29 +511,6 @@ const PROGMEM uchar mouse_extra_hid_report[] = {
     0x81, 0x00,                //   Input (Data, Array, Absolute)
     0xC0                       // End Collection
 #    endif
-};
-#endif
-
-#ifdef RAW_ENABLE
-const PROGMEM uchar raw_hid_report[] = {
-    0x06, 0x60, 0xFF,  // Usage Page (Vendor Defined)
-    0x09, 0x61,        // Usage (Vendor Defined)
-    0xA1, 0x01,        // Collection (Application)
-    // Data to host
-    0x09, 0x62,             //   Usage (Vendor Defined)
-    0x15, 0x00,             //   Logical Minimum (0)
-    0x26, 0xFF, 0x00,       //   Logical Maximum (255)
-    0x95, RAW_BUFFER_SIZE,  //   Report Count
-    0x75, 0x08,             //   Report Size (8)
-    0x81, 0x02,             //   Input (Data, Variable, Absolute)
-    // Data from host
-    0x09, 0x63,             //   Usage (Vendor Defined)
-    0x15, 0x00,             //   Logical Minimum (0)
-    0x26, 0xFF, 0x00,       //   Logical Maximum (255)
-    0x95, RAW_BUFFER_SIZE,  //   Report Count
-    0x75, 0x08,             //   Report Size (8)
-    0x91, 0x02,             //   Output (Data, Variable, Absolute)
-    0xC0                    // End Collection
 };
 #endif
 
@@ -660,46 +660,10 @@ const PROGMEM usbConfigurationDescriptor_t usbConfigurationDescriptor = {
         .bInterval           = USB_POLLING_INTERVAL_MS
     },
 
-#    if defined(MOUSE_ENABLE) || defined(EXTRAKEY_ENABLE)
-    /*
-     * Mouse/Extrakeys
-     */
-    .mouseExtraInterface = {
-        .header = {
-            .bLength         = sizeof(usbInterfaceDescriptor_t),
-            .bDescriptorType = USBDESCR_INTERFACE
-        },
-        .bInterfaceNumber    = MOUSE_EXTRA_INTERFACE,
-        .bAlternateSetting   = 0x00,
-        .bNumEndpoints       = 1,
-        .bInterfaceClass     = 0x03,
-        .bInterfaceSubClass  = 0x00,
-        .bInterfaceProtocol  = 0x00,
-        .iInterface          = 0x00
-    },
-    .mouseExtraHID = {
-        .header = {
-            .bLength         = sizeof(usbHIDDescriptor_t),
-            .bDescriptorType = USBDESCR_HID
-        },
-        .bcdHID              = 0x0101,
-        .bCountryCode        = 0x00,
-        .bNumDescriptors     = 1,
-        .bDescriptorType     = USBDESCR_HID_REPORT,
-        .wDescriptorLength   = sizeof(mouse_extra_hid_report)
-    },
-    .mouseExtraINEndpoint = {
-        .header = {
-            .bLength         = sizeof(usbEndpointDescriptor_t),
-            .bDescriptorType = USBDESCR_ENDPOINT
-        },
-        .bEndpointAddress    = (USBRQ_DIR_DEVICE_TO_HOST | USB_CFG_EP3_NUMBER),
-        .bmAttributes        = 0x03,
-        .wMaxPacketSize      = 8,
-        .bInterval           = USB_POLLING_INTERVAL_MS
-    },
-#    endif
 #    if defined(RAW_ENABLE)
+    /*
+     * RAW HID
+     */
     .rawInterface = {
         .header = {
             .bLength         = sizeof(usbInterfaceDescriptor_t),
@@ -742,6 +706,45 @@ const PROGMEM usbConfigurationDescriptor_t usbConfigurationDescriptor = {
         .bEndpointAddress    = (USBRQ_DIR_HOST_TO_DEVICE | USB_CFG_EP3_NUMBER),
         .bmAttributes        = 0x03,
         .wMaxPacketSize      = RAW_EPSIZE,
+        .bInterval           = USB_POLLING_INTERVAL_MS
+    },
+#    endif
+#    if defined(MOUSE_ENABLE) || defined(EXTRAKEY_ENABLE)
+    /*
+     * Mouse/Extrakeys
+     */
+    .mouseExtraInterface = {
+        .header = {
+            .bLength         = sizeof(usbInterfaceDescriptor_t),
+            .bDescriptorType = USBDESCR_INTERFACE
+        },
+        .bInterfaceNumber    = MOUSE_EXTRA_INTERFACE,
+        .bAlternateSetting   = 0x00,
+        .bNumEndpoints       = 1,
+        .bInterfaceClass     = 0x03,
+        .bInterfaceSubClass  = 0x00,
+        .bInterfaceProtocol  = 0x00,
+        .iInterface          = 0x00
+    },
+    .mouseExtraHID = {
+        .header = {
+            .bLength         = sizeof(usbHIDDescriptor_t),
+            .bDescriptorType = USBDESCR_HID
+        },
+        .bcdHID              = 0x0101,
+        .bCountryCode        = 0x00,
+        .bNumDescriptors     = 1,
+        .bDescriptorType     = USBDESCR_HID_REPORT,
+        .wDescriptorLength   = sizeof(mouse_extra_hid_report)
+    },
+    .mouseExtraINEndpoint = {
+        .header = {
+            .bLength         = sizeof(usbEndpointDescriptor_t),
+            .bDescriptorType = USBDESCR_ENDPOINT
+        },
+        .bEndpointAddress    = (USBRQ_DIR_DEVICE_TO_HOST | USB_CFG_EP3_NUMBER),
+        .bmAttributes        = 0x03,
+        .wMaxPacketSize      = 8,
         .bInterval           = USB_POLLING_INTERVAL_MS
     },
 #    endif
@@ -844,15 +847,15 @@ USB_PUBLIC usbMsgLen_t usbFunctionDescriptor(struct usbRequest *rq) {
                     usbMsgPtr = (unsigned char *)&usbConfigurationDescriptor.keyboardHID;
                     len       = sizeof(usbHIDDescriptor_t);
                     break;
-#if defined(MOUSE_ENABLE) || defined(EXTRAKEY_ENABLE)
-                case MOUSE_EXTRA_INTERFACE:
-                    usbMsgPtr = (unsigned char *)&usbConfigurationDescriptor.mouseExtraHID;
-                    len       = sizeof(usbHIDDescriptor_t);
-                    break;
-#endif
 #if defined(RAW_ENABLE)
                 case RAW_INTERFACE:
                     usbMsgPtr = (unsigned char *)&usbConfigurationDescriptor.rawHID;
+                    len       = sizeof(usbHIDDescriptor_t);
+                    break;
+#endif
+#if defined(MOUSE_ENABLE) || defined(EXTRAKEY_ENABLE)
+                case MOUSE_EXTRA_INTERFACE:
+                    usbMsgPtr = (unsigned char *)&usbConfigurationDescriptor.mouseExtraHID;
                     len       = sizeof(usbHIDDescriptor_t);
                     break;
 #endif
@@ -871,16 +874,16 @@ USB_PUBLIC usbMsgLen_t usbFunctionDescriptor(struct usbRequest *rq) {
                     usbMsgPtr = (unsigned char *)keyboard_hid_report;
                     len       = sizeof(keyboard_hid_report);
                     break;
-#if defined(MOUSE_ENABLE) || defined(EXTRAKEY_ENABLE)
-                case MOUSE_EXTRA_INTERFACE:
-                    usbMsgPtr = (unsigned char *)mouse_extra_hid_report;
-                    len       = sizeof(mouse_extra_hid_report);
-                    break;
-#endif
 #if defined(RAW_ENABLE)
                 case RAW_INTERFACE:
                     usbMsgPtr = (unsigned char *)raw_hid_report;
                     len       = sizeof(raw_hid_report);
+                    break;
+#endif
+#if defined(MOUSE_ENABLE) || defined(EXTRAKEY_ENABLE)
+                case MOUSE_EXTRA_INTERFACE:
+                    usbMsgPtr = (unsigned char *)mouse_extra_hid_report;
+                    len       = sizeof(mouse_extra_hid_report);
                     break;
 #endif
 #if defined(CONSOLE_ENABLE)

--- a/tmk_core/protocol/vusb/vusb.h
+++ b/tmk_core/protocol/vusb/vusb.h
@@ -89,17 +89,17 @@ typedef struct usbConfigurationDescriptor {
     usbHIDDescriptor_t                 keyboardHID;
     usbEndpointDescriptor_t            keyboardINEndpoint;
 
-#if defined(MOUSE_ENABLE) || defined(EXTRAKEY_ENABLE)
-    usbInterfaceDescriptor_t mouseExtraInterface;
-    usbHIDDescriptor_t       mouseExtraHID;
-    usbEndpointDescriptor_t  mouseExtraINEndpoint;
-#endif
-
 #if defined(RAW_ENABLE)
     usbInterfaceDescriptor_t rawInterface;
     usbHIDDescriptor_t       rawHID;
     usbEndpointDescriptor_t  rawINEndpoint;
     usbEndpointDescriptor_t  rawOUTEndpoint;
+#endif
+
+#if defined(MOUSE_ENABLE) || defined(EXTRAKEY_ENABLE)
+    usbInterfaceDescriptor_t mouseExtraInterface;
+    usbHIDDescriptor_t       mouseExtraHID;
+    usbEndpointDescriptor_t  mouseExtraINEndpoint;
 #endif
 
 #if defined(CONSOLE_ENABLE)


### PR DESCRIPTION
This might seem irrelevant now as we only got 2 endpoints, but with a 3rd endpoint (https://github.com/qmk/qmk_firmware/pull/9020) it is needed.

I have PRed in master as this is NOT breaking change.

## Description

- Reordered usb_interface enumeration.
- VIA expects RAW_HID endpoint to be at interface 1.
- This does not break anything with only 2 endpoints. Keyboard is always at interface 0 and the extra feature is at interface 1.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
