### PR TITLE
Issue 9942: Add LSA, RSA, RCS, LSA_T, RSA_T, and RCS_T

### DIFF
--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -394,7 +394,7 @@ See also: [Modifier Keys](feature_advanced_keycodes.md#modifier-keys)
 |`SGUI(kc)`|`SCMD(kc)`, `SWIN(kc)`         |Hold Left Shift and GUI and press `kc`                |
 |`LCA(kc)` |                               |Hold Left Control and Alt and press `kc`              |
 |`LSA(kc)` |                               |Hold Left Shift and Left Alt and press `kc`           |
-|`RSA(kc)` |`SAGR(kc)`                     |Hold Right Shift and Right Alt (Alt Gr) and press `kc`|
+|`RSA(kc)` |`SAGR(kc)`                     |Hold Right Shift and Right Alt (AltGr) and press `kc` |
 |`RCS(kc)` |                               |Hold Right Control and Right Shift and press `kc`     |
 |`LCAG(kc)`|                               |Hold Left Control, Alt and GUI and press `kc`         |
 |`MEH(kc)` |                               |Hold Left Control, Shift and Alt and press `kc`       |

--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -381,45 +381,51 @@ See also: [Mouse Keys](feature_mouse_keys.md)
 
 See also: [Modifier Keys](feature_advanced_keycodes.md#modifier-keys)
 
-|Key       |Aliases                        |Description                                         |
-|----------|-------------------------------|----------------------------------------------------|
-|`LCTL(kc)`|`C(kc)`                        |Hold Left Control and press `kc`                    |
-|`LSFT(kc)`|`S(kc)`                        |Hold Left Shift and press `kc`                      |
-|`LALT(kc)`|`A(kc)`, `LOPT(kc)`            |Hold Left Alt and press `kc`                        |
-|`LGUI(kc)`|`G(kc)`, `LCMD(kc)`, `LWIN(kc)`|Hold Left GUI and press `kc`                        |
-|`RCTL(kc)`|                               |Hold Right Control and press `kc`                   |
-|`RSFT(kc)`|                               |Hold Right Shift and press `kc`                     |
-|`RALT(kc)`|`ROPT(kc)`, `ALGR(kc)`         |Hold Right Alt and press `kc`                       |
-|`RGUI(kc)`|`RCMD(kc)`, `LWIN(kc)`         |Hold Right GUI and press `kc`                       |
-|`SGUI(kc)`|`SCMD(kc)`, `SWIN(kc)`         |Hold Left Shift and GUI and press `kc`              |
-|`LCA(kc)` |                               |Hold Left Control and Alt and press `kc`            |
-|`LCAG(kc)`|                               |Hold Left Control, Alt and GUI and press `kc`       |
-|`MEH(kc)` |                               |Hold Left Control, Shift and Alt and press `kc`     |
-|`HYPR(kc)`|                               |Hold Left Control, Shift, Alt and GUI and press `kc`|
-|`KC_MEH`  |                               |Left Control, Shift and Alt                         |
-|`KC_HYPR` |                               |Left Control, Shift, Alt and GUI                    |
+|Key       |Aliases                        |Description                                           |
+|----------|-------------------------------|------------------------------------------------------|
+|`LCTL(kc)`|`C(kc)`                        |Hold Left Control and press `kc`                      |
+|`LSFT(kc)`|`S(kc)`                        |Hold Left Shift and press `kc`                        |
+|`LALT(kc)`|`A(kc)`, `LOPT(kc)`            |Hold Left Alt and press `kc`                          |
+|`LGUI(kc)`|`G(kc)`, `LCMD(kc)`, `LWIN(kc)`|Hold Left GUI and press `kc`                          |
+|`RCTL(kc)`|                               |Hold Right Control and press `kc`                     |
+|`RSFT(kc)`|                               |Hold Right Shift and press `kc`                       |
+|`RALT(kc)`|`ROPT(kc)`, `ALGR(kc)`         |Hold Right Alt (Alt Gr) and press `kc`                |
+|`RGUI(kc)`|`RCMD(kc)`, `LWIN(kc)`         |Hold Right GUI and press `kc`                         |
+|`SGUI(kc)`|`SCMD(kc)`, `SWIN(kc)`         |Hold Left Shift and GUI and press `kc`                |
+|`LCA(kc)` |                               |Hold Left Control and Alt and press `kc`              |
+|`LSA(kc)` |                               |Hold Left Shift and Left Alt and press `kc`           |
+|`RSA(kc)` |`SAGR(kc)`                     |Hold Right Shift and Right Alt (Alt Gr) and press `kc`|
+|`RCS(kc)` |                               |Hold Right Control and Right Shift and press `kc`     |
+|`LCAG(kc)`|                               |Hold Left Control, Alt and GUI and press `kc`         |
+|`MEH(kc)` |                               |Hold Left Control, Shift and Alt and press `kc`       |
+|`HYPR(kc)`|                               |Hold Left Control, Shift, Alt and GUI and press `kc`  |
+|`KC_MEH`  |                               |Left Control, Shift and Alt                           |
+|`KC_HYPR` |                               |Left Control, Shift, Alt and GUI                      |
 
 ## Mod-Tap Keys :id=mod-tap-keys
 
 See also: [Mod-Tap](mod_tap.md)
 
-|Key          |Aliases                                                          |Description                                            |
-|-------------|-----------------------------------------------------------------|-------------------------------------------------------|
-|`MT(mod, kc)`|                                                                 |`mod` when held, `kc` when tapped                      |
-|`LCTL_T(kc)` |`CTL_T(kc)`                                                      |Left Control when held, `kc` when tapped               |
-|`LSFT_T(kc)` |`SFT_T(kc)`                                                      |Left Shift when held, `kc` when tapped                 |
-|`LALT_T(kc)` |`LOPT_T(kc)`, `ALT_T(kc)`, `OPT_T(kc)`                           |Left Alt when held, `kc` when tapped                   |
-|`LGUI_T(kc)` |`LCMD_T(kc)`, `LWIN_T(kc)`, `GUI_T(kc)`, `CMD_T(kc)`, `WIN_T(kc)`|Left GUI when held, `kc` when tapped                   |
-|`RCTL_T(kc)` |                                                                 |Right Control when held, `kc` when tapped              |
-|`RSFT_T(kc)` |                                                                 |Right Shift when held, `kc` when tapped                |
-|`RALT_T(kc)` |`ROPT_T(kc)`, `ALGR_T(kc)`                                       |Right Alt when held, `kc` when tapped                  |
-|`RGUI_T(kc)` |`RCMD_T(kc)`, `RWIN_T(kc)`                                       |Right GUI when held, `kc` when tapped                  |
-|`SGUI_T(kc)` |`SCMD_T(kc)`, `SWIN_T(kc)`                                       |Left Shift and GUI when held, `kc` when tapped         |
-|`LCA_T(kc)`  |                                                                 |Left Control and Alt when held, `kc` when tapped       |
-|`LCAG_T(kc)` |                                                                 |Left Control, Alt and GUI when held, `kc` when tapped  |
-|`RCAG_T(kc)` |                                                                 |Right Control, Alt and GUI when held, `kc` when tapped |
-|`C_S_T(kc)`  |                                                                 |Left Control and Shift when held, `kc` when tapped     |
-|`MEH_T(kc)`  |                                                                 |Left Control, Shift and Alt when held, `kc` when tapped|
+|Key          |Aliases                                                          |Description                                                   |
+|-------------|-----------------------------------------------------------------|--------------------------------------------------------------|
+|`MT(mod, kc)`|                                                                 |`mod` when held, `kc` when tapped                             |
+|`LCTL_T(kc)` |`CTL_T(kc)`                                                      |Left Control when held, `kc` when tapped                      |
+|`LSFT_T(kc)` |`SFT_T(kc)`                                                      |Left Shift when held, `kc` when tapped                        |
+|`LALT_T(kc)` |`LOPT_T(kc)`, `ALT_T(kc)`, `OPT_T(kc)`                           |Left Alt when held, `kc` when tapped                          |
+|`LGUI_T(kc)` |`LCMD_T(kc)`, `LWIN_T(kc)`, `GUI_T(kc)`, `CMD_T(kc)`, `WIN_T(kc)`|Left GUI when held, `kc` when tapped                          |
+|`RCTL_T(kc)` |                                                                 |Right Control when held, `kc` when tapped                     |
+|`RSFT_T(kc)` |                                                                 |Right Shift when held, `kc` when tapped                       |
+|`RALT_T(kc)` |`ROPT_T(kc)`, `ALGR_T(kc)`                                       |Right Alt (Alt Gr) when held, `kc` when tapped                |
+|`RGUI_T(kc)` |`RCMD_T(kc)`, `RWIN_T(kc)`                                       |Right GUI when held, `kc` when tapped                         |
+|`SGUI_T(kc)` |`SCMD_T(kc)`, `SWIN_T(kc)`                                       |Left Shift and GUI when held, `kc` when tapped                |
+|`LCA_T(kc)`  |                                                                 |Left Control and Alt when held, `kc` when tapped              |
+|`LSA_T(kc)`  |                                                                 |Left Shift and Left Alt when held, `kc` when tapped           |
+|`RSA_T(kc)`  |`SAGR_T(kc)`                                                     |Right Shift and Right Alt (Alt Gr) when held, `kc` when tapped|
+|`RCS_T(kc)`  |                                                                 |Right Control and Right Shift when held, `kc` when tapped     |
+|`LCAG_T(kc)` |                                                                 |Left Control, Alt and GUI when held, `kc` when tapped         |
+|`RCAG_T(kc)` |                                                                 |Right Control, Alt and GUI when held, `kc` when tapped        |
+|`C_S_T(kc)`  |                                                                 |Left Control and Shift when held, `kc` when tapped            |
+|`MEH_T(kc)`  |                                                                 |Left Control, Shift and Alt when held, `kc` when tapped       |
 |`HYPR_T(kc)` |`ALL_T(kc)`                                                      |Left Control, Shift, Alt and GUI when held, `kc` when tapped - more info [here](http://brettterpstra.com/2012/12/08/a-useful-caps-lock-key/)|
 
 ## RGB Lighting :id=rgb-lighting

--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -420,7 +420,7 @@ See also: [Mod-Tap](mod_tap.md)
 |`SGUI_T(kc)` |`SCMD_T(kc)`, `SWIN_T(kc)`                                       |Left Shift and GUI when held, `kc` when tapped                |
 |`LCA_T(kc)`  |                                                                 |Left Control and Alt when held, `kc` when tapped              |
 |`LSA_T(kc)`  |                                                                 |Left Shift and Left Alt when held, `kc` when tapped           |
-|`RSA_T(kc)`  |`SAGR_T(kc)`                                                     |Right Shift and Right Alt (Alt Gr) when held, `kc` when tapped|
+|`RSA_T(kc)`  |`SAGR_T(kc)`                                                     |Right Shift and Right Alt (AltGr) when held, `kc` when tapped |
 |`RCS_T(kc)`  |                                                                 |Right Control and Right Shift when held, `kc` when tapped     |
 |`LCAG_T(kc)` |                                                                 |Left Control, Alt and GUI when held, `kc` when tapped         |
 |`RCAG_T(kc)` |                                                                 |Right Control, Alt and GUI when held, `kc` when tapped        |

--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -389,7 +389,7 @@ See also: [Modifier Keys](feature_advanced_keycodes.md#modifier-keys)
 |`LGUI(kc)`|`G(kc)`, `LCMD(kc)`, `LWIN(kc)`|Hold Left GUI and press `kc`                          |
 |`RCTL(kc)`|                               |Hold Right Control and press `kc`                     |
 |`RSFT(kc)`|                               |Hold Right Shift and press `kc`                       |
-|`RALT(kc)`|`ROPT(kc)`, `ALGR(kc)`         |Hold Right Alt (Alt Gr) and press `kc`                |
+|`RALT(kc)`|`ROPT(kc)`, `ALGR(kc)`         |Hold Right Alt (AltGr) and press `kc`                 |
 |`RGUI(kc)`|`RCMD(kc)`, `LWIN(kc)`         |Hold Right GUI and press `kc`                         |
 |`SGUI(kc)`|`SCMD(kc)`, `SWIN(kc)`         |Hold Left Shift and GUI and press `kc`                |
 |`LCA(kc)` |                               |Hold Left Control and Alt and press `kc`              |

--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -415,7 +415,7 @@ See also: [Mod-Tap](mod_tap.md)
 |`LGUI_T(kc)` |`LCMD_T(kc)`, `LWIN_T(kc)`, `GUI_T(kc)`, `CMD_T(kc)`, `WIN_T(kc)`|Left GUI when held, `kc` when tapped                          |
 |`RCTL_T(kc)` |                                                                 |Right Control when held, `kc` when tapped                     |
 |`RSFT_T(kc)` |                                                                 |Right Shift when held, `kc` when tapped                       |
-|`RALT_T(kc)` |`ROPT_T(kc)`, `ALGR_T(kc)`                                       |Right Alt (Alt Gr) when held, `kc` when tapped                |
+|`RALT_T(kc)` |`ROPT_T(kc)`, `ALGR_T(kc)`                                       |Right Alt (AltGr) when held, `kc` when tapped                 |
 |`RGUI_T(kc)` |`RCMD_T(kc)`, `RWIN_T(kc)`                                       |Right GUI when held, `kc` when tapped                         |
 |`SGUI_T(kc)` |`SCMD_T(kc)`, `SWIN_T(kc)`                                       |Left Shift and GUI when held, `kc` when tapped                |
 |`LCA_T(kc)`  |                                                                 |Left Control and Alt when held, `kc` when tapped              |

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -540,6 +540,9 @@ enum quantum_keycodes {
 #define SCMD(kc) SGUI(kc)
 #define SWIN(kc) SGUI(kc)
 #define LCA(kc) (QK_LCTL | QK_LALT | (kc))
+#define LSA(kc) (QK_LSFT | QK_LALT | (kc))
+#define RSA(kc) (QK_RSFT | QK_RALT | (kc))
+#define RCS(kc) (QK_RCTL | QK_RSFT | (kc))
 
 #define MOD_HYPR 0xF
 #define MOD_MEH 0x7
@@ -763,6 +766,10 @@ enum quantum_keycodes {
 #define SCMD_T(kc) SGUI_T(kc)
 #define SWIN_T(kc) SGUI_T(kc)
 #define LCA_T(kc) MT(MOD_LCTL | MOD_LALT, kc)  // Left Control + Alt
+#define LSA_T(kc) MT(MOD_LSFT | MOD_LALT, kc)  // Left Alt + Left Shift, used for vertical text selection and keyboard language-switching
+#define RSA_T(kc) MT(MOD_RSFT | MOD_RALT, kc)  // Right Alt + Shift, used by many locales for special characters
+#define RCS_T(kc) MT(MOD_RCTL | MOD_RSFT, kc)  // Right Control + Shift, used by some locales for special characters
+
 #define ALL_T(kc) HYPR_T(kc)
 
 // Dedicated keycode versions for Hyper and Meh, if you want to use them as standalone keys rather than mod-tap

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -767,10 +767,10 @@ enum quantum_keycodes {
 #define SCMD_T(kc) SGUI_T(kc)
 #define SWIN_T(kc) SGUI_T(kc)
 #define LCA_T(kc) MT(MOD_LCTL | MOD_LALT, kc)  // Left Control + Alt
-#define LSA_T(kc) MT(MOD_LSFT | MOD_LALT, kc)  // Left Alt + Left Shift, used for vertical text selection and keyboard language-switching
-#define RSA_T(kc) MT(MOD_RSFT | MOD_RALT, kc)  // Right Alt + Shift, used by many locales for special characters
-#define RCS_T(kc) MT(MOD_RCTL | MOD_RSFT, kc)  // Right Control + Shift, used by some locales for special characters
-#define SAGR_T(kc) RSA_T(kc)    // Shift + Alt Gr nickname
+#define LSA_T(kc) MT(MOD_LSFT | MOD_LALT, kc)  // Left Shift + Alt
+#define RSA_T(kc) MT(MOD_RSFT | MOD_RALT, kc)  // Right Shift + Alt
+#define RCS_T(kc) MT(MOD_RCTL | MOD_RSFT, kc)  // Right Control + Shift
+#define SAGR_T(kc) RSA_T(kc)
 
 #define ALL_T(kc) HYPR_T(kc)
 

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -543,6 +543,7 @@ enum quantum_keycodes {
 #define LSA(kc) (QK_LSFT | QK_LALT | (kc))
 #define RSA(kc) (QK_RSFT | QK_RALT | (kc))
 #define RCS(kc) (QK_RCTL | QK_RSFT | (kc))
+#define SAGR(kc) RSA(kc)
 
 #define MOD_HYPR 0xF
 #define MOD_MEH 0x7
@@ -769,6 +770,7 @@ enum quantum_keycodes {
 #define LSA_T(kc) MT(MOD_LSFT | MOD_LALT, kc)  // Left Alt + Left Shift, used for vertical text selection and keyboard language-switching
 #define RSA_T(kc) MT(MOD_RSFT | MOD_RALT, kc)  // Right Alt + Shift, used by many locales for special characters
 #define RCS_T(kc) MT(MOD_RCTL | MOD_RSFT, kc)  // Right Control + Shift, used by some locales for special characters
+#define SAGR_T(kc) RSA_T(kc)    // Shift + Alt Gr nickname
 
 #define ALL_T(kc) HYPR_T(kc)
 


### PR DESCRIPTION
Add codes to quantum_keycodes for LSA, RSA, RCS, and their corresponding _T macros

## Description

Per feature request 9942, added macro defines for common modifier combos.

1. LSA(kc) & LSA_T(kc) - Left Shift + Left Alt
2. RSA(kc) & RSA_T(kc) - Right Shift + Right Alt (Alt Gr)
3. RCS(kc) & RCS_T(kc) - Right Ctrl + Right Shift 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* Fixes #9942

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
