### PR TITLE
Don't compile outputselect.c if Bluetooth is disabled

### DIFF
--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -17,7 +17,7 @@
 #include <ctype.h>
 #include "quantum.h"
 
-#ifdef PROTOCOL_LUFA
+#ifdef BLUETOOTH_ENABLE
 #    include "outputselect.h"
 #endif
 
@@ -627,7 +627,7 @@ void matrix_init_quantum() {
 #ifdef HAPTIC_ENABLE
     haptic_init();
 #endif
-#ifdef OUTPUT_AUTO_ENABLE
+#if defined(BLUETOOTH_ENABLE) && defined(OUTPUT_AUTO_ENABLE)
     set_output(OUTPUT_AUTO);
 #endif
 #ifdef DIP_SWITCH_ENABLE

--- a/tmk_core/protocol/lufa.mk
+++ b/tmk_core/protocol/lufa.mk
@@ -15,9 +15,8 @@ else
 endif
 
 LUFA_SRC = lufa.c \
-	   usb_descriptor.c \
-	   outputselect.c \
-	   $(LUFA_SRC_USB)
+	usb_descriptor.c \
+	$(LUFA_SRC_USB)
 
 ifeq ($(strip $(MIDI_ENABLE)), yes)
 	include $(TMK_PATH)/protocol/midi.mk
@@ -25,23 +24,27 @@ endif
 
 ifeq ($(strip $(BLUETOOTH_ENABLE)), yes)
 	LUFA_SRC += $(LUFA_DIR)/bluetooth.c \
-	$(TMK_DIR)/protocol/serial_uart.c
+		outputselect.c \
+		$(TMK_DIR)/protocol/serial_uart.c
 endif
 
 ifeq ($(strip $(BLUETOOTH)), AdafruitBLE)
-		LUFA_SRC += spi_master.c
-		LUFA_SRC += analog.c
-		LUFA_SRC += $(LUFA_DIR)/adafruit_ble.cpp
+	LUFA_SRC += spi_master.c \
+		analog.c \
+		outputselect.c \
+		$(LUFA_DIR)/adafruit_ble.cpp
 endif
 
 ifeq ($(strip $(BLUETOOTH)), AdafruitEZKey)
 	LUFA_SRC += $(LUFA_DIR)/bluetooth.c \
-	$(TMK_DIR)/protocol/serial_uart.c
+		outputselect.c \
+		$(TMK_DIR)/protocol/serial_uart.c
 endif
 
 ifeq ($(strip $(BLUETOOTH)), RN42)
 	LUFA_SRC += $(LUFA_DIR)/bluetooth.c \
-	$(TMK_DIR)/protocol/serial_uart.c
+		outputselect.c \
+		$(TMK_DIR)/protocol/serial_uart.c
 endif
 
 ifeq ($(strip $(VIRTSER_ENABLE)), yes)

--- a/tmk_core/protocol/lufa/lufa.c
+++ b/tmk_core/protocol/lufa/lufa.c
@@ -53,7 +53,6 @@
 #include "lufa.h"
 #include "quantum.h"
 #include <util/atomic.h>
-#include "outputselect.h"
 
 #ifdef NKRO_ENABLE
 #    include "keycode_config.h"
@@ -66,6 +65,7 @@ extern keymap_config_t keymap_config;
 #endif
 
 #ifdef BLUETOOTH_ENABLE
+#    include "outputselect.h"
 #    ifdef MODULE_ADAFRUIT_BLE
 #        include "adafruit_ble.h"
 #    else
@@ -554,9 +554,10 @@ static uint8_t keyboard_leds(void) { return keyboard_led_state; }
  */
 static void send_keyboard(report_keyboard_t *report) {
     uint8_t timeout = 255;
-    uint8_t where   = where_to_send();
 
 #ifdef BLUETOOTH_ENABLE
+    uint8_t where   = where_to_send();
+
     if (where == OUTPUT_BLUETOOTH || where == OUTPUT_USB_AND_BT) {
 #    ifdef MODULE_ADAFRUIT_BLE
         adafruit_ble_send_keys(report->mods, report->keys, sizeof(report->keys));
@@ -578,11 +579,11 @@ static void send_keyboard(report_keyboard_t *report) {
         }
 #    endif
     }
-#endif
 
     if (where != OUTPUT_USB && where != OUTPUT_USB_AND_BT) {
         return;
     }
+#endif
 
     /* Select the Keyboard Report Endpoint */
     uint8_t ep   = KEYBOARD_IN_EPNUM;
@@ -618,9 +619,10 @@ static void send_keyboard(report_keyboard_t *report) {
 static void send_mouse(report_mouse_t *report) {
 #ifdef MOUSE_ENABLE
     uint8_t timeout = 255;
-    uint8_t where   = where_to_send();
 
 #    ifdef BLUETOOTH_ENABLE
+    uint8_t where   = where_to_send();
+
     if (where == OUTPUT_BLUETOOTH || where == OUTPUT_USB_AND_BT) {
 #        ifdef MODULE_ADAFRUIT_BLE
         // FIXME: mouse buttons
@@ -637,11 +639,11 @@ static void send_mouse(report_mouse_t *report) {
         bluefruit_serial_send(0x00);
 #        endif
     }
-#    endif
 
     if (where != OUTPUT_USB && where != OUTPUT_USB_AND_BT) {
         return;
     }
+#    endif
 
     /* Select the Mouse Report Endpoint */
     Endpoint_SelectEndpoint(MOUSE_IN_EPNUM);
@@ -696,9 +698,9 @@ static void send_system(uint16_t data) {
  */
 static void send_consumer(uint16_t data) {
 #ifdef EXTRAKEY_ENABLE
+#    ifdef BLUETOOTH_ENABLE
     uint8_t where = where_to_send();
 
-#    ifdef BLUETOOTH_ENABLE
     if (where == OUTPUT_BLUETOOTH || where == OUTPUT_USB_AND_BT) {
 #        ifdef MODULE_ADAFRUIT_BLE
         adafruit_ble_send_consumer_key(data, 0);
@@ -728,11 +730,11 @@ static void send_consumer(uint16_t data) {
         bluefruit_serial_send(0x00);
 #        endif
     }
-#    endif
 
     if (where != OUTPUT_USB && where != OUTPUT_USB_AND_BT) {
         return;
     }
+#    endif
 
     send_extra(REPORT_ID_CONSUMER, data);
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

If Bluetooth is disabled we should always output over USB, so the `where_to_send()` call and early return can safely be placed behind the `BLUETOOTH_ENABLE` ifdef.

Saves about 90 bytes on avr-gcc 8.4.0 with `gh60/satan:default`, should be no change for boards with Bluetooth enabled.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
