### PR TITLE
Fix MIDI sustain effect issue

### DIFF
--- a/quantum/process_keycode/process_midi.c
+++ b/quantum/process_keycode/process_midi.c
@@ -68,10 +68,12 @@ bool process_midi(uint16_t keycode, keyrecord_t *record) {
             uint8_t tone     = keycode - MIDI_TONE_MIN;
             uint8_t velocity = compute_velocity(midi_config.velocity);
             if (record->event.pressed) {
-                uint8_t note = midi_compute_note(keycode);
-                midi_send_noteon(&midi_device, channel, note, velocity);
-                dprintf("midi noteon channel:%d note:%d velocity:%d\n", channel, note, velocity);
-                tone_status[tone] = note;
+                if (tone_status[tone] == MIDI_INVALID_NOTE) {
+                    uint8_t note = midi_compute_note(keycode);
+                    midi_send_noteon(&midi_device, channel, note, velocity);
+                    dprintf("midi noteon channel:%d note:%d velocity:%d\n", channel, note, velocity);
+                    tone_status[tone] = note;
+                }
             } else {
                 uint8_t note = tone_status[tone];
                 if (note != MIDI_INVALID_NOTE) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
When duplicate notes are pressed, the duplicate notes keep ringing or make the sustain effect until you unplug the USB cable.
For example, "duplicate notes" here means **C**, **E** and **G**  when C chord (**C, E, and G**) and C7 chord (**C, E, G**, and A#) are pressed at the same time.  
This issue can be replicated with GarageBand, Logic Pro, Piano 10 (Windows), etc.
(Ableton Live 10 didn't have this problem.)

<!--- Describe your changes in detail here. -->
A quick fix was found as the modification shown in the process_midi.c code.
Assuming QMK Firmware is mainly based on the "common sense" that there are no duplicate keys on the single keyboard.
Number keys on the upper row and num-pad keys are individual keys.
Probably handling duplicate keys are not well-developed because of such reason.
I guess something irregular happens when the same keys are pressed before the first one being released.

The modification is to suppress the second or further midi_send_noteon() if the note is already turned on.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/qmk/qmk_firmware/issues/10199#issue-688525281

## Known Issues, which we define it is out of the scope of this push request

It should play the notes which are pressed all the time. However, in some sequences, the notes turn OFF even though the keys are remained pressed.
It happens when the same note(s) is/are played with multiple keys.
For example, when two keys are assigned for `MI_C` and when one of the keys is released after both were pressed, `MI_C` should stay ON since another key is still pressed. However, `MI_C` turns OFF when the first key is released.

Thanks to jakobkg and tzarc, the details are described [here](https://github.com/qmk/qmk_firmware/issues/10199#issuecomment-691449929) and [here](https://github.com/qmk/qmk_firmware/pull/10361#issuecomment-703148519).

First of all, we'd like to get rid of the problematic sustain effect immediately by this push request.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
