### PR TITLE
Swap ergo lower layer shortcuts for zoom keys in my personal keymaps

### DIFF
--- a/keyboards/crkbd/keymaps/bcat/keymap.c
+++ b/keyboards/crkbd/keymaps/bcat/keymap.c
@@ -13,9 +13,9 @@ enum layer {
 #define LY_RSE MO(LAYER_RAISE)
 
 #define KY_CSPC LCTL(KC_SPC)
-#define KY_LOCK LGUI(KC_L)
-#define KY_WINL LGUI(KC_LEFT)
-#define KY_WINR LGUI(KC_RGHT)
+#define KY_ZMIN LCTL(KC_EQL)
+#define KY_ZMOUT LCTL(KC_MINS)
+#define KY_ZMRST LCTL(KC_0)
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Default layer: http://www.keyboard-layout-editor.com/#/gists/08d9827d916662a9414f48805aa895a5 */
@@ -29,7 +29,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Lower layer: http://www.keyboard-layout-editor.com/#/gists/c3fba5eaa2cd70fdfbdbc0f9e34d3bc0 */
     [LAYER_LOWER] = LAYOUT(
         MC_ALTT,  KC_EXLM,  KC_AT,    KC_HASH,  KC_DLR,   KC_PERC,                      KC_CIRC,  KC_AMPR,  KC_ASTR,  KC_LPRN,  KC_RPRN,  _______,
-        KY_CSPC,  KY_WINL,  KY_WINR,  KY_LOCK,  KC_WBAK,  KC_WFWD,                      KC_PIPE,  KC_UNDS,  KC_PLUS,  KC_LCBR,  KC_RCBR,  KC_TILD,
+        KY_CSPC,  KY_ZMRST, KY_ZMOUT, KY_ZMIN,  KC_WBAK,  KC_WFWD,                      KC_PIPE,  KC_UNDS,  KC_PLUS,  KC_LCBR,  KC_RCBR,  KC_TILD,
         _______,  KC_APP,   KC_PSCR,  KC_SLCK,  KC_PAUS,  KC_LGUI,                      KC_BSLS,  KC_MINS,  KC_EQL,   KC_LBRC,  KC_RBRC,  KC_GRV,
                                                 _______,  _______,  _______,  _______,  _______,  _______
     ),

--- a/keyboards/crkbd/keymaps/bcat/readme.md
+++ b/keyboards/crkbd/keymaps/bcat/readme.md
@@ -50,7 +50,7 @@ elimination.
 
 ## Lower layer
 
-![Lower layer layout](https://i.imgur.com/djIkwsa.png)
+![Lower layer layout](https://i.imgur.com/vaIc9JY.png)
 
 ([KLE](http://www.keyboard-layout-editor.com/#/gists/c3fba5eaa2cd70fdfbdbc0f9e34d3bc0))
 
@@ -74,8 +74,8 @@ And yup, the shifted versions are above the unshifted versions.
 * Remaining keys from a TKL are placed out of the way on the bottom row of the
 left half.
 
-* The home row on the left half contains handy shortcuts for window movement,
-and browser navigation, and screen lock.
+* The home row on the left half contains handy shortcuts for zooming and browser
+navigation.
 
 * Lower+Esc is bound to Ctrl+Space because the Ctrl and Space keys are both on
 the left thumb, so this key combination (which I use for tmux prefix and editor
@@ -109,7 +109,8 @@ keys (F1–F5) on the home row.)
 * Insert and Delete are on the rightmost column, because there didn't seem to
 be a better place to put them.
 
-* Caps Lock is bound in the same position as on an HHKB, for lack of an obvious better location.
+* Caps Lock is bound in the same position as on an HHKB, for lack of an obvious
+better location.
 
 ## Adjust layer
 

--- a/keyboards/lily58/keymaps/bcat/keymap.c
+++ b/keyboards/lily58/keymaps/bcat/keymap.c
@@ -13,9 +13,9 @@ enum layer {
 #define LY_RSE MO(LAYER_RAISE)
 
 #define KY_CSPC LCTL(KC_SPC)
-#define KY_LOCK LGUI(KC_L)
-#define KY_WINL LGUI(KC_LEFT)
-#define KY_WINR LGUI(KC_RGHT)
+#define KY_ZMIN LCTL(KC_EQL)
+#define KY_ZMOUT LCTL(KC_MINS)
+#define KY_ZMRST LCTL(KC_0)
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Default layer: http://www.keyboard-layout-editor.com/#/gists/e0eb3af65961e9fd612dcff3ddd88e4f */
@@ -31,7 +31,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [LAYER_LOWER] = LAYOUT(
         _______,  _______,  _______,  _______,  _______,  _______,                      _______,  _______,  _______,  _______,  _______,  _______,
         MC_ALTT,  KC_EXLM,  KC_AT,    KC_HASH,  KC_DLR,   KC_PERC,                      KC_CIRC,  KC_AMPR,  KC_ASTR,  KC_LPRN,  KC_RPRN,  _______,
-        KY_CSPC,  KY_WINL,  KY_WINR,  KY_LOCK,  KC_WBAK,  KC_WFWD,                      KC_PIPE,  KC_UNDS,  KC_PLUS,  KC_LCBR,  KC_RCBR,  KC_TILD,
+        KY_CSPC,  KY_ZMRST, KY_ZMOUT, KY_ZMIN,  KC_WBAK,  KC_WFWD,                      KC_PIPE,  KC_UNDS,  KC_PLUS,  KC_LCBR,  KC_RCBR,  KC_TILD,
         _______,  KC_APP,   KC_PSCR,  KC_SLCK,  KC_PAUS,  KC_LGUI,  _______,  _______,  KC_BSLS,  KC_MINS,  KC_EQL,   KC_LBRC,  KC_RBRC,  KC_GRV,
                                       _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______
     ),

--- a/keyboards/lily58/keymaps/bcat/readme.md
+++ b/keyboards/lily58/keymaps/bcat/readme.md
@@ -22,7 +22,7 @@ browser back/forward navigation keys.
 
 ## Lower layer
 
-![Lower layer layout](https://i.imgur.com/JVF1p1Q.png)
+![Lower layer layout](https://i.imgur.com/sNKWpUC.png)
 
 ([KLE](http://www.keyboard-layout-editor.com/#/gists/19ad0d3b5d745fbb2818db09740f5a11))
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Just swapping out some shortcut keys I don't use for Chrome zoom keys (which I find myself perpetually mistyping on my ergo boards).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [X] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
