### PR TITLE
Turn OLED off on suspend in soundmonster keymap

### DIFF
--- a/keyboards/crkbd/keymaps/soundmonster/keymap.c
+++ b/keyboards/crkbd/keymaps/soundmonster/keymap.c
@@ -298,6 +298,10 @@ void render_status_secondary(void) {
     render_mod_status_ctrl_shift(get_mods()|get_oneshot_mods());
 }
 
+void suspend_power_down_user() {
+    oled_off();
+}
+
 void oled_task_user(void) {
     if (timer_elapsed32(oled_timer) > 30000) {
         oled_off();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
crkbd soundmonster uses a timeout to turn off the OLED screen.
If the computer suspends, the microcontroller goes into power saving mode. This stops the timer (I think).
So the OLED never turns off when the computer is suspended.
Explicitly turning it off on suspend fixes this.

<!--- Describe your changes in detail here. -->

## Types of Changes
add `suspend_power_down_user` to turn off OLED on power down.
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
