### PR TITLE
Revert back to the old matrix (Take the blue pill)

### DIFF
--- a/keyboards/duck/tcv3/matrix.c
+++ b/keyboards/duck/tcv3/matrix.c
@@ -140,7 +140,7 @@ static void init_rows(void) {
 }
 
 static uint8_t read_rows(uint8_t col) {
-  if (col == 20) {
+  if (col == 19) {
     return PINE&(1<<2) ? 0 : (1<<0);
   } else {
       return (PIND&(1<<0) ? (1<<1) : 0) |

--- a/keyboards/duck/tcv3/matrix.c
+++ b/keyboards/duck/tcv3/matrix.c
@@ -21,8 +21,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "util.h"
 #include "print.h"
 #include "debug.h"
-#include "debounce.h"
-#include "wait.h"
+
+static uint8_t debouncing = DEBOUNCE;
 
 /* matrix state(1:on, 0:off) */
 static matrix_row_t matrix[MATRIX_ROWS];
@@ -74,16 +74,13 @@ void matrix_init(void) {
     matrix_debouncing[i] = 0;
   }
 
-  debounce_init(MATRIX_ROWS);
-
   matrix_init_quantum();
 }
-uint8_t matrix_scan(void) {
-    bool changed = false;
 
-    for (uint8_t col = 0; col < MATRIX_COLS; col++) {
+uint8_t matrix_scan(void) {
+  for (uint8_t col = 0; col < MATRIX_COLS; col++) {
     select_col(col);
-    wait_us(30);
+    _delay_us(3);
 
     uint8_t rows = read_rows(col);
 
@@ -92,16 +89,27 @@ uint8_t matrix_scan(void) {
       bool curr_bit = rows & (1<<row);
       if (prev_bit != curr_bit) {
         matrix_debouncing[row] ^= ((matrix_row_t)1<<col);
-        changed = true;
+        if (debouncing) {
+            dprint("bounce!: "); dprintf("%02X", debouncing); dprintln();
+        }
+        debouncing = DEBOUNCE;
       }
     }
     unselect_cols();
   }
 
-  debounce(matrix, matrix_debouncing, MATRIX_ROWS, changed);
+  if (debouncing) {
+    if (--debouncing) {
+      _delay_ms(1);
+    } else {
+      for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
+        matrix[i] = matrix_debouncing[i];
+      }
+    }
+  }
 
   matrix_scan_quantum();
-  return (uint8_t)changed;
+  return 1;
 }
 
 inline matrix_row_t matrix_get_row(uint8_t row) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Apparently our matrix changes to accomodate debounce were flawed and didn't work with Duck TC-V3, this commit reverts back to what it was before. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
