### PR TITLE
Add python and pip to Windows instructions

### DIFF
--- a/docs/newbs_getting_started.md
+++ b/docs/newbs_getting_started.md
@@ -50,7 +50,7 @@ After opening a new MSYS2 MinGW 64-bit terminal, make sure `pacman` is up to dat
 
 You may be asked to close and reopen the window. Do this and keep running the above command until it says `there is nothing to do`. Then run the following:
 
-    pacman -S git mingw-w64-x86_64-toolchain mingw-w64-x86_64-python3-pip
+    pacman -S git python3 python3-pip mingw-w64-x86_64-toolchain mingw-w64-x86_64-python3-pip
     python3 -m pip install qmk
 
 ### macOS


### PR DESCRIPTION
Added packages python3 and python3-pip in the pacman command.

## Description

The installation instructions did not work on Windows 10. Packages python3 and python3-pip needed to be installed by adding separate parameters in the pacman command when using a fresh MSYS2 install on Windows 10.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
