### PR TITLE
Define STM32_DMA_REQUIRED when using DMA-based WS2812 driver on STM32.

### DIFF
--- a/common_features.mk
+++ b/common_features.mk
@@ -304,6 +304,12 @@ ifeq ($(strip $(WS2812_DRIVER_REQUIRED)), yes)
         SRC += ws2812.c
     else
         SRC += ws2812_$(strip $(WS2812_DRIVER)).c
+
+        ifeq ($(strip $(PLATFORM)), CHIBIOS)
+            ifeq ($(strip $(WS2812_DRIVER)), pwm)
+                OPT_DEFS += -DSTM32_DMA_REQUIRED=TRUE
+            endif
+        endif
     endif
 
     # add extra deps

--- a/keyboards/zvecr/split_blackpill/rules.mk
+++ b/keyboards/zvecr/split_blackpill/rules.mk
@@ -31,6 +31,5 @@ FAUXCLICKY_ENABLE = no      # Use buzzer to emulate clicky switches
 SPLIT_KEYBOARD = yes
 SERIAL_DRIVER = usart
 WS2812_DRIVER = pwm
-OPT_DEFS += -DSTM32_DMA_REQUIRED=TRUE
 
 LAYOUTS = ortho_4x12

--- a/keyboards/zvecr/zv48/rules.mk
+++ b/keyboards/zvecr/zv48/rules.mk
@@ -22,7 +22,6 @@ FAUXCLICKY_ENABLE = no      # Use buzzer to emulate clicky switches
 SPLIT_KEYBOARD = yes
 SERIAL_DRIVER = usart
 WS2812_DRIVER = pwm
-OPT_DEFS += -DSTM32_DMA_REQUIRED=TRUE
 
 DEFAULT_FOLDER = zvecr/zv48/f401
 


### PR DESCRIPTION
## Description

The PWM-based WS2812 driver on ChibiOS/STM32 requires DMA. For some reason, one of the definitions isn't set up correctly by ChibiOS, and requires manual intervention to get it to cooperate.

This PR ensures that the definition `STM32_DMA_REQUIRED` is correctly set when using the PWM driver.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
