### PR TITLE
Changed US_RBRC to KC_RBRC instead of KC_LBRC

### DIFF
--- a/quantum/keymap_extras/keymap_us_international.h
+++ b/quantum/keymap_extras/keymap_us_international.h
@@ -59,7 +59,7 @@
 #define US_O    KC_O    // O
 #define US_P    KC_P    // P
 #define US_LBRC KC_LBRC // [
-#define US_RBRC KC_LBRC // ]
+#define US_RBRC KC_RBRC // ]
 #define US_BSLS KC_BSLS // (backslash)
 // Row 3
 #define US_A    KC_A    // A


### PR DESCRIPTION
This pull request contains a simple fix to a simple bug: the US International keyboard layout erroneously assigns both left and right square bracket to left square bracket.

The fix consists of letting US_RBRC reference KC_RBRC instead of KC_LBRC.