### PR TITLE
Slight speed increases for matrix scanning

### DIFF
--- a/quantum/matrix.c
+++ b/quantum/matrix.c
@@ -48,17 +48,22 @@ static void init_pins(void) {
 }
 
 static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row) {
-    matrix_row_t last_row_value = current_matrix[current_row];
-    current_matrix[current_row] = 0;
+    // Start with a clear matrix row
+    matrix_row_t current_row_value = 0;
 
     for (uint8_t col_index = 0; col_index < MATRIX_COLS; col_index++) {
         pin_t pin = direct_pins[current_row][col_index];
         if (pin != NO_PIN) {
-            current_matrix[current_row] |= readPin(pin) ? 0 : (MATRIX_ROW_SHIFTER << col_index);
+            current_row_value |= readPin(pin) ? 0 : (MATRIX_ROW_SHIFTER << col_index);
         }
     }
 
-    return (last_row_value != current_matrix[current_row]);
+    // If the row has changed, store the row and return the changed flag.
+    if (current_matrix[current_row] != current_row_value) {
+        current_matrix[current_row] = current_row_value;
+        return true;
+    }
+    return false;
 }
 
 #elif defined(DIODE_DIRECTION)
@@ -84,12 +89,9 @@ static void init_pins(void) {
     }
 }
 
-static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row) {
-    // Store last value of row prior to reading
-    matrix_row_t last_row_value = current_matrix[current_row];
-
-    // Clear data in matrix row
-    current_matrix[current_row] = 0;
+static bool  read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row) {
+    // Start with a clear matrix row
+    matrix_row_t current_row_value = 0;
 
     // Select row and wait for row selecton to stabilize
     select_row(current_row);
@@ -101,13 +103,18 @@ static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
         uint8_t pin_state = readPin(col_pins[col_index]);
 
         // Populate the matrix row with the state of the col pin
-        current_matrix[current_row] |= pin_state ? 0 : (MATRIX_ROW_SHIFTER << col_index);
+        current_row_value |= pin_state ? 0 : (MATRIX_ROW_SHIFTER << col_index);
     }
 
     // Unselect row
     unselect_row(current_row);
 
-    return (last_row_value != current_matrix[current_row]);
+    // If the row has changed, store the row and return the changed flag.
+    if (current_matrix[current_row] != current_row_value) {
+        current_matrix[current_row] = current_row_value;
+        return true;
+    }
+    return false;
 }
 
 #    elif (DIODE_DIRECTION == ROW2COL)
@@ -143,19 +150,21 @@ static bool read_rows_on_col(matrix_row_t current_matrix[], uint8_t current_col)
     for (uint8_t row_index = 0; row_index < MATRIX_ROWS; row_index++) {
         // Store last value of row prior to reading
         matrix_row_t last_row_value = current_matrix[row_index];
+        matrix_row_t current_row_value = last_row_value;
 
         // Check row pin state
         if (readPin(row_pins[row_index]) == 0) {
             // Pin LO, set col bit
-            current_matrix[row_index] |= (MATRIX_ROW_SHIFTER << current_col);
+            current_row_value |= (MATRIX_ROW_SHIFTER << current_col);
         } else {
             // Pin HI, clear col bit
-            current_matrix[row_index] &= ~(MATRIX_ROW_SHIFTER << current_col);
+            current_row_value &= ~(MATRIX_ROW_SHIFTER << current_col);
         }
 
         // Determine if the matrix changed state
-        if ((last_row_value != current_matrix[row_index]) && !(matrix_changed)) {
-            matrix_changed = true;
+        if ((last_row_value != current_row_value)) {
+            matrix_changed |= true;
+            current_matrix[row_index] = current_row_value;
         }
     }
 

--- a/quantum/split_common/matrix.c
+++ b/quantum/split_common/matrix.c
@@ -65,17 +65,22 @@ static void init_pins(void) {
 }
 
 static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row) {
-    matrix_row_t last_row_value = current_matrix[current_row];
-    current_matrix[current_row] = 0;
+    // Start with a clear matrix row
+    matrix_row_t current_row_value = 0;
 
     for (uint8_t col_index = 0; col_index < MATRIX_COLS; col_index++) {
         pin_t pin = direct_pins[current_row][col_index];
         if (pin != NO_PIN) {
-            current_matrix[current_row] |= readPin(pin) ? 0 : (MATRIX_ROW_SHIFTER << col_index);
+            current_row_value |= readPin(pin) ? 0 : (MATRIX_ROW_SHIFTER << col_index);
         }
     }
 
-    return (last_row_value != current_matrix[current_row]);
+    // If the row has changed, store the row and return the changed flag.
+    if (current_matrix[current_row] != current_row_value) {
+        current_matrix[current_row] = current_row_value;
+        return true;
+    }
+    return false;
 }
 
 #elif defined(DIODE_DIRECTION)
@@ -101,12 +106,9 @@ static void init_pins(void) {
     }
 }
 
-static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row) {
-    // Store last value of row prior to reading
-    matrix_row_t last_row_value = current_matrix[current_row];
-
-    // Clear data in matrix row
-    current_matrix[current_row] = 0;
+static bool  read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row) {
+    // Start with a clear matrix row
+    matrix_row_t current_row_value = 0;
 
     // Select row and wait for row selecton to stabilize
     select_row(current_row);
@@ -118,13 +120,18 @@ static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
         uint8_t pin_state = readPin(col_pins[col_index]);
 
         // Populate the matrix row with the state of the col pin
-        current_matrix[current_row] |= pin_state ? 0 : (MATRIX_ROW_SHIFTER << col_index);
+        current_row_value |= pin_state ? 0 : (MATRIX_ROW_SHIFTER << col_index);
     }
 
     // Unselect row
     unselect_row(current_row);
 
-    return (last_row_value != current_matrix[current_row]);
+    // If the row has changed, store the row and return the changed flag.
+    if (current_matrix[current_row] != current_row_value) {
+        current_matrix[current_row] = current_row_value;
+        return true;
+    }
+    return false;
 }
 
 #    elif (DIODE_DIRECTION == ROW2COL)
@@ -160,19 +167,21 @@ static bool read_rows_on_col(matrix_row_t current_matrix[], uint8_t current_col)
     for (uint8_t row_index = 0; row_index < ROWS_PER_HAND; row_index++) {
         // Store last value of row prior to reading
         matrix_row_t last_row_value = current_matrix[row_index];
+        matrix_row_t current_row_value = last_row_value;
 
         // Check row pin state
         if (readPin(row_pins[row_index]) == 0) {
             // Pin LO, set col bit
-            current_matrix[row_index] |= (MATRIX_ROW_SHIFTER << current_col);
+            current_row_value |= (MATRIX_ROW_SHIFTER << current_col);
         } else {
             // Pin HI, clear col bit
-            current_matrix[row_index] &= ~(MATRIX_ROW_SHIFTER << current_col);
+            current_row_value &= ~(MATRIX_ROW_SHIFTER << current_col);
         }
 
         // Determine if the matrix changed state
-        if ((last_row_value != current_matrix[row_index]) && !(matrix_changed)) {
-            matrix_changed = true;
+        if ((last_row_value != current_row_value)) {
+            matrix_changed |= true;
+            current_matrix[row_index] = current_row_value;
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
While a big limit is the 30us delay within matrix scanning, that figure can be configured now along with overall optimisation. These changes can net up to 10% increases depending on matrix size and scanning method. In DIRECT_PINS cases its maybe in the region of 1% but I figured it was worth keeping the code consistent.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
