### PR TITLE
[Feature] Swap buttons on PS2 Mouse/Trackball

### DIFF
--- a/docs/feature_ps2_mouse.md
+++ b/docs/feature_ps2_mouse.md
@@ -246,7 +246,7 @@ Fine control over the scrolling is supported with the following defines:
 #define PS2_MOUSE_SCROLL_DIVISOR_V 2
 ```
 
-### Invert Mouse buttons
+### Invert Mouse buttons :id=invert-buttons
 
 To invert the left & right buttonsyou can put:
 

--- a/docs/feature_ps2_mouse.md
+++ b/docs/feature_ps2_mouse.md
@@ -248,7 +248,7 @@ Fine control over the scrolling is supported with the following defines:
 
 ### Invert Mouse buttons :id=invert-buttons
 
-To invert the left & right buttonsyou can put:
+To invert the left & right buttons you can put:
 
 ```c
 #define PS2_MOUSE_INVERT_BUTTONS

--- a/docs/feature_ps2_mouse.md
+++ b/docs/feature_ps2_mouse.md
@@ -246,6 +246,16 @@ Fine control over the scrolling is supported with the following defines:
 #define PS2_MOUSE_SCROLL_DIVISOR_V 2
 ```
 
+### Invert Mouse buttons
+
+To invert the left & right buttonsyou can put:
+
+```c
+#define PS2_MOUSE_INVERT_BUTTONS
+```
+
+into config.h.
+
 ### Invert Mouse and Scroll Axes :id=invert-mouse-and-scroll-axes
 
 To invert the X and Y axes you can put:

--- a/tmk_core/protocol/ps2_mouse.c
+++ b/tmk_core/protocol/ps2_mouse.c
@@ -148,17 +148,10 @@ static inline void ps2_mouse_convert_report_to_hid(report_mouse_t *mouse_report)
     mouse_report->y = Y_IS_NEG ? ((!Y_IS_OVF && -127 <= mouse_report->y && mouse_report->y <= -1) ? mouse_report->y : -127) : ((!Y_IS_OVF && 0 <= mouse_report->y && mouse_report->y <= 127) ? mouse_report->y : 127);
 
 #ifdef PS2_MOUSE_INVERT_BUTTONS
-    mouse_report->buttons = (
-        /* Change right to left */
-        BIT_SET_BY(mouse_report->buttons, PS2_MOUSE_BTN_LEFT, PS2_MOUSE_BTN_RIGHT) |
-        /* Change left to right */
-        BIT_SET_BY(mouse_report->buttons, PS2_MOUSE_BTN_RIGHT, PS2_MOUSE_BTN_LEFT) |
-        /* Leave the rest */
-        BITMASK_CLEAR(mouse_report->buttons, (BIT_VALUE(PS2_MOUSE_BTN_MASK, PS2_MOUSE_BTN_LEFT) | BIT_VALUE(PS2_MOUSE_BTN_MASK, PS2_MOUSE_BTN_RIGHT)))
-    /* Remove sign and overflow flags */
-    ) & PS2_MOUSE_BTN_MASK;
+    // remove sign and overflow flags and apply buttons LUT
+    mouse_report->buttons = btns_lut[mouse_report->buttons & PS2_MOUSE_BTN_MASK];
 #else
-    /* remove sign and overflow flags */
+    // remove sign and overflow flags
     mouse_report->buttons &= PS2_MOUSE_BTN_MASK;
 #endif
 

--- a/tmk_core/protocol/ps2_mouse.c
+++ b/tmk_core/protocol/ps2_mouse.c
@@ -147,11 +147,23 @@ static inline void ps2_mouse_convert_report_to_hid(report_mouse_t *mouse_report)
     mouse_report->x = X_IS_NEG ? ((!X_IS_OVF && -127 <= mouse_report->x && mouse_report->x <= -1) ? mouse_report->x : -127) : ((!X_IS_OVF && 0 <= mouse_report->x && mouse_report->x <= 127) ? mouse_report->x : 127);
     mouse_report->y = Y_IS_NEG ? ((!Y_IS_OVF && -127 <= mouse_report->y && mouse_report->y <= -1) ? mouse_report->y : -127) : ((!Y_IS_OVF && 0 <= mouse_report->y && mouse_report->y <= 127) ? mouse_report->y : 127);
 
+#ifdef PS2_MOUSE_INVERT_BUTTONS
+    mouse_report->buttons = ( \
+        // Change right to left
+        BIT_SET_BY(mouse_report->buttons, PS2_MOUSE_BTN_LEFT, PS2_MOUSE_BTN_RIGHT) | \
+        // Change left to right
+        BIT_SET_BY(mouse_report->buttons, PS2_MOUSE_BTN_RIGHT,PS2_MOUSE_BTN_LEFT) | \
+        // Leave the rest untouched
+        BITMASK_CLEAR(mouse_report->buttons, (
+            // Calculate mask for the rest
+            BIT_VALUE(PS2_MOUSE_BTN_MASK, PS2_MOUSE_BTN_LEFT) | \
+            BIT_VALUE(PS2_MOUSE_BTN_MASK, PS2_MOUSE_BTN_RIGHT)
+        ))
+    // remove sign and overflow flags
+    ) & PS2_MOUSE_BTN_MASK;
+#else
     // remove sign and overflow flags
     mouse_report->buttons &= PS2_MOUSE_BTN_MASK;
-
-#ifdef PS2_MOUSE_INVERT_BUTTONS
-    mouse_report->buttons = (mouse_report->buttons >> PS2_MOUSE_BTN_LEFT & 1U) << PS2_MOUSE_BTN_RIGHT | (mouse_report->buttons >> PS2_MOUSE_BTN_RIGHT & 1U) << PS2_MOUSE_BTN_LEFT | (mouse_report->buttons >> PS2_MOUSE_BTN_MIDDLE & 1U) << PS2_MOUSE_BTN_MIDDLE;
 #endif
 
 #ifdef PS2_MOUSE_INVERT_X

--- a/tmk_core/protocol/ps2_mouse.c
+++ b/tmk_core/protocol/ps2_mouse.c
@@ -151,10 +151,7 @@ static inline void ps2_mouse_convert_report_to_hid(report_mouse_t *mouse_report)
     mouse_report->buttons &= PS2_MOUSE_BTN_MASK;
 
 #ifdef PS2_MOUSE_INVERT_BUTTONS
-    int buttons = mouse_report->buttons;
-    buttons |= ((mouse_report->buttons >> PS2_MOUSE_BTN_LEFT) & 1U) << 1;
-    buttons |= (mouse_report->buttons >> PS2_MOUSE_BTN_RIGHT) & 1U;
-    mouse_report->buttons = buttons;
+    mouse_report->buttons = (mouse_report->buttons >> PS2_MOUSE_BTN_LEFT & 1U) << PS2_MOUSE_BTN_RIGHT | (mouse_report->buttons >> PS2_MOUSE_BTN_RIGHT & 1U) << PS2_MOUSE_BTN_LEFT | (mouse_report->buttons >> PS2_MOUSE_BTN_MIDDLE & 1U) << PS2_MOUSE_BTN_MIDDLE;
 #endif
 
 #ifdef PS2_MOUSE_INVERT_X

--- a/tmk_core/protocol/ps2_mouse.c
+++ b/tmk_core/protocol/ps2_mouse.c
@@ -147,13 +147,13 @@ static inline void ps2_mouse_convert_report_to_hid(report_mouse_t *mouse_report)
     mouse_report->x = X_IS_NEG ? ((!X_IS_OVF && -127 <= mouse_report->x && mouse_report->x <= -1) ? mouse_report->x : -127) : ((!X_IS_OVF && 0 <= mouse_report->x && mouse_report->x <= 127) ? mouse_report->x : 127);
     mouse_report->y = Y_IS_NEG ? ((!Y_IS_OVF && -127 <= mouse_report->y && mouse_report->y <= -1) ? mouse_report->y : -127) : ((!Y_IS_OVF && 0 <= mouse_report->y && mouse_report->y <= 127) ? mouse_report->y : 127);
 
-    // remove sign and overflow flags
-    mouse_report->buttons &= PS2_MOUSE_BTN_MASK;
-
 #ifdef PS2_MOUSE_INVERT_BUTTONS
     // swap left & rigth buttons & remove sign and overflow flags
-    uint8_t btns_change = ((mouse_report->buttons >> PS2_MOUSE_BTN_LEFT) ^ (mouse_report->buttons >> PS2_MOUSE_BTN_RIGHT)) & 1;
-    mouse_report->buttons ^= ((btns_change << PS2_MOUSE_BTN_LEFT) | (btns_change << PS2_MOUSE_BTN_RIGHT));
+    uint8_t btns_change   = ((mouse_report->buttons >> PS2_MOUSE_BTN_LEFT) ^ (mouse_report->buttons >> PS2_MOUSE_BTN_RIGHT)) & 1;
+    mouse_report->buttons = (mouse_report->buttons ^ ((btns_change << PS2_MOUSE_BTN_LEFT) | (btns_change << PS2_MOUSE_BTN_RIGHT))) & PS2_MOUSE_BTN_MASK;
+#else
+    // remove sign and overflow flags
+    mouse_report->buttons &= PS2_MOUSE_BTN_MASK;
 #endif
 
 #ifdef PS2_MOUSE_INVERT_X

--- a/tmk_core/protocol/ps2_mouse.c
+++ b/tmk_core/protocol/ps2_mouse.c
@@ -148,21 +148,17 @@ static inline void ps2_mouse_convert_report_to_hid(report_mouse_t *mouse_report)
     mouse_report->y = Y_IS_NEG ? ((!Y_IS_OVF && -127 <= mouse_report->y && mouse_report->y <= -1) ? mouse_report->y : -127) : ((!Y_IS_OVF && 0 <= mouse_report->y && mouse_report->y <= 127) ? mouse_report->y : 127);
 
 #ifdef PS2_MOUSE_INVERT_BUTTONS
-    mouse_report->buttons = ( \
-        // Change right to left
-        BIT_SET_BY(mouse_report->buttons, PS2_MOUSE_BTN_LEFT, PS2_MOUSE_BTN_RIGHT) | \
-        // Change left to right
-        BIT_SET_BY(mouse_report->buttons, PS2_MOUSE_BTN_RIGHT,PS2_MOUSE_BTN_LEFT) | \
-        // Leave the rest untouched
-        BITMASK_CLEAR(mouse_report->buttons, (
-            // Calculate mask for the rest
-            BIT_VALUE(PS2_MOUSE_BTN_MASK, PS2_MOUSE_BTN_LEFT) | \
-            BIT_VALUE(PS2_MOUSE_BTN_MASK, PS2_MOUSE_BTN_RIGHT)
-        ))
-    // remove sign and overflow flags
+    mouse_report->buttons = (
+        /* Change right to left */
+        BIT_SET_BY(mouse_report->buttons, PS2_MOUSE_BTN_LEFT, PS2_MOUSE_BTN_RIGHT) |
+        /* Change left to right */
+        BIT_SET_BY(mouse_report->buttons, PS2_MOUSE_BTN_RIGHT, PS2_MOUSE_BTN_LEFT) |
+        /* Leave the rest */
+        BITMASK_CLEAR(mouse_report->buttons, (BIT_VALUE(PS2_MOUSE_BTN_MASK, PS2_MOUSE_BTN_LEFT) | BIT_VALUE(PS2_MOUSE_BTN_MASK, PS2_MOUSE_BTN_RIGHT)))
+    /* Remove sign and overflow flags */
     ) & PS2_MOUSE_BTN_MASK;
 #else
-    // remove sign and overflow flags
+    /* remove sign and overflow flags */
     mouse_report->buttons &= PS2_MOUSE_BTN_MASK;
 #endif
 

--- a/tmk_core/protocol/ps2_mouse.c
+++ b/tmk_core/protocol/ps2_mouse.c
@@ -36,6 +36,16 @@ static inline void ps2_mouse_clear_report(report_mouse_t *mouse_report);
 static inline void ps2_mouse_enable_scrolling(void);
 static inline void ps2_mouse_scroll_button_task(report_mouse_t *mouse_report);
 
+#ifdef PS2_MOUSE_INVERT_BUTTONS
+/*
+ * LUT for change mouse buttons
+ *
+ * table index is the mouse_report->buttons state from PS2 (after &= PS2_MOUSE_BTN_MASK)
+ * the value replace the mouse_report->buttons before to send to the USB interface
+ */
+static const uint8_t btns_lut[8] = {0b000, 0b010, 0b001, 0b011, 0b100, 0b101, 0b110, 0b111};
+#endif
+
 /* ============================= IMPLEMENTATION ============================ */
 
 /* supports only 3 button mouse at this time */

--- a/tmk_core/protocol/ps2_mouse.c
+++ b/tmk_core/protocol/ps2_mouse.c
@@ -150,6 +150,13 @@ static inline void ps2_mouse_convert_report_to_hid(report_mouse_t *mouse_report)
     // remove sign and overflow flags
     mouse_report->buttons &= PS2_MOUSE_BTN_MASK;
 
+#ifdef PS2_MOUSE_INVERT_BUTTONS
+    int buttons = mouse_report->buttons;
+    buttons |= ((mouse_report->buttons >> PS2_MOUSE_BTN_LEFT) & 1U) << 1;
+    buttons |= (mouse_report->buttons >> PS2_MOUSE_BTN_RIGHT) & 1U;
+    mouse_report->buttons = buttons;
+#endif
+
 #ifdef PS2_MOUSE_INVERT_X
     mouse_report->x = -mouse_report->x;
 #endif

--- a/tmk_core/protocol/ps2_mouse.c
+++ b/tmk_core/protocol/ps2_mouse.c
@@ -36,8 +36,6 @@ static inline void ps2_mouse_clear_report(report_mouse_t *mouse_report);
 static inline void ps2_mouse_enable_scrolling(void);
 static inline void ps2_mouse_scroll_button_task(report_mouse_t *mouse_report);
 
-#endif
-
 /* ============================= IMPLEMENTATION ============================ */
 
 /* supports only 3 button mouse at this time */
@@ -149,13 +147,13 @@ static inline void ps2_mouse_convert_report_to_hid(report_mouse_t *mouse_report)
     mouse_report->x = X_IS_NEG ? ((!X_IS_OVF && -127 <= mouse_report->x && mouse_report->x <= -1) ? mouse_report->x : -127) : ((!X_IS_OVF && 0 <= mouse_report->x && mouse_report->x <= 127) ? mouse_report->x : 127);
     mouse_report->y = Y_IS_NEG ? ((!Y_IS_OVF && -127 <= mouse_report->y && mouse_report->y <= -1) ? mouse_report->y : -127) : ((!Y_IS_OVF && 0 <= mouse_report->y && mouse_report->y <= 127) ? mouse_report->y : 127);
 
-#ifdef PS2_MOUSE_INVERT_BUTTONS
-    // swap left & rigth buttons & remove sign and overflow flags
-    uint8_t btns_change      = ((mouse_report->buttons >> PS2_MOUSE_BTN_LEFT) ^ (mouse_report->buttons >> PS2_MOUSE_BTN_RIGHT)) & 1;
-    mouse_report->buttons = ((btns_change << PS2_MOUSE_BTN_LEFT) | (btns_change << PS2_MOUSE_BTN_RIGHT)) & PS2_MOUSE_BTN_MASK;
-#else
     // remove sign and overflow flags
     mouse_report->buttons &= PS2_MOUSE_BTN_MASK;
+
+#ifdef PS2_MOUSE_INVERT_BUTTONS
+    // swap left & rigth buttons & remove sign and overflow flags
+    uint8_t btns_change = ((mouse_report->buttons >> PS2_MOUSE_BTN_LEFT) ^ (mouse_report->buttons >> PS2_MOUSE_BTN_RIGHT)) & 1;
+    mouse_report->buttons ^= ((btns_change << PS2_MOUSE_BTN_LEFT) | (btns_change << PS2_MOUSE_BTN_RIGHT));
 #endif
 
 #ifdef PS2_MOUSE_INVERT_X

--- a/tmk_core/protocol/ps2_mouse.c
+++ b/tmk_core/protocol/ps2_mouse.c
@@ -148,9 +148,10 @@ static inline void ps2_mouse_convert_report_to_hid(report_mouse_t *mouse_report)
     mouse_report->y = Y_IS_NEG ? ((!Y_IS_OVF && -127 <= mouse_report->y && mouse_report->y <= -1) ? mouse_report->y : -127) : ((!Y_IS_OVF && 0 <= mouse_report->y && mouse_report->y <= 127) ? mouse_report->y : 127);
 
 #ifdef PS2_MOUSE_INVERT_BUTTONS
-    // swap left & rigth buttons & remove sign and overflow flags
-    uint8_t btns_change   = ((mouse_report->buttons >> PS2_MOUSE_BTN_LEFT) ^ (mouse_report->buttons >> PS2_MOUSE_BTN_RIGHT)) & 1;
-    mouse_report->buttons = (mouse_report->buttons ^ ((btns_change << PS2_MOUSE_BTN_LEFT) | (btns_change << PS2_MOUSE_BTN_RIGHT))) & PS2_MOUSE_BTN_MASK;
+    // swap left & right buttons
+    uint8_t needs_left = mouse_report->buttons & PS2_MOUSE_BTN_RIGHT;
+    uint8_t needs_right = mouse_report->buttons & PS2_MOUSE_BTN_LEFT;
+    mouse_report->buttons = (mouse_report->buttons & ~(PS2_MOUSE_BTN_MASK)) | (needs_left ? PS2_MOUSE_BTN_LEFT : 0) | (needs_right ? PS2_MOUSE_BTN_RIGHT : 0);
 #else
     // remove sign and overflow flags
     mouse_report->buttons &= PS2_MOUSE_BTN_MASK;

--- a/tmk_core/protocol/ps2_mouse.h
+++ b/tmk_core/protocol/ps2_mouse.h
@@ -21,17 +21,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <stdbool.h>
 #include "debug.h"
 
-/*
- * Binary manipulation macros
- */
-
-/* a=target variable, b=bit number to act upon 0-n, c=bit number to act upon 0-n */
-#define BIT_SET_BY(a, b, c) ((a >> b & 1U) << c)
-#define BIT_GET(a, b) (a >> b & 1U)
-#define BIT_VALUE(a, b) ((a >> b & 1U) << b)
-/* x=target variable, y=mask */
-#define BITMASK_CLEAR(x,y) ((x) & (~(y)))
-
 #define PS2_MOUSE_SEND(command, message)                                                \
     do {                                                                                \
         __attribute__((unused)) uint8_t rcv = ps2_host_send(command);                   \
@@ -86,14 +75,24 @@ __attribute__((unused)) static enum ps2_mouse_mode_e {
  *    1|[                    X movement(0-255)                         ]
  *    2|[                    Y movement(0-255)                         ]
  */
-#define PS2_MOUSE_BTN_MASK 0x07
-#define PS2_MOUSE_BTN_LEFT 0
-#define PS2_MOUSE_BTN_RIGHT 1
-#define PS2_MOUSE_BTN_MIDDLE 2
-#define PS2_MOUSE_X_SIGN 4
-#define PS2_MOUSE_Y_SIGN 5
-#define PS2_MOUSE_X_OVFLW 6
-#define PS2_MOUSE_Y_OVFLW 7
+#define PS2_MOUSE_BTN_MASK 0x07 // 0b0000111
+#define PS2_MOUSE_BTN_LEFT 0    // 0b0000001
+#define PS2_MOUSE_BTN_RIGHT 1   // 0b0000010
+#define PS2_MOUSE_BTN_MIDDLE 2  // 0b0000100
+#define PS2_MOUSE_X_SIGN 4      // 0b0001000
+#define PS2_MOUSE_Y_SIGN 5      // 0b0010000
+#define PS2_MOUSE_X_OVFLW 6     // 0b0100000
+#define PS2_MOUSE_Y_OVFLW 7     // 0b1000000
+
+#ifdef PS2_MOUSE_INVERT_BUTTONS
+/*
+ * LUT for change mouse buttons
+ *
+ * table index is the mouse_report->buttons state from PS2 (after &= PS2_MOUSE_BTN_MASK)
+ * the value replace the mouse_report->buttons before to send to the USB interface
+ */
+static const __attribute__((unused)) uint8_t btns_lut[8] = {0b000, 0b010, 0b001, 0b011, 0b100, 0b101, 0b110, 0b111};
+#endif
 
 /* mouse button to start scrolling; set 0 to disable scroll */
 #ifndef PS2_MOUSE_SCROLL_BTN_MASK

--- a/tmk_core/protocol/ps2_mouse.h
+++ b/tmk_core/protocol/ps2_mouse.h
@@ -75,24 +75,14 @@ __attribute__((unused)) static enum ps2_mouse_mode_e {
  *    1|[                    X movement(0-255)                         ]
  *    2|[                    Y movement(0-255)                         ]
  */
-#define PS2_MOUSE_BTN_MASK 0x07 // 0b0000111
-#define PS2_MOUSE_BTN_LEFT 0    // 0b0000001
-#define PS2_MOUSE_BTN_RIGHT 1   // 0b0000010
-#define PS2_MOUSE_BTN_MIDDLE 2  // 0b0000100
-#define PS2_MOUSE_X_SIGN 4      // 0b0001000
-#define PS2_MOUSE_Y_SIGN 5      // 0b0010000
-#define PS2_MOUSE_X_OVFLW 6     // 0b0100000
-#define PS2_MOUSE_Y_OVFLW 7     // 0b1000000
-
-#ifdef PS2_MOUSE_INVERT_BUTTONS
-/*
- * LUT for change mouse buttons
- *
- * table index is the mouse_report->buttons state from PS2 (after &= PS2_MOUSE_BTN_MASK)
- * the value replace the mouse_report->buttons before to send to the USB interface
- */
-static const __attribute__((unused)) uint8_t btns_lut[8] = {0b000, 0b010, 0b001, 0b011, 0b100, 0b101, 0b110, 0b111};
-#endif
+#define PS2_MOUSE_BTN_MASK 0x07
+#define PS2_MOUSE_BTN_LEFT 0
+#define PS2_MOUSE_BTN_RIGHT 1
+#define PS2_MOUSE_BTN_MIDDLE 2
+#define PS2_MOUSE_X_SIGN 4
+#define PS2_MOUSE_Y_SIGN 5
+#define PS2_MOUSE_X_OVFLW 6
+#define PS2_MOUSE_Y_OVFLW 7
 
 /* mouse button to start scrolling; set 0 to disable scroll */
 #ifndef PS2_MOUSE_SCROLL_BTN_MASK

--- a/tmk_core/protocol/ps2_mouse.h
+++ b/tmk_core/protocol/ps2_mouse.h
@@ -21,6 +21,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <stdbool.h>
 #include "debug.h"
 
+/*
+ * Binary manipulation macros
+ */
+
+/* a=target variable, b=bit number to act upon 0-n, c=bit number to act upon 0-n */
+#define BIT_SET_BY(a, b, c) ((a >> b & 1U) << c)
+#define BIT_GET(a, b) (a >> b & 1U)
+#define BIT_VALUE(a, b) ((a >> b & 1U) << b)
+/* x=target variable, y=mask */
+#define BITMASK_CLEAR(x,y) ((x) & (~(y)))
+
 #define PS2_MOUSE_SEND(command, message)                                                \
     do {                                                                                \
         __attribute__((unused)) uint8_t rcv = ps2_host_send(command);                   \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This add the config parameter PS2_MOUSE_INVERT_BUTTONS that invert the left & right button on the PS2 mouse.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/qmk/qmk_firmware/issues/9204

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
