### PR TITLE
Add support for #define WS2812_RGB to support non-standard implementa…

### DIFF
--- a/drivers/chibios/ws2812.c
+++ b/drivers/chibios/ws2812.c
@@ -88,9 +88,15 @@ void ws2812_setleds(LED_TYPE *ledarray, uint16_t leds) {
     chSysLock();
 
     for (uint8_t i = 0; i < leds; i++) {
+#ifdef WS2812_RGB
+        // Support for strange RGB implementations
+        sendByte(ledarray[i].r);
+        sendByte(ledarray[i].g);
+#else
         // WS2812 protocol dictates grb order
         sendByte(ledarray[i].g);
         sendByte(ledarray[i].r);
+#endif
         sendByte(ledarray[i].b);
 #ifdef RGBW
         sendByte(ledarray[i].w);

--- a/drivers/chibios/ws2812_pwm.c
+++ b/drivers/chibios/ws2812_pwm.c
@@ -221,6 +221,10 @@ void ws2812_setleds(LED_TYPE* ledarray, uint16_t leds) {
     }
 
     for (uint16_t i = 0; i < leds; i++) {
+ #ifdef WS2812_RGB
+        // Support for strange RGB implementations
+        ws2812_write_led(i, ledarray[i].g, ledarray[i].r, ledarray[i].b);
+#else
         ws2812_write_led(i, ledarray[i].r, ledarray[i].g, ledarray[i].b);
     }
 }

--- a/drivers/chibios/ws2812_spi.c
+++ b/drivers/chibios/ws2812_spi.c
@@ -61,9 +61,14 @@ static uint8_t get_protocol_eq(uint8_t data, int pos) {
 
 static void set_led_color_rgb(LED_TYPE color, int pos) {
     uint8_t* tx_start = &txbuf[PREAMBLE_SIZE];
-
+#ifdef WS2812_RGB
+        // Support for strange RGB implementations
+    for (int j = 0; j < 4; j++) tx_start[BYTES_FOR_LED * pos + j] = get_protocol_eq(color.r, j);
+    for (int j = 0; j < 4; j++) tx_start[BYTES_FOR_LED * pos + BYTES_FOR_LED_BYTE + j] = get_protocol_eq(color.g, j);
+#else
     for (int j = 0; j < 4; j++) tx_start[BYTES_FOR_LED * pos + j] = get_protocol_eq(color.g, j);
     for (int j = 0; j < 4; j++) tx_start[BYTES_FOR_LED * pos + BYTES_FOR_LED_BYTE + j] = get_protocol_eq(color.r, j);
+#endif
     for (int j = 0; j < 4; j++) tx_start[BYTES_FOR_LED * pos + BYTES_FOR_LED_BYTE * 2 + j] = get_protocol_eq(color.b, j);
 }
 


### PR DESCRIPTION
Add support for #define WS2812_RGB to support non-standard implementations like the Adafruit through hole leds that take RGB instead of GRB data.
## Description
Added conditional compile to ws2812.c, ws2812_pwm.c and ws2812_spi.c to allow the green and red values to be swapped for non-standard leds. 
Using a mixture is not supported and will require one type to have the color values assigned manually for correct operation.
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ X] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [X ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
