### PR TITLE
Reclassify alpha/special auto shift keys for software Dvorak

### DIFF
--- a/docs/feature_auto_shift.md
+++ b/docs/feature_auto_shift.md
@@ -103,6 +103,14 @@ Do not Auto Shift numeric keys, zero through nine.
 
 Do not Auto Shift alpha characters, which include A through Z.
 
+### INVERT_DVORAK_FOR_AUTO_SHIFT (simple define)
+
+Classifies keys as SPECIAL/ALPHA according to what they would send *after*
+being remapped from US (QWERTY) to Dvorak.  With `INVERT_DVORAK_FOR_AUTO_SHIFT`
+and `NO_AUTO_SHIFT_SPECIAL` defined, Auto Shift will not be applied to Q, even
+if `NO_AUTO_SHIFT_ALPHA` is not defined.  This is because Q is a special
+character (') once remapped to Dvorak.
+
 ## Using Auto Shift Setup
 
 This will enable you to define three keys temporarily to increase, decrease and report your `AUTO_SHIFT_TIMEOUT`.

--- a/quantum/process_keycode/process_auto_shift.c
+++ b/quantum/process_keycode/process_auto_shift.c
@@ -100,15 +100,43 @@ bool process_auto_shift(uint16_t keycode, keyrecord_t *record) {
                 return true;
 
 #    ifndef NO_AUTO_SHIFT_ALPHA
+#        ifndef INVERT_DVORAK_FOR_AUTO_SHIFT
             case KC_A ... KC_Z:
+#        else
+            // Exclude "qwez", which when remapped from QWERTY to
+            // Dvorak in software become "',.;" respectively.
+            case KC_A ... KC_D:
+            case KC_F ... KC_P:
+            case KC_R ... KC_V:
+            case KC_X ... KC_Z:
+            // Include ",./;", which become "wvzs" respectively when remapped
+            // from QWERTY to Dvorak.
+            case KC_COMMA:
+            case KC_DOT:
+            case KC_SLASH:
+            case KC_SEMICOLON:
+#        endif /* INVERT_DVORAK_FOR_AUTO_SHIFT */
 #    endif
 #    ifndef NO_AUTO_SHIFT_NUMERIC
             case KC_1 ... KC_0:
 #    endif
 #    ifndef NO_AUTO_SHIFT_SPECIAL
             case KC_TAB:
-            case KC_MINUS ... KC_SLASH:
             case KC_NONUS_BSLASH:
+#        ifndef INVERT_DVORAK_FOR_AUTO_SHIFT
+            case KC_MINUS ... KC_SLASH:
+#        else
+            // Exclude ",./;", which become "wvzs" respectively when remapped
+            // from QWERTY to Dvorak.
+            case KC_MINUS ... KC_NONUS_HASH:
+            case KC_QUOTE ... KC_GRAVE:
+            // Include "qwez", which are "',.;" respectively when remapped from
+            // QWERTY to Dvorak in software.
+            case KC_Q:
+            case KC_W:
+            case KC_E:
+            case KC_Z:
+#        endif /* INVERT_DVORAK_FOR_AUTO_SHIFT */
 #    endif
                 autoshift_flush();
                 if (!autoshift_enabled) return true;


### PR DESCRIPTION
## Description

Currently the autoshift macros (NO_AUTO_SHIFT_SPECIAL and NO_AUTO_SHIFT_ALPHA) may behave in surpising ways when remapping QWERTY -> Dvorak in software (i.e. the OS, rather than QMK).  For example, if NO_AUTO_SHIFT_SPECIAL is defined (and NO_AUTO_SHIFT_ALPHA is not defined), then KC_Q *will* be auto-shifted, but this will be remapped by the OS to shift-quote, seemingly inconsistent with the intent to not auto shift punctuation characters.

This PR adds alternative logic conditional on a new INVERT_DVORAK_FOR_AUTO_SHIFT preprocessor symbol that classifies keys as SPECIAL/ALPHA according to what that would be *after* an additional layer of remapping.

This approach isn't really scalable to other software remaps, so I'll understand if you don't want to merge it into the main QMK repo.  That said, I know I'm not the only one remapping US -> Dvorak in software, since there's already some keymaps designed for that.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
