### PR TITLE
PDBDOWN should be PCBDOWN for atreus_mirrored.

### DIFF
--- a/keyboards/atreus/astar_mirrored/config.h
+++ b/keyboards/atreus/astar_mirrored/config.h
@@ -28,7 +28,7 @@
  *                  ROW2COL = ROW = Anode (+), COL = Cathode (-, marked on diode)
  *
 */
-#define PDBDOWN 1
+#define PCBDOWN 1
 
 #define MATRIX_ROW_PINS { D0, D1, D3, D2 }
 #define MATRIX_COL_PINS { B7, D6, F7, F6, B6, D4, E6, B4, B5, C6, D7 }


### PR DESCRIPTION
This fixes a bug which would cause the two center keys to be swapped
when building the firmware for atreus_mirrored.

## Description

"PCBDOWN" was spelled incorrectly in the atreus_mirrored version of the atreus firmware. I fixed
the typo, and now the two center keys are swapped like they are supposed to be.

This makes the firmware work the way that it is documented in the code, but it will change the keymaps of anyone currently using the atreus_mirrored variant.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [X ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
