### PR TITLE
Compiler warning when using WS2812 

### DIFF
--- a/quantum/rgb_matrix_drivers.c
+++ b/quantum/rgb_matrix_drivers.c
@@ -111,6 +111,10 @@ const rgb_matrix_driver_t rgb_matrix_driver = {
 #    endif
 
 #elif defined(WS2812)
+#    if defined(RGBLIGHT_ENABLE) && !defined(RGBLIGHT_CUSTOM_DRIVER)
+#        pragma message "Cannot use RGBLIGHT and RGB Matrix using WS2812 at the same time."
+#        pragma message "You need to use a custom driver, or re-implement the WS2812 driver to use a different configuration."
+#    endif
 
 // LED color buffer
 LED_TYPE rgb_matrix_ws2812_array[DRIVER_LED_TOTAL];


### PR DESCRIPTION
Specifically, when rgb matrix is enabled and using the ws2812 driver, and rgb light is enabled at the same time, print a message about coexistence because it can cause issues, since you cannot change pins/config for the WS2812 driver.


## Types of Changes

- [x] Core
- [x] Bugfix

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
