### PR TITLE
[Docs] New section to modifier docs: Checking Modifier State

### DIFF
--- a/docs/feature_advanced_keycodes.md
+++ b/docs/feature_advanced_keycodes.md
@@ -61,7 +61,9 @@ The full list of mod masks is as follows:
 Aside from accessing the currently active modifiers using `get_mods()`, there exists some other functions you can use to modify the modifier state, where the `mods` argument refers to the modifiers bitmask.
 
 * `add_mods(mods)`: Enable `mods` without affecting any other modifiers
+* `register_mods(mods)`: Like `add_mods` but send a keyboard report immediately.
 * `del_mods(mods)`: Disable `mods` without affecting any other modifiers
+* `unregister_mods(mods)`: Like `del_mods` but send a keyboard report immediately.
 * `set_mods(mods)`: Overwrite current modifier state with `mods`
 * `clear_mods()`: Reset the modifier state by disabling all modifiers
 

--- a/docs/feature_advanced_keycodes.md
+++ b/docs/feature_advanced_keycodes.md
@@ -88,7 +88,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 
     case KC_ESC:
         // Detect the activation of only Left Alt
-        if (get_mods() & MOD_BIT(KC_LALT) == MOD_BIT(KC_LALT)) {
+        if ((get_mods() & MOD_BIT(KC_LALT)) == MOD_BIT(KC_LALT)) {
             if (record->event.pressed) {
                 // No need to register KC_LALT because it's already active.
                 // The Alt modifier will apply on this KC_TAB.

--- a/docs/feature_advanced_keycodes.md
+++ b/docs/feature_advanced_keycodes.md
@@ -25,9 +25,10 @@ You can also chain them, for example `LCTL(LALT(KC_DEL))` or `C(A(KC_DEL))` make
 
 # Checking Modifier State :id=checking-modifier-state
 
-The current modifier state can mainly be accessed with two functions: `get_mods()` for normal modifiers and modtaps and `get_oneshot_mods()` for one-shot modifiers.
+The current modifier state can mainly be accessed with two functions: `get_mods()` for normal modifiers and modtaps and `get_oneshot_mods()` for one-shot modifiers (unless they're held, in which case they act like normal modifier keys).
 
 The presence of one or more specific modifiers in the current modifier state can be detected by ANDing the modifier state with a mod mask corresponding to the set of modifiers you want to match for.
+For more information on bitwise operators in C, click [here](https://en.wikipedia.org/wiki/Bitwise_operations_in_C) to open the Wikipedia page on the topic.
 
 In practice, this means that you can check modifier state with `get_mods() & MOD_BIT(KC_<mod>)` (see the [list of modifier keycodes](keycodes_basic.md#modifiers)) or with `get_mods() & MOD_MASK_<mod>` if the difference between left and right hand modifiers is not important and you want to match both. Same thing can be done for one-shot modifiers if you replace `get_mods()` with `get_oneshot_mods()`.
 
@@ -53,8 +54,8 @@ The full list of mod masks is as follows:
 
 Aside from accessing the currently active modifiers using `get_mods()`, there exists some other functions you can use to modify the modifier state, where the `mods` argument refers to the modifiers bitmask.
 
-* `add_mods(mods)`: Enable `mods`
-* `del_mods(mods)`: Disable `mods`
+* `add_mods(mods)`: Enable `mods` without affecting any other modifiers
+* `del_mods(mods)`: Disable `mods` without affecting any other modifiers
 * `set_mods(mods)`: Overwrite current modifier state with `mods`
 * `clear_mods()`: Reset the modifier state by disabling all modifiers
 
@@ -64,6 +65,8 @@ Similarly, in addition to `get_oneshot_mods()`, there also exists these function
 * `clear_oneshot_mods()`: Reset the one-shot modifier state by disabling all one-shot modifiers
 
 ## Examples :id=examples
+
+The following examples use [advanced macro functions](feature_macros#advanced-macro-functions) which you can read more about in the [documentation page on macros](feature_macros).
 
 ### Alt + Escape for Alt + Tab :id=alt-escape-for-alt-tab
 

--- a/docs/feature_advanced_keycodes.md
+++ b/docs/feature_advanced_keycodes.md
@@ -63,6 +63,8 @@ Aside from accessing the currently active modifiers using `get_mods()`, there ex
 
 Similarly, in addition to `get_oneshot_mods()`, there also exists these functions for one-shot mods:
 
+* `add_oneshot_mods(mods)`: Enable `mods` without affecting any other one-shot modifiers
+* `del_oneshot_mods(mods)`: Disable `mods` without affecting any other one-shot modifiers
 * `set_oneshot_mods(mods)`: Overwrite current one-shot modifier state with `mods`
 * `clear_oneshot_mods()`: Reset the one-shot modifier state by disabling all one-shot modifiers
 

--- a/docs/feature_advanced_keycodes.md
+++ b/docs/feature_advanced_keycodes.md
@@ -68,7 +68,7 @@ Similarly, in addition to `get_oneshot_mods()`, there also exists these function
 
 ## Examples :id=examples
 
-The following examples use [advanced macro functions](feature_macros#advanced-macro-functions) which you can read more about in the [documentation page on macros](feature_macros).
+The following examples use [advanced macro functions](feature_macros.md#advanced-macro-functions) which you can read more about in the [documentation page on macros](feature_macros.md).
 
 ### Alt + Escape for Alt + Tab :id=alt-escape-for-alt-tab
 

--- a/docs/feature_advanced_keycodes.md
+++ b/docs/feature_advanced_keycodes.md
@@ -63,9 +63,9 @@ Similarly, in addition to `get_oneshot_mods()`, there also exists these function
 * `set_oneshot_mods(mods)`: Overwrite current one-shot modifier state with `mods`
 * `clear_oneshot_mods()`: Reset the one-shot modifier state by disabling all one-shot modifiers
 
-## Examples
+## Examples :id=examples
 
-### Alt + Escape for Alt + Tab
+### Alt + Escape for Alt + Tab :id=alt-escape-for-alt-tab
 
 Simple example where chording Left Alt with `KC_ESC` makes it behave like `KC_TAB` for alt-tabbing between applications. Keep in mind that this removes the ability to trigger the actual Alt+Escape keyboard shortcut. Though it keeps the ability to do AltGr+Escape.
 
@@ -94,7 +94,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 };
 ```
 
-### Shift + Backspace for Delete
+### Shift + Backspace for Delete :id=shift-backspace-for-delete
 
 Advanced example where the original behaviour of shift is cancelled when chorded with `KC_BSPC` and is instead fully replaced by `KC_DEL`. Two main variables are created to make this work well: `mod_state` and `delkey_registered`. The first one stores the modifier state and is used to restore it after registering `KC_DEL`. The second variable is a boolean variable (true or false) which keeps track of the status of `KC_DEL` to manage the release of the whole Backspace/Delete key correctly.
 

--- a/docs/feature_advanced_keycodes.md
+++ b/docs/feature_advanced_keycodes.md
@@ -27,7 +27,7 @@ You can also chain them, for example `LCTL(LALT(KC_DEL))` or `C(A(KC_DEL))` make
 
 The current modifier state can mainly be accessed with two functions: `get_mods()` for normal modifiers and modtaps and `get_oneshot_mods()` for one-shot modifiers (unless they're held, in which case they act like normal modifier keys).
 
-The presence of one or more specific modifiers in the current modifier state can be detected by ANDing the modifier state with a mod mask corresponding to the set of modifiers you want to match for. The reason why bitwise operators are used is that the modifier state is stored as a single byte in the format C<sub>L</sub>S<sub>L</sub>A<sub>L</sub>G<sub>L</sub>C<sub>R</sub>S<sub>R</sub>A<sub>R</sub>G<sub>R</sub>.
+The presence of one or more specific modifiers in the current modifier state can be detected by ANDing the modifier state with a mod mask corresponding to the set of modifiers you want to match for. The reason why bitwise operators are used is that the modifier state is stored as a single byte in the format (GASC)<sub>R</sub>(GASC)<sub>L</sub>.
 
 Thus, to give an example, `01000010` would be the internal representation of LShift+RAlt.
 For more information on bitwise operators in C, click [here](https://en.wikipedia.org/wiki/Bitwise_operations_in_C) to open the Wikipedia page on the topic.

--- a/docs/feature_advanced_keycodes.md
+++ b/docs/feature_advanced_keycodes.md
@@ -27,7 +27,9 @@ You can also chain them, for example `LCTL(LALT(KC_DEL))` or `C(A(KC_DEL))` make
 
 The current modifier state can mainly be accessed with two functions: `get_mods()` for normal modifiers and modtaps and `get_oneshot_mods()` for one-shot modifiers (unless they're held, in which case they act like normal modifier keys).
 
-The presence of one or more specific modifiers in the current modifier state can be detected by ANDing the modifier state with a mod mask corresponding to the set of modifiers you want to match for.
+The presence of one or more specific modifiers in the current modifier state can be detected by ANDing the modifier state with a mod mask corresponding to the set of modifiers you want to match for. The reason why bitwise operators are used is that the modifier state is stored as a single byte in the format C<sub>L</sub>S<sub>L</sub>A<sub>L</sub>G<sub>L</sub>C<sub>R</sub>S<sub>R</sub>A<sub>R</sub>G<sub>R</sub>.
+
+Thus, to give an example, `01000010` would be the internal representation of LShift+RAlt.
 For more information on bitwise operators in C, click [here](https://en.wikipedia.org/wiki/Bitwise_operations_in_C) to open the Wikipedia page on the topic.
 
 In practice, this means that you can check modifier state with `get_mods() & MOD_BIT(KC_<mod>)` (see the [list of modifier keycodes](keycodes_basic.md#modifiers)) or with `get_mods() & MOD_MASK_<mod>` if the difference between left and right hand modifiers is not important and you want to match both. Same thing can be done for one-shot modifiers if you replace `get_mods()` with `get_oneshot_mods()`.

--- a/docs/feature_macros.md
+++ b/docs/feature_macros.md
@@ -209,7 +209,7 @@ SEND_STRING(".."SS_TAP(X_END));
 
 There are some functions you may find useful in macro-writing. Keep in mind that while you can write some fairly advanced code within a macro, if your functionality gets too complex you may want to define a custom keycode instead. Macros are meant to be simple.
 
-?> You can also use the functions described in [Useful functions](ref_functions.md) for additional functionality. For example `reset_keyboard()` allows you to reset the keyboard as part of a macro.
+?> You can also use the functions described in [Useful function](ref_functions.md) and [Checking modifier state](feature_advanced_keycodes#checking-modifier-state) for additional functionality. For example, `reset_keyboard()` allows you to reset the keyboard as part of a macro and `get_mods() & MOD_MASK_SHIFT` lets you check for the existence of active shift modifiers.
 
 ### `record->event.pressed`
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Added a new section to the documentation on modifiers on the topic of checking modifier states. I explain how to use mod masks to detect modifiers and give two code examples, including the very frequently asked for shift + backspace → del functionality.

Speaking of the del example, I have used an implementation that involves creating a new variable `uint8_t mod_state` and using it in `set_mods(mod_state)`. I know that it could be avoided by doing `add_mods(MOD_MASK_SHIFT)` or `add_mods(MOD_BIT(KC_LSFT))` instead but I chose against the latter options for multiple reasons; `add_mods(MOD_MASK_SHIFT)` would enable both shifts which can be problematic for people for whom pressing both shifts produces something special like toggling Caps Lock. `add_mods(MOD_BIT(KC_LSFT))` presupposes that the user chorded `KC_BSPC` with `KC_LSFT` which may or may not be the case. This can be problematic for people who use the distinction between left and right shift in other places of their code. Using `set_mods(mod_state)` might be a little more complex but it avoids those edge cases.

The main problem with the proposed implementation of shift + backspace for delete is that if you hold `KC_BSPC` held and then turn shift on and off while holding down `KC_BSPC`, it will ignore the custom shift mapping. The custom shift code only applies on the conditions of the initial press of `KC_BSPC`. Let me know if there is an implementation which solves this issue.

~~Since this also explains functions such as `add_mods()`, can I remove these kinds of comments in `tmk_core/common/action_util.c`?:~~
```c
/** \brief Set oneshot layer
 *
 * FIXME: needs doc
 */
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
