### PR TITLE
Fix documentation of `lsusb` behaviour

### DIFF
--- a/docs/hardware_avr.md
+++ b/docs/hardware_avr.md
@@ -77,7 +77,7 @@ Do change the `MANUFACTURER` and `PRODUCT` lines to accurately reflect your keyb
 #define PRODUCT         my_awesome_keyboard
 ```
 
-?> Windows and macOS will display the `MANUFACTURER` and `PRODUCT` in the list of USB devices. `lsusb` on Linux instead takes these from the list maintained by the [USB ID Repository](http://www.linux-usb.org/usb-ids.html) by default. `lsusb -v` will show the values reported by the device, and they are also present in kernel logs after plugging it in.
+?> Windows and macOS will display the `MANUFACTURER` and `PRODUCT` in the list of USB devices. `lsusb` on Linux instead prefers the values in the list maintained by the [USB ID Repository](http://www.linux-usb.org/usb-ids.html). By default, it will only use `MANUFACTURER` and `PRODUCT` if the list does not contain that `VENDOR_ID` / `PRODUCT_ID`. `sudo lsusb -v` will show the values reported by the device, and they are also present in kernel logs after plugging it in.
 
 ### Keyboard Matrix Configuration
 


### PR DESCRIPTION
The documentation did not accurately reflect the behaviour of `lsusb` , which might result in minor confusion.

## Description

On Fedora 32 (and I assume most other distributions), `lsusb` will display the configured `MANUFACTURER` and `PRODUCT` if the database does not contain entries for the `VENDOR_ID` and `PRODUCT_ID` used. Considering the DB does not contain any entries for the vendor `0xFEED`, it should just display the values as advertised by the device.

Similarly, doing a `lsusb -v` will not show those values, as it seems that a regular user does not have the required permissions to read them. It will just leave the field empty. Doing a `sudo lsusb -v` fixes this.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

Most don't apply because it's just a two-line documentation fix.
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
