### PR TITLE
[Keymap] clean up helix:five_rows keymap

### DIFF
--- a/keyboards/helix/rev2/keymaps/five_rows/keymap.c
+++ b/keyboards/helix/rev2/keymaps/five_rows/keymap.c
@@ -1,11 +1,9 @@
 #include QMK_KEYBOARD_H
+#include "util.h"
 #include "bootloader.h"
 #ifdef PROTOCOL_LUFA
 #include "lufa.h"
 #include "split_util.h"
-#endif
-#ifdef AUDIO_ENABLE
-  #include "audio.h"
 #endif
 #ifdef CONSOLE_ENABLE
   #include <print.h>
@@ -282,28 +280,10 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 #endif
 
 
-#ifdef AUDIO_ENABLE
-
-float tone_qwerty[][2]     = SONG(QWERTY_SOUND);
-float tone_dvorak[][2]     = SONG(DVORAK_SOUND);
-float tone_colemak[][2]    = SONG(COLEMAK_SOUND);
-float tone_plover[][2]     = SONG(PLOVER_SOUND);
-float tone_plover_gb[][2]  = SONG(PLOVER_GOODBYE_SOUND);
-float music_scale[][2]     = SONG(MUSIC_SCALE_SOUND);
-#endif
-
 int current_default_layer;
 
-uint32_t default_layer_state_set_kb(uint32_t state) {
-    // 1<<_QWERTY  - 1 == 1 - 1 == _QWERTY (=0)
-    // 1<<_COLEMAK - 1 == 2 - 1 == _COLEMAK (=1)
-    current_default_layer = state - 1;
-    // 1<<_DVORAK  - 2 == 4 - 2 == _DVORAK (=2)
-    if ( current_default_layer == 3 ) current_default_layer -= 1;
-    // 1<<_EUCALYN - 5 == 8 - 5 == _EUCALYN (=3)
-    if ( current_default_layer == 7 ) current_default_layer -= 4;
-    // 1<<_KEYPAD  - 12 == 16 - 12 == _KEYPAD (=4)
-    if ( current_default_layer == 15 ) current_default_layer -= 11;
+uint32_t default_layer_state_set_user(uint32_t state) {
+    current_default_layer = biton32(state);
     return state;
 }
 
@@ -326,45 +306,30 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
   switch (keycode) {
     case QWERTY:
       if (record->event.pressed) {
-        #ifdef AUDIO_ENABLE
-          PLAY_SONG(tone_qwerty);
-        #endif
         update_base_layer(_QWERTY);
       }
       return false;
       break;
     case COLEMAK:
       if (record->event.pressed) {
-        #ifdef AUDIO_ENABLE
-          PLAY_SONG(tone_colemak);
-        #endif
         update_base_layer(_COLEMAK);
       }
       return false;
       break;
     case DVORAK:
       if (record->event.pressed) {
-        #ifdef AUDIO_ENABLE
-          PLAY_SONG(tone_dvorak);
-        #endif
         update_base_layer(_DVORAK);
       }
       return false;
       break;
     case EUCALYN:
       if (record->event.pressed) {
-        #ifdef AUDIO_ENABLE
-          PLAY_SONG(tone_dvorak);
-        #endif
         update_base_layer(_EUCALYN);
       }
       return false;
       break;
     case KEYPAD:
       if (record->event.pressed) {
-        #ifdef AUDIO_ENABLE
-          PLAY_SONG(tone_dvorak);
-        #endif
         update_base_layer(_KEYPAD);
       }
       return false;
@@ -412,34 +377,5 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 }
 
 void matrix_init_user(void) {
-#ifdef AUDIO_ENABLE
-    startup_user();
-#endif
-    INIT_HELIX_OLED();
+    INIT_HELIX_OLED(); /* define in layer_number.h */
 }
-
-
-#ifdef AUDIO_ENABLE
-
-void startup_user()
-{
-    _delay_ms(20); // gets rid of tick
-}
-
-void shutdown_user()
-{
-    _delay_ms(150);
-    stop_all_notes();
-}
-
-void music_on_user(void)
-{
-    music_scale_user();
-}
-
-void music_scale_user(void)
-{
-    PLAY_SONG(music_scale);
-}
-
-#endif

--- a/keyboards/helix/rev2/keymaps/five_rows/keymap.c
+++ b/keyboards/helix/rev2/keymaps/five_rows/keymap.c
@@ -20,153 +20,199 @@ enum custom_keycodes {
   DVORAK,
   EUCALYN,
   KEYPAD,
-  KC_xEISU,
-  KC_xKANA,
-  KC_ZERO2,
+  xEISU,
+  xKANA,
+  ZERO2,
   RGBRST
 };
 
+#define LAYOUT_wrapper(...)    LAYOUT(__VA_ARGS__)
+
 //Macros
 #define KC_LOWER  MO(_LOWER)
-#define KC_RABS   LT(_RAISE,KC_BSPC)
-#define KC_RAEN   LT(_RAISE,KC_ENT)
-#define KC_FF12   LT(_PADFUNC,KC_F12)
-#define KC_____   _______
-#define KC_XXXX   XXXXXXX
+#define XXXX      XXXXXXX
+#define ____      _______
 #define KC_ADJ    MO(_ADJUST)
 #define KC_LSMI   LSFT(KC_MINS)
 #define KC_LSEQ   LSFT(KC_EQL)
 #define KC_LSRB   LSFT(KC_RBRC)
 #define KC_LSLB   LSFT(KC_LBRC)
-#define ___       _______
+
+#define _1_2_3_4_5           KC_1, KC_2, KC_3, KC_4, KC_5
+#define _6_7_8_9_0           KC_6, KC_7, KC_8, KC_9, KC_0
+#define L_LOWER2_CAPS_LALT_LGUI_SPC_RABS \
+    KC_LOWER, KC_LOWER, KC_CAPS, KC_LALT, KC_LGUI, KC_SPC, LT(_RAISE,KC_BSPC)
+#define R_RAEN_SPC_RGUI_RALT_APP_LOWER2 \
+    LT(_RAISE,KC_ENT), KC_SPC, KC_RGUI, KC_RALT,  KC_APP, KC_LOWER, KC_LOWER
+
 
 #if MATRIX_ROWS == 10 // HELIX_ROWS == 5
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
   /* Qwerty
-   * ,-----------------------------------------.             ,-----------------------------------------.
-   * | ESC  |   1  |   2  |   3  |   4  |   5  |             |   6  |   7  |   8  |   9  |   0  |  BS  |
-   * |------+------+------+------+------+------|             |------+------+------+------+------+------|
-   * | Tab  |   Q  |   W  |   E  |   R  |   T  |             |   Y  |   U  |   I  |   O  |   P  |  \   |
-   * |------+------+------+------+------+------|             |------+------+------+------+------+------|
-   * | Ctrl |   A  |   S  |   D  |   F  |   G  |             |   H  |   J  |   K  |   L  |   ;  | Ctrl |
-   * |------+------+------+------+------+------+------+------+------+------+------+------+------+------|
-   * | Shift|   Z  |   X  |   C  |   V  |   B  |   `  |   '  |   N  |   M  |   ,  |   .  |   /  | Shift|
-   * |------+------+------+------+------+------+------+------+------+------+------+------+------+------|
-   * |Lower | Lower| Caps |  Alt |  GUI | Space|  BS  | Enter| Space| GUI  | Alt  | Menu |Lower |Lower |
-   * `-------------------------------------------------------------------------------------------------'
+   * ,-----------------------------------.           ,-----------------------------------.
+   * | ESC |  1  |  2  |  3  |  4  |  5  |           |  6  |  7  |  8  |  9  |  0  | BS  |
+   * |-----+-----+-----+-----+-----+-----|           |-----+-----+-----+-----+-----+-----|
+   * | Tab |  Q  |  W  |  E  |  R  |  T  |           |  Y  |  U  |  I  |  O  |  P  |  \  |
+   * |-----+-----+-----+-----+-----+-----|           |-----+-----+-----+-----+-----+-----|
+   * | Ctrl|  A  |  S  |  D  |  F  |  G  |           |  H  |  J  |  K  |  L  |  ;  |Ctrl |
+   * |-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----|
+   * |Shift|  Z  |  X  |  C  |  V  |  B  |  `  |  '  |  N  |  M  |  ,  |  .  |  /  |Shift|
+   * |-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----|
+   * |Lower|Lower|Caps | Alt | GUI |Space|  BS |Enter|Space| GUI | Alt |Menu |Lower|Lower|
+   * `-----------------------------------------------------------------------------------'
    */
-  [_QWERTY] = LAYOUT_kc( \
-      ESC,    1,    2,    3,    4,    5,                  6,    7,    8,    9,    0,  BSPC, \
-      TAB,    Q,    W,    E,    R,    T,                  Y,    U,    I,    O,    P,  BSLS, \
-      LCTL,   A,    S,    D,    F,    G,                  H,    J,    K,    L, SCLN,  RCTL, \
-      LSFT,   Z,    X,    C,    V,    B,    GRV,  QUOT,   N,    M, COMM,  DOT, SLSH,  RSFT, \
-      LOWER, LOWER, CAPS, LALT, LGUI, SPC, RABS,  RAEN, SPC, RGUI, RALT,  APP,LOWER, LOWER \
-      ),
+#define _Q_W_E_R_T           KC_Q, KC_W, KC_E, KC_R, KC_T
+#define _Y_U_I_O_P           KC_Y, KC_U, KC_I, KC_O, KC_P
+#define _A_S_D_F_G           KC_A, KC_S, KC_D, KC_F, KC_G
+#define _H_J_K_L_SCLN        KC_H, KC_J, KC_K, KC_L, KC_SCLN
+#define _Z_X_C_V_B           KC_Z, KC_X, KC_C, KC_V, KC_B
+#define _N_M_COMM_DOT_SLSH   KC_N, KC_M, KC_COMM, KC_DOT, KC_SLSH
+
+  [_QWERTY] = LAYOUT_wrapper( \
+    KC_ESC,   _1_2_3_4_5,                       _6_7_8_9_0,         KC_BSPC, \
+    KC_TAB,   _Q_W_E_R_T,                       _Y_U_I_O_P,         KC_BSLS, \
+    KC_LCTL,  _A_S_D_F_G,                       _H_J_K_L_SCLN,      KC_RCTL, \
+    KC_LSFT,  _Z_X_C_V_B,     KC_GRV,  KC_QUOT, _N_M_COMM_DOT_SLSH, KC_RSFT, \
+    L_LOWER2_CAPS_LALT_LGUI_SPC_RABS,  R_RAEN_SPC_RGUI_RALT_APP_LOWER2  \
+   ),
 
   /* Colemak
-   * ,-----------------------------------------.             ,-----------------------------------------.
-   * | ESC  |   1  |   2  |   3  |   4  |   5  |             |   6  |   7  |   8  |   9  |   0  | Bksp |
-   * |------+------+------+------+------+------|             |------+------+------+------+------+------|
-   * | Tab  |   Q  |   W  |   F  |   P  |   G  |             |   J  |   L  |   U  |   Y  |   ;  | \    |
-   * |------+------+------+------+------+------|             |------+------+------+------+------+------|
-   * | Ctrl |   A  |   R  |   S  |   T  |   D  |             |   H  |   N  |   E  |   I  |   O  | Ctrl |
-   * |------+------+------+------+------+------+------+------+------+------+------+------+------+------|
-   * | Shift|   Z  |   X  |   C  |   V  |   B  |   `  |   '  |   K  |   M  |   ,  |   .  |   /  | Shift|
-   * |------+------+------+------+------+------+------+------+------+------+------+------+------+------|
-   * |Lower | Lower| Caps |  Alt |  GUI | Space|  BS  | Enter| Space| GUI  | Alt  | Menu |Lower |Lower |
-   * `-------------------------------------------------------------------------------------------------'
+   * ,-----------------------------------.           ,-----------------------------------.
+   * | ESC |  1  |  2  |  3  |  4  |  5  |           |  6  |  7  |  8  |  9  |  0  | BS  |
+   * |-----+-----+-----+-----+-----+-----|           |-----+-----+-----+-----+-----+-----|
+   * | Tab |  Q  |  W  |  F  |  P  |  G  |           |  J  |  L  |  U  |  Y  |  ;  |  \  |
+   * |-----+-----+-----+-----+-----+-----|           |-----+-----+-----+-----+-----+-----|
+   * | Ctrl|  A  |  R  |  S  |  T  |  D  |           |  H  |  N  |  E  |  I  |  O  |Ctrl |
+   * |-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----|
+   * |Shift|  Z  |  X  |  C  |  V  |  B  |  `  |  '  |  K  |  M  |  ,  |  .  |  /  |Shift|
+   * |-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----|
+   * |Lower|Lower|Caps | Alt | GUI |Space|  BS |Enter|Space| GUI | Alt |Menu |Lower|Lower|
+   * `-----------------------------------------------------------------------------------'
    */
-  [_COLEMAK] = LAYOUT_kc( \
-      ESC,    1,    2,    3,    4,    5,                  6,    7,    8,    9,    0,  BSPC, \
-      TAB,    Q,    W,    F,    P,    G,                  J,    L,    U,    Y, SCLN,  BSLS, \
-      LCTL,   A,    R,    S,    T,    D,                  H,    N,    E,    I,    O,  RCTL, \
-      LSFT,   Z,    X,    C,    V,    B,    GRV,  QUOT,   K,    M, COMM,  DOT, SLSH,  RSFT, \
-      LOWER, LOWER, CAPS, LALT, LGUI, SPC, RABS,  RAEN, SPC, RGUI, RALT,  APP,LOWER, LOWER \
-      ),
+#define _Q_W_F_P_G           KC_Q, KC_W, KC_F, KC_P, KC_G
+#define _J_L_U_Y_SCLN        KC_J, KC_L, KC_U, KC_Y, KC_SCLN
+#define _A_R_S_T_D           KC_A, KC_R, KC_S, KC_T, KC_D
+#define _H_N_E_I_O           KC_H, KC_N, KC_E, KC_I, KC_O
+#define _Z_X_C_V_B           KC_Z, KC_X, KC_C, KC_V, KC_B
+#define _K_M_COMM_DOT_SLSH   KC_K, KC_M, KC_COMM, KC_DOT, KC_SLSH
+
+  [_COLEMAK] = LAYOUT_wrapper( \
+    KC_ESC,   _1_2_3_4_5,                       _6_7_8_9_0,         KC_BSPC, \
+    KC_TAB,   _Q_W_F_P_G,                       _J_L_U_Y_SCLN,      KC_BSLS, \
+    KC_LCTL,  _A_R_S_T_D,                       _H_N_E_I_O,         KC_RCTL, \
+    KC_LSFT,  _Z_X_C_V_B,     KC_GRV,  KC_QUOT, _K_M_COMM_DOT_SLSH, KC_RSFT, \
+    L_LOWER2_CAPS_LALT_LGUI_SPC_RABS,  R_RAEN_SPC_RGUI_RALT_APP_LOWER2  \
+  ),
 
   /* Dvorak
-   * ,-----------------------------------------.             ,-----------------------------------------.
-   * | ESC  |   1  |   2  |   3  |   4  |   5  |             |   6  |   7  |   8  |   9  |   0  | Bksp |
-   * |------+------+------+------+------+------|             |------+------+------+------+------+------|
-   * | Tab  |   '  |   ,  |   .  |   P  |   Y  |             |   F  |   G  |   C  |   R  |   L  |  \   |
-   * |------+------+------+------+------+------|             |------+------+------+------+------+------|
-   * | Ctrl |   A  |   O  |   E  |   U  |   I  |             |   D  |   H  |   T  |   N  |   S  | Ctrl |
-   * |------+------+------+------+------+------+------+------+------+------+------+------+------+------|
-   * | Shift|   ;  |   Q  |   J  |   K  |   X  |   `  |   /  |   B  |   M  |   W  |   V  |   Z  | Shift|
-   * |------+------+------+------+------+------+------+------+------+------+------+------+------+------|
-   * |Lower | Lower| Caps |  Alt |  GUI | Space|  BS  | Enter| Space| GUI  | Alt  | Menu |Lower |Lower |
-   * `-------------------------------------------------------------------------------------------------'
+   * ,-----------------------------------.           ,-----------------------------------.
+   * | ESC |  1  |  2  |  3  |  4  |  5  |           |  6  |  7  |  8  |  9  |  0  | BS  |
+   * |-----+-----+-----+-----+-----+-----|           |-----+-----+-----+-----+-----+-----|
+   * | Tab |  '  |  ,  |  .  |  P  |  Y  |           |  F  |  G  |  C  |  R  |  L  |  \  |
+   * |-----+-----+-----+-----+-----+-----|           |-----+-----+-----+-----+-----+-----|
+   * | Ctrl|  A  |  O  |  E  |  U  |  I  |           |  D  |  H  |  T  |  N  |  S  |Ctrl |
+   * |-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----|
+   * |Shift|  ;  |  Q  |  J  |  K  |  X  |  `  |  /  |  B  |  M  |  W  |  V  |  Z  |Shift|
+   * |-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----|
+   * |Lower|Lower|Caps | Alt | GUI |Space|  BS |Enter|Space| GUI | Alt |Menu |Lower|Lower|
+   * `-----------------------------------------------------------------------------------'
    */
-  [_DVORAK] = LAYOUT_kc( \
-      ESC,    1,    2,    3,    4,    5,                  6,    7,    8,    9,    0,  BSPC, \
-      TAB, QUOT, COMM,  DOT,    P,    Y,                  F,    G,    C,    R,    L,  BSLS, \
-      LCTL,   A,    O,    E,    U,    I,                  D,    H,    T,    N,    S,  RCTL, \
-      LSFT, SCLN,   Q,    J,    K,    X,    GRV,  SLSH,   B,    M,    W,    V,    Z,  RSFT, \
-      LOWER, LOWER, CAPS, LALT, LGUI, SPC, RABS,  RAEN, SPC, RGUI, RALT,  APP,LOWER, LOWER \
-      ),
+#define _QUOT_COMM_DOT_P_Y   KC_QUOT, KC_COMM, KC_DOT, KC_P, KC_Y
+#define _F_G_C_R_L           KC_F, KC_G, KC_C, KC_R, KC_L
+#define _A_O_E_U_I           KC_A, KC_O, KC_E, KC_U, KC_I
+#define _D_H_T_N_S           KC_D, KC_H, KC_T, KC_N, KC_S
+#define _SCLN_Q_J_K_X        KC_SCLN, KC_Q, KC_J, KC_K, KC_X
+#define _B_M_W_V_Z           KC_B, KC_M, KC_W, KC_V, KC_Z
+
+  [_DVORAK] = LAYOUT_wrapper( \
+    KC_ESC,   _1_2_3_4_5,                       _6_7_8_9_0,    KC_BSPC, \
+    KC_TAB,   _QUOT_COMM_DOT_P_Y,               _F_G_C_R_L,    KC_BSLS, \
+    KC_LCTL,  _A_O_E_U_I,                       _D_H_T_N_S,    KC_RCTL, \
+    KC_LSFT,  _SCLN_Q_J_K_X,  KC_GRV,  KC_SLSH, _B_M_W_V_Z,    KC_RSFT, \
+    L_LOWER2_CAPS_LALT_LGUI_SPC_RABS,  R_RAEN_SPC_RGUI_RALT_APP_LOWER2  \
+   ),
 
   /* Eucalyn (http://eucalyn.hatenadiary.jp/entry/about-eucalyn-layout)
-   * ,-----------------------------------------.             ,-----------------------------------------.
-   * | ESC  |   1  |   2  |   3  |   4  |   5  |             |   6  |   7  |   8  |   9  |   0  | Bksp |
-   * |------+------+------+------+------+------|             |------+------+------+------+------+------|
-   * | Tab  |   Q  |   W  |   ,  |   .  |   ;  |             |   M  |   R  |   D  |   Y  |   P  |  \   |
-   * |------+------+------+------+------+------|             |------+------+------+------+------+------|
-   * | Ctrl |   A  |   O  |   E  |   I  |   U  |             |   G  |   T  |   K  |   S  |   N  | Ctrl |
-   * |------+------+------+------+------+------+------+------+------+------+------+------+------+------|
-   * | Shift|   Z  |   X  |   C  |   V  |   F  |   `  |   '  |   B  |   H  |   J  |   L  |   /  | Shift|
-   * |------+------+------+------+------+------+------+------+------+------+------+------+------+------|
-   * |Lower | Lower| Caps |  Alt |  GUI | Space|  BS  | Enter| Space| GUI  | Alt  | Menu |Lower |Lower |
-   * `-------------------------------------------------------------------------------------------------'
+   * ,-----------------------------------.           ,-----------------------------------.
+   * | ESC |  1  |  2  |  3  |  4  |  5  |           |  6  |  7  |  8  |  9  |  0  | BS  |
+   * |-----+-----+-----+-----+-----+-----|           |-----+-----+-----+-----+-----+-----|
+   * | Tab |  Q  |  W  |  ,  |  .  |  ;  |           |  M  |  R  |  D  |  Y  |  P  |  \  |
+   * |-----+-----+-----+-----+-----+-----|           |-----+-----+-----+-----+-----+-----|
+   * | Ctrl|  A  |  O  |  E  |  I  |  U  |           |  G  |  T  |  K  |  S  |  N  |Ctrl |
+   * |-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----|
+   * |Shift|  Z  |  X  |  C  |  V  |  F  |  `  |  '  |  B  |  H  |  J  |  L  |  /  |Shift|
+   * |-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----|
+   * |Lower|Lower|Caps | Alt | GUI |Space|  BS |Enter|Space| GUI | Alt |Menu |Lower|Lower|
+   * `-----------------------------------------------------------------------------------'
    */
-  [_EUCALYN] = LAYOUT_kc( \
-      ESC,    1,    2,    3,    4,    5,                  6,    7,    8,    9,    0,  BSPC, \
-      TAB,    Q,    W, COMM,  DOT, SCLN,                  M,    R,    D,    Y,    P,  BSLS, \
-      LCTL,   A,    O,    E,    I,    U,                  G,    T,    K,    S,    N,  RCTL, \
-      LSFT,   Z,    X,    C,    V,    F,    GRV,  QUOT,   B,    H,    J,    L, SLSH,  RSFT, \
-      LOWER, LOWER, CAPS, LALT, LGUI, SPC, RABS,  RAEN, SPC, RGUI, RALT,  APP,LOWER, LOWER \
-      ),
+#define _Q_W_COMM_DOT_SCLN   KC_Q, KC_W, KC_COMM, KC_DOT, KC_SCLN
+#define _M_R_D_Y_P           KC_M, KC_R, KC_D, KC_Y, KC_P
+#define _A_O_E_I_U           KC_A, KC_O, KC_E, KC_I, KC_U
+#define _G_T_K_S_N           KC_G, KC_T, KC_K, KC_S, KC_N
+#define _Z_X_C_V_F           KC_Z, KC_X, KC_C, KC_V, KC_F
+#define _B_H_J_L_SLSH        KC_B, KC_H, KC_J, KC_L, KC_SLSH
+
+  [_EUCALYN] = LAYOUT_wrapper( \
+    KC_ESC,   _1_2_3_4_5,                       _6_7_8_9_0,     KC_BSPC, \
+    KC_TAB,   _Q_W_COMM_DOT_SCLN,               _M_R_D_Y_P,     KC_BSLS, \
+    KC_LCTL,  _A_O_E_I_U,                       _G_T_K_S_N,     KC_RCTL, \
+    KC_LSFT,  _Z_X_C_V_F,     KC_GRV,  KC_QUOT, _B_H_J_L_SLSH,  KC_RSFT, \
+    L_LOWER2_CAPS_LALT_LGUI_SPC_RABS,  R_RAEN_SPC_RGUI_RALT_APP_LOWER2  \
+  ),
 
   /* Keypad
-   * ,-----------------------------------------.             ,-----------------------------------------.
-   * | Tab  |   /  |   *  | Del  |  F1  |  F6  |             |  F1  |  F6  | Del  | Tab  |   /  |   *  |
-   * |------+------+------+------+------+------|             |------+------+------+------+------+------|
-   * |   7  |   8  |   9  | BS   |  F2  |  F7  |             |  F2  |  F7  | BS   |   7  |   8  |   9  |
-   * |------+------+------+------+------+------|             |------+------+------+------+------+------|
-   * |   4  |   5  |   6  |  -   |  F3  |  F8  |             |  F3  |  F8  |  -   |   4  |   5  |   6  |
-   * |------+------+------+------+------+------+------+------+------+------+------+------+------+------|
-   * |   1  |   2  |   3  |  +   |  F4  |  F9  |  F11 |  F11 |  F4  |  F9  |  +   |   1  |   2  |   3  |
-   * |------+------+------+------+------+------+------+------+------+------+------+------+------+------|
-   * |   0  |   ,  |   .  | Enter|  F5  |  F10 |  F12 |  F12 |  F5  |  F10 | Enter|   0  |  ,   |   .  |
-   * `-------------------------------------------------------------------------------------------------'
+   * ,-----------------------------------.           ,-----------------------------------.
+   * | Tab |  /  |  *  | Del |  F1 |  F6 |           |  F1 |  F6 | Del | Tab |  /  |  *  |
+   * |-----+-----+-----+-----+-----+-----|           |-----+-----+-----+-----+-----+-----|
+   * |  7  |  8  |  9  | BS  |  F2 |  F7 |           |  F2 |  F7 | BS  |  7  |  8  |  9  |
+   * |-----+-----+-----+-----+-----+-----|           |-----+-----+-----+-----+-----+-----|
+   * |  4  |  5  |  6  |  -  |  F3 |  F8 |           |  F3 |  F8 |  -  |  4  |  5  |  6  |
+   * |-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----|
+   * |  1  |  2  |  3  |  +  |  F4 |  F9 | F11 | F11 |  F4 |  F9 |  +  |  1  |  2  |  3  |
+   * |-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----|
+   * |  0  |  ,  |  .  |Enter|  F5 |  F10| F12 | F12 |  F5 |  F10|Enter|  0  |  ,  |  .  |
+   * `-----------------------------------------------------------------------------------'
    */
-  [_KEYPAD] = LAYOUT_kc( \
-      TAB,  PSLS, PAST, DEL,    F1,   F6,               F1,   F6,  DEL,  TAB, PSLS, PAST, \
-      KP_7, KP_8, KP_9, BSPC,   F2,   F7,               F2,   F7, BSPC, KP_7, KP_8, KP_9, \
-      KP_4, KP_5, KP_6, PMNS,   F3,   F8,               F3,   F8, PMNS, KP_4, KP_5, KP_6, \
-      KP_1, KP_2, KP_3, PPLS,   F4,   F9,  F11,  F11,   F4,   F9, PPLS, KP_1, KP_2, KP_3, \
-      KP_0, COMM, PDOT, PENT,   F5,  F10, FF12, FF12,   F5,  F10, PENT, KP_0, COMM, PDOT \
-      ),
+#define KP_TOP KC_TAB,  KC_PSLS, KC_PAST
+#define KP_789 KC_KP_7, KC_KP_8, KC_KP_9
+#define KP_456 KC_KP_4, KC_KP_5, KC_KP_6
+#define KP_123 KC_KP_1, KC_KP_2, KC_KP_3
+#define KP_BTM KC_KP_0, KC_COMM, KC_PDOT
+#define F_1_6  KC_F1, KC_F6
+#define F_2_7  KC_F2, KC_F7
+#define F_3_8  KC_F3, KC_F8
+#define F_4_9  KC_F4, KC_F9
+#define F_510  KC_F5, KC_F10
+#define FF12   LT(_PADFUNC,KC_F12)
+
+  [_KEYPAD] = LAYOUT_wrapper( \
+    KP_TOP, KC_DEL,  F_1_6,                     F_1_6,  KC_DEL, KP_TOP, \
+    KP_789, KC_BSPC, F_2_7,                     F_2_7, KC_BSPC, KP_789, \
+    KP_456, KC_PMNS, F_3_8,                     F_3_8, KC_PMNS, KP_456, \
+    KP_123, KC_PPLS, F_4_9,  KC_F11,  KC_F11,  F_4_9, KC_PPLS, KP_123, \
+    KP_BTM, KC_PENT, F_510,    FF12,    FF12,  F_510, KC_PENT, KP_BTM  \
+  ),
 
   /*  AUX modifier key layer
-   * ,-----------------------------------------.             ,-----------------------------------------.
-   * |      |      |      |      |      |      |             |      |      |      |      |      |      |
-   * |------+------+------+------+------+------|             |------+------+------+------+------+------|
-   * |      |      |      |      |      |      |             |      |      |      |      |      |      |
-   * |------+------+------+------+------+------|             |------+------+------+------+------+------|
-   * |      |      |      |      |      |      |             |      |      |      |      |      |      |
-   * |------+------+------+------+------+------+------+------+------+------+------+------+------+------|
-   * |      |      |      |      |      |      |      |      |      |      |      |      |      |      |
-   * |------+------+------+------+------+------+------+------+------+------+------+------+------+------|
-   * |      |  00  |      |      |      |      |      |      |      |      |      |      |  00  |      |
-   * `-------------------------------------------------------------------------------------------------'
+   * ,-----------------------------------.           ,-----------------------------------.
+   * |     |     |     |     |     |     |           |     |     |     |     |     |     |
+   * |-----+-----+-----+-----+-----+-----|           |-----+-----+-----+-----+-----+-----|
+   * |     |     |     |     |     |     |           |     |     |     |     |     |     |
+   * |-----+-----+-----+-----+-----+-----|           |-----+-----+-----+-----+-----+-----|
+   * |     |     |     |     |     |     |           |     |     |     |     |     |     |
+   * |-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----|
+   * |     |     |     |     |     |     |     |     |     |     |     |     |     |     |
+   * |-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----|
+   * |     | 00  |     |     |     |     |     |     |     |     |     |     | 00  |     |
+   * `-----------------------------------------------------------------------------------'
    */
-  [_KAUX] = LAYOUT_kc( \
+  [_KAUX] = LAYOUT( \
       ____, ____, ____, ____, ____, ____,             ____, ____, ____, ____, ____, ____, \
       ____, ____, ____, ____, ____, ____,             ____, ____, ____, ____, ____, ____, \
       ____, ____, ____, ____, ____, ____,             ____, ____, ____, ____, ____, ____, \
       ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, \
-      ____,ZERO2, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ZERO2,____ \
+      ____,ZERO2, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____,ZERO2, ____ \
    ),
 
   /*  Keypad function layer
@@ -182,12 +228,20 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    * |      |      |      |      |      |      |      |      |      |      |      |      |      |      |
    * `-------------------------------------------------------------------------------------------------'
    */
-  [_PADFUNC] = LAYOUT_kc( \
-      XXXX, XXXX, XXXX, PAUS, SLCK, PSCR,             PSCR, SLCK, PAUS, XXXX, XXXX, XXXX, \
-      XXXX, XXXX, XXXX, HOME, UP,   PGUP,             PGUP, UP,   HOME, XXXX, XXXX, XXXX, \
-      XXXX,  DEL,  INS, LEFT, DOWN, RGHT,             LEFT, DOWN, RGHT, INS,  DEL,  XXXX, \
-      XXXX, XXXX, XXXX, END,  XXXX, PGDN,  ADJ,  ADJ, PGDN, XXXX, END,  XXXX, XXXX, XXXX, \
-      XXXX, XXXX, XXXX, XXXX, XXXX, XXXX, ____, ____, XXXX, XXXX, XXXX, XXXX, XXXX, XXXX \
+#define _PAUS_SLCK_PSCR           KC_PAUS, KC_SLCK, KC_PSCR
+#define _PSCR_SLCK_PAUS           KC_PSCR, KC_SLCK, KC_PAUS
+#define _HOME_UP_PGUP             KC_HOME, KC_UP,   KC_PGUP
+#define _PGUP_UP_HOME             KC_PGUP, KC_UP,   KC_HOME
+#define _DEL_INS_LEFT_DOWN_RGHT   KC_DEL,  KC_INS,  KC_LEFT, KC_DOWN, KC_RGHT
+#define _LEFT_DOWN_RGHT_INS_DEL   KC_LEFT, KC_DOWN, KC_RGHT, KC_INS,  KC_DEL
+#define _PGDN_ADJ_ADJ_PGDN        KC_PGDN, KC_ADJ,  KC_ADJ,  KC_PGDN
+
+  [_PADFUNC] = LAYOUT_wrapper( \
+      XXXX, XXXX, XXXX, _PAUS_SLCK_PSCR,               _PSCR_SLCK_PAUS,       XXXX, XXXX, XXXX, \
+      XXXX, XXXX, XXXX,   _HOME_UP_PGUP,               _PGUP_UP_HOME,         XXXX, XXXX, XXXX, \
+      XXXX,     _DEL_INS_LEFT_DOWN_RGHT,               _LEFT_DOWN_RGHT_INS_DEL,           XXXX, \
+      XXXX, XXXX, XXXX, KC_END, XXXX,   _PGDN_ADJ_ADJ_PGDN,     XXXX, KC_END, XXXX, XXXX, XXXX, \
+      XXXX, XXXX, XXXX, XXXX,   XXXX, XXXX, ____, ____,   XXXX, XXXX,   XXXX, XXXX, XXXX, XXXX \
    ),
 
   /* Lower
@@ -203,12 +257,22 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    * |      |      | PrtSc|      |      |      |      |      |      |      |      | PrtSc|      |      |
    * `-------------------------------------------------------------------------------------------------'
    */
-  [_LOWER] = LAYOUT_kc( \
-      XXXX,  F1,   F2,   F3,   F4,   F5,                F6,   F7,   F8,   F9,  F10,  F11, \
-      XXXX, XXXX, PAUS, SLCK, INS,  XXXX,             XXXX,  INS, SLCK, PAUS, XXXX,  F12, \
-      ____, HOME, XXXX, UP,   DEL,  PGUP,             PGUP,  DEL,   UP, XXXX, HOME, ____, \
-      ____, END,  LEFT, DOWN, RGHT, PGDN, XXXX, XXXX, PGDN, LEFT, DOWN, RGHT,  END, ____, \
-      ____, ____, PSCR, ____, ____, ____,  ADJ,  ADJ, ____, ____, ____, PSCR, ____, ____ \
+#define _F1_F2_F3_F4_F5           KC_F1, KC_F2, KC_F3, KC_F4, KC_F5
+#define _F6_F7_F8_F9_F10_F11      KC_F6, KC_F7, KC_F8, KC_F9, KC_F10, KC_F11
+#define _PAUS_SLCK_INS            KC_PAUS, KC_SLCK, KC_INS
+#define _INS_SLCK_PAUS            KC_INS,  KC_SLCK, KC_PAUS
+#define _ADJ_ADJ                  KC_ADJ,  KC_ADJ
+#define _UP_DEL_PGUP              KC_UP,   KC_DEL,  KC_PGUP
+#define _PGUP_DEL_UP              KC_PGUP, KC_DEL,  KC_UP
+#define _END_LEFT_DOWN_RGHT_PGDN  KC_END,  KC_LEFT, KC_DOWN, KC_RGHT, KC_PGDN
+#define _PGDN_LEFT_DOWN_RGHT_END  KC_PGDN, KC_LEFT, KC_DOWN, KC_RGHT, KC_END
+
+  [_LOWER] = LAYOUT_wrapper( \
+      XXXX, _F1_F2_F3_F4_F5,                             _F6_F7_F8_F9_F10_F11, \
+      XXXX, XXXX,    _PAUS_SLCK_INS,   XXXX,             XXXX,  _INS_SLCK_PAUS,    XXXX, KC_F12, \
+      ____, KC_HOME, XXXX, _UP_DEL_PGUP,                 _PGUP_DEL_UP,      XXXX, KC_HOME, ____, \
+      ____, _END_LEFT_DOWN_RGHT_PGDN,        XXXX, XXXX, _PGDN_LEFT_DOWN_RGHT_END,         ____, \
+      ____, ____, KC_PSCR, ____, ____, ____,  _ADJ_ADJ,  ____, ____, ____, KC_PSCR, ____, ____ \
       ),
 
   /* Raise
@@ -224,12 +288,18 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    * |      |      |      |      |      |      |      |      |      |      |      |      |      |      |
    * `-------------------------------------------------------------------------------------------------'
    */
-  [_RAISE] = LAYOUT_kc( \
+#define _LSMI_MINS             KC_LSMI, KC_MINS
+#define _EQL_LSEQ              KC_EQL,  KC_LSEQ
+#define _LSLB_LBRC             KC_LSLB, KC_LBRC
+#define _RBRC_LSRB             KC_RBRC, KC_LSRB
+#define _MNXT_VOLD_VOLU_MPLY   KC_MNXT, KC_VOLD, KC_VOLU, KC_MPLY
+
+  [_RAISE] = LAYOUT_wrapper( \
       XXXX, XXXX, XXXX, XXXX, XXXX, XXXX,             XXXX, XXXX, XXXX, XXXX, XXXX, XXXX, \
-      XXXX, XXXX, XXXX, XXXX, LSMI, MINS,              EQL, LSEQ, XXXX, XXXX, XXXX, XXXX, \
-      ____, XXXX, XXXX, XXXX, LSLB, LBRC,             RBRC, LSRB, XXXX, XXXX, XXXX, ____, \
-      ____, XXXX, XXXX, XXXX, XXXX,xEISU,xEISU, xKANA,xKANA,MNXT, VOLD, VOLU, MPLY, ____, \
-      ADJ,   ADJ, XXXX, ____, ____, XXXX, ____, ____, XXXX, ____, ____, XXXX,  ADJ,  ADJ \
+      XXXX, XXXX, XXXX, XXXX, _LSMI_MINS,             _EQL_LSEQ,  XXXX, XXXX, XXXX, XXXX, \
+      ____, XXXX, XXXX, XXXX, _LSLB_LBRC,             _RBRC_LSRB, XXXX, XXXX, XXXX, ____, \
+      ____, XXXX, XXXX, XXXX, XXXX,xEISU,xEISU, xKANA,xKANA, _MNXT_VOLD_VOLU_MPLY,  ____, \
+      _ADJ_ADJ,   XXXX, ____, ____, XXXX, ____, ____, XXXX, ____, ____, XXXX,   _ADJ_ADJ \
       ),
 
   /* Adjust (Lower + Raise)
@@ -249,8 +319,8 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
       XXXXXXX, KEYPAD,  DVORAK,  COLEMAK, EUCALYN,  QWERTY,          QWERTY,  EUCALYN, COLEMAK,  DVORAK,  KEYPAD, XXXXXXX, \
       XXXXXXX, RESET,   RGBRST,  RGB_TOG,   AU_ON, AG_SWAP,          AG_SWAP,   AU_ON, RGB_TOG,  RGBRST, XXXXXXX, XXXXXXX, \
       RGB_HUI, RGB_SAI, RGB_VAI, RGB_MOD,  AU_OFF, AG_NORM,          AG_NORM,  AU_OFF, RGB_MOD, RGB_VAI, RGB_SAI, RGB_HUI, \
-      RGB_HUD, RGB_SAD, RGB_VAD, XXXXXXX, XXXXXXX, XXXXXXX, ___,___, XXXXXXX, XXXXXXX, XXXXXXX, RGB_VAD, RGB_SAD, RGB_HUD, \
-      _______, _______, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, ___,___, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, _______, _______ \
+      RGB_HUD, RGB_SAD, RGB_VAD, XXXXXXX, XXXXXXX, XXXXXXX,____,____,XXXXXXX, XXXXXXX, XXXXXXX, RGB_VAD, RGB_SAD, RGB_HUD, \
+      _______, _______, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,____,____,XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, _______, _______ \
    ),
 
   /*  AUX modifier key layer
@@ -266,12 +336,13 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    * |      |      |      |      |      |  BS  | Enter|      |      |      |      |      |      |      |
    * `-------------------------------------------------------------------------------------------------'
    */
-  [_AUX] = LAYOUT_kc( \
+#define _BSPC_RAEN KC_BSPC, LT(_RAISE,KC_ENT)
+  [_AUX] = LAYOUT_wrapper( \
       ____, ____, ____, ____, ____, ____,             ____, ____, ____, ____, ____, ____, \
       ____, ____, ____, ____, ____, ____,             ____, ____, ____, ____, ____, ____, \
       ____, ____, ____, ____, ____, ____,             ____, ____, ____, ____, ____, ____, \
       ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, \
-      ____, ____, ____, ____, ____, BSPC, RAEN, ____, ____, ____, ____, ____, ____, ____ \
+      ____, ____, ____, ____, ____, _BSPC_RAEN, ____, ____, ____, ____, ____, ____, ____ \
       )
 };
 
@@ -334,13 +405,13 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
       }
       return false;
       break;
-    case KC_ZERO2:
+    case ZERO2:
       if (record->event.pressed) {
           SEND_STRING("00");
       }
       return false;
       break;
-    case KC_xEISU:
+    case xEISU:
       if (record->event.pressed) {
         if(keymap_config.swap_lalt_lgui==false){
           register_code(KC_LANG2);
@@ -352,7 +423,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
       }
       return false;
       break;
-    case KC_xKANA:
+    case xKANA:
       if (record->event.pressed) {
         if(keymap_config.swap_lalt_lgui==false){
           register_code(KC_LANG1);

--- a/keyboards/helix/rev2/keymaps/five_rows/keymap.c
+++ b/keyboards/helix/rev2/keymaps/five_rows/keymap.c
@@ -7,39 +7,14 @@
 #ifdef AUDIO_ENABLE
   #include "audio.h"
 #endif
-#ifdef SSD1306OLED
-  #include "ssd1306.h"
-#endif
 #ifdef CONSOLE_ENABLE
   #include <print.h>
 #endif
+#include "layer_number.h"
 
 extern keymap_config_t keymap_config;
 
-#ifdef RGBLIGHT_ENABLE
-//Following line allows macro to read current RGB settings
-extern rgblight_config_t rgblight_config;
-#endif
-
 extern uint8_t is_master;
-
-// Each layer gets a name for readability, which is then used in the keymap matrix below.
-// The underscores don't mean anything - you can have a layer called STUFF or any other name.
-// Layer names don't all need to be of the same length, obviously, and you can also skip them
-// entirely and just use numbers.
-enum layer_number {
-    _QWERTY = 0,
-    _COLEMAK,
-    _DVORAK,
-    _EUCALYN,
-    _KEYPAD,
-    _AUX,
-    _KAUX,
-    _LOWER,
-    _RAISE,
-    _PADFUNC,
-    _ADJUST,
-};
 
 enum custom_keycodes {
   QWERTY = SAFE_RANGE,
@@ -317,7 +292,7 @@ float tone_plover_gb[][2]  = SONG(PLOVER_GOODBYE_SOUND);
 float music_scale[][2]     = SONG(MUSIC_SCALE_SOUND);
 #endif
 
-static int current_default_layer;
+int current_default_layer;
 
 uint32_t default_layer_state_set_kb(uint32_t state) {
     // 1<<_QWERTY  - 1 == 1 - 1 == _QWERTY (=0)
@@ -437,13 +412,10 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 }
 
 void matrix_init_user(void) {
-    #ifdef AUDIO_ENABLE
-        startup_user();
-    #endif
-    #ifdef SSD1306OLED
-        //SSD1306 OLED init, make sure to add #define SSD1306OLED in config.h
-        iota_gfx_init(!has_usb());   // turns on the display
-    #endif
+#ifdef AUDIO_ENABLE
+    startup_user();
+#endif
+    INIT_HELIX_OLED();
 }
 
 
@@ -469,172 +441,5 @@ void music_scale_user(void)
 {
     PLAY_SONG(music_scale);
 }
-
-#endif
-
-
-//SSD1306 OLED update loop, make sure to add #define SSD1306OLED in config.h
-#if defined(SSD1306OLED) || defined(OLED_DRIVER_ENABLE)
-
-#if defined(OLED_DRIVER_ENABLE)
-oled_rotation_t oled_init_user(oled_rotation_t rotation) {
-  if (is_master) {
-    return OLED_ROTATION_0;
-  } else {
-    return OLED_ROTATION_180;
-  }
-}
-#else
-#define oled_write(data,flag)    matrix_write(matrix, data)
-#define oled_write_P(data,flag)  matrix_write_P(matrix, data)
-#endif
-
-#ifdef SSD1306OLED
-void matrix_scan_user(void) {
-     iota_gfx_task();  // this is what updates the display continuously
-}
-
-void matrix_update(struct CharacterMatrix *dest,
-                          const struct CharacterMatrix *source) {
-  if (memcmp(dest->display, source->display, sizeof(dest->display))) {
-    memcpy(dest->display, source->display, sizeof(dest->display));
-    dest->dirty = true;
-  }
-}
-#endif
-
-#ifdef SSD1306OLED
-static void render_logo(struct CharacterMatrix *matrix) {
-#else
-static void render_logo(void) {
-#endif
-
-  static char logo[]={
-    0x80,0x81,0x82,0x83,0x84,0x85,0x86,0x87,0x88,0x89,0x8a,0x8b,0x8c,0x8d,0x8e,0x8f,0x90,0x91,0x92,0x93,0x94,
-    0xa0,0xa1,0xa2,0xa3,0xa4,0xa5,0xa6,0xa7,0xa8,0xa9,0xaa,0xab,0xac,0xad,0xae,0xaf,0xb0,0xb1,0xb2,0xb3,0xb4,
-    0xc0,0xc1,0xc2,0xc3,0xc4,0xc5,0xc6,0xc7,0xc8,0xc9,0xca,0xcb,0xcc,0xcd,0xce,0xcf,0xd0,0xd1,0xd2,0xd3,0xd4,
-    0};
-  oled_write(logo, false);
-#ifdef RGBLIGHT_ENABLE
-  char buf[30];
-  if (RGBLIGHT_MODES > 1 && rgblight_config.enable) {
-      snprintf(buf, sizeof(buf), " LED %2d: %d,%d,%d ",
-               rgblight_config.mode,
-               rgblight_config.hue/RGBLIGHT_HUE_STEP,
-               rgblight_config.sat/RGBLIGHT_SAT_STEP,
-               rgblight_config.val/RGBLIGHT_VAL_STEP);
-      oled_write(buf, false);
-#ifndef SSD1306OLED
-  } else {
-      oled_write_P( PSTR("\n"), false);
-#endif
-  }
-#endif
-  //matrix_write_P(&matrix, PSTR(" Split keyboard kit"));
-}
-
-static const char Qwerty_name[]  PROGMEM = " Qwerty";
-static const char Colemak_name[] PROGMEM = " Colemak";
-static const char Dvorak_name[]  PROGMEM = " Dvorak";
-static const char Eucalyn_name[] PROGMEM = " Eucalyn";
-static const char Keypad_name[]  PROGMEM = " Keypad";
-
-static const char AUX_name[]     PROGMEM = ":AUX";
-static const char KAUX_name[]    PROGMEM = ":00";
-static const char Padfunc_name[] PROGMEM = ":PadFunc";
-static const char Lower_name[]   PROGMEM = ":Func";
-static const char Raise_name[]   PROGMEM = ":Extra";
-static const char Adjust_name[]  PROGMEM = ":Adjust";
-
-static const char *layer_names[] = {
-    [_QWERTY] = Qwerty_name,
-    [_COLEMAK] = Colemak_name,
-    [_DVORAK] = Dvorak_name,
-    [_EUCALYN]= Eucalyn_name,
-    [_KEYPAD] = Keypad_name,
-    [_AUX]    = AUX_name,
-    [_KAUX]   = KAUX_name,
-    [_LOWER]  = Lower_name,
-    [_RAISE]  = Raise_name,
-    [_PADFUNC]= Padfunc_name,
-    [_ADJUST] = Adjust_name
-};
-
-#ifdef SSD1306OLED
-void render_status(struct CharacterMatrix *matrix) {
-#else
-void render_status(void) {
-#endif
-
-  // Render to mode icon
-  static char logo[][2][3]={{{0x95,0x96,0},{0xb5,0xb6,0}},{{0x97,0x98,0},{0xb7,0xb8,0}}};
-  if(keymap_config.swap_lalt_lgui==false){
-    oled_write(logo[0][0], false);
-    oled_write_P(PSTR("\n"), false);
-    oled_write(logo[0][1], false);
-  }else{
-    oled_write(logo[1][0], false);
-    oled_write_P(PSTR("\n"), false);
-    oled_write(logo[1][1], false);
-  }
-
-  // Define layers here, Have not worked out how to have text displayed for each layer. Copy down the number you see and add a case for it below
-  int name_num;
-  uint32_t lstate;
-  oled_write_P(layer_names[current_default_layer], false);
-  oled_write_P(PSTR("\n"), false);
-  for( lstate = layer_state, name_num = 0;
-       lstate && name_num < sizeof(layer_names)/sizeof(char *);
-       lstate >>=1, name_num++ ) {
-      if( (lstate & 1) != 0 ) {
-          if( layer_names[name_num] ) {
-              oled_write_P(layer_names[name_num], false);
-          }
-      }
-  }
-
-  // Host Keyboard LED Status
-  char led[40];
-    snprintf(led, sizeof(led), "\n%s  %s  %s",
-             (host_keyboard_leds() & (1<<USB_LED_NUM_LOCK)) ? "NUMLOCK" : "       ",
-             (host_keyboard_leds() & (1<<USB_LED_CAPS_LOCK)) ? "CAPS" : "    ",
-             (host_keyboard_leds() & (1<<USB_LED_SCROLL_LOCK)) ? "SCLK" : "    ");
-    oled_write(led, false);
-}
-
-#ifdef SSD1306OLED
-void iota_gfx_task_user(void) {
-  struct CharacterMatrix matrix;
-
-#if DEBUG_TO_SCREEN
-  if (debug_enable) {
-    return;
-  }
-#endif
-
-  matrix_clear(&matrix);
-  if(is_master){
-    render_status(&matrix);
-  }else{
-    render_logo(&matrix);
-  }
-  matrix_update(&display, &matrix);
-}
-#else
-void oled_task_user(void) {
-
-#if DEBUG_TO_SCREEN
-  if (debug_enable) {
-    return;
-  }
-#endif
-
-  if(is_master){
-    render_status();
-  }else{
-    render_logo();
-  }
-}
-#endif
 
 #endif

--- a/keyboards/helix/rev2/keymaps/five_rows/keymap.c
+++ b/keyboards/helix/rev2/keymaps/five_rows/keymap.c
@@ -1,3 +1,19 @@
+/* Copyright 2020 mtei
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include QMK_KEYBOARD_H
 #include "util.h"
 #include "bootloader.h"

--- a/keyboards/helix/rev2/keymaps/five_rows/keymap.c
+++ b/keyboards/helix/rev2/keymaps/five_rows/keymap.c
@@ -440,8 +440,8 @@ void matrix_init_user(void) {
     #ifdef AUDIO_ENABLE
         startup_user();
     #endif
-    //SSD1306 OLED init, make sure to add #define SSD1306OLED in config.h
     #ifdef SSD1306OLED
+        //SSD1306 OLED init, make sure to add #define SSD1306OLED in config.h
         iota_gfx_init(!has_usb());   // turns on the display
     #endif
 }
@@ -474,8 +474,22 @@ void music_scale_user(void)
 
 
 //SSD1306 OLED update loop, make sure to add #define SSD1306OLED in config.h
-#ifdef SSD1306OLED
+#if defined(SSD1306OLED) || defined(OLED_DRIVER_ENABLE)
 
+#if defined(OLED_DRIVER_ENABLE)
+oled_rotation_t oled_init_user(oled_rotation_t rotation) {
+  if (is_master) {
+    return OLED_ROTATION_0;
+  } else {
+    return OLED_ROTATION_180;
+  }
+}
+#else
+#define oled_write(data,flag)    matrix_write(matrix, data)
+#define oled_write_P(data,flag)  matrix_write_P(matrix, data)
+#endif
+
+#ifdef SSD1306OLED
 void matrix_scan_user(void) {
      iota_gfx_task();  // this is what updates the display continuously
 }
@@ -487,15 +501,20 @@ void matrix_update(struct CharacterMatrix *dest,
     dest->dirty = true;
   }
 }
+#endif
 
+#ifdef SSD1306OLED
 static void render_logo(struct CharacterMatrix *matrix) {
+#else
+static void render_logo(void) {
+#endif
 
   static char logo[]={
     0x80,0x81,0x82,0x83,0x84,0x85,0x86,0x87,0x88,0x89,0x8a,0x8b,0x8c,0x8d,0x8e,0x8f,0x90,0x91,0x92,0x93,0x94,
     0xa0,0xa1,0xa2,0xa3,0xa4,0xa5,0xa6,0xa7,0xa8,0xa9,0xaa,0xab,0xac,0xad,0xae,0xaf,0xb0,0xb1,0xb2,0xb3,0xb4,
     0xc0,0xc1,0xc2,0xc3,0xc4,0xc5,0xc6,0xc7,0xc8,0xc9,0xca,0xcb,0xcc,0xcd,0xce,0xcf,0xd0,0xd1,0xd2,0xd3,0xd4,
     0};
-  matrix_write(matrix, logo);
+  oled_write(logo, false);
 #ifdef RGBLIGHT_ENABLE
   char buf[30];
   if (RGBLIGHT_MODES > 1 && rgblight_config.enable) {
@@ -504,7 +523,11 @@ static void render_logo(struct CharacterMatrix *matrix) {
                rgblight_config.hue/RGBLIGHT_HUE_STEP,
                rgblight_config.sat/RGBLIGHT_SAT_STEP,
                rgblight_config.val/RGBLIGHT_VAL_STEP);
-      matrix_write(matrix, buf);
+      oled_write(buf, false);
+#ifndef SSD1306OLED
+  } else {
+      oled_write_P( PSTR("\n"), false);
+#endif
   }
 #endif
   //matrix_write_P(&matrix, PSTR(" Split keyboard kit"));
@@ -537,31 +560,35 @@ static const char *layer_names[] = {
     [_ADJUST] = Adjust_name
 };
 
+#ifdef SSD1306OLED
 void render_status(struct CharacterMatrix *matrix) {
+#else
+void render_status(void) {
+#endif
 
   // Render to mode icon
   static char logo[][2][3]={{{0x95,0x96,0},{0xb5,0xb6,0}},{{0x97,0x98,0},{0xb7,0xb8,0}}};
   if(keymap_config.swap_lalt_lgui==false){
-    matrix_write(matrix, logo[0][0]);
-    matrix_write_P(matrix, PSTR("\n"));
-    matrix_write(matrix, logo[0][1]);
+    oled_write(logo[0][0], false);
+    oled_write_P(PSTR("\n"), false);
+    oled_write(logo[0][1], false);
   }else{
-    matrix_write(matrix, logo[1][0]);
-    matrix_write_P(matrix, PSTR("\n"));
-    matrix_write(matrix, logo[1][1]);
+    oled_write(logo[1][0], false);
+    oled_write_P(PSTR("\n"), false);
+    oled_write(logo[1][1], false);
   }
 
   // Define layers here, Have not worked out how to have text displayed for each layer. Copy down the number you see and add a case for it below
   int name_num;
   uint32_t lstate;
-  matrix_write_P(matrix, layer_names[current_default_layer]);
-  matrix_write_P(matrix, PSTR("\n"));
+  oled_write_P(layer_names[current_default_layer], false);
+  oled_write_P(PSTR("\n"), false);
   for( lstate = layer_state, name_num = 0;
        lstate && name_num < sizeof(layer_names)/sizeof(char *);
        lstate >>=1, name_num++ ) {
       if( (lstate & 1) != 0 ) {
           if( layer_names[name_num] ) {
-              matrix_write_P(matrix, layer_names[name_num]);
+              oled_write_P(layer_names[name_num], false);
           }
       }
   }
@@ -572,10 +599,10 @@ void render_status(struct CharacterMatrix *matrix) {
              (host_keyboard_leds() & (1<<USB_LED_NUM_LOCK)) ? "NUMLOCK" : "       ",
              (host_keyboard_leds() & (1<<USB_LED_CAPS_LOCK)) ? "CAPS" : "    ",
              (host_keyboard_leds() & (1<<USB_LED_SCROLL_LOCK)) ? "SCLK" : "    ");
-  matrix_write(matrix, led);
+    oled_write(led, false);
 }
 
-
+#ifdef SSD1306OLED
 void iota_gfx_task_user(void) {
   struct CharacterMatrix matrix;
 
@@ -593,5 +620,21 @@ void iota_gfx_task_user(void) {
   }
   matrix_update(&display, &matrix);
 }
+#else
+void oled_task_user(void) {
+
+#if DEBUG_TO_SCREEN
+  if (debug_enable) {
+    return;
+  }
+#endif
+
+  if(is_master){
+    render_status();
+  }else{
+    render_logo();
+  }
+}
+#endif
 
 #endif

--- a/keyboards/helix/rev2/keymaps/five_rows/layer_number.h
+++ b/keyboards/helix/rev2/keymaps/five_rows/layer_number.h
@@ -1,0 +1,26 @@
+#pragma once
+
+// Each layer gets a name for readability, which is then used in the keymap matrix below.
+// The underscores don't mean anything - you can have a layer called STUFF or any other name.
+// Layer names don't all need to be of the same length, obviously, and you can also skip them
+// entirely and just use numbers.
+enum layer_number {
+    _QWERTY = 0,
+    _COLEMAK,
+    _DVORAK,
+    _EUCALYN,
+    _KEYPAD,
+    _AUX,
+    _KAUX,
+    _LOWER,
+    _RAISE,
+    _PADFUNC,
+    _ADJUST,
+};
+
+#if defined(SSD1306OLED)
+extern void init_helix_oled(void);
+#   define INIT_HELIX_OLED() init_helix_oled();
+#else
+#   define INIT_HELIX_OLED()
+#endif

--- a/keyboards/helix/rev2/keymaps/five_rows/oled_display.c
+++ b/keyboards/helix/rev2/keymaps/five_rows/oled_display.c
@@ -54,12 +54,12 @@ static void render_logo(struct CharacterMatrix *matrix) {
 static void render_logo(void) {
 #    endif
 
-    static char logo[]={
+    static const char helix_logo[] PROGMEM = {
         0x80,0x81,0x82,0x83,0x84,0x85,0x86,0x87,0x88,0x89,0x8a,0x8b,0x8c,0x8d,0x8e,0x8f,0x90,0x91,0x92,0x93,0x94,
         0xa0,0xa1,0xa2,0xa3,0xa4,0xa5,0xa6,0xa7,0xa8,0xa9,0xaa,0xab,0xac,0xad,0xae,0xaf,0xb0,0xb1,0xb2,0xb3,0xb4,
         0xc0,0xc1,0xc2,0xc3,0xc4,0xc5,0xc6,0xc7,0xc8,0xc9,0xca,0xcb,0xcc,0xcd,0xce,0xcf,0xd0,0xd1,0xd2,0xd3,0xd4,
         0};
-    oled_write(logo, false);
+    oled_write_P(helix_logo, false);
 #    ifdef RGBLIGHT_ENABLE
     char buf[30];
     if (RGBLIGHT_MODES > 1 && rgblight_is_enabled()) {
@@ -111,15 +111,15 @@ void render_status(void) {
 #    endif
 
     // Render to mode icon
-    static char logo[][2][3]={{{0x95,0x96,0},{0xb5,0xb6,0}},{{0x97,0x98,0},{0xb7,0xb8,0}}};
+    static const char os_logo[][2][3] PROGMEM ={{{0x95,0x96,0},{0xb5,0xb6,0}},{{0x97,0x98,0},{0xb7,0xb8,0}}};
     if(keymap_config.swap_lalt_lgui==false){
-        oled_write(logo[0][0], false);
+        oled_write_P(os_logo[0][0], false);
         oled_write_P(PSTR("\n"), false);
-        oled_write(logo[0][1], false);
+        oled_write_P(os_logo[0][1], false);
     } else {
-        oled_write(logo[1][0], false);
+        oled_write_P(os_logo[1][0], false);
         oled_write_P(PSTR("\n"), false);
-        oled_write(logo[1][1], false);
+        oled_write_P(os_logo[1][1], false);
     }
 
     // Define layers here, Have not worked out how to have text displayed for each layer. Copy down the number you see and add a case for it below
@@ -130,8 +130,8 @@ void render_status(void) {
     for (lstate = layer_state, name_num = 0;
          lstate && name_num < sizeof(layer_names)/sizeof(char *);
          lstate >>=1, name_num++) {
-        if( (lstate & 1) != 0 ) {
-            if( layer_names[name_num] ) {
+        if ((lstate & 1) != 0) {
+            if (layer_names[name_num]) {
                 oled_write_P(layer_names[name_num], false);
             }
         }

--- a/keyboards/helix/rev2/keymaps/five_rows/oled_display.c
+++ b/keyboards/helix/rev2/keymaps/five_rows/oled_display.c
@@ -23,7 +23,7 @@ void init_helix_oled(void) {
 
 #    if defined(OLED_DRIVER_ENABLE)
 oled_rotation_t oled_init_user(oled_rotation_t rotation) {
-    if (is_master) {
+    if (is_keyboard_master()) {
         return OLED_ROTATION_0;
     } else {
         return OLED_ROTATION_180;
@@ -157,7 +157,7 @@ void iota_gfx_task_user(void) {
 #        endif
 
     matrix_clear(&matrix);
-    if (is_master) {
+    if (is_keyboard_master()) {
         render_status(&matrix);
     } else {
         render_logo(&matrix);
@@ -173,7 +173,7 @@ void oled_task_user(void) {
     }
 #        endif
 
-    if(is_master){
+    if(is_keyboard_master()){
         render_status();
     }else{
         render_logo();

--- a/keyboards/helix/rev2/keymaps/five_rows/oled_display.c
+++ b/keyboards/helix/rev2/keymaps/five_rows/oled_display.c
@@ -1,0 +1,184 @@
+#include QMK_KEYBOARD_H
+#include <stdio.h>
+#ifdef CONSOLE_ENABLE
+  #include <print.h>
+#endif
+#ifdef SSD1306OLED
+  #include "ssd1306.h"
+#endif
+#include "string.h"
+#include "layer_number.h"
+
+extern int current_default_layer;
+
+void init_helix_oled(void) {
+#ifdef SSD1306OLED
+    //SSD1306 OLED init, make sure to add #define SSD1306OLED in config.h
+    iota_gfx_init(!has_usb());   // turns on the display
+#endif
+}
+
+//SSD1306 OLED update loop, make sure to add #define SSD1306OLED in config.h
+#if defined(SSD1306OLED) || defined(OLED_DRIVER_ENABLE)
+
+#    if defined(OLED_DRIVER_ENABLE)
+oled_rotation_t oled_init_user(oled_rotation_t rotation) {
+    if (is_master) {
+        return OLED_ROTATION_0;
+    } else {
+        return OLED_ROTATION_180;
+    }
+}
+#    else
+#    define oled_write(data,flag)    matrix_write(matrix, data)
+#    define oled_write_P(data,flag)  matrix_write_P(matrix, data)
+#    endif
+
+#    ifdef SSD1306OLED
+void matrix_scan_user(void) {
+    iota_gfx_task();  // this is what updates the display continuously
+}
+
+void matrix_update(struct CharacterMatrix *dest,
+                   const struct CharacterMatrix *source) {
+    if (memcmp(dest->display, source->display, sizeof(dest->display))) {
+        memcpy(dest->display, source->display, sizeof(dest->display));
+        dest->dirty = true;
+    }
+}
+#    endif
+
+#    ifdef SSD1306OLED
+static void render_logo(struct CharacterMatrix *matrix) {
+#    else
+static void render_logo(void) {
+#    endif
+
+    static char logo[]={
+        0x80,0x81,0x82,0x83,0x84,0x85,0x86,0x87,0x88,0x89,0x8a,0x8b,0x8c,0x8d,0x8e,0x8f,0x90,0x91,0x92,0x93,0x94,
+        0xa0,0xa1,0xa2,0xa3,0xa4,0xa5,0xa6,0xa7,0xa8,0xa9,0xaa,0xab,0xac,0xad,0xae,0xaf,0xb0,0xb1,0xb2,0xb3,0xb4,
+        0xc0,0xc1,0xc2,0xc3,0xc4,0xc5,0xc6,0xc7,0xc8,0xc9,0xca,0xcb,0xcc,0xcd,0xce,0xcf,0xd0,0xd1,0xd2,0xd3,0xd4,
+        0};
+    oled_write(logo, false);
+#    ifdef RGBLIGHT_ENABLE
+    char buf[30];
+    if (RGBLIGHT_MODES > 1 && rgblight_is_enabled()) {
+        snprintf(buf, sizeof(buf), " LED %2d: %d,%d,%d ",
+                 rgblight_get_mode(),
+                 rgblight_get_hue()/RGBLIGHT_HUE_STEP,
+                 rgblight_get_sat()/RGBLIGHT_SAT_STEP,
+                 rgblight_get_val()/RGBLIGHT_VAL_STEP);
+        oled_write(buf, false);
+#        ifndef SSD1306OLED
+    } else {
+        oled_write_P( PSTR("\n"), false);
+#        endif
+    }
+#    endif
+}
+
+static const char Qwerty_name[]  PROGMEM = " Qwerty";
+static const char Colemak_name[] PROGMEM = " Colemak";
+static const char Dvorak_name[]  PROGMEM = " Dvorak";
+static const char Eucalyn_name[] PROGMEM = " Eucalyn";
+static const char Keypad_name[]  PROGMEM = " Keypad";
+
+static const char AUX_name[]     PROGMEM = ":AUX";
+static const char KAUX_name[]    PROGMEM = ":00";
+static const char Padfunc_name[] PROGMEM = ":PadFunc";
+static const char Lower_name[]   PROGMEM = ":Func";
+static const char Raise_name[]   PROGMEM = ":Extra";
+static const char Adjust_name[]  PROGMEM = ":Adjust";
+
+static const char *layer_names[] = {
+    [_QWERTY] = Qwerty_name,
+    [_COLEMAK] = Colemak_name,
+    [_DVORAK] = Dvorak_name,
+    [_EUCALYN]= Eucalyn_name,
+    [_KEYPAD] = Keypad_name,
+    [_AUX]    = AUX_name,
+    [_KAUX]   = KAUX_name,
+    [_LOWER]  = Lower_name,
+    [_RAISE]  = Raise_name,
+    [_PADFUNC]= Padfunc_name,
+    [_ADJUST] = Adjust_name
+};
+
+#    ifdef SSD1306OLED
+void render_status(struct CharacterMatrix *matrix) {
+#    else
+void render_status(void) {
+#    endif
+
+    // Render to mode icon
+    static char logo[][2][3]={{{0x95,0x96,0},{0xb5,0xb6,0}},{{0x97,0x98,0},{0xb7,0xb8,0}}};
+    if(keymap_config.swap_lalt_lgui==false){
+        oled_write(logo[0][0], false);
+        oled_write_P(PSTR("\n"), false);
+        oled_write(logo[0][1], false);
+    } else {
+        oled_write(logo[1][0], false);
+        oled_write_P(PSTR("\n"), false);
+        oled_write(logo[1][1], false);
+    }
+
+    // Define layers here, Have not worked out how to have text displayed for each layer. Copy down the number you see and add a case for it below
+    int name_num;
+    uint32_t lstate;
+    oled_write_P(layer_names[current_default_layer], false);
+    oled_write_P(PSTR("\n"), false);
+    for (lstate = layer_state, name_num = 0;
+         lstate && name_num < sizeof(layer_names)/sizeof(char *);
+         lstate >>=1, name_num++) {
+        if( (lstate & 1) != 0 ) {
+            if( layer_names[name_num] ) {
+                oled_write_P(layer_names[name_num], false);
+            }
+        }
+    }
+
+    // Host Keyboard LED Status
+    char led[40];
+    snprintf(led, sizeof(led), "\n%s  %s  %s",
+             (host_keyboard_leds() & (1<<USB_LED_NUM_LOCK)) ? "NUMLOCK" : "       ",
+             (host_keyboard_leds() & (1<<USB_LED_CAPS_LOCK)) ? "CAPS" : "    ",
+             (host_keyboard_leds() & (1<<USB_LED_SCROLL_LOCK)) ? "SCLK" : "    ");
+    oled_write(led, false);
+}
+
+#    ifdef SSD1306OLED
+void iota_gfx_task_user(void) {
+    struct CharacterMatrix matrix;
+
+#        if DEBUG_TO_SCREEN
+    if (debug_enable) {
+        return;
+    }
+#        endif
+
+    matrix_clear(&matrix);
+    if (is_master) {
+        render_status(&matrix);
+    } else {
+        render_logo(&matrix);
+    }
+    matrix_update(&display, &matrix);
+}
+#    else
+void oled_task_user(void) {
+
+#        if DEBUG_TO_SCREEN
+    if (debug_enable) {
+        return;
+    }
+#        endif
+
+    if(is_master){
+        render_status();
+    }else{
+        render_logo();
+    }
+}
+#    endif
+
+#endif

--- a/keyboards/helix/rev2/keymaps/five_rows/oled_display.c
+++ b/keyboards/helix/rev2/keymaps/five_rows/oled_display.c
@@ -1,3 +1,19 @@
+/* Copyright 2020 mtei
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include QMK_KEYBOARD_H
 #include <stdio.h>
 #ifdef CONSOLE_ENABLE

--- a/keyboards/helix/rev2/keymaps/five_rows/rules.mk
+++ b/keyboards/helix/rev2/keymaps/five_rows/rules.mk
@@ -25,19 +25,51 @@ HELIX_ROWS = 5              # Helix Rows is 4 or 5
 # IOS_DEVICE_ENABLE = no      # connect to IOS device (iPad,iPhone)
 
 ifneq ($(strip $(HELIX)),)
-  ifeq ($(findstring console,$(HELIX)), console)
-    CONSOLE_ENABLE = yes
-  endif
-  ## make HELIX=stdole helix:five_rows -- use TOP/drivers/oled/oled_driver.c
-  ifeq ($(findstring stdole,$(HELIX)), stdole)
-    OLED_ENABLE = new
-  endif
-  ## make HELIX=oled helix:five_rows -- use helix/local_drivers/ssd1306.c
+  define KEYMAP_OPTION_PARSE
+    # $xinfo .$1.x #debug
+    # parse  'dispoff', 'consle', 'stdole', 'oled', 'sc'
+    ifeq ($(strip $1),dispoff)
+        OLED_ENABLE = no
+        OLED_DRIVER_ENABLE = no
+        LED_BACK_ENABLE = no
+        LED_UNDERGLOW_ENABLE = no
+    endif
+    ifeq ($(strip $1),console)
+        CONSOLE_ENABLE = yes
+    endif
+    ifeq ($(strip $1),stdole)
+        ## make HELIX=stdole helix:five_rows -- use TOP/drivers/oled/oled_driver.c
+        OLED_ENABLE = new
+    endif
+    ifeq ($(strip $1),oled)
+         ## make HELIX=oled helix:five_rows -- use helix/local_drivers/ssd1306.c
+        OLED_ENABLE = yes
+    endif
+    ifeq ($(strip $1),back)
+        LED_BACK_ENABLE = yes
+    endif
+    ifeq ($(strip $1),sc)
+        SPLIT_KEYBOARD = yes
+    endif
+  endef # end of KEYMAP_OPTION_PARSE
+
+  COMMA=,
+  $(eval $(foreach A_OPTION_NAME,$(subst $(COMMA), ,$(HELIX)),  \
+      $(call KEYMAP_OPTION_PARSE,$(A_OPTION_NAME))))
 endif
 
 ifeq ($(strip $(OLED_ENABLE)), new)
     OLED_DRIVER_ENABLE = yes
     OLED_ENABLE = no
+    SRC += oled_display.c
+    ifeq ($(strip $(LOCAL_GLCDFONT)), yes)
+       OPT_DEFS += -DOLED_FONT_H=\<helixfont.h\>
+    else
+       OPT_DEFS += -DOLED_FONT_H=\"common/glcdfont.c\"
+    endif
+endif
+ifeq ($(strip $(OLED_ENABLE)), yes)
+    SRC += oled_display.c
 endif
 
 # convert Helix-specific options (that represent combinations of standard options)

--- a/keyboards/helix/rev2/keymaps/five_rows/rules.mk
+++ b/keyboards/helix/rev2/keymaps/five_rows/rules.mk
@@ -28,6 +28,16 @@ ifneq ($(strip $(HELIX)),)
   ifeq ($(findstring console,$(HELIX)), console)
     CONSOLE_ENABLE = yes
   endif
+  ## make HELIX=stdole helix:five_rows -- use TOP/drivers/oled/oled_driver.c
+  ifeq ($(findstring stdole,$(HELIX)), stdole)
+    OLED_ENABLE = new
+  endif
+  ## make HELIX=oled helix:five_rows -- use helix/local_drivers/ssd1306.c
+endif
+
+ifeq ($(strip $(OLED_ENABLE)), new)
+    OLED_DRIVER_ENABLE = yes
+    OLED_ENABLE = no
 endif
 
 # convert Helix-specific options (that represent combinations of standard options)

--- a/keyboards/helix/rev3_5rows/keymaps/five_rows/config.h
+++ b/keyboards/helix/rev3_5rows/keymaps/five_rows/config.h
@@ -1,0 +1,47 @@
+/*
+This is the c configuration file for the keymap
+
+Copyright 2012 Jun Wako <wakojun@gmail.com>
+Copyright 2015 Jack Humbert
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef CONFIG_USER_H
+#define CONFIG_USER_H
+
+#undef TAPPING_TERM
+#define TAPPING_TERM 300
+#define PERMISSIVE_HOLD
+/* when TAPPING_TERM >= 500 same effect PERMISSIVE_HOLD.
+   see tmk_core/common/action_tapping.c */
+
+// place overrides here
+
+// If you need more program area, try select and reduce rgblight modes to use.
+
+// Selection of RGBLIGHT MODE to use.
+#if defined(LED_ANIMATIONS)
+   #define RGBLIGHT_EFFECT_BREATHING
+   #define RGBLIGHT_EFFECT_RAINBOW_MOOD
+   #define RGBLIGHT_EFFECT_RAINBOW_SWIRL
+   //#define RGBLIGHT_EFFECT_SNAKE
+   //#define RGBLIGHT_EFFECT_KNIGHT
+   #define RGBLIGHT_EFFECT_CHRISTMAS
+   #define RGBLIGHT_EFFECT_STATIC_GRADIENT
+   //#define RGBLIGHT_EFFECT_RGB_TEST
+   //#define RGBLIGHT_EFFECT_ALTERNATING
+#endif
+
+#endif /* CONFIG_USER_H */

--- a/keyboards/helix/rev3_5rows/keymaps/five_rows/config.h
+++ b/keyboards/helix/rev3_5rows/keymaps/five_rows/config.h
@@ -3,6 +3,7 @@ This is the c configuration file for the keymap
 
 Copyright 2012 Jun Wako <wakojun@gmail.com>
 Copyright 2015 Jack Humbert
+Copyright 2020 mtei
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/keyboards/helix/rev3_5rows/keymaps/five_rows/keyboard_post_init_user_scan.c
+++ b/keyboards/helix/rev3_5rows/keymaps/five_rows/keyboard_post_init_user_scan.c
@@ -1,0 +1,7 @@
+#include QMK_KEYBOARD_H
+
+void keyboard_post_init_user(void) {
+#if defined(DEBUG_MATRIX_SCAN_RATE)
+    debug_enable = true;
+#endif
+}

--- a/keyboards/helix/rev3_5rows/keymaps/five_rows/keymap.c
+++ b/keyboards/helix/rev3_5rows/keymaps/five_rows/keymap.c
@@ -1,3 +1,19 @@
+/* Copyright 2020 mtei
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include QMK_KEYBOARD_H
 #include "util.h"
 #include "bootloader.h"

--- a/keyboards/helix/rev3_5rows/keymaps/five_rows/keymap.c
+++ b/keyboards/helix/rev3_5rows/keymaps/five_rows/keymap.c
@@ -1,0 +1,452 @@
+#include QMK_KEYBOARD_H
+#include "util.h"
+#include "bootloader.h"
+#ifdef PROTOCOL_LUFA
+#include "lufa.h"
+#include "split_util.h"
+#endif
+#ifdef CONSOLE_ENABLE
+  #include <print.h>
+#endif
+#include "layer_number.h"
+
+extern keymap_config_t keymap_config;
+
+extern uint8_t is_master;
+
+enum custom_keycodes {
+  QWERTY = SAFE_RANGE,
+  COLEMAK,
+  DVORAK,
+  EUCALYN,
+  KEYPAD,
+  xEISU,
+  xKANA,
+  ZERO2,
+  RGBRST
+};
+
+#define LAYOUT_wrapper(...)    LAYOUT(__VA_ARGS__)
+
+//Macros
+#define KC_LOWER  MO(_LOWER)
+#define XXXX      XXXXXXX
+#define ____      _______
+#define KC_ADJ    MO(_ADJUST)
+#define KC_LSMI   LSFT(KC_MINS)
+#define KC_LSEQ   LSFT(KC_EQL)
+#define KC_LSRB   LSFT(KC_RBRC)
+#define KC_LSLB   LSFT(KC_LBRC)
+
+#define _1_2_3_4_5           KC_1, KC_2, KC_3, KC_4, KC_5
+#define _6_7_8_9_0           KC_6, KC_7, KC_8, KC_9, KC_0
+#define L_LOWER2_CAPS_LALT_LGUI_SPC_RABS \
+    KC_LOWER, KC_LOWER, KC_CAPS, KC_LALT, KC_LGUI, KC_SPC, LT(_RAISE,KC_BSPC)
+#define R_RAEN_SPC_RGUI_RALT_APP_LOWER2 \
+    LT(_RAISE,KC_ENT), KC_SPC, KC_RGUI, KC_RALT,  KC_APP, KC_LOWER, KC_LOWER
+
+
+#if MATRIX_ROWS == 10 // HELIX_ROWS == 5
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+  /* Qwerty
+   * ,-----------------------------------.           ,-----------------------------------.
+   * | ESC |  1  |  2  |  3  |  4  |  5  |           |  6  |  7  |  8  |  9  |  0  | BS  |
+   * |-----+-----+-----+-----+-----+-----|           |-----+-----+-----+-----+-----+-----|
+   * | Tab |  Q  |  W  |  E  |  R  |  T  |           |  Y  |  U  |  I  |  O  |  P  |  \  |
+   * |-----+-----+-----+-----+-----+-----|           |-----+-----+-----+-----+-----+-----|
+   * | Ctrl|  A  |  S  |  D  |  F  |  G  |           |  H  |  J  |  K  |  L  |  ;  |Ctrl |
+   * |-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----|
+   * |Shift|  Z  |  X  |  C  |  V  |  B  |  `  |  '  |  N  |  M  |  ,  |  .  |  /  |Shift|
+   * |-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----|
+   * |Lower|Lower|Caps | Alt | GUI |Space|  BS |Enter|Space| GUI | Alt |Menu |Lower|Lower|
+   * `-----------------------------------------------------------------------------------'
+   */
+#define _Q_W_E_R_T           KC_Q, KC_W, KC_E, KC_R, KC_T
+#define _Y_U_I_O_P           KC_Y, KC_U, KC_I, KC_O, KC_P
+#define _A_S_D_F_G           KC_A, KC_S, KC_D, KC_F, KC_G
+#define _H_J_K_L_SCLN        KC_H, KC_J, KC_K, KC_L, KC_SCLN
+#define _Z_X_C_V_B           KC_Z, KC_X, KC_C, KC_V, KC_B
+#define _N_M_COMM_DOT_SLSH   KC_N, KC_M, KC_COMM, KC_DOT, KC_SLSH
+
+  [_QWERTY] = LAYOUT_wrapper( \
+    KC_ESC,   _1_2_3_4_5,                       _6_7_8_9_0,         KC_BSPC, \
+    KC_TAB,   _Q_W_E_R_T,                       _Y_U_I_O_P,         KC_BSLS, \
+    KC_LCTL,  _A_S_D_F_G,                       _H_J_K_L_SCLN,      KC_RCTL, \
+    KC_LSFT,  _Z_X_C_V_B,     KC_GRV,  KC_QUOT, _N_M_COMM_DOT_SLSH, KC_RSFT, \
+    L_LOWER2_CAPS_LALT_LGUI_SPC_RABS,  R_RAEN_SPC_RGUI_RALT_APP_LOWER2  \
+   ),
+
+  /* Colemak
+   * ,-----------------------------------.           ,-----------------------------------.
+   * | ESC |  1  |  2  |  3  |  4  |  5  |           |  6  |  7  |  8  |  9  |  0  | BS  |
+   * |-----+-----+-----+-----+-----+-----|           |-----+-----+-----+-----+-----+-----|
+   * | Tab |  Q  |  W  |  F  |  P  |  G  |           |  J  |  L  |  U  |  Y  |  ;  |  \  |
+   * |-----+-----+-----+-----+-----+-----|           |-----+-----+-----+-----+-----+-----|
+   * | Ctrl|  A  |  R  |  S  |  T  |  D  |           |  H  |  N  |  E  |  I  |  O  |Ctrl |
+   * |-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----|
+   * |Shift|  Z  |  X  |  C  |  V  |  B  |  `  |  '  |  K  |  M  |  ,  |  .  |  /  |Shift|
+   * |-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----|
+   * |Lower|Lower|Caps | Alt | GUI |Space|  BS |Enter|Space| GUI | Alt |Menu |Lower|Lower|
+   * `-----------------------------------------------------------------------------------'
+   */
+#define _Q_W_F_P_G           KC_Q, KC_W, KC_F, KC_P, KC_G
+#define _J_L_U_Y_SCLN        KC_J, KC_L, KC_U, KC_Y, KC_SCLN
+#define _A_R_S_T_D           KC_A, KC_R, KC_S, KC_T, KC_D
+#define _H_N_E_I_O           KC_H, KC_N, KC_E, KC_I, KC_O
+#define _Z_X_C_V_B           KC_Z, KC_X, KC_C, KC_V, KC_B
+#define _K_M_COMM_DOT_SLSH   KC_K, KC_M, KC_COMM, KC_DOT, KC_SLSH
+
+  [_COLEMAK] = LAYOUT_wrapper( \
+    KC_ESC,   _1_2_3_4_5,                       _6_7_8_9_0,         KC_BSPC, \
+    KC_TAB,   _Q_W_F_P_G,                       _J_L_U_Y_SCLN,      KC_BSLS, \
+    KC_LCTL,  _A_R_S_T_D,                       _H_N_E_I_O,         KC_RCTL, \
+    KC_LSFT,  _Z_X_C_V_B,     KC_GRV,  KC_QUOT, _K_M_COMM_DOT_SLSH, KC_RSFT, \
+    L_LOWER2_CAPS_LALT_LGUI_SPC_RABS,  R_RAEN_SPC_RGUI_RALT_APP_LOWER2  \
+  ),
+
+  /* Dvorak
+   * ,-----------------------------------.           ,-----------------------------------.
+   * | ESC |  1  |  2  |  3  |  4  |  5  |           |  6  |  7  |  8  |  9  |  0  | BS  |
+   * |-----+-----+-----+-----+-----+-----|           |-----+-----+-----+-----+-----+-----|
+   * | Tab |  '  |  ,  |  .  |  P  |  Y  |           |  F  |  G  |  C  |  R  |  L  |  \  |
+   * |-----+-----+-----+-----+-----+-----|           |-----+-----+-----+-----+-----+-----|
+   * | Ctrl|  A  |  O  |  E  |  U  |  I  |           |  D  |  H  |  T  |  N  |  S  |Ctrl |
+   * |-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----|
+   * |Shift|  ;  |  Q  |  J  |  K  |  X  |  `  |  /  |  B  |  M  |  W  |  V  |  Z  |Shift|
+   * |-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----|
+   * |Lower|Lower|Caps | Alt | GUI |Space|  BS |Enter|Space| GUI | Alt |Menu |Lower|Lower|
+   * `-----------------------------------------------------------------------------------'
+   */
+#define _QUOT_COMM_DOT_P_Y   KC_QUOT, KC_COMM, KC_DOT, KC_P, KC_Y
+#define _F_G_C_R_L           KC_F, KC_G, KC_C, KC_R, KC_L
+#define _A_O_E_U_I           KC_A, KC_O, KC_E, KC_U, KC_I
+#define _D_H_T_N_S           KC_D, KC_H, KC_T, KC_N, KC_S
+#define _SCLN_Q_J_K_X        KC_SCLN, KC_Q, KC_J, KC_K, KC_X
+#define _B_M_W_V_Z           KC_B, KC_M, KC_W, KC_V, KC_Z
+
+  [_DVORAK] = LAYOUT_wrapper( \
+    KC_ESC,   _1_2_3_4_5,                       _6_7_8_9_0,    KC_BSPC, \
+    KC_TAB,   _QUOT_COMM_DOT_P_Y,               _F_G_C_R_L,    KC_BSLS, \
+    KC_LCTL,  _A_O_E_U_I,                       _D_H_T_N_S,    KC_RCTL, \
+    KC_LSFT,  _SCLN_Q_J_K_X,  KC_GRV,  KC_SLSH, _B_M_W_V_Z,    KC_RSFT, \
+    L_LOWER2_CAPS_LALT_LGUI_SPC_RABS,  R_RAEN_SPC_RGUI_RALT_APP_LOWER2  \
+   ),
+
+  /* Eucalyn (http://eucalyn.hatenadiary.jp/entry/about-eucalyn-layout)
+   * ,-----------------------------------.           ,-----------------------------------.
+   * | ESC |  1  |  2  |  3  |  4  |  5  |           |  6  |  7  |  8  |  9  |  0  | BS  |
+   * |-----+-----+-----+-----+-----+-----|           |-----+-----+-----+-----+-----+-----|
+   * | Tab |  Q  |  W  |  ,  |  .  |  ;  |           |  M  |  R  |  D  |  Y  |  P  |  \  |
+   * |-----+-----+-----+-----+-----+-----|           |-----+-----+-----+-----+-----+-----|
+   * | Ctrl|  A  |  O  |  E  |  I  |  U  |           |  G  |  T  |  K  |  S  |  N  |Ctrl |
+   * |-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----|
+   * |Shift|  Z  |  X  |  C  |  V  |  F  |  `  |  '  |  B  |  H  |  J  |  L  |  /  |Shift|
+   * |-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----|
+   * |Lower|Lower|Caps | Alt | GUI |Space|  BS |Enter|Space| GUI | Alt |Menu |Lower|Lower|
+   * `-----------------------------------------------------------------------------------'
+   */
+#define _Q_W_COMM_DOT_SCLN   KC_Q, KC_W, KC_COMM, KC_DOT, KC_SCLN
+#define _M_R_D_Y_P           KC_M, KC_R, KC_D, KC_Y, KC_P
+#define _A_O_E_I_U           KC_A, KC_O, KC_E, KC_I, KC_U
+#define _G_T_K_S_N           KC_G, KC_T, KC_K, KC_S, KC_N
+#define _Z_X_C_V_F           KC_Z, KC_X, KC_C, KC_V, KC_F
+#define _B_H_J_L_SLSH        KC_B, KC_H, KC_J, KC_L, KC_SLSH
+
+  [_EUCALYN] = LAYOUT_wrapper( \
+    KC_ESC,   _1_2_3_4_5,                       _6_7_8_9_0,     KC_BSPC, \
+    KC_TAB,   _Q_W_COMM_DOT_SCLN,               _M_R_D_Y_P,     KC_BSLS, \
+    KC_LCTL,  _A_O_E_I_U,                       _G_T_K_S_N,     KC_RCTL, \
+    KC_LSFT,  _Z_X_C_V_F,     KC_GRV,  KC_QUOT, _B_H_J_L_SLSH,  KC_RSFT, \
+    L_LOWER2_CAPS_LALT_LGUI_SPC_RABS,  R_RAEN_SPC_RGUI_RALT_APP_LOWER2  \
+  ),
+
+  /* Keypad
+   * ,-----------------------------------.           ,-----------------------------------.
+   * | Tab |  /  |  *  | Del |  F1 |  F6 |           |  F1 |  F6 | Del | Tab |  /  |  *  |
+   * |-----+-----+-----+-----+-----+-----|           |-----+-----+-----+-----+-----+-----|
+   * |  7  |  8  |  9  | BS  |  F2 |  F7 |           |  F2 |  F7 | BS  |  7  |  8  |  9  |
+   * |-----+-----+-----+-----+-----+-----|           |-----+-----+-----+-----+-----+-----|
+   * |  4  |  5  |  6  |  -  |  F3 |  F8 |           |  F3 |  F8 |  -  |  4  |  5  |  6  |
+   * |-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----|
+   * |  1  |  2  |  3  |  +  |  F4 |  F9 | F11 | F11 |  F4 |  F9 |  +  |  1  |  2  |  3  |
+   * |-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----|
+   * |  0  |  ,  |  .  |Enter|  F5 |  F10| F12 | F12 |  F5 |  F10|Enter|  0  |  ,  |  .  |
+   * `-----------------------------------------------------------------------------------'
+   */
+#define KP_TOP KC_TAB,  KC_PSLS, KC_PAST
+#define KP_789 KC_KP_7, KC_KP_8, KC_KP_9
+#define KP_456 KC_KP_4, KC_KP_5, KC_KP_6
+#define KP_123 KC_KP_1, KC_KP_2, KC_KP_3
+#define KP_BTM KC_KP_0, KC_COMM, KC_PDOT
+#define F_1_6  KC_F1, KC_F6
+#define F_2_7  KC_F2, KC_F7
+#define F_3_8  KC_F3, KC_F8
+#define F_4_9  KC_F4, KC_F9
+#define F_510  KC_F5, KC_F10
+#define FF12   LT(_PADFUNC,KC_F12)
+
+  [_KEYPAD] = LAYOUT_wrapper( \
+    KP_TOP, KC_DEL,  F_1_6,                     F_1_6,  KC_DEL, KP_TOP, \
+    KP_789, KC_BSPC, F_2_7,                     F_2_7, KC_BSPC, KP_789, \
+    KP_456, KC_PMNS, F_3_8,                     F_3_8, KC_PMNS, KP_456, \
+    KP_123, KC_PPLS, F_4_9,  KC_F11,  KC_F11,  F_4_9, KC_PPLS, KP_123, \
+    KP_BTM, KC_PENT, F_510,    FF12,    FF12,  F_510, KC_PENT, KP_BTM  \
+  ),
+
+  /*  AUX modifier key layer
+   * ,-----------------------------------.           ,-----------------------------------.
+   * |     |     |     |     |     |     |           |     |     |     |     |     |     |
+   * |-----+-----+-----+-----+-----+-----|           |-----+-----+-----+-----+-----+-----|
+   * |     |     |     |     |     |     |           |     |     |     |     |     |     |
+   * |-----+-----+-----+-----+-----+-----|           |-----+-----+-----+-----+-----+-----|
+   * |     |     |     |     |     |     |           |     |     |     |     |     |     |
+   * |-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----|
+   * |     |     |     |     |     |     |     |     |     |     |     |     |     |     |
+   * |-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----|
+   * |     | 00  |     |     |     |     |     |     |     |     |     |     | 00  |     |
+   * `-----------------------------------------------------------------------------------'
+   */
+  [_KAUX] = LAYOUT( \
+      ____, ____, ____, ____, ____, ____,             ____, ____, ____, ____, ____, ____, \
+      ____, ____, ____, ____, ____, ____,             ____, ____, ____, ____, ____, ____, \
+      ____, ____, ____, ____, ____, ____,             ____, ____, ____, ____, ____, ____, \
+      ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, \
+      ____,ZERO2, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____,ZERO2, ____ \
+   ),
+
+  /*  Keypad function layer
+   * ,-----------------------------------------.             ,-----------------------------------------.
+   * |      |      |      | Pause| ScrLk| PtrSc|             | PtrSc| ScrLk| Pause|      |      |      |
+   * |------+------+------+------+------+------|             |------+------+------+------+------+------|
+   * |      |      |      | Home |  Up  | PgUp |             | PgUp |  Up  | Home |      |      |      |
+   * |------+------+------+------+------+------|             |------+------+------+------+------+------|
+   * |      |Delete|Insert| Left | Down | Right|             | Left | Down | Right|Insert|Delete|      |
+   * |------+------+------+------+------+------+------+------+------+------+------+------+------+------|
+   * |      |      |      | End  |      | PgDn |Adjust|Adjust| PgDn |      | End  |      |      |      |
+   * |------+------+------+------+------+------+------+------+------+------+------+------+------+------|
+   * |      |      |      |      |      |      |      |      |      |      |      |      |      |      |
+   * `-------------------------------------------------------------------------------------------------'
+   */
+#define _PAUS_SLCK_PSCR           KC_PAUS, KC_SLCK, KC_PSCR
+#define _PSCR_SLCK_PAUS           KC_PSCR, KC_SLCK, KC_PAUS
+#define _HOME_UP_PGUP             KC_HOME, KC_UP,   KC_PGUP
+#define _PGUP_UP_HOME             KC_PGUP, KC_UP,   KC_HOME
+#define _DEL_INS_LEFT_DOWN_RGHT   KC_DEL,  KC_INS,  KC_LEFT, KC_DOWN, KC_RGHT
+#define _LEFT_DOWN_RGHT_INS_DEL   KC_LEFT, KC_DOWN, KC_RGHT, KC_INS,  KC_DEL
+#define _PGDN_ADJ_ADJ_PGDN        KC_PGDN, KC_ADJ,  KC_ADJ,  KC_PGDN
+
+  [_PADFUNC] = LAYOUT_wrapper( \
+      XXXX, XXXX, XXXX, _PAUS_SLCK_PSCR,               _PSCR_SLCK_PAUS,       XXXX, XXXX, XXXX, \
+      XXXX, XXXX, XXXX,   _HOME_UP_PGUP,               _PGUP_UP_HOME,         XXXX, XXXX, XXXX, \
+      XXXX,     _DEL_INS_LEFT_DOWN_RGHT,               _LEFT_DOWN_RGHT_INS_DEL,           XXXX, \
+      XXXX, XXXX, XXXX, KC_END, XXXX,   _PGDN_ADJ_ADJ_PGDN,     XXXX, KC_END, XXXX, XXXX, XXXX, \
+      XXXX, XXXX, XXXX, XXXX,   XXXX, XXXX, ____, ____,   XXXX, XXXX,   XXXX, XXXX, XXXX, XXXX \
+   ),
+
+  /* Lower
+   * ,-----------------------------------------.             ,-----------------------------------------.
+   * |      |  F1  |  F2  |  F3  |  F4  |  F5  |             |  F6  |  F7  |  F8  |  F9  |  F10 | F11  |
+   * |------+------+------+------+------+------|             |------+------+------+------+------+------|
+   * |      |      |Pause | ScrLk| Ins  |      |             |      | Ins  | ScrLk|Pause |      | F12  |
+   * |------+------+------+------+------+------|             |------+------+------+------+------+------|
+   * |      | PgUp |      | Up   |Delete| Home |             | Home |Delete| Up   |      | PgUp |      |
+   * |------+------+------+------+------+------+------+------+------+------+------+------+------+------|
+   * |      | PgDn | Left | Down | Right| End  |Adjust|Adjust| End  | Left | Down | Right| PgDn |      |
+   * |------+------+------+------+------+------+------+------+------+------+------+------+------+------|
+   * |      |      | PrtSc|      |      |      |      |      |      |      |      | PrtSc|      |      |
+   * `-------------------------------------------------------------------------------------------------'
+   */
+#define _F1_F2_F3_F4_F5           KC_F1, KC_F2, KC_F3, KC_F4, KC_F5
+#define _F6_F7_F8_F9_F10_F11      KC_F6, KC_F7, KC_F8, KC_F9, KC_F10, KC_F11
+#define _PAUS_SLCK_INS            KC_PAUS, KC_SLCK, KC_INS
+#define _INS_SLCK_PAUS            KC_INS,  KC_SLCK, KC_PAUS
+#define _ADJ_ADJ                  KC_ADJ,  KC_ADJ
+#define _UP_DEL_PGUP              KC_UP,   KC_DEL,  KC_PGUP
+#define _PGUP_DEL_UP              KC_PGUP, KC_DEL,  KC_UP
+#define _END_LEFT_DOWN_RGHT_PGDN  KC_END,  KC_LEFT, KC_DOWN, KC_RGHT, KC_PGDN
+#define _PGDN_LEFT_DOWN_RGHT_END  KC_PGDN, KC_LEFT, KC_DOWN, KC_RGHT, KC_END
+
+  [_LOWER] = LAYOUT_wrapper( \
+      XXXX, _F1_F2_F3_F4_F5,                             _F6_F7_F8_F9_F10_F11, \
+      XXXX, XXXX,    _PAUS_SLCK_INS,   XXXX,             XXXX,  _INS_SLCK_PAUS,    XXXX, KC_F12, \
+      ____, KC_HOME, XXXX, _UP_DEL_PGUP,                 _PGUP_DEL_UP,      XXXX, KC_HOME, ____, \
+      ____, _END_LEFT_DOWN_RGHT_PGDN,        XXXX, XXXX, _PGDN_LEFT_DOWN_RGHT_END,         ____, \
+      ____, ____, KC_PSCR, ____, ____, ____,  _ADJ_ADJ,  ____, ____, ____, KC_PSCR, ____, ____ \
+      ),
+
+  /* Raise
+   * ,-----------------------------------------.             ,-----------------------------------------.
+   * |      |      |      |      |      |      |             |      |      |      |      |      |      |
+   * |------+------+------+------+------+------|             |------+------+------+------+------+------|
+   * |      |      |      |      |  _   |  -   |             |  =   |  +   |      |      |      |      |
+   * |------+------+------+------+------+------|             |------+------+------+------+------+------|
+   * |      |      |      |      |  {   |  [   |             |  ]   |  }   |      |      |      |      |
+   * |------+------+------+------+------+------+------+------+------+------+------+------+------+------|
+   * |      |      |      |      |      | EISU | EISU | KANA | KANA | Next | Vol- | Vol+ | Play |      |
+   * |------+------+------+------+------+------+------+------+------+------+------+------+------+------|
+   * |      |      |      |      |      |      |      |      |      |      |      |      |      |      |
+   * `-------------------------------------------------------------------------------------------------'
+   */
+#define _LSMI_MINS             KC_LSMI, KC_MINS
+#define _EQL_LSEQ              KC_EQL,  KC_LSEQ
+#define _LSLB_LBRC             KC_LSLB, KC_LBRC
+#define _RBRC_LSRB             KC_RBRC, KC_LSRB
+#define _MNXT_VOLD_VOLU_MPLY   KC_MNXT, KC_VOLD, KC_VOLU, KC_MPLY
+
+  [_RAISE] = LAYOUT_wrapper( \
+      XXXX, XXXX, XXXX, XXXX, XXXX, XXXX,             XXXX, XXXX, XXXX, XXXX, XXXX, XXXX, \
+      XXXX, XXXX, XXXX, XXXX, _LSMI_MINS,             _EQL_LSEQ,  XXXX, XXXX, XXXX, XXXX, \
+      ____, XXXX, XXXX, XXXX, _LSLB_LBRC,             _RBRC_LSRB, XXXX, XXXX, XXXX, ____, \
+      ____, XXXX, XXXX, XXXX, XXXX,xEISU,xEISU, xKANA,xKANA, _MNXT_VOLD_VOLU_MPLY,  ____, \
+      _ADJ_ADJ,   XXXX, ____, ____, XXXX, ____, ____, XXXX, ____, ____, XXXX,   _ADJ_ADJ \
+      ),
+
+  /* Adjust (Lower + Raise)
+   * ,-----------------------------------------.             ,-----------------------------------------.
+   * |      |Keypad|Dvorak|Colemk|Euclyn|Qwerty|             |Qwerty|Euclyn|Colemk|Dvorak|Keypad|      |
+   * |------+------+------+------+------+------|             |------+------+------+------+------+------|
+   * |      | Reset|RGBRST|RGB ON|Aud on| Win  |             | Win  |Aud on|RGB ON|RGBRST|      |      |
+   * |------+------+------+------+------+------|             |------+------+------+------+------+------|
+   * | HUE+ | SAT+ | VAL+ |RGB md|Audoff| Mac  |             | Mac  |Audoff|RGB md| VAL+ | SAT+ | HUE+ |
+   * |------+------+------+------+------+------+------+------+------+------+------+------+------+------|
+   * | HUE- | SAT- | VAL- |      |      |      |      |      |      |      |      | VAL- | SAT- | HUE- |
+   * |------+------+------+------+------+------+------+------+------+------+------+------+------+------|
+   * |      |      |      |      |      |      |      |      |      |      |      |      |      |      |
+   * `-------------------------------------------------------------------------------------------------'
+   */
+  [_ADJUST] =  LAYOUT( \
+      XXXXXXX, KEYPAD,  DVORAK,  COLEMAK, EUCALYN,  QWERTY,          QWERTY,  EUCALYN, COLEMAK,  DVORAK,  KEYPAD, XXXXXXX, \
+      XXXXXXX, RESET,   RGBRST,  RGB_TOG,   AU_ON, AG_SWAP,          AG_SWAP,   AU_ON, RGB_TOG,  RGBRST, XXXXXXX, XXXXXXX, \
+      RGB_HUI, RGB_SAI, RGB_VAI, RGB_MOD,  AU_OFF, AG_NORM,          AG_NORM,  AU_OFF, RGB_MOD, RGB_VAI, RGB_SAI, RGB_HUI, \
+      RGB_HUD, RGB_SAD, RGB_VAD, XXXXXXX, XXXXXXX, XXXXXXX,____,____,XXXXXXX, XXXXXXX, XXXXXXX, RGB_VAD, RGB_SAD, RGB_HUD, \
+      _______, _______, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,____,____,XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, _______, _______ \
+   ),
+
+  /*  AUX modifier key layer
+   * ,-----------------------------------------.             ,-----------------------------------------.
+   * |      |      |      |      |      |      |             |      |      |      |      |      |      |
+   * |------+------+------+------+------+------|             |------+------+------+------+------+------|
+   * |      |      |      |      |      |      |             |      |      |      |      |      |      |
+   * |------+------+------+------+------+------|             |------+------+------+------+------+------|
+   * |      |      |      |      |      |      |             |      |      |      |      |      |      |
+   * |------+------+------+------+------+------+------+------+------+------+------+------+------+------|
+   * |      |      |      |      |      |      |      |      |      |      |      |      |      |      |
+   * |------+------+------+------+------+------+------+------+------+------+------+------+------+------|
+   * |      |      |      |      |      |  BS  | Enter|      |      |      |      |      |      |      |
+   * `-------------------------------------------------------------------------------------------------'
+   */
+#define _BSPC_RAEN KC_BSPC, LT(_RAISE,KC_ENT)
+  [_AUX] = LAYOUT_wrapper( \
+      ____, ____, ____, ____, ____, ____,             ____, ____, ____, ____, ____, ____, \
+      ____, ____, ____, ____, ____, ____,             ____, ____, ____, ____, ____, ____, \
+      ____, ____, ____, ____, ____, ____,             ____, ____, ____, ____, ____, ____, \
+      ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, \
+      ____, ____, ____, ____, ____, _BSPC_RAEN, ____, ____, ____, ____, ____, ____, ____ \
+      )
+};
+
+#else
+#error "undefined keymaps"
+#endif
+
+
+int current_default_layer;
+
+uint32_t default_layer_state_set_user(uint32_t state) {
+    current_default_layer = biton32(state);
+    return state;
+}
+
+void update_base_layer(int base)
+{
+    if( current_default_layer != base ) {
+        eeconfig_update_default_layer(1UL<<base);
+        default_layer_set(1UL<<base);
+        layer_off(_AUX);
+        layer_off(_KAUX);
+    } else {
+        if( base < _KEYPAD )
+            layer_invert(_AUX);
+        else
+            layer_invert(_KAUX);
+    }
+}
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  switch (keycode) {
+    case QWERTY:
+      if (record->event.pressed) {
+        update_base_layer(_QWERTY);
+      }
+      return false;
+      break;
+    case COLEMAK:
+      if (record->event.pressed) {
+        update_base_layer(_COLEMAK);
+      }
+      return false;
+      break;
+    case DVORAK:
+      if (record->event.pressed) {
+        update_base_layer(_DVORAK);
+      }
+      return false;
+      break;
+    case EUCALYN:
+      if (record->event.pressed) {
+        update_base_layer(_EUCALYN);
+      }
+      return false;
+      break;
+    case KEYPAD:
+      if (record->event.pressed) {
+        update_base_layer(_KEYPAD);
+      }
+      return false;
+      break;
+    case ZERO2:
+      if (record->event.pressed) {
+          SEND_STRING("00");
+      }
+      return false;
+      break;
+    case xEISU:
+      if (record->event.pressed) {
+        if(keymap_config.swap_lalt_lgui==false){
+          register_code(KC_LANG2);
+        }else{
+          SEND_STRING(SS_LALT("`"));
+        }
+      } else {
+        unregister_code(KC_LANG2);
+      }
+      return false;
+      break;
+    case xKANA:
+      if (record->event.pressed) {
+        if(keymap_config.swap_lalt_lgui==false){
+          register_code(KC_LANG1);
+        }else{
+          SEND_STRING(SS_LALT("`"));
+        }
+      } else {
+        unregister_code(KC_LANG1);
+      }
+      return false;
+      break;
+    case RGBRST:
+      #ifdef RGBLIGHT_ENABLE
+        if (record->event.pressed) {
+          eeconfig_update_rgblight_default();
+          rgblight_enable();
+        }
+      #endif
+      break;
+  }
+  return true;
+}
+
+void matrix_init_user(void) {
+    INIT_HELIX_OLED(); /* define in layer_number.h */
+}

--- a/keyboards/helix/rev3_5rows/keymaps/five_rows/layer_number.h
+++ b/keyboards/helix/rev3_5rows/keymaps/five_rows/layer_number.h
@@ -1,0 +1,26 @@
+#pragma once
+
+// Each layer gets a name for readability, which is then used in the keymap matrix below.
+// The underscores don't mean anything - you can have a layer called STUFF or any other name.
+// Layer names don't all need to be of the same length, obviously, and you can also skip them
+// entirely and just use numbers.
+enum layer_number {
+    _QWERTY = 0,
+    _COLEMAK,
+    _DVORAK,
+    _EUCALYN,
+    _KEYPAD,
+    _AUX,
+    _KAUX,
+    _LOWER,
+    _RAISE,
+    _PADFUNC,
+    _ADJUST,
+};
+
+#if defined(SSD1306OLED)
+extern void init_helix_oled(void);
+#   define INIT_HELIX_OLED() init_helix_oled();
+#else
+#   define INIT_HELIX_OLED()
+#endif

--- a/keyboards/helix/rev3_5rows/keymaps/five_rows/oled_display.c
+++ b/keyboards/helix/rev3_5rows/keymaps/five_rows/oled_display.c
@@ -54,12 +54,12 @@ static void render_logo(struct CharacterMatrix *matrix) {
 static void render_logo(void) {
 #    endif
 
-    static char logo[]={
+    static const char helix_logo[] PROGMEM = {
         0x80,0x81,0x82,0x83,0x84,0x85,0x86,0x87,0x88,0x89,0x8a,0x8b,0x8c,0x8d,0x8e,0x8f,0x90,0x91,0x92,0x93,0x94,
         0xa0,0xa1,0xa2,0xa3,0xa4,0xa5,0xa6,0xa7,0xa8,0xa9,0xaa,0xab,0xac,0xad,0xae,0xaf,0xb0,0xb1,0xb2,0xb3,0xb4,
         0xc0,0xc1,0xc2,0xc3,0xc4,0xc5,0xc6,0xc7,0xc8,0xc9,0xca,0xcb,0xcc,0xcd,0xce,0xcf,0xd0,0xd1,0xd2,0xd3,0xd4,
         0};
-    oled_write(logo, false);
+    oled_write_P(helix_logo, false);
 #    ifdef RGBLIGHT_ENABLE
     char buf[30];
     if (RGBLIGHT_MODES > 1 && rgblight_is_enabled()) {
@@ -111,15 +111,15 @@ void render_status(void) {
 #    endif
 
     // Render to mode icon
-    static char logo[][2][3]={{{0x95,0x96,0},{0xb5,0xb6,0}},{{0x97,0x98,0},{0xb7,0xb8,0}}};
+    static const char os_logo[][2][3] PROGMEM ={{{0x95,0x96,0},{0xb5,0xb6,0}},{{0x97,0x98,0},{0xb7,0xb8,0}}};
     if(keymap_config.swap_lalt_lgui==false){
-        oled_write(logo[0][0], false);
+        oled_write_P(os_logo[0][0], false);
         oled_write_P(PSTR("\n"), false);
-        oled_write(logo[0][1], false);
+        oled_write_P(os_logo[0][1], false);
     } else {
-        oled_write(logo[1][0], false);
+        oled_write_P(os_logo[1][0], false);
         oled_write_P(PSTR("\n"), false);
-        oled_write(logo[1][1], false);
+        oled_write_P(os_logo[1][1], false);
     }
 
     // Define layers here, Have not worked out how to have text displayed for each layer. Copy down the number you see and add a case for it below
@@ -130,8 +130,8 @@ void render_status(void) {
     for (lstate = layer_state, name_num = 0;
          lstate && name_num < sizeof(layer_names)/sizeof(char *);
          lstate >>=1, name_num++) {
-        if( (lstate & 1) != 0 ) {
-            if( layer_names[name_num] ) {
+        if ((lstate & 1) != 0) {
+            if (layer_names[name_num]) {
                 oled_write_P(layer_names[name_num], false);
             }
         }

--- a/keyboards/helix/rev3_5rows/keymaps/five_rows/oled_display.c
+++ b/keyboards/helix/rev3_5rows/keymaps/five_rows/oled_display.c
@@ -1,0 +1,184 @@
+#include QMK_KEYBOARD_H
+#include <stdio.h>
+#ifdef CONSOLE_ENABLE
+  #include <print.h>
+#endif
+#ifdef SSD1306OLED
+  #include "ssd1306.h"
+#endif
+#include "string.h"
+#include "layer_number.h"
+
+extern int current_default_layer;
+
+void init_helix_oled(void) {
+#ifdef SSD1306OLED
+    //SSD1306 OLED init, make sure to add #define SSD1306OLED in config.h
+    iota_gfx_init(!has_usb());   // turns on the display
+#endif
+}
+
+//SSD1306 OLED update loop, make sure to add #define SSD1306OLED in config.h
+#if defined(SSD1306OLED) || defined(OLED_DRIVER_ENABLE)
+
+#    if defined(OLED_DRIVER_ENABLE)
+oled_rotation_t oled_init_user(oled_rotation_t rotation) {
+    if (is_keyboard_master()) {
+        return OLED_ROTATION_0;
+    } else {
+        return OLED_ROTATION_180;
+    }
+}
+#    else
+#    define oled_write(data,flag)    matrix_write(matrix, data)
+#    define oled_write_P(data,flag)  matrix_write_P(matrix, data)
+#    endif
+
+#    ifdef SSD1306OLED
+void matrix_scan_user(void) {
+    iota_gfx_task();  // this is what updates the display continuously
+}
+
+void matrix_update(struct CharacterMatrix *dest,
+                   const struct CharacterMatrix *source) {
+    if (memcmp(dest->display, source->display, sizeof(dest->display))) {
+        memcpy(dest->display, source->display, sizeof(dest->display));
+        dest->dirty = true;
+    }
+}
+#    endif
+
+#    ifdef SSD1306OLED
+static void render_logo(struct CharacterMatrix *matrix) {
+#    else
+static void render_logo(void) {
+#    endif
+
+    static char logo[]={
+        0x80,0x81,0x82,0x83,0x84,0x85,0x86,0x87,0x88,0x89,0x8a,0x8b,0x8c,0x8d,0x8e,0x8f,0x90,0x91,0x92,0x93,0x94,
+        0xa0,0xa1,0xa2,0xa3,0xa4,0xa5,0xa6,0xa7,0xa8,0xa9,0xaa,0xab,0xac,0xad,0xae,0xaf,0xb0,0xb1,0xb2,0xb3,0xb4,
+        0xc0,0xc1,0xc2,0xc3,0xc4,0xc5,0xc6,0xc7,0xc8,0xc9,0xca,0xcb,0xcc,0xcd,0xce,0xcf,0xd0,0xd1,0xd2,0xd3,0xd4,
+        0};
+    oled_write(logo, false);
+#    ifdef RGBLIGHT_ENABLE
+    char buf[30];
+    if (RGBLIGHT_MODES > 1 && rgblight_is_enabled()) {
+        snprintf(buf, sizeof(buf), " LED %2d: %d,%d,%d ",
+                 rgblight_get_mode(),
+                 rgblight_get_hue()/RGBLIGHT_HUE_STEP,
+                 rgblight_get_sat()/RGBLIGHT_SAT_STEP,
+                 rgblight_get_val()/RGBLIGHT_VAL_STEP);
+        oled_write(buf, false);
+#        ifndef SSD1306OLED
+    } else {
+        oled_write_P( PSTR("\n"), false);
+#        endif
+    }
+#    endif
+}
+
+static const char Qwerty_name[]  PROGMEM = " Qwerty";
+static const char Colemak_name[] PROGMEM = " Colemak";
+static const char Dvorak_name[]  PROGMEM = " Dvorak";
+static const char Eucalyn_name[] PROGMEM = " Eucalyn";
+static const char Keypad_name[]  PROGMEM = " Keypad";
+
+static const char AUX_name[]     PROGMEM = ":AUX";
+static const char KAUX_name[]    PROGMEM = ":00";
+static const char Padfunc_name[] PROGMEM = ":PadFunc";
+static const char Lower_name[]   PROGMEM = ":Func";
+static const char Raise_name[]   PROGMEM = ":Extra";
+static const char Adjust_name[]  PROGMEM = ":Adjust";
+
+static const char *layer_names[] = {
+    [_QWERTY] = Qwerty_name,
+    [_COLEMAK] = Colemak_name,
+    [_DVORAK] = Dvorak_name,
+    [_EUCALYN]= Eucalyn_name,
+    [_KEYPAD] = Keypad_name,
+    [_AUX]    = AUX_name,
+    [_KAUX]   = KAUX_name,
+    [_LOWER]  = Lower_name,
+    [_RAISE]  = Raise_name,
+    [_PADFUNC]= Padfunc_name,
+    [_ADJUST] = Adjust_name
+};
+
+#    ifdef SSD1306OLED
+void render_status(struct CharacterMatrix *matrix) {
+#    else
+void render_status(void) {
+#    endif
+
+    // Render to mode icon
+    static char logo[][2][3]={{{0x95,0x96,0},{0xb5,0xb6,0}},{{0x97,0x98,0},{0xb7,0xb8,0}}};
+    if(keymap_config.swap_lalt_lgui==false){
+        oled_write(logo[0][0], false);
+        oled_write_P(PSTR("\n"), false);
+        oled_write(logo[0][1], false);
+    } else {
+        oled_write(logo[1][0], false);
+        oled_write_P(PSTR("\n"), false);
+        oled_write(logo[1][1], false);
+    }
+
+    // Define layers here, Have not worked out how to have text displayed for each layer. Copy down the number you see and add a case for it below
+    int name_num;
+    uint32_t lstate;
+    oled_write_P(layer_names[current_default_layer], false);
+    oled_write_P(PSTR("\n"), false);
+    for (lstate = layer_state, name_num = 0;
+         lstate && name_num < sizeof(layer_names)/sizeof(char *);
+         lstate >>=1, name_num++) {
+        if( (lstate & 1) != 0 ) {
+            if( layer_names[name_num] ) {
+                oled_write_P(layer_names[name_num], false);
+            }
+        }
+    }
+
+    // Host Keyboard LED Status
+    char led[40];
+    snprintf(led, sizeof(led), "\n%s  %s  %s",
+             (host_keyboard_leds() & (1<<USB_LED_NUM_LOCK)) ? "NUMLOCK" : "       ",
+             (host_keyboard_leds() & (1<<USB_LED_CAPS_LOCK)) ? "CAPS" : "    ",
+             (host_keyboard_leds() & (1<<USB_LED_SCROLL_LOCK)) ? "SCLK" : "    ");
+    oled_write(led, false);
+}
+
+#    ifdef SSD1306OLED
+void iota_gfx_task_user(void) {
+    struct CharacterMatrix matrix;
+
+#        if DEBUG_TO_SCREEN
+    if (debug_enable) {
+        return;
+    }
+#        endif
+
+    matrix_clear(&matrix);
+    if (is_keyboard_master()) {
+        render_status(&matrix);
+    } else {
+        render_logo(&matrix);
+    }
+    matrix_update(&display, &matrix);
+}
+#    else
+void oled_task_user(void) {
+
+#        if DEBUG_TO_SCREEN
+    if (debug_enable) {
+        return;
+    }
+#        endif
+
+    if(is_keyboard_master()){
+        render_status();
+    }else{
+        render_logo();
+    }
+}
+#    endif
+
+#endif

--- a/keyboards/helix/rev3_5rows/keymaps/five_rows/oled_display.c
+++ b/keyboards/helix/rev3_5rows/keymaps/five_rows/oled_display.c
@@ -1,3 +1,19 @@
+/* Copyright 2020 mtei
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include QMK_KEYBOARD_H
 #include <stdio.h>
 #ifdef CONSOLE_ENABLE

--- a/keyboards/helix/rev3_5rows/keymaps/five_rows/rules.mk
+++ b/keyboards/helix/rev3_5rows/keymaps/five_rows/rules.mk
@@ -1,0 +1,44 @@
+# QMK Standard Build Options
+#   change to "no" to disable the options, or define them in the Makefile in
+#   the appropriate keymap folder that will get included automatically
+#
+#   See TOP/docs/config_options.md for more information.
+#
+ CONSOLE_ENABLE = no        # Console for debug
+ COMMAND_ENABLE = no        # Commands for debug and configuration
+ # CONSOLE_ENABLE and COMMAND_ENABLE
+ #      yes, no  +1500
+ #      yes, yes +3200
+ #      no,  yes +400
+LTO_ENABLE = no  # if firmware size over limit, try this option
+
+ifneq ($(strip $(HELIX)),)
+  define KEYMAP_OPTION_PARSE
+    # $xinfo .$1.x #debug
+    # parse  'dispoff', 'consle', 'back', 'oled'
+    ifeq ($(strip $1),dispoff)
+        OLED_DRIVER_ENABLE = no
+        RGBLIGHT_ENABLE = no
+    endif
+    ifeq ($(strip $1),console)
+        CONSOLE_ENABLE = yes
+    endif
+    ifeq ($(strip $1),oled)
+        OLED_DRIVER_ENABLE = yes
+    endif
+    ifeq ($(strip $1),back)
+        RGBLIGHT_ENABLE = yes
+    endif
+    ifeq ($(strip $1),scan)
+        # use DEBUG_MATRIX_SCAN_RATE
+        # see docs/newbs_testing_debugging.md
+        OPT_DEFS +=  -DDEBUG_MATRIX_SCAN_RATE
+        CONSOLE_ENABLE = yes
+        SRC += keyboard_post_init_user_scan.c
+    endif
+  endef # end of KEYMAP_OPTION_PARSE
+
+  COMMA=,
+  $(eval $(foreach A_OPTION_NAME,$(subst $(COMMA), ,$(HELIX)),  \
+      $(call KEYMAP_OPTION_PARSE,$(A_OPTION_NAME))))
+endif


### PR DESCRIPTION

## Description

Clean up my keymap 'helix:five_rows'

* Makes the OLED driver used by the helix:five_rows keymap switchable.
* Separated the OLED related code from keymap.c and moved it to oled_display.c.
* Removing unused audio-related code.
* Stopped using `LAYOUT_kc()`.
* Ported the keymap from helix/rev2:five_rows to helix/rev3_5rows:five_rows.

ssd1306.c v.s. oled_driver.c (helix/rev2:five_rows)

|text size | data size | bss size | OLED          |scan rate | configure      |
|----------|-----------|----------|---------------|----------|----------------|
| 18880    | 58        | 235      | none          | 1590     | Helix old code |
| 18554    | 40        | 231      | none          | 1202     | split_common   |
| 24048    | 196       | 342      | ssd1306.c     | 739      | Helix old code |
| 23750    | 176       | 338      | ssd1306.c     | 642      | split_common   |
| 24590    | 210       | 798      | oled_driver.c | 293      | Helix old code |
| 24290    | 190       | 794      | oled_driver.c | 277      | split_common   |

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
