### PR TITLE
[Keyboard] Add via compatibility to Daisy 40 [1/2]

### DIFF
--- a/keyboards/daisy/config.h
+++ b/keyboards/daisy/config.h
@@ -25,7 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define DEVICE_VER      0x0501
 #define MANUFACTURER    KTEC
 #define PRODUCT         Daisy
-#define DESCRIPTION     QMK + VIA port for Daisy
+#define DESCRIPTION     qmk port for Daisy
 
 /* key matrix size */
 #define MATRIX_ROWS 4

--- a/keyboards/daisy/config.h
+++ b/keyboards/daisy/config.h
@@ -20,12 +20,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "config_common.h"
 
 /* USB Device descriptor parameter */
-#define VENDOR_ID       0xFEED
-#define PRODUCT_ID      0x7169
+#define VENDOR_ID       0x4B50
+#define PRODUCT_ID      0xD7DC
 #define DEVICE_VER      0x0501
 #define MANUFACTURER    KTEC
 #define PRODUCT         Daisy
-#define DESCRIPTION     qmk port for Daisy
+#define DESCRIPTION     QMK + VIA port for Daisy
 
 /* key matrix size */
 #define MATRIX_ROWS 4

--- a/keyboards/daisy/keymaps/via/keymap.c
+++ b/keyboards/daisy/keymaps/via/keymap.c
@@ -1,0 +1,83 @@
+/* Copyright 2020
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include QMK_KEYBOARD_H
+
+// Defines names for use in layer keycodes and the keymap
+enum layer_names {
+    _BL,
+    _LW,
+    _RS
+};
+
+#define LOWER MO(_LW)
+#define RAISE MO(_RS)
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    /* Base Layer
+     * ┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┐
+     * │Esc│ Q │ W │ E │ R │ T │ Y │ U │ I │ O │ P │ \ │
+     * ├───┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴───┤
+     * │Tab │ A │ S │ D │ F │ G │ H │ J │ K │ L │ Enter│
+     * ├────┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬────┤
+     * │Shift │ Z │ X │ C │ V │ B │ N │ M │ , │ . │  / │
+     * ├────┬─┴─┬─┴──┬┴───┴───┼───┴───┴──┬┴───┼───┼────┤
+     * │Ctrl│GUI│Alt │        │ Backspace│Lowr│Rse│ Alt│
+     * └────┴───┴────┴────────┴──────────┴────┴───┴────┘
+     */
+    [_BL] = LAYOUT(
+        KC_GESC, KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_BSLS,
+        KC_TAB,  KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,             KC_ENT,
+        KC_LSFT,          KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH,
+        KC_LCTL, KC_LGUI, KC_LALT,                   KC_SPC,  KC_BSPC,                   LOWER,   RAISE,   KC_RALT
+    ),
+
+    /* Function Layer 1 (Lower)
+     * ┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┐
+     * │ ` │ 1 │ 2 │ 3 │ 4 │ 5 │ 6 │ 7 │ 8 │ 9 │ 0 │ - │
+     * └───┴┬──┴┬──┴┬──┴───┴───┴┬──┴┬──┴┬──┴┬──┴┬──┴───┘
+     * │    │ = │ ▴ │   │   │   │ [ │ ] │ ; │ ' │      │
+     * ├────└─┬─┴─┬─┴─┬───┐─┴─┬─└───┴───┴───┴───┘─┬────┤
+     * │      │ ◂ │ ▾ │ ▸ │   │   │   │   │   │   │    │
+     * ├────┬─└───┴───┴───┘───┌──────────┐┴───┼───┼────┤
+     * │    │   │    │        │   Delete │    │   │    │
+     * └────┴───┴────┴────────└──────────┘────┴───┴────┘
+     */
+    [_LW] = LAYOUT(
+        KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS,
+        _______, KC_EQL,  KC_UP,   _______, _______, _______, KC_LBRC, KC_RBRC, KC_SCLN, KC_QUOT,          _______,
+        _______,          KC_LEFT, KC_DOWN, KC_RGHT, _______, _______, _______, _______, _______, _______, _______,
+        _______, _______, _______,                   _______, KC_DEL,                    _______, _______, _______
+    ),
+
+    /* Function Layer 2 (Raise)
+     * ┌───┬───┬───┬───┬───┬───┬───┐───┌───┬───┐───┬───┐
+     * │Rst│F1 │F2 │F3 │F4 │F5 │F6 │   │Hom│PgU│   │   │
+     * └───┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┐──└┬──┴┬──┴┐──┴───┤
+     * │    │F7 │F8 │F9 │F10│F11│F12│   │ ; │ ' │      │
+     * ├────└─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴───┴───┴───┴───┴─┐────┤
+     * │      │RGB│Mod│HuD│HuI│VaD│VaI│SaD│SaI│BLS│    │
+     * ├────┬─└───┴───┴───┴───┴───┴───┴───┴───┴───┘────┤
+     * │    │   │    │        │          │    │   │    │
+     * └────┴───┴────┴────────┴──────────┴────┴───┴────┘
+     */
+    [_RS] = LAYOUT(
+        RESET,   KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   _______, KC_HOME, KC_PGUP, _______, _______,
+        _______, KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  _______, KC_END,  KC_PGDN,          _______,
+        _______,          RGB_TOG, RGB_MOD, RGB_HUD, RGB_HUI, RGB_VAD, RGB_VAI, RGB_SAD, RGB_SAI, BL_STEP, _______,
+        _______, _______, _______,                   _______, _______,                   _______, _______, _______
+    )
+};

--- a/keyboards/daisy/keymaps/via/keymap.c
+++ b/keyboards/daisy/keymaps/via/keymap.c
@@ -20,7 +20,8 @@
 enum layer_names {
     _BL,
     _LW,
-    _RS
+    _RS,
+    _EM
 };
 
 #define LOWER MO(_LW)
@@ -79,5 +80,23 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         _______, KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  _______, KC_END,  KC_PGDN,          _______,
         _______,          RGB_TOG, RGB_MOD, RGB_HUD, RGB_HUI, RGB_VAD, RGB_VAI, RGB_SAD, RGB_SAI, BL_STEP, _______,
         _______, _______, _______,                   _______, _______,                   _______, _______, _______
+    ),
+
+    /* Empty 4th layer for VIA
+     * ┌───┬───┬───┬───┬───┬───┬───┐───┌───┬───┐───┬───┐
+     * |   |   |   |   |   |   |   |   |   |   |   |   |
+     * └───┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┐──└┬──┴┬──┴┐──┴───┤
+     * │    │   │   │   │   │   │   │   │   │   │      │
+     * ├────└─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴───┴───┴───┴───┴─┐────┤
+     * │      │   │   │   │   │   │   │   │   │   │    │
+     * ├────┬─└───┴───┴───┴───┴───┴───┴───┴───┴───┘────┤
+     * │    │   │    │        │          │    │   │    │
+     * └────┴───┴────┴────────┴──────────┴────┴───┴────┘
+     */
+    [_EM] = LAYOUT(
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS
     )
 };

--- a/keyboards/daisy/keymaps/via/readme.md
+++ b/keyboards/daisy/keymaps/via/readme.md
@@ -1,0 +1,1 @@
+# VIA keymap for Daisy

--- a/keyboards/daisy/keymaps/via/rules.mk
+++ b/keyboards/daisy/keymaps/via/rules.mk
@@ -1,0 +1,1 @@
+VIA_ENABLE = yes

--- a/keyboards/daisy/rules.mk
+++ b/keyboards/daisy/rules.mk
@@ -14,7 +14,7 @@ BOOTLOADER = atmel-dfu
 # Build Options
 #   change yes to no to disable
 #
-BOOTMAGIC_ENABLE = no       # Virtual DIP switch configuration
+BOOTMAGIC_ENABLE = yes      # Virtual DIP switch configuration
 MOUSEKEY_ENABLE = no        # Mouse keys
 EXTRAKEY_ENABLE = yes       # Audio control and System control
 CONSOLE_ENABLE = no         # Console for debug
@@ -30,5 +30,3 @@ BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
 AUDIO_ENABLE = no           # Audio output on port C6
 FAUXCLICKY_ENABLE = no      # Use buzzer to emulate clicky switches
 HD44780_ENABLE = no         # Enable support for HD44780 based LCDs
-VIA_ENABLE = yes
-BOOTMAGIC_ENABLE = lite

--- a/keyboards/daisy/rules.mk
+++ b/keyboards/daisy/rules.mk
@@ -30,3 +30,5 @@ BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
 AUDIO_ENABLE = no           # Audio output on port C6
 FAUXCLICKY_ENABLE = no      # Use buzzer to emulate clicky switches
 HD44780_ENABLE = no         # Enable support for HD44780 based LCDs
+VIA_ENABLE = yes
+BOOTMAGIC_ENABLE = lite

--- a/keyboards/daisy/rules.mk
+++ b/keyboards/daisy/rules.mk
@@ -14,7 +14,7 @@ BOOTLOADER = atmel-dfu
 # Build Options
 #   change yes to no to disable
 #
-BOOTMAGIC_ENABLE = yes      # Virtual DIP switch configuration
+BOOTMAGIC_ENABLE = lite     # Virtual DIP switch configuration
 MOUSEKEY_ENABLE = no        # Mouse keys
 EXTRAKEY_ENABLE = yes       # Audio control and System control
 CONSOLE_ENABLE = no         # Console for debug


### PR DESCRIPTION
## Description

Adds compatibility for VIA on Daisy 40, for both split and full size spacebar

![fullsize](https://user-images.githubusercontent.com/778141/88359117-1ce6bb00-cd37-11ea-8834-aa11b13a9d8e.jpg)
![split](https://user-images.githubusercontent.com/778141/88359121-1f491500-cd37-11ea-9910-3d035429cc61.jpg)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## VIA Pull Request

https://github.com/the-via/keyboards/pull/226

## Issues Fixed or Closed by This PR

* N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
