### PR TITLE
Change MIDI velocity implementation to allow direct control of velocity value

### DIFF
--- a/quantum/process_keycode/process_midi.c
+++ b/quantum/process_keycode/process_midi.c
@@ -128,13 +128,24 @@ bool process_midi(uint16_t keycode, keyrecord_t *record) {
             return false;
         case MI_VELD:
             if (record->event.pressed && midi_config.velocity > 0) {
-                midi_config.velocity--;
+                if (midi_config.velocity > 12 ) {
+                    midi_config.velocity -= 13;
+                }
+                else {
+                    midi_config.velocity = 0;
+                }
+
                 dprintf("midi velocity %d\n", midi_config.velocity);
             }
             return false;
         case MI_VELU:
             if (record->event.pressed && midi_config.velocity < 127) {
-                midi_config.velocity++;
+                if (midi_config.velocity < 115 ) {
+                    midi_config.velocity += 13;
+                }
+                else {
+                    midi_config.velocity = 127;
+                }
                 dprintf("midi velocity %d\n", midi_config.velocity);
             }
             return false;

--- a/quantum/process_keycode/process_midi.c
+++ b/quantum/process_keycode/process_midi.c
@@ -128,7 +128,9 @@ bool process_midi(uint16_t keycode, keyrecord_t *record) {
             return false;
         case MI_VELD:
             if (record->event.pressed && midi_config.velocity > 0) {
-                if (midi_config.velocity > 12) {
+                if (midi_config.velocity == 127) {
+                    midi_config.velocity -= 10;
+                } else if (midi_config.velocity > 12) {
                     midi_config.velocity -= 13;
                 } else {
                     midi_config.velocity = 0;

--- a/quantum/process_keycode/process_midi.c
+++ b/quantum/process_keycode/process_midi.c
@@ -41,12 +41,12 @@ static int8_t   midi_modulation_step;
 static uint16_t midi_modulation_timer;
 midi_config_t   midi_config;
 
-inline uint8_t compute_velocity(uint8_t setting) { return (setting + 1) * (128 / (MIDI_VELOCITY_MAX - MIDI_VELOCITY_MIN + 1)); }
+inline uint8_t compute_velocity(uint8_t setting) { return setting * (128 / (MIDI_VELOCITY_MAX - MIDI_VELOCITY_MIN)); }
 
 void midi_init(void) {
     midi_config.octave              = MI_OCT_2 - MIDI_OCTAVE_MIN;
     midi_config.transpose           = 0;
-    midi_config.velocity            = (compute_velocity(MIDI_VELOCITY_MAX - MIDI_VELOCITY_MIN));
+    midi_config.velocity            = 127;
     midi_config.channel             = 0;
     midi_config.modulation_interval = 8;
 

--- a/quantum/process_keycode/process_midi.c
+++ b/quantum/process_keycode/process_midi.c
@@ -128,10 +128,9 @@ bool process_midi(uint16_t keycode, keyrecord_t *record) {
             return false;
         case MI_VELD:
             if (record->event.pressed && midi_config.velocity > 0) {
-                if (midi_config.velocity > 12 ) {
+                if (midi_config.velocity > 12) {
                     midi_config.velocity -= 13;
-                }
-                else {
+                } else {
                     midi_config.velocity = 0;
                 }
 
@@ -140,10 +139,9 @@ bool process_midi(uint16_t keycode, keyrecord_t *record) {
             return false;
         case MI_VELU:
             if (record->event.pressed && midi_config.velocity < 127) {
-                if (midi_config.velocity < 115 ) {
+                if (midi_config.velocity < 115) {
                     midi_config.velocity += 13;
-                }
-                else {
+                } else {
                     midi_config.velocity = 127;
                 }
                 dprintf("midi velocity %d\n", midi_config.velocity);

--- a/quantum/process_keycode/process_midi.c
+++ b/quantum/process_keycode/process_midi.c
@@ -46,7 +46,7 @@ inline uint8_t compute_velocity(uint8_t setting) { return (setting + 1) * (128 /
 void midi_init(void) {
     midi_config.octave              = MI_OCT_2 - MIDI_OCTAVE_MIN;
     midi_config.transpose           = 0;
-    midi_config.velocity            = (MIDI_VELOCITY_MAX - MIDI_VELOCITY_MIN);
+    midi_config.velocity            = (compute_velocity(MIDI_VELOCITY_MAX - MIDI_VELOCITY_MIN));
     midi_config.channel             = 0;
     midi_config.modulation_interval = 8;
 
@@ -66,7 +66,7 @@ bool process_midi(uint16_t keycode, keyrecord_t *record) {
         case MIDI_TONE_MIN ... MIDI_TONE_MAX: {
             uint8_t channel  = midi_config.channel;
             uint8_t tone     = keycode - MIDI_TONE_MIN;
-            uint8_t velocity = compute_velocity(midi_config.velocity);
+            uint8_t velocity = midi_config.velocity;
             if (record->event.pressed) {
                 uint8_t note = midi_compute_note(keycode);
                 midi_send_noteon(&midi_device, channel, note, velocity);
@@ -122,7 +122,7 @@ bool process_midi(uint16_t keycode, keyrecord_t *record) {
             return false;
         case MIDI_VELOCITY_MIN ... MIDI_VELOCITY_MAX:
             if (record->event.pressed) {
-                midi_config.velocity = keycode - MIDI_VELOCITY_MIN;
+                midi_config.velocity = compute_velocity(keycode - MIDI_VELOCITY_MIN);
                 dprintf("midi velocity %d\n", midi_config.velocity);
             }
             return false;
@@ -133,7 +133,7 @@ bool process_midi(uint16_t keycode, keyrecord_t *record) {
             }
             return false;
         case MI_VELU:
-            if (record->event.pressed) {
+            if (record->event.pressed && midi_config.velocity < 127) {
                 midi_config.velocity++;
                 dprintf("midi velocity %d\n", midi_config.velocity);
             }

--- a/quantum/process_keycode/process_midi.h
+++ b/quantum/process_keycode/process_midi.h
@@ -35,7 +35,7 @@ typedef union {
     struct {
         uint8_t octave : 4;
         int8_t  transpose : 4;
-        uint8_t velocity;
+        uint8_t velocity : 7;
         uint8_t channel : 4;
         uint8_t modulation_interval : 4;
     };

--- a/quantum/process_keycode/process_midi.h
+++ b/quantum/process_keycode/process_midi.h
@@ -35,7 +35,7 @@ typedef union {
     struct {
         uint8_t octave : 4;
         int8_t  transpose : 4;
-        uint8_t velocity : 4;
+        uint8_t velocity;
         uint8_t channel : 4;
         uint8_t modulation_interval : 4;
     };

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -341,7 +341,8 @@ enum quantum_keycodes {
     MI_TRNSU,  // transpose up
 
     MIDI_VELOCITY_MIN,
-    MI_VEL_1 = MIDI_VELOCITY_MIN,
+    MI_VEL_0 = MIDI_VELOCITY_MIN,
+    MI_VEL_1,
     MI_VEL_2,
     MI_VEL_3,
     MI_VEL_4,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I've been trying to make a MIDI keyboard based on QMK, and one of the challenges of using mechanical keyboard switches for this is the lack of velocity sensitivity. To compensate, I was trying to add velocity control with an analog input, like a potentiometer. To my disappointment, I wasn't able to use my potentiometer to change velocity freely between 0-127, as the current implementation forces velocity down to a range of 1-10 which is far too low resolution for my wants and needs. These changes are an attempt at fixing this without breaking the current velocity keycodes, to allow the old method to work, and open up for setting velocity directly with something as simple as
`midi_config.velocity = analogReadPin(POT_PIN) >> 3`

My changes are at a relatively low level so I wanted to make this PR early so I don't put too much work in only to end up reworking them if they don't mesh well with the ongoing refactoring. As far as I can tell these parts of QMK are barely being used by any keymaps so I'm not super worried about them, but I understand that changes might be needed to preserve existing behaviour even better than what I have currently implemented.

As a side effect of my changes, the function `compute_velocity()` in process_midi.c is now only called when velocity is actually changed via the related keycodes, instead of being called on every MIDI note on or note off being message sent which should help performance a tiny bit.

I'm currently unsure if I have reached parity with how the existing MIDI_VELOCITY_MAX and MIDI_VELOCITY_MIN values are being used, but they don't seem to be very well implemented at the moment as it's possible to repeatedly press MI_VELU and have velocity overflow past 127 and wrap back to 0 which is very jarring. This behavior has been changed in this PR, to limit velocity values to 0-127 when being changed using these keycodes.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [X] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* None, this is an expansion on an existing, but not much used, feature

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
