### PR TITLE
IS31FL3741 driver fixup

### DIFF
--- a/drivers/issi/is31fl3741.c
+++ b/drivers/issi/is31fl3741.c
@@ -97,14 +97,13 @@ bool IS31FL3741_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     IS31FL3741_write_register(addr, ISSI_COMMANDREGISTER, ISSI_PAGE_PWM0);
 
     for (int i = 0; i < 342; i += 18) {
-        g_twi_transfer_buffer[0] = i % 180;
-
         if (i == 180) {
             // unlock the command register and select PG2
             IS31FL3741_write_register(addr, ISSI_COMMANDREGISTER_WRITELOCK, 0xC5);
             IS31FL3741_write_register(addr, ISSI_COMMANDREGISTER, ISSI_PAGE_PWM1);
         }
 
+        g_twi_transfer_buffer[0] = i % 180;
         memcpy(g_twi_transfer_buffer + 1, pwm_buffer + i, 18);
 
 #if ISSI_PERSISTENCE > 0

--- a/drivers/issi/is31fl3741.c
+++ b/drivers/issi/is31fl3741.c
@@ -250,4 +250,6 @@ void IS31FL3741_set_scaling_registers(const is31_led *pled, uint8_t red, uint8_t
     g_scaling_registers[pled->driver][pled->r] = red;
     g_scaling_registers[pled->driver][pled->g] = green;
     g_scaling_registers[pled->driver][pled->b] = blue;
+
+    g_scaling_registers_update_required[pled->driver] = true;
 }

--- a/drivers/issi/is31fl3741.h
+++ b/drivers/issi/is31fl3741.h
@@ -23,10 +23,10 @@
 #include <stdbool.h>
 
 typedef struct is31_led {
-    uint8_t  driver : 2;
-    uint16_t r;
-    uint16_t g;
-    uint16_t b;
+    uint32_t driver : 2;
+    uint32_t r : 10;
+    uint32_t g : 10;
+    uint32_t b : 10;
 } __attribute__((packed)) is31_led;
 
 extern const is31_led g_is31_leds[DRIVER_LED_TOTAL];

--- a/drivers/issi/is31fl3741.h
+++ b/drivers/issi/is31fl3741.h
@@ -30,7 +30,6 @@ typedef struct is31_led {
 } __attribute__((packed)) is31_led;
 
 extern const is31_led g_is31_leds[DRIVER_LED_TOTAL];
-extern const is31_led g_is31_indicator_leds[DRIVER_INDICATOR_LED_TOTAL];
 
 void IS31FL3741_init(uint8_t addr);
 void IS31FL3741_write_register(uint8_t addr, uint8_t reg, uint8_t data);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Fix up a few things about IS31FL3741 driver.
- Fix issue with data transfer of CS1_SW7 to CS18_SW7. https://github.com/qmk/qmk_firmware/pull/10519/commits/0e40e9e7097401ca01d682e0714af43178a3e838
- Fix issue with handling of scaling register buffer's dirty flag. https://github.com/qmk/qmk_firmware/pull/10519/commits/05731f157a33a0cc86ee9012b4fa312de016486c
- Remove unused extern declaration. https://github.com/qmk/qmk_firmware/pull/10519/commits/f792491a848b6ea2d0380f26071a9f023fe2ab87
- Compaction of struct is31_led utilizing bit fields. https://github.com/qmk/qmk_firmware/commit/46538d9cd153afd356bc45ab22137b7b88644b5e
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Driver
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #9961
* https://github.com/qmk/qmk_firmware/issues/10423

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).