### PR TITLE
Add definition based on currently-selected serial driver.

### DIFF
--- a/common_features.mk
+++ b/common_features.mk
@@ -436,8 +436,10 @@ ifeq ($(strip $(SPLIT_KEYBOARD)), yes)
 
         SERIAL_DRIVER ?= bitbang
         ifeq ($(strip $(SERIAL_DRIVER)), bitbang)
+            OPT_DEFS += -DSERIAL_DRIVER_bitbang
             QUANTUM_LIB_SRC += serial.c
         else
+            OPT_DEFS += -DSERIAL_DRIVER_$(strip $(SERIAL_DRIVER))
             QUANTUM_LIB_SRC += serial_$(strip $(SERIAL_DRIVER)).c
         endif
     endif

--- a/common_features.mk
+++ b/common_features.mk
@@ -435,11 +435,10 @@ ifeq ($(strip $(SPLIT_KEYBOARD)), yes)
         endif
 
         SERIAL_DRIVER ?= bitbang
+        OPT_DEFS += -DSERIAL_DRIVER_$(strip $(shell echo $(SERIAL_DRIVER) | tr '[:lower:]' '[:upper:]'))
         ifeq ($(strip $(SERIAL_DRIVER)), bitbang)
-            OPT_DEFS += -DSERIAL_DRIVER_bitbang
             QUANTUM_LIB_SRC += serial.c
         else
-            OPT_DEFS += -DSERIAL_DRIVER_$(strip $(SERIAL_DRIVER))
             QUANTUM_LIB_SRC += serial_$(strip $(SERIAL_DRIVER)).c
         endif
     endif


### PR DESCRIPTION
## Description

Adds a `#define` based on the currently selected serial driver, so that preprocessor can be used to modify functionality in code.
Djinn has a serial driver based off the normal `serial_usart.c`, but adds arbitrary data transfer from master to slave and back.
Would be useful if I could determine which serial driver was in use from `users/` and modify my user area's functionality accordingly.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
