### PR TITLE
Add noeeprom speed function for RGBLIGHT

### DIFF
--- a/docs/feature_rgblight.md
+++ b/docs/feature_rgblight.md
@@ -377,6 +377,17 @@ rgblight_sethsv(HSV_GREEN, 2); // led 2
 |`rgblight_sethsv(h, s, v)`                  |Set effect range LEDs to the given HSV value where `h`/`s`/`v` are between 0 and 255 |
 |`rgblight_sethsv_noeeprom(h, s, v)`         |Set effect range LEDs to the given HSV value where `h`/`s`/`v` are between 0 and 255 (not written to EEPROM) |
 
+#### Speed functions
+|Function                                    |Description  |
+|--------------------------------------------|-------------|
+|`rgblight_increase_speed()`                 |Increases the animation speed. |
+|`rgblight_increase_speed_noeeprom()`        |Increases the animation speed. (no written to EEPROM) |
+|`rgblight_decrease_speed()`                 |Decreases the animation speed. |
+|`rgblight_decrease_speed_noeeprom()`        |Decreases the animation speed. (no written to EEPROM) |
+|`rgblight_set_speed()`                      |Sets the speed. Value is between 0 and 255. |
+|`rgblight_set_speed_noeeprom()`             |Sets the speed. Value is between 0 and 255. (no written to EEPROM) |
+
+
 #### layer functions
 |Function                                    |Description  |
 |--------------------------------------------|-------------|

--- a/docs/feature_rgblight.md
+++ b/docs/feature_rgblight.md
@@ -380,12 +380,12 @@ rgblight_sethsv(HSV_GREEN, 2); // led 2
 #### Speed functions
 |Function                                    |Description  |
 |--------------------------------------------|-------------|
-|`rgblight_increase_speed()`                 |Increases the animation speed. |
-|`rgblight_increase_speed_noeeprom()`        |Increases the animation speed. (no written to EEPROM) |
-|`rgblight_decrease_speed()`                 |Decreases the animation speed. |
-|`rgblight_decrease_speed_noeeprom()`        |Decreases the animation speed. (no written to EEPROM) |
-|`rgblight_set_speed()`                      |Sets the speed. Value is between 0 and 255. |
-|`rgblight_set_speed_noeeprom()`             |Sets the speed. Value is between 0 and 255. (no written to EEPROM) |
+|`rgblight_increase_speed()`                 |Increases the animation speed |
+|`rgblight_increase_speed_noeeprom()`        |Increases the animation speed (not written to EEPROM) |
+|`rgblight_decrease_speed()`                 |Decreases the animation speed |
+|`rgblight_decrease_speed_noeeprom()`        |Decreases the animation speed (not written to EEPROM) |
+|`rgblight_set_speed()`                      |Sets the speed. Value is between 0 and 255 |
+|`rgblight_set_speed_noeeprom()`             |Sets the speed. Value is between 0 and 255 (not written to EEPROM) |
 
 
 #### layer functions

--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -406,17 +406,28 @@ void rgblight_decrease_val_helper(bool write_to_eeprom) {
 }
 void rgblight_decrease_val_noeeprom(void) { rgblight_decrease_val_helper(false); }
 void rgblight_decrease_val(void) { rgblight_decrease_val_helper(true); }
-void rgblight_increase_speed(void) {
+
+
+void rgblight_increase_speed_helper(bool write_to_eeprom) {
     if (rgblight_config.speed < 3) rgblight_config.speed++;
     // RGBLIGHT_SPLIT_SET_CHANGE_HSVS; // NEED?
-    eeconfig_update_rgblight(rgblight_config.raw);  // EECONFIG needs to be increased to support this
+    if (write_to_eeprom) {
+        eeconfig_update_rgblight(rgblight_config.raw);  // EECONFIG needs to be increased to support this
+    }
 }
+void rgblight_increase_speed(void) { rgblight_increase_speed_helper(true); }
+void rgblight_increase_speed_noeeprom(void) { rgblight_increase_speed_helper(false); }
 
-void rgblight_decrease_speed(void) {
+void rgblight_decrease_speed_helper(bool write_to_eeprom) {
     if (rgblight_config.speed > 0) rgblight_config.speed--;
     // RGBLIGHT_SPLIT_SET_CHANGE_HSVS; // NEED??
-    eeconfig_update_rgblight(rgblight_config.raw);  // EECONFIG needs to be increased to support this
+    if (write_to_eeprom) {
+        eeconfig_update_rgblight(rgblight_config.raw);  // EECONFIG needs to be increased to support this
+    }
 }
+void rgblight_decrease_speed(void) { rgblight_decrease_speed_helper(true); }
+void rgblight_decrease_speed_noeeprom(void) { rgblight_decrease_speed_helper(false); }
+
 
 void rgblight_sethsv_noeeprom_old(uint8_t hue, uint8_t sat, uint8_t val) {
     if (rgblight_config.enable) {

--- a/quantum/rgblight.h
+++ b/quantum/rgblight.h
@@ -336,7 +336,9 @@ void rgblight_increase_val_noeeprom(void);
 void rgblight_decrease_val(void);
 void rgblight_decrease_val_noeeprom(void);
 void rgblight_increase_speed(void);
+void rgblight_increase_speed_noeeprom(void);
 void rgblight_decrease_speed(void);
+void rgblight_decrease_speed_noeeprom(void);
 void rgblight_sethsv(uint8_t hue, uint8_t sat, uint8_t val);
 void rgblight_sethsv_noeeprom(uint8_t hue, uint8_t sat, uint8_t val);
 


### PR DESCRIPTION
## Description

Add the no-eeprom versions of the speed functions for the RGB Light feature

## Types of Changes

- [x] Core
- [x] Documentation

## Issues Fixed or Closed by This PR

* Closes #9504

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
