### PR TITLE
Make Magic handling more consistent in Action Keycode handling

### DIFF
--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -186,8 +186,6 @@ If you define these options you will enable the associated feature, which may in
   * Disables keycode filtering for Mod-Tap and Layer-Tap keycodes. Eg, if you enable this, you would need to specify `MT(MOD_CTL, KC_A)` if you want to use `KC_A`.
 * `#define MOUSE_EXTENDED_REPORT`
   * Enables support for extended reports (-32767 to 32767, instead of -127 to 127), which may allow for smoother reporting, and prevent maxing out of the reports. Applies to both Pointing Device and Mousekeys.
-* `#define MAGIC_ENFORCE_HANDLING`
-  * Enables magic configuration handling for advanced keycodes (such as Mod Tap and Layer Tap)
 * `#define ONESHOT_TIMEOUT 300`
   * how long before oneshot times out
 * `#define ONESHOT_TAP_TOGGLE 2`
@@ -214,6 +212,9 @@ If you define these options you will enable the associated feature, which may in
   * Sets the delay for Tap Hold keys (`LT`, `MT`) when using `KC_CAPS_LOCK` keycode, as this has some special handling on MacOS.  The value is in milliseconds, and defaults to 80 ms if not defined. For macOS, you may want to set this to 200 or higher.
 * `#define KEY_OVERRIDE_REPEAT_DELAY 500`
   * Sets the key repeat interval for [key overrides](feature_key_overrides.md).
+* `#define LEGACY_MAGIC_HANDLING`
+  * Enables magic configuration handling for advanced keycodes (such as Mod Tap and Layer Tap)
+
 
 ## RGB Light Configuration
 

--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -186,6 +186,8 @@ If you define these options you will enable the associated feature, which may in
   * Disables keycode filtering for Mod-Tap and Layer-Tap keycodes. Eg, if you enable this, you would need to specify `MT(MOD_CTL, KC_A)` if you want to use `KC_A`.
 * `#define MOUSE_EXTENDED_REPORT`
   * Enables support for extended reports (-32767 to 32767, instead of -127 to 127), which may allow for smoother reporting, and prevent maxing out of the reports. Applies to both Pointing Device and Mousekeys.
+* `#define MAGIC_ENFORCE_HANDING`
+  * Enables magic configuration handling for advanced keycodes (such as Mod Tap and Layer Tap)
 * `#define ONESHOT_TIMEOUT 300`
   * how long before oneshot times out
 * `#define ONESHOT_TAP_TOGGLE 2`

--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -186,7 +186,7 @@ If you define these options you will enable the associated feature, which may in
   * Disables keycode filtering for Mod-Tap and Layer-Tap keycodes. Eg, if you enable this, you would need to specify `MT(MOD_CTL, KC_A)` if you want to use `KC_A`.
 * `#define MOUSE_EXTENDED_REPORT`
   * Enables support for extended reports (-32767 to 32767, instead of -127 to 127), which may allow for smoother reporting, and prevent maxing out of the reports. Applies to both Pointing Device and Mousekeys.
-* `#define MAGIC_ENFORCE_HANDING`
+* `#define MAGIC_ENFORCE_HANDLING`
   * Enables magic configuration handling for advanced keycodes (such as Mod Tap and Layer Tap)
 * `#define ONESHOT_TIMEOUT 300`
   * how long before oneshot times out

--- a/quantum/keycode_config.c
+++ b/quantum/keycode_config.c
@@ -16,14 +16,12 @@
 
 #include "keycode_config.h"
 
-extern keymap_config_t keymap_config;
-
 /** \brief keycode_config
  *
  * This function is used to check a specific keycode against the bootmagic config,
  * and will return the corrected keycode, when appropriate.
  */
-uint16_t keycode_config(uint16_t keycode) {
+__attribute__((weak)) uint16_t keycode_config(uint16_t keycode) {
     switch (keycode) {
         case KC_CAPS_LOCK:
         case KC_LOCKING_CAPS_LOCK:
@@ -123,7 +121,7 @@ uint16_t keycode_config(uint16_t keycode) {
  *  and will remove or replace mods, based on that.
  */
 
-uint8_t mod_config(uint8_t mod) {
+__attribute__((weak)) uint8_t mod_config(uint8_t mod) {
     if (keymap_config.swap_lalt_lgui) {
         if ((mod & MOD_RGUI) == MOD_LGUI) {
             mod &= ~MOD_LGUI;

--- a/quantum/keymap_common.c
+++ b/quantum/keymap_common.c
@@ -74,19 +74,19 @@ action_t action_for_keycode(uint16_t keycode) {
         case QK_MODS ... QK_MODS_MAX:;
         // Has a modifier
         // Split it up
-#ifdef MAGIC_ENFORCE_HANDLING
-            action.code = ACTION_MODS_KEY(mod_config(QK_MODS_GET_MODS(keycode)), keycode_config(QK_MODS_GET_BASIC_KEYCODE(keycode))); // adds modifier to key
-#else                                                                                                                                 // MAGIC_ENFORCE_HANDLING
+#ifdef LEGACY_MAGIC_HANDLING
             action.code = ACTION_MODS_KEY(QK_MODS_GET_MODS(keycode), QK_MODS_GET_BASIC_KEYCODE(keycode)); // adds modifier to key
-#endif                                                                                                                                // MAGIC_ENFORCE_HANDLING
+#else                                                                                                                                 // LEGACY_MAGIC_HANDLING
+            action.code = ACTION_MODS_KEY(mod_config(QK_MODS_GET_MODS(keycode)), keycode_config(QK_MODS_GET_BASIC_KEYCODE(keycode))); // adds modifier to key
+#endif                                                                                                                                // LEGACY_MAGIC_HANDLING
             break;
 #ifndef NO_ACTION_LAYER
         case QK_LAYER_TAP ... QK_LAYER_TAP_MAX:
-#    ifdef MAGIC_ENFORCE_HANDLING
-            action.code = ACTION_LAYER_TAP_KEY(QK_LAYER_TAP_GET_LAYER(keycode), keycode_config(QK_LAYER_TAP_GET_TAP_KEYCODE(keycode)));
-#    else  // MAGIC_ENFORCE_HANDLING
+#    ifdef LEGACY_MAGIC_HANDLING
             action.code = ACTION_LAYER_TAP_KEY(QK_LAYER_TAP_GET_LAYER(keycode), QK_LAYER_TAP_GET_TAP_KEYCODE(keycode));
-#    endif // MAGIC_ENFORCE_HANDLING
+#    else  // LEGACY_MAGIC_HANDLING
+            action.code = ACTION_LAYER_TAP_KEY(QK_LAYER_TAP_GET_LAYER(keycode), keycode_config(QK_LAYER_TAP_GET_TAP_KEYCODE(keycode)));
+#    endif // LEGACY_MAGIC_HANDLING
             break;
         case QK_TO ... QK_TO_MAX:;
             // Layer set "GOTO"
@@ -134,20 +134,20 @@ action_t action_for_keycode(uint16_t keycode) {
 #ifndef NO_ACTION_TAPPING
         case QK_MOD_TAP ... QK_MOD_TAP_MAX:
             mod = mod_config(QK_MOD_TAP_GET_MODS(keycode));
-#    ifdef MAGIC_ENFORCE_HANDLING
-            action.code = ACTION_MODS_TAP_KEY(mod, keycode_config(QK_MOD_TAP_GET_TAP_KEYCODE(keycode)));
-#    else  // MAGIC_ENFORCE_HANDLING
+#    ifdef LEGACY_MAGIC_HANDLING
             action.code = ACTION_MODS_TAP_KEY(mod, QK_MOD_TAP_GET_TAP_KEYCODE(keycode));
-#    endif // MAGIC_ENFORCE_HANDLING
+#    else  // LEGACY_MAGIC_HANDLING
+            action.code = ACTION_MODS_TAP_KEY(mod, keycode_config(QK_MOD_TAP_GET_TAP_KEYCODE(keycode)));
+#    endif // LEGACY_MAGIC_HANDLING
             break;
 #endif
 #ifdef SWAP_HANDS_ENABLE
         case QK_SWAP_HANDS ... QK_SWAP_HANDS_MAX:
-#    ifdef MAGIC_ENFORCE_HANDLING
-            action.code = ACTION(ACT_SWAP_HANDS, keycode_config(QK_SWAP_HANDS_GET_TAP_KEYCODE(keycode)));
-#    else  // MAGIC_ENFORCE_HANDLING
+#    ifdef LEGACY_MAGIC_HANDLING
             action.code = ACTION(ACT_SWAP_HANDS, QK_SWAP_HANDS_GET_TAP_KEYCODE(keycode));
-#    endif // MAGIC_ENFORCE_HANDLING
+#    else  // LEGACY_MAGIC_HANDLING
+            action.code = ACTION(ACT_SWAP_HANDS, keycode_config(QK_SWAP_HANDS_GET_TAP_KEYCODE(keycode)));
+#    endif // LEGACY_MAGIC_HANDLING
             break;
 #endif
 

--- a/quantum/keymap_common.c
+++ b/quantum/keymap_common.c
@@ -77,7 +77,7 @@ action_t action_for_keycode(uint16_t keycode) {
 #ifdef MAGIC_ENFORCE_HANDLING
             action.code = ACTION_MODS_KEY(mod_config(QK_MODS_GET_MODS(keycode)), keycode_config(QK_MODS_GET_BASIC_KEYCODE(keycode))); // adds modifier to key
 #else                                                                                                                                 // MAGIC_ENFORCE_HANDLING
-            action.code = ACTION_MODS_KEY(QK_MODS_GET_MODS(keycode), QK_MODS_GET_BASIC_KEYCODE(keycode))); // adds modifier to key
+            action.code = ACTION_MODS_KEY(QK_MODS_GET_MODS(keycode), QK_MODS_GET_BASIC_KEYCODE(keycode)); // adds modifier to key
 #endif                                                                                                                                // MAGIC_ENFORCE_HANDLING
             break;
 #ifndef NO_ACTION_LAYER

--- a/quantum/keymap_common.c
+++ b/quantum/keymap_common.c
@@ -133,21 +133,21 @@ action_t action_for_keycode(uint16_t keycode) {
 #endif
 #ifndef NO_ACTION_TAPPING
         case QK_MOD_TAP ... QK_MOD_TAP_MAX:
-            mod         = mod_config(QK_MOD_TAP_GET_MODS(keycode));
-#ifdef MAGIC_ENFORCE_HANDLING
+            mod = mod_config(QK_MOD_TAP_GET_MODS(keycode));
+#    ifdef MAGIC_ENFORCE_HANDLING
             action.code = ACTION_MODS_TAP_KEY(mod, keycode_config(QK_MOD_TAP_GET_TAP_KEYCODE(keycode)));
-#else // MAGIC_ENFORCE_HANDLING
+#    else  // MAGIC_ENFORCE_HANDLING
             action.code = ACTION_MODS_TAP_KEY(mod, QK_MOD_TAP_GET_TAP_KEYCODE(keycode));
-#endif // MAGIC_ENFORCE_HANDLING
+#    endif // MAGIC_ENFORCE_HANDLING
             break;
 #endif
 #ifdef SWAP_HANDS_ENABLE
         case QK_SWAP_HANDS ... QK_SWAP_HANDS_MAX:
-#ifdef MAGIC_ENFORCE_HANDLING
+#    ifdef MAGIC_ENFORCE_HANDLING
             action.code = ACTION(ACT_SWAP_HANDS, keycode_config(QK_SWAP_HANDS_GET_TAP_KEYCODE(keycode)));
-#else // MAGIC_ENFORCE_HANDLING
+#    else  // MAGIC_ENFORCE_HANDLING
             action.code = ACTION(ACT_SWAP_HANDS, QK_SWAP_HANDS_GET_TAP_KEYCODE(keycode));
-#endif //MAGIC_ENFORCE_HANDLING
+#    endif // MAGIC_ENFORCE_HANDLING
             break;
 #endif
 

--- a/quantum/keymap_common.c
+++ b/quantum/keymap_common.c
@@ -76,9 +76,9 @@ action_t action_for_keycode(uint16_t keycode) {
         // Split it up
 #ifdef LEGACY_MAGIC_HANDLING
             action.code = ACTION_MODS_KEY(QK_MODS_GET_MODS(keycode), QK_MODS_GET_BASIC_KEYCODE(keycode)); // adds modifier to key
-#else                                                                                                                                 // LEGACY_MAGIC_HANDLING
+#else                                                                                                     // LEGACY_MAGIC_HANDLING
             action.code = ACTION_MODS_KEY(mod_config(QK_MODS_GET_MODS(keycode)), keycode_config(QK_MODS_GET_BASIC_KEYCODE(keycode))); // adds modifier to key
-#endif                                                                                                                                // LEGACY_MAGIC_HANDLING
+#endif                                                                                                    // LEGACY_MAGIC_HANDLING
             break;
 #ifndef NO_ACTION_LAYER
         case QK_LAYER_TAP ... QK_LAYER_TAP_MAX:

--- a/quantum/keymap_common.c
+++ b/quantum/keymap_common.c
@@ -72,13 +72,21 @@ action_t action_for_keycode(uint16_t keycode) {
             action.code = ACTION_TRANSPARENT;
             break;
         case QK_MODS ... QK_MODS_MAX:;
-            // Has a modifier
-            // Split it up
-            action.code = ACTION_MODS_KEY(mod_config(QK_MODS_GET_MODS(keycode)), keycode_configQK_MODS_GET_BASIC_KEYCODE(keycode))); // adds modifier to key
+        // Has a modifier
+        // Split it up
+#ifdef MAGIC_ENFORCE_HANDLING
+            action.code = ACTION_MODS_KEY(mod_config(QK_MODS_GET_MODS(keycode)), keycode_config(QK_MODS_GET_BASIC_KEYCODE(keycode))); // adds modifier to key
+#else                                                                                                                                 // MAGIC_ENFORCE_HANDLING
+            action.code = ACTION_MODS_KEY(QK_MODS_GET_MODS(keycode), QK_MODS_GET_BASIC_KEYCODE(keycode))); // adds modifier to key
+#endif                                                                                                                                // MAGIC_ENFORCE_HANDLING
             break;
 #ifndef NO_ACTION_LAYER
         case QK_LAYER_TAP ... QK_LAYER_TAP_MAX:
+#    ifdef MAGIC_ENFORCE_HANDLING
             action.code = ACTION_LAYER_TAP_KEY(QK_LAYER_TAP_GET_LAYER(keycode), keycode_config(QK_LAYER_TAP_GET_TAP_KEYCODE(keycode)));
+#    else  // MAGIC_ENFORCE_HANDLING
+            action.code = ACTION_LAYER_TAP_KEY(QK_LAYER_TAP_GET_LAYER(keycode), QK_LAYER_TAP_GET_TAP_KEYCODE(keycode));
+#    endif // MAGIC_ENFORCE_HANDLING
             break;
         case QK_TO ... QK_TO_MAX:;
             // Layer set "GOTO"
@@ -126,12 +134,20 @@ action_t action_for_keycode(uint16_t keycode) {
 #ifndef NO_ACTION_TAPPING
         case QK_MOD_TAP ... QK_MOD_TAP_MAX:
             mod         = mod_config(QK_MOD_TAP_GET_MODS(keycode));
+#ifdef MAGIC_ENFORCE_HANDLING
             action.code = ACTION_MODS_TAP_KEY(mod, keycode_config(QK_MOD_TAP_GET_TAP_KEYCODE(keycode)));
+#else // MAGIC_ENFORCE_HANDLING
+            action.code = ACTION_MODS_TAP_KEY(mod, QK_MOD_TAP_GET_TAP_KEYCODE(keycode));
+#endif // MAGIC_ENFORCE_HANDLING
             break;
 #endif
 #ifdef SWAP_HANDS_ENABLE
         case QK_SWAP_HANDS ... QK_SWAP_HANDS_MAX:
+#ifdef MAGIC_ENFORCE_HANDLING
             action.code = ACTION(ACT_SWAP_HANDS, keycode_config(QK_SWAP_HANDS_GET_TAP_KEYCODE(keycode)));
+#else // MAGIC_ENFORCE_HANDLING
+            action.code = ACTION(ACT_SWAP_HANDS, QK_SWAP_HANDS_GET_TAP_KEYCODE(keycode));
+#endif //MAGIC_ENFORCE_HANDLING
             break;
 #endif
 

--- a/quantum/keymap_common.c
+++ b/quantum/keymap_common.c
@@ -74,11 +74,11 @@ action_t action_for_keycode(uint16_t keycode) {
         case QK_MODS ... QK_MODS_MAX:;
             // Has a modifier
             // Split it up
-            action.code = ACTION_MODS_KEY(QK_MODS_GET_MODS(keycode), QK_MODS_GET_BASIC_KEYCODE(keycode)); // adds modifier to key
+            action.code = ACTION_MODS_KEY(mod_config(QK_MODS_GET_MODS(keycode)), keycode_configQK_MODS_GET_BASIC_KEYCODE(keycode))); // adds modifier to key
             break;
 #ifndef NO_ACTION_LAYER
         case QK_LAYER_TAP ... QK_LAYER_TAP_MAX:
-            action.code = ACTION_LAYER_TAP_KEY(QK_LAYER_TAP_GET_LAYER(keycode), QK_LAYER_TAP_GET_TAP_KEYCODE(keycode));
+            action.code = ACTION_LAYER_TAP_KEY(QK_LAYER_TAP_GET_LAYER(keycode), keycode_config(QK_LAYER_TAP_GET_TAP_KEYCODE(keycode)));
             break;
         case QK_TO ... QK_TO_MAX:;
             // Layer set "GOTO"
@@ -126,12 +126,12 @@ action_t action_for_keycode(uint16_t keycode) {
 #ifndef NO_ACTION_TAPPING
         case QK_MOD_TAP ... QK_MOD_TAP_MAX:
             mod         = mod_config(QK_MOD_TAP_GET_MODS(keycode));
-            action.code = ACTION_MODS_TAP_KEY(mod, QK_MOD_TAP_GET_TAP_KEYCODE(keycode));
+            action.code = ACTION_MODS_TAP_KEY(mod, keycode_config(QK_MOD_TAP_GET_TAP_KEYCODE(keycode)));
             break;
 #endif
 #ifdef SWAP_HANDS_ENABLE
         case QK_SWAP_HANDS ... QK_SWAP_HANDS_MAX:
-            action.code = ACTION(ACT_SWAP_HANDS, QK_SWAP_HANDS_GET_TAP_KEYCODE(keycode));
+            action.code = ACTION(ACT_SWAP_HANDS, keycode_config(QK_SWAP_HANDS_GET_TAP_KEYCODE(keycode)));
             break;
 #endif
 


### PR DESCRIPTION
## Description

Fixes up some of the quantum handlers to properly respect magic status.  

Specifically, there are a number of non-basic keycodes that don't respect the magic status currently, and this change aims to bring most of these keycodes in line, to respect the magic status.

For instance, LT doesn't respect the changes currently. So if you have Caps Lock for the keycode (eg `LT(2, KC_CAPS)`), and caps<->Escape enabled for magic, previously, it would still be caps lock.  

## Types of Changes

- [x] Core
- [x] Bugfix
- [x] Enhancement/optimization

## Issues Fixed or Closed by This PR

* [Chat on discord](https://discordapp.com/channels/440868230475677696/440868230475677698/711917597066526740)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
