### PR TITLE
Add `st-flash` flash target

### DIFF
--- a/docs/flashing.md
+++ b/docs/flashing.md
@@ -239,3 +239,4 @@ There are a number of DFU commands that you can use to flash firmware to a STM32
 * `:dfu-util-split-left` - This flashes the normal firmware, just like the default option (`:dfu-util`). However, this also configures the "Left Side" EEPROM setting for split keyboards.
 * `:dfu-util-split-right` - This flashes the normal firmware, just like the default option (`:dfu-util`). However, this also configures the "Right Side" EEPROM setting for split keyboards.
 * `:st-link-cli` - This allows you to flash the firmware via ST-LINK's CLI utility, rather than dfu-util. 
+* `:st-flash` - This allows you to flash the firmware via the `st-flash` utility from [STLink Tools](https://github.com/stlink-org/stlink), rather than dfu-util.

--- a/lib/python/qmk/cli/flash.py
+++ b/lib/python/qmk/cli/flash.py
@@ -27,6 +27,7 @@ def print_bootloader_help():
     cli.echo('\tdfu-util-split-left')
     cli.echo('\tdfu-util-split-right')
     cli.echo('\tst-link-cli')
+    cli.echo('\tst-flash')
     cli.echo('For more info, visit https://docs.qmk.fm/#/flashing')
 
 

--- a/tmk_core/chibios.mk
+++ b/tmk_core/chibios.mk
@@ -261,12 +261,14 @@ ifneq ("$(SERIAL)","")
 endif
 
 ST_LINK_ARGS ?=
+ST_FLASH_ARGS ?=
 
 # List any extra directories to look for libraries here.
 EXTRALIBDIRS = $(RULESPATH)/ld
 
 DFU_UTIL ?= dfu-util
 ST_LINK_CLI ?= st-link_cli
+ST_FLASH ?= st-flash
 
 define EXEC_DFU_UTIL
 	until $(DFU_UTIL) -l | grep -q "Found DFU"; do\
@@ -299,6 +301,9 @@ dfu-util-split-right: dfu-util
 
 st-link-cli: $(BUILD_DIR)/$(TARGET).hex sizeafter
 	$(ST_LINK_CLI) $(ST_LINK_ARGS) -q -c SWD -p $(BUILD_DIR)/$(TARGET).hex -Rst
+
+st-flash: $(BUILD_DIR)/$(TARGET).hex sizeafter
+	$(ST_FLASH) $(ST_FLASH_ARGS) --reset --format ihex write $(BUILD_DIR)/$(TARGET).hex
 
 
 # Autodetect teensy loader


### PR DESCRIPTION
## Description

Add support for flashing the firmware via the `st-flash` utility from the STLink Tools package (https://github.com/stlink-org/stlink).

The ST-LINK CLI utility used by the `st-link-cli` target is proprietary and Windows-only; the `st-flash` utility is open source (BSD 3-clause), and the STLink Tools package (called `stlink`, or sometimes `stlink-tools`) is available in many Linux distributions and in Homebrew for Mac OS.

I tested this with some STM32 development boards:
* STM32F103C8T6 “Bluepill” with the [STM32duino user bootloader](https://github.com/rogerclarkmelbourne/STM32duino-bootloader/) (the bootloader remains intact after flashing the `handwired/onekey/bluepill` firmware over ST-LINK)
* STM32F401CCU6 “Blackpill”
* STM32F411CEU6 “Blackpill”

The main reason for this PR is that some of the STM32F401CCU6 “Blackpill” boards sold on AliExpress apparently suffer from a combination of design deficiency and suboptimal component quality, and the builtin DFU bootloader on them is unreliable to the point of being unusable, so flashing them over ST-LINK seems to be much easier than trying to make the DFU bootloader start up properly by heating up the MCU. The problem is that the designer of those boards decided to use a 25 MHz crystal for HSE, and the builtin DFU bootloader attempts to determine the HSE frequency using the builtin HSI RC oscillator as a reference, which could actually work properly if the HSI frequency was within ±1% of 16 MHz, as written in the datasheet; however, apparently on some chips the factory calibration of HSI is much worse, and if the error is more than about 2% (for the 25 MHz crystal), the HSE frequency detection does not work properly, and then DFU gets lots of USB errors and does not work. Running the actual QMK firmware on those boards is not a problem, however, because the firmware uses a static PLL configuration for the 25 MHz crystal, and a wrong HSI frequency does not matter.

Other “Blackpill” board versions (STM32F411CEU6 and the updated STM32F401CEU6) could potentially have the same problem (they have the same 25 MHz HSE crystal).

I targeted the PR to `develop`, as requested in the new PR checklist, but the base of the branch is also suitable for `master`, if you decide that the change is trivial enough to be added there directly.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
