### PR TITLE
Fix KEYBOARD_SHARED_EP incompatibility with VIA

### DIFF
--- a/tmk_core/protocol/usb_descriptor.h
+++ b/tmk_core/protocol/usb_descriptor.h
@@ -60,6 +60,11 @@ typedef struct {
     USB_Descriptor_Interface_t Keyboard_Interface;
     USB_HID_Descriptor_HID_t   Keyboard_HID;
     USB_Descriptor_Endpoint_t  Keyboard_INEndpoint;
+#else
+    // Shared Interface
+    USB_Descriptor_Interface_t Shared_Interface;
+    USB_HID_Descriptor_HID_t   Shared_HID;
+    USB_Descriptor_Endpoint_t  Shared_INEndpoint;
 #endif
 
 #ifdef RAW_ENABLE
@@ -77,7 +82,7 @@ typedef struct {
     USB_Descriptor_Endpoint_t  Mouse_INEndpoint;
 #endif
 
-#ifdef SHARED_EP_ENABLE
+#if defined(SHARED_EP_ENABLE) && !defined(KEYBOARD_SHARED_EP)
     // Shared Interface
     USB_Descriptor_Interface_t Shared_Interface;
     USB_HID_Descriptor_HID_t   Shared_HID;
@@ -132,6 +137,7 @@ enum usb_interfaces {
 #ifndef KEYBOARD_SHARED_EP
     KEYBOARD_INTERFACE,
 #else
+    SHARED_INTERFACE,
 #    define KEYBOARD_INTERFACE SHARED_INTERFACE
 #endif
 
@@ -146,7 +152,7 @@ enum usb_interfaces {
     MOUSE_INTERFACE,
 #endif
 
-#ifdef SHARED_EP_ENABLE
+#if defined(SHARED_EP_ENABLE) && !defined(KEYBOARD_SHARED_EP)
     SHARED_INTERFACE,
 #endif
 


### PR DESCRIPTION
## Description

The `KEYBOARD_SHARED_EP=yes` option was breaking the VIA support, because the raw HID interface number in this case was 0 instead of 1, and the VIA app depends on the exact interface number for raw HID. Change the interface ordering to put the shared interface before the raw HID interface if `KEYBOARD_SHARED_EP` is enabled, so that the raw HID interface can keep its number.

I verified this on XD87 HS (atmega32u4, no official VIA JSON yet), bare Pro Micro flashed with `make contra:via:flash KEYBOARD_SHARED_EP=yes`, and bare Bluepill (STM32F103) flashed with `make cannonkeys/practice60:via:flash KEYBOARD_SHARED_EP=yes` (VIA JSON in a pending and buggy PR). In all those cases just adding `KEYBOARD_SHARED_EP=yes` prevented the board from being detected in the Linux VIA app; applying the patch made the VIA app work properly again.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
