### PR TITLE
Ignore layer tap interrupts

### DIFF
--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -147,6 +147,9 @@ If you define these options you will enable the associated feature, which may in
   * See [Ignore Mod Tap Interrupt](tap_hold.md#ignore-mod-tap-interrupt) for details
 * `#define IGNORE_MOD_TAP_INTERRUPT_PER_KEY`
   * enables handling for per key `IGNORE_MOD_TAP_INTERRUPT` settings
+* `#define IGNORE_LAYER_TAP_INTERRUPT`
+  * Like `IGNORE_MOD_TAP_INTERRUPT`, but for layer tapping.
+  * See [Ignore Layer Tap Interrupt](tap_hold.md#ignore-mod-tap-interrupt) for details
 * `#define TAPPING_FORCE_HOLD`
   * makes it possible to use a dual role key as modifier shortly after having been tapped
   * See [Tapping Force Hold](tap_hold.md#tapping-force-hold)

--- a/docs/tap_hold.md
+++ b/docs/tap_hold.md
@@ -124,6 +124,32 @@ bool get_ignore_mod_tap_interrupt(uint16_t keycode, keyrecord_t *record) {
 }
 ```
 
+The described functionality only works for mod taps. To get the same results for layer taps, add this to your `config.h`:
+
+```c
+#define IGNORE_LAYER_TAP_INTERRUPT
+```
+
+In case you also enabled `IGNORE_MOD_TAP_INTERRUPT_PER_KEY`, you can reuse this function to control layer taps:
+
+```c
+bool get_ignore_mod_tap_interrupt(uint16_t keycode, keyrecord_t *record) {
+    switch (keycode) {
+        case SFT_T(KC_SPC):
+            return true;
+        case LT(_FN, KC_F):
+            // interrupt causes 'f'
+            return true;
+        case LT(_RAISE, KC_BSPC):
+            // interrupt causes layer switch
+            return false;
+        default:
+            return false;
+    }
+}
+```
+
+
 ## Tapping Force Hold
 
 To enable `tapping force hold`, add the following to your `config.h`: 

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -562,8 +562,22 @@ void process_action(keyrecord_t *record, action_t action) {
                     /* tap key */
                     if (event.pressed) {
                         if (tap_count > 0) {
-                            dprint("KEYMAP_TAP_KEY: Tap: register_code\n");
-                            register_code(action.layer_tap.code);
+#        ifdef IGNORE_LAYER_TAP_INTERRUPT
+                            if (
+#            ifdef IGNORE_MOD_TAP_INTERRUPT_PER_KEY
+                                !get_ignore_mod_tap_interrupt(get_event_keycode(record->event, false), record) &&
+#            endif
+                                record->tap.interrupted) {
+                                dprint("layer_tap: tap: cancel: layer_on\n");
+                                // ad hoc: set 0 to cancel tap
+                                record->tap.count = 0;
+                                layer_on(action.layer_tap.val);
+                            } else
+#        endif
+                            {
+                                dprint("KEYMAP_TAP_KEY: Tap: register_code\n");
+                                register_code(action.layer_tap.code);
+                            }
                         } else {
                             dprint("KEYMAP_TAP_KEY: No tap: On on press\n");
                             layer_on(action.layer_tap.val);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This PR adds `IGNORE_LAYER_TAP_INTERRUPT` for layer taps. This is especially
useful when combined with `IGNORE_MOD_TAP_INTERRUPT_PER_KEY`.
For example, when you want a layer tap like `LT(_FN, KC_F)` to trigger `f` instead of
a layer change, but `LT(_RAISE, KC_BSPC)` to change the layer when interrupted.

The changes requires `IGNORE_LAYER_TAP_INTERRUPT` to be defined.
In case `#define IGNORE_MOD_TAP_INTERRUPT_PER_KEY` is set as well, you'll be
able to reuse the `get_ignore_mod_tap_interrupt()` function for
layer taps like this:

```c
bool get_ignore_mod_tap_interrupt(uint16_t keycode, keyrecord_t *record) {
    switch (keycode) {
        case SFT_T(KC_SPC):
            return true;
        case LT(_FN, KC_F):
            // interrupt causes 'f'
            return true;
        case LT(_RAISE, KC_BSPC):
            // interrupt causes layer switch
            return false;
        default:
            return false;
    }
}
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
