### PR TITLE
Allow backlight duty cycle limit

### DIFF
--- a/docs/feature_backlight.md
+++ b/docs/feature_backlight.md
@@ -62,14 +62,15 @@ Valid driver values are `pwm`, `software`, `custom` or `no`. See below for help 
 
 To configure the backlighting, `#define` these in your `config.h`:
 
-|Define               |Default      |Description                                                                          |
-|---------------------|-------------|-------------------------------------------------------------------------------------|
-|`BACKLIGHT_PIN`      |*Not defined*|The pin that controls the LED(s)                                                     |
-|`BACKLIGHT_LEVELS`   |`3`          |The number of brightness levels (maximum 31 excluding off)                           |
-|`BACKLIGHT_CAPS_LOCK`|*Not defined*|Enable Caps Lock indicator using backlight (for keyboards without dedicated LED)     |
-|`BACKLIGHT_BREATHING`|*Not defined*|Enable backlight breathing, if supported                                             |
-|`BREATHING_PERIOD`   |`6`          |The length of one backlight "breath" in seconds                                      |
-|`BACKLIGHT_ON_STATE` |`1`          |The state of the backlight pin when the backlight is "on" - `1` for high, `0` for low|
+| Define                 | Default       | Description                                                                                                       |
+|------------------------|---------------|-------------------------------------------------------------------------------------------------------------------|
+| `BACKLIGHT_PIN`        | *Not defined* | The pin that controls the LED(s)                                                                                  |
+| `BACKLIGHT_LEVELS`     | `3`           | The number of brightness levels (maximum 31 excluding off)                                                        |
+| `BACKLIGHT_CAPS_LOCK`  | *Not defined* | Enable Caps Lock indicator using backlight (for keyboards without dedicated LED)                                  |
+| `BACKLIGHT_BREATHING`  | *Not defined* | Enable backlight breathing, if supported                                                                          |
+| `BREATHING_PERIOD`     | `6`           | The length of one backlight "breath" in seconds                                                                   |
+| `BACKLIGHT_ON_STATE`   | `1`           | The state of the backlight pin when the backlight is "on" - `1` for high, `0` for low                             |
+| `BACKLIGHT_LIMIT_VAL ` | `255`         | The maximum duty cycle of the backlight -- `255` allows for full brightness, any lower will decrease the maximum. |
 
 Unless you are designing your own keyboard, you generally should not need to change the `BACKLIGHT_PIN` or `BACKLIGHT_ON_STATE`.
 

--- a/quantum/backlight/backlight_avr.c
+++ b/quantum/backlight/backlight_avr.c
@@ -3,6 +3,11 @@
 #include "backlight_driver_common.h"
 #include "debug.h"
 
+// Maximum duty cycle limit
+#ifndef BACKLIGHT_LIMIT_VAL
+#    define BACKLIGHT_LIMIT_VAL 255
+#endif
+
 // This logic is a bit complex, we support 3 setups:
 //
 //   1. Hardware PWM when backlight is wired to a PWM pin.
@@ -240,6 +245,11 @@ static uint16_t cie_lightness(uint16_t v) {
     }
 }
 
+// rescale the supplied backlight value to be in terms of the value limit
+static uint32_t rescale_limit_val(uint32_t val) {
+    return (val * (BACKLIGHT_LIMIT_VAL + 1)) / 256;
+}
+
 // range for val is [0..TIMER_TOP]. PWM pin is high while the timer count is below val.
 static inline void set_pwm(uint16_t val) { OCRxx = val; }
 
@@ -269,7 +279,7 @@ void backlight_set(uint8_t level) {
 #endif
     }
     // Set the brightness
-    set_pwm(cie_lightness(TIMER_TOP * (uint32_t)level / BACKLIGHT_LEVELS));
+    set_pwm(cie_lightness(rescale_limit_val(TIMER_TOP * (uint32_t)level / BACKLIGHT_LEVELS)));
 }
 
 void backlight_task(void) {}
@@ -375,7 +385,7 @@ ISR(TIMERx_OVF_vect)
         breathing_interrupt_disable();
     }
 
-    set_pwm(cie_lightness(scale_backlight((uint16_t)pgm_read_byte(&breathing_table[index]) * 0x0101U)));
+    set_pwm(cie_lightness(rescale_limit_val(scale_backlight((uint16_t)pgm_read_byte(&breathing_table[index]) * 0x0101U))));
 }
 
 #endif  // BACKLIGHT_BREATHING


### PR DESCRIPTION
## Description

Needed to be able to apply a limit to the backlighting duty cycle -- breadboard testing of using QMK's backlight code to control an LCD backlight showed it was pulling 80mA, but in circuit with SMT components it showed it was capable of pulling 400mA per LCD.

Artificially limiting the duty cycle allows controlling max brightness instead of messing about with current limiting circuits, much like the RGB limit constants we already have.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
