### PR TITLE
Make WPM able to sync between keyboard halves on Ergodox Infinity.

### DIFF
--- a/keyboards/ergodox_infinity/ergodox_infinity.c
+++ b/keyboards/ergodox_infinity/ergodox_infinity.c
@@ -50,30 +50,30 @@ void init_serial_link_hal(void) {
 // Which will reduce the brightness range
 #define PRESCALAR_DEFINE 0
 void lcd_backlight_hal_init(void) {
-	// Setup Backlight
+    // Setup Backlight
     SIM->SCGC6 |= SIM_SCGC6_FTM0;
     FTM0->CNT = 0; // Reset counter
 
-	// PWM Period
-	// 16-bit maximum
-	FTM0->MOD = 0xFFFF;
+    // PWM Period
+    // 16-bit maximum
+    FTM0->MOD = 0xFFFF;
 
-	// Set FTM to PWM output - Edge Aligned, Low-true pulses
+    // Set FTM to PWM output - Edge Aligned, Low-true pulses
 #define CNSC_MODE FTM_SC_CPWMS | FTM_SC_PS(4) | FTM_SC_CLKS(0)
-	CHANNEL_RED.CnSC = CNSC_MODE;
-	CHANNEL_GREEN.CnSC = CNSC_MODE;
-	CHANNEL_BLUE.CnSC = CNSC_MODE;
+    CHANNEL_RED.CnSC = CNSC_MODE;
+    CHANNEL_GREEN.CnSC = CNSC_MODE;
+    CHANNEL_BLUE.CnSC = CNSC_MODE;
 
-	// System clock, /w prescalar setting
-	FTM0->SC = FTM_SC_CLKS(1) | FTM_SC_PS(PRESCALAR_DEFINE);
+    // System clock, /w prescalar setting
+    FTM0->SC = FTM_SC_CLKS(1) | FTM_SC_PS(PRESCALAR_DEFINE);
 
-	CHANNEL_RED.CnV = 0;
-	CHANNEL_GREEN.CnV = 0;
-	CHANNEL_BLUE.CnV = 0;
+    CHANNEL_RED.CnV = 0;
+    CHANNEL_GREEN.CnV = 0;
+    CHANNEL_BLUE.CnV = 0;
 
-	RGB_PORT_GPIO->PDDR |= (1 << RED_PIN);
-	RGB_PORT_GPIO->PDDR |= (1 << GREEN_PIN);
-	RGB_PORT_GPIO->PDDR |= (1 << BLUE_PIN);
+    RGB_PORT_GPIO->PDDR |= (1 << RED_PIN);
+    RGB_PORT_GPIO->PDDR |= (1 << GREEN_PIN);
+    RGB_PORT_GPIO->PDDR |= (1 << BLUE_PIN);
 
 #define RGB_MODE PORTx_PCRn_SRE | PORTx_PCRn_DSE | PORTx_PCRn_MUX(4)
     RGB_PORT->PCR[RED_PIN] = RGB_MODE;
@@ -105,9 +105,9 @@ static uint16_t cie_lightness(uint16_t v) {
 }
 
 void lcd_backlight_hal_color(uint16_t r, uint16_t g, uint16_t b) {
-	CHANNEL_RED.CnV = cie_lightness(r);
-	CHANNEL_GREEN.CnV = cie_lightness(g);
-	CHANNEL_BLUE.CnV = cie_lightness(b);
+    CHANNEL_RED.CnV = cie_lightness(r);
+    CHANNEL_GREEN.CnV = cie_lightness(g);
+    CHANNEL_BLUE.CnV = cie_lightness(b);
 }
 
 __attribute__ ((weak))
@@ -120,39 +120,39 @@ void matrix_scan_user(void) {
 
 
 void matrix_init_kb(void) {
-	// put your keyboard start-up code here
-	// runs once when the firmware starts up
+    // put your keyboard start-up code here
+    // runs once when the firmware starts up
 
-	matrix_init_user();
-	// The backlight always has to be initialized, otherwise it will stay lit
+    matrix_init_user();
+    // The backlight always has to be initialized, otherwise it will stay lit
 #ifndef VISUALIZER_ENABLE
-	lcd_backlight_hal_init();
+    lcd_backlight_hal_init();
 #endif
 #ifdef WPM_ENABLE
-	add_remote_objects(remote_objects, sizeof(remote_objects) / sizeof(remote_object_t*));
+    add_remote_objects(remote_objects, sizeof(remote_objects) / sizeof(remote_object_t*));
 #endif
 }
 
 void matrix_scan_kb(void) {
-	// put your looping keyboard code here
-	// runs every cycle (a lot)
+    // put your looping keyboard code here
+    // runs every cycle (a lot)
 
 #ifdef WPM_ENABLE
-	if (is_serial_link_master()) {
-		uint8_t current_wpm = get_current_wpm();
-		if (current_wpm != last_sent_wpm) {
-			*begin_write_current_wpm() = current_wpm;
-			end_write_current_wpm();
-			last_sent_wpm = current_wpm;
-		}
-	} else if (is_serial_link_connected()) {
-		uint8_t* new_wpm = read_current_wpm();
-		if (new_wpm) {
-			set_current_wpm(*new_wpm);
-		}
-	}
+    if (is_serial_link_master()) {
+        uint8_t current_wpm = get_current_wpm();
+        if (current_wpm != last_sent_wpm) {
+            *begin_write_current_wpm() = current_wpm;
+            end_write_current_wpm();
+            last_sent_wpm = current_wpm;
+        }
+    } else if (is_serial_link_connected()) {
+        uint8_t* new_wpm = read_current_wpm();
+        if (new_wpm) {
+            set_current_wpm(*new_wpm);
+        }
+    }
 #endif
-	matrix_scan_user();
+    matrix_scan_user();
 }
 
 bool is_keyboard_master(void) {


### PR DESCRIPTION
Make Ergodox Infinity sync calculated Words Per Minute between keyboard halves.

## Description

The Words Per Minute calculation feature from PR #8054 that was merged back in March included code to sync the WPM value between keyboard halves using the split_common framework. This PR adds code to Ergodox Infinity to sync the WPM value between its keyboard halves, since it's using a different transport mechanism (serial_link).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
