### PR TITLE
Allow for WS2812 PWM to work on DMAMUX-capable devices

### DIFF
--- a/docs/ws2812_driver.md
+++ b/docs/ws2812_driver.md
@@ -92,6 +92,7 @@ Configure the hardware via your config.h:
 #define WS2812_PWM_PAL_MODE 2  // Pin "alternate function", see the respective datasheet for the appropriate values for your MCU. default: 2
 #define WS2812_DMA_STREAM STM32_DMA1_STREAM2  // DMA Stream for TIMx_UP, see the respective reference manual for the appropriate values for your MCU.
 #define WS2812_DMA_CHANNEL 2  // DMA Channel for TIMx_UP, see the respective reference manual for the appropriate values for your MCU.
+#define WS2812_DMAMUX_ID STM32_DMAMUX1_TIM2_UP // DMAMUX configuration for TIMx_UP -- only required if your MCU has a DMAMUX peripheral, see the respective reference manual for the appropriate values for your MCU.
 ```
 
 You must also turn on the PWM feature in your halconf.h and mcuconf.h
@@ -117,5 +118,5 @@ Note: This only applies to STM32 boards.
 
  To configure the `RGB_DI_PIN` to open drain configuration add this to your config.h file: 
 ```c
- #define WS2812_EXTERNAL_PULLUP 
+#define WS2812_EXTERNAL_PULLUP
 ```

--- a/drivers/chibios/ws2812_pwm.c
+++ b/drivers/chibios/ws2812_pwm.c
@@ -23,6 +23,9 @@
 #ifndef WS2812_DMA_CHANNEL
 #    define WS2812_DMA_CHANNEL 2  // DMA Channel for TIMx_UP
 #endif
+#if (STM32_DMA_SUPPORTS_DMAMUX == TRUE) && !defined(WS2812_DMAMUX_ID)
+#    error "please consult your MCU's datasheet and specify in your config.h: #define WS2812_DMAMUX_ID STM32_DMAMUX1_TIM?_UP"
+#endif
 
 // Push Pull or Open Drain Configuration
 // Default Push Pull
@@ -183,6 +186,11 @@ void ws2812_init(void) {
     dmaStreamSetTransactionSize(WS2812_DMA_STREAM, WS2812_BIT_N);
     dmaStreamSetMode(WS2812_DMA_STREAM, STM32_DMA_CR_CHSEL(WS2812_DMA_CHANNEL) | STM32_DMA_CR_DIR_M2P | STM32_DMA_CR_PSIZE_WORD | STM32_DMA_CR_MSIZE_WORD | STM32_DMA_CR_MINC | STM32_DMA_CR_CIRC | STM32_DMA_CR_PL(3));
     // M2P: Memory 2 Periph; PL: Priority Level
+
+#if (STM32_DMA_SUPPORTS_DMAMUX == TRUE)
+    // If the MCU has a DMAMUX we need to assign the correct resource
+    dmaSetRequestSource(WS2812_DMA_STREAM, WS2812_DMAMUX_ID);
+#endif
 
     // Start DMA
     dmaStreamEnable(WS2812_DMA_STREAM);


### PR DESCRIPTION
## Description

Newer STM32 MCUs have a DMAMUX peripheral, which allows mapping of DMAs to different DMA streams, rather than hard-defining the target streams in silicon.

Affects STM32L4+ devices, as well as the soon-to-be-supported-by-QMK STM32G4/H7 families.

Tested on F303/Proton-C (ChibiOS v19, non-DMAMUX), G474 (ChibiOS v20, with DMAMUX). 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
