### PR TITLE
Ergodox Infinity: Add EE_HANDS support.

### DIFF
--- a/keyboards/ergodox_infinity/matrix.c
+++ b/keyboards/ergodox_infinity/matrix.c
@@ -24,6 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "print.h"
 #include "debug.h"
 #include "matrix.h"
+#include "eeconfig.h"
 #include "serial_link/system/serial_link.h"
 
 
@@ -118,8 +119,12 @@ uint8_t matrix_scan(void)
     }
 
     uint8_t offset = 0;
-#ifdef MASTER_IS_ON_RIGHT
+#if (defined(EE_HANDS) || defined(MASTER_IS_ON_RIGHT))
+#ifdef EE_HANDS
+    if (is_serial_link_master() && !eeconfig_read_handedness()) {
+#else
     if (is_serial_link_master()) {
+#endif
         offset = MATRIX_ROWS - LOCAL_MATRIX_ROWS;
     }
 #endif
@@ -162,7 +167,13 @@ void matrix_print(void)
 
 void matrix_set_remote(matrix_row_t* rows, uint8_t index) {
     uint8_t offset = 0;
-#ifdef MASTER_IS_ON_RIGHT
+#ifdef EE_HANDS
+    if (eeconfig_read_handedness()) {
+        offset = LOCAL_MATRIX_ROWS * (index + 1);
+    } else {
+        offset = MATRIX_ROWS - LOCAL_MATRIX_ROWS * (index + 2);
+    }
+#elif defined(MASTER_IS_ON_RIGHT)
     offset = MATRIX_ROWS - LOCAL_MATRIX_ROWS * (index + 2);
 #else
     offset = LOCAL_MATRIX_ROWS * (index + 1);

--- a/keyboards/ergodox_infinity/readme.md
+++ b/keyboards/ergodox_infinity/readme.md
@@ -29,6 +29,9 @@ Input Club Infinity Ergodox](https://github.com/fredizzimo/infinity_ergodox/blob
 The Infinity is two completely independent keyboards, that can connect together.
 You have a few options in how you flash the firmware:
 
+- Add `#define EE_HANDS` to your config.h, initialize the EEPROM values (see below),
+  and then flash the same firmware to both halves.
+
 - Flash the left half, rebuild the firmware with "MASTER=right" and then flash
   the right half.  This allows you to plug in either half directly to the
   computer and is what the above instructions do.
@@ -43,6 +46,35 @@ You have a few options in how you flash the firmware:
   directly connect the right half to the computer.
 
 - For minor changes such as changing only the keymap without having updated
-  any part of the firmware code itself, you can program only the MASTER half.
+  any part of the firmware code itself, you can program only the MASTER half,
+  but it is safest to program both halves.
 
-- It is safest to program both halves though.
+### EE_HANDS initialization
+
+To initialize the EEPROM values for `EE_HANDS` to work properly, these steps should work.
+They only need to be done once, unless you reset the EEPROM later.
+
+  - Plug in the left keyboard half to the computer, and press its program button.
+
+  - Flash the left half with `make ergodox_infinity:default:dfu-util-split-left`
+    (If you need to use a different method to flash your keyboard, still run this command,
+    and abort it with Ctrl+C when the flashing attempts starts to print errors,
+    then flash the built firmware).
+
+  - On the left half, press the top vertical 1.5U key (second from the top in the rightmost column) once,
+    then the 1U key at the bottom in the opposite corner (bottom left corner).
+
+  - Plug in the right keyboard half to the computer, and press its program button.
+
+  - Flash the right half with `make ergodox_infinity:default:dfu-util-split-right`
+
+  - On the right half, press the top vertical 1.5U key (second from the top in the leftmost column) once,
+    then the 1U key at the bottom in the opposite corner (bottom right corner).
+
+  - Add `#define EE_HANDS` to the config.h file of your keymap, and build your firmware using
+    `make ergodox_infinity:keymapname`.
+
+  - After this, you can flash both halves with the same firmware, _without_ having to rebuild with
+    "MASTER=right" or risking a mirrored keyboard when connected the wrong way.
+    If you reset your EEPROM later, you'll have to follow these steps again, though.
+


### PR DESCRIPTION
Add EE_HANDS support to Ergodox Infinity.

## Description

Ergodox Infinity doesn't use the split_common framework, but either half (or both) can be connected to the computer (with the second half optionally connected to that half, to make them behave as a single keyboard). Currently, the two halves must be flashed with separate firmwares to be able to work "in both directions", which requires QMK to be rebuilt with MASTER=right.

This PR adds the ability to use the EE_HANDS feature on Ergodox Infinity, making it possible to flash both halves with the same firmware and still have them behave properly, regardless of how the two halves are connected to the computer. I also added a guide to set the required EEPROM values (in ergodox_infinity/readme.md), as it's currently a bit awkward on devices using dfu-util.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
