### PR TITLE
Add OLED support for Riblee F411

### DIFF
--- a/keyboards/handwired/riblee_f411/config.h
+++ b/keyboards/handwired/riblee_f411/config.h
@@ -28,7 +28,7 @@
 #define MATRIX_COLS 12
 
 #define MATRIX_ROW_PINS { A6, A5, A4, A3, A2 }
-#define MATRIX_COL_PINS { B10, B1, B0, B15, A8, B3, B4, B5, B6, B7, B8, B9 }
+#define MATRIX_COL_PINS { B10, B1, B0, B15, A8, B3, B4, B5, B14, A0, B8, B9 }
 #define UNUSED_PINS
 
 #define DIODE_DIRECTION COL2ROW
@@ -39,3 +39,5 @@
 #define MOUSEKEY_INTERVAL 32
 
 #define TAPPING_TERM 175
+
+#define OLED_DISPLAY_128X64

--- a/keyboards/handwired/riblee_f411/halconf.h
+++ b/keyboards/handwired/riblee_f411/halconf.h
@@ -1,0 +1,20 @@
+/* Copyright 2020 Janos Daniel Reibl <janos.daniel.reibl@protonmail.com> @riblee
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#define HAL_USE_I2C TRUE
+
+#include_next "halconf.h"

--- a/keyboards/handwired/riblee_f411/mcuconf.h
+++ b/keyboards/handwired/riblee_f411/mcuconf.h
@@ -1,0 +1,25 @@
+/* Copyright 2020 Nick Brassel (tzarc)
+ * Copyright 2020 Janos Daniel Reibl <janos.daniel.reibl@protonmail.com> @riblee
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include_next "mcuconf.h"
+
+#undef STM32_I2C_USE_I2C1
+#define STM32_I2C_USE_I2C1 TRUE
+
+#undef I2C_DRIVER
+#define I2C_DRIVER I2CD1

--- a/keyboards/handwired/riblee_f411/rules.mk
+++ b/keyboards/handwired/riblee_f411/rules.mk
@@ -24,3 +24,6 @@ BLUETOOTH_ENABLE = no       # Enable Bluetooth
 AUDIO_ENABLE = no           # Audio output
 
 LAYOUTS = ortho_5x12
+
+OLED_DRIVER_ENABLE = yes
+RAW_ENABLE = yes

--- a/layouts/community/ortho_5x12/riblee/keymap.c
+++ b/layouts/community/ortho_5x12/riblee/keymap.c
@@ -48,6 +48,27 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * `-----------------------------------------------------------------------------------'
  */
 [_QWERTY] = LAYOUT_ortho_5x12(
+    KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_BSPC,
+    KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_DEL,
+    KC_ESC,  KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,
+    KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_ENT,
+    BACKLIT, KC_LCTL, KC_LALT, KC_LGUI, LOWER,   KC_SPC,  KC_SPC,  RAISE,   KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT
+),
+
+/* Hungarian
+* ,-----------------------------------------------------------------------------------.
+* |   `  |   1  |   2  |   3  |   4  |   5  |   6  |   7  |   8  |   9  |   0  | Bksp |
+* |------+------+------+------+------+------+------+------+------+------+------+------|
+* | Tab  |   Q  |   W  |   E  |   R  |   T  |   Y  |   U  |   I  |   O  |   P  | Del  |
+* |------+------+------+------+------+-------------+------+------+------+------+------|
+* | Esc  |   A  |   S  |   D  |   F  |   G  |   H  |   J  |   K  |   L  |   ;  |  "   |
+* |------+------+------+------+------+------|------+------+------+------+------+------|
+* | Shift|   Z  |   X  |   C  |   V  |   B  |   N  |   M  |   ,  |   .  |   /  |Enter |
+* |------+------+------+------+------+------+------+------+------+------+------+------|
+* | Brite| Ctrl | Alt  | GUI  |Lower |Space |Space |Raise | Left | Down |  Up  |Right |
+* `-----------------------------------------------------------------------------------'
+*/
+[_HUNGARIAN] = LAYOUT_ortho_5x12(
     KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,      KC_8,      KC_9,      KC_0,    KC_BSPC,
     KC_TAB,  KC_Q,    KC_W,    C_KC_E,  KC_R,    KC_T,    KC_Y,    C_KC_U,    C_KC_I,    C_KC_O,    KC_P,    KC_DEL,
     KC_ESC,  C_KC_A,  KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,      KC_K,      KC_L,      KC_SCLN, KC_QUOT,
@@ -153,11 +174,11 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * `-----------------------------------------------------------------------------------'
  */
 [_ADJUST] = LAYOUT_ortho_5x12(
-    KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,   KC_F11,  KC_F12,
-    _______, RESET,   DEBUG,   _______, _______, _______, _______, TERM_ON, TERM_OFF,_______,  _______, KC_DEL,
-    _______, _______, MU_MOD,  AU_ON,   AU_OFF,  AG_NORM, AG_SWAP, QWERTY,  COLEMAK, DVORAK,   _______, _______,
-    _______, _______, _______, _______, _______, _______, NK_TOGG, LCG_SWP, LCG_NRM, UC_MOD,   _______, _______,
-    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,  _______, _______
+    KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,   KC_F11,    KC_F12,
+    _______, RESET,   DEBUG,   _______, _______, _______, _______, TERM_ON, TERM_OFF,_______,  _______,   KC_DEL,
+    _______, _______, MU_MOD,  AU_ON,   AU_OFF,  AG_NORM, AG_SWAP, QWERTY,  COLEMAK, DVORAK,   HUNGARIAN, _______,
+    _______, _______, _______, _______, _______, _______, NK_TOGG, LCG_SWP, LCG_NRM, UC_MOD,   _______,   _______,
+    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,  _______,   _______
 )
 
 };

--- a/users/riblee/riblee.c
+++ b/users/riblee/riblee.c
@@ -218,7 +218,7 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
         receive_buffer_length = 0;
     }
 
-    // Reset the offset to prevent overwrining memory outside of the buffer
+    // Reset the offset to prevent overwriting memory outside of the buffer
     if (receive_buffer_length + 32 >= 128) {
         receive_buffer_length = 0;
     }

--- a/users/riblee/riblee.c
+++ b/users/riblee/riblee.c
@@ -15,6 +15,8 @@
  */
 
 #include "riblee.h"
+#include "raw_hid.h"
+#include <string.h>
 
 const uint8_t shift = MOD_BIT(KC_LSFT) | MOD_BIT(KC_RSFT);
 
@@ -150,6 +152,12 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             }
             return false;
             break;
+        case HUNGARIAN:
+            if (record->event.pressed) {
+                set_single_persistent_default_layer(_HUNGARIAN);
+            }
+            return false;
+            break;
         case BACKLIT:
             if (record->event.pressed) {
                 register_code(keycode_config(KC_LGUI));
@@ -164,3 +172,59 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     }
     return true;
 };
+
+#ifdef OLED_DRIVER_ENABLE
+
+static char receive_buffer[128] = {};
+static uint8_t receive_buffer_length = 0;
+
+void oled_task_user(void) {
+    // Keyboard Layer Status
+    oled_write_P(PSTR("Layer: "), false);
+
+    switch (get_highest_layer(layer_state)) {
+        case _QWERTY:
+            oled_write_P(PSTR("Default\n"), false);
+            break;
+        case _LOWER:
+            oled_write_P(PSTR("Lower\n"), false);
+            break;
+        case _RAISE:
+            oled_write_P(PSTR("Raise\n"), false);
+            break;
+        case _ADJUST:
+            oled_write_P(PSTR("Adjust\n"), false);
+            break;
+        default:
+            oled_write_P(PSTR("Undefined\n"), false);
+    }
+
+    // Print string received via HID RAW
+    oled_write_ln(receive_buffer, false);
+}
+
+#ifdef RAW_ENABLE
+
+void raw_hid_receive(uint8_t *data, uint8_t length) {
+
+    // Append data to receive_buffer, without the first byte
+    memcpy(receive_buffer + receive_buffer_length, data + 1, length - 1);
+    receive_buffer_length += (length - 1);
+
+    // First byte indicate if we will recive more package for the current string
+    // If it's 1 then this was the last package and we can reset the offset
+    if (data[0] == 1) {
+        // Reset the offset for memcpy to the begining of our buffer
+        receive_buffer_length = 0;
+    }
+
+    // Reset the offset to prevent overwrining memory outside of the buffer
+    if (receive_buffer_length + 32 >= 128) {
+        receive_buffer_length = 0;
+    }
+
+}
+
+#endif
+
+#endif

--- a/users/riblee/riblee.h
+++ b/users/riblee/riblee.h
@@ -18,8 +18,9 @@
 
 #include QMK_KEYBOARD_H
 
-enum preonic_layers {
+enum layer_names {
     _QWERTY,
+    _HUNGARIAN,
     _COLEMAK,
     _DVORAK,
     _LOWER,
@@ -27,8 +28,9 @@ enum preonic_layers {
     _ADJUST
 };
 
-enum preonic_keycodes {
+enum custom_keycodes {
     QWERTY = SAFE_RANGE,
+    HUNGARIAN,
     COLEMAK,
     DVORAK,
     BACKLIT


### PR DESCRIPTION
## Description

This PR adds OLED support for my F411 based keyboard.
The KB can receive strings via the RAW HID interface and can display them after the current layer. This can be useful for displaying system information such as CPU utilization and temperature.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
