### PR TITLE
Fix ChibiOS FPU build logic

### DIFF
--- a/tmk_core/chibios.mk
+++ b/tmk_core/chibios.mk
@@ -220,6 +220,18 @@ COMPILEFLAGS += -fno-common
 COMPILEFLAGS += -fshort-wchar
 COMPILEFLAGS += $(THUMBFLAGS)
 
+# FPU options default (Cortex-M4 and Cortex-M7 single precision).
+USE_FPU_OPT ?= -mfloat-abi=hard -mfpu=fpv4-sp-d16 -fsingle-precision-constant
+
+# FPU-related options
+USE_FPU ?= no
+ifneq ($(USE_FPU),no)
+  COMPILEFLAGS += $(USE_FPU_OPT)
+  OPT_DEFS += -DCORTEX_USE_FPU=TRUE
+else
+  OPT_DEFS += -DCORTEX_USE_FPU=FALSE
+endif
+
 CFLAGS += $(COMPILEFLAGS)
 
 ASFLAGS += $(THUMBFLAGS)
@@ -240,22 +252,6 @@ OPT_DEFS += -DPROTOCOL_CHIBIOS
 OPT_DEFS += -DPORT_IGNORE_GCC_VERSION_CHECK=1
 
 MCUFLAGS = -mcpu=$(MCU)
-
-# FPU options default (Cortex-M4 and Cortex-M7 single precision).
-ifeq ($(USE_FPU_OPT),)
-  USE_FPU_OPT = -mfloat-abi=$(USE_FPU) -mfpu=fpv4-sp-d16 -fsingle-precision-constant
-endif
-
-# FPU-related options
-ifeq ($(USE_FPU),)
-  USE_FPU = no
-endif
-ifneq ($(USE_FPU),no)
-  OPT    += $(USE_FPU_OPT)
-  OPT_DEFS  += -DCORTEX_USE_FPU=TRUE
-else
-  OPT_DEFS  += -DCORTEX_USE_FPU=FALSE
-endif
 
 DEBUG = gdb
 

--- a/tmk_core/rules.mk
+++ b/tmk_core/rules.mk
@@ -46,7 +46,7 @@ FORMAT = ihex
 # Optimization level, can be [0, 1, 2, 3, s].
 #     0 = turn off optimization. s = optimize for size.
 #     (Note: 3 is not always the best optimization level. See avr-libc FAQ.)
-OPT = s
+OPT ?= s
 
 # Compiler flag to set the C Standard level.
 #     c89   = "ANSI" C


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Currently the fpu logic sets float-abi to yes/no, from <https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html>,
> -mfloat-abi=name
> Specifies which floating-point ABI to use. Permissible values are: ‘soft’, ‘softfp’ and ‘hard’.

Change the OPT logic to CFLAGS and it starts spitting out errors,
```console
note: valid arguments to '-mfloat-abi=' are: hard soft softfp
```

Now the OPT variable is not reused, I have also made it overridable so we can test scenarios like `make <kb>:<km> OPT=2`.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
