### PR TITLE
Remove hjson

### DIFF
--- a/lib/python/kle2xy.py
+++ b/lib/python/kle2xy.py
@@ -1,7 +1,9 @@
 """ Original code from https://github.com/skullydazed/kle2xy
 """
+import json
 
-import hjson
+from collections import OrderedDict
+
 from decimal import Decimal
 
 
@@ -47,9 +49,7 @@ class KLE2xy(list):
             self.name = properties['name']
 
     def parse_layout(self, layout):  # noqa  FIXME(skullydazed): flake8 says this has a complexity of 25, it should be refactored.
-        # Wrap this in a dictionary so hjson will parse KLE raw data
-        layout = '{"layout": [' + layout + ']}'
-        layout = hjson.loads(layout)['layout']
+        layout = json.loads(layout, object_pairs_hook=OrderedDict)
 
         # Initialize our state machine
         current_key = self.key_skel.copy()


### PR DESCRIPTION
## Description

It seems like hjson is only used to provide an `OrderedDict` for the object type, but this is well supported by the `json` stdlib. This also removes a fairly obscure dependency from being added by distributions which hasn't had a proper update for years.

## Types of Changes
- [x] Enhancement/optimization

## Issues Fixed or Closed by This PR


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
