### PR TITLE
[Keymap] layer indicator lights

### DIFF
--- a/users/stanrc85/rgblight_layers.c
+++ b/users/stanrc85/rgblight_layers.c
@@ -42,6 +42,9 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 }
 
 bool led_update_user(led_t led_state) {
-    rgblight_set_layer_state(0, led_state.caps_lock);
-    return true;
+    //rgblight_set_layer_state(0, led_state.caps_lock);
+    writePin(INDICATOR_PIN_0, !led_state.caps_lock);
+    writePin(INDICATOR_PIN_1, !led_state.num_lock);
+    writePin(INDICATOR_PIN_2, !led_state.scroll_lock);
+    return false;
 }

--- a/users/stanrc85/rgblight_layers.c
+++ b/users/stanrc85/rgblight_layers.c
@@ -1,5 +1,8 @@
 #include "stanrc85.h"
 
+static uint8_t middle = 0;
+static uint8_t bottom = 0;
+
 const rgblight_segment_t PROGMEM my_capslock_layer[] = RGBLIGHT_LAYER_SEGMENTS(
     {3, 2, HSV_RED},
     {10, 2, HSV_RED}
@@ -38,13 +41,28 @@ layer_state_t layer_state_set_user(layer_state_t state) {
     rgblight_set_layer_state(1, layer_state_cmp(state, 1));
     rgblight_set_layer_state(2, layer_state_cmp(state, 2));
     rgblight_set_layer_state(3, layer_state_cmp(state, 3));
+    middle = bottom = 0;
+    switch (get_highest_layer(state)) {
+    case _FN1_60:
+        middle = 1;
+        break;
+    case _FN2_60:
+        bottom = 1;
+        break;
+    case _DEFAULT:
+        middle = 1;
+        bottom = 1;
+        break;
+    default: //  for any other layers, or the default layer
+        break;
+    }
     return state;
 }
 
 bool led_update_user(led_t led_state) {
     //rgblight_set_layer_state(0, led_state.caps_lock);
     writePin(INDICATOR_PIN_0, !led_state.caps_lock);
-    writePin(INDICATOR_PIN_1, !led_state.num_lock);
-    writePin(INDICATOR_PIN_2, !led_state.scroll_lock);
+    writePin(INDICATOR_PIN_1, !middle);
+    writePin(INDICATOR_PIN_2, !bottom);
     return false;
 }

--- a/users/stanrc85/rgblight_layers_osa.c
+++ b/users/stanrc85/rgblight_layers_osa.c
@@ -1,5 +1,8 @@
 #include "stanrc85.h"
 
+static uint8_t middle = 0;
+static uint8_t bottom = 0;
+
 const rgblight_segment_t PROGMEM my_capslock_layer[] = RGBLIGHT_LAYER_SEGMENTS(
     {2, 2, HSV_RED},
     {6, 2, HSV_RED}
@@ -38,13 +41,28 @@ layer_state_t layer_state_set_user(layer_state_t state) {
     rgblight_set_layer_state(1, layer_state_cmp(state, 1));
     rgblight_set_layer_state(2, layer_state_cmp(state, 2));
     rgblight_set_layer_state(3, layer_state_cmp(state, 3));
+    middle = bottom = 0;
+    switch (get_highest_layer(state)) {
+    case _FN1_60:
+        middle = 1;
+        break;
+    case _FN2_60:
+        bottom = 1;
+        break;
+    case _DEFAULT:
+        middle = 1;
+        bottom = 1;
+        break;
+    default: //  for any other layers, or the default layer
+        break;
+    }
     return state;
 }
 
 bool led_update_user(led_t led_state) {
     //rgblight_set_layer_state(0, led_state.caps_lock);
     writePin(C7, led_state.caps_lock);
-    writePin(C6, led_state.num_lock);
-    writePin(B6, led_state.scroll_lock);
+    writePin(C6, middle);
+    writePin(B6, bottom);
     return false;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

Making better use of num lock and scroll lock indicators lights by using them for layer indicators instead. 

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
