### PR TITLE
Fix running qmk info without any arguments

### DIFF
--- a/lib/python/qmk/cli/info.py
+++ b/lib/python/qmk/cli/info.py
@@ -84,8 +84,13 @@ def info(cli):
     """Compile an info.json for a particular keyboard and pretty-print it.
     """
     # Determine our keyboard(s)
+    if not cli.config.info.keyboard:
+        cli.log.error('Missing paramater: --keyboard')
+        cli.subcommands['info'].print_help()
+        exit(1)
+
     if not is_keyboard(cli.config.info.keyboard):
-        cli.log.error('Invalid keyboard: %s!', cli.config.info.keyboard)
+        cli.log.error('Invalid keyboard: "%s"', cli.config.info.keyboard)
         exit(1)
 
     # Build the info.json file

--- a/lib/python/qmk/cli/info.py
+++ b/lib/python/qmk/cli/info.py
@@ -72,6 +72,53 @@ def show_matrix(info_json, title_caps=True):
         print(render_layout(info_json['layouts'][layout_name]['layout'], labels))
 
 
+def print_friendly_output(info_json):
+    """Print the info.json in a friendly text format.
+    """
+    cli.echo('{fg_blue}Keyboard Name{fg_reset}: %s', info_json.get('keyboard_name', 'Unknown'))
+    cli.echo('{fg_blue}Manufacturer{fg_reset}: %s', info_json.get('manufacturer', 'Unknown'))
+    if 'url' in info_json:
+        cli.echo('{fg_blue}Website{fg_reset}: %s', info_json.get('url', ''))
+    if info_json.get('maintainer', 'qmk') == 'qmk':
+        cli.echo('{fg_blue}Maintainer{fg_reset}: QMK Community')
+    else:
+        cli.echo('{fg_blue}Maintainer{fg_reset}: %s', info_json['maintainer'])
+    cli.echo('{fg_blue}Keyboard Folder{fg_reset}: %s', info_json.get('keyboard_folder', 'Unknown'))
+    cli.echo('{fg_blue}Layouts{fg_reset}: %s', ', '.join(sorted(info_json['layouts'].keys())))
+    if 'width' in info_json and 'height' in info_json:
+        cli.echo('{fg_blue}Size{fg_reset}: %s x %s' % (info_json['width'], info_json['height']))
+    cli.echo('{fg_blue}Processor{fg_reset}: %s', info_json.get('processor', 'Unknown'))
+    cli.echo('{fg_blue}Bootloader{fg_reset}: %s', info_json.get('bootloader', 'Unknown'))
+
+    if cli.config.info.layouts:
+        show_layouts(info_json, True)
+
+    if cli.config.info.matrix:
+        show_matrix(info_json, True)
+
+    if cli.config_source.info.keymap and cli.config_source.info.keymap != 'config_file':
+        show_keymap(info_json, True)
+
+
+def print_text_output(info_json):
+    """Print the info.json in a plain text format.
+    """
+    for key in sorted(info_json):
+        if key == 'layouts':
+            cli.echo('{fg_blue}layouts{fg_reset}: %s', ', '.join(sorted(info_json['layouts'].keys())))
+        else:
+            cli.echo('{fg_blue}%s{fg_reset}: %s', key, info_json[key])
+
+    if cli.config.info.layouts:
+        show_layouts(info_json, False)
+
+    if cli.config.info.matrix:
+        show_matrix(info_json, False)
+
+    if cli.config_source.info.keymap and cli.config_source.info.keymap != 'config_file':
+        show_keymap(info_json, False)
+
+
 @cli.argument('-kb', '--keyboard', help='Keyboard to show info for.')
 @cli.argument('-km', '--keymap', help='Show the layers for a JSON keymap too.')
 @cli.argument('-l', '--layouts', action='store_true', help='Render the layouts.')
@@ -102,45 +149,10 @@ def info(cli):
         exit()
 
     if cli.args.format == 'text':
-        for key in sorted(kb_info_json):
-            if key == 'layouts':
-                cli.echo('{fg_blue}layouts{fg_reset}: %s', ', '.join(sorted(kb_info_json['layouts'].keys())))
-            else:
-                cli.echo('{fg_blue}%s{fg_reset}: %s', key, kb_info_json[key])
-
-        if cli.config.info.layouts:
-            show_layouts(kb_info_json, False)
-
-        if cli.config.info.matrix:
-            show_matrix(kb_info_json, False)
-
-        if cli.config_source.info.keymap and cli.config_source.info.keymap != 'config_file':
-            show_keymap(kb_info_json, False)
+        print_text_output(kb_info_json)
 
     elif cli.args.format == 'friendly':
-        cli.echo('{fg_blue}Keyboard Name{fg_reset}: %s', kb_info_json.get('keyboard_name', 'Unknown'))
-        cli.echo('{fg_blue}Manufacturer{fg_reset}: %s', kb_info_json.get('manufacturer', 'Unknown'))
-        if 'url' in kb_info_json:
-            cli.echo('{fg_blue}Website{fg_reset}: %s', kb_info_json['url'])
-        if kb_info_json.get('maintainer') == 'qmk':
-            cli.echo('{fg_blue}Maintainer{fg_reset}: QMK Community')
-        else:
-            cli.echo('{fg_blue}Maintainer{fg_reset}: %s', kb_info_json.get('maintainer', 'qmk'))
-        cli.echo('{fg_blue}Keyboard Folder{fg_reset}: %s', kb_info_json.get('keyboard_folder', 'Unknown'))
-        cli.echo('{fg_blue}Layouts{fg_reset}: %s', ', '.join(sorted(kb_info_json['layouts'].keys())))
-        if 'width' in kb_info_json and 'height' in kb_info_json:
-            cli.echo('{fg_blue}Size{fg_reset}: %s x %s' % (kb_info_json['width'], kb_info_json['height']))
-        cli.echo('{fg_blue}Processor{fg_reset}: %s', kb_info_json.get('processor', 'Unknown'))
-        cli.echo('{fg_blue}Bootloader{fg_reset}: %s', kb_info_json.get('bootloader', 'Unknown'))
-
-        if cli.config.info.layouts:
-            show_layouts(kb_info_json, True)
-
-        if cli.config.info.matrix:
-            show_matrix(kb_info_json, True)
-
-        if cli.config_source.info.keymap and cli.config_source.info.keymap != 'config_file':
-            show_keymap(kb_info_json, True)
+        print_friendly_output(kb_info_json)
 
     else:
         cli.log.error('Unknown format: %s', cli.args.format)

--- a/lib/python/qmk/path.py
+++ b/lib/python/qmk/path.py
@@ -11,9 +11,10 @@ from qmk.errors import NoSuchKeyboardError
 def is_keyboard(keyboard_name):
     """Returns True if `keyboard_name` is a keyboard we can compile.
     """
-    keyboard_path = QMK_FIRMWARE / 'keyboards' / keyboard_name
-    rules_mk = keyboard_path / 'rules.mk'
-    return rules_mk.exists()
+    if keyboard_name:
+        keyboard_path = QMK_FIRMWARE / 'keyboards' / keyboard_name
+        rules_mk = keyboard_path / 'rules.mk'
+        return rules_mk.exists()
 
 
 def under_qmk_firmware():


### PR DESCRIPTION

## Description

Currently `qmk info` will crash if run without --keyboard. This fixes that.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
