### PR TITLE
Add description in Bluetooth docs for requiring NKRO to be disabled

### DIFF
--- a/docs/feature_bluetooth.md
+++ b/docs/feature_bluetooth.md
@@ -26,7 +26,10 @@ A Bluefruit UART friend can be converted to an SPI friend, however this [require
 
 <!-- FIXME: Document bluetooth support more completely. -->
 ## Bluetooth Rules.mk Options
-Use only one of these
+
+The currently supported Bluetooth chipsets do not support [N-Key Rollover (NKRO)](reference_glossary.md#n-key-rollover-nkro), so `rules.mk` must contain `NKRO_ENABLE = no`.
+
+Use only one of these to enable Bluetooth:
 * BLUETOOTH_ENABLE = yes (Legacy Option)
 * BLUETOOTH = RN42
 * BLUETOOTH = AdafruitBLE

--- a/tmk_core/common.mk
+++ b/tmk_core/common.mk
@@ -99,11 +99,15 @@ ifeq ($(strip $(COMMAND_ENABLE)), yes)
 endif
 
 ifeq ($(strip $(NKRO_ENABLE)), yes)
-    ifneq ($(PROTOCOL),VUSB)
+    ifeq ($(PROTOCOL), VUSB)
+        $(info NKRO is not currently supported on V-USB, and has been disabled.)
+    else ifeq ($(strip $(BLUETOOTH_ENABLE)), yes)
+        $(info NKRO is not currently supported with Bluetooth, and has been disabled.)
+    else ifneq ($(BLUETOOTH),)
+        $(info NKRO is not currently supported with Bluetooth, and has been disabled.)
+    else
         TMK_COMMON_DEFS += -DNKRO_ENABLE
         SHARED_EP_ENABLE = yes
-    else
-        $(info NKRO is not currently supported on V-USB, and has been disabled.)
     endif
 endif
 


### PR DESCRIPTION
Expand documentation in Bluetooth rules.mk options for requiring 

## Description

As seen in #10314, the Bluetooth documentation is missing some information about support for NKRO, and how enabling it can be problematic.
This change expands slightly on the Bluetooth feature documentation, and while not nearly comprehensive or sufficient for covering managing Bluetooth in qmk, could likely save some time and troubleshooting.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

None

## Checklist

- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
