### PR TITLE
GH60 v1.3: update default keymap

### DIFF
--- a/keyboards/gh60/v1p3/keymaps/default/keymap.c
+++ b/keyboards/gh60/v1p3/keymaps/default/keymap.c
@@ -17,17 +17,17 @@
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [0] = LAYOUT_all(
-        KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_HOME, KC_END,  KC_END,
-        KC_TAB,      KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC,        KC_BSPC,
-        KC_CAPS,       KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_TILD, KC_ENT,
-        KC_LSFT, KC_NUHS, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT, KC_UP,   KC_UP,   KC_DEL,
-        KC_LCTL, KC_LGUI, KC_LGUI, KC_LALT, KC_LALT, MO(1),                     KC_SPC,  MO(1),   KC_RCTL, KC_APP,  KC_LEFT, KC_DOWN, KC_DOWN, KC_RGHT
+        KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_GRV,  KC_BSPC, KC_BSPC,
+        KC_TAB,      KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC,        KC_BSLS,
+        KC_CAPS,       KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_NUHS, KC_ENT,
+        KC_LSFT, KC_NUBS, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT, KC_UP,   KC_UP,   KC_DEL,
+        KC_LCTL, KC_LGUI, KC_LGUI, KC_LALT, KC_LALT, MO(1),            KC_SPC,           MO(1),   KC_RALT, KC_APP,  KC_LEFT, KC_DOWN, KC_DOWN, KC_RGHT
     ),
     [1] = LAYOUT_all(
-        _______, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_DEL,  KC_DEL,  KC_DEL,
-        _______,     RGB_TOG, KC_UP,   RGB_MOD, RGB_HUI, RGB_HUD, RGB_SAI, RGB_SAD, RGB_VAI, RGB_VAD, _______, _______, _______,        _______,
-        _______,       KC_LEFT, KC_DOWN, KC_RGHT, _______, _______, _______, _______, _______, _______, _______, _______, KC_HASH, _______,
-        _______, _______, RESET,   BL_DEC,  BL_TOGG, BL_INC,  _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
-        _______, _______, _______, _______, _______, _______,                   _______, _______, _______, _______, _______, _______, _______, _______
+        KC_NO,   KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_NO,   KC_NO,   KC_NO,
+        KC_NO,       RGB_TOG, KC_UP,   RGB_MOD, RGB_HUI, RGB_HUD, RGB_SAI, RGB_SAD, RGB_SPI, RGB_SPD, KC_PSCR, KC_SLCK, KC_PAUS,        KC_NO,
+        KC_NO,         KC_LEFT, KC_DOWN, KC_RGHT, RGB_VAI, RGB_SAD, KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_HOME, KC_PGUP, KC_NO,
+        KC_NO,   KC_NO,   RESET,   BL_DEC,  BL_ON,   BL_INC,  KC_NO,   KC_VOLD, KC_MUTE, KC_VOLU, KC_END,  KC_PGDN, KC_NO,   KC_NO,   KC_NO,   KC_NO,
+        KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,            KC_NO,            KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO
     ),
 };


### PR DESCRIPTION
## Description

The vendor contacted nMaib0 (who provided me with the initial files I used to generate this source) with an inquiry as to whether the default keymap could be posted on QMK Configurator. I've converted their JSON keymap to C here.

## Types of Changes

- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
