### PR TITLE
Fix error handling in SPI master driver.

### DIFF
--- a/drivers/avr/spi_master.c
+++ b/drivers/avr/spi_master.c
@@ -140,27 +140,33 @@ spi_status_t spi_read() {
 }
 
 spi_status_t spi_transmit(const uint8_t *data, uint16_t length) {
-    spi_status_t status = SPI_STATUS_ERROR;
+    spi_status_t status;
 
     for (uint16_t i = 0; i < length; i++) {
         status = spi_write(data[i]);
+
+        if (status < 0) {
+            return status;
+        }
     }
 
-    return status;
+    return SPI_STATUS_SUCCESS;
 }
 
 spi_status_t spi_receive(uint8_t *data, uint16_t length) {
-    spi_status_t status = SPI_STATUS_ERROR;
+    spi_status_t status;
 
     for (uint16_t i = 0; i < length; i++) {
         status = spi_read();
 
-        if (status > 0) {
+        if (status >= 0) {
             data[i] = status;
+        } else {
+            return status;
         }
     }
 
-    return (status < 0) ? status : SPI_STATUS_SUCCESS;
+    return SPI_STATUS_SUCCESS;
 }
 
 void spi_stop(void) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This PR fixes two issues with the AVR SPI master driver, specifically in the error handling in `spi_receive`.  As it is, errors are only detected in the last byte and, more importantly, received zero bytes are ignored.  The fix follows the simplest path of returning immediately in case of error, operating under the assumption that partial reads would be useless anyway.

I have currently no easy way to test this as my keyboard doesn't use the `spi_master` driver, or any of the QMK functionality that currently depends on it, so I have only verified that it compiles properly and that it looks like a reasonable fix.  Sorry for that.

Let me know if you like me to make any changes.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation
