### PR TITLE
Fixed slave-side keyboard half unresponsiveness

### DIFF
--- a/quantum/split_common/split_util.c
+++ b/quantum/split_common/split_util.c
@@ -39,7 +39,10 @@ volatile bool isLeftHand = true;
 #if defined(SPLIT_USB_DETECT)
 #    if defined(PROTOCOL_LUFA)
 static inline bool usbHasActiveConnection(void) { return USB_Device_IsAddressSet(); }
-static inline void usbDisable(void) { USB_Disable(); USB_DeviceState = DEVICE_STATE_Unattached; }
+static inline void usbDisable(void) {
+    USB_Disable();
+    USB_DeviceState = DEVICE_STATE_Unattached;
+}
 #    elif defined(PROTOCOL_CHIBIOS)
 static inline bool usbHasActiveConnection(void) { return usbGetDriverStateI(&USBD1) == USB_ACTIVE; }
 static inline void usbDisable(void) { usbStop(&USBD1); }


### PR DESCRIPTION
## Description

Due to how LUFA handles `USB_Disable()`, the slave side is stuck in `USB_DeviceTask()`, because `USB_DeviceState` is not set to `DEVICE_STATE_Unattached`. This PR fixes this on the qmk-side.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

Fixes #9350

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
