### PR TITLE
Modified tmk_core/rules.mk to avoid linking errors

### DIFF
--- a/tmk_core/rules.mk
+++ b/tmk_core/rules.mk
@@ -104,7 +104,7 @@ CFLAGS += -Wa,-adhlns=$(@:%.o=%.lst)
 CFLAGS += $(CSTANDARD)
 
 # This fixes lots of keyboards linking errors but SHOULDN'T BE A FINAL SOLUTION
-# Fixing of multiple variable definitions must be fixed.
+# Fixing of multiple variable definitions must be made.
 CFLAGS += -fcommon
 
 #---------------- Compiler Options C++ ----------------

--- a/tmk_core/rules.mk
+++ b/tmk_core/rules.mk
@@ -103,6 +103,10 @@ endif
 CFLAGS += -Wa,-adhlns=$(@:%.o=%.lst)
 CFLAGS += $(CSTANDARD)
 
+# This fixes lots of keyboards linking errors but SHOULDN'T BE A FINAL SOLUTION
+# Fixing of multiple variable definitions must be fixed.
+CFLAGS += -fcommon
+
 #---------------- Compiler Options C++ ----------------
 #  -g*:          generate debugging information
 #  -O*:          optimization level
@@ -119,6 +123,7 @@ CXXFLAGS += -O$(OPT)
 CXXFLAGS += -w
 CXXFLAGS += -Wall
 CXXFLAGS += -Wundef
+
 ifneq ($(strip $(ALLOW_WARNINGS)), yes)
     CXXFLAGS += -Werror
 endif


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Added `-fcommon` flag to avoid linking errors due to multiple variable definitions. Though this is neither a definitive nor good solution. Proper changes with use of `extern` keyword to avoid those multiple definitions must be made.

I recently bought a Drop CTRL and qmk_firmware couldn't compile it. Investigating the reason of that I found issue #9733, and PR #9485 fixing this issue. That PR has not yet been merged due to changes on non-default keymaps, problems with this mentioned in https://github.com/qmk/qmk_firmware/pull/9485#issuecomment-647044303. As @DelusionalLogic said, using -fcommon is also an option. Before gcc 10 this was the default but it isn't anymore, breaking a bunch of keyboards that need to be fixed.

I've tested make all:default with and without the change and it reduces the number of [ERRORS] from [21](https://github.com/qmk/qmk_firmware/files/5426637/logmaster.txt) to [12](https://github.com/qmk/qmk_firmware/files/5426638/logcambioswithfcommon.txt)

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #9733

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
