### PR TITLE
Removed the need for timeout if using SPLIT_USB_DETECT

### DIFF
--- a/common_features.mk
+++ b/common_features.mk
@@ -428,8 +428,10 @@ ifeq ($(strip $(SPLIT_KEYBOARD)), yes)
         # Functions added via QUANTUM_LIB_SRC are only included in the final binary if they're called.
         # Unused functions are pruned away, which is why we can add multiple drivers here without bloat.
         ifeq ($(PLATFORM),AVR)
-            QUANTUM_LIB_SRC += i2c_master.c \
-                               i2c_slave.c
+            ifneq ($(NO_I2C),yes)
+                QUANTUM_LIB_SRC += i2c_master.c \
+                                   i2c_slave.c
+            endif
         endif
 
         SERIAL_DRIVER ?= bitbang

--- a/drivers/avr/serial.c
+++ b/drivers/avr/serial.c
@@ -20,11 +20,11 @@
 
 #ifdef SOFT_SERIAL_PIN
 
-#    ifdef __AVR_ATmega32U4__
-// if using ATmega32U4 I2C, can not use PD0 and PD1 in soft serial.
+#    if defined(__AVR_ATmega16U2__) || defined(__AVR_ATmega32U2__) || defined(__AVR_ATmega16U4__) || defined(__AVR_ATmega32U4__)
+// if using ATmegaxxU4 I2C, can not use PD0 and PD1 in soft serial.
 #        ifdef USE_AVR_I2C
 #            if SOFT_SERIAL_PIN == D0 || SOFT_SERIAL_PIN == D1
-#                error Using ATmega32U4 I2C, so can not use PD0, PD1
+#                error Using ATmegaxxU4 I2C, so can not use PD0, PD1
 #            endif
 #        endif
 
@@ -52,7 +52,7 @@
 #                define EICRx_BIT (~(_BV(ISC30) | _BV(ISC31)))
 #                define SERIAL_PIN_INTERRUPT INT3_vect
 #            endif
-#        elif SOFT_SERIAL_PIN == E6
+#        elif (defined(__AVR_ATmega16U4__) || defined(__AVR_ATmega32U4__)) && SOFT_SERIAL_PIN == E6
 #            define EIMSK_BIT _BV(INT6)
 #            define EICRx_BIT (~(_BV(ISC60) | _BV(ISC61)))
 #            define SERIAL_PIN_INTERRUPT INT6_vect
@@ -61,7 +61,7 @@
 #        endif
 
 #    else
-#        error serial.c now support ATmega32U4 only
+#        error serial.c currently only supports ATmegaxxU2 and ATmegaxxU4
 #    endif
 
 #    define ALWAYS_INLINE __attribute__((always_inline))

--- a/quantum/mcu_selection.mk
+++ b/quantum/mcu_selection.mk
@@ -252,6 +252,9 @@ ifneq (,$(filter $(MCU),atmega16u2 atmega32u2 atmega16u4 atmega32u4 at90usb646 a
   ifeq (,$(filter $(NO_INTERRUPT_CONTROL_ENDPOINT),yes))
     OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
   endif
+  ifneq (,$(filter $(MCU),atmega16u2 atmega32u2))
+    NO_I2C = yes
+  endif
 endif
 
 ifneq (,$(filter $(MCU),atmega32a))

--- a/quantum/split_common/transport.h
+++ b/quantum/split_common/transport.h
@@ -8,3 +8,6 @@ void transport_slave_init(void);
 // returns false if valid data not received from slave
 bool transport_master(matrix_row_t matrix[]);
 void transport_slave(matrix_row_t matrix[]);
+
+// returns false if master has no USB connection
+bool transport_slave_detect(void);

--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,12 @@
 [![GitHub contributors](https://img.shields.io/github/contributors/qmk/qmk_firmware.svg)](https://github.com/qmk/qmk_firmware/pulse/monthly)
 [![GitHub forks](https://img.shields.io/github/forks/qmk/qmk_firmware.svg?style=social&label=Fork)](https://github.com/qmk/qmk_firmware/)
 
+# THIS IS THE DEVELOP BRANCH
+
+Warning- This is the `develop` branch of QMK Firmware. You may encounter broken code here. Please see [Breaking Changes](https://docs.qmk.fm/#/breaking_changes) for more information.
+
+# Original readme continues
+
 This is a keyboard firmware based on the [tmk\_keyboard firmware](https://github.com/tmk/tmk_keyboard) with some useful features for Atmel AVR and ARM controllers, and more specifically, the [OLKB product line](https://olkb.com), the [ErgoDox EZ](https://ergodox-ez.com) keyboard, and the [Clueboard product line](https://clueboard.co).
 
 ## Documentation

--- a/tmk_core/common/matrix.h
+++ b/tmk_core/common/matrix.h
@@ -30,16 +30,6 @@ typedef uint32_t matrix_row_t;
 #    error "MATRIX_COLS: invalid value"
 #endif
 
-#if (MATRIX_ROWS <= 8)
-typedef uint8_t matrix_col_t;
-#elif (MATRIX_ROWS <= 16)
-typedef uint16_t matrix_col_t;
-#elif (MATRIX_ROWS <= 32)
-typedef uint32_t matrix_col_t;
-#else
-#    error "MATRIX_ROWS: invalid value"
-#endif
-
 #define MATRIX_ROW_SHIFTER ((matrix_row_t)1)
 
 #define MATRIX_IS_ON(row, col) (matrix_get_row(row) && (1 << col))


### PR DESCRIPTION
Following my issue https://github.com/qmk/qmk_firmware/issues/8990, I created a fix for the described problem. To reiterate:

With `SPLIT_USB_DETECT`, QMK currently tries to find a USB connection during a timeout period (default 2 seconds). If not found, the board half is set to slave, otherwise to master. This is unreliable, if the connection is not found within the timeout period for some reason. Now, the detection is much faster and reliable. It is not required to wait for any timeout to finish.

## Description

I implemented a communication phase during the USB master side detection, which works like this:

- Both halves are initialized as slaves w.r.t. the transport that is used
- Both halves check for USB connection indefinitely, until one of them finds it
- The USB-connected half tells the other half, that it found the connection and thus becomes the master
- The slave half then stops looking for USB and becomes the slave

I tested for UART but implemented changes for I2C as well. I would be happy, if someone could test it, since I have no I2C board available.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

https://github.com/qmk/qmk_firmware/issues/8990

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
