### PR TITLE
Allow modified keycodes in Unicode input

### DIFF
--- a/quantum/process_keycode/process_unicode_common.c
+++ b/quantum/process_keycode/process_unicode_common.c
@@ -136,20 +136,10 @@ __attribute__((weak)) void unicode_input_cancel(void) {
     set_mods(unicode_saved_mods);  // Reregister previously set mods
 }
 
-__attribute__((weak)) uint16_t hex_to_keycode(uint8_t hex) {
-    if (hex == 0x0) {
-        return KC_0;
-    } else if (hex < 0xA) {
-        return KC_1 + (hex - 0x1);
-    } else {
-        return KC_A + (hex - 0xA);
-    }
-}
-
 void register_hex(uint16_t hex) {
     for (int i = 3; i >= 0; i--) {
         uint8_t digit = ((hex >> (i * 4)) & 0xF);
-        tap_code(hex_to_keycode(digit));
+        tap_code16(hex_to_keycode(digit));
     }
 }
 
@@ -162,10 +152,10 @@ void register_hex32(uint32_t hex) {
         uint8_t digit = ((hex >> (i * 4)) & 0xF);
         if (digit == 0) {
             if (!onzerostart) {
-                tap_code(hex_to_keycode(digit));
+                tap_code16(hex_to_keycode(digit));
             }
         } else {
-            tap_code(hex_to_keycode(digit));
+            tap_code16(hex_to_keycode(digit));
             onzerostart = false;
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Especially useful if you have your OS layout set to something non-US ANSI, where the number row is flipped (such as French AZERTY).

For example, you could add the following to your keymap.c:
```c
uint16_t hex_to_keycode(uint8_t hex) {
    switch (hex) {
        case 0:
            return FR_0;
        case 1 ... 9:
            return FR_1 + (hex - 1);
        case 0xA:
            return FR_A;
        case 0xB:
            return FR_B;
        case 0xC:
            return FR_C;
        case 0xD:
            return FR_D;
        case 0xE:
            return FR_E;
        case 0xF:
            return FR_F;
        default:
            return KC_NO;
    }
}
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
