### PR TITLE
E85 backlight & LED indicator updates

### DIFF
--- a/keyboards/exclusive/e85/config.h
+++ b/keyboards/exclusive/e85/config.h
@@ -52,9 +52,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #define SOFT_SERIAL_PIN D0  // or D1, D2, D3, E6
 
-// #define BACKLIGHT_PIN B6
-// #define BACKLIGHT_BREATHING
-// #define BACKLIGHT_LEVELS 6
+#define BACKLIGHT_PIN B6
+#define BACKLIGHT_BREATHING
+#define BACKLIGHT_LEVELS 6
 
 #define RGB_DI_PIN E2
 #ifdef RGB_DI_PIN

--- a/keyboards/exclusive/e85/hotswap/hotswap.c
+++ b/keyboards/exclusive/e85/hotswap/hotswap.c
@@ -15,3 +15,18 @@
  */
 
 #include "hotswap.h"
+
+void keyboard_pre_init_kb(void) {
+    setPinOutput(C7);
+    setPinOutput(B5);
+
+    keyboard_pre_init_user();
+}
+
+bool led_update_kb(led_t led_state) {
+    if (led_update_user(led_state)) {
+        writePin(C7, led_state.caps_lock);
+        writePin(B5, led_state.scroll_lock);
+    }
+    return true;
+}

--- a/keyboards/exclusive/e85/hotswap/keymaps/via/rules.mk
+++ b/keyboards/exclusive/e85/hotswap/keymaps/via/rules.mk
@@ -1,3 +1,4 @@
 VIA_ENABLE = yes
 CONSOLE_ENABLE = no        # Console for debug
 COMMAND_ENABLE = no        # Commands for debug and configuration
+BACKLIGHT_ENABLE = yes

--- a/keyboards/exclusive/e85/soldered/keymaps/via/rules.mk
+++ b/keyboards/exclusive/e85/soldered/keymaps/via/rules.mk
@@ -1,3 +1,4 @@
 VIA_ENABLE = yes
 CONSOLE_ENABLE = no        # Console for debug
 COMMAND_ENABLE = no        # Commands for debug and configuration
+BACKLIGHT_ENABLE = yes

--- a/keyboards/exclusive/e85/soldered/soldered.c
+++ b/keyboards/exclusive/e85/soldered/soldered.c
@@ -17,14 +17,16 @@
 #include "soldered.h"
 
 void keyboard_pre_init_kb(void) {
-  setPinOutput(C7);
-  
-  keyboard_pre_init_user();
+    setPinOutput(C7);
+    setPinOutput(B5);
+
+    keyboard_pre_init_user();
 }
 
 bool led_update_kb(led_t led_state) {
     if (led_update_user(led_state)) {
         writePin(C7, led_state.caps_lock);
+        writePin(B5, led_state.scroll_lock);
     }
     return true;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Both the e85 soldered and hotswap PCBs support in-switch backlighting. This PR enables it for the VIA keymaps.
Also update the LED indicator code for both soldered and hotswap PCBs to handle both caps and scroll lock LEDs.

cc: @mechmerlin 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
