### PR TITLE
spidey3 userspace: GUI F-Key lock was affecting some non-F-keys

### DIFF
--- a/users/spidey3/spidey3.c
+++ b/users/spidey3/spidey3.c
@@ -223,7 +223,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             }
             break;
 
-        case KC_F1 ... KC_F24:
+        case KC_F1 ... KC_F12:
             return process_gflock(keycode, record);
     }
 


### PR DESCRIPTION
##  Description

Fixes a bug that caused cursor keys and some other keys to be sent as LGUI(key) when GUI F-key lock mode was on.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
