### PR TITLE
Make tap dance prefer tapping term from get_tapping_term over TAPPING_TERM

### DIFF
--- a/quantum/process_keycode/process_tap_dance.c
+++ b/quantum/process_keycode/process_tap_dance.c
@@ -171,7 +171,11 @@ void matrix_scan_tap_dance() {
         if (action->custom_tapping_term > 0) {
             tap_user_defined = action->custom_tapping_term;
         } else {
+            #ifdef TAPPING_TERM_PER_KEY
+            tap_user_defined = get_tapping_term(action->state.keycode);
+            #else
             tap_user_defined = TAPPING_TERM;
+            #endif
         }
         if (action->state.count && timer_elapsed(action->state.timer) > tap_user_defined) {
             process_tap_dance_action_on_dance_finished(action);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Adding the `get_tapping_term` method to your keymap.c allows you to control the tapping term from your code, and specify what it will be based on the keycode. Previously tap dance would not use this; it would only use the parameter passed to it (if you used `ACTION_TAP_DANCE_FN_ADVANCED_TIME`) or the defined `TAPPING_TERM`. This PR makes it use the result of `get_tapping_term` if `TAPPING_TERM_PER_KEY` is defined.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #9802

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
