### PR TITLE
Add function to determine if the OLED is on

### DIFF
--- a/docs/feature_oled_driver.md
+++ b/docs/feature_oled_driver.md
@@ -300,6 +300,10 @@ bool oled_on(void);
 // Returns true if the screen was off or turns off
 bool oled_off(void);
 
+// Returns true if the oled is currently on, false if it is
+// not
+bool is_oled_on(void);
+
 // Basically it's oled_render, but with timeout management and oled_task_user calling!
 void oled_task(void);
 

--- a/drivers/oled/oled_driver.c
+++ b/drivers/oled/oled_driver.c
@@ -534,6 +534,8 @@ bool oled_off(void) {
     return !oled_active;
 }
 
+bool is_oled_on(void) { return oled_active; }
+
 // Set the specific 8 lines rows of the screen to scroll.
 // 0 is the default for start, and 7 for end, which is the entire
 // height of the screen.  For 128x32 screens, rows 4-7 are not used.

--- a/drivers/oled/oled_driver.h
+++ b/drivers/oled/oled_driver.h
@@ -257,6 +257,10 @@ bool oled_on(void);
 // Returns true if the screen was off or turns off
 bool oled_off(void);
 
+// Returns true if the oled is currently on, false if it is
+// not
+bool is_oled_on(void);
+
 // Basically it's oled_render, but with timeout management and oled_task_user calling!
 void oled_task(void);
 


### PR DESCRIPTION
Split out from https://github.com/qmk/qmk_firmware/pull/10272. This adds a function to determine if the OLED is currently on, for usage in update code to make sure that you don't necessarily turn on the OLED again when it's currently off.