### PR TITLE
Re-fix the STM32 dual-bank bootloader stuff.

### DIFF
--- a/tmk_core/common/chibios/bootloader.c
+++ b/tmk_core/common/chibios/bootloader.c
@@ -41,34 +41,26 @@ extern uint32_t __ram0_end__;
         } while (0)
 
 void bootloader_jump(void) {
-    *MAGIC_ADDR = BOOTLOADER_MAGIC;  // set magic flag => reset handler will jump into boot loader
+    // For STM32 MCUs with dual-bank flash, and we're incapable of jumping to the bootloader. The first valid flash
+    // bank is executed unconditionally after a reset, so it doesn't enter DFU unless BOOT0 is high. Instead, we do
+    // it with hardware...in this case, we pull a GPIO high/low depending on the configuration, connects 3.3V to
+    // BOOT0's RC charging circuit, lets it charge the capacitor, and issue a system reset. See the QMK discord
+    // #hardware channel pins for an example circuit.
+    palSetPadMode(PAL_PORT(STM32_BOOTLOADER_DUAL_BANK_GPIO), PAL_PAD(STM32_BOOTLOADER_DUAL_BANK_GPIO), PAL_MODE_OUTPUT_PUSHPULL);
+#    if STM32_BOOTLOADER_DUAL_BANK_POLARITY
+    palSetPad(PAL_PORT(STM32_BOOTLOADER_DUAL_BANK_GPIO), PAL_PAD(STM32_BOOTLOADER_DUAL_BANK_GPIO));
+#    else
+    palClearPad(PAL_PORT(STM32_BOOTLOADER_DUAL_BANK_GPIO), PAL_PAD(STM32_BOOTLOADER_DUAL_BANK_GPIO));
+#    endif
+
+    // Wait for a while for the capacitor to charge
+    bootdelay(STM32_BOOTLOADER_DUAL_BANK_DELAY);
+
+    // Issue a system reset to get the ROM bootloader to execute, with BOOT0 high
     NVIC_SystemReset();
 }
 
-void enter_bootloader_mode_if_requested(void) {
-    unsigned long *check = MAGIC_ADDR;
-    if (*check == BOOTLOADER_MAGIC) {
-        *check = 0;
-
-        // For STM32 MCUs with dual-bank flash, and we're incapable of jumping to the bootloader. The first valid flash
-        // bank is executed unconditionally after a reset, so it doesn't enter DFU unless BOOT0 is high. Instead, we do
-        // it with hardware...in this case, we pull a GPIO high/low depending on the configuration, connects 3.3V to
-        // BOOT0's RC charging circuit, lets it charge the capacitor, and issue a system reset. See the QMK discord
-        // #hardware channel pins for an example circuit.
-        palSetPadMode(PAL_PORT(STM32_BOOTLOADER_DUAL_BANK_GPIO), PAL_PAD(STM32_BOOTLOADER_DUAL_BANK_GPIO), PAL_MODE_OUTPUT_PUSHPULL);
-#    if STM32_BOOTLOADER_DUAL_BANK_POLARITY
-        palSetPad(PAL_PORT(STM32_BOOTLOADER_DUAL_BANK_GPIO), PAL_PAD(STM32_BOOTLOADER_DUAL_BANK_GPIO));
-#    else
-        palClearPad(PAL_PORT(STM32_BOOTLOADER_DUAL_BANK_GPIO), PAL_PAD(STM32_BOOTLOADER_DUAL_BANK_GPIO));
-#    endif
-
-        // Wait for a while for the capacitor to charge
-        bootdelay(STM32_BOOTLOADER_DUAL_BANK_DELAY);
-
-        // Issue a system reset to get the ROM bootloader to execute, with BOOT0 high
-        NVIC_SystemReset();
-    }
-}
+void enter_bootloader_mode_if_requested(void) {}  // not needed at all, but if anybody attempts to invoke it....
 
 #elif defined(STM32_BOOTLOADER_ADDRESS)  // STM32_BOOTLOADER_DUAL_BANK
 

--- a/tmk_core/common/chibios/bootloader.c
+++ b/tmk_core/common/chibios/bootloader.c
@@ -2,6 +2,7 @@
 
 #include "ch.h"
 #include "hal.h"
+#include "wait.h"
 
 /* This code should be checked whether it runs correctly on platforms */
 #define SYMVAL(sym) (uint32_t)(((uint8_t *)&(sym)) - ((uint8_t *)0))
@@ -31,15 +32,6 @@
 
 extern uint32_t __ram0_end__;
 
-#    define bootdelay(loopcount)                  \
-        do {                                      \
-            for (int i = 0; i < loopcount; ++i) { \
-                __asm__ volatile("nop\n\t"        \
-                                 "nop\n\t"        \
-                                 "nop\n\t");      \
-            }                                     \
-        } while (0)
-
 void bootloader_jump(void) {
     // For STM32 MCUs with dual-bank flash, and we're incapable of jumping to the bootloader. The first valid flash
     // bank is executed unconditionally after a reset, so it doesn't enter DFU unless BOOT0 is high. Instead, we do
@@ -54,7 +46,7 @@ void bootloader_jump(void) {
 #    endif
 
     // Wait for a while for the capacitor to charge
-    bootdelay(STM32_BOOTLOADER_DUAL_BANK_DELAY);
+    wait_ms(100);
 
     // Issue a system reset to get the ROM bootloader to execute, with BOOT0 high
     NVIC_SystemReset();


### PR DESCRIPTION
## Description

Apparently I hadn't actually updated to the latest copy when I merged. Serves me right for assuming it was unchanged.
Anyways, this swaps things out to jump to bootloader directly when using dual-bank flash -- there's no need to go through the process of resetting the MCU, then charging the capacitor, and resetting the MCU a second time.

This change makes it so that we skip the first reset -- i.e. we only charge the capacitor then issue a system reset.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
