### PR TITLE
Fixing MIDI for ARM without NKRO enabled

### DIFF
--- a/tmk_core/protocol/midi/qmk_midi.h
+++ b/tmk_core/protocol/midi/qmk_midi.h
@@ -2,6 +2,7 @@
 
 #ifdef MIDI_ENABLE
 #    include "midi.h"
+#    include <LUFA/Drivers/USB/USB.h>
 extern MidiDevice midi_device;
 void              setup_midi(void);
 void              send_midi_packet(MIDI_EventPacket_t* event);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
MIDI does not work for ARM without NKRO enabled, because it includes this header file. By adding this, the correct header is included regardless of NKRO, while allowing AVR to continue to work.
## Types of Changes
Adding header file.
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* fixes #9439

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
