### PR TITLE
Fix Tap-Hold Configs

### DIFF
--- a/keyboards/handwired/tennie/keymaps/default/config.h
+++ b/keyboards/handwired/tennie/keymaps/default/config.h
@@ -17,3 +17,4 @@
 #pragma once
 
 // place overrides here
+#define TAPPING_TOGGLE 2

--- a/keyboards/handwired/tennie/keymaps/default/keymap.c
+++ b/keyboards/handwired/tennie/keymaps/default/keymap.c
@@ -15,9 +15,6 @@
  */
 #include QMK_KEYBOARD_H
 
-#define TAPPING_TOGGLE 2
-
-
 // Layer names
 #define base  0
 #define shrek 1

--- a/keyboards/marksard/leftover30/keymaps/default/keymap.c
+++ b/keyboards/marksard/leftover30/keymaps/default/keymap.c
@@ -99,7 +99,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   )
 };
 
-uint16_t get_tapping_term(uint16_t keycode) {
+uint16_t get_tapping_term(uint16_t keycode, keyrecord_t *record) {
   switch (keycode) {
     case KC_SPRA:
       return TAPPING_LAYER_TERM;

--- a/quantum/process_keycode/process_space_cadet.c
+++ b/quantum/process_keycode/process_space_cadet.c
@@ -14,11 +14,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "process_space_cadet.h"
-#include "action_tapping.h"
-
-#ifdef NO_ACTION_TAPPING
-__attribute__((weak)) uint16_t get_tapping_term(uint16_t keycode, keyrecord_t *record) { return TAPPING_TERM; };
-#endif
 
 // ********** OBSOLETE DEFINES, STOP USING! (pls?) **********
 // Shift / paren setup

--- a/quantum/process_keycode/process_space_cadet.c
+++ b/quantum/process_keycode/process_space_cadet.c
@@ -14,6 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "process_space_cadet.h"
+#include "action_tapping.h"
 
 // ********** OBSOLETE DEFINES, STOP USING! (pls?) **********
 // Shift / paren setup
@@ -92,7 +93,12 @@ void perform_space_cadet(keyrecord_t *record, uint16_t sc_keycode, uint8_t holdM
             register_mods(MOD_BIT(holdMod));
         }
     } else {
-        if (sc_last == holdMod && timer_elapsed(sc_timer) < get_tapping_term(sc_keycode, record)) {
+#ifdef TAPPING_TERM_PER_KEY
+        if (sc_last == holdMod && timer_elapsed(sc_timer) < get_tapping_term(sc_keycode, record))
+#else
+        if (sc_last == holdMod && timer_elapsed(sc_timer) < TAPPING_TERM)
+#endif
+        {
             if (holdMod != tapMod) {
                 if (IS_MOD(holdMod)) {
                     unregister_mods(MOD_BIT(holdMod));

--- a/quantum/process_keycode/process_space_cadet.h
+++ b/quantum/process_keycode/process_space_cadet.h
@@ -19,6 +19,3 @@
 
 void perform_space_cadet(keyrecord_t *record, uint16_t sc_keycode, uint8_t holdMod, uint8_t tapMod, uint8_t keycode);
 bool process_space_cadet(uint16_t keycode, keyrecord_t *record);
-#ifdef NO_ACTION_TAPPING
-uint16_t get_tapping_term(uint16_t keycode, keyrecord_t *record);
-#endif

--- a/quantum/process_keycode/process_tap_dance.c
+++ b/quantum/process_keycode/process_tap_dance.c
@@ -14,7 +14,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "quantum.h"
-#include "action_tapping.h"
 
 #ifndef NO_ACTION_ONESHOT
 uint8_t get_oneshot_mods(void);

--- a/quantum/process_keycode/process_tap_dance.c
+++ b/quantum/process_keycode/process_tap_dance.c
@@ -169,7 +169,7 @@ void matrix_scan_tap_dance() {
 #ifdef TAPPING_TERM_PER_KEY
             tap_user_defined = get_tapping_term(action->state.keycode, NULL);
 #else
-            tap_user_defined = 200;
+            tap_user_defined = TAPPING_TERM;
 #endif
         }
         if (action->state.count && timer_elapsed(action->state.timer) > tap_user_defined) {

--- a/quantum/process_keycode/process_tap_dance.c
+++ b/quantum/process_keycode/process_tap_dance.c
@@ -166,7 +166,11 @@ void matrix_scan_tap_dance() {
         if (action->custom_tapping_term > 0) {
             tap_user_defined = action->custom_tapping_term;
         } else {
+#ifdef TAPPING_TERM_PER_KEY
             tap_user_defined = get_tapping_term(action->state.keycode, NULL);
+#else
+            tap_user_defined = 200;
+#endif
         }
         if (action->state.count && timer_elapsed(action->state.timer) > tap_user_defined) {
             process_tap_dance_action_on_dance_finished(action);

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -56,6 +56,7 @@
 #include "config_common.h"
 #include "led.h"
 #include "action_util.h"
+#include "action_tapping.h"
 #include "print.h"
 #include "send_string_keycodes.h"
 #include "suspend.h"

--- a/tmk_core/common/action_tapping.h
+++ b/tmk_core/common/action_tapping.h
@@ -22,8 +22,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    define TAPPING_TERM 200
 #endif
 
-//#define RETRO_TAPPING // Tap anyway, even after TAPPING_TERM, as long as there was no interruption
-
 /* tap count needed for toggling a feature */
 #ifndef TAPPING_TOGGLE
 #    define TAPPING_TOGGLE 5
@@ -33,8 +31,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #ifndef NO_ACTION_TAPPING
 uint16_t get_event_keycode(keyevent_t event, bool update_layer_cache);
-uint16_t get_tapping_term(uint16_t keycode, keyrecord_t *record);
 void     action_tapping_process(keyrecord_t record);
+
+uint16_t get_tapping_term(uint16_t keycode, keyrecord_t *record);
+bool get_permissive_hold(uint16_t keycode, keyrecord_t *record);
+bool get_ignore_mod_tap_interrupt(uint16_t keycode, keyrecord_t *record);
+bool get_tapping_force_hold(uint16_t keycode, keyrecord_t *record);
+bool get_retro_tapping(uint16_t keycode, keyrecord_t *record);
 #endif
 
 #endif


### PR DESCRIPTION
## Description

Makes sure that `action_tapping.h` is always included, by adding it to `quantum.h`
Includes the proper prototypes for all of the tap-hold per key functions. 

This makes sure that TAPPING_TERM is picked up consistently, and will error out if it's defined incorrectly.  And same for the per key functions. 

## Types of Changes

- [x] Core
- [x] Bugfix
- [x] Enhancement/optimization

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
