### PR TITLE
Remove rules.mk for gboards/engine and gboards/g

### DIFF
--- a/keyboards/gboards/engine/rules.mk
+++ b/keyboards/gboards/engine/rules.mk
@@ -1,1 +1,0 @@
-SRC += engine.c

--- a/keyboards/gboards/g/rules.mk
+++ b/keyboards/gboards/g/rules.mk
@@ -1,1 +1,0 @@
-SRC += engine.c


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

These folders don't contain actual keyboard definitions, so they should not have a rules.mk as that is one of the criteria, and is causing these lines in the API error_log:

```
"Warning: gboards/engine: Falling back to searching for KEYMAP/LAYOUT macros."
"Warning: gboards/g: Falling back to searching for KEYMAP/LAYOUT macros."
```

Otherwise @germ if you still need these would it be possible to use a different name so it doesn't get picked up? I don't see any references to it in your current boards or open PRs.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
