### PR TITLE
Make One Shot Layer clearing configurable

### DIFF
--- a/tmk_core/common/action.h
+++ b/tmk_core/common/action.h
@@ -116,6 +116,11 @@ bool is_tap_action(action_t action);
 void process_record_tap_hint(keyrecord_t *record);
 #endif
 
+#ifndef NO_ACTION_ONESHOT
+bool get_clear_oneshot_layer(uint16_t keycode, keyrecord_t *record, bool default_value);
+uint16_t get_record_keycode(keyrecord_t *record, bool update_layer_cache);
+#endif
+
 /* debug */
 void debug_event(keyevent_t event);
 void debug_record(keyrecord_t record);


### PR DESCRIPTION
## Description

PR #8832 changed the behavior of One Shot Layer — now the layer is cleared after any keypress event for which `process_record_quantum()` returns `false` for any reason.  However, some people consider this new behavior to be a bug (#9521).  Revert this part of changes made in #8832 and make clearing of One Shot Layer configurable.

`bool get_clear_oneshot_layer(uint16_t keycode, keyrecord_t *record, bool default_value)` is mostly modeled after function for configuring dual role keys, except the `default_value` argument contains the result of the decision made by the core code (so that the user implementation could skip checking for regular modifier keys). The `get_record_keycode()` lookup does not look very nice, but other similar function also do the same lookup (although it is hidden behind a define in that case; maybe some define to enable the feature should also be added here for optimization).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #9521

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
