### PR TITLE
Add TAP_CODE_DELAY to Mod-Tap

### DIFF
--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -357,6 +357,8 @@ void process_action(keyrecord_t *record, action_t action) {
                             dprint("MODS_TAP: Tap: unregister_code\n");
                             if (action.layer_tap.code == KC_CAPS) {
                                 wait_ms(TAP_HOLD_CAPS_DELAY);
+                            } else {
+                                wait_ms(TAP_CODE_DELAY);
                             }
                             unregister_code(action.key.code);
                         } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Adds TAP_CODE_DELAY to the Mod-Tap function and fixes #9418.

This is my first contribution to QMK, so please check that I didn't do any obvious mistakes here 👼 I tested this on my ErgoDox and it works well, but I'm unsure if this could have any side effects.

Note: There were compilation errors and "firmware too large" messages when running `make all`, but I think these may be related to my build environment or outdated layouts and are not caused by my change, but I'm not 100% sure about this.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

<!--- Describe your changes in detail here. -->

## Types of Changes

Copied the `else` branch as suggested by @fauxpark in #9418 from Layer-Tap.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #9418

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
