### PR TITLE
[Fix] Adapt build workflow in order to compute mcu context variables before executing rules

### DIFF
--- a/build_keyboard.mk
+++ b/build_keyboard.mk
@@ -101,6 +101,9 @@ MAIN_KEYMAP_PATH_5 := $(KEYBOARD_PATH_5)/keymaps/$(KEYMAP)
 # Check for keymap.json first, so we can regenerate keymap.c
 include build_json.mk
 
+# Execute mcu_selection before rules.mk, then mcu context variables are available for rules.mk
+include quantum/mcu_selection.mk
+
 ifeq ("$(wildcard $(KEYMAP_PATH))", "")
     # Look through the possible keymap folders until we find a matching keymap.c
     ifneq ("$(wildcard $(MAIN_KEYMAP_PATH_5)/keymap.c)","")
@@ -145,8 +148,6 @@ endif
 ifneq ($(FORCE_LAYOUT),)
     TARGET := $(TARGET)_$(FORCE_LAYOUT)
 endif
-
-include quantum/mcu_selection.mk
 
 ifdef MCU_FAMILY
     OPT_DEFS += -DQMK_STM32


### PR DESCRIPTION
Adapt build workflow in order to compute mcu context variables before executing rules.

## Description

I start to have an issue on the PR #9415.
A community configuration for ortholinear 5x12 keyboard wasn't able to build because there is a condition looking at the var `PROTOCOL` in the `rules.mk` file: https://github.com/qmk/qmk_firmware/blob/master/layouts/community/ortho_5x12/xyverz/rules.mk#L27

The `PROTOCOL` var is computed into `quantum/mcu_selection.mk`. `mcu_selection.mk`file is executed AFTER executing all `rules.mk`, if you look at the include order into `build_keyboard.mk`.

By changing the include order, `PROTOCOL` and others "mcu context variables" are computed BEFORE executing all `rules.mk`, then `rules.mk` can use the "mcu context variables" without issue.

ℹ️  Interesting point: vars defined into `rules.mk` are available into `quantum/mcu_selection.mk`, it's independent of the include orders. So, vars are evaluate during a first execution loop, then `mk` files are executed in a second execution loop with all the vars previously evaluated.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
