### PR TITLE
Add custom handler for tapped keycodes

### DIFF
--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -181,6 +181,9 @@ If you define these options you will enable the associated feature, which may in
   * Sets the delay between `register_code` and `unregister_code`, if you're having issues with it registering properly (common on VUSB boards). The value is in milliseconds.
 * `#define TAP_HOLD_CAPS_DELAY 80`
   * Sets the delay for Tap Hold keys (`LT`, `MT`) when using `KC_CAPSLOCK` keycode, as this has some special handling on MacOS.  The value is in milliseconds, and defaults to 80 ms if not defined. For macOS, you may want to set this to 200 or higher.
+* `#define CUSTOM_TAPPING_KEYS`
+  * Allows custom handling of tapped `LT` and `MT` keys.
+  * See [caveats](feature_layers.md#caveats) for details.
 
 ## RGB Light Configuration
 

--- a/docs/feature_layers.md
+++ b/docs/feature_layers.md
@@ -23,6 +23,38 @@ Currently, `LT()` and `MT()` are limited to the [Basic Keycode set](keycodes_bas
 
 Expanding this would be complicated, at best. Moving to a 32-bit keycode would solve a lot of this, but would double the amount of space that the keymap matrix uses. And it could potentially cause issues, too. If you need to apply modifiers to your tapped keycode, [Tap Dance](feature_tap_dance.md#example-5-using-tap-dance-for-advanced-mod-tap-and-layer-tap-keys) can be used to accomplish this.
 
+Another workaround for this is adding `#define CUSTOM_TAPPING_KEYS` in your `config.h` and using a custom tap handler function in your keymap:
+
+```c
+bool process_tap(uint16_t keycode, keyrecord_t *record) {
+    switch (keycode) {
+        // LSFT_T(KC_LPRN) is in fact LSFT_T(KC_9) or MT(MOD_LSFT, KC_9), but using the shifted value expresses the original intend in a better way
+        case LSFT_T(KC_LPRN):
+            if (record->event.pressed) {
+                register_code16(KC_LPRN);
+            } else {
+                unregister_code16(KC_LPRN);
+            }
+            // returning false prevents qmk from handling the keycode
+            return false;
+
+        case RSFT_T(KC_RPRN):
+            if (record->event.pressed) {
+                register_code16(KC_RPRN);
+            } else {
+                unregister_code16(KC_RPRN);
+            }
+            return false;
+
+        default:
+            // let qmk handle the tapped key
+            return true;
+    }
+}
+```
+
+However, also this solution has a problem: You're not able to use different handlers for normal and shifted keycodes as eg. LSFT_T(KC_LPRN) and LSFT_T(KC_9) are the same.
+
 Additionally, if at least one right-handed modifier is specified in a Mod Tap or Layer Tap, it will cause all modifiers specified to become right-handed, so it is not possible to mix and match the two.
 
 ## Working with Layers :id=working-with-layers

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -51,6 +51,10 @@ int retro_tapping_counter = 0;
 __attribute__((weak)) bool get_ignore_mod_tap_interrupt(uint16_t keycode, keyrecord_t *record) { return false; }
 #endif
 
+#ifdef CUSTOM_TAPPING_KEYS
+__attribute__((weak)) bool process_tap(uint16_t keycode, keyrecord_t *record) { return true; }
+#endif
+
 #ifndef TAP_CODE_DELAY
 #    define TAP_CODE_DELAY 0
 #endif
@@ -353,7 +357,12 @@ void process_action(keyrecord_t *record, action_t action) {
 #    endif
                             {
                                 dprint("MODS_TAP: Tap: register_code\n");
-                                register_code(action.key.code);
+#    ifdef CUSTOM_TAPPING_KEYS
+                                if (process_tap(get_event_keycode(record->event, false), record))
+#    endif
+                                {
+                                    register_code(action.key.code);
+                                }
                             }
                         } else {
                             dprint("MODS_TAP: No tap: add_mods\n");
@@ -367,7 +376,12 @@ void process_action(keyrecord_t *record, action_t action) {
                             } else {
                                 wait_ms(TAP_CODE_DELAY);
                             }
-                            unregister_code(action.key.code);
+#    ifdef CUSTOM_TAPPING_KEYS
+                            if (process_tap(get_event_keycode(record->event, false), record))
+#    endif
+                            {
+                                unregister_code(action.key.code);
+                            }
                         } else {
                             dprint("MODS_TAP: No tap: add_mods\n");
                             unregister_mods(mods);
@@ -562,8 +576,13 @@ void process_action(keyrecord_t *record, action_t action) {
                     /* tap key */
                     if (event.pressed) {
                         if (tap_count > 0) {
-                            dprint("KEYMAP_TAP_KEY: Tap: register_code\n");
-                            register_code(action.layer_tap.code);
+#        ifdef CUSTOM_TAPPING_KEYS
+                              if (process_tap(get_event_keycode(record->event, false), record))
+#        endif
+                              {
+                                  dprint("KEYMAP_TAP_KEY: Tap: register_code\n");
+                                  register_code(action.layer_tap.code);
+                              }
                         } else {
                             dprint("KEYMAP_TAP_KEY: No tap: On on press\n");
                             layer_on(action.layer_tap.val);
@@ -576,7 +595,12 @@ void process_action(keyrecord_t *record, action_t action) {
                             } else {
                                 wait_ms(TAP_CODE_DELAY);
                             }
-                            unregister_code(action.layer_tap.code);
+#        ifdef CUSTOM_TAPPING_KEYS
+                            if (process_tap(get_event_keycode(record->event, false), record))
+#        endif
+                            {
+                                unregister_code(action.layer_tap.code);
+                            }
                         } else {
                             dprint("KEYMAP_TAP_KEY: No tap: Off on release\n");
                             layer_off(action.layer_tap.val);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Currently the MT/LT tap implementations doesn't allow shifted keys as
described [here](https://github.com/qmk/qmk_firmware/issues/2440#issuecomment-368684070)
and multiple other places.

There's already a [PR](https://github.com/qmk/qmk_firmware/pull/2055) to
address this, but here's a different approach to address this problem by giving
the user the possibility to handle tapped keycodes themselves by using a
`process_tap()` function (naming probably too generic).

Pros:

* Works for mod and layer taps.
* Not restricted to shifted keycodes, other modifiers and macros are possible
  as well.
* Optional feature without unwanted side effects when enabled.
* Consistent behavior when holding a MT and tapping another MT
  (e.g. a rollover from `LSFT_T(KC_LPRN)` to `RCTL_T(KC_QUOT)` - this doesn't
  work well (for me) with space cadet or tap dances as they don't respect
  `IGNORE_MOD_TAP_INTERRUPT`)


Cons:

* You're not able to have different actions for e.g. `LCTL_T(KC_LPRN)` and
  `LCTL_T(KC_9)` as they're basically the same as well.
* Feels like a dirty hack


Example:

```c
bool process_tap(uint16_t keycode, keyrecord_t *record) {
    switch (keycode) {
        // LSFT_T(KC_LPRN) is in fact LSFT_T(KC_9) or MT(MOD_LSFT, KC_9), but using the shifted value expresses the original intend in a better way
        case LSFT_T(KC_LPRN):
            if (record->event.pressed) {
                register_code16(KC_LPRN);
            } else {
                unregister_code16(KC_LPRN);
            }
            // returning false prevents qmk from handling the keycode
            return false;

        case RSFT_T(KC_RPRN):
            if (record->event.pressed) {
                register_code16(KC_RPRN);
            } else {
                unregister_code16(KC_RPRN);
            }
            return false;

        default:
            // let qmk handle the tapped key
            return true;
    }
}
```


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
