### PR TITLE
Auto shift: support repeats and early registration

### DIFF
--- a/docs/feature_auto_shift.md
+++ b/docs/feature_auto_shift.md
@@ -20,10 +20,11 @@ have not released the key after the `AUTO_SHIFT_TIMEOUT` period, then a shifted
 version of the key is emitted. If the time is less than the `AUTO_SHIFT_TIMEOUT`
 time, or you press another key, then the normal state is emitted.
 
-If you hold the key down, it will repeat the shifted key.  If you want to repeat
-the normal key, then tap it once then immediately (within `TAPPING_TERM`) hold
-it down again.  The ability to repeat the normal key like this will be disabled
-if `TAPPING_FORCE_HOLD` is set.
+If `AUTO_SHIFT_REPEAT` is defined, there is keyrepeat support. Holding the key
+down will repeat the shifted key, though this can be disabled with
+`AUTO_SHIFT_NO_AUTO_REPEAT`. If you want to repeat the normal key, then tap it
+once then immediately (within `TAPPING_TERM`) hold it down again (this works
+with the shifted value as well if auto-repeat is disabled).
 
 ## Are There Limitations to Auto Shift?
 
@@ -34,6 +35,11 @@ other characters you wanted shifted, but were not. This simply comes down to
 practice. As we get in a hurry, we think we have hit the key long enough for a
 shifted version, but we did not. On the other hand, we may think we are tapping
 the keys, but really we have held it for a little longer than anticipated.
+
+Additionally, with keyrepeat the desired shift state can get mixed up. It will
+always 'belong' to the last key pressed. For example, keyrepeating a capital
+and then tapping something lowercase (whether or not it's an Auto Shift key)
+will result in the capital's *key* still being held, but shift not.
 
 ## How Do I Enable Auto Shift?
 
@@ -102,6 +108,14 @@ Do not Auto Shift numeric keys, zero through nine.
 ### NO_AUTO_SHIFT_ALPHA (simple define)
 
 Do not Auto Shift alpha characters, which include A through Z.
+
+### AUTO_SHIFT_REPEAT (simple define)
+
+Enables keyrepeat.
+
+### AUTO_SHIFT_NO_AUTO_REPEAT (simple define)
+
+Disables automatically keyrepeating when `AUTO_SHIFT_TIMEOUT` is exceeded.
 
 ## Using Auto Shift Setup
 

--- a/docs/feature_auto_shift.md
+++ b/docs/feature_auto_shift.md
@@ -15,25 +15,25 @@ problem.
 When you tap a key, it stays depressed for a short period of time before it is
 then released. This depressed time is a different length for everyone. Auto Shift
 defines a constant `AUTO_SHIFT_TIMEOUT` which is typically set to twice your
-normal pressed state time. When you press a key, a timer starts and then stops
-when you release the key. If the time depressed is greater than or equal to the
-`AUTO_SHIFT_TIMEOUT`, then a shifted version of the key is emitted. If the time
-is less than the `AUTO_SHIFT_TIMEOUT` time, then the normal state is emitted.
+normal pressed state time. When you press a key, a timer starts, and if you
+have not released the key after the `AUTO_SHIFT_TIMEOUT` period, then a shifted
+version of the key is emitted. If the time is less than the `AUTO_SHIFT_TIMEOUT`
+time, or you press another key, then the normal state is emitted.
+
+If you hold the key down, it will repeat the shifted key.  If you want to repeat
+the normal key, then tap it once then immediately (within `TAPPING_TERM`) hold
+it down again.  The ability to repeat the normal key like this will be disabled
+if `TAPPING_FORCE_HOLD` is set.
 
 ## Are There Limitations to Auto Shift?
 
 Yes, unfortunately.
 
-1. Key repeat will cease to work. For example, before if you wanted 20 'a'
-   characters, you could press and hold the 'a' key for a second or two. This no
-   longer works with Auto Shift because it is timing your depressed time instead
-   of emitting a depressed key state to your operating system.
-2. You will have characters that are shifted when you did not intend on shifting, and
-   other characters you wanted shifted, but were not. This simply comes down to
-   practice. As we get in a hurry, we think we have hit the key long enough
-   for a shifted version, but we did not. On the other hand, we may think we are
-   tapping the keys, but really we have held it for a little longer than
-   anticipated.
+You will have characters that are shifted when you did not intend on shifting, and
+other characters you wanted shifted, but were not. This simply comes down to
+practice. As we get in a hurry, we think we have hit the key long enough for a
+shifted version, but we did not. On the other hand, we may think we are tapping
+the keys, but really we have held it for a little longer than anticipated.
 
 ## How Do I Enable Auto Shift?
 

--- a/quantum/process_keycode/process_auto_shift.c
+++ b/quantum/process_keycode/process_auto_shift.c
@@ -56,7 +56,7 @@ static bool autoshift_press(uint16_t keycode, keyrecord_t *record) {
         return true;
     }
 #    endif
-#    ifndef AUTO_SHIFT_NO_REPEAT
+#    ifdef AUTO_SHIFT_REPEAT
     const uint16_t elapsed = TIMER_DIFF_16(record->event.time, autoshift_time);
 #        ifndef AUTO_SHIFT_NO_AUTO_REPEAT
     if (!autoshift_flags.lastshifted) {
@@ -111,7 +111,7 @@ static void autoshift_end(uint16_t keycode, uint16_t now, bool matrix_trigger) {
             add_weak_mods(MOD_BIT(KC_LSFT));
             register_code(autoshift_lastkey);
             autoshift_flags.lastshifted = true;
-#    if !defined(AUTO_SHIFT_NO_REPEAT) && !defined(AUTO_SHIFT_NO_AUTO_REPEAT)
+#    if defined(AUTO_SHIFT_REPEAT) && !defined(AUTO_SHIFT_NO_AUTO_REPEAT)
             if (matrix_trigger) {
                 // Prevents release.
                 return;

--- a/quantum/process_keycode/process_auto_shift.c
+++ b/quantum/process_keycode/process_auto_shift.c
@@ -140,7 +140,7 @@ static void autoshift_check_record(uint16_t keycode, keyrecord_t *record) {
     if (keycode == autoshift_lastkey && !record->event.pressed) {
         // Time since the initial press was recorded.
         const uint16_t elapsed = TIMER_DIFF_16(record->event.time, autoshift_time);
-        if (elapsed < autoshift_timeout) {
+        if (!autoshift_flags.registered && elapsed < autoshift_timeout) {
             autoshift_flags.lastshifted = false;
             // Auto-shiftable key is being released before the shift timeout;
             // simulate the original press then let the usual processing take

--- a/quantum/process_keycode/process_auto_shift.c
+++ b/quantum/process_keycode/process_auto_shift.c
@@ -27,38 +27,18 @@ static uint16_t autoshift_lastkey = KC_NO;
 static struct {
     // Whether autoshift is enabled.
     bool enabled : 1;
-    // Whether the last autoshifted key was released after the timeout.  This
+    // Whether the last auto-shifted key was released after the timeout.  This
     // is used to replicate the last key for a tap-then-hold.
     bool lastshifted : 1;
-    // Whether an auto-shiftable key is currently being pressed.
+    // Whether an auto-shiftable key has been pressed but not processed.
     bool in_progress : 1;
     // Whether the auto-shifted keypress has been registered.
-    bool registered : 1;
-    // Whether autoshift is currently "holding" the shift key.
     bool holding_shift : 1;
-} autoshift_flags = {true, false, false, false, false};
+} autoshift_flags = {true, false, false, false};
 
-/** \brief Resets the autoshift state */
-static void autoshift_flush(uint16_t now) {
-    if (autoshift_flags.in_progress && !autoshift_flags.registered) {
-        // Register the key.
-        register_code(autoshift_lastkey);
-#    if TAP_CODE_DELAY > 0
-        wait_ms(TAP_CODE_DELAY);
-#    endif
-    }
-    // Roll the autoshift_time forward for detecting tap-and-hold.
-    autoshift_time                = now;
-    autoshift_flags.in_progress   = false;
-    autoshift_flags.registered    = false;
-}
-
-/** \brief Releases the shift key if it was held by auto-shift */
+/** \brief Releases the shift key if it was held by autoshift */
 static void autoshift_flush_shift(void) {
-    if (autoshift_flags.holding_shift) {
-        // Release the shift key if it was simulated.
-        unregister_code(KC_LSFT);
-    }
+    del_weak_mods(MOD_BIT(KC_LSFT));
     autoshift_flags.holding_shift = false;
 }
 
@@ -71,24 +51,35 @@ static bool autoshift_press(uint16_t keycode, keyrecord_t *record) {
         return true;
     }
 
-    const uint16_t elapsed = TIMER_DIFF_16(record->event.time, autoshift_time);
-    autoshift_flush(record->event.time);
-
 #    ifndef AUTO_SHIFT_MODIFIERS
-    if (get_mods() ^ (autoshift_flags.holding_shift ? MOD_BIT(KC_LSFT) : 0)) {
+    if (get_mods() & (~MOD_BIT(KC_LSFT))) {
         return true;
     }
 #    endif
-#    ifndef TAPPING_FORCE_HOLD
-    if (elapsed < TAPPING_TERM && keycode == autoshift_lastkey && !autoshift_flags.lastshifted) {
-        // Allow a tap-then-hold to hold the unshifted key.
-        autoshift_lastkey = KC_NO;
-        return true;
+#    ifndef AUTO_SHIFT_NO_REPEAT
+    const uint16_t elapsed = TIMER_DIFF_16(record->event.time, autoshift_time);
+#        ifndef AUTO_SHIFT_NO_AUTO_REPEAT
+    if (!autoshift_flags.lastshifted) {
+#        endif
+        if (elapsed < TAPPING_TERM && keycode == autoshift_lastkey) {
+            // Allow a tap-then-hold for keyrepeat.
+            if (!autoshift_flags.lastshifted) {
+                register_code(autoshift_lastkey);
+            } else {
+                // Simulate pressing the shift key.
+                add_weak_mods(MOD_BIT(KC_LSFT));
+                register_code(autoshift_lastkey);
+            }
+            return false;
+        }
+#        ifndef AUTO_SHIFT_NO_AUTO_REPEAT
     }
+#        endif
 #    endif
 
     // Record the keycode so we can simulate it later.
     autoshift_lastkey           = keycode;
+    autoshift_time              = record->event.time;
     autoshift_flags.in_progress = true;
 
 #    if !defined(NO_ACTION_ONESHOT) && !defined(NO_ACTION_TAPPING)
@@ -99,114 +90,82 @@ static bool autoshift_press(uint16_t keycode, keyrecord_t *record) {
 
 /** \brief Registers an autoshiftable key under the right conditions
  *
- * If the autoshift delay has elapsed and no shift has already been registered,
- * register a shift and the key.
+ * If the autoshift delay has elapsed, register a shift and the key.
  *
- * \return True if the timeout had elapsed.
+ * If the autoshift key is released before the delay has elapsed, register the
+ * key without a shift.
  */
-void autoshift_check_timeout(uint16_t now) {
-    const uint16_t elapsed = TIMER_DIFF_16(now, autoshift_time);
-    if (elapsed >= autoshift_timeout) {
-        // The timeout has expired, so simulate the keypress.
-        if (!(get_mods() & (MOD_BIT(KC_LSFT) | MOD_BIT(KC_RSFT)))) {
+static void autoshift_end(uint16_t keycode, uint16_t now, bool matrix_trigger) {
+    // Called on key down with KC_NO, auto-shifted key up, and timeout.
+    if (autoshift_flags.in_progress) {
+        // Process the auto-shiftable key.
+        autoshift_flags.in_progress = false;
+
+        // Time since the initial press was recorded.
+        const uint16_t elapsed = TIMER_DIFF_16(now, autoshift_time);
+        if (elapsed < autoshift_timeout) {
+            register_code(autoshift_lastkey);
+            autoshift_flags.lastshifted = false;
+        } else {
             // Simulate pressing the shift key.
-            register_code(KC_LSFT);
-            autoshift_flags.lastshifted   = true;
-            autoshift_flags.holding_shift = true;
+            add_weak_mods(MOD_BIT(KC_LSFT));
+            register_code(autoshift_lastkey);
+            autoshift_flags.lastshifted = true;
+#    if !defined(AUTO_SHIFT_NO_REPEAT) && !defined(AUTO_SHIFT_NO_AUTO_REPEAT)
+            if (matrix_trigger) {
+                // Prevents release.
+                return;
+            }
+#    endif
         }
-        register_code(autoshift_lastkey);
-        autoshift_flags.registered = true;
 
 #    if TAP_CODE_DELAY > 0
         wait_ms(TAP_CODE_DELAY);
 #    endif
-    }
-}
-
-/** \brief Registers an autoshiftable key under the right conditions
- *
- * If the autoshift delay has elapsed and no shift has already been registered,
- * register a shift and the key.
- *
- * If the autoshift key is released before the delay has elapsed, register the
- * key without a shift.
- *
- * If another key is pressed, register the key.
- */
-static void autoshift_check_record(uint16_t keycode, keyrecord_t *record) {
-    if (!autoshift_flags.in_progress) {
-        return;
-    }
-
-    // Process the release of the autoshiftable key.
-    if (keycode == autoshift_lastkey && !record->event.pressed) {
+        unregister_code(autoshift_lastkey);
         autoshift_flush_shift();
-        // Time since the initial press was recorded.
-        const uint16_t elapsed = TIMER_DIFF_16(record->event.time, autoshift_time);
-        if (!autoshift_flags.registered && elapsed < autoshift_timeout) {
-            // Auto-shiftable key is being released before the shift timeout;
-            // simulate the original press then let the usual processing take
-            // care of the release.
-            register_code(keycode);
-            autoshift_flags.lastshifted = false;
-            autoshift_flags.registered  = true;
-#    if TAP_CODE_DELAY > 0
-            wait_ms(TAP_CODE_DELAY);
-#    endif
-        }
-        autoshift_flush(record->event.time);
-    } else if (record->event.pressed) {
-        if (keycode == KC_LSFT) {
-            // If the user presses shift, auto-shift will not hold shift for
-            // them.
-            autoshift_flags.holding_shift = false;
-        } else if (!autoshift_flags.registered) {
-            // If the key isn't registered yet, it means the timeout hasn't
-            // elapsed, so register the key without additional shifting.
-            autoshift_flush(0);
-            autoshift_lastkey = KC_NO;
-        } else {
-            // The key is registered; flush any shift state for the
-            // non-autoshiftable key.
+    } else {
+        // Release after keyrepeat.
+        unregister_code(keycode);
+        if (keycode == autoshift_lastkey) {
+            // This will only fire when the key was the last auto-shiftable
+            // pressed. That prevents aaaaBBBB then releasing a from unshifting
+            // later Bs (if B wasn't auto-shiftable).
             autoshift_flush_shift();
         }
     }
+    // Roll the autoshift_time forward for detecting tap-and-hold.
+    autoshift_time = now;
 }
 
-/** \brief Simulates auto-shifted key presses
+/** \brief Simulates auto-shifted key releases when timeout is hit
  *
  *  Can be called from \c matrix_scan_user so that auto-shifted keys are sent
  *  immediately after the timeout has expired, rather than waiting for the key
  *  to be released.
  */
 void autoshift_matrix_scan(void) {
-    if (!autoshift_flags.in_progress || autoshift_flags.registered) {
-        return;
+    if (autoshift_flags.in_progress) {
+        const uint16_t now     = timer_read();
+        const uint16_t elapsed = TIMER_DIFF_16(now, autoshift_time);
+        if (elapsed >= autoshift_timeout) {
+            autoshift_end(autoshift_lastkey, now, true);
+        }
     }
-
-    autoshift_check_timeout(timer_read());
 }
 
 void autoshift_toggle(void) {
-    if (autoshift_flags.enabled) {
-        autoshift_flags.enabled = false;
+    autoshift_flags.enabled = !autoshift_flags.enabled;
+    if (!autoshift_flags.enabled) {
         autoshift_flush_shift();
-        autoshift_flush(0);
-    } else {
-        autoshift_flags.enabled = true;
     }
 }
 
-void autoshift_enable(void) {
-    autoshift_flags.enabled = true;
-    autoshift_flush_shift();
-    autoshift_flush(0);
-}
+void autoshift_enable(void) { autoshift_flags.enabled = true; }
 
 void autoshift_disable(void) {
     autoshift_flags.enabled = false;
     autoshift_flush_shift();
-    autoshift_flush(0);
 }
 
 #    ifndef AUTO_SHIFT_NO_SETUP
@@ -227,11 +186,18 @@ void set_autoshift_timeout(uint16_t timeout) { autoshift_timeout = timeout; }
 
 bool process_auto_shift(uint16_t keycode, keyrecord_t *record) {
     if (record->event.pressed) {
+        if (autoshift_flags.in_progress) {
+            // Evaluate previous key if there is one. Doing this elsewhere is
+            // more complicated and easier to break.
+            autoshift_end(KC_NO, record->event.time, false);
+        }
+        // For pressing another key while keyrepeating shifted autoshift.
+        autoshift_flush_shift();
+
         switch (keycode) {
             case KC_ASTG:
                 autoshift_toggle();
                 return true;
-
             case KC_ASON:
                 autoshift_enable();
                 return true;
@@ -251,26 +217,28 @@ bool process_auto_shift(uint16_t keycode, keyrecord_t *record) {
                 autoshift_timer_report();
                 return true;
 #    endif
-
-#    ifndef NO_AUTO_SHIFT_ALPHA
-            case KC_A ... KC_Z:
-#    endif
-#    ifndef NO_AUTO_SHIFT_NUMERIC
-            case KC_1 ... KC_0:
-#    endif
-#    ifndef NO_AUTO_SHIFT_SPECIAL
-            case KC_TAB:
-            case KC_MINUS ... KC_SLASH:
-            case KC_NONUS_BSLASH:
-#    endif
-                return autoshift_press(keycode, record);
-
-            default:
-                break;
         }
     }
 
-    autoshift_check_record(keycode, record);
+    switch (keycode) {
+#    ifndef NO_AUTO_SHIFT_ALPHA
+        case KC_A ... KC_Z:
+#    endif
+#    ifndef NO_AUTO_SHIFT_NUMERIC
+        case KC_1 ... KC_0:
+#    endif
+#    ifndef NO_AUTO_SHIFT_SPECIAL
+        case KC_TAB:
+        case KC_MINUS ... KC_SLASH:
+        case KC_NONUS_BSLASH:
+#    endif
+            if (record->event.pressed) {
+                return autoshift_press(keycode, record);
+            } else {
+                autoshift_end(keycode, record->event.time, false);
+                return false;
+            }
+    }
     return true;
 }
 

--- a/quantum/process_keycode/process_auto_shift.h
+++ b/quantum/process_keycode/process_auto_shift.h
@@ -30,3 +30,4 @@ void     autoshift_toggle(void);
 bool     get_autoshift_state(void);
 uint16_t get_autoshift_timeout(void);
 void     set_autoshift_timeout(uint16_t timeout);
+void     autoshift_matrix_scan(void);

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -58,6 +58,10 @@ float bell_song[][2] = SONG(TERMINAL_SOUND);
 #    endif
 #endif
 
+#ifdef AUTO_SHIFT_ENABLE
+#    include "process_auto_shift.h"
+#endif
+
 static void do_code16(uint16_t code, void (*f)(uint8_t)) {
     switch (code) {
         case QK_MODS ... QK_MODS_MAX:
@@ -669,6 +673,10 @@ void matrix_scan_quantum() {
 
 #ifdef DIP_SWITCH_ENABLE
     dip_switch_read(false);
+#endif
+
+#ifdef AUTO_SHIFT_ENABLE
+    autoshift_matrix_scan();
 #endif
 
     matrix_scan_kb();


### PR DESCRIPTION
## Description

Instead of waiting for the next record to tap the autoshiftable key, register a matrix_scan function that will check the timeout and register the key immediately if the timeout period has elapsed.  This means the user gets immediate feedback about their press and doesn't have to guess whether it's been long enough.

Additionally, don't unregister the keypress immediately.  This means that auto-shifted keys can be held down.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* #7048 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

I've tested with `AUTO_SHIFT_ENABLE`, `NO_AUTO_SHIFT_ALPHA` on an Ergodox EZ, with taps, holds, and tap-then-holds, and rollovers to autoshiftable and non-autoshiftable keys.  There are a lot of edge cases.