### PR TITLE
[Core] DYNAMIC_KEYMAP_EEPROM_MAX_ADDR check

### DIFF
--- a/quantum/dynamic_keymap.c
+++ b/quantum/dynamic_keymap.c
@@ -44,7 +44,7 @@
 
 // Due to usage of uint16_t check for max 65535
 #if DYNAMIC_KEYMAP_EEPROM_MAX_ADDR > 65535
-    #error "DYNAMIC_KEYMAP_EEPROM_MAX_ADDR is greater than 65535"
+    #error DYNAMIC_KEYMAP_EEPROM_MAX_ADDR is greater than 65535
 #endif
 
 // If DYNAMIC_KEYMAP_EEPROM_ADDR not explicitly defined in config.h,

--- a/quantum/dynamic_keymap.c
+++ b/quantum/dynamic_keymap.c
@@ -42,6 +42,11 @@
 #    endif
 #endif
 
+// Due to usage of uint16_t check for max 65535
+#if DYNAMIC_KEYMAP_EEPROM_MAX_ADDR > 65535
+    #error "DYNAMIC_KEYMAP_EEPROM_MAX_ADDR is greater than 65535"
+#endif
+
 // If DYNAMIC_KEYMAP_EEPROM_ADDR not explicitly defined in config.h,
 // default it start after VIA_EEPROM_CUSTOM_ADDR+VIA_EEPROM_CUSTOM_SIZE
 #ifndef DYNAMIC_KEYMAP_EEPROM_ADDR

--- a/quantum/dynamic_keymap.c
+++ b/quantum/dynamic_keymap.c
@@ -44,7 +44,7 @@
 
 // Due to usage of uint16_t check for max 65535
 #if DYNAMIC_KEYMAP_EEPROM_MAX_ADDR > 65535
-    #error DYNAMIC_KEYMAP_EEPROM_MAX_ADDR is greater than 65535
+#    error DYNAMIC_KEYMAP_EEPROM_MAX_ADDR must be less than 65536
 #endif
 
 // If DYNAMIC_KEYMAP_EEPROM_ADDR not explicitly defined in config.h,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Due to the return type of `uint16_t` it would be a temporary control to add in a check for the size

Previously it would compile with a number greater than 65535, e.g.  65536. 

However as shown in the issue below, the compiler only tells us when the #define is much larger than the `uint16_t` max size.

https://github.com/qmk/qmk_firmware/issues/8742 - see  more here

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Max EEPROM size check for dynamic keymaps

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
