### PR TITLE
Wazowski fixed keymap placement

### DIFF
--- a/keyboards/keebzdotnet/wazowski/info.json
+++ b/keyboards/keebzdotnet/wazowski/info.json
@@ -1,25 +1,25 @@
 {
     "keyboard_name": "wazowski",
-    "url": "",
+    "url": "https://www.keebz.net/shop/wazoski-pcb",
     "maintainer": "keebzdotnet",
     "width": 9,
     "height": 5,
     "layouts": {
         "LAYOUT": {
             "layout": [
-                {"label":"k00", "x":0, "y":3},
-                {"label":"k01", "x":1, "y":0},
-                {"label":"k02", "x":1, "y":4},
-                {"label":"k03", "x":2, "y":3},
+                {"label":"k01", "x":1, "y":1},
                 {"label":"k04", "x":3, "y":2},
-                {"label":"k05", "x":3, "y":4},
                 {"label":"k06", "x":4, "y":2},
-                {"label":"k07", "x":4, "y":3},
                 {"label":"k08", "x":5, "y":2},
+                {"label":"k12", "x":7, "y":3},
+                {"label":"k00", "x":0, "y":3},
+                {"label":"k03", "x":2, "y":3},
+                {"label":"k07", "x":4, "y":3},
                 {"label":"k09", "x":5, "y":3},
                 {"label":"k10", "x":6, "y":2},
+                {"label":"k02", "x":1, "y":4},
+                {"label":"k05", "x":3, "y":4},
                 {"label":"k11", "x":7, "y":1},
-                {"label":"k12", "x":7, "y":3},
                 {"label":"k13", "x":8, "y":2}
             ]
         }


### PR DESCRIPTION
- online configurator keys were in the wrong location and needed to be fixed
- fixed a key being to high on the y position


## Description

When I used the online configuration my keys were wrong. So I had to map out what was wrong and where they went. I think I fixed it. I think its because I put the switches in weird places on the board. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
