### PR TITLE
planck/rev6: Enable WS2812 LED matrix with pwm drivers

### DIFF
--- a/keyboards/planck/rev6/chconf.h
+++ b/keyboards/planck/rev6/chconf.h
@@ -1,0 +1,21 @@
+/* Copyright 2020 QMK Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Need to override the SysTick timer to use TIM3 -- this is a 16-bit timer on F303
+// so we need to change resolution and frequency to match.
+#define CH_CFG_ST_RESOLUTION 16
+#define CH_CFG_ST_FREQUENCY 10000
+#include_next "chconf.h"

--- a/keyboards/planck/rev6/config.h
+++ b/keyboards/planck/rev6/config.h
@@ -126,17 +126,18 @@
 /* override number of MIDI tone keycodes (each octave adds 12 keycodes and allocates 12 bytes) */
 //#define MIDI_TONE_KEYCODE_OCTAVES 1
 
-// #define WS2812_LED_N 2
-// #define RGBLED_NUM WS2812_LED_N
-// #define WS2812_TIM_N 2
-// #define WS2812_TIM_CH 2
-// #define PORT_WS2812     GPIOA
-// #define PIN_WS2812      1
-// #define WS2812_DMA_STREAM STM32_DMA1_STREAM2  // DMA stream for TIMx_UP (look up in reference manual under DMA Channel selection)
-//#define WS2812_DMA_CHANNEL 7                  // DMA channel for TIMx_UP
-//#define WS2812_EXTERNAL_PULLUP
+
+/*
+ * WS2812 Underglow Matrix options
+ */
 #define RGB_DI_PIN A1
 #define RGBLED_NUM 9
-#define RGBLIGHT_ANIMATIONS
+#define DRIVER_LED_TOTAL RGBLED_NUM
+
+#define WS2812_PWM_DRIVER PWMD2
+#define WS2812_PWM_CHANNEL 2
+#define WS2812_PWM_PAL_MODE 1
+#define WS2812_DMA_STREAM STM32_DMA1_STREAM2
+#define WS2812_DMA_CHANNEL 2
 
 #endif

--- a/keyboards/planck/rev6/mcuconf.h
+++ b/keyboards/planck/rev6/mcuconf.h
@@ -1,0 +1,30 @@
+/* Copyright 2020 QMK Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include_next "mcuconf.h"
+
+// The SysTick timer from the normal quantum/stm32 uses TIM2 -- the WS2812 pin used
+// on the Planck requires the use of TIM2 to run PWM -- rework which timers are
+// allocated for PWM usage.
+#undef STM32_PWM_USE_TIM2
+#undef STM32_PWM_USE_TIM3
+#define STM32_PWM_USE_TIM2 TRUE
+#define STM32_PWM_USE_TIM3 FALSE
+
+// As mentioned above, we need to reallocate the SysTick timer used from
+// TIM2 to TIM3.
+#undef STM32_ST_USE_TIMER
+#define STM32_ST_USE_TIMER 3

--- a/keyboards/planck/rev6/rev6.c
+++ b/keyboards/planck/rev6/rev6.c
@@ -15,6 +15,25 @@
  */
 #include "rev6.h"
 
+led_config_t g_led_config = { {
+  // Key Matrix to LED Index
+  { NO_LED, 6,      NO_LED, NO_LED, 5,      NO_LED },
+  { NO_LED, NO_LED, NO_LED, NO_LED, NO_LED, NO_LED },
+  { NO_LED, NO_LED, NO_LED, NO_LED, NO_LED, 0      },
+  { NO_LED, 7,      NO_LED, NO_LED, 2,      NO_LED },
+  { NO_LED, 4,      NO_LED, NO_LED, 3,      NO_LED },
+  { NO_LED, NO_LED, NO_LED, NO_LED, NO_LED, NO_LED },
+  { NO_LED, NO_LED, NO_LED, NO_LED, NO_LED, NO_LED },
+  { NO_LED, 1,      NO_LED, NO_LED, 8,      NO_LED },
+}, {
+  // LED Index to Physical Position
+  {112, 39}, {148, 60}, {206, 53}, {206, 3}, {150, 3}, {74, 3}, {18, 3}, {18, 54}, {77, 60}
+}, {
+  // LED Index to Flag
+  LED_FLAG_ALL, LED_FLAG_ALL, LED_FLAG_ALL, LED_FLAG_ALL, LED_FLAG_ALL,
+  LED_FLAG_ALL, LED_FLAG_ALL, LED_FLAG_ALL, LED_FLAG_ALL
+} };
+
 void matrix_init_kb(void) {
 	matrix_init_user();
 }

--- a/keyboards/planck/rev6/rules.mk
+++ b/keyboards/planck/rev6/rules.mk
@@ -18,13 +18,14 @@ AUDIO_ENABLE = yes           # Audio output
 UNICODE_ENABLE = no         # Unicode
 BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
 RGBLIGHT_ENABLE = yes        # Enable WS2812 RGB underlight.
-WS2812_DRIVER = bitbang
+WS2812_DRIVER = pwm
 API_SYSEX_ENABLE = no
 
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
 SLEEP_LED_ENABLE = no    # Breathing sleep LED during USB suspend
 #SLEEP_LED_ENABLE = yes  # Breathing sleep LED during USB suspend
 
+RGB_MATRIX_ENABLE = WS2812
 # SERIAL_LINK_ENABLE = yes
 ENCODER_ENABLE = yes
 DIP_SWITCH_ENABLE = yes


### PR DESCRIPTION
This patch enables pwm drivers for the rev6 planck by default, and includes the necessary configuration for it to work out of the box.

## Description

- The default WS2812 driver has been changed from bitbang to pwm.
- RGB_MATRIX_ENABLE has been set to WS2812 by default in the rev6 rules.mk.
- In rev6.c, I've added a led_config_t define to allow the matrix indexing to work properly (taken from https://github.com/qmk/qmk_firmware/pull/6675).
- DRIVER_LED_TOTAL is set in the rev6 config.h, as well as some WS2812 config options.
- Lastly, overrides for chconf.h and mcuconf.h have been created to fix some board-specific issues with the default driver configuration.

I built the new version with all keymaps for the planck, and the only ones that have issues related to this pull request are those that define RGB_DI_PIN or RGBLED_NUM (bbaserdem, chance, experimental, myoung34, and yang). Others fail, but they seem to be for unrelated reasons.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
