### PR TITLE
Keebio BFO-9000 6x7 keymap (OS X)

### DIFF
--- a/keyboards/keebio/bfo9000/keymaps/liorgonnen/README.md
+++ b/keyboards/keebio/bfo9000/keymaps/liorgonnen/README.md
@@ -1,0 +1,1 @@
+See this layout [here](https://i.imgur.com/wxi8VBS.jpg).

--- a/keyboards/keebio/bfo9000/keymaps/liorgonnen/config.h
+++ b/keyboards/keebio/bfo9000/keymaps/liorgonnen/config.h
@@ -1,0 +1,26 @@
+/*
+This is the c configuration file for the keymap
+
+Copyright 2012 Jun Wako <wakojun@gmail.com>
+Copyright 2015 Jack Humbert
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#define NO_ACTION_TAPPING
+#define NO_ACTION_ONESHOT
+//#define NO_ACTION_MACRO
+//#define NO_ACTION_FUNCTION

--- a/keyboards/keebio/bfo9000/keymaps/liorgonnen/keymap.c
+++ b/keyboards/keebio/bfo9000/keymaps/liorgonnen/keymap.c
@@ -1,0 +1,17 @@
+#include QMK_KEYBOARD_H
+
+#define _BASE 0
+#define LOCK LCTL(LGUI(KC_Q))
+#define SFT_CMD LSFT(KC_LGUI)
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+[_BASE] = LAYOUT( \
+    LOCK,    KC_ESC,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,  _______, _______,        KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  _______, _______, \
+    KC_VOLU, KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,   _______, _______,        KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  _______, _______, \
+    KC_VOLD, KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,   _______, _______,        KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, _______, _______, \
+    KC_ESC,  KC_BSPC, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,   _______, _______,        KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_BSLS, _______, _______, \
+    KC_PGUP, KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,   _______, _______,        KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_UP,   KC_RSFT, _______, _______, \
+    KC_PGDN, KC_TAB,  SFT_CMD, KC_LCTL, KC_LALT, KC_LGUI, KC_SPC, _______, _______,        KC_ENT,  KC_RGUI, KC_RALT, KC_RCTL, KC_LEFT, KC_DOWN, KC_RGHT, _______, _______ \
+)
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
This is a 6x7 layout keymap for Keebio's BFO-9000.
The layout aims to be very close to the MacBook Pro keyboard layout with a few improvements.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
