### PR TITLE
Improve Pointing Device report sending

### DIFF
--- a/docs/feature_pointing_device.md
+++ b/docs/feature_pointing_device.md
@@ -27,7 +27,7 @@ Once you have made the necessary changes to the mouse report, you need to send i
 
 When the mouse report is sent, the x, y, v, and h values are set to 0 (this is done in `pointing_device_send()`, which can be overridden to avoid this behavior).  This way, button states persist, but movement will only occur once.  For further customization, both `pointing_device_init` and `pointing_device_task` can be overridden.
 
-Additionlly, by default, `pointing_device_send()` will only send a report when the report has actually changed.  This prevents it from continuously sending mouse reports, which will keep the host system awake.  This behavior can be changed by creating your own `pointing_device_send()` function.
+Additionally, by default, `pointing_device_send()` will only send a report when the report has actually changed.  This prevents it from continuously sending mouse reports, which will keep the host system awake.  This behavior can be changed by creating your own `pointing_device_send()` function.
 
 Also, you use the `has_mouse_report_changed(old, new)` function to check to see if the report has changed. 
 

--- a/docs/feature_pointing_device.md
+++ b/docs/feature_pointing_device.md
@@ -27,7 +27,7 @@ Once you have made the necessary changes to the mouse report, you need to send i
 
 When the mouse report is sent, the x, y, v, and h values are set to 0 (this is done in `pointing_device_send()`, which can be overridden to avoid this behavior).  This way, button states persist, but movement will only occur once.  For further customization, both `pointing_device_init` and `pointing_device_task` can be overridden.
 
-Additionlly, by default, `pointing_device_send()` will only send a report when the report has actually changed.  This prevents it from continuously sending mouse reports, which will keep the host system awake.  This behavior can be changed by creating your own `pointing_device_send()` function, or by adding `#define POINTING_DEVICE_ALWAYS_SEND_REPORT` to your config.h setting. 
+Additionlly, by default, `pointing_device_send()` will only send a report when the report has actually changed.  This prevents it from continuously sending mouse reports, which will keep the host system awake.  This behavior can be changed by creating your own `pointing_device_send()` function.
 
 Also, you use the `has_mouse_report_changed(old, new)` function to check to see if the report has changed. 
 

--- a/docs/feature_pointing_device.md
+++ b/docs/feature_pointing_device.md
@@ -27,6 +27,10 @@ Once you have made the necessary changes to the mouse report, you need to send i
 
 When the mouse report is sent, the x, y, v, and h values are set to 0 (this is done in `pointing_device_send()`, which can be overridden to avoid this behavior).  This way, button states persist, but movement will only occur once.  For further customization, both `pointing_device_init` and `pointing_device_task` can be overridden.
 
+Additionlly, by default, `pointing_device_send()` will only send a report when the report has actually changed.  This prevents it from continuously sending mouse reports, which will keep the host system awake.  This behavior can be changed by creating your own `pointing_device_send()` function, or by adding `#define POINTING_DEVICE_ALWAYS_SEND_REPORT` to your config.h setting. 
+
+Also, you use the `has_mouse_report_changed(old, new)` function to check to see if the report has changed. 
+
 In the following example, a custom key is used to click the mouse and scroll 127 units vertically and horizontally, then undo all of that when released - because that's a totally useful function.  Listen, this is an example:
 
 ```c

--- a/docs/feature_pointing_device.md
+++ b/docs/feature_pointing_device.md
@@ -29,7 +29,7 @@ When the mouse report is sent, the x, y, v, and h values are set to 0 (this is d
 
 Additionally, by default, `pointing_device_send()` will only send a report when the report has actually changed.  This prevents it from continuously sending mouse reports, which will keep the host system awake.  This behavior can be changed by creating your own `pointing_device_send()` function.
 
-Also, you use the `has_mouse_report_changed(old, new)` function to check to see if the report has changed. 
+Also, you use the `has_mouse_report_changed(new, old)` function to check to see if the report has changed.
 
 In the following example, a custom key is used to click the mouse and scroll 127 units vertically and horizontally, then undo all of that when released - because that's a totally useful function.  Listen, this is an example:
 

--- a/quantum/pointing_device.c
+++ b/quantum/pointing_device.c
@@ -25,18 +25,34 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 static report_mouse_t mouseReport = {};
 
+__attribute__((weak)) bool has_mouse_report_changed(report_mouse_t new, report_mouse_t old) {
+    return (new.buttons != old.buttons) ||
+           (new.x && new.x != old.x) ||
+           (new.y && new.y != old.y) ||
+           (new.h && new.h != old.h) ||
+           (new.v && new.v != old.v);
+}
+
+
 __attribute__((weak)) void pointing_device_init(void) {
     // initialize device, if that needs to be done.
 }
 
 __attribute__((weak)) void pointing_device_send(void) {
+    static report_mouse_t old_report = {};
+
     // If you need to do other things, like debugging, this is the place to do it.
-    host_mouse_send(&mouseReport);
+#ifndef POINTING_DEVICE_ALWAYS_SEND_REPORT
+    if (has_mouse_report_changed(mouseReport, old_report))
+#endif
+        host_mouse_send(&mouseReport);
+
     // send it and 0 it out except for buttons, so those stay until they are explicity over-ridden using update_pointing_device
     mouseReport.x = 0;
     mouseReport.y = 0;
     mouseReport.v = 0;
     mouseReport.h = 0;
+    old_report = mouseReport;
 }
 
 __attribute__((weak)) void pointing_device_task(void) {

--- a/quantum/pointing_device.c
+++ b/quantum/pointing_device.c
@@ -39,15 +39,10 @@ __attribute__((weak)) void pointing_device_init(void) {
 }
 
 __attribute__((weak)) void pointing_device_send(void) {
-#ifndef POINTING_DEVICE_ALWAYS_SEND_REPORT
     static report_mouse_t old_report = {};
-#endif
 
     // If you need to do other things, like debugging, this is the place to do it.
-#ifndef POINTING_DEVICE_ALWAYS_SEND_REPORT
-    if (has_mouse_report_changed(mouseReport, old_report))
-#endif
-    {
+    if (has_mouse_report_changed(mouseReport, old_report)) {
         host_mouse_send(&mouseReport);
     }
     // send it and 0 it out except for buttons, so those stay until they are explicity over-ridden using update_pointing_device
@@ -55,9 +50,7 @@ __attribute__((weak)) void pointing_device_send(void) {
     mouseReport.y = 0;
     mouseReport.v = 0;
     mouseReport.h = 0;
-#ifndef POINTING_DEVICE_ALWAYS_SEND_REPORT
     old_report = mouseReport;
-#endif
 }
 
 __attribute__((weak)) void pointing_device_task(void) {

--- a/quantum/pointing_device.c
+++ b/quantum/pointing_device.c
@@ -47,8 +47,9 @@ __attribute__((weak)) void pointing_device_send(void) {
 #ifndef POINTING_DEVICE_ALWAYS_SEND_REPORT
     if (has_mouse_report_changed(mouseReport, old_report))
 #endif
+    {
         host_mouse_send(&mouseReport);
-
+    }
     // send it and 0 it out except for buttons, so those stay until they are explicity over-ridden using update_pointing_device
     mouseReport.x = 0;
     mouseReport.y = 0;

--- a/quantum/pointing_device.c
+++ b/quantum/pointing_device.c
@@ -39,7 +39,9 @@ __attribute__((weak)) void pointing_device_init(void) {
 }
 
 __attribute__((weak)) void pointing_device_send(void) {
+#ifndef POINTING_DEVICE_ALWAYS_SEND_REPORT
     static report_mouse_t old_report = {};
+#endif
 
     // If you need to do other things, like debugging, this is the place to do it.
 #ifndef POINTING_DEVICE_ALWAYS_SEND_REPORT
@@ -52,7 +54,9 @@ __attribute__((weak)) void pointing_device_send(void) {
     mouseReport.y = 0;
     mouseReport.v = 0;
     mouseReport.h = 0;
+#ifndef POINTING_DEVICE_ALWAYS_SEND_REPORT
     old_report = mouseReport;
+#endif
 }
 
 __attribute__((weak)) void pointing_device_task(void) {

--- a/quantum/pointing_device.h
+++ b/quantum/pointing_device.h
@@ -26,3 +26,4 @@ void           pointing_device_task(void);
 void           pointing_device_send(void);
 report_mouse_t pointing_device_get_report(void);
 void           pointing_device_set_report(report_mouse_t newMouseReport);
+bool           has_mouse_report_changed(report_mouse_t new, report_mouse_t old);


### PR DESCRIPTION
## Description

Expands the `pointing_device_send()` function to be more robust. 

Specifically, it's not a good idea to always send the mouse report to the host system, as this is considered activity, and may/will keep the system awake.  So reports should only be sent when there is an update.  

Additionally, after #10179, it became apparent that any changes that happened and weren't immediately sent and you manually checked for activity (such as with the ploopyco code), the reports could get "stuck".  As such, this moves the logic to the send function, so that it's better able to check. 



## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [x] Enhancement/optimization
- [x] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
