### PR TITLE
CLI: Fix MCU lists for `qmk info`

### DIFF
--- a/lib/python/qmk/constants.py
+++ b/lib/python/qmk/constants.py
@@ -9,7 +9,6 @@ QMK_FIRMWARE = Path.cwd()
 MAX_KEYBOARD_SUBFOLDERS = 5
 
 # Supported processor types
-ARM_PROCESSORS = 'cortex-m0', 'cortex-m0plus', 'cortex-m3', 'cortex-m4', 'MKL26Z64', 'MK20DX128', 'MK20DX256', 'STM32F042', 'STM32F072', 'STM32F103', 'STM32F303', 'STM32F401', 'STM32F411'
-AVR_PROCESSORS = 'atmega16u2', 'atmega32u2', 'atmega16u4', 'atmega32u4', 'at90usb646', 'at90usb647', 'at90usb1286', 'at90usb1287', 'atmega328p', 'atmega32a', None
-ALL_PROCESSORS = ARM_PROCESSORS + AVR_PROCESSORS
-VUSB_PROCESSORS = 'atmega328p', 'atmega32a', 'atmega328', 'attiny85'
+CHIBIOS_PROCESSORS = 'cortex-m0', 'cortex-m0plus', 'cortex-m3', 'cortex-m4', 'MKL26Z64', 'MK20DX128', 'MK20DX256', 'STM32F042', 'STM32F072', 'STM32F103', 'STM32F303', 'STM32F401', 'STM32F411'
+LUFA_PROCESSORS = 'atmega16u2', 'atmega32u2', 'atmega16u4', 'atmega32u4', 'at90usb646', 'at90usb647', 'at90usb1286', 'at90usb1287', None
+VUSB_PROCESSORS = 'atmega32a', 'atmega328p', 'atmega328', 'attiny85'

--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from milc import cli
 
-from qmk.constants import ARM_PROCESSORS, AVR_PROCESSORS, VUSB_PROCESSORS
+from qmk.constants import CHIBIOS_PROCESSORS, LUFA_PROCESSORS, VUSB_PROCESSORS
 from qmk.c_parse import find_layouts
 from qmk.keyboard import config_h, rules_mk
 from qmk.makefile import parse_rules_mk_file
@@ -95,9 +95,9 @@ def _extract_rules_mk(info_data):
     rules = rules_mk(info_data['keyboard_folder'])
     mcu = rules.get('MCU')
 
-    if mcu in ARM_PROCESSORS:
+    if mcu in CHIBIOS_PROCESSORS:
         arm_processor_rules(info_data, rules)
-    elif mcu in AVR_PROCESSORS:
+    elif mcu in LUFA_PROCESSORS + VUSB_PROCESSORS:
         avr_processor_rules(info_data, rules)
     else:
         cli.log.warning("%s: Unknown MCU: %s" % (info_data['keyboard_folder'], mcu))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Aligns this logic more closely with that in qmk_compiler, and also fixes:
```
⚠ xd002: Unknown MCU: attiny85
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
