### PR TITLE
[Docs] Fix Japanese documents 'original document' comment 

### DIFF
--- a/docs/ja/config_options.md
+++ b/docs/ja/config_options.md
@@ -1,7 +1,7 @@
 # QMK の設定
 
 <!---
-  original document: 0.8.62:docs/config_options.md
+  original document: 0.9.43:docs/config_options.md
   git diff 0.9.43 HEAD -- docs/config_options.md | cat
 -->
 

--- a/docs/ja/driver_installation_zadig.md
+++ b/docs/ja/driver_installation_zadig.md
@@ -1,7 +1,7 @@
 # Zadig を使ったブートローダドライバのインストール
 
 <!---
-  original document: 0.9.0:docs/driver_installation_zadig.md
+  original document: 0.9.43:docs/driver_installation_zadig.md
   git diff 0.9.43 HEAD -- docs/driver_installation_zadig.md | cat
 -->
 

--- a/docs/ja/faq_build.md
+++ b/docs/ja/faq_build.md
@@ -1,7 +1,7 @@
 # よくあるビルドの質問
 
 <!---
-  original document: 0.9.10:docs/faq_build.md
+  original document: 0.9.43:docs/faq_build.md
   git diff 0.9.43 HEAD -- docs/faq_build.md | cat
 -->
 

--- a/docs/ja/feature_dip_switch.md
+++ b/docs/ja/feature_dip_switch.md
@@ -1,7 +1,7 @@
 # DIP スイッチ
 
 <!---
-  original document: 0.8.94:docs/feature_dip_switch.md
+  original document: 0.9.43:docs/feature_dip_switch.md
   git diff 0.9.43 HEAD -- docs/feature_dip_switch.md | cat
 -->
 

--- a/docs/ja/feature_dynamic_macros.md
+++ b/docs/ja/feature_dynamic_macros.md
@@ -1,7 +1,7 @@
 # 動的マクロ: ランタイムでのマクロの記録および再生
 
 <!---
-  original document: 0.8.123:docs/feature_dynamic_macros.md
+  original document: 0.9.43:docs/feature_dynamic_macros.md
   git diff 0.9.43 HEAD -- docs/feature_dynamic_macros.md | cat
 -->
 

--- a/docs/ja/feature_encoders.md
+++ b/docs/ja/feature_encoders.md
@@ -1,7 +1,7 @@
 # エンコーダ
 
 <!---
-  original document: 0.8.123:docs/feature_encoders.md
+  original document: 0.9.43:docs/feature_encoders.md
   git diff 0.9.43 HEAD -- docs/feature_encoders.md | cat
 -->
 

--- a/docs/ja/feature_hd44780.md
+++ b/docs/ja/feature_hd44780.md
@@ -1,7 +1,7 @@
 # HD44780 LCD ディスプレイ
 
 <!---
-  original document: 0.8.123:docs/feature_hd44780.md
+  original document: 0.9.43:docs/feature_hd44780.md
   git diff 0.9.43 HEAD -- docs/feature_hd44780.md | cat
 -->
 

--- a/docs/ja/feature_layers.md
+++ b/docs/ja/feature_layers.md
@@ -1,7 +1,7 @@
 # レイヤー :id=layers
 
 <!---
-  original document: 0.9.20:docs/feature_layers.md
+  original document: 0.9.43:docs/feature_layers.md
   git diff 0.9.43 HEAD -- docs/feature_layers.md | cat
 -->
 

--- a/docs/ja/feature_split_keyboard.md
+++ b/docs/ja/feature_split_keyboard.md
@@ -1,7 +1,7 @@
 # 分割キーボード
 
 <!---
-  original document:0.9.5:docs/feature_split_keyboard.md
+  original document:0.9.43:docs/feature_split_keyboard.md
   git diff 0.9.43 HEAD -- docs/feature_split_keyboard.md | cat
 -->
 

--- a/docs/ja/feature_userspace.md
+++ b/docs/ja/feature_userspace.md
@@ -1,7 +1,7 @@
 # ユーザスペース: キーマップ間でのコードの共有
 
 <!---
-  original document: 0.9.0:docs/feature_userspace.md
+  original document: 0.9.43:docs/feature_userspace.md
   git diff 0.9.43 HEAD -- docs/feature_userspace.md | cat
 -->
 

--- a/docs/ja/getting_started_github.md
+++ b/docs/ja/getting_started_github.md
@@ -1,7 +1,7 @@
 # QMK で GitHub を使う方法
 
 <!---
-  original document: 0.8.82:docs/getting_started_github.md
+  original document: 0.9.43:docs/getting_started_github.md
   git diff 0.9.43 HEAD -- docs/getting_started_github.md | cat
 -->
 


### PR DESCRIPTION
## Description

I fixed the comment indicating the original document.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

tagging: @shelaf