### PR TITLE
[Keyboard] Fix Planck/Rev6 compiler issue

### DIFF
--- a/keyboards/planck/rev6/rev6.c
+++ b/keyboards/planck/rev6/rev6.c
@@ -15,6 +15,7 @@
  */
 #include "rev6.h"
 
+#ifdef RGB_MATRIX_ENABLE
 led_config_t g_led_config = { {
   // Key Matrix to LED Index
   { NO_LED, 6,      NO_LED, NO_LED, 5,      NO_LED },
@@ -33,6 +34,7 @@ led_config_t g_led_config = { {
   LED_FLAG_ALL, LED_FLAG_ALL, LED_FLAG_ALL, LED_FLAG_ALL, LED_FLAG_ALL,
   LED_FLAG_ALL, LED_FLAG_ALL, LED_FLAG_ALL, LED_FLAG_ALL
 } };
+#endif
 
 void matrix_init_kb(void) {
 	matrix_init_user();

--- a/keyboards/planck/rev6/rules.mk
+++ b/keyboards/planck/rev6/rules.mk
@@ -23,9 +23,8 @@ API_SYSEX_ENABLE = no
 
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
 SLEEP_LED_ENABLE = no    # Breathing sleep LED during USB suspend
-#SLEEP_LED_ENABLE = yes  # Breathing sleep LED during USB suspend
 
-RGB_MATRIX_ENABLE = WS2812
+# RGB_MATRIX_ENABLE = WS2812
 # SERIAL_LINK_ENABLE = yes
 ENCODER_ENABLE = yes
 DIP_SWITCH_ENABLE = yes


### PR DESCRIPTION
Specifically, don't want to have both RGBLight and RGB Matrix (with WS2812) enabled at the same time.  This will cause issues in usage, but apparently not when compiling.  Additionally, the led matrix was not encapsulated with preprocessor code.


## Types of Changes

- [x] Bugfix
- [x] Keyboard (addition or update)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
