### PR TITLE
Added missing shutdown_user() hook

### DIFF
--- a/tmk_core/common/command.c
+++ b/tmk_core/common/command.c
@@ -359,16 +359,8 @@ static bool command_common(uint8_t code) {
         // jump to bootloader
         case MAGIC_KC(MAGIC_KEY_BOOTLOADER):
         case MAGIC_KC(MAGIC_KEY_BOOTLOADER_ALT):
-            clear_keyboard();  // clear to prevent stuck keys
             print("\n\nJumping to bootloader... ");
-#ifdef AUDIO_ENABLE
-            stop_all_notes();
-            shutdown_user();
-#else
-            shutdown_user();
-            wait_ms(1000);
-#endif
-            bootloader_jump();  // not return
+            reset_keyboard();
             break;
 
         // debug toggle

--- a/tmk_core/common/command.c
+++ b/tmk_core/common/command.c
@@ -365,6 +365,7 @@ static bool command_common(uint8_t code) {
             stop_all_notes();
             shutdown_user();
 #else
+            shutdown_user();
             wait_ms(1000);
 #endif
             bootloader_jump();  // not return


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Currently the COMMAND+B(reboot the keyboard) missed the shutdown_user() hook.
It should be same as the reset_keyboard() function called while click the RESET key. 
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x ] Core
- [ ] Bugfix
- [ ] New feature
- [x ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
