### PR TITLE
[Keymap] ANAVI Macro Pad 8 fix kodi and default

### DIFF
--- a/keyboards/anavi/macropad8/keymaps/default/keymap.c
+++ b/keyboards/anavi/macropad8/keymaps/default/keymap.c
@@ -25,7 +25,7 @@ oled_rotation_t oled_init_user(oled_rotation_t rotation) {
 void oled_task_user(void) {
   // Host Keyboard Layer Status
   oled_write_ln_P(PSTR("ANAVI Macro Pad 8"), false);
-  oled_write_P(PSTR("Active layer:"), false);
+  oled_write_P(PSTR("Active layer: "), false);
 
   switch (get_highest_layer(layer_state)) {
     case _MAIN:

--- a/keyboards/anavi/macropad8/keymaps/kodi/keymap.c
+++ b/keyboards/anavi/macropad8/keymaps/kodi/keymap.c
@@ -12,6 +12,18 @@ const uint8_t RGBLED_RAINBOW_MOOD_INTERVALS[] PROGMEM = {60, 30, 15};
 const uint8_t RGBLED_RAINBOW_SWIRL_INTERVALS[] PROGMEM = {20, 10, 4};
 #endif
 
+/**
+ * Kodi shortcuts:
+ *
+ * ESC - Previous menu OR Home screen
+ * Enter - Select
+ * X - Stop
+ * Arrows to move
+ *
+ * For details have a look at:
+ * https://kodi.wiki/view/Keyboard_controls
+ */
+
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   [_MAIN] = LAYOUT_ortho_2x4(
      KC_ESC, KC_UP, KC_ENTER, KC_X,
@@ -32,11 +44,11 @@ oled_rotation_t oled_init_user(oled_rotation_t rotation) {
 void oled_task_user(void) {
   // Host Keyboard Layer Status
   oled_write_ln_P(PSTR("ANAVI Macro Pad 8"), false);
-  oled_write_P(PSTR("Active layer:"), false);
+  oled_write_P(PSTR("Active layer: "), false);
 
   switch (get_highest_layer(layer_state)) {
     case _MAIN:
-      oled_write_ln_P(PSTR("Main"), false);
+      oled_write_ln_P(PSTR("Kodi"), false);
       break;
     case _FN:
       oled_write_ln_P(PSTR("FN"), false);


### PR DESCRIPTION
Improvements and bug fixes for the keymaps kodi and default for
ANAVI Macro Pad 8:

- Add space to the end of string "Active layer: " for better
  visibility on the mini I2C OLED display for both keymaps
- Replace "Main" with "Kodi" for the Kodi keymap
- Add comment with reference to Kodi documentation for the
  available shortcuts in this keymap

Signed-off-by: Leon Anavi <leon@anavi.org>

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Improvements and bug fixes for the keymaps kodi and default for ANAVI Macro Pad 8 as explained in the git commit message.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
