### PR TITLE
add definition WS2812_BYTE_ORDER to fix RGB LED issues

### DIFF
--- a/docs/ws2812_driver.md
+++ b/docs/ws2812_driver.md
@@ -31,7 +31,7 @@ The default setting is 280 µs, which should work for most cases, but this can b
 #### Byte Order
 
 Some variants of the WS2812 may have their color components in a different physical or logical order. For example, the WS2812B-2020 has physically swapped red and green LEDs, which causes the wrong color to be displayed, because the default order of the bytes sent over the wire is defined as GRB.
-In this case, you can change the byte order with the following define:
+In this case, you can change the byte order by defining `WS2812_BYTE_ORDER` as one of the following values:
 
 | Byte order                        | Known devices                 |
 |-----------------------------------|-------------------------------|

--- a/docs/ws2812_driver.md
+++ b/docs/ws2812_driver.md
@@ -35,7 +35,7 @@ Without correction, this causes the two internal LEDs to swap colors and display
 The default setting GRB allows other addressable LEDs to work properly with the correct byte structure (G[7-0]R[7-0]G[7-0]), however the WS2812B-2020 needs the green and red bytes reversed.
 
 ```c
-#define WS2812_BYTE_ORDER RGB
+#define WS2812_BYTE_ORDER WS2812_BYTE_ORDER_RGB
 ```
 
 ### Bitbang

--- a/docs/ws2812_driver.md
+++ b/docs/ws2812_driver.md
@@ -28,14 +28,16 @@ The default setting is 280 µs, which should work for most cases, but this can b
 #define WS2812_TRST_US 80
 ```
 
-### Byte Order
+#### Byte Order
 
 Some variants of the WS2812 may have their color components in a different physical or logical order. For example, the WS2812B-2020 has physically swapped red and green LEDs, which causes the wrong color to be displayed, because the default order of the bytes sent over the wire is defined as GRB.
 In this case, you can change the byte order with the following define:
 
-```c
-#define WS2812_BYTE_ORDER WS2812_BYTE_ORDER_RGB
-```
+| Byte order                        | Known devices                 |
+|-----------------------------------|-------------------------------|
+| `WS2812_BYTE_ORDER_GRB` (default) | Most WS2812's, SK6812, SK6805 |
+| `WS2812_BYTE_ORDER_RGB`           | WS2812B-2020                  |
+
 
 ### Bitbang
 Default driver, the absence of configuration assumes this driver. To configure it, add this to your rules.mk:

--- a/docs/ws2812_driver.md
+++ b/docs/ws2812_driver.md
@@ -28,11 +28,10 @@ The default setting is 280 µs, which should work for most cases, but this can b
 #define WS2812_TRST_US 80
 ```
 
-### Addressable LED byte order
+### Byte Order
 
-The WS2812B-2020 addressable LED has a physically different layout with reversed internal red and green LEDs. 
-Without correction, this causes the two internal LEDs to swap colors and display the wrong color.
-The default setting GRB allows other addressable LEDs to work properly with the correct byte structure (G[7-0]R[7-0]G[7-0]), however the WS2812B-2020 needs the green and red bytes reversed.
+Some variants of the WS2812 may have their color components in a different physical or logical order. For example, the WS2812B-2020 has physically swapped red and green LEDs, which causes the wrong color to be displayed, because the default order of the bytes sent over the wire is defined as GRB.
+In this case, you can change the byte order with the following define:
 
 ```c
 #define WS2812_BYTE_ORDER WS2812_BYTE_ORDER_RGB

--- a/docs/ws2812_driver.md
+++ b/docs/ws2812_driver.md
@@ -35,7 +35,7 @@ Without correction, this causes the two internal LEDs to swap colors and display
 The default setting GRB allows other addressable LEDs to work properly with the correct byte structure (G[7-0]R[7-0]G[7-0]), however the WS2812B-2020 needs the green and red bytes reversed.
 
 ```c
-#define WS2812_BYTE_ORDER
+#define WS2812_BYTE_ORDER RGB
 ```
 
 ### Bitbang

--- a/docs/ws2812_driver.md
+++ b/docs/ws2812_driver.md
@@ -28,6 +28,16 @@ The default setting is 280 µs, which should work for most cases, but this can b
 #define WS2812_TRST_US 80
 ```
 
+### LED Type - WS2812B-2020
+
+The WS2812B-2020 addressable LED has a physically different layout with reversed internal red and green LEDs. 
+This causes the two LEDs to swap colors without correction and display the wrong color.
+The default setting allows other addressable LEDs to work properly with the correct byte structure (G[7-0]R[7-0]G[7-0]), however the WS2812B-2020 needs the green and red bytes reversed.
+
+```c
+#define LED_TYPE_WS2812B_2020
+```
+
 ### Bitbang
 Default driver, the absence of configuration assumes this driver. To configure it, add this to your rules.mk:
 

--- a/docs/ws2812_driver.md
+++ b/docs/ws2812_driver.md
@@ -28,14 +28,14 @@ The default setting is 280 µs, which should work for most cases, but this can b
 #define WS2812_TRST_US 80
 ```
 
-### LED Type - WS2812B-2020
+### Addressable LED byte order
 
 The WS2812B-2020 addressable LED has a physically different layout with reversed internal red and green LEDs. 
-This causes the two LEDs to swap colors without correction and display the wrong color.
-The default setting allows other addressable LEDs to work properly with the correct byte structure (G[7-0]R[7-0]G[7-0]), however the WS2812B-2020 needs the green and red bytes reversed.
+Without correction, this causes the two internal LEDs to swap colors and display the wrong color.
+The default setting GRB allows other addressable LEDs to work properly with the correct byte structure (G[7-0]R[7-0]G[7-0]), however the WS2812B-2020 needs the green and red bytes reversed.
 
 ```c
-#define LED_TYPE_WS2812B_2020
+#define WS2812_BYTE_ORDER
 ```
 
 ### Bitbang

--- a/drivers/chibios/ws2812.c
+++ b/drivers/chibios/ws2812.c
@@ -22,6 +22,14 @@
 #    define WS2812_OUTPUT_MODE PAL_MODE_OUTPUT_OPENDRAIN
 #endif
 
+// WS2812 Byte Order
+#define WS2812_BYTE_ORDER_RGB 0
+#define WS2812_BYTE_ORDER_GRB 1
+
+#ifndef WS2812_BYTE_ORDER
+#    define WS2812_BYTE_ORDER WS2812_BYTE_ORDER_GRB
+#endif
+
 #define NUMBER_NOPS 6
 #define CYCLES_PER_SEC (STM32_SYSCLK / NUMBER_NOPS * NOP_FUDGE)
 #define NS_PER_SEC (1000000000L)  // Note that this has to be SIGNED since we want to be able to check for negative values of derivatives
@@ -89,9 +97,16 @@ void ws2812_setleds(LED_TYPE *ledarray, uint16_t leds) {
 
     for (uint8_t i = 0; i < leds; i++) {
         // WS2812 protocol dictates grb order
+#if (WS2812_BYTE_ORDER == WS2812_BYTE_ORDER_GRB)
         sendByte(ledarray[i].g);
         sendByte(ledarray[i].r);
         sendByte(ledarray[i].b);
+#elif (WS2812_BYTE_ORDER == WS2812_BYTE_ORDER_RGB)
+        sendByte(ledarray[i].r);
+        sendByte(ledarray[i].g);
+        sendByte(ledarray[i].b);
+#endif
+
 #ifdef RGBW
         sendByte(ledarray[i].w);
 #endif

--- a/drivers/chibios/ws2812.c
+++ b/drivers/chibios/ws2812.c
@@ -22,14 +22,6 @@
 #    define WS2812_OUTPUT_MODE PAL_MODE_OUTPUT_OPENDRAIN
 #endif
 
-// WS2812 Byte Order
-#define WS2812_BYTE_ORDER_RGB 0
-#define WS2812_BYTE_ORDER_GRB 1
-
-#ifndef WS2812_BYTE_ORDER
-#    define WS2812_BYTE_ORDER WS2812_BYTE_ORDER_GRB
-#endif
-
 #define NUMBER_NOPS 6
 #define CYCLES_PER_SEC (STM32_SYSCLK / NUMBER_NOPS * NOP_FUDGE)
 #define NS_PER_SEC (1000000000L)  // Note that this has to be SIGNED since we want to be able to check for negative values of derivatives

--- a/drivers/chibios/ws2812_pwm.c
+++ b/drivers/chibios/ws2812_pwm.c
@@ -40,6 +40,14 @@
 #    endif
 #endif
 
+// WS2812 Byte Order
+#define WS2812_BYTE_ORDER_RGB 0
+#define WS2812_BYTE_ORDER_GRB 1
+
+#ifndef WS2812_BYTE_ORDER
+#    define WS2812_BYTE_ORDER WS2812_BYTE_ORDER_GRB
+#endif
+
 #ifndef WS2812_PWM_TARGET_PERIOD
 //#    define WS2812_PWM_TARGET_PERIOD 800000 // Original code is 800k...?
 #    define WS2812_PWM_TARGET_PERIOD 80000  // TODO: work out why 10x less on f303/f4x1
@@ -104,6 +112,7 @@
  */
 #define WS2812_BIT(led, byte, bit) (24 * (led) + 8 * (byte) + (7 - (bit)))
 
+#if (WS2812_BYTE_ORDER == WS2812_BYTE_ORDER_GRB)
 /**
  * @brief   Determine the index in @ref ws2812_frame_buffer "the frame buffer" of a given red bit
  *
@@ -114,7 +123,7 @@
  *
  * @return                          The bit index
  */
-#define WS2812_RED_BIT(led, bit) WS2812_BIT((led), 1, (bit))
+#   define WS2812_RED_BIT(led, bit) WS2812_BIT((led), 1, (bit))
 
 /**
  * @brief   Determine the index in @ref ws2812_frame_buffer "the frame buffer" of a given green bit
@@ -126,7 +135,7 @@
  *
  * @return                          The bit index
  */
-#define WS2812_GREEN_BIT(led, bit) WS2812_BIT((led), 0, (bit))
+#   define WS2812_GREEN_BIT(led, bit) WS2812_BIT((led), 0, (bit))
 
 /**
  * @brief   Determine the index in @ref ws2812_frame_buffer "the frame buffer" of a given blue bit
@@ -138,7 +147,45 @@
  *
  * @return                          The bit index
  */
-#define WS2812_BLUE_BIT(led, bit) WS2812_BIT((led), 2, (bit))
+#   define WS2812_BLUE_BIT(led, bit) WS2812_BIT((led), 2, (bit))
+
+#elif (WS2812_BYTE_ORDER == WS2812_BYTE_ORDER_RGB)
+/**
+ * @brief   Determine the index in @ref ws2812_frame_buffer "the frame buffer" of a given red bit
+ *
+ * @note    The red byte is the middle byte in the color packet
+ *
+ * @param[in] led:                  The led index [0, @ref RGBLED_NUM)
+ * @param[in] bit:                  The bit number [0, 7]
+ *
+ * @return                          The bit index
+ */
+#   define WS2812_RED_BIT(led, bit) WS2812_BIT((led), 0, (bit))
+
+/**
+ * @brief   Determine the index in @ref ws2812_frame_buffer "the frame buffer" of a given green bit
+ *
+ * @note    The red byte is the first byte in the color packet
+ *
+ * @param[in] led:                  The led index [0, @ref RGBLED_NUM)
+ * @param[in] bit:                  The bit number [0, 7]
+ *
+ * @return                          The bit index
+ */
+#   define WS2812_GREEN_BIT(led, bit) WS2812_BIT((led), 1, (bit))
+
+/**
+ * @brief   Determine the index in @ref ws2812_frame_buffer "the frame buffer" of a given blue bit
+ *
+ * @note    The red byte is the last byte in the color packet
+ *
+ * @param[in] led:                  The led index [0, @ref RGBLED_NUM)
+ * @param[in] bit:                  The bit index [0, 7]
+ *
+ * @return                          The bit index
+ */
+#   define WS2812_BLUE_BIT(led, bit) WS2812_BIT((led), 2, (bit))
+#endif
 
 /* --- PRIVATE VARIABLES ---------------------------------------------------- */
 

--- a/drivers/chibios/ws2812_pwm.c
+++ b/drivers/chibios/ws2812_pwm.c
@@ -40,14 +40,6 @@
 #    endif
 #endif
 
-// WS2812 Byte Order
-#define WS2812_BYTE_ORDER_RGB 0
-#define WS2812_BYTE_ORDER_GRB 1
-
-#ifndef WS2812_BYTE_ORDER
-#    define WS2812_BYTE_ORDER WS2812_BYTE_ORDER_GRB
-#endif
-
 #ifndef WS2812_PWM_TARGET_PERIOD
 //#    define WS2812_PWM_TARGET_PERIOD 800000 // Original code is 800k...?
 #    define WS2812_PWM_TARGET_PERIOD 80000  // TODO: work out why 10x less on f303/f4x1

--- a/drivers/chibios/ws2812_spi.c
+++ b/drivers/chibios/ws2812_spi.c
@@ -32,6 +32,14 @@
 #    endif
 #endif
 
+// WS2812 Byte Order
+#define WS2812_BYTE_ORDER_RGB 0
+#define WS2812_BYTE_ORDER_GRB 1
+
+#ifndef WS2812_BYTE_ORDER
+#    define WS2812_BYTE_ORDER WS2812_BYTE_ORDER_GRB
+#endif
+
 #define BYTES_FOR_LED_BYTE 4
 #define NB_COLORS 3
 #define BYTES_FOR_LED (BYTES_FOR_LED_BYTE * NB_COLORS)
@@ -62,9 +70,15 @@ static uint8_t get_protocol_eq(uint8_t data, int pos) {
 static void set_led_color_rgb(LED_TYPE color, int pos) {
     uint8_t* tx_start = &txbuf[PREAMBLE_SIZE];
 
+#if (WS2812_BYTE_ORDER == WS2812_BYTE_ORDER_GRB)
     for (int j = 0; j < 4; j++) tx_start[BYTES_FOR_LED * pos + j] = get_protocol_eq(color.g, j);
     for (int j = 0; j < 4; j++) tx_start[BYTES_FOR_LED * pos + BYTES_FOR_LED_BYTE + j] = get_protocol_eq(color.r, j);
     for (int j = 0; j < 4; j++) tx_start[BYTES_FOR_LED * pos + BYTES_FOR_LED_BYTE * 2 + j] = get_protocol_eq(color.b, j);
+#elif (WS2812_BYTE_ORDER == WS2812_BYTE_ORDER_RGB)
+    for (int j = 0; j < 4; j++) tx_start[BYTES_FOR_LED * pos + j] = get_protocol_eq(color.r, j);
+    for (int j = 0; j < 4; j++) tx_start[BYTES_FOR_LED * pos + BYTES_FOR_LED_BYTE + j] = get_protocol_eq(color.g, j);
+    for (int j = 0; j < 4; j++) tx_start[BYTES_FOR_LED * pos + BYTES_FOR_LED_BYTE * 2 + j] = get_protocol_eq(color.b, j);    
+#endif
 }
 
 void ws2812_init(void) {

--- a/drivers/chibios/ws2812_spi.c
+++ b/drivers/chibios/ws2812_spi.c
@@ -32,14 +32,6 @@
 #    endif
 #endif
 
-// WS2812 Byte Order
-#define WS2812_BYTE_ORDER_RGB 0
-#define WS2812_BYTE_ORDER_GRB 1
-
-#ifndef WS2812_BYTE_ORDER
-#    define WS2812_BYTE_ORDER WS2812_BYTE_ORDER_GRB
-#endif
-
 #define BYTES_FOR_LED_BYTE 4
 #define NB_COLORS 3
 #define BYTES_FOR_LED (BYTES_FOR_LED_BYTE * NB_COLORS)

--- a/quantum/color.h
+++ b/quantum/color.h
@@ -36,13 +36,23 @@
 #    define LED_TYPE RGB
 #endif
 
-// WS2812 specific layout
+// only set if using WS2812B-2020, fixes LED bit order
+// If define is not set, the red and green are reversed
+#ifdef LED_TYPE_WS2812B_2020
+// WS2812B-2020 specific layout
+typedef struct PACKED {
+    uint8_t r;
+    uint8_t g;
+    uint8_t b;
+} cRGB;
+#else // WS2812C
 typedef struct PACKED {
     uint8_t g;
     uint8_t r;
     uint8_t b;
 } cRGB;
 
+#endif
 typedef cRGB RGB;
 
 // WS2812 specific layout

--- a/quantum/color.h
+++ b/quantum/color.h
@@ -42,6 +42,7 @@
 #ifndef WS2812_BYTE_ORDER
 #    define WS2812_BYTE_ORDER WS2812_BYTE_ORDER_GRB
 #endif
+
 typedef struct PACKED {
 #if (WS2812_BYTE_ORDER == WS2812_BYTE_ORDER_GRB)
     uint8_t g;
@@ -53,6 +54,7 @@ typedef struct PACKED {
     uint8_t b;
 #endif
 } cRGB;
+
 typedef cRGB RGB;
 
 // WS2812 specific layout

--- a/quantum/color.h
+++ b/quantum/color.h
@@ -36,22 +36,22 @@
 #    define LED_TYPE RGB
 #endif
 
-// only set if using WS2812B-2020, fixes LED bit order
-// If define is not set, the red and green are reversed
-#ifdef LED_TYPE_WS2812B_2020
-// WS2812B-2020 specific layout
-typedef struct PACKED {
-    uint8_t r;
-    uint8_t g;
-    uint8_t b;
-} cRGB;
-#else // WS2812C
-typedef struct PACKED {
-    uint8_t g;
-    uint8_t r;
-    uint8_t b;
-} cRGB;
 
+#ifndef WS2812_BYTE_ORDER
+// default structure - G[7..0]R[7..0]B[7..0]
+// WS2812 specific layout
+typedef struct PACKED {
+    uint8_t g;
+    uint8_t r;
+    uint8_t b;
+} cRGB;
+#elif (WS2812_BYTE_ORDER == RGB)
+// WS2812B-2020 structure - R[7..0]G[7..0]B[7..0]
+typedef struct PACKED {
+    uint8_t r;
+    uint8_t g;
+    uint8_t b;
+} cRGB;
 #endif
 typedef cRGB RGB;
 

--- a/quantum/color.h
+++ b/quantum/color.h
@@ -36,23 +36,23 @@
 #    define LED_TYPE RGB
 #endif
 
+#define WS2812_BYTE_ORDER_RGB 0
+#define WS2812_BYTE_ORDER_GRB 1
 
 #ifndef WS2812_BYTE_ORDER
-// default structure - G[7..0]R[7..0]B[7..0]
-// WS2812 specific layout
-typedef struct PACKED {
-    uint8_t g;
-    uint8_t r;
-    uint8_t b;
-} cRGB;
-#elif (WS2812_BYTE_ORDER == RGB)
-// WS2812B-2020 structure - R[7..0]G[7..0]B[7..0]
-typedef struct PACKED {
-    uint8_t r;
-    uint8_t g;
-    uint8_t b;
-} cRGB;
+#    define WS2812_BYTE_ORDER WS2812_BYTE_ORDER_GRB
 #endif
+typedef struct PACKED {
+#if (WS2812_BYTE_ORDER == WS2812_BYTE_ORDER_GRB)
+    uint8_t g;
+    uint8_t r;
+    uint8_t b;
+#elif (WS2812_BYTE_ORDER == WS2812_BYTE_ORDER_RGB)
+    uint8_t r;
+    uint8_t g;
+    uint8_t b;
+#endif
+} cRGB;
 typedef cRGB RGB;
 
 // WS2812 specific layout

--- a/quantum/color.h
+++ b/quantum/color.h
@@ -59,9 +59,15 @@ typedef cRGB RGB;
 
 // WS2812 specific layout
 typedef struct PACKED {
+#if (WS2812_BYTE_ORDER == WS2812_BYTE_ORDER_GRB)
     uint8_t g;
     uint8_t r;
     uint8_t b;
+#elif (WS2812_BYTE_ORDER == WS2812_BYTE_ORDER_RGB)
+    uint8_t r;
+    uint8_t g;
+    uint8_t b;
+#endif
     uint8_t w;
 } cRGBW;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

While flashing and repairing some hbcp PCBs, I realized that the LEDs were not showing the correct color - specifically that the red and green channels were reversed. The LEDs on the board are WS2812B-2020 from WorldSemi. I replaced one LED with a WS2812C-2020, and it was the correct colors, according to the VIA output (and QMK). After examining the datasheets for each LED, I found that even though the software is the same (G, R then B, 1 byte each) the hardware is not - the red and green LEDs are reversed physically! 

https://i.imgur.com/kB3mPyI.jpg

https://i.imgur.com/dmB1aY1.png

I created a definition, `WS2812_BYTE_ORDER` in color.h to define the byte order for the LED. The RGB definition swaps the R and G bytes and corrects the color issue.

https://i.imgur.com/sLcRLYU.jpg

If WS2812B-2020 LEDs are used, `#define WS2812_BYTE_ORDER WS2812_BYTE_ORDER_RGB` should be placed in the `config.h` file. I tested this successfully with the hbcp code. 

This added definition should not affect any other existing PCBs without it, due to defaulting to the "standard" GRB structure. I tested this with a few PCBs I had on hand, namely h88, h87a and some prototypes.

Thanks to @Xelus22 for the assistance.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* Incorrect RGB coloring with WS2812B-2020 LEDs due to byte structure difference

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
