### PR TITLE
fix Dactyl-Manuform 5x6_5 compilation

### DIFF
--- a/keyboards/handwired/dactyl_manuform/5x6_5/config.h
+++ b/keyboards/handwired/dactyl_manuform/5x6_5/config.h
@@ -20,7 +20,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "config_common.h"
 
-
+#define PRODUCT_ID      0x3536
+#define DEVICE_VER      0x0002
 #define PRODUCT         Dactyl-Manuform (5x6)
 
 /* key matrix size */


### PR DESCRIPTION
## Description

Seems we were (read: I was) a bit overzealous in merging #9659 – the USB Device descriptors weren't fully set up, so it didn't actually compile:

```shell
noroadsleft ~/qmk_firmware/keyboards/handwired/dactyl_manuform/5x6_5 (master)
$ qmk compile -km all
Ψ Compiling keymap with make handwired/dactyl_manuform/5x6_5:all


QMK Firmware 0.9.46
Making handwired/dactyl_manuform/5x6_5 with keymap default

avr-gcc.exe (GCC) 8.3.0
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Compiling: keyboards/handwired/dactyl_manuform/dactyl_manuform.c                                    [OK]
Compiling: keyboards/handwired/dactyl_manuform/5x6_5/5x6_5.c                                        [OK]
Compiling: .build/obj_handwired_dactyl_manuform_5x6_5/src/keymap.c                                  [OK]
...
Compiling: tmk_core/protocol/usb_descriptor.c                                                      tmk_core/protocol/usb_descriptor.c:305:35: error: 'PRODUCT_ID' undeclared here (not in a function); did you mean 'PRODUCT'?
     .ProductID                  = PRODUCT_ID,
                                   ^~~~~~~~~~
                                   PRODUCT
tmk_core/protocol/usb_descriptor.c:306:35: error: 'DEVICE_VER' undeclared here (not in a function)
     .ReleaseNumber              = DEVICE_VER,
                                   ^~~~~~~~~~
 [ERRORS]
 |
 |
 |
make[1]: *** [tmk_core/rules.mk:386: .build/obj_handwired_dactyl_manuform_5x6_5_default/usb_descriptor.o] Error 1
Make finished with errors
make: *** [Makefile:584: handwired/dactyl_manuform/5x6_5:all] Error 1
```

Fixed by adding `PRODUCT_ID` and `DEVICE_VER` definitions.

cc: @jceb 


## Types of Changes

- [x] Bugfix
- [x] Keyboard (addition or update)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
