### PR TITLE
[Keymap] plattfot - Update and fix issue with DBL_TAP

### DIFF
--- a/keyboards/kyria/keymaps/plattfot/README.md
+++ b/keyboards/kyria/keymaps/plattfot/README.md
@@ -21,8 +21,8 @@ thumb keys to make it work without them.
  // |--------+------+------+------+------+------+-------------.  ,-------------+------+------+------+------+------+--------|
  // | LShift |   Z  |   X  |   C  |   V  |   B  | Lead | RAISE|  | LOWER|DBLTAP|   N  |   M  | ,  < | . >  | /  ? | RShift |
  // `----------------------+------+------+------+------+------|  |------+------+------+------+------+----------------------'
- //                        | MPlay| GUI  | LCtrl| Space| LALT |  | Enter|BSpace| NAV  | LAlt |Worksp|
- //                        |      |      |      |      |      |  |      |      |      |      |toggle|
+ //                        | MPlay| GUI  | LCtrl| Space| LALT |  | Enter|BSpace| NAV  | LCTL+|Worksp|
+ //                        |      |      |      |      |      |  |      |      |      | LALT |toggle|
  //                        `----------------------------------'  `----------------------------------'
 ```
 
@@ -103,15 +103,18 @@ programming, and it is editor agnostic.
  // |--------+------+------+------+------+------|                              |------+------+------+------+------+--------|
  // |        |      |      |      |      | F11  |                              | F12  |      |      |      |      |        |
  // |--------+------+------+------+------+------+-------------.  ,-------------+------+------+------+------+------+--------|
- // |        |      |      |      |      |      |ScLock|      |  |      | Ins  |      |      |      |      |      |        |
+ // |        |      |      |      |      |      |ScLock|      |  |      | Ins  |      |      |      |      |      |CapsLock|
  // `----------------------+------+------+------+------+------|  |------+------+------+------+------+----------------------'
- //                        |      |      |      |      |      |  | Esc  | Del  |      | RAlt |      |
+ //                        |      |      |      |      |      |  |      |      |      | RAlt |      |
  //                        |      |      |      |      |      |  |      |      |      |      |      |
  //                        `----------------------------------'  `----------------------------------'
 ```
 
 Access to the functional keys, which I mostly use to run `emacs`
 compilation mode.
+
+This layer also includes key that changes the state, like insert and
+caps lock.
 
 Scroll Lock is used to toggle between English and Swedish.
 
@@ -130,7 +133,7 @@ Right rotary encoder
  // ,-------------------------------------------.                              ,-------------------------------------------.
  // |        |   1  |  2   |  3   |  4   |  5   |                              |  6   |  7   |  8   |  9   |  0   |        |
  // |--------+------+------+------+------+------|                              |------+------+------+------+------+--------|
- // |        |      |      |      |      |      |                              |      | Left | Up   | Down | Right|        |
+ // |        |      | ESC  |  DEL |      |      |                              |      | Left | Up   | Down | Right|        |
  // |--------+------+------+------+------+------+-------------.  ,-------------+------+------+------+------+------+--------|
  // |        |      |      |      |      |      |      |      |  |      |      |      |      |      |      |      |        |
  // `----------------------+------+------+------+------+------|  |------+------+------+------+------+----------------------'
@@ -143,6 +146,9 @@ Access to the number as well as the arrow keys. Got use to the number
 row after using [ErgoDox](https://www.ergodox.io/) keyboards for a few
 years. Do not feel I need a numpad layer, which seems to be quite
 common with small keyboards like this.
+
+Esc and Delete is also on this layer as they are easy to reach and they
+only need to be chord with the modifiers.
 
 # Adjust Layer: RGB
 ```

--- a/keyboards/kyria/keymaps/plattfot/keymap.c
+++ b/keyboards/kyria/keymaps/plattfot/keymap.c
@@ -52,8 +52,8 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |--------+------+------+------+------+------+-------------.  ,-------------+------+------+------+------+------+--------|
  * | LShift |   Z  |   X  |   C  |   V  |   B  | Lead | RAISE|  | LOWER|DBLTAP|   N  |   M  | ,  < | . >  | /  ? | RShift |
  * `----------------------+------+------+------+------+------|  |------+------+------+------+------+----------------------'
- *                        | MPlay| GUI  | LCtrl| Space| LALT |  | Enter|BSpace| NAV  | LAlt |Worksp|
- *                        |      |      |      |      |      |  |      |      |      |      |toggle|
+ *                        | MPlay| GUI  | LCtrl| Space| LALT |  | Enter|BSpace| NAV  |LCTL+ |Worksp|
+ *                        |      |      |      |      |      |  |      |      |      |LALT  |toggle|
  *                        `----------------------------------'  `----------------------------------'
  */
     [_DEFAULT] = LAYOUT(
@@ -91,26 +91,26 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |--------+------+------+------+------+------|                              |------+------+------+------+------+--------|
  * |        |      |      |      |      | F11  |                              | F12  |      |      |      |      |        |
  * |--------+------+------+------+------+------+-------------.  ,-------------+------+------+------+------+------+--------|
- * |        |      |      |      |      |      |ScLock|      |  |      | Ins  |      |      |      |      |      |        |
+ * |        |      |      |      |      |      |ScLock|      |  |      | Ins  |      |      |      |      |      |CapsLock|
  * `----------------------+------+------+------+------+------|  |------+------+------+------+------+----------------------'
- *                        |      |      |      |      |      |  | Esc  | Del  |      | RAlt |      |
+ *                        |      |      |      |      |      |  |      |      |      | RAlt |      |
  *                        |      |      |      |      |      |  |      |      |      |      |      |
  *                        `----------------------------------'  `----------------------------------'
  */
     [_RAISE] = LAYOUT(
       _______, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,                                       KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  _______,
       _______, _______, _______, _______, _______, KC_F11,                                      KC_F12,  _______, _______, _______, _______, _______,
-      _______, _______, _______, _______, _______, _______, KC_SLCK, _______, _______, KC_INS,  _______, _______, _______, _______, _______, _______,
-                                 _______, _______, _______, _______, _______, KC_ESC,  KC_DEL,  _______, KC_RALT, _______
+      _______, _______, _______, _______, _______, _______, KC_SLCK, _______, _______, KC_INS,  _______, _______, _______, _______, _______, KC_CAPS,
+                                 _______, _______, _______, _______, _______, _______, _______, _______, KC_RALT, _______
 
     ),
 /*
- * Navigation Layer: Number keys, navigation
+ * Navigation Layer: Number keys, navigation, modification
  *
  * ,-------------------------------------------.                              ,-------------------------------------------.
  * |        |   1  |  2   |  3   |  4   |  5   |                              |  6   |  7   |  8   |  9   |  0   |        |
  * |--------+------+------+------+------+------|                              |------+------+------+------+------+--------|
- * |        |      |      |      |      |      |                              |      | Left | Up   | Down | Right|        |
+ * |        |      | Esc  | Del  |      |      |                              |      | Left | Up   | Down | Right|        |
  * |--------+------+------+------+------+------+-------------.  ,-------------+------+------+------+------+------+--------|
  * |        |      |      |      |      |      |      |      |  |      |      |      |      |      |      |      |        |
  * `----------------------+------+------+------+------+------|  |------+------+------+------+------+----------------------'
@@ -120,7 +120,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  */
     [_NAV] = LAYOUT(
       _______, KC_1, 	KC_2,    KC_3,    KC_4,    KC_5,                                        KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    _______,
-      _______, _______, _______, _______, _______, _______,                                     _______, KC_LEFT, KC_UP, KC_DOWN,   KC_RGHT, _______,
+      _______, _______, KC_ESC,  KC_DEL,  _______, _______,                                     _______, KC_LEFT, KC_UP, KC_DOWN,   KC_RGHT, _______,
       _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
                                  _______, _______, _______, _______, _______, _______, _______, _______, KC_RCTL, _______
     ),
@@ -177,27 +177,22 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
                 // Double tap gets messed up with macros, turning it off
                 double_tap_it = false;
                 SEND_STRING("()" SS_TAP(X_LEFT));
-                clear_oneshot_layer_state(ONESHOT_OTHER_KEY_PRESSED);
                 return false;
             case M_LRCBR:
                 double_tap_it = false;
                 SEND_STRING("{}" SS_TAP(X_LEFT));
-                clear_oneshot_layer_state(ONESHOT_OTHER_KEY_PRESSED);
                 return false;
             case M_LRBRC:
                 double_tap_it = false;
                 SEND_STRING("[]" SS_TAP(X_LEFT));
-                clear_oneshot_layer_state(ONESHOT_OTHER_KEY_PRESSED);
                 return false;
             case M_LRABR:
                 double_tap_it = false;
                 SEND_STRING("<>" SS_TAP(X_LEFT));
-                clear_oneshot_layer_state(ONESHOT_OTHER_KEY_PRESSED);
                 return false;
             case M_DQUOT:
                 double_tap_it = false;
                 SEND_STRING("''" SS_TAP(X_LEFT));
-                clear_oneshot_layer_state(ONESHOT_OTHER_KEY_PRESSED);
                 return false;
             case DBL_TAP:
                 double_tap_it = !double_tap_it;
@@ -206,10 +201,14 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
                 double_tap_it = false;
                 return true;
         }
-    } else if (double_tap_it && keycode != DBL_TAP) {
+
+    } else if (double_tap_it &&
+               keycode != DBL_TAP &&
+               keycode != OSL(_RAISE) &&
+               keycode != OSL(_LOWER) &&
+               keycode != MO(_NAV)) {
         double_tap_it = false;
         tap_code16(keycode);
-        clear_oneshot_layer_state(ONESHOT_OTHER_KEY_PRESSED);
     }
 
     return true;


### PR DESCRIPTION
## Description
- Fix typo in the default layout.
- Move esc and del to the navi layer.
- Fix issue with oneshot layer and double tap aka DBL_TAP.
- Add caps lock to the raise layer.

Was relying on a broken behavior for the double tap to work with
oneshot keys, i.e. the oneshot layer not being cleared after a key
press in `process_record_user`, which allowed me to first press an
oneshot key, then double tap and then a key. With the behavior fixed,
this no longer works. As the oneshot layer will be cleared when double
tap is pressed.

To make double tap useful again. I changed that any of the layer keys
does not clear the double tap. Which allows me for example to first
press double tap, then an oneshot key and then a key. So now I'm able
to type my double symbols again.
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->



<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #9521 - Will no longer be an issue for me

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
