### PR TITLE
[Keyboard] Fix Moonlander indicator LEDs during sleep

### DIFF
--- a/keyboards/moonlander/matrix.c
+++ b/keyboards/moonlander/matrix.c
@@ -272,8 +272,7 @@ void matrix_print(void) {
 // DO NOT REMOVE
 // Needed for proper wake/sleep
 void matrix_power_up(void) {
-    mcp23018_init();
-
+    bool temp_launching = is_launching;
     // outputs
     setPinOutput(B10);
     setPinOutput(B11);
@@ -290,6 +289,17 @@ void matrix_power_up(void) {
     setPinInputLow(A6);
     setPinInputLow(A7);
     setPinInputLow(B0);
+
+    mcp23018_init();
+    is_launching = temp_launching;
+    if (!is_launching) {
+        ML_LED_1(false);
+        ML_LED_2(false);
+        ML_LED_3(false);
+        ML_LED_4(false);
+        ML_LED_5(false);
+        ML_LED_6(false);
+    }
 
     // initialize matrix state: all keys off
     for (uint8_t i=0; i < MATRIX_ROWS; i++) {


### PR DESCRIPTION
## Description

Fixes issue with the indicator LEDs flashing during sleep.

This is because it re-inits the expander during `matrix_power_up`, which triggers this behavior.  This moves things around a bit, so that it matches the actual initialization better, and stores the state for leds, peventing it from constantly flashing them. 

## Types of Changes

- [x] Bugfix
- [x] Keyboard (addition or update)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
