### PR TITLE
Fix TWIlib compilation on avr-gcc 10

### DIFF
--- a/keyboards/lfkeyboards/TWIlib.c
+++ b/keyboards/lfkeyboards/TWIlib.c
@@ -11,6 +11,19 @@
 #include "util/delay.h"
 #include "print.h"
 
+// Global transmit buffer
+volatile uint8_t *TWITransmitBuffer;
+// Global receive buffer
+volatile uint8_t TWIReceiveBuffer[RXMAXBUFLEN];
+// Buffer indexes
+volatile int TXBuffIndex; // Index of the transmit buffer. Is volatile, can change at any time.
+int RXBuffIndex; // Current index in the receive buffer
+// Buffer lengths
+int TXBuffLen; // The total length of the transmit buffer
+int RXBuffLen; // The total number of bytes to read (should be less than RXMAXBUFFLEN)
+
+TWIInfoStruct TWIInfo;
+
 void TWIInit()
 {
 	TWIInfo.mode = Ready;

--- a/keyboards/lfkeyboards/TWIlib.h
+++ b/keyboards/lfkeyboards/TWIlib.h
@@ -16,16 +16,6 @@
 #define TXMAXBUFLEN 20
 // Receive buffer length
 #define RXMAXBUFLEN 20
-// Global transmit buffer
-volatile uint8_t *TWITransmitBuffer;
-// Global receive buffer
-volatile uint8_t TWIReceiveBuffer[RXMAXBUFLEN];
-// Buffer indexes
-volatile int TXBuffIndex; // Index of the transmit buffer. Is volatile, can change at any time.
-int RXBuffIndex; // Current index in the receive buffer
-// Buffer lengths
-int TXBuffLen; // The total length of the transmit buffer
-int RXBuffLen; // The total number of bytes to read (should be less than RXMAXBUFFLEN)
 
 typedef enum {
 	Ready,
@@ -42,8 +32,8 @@ typedef enum {
 	uint8_t errorCode;
 	uint8_t repStart;
 	}TWIInfoStruct;
-TWIInfoStruct TWIInfo;
 
+extern TWIInfoStruct TWIInfo;
 
 // TWI Status Codes
 #define TWI_START_SENT			0x08 // Start sent

--- a/keyboards/meira/TWIlib.c
+++ b/keyboards/meira/TWIlib.c
@@ -11,6 +11,19 @@
 #include "util/delay.h"
 #include "print.h"
 
+// Global transmit buffer
+volatile uint8_t *TWITransmitBuffer;
+// Global receive buffer
+volatile uint8_t TWIReceiveBuffer[RXMAXBUFLEN];
+// Buffer indexes
+volatile int TXBuffIndex; // Index of the transmit buffer. Is volatile, can change at any time.
+int RXBuffIndex; // Current index in the receive buffer
+// Buffer lengths
+int TXBuffLen; // The total length of the transmit buffer
+int RXBuffLen; // The total number of bytes to read (should be less than RXMAXBUFFLEN)
+
+TWIInfoStruct TWIInfo;
+
 void TWIInit()
 {
 	TWIInfo.mode = Ready;

--- a/keyboards/meira/TWIlib.h
+++ b/keyboards/meira/TWIlib.h
@@ -16,16 +16,6 @@
 #define TXMAXBUFLEN 20
 // Receive buffer length
 #define RXMAXBUFLEN 20
-// Global transmit buffer
-volatile uint8_t *TWITransmitBuffer;
-// Global receive buffer
-volatile uint8_t TWIReceiveBuffer[RXMAXBUFLEN];
-// Buffer indexes
-volatile int TXBuffIndex; // Index of the transmit buffer. Is volatile, can change at any time.
-int RXBuffIndex; // Current index in the receive buffer
-// Buffer lengths
-int TXBuffLen; // The total length of the transmit buffer
-int RXBuffLen; // The total number of bytes to read (should be less than RXMAXBUFFLEN)
 
 typedef enum {
 	Ready,
@@ -42,8 +32,8 @@ typedef enum {
 	uint8_t errorCode;
 	uint8_t repStart;
 	}TWIInfoStruct;
-TWIInfoStruct TWIInfo;
 
+extern TWIInfoStruct TWIInfo;
 
 // TWI Status Codes
 #define TWI_START_SENT			0x08 // Start sent


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
```console
Making meira/featherble with keymap default                                                            [ERRORS]
 | 
 | /usr/bin/avr-ld: .build/obj_meira_featherble_default/keyboards/meira/meira.o:/home/zvecr/qmk_firmware/keyboards/meira/TWIlib.h:45: multiple definition of `TWIInfo'; .build/obj_meira_featherble_default/TWIlib.o:/home/zvecr/qmk_firmware/keyboards/meira/TWIlib.h:45: first defined here
 | /usr/bin/avr-ld: .build/obj_meira_featherble_default/keyboards/meira/meira.o:/home/zvecr/qmk_firmware/keyboards/meira/TWIlib.h:28: multiple definition of `RXBuffLen'; .build/obj_meira_featherble_default/TWIlib.o:/home/zvecr/qmk_firmware/keyboards/meira/TWIlib.h:28: first defined here
 | /usr/bin/avr-ld: .build/obj_meira_featherble_default/keyboards/meira/meira.o:/home/zvecr/qmk_firmware/keyboards/meira/TWIlib.h:27: multiple definition of `TXBuffLen'; .build/obj_meira_featherble_default/TWIlib.o:/home/zvecr/qmk_firmware/keyboards/meira/TWIlib.h:27: first defined here
 | /usr/bin/avr-ld: .build/obj_meira_featherble_default/keyboards/meira/meira.o:/home/zvecr/qmk_firmware/keyboards/meira/TWIlib.h:25: multiple definition of `RXBuffIndex'; .build/obj_meira_featherble_default/TWIlib.o:/home/zvecr/qmk_firmware/keyboards/meira/TWIlib.h:25: first defined here
 | /usr/bin/avr-ld: .build/obj_meira_featherble_default/keyboards/meira/meira.o:/home/zvecr/qmk_firmware/keyboards/meira/TWIlib.h:24: multiple definition of `TXBuffIndex'; .build/obj_meira_featherble_default/TWIlib.o:/home/zvecr/qmk_firmware/keyboards/meira/TWIlib.h:24: first defined here
 | /usr/bin/avr-ld: .build/obj_meira_featherble_default/keyboards/meira/meira.o:/home/zvecr/qmk_firmware/keyboards/meira/TWIlib.h:22: multiple definition of `TWIReceiveBuffer'; .build/obj_meira_featherble_default/TWIlib.o:/home/zvecr/qmk_firmware/keyboards/meira/TWIlib.h:22: first defined here
 | /usr/bin/avr-ld: .build/obj_meira_featherble_default/keyboards/meira/meira.o:/home/zvecr/qmk_firmware/keyboards/meira/TWIlib.h:20: multiple definition of `TWITransmitBuffer'; .build/obj_meira_featherble_default/TWIlib.o:/home/zvecr/qmk_firmware/keyboards/meira/TWIlib.h:20: first defined here
 | collect2: error: ld returned 1 exit status
 | 
make[1]: *** [tmk_core/rules.mk:306: .build/meira_featherble_default.elf] Error 1
```

Also fixes various `lfkeyboards` boards.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
