### PR TITLE
OLED driver function to set pixels

### DIFF
--- a/docs/feature_oled_driver.md
+++ b/docs/feature_oled_driver.md
@@ -247,6 +247,10 @@ void oled_write_raw_byte(const char data, uint16_t index);
 // Writes a PROGMEM string to the buffer at current cursor position
 void oled_write_raw_P(const char *data, uint16_t size);
 
+// Sets a specific pixel on or off
+// Coordinates start at top-left and go right and down for positive x and y
+void oled_write_pixel(int16_t x, int16_t y, bool on);
+
 // Can be used to manually turn on the screen if it is off
 // Returns true if the screen was on or turns on
 bool oled_on(void);

--- a/docs/feature_oled_driver.md
+++ b/docs/feature_oled_driver.md
@@ -249,7 +249,7 @@ void oled_write_raw_P(const char *data, uint16_t size);
 
 // Sets a specific pixel on or off
 // Coordinates start at top-left and go right and down for positive x and y
-void oled_write_pixel(int16_t x, int16_t y, bool on);
+void oled_write_pixel(uint8_t x, uint8_t y, bool on);
 
 // Can be used to manually turn on the screen if it is off
 // Returns true if the screen was on or turns on

--- a/drivers/oled/oled_driver.c
+++ b/drivers/oled/oled_driver.c
@@ -463,7 +463,7 @@ void oled_write_raw(const char *data, uint16_t size) {
 }
 
 void oled_write_pixel(uint8_t x, uint8_t y, bool on) {
-    if (x > OLED_DISPLAY_WIDTH || y > OLED_DISPLAY_HEIGHT) {
+    if (x >= OLED_DISPLAY_WIDTH || y >= OLED_DISPLAY_HEIGHT) {
         return;
     }
     uint16_t index = x + (y / 8) * OLED_DISPLAY_WIDTH;

--- a/drivers/oled/oled_driver.c
+++ b/drivers/oled/oled_driver.c
@@ -462,8 +462,8 @@ void oled_write_raw(const char *data, uint16_t size) {
     }
 }
 
-void oled_write_pixel(int16_t x, int16_t y, bool on) {
-    if (x < 0 || y < 0 || x >= OLED_DISPLAY_WIDTH || y >= OLED_DISPLAY_HEIGHT) {
+void oled_write_pixel(uint8_t x, uint8_t y, bool on) {
+    if (x > OLED_DISPLAY_WIDTH || y > OLED_DISPLAY_HEIGHT) {
         return;
     }
     uint16_t index = x + (y / 8) * OLED_DISPLAY_WIDTH;

--- a/drivers/oled/oled_driver.c
+++ b/drivers/oled/oled_driver.c
@@ -462,6 +462,19 @@ void oled_write_raw(const char *data, uint16_t size) {
     }
 }
 
+void oled_write_pixel(int16_t x, int16_t y, bool on) {
+    if (x < 0 || y < 0 || x >= OLED_DISPLAY_WIDTH || y >= OLED_DISPLAY_HEIGHT) {
+        return;
+    }
+    uint16_t index = x + (y / 8) * OLED_DISPLAY_WIDTH;
+    if (on) {
+        oled_buffer[index] |= (1 << (y % 8));
+    } else {
+        oled_buffer[index] &= ~(1 << (y % 8));
+    }
+    oled_dirty |= (1 << (index / OLED_BLOCK_SIZE));
+}
+
 #if defined(__AVR__)
 void oled_write_P(const char *data, bool invert) {
     uint8_t c = pgm_read_byte(data);
@@ -630,19 +643,6 @@ void oled_task(void) {
 #    endif
     }
 #endif
-}
-
-void oled_write_pixel(int16_t x, int16_t y, bool on) {
-    if (x < 0 || y < 0 || x >= OLED_DISPLAY_WIDTH || y >= OLED_DISPLAY_HEIGHT) {
-        return;
-    }
-    uint16_t index = x + (y / 8) * OLED_DISPLAY_WIDTH;
-    if (on) {
-        oled_buffer[index] |= (1 << (y % 8));
-    } else {
-        oled_buffer[index] &= ~(1 << (y % 8));
-    }
-    oled_dirty |= (1 << (index / OLED_BLOCK_SIZE));
 }
 
 __attribute__((weak)) void oled_task_user(void) {}

--- a/drivers/oled/oled_driver.c
+++ b/drivers/oled/oled_driver.c
@@ -632,4 +632,17 @@ void oled_task(void) {
 #endif
 }
 
+void oled_write_pixel(int16_t x, int16_t y, bool on) {
+    if (x < 0 || y < 0 || x >= OLED_DISPLAY_WIDTH || y >= OLED_DISPLAY_HEIGHT) {
+        return;
+    }
+    uint16_t index = x + (y / 8) * OLED_DISPLAY_WIDTH;
+    if (on) {
+        oled_buffer[index] |= (1 << (y % 8));
+    } else {
+        oled_buffer[index] &= ~(1 << (y % 8));
+    }
+    oled_dirty |= (1 << (index / OLED_BLOCK_SIZE));
+}
+
 __attribute__((weak)) void oled_task_user(void) {}

--- a/drivers/oled/oled_driver.h
+++ b/drivers/oled/oled_driver.h
@@ -208,7 +208,7 @@ void oled_write_raw_byte(const char data, uint16_t index);
 
 // Sets a specific pixel on or off
 // Coordinates start at top-left and go right and down for positive x and y
-void oled_write_pixel(int16_t x, int16_t y, bool on);
+void oled_write_pixel(uint8_t x, uint8_t y, bool on);
 
 #if defined(__AVR__)
 // Writes a PROGMEM string to the buffer at current cursor position

--- a/drivers/oled/oled_driver.h
+++ b/drivers/oled/oled_driver.h
@@ -206,6 +206,10 @@ void oled_pan(bool left);
 void oled_write_raw(const char *data, uint16_t size);
 void oled_write_raw_byte(const char data, uint16_t index);
 
+// Sets a specific pixel on or off
+// Coordinates start at top-left and go right and down for positive x and y
+void oled_write_pixel(int16_t x, int16_t y, bool on);
+
 #if defined(__AVR__)
 // Writes a PROGMEM string to the buffer at current cursor position
 // Advances the cursor while writing, inverts the pixels if true
@@ -277,7 +281,3 @@ uint8_t oled_max_chars(void);
 
 // Returns the maximum number of lines that will fit on the oled
 uint8_t oled_max_lines(void);
-
-// Sets a specific pixel on or off
-// Coordinates start at top-left and go right and down for positive x and y
-void oled_write_pixel(int16_t x, int16_t y, bool on);

--- a/drivers/oled/oled_driver.h
+++ b/drivers/oled/oled_driver.h
@@ -277,3 +277,7 @@ uint8_t oled_max_chars(void);
 
 // Returns the maximum number of lines that will fit on the oled
 uint8_t oled_max_lines(void);
+
+// Sets a specific pixel on or off
+// Coordinates start at top-left and go right and down for positive x and y
+void oled_write_pixel(int16_t x, int16_t y, bool on);


### PR DESCRIPTION
Add a function to set individual pixels to oled driver.

## Description

Add a function to turn an individual pixel on or off, based on x and y coordinates. Coordinates start from top-left and positive values of x and y move right and down respectively.

Allows for things like [a starfield](https://imgur.com/gallery/HeFWeKJ) ([example code](https://github.com/GauthamYerroju/qmk_firmware/blob/oled_starfield/keyboards/kyria/keymaps/gotham/oled_animations/starfield.c)), or [bitmap rendering at exact pixel positions](https://imgur.com/gallery/yk9k0XP)  ([example code](https://github.com/GauthamYerroju/qmk_firmware/blob/oled_starfield/keyboards/kyria/keymaps/gotham/oled_animations/dvd_logo.c)).

The bitmap rendering example code has an implementation for ```oled_write_bitmap(bitmap, x, y, width, height, erase_flag)``` ([here](https://github.com/GauthamYerroju/qmk_firmware/blob/oled_starfield/keyboards/kyria/keymaps/gotham/oled_animations/common.c)) and it works great, but I am not sure if it's performant or worthy enough for a PR. I am able to push 60 fps on the DVD logo without noticeable lag on pro micros (granted my max WPM is only around 50).

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

None

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
