### PR TITLE
Add documentation link to Tap-Hold Configuration Options from Mod-Tap

### DIFF
--- a/docs/mod_tap.md
+++ b/docs/mod_tap.md
@@ -55,3 +55,7 @@ Unfortunately, these keycodes cannot be used in Mod-Taps or Layer-Taps, since an
 Additionally, you may run into issues when using Remote Desktop Connection on Windows. Because these codes send shift very fast, Remote Desktop may miss the codes.
 
 To fix this, open Remote Desktop Connection, click on "Show Options", open the the "Local Resources" tab. In the keyboard section, change the drop down to "On this Computer". This will fix the issue, and allow the characters to work correctly.
+
+## Other Resources
+
+See the [Tap-Hold Configuration Options](tap_hold.md) for additional flags that tweak Mod-Tap behavior.


### PR DESCRIPTION
## Description

This PR adds a link to the tap-hold config options page from mod-tap. Specifically, this will help users that are unaware of the available settings that affect mod-tap (like TAPPING_FORCE_HOLD).

## Types of Changes

- [x] Documentation
