### PR TITLE
Share button state from mousekey to pointing_device

### DIFF
--- a/docs/feature_mouse_keys.md
+++ b/docs/feature_mouse_keys.md
@@ -140,3 +140,7 @@ To use constant speed mode, you must at least define `MK_COMBINED` in your keyma
 ```c
 #define MK_COMBINED
 ```
+
+## Use with PS/2 Mouse and Pointing Device
+
+Mouse keys button state is shared with [PS/2 mouse](feature_ps2_mouse.md) and [pointing device](feature_pointing_device.md) so mouse keys button presses can be used for clicks and drags.

--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,12 @@
 [![GitHub contributors](https://img.shields.io/github/contributors/qmk/qmk_firmware.svg)](https://github.com/qmk/qmk_firmware/pulse/monthly)
 [![GitHub forks](https://img.shields.io/github/forks/qmk/qmk_firmware.svg?style=social&label=Fork)](https://github.com/qmk/qmk_firmware/)
 
+# THIS IS THE DEVELOP BRANCH
+
+Warning- This is the `develop` branch of QMK Firmware. You may encounter broken code here. Please see [Breaking Changes](https://docs.qmk.fm/#/breaking_changes) for more information.
+
+# Original readme continues
+
 This is a keyboard firmware based on the [tmk\_keyboard firmware](https://github.com/tmk/tmk_keyboard) with some useful features for Atmel AVR and ARM controllers, and more specifically, the [OLKB product line](https://olkb.com), the [ErgoDox EZ](https://ergodox-ez.com) keyboard, and the [Clueboard product line](https://clueboard.co).
 
 ## Documentation

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -37,6 +37,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    include "nodebug.h"
 #endif
 
+#ifdef POINTING_DEVICE_ENABLE
+#    include "pointing_device.h"
+#endif
+
 int tp_buttons;
 
 #ifdef RETRO_TAPPING
@@ -219,6 +223,19 @@ void process_record_handler(keyrecord_t *record) {
 
     process_action(record, action);
 }
+
+#if defined(PS2_MOUSE_ENABLE) || defined(POINTING_DEVICE_ENABLE)
+void register_button(bool pressed, enum mouse_buttons button) {
+    #ifdef PS2_MOUSE_ENABLE
+    tp_buttons = pressed ? tp_buttons | button : tp_buttons & ~button;
+    #endif
+    #ifdef POINTING_DEVICE_ENABLE
+    report_mouse_t currentReport = pointing_device_get_report();
+    currentReport.buttons = pressed ? currentReport.buttons | button : currentReport.buttons & ~button;
+    pointing_device_set_report(currentReport);
+    #endif
+}
+#endif
 
 /** \brief Take an action and processes it.
  *
@@ -404,15 +421,23 @@ void process_action(keyrecord_t *record, action_t action) {
             if (event.pressed) {
                 mousekey_on(action.key.code);
                 switch (action.key.code) {
-#    ifdef PS2_MOUSE_ENABLE
+#    if defined(PS2_MOUSE_ENABLE) || defined(POINTING_DEVICE_ENABLE)
                     case KC_MS_BTN1:
-                        tp_buttons |= (1 << 0);
+                        register_button(true, MOUSE_BTN1);
                         break;
                     case KC_MS_BTN2:
-                        tp_buttons |= (1 << 1);
+                        register_button(true, MOUSE_BTN2);
                         break;
                     case KC_MS_BTN3:
-                        tp_buttons |= (1 << 2);
+                        register_button(true, MOUSE_BTN3);
+                        break;
+#    endif
+#    ifdef POINTING_DEVICE_ENABLE
+                    case KC_MS_BTN4:
+                        register_button(true, MOUSE_BTN4);
+                        break;
+                    case KC_MS_BTN5:
+                        register_button(true, MOUSE_BTN5);
                         break;
 #    endif
                     default:
@@ -422,15 +447,23 @@ void process_action(keyrecord_t *record, action_t action) {
             } else {
                 mousekey_off(action.key.code);
                 switch (action.key.code) {
-#    ifdef PS2_MOUSE_ENABLE
+#    if defined(PS2_MOUSE_ENABLE) || defined(POINTING_DEVICE_ENABLE)
                     case KC_MS_BTN1:
-                        tp_buttons &= ~(1 << 0);
+                        register_button(false, MOUSE_BTN1);
                         break;
                     case KC_MS_BTN2:
-                        tp_buttons &= ~(1 << 1);
+                        register_button(false, MOUSE_BTN2);
                         break;
                     case KC_MS_BTN3:
-                        tp_buttons &= ~(1 << 2);
+                        register_button(false, MOUSE_BTN3);
+                        break;
+#    endif
+#    ifdef POINTING_DEVICE_ENABLE
+                    case KC_MS_BTN4:
+                        register_button(false, MOUSE_BTN4);
+                        break;
+                    case KC_MS_BTN5:
+                        register_button(false, MOUSE_BTN5);
                         break;
 #    endif
                     default:


### PR DESCRIPTION
## Description

If you enable mousekey (mouse keys) with pointing_device (pointing device) and add button keycodes to your keymap, you'll get a click from mousekey but drags with pointing_device movement won't work as button state needs to be sent with the move. If you handle the mousekey button keycodes yourself in process_record_user() to update pointing_device button state you'll break drags using mousekey movement. If you handle mousekey movement keycodes too then you've just re-implemented mousekey.

This change shares button state from mousekey to pointing_device to support simultaneous use of mousekey and pointing_device, including mouse drags with mousekey buttons and mousekey or pointing_device movement.

To use, enable mousekey and pointing_device and add button keycodes to keymap.  No extra code is required. 

See also #9124.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Enhancement/optimization
- [x] Documentation

## Checklist
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
