### PR TITLE
Fix layer mask size for RGBLIGHT_LAYER_BLINK

### DIFF
--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -672,9 +672,9 @@ static void rgblight_layers_write(void) {
 }
 
 #    ifdef RGBLIGHT_LAYER_BLINK
-uint8_t         _blinked_layer_mask = 0;
-uint16_t        _blink_duration     = 0;
-static uint16_t _blink_timer;
+rgblight_layer_mask_t _blinked_layer_mask = 0;
+uint16_t              _blink_duration     = 0;
+static uint16_t       _blink_timer;
 
 void rgblight_blink_layer(uint8_t layer, uint16_t duration_ms) {
     rgblight_set_layer_state(layer, true);


### PR DESCRIPTION
## Description

The blinked layer mask had the wrong size if RGBLIGHT_MAX_LAYERS > 8, potentially leading to incorrect behavior.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
