### PR TITLE
ws2812: Fix number of nops for AVR at 8 MHz

### DIFF
--- a/drivers/avr/ws2812.c
+++ b/drivers/avr/ws2812.c
@@ -68,11 +68,25 @@ void ws2812_setleds(LED_TYPE *ledarray, uint16_t number_of_leds) {
 #define w_totalcycles (((F_CPU / 1000) * w_totalperiod + 500000) / 1000000)
 
 // w1 - nops between rising edge and falling edge - low
-#define w1 (w_zerocycles - w_fixedlow)
+#if w_zerocycles >= w_fixedlow
+#    define w1 (w_zerocycles - w_fixedlow)
+#else
+#    define w1 0
+#endif
+
 // w2   nops between fe low and fe high
-#define w2 (w_onecycles - w_fixedhigh - w1)
+#if w_onecycles >= (w_fixedhigh + w1)
+#    define w2 (w_onecycles - w_fixedhigh - w1)
+#else
+#    define w2 0
+#endif
+
 // w3   nops to complete loop
-#define w3 (w_totalcycles - w_fixedtotal - w1 - w2)
+#if w_totalcycles >= (w_fixedtotal + w1 + w2)
+#    define w3 (w_totalcycles - w_fixedtotal - w1 - w2)
+#else
+#    define w3 0
+#endif
 
 #if w1 > 0
 #    define w1_nops w1

--- a/drivers/avr/ws2812.c
+++ b/drivers/avr/ws2812.c
@@ -67,31 +67,25 @@ void ws2812_setleds(LED_TYPE *ledarray, uint16_t number_of_leds) {
 #define w_onecycles (((F_CPU / 1000) * w_onepulse + 500000) / 1000000)
 #define w_totalcycles (((F_CPU / 1000) * w_totalperiod + 500000) / 1000000)
 
-// w1 - nops between rising edge and falling edge - low
+// w1_nops - nops between rising edge and falling edge - low
 #if w_zerocycles >= w_fixedlow
-#    define w1 (w_zerocycles - w_fixedlow)
-#else
-#    define w1 0
-#endif
-
-// w2   nops between fe low and fe high
-#if w_onecycles >= (w_fixedhigh + w1)
-#    define w2 (w_onecycles - w_fixedhigh - w1)
-#else
-#    define w2 0
-#endif
-
-// w3   nops to complete loop
-#if w_totalcycles >= (w_fixedtotal + w1 + w2)
-#    define w3 (w_totalcycles - w_fixedtotal - w1 - w2)
-#else
-#    define w3 0
-#endif
-
-#if w1 > 0
-#    define w1_nops w1
+#    define w1_nops (w_zerocycles - w_fixedlow)
 #else
 #    define w1_nops 0
+#endif
+
+// w2_nops - nops between fe low and fe high
+#if w_onecycles >= (w_fixedhigh + w1_nops)
+#    define w2_nops (w_onecycles - w_fixedhigh - w1_nops)
+#else
+#    define w2_nops 0
+#endif
+
+// w3_nops - nops to complete loop
+#if w_totalcycles >= (w_fixedtotal + w1_nops + w2_nops)
+#    define w3_nops (w_totalcycles - w_fixedtotal - w1_nops - w2_nops)
+#else
+#    define w3_nops 0
 #endif
 
 // The only critical timing parameter is the minimum pulse length of the "0"
@@ -102,18 +96,6 @@ void ws2812_setleds(LED_TYPE *ledarray, uint16_t number_of_leds) {
 #elif w_lowtime > 450
 #    warning "Light_ws2812: The timing is critical and may only work on WS2812B, not on WS2812(S)."
 #    warning "Please consider a higher clockspeed, if possible"
-#endif
-
-#if w2 > 0
-#    define w2_nops w2
-#else
-#    define w2_nops 0
-#endif
-
-#if w3 > 0
-#    define w3_nops w3
-#else
-#    define w3_nops 0
 #endif
 
 #define w_nop1 "nop      \n\t"


### PR DESCRIPTION
## Description

When trying to calculate the number of nops for AVR running at 8 MHz, the value of `w3` is expected to be negative; however, because `F_CPU` is defined in tmk_core/avr.mk with the `UL` suffix, the preprocessor performs its calculations using `unsigned long`, getting a very large positive number instead of the expected negative number; this then results in generating code with a huge number of nops.  Fix the broken calculations by performing a comparison before subtraction, so that the unsigned number wraparound does not occur.

The keyboard which triggers the problem is `handwired/promethium`; the buggy code silently compiles, but the resulting timings would be wrong (but apparently not wrong enough to be noticed, because for most WS8212-like LEDs a low level pulse of 6 us is not enough to trigger a reset).

-----

~~I cannot actually test the change on a real hardware (I tested that it does not break the generated code for XD87 HS, which has ATmega32u4 running at 16 MHz, but I don't have any hardware which uses 8 Mhz).~~ *Update:* Got a 3.3V Pro Micro board for testing and verified that the code actually works (at least with those LEDs that I have).

I looked at the Travis build report for #9558 and found a single keyboard which actually has ATmega32u4 running at 8 MHz with some WS2812-style LEDs connected, then looked at the generated assembly code and noticed that it is obviously wrong (has lots of NOPs), and the fix makes it look right (no NOPs at the end of the loop).

~~It should be possible to simplify the code by removing the subsequent checks like `w1 > 0`, but I did not touch them for now to avoid conflicts with #9558.~~ *Update:* Removed useless code.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
