### PR TITLE
ISSI driver compile error fix

### DIFF
--- a/drivers/issi/is31fl3731.c
+++ b/drivers/issi/is31fl3731.c
@@ -64,7 +64,7 @@ uint8_t g_twi_transfer_buffer[20];
 uint8_t g_pwm_buffer[DRIVER_COUNT][144];
 bool    g_pwm_buffer_update_required[DRIVER_COUNT] = {false};
 
-uint8_t g_led_control_registers[DRIVER_COUNT][18]             = {{0}, {0}};
+uint8_t g_led_control_registers[DRIVER_COUNT][18]             = {{0}};
 bool    g_led_control_registers_update_required[DRIVER_COUNT] = {false};
 
 // This is the bit pattern in the LED control registers


### PR DESCRIPTION
Fix compile error for when `DRIVER_COUNT` is 1 (it is usually 2 or more).

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
