### PR TITLE
Fix ssd1306 compilation on avr-gcc 10

### DIFF
--- a/drivers/avr/ssd1306.c
+++ b/drivers/avr/ssd1306.c
@@ -14,6 +14,8 @@
 #    include "sendchar.h"
 #    include "timer.h"
 
+struct CharacterMatrix display;
+
 // Set this to 1 to help diagnose early startup problems
 // when testing power-on with ble.  Turn it off otherwise,
 // as the latency of printing most of the debug info messes

--- a/drivers/avr/ssd1306.h
+++ b/drivers/avr/ssd1306.h
@@ -66,7 +66,7 @@ struct CharacterMatrix {
     bool     dirty;
 };
 
-struct CharacterMatrix display;
+extern struct CharacterMatrix display;
 
 bool iota_gfx_init(void);
 void iota_gfx_task(void);

--- a/keyboards/claw44/ssd1306.c
+++ b/keyboards/claw44/ssd1306.c
@@ -13,6 +13,8 @@
 #include "sendchar.h"
 #include "timer.h"
 
+struct CharacterMatrix display;
+
 extern const unsigned char font[] PROGMEM;
 
 // Set this to 1 to help diagnose early startup problems

--- a/keyboards/claw44/ssd1306.h
+++ b/keyboards/claw44/ssd1306.h
@@ -65,7 +65,7 @@ struct CharacterMatrix {
   bool dirty;
 };
 
-struct CharacterMatrix display;
+extern struct CharacterMatrix display;
 
 bool iota_gfx_init(bool rotate);
 void iota_gfx_task(void);

--- a/keyboards/comet46/ssd1306.c
+++ b/keyboards/comet46/ssd1306.c
@@ -13,6 +13,8 @@
 #include "sendchar.h"
 #include "timer.h"
 
+struct CharacterMatrix display;
+
 extern const unsigned char font[] PROGMEM;
 
 // Set this to 1 to help diagnose early startup problems

--- a/keyboards/comet46/ssd1306.h
+++ b/keyboards/comet46/ssd1306.h
@@ -65,7 +65,7 @@ struct CharacterMatrix {
   bool dirty;
 };
 
-struct CharacterMatrix display;
+extern struct CharacterMatrix display;
 
 bool iota_gfx_init(bool rotate);
 void iota_gfx_task(void);

--- a/keyboards/crkbd/ssd1306.c
+++ b/keyboards/crkbd/ssd1306.c
@@ -13,6 +13,8 @@
 #include "sendchar.h"
 #include "timer.h"
 
+struct CharacterMatrix display;
+
 extern const unsigned char font[] PROGMEM;
 
 #ifndef OLED_BLANK_CHAR

--- a/keyboards/crkbd/ssd1306.h
+++ b/keyboards/crkbd/ssd1306.h
@@ -65,7 +65,7 @@ struct CharacterMatrix {
   bool dirty;
 };
 
-struct CharacterMatrix display;
+extern struct CharacterMatrix display;
 
 bool iota_gfx_init(bool rotate);
 void iota_gfx_task(void);

--- a/keyboards/helix/local_drivers/ssd1306.c
+++ b/keyboards/helix/local_drivers/ssd1306.c
@@ -19,6 +19,8 @@
 #include "sendchar.h"
 #include "timer.h"
 
+struct CharacterMatrix display;
+
 // Set this to 1 to help diagnose early startup problems
 // when testing power-on with ble.  Turn it off otherwise,
 // as the latency of printing most of the debug info messes

--- a/keyboards/helix/local_drivers/ssd1306.h
+++ b/keyboards/helix/local_drivers/ssd1306.h
@@ -66,7 +66,7 @@ struct CharacterMatrix {
   bool dirty;
 };
 
-struct CharacterMatrix display;
+extern struct CharacterMatrix display;
 
 bool iota_gfx_init(bool rotate);
 void iota_gfx_task(void);

--- a/keyboards/yosino58/ssd1306.c
+++ b/keyboards/yosino58/ssd1306.c
@@ -13,6 +13,8 @@
 #include "sendchar.h"
 #include "timer.h"
 
+struct CharacterMatrix display;
+
 extern const unsigned char font[] PROGMEM;
 
 // Set this to 1 to help diagnose early startup problems

--- a/keyboards/yosino58/ssd1306.h
+++ b/keyboards/yosino58/ssd1306.h
@@ -70,7 +70,7 @@ struct CharacterMatrix {
   bool dirty;
 };
 
-struct CharacterMatrix display;
+extern struct CharacterMatrix display;
 
 bool iota_gfx_init(bool rotate);
 void iota_gfx_task(void);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
From #9147,

```console
Linking: .build/crkbd_rev1_default.elf                                                              [ERRORS]
 | 
 | /usr/bin/avr-ld: .build/obj_crkbd_rev1_default/./lib/layer_state_reader.o:/home/nihilazo/projects/qmk_firmware/keyboards/crkbd/ssd1306.h:68: multiple definition of `display'; .build/obj_crkbd_rev1_default/ssd1306.o:/home/nihilazo/projects/qmk_firmware/keyboards/crkbd/ssd1306.h:68: first defined here
 | /usr/bin/avr-ld: .build/obj_crkbd_rev1_default/./lib/logo_reader.o:/home/nihilazo/projects/qmk_firmware/keyboards/crkbd/ssd1306.h:68: multiple definition of `display'; .build/obj_crkbd_rev1_default/ssd1306.o:/home/nihilazo/projects/qmk_firmware/keyboards/crkbd/ssd1306.h:68: first defined here
 | /usr/bin/avr-ld: .build/obj_crkbd_rev1_default/./lib/keylogger.o:/home/nihilazo/projects/qmk_firmware/keyboards/crkbd/ssd1306.h:68: multiple definition of `display'; .build/obj_crkbd_rev1_default/ssd1306.o:/home/nihilazo/projects/qmk_firmware/keyboards/crkbd/ssd1306.h:68: first defined here
 | /usr/bin/avr-ld: .build/obj_crkbd_rev1_default/keyboards/crkbd/crkbd.o:/home/nihilazo/projects/qmk_firmware/keyboards/crkbd/ssd1306.h:68: multiple definition of `display'; .build/obj_crkbd_rev1_default/ssd1306.o:/home/nihilazo/projects/qmk_firmware/keyboards/crkbd/ssd1306.h:68: first defined here
 | /usr/bin/avr-ld: .build/obj_crkbd_rev1_default/keyboards/crkbd/rev1/rev1.o:/home/nihilazo/projects/qmk_firmware/keyboards/crkbd/ssd1306.h:68: multiple definition of `display'; .build/obj_crkbd_rev1_default/ssd1306.o:/home/nihilazo/projects/qmk_firmware/keyboards/crkbd/ssd1306.h:68: first defined here
 | /usr/bin/avr-ld: .build/obj_crkbd_rev1_default/keyboards/crkbd/keymaps/default/keymap.o:/home/nihilazo/projects/qmk_firmware/keyboards/crkbd/ssd1306.h:68: multiple definition of `display'; .build/obj_crkbd_rev1_default/ssd1306.o:/home/nihilazo/projects/qmk_firmware/keyboards/crkbd/ssd1306.h:68: first defined here
 | collect2: error: ld returned 1 exit status
 | 
make[1]: *** [tmk_core/rules.mk:306: .build/crkbd_rev1_default.elf] Error 1
Make finished with errors
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #9147

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
