### PR TITLE
Move dip switch init to back of the init process

### DIFF
--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -630,9 +630,6 @@ void matrix_init_quantum() {
 #ifdef OUTPUT_AUTO_ENABLE
     set_output(OUTPUT_AUTO);
 #endif
-#ifdef DIP_SWITCH_ENABLE
-    dip_switch_init();
-#endif
 
     matrix_init_kb();
 }

--- a/tmk_core/common/keyboard.c
+++ b/tmk_core/common/keyboard.c
@@ -86,6 +86,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifdef VIA_ENABLE
 #    include "via.h"
 #endif
+#ifdef DIP_SWITCH_ENABLE
+#    include "dip_switch.h"
+#endif
 
 // Only enable this if console is enabled to print to
 #if defined(DEBUG_MATRIX_SCAN_RATE) && defined(CONSOLE_ENABLE)
@@ -269,6 +272,10 @@ void keyboard_init(void) {
     keymap_config.nkro = 1;
     eeconfig_update_keymap(keymap_config.raw);
 #endif
+#ifdef DIP_SWITCH_ENABLE
+    dip_switch_init();
+#endif
+
     keyboard_post_init_kb(); /* Always keep this last */
 }
 


### PR DESCRIPTION
## Description

Init's too early to be able to set a number of settings. 

This moves it to the very end (well, almost), so that everything else is inited
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* discord chat

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
