### PR TITLE
Indicator LED modes

### DIFF
--- a/keyboards/nk65/config.h
+++ b/keyboards/nk65/config.h
@@ -144,14 +144,3 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // VIA lighting is handled by the keyboard-level code
 #define VIA_CUSTOM_LIGHTING_ENABLE
-
-// Chooses the mode for the indicator LEDs
-// CAPS_LOCK
-//  Top LED - whether caps lock is on
-//  Middle LED - layer 1 is current layer
-//  Bottom LED - layer 2 is current layer
-// LAYERS
-//  Top LED - layer 1 is current layer
-//  Middle LED - layer 2 is current layer
-//  Bottom LED - layer 3 is current layer
-#define INDICATOR_LED_MODE CAPS_LOCK

--- a/keyboards/nk65/config.h
+++ b/keyboards/nk65/config.h
@@ -144,3 +144,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // VIA lighting is handled by the keyboard-level code
 #define VIA_CUSTOM_LIGHTING_ENABLE
+
+// Chooses the mode for the indicator LEDs
+// CAPS_LOCK
+//  Top LED - whether caps lock is on
+//  Middle LED - layer 1 is current layer
+//  Bottom LED - layer 2 is current layer
+// LAYERS
+//  Top LED - layer 1 is current layer
+//  Middle LED - layer 2 is current layer
+//  Bottom LED - layer 3 is current layer
+#define INDICATOR_LED_MODE CAPS_LOCK

--- a/keyboards/nk65/nk65.c
+++ b/keyboards/nk65/nk65.c
@@ -27,15 +27,6 @@
  */
 bool led_update_kb(led_t led_state) {
     bool res = led_update_user(led_state);
-#if INDICATOR_LED_MODE == CAPS_LOCK
-    if(res) {
-        if (led_state.caps_lock) {
-            IS31FL3733_set_color( 7+64-1, 0, 255, 0 );
-        } else {
-            IS31FL3733_set_color( 7+64-1, 0, 0, 0 );
-        }
-    }
-#endif
     return res;
 }
 
@@ -45,15 +36,6 @@ __attribute__((weak)) layer_state_t layer_state_set_user(layer_state_t state) {
     uint8_t B = 0;
     int channel = 6;
 
-#if INDICATOR_LED_MODE == CAPS_LOCK
-    if (state & (1UL << 1)) {
-        R = 255;
-        B = 255;
-    }
-    if (state & (1UL << 2)) {
-        G = 255;
-    }
-#elif INDICATOR_LED_MODE == LAYERS
     if (state & (1UL << 1)) {
         channel = 7;
         G = 255;
@@ -65,7 +47,10 @@ __attribute__((weak)) layer_state_t layer_state_set_user(layer_state_t state) {
     if (state & (1UL << 3)) {
         G = 255;
     }
-#endif
+
+    if (channel == 6) {
+      IS31FL3733_set_color( 7+64-1, 0, 0, 0 );
+    }
 
     IS31FL3733_set_color( channel+64-1, R, G, B );
   return state;

--- a/keyboards/nk65/nk65.c
+++ b/keyboards/nk65/nk65.c
@@ -20,13 +20,14 @@
 #include "nk65.h"
 #include "drivers/issi/is31fl3733.h"
 
-/* Indicator LEDS are part of the LED driver 
+/* Indicator LEDS are part of the LED driver
  * Top LED is blue only. LED driver 2 RGB 7 Green channel
  * Middle LED is blue and red. LED driver 2 RGB 6 Red and Blue channel
  * Bottom LED is red only LED driver 2 RGB 6 Green channel.
  */
 bool led_update_kb(led_t led_state) {
     bool res = led_update_user(led_state);
+#if INDICATOR_LED_MODE == CAPS_LOCK
     if(res) {
         if (led_state.caps_lock) {
             IS31FL3733_set_color( 7+64-1, 0, 255, 0 );
@@ -34,6 +35,7 @@ bool led_update_kb(led_t led_state) {
             IS31FL3733_set_color( 7+64-1, 0, 0, 0 );
         }
     }
+#endif
     return res;
 }
 
@@ -41,6 +43,9 @@ __attribute__((weak)) layer_state_t layer_state_set_user(layer_state_t state) {
     uint8_t R = 0;
     uint8_t G = 0;
     uint8_t B = 0;
+    int channel = 6;
+
+#ifdef INDICATOR_LED_MODE == CAPS_LOCK
     if (state & (1UL << 1)) {
         R = 255;
         B = 255;
@@ -48,7 +53,20 @@ __attribute__((weak)) layer_state_t layer_state_set_user(layer_state_t state) {
     if (state & (1UL << 2)) {
         G = 255;
     }
-    
-    IS31FL3733_set_color( 6+64-1, R, G, B );
+#elif INDICATOR_LED_MODE == LAYERS
+    if (state & (1UL << 1)) {
+        channel = 7;
+        G = 255;
+    }
+    if (state & (1UL << 2)) {
+        R = 255;
+        B = 255;
+    }
+    if (state & (1UL << 3)) {
+        G = 255;
+    }
+#endif
+
+    IS31FL3733_set_color( channel+64-1, R, G, B );
   return state;
 }

--- a/keyboards/nk65/nk65.c
+++ b/keyboards/nk65/nk65.c
@@ -45,7 +45,7 @@ __attribute__((weak)) layer_state_t layer_state_set_user(layer_state_t state) {
     uint8_t B = 0;
     int channel = 6;
 
-#ifdef INDICATOR_LED_MODE == CAPS_LOCK
+#if INDICATOR_LED_MODE == CAPS_LOCK
     if (state & (1UL << 1)) {
         R = 255;
         B = 255;


### PR DESCRIPTION
Maintains the existing LED indicator functionality, but adds a layer mode. The two indicator modes are

### CAPS_LOCK
  - Top LED - whether caps lock is on
  - Middle LED - layer 1 is current layer
  - Bottom LED - layer 2 is current layer

### LAYERS
  - Top LED - layer 1 is current layer
  - Middle LED - layer 2 is current layer
  - Bottom LED - layer 3 is current layer

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
