### PR TITLE
Fix issues with suspend code for ZSA split boards

### DIFF
--- a/keyboards/ergodox_ez/matrix.c
+++ b/keyboards/ergodox_ez/matrix.c
@@ -237,3 +237,18 @@ static void select_row(uint8_t row) {
         }
     }
 }
+
+// DO NOT REMOVE
+// Needed for proper wake/sleep
+void matrix_power_up(void) {
+    mcp23018_status = init_mcp23018();
+
+    unselect_rows();
+    init_cols();
+
+    // initialize matrix state: all keys off
+    for (uint8_t i=0; i < MATRIX_ROWS; i++) {
+        matrix[i] = 0;
+    }
+
+}

--- a/keyboards/moonlander/matrix.c
+++ b/keyboards/moonlander/matrix.c
@@ -268,3 +268,32 @@ void matrix_print(void) {
         printf("\n");
     }
 }
+
+// DO NOT REMOVE
+// Needed for proper wake/sleep
+void matrix_power_up(void) {
+    mcp23018_init();
+
+    // outputs
+    setPinOutput(B10);
+    setPinOutput(B11);
+    setPinOutput(B12);
+    setPinOutput(B13);
+    setPinOutput(B14);
+    setPinOutput(B15);
+
+    // inputs
+    setPinInputLow(A0);
+    setPinInputLow(A1);
+    setPinInputLow(A2);
+    setPinInputLow(A3);
+    setPinInputLow(A6);
+    setPinInputLow(A7);
+    setPinInputLow(B0);
+
+    // initialize matrix state: all keys off
+    for (uint8_t i=0; i < MATRIX_ROWS; i++) {
+        matrix[i] = 0;
+    }
+
+}


### PR DESCRIPTION
## Description

Due to ignorance on my part, the `matrix_power_up` function was removed from the ErgoDox EZ when converting it to the Custom Matrix lite code. 

This re-adds the code back, as well as adds it for the Moonlander.


## Types of Changes

- [x] Bugfix
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)

## Issues Fixed or Closed by This PR

* Fixes #10634

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
