### PR TITLE
split_3x6_3 layout support

### DIFF
--- a/keyboards/centromere/centromere.h
+++ b/keyboards/centromere/centromere.h
@@ -45,3 +45,5 @@
     { KC_NO, KC_NO, k32, k33, k34, k35, k36, k37, KC_NO, KC_NO }, \
     { KC_NO, KC_NO, k2a, k1a, k0a, k0b, k1b, k2b, KC_NO, KC_NO }  \
   }
+
+#define LAYOUT_split_3x6_3 LAYOUT

--- a/keyboards/centromere/rules.mk
+++ b/keyboards/centromere/rules.mk
@@ -40,3 +40,5 @@ OPT_DEFS += -DCENTROMERE_PROMICRO
 
 # # project specific files
 SRC = matrix.c
+
+LAYOUTS = split_3x6_3

--- a/keyboards/crkbd/rev1/rev1.h
+++ b/keyboards/crkbd/rev1/rev1.h
@@ -52,3 +52,5 @@
                                             KC_##L30, KC_##L31, KC_##L32, KC_##R30, KC_##R31, KC_##R32 \
   )
 // clang-format on
+
+#define LAYOUT_split_3x6_3 LAYOUT

--- a/keyboards/crkbd/rev1/rules.mk
+++ b/keyboards/crkbd/rev1/rules.mk
@@ -1,3 +1,5 @@
 SRC += 	matrix.c \
 		split_util.c \
 		split_scomm.c
+
+LAYOUTS = split_3x6_3


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

This pull request adds support for the split_3x6_3 layout to keyboards that are compatible.

## Description

Add support for the split_3x6_3 layout to the following keyboards:

- Centromere, maintained by @spe2 
- Crkbd, maintained by @foostan 

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
