### PR TITLE
Change `led` to `led_matrix` in rgb_matrix_drivers

### DIFF
--- a/quantum/rgb_matrix_drivers.c
+++ b/quantum/rgb_matrix_drivers.c
@@ -98,27 +98,27 @@ const rgb_matrix_driver_t rgb_matrix_driver = {
 #elif defined(WS2812)
 
 // LED color buffer
-LED_TYPE ws2812_led_array[DRIVER_LED_TOTAL];
+LED_TYPE rgb_matrix_ws2812_array[DRIVER_LED_TOTAL];
 
 static void init(void) {}
 
 static void flush(void) {
     // Assumes use of RGB_DI_PIN
-    ws2812_setleds(ws2812_led_array, DRIVER_LED_TOTAL);
+    ws2812_setleds(rgb_matrix_ws2812_array, DRIVER_LED_TOTAL);
 }
 
 // Set an led in the buffer to a color
 static inline void setled(int i, uint8_t r, uint8_t g, uint8_t b) {
-    ws2812_led_array[i].r = r;
-    ws2812_led_array[i].g = g;
-    ws2812_led_array[i].b = b;
+    rgb_matrix_ws2812_array[i].r = r;
+    rgb_matrix_ws2812_array[i].g = g;
+    rgb_matrix_ws2812_array[i].b = b;
 #    ifdef RGBW
-    convert_rgb_to_rgbw(ws2812_led_array[i]);
+    convert_rgb_to_rgbw(rgb_matrix_ws2812_array[i]);
 #    endif
 }
 
 static void setled_all(uint8_t r, uint8_t g, uint8_t b) {
-    for (int i = 0; i < sizeof(ws2812_led_array) / sizeof(ws2812_led_array[0]); i++) {
+    for (int i = 0; i < sizeof(rgb_matrix_ws2812_array) / sizeof(rgb_matrix_ws2812_array[0]); i++) {
         setled(i, r, g, b);
     }
 }

--- a/quantum/rgb_matrix_drivers.c
+++ b/quantum/rgb_matrix_drivers.c
@@ -98,27 +98,27 @@ const rgb_matrix_driver_t rgb_matrix_driver = {
 #elif defined(WS2812)
 
 // LED color buffer
-LED_TYPE led[DRIVER_LED_TOTAL];
+LED_TYPE led_matrix[DRIVER_LED_TOTAL];
 
 static void init(void) {}
 
 static void flush(void) {
     // Assumes use of RGB_DI_PIN
-    ws2812_setleds(led, DRIVER_LED_TOTAL);
+    ws2812_setleds(led_matrix, DRIVER_LED_TOTAL);
 }
 
 // Set an led in the buffer to a color
 static inline void setled(int i, uint8_t r, uint8_t g, uint8_t b) {
-    led[i].r = r;
-    led[i].g = g;
-    led[i].b = b;
+    led_matrix[i].r = r;
+    led_matrix[i].g = g;
+    led_matrix[i].b = b;
 #    ifdef RGBW
-    convert_rgb_to_rgbw(led[i]);
+    convert_rgb_to_rgbw(led_matrix[i]);
 #    endif
 }
 
 static void setled_all(uint8_t r, uint8_t g, uint8_t b) {
-    for (int i = 0; i < sizeof(led) / sizeof(led[0]); i++) {
+    for (int i = 0; i < sizeof(led_matrix) / sizeof(led_matrix[0]); i++) {
         setled(i, r, g, b);
     }
 }

--- a/quantum/rgb_matrix_drivers.c
+++ b/quantum/rgb_matrix_drivers.c
@@ -98,27 +98,27 @@ const rgb_matrix_driver_t rgb_matrix_driver = {
 #elif defined(WS2812)
 
 // LED color buffer
-LED_TYPE led_matrix[DRIVER_LED_TOTAL];
+LED_TYPE ws2812_led_array[DRIVER_LED_TOTAL];
 
 static void init(void) {}
 
 static void flush(void) {
     // Assumes use of RGB_DI_PIN
-    ws2812_setleds(led_matrix, DRIVER_LED_TOTAL);
+    ws2812_setleds(ws2812_led_array, DRIVER_LED_TOTAL);
 }
 
 // Set an led in the buffer to a color
 static inline void setled(int i, uint8_t r, uint8_t g, uint8_t b) {
-    led_matrix[i].r = r;
-    led_matrix[i].g = g;
-    led_matrix[i].b = b;
+    ws2812_led_array[i].r = r;
+    ws2812_led_array[i].g = g;
+    ws2812_led_array[i].b = b;
 #    ifdef RGBW
-    convert_rgb_to_rgbw(led_matrix[i]);
+    convert_rgb_to_rgbw(ws2812_led_array[i]);
 #    endif
 }
 
 static void setled_all(uint8_t r, uint8_t g, uint8_t b) {
-    for (int i = 0; i < sizeof(led_matrix) / sizeof(led_matrix[0]); i++) {
+    for (int i = 0; i < sizeof(ws2812_led_array) / sizeof(ws2812_led_array[0]); i++) {
         setled(i, r, g, b);
     }
 }


### PR DESCRIPTION
Is a minor change that only affects the driver file. 

However, this will allow somebody to run rgblight along side rgb matrix
using the ws2812 driver, as well.  Specifically, so you can use the
custom driver for rgblight to set a different pin (barring a change to
the `ws2812_setleds` function).  

Courtesy of discord conversion:
https://discordapp.com/channels/440868230475677696/568161140534935572/721555623191248906


Specifically, the issue is that both rgblight and rgb matrix use an array named `led` to hold the LED array before sending it to the hardware. This creates a conflict.  Renaming the led array in rgb matrix allows for coexistence. 


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
