### PR TITLE
WSL path not always starting with /mnt

### DIFF
--- a/util/wsl_install.sh
+++ b/util/wsl_install.sh
@@ -4,7 +4,10 @@ util_dir=$(dirname "$0")
 dir=$(cd -P -- "$util_dir" && pwd -P)
 pushd "$dir";
 
-if [[ $dir != /mnt/* ]];
+mount_point=$(df ${dir} | tail -1 | cut -d' ' -f 1);
+valid_windows_mount="^[A-Z]:\\\\$"
+
+if [[ ! $mount_point =~ $valid_windows_mount ]];
 then
     echo
     echo "You need to clone the qmk_firmware repository outside the linux filesystem."
@@ -31,7 +34,7 @@ source "$dir/win_shared_install.sh"
 
 pip3 install -r ${util_dir}/../requirements.txt
 
-echo 
+echo
 echo "Creating a softlink to the utils directory as ~/qmk_utils."
 echo "This is needed so that the the make system can find all utils it need."
 read -p "Press enter to continue (ctrl-c to abort)"

--- a/util/wsl_install.sh
+++ b/util/wsl_install.sh
@@ -4,7 +4,7 @@ util_dir=$(dirname "$0")
 dir=$(cd -P -- "$util_dir" && pwd -P)
 pushd "$dir";
 
-mount_point=$(df ${dir} | tail -1 | cut -d' ' -f 1);
+mount_point=$(df "${dir}" | tail -1 | awk '{print $1}')
 valid_windows_mount="^[A-Z]:\\\\$"
 
 if [[ ! $mount_point =~ $valid_windows_mount ]];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The windows filesystem inside wsl is not always mounted on /mnt, as it can be changed by the user. see the key `root` on the `automount` section in [the wsl docs](https://docs.microsoft.com/en-us/windows/wsl/wsl-config#automount)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

*  #9593

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
