### PR TITLE
[Fix] Import users addition at the right step in the build_keyboard workflow and deactivate NKRO for VUSB Protocol

### DIFF
--- a/build_keyboard.mk
+++ b/build_keyboard.mk
@@ -91,7 +91,6 @@ ifneq ("$(wildcard $(KEYBOARD_PATH_1)/rules.mk)","")
     include $(KEYBOARD_PATH_1)/rules.mk
 endif
 
-
 MAIN_KEYMAP_PATH_1 := $(KEYBOARD_PATH_1)/keymaps/$(KEYMAP)
 MAIN_KEYMAP_PATH_2 := $(KEYBOARD_PATH_2)/keymaps/$(KEYMAP)
 MAIN_KEYMAP_PATH_3 := $(KEYBOARD_PATH_3)/keymaps/$(KEYMAP)
@@ -131,6 +130,14 @@ ifeq ("$(wildcard $(KEYMAP_PATH))", "")
         # this state should never be reached
     endif
 endif
+
+# Userspace setup
+ifeq ("$(USER_NAME)","")
+    USER_NAME := $(KEYMAP)
+endif
+USER_PATH := users/$(USER_NAME)
+# Userspace rules.mk
+-include $(USER_PATH)/rules.mk
 
 ifeq ($(strip $(CTPC)), yes)
   CONVERT_TO_PROTON_C=yes
@@ -279,13 +286,7 @@ ifneq ("$(wildcard $(KEYBOARD_PATH_5)/post_config.h)","")
     POST_CONFIG_H += $(KEYBOARD_PATH_5)/post_config.h
 endif
 
-# Userspace setup and definitions
-ifeq ("$(USER_NAME)","")
-    USER_NAME := $(KEYMAP)
-endif
-USER_PATH := users/$(USER_NAME)
-
--include $(USER_PATH)/rules.mk
+# Userspace config
 ifneq ("$(wildcard $(USER_PATH)/config.h)","")
     CONFIG_H += $(USER_PATH)/config.h
 endif

--- a/layouts/community/ortho_5x12/xyverz/rules.mk
+++ b/layouts/community/ortho_5x12/xyverz/rules.mk
@@ -23,9 +23,5 @@ endif
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
 SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
 
-# Enable N-Key Rollover, except in cases of VUSB:
-ifeq ($(strip $(PROTOCOL)), VUSB)
-  NKRO_ENABLE = no
-else
-  NKRO_ENABLE = yes
-endif
+# Enable N-Key Rollover
+NKRO_ENABLE = yes

--- a/quantum/mcu_selection.mk
+++ b/quantum/mcu_selection.mk
@@ -320,3 +320,8 @@ ifneq (,$(filter $(MCU),attiny85))
   NO_UART ?= yes
   NO_SUSPEND_POWER_DOWN ?= yes
 endif
+
+ifeq ($(strip $(PROTOCOL)),VUSB)
+  # prevent VUSB boards from enabling NKRO, as they do not support it.
+  NKRO_ENABLE = no
+endif

--- a/users/curry/rules.mk
+++ b/users/curry/rules.mk
@@ -62,10 +62,3 @@ endif
 ifeq ($(strip $(MAKE_BOOTLOADER)), yes)
     OPT_DEFS += -DMAKE_BOOTLOADER
 endif
-
-# At least until build.mk or the like drops, this is here to prevent
-# VUSB boards from enabling NKRO, as they do not support it. Ideally
-# this should be handled per keyboard, but until that happens ...
-ifeq ($(strip $(PROTOCOL)), VUSB)
-    NKRO_ENABLE       = no
-endif

--- a/users/drashna/rules.mk
+++ b/users/drashna/rules.mk
@@ -49,13 +49,6 @@ ifeq ($(strip $(MAKE_BOOTLOADER)), yes)
     OPT_DEFS += -DMAKE_BOOTLOADER
 endif
 
-# At least until build.mk or the like drops, this is here to prevent
-# VUSB boards from enabling NKRO, as they do not support it. Ideally
-# this should be handled per keyboard, but until that happens ...
-ifeq ($(strip $(PROTOCOL)), VUSB)
-    NKRO_ENABLE       = no
-endif
-
 ifeq ($(strip $(OLED_DRIVER_ENABLE)), yes)
     SRC += oled_stuff.c
 endif


### PR DESCRIPTION
This PR has 2 changes:
- it import `userspace rules.mk` after importing all `keyboard/community rules.mk`, but before the `mcu_selection.mk`
- it overrides the variable `NKRO_ENABLE` at the value `no`  in the `mcu_selection.mk` file for VUSB protocol **only**.

## Description
There is a workaround used in some community configuration in order to be compliant with "all board":

```Makefile
ifeq ($(strip $(PROTOCOL)), VUSB)
    NKRO_ENABLE = no
endif
```

By defining the `NKRO_ENABLE` variable when we defined the `PROTOCOL` variable at `VUSB`, we can avoid activating `NKRO` for an unsupported board.

This way, there is no knowledge needed on the maintainers' side to know the NKRO must be disabled for specifics boards.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
