### PR TITLE
docker_build isn't explicitly run with enough privileges

### DIFF
--- a/util/docker_build.sh
+++ b/util/docker_build.sh
@@ -54,7 +54,7 @@ dir=$(pwd -W 2>/dev/null) || dir=$PWD  # Use Windows path if on Windows
 
 # Run container and build firmware
 docker run --rm -it $usb_args \
-	--user $(id -u):$(id -g) \
+	--user root \
 	-w /qmk_firmware \
 	-v "$dir":/qmk_firmware \
 	-e ALT_GET_KEYBOARDS=true \


### PR DESCRIPTION
## Description
### util/docker_build wrongly assumes we're root
For the container to successfully write to our USB, it needs write permissions
to `/dev`. The `util/docker_build` starts the
container as the current user which doesn't necessarily have these permissions.  
   
One way to address this is to explicitly start the container as root.

### Reproduce
#### Dmesg 
During keyboard RESET we see the following, affirming keyboard entered RESET.
```
[131425.122906] usb 1-1: USB disconnect, device number 46
[131425.765291] usb 1-1: new full-speed USB device number 47 using xhci_hcd
[131425.907117] usb 1-1: New USB device found, idVendor=03eb, idProduct=2ff4, bcdDevice= 0.00
[131425.907120] usb 1-1: New USB device strings: Mfr=1, Product=2, SerialNumber=3
[131425.907121] usb 1-1: Product: ATm32U4DFU
[131425.907122] usb 1-1: Manufacturer: ATMEL
[131425.907123] usb 1-1: SerialNumber: 1.0.0
```

#### docker_build fails
Doesn't ever find the keyboard
```
./util/docker_build.sh dztech/dz60rgb_ansi/v2:edd:dfu

QMK Firmware 0.10.36
Making dztech/dz60rgb_ansi/v2 with keymap edd and target dfu

avr-gcc (GCC) 5.4.0
Copyright (C) 2015 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Size before:
   text	   data	    bss	    dec	    hex	filename
      0	  25990	      0	  25990	   6586	.build/dztech_dz60rgb_ansi_v2_edd.hex

Copying dztech_dz60rgb_ansi_v2_edd.hex to qmk_firmware folder                                       [OK]
Checking file size of dztech_dz60rgb_ansi_v2_edd.hex                                                [OK]
 * The firmware size is fine - 25990/28672 (90%, 2682 bytes free)
dfu-programmer: no device present.
ERROR: Bootloader not found. Trying again in 5s.
dfu-programmer: no device present.
ERROR: Bootloader not found. Trying again in 5s.
dfu-programmer: no device present.
ERROR: Bootloader not found. Trying again in 5s.
dfu-programmer: no device present.
...
...
```

#### Narrowing it down
We can reproduce the issue outside the script with this manual `docker run`
when we aren't root or in its group.
```
docker run --rm --user $(id -u):$(id -g) -it --privileged -v /dev:/dev -w /qmk_firmware -v /home/edd/qmk_firmware:/qmk_firmware -e ALT_GET_KEYBOARDS=true qmkfm/qmk_firmware make dztech/dz60rgb_ansi/v2:edd:dfu
```

### Fix
It is fixed if the container runs as root, instead of our own user
which may or may not be root.
```
docker run --rm --user root -it --privileged -v /dev:/dev -w /qmk_firmware -v /home/edd/qmk_firmware:/qmk_firmware -e ALT_GET_KEYBOARDS=true qmkfm/qmk_firmware make dztech/dz60rgb_ansi/v2:edd:dfu
```
> `--user root` can be omitted as root is the default, if the Dockerfile omits it.

```
QMK Firmware 0.10.36
Making dztech/dz60rgb_ansi/v2 with keymap edd and target dfu

avr-gcc (GCC) 5.4.0
Copyright (C) 2015 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Size before:
   text	   data	    bss	    dec	    hex	filename
      0	  25990	      0	  25990	   6586	.build/dztech_dz60rgb_ansi_v2_edd.hex

Copying dztech_dz60rgb_ansi_v2_edd.hex to qmk_firmware folder                                       [OK]
Checking file size of dztech_dz60rgb_ansi_v2_edd.hex                                                [OK]
 * The firmware size is fine - 25990/28672 (90%, 2682 bytes free)
Bootloader Version: 0x00 (0)
Validating...
25990 bytes used (90.65%)
```
Succeeds.

## Types of Changes
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
