### PR TITLE
add split&matrix encoder support

### DIFF
--- a/docs/feature_encoders.md
+++ b/docs/feature_encoders.md
@@ -6,6 +6,12 @@ Basic encoders are supported by adding this to your `rules.mk`:
 ENCODER_ENABLE = yes
 ```
 
+There are two options.
+* Basic Support (Classic)
+* More flexible support (New)
+
+## Basic Support (Classic)
+
 and this to your `config.h`:
 
 ```c
@@ -19,6 +25,29 @@ Each PAD_A/B variable defines an array so multiple encoders can be defined, e.g.
 #define ENCODERS_PAD_A { encoder1a, encoder2a }
 #define ENCODERS_PAD_B { encoder1b, encoder2b }
 ```
+
+## Flexible Support (New)
+
+and this to your `config.h`:
+
+```c
+//A and B are connected to the pins, and C is connected to GND.
+#define MATRIX_ENCODER_PINS_ABC {{B1,B3,NO_PIN}}
+
+//When placed in the key matrix and pad C is connected to the row with a diode.
+#define MATRIX_ENCODER_PINS_ABC {{E6,B4,B2},{E6,B4,B6}}
+
+//For a split keyboard, if you have a different number of encoders on the left and right sides of the keyboard,
+// or if you have different pin assignments on the left and right sides of the keyboard, you can specify like this
+#define MATRIX_ENCODER_PINS_ABC {{E6,B4,B2},{E6,B4,B6}}
+#define MATRIX_ENCODER_PINS_ABC_RIGHT {{E6,B4,B6}}
+
+//To place Encoder on the right side only with a split keyboard.
+#define MATRIX_ENCODER_PINS_ABC {}
+#define MATRIX_ENCODER_PINS_ABC_RIGHT {{E6,B4,B6}}
+```
+
+## Direction and Resolution
 
 If your encoder's clockwise directions are incorrect, you can swap the A & B pad definitions.  They can also be flipped with a define:
 
@@ -78,6 +107,16 @@ void encoder_update_user(uint8_t index, bool clockwise) {
 }
 ```
 
-## Hardware
+## Hardware 
+
+### Basic Support (Classic)
 
 The A an B lines of the encoders should be wired directly to the MCU, and the C/common lines should be wired to ground.
+
+### Flexible Support (New)
+
+The A and B lines of the encoder can be wired directly to the MCU or to a column in the key matrix.
+The C/common line should be wired to ground or with a diode and wired to the key matrix row.
+
+If a key is present in the same column as the A and B lines where the encoder is placed, it is recommended that you place a diode at the input to the Encoders on the A and B lines.
+This is to eliminate the possibility of determining that the B key is pressed when the A key is pressed at the same time as the encoder is rotated.

--- a/docs/feature_encoders.md
+++ b/docs/feature_encoders.md
@@ -6,11 +6,9 @@ Basic encoders are supported by adding this to your `rules.mk`:
 ENCODER_ENABLE = yes
 ```
 
-There are two options.
-* Basic Support (Classic)
-* More flexible support (New)
+There are two options. Basic or Advanced.
 
-## Basic Support (Classic)
+## Basic
 
 and this to your `config.h`:
 
@@ -26,7 +24,7 @@ Each PAD_A/B variable defines an array so multiple encoders can be defined, e.g.
 #define ENCODERS_PAD_B { encoder1b, encoder2b }
 ```
 
-## Flexible Support (New)
+## Advanced
 
 and this to your `config.h`:
 
@@ -109,11 +107,11 @@ void encoder_update_user(uint8_t index, bool clockwise) {
 
 ## Hardware 
 
-### Basic Support (Classic)
+### Basic
 
 The A an B lines of the encoders should be wired directly to the MCU, and the C/common lines should be wired to ground.
 
-### Flexible Support (New)
+### Advanced
 
 The A and B lines of the encoder can be wired directly to the MCU or to a column in the key matrix.
 The C/common line should be wired to ground or with a diode and wired to the key matrix row.

--- a/docs/feature_encoders.md
+++ b/docs/feature_encoders.md
@@ -41,7 +41,6 @@ and this to your `config.h`:
 #define MATRIX_ENCODER_PINS_ABC_RIGHT {{E6,B4,B6}}
 
 //To place Encoder on the right side only with a split keyboard.
-#define MATRIX_ENCODER_PINS_ABC {}
 #define MATRIX_ENCODER_PINS_ABC_RIGHT {{E6,B4,B6}}
 ```
 

--- a/quantum/encoder.c
+++ b/quantum/encoder.c
@@ -27,15 +27,27 @@
 #    define ENCODER_RESOLUTION 4
 #endif
 
-#if !defined(ENCODERS_PAD_A) || !defined(ENCODERS_PAD_B)
-#    error "No encoder pads defined by ENCODERS_PAD_A and ENCODERS_PAD_B"
+#if !(defined(ENCODERS_PAD_A) && defined(ENCODERS_PAD_B)) \
+    && !(!defined(SPLIT_KEYBOARD) && defined(MATRIX_ENCODER_PINS_ABC)) \
+    && !(defined(SPLIT_KEYBOARD) && (defined(MATRIX_ENCODER_PINS_ABC) || defined(MATRIX_ENCODER_PINS_ABC_RIGHT)))
+#    error "No encoder pads defined by ENCODERS_PAD_A and ENCODERS_PAD_B or MATRIX_ENCODER_PINS_ABC or SPLIT_KEYBOARD MATRIX_ENCODER_PINS_ABC and MATRIX_ENCODER_PINS_ABC_RIGHT"
 #endif
 
-#define NUMBER_OF_ENCODERS (sizeof(encoders_pad_a) / sizeof(pin_t))
-static pin_t encoders_pad_a[] = ENCODERS_PAD_A;
-static pin_t encoders_pad_b[] = ENCODERS_PAD_B;
-#ifdef ENCODER_RESOLUTIONS
-static uint8_t encoder_resolutions[] = ENCODER_RESOLUTIONS;
+#if (defined(ENCODERS_PAD_A) && defined(ENCODERS_PAD_B))
+    #define ENCODER_SIMPLE
+#elif defined(SPLIT_KEYBOARD)
+    #define ENCODER_MATRIX_SPLIT
+#else
+    #define ENCODER_MATRIX
+#endif
+
+#ifdef ENCODER_SIMPLE
+    #define NUMBER_OF_ENCODERS (sizeof(encoders_pad_a) / sizeof(pin_t))
+    static pin_t encoders_pad_a[] = ENCODERS_PAD_A;
+    static pin_t encoders_pad_b[] = ENCODERS_PAD_B;
+    #ifdef ENCODER_RESOLUTIONS
+    static uint8_t encoder_resolutions[] = ENCODER_RESOLUTIONS;
+    #endif
 #endif
 
 #ifndef ENCODER_DIRECTION_FLIP
@@ -47,102 +59,304 @@ static uint8_t encoder_resolutions[] = ENCODER_RESOLUTIONS;
 #endif
 static int8_t encoder_LUT[] = {0, -1, 1, 0, 1, 0, 0, -1, -1, 0, 0, 1, 0, 1, -1, 0};
 
-static uint8_t encoder_state[NUMBER_OF_ENCODERS]  = {0};
-static int8_t  encoder_pulses[NUMBER_OF_ENCODERS] = {0};
+#ifdef ENCODER_SIMPLE
+    static uint8_t encoder_state[NUMBER_OF_ENCODERS]  = {0};
+    static int8_t  encoder_pulses[NUMBER_OF_ENCODERS] = {0};
 
-#ifdef SPLIT_KEYBOARD
-// right half encoders come over as second set of encoders
-static uint8_t encoder_value[NUMBER_OF_ENCODERS * 2] = {0};
-// row offsets for each hand
-static uint8_t thisHand, thatHand;
-#else
-static uint8_t encoder_value[NUMBER_OF_ENCODERS] = {0};
-#endif
+    #ifdef SPLIT_KEYBOARD
+    // right half encoders come over as second set of encoders
+    static uint8_t encoder_value[NUMBER_OF_ENCODERS * 2] = {0};
+    // row offsets for each hand
+    static uint8_t thisHand, thatHand;
+    #else
+    static uint8_t encoder_value[NUMBER_OF_ENCODERS] = {0};
+    #endif
 
-__attribute__((weak)) void encoder_update_user(int8_t index, bool clockwise) {}
+    __attribute__((weak)) void encoder_update_user(int8_t index, bool clockwise) {}
 
-__attribute__((weak)) void encoder_update_kb(int8_t index, bool clockwise) { encoder_update_user(index, clockwise); }
+    __attribute__((weak)) void encoder_update_kb(int8_t index, bool clockwise) { encoder_update_user(index, clockwise); }
 
-void encoder_init(void) {
-#if defined(SPLIT_KEYBOARD) && defined(ENCODERS_PAD_A_RIGHT) && defined(ENCODERS_PAD_B_RIGHT)
-    if (!isLeftHand) {
-        const pin_t encoders_pad_a_right[] = ENCODERS_PAD_A_RIGHT;
-        const pin_t encoders_pad_b_right[] = ENCODERS_PAD_B_RIGHT;
-#    if defined(ENCODER_RESOLUTIONS_RIGHT)
-        const uint8_t encoder_resolutions_right[] = ENCODER_RESOLUTIONS_RIGHT;
-#    endif
-        for (uint8_t i = 0; i < NUMBER_OF_ENCODERS; i++) {
-            encoders_pad_a[i] = encoders_pad_a_right[i];
-            encoders_pad_b[i] = encoders_pad_b_right[i];
-#    if defined(ENCODER_RESOLUTIONS_RIGHT)
-            encoder_resolutions[i] = encoder_resolutions_right[i];
-#    endif
+    void encoder_init(void) {
+    #if defined(SPLIT_KEYBOARD) && defined(ENCODERS_PAD_A_RIGHT) && defined(ENCODERS_PAD_B_RIGHT)
+        if (!isLeftHand) {
+            const pin_t encoders_pad_a_right[] = ENCODERS_PAD_A_RIGHT;
+            const pin_t encoders_pad_b_right[] = ENCODERS_PAD_B_RIGHT;
+        #    if defined(ENCODER_RESOLUTIONS_RIGHT)
+            const uint8_t encoder_resolutions_right[] = ENCODER_RESOLUTIONS_RIGHT;
+        #    endif
+            for (uint8_t i = 0; i < NUMBER_OF_ENCODERS; i++) {
+                encoders_pad_a[i] = encoders_pad_a_right[i];
+                encoders_pad_b[i] = encoders_pad_b_right[i];
+        #    if defined(ENCODER_RESOLUTIONS_RIGHT)
+                encoder_resolutions[i] = encoder_resolutions_right[i];
+        #    endif
+            }
         }
+    #endif
+
+        for (int i = 0; i < NUMBER_OF_ENCODERS; i++) {
+            setPinInputHigh(encoders_pad_a[i]);
+            setPinInputHigh(encoders_pad_b[i]);
+
+            encoder_state[i] = (readPin(encoders_pad_a[i]) << 0) | (readPin(encoders_pad_b[i]) << 1);
+        }
+
+    #ifdef SPLIT_KEYBOARD
+        thisHand = isLeftHand ? 0 : NUMBER_OF_ENCODERS;
+        thatHand = NUMBER_OF_ENCODERS - thisHand;
+    #endif
     }
-#endif
 
-    for (int i = 0; i < NUMBER_OF_ENCODERS; i++) {
-        setPinInputHigh(encoders_pad_a[i]);
-        setPinInputHigh(encoders_pad_b[i]);
-
-        encoder_state[i] = (readPin(encoders_pad_a[i]) << 0) | (readPin(encoders_pad_b[i]) << 1);
-    }
-
-#ifdef SPLIT_KEYBOARD
-    thisHand = isLeftHand ? 0 : NUMBER_OF_ENCODERS;
-    thatHand = NUMBER_OF_ENCODERS - thisHand;
-#endif
-}
-
-static void encoder_update(int8_t index, uint8_t state) {
-    uint8_t i = index;
-
-#ifdef ENCODER_RESOLUTIONS
-    int8_t resolution = encoder_resolutions[i];
-#else
-    int8_t resolution = ENCODER_RESOLUTION;
-#endif
-
-#ifdef SPLIT_KEYBOARD
-    index += thisHand;
-#endif
-    encoder_pulses[i] += encoder_LUT[state & 0xF];
-    if (encoder_pulses[i] >= resolution) {
-        encoder_value[index]++;
-        encoder_update_kb(index, ENCODER_COUNTER_CLOCKWISE);
-    }
-    if (encoder_pulses[i] <= -resolution) {  // direction is arbitrary here, but this clockwise
-        encoder_value[index]--;
-        encoder_update_kb(index, ENCODER_CLOCKWISE);
-    }
-    encoder_pulses[i] %= resolution;
-}
-
-void encoder_read(void) {
-    for (uint8_t i = 0; i < NUMBER_OF_ENCODERS; i++) {
-        encoder_state[i] <<= 2;
-        encoder_state[i] |= (readPin(encoders_pad_a[i]) << 0) | (readPin(encoders_pad_b[i]) << 1);
-        encoder_update(i, encoder_state[i]);
-    }
-}
-
-#ifdef SPLIT_KEYBOARD
-void encoder_state_raw(uint8_t* slave_state) { memcpy(slave_state, &encoder_value[thisHand], sizeof(uint8_t) * NUMBER_OF_ENCODERS); }
-
-void encoder_update_raw(uint8_t* slave_state) {
-    for (uint8_t i = 0; i < NUMBER_OF_ENCODERS; i++) {
-        uint8_t index = i + thatHand;
-        int8_t  delta = slave_state[i] - encoder_value[index];
-        while (delta > 0) {
-            delta--;
+    static void encoder_update(int8_t index, uint8_t state) {
+        uint8_t i = index;
+    #ifdef ENCODER_RESOLUTIONS
+        int8_t resolution = encoder_resolutions[i];
+    #else
+        int8_t resolution = ENCODER_RESOLUTION;
+    #endif
+    #ifdef SPLIT_KEYBOARD
+        index += thisHand;
+    #endif
+        encoder_pulses[i] += encoder_LUT[state & 0xF];
+        if (encoder_pulses[i] >= resolution) {
             encoder_value[index]++;
             encoder_update_kb(index, ENCODER_COUNTER_CLOCKWISE);
         }
-        while (delta < 0) {
-            delta++;
+        if (encoder_pulses[i] <= -resolution) {  // direction is arbitrary here, but this clockwise
             encoder_value[index]--;
             encoder_update_kb(index, ENCODER_CLOCKWISE);
         }
+        encoder_pulses[i] %= resolution;
     }
-}
+
+    void encoder_read(void) {
+        for (uint8_t i = 0; i < NUMBER_OF_ENCODERS; i++) {
+            encoder_state[i] <<= 2;
+            encoder_state[i] |= (readPin(encoders_pad_a[i]) << 0) | (readPin(encoders_pad_b[i]) << 1);
+            encoder_update(i, encoder_state[i]);
+        }
+    }
+
+    #ifdef SPLIT_KEYBOARD
+    void encoder_state_raw(uint8_t* slave_state) { memcpy(slave_state, &encoder_value[thisHand], sizeof(uint8_t) * NUMBER_OF_ENCODERS); }
+
+    void encoder_update_raw(uint8_t* slave_state) {
+        for (uint8_t i = 0; i < NUMBER_OF_ENCODERS; i++) {
+            uint8_t index = i + thatHand;
+            int8_t  delta = slave_state[i] - encoder_value[index];
+            while (delta > 0) {
+                delta--;
+                encoder_value[index]++;
+                encoder_update_kb(index, ENCODER_COUNTER_CLOCKWISE);
+            }
+            while (delta < 0) {
+                delta++;
+                encoder_value[index]--;
+                encoder_update_kb(index, ENCODER_CLOCKWISE);
+            }
+        }
+    }
+    #endif
+#else
+    #if defined(SPLIT_KEYBOARD) && defined(MATRIX_ENCODER_PINS_ABC) && defined(MATRIX_ENCODER_PINS_ABC_RIGHT)
+        //split keyboard,both encoder
+        static pin_t matrix_encoders_pins_left[][3] = MATRIX_ENCODER_PINS_ABC;
+        static pin_t matrix_encoders_pins_right[][3] = MATRIX_ENCODER_PINS_ABC_RIGHT;
+        #define NUMBER_OF_ENCODERS_LEFT (sizeof(matrix_encoders_pins_left)/ sizeof(*matrix_encoders_pins_left))
+        #define NUMBER_OF_ENCODERS_RIGHT (sizeof(matrix_encoders_pins_right)/ sizeof(*matrix_encoders_pins_right))
+        static uint8_t encoder_state_left[NUMBER_OF_ENCODERS_LEFT]  = {0};
+        static int8_t  encoder_pulses_left[NUMBER_OF_ENCODERS_LEFT] = {0};
+        static uint8_t encoder_value_left[NUMBER_OF_ENCODERS_LEFT] = {0};
+        static uint8_t encoder_state_right[NUMBER_OF_ENCODERS_RIGHT]  = {0};
+        static int8_t  encoder_pulses_right[NUMBER_OF_ENCODERS_RIGHT] = {0};
+        static uint8_t encoder_value_right[NUMBER_OF_ENCODERS_RIGHT] = {0};
+        static pin_t row_pins_left[] = MATRIX_ROW_PINS;
+        #ifdef MATRIX_ROW_PINS_RIGHT
+        static pin_t row_pins_right[] = MATRIX_ROW_PINS_RIGHT;
+        #else
+        static pin_t row_pins_right = MATRIX_ROW_PINS;
+        #endif
+        static pin_t col_pins_left[] = MATRIX_COL_PINS;
+        #ifdef MATRIX_COL_PINS_RIGHT
+        static pin_t col_pins_right[] = MATRIX_COL_PINS_RIGHT;
+        #else
+        static pin_t col_pins_right[] = MATRIX_COL_PINS;
+        #endif
+    #elif defined(SPLIT_KEYBOARD) && !defined(MATRIX_ENCODER_PINS_ABC) && defined(MATRIX_ENCODER_PINS_ABC_RIGHT)
+        //split keyboard,right only encoder
+        static pin_t matrix_encoders_pins_right[][3] = MATRIX_ENCODER_PINS_ABC_RIGHT;
+        #define NUMBER_OF_ENCODERS_RIGHT (sizeof(matrix_encoders_pins_right)/ sizeof(*matrix_encoders_pins_right))
+        #define NUMBER_OF_ENCODERS_LEFT 0
+        static uint8_t encoder_state_right[NUMBER_OF_ENCODERS_RIGHT]  = {0};
+        static int8_t  encoder_pulses_right[NUMBER_OF_ENCODERS_RIGHT] = {0};
+        static uint8_t encoder_value_right[NUMBER_OF_ENCODERS_RIGHT] = {0};
+        #ifdef MATRIX_ROW_PINS_RIGHT
+        static pin_t row_pins_right[] = MATRIX_ROW_PINS_RIGHT;
+        #else
+        static pin_t row_pins_right = MATRIX_ROW_PINS;
+        #endif
+        #ifdef MATRIX_COL_PINS_RIGHT
+        static pin_t col_pins_right[] = MATRIX_COL_PINS_RIGHT;
+        #else
+        static pin_t col_pins_right[] = MATRIX_COL_PINS;
+        #endif
+    #else
+        //non split keyboard or left only encoder
+        static pin_t matrix_encoders_pins[][3] = MATRIX_ENCODER_PINS_ABC;
+        #define NUMBER_OF_ENCODERS (sizeof(matrix_encoders_pins)/ sizeof(*matrix_encoders_pins))
+        static uint8_t encoder_state[NUMBER_OF_ENCODERS]  = {0};
+        static int8_t  encoder_pulses[NUMBER_OF_ENCODERS] = {0};
+        static uint8_t encoder_value[NUMBER_OF_ENCODERS] = {0};
+        static pin_t row_pins[] = MATRIX_ROW_PINS;
+        static pin_t col_pins[] = MATRIX_COL_PINS;
+    #endif
+
+    #ifdef ENCODER_RESOLUTIONS
+        static uint8_t encoder_resolutions[] = ENCODER_RESOLUTIONS;
+    #endif
+    #ifdef ENCODER_RESOLUTIONS_RIGHT
+        static uint8_t encoder_resolutions_right[] = ENCODER_RESOLUTIONS_RIGHT;
+    #endif
+
+    static void encoder_update(int8_t index, uint8_t state) {
+        #if defined(SPLIT_KEYBOARD) && defined(MATRIX_ENCODER_PINS_ABC) && defined(MATRIX_ENCODER_PINS_ABC_RIGHT)
+            //split keyboard,both encoder
+            int8_t *current_encoder_pulses = isLeftHand ? encoder_pulses_left:encoder_pulses_right;
+            uint8_t *current_encoder_value = isLeftHand ? encoder_value_left:encoder_value_right;
+            uint8_t total_index = isLeftHand ? index : index + NUMBER_OF_ENCODERS_LEFT;
+            #if defined(ENCODER_RESOLUTIONS) && defined(ENCODER_RESOLUTIONS_RIGHT )
+            int8_t resolution = isLeftHand ? encoder_resolutions[index]:encoder_resolutions_right[index];
+            #elif defined(ENCODER_RESOLUTIONS)
+            int8_t resolution = isLeftHand ? encoder_resolutions[index]:ENCODER_RESOLUTION;
+            #elif defined(ENCODER_RESOLUTIONS_RIGHT)
+            int8_t resolution = isLeftHand ? ENCODER_RESOLUTION:encoder_resolutions_right[index];
+            #else
+            int8_t resolution = ENCODER_RESOLUTION;
+            #endif
+        #elif defined(SPLIT_KEYBOARD) && !defined(MATRIX_ENCODER_PINS_ABC) && defined(MATRIX_ENCODER_PINS_ABC_RIGHT)
+            //split keyboard,right only encoder
+            int8_t *current_encoder_pulses = encoder_pulses_right;
+            uint8_t *current_encoder_value = encoder_value_right;
+            uint8_t total_index = index;
+            #if defined(ENCODER_RESOLUTIONS_RIGHT)
+                int8_t resolution = encoder_resolutions_right[index];
+            #else
+                int8_t resolution = ENCODER_RESOLUTION;
+            #endif
+        #else
+            //non split keyboard or left only encoder
+            int8_t *current_encoder_pulses = encoder_pulses;
+            uint8_t *current_encoder_value = encoder_value;
+            uint8_t total_index = index;
+            #if defined(ENCODER_RESOLUTIONS)
+                int8_t resolution = encoder_resolutions[index];
+            #else
+                int8_t resolution = ENCODER_RESOLUTION;
+            #endif
+        #endif
+
+        current_encoder_pulses[index] += encoder_LUT[state & 0xF];
+
+        if (current_encoder_pulses[index] >= resolution) {
+            current_encoder_value[index]++;
+            encoder_update_kb(total_index, ENCODER_COUNTER_CLOCKWISE);
+        }
+        if (current_encoder_pulses[index] <= -resolution) {
+            current_encoder_value[index]--;
+            encoder_update_kb(total_index, ENCODER_CLOCKWISE);
+        }
+        current_encoder_pulses[index] %= resolution;
+    }
+    static void encoder_read_all(void){
+        #if defined(SPLIT_KEYBOARD) && defined(MATRIX_ENCODER_PINS_ABC) && defined(MATRIX_ENCODER_PINS_ABC_RIGHT)
+            //split keyboard,both encoder
+            pin_t *current_rows = isLeftHand ? row_pins_left:row_pins_right;
+            pin_t *current_cols = isLeftHand ? col_pins_left:col_pins_right;
+            uint8_t *current_encoder_state = isLeftHand ? encoder_state_left:encoder_state_right;
+            pin_t *current_matrix = isLeftHand ? (pin_t *)matrix_encoders_pins_left:(pin_t *)matrix_encoders_pins_right;
+            uint8_t encoder_count = isLeftHand ? NUMBER_OF_ENCODERS_LEFT:NUMBER_OF_ENCODERS_RIGHT;
+        #elif defined(SPLIT_KEYBOARD) && !defined(MATRIX_ENCODER_PINS_ABC) && defined(MATRIX_ENCODER_PINS_ABC_RIGHT)
+            //split keyboard,right only encoder
+            pin_t *current_rows = row_pins_right;
+            pin_t *current_cols = col_pins_right;
+            uint8_t *current_encoder_state = encoder_state_right;
+            pin_t *current_matrix = (pin_t *)matrix_encoders_pins_right;
+            uint8_t encoder_count = NUMBER_OF_ENCODERS_RIGHT;
+        #else
+            //non split keyboard or left only encoder
+            pin_t *current_rows = row_pins;
+            pin_t *current_cols = col_pins;
+            uint8_t *current_encoder_state = encoder_state;
+            pin_t *current_matrix = (pin_t *)matrix_encoders_pins;
+            uint8_t encoder_count = NUMBER_OF_ENCODERS;
+        #endif
+        //unselect rows(all)
+        for (int i = 0; i < MATRIX_ROWS; i++) {
+            setPinOutput(current_rows[i]);
+            writePinHigh(current_rows[i]);
+        }
+        //unselect cols(all)
+        for (int i = 0; i < MATRIX_COLS; i++) {
+            setPinOutput(current_cols[i]);
+            writePinLow(current_cols[i]);
+        }
+
+        for (int i = 0; i < encoder_count; i++) {
+            //select row(C)
+            writePinLow(current_matrix[i*3+2]);
+            //select cols(A&B)
+            setPinInputHigh(current_matrix[i*3+0]);
+            setPinInputHigh(current_matrix[i*3+1]);
+            matrix_io_delay();
+            //read cols
+            current_encoder_state[i] <<= 2;
+            current_encoder_state[i] |= (readPin(current_matrix[i*3+0]) << 0) | (readPin(current_matrix[i*3+1]) << 1);
+            encoder_update(i, current_encoder_state[i]);
+
+            //unselect row(C)
+            writePinHigh(current_matrix[i*3+2]);
+
+            //unselect cols(A&B)
+            setPinOutput(current_matrix[i*3+0]);
+            writePinLow(current_matrix[i*3+0]);
+            setPinOutput(current_matrix[i*3+1]);
+            writePinLow(current_matrix[i*3+1]);
+        }
+
+        // Before scanning the key matrix, it must be returned to the initial state (all cols InputHigh)
+        for (int i = 0; i < MATRIX_COLS; i++) {
+            setPinInputHigh(current_cols[i]);
+        }
+    }
+
+    __attribute__((weak)) void encoder_update_user(int8_t index, bool clockwise) {}
+    __attribute__((weak)) void encoder_update_kb(int8_t index, bool clockwise) { encoder_update_user(index, clockwise); }
+    void encoder_init(void) {
+        encoder_read_all();
+    }
+    void encoder_read(void) {
+        encoder_read_all();
+    }
+
+    #if defined(SPLIT_KEYBOARD) && defined(MATRIX_ENCODER_PINS_ABC_RIGHT)
+    void encoder_state_raw(uint8_t* slave_state) {
+        memcpy(slave_state, &encoder_value_right[0], sizeof(uint8_t) * NUMBER_OF_ENCODERS_RIGHT);
+    }
+    void encoder_update_raw(uint8_t* slave_state) {
+        for (uint8_t i = 0; i < NUMBER_OF_ENCODERS_RIGHT; i++) {
+            uint8_t total_index = i + NUMBER_OF_ENCODERS_LEFT;
+            int8_t  delta = slave_state[i] - encoder_value_right[i];
+            while (delta > 0) {
+                delta--;
+                encoder_value_right[i]++;
+                encoder_update_kb(total_index, ENCODER_COUNTER_CLOCKWISE);
+            }
+            while (delta < 0) {
+                delta++;
+                encoder_value_right[i]--;
+                encoder_update_kb(total_index, ENCODER_CLOCKWISE);
+            }
+        }
+    }
+    #endif
 #endif

--- a/quantum/encoder.c
+++ b/quantum/encoder.c
@@ -32,7 +32,7 @@
 #endif
 
 #if (defined(ENCODERS_PAD_A) && defined(ENCODERS_PAD_B))
-#    define ENCODER_SIMPLE
+#    define ENCODER_BASIC
 #endif
 
 #if defined(SPLIT_KEYBOARD) && defined(MATRIX_ENCODER_PINS_ABC) && defined(MATRIX_ENCODER_PINS_ABC_RIGHT)
@@ -41,7 +41,7 @@
 #    define split_keyboard_right_only_encoder
 #endif
 
-#if defined(ENCODER_SIMPLE)
+#if defined(ENCODER_BASIC)
 #    define NUMBER_OF_ENCODERS (sizeof(encoders_pad_a) / sizeof(pin_t))
 static pin_t encoders_pad_a[] = ENCODERS_PAD_A;
 static pin_t encoders_pad_b[] = ENCODERS_PAD_B;
@@ -59,7 +59,7 @@ static uint8_t encoder_resolutions[] = ENCODER_RESOLUTIONS;
 #endif
 static int8_t encoder_LUT[] = {0, -1, 1, 0, 1, 0, 0, -1, -1, 0, 0, 1, 0, 1, -1, 0};
 
-#if defined(ENCODER_SIMPLE)
+#if defined(ENCODER_BASIC)
 
 static uint8_t encoder_state[NUMBER_OF_ENCODERS]  = {0};
 static int8_t  encoder_pulses[NUMBER_OF_ENCODERS] = {0};
@@ -159,7 +159,7 @@ void encoder_update_raw(uint8_t* slave_state) {
 }
 #    endif
 
-#else  // ! defined(ENCODER_SIMPLE)
+#else  // ! defined(ENCODER_BASIC)
 
 extern bool peek_matrix(uint8_t row_index, uint8_t col_index, bool read_raw);
 
@@ -401,4 +401,4 @@ void encoder_update_raw(uint8_t *slave_state) {
 }
 #    endif
 
-#endif  // end of  #if defined(ENCODER_SIMPLE)
+#endif  // end of  #if defined(ENCODER_BASIC)

--- a/quantum/encoder.c
+++ b/quantum/encoder.c
@@ -188,7 +188,7 @@ typedef struct {
     #if defined(MATRIX_ROW_PINS_RIGHT)
     static pin_t row_pins_right[] = MATRIX_ROW_PINS_RIGHT;
     #else
-    static pin_t row_pins_right = MATRIX_ROW_PINS;
+    static pin_t row_pins_right[] = MATRIX_ROW_PINS;
     #endif
     static pin_t col_pins_left[] = MATRIX_COL_PINS;
     #if defined(MATRIX_COL_PINS_RIGHT)
@@ -204,7 +204,7 @@ typedef struct {
     #if defined(MATRIX_ROW_PINS_RIGHT)
     static pin_t row_pins_right[] = MATRIX_ROW_PINS_RIGHT;
     #else
-    static pin_t row_pins_right = MATRIX_ROW_PINS;
+    static pin_t row_pins_right[] = MATRIX_ROW_PINS;
     #endif
     #if defined(MATRIX_COL_PINS_RIGHT)
     static pin_t col_pins_right[] = MATRIX_COL_PINS_RIGHT;

--- a/quantum/encoder.c
+++ b/quantum/encoder.c
@@ -227,18 +227,18 @@ static uint8_t encoder_resolutions[]       = ENCODER_RESOLUTIONS;
 static uint8_t encoder_resolutions_right[] = ENCODER_RESOLUTIONS_RIGHT;
 #    endif
 
-static inline void encoder_update_common(uint8_t state, encoder_t current_encoder, uint8_t total_index, int8_t resolution) {
-    current_encoder.pulse += encoder_LUT[state & 0xF];
+static inline void encoder_update_common(uint8_t state, encoder_t *current_encoder, uint8_t total_index, int8_t resolution) {
+    current_encoder->pulse += encoder_LUT[state & 0xF];
 
-    if (current_encoder.pulse >= resolution) {
-        current_encoder.value++;
+    if (current_encoder->pulse >= resolution) {
+        current_encoder->value++;
         encoder_update_kb(total_index, ENCODER_COUNTER_CLOCKWISE);
     }
-    if (current_encoder.pulse <= -resolution) {
-        current_encoder.value--;
+    if (current_encoder->pulse <= -resolution) {
+        current_encoder->value--;
         encoder_update_kb(total_index, ENCODER_CLOCKWISE);
     }
-    current_encoder.pulse %= resolution;
+    current_encoder->pulse %= resolution;
 }
 static void encoder_update(int8_t index, uint8_t state) {
 // clang-format off
@@ -249,14 +249,14 @@ static void encoder_update(int8_t index, uint8_t state) {
             #else
                 int8_t resolution = ENCODER_RESOLUTION;
             #endif
-            encoder_update_common(state,encoders_left[index],index,resolution);
+            encoder_update_common(state,(encoder_t *)&encoders_left[index],index,resolution);
         }else{
             #if defined(ENCODER_RESOLUTIONS_RIGHT)
                 int8_t resolution = encoder_resolutions_right[index];
             #else
                 int8_t resolution = ENCODER_RESOLUTION;
             #endif
-            encoder_update_common(state,encoders_right[index],index + NUMBER_OF_ENCODERS_LEFT,resolution);
+            encoder_update_common(state,(encoder_t *)&encoders_right[index],index + NUMBER_OF_ENCODERS_LEFT,resolution);
         }
     #elif defined(split_keyboard_right_only_encoder)
         #if defined(ENCODER_RESOLUTIONS_RIGHT)
@@ -264,14 +264,14 @@ static void encoder_update(int8_t index, uint8_t state) {
         #else
             int8_t resolution = ENCODER_RESOLUTION;
         #endif
-        encoder_update_common(state,encoders_right[index],index + NUMBER_OF_ENCODERS_LEFT,resolution);
+        encoder_update_common(state,(encoder_t *)&encoders_right[index],index + NUMBER_OF_ENCODERS_LEFT,resolution);
     #else //non split keyboard or left only encoder
         #if defined(ENCODER_RESOLUTIONS)
             int8_t resolution = encoder_resolutions[index];
         #else
             int8_t resolution = ENCODER_RESOLUTION;
         #endif
-        encoder_update_common(state,encoders[index],index,resolution);
+        encoder_update_common(state,(encoder_t *)&encoders[index],index,resolution);
     #endif
     // clang-format on
 }

--- a/quantum/encoder.c
+++ b/quantum/encoder.c
@@ -323,8 +323,16 @@ static void encoder_read_all(void) {
         encoder_read_all_common(row_pins_right, (pin_t *)matrix_encoders_pins_right, NUMBER_OF_ENCODERS_RIGHT, encoders_right);
     }
 #    elif defined(split_keyboard_right_only_encoder)
+    if (isLeftHand) {
+        return;
+    }
     encoder_read_all_common(row_pins_right, (pin_t *)matrix_encoders_pins_right, NUMBER_OF_ENCODERS_RIGHT, encoders_right);
 #    else  // non split keyboard or left only encoder
+#        if defined(SPLIT_KEYBOARD)
+    if (!isLeftHand) {
+        return;
+    }
+#        endif
     encoder_read_all_common(row_pins, (pin_t *)matrix_encoders_pins, NUMBER_OF_ENCODERS, encoders);
 #    endif
 }

--- a/quantum/split_common/transport.c
+++ b/quantum/split_common/transport.c
@@ -15,7 +15,7 @@
 #    include "backlight.h"
 #endif
 
-#ifdef ENCODER_ENABLE
+#ifdef encoder_transport_enable
 #    include "encoder.h"
     #if (defined(ENCODERS_PAD_A) && defined(ENCODERS_PAD_B))
         static pin_t encoders_pad[] = ENCODERS_PAD_A;
@@ -39,7 +39,7 @@ typedef struct _I2C_slave_buffer_t {
 #    if defined(RGBLIGHT_ENABLE) && defined(RGBLIGHT_SPLIT)
     rgblight_syncinfo_t rgblight_sync;
 #    endif
-#    ifdef ENCODER_ENABLE
+#    ifdef encoder_transport_enable
     uint8_t encoder_state[NUMBER_OF_ENCODERS];
 #    endif
 #    ifdef WPM_ENABLE
@@ -139,7 +139,7 @@ typedef struct _Serial_s2m_buffer_t {
     // TODO: if MATRIX_COLS > 8 change to uint8_t packed_matrix[] for pack/unpack
     matrix_row_t smatrix[ROWS_PER_HAND];
 
-#    ifdef ENCODER_ENABLE
+#    ifdef encoder_transport_enable
     uint8_t      encoder_state[NUMBER_OF_ENCODERS];
 #    endif
 

--- a/quantum/split_common/transport.c
+++ b/quantum/split_common/transport.c
@@ -20,9 +20,11 @@
     #if (defined(ENCODERS_PAD_A) && defined(ENCODERS_PAD_B))
         static pin_t encoders_pad[] = ENCODERS_PAD_A;
         #define NUMBER_OF_ENCODERS (sizeof(encoders_pad) / sizeof(pin_t))
+        #define encoder_transport_enable
     #elif defined(MATRIX_ENCODER_PINS_ABC_RIGHT)
         static pin_t matrix_encoders_pins_right[][3] = MATRIX_ENCODER_PINS_ABC_RIGHT;
         #define NUMBER_OF_ENCODERS_RIGHT (sizeof(matrix_encoders_pins_right)/ sizeof(*matrix_encoders_pins_right))
+        #define encoder_transport_enable
     #endif
 #endif
 
@@ -87,7 +89,7 @@ bool transport_master(matrix_row_t matrix[]) {
     }
 #    endif
 
-#    if defined(ENCODER_ENABLE) && (defined(ENCODERS_PAD_A) && defined(ENCODERS_PAD_B) || defined(NUMBER_OF_ENCODERS_RIGHT))
+#    if defined(encoder_transport_enable)
     i2c_readReg(SLAVE_I2C_ADDRESS, I2C_ENCODER_START, (void *)i2c_buffer->encoder_state, sizeof(i2c_buffer->encoder_state), TIMEOUT);
     encoder_update_raw(i2c_buffer->encoder_state);
 #    endif
@@ -120,7 +122,7 @@ void transport_slave(matrix_row_t matrix[]) {
     }
 #    endif
 
-#    if defined(ENCODER_ENABLE) && (defined(ENCODERS_PAD_A) && defined(ENCODERS_PAD_B)) || defined(NUMBER_OF_ENCODERS_RIGHT)
+#    if defined(encoder_transport_enable)
     encoder_state_raw(i2c_buffer->encoder_state);
 #    endif
 
@@ -256,7 +258,7 @@ bool transport_master(matrix_row_t matrix[]) {
     serial_m2s_buffer.backlight_level = is_backlight_enabled() ? get_backlight_level() : 0;
 #    endif
 
-#    if defined(ENCODER_ENABLE) && (defined(ENCODERS_PAD_A) && defined(ENCODERS_PAD_B) || defined(NUMBER_OF_ENCODERS_RIGHT))
+#    if defined(encoder_transport_enable)
     encoder_update_raw((uint8_t *)serial_s2m_buffer.encoder_state);
 #    endif
 
@@ -277,7 +279,7 @@ void transport_slave(matrix_row_t matrix[]) {
     backlight_set(serial_m2s_buffer.backlight_level);
 #    endif
 
-#    if defined(ENCODER_ENABLE) && (defined(ENCODERS_PAD_A) && defined(ENCODERS_PAD_B) || defined(NUMBER_OF_ENCODERS_RIGHT))
+#    if defined(encoder_transport_enable)
     encoder_state_raw((uint8_t *)serial_s2m_buffer.encoder_state);
 #    endif
 

--- a/quantum/split_common/transport.c
+++ b/quantum/split_common/transport.c
@@ -23,7 +23,7 @@
         #define encoder_transport_enable
     #elif defined(MATRIX_ENCODER_PINS_ABC_RIGHT)
         static pin_t matrix_encoders_pins_right[][3] = MATRIX_ENCODER_PINS_ABC_RIGHT;
-        #define NUMBER_OF_ENCODERS_RIGHT (sizeof(matrix_encoders_pins_right)/ sizeof(*matrix_encoders_pins_right))
+        #define NUMBER_OF_ENCODERS (sizeof(matrix_encoders_pins_right)/ sizeof(*matrix_encoders_pins_right))
         #define encoder_transport_enable
     #endif
 #endif
@@ -40,11 +40,7 @@ typedef struct _I2C_slave_buffer_t {
     rgblight_syncinfo_t rgblight_sync;
 #    endif
 #    ifdef ENCODER_ENABLE
-    #if (defined(ENCODERS_PAD_A) && defined(ENCODERS_PAD_B))
-    uint8_t      encoder_state[NUMBER_OF_ENCODERS];
-    #elif defined(NUMBER_OF_ENCODERS_RIGHT)
-    uint8_t      encoder_state[NUMBER_OF_ENCODERS_RIGHT];
-    #endif
+    uint8_t encoder_state[NUMBER_OF_ENCODERS];
 #    endif
 #    ifdef WPM_ENABLE
     uint8_t current_wpm;
@@ -144,11 +140,7 @@ typedef struct _Serial_s2m_buffer_t {
     matrix_row_t smatrix[ROWS_PER_HAND];
 
 #    ifdef ENCODER_ENABLE
-    #if (defined(ENCODERS_PAD_A) && defined(ENCODERS_PAD_B))
     uint8_t      encoder_state[NUMBER_OF_ENCODERS];
-    #elif defined(NUMBER_OF_ENCODERS_RIGHT)
-    uint8_t      encoder_state[NUMBER_OF_ENCODERS_RIGHT];
-    #endif
 #    endif
 
 } Serial_s2m_buffer_t;

--- a/quantum/split_common/transport.c
+++ b/quantum/split_common/transport.c
@@ -15,7 +15,7 @@
 #    include "backlight.h"
 #endif
 
-#ifdef encoder_transport_enable
+#ifdef ENCODER_ENABLE
 #    include "encoder.h"
     #if (defined(ENCODERS_PAD_A) && defined(ENCODERS_PAD_B))
         static pin_t encoders_pad[] = ENCODERS_PAD_A;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Enables flexible wiring of Encoders.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
The following issues are in the current encoder feature.
- The same number of encoders are needed for left and right keyboards (#10096).
- The A/B line of Encoder occupies the pin.
　(It is not impossible to wire A/B line to the matrix, but if you wire to GND, you cannot wire in parallel.)

This solves the two issues above.
Similar to #7209, but #10096 will also be improved.

**I created and tested the circuit diagram on [this gist](https://gist.github.com/hsakoh/ca28268f6d7d3f1d24912176c4515354) on a breadboard.**

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* #10096
* #7209

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

I've only been touching QMK for a week now, I may have a fundamental misunderstanding. 
So please be nice and gentle.