### PR TITLE
ADB-USB converter M0118 ISO layout

### DIFF
--- a/keyboards/converter/adb_usb/adb_usb.h
+++ b/keyboards/converter/adb_usb/adb_usb.h
@@ -127,16 +127,16 @@ Ported to QMK by Peter Roe <pete@13bit.me>
    K35,K12,K13,K14,K15,K17,K16,K1A,K1C,K19,K1D,K1B,K18,K33, K47,K51,K4B,K43, \
    K30,K0C,K0D,K0E,K0F,K11,K10,K20,K22,K1F,K23,K21,K1E,K24, K59,K5B,K5C,K45, \
    K39,K00,K01,K02,K03,K05,K04,K26,K28,K25,K29,K27,K2A,     K56,K57,K58,K4E, \
-   K38,K0A,K06,K07,K08,K09,K0B,K2D,K2E,K2B,K2F,K2C,K7B,K3E, K53,K54,K55,     \
+   K38,K32,K06,K07,K08,K09,K0B,K2D,K2E,K2B,K2F,K2C,K7B,K3E, K53,K54,K55,     \
    K36,K3A,K37,            K31,            K7C,K3B,K3C,K3D, K52,    K41,K4C  \
 ) { \
   { K00,   K01,   K02,   K03,   K04,   K05,   K06,   K07   }, \
-  { K08,   K09,   K0A,   K0B,   K0C,   K0D,   K0E,   K0F   }, \
+  { K08,   K09,   KC_NO, K0B,   K0C,   K0D,   K0E,   K0F   }, \
   { K10,   K11,   K12,   K13,   K14,   K15,   K16,   K17   }, \
   { K18,   K19,   K1A,   K1B,   K1C,   K1D,   K1E,   K1F   }, \
   { K20,   K21,   K22,   K23,   K24,   K25,   K26,   K27   }, \
   { K28,   K29,   K2A,   K2B,   K2C,   K2D,   K2E,   K2F   }, \
-  { K30,   K31,   KC_NO, K33,   KC_NO, K35,   K36,   K37   }, \
+  { K30,   K31,   K32,   K33,   KC_NO, K35,   K36,   K37   }, \
   { K38,   K39,   K3A,   K3B,   K3C,   K3D,   K3E,   KC_NO }, \
   { KC_NO, K41,   KC_NO, K43,   KC_NO, K45,   KC_NO, K47   }, \
   { KC_NO, KC_NO, KC_NO, K4B,   K4C,   KC_NO, K4E,   KC_NO }, \
@@ -145,7 +145,7 @@ Ported to QMK by Peter Roe <pete@13bit.me>
   { KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO }, \
   { KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO }, \
   { KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO }, \
-  { KC_NO, KC_NO, KC_NO, K7B,   K7C, KC_NO, KC_NO, K7F   }  \
+  { KC_NO, KC_NO, KC_NO, K7B,   K7C,   KC_NO, KC_NO, K7F   }  \
 }
 
 #endif

--- a/keyboards/converter/adb_usb/adb_usb.h
+++ b/keyboards/converter/adb_usb/adb_usb.h
@@ -106,4 +106,46 @@ Ported to QMK by Peter Roe <pete@13bit.me>
   { KC_NO, KC_NO, KC_NO, K7B,   KC_NO, KC_NO, KC_NO, K7F   }  \
 }
 
+/* M0118 Apple Standard Keyboard ISO
+ *                     +-------+
+ *                     | power |
+ *                     +-------+
+ * +---+---+---+---+---+---+---+---+---+---+---+---+---+-----+ +---+---+---+---+
+ * |esc| 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 0 | - | = | bks | |clr| = | / | * |
+ * +---------------------------------------------------------+ +---+---+---+---+
+ * | tab | q | w | e | r | t | y | u | i | o | p | [ | ] |Ret| | 7 | 8 | 9 | + |
+ * +-----------------------------------------------------`   | +---+---+---+---+
+ * | caps | a | s | d | f | g | h | j | k | l | ; | ' | # |  | | 4 | 5 | 6 | - |
+ * +---------------------------------------------------------+ +---+---+---+---+
+ * |shif| \ | z | x | c | v | b | n | m | , | . | / |Shif| up| | 1 | 2 | 3 |   |
+ * +---------------------------------------------------------+ +-------+---|ent|
+ * |ctrl|opt  |comnd|                     |comnd |lef|rig|dwn| |   0   | . |   |
+ * +---------------------------------------------------------+ +-------+---+---+
+ */
+#define LAYOUT_m0118_iso( \
+                           K7F,                                              \
+   K35,K12,K13,K14,K15,K17,K16,K1A,K1C,K19,K1D,K1B,K18,K33, K47,K51,K4B,K43, \
+   K30,K0C,K0D,K0E,K0F,K11,K10,K20,K22,K1F,K23,K21,K1E,K24, K59,K5B,K5C,K45, \
+   K39,K00,K01,K02,K03,K05,K04,K26,K28,K25,K29,K27,K2A,     K56,K57,K58,K4E, \
+   K38,K0A,K06,K07,K08,K09,K0B,K2D,K2E,K2B,K2F,K2C,K7B,K3E, K53,K54,K55,     \
+   K36,K3A,K37,            K31,            K7C,K3B,K3C,K3D, K52,    K41,K4C  \
+) { \
+  { K00,   K01,   K02,   K03,   K04,   K05,   K06,   K07   }, \
+  { K08,   K09,   K0A,   K0B,   K0C,   K0D,   K0E,   K0F   }, \
+  { K10,   K11,   K12,   K13,   K14,   K15,   K16,   K17   }, \
+  { K18,   K19,   K1A,   K1B,   K1C,   K1D,   K1E,   K1F   }, \
+  { K20,   K21,   K22,   K23,   K24,   K25,   K26,   K27   }, \
+  { K28,   K29,   K2A,   K2B,   K2C,   K2D,   K2E,   K2F   }, \
+  { K30,   K31,   KC_NO, K33,   KC_NO, K35,   K36,   K37   }, \
+  { K38,   K39,   K3A,   K3B,   K3C,   K3D,   K3E,   KC_NO }, \
+  { KC_NO, K41,   KC_NO, K43,   KC_NO, K45,   KC_NO, K47   }, \
+  { KC_NO, KC_NO, KC_NO, K4B,   K4C,   KC_NO, K4E,   KC_NO }, \
+  { KC_NO, K51,   K52,   K53,   K54,   K55,   K56,   K57   }, \
+  { K58,   K59,   KC_NO, K5B,   K5C,   KC_NO, KC_NO, KC_NO }, \
+  { KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO }, \
+  { KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO }, \
+  { KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO }, \
+  { KC_NO, KC_NO, KC_NO, K7B,   K7C, KC_NO, KC_NO, K7F   }  \
+}
+
 #endif

--- a/keyboards/converter/adb_usb/readme.md
+++ b/keyboards/converter/adb_usb/readme.md
@@ -82,3 +82,4 @@ QMK Port Changelog
 ---------
 - 2018/09/16 - Initial release.
 - 2018/12/23 - Fixed lock LED support.
+- 2020/12/05 - Added M0118 ANSI layout.


### PR DESCRIPTION
## Description

Added a layout for the ISO Apple Standard Keyboard (M0118) to the ADB-USB converter.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
