### PR TITLE
Select unicode keycode from pair using current, not saved, mods

### DIFF
--- a/quantum/process_keycode/process_unicode_common.h
+++ b/quantum/process_keycode/process_unicode_common.h
@@ -75,7 +75,6 @@ typedef union {
 } unicode_config_t;
 
 extern unicode_config_t unicode_config;
-extern uint8_t          unicode_saved_mods;
 
 void    unicode_input_mode_init(void);
 uint8_t get_unicode_input_mode(void);

--- a/quantum/process_keycode/process_unicodemap.c
+++ b/quantum/process_keycode/process_unicodemap.c
@@ -21,7 +21,7 @@ __attribute__((weak)) uint16_t unicodemap_index(uint16_t keycode) {
         // Keycode is a pair: extract index based on Shift / Caps Lock state
         uint16_t index = keycode - QK_UNICODEMAP_PAIR;
 
-        bool shift = unicode_saved_mods & MOD_MASK_SHIFT;
+        bool shift = get_mods() & MOD_MASK_SHIFT;
         bool caps  = IS_HOST_LED_ON(USB_LED_CAPS_LOCK);
         if (shift ^ caps) {
             index >>= 7;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

When using UNICODEMAP, each entry comprises a pair of (typically) upper and lower case characters, and the unicodemap_index() function, in process_unicodemap.c,  is used to extract the right one, based on the current shift state.  This, unfortunately, is done by exposing a variable, unicode_saved_mods, from process_unicode_common.c, which is used there as temporary storage for the modifier state during the generation and transmission of the unicode sequence.  This probably worked well when first written, but the structure of the code must have changed, so that the cross reference to that variable now happens before it gets set.  Thus, the selection of the correct member of the pair is done using the saved modifier state from the previous iteration.

To see this, use a keyboard configuration that's set up with UNICODEMAP, and repeatedly tap a key that uses such a pair, while experimenting with pressing and releasing a shift key.  You'll see that the shift key takes effect one key press later than expected, and keeps having an effect one key press too long.

The simple solution is to let unicodemap_index() query the modifier state itself, instead of relying on a side effect of another part of the code.  At the same time, this patch removes the exposure of the variable, which is not used anywhere else.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #9533

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
