### PR TITLE
Warn when building a board that uses arm_atsam

### DIFF
--- a/tmk_core/arm_atsam.mk
+++ b/tmk_core/arm_atsam.mk
@@ -50,6 +50,14 @@ MCUFLAGS += -D__$(ARM_ATSAM)__
 #     For a directory that has spaces, enclose it in quotes.
 EXTRALIBDIRS =
 
+cpfirmware: warn-arm_atsam
+.INTERMEDIATE: warn-arm_atsam
+warn-arm_atsam: $(FIRMWARE_FORMAT)
+	$(info @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@)
+	$(info This MCU support package has a lack of support from the upstream provider (Massdrop).)
+	$(info It's likely that this keyboard will be deprecated in the near future.)
+	$(info @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@)
+
 # Convert hex to bin.
 bin: $(BUILD_DIR)/$(TARGET).hex
 	$(OBJCOPY) -Iihex -Obinary $(BUILD_DIR)/$(TARGET).hex $(BUILD_DIR)/$(TARGET).bin

--- a/tmk_core/arm_atsam.mk
+++ b/tmk_core/arm_atsam.mk
@@ -55,7 +55,8 @@ cpfirmware: warn-arm_atsam
 warn-arm_atsam: $(FIRMWARE_FORMAT)
 	$(info @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@)
 	$(info This MCU support package has a lack of support from the upstream provider (Massdrop).)
-	$(info It's likely that this keyboard will be deprecated in the near future.)
+	$(info Please ask them for support for build issues, and encourage them to align their future
+	$(info board design choices to gain proper compatibility with QMK.
 	$(info @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@)
 
 # Convert hex to bin.

--- a/tmk_core/arm_atsam.mk
+++ b/tmk_core/arm_atsam.mk
@@ -55,10 +55,10 @@ cpfirmware: warn-arm_atsam
 warn-arm_atsam: $(FIRMWARE_FORMAT)
 	$(info @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@)
 	$(info This MCU support package has a lack of support from the upstream provider (Massdrop).)
-	$(info There are currently questions about valid licensing, and at this stage it's likely
-	$(info their boards and supporting code will be removed from QMK in the near future. Please
-	$(info contact Massdrop for support, and encourage them to align their future board design
-	$(info choices to gain proper license compatibility with QMK.
+	$(info There are currently questions about valid licensing, and at this stage it's likely)
+	$(info their boards and supporting code will be removed from QMK in the near future. Please)
+	$(info contact Massdrop for support, and encourage them to align their future board design)
+	$(info choices to gain proper license compatibility with QMK.)
 	$(info @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@)
 
 # Convert hex to bin.

--- a/tmk_core/arm_atsam.mk
+++ b/tmk_core/arm_atsam.mk
@@ -55,8 +55,10 @@ cpfirmware: warn-arm_atsam
 warn-arm_atsam: $(FIRMWARE_FORMAT)
 	$(info @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@)
 	$(info This MCU support package has a lack of support from the upstream provider (Massdrop).)
-	$(info Please ask them for support for build issues, and encourage them to align their future
-	$(info board design choices to gain proper compatibility with QMK.
+	$(info There are currently questions about valid licensing, and at this stage it's likely
+	$(info their boards and supporting code will be removed from QMK in the near future. Please
+	$(info contact Massdrop for support, and encourage them to align their future board design
+	$(info choices to gain proper license compatibility with QMK.
 	$(info @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@)
 
 # Convert hex to bin.


### PR DESCRIPTION
## Description

Add deprecation warning during build when building a board that uses arm_atsam.

![image](https://user-images.githubusercontent.com/2985843/130155153-5c381e37-fb00-471a-9da1-b9595d5554b5.png)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
