### PR TITLE
Add support for using podman to util/docker_build.sh

### DIFF
--- a/docs/getting_started_docker.md
+++ b/docs/getting_started_docker.md
@@ -4,8 +4,9 @@ This project includes a Docker workflow that will allow you to build a new firmw
 
 ## Requirements
 
-The main prerequisite is a working `docker` install.
+The main prerequisite is a working `docker` or `podman` install.
 * [Docker CE](https://docs.docker.com/install/#supported-platforms)
+* [Podman](https://podman.io/getting-started/installation)
 
 ## Usage
 
@@ -36,6 +37,13 @@ You can also start the script without any parameters, in which case it will ask 
 ```bash
 util/docker_build.sh
 # Reads parameters as input (leave blank for all keyboards/keymaps)
+```
+
+You can manually set which container runtime you want to use by setting the `RUNTIME` environment variable to it's name or path.
+By default docker or podman are automatically detected and docker is preferred over podman.
+
+```bash
+RUNTIME="podman" util/docker_build.sh keyboard:keymap:target
 ```
 
 ## FAQ

--- a/util/docker_build.sh
+++ b/util/docker_build.sh
@@ -17,11 +17,26 @@ done
 if [ $# -gt 1 ]; then
 	errcho "$USAGE"
 	exit 1
-elif ! command -v docker >/dev/null 2>&1; then
-	errcho "Error: docker not found"
-	errcho "See https://docs.docker.com/install/#supported-platforms for installation instructions"
-	exit 2
 fi
+
+# Allow $RUNTIME to be overriden by the user as an environment variable
+# Else check if either docker or podman exit and set them as runtime
+# if none are found error out
+if [ -z "$RUNTIME" ]; then
+	if command -v docker >/dev/null 2>&1; then
+		RUNTIME="docker"
+	elif command -v podman >/dev/null 2>&1; then
+		RUNTIME="podman"
+	else
+		errcho "Error: no compatible container runtime found."
+		errcho "Either podman or docker are required."
+		errcho "See https://podman.io/getting-started/installation"
+		errcho "or https://docs.docker.com/install/#supported-platforms"
+		errcho "for installation instructions."
+		exit 2
+	fi
+fi
+	
 
 # Determine arguments
 if [ $# -eq 0 ]; then
@@ -41,20 +56,26 @@ if [ -z "$keyboard" ]; then
 	keyboard=all
 fi
 if [ -n "$target" ]; then
-	if [ "$(uname)" = "Linux" ] || docker-machine active >/dev/null 2>&1; then
-		usb_args="--privileged -v /dev:/dev"
-	else
+	# IF we are using docker on non Linux and docker-machine isn't working print an error
+	# ELSE set usb_args
+	if [ ! "$(uname)" = "Linux" ] && [ "$RUNTIME" = "docker" ] && ! docker-machine active >/dev/null 2>&1; then
 		errcho "Error: target requires docker-machine to work on your platform"
 		errcho "See http://gw.tnode.com/docker/docker-machine-with-usb-support-on-windows-macos"
 		errcho "Consider flashing with QMK Toolbox (https://github.com/qmk/qmk_toolbox) instead"
 		exit 3
+	else
+		usb_args="--privileged -v /dev:/dev"
 	fi
 fi
 dir=$(pwd -W 2>/dev/null) || dir=$PWD  # Use Windows path if on Windows
 
+if [ "$RUNTIME" = "docker" ]; then
+	uid_arg="--user $(id -u):$(id -g)"
+fi
+
 # Run container and build firmware
-docker run --rm -it $usb_args \
-	--user $(id -u):$(id -g) \
+"$RUNTIME" run --rm -it $usb_args \
+	$uid_arg \
 	-w /qmk_firmware \
 	-v "$dir":/qmk_firmware \
 	-e ALT_GET_KEYBOARDS=true \


### PR DESCRIPTION
## Description

* break out runtime into the RUNTIME variable
* allows RUNTIME to be set by the user
* decides on docker or podman if docker isn't avaible
* rewrote check for docker-machine to account only for docker runtime
* put --user arg into a variable only to be used with docker
  this is not needed with podman as podman maps the containers root id
  to the users id.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
