### PR TITLE
Add support for controlling the OLEDs via raw HID

### DIFF
--- a/common_features.mk
+++ b/common_features.mk
@@ -459,6 +459,11 @@ ifeq ($(strip $(OLED_DRIVER_ENABLE)), yes)
     COMMON_VPATH += $(DRIVER_PATH)/oled
     QUANTUM_LIB_SRC += i2c_master.c
     SRC += oled_driver.c
+
+    ifeq ($(strip $(OLED_CONTROL_ENABLE)), yes)
+        OPT_DEFS += -DOLED_CONTROL_ENABLE
+        SRC += oledctrl.c
+    endif
 endif
 
 include $(DRIVER_PATH)/qwiic/qwiic.mk

--- a/docs/feature_oledctrl.md
+++ b/docs/feature_oledctrl.md
@@ -1,0 +1,148 @@
+# OLED Control
+
+QMK has the ability to control the content of the OLED screens attached to your keyboard. Generally this is done through keyboard-level C code, but this feature allows the content of the screens to be changed from the operating system. This makes it possible to have more dynamic information displayed, such as current weather, stocks, system utilization, and anything else you can imagine.
+
+![Lily58 with custom OLED content](https://raw.githubusercontent.com/Drauthius/go-oled-controller/master/example.jpg)
+
+Controlling the OLED screens requires that the keyboard uses the [OLED driver](feature_oled_driver.md), and that there is a user-space program using [raw HID](feature_rawhid.md) to communicate with the firmware. This feature is compatible with VIA, but typically only one program can communicate with the keyboard at one time.
+
+## Usage
+
+To enable the OLED control feature, there are three steps. First, when compiling your keyboard, you'll need to add the following to your `rules.mk`:
+
+```make
+OLED_DRIVER_ENABLE = yes
+OLED_CONTROL_ENABLE = yes
+RAW_ENABLE = yes
+```
+
+Then in your `keymap.c` file, inside the `oled_task()` function, add a call to the OLED control library to draw the screen. This example will fill the screen with information from the operating system if there is any available, otherwise revert to the default information:
+
+```c
+void oled_task_user(void) {
+#ifdef OLED_CONTROL_ENABLE
+    // If the screen has been filled by the operating system, then use that,
+    // otherwise revert to the default.
+    if (oledctrl_draw()) {
+        return;
+    }
+#endif
+
+    // Normal content to show goes here.
+    ...
+}
+```
+
+The last, and most important step, is to have a user-space program that feeds the OLED screens with things to draw. This is done through the [raw HID feature](feature_rawhid.md), using the protocol described below.
+
+## Protocol
+
+Data sent to and from the firmware contains a three-byte header. The first byte is the type, the second is the subtype, and the third is the screen index to control, starting at zero.
+
+### Sending a command
+
+|Byte|Description|
+|----|-----------|
+|1   |Should always be `0xC0`, to indicate that this is a command.|
+|2   |A command ID from the table below.|
+|3   |Screen ID. `0x00` to control the master side, or `0x01` to control the slave side, which requires split to be enabled.|
+|4..32|Any other data that the command might need.|
+
+|Command|Name|Description|
+|-------|----|-----------|
+|`0x00` |Set Up|Prepare the screen. This will clear all the content, and return the screen width and height as number of characters in the fourth and fifth bytes of the response.|
+|`0x01` |Clear|Clear the content of the screen.|
+|`0x02` |Set Line|Set the content of a line/row. The fourth byte should be which line to modify, and all the bytes following should be the content. Will replace everything on that line, and will not wrap to the next one.|
+|`0x03` |Set Chars|Set a portion of the screen. The fourth byte should be the offset, the fifth byte the length of the data, and all the bytes following should be the content. Will replace until the length is reached, and will wrap if it goes over a line.|
+|`0x04` |Present|Show the changes to the screen. This has to be called after the desired number of lines or characters have been set.|
+
+### Receiving a response
+
+|Byte|Description|
+|----|-----------|
+|1   |The result code. Either `0x00` for success, or `0x01` for failure.|
+|2   |The command ID that the response is for.|
+|3   |The screen ID.|
+|4..32|Typically the same data that was sent as a command. The exception is the Set Up command, which will return the width and height of the OLED screen.|
+
+### Receiving an event
+
+The module also supports events, which are typically generated from key presses on the keyboard sent to the user-space program through the raw HID channel. This allows for certain key presses to change what the user-space program displays or does.
+
+|Byte|Description|
+|1   |Always `0xC1`, to indicate that this is an event.|
+|2   |An event ID from the table below.|
+|3..32|Any other data that the event wants to pass.|
+
+Below is a list of predefined events, but it is up to the user-space program to interpret and handle them.
+
+|Event|Name|Description|
+|`0x00`|Set Tag|Specify which tag/view to show on the screen. The third byte is the screen ID, and the fourth is the tag ID that the user-space program recognises.|
+|`0x01`|Increment Tag|Tell the user-space program to show the next tag. The third byte is the screen ID.|
+|`0x02`|Decrement Tag|Tell the user-space program to show the previous tag. The third byte is the screen ID.|
+|\*   | | Any other value. It is up to the user-space program to parse and handle the events, and can essentially do anything.|
+
+To send an event simply invoke the function `oledctrl_send_event()` with an event ID, and any data that you wish to pass. This example in `keymap.c` uses custom keycodes defined in VIA to allow for sending events:
+
+```c
+#ifdef OLED_CONTROL_ENABLE
+    #include "oledctrl.h"
+    #include "via.h"
+#endif
+
+enum custom_keycodes {
+#ifdef OLED_CONTROL_ENABLE
+    INC_TAG = USER00,
+    DEC_TAG = USER01,
+#endif
+};
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    switch (keycode) {
+#ifdef OLED_CONTROL_ENABLE
+    case INC_TAG:
+        uint8_t screen = 0x00;
+        oledctrl_send_event(OLEDCTRL_EVENT_INCREMENT_TAG, &screen, 1);
+        return false; // Don't keep processing.
+        break;
+    case DEC_TAG:
+        uint8_t screen = 0x00;
+        oledctrl_send_event(OLEDCTRL_EVENT_DECREMENT_TAG, &screen, 1);
+        return false; // Don't keep processing.
+        break;
+#endif
+    }
+}
+```
+
+The `USER00` and `USER01` keycodes then need be assigned to the keymap, either statically or in VIA.
+
+A rotary encoder could be set up in a similar way to send events when it is spun, thus changing the content of the screen.
+
+## Split keyboard
+
+This feature has support for controlling the OLED screens on split keyboards that use the Split Common code.
+
+To compile the code necessary to make the feature work, simply add the following to your `config.h`:
+
+```c
+#define OLEDCTRL_SPLIT
+```
+
+Then, any commands sent over raw HID with the screen ID field set to `0x01` will be passed to the slave side via the serial or I2C. It might be necessary to add a short delay, e.g. 10 milliseconds, between commands to the slave side, or some commands might get overwritten before the slave side has time to process them.
+
+## Special characters
+
+When writing content to the OLED screens, the font file will be used. This makes it possible to show different icons and even logos. There are utilities online where one can upload and modify `glcdfont.c` files, and then load them into the firmware and have the user-space program show them on the screens by including the correct decimal value. For example, adding the byte `0x01` to the content of the Set Line or Set Chars command will draw the second character in the font file.
+
+Furthermore, this feature recognises and replaces some specific characters. The replacement is done in the QMK firmware, which allows for quick output to certain changes, such as the current layer.
+
+|Characters|Replaced by|
+|----------|-----------|
+|`%l`      |The current layer, as returned by the overridable function `read_layer_state()`.|
+
+## Advanced
+
+### Custom raw HID receive function
+
+Define `OLEDCTRL_CUSTOM_HID_RECEIVE` in `config.h` to not have this feature create a function for handling raw HID messages directly. When defined, you will need to manually call `oledctrl_handle_cmd()` within your own handling of raw HID messages to have this feature do anything.

--- a/drivers/oled/oled_driver.c
+++ b/drivers/oled/oled_driver.c
@@ -106,6 +106,7 @@ uint8_t         oled_rotation_width = 0;
 uint8_t         oled_scroll_speed   = 0;  // this holds the speed after being remapped to ssd1306 internal values
 uint8_t         oled_scroll_start   = 0;
 uint8_t         oled_scroll_end     = 7;
+bool            oled_interpret_char = true;
 #if OLED_TIMEOUT > 0
 uint32_t oled_timeout;
 #endif
@@ -369,16 +370,18 @@ void oled_advance_char(void) {
 
 // Main handler that writes character data to the display buffer
 void oled_write_char(const char data, bool invert) {
-    // Advance to the next line if newline
-    if (data == '\n') {
-        // Old source wrote ' ' until end of line...
-        oled_advance_page(true);
-        return;
-    }
+    if (oled_interpret_char) {
+        // Advance to the next line if newline
+        if (data == '\n') {
+            // Old source wrote ' ' until end of line...
+            oled_advance_page(true);
+            return;
+        }
 
-    if (data == '\r') {
-        oled_advance_page(false);
-        return;
+        if (data == '\r') {
+            oled_advance_page(false);
+            return;
+        }
     }
 
     // copy the current render buffer to check for dirty after
@@ -612,6 +615,10 @@ uint8_t oled_max_lines(void) {
         return OLED_DISPLAY_HEIGHT / OLED_FONT_HEIGHT;
     }
     return OLED_DISPLAY_WIDTH / OLED_FONT_HEIGHT;
+}
+
+void oled_interpret_newline(bool interpret) {
+    oled_interpret_char = interpret;
 }
 
 void oled_task(void) {

--- a/drivers/oled/oled_driver.h
+++ b/drivers/oled/oled_driver.h
@@ -294,3 +294,7 @@ uint8_t oled_max_chars(void);
 
 // Returns the maximum number of lines that will fit on the oled
 uint8_t oled_max_lines(void);
+
+// Set whether newline and carriage return should be interpreted when writing,
+// or if the character from the font should be written instead.
+void oled_interpret_newline(bool interpret);

--- a/quantum/oledctrl.c
+++ b/quantum/oledctrl.c
@@ -1,0 +1,294 @@
+/* Copyright 2020 Albert Diserholt (Drauthius)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifdef RAW_ENABLE
+#   include "raw_hid.h"
+#endif
+
+#ifndef OLED_DRIVER_ENABLE
+#    error "OLED_DRIVER_ENABLE is not enabled"
+#endif
+
+#include <stdio.h>
+#include <string.h>
+
+#include "quantum.h"
+
+#include "oledctrl.h"
+
+#ifndef MAX
+#    define MAX(X, Y) ((X) > (Y) ? (X) : (Y))
+#endif
+
+#ifndef MIN
+#    define MIN(a, b) (((a) < (b)) ? (a) : (b))
+#endif
+
+#define SCREEN_BUFFER_LEN \
+    MAX(((OLED_DISPLAY_WIDTH / OLED_FONT_WIDTH) * (OLED_DISPLAY_HEIGHT / OLED_FONT_HEIGHT))\
+       ,((OLED_DISPLAY_HEIGHT / OLED_FONT_WIDTH) * (OLED_DISPLAY_WIDTH / OLED_FONT_HEIGHT)))
+
+// The current text shown on the screen.
+static char front_buffer[SCREEN_BUFFER_LEN + 1] = {0};
+// The buffer containing the text to show when presenting.
+static char back_buffer[SCREEN_BUFFER_LEN + 1] = {0};
+// Whether the front buffer contains variables.
+static bool buffer_has_variables = false;
+// Buffer for substituting variables with text.
+static char var_buffer[MAX(OLED_DISPLAY_WIDTH / OLED_FONT_WIDTH, OLED_DISPLAY_HEIGHT / OLED_FONT_WIDTH)];
+
+// Checks whether the OS has set any content.
+bool oledctrl_has_content(void) {
+    return front_buffer[0] != 0;
+}
+
+// Override in keyboard-level code to translate the current layer to a name.
+__attribute__((weak)) const char *read_layer_state(void) {
+    static char layer_state_str[24];
+    snprintf(layer_state_str, sizeof(layer_state_str), "Layer: %ld", layer_state);
+    return layer_state_str;
+}
+
+/**
+ * Write the front buffer to the OLED screen.
+ * This method supports some simple substitutions of variables inside the
+ * lines. For example, "%l" will be replaced with the result of the
+ * read_layer_state() function, which if undefined will be "Layer: " followed
+ * by a number.
+ * Note that if the line becomes too long for it to fit on the screen, text
+ * will be cut off at the end.
+ *
+ * Current handled variables:
+ *   %l  -  Layer information
+ */
+bool oledctrl_draw(void) {
+    if (!oledctrl_has_content()) {
+        return false;
+    }
+
+    if (!buffer_has_variables) {
+        oled_write(front_buffer, false);
+        return true;
+    }
+
+    // Handle variables.
+    // A bit convoluted, but it works.
+    for (int row = 0; row < oled_max_lines(); ++row) {
+        for (int col = 0, i = row * oled_max_chars(); col < oled_max_chars(); ++col, ++i) {
+            // Don't write the final null character, or screen might scroll up.
+            if (front_buffer[i] == 0) {
+                break;
+            } else if (front_buffer[i] == '%' && i + 1 < sizeof(front_buffer)) {
+                int len = 0;
+                switch (front_buffer[i+1]) {
+                    case 'l': {
+                        len = snprintf(var_buffer, sizeof(var_buffer), read_layer_state());
+                        break;
+                    }
+                    /* Add other substitutions here. */
+                }
+
+                if (len > 0) {
+                    // A substitution occurred. The content of the var_buffer will
+                    // either be printed in full, or until the end of the line.
+                    len = MIN(MIN(len, oled_max_chars() - col), sizeof(var_buffer) - 1);
+                    var_buffer[len] = 0; // Chop if off if necessary.
+                    oled_write(var_buffer, false);
+                    col += len - 1; // Will be incremented once more by the loop.
+                    ++i; // Skip the variable character.
+                    continue;
+                }
+            }
+
+            // Write the character normally to the screen.
+            oled_write_char(front_buffer[i], false);
+        }
+    }
+
+    return true;
+}
+
+// Send an event over HID raw.
+void oledctrl_send_event(uint8_t event, uint8_t *args, uint8_t args_len) {
+    uint8_t event_buffer[32] = { OLEDCTRL_MSG_EVENT, event };
+    memcpy(&event_buffer[2], args, MIN(args_len, sizeof(event_buffer) - 3));
+
+    raw_hid_send(event_buffer, sizeof(event_buffer));
+}
+
+// Handle a command.
+void oledctrl_handle_cmd(uint8_t *data, uint8_t length) {
+    if (!data || length < 1) {
+        // No data.
+        return;
+    }
+
+    // First byte becomes the result code.
+    enum oledctrl_result_id *result = &data[0];
+
+    if (length < 4 || data[0] != OLEDCTRL_MSG_COMMAND) {
+        // Incomplete header or invalid message.
+        *result = OLEDCTRL_RES_FAILURE;
+        return;
+    }
+
+    // The next two bytes are the command and screen, followed by any data.
+    uint8_t command = data[1];
+    enum oledctrl_screen_id screen = data[2];
+    uint8_t *command_data = &data[3];
+    uint8_t command_length = length - 4;
+
+    if (screen == OLEDCTRL_SCR_SLAVE && is_keyboard_master()) {
+#ifdef OLEDCTRL_SPLIT
+        // This is a command for the slave. Send it over.
+        oledctrl_send_msg(data, length);
+        *result = OLEDCTRL_RES_SUCCESS; // No way to know whether it was successfully received.
+#endif // OLEDCTRL_SPLIT
+    } else if (screen == OLEDCTRL_SCR_MASTER || (screen == OLEDCTRL_SCR_SLAVE && !is_keyboard_master())) {
+        switch (command) {
+            case OLEDCTRL_CMD_SET_UP: // Return the size of the OLED screen.
+                if (command_length < 2) {
+                    // No room to fill in the return values.
+                    *result = OLEDCTRL_RES_FAILURE;
+                    return;
+                }
+                command_data[0] = oled_max_chars();
+                command_data[1] = oled_max_lines();
+                // Fall through
+            case OLEDCTRL_CMD_CLEAR: // Clear the buffers and screens
+                memset(front_buffer, 0, sizeof(front_buffer));
+                memset(back_buffer, ' ', sizeof(back_buffer));
+                oled_clear();
+                oled_interpret_newline(command == OLEDCTRL_CMD_CLEAR); // Let userspace use all the characters in the font.
+                *result = OLEDCTRL_RES_SUCCESS;
+                break;
+            case OLEDCTRL_CMD_SET_LINE: { // Set a line of text.
+                if (command_length < 2) {
+                    // Missing arguments.
+                    *result = OLEDCTRL_RES_FAILURE;
+                    return;
+                }
+                uint8_t line = command_data[0];
+                char *text = (char*)&command_data[1];
+                if (line >= oled_max_lines()) {
+                    // Line out of bounds
+                    *result = OLEDCTRL_RES_FAILURE;
+                    return;
+                }
+
+                uint8_t len = MIN(strnlen(text, command_length), oled_max_chars());
+                memcpy(&back_buffer[line * oled_max_chars()], text, len);
+                if (len < oled_max_chars()) {
+                    // Erase everything else until the end of the line.
+                    memset(&back_buffer[line * oled_max_chars() + len], ' ', oled_max_chars() - len);
+                }
+                *result = OLEDCTRL_RES_SUCCESS;
+                break;
+            }
+            case OLEDCTRL_CMD_SET_CHARS:
+                if (command_length < 3) {
+                    // Missing arguments.
+                    *result = OLEDCTRL_RES_FAILURE;
+                    return;
+                }
+                uint8_t offset = command_data[0];
+                uint8_t len = command_data[1];
+                char *text = (char*)&command_data[2];
+                if (offset >= sizeof(back_buffer)) {
+                    // Offset out of bounds
+                    *result = OLEDCTRL_RES_FAILURE;
+                    return;
+                } else if (len > command_length - 3) {
+                    // Length too big
+                    *result = OLEDCTRL_RES_FAILURE;
+                    return;
+                }
+
+                memcpy(&back_buffer[offset], text, MIN(len, sizeof(back_buffer) - offset - 1));
+                *result = OLEDCTRL_RES_SUCCESS;
+                break;
+            case OLEDCTRL_CMD_PRESENT: // Copy the content of the back buffer to the front buffer.
+                memcpy(front_buffer, back_buffer, SCREEN_BUFFER_LEN);
+                front_buffer[sizeof(front_buffer) - 1] = 0;
+                *result = OLEDCTRL_RES_SUCCESS;
+                buffer_has_variables = strchr(front_buffer, '%');
+                break;
+            default:
+                *result = OLEDCTRL_RES_FAILURE;
+                break;
+        }
+    } else {
+        // Unknown screen.
+        *result = OLEDCTRL_RES_FAILURE;
+    }
+}
+
+// Define OLEDCTRL_CUSTOM_HID_RECEIVE to handle HID messages in keyboard-level code.
+#ifndef OLEDCTRL_CUSTOM_HID_RECEIVE
+
+#   ifdef VIA_ENABLE
+#       define raw_hid_receive raw_hid_receive_kb
+#   endif
+
+// Handle raw HID messages.
+void raw_hid_receive(uint8_t *data, uint8_t length) {
+    oledctrl_handle_cmd(data, length);
+
+    // VIA code will take care of responding if enabled.
+#   ifndef VIA_ENABLE
+    if (!is_keyboard_master()) {
+        return; // Slave cannot answer to HID messages
+    }
+
+    // Return the same buffer, presumably with values changed.
+    raw_hid_send(data, length);
+#   endif // !VIA_ENABLE
+}
+
+#endif // !OLEDCTRL_CUSTOM_HID_RECEIVE
+
+#ifdef OLEDCTRL_SPLIT
+
+// Message from the master to the slave.
+static uint8_t oled_ctrl_msg[OLEDCTRL_MSG_MAX_LEN];
+// Whether a message is ready to be sent.
+static bool oled_ctrl_pending;
+
+/* for split keyboard master side */
+void oledctrl_send_msg(const uint8_t *msg, uint8_t len) {
+    memcpy(oled_ctrl_msg, msg, MIN(sizeof(oled_ctrl_msg), len));
+    oled_ctrl_pending = true;
+}
+
+bool oledctrl_is_msg_pending(void) { return oled_ctrl_pending; }
+
+void oledctrl_clear_msg_pending(void) { oled_ctrl_pending = false; }
+
+void oledctrl_get_syncinfo(oledctrl_syncinfo_t *syncinfo) {
+    memcpy(syncinfo->msg, oled_ctrl_msg, OLEDCTRL_MSG_MAX_LEN);
+}
+
+/* for split keyboard slave side */
+void oledctrl_update_sync(oledctrl_syncinfo_t *syncinfo) {
+    oledctrl_receive_msg(syncinfo->msg, OLEDCTRL_MSG_MAX_LEN);
+}
+
+// Process any message from the master.
+void oledctrl_receive_msg(uint8_t *msg, uint8_t len) {
+    oledctrl_handle_cmd(msg, len);
+}
+
+#endif // OLEDCTRL_SPLIT

--- a/quantum/oledctrl.h
+++ b/quantum/oledctrl.h
@@ -1,0 +1,139 @@
+/* Copyright 2020 Albert Diserholt (Drauthius)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+/*
+ * This module adds support for controlling the content of the OLED
+ * screen(s) from the operating system via raw HID.
+ * Add "OLED_CONTROL_ENABLE=yes" to your rules.mk to build the support
+ * needed to send commands from the operating system to the firmware.
+ *
+ * See docs/feature_oledctrl.md for more information about the protocol.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "usb_descriptor.h" // For RAW_EPSIZE
+
+// Maximum length of a HID message
+#ifndef OLEDCTRL_MSG_MAX_LEN
+#    define OLEDCTRL_MSG_MAX_LEN RAW_EPSIZE
+#endif
+
+// The type of a message understood by the OLED controlling code.
+// The IDs must not clash with VIA.
+enum oledctrl_message_id {
+    OLEDCTRL_MSG_FIRST    = 0xC0,
+    OLEDCTRL_MSG_COMMAND  = OLEDCTRL_MSG_FIRST,
+    OLEDCTRL_MSG_EVENT    = 0xC1,
+    OLEDCTRL_MSG_LAST,
+};
+
+// Result codes for the commands.
+// First byte in responses from the firmware.
+enum oledctrl_result_id {
+    OLEDCTRL_RES_SUCCESS = 0x00,
+    OLEDCTRL_RES_FAILURE = 0x01,
+};
+
+/*
+ * The commands that are recognised to control the OLEDs.
+ * OLEDCTRL_CMD_SET_UP:
+ *   This is equivalent to clear, but also returns the number of characters
+ *   that can be written to the screen in the fourth and fifth bytes of the
+ *   response (columns and rows, respectively).
+ *
+ * OLEDCTRL_CMD_CLEAR:
+ *   Clear the entire screen. Depending on how oled_task_user() looks, this might
+ *   revert the screen to its "default" (uncontrolled) state.
+ *
+ * OLEDCTRL_CMD_SET_LINE:
+ *   Set the content of a line (row) of the screen. The fourth byte should be which
+ *   line to modify, and the fifth byte and onwards should be content that is
+ *   desired on that line. Will replace everything on that line, and will not
+ *   wrap to the next one.
+ *
+ * OLEDCTRL_CMD_SET_CHARS:
+ *   Set a portion of the screen. The fourth byte should be the offset, the fifth byte
+ *   the length of the string, and the sixth byte and onwards should be the string to
+ *   set. Will replace only until the length, and will wrap if it goes over a line.
+ *
+ * OLEDCTRL_CMD_PRESENT:
+ *   Show the changes to the screen. This has to be called after the desired
+ *   number of OLEDCTRL_CMD_SET_LINE commands have been issued. Think of it as double
+ *   buffering, where this command will present the content of the back buffer.
+ */
+enum oledctrl_command_id {
+    OLEDCTRL_CMD_SET_UP    = 0x00,
+    OLEDCTRL_CMD_CLEAR     = 0x01,
+    OLEDCTRL_CMD_SET_LINE  = 0x02,
+    OLEDCTRL_CMD_SET_CHARS = 0x03,
+    OLEDCTRL_CMD_PRESENT   = 0x04,
+};
+
+/*
+ * The events that the firmware might send, triggered by keyboard-level code.
+ * They are the second byte in messages sent from the firmware.
+ * OLEDCTRL_EVENT_SET_TAG:
+ *   A specific tag is requested to be shown on a specific screen. The third
+ *   byte is the screen (oledctrl_screen_id below), and the fourth is the tag ID.
+ *   Note that KC_1 => tag ID 1.
+ *
+ * OLEDCTRL_EVENT_INCREMENT_TAG:
+ *   Go to the next tag for a specific screen. The third byte is the screen
+ *   (oledctrl_screen_id below).
+ *
+ * OLEDCTRL_EVENT_DECREMENT_TAG:
+ *   Go to the previous tag for a specific screen. The third byte is the
+ *   screen (oledctrl_screen_id below).
+ */
+enum oledctrl_event_id {
+    OLEDCTRL_EVENT_SET_TAG       = 0x00,
+    OLEDCTRL_EVENT_INCREMENT_TAG = 0x01,
+    OLEDCTRL_EVENT_DECREMENT_TAG = 0x02,
+};
+
+// Which OLED screen to control.
+// Typically the third byte in messages to and from the firmware.
+enum oledctrl_screen_id {
+    OLEDCTRL_SCR_MASTER = 0x00,
+    OLEDCTRL_SCR_SLAVE  = 0x01,
+};
+
+bool oledctrl_has_content(void);
+bool oledctrl_draw(void);
+
+void oledctrl_handle_cmd(uint8_t *data, uint8_t length);
+void oledctrl_send_event(enum oledctrl_event_id event, uint8_t *args, uint8_t args_len);
+
+#ifdef OLEDCTRL_SPLIT
+
+typedef struct _oledctrl_syncinfo_t {
+    uint8_t msg[OLEDCTRL_MSG_MAX_LEN];
+} oledctrl_syncinfo_t;
+
+/* for split keyboard master side */
+void oledctrl_send_msg(const uint8_t *msg, uint8_t len);
+bool oledctrl_is_msg_pending(void);
+void oledctrl_clear_msg_pending(void);
+void oledctrl_get_syncinfo(oledctrl_syncinfo_t *syncinfo);
+/* for split keyboard slave side */
+void oledctrl_update_sync(oledctrl_syncinfo_t *syncinfo);
+void oledctrl_receive_msg(uint8_t *msg, uint8_t len);
+
+#endif // OLEDCTRL_SPLIT

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -162,6 +162,10 @@ extern layer_state_t layer_state;
 #    include "haptic.h"
 #endif
 
+#ifdef OLED_CONTROL_ENABLE
+#    include "oledctrl.h"
+#endif
+
 #ifdef OLED_DRIVER_ENABLE
 #    include "oled_driver.h"
 #endif

--- a/quantum/via.c
+++ b/quantum/via.c
@@ -385,8 +385,8 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
         }
         default: {
             // The command ID is not known
-            // Return the unhandled state
-            *command_id = id_unhandled;
+            // Let the keyboard-level code handle it, or return the unhandled state
+            raw_hid_receive_kb(data, length);
             break;
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

This change adds a feature that can be turned on to set the content of the OLED screens using a user-space program that implements a specific protocol over raw HID.

I have verified it with my Lily58 using serial and split. I have not tested the I2C split variant, only verified that it compiles.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
