### PR TITLE
Fix error_log complaint about handwired/onekey layout macro

### DIFF
--- a/keyboards/handwired/onekey/keymaps/adc/keymap.c
+++ b/keyboards/handwired/onekey/keymaps/adc/keymap.c
@@ -7,7 +7,7 @@ enum custom_keycodes {
 };
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    LAYOUT(ADC_SAMPLE)  //
+    LAYOUT_ortho_1x1(ADC_SAMPLE)
 };
 
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
@@ -16,7 +16,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             if (record->event.pressed) {
                 int16_t val = analogReadPin(ADC_PIN);
 
-                char buffer [50];
+                char buffer[50];
                 sprintf(buffer, "ADC:%u\n", val);
 #ifdef CONSOLE_ENABLE
                     printf(buffer);
@@ -30,5 +30,5 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 };
 
 // adc_mux pinToMux(pin_t pin) {
-//     return TO_MUX( ADC_CHANNEL_IN1,  0 );
+//     return TO_MUX(ADC_CHANNEL_IN1, 0);
 // };

--- a/keyboards/handwired/onekey/keymaps/backlight/keymap.c
+++ b/keyboards/handwired/onekey/keymaps/backlight/keymap.c
@@ -2,39 +2,38 @@
 
 //Tap Dance Declarations
 enum {
-  TD_BL = 0
+    TD_BL = 0
 };
 
-void dance_cln_finished (qk_tap_dance_state_t *state, void *user_data) {
-  // noop
+void dance_cln_finished(qk_tap_dance_state_t *state, void *user_data) {
+    // noop
 }
 
-void dance_cln_reset (qk_tap_dance_state_t *state, void *user_data) {
-  switch (state->count) {
-    case 1:
-      // single tap - step through backlight
-      backlight_step();
-      break;
+void dance_cln_reset(qk_tap_dance_state_t *state, void *user_data) {
+    switch (state->count) {
+        case 1:
+            // single tap - step through backlight
+            backlight_step();
+            break;
 #ifdef BACKLIGHT_BREATHING
-    case 2:
-      // double tap - toggle breathing
-      breathing_toggle();
-      break;
-    case 3:
-      //tripple tap - do some pulse stuff
-      breathing_pulse();
-      break;
+        case 2:
+            // double tap - toggle breathing
+            breathing_toggle();
+            break;
+        case 3:
+            // triple tap - do some pulse stuff
+            breathing_pulse();
+            break;
 #endif
-    default:
-      // more - nothing
-      break;
-  }
+        default:
+            break;
+    }
 }
 
 qk_tap_dance_action_t tap_dance_actions[] = {
-  [TD_BL]  = ACTION_TAP_DANCE_FN_ADVANCED (NULL, dance_cln_finished, dance_cln_reset)
+    [TD_BL]  = ACTION_TAP_DANCE_FN_ADVANCED(NULL, dance_cln_finished, dance_cln_reset)
 };
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-  LAYOUT( TD(TD_BL) )
+    LAYOUT_ortho_1x1(TD(TD_BL))
 };

--- a/keyboards/handwired/onekey/keymaps/default/keymap.c
+++ b/keyboards/handwired/onekey/keymaps/default/keymap.c
@@ -1,5 +1,5 @@
 #include QMK_KEYBOARD_H
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-  LAYOUT( KC_A )
+    LAYOUT_ortho_1x1(KC_A)
 };

--- a/keyboards/handwired/onekey/keymaps/default_json/keymap.json
+++ b/keyboards/handwired/onekey/keymaps/default_json/keymap.json
@@ -1,9 +1,9 @@
 {
- "keyboard":"handwired/onekey/pytest",
- "keymap":"default_json",
- "layout":"LAYOUT_ortho_1x1",
- "layers":[["KC_A"]],
- "author":"qmk",
- "notes":"This file is a keymap.json file for handwired/onekey/pytest",
- "version":1
+    "keyboard": "handwired/onekey/pytest",
+    "keymap": "default_json",
+    "layout": "LAYOUT_ortho_1x1",
+    "layers": [["KC_A"]],
+    "author": "qmk",
+    "notes": "This file is a keymap.json file for handwired/onekey/pytest",
+    "version": 1
 }

--- a/keyboards/handwired/onekey/keymaps/default_json/keymap.json
+++ b/keyboards/handwired/onekey/keymaps/default_json/keymap.json
@@ -1,7 +1,7 @@
 {
  "keyboard":"handwired/onekey/pytest",
  "keymap":"default_json",
- "layout":"LAYOUT",
+ "layout":"LAYOUT_ortho_1x1",
  "layers":[["KC_A"]],
  "author":"qmk",
  "notes":"This file is a keymap.json file for handwired/onekey/pytest",

--- a/keyboards/handwired/onekey/keymaps/eep_rst/keymap.c
+++ b/keyboards/handwired/onekey/keymaps/eep_rst/keymap.c
@@ -1,5 +1,5 @@
 #include QMK_KEYBOARD_H
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-  LAYOUT( EEP_RST )
+    LAYOUT_ortho_1x1(EEP_RST)
 };

--- a/keyboards/handwired/onekey/keymaps/i2c_scanner/keymap.c
+++ b/keyboards/handwired/onekey/keymaps/i2c_scanner/keymap.c
@@ -21,7 +21,7 @@ i2c_status_t i2c_start_bodge(uint8_t address, uint16_t timeout) {
 #endif
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    LAYOUT(KC_A)  //
+    LAYOUT_ortho_1x1(KC_A)
 };
 
 void do_scan(void) {

--- a/keyboards/handwired/onekey/keymaps/reset/keymap.c
+++ b/keyboards/handwired/onekey/keymaps/reset/keymap.c
@@ -1,5 +1,5 @@
 #include QMK_KEYBOARD_H
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-  LAYOUT( RESET )
+    LAYOUT_ortho_1x1(RESET)
 };

--- a/keyboards/handwired/onekey/keymaps/rgb/keymap.c
+++ b/keyboards/handwired/onekey/keymaps/rgb/keymap.c
@@ -1,11 +1,11 @@
 #include QMK_KEYBOARD_H
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-  LAYOUT( RGB_MOD )
+    LAYOUT_ortho_1x1(RGB_MOD)
 };
 
 void keyboard_post_init_user(void) {
-  rgblight_enable_noeeprom();
-  rgblight_sethsv_noeeprom_cyan();
-  rgblight_mode_noeeprom(RGBLIGHT_MODE_RAINBOW_SWIRL);
+    rgblight_enable_noeeprom();
+    rgblight_sethsv_noeeprom_cyan();
+    rgblight_mode_noeeprom(RGBLIGHT_MODE_RAINBOW_SWIRL);
 }

--- a/keyboards/handwired/onekey/onekey.h
+++ b/keyboards/handwired/onekey/onekey.h
@@ -18,8 +18,8 @@
 
 #include "quantum.h"
 
-#define LAYOUT( \
+#define LAYOUT_ortho_1x1( \
     k00 \
-  ) { \
-    { k00 }  \
+) { \
+    { k00 } \
 }

--- a/layouts/community/ortho_1x1/test/keymap.c
+++ b/layouts/community/ortho_1x1/test/keymap.c
@@ -2,11 +2,6 @@
 
 /* This keyboard/layout is used to test community layout discovery/compilation. */
 
-#define _DEFAULT 0
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-
-[_DEFAULT] = LAYOUT (
-    KC_B
-),
+    LAYOUT_ortho_1x1(KC_B)
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

```
Error: handwired/onekey: Missing layout pp macro for ['ortho_1x1']
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
