### PR TITLE
[Keyboard] Fixes for PloopyCo mouse and readme

### DIFF
--- a/keyboards/ploopyco/mouse/mouse.c
+++ b/keyboards/ploopyco/mouse/mouse.c
@@ -140,7 +140,7 @@ __attribute__((weak)) void process_mouse(report_mouse_t* mouse_report) {
         if (debug_mouse) dprintf("Cons] X: %d, Y: %d\n", data.dx, data.dy);
         // dprintf("Elapsed:%u, X: %f Y: %\n", i, pgm_read_byte(firmware_data+i));
 
-        process_mouse_user(mouse_report, data.dx, data.dy);
+        process_mouse_user(mouse_report, data.dx, -data.dy);
     }
 }
 

--- a/keyboards/ploopyco/mouse/readme.md
+++ b/keyboards/ploopyco/mouse/readme.md
@@ -2,9 +2,8 @@
 
 ![Ploopyco Mouse](https://www.ploopy.co/uploads/1/2/7/6/127652558/s905404500980887952_p10_i19_w1414.jpeg)
 
-It's a DIY, QMK Powered Trackball!!!!
+It's a DIY, QMK Powered Mouse!!!!
 
-Everything works. However the scroll wheel has some issues and acts very odd.
 
 * Keyboard Maintainer: [PloopyCo](https://github.com/ploopyco), [Drashna Jael're](https://github.com/drashna/), [Germ](https://github.com/germ/)
 * Hardware Supported: ATMega32u4 8MHz(3.3v)  
@@ -51,27 +50,3 @@ To configure/set your own array, there are two defines to use, `PLOOPY_DPI_OPTIO
 The `PLOOPY_DPI_OPTIONS` array sets the values that you want to be able to cycle through, and the order they are in.  The "default" define lets the firmware know which of these options is the default and should be loaded by default. 
 
 The `DPI_CONFIG` macro will cycle through the values in the array, each time you hit it.  And it stores this value in persistent memory, so it will load it the next time the device powers up. 
-
-
-# Programming QMK-DFU onto the PloopyCo Mouse
-
-If you would rather have DFU on this board, you can use the QMK-DFU bootloader on the device.  To do so, you want to run: 
-
-    make ploopyco/trackball:default:production
-
-Once you have that, you'll need to [ISP Flash](https://docs.qmk.fm/#/isp_flashing_guide) the chip with the new bootloader hex file created (or the production hex), and set the fuses:
-
-
-| Fuse     | Setting          |
-|----------|------------------|
-| Low      | `0xDF`           |
-| High     | `0xD8` or `0x98` |
-| Extended | `0xCB`           |
-
-Original (Caterina) settings: 
-
-| Fuse     | Setting          |
-|----------|------------------|
-| Low      | `0xFF`           |
-| High     | `0xD8`           |
-| Extended | `0xFE`           |

--- a/keyboards/ploopyco/mouse/rules.mk
+++ b/keyboards/ploopyco/mouse/rules.mk
@@ -5,7 +5,7 @@ MCU = atmega32u4
 F_CPU = 8000000
 
 # Bootloader selection
-BOOTLOADER = qmk-dfu
+BOOTLOADER = atmel-dfu
 
 # Build Options
 #   change yes to no to disable

--- a/keyboards/ploopyco/trackball/readme.md
+++ b/keyboards/ploopyco/trackball/readme.md
@@ -4,8 +4,6 @@
 
 It's a DIY, QMK Powered Trackball!!!!
 
-Everything works. However the scroll wheel has some issues and acts very odd.
-
 * Keyboard Maintainer: [PloopyCo](https://github.com/ploopyco), [Drashna Jael're](https://github.com/drashna/), [Germ](https://github.com/germ/)
 * Hardware Supported: ATMega32u4 8MHz(3.3v)  
 * Hardware Availability: [Store](https://ploopy.co), [GitHub](https://github.com/ploopyco)


### PR DESCRIPTION

## Description

* Fix inverted Y access. 
* Remote ISP flashing info (not needed on the mouse)
* Minor tweaks


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bugfix
- [x] Keyboard (addition or update)


## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
