### PR TITLE
OLED display update interval support

### DIFF
--- a/docs/feature_oled_driver.md
+++ b/docs/feature_oled_driver.md
@@ -149,6 +149,7 @@ void oled_task_user(void) {
 |`OLED_SCROLL_TIMEOUT_RIGHT`|*Not defined*    |Scroll timeout direction is right when defined, left when undefined.                                                      |
 |`OLED_IC`                  |`OLED_IC_SSD1306`|Set to `OLED_IC_SH1106` if you're using the SH1106 OLED controller.                                                       |
 |`OLED_COLUMN_OFFSET`       |`0`              |(SH1106 only.) Shift output to the right this many pixels.<br />Useful for 128x64 displays centered on a 132x64 SH1106 IC.|
+|`OLED_UPDATE_INTERVAL_MS`  |`0`              |Set the time interval for updating the OLED display in ms. This will improve the matrix scan rate.                        |
 
  ## 128x64 & Custom sized OLED Displays
 

--- a/docs/feature_oled_driver.md
+++ b/docs/feature_oled_driver.md
@@ -149,7 +149,7 @@ void oled_task_user(void) {
 |`OLED_SCROLL_TIMEOUT_RIGHT`|*Not defined*    |Scroll timeout direction is right when defined, left when undefined.                                                      |
 |`OLED_IC`                  |`OLED_IC_SSD1306`|Set to `OLED_IC_SH1106` if you're using the SH1106 OLED controller.                                                       |
 |`OLED_COLUMN_OFFSET`       |`0`              |(SH1106 only.) Shift output to the right this many pixels.<br />Useful for 128x64 displays centered on a 132x64 SH1106 IC.|
-|`OLED_UPDATE_INTERVAL_MS`  |`0`              |Set the time interval for updating the OLED display in ms. This will improve the matrix scan rate.                        |
+|`OLED_UPDATE_INTERVAL`  |`0`              |Set the time interval for updating the OLED display in ms. This will improve the matrix scan rate.                        |
 
  ## 128x64 & Custom sized OLED Displays
 

--- a/drivers/oled/oled_driver.c
+++ b/drivers/oled/oled_driver.c
@@ -112,6 +112,9 @@ uint32_t oled_timeout;
 #if OLED_SCROLL_TIMEOUT > 0
 uint32_t oled_scroll_timeout;
 #endif
+#if OLED_UPDATE_INTERVAL_MS > 0
+uint16_t oled_update_timeout;
+#endif
 
 // Internal variables to reduce math instructions
 
@@ -618,6 +621,13 @@ void oled_task(void) {
     if (!oled_initialized) {
         return;
     }
+
+#if OLED_UPDATE_INTERVAL_MS > 0
+    if (timer_elapsed(oled_update_timeout) < OLED_UPDATE_INTERVAL_MS) {
+        return;
+    }
+    oled_update_timeout = timer_read();
+#endif
 
     oled_set_cursor(0, 0);
 

--- a/drivers/oled/oled_driver.c
+++ b/drivers/oled/oled_driver.c
@@ -622,8 +622,8 @@ void oled_task(void) {
         return;
     }
 
-#if OLED_UPDATE_INTERVAL_MS > 0
-    if (timer_elapsed(oled_update_timeout) < OLED_UPDATE_INTERVAL_MS) {
+#if OLED_UPDATE_INTERVAL > 0
+    if (timer_elapsed(oled_update_timeout) < OLED_UPDATE_INTERVAL) {
         return;
     }
     oled_update_timeout = timer_read();

--- a/drivers/oled/oled_driver.c
+++ b/drivers/oled/oled_driver.c
@@ -112,7 +112,7 @@ uint32_t oled_timeout;
 #if OLED_SCROLL_TIMEOUT > 0
 uint32_t oled_scroll_timeout;
 #endif
-#if OLED_UPDATE_INTERVAL_MS > 0
+#if OLED_UPDATE_INTERVAL > 0
 uint16_t oled_update_timeout;
 #endif
 


### PR DESCRIPTION
## Description

This PR adds support for OLED_UPDATE_INTERVAL_MS to oled_driver.c.

Use of the OLED driver has degraded matrix scan performance.
The matrix scan rate can be improved by changing the update interval of the OLED display to the length specified by OLED_UPDATE_INTERVAL.

Example.
* OLED_DRIVER_ENABLE = no

```
*** yushakobo - Helix rev3 5rows connected -- 0x3265:0x3
  > matrix scan frequency: 929
  > matrix scan frequency: 1071
  > matrix scan frequency: 1073
  > matrix scan frequency: 1074
```

* OLED_DRIVER_ENABLE = yes
  ```
  *** yushakobo - Helix rev3 5rows connected -- 0x3265:0x3
    > matrix scan frequency: 220
    > matrix scan frequency: 301
    > matrix scan frequency: 299
    > matrix scan frequency: 299
  ```
  * #define OLED_UPDATE_INTERVAL 30
    ```
    *** yushakobo - Helix rev3 5rows connected -- 0x3265:0x3
      > matrix scan frequency: 765
      > matrix scan frequency: 989
      > matrix scan frequency: 992
      > matrix scan frequency: 989
    ```
  * #define OLED_UPDATE_INTERVAL 50
    ```
    *** yushakobo - Helix rev3 5rows connected -- 0x3265:0x3
      > matrix scan frequency: 894
      > matrix scan frequency: 1018
      > matrix scan frequency: 1022
      > matrix scan frequency: 1024
    ```

Tag: @XScorpion2 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
