### PR TITLE
make Canoe Gen2 static indicator rgb color configurable

### DIFF
--- a/keyboards/percent/canoe_gen2/rgb_matrix_kb.inc
+++ b/keyboards/percent/canoe_gen2/rgb_matrix_kb.inc
@@ -22,12 +22,14 @@ RGB_MATRIX_EFFECT(indicator_static)
 #ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
 static bool indicator_static(effect_params_t* params) {
+    HSV hsv = rgb_matrix_config.hsv;
+    RGB rgb = hsv_to_rgb(hsv);
     RGB_MATRIX_USE_LIMITS(led_min, led_max);
     for (uint8_t i = led_min ; i < 74; i++) {
         rgb_matrix_set_color(i, 0x00, 0x00, 0x00);
     }
     for (uint8_t i = 74 ; i < led_max; i++) {
-        rgb_matrix_set_color(i, 0xff, 0xff, 0xff);
+        rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
     }
     return led_max < DRIVER_LED_TOTAL;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Made the static color preset for the indicator RGB LEDs on Canoe Gen2 configurable instead of static white.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
