### PR TITLE
CLI: Fix stripping of `ANY` from Configurator exports

### DIFF
--- a/lib/python/qmk/keymap.py
+++ b/lib/python/qmk/keymap.py
@@ -103,6 +103,8 @@ def generate(keyboard, layout, layers, type='c', keymap=None):
         for layer_num, layer in enumerate(layers):
             if layer_num != 0:
                 layer_txt[-1] = layer_txt[-1] + ','
+
+            layer = map(_strip_any, layer)
             layer_keys = ', '.join(layer)
             layer_txt.append('\t[%s] = %s(%s)' % (layer_num, layout, layer_keys))
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

058737f broke it ¯\_(ツ)_/¯

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
