### PR TITLE
Quefrency rev1: Fix default VIA layout options

### DIFF
--- a/keyboards/keebio/quefrency/rev1/config.h
+++ b/keyboards/keebio/quefrency/rev1/config.h
@@ -57,4 +57,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGBLED_NUM 16    // Number of LEDs
 
 // Set 65% column (option 1) and Macro (option 2) on by default
-#define VIA_EEPROM_LAYOUT_OPTIONS_DEFAULT 0x06
+#define VIA_EEPROM_LAYOUT_OPTIONS_DEFAULT 0x60


### PR DESCRIPTION
## Description

Apparently VIA allocates bits in the layout options field from the lowest bit, but starting from the **last** option defined in the JSON file.  So the default value `0x06` was actually trying to set the value `3` (`0b11`) for the second-to-last option ("Right Shift"), which had only 3 values defined, and the attempt to set an undefined option value caused the VIA app to hang with a black window.

Fix the default layout options so that it works as intended (the "Macropad" and "65% Column" options are set).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
