### PR TITLE
OLED driver fixes

### DIFF
--- a/drivers/oled/oled_driver.c
+++ b/drivers/oled/oled_driver.c
@@ -469,10 +469,13 @@ void oled_write_raw(const char *data, uint16_t size) {
 }
 
 void oled_write_pixel(uint8_t x, uint8_t y, bool on) {
-    if (x >= OLED_DISPLAY_WIDTH || y >= OLED_DISPLAY_HEIGHT) {
+    if (x >= oled_rotation_width) {
         return;
     }
-    uint16_t index = x + (y / 8) * OLED_DISPLAY_WIDTH;
+    uint16_t index = x + (y / 8) * oled_rotation_width;
+    if (index >= OLED_MATRIX_SIZE) {
+        return;
+    }
     uint8_t data = oled_buffer[index];
     if (on) {
         data |= (1 << (y % 8));

--- a/drivers/oled/oled_driver.c
+++ b/drivers/oled/oled_driver.c
@@ -75,8 +75,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define CHARGE_PUMP 0x8D
 
 // Misc defines
-#define OLED_BLOCK_COUNT (sizeof(OLED_BLOCK_TYPE) * 8)
-#define OLED_BLOCK_SIZE (OLED_MATRIX_SIZE / OLED_BLOCK_COUNT)
+#ifndef OLED_BLOCK_COUNT
+#    define OLED_BLOCK_COUNT (sizeof(OLED_BLOCK_TYPE) * 8)
+#endif
+#ifndef OLED_BLOCK_SIZE
+#    define OLED_BLOCK_SIZE (OLED_MATRIX_SIZE / OLED_BLOCK_COUNT)
+#endif
 
 // i2c defines
 #define I2C_CMD 0x00

--- a/drivers/oled/oled_driver.c
+++ b/drivers/oled/oled_driver.c
@@ -413,7 +413,7 @@ void oled_write_char(const char data, bool invert) {
         uint16_t index = oled_cursor - &oled_buffer[0];
         oled_dirty |= (1 << (index / OLED_BLOCK_SIZE));
         // Edgecase check if the written data spans the 2 chunks
-        oled_dirty |= (1 << ((index + OLED_FONT_WIDTH) / OLED_BLOCK_SIZE));
+        oled_dirty |= (1 << ((index + OLED_FONT_WIDTH - 1) / OLED_BLOCK_SIZE));
     }
 
     // Finally move to the next char

--- a/drivers/oled/oled_driver.c
+++ b/drivers/oled/oled_driver.c
@@ -275,7 +275,7 @@ void oled_render(void) {
 
     // Find first dirty block
     uint8_t update_start = 0;
-    while (!(oled_dirty & (1 << update_start))) {
+    while (!(oled_dirty & ((OLED_BLOCK_TYPE)1 << update_start))) {
         ++update_start;
     }
 
@@ -321,7 +321,7 @@ void oled_render(void) {
     oled_on();
 
     // Clear dirty flag
-    oled_dirty &= ~(1 << update_start);
+    oled_dirty &= ~((OLED_BLOCK_TYPE)1 << update_start);
 }
 
 void oled_set_cursor(uint8_t col, uint8_t line) {
@@ -411,9 +411,9 @@ void oled_write_char(const char data, bool invert) {
     // Dirty check
     if (memcmp(&oled_temp_buffer, oled_cursor, OLED_FONT_WIDTH)) {
         uint16_t index = oled_cursor - &oled_buffer[0];
-        oled_dirty |= (1 << (index / OLED_BLOCK_SIZE));
+        oled_dirty |= ((OLED_BLOCK_TYPE)1 << (index / OLED_BLOCK_SIZE));
         // Edgecase check if the written data spans the 2 chunks
-        oled_dirty |= (1 << ((index + OLED_FONT_WIDTH - 1) / OLED_BLOCK_SIZE));
+        oled_dirty |= ((OLED_BLOCK_TYPE)1 << ((index + OLED_FONT_WIDTH - 1) / OLED_BLOCK_SIZE));
     }
 
     // Finally move to the next char
@@ -463,7 +463,7 @@ void oled_write_raw_byte(const char data, uint16_t index) {
     if (index > OLED_MATRIX_SIZE) index = OLED_MATRIX_SIZE;
     if (oled_buffer[index] == data) return;
     oled_buffer[index] = data;
-    oled_dirty |= (1 << (index / OLED_BLOCK_SIZE));
+    oled_dirty |= ((OLED_BLOCK_TYPE)1 << (index / OLED_BLOCK_SIZE));
 }
 
 void oled_write_raw(const char *data, uint16_t size) {
@@ -471,7 +471,7 @@ void oled_write_raw(const char *data, uint16_t size) {
     for (uint16_t i = 0; i < size; i++) {
         if (oled_buffer[i] == data[i]) continue;
         oled_buffer[i] = data[i];
-        oled_dirty |= (1 << (i / OLED_BLOCK_SIZE));
+        oled_dirty |= ((OLED_BLOCK_TYPE)1 << (i / OLED_BLOCK_SIZE));
     }
 }
 
@@ -491,7 +491,7 @@ void oled_write_pixel(uint8_t x, uint8_t y, bool on) {
     }
     if (oled_buffer[index] != data) {
         oled_buffer[index] = data;
-        oled_dirty |= (1 << (index / OLED_BLOCK_SIZE));
+        oled_dirty |= ((OLED_BLOCK_TYPE)1 << (index / OLED_BLOCK_SIZE));
     }
 }
 
@@ -515,7 +515,7 @@ void oled_write_raw_P(const char *data, uint16_t size) {
         uint8_t c = pgm_read_byte(data++);
         if (oled_buffer[i] == c) continue;
         oled_buffer[i] = c;
-        oled_dirty |= (1 << (i / OLED_BLOCK_SIZE));
+        oled_dirty |= ((OLED_BLOCK_TYPE)1 << (i / OLED_BLOCK_SIZE));
     }
 }
 #endif  // defined(__AVR__)

--- a/drivers/oled/oled_driver.c
+++ b/drivers/oled/oled_driver.c
@@ -473,12 +473,16 @@ void oled_write_pixel(uint8_t x, uint8_t y, bool on) {
         return;
     }
     uint16_t index = x + (y / 8) * OLED_DISPLAY_WIDTH;
+    uint8_t data = oled_buffer[index];
     if (on) {
-        oled_buffer[index] |= (1 << (y % 8));
+        data |= (1 << (y % 8));
     } else {
-        oled_buffer[index] &= ~(1 << (y % 8));
+        data &= ~(1 << (y % 8));
     }
-    oled_dirty |= (1 << (index / OLED_BLOCK_SIZE));
+    if (oled_buffer[index] != data) {
+        oled_buffer[index] = data;
+        oled_dirty |= (1 << (index / OLED_BLOCK_SIZE));
+    }
 }
 
 #if defined(__AVR__)

--- a/drivers/oled/oled_driver.c
+++ b/drivers/oled/oled_driver.c
@@ -82,6 +82,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    define OLED_BLOCK_SIZE (OLED_MATRIX_SIZE / OLED_BLOCK_COUNT)
 #endif
 
+#define OLED_ALL_BLOCKS_MASK (((((OLED_BLOCK_TYPE)1 << (OLED_BLOCK_COUNT - 1)) - 1) << 1) | 1)
+
 // i2c defines
 #define I2C_CMD 0x00
 #define I2C_DATA 0x40
@@ -216,7 +218,7 @@ __attribute__((weak)) oled_rotation_t oled_init_user(oled_rotation_t rotation) {
 void oled_clear(void) {
     memset(oled_buffer, 0, sizeof(oled_buffer));
     oled_cursor = &oled_buffer[0];
-    oled_dirty  = -1;  // -1 will be max value as long as display_dirty is unsigned type
+    oled_dirty  = OLED_ALL_BLOCKS_MASK;
 }
 
 static void calc_bounds(uint8_t update_start, uint8_t *cmd_array) {
@@ -266,6 +268,7 @@ static void rotate_90(const uint8_t *src, uint8_t *dest) {
 
 void oled_render(void) {
     // Do we have work to do?
+    oled_dirty &= OLED_ALL_BLOCKS_MASK;
     if (!oled_dirty || oled_scrolling) {
         return;
     }
@@ -445,7 +448,7 @@ void oled_pan(bool left) {
             }
         }
     }
-    oled_dirty = ~((OLED_BLOCK_TYPE)0);
+    oled_dirty = OLED_ALL_BLOCKS_MASK;
 }
 
 oled_buffer_reader_t oled_read_raw(uint16_t start_index) {
@@ -606,7 +609,7 @@ bool oled_scroll_off(void) {
             return oled_scrolling;
         }
         oled_scrolling = false;
-        oled_dirty     = -1;
+        oled_dirty     = OLED_ALL_BLOCKS_MASK;
     }
     return !oled_scrolling;
 }


### PR DESCRIPTION
## Description

Fix several problems in the OLED driver:
1. `oled_write_pixel()` was unconditionally setting the dirty bit for the touched block, even if the pixel value was not actually changed. This made `oled_write_pixel()` unusable inside `oled_task_user()` if the implementation of `oled_task_user()` was redrawing the whole image unconditionally.
2. `oled_write_pixel()` did not handle the 90° or 270° rotation properly.
3. Attempting to override `OLED_BLOCK_COUNT` with a custom value in config.h resulted in a compile error, even though the documentation listed `OLED_BLOCK_COUNT` as one of the configurable values.
4. Using a custom `OLED_BLOCK_COUNT` could result in out-of-range accesses inside `oled_render()`, because in this case some bits in `oled_dirty` may not correspond to existing blocks, but some code could set those bits.
5. `oled_write_char()` could dirty more blocks than needed, because it tried to dirty the block corresponding to the location just beyond the last column of the character, instead of that last column.
6. ` #define OLED_BLOCK_TYPE uint32_t` did not work properly on AVR, because some bit shifts were performed on `int` values, which are 16 bit on AVR.

Fixes are in separate commits, but they touch the same code, therefore all of them are in a single PR.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
