### PR TITLE
Add big spacebar defaults to Underscore33 

### DIFF
--- a/keyboards/underscore33/rev1/keymaps/default/config.h
+++ b/keyboards/underscore33/rev1/keymaps/default/config.h
@@ -1,3 +1,18 @@
+/* Copyright 2020 tominabox1
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 #pragma once
 
 /* Combos */

--- a/keyboards/underscore33/rev1/keymaps/default/keymap.c
+++ b/keyboards/underscore33/rev1/keymaps/default/keymap.c
@@ -21,10 +21,6 @@ enum layers{
   _NAV
 };
 
-enum custom_keycodes{
-  RGBRST = SAFE_RANGE,
-};
-
 #define KC_NUM_SPC LT(_NUM_SYM, KC_SPC)
 #define KC_NAV_ENT LT(_NAV, KC_ENT)
 #define KC_GA LGUI_T(KC_A)
@@ -60,7 +56,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   ),
 
   [_NAV] = LAYOUT_33_split_space(
-      RESET,   RGBRST,  AG_NORM,  AG_SWAP,  DEBUG,   KC_GRV,  KC_PGDN,    KC_UP,  KC_PGUP,  KC_SCLN,
+      RESET,    KC_NO,    KC_NO,    KC_NO,  KC_NO,   KC_GRV,  KC_PGDN,    KC_UP,  KC_PGUP,  KC_SCLN,
     RGB_TOG,  RGB_HUI,  RGB_SAI,  RGB_VAI,  KC_NO,  KC_HOME,  KC_LEFT,  KC_DOWN,  KC_RGHT,   KC_END,
     RGB_MOD,  RGB_HUD,  RGB_SAD,  RGB_VAD,  KC_NO,  KC_MINS,    KC_RO,  KC_COMM,   KC_DOT,  KC_BSLS,
                    KC_TRNS, KC_TRNS, KC_TRNS,   KC_TRNS,   KC_TRNS

--- a/keyboards/underscore33/rev1/keymaps/default_big_space/config.h
+++ b/keyboards/underscore33/rev1/keymaps/default_big_space/config.h
@@ -1,0 +1,5 @@
+#pragma once
+
+/* Combos */
+#define COMBO_COUNT 5
+#define COMBO_TERM 50

--- a/keyboards/underscore33/rev1/keymaps/default_big_space/config.h
+++ b/keyboards/underscore33/rev1/keymaps/default_big_space/config.h
@@ -1,3 +1,18 @@
+/* Copyright 2020 tominabox1
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 #pragma once
 
 /* Combos */

--- a/keyboards/underscore33/rev1/keymaps/default_big_space/keymap.c
+++ b/keyboards/underscore33/rev1/keymaps/default_big_space/keymap.c
@@ -1,0 +1,86 @@
+/* Copyright 2020 tominabox1
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include QMK_KEYBOARD_H
+
+enum layers{
+  _BASE,
+  _NUM_SYM,
+  _NAV
+};
+
+enum custom_keycodes{
+  RGBRST = SAFE_RANGE,
+};
+
+#define KC_NUM_SPC LT(_NUM_SYM, KC_SPC)
+#define KC_NAV_ENT LT(_NAV, KC_ENT)
+#define KC_GA LGUI_T(KC_A)
+#define KC_AS LALT_T(KC_S)
+#define KC_CD LCTL_T(KC_D)
+#define KC_SF LSFT_T(KC_F)
+#define KC_SJ RSFT_T(KC_J)
+#define KC_CK RCTL_T(KC_K)
+#define KC_AL RALT_T(KC_L)
+#define KC_GSCLN RGUI_T(KC_SCLN)
+
+enum combo_events {
+  COMBO_BSPC,
+  COMBO_NUMBAK,
+  COMBO_TAB,
+  COMBO_ESC,
+  COMBO_DEL,
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  [_BASE] = LAYOUT_33_big_space(
+    KC_Q,   KC_W,   KC_E,   KC_R,   KC_T,   KC_Y,   KC_U,    KC_I,   KC_O,     KC_P,
+   KC_GA,  KC_AS,  KC_CD,  KC_SF,   KC_G,   KC_H,  KC_SJ,   KC_CK,  KC_AL, KC_GSCLN,
+    KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,   KC_N,   KC_M, KC_COMM, KC_DOT,  KC_SLSH,
+                        KC_LCTL, KC_NUM_SPC, KC_NAV_ENT
+  ),
+
+  [_NUM_SYM] = LAYOUT_33_big_space(
+       KC_1,     KC_2,     KC_3,     KC_4,      KC_5,     KC_6,     KC_7,     KC_8,     KC_9,     KC_0,
+    KC_EXLM,    KC_AT,  KC_HASH,   KC_DLR,   KC_PERC,  KC_CIRC,  KC_AMPR,  KC_ASTR, KC_EQUAL,  KC_MINS,
+    KC_BSLS,  KC_LCBR,  KC_LBRC,  KC_LPRN,   KC_UNDS,  KC_RPRN,  KC_RBRC,  KC_RCBR,   KC_DOT,   KC_GRV,
+                        KC_TRNS, KC_TRNS,   KC_TRNS
+  ),
+
+  [_NAV] = LAYOUT_33_big_space(
+      RESET,   RGBRST,  AG_NORM,  AG_SWAP,  DEBUG,   KC_GRV,  KC_PGDN,    KC_UP,  KC_PGUP,  KC_SCLN,
+    RGB_TOG,  RGB_HUI,  RGB_SAI,  RGB_VAI,  KC_NO,  KC_HOME,  KC_LEFT,  KC_DOWN,  KC_RGHT,   KC_END,
+    RGB_MOD,  RGB_HUD,  RGB_SAD,  RGB_VAD,  KC_NO,  KC_MINS,    KC_RO,  KC_COMM,   KC_DOT,  KC_BSLS,
+                        KC_TRNS,   KC_TRNS,   KC_TRNS
+  ),
+};
+
+
+#ifdef COMBO_ENABLE
+const uint16_t PROGMEM combo_bspc[] = {KC_O, KC_P, COMBO_END};
+const uint16_t PROGMEM combo_numbak[] = {KC_0, KC_9, COMBO_END};
+const uint16_t PROGMEM combo_tab[] = {KC_Q, KC_W, COMBO_END};
+const uint16_t PROGMEM combo_esc[] = {KC_E, KC_W, COMBO_END};
+const uint16_t PROGMEM combo_del[] = {KC_MINS, KC_EQL, COMBO_END};
+
+combo_t key_combos[COMBO_COUNT] = {
+  [COMBO_BSPC] = COMBO(combo_bspc,KC_BSPC),
+  [COMBO_NUMBAK] = COMBO(combo_numbak,KC_BSPC),
+  [COMBO_TAB] = COMBO(combo_tab,KC_TAB),
+  [COMBO_ESC] = COMBO(combo_esc,KC_ESC),
+  [COMBO_DEL] = COMBO(combo_del,KC_DEL),
+
+};
+#endif

--- a/keyboards/underscore33/rev1/keymaps/default_big_space/keymap.c
+++ b/keyboards/underscore33/rev1/keymaps/default_big_space/keymap.c
@@ -21,10 +21,6 @@ enum layers{
   _NAV
 };
 
-enum custom_keycodes{
-  RGBRST = SAFE_RANGE,
-};
-
 #define KC_NUM_SPC LT(_NUM_SYM, KC_SPC)
 #define KC_NAV_ENT LT(_NAV, KC_ENT)
 #define KC_GA LGUI_T(KC_A)
@@ -60,7 +56,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   ),
 
   [_NAV] = LAYOUT_33_big_space(
-      RESET,   RGBRST,  AG_NORM,  AG_SWAP,  DEBUG,   KC_GRV,  KC_PGDN,    KC_UP,  KC_PGUP,  KC_SCLN,
+      RESET,    KC_NO,    KC_NO,    KC_NO,  KC_NO,   KC_GRV,  KC_PGDN,    KC_UP,  KC_PGUP,  KC_SCLN,
     RGB_TOG,  RGB_HUI,  RGB_SAI,  RGB_VAI,  KC_NO,  KC_HOME,  KC_LEFT,  KC_DOWN,  KC_RGHT,   KC_END,
     RGB_MOD,  RGB_HUD,  RGB_SAD,  RGB_VAD,  KC_NO,  KC_MINS,    KC_RO,  KC_COMM,   KC_DOT,  KC_BSLS,
                         KC_TRNS,   KC_TRNS,   KC_TRNS

--- a/keyboards/underscore33/rev1/keymaps/default_big_space/readme.md
+++ b/keyboards/underscore33/rev1/keymaps/default_big_space/readme.md
@@ -1,0 +1,3 @@
+# Default _33 Rev2 Layout
+
+This is the recommended default layout. 

--- a/keyboards/underscore33/rev1/keymaps/default_big_space/readme.md
+++ b/keyboards/underscore33/rev1/keymaps/default_big_space/readme.md
@@ -1,3 +1,3 @@
-# Default _33 Rev2 Layout
+# Default _33 Rev1 Layout (with big spacebar)
 
 This is the recommended default layout. 

--- a/keyboards/underscore33/rev1/keymaps/default_big_space/rules.mk
+++ b/keyboards/underscore33/rev1/keymaps/default_big_space/rules.mk
@@ -1,0 +1,1 @@
+COMBO_ENABLE = yes

--- a/keyboards/underscore33/rev2/keymaps/default/config.h
+++ b/keyboards/underscore33/rev2/keymaps/default/config.h
@@ -1,3 +1,18 @@
+/* Copyright 2020 tominabox1
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 #pragma once
 
 /* Combos */

--- a/keyboards/underscore33/rev2/keymaps/default/keymap.c
+++ b/keyboards/underscore33/rev2/keymaps/default/keymap.c
@@ -21,10 +21,6 @@ enum layers{
   _NAV
 };
 
-enum custom_keycodes{
-  RGBRST = SAFE_RANGE,
-};
-
 #define KC_NUM_SPC LT(_NUM_SYM, KC_SPC)
 #define KC_NAV_ENT LT(_NAV, KC_ENT)
 #define KC_GA LGUI_T(KC_A)
@@ -60,7 +56,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   ),
 
   [_NAV] = LAYOUT_33_split_space(
-      RESET,   RGBRST,  AG_NORM,  AG_SWAP,  DEBUG,   KC_GRV,  KC_PGDN,    KC_UP,  KC_PGUP,  KC_SCLN,
+    RESET,    KC_NO,    KC_NO,    KC_NO,  KC_NO,   KC_GRV,  KC_PGDN,    KC_UP,  KC_PGUP,  KC_SCLN,
     RGB_TOG,  RGB_HUI,  RGB_SAI,  RGB_VAI,  KC_NO,  KC_HOME,  KC_LEFT,  KC_DOWN,  KC_RGHT,   KC_END,
     RGB_MOD,  RGB_HUD,  RGB_SAD,  RGB_VAD,  KC_NO,  KC_MINS,    KC_RO,  KC_COMM,   KC_DOT,  KC_BSLS,
                    KC_TRNS,  KC_TRNS,  KC_TRNS, KC_TRNS,   KC_TRNS,   KC_TRNS

--- a/keyboards/underscore33/rev2/keymaps/default_big_space/config.h
+++ b/keyboards/underscore33/rev2/keymaps/default_big_space/config.h
@@ -1,0 +1,5 @@
+#pragma once
+
+/* Combos */
+#define COMBO_COUNT 5
+#define COMBO_TERM 50

--- a/keyboards/underscore33/rev2/keymaps/default_big_space/config.h
+++ b/keyboards/underscore33/rev2/keymaps/default_big_space/config.h
@@ -1,3 +1,18 @@
+/* Copyright 2020 tominabox1
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 #pragma once
 
 /* Combos */

--- a/keyboards/underscore33/rev2/keymaps/default_big_space/keymap.c
+++ b/keyboards/underscore33/rev2/keymaps/default_big_space/keymap.c
@@ -1,0 +1,86 @@
+/* Copyright 2020 tominabox1
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include QMK_KEYBOARD_H
+
+enum layers{
+  _BASE,
+  _NUM_SYM,
+  _NAV
+};
+
+enum custom_keycodes{
+  RGBRST = SAFE_RANGE,
+};
+
+#define KC_NUM_SPC LT(_NUM_SYM, KC_SPC)
+#define KC_NAV_ENT LT(_NAV, KC_ENT)
+#define KC_GA LGUI_T(KC_A)
+#define KC_AS LALT_T(KC_S)
+#define KC_CD LCTL_T(KC_D)
+#define KC_SF LSFT_T(KC_F)
+#define KC_SJ RSFT_T(KC_J)
+#define KC_CK RCTL_T(KC_K)
+#define KC_AL RALT_T(KC_L)
+#define KC_GSCLN RGUI_T(KC_SCLN)
+
+enum combo_events {
+  COMBO_BSPC,
+  COMBO_NUMBAK,
+  COMBO_TAB,
+  COMBO_ESC,
+  COMBO_DEL,
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  [_BASE] = LAYOUT_33_big_space(
+    KC_Q,   KC_W,   KC_E,   KC_R,   KC_T,   KC_Y,   KC_U,    KC_I,   KC_O,     KC_P,
+   KC_GA,  KC_AS,  KC_CD,  KC_SF,   KC_G,   KC_H,  KC_SJ,   KC_CK,  KC_AL, KC_GSCLN,
+    KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,   KC_N,   KC_M, KC_COMM, KC_DOT,  KC_SLSH,
+                        KC_LCTL, KC_NUM_SPC, KC_NAV_ENT
+  ),
+
+  [_NUM_SYM] = LAYOUT_33_big_space(
+       KC_1,     KC_2,     KC_3,     KC_4,      KC_5,     KC_6,     KC_7,     KC_8,     KC_9,     KC_0,
+    KC_EXLM,    KC_AT,  KC_HASH,   KC_DLR,   KC_PERC,  KC_CIRC,  KC_AMPR,  KC_ASTR, KC_EQUAL,  KC_MINS,
+    KC_BSLS,  KC_LCBR,  KC_LBRC,  KC_LPRN,   KC_UNDS,  KC_RPRN,  KC_RBRC,  KC_RCBR,   KC_DOT,   KC_GRV,
+                        KC_TRNS, KC_TRNS,   KC_TRNS
+  ),
+
+  [_NAV] = LAYOUT_33_big_space(
+      RESET,   RGBRST,  AG_NORM,  AG_SWAP,  DEBUG,   KC_GRV,  KC_PGDN,    KC_UP,  KC_PGUP,  KC_SCLN,
+    RGB_TOG,  RGB_HUI,  RGB_SAI,  RGB_VAI,  KC_NO,  KC_HOME,  KC_LEFT,  KC_DOWN,  KC_RGHT,   KC_END,
+    RGB_MOD,  RGB_HUD,  RGB_SAD,  RGB_VAD,  KC_NO,  KC_MINS,    KC_RO,  KC_COMM,   KC_DOT,  KC_BSLS,
+                        KC_TRNS,   KC_TRNS,   KC_TRNS
+  ),
+};
+
+
+#ifdef COMBO_ENABLE
+const uint16_t PROGMEM combo_bspc[] = {KC_O, KC_P, COMBO_END};
+const uint16_t PROGMEM combo_numbak[] = {KC_0, KC_9, COMBO_END};
+const uint16_t PROGMEM combo_tab[] = {KC_Q, KC_W, COMBO_END};
+const uint16_t PROGMEM combo_esc[] = {KC_E, KC_W, COMBO_END};
+const uint16_t PROGMEM combo_del[] = {KC_MINS, KC_EQL, COMBO_END};
+
+combo_t key_combos[COMBO_COUNT] = {
+  [COMBO_BSPC] = COMBO(combo_bspc,KC_BSPC),
+  [COMBO_NUMBAK] = COMBO(combo_numbak,KC_BSPC),
+  [COMBO_TAB] = COMBO(combo_tab,KC_TAB),
+  [COMBO_ESC] = COMBO(combo_esc,KC_ESC),
+  [COMBO_DEL] = COMBO(combo_del,KC_DEL),
+
+};
+#endif

--- a/keyboards/underscore33/rev2/keymaps/default_big_space/keymap.c
+++ b/keyboards/underscore33/rev2/keymaps/default_big_space/keymap.c
@@ -21,10 +21,6 @@ enum layers{
   _NAV
 };
 
-enum custom_keycodes{
-  RGBRST = SAFE_RANGE,
-};
-
 #define KC_NUM_SPC LT(_NUM_SYM, KC_SPC)
 #define KC_NAV_ENT LT(_NAV, KC_ENT)
 #define KC_GA LGUI_T(KC_A)
@@ -60,7 +56,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   ),
 
   [_NAV] = LAYOUT_33_big_space(
-      RESET,   RGBRST,  AG_NORM,  AG_SWAP,  DEBUG,   KC_GRV,  KC_PGDN,    KC_UP,  KC_PGUP,  KC_SCLN,
+      RESET,    KC_NO,    KC_NO,    KC_NO,  KC_NO,   KC_GRV,  KC_PGDN,    KC_UP,  KC_PGUP,  KC_SCLN,
     RGB_TOG,  RGB_HUI,  RGB_SAI,  RGB_VAI,  KC_NO,  KC_HOME,  KC_LEFT,  KC_DOWN,  KC_RGHT,   KC_END,
     RGB_MOD,  RGB_HUD,  RGB_SAD,  RGB_VAD,  KC_NO,  KC_MINS,    KC_RO,  KC_COMM,   KC_DOT,  KC_BSLS,
                         KC_TRNS,   KC_TRNS,   KC_TRNS

--- a/keyboards/underscore33/rev2/keymaps/default_big_space/readme.md
+++ b/keyboards/underscore33/rev2/keymaps/default_big_space/readme.md
@@ -1,0 +1,3 @@
+# Default _33 Rev2 Layout
+
+This is the recommended default layout. 

--- a/keyboards/underscore33/rev2/keymaps/default_big_space/readme.md
+++ b/keyboards/underscore33/rev2/keymaps/default_big_space/readme.md
@@ -1,3 +1,3 @@
-# Default _33 Rev2 Layout
+# Default _33 Rev2 Layout (with big spacebar)
 
 This is the recommended default layout. 

--- a/keyboards/underscore33/rev2/keymaps/default_big_space/rules.mk
+++ b/keyboards/underscore33/rev2/keymaps/default_big_space/rules.mk
@@ -1,0 +1,1 @@
+COMBO_ENABLE = yes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Accidentally left off big spacebar default keycaps

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
