### PR TITLE
Fix i2c EEPROM compile issue when Console is enabled

### DIFF
--- a/drivers/eeprom/eeprom_i2c.c
+++ b/drivers/eeprom/eeprom_i2c.c
@@ -34,11 +34,11 @@
 #include "i2c_master.h"
 #include "eeprom.h"
 #include "eeprom_i2c.h"
-
 // #define DEBUG_EEPROM_OUTPUT
 
 #ifdef DEBUG_EEPROM_OUTPUT
-#    include "print.h"
+#    include "timer.h"
+#    include "debug.h"
 #endif  // DEBUG_EEPROM_OUTPUT
 
 static inline void init_i2c_if_required(void) {
@@ -60,7 +60,7 @@ static inline void fill_target_address(uint8_t *buffer, const void *addr) {
 void eeprom_driver_init(void) {}
 
 void eeprom_driver_erase(void) {
-#ifdef CONSOLE_ENABLE
+#ifdef DEBUG_EEPROM_OUTPUT
     uint32_t start = timer_read32();
 #endif
 
@@ -70,7 +70,7 @@ void eeprom_driver_erase(void) {
         eeprom_write_block(buf, (void *)(uintptr_t)addr, EXTERNAL_EEPROM_PAGE_SIZE);
     }
 
-#ifdef CONSOLE_ENABLE
+#ifdef DEBUG_EEPROM_OUTPUT
     dprintf("EEPROM erase took %ldms to complete\n", ((long)(timer_read32() - start)));
 #endif
 }

--- a/drivers/eeprom/eeprom_i2c.c
+++ b/drivers/eeprom/eeprom_i2c.c
@@ -34,9 +34,10 @@
 #include "i2c_master.h"
 #include "eeprom.h"
 #include "eeprom_i2c.h"
+
 // #define DEBUG_EEPROM_OUTPUT
 
-#ifdef DEBUG_EEPROM_OUTPUT
+#if defined(CONSOLE_ENABLE) && defined(DEBUG_EEPROM_OUTPUT)
 #    include "timer.h"
 #    include "debug.h"
 #endif  // DEBUG_EEPROM_OUTPUT
@@ -60,7 +61,7 @@ static inline void fill_target_address(uint8_t *buffer, const void *addr) {
 void eeprom_driver_init(void) {}
 
 void eeprom_driver_erase(void) {
-#ifdef DEBUG_EEPROM_OUTPUT
+#if defined(CONSOLE_ENABLE) && defined(DEBUG_EEPROM_OUTPUT)
     uint32_t start = timer_read32();
 #endif
 
@@ -70,7 +71,7 @@ void eeprom_driver_erase(void) {
         eeprom_write_block(buf, (void *)(uintptr_t)addr, EXTERNAL_EEPROM_PAGE_SIZE);
     }
 
-#ifdef DEBUG_EEPROM_OUTPUT
+#if defined(CONSOLE_ENABLE) && defined(DEBUG_EEPROM_OUTPUT)
     dprintf("EEPROM erase took %ldms to complete\n", ((long)(timer_read32() - start)));
 #endif
 }
@@ -83,7 +84,7 @@ void eeprom_read_block(void *buf, const void *addr, size_t len) {
     i2c_transmit(EXTERNAL_EEPROM_I2C_ADDRESS((uintptr_t)addr), complete_packet, EXTERNAL_EEPROM_ADDRESS_SIZE, 100);
     i2c_receive(EXTERNAL_EEPROM_I2C_ADDRESS((uintptr_t)addr), buf, len, 100);
 
-#ifdef DEBUG_EEPROM_OUTPUT
+#if defined(CONSOLE_ENABLE) && defined(DEBUG_EEPROM_OUTPUT)
     dprintf("[EEPROM R] 0x%04X: ", ((int)addr));
     for (size_t i = 0; i < len; ++i) {
         dprintf(" %02X", (int)(((uint8_t *)buf)[i]));
@@ -110,7 +111,7 @@ void eeprom_write_block(const void *buf, void *addr, size_t len) {
             complete_packet[EXTERNAL_EEPROM_ADDRESS_SIZE + i] = read_buf[i];
         }
 
-#ifdef DEBUG_EEPROM_OUTPUT
+#if defined(CONSOLE_ENABLE) && defined(DEBUG_EEPROM_OUTPUT)
         dprintf("[EEPROM W] 0x%04X: ", ((int)target_addr));
         for (uint8_t i = 0; i < write_length; i++) {
             dprintf(" %02X", (int)(read_buf[i]));


### PR DESCRIPTION
## Description

If console is enabled, the i2c EEPROM support fails to compile. 

This adds the correct includes to ensure that everything compiles properly

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

*  Mine

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
