### PR TITLE
Add support for 4 IS31FL3731 devices

### DIFF
--- a/quantum/rgb_matrix_drivers.c
+++ b/quantum/rgb_matrix_drivers.c
@@ -34,6 +34,12 @@ static void init(void) {
 #        ifdef DRIVER_ADDR_2
     IS31FL3731_init(DRIVER_ADDR_2);
 #        endif
+#        ifdef DRIVER_ADDR_3
+    IS31FL3731_init(DRIVER_ADDR_3);
+#        endif
+#        ifdef DRIVER_ADDR_4
+    IS31FL3731_init(DRIVER_ADDR_4);
+#        endif
 #    elif defined(IS31FL3733)
     IS31FL3733_init(DRIVER_ADDR_1, 0);
 #    elif defined(IS31FL3737)
@@ -60,6 +66,12 @@ static void init(void) {
 #        ifdef DRIVER_ADDR_2
     IS31FL3731_update_led_control_registers(DRIVER_ADDR_2, 1);
 #        endif
+#        ifdef DRIVER_ADDR_3
+    IS31FL3731_update_led_control_registers(DRIVER_ADDR_3, 2);
+#        endif
+#        ifdef DRIVER_ADDR_4
+    IS31FL3731_update_led_control_registers(DRIVER_ADDR_4, 3);
+#        endif
 #    elif defined(IS31FL3733)
     IS31FL3733_update_led_control_registers(DRIVER_ADDR_1, 0);
     IS31FL3733_update_led_control_registers(DRIVER_ADDR_2, 1);
@@ -75,6 +87,12 @@ static void flush(void) {
     IS31FL3731_update_pwm_buffers(DRIVER_ADDR_1, 0);
 #        ifdef DRIVER_ADDR_2
     IS31FL3731_update_pwm_buffers(DRIVER_ADDR_2, 1);
+#        endif
+#        ifdef DRIVER_ADDR_3
+    IS31FL3731_update_pwm_buffers(DRIVER_ADDR_3, 2);
+#        endif
+#        ifdef DRIVER_ADDR_4
+    IS31FL3731_update_pwm_buffers(DRIVER_ADDR_4, 3);
 #        endif
 }
 


### PR DESCRIPTION

## Description

This is a simple change.Support for IS31FL3731 has been changed from 2 to 4.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
