### PR TITLE
Really fix Ubuntu/Debian setup when $PATH contains spaces

### DIFF
--- a/docs/newbs_getting_started.md
+++ b/docs/newbs_getting_started.md
@@ -97,7 +97,7 @@ In most situations you will want to answer Yes to all of the prompts.
 It's possible, that you will get an error saying something like: `bash: qmk: command not found`.
 This is due to a [bug](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=839155) Debian introduced with their Bash 4.4 release, which removed `$HOME/.local/bin` from the PATH. This bug was later fixed on Debian and Ubuntu.
 Sadly, Ubuntu reitroduced this bug and is [yet to fix it](https://bugs.launchpad.net/ubuntu/+source/bash/+bug/1588562).
-Luckily, the fix is easy. Run this as your user: `echo "PATH=$HOME/.local/bin:\"$PATH\"" >> $HOME/.bashrc && source $HOME/.bashrc`
+Luckily, the fix is easy. Run this as your user: `echo 'PATH="$HOME/.local/bin:$PATH"' >> $HOME/.bashrc && source $HOME/.bashrc`
 
 ?>**Note on FreeBSD**:
 It is suggested to run `qmk setup` as a non-`root` user to start with, but this will likely identify packages that need to be installed to your


### PR DESCRIPTION
## Description

PR #9307 fixed the immediately visible problem (the command that was added to `$HOME/.bashrc` was incorrect because of missing quotes around paths with spaces).  However, the modified command is still wrong — it captures the value of `$PATH` at the setup time, and the resulting command written out to `$HOME/.bashrc` will overwrite `$PATH` with that captured value, ignoring any changes in the environment.  This may be especially important for WSL, where the initial value of `$PATH` in Linux includes everything which has been added to `%PATH%` on the Windows side; after adding that command to `$HOME/.bashrc` the WSL environment will no longer pick up any changes made by newly installed Windows software.

Instead of that, use single quotes around the command, so that the environment variables are not expanded at the setup time, and the command that is added to `$HOME/.bashrc` becomes exactly this:

```sh
PATH="$HOME/.local/bin:$PATH"
```

This command will use the `$HOME` and `$PATH` environment variable values at the time the command is executed, not at the time the QMK setup is performed, so any further updates to `$PATH` are taken into account. Double quotes also ensure that the command is safe even if the values of those environment variables contain spaces.


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
