### PR TITLE
Change TMO to use layer_state_set_kb as is customary at the keyboard level.

### DIFF
--- a/keyboards/tmo50/tmo50.c
+++ b/keyboards/tmo50/tmo50.c
@@ -51,34 +51,51 @@ void led_set_kb(uint8_t usb_led) {
 	led_set_user(usb_led);
 }
 
-uint32_t layer_state_set_user(uint32_t state)
+layer_state_t layer_state_set_kb(layer_state_t state)
 {
-  // if on layer 0, turn on B0 LED, otherwise off.
-    if (biton32(state) == 0) {
+  state = layer_state_set_user(state);
+  process_indicator_led_kb(state);
+
+  return state;
+}
+
+__attribute__((weak))
+bool process_indicator_led_user(layer_state_t state){
+  return true;
+}
+
+bool process_indicator_led_kb(layer_state_t state)
+{
+  if(process_indicator_led_user(state))
+  {
+    // if on layer 0, turn on B0 LED, otherwise off.
+    if (get_highest_layer(state) == 0) {
         PORTB &= ~(1<<PB0);
     } else {
         PORTB |= (1<<PB0);
     }
 
-  // if on layer 1, turn on B1 LED, otherwise off.
-    if (biton32(state) == 1) {
+    // if on layer 1, turn on B1 LED, otherwise off.
+    if (get_highest_layer(state) == 1) {
         PORTB &= ~(1<<PB1);
     } else {
         PORTB |= (1<<PB1);
     }
-  // if on layer 2, turn on B2 LED, otherwise off.
-    if (biton32(state) == 2) {
+
+    // if on layer 2, turn on B2 LED, otherwise off.
+    if (get_highest_layer(state) == 2) {
         PORTB &= ~(1<<PB2);
     } else {
         PORTB |= (1<<PB2);
     }
 
-  // if on layer 3, turn on B3 LED, otherwise off.
-    if (biton32(state) == 3) {
+    // if on layer 3, turn on B3 LED, otherwise off.
+    if (get_highest_layer(state) == 3) {
         PORTB &= ~(1<<PB3);
     } else {
         PORTB |= (1<<PB3);
     }
+  }
 
-    return state;
+  return true;
 }

--- a/keyboards/tmo50/tmo50.h
+++ b/keyboards/tmo50/tmo50.h
@@ -17,6 +17,10 @@
 
 #include "quantum.h"
 
+bool process_indicator_led_kb(layer_state_t state);
+__attribute__((weak))
+bool process_indicator_led_user(layer_state_t state);
+
 /* This a shortcut to help you visually see your layout.
  *
  * The first section contains all of the arguments representing the physical
@@ -51,4 +55,3 @@
 	{ K20, K21, K22, K23, K24,   K25,   K26,   K27, K28,   K29,   K2A, K2B,   K2C,   K2D },   \
 	{ K30, K31, K32, K33, KC_NO, KC_NO, KC_NO, K37, KC_NO, KC_NO, K3A, KC_NO, KC_NO, KC_NO }  \
 }
-


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The keyboard should implement `_kb` methods, not `_user`. This was causing conflict with the routines I defined in my user keymap.
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
