### PR TITLE
gcc 10 compatibility for Drop alt

### DIFF
--- a/keyboards/massdrop/alt/keymaps/abishalom/keymap.c
+++ b/keyboards/massdrop/alt/keymaps/abishalom/keymap.c
@@ -12,8 +12,6 @@ enum alt_keycodes {
 
 #define TG_NKRO MAGIC_TOGGLE_NKRO //Toggle 6KRO / NKRO mode
 
-keymap_config_t keymap_config;
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [0] = LAYOUT(
         KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_DEL,  \

--- a/keyboards/massdrop/alt/keymaps/bonta/keymap.c
+++ b/keyboards/massdrop/alt/keymaps/bonta/keymap.c
@@ -14,8 +14,6 @@ enum alt_keycodes {
 #define RGB_BRU RGB_VAI
 #define RGB_BRD RGB_VAD
 
-keymap_config_t keymap_config;
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [0] = LAYOUT(
         KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_DEL,  \

--- a/keyboards/massdrop/alt/keymaps/default/keymap.c
+++ b/keyboards/massdrop/alt/keymaps/default/keymap.c
@@ -10,8 +10,6 @@ enum alt_keycodes {
     MD_BOOT,               //Restart into bootloader after hold timeout
 };
 
-keymap_config_t keymap_config;
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [0] = LAYOUT_65_ansi_blocker(
         KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_DEL,  \

--- a/keyboards/massdrop/alt/keymaps/default_md/keymap.c
+++ b/keyboards/massdrop/alt/keymaps/default_md/keymap.c
@@ -21,8 +21,6 @@ enum alt_keycodes {
     MD_BOOT             //Restart into bootloader after hold timeout                //Working
 };
 
-keymap_config_t keymap_config;
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [0] = LAYOUT(
         KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_DEL,  \

--- a/keyboards/massdrop/alt/keymaps/favorable-mutation/keymap.c
+++ b/keyboards/massdrop/alt/keymaps/favorable-mutation/keymap.c
@@ -28,8 +28,6 @@ enum alt_keycodes {
 //
 //TODO tap/toggle for layers
 
-keymap_config_t keymap_config;
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [0] = LAYOUT(
         KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_SPOT,

--- a/keyboards/massdrop/alt/keymaps/mac/keymap.c
+++ b/keyboards/massdrop/alt/keymaps/mac/keymap.c
@@ -10,8 +10,6 @@ enum alt_keycodes {
     MD_BOOT,               //Restart into bootloader after hold timeout
 };
 
-keymap_config_t keymap_config;
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [0] = LAYOUT(
         KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_DEL,  \

--- a/keyboards/massdrop/alt/keymaps/mac_md/keymap.c
+++ b/keyboards/massdrop/alt/keymaps/mac_md/keymap.c
@@ -21,8 +21,6 @@ enum alt_keycodes {
     MD_BOOT             //Restart into bootloader after hold timeout                //Working
 };
 
-keymap_config_t keymap_config;
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [0] = LAYOUT(
         KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_DEL,  \

--- a/keyboards/massdrop/alt/keymaps/reywood/keymap.c
+++ b/keyboards/massdrop/alt/keymaps/reywood/keymap.c
@@ -26,8 +26,6 @@ enum alt_keycodes {
 #define TG_NKRO MAGIC_TOGGLE_NKRO //Toggle 6KRO / NKRO mode
 #define ______ KC_TRNS
 
-keymap_config_t keymap_config;
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   [0] = LAYOUT(
     KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_DEL,  \

--- a/tmk_core/protocol/arm_atsam/i2c_master.c
+++ b/tmk_core/protocol/arm_atsam/i2c_master.c
@@ -28,6 +28,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #    define I2C_LED_USE_DMA 1  // Set 1 to use background DMA transfers for leds, Set 0 to use inline software transfers
 
+DmacDescriptor dmac_desc;
+DmacDescriptor dmac_desc_wb;
+
 static uint8_t i2c_led_q[I2C_Q_SIZE];  // I2C queue circular buffer
 static uint8_t i2c_led_q_s;            // Start of circular buffer
 static uint8_t i2c_led_q_e;            // End of circular buffer

--- a/tmk_core/protocol/arm_atsam/i2c_master.h
+++ b/tmk_core/protocol/arm_atsam/i2c_master.h
@@ -24,8 +24,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    include "issi3733_driver.h"
 #    include "config.h"
 
-__attribute__((__aligned__(16))) DmacDescriptor dmac_desc;
-__attribute__((__aligned__(16))) DmacDescriptor dmac_desc_wb;
+extern __attribute__((__aligned__(16))) DmacDescriptor dmac_desc;
+extern __attribute__((__aligned__(16))) DmacDescriptor dmac_desc_wb;
 
 uint8_t I2C3733_Init_Control(void);
 uint8_t I2C3733_Init_Drivers(void);


### PR DESCRIPTION
According to the official documentation[1] gcc 10 is more strict about
correct extern usage.

I've had to split the definition and declaration of dmac_desc and dmac_desc_wb
from i2c_master.{c,h}. This could be an issue if anyone includes the
i2c_master.h file without liking with the object file.

I've also had to remove the keymap_config definition from all the massdrop alt
keymaps, since it's defined in magic.c as well. The same would have to be done
for other keymaps. It doesn't seem like any of the in-tree keymaps use the
variable anyway. Anyone using it would have to declare it extern in their
keymap.

With these changes all the in-tree keymaps for the massdrop alt now compiles in
gcc 10

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #9268 (This issue tracks multiple problems, this fixes part of it)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
