### PR TITLE
Add Via support for Hasu FC660C controller

### DIFF
--- a/keyboards/fc660c/config.h
+++ b/keyboards/fc660c/config.h
@@ -21,7 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "config_common.h"
 
 /* USB Device descriptor parameter */
-#define VENDOR_ID       0xFEED
+#define VENDOR_ID       0x4853 /* HS */
 #define PRODUCT_ID      0x660C
 #define DEVICE_VER      0x0100
 #define MANUFACTURER    QMK
@@ -29,7 +29,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define DESCRIPTION     Leopold FC660C with Hasu alternative controller using QMK
 
 /* key matrix size */
-#define MATRIX_ROWS 8
+#define MATRIX_ROWS 5
 #define MATRIX_COLS 16
 
 //#define DIODE_DIRECTION

--- a/keyboards/fc660c/config.h
+++ b/keyboards/fc660c/config.h
@@ -24,8 +24,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID       0x4853 /* HS */
 #define PRODUCT_ID      0x660C
 #define DEVICE_VER      0x0100
-#define MANUFACTURER    QMK
-#define PRODUCT         Leopold FC660C with QMK
+#define MANUFACTURER    Hasu
+#define PRODUCT         FC660C
 #define DESCRIPTION     Leopold FC660C with Hasu alternative controller using QMK
 
 /* key matrix size */

--- a/keyboards/fc660c/fc660c.h
+++ b/keyboards/fc660c/fc660c.h
@@ -36,13 +36,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     { KC_NO,    K31, K32, K33, K34, K35, K36, K37,   \
       K38, K39, K3A, K3B, K3C, K3D, KC_NO,    KC_NO    }, \
     { K40, K41, K42, K43, K44, K45, K46, K47,   \
-      K48, K49, K4A, K4B, KC_NO,    KC_NO,    K4E, KC_NO    }, \
-    { KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,      \
-      KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO    }, \
-    { KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,      \
-      KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO    }, \
-    { KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,      \
-      KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO    }  \
+      K48, K49, K4A, K4B, KC_NO,    KC_NO,    K4E, KC_NO    }  \
 }
 /*
 KEYMAP(

--- a/keyboards/fc660c/keymaps/via/README.md
+++ b/keyboards/fc660c/keymaps/via/README.md
@@ -1,0 +1,5 @@
+# The default keymap for the FC660C with Via enabled
+
+Emulates original keymap.
+
+![](https://i.imgur.com/fg89nez.jpg)

--- a/keyboards/fc660c/keymaps/via/keymap.c
+++ b/keyboards/fc660c/keymaps/via/keymap.c
@@ -1,0 +1,46 @@
+/*
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  [0] = LAYOUT(
+        KC_ESC, KC_1,   KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,   KC_0,   KC_MINS,KC_EQL, KC_BSPC,     KC_INS,
+        KC_TAB, KC_Q,   KC_W,   KC_E,   KC_R,   KC_T,   KC_Y,   KC_U,   KC_I,   KC_O,   KC_P,   KC_LBRC,KC_RBRC,KC_BSLS,     KC_DEL,
+        KC_CAPS,KC_A,   KC_S,   KC_D,   KC_F,   KC_G,   KC_H,   KC_J,   KC_K,   KC_L,   KC_SCLN,KC_QUOT,     KC_ENT,
+        KC_LSFT,KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,   KC_N,   KC_M,   KC_COMM,KC_DOT, KC_SLSH,KC_RSFT,     KC_UP,
+        KC_LCTL,KC_LGUI,KC_LALT,                KC_SPC,                 KC_RALT,KC_RCTL,MO(1),       KC_LEFT,KC_DOWN,KC_RGHT
+    ),
+  [1] = LAYOUT(
+        KC_GRV, KC_F1,  KC_F2,  KC_F3,  KC_F4,  KC_F5,  KC_F6,  KC_F7,  KC_F8,  KC_F9,  KC_F10, KC_F11, KC_F12, _______,     _______,
+        _______,_______,_______,_______,_______,_______,_______,_______,KC_PSCR,KC_SLCK,KC_PAUS,_______,_______,_______,     _______,
+        _______,_______,_______,_______,_______,_______,_______,_______,KC_HOME,KC_PGUP,_______,_______,     _______,
+        _______,_______,_______,_______,_______,_______,_______,_______,KC_END, KC_PGDN,_______,_______,     _______,
+        _______,_______,_______,                _______,                _______,_______,_______,     _______,_______,_______
+    ),
+  [2] = LAYOUT(
+        _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,     _______,
+        _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,     _______,
+        _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,     _______,
+        _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,     _______,
+        _______,_______,_______,                _______,                _______,_______,_______,     _______,_______,_______
+    ),
+  [3] = LAYOUT(
+        _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,     _______,
+        _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,     _______,
+        _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,     _______,
+        _______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,_______,     _______,
+        _______,_______,_______,                _______,                _______,_______,_______,     _______,_______,_______
+    )
+};

--- a/keyboards/fc660c/keymaps/via/rules.mk
+++ b/keyboards/fc660c/keymaps/via/rules.mk
@@ -1,0 +1,2 @@
+VIA_ENABLE = yes
+LTO_ENABLE = yes


### PR DESCRIPTION
## Description

Add VIA support for Hasu FC660C controller.

I had to reduce the matrix rows to 5 so that it would fit. The last three rows were not being used.

## Via PR
https://github.com/the-via/keyboards/pull/184

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
