### PR TITLE
`qmk info`: Add `--ascii` flag

### DIFF
--- a/lib/python/qmk/cli/info.py
+++ b/lib/python/qmk/cli/info.py
@@ -3,6 +3,7 @@
 Compile an info.json for a particular keyboard and pretty-print it.
 """
 import json
+import platform
 
 from milc import cli
 
@@ -140,6 +141,11 @@ def info(cli):
     if not is_keyboard(cli.config.info.keyboard):
         cli.log.error('Invalid keyboard: "%s"', cli.config.info.keyboard)
         return False
+
+    platform_id = platform.platform().lower()
+
+    if 'windows' in platform_id:
+        cli.config.info.ascii = True
 
     # Build the info.json file
     kb_info_json = info_json(cli.config.info.keyboard)

--- a/lib/python/qmk/cli/info.py
+++ b/lib/python/qmk/cli/info.py
@@ -144,8 +144,6 @@ def info(cli):
         cli.log.error('Invalid keyboard: "%s"', cli.config.info.keyboard)
         return False
 
-    platform_id = platform.platform().lower()
-
     # Build the info.json file
     kb_info_json = info_json(cli.config.info.keyboard)
 

--- a/lib/python/qmk/cli/info.py
+++ b/lib/python/qmk/cli/info.py
@@ -133,7 +133,7 @@ def info(cli):
     """
     # Determine our keyboard(s)
     if not cli.config.info.keyboard:
-        cli.log.error('Missing paramater: --keyboard')
+        cli.log.error('Missing parameter: --keyboard')
         cli.subcommands['info'].print_help()
         return False
 

--- a/lib/python/qmk/cli/info.py
+++ b/lib/python/qmk/cli/info.py
@@ -13,11 +13,13 @@ from qmk.keymap import locate_keymap
 from qmk.info import info_json
 from qmk.path import is_keyboard
 
+platform_id = platform.platform().lower()
+
 ROW_LETTERS = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnop'
 COL_LETTERS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijilmnopqrstuvwxyz'
 
 
-def show_keymap(kb_info_json, render_ascii, title_caps=True):
+def show_keymap(kb_info_json, title_caps=True):
     """Render the keymap in ascii art.
     """
     keymap_path = locate_keymap(cli.config.info.keyboard, cli.config.info.keymap)
@@ -37,19 +39,19 @@ def show_keymap(kb_info_json, render_ascii, title_caps=True):
             else:
                 cli.echo('{fg_cyan}layer_%s{fg_reset}:', layer_num)
 
-            print(render_layout(kb_info_json['layouts'][layout_name]['layout'], render_ascii, layer))
+            print(render_layout(kb_info_json['layouts'][layout_name]['layout'], cli.config.info.ascii, layer))
 
 
-def show_layouts(kb_info_json, render_ascii, title_caps=True):
+def show_layouts(kb_info_json, title_caps=True):
     """Render the layouts with info.json labels.
     """
-    for layout_name, layout_art in render_layouts(kb_info_json, render_ascii).items():
+    for layout_name, layout_art in render_layouts(kb_info_json, cli.config.info.ascii).items():
         title = layout_name.title() if title_caps else layout_name
         cli.echo('{fg_cyan}%s{fg_reset}:', title)
         print(layout_art)  # Avoid passing dirty data to cli.echo()
 
 
-def show_matrix(kb_info_json, render_ascii, title_caps=True):
+def show_matrix(kb_info_json, title_caps=True):
     """Render the layout with matrix labels in ascii art.
     """
     for layout_name, layout in kb_info_json['layouts'].items():
@@ -70,7 +72,7 @@ def show_matrix(kb_info_json, render_ascii, title_caps=True):
         else:
             cli.echo('{fg_blue}matrix_%s{fg_reset}:', layout_name)
 
-        print(render_layout(kb_info_json['layouts'][layout_name]['layout'], render_ascii, labels))
+        print(render_layout(kb_info_json['layouts'][layout_name]['layout'], cli.config.info.ascii, labels))
 
 
 def print_friendly_output(kb_info_json):
@@ -92,13 +94,13 @@ def print_friendly_output(kb_info_json):
     cli.echo('{fg_blue}Bootloader{fg_reset}: %s', kb_info_json.get('bootloader', 'Unknown'))
 
     if cli.config.info.layouts:
-        show_layouts(kb_info_json, cli.config.info.ascii, True)
+        show_layouts(kb_info_json, True)
 
     if cli.config.info.matrix:
-        show_matrix(kb_info_json, cli.config.info.ascii, True)
+        show_matrix(kb_info_json, True)
 
     if cli.config_source.info.keymap and cli.config_source.info.keymap != 'config_file':
-        show_keymap(kb_info_json, cli.config.info.ascii, True)
+        show_keymap(kb_info_json, True)
 
 
 def print_text_output(kb_info_json):
@@ -111,13 +113,13 @@ def print_text_output(kb_info_json):
             cli.echo('{fg_blue}%s{fg_reset}: %s', key, kb_info_json[key])
 
     if cli.config.info.layouts:
-        show_layouts(kb_info_json, cli.config.info.ascii, False)
+        show_layouts(kb_info_json, False)
 
     if cli.config.info.matrix:
-        show_matrix(kb_info_json, cli.config.info.ascii, False)
+        show_matrix(kb_info_json, False)
 
     if cli.config_source.info.keymap and cli.config_source.info.keymap != 'config_file':
-        show_keymap(kb_info_json, cli.config.info.ascii, False)
+        show_keymap(kb_info_json, False)
 
 
 @cli.argument('-kb', '--keyboard', help='Keyboard to show info for.')
@@ -125,7 +127,7 @@ def print_text_output(kb_info_json):
 @cli.argument('-l', '--layouts', action='store_true', help='Render the layouts.')
 @cli.argument('-m', '--matrix', action='store_true', help='Render the layouts with matrix information.')
 @cli.argument('-f', '--format', default='friendly', arg_only=True, help='Format to display the data in (friendly, text, json) (Default: friendly).')
-@cli.argument('--ascii', action='store_true', help='Render layout box drawings in ASCII only.')
+@cli.argument('--ascii', action='store_true', default='windows' in platform_id, help='Render layout box drawings in ASCII only.')
 @cli.subcommand('Keyboard information.')
 @automagic_keyboard
 @automagic_keymap

--- a/lib/python/qmk/cli/info.py
+++ b/lib/python/qmk/cli/info.py
@@ -146,9 +146,6 @@ def info(cli):
 
     platform_id = platform.platform().lower()
 
-    if 'windows' in platform_id:
-        cli.config.info.ascii = True
-
     # Build the info.json file
     kb_info_json = info_json(cli.config.info.keyboard)
 

--- a/lib/python/qmk/cli/info.py
+++ b/lib/python/qmk/cli/info.py
@@ -16,7 +16,7 @@ ROW_LETTERS = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnop'
 COL_LETTERS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijilmnopqrstuvwxyz'
 
 
-def show_keymap(kb_info_json, title_caps=True):
+def show_keymap(kb_info_json, render_ascii, title_caps=True):
     """Render the keymap in ascii art.
     """
     keymap_path = locate_keymap(cli.config.info.keyboard, cli.config.info.keymap)
@@ -36,19 +36,19 @@ def show_keymap(kb_info_json, title_caps=True):
             else:
                 cli.echo('{fg_cyan}layer_%s{fg_reset}:', layer_num)
 
-            print(render_layout(kb_info_json['layouts'][layout_name]['layout'], layer))
+            print(render_layout(kb_info_json['layouts'][layout_name]['layout'], render_ascii, layer))
 
 
-def show_layouts(kb_info_json, title_caps=True):
+def show_layouts(kb_info_json, render_ascii, title_caps=True):
     """Render the layouts with info.json labels.
     """
-    for layout_name, layout_art in render_layouts(kb_info_json).items():
+    for layout_name, layout_art in render_layouts(kb_info_json, render_ascii).items():
         title = layout_name.title() if title_caps else layout_name
         cli.echo('{fg_cyan}%s{fg_reset}:', title)
         print(layout_art)  # Avoid passing dirty data to cli.echo()
 
 
-def show_matrix(kb_info_json, title_caps=True):
+def show_matrix(kb_info_json, render_ascii, title_caps=True):
     """Render the layout with matrix labels in ascii art.
     """
     for layout_name, layout in kb_info_json['layouts'].items():
@@ -69,7 +69,7 @@ def show_matrix(kb_info_json, title_caps=True):
         else:
             cli.echo('{fg_blue}matrix_%s{fg_reset}:', layout_name)
 
-        print(render_layout(kb_info_json['layouts'][layout_name]['layout'], labels))
+        print(render_layout(kb_info_json['layouts'][layout_name]['layout'], render_ascii, labels))
 
 
 def print_friendly_output(kb_info_json):
@@ -91,13 +91,13 @@ def print_friendly_output(kb_info_json):
     cli.echo('{fg_blue}Bootloader{fg_reset}: %s', kb_info_json.get('bootloader', 'Unknown'))
 
     if cli.config.info.layouts:
-        show_layouts(kb_info_json, True)
+        show_layouts(kb_info_json, cli.config.info.ascii, True)
 
     if cli.config.info.matrix:
-        show_matrix(kb_info_json, True)
+        show_matrix(kb_info_json, cli.config.info.ascii, True)
 
     if cli.config_source.info.keymap and cli.config_source.info.keymap != 'config_file':
-        show_keymap(kb_info_json, True)
+        show_keymap(kb_info_json, cli.config.info.ascii, True)
 
 
 def print_text_output(kb_info_json):
@@ -110,13 +110,13 @@ def print_text_output(kb_info_json):
             cli.echo('{fg_blue}%s{fg_reset}: %s', key, kb_info_json[key])
 
     if cli.config.info.layouts:
-        show_layouts(kb_info_json, False)
+        show_layouts(kb_info_json, cli.config.info.ascii, False)
 
     if cli.config.info.matrix:
-        show_matrix(kb_info_json, False)
+        show_matrix(kb_info_json, cli.config.info.ascii, False)
 
     if cli.config_source.info.keymap and cli.config_source.info.keymap != 'config_file':
-        show_keymap(kb_info_json, False)
+        show_keymap(kb_info_json, cli.config.info.ascii, False)
 
 
 @cli.argument('-kb', '--keyboard', help='Keyboard to show info for.')
@@ -124,6 +124,7 @@ def print_text_output(kb_info_json):
 @cli.argument('-l', '--layouts', action='store_true', help='Render the layouts.')
 @cli.argument('-m', '--matrix', action='store_true', help='Render the layouts with matrix information.')
 @cli.argument('-f', '--format', default='friendly', arg_only=True, help='Format to display the data in (friendly, text, json) (Default: friendly).')
+@cli.argument('--ascii', action='store_true', help='Render layout box drawings in ASCII only.')
 @cli.subcommand('Keyboard information.')
 @automagic_keyboard
 @automagic_keymap

--- a/lib/python/qmk/keyboard.py
+++ b/lib/python/qmk/keyboard.py
@@ -9,6 +9,25 @@ from glob import glob
 from qmk.c_parse import parse_config_h_file
 from qmk.makefile import parse_rules_mk_file
 
+BOX_DRAWING_CHARACTERS = {  # noqa: this reads better across multiple lines
+    "unicode": {
+        "tl": "┌",
+        "tr": "┐",
+        "bl": "└",
+        "br": "┘",
+        "v": "│",
+        "h": "─"
+    },
+    "ascii": {
+        "tl": " ",
+        "tr": " ",
+        "bl": "|",
+        "br": "|",
+        "v": "|",
+        "h": "_"
+    }
+}
+
 base_path = os.path.join(os.getcwd(), "keyboards") + os.path.sep
 
 
@@ -72,10 +91,11 @@ def rules_mk(keyboard):
     return rules
 
 
-def render_layout(layout_data, key_labels=None):
+def render_layout(layout_data, render_ascii, key_labels=None):
     """Renders a single layout.
     """
     textpad = [array('u', ' ' * 200) for x in range(50)]
+    style = 'ascii' if render_ascii else 'unicode'
 
     for key in layout_data:
         x = ceil(key.get('x', 0) * 4)
@@ -97,13 +117,13 @@ def render_layout(layout_data, key_labels=None):
             label = label[:label_len]
 
         label_blank = ' ' * label_len
-        label_border = '─' * label_len
+        label_border = BOX_DRAWING_CHARACTERS[style]['h'] * label_len
         label_middle = label + ' '*label_leftover  # noqa: yapf insists there be no whitespace around *
 
-        top_line = array('u', '┌' + label_border + '┐')
-        lab_line = array('u', '│' + label_middle + '│')
-        mid_line = array('u', '│' + label_blank + '│')
-        bot_line = array('u', '└' + label_border + "┘")
+        top_line = array('u', BOX_DRAWING_CHARACTERS[style]['tl'] + label_border + BOX_DRAWING_CHARACTERS[style]['tr'])
+        lab_line = array('u', BOX_DRAWING_CHARACTERS[style]['v'] + label_middle + BOX_DRAWING_CHARACTERS[style]['v'])
+        mid_line = array('u', BOX_DRAWING_CHARACTERS[style]['v'] + label_blank + BOX_DRAWING_CHARACTERS[style]['v'])
+        bot_line = array('u', BOX_DRAWING_CHARACTERS[style]['bl'] + label_border + BOX_DRAWING_CHARACTERS[style]['br'])
 
         textpad[y][x:x + w] = top_line
         textpad[y + 1][x:x + w] = lab_line
@@ -119,13 +139,13 @@ def render_layout(layout_data, key_labels=None):
     return '\n'.join(lines)
 
 
-def render_layouts(info_json):
+def render_layouts(info_json, render_ascii):
     """Renders all the layouts from an `info_json` structure.
     """
     layouts = {}
 
     for layout in info_json['layouts']:
         layout_data = info_json['layouts'][layout]['layout']
-        layouts[layout] = render_layout(layout_data)
+        layouts[layout] = render_layout(layout_data, render_ascii)
 
     return layouts

--- a/lib/python/qmk/keyboard.py
+++ b/lib/python/qmk/keyboard.py
@@ -9,14 +9,14 @@ from glob import glob
 from qmk.c_parse import parse_config_h_file
 from qmk.makefile import parse_rules_mk_file
 
-BOX_DRAWING_CHARACTERS = {  # noqa: this reads better across multiple lines
+BOX_DRAWING_CHARACTERS = {
     "unicode": {
         "tl": "┌",
         "tr": "┐",
         "bl": "└",
         "br": "┘",
         "v": "│",
-        "h": "─"
+        "h": "─",
     },
     "ascii": {
         "tl": " ",
@@ -24,8 +24,8 @@ BOX_DRAWING_CHARACTERS = {  # noqa: this reads better across multiple lines
         "bl": "|",
         "br": "|",
         "v": "|",
-        "h": "_"
-    }
+        "h": "_",
+    },
 }
 
 base_path = os.path.join(os.getcwd(), "keyboards") + os.path.sep
@@ -96,6 +96,7 @@ def render_layout(layout_data, render_ascii, key_labels=None):
     """
     textpad = [array('u', ' ' * 200) for x in range(50)]
     style = 'ascii' if render_ascii else 'unicode'
+    box_chars = BOX_DRAWING_CHARACTERS[style]
 
     for key in layout_data:
         x = ceil(key.get('x', 0) * 4)
@@ -117,13 +118,13 @@ def render_layout(layout_data, render_ascii, key_labels=None):
             label = label[:label_len]
 
         label_blank = ' ' * label_len
-        label_border = BOX_DRAWING_CHARACTERS[style]['h'] * label_len
+        label_border = box_chars['h'] * label_len
         label_middle = label + ' '*label_leftover  # noqa: yapf insists there be no whitespace around *
 
-        top_line = array('u', BOX_DRAWING_CHARACTERS[style]['tl'] + label_border + BOX_DRAWING_CHARACTERS[style]['tr'])
-        lab_line = array('u', BOX_DRAWING_CHARACTERS[style]['v'] + label_middle + BOX_DRAWING_CHARACTERS[style]['v'])
-        mid_line = array('u', BOX_DRAWING_CHARACTERS[style]['v'] + label_blank + BOX_DRAWING_CHARACTERS[style]['v'])
-        bot_line = array('u', BOX_DRAWING_CHARACTERS[style]['bl'] + label_border + BOX_DRAWING_CHARACTERS[style]['br'])
+        top_line = array('u', box_chars['tl'] + label_border + box_chars['tr'])
+        lab_line = array('u', box_chars['v'] + label_middle + box_chars['v'])
+        mid_line = array('u', box_chars['v'] + label_blank + box_chars['v'])
+        bot_line = array('u', box_chars['bl'] + label_border + box_chars['br'])
 
         textpad[y][x:x + w] = top_line
         textpad[y + 1][x:x + w] = lab_line

--- a/lib/python/qmk/tests/test_cli_commands.py
+++ b/lib/python/qmk/tests/test_cli_commands.py
@@ -1,6 +1,10 @@
+import platform
+
 from subprocess import STDOUT, PIPE
 
 from qmk.commands import run
+
+is_windows = 'windows' in platform.platform().lower()
 
 
 def check_subcommand(command, *args):
@@ -148,7 +152,11 @@ def test_info_keymap_render():
     check_returncode(result)
     assert 'Keyboard Name: handwired/onekey/pytest' in result.stdout
     assert 'Processor: STM32F303' in result.stdout
-    assert '│A │' in result.stdout
+
+    if is_windows:
+        assert '|A |' in result.stdout
+    else:
+        assert '│A │' in result.stdout
 
 
 def test_info_matrix_render():
@@ -157,7 +165,12 @@ def test_info_matrix_render():
     assert 'Keyboard Name: handwired/onekey/pytest' in result.stdout
     assert 'Processor: STM32F303' in result.stdout
     assert 'LAYOUT_ortho_1x1' in result.stdout
-    assert '│0A│' in result.stdout
+
+    if is_windows:
+        assert '|0A|' in result.stdout
+    else:
+        assert '│0A│' in result.stdout
+
     assert 'Matrix for "LAYOUT_ortho_1x1"' in result.stdout
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Replaced #10734 with something more useful.

MinGW Python on MSYS2 has trouble rendering the box drawing characters (because it's a native binary and thus thinks the character set is cp1252). As a hacky workaround, we can use ASCII characters instead.

![image](https://user-images.githubusercontent.com/4781841/97628253-900f7400-1a80-11eb-974c-780c0453a885.png)

It's not as pretty, but it's something.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
