### PR TITLE
Allow the use of only one IS31FL3731 LED driver

### DIFF
--- a/quantum/process_keycode/process_rgb.c
+++ b/quantum/process_keycode/process_rgb.c
@@ -23,6 +23,7 @@ typedef void (*rgb_func_pointer)(void);
  *
  * noinline to optimise for firmware size not speed (not in hot path)
  */
+#if !(defined(RGBLIGHT_DISABLE_KEYCODES) || defined(RGB_MATRIX_DISABLE_KEYCODES))
 static void __attribute__((noinline)) handleKeycodeRGB(const uint8_t is_shifted, const rgb_func_pointer inc_func, const rgb_func_pointer dec_func) {
     if (is_shifted) {
         dec_func();
@@ -30,6 +31,7 @@ static void __attribute__((noinline)) handleKeycodeRGB(const uint8_t is_shifted,
         inc_func();
     }
 }
+#endif
 
 /**
  * Wrapper for animation mode
@@ -56,7 +58,9 @@ bool process_rgb(const uint16_t keycode, const keyrecord_t *record) {
     // Split keyboards need to trigger on key-up for edge-case issue
     if (!record->event.pressed) {
 #endif
+#if !(defined(RGBLIGHT_DISABLE_KEYCODES) || defined(RGB_MATRIX_DISABLE_KEYCODES))
         uint8_t shifted = get_mods() & MOD_MASK_SHIFT;
+#endif
         switch (keycode) {
             case RGB_TOG:
 #if defined(RGBLIGHT_ENABLE) && !defined(RGBLIGHT_DISABLE_KEYCODES)

--- a/quantum/rgb_matrix_drivers.c
+++ b/quantum/rgb_matrix_drivers.c
@@ -31,7 +31,9 @@ static void init(void) {
     i2c_init();
 #    ifdef IS31FL3731
     IS31FL3731_init(DRIVER_ADDR_1);
+#      ifdef DRIVER_ADDR_2
     IS31FL3731_init(DRIVER_ADDR_2);
+#      endif
 #    elif defined(IS31FL3733)
     IS31FL3733_init(DRIVER_ADDR_1, 0);
 #    elif defined(IS31FL3737)
@@ -55,7 +57,9 @@ static void init(void) {
     // This actually updates the LED drivers
 #    ifdef IS31FL3731
     IS31FL3731_update_led_control_registers(DRIVER_ADDR_1, 0);
+#      ifdef DRIVER_ADDR_2
     IS31FL3731_update_led_control_registers(DRIVER_ADDR_2, 1);
+#      endif
 #    elif defined(IS31FL3733)
     IS31FL3733_update_led_control_registers(DRIVER_ADDR_1, 0);
     IS31FL3733_update_led_control_registers(DRIVER_ADDR_2, 1);
@@ -69,7 +73,9 @@ static void init(void) {
 #    ifdef IS31FL3731
 static void flush(void) {
     IS31FL3731_update_pwm_buffers(DRIVER_ADDR_1, 0);
+#      ifdef DRIVER_ADDR_2
     IS31FL3731_update_pwm_buffers(DRIVER_ADDR_2, 1);
+#      endif
 }
 
 const rgb_matrix_driver_t rgb_matrix_driver = {


### PR DESCRIPTION
Core fixes required for OpenDeck32.

Requested split from https://github.com/qmk/qmk_firmware/pull/10305#pullrequestreview-492256442 

## Description

* Allows the use of only one IS31FL3731 LED driver (instead of two)
* Removes unused variables when `RGB_MATRIX_DISABLE_KEYCODES` is set, preventing a clean compile with `-Werror`.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* (let me know if you want me to create issues for this, I'm refraining from doing it to avoid a race with some one fixing it before this is merged).

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
