### PR TITLE
[Keyboard] Fix compiler errors for Kingly Key boards

### DIFF
--- a/keyboards/kingly_keys/ave/ortho/keymaps/default/keymap.c
+++ b/keyboards/kingly_keys/ave/ortho/keymaps/default/keymap.c
@@ -184,16 +184,13 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 //  )
 
 
-#ifndef TAPPING_TERM
-#    define TAPPING_TERM 200
-#endif
 // Per-Key Tapping Term Definitions:
 uint16_t get_tapping_term(uint16_t keycode, keyrecord_t *record) {
     switch (keycode) {
         case TD(TD_DBQT):
             return 235;
         default:
-            return TAPPING_TERM;
+            return 200;
     }
 }
 

--- a/keyboards/kingly_keys/ave/ortho/keymaps/default/keymap.c
+++ b/keyboards/kingly_keys/ave/ortho/keymaps/default/keymap.c
@@ -1,19 +1,19 @@
- /* 
+ /*
  Copyright 2020 Garret Gartner
-  
- This program is free software: you can redistribute it and/or modify 
- it under the terms of the GNU General Public License as published by 
- the Free Software Foundation, either version 2 of the License, or 
- (at your option) any later version. 
-  
- This program is distributed in the hope that it will be useful, 
- but WITHOUT ANY WARRANTY; without even the implied warranty of 
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- GNU General Public License for more details. 
-  
- You should have received a copy of the GNU General Public License 
- along with this program.  If not, see <http://www.gnu.org/licenses/>. 
- */ 
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 2 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #include QMK_KEYBOARD_H
 
@@ -159,7 +159,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 
 //  KEYMAP TEMPLATE:
-//  
+//
 //  /* <_LAYER>:
 //  *
 //  * ┌────┐ ┌────┐                                       ┌────┬────┬────┐
@@ -184,6 +184,9 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 //  )
 
 
+#ifndef TAPPING_TERM
+#    define TAPPING_TERM 200
+#endif
 // Per-Key Tapping Term Definitions:
 uint16_t get_tapping_term(uint16_t keycode) {
   switch (keycode) {

--- a/keyboards/kingly_keys/ave/ortho/keymaps/default/keymap.c
+++ b/keyboards/kingly_keys/ave/ortho/keymaps/default/keymap.c
@@ -188,15 +188,14 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 #    define TAPPING_TERM 200
 #endif
 // Per-Key Tapping Term Definitions:
-uint16_t get_tapping_term(uint16_t keycode) {
-  switch (keycode) {
-    case TD(TD_DBQT):
-      return 235;
-    default:
-      return TAPPING_TERM;
-  }
+uint16_t get_tapping_term(uint16_t keycode, keyrecord_t *record) {
+    switch (keycode) {
+        case TD(TD_DBQT):
+            return 235;
+        default:
+            return TAPPING_TERM;
+    }
 }
-
 
 // Encoder Customization: (*Order-of-Keycode Specific)
 void encoder_update_user(uint8_t index, bool clockwise) {

--- a/keyboards/kingly_keys/ave/ortho/keymaps/default/keymap.c
+++ b/keyboards/kingly_keys/ave/ortho/keymaps/default/keymap.c
@@ -190,7 +190,7 @@ uint16_t get_tapping_term(uint16_t keycode, keyrecord_t *record) {
         case TD(TD_DBQT):
             return 235;
         default:
-            return 200;
+            return TAPPING_TERM;
     }
 }
 

--- a/keyboards/kingly_keys/ave/staggered/keymaps/default/keymap.c
+++ b/keyboards/kingly_keys/ave/staggered/keymaps/default/keymap.c
@@ -183,9 +183,6 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 //      _______,      _______,   _______,   _______,                    _______,   _______,                              _______,   _______,   _______
 //  )
 
-#ifndef TAPPING_TERM
-#    define TAPPING_TERM 200
-#endif
 
 // Per-Key Tapping Term Definitions:
 uint16_t get_tapping_term(uint16_t keycode, keyrecord_t *record) {
@@ -193,7 +190,7 @@ uint16_t get_tapping_term(uint16_t keycode, keyrecord_t *record) {
         case TD(TD_DBQT):
             return 235;
         default:
-            return TAPPING_TERM;
+            return 200;
     }
 }
 

--- a/keyboards/kingly_keys/ave/staggered/keymaps/default/keymap.c
+++ b/keyboards/kingly_keys/ave/staggered/keymaps/default/keymap.c
@@ -1,19 +1,19 @@
- /* 
+ /*
  Copyright 2020 Garret Gartner
-  
- This program is free software: you can redistribute it and/or modify 
- it under the terms of the GNU General Public License as published by 
- the Free Software Foundation, either version 2 of the License, or 
- (at your option) any later version. 
-  
- This program is distributed in the hope that it will be useful, 
- but WITHOUT ANY WARRANTY; without even the implied warranty of 
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- GNU General Public License for more details. 
-  
- You should have received a copy of the GNU General Public License 
- along with this program.  If not, see <http://www.gnu.org/licenses/>. 
- */ 
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 2 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #include QMK_KEYBOARD_H
 
@@ -183,7 +183,9 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 //      _______,      _______,   _______,   _______,                    _______,   _______,                              _______,   _______,   _______
 //  )
 
-
+#ifndef TAPPING_TERM
+#    define TAPPING_TERM 200
+#endif
 
 // Per-Key Tapping Term Definitions:
 uint16_t get_tapping_term(uint16_t keycode) {

--- a/keyboards/kingly_keys/ave/staggered/keymaps/default/keymap.c
+++ b/keyboards/kingly_keys/ave/staggered/keymaps/default/keymap.c
@@ -188,16 +188,14 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 #endif
 
 // Per-Key Tapping Term Definitions:
-uint16_t get_tapping_term(uint16_t keycode) {
-  switch (keycode) {
-    case TD(TD_DBQT):
-      return 235;
-    default:
-      return TAPPING_TERM;
-  }
+uint16_t get_tapping_term(uint16_t keycode, keyrecord_t *record) {
+    switch (keycode) {
+        case TD(TD_DBQT):
+            return 235;
+        default:
+            return TAPPING_TERM;
+    }
 }
-
-
 
 // Encoder Customization: (*Order-of-Keycode Specific)
 void encoder_update_user(uint8_t index, bool clockwise) {

--- a/keyboards/kingly_keys/ave/staggered/keymaps/default/keymap.c
+++ b/keyboards/kingly_keys/ave/staggered/keymaps/default/keymap.c
@@ -190,7 +190,7 @@ uint16_t get_tapping_term(uint16_t keycode, keyrecord_t *record) {
         case TD(TD_DBQT):
             return 235;
         default:
-            return 200;
+            return TAPPING_TERM;
     }
 }
 


### PR DESCRIPTION

## Description

Tapping term was referenced, but not defined by default.  


## Types of Changes

- [x] Bugfix
- [x] Keyboard (addition or update)

## Issues Fixed or Closed by This PR

* Travis CI 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
