### PR TITLE
Allow APM32 MCUs on certain CannonKeys PCBs

### DIFF
--- a/keyboards/cannonkeys/an_c/rules.mk
+++ b/keyboards/cannonkeys/an_c/rules.mk
@@ -20,6 +20,7 @@ WS2812_DRIVER = spi
 
 LAYOUTS = 60_ansi 60_tsangan_hhkb
 
+# Wildcard to allow APM32 MCU 
 DFU_SUFFIX_ARGS = -p FFFF -v FFFF
 
 # Enter lower-power sleep mode when on the ChibiOS idle thread

--- a/keyboards/cannonkeys/an_c/rules.mk
+++ b/keyboards/cannonkeys/an_c/rules.mk
@@ -20,7 +20,7 @@ WS2812_DRIVER = spi
 
 LAYOUTS = 60_ansi 60_tsangan_hhkb
 
-DFU_SUFFIX_ARGS =
+DFU_SUFFIX_ARGS = -p FFFF -v FFFF
 
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/cannonkeys/an_c/rules.mk
+++ b/keyboards/cannonkeys/an_c/rules.mk
@@ -20,6 +20,7 @@ WS2812_DRIVER = spi
 
 LAYOUTS = 60_ansi 60_tsangan_hhkb
 
+DFU_SUFFIX_ARGS =
 
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/cannonkeys/db60/rules.mk
+++ b/keyboards/cannonkeys/db60/rules.mk
@@ -17,6 +17,7 @@ WS2812_DRIVER = spi
 
 LAYOUTS = 60_ansi 60_tsangan_hhkb 60_iso
 
+# Wildcard to allow APM32 MCU 
 DFU_SUFFIX_ARGS = -p FFFF -v FFFF
 
 # Enter lower-power sleep mode when on the ChibiOS idle thread

--- a/keyboards/cannonkeys/db60/rules.mk
+++ b/keyboards/cannonkeys/db60/rules.mk
@@ -17,7 +17,7 @@ WS2812_DRIVER = spi
 
 LAYOUTS = 60_ansi 60_tsangan_hhkb 60_iso
 
-DFU_SUFFIX_ARGS =
+DFU_SUFFIX_ARGS = -p FFFF -v FFFF
 
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/cannonkeys/db60/rules.mk
+++ b/keyboards/cannonkeys/db60/rules.mk
@@ -17,5 +17,7 @@ WS2812_DRIVER = spi
 
 LAYOUTS = 60_ansi 60_tsangan_hhkb 60_iso
 
+DFU_SUFFIX_ARGS =
+
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/cannonkeys/devastatingtkl/rules.mk
+++ b/keyboards/cannonkeys/devastatingtkl/rules.mk
@@ -16,7 +16,7 @@ BACKLIGHT_ENABLE = yes
 RGBLIGHT_ENABLE = yes
 WS2812_DRIVER = spi
 
-DFU_SUFFIX_ARGS =
+DFU_SUFFIX_ARGS = -p FFFF -v FFFF
 
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/cannonkeys/devastatingtkl/rules.mk
+++ b/keyboards/cannonkeys/devastatingtkl/rules.mk
@@ -16,6 +16,7 @@ BACKLIGHT_ENABLE = yes
 RGBLIGHT_ENABLE = yes
 WS2812_DRIVER = spi
 
+# Wildcard to allow APM32 MCU 
 DFU_SUFFIX_ARGS = -p FFFF -v FFFF
 
 # Enter lower-power sleep mode when on the ChibiOS idle thread

--- a/keyboards/cannonkeys/devastatingtkl/rules.mk
+++ b/keyboards/cannonkeys/devastatingtkl/rules.mk
@@ -16,5 +16,7 @@ BACKLIGHT_ENABLE = yes
 RGBLIGHT_ENABLE = yes
 WS2812_DRIVER = spi
 
+DFU_SUFFIX_ARGS =
+
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/cannonkeys/instant60/rules.mk
+++ b/keyboards/cannonkeys/instant60/rules.mk
@@ -19,6 +19,7 @@ WS2812_DRIVER = spi
 
 LAYOUTS = 60_ansi 60_tsangan_hhkb
 
+# Wildcard to allow APM32 MCU 
 DFU_SUFFIX_ARGS = -p FFFF -v FFFF
 
 # Enter lower-power sleep mode when on the ChibiOS idle thread

--- a/keyboards/cannonkeys/instant60/rules.mk
+++ b/keyboards/cannonkeys/instant60/rules.mk
@@ -19,7 +19,7 @@ WS2812_DRIVER = spi
 
 LAYOUTS = 60_ansi 60_tsangan_hhkb
 
-DFU_SUFFIX_ARGS =
+DFU_SUFFIX_ARGS = -p FFFF -v FFFF
 
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/cannonkeys/instant60/rules.mk
+++ b/keyboards/cannonkeys/instant60/rules.mk
@@ -19,6 +19,7 @@ WS2812_DRIVER = spi
 
 LAYOUTS = 60_ansi 60_tsangan_hhkb
 
+DFU_SUFFIX_ARGS =
 
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/cannonkeys/instant65/rules.mk
+++ b/keyboards/cannonkeys/instant65/rules.mk
@@ -22,4 +22,4 @@ WS2812_DRIVER = spi
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
-DFU_SUFFIX_ARGS =
+DFU_SUFFIX_ARGS = -p FFFF -v FFFF

--- a/keyboards/cannonkeys/instant65/rules.mk
+++ b/keyboards/cannonkeys/instant65/rules.mk
@@ -22,4 +22,5 @@ WS2812_DRIVER = spi
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
+# Wildcard to allow APM32 MCU 
 DFU_SUFFIX_ARGS = -p FFFF -v FFFF

--- a/keyboards/cannonkeys/instant65/rules.mk
+++ b/keyboards/cannonkeys/instant65/rules.mk
@@ -21,3 +21,5 @@ WS2812_DRIVER = spi
 
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
+
+DFU_SUFFIX_ARGS =

--- a/keyboards/cannonkeys/obliterated75/rules.mk
+++ b/keyboards/cannonkeys/obliterated75/rules.mk
@@ -19,7 +19,7 @@ AUDIO_ENABLE = no           # Audio output on port C6
 FAUXCLICKY_ENABLE = no      # Use buzzer to emulate clicky switches
 WS2812_DRIVER = spi
 
-DFU_SUFFIX_ARGS =
+DFU_SUFFIX_ARGS = -p FFFF -v FFFF
 
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/cannonkeys/obliterated75/rules.mk
+++ b/keyboards/cannonkeys/obliterated75/rules.mk
@@ -19,6 +19,7 @@ AUDIO_ENABLE = no           # Audio output on port C6
 FAUXCLICKY_ENABLE = no      # Use buzzer to emulate clicky switches
 WS2812_DRIVER = spi
 
+# Wildcard to allow APM32 MCU 
 DFU_SUFFIX_ARGS = -p FFFF -v FFFF
 
 # Enter lower-power sleep mode when on the ChibiOS idle thread

--- a/keyboards/cannonkeys/obliterated75/rules.mk
+++ b/keyboards/cannonkeys/obliterated75/rules.mk
@@ -19,5 +19,7 @@ AUDIO_ENABLE = no           # Audio output on port C6
 FAUXCLICKY_ENABLE = no      # Use buzzer to emulate clicky switches
 WS2812_DRIVER = spi
 
+DFU_SUFFIX_ARGS =
+
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/cannonkeys/rekt1800/rules.mk
+++ b/keyboards/cannonkeys/rekt1800/rules.mk
@@ -15,7 +15,7 @@ CUSTOM_MATRIX = no          # Custom matrix file
 BACKLIGHT_ENABLE = yes
 RGBLIGHT_ENABLE = no
 
-DFU_SUFFIX_ARGS =
+DFU_SUFFIX_ARGS = -p FFFF -v FFFF
 
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/cannonkeys/rekt1800/rules.mk
+++ b/keyboards/cannonkeys/rekt1800/rules.mk
@@ -15,6 +15,7 @@ CUSTOM_MATRIX = no          # Custom matrix file
 BACKLIGHT_ENABLE = yes
 RGBLIGHT_ENABLE = no
 
+# Wildcard to allow APM32 MCU 
 DFU_SUFFIX_ARGS = -p FFFF -v FFFF
 
 # Enter lower-power sleep mode when on the ChibiOS idle thread

--- a/keyboards/cannonkeys/rekt1800/rules.mk
+++ b/keyboards/cannonkeys/rekt1800/rules.mk
@@ -15,5 +15,7 @@ CUSTOM_MATRIX = no          # Custom matrix file
 BACKLIGHT_ENABLE = yes
 RGBLIGHT_ENABLE = no
 
+DFU_SUFFIX_ARGS =
+
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/cannonkeys/satisfaction75/rules.mk
+++ b/keyboards/cannonkeys/satisfaction75/rules.mk
@@ -24,7 +24,7 @@ QWIIC_ENABLE += MICRO_OLED
 
 DEFAULT_FOLDER = cannonkeys/satisfaction75/rev1
 
-DFU_SUFFIX_ARGS =
+DFU_SUFFIX_ARGS = -p FFFF -v FFFF
 
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/cannonkeys/satisfaction75/rules.mk
+++ b/keyboards/cannonkeys/satisfaction75/rules.mk
@@ -24,6 +24,7 @@ QWIIC_ENABLE += MICRO_OLED
 
 DEFAULT_FOLDER = cannonkeys/satisfaction75/rev1
 
+# Wildcard to allow APM32 MCU 
 DFU_SUFFIX_ARGS = -p FFFF -v FFFF
 
 # Enter lower-power sleep mode when on the ChibiOS idle thread

--- a/keyboards/cannonkeys/satisfaction75/rules.mk
+++ b/keyboards/cannonkeys/satisfaction75/rules.mk
@@ -24,6 +24,7 @@ QWIIC_ENABLE += MICRO_OLED
 
 DEFAULT_FOLDER = cannonkeys/satisfaction75/rev1
 
+DFU_SUFFIX_ARGS =
 
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/cannonkeys/savage65/rules.mk
+++ b/keyboards/cannonkeys/savage65/rules.mk
@@ -21,6 +21,7 @@ WS2812_DRIVER = spi
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
+# Wildcard to allow APM32 MCU 
 DFU_SUFFIX_ARGS = -p FFFF -v FFFF
 
 LAYOUTS = 65_ansi_blocker 65_ansi_blocker_split_bs 65_ansi_blocker_tsangan 65_iso_blocker

--- a/keyboards/cannonkeys/savage65/rules.mk
+++ b/keyboards/cannonkeys/savage65/rules.mk
@@ -21,6 +21,6 @@ WS2812_DRIVER = spi
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
-DFU_SUFFIX_ARGS =
+DFU_SUFFIX_ARGS = -p FFFF -v FFFF
 
 LAYOUTS = 65_ansi_blocker 65_ansi_blocker_split_bs 65_ansi_blocker_tsangan 65_iso_blocker

--- a/keyboards/cannonkeys/savage65/rules.mk
+++ b/keyboards/cannonkeys/savage65/rules.mk
@@ -21,4 +21,6 @@ WS2812_DRIVER = spi
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
+DFU_SUFFIX_ARGS =
+
 LAYOUTS = 65_ansi_blocker 65_ansi_blocker_split_bs 65_ansi_blocker_tsangan 65_iso_blocker

--- a/keyboards/cannonkeys/tmov2/rules.mk
+++ b/keyboards/cannonkeys/tmov2/rules.mk
@@ -21,4 +21,5 @@ WS2812_DRIVER = spi
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
+# Wildcard to allow APM32 MCU 
 DFU_SUFFIX_ARGS = -p FFFF -v FFFF

--- a/keyboards/cannonkeys/tmov2/rules.mk
+++ b/keyboards/cannonkeys/tmov2/rules.mk
@@ -21,4 +21,4 @@ WS2812_DRIVER = spi
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
-DFU_SUFFIX_ARGS =
+DFU_SUFFIX_ARGS = -p FFFF -v FFFF

--- a/keyboards/cannonkeys/tmov2/rules.mk
+++ b/keyboards/cannonkeys/tmov2/rules.mk
@@ -20,3 +20,5 @@ WS2812_DRIVER = spi
 
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
+
+DFU_SUFFIX_ARGS =


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Allow APM32 MCUs on certain CannonKeys PCBs
We'll do this by removing the DFU suffix which locks in the firmware to just STM32 device ids.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
