### PR TITLE
Add AT90USB support for serial.c

### DIFF
--- a/drivers/avr/serial.c
+++ b/drivers/avr/serial.c
@@ -20,75 +20,90 @@
 
 #ifdef SOFT_SERIAL_PIN
 
-#    if (defined(__AVR_AT90USB646__) || defined(__AVR_AT90USB647__) || defined(__AVR_AT90USB1286__) || defined(__AVR_AT90USB1287__) || defined(__AVR_ATmega16U2__) || defined(__AVR_ATmega32U2__) || defined(__AVR_ATmega16U4__) || defined(__AVR_ATmega32U4__))
-// if using ATmega32U4 I2C, can not use PD0 and PD1 in soft serial.
-#        ifdef USE_AVR_I2C
-#            if SOFT_SERIAL_PIN == D0 || SOFT_SERIAL_PIN == D1
-#                error Using I2C, so can not use PD0, PD1
-#            endif
+#    if !(defined(__AVR_AT90USB646__) || defined(__AVR_AT90USB647__) || defined(__AVR_AT90USB1286__) || defined(__AVR_AT90USB1287__) || defined(__AVR_ATmega16U2__) || defined(__AVR_ATmega32U2__) || defined(__AVR_ATmega16U4__) || defined(__AVR_ATmega32U4__))
+#        error serial.c is not supported for the currently selected MCU
+#    endif
+// if using ATmega32U4/2, AT90USBxxx I2C, can not use PD0 and PD1 in soft serial.
+#    if defined(__AVR_ATmega16U4__) || defined(__AVR_ATmega32U4__) || defined(__AVR_AT90USB646__) || defined(__AVR_AT90USB647__) || defined(__AVR_AT90USB1286__) || defined(__AVR_AT90USB1287__)
+#        if defined(USE_AVR_I2C) && (SOFT_SERIAL_PIN == D0 || SOFT_SERIAL_PIN == D1)
+#            error Using I2C, so can not use PD0, PD1
 #        endif
-#        if SOFT_SERIAL_PIN >= D0 && SOFT_SERIAL_PIN <= D3
-#            if SOFT_SERIAL_PIN == D0
-#                define EIMSK_BIT _BV(INT0)
-#                define EICRx_BIT (~(_BV(ISC00) | _BV(ISC01)))
-#                define SERIAL_PIN_INTERRUPT INT0_vect
-#            endif
-#            if SOFT_SERIAL_PIN == D1
-#                define EIMSK_BIT _BV(INT1)
-#                define EICRx_BIT (~(_BV(ISC10) | _BV(ISC11)))
-#                define SERIAL_PIN_INTERRUPT INT1_vect
-#            endif
-#            if SOFT_SERIAL_PIN == D2
-#                define EIMSK_BIT _BV(INT2)
-#                define EICRx_BIT (~(_BV(ISC20) | _BV(ISC21)))
-#                define SERIAL_PIN_INTERRUPT INT2_vect
-#            endif
-#            if SOFT_SERIAL_PIN == D3
-#                define EIMSK_BIT _BV(INT3)
-#                define EICRx_BIT (~(_BV(ISC30) | _BV(ISC31)))
-#                define SERIAL_PIN_INTERRUPT INT3_vect
-#            endif
-#        elif SOFT_SERIAL_PIN >= E4 && SOFT_SERIAL_PIN <= E7
-#            if (defined(__AVR_AT90USB646__) || defined(__AVR_AT90USB647__) || defined(__AVR_AT90USB1286__) || defined(__AVR_AT90USB1287__))
-#                if SOFT_SERIAL_PIN == E4
-#                    define EIMSK_BIT _BV(INT4)
-#                    define EICRx_BIT (~(_BV(ISC40) | _BV(ISC41)))
-#                    define SERIAL_PIN_INTERRUPT INT4_vect
-#                endif
-#                if SOFT_SERIAL_PIN == E5
-#                    define EIMSK_BIT _BV(INT5)
-#                    define EICRx_BIT (~(_BV(ISC50) | _BV(ISC51)))
-#                    define SERIAL_PIN_INTERRUPT INT5_vect
-#                endif
-#                if SOFT_SERIAL_PIN == E7
-#                    define EIMSK_BIT _BV(INT7)
-#                    define EICRx_BIT (~(_BV(ISC70) | _BV(ISC71)))
-#                    define SERIAL_PIN_INTERRUPT INT7_vect
-#                endif
-#            endif
-#            if !(defined(__AVR_ATmega16U2__) || defined(__AVR_ATmega32U2__)) && SOFT_SERIAL_PIN == E6
-#                define EIMSK_BIT _BV(INT6)
-#                define EICRx_BIT (~(_BV(ISC60) | _BV(ISC61)))
-#                define SERIAL_PIN_INTERRUPT INT6_vect
-#            endif
-#        endif
-#    elif defined(__AVR_ATmega32A__)
-#        if SOFT_SERIAL_PIN == D2
-#            define EIMSK_BIT _BV(INT0)
-#            define EICRx_BIT (~(_BV(ISC00) | _BV(ISC01)))
-#            define SERIAL_PIN_INTERRUPT INT0_vect
-#        elif SOFT_SERIAL_PIN == D3
-#            define EIMSK_BIT _BV(INT1)
-#            define EICRx_BIT (~(_BV(ISC10) | _BV(ISC11)))
-#            define SERIAL_PIN_INTERRUPT INT1_vect
-#        endif
+#    endif
+// PD0..PD3, common config
+#    if SOFT_SERIAL_PIN == D0
+#        define EIMSK_BIT _BV(INT0)
+#        define EICRx_BIT (~(_BV(ISC00) | _BV(ISC01)))
+#        define SERIAL_PIN_INTERRUPT INT0_vect
+#    elif SOFT_SERIAL_PIN == D1
+#        define EIMSK_BIT _BV(INT1)
+#        define EICRx_BIT (~(_BV(ISC10) | _BV(ISC11)))
+#        define SERIAL_PIN_INTERRUPT INT1_vect
+#    elif SOFT_SERIAL_PIN == D2
+#        define EIMSK_BIT _BV(INT2)
+#        define EICRx_BIT (~(_BV(ISC20) | _BV(ISC21)))
+#        define SERIAL_PIN_INTERRUPT INT2_vect
+#    elif SOFT_SERIAL_PIN == D3
+#        define EIMSK_BIT _BV(INT3)
+#        define EICRx_BIT (~(_BV(ISC30) | _BV(ISC31)))
+#        define SERIAL_PIN_INTERRUPT INT3_vect
+#    endif
 
-#        ifndef SERIAL_PIN_INTERRUPT
-#            error invalid SOFT_SERIAL_PIN value
+// ATmegaxxU2 specific config
+#    if defined(__AVR_ATmega16U2__) || defined(__AVR_ATmega32U2__)
+// PD4(INT5), PD6(INT6), PD7(INT7), PC7(INT4)
+#        if SOFT_SERIAL_PIN == D4
+#            define EIMSK_BIT _BV(INT5)
+#            define EICRx_BIT (~(_BV(ISC50) | _BV(ISC51)))
+#            define SERIAL_PIN_INTERRUPT INT5_vect
+#        elif SOFT_SERIAL_PIN == D6
+#            define EIMSK_BIT _BV(INT6)
+#            define EICRx_BIT (~(_BV(ISC60) | _BV(ISC61)))
+#            define SERIAL_PIN_INTERRUPT INT6_vect
+#        elif SOFT_SERIAL_PIN == D7
+#            define EIMSK_BIT _BV(INT7)
+#            define EICRx_BIT (~(_BV(ISC70) | _BV(ISC71)))
+#            define SERIAL_PIN_INTERRUPT INT7_vect
+#        elif SOFT_SERIAL_PIN == C7
+#            define EIMSK_BIT _BV(INT4)
+#            define EICRx_BIT (~(_BV(ISC40) | _BV(ISC41)))
+#            define SERIAL_PIN_INTERRUPT INT4_vect
 #        endif
+#    endif
 
-#    else
-#        error serial.c does not currently support selected MCU
+// ATmegaxxU4 specific config
+#    if defined(__AVR_ATmega16U4__) || defined(__AVR_ATmega32U4__)
+// PE6(INT6)
+#        if SOFT_SERIAL_PIN == E6
+#            define EIMSK_BIT _BV(INT6)
+#            define EICRx_BIT (~(_BV(ISC60) | _BV(ISC61)))
+#            define SERIAL_PIN_INTERRUPT INT6_vect
+#        endif
+#    endif
+
+// AT90USBxxx specific config
+#    if defined(__AVR_AT90USB646__) || defined(__AVR_AT90USB647__) || defined(__AVR_AT90USB1286__) || defined(__AVR_AT90USB1287__)
+// PE4..PE7(INT4..INT7)
+#        if SOFT_SERIAL_PIN == E4
+#            define EIMSK_BIT _BV(INT4)
+#            define EICRx_BIT (~(_BV(ISC40) | _BV(ISC41)))
+#            define SERIAL_PIN_INTERRUPT INT4_vect
+#        elif SOFT_SERIAL_PIN == E5
+#            define EIMSK_BIT _BV(INT5)
+#            define EICRx_BIT (~(_BV(ISC50) | _BV(ISC51)))
+#            define SERIAL_PIN_INTERRUPT INT5_vect
+#        elif SOFT_SERIAL_PIN == E6
+#            define EIMSK_BIT _BV(INT6)
+#            define EICRx_BIT (~(_BV(ISC60) | _BV(ISC61)))
+#            define SERIAL_PIN_INTERRUPT INT6_vect
+#        elif SOFT_SERIAL_PIN == E7
+#            define EIMSK_BIT _BV(INT7)
+#            define EICRx_BIT (~(_BV(ISC70) | _BV(ISC71)))
+#            define SERIAL_PIN_INTERRUPT INT7_vect
+#        endif
+#    endif
+
+#    ifndef SERIAL_PIN_INTERRUPT
+#        error invalid SOFT_SERIAL_PIN value
 #    endif
 
 #    define setPinInputHigh(pin) (DDRx_ADDRESS(pin) &= ~_BV((pin)&0xF), PORTx_ADDRESS(pin) |= _BV((pin)&0xF))

--- a/drivers/avr/serial.c
+++ b/drivers/avr/serial.c
@@ -258,7 +258,7 @@ void soft_serial_target_init(SSTD_t *sstd_table, int sstd_table_size) {
     Transaction_table_size = (uint8_t)sstd_table_size;
     serial_input_with_pullup();
 
--    // Enable INT0-INT7
+    // Enable INT0-INT7
     EIMSK |= EIMSK_BIT;
 #    if EIMSK_BIT >= _BV(INT4)
     EICRB &= EICRx_BIT;

--- a/drivers/avr/serial.c
+++ b/drivers/avr/serial.c
@@ -258,13 +258,11 @@ void soft_serial_target_init(SSTD_t *sstd_table, int sstd_table_size) {
     Transaction_table_size = (uint8_t)sstd_table_size;
     serial_input_with_pullup();
 
-    // Enable INT0-INT3,INT6
+-    // Enable INT0-INT7
     EIMSK |= EIMSK_BIT;
-#    if SOFT_SERIAL_PIN == E6
-    // Trigger on falling edge of INT6
+#    if EIMSK_BIT >= _BV(INT4)
     EICRB &= EICRx_BIT;
 #    else
-    // Trigger on falling edge of INT0-INT3
     EICRA &= EICRx_BIT;
 #    endif
 }

--- a/drivers/avr/serial.c
+++ b/drivers/avr/serial.c
@@ -20,49 +20,82 @@
 
 #ifdef SOFT_SERIAL_PIN
 
-#    if defined(__AVR_ATmega16U2__) || defined(__AVR_ATmega32U2__) || defined(__AVR_ATmega16U4__) || defined(__AVR_ATmega32U4__)
-// if using ATmegaxxU4 I2C, can not use PD0 and PD1 in soft serial.
+#    if (defined(__AVR_AT90USB646__) || defined(__AVR_AT90USB647__) || defined(__AVR_AT90USB1286__) || defined(__AVR_AT90USB1287__) || defined(__AVR_ATmega16U2__) || defined(__AVR_ATmega32U2__) || defined(__AVR_ATmega16U4__) || defined(__AVR_ATmega32U4__))
+// if using ATmega32U4 I2C, can not use PD0 and PD1 in soft serial.
 #        ifdef USE_AVR_I2C
 #            if SOFT_SERIAL_PIN == D0 || SOFT_SERIAL_PIN == D1
-#                error Using ATmegaxxU4 I2C, so can not use PD0, PD1
+#                error Using I2C, so can not use PD0, PD1
 #            endif
 #        endif
-
-#        define setPinInputHigh(pin) (DDRx_ADDRESS(pin) &= ~_BV((pin)&0xF), PORTx_ADDRESS(pin) |= _BV((pin)&0xF))
-#        define setPinOutput(pin) (DDRx_ADDRESS(pin) |= _BV((pin)&0xF))
-#        define writePinHigh(pin) (PORTx_ADDRESS(pin) |= _BV((pin)&0xF))
-#        define writePinLow(pin) (PORTx_ADDRESS(pin) &= ~_BV((pin)&0xF))
-#        define readPin(pin) ((bool)(PINx_ADDRESS(pin) & _BV((pin)&0xF)))
-
 #        if SOFT_SERIAL_PIN >= D0 && SOFT_SERIAL_PIN <= D3
 #            if SOFT_SERIAL_PIN == D0
 #                define EIMSK_BIT _BV(INT0)
 #                define EICRx_BIT (~(_BV(ISC00) | _BV(ISC01)))
 #                define SERIAL_PIN_INTERRUPT INT0_vect
-#            elif SOFT_SERIAL_PIN == D1
+#            endif
+#            if SOFT_SERIAL_PIN == D1
 #                define EIMSK_BIT _BV(INT1)
 #                define EICRx_BIT (~(_BV(ISC10) | _BV(ISC11)))
 #                define SERIAL_PIN_INTERRUPT INT1_vect
-#            elif SOFT_SERIAL_PIN == D2
+#            endif
+#            if SOFT_SERIAL_PIN == D2
 #                define EIMSK_BIT _BV(INT2)
 #                define EICRx_BIT (~(_BV(ISC20) | _BV(ISC21)))
 #                define SERIAL_PIN_INTERRUPT INT2_vect
-#            elif SOFT_SERIAL_PIN == D3
+#            endif
+#            if SOFT_SERIAL_PIN == D3
 #                define EIMSK_BIT _BV(INT3)
 #                define EICRx_BIT (~(_BV(ISC30) | _BV(ISC31)))
 #                define SERIAL_PIN_INTERRUPT INT3_vect
 #            endif
-#        elif (defined(__AVR_ATmega16U4__) || defined(__AVR_ATmega32U4__)) && SOFT_SERIAL_PIN == E6
-#            define EIMSK_BIT _BV(INT6)
-#            define EICRx_BIT (~(_BV(ISC60) | _BV(ISC61)))
-#            define SERIAL_PIN_INTERRUPT INT6_vect
-#        else
+#        elif SOFT_SERIAL_PIN >= E4 && SOFT_SERIAL_PIN <= E7
+#            if (defined(__AVR_AT90USB646__) || defined(__AVR_AT90USB647__) || defined(__AVR_AT90USB1286__) || defined(__AVR_AT90USB1287__))
+#                if SOFT_SERIAL_PIN == E4
+#                    define EIMSK_BIT _BV(INT4)
+#                    define EICRx_BIT (~(_BV(ISC40) | _BV(ISC41)))
+#                    define SERIAL_PIN_INTERRUPT INT4_vect
+#                endif
+#                if SOFT_SERIAL_PIN == E5
+#                    define EIMSK_BIT _BV(INT5)
+#                    define EICRx_BIT (~(_BV(ISC50) | _BV(ISC51)))
+#                    define SERIAL_PIN_INTERRUPT INT5_vect
+#                endif
+#                if SOFT_SERIAL_PIN == E7
+#                    define EIMSK_BIT _BV(INT7)
+#                    define EICRx_BIT (~(_BV(ISC70) | _BV(ISC71)))
+#                    define SERIAL_PIN_INTERRUPT INT7_vect
+#                endif
+#            endif
+#            if !(defined(__AVR_ATmega16U2__) || defined(__AVR_ATmega32U2__)) && SOFT_SERIAL_PIN == E6
+#                define EIMSK_BIT _BV(INT6)
+#                define EICRx_BIT (~(_BV(ISC60) | _BV(ISC61)))
+#                define SERIAL_PIN_INTERRUPT INT6_vect
+#            endif
+#        endif
+#    elif defined(__AVR_ATmega32A__)
+#        if SOFT_SERIAL_PIN == D2
+#            define EIMSK_BIT _BV(INT0)
+#            define EICRx_BIT (~(_BV(ISC00) | _BV(ISC01)))
+#            define SERIAL_PIN_INTERRUPT INT0_vect
+#        elif SOFT_SERIAL_PIN == D3
+#            define EIMSK_BIT _BV(INT1)
+#            define EICRx_BIT (~(_BV(ISC10) | _BV(ISC11)))
+#            define SERIAL_PIN_INTERRUPT INT1_vect
+#        endif
+
+#        ifndef SERIAL_PIN_INTERRUPT
 #            error invalid SOFT_SERIAL_PIN value
 #        endif
 
 #    else
-#        error serial.c currently only supports ATmegaxxU2 and ATmegaxxU4
+#        error serial.c does not currently support selected MCU
 #    endif
+
+#    define setPinInputHigh(pin) (DDRx_ADDRESS(pin) &= ~_BV((pin)&0xF), PORTx_ADDRESS(pin) |= _BV((pin)&0xF))
+#    define setPinOutput(pin) (DDRx_ADDRESS(pin) |= _BV((pin)&0xF))
+#    define writePinHigh(pin) (PORTx_ADDRESS(pin) |= _BV((pin)&0xF))
+#    define writePinLow(pin) (PORTx_ADDRESS(pin) &= ~_BV((pin)&0xF))
+#    define readPin(pin) ((bool)(PINx_ADDRESS(pin) & _BV((pin)&0xF)))
 
 #    define ALWAYS_INLINE __attribute__((always_inline))
 #    define NO_INLINE __attribute__((noinline))

--- a/drivers/avr/serial.c
+++ b/drivers/avr/serial.c
@@ -34,18 +34,22 @@
 #        define EIMSK_BIT _BV(INT0)
 #        define EICRx_BIT (~(_BV(ISC00) | _BV(ISC01)))
 #        define SERIAL_PIN_INTERRUPT INT0_vect
+#        define EICRx EICRA
 #    elif SOFT_SERIAL_PIN == D1
 #        define EIMSK_BIT _BV(INT1)
 #        define EICRx_BIT (~(_BV(ISC10) | _BV(ISC11)))
 #        define SERIAL_PIN_INTERRUPT INT1_vect
+#        define EICRx EICRA
 #    elif SOFT_SERIAL_PIN == D2
 #        define EIMSK_BIT _BV(INT2)
 #        define EICRx_BIT (~(_BV(ISC20) | _BV(ISC21)))
 #        define SERIAL_PIN_INTERRUPT INT2_vect
+#        define EICRx EICRA
 #    elif SOFT_SERIAL_PIN == D3
 #        define EIMSK_BIT _BV(INT3)
 #        define EICRx_BIT (~(_BV(ISC30) | _BV(ISC31)))
 #        define SERIAL_PIN_INTERRUPT INT3_vect
+#        define EICRx EICRA
 #    endif
 
 // ATmegaxxU2 specific config
@@ -55,18 +59,22 @@
 #            define EIMSK_BIT _BV(INT5)
 #            define EICRx_BIT (~(_BV(ISC50) | _BV(ISC51)))
 #            define SERIAL_PIN_INTERRUPT INT5_vect
+#            define EICRx EICRB
 #        elif SOFT_SERIAL_PIN == D6
 #            define EIMSK_BIT _BV(INT6)
 #            define EICRx_BIT (~(_BV(ISC60) | _BV(ISC61)))
 #            define SERIAL_PIN_INTERRUPT INT6_vect
+#            define EICRx EICRB
 #        elif SOFT_SERIAL_PIN == D7
 #            define EIMSK_BIT _BV(INT7)
 #            define EICRx_BIT (~(_BV(ISC70) | _BV(ISC71)))
 #            define SERIAL_PIN_INTERRUPT INT7_vect
+#            define EICRx EICRB
 #        elif SOFT_SERIAL_PIN == C7
 #            define EIMSK_BIT _BV(INT4)
 #            define EICRx_BIT (~(_BV(ISC40) | _BV(ISC41)))
 #            define SERIAL_PIN_INTERRUPT INT4_vect
+#            define EICRx EICRB
 #        endif
 #    endif
 
@@ -77,6 +85,7 @@
 #            define EIMSK_BIT _BV(INT6)
 #            define EICRx_BIT (~(_BV(ISC60) | _BV(ISC61)))
 #            define SERIAL_PIN_INTERRUPT INT6_vect
+#            define EICRx EICRB
 #        endif
 #    endif
 
@@ -87,18 +96,22 @@
 #            define EIMSK_BIT _BV(INT4)
 #            define EICRx_BIT (~(_BV(ISC40) | _BV(ISC41)))
 #            define SERIAL_PIN_INTERRUPT INT4_vect
+#            define EICRx EICRB
 #        elif SOFT_SERIAL_PIN == E5
 #            define EIMSK_BIT _BV(INT5)
 #            define EICRx_BIT (~(_BV(ISC50) | _BV(ISC51)))
 #            define SERIAL_PIN_INTERRUPT INT5_vect
+#            define EICRx EICRB
 #        elif SOFT_SERIAL_PIN == E6
 #            define EIMSK_BIT _BV(INT6)
 #            define EICRx_BIT (~(_BV(ISC60) | _BV(ISC61)))
 #            define SERIAL_PIN_INTERRUPT INT6_vect
+#            define EICRx EICRB
 #        elif SOFT_SERIAL_PIN == E7
 #            define EIMSK_BIT _BV(INT7)
 #            define EICRx_BIT (~(_BV(ISC70) | _BV(ISC71)))
 #            define SERIAL_PIN_INTERRUPT INT7_vect
+#            define EICRx EICRB
 #        endif
 #    endif
 
@@ -260,11 +273,7 @@ void soft_serial_target_init(SSTD_t *sstd_table, int sstd_table_size) {
 
     // Enable INT0-INT7
     EIMSK |= EIMSK_BIT;
-#    if EIMSK_BIT >= _BV(INT4)
-    EICRB &= EICRx_BIT;
-#    else
-    EICRA &= EICRx_BIT;
-#    endif
+    EICRx &= EICRx_BIT;
 }
 
 // Used by the sender to synchronize timing with the reciver.


### PR DESCRIPTION

## Description

Adds support for the AT90USB chips in the serial driver for AVR. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Enhancement/optimization


## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
