### PR TITLE
CLI: update subcommands to use return instead of exit()

### DIFF
--- a/lib/python/qmk/cli/doctor.py
+++ b/lib/python/qmk/cli/doctor.py
@@ -328,3 +328,5 @@ def doctor(cli):
     else:
         cli.log.info('{fg_yellow}Problems detected, please fix these problems before proceeding.')
         # FIXME(skullydazed/unclaimed): Link to a document about troubleshooting, or discord or something
+
+    return ok

--- a/lib/python/qmk/cli/info.py
+++ b/lib/python/qmk/cli/info.py
@@ -134,11 +134,11 @@ def info(cli):
     if not cli.config.info.keyboard:
         cli.log.error('Missing paramater: --keyboard')
         cli.subcommands['info'].print_help()
-        exit(1)
+        return False
 
     if not is_keyboard(cli.config.info.keyboard):
         cli.log.error('Invalid keyboard: "%s"', cli.config.info.keyboard)
-        exit(1)
+        return False
 
     # Build the info.json file
     kb_info_json = info_json(cli.config.info.keyboard)
@@ -146,13 +146,10 @@ def info(cli):
     # Output in the requested format
     if cli.args.format == 'json':
         print(json.dumps(kb_info_json))
-        exit()
-
-    if cli.args.format == 'text':
+    elif cli.args.format == 'text':
         print_text_output(kb_info_json)
-
     elif cli.args.format == 'friendly':
         print_friendly_output(kb_info_json)
-
     else:
         cli.log.error('Unknown format: %s', cli.args.format)
+        return False

--- a/lib/python/qmk/cli/json/keymap.py
+++ b/lib/python/qmk/cli/json/keymap.py
@@ -13,4 +13,4 @@ def json_keymap(cli):
     """Renamed to `qmk json2c`.
     """
     cli.log.error('This command has been renamed to `qmk json2c`.')
-    exit(1)
+    return False

--- a/lib/python/qmk/cli/json2c.py
+++ b/lib/python/qmk/cli/json2c.py
@@ -22,12 +22,12 @@ def json2c(cli):
         # TODO(skullydazed/anyone): Read file contents from STDIN
         cli.log.error('Reading from STDIN is not (yet) supported.')
         cli.print_usage()
-        exit(1)
+        return False
 
     if not cli.args.filename.exists():
         cli.log.error('JSON file does not exist!')
         cli.print_usage()
-        exit(1)
+        return False
 
     # Environment processing
     if cli.args.output and cli.args.output.name == '-':

--- a/lib/python/qmk/cli/kle2json.py
+++ b/lib/python/qmk/cli/kle2json.py
@@ -37,7 +37,8 @@ def kle2json(cli):
         file_path = Path(os.environ['ORIG_CWD'], cli.args.filename)
     # Check for valid file_path for more graceful failure
     if not file_path.exists():
-        return cli.log.error('File {fg_cyan}%s{style_reset_all} was not found.', file_path)
+        cli.log.error('File {fg_cyan}%s{style_reset_all} was not found.', file_path)
+        return False
     out_path = file_path.parent
     raw_code = file_path.open().read()
     # Check if info.json exists, allow overwrite with force
@@ -50,8 +51,7 @@ def kle2json(cli):
     except Exception as e:
         cli.log.error('Could not parse KLE raw data: %s', raw_code)
         cli.log.exception(e)
-        # FIXME: This should be better
-        return cli.log.error('Could not parse KLE raw data.')
+        return False
     keyboard = OrderedDict(
         keyboard_name=kle.name,
         url='',

--- a/lib/python/qmk/cli/list/keymaps.py
+++ b/lib/python/qmk/cli/list/keymaps.py
@@ -15,7 +15,7 @@ def list_keymaps(cli):
     """
     if not is_keyboard(cli.config.list_keymaps.keyboard):
         cli.log.error('Keyboard %s does not exist!', cli.config.list_keymaps.keyboard)
-        exit(1)
+        return False
 
     for name in qmk.keymap.list_keymaps(cli.config.list_keymaps.keyboard):
         print(name)

--- a/lib/python/qmk/cli/new/keymap.py
+++ b/lib/python/qmk/cli/new/keymap.py
@@ -29,15 +29,15 @@ def new_keymap(cli):
     # check directories
     if not kb_path.exists():
         cli.log.error('Keyboard %s does not exist!', kb_path)
-        exit(1)
+        return False
 
     if not keymap_path_default.exists():
         cli.log.error('Keyboard default %s does not exist!', keymap_path_default)
-        exit(1)
+        return False
 
     if keymap_path_new.exists():
         cli.log.error('Keymap %s already exists!', keymap_path_new)
-        exit(1)
+        return False
 
     # create user directory with default keymap files
     shutil.copytree(keymap_path_default, keymap_path_new, symlinks=True)

--- a/lib/python/qmk/tests/.gitignore
+++ b/lib/python/qmk/tests/.gitignore
@@ -1,0 +1,2 @@
+# Ignore generated info.json from pytest
+info.json

--- a/lib/python/qmk/tests/test_cli_commands.py
+++ b/lib/python/qmk/tests/test_cli_commands.py
@@ -45,8 +45,9 @@ def test_config():
 
 
 def test_kle2json():
-    result = check_subcommand('kle2json', 'kle.txt', '-f')
+    result = check_subcommand('kle2json', 'lib/python/qmk/tests/kle.txt', '-f')
     check_returncode(result)
+    assert 'Wrote out' in result.stdout
 
 
 def test_doctor():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

With https://github.com/qmk/qmk_cli/pull/27 merged, subcommands can now produce exit codes when CLI is installed.

Any instances where `exit(1)` has been changed to `return False` would be broken until a new release of CLI is published (and the user updates it), but depending on whether anything currently relies on the exit codes this may not be an issue. I think this should also remove the need to [grep here](https://github.com/qmk/qmk_firmware/blob/master/.github/workflows/info.yml#L50), too.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
