### PR TITLE
[Keyboard] Fix compiler issues for handwired/6macro

### DIFF
--- a/keyboards/handwired/6macro/config.h
+++ b/keyboards/handwired/6macro/config.h
@@ -41,6 +41,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define RGB_DI_PIN D2
 #define RGBLED_NUM 10
+#define DRIVER_LED_TOTAL RGBLED_NUM
 #define RGBLIGHT_HUE_STEP 10
 #define RGBLIGHT_SAT_STEP 17
 #define RGBLIGHT_VAL_STEP 17

--- a/keyboards/handwired/6macro/rules.mk
+++ b/keyboards/handwired/6macro/rules.mk
@@ -2,33 +2,24 @@
 MCU = atmega32u2
 
 # Bootloader selection
-#   Teensy       halfkay
-#   Pro Micro    caterina
-#   Atmel DFU    atmel-dfu
-#   LUFA DFU     lufa-dfu
-#   QMK DFU      qmk-dfu
-#   ATmega32A    bootloadHID
-#   ATmega328P   USBasp
 BOOTLOADER = atmel-dfu
 
 # Build Options
 #   change yes to no to disable
 #
-BOOTMAGIC_ENABLE = no      	# Virtual DIP switch configuration(+1000)
-MOUSEKEY_ENABLE = yes      	# Mouse keys(+4700)
-EXTRAKEY_ENABLE = yes      	# Audio control and System control(+450)
-CONSOLE_ENABLE = no        	# Console for debug(+400)
+BOOTMAGIC_ENABLE = no      	# Virtual DIP switch configuration
+MOUSEKEY_ENABLE = yes      	# Mouse keys
+EXTRAKEY_ENABLE = yes      	# Audio control and System control
+CONSOLE_ENABLE = no        	# Console for debug
 COMMAND_ENABLE = no        	# Commands for debug and configuration
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
 SLEEP_LED_ENABLE = no      	# Breathing sleep LED during USB suspend
 # if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
 NKRO_ENABLE = yes          	# USB Nkey Rollover
-RGB_MATRIX_ENABLE = yes     # Enable per-key coordinate based RGB effects. Do not enable with RGBlight (+8500)
+RGB_MATRIX_ENABLE = no     # Enable per-key coordinate based RGB effects. Do not enable with RGBlight
 RGB_MATRIX_DRIVER = WS2812
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality on B7 by default
+BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = yes       # Enable keyboard RGB underglow
-MIDI_ENABLE = no            # MIDI support (+2400 to 4200, depending on config)
 UNICODE_ENABLE = yes        # Unicode
-BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
-AUDIO_ENABLE = no           # Audio output on port C6
-FAUXCLICKY_ENABLE = no      # Use buzzer to emulate clicky switches
+BLUETOOTH_ENABLE = no       # Enable Bluetooth
+AUDIO_ENABLE = no           # Audio output


### PR DESCRIPTION

## Description

RGB Matrix wasn't enabled previously, but was enabled in develop.  This is causing the keyboard to fail on build

## Types of Changes

- [x] Bugfix
- [x] Keyboard (addition or update)

## Issues Fixed or Closed by This PR

* Travis CI 

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
