### PR TITLE
handwired/onekey/blackpill_f401: Fix I2C pin config mismatch

### DIFF
--- a/keyboards/handwired/onekey/blackpill_f401/blackpill_f401.c
+++ b/keyboards/handwired/onekey/blackpill_f401/blackpill_f401.c
@@ -1,0 +1,23 @@
+/* Copyright 2020 Sergey Vlasov (sigprof)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include QMK_KEYBOARD_H
+
+void board_init(void) {
+    // B9 is configured as I2C1_SDA in the board file; that function must be
+    // disabled before using B7 as I2C1_SDA.
+    setPinInputHigh(B9);
+}


### PR DESCRIPTION
## Description

By default the `i2c_master` driver for ChibiOS uses the B6 pin for `I2C1_SCL` and the B7 pin for `I2C1_SDA`.  However, the ChibiOS board file used for the F401 Blackpill board (`ST_STM32F401C_DISCOVERY`) configures B6 as `I2C1_SCL` and B9 as `I2C1_SDA`, and if that configuration is left unchanged, enabling the `i2c_master` driver results in having two pins (B7 and B9) configured as `I2C1_SDA` at the same time, which does not work properly (experimental results show that the B9 pin still works as `I2C1_SDA` in that case, and the B7 pin does not work).

Configure the B9 pin as an input with pull-up in `board_init()`, so that the B7 pin can be configured as `I2C1_SDA` by the I2C driver.

Tested on a Blackpill board marked “WeAct V3.0” with STM32F401CCU6 and several OLED displays (with a keymap for OLED testing which will go in a separate PR).

Note that `handwired/onekey/blackpill_f411` does not need a similar change, because its ChibiOS setup is based on the `ST_NUCLEO64_F411RE` board definition, which does not configure any pins for I2C1-related alternate functions.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
