### PR TITLE
Fix sharing of mouse button state from mousekeys to ps2_mouse

### DIFF
--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -393,7 +393,9 @@ void process_action(keyrecord_t *record, action_t action) {
         /* Mouse key */
         case ACT_MOUSEKEY:
             if (event.pressed) {
+                mousekey_on(action.key.code);
                 switch (action.key.code) {
+#    ifdef PS2_MOUSE_ENABLE
                     case KC_MS_BTN1:
                         tp_buttons |= (1 << 0);
                         break;
@@ -403,13 +405,15 @@ void process_action(keyrecord_t *record, action_t action) {
                     case KC_MS_BTN3:
                         tp_buttons |= (1 << 2);
                         break;
+#    endif
                     default:
+                        mousekey_send();
                         break;
                 }
-                mousekey_on(action.key.code);
-                mousekey_send();
             } else {
+                mousekey_off(action.key.code);
                 switch (action.key.code) {
+#    ifdef PS2_MOUSE_ENABLE
                     case KC_MS_BTN1:
                         tp_buttons &= ~(1 << 0);
                         break;
@@ -419,11 +423,11 @@ void process_action(keyrecord_t *record, action_t action) {
                     case KC_MS_BTN3:
                         tp_buttons &= ~(1 << 2);
                         break;
+#    endif
                     default:
+                        mousekey_send();
                         break;
                 }
-                mousekey_off(action.key.code);
-                mousekey_send();
             }
             break;
 #endif


### PR DESCRIPTION
Fix sharing of mouse button state from mousekeys to ps2_mouse.

<!--- Provide a general summary of your changes in the title above. -->


<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

#1327 shares mousekeys button state with ps2_mouse but prevents clicks when using only mousekeys.

#1344 fixes this but produces clicks from both mousekeys and ps2_mouse.

https://github.com/qmk/qmk_firmware/issues/1339#issuecomment-304580379 would fix the missing and duplicate cilcks but break mousekeys dragging.

With this change, when ps2_mouse is disabled, mousekeys works as usual.  With ps2_mouse enabled, mousekeys button state is shared with ps2_mouse for clicking, dragging, and scrolling, mousekeys clicks are produced by ps2_mouse only, and mousekeys button state is transferred to mousekeys without generating clicks to enable mousekeys dragging. 


<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR
Resolves #1339.
* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
