### PR TITLE
[Keyboard] YMDK NP21: correct numpad layout matrix

### DIFF
--- a/keyboards/ymdk_np21/ymdk_np21.h
+++ b/keyboards/ymdk_np21/ymdk_np21.h
@@ -50,15 +50,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define LAYOUT_numpad_6x4( \
     k00,  k10,  k20,  k30, \
     k01,  k11,  k21,  k31, \
-    k02,  k12,  k22,\
-    k03,  k13,  k23,  k33, \
+    k02,  k12,  k22, \
+    k03,  k13,  k23,  k32, \
     k04,  k14,  k24, \
-    k05,        k25,  k35 \
+    k05,        k25,  k34 \
 ) { \
     { k00, k01, k02, k03, k04, k05 }, \
     { k10, k11, k12, k13, k14, XXX }, \
     { k20, k21, k22, k23, k24, k25 }, \
-    { k30, k31, XXX, k33, XXX, k35 } \
+    { k30, k31, k32, XXX, k34, XXX } \
 }
 
 #define LAYOUT LAYOUT_ortho_4x6


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->


<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I noticed that my KC_PPLS and KC_PENT keys weren't actually doing
anything. By looking at the ortho_6x4 layout, I guessed that maybe the
pins were incorrect and guessed the proper ones. Now, my numpad is fully
functional.

It's quite possible that this is only the case for my specific board (maybe a mistake during soldering?), however.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
