### PR TITLE
NK65 eeprom compatibility with 128KB and 256KB

### DIFF
--- a/keyboards/nk65/config.h
+++ b/keyboards/nk65/config.h
@@ -144,3 +144,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // VIA lighting is handled by the keyboard-level code
 #define VIA_CUSTOM_LIGHTING_ENABLE
+
+/* Custom EEPROM start addressing. This is to support
+ * both 128kb and 256kb versions of F303.
+ * Register 0x1FFFF7CC holds the size of the flash memory.
+ */
+#define EEPROM_START_ADDRESS
+#define FEE_MCU_FLASH_SIZE                              \
+({                                                      \
+    uint16_t (*flash_size) = (uint16_t*)(0x1FFFF7CC );  \
+    *flash_size;                                        \
+})

--- a/keyboards/nk65/config.h
+++ b/keyboards/nk65/config.h
@@ -152,6 +152,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define EEPROM_START_ADDRESS
 #define FEE_MCU_FLASH_SIZE                              \
 ({                                                      \
-    uint16_t (*flash_size) = (uint16_t*)(0x1FFFF7CC );  \
+    uint16_t (*flash_size) = (uint16_t*)FLASHSIZE_BASE;  \
     *flash_size;                                        \
 })

--- a/keyboards/nk65/nk65.c
+++ b/keyboards/nk65/nk65.c
@@ -20,7 +20,7 @@
 #include "nk65.h"
 #include "drivers/issi/is31fl3733.h"
 
-/* Indicator LEDS are part of the LED driver 
+/* Indicator LEDS are part of the LED driver
  * Top LED is blue only. LED driver 2 RGB 7 Green channel
  * Middle LED is blue and red. LED driver 2 RGB 6 Red and Blue channel
  * Bottom LED is red only LED driver 2 RGB 6 Green channel.
@@ -48,7 +48,7 @@ __attribute__((weak)) layer_state_t layer_state_set_user(layer_state_t state) {
     if (state & (1UL << 2)) {
         G = 255;
     }
-    
+
     IS31FL3733_set_color( 6+64-1, R, G, B );
   return state;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

Due to some manufacturing constrains, a large number of NK65s have been made (but not sold) with a F303CB chip.
After contacting ST the Application Engineer has informed me that CB and CC share the same die, but CB is validated to have working Flash up to 128KB. This means that in both versions of the chip, 256KB are addressable but not necessarily functioning. 

This workaround asks for the size of the flash memory from the internal register. This means that it will auto adjust to 128KB or 256KB.

This saves adding a whole new chip class "F303xB" that chibios doesn't have, probably because the only difference is the flash size. Downside is that the every time there is an eeprom access an extra cycle is used to read that register. This is the reason I opted to not add it in core.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
