### PR TITLE
Add support for shared EP on V-USB boards

### DIFF
--- a/tmk_core/common/report.h
+++ b/tmk_core/common/report.h
@@ -123,12 +123,6 @@ enum desktop_usages {
 
 #define KEYBOARD_REPORT_KEYS 6
 
-/* VUSB hardcodes keyboard and mouse+extrakey only */
-#if defined(PROTOCOL_VUSB)
-#    undef KEYBOARD_SHARED_EP
-#    undef MOUSE_SHARED_EP
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/tmk_core/protocol/vusb/vusb.c
+++ b/tmk_core/protocol/vusb/vusb.c
@@ -52,18 +52,22 @@ enum usb_interfaces {
     SHARED_INTERFACE = NEXT_INTERFACE,
 #    define KEYBOARD_INTERFACE SHARED_INTERFACE
 #endif
+
 // It is important that the Raw HID interface is at a constant
 // interface number, to support Linux/OSX platforms and chrome.hid
 // If Raw HID is enabled, let it be always 1.
 #ifdef RAW_ENABLE
     RAW_INTERFACE = NEXT_INTERFACE,
 #endif
+
 #if defined(SHARED_EP_ENABLE) && !defined(KEYBOARD_SHARED_EP)
     SHARED_INTERFACE = NEXT_INTERFACE,
 #endif
+
 #ifdef CONSOLE_ENABLE
     CONSOLE_INTERFACE = NEXT_INTERFACE,
 #endif
+
     TOTAL_INTERFACES = NEXT_INTERFACE
 };
 
@@ -481,9 +485,9 @@ const PROGMEM uchar shared_hid_report[] = {
     0x81, 0x06,        //     Input (Data, Variable, Relative)
     0xC0,              //   End Collection
     0xC0,              // End Collection
-#    endif
+#endif
 
-#    ifdef EXTRAKEY_ENABLE
+#ifdef EXTRAKEY_ENABLE
     // Extrakeys report descriptor
     0x05, 0x01,              // Usage Page (Generic Desktop)
     0x09, 0x80,              // Usage (System Control)
@@ -510,7 +514,7 @@ const PROGMEM uchar shared_hid_report[] = {
     0x75, 0x10,                //   Report Size (16)
     0x81, 0x00,                //   Input (Data, Array, Absolute)
     0xC0                       // End Collection
-#    endif
+#endif
 #ifdef SHARED_EP_ENABLE
 };
 #endif
@@ -646,7 +650,7 @@ const PROGMEM usbConfigurationDescriptor_t usbConfigurationDescriptor = {
         .bMaxPower           = USB_MAX_POWER_CONSUMPTION / 2
     },
 
-#ifndef KEYBOARD_SHARED_EP
+#    ifndef KEYBOARD_SHARED_EP
     /*
      * Keyboard
      */
@@ -684,7 +688,7 @@ const PROGMEM usbConfigurationDescriptor_t usbConfigurationDescriptor = {
         .wMaxPacketSize      = 8,
         .bInterval           = USB_POLLING_INTERVAL_MS
     },
-#endif
+#    endif
 
 #    if defined(RAW_ENABLE)
     /*
@@ -735,6 +739,7 @@ const PROGMEM usbConfigurationDescriptor_t usbConfigurationDescriptor = {
         .bInterval           = USB_POLLING_INTERVAL_MS
     },
 #    endif
+
 #    ifdef SHARED_EP_ENABLE
     /*
      * Shared
@@ -783,6 +788,7 @@ const PROGMEM usbConfigurationDescriptor_t usbConfigurationDescriptor = {
         .bInterval           = USB_POLLING_INTERVAL_MS
     },
 #    endif
+
 #    if defined(CONSOLE_ENABLE)
     /*
      * Console
@@ -830,7 +836,7 @@ const PROGMEM usbConfigurationDescriptor_t usbConfigurationDescriptor = {
         .bmAttributes        = 0x03,
         .wMaxPacketSize      = CONSOLE_EPSIZE,
         .bInterval           = 0x01
-    },
+    }
 #    endif
 };
 
@@ -890,6 +896,7 @@ USB_PUBLIC usbMsgLen_t usbFunctionDescriptor(struct usbRequest *rq) {
                     len       = sizeof(usbHIDDescriptor_t);
                     break;
 #endif
+
 #if defined(CONSOLE_ENABLE)
                 case CONSOLE_INTERFACE:
                     usbMsgPtr = (usbMsgPtr_t)&usbConfigurationDescriptor.consoleHID;
@@ -907,6 +914,7 @@ USB_PUBLIC usbMsgLen_t usbFunctionDescriptor(struct usbRequest *rq) {
                     len       = sizeof(keyboard_hid_report);
                     break;
 #endif
+
 #if defined(RAW_ENABLE)
                 case RAW_INTERFACE:
                     usbMsgPtr = (usbMsgPtr_t)raw_hid_report;
@@ -920,6 +928,7 @@ USB_PUBLIC usbMsgLen_t usbFunctionDescriptor(struct usbRequest *rq) {
                     len       = sizeof(shared_hid_report);
                     break;
 #endif
+
 #if defined(CONSOLE_ENABLE)
                 case CONSOLE_INTERFACE:
                     usbMsgPtr = (usbMsgPtr_t)console_hid_report;

--- a/tmk_core/protocol/vusb/vusb.h
+++ b/tmk_core/protocol/vusb/vusb.h
@@ -85,9 +85,16 @@ typedef struct usbHIDDescriptor {
 
 typedef struct usbConfigurationDescriptor {
     usbConfigurationDescriptorHeader_t header;
-    usbInterfaceDescriptor_t           keyboardInterface;
-    usbHIDDescriptor_t                 keyboardHID;
-    usbEndpointDescriptor_t            keyboardINEndpoint;
+
+#ifndef KEYBOARD_SHARED_EP
+    usbInterfaceDescriptor_t keyboardInterface;
+    usbHIDDescriptor_t       keyboardHID;
+    usbEndpointDescriptor_t  keyboardINEndpoint;
+#else
+    usbInterfaceDescriptor_t sharedInterface;
+    usbHIDDescriptor_t       sharedHID;
+    usbEndpointDescriptor_t  sharedINEndpoint;
+#endif
 
 #if defined(RAW_ENABLE)
     usbInterfaceDescriptor_t rawInterface;
@@ -96,10 +103,10 @@ typedef struct usbConfigurationDescriptor {
     usbEndpointDescriptor_t  rawOUTEndpoint;
 #endif
 
-#if defined(MOUSE_ENABLE) || defined(EXTRAKEY_ENABLE)
-    usbInterfaceDescriptor_t mouseExtraInterface;
-    usbHIDDescriptor_t       mouseExtraHID;
-    usbEndpointDescriptor_t  mouseExtraINEndpoint;
+#if defined(SHARED_EP_ENABLE) && !defined(KEYBOARD_SHARED_EP)
+    usbInterfaceDescriptor_t sharedInterface;
+    usbHIDDescriptor_t       sharedHID;
+    usbEndpointDescriptor_t  sharedINEndpoint;
 #endif
 
 #if defined(CONSOLE_ENABLE)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Basically just a rename of the mouse/extra interface to shared, and implementing `KEYBOARD_SHARED_EP`.
Tested on Plaid-Pad, but a more thorough typing test might be useful.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
