### PR TITLE
Fix crkbd slave matrix print to require debug_matrix

### DIFF
--- a/keyboards/crkbd/rev1/split_scomm.c
+++ b/keyboards/crkbd/rev1/split_scomm.c
@@ -8,8 +8,7 @@
 #include <split_scomm.h>
 #include "serial.h"
 #ifdef CONSOLE_ENABLE
-  #include <print.h>
-  #include <debug.h>
+  #include "debug.h"
 #endif
 
 uint8_t volatile serial_slave_buffer[SERIAL_SLAVE_BUFFER_LENGTH] = {0};

--- a/keyboards/crkbd/rev1/split_scomm.c
+++ b/keyboards/crkbd/rev1/split_scomm.c
@@ -9,6 +9,7 @@
 #include "serial.h"
 #ifdef CONSOLE_ENABLE
   #include <print.h>
+  #include <debug.h>
 #endif
 
 uint8_t volatile serial_slave_buffer[SERIAL_SLAVE_BUFFER_LENGTH] = {0};
@@ -63,9 +64,11 @@ int serial_update_buffers(int master_update)
         if( smatstatus == TRANSACTION_END ) {
             s_change_old = s_change_new;
 #ifdef CONSOLE_ENABLE
-            uprintf("slave matrix = %b %b %b %b\n",
+            if (debug_matrix) {
+                uprintf("slave matrix = %b %b %b %b\n",
                     serial_slave_buffer[0], serial_slave_buffer[1],
                     serial_slave_buffer[2], serial_slave_buffer[3]);
+            }
 #endif
         }
     } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
The crkbd prints slave matrix debug info with CONSOLE_ENABLE.  This change only prints with debug_matrix.
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
