### PR TITLE
moved encoder code to timberwolf.c

### DIFF
--- a/keyboards/metamechs/timberwolf/keymaps/a_ansi/keymap.c
+++ b/keyboards/metamechs/timberwolf/keymaps/a_ansi/keymap.c
@@ -34,11 +34,3 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 		MO(1)  ,_______,_______,_______                        ,_______                ,_______,_______,                _______,_______,_______,_______ 
     )
 };
-
-void encoder_update_user(uint8_t index, bool clockwise) {
-	if (clockwise) {
-		tap_code(KC_VOLU);
-	} else {
-		tap_code(KC_VOLD);
-	}
-}

--- a/keyboards/metamechs/timberwolf/keymaps/a_iso/keymap.c
+++ b/keyboards/metamechs/timberwolf/keymaps/a_iso/keymap.c
@@ -34,11 +34,3 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 		MO(1)  ,_______,_______,_______                        ,_______                ,_______,_______,                _______,_______,_______,_______ 
     )
 };
-
-void encoder_update_user(uint8_t index, bool clockwise) {
-	if (clockwise) {
-		tap_code(KC_VOLU);
-	} else {
-		tap_code(KC_VOLD);
-	}
-}

--- a/keyboards/metamechs/timberwolf/keymaps/b_ansi/keymap.c
+++ b/keyboards/metamechs/timberwolf/keymaps/b_ansi/keymap.c
@@ -34,11 +34,3 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 		MO(1)  ,_______,_______,_______                        ,_______                ,_______,_______,_______        ,_______,_______,_______ 
     )
 };
-
-void encoder_update_user(uint8_t index, bool clockwise) {
-	if (clockwise) {
-		tap_code(KC_VOLU);
-	} else {
-		tap_code(KC_VOLD);
-	}
-}

--- a/keyboards/metamechs/timberwolf/keymaps/b_iso/keymap.c
+++ b/keyboards/metamechs/timberwolf/keymaps/b_iso/keymap.c
@@ -34,11 +34,3 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 		MO(1)  ,_______,_______,_______                        ,_______                ,_______,_______,_______        ,_______,_______,_______ 
     )
 };
-
-void encoder_update_user(uint8_t index, bool clockwise) {
-	if (clockwise) {
-		tap_code(KC_VOLU);
-	} else {
-		tap_code(KC_VOLD);
-	}
-}

--- a/keyboards/metamechs/timberwolf/keymaps/default/keymap.c
+++ b/keyboards/metamechs/timberwolf/keymaps/default/keymap.c
@@ -34,11 +34,3 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 		MO(1)  ,_______,_______,_______                        ,_______                ,_______,_______,_______,_______,_______,_______,_______,_______ 
     )
 };
-
-void encoder_update_user(uint8_t index, bool clockwise) {
-	if (clockwise) {
-		tap_code(KC_VOLU);
-	} else {
-		tap_code(KC_VOLD);
-	}
-}

--- a/keyboards/metamechs/timberwolf/keymaps/prime_ansi/keymap.c
+++ b/keyboards/metamechs/timberwolf/keymaps/prime_ansi/keymap.c
@@ -34,11 +34,3 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 		MO(1)  ,_______,_______,_______                        ,_______                ,_______,_______,_______        ,_______,_______,_______ 
     )
 };
-
-void encoder_update_user(uint8_t index, bool clockwise) {
-	if (clockwise) {
-		tap_code(KC_VOLU);
-	} else {
-		tap_code(KC_VOLD);
-	}
-}

--- a/keyboards/metamechs/timberwolf/keymaps/prime_iso/keymap.c
+++ b/keyboards/metamechs/timberwolf/keymaps/prime_iso/keymap.c
@@ -34,11 +34,3 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 		MO(1)  ,_______,_______,_______                        ,_______                ,_______,_______,_______        ,_______,_______,_______ 
     )
 };
-
-void encoder_update_user(uint8_t index, bool clockwise) {
-	if (clockwise) {
-		tap_code(KC_VOLU);
-	} else {
-		tap_code(KC_VOLD);
-	}
-}

--- a/keyboards/metamechs/timberwolf/keymaps/via/keymap.c
+++ b/keyboards/metamechs/timberwolf/keymaps/via/keymap.c
@@ -50,11 +50,3 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 		_______,_______,_______,_______                        ,_______                ,_______,_______,_______,_______,_______,_______,_______,_______ 
     )
 };
-
-void encoder_update_user(uint8_t index, bool clockwise) {
-	if (clockwise) {
-		tap_code(KC_VOLU);
-	} else {
-		tap_code(KC_VOLD);
-	}
-}

--- a/keyboards/metamechs/timberwolf/timberwolf.c
+++ b/keyboards/metamechs/timberwolf/timberwolf.c
@@ -28,7 +28,8 @@ bool led_update_kb(led_t led_state) {
     return runDefault;
 }
 
-void encoder_update_kb(uint8_t index, bool clockwise) {
+__attribute__((weak))
+void encoder_update_user(uint8_t index, bool clockwise) {
 	if (clockwise) {
 		tap_code(KC_VOLU);
 	} else {

--- a/keyboards/metamechs/timberwolf/timberwolf.c
+++ b/keyboards/metamechs/timberwolf/timberwolf.c
@@ -27,3 +27,11 @@ bool led_update_kb(led_t led_state) {
     }
     return runDefault;
 }
+
+void encoder_update_kb(uint8_t index, bool clockwise) {
+	if (clockwise) {
+		tap_code(KC_VOLU);
+	} else {
+		tap_code(KC_VOLD);
+	}
+}


### PR DESCRIPTION
## Description

Found that having encoder code in keymap files made it so that when you flashed firmware from qmk configurator, the encoder stopped working. moved the code to keyboard.c in order to fix that issue

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
