### PR TITLE
[Fix] Mixi macropad encoder orientation

### DIFF
--- a/keyboards/mixi/config.h
+++ b/keyboards/mixi/config.h
@@ -21,8 +21,9 @@
     { C6, F7, B6 } \
 }
 
-#define ENCODERS_PAD_A { D7, B3 }
-#define ENCODERS_PAD_B { E6, B1 }
+#define ENCODER_DIRECTION_FLIP
+#define ENCODERS_PAD_A { E6, B1 }
+#define ENCODERS_PAD_B { D7, B3 }
 
 /* Set 0 if debouncing isn't needed */
 #define DEBOUNCE 5

--- a/keyboards/mixi/config.h
+++ b/keyboards/mixi/config.h
@@ -21,8 +21,8 @@
     { C6, F7, B6 } \
 }
 
-#define ENCODERS_PAD_A { D7, B1 }
-#define ENCODERS_PAD_B { E6, B3 }
+#define ENCODERS_PAD_A { D7, B3 }
+#define ENCODERS_PAD_B { E6, B1 }
 
 /* Set 0 if debouncing isn't needed */
 #define DEBOUNCE 5


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

On the Mixi macropad, the secondary encoder's orientation is wrong, it seems the pin configuration swapped, the expected behavior when rotated clockwise should be increase the value, however it will decrease the registered value.

### Expected:
* Rotate clockwise should increase the value like `Brightness Up`

### Actual:
* Rotate clockwise is decrease the value, eg: `Brightness Down`

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
