### PR TITLE
Fix Belgian sendstring file

### DIFF
--- a/quantum/keymap_extras/sendstring_belgian.h
+++ b/quantum/keymap_extras/sendstring_belgian.h
@@ -88,7 +88,7 @@ const uint8_t ascii_to_keycode_lut[128] PROGMEM = {
     // P     Q        R        S        T        U        V        W
     BE_P,    BE_Q,    BE_R,    BE_S,    BE_T,    BE_U,    BE_V,    BE_W,
     // X     Y        Z        [        \        ]        ^        _
-    BE_X,    BE_Y,    BE_Z,    BE_CIRC, BE_LABK, BE_DLR,  BE_SECT, BE_MINS,
+    BE_X,    BE_Y,    BE_Z,    BE_SECT, BE_LABK, BE_DLR,  BE_SECT, BE_MINS,
     // `     a        b        c        d        e        f        g
     BE_MICR, BE_A,    BE_B,    BE_C,    BE_D,    BE_E,    BE_F,    BE_G,
     // h     i        j        k        l        m        n        o


### PR DESCRIPTION
Specifically, the `BE_CIRC` is an alt-ed keycode, which means it 
doesn't fit into the 8 bit keycode range...  It should be `BE_SECT`,
as it is already alt-ed by the alt lut.

Confirmed that this change fixes compilation warnings and works 
correctly, on reddit. 
https://www.reddit.com/r/olkb/comments/iywin1/unsigned_conversion_from_int_to_unsigned_char/g6jvfgl/

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* won't compile ... reporting in 2 reddit threads

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
