### PR TITLE
Improve LAYOUT macro searching

### DIFF
--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -108,19 +108,20 @@ def _search_keyboard_h(layouts, path):
         if keyboard_h_path.exists():
             layouts.update(find_layouts(keyboard_h_path))
 
+    return layouts
+
 
 def _find_all_layouts(keyboard):
     """Looks for layout macros associated with this keyboard.
     """
-    layouts = {}
     rules = rules_mk(keyboard)
 
     # Pull in all layouts defined in the standard files
-    _search_keyboard_h(layouts, Path(keyboard))
+    layouts = _search_keyboard_h(Path(keyboard))
 
     if not layouts:
         # Search in DEFAULT_FOLDER next, if we didn't get any hits
-        _search_keyboard_h(layouts, Path(rules.get('DEFAULT_FOLDER', keyboard)))
+        layouts = _search_keyboard_h(layouts, Path(rules.get('DEFAULT_FOLDER', keyboard)))
 
     if not layouts:
         # If we didn't find any layouts above we widen our search. This is error

--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -18,13 +18,9 @@ def info_json(keyboard):
     """
     cur_dir = Path('keyboards')
     rules = parse_rules_mk_file(cur_dir / keyboard / 'rules.mk')
-    default_folder = rules.get('DEFAULT_FOLDER', '')
-
-    if not default_folder == keyboard:
-        rules = parse_rules_mk_file(cur_dir / Path(default_folder) / 'rules.mk', rules)
-        default_folder = rules.get('DEFAULT_FOLDER', keyboard)
-
-    keyboard = default_folder
+    if 'DEFAULT_FOLDER' in rules:
+        keyboard = rules['DEFAULT_FOLDER']
+        rules = parse_rules_mk_file(cur_dir / keyboard / 'rules.mk', rules)
 
     info_data = {
         'keyboard_name': str(keyboard),

--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -99,8 +99,9 @@ def _extract_rules_mk(info_data):
     return info_data
 
 
-def _search_keyboard_h(layouts, path):
+def _search_keyboard_h(path):
     current_path = Path('keyboards/')
+    layouts = {}
     for directory in path.parts:
         current_path = current_path / directory
         keyboard_h = '%s.h' % (directory,)

--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -17,7 +17,7 @@ def info_json(keyboard):
     """Generate the info.json data for a specific keyboard.
     """
     cur_dir = Path('keyboards')
-    rules = parse_rules_mk_file(cur_dir / Path(keyboard) / 'rules.mk')
+    rules = parse_rules_mk_file(cur_dir / keyboard / 'rules.mk')
     default_folder = rules.get('DEFAULT_FOLDER', '')
 
     if not default_folder == keyboard:

--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -16,13 +16,6 @@ from qmk.math import compute
 def info_json(keyboard):
     """Generate the info.json data for a specific keyboard.
     """
-    info_data = {
-        'keyboard_name': str(keyboard),
-        'keyboard_folder': str(keyboard),
-        'layouts': {},
-        'maintainer': 'qmk',
-    }
-
     cur_dir = Path('keyboards')
     rules = parse_rules_mk_file(cur_dir / Path(keyboard) / 'rules.mk')
     default_folder = rules.get('DEFAULT_FOLDER', '')
@@ -32,6 +25,13 @@ def info_json(keyboard):
         default_folder = rules.get('DEFAULT_FOLDER', keyboard)
 
     keyboard = default_folder
+
+    info_data = {
+        'keyboard_name': str(keyboard),
+        'keyboard_folder': str(keyboard),
+        'layouts': {},
+        'maintainer': 'qmk',
+    }
 
     for layout_name, layout_json in _find_all_layouts(keyboard, rules).items():
         if not layout_name.startswith('LAYOUT_kc'):

--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -99,21 +99,28 @@ def _extract_rules_mk(info_data):
     return info_data
 
 
-def _find_all_layouts(keyboard):
-    """Looks for layout macros associated with this keyboard.
-    """
-    layouts = {}
-    rules = rules_mk(keyboard)
-    keyboard_path = Path(rules.get('DEFAULT_FOLDER', keyboard))
-
-    # Pull in all layouts defined in the standard files
+def _search_keyboard_h(layouts, path):
     current_path = Path('keyboards/')
-    for directory in keyboard_path.parts:
+    for directory in path.parts:
         current_path = current_path / directory
         keyboard_h = '%s.h' % (directory,)
         keyboard_h_path = current_path / keyboard_h
         if keyboard_h_path.exists():
             layouts.update(find_layouts(keyboard_h_path))
+
+
+def _find_all_layouts(keyboard):
+    """Looks for layout macros associated with this keyboard.
+    """
+    layouts = {}
+    rules = rules_mk(keyboard)
+
+    # Pull in all layouts defined in the standard files
+    _search_keyboard_h(layouts, Path(keyboard))
+
+    if not layouts:
+        # Search in DEFAULT_FOLDER next, if we didn't get any hits
+        _search_keyboard_h(layouts, Path(rules.get('DEFAULT_FOLDER', keyboard)))
 
     if not layouts:
         # If we didn't find any layouts above we widen our search. This is error


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Trying to fix the issue I discovered in https://github.com/qmk/qmk_firmware/pull/9528#issuecomment-648536062, where the presence of `DEFAULT_FOLDER` causes `qmk info` to check there first, even if we are as or more specific.

ie:
`qmk info -kb helix -l` should search `helix.h`, then `rev2/rev2.h`. But if we want `helix/rev1` instead, we should search there first, *then* fall back on `DEFAULT_FOLDER`, *then* search everywhere else.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
