### PR TITLE
Fix int wrapping for timer_expired macros 

### DIFF
--- a/tmk_core/common/timer.h
+++ b/tmk_core/common/timer.h
@@ -45,8 +45,8 @@ uint16_t timer_elapsed(uint16_t last);
 uint32_t timer_elapsed32(uint32_t last);
 
 // Utility functions to check if a future time has expired & autmatically handle time wrapping if checked / reset frequently (half of max value)
-#define timer_expired(current, future) (((uint16_t)current - (uint16_t)future) < 0x8000)
-#define timer_expired32(current, future) (((uint32_t)current - (uint32_t)future) < 0x80000000)
+#define timer_expired(current, future) ((uint16_t)(current - future) < UINT16_MAX / 2)
+#define timer_expired32(current, future) ((uint32_t)(current - future) < UINT32_MAX / 2)
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Small change to the timer_expired macros to fix cases on ARM where the int wrapping did not happen as expected, making the macros always return true. Additionally, switched from using a hex value for the half mark to the int max macros instead for clarity.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
