### PR TITLE
MSYS2: Switch to bootloadHID package and bring back avrdude package

### DIFF
--- a/docs/driver_installation_zadig.md
+++ b/docs/driver_installation_zadig.md
@@ -23,7 +23,7 @@ Zadig will automatically detect the bootloader device. You may sometimes need to
 
 !> If Zadig lists one or more devices with the `HidUsb` driver, your keyboard is probably not in bootloader mode. The arrow will be colored orange and you will be asked to confirm modifying a system driver. **Do not** proceed if this is the case!
 
-If the arrow appears green, select the driver, and click **Install Driver**. The `libusb-win32` driver will usually work for AVR, and `WinUSB` for ARM, but if you still cannot flash the board, try installing a different driver from the list. For flashing a USBaspLoader device via command line with msys2, the `libusbk` driver is recommended, otherwise `libusb-win32` will work fine if you are using QMK Toolbox for flashing.
+If the arrow appears green, select the driver, and click **Install Driver**. The `libusb-win32` driver will usually work for AVR, and `WinUSB` for ARM, but if you still cannot flash the board, try installing a different driver from the list. USBAspLoader devices must use the `libusbK` driver.
 
 ![Zadig with a bootloader driver correctly installed](https://i.imgur.com/b8VgXzx.png)
 

--- a/util/activate_msys2.sh
+++ b/util/activate_msys2.sh
@@ -5,7 +5,6 @@ function export_variables {
     export PATH=$PATH:$util_dir
     export PATH=$PATH:$util_dir/dfu-programmer
     export PATH=$PATH:$util_dir/dfu-util-0.9-win64
-    export PATH=$PATH:$util_dir/bootloadHID.2012-12-08/commandline
     export PATH=$PATH:$util_dir/avr8-gnu-toolchain/bin
     export PATH=$PATH:$util_dir/gcc-arm-none-eabi/bin
 }

--- a/util/activate_wsl.sh
+++ b/util/activate_wsl.sh
@@ -7,7 +7,6 @@ function export_variables {
     export DFU_PROGRAMMER=$download_dir/dfu-programmer/dfu-programmer.exe
     export DFU_UTIL=$download_dir/dfu-util-0.9-win64/dfu-util.exe
     export TEENSY_LOADER_CLI=$download_dir/teensy_loader_cli.exe
-    export BOOTLOADHID_PROGRAMMER=$download_dir/bootloadHID.2012-12-08/commandline/bootloadHID.exe
 }
 
 export_variables

--- a/util/drivers.txt
+++ b/util/drivers.txt
@@ -4,7 +4,7 @@
 # Driver can be one of winusb,libusb,libusbk
 # Use Windows Powershell and type [guid]::NewGuid() to generate guids
 winusb,STM32 Bootloader,0483,DF11,6d98a87f-4ecf-464d-89ed-8c684d857a75
-libusb,USBaspLoader,16C0,05DC,e69affdc-0ef0-427c-aefb-4e593c9d2724
+libusbk,USBaspLoader,16C0,05DC,e69affdc-0ef0-427c-aefb-4e593c9d2724
 winusb,Kiibohd DFU Bootloader,1C11,B007,aa5a3f86-b81e-4416-89ad-0c1ea1ed63af
 libusb,ATmega16U2,03EB,2FEF,007274da-b75f-492e-a288-8fc0aff8339f
 libusb,ATmega32U2,03EB,2FF0,ddc2c572-cb6e-4f61-a6cc-1a5de941f063

--- a/util/msys2_install.sh
+++ b/util/msys2_install.sh
@@ -20,10 +20,7 @@ function install_avr {
     rm avr8-gnu-toolchain/bin/make.exe
     rm avr-gcc-8.3.0-x86-mingw.zip
 
-    # FIXME: As of 2020-05-19, the MSYS2 avrdude cannot flash USBaspLoader devices, for some reason
-    # (warning: cannot set sck period)
-    # However, the avr-gcc toolchain above contains an avrdude which can, so let's just not install this for now
-    #pacman --needed --disable-download-timeout -S mingw-w64-x86_64-avrdude
+    pacman --needed --disable-download-timeout -S mingw-w64-x86_64-avrdude mingw-w64-x86_64-bootloadhid
 }
 
 function install_arm {

--- a/util/win_shared_install.sh
+++ b/util/win_shared_install.sh
@@ -18,10 +18,6 @@ function install_utils {
     wget 'https://www.pjrc.com/teensy/teensy_loader_cli_windows.zip'
     unzip teensy_loader_cli_windows.zip
 
-    echo "Installing bootloadHID"
-    wget 'https://www.obdev.at/downloads/vusb/bootloadHID.2012-12-08.zip'
-    unzip bootloadHID.2012-12-08.zip
-
     echo "Downloading the QMK driver installer"
     wget -qO- https://api.github.com/repos/qmk/qmk_driver_installer/releases | grep browser_download_url | head -n 1 | cut -d '"' -f 4 | wget -i -
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

MSYS2 now has a bootloadHID package, so let's use it instead of downloading the zip from obdev.
Also, the "bug" in the avrdude package is not really a bug - USBAspLoader just requires the libusbK driver to be installed on it. So I've updated the drivers.txt and put back the avrdude package.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
