### PR TITLE
Provide a method to allow user code to override clearing of One Shot Layer

### DIFF
--- a/docs/one_shot_keys.md
+++ b/docs/one_shot_keys.md
@@ -26,6 +26,17 @@ For one shot mods, you need to call `set_oneshot_mods(MOD)` to set it, or `clear
 
 !> If you're having issues with OSM translating over Remote Desktop Connection, this can be fixed by opening the settings, going to the "Local Resources" tap, and in the keyboard section, change the drop down to "On this Computer".  This will fix the issue and allow OSM to function properly over Remote Desktop.
 
+By default, oneshots are cleared after the next key is pressed; but in some cases it may be desirable to override this behavior, e.g. for certain complex behavior implemented in `process_record_user()`.
+To override for the current event that is being processed, you can call `set_clear_oneshot(bool yn)`:
+
+```c
+set_clear_oneshot(true); // oneshot will be cleared
+```
+or
+```c
+set_clear_oneshot(false); // oneshot will NOT be cleared
+```
+
 ## Callbacks
 
 When you'd like to perform custom logic when pressing a one shot key, there are several callbacks you can choose to implement. You could indicate changes in one shot keys by flashing an LED or making a sound, for example.

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -183,6 +183,16 @@ void process_record_tap_hint(keyrecord_t *record) {
 }
 #endif
 
+#ifndef NO_ACTION_ONESHOT
+static bool clear_oneshot_enable;
+
+/** \brief Indicate whether one-shot layer should be cleared after this record
+ */
+void set_clear_oneshot(bool yn) {
+    clear_oneshot_enable = yn;
+}
+#endif
+
 /** \brief Take a key event (key press or key release) and processes it.
  *
  * FIXME: Needs documentation.
@@ -192,9 +202,13 @@ void process_record(keyrecord_t *record) {
         return;
     }
 
+#ifndef NO_ACTION_ONESHOT
+    clear_oneshot_enable = true;
+#endif
+
     if (!process_record_quantum(record)) {
 #ifndef NO_ACTION_ONESHOT
-        if (is_oneshot_layer_active() && record->event.pressed) {
+        if (clear_oneshot_enable && is_oneshot_layer_active() && record->event.pressed) {
             clear_oneshot_layer_state(ONESHOT_OTHER_KEY_PRESSED);
         }
 #endif
@@ -238,7 +252,7 @@ void process_action(keyrecord_t *record, action_t action) {
 #ifndef NO_ACTION_ONESHOT
     bool do_release_oneshot = false;
     // notice we only clear the one shot layer if the pressed key is not a modifier.
-    if (is_oneshot_layer_active() && event.pressed && (action.kind.id == ACT_USAGE || !IS_MOD(action.key.code))
+    if (clear_oneshot_enable && is_oneshot_layer_active() && event.pressed && (action.kind.id == ACT_USAGE || !IS_MOD(action.key.code))
 #    ifdef SWAP_HANDS_ENABLE
         && !(action.kind.id == ACT_SWAP_HANDS && action.swap.code == OP_SH_ONESHOT)
 #    endif

--- a/tmk_core/common/action.h
+++ b/tmk_core/common/action.h
@@ -116,6 +116,10 @@ bool is_tap_action(action_t action);
 void process_record_tap_hint(keyrecord_t *record);
 #endif
 
+#ifndef NO_ACTION_ONESHOT
+void set_clear_oneshot(bool yn);
+#endif
+
 /* debug */
 void debug_event(keyevent_t event);
 void debug_record(keyrecord_t record);


### PR DESCRIPTION
## Description

PR #8832 fixed Issue #7599, but changed behavior in case `process_record_user()` returns false. While I still believe that this is, in the vast majority of cases, the correct behavior, there are some use cases (see Issue #9521) where it is undesirable.

This PR gives developers the ability to set an indicator of whether the One Shot should be cleared in their `process_record_kb()` or `process_record_user()` code. The behavior is reset before each key event.

Note that this is an alternative to PR #9538, which provides a callback to do the same thing. I present this PR as a simpler alternative, that should be easier for developers to use in most cases, as it doesn't require the maintenance of additional state within user code to allow implementation of a callback. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* #9521 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
