### PR TITLE
Enable forcing of master side for split boards

### DIFF
--- a/common_features.mk
+++ b/common_features.mk
@@ -428,8 +428,10 @@ ifeq ($(strip $(SPLIT_KEYBOARD)), yes)
         # Functions added via QUANTUM_LIB_SRC are only included in the final binary if they're called.
         # Unused functions are pruned away, which is why we can add multiple drivers here without bloat.
         ifeq ($(PLATFORM),AVR)
-            QUANTUM_LIB_SRC += i2c_master.c \
-                               i2c_slave.c
+            ifneq ($(NO_I2C),yes)
+                QUANTUM_LIB_SRC += i2c_master.c \
+                                   i2c_slave.c
+            endif
         endif
 
         SERIAL_DRIVER ?= bitbang

--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -290,6 +290,14 @@ There are a few different ways to set handedness for split keyboards (listed in 
   * Default behavior for ARM
   * Required for AVR Teensy
 
+* `#define FORCE_MASTER`
+  * Delegates master and slave manually.
+  * The master half setting follows `#define MASTER_LEFT` or `#define MASTER_RIGHT`.
+  * This avoids having to wait for the timeout for USB-based detection. It makes split boards usable in situations, where USB detection leads to problems:
+    * Power cycle/power up PC
+    * Use in BIOS/UEFI without any delay
+  * Disadvantage: The USB cable can only be connected to the chosen master half!
+  
 * `#define SPLIT_USB_TIMEOUT 2000`
   * Maximum timeout when detecting master/slave when using `SPLIT_USB_DETECT`
 

--- a/drivers/avr/serial.c
+++ b/drivers/avr/serial.c
@@ -20,11 +20,11 @@
 
 #ifdef SOFT_SERIAL_PIN
 
-#    ifdef __AVR_ATmega32U4__
-// if using ATmega32U4 I2C, can not use PD0 and PD1 in soft serial.
+#    if defined(__AVR_ATmega16U2__) || defined(__AVR_ATmega32U2__) || defined(__AVR_ATmega16U4__) || defined(__AVR_ATmega32U4__)
+// if using ATmegaxxU4 I2C, can not use PD0 and PD1 in soft serial.
 #        ifdef USE_AVR_I2C
 #            if SOFT_SERIAL_PIN == D0 || SOFT_SERIAL_PIN == D1
-#                error Using ATmega32U4 I2C, so can not use PD0, PD1
+#                error Using ATmegaxxU4 I2C, so can not use PD0, PD1
 #            endif
 #        endif
 
@@ -52,7 +52,7 @@
 #                define EICRx_BIT (~(_BV(ISC30) | _BV(ISC31)))
 #                define SERIAL_PIN_INTERRUPT INT3_vect
 #            endif
-#        elif SOFT_SERIAL_PIN == E6
+#        elif (defined(__AVR_ATmega16U4__) || defined(__AVR_ATmega32U4__)) && SOFT_SERIAL_PIN == E6
 #            define EIMSK_BIT _BV(INT6)
 #            define EICRx_BIT (~(_BV(ISC60) | _BV(ISC61)))
 #            define SERIAL_PIN_INTERRUPT INT6_vect
@@ -61,7 +61,7 @@
 #        endif
 
 #    else
-#        error serial.c now support ATmega32U4 only
+#        error serial.c currently only supports ATmegaxxU2 and ATmegaxxU4
 #    endif
 
 #    define ALWAYS_INLINE __attribute__((always_inline))

--- a/quantum/mcu_selection.mk
+++ b/quantum/mcu_selection.mk
@@ -252,6 +252,9 @@ ifneq (,$(filter $(MCU),atmega16u2 atmega32u2 atmega16u4 atmega32u4 at90usb646 a
   ifeq (,$(filter $(NO_INTERRUPT_CONTROL_ENDPOINT),yes))
     OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
   endif
+  ifneq (,$(filter $(MCU),atmega16u2 atmega32u2))
+    NO_I2C = yes
+  endif
 endif
 
 ifneq (,$(filter $(MCU),atmega32a))

--- a/quantum/process_keycode/process_midi.c
+++ b/quantum/process_keycode/process_midi.c
@@ -41,12 +41,12 @@ static int8_t   midi_modulation_step;
 static uint16_t midi_modulation_timer;
 midi_config_t   midi_config;
 
-inline uint8_t compute_velocity(uint8_t setting) { return (setting + 1) * (128 / (MIDI_VELOCITY_MAX - MIDI_VELOCITY_MIN + 1)); }
+inline uint8_t compute_velocity(uint8_t setting) { return setting * (128 / (MIDI_VELOCITY_MAX - MIDI_VELOCITY_MIN)); }
 
 void midi_init(void) {
     midi_config.octave              = MI_OCT_2 - MIDI_OCTAVE_MIN;
     midi_config.transpose           = 0;
-    midi_config.velocity            = (MIDI_VELOCITY_MAX - MIDI_VELOCITY_MIN);
+    midi_config.velocity            = 127;
     midi_config.channel             = 0;
     midi_config.modulation_interval = 8;
 
@@ -66,7 +66,7 @@ bool process_midi(uint16_t keycode, keyrecord_t *record) {
         case MIDI_TONE_MIN ... MIDI_TONE_MAX: {
             uint8_t channel  = midi_config.channel;
             uint8_t tone     = keycode - MIDI_TONE_MIN;
-            uint8_t velocity = compute_velocity(midi_config.velocity);
+            uint8_t velocity = midi_config.velocity;
             if (record->event.pressed) {
                 uint8_t note = midi_compute_note(keycode);
                 midi_send_noteon(&midi_device, channel, note, velocity);
@@ -122,19 +122,30 @@ bool process_midi(uint16_t keycode, keyrecord_t *record) {
             return false;
         case MIDI_VELOCITY_MIN ... MIDI_VELOCITY_MAX:
             if (record->event.pressed) {
-                midi_config.velocity = keycode - MIDI_VELOCITY_MIN;
+                midi_config.velocity = compute_velocity(keycode - MIDI_VELOCITY_MIN);
                 dprintf("midi velocity %d\n", midi_config.velocity);
             }
             return false;
         case MI_VELD:
             if (record->event.pressed && midi_config.velocity > 0) {
-                midi_config.velocity--;
+                if (midi_config.velocity == 127) {
+                    midi_config.velocity -= 10;
+                } else if (midi_config.velocity > 12) {
+                    midi_config.velocity -= 13;
+                } else {
+                    midi_config.velocity = 0;
+                }
+
                 dprintf("midi velocity %d\n", midi_config.velocity);
             }
             return false;
         case MI_VELU:
-            if (record->event.pressed) {
-                midi_config.velocity++;
+            if (record->event.pressed && midi_config.velocity < 127) {
+                if (midi_config.velocity < 115) {
+                    midi_config.velocity += 13;
+                } else {
+                    midi_config.velocity = 127;
+                }
                 dprintf("midi velocity %d\n", midi_config.velocity);
             }
             return false;

--- a/quantum/process_keycode/process_midi.h
+++ b/quantum/process_keycode/process_midi.h
@@ -35,7 +35,7 @@ typedef union {
     struct {
         uint8_t octave : 4;
         int8_t  transpose : 4;
-        uint8_t velocity : 4;
+        uint8_t velocity : 7;
         uint8_t channel : 4;
         uint8_t modulation_interval : 4;
     };

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -343,7 +343,8 @@ enum quantum_keycodes {
     MI_TRNSU,  // transpose up
 
     MIDI_VELOCITY_MIN,
-    MI_VEL_1 = MIDI_VELOCITY_MIN,
+    MI_VEL_0 = MIDI_VELOCITY_MIN,
+    MI_VEL_1,
     MI_VEL_2,
     MI_VEL_3,
     MI_VEL_4,

--- a/quantum/split_common/split_util.c
+++ b/quantum/split_common/split_util.c
@@ -35,6 +35,10 @@
 #    define SPLIT_USB_DETECT  // Force this on for now
 #endif
 
+#ifdef FORCE_MASTER
+#   define SPLIT_USB_DETECT
+#endif
+
 volatile bool isLeftHand = true;
 
 #if defined(SPLIT_USB_DETECT)
@@ -121,6 +125,7 @@ __attribute__((weak)) bool is_keyboard_left(void) {
 }
 
 __attribute__((weak)) bool is_keyboard_master(void) {
+#ifndef FORCE_MASTER
     static enum { UNKNOWN, MASTER, SLAVE } usbstate = UNKNOWN;
 
     // only check once, as this is called often
@@ -129,6 +134,25 @@ __attribute__((weak)) bool is_keyboard_master(void) {
     }
 
     return (usbstate == MASTER);
+#else
+#   if defined(SPLIT_HAND_PIN) || defined(SPLIT_HAND_MATRIX_GRID) || defined(EE_HANDS)
+#       if defined(MASTER_RIGHT)
+    bool master = !is_keyboard_left();
+#       endif    
+    bool master = is_keyboard_left();
+
+    if(!master)
+    {
+        usbDisable();
+    }
+
+    return master;
+
+#   else
+#       error "Forcing the master side requires left/right identification by means of SPLIT_HAND_PIN, SPLIT_HAND_MATRIX_GRID, or EE_HANDS!"
+#   endif
+    
+#endif
 }
 
 // this code runs before the keyboard is fully initialized

--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,12 @@
 [![GitHub contributors](https://img.shields.io/github/contributors/qmk/qmk_firmware.svg)](https://github.com/qmk/qmk_firmware/pulse/monthly)
 [![GitHub forks](https://img.shields.io/github/forks/qmk/qmk_firmware.svg?style=social&label=Fork)](https://github.com/qmk/qmk_firmware/)
 
+# THIS IS THE DEVELOP BRANCH
+
+Warning- This is the `develop` branch of QMK Firmware. You may encounter broken code here. Please see [Breaking Changes](https://docs.qmk.fm/#/breaking_changes) for more information.
+
+# Original readme continues
+
 This is a keyboard firmware based on the [tmk\_keyboard firmware](https://github.com/tmk/tmk_keyboard) with some useful features for Atmel AVR and ARM controllers, and more specifically, the [OLKB product line](https://olkb.com), the [ErgoDox EZ](https://ergodox-ez.com) keyboard, and the [Clueboard product line](https://clueboard.co).
 
 ## Documentation

--- a/tmk_core/common/matrix.h
+++ b/tmk_core/common/matrix.h
@@ -30,16 +30,6 @@ typedef uint32_t matrix_row_t;
 #    error "MATRIX_COLS: invalid value"
 #endif
 
-#if (MATRIX_ROWS <= 8)
-typedef uint8_t matrix_col_t;
-#elif (MATRIX_ROWS <= 16)
-typedef uint16_t matrix_col_t;
-#elif (MATRIX_ROWS <= 32)
-typedef uint32_t matrix_col_t;
-#else
-#    error "MATRIX_ROWS: invalid value"
-#endif
-
 #define MATRIX_ROW_SHIFTER ((matrix_row_t)1)
 
 #define MATRIX_IS_ON(row, col) (matrix_get_row(row) && (1 << col))


### PR DESCRIPTION
## Description

Since changing split behaviour as in https://github.com/qmk/qmk_firmware/pull/9742 requires too many changes to the code base (at the moment), I made it possible to force one side of a split board to be the master. This is done regardless of the USB connection status. Therefore, keyboard startup happens with no timeout or delay.

This can be enabled by defining `FORCE_MASTER` in a keyboard's `config.h`. The master side is then determined by `MASTER_RIGHT` or `MASTER_LEFT`, so the setting defaults to making the left side the master.

A check in the define statements prevents an infinite loop.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
