### PR TITLE
Add joestrong keymap for quefrency rev 2

### DIFF
--- a/keyboards/keebio/quefrency/keymaps/joestrong/README.md
+++ b/keyboards/keebio/quefrency/keymaps/joestrong/README.md
@@ -1,8 +1,8 @@
 # JoeStrong's Quefrency layout - 60% ISO
 
-Standard UK ISO qwerty layout
-Function key in place of Caps Lock
-Function layer provides vim-like arrows and various function keys
+* Standard UK ISO qwerty layout
+* Function key in place of Caps Lock
+* Function layer provides vim-like arrows and various function keys
 
 ## Default layer
 

--- a/keyboards/keebio/quefrency/keymaps/joestrong/README.md
+++ b/keyboards/keebio/quefrency/keymaps/joestrong/README.md
@@ -1,0 +1,17 @@
+# JoeStrong's Quefrency layout - 60% ISO
+
+Standard UK ISO qwerty layout
+Function key in place of Caps Lock
+Function layer provides vim-like arrows and various function keys
+
+## Default layer
+
+![Default layer layout](https://i.imgur.com/HXeKSGN.png)
+
+([KLE](http://www.keyboard-layout-editor.com/#/gists/f606625fbc4b84a0e9f82fff308aad29))
+
+## Function layer
+
+![Function layer layout](https://i.imgur.com/cVKl9tB.png)
+
+([KLE](http://www.keyboard-layout-editor.com/#/gists/b75402b2838f36e319f1c0a7fef07dd6))

--- a/keyboards/keebio/quefrency/keymaps/joestrong/config.h
+++ b/keyboards/keebio/quefrency/keymaps/joestrong/config.h
@@ -1,0 +1,27 @@
+/*
+This is the c configuration file for the keymap
+
+Copyright 2012 Jun Wako <wakojun@gmail.com>
+Copyright 2015 Jack Humbert
+Copyright 2018 Danny Nguyen <danny@keeb.io>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+/* Use I2C or Serial, not both */
+
+#define USE_SERIAL
+// #define USE_I2C

--- a/keyboards/keebio/quefrency/keymaps/joestrong/keymap.c
+++ b/keyboards/keebio/quefrency/keymaps/joestrong/keymap.c
@@ -1,0 +1,32 @@
+#include QMK_KEYBOARD_H
+#include "keymap_uk.h"
+
+
+// Each layer gets a name for readability, which is then used in the keymap matrix below.
+// The underscores don't mean anything - you can have a layer called STUFF or any other name.
+// Layer names don't all need to be of the same length, obviously, and you can also skip them
+// entirely and just use numbers.
+#define _BASE 0
+#define _FN1 1
+
+enum custom_keycodes {
+  QWERTY = SAFE_RANGE,
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  [_BASE] = LAYOUT_60_iso(
+    KC_GESC, KC_1,    KC_2,     KC_3,    KC_4,    KC_5,    KC_6,        KC_7,    KC_8,    KC_9,    KC_0,     KC_MINS, KC_EQL,  _______, KC_BSPC,
+    KC_TAB,  KC_Q,    KC_W,     KC_E,    KC_R,    KC_T,                 KC_Y,    KC_U,    KC_I,    KC_O,     KC_P,    KC_LBRC, KC_RBRC,
+    MO(_FN1),KC_A,    KC_S,     KC_D,    KC_F,    KC_G,                 KC_H,    KC_J,    KC_K,    KC_L,     KC_SCLN, KC_QUOT, KC_NUHS, KC_ENT,
+    KC_LSFT, UK_BSLS, KC_Z,     KC_X,    KC_C,    KC_V,    KC_B,        KC_N,    KC_M,    KC_COMM, KC_DOT,   KC_SLSH,          KC_RSFT, _______,
+    KC_LCTL, KC_LGUI, MO(_FN1), KC_LALT,          KC_SPC,               _______, KC_SPC,  KC_RALT, MO(_FN1), _______,          KC_LGUI, KC_RCTL
+  ),
+
+  [_FN1] = LAYOUT_60_iso(
+    KC_GRV,  KC_F1,   KC_F2,       KC_F3,     KC_F4,    KC_F5,   KC_F6,       KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  _______, _______,
+    RGB_TOG, RGB_MOD, _______,     _______,   _______,  _______,              _______, KC_PGDN, KC_PGUP, _______, _______, _______, _______,
+    _______, _______, KC__VOLDOWN, KC__VOLUP, KC__MUTE, _______,              KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT, KC_DEL,  _______, _______, _______,
+    _______, _______, _______,     _______,   _______,  _______, _______,     _______, _______, _______, _______, _______,          _______, _______,
+    _______, _______, _______,     _______,             _______,              _______, _______, _______, _______, _______,          _______, _______
+  )
+};

--- a/keyboards/keebio/quefrency/keymaps/joestrong/keymap.c
+++ b/keyboards/keebio/quefrency/keymaps/joestrong/keymap.c
@@ -1,32 +1,41 @@
+/* Copyright 2020 Joseph Strong
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 #include QMK_KEYBOARD_H
 #include "keymap_uk.h"
 
-
-// Each layer gets a name for readability, which is then used in the keymap matrix below.
-// The underscores don't mean anything - you can have a layer called STUFF or any other name.
-// Layer names don't all need to be of the same length, obviously, and you can also skip them
-// entirely and just use numbers.
-#define _BASE 0
-#define _FN1 1
-
-enum custom_keycodes {
-  QWERTY = SAFE_RANGE,
+// Defines names for use in layer keycodes and the keymap
+enum layer_names {
+    _BASE,
+    _FN1
 };
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-  [_BASE] = LAYOUT_60_iso(
-    KC_GESC, KC_1,    KC_2,     KC_3,    KC_4,    KC_5,    KC_6,        KC_7,    KC_8,    KC_9,    KC_0,     KC_MINS, KC_EQL,  _______, KC_BSPC,
-    KC_TAB,  KC_Q,    KC_W,     KC_E,    KC_R,    KC_T,                 KC_Y,    KC_U,    KC_I,    KC_O,     KC_P,    KC_LBRC, KC_RBRC,
-    MO(_FN1),KC_A,    KC_S,     KC_D,    KC_F,    KC_G,                 KC_H,    KC_J,    KC_K,    KC_L,     KC_SCLN, KC_QUOT, KC_NUHS, KC_ENT,
-    KC_LSFT, UK_BSLS, KC_Z,     KC_X,    KC_C,    KC_V,    KC_B,        KC_N,    KC_M,    KC_COMM, KC_DOT,   KC_SLSH,          KC_RSFT, _______,
-    KC_LCTL, KC_LGUI, MO(_FN1), KC_LALT,          KC_SPC,               _______, KC_SPC,  KC_RALT, MO(_FN1), _______,          KC_LGUI, KC_RCTL
-  ),
+    [_BASE] = LAYOUT_60_iso(
+        KC_GESC, KC_1,    KC_2,     KC_3,    KC_4,    KC_5,    KC_6,        KC_7,    KC_8,    KC_9,    KC_0,     KC_MINS, KC_EQL,  _______, KC_BSPC,
+        KC_TAB,  KC_Q,    KC_W,     KC_E,    KC_R,    KC_T,                 KC_Y,    KC_U,    KC_I,    KC_O,     KC_P,    KC_LBRC, KC_RBRC,
+        MO(_FN1),KC_A,    KC_S,     KC_D,    KC_F,    KC_G,                 KC_H,    KC_J,    KC_K,    KC_L,     KC_SCLN, KC_QUOT, KC_NUHS, KC_ENT,
+        KC_LSFT, UK_BSLS, KC_Z,     KC_X,    KC_C,    KC_V,    KC_B,        KC_N,    KC_M,    KC_COMM, KC_DOT,   KC_SLSH,          KC_RSFT, _______,
+        KC_LCTL, KC_LGUI, MO(_FN1), KC_LALT,          KC_SPC,               _______, KC_SPC,  KC_RALT, MO(_FN1), _______,          KC_LGUI, KC_RCTL
+    ),
 
-  [_FN1] = LAYOUT_60_iso(
-    KC_GRV,  KC_F1,   KC_F2,       KC_F3,     KC_F4,    KC_F5,   KC_F6,       KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  _______, _______,
-    RGB_TOG, RGB_MOD, _______,     _______,   _______,  _______,              _______, KC_PGDN, KC_PGUP, _______, _______, _______, _______,
-    _______, _______, KC__VOLDOWN, KC__VOLUP, KC__MUTE, _______,              KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT, KC_DEL,  _______, _______, _______,
-    _______, _______, _______,     _______,   _______,  _______, _______,     _______, _______, _______, _______, _______,          _______, _______,
-    _______, _______, _______,     _______,             _______,              _______, _______, _______, _______, _______,          _______, _______
-  )
+    [_FN1] = LAYOUT_60_iso(
+        KC_GRV,  KC_F1,   KC_F2,       KC_F3,     KC_F4,    KC_F5,   KC_F6,       KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  _______, _______,
+        RGB_TOG, RGB_MOD, _______,     _______,   _______,  _______,              _______, KC_PGDN, KC_PGUP, _______, _______, _______, _______,
+        _______, _______, KC__VOLDOWN, KC__VOLUP, KC__MUTE, _______,              KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT, KC_DEL,  _______, _______, _______,
+        _______, _______, _______,     _______,   _______,  _______, _______,     _______, _______, _______, _______, _______,          _______, _______,
+        _______, _______, _______,     _______,             _______,              _______, _______, _______, _______, _______,          _______, _______
+    )
 };


### PR DESCRIPTION
## Description

Adds a UK ISO keymap for the 60% version of quefrency rev 2

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
