### PR TITLE
Fix SPLIT_KEYBOARD compilation for ATMega*U2, which doesn't have VBUS/OTG control

### DIFF
--- a/quantum/split_common/split_util.c
+++ b/quantum/split_common/split_util.c
@@ -72,7 +72,7 @@ bool usbIsActive(void) {
 
     return false;
 }
-#elif defined(PROTOCOL_LUFA)
+#elif defined(PROTOCOL_LUFA) && defined(OTGPADE)
 static inline bool usbIsActive(void) {
     USB_OTGPAD_On();  // enables VBUS pad
     wait_us(5);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

in split_util.c a code block `#ifdef`'d for AVR deals with specific USB features that only ATMega*U4 support, compilation on U2 fails like this:

```
quantum/split_common/split_util.c:77:5: error: implicit declaration of function 'USB_OTGPAD_On'; did you mean 'USB_REG_On'? [-Werror=implicit-function-declaration]
   77 |     USB_OTGPAD_On();  // enables VBUS pad
      |     ^~~~~~~~~~~~~
      |     USB_REG_On
quantum/split_common/split_util.c:80:12: error: implicit declaration of function 'USB_VBUS_GetStatus' [-Werror=implicit-function-declaration]
   80 |     return USB_VBUS_GetStatus();  // checks state of VBUS
      |            ^~~~~~~~~~~~~~~~~~
```

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This PR adjusts the ifdef to not attempt to use these facilities on ATmega16U2 and ATMega32U2 targets.
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
