### PR TITLE
redox: sync RGB on left and right sides

### DIFF
--- a/keyboards/redox/rev1/config.h
+++ b/keyboards/redox/rev1/config.h
@@ -62,6 +62,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define RGBLED_NUM 14    // Number of LEDs
 
+#define RGBLIGHT_SPLIT   // sync LEDs between RIGHT and LEFT hand
+
 /*
  * Feature disable options
  *  These options are also useful to firmware size reduction.


### PR DESCRIPTION
## Description

Enable left right RGB sync with #define RGBLIGHT_SPLIT macro
<!--- Describe your changes in detail here. -->

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [X] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
