### PR TITLE
Add brightness level API to OLED driver

### DIFF
--- a/docs/feature_oled_driver.md
+++ b/docs/feature_oled_driver.md
@@ -149,7 +149,7 @@ void oled_task_user(void) {
 |`OLED_SCROLL_TIMEOUT_RIGHT`|*Not defined*    |Scroll timeout direction is right when defined, left when undefined.                                                      |
 |`OLED_IC`                  |`OLED_IC_SSD1306`|Set to `OLED_IC_SH1106` if you're using the SH1106 OLED controller.                                                       |
 |`OLED_COLUMN_OFFSET`       |`0`              |(SH1106 only.) Shift output to the right this many pixels.<br />Useful for 128x64 displays centered on a 132x64 SH1106 IC.|
-|`OLED_BRIGHTNESS`          |`143`            |The default brightness level of the OLED, from 0 to 255.                                                                  |
+|`OLED_BRIGHTNESS`          |`255`            |The default brightness level of the OLED, from 0 to 255.                                                                  |
 
  ## 128x64 & Custom sized OLED Displays
 

--- a/docs/feature_oled_driver.md
+++ b/docs/feature_oled_driver.md
@@ -140,8 +140,8 @@ void oled_task_user(void) {
 |---------------------------|-----------------|--------------------------------------------------------------------------------------------------------------------------|
 |`OLED_DISPLAY_ADDRESS`     |`0x3C`           |The i2c address of the OLED Display                                                                                       |
 |`OLED_FONT_H`              |`"glcdfont.c"`   |The font code file to use for custom fonts                                                                                |
-|`OLED_FONT_START`          |`0`              |The starting characer index for custom fonts                                                                              |
-|`OLED_FONT_END`            |`223`            |The ending characer index for custom fonts                                                                                |
+|`OLED_FONT_START`          |`0`              |The starting character index for custom fonts                                                                             |
+|`OLED_FONT_END`            |`223`            |The ending character index for custom fonts                                                                               |
 |`OLED_FONT_WIDTH`          |`6`              |The font width                                                                                                            |
 |`OLED_FONT_HEIGHT`         |`8`              |The font height (untested)                                                                                                |
 |`OLED_TIMEOUT`             |`60000`          |Turns off the OLED screen after 60000ms of keyboard inactivity. Helps reduce OLED Burn-in. Set to 0 to disable.           |
@@ -149,6 +149,7 @@ void oled_task_user(void) {
 |`OLED_SCROLL_TIMEOUT_RIGHT`|*Not defined*    |Scroll timeout direction is right when defined, left when undefined.                                                      |
 |`OLED_IC`                  |`OLED_IC_SSD1306`|Set to `OLED_IC_SH1106` if you're using the SH1106 OLED controller.                                                       |
 |`OLED_COLUMN_OFFSET`       |`0`              |(SH1106 only.) Shift output to the right this many pixels.<br />Useful for 128x64 displays centered on a 132x64 SH1106 IC.|
+|`OLED_BRIGHTNESS`          |`143`            |The default brightness level of the OLED, from 0 to 255.                                                                  |
 
  ## 128x64 & Custom sized OLED Displays
 
@@ -303,6 +304,12 @@ bool oled_off(void);
 // Returns true if the oled is currently on, false if it is
 // not
 bool is_oled_on(void);
+
+// Sets the brightness level of the display
+uint8_t oled_set_brightness(uint8_t level);
+
+// Gets the current brightness level of the display
+uint8_t oled_get_brightness(void);
 
 // Basically it's oled_render, but with timeout management and oled_task_user calling!
 void oled_task(void);

--- a/drivers/oled/oled_driver.c
+++ b/drivers/oled/oled_driver.c
@@ -107,6 +107,7 @@ OLED_BLOCK_TYPE oled_dirty          = 0;
 bool            oled_initialized    = false;
 bool            oled_active         = false;
 bool            oled_scrolling      = false;
+uint8_t         oled_brightness     = OLED_BRIGHTNESS;
 uint8_t         oled_rotation       = 0;
 uint8_t         oled_rotation_width = 0;
 uint8_t         oled_scroll_speed   = 0;  // this holds the speed after being remapped to ssd1306 internal values
@@ -193,7 +194,7 @@ bool oled_init(uint8_t rotation) {
         }
     }
 
-    static const uint8_t PROGMEM display_setup2[] = {I2C_CMD, COM_PINS, OLED_COM_PINS, CONTRAST, 0x8F, PRE_CHARGE_PERIOD, 0xF1, VCOM_DETECT, 0x40, DISPLAY_ALL_ON_RESUME, NORMAL_DISPLAY, DEACTIVATE_SCROLL, DISPLAY_ON};
+    static const uint8_t PROGMEM display_setup2[] = {I2C_CMD, COM_PINS, OLED_COM_PINS, CONTRAST, OLED_BRIGHTNESS, PRE_CHARGE_PERIOD, 0xF1, VCOM_DETECT, 0x20, DISPLAY_ALL_ON_RESUME, NORMAL_DISPLAY, DEACTIVATE_SCROLL, DISPLAY_ON};
     if (I2C_TRANSMIT_P(display_setup2) != I2C_STATUS_SUCCESS) {
         print("display_setup2 failed\n");
         return false;
@@ -549,6 +550,20 @@ bool oled_off(void) {
 }
 
 bool is_oled_on(void) { return oled_active; }
+
+uint8_t oled_set_brightness(uint8_t level) {
+    uint8_t set_contrast[] = {I2C_CMD, CONTRAST, level};
+    if (oled_brightness != level) {
+        if (I2C_TRANSMIT(set_contrast) != I2C_STATUS_SUCCESS) {
+            print("set_brightness cmd failed\n");
+            return oled_brightness;
+        }
+        oled_brightness = level;
+    }
+    return oled_brightness;
+}
+
+uint8_t oled_get_brightness(void) { return oled_brightness; }
 
 // Set the specific 8 lines rows of the screen to scroll.
 // 0 is the default for start, and 7 for end, which is the entire

--- a/drivers/oled/oled_driver.h
+++ b/drivers/oled/oled_driver.h
@@ -141,6 +141,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #if !defined(OLED_FONT_HEIGHT)
 #    define OLED_FONT_HEIGHT 8
 #endif
+// Default brightness level
+#if !defined(OLED_BRIGHTNESS)
+#    define OLED_BRIGHTNESS 143
+#endif
 
 #if !defined(OLED_TIMEOUT)
 #    if defined(OLED_DISABLE_TIMEOUT)
@@ -260,6 +264,12 @@ bool oled_off(void);
 // Returns true if the oled is currently on, false if it is
 // not
 bool is_oled_on(void);
+
+// Sets the brightness of the display
+uint8_t oled_set_brightness(uint8_t level);
+
+// Gets the current brightness of the display
+uint8_t oled_get_brightness(void);
 
 // Basically it's oled_render, but with timeout management and oled_task_user calling!
 void oled_task(void);

--- a/drivers/oled/oled_driver.h
+++ b/drivers/oled/oled_driver.h
@@ -143,7 +143,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #endif
 // Default brightness level
 #if !defined(OLED_BRIGHTNESS)
-#    define OLED_BRIGHTNESS 143
+#    define OLED_BRIGHTNESS 255
 #endif
 
 #if !defined(OLED_TIMEOUT)

--- a/keyboards/handwired/onekey/keymaps/oled/keymap.c
+++ b/keyboards/handwired/onekey/keymaps/oled/keymap.c
@@ -144,6 +144,12 @@ static void dance_oled_finished(qk_tap_dance_state_t *state, void *user_data) {
                 }
             }
             break;
+        case 4:
+            if (!state->pressed) {
+                // quadruple tap - step through brightness levels
+                oled_set_brightness(oled_get_brightness() + 0x10);
+            }
+            break;
         default:
             break;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

🔅 🔆

The SSD1306 datasheet calls this "contrast", probably a holdover from LCDs, but since OLEDs emit light, it is actually brightness.

The VCOM deselect level was changed from 0x40 to 0x20 in order to get what seems (to me) to be a larger brightness range - at 0x40 the OLED is quite bright but at brightness level 0, the display only dims a little bit. Likewise, when set to 0x00, the maximum brightness is noticeably dimmer, but the minimum is *much* dimmer. 0x20 appears to be the sweet spot from my 5 seconds of experimentation (I also note that this is the value upon reset). Maybe there is some way to dynamically change the VCOM deselect along with the brightness level...

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
