### PR TITLE
Add references for is_keyboard_left()

### DIFF
--- a/tmk_core/common/bootmagic_lite.c
+++ b/tmk_core/common/bootmagic_lite.c
@@ -1,7 +1,5 @@
 #include "quantum.h"
 
-bool is_keyboard_left(void);
-
 /** \brief Reset eeprom
  *
  * ...just incase someone wants to only change the eeprom behaviour

--- a/tmk_core/common/keyboard.c
+++ b/tmk_core/common/keyboard.c
@@ -222,6 +222,12 @@ void keyboard_setup(void) {
  */
 __attribute__((weak)) bool is_keyboard_master(void) { return true; }
 
+/** \brief is_keyboard_left
+ *
+ * FIXME: needs doc
+ */
+__attribute__((weak)) bool is_keyboard_left(void) { return true; }
+
 /** \brief should_process_keypress
  *
  * Override this function if you have a condition where keypresses processing should change:

--- a/tmk_core/common/keyboard.h
+++ b/tmk_core/common/keyboard.h
@@ -63,6 +63,8 @@ void keyboard_task(void);
 void keyboard_set_leds(uint8_t leds);
 /* it runs whenever code has to behave differently on a slave */
 bool is_keyboard_master(void);
+/* it runs whenever code has to behave differently on left vs right split */
+bool is_keyboard_left(void);
 
 void keyboard_pre_init_kb(void);
 void keyboard_pre_init_user(void);


### PR DESCRIPTION
## Description

This function is used a couple of places for split keyboards, but never actually set in the core (outside of split code), so there is no direct way to reference it. 

This adds it to `keyboard.[ch]` so that it can be used everywhere. 

## Types of Changes

- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* DMs on discord

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
