### PR TITLE
Fix Belgian sendstring properly

### DIFF
--- a/quantum/keymap_extras/sendstring_belgian.h
+++ b/quantum/keymap_extras/sendstring_belgian.h
@@ -88,7 +88,7 @@ const uint8_t ascii_to_keycode_lut[128] PROGMEM = {
     // P     Q        R        S        T        U        V        W
     BE_P,    BE_Q,    BE_R,    BE_S,    BE_T,    BE_U,    BE_V,    BE_W,
     // X     Y        Z        [        \        ]        ^        _
-    BE_X,    BE_Y,    BE_Z,    BE_SECT, BE_LABK, BE_DLR,  BE_SECT, BE_MINS,
+    BE_X,    BE_Y,    BE_Z,    BE_DCIR, BE_LABK, BE_DLR,  BE_SECT, BE_MINS,
     // `     a        b        c        d        e        f        g
     BE_MICR, BE_A,    BE_B,    BE_C,    BE_D,    BE_E,    BE_F,    BE_G,
     // h     i        j        k        l        m        n        o


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

`[` is on AltGr+`^` (dead circumflex, `BE_DCIR`), not the non-dead one (`BE_CIRC`).

#10443

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
