### PR TITLE
docs(massdrop alt/ctrl): update link to loader releases

### DIFF
--- a/keyboards/massdrop/alt/readme.md
+++ b/keyboards/massdrop/alt/readme.md
@@ -14,7 +14,7 @@ Make example for this keyboard (after setting up your build environment):
 
 For information on flashing this keyboard, visit the following links:
 
-[Massdrop Loader Releases](https://github.com/Massdrop/mdloader/releases/tag/0.0.1)  
+[Massdrop Loader Releases](https://github.com/Massdrop/mdloader/releases)  
 [Massdrop Loader Repository and Instructions](https://github.com/Massdrop/mdloader)
 
 See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).

--- a/keyboards/massdrop/ctrl/readme.md
+++ b/keyboards/massdrop/ctrl/readme.md
@@ -14,7 +14,7 @@ Make example for this keyboard (after setting up your build environment):
 
 For information on flashing this keyboard, visit the following links:
 
-[Massdrop Loader Releases](https://github.com/Massdrop/mdloader/releases/tag/0.0.1)  
+[Massdrop Loader Releases](https://github.com/Massdrop/mdloader/releases)  
 [Massdrop Loader Repository and Instructions](https://github.com/Massdrop/mdloader)
 
 See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).


### PR DESCRIPTION
Update the link to the Massdrop Loader releases page to point to the releases index rather than release 0.0.1 (current version is 1.0.5). This will reduce the chance that someone will get stuck using an old version of `mdloader`

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation
