### PR TITLE
Split transport mirror

### DIFF
--- a/docs/feature_split_keyboard.md
+++ b/docs/feature_split_keyboard.md
@@ -191,6 +191,12 @@ communication protocol and may impact the matrix scan speed when enabled.
 The purpose of this feature is to support cosmetic use of modifer state (e.g.
 displaying status on an OLED screen).
 
+```c
+#define SPLIT_TRANSPORT_MIRROR
+```
+
+This mirrors the master side matrix to the slave side for features that react or require knowledge of master side key presses on the slave side.  This adds a few bytes of data to the split communication protocol and may impact the matrix scan speed when enabled. The purpose of this feature is to support cosmetic use of key events (e.g. RGB reacting to Keypresses).
+
 ###  Hardware Configuration Options
 
 There are some settings that you may need to configure, based on how the hardware is set up. 

--- a/docs/ja/understanding_qmk.md
+++ b/docs/ja/understanding_qmk.md
@@ -147,7 +147,6 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
       * [`bool process_haptic(uint16_t keycode, keyrecord_t *record)`](https://github.com/qmk/qmk_firmware/blob/2cee371bf125a6ec541dd7c5a809573facc7c456/drivers/haptic/haptic.c#L216)
       * [`bool process_record_kb(uint16_t keycode, keyrecord_t *record)`](https://github.com/qmk/qmk_firmware/blob/e1203a222bb12ab9733916164a000ef3ac48da93/keyboards/clueboard/card/card.c#L20)
          * [`bool process_record_user(uint16_t keycode, keyrecord_t *record)`](https://github.com/qmk/qmk_firmware/blob/e1203a222bb12ab9733916164a000ef3ac48da93/keyboards/clueboard/card/keymaps/default/keymap.c#L58)
-      * [`bool process_rgb_matrix(uint16_t keycode, keyrecord_t *record)`](https://github.com/qmk/qmk_firmware/blob/e1203a222bb12ab9733916164a000ef3ac48da93/quantum/rgb_matrix.c#L139)
       * [`bool process_midi(uint16_t keycode, keyrecord_t *record)`](https://github.com/qmk/qmk_firmware/blob/e1203a222bb12ab9733916164a000ef3ac48da93/quantum/process_keycode/process_midi.c#L81)
       * [`bool process_audio(uint16_t keycode, keyrecord_t *record)`](https://github.com/qmk/qmk_firmware/blob/e1203a222bb12ab9733916164a000ef3ac48da93/quantum/process_keycode/process_audio.c#L19)
       * [`bool process_steno(uint16_t keycode, keyrecord_t *record)`](https://github.com/qmk/qmk_firmware/blob/e1203a222bb12ab9733916164a000ef3ac48da93/quantum/process_keycode/process_steno.c#L160)

--- a/docs/understanding_qmk.md
+++ b/docs/understanding_qmk.md
@@ -142,7 +142,6 @@ The `process_record()` function itself is deceptively simple, but hidden within 
     * [`bool process_haptic(uint16_t keycode, keyrecord_t *record)`](https://github.com/qmk/qmk_firmware/blob/2cee371bf125a6ec541dd7c5a809573facc7c456/drivers/haptic/haptic.c#L216)
     * [`bool process_record_kb(uint16_t keycode, keyrecord_t *record)`](https://github.com/qmk/qmk_firmware/blob/e1203a222bb12ab9733916164a000ef3ac48da93/keyboards/clueboard/card/card.c#L20)
       * [`bool process_record_user(uint16_t keycode, keyrecord_t *record)`](https://github.com/qmk/qmk_firmware/blob/e1203a222bb12ab9733916164a000ef3ac48da93/keyboards/clueboard/card/keymaps/default/keymap.c#L58)
-    * [`bool process_rgb_matrix(uint16_t keycode, keyrecord_t *record)`](https://github.com/qmk/qmk_firmware/blob/e1203a222bb12ab9733916164a000ef3ac48da93/quantum/rgb_matrix.c#L139)
     * [`bool process_midi(uint16_t keycode, keyrecord_t *record)`](https://github.com/qmk/qmk_firmware/blob/e1203a222bb12ab9733916164a000ef3ac48da93/quantum/process_keycode/process_midi.c#L81)
     * [`bool process_audio(uint16_t keycode, keyrecord_t *record)`](https://github.com/qmk/qmk_firmware/blob/e1203a222bb12ab9733916164a000ef3ac48da93/quantum/process_keycode/process_audio.c#L19)
     * [`bool process_steno(uint16_t keycode, keyrecord_t *record)`](https://github.com/qmk/qmk_firmware/blob/e1203a222bb12ab9733916164a000ef3ac48da93/quantum/process_keycode/process_steno.c#L160)

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -225,9 +225,6 @@ bool process_record_quantum(keyrecord_t *record) {
 #ifdef HAPTIC_ENABLE
             process_haptic(keycode, record) &&
 #endif  // HAPTIC_ENABLE
-#if defined(RGB_MATRIX_ENABLE)
-            process_rgb_matrix(keycode, record) &&
-#endif
 #if defined(VIA_ENABLE)
             process_record_via(keycode, record) &&
 #endif
@@ -639,9 +636,6 @@ void matrix_init_quantum() {
 #ifdef AUDIO_ENABLE
     audio_init();
 #endif
-#ifdef RGB_MATRIX_ENABLE
-    rgb_matrix_init();
-#endif
 #if defined(UNICODE_ENABLE) || defined(UNICODEMAP_ENABLE) || defined(UCIS_ENABLE)
     unicode_input_mode_init();
 #endif
@@ -694,10 +688,6 @@ void matrix_scan_quantum() {
 
 #ifdef LED_MATRIX_ENABLE
     led_matrix_task();
-#endif
-
-#ifdef RGB_MATRIX_ENABLE
-    rgb_matrix_task();
 #endif
 
 #ifdef WPM_ENABLE

--- a/quantum/rgb_matrix.c
+++ b/quantum/rgb_matrix.c
@@ -184,11 +184,12 @@ void rgb_matrix_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
 
 void rgb_matrix_set_color_all(uint8_t red, uint8_t green, uint8_t blue) { rgb_matrix_driver.set_color_all(red, green, blue); }
 
-bool process_rgb_matrix(uint16_t keycode, keyrecord_t *record) {
+void process_rgb_matrix(uint8_t row, uint8_t col, bool pressed) {
+#ifndef RGB_MATRIX_SPLIT
+    if (!is_keyboard_master()) return;
+#endif
 #if RGB_DISABLE_TIMEOUT > 0
-    if (record->event.pressed) {
-        rgb_anykey_timer = 0;
-    }
+    rgb_anykey_timer = 0;
 #endif  // RGB_DISABLE_TIMEOUT > 0
 
 #ifdef RGB_MATRIX_KEYREACTIVE_ENABLED
@@ -196,12 +197,12 @@ bool process_rgb_matrix(uint16_t keycode, keyrecord_t *record) {
     uint8_t led_count = 0;
 
 #    if defined(RGB_MATRIX_KEYRELEASES)
-    if (!record->event.pressed)
+    if (!pressed)
 #    elif defined(RGB_MATRIX_KEYPRESSES)
-    if (record->event.pressed)
+    if (pressed)
 #    endif  // defined(RGB_MATRIX_KEYRELEASES)
     {
-        led_count = rgb_matrix_map_row_column_to_led(record->event.key.row, record->event.key.col, led);
+        led_count = rgb_matrix_map_row_column_to_led(row, col, led);
     }
 
     if (last_hit_buffer.count + led_count > LED_HITS_TO_REMEMBER) {
@@ -224,11 +225,9 @@ bool process_rgb_matrix(uint16_t keycode, keyrecord_t *record) {
 
 #if defined(RGB_MATRIX_FRAMEBUFFER_EFFECTS) && !defined(DISABLE_RGB_MATRIX_TYPING_HEATMAP)
     if (rgb_matrix_config.mode == RGB_MATRIX_TYPING_HEATMAP) {
-        process_rgb_matrix_typing_heatmap(record);
+        process_rgb_matrix_typing_heatmap(row, col);
     }
 #endif  // defined(RGB_MATRIX_FRAMEBUFFER_EFFECTS) && !defined(DISABLE_RGB_MATRIX_TYPING_HEATMAP)
-
-    return true;
 }
 
 void rgb_matrix_test(void) {

--- a/quantum/rgb_matrix.h
+++ b/quantum/rgb_matrix.h
@@ -98,7 +98,7 @@ uint8_t rgb_matrix_map_row_column_to_led(uint8_t row, uint8_t column, uint8_t *l
 void rgb_matrix_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
 void rgb_matrix_set_color_all(uint8_t red, uint8_t green, uint8_t blue);
 
-bool process_rgb_matrix(uint16_t keycode, keyrecord_t *record);
+void process_rgb_matrix(uint8_t row, uint8_t col, bool pressed);
 
 void rgb_matrix_task(void);
 

--- a/quantum/rgb_matrix_animations/typing_heatmap_anim.h
+++ b/quantum/rgb_matrix_animations/typing_heatmap_anim.h
@@ -6,9 +6,7 @@ RGB_MATRIX_EFFECT(TYPING_HEATMAP)
 #            define RGB_MATRIX_TYPING_HEATMAP_DECREASE_DELAY_MS 25
 #        endif
 
-void process_rgb_matrix_typing_heatmap(keyrecord_t* record) {
-    uint8_t row   = record->event.key.row;
-    uint8_t col   = record->event.key.col;
+void process_rgb_matrix_typing_heatmap(uint8_t row, uint8_t col) {
     uint8_t m_row = row - 1;
     uint8_t p_row = row + 1;
     uint8_t m_col = col - 1;

--- a/quantum/split_common/matrix.c
+++ b/quantum/split_common/matrix.c
@@ -257,7 +257,7 @@ bool matrix_post_scan(void) {
         static uint8_t error_count;
 
         matrix_row_t slave_matrix[ROWS_PER_HAND] = {0};
-        if (!transport_master(matrix + thisHand, matrix + thatHand)) {
+        if (!transport_master(matrix + thisHand, slave_matrix)) {
             error_count++;
 
             if (error_count > ERROR_DISCONNECT_COUNT) {

--- a/quantum/split_common/matrix.c
+++ b/quantum/split_common/matrix.c
@@ -257,7 +257,7 @@ bool matrix_post_scan(void) {
         static uint8_t error_count;
 
         matrix_row_t slave_matrix[ROWS_PER_HAND] = {0};
-        if (!transport_master(slave_matrix)) {
+        if (!transport_master(matrix + thisHand, matrix + thatHand)) {
             error_count++;
 
             if (error_count > ERROR_DISCONNECT_COUNT) {
@@ -282,7 +282,7 @@ bool matrix_post_scan(void) {
 
         matrix_scan_quantum();
     } else {
-        transport_slave(matrix + thisHand);
+        transport_slave(matrix + thatHand, matrix + thisHand);
 
         matrix_slave_scan_user();
     }

--- a/quantum/split_common/transport.h
+++ b/quantum/split_common/transport.h
@@ -6,5 +6,5 @@ void transport_master_init(void);
 void transport_slave_init(void);
 
 // returns false if valid data not received from slave
-bool transport_master(matrix_row_t matrix[]);
-void transport_slave(matrix_row_t matrix[]);
+bool transport_master(matrix_row_t master_matrix[], matrix_row_t slave_matrix[]);
+void transport_slave(matrix_row_t master_matrix[], matrix_row_t slave_matrix[]);

--- a/tmk_core/common/eeconfig.h
+++ b/tmk_core/common/eeconfig.h
@@ -21,7 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <stdbool.h>
 
 #ifndef EECONFIG_MAGIC_NUMBER
-#    define EECONFIG_MAGIC_NUMBER (uint16_t)0xFEEC
+#    define EECONFIG_MAGIC_NUMBER (uint16_t)0xFEEB // When changing, decrement this value to avoid future re-init issues
 #endif
 #define EECONFIG_MAGIC_NUMBER_OFF (uint16_t)0xFFFF
 

--- a/tmk_core/common/keyboard.c
+++ b/tmk_core/common/keyboard.c
@@ -54,6 +54,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifdef RGBLIGHT_ENABLE
 #    include "rgblight.h"
 #endif
+#ifdef RGB_MATRIX_ENABLE
+#    include "rgb_matrix.h"
+#endif
 #ifdef ENCODER_ENABLE
 #    include "encoder.h"
 #endif
@@ -306,6 +309,9 @@ void keyboard_init(void) {
 #ifdef RGBLIGHT_ENABLE
     rgblight_init();
 #endif
+#ifdef RGB_MATRIX_ENABLE
+    rgb_matrix_init();
+#endif
 #ifdef ENCODER_ENABLE
     encoder_init();
 #endif
@@ -331,6 +337,17 @@ void keyboard_init(void) {
 #endif
 
     keyboard_post_init_kb(); /* Always keep this last */
+}
+
+/** \brief key_event_task
+ *
+ * This function is responsible for calling into other systems when they need to respond to electrical switch press events.
+ * This is differnet than keycode events as no layer processing, or filtering occurs.
+ */
+void switch_events(uint8_t row, uint8_t col, bool pressed) {
+#if defined(RGB_MATRIX_ENABLE)
+    process_rgb_matrix(row, col, pressed);
+#endif
 }
 
 /** \brief Keyboard task: Do keyboard routine jobs
@@ -363,32 +380,35 @@ void keyboard_task(void) {
     uint8_t matrix_changed = matrix_scan();
     if (matrix_changed) last_matrix_activity_trigger();
 
-    if (should_process_keypress()) {
-        for (uint8_t r = 0; r < MATRIX_ROWS; r++) {
-            matrix_row    = matrix_get_row(r);
-            matrix_change = matrix_row ^ matrix_prev[r];
-            if (matrix_change) {
+    for (uint8_t r = 0; r < MATRIX_ROWS; r++) {
+        matrix_row    = matrix_get_row(r);
+        matrix_change = matrix_row ^ matrix_prev[r];
+        if (matrix_change) {
 #ifdef MATRIX_HAS_GHOST
-                if (has_ghost_in_row(r, matrix_row)) {
-                    continue;
-                }
+            if (has_ghost_in_row(r, matrix_row)) {
+                continue;
+            }
 #endif
-                if (debug_matrix) matrix_print();
-                matrix_row_t col_mask = 1;
-                for (uint8_t c = 0; c < MATRIX_COLS; c++, col_mask <<= 1) {
-                    if (matrix_change & col_mask) {
+            if (debug_matrix) matrix_print();
+            matrix_row_t col_mask = 1;
+            for (uint8_t c = 0; c < MATRIX_COLS; c++, col_mask <<= 1) {
+                if (matrix_change & col_mask) {
+                    if (should_process_keypress()) {
                         action_exec((keyevent_t){
                             .key = (keypos_t){.row = r, .col = c}, .pressed = (matrix_row & col_mask), .time = (timer_read() | 1) /* time should not be 0 */
                         });
-                        // record a processed key
-                        matrix_prev[r] ^= col_mask;
-#ifdef QMK_KEYS_PER_SCAN
-                        // only jump out if we have processed "enough" keys.
-                        if (++keys_processed >= QMK_KEYS_PER_SCAN)
-#endif
-                            // process a key per task call
-                            goto MATRIX_LOOP_END;
                     }
+                    // record a processed key
+                    matrix_prev[r] ^= col_mask;
+
+                    switch_events(r, c, (matrix_row & col_mask));
+
+#ifdef QMK_KEYS_PER_SCAN
+                    // only jump out if we have processed "enough" keys.
+                    if (++keys_processed >= QMK_KEYS_PER_SCAN)
+#endif
+                        // process a key per task call
+                        goto MATRIX_LOOP_END;
                 }
             }
         }
@@ -408,6 +428,10 @@ MATRIX_LOOP_END:
 
 #if defined(RGBLIGHT_ENABLE)
     rgblight_task();
+#endif
+
+#ifdef RGB_MATRIX_ENABLE
+    rgb_matrix_task();
 #endif
 
 #if defined(BACKLIGHT_ENABLE)


### PR DESCRIPTION
## Description

Added a define option for split keyboards to transport the master matrix to the slave side. This allows systems (such as rgb matrix's key reactive animations) to be processed on the slave side instead of the master side, or mirrored in the case of the up coming split rgb matrix split support.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
