### PR TITLE
fix matrix_io_delay() timing in quantum/matrix.c

### DIFF
--- a/quantum/matrix.c
+++ b/quantum/matrix.c
@@ -109,6 +109,7 @@ static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
 
     // Select row
     select_row(current_row);
+    matrix_output_select_delay();
 
     // For each col...
     for (uint8_t col_index = 0; col_index < MATRIX_COLS; col_index++) {
@@ -122,7 +123,7 @@ static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
     // Unselect row
     unselect_row(current_row);
     if (current_row + 1 < MATRIX_ROWS) {
-        matrix_io_delay();  // wait for row signal to go HIGH
+        matrix_output_unselect_delay();  // wait for row signal to go HIGH
     }
 
     // If the row has changed, store the row and return the changed flag.
@@ -161,6 +162,7 @@ static bool read_rows_on_col(matrix_row_t current_matrix[], uint8_t current_col)
 
     // Select col
     select_col(current_col);
+    matrix_output_select_delay();
 
     // For each row...
     for (uint8_t row_index = 0; row_index < MATRIX_ROWS; row_index++) {
@@ -187,7 +189,7 @@ static bool read_rows_on_col(matrix_row_t current_matrix[], uint8_t current_col)
     // Unselect col
     unselect_col(current_col);
     if (current_col + 1 < MATRIX_COLS) {
-        matrix_io_delay();  // wait for col signal to go HIGH
+        matrix_output_unselect_delay();  // wait for row signal to go HIGH
     }
 
     return matrix_changed;

--- a/quantum/matrix.c
+++ b/quantum/matrix.c
@@ -107,7 +107,7 @@ static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
     // Start with a clear matrix row
     matrix_row_t current_row_value = 0;
 
-    // Select row and wait for row selecton to stabilize
+    // Select row
     select_row(current_row);
 
     // For each col...
@@ -122,7 +122,7 @@ static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
     // Unselect row
     unselect_row(current_row);
     if( current_row + 1 < MATRIX_ROWS ) {
-        matrix_io_delay();
+        matrix_io_delay(); // wait for row signal to HIGH
     }
 
     // If the row has changed, store the row and return the changed flag.
@@ -159,7 +159,7 @@ static void init_pins(void) {
 static bool read_rows_on_col(matrix_row_t current_matrix[], uint8_t current_col) {
     bool matrix_changed = false;
 
-    // Select col and wait for col selecton to stabilize
+    // Select col
     select_col(current_col);
 
     // For each row...
@@ -187,7 +187,7 @@ static bool read_rows_on_col(matrix_row_t current_matrix[], uint8_t current_col)
     // Unselect col
     unselect_col(current_col);
     if( current_col + 1 < MATRIX_COLS ) {
-        matrix_io_delay();
+        matrix_io_delay(); // wait for col signal to HIGH
     }
 
     return matrix_changed;

--- a/quantum/matrix.c
+++ b/quantum/matrix.c
@@ -186,8 +186,8 @@ static bool read_rows_on_col(matrix_row_t current_matrix[], uint8_t current_col)
 
     // Unselect col
     unselect_col(current_col);
-    if( current_col + 1 < MATRIX_COLS ) {
-        matrix_io_delay(); // wait for col signal to HIGH
+    if (current_col + 1 < MATRIX_COLS) {
+        matrix_io_delay();  // wait for col signal to go HIGH
     }
 
     return matrix_changed;

--- a/quantum/matrix.c
+++ b/quantum/matrix.c
@@ -109,7 +109,6 @@ static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
 
     // Select row and wait for row selecton to stabilize
     select_row(current_row);
-    matrix_io_delay();
 
     // For each col...
     for (uint8_t col_index = 0; col_index < MATRIX_COLS; col_index++) {
@@ -122,6 +121,9 @@ static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
 
     // Unselect row
     unselect_row(current_row);
+    if( current_row + 1 < MATRIX_ROWS ) {
+        matrix_io_delay();
+    }
 
     // If the row has changed, store the row and return the changed flag.
     if (current_matrix[current_row] != current_row_value) {
@@ -159,7 +161,6 @@ static bool read_rows_on_col(matrix_row_t current_matrix[], uint8_t current_col)
 
     // Select col and wait for col selecton to stabilize
     select_col(current_col);
-    matrix_io_delay();
 
     // For each row...
     for (uint8_t row_index = 0; row_index < MATRIX_ROWS; row_index++) {
@@ -185,6 +186,9 @@ static bool read_rows_on_col(matrix_row_t current_matrix[], uint8_t current_col)
 
     // Unselect col
     unselect_col(current_col);
+    if( current_col + 1 < MATRIX_COLS ) {
+        matrix_io_delay();
+    }
 
     return matrix_changed;
 }

--- a/quantum/matrix.c
+++ b/quantum/matrix.c
@@ -121,8 +121,8 @@ static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
 
     // Unselect row
     unselect_row(current_row);
-    if( current_row + 1 < MATRIX_ROWS ) {
-        matrix_io_delay(); // wait for row signal to HIGH
+    if (current_row + 1 < MATRIX_ROWS) {
+        matrix_io_delay();  // wait for row signal to go HIGH
     }
 
     // If the row has changed, store the row and return the changed flag.

--- a/quantum/matrix.c
+++ b/quantum/matrix.c
@@ -189,7 +189,7 @@ static bool read_rows_on_col(matrix_row_t current_matrix[], uint8_t current_col)
     // Unselect col
     unselect_col(current_col);
     if (current_col + 1 < MATRIX_COLS) {
-        matrix_output_unselect_delay();  // wait for row signal to go HIGH
+        matrix_output_unselect_delay();  // wait for col signal to go HIGH
     }
 
     return matrix_changed;

--- a/quantum/matrix_common.c
+++ b/quantum/matrix_common.c
@@ -1,3 +1,4 @@
+#include "quantum.h"
 #include "matrix.h"
 #include "debounce.h"
 #include "wait.h"

--- a/quantum/matrix_common.c
+++ b/quantum/matrix_common.c
@@ -87,7 +87,7 @@ uint8_t matrix_key_count(void) {
 /*　`matrix_io_delay ()` exists for backwards compatibility. From now on, use matrix_output_unselect_delay().　*/
 __attribute__((weak)) void matrix_io_delay(void) { wait_us(MATRIX_IO_DELAY); }
 
-__attribute__((weak)) void matrix_output_select_delay(void) { waitOutputPinValid(); }
+__attribute__((weak)) void matrix_output_select_delay(void) { waitInputPinDelay(); }
 __attribute__((weak)) void matrix_output_unselect_delay(void) { matrix_io_delay(); }
 
 // CUSTOM MATRIX 'LITE'

--- a/quantum/matrix_common.c
+++ b/quantum/matrix_common.c
@@ -83,7 +83,11 @@ uint8_t matrix_key_count(void) {
     return count;
 }
 
+/*　`matrix_io_delay ()` exists for backwards compatibility. From now on, use matrix_output_unselect_delay().　*/
 __attribute__((weak)) void matrix_io_delay(void) { wait_us(MATRIX_IO_DELAY); }
+
+__attribute__((weak)) void matrix_output_select_delay(void) { waitOutputPinValid(); }
+__attribute__((weak)) void matrix_output_unselect_delay(void) { matrix_io_delay(); }
 
 // CUSTOM MATRIX 'LITE'
 __attribute__((weak)) void matrix_init_custom(void) {}

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -229,7 +229,12 @@ typedef ioline_t pin_t;
 #endif
 
 #if defined(__ARMEL__) || defined(__ARMEB__)
-#    define waitOutputPinValid() wait_cpuclock(STM32_SYSCLK/1000000L / 4)
+#    if  defined(STM32_SYSCLK)
+#        define WAITOUTPUTPINVALID_DELAY (STM32_SYSCLK/1000000L / 4)
+#    elif defined(KINETIS_SYSCLK_FREQUENCY)
+#        define WAITOUTPUTPINVALID_DELAY (KINETIS_SYSCLK_FREQUENCY/1000000L / 4)
+#    endif
+#    define waitOutputPinValid() wait_cpuclock(WAITOUTPUTPINVALID_DELAY)
 #endif
 
 // Atomic macro to help make GPIO and other controls atomic.

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -208,6 +208,8 @@ typedef uint8_t pin_t;
 
 #    define togglePin(pin) (PORTx_ADDRESS(pin) ^= _BV((pin)&0xF))
 
+#    define waitOutputPinValid() wait_cpuclock(1)
+
 #elif defined(PROTOCOL_CHIBIOS)
 typedef ioline_t pin_t;
 
@@ -223,6 +225,11 @@ typedef ioline_t pin_t;
 #    define readPin(pin) palReadLine(pin)
 
 #    define togglePin(pin) palToggleLine(pin)
+
+#endif
+
+#if defined(__ARMEL__) || defined(__ARMEB__)
+#    define waitOutputPinValid() wait_cpuclock(STM32_SYSCLK/1000000L / 4)
 #endif
 
 // Atomic macro to help make GPIO and other controls atomic.

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -208,9 +208,10 @@ typedef uint8_t pin_t;
 
 #    define togglePin(pin) (PORTx_ADDRESS(pin) ^= _BV((pin)&0xF))
 
-/*   The AVR series GPIOs have a one clock read delay for changes in the digital input signal. */
+/*   The AVR series GPIOs have a one clock read delay for changes in the digital input signal.
+ *   But here's more margin to make it two clocks. */
 #    if !defined(GPIO_INPUT_PIN_DELAY)
-#        define GPIO_INPUT_PIN_DELAY 1
+#        define GPIO_INPUT_PIN_DELAY 2
 #    endif
 #    define waitInputPinDelay() wait_cpuclock(GPIO_INPUT_PIN_DELAY)
 

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -208,7 +208,11 @@ typedef uint8_t pin_t;
 
 #    define togglePin(pin) (PORTx_ADDRESS(pin) ^= _BV((pin)&0xF))
 
-#    define waitOutputPinValid() wait_cpuclock(1)
+/*   The AVR series GPIOs have a one clock read delay for changes in the digital input signal. */
+#    if !defined(GPIO_INPUT_PIN_DELAY)
+#        define GPIO_INPUT_PIN_DELAY 1
+#    endif
+#    define waitInputPinDelay() wait_cpuclock(GPIO_INPUT_PIN_DELAY)
 
 #elif defined(PROTOCOL_CHIBIOS)
 typedef ioline_t pin_t;
@@ -229,12 +233,24 @@ typedef ioline_t pin_t;
 #endif
 
 #if defined(__ARMEL__) || defined(__ARMEB__)
-#    if  defined(STM32_SYSCLK)
-#        define WAITOUTPUTPINVALID_DELAY (STM32_SYSCLK/1000000L / 4)
-#    elif defined(KINETIS_SYSCLK_FREQUENCY)
-#        define WAITOUTPUTPINVALID_DELAY (KINETIS_SYSCLK_FREQUENCY/1000000L / 4)
+/* For GPIOs on ARM-based MCUs, the input pins are sampled by the clock of the bus
+ * to which the GPIO is connected.
+ * The connected buses differ depending on the various series of MCUs.
+ * And since the instruction execution clock of the CPU and the bus clock of GPIO are different,
+ * there is a delay of several clocks to read the change of the input signal.
+ *
+ * Define this delay with the GPIO_INPUT_PIN_DELAY macro.
+ * If the GPIO_INPUT_PIN_DELAY macro is not defined, the following default values will be used.
+ * (A fairly large value of 0.25 microseconds is set.)
+ */
+#    if !defined(GPIO_INPUT_PIN_DELAY)
+#        if defined(STM32_SYSCLK)
+#            define GPIO_INPUT_PIN_DELAY (STM32_SYSCLK/1000000L / 4)
+#        elif defined(KINETIS_SYSCLK_FREQUENCY)
+#            define GPIO_INPUT_PIN_DELAY (KINETIS_SYSCLK_FREQUENCY/1000000L / 4)
+#        endif
 #    endif
-#    define waitOutputPinValid() wait_cpuclock(WAITOUTPUTPINVALID_DELAY)
+#    define waitInputPinDelay() wait_cpuclock(GPIO_INPUT_PIN_DELAY)
 #endif
 
 // Atomic macro to help make GPIO and other controls atomic.

--- a/quantum/split_common/matrix.c
+++ b/quantum/split_common/matrix.c
@@ -199,8 +199,8 @@ static bool read_rows_on_col(matrix_row_t current_matrix[], uint8_t current_col)
 
     // Unselect col
     unselect_col(current_col);
-    if( current_col + 1 < MATRIX_COLS ) {
-        matrix_io_delay(); // wait for col signal to HIGH
+    if (current_col + 1 < MATRIX_COLS) {
+        matrix_io_delay();  // wait for col signal to go HIGH
     }
 
     return matrix_changed;

--- a/quantum/split_common/matrix.c
+++ b/quantum/split_common/matrix.c
@@ -120,9 +120,8 @@ static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
     // Start with a clear matrix row
     matrix_row_t current_row_value = 0;
 
-    // Select row and wait for row selecton to stabilize
+    // Select row
     select_row(current_row);
-    matrix_io_delay();
 
     // For each col...
     for (uint8_t col_index = 0; col_index < MATRIX_COLS; col_index++) {
@@ -135,6 +134,9 @@ static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
 
     // Unselect row
     unselect_row(current_row);
+    if( current_row + 1 < MATRIX_ROWS ) {
+        matrix_io_delay(); // wait for row signal to HIGH
+    }
 
     // If the row has changed, store the row and return the changed flag.
     if (current_matrix[current_row] != current_row_value) {
@@ -170,9 +172,8 @@ static void init_pins(void) {
 static bool read_rows_on_col(matrix_row_t current_matrix[], uint8_t current_col) {
     bool matrix_changed = false;
 
-    // Select col and wait for col selecton to stabilize
+    // Select col
     select_col(current_col);
-    matrix_io_delay();
 
     // For each row...
     for (uint8_t row_index = 0; row_index < ROWS_PER_HAND; row_index++) {
@@ -198,6 +199,9 @@ static bool read_rows_on_col(matrix_row_t current_matrix[], uint8_t current_col)
 
     // Unselect col
     unselect_col(current_col);
+    if( current_col + 1 < MATRIX_COLS ) {
+        matrix_io_delay(); // wait for col signal to HIGH
+    }
 
     return matrix_changed;
 }

--- a/quantum/split_common/matrix.c
+++ b/quantum/split_common/matrix.c
@@ -202,7 +202,7 @@ static bool read_rows_on_col(matrix_row_t current_matrix[], uint8_t current_col)
     // Unselect col
     unselect_col(current_col);
     if (current_col + 1 < MATRIX_COLS) {
-        matrix_output_unselect_delay();  // wait for row signal to go HIGH
+        matrix_output_unselect_delay();  // wait for col signal to go HIGH
     }
 
     return matrix_changed;

--- a/quantum/split_common/matrix.c
+++ b/quantum/split_common/matrix.c
@@ -134,8 +134,8 @@ static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
 
     // Unselect row
     unselect_row(current_row);
-    if( current_row + 1 < MATRIX_ROWS ) {
-        matrix_io_delay(); // wait for row signal to HIGH
+    if (current_row + 1 < MATRIX_ROWS) {
+        matrix_io_delay();  // wait for row signal to go HIGH
     }
 
     // If the row has changed, store the row and return the changed flag.

--- a/quantum/split_common/matrix.c
+++ b/quantum/split_common/matrix.c
@@ -122,6 +122,7 @@ static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
 
     // Select row
     select_row(current_row);
+    matrix_output_select_delay();
 
     // For each col...
     for (uint8_t col_index = 0; col_index < MATRIX_COLS; col_index++) {
@@ -135,7 +136,7 @@ static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
     // Unselect row
     unselect_row(current_row);
     if (current_row + 1 < MATRIX_ROWS) {
-        matrix_io_delay();  // wait for row signal to go HIGH
+        matrix_output_unselect_delay();  // wait for row signal to go HIGH
     }
 
     // If the row has changed, store the row and return the changed flag.
@@ -174,6 +175,7 @@ static bool read_rows_on_col(matrix_row_t current_matrix[], uint8_t current_col)
 
     // Select col
     select_col(current_col);
+    matrix_output_select_delay();
 
     // For each row...
     for (uint8_t row_index = 0; row_index < ROWS_PER_HAND; row_index++) {
@@ -200,7 +202,7 @@ static bool read_rows_on_col(matrix_row_t current_matrix[], uint8_t current_col)
     // Unselect col
     unselect_col(current_col);
     if (current_col + 1 < MATRIX_COLS) {
-        matrix_io_delay();  // wait for col signal to go HIGH
+        matrix_output_unselect_delay();  // wait for row signal to go HIGH
     }
 
     return matrix_changed;

--- a/tmk_core/common/matrix.h
+++ b/tmk_core/common/matrix.h
@@ -57,6 +57,9 @@ matrix_row_t matrix_get_row(uint8_t row);
 /* print matrix for debug */
 void matrix_print(void);
 /* delay between changing matrix pin state and reading values */
+void matrix_output_select_delay(void);
+void matrix_output_unselect_delay(void);
+/* only for backwards compatibility. delay between changing matrix pin state and reading values */
 void matrix_io_delay(void);
 
 /* power control */

--- a/tmk_core/common/wait.h
+++ b/tmk_core/common/wait.h
@@ -7,10 +7,62 @@
 extern "C" {
 #endif
 
+#if defined(__ARMEL__) || defined(__ARMEB__)
+#    ifndef __OPTIMIZE__
+#        error "Compiler optimizations disabled; wait_cpuclock() won't work as designed"
+#    endif
+
+#    define CLOCK_DELAY_NOP8 "nop\n\t nop\n\t nop\n\t nop\n\t   nop\n\t nop\n\t nop\n\t nop\n\t"
+
+#define WAIT_CPUCLOCK_DEFINED
+
+__attribute__((always_inline))
+static inline void wait_cpuclock(unsigned int n) { /* n: 1..135 */
+    /* The argument n must be a constant expression.
+     * That way, compiler optimization will remove unnecessary code. */
+    if (n < 1) { return; }
+    if (n > 8) {
+        unsigned int n8 = n/8;
+        n = n - n8*8;
+        switch (n8) {
+        case 16: asm volatile (CLOCK_DELAY_NOP8::: "memory");
+        case 15: asm volatile (CLOCK_DELAY_NOP8::: "memory");
+        case 14: asm volatile (CLOCK_DELAY_NOP8::: "memory");
+        case 13: asm volatile (CLOCK_DELAY_NOP8::: "memory");
+        case 12: asm volatile (CLOCK_DELAY_NOP8::: "memory");
+        case 11: asm volatile (CLOCK_DELAY_NOP8::: "memory");
+        case 10: asm volatile (CLOCK_DELAY_NOP8::: "memory");
+        case  9: asm volatile (CLOCK_DELAY_NOP8::: "memory");
+        case  8: asm volatile (CLOCK_DELAY_NOP8::: "memory");
+        case  7: asm volatile (CLOCK_DELAY_NOP8::: "memory");
+        case  6: asm volatile (CLOCK_DELAY_NOP8::: "memory");
+        case  5: asm volatile (CLOCK_DELAY_NOP8::: "memory");
+        case  4: asm volatile (CLOCK_DELAY_NOP8::: "memory");
+        case  3: asm volatile (CLOCK_DELAY_NOP8::: "memory");
+        case  2: asm volatile (CLOCK_DELAY_NOP8::: "memory");
+        case  1: asm volatile (CLOCK_DELAY_NOP8::: "memory");
+        case  0: break;
+        }
+    }
+    switch (n) {
+    case 8: asm volatile ("nop"::: "memory");
+    case 7: asm volatile ("nop"::: "memory");
+    case 6: asm volatile ("nop"::: "memory");
+    case 5: asm volatile ("nop"::: "memory");
+    case 4: asm volatile ("nop"::: "memory");
+    case 3: asm volatile ("nop"::: "memory");
+    case 2: asm volatile ("nop"::: "memory");
+    case 1: asm volatile ("nop"::: "memory");
+    case 0: break;
+    }
+}
+#endif
+
 #if defined(__AVR__)
 #    include <util/delay.h>
 #    define wait_ms(ms) _delay_ms(ms)
 #    define wait_us(us) _delay_us(us)
+#    define wait_cpuclock(x) __builtin_avr_delay_cycles(x)
 #elif defined PROTOCOL_CHIBIOS
 #    include "ch.h"
 #    define wait_ms(ms)                     \

--- a/tmk_core/common/wait.h
+++ b/tmk_core/common/wait.h
@@ -12,12 +12,12 @@ extern "C" {
 #        pragma message "Compiler optimizations disabled; wait_cpuclock() won't work as designed"
 #    endif
 
+#    define wait_cpuclock(x) wait_cpuclock_allnop(x)
+
 #    define CLOCK_DELAY_NOP8 "nop\n\t nop\n\t nop\n\t nop\n\t   nop\n\t nop\n\t nop\n\t nop\n\t"
 
-#define WAIT_CPUCLOCK_DEFINED
-
 __attribute__((always_inline))
-static inline void wait_cpuclock(unsigned int n) { /* n: 1..135 */
+static inline void wait_cpuclock_allnop(unsigned int n) { /* n: 1..135 */
     /* The argument n must be a constant expression.
      * That way, compiler optimization will remove unnecessary code. */
     if (n < 1) { return; }

--- a/tmk_core/common/wait.h
+++ b/tmk_core/common/wait.h
@@ -9,7 +9,7 @@ extern "C" {
 
 #if defined(__ARMEL__) || defined(__ARMEB__)
 #    ifndef __OPTIMIZE__
-#        warning "Compiler optimizations disabled; wait_cpuclock() won't work as designed"
+#        pragma message "Compiler optimizations disabled; wait_cpuclock() won't work as designed"
 #    endif
 
 #    define CLOCK_DELAY_NOP8 "nop\n\t nop\n\t nop\n\t nop\n\t   nop\n\t nop\n\t nop\n\t nop\n\t"

--- a/tmk_core/common/wait.h
+++ b/tmk_core/common/wait.h
@@ -9,7 +9,7 @@ extern "C" {
 
 #if defined(__ARMEL__) || defined(__ARMEB__)
 #    ifndef __OPTIMIZE__
-#        error "Compiler optimizations disabled; wait_cpuclock() won't work as designed"
+#        warning "Compiler optimizations disabled; wait_cpuclock() won't work as designed"
 #    endif
 
 #    define CLOCK_DELAY_NOP8 "nop\n\t nop\n\t nop\n\t nop\n\t   nop\n\t nop\n\t nop\n\t nop\n\t"


### PR DESCRIPTION
## Description

~~The timing of the call to matrix_io_delay() has been changed to the appropriate time.  With this change, we can reduce the number of times we call matrix_io_delay() by one.~~

**Separated `matrix_io_delay()` into the following two functions so that you can set the appropriate delay value for each.**

* `matrix_output_select_delay()` -  after `select_row()/select_col()`
  The delay is a small number of clocks specific to the MCU.  
  The default implementation is as follows:
  ```c
  __attribute__((weak)) void matrix_output_select_delay(void) { waitInputPinDelay(); }
  ```
   See below for more information on `waitInputPinDelay()`.

* `matrix_output_unselect_delay()` - after `unselect_row()/unselect_col()`
  The delay is in the range of a few microseconds, depending on the capacitance and resistance of the entire keyboard circuitry.  
  The default implementation is as follows:
  ```c
  __attribute__((weak)) void matrix_io_delay(void) { wait_us(MATRIX_IO_DELAY); }
  __attribute__((weak)) void matrix_output_unselect_delay(void) { matrix_io_delay(); }
  ```

**Added `waitInputPinDelay()` into `quantum/quantum.h`.**

On AVR's GPIO and ARM's GPIO, the input signal changes need some clock time to be read into the input pins.

The `waitInputPinDelay()` will wait the necessary time. The wait time is set to `GPIO_INPUT_PIN_DELAY` in units of the clock.

If `GPIO_INPUT_PIN_DELAY` is not set, the following values are used.

* AVR
  The datasheets for ATmega32u4/16u4, ATmega32u2/16u2, ATmega328p, AT90usb646/1286, etc. say that a delay of one clock is required after a change in the input signal.  Therefore, the default value of GPIO_INPUT_PIN_DELAY can be set to 1, but we'll set it to 2 to allow for some leeway.

* ARM-based MCUs
  For GPIOs on ARM-based MCUs, the input pins are sampled by the clock of the bus to which the GPIO is connected.
  The connected buses differ depending on the various series of MCUs.
  Also, since the CPU instruction execution clock and GPIO bus clock can vary depending on the MCU GPIO bus configuration and MCU internal register settings, the optimal delay value cannot be determined. Therefore, GPIO_INPUT_PIN_DELAY defaults to a rather large value of 0.25 microseconds.

<details>
<summary><strong>Current matrix.c timing (click)</strong></summary>

### current matrix.c timing
#### over view
![old_overview](https://user-images.githubusercontent.com/2170248/86160712-1eadcc00-bb47-11ea-848d-7d6e51300564.png)

#### detail view
![old_detail](https://user-images.githubusercontent.com/2170248/86160734-27060700-bb47-11ea-9e16-cea8ef704028.png)

</details>
<details>
<summary><strong>New matrix.c timing (click)</strong></summary>

### new matrix.c timing
#### over view
![new_overview](https://user-images.githubusercontent.com/2170248/86160753-2ff6d880-bb47-11ea-97da-8bc36d6fef48.png)

#### detail view
![new_detail](https://user-images.githubusercontent.com/2170248/99230147-4bcaf480-2832-11eb-9485-d62d29bb3764.PNG)
</details>

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
