### PR TITLE
YMD75: move MCU/Bootloader rules to revision level

### DIFF
--- a/keyboards/ymd75/rev1/rules.mk
+++ b/keyboards/ymd75/rev1/rules.mk
@@ -1,3 +1,16 @@
+# MCU name
+MCU = atmega32a
+
+# Bootloader selection
+#   Teensy       halfkay
+#   Pro Micro    caterina
+#   Atmel DFU    atmel-dfu
+#   LUFA DFU     lufa-dfu
+#   QMK DFU      qmk-dfu
+#   ATmega32A    bootloadHID
+#   ATmega328P   USBasp
+BOOTLOADER = bootloadHID
+
 # build options
 BOOTMAGIC_ENABLE = yes
 MOUSEKEY_ENABLE = no

--- a/keyboards/ymd75/rev2/rules.mk
+++ b/keyboards/ymd75/rev2/rules.mk
@@ -1,3 +1,16 @@
+# MCU name
+MCU = atmega32a
+
+# Bootloader selection
+#   Teensy       halfkay
+#   Pro Micro    caterina
+#   Atmel DFU    atmel-dfu
+#   LUFA DFU     lufa-dfu
+#   QMK DFU      qmk-dfu
+#   ATmega32A    bootloadHID
+#   ATmega328P   USBasp
+BOOTLOADER = bootloadHID
+
 # build options
 BOOTMAGIC_ENABLE = yes
 MOUSEKEY_ENABLE = no

--- a/keyboards/ymd75/rules.mk
+++ b/keyboards/ymd75/rules.mk
@@ -1,14 +1,1 @@
-# MCU name
-MCU = atmega32a
-
-# Bootloader selection
-#   Teensy       halfkay
-#   Pro Micro    caterina
-#   Atmel DFU    atmel-dfu
-#   LUFA DFU     lufa-dfu
-#   QMK DFU      qmk-dfu
-#   ATmega32A    bootloadHID
-#   ATmega328P   USBasp
-BOOTLOADER = bootloadHID
-
 DEFAULT_FOLDER = ymd75/rev1


### PR DESCRIPTION
## Description

Work-around for an issue with QMK Configurator's API that prevents it from compiling firmware for this board.

## Types of Changes

- [x] Enhancement/optimization
- [x] Keyboard (addition or update)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
