### PR TITLE
Fix STM32duino bootloader

### DIFF
--- a/bootloader.mk
+++ b/bootloader.mk
@@ -110,7 +110,7 @@ endif
 
 ifeq ($(strip $(BOOTLOADER)), stm32duino)
     OPT_DEFS += -DBOOTLOADER_STM32DUINO
-    MCU_LDSCRIPT ?= STM32F103x8_stm32duino_bootloader
+    MCU_LDSCRIPT = STM32F103x8_stm32duino_bootloader
     BOARD = STM32_F103_STM32DUINO
     # STM32F103 does NOT have an USB bootloader in ROM (only serial), so setting anything here does not make much sense
     STM32_BOOTLOADER_ADDRESS = 0x80000000

--- a/keyboards/wolfmarkclub/wm1/rules.mk
+++ b/keyboards/wolfmarkclub/wm1/rules.mk
@@ -1,11 +1,9 @@
 # MCU name
 MCU = STM32F103
 
-# Bootloader selection
-BOOTLOADER = stm32duino
-
 # GENERIC STM32F103C8T6 board - mass storage bootloader
 MCU_LDSCRIPT = wm1_f103
+BOARD = STM32_F103_STM32DUINO
 
 PROGRAM_CMD = echo 'CLI flashing not supported' >&2
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

`MCU_LDSCRIPT` in bootloader.mk must use `=`, not `?=`, otherwise it will not set the correct value due to there already being one set from mcu_selection.mk. As a result, `wolfmark/wm1` cannot have this bootloader set because rules.mk is processed first, but it seems to actually have a custom mass storage bootloader anyway.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #10645

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
