### PR TITLE
Added OLED Initialized checks

### DIFF
--- a/drivers/oled/oled_driver.c
+++ b/drivers/oled/oled_driver.c
@@ -271,6 +271,10 @@ static void rotate_90(const uint8_t *src, uint8_t *dest) {
 }
 
 void oled_render(void) {
+    if (!oled_initialized) {
+        return;
+    }
+
     // Do we have work to do?
     oled_dirty &= OLED_ALL_BLOCKS_MASK;
     if (!oled_dirty || oled_scrolling) {
@@ -527,6 +531,10 @@ void oled_write_raw_P(const char *data, uint16_t size) {
 #endif  // defined(__AVR__)
 
 bool oled_on(void) {
+    if (!oled_initialized) {
+        return oled_active;
+    }
+
 #if OLED_TIMEOUT > 0
     oled_timeout = timer_read32() + OLED_TIMEOUT;
 #endif
@@ -543,6 +551,10 @@ bool oled_on(void) {
 }
 
 bool oled_off(void) {
+    if (!oled_initialized) {
+        return !oled_active;
+    }
+
     static const uint8_t PROGMEM display_off[] = {I2C_CMD, DISPLAY_OFF};
     if (oled_active) {
         if (I2C_TRANSMIT_P(display_off) != I2C_STATUS_SUCCESS) {
@@ -557,6 +569,10 @@ bool oled_off(void) {
 bool is_oled_on(void) { return oled_active; }
 
 uint8_t oled_set_brightness(uint8_t level) {
+    if (!oled_initialized) {
+        return oled_brightness;
+    }
+
     uint8_t set_contrast[] = {I2C_CMD, CONTRAST, level};
     if (oled_brightness != level) {
         if (I2C_TRANSMIT(set_contrast) != I2C_STATUS_SUCCESS) {
@@ -596,6 +612,10 @@ void oled_scroll_set_speed(uint8_t speed) {
 }
 
 bool oled_scroll_right(void) {
+    if (!oled_initialized) {
+        return oled_scrolling;
+    }
+
     // Dont enable scrolling if we need to update the display
     // This prevents scrolling of bad data from starting the scroll too early after init
     if (!oled_dirty && !oled_scrolling) {
@@ -610,6 +630,10 @@ bool oled_scroll_right(void) {
 }
 
 bool oled_scroll_left(void) {
+    if (!oled_initialized) {
+        return oled_scrolling;
+    }
+
     // Dont enable scrolling if we need to update the display
     // This prevents scrolling of bad data from starting the scroll too early after init
     if (!oled_dirty && !oled_scrolling) {
@@ -624,6 +648,10 @@ bool oled_scroll_left(void) {
 }
 
 bool oled_scroll_off(void) {
+    if (!oled_initialized) {
+        return !oled_scrolling;
+    }
+
     if (oled_scrolling) {
         static const uint8_t PROGMEM display_scroll_off[] = {I2C_CMD, DEACTIVATE_SCROLL};
         if (I2C_TRANSMIT_P(display_scroll_off) != I2C_STATUS_SUCCESS) {


### PR DESCRIPTION
## Description
Added checks before transmits to see if the oled was properly initialized. If not, these checks will early out before the i2c transmit calls reducing wait timeouts from lagging the keyboard.
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
