### PR TITLE
Add support for hsv->rgb conversion without using CIE curve.

### DIFF
--- a/keyboards/anavi/macropad8/rules.mk
+++ b/keyboards/anavi/macropad8/rules.mk
@@ -23,7 +23,6 @@ NKRO_ENABLE = yes           # Nkey Rollover - if this doesn't work, see here: ht
 BACKLIGHT_ENABLE = yes       # Enable keyboard backlight functionality
 MIDI_ENABLE = no            # MIDI controls
 AUDIO_ENABLE = no           # Audio output on port C6
-UNICODE_ENABLE = yes        # Unicode
 BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
 RGBLIGHT_ENABLE = yes       # Enable WS2812 RGB underlight.
 OLED_DRIVER_ENABLE = yes     # Enable Support for SSD1306 or SH1106 OLED Displays; Communicating over I2C

--- a/quantum/color.c
+++ b/quantum/color.c
@@ -18,14 +18,20 @@
 #include "led_tables.h"
 #include "progmem.h"
 
-RGB hsv_to_rgb(HSV hsv) {
+RGB hsv_to_rgb_impl(HSV hsv, bool use_cie) {
     RGB      rgb;
     uint8_t  region, remainder, p, q, t;
     uint16_t h, s, v;
 
     if (hsv.s == 0) {
 #ifdef USE_CIE1931_CURVE
-        rgb.r = rgb.g = rgb.b = pgm_read_byte(&CIE1931_CURVE[hsv.v]);
+        if (use_cie) {
+            rgb.r = rgb.g = rgb.b = pgm_read_byte(&CIE1931_CURVE[hsv.v]);
+        } else {
+            rgb.r = hsv.v;
+            rgb.g = hsv.v;
+            rgb.b = hsv.v;
+        }
 #else
         rgb.r = hsv.v;
         rgb.g = hsv.v;
@@ -37,7 +43,11 @@ RGB hsv_to_rgb(HSV hsv) {
     h = hsv.h;
     s = hsv.s;
 #ifdef USE_CIE1931_CURVE
-    v = pgm_read_byte(&CIE1931_CURVE[hsv.v]);
+    if (use_cie) {
+        v = pgm_read_byte(&CIE1931_CURVE[hsv.v]);
+    } else {
+        v = hsv.v;
+    }
 #else
     v = hsv.v;
 #endif
@@ -85,6 +95,16 @@ RGB hsv_to_rgb(HSV hsv) {
 
     return rgb;
 }
+
+RGB hsv_to_rgb(HSV hsv) {
+#ifdef USE_CIE1931_CURVE
+    return hsv_to_rgb_impl(hsv, true);
+#else
+    return hsv_to_rgb_impl(hsv, false);
+#endif
+}
+
+RGB hsv_to_rgb_nocie(HSV hsv) { return hsv_to_rgb_impl(hsv, false); }
 
 #ifdef RGBW
 #    ifndef MIN

--- a/quantum/color.h
+++ b/quantum/color.h
@@ -64,6 +64,7 @@ typedef struct PACKED {
 #endif
 
 RGB hsv_to_rgb(HSV hsv);
+RGB hsv_to_rgb_nocie(HSV hsv);
 #ifdef RGBW
 void convert_rgb_to_rgbw(LED_TYPE *led);
 #endif


### PR DESCRIPTION
## Description

As preparation for the new drawing APIs, I need to add support for HSV -> RGB conversions but disregard the CIE curve when doing so.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
