### PR TITLE
mattly's mirrored centromere layout

### DIFF
--- a/keyboards/centromere/keymaps/mattly/keymap.c
+++ b/keyboards/centromere/keymaps/mattly/keymap.c
@@ -5,7 +5,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
   // I apparently soldered in my switches on the wrong sides of the boards, so this is mirrored
 
-  [_BASE_MAC] = LAYOUT_split_3x6_3( \
+  [_BASE_MAC] = LAYOUT_split_3x6_3(
     KC_SCLN, KC_P,    O_CTL,   I_ALT,   U_GUI,   KC_Y,               KC_T,    R_GUI,   E_ALT,   W_CTL,   KC_Q,    KC_BSPC,
     KC_QUOT, MINSCTL, L_ALT,   K_GUI,   J_SFT,   KC_H,               KC_G,    F_SFT,   D_GUI,   S_ALT,   A_CTL,   KC_CAPS,
     KC_ENT,  KC_SLSH, KC_DOT,  KC_COMM, KC_M,    KC_N,               KC_B,    KC_V,    KC_C,    KC_X,    KC_Z,    NAVLOCK,
@@ -53,4 +53,3 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
                                    _______, _______, _______,   _______, _______, _______
   ),
 };
-

--- a/keyboards/centromere/keymaps/mattly/keymap.c
+++ b/keyboards/centromere/keymaps/mattly/keymap.c
@@ -1,0 +1,56 @@
+#include QMK_KEYBOARD_H
+#include "mattly.h"
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+  // I apparently soldered in my switches on the wrong sides of the boards, so this is mirrored
+
+  [_BASE_MAC] = LAYOUT_split_3x6_3( \
+    KC_SCLN, KC_P,    O_CTL,   I_ALT,   U_GUI,   KC_Y,               KC_T,    R_GUI,   E_ALT,   W_CTL,   KC_Q,    KC_BSPC,
+    KC_QUOT, MINSCTL, L_ALT,   K_GUI,   J_SFT,   KC_H,               KC_G,    F_SFT,   D_GUI,   S_ALT,   A_CTL,   KC_CAPS,
+    KC_ENT,  KC_SLSH, KC_DOT,  KC_COMM, KC_M,    KC_N,               KC_B,    KC_V,    KC_C,    KC_X,    KC_Z,    NAVLOCK,
+                                  DEL_WRP, BSP_SYM, SPC_SFT,  SPC_SFT, TAB_NUM, ESC_HYP
+  ),
+
+  [_OVER_WIN] = LAYOUT_split_3x6_3(
+    _______, _______, O_GUI,   _______, U_CTL,   _______,            _______, R_CTL,   _______, W_GUI,   _______, _______,
+    _______, MINSGUI, _______, K_CTL,   _______, _______,            _______, _______, D_CTL,   _______, A_GUI,   _______,
+    _______, _______, _______, _______, _______, _______,            _______, _______, _______, _______, _______, _______,
+                                  _______, _______, _______,   _______, _______, _______
+  ),
+
+
+  [_SYMBOL] = LAYOUT_split_3x6_3(
+    _______, XXXXXXX, KC_ASTR, KC_PLUS, KC_RABK, KC_LABK,            KC_RBRC, KC_LBRC, KC_TILD, KC_GRV,  KC_AMPR, _______,
+    _______, KC_UNDS, KC_AT,   KC_EXLM, KC_COLN, KC_SCLN,            KC_RPRN, KC_LPRN, KC_EQL,  KC_PERC, KC_DLR,  _______,
+    _______, KC_QUES, KC_BSLS, KC_PIPE, KC_DQUO, KC_QUOT,            KC_RCBR, KC_LCBR, KC_HASH, KC_CIRC, KC_HASH, XXXXXXX,
+                                  _______, _______, _______,   _______, _______, _______
+  ),
+
+  [_NAVNUM] = LAYOUT_split_3x6_3(
+    KC_PLUS, KC_DOT,  KC_P9,   KC_P8,   KC_P7,   KC_DLR,             KC_PGUP, M_FWORD, KC_UP,   M_BWORD, M_NAVFW, M_NXWIN,
+    KC_MINS, KC_EQL,  KC_P6,   KC_P5,   KC_P4,   KC_PERC,            KC_PGDN, KC_RGHT, KC_DOWN, KC_LEFT, M_NAVBK, M_PVWIN,
+    KC_ASTR, KC_COMM, KC_P3,   KC_P2,   KC_P1,   KC_P0,              M_NXTAB, KC_END,  XXXXXXX, KC_HOME, M_PVTAB, _______,
+                                   KC_P0,  _______, _______,  _______, _______, _______
+  ),
+  [_NAVNUM_WIN] = LAYOUT_split_3x6_3(
+    _______, _______, _______, _______, _______, _______,            _______, W_FWORD, _______, W_BWORD, W_NAVFW, W_NXWIN,
+    _______, _______, _______, _______, _______, _______,            _______, _______, _______, _______, W_NAVBK, W_PVWIN,
+    _______, _______, _______, _______, _______, _______,            W_NXTAB, _______, _______, _______, W_PVTAB, _______,
+                                   _______, _______, _______,   _______, _______, _______
+  ),
+
+  [_FUNCT] = LAYOUT_split_3x6_3(
+    KC_F15,  KC_F12,  KC_F9,   KC_F8,   KC_F7,   KC_VOLU,            XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, RESET,
+    KC_F14,  KC_F11,  KC_F6,   KC_F5,   KC_F4,   KC_MUTE,            XXXXXXX, TOG_WIN, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+    KC_F13,  KC_F10,  KC_F3,   KC_F2,   KC_F1,   KC_VOLD,            XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+                                   _______, _______, _______,   _______, _______, _______
+  ),
+  [_FUNCT_WIN] = LAYOUT_split_3x6_3(
+    _______, _______, _______, _______, _______, _______,            _______, _______, _______, _______, _______, _______,
+    _______, _______, _______, _______, _______, _______,            _______, _______, _______, _______, _______, _______,
+    _______, _______, _______, _______, _______, _______,            _______, _______, _______, _______, _______, _______,
+                                   _______, _______, _______,   _______, _______, _______
+  ),
+};
+

--- a/keyboards/centromere/keymaps/mattly/rules.mk
+++ b/keyboards/centromere/keymaps/mattly/rules.mk
@@ -1,14 +1,1 @@
-# MCU name
-MCU = atmega32u4
-
-# Bootloader selection
-#   Teensy       halfkay
-#   Pro Micro    caterina
-#   Atmel DFU    atmel-dfu
-#   LUFA DFU     lufa-dfu
-#   QMK DFU      qmk-dfu
-#   ATmega32A    bootloadHID
-#   ATmega328P   USBasp
-BOOTLOADER = caterina
-
-MOUSEKEY_ENABLE = no	# Mouse keys
+MOUSEKEY_ENABLE = no

--- a/keyboards/centromere/keymaps/mattly/rules.mk
+++ b/keyboards/centromere/keymaps/mattly/rules.mk
@@ -1,0 +1,14 @@
+# MCU name
+MCU = atmega32u4
+
+# Bootloader selection
+#   Teensy       halfkay
+#   Pro Micro    caterina
+#   Atmel DFU    atmel-dfu
+#   LUFA DFU     lufa-dfu
+#   QMK DFU      qmk-dfu
+#   ATmega32A    bootloadHID
+#   ATmega328P   USBasp
+BOOTLOADER = caterina
+
+MOUSEKEY_ENABLE = no	# Mouse keys


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I added a layout for my centromere, and I believe this is the first user layout for this keyboard.

Since there wasn't a build guide, I soldered the switches in upside-down, so the layout is mirrored. If someone knows a better way to handle swapping the keycodes, I'd appreciate it.

For some reason it's also powering-on into the second layer (`OVER_WIN`) instead of the first layer. It's annoying but if anyone knows why I'd appreciate it.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
