### PR TITLE
fix: broken keyboard and keymap reference

### DIFF
--- a/keyboards/handwired/dactyl_manuform/5x6_5/keymaps/default/keymap.json
+++ b/keyboards/handwired/dactyl_manuform/5x6_5/keymaps/default/keymap.json
@@ -2,8 +2,8 @@
     "version": 1,
     "notes": "",
     "author": "Jan Christoph Ebersbach",
-    "keyboard": "dactyl_manuform/5x6_5/default",
-    "keymap": "dactyl_manuform_5x6_5_default",
+    "keyboard": "handwired/dactyl_manuform/5x6_5",
+    "keymap": "default",
     "layout": "LAYOUT_5x6_5",
     "layers": [
         [


### PR DESCRIPTION
## Description

Fix keymap reference to the dactyl_manuform_5x6_5

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
