### PR TITLE
Add new dual layer keymap for xd002 macropad

### DIFF
--- a/keyboards/xd002/keymaps/multilayer_rgb/config.h
+++ b/keyboards/xd002/keymaps/multilayer_rgb/config.h
@@ -1,0 +1,21 @@
+/* Copyright 2020 elmo-space<mail@elmo.space>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*enable layers*/
+#undef NO_ACTION_LAYER
+
+/* increase tap duration (spotify doesn't like very short taps)*/
+#define TAP_CODE_DELAY 100

--- a/keyboards/xd002/keymaps/multilayer_rgb/keymap.c
+++ b/keyboards/xd002/keymaps/multilayer_rgb/keymap.c
@@ -1,0 +1,169 @@
+/* Copyright 2020 elmo-space<mail@elmo.space>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include QMK_KEYBOARD_H
+#include "rgblite.h"
+
+#define _FUNC 1
+
+// set your keycodes here
+#define layer1_left  KC_PAUS
+#define layer1_right KC_MPLY
+#define layer2_left  KC_MPRV
+#define layer2_right KC_MNXT
+
+
+enum custom_keycodes {
+  LEFT1,
+  RIGHT1,
+  LEFT2,
+  RIGHT2
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  [0] = LAYOUT(
+    LEFT1,  RIGHT1
+  ),
+  [1] = LAYOUT(
+    LEFT2,  RIGHT2
+  )
+};
+
+static bool key1_down = false;
+static bool key2_down = false;
+static char layer_switched = 0; // this prevents the individual keys getting triggered after a layerchange
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record)
+{
+    switch (keycode)
+    {
+    case LEFT1:
+        if (record->event.pressed)
+        {
+            if (key2_down)
+            {
+                layer_on(1);
+                layer_switched = 2;
+                return false;
+                break;
+            }
+            key1_down = true;
+        }
+        else {
+            if (layer_switched > 0) {
+                --layer_switched;
+                key1_down = false;
+            }
+            else {
+                tap_code(layer1_left);
+                key1_down = false;
+            }
+        }
+        return false;
+        break;
+    case RIGHT1:
+        if (record->event.pressed)
+        {
+            if (key1_down)
+            {
+                layer_on(1);
+                layer_switched = 2;
+                return false;
+                break;
+            }
+            key2_down = true;
+        }
+        else {
+            if (layer_switched > 0) {
+                --layer_switched;
+                key2_down = false;
+            }
+            else {
+                tap_code(layer1_right);
+                key2_down = false;
+            }
+        }
+        return false;
+        break;
+    case LEFT2:
+        if (record->event.pressed)
+        {
+            if (key2_down)
+            {
+                layer_off(1);
+                layer_switched = 2;
+                return false;
+                break;
+            }
+            key1_down = true;
+        }
+        else {
+            if (layer_switched > 0) {
+                --layer_switched;
+                key1_down = false;
+            }
+            else {
+                tap_code(layer2_left);
+                key1_down = false;
+            }
+        }
+        return false;
+        break;
+    case RIGHT2:
+        if (record->event.pressed)
+        {
+            if (key1_down)
+            {
+                layer_off(1);
+                layer_switched = 2;
+                return false;
+                break;
+            }
+            key2_down = true;
+        }
+        else {
+            if (layer_switched > 0) {
+                --layer_switched;
+                key2_down = false;
+            }
+            else {
+                tap_code(layer2_right);
+                key2_down = false;
+            }
+        }
+        return false;
+        break;
+    }
+    return true;
+};
+
+// layer colors
+layer_state_t layer_state_set_user(layer_state_t state) {
+    switch (biton(state)) {
+    case _FUNC:
+        rgblight_setrgb_red();
+        break;
+    default: //  for any other layers, or the default layer
+        rgblight_setrgb_green();
+        break;
+    }
+  return state;
+}
+
+// default color
+void keyboard_post_init_user(void) {
+    rgblight_setrgb_green();
+}

--- a/keyboards/xd002/keymaps/multilayer_rgb/rgblite.h
+++ b/keyboards/xd002/keymaps/multilayer_rgb/rgblite.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "ws2812.h"
+#include "rgblight_list.h"
+
+static inline void rgblight_setrgb(uint8_t _r, uint8_t _g, uint8_t _b) {
+    LED_TYPE leds[RGBLED_NUM] = {{.r = _r, .g = _g, .b = _b}, {.r = _r, .g = _g, .b = _b}};
+    ws2812_setleds(leds, RGBLED_NUM);
+}

--- a/keyboards/xd002/keymaps/multilayer_rgb/rules.mk
+++ b/keyboards/xd002/keymaps/multilayer_rgb/rules.mk
@@ -1,0 +1,2 @@
+SRC += ws2812.c
+EXTRAKEY_ENABLE = yes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Added a new keymap for the xd002 macropad that adds a second layer and enables RGB.
The layers can be switched by pressing both buttons at the same time and the active layer is indicated by the RGB color.
This keymap gives the user a total of four usable keycodes on the pad which increases the usablility of that small thing a lot.

The firmware uses almost the entire flash of the Attiny with only 230 bytes left free.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
