### PR TITLE
Bigger combo index

### DIFF
--- a/docs/ChangeLog/20200829/PR9318.md
+++ b/docs/ChangeLog/20200829/PR9318.md
@@ -1,0 +1,11 @@
+### Bigger integer type when looping over combos.
+
+[#9318](https://github.com/qmk/qmk_firmware/pull/9318)
+
+Changes `uint8_t` to `uint16_t` so it is possible have more than 256 combos.
+
+Any fork that uses `process_combo_event` needs to update the function's first argument to `uint16_t`.
+
+| Old function                                                  | New Function                                                   |
+|---------------------------------------------------------------|----------------------------------------------------------------|
+| `void process_combo_event(uint8_t combo_index, bool pressed)` | `void process_combo_event(uint16_t combo_index, bool pressed)` |

--- a/keyboards/ashpil/modelm_usbc/keymaps/ashpil/keymap.c
+++ b/keyboards/ashpil/modelm_usbc/keymaps/ashpil/keymap.c
@@ -36,7 +36,7 @@ combo_t key_combos[COMBO_COUNT] = {
   [CTRL_PAUS_RESET] = COMBO_ACTION(reset_combo),
 };
 
-void process_combo_event(uint8_t combo_index, bool pressed) {
+void process_combo_event(uint16_t combo_index, bool pressed) {
   switch(combo_index) {
     case CTRL_PAUS_RESET:
       if (pressed) {

--- a/keyboards/converter/usb_usb/keymaps/chriskopher/combo.c
+++ b/keyboards/converter/usb_usb/keymaps/chriskopher/combo.c
@@ -33,7 +33,7 @@ combo_t key_combos[COMBO_COUNT] = {
 };
 
 // Called after a combo event is triggered
-void process_combo_event(uint8_t combo_index, bool pressed) {
+void process_combo_event(uint16_t combo_index, bool pressed) {
     switch (combo_index) {
         case SD_LAYER_COMBO:
             if (pressed) {

--- a/keyboards/converter/usb_usb/keymaps/narze/keymap.c
+++ b/keyboards/converter/usb_usb/keymaps/narze/keymap.c
@@ -153,7 +153,7 @@ void matrix_setup(void) {
     set_superduper_key_combos();
 }
 
-void process_combo_event(uint8_t combo_index, bool pressed) {
+void process_combo_event(uint16_t combo_index, bool pressed) {
     if (pressed) {
         switch(combo_index) {
             case CB_SUPERDUPER:

--- a/keyboards/ergodox_infinity/keymaps/narze/keymap.c
+++ b/keyboards/ergodox_infinity/keymaps/narze/keymap.c
@@ -683,7 +683,7 @@ void matrix_scan_user(void) {
 
 // Combos
 
-void process_combo_event(uint8_t combo_index, bool pressed) {
+void process_combo_event(uint16_t combo_index, bool pressed) {
     if (pressed) {
         switch(combo_index) {
             case CB_SUPERDUPER:

--- a/keyboards/gboards/g/keymap_combo.h
+++ b/keyboards/gboards/g/keymap_combo.h
@@ -60,7 +60,7 @@ int COMBO_LEN = sizeof(key_combos) / sizeof(key_combos[0]);
 #define COMB BLANK
 #define SUBS A_ACTI
 #define TOGG A_TOGG
-void process_combo_event(uint8_t combo_index, bool pressed) {
+void process_combo_event(uint16_t combo_index, bool pressed) {
     switch (combo_index) {
 #include "combos.def"
     }

--- a/keyboards/maxr1998/pulse4k/pulse4k.c
+++ b/keyboards/maxr1998/pulse4k/pulse4k.c
@@ -30,7 +30,7 @@ combo_t key_combos[COMBO_COUNT] = {
 
 bool led_adjust_active = false;
 
-void process_combo_event(uint8_t combo_index, bool pressed) {
+void process_combo_event(uint16_t combo_index, bool pressed) {
     if (combo_index == LED_ADJUST) {
         led_adjust_active = pressed;
     }

--- a/keyboards/minidox/keymaps/rsthd_combos/keymap.c
+++ b/keyboards/minidox/keymaps/rsthd_combos/keymap.c
@@ -45,7 +45,7 @@ combo_t key_combos[COMBO_COUNT] = {
   [BOT_CTR] = COMBO_ACTION(bx_combo),
 };
 
-  void process_combo_event(uint8_t combo_index, bool pressed) {
+  void process_combo_event(uint16_t combo_index, bool pressed) {
     switch(combo_index) {
       case MID_R:
       if (pressed) {

--- a/keyboards/planck/keymaps/narze/keymap.c
+++ b/keyboards/planck/keymaps/narze/keymap.c
@@ -357,7 +357,7 @@ void matrix_setup(void) {
 void matrix_scan_user(void) {
 }
 
-void process_combo_event(uint8_t combo_index, bool pressed) {
+void process_combo_event(uint16_t combo_index, bool pressed) {
     if (pressed) {
         switch(combo_index) {
             case CB_SUPERDUPER:

--- a/keyboards/xd75/keymaps/4sstylz/keymap.c
+++ b/keyboards/xd75/keymaps/4sstylz/keymap.c
@@ -129,7 +129,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
   return true;
 }
 
-void process_combo_event(uint8_t combo_index, bool pressed) {
+void process_combo_event(uint16_t combo_index, bool pressed) {
   switch(combo_index) {
     case SCR_LCK:
       if (pressed) {

--- a/quantum/process_keycode/process_combo.c
+++ b/quantum/process_keycode/process_combo.c
@@ -24,10 +24,10 @@ extern combo_t  key_combos[];
 extern int      COMBO_LEN;
 #endif
 
-__attribute__((weak)) void process_combo_event(uint8_t combo_index, bool pressed) {}
+__attribute__((weak)) void process_combo_event(uint16_t combo_index, bool pressed) {}
 
 static uint16_t timer               = 0;
-static uint8_t  current_combo_index = 0;
+static uint16_t  current_combo_index = 0;
 static bool     drop_buffer         = false;
 static bool     is_active           = false;
 static bool     b_combo_enable      = true;  // defaults to enabled
@@ -83,7 +83,7 @@ static inline void dump_key_buffer(bool emit) {
 
 static bool process_single_combo(combo_t *combo, uint16_t keycode, keyrecord_t *record) {
     uint8_t count = 0;
-    uint8_t index = -1;
+    uint16_t index = -1;
     /* Find index of keycode and number of combo keys */
     for (const uint16_t *keys = combo->keys;; ++count) {
         uint16_t key = pgm_read_word(&keys[count]);

--- a/quantum/process_keycode/process_combo.h
+++ b/quantum/process_keycode/process_combo.h
@@ -56,7 +56,7 @@ typedef struct {
 
 bool process_combo(uint16_t keycode, keyrecord_t *record);
 void matrix_scan_combo(void);
-void process_combo_event(uint8_t combo_index, bool pressed);
+void process_combo_event(uint16_t combo_index, bool pressed);
 
 void combo_enable(void);
 void combo_disable(void);

--- a/users/issmirnov/issmirnov.c
+++ b/users/issmirnov/issmirnov.c
@@ -26,7 +26,7 @@ combo_t key_combos[COMBO_COUNT] = {
 };
 
 
-void process_combo_event(uint8_t combo_index, bool pressed) {
+void process_combo_event(uint16_t combo_index, bool pressed) {
   switch(combo_index) {
     case XC_COPY:
       if (pressed) {

--- a/users/kuchosauronad0/combo.c
+++ b/users/kuchosauronad0/combo.c
@@ -1,6 +1,6 @@
 #include "combo.h"
 
-void process_combo_event(uint8_t combo_index, bool pressed){
+void process_combo_event(uint16_t combo_index, bool pressed){
   switch(combo_index) {
     case ZV_COPY:
       if (pressed) {

--- a/users/ninjonas/combos.c
+++ b/users/ninjonas/combos.c
@@ -23,7 +23,7 @@ combo_t key_combos[COMBO_COUNT] = {
   [XV_PASTE] = COMBO_ACTION(paste_combo),
 };
 
-void process_combo_event(uint8_t combo_index, bool pressed) {
+void process_combo_event(uint16_t combo_index, bool pressed) {
   switch(combo_index) {
     case EQ_QUIT:
       if (pressed) {

--- a/users/yet-another-developer/combo.c
+++ b/users/yet-another-developer/combo.c
@@ -1,6 +1,6 @@
 #include "combo.h"
 
-void process_combo_event(uint8_t combo_index, bool pressed){
+void process_combo_event(uint16_t combo_index, bool pressed){
   switch(combo_index) {
     case ZV_COPY:
       if (pressed) {


### PR DESCRIPTION
## Description

Changes `uint8_t` to `uin16_t` when looping over combos. With 16 bits we can have much more than 256 combos.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
