### PR TITLE
Fix 'does not have a readme.md' warnings

### DIFF
--- a/keyboards/ergodox_stm32/readme.md
+++ b/keyboards/ergodox_stm32/readme.md
@@ -1,0 +1,9 @@
+# ergodox_stm32
+
+* Keyboard Maintainer: [Codetector1374](https://github.com/Codetector1374)
+
+Make example for this keyboard (after setting up your build environment):
+
+    make ergodox_stm32:default
+
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).

--- a/keyboards/handwired/myskeeb/readme.md
+++ b/keyboards/handwired/myskeeb/readme.md
@@ -1,0 +1,11 @@
+# myskeeb
+
+Handwired Keyboard based on the Ergodash, with an OLED similar to Kyria.
+
+* Keyboard Maintainer: [su8044](https://github.com/su8044)
+
+Make example for this keyboard (after setting up your build environment):
+
+    make handwired/myskeeb:default
+
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Spotted within the output of http://compile.qmk.fm/v1/keyboards/error_log.

```json
{
	"severity": "warning",
	"message": "Warning: ergodox_stm32 does not have a readme.md."
}, {
	"severity": "warning",
	"message": "Warning: handwired/myskeeb does not have a readme.md."
}
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
