### PR TITLE
Fix RGB_DISABLE_TIMEOUT overflow warning (#9866)

### DIFF
--- a/quantum/rgb_matrix.c
+++ b/quantum/rgb_matrix.c
@@ -58,7 +58,7 @@ const point_t k_rgb_matrix_center = RGB_MATRIX_CENTER;
 // ------------------------------------------
 
 #if defined(RGB_DISABLE_AFTER_TIMEOUT) && !defined(RGB_DISABLE_TIMEOUT)
-#    define RGB_DISABLE_TIMEOUT (RGB_DISABLE_AFTER_TIMEOUT * 1200ul)
+#    define RGB_DISABLE_TIMEOUT (RGB_DISABLE_AFTER_TIMEOUT * 1200UL)
 #endif
 
 #ifndef RGB_DISABLE_TIMEOUT

--- a/quantum/rgb_matrix.c
+++ b/quantum/rgb_matrix.c
@@ -58,7 +58,7 @@ const point_t k_rgb_matrix_center = RGB_MATRIX_CENTER;
 // ------------------------------------------
 
 #if defined(RGB_DISABLE_AFTER_TIMEOUT) && !defined(RGB_DISABLE_TIMEOUT)
-#    define RGB_DISABLE_TIMEOUT (RGB_DISABLE_AFTER_TIMEOUT * 1200)
+#    define RGB_DISABLE_TIMEOUT (RGB_DISABLE_AFTER_TIMEOUT * 1200ul)
 #endif
 
 #ifndef RGB_DISABLE_TIMEOUT


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Forces long integer math in the expansion of `RGB_DISABLE_TIMEOUT` when a config file uses the deprecated define `RGB_DISABLE_AFTER_TIMEOUT` to prevent overflow with values greater than 27.
```C
#    define RGB_DISABLE_TIMEOUT (RGB_DISABLE_AFTER_TIMEOUT * 1200ul)
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #9866 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
