### PR TITLE
Switch my Chrome OS media keys workaround from mouse keys to NKRO

### DIFF
--- a/keyboards/crkbd/keymaps/bcat/keymap.c
+++ b/keyboards/crkbd/keymaps/bcat/keymap.c
@@ -14,7 +14,6 @@ enum layer {
 
 #define KY_CSPC LCTL(KC_SPC)
 #define KY_LOCK LGUI(KC_L)
-#define KY_NKRO MAGIC_TOGGLE_NKRO
 #define KY_WINL LGUI(KC_LEFT)
 #define KY_WINR LGUI(KC_RGHT)
 
@@ -45,7 +44,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
     /* Adjust layer: http://www.keyboard-layout-editor.com/#/gists/77e7572e077b36a23eb2086017e16fee */
     [LAYER_ADJUST] = LAYOUT(
-        _______,  KY_NKRO,  KC_MPLY,  KC_VOLU,  KC_MSTP,  _______,                      EEP_RST,  RESET,    _______,  _______,  _______,  _______,
+        _______,  NK_TOGG,  KC_MPLY,  KC_VOLU,  KC_MSTP,  _______,                      EEP_RST,  RESET,    _______,  _______,  _______,  _______,
         _______,  _______,  KC_MPRV,  KC_VOLD,  KC_MNXT,  _______,                      RGB_RMOD, RGB_VAD,  RGB_VAI,  RGB_MOD,  RGB_SPI,  _______,
         _______,  _______,  _______,  KC_MUTE,  _______,  _______,                      RGB_HUI,  RGB_SAD,  RGB_SAI,  RGB_HUD,  RGB_SPD,  _______,
                                                 _______,  _______,  _______,  RGB_TOG,  _______,  _______

--- a/keyboards/crkbd/keymaps/bcat/keymap.c
+++ b/keyboards/crkbd/keymaps/bcat/keymap.c
@@ -14,6 +14,7 @@ enum layer {
 
 #define KY_CSPC LCTL(KC_SPC)
 #define KY_LOCK LGUI(KC_L)
+#define KY_NKRO MAGIC_TOGGLE_NKRO
 #define KY_WINL LGUI(KC_LEFT)
 #define KY_WINR LGUI(KC_RGHT)
 
@@ -44,7 +45,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
     /* Adjust layer: http://www.keyboard-layout-editor.com/#/gists/77e7572e077b36a23eb2086017e16fee */
     [LAYER_ADJUST] = LAYOUT(
-        _______,  _______,  KC_MPLY,  KC_VOLU,  KC_MSTP,  _______,                      EEP_RST,  RESET,    _______,  _______,  _______,  _______,
+        _______,  KY_NKRO,  KC_MPLY,  KC_VOLU,  KC_MSTP,  _______,                      EEP_RST,  RESET,    _______,  _______,  _______,  _______,
         _______,  _______,  KC_MPRV,  KC_VOLD,  KC_MNXT,  _______,                      RGB_RMOD, RGB_VAD,  RGB_VAI,  RGB_MOD,  RGB_SPI,  _______,
         _______,  _______,  _______,  KC_MUTE,  _______,  _______,                      RGB_HUI,  RGB_SAD,  RGB_SAI,  RGB_HUD,  RGB_SPD,  _______,
                                                 _______,  _______,  _______,  RGB_TOG,  _______,  _______

--- a/keyboards/crkbd/keymaps/bcat/readme.md
+++ b/keyboards/crkbd/keymaps/bcat/readme.md
@@ -113,7 +113,7 @@ be a better place to put them.
 
 ## Adjust layer
 
-![Adjust layer layout](https://i.imgur.com/LEHM4DU.png)
+![Adjust layer layout](https://i.imgur.com/fZouko5.png)
 
 ([KLE](http://www.keyboard-layout-editor.com/#/gists/77e7572e077b36a23eb2086017e16fee))
 

--- a/keyboards/keebio/quefrency/keymaps/bcat/keymap.c
+++ b/keyboards/keebio/quefrency/keymaps/bcat/keymap.c
@@ -7,6 +7,8 @@ enum layer {
 
 #define LY_FN MO(LAYER_FUNCTION)
 
+#define KY_NKRO MAGIC_TOGGLE_NKRO
+
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Default layer: http://www.keyboard-layout-editor.com/#/gists/60a262432bb340b37d364a4424f3037b */
     [LAYER_DEFAULT] = LAYOUT_65(
@@ -20,7 +22,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Function layer: http://www.keyboard-layout-editor.com/#/gists/59636898946da51f91fb290f8e078b4d */
     [LAYER_FUNCTION] = LAYOUT_65(
         _______,  KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   KC_INS,   KC_DEL,   RGB_HUI,
-        KC_CAPS,  _______,  KC_MPLY,  KC_VOLU,  KC_MSTP,  _______,  EEP_RST,  RESET,    KC_PSCR,  KC_SLCK,  KC_PAUS,  _______,  _______,  _______,            RGB_SAI,
+        KC_CAPS,  KY_NKRO,  KC_MPLY,  KC_VOLU,  KC_MSTP,  _______,  EEP_RST,  RESET,    KC_PSCR,  KC_SLCK,  KC_PAUS,  _______,  _______,  _______,            RGB_SAI,
         _______,  _______,  KC_MPRV,  KC_VOLD,  KC_MNXT,  _______,  _______,  _______,  _______,  _______,  _______,  _______,            RGB_TOG,            RGB_SAD,
         _______,  KC_APP,   _______,  KC_MUTE,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,                      RGB_VAI,  RGB_HUD,
         _______,  _______,  _______,  _______,  _______,                      _______,  _______,  _______,  _______,  _______,            RGB_RMOD, RGB_VAD,  RGB_MOD

--- a/keyboards/keebio/quefrency/keymaps/bcat/keymap.c
+++ b/keyboards/keebio/quefrency/keymaps/bcat/keymap.c
@@ -7,8 +7,6 @@ enum layer {
 
 #define LY_FN MO(LAYER_FUNCTION)
 
-#define KY_NKRO MAGIC_TOGGLE_NKRO
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Default layer: http://www.keyboard-layout-editor.com/#/gists/60a262432bb340b37d364a4424f3037b */
     [LAYER_DEFAULT] = LAYOUT_65(
@@ -22,7 +20,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Function layer: http://www.keyboard-layout-editor.com/#/gists/59636898946da51f91fb290f8e078b4d */
     [LAYER_FUNCTION] = LAYOUT_65(
         _______,  KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   KC_INS,   KC_DEL,   RGB_HUI,
-        KC_CAPS,  KY_NKRO,  KC_MPLY,  KC_VOLU,  KC_MSTP,  _______,  EEP_RST,  RESET,    KC_PSCR,  KC_SLCK,  KC_PAUS,  _______,  _______,  _______,            RGB_SAI,
+        KC_CAPS,  NK_TOGG,  KC_MPLY,  KC_VOLU,  KC_MSTP,  _______,  EEP_RST,  RESET,    KC_PSCR,  KC_SLCK,  KC_PAUS,  _______,  _______,  _______,            RGB_SAI,
         _______,  _______,  KC_MPRV,  KC_VOLD,  KC_MNXT,  _______,  _______,  _______,  _______,  _______,  _______,  _______,            RGB_TOG,            RGB_SAD,
         _______,  KC_APP,   _______,  KC_MUTE,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,                      RGB_VAI,  RGB_HUD,
         _______,  _______,  _______,  _______,  _______,                      _______,  _______,  _______,  _______,  _______,            RGB_RMOD, RGB_VAD,  RGB_MOD

--- a/keyboards/keebio/quefrency/keymaps/bcat/readme.md
+++ b/keyboards/keebio/quefrency/keymaps/bcat/readme.md
@@ -12,6 +12,6 @@ ESDF cluster), and RGB controls in the function layer (on the arrow/nav keys).
 
 ## Function layer
 
-![Function layer layout](https://i.imgur.com/Wmx1hfx.png)
+![Function layer layout](https://i.imgur.com/Fzshl0F.png)
 
 ([KLE](http://www.keyboard-layout-editor.com/#/gists/59636898946da51f91fb290f8e078b4d))

--- a/keyboards/lily58/keymaps/bcat/keymap.c
+++ b/keyboards/lily58/keymaps/bcat/keymap.c
@@ -14,7 +14,6 @@ enum layer {
 
 #define KY_CSPC LCTL(KC_SPC)
 #define KY_LOCK LGUI(KC_L)
-#define KY_NKRO MAGIC_TOGGLE_NKRO
 #define KY_WINL LGUI(KC_LEFT)
 #define KY_WINR LGUI(KC_RGHT)
 
@@ -49,7 +48,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Adjust layer: http://www.keyboard-layout-editor.com/#/gists/8f6a3f08350a9bbe1d414b22bca4e6c7 */
     [LAYER_ADJUST] = LAYOUT(
         _______,  _______,  _______,  _______,  _______,  _______,                      _______,  _______,  _______,  _______,  _______,  _______,
-        _______,  KY_NKRO,  KC_MPLY,  KC_VOLU,  KC_MSTP,  _______,                      EEP_RST,  RESET,    _______,  _______,  _______,  _______,
+        _______,  NK_TOGG,  KC_MPLY,  KC_VOLU,  KC_MSTP,  _______,                      EEP_RST,  RESET,    _______,  _______,  _______,  _______,
         _______,  _______,  KC_MPRV,  KC_VOLD,  KC_MNXT,  _______,                      _______,  _______,  _______,  _______,  _______,  _______,
         _______,  _______,  _______,  KC_MUTE,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,
                                       _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______

--- a/keyboards/lily58/keymaps/bcat/keymap.c
+++ b/keyboards/lily58/keymaps/bcat/keymap.c
@@ -14,6 +14,7 @@ enum layer {
 
 #define KY_CSPC LCTL(KC_SPC)
 #define KY_LOCK LGUI(KC_L)
+#define KY_NKRO MAGIC_TOGGLE_NKRO
 #define KY_WINL LGUI(KC_LEFT)
 #define KY_WINR LGUI(KC_RGHT)
 
@@ -48,7 +49,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Adjust layer: http://www.keyboard-layout-editor.com/#/gists/8f6a3f08350a9bbe1d414b22bca4e6c7 */
     [LAYER_ADJUST] = LAYOUT(
         _______,  _______,  _______,  _______,  _______,  _______,                      _______,  _______,  _______,  _______,  _______,  _______,
-        _______,  _______,  KC_MPLY,  KC_VOLU,  KC_MSTP,  _______,                      EEP_RST,  RESET,    _______,  _______,  _______,  _______,
+        _______,  KY_NKRO,  KC_MPLY,  KC_VOLU,  KC_MSTP,  _______,                      EEP_RST,  RESET,    _______,  _______,  _______,  _______,
         _______,  _______,  KC_MPRV,  KC_VOLD,  KC_MNXT,  _______,                      _______,  _______,  _______,  _______,  _______,  _______,
         _______,  _______,  _______,  KC_MUTE,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,
                                       _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______

--- a/keyboards/lily58/keymaps/bcat/readme.md
+++ b/keyboards/lily58/keymaps/bcat/readme.md
@@ -34,6 +34,6 @@ browser back/forward navigation keys.
 
 ## Adjust layer
 
-![Adjust layer layout](https://i.imgur.com/Rv6jQtC.png)
+![Adjust layer layout](https://i.imgur.com/Q3PGsiK.png)
 
 ([KLE](http://www.keyboard-layout-editor.com/#/gists/8f6a3f08350a9bbe1d414b22bca4e6c7))

--- a/layouts/community/60_ansi_split_bs_rshift/bcat/keymap.c
+++ b/layouts/community/60_ansi_split_bs_rshift/bcat/keymap.c
@@ -9,8 +9,6 @@ enum layer {
 #define LY_FN1 MO(LAYER_FUNCTION_1)
 #define LY_FN2 MO(LAYER_FUNCTION_2)
 
-#define KY_NKRO MAGIC_TOGGLE_NKRO
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Default layer: http://www.keyboard-layout-editor.com/#/gists/327b41b5a933b3d44bf60ca9822e85dc */
     [LAYER_DEFAULT] = LAYOUT_60_ansi_split_bs_rshift(
@@ -33,7 +31,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Function 2 layer: http://www.keyboard-layout-editor.com/#/gists/6e1068e4f91bbacccaf5ac0acbeec79c */
     [LAYER_FUNCTION_2] = LAYOUT_60_ansi_split_bs_rshift(
         _______,  KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   KC_INS,   KC_DEL,
-        _______,  KY_NKRO,  KC_MPLY,  KC_VOLU,  KC_MSTP,  BL_BRTG,  EEP_RST,  RESET,    _______,  _______,  _______,  RGB_VAI,  _______,  _______,
+        _______,  NK_TOGG,  KC_MPLY,  KC_VOLU,  KC_MSTP,  BL_BRTG,  EEP_RST,  RESET,    _______,  _______,  _______,  RGB_VAI,  _______,  _______,
         _______,  _______,  KC_MPRV,  KC_VOLD,  KC_MNXT,  BL_INC,   _______,  RGB_SPI,  RGB_HUI,  RGB_SAI,  RGB_RMOD, RGB_MOD,            RGB_TOG,
         _______,  _______,  _______,  KC_MUTE,  _______,  BL_DEC,   _______,  RGB_SPD,  RGB_HUD,  RGB_SAD,  RGB_VAD,  _______,                      _______,
         _______,  _______,  _______,                                _______,                                          _______,  _______,  _______,  _______

--- a/layouts/community/60_ansi_split_bs_rshift/bcat/keymap.c
+++ b/layouts/community/60_ansi_split_bs_rshift/bcat/keymap.c
@@ -9,6 +9,8 @@ enum layer {
 #define LY_FN1 MO(LAYER_FUNCTION_1)
 #define LY_FN2 MO(LAYER_FUNCTION_2)
 
+#define KY_NKRO MAGIC_TOGGLE_NKRO
+
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Default layer: http://www.keyboard-layout-editor.com/#/gists/327b41b5a933b3d44bf60ca9822e85dc */
     [LAYER_DEFAULT] = LAYOUT_60_ansi_split_bs_rshift(
@@ -31,7 +33,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Function 2 layer: http://www.keyboard-layout-editor.com/#/gists/6e1068e4f91bbacccaf5ac0acbeec79c */
     [LAYER_FUNCTION_2] = LAYOUT_60_ansi_split_bs_rshift(
         _______,  KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   KC_INS,   KC_DEL,
-        _______,  _______,  KC_MPLY,  KC_VOLU,  KC_MSTP,  BL_BRTG,  EEP_RST,  RESET,    _______,  _______,  _______,  RGB_VAI,  _______,  _______,
+        _______,  KY_NKRO,  KC_MPLY,  KC_VOLU,  KC_MSTP,  BL_BRTG,  EEP_RST,  RESET,    _______,  _______,  _______,  RGB_VAI,  _______,  _______,
         _______,  _______,  KC_MPRV,  KC_VOLD,  KC_MNXT,  BL_INC,   _______,  RGB_SPI,  RGB_HUI,  RGB_SAI,  RGB_RMOD, RGB_MOD,            RGB_TOG,
         _______,  _______,  _______,  KC_MUTE,  _______,  BL_DEC,   _______,  RGB_SPD,  RGB_HUD,  RGB_SAD,  RGB_VAD,  _______,                      _______,
         _______,  _______,  _______,                                _______,                                          _______,  _______,  _______,  _______

--- a/layouts/community/60_ansi_split_bs_rshift/bcat/readme.md
+++ b/layouts/community/60_ansi_split_bs_rshift/bcat/readme.md
@@ -19,6 +19,6 @@ layout](https://github.com/qmk/qmk_firmware/tree/master/layouts/community/60_tsa
 
 ## Function 2 layer
 
-![Function 2 layer layout](https://i.imgur.com/WRvsEuZ.png)
+![Function 2 layer layout](https://i.imgur.com/vJaCzVo.png)
 
 ([KLE](http://www.keyboard-layout-editor.com/#/gists/6e1068e4f91bbacccaf5ac0acbeec79c))

--- a/layouts/community/60_tsangan_hhkb/bcat/keymap.c
+++ b/layouts/community/60_tsangan_hhkb/bcat/keymap.c
@@ -9,8 +9,6 @@ enum layer {
 #define LY_FN1 MO(LAYER_FUNCTION_1)
 #define LY_FN2 MO(LAYER_FUNCTION_2)
 
-#define KY_NKRO MAGIC_TOGGLE_NKRO
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Default layer: http://www.keyboard-layout-editor.com/#/gists/86b33d75aa6f56d8781ab3d8475f4e77 */
     [LAYER_DEFAULT] = LAYOUT_60_tsangan_hhkb(
@@ -33,7 +31,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Function 2 layer: http://www.keyboard-layout-editor.com/#/gists/65ac939caec878401603bc36290852d4 */
     [LAYER_FUNCTION_2] = LAYOUT_60_tsangan_hhkb(
         _______,  KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   KC_INS,   KC_DEL,
-        _______,  KY_NKRO,  KC_MPLY,  KC_VOLU,  KC_MSTP,  BL_BRTG,  EEP_RST,  RESET,    _______,  _______,  _______,  RGB_VAI,  _______,  _______,
+        _______,  NK_TOGG,  KC_MPLY,  KC_VOLU,  KC_MSTP,  BL_BRTG,  EEP_RST,  RESET,    _______,  _______,  _______,  RGB_VAI,  _______,  _______,
         _______,  _______,  KC_MPRV,  KC_VOLD,  KC_MNXT,  BL_INC,   _______,  RGB_SPI,  RGB_HUI,  RGB_SAI,  RGB_RMOD, RGB_MOD,            RGB_TOG,
         _______,  _______,  _______,  KC_MUTE,  _______,  BL_DEC,   _______,  RGB_SPD,  RGB_HUD,  RGB_SAD,  RGB_VAD,  _______,                      _______,
         _______,  _______,  _______,                                _______,                                          _______,  _______,            _______

--- a/layouts/community/60_tsangan_hhkb/bcat/keymap.c
+++ b/layouts/community/60_tsangan_hhkb/bcat/keymap.c
@@ -9,6 +9,8 @@ enum layer {
 #define LY_FN1 MO(LAYER_FUNCTION_1)
 #define LY_FN2 MO(LAYER_FUNCTION_2)
 
+#define KY_NKRO MAGIC_TOGGLE_NKRO
+
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Default layer: http://www.keyboard-layout-editor.com/#/gists/86b33d75aa6f56d8781ab3d8475f4e77 */
     [LAYER_DEFAULT] = LAYOUT_60_tsangan_hhkb(
@@ -31,7 +33,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Function 2 layer: http://www.keyboard-layout-editor.com/#/gists/65ac939caec878401603bc36290852d4 */
     [LAYER_FUNCTION_2] = LAYOUT_60_tsangan_hhkb(
         _______,  KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   KC_INS,   KC_DEL,
-        _______,  _______,  KC_MPLY,  KC_VOLU,  KC_MSTP,  BL_BRTG,  EEP_RST,  RESET,    _______,  _______,  _______,  RGB_VAI,  _______,  _______,
+        _______,  KY_NKRO,  KC_MPLY,  KC_VOLU,  KC_MSTP,  BL_BRTG,  EEP_RST,  RESET,    _______,  _______,  _______,  RGB_VAI,  _______,  _______,
         _______,  _______,  KC_MPRV,  KC_VOLD,  KC_MNXT,  BL_INC,   _______,  RGB_SPI,  RGB_HUI,  RGB_SAI,  RGB_RMOD, RGB_MOD,            RGB_TOG,
         _______,  _______,  _______,  KC_MUTE,  _______,  BL_DEC,   _______,  RGB_SPD,  RGB_HUD,  RGB_SAD,  RGB_VAD,  _______,                      _______,
         _______,  _______,  _______,                                _______,                                          _______,  _______,            _______

--- a/layouts/community/60_tsangan_hhkb/bcat/readme.md
+++ b/layouts/community/60_tsangan_hhkb/bcat/readme.md
@@ -39,6 +39,6 @@ and/or blockers, so there aren't switches installed in those positions.
 
 ## Function 2 layer
 
-![Function 2 layer layout](https://i.imgur.com/37APm7c.png)
+![Function 2 layer layout](https://i.imgur.com/vdNpFae.png)
 
 ([KLE](http://www.keyboard-layout-editor.com/#/gists/65ac939caec878401603bc36290852d4))

--- a/layouts/community/65_ansi_blocker_split_bs/bcat/keymap.c
+++ b/layouts/community/65_ansi_blocker_split_bs/bcat/keymap.c
@@ -7,6 +7,8 @@ enum layer {
 
 #define LY_FN MO(LAYER_FUNCTION)
 
+#define KY_NKRO MAGIC_TOGGLE_NKRO
+
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Default layer: http://www.keyboard-layout-editor.com/#/gists/dd675b40cc4df2c7bb78847ac29f5988 */
     [LAYER_DEFAULT] = LAYOUT_65_ansi_blocker_split_bs(
@@ -20,7 +22,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Function layer: http://www.keyboard-layout-editor.com/#/gists/f29128427f674c43777f045e363d1b44 */
     [LAYER_FUNCTION] = LAYOUT_65_ansi_blocker_split_bs(
         _______,  KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   KC_INS,   KC_DEL,   _______,
-        KC_CAPS,  _______,  KC_MPLY,  KC_VOLU,  KC_MSTP,  _______,  EEP_RST,  RESET,    KC_PSCR,  KC_SLCK,  KC_PAUS,  _______,  _______,  _______,            _______,
+        KC_CAPS,  KY_NKRO,  KC_MPLY,  KC_VOLU,  KC_MSTP,  _______,  EEP_RST,  RESET,    KC_PSCR,  KC_SLCK,  KC_PAUS,  _______,  _______,  _______,            _______,
         _______,  _______,  KC_MPRV,  KC_VOLD,  KC_MNXT,  _______,  _______,  _______,  _______,  _______,  _______,  _______,            _______,            _______,
         _______,  KC_APP,   _______,  KC_MUTE,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,                      _______,  _______,
         _______,  _______,  _______,                      _______,                                _______,  _______,                      _______,  _______,  _______

--- a/layouts/community/65_ansi_blocker_split_bs/bcat/keymap.c
+++ b/layouts/community/65_ansi_blocker_split_bs/bcat/keymap.c
@@ -7,8 +7,6 @@ enum layer {
 
 #define LY_FN MO(LAYER_FUNCTION)
 
-#define KY_NKRO MAGIC_TOGGLE_NKRO
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Default layer: http://www.keyboard-layout-editor.com/#/gists/dd675b40cc4df2c7bb78847ac29f5988 */
     [LAYER_DEFAULT] = LAYOUT_65_ansi_blocker_split_bs(
@@ -22,7 +20,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Function layer: http://www.keyboard-layout-editor.com/#/gists/f29128427f674c43777f045e363d1b44 */
     [LAYER_FUNCTION] = LAYOUT_65_ansi_blocker_split_bs(
         _______,  KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   KC_INS,   KC_DEL,   _______,
-        KC_CAPS,  KY_NKRO,  KC_MPLY,  KC_VOLU,  KC_MSTP,  _______,  EEP_RST,  RESET,    KC_PSCR,  KC_SLCK,  KC_PAUS,  _______,  _______,  _______,            _______,
+        KC_CAPS,  NK_TOGG,  KC_MPLY,  KC_VOLU,  KC_MSTP,  _______,  EEP_RST,  RESET,    KC_PSCR,  KC_SLCK,  KC_PAUS,  _______,  _______,  _______,            _______,
         _______,  _______,  KC_MPRV,  KC_VOLD,  KC_MNXT,  _______,  _______,  _______,  _______,  _______,  _______,  _______,            _______,            _______,
         _______,  KC_APP,   _______,  KC_MUTE,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,                      _______,  _______,
         _______,  _______,  _______,                      _______,                                _______,  _______,                      _______,  _______,  _______

--- a/layouts/community/65_ansi_blocker_split_bs/bcat/readme.md
+++ b/layouts/community/65_ansi_blocker_split_bs/bcat/readme.md
@@ -12,6 +12,6 @@ keys, an HHKB-style (split) backspace, and media controls in the function layer
 
 ## Function layer
 
-![Function layer layout](https://i.imgur.com/Q304GlI.png)
+![Function layer layout](https://i.imgur.com/CsxfVfd.png)
 
 ([KLE](http://www.keyboard-layout-editor.com/#/gists/f29128427f674c43777f045e363d1b44))

--- a/users/bcat/rules.mk
+++ b/users/bcat/rules.mk
@@ -3,10 +3,15 @@ SRC += bcat.c
 # Enable Bootmagic Lite to consistently reset to bootloader and clear EEPROM.
 BOOTMAGIC_ENABLE = lite
 
-# Enable media keys on all keyboards. (Even though I don't use mouse keys, they
-# seem to be required for media keys to register on Chrome OS.)
+# Enable media keys on all keyboards.
 EXTRAKEY_ENABLE = yes
-MOUSEKEY_ENABLE = yes
+
+# Enable N-key rollover on all keyboards. In addition to its intended
+# functionality, as of July 2020, this is required for Chrome OS to process
+# media keys. (It appears that Chrome OS filters out key events from the second
+# USB endpoint's consumer and system control devices unless that endpoint also
+# reports a keyboard or mouse device.)
+NKRO_ENABLE = yes
 
 # Enable link-time optimization to reduce binary size.
 LINK_TIME_OPTIMIZATION_ENABLE = yes
@@ -14,7 +19,7 @@ LINK_TIME_OPTIMIZATION_ENABLE = yes
 # Disable unused build options on all keyboards.
 COMMAND_ENABLE = no
 CONSOLE_ENABLE = no
-NKRO_ENABLE = no
+MOUSEKEY_ENABLE = no
 TERMINAL_ENABLE = no
 
 # Disable unused hardware options on all keyboards.
@@ -22,7 +27,7 @@ FAUXCLICKY_ENABLE = no
 MIDI_ENABLE = no
 SLEEP_LED_ENABLE = no
 
-# Disable unused other options.
+# Disable other unused options on all keyboards.
 API_SYSEX_ENABLE = no
 AUTO_SHIFT_ENABLE = no
 COMBO_ENABLE = no


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

On further investigation, it seems that Chrome OS isn't processing media keys unless the USB endpoint with the consumer and system control devices also contains a keyboard or mouse device. Mouse keys aren't useful to me, and they actually seem to cause a Windows bug instead (#8323), so I'm switching to NKRO. This functions as an equivalent workaround for Chrome OS, and is also at least theoretically useful to me.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [X] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
