### PR TITLE
ChibiOS upgrade: Filter 'all' builds by platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,15 +278,15 @@ define PARSE_RULE
     ifeq ($$(call COMPARE_AND_REMOVE_FROM_RULE,all),true)
         KEYBOARD_RULE=all
         $$(eval $$(call PARSE_ALL_KEYBOARDS))
-    else ifeq ($$(call COMPARE_AND_REMOVE_FROM_RULE,avr),true)
+    else ifeq ($$(call COMPARE_AND_REMOVE_FROM_RULE,all-avr),true)
         KEYBOARD_RULE=all
         REQUIRE_PLATFORM_KEY := avr
         $$(eval $$(call PARSE_ALL_KEYBOARDS))
-    else ifeq ($$(call COMPARE_AND_REMOVE_FROM_RULE,chibios),true)
+    else ifeq ($$(call COMPARE_AND_REMOVE_FROM_RULE,all-chibios),true)
         KEYBOARD_RULE=all
         REQUIRE_PLATFORM_KEY := chibios
         $$(eval $$(call PARSE_ALL_KEYBOARDS))
-    else ifeq ($$(call COMPARE_AND_REMOVE_FROM_RULE,arm_atsam),true)
+    else ifeq ($$(call COMPARE_AND_REMOVE_FROM_RULE,all-arm_atsam),true)
         KEYBOARD_RULE=all
         REQUIRE_PLATFORM_KEY := arm_atsam
         $$(eval $$(call PARSE_ALL_KEYBOARDS))

--- a/Makefile
+++ b/Makefile
@@ -272,10 +272,23 @@ endef
 define PARSE_RULE
     RULE := $1
     COMMANDS :=
+    REQUIRE_PLATFORM_KEY :=
     # If the rule starts with all, then continue the parsing from
     # PARSE_ALL_KEYBOARDS
     ifeq ($$(call COMPARE_AND_REMOVE_FROM_RULE,all),true)
         KEYBOARD_RULE=all
+        $$(eval $$(call PARSE_ALL_KEYBOARDS))
+    else ifeq ($$(call COMPARE_AND_REMOVE_FROM_RULE,avr),true)
+        KEYBOARD_RULE=all
+        REQUIRE_PLATFORM_KEY := avr
+        $$(eval $$(call PARSE_ALL_KEYBOARDS))
+    else ifeq ($$(call COMPARE_AND_REMOVE_FROM_RULE,chibios),true)
+        KEYBOARD_RULE=all
+        REQUIRE_PLATFORM_KEY := chibios
+        $$(eval $$(call PARSE_ALL_KEYBOARDS))
+    else ifeq ($$(call COMPARE_AND_REMOVE_FROM_RULE,arm_atsam),true)
+        KEYBOARD_RULE=all
+        REQUIRE_PLATFORM_KEY := arm_atsam
         $$(eval $$(call PARSE_ALL_KEYBOARDS))
     else ifeq ($$(call COMPARE_AND_REMOVE_FROM_RULE,test),true)
         $$(eval $$(call PARSE_TEST))
@@ -447,7 +460,7 @@ define PARSE_KEYMAP
     # Format it in bold
     KB_SP := $(BOLD)$$(KB_SP)$(NO_COLOR)
     # Specify the variables that we are passing forward to submake
-    MAKE_VARS := KEYBOARD=$$(CURRENT_KB) KEYMAP=$$(CURRENT_KM)
+    MAKE_VARS := KEYBOARD=$$(CURRENT_KB) KEYMAP=$$(CURRENT_KM) REQUIRE_PLATFORM_KEY=$$(REQUIRE_PLATFORM_KEY)
     # And the first part of the make command
     MAKE_CMD := $$(MAKE) -r -R -C $(ROOT_DIR) -f build_keyboard.mk $$(MAKE_TARGET)
     # The message to display
@@ -466,6 +479,8 @@ define BUILD
         LOG=$$$$($$(MAKE_CMD) $$(MAKE_VARS) SILENT=true 2>&1) ; \
         if [ $$$$? -gt 0 ]; \
             then $$(PRINT_ERROR_PLAIN); \
+        elif [ "$$$$LOG" = "skipped" ] ; \
+            then $$(PRINT_SKIPPED_PLAIN); \
         elif [ "$$$$LOG" != "" ] ; \
             then $$(PRINT_WARNING_PLAIN); \
         else \

--- a/build_keyboard.mk
+++ b/build_keyboard.mk
@@ -317,6 +317,13 @@ SRC += $(TMK_COMMON_SRC)
 OPT_DEFS += $(TMK_COMMON_DEFS)
 EXTRALDFLAGS += $(TMK_COMMON_LDFLAGS)
 
+SKIP_COMPILE := no
+ifneq ($(REQUIRE_PLATFORM_KEY),)
+    ifneq ($(REQUIRE_PLATFORM_KEY),$(PLATFORM_KEY))
+        SKIP_COMPILE := yes
+    endif
+endif
+
 include $(TMK_PATH)/$(PLATFORM_KEY).mk
 ifneq ($(strip $(PROTOCOL)),)
     include $(TMK_PATH)/protocol/$(strip $(shell echo $(PROTOCOL) | tr '[:upper:]' '[:lower:]')).mk
@@ -352,7 +359,13 @@ $(KEYBOARD_OUTPUT)_INC := $(PROJECT_INC) $(GFXINC)
 $(KEYBOARD_OUTPUT)_CONFIG := $(PROJECT_CONFIG)
 
 # Default target.
+ifeq ($(SKIP_COMPILE),no)
 all: build check-size
+else
+all:
+	echo "skipped" >&2
+endif
+
 build: elf cpfirmware
 check-size: build
 objs-size: build

--- a/message.mk
+++ b/message.mk
@@ -5,6 +5,7 @@ ifeq ($(COLOR),true)
 	OK_COLOR=\033[32;01m
 	ERROR_COLOR=\033[31;01m
 	WARN_COLOR=\033[33;01m
+	SKIPPED_COLOR=\033[36;01m
 	BLUE=\033[0;34m
 	BOLD=\033[1m
 endif
@@ -20,6 +21,7 @@ ON_ERROR ?= exit 1
 OK_STRING=$(OK_COLOR)[OK]$(NO_COLOR)\n
 ERROR_STRING=$(ERROR_COLOR)[ERRORS]$(NO_COLOR)\n
 WARN_STRING=$(WARN_COLOR)[WARNINGS]$(NO_COLOR)\n
+SKIPPED_STRING=$(SKIPPED_COLOR)[SKIPPED]$(NO_COLOR)\n
 
 TAB_LOG = printf "\n%s\n\n" "$$LOG" | $(AWK) '{ sub(/^/," | "); print }'
 TAB_LOG_PLAIN = printf "%s\n" "$$LOG"
@@ -29,6 +31,7 @@ PRINT_ERROR = ($(SILENT) ||printf " $(ERROR_STRING)" | $(AWK_STATUS)) && $(TAB_L
 PRINT_WARNING = ($(SILENT) || printf " $(WARN_STRING)" | $(AWK_STATUS)) && $(TAB_LOG)
 PRINT_ERROR_PLAIN = ($(SILENT) ||printf " $(ERROR_STRING)" | $(AWK_STATUS)) && $(TAB_LOG_PLAIN) && $(ON_ERROR)
 PRINT_WARNING_PLAIN = ($(SILENT) || printf " $(WARN_STRING)" | $(AWK_STATUS)) && $(TAB_LOG_PLAIN)
+PRINT_SKIPPED_PLAIN = ($(SILENT) || printf " $(SKIPPED_STRING)" | $(AWK_STATUS))
 PRINT_OK = $(SILENT) || printf " $(OK_STRING)" | $(AWK_STATUS)
 BUILD_CMD = LOG=$$($(CMD) 2>&1) ; if [ $$? -gt 0 ]; then $(PRINT_ERROR); elif [ "$$LOG" != "" ] ; then $(PRINT_WARNING); else $(PRINT_OK); fi;
 MAKE_MSG_FORMAT = $(AWK) '{ printf "%-118s", $$0;}'


### PR DESCRIPTION
## Description

Adds support for building all keyboards, filtered by platform key.
Examples:

```
make all:default             # as before
make all-avr:default         # only build AVR-based keyboards
make all-chibios:default     # only build ChibiOS keyboards
make all-arm_atsam:default   # only build arm_atsam-based keyboards
```

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
