### PR TITLE
[Keyboard] add handwired/naho6key

### DIFF
--- a/keyboards/handwired/naho6key/config.h
+++ b/keyboards/handwired/naho6key/config.h
@@ -1,0 +1,67 @@
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#include "config_common.h"
+
+/* Pinout */
+#define PIN_ROW_LEFT D4   // Pro Micro: 4
+#define PIN_ROW_RIGHT D0  // Pro Micro: 3
+#define PIN_COL_1 F6      // Pro Micro: A1
+#define PIN_COL_2 F5      // Pro Micro: A2
+#define PIN_COL_3 F4      // Pro Micro: A3
+#define PIN_LED_R E6      // Pro Micro: 7
+#define PIN_LED_G B4      // Pro Micro: 8
+#define PIN_LED_B B5      // Pro Micro: 9
+
+// Unicode mode (UC_LNX, UC_WINC, or UC_MAC)
+#define UNICODE_SELECTED_MODES UC_LNX
+
+// Transform TT into LT/MO
+#define TAPPING_TOGGLE 1
+
+// USB Device descriptor parameter
+#define VENDOR_ID 0xFEED
+#define PRODUCT_ID 0x6061
+#define DEVICE_VER 0x0001
+#define MANUFACTURER qmkbuilder
+#define PRODUCT keyboard
+#define DESCRIPTION Keyboard(macro 6 key by naholyr)
+
+// key matrix size
+#define MATRIX_ROWS 2
+#define MATRIX_COLS 3
+
+// key matrix pins
+#define MATRIX_ROW_PINS \
+    { PIN_ROW_LEFT, PIN_ROW_RIGHT }
+#define MATRIX_COL_PINS \
+    { PIN_COL_1, PIN_COL_2, PIN_COL_3 }
+#define UNUSED_PINS
+
+/* COL2ROW or ROW2COL */
+#define DIODE_DIRECTION COL2ROW
+
+/* Set 0 if debouncing isn't needed */
+//#define DEBOUNCING_DELAY 5
+
+/* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
+//#define LOCKING_SUPPORT_ENABLE
+
+/* Locking resynchronize hack */
+#define LOCKING_RESYNC_ENABLE
+
+/* key combination for command */
+#define IS_COMMAND() (keyboard_report->mods == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT)))
+
+/* prevent stuck modifiers */
+#define PREVENT_STUCK_MODIFIERS
+
+#ifdef RGB_DI_PIN
+#    define RGBLIGHT_ANIMATIONS
+#    define RGBLED_NUM 0
+#    define RGBLIGHT_HUE_STEP 8
+#    define RGBLIGHT_SAT_STEP 8
+#    define RGBLIGHT_VAL_STEP 8
+#endif
+
+#endif

--- a/keyboards/handwired/naho6key/keymaps/default/keymap.c
+++ b/keyboards/handwired/naho6key/keymaps/default/keymap.c
@@ -1,0 +1,117 @@
+#include "../../naho6key.h"
+#include "../../config.h"
+// deprecated includes when I sent actual strings instead of macro kbd
+// #include "keymap_french.h"
+// #include "sendstring_french.h"
+
+// layers
+#define _BASE 0
+#define _EMOJI 1
+#define _NAV 2
+#define _MOUSE 3
+#define _MEDIA 4
+
+enum custom_keycodes {
+    CK_LT_MEDIA_BASE = SAFE_RANGE,
+};
+
+///////////////////////
+// Unicode Map (emojis)
+
+enum unicode_name {
+    PI,        // π
+    FACEPALM,  // 🤦
+    SHRUG,     // 🤷
+    THUMBSUP,  // 👍
+    ROFL,      // 🤣
+};
+
+const uint32_t PROGMEM unicode_map[] = {
+    [PI]       = 0x003C0,  // π
+    [FACEPALM] = 0x1F926,  // 🤦
+    [SHRUG]    = 0x1F937,  // 🤷
+    [THUMBSUP] = 0x1F44D,  // 👍
+    [ROFL]     = 0x1F923,  // 🤣
+};
+
+///////////////////////
+// Actual layout
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    // (white) Base: COPY, (hold = emoji), CUT  //  PAST, NEXT LAYER (hold, or dbltap to toggle), CALCULATOR
+    // (pink)  Emoji: 🤦, …, 🤷  //  👍, π, 🤣
+    [_BASE]  = KEYMAP(KC_COPY, MO(_EMOJI), KC_CUT, KC_PASTE, TT(_NAV), KC_CALCULATOR),
+    [_EMOJI] = KEYMAP(X(FACEPALM), _______, X(SHRUG), X(THUMBSUP), X(PI), X(ROFL)),
+    // (blue)  Nav: LEFT, SHIFT, RIGHT  //  DOWN, NEXT LAYER (hold, or dbltap to toggle), UP
+    [_NAV] = KEYMAP(KC_LEFT, KC_LSFT, KC_RIGHT, KC_DOWN, TT(_MOUSE), KC_UP),
+    // (red)   Mouse: LEFT, CLICK, RIGHT  //  DOWN, MEDIA (hold) or BASE (tap), UP
+    // Note: we want to use LT(MEDIA, TO(BASE)) but LT only supports basic keycodes, so we have to use a custom implementation
+    [_MOUSE] = KEYMAP(KC_MS_LEFT, KC_MS_BTN1, KC_MS_RIGHT, KC_MS_DOWN, CK_LT_MEDIA_BASE, KC_MS_UP),
+    // (green) Media: VOL-, MUTE, VOL+  //  PLAY-PAUSE, NEXT LAYER, RGUI
+    [_MEDIA] = KEYMAP(KC_AUDIO_VOL_DOWN, KC_AUDIO_MUTE, KC_AUDIO_VOL_UP, KC_MEDIA_PLAY_PAUSE, _______, KC_MS_BTN2),
+};
+
+///////////////////////
+// LED management, using a basic RGB LED wired to 3 pins
+
+void keyboard_pre_init_user(void) {
+    // Set our LED pins as output
+    setPinOutput(PIN_LED_R);
+    setPinOutput(PIN_LED_G);
+    setPinOutput(PIN_LED_B);
+}
+
+void setRGB(bool r, bool g, bool b) {
+    writePin(PIN_LED_R, r);
+    writePin(PIN_LED_G, g);
+    writePin(PIN_LED_B, b);
+}
+
+layer_state_t layer_state_set_user(layer_state_t state) {
+    switch (get_highest_layer(state)) {
+        case _BASE:
+            setRGB(1, 1, 1);
+            break;
+        case _EMOJI:
+            setRGB(1, 0, 1);
+            break;
+        case _NAV:
+            setRGB(0, 0, 1);
+            break;
+        case _MOUSE:
+            setRGB(1, 0, 0);
+            break;
+        case _MEDIA:
+            setRGB(0, 1, 0);
+            break;
+    }
+    return state;
+}
+
+// Helper (not used anymore, kept for the record)
+// bool isShiftHeld(void) { return get_mods() & MOD_BIT(KC_LSHIFT) || get_mods() & MOD_BIT(KC_RSHIFT); }
+
+// Handle special key: HOLD = MO(MEDIA), TAP = TO(BASE)
+static bool moveToBaseOnRelease = false;
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    if (keycode == CK_LT_MEDIA_BASE) {
+        if (record->event.pressed) {
+            // Held = toggle MEDIA on
+            moveToBaseOnRelease = true;
+            layer_on(_MEDIA);
+        } else {
+            // Released = move to BASE if no MEDIA key was pressed
+            if (moveToBaseOnRelease) {
+                // No other key was pressed meanwhile
+                layer_move(_BASE);
+            } else {
+                layer_off(_MEDIA);
+            }
+        }
+    } else {
+        // Other key event meanwhile: means we're using as a layer modifier → do NOT move to BASE on release
+        moveToBaseOnRelease = false;
+    }
+    return true;
+}

--- a/keyboards/handwired/naho6key/naho6key.c
+++ b/keyboards/handwired/naho6key/naho6key.c
@@ -1,0 +1,1 @@
+#include "naho6key.h"

--- a/keyboards/handwired/naho6key/naho6key.h
+++ b/keyboards/handwired/naho6key/naho6key.h
@@ -1,0 +1,13 @@
+#ifndef NAHO6KEY_H
+#define NAHO6KEY_H
+
+#include "quantum.h"
+
+// LEFT:  KL0, KL1, KL2
+// RIGHT: KR0, KR1, KR2
+#define KEYMAP(KL0, KL1, KL2, KR0, KR1, KR2) \
+    {                                        \
+        {KL0, KL1, KL2}, { KR0, KR1, KR2 }   \
+    }
+
+#endif

--- a/keyboards/handwired/naho6key/readme.md
+++ b/keyboards/handwired/naho6key/readme.md
@@ -1,0 +1,89 @@
+# naholyr’s 6-key: training with QMK and Pro-Micro
+
+Disclaimer: I'm an absolute noob in electronics, and just discovered QMK, so I had to dive in and learn. This is the project I used to learn, I hope it could help others to understand the internals more easily.
+
+The main goal was to train with QMK, and validate a few things:
+
+- Doing fun things with layer switching policies
+- Send emojis and standard Unicode characters
+- Try special keycodes
+- Try controlling the mouse
+- Play with an RGB LED
+
+## The Keymap
+
+(click on the image to open Keyboard Layout Editor)
+
+[![](https://i.imgur.com/FtkCXfz.png)](http://www.keyboard-layout-editor.com/##@@_c=%23fffbcf&f:1&fa@:0&:0&:2%3B%3B&=copy%0A%E2%86%90%0A%F0%9F%A4%A6%0A%0A%F0%9F%94%89%0A%0A%E2%86%90&_c=%239bc79b%3B&=emoji%20%E2%87%A8%0Aclick%0A%0A%0A%F0%9F%94%87%0A%0Ashift&_c=%23fffbcf%3B&=cut%0A%E2%86%92%0A%F0%9F%A4%B7%0A%0A%F0%9F%94%8A%0A%0A%E2%86%92&_x:0.75&c=%23ffb5b5%3B&=paste%0A%E2%86%93%0A%F0%9F%91%8D%0A%0A%E2%8F%AF%0A%0A%E2%86%93&_c=%239e9e9e%3B&=nav%20%E2%87%A9%0Amedia%20%E2%87%A9%0A%CF%80%0A%0Abase%20%E2%86%BA%0A%0Amouse%20%E2%87%A9&_c=%23ffb5b5%3B&=calc%0A%E2%86%91%0A%F0%9F%A4%A3%0A%0Ar.%20click%0A%0A%E2%86%91)
+
+I've worked with 2 "rows" (left/right) of 3 columns, each "row" having generally 2 "main" buttons surrounding a middle "action" button.
+
+We have 5 layers, each one its own color:
+
+- Base (white) = copy/cut/paste/calculator (why not?)
+    - left action = activate emoji (as modifier)
+    - right action = activate keyboard nav (hold for temporary, tap to toggle)
+- Emoji (pink) = facepalm/shrug/thumbsup/rofl
+    - left action unavailable
+    - right action = Pi (why not?)
+- Keyboard nav (blue) = left/right/down/up
+    - left action = shift
+    - right action = activate mouse nav (hold for temporary, tap to toggle)
+- Mouse nav (red) = left/right/down/up
+    - left action = left click
+    - right action = active media (hold) or back to base (tap)
+- Media (green) = vol-/vol+/pause/right click
+    - left action = mute
+    - right action unavailable
+    
+With this keymap you can hold right action + left action (= keyboard nav + shift), move cursor (selecting text as shift is pressed), then release and press copy/cut then paste, this sort of tremendously useful and difficult things to do with a normal keyboard (irony intended).
+
+## The wiring
+
+Here is the circuit schematic (quite ugly, and probably wrong as I didn't have the "RGB LED" component, but you get it):
+
+![](https://i.imgur.com/4kUTRUX.png)
+
+LED is **obviously not wired without resistors** (never do this!), I actually used different resistors on each of its branch to mitigate brightness and have balanced colors:
+
+- R = 1 kΩ
+- G = 10 kΩ
+- B = 5 kΩ
+
+Here is a (weirdly cabled) real-life prototype on a breadboard:
+
+![](https://i.imgur.com/qpYPpJ4.jpg)
+
+The real-life picture + the circuit schematic should be enough to get it all.
+
+## How to make it yourself
+
+### Hardware
+
+- Mandatory components:
+  - A Pro Micro controller (if you use another one, translating pins should be enough)
+  - 6 buttons (the actual keys)
+  - 6 diodes (I used 1N4148)
+  - something to make it all hold, like a soldering iron (for the controller), breadboard, wires…
+  - A computer and a micro-USB cable **with data** (don't laugh, many of the micro-USB cables you'll find in your drawers are charge-only, and you may ‑ as I did ‑ believe your controller is dead and lose HOURS)
+- Optional components:
+  - 1 button (the small reset button)
+  - A wired RGB LED (the one with 4 legs)
+  - 3 resistors (I used 1K, 5K, and 10K)
+
+Wire it all as described above 😁 then flash the beast (see below)!
+
+### Software
+
+- Install QMK: see the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools)
+- Clone this repository
+- Plug your freshly built incredibly powerful macro pad
+- Build and flash the firmware
+
+```
+make handwired/naho6key:default:flash
+```
+
+After building the firmware, it should be waiting with a message like *Detecting USB port, reset your controller now.......*, just press the "reset" button (or short the "GND" and "RST" pins). If it's not detecting your controller, unplug it, hold the "reset" button while plugging it again, and then release the reset button.
+
+For more information, see the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).

--- a/keyboards/handwired/naho6key/rules.mk
+++ b/keyboards/handwired/naho6key/rules.mk
@@ -1,0 +1,69 @@
+# MCU name
+MCU = atmega32u4
+
+# Bootloader selection
+#   Teensy       halfkay
+#   Pro Micro    caterina
+#   Atmel DFU    atmel-dfu
+#   LUFA DFU     lufa-dfu
+#   QMK DFU      qmk-dfu
+#   ATmega32A    bootloadHID
+#   ATmega328P   USBasp
+BOOTLOADER = caterina
+
+# Processor frequency.
+#     This will define a symbol, F_CPU, in all source code files equal to the
+#     processor frequency in Hz. You can then use this symbol in your source code to
+#     calculate timings. Do NOT tack on a 'UL' at the end, this will be done
+#     automatically to create a 32-bit value in your source code.
+#
+#     This will be an integer division of F_USB below, as it is sourced by
+#     F_USB after it has run through any CPU prescalers. Note that this value
+#     does not *change* the processor frequency - it should merely be updated to
+#     reflect the processor speed set externally so that the code can use accurate
+#     software delays.
+F_CPU = 16000000
+
+#
+# LUFA specific
+#
+# Target architecture (see library "Board Types" documentation).
+ARCH = AVR8
+
+# Input clock frequency.
+#     This will define a symbol, F_USB, in all source code files equal to the
+#     input clock frequency (before any prescaling is performed) in Hz. This value may
+#     differ from F_CPU if prescaling is used on the latter, and is required as the
+#     raw input clock is fed directly to the PLL sections of the AVR for high speed
+#     clock generation for the USB and other AVR subsections. Do NOT tack on a 'UL'
+#     at the end, this will be done automatically to create a 32-bit value in your
+#     source code.
+#
+#     If no clock division is performed on the input clock inside the AVR (via the
+#     CPU clock adjust registers or the clock division fuses), this will be equal to F_CPU.
+F_USB = $(F_CPU)
+
+# Interrupt driven control endpoint task(+60)
+OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
+
+
+# Boot Section Size in *bytes*
+OPT_DEFS += -DBOOTLOADER_SIZE=4096
+
+
+# Build Options
+#   comment out to disable the options.
+#
+BOOTMAGIC_ENABLE ?= no	# Virtual DIP switch configuration(+1000)
+MOUSEKEY_ENABLE ?= yes	# Mouse keys(+4700)
+EXTRAKEY_ENABLE ?= yes	# Audio control and System control(+450)
+CONSOLE_ENABLE ?= no	# Console for debug(+400)
+COMMAND_ENABLE ?= no    # Commands for debug and configuration
+SLEEP_LED_ENABLE ?= no  # Breathing sleep LED during USB suspend
+NKRO_ENABLE ?= no		# USB Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+BACKLIGHT_ENABLE ?= no  # Enable keyboard backlight functionality
+AUDIO_ENABLE ?= no
+RGBLIGHT_ENABLE ?= no
+# Unicode
+UNICODE_ENABLE = no
+UNICODEMAP_ENABLE = yes


### PR DESCRIPTION
## Description

Adds a 6 key handwired keyboard for training purpose, with all the wiring and schematics information in readme, made for noobs like me who want to play with some advanced features.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
  - Not sure about the `info.json` as I didn't use the configurator, and have custom C++ code I'm not sure where to put in configurator
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
