### PR TITLE
Add support for soft serial to ATmega32U2

### DIFF
--- a/common_features.mk
+++ b/common_features.mk
@@ -417,8 +417,10 @@ ifeq ($(strip $(SPLIT_KEYBOARD)), yes)
         # Functions added via QUANTUM_LIB_SRC are only included in the final binary if they're called.
         # Unused functions are pruned away, which is why we can add multiple drivers here without bloat.
         ifeq ($(PLATFORM),AVR)
-            QUANTUM_LIB_SRC += i2c_master.c \
-                               i2c_slave.c
+            ifneq ($(NO_I2C),yes)
+                QUANTUM_LIB_SRC += i2c_master.c \
+                                   i2c_slave.c
+            endif
         endif
 
         SERIAL_DRIVER ?= bitbang

--- a/drivers/avr/serial.c
+++ b/drivers/avr/serial.c
@@ -21,10 +21,10 @@
 #ifdef SOFT_SERIAL_PIN
 
 #    if defined(__AVR_ATmega16U2__) || defined(__AVR_ATmega32U2__) || defined(__AVR_ATmega16U4__) || defined(__AVR_ATmega32U4__)
-// if using ATmega32U4 I2C, can not use PD0 and PD1 in soft serial.
+// if using ATmegaxxU4 I2C, can not use PD0 and PD1 in soft serial.
 #        ifdef USE_AVR_I2C
 #            if SOFT_SERIAL_PIN == D0 || SOFT_SERIAL_PIN == D1
-#                error Using ATmega32U4 I2C, so can not use PD0, PD1
+#                error Using ATmegaxxU4 I2C, so can not use PD0, PD1
 #            endif
 #        endif
 

--- a/drivers/avr/serial.c
+++ b/drivers/avr/serial.c
@@ -20,7 +20,7 @@
 
 #ifdef SOFT_SERIAL_PIN
 
-#    if defined(__AVR_ATmega32U4__) || defined(__AVR_ATmega32U2__)
+#    if defined(__AVR_ATmega16U2__) || defined(__AVR_ATmega32U2__) || defined(__AVR_ATmega16U4__) || defined(__AVR_ATmega32U4__)
 // if using ATmega32U4 I2C, can not use PD0 and PD1 in soft serial.
 #        ifdef USE_AVR_I2C
 #            if SOFT_SERIAL_PIN == D0 || SOFT_SERIAL_PIN == D1

--- a/drivers/avr/serial.c
+++ b/drivers/avr/serial.c
@@ -61,7 +61,7 @@
 #        endif
 
 #    else
-#        error serial.c now support ATmega32U4 and ATmega32U2 only
+#        error serial.c currently only supports ATmegaxxU2 and ATmegaxxU4
 #    endif
 
 #    define ALWAYS_INLINE __attribute__((always_inline))

--- a/drivers/avr/serial.c
+++ b/drivers/avr/serial.c
@@ -52,7 +52,7 @@
 #                define EICRx_BIT (~(_BV(ISC30) | _BV(ISC31)))
 #                define SERIAL_PIN_INTERRUPT INT3_vect
 #            endif
-#        elif defined(__AVR_ATmega16U4__) || defined(__AVR_ATmega32U4__) && SOFT_SERIAL_PIN == E6
+#        elif (defined(__AVR_ATmega16U4__) || defined(__AVR_ATmega32U4__)) && SOFT_SERIAL_PIN == E6
 #            define EIMSK_BIT _BV(INT6)
 #            define EICRx_BIT (~(_BV(ISC60) | _BV(ISC61)))
 #            define SERIAL_PIN_INTERRUPT INT6_vect

--- a/drivers/avr/serial.c
+++ b/drivers/avr/serial.c
@@ -52,7 +52,7 @@
 #                define EICRx_BIT (~(_BV(ISC30) | _BV(ISC31)))
 #                define SERIAL_PIN_INTERRUPT INT3_vect
 #            endif
-#        elif defined(__AVR_ATmega32U4__) && SOFT_SERIAL_PIN == E6
+#        elif defined(__AVR_ATmega16U4__) || defined(__AVR_ATmega32U4__) && SOFT_SERIAL_PIN == E6
 #            define EIMSK_BIT _BV(INT6)
 #            define EICRx_BIT (~(_BV(ISC60) | _BV(ISC61)))
 #            define SERIAL_PIN_INTERRUPT INT6_vect

--- a/drivers/avr/serial.c
+++ b/drivers/avr/serial.c
@@ -20,7 +20,7 @@
 
 #ifdef SOFT_SERIAL_PIN
 
-#    ifdef __AVR_ATmega32U4__
+#    if defined(__AVR_ATmega32U4__) || defined(__AVR_ATmega32U2__)
 // if using ATmega32U4 I2C, can not use PD0 and PD1 in soft serial.
 #        ifdef USE_AVR_I2C
 #            if SOFT_SERIAL_PIN == D0 || SOFT_SERIAL_PIN == D1
@@ -52,7 +52,7 @@
 #                define EICRx_BIT (~(_BV(ISC30) | _BV(ISC31)))
 #                define SERIAL_PIN_INTERRUPT INT3_vect
 #            endif
-#        elif SOFT_SERIAL_PIN == E6
+#        elif defined(__AVR_ATmega32U4__) && SOFT_SERIAL_PIN == E6
 #            define EIMSK_BIT _BV(INT6)
 #            define EICRx_BIT (~(_BV(ISC60) | _BV(ISC61)))
 #            define SERIAL_PIN_INTERRUPT INT6_vect
@@ -61,7 +61,7 @@
 #        endif
 
 #    else
-#        error serial.c now support ATmega32U4 only
+#        error serial.c now support ATmega32U4 and ATmega32U2 only
 #    endif
 
 #    define ALWAYS_INLINE __attribute__((always_inline))

--- a/quantum/mcu_selection.mk
+++ b/quantum/mcu_selection.mk
@@ -252,6 +252,9 @@ ifneq (,$(filter $(MCU),atmega16u2 atmega32u2 atmega16u4 atmega32u4 at90usb646 a
   ifeq (,$(filter $(NO_INTERRUPT_CONTROL_ENDPOINT),yes))
     OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
   endif
+  ifneq (,$(filter $(MCU),atmega16u2 atmega32u2))
+    NO_I2C = yes
+  endif
 endif
 
 ifneq (,$(filter $(MCU),atmega32a))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
serial.c now support ATmega32U4 only. However, ATmega32U2 has a similar feature, and it's not difficult to add ATmega32U2. This change adds soft serial support to the ATmega32U2.

Thanks to @mtei for his help in sending this pull request. The most of the code came from his ideas.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
