### PR TITLE
Parse version better in `qmk doctor` GCC version checks

### DIFF
--- a/lib/python/qmk/cli/doctor.py
+++ b/lib/python/qmk/cli/doctor.py
@@ -5,6 +5,7 @@ Check out the user's QMK environment and make sure it's ready to compile.
 import platform
 import shutil
 import subprocess
+from packaging import version
 from pathlib import Path
 
 from milc import cli
@@ -17,10 +18,10 @@ ESSENTIAL_BINARIES = {
     'avrdude': {},
     'dfu-util': {},
     'avr-gcc': {
-        'version_arg': '-dumpfullversion'
+        'version_arg': '-dumpversion'
     },
     'arm-none-eabi-gcc': {
-        'version_arg': '-dumpfullversion'
+        'version_arg': '-dumpversion'
     },
     'bin/qmk': {},
 }
@@ -66,8 +67,8 @@ def check_avr_gcc_version():
     if 'output' in ESSENTIAL_BINARIES['avr-gcc']:
         version_number = ESSENTIAL_BINARIES['avr-gcc']['output'].strip()
 
-        major, minor, rest = version_number.split('.', 2)
-        if int(major) > 8:
+        parsed_version = version.parse(version_number)
+        if parsed_version.major > 8:
             cli.log.error('We do not recommend avr-gcc newer than 8. Downgrading to 8.x is recommended.')
             return False
 

--- a/lib/python/qmk/cli/doctor.py
+++ b/lib/python/qmk/cli/doctor.py
@@ -3,9 +3,9 @@
 Check out the user's QMK environment and make sure it's ready to compile.
 """
 import platform
+import re
 import shutil
 import subprocess
-from packaging import version
 from pathlib import Path
 
 from milc import cli
@@ -51,6 +51,16 @@ def _deprecated_udev_rule(vid, pid=None):
         return 'SUBSYSTEMS=="usb", ATTRS{idVendor}=="%s", MODE:="0666"' % vid
 
 
+def parse_gcc_version(version):
+    m = re.match("(\d+)(?:\.(\d+))?(?:\.(\d+))?", version)
+
+    return {
+        'major': int(m.group(1)),
+        'minor': int(m.group(2)) if m.group(2) else 0,
+        'patch': int(m.group(3)) if m.group(3) else 0
+    }
+
+
 def check_arm_gcc_version():
     """Returns True if the arm-none-eabi-gcc version is not known to cause problems.
     """
@@ -67,8 +77,8 @@ def check_avr_gcc_version():
     if 'output' in ESSENTIAL_BINARIES['avr-gcc']:
         version_number = ESSENTIAL_BINARIES['avr-gcc']['output'].strip()
 
-        parsed_version = version.parse(version_number)
-        if parsed_version.major > 8:
+        parsed_version = parse_gcc_version(version_number)
+        if parsed_version['major'] > 8:
             cli.log.error('We do not recommend avr-gcc newer than 8. Downgrading to 8.x is recommended.')
             return False
 

--- a/lib/python/qmk/cli/doctor.py
+++ b/lib/python/qmk/cli/doctor.py
@@ -52,7 +52,7 @@ def _deprecated_udev_rule(vid, pid=None):
 
 
 def parse_gcc_version(version):
-    m = re.match("(\d+)(?:\.(\d+))?(?:\.(\d+))?", version)
+    m = re.match(r"(\d+)(?:\.(\d+))?(?:\.(\d+))?", version)
 
     return {
         'major': int(m.group(1)),

--- a/lib/python/qmk/cli/doctor.py
+++ b/lib/python/qmk/cli/doctor.py
@@ -17,10 +17,10 @@ ESSENTIAL_BINARIES = {
     'avrdude': {},
     'dfu-util': {},
     'avr-gcc': {
-        'version_arg': '-dumpversion'
+        'version_arg': '-dumpfullversion'
     },
     'arm-none-eabi-gcc': {
-        'version_arg': '-dumpversion'
+        'version_arg': '-dumpfullversion'
     },
     'bin/qmk': {},
 }

--- a/lib/python/qmk/tests/test_cli_commands.py
+++ b/lib/python/qmk/tests/test_cli_commands.py
@@ -115,7 +115,7 @@ def test_list_keymaps_no_keyboard_found():
 def test_json2c():
     result = check_subcommand('json2c', 'keyboards/handwired/onekey/keymaps/default_json/keymap.json')
     check_returncode(result, 0)
-    assert result.stdout == '#include QMK_KEYBOARD_H\nconst uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {\t[0] = LAYOUT(KC_A)};\n\n'
+    assert result.stdout == '#include QMK_KEYBOARD_H\nconst uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {\t[0] = LAYOUT_ortho_1x1(KC_A)};\n\n'
 
 
 def test_info():
@@ -132,7 +132,7 @@ def test_info_keyboard_render():
     check_returncode(result)
     assert 'Keyboard Name: handwired/onekey/pytest' in result.stdout
     assert 'Processor: STM32F303' in result.stdout
-    assert 'Layout:' in result.stdout
+    assert 'Layouts:' in result.stdout
     assert 'k0' in result.stdout
 
 
@@ -149,6 +149,6 @@ def test_info_matrix_render():
     check_returncode(result)
     assert 'Keyboard Name: handwired/onekey/pytest' in result.stdout
     assert 'Processor: STM32F303' in result.stdout
-    assert 'LAYOUT' in result.stdout
+    assert 'LAYOUT_ortho_1x1' in result.stdout
     assert '│0A│' in result.stdout
-    assert 'Matrix for "LAYOUT"' in result.stdout
+    assert 'Matrix for "LAYOUT_ortho_1x1"' in result.stdout

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ appdirs
 argcomplete
 colorama
 hjson
+packaging

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ appdirs
 argcomplete
 colorama
 hjson
-packaging


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

To avoid the case where the `version_number.split('.', 2)` fails due to:

> -dumpversion
> Print the compiler version (for example, 3.0, 6.3.0 or 7)—and don’t do anything else. This is the compiler version used in filesystem paths and specs. **Depending on how the compiler has been configured it can be just a single number (major version), two numbers separated by a dot (major and minor version) or three numbers separated by dots (major, minor and patchlevel version).**
>
> -dumpfullversion
> Print the full compiler version—and don’t do anything else. The output is always three numbers separated by dots, major, minor and patchlevel version.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
