### PR TITLE
Fix the mousekey scrolling

### DIFF
--- a/tmk_core/common/mousekey.c
+++ b/tmk_core/common/mousekey.c
@@ -35,7 +35,7 @@ static report_mouse_t mouse_report = {0};
 static void           mousekey_debug(void);
 static uint8_t        mousekey_accel  = 0;
 static uint8_t        mousekey_repeat = 0;
-static uint16_t       last_timer      = 0;
+static uint8_t        mousekey_wheel_repeat = 0;
 
 #ifndef MK_3_SPEED
 
@@ -92,12 +92,12 @@ static uint8_t wheel_unit(void) {
         unit = (MOUSEKEY_WHEEL_DELTA * mk_wheel_max_speed) / 2;
     } else if (mousekey_accel & (1 << 2)) {
         unit = (MOUSEKEY_WHEEL_DELTA * mk_wheel_max_speed);
-    } else if (mousekey_repeat == 0) {
+    } else if (mousekey_wheel_repeat == 0) {
         unit = MOUSEKEY_WHEEL_DELTA;
-    } else if (mousekey_repeat >= mk_wheel_time_to_max) {
+    } else if (mousekey_wheel_repeat >= mk_wheel_time_to_max) {
         unit = MOUSEKEY_WHEEL_DELTA * mk_wheel_max_speed;
     } else {
-        unit = (MOUSEKEY_WHEEL_DELTA * mk_wheel_max_speed * mousekey_repeat) / mk_wheel_time_to_max;
+        unit = (MOUSEKEY_WHEEL_DELTA * mk_wheel_max_speed * mousekey_wheel_repeat) / mk_wheel_time_to_max;
     }
     return (unit > MOUSEKEY_WHEEL_MAX ? MOUSEKEY_WHEEL_MAX : (unit == 0 ? 1 : unit));
 }
@@ -105,14 +105,17 @@ static uint8_t wheel_unit(void) {
 void mousekey_task(void) {
     // report cursor and scroll movement independently
     report_mouse_t const tmpmr = mouse_report;
-    if ((mouse_report.x || mouse_report.y) && timer_elapsed(last_timer_c) > (mousekey_repeat ? mk_interval : mk_delay * 10)) {
+
+    mouse_report.x = 0;
+    mouse_report.y = 0;
+    mouse_report.v = 0;
+    mouse_report.h = 0;
+
+    if ((tmpmr.x || tmpmr.y) && timer_elapsed(last_timer_c) > (mousekey_repeat ? mk_interval : mk_delay * 10)) {
         if (mousekey_repeat != UINT8_MAX) mousekey_repeat++;
-        mouse_report.v = 0;
-        mouse_report.h = 0;
-        if (mouse_report.x > 0) mouse_report.x = move_unit();
-        if (mouse_report.x < 0) mouse_report.x = move_unit() * -1;
-        if (mouse_report.y > 0) mouse_report.y = move_unit();
-        if (mouse_report.y < 0) mouse_report.y = move_unit() * -1;
+        if (tmpmr.x != 0) mouse_report.x = move_unit() * ((tmpmr.x > 0) ? 1 : -1);
+        if (tmpmr.y != 0) mouse_report.y = move_unit() * ((tmpmr.y > 0) ? 1 : -1);
+
         /* diagonal move [1/sqrt(2)] */
         if (mouse_report.x && mouse_report.y) {
             mouse_report.x = times_inv_sqrt2(mouse_report.x);
@@ -124,18 +127,12 @@ void mousekey_task(void) {
                 mouse_report.y = 1;
             }
         }
-        mousekey_send();
-        last_timer_c = last_timer;
-        mouse_report = tmpmr;
     }
-    if ((mouse_report.v || mouse_report.h) && timer_elapsed(last_timer_w) > (mousekey_repeat ? mk_wheel_interval : mk_wheel_delay * 10)) {
-        if (mousekey_repeat != UINT8_MAX) mousekey_repeat++;
-        mouse_report.x = 0;
-        mouse_report.y = 0;
-        if (mouse_report.v > 0) mouse_report.v = wheel_unit();
-        if (mouse_report.v < 0) mouse_report.v = wheel_unit() * -1;
-        if (mouse_report.h > 0) mouse_report.h = wheel_unit();
-        if (mouse_report.h < 0) mouse_report.h = wheel_unit() * -1;
+    if ((tmpmr.v || tmpmr.h) && timer_elapsed(last_timer_w) > (mousekey_wheel_repeat ? mk_wheel_interval : mk_wheel_delay * 10)) {
+        if (mousekey_wheel_repeat != UINT8_MAX) mousekey_wheel_repeat++;
+        if (tmpmr.v != 0) mouse_report.v = wheel_unit() * ((tmpmr.v > 0) ? 1 : -1);
+        if (tmpmr.h != 0) mouse_report.h = wheel_unit() * ((tmpmr.h > 0) ? 1 : -1);
+
         /* diagonal move [1/sqrt(2)] */
         if (mouse_report.v && mouse_report.h) {
             mouse_report.v = times_inv_sqrt2(mouse_report.v);
@@ -147,10 +144,10 @@ void mousekey_task(void) {
                 mouse_report.h = 1;
             }
         }
-        mousekey_send();
-        last_timer_w = last_timer;
-        mouse_report = tmpmr;
     }
+
+    if (mouse_report.x || mouse_report.y || mouse_report.v || mouse_report.h) mousekey_send();
+    mouse_report = tmpmr;
 }
 
 void mousekey_on(uint8_t code) {
@@ -186,6 +183,7 @@ void mousekey_on(uint8_t code) {
         mousekey_accel |= (1 << 1);
     else if (code == KC_MS_ACCEL2)
         mousekey_accel |= (1 << 2);
+
 }
 
 void mousekey_off(uint8_t code) {
@@ -221,7 +219,8 @@ void mousekey_off(uint8_t code) {
         mousekey_accel &= ~(1 << 1);
     else if (code == KC_MS_ACCEL2)
         mousekey_accel &= ~(1 << 2);
-    if (mouse_report.x == 0 && mouse_report.y == 0 && mouse_report.v == 0 && mouse_report.h == 0) mousekey_repeat = 0;
+    if (mouse_report.x == 0 && mouse_report.y == 0) mousekey_repeat = 0;
+    if (mouse_report.v == 0 && mouse_report.h == 0) mousekey_wheel_repeat = 0;
 }
 
 #else /* #ifndef MK_3_SPEED */
@@ -243,20 +242,22 @@ uint16_t        w_intervals[mkspd_COUNT] = {MK_W_INTERVAL_UNMOD, MK_W_INTERVAL_0
 void mousekey_task(void) {
     // report cursor and scroll movement independently
     report_mouse_t const tmpmr = mouse_report;
-    if ((mouse_report.x || mouse_report.y) && timer_elapsed(last_timer_c) > c_intervals[mk_speed]) {
-        mouse_report.h = 0;
-        mouse_report.v = 0;
-        mousekey_send();
-        last_timer_c = last_timer;
-        mouse_report = tmpmr;
+    mouse_report.x = 0;
+    mouse_report.y = 0;
+    mouse_report.v = 0;
+    mouse_report.h = 0;
+
+    if ((tmpmr.x || tmpmr.y) && timer_elapsed(last_timer_c) > c_intervals[mk_speed]) {
+        mouse_report.x = tmpmr.x;
+        mouse_report.y = tmpmr.y;
     }
-    if ((mouse_report.h || mouse_report.v) && timer_elapsed(last_timer_w) > w_intervals[mk_speed]) {
-        mouse_report.x = 0;
-        mouse_report.y = 0;
-        mousekey_send();
-        last_timer_w = last_timer;
-        mouse_report = tmpmr;
+    if ((tmpmr.h || tmpmr.v) && timer_elapsed(last_timer_w) > w_intervals[mk_speed]) {
+        mouse_report.v = tmpmr.v;
+        mouse_report.h = tmpmr.h;
     }
+
+    if (mouse_report.x || mouse_report.y || mouse_report.v || mouse_report.h) mousekey_send();
+    mouse_report = tmpmr;
 }
 
 void adjust_speed(void) {
@@ -371,13 +372,16 @@ void mousekey_off(uint8_t code) {
 
 void mousekey_send(void) {
     mousekey_debug();
+    uint16_t time = timer_read();
+    if (mouse_report.x || mouse_report.y) last_timer_c = time;
+    if (mouse_report.v || mouse_report.h) last_timer_w = time;
     host_mouse_send(&mouse_report);
-    last_timer = timer_read();
 }
 
 void mousekey_clear(void) {
     mouse_report    = (report_mouse_t){};
     mousekey_repeat = 0;
+    mousekey_wheel_repeat = 0;
     mousekey_accel  = 0;
 }
 


### PR DESCRIPTION
Mousekey scrolling should have a separate repeat variable
to keep track of scrolling acceleration, instead of being
tied to mouse movement scolling in mousekeys. The send function
should record when the last movement was made since this is
when movement is actually sent. Doing this fixes the bug where
the initial press of a mousekey scroll button causes a double scroll.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/qmk/qmk_firmware/issues/5690

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
