### PR TITLE
Gherkin 26, 27, 28, 30 keys compatibility

### DIFF
--- a/keyboards/40percentclub/gherkin/keymaps/stevexyz/keymap.c
+++ b/keyboards/40percentclub/gherkin/keymaps/stevexyz/keymap.c
@@ -16,7 +16,8 @@
 
 
 /*
- * see jj40/stevexyz for more information
+ * The 25% SuperMicro keyboard: a pure - full features - "Alpha 26" keymap on Gherkin, compatible also with 28 and 30 keys layouts
+ * See https://github.com/stevexyz/qmk_firmware/blob/master/keyboards/40percentclub/gherkin/keymaps/stevexyz/readme.md for more information
  */
 
 
@@ -56,7 +57,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * ,---------------------------------------------------------------------.
  * |      |      |      |      |      |      |      |      |      |      |
  * |   Q  |   W  |   E  |   R  |   T  |   Y  |   U  |   I  |   O  |   P  |
- * | ____ | ____ | ____ | ____ | ____ | ____ | ____ | ____ | ____ | ____ |
+ * | ____ | ____ | ____ | ____ | ____ | FnNav|NumSym|  Alt | Ctrl | Shift|
  * |------+------+------+------+-------------+------+------+------+------|
  * |      |      |      |      |      |      |      |      |      |      |
  * |   A  |   S  |   D  |   F  |   G  |   H  |   J  |   K  |   L  | Enter|
@@ -68,83 +69,73 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  *        '-------------------------------------------------------'       
  */
   [LAYER_HOME] = LAYOUT_ortho_3x10(
-         LT(LAYER_ARROWPAD, KC_Q), LT(LAYER_NUMPAD, KC_W), LT(LAYER_MEDIAPAD, KC_E), KC_R, KC_T, KC_Y, KC_U, KC_I, KC_O, KC_P,
-         MT(MOD_LSFT, KC_A), LT(LAYER_FUNC, KC_S), LT(LAYER_NUMSYM, KC_D), MT(MOD_RALT, KC_F), MT(MOD_LGUI, KC_G), MT(MOD_RGUI, KC_H), MT(MOD_RALT, KC_J), LT(LAYER_FUNC, KC_K), LT(LAYER_NUMSYM, KC_L), MT(MOD_RSFT, KC_ENT),
-         XXXXXXX, MT(MOD_LCTL, KC_Z), MT(MOD_LALT, KC_X), LT(LAYER_FUNC, KC_C), LT(LAYER_NUMSYM, KC_V), MT(MOD_LSFT, KC_B), MT(MOD_LALT, KC_N), MT(MOD_RCTL, KC_M), MT(MOD_RSFT, KC_SPC), XXXXXXX ),
+    LT(LAYER_ARROWPAD, KC_Q), LT(LAYER_NUMPAD, KC_W), LT(LAYER_MEDIAPAD, KC_E), KC_R, KC_T, LT(LAYER_FUNC, KC_Y), LT(LAYER_NUMSYM, KC_U), MT(MOD_LALT, KC_I), MT(MOD_RCTL, KC_O), MT(MOD_RSFT, KC_P),
+    MT(MOD_LSFT, KC_A), LT(LAYER_FUNC, KC_S), LT(LAYER_NUMSYM, KC_D), MT(MOD_RALT, KC_F), MT(MOD_LGUI, KC_G), MT(MOD_RGUI, KC_H), MT(MOD_RALT, KC_J), LT(LAYER_FUNC, KC_K), LT(LAYER_NUMSYM, KC_L), MT(MOD_RSFT, KC_ENT),
+    KC_DOWN, MT(MOD_LCTL, KC_Z), MT(MOD_LALT, KC_X), LT(LAYER_FUNC, KC_C), LT(LAYER_NUMSYM, KC_V), MT(MOD_LSFT, KC_B), MT(MOD_LALT, KC_N), MT(MOD_RCTL, KC_M), MT(MOD_RSFT, KC_SPC), KC_BSPC
+  ),
 
 /* Function and Navigation Layer
  * ,---------------------------------------------------------------------.
  * |      |      |      |      |      |      |      |      |      |      |
  * |  F1  |  F2  |  F3  |  F4  |  F5  |  F6  |  F7  |  F8  |  F9  |  F10 |
- * | ____ | ____ | ____ | ____ | ____ | ____ | ____ | ____ | ____ | ____ |
+ * | ____ | ____ | ____ | ____ | ____ | ____ |SysLay|  Alt | Ctrl | Shift|
  * |------+------+------+------+-------------+------+------+------+------|
  * |      |      |      |      |      |      |      |      |      |      |
- * |  ESC | Home | PgDn | PgUp |  End | Left | Down |  Up  | Right| Baksp|
+ * |  ESC | Home | PgDn | PgUp |  End | Left | Down |  Up  | Right|Backsp|
  * | Shift| ____ |SysLay| AltGr| OSkey| OSkey| AltGr| ____ |SysLay| Shift|
  * '------+------+------+------+------+------|------+------+------+------'
  *        |      |      |      |      |      |      |      |      |       
- *        | ____ | ____ |      | ____ | ____ | ____ | ____ | ____ |       
+ *        |  F11 |  F12 |      | Space|PrnScr|ScrLck|Pause |Backsp|       
  *        | Ctrl |  Alt | ____ |SysLay| Shift|  Alt | Ctrl | Shift|       
  *        '-------------------------------------------------------'       
  */
   [LAYER_FUNC] = LAYOUT_ortho_3x10(
-         KC_F1, KC_F2, KC_F3, KC_F4, KC_F5, KC_F6, KC_F7, KC_F8, KC_F9, KC_F10,
-         MT(MOD_LSFT, KC_ESC), KC_HOME, LT(LAYER_SYST, KC_PGDN), MT(MOD_RALT, KC_PGUP), MT(MOD_LGUI, KC_END), MT(MOD_RGUI, KC_LEFT), MT(MOD_RALT, KC_DOWN), KC_UP, LT(LAYER_SYST, KC_RGHT), MT(MOD_RSFT, KC_BSPC),
-         XXXXXXX, KC_LCTL, KC_LALT, KC_NO, MO(LAYER_SYST), KC_LSFT, KC_LALT, KC_RCTL, MT(MOD_RSFT, KC_SPC), XXXXXXX ),
+    KC_F1, KC_F2, KC_F3, KC_F4, KC_F5, KC_F6, LT(LAYER_SYST, KC_F7), MT(MOD_LALT, KC_F8), MT(MOD_RCTL,KC_F9), MT(MOD_RSFT, KC_F10),
+    MT(MOD_LSFT, KC_ESC), KC_HOME, LT(LAYER_SYST, KC_PGDN), MT(MOD_RALT, KC_PGUP), MT(MOD_LGUI, KC_END), MT(MOD_RGUI, KC_LEFT), MT(MOD_RALT, KC_DOWN), KC_UP, LT(LAYER_SYST, KC_RGHT), MT(MOD_RSFT, KC_BSPC),
+    KC_DOWN, MT(KC_LCTL, KC_F11), MT(KC_LALT, KC_F12), KC_NO, LT(LAYER_SYST, KC_SPACE), MT(KC_LSFT, KC_PSCR), MT(KC_LALT, KC_SLCK), MT(KC_RCTL, KC_PAUS), MT(MOD_RSFT, KC_BSPC), KC_UP
+  ),
 
 /* Number and Symbols Layer
  * ,---------------------------------------------------------------------.
  * |   !  |   @  |   #  |   $  |   %  |   ^  |   &  |   *  |   (  |   )  |
  * |   1  |   2  |   3  |   4  |   5  |   6  |   7  |   8  |   9  |   0  |
- * | ____ | ____ | ____ | ____ | ____ | ____ | ____ | ____ | ____ | ____ |
+ * | ____ | ____ | ____ | ____ | ____ |SysLay| ____ |  Alt | Ctrl | Shift|
  * |------+------+------+------+-------------+------+------+------+------|
  * |      |   ~  |   _  |   +  |   {  |   }  |  |   |   :  |   "  |      |
  * |  TAB |   `  |   -  |   =  |   [  |   ]  |  \   |   ;  |   '  | Del  |
  * | Shift|SysLay| ____ | AltGr| OSkey| OSkey| AltGr|SysLay| ____ | Shift|
  * ' -----+------+------+------+------+------|------+------+------+------'
  *        |      |      |      |      |   <  |   >  |   ?  |      |       
- *        | ____ | ____ | ____ |      |   ,  |   .  |   /  | ____ |       
+ *        |BackSp|  Del | Enter|      |   ,  |   .  |   /  | Enter|       
  *        | Ctrl |  Alt |SysLay| ____ | Shift|  Alt | Ctrl | Shift|       
  *        '-------------------------------------------------------'       
  */
   [LAYER_NUMSYM] = LAYOUT_ortho_3x10(
-         KC_1, KC_2, KC_3, KC_4, KC_5, KC_6, KC_7, KC_8, KC_9, KC_0,
-         MT(MOD_LSFT, KC_TAB), LT(LAYER_SYST, KC_GRV), KC_MINS, MT(MOD_RALT, KC_EQL), MT(MOD_LGUI, KC_LBRC), MT(MOD_RGUI, KC_RBRC), MT(MOD_RALT, KC_BSLS), LT(LAYER_SYST, KC_SCLN), KC_QUOT, MT(MOD_RSFT, KC_DEL),
-         XXXXXXX, KC_LCTL, KC_LALT, MO(LAYER_SYST), KC_NO, MT(MOD_LSFT, KC_COMM), MT(MOD_LALT, KC_DOT), MT(MOD_RCTL, KC_SLSH), MT(MOD_RSFT, KC_SPC), XXXXXXX ),
+    KC_1, KC_2, KC_3, KC_4, KC_5, LT(LAYER_SYST, KC_6), KC_7, MT(MOD_LALT, KC_8), MT(MOD_RCTL,KC_9), MT(MOD_RSFT, KC_0),
+    MT(MOD_LSFT, KC_TAB), LT(LAYER_SYST, KC_GRV), KC_MINS, MT(MOD_RALT, KC_EQL), MT(MOD_LGUI, KC_LBRC), MT(MOD_RGUI, KC_RBRC), MT(MOD_RALT, KC_BSLS), LT(LAYER_SYST, KC_SCLN), KC_QUOT, MT(MOD_RSFT, KC_DEL),
+    KC_LEFT, MT(KC_LCTL, KC_BSPC), MT(KC_LALT, KC_DEL), LT(LAYER_SYST, KC_ENT), KC_NO, MT(MOD_LSFT, KC_COMM), MT(MOD_LALT, KC_DOT), MT(MOD_RCTL, KC_SLSH), MT(MOD_RSFT, KC_ENT), KC_RGHT
+  ),
 
 /* System Layer
  * ,---------------------------------------------------------------------.
  * |      |      |      |      |      |      |      |      |      |      |
- * | F11  | F12  | Play | Next |MsWhlU|MsBtn1|OSMenu|SysReq|MsBtn2|Backsp|
- * | ____ | ____ | ____ | ____ | ____ | ____ | ____ | ____ | ____ | ____ |
+ * | Play | Stop | Prev | Next |MsBtn1|MsLeft|MSDown| MsUp |MsRigh|MsBtn2|
+ * | ____ | ____ | ____ | ____ | ____ | ____ | ____ | ____ | ____ | Shift|
  * |------+------+------+------+-------------+------+------+------+------|
  * |      |      |      |      |      |      |      |      |      |      |
- * | Caps | Mute | Vol- | Vol+ |MsWhlD|MsLeft|MSDown| MsUp |MsRigh| Ins  |
- * | Shift| ____ | ____ | ____ | ____ | ____ | ____ | ____ | ____ | Shift|
+ * |Backsp| Mute | Vol- | Vol+ |MsWhlD| Left | Down |  Up  | Right|Backsp|
+ * | ____ | ____ | ____ | ____ | ____ | ____ | ____ | ____ | ____ | ____ |
  * '------+------+------+------+------+------|------+------+------+------'
  *        |      |      |      |      |      |      |      |      |       
- *        | ____ | ____ |      |      |PrnScr|ScrLck|Pause | ____ |       
- *        | Ctrl |  Alt | ____ | ____ | ____ | ____ | ____ | Shift|       
- *        '-------------------------------------------------------'       
- * simplified view (for media and mouse there are dedicated layers)
- * ,---------------------------------------------------------------------.
- * |      |      |      |      |      |      |      |      |      |      |
- * | F11  | F12  |      |      |      |      |OSMenu|SysReq|      |Backsp|
- * | ____ | ____ | ____ | ____ | ____ | ____ | ____ | ____ | ____ | ____ |
- * |------+------+------+------+-------------+------+------+------+------|
- * |      |      |      |      |      |      |      |      |      |      |
- * | Caps |      |      |      |      |      |      |      |      | Ins  |
- * | Shift| ____ | ____ | ____ | ____ | ____ | ____ | ____ | ____ | Shift|
- * '------+------+------+------+------+------|------+------+------+------+
- *        |      |      |      |      |      |      |      |      |        
- *        |      |      |      |      |PrnScr|ScrLck|Pause |      |       
- *        | Ctrl |  Alt | ____ | ____ | ____ | ____ | ____ | Shift|       
+ *        | ____ | ____ | Enter| Space| Mute | Vol- | Vol+ | Space|       
+ *        | Ctrl |  Alt | ____ | ____ | Shift| Alt  | Ctrl | ____ |       
  *        '-------------------------------------------------------'       
  */
   [LAYER_SYST] = LAYOUT_ortho_3x10(
-         KC_F11, KC_F12, KC_MPLY, KC_MNXT, KC_MS_WH_UP, KC_MS_BTN1, KC_APP, KC_SYSREQ, KC_MS_BTN2, KC_BSPC, 
-         MT(MOD_LSFT, KC_CAPS), KC_MUTE, KC_VOLD, KC_VOLU, KC_MS_WH_DOWN, KC_MS_LEFT, KC_MS_DOWN, KC_MS_UP, KC_MS_RIGHT, MT(MOD_RSFT, KC_INS), 
-         XXXXXXX, KC_LCTL, KC_LALT, KC_NO, KC_NO, KC_PSCR, KC_SLCK, KC_PAUS, MT(MOD_RSFT, KC_SPC), XXXXXXX ),
+    KC_MPLY, KC_STOP, KC_MPRV, KC_MNXT, KC_MS_BTN1, KC_MS_LEFT, KC_MS_DOWN, KC_MS_UP, KC_MS_RIGHT, MT(MOD_RSFT, KC_MS_BTN2),
+    KC_BSPC, KC_DEL, KC_PGDN, KC_PGUP, KC_APP, KC_LEFT, KC_DOWN, KC_UP, KC_RGHT, KC_BSPC,
+    KC_PGDN, MT(KC_LCTL, KC_CAPS), MT(KC_LALT, KC_INS), KC_ENT, KC_SPC, MT(MOD_RSFT, KC_MUTE), MT(MOD_LALT, KC_VOLD), MT(MOD_RCTL, KC_VOLU), KC_SPC, KC_PGUP
+  ),
 
  /* ArrowPad (mod su Q)  /------mouse-------\ /-----cursor-------\
  * ,---------------------------------------------------------------------.
@@ -157,23 +148,24 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * | Shift| ____ | ____ | ____ | ____ | ____ | ____ | ____ | ____ | ____ |
  * '------+------+------+------+------+------|------+------+------+------'
  *        |      |      |      |      |      |      |      |      |        
- *        |      |      |MsWhlU|MsDown|MsWhlD|  End | Down | PdDn |       
+ *        |      |      |MsWhlU|MsDown|MsWhlD|  End | PgDn | PgDn |       
  *        | Ctrl |  Alt | ____ | ____ | ____ | ____ | ____ | ____ |       
  *        '-------------------------------------------------------'       
  */
   [LAYER_ARROWPAD] = LAYOUT_ortho_3x10(
-         KC_NO, KC_NO, KC_NO, KC_MS_BTN1, KC_MS_UP, KC_MS_BTN2, KC_HOME, KC_UP, KC_PGUP, KC_BSPC, 
-         KC_LSFT, KC_NO, KC_NO, KC_MS_LEFT, KC_MS_DOWN, KC_MS_RIGHT, KC_LEFT, KC_DOWN, KC_RIGHT, KC_ENT, 
-         XXXXXXX, KC_LCTL, KC_LALT, KC_MS_WH_UP, KC_MS_DOWN, KC_MS_WH_DOWN, KC_END, KC_DOWN, KC_PGDN, XXXXXXX ),
+    KC_NO, KC_NO, KC_NO, KC_MS_BTN1, KC_MS_UP, KC_MS_BTN2, KC_HOME, KC_UP, KC_PGUP, KC_BSPC, 
+    KC_LSFT, KC_NO, KC_NO, KC_MS_LEFT, KC_MS_DOWN, KC_MS_RIGHT, KC_LEFT, KC_DOWN, KC_RIGHT, KC_ENT, 
+    XXXXXXX, KC_LCTL, KC_LALT, KC_MS_WH_UP, KC_MS_DOWN, KC_MS_WH_DOWN, KC_END, KC_PGDN, KC_PGDN, XXXXXXX 
+  ),
 
 /* NumPad (mod su W)
  * ,---------------------------------------------------------------------.
  * |      |      |      |      |      |      |      |      |      |      |
- * |      |      |   /  |   *  |   -  |Backsp|   7  |   8  |   9  |  0   |
+ * |      |      |   3  |   *  |   -  |Backsp|   7  |   8  |   9  |  0   |
  * | ____ | ____ | ____ | ____ | ____ | ____ | ____ | ____ | ____ | ____ |
  * |------+------+------+------+-------------+------+------+------+------|
  * |      |      |      |      |      |      |      |      |      |      |
- * |      |      |      |   =  |   +  |   .  |   4  |   5  |   6  | Enter|
+ * |      |      |   /  |   =  |   +  |   .  |   4  |   5  |   6  | Enter|
  * | Shift| ____ | ____ | ____ | ____ | ____ | ____ | ____ | ____ | ____ |
  * '------+------+------+------+------+------|------+------+------+------'
  *        |      |      |      |      |      |      |      |      |       
@@ -182,9 +174,10 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  *        '-------------------------------------------------------'       
  */
   [LAYER_NUMPAD] = LAYOUT_ortho_3x10(
-         KC_NO, KC_NO, KC_KP_SLASH, KC_KP_ASTERISK, KC_KP_MINUS, KC_BSPC, KC_7, KC_8, KC_9, KC_0, 
-         KC_LSFT, KC_NO, KC_NO, KC_KP_EQUAL, KC_KP_PLUS, KC_DOT, KC_4, KC_5, KC_6, KC_ENT, 
-         XXXXXXX, KC_LCTL, KC_LALT, KC_NO, KC_TAB, KC_COMM, KC_1, KC_2, KC_3, XXXXXXX ),
+    KC_NO, KC_NO, KC_3, KC_KP_ASTERISK, KC_KP_MINUS, KC_BSPC, KC_7, KC_8, KC_9, KC_0, 
+    KC_LSFT, KC_NO, KC_KP_SLASH, KC_KP_EQUAL, KC_KP_PLUS, KC_DOT, KC_4, KC_5, KC_6, KC_ENT, 
+    XXXXXXX, KC_LCTL, KC_LALT, KC_NO, KC_TAB, KC_COMM, KC_1, KC_2, KC_3, XXXXXXX 
+  ),
  
  /* MediaPad (mod su E)
  * ,---------------------------------------------------------------------.
@@ -202,9 +195,10 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  *        '-------------------------------------------------------'       
  */
   [LAYER_MEDIAPAD] = LAYOUT_ortho_3x10(
-         KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_VOLU, KC_NO, KC_NO, 
-         KC_LSFT, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_MPRV, KC_MPLY, KC_MNXT, KC_NO, 
-         XXXXXXX, KC_LCTL, KC_LALT, KC_NO, KC_NO, KC_NO, KC_MUTE, KC_VOLD, KC_NO, XXXXXXX ),  
+    KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_VOLU, KC_NO, KC_NO, 
+    KC_LSFT, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_MPRV, KC_MPLY, KC_MNXT, KC_NO, 
+    XXXXXXX, KC_LCTL, KC_LALT, KC_NO, KC_NO, KC_NO, KC_MUTE, KC_VOLD, KC_NO, XXXXXXX 
+  ),  
     
 };
 
@@ -225,15 +219,13 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case CK_TRIPLEZERO:
       if (record->event.pressed) {
         SEND_STRING("000");
-      } // else { when released... }
+      } // else { when released }
       break;
   }
   return true;
 };
 
 void keyboard_pre_init_user(void) {
-  // Call the keyboard pre init code.
-
   // Set our LED pins as output
   setPinOutput(D5);
   setPinOutput(B0);

--- a/keyboards/40percentclub/gherkin/keymaps/stevexyz/readme.md
+++ b/keyboards/40percentclub/gherkin/keymaps/stevexyz/readme.md
@@ -1,11 +1,14 @@
-# gherkin super micro edition
+# The 25% SuperMicro keyboard
+## A full featured keymap on Gherkin compatible with a pure "Alpha 26" layout
 
-With this configuration the "28" layout first experimented on the plank-like jj40 is being ported to a more proper board, leaving just two keys not used.
+With this configuration the "SuperMicro" layout first experimented on the plank-like jj40 is being ported to a more proper board, and with the last changes, this layout has been made compatible also to a "26 keys" one. So you can now choose to leave all 30 keys on the keyboard, or remove the two on the bottom line corners to have the "old" and comfortable 28 keys layout, or remove also space and enter to have the simplest "pure alpha" one! And even the intermediate 27 keys one is an interesting compatible option!
 
-For more information please have a look at https://github.com/stevexyz/qmk_firmware/blob/master/keyboards/jj40/keymaps/stevexyz/readme.md 
+This keymap is for a generic usage, trying to avoid as much gimmick as possible (considering the number of keys) and retain muscle memory from people used to the standard Qwerty 104 keys one. Functions and numbers (with related symbols) are on the first row as expected; other examples of design coherency include the symbols on the central row laid out in the same order as you'll find on a standard full keyboard, and the cursor movement aligned to the common unix vi standard ("hjkl", and for symmetry "sdfg" for home/pgdn/pgup/end). I've personally used this layout for months on my home PC in parallel to my portable work PC.
 
-The image below explain the main layers. In addition to them with q, w and e there are three specific dedicated layers for cursors/mouse, numpad and media.
-![layers](https://raw.githubusercontent.com/stevexyz/qmk_firmware/master/keyboards/40percentclub/gherkin/keymaps/stevexyz/layers.jpeg)
+Relying just on the alphabetic keys this layout can be also very easily ported and tested on any qmk supported keyboard (ok, butterstick excluded).
+
+The image below explains the main layers activated respectively with F, N or both modifiers pressed together. In addition to them there are available 5 layers that can be personalized as needed or completely removed without losing any functionality; three of them are currently setup in the default keymap for cursors/mouse, numpad and media (activated with q, w and e respectively).
+![layers](https://raw.githubusercontent.com/stevexyz/qmk_firmware/master/keyboards/40percentclub/gherkin/keymaps/stevexyz/newlayout26272830.jpg)
 
 ![prototype](https://github.com/stevexyz/qmk_firmware/blob/master/keyboards/40percentclub/gherkin/keymaps/stevexyz/gherkin28.jpeg)
 

--- a/keyboards/40percentclub/gherkin/keymaps/stevexyz/readme.md
+++ b/keyboards/40percentclub/gherkin/keymaps/stevexyz/readme.md
@@ -8,7 +8,8 @@ This keymap is for a generic usage, trying to avoid as much gimmick as possible 
 Relying just on the alphabetic keys this layout can be also very easily ported and tested on any qmk supported keyboard (ok, butterstick excluded).
 
 The image below explains the main layers activated respectively with F, N or both modifiers pressed together. In addition to them there are available 5 layers that can be personalized as needed or completely removed without losing any functionality; three of them are currently setup in the default keymap for cursors/mouse, numpad and media (activated with q, w and e respectively).
-![layers](https://raw.githubusercontent.com/stevexyz/qmk_firmware/master/keyboards/40percentclub/gherkin/keymaps/stevexyz/newlayout26272830.jpg)
+
+![layers](https://github.com/stevexyz/qmk_firmware/blob/master/keyboards/40percentclub/gherkin/keymaps/stevexyz/newlayout26272830.jpg)
 
 ![prototype](https://github.com/stevexyz/qmk_firmware/blob/master/keyboards/40percentclub/gherkin/keymaps/stevexyz/gherkin28.jpeg)
 


### PR DESCRIPTION
## Description

This update of the Gherkin keymap make the original 28 keys design compatible to a 26 "pure alpha" one, as well as 27 (alpha+space) and 30 keys (all the Gherkin switches installed).

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

No issues detected to close

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
