### PR TITLE
Fix DMA stream ID calculation in ws2812_pwm

### DIFF
--- a/drivers/chibios/ws2812_pwm.c
+++ b/drivers/chibios/ws2812_pwm.c
@@ -177,7 +177,7 @@ void ws2812_init(void) {
 
     // Configure DMA
     // dmaInit(); // Joe added this
-    dmaStreamAlloc(WS2812_DMA_STREAM - STM32_DMA1_STREAM1, 10, NULL, NULL);
+    dmaStreamAlloc(WS2812_DMA_STREAM - STM32_DMA_STREAM(0), 10, NULL, NULL);
     dmaStreamSetPeripheral(WS2812_DMA_STREAM, &(WS2812_PWM_DRIVER.tim->CCR[WS2812_PWM_CHANNEL - 1]));  // Ziel ist der An-Zeit im Cap-Comp-Register
     dmaStreamSetMemory0(WS2812_DMA_STREAM, ws2812_frame_buffer);
     dmaStreamSetTransactionSize(WS2812_DMA_STREAM, WS2812_BIT_N);


### PR DESCRIPTION
## Description

Some STM32 chips have `STM32_DMA1_STREAM1` as the first DMA stream, others (F4xx, F7xx, H7xx) have `STM32_DMA1_STREAM0`.  Instead of those names, use `STM32_DMA_STREAM(0)`, which should always give the first `stm32_dma_stream_t` structure in the DMA streams array, so that the stream ID would be calculated correctly.

I don't actually have the hardware to test the change at the moment (I found the problem when trying to adapt the DMA streams code from ws2812_pwm for a different purpose and running it on the F401 Blackpill board — the DMA completion callback was not invoked, because `dmaStreamAlloc()` was called for a wrong stream ID).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
