### PR TITLE
Rework my Crkbd and Lily58 modifier keys

### DIFF
--- a/keyboards/crkbd/keymaps/bcat/keymap.c
+++ b/keyboards/crkbd/keymaps/bcat/keymap.c
@@ -7,31 +7,38 @@ enum layer {
     LAYER_ADJUST,
 };
 
+enum keycode {
+    MC_ALTT = SAFE_RANGE,
+};
+
 #define LY_LWR MO(LAYER_LOWER)
 #define LY_RSE MO(LAYER_RAISE)
 
-#define KY_CESC LCTL_T(KC_ESC)
+#define KY_CSPC LCTL(KC_SPC)
+#define KY_LOCK LGUI(KC_L)
+#define KY_WINL LGUI(KC_LEFT)
+#define KY_WINR LGUI(KC_RGHT)
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Default layer: http://www.keyboard-layout-editor.com/#/gists/08d9827d916662a9414f48805aa895a5 */
     [LAYER_DEFAULT] = LAYOUT(
         KC_TAB,   KC_Q,     KC_W,     KC_E,     KC_R,     KC_T,                         KC_Y,     KC_U,     KC_I,     KC_O,     KC_P,     KC_BSPC,
-        KY_CESC,  KC_A,     KC_S,     KC_D,     KC_F,     KC_G,                         KC_H,     KC_J,     KC_K,     KC_L,     KC_SCLN,  KC_QUOT,
+        KC_ESC,   KC_A,     KC_S,     KC_D,     KC_F,     KC_G,                         KC_H,     KC_J,     KC_K,     KC_L,     KC_SCLN,  KC_QUOT,
         KC_LSFT,  KC_Z,     KC_X,     KC_C,     KC_V,     KC_B,                         KC_N,     KC_M,     KC_COMM,  KC_DOT,   KC_SLSH,  KC_RSFT,
-                                                KC_LALT,  LY_LWR,   KC_SPC,   KC_ENT,   LY_RSE,   KC_RGUI
+                                                KC_LCTL,  LY_LWR,   KC_SPC,   KC_ENT,   LY_RSE,   KC_RALT
     ),
 
     /* Lower layer: http://www.keyboard-layout-editor.com/#/gists/c3fba5eaa2cd70fdfbdbc0f9e34d3bc0 */
     [LAYER_LOWER] = LAYOUT(
-        KC_CAPS,  KC_EXLM,  KC_AT,    KC_HASH,  KC_DLR,   KC_PERC,                      KC_CIRC,  KC_AMPR,  KC_ASTR,  KC_LPRN,  KC_RPRN,  _______,
-        _______,  _______,  _______,  _______,  _______,  _______,                      KC_PIPE,  KC_UNDS,  KC_PLUS,  KC_LCBR,  KC_RCBR,  KC_TILD,
-        _______,  KC_APP,   KC_PSCR,  KC_SLCK,  KC_PAUS,  _______,                      KC_BSLS,  KC_MINS,  KC_EQL,   KC_LBRC,  KC_RBRC,  KC_GRV,
+        MC_ALTT,  KC_EXLM,  KC_AT,    KC_HASH,  KC_DLR,   KC_PERC,                      KC_CIRC,  KC_AMPR,  KC_ASTR,  KC_LPRN,  KC_RPRN,  _______,
+        KY_CSPC,  KY_WINL,  KY_WINR,  KY_LOCK,  KC_WBAK,  KC_WFWD,                      KC_PIPE,  KC_UNDS,  KC_PLUS,  KC_LCBR,  KC_RCBR,  KC_TILD,
+        _______,  KC_APP,   KC_PSCR,  KC_SLCK,  KC_PAUS,  KC_LGUI,                      KC_BSLS,  KC_MINS,  KC_EQL,   KC_LBRC,  KC_RBRC,  KC_GRV,
                                                 _______,  _______,  _______,  _______,  _______,  _______
     ),
 
     /* Raise layer: http://www.keyboard-layout-editor.com/#/gists/08b44355d4ca85d294bad9e2821f91d7 */
     [LAYER_RAISE] = LAYOUT(
-        _______,  KC_1,     KC_2,     KC_3,     KC_4,     KC_5,                         KC_6,     KC_7,     KC_8,     KC_9,     KC_0,     _______,
+        KC_CAPS,  KC_1,     KC_2,     KC_3,     KC_4,     KC_5,                         KC_6,     KC_7,     KC_8,     KC_9,     KC_0,     _______,
         _______,  KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,                        KC_LEFT,  KC_DOWN,  KC_UP,    KC_RGHT,  KC_F11,   KC_DEL,
         _______,  KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,                       KC_HOME,  KC_PGDN,  KC_PGUP,  KC_END,   KC_F12,   KC_INS,
                                                 _______,  _______,  _______,  _______,  _______,  _______
@@ -48,4 +55,29 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 layer_state_t layer_state_set_user(layer_state_t state) {
     return update_tri_layer_state(state, LAYER_LOWER, LAYER_RAISE, LAYER_ADJUST);
+}
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    static bool alt_tab_pressed = false;
+    switch (keycode) {
+        case MC_ALTT:
+            if (record->event.pressed) {
+                if (!alt_tab_pressed) {
+                    register_code(KC_LALT);
+                    alt_tab_pressed = true;
+                }
+                register_code(KC_TAB);
+            } else {
+                unregister_code(KC_TAB);
+            }
+            return false;
+        case LY_LWR:
+            if (!record->event.pressed && alt_tab_pressed) {
+                unregister_code(KC_LALT);
+                alt_tab_pressed = false;
+            }
+            /* fallthrough */
+        default:
+            return true;
+    }
 }

--- a/keyboards/crkbd/keymaps/bcat/keymap.c
+++ b/keyboards/crkbd/keymaps/bcat/keymap.c
@@ -1,14 +1,12 @@
 #include QMK_KEYBOARD_H
 
+#include "bcat.h"
+
 enum layer {
     LAYER_DEFAULT,
     LAYER_LOWER,
     LAYER_RAISE,
     LAYER_ADJUST,
-};
-
-enum keycode {
-    MC_ALTT = SAFE_RANGE,
 };
 
 #define LY_LWR MO(LAYER_LOWER)
@@ -53,31 +51,6 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     ),
 };
 
-layer_state_t layer_state_set_user(layer_state_t state) {
+layer_state_t layer_state_set_keymap(layer_state_t state) {
     return update_tri_layer_state(state, LAYER_LOWER, LAYER_RAISE, LAYER_ADJUST);
-}
-
-bool process_record_user(uint16_t keycode, keyrecord_t *record) {
-    static bool alt_tab_pressed = false;
-    switch (keycode) {
-        case MC_ALTT:
-            if (record->event.pressed) {
-                if (!alt_tab_pressed) {
-                    register_code(KC_LALT);
-                    alt_tab_pressed = true;
-                }
-                register_code(KC_TAB);
-            } else {
-                unregister_code(KC_TAB);
-            }
-            return false;
-        case LY_LWR:
-            if (!record->event.pressed && alt_tab_pressed) {
-                unregister_code(KC_LALT);
-                alt_tab_pressed = false;
-            }
-            /* fallthrough */
-        default:
-            return true;
-    }
 }

--- a/keyboards/crkbd/keymaps/bcat/readme.md
+++ b/keyboards/crkbd/keymaps/bcat/readme.md
@@ -4,11 +4,11 @@ This is my favorite split ergo layout for typing, featuring the traditional
 four ortho/ergo layers (Default, Lower, Raise, Adjust). It is loosely inspired
 by the default Planck (numbers on Lower, symbols on Raise) and Crkbd (Space on
 left, Enter on right) layouts, but has since been redesigned heavily according
-to the principles described below:
+to the principles described below.
 
-* Since most of the modifiers are on the left half, keys frequently pressed
-together with mods (e.g., numbers, function keys, etc.) are on the Raise layer
-activated by the right thumb.
+* Since my most-frequently-used keyboard shortcuts involve Ctrl, which lives on
+the left half of the keyboard, keys frequently used with it (numbers, function
+keys, etc.) are on the Raise layer activated by the right thumb.
 
 * Navigation can be done on the right half alone, to enable simultaneous
 left-handed mousing. Additionally, Web pages can be scrolled with Space or
@@ -22,7 +22,7 @@ layer-switch keys to correct mistakes.
 
 ## Default layer
 
-![Default layer layout](https://i.imgur.com/s1LDlSQ.png)
+![Default layer layout](https://i.imgur.com/g5N7g8D.png)
 
 ([KLE](http://www.keyboard-layout-editor.com/#/gists/08d9827d916662a9414f48805aa895a5))
 
@@ -31,29 +31,26 @@ layer-switch keys to correct mistakes.
 * Tab and Backspace are in familiar locations from my row-staggered boards
 (almost all of which use HHKB-style split backspace).
 
+* The Esc key is next to the home row for convenience in Vim.
+
 * Likewise, the Ctrl key is in the same place as on my row-staggered boards
 (where I've been remapping Caps Lock as Ctrl since before even using QMK).
 
-* There are two Shift keys, because I do use Right Shift on occasion (even
-though I'm predominately a Left Shift-er).
+* There are two Shift keys, although I generally use Left Shift. (I've
+considered replacing Right Shift with another key, but haven't chosen one.)
 
-* Lower and Raise layer-switch keys are below the left and right thumb,
-respectively, when resting my fingers on the home row.
+* Lower and Raise layer-switch keys are in the resting postion of my left and
+right thumbs, respectively.
 
 * Space and Enter are on the big thumb keys so they're easy to press.
 
-* Alt is on the left so I can navigate back (Alt+Raise+H) and forward
-(Alt+Raise+L) without having to uncomfortably hit two thumb keys on the same
-half. This puts Super on the right by the process of elimination.
-
-* Escape shares a mod-tap key with Ctrl, which is convenient for Vim, but not
-something I'm totally in love with, as even after tweaking `TAPPING_TERM` I
-still get occasional spurious Esc taps. (I might move Esc up a key and put Tab
-on a layer, but that'd take some getting used to....)
+* Ctrl is on the left for ease of chording, especially one-handed use of common
+shortcuts like Ctrl+T and Ctrl+W. This puts Alt on the right by the process of
+elimination.
 
 ## Lower layer
 
-![Lower layer layout](https://i.imgur.com/SsxvCgy.png)
+![Lower layer layout](https://i.imgur.com/djIkwsa.png)
 
 ([KLE](http://www.keyboard-layout-editor.com/#/gists/c3fba5eaa2cd70fdfbdbc0f9e34d3bc0))
 
@@ -74,17 +71,23 @@ bottom row.
 right half, with the same relative positions as on a row-staggered HHKB layout.
 And yup, the shifted versions are above the unshifted versions.
 
-* Caps Lock is bound in the same position as on an HHKB, for lack of an obvious
-better location.
+* Remaining keys from a TKL are placed out of the way on the bottom row of the
+left half.
 
-* Some extra keys are placed on the bottom row of the left half, ensuring every
-key on a TKL has a binding.
+* The home row on the left half contains handy shortcuts for window movement,
+and browser naviation, and screen lock.
 
-* The left-half home row is reversed for future use. (It's free real estate.)
+* Lower+Esc is bound to Ctrl+Space because the Ctrl and Space keys are both on
+the left thumb, so this key combination (which I use for tmux prefix and editor
+autocomplete) is hard to press in its natural location.
+
+* Lower+Tab is bound to a custom Alt+Tab macro that keeps the Alt modifier held
+as long as the Lower key is held down. This means that window switching is on
+Lower+Tab immediately next to brwoser tab switching (Ctrl+Tab).
 
 ## Raise layer
 
-![Raise layer layout](https://i.imgur.com/cVoKygg.png)
+![Raise layer layout](https://i.imgur.com/VNEiV9A.png)
 
 ([KLE](http://www.keyboard-layout-editor.com/#/gists/08b44355d4ca85d294bad9e2821f91d7))
 
@@ -105,6 +108,8 @@ keys (F1–F5) on the home row.)
 
 * Insert and Delete are on the rightmost column, because there didn't seem to
 be a better place to put them.
+
+* Caps Lock is bound in the same position as on an HHKB, for lack of an obvious better location.
 
 ## Adjust layer
 

--- a/keyboards/crkbd/keymaps/bcat/readme.md
+++ b/keyboards/crkbd/keymaps/bcat/readme.md
@@ -39,7 +39,7 @@ layer-switch keys to correct mistakes.
 * There are two Shift keys, although I generally use Left Shift. (I've
 considered replacing Right Shift with another key, but haven't chosen one.)
 
-* Lower and Raise layer-switch keys are in the resting postion of my left and
+* Lower and Raise layer-switch keys are in the resting position of my left and
 right thumbs, respectively.
 
 * Space and Enter are on the big thumb keys so they're easy to press.
@@ -75,7 +75,7 @@ And yup, the shifted versions are above the unshifted versions.
 left half.
 
 * The home row on the left half contains handy shortcuts for window movement,
-and browser naviation, and screen lock.
+and browser navigation, and screen lock.
 
 * Lower+Esc is bound to Ctrl+Space because the Ctrl and Space keys are both on
 the left thumb, so this key combination (which I use for tmux prefix and editor
@@ -83,7 +83,7 @@ autocomplete) is hard to press in its natural location.
 
 * Lower+Tab is bound to a custom Alt+Tab macro that keeps the Alt modifier held
 as long as the Lower key is held down. This means that window switching is on
-Lower+Tab immediately next to brwoser tab switching (Ctrl+Tab).
+Lower+Tab immediately next to browser tab switching (Ctrl+Tab).
 
 ## Raise layer
 

--- a/keyboards/lily58/keymaps/bcat/config.h
+++ b/keyboards/lily58/keymaps/bcat/config.h
@@ -1,6 +1,3 @@
 #pragma once
 
 #define EE_HANDS
-
-/* Work around Elite-C v3 with broken VBUS detection. */
-#define SPLIT_USB_DETECT

--- a/keyboards/lily58/keymaps/bcat/keymap.c
+++ b/keyboards/lily58/keymaps/bcat/keymap.c
@@ -1,5 +1,7 @@
 #include QMK_KEYBOARD_H
 
+#include "bcat.h"
+
 enum layer {
     LAYER_DEFAULT,
     LAYER_LOWER,
@@ -10,31 +12,34 @@ enum layer {
 #define LY_LWR MO(LAYER_LOWER)
 #define LY_RSE MO(LAYER_RAISE)
 
-#define KY_CESC LCTL_T(KC_ESC)
+#define KY_CSPC LCTL(KC_SPC)
+#define KY_LOCK LGUI(KC_L)
+#define KY_WINL LGUI(KC_LEFT)
+#define KY_WINR LGUI(KC_RGHT)
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Default layer: http://www.keyboard-layout-editor.com/#/gists/e0eb3af65961e9fd612dcff3ddd88e4f */
     [LAYER_DEFAULT] = LAYOUT(
         KC_EQL,   KC_1,     KC_2,     KC_3,     KC_4,     KC_5,                         KC_6,     KC_7,     KC_8,     KC_9,     KC_0,     KC_MINS,
         KC_TAB,   KC_Q,     KC_W,     KC_E,     KC_R,     KC_T,                         KC_Y,     KC_U,     KC_I,     KC_O,     KC_P,     KC_BSPC,
-        KY_CESC,  KC_A,     KC_S,     KC_D,     KC_F,     KC_G,                         KC_H,     KC_J,     KC_K,     KC_L,     KC_SCLN,  KC_QUOT,
+        KC_ESC,   KC_A,     KC_S,     KC_D,     KC_F,     KC_G,                         KC_H,     KC_J,     KC_K,     KC_L,     KC_SCLN,  KC_QUOT,
         KC_LSFT,  KC_Z,     KC_X,     KC_C,     KC_V,     KC_B,     KC_WBAK,  KC_WFWD,  KC_N,     KC_M,     KC_COMM,  KC_DOT,   KC_SLSH,  KC_RSFT,
-                                      KC_LCTL,  KC_LALT,  LY_LWR,   KC_SPC,   KC_ENT,   LY_RSE,   KC_RGUI,  KC_APP
+                                      KC_LGUI,  KC_LCTL,  LY_LWR,   KC_SPC,   KC_ENT,   LY_RSE,   KC_RALT,  KC_APP
     ),
 
     /* Lower layer: http://www.keyboard-layout-editor.com/#/gists/19ad0d3b5d745fbb2818db09740f5a11 */
     [LAYER_LOWER] = LAYOUT(
         _______,  _______,  _______,  _______,  _______,  _______,                      _______,  _______,  _______,  _______,  _______,  _______,
-        KC_CAPS,  KC_EXLM,  KC_AT,    KC_HASH,  KC_DLR,   KC_PERC,                      KC_CIRC,  KC_AMPR,  KC_ASTR,  KC_LPRN,  KC_RPRN,  _______,
-        _______,  _______,  _______,  _______,  _______,  _______,                      KC_PIPE,  KC_UNDS,  KC_PLUS,  KC_LCBR,  KC_RCBR,  KC_TILD,
-        _______,  KC_APP,   KC_PSCR,  KC_SLCK,  KC_PAUS,  _______,  _______,  _______,  KC_BSLS,  KC_MINS,  KC_EQL,   KC_LBRC,  KC_RBRC,  KC_GRV,
+        MC_ALTT,  KC_EXLM,  KC_AT,    KC_HASH,  KC_DLR,   KC_PERC,                      KC_CIRC,  KC_AMPR,  KC_ASTR,  KC_LPRN,  KC_RPRN,  _______,
+        KY_CSPC,  KY_WINL,  KY_WINR,  KY_LOCK,  KC_WBAK,  KC_WFWD,                      KC_PIPE,  KC_UNDS,  KC_PLUS,  KC_LCBR,  KC_RCBR,  KC_TILD,
+        _______,  KC_APP,   KC_PSCR,  KC_SLCK,  KC_PAUS,  KC_LGUI,  _______,  _______,  KC_BSLS,  KC_MINS,  KC_EQL,   KC_LBRC,  KC_RBRC,  KC_GRV,
                                       _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______
     ),
 
     /* Raise layer: http://www.keyboard-layout-editor.com/#/gists/912be7955f781cdaf692cc4d4c0b5823 */
     [LAYER_RAISE] = LAYOUT(
         _______,  _______,  _______,  _______,  _______,  _______,                      _______,  _______,  _______,  _______,  _______,  _______,
-        _______,  KC_1,     KC_2,     KC_3,     KC_4,     KC_5,                         KC_6,     KC_7,     KC_8,     KC_9,     KC_0,     _______,
+        KC_CAPS,  KC_1,     KC_2,     KC_3,     KC_4,     KC_5,                         KC_6,     KC_7,     KC_8,     KC_9,     KC_0,     _______,
         _______,  KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,                        KC_LEFT,  KC_DOWN,  KC_UP,    KC_RGHT,  KC_F11,   KC_DEL,
         _______,  KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   _______,  _______,  KC_HOME,  KC_PGDN,  KC_PGUP,  KC_END,   KC_F12,   KC_INS,
                                       _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______
@@ -50,6 +55,6 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     ),
 };
 
-layer_state_t layer_state_set_user(layer_state_t state) {
+layer_state_t layer_state_set_keymap(layer_state_t state) {
     return update_tri_layer_state(state, LAYER_LOWER, LAYER_RAISE, LAYER_ADJUST);
 }

--- a/keyboards/lily58/keymaps/bcat/readme.md
+++ b/keyboards/lily58/keymaps/bcat/readme.md
@@ -11,24 +11,24 @@ using layers for numbers and symbols, so in practice this goes unused.
 placed in the same positions as on the ErgoDox EZ. (There's no real reason for
 this; I just had to do _something_ with those keys.)
 
-* The extra thumb keys are used for dedicated Ctrl/Menu keys (not super useful)
-and browser back/forward navigation keys (actually more useful than expected).
+* The extra thumb keys are used for dedicated Super/Menu keys, as well as
+browser back/forward navigation keys.
 
 ## Default layer
 
-![Default layer layout](https://i.imgur.com/wx1brJV.png)
+![Default layer layout](https://i.imgur.com/FNITWJ0.png)
 
 ([KLE](http://www.keyboard-layout-editor.com/#/gists/e0eb3af65961e9fd612dcff3ddd88e4f))
 
 ## Lower layer
 
-![Lower layer layout](https://i.imgur.com/9JlbNAd.png)
+![Lower layer layout](https://i.imgur.com/JVF1p1Q.png)
 
 ([KLE](http://www.keyboard-layout-editor.com/#/gists/19ad0d3b5d745fbb2818db09740f5a11))
 
 ## Raise layer
 
-![Raise layer layout](https://i.imgur.com/Ue8tu1v.png)
+![Raise layer layout](https://i.imgur.com/NaWTavA.png)
 
 ([KLE](http://www.keyboard-layout-editor.com/#/gists/912be7955f781cdaf692cc4d4c0b5823))
 

--- a/users/bcat/bcat.c
+++ b/users/bcat/bcat.c
@@ -1,6 +1,43 @@
-#include "quantum.h"
+#include "bcat.h"
 
 #if defined(RGBLIGHT_ENABLE)
 /* Adjust RGB static hue ranges for shorter gradients than default. */
 const uint8_t RGBLED_GRADIENT_RANGES[] PROGMEM = {255, 127, 63, 31, 15};
 #endif
+
+static int8_t alt_tab_layer = -1;
+
+__attribute__((weak)) bool process_record_keymap(uint16_t keycode, keyrecord_t *record) { return true; }
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    if (!process_record_keymap(keycode, record)) {
+        return false;
+    }
+    switch (keycode) {
+        /* Alt+Tab that holds Alt until current layer is released: */
+        case MC_ALTT:
+            if (record->event.pressed) {
+                if (alt_tab_layer < 0) {
+                    alt_tab_layer = layer_switch_get_layer(record->event.key);
+                    register_code(KC_LALT);
+                }
+                register_code(KC_TAB);
+            } else {
+                unregister_code(KC_TAB);
+            }
+            return false;
+        default:
+            return true;
+    }
+}
+
+__attribute__((weak)) layer_state_t layer_state_set_keymap(layer_state_t state) { return state; }
+
+layer_state_t layer_state_set_user(layer_state_t state) {
+    state = layer_state_set_keymap(state);
+    if (alt_tab_layer >= 0 && !layer_state_cmp(state, alt_tab_layer)) {
+        unregister_code(KC_LALT);
+        alt_tab_layer = -1;
+    }
+    return state;
+}

--- a/users/bcat/bcat.h
+++ b/users/bcat/bcat.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "quantum.h"
+
+enum user_keycodes {
+    MC_ALTT = SAFE_RANGE,
+    KEYMAP_SAFE_RANGE,
+};

--- a/users/bcat/rules.mk
+++ b/users/bcat/rules.mk
@@ -3,8 +3,10 @@ SRC += bcat.c
 # Enable Bootmagic Lite to consistently reset to bootloader and clear EEPROM.
 BOOTMAGIC_ENABLE = lite
 
-# Enable media keys on all keyboards.
+# Enable media keys on all keyboards. (Even though I don't use mouse keys, they
+# seem to be required for media keys to register on Chrome OS.)
 EXTRAKEY_ENABLE = yes
+MOUSEKEY_ENABLE = yes
 
 # Enable link-time optimization to reduce binary size.
 LINK_TIME_OPTIMIZATION_ENABLE = yes
@@ -12,7 +14,6 @@ LINK_TIME_OPTIMIZATION_ENABLE = yes
 # Disable unused build options on all keyboards.
 COMMAND_ENABLE = no
 CONSOLE_ENABLE = no
-MOUSEKEY_ENABLE = no
 NKRO_ENABLE = no
 TERMINAL_ENABLE = no
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I started out by splitting my Crkbd's Ctrl/Esc mod-tap key into two separate keys and just, well, spiraled from there.

Incidentally, I also removed `SPLIT_USB_DETECT` from my Lily58 since I've switched it to controllers with working VUSB detection, and I re-enabled `MOUSEKEY_ENABLE` because otherwise media keys don't work on Chrome OS. (I'm still not sure if this is a Chrome OS bug or a QMK one.)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [X] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
