### PR TITLE
Add stecha keymaps for crkbd, boardwalk, xd75 and preonic

### DIFF
--- a/keyboards/boardwalk/keymaps/stecha/config.h
+++ b/keyboards/boardwalk/keymaps/stecha/config.h
@@ -1,0 +1,16 @@
+/*
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once

--- a/keyboards/boardwalk/keymaps/stecha/keymap.c
+++ b/keyboards/boardwalk/keymaps/stecha/keymap.c
@@ -1,0 +1,61 @@
+/*
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include QMK_KEYBOARD_H
+
+// Layer shorthand
+#define _QW 0
+#define _NUM 1
+#define _SYM 2
+
+#define LOWER LT(1, KC_SPC)
+#define RAISE LT(2, KC_ENT)
+
+#define CTRLESC CTL_T(KC_ESC)
+#define CTRLTAB LCTL_T(KC_TAB)
+#define DSKLEFT C(G(KC_LEFT))
+#define DSKRGHT C(G(KC_RIGHT))
+#define LSFTSLS LSFT_T(KC_BSLS)
+#define LSFTGRV LSFT_T(KC_GRV)
+#define PRSCR KC_PSCREEN
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  /* Keymap _QWE: Base Layer (Default Layer) */
+  [_QW] = LAYOUT_ortho_hhkb(
+  KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_NO,   KC_NO,   KC_6,   KC_7,    KC_8,    KC_9,    KC_0,    KC_EQL,  \
+  KC_ESC,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    DSKLEFT, DSKRGHT, KC_Y,   KC_U,    KC_I,    KC_O,    KC_P,    KC_BSPC, \
+  CTRLTAB, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_LBRC, KC_RBRC, KC_H,   KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, \
+  LSFTSLS, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_MINS, KC_EQL,  KC_N,   KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT, \
+           KC_NO,   KC_LGUI, KC_LALT, MO(_NUM),      KC_SPC,        KC_ENT,       MO(_SYM),KC_RGUI, KC_RALT, KC_NO             \
+  ),
+
+  /* Keymap LOWER: Lower Layer */
+  [_NUM] = LAYOUT_ortho_hhkb(
+  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_NO,   KC_NO,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  \
+  KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_HOME, KC_PGUP, KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_BSPC, \
+  CTRLTAB, KC_LT,   KC_HOME, KC_PGUP, KC_PGDN, KC_END,  KC_NO,   KC_NO,   KC_LEFT, KC_DOWN, KC_UP,   KC_RIGHT,KC_GT,   KC_TAB,  \
+  LSFTGRV, KC_UNDS, KC_LPRN, KC_DEL,  KC_MINS, KC_LBRC, KC_END,  KC_PGDN, KC_RBRC, KC_EQL,  KC_INS,  KC_RPRN, KC_PLUS, KC_RSFT, \
+           PRSCR,   KC_LGUI, KC_LALT, MO(_NUM),      KC_SPC,        KC_ENT,        MO(_SYM),KC_RGUI, KC_RALT, KC_NO             \
+  ),
+
+  /* Keymap RAISE: Raise Layer */
+  [_SYM] = LAYOUT_ortho_hhkb(
+  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_NO,   KC_NO,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  \
+  KC_ESC,  KC_EXLM, KC_AT,   KC_HASH, KC_DLR,  KC_PERC, KC_HOME, KC_PGUP, KC_CIRC, KC_AMPR, KC_ASTR, KC_LPRN, KC_RPRN, KC_BSPC, \
+  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_NO,   KC_NO,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  \
+  LSFTGRV, RGB_MOD, RESET,   RGB_HUD, RGB_SAD, RGB_VAD, KC_END,  KC_PGDN, RGB_VAI, RGB_SAI, RGB_HUI, KC_NO,   RGB_TOG, KC_RSFT, \
+           KC_NO,   KC_LGUI, KC_LALT, MO(_NUM),      KC_SPC,        KC_ENT,        MO(_SYM),KC_RGUI, KC_RALT, KC_NO
+  )
+};

--- a/keyboards/boardwalk/keymaps/stecha/readme.md
+++ b/keyboards/boardwalk/keymaps/stecha/readme.md
@@ -1,0 +1,1 @@
+# Stecha's keymap for Boardwalk

--- a/keyboards/boardwalk/keymaps/stecha/rules.mk
+++ b/keyboards/boardwalk/keymaps/stecha/rules.mk
@@ -1,0 +1,14 @@
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+RGBLIGHT_ENABLE = yes

--- a/keyboards/crkbd/keymaps/stecha/config.h
+++ b/keyboards/crkbd/keymaps/stecha/config.h
@@ -1,0 +1,46 @@
+/*
+This is the c configuration file for the keymap
+
+Copyright 2012 Jun Wako <wakojun@gmail.com>
+Copyright 2015 Jack Humbert
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+//#define USE_MATRIX_I2C
+
+/* Select hand configuration */
+
+#define MASTER_LEFT
+// #define MASTER_RIGHT
+// #define EE_HANDS
+
+#define SSD1306OLED
+
+#define USE_SERIAL_PD2
+
+#define TAPPING_FORCE_HOLD
+#define TAPPING_TERM 100
+
+#ifdef RGBLIGHT_ENABLE
+    #undef RGBLED_NUM
+    #define RGBLIGHT_ANIMATIONS
+    #define RGBLED_NUM 27
+    #define RGBLIGHT_LIMIT_VAL 120
+    #define RGBLIGHT_HUE_STEP 10
+    #define RGBLIGHT_SAT_STEP 17
+    #define RGBLIGHT_VAL_STEP 17
+#endif

--- a/keyboards/crkbd/keymaps/stecha/keymap.c
+++ b/keyboards/crkbd/keymaps/stecha/keymap.c
@@ -1,0 +1,182 @@
+#include QMK_KEYBOARD_H
+
+#ifdef RGBLIGHT_ENABLE
+// Following line allows macro to read current RGB settings
+extern rgblight_config_t rgblight_config;
+#endif
+
+extern uint8_t is_master;
+
+// Each layer gets a name for readability, which is then used in the keymap matrix below.
+// The underscores don't mean anything - you can have a layer called STUFF or any other name.
+// Layer names don't all need to be of the same length, obviously, and you can also skip them
+// entirely and just use numbers.
+#define _QWERTY 0
+#define _NUM 1
+#define _SYM 2
+
+enum custom_keycodes { QWERTY = SAFE_RANGE, NUM, SYM, ALT_TAB, DSKP_LEFT, DSKP_RIGHT };
+
+enum macro_keycodes {
+    KC_SAMPLEMACRO,
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+    [_QWERTY] = LAYOUT(KC_ESC, KC_Q, KC_W, KC_E, KC_R, KC_T, KC_Y, KC_U, KC_I, KC_O, KC_P, KC_BSPC, LCTL_T(KC_TAB), KC_A, KC_S, KC_D, KC_F, KC_G, KC_H, KC_J, KC_K, KC_L, KC_SCLN, KC_QUOT, LSFT_T(KC_BSLS), KC_Z, KC_X, KC_C, KC_V, KC_B, KC_N, KC_M, KC_COMM, KC_DOT, KC_SLSH, KC_RSFT, DSKP_LEFT, NUM, KC_SPC, KC_ENT, SYM, DSKP_RIGHT),
+
+    [_NUM] = LAYOUT(KC_ESC, KC_1, KC_2, KC_3, KC_4, KC_5, KC_6, KC_7, KC_8, KC_9, KC_0, KC_BSPC, LCTL_T(KC_TAB), KC_LT, KC_HOME, KC_PGUP, KC_PGDN, KC_END, KC_LEFT, KC_DOWN, KC_UP, KC_RGHT, KC_GT, KC_TAB, LSFT_T(KC_GRV), KC_UNDS, KC_LPRN, KC_DEL, KC_MINS, KC_LBRC, KC_RBRC, KC_EQL, KC_INS, KC_RPRN, KC_PLUS, KC_RSFT, DSKP_LEFT, NUM, KC_SPC, KC_ENT, SYM, DSKP_RIGHT),
+
+    [_SYM] = LAYOUT(KC_ESC, KC_EXLM, KC_AT, KC_HASH, KC_DLR, KC_PERC, KC_CIRC, KC_AMPR, KC_ASTR, KC_LPRN, KC_RPRN, KC_BSPC, KC_F1, KC_F2, KC_F3, KC_F4, KC_F5, KC_F6, KC_F7, KC_F8, KC_F9, KC_F10, KC_F11, KC_F12, LSFT_T(KC_GRV), RGB_MOD, RESET, RGB_HUD, RGB_SAD, RGB_VAD, RGB_VAI, RGB_SAI, RGB_HUI, KC_NO, RGB_TOG, KC_RSFT, DSKP_LEFT, NUM, KC_SPC, KC_ENT, SYM, DSKP_RIGHT)};
+
+int RGB_current_mode;
+
+void persistent_default_layer_set(uint16_t default_layer) {
+    eeconfig_update_default_layer(default_layer);
+    default_layer_set(default_layer);
+}
+
+// Setting ADJUST layer RGB back to default
+void update_tri_layer_RGB(uint8_t layer1, uint8_t layer2, uint8_t layer3) {
+    if (IS_LAYER_ON(layer1) && IS_LAYER_ON(layer2)) {
+        layer_on(layer3);
+    } else {
+        layer_off(layer3);
+    }
+}
+
+void matrix_init_user(void) {
+#ifdef RGBLIGHT_ENABLE
+    RGB_current_mode = rgblight_config.mode;
+#endif
+// SSD1306 OLED init, make sure to add #define SSD1306OLED in config.h
+#ifdef SSD1306OLED
+    iota_gfx_init(!has_usb());  // turns on the display
+#endif
+}
+
+// SSD1306 OLED update loop, make sure to add #define SSD1306OLED in config.h
+#ifdef SSD1306OLED
+
+// When add source files to SRC in rules.mk, you can use functions.
+const char *read_layer_state(void);
+const char *read_logo(void);
+void        set_keylog(uint16_t keycode, keyrecord_t *record);
+const char *read_keylog(void);
+const char *read_keylogs(void);
+
+// const char *read_mode_icon(bool swap);
+// const char *read_host_led_state(void);
+// void set_timelog(void);
+// const char *read_timelog(void);
+
+void matrix_scan_user(void) { iota_gfx_task(); }
+
+void matrix_render_user(struct CharacterMatrix *matrix) {
+    if (is_master) {
+        // If you want to change the display of OLED, you need to change here
+        matrix_write_ln(matrix, read_layer_state());
+        matrix_write_ln(matrix, read_keylog());
+        // matrix_write_ln(matrix, read_keylogs());
+        // matrix_write_ln(matrix, read_mode_icon(keymap_config.swap_lalt_lgui));
+        // matrix_write_ln(matrix, read_host_led_state());
+        // matrix_write_ln(matrix, read_timelog());
+    } else {
+        matrix_write(matrix, read_logo());
+    }
+}
+
+void matrix_update(struct CharacterMatrix *dest, const struct CharacterMatrix *source) {
+    if (memcmp(dest->display, source->display, sizeof(dest->display))) {
+        memcpy(dest->display, source->display, sizeof(dest->display));
+        dest->dirty = true;
+    }
+}
+
+void iota_gfx_task_user(void) {
+    struct CharacterMatrix matrix;
+    matrix_clear(&matrix);
+    matrix_render_user(&matrix);
+    matrix_update(&display, &matrix);
+}
+#endif  // SSD1306OLED
+
+uint16_t key_timer;
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    if (record->event.pressed) {
+#ifdef SSD1306OLED
+        set_keylog(keycode, record);
+#endif
+        // set_timelog();
+    }
+
+    switch (keycode) {
+        case QWERTY:
+            if (record->event.pressed) {
+                persistent_default_layer_set(1UL << _QWERTY);
+            }
+            return false;
+        case NUM:
+            if (record->event.pressed) {
+                layer_on(_NUM);
+            } else {
+                layer_off(_NUM);
+            }
+            return false;
+        case SYM:
+            if (record->event.pressed) {
+                layer_on(_SYM);
+            } else {
+                layer_off(_SYM);
+            }
+            return false;
+        case DSKP_LEFT:
+            if (record->event.pressed) {  // key down
+                key_timer = timer_read();
+                register_mods(MOD_BIT(KC_LGUI));
+            } else {                                   // key up
+                if (timer_elapsed(key_timer) < 200) {  // up before 200ms considered a tap
+                    tap_code16(C(KC_LEFT));
+                }
+                unregister_mods(MOD_BIT(KC_LGUI));
+            }
+            return false;
+        case DSKP_RIGHT:
+            if (record->event.pressed) {  // key down
+                key_timer = timer_read();
+                register_mods(MOD_BIT(KC_LALT));
+            } else {
+                unregister_mods(MOD_BIT(KC_LALT));     // key up
+                if (timer_elapsed(key_timer) < 200) {  // up before 200ms considered a tap
+                    tap_code16(C(G(KC_RIGHT)));
+                }
+            }
+            return false;
+        case ALT_TAB:
+            if (record->event.pressed) {  // key down
+                key_timer = timer_read();
+                register_mods(MOD_BIT(KC_LCTL));
+            } else {  // key up
+                unregister_mods(MOD_BIT(KC_LCTL));
+                if (timer_elapsed(key_timer) < 200) {  // up before 200ms considered a tap
+                    tap_code16(LALT(KC_TAB));
+                }
+            }
+            return false;
+        case RGB_MOD:
+#ifdef RGBLIGHT_ENABLE
+            if (record->event.pressed) {
+                rgblight_mode(RGB_current_mode);
+                rgblight_step();
+                RGB_current_mode = rgblight_config.mode;
+            }
+#endif
+            return false;
+
+#ifdef RGBLIGHT_ENABLE
+#endif
+            break;
+    }
+    return true;
+}

--- a/keyboards/crkbd/keymaps/stecha/rules.mk
+++ b/keyboards/crkbd/keymaps/stecha/rules.mk
@@ -1,0 +1,10 @@
+
+# If you want to change the display of OLED, you need to change here
+SRC +=  ./lib/glcdfont.c \
+        ./lib/rgb_state_reader.c \
+        ./lib/layer_state_reader.c \
+        ./lib/logo_reader.c \
+        ./lib/keylogger.c \
+        # ./lib/mode_icon_reader.c \
+        # ./lib/host_led_state_reader.c \
+        # ./lib/timelogger.c \

--- a/keyboards/preonic/keymaps/stecha/config.h
+++ b/keyboards/preonic/keymaps/stecha/config.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#ifdef AUDIO_ENABLE
+    #define STARTUP_SONG SONG(PREONIC_SOUND)
+    // #define STARTUP_SONG SONG(NO_SOUND)
+
+    #define DEFAULT_LAYER_SONGS { SONG(QWERTY_SOUND), \
+                                  SONG(COLEMAK_SOUND), \
+                                  SONG(DVORAK_SOUND) \
+                                }
+#endif
+
+#define MUSIC_MASK (keycode != KC_NO)
+
+/*
+ * MIDI options
+ */
+
+/* Prevent use of disabled MIDI features in the keymap */
+//#define MIDI_ENABLE_STRICT 1
+
+/* enable basic MIDI features:
+   - MIDI notes can be sent when in Music mode is on
+*/
+
+#define MIDI_BASIC
+
+/* enable advanced MIDI features:
+   - MIDI notes can be added to the keymap
+   - Octave shift and transpose
+   - Virtual sustain, portamento, and modulation wheel
+   - etc.
+*/
+//#define MIDI_ADVANCED
+
+/* override number of MIDI tone keycodes (each octave adds 12 keycodes and allocates 12 bytes) */
+//#define MIDI_TONE_KEYCODE_OCTAVES 2

--- a/keyboards/preonic/keymaps/stecha/keymap.c
+++ b/keyboards/preonic/keymaps/stecha/keymap.c
@@ -1,0 +1,310 @@
+/* Copyright 2015-2017 Jack Humbert
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include QMK_KEYBOARD_H
+#include "muse.h"
+
+enum preonic_layers {
+  _QWERTY,
+  _COLEMAK,
+  _DVORAK,
+  _LOWER,
+  _RAISE,
+  _ADJUST
+};
+
+enum preonic_keycodes {
+  QWERTY = SAFE_RANGE,
+  COLEMAK,
+  DVORAK,
+  LOWER,
+  RAISE,
+  BACKLIT
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+/* Qwerty
+ * ,-----------------------------------------------------------------------------------.
+ * |   `  |   1  |   2  |   3  |   4  |   5  |   6  |   7  |   8  |   9  |   0  | Bksp |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * | Tab  |   Q  |   W  |   E  |   R  |   T  |   Y  |   U  |   I  |   O  |   P  | Del  |
+ * |------+------+------+------+------+-------------+------+------+------+------+------|
+ * | Esc  |   A  |   S  |   D  |   F  |   G  |   H  |   J  |   K  |   L  |   ;  |  "   |
+ * |------+------+------+------+------+------|------+------+------+------+------+------|
+ * | Shift|   Z  |   X  |   C  |   V  |   B  |   N  |   M  |   ,  |   .  |   /  |Enter |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * | Brite| Ctrl | Alt  | GUI  |Lower |    Space    |Raise | Left | Down |  Up  |Right |
+ * `-----------------------------------------------------------------------------------'
+ */
+[_QWERTY] = LAYOUT_preonic_grid( \
+  KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_BSPC, \
+  KC_ESC,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_BSPC,  \
+  LCTL_T(KC_TAB),  KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, \
+  LSFT_T(KC_GRV), KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT,  \
+  BACKLIT, KC_LCTL, KC_LGUI, KC_LALT, LOWER,   KC_SPC,  KC_ENT,  RAISE,   KC_RGUI, KC_RALT, KC_NO,   KC_RCTRL  \
+),
+
+/* Colemak
+ * ,-----------------------------------------------------------------------------------.
+ * |   `  |   1  |   2  |   3  |   4  |   5  |   6  |   7  |   8  |   9  |   0  | Bksp |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * | Tab  |   Q  |   W  |   F  |   P  |   G  |   J  |   L  |   U  |   Y  |   ;  | Del  |
+ * |------+------+------+------+------+-------------+------+------+------+------+------|
+ * | Esc  |   A  |   R  |   S  |   T  |   D  |   H  |   N  |   E  |   I  |   O  |  "   |
+ * |------+------+------+------+------+------|------+------+------+------+------+------|
+ * | Shift|   Z  |   X  |   C  |   V  |   B  |   K  |   M  |   ,  |   .  |   /  |Enter |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * | Brite| Ctrl | Alt  | GUI  |Lower |    Space    |Raise | Left | Down |  Up  |Right |
+ * `-----------------------------------------------------------------------------------'
+ */
+[_COLEMAK] = LAYOUT_preonic_grid( \
+  KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_BSPC, \
+  KC_TAB,  KC_Q,    KC_W,    KC_F,    KC_P,    KC_G,    KC_J,    KC_L,    KC_U,    KC_Y,    KC_SCLN, KC_DEL,  \
+  KC_ESC,  KC_A,    KC_R,    KC_S,    KC_T,    KC_D,    KC_H,    KC_N,    KC_E,    KC_I,    KC_O,    KC_QUOT, \
+  KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_K,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_ENT,  \
+  BACKLIT, KC_LCTL, KC_LALT, KC_LGUI, LOWER,   KC_SPC,  KC_SPC,  RAISE,   KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT  \
+),
+
+/* Dvorak
+ * ,-----------------------------------------------------------------------------------.
+ * |   `  |   1  |   2  |   3  |   4  |   5  |   6  |   7  |   8  |   9  |   0  | Bksp |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * | Tab  |   "  |   ,  |   .  |   P  |   Y  |   F  |   G  |   C  |   R  |   L  | Del  |
+ * |------+------+------+------+------+-------------+------+------+------+------+------|
+ * | Esc  |   A  |   O  |   E  |   U  |   I  |   D  |   H  |   T  |   N  |   S  |  /   |
+ * |------+------+------+------+------+------|------+------+------+------+------+------|
+ * | Shift|   ;  |   Q  |   J  |   K  |   X  |   B  |   M  |   W  |   V  |   Z  |Enter |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * | Brite| Ctrl | Alt  | GUI  |Lower |    Space    |Raise | Left | Down |  Up  |Right |
+ * `-----------------------------------------------------------------------------------'
+ */
+[_DVORAK] = LAYOUT_preonic_grid( \
+  KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_BSPC, \
+  KC_TAB,  KC_QUOT, KC_COMM, KC_DOT,  KC_P,    KC_Y,    KC_F,    KC_G,    KC_C,    KC_R,    KC_L,    KC_DEL,  \
+  KC_ESC,  KC_A,    KC_O,    KC_E,    KC_U,    KC_I,    KC_D,    KC_H,    KC_T,    KC_N,    KC_S,    KC_SLSH, \
+  KC_LSFT, KC_SCLN, KC_Q,    KC_J,    KC_K,    KC_X,    KC_B,    KC_M,    KC_W,    KC_V,    KC_Z,    KC_ENT,  \
+  BACKLIT, KC_LCTL, KC_LALT, KC_LGUI, LOWER,   KC_SPC,  KC_SPC,  RAISE,   KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT  \
+),
+
+/* Lower
+ * ,-----------------------------------------------------------------------------------.
+ * |   ~  |   !  |   @  |   #  |   $  |   %  |   ^  |   &  |   *  |   (  |   )  | Bksp |
+ * |------+------+------+------+------+-------------+------+------+------+------+------|
+ * |   ~  |   !  |   @  |   #  |   $  |   %  |   ^  |   &  |   *  |   (  |   )  | Del  |
+ * |------+------+------+------+------+-------------+------+------+------+------+------|
+ * | Del  |  F1  |  F2  |  F3  |  F4  |  F5  |  F6  |   _  |   +  |   {  |   }  |  |   |
+ * |------+------+------+------+------+------|------+------+------+------+------+------|
+ * |      |  F7  |  F8  |  F9  |  F10 |  F11 |  F12 |ISO ~ |ISO | |      |      |      |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      |      |      |      |      |             |      | Next | Vol- | Vol+ | Play |
+ * `-----------------------------------------------------------------------------------'
+ */
+[_LOWER] = LAYOUT_preonic_grid( \
+  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12, \
+  KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_BSPC,  \
+  LCTL_T(KC_TAB), KC_LT, KC_HOME,     KC_PGUP, KC_PGDN, KC_END,  KC_LEFT, KC_DOWN, KC_UP, KC_RIGHT, KC_GT, KC_TAB, \
+  LSFT_T(KC_GRV), KC_UNDS, KC_LPRN, KC_DEL, KC_MINS, KC_LBRC,  KC_RBRC, KC_EQL, KC_INS, KC_RPRN, KC_PLUS, KC_RSFT, \
+  KC_NO, KC_NO, KC_LGUI, KC_LALT, KC_NO, KC_SPC, KC_ENT, KC_NO, KC_RGUI, KC_RALT, KC_NO, KC_RCTRL \
+),
+
+/* Raise
+ * ,-----------------------------------------------------------------------------------.
+ * |   `  |   1  |   2  |   3  |   4  |   5  |   6  |   7  |   8  |   9  |   0  | Bksp |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |   `  |   1  |   2  |   3  |   4  |   5  |   6  |   7  |   8  |   9  |   0  | Del  |
+ * |------+------+------+------+------+-------------+------+------+------+------+------|
+ * | Del  |  F1  |  F2  |  F3  |  F4  |  F5  |  F6  |   -  |   =  |   [  |   ]  |  \   |
+ * |------+------+------+------+------+------|------+------+------+------+------+------|
+ * |      |  F7  |  F8  |  F9  |  F10 |  F11 |  F12 |ISO # |ISO / |      |      |      |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      |      |      |      |      |             |      | Next | Vol- | Vol+ | Play |
+ * `-----------------------------------------------------------------------------------'
+ */
+[_RAISE] = LAYOUT_preonic_grid( \
+  KC_F1, KC_F2, KC_F3, KC_F4, KC_F5, KC_F6,    KC_F7, KC_F8, KC_F9, KC_F10, KC_F11, KC_F12, \
+  KC_ESC, KC_EXLM, KC_AT, KC_HASH, KC_DLR, KC_PERC,    KC_CIRC, KC_AMPR, KC_ASTR, KC_LPRN, KC_RPRN, KC_BSPC,  \
+  KC_F1, KC_F2, KC_F3, KC_F4, KC_F5, KC_F6,   KC_F7, KC_F8, KC_F9, KC_F10, KC_F11, KC_F12, \
+  _______, _______,  _______, _______, C(G(KC_LEFT)), _______, _______, C(G(KC_RIGHT)), _______, _______, _______, _______, \
+  _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______  \
+),
+
+/* Adjust (Lower + Raise)
+ * ,-----------------------------------------------------------------------------------.
+ * |  F1  |  F2  |  F3  |  F4  |  F5  |  F6  |  F7  |  F8  |  F9  |  F10 |  F11 |  F12 |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      | Reset|      |      |      |      |      |      |      |      |      |  Del |
+ * |------+------+------+------+------+-------------+------+------+------+------+------|
+ * |      |      |      |Aud on|AudOff|AGnorm|AGswap|Qwerty|Colemk|Dvorak|      |      |
+ * |------+------+------+------+------+------|------+------+------+------+------+------|
+ * |      |Voice-|Voice+|Mus on|MusOff|MidiOn|MidOff|      |      |      |      |      |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      |      |      |      |      |             |      |      |      |      |      |
+ * `-----------------------------------------------------------------------------------'
+ */
+[_ADJUST] = LAYOUT_preonic_grid( \
+  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  \
+  _______, RESET,   DEBUG,   _______, _______, _______, _______, TERM_ON, TERM_OFF,_______, _______, KC_DEL,  \
+  _______, _______, MU_MOD,  AU_ON,   AU_OFF,  AG_NORM, AG_SWAP, QWERTY,  COLEMAK, DVORAK,  _______, _______, \
+  _______, MUV_DE,  MUV_IN,  MU_ON,   MU_OFF,  MI_ON,   MI_OFF,  _______, _______, _______, _______, _______, \
+  _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______  \
+)
+
+
+};
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  switch (keycode) {
+        case QWERTY:
+          if (record->event.pressed) {
+            set_single_persistent_default_layer(_QWERTY);
+          }
+          return false;
+          break;
+        case COLEMAK:
+          if (record->event.pressed) {
+            set_single_persistent_default_layer(_COLEMAK);
+          }
+          return false;
+          break;
+        case DVORAK:
+          if (record->event.pressed) {
+            set_single_persistent_default_layer(_DVORAK);
+          }
+          return false;
+          break;
+        case LOWER:
+          if (record->event.pressed) {
+            layer_on(_LOWER);
+            update_tri_layer(_LOWER, _RAISE, _ADJUST);
+          } else {
+            layer_off(_LOWER);
+            update_tri_layer(_LOWER, _RAISE, _ADJUST);
+          }
+          return false;
+          break;
+        case RAISE:
+          if (record->event.pressed) {
+            layer_on(_RAISE);
+            update_tri_layer(_LOWER, _RAISE, _ADJUST);
+          } else {
+            layer_off(_RAISE);
+            update_tri_layer(_LOWER, _RAISE, _ADJUST);
+          }
+          return false;
+          break;
+        case BACKLIT:
+          if (record->event.pressed) {
+            register_code(KC_RSFT);
+            #ifdef BACKLIGHT_ENABLE
+              backlight_step();
+            #endif
+            #ifdef __AVR__
+            writePinLow(E6);
+            #endif
+          } else {
+            unregister_code(KC_RSFT);
+            #ifdef __AVR__
+            writePinHigh(E6);
+            #endif
+          }
+          return false;
+          break;
+      }
+    return true;
+};
+
+bool muse_mode = false;
+uint8_t last_muse_note = 0;
+uint16_t muse_counter = 0;
+uint8_t muse_offset = 70;
+uint16_t muse_tempo = 50;
+
+void encoder_update_user(uint8_t index, bool clockwise) {
+  if (muse_mode) {
+    if (IS_LAYER_ON(_RAISE)) {
+      if (clockwise) {
+        muse_offset++;
+      } else {
+        muse_offset--;
+      }
+    } else {
+      if (clockwise) {
+        muse_tempo+=1;
+      } else {
+        muse_tempo-=1;
+      }
+    }
+  } else {
+    if (clockwise) {
+      register_code(KC_PGDN);
+      unregister_code(KC_PGDN);
+    } else {
+      register_code(KC_PGUP);
+      unregister_code(KC_PGUP);
+    }
+  }
+}
+
+void dip_switch_update_user(uint8_t index, bool active) {
+    switch (index) {
+        case 0:
+            if (active) {
+                layer_on(_ADJUST);
+            } else {
+                layer_off(_ADJUST);
+            }
+            break;
+        case 1:
+            if (active) {
+                muse_mode = true;
+            } else {
+                muse_mode = false;
+            }
+    }
+}
+
+
+void matrix_scan_user(void) {
+#ifdef AUDIO_ENABLE
+    if (muse_mode) {
+        if (muse_counter == 0) {
+            uint8_t muse_note = muse_offset + SCALE[muse_clock_pulse()];
+            if (muse_note != last_muse_note) {
+                stop_note(compute_freq_for_midi_note(last_muse_note));
+                play_note(compute_freq_for_midi_note(muse_note), 0xF);
+                last_muse_note = muse_note;
+            }
+        }
+        muse_counter = (muse_counter + 1) % muse_tempo;
+    } else {
+        if (muse_counter) {
+            stop_all_notes();
+            muse_counter = 0;
+        }
+    }
+#endif
+}
+
+bool music_mask_user(uint16_t keycode) {
+  switch (keycode) {
+    case RAISE:
+    case LOWER:
+      return false;
+    default:
+      return true;
+  }
+}

--- a/keyboards/preonic/keymaps/stecha/readme.md
+++ b/keyboards/preonic/keymaps/stecha/readme.md
@@ -1,0 +1,1 @@
+# The default Preonic layout - largely based on the Planck's

--- a/keyboards/preonic/keymaps/stecha/rules.mk
+++ b/keyboards/preonic/keymaps/stecha/rules.mk
@@ -1,0 +1,1 @@
+SRC += muse.c

--- a/keyboards/xd75/keymaps/stecha-gh/config.h
+++ b/keyboards/xd75/keymaps/stecha-gh/config.h
@@ -1,0 +1,19 @@
+/* Copyright 2017 Benjamin Kesselring
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// place overrides here

--- a/keyboards/xd75/keymaps/stecha-gh/keymap.c
+++ b/keyboards/xd75/keymaps/stecha-gh/keymap.c
@@ -1,0 +1,110 @@
+/* Copyright 2017 Wunder
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include QMK_KEYBOARD_H
+
+// Layer shorthand
+#define _QWERTY 0
+#define _NUM 1
+#define _SYM 2
+
+// Defines the keycodes used by our macros in process_record_user
+enum custom_keycodes { ALT_TAB = SAFE_RANGE, DSKP_LEFT, DSKP_RIGHT };
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+    /* QWERTY
+     * .--------------------------------------------------------------------------------------------------------------------------------------.
+     * | ESC    | 1      | 2      | 3      | 4      | 5      | -      | `      | =      | 6      | 7      | 8      | 9      | 0      | BACKSP |
+     * |--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+-----------------|
+     * | TAB    | Q      | W      | E      | R      | T      | [      | \      | ]      | Y      | U      | I      | O      | P      | '      |
+     * |--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+-----------------+--------|
+     * | CAP LK | A      | S      | D      | F      | G      | HOME   | DEL    | PG UP  | H      | J      | K      | L      | ;      | ENTER  |
+     * |--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------------------------+--------|
+     * | LSHIFT | Z      | X      | C      | V      | B      | END    | UP     | PG DN  | N      | M      | ,      | .      | /      | RSHIFT |
+     * |--------+--------+--------+--------+--------+-----------------+--------+--------+--------+--------+-----------------+--------+--------|
+     * | LCTRL  | LGUI   | LALT   | FN     | SPACE  | SPACE  | LEFT   | DOWN   | RIGHT  | SPACE  | SPACE  | FN     | RALT   | RGUI   | RCTRL  |
+     * '--------------------------------------------------------------------------------------------------------------------------------------'
+     */
+
+    [_QWERTY] = LAYOUT_ortho_5x15(/* QWERTY */
+                                  KC_MINS, KC_1, KC_2, KC_3, KC_4, KC_5, KC_NO, KC_NO, KC_NO, KC_6, KC_7, KC_8, KC_9, KC_0, KC_EQL, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_T, C(G(KC_LEFT)), KC_NO, C(G(KC_RIGHT)), KC_Y, KC_U, KC_I, KC_O, KC_P, KC_BSPC, LCTL_T(KC_TAB), KC_A, KC_S, KC_D, KC_F, KC_G, KC_LBRC, KC_NO, KC_RBRC, KC_H, KC_J, KC_K, KC_L, KC_SCLN, KC_QUOT, LSFT_T(KC_BSLS), KC_Z, KC_X, KC_C, KC_V, KC_B, KC_MINS, KC_UP, KC_EQL, KC_N, KC_M, KC_COMM, KC_DOT, KC_SLSH, KC_RSFT, KC_NO, KC_NO, KC_LGUI, KC_LALT, MO(_NUM), KC_SPC, KC_NO, KC_DOWN, KC_NO, KC_ENT, MO(_SYM), KC_RGUI, KC_RALT, KC_NO, KC_RCTRL),
+
+    /* FUNCTION
+     * .--------------------------------------------------------------------------------------------------------------------------------------.
+     * | F1     | F2     | F3     | F4     | F5     | F6     | NUM LK | P/     | P*     | F7     | F8     | F9     | F10    | F11    | F12    |
+     * |--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------|
+     * | SELECT | CALC   | MYCOMP | MAIL   | RGB HD | RGB HI | P7     | P8     | P9     | -      |        |        | PR SCR | SCR LK | PAUSE  |
+     * |--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------|
+     * | PREV   | PLAY   | NEXT   | STOP   | RGB SD | RGB SI | P4     | P5     | P6     | +      |        | RESET  |        |        |        |
+     * |--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------|
+     * | VOL-   | MUTE   | VOL+   | APP    | RGB VD | RGB VI | P1     | P2     | P3     | PENT   |        |        |        |        |        |
+     * |--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------|
+     * |        |        | RGB TG | FN     | RGB RMD| RGB MD | P0     |        | P.     | PENT   | PENT   | FN     |        |        |        |
+     * '--------------------------------------------------------------------------------------------------------------------------------------'
+     */
+
+    [_NUM] = LAYOUT_ortho_5x15(/* NUM */
+                               KC_F1, KC_F2, KC_F3, KC_F4, KC_F5, KC_F6, KC_NO, KC_NO, KC_NO, KC_F7, KC_F8, KC_F9, KC_F10, KC_F11, KC_F12, KC_ESC, KC_1, KC_2, KC_3, KC_4, KC_5, KC_HOME, RESET, KC_PGUP, KC_6, KC_7, KC_8, KC_9, KC_0, KC_BSPC, LCTL_T(KC_TAB), KC_LT, KC_HOME, KC_PGUP, KC_PGDN, KC_END, KC_NO, KC_NO, KC_NO, KC_LEFT, KC_DOWN, KC_UP, KC_RIGHT, KC_GT, KC_TAB, LSFT_T(KC_GRV), KC_UNDS, KC_LPRN, KC_DEL, KC_MINS, KC_LBRC, KC_END, KC_PSCREEN, KC_PGDN, KC_RBRC, KC_EQL, KC_INS, KC_RPRN, KC_PLUS, KC_RSFT, KC_NO, KC_NO, KC_LGUI, KC_LALT, MO(_NUM), KC_SPC, KC_NO, KC_NO, KC_NO, KC_ENT, MO(_SYM), KC_RGUI, KC_RALT, KC_NO, KC_RCTRL),
+
+    [_SYM] = LAYOUT_ortho_5x15(/* SYM */
+                               KC_F1, KC_F2, KC_F3, KC_F4, KC_F5, KC_F6, KC_NO, KC_NO, KC_NO, KC_F7, KC_F8, KC_F9, KC_F10, KC_F11, KC_F12, KC_ESC, KC_EXLM, KC_AT, KC_HASH, KC_DLR, KC_PERC, KC_HOME, RESET, KC_PGUP, KC_CIRC, KC_AMPR, KC_ASTR, KC_LPRN, KC_RPRN, KC_BSPC, KC_F1, KC_F2, KC_F3, KC_F4, KC_F5, KC_F6, KC_NO, KC_NO, KC_NO, KC_F7, KC_F8, KC_F9, KC_F10, KC_F11, KC_F12, LSFT_T(KC_GRV), RGB_MOD, RESET, RGB_HUD, RGB_SAD, RGB_VAD, KC_END, KC_PSCREEN, KC_PGDN, RGB_VAI, RGB_SAI, RGB_HUI, KC_NO, RGB_TOG, KC_RSFT, KC_NO, KC_NO, KC_LGUI, KC_LALT, MO(_NUM), KC_SPC, KC_NO, KC_NO, KC_NO, KC_ENT, MO(_SYM), KC_RGUI, KC_RALT, KC_NO, KC_RCTRL)};
+
+uint16_t key_timer;
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    switch (keycode) {
+        case DSKP_LEFT:
+            if (record->event.pressed) {  // key down
+                key_timer = timer_read();
+                register_mods(MOD_BIT(KC_LGUI));
+            } else {                                   // key up
+                if (timer_elapsed(key_timer) < 200) {  // up before 200ms considered a tap
+                    tap_code16(C(KC_LEFT));
+                }
+                unregister_mods(MOD_BIT(KC_LGUI));
+            }
+            return false;
+        case DSKP_RIGHT:
+            if (record->event.pressed) {  // key down
+                key_timer = timer_read();
+                register_mods(MOD_BIT(KC_LALT));
+            } else {
+                unregister_mods(MOD_BIT(KC_LALT));     // key up
+                if (timer_elapsed(key_timer) < 200) {  // up before 200ms considered a tap
+                    tap_code16(C(G(KC_RIGHT)));
+                }
+            }
+            return false;
+        case ALT_TAB:
+            if (record->event.pressed) {  // key down
+                key_timer = timer_read();
+                register_mods(MOD_BIT(KC_LCTL));
+            } else {  // key up
+                unregister_mods(MOD_BIT(KC_LCTL));
+                if (timer_elapsed(key_timer) < 200) {  // up before 200ms considered a tap
+                    tap_code16(LALT(KC_TAB));
+                }
+            }
+            return false;
+    }
+    return true;
+}
+
+void matrix_init_user(void) {}
+
+void matrix_scan_user(void) {}
+
+void led_set_user(uint8_t usb_led) {}

--- a/keyboards/xd75/keymaps/stecha-gh/readme.md
+++ b/keyboards/xd75/keymaps/stecha-gh/readme.md
@@ -1,0 +1,1 @@
+# The default keymap for xd75, with led controls

--- a/keyboards/xd75/keymaps/stecha/config.h
+++ b/keyboards/xd75/keymaps/stecha/config.h
@@ -1,0 +1,19 @@
+/* Copyright 2017 Benjamin Kesselring
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// place overrides here

--- a/keyboards/xd75/keymaps/stecha/keymap.c
+++ b/keyboards/xd75/keymaps/stecha/keymap.c
@@ -79,7 +79,7 @@ uint16_t key_timer;
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     switch (keycode) {
         case DSKP_LEFT:
-            if (record->event.pressed) { r // key down
+            if (record->event.pressed) { // key down
                 key_timer = timer_read();
                 register_mods(MOD_BIT(KC_LGUI));
             } else {                                   // key up

--- a/keyboards/xd75/keymaps/stecha/keymap.c
+++ b/keyboards/xd75/keymaps/stecha/keymap.c
@@ -1,0 +1,122 @@
+/* Copyright 2017 Wunder
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include QMK_KEYBOARD_H
+
+// Layer shorthand
+#define _QWERTY 0
+#define _NUM 1
+#define _SYM 2
+
+// Defines the keycodes used by our macros in process_record_user
+enum custom_keycodes { ALT_TAB = SAFE_RANGE, DSKP_LEFT, DSKP_RIGHT };
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+    /* QWERTY
+     * .--------------------------------------------------------------------------------------------------------------------------------------.
+     * | ESC    | 1      | 2      | 3      | 4      | 5      | -      | `      | =      | 6      | 7      | 8      | 9      | 0      | BACKSP |
+     * |--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+-----------------|
+     * | TAB    | Q      | W      | E      | R      | T      | [      | \      | ]      | Y      | U      | I      | O      | P      | '      |
+     * |--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+-----------------+--------|
+     * | CAP LK | A      | S      | D      | F      | G      | HOME   | DEL    | PG UP  | H      | J      | K      | L      | ;      | ENTER  |
+     * |--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------------------------+--------|
+     * | LSHIFT | Z      | X      | C      | V      | B      | END    | UP     | PG DN  | N      | M      | ,      | .      | /      | RSHIFT |
+     * |--------+--------+--------+--------+--------+-----------------+--------+--------+--------+--------+-----------------+--------+--------|
+     * | LCTRL  | LGUI   | LALT   | FN     | SPACE  | SPACE  | LEFT   | DOWN   | RIGHT  | SPACE  | SPACE  | FN     | RALT   | RGUI   | RCTRL  |
+     * '--------------------------------------------------------------------------------------------------------------------------------------'
+     */
+
+    [_QWERTY] = LAYOUT_ortho_5x15(/* QWERTY */
+        KC_GRV, KC_1, KC_2, KC_3, KC_4, KC_5, KC_NO, KC_NO, KC_NO, KC_6, KC_7, KC_8, KC_9, KC_0, KC_EQL,
+        KC_ESC, KC_Q, KC_W, KC_E, KC_R, KC_T, C(G(KC_LEFT)), KC_NO, C(G(KC_RIGHT)), KC_Y, KC_U, KC_I, KC_O, KC_P, KC_BSPC,
+        LCTL_T(KC_TAB), KC_A, KC_S, KC_D, KC_F, KC_G, KC_LBRC, KC_NO, KC_RBRC, KC_H, KC_J, KC_K, KC_L, KC_SCLN, KC_QUOT,
+        LSFT_T(KC_BSLS), KC_Z, KC_X, KC_C, KC_V, KC_B, KC_MINS, KC_UP, KC_EQL, KC_N, KC_M, KC_COMM, KC_DOT, KC_SLSH, KC_RSFT,
+        KC_NO, KC_NO, KC_LGUI, KC_LALT, MO(_NUM), KC_SPC, KC_NO, KC_DOWN, KC_NO, KC_ENT, MO(_SYM), KC_RGUI, KC_RALT, KC_NO, KC_RCTRL),
+
+    /* FUNCTION
+     * .--------------------------------------------------------------------------------------------------------------------------------------.
+     * | F1     | F2     | F3     | F4     | F5     | F6     | NUM LK | P/     | P*     | F7     | F8     | F9     | F10    | F11    | F12    |
+     * |--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------|
+     * | SELECT | CALC   | MYCOMP | MAIL   | RGB HD | RGB HI | P7     | P8     | P9     | -      |        |        | PR SCR | SCR LK | PAUSE  |
+     * |--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------|
+     * | PREV   | PLAY   | NEXT   | STOP   | RGB SD | RGB SI | P4     | P5     | P6     | +      |        | RESET  |        |        |        |
+     * |--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------|
+     * | VOL-   | MUTE   | VOL+   | APP    | RGB VD | RGB VI | P1     | P2     | P3     | PENT   |        |        |        |        |        |
+     * |--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------|
+     * |        |        | RGB TG | FN     | RGB RMD| RGB MD | P0     |        | P.     | PENT   | PENT   | FN     |        |        |        |
+     * '--------------------------------------------------------------------------------------------------------------------------------------'
+     */
+
+    [_NUM] = LAYOUT_ortho_5x15(/* NUM */
+        KC_F1, KC_F2, KC_F3, KC_F4, KC_F5, KC_F6, KC_NO, KC_NO, KC_NO, KC_F7, KC_F8, KC_F9, KC_F10, KC_F11, KC_F12,
+        KC_ESC, KC_1, KC_2, KC_3, KC_4, KC_5, KC_HOME, RESET, KC_PGUP, KC_6, KC_7, KC_8, KC_9, KC_0, KC_BSPC,
+        LCTL_T(KC_TAB), KC_LT, KC_HOME, KC_PGUP, KC_PGDN, KC_END, KC_NO, KC_NO, KC_NO, KC_LEFT, KC_DOWN, KC_UP, KC_RIGHT, KC_GT, KC_TAB,
+        LSFT_T(KC_GRV), KC_UNDS, KC_LPRN, KC_DEL, KC_MINS, KC_LBRC, KC_END, KC_PSCREEN, KC_PGDN, KC_RBRC, KC_EQL, KC_INS, KC_RPRN, KC_PLUS, KC_RSFT,
+        KC_NO, KC_NO, KC_LGUI, KC_LALT, MO(_NUM), KC_SPC, KC_NO, KC_NO, KC_NO, KC_ENT, MO(_SYM), KC_RGUI, KC_RALT, KC_NO, KC_RCTRL),
+
+    [_SYM] = LAYOUT_ortho_5x15(/* SYM */
+        KC_F1, KC_F2, KC_F3, KC_F4, KC_F5, KC_F6, KC_NO, KC_NO, KC_NO, KC_F7, KC_F8, KC_F9, KC_F10, KC_F11, KC_F12,
+        KC_ESC, KC_EXLM, KC_AT, KC_HASH, KC_DLR, KC_PERC, KC_HOME, RESET, KC_PGUP, KC_CIRC, KC_AMPR, KC_ASTR, KC_LPRN, KC_RPRN, KC_BSPC,
+        KC_F1, KC_F2, KC_F3, KC_F4, KC_F5, KC_F6, KC_NO, KC_NO, KC_NO, KC_F7, KC_F8, KC_F9, KC_F10, KC_F11, KC_F12,
+        LSFT_T(KC_GRV), RGB_MOD, RESET, RGB_HUD, RGB_SAD, RGB_VAD, KC_END, KC_PSCREEN, KC_PGDN, RGB_VAI, RGB_SAI, RGB_HUI, KC_NO, RGB_TOG, KC_RSFT,
+        KC_NO, KC_NO, KC_LGUI, KC_LALT, MO(_NUM), KC_SPC, KC_NO, KC_NO, KC_NO, KC_ENT, MO(_SYM), KC_RGUI, KC_RALT, KC_NO, KC_RCTRL)};
+
+uint16_t key_timer;
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    switch (keycode) {
+        case DSKP_LEFT:
+            if (record->event.pressed) { r // key down
+                key_timer = timer_read();
+                register_mods(MOD_BIT(KC_LGUI));
+            } else {                                   // key up
+                if (timer_elapsed(key_timer) < 200) {  // up before 200ms considered a tap
+                    tap_code16(C(KC_LEFT));
+                }
+                unregister_mods(MOD_BIT(KC_LGUI));
+            }
+            return false;
+        case DSKP_RIGHT:
+            if (record->event.pressed) {  // key down
+                key_timer = timer_read();
+                register_mods(MOD_BIT(KC_LALT));
+            } else {
+                unregister_mods(MOD_BIT(KC_LALT));     // key up
+                if (timer_elapsed(key_timer) < 200) {  // up before 200ms considered a tap
+                    tap_code16(C(G(KC_RIGHT)));
+                }
+            }
+            return false;
+        case ALT_TAB:
+            if (record->event.pressed) {  // key down
+                key_timer = timer_read();
+                register_mods(MOD_BIT(KC_LCTL));
+            } else {  // key up
+                unregister_mods(MOD_BIT(KC_LCTL));
+                if (timer_elapsed(key_timer) < 200) {  // up before 200ms considered a tap
+                    tap_code16(LALT(KC_TAB));
+                }
+            }
+            return false;
+    }
+    return true;
+}
+
+void matrix_init_user(void) {}
+
+void matrix_scan_user(void) {}
+
+void led_set_user(uint8_t usb_led) {}

--- a/keyboards/xd75/keymaps/stecha/readme.md
+++ b/keyboards/xd75/keymaps/stecha/readme.md
@@ -1,0 +1,1 @@
+# The default keymap for xd75, with led controls


### PR DESCRIPTION
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Add personal keymaps for the following keyboards:

- crkbd
- boardwalk
- xd75
- preonic/rev3

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* none

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
