### PR TITLE
Add shift-to-disable to RGB_TOG keycode

### DIFF
--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -175,7 +175,7 @@ All RGB keycodes are currently shared with the RGBLIGHT system:
 
 |Key                |Aliases   |Description                                                                           |
 |-------------------|----------|--------------------------------------------------------------------------------------|
-|`RGB_TOG`          |          |Toggle RGB lighting on or off                                                         |
+|`RGB_TOG`          |          |Toggle RGB lighting on or off, turn off when Shift is held                            |
 |`RGB_MODE_FORWARD` |`RGB_MOD` |Cycle through modes, reverse direction when Shift is held                             |
 |`RGB_MODE_REVERSE` |`RGB_RMOD`|Cycle through modes in reverse, forward direction when Shift is held                  |
 |`RGB_HUI`          |          |Increase hue, decrease hue when Shift is held                                         |

--- a/docs/feature_rgblight.md
+++ b/docs/feature_rgblight.md
@@ -45,7 +45,7 @@ Changing the **Value** sets the overall brightness.<br>
 
 |Key                |Aliases   |Description                                                         |
 |-------------------|----------|--------------------------------------------------------------------|
-|`RGB_TOG`          |          |Toggle RGB lighting on or off                                       |
+|`RGB_TOG`          |          |Toggle RGB lighting on or off, turn off when Shift is held          |
 |`RGB_MODE_FORWARD` |`RGB_MOD` |Cycle through modes, reverse direction when Shift is held           |
 |`RGB_MODE_REVERSE` |`RGB_RMOD`|Cycle through modes in reverse, forward direction when Shift is held|
 |`RGB_HUI`          |          |Increase hue, decrease hue when Shift is held                       |

--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -421,7 +421,7 @@ See also: [RGB Lighting](feature_rgblight.md)
 
 |Key                |Aliases   |Description                                                         |
 |-------------------|----------|--------------------------------------------------------------------|
-|`RGB_TOG`          |          |Toggle RGB lighting on or off                                       |
+|`RGB_TOG`          |          |Toggle RGB lighting on or off, turn off when Shift is held          |
 |`RGB_MODE_FORWARD` |`RGB_MOD` |Cycle through modes, reverse direction when Shift is held           |
 |`RGB_MODE_REVERSE` |`RGB_RMOD`|Cycle through modes in reverse, forward direction when Shift is held|
 |`RGB_HUI`          |          |Increase hue, decrease hue when Shift is held                       |
@@ -446,7 +446,7 @@ See also: [RGB Matrix Lighting](feature_rgb_matrix.md)
 
 |Key                |Aliases   |Description                                                                           |
 |-------------------|----------|--------------------------------------------------------------------------------------|
-|`RGB_TOG`          |          |Toggle RGB lighting on or off                                                         |
+|`RGB_TOG`          |          |Toggle RGB lighting on or off, turn off when Shift is held                            |
 |`RGB_MODE_FORWARD` |`RGB_MOD` |Cycle through modes, reverse direction when Shift is held                             |
 |`RGB_MODE_REVERSE` |`RGB_RMOD`|Cycle through modes in reverse, forward direction when Shift is held                  |
 |`RGB_HUI`          |          |Increase hue, decrease hue when Shift is held                                         |

--- a/quantum/process_keycode/process_rgb.c
+++ b/quantum/process_keycode/process_rgb.c
@@ -59,7 +59,7 @@ bool process_rgb(const uint16_t keycode, const keyrecord_t *record) {
         uint8_t shifted = get_mods() & MOD_MASK_SHIFT;
         switch (keycode) {
             case RGB_TOG:
-                rgblight_toggle();
+                handleKeycodeRGB(shifted, rgblight_toggle, rgblight_disable);
                 return false;
             case RGB_MODE_FORWARD:
                 handleKeycodeRGB(shifted, rgblight_step, rgblight_step_reverse);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Add shift-to-disable function to RGB_TOG keycode, so that if RGB_TOG is pressed while shift is held, RGB will be turned off.

Currently when flashing RGB-enabled firmware on the crkbd, one half may start up with RGB on and the other with RGB off.  This provides an easy way to get both halves in sync without requiring a new keycode.

Also see #7484.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR
* Resolves #6594.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
