### PR TITLE
Enable backlight breathing support for the TADA68

### DIFF
--- a/keyboards/tada68/config.h
+++ b/keyboards/tada68/config.h
@@ -37,8 +37,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MATRIX_COL_PINS {F0,F1,E6,C7,C6,B7,D4,B1,B0,B5,B4,D7,D6,B3,F4}
 #define UNUSED_PINS
 
-#define BACKLIGHT_PIN B6
-
 /* COL2ROW or ROW2COL */
 #define DIODE_DIRECTION COL2ROW
 
@@ -53,8 +51,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* Locking resynchronize hack */
 #define LOCKING_RESYNC_ENABLE
 
-/* Backlight configuration
- */
+/* Backlight configuration */
+#define BACKLIGHT_PIN B6
+#define BACKLIGHT_BREATHING
 #define BACKLIGHT_LEVELS 4
 
 /*


### PR DESCRIPTION
## Description

The factory TMK firmware for the TADA68 supports backlight breathing,
so I was surprised when the BL_BRTG key I set up in the online QMK
configurator didn't work.

As far as I can tell, this was just a simple omission.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
