### PR TITLE
CLI: Add ATmega328 and ATtiny85 to supported CPUs

### DIFF
--- a/lib/python/qmk/constants.py
+++ b/lib/python/qmk/constants.py
@@ -12,4 +12,4 @@ MAX_KEYBOARD_SUBFOLDERS = 5
 ARM_PROCESSORS = 'cortex-m0', 'cortex-m0plus', 'cortex-m3', 'cortex-m4', 'MKL26Z64', 'MK20DX128', 'MK20DX256', 'STM32F042', 'STM32F072', 'STM32F103', 'STM32F303'
 AVR_PROCESSORS = 'at90usb1286', 'at90usb646', 'atmega16u2', 'atmega328p', 'atmega32a', 'atmega32u2', 'atmega32u4', None
 ALL_PROCESSORS = ARM_PROCESSORS + AVR_PROCESSORS
-VUSB_PROCESSORS = 'atmega328p', 'atmega32a'
+VUSB_PROCESSORS = 'atmega328p', 'atmega32a', 'atmega328'

--- a/lib/python/qmk/constants.py
+++ b/lib/python/qmk/constants.py
@@ -12,4 +12,4 @@ MAX_KEYBOARD_SUBFOLDERS = 5
 ARM_PROCESSORS = 'cortex-m0', 'cortex-m0plus', 'cortex-m3', 'cortex-m4', 'MKL26Z64', 'MK20DX128', 'MK20DX256', 'STM32F042', 'STM32F072', 'STM32F103', 'STM32F303'
 AVR_PROCESSORS = 'at90usb1286', 'at90usb646', 'atmega16u2', 'atmega328p', 'atmega32a', 'atmega32u2', 'atmega32u4', None
 ALL_PROCESSORS = ARM_PROCESSORS + AVR_PROCESSORS
-VUSB_PROCESSORS = 'atmega328p', 'atmega32a', 'atmega328'
+VUSB_PROCESSORS = 'atmega328p', 'atmega32a', 'atmega328', 'attiny85'


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Support for ATmega328 was added in #9043.
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
