### PR TITLE
Output an error message if LINK_TIME_OPTIMIZATION_ENABLE is set but LTO_ENABLE is not

### DIFF
--- a/tmk_core/common.mk
+++ b/tmk_core/common.mk
@@ -161,6 +161,8 @@ ifeq ($(strip $(LTO_ENABLE)), yes)
     EXTRAFLAGS += -flto
     TMK_COMMON_DEFS += -DLTO_ENABLE
     TMK_COMMON_DEFS += -DLINK_TIME_OPTIMIZATON_ENABLE
+else ifdef LINK_TIME_OPTIMIZATION_ENABLE
+    $(error The LINK_TIME_OPTIMIZATION_ENABLE flag is deprecated. Use LTO_ENABLE instead.)
 endif
 
 # Search Path

--- a/tmk_core/common.mk
+++ b/tmk_core/common.mk
@@ -162,7 +162,7 @@ ifeq ($(strip $(LTO_ENABLE)), yes)
     TMK_COMMON_DEFS += -DLTO_ENABLE
     TMK_COMMON_DEFS += -DLINK_TIME_OPTIMIZATON_ENABLE
 else ifdef LINK_TIME_OPTIMIZATION_ENABLE
-    $(error The LINK_TIME_OPTIMIZATION_ENABLE flag is deprecated. Use LTO_ENABLE instead.)
+    $(error The LINK_TIME_OPTIMIZATION_ENABLE flag has been renamed to LTO_ENABLE.)
 endif
 
 # Search Path


### PR DESCRIPTION

## Description

Commit 92385b3fb617326b129609726020453c8949c7f8 renamed the `LINK_TIME_OPTIMIZATION_ENABLE` flag to `LTO_ENABLE`. Unfortunately, any configurations that were using the old flag but not caught under this merge (e.g. checked out on forks or other branches) have the side effect of having the optimizations silently disabled.

A few hours of debugging time was spent trying to figure out why a test keymap was suddenly throwing firmware too large errors at the final link step for an Iris keyboard after a `git pull`.

This change fails the build with an explicit error message **if and only if** the user has set `LINK_TIME_OPTIMIZATION_ENABLE` (the old name) but not `LTO_ENABLE`, in an effort to stave off questions to Discord about helping to debug this fun little issue.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] ~My change requires a change to the documentation.~
- [ ] ~I have updated the documentation accordingly.~
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] ~I have added tests to cover my changes.~ (No test harness available for makefiles?)
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
