### PR TITLE
Update OLED driver to support some new displays

### DIFF
--- a/drivers/oled/oled_driver.c
+++ b/drivers/oled/oled_driver.c
@@ -225,9 +225,6 @@ static void calc_bounds(uint8_t update_start, uint8_t *cmd_array) {
     cmd_array[0] = PAM_PAGE_ADDR | start_page;
     cmd_array[1] = PAM_SETCOLUMN_LSB | ((OLED_COLUMN_OFFSET + start_column) & 0x0f);
     cmd_array[2] = PAM_SETCOLUMN_MSB | ((OLED_COLUMN_OFFSET + start_column) >> 4 & 0x0f);
-    cmd_array[3] = NOP;
-    cmd_array[4] = NOP;
-    cmd_array[5] = NOP;
 #else
     // Commands for use in Horizontal Addressing mode.
     cmd_array[1] = start_column + OLED_COLUMN_OFFSET;
@@ -252,10 +249,19 @@ static void calc_bounds_90(uint8_t update_start, uint8_t *cmd_array) {
     // Top page number for a block which is at the bottom edge of the screen.
     const uint8_t bottom_block_top_page  = (height_in_pages - page_inc_per_block) % height_in_pages;
 
+#if (OLED_IC == OLED_IC_SH1106)
+    // Only the Page Addressing Mode is supported
+    uint8_t start_page   = bottom_block_top_page - (OLED_BLOCK_SIZE * update_start % OLED_DISPLAY_HEIGHT / 8);
+    uint8_t start_column = OLED_BLOCK_SIZE * update_start / OLED_DISPLAY_HEIGHT * 8;
+    cmd_array[0] = PAM_PAGE_ADDR | start_page;
+    cmd_array[1] = PAM_SETCOLUMN_LSB | ((OLED_COLUMN_OFFSET + start_column) & 0x0f);
+    cmd_array[2] = PAM_SETCOLUMN_MSB | ((OLED_COLUMN_OFFSET + start_column) >> 4 & 0x0f);
+#else
     cmd_array[1] = OLED_BLOCK_SIZE * update_start / OLED_DISPLAY_HEIGHT * 8 + OLED_COLUMN_OFFSET;
     cmd_array[4] = bottom_block_top_page - (OLED_BLOCK_SIZE * update_start % OLED_DISPLAY_HEIGHT / 8);
     cmd_array[2] = (OLED_BLOCK_SIZE + OLED_DISPLAY_HEIGHT - 1) / OLED_DISPLAY_HEIGHT * 8 - 1 + cmd_array[1];
     cmd_array[5] = (OLED_BLOCK_SIZE + OLED_DISPLAY_HEIGHT - 1) % OLED_DISPLAY_HEIGHT / 8 + cmd_array[4];
+#endif
 }
 
 uint8_t crot(uint8_t a, int8_t n) {
@@ -286,7 +292,11 @@ void oled_render(void) {
     }
 
     // Set column & page position
+#if (OLED_IC != OLED_IC_SH1106)
     static uint8_t display_start[] = {I2C_CMD, COLUMN_ADDR, 0, OLED_DISPLAY_WIDTH - 1, PAGE_ADDR, 0, OLED_DISPLAY_HEIGHT / 8 - 1};
+#else
+    static uint8_t display_start[] = {I2C_CMD, PAM_PAGE_ADDR, PAM_SETCOLUMN_LSB, PAM_SETCOLUMN_MSB};
+#endif
     if (!HAS_FLAGS(oled_rotation, OLED_ROTATION_90)) {
         calc_bounds(update_start, &display_start[1]);  // Offset from I2C_CMD byte at the start
     } else {
@@ -316,11 +326,32 @@ void oled_render(void) {
             rotate_90(&oled_buffer[OLED_BLOCK_SIZE * update_start + source_map[i]], &temp_buffer[target_map[i]]);
         }
 
+#if (OLED_IC != OLED_IC_SH1106)
         // Send render data chunk after rotating
         if (I2C_WRITE_REG(I2C_DATA, &temp_buffer[0], OLED_BLOCK_SIZE) != I2C_STATUS_SUCCESS) {
             print("oled_render90 data failed\n");
             return;
         }
+#else
+        // For SH1106 the data chunk must be split into separate pieces for each page
+        const uint8_t columns_in_block = (OLED_BLOCK_SIZE + OLED_DISPLAY_HEIGHT - 1) / OLED_DISPLAY_HEIGHT * 8;
+        const uint8_t num_pages = OLED_BLOCK_SIZE / columns_in_block;
+        for (uint8_t i = 0; i < num_pages; ++i) {
+            // Send column & page position for all pages except the first one
+            if (i > 0) {
+                display_start[1]++;
+                if (I2C_TRANSMIT(display_start) != I2C_STATUS_SUCCESS) {
+                    print("oled_render offset command failed\n");
+                    return;
+                }
+            }
+            // Send data for the page
+            if (I2C_WRITE_REG(I2C_DATA, &temp_buffer[columns_in_block * i], columns_in_block) != I2C_STATUS_SUCCESS) {
+                print("oled_render90 data failed\n");
+                return;
+            }
+        }
+#endif
     }
 
     // Turn on display if it is off

--- a/drivers/oled/oled_driver.c
+++ b/drivers/oled/oled_driver.c
@@ -230,7 +230,7 @@ static void calc_bounds(uint8_t update_start, uint8_t *cmd_array) {
     cmd_array[5] = NOP;
 #else
     // Commands for use in Horizontal Addressing mode.
-    cmd_array[1] = start_column;
+    cmd_array[1] = start_column + OLED_COLUMN_OFFSET;
     cmd_array[4] = start_page;
     cmd_array[2] = (OLED_BLOCK_SIZE + OLED_DISPLAY_WIDTH - 1) % OLED_DISPLAY_WIDTH + cmd_array[1];
     cmd_array[5] = (OLED_BLOCK_SIZE + OLED_DISPLAY_WIDTH - 1) / OLED_DISPLAY_WIDTH - 1;
@@ -238,7 +238,7 @@ static void calc_bounds(uint8_t update_start, uint8_t *cmd_array) {
 }
 
 static void calc_bounds_90(uint8_t update_start, uint8_t *cmd_array) {
-    cmd_array[1] = OLED_BLOCK_SIZE * update_start / OLED_DISPLAY_HEIGHT * 8;
+    cmd_array[1] = OLED_BLOCK_SIZE * update_start / OLED_DISPLAY_HEIGHT * 8 + OLED_COLUMN_OFFSET;
     cmd_array[4] = OLED_BLOCK_SIZE * update_start % OLED_DISPLAY_HEIGHT;
     cmd_array[2] = (OLED_BLOCK_SIZE + OLED_DISPLAY_HEIGHT - 1) / OLED_DISPLAY_HEIGHT * 8 - 1 + cmd_array[1];
     ;

--- a/drivers/oled/oled_driver.c
+++ b/drivers/oled/oled_driver.c
@@ -233,16 +233,29 @@ static void calc_bounds(uint8_t update_start, uint8_t *cmd_array) {
     cmd_array[1] = start_column + OLED_COLUMN_OFFSET;
     cmd_array[4] = start_page;
     cmd_array[2] = (OLED_BLOCK_SIZE + OLED_DISPLAY_WIDTH - 1) % OLED_DISPLAY_WIDTH + cmd_array[1];
-    cmd_array[5] = (OLED_BLOCK_SIZE + OLED_DISPLAY_WIDTH - 1) / OLED_DISPLAY_WIDTH - 1;
+    cmd_array[5] = (OLED_BLOCK_SIZE + OLED_DISPLAY_WIDTH - 1) / OLED_DISPLAY_WIDTH - 1 + cmd_array[4];
 #endif
 }
 
 static void calc_bounds_90(uint8_t update_start, uint8_t *cmd_array) {
+    // Block numbering starts from the bottom left corner, going up and then to
+    // the right.  The controller needs the page and column numbers for the top
+    // left and bottom right corners of that block.
+
+    // Total number of pages across the screen height.
+    const uint8_t height_in_pages = OLED_DISPLAY_HEIGHT / 8;
+
+    // Difference of starting page numbers for adjacent blocks; may be 0 if
+    // blocks are large enough to occupy one or more whole 8px columns.
+    const uint8_t page_inc_per_block = OLED_BLOCK_SIZE % OLED_DISPLAY_HEIGHT / 8;
+
+    // Top page number for a block which is at the bottom edge of the screen.
+    const uint8_t bottom_block_top_page  = (height_in_pages - page_inc_per_block) % height_in_pages;
+
     cmd_array[1] = OLED_BLOCK_SIZE * update_start / OLED_DISPLAY_HEIGHT * 8 + OLED_COLUMN_OFFSET;
-    cmd_array[4] = OLED_BLOCK_SIZE * update_start % OLED_DISPLAY_HEIGHT;
+    cmd_array[4] = bottom_block_top_page - (OLED_BLOCK_SIZE * update_start % OLED_DISPLAY_HEIGHT / 8);
     cmd_array[2] = (OLED_BLOCK_SIZE + OLED_DISPLAY_HEIGHT - 1) / OLED_DISPLAY_HEIGHT * 8 - 1 + cmd_array[1];
-    ;
-    cmd_array[5] = (OLED_BLOCK_SIZE + OLED_DISPLAY_HEIGHT - 1) % OLED_DISPLAY_HEIGHT / 8;
+    cmd_array[5] = (OLED_BLOCK_SIZE + OLED_DISPLAY_HEIGHT - 1) % OLED_DISPLAY_HEIGHT / 8 + cmd_array[4];
 }
 
 uint8_t crot(uint8_t a, int8_t n) {


### PR DESCRIPTION
## Description

Update the OLED driver to make it work with more display variants:
* [64×32 SSD1306](https://www.aliexpress.com/item/33047471191.html)
* [64×48 SSD1306](https://www.aliexpress.com/item/32847587362.html)
* [64×128 SH1107](https://www.aliexpress.com/item/4000465625534.html)

Changes which needed to be made in the driver code:
1. All of those displays need `#define OLED_COLUMN_OFFSET 32`, however, the existing driver code supported `OLED_COLUMN_OFFSET` only for `OLED_IC_SH1106`; the code for `OLED_IC_SSD1306` needed to be updated to use the offset too.
2. Address calculations in `calc_bounds_90()` were wrong, but they gave correct values for previously supported displays. The errors were uncovered when trying to configure the driver for the 64×48 display size — in this case the display width is no longer an integer multiple of the display height, and therefore blocks no longer occupy the whole height when using 90°/270° rotation, and the top and bottom page numbers in addressing commands must be calculated properly.
3. While fixing the code, I also implemented the 90°/270° rotation support for `OLED_IC_SH1106` — it gives a 20% to 50% performance penalty when testing on the 128×32 SSD1306 display (which actually supports both command sets), but this is still better than no rotation support at all.

Fixes from #10377 are also needed to make these displays work properly.

### TODO before removing the draft status

- [ ] Document `OLED_COLUMN_OFFSET` support for `OLED_IC_SSD1306`
- [ ] Document rotation support for `OLED_IC_SH1106`
- [ ] Figure out the appropriate location for example display configs and add configs for these displays there

### Configuration for the 64×32 SSD1306 display

```c
#define OLED_DISPLAY_CUSTOM
#define OLED_DISPLAY_WIDTH 64
#define OLED_DISPLAY_HEIGHT 32
#define OLED_COLUMN_OFFSET 32
#define OLED_MATRIX_SIZE (OLED_DISPLAY_HEIGHT / 8 * OLED_DISPLAY_WIDTH)
#define OLED_BLOCK_TYPE uint8_t
#define OLED_BLOCK_COUNT (sizeof(OLED_BLOCK_TYPE) * 8)
#define OLED_BLOCK_SIZE (OLED_MATRIX_SIZE / OLED_BLOCK_COUNT)
#define OLED_COM_PINS COM_PINS_ALT
#define OLED_SOURCE_MAP { 0, 8, 16, 24 }
#define OLED_TARGET_MAP { 24, 16, 8, 0 }
```

### Configuration for the 64×48 SSD1306 display

```c
#define OLED_DISPLAY_CUSTOM
#define OLED_DISPLAY_WIDTH 64
#define OLED_DISPLAY_HEIGHT 48
#define OLED_COLUMN_OFFSET 32
#define OLED_MATRIX_SIZE (OLED_DISPLAY_HEIGHT / 8 * OLED_DISPLAY_WIDTH)
#define OLED_BLOCK_TYPE uint32_t
#define OLED_BLOCK_COUNT 24
#define OLED_BLOCK_SIZE (OLED_MATRIX_SIZE / OLED_BLOCK_COUNT)
#define OLED_COM_PINS COM_PINS_ALT
#define OLED_SOURCE_MAP { 0, 8 }
#define OLED_TARGET_MAP { 8, 0 }
```

### Configuration for the 64×128 SH1107 display

```c
#define OLED_DISPLAY_CUSTOM
#define OLED_DISPLAY_WIDTH 64
#define OLED_DISPLAY_HEIGHT 128
#define OLED_COLUMN_OFFSET 32
#define OLED_MATRIX_SIZE (OLED_DISPLAY_HEIGHT / 8 * OLED_DISPLAY_WIDTH)
#define OLED_BLOCK_TYPE uint16_t
#define OLED_SOURCE_MAP { 0, 8, 16, 24, 32, 40, 48, 56 }
#define OLED_TARGET_MAP { 56, 48, 40, 32, 24, 16, 8, 0 }
#define OLED_BLOCK_COUNT (sizeof(OLED_BLOCK_TYPE) * 8)
#define OLED_BLOCK_SIZE (OLED_MATRIX_SIZE / OLED_BLOCK_COUNT)
#define OLED_COM_PINS COM_PINS_ALT
#define OLED_IC OLED_IC_SH1106
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
