### PR TITLE
Preonic rev2/rev1 bootmagic lite bugfix

### DIFF
--- a/keyboards/preonic/rev1/config.h
+++ b/keyboards/preonic/rev1/config.h
@@ -23,3 +23,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define DEVICE_VER      0x0001
 
 #endif
+
+#define BOOTMAGIC_LITE_ROW 3
+#define BOOTMAGIC_LITE_COLUMN 5 //hold b while plugging in to enter bootloader

--- a/keyboards/preonic/rev2/config.h
+++ b/keyboards/preonic/rev2/config.h
@@ -25,4 +25,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #endif
 
 #define BOOTMAGIC_LITE_ROW 3
-#define BOOTMAGIC_LITE_COLUMN 5
+#define BOOTMAGIC_LITE_COLUMN 5 //hold b while plugging in to enter bootloader

--- a/keyboards/preonic/rev2/config.h
+++ b/keyboards/preonic/rev2/config.h
@@ -23,3 +23,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define DEVICE_VER      0x0002
 
 #endif
+
+#define BOOTMAGIC_LITE_ROW 3
+#define BOOTMAGIC_LITE_COLUMN 5


### PR DESCRIPTION
set up bootmagic lite to enable bootloader mode on plug in with rev1 and rev2 preonic

## Description
if bootmagic lite was working properly it would enter bootloader mode when space  + b is held. it does not however, at least for me so i set up the option to use the letter b to enter the mode. it's not necessary to change the documentation since holding space plus b will work as long as at least b is held.

it should not use much more ram as bootmagic lite is already enabled.
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
