### PR TITLE
Add stm32-dfu and apm32-dfu to bootloader.mk

### DIFF
--- a/bootloader.mk
+++ b/bootloader.mk
@@ -20,17 +20,19 @@
 # Sets the bootloader defined in the keyboard's/keymap's rules.mk
 # Current options:
 #
-# halfkay        PJRC Teensy
-# caterina       Pro Micro (Sparkfun/generic)
-# atmel-dfu      Atmel factory DFU
-# lufa-dfu       LUFA DFU
-# qmk-dfu        QMK DFU (LUFA + blinkenlight)
-# bootloadHID    HIDBootFlash compatible (ATmega32A)
-# USBasp         USBaspLoader (ATmega328P)
-# kiibohd        Input:Club Kiibohd bootloader (only used on their boards)
-# stm32duino     STM32Duino (STM32F103x8)
-# stm32-dfu      STM32 USB DFU in ROM
-# apm32-dfu      APM32 USB DFU in ROM
+# AVR:
+#     halfkay     PJRC Teensy
+#     caterina    Pro Micro (Sparkfun/generic)
+#     atmel-dfu   Atmel factory DFU
+#     lufa-dfu    LUFA DFU
+#     qmk-dfu     QMK DFU (LUFA + blinkenlight)
+#     bootloadHID HIDBootFlash compatible (ATmega32A)
+#     USBasp      USBaspLoader (ATmega328P)
+# ARM:
+#     kiibohd     Input:Club Kiibohd bootloader (only used on their boards)
+#     stm32duino  STM32Duino (STM32F103x8)
+#     stm32-dfu   STM32 USB DFU in ROM
+#     apm32-dfu   APM32 USB DFU in ROM
 #
 # BOOTLOADER_SIZE can still be defined manually, but it's recommended
 # you add any possible configuration to this list

--- a/bootloader.mk
+++ b/bootloader.mk
@@ -29,6 +29,8 @@
 # USBasp         USBaspLoader (ATmega328P)
 # kiibohd        Input:Club Kiibohd bootloader (only used on their boards)
 # stm32duino     STM32Duino (STM32F103x8)
+# stm32-dfu      STM32 USB DFU in ROM
+# apm32-dfu      APM32 USB DFU in ROM
 #
 # BOOTLOADER_SIZE can still be defined manually, but it's recommended
 # you add any possible configuration to this list
@@ -95,6 +97,20 @@ ifdef BOOTLOADER_SIZE
     OPT_DEFS += -DBOOTLOADER_SIZE=$(strip $(BOOTLOADER_SIZE))
 endif
 
+ifeq ($(strip $(BOOTLOADER)), stm32-dfu)
+    OPT_DEFS += -DBOOTLOADER_STM32_DFU
+
+    # Options to pass to dfu-util when flashing
+    DFU_ARGS ?= -d 0483:DF11 -a 0 -s 0x08000000:leave
+    DFU_SUFFIX_ARGS ?= -v 0483 -p DF11
+endif
+ifeq ($(strip $(BOOTLOADER)), apm32-dfu)
+    OPT_DEFS += -DBOOTLOADER_APM32_DFU
+
+    # Options to pass to dfu-util when flashing
+    DFU_ARGS ?= -d 314B:0106 -a 0 -s 0x08000000:leave
+    DFU_SUFFIX_ARGS ?= -v 314B -p 0106
+endif
 ifeq ($(strip $(BOOTLOADER)), kiibohd)
     OPT_DEFS += -DBOOTLOADER_KIIBOHD
     ifeq ($(strip $(MCU_ORIG)), MK20DX128)
@@ -104,10 +120,10 @@ ifeq ($(strip $(BOOTLOADER)), kiibohd)
         MCU_LDSCRIPT = MK20DX256BLDR8
     endif
 
+    # Options to pass to dfu-util when flashing
     DFU_ARGS = -d 1C11:B007
     DFU_SUFFIX_ARGS = -v 1C11 -p B007
 endif
-
 ifeq ($(strip $(BOOTLOADER)), stm32duino)
     OPT_DEFS += -DBOOTLOADER_STM32DUINO
     MCU_LDSCRIPT = STM32F103x8_stm32duino_bootloader
@@ -115,6 +131,7 @@ ifeq ($(strip $(BOOTLOADER)), stm32duino)
     # STM32F103 does NOT have an USB bootloader in ROM (only serial), so setting anything here does not make much sense
     STM32_BOOTLOADER_ADDRESS = 0x80000000
 
-    DFU_ARGS = -d 1EAF:0003 -a2 -R
+    # Options to pass to dfu-util when flashing
+    DFU_ARGS = -d 1EAF:0003 -a 2 -R
     DFU_SUFFIX_ARGS = -v 1EAF -p 0003
 endif

--- a/docs/flashing.md
+++ b/docs/flashing.md
@@ -1,105 +1,89 @@
 # Flashing Instructions and Bootloader Information
 
-There are quite a few different types of bootloaders that keyboards use, and just about all of them use a different flashing method. Luckily, projects like the [QMK Toolbox](https://github.com/qmk/qmk_toolbox/releases) aim to be compatible with all the different types without having to think about it much, but this article will describe the different types of bootloaders, and available methods for flashing them.
+There are quite a few different types of bootloaders that keyboards use, and almost all of them use their own flashing method and tools. Luckily, projects like the [QMK Toolbox](https://github.com/qmk/qmk_toolbox/releases) aim to support as many of them as possible, but this article will describe the different types of bootloaders, and available methods for flashing them.
 
-If you have a bootloader selected with the `BOOTLOADER` variable in your `rules.mk`, QMK will automatically calculate if your .hex file is the right size to be flashed to the device, and output the total size in bytes (along with the max).
+If you have a bootloader selected with the `BOOTLOADER` variable in your `rules.mk`, QMK will automatically calculate if your .hex file is the right size to be flashed to the device, and output the total size in bytes (along with the max). You will also be able to use the CLI to flash your keyboard, by running:
 
-## DFU
+```
+$ qmk flash -kb <keyboard> -km <keymap>
+```
+See the [`qmk flash`](cli_commands.md#qmk-flash) documentation for more information.
 
-Atmel's DFU bootloader comes on all atmega32u4 chips by default, and is used by many keyboards that have their own ICs on their PCBs (Older OLKB boards, Clueboards). Some keyboards may also use LUFA's DFU bootloader (or QMK's fork) (Newer OLKB boards) that adds in additional features specific to that hardware.
+## Atmel DFU
 
-To ensure compatibility with the DFU bootloader, make sure this block is present your `rules.mk` (optionally with `lufa-dfu` or `qmk-dfu` instead):
+Atmel's DFU bootloader comes on all USB AVRs by default (except for 16/32U4RC), and is used by many keyboards that have their own ICs on their PCBs (older OLKB boards, Clueboards). Some keyboards may also use LUFA's DFU bootloader, or QMK's fork of it (newer OLKB boards), that adds in additional features specific to that hardware.
+
+To ensure compatibility with the DFU bootloader, make sure this block is present in your `rules.mk` (optionally with `lufa-dfu` or `qmk-dfu` instead):
 
 ```make
 # Bootloader selection
-#   Teensy       halfkay
-#   Pro Micro    caterina
-#   Atmel DFU    atmel-dfu
-#   LUFA DFU     lufa-dfu
-#   QMK DFU      qmk-dfu
-#   ATmega32A    bootloadHID
-#   ATmega328P   USBasp
 BOOTLOADER = atmel-dfu
 ```
 
 Compatible flashers:
 
 * [QMK Toolbox](https://github.com/qmk/qmk_toolbox/releases) (recommended GUI)
-* [dfu-programmer](https://github.com/dfu-programmer/dfu-programmer) / `:dfu` in QMK (recommended command line)
+* [dfu-programmer](https://github.com/dfu-programmer/dfu-programmer) / `:dfu` target in QMK (recommended command line)
 
 Flashing sequence:
 
-1. Press the `RESET` keycode, or tap the RESET button (or short RST to GND).
+1. Press the `RESET` keycode, tap the RESET button, or short RST to GND
 2. Wait for the OS to detect the device
-3. Erase the memory (may be done automatically)
+3. Erase the flash memory (will be done automatically if using the Toolbox or CLI/make command)
 4. Flash a .hex file
-5. Reset the device into application mode (may be done automatically)
-
-or:
-
-    make <keyboard>:<keymap>:dfu
+5. Reset the device into application mode (will be done automatically as above)
 
 ### QMK DFU
 
-QMK has a fork of the LUFA DFU bootloader that allows for a simple matrix scan for exiting the bootloader and returning to the application, as well as flashing an LED/making a ticking noise with a speaker when things are happening. To enable these features, use this block in your `config.h` (The key that exits the bootloader needs to be hooked-up to the INPUT and OUTPUT defined here):
+QMK maintains [a fork of the LUFA DFU bootloader](https://github.com/qmk/lufa/tree/master/Bootloaders/DFU) that additionally performs a simple matrix scan for exiting the bootloader and returning to the application, as well as flashing an LED/making a ticking noise with a speaker when things are happening. To enable these features, add the following defines to your `config.h`:
 
-    #define QMK_ESC_OUTPUT F1 // usually COL
-    #define QMK_ESC_INPUT D5 // usually ROW
-    #define QMK_LED E6
-    #define QMK_SPEAKER C6
+```c
+#define QMK_ESC_OUTPUT F1  // COL pin if COL2ROW
+#define QMK_ESC_INPUT D5  // ROW pin if COL2ROW
+// Optional:
+//#define QMK_LED E6
+//#define QMK_SPEAKER C6
+```
+Currently we do not recommend making `QMK_ESC` the same key as the one designated for [Bootmagic Lite](feature_bootmagic.md#bootmagic-lite), as holding it down will cause the MCU to loop back and forth between entering and exiting the bootloader.
 
-The Manufacturer and Product names are automatically pulled from your `config.h`, and "Bootloader" is added to the product.
+The manufacturer and product strings are automatically pulled from `config.h`, with " Bootloader" appended to the product string.
 
-To generate this bootloader, use the `bootloader` target, eg `make planck/rev4:default:bootloader`.
+To generate this bootloader, use the `bootloader` target, eg. `make planck/rev4:default:bootloader`. To generate a production-ready .hex file (combining QMK and the bootloader), use the `production` target, eg. `make planck/rev4:default:production`.
 
-To generate a production-ready .hex file (containing the application and the bootloader), use the `production` target, eg `make planck/rev4:default:production`.
-
-### DFU commands
+### DFU Commands
 
 There are a number of DFU commands that you can use to flash firmware to a DFU device:
 
 * `:dfu` - This is the normal option and waits until a DFU device is available, and then flashes the firmware. This will check every 5 seconds, to see if a DFU device has appeared.
 * `:dfu-ee` - This flashes an `eep` file instead of the normal hex.  This is uncommon. 
-* `:dfu-split-left` - This flashes the normal firmware, just like the default option (`:dfu`). However, this also flashes the "Left Side" EEPROM file for split keyboards. _This is ideal for Elite C based split keyboards._
-* `:dfu-split-right` - This flashes the normal firmware, just like the default option (`:dfu`). However, this also flashes the "Right Side" EEPROM file for split keyboards. _This is ideal for Elite C based split keyboards._
+* `:dfu-split-left` - This flashes the normal firmware, just like the default option (`:dfu`). However, this also flashes the "Left Side" EEPROM file for split keyboards. *This is ideal for Elite C based split keyboards.*
+* `:dfu-split-right` - This flashes the normal firmware, just like the default option (`:dfu`). However, this also flashes the "Right Side" EEPROM file for split keyboards. *This is ideal for Elite C based split keyboards.*
 
 ## Caterina
 
-Arduino boards and their clones use the [Caterina bootloader](https://github.com/arduino/ArduinoCore-avr/tree/master/bootloaders/caterina) (any keyboard built with a Pro Micro, or clone), and uses the avr109 protocol to communicate through virtual serial. Bootloaders like [A-Star](https://www.pololu.com/docs/0J61/9) are based on Caterina.
+Arduino boards and their clones use the [Caterina bootloader](https://github.com/arduino/ArduinoCore-avr/tree/master/bootloaders/caterina) or a variant of it (any keyboard built with a Pro Micro or clone, and the Pololu A-Star), and uses the AVR109 protocol to communicate through virtual serial.
 
-To ensure compatibility with the Caterina bootloader, make sure this block is present your `rules.mk`:
+To ensure compatibility with the Caterina bootloader, make sure this block is present in your `rules.mk`:
 
 ```make
 # Bootloader selection
-#   Teensy       halfkay
-#   Pro Micro    caterina
-#   Atmel DFU    atmel-dfu
-#   LUFA DFU     lufa-dfu
-#   QMK DFU      qmk-dfu
-#   ATmega32A    bootloadHID
-#   ATmega328P   USBasp
 BOOTLOADER = caterina
 ```
 
 Compatible flashers:
 
 * [QMK Toolbox](https://github.com/qmk/qmk_toolbox/releases) (recommended GUI)
-* [avrdude](http://www.nongnu.org/avrdude/) with avr109 / `:avrdude` (recommended command line)
+* [avrdude](http://www.nongnu.org/avrdude/) with the `avr109` programmer / `:avrdude` target in QMK (recommended command line)
 * [AVRDUDESS](https://github.com/zkemble/AVRDUDESS)
 
 Flashing sequence:
 
-1. Press the `RESET` keycode, or short RST to GND quickly (you only have 7 seconds to flash once it enters)
+1. Press the `RESET` keycode, or short RST to GND quickly (you only have 7 seconds to flash once it enters) - some variants may require you to short twice within 750 milliseconds
 2. Wait for the OS to detect the device
 3. Flash a .hex file
 4. Wait for the device to reset automatically
 
-or
-
-    make <keyboard>:<keymap>:avrdude
-
-
-### Caterina commands
+### Caterina Commands
 
 There are a number of DFU commands that you can use to flash firmware to a DFU device:
 
@@ -108,23 +92,14 @@ There are a number of DFU commands that you can use to flash firmware to a DFU d
 * `:avrdude-split-left` - This flashes the normal firmware, just like the default option (`:avrdude`). However, this also flashes the "Left Side" EEPROM file for split keyboards. _This is ideal for Pro Micro based split keyboards._
 * `:avrdude-split-right` - This flashes the normal firmware, just like the default option (`:avrdude`). However, this also flashes the "Right Side" EEPROM file for split keyboards. _This is ideal for Pro Micro based split keyboards._
 
+## HalfKay
 
+HalfKay is a super-slim bootloader developed by PJRC that uses HID, and comes on all Teensys (namely the 2.0). It is currently closed-source, and thus once overwritten (eg. via ISP flashing another bootloader), cannot be restored.
 
-## Halfkay
-
-Halfkay is a super-slim protocol developed by PJRC that uses HID, and comes on all Teensys (namely the 2.0).
-
-To ensure compatibility with the Halfkay bootloader, make sure this block is present your `rules.mk`:
+To ensure compatibility with the Halfkay bootloader, make sure this block is present in your `rules.mk`:
 
 ```make
 # Bootloader selection
-#   Teensy       halfkay
-#   Pro Micro    caterina
-#   Atmel DFU    atmel-dfu
-#   LUFA DFU     lufa-dfu
-#   QMK DFU      qmk-dfu
-#   ATmega32A    bootloadHID
-#   ATmega328P   USBasp
 BOOTLOADER = halfkay
 ```
 
@@ -132,7 +107,7 @@ Compatible flashers:
 
 * [QMK Toolbox](https://github.com/qmk/qmk_toolbox/releases) (recommended GUI)
 * [Teensy Loader](https://www.pjrc.com/teensy/loader.html)
-* [Teensy Loader Command Line](https://www.pjrc.com/teensy/loader_cli.html) (recommended command line)
+* [Teensy Loader Command Line](https://www.pjrc.com/teensy/loader_cli.html) / `:teensy` target in QMK (recommended command line)
 
 Flashing sequence:
 
@@ -143,26 +118,19 @@ Flashing sequence:
 
 ## USBasploader
 
-USBasploader is a bootloader developed by matrixstorm. It is used in some non-USB AVR chips such as the ATmega328P, which run V-USB.
+USBasploader is a bootloader originally developed by [Objective Development](https://www.obdev.at/products/vusb/usbasploader.html). It emulates a USBasp ISP programmer and is used in some non-USB AVR chips such as the ATmega328P, which run V-USB.
 
 To ensure compatibility with the USBasploader bootloader, make sure this block is present in your `rules.mk`:
 
 ```make
 # Bootloader selection
-#   Teensy       halfkay
-#   Pro Micro    caterina
-#   Atmel DFU    atmel-dfu
-#   LUFA DFU     lufa-dfu
-#   QMK DFU      qmk-dfu
-#   ATmega32A    bootloadHID
-#   ATmega328P   USBasp
 BOOTLOADER = USBasp
 ```
 
 Compatible flashers:
 
 * [QMK Toolbox](https://github.com/qmk/qmk_toolbox/releases) (recommended GUI)
-* [avrdude](http://www.nongnu.org/avrdude/) with the `usbasp` programmer
+* [avrdude](http://www.nongnu.org/avrdude/) with the `usbasp` programmer / `:usbasp` target in QMK (recommended command line)
 * [AVRDUDESS](https://github.com/zkemble/AVRDUDESS)
 
 Flashing sequence:
@@ -170,66 +138,59 @@ Flashing sequence:
 1. Press the `RESET` keycode, or keep the boot pin shorted to GND while quickly shorting RST to GND
 2. Wait for the OS to detect the device
 3. Flash a .hex file
-4. Reset the device into application mode (may be done automatically)
+4. Press the RESET button on the PCB or short RST to GND
 
 ## BootloadHID
 
-BootloadHID is a USB bootloader for AVR microcontrollers. The uploader tool requires no kernel level driver on Windows and can therefore be run without installing any DLLs.
+BootloadHID is a USB bootloader for AVR microcontrollers. It presents itself as an HID input device, much like HalfKay, and can therefore be run without installing any driver on Windows.
 
-To ensure compatibility with the bootloadHID bootloader, make sure this block is present your `rules.mk`:
+To ensure compatibility with the bootloadHID bootloader, make sure this block is present in your `rules.mk`:
 
 ```make
 # Bootloader selection
-#   Teensy       halfkay
-#   Pro Micro    caterina
-#   Atmel DFU    atmel-dfu
-#   LUFA DFU     lufa-dfu
-#   QMK DFU      qmk-dfu
-#   ATmega32A    bootloadHID
-#   ATmega328P   USBasp
 BOOTLOADER = bootloadHID
 ```
 
 Compatible flashers:
 
-* [HIDBootFlash](http://vusb.wikidot.com/project:hidbootflash) (recommended Windows GUI)
-* [bootloadhid Command Line](https://www.obdev.at/products/vusb/bootloadhid.html) / `:BootloadHID` in QMK (recommended command line)
+* [QMK Toolbox](https://github.com/qmk/qmk_toolbox/releases) (recommended GUI)
+* [HIDBootFlash](http://vusb.wikidot.com/project:hidbootflash)
+* [bootloadHID CLI](https://www.obdev.at/products/vusb/bootloadhid.html) / `:bootloadHID` target in QMK (recommended command line)
 
 Flashing sequence:
 
 1. Enter the bootloader using any of the following methods:
-    * Tap the `RESET` keycode (may not work on all devices)
-    * Hold the salt key while plugging the keyboard in (usually documented within keyboard readme) 
+    * Tap the `RESET` keycode; or
+    * Hold the salt key while plugging the keyboard in - for PS2AVRGB boards, this is usually the key connected to pins A0 and B0, otherwise it will be documented in your keyboard's readme
 2. Wait for the OS to detect the device
 3. Flash a .hex file
 4. Reset the device into application mode (may be done automatically)
 
-or:
+## STM32/APM32 DFU
 
-    make <keyboard>:<keymap>:bootloadHID
+All STM32 and APM32 MCUs, except for F103 (see the [STM32duino section](#stm32duino)) come preloaded with a factory bootloader that cannot be modified nor deleted.
 
-## STM32
+To ensure compatibility with the STM32-DFU bootloader, make sure this block is present in your `rules.mk` (optionally with `apm32-dfu` instead):
 
-All STM32 chips come preloaded with a factory bootloader that cannot be modified nor deleted. Some STM32 chips have bootloaders that do not come with USB programming (e.g. STM32F103) but the process is still the same.
-
-At the moment, no `BOOTLOADER` variable is needed on `rules.mk` for STM32.
+```make
+# Bootloader selection
+BOOTLOADER = stm32-dfu
+```
 
 Compatible flashers:
 
 * [QMK Toolbox](https://github.com/qmk/qmk_toolbox/releases) (recommended GUI)
-* [dfu-util](https://github.com/Stefan-Schmidt/dfu-util) / `:dfu-util` (recommended command line)
+* [dfu-util](http://dfu-util.sourceforge.net/) / `:dfu-util` target in QMK (recommended command line)
 
 Flashing sequence:
 
 1. Enter the bootloader using any of the following methods:
     * Tap the `RESET` keycode (may not work on STM32F042 devices)
-    * If a reset circuit is present, tap the RESET button
+    * If a reset circuit is present, tap the RESET button; some boards may also have a toggle switch that must be flipped
     * Otherwise, you need to bridge BOOT0 to VCC (via BOOT0 button or bridge), short RESET to GND (via RESET button or bridge), and then let go of the BOOT0 bridge
 2. Wait for the OS to detect the device
 3. Flash a .bin file
-    * You will receive a warning about the DFU signature; Just ignore it
 4. Reset the device into application mode (may be done automatically)
-    * If you are building from command line (e.g. `make planck/rev6:default:dfu-util`), make sure that `:leave` is passed to the `DFU_ARGS` variable inside your `rules.mk` (e.g. `DFU_ARGS = -d 0483:df11 -a 0 -s 0x08000000:leave`) so that your device resets after flashing
 
 ### STM32 Commands
 
@@ -240,3 +201,49 @@ There are a number of DFU commands that you can use to flash firmware to a STM32
 * `:dfu-util-split-right` - This flashes the normal firmware, just like the default option (`:dfu-util`). However, this also configures the "Right Side" EEPROM setting for split keyboards.
 * `:st-link-cli` - This allows you to flash the firmware via ST-LINK's CLI utility, rather than dfu-util. 
 * `:st-flash` - This allows you to flash the firmware via the `st-flash` utility from [STLink Tools](https://github.com/stlink-org/stlink), rather than dfu-util.
+
+## STM32duino
+
+This bootloader is used almost exclusively for STM32F103 boards, as they do not come with a USB DFU bootloader. The source code and prebuilt binaries can be found [here](https://github.com/rogerclarkmelbourne/STM32duino-bootloader).
+
+To ensure compatibility with the STM32duino bootloader, make sure this block is present in your `rules.mk`:
+
+```make
+# Bootloader selection
+BOOTLOADER = stm32duino
+```
+
+Compatible flashers:
+
+* [QMK Toolbox](https://github.com/qmk/qmk_toolbox/releases) (recommended GUI)
+* [dfu-util](http://dfu-util.sourceforge.net/) / `:dfu-util` target in QMK (recommended command line)
+
+Flashing sequence:
+
+1. Enter the bootloader using any of the following methods:
+    * Tap the `RESET` keycode
+    * If a reset circuit is present, tap the RESET button
+    * Otherwise, you need to bridge BOOT0 to VCC (via BOOT0 button or bridge), short RESET to GND (via RESET button or bridge), and then let go of the BOOT0 bridge
+2. Wait for the OS to detect the device
+3. Flash a .bin file
+4. Reset the device into application mode (may be done automatically)
+
+## Kiibohd DFU
+
+Keyboards produced by Input Club use NXP Kinetis microcontrollers rather than STM32, and come with their own [custom bootloader](https://github.com/kiibohd/controller/tree/master/Bootloader), however the process and protocol is largely the same.
+
+The `rules.mk` setting for this bootloader is `kiibohd`, but since this bootloader is limited to Input Club boards, it should not be necessary at keymap or user level.
+
+Compatible flashers:
+
+* [QMK Toolbox](https://github.com/qmk/qmk_toolbox/releases) (recommended GUI)
+* [dfu-util](http://dfu-util.sourceforge.net/) / `:dfu-util` target in QMK (recommended command line)
+
+Flashing sequence:
+
+1. Enter the bootloader using any of the following methods:
+    * Tap the `RESET` keycode (this may only enter the MCU into a "secure" bootloader mode; see https://github.com/qmk/qmk_firmware/issues/6112)
+    * Press the RESET button on the PCB
+2. Wait for the OS to detect the device
+3. Flash a .bin file
+4. Reset the device into application mode (may be done automatically)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Part 1, adding the options. Parts 2-?? will be to set `BOOTLOADER` for all applicable STM32 boards, and remove the dfu-util args from mcu_selection.mk.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
