### PR TITLE
Add support for 4 IS31FL3731 devices

### DIFF
--- a/quantum/rgb_matrix_drivers.c
+++ b/quantum/rgb_matrix_drivers.c
@@ -31,9 +31,9 @@ static void init(void) {
     i2c_init();
 #    ifdef IS31FL3731
     IS31FL3731_init(DRIVER_ADDR_1);
-#        ifdef DRIVER_ADDR_2
     IS31FL3731_init(DRIVER_ADDR_2);
-#        endif
+    IS31FL3731_init(DRIVER_ADDR_3);
+    IS31FL3731_init(DRIVER_ADDR_4);
 #    elif defined(IS31FL3733)
     IS31FL3733_init(DRIVER_ADDR_1, 0);
 #    elif defined(IS31FL3737)
@@ -57,9 +57,9 @@ static void init(void) {
     // This actually updates the LED drivers
 #    ifdef IS31FL3731
     IS31FL3731_update_led_control_registers(DRIVER_ADDR_1, 0);
-#        ifdef DRIVER_ADDR_2
     IS31FL3731_update_led_control_registers(DRIVER_ADDR_2, 1);
-#        endif
+    IS31FL3731_update_led_control_registers(DRIVER_ADDR_3, 2);
+    IS31FL3731_update_led_control_registers(DRIVER_ADDR_4, 3);
 #    elif defined(IS31FL3733)
     IS31FL3733_update_led_control_registers(DRIVER_ADDR_1, 0);
     IS31FL3733_update_led_control_registers(DRIVER_ADDR_2, 1);
@@ -73,9 +73,9 @@ static void init(void) {
 #    ifdef IS31FL3731
 static void flush(void) {
     IS31FL3731_update_pwm_buffers(DRIVER_ADDR_1, 0);
-#        ifdef DRIVER_ADDR_2
     IS31FL3731_update_pwm_buffers(DRIVER_ADDR_2, 1);
-#        endif
+    IS31FL3731_update_pwm_buffers(DRIVER_ADDR_3, 2);
+    IS31FL3731_update_pwm_buffers(DRIVER_ADDR_4, 3);
 }
 
 const rgb_matrix_driver_t rgb_matrix_driver = {


### PR DESCRIPTION
## Description

This is a simple change.Support for IS31FL3731 has been changed from 2 to 4.
It is worth noting that this change may cause problems with the compilation of other user files.
But I think it's worth it because it will support more IS31FL3731 chips working simultaneously.
We can solve the compilation error problem by making a simple change to other user files with compilation errors.It goes like this:
In their config.h file, make the changes with this template

#define DRIVER_ADDR_1 0b1110100
#define DRIVER_ADDR_2 0b1110110
#define DRIVER_ADDR_3 0b1110110
#define DRIVER_ADDR_4 0b1110110
#define DRIVER_COUNT 4
#define DRIVER_1_LED_TOTAL 36
#define DRIVER_2_LED_TOTAL 36
#define DRIVER_LED_TOTAL (DRIVER_1_LED_TOTAL + DRIVER_2_LED_TOTAL)


## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* This is a simple change.Support for IS31FL3731 has been changed from 2 to 4.

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
