### PR TITLE
[Bug] Fix issue with register_button function

### DIFF
--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -237,6 +237,7 @@ void register_button(bool pressed, enum mouse_buttons button) {
     report_mouse_t currentReport = pointing_device_get_report();
     currentReport.buttons        = pressed ? currentReport.buttons | button : currentReport.buttons & ~button;
     pointing_device_set_report(currentReport);
+    pointing_device_send();
 #    endif
 }
 #endif


### PR DESCRIPTION
Specifically, it's not enough to just set the report here, you need to also send the report immediately.  

It's making the assumption that every `pointing_device_task()` call will send the report to the host system.  Normally, that would happen. But doing that keeps the host system awake. The best/proper way to handle this is to immediately send the report after it's been changed.

I did not catch this until testing and user feedback. 

## Types of Changes

- [x] Core
- [x] Bugfix

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
