### PR TITLE
Moved ergodone LED boot animation to user level. Default layer tidy up

### DIFF
--- a/keyboards/ergodone/ergodone.c
+++ b/keyboards/ergodone/ergodone.c
@@ -14,17 +14,8 @@ extern inline void ergodox_right_led_off(uint8_t led);
 
 extern inline void ergodox_led_all_off(void);
 
-void ergodox_led_init(void);
-void ergodox_blink_all_leds(void);
-
-void matrix_init_kb(void) {
-  ergodox_led_init();
-  ergodox_blink_all_leds();
-  matrix_init_user();
-}
-
 void ergodox_led_init(void)
- {
+{
      DDRB  |=  (1<<PB5 | 1<<PB6 | 1<<PB3);
      PORTB &= ~(1<<PB5 | 1<<PB6 | 1<<PB3);
      DDRB  |=  (1<<PB0);
@@ -33,22 +24,7 @@ void ergodox_led_init(void)
      PORTD |=  (1<<PB5);
 }
 
-void ergodox_blink_all_leds(void)
-{
-    ergodox_led_all_off();
-    ergodox_led_all_set(LED_BRIGHTNESS_HI);
-    ergodox_right_led_1_on();
-    _delay_ms(50);
-    ergodox_right_led_2_on();
-    _delay_ms(50);
-    ergodox_right_led_3_on();
-    _delay_ms(50);
-    ergodox_right_led_1_off();
-    _delay_ms(50);
-    ergodox_right_led_2_off();
-    _delay_ms(50);
-    ergodox_right_led_3_off();
-    //ergodox_led_all_on();
-    //_delay_ms(333);
-    ergodox_led_all_off();
+void matrix_init_kb(void) {
+  ergodox_led_init();
+  matrix_init_user();
 }

--- a/keyboards/ergodone/ergodone.h
+++ b/keyboards/ergodone/ergodone.h
@@ -61,11 +61,28 @@ inline void ergodox_led_all_off(void) {
     ergodox_right_led_3_off();
     ergodox_board_led_off();
 }
+
 inline void ergodox_right_led_1_set(uint8_t n)          {}
 inline void ergodox_right_led_2_set(uint8_t n)          {}
 inline void ergodox_right_led_3_set(uint8_t n)          {}
 inline void ergodox_right_led_set(uint8_t l, uint8_t n) {}
 inline void ergodox_led_all_set(uint8_t n)              {}
+
+inline static void ergodox_blink_all_leds(void) {
+    ergodox_led_all_off();
+    ergodox_led_all_set(LED_BRIGHTNESS_HI);
+    ergodox_right_led_1_on();
+    _delay_ms(50);
+    ergodox_right_led_2_on();
+    _delay_ms(50);
+    ergodox_right_led_3_on();
+    _delay_ms(50);
+    ergodox_right_led_1_off();
+    _delay_ms(50);
+    ergodox_right_led_2_off();
+    _delay_ms(50);
+    ergodox_led_all_off();
+}
 
 /*
  *   LEFT HAND: LINES 76-83

--- a/keyboards/ergodone/keymaps/default/keymap.c
+++ b/keyboards/ergodone/keymaps/default/keymap.c
@@ -1,9 +1,11 @@
 #include QMK_KEYBOARD_H
 #include "version.h"
 
-#define BASE 0 // default layer
-#define SYMB 1 // symbols
-#define MDIA 2 // media keys
+enum layer_names {
+  BASE, // default layer
+  SYMBOLS,
+  MEDIA
+};
 
 enum custom_keycodes {
   PLACEHOLDER = SAFE_RANGE, // can always be here
@@ -39,19 +41,19 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 [BASE] = LAYOUT_ergodox(  // layer 0 : default
         // left hand
         KC_EQL,         KC_1,         KC_2,   KC_3,   KC_4,   KC_5,   KC_LEFT,
-        KC_DEL,         KC_Q,         KC_W,   KC_E,   KC_R,   KC_T,   TG(SYMB),
+        KC_DEL,         KC_Q,         KC_W,   KC_E,   KC_R,   KC_T,   TG(SYMBOLS),
         KC_BSPC,        KC_A,         KC_S,   KC_D,   KC_F,   KC_G,
         KC_LSFT,        CTL_T(KC_Z),  KC_X,   KC_C,   KC_V,   KC_B,   ALL_T(KC_NO),
-        LT(SYMB,KC_GRV),KC_QUOT,      LALT(KC_LSFT),  KC_LEFT,KC_RGHT,
+        LT(SYMBOLS,KC_GRV),KC_QUOT,      LALT(KC_LSFT),  KC_LEFT,KC_RGHT,
                                               ALT_T(KC_APP),  KC_LGUI,
                                                               KC_HOME,
                                                KC_SPC,KC_BSPC,KC_END,
         // right hand
              KC_RGHT,     KC_6,   KC_7,  KC_8,   KC_9,   KC_0,             KC_MINS,
-             TG(SYMB),    KC_Y,   KC_U,  KC_I,   KC_O,   KC_P,             KC_BSLS,
-                          KC_H,   KC_J,  KC_K,   KC_L,   LT(MDIA, KC_SCLN),GUI_T(KC_QUOT),
+             TG(SYMBOLS),    KC_Y,   KC_U,  KC_I,   KC_O,   KC_P,             KC_BSLS,
+                          KC_H,   KC_J,  KC_K,   KC_L,   LT(MEDIA, KC_SCLN),GUI_T(KC_QUOT),
              MEH_T(KC_NO),KC_N,   KC_M,  KC_COMM,KC_DOT, CTL_T(KC_SLSH),   KC_RSFT,
-                                  KC_UP, KC_DOWN,KC_LBRC,KC_RBRC,          TT(SYMB),
+                                  KC_UP, KC_DOWN,KC_LBRC,KC_RBRC,          TT(SYMBOLS),
              KC_LALT,        CTL_T(KC_ESC),
              KC_PGUP,
              KC_PGDN,KC_TAB, KC_ENT
@@ -77,8 +79,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  *                                 |      |      |      |       |      |      |      |
  *                                 `--------------------'       `--------------------'
  */
-// SYMBOLS
-[SYMB] = LAYOUT_ergodox(
+[SYMBOLS] = LAYOUT_ergodox(
        // left hand
        VRSN,   KC_F1,  KC_F2,  KC_F3,  KC_F4,  KC_F5,  KC_TRNS,
        KC_TRNS,KC_EXLM,KC_AT,  KC_LCBR,KC_RCBR,KC_PIPE,KC_TRNS,
@@ -120,7 +121,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  *                                 `--------------------'       `--------------------'
  */
 // MEDIA AND MOUSE
-[MDIA] = LAYOUT_ergodox(
+[MEDIA] = LAYOUT_ergodox(
        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
        KC_TRNS, KC_TRNS, KC_TRNS, KC_MS_U, KC_TRNS, KC_TRNS, KC_TRNS,
        KC_TRNS, KC_TRNS, KC_MS_L, KC_MS_D, KC_MS_R, KC_TRNS,
@@ -170,7 +171,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 
 // Runs just one time when the keyboard initializes.
 void matrix_init_user(void) {
-
+    ergodox_blink_all_leds();
 };
 
 

--- a/keyboards/ergodone/keymaps/eozaki/keymap.c
+++ b/keyboards/ergodone/keymaps/eozaki/keymap.c
@@ -190,7 +190,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 
 // Runs just one time when the keyboard initializes.
 void matrix_init_user(void) {
-
+    ergodox_blink_all_leds();
 };
 
 

--- a/keyboards/ergodone/keymaps/erovia/keymap.c
+++ b/keyboards/ergodone/keymaps/erovia/keymap.c
@@ -199,6 +199,7 @@ void default_layer_led_set(void) {
 
 // Runs just one time when the keyboard initializes.
 void matrix_init_user(void) {
+    ergodox_blink_all_leds();
     default_layer_led_set();
 };
 

--- a/keyboards/ergodone/keymaps/kloki/keymap.c
+++ b/keyboards/ergodone/keymaps/kloki/keymap.c
@@ -209,7 +209,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 
 // Runs just one time when the keyboard initializes.
 void matrix_init_user(void) {
-
+  ergodox_blink_all_leds();
 };
 
 

--- a/keyboards/ergodone/keymaps/vega/keymap.c
+++ b/keyboards/ergodone/keymaps/vega/keymap.c
@@ -529,7 +529,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 // Runs just one time when the keyboard initializes.
 void matrix_init_user(void) {
-
+	ergodox_blink_all_leds();
 };
 
 // Runs constantly in the background, in a loop.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Ergodone: moved `ergodox_blink_all_leds()` from keyboard level to user level for default and all userspaces (so all functionality is the same)

Small tidy up for default layer
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
