### PR TITLE
More Bluetooth refactoring

### DIFF
--- a/tmk_core/common/progmem.h
+++ b/tmk_core/common/progmem.h
@@ -4,6 +4,7 @@
 #    include <avr/pgmspace.h>
 #else
 #    define PROGMEM
+#    define PGM_P const char *
 #    define memcpy_P(dest, src, n) memcpy(dest, src, n)
 #    define pgm_read_byte(address_short) *((uint8_t*)(address_short))
 #    define pgm_read_word(address_short) *((uint16_t*)(address_short))

--- a/tmk_core/protocol/lufa/adafruit_ble.h
+++ b/tmk_core/protocol/lufa/adafruit_ble.h
@@ -2,18 +2,19 @@
  * Author: Wez Furlong, 2016
  * Supports the Adafruit BLE board built around the nRF51822 chip.
  */
+
 #pragma once
-#ifdef MODULE_ADAFRUIT_BLE
-#    include <stdbool.h>
-#    include <stdint.h>
-#    include <string.h>
 
-#    include "config_common.h"
-#    include "progmem.h"
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
 
-#    ifdef __cplusplus
+#include "config_common.h"
+#include "progmem.h"
+
+#ifdef __cplusplus
 extern "C" {
-#    endif
+#endif
 
 /* Instruct the module to enable HID keyboard support and reset */
 extern bool adafruit_ble_enable_keyboard(void);
@@ -54,8 +55,6 @@ extern uint32_t adafruit_ble_read_battery_voltage(void);
 extern bool adafruit_ble_set_mode_leds(bool on);
 extern bool adafruit_ble_set_power_level(int8_t level);
 
-#    ifdef __cplusplus
+#ifdef __cplusplus
 }
-#    endif
-
-#endif  // MODULE_ADAFRUIT_BLE
+#endif

--- a/tmk_core/protocol/lufa/outputselect.c
+++ b/tmk_core/protocol/lufa/outputselect.c
@@ -12,8 +12,12 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "lufa.h"
 #include "outputselect.h"
+
+#if defined(PROTOCOL_LUFA)
+#    include "lufa.h"
+#endif
+
 #ifdef MODULE_ADAFRUIT_BLE
 #    include "adafruit_ble.h"
 #endif
@@ -35,12 +39,18 @@ void set_output(uint8_t output) {
  */
 __attribute__((weak)) void set_output_user(uint8_t output) {}
 
+static bool is_usb_configured(void) {
+#if defined(PROTOCOL_LUFA)
+    return USB_DeviceState == DEVICE_STATE_Configured;
+#endif
+}
+
 /** \brief Auto Detect Output
  *
  * FIXME: Needs doc
  */
 uint8_t auto_detect_output(void) {
-    if (USB_DeviceState == DEVICE_STATE_Configured) {
+    if (is_usb_configured()) {
         return OUTPUT_USB;
     }
 

--- a/tmk_core/protocol/lufa/outputselect.h
+++ b/tmk_core/protocol/lufa/outputselect.h
@@ -12,6 +12,10 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#pragma once
+
+#include <stdint.h>
+
 enum outputs {
     OUTPUT_AUTO,
 

--- a/tmk_core/protocol/serial.h
+++ b/tmk_core/protocol/serial.h
@@ -35,13 +35,10 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 */
 
-#ifndef SERIAL_H
-#define SERIAL_H
+#pragma once
 
 /* host role */
 void    serial_init(void);
 uint8_t serial_recv(void);
 int16_t serial_recv2(void);
 void    serial_send(uint8_t data);
-
-#endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Just some more prep work for Bluetooth API.

 - Added `PGM_P` equivalent for ARM
 - Include guards to `#pragma once` for some files I've touched (to make later diffs easier to read)
 - Added `is_usb_configured()` for output selection, only LUFA implemented so far

More stuff ~~I may add to this PR~~ for the next PR:

 - Rename `adafruit_ble.[cpp|h]` to `bluefruit_le`
 - Remove `bluefruit_keyboard_print_report()` and change `bluefruit_serial_send()` usages to `serial_send()`
 - Drop support for Adafruit EZ-Key (product discontinued)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
