### PR TITLE
Action tapping refactor

### DIFF
--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -147,16 +147,13 @@ void reset_keyboard(void) {
     bootloader_jump();
 }
 
-/* Convert record into usable keycode via the contained event. */
-uint16_t get_record_keycode(keyrecord_t *record, bool update_layer_cache) { return get_event_keycode(record->event, update_layer_cache); }
-
 /* Convert event into usable keycode. Checks the layer cache to ensure that it
  * retains the correct keycode after a layer change, if the key is still pressed.
  * "update_layer_cache" is to ensure that it only updates the layer cache when
  * appropriate, otherwise, it will update it and cause layer tap (and other keys)
  * from triggering properly.
  */
-uint16_t get_event_keycode(keyevent_t event, bool update_layer_cache) {
+static uint16_t get_event_keycode(keyevent_t event, bool update_layer_cache) {
 #if !defined(NO_ACTION_LAYER) && !defined(STRICT_LAYER_RELEASE)
     /* TODO: Use store_or_get_action() or a similar function. */
     if (!disable_action_cache) {
@@ -173,6 +170,9 @@ uint16_t get_event_keycode(keyevent_t event, bool update_layer_cache) {
 #endif
         return keymap_key_to_keycode(layer_switch_get_layer(event.key), event.key);
 }
+
+/* Convert record into usable keycode via the contained event. */
+uint16_t get_record_keycode(keyrecord_t *record, bool update_layer_cache) { return get_event_keycode(record->event, update_layer_cache); }
 
 /* Get keycode, and then call keyboard function */
 void post_process_record_quantum(keyrecord_t *record) {

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -327,7 +327,6 @@ void     matrix_scan_kb(void);
 void     matrix_init_user(void);
 void     matrix_scan_user(void);
 uint16_t get_record_keycode(keyrecord_t *record, bool update_layer_cache);
-uint16_t get_event_keycode(keyevent_t event, bool update_layer_cache);
 bool     process_action_kb(keyrecord_t *record);
 bool     process_record_kb(uint16_t keycode, keyrecord_t *record);
 bool     process_record_user(uint16_t keycode, keyrecord_t *record);

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -363,7 +363,7 @@ void process_action(keyrecord_t *record, action_t action) {
 #    if !defined(IGNORE_MOD_TAP_INTERRUPT) || defined(IGNORE_MOD_TAP_INTERRUPT_PER_KEY)
                             if (
 #        ifdef IGNORE_MOD_TAP_INTERRUPT_PER_KEY
-                                !get_ignore_mod_tap_interrupt(get_event_keycode(record->event, false), record) &&
+                                !get_ignore_mod_tap_interrupt(get_record_keycode(record, false), record) &&
 #        endif
                                 record->tap.interrupted) {
                                 dprint("mods_tap: tap: cancel: add_mods\n");
@@ -743,7 +743,7 @@ void process_action(keyrecord_t *record, action_t action) {
             } else {
                 if (
 #        ifdef RETRO_TAPPING_PER_KEY
-                    get_retro_tapping(get_event_keycode(record->event, false), record) &&
+                    get_retro_tapping(get_record_keycode(record, false), record) &&
 #        endif
                     retro_tapping_counter == 2) {
                     tap_code(action.layer_tap.code);

--- a/tmk_core/common/action_tapping.h
+++ b/tmk_core/common/action_tapping.h
@@ -30,7 +30,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define WAITING_BUFFER_SIZE 8
 
 #ifndef NO_ACTION_TAPPING
-uint16_t get_event_keycode(keyevent_t event, bool update_layer_cache);
+uint16_t get_record_keycode(keyrecord_t *record, bool update_layer_cache);
 void     action_tapping_process(keyrecord_t record);
 
 uint16_t get_tapping_term(uint16_t keycode, keyrecord_t *record);


### PR DESCRIPTION
## Description

Refactor the massive nested ladder of death in `action_tapping.c`.

Also, throw away `get_event_keycode` in favor of `get_record_keycode`

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
