### PR TITLE
shell.nix improvements, and fix problems on Darwin

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -7,10 +7,34 @@ let
   };
 
   pkgs = import nixpkgs { };
+
+  hjson = with pkgs.python3Packages; buildPythonPackage rec {
+    pname = "hjson";
+    version = "3.0.1";
+
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "1yaimcgz8w0ps1wk28wk9g9zdidp79d14xqqj9rjkvxalvx2f5qx";
+    };
+    doCheck = false;
+  };
+
+  pythonEnv = pkgs.python3.withPackages (p: with p; [
+    # requirements.txt
+    appdirs
+    argcomplete
+    colorama
+    hjson
+    # requirements-dev.txt
+    nose2
+    flake8
+    pep8-naming
+    yapf
+  ]);
 in
 
 with pkgs;
-let 
+let
   avrlibc = pkgsCross.avr.libcCross;
 
   avr_incflags = [
@@ -26,8 +50,8 @@ in
 stdenv.mkDerivation {
   name = "qmk-firmware";
 
-  buildInputs = [ dfu-programmer dfu-util diffutils git python3 ]
-    ++ lib.optional avr [ 
+  buildInputs = [ dfu-programmer dfu-util diffutils git pythonEnv ]
+    ++ lib.optional avr [
       pkgsCross.avr.buildPackages.binutils
       pkgsCross.avr.buildPackages.gcc8
       avrlibc

--- a/shell.nix
+++ b/shell.nix
@@ -1,21 +1,12 @@
 { avr ? true, arm ? true, teensy ? true }:
 
 let
-  overlay = self: super:
-    let addDarwinSupport = pkg: pkg.overrideAttrs (oldAttrs: {
-      meta.platforms = (oldAttrs.meta.platforms or []) ++ self.lib.platforms.darwin;
-    });
-    in {
-      dfu-programmer = addDarwinSupport super.dfu-programmer;
-      teensy-loader-cli = addDarwinSupport super.teensy-loader-cli;
-    };
-
   nixpkgs = builtins.fetchTarball {
     url = "https://github.com/NixOS/nixpkgs/archive/903266491b7b9b0379e88709feca0af900def0d9.tar.gz";
     sha256 = "1b5wjrfgyha6s15k1yjyx41hvrpmd5szpkpkxk6l5hyrfqsr8wip";
   };
 
-  pkgs = import nixpkgs { overlays = [ overlay ]; };
+  pkgs = import nixpkgs { };
 in
 
 with pkgs;

--- a/shell.nix
+++ b/shell.nix
@@ -47,7 +47,7 @@ let
     "-L${avrlibc}/avr/lib/avr51"
   ];
 in
-stdenv.mkDerivation {
+mkShell {
   name = "qmk-firmware";
 
   buildInputs = [ dfu-programmer dfu-util diffutils git pythonEnv ]
@@ -62,4 +62,9 @@ stdenv.mkDerivation {
 
   AVR_CFLAGS = lib.optional avr avr_incflags;
   AVR_ASFLAGS = lib.optional avr avr_incflags;
+  shellHook = ''
+    # Prevent the avr-gcc wrapper from picking up host GCC flags
+    # like -iframework, which is problematic on Darwin
+    unset NIX_TARGET_CFLAGS_COMPILE
+  '';
 }


### PR DESCRIPTION
Improvements to shell.nix were made in #8910 by @thorstenweber83, but the result was that the nix shell no longer worked on Darwin.

I have tidied up and improved some of the Nix expression, fixing this issue along the way. If someone would be kind enough to test this on Linux too, that would be appreciated, though I don't expect issues.

## Description

- Removed unnecessary overrides
- Provided a more complete Python environment, adequate for actually running/developing `bin/qmk`
- Unset NIX_TARGET_CFLAGS_COMPILE in the Nix shell, to avoid incompatible host CC flags getting picked up by avr-gcc.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
