### PR TITLE
Configurable Serial USART Timeout

### DIFF
--- a/docs/serial_driver.md
+++ b/docs/serial_driver.md
@@ -60,6 +60,7 @@ Configure the hardware via your config.h:
                                    //  5: about 19200 baud
 #define SERIAL_USART_DRIVER SD1 // USART driver of TX pin. default: SD1
 #define SERIAL_USART_TX_PAL_MODE 7 // Pin "alternate function", see the respective datasheet for the appropriate values for your MCU. default: 7
+#define SERIAL_USART_TIMEOUT 100 // USART driver timeout. default 100
 ```
 
 You must also enable the ChibiOS `SERIAL` feature:

--- a/drivers/chibios/serial_usart.c
+++ b/drivers/chibios/serial_usart.c
@@ -58,7 +58,10 @@
 #    error invalid SELECT_SOFT_SERIAL_SPEED value
 #endif
 
-#define TIMEOUT 100
+#ifndef SERIAL_USART_TIMEOUT
+    #define SERIAL_USART_TIMEOUT 100
+#endif
+
 #define HANDSHAKE_MAGIC 7
 
 static inline msg_t sdWriteHalfDuplex(SerialDriver* driver, uint8_t* data, uint8_t size) {
@@ -201,21 +204,21 @@ int soft_serial_transaction(int index) {
     sdClear(&SERIAL_USART_DRIVER);
 
     // First chunk is always transaction id
-    sdWriteTimeout(&SERIAL_USART_DRIVER, &sstd_index, sizeof(sstd_index), TIME_MS2I(TIMEOUT));
+    sdWriteTimeout(&SERIAL_USART_DRIVER, &sstd_index, sizeof(sstd_index), TIME_MS2I(SERIAL_USART_TIMEOUT));
 
     uint8_t sstd_index_shake = 0xFF;
 
     // Which we always read back first so that we can error out correctly
     //   - due to the half duplex limitations on return codes, we always have to read *something*
     //   - without the read, write only transactions *always* succeed, even during the boot process where the slave is not ready
-    res = sdReadTimeout(&SERIAL_USART_DRIVER, &sstd_index_shake, sizeof(sstd_index_shake), TIME_MS2I(TIMEOUT));
+    res = sdReadTimeout(&SERIAL_USART_DRIVER, &sstd_index_shake, sizeof(sstd_index_shake), TIME_MS2I(SERIAL_USART_TIMEOUT));
     if (res < 0 || (sstd_index_shake != (sstd_index ^ HANDSHAKE_MAGIC))) {
         dprintf("serial::usart_shake NO_RESPONSE\n");
         return TRANSACTION_NO_RESPONSE;
     }
 
     if (trans->initiator2target_buffer_size) {
-        res = sdWriteTimeout(&SERIAL_USART_DRIVER, trans->initiator2target_buffer, trans->initiator2target_buffer_size, TIME_MS2I(TIMEOUT));
+        res = sdWriteTimeout(&SERIAL_USART_DRIVER, trans->initiator2target_buffer, trans->initiator2target_buffer_size, TIME_MS2I(SERIAL_USART_TIMEOUT));
         if (res < 0) {
             dprintf("serial::usart_transmit NO_RESPONSE\n");
             return TRANSACTION_NO_RESPONSE;
@@ -223,7 +226,7 @@ int soft_serial_transaction(int index) {
     }
 
     if (trans->target2initiator_buffer_size) {
-        res = sdReadTimeout(&SERIAL_USART_DRIVER, trans->target2initiator_buffer, trans->target2initiator_buffer_size, TIME_MS2I(TIMEOUT));
+        res = sdReadTimeout(&SERIAL_USART_DRIVER, trans->target2initiator_buffer, trans->target2initiator_buffer_size, TIME_MS2I(SERIAL_USART_TIMEOUT));
         if (res < 0) {
             dprintf("serial::usart_receive NO_RESPONSE\n");
             return TRANSACTION_NO_RESPONSE;

--- a/drivers/chibios/serial_usart.c
+++ b/drivers/chibios/serial_usart.c
@@ -59,7 +59,7 @@
 #endif
 
 #ifndef SERIAL_USART_TIMEOUT
-    #define SERIAL_USART_TIMEOUT 100
+#    define SERIAL_USART_TIMEOUT 100
 #endif
 
 #define HANDSHAKE_MAGIC 7


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Added an option to allow overriding the serial usart timeout. Reducing this on a STM32F303CC Split has shown a noticeable improvement on keyboard startup speed as well as a very small improvement on matrix scan speed. Going from 100ms to 10ms made it startup significantly faster (sadly didn't time it), and the scan speed improved by ~50 scans per second.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
