### PR TITLE
[Docs] Wording & formatting changes in the Tapping Force Hold section of the Tap Hold page + removed trailing whitespaces

### DIFF
--- a/docs/tap_hold.md
+++ b/docs/tap_hold.md
@@ -47,7 +47,7 @@ As of [PR#1359](https://github.com/qmk/qmk_firmware/pull/1359/), there is a new 
 
 This makes tap and hold keys (like Mod Tap) work better for fast typists, or for high `TAPPING_TERM` settings. 
 
-If you press a Mod Tap key, tap another key (press and release) and then release the Mod Tap key, all within the tapping term, it will output the "tapping" function for both keys.
+If you press a Mod Tap key, tap another key (press and release) and then release the Mod Tap key, all within the tapping term, it will output the tapping function for both keys.
 
 For Instance:
 
@@ -87,7 +87,7 @@ To enable this setting, add this to your `config.h`:
 #define IGNORE_MOD_TAP_INTERRUPT
 ```
 
-Similar to Permissive Hold, this alters how the firmware processes inputs for fast typists. If you press a Mod Tap key, press another key, release the Mod Tap key, and then release the normal key, it would normally output the "tapping" function for both keys. This may not be desirable for rolling combo keys. 
+Similar to Permissive Hold, this alters how the firmware processes inputs for fast typists. If you press a Mod Tap key, press another key, release the Mod Tap key, and then release the normal key, it would normally output the tapping function for both keys. This may not be desirable for rolling combo keys.
 
 Setting `Ignore Mod Tap Interrupt` requires  holding both keys for the `TAPPING_TERM` to trigger the hold function (the mod).
 
@@ -132,21 +132,21 @@ To enable `tapping force hold`, add the following to your `config.h`:
 #define TAPPING_FORCE_HOLD
 ```
 
-When the user holds a key after tap, this repeats the tapped key rather to hold a modifier key.  This allows to use auto repeat for the tapped key.  
+When the user holds a key after tapping it, the tapping function is repeated by default, rather than activating the hold function. This allows to keep the ability to auto-repeat the tapping function of a dual-role key. `TAPPING_FORCE_HOLD` removes that ability to let the user activate the hold function instead, in the case of holding the dual-role key after having tapped it.
 
 Example:
 
-- SFT_T(KC_A) Down
-- SFT_T(KC_A) Up
-- SFT_T(KC_A) Down
-- wait more than tapping term...
-- SFT_T(KC_A) Up
+- `SFT_T(KC_A)` Down
+- `SFT_T(KC_A)` Up
+- `SFT_T(KC_A)` Down
+- wait until the tapping term expires...
+- `SFT_T(KC_A)` Up
 
 With default settings, `a` will be sent on the first release, then `a` will be sent on the second press allowing the computer to trigger its auto repeat function.
 
 With `TAPPING_FORCE_HOLD`, the second press will be interpreted as a Shift, allowing to use it as a modifier shortly after having used it as a tap.
 
-!> `TAPPING_FORCE_HOLD` will break anything that uses tapping toggles (Such as the `TT` layer keycode, and the One Shot Tapping Toggle).
+!> `TAPPING_FORCE_HOLD` will break anything that uses tapping toggles (Such as the `TT` layer keycode, and the One Shot Tap Toggle).
 
 For more granular control of this feature, you can add the following to your `config.h`:
 

--- a/docs/tap_hold.md
+++ b/docs/tap_hold.md
@@ -132,7 +132,7 @@ To enable `tapping force hold`, add the following to your `config.h`:
 #define TAPPING_FORCE_HOLD
 ```
 
-When the user holds a key after tapping it, the tapping function is repeated by default, rather than activating the hold function. This allows to keep the ability to auto-repeat the tapping function of a dual-role key. `TAPPING_FORCE_HOLD` removes that ability to let the user activate the hold function instead, in the case of holding the dual-role key after having tapped it.
+When the user holds a key after tapping it, the tapping function is repeated by default, rather than activating the hold function. This allows keeping the ability to auto-repeat the tapping function of a dual-role key. `TAPPING_FORCE_HOLD` removes that ability to let the user activate the hold function instead, in the case of holding the dual-role key after having tapped it.
 
 Example:
 

--- a/docs/tap_hold.md
+++ b/docs/tap_hold.md
@@ -1,22 +1,22 @@
 # Tap-Hold Configuration Options
 
-While Tap-Hold options are fantastic, they are not without their issues.  We have tried to configure them with reasonable defaults, but that may still cause issues for some people. 
+While Tap-Hold options are fantastic, they are not without their issues.  We have tried to configure them with reasonable defaults, but that may still cause issues for some people.
 
 These options let you modify the behavior of the Tap-Hold keys.
 
 ## Tapping Term
 
-The crux of all of the following features is the tapping term setting.  This determines what is a tap and what is a hold.  And the exact timing for this to feel natural can vary from keyboard to keyboard, from switch to switch, and from key to key.  
+The crux of all of the following features is the tapping term setting.  This determines what is a tap and what is a hold.  And the exact timing for this to feel natural can vary from keyboard to keyboard, from switch to switch, and from key to key.
 
-You can set the global time for this by adding the following setting to your `config.h`: 
+You can set the global time for this by adding the following setting to your `config.h`:
 
 ```c
 #define TAPPING_TERM 200
 ```
 
-This setting is defined in milliseconds, and does default to 200ms.  This is a good average for a majority of people. 
+This setting is defined in milliseconds, and does default to 200ms.  This is a good average for a majority of people.
 
-For more granular control of this feature, you can add the following to your `config.h`: 
+For more granular control of this feature, you can add the following to your `config.h`:
 ```c
 #define TAPPING_TERM_PER_KEY
 ```
@@ -45,7 +45,7 @@ As of [PR#1359](https://github.com/qmk/qmk_firmware/pull/1359/), there is a new 
 #define PERMISSIVE_HOLD
 ```
 
-This makes tap and hold keys (like Mod Tap) work better for fast typists, or for high `TAPPING_TERM` settings. 
+This makes tap and hold keys (like Mod Tap) work better for fast typists, or for high `TAPPING_TERM` settings.
 
 If you press a Mod Tap key, tap another key (press and release) and then release the Mod Tap key, all within the tapping term, it will output the tapping function for both keys.
 
@@ -56,7 +56,7 @@ For Instance:
 - `KC_X` Up
 - `SFT_T(KC_A)` Up
 
-Normally, if you do all this within the `TAPPING_TERM` (default: 200ms) this will be registered as `ax` by the firmware and host system. With permissive hold enabled, this modifies how this is handled by considering the Mod Tap keys as a Mod if another key is tapped, and would registered as `X` (`SHIFT`+`x`). 
+Normally, if you do all this within the `TAPPING_TERM` (default: 200ms) this will be registered as `ax` by the firmware and host system. With permissive hold enabled, this modifies how this is handled by considering the Mod Tap keys as a Mod if another key is tapped, and would registered as `X` (`SHIFT`+`x`).
 
 ?> If you have `Ignore Mod Tap Interrupt` enabled, as well, this will modify how both work. The regular key has the modifier added if the first key is released first or if both keys are held longer than the `TAPPING_TERM`.
 
@@ -126,7 +126,7 @@ bool get_ignore_mod_tap_interrupt(uint16_t keycode, keyrecord_t *record) {
 
 ## Tapping Force Hold
 
-To enable `tapping force hold`, add the following to your `config.h`: 
+To enable `tapping force hold`, add the following to your `config.h`:
 
 ```c
 #define TAPPING_FORCE_HOLD
@@ -169,7 +169,7 @@ bool get_tapping_force_hold(uint16_t keycode, keyrecord_t *record) {
 
 ## Retro Tapping
 
-To enable `retro tapping`, add the following to your `config.h`: 
+To enable `retro tapping`, add the following to your `config.h`:
 
 ```c
 #define RETRO_TAPPING
@@ -179,11 +179,11 @@ Holding and releasing a dual function key without pressing another key will resu
 
 For instance, holding and releasing `LT(2, KC_SPACE)` without hitting another key will result in nothing happening. With this enabled, it will send `KC_SPACE` instead.
 
-## Why do we include the key record for the per key functions? 
+## Why do we include the key record for the per key functions?
 
-One thing that you may notice is that we include the key record for all of the "per key" functions, and may be wondering why we do that. 
+One thing that you may notice is that we include the key record for all of the "per key" functions, and may be wondering why we do that.
 
-Well, it's simply really: customization.  But specifically, it depends on how your keyboard is wired up.  For instance, if each row is actually using a row in the keyboard's matrix, then it may be simpler to use `if (record->event.row == 3)` instead of checking a whole bunch of keycodes.  Which is especially good for those people using the Tap Hold type keys on the home row. So you could fine tune those to not interfere with your normal typing. 
+Well, it's simply really: customization.  But specifically, it depends on how your keyboard is wired up.  For instance, if each row is actually using a row in the keyboard's matrix, then it may be simpler to use `if (record->event.row == 3)` instead of checking a whole bunch of keycodes.  Which is especially good for those people using the Tap Hold type keys on the home row. So you could fine tune those to not interfere with your normal typing.
 
 ## Why is there no `*_kb` or `*_user` functions?!
 

--- a/docs/tap_hold.md
+++ b/docs/tap_hold.md
@@ -183,7 +183,7 @@ For instance, holding and releasing `LT(2, KC_SPACE)` without hitting another ke
 
 One thing that you may notice is that we include the key record for all of the "per key" functions, and may be wondering why we do that.
 
-Well, it's simply really: customization.  But specifically, it depends on how your keyboard is wired up.  For instance, if each row is actually using a row in the keyboard's matrix, then it may be simpler to use `if (record->event.row == 3)` instead of checking a whole bunch of keycodes.  Which is especially good for those people using the Tap Hold type keys on the home row. So you could fine tune those to not interfere with your normal typing.
+Well, it's simple really: customization.  But specifically, it depends on how your keyboard is wired up.  For instance, if each row is actually using a row in the keyboard's matrix, then it may be simpler to use `if (record->event.row == 3)` instead of checking a whole bunch of keycodes.  Which is especially good for those people using the Tap Hold type keys on the home row. So you could fine tune those to not interfere with your normal typing.
 
 ## Why is there no `*_kb` or `*_user` functions?!
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I corrected the incorrect "this repeats the tapped key **rather to** hold a modifier key." and used the opportunity to reword that paragraph in the Tapping Force Hold section a bit to make it clearer what is the *default* behaviour, and contrasted it with the `TAPPING_FORCE_HOLD` behaviour and let it know that it applies to all dual-role keys, not just mod-taps.

Additionally, I also formatted the example by putting the pressed keys between backticks as done everywhere else in the Tap Hold configuration settings documentation page.

Then, I also replaced the "tapping" in "One Shot Tapping Toggle" by simply "tap" because that's what the One-Shot documentation page uses exclusively.

Finally, I removed the quotes around the word "tapping" in `the "tapping" function` because they're unnecessary.

EDIT: A second commit removing all trailing whitespaces in the Tap Hold configuration settings page was added.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
