### PR TITLE
Fix firmware size calculations for ARM MCUs.

### DIFF
--- a/tmk_core/arm_atsam.mk
+++ b/tmk_core/arm_atsam.mk
@@ -32,12 +32,14 @@ CFLAGS += $(COMPILEFLAGS)
 CXXFLAGS += $(COMPILEFLAGS)
 CXXFLAGS += -fno-exceptions -std=c++11
 
+LDSCRIPT = $(LIB_PATH)/arm_atsam/packs/atmel/SAMD51_DFP/1.0.70/gcc/gcc/samd51j18a_flash.ld
+
 LDFLAGS +=-Wl,--gc-sections
 LDFLAGS += -Wl,-Map="%OUT%%PROJ_NAME%.map"
 LDFLAGS += -Wl,--start-group
 LDFLAGS += -Wl,--end-group
 LDFLAGS += --specs=rdimon.specs
-LDFLAGS += -T$(LIB_PATH)/arm_atsam/packs/atmel/SAMD51_DFP/1.0.70/gcc/gcc/samd51j18a_flash.ld
+LDFLAGS += -T$(LDSCRIPT)
 
 OPT_DEFS += -DPROTOCOL_ARM_ATSAM
 


### PR DESCRIPTION
##  Description

Updates to the main `rules.mk` file to allow for firmware size calculation for ARM cores, using the output from arm-none-eabi-size and the linker. Open to thoughts on which non-massdrop keyboards to test-compile and whether I need to add a specific bootloader size check.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* N/A

## Checklist

- [x My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
