### PR TITLE
[Core] Added `add_oneshot_mods` & `del_oneshot_mods`

### DIFF
--- a/tmk_core/common/action_util.c
+++ b/tmk_core/common/action_util.c
@@ -290,6 +290,32 @@ void set_macro_mods(uint8_t mods) { macro_mods = mods; }
 void clear_macro_mods(void) { macro_mods = 0; }
 
 #ifndef NO_ACTION_ONESHOT
+/** \brief get oneshot mods
+ *
+ * FIXME: needs doc
+ */
+uint8_t get_oneshot_mods(void) { return oneshot_mods; }
+
+void add_oneshot_mods(uint8_t mods) {
+    if (oneshot_mods != mods) {
+#    if (defined(ONESHOT_TIMEOUT) && (ONESHOT_TIMEOUT > 0))
+        oneshot_time = timer_read();
+#    endif
+        oneshot_mods |= mods;
+        oneshot_mods_changed_kb(mods);
+    }
+}
+
+void del_oneshot_mods(uint8_t mods) {
+    if (oneshot_mods) {
+        oneshot_mods &= ~mods;
+#    if (defined(ONESHOT_TIMEOUT) && (ONESHOT_TIMEOUT > 0))
+        oneshot_time = oneshot_mods ? timer_read() : 0;
+#    endif
+        oneshot_mods_changed_kb(oneshot_mods);
+    }
+}
+
 /** \brief set oneshot mods
  *
  * FIXME: needs doc
@@ -316,11 +342,6 @@ void clear_oneshot_mods(void) {
         oneshot_mods_changed_kb(oneshot_mods);
     }
 }
-/** \brief get oneshot mods
- *
- * FIXME: needs doc
- */
-uint8_t get_oneshot_mods(void) { return oneshot_mods; }
 #endif
 
 /** \brief Called when the one shot modifiers have been changed.

--- a/tmk_core/common/action_util.c
+++ b/tmk_core/common/action_util.c
@@ -297,7 +297,7 @@ void clear_macro_mods(void) { macro_mods = 0; }
 uint8_t get_oneshot_mods(void) { return oneshot_mods; }
 
 void add_oneshot_mods(uint8_t mods) {
-    if (oneshot_mods != mods) {
+    if ((oneshot_mods & mods) != mods) {
 #    if (defined(ONESHOT_TIMEOUT) && (ONESHOT_TIMEOUT > 0))
         oneshot_time = timer_read();
 #    endif
@@ -307,7 +307,7 @@ void add_oneshot_mods(uint8_t mods) {
 }
 
 void del_oneshot_mods(uint8_t mods) {
-    if (oneshot_mods) {
+    if (oneshot_mods & mods) {
         oneshot_mods &= ~mods;
 #    if (defined(ONESHOT_TIMEOUT) && (ONESHOT_TIMEOUT > 0))
         oneshot_time = oneshot_mods ? timer_read() : 0;

--- a/tmk_core/common/action_util.h
+++ b/tmk_core/common/action_util.h
@@ -57,12 +57,11 @@ void    set_macro_mods(uint8_t mods);
 void    clear_macro_mods(void);
 
 /* oneshot modifier */
-void    set_oneshot_mods(uint8_t mods);
 uint8_t get_oneshot_mods(void);
+void    add_oneshot_mods(uint8_t mods);
+void    del_oneshot_mods(uint8_t mods);
+void    set_oneshot_mods(uint8_t mods);
 void    clear_oneshot_mods(void);
-void    oneshot_toggle(void);
-void    oneshot_enable(void);
-void    oneshot_disable(void);
 bool    has_oneshot_mods_timed_out(void);
 
 uint8_t get_oneshot_locked_mods(void);


### PR DESCRIPTION
## Description

To be consistent with all the other mod functions in `action_util` that all had a `add...mods(mods)` and `del...mods(mods)` function, I added similar functions for one shot mods.

`add_oneshot_mods` takes a modmask as an argument and adds the modifier passed in argument to the one shot mod state by ORing the two together. The one shot timer gets also updated.

`del_oneshot_mods` disables the passed modifier(s) in the current one shot mod state in the same fashion as all other del...mods functions in the file. The one shot timer gets reset to 0 if no shot mod is left after the deletion but gets restarted if there still remains a one shot modifier. Please let me know if you find any pitfalls in changing the one shot timer this way.

Aside from adding two new functions, I also:

Deleted undefined and unused prototypes:
- `void oneshot_enable(void)`
- `void oneshot_disable(void)`
- `void oneshot_toggle(void)`

Reordered the oneshot functions to follow the same order as other mod functions, 
that is to say : get, add, del, set, clear

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation (See PS)

## Issues Fixed or Closed by This PR

* N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (see PS)
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

PS: I have opened another PR (#10550)  which adds a "Checking modifier state" section to the documentation page on modifiers which lists all mod masks and mod functions such as `add_mods()` and so on. While it does not currently mention the new functions of this PR, these can be very easily added to the docs of PR #10550.
