### PR TITLE
Add Indicator flag for RGB Matrix

### DIFF
--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -159,15 +159,16 @@ As mentioned earlier, the center of the keyboard by default is expected to be `{
 
 ## Flags :id=flags
 
-|Define                              |Description                                |
-|------------------------------------|-------------------------------------------|
-|`#define HAS_FLAGS(bits, flags)`    |Returns true if `bits` has all `flags` set.|
-|`#define HAS_ANY_FLAGS(bits, flags)`|Returns true if `bits` has any `flags` set.|
-|`#define LED_FLAG_NONE      0x00`   |If this LED has no flags.                  |
-|`#define LED_FLAG_ALL       0xFF`   |If this LED has all flags.                 |
-|`#define LED_FLAG_MODIFIER  0x01`   |If the Key for this LED is a modifier.     |
-|`#define LED_FLAG_UNDERGLOW 0x02`   |If the LED is for underglow.               |
-|`#define LED_FLAG_KEYLIGHT  0x04`   |If the LED is for key backlight.           |
+|Define                              |Description                                  |
+|------------------------------------|---------------------------------------------|
+|`#define HAS_FLAGS(bits, flags)`    |Returns true if `bits` has all `flags` set.  |
+|`#define HAS_ANY_FLAGS(bits, flags)`|Returns true if `bits` has any `flags` set.  |
+|`#define LED_FLAG_NONE      0x00`   |If this LED has no flags.                    |
+|`#define LED_FLAG_ALL       0xFF`   |If this LED has all flags.                   |
+|`#define LED_FLAG_MODIFIER  0x01`   |If the Key for this LED is a modifier.       |
+|`#define LED_FLAG_UNDERGLOW 0x02`   |If the LED is for underglow.                 |
+|`#define LED_FLAG_KEYLIGHT  0x04`   |If the LED is for key backlight.             |
+|`#define LED_FLAG_INDICATOR 0x08`   |If the LED is for keyboard state indication. |
 
 ## Keycodes :id=keycodes
 

--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -159,16 +159,16 @@ As mentioned earlier, the center of the keyboard by default is expected to be `{
 
 ## Flags :id=flags
 
-|Define                              |Description                                  |
-|------------------------------------|---------------------------------------------|
-|`#define HAS_FLAGS(bits, flags)`    |Returns true if `bits` has all `flags` set.  |
-|`#define HAS_ANY_FLAGS(bits, flags)`|Returns true if `bits` has any `flags` set.  |
-|`#define LED_FLAG_NONE      0x00`   |If this LED has no flags.                    |
-|`#define LED_FLAG_ALL       0xFF`   |If this LED has all flags.                   |
-|`#define LED_FLAG_MODIFIER  0x01`   |If the Key for this LED is a modifier.       |
-|`#define LED_FLAG_UNDERGLOW 0x02`   |If the LED is for underglow.                 |
-|`#define LED_FLAG_KEYLIGHT  0x04`   |If the LED is for key backlight.             |
-|`#define LED_FLAG_INDICATOR 0x08`   |If the LED is for keyboard state indication. |
+|Define                      |Value |Description                                      |
+|----------------------------|------|-------------------------------------------------|
+|`HAS_FLAGS(bits, flags)`    |*n/a* |Evaluates to `true` if `bits` has all `flags` set|
+|`HAS_ANY_FLAGS(bits, flags)`|*n/a* |Evaluates to `true` if `bits` has any `flags` set|
+|`LED_FLAG_NONE`             |`0x00`|If this LED has no flags                         |
+|`LED_FLAG_ALL`              |`0xFF`|If this LED has all flags                        |
+|`LED_FLAG_MODIFIER`         |`0x01`|If the LED is on a modifier key                  |
+|`LED_FLAG_UNDERGLOW`        |`0x02`|If the LED is for underglow                      |
+|`LED_FLAG_KEYLIGHT`         |`0x04`|If the LED is for key backlight                  |
+|`LED_FLAG_INDICATOR`        |`0x08`|If the LED is for keyboard state indication      |
 
 ## Keycodes :id=keycodes
 

--- a/quantum/rgb_matrix_types.h
+++ b/quantum/rgb_matrix_types.h
@@ -56,6 +56,7 @@ typedef struct PACKED {
 #define LED_FLAG_MODIFIER 0x01
 #define LED_FLAG_UNDERGLOW 0x02
 #define LED_FLAG_KEYLIGHT 0x04
+#define LED_FLAG_INDICATOR 0x08
 
 #define NO_LED 255
 


### PR DESCRIPTION
This adds a new flag for the RGB Matrix feature that lets you specify if the LED is an indicator LED, to be used to indicate the system state of the keyboard (eg caps/num/etc lock status, layer indication, modifer status, etc).

## Types of Changes

- [x] Core
- [x] Enhancement/optimization
- [x] Documentation

## Checklist
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
