### PR TITLE
Keep track of last matrix activity

### DIFF
--- a/quantum/split_common/matrix.c
+++ b/quantum/split_common/matrix.c
@@ -285,22 +285,23 @@ void matrix_post_scan(void) {
 }
 
 uint8_t matrix_scan(void) {
-    bool changed = matrix_pre_scan();
+    bool local_changed = false;
+    bool remote_changed = matrix_pre_scan();
 
 #if defined(DIRECT_PINS) || (DIODE_DIRECTION == COL2ROW)
     // Set row, read cols
     for (uint8_t current_row = 0; current_row < ROWS_PER_HAND; current_row++) {
-        changed |= read_cols_on_row(raw_matrix, current_row);
+        local_changed |= read_cols_on_row(raw_matrix, current_row);
     }
 #elif (DIODE_DIRECTION == ROW2COL)
     // Set col, read rows
     for (uint8_t current_col = 0; current_col < MATRIX_COLS; current_col++) {
-        changed |= read_rows_on_col(raw_matrix, current_col);
+        local_changed |= read_rows_on_col(raw_matrix, current_col);
     }
 #endif
 
-    debounce(raw_matrix, matrix + thisHand, ROWS_PER_HAND, changed);
+    debounce(raw_matrix, matrix + thisHand, ROWS_PER_HAND, local_changed);
 
     matrix_post_scan();
-    return (uint8_t)changed;
+    return (uint8_t)(local_changed || remote_changed);
 }

--- a/tmk_core/common/keyboard.h
+++ b/tmk_core/common/keyboard.h
@@ -73,6 +73,9 @@ void keyboard_post_init_user(void);
 void housekeeping_task_kb(void);
 void housekeeping_task_user(void);
 
+uint32_t last_matrix_activity_time(void);     // Timestamp of the last matrix activity
+uint32_t last_matrix_activity_elapsed(void);  // Number of milliseconds since the last matrix activity
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Description

This PR adds support for recording the last time matrix activity was detected.
Two new APIs have been added:
```c
uint32_t last_matrix_activity_time(void);     // Timestamp of the last matrix activity
uint32_t last_matrix_activity_elapsed(void);  // Number of milliseconds since the last matrix activity
```

These values are compatible with normal matrix scanning, as well as split_common.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
