### PR TITLE
planck/rev6: Fix a few issues in pwm driver enable

### DIFF
--- a/keyboards/planck/rev6/rev6.c
+++ b/keyboards/planck/rev6/rev6.c
@@ -15,6 +15,7 @@
  */
 #include "rev6.h"
 
+#ifdef RGB_MATRIX_ENABLE
 led_config_t g_led_config = { {
   // Key Matrix to LED Index
   { NO_LED, 6,      NO_LED, NO_LED, 5,      NO_LED },
@@ -41,6 +42,7 @@ void matrix_init_kb(void) {
 void matrix_scan_kb(void) {
 	matrix_scan_user();
 }
+#endif
 
 #ifdef DIP_SWITCH_ENABLE
 __attribute__((weak))

--- a/keyboards/planck/rev6/rules.mk
+++ b/keyboards/planck/rev6/rules.mk
@@ -17,15 +17,16 @@ MIDI_ENABLE = no            # MIDI controls
 AUDIO_ENABLE = yes           # Audio output
 UNICODE_ENABLE = no         # Unicode
 BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
-RGBLIGHT_ENABLE = yes        # Enable WS2812 RGB underlight.
-WS2812_DRIVER = pwm
 API_SYSEX_ENABLE = no
 
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
 SLEEP_LED_ENABLE = no    # Breathing sleep LED during USB suspend
 #SLEEP_LED_ENABLE = yes  # Breathing sleep LED during USB suspend
 
+RGBLIGHT_ENABLE = no        # Disable WS2812 RGB underlight, use RGB_MATRIX instead.
+WS2812_DRIVER = pwm
 RGB_MATRIX_ENABLE = WS2812
+
 # SERIAL_LINK_ENABLE = yes
 ENCODER_ENABLE = yes
 DIP_SWITCH_ENABLE = yes


### PR DESCRIPTION
As pointed out by drashna, there were a few problems in the initial
commit: RGBLIGHT and RGB_MATRIX were both enabled simultaneously, and
the matrix-related code wasn't ifdef protected. These should both be
fixed.

## Description
- Set RGBLIGHT_ENABLED to no, comment that RGB_MATRIX is being used instead.
- Surrounded matrix-related code in rev6.c with an ifdef directive.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/qmk/qmk_firmware/pull/9735#issuecomment-670277383

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).