### PR TITLE
[Keyboard] Fix unused variables in mschwingen modelm

### DIFF
--- a/keyboards/mschwingen/modelm/modelm.c
+++ b/keyboards/mschwingen/modelm/modelm.c
@@ -47,19 +47,19 @@ static cRGB led[RGBLED_NUM] = {{255, 255, 255}, {255, 255, 255}, {255, 255, 255}
 
 static const cRGB black = {.r = 0, .g = 0, .b = 0};
 
-static const cRGB green  = {.r = 0, .g = BRIGHT, .b = 0};
-static const cRGB lgreen = {.r = 0, .g = DIM, .b = 0};
+static const __attribute__((unused)) cRGB green  = {.r = 0, .g = BRIGHT, .b = 0};
+static const __attribute__((unused)) cRGB lgreen = {.r = 0, .g = DIM, .b = 0};
 
-static const cRGB red  = {.r = BRIGHT, .g = 0, .b = 0};
-static const cRGB lred = {.r = DIM, .g = 0, .b = 0};
+static const __attribute__((unused)) cRGB red  = {.r = BRIGHT, .g = 0, .b = 0};
+static const __attribute__((unused)) cRGB lred = {.r = DIM, .g = 0, .b = 0};
 
-static const cRGB blue  = {.r = 0, .g = 0, .b = BRIGHT};
-static const cRGB lblue = {.r = 0, .g = 0, .b = DIM};
+static const __attribute__((unused)) cRGB blue  = {.r = 0, .g = 0, .b = BRIGHT};
+static const __attribute__((unused)) cRGB lblue = {.r = 0, .g = 0, .b = DIM};
 
-static const cRGB turq  = {.r = 0, .g = BRIGHT, .b = BRIGHT};
-static const cRGB lturq = {.r = 0, .g = DIM, .b = DIM};
+static const __attribute__((unused)) cRGB turq  = {.r = 0, .g = BRIGHT, .b = BRIGHT};
+static const __attribute__((unused)) cRGB lturq = {.r = 0, .g = DIM, .b = DIM};
 
-static const cRGB white = {.r = BRIGHT, .g = BRIGHT, .b = BRIGHT};
+static const __attribute__((unused)) cRGB white = {.r = BRIGHT, .g = BRIGHT, .b = BRIGHT};
 
 static led_t   led_state;
 static uint8_t layer;


### PR DESCRIPTION
Specifically, the lgreen variable isn't used, and avr-gcc 8.x complains about this. To prevent it from being an issue, just set all of these led variables to be unused.

## Types of Changes
- [x] Bugfix
- [x] Keyboard (addition or update)

## Issues Fixed or Closed by This PR

* Another case of avr-gcc 8+ not liking how things are done

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
