### PR TITLE
[Bugfix] Fix Swap Hands bug introduced by OSH

### DIFF
--- a/tmk_core/common/action_util.c
+++ b/tmk_core/common/action_util.c
@@ -97,7 +97,7 @@ static uint16_t oneshot_layer_time = 0;
 inline bool     has_oneshot_layer_timed_out() { return TIMER_DIFF_16(timer_read(), oneshot_layer_time) >= ONESHOT_TIMEOUT && !(get_oneshot_layer_state() & ONESHOT_TOGGLED); }
 #        ifdef SWAP_HANDS_ENABLE
 static uint16_t oneshot_swaphands_time = 0;
-inline bool     has_oneshot_swaphands_timed_out() { return TIMER_DIFF_16(timer_read(), oneshot_swaphands_time) >= ONESHOT_TIMEOUT && !(swap_hands_oneshot >= SHO_PRESSED); }
+inline bool     has_oneshot_swaphands_timed_out() { return TIMER_DIFF_16(timer_read(), oneshot_swaphands_time) >= ONESHOT_TIMEOUT && (swap_hands_oneshot == SHO_ACTIVE); }
 #        endif
 #    endif
 


### PR DESCRIPTION
Fixes the handling for the oneshot cleanup, so it only cleans up if it is active.  It should not cleanup of SHO is off (eg using a normal oneshot key), nor if it's actively pressed or used.  

Previous behavior BROKE swap hand keys completely.


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* Fixes #9967 

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).


## Additional notes

I've tested this out with a few of the keys to ensure that both OneShot Swap works, as well as some of the other Swap Hand keys work. 

Based on the code, the "cleanup" should only occur on timeout, and this is the simplest way to do this. 