### PR TITLE
Remove inclusion of adafruit_ble.h from ssd1306.c

### DIFF
--- a/drivers/avr/ssd1306.c
+++ b/drivers/avr/ssd1306.c
@@ -5,9 +5,6 @@
 #    include <string.h>
 #    include "print.h"
 #    include "glcdfont.c"
-#    ifdef ADAFRUIT_BLE_ENABLE
-#        include "adafruit_ble.h"
-#    endif
 #    ifdef PROTOCOL_LUFA
 #        include "lufa.h"
 #    endif

--- a/keyboards/claw44/ssd1306.c
+++ b/keyboards/claw44/ssd1306.c
@@ -4,9 +4,6 @@
 #include "i2c.h"
 #include <string.h>
 #include "print.h"
-#ifdef ADAFRUIT_BLE_ENABLE
-#include "adafruit_ble.h"
-#endif
 #ifdef PROTOCOL_LUFA
 #include "lufa.h"
 #endif

--- a/keyboards/comet46/ssd1306.c
+++ b/keyboards/comet46/ssd1306.c
@@ -4,9 +4,6 @@
 #include "i2c.h"
 #include <string.h>
 #include "print.h"
-#ifdef ADAFRUIT_BLE_ENABLE
-#include "adafruit_ble.h"
-#endif
 #ifdef PROTOCOL_LUFA
 #include "lufa.h"
 #endif

--- a/keyboards/crkbd/ssd1306.c
+++ b/keyboards/crkbd/ssd1306.c
@@ -4,9 +4,6 @@
 #include "i2c.h"
 #include <string.h>
 #include "print.h"
-#ifdef ADAFRUIT_BLE_ENABLE
-#include "adafruit_ble.h"
-#endif
 #ifdef PROTOCOL_LUFA
 #include "lufa.h"
 #endif

--- a/keyboards/helix/local_drivers/ssd1306.c
+++ b/keyboards/helix/local_drivers/ssd1306.c
@@ -10,9 +10,6 @@
 #else
 #include <helixfont.h>
 #endif
-#ifdef ADAFRUIT_BLE_ENABLE
-#include "adafruit_ble.h"
-#endif
 #ifdef PROTOCOL_LUFA
 #include "lufa.h"
 #endif

--- a/keyboards/yosino58/ssd1306.c
+++ b/keyboards/yosino58/ssd1306.c
@@ -4,9 +4,6 @@
 #include "i2c.h"
 #include <string.h>
 #include "print.h"
-#ifdef ADAFRUIT_BLE_ENABLE
-#include "adafruit_ble.h"
-#endif
 #ifdef PROTOCOL_LUFA
 #include "lufa.h"
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Nothing declared in this header is used by the SSD1306 code - not even the Comet46 which is a wireless split that uses the same BLE module but not the Adafruit firmware.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
