### PR TITLE
kbdfans/kbd67/rev2: Fix ISO layout macro

### DIFF
--- a/keyboards/kbdfans/kbd67/rev2/rev2.h
+++ b/keyboards/kbdfans/kbd67/rev2/rev2.h
@@ -89,8 +89,8 @@
 
 #define LAYOUT_65_iso( \
     K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C,      K0E, K0F, \
-    K10,      K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, K1C,      K1E, K1F, \
-    K20,      K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B, K2C, K1D, K2D, K2F, \
+    K10,      K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, K1C, K1D,      K1F, \
+    K20,      K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B, K2C, K1E, K2D, K2F, \
     K30, K31, K32, K33, K34, K35, K36, K37, K38, K39, K3A, K3B,      K3D, K3E, K3F, \
     K40, K41,      K43,           K46,                K4A, K4B, K4C, K4D, K4E, K4F  \
 ) \


### PR DESCRIPTION
## Description

A user in Discord reported that the right bracket and ISO hash keys on KBD67 rev2 using `LAYOUT_65_iso` were swapped:

https://discord.com/channels/440868230475677696/473506116718952450/719224587812077588
https://discord.com/channels/440868230475677696/473506116718952450/719226060310446160

Swapping the mappings of those keys in configurator produced a firmware which worked properly for that user:

https://discord.com/channels/440868230475677696/473506116718952450/719226879629852765

When comparing `LAYOUT_65_iso` with `LAYOUT_65_ansi`, the problem with a wrong assignment of the right bracket key is obvious — that key is `K1D` in the ANSI layout macro, but the ISO layout macro had `K1E` there, and `K1D` was at the position of the ISO hash key. The proper assignment for the ISO hash key is less obvious, but given the fact that the user was able to work around the problem by swapping the mappings for those keys, `K1E` should be the correct matrix position for that key.

Fix the `LAYOUT_65_iso` macro by swapping those arguments (and also align the `K1D` argument for the right bracket key properly).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [X] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
