### PR TITLE
Force SPLIT_USB_DETECT for AVR Teensy controllers

### DIFF
--- a/quantum/split_common/split_util.c
+++ b/quantum/split_common/split_util.c
@@ -31,7 +31,7 @@
 #    define SPLIT_USB_TIMEOUT_POLL 10
 #endif
 
-#ifdef PROTOCOL_CHIBIOS
+#if defined(PROTOCOL_CHIBIOS) || defined(BOOTLOADER_HALFKAY)
 #    define SPLIT_USB_DETECT  // Force this on for now
 #endif
 


### PR DESCRIPTION
## Description

Because the AVR Teensy controllers lack the correct hardware configuration, the only effective way to detect which side is the master, is to use the SPLIT_USB_DETECT method.   This forces the check for these controllers. 

## Types of Changes

- [x] Core
- [x] Enhancement/optimization


## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
