### PR TITLE
Make GPIO functions for AVR atomic

### DIFF
--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -191,7 +191,7 @@ typedef uint8_t pin_t;
 #    define GPIO_BARRIER() asm volatile("")
 
 #    define setPinInput(pin) \
-    do { \
+    (__extension__({ \
         volatile uint8_t *ddr = &DDRx_ADDRESS(pin); \
         volatile uint8_t *port = &PORTx_ADDRESS(pin); \
         uint8_t inv_mask = (uint8_t)~_BV((pin) & 0xF); \
@@ -201,10 +201,10 @@ typedef uint8_t pin_t;
             *port &= inv_mask; \
         } \
         GPIO_BARRIER(); \
-    } while(0)
+    }))
 
 #    define setPinInputHigh(pin) \
-    do { \
+    (__extension__({ \
         volatile uint8_t *ddr = &DDRx_ADDRESS(pin); \
         volatile uint8_t *port = &PORTx_ADDRESS(pin); \
         uint8_t mask = _BV((pin) & 0xF); \
@@ -216,12 +216,12 @@ typedef uint8_t pin_t;
             *port |= mask; \
         } \
         GPIO_BARRIER(); \
-    } while(0)
+    }))
 
 #    define setPinInputLow(pin) _Static_assert(0, "AVR processors cannot implement an input as pull low")
 
 #    define setPinOutput(pin) \
-    do { \
+    (__extension__({ \
         if (__builtin_constant_p(pin)) { \
             if (((pin) & 0xF) <= 7) { \
                 asm volatile("sbi %0,%1" : : "I"(_SFR_IO_ADDR(DDRx_ADDRESS(pin))), "I"((pin) & 0xF)); \
@@ -235,10 +235,10 @@ typedef uint8_t pin_t;
             } \
             GPIO_BARRIER(); \
         } \
-    } while(0)
+    }))
 
 #    define writePinHigh(pin) \
-    do { \
+    (__extension__ ({ \
         if (__builtin_constant_p(pin)) { \
             if (((pin) & 0xF) <= 7) { \
                 asm volatile("sbi %0,%1" : : "I"(_SFR_IO_ADDR(PORTx_ADDRESS(pin))), "I"((pin) & 0xF)); \
@@ -252,10 +252,10 @@ typedef uint8_t pin_t;
             } \
             GPIO_BARRIER(); \
         } \
-    } while(0)
+    }))
 
 #    define writePinLow(pin) \
-    do { \
+    (__extension__ ({ \
         if (__builtin_constant_p(pin)) { \
             if (((pin) & 0xF) <= 7) { \
                 asm volatile("cbi %0,%1" : : "I"(_SFR_IO_ADDR(PORTx_ADDRESS(pin))), "I"((pin) & 0xF)); \
@@ -269,20 +269,14 @@ typedef uint8_t pin_t;
             } \
             GPIO_BARRIER(); \
         } \
-    } while(0)
+    }))
 
-#    define writePin(pin, level) \
-    do { \
-        if (level) \
-            writePinHigh(pin); \
-        else \
-            writePinLow(pin); \
-    } while(0)
+#    define writePin(pin, level) ((level) ? writePinHigh(pin) : writePinLow(pin))
 
 #    define readPin(pin) ((bool)(PINx_ADDRESS(pin) & _BV((pin)&0xF)))
 
 #    define togglePin(pin) \
-    do { \
+    (__extension__({ \
         volatile uint8_t *port = &PORTx_ADDRESS(pin); \
         uint8_t mask = _BV((pin) & 0xF); \
         GPIO_FORCE_PRECOMPUTE(mask); \
@@ -290,7 +284,7 @@ typedef uint8_t pin_t;
             *port ^= mask; \
         } \
         GPIO_BARRIER(); \
-    } while(0)
+    }))
 
 
 #elif defined(PROTOCOL_CHIBIOS)

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -192,104 +192,104 @@ typedef uint8_t pin_t;
 
 #    define setPinInput(pin) \
     do { \
-	volatile uint8_t *ddr = &DDRx_ADDRESS(pin); \
-	volatile uint8_t *port = &PORTx_ADDRESS(pin); \
-	uint8_t inv_mask = (uint8_t)~_BV((pin) & 0xF); \
-	GPIO_FORCE_PRECOMPUTE(inv_mask); \
-	ATOMIC_BLOCK(ATOMIC_RESTORESTATE) { \
-	    *ddr &= inv_mask; \
-	    *port &= inv_mask; \
-	} \
-	GPIO_BARRIER(); \
+        volatile uint8_t *ddr = &DDRx_ADDRESS(pin); \
+        volatile uint8_t *port = &PORTx_ADDRESS(pin); \
+        uint8_t inv_mask = (uint8_t)~_BV((pin) & 0xF); \
+        GPIO_FORCE_PRECOMPUTE(inv_mask); \
+        ATOMIC_BLOCK(ATOMIC_RESTORESTATE) { \
+            *ddr &= inv_mask; \
+            *port &= inv_mask; \
+        } \
+        GPIO_BARRIER(); \
     } while(0)
 
 #    define setPinInputHigh(pin) \
     do { \
-	volatile uint8_t *ddr = &DDRx_ADDRESS(pin); \
-	volatile uint8_t *port = &PORTx_ADDRESS(pin); \
-	uint8_t mask = _BV((pin) & 0xF); \
-	uint8_t inv_mask = (uint8_t)~mask; \
-	GPIO_FORCE_PRECOMPUTE(mask); \
-	GPIO_FORCE_PRECOMPUTE(inv_mask); \
-	ATOMIC_BLOCK(ATOMIC_RESTORESTATE) { \
-	    *ddr &= inv_mask; \
-	    *port |= mask; \
-	} \
-	GPIO_BARRIER(); \
+        volatile uint8_t *ddr = &DDRx_ADDRESS(pin); \
+        volatile uint8_t *port = &PORTx_ADDRESS(pin); \
+        uint8_t mask = _BV((pin) & 0xF); \
+        uint8_t inv_mask = (uint8_t)~mask; \
+        GPIO_FORCE_PRECOMPUTE(mask); \
+        GPIO_FORCE_PRECOMPUTE(inv_mask); \
+        ATOMIC_BLOCK(ATOMIC_RESTORESTATE) { \
+            *ddr &= inv_mask; \
+            *port |= mask; \
+        } \
+        GPIO_BARRIER(); \
     } while(0)
 
 #    define setPinInputLow(pin) _Static_assert(0, "AVR processors cannot implement an input as pull low")
 
 #    define setPinOutput(pin) \
     do { \
-	if (__builtin_constant_p(pin)) { \
-	    if (((pin) & 0xF) <= 7) { \
-		asm volatile("sbi %0,%1" : : "I"(_SFR_IO_ADDR(DDRx_ADDRESS(pin))), "I"((pin) & 0xF)); \
-	    } \
-	} else { \
-	    volatile uint8_t *ddr = &DDRx_ADDRESS(pin); \
-	    uint8_t mask = _BV((pin) & 0xF); \
-	    GPIO_FORCE_PRECOMPUTE(mask); \
-	    ATOMIC_BLOCK(ATOMIC_RESTORESTATE) { \
-		*ddr |= mask; \
-	    } \
-	    GPIO_BARRIER(); \
-	} \
+        if (__builtin_constant_p(pin)) { \
+            if (((pin) & 0xF) <= 7) { \
+                asm volatile("sbi %0,%1" : : "I"(_SFR_IO_ADDR(DDRx_ADDRESS(pin))), "I"((pin) & 0xF)); \
+            } \
+        } else { \
+            volatile uint8_t *ddr = &DDRx_ADDRESS(pin); \
+            uint8_t mask = _BV((pin) & 0xF); \
+            GPIO_FORCE_PRECOMPUTE(mask); \
+            ATOMIC_BLOCK(ATOMIC_RESTORESTATE) { \
+                *ddr |= mask; \
+            } \
+            GPIO_BARRIER(); \
+        } \
     } while(0)
 
 #    define writePinHigh(pin) \
     do { \
-	if (__builtin_constant_p(pin)) { \
-	    if (((pin) & 0xF) <= 7) { \
-		asm volatile("sbi %0,%1" : : "I"(_SFR_IO_ADDR(PORTx_ADDRESS(pin))), "I"((pin) & 0xF)); \
-	    } \
-	} else { \
-	    volatile uint8_t *port = &PORTx_ADDRESS(pin); \
-	    uint8_t mask = _BV((pin) & 0xF); \
-	    GPIO_FORCE_PRECOMPUTE(mask); \
-	    ATOMIC_BLOCK(ATOMIC_RESTORESTATE) { \
-		*port |= mask; \
-	    } \
-	    GPIO_BARRIER(); \
-	} \
+        if (__builtin_constant_p(pin)) { \
+            if (((pin) & 0xF) <= 7) { \
+                asm volatile("sbi %0,%1" : : "I"(_SFR_IO_ADDR(PORTx_ADDRESS(pin))), "I"((pin) & 0xF)); \
+            } \
+        } else { \
+            volatile uint8_t *port = &PORTx_ADDRESS(pin); \
+            uint8_t mask = _BV((pin) & 0xF); \
+            GPIO_FORCE_PRECOMPUTE(mask); \
+            ATOMIC_BLOCK(ATOMIC_RESTORESTATE) { \
+                *port |= mask; \
+            } \
+            GPIO_BARRIER(); \
+        } \
     } while(0)
 
 #    define writePinLow(pin) \
     do { \
-	if (__builtin_constant_p(pin)) { \
-	    if (((pin) & 0xF) <= 7) { \
-		asm volatile("cbi %0,%1" : : "I"(_SFR_IO_ADDR(PORTx_ADDRESS(pin))), "I"((pin) & 0xF)); \
-	    } \
-	} else { \
-	    volatile uint8_t *port = &PORTx_ADDRESS(pin); \
-	    uint8_t inv_mask = (uint8_t)~_BV((pin) & 0xF); \
-	    GPIO_FORCE_PRECOMPUTE(inv_mask); \
-	    ATOMIC_BLOCK(ATOMIC_RESTORESTATE) { \
-		*port &= inv_mask; \
-	    } \
-	    GPIO_BARRIER(); \
-	} \
+        if (__builtin_constant_p(pin)) { \
+            if (((pin) & 0xF) <= 7) { \
+                asm volatile("cbi %0,%1" : : "I"(_SFR_IO_ADDR(PORTx_ADDRESS(pin))), "I"((pin) & 0xF)); \
+            } \
+        } else { \
+            volatile uint8_t *port = &PORTx_ADDRESS(pin); \
+            uint8_t inv_mask = (uint8_t)~_BV((pin) & 0xF); \
+            GPIO_FORCE_PRECOMPUTE(inv_mask); \
+            ATOMIC_BLOCK(ATOMIC_RESTORESTATE) { \
+                *port &= inv_mask; \
+            } \
+            GPIO_BARRIER(); \
+        } \
     } while(0)
 
 #    define writePin(pin, level) \
     do { \
-	if (level) \
-	    writePinHigh(pin); \
-	else \
-	    writePinLow(pin); \
+        if (level) \
+            writePinHigh(pin); \
+        else \
+            writePinLow(pin); \
     } while(0)
 
 #    define readPin(pin) ((bool)(PINx_ADDRESS(pin) & _BV((pin)&0xF)))
 
 #    define togglePin(pin) \
     do { \
-	volatile uint8_t *port = &PORTx_ADDRESS(pin); \
-	uint8_t mask = _BV((pin) & 0xF); \
-	GPIO_FORCE_PRECOMPUTE(mask); \
-	ATOMIC_BLOCK(ATOMIC_RESTORESTATE) { \
-	    *port ^= mask; \
-	} \
-	GPIO_BARRIER(); \
+        volatile uint8_t *port = &PORTx_ADDRESS(pin); \
+        uint8_t mask = _BV((pin) & 0xF); \
+        GPIO_FORCE_PRECOMPUTE(mask); \
+        ATOMIC_BLOCK(ATOMIC_RESTORESTATE) { \
+            *port ^= mask; \
+        } \
+        GPIO_BARRIER(); \
     } while(0)
 
 

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -223,7 +223,9 @@ typedef uint8_t pin_t;
 #    define setPinOutput(pin) \
     do { \
 	if (__builtin_constant_p(pin)) { \
-	    asm volatile("sbi %0,%1" : : "I"(_SFR_IO_ADDR(DDRx_ADDRESS(pin))), "I"((pin) & 0xF)); \
+	    if (((pin) & 0xF) <= 7) { \
+		asm volatile("sbi %0,%1" : : "I"(_SFR_IO_ADDR(DDRx_ADDRESS(pin))), "I"((pin) & 0xF)); \
+	    } \
 	} else { \
 	    volatile uint8_t *ddr = &DDRx_ADDRESS(pin); \
 	    uint8_t mask = _BV((pin) & 0xF); \
@@ -238,7 +240,9 @@ typedef uint8_t pin_t;
 #    define writePinHigh(pin) \
     do { \
 	if (__builtin_constant_p(pin)) { \
-	    asm volatile("sbi %0,%1" : : "I"(_SFR_IO_ADDR(PORTx_ADDRESS(pin))), "I"((pin) & 0xF)); \
+	    if (((pin) & 0xF) <= 7) { \
+		asm volatile("sbi %0,%1" : : "I"(_SFR_IO_ADDR(PORTx_ADDRESS(pin))), "I"((pin) & 0xF)); \
+	    } \
 	} else { \
 	    volatile uint8_t *port = &PORTx_ADDRESS(pin); \
 	    uint8_t mask = _BV((pin) & 0xF); \
@@ -253,7 +257,9 @@ typedef uint8_t pin_t;
 #    define writePinLow(pin) \
     do { \
 	if (__builtin_constant_p(pin)) { \
-	    asm volatile("cbi %0,%1" : : "I"(_SFR_IO_ADDR(PORTx_ADDRESS(pin))), "I"((pin) & 0xF)); \
+	    if (((pin) & 0xF) <= 7) { \
+		asm volatile("cbi %0,%1" : : "I"(_SFR_IO_ADDR(PORTx_ADDRESS(pin))), "I"((pin) & 0xF)); \
+	    } \
 	} else { \
 	    volatile uint8_t *port = &PORTx_ADDRESS(pin); \
 	    uint8_t inv_mask = (uint8_t)~_BV((pin) & 0xF); \


### PR DESCRIPTION
## Description

On AVR MCUs the GPIO macros like `writePinLow()` perform read-modify-write operations on `PORTx` and `DDRx` registers, unless their argument is a compile time constant (in that case the compiler can optimize those operations into single `cbi` or `sbi` instructions).  Usually this works without any problems; however, the software PWM emulation code in `quantum/backlight/backlight_avr.c` manipulates GPIOs from interrupt handlers, and this may cause issues which manifest in a flickering backlight on some boards (#5953).  The problem happens when the read-modify-write sequence performed by the matrix scanning code is interrupted by the software PWM handler, and the software PWM uses a pin from the same port as one of the matrix row pins (or column pins for a ROW2COL matrix); in this case the resumed read-modify-write code will overwrite the update performed by the software PWM emulation code.

Change the implementation of all GPIO functions so that they are atomic with respect to interrupts; this is achieved by disabling interrupts around the read-modify-write operations.  This fixes #5953, and should not break other boards, although there will be some additional overhead for some GPIO operations (but the most common case of performing `writePinLow()` or `writePinHigh()` on pins which are known at compile time should have no additional overhead, because in this case the assembly implementation using `cbi` or `sbi` should be picked by the compiler).

------

This change fixes the issue #5953 (tested on the XD87 HS board), at least if the RGB underglow is not used (a running rgblight animation would still cause noticeable flicker, especially when the backlight brightness is low, but that is a separate issue). However, I'm not really happy about adding overhead to all those GPIO function (although that overhead may be not that large in practice — I measured the scanning rate on XD87 HS, and this change decreased it from 2187 to 2077 scans per second, which is not very significant).

Technically some part of these changes are not really required to fix the backlight issue:

* The backlight code actually touches only the `PORTx` register from interrupts, therefore the code which accesses `DDRx` may be left as is, but that just does not feel right.
* Intermediate variables are used so that the compiler will hopefully perform those calculations outside of the code section where interrupts are disabled (this does not actually work 100%, but at least the shifting loop is usually ran with interrupts still enabled). This should decrease interrupt latency, which could be especially important for V-USB devices (although maybe we could disable this extra code for them anyway; at the moment I don't have any V-USB hardware and cannot check whether it would have any issues with interrupt latency when this code is enabled).
* Disabling interrupts around the body of `setPinInput()` and `setPinInputHigh()` as a whole is not required — it could be possible to add a special case for the constant argument there and just perform a sequence of two `cbi`/`sbi` instructions without disabling interrupts. However, that would result in a possibility of receiving an interrupt in an intermediate state when the pin is already configured as input, but the pullup state is wrong. (Note that for switching from input to output that possibility still exists, and the intermediate state in that case might be even worse — the pin could actively output a wrong logical level for some time; maybe we should add functions like `setPinOutputLow()` and `setPinOutputHigh()`, which change `PORTx` before `DDRx`, and use `setPinOutputLow()` in the matrix scanning code.)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #5953

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
