### PR TITLE
add a way to have only one oled display on split kbs

### DIFF
--- a/docs/feature_oled_driver.md
+++ b/docs/feature_oled_driver.md
@@ -56,6 +56,10 @@ void oled_task_user(void) {
 #endif
 ```
 
+## Using Single Display On Split Keyboards
+
+If you have a oled display enabled in your code, but do not have it connected to your keyboard you will experience lagging in registering keypresses. This usually happens if you have a split keyboard and decide to put a display on only one side. Defining either `OLED_NO_DISPLAY_ON_MASTER` or `OLED_NO_DISPLAY_ON_SLAVE` will disable the oled display on one side.
+
 ## Logo Example
 
 In the default font, certain ranges of characters are reserved for a QMK logo. To render this logo to the OLED screen, use the following code example:

--- a/drivers/oled/oled_driver.c
+++ b/drivers/oled/oled_driver.c
@@ -499,6 +499,9 @@ void oled_write_raw_P(const char *data, uint16_t size) {
 #endif  // defined(__AVR__)
 
 bool oled_on(void) {
+    if (!oled_initialized) {
+        return false;
+    }
 #if OLED_TIMEOUT > 0
     oled_timeout = timer_read32() + OLED_TIMEOUT;
 #endif
@@ -515,6 +518,10 @@ bool oled_on(void) {
 }
 
 bool oled_off(void) {
+    if (!oled_initialized) {
+        return oled_active;
+    }
+
     static const uint8_t PROGMEM display_off[] = {I2C_CMD, DISPLAY_OFF};
     if (oled_active) {
         if (I2C_TRANSMIT_P(display_off) != I2C_STATUS_SUCCESS) {

--- a/tmk_core/common/keyboard.c
+++ b/tmk_core/common/keyboard.c
@@ -240,7 +240,15 @@ void keyboard_init(void) {
     qwiic_init();
 #endif
 #ifdef OLED_DRIVER_ENABLE
-    oled_init(OLED_ROTATION_0);
+    if (is_keyboard_master()){
+#       ifndef OLED_NO_DISPLAY_ON_MASTER
+        oled_init(OLED_ROTATION_0);
+#       endif
+    } else {
+#       ifndef OLED_NO_DISPLAY_ON_SLAVE
+        led_init(OLED_ROTATION_0);
+#       endif
+    }
 #endif
 #ifdef PS2_MOUSE_ENABLE
     ps2_mouse_init();


### PR DESCRIPTION
When there is only one display on split keyboards,
there is a lag on the half that does not have the display.
That produces a lot of frustration especially for new,
less experienced users.

This commit allows to disable the display on one side,
without disabling the oled driver completely.

By defining OLED_NO_DISPLAY_ON_MASTER or
OLED_NO_DISPLAY_ON_SLAVE we disable the oled display.

This closes https://github.com/qmk/qmk_firmware/issues/9060

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR
    https://github.com/qmk/qmk_firmware/issues/9060
* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
