### PR TITLE
Add magic capable (un)register functions

### DIFF
--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -108,6 +108,34 @@ void tap_code16(uint16_t code) {
     unregister_code16(code);
 }
 
+void register_magic_code(uint8_t code) { register_code(keycode_config(code)); }
+
+void register_magic_code16(uint16_t keycode) {
+    if (keycode >= QK_MODS && keycode <= QK_MODS_MAX) {
+        keycode = (mod_config((keycode >> 8) & 0x1F) << 8 | keycode_config(keycode & 0xFF));
+    }
+    register_code16(keycode_config(keycode));
+}
+
+void unregister_magic_code(uint8_t code) { unregister_code(keycode_config(code)); }
+
+void unregister_magic_code16(uint16_t keycode) {
+    if (keycode >= QK_MODS && keycode <= QK_MODS_MAX) {
+        keycode = (mod_config((keycode >> 8) & 0x1F) << 8 | keycode_config(keycode & 0xFF));
+    }
+    unregister_code16(keycode_config(keycode));
+}
+
+void tap_magic_code(uint8_t keycode) { tap_code(keycode_config(keycode)); }
+void tap_magic_code_delay(uint8_t keycode, uint16_t delay) { tap_code_delay(keycode_config(keycode), delay); }
+
+void tap_magic_code16(uint16_t keycode) {
+    if (keycode >= QK_MODS && keycode <= QK_MODS_MAX) {
+        keycode = (mod_config((keycode >> 8) & 0x1F) << 8 | keycode_config(keycode & 0xFF));
+    }
+    tap_code16(keycode_config(keycode));
+}
+
 __attribute__((weak)) bool process_action_kb(keyrecord_t *record) { return true; }
 
 __attribute__((weak)) bool process_record_kb(uint16_t keycode, keyrecord_t *record) { return process_record_user(keycode, record); }

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -232,6 +232,13 @@ void shutdown_user(void);
 void register_code16(uint16_t code);
 void unregister_code16(uint16_t code);
 void tap_code16(uint16_t code);
+void register_magic_code(uint8_t code);
+void register_magic_code16(uint16_t keycode);
+void unregister_magic_code(uint8_t code);
+void unregister_magic_code16(uint16_t keycode);
+void tap_magic_code(uint8_t keycode);
+void tap_magic_code_delay(uint8_t keycode, uint16_t delay);
+void tap_magic_code16(uint16_t keycode);
 
 void led_set_user(uint8_t usb_led);
 void led_set_kb(uint8_t usb_led);


### PR DESCRIPTION
## Description

Adds support for "magic" processing of the (un)register_code(16) functions. 

This is useful if you want to have the automagic handling of the keycodes, so that it swaps out modifiers or the like. 

These functions will operate like a normal key, so it's possible to disable GUI keys, for instance. 


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] New feature
- [x] Enhancement/optimization
- [x] Documentation


## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
