### PR TITLE
Fix compilation warning for the DZ60RGB/DZ65RGB when RGB matrix is disabled

### DIFF
--- a/keyboards/dztech/dz60rgb/dz60rgb.c
+++ b/keyboards/dztech/dz60rgb/dz60rgb.c
@@ -92,7 +92,6 @@ led_config_t g_led_config = {
         1, 1, 1,          1,       1, 4, 1, 1, 1
     }
 };
-#endif
 
 void suspend_power_down_kb(void) {
     rgb_matrix_set_suspend_state(true);
@@ -110,3 +109,4 @@ void rgb_matrix_indicators_user(void) {
         rgb_matrix_set_color(40, 0xFF, 0xFF, 0xFF);
     }
 }
+#endif

--- a/keyboards/dztech/dz60rgb_ansi/dz60rgb_ansi.c
+++ b/keyboards/dztech/dz60rgb_ansi/dz60rgb_ansi.c
@@ -90,7 +90,6 @@ led_config_t g_led_config = {
         1, 1, 1,          1,          4, 1, 1, 1
     }
 };
-#endif
 
 void suspend_power_down_kb(void) {
     rgb_matrix_set_suspend_state(true);
@@ -108,3 +107,4 @@ void rgb_matrix_indicators_user(void) {
         rgb_matrix_set_color(40, 0xFF, 0xFF, 0xFF);
     }
 }
+#endif

--- a/keyboards/dztech/dz60rgb_wkl/dz60rgb_wkl.c
+++ b/keyboards/dztech/dz60rgb_wkl/dz60rgb_wkl.c
@@ -91,7 +91,6 @@ led_config_t g_led_config = {
         1, 1, 1,          4,             1, 1, 1
     }
 };
-#endif
 
 void suspend_power_down_kb(void) {
     rgb_matrix_set_suspend_state(true);
@@ -109,3 +108,4 @@ void rgb_matrix_indicators_user(void) {
         rgb_matrix_set_color(41, 0xFF, 0xFF, 0xFF);
     }
 }
+#endif

--- a/keyboards/dztech/dz65rgb/dz65rgb.c
+++ b/keyboards/dztech/dz65rgb/dz65rgb.c
@@ -97,7 +97,6 @@ led_config_t g_led_config = {
         1, 1, 1,          4,       1, 1, 1, 1, 1, 1
     }
 };
-#endif
 
 void suspend_power_down_kb(void) {
     rgb_matrix_set_suspend_state(true);
@@ -115,3 +114,4 @@ void rgb_matrix_indicators_user(void) {
         rgb_matrix_set_color(30, 0xFF, 0xFF, 0xFF);
     }
 }
+#endif


### PR DESCRIPTION
Simple fix. Previously if `RGB_MATRIX_ENABLE=no` was set, a compilation warning would be produced preventing build completion. Moving the `#endif` on a `#ifdef RGB_MATRIX_ENABLE` solves this issue.
