### PR TITLE
Allow for user song lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ __pycache__
 
 # prerequisites for updating ChibiOS
 /util/fmpp*
+
+# Allow to exist but don't include it in the repo
+user_song_list.h

--- a/quantum/audio/song_list.h
+++ b/quantum/audio/song_list.h
@@ -20,6 +20,12 @@
 
 #include "musical_notes.h"
 
+#if __GNUC__ > 5  // don't use for older gcc compilers since check isn't supported.
+#    if __has_include("user_song_list.h")
+#        include "user_song_list.h"
+#    endif  // if file exists
+#endif      // __GNUC__
+
 #define NO_SOUND
 
 /* Ode to Joy
@@ -146,44 +152,126 @@
  *   proof of permission to use them, or public domain status.
  */
 
-#define CLOSE_ENCOUNTERS_5_NOTE
-#define DOE_A_DEER
-#define IN_LIKE_FLINT
-#define IMPERIAL_MARCH
-#define BASKET_CASE
-#define COIN_SOUND
-#define ONE_UP_SOUND
-#define SONIC_RING
-#define ZELDA_PUZZLE
-#define ZELDA_TREASURE
-#define OVERWATCH_THEME
-#define MARIO_THEME
-#define MARIO_GAMEOVER
-#define MARIO_MUSHROOM
-#define E1M1_DOOM
-#define DISNEY_SONG
-#define NUMBER_ONE
-#define CABBAGE_SONG
-#define OLD_SPICE
-#define VICTORY_FANFARE_SHORT
-#define ALL_STAR
-#define RICK_ROLL
-#define FF_PRELUDE
-#define TO_BOLDLY_GO
-#define KATAWARE_DOKI
-#define MEGALOVANIA
-#define MICHISHIRUBE
-#define LIEBESLEID
-#define MELODIES_OF_LIFE
-#define EYES_ON_ME
-#define SONG_OF_THE_ANCIENTS
-#define NIER_AMUSEMENT_PARK
-#define COPIED_CITY
-#define VAGUE_HOPE_COLD_RAIN
-#define KAINE_SALVATION
-#define WEIGHT_OF_THE_WORLD
-#define ISABELLAS_LULLABY
-#define TERRAS_THEME
-#define RENAI_CIRCULATION
-#define PLATINUM_DISCO
-#define LP_NUMB
+#ifndef CLOSE_ENCOUNTERS_5_NOTE
+#    define CLOSE_ENCOUNTERS_5_NOTE
+#endif
+#ifndef DOE_A_DEER
+#    define DOE_A_DEER
+#endif
+#ifndef IN_LIKE_FLINT
+#    define IN_LIKE_FLINT
+#endif
+#ifndef IMPERIAL_MARCH
+#    define IMPERIAL_MARCH
+#endif
+#ifndef BASKET_CASE
+#    define BASKET_CASE
+#endif
+#ifndef COIN_SOUND
+#    define COIN_SOUND
+#endif
+#ifndef ONE_UP_SOUND
+#    define ONE_UP_SOUND
+#endif
+#ifndef SONIC_RING
+#    define SONIC_RING
+#endif
+#ifndef ZELDA_PUZZLE
+#    define ZELDA_PUZZLE
+#endif
+#ifndef ZELDA_TREASURE
+#    define ZELDA_TREASURE
+#endif
+#ifndef OVERWATCH_THEME
+#    define OVERWATCH_THEME
+#endif
+#ifndef MARIO_THEME
+#    define MARIO_THEME
+#endif
+#ifndef MARIO_GAMEOVER
+#    define MARIO_GAMEOVER
+#endif
+#ifndef MARIO_MUSHROOM
+#    define MARIO_MUSHROOM
+#endif
+#ifndef E1M1_DOOM
+#    define E1M1_DOOM
+#endif
+#ifndef DISNEY_SONG
+#    define DISNEY_SONG
+#endif
+#ifndef NUMBER_ONE
+#    define NUMBER_ONE
+#endif
+#ifndef CABBAGE_SONG
+#    define CABBAGE_SONG
+#endif
+#ifndef OLD_SPICE
+#    define OLD_SPICE
+#endif
+#ifndef VICTORY_FANFARE_SHORT
+#    define VICTORY_FANFARE_SHORT
+#endif
+#ifndef ALL_STAR
+#    define ALL_STAR
+#endif
+#ifndef RICK_ROLL
+#    define RICK_ROLL
+#endif
+#ifndef FF_PRELUDE
+#    define FF_PRELUDE
+#endif
+#ifndef TO_BOLDLY_GO
+#    define TO_BOLDLY_GO
+#endif
+#ifndef KATAWARE_DOKI
+#    define KATAWARE_DOKI
+#endif
+#ifndef MEGALOVANIA
+#    define MEGALOVANIA
+#endif
+#ifndef MICHISHIRUBE
+#    define MICHISHIRUBE
+#endif
+#ifndef LIEBESLEID
+#    define LIEBESLEID
+#endif
+#ifndef MELODIES_OF_LIFE
+#    define MELODIES_OF_LIFE
+#endif
+#ifndef EYES_ON_ME
+#    define EYES_ON_ME
+#endif
+#ifndef SONG_OF_THE_ANCIENTS
+#    define SONG_OF_THE_ANCIENTS
+#endif
+#ifndef NIER_AMUSEMENT_PARK
+#    define NIER_AMUSEMENT_PARK
+#endif
+#ifndef COPIED_CITY
+#    define COPIED_CITY
+#endif
+#ifndef VAGUE_HOPE_COLD_RAIN
+#    define VAGUE_HOPE_COLD_RAIN
+#endif
+#ifndef KAINE_SALVATION
+#    define KAINE_SALVATION
+#endif
+#ifndef WEIGHT_OF_THE_WORLD
+#    define WEIGHT_OF_THE_WORLD
+#endif
+#ifndef ISABELLAS_LULLABY
+#    define ISABELLAS_LULLABY
+#endif
+#ifndef TERRAS_THEME
+#    define TERRAS_THEME
+#endif
+#ifndef RENAI_CIRCULATION
+#    define RENAI_CIRCULATION
+#endif
+#ifndef PLATINUM_DISCO
+#    define PLATINUM_DISCO
+#endif
+#ifndef LP_NUMB
+#    define LP_NUMB
+#endif


### PR DESCRIPTION
## Description

Allows for user song lists to be added, but keeps them out of the repo (for legal reasons). 

Additionally, defines the removed songs weakly, so people can use them without issue.


## Types of Changes
- [x] Core
- [x] Enhancement/optimization


## Checklist
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
