### PR TITLE
Fix for issue #10386 - Can't compile preonic:dudeofawesome

### DIFF
--- a/keyboards/preonic/keymaps/dudeofawesome/keymap.c
+++ b/keyboards/preonic/keymaps/dudeofawesome/keymap.c
@@ -256,10 +256,14 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         #ifdef BACKLIGHT_ENABLE
           backlight_step();
         #endif
-        PORTE &= ~(1<<6);
+        #ifdef __AVR__
+          writePinLow(E6);
+        #endif
       } else {
         unregister_code(KC_RSFT);
-        PORTE |= (1<<6);
+        #ifdef __AVR__
+          writePinHigh(E6);
+        #endif
       }
       return false;
   }

--- a/users/dudeofawesome/dudeofawesome.h
+++ b/users/dudeofawesome/dudeofawesome.h
@@ -7,6 +7,10 @@
 #define TAPPING_TOGGLE 2
 
 #ifdef AUDIO_ENABLE
+    #ifdef WORKMAN_SOUND
+        #undef WORKMAN_SOUND
+    #endif
+
     #define WORKMAN_SOUND \
         E__NOTE(_GS7),    \
         ED_NOTE(_E7),     \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
I've wanted to help @NeoScaler with his bug. He couldn't compile Preonic (rev3) with dudeofawesome keymap as it wasn't prepared for STM and it had some issues described in [#10386](https://github.com/qmk/qmk_firmware/issues/10386).
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* [#10386](https://github.com/qmk/qmk_firmware/issues/10386)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage) - I've compiled but can't flash the keyboard as I don't have it available.
