### PR TITLE
Oled task update timer change

### DIFF
--- a/drivers/oled/oled_driver.c
+++ b/drivers/oled/oled_driver.c
@@ -639,15 +639,15 @@ void oled_task(void) {
     }
 
 #if OLED_UPDATE_INTERVAL > 0
-    if (timer_elapsed(oled_update_timeout) < OLED_UPDATE_INTERVAL) {
-        return;
+    if (timer_elapsed(oled_update_timeout) >= OLED_UPDATE_INTERVAL) {
+        oled_update_timeout = timer_read();
+        oled_set_cursor(0, 0);
+        oled_task_user();
     }
-    oled_update_timeout = timer_read();
-#endif
-
+#else
     oled_set_cursor(0, 0);
-
     oled_task_user();
+#endif
 
 #if OLED_SCROLL_TIMEOUT > 0
     if (oled_dirty && oled_scrolling) {


### PR DESCRIPTION
## Description

This is a minor change to the previous PR: https://github.com/qmk/qmk_firmware/pull/10388
Per discussion in that PR, the main cause of the scanning performance hit was the oled_task frequency, not the display updates as they were guarded by a dirty flag. This change allows the oled to be flushed if there is still dirty data in between oled_task ticks. The benifit of this approach is that the oled display remains, in all appearances, still performant while retaining the high matrix scan rates as achieved by not running oled_task so frequently.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
