### PR TITLE
Crkbd implementing return value for matrix_scan()

### DIFF
--- a/keyboards/crkbd/rev1/legacy/matrix.c
+++ b/keyboards/crkbd/rev1/legacy/matrix.c
@@ -155,6 +155,7 @@ void matrix_init(void)
 
 uint8_t _matrix_scan(void)
 {
+	bool changed = false;
     // Right hand is stored after the left in the matirx so, we need to offset it
     int offset = isLeftHand ? 0 : (ROWS_PER_HAND);
 
@@ -163,6 +164,7 @@ uint8_t _matrix_scan(void)
         _delay_us(30);  // without this wait read unstable value.
         matrix_row_t cols = read_cols();
         if (matrix_debouncing[i+offset] != cols) {
+			changed = true;
             matrix_debouncing[i+offset] = cols;
             debouncing = DEBOUNCE;
         }
@@ -179,7 +181,7 @@ uint8_t _matrix_scan(void)
         }
     }
 
-    return 1;
+    return changed;
 }
 
 #ifdef USE_MATRIX_I2C
@@ -237,16 +239,17 @@ int serial_transaction(int master_changed) {
 
 uint8_t matrix_scan(void)
 {
+	bool changed = false;
     if (is_master) {
-        matrix_master_scan();
+        changed |= matrix_master_scan();
     }else{
-        matrix_slave_scan();
+        changed |= matrix_slave_scan();
         int offset = (isLeftHand) ? ROWS_PER_HAND : 0;
         memcpy(&matrix[offset],
                (void *)serial_master_buffer, SERIAL_MASTER_BUFFER_LENGTH);
         matrix_scan_quantum();
     }
-    return 1;
+    return (uint8_t) changed;
 }
 
 
@@ -297,8 +300,8 @@ uint8_t matrix_master_scan(void) {
     return ret;
 }
 
-void matrix_slave_scan(void) {
-    _matrix_scan();
+uint8_t matrix_slave_scan(void) {
+    int ret = _matrix_scan();
 
     int offset = (isLeftHand) ? 0 : ROWS_PER_HAND;
 
@@ -322,6 +325,7 @@ void matrix_slave_scan(void) {
     slave_buffer_change_count += change;
   #endif
 #endif
+	return ret;
 }
 
 bool matrix_is_modified(void)

--- a/keyboards/crkbd/rev1/legacy/matrix.c
+++ b/keyboards/crkbd/rev1/legacy/matrix.c
@@ -155,7 +155,7 @@ void matrix_init(void)
 
 uint8_t _matrix_scan(void)
 {
-	bool changed = false;
+    bool changed = false;
     // Right hand is stored after the left in the matirx so, we need to offset it
     int offset = isLeftHand ? 0 : (ROWS_PER_HAND);
 
@@ -164,7 +164,7 @@ uint8_t _matrix_scan(void)
         _delay_us(30);  // without this wait read unstable value.
         matrix_row_t cols = read_cols();
         if (matrix_debouncing[i+offset] != cols) {
-			changed = true;
+            changed = true;
             matrix_debouncing[i+offset] = cols;
             debouncing = DEBOUNCE;
         }
@@ -239,7 +239,7 @@ int serial_transaction(int master_changed) {
 
 uint8_t matrix_scan(void)
 {
-	bool changed = false;
+    bool changed = false;
     if (is_master) {
         changed |= matrix_master_scan();
     }else{
@@ -317,7 +317,7 @@ uint8_t matrix_slave_scan(void) {
     for (int i = 0; i < ROWS_PER_HAND; ++i) {
   #ifdef SERIAL_USE_MULTI_TRANSACTION
         if( serial_slave_buffer[i] != matrix[offset+i] )
-	    change = 1;
+        change = 1;
   #endif
         serial_slave_buffer[i] = matrix[offset+i];
     }
@@ -325,7 +325,7 @@ uint8_t matrix_slave_scan(void) {
     slave_buffer_change_count += change;
   #endif
 #endif
-	return ret;
+    return ret;
 }
 
 bool matrix_is_modified(void)

--- a/keyboards/crkbd/rev1/legacy/split_util.h
+++ b/keyboards/crkbd/rev1/legacy/split_util.h
@@ -27,7 +27,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 extern volatile bool isLeftHand;
 
 // slave version of matix scan, defined in matrix.c
-void matrix_slave_scan(void);
+uint8_t matrix_slave_scan(void);
 
 void split_keyboard_setup(void);
 bool has_usb(void);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
The OLED screen on the keyboard never turns off with the timeout as it supposed to.

With debugging output, it appears `keyboard_task()` in tmk_core/common/keyboard.c is constantly calling `oled_on()`. This only happens when `OLED_DRIVER_ENABLE` is defined and `OLED_DISABLE_TIMEOUT` is not defined.

It appears that the return value of `matrix_scam()` is interpreted as a boolean of whether there are updates. And the custom implementation of that function in crkbd returns a constant 1.

Thus I imitate the way quantum/matrix.c implement this return value and applied it to the crkbd implementation.

Despite a required change of the return type for `matrix_slave_scan()` from `void` to `uint8_t`, this function is never meant to and never does be called anywhere else. This change should not affect anything else.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
