### PR TITLE
Fixed Spanish keymap extra ES_DIAE symbol

### DIFF
--- a/quantum/keymap_extras/keymap_spanish.h
+++ b/quantum/keymap_extras/keymap_spanish.h
@@ -117,7 +117,7 @@
 #define ES_CIRC S(ES_GRV)  // ^ (dead)
 #define ES_ASTR S(ES_PLUS) // *
 // Row 3
-#define ES_DIAE S(ES_ACUT)  // ¨ (dead)
+#define ES_DIAE S(ES_ACUT) // ¨ (dead)
 // Row 4
 #define ES_RABK S(ES_LABK) // >
 #define ES_SCLN S(KC_COMM) // ;

--- a/quantum/keymap_extras/keymap_spanish.h
+++ b/quantum/keymap_extras/keymap_spanish.h
@@ -117,7 +117,7 @@
 #define ES_CIRC S(ES_GRV)  // ^ (dead)
 #define ES_ASTR S(ES_PLUS) // *
 // Row 3
-#define ES_DIAE S(ES_GRV)  // ¨ (dead)
+#define ES_DIAE S(ES_ACUT)  // ¨ (dead)
 // Row 4
 #define ES_RABK S(ES_LABK) // >
 #define ES_SCLN S(KC_COMM) // ;


### PR DESCRIPTION
`ES_DIAE` should be `S(ES_ACUT)` not `S(ES_GRV)`

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
