### PR TITLE
Add customMK Genesis Macro Pad

### DIFF
--- a/keyboards/custommk/genesis/config.h
+++ b/keyboards/custommk/genesis/config.h
@@ -1,4 +1,4 @@
-/* Copyright 2020 David Hoelscher (customMK)
+/* Copyright 2020 customMK
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -51,9 +51,6 @@
 #define ENCODERS_PAD_B { F7, D1 }
 #define ENCODER_RESOLUTION 4
 #define TAP_CODE_DELAY 10
-
-#define BOOTMAGIC_LITE_COLUMN 0
-#define BOOTMAGIC_LITE_ROW 0
 
 #define RGB_DI_PIN E6
 #define RGBLIGHT_ANIMATIONS

--- a/keyboards/custommk/genesis/config.h
+++ b/keyboards/custommk/genesis/config.h
@@ -22,8 +22,8 @@
 /* USB Device descriptor parameter */
 #define VENDOR_ID       0xF35B
 #define PRODUCT_ID      0xFAB0
-#define MANUFACTURER    customMK
 #define DEVICE_VER      0x0001
+#define MANUFACTURER    customMK
 #define PRODUCT         Genesis
 
 /* key matrix size */

--- a/keyboards/custommk/genesis/config.h
+++ b/keyboards/custommk/genesis/config.h
@@ -1,0 +1,65 @@
+/* Copyright 2020 David Hoelscher (customMK)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+
+#include "config_common.h"
+
+/* USB Device descriptor parameter */
+#define VENDOR_ID       0xF35B
+#define PRODUCT_ID      0xFAB0
+#define MANUFACTURER    customMK
+#define DEVICE_VER      0x0001
+#define PRODUCT         Genesis
+
+/* key matrix size */
+#define MATRIX_ROWS 5
+#define MATRIX_COLS 4
+
+/* key matrix pins */
+#define MATRIX_ROW_PINS { F0, C7, C6, B6, B5 }
+#define MATRIX_COL_PINS { F4, F5, D7, B4 }
+#define UNUSED_PINS
+
+/* COL2ROW or ROW2COL */
+#define DIODE_DIRECTION COL2ROW
+
+/* Set 0 if debouncing isn't needed */
+#define DEBOUNCE 5
+
+/* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
+#define LOCKING_SUPPORT_ENABLE
+
+/* Locking resynchronize hack */
+#define LOCKING_RESYNC_ENABLE
+
+#define ENCODERS_PAD_A { F6, D2 }
+#define ENCODERS_PAD_B { F7, D1 }
+#define ENCODER_RESOLUTION 4
+#define TAP_CODE_DELAY 10
+
+#define BOOTMAGIC_LITE_COLUMN 0
+#define BOOTMAGIC_LITE_ROW 0
+
+#define RGB_DI_PIN E6
+#define RGBLIGHT_ANIMATIONS
+#define RGBLED_NUM 13
+#define RGBLIGHT_HUE_STEP 8
+#define RGBLIGHT_SAT_STEP 8
+#define RGBLIGHT_VAL_STEP 8
+#define RGBLIGHT_LIMIT_VAL 128
+

--- a/keyboards/custommk/genesis/genesis.c
+++ b/keyboards/custommk/genesis/genesis.c
@@ -1,0 +1,36 @@
+/* Copyright 2020 David Hoelscher (customMK)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "genesis.h"
+
+void encoder_update_user(uint8_t index, bool clockwise) {
+	/* top left encoder */
+	if (index == 0) {
+		if (clockwise) {
+			tap_code(KC_VOLU);
+		} else {
+			tap_code(KC_VOLD);
+		}
+	}
+	/* top right encoder */
+	else if (index == 1) {
+		if (clockwise) {
+			tap_code(KC_VOLU);
+		} else {
+			tap_code(KC_VOLD);
+		}
+	}    
+}

--- a/keyboards/custommk/genesis/genesis.c
+++ b/keyboards/custommk/genesis/genesis.c
@@ -1,4 +1,4 @@
-/* Copyright 2020 David Hoelscher (customMK)
+/* Copyright 2020 customMK
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,7 +16,7 @@
 
 #include "genesis.h"
 
-void encoder_update_user(uint8_t index, bool clockwise) {
+__attribute__((weak)) void encoder_update_user(uint8_t index, bool clockwise) {
 	/* top left encoder */
 	if (index == 0) {
 		if (clockwise) {

--- a/keyboards/custommk/genesis/genesis.h
+++ b/keyboards/custommk/genesis/genesis.h
@@ -1,0 +1,48 @@
+/* Copyright 2020 David Hoelscher (customMK)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "quantum.h"
+
+#define LAYOUT_NUM( \
+	K00, K01, K02, K03, \
+	K10, K11, K12, K13, \
+	K20, K21, K22, K23, \
+	K30, K31, K32, K33, \
+	K40, K41, K42, K43  \
+) { \
+	{ K00,   K01,   K02,   K03 }, \
+	{ K10,   K11,   K12,   KC_NO }, \
+	{ K20,   K21,   K22,   K23 }, \
+	{ K30,   K31,   K32,   KC_NO }, \
+	{ K40,   KC_NO, K42,   K43 }  \
+}
+
+#define LAYOUT_ORTHO( \
+	K00, K01, K02, K03, \
+	K10, K11, K12, K13, \
+	K20, K21, K22, K23, \
+	K30, K31, K32, K33, \
+	K40, K41, K42, K43  \
+) { \
+	{ K00,   K01,   K02,   K03 }, \
+	{ K10,   K11,   K12,   K13 }, \
+	{ K20,   K21,   K22,   K23 }, \
+	{ K30,   K31,   K32,   K33 }, \
+	{ K40,   K41,   K42,   K43 }  \
+}
+

--- a/keyboards/custommk/genesis/genesis.h
+++ b/keyboards/custommk/genesis/genesis.h
@@ -1,4 +1,4 @@
-/* Copyright 2020 David Hoelscher (customMK)
+/* Copyright 2020 customMK
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,12 +18,12 @@
 
 #include "quantum.h"
 
-#define LAYOUT_NUM( \
+#define LAYOUT_numpad_5x4( \
 	K00, K01, K02, K03, \
-	K10, K11, K12, K13, \
+	K10, K11, K12,      \
 	K20, K21, K22, K23, \
-	K30, K31, K32, K33, \
-	K40, K41, K42, K43  \
+	K30, K31, K32,      \
+	K40,      K42, K43  \
 ) { \
 	{ K00,   K01,   K02,   K03 }, \
 	{ K10,   K11,   K12,   KC_NO }, \
@@ -32,7 +32,7 @@
 	{ K40,   KC_NO, K42,   K43 }  \
 }
 
-#define LAYOUT_ORTHO( \
+#define LAYOUT_ortho_5x4( \
 	K00, K01, K02, K03, \
 	K10, K11, K12, K13, \
 	K20, K21, K22, K23, \

--- a/keyboards/custommk/genesis/info.json
+++ b/keyboards/custommk/genesis/info.json
@@ -1,0 +1,12 @@
+{
+    "keyboard_name": "Genesis", 
+    "url": "https://www.customMK.com", 
+    "maintainer": "customMK", 
+    "width": 4, 
+    "height": 5, 
+    "layouts": {
+        "LAYOUT": {
+            "layout": [{"label":"MO(1)", "x":0, "y":0}, {"label":"/", "x":1, "y":0}, {"label":"*", "x":2, "y":0}, {"label":"Mute", "x":3, "y":0}, {"label":"7", "x":0, "y":1}, {"label":"8", "x":1, "y":1}, {"label":"9", "x":2, "y":1}, {"label":"+", "x":3, "y":1}, {"label":"4", "x":0, "y":2}, {"label":"5", "x":1, "y":2}, {"label":"6", "x":2, "y":2}, {"label":"Pg Up", "x":3, "y":2}, {"label":"1", "x":0, "y":3}, {"label":"2", "x":1, "y":3}, {"label":"3", "x":2, "y":3}, {"label":"Pg Dn", "x":3, "y":3}, {"label":"0", "x":0, "y":4}, {"label":"Spc", "x":1, "y":4}, {"label":".", "x":2, "y":4}, {"label":"Enter", "x":3, "y":4}]
+        }
+    }
+}

--- a/keyboards/custommk/genesis/info.json
+++ b/keyboards/custommk/genesis/info.json
@@ -5,8 +5,12 @@
     "width": 4, 
     "height": 5, 
     "layouts": {
-        "LAYOUT": {
+        "LAYOUT_ortho_5x4": {
             "layout": [{"label":"MO(1)", "x":0, "y":0}, {"label":"/", "x":1, "y":0}, {"label":"*", "x":2, "y":0}, {"label":"Mute", "x":3, "y":0}, {"label":"7", "x":0, "y":1}, {"label":"8", "x":1, "y":1}, {"label":"9", "x":2, "y":1}, {"label":"+", "x":3, "y":1}, {"label":"4", "x":0, "y":2}, {"label":"5", "x":1, "y":2}, {"label":"6", "x":2, "y":2}, {"label":"Pg Up", "x":3, "y":2}, {"label":"1", "x":0, "y":3}, {"label":"2", "x":1, "y":3}, {"label":"3", "x":2, "y":3}, {"label":"Pg Dn", "x":3, "y":3}, {"label":"0", "x":0, "y":4}, {"label":"Spc", "x":1, "y":4}, {"label":".", "x":2, "y":4}, {"label":"Enter", "x":3, "y":4}]
+        },
+        "LAYOUT_numpad_5x4": {
+            "layout": [{"label":"MO(1)", "x":0, "y":0}, {"label":"/", "x":1, "y":0}, {"label":"*", "x":2, "y":0}, {"label":"-", "x":3, "y":0}, {"label":"7", "x":0, "y":1}, {"label":"8", "x":1, "y":1}, {"label":"9", "x":2, "y":1}, {"label":"+", "x":3, "y":1, "h":2}, {"label":"4", "x":0, "y":2}, {"label":"5", "x":1, "y":2}, {"label":"6", "x":2, "y":2}, {"label":"1", "x":0, "y":3}, {"label":"2", "x":1, "y":3}, {"label":"3", "x":2, "y":3}, {"label":"Enter", "x":3, "y":3, "h":2}, {"label":"0", "x":0, "y":4, "w":2}, {"label":".", "x":2, "y":4}]
         }
+        
     }
 }

--- a/keyboards/custommk/genesis/keymaps/default/keymap.c
+++ b/keyboards/custommk/genesis/keymaps/default/keymap.c
@@ -1,4 +1,4 @@
-/* Copyright 2020 David Hoelscher (customMK)
+/* Copyright 2020 customMK
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,14 +18,14 @@
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
-	[0] = LAYOUT_ORTHO(
+	[0] = LAYOUT_ortho_5x4(
 			MO(1),   KC_PSLS, KC_PAST, KC_PMNS, 
 			KC_P7,   KC_P8,   KC_P9,   KC_BSPC, 
 			KC_P4,   KC_P5,   KC_P6,   KC_PPLS, 
 			KC_P1,   KC_P2,   KC_P3,   KC_CAPS,
 			KC_P0,   KC_SPC,  KC_PDOT, KC_ENT),
 
-	[1] = LAYOUT_ORTHO(
+	[1] = LAYOUT_ortho_5x4(
 			KC_TRNS, KC_VOLU, RGB_TOG, RGB_MOD, 
 			KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 
 			RGB_VAI, RGB_VAD, RGB_SPI, RGB_SPD, 

--- a/keyboards/custommk/genesis/keymaps/default/keymap.c
+++ b/keyboards/custommk/genesis/keymaps/default/keymap.c
@@ -1,0 +1,37 @@
+/* Copyright 2020 David Hoelscher (customMK)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+	[0] = LAYOUT_ORTHO(
+			MO(1),   KC_PSLS, KC_PAST, KC_PMNS, 
+			KC_P7,   KC_P8,   KC_P9,   KC_BSPC, 
+			KC_P4,   KC_P5,   KC_P6,   KC_PPLS, 
+			KC_P1,   KC_P2,   KC_P3,   KC_CAPS,
+			KC_P0,   KC_SPC,  KC_PDOT, KC_ENT),
+
+	[1] = LAYOUT_ORTHO(
+			KC_TRNS, KC_VOLU, RGB_TOG, RGB_MOD, 
+			KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 
+			RGB_VAI, RGB_VAD, RGB_SPI, RGB_SPD, 
+			KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 
+			RGB_HUI, KC_TRNS, KC_TRNS, RGB_HUD),
+
+};
+
+

--- a/keyboards/custommk/genesis/keymaps/default/readme.md
+++ b/keyboards/custommk/genesis/keymaps/default/readme.md
@@ -1,0 +1,6 @@
+# Default Genesis Macro Pad Layout
+
+This is the default layout for the Genesis Macro Pad. It assumes all 1u switches 
+and optional rotary encoder in the top-left or top-right corner for media volume 
+control. The top left switch activates Layer 1 which enables control of the RGB
+underglow.

--- a/keyboards/custommk/genesis/keymaps/numpad/keymap.c
+++ b/keyboards/custommk/genesis/keymaps/numpad/keymap.c
@@ -1,0 +1,51 @@
+/* Copyright 2020 David Hoelscher (customMK)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+	[0] = LAYOUT_NUM(
+			MO(1),  KC_PSLS,  KC_PAST, KC_PMNS, 
+			KC_P7,  KC_P8,    KC_P9,   ______, 
+			KC_P4,  KC_P5,    KC_P6,   KC_PPLS, 
+			KC_P1,  KC_P2,    KC_P3,   ______, 
+			KC_P0,  ______,   KC_PDOT, KC_ENT),
+
+	[1] = LAYOUT_NUM(
+			KC_TRNS, KC_TRNS, RGB_TOG, RGB_MOD, 
+			KC_TRNS, KC_TRNS, KC_TRNS, ______, 
+			RGB_VAI, RGB_VAD, RGB_SPI, RGB_SPD, 
+			KC_TRNS, KC_TRNS, KC_TRNS, ______, 
+			RGB_HUI, ______,  KC_TRNS, RGB_HUD),
+
+	[2] = LAYOUT_NUM(
+			KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 
+			KC_TRNS, KC_TRNS, KC_TRNS, ______, 
+			KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 
+			KC_TRNS, KC_TRNS, KC_TRNS, ______, 
+			KC_TRNS, ______,  KC_TRNS, KC_TRNS),
+
+	[3] = LAYOUT_NUM(
+			KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 
+			KC_TRNS, KC_TRNS, KC_TRNS, ______, 
+			KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 
+			KC_TRNS, KC_TRNS, KC_TRNS, ______, 
+			KC_TRNS, ______,  KC_TRNS, KC_TRNS),
+
+};
+
+

--- a/keyboards/custommk/genesis/keymaps/numpad/keymap.c
+++ b/keyboards/custommk/genesis/keymaps/numpad/keymap.c
@@ -1,4 +1,4 @@
-/* Copyright 2020 David Hoelscher (customMK)
+/* Copyright 2020 customMK
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,33 +18,33 @@
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
-	[0] = LAYOUT_NUM(
+	[0] = LAYOUT_numpad_5x4(
 			MO(1),  KC_PSLS,  KC_PAST, KC_PMNS, 
-			KC_P7,  KC_P8,    KC_P9,   ______, 
+			KC_P7,  KC_P8,    KC_P9,    
 			KC_P4,  KC_P5,    KC_P6,   KC_PPLS, 
-			KC_P1,  KC_P2,    KC_P3,   ______, 
-			KC_P0,  ______,   KC_PDOT, KC_ENT),
+			KC_P1,  KC_P2,    KC_P3,    
+			KC_P0,            KC_PDOT, KC_ENT),
 
-	[1] = LAYOUT_NUM(
+	[1] = LAYOUT_numpad_5x4(
 			KC_TRNS, KC_TRNS, RGB_TOG, RGB_MOD, 
-			KC_TRNS, KC_TRNS, KC_TRNS, ______, 
+			KC_TRNS, KC_TRNS, KC_TRNS,   
 			RGB_VAI, RGB_VAD, RGB_SPI, RGB_SPD, 
-			KC_TRNS, KC_TRNS, KC_TRNS, ______, 
-			RGB_HUI, ______,  KC_TRNS, RGB_HUD),
+			KC_TRNS, KC_TRNS, KC_TRNS, 	 
+			RGB_HUI, 	      KC_TRNS, RGB_HUD),
 
-	[2] = LAYOUT_NUM(
+	[2] = LAYOUT_numpad_5x4(
 			KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 
-			KC_TRNS, KC_TRNS, KC_TRNS, ______, 
+			KC_TRNS, KC_TRNS, KC_TRNS,   
 			KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 
-			KC_TRNS, KC_TRNS, KC_TRNS, ______, 
-			KC_TRNS, ______,  KC_TRNS, KC_TRNS),
+			KC_TRNS, KC_TRNS, KC_TRNS,   
+			KC_TRNS,          KC_TRNS, KC_TRNS),
 
-	[3] = LAYOUT_NUM(
+	[3] = LAYOUT_numpad_5x4(
 			KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 
-			KC_TRNS, KC_TRNS, KC_TRNS, ______, 
+			KC_TRNS, KC_TRNS, KC_TRNS,   
 			KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 
-			KC_TRNS, KC_TRNS, KC_TRNS, ______, 
-			KC_TRNS, ______,  KC_TRNS, KC_TRNS),
+			KC_TRNS, KC_TRNS, KC_TRNS,   
+			KC_TRNS,          KC_TRNS, KC_TRNS),
 
 };
 

--- a/keyboards/custommk/genesis/keymaps/numpad/readme.md
+++ b/keyboards/custommk/genesis/keymaps/numpad/readme.md
@@ -1,0 +1,3 @@
+# Numpad Genesis Macro Pad Layout
+
+This is the numpad layout for the Genesis Macro Pad. It assumes the 0, +, and enter keys are all 2u size, with an optional rotary encoder in the top-left or top-right corner for media volume control. The top left switch activates Layer 1 which enables control of the RGB underglow.

--- a/keyboards/custommk/genesis/keymaps/via/keymap.c
+++ b/keyboards/custommk/genesis/keymaps/via/keymap.c
@@ -1,0 +1,51 @@
+/* Copyright 2020 David Hoelscher (customMK)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+	[0] = LAYOUT_ORTHO(
+			MO(1),   KC_PSLS, KC_PAST, KC_PMNS, 
+			KC_P7,   KC_P8,   KC_P9,   KC_PPLS, 
+			KC_P4,   KC_P5,   KC_P6,   KC_PGUP, 
+			KC_P1,   KC_P2,   KC_P3,   KC_PGDN, 
+			KC_P0,   KC_SPC,  KC_PDOT, KC_PENT),
+
+	[1] = LAYOUT_ORTHO(
+			KC_TRNS, RGB_TOG, RGB_MOD, KC_TRNS, 
+			KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 
+			RGB_VAI, RGB_VAD, RGB_SPI, RGB_SPD, 
+			KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 
+			RGB_HUI, RGB_HUD, KC_TRNS, KC_TRNS),
+
+	[2] = LAYOUT_ORTHO(
+			KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 
+			KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 
+			KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 
+			KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 
+			KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS),
+
+	[3] = LAYOUT_ORTHO(
+			KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 
+			KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 
+			KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 
+			KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 
+			KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS),
+
+};
+
+

--- a/keyboards/custommk/genesis/keymaps/via/keymap.c
+++ b/keyboards/custommk/genesis/keymaps/via/keymap.c
@@ -1,4 +1,4 @@
-/* Copyright 2020 David Hoelscher (customMK)
+/* Copyright 2020 customMK
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,28 +18,28 @@
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
-	[0] = LAYOUT_ORTHO(
+	[0] = LAYOUT_ortho_5x4(
 			MO(1),   KC_PSLS, KC_PAST, KC_PMNS, 
 			KC_P7,   KC_P8,   KC_P9,   KC_PPLS, 
 			KC_P4,   KC_P5,   KC_P6,   KC_PGUP, 
 			KC_P1,   KC_P2,   KC_P3,   KC_PGDN, 
 			KC_P0,   KC_SPC,  KC_PDOT, KC_PENT),
 
-	[1] = LAYOUT_ORTHO(
+	[1] = LAYOUT_ortho_5x4(
 			KC_TRNS, RGB_TOG, RGB_MOD, KC_TRNS, 
 			KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 
 			RGB_VAI, RGB_VAD, RGB_SPI, RGB_SPD, 
 			KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 
 			RGB_HUI, RGB_HUD, KC_TRNS, KC_TRNS),
 
-	[2] = LAYOUT_ORTHO(
+	[2] = LAYOUT_ortho_5x4(
 			KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 
 			KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 
 			KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 
 			KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 
 			KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS),
 
-	[3] = LAYOUT_ORTHO(
+	[3] = LAYOUT_ortho_5x4(
 			KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 
 			KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 
 			KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 

--- a/keyboards/custommk/genesis/keymaps/via/readme.md
+++ b/keyboards/custommk/genesis/keymaps/via/readme.md
@@ -1,0 +1,3 @@
+# Genesis Macro Pad Layout for VIA
+
+This is the via layout for the Genesis Macro Pad. It is identical to the default 1u layout which assumes all 1u switches and optional rotary encoder in the top-left or top-right corner for media volume control. The top-left switch activates Layer 1 which enables control of the RGB underglow.

--- a/keyboards/custommk/genesis/keymaps/via/rules.mk
+++ b/keyboards/custommk/genesis/keymaps/via/rules.mk
@@ -1,0 +1,2 @@
+VIA_ENABLE = yes
+LTO_ENABLE = yes

--- a/keyboards/custommk/genesis/readme.md
+++ b/keyboards/custommk/genesis/readme.md
@@ -3,7 +3,7 @@
 ![Genesis Macro Pad](https://i.imgur.com/voBjLrM.jpeg)
 ![Genesis Macro Pad PCB](https://i.imgur.com/ST2vtkV.jpeg)
 
-Genesis is 5x4 ortholinear layout macro pad designed and produced by customMK. 
+Genesis is a 5x4 ortholinear macro pad designed and produced by customMK. 
 
 * Keyboard Maintainer: [customMK](https://github.com/customMK)
 * Hardware Supported: Genesis Macro Pad

--- a/keyboards/custommk/genesis/readme.md
+++ b/keyboards/custommk/genesis/readme.md
@@ -15,7 +15,7 @@ Make example for this keyboard (after setting up your build environment):
 
 Flashing example for this keyboard:
 
-    make custommk/genesis:default:dfu
+    make custommk/genesis:default:flash
 
 Genesis Macro Pad has qmk-dfu bootloader preinstalled. To enter the bootloader, run the flashing command above, and then either plug in the USB connection while holding the top-left key, or alternatively, plug in the USB connection and then press the reset button on the PCB
 

--- a/keyboards/custommk/genesis/readme.md
+++ b/keyboards/custommk/genesis/readme.md
@@ -1,0 +1,22 @@
+# Genesis
+
+![Genesis Macro Pad](https://i.imgur.com/voBjLrM.jpeg)
+![Genesis Macro Pad PCB](https://i.imgur.com/ST2vtkV.jpeg)
+
+Genesis is 5x4 ortholinear layout macro pad designed and produced by customMK. 
+
+* Keyboard Maintainer: [customMK](https://github.com/customMK)
+* Hardware Supported: Genesis Macro Pad
+* Hardware Availability: [customMK](https://shop.custommk.com/products/genesis_macropad)
+
+Make example for this keyboard (after setting up your build environment):
+
+    make custommk/genesis:default
+
+Flashing example for this keyboard:
+
+    make custommk/genesis:default:dfu
+
+Genesis Macro Pad has qmk-dfu bootloader preinstalled. To enter the bootloader, run the flashing command above, and then either plug in the USB connection while holding the top-left key, or alternatively, plug in the USB connection and then press the reset button on the PCB
+
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).

--- a/keyboards/custommk/genesis/rules.mk
+++ b/keyboards/custommk/genesis/rules.mk
@@ -1,20 +1,23 @@
 # MCU name
 MCU = atmega32u4
+
+# Bootloader selection
 BOOTLOADER = qmk-dfu
 
-
-
 # Build Options
-#   comment out to disable the options.
+#   change yes to no to disable
 #
-BOOTMAGIC_ENABLE = full	# Virtual DIP switch configuration(+1000)
-MOUSEKEY_ENABLE = no	# Mouse keys(+4700)
-EXTRAKEY_ENABLE = yes	# Audio control and System control(+450)
-CONSOLE_ENABLE = no	# Console for debug(+400)
-COMMAND_ENABLE = no    # Commands for debug and configuration
-SLEEP_LED_ENABLE = no  # Breathing sleep LED during USB suspend
-NKRO_ENABLE = yes		# USB Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
-BACKLIGHT_ENABLE = no  # Enable keyboard backlight functionality
-AUDIO_ENABLE = no
+BOOTMAGIC_ENABLE = lite     # Virtual DIP switch configuration
+MOUSEKEY_ENABLE = yes       # Mouse keys
+EXTRAKEY_ENABLE = yes       # Audio control and System control
+CONSOLE_ENABLE = no         # Console for debug
+COMMAND_ENABLE = no         # Commands for debug and configuration
+# Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
+SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
+# if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+NKRO_ENABLE = yes           # USB Nkey Rollover
+BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
+RGBLIGHT_ENABLE = yes        # Enable keyboard RGB underglow
+BLUETOOTH_ENABLE = no       # Enable Bluetooth
+AUDIO_ENABLE = no           # Audio output
 ENCODER_ENABLE = yes
-RGBLIGHT_ENABLE = yes

--- a/keyboards/custommk/genesis/rules.mk
+++ b/keyboards/custommk/genesis/rules.mk
@@ -1,0 +1,20 @@
+# MCU name
+MCU = atmega32u4
+BOOTLOADER = qmk-dfu
+
+
+
+# Build Options
+#   comment out to disable the options.
+#
+BOOTMAGIC_ENABLE = full	# Virtual DIP switch configuration(+1000)
+MOUSEKEY_ENABLE = no	# Mouse keys(+4700)
+EXTRAKEY_ENABLE = yes	# Audio control and System control(+450)
+CONSOLE_ENABLE = no	# Console for debug(+400)
+COMMAND_ENABLE = no    # Commands for debug and configuration
+SLEEP_LED_ENABLE = no  # Breathing sleep LED during USB suspend
+NKRO_ENABLE = yes		# USB Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+BACKLIGHT_ENABLE = no  # Enable keyboard backlight functionality
+AUDIO_ENABLE = no
+ENCODER_ENABLE = yes
+RGBLIGHT_ENABLE = yes


### PR DESCRIPTION
Adding keyboard and keymap files for customMK Genesis, a 5x4 macro pad.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
