### PR TITLE
Updating comment diagram to match code in lets_split_eh/doxish_dvorak

### DIFF
--- a/keyboards/lets_split_eh/keymaps/doxish_dvorak/keymap.c
+++ b/keyboards/lets_split_eh/keymaps/doxish_dvorak/keymap.c
@@ -24,15 +24,15 @@ enum custom_keycodes {
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
-/* Qwerty
+/* Dvorak
  * ,-----------------------------------------------------------------------------------.
- * | Tab  |   Q  |   W  |   E  |   R  |   T  |   Y  |   U  |   I  |   O  |   P  | Bksp |
+ * |  '   |   ,  |   .  |   P  |   Y  | Tab  | Bksp |   F  |   G  |   C  |   R  |   L  |
  * |------+------+------+------+------+-------------+------+------+------+------+------|
- * | Func |   A  |   S  |   D  |   F  |   G  |   H  |   J  |   K  |   L  |   ;  | Enter|
+ * |   A  |   O  |   E  |   U  |   I  | Enter| Enter|   D  |   H  |   T  |   N  |   S  |
  * |------+------+------+------+------+------|------+------+------+------+------+------|
- * | Shift|   Z  |   X  |   C  |   V  |   B  |   N  |   M  |   ,  |   .  |   /  |  '   |
+ * |   ;  |   Q  |   J  |   K  |   X  | Shift| Shift|   B  |   M  |   W  |   V  |   Z  |
  * |------+------+------+------+------+------+------+------+------+------+------+------|
- * | Ctrl |  `   | GUI  | Alt  |Lower |    Space    |Raise | Left | Down |  Up  |Right |
+ * | Ctrl | GUI  | Alt  | Shift|Space |Lower |Raise |Space | Left | Down |  Up  |Right |
  * `-----------------------------------------------------------------------------------'
  */
 [_DVORAK] = LAYOUT( \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
The doxish_dvorak layout originally committed by @ROMUSKING did not change the diagram in comments to match the changes to the layout. This PR makes that diagram change. This is for the lets_split_eh keyboard.

This PR solely changes comments.
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->



<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [X] Keymap/layout/userspace (addition or update)
- [ ] Documentation

