### PR TITLE
Fix typo causing `redefined error` in keymap_french_osx 

### DIFF
--- a/quantum/keymap_extras/keymap_french_osx.h
+++ b/quantum/keymap_extras/keymap_french_osx.h
@@ -237,7 +237,7 @@
 #define FR_PERM S(A(FR_LUGR)) // ‰
 // Row 4
 #define FR_GTEQ S(A(FR_LABK)) // ≥
-#define FR_LSAQ S(A(FR_W))    // ›
+#define FR_RSAQ S(A(FR_W))    // ›
 #define FR_FRSL S(A(FR_X))    // ⁄
 #define FR_CENT S(A(FR_C))    // ¢
 #define FR_SQRT S(A(FR_V))    // √


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
I encountered an error while compiling my french osx based keymap.
I noticed `FR_LSAQ` was defined twice and `FR_RSAQ` was missing, probably a miss copy/paste on #8700.

So... here is my one char contribution :)

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #8700

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
