### PR TITLE
Add defines for RGB/HSV black(off).

### DIFF
--- a/quantum/rgblight_list.h
+++ b/quantum/rgblight_list.h
@@ -34,6 +34,8 @@
 #define RGB_PURPLE 0x7A, 0x00, 0xFF
 #define RGB_MAGENTA 0xFF, 0x00, 0xFF
 #define RGB_PINK 0xFF, 0x80, 0xBF
+#define RGB_BLACK 0x00, 0x00, 0x00
+#define RGB_OFF RGB_BLACK
 
 /*            HSV COLORS            */
 #define HSV_WHITE 0, 0, 255
@@ -54,6 +56,8 @@
 #define HSV_PURPLE 191, 255, 255
 #define HSV_MAGENTA 213, 255, 255
 #define HSV_PINK 234, 128, 255
+#define HSV_BLACK 0, 0, 0
+#define HSV_OFF HSV_BLACK
 
 /*
 ########################################################################################


### PR DESCRIPTION
Added "black" to RGB color definitions, including a synonym "off".

Code using pre-defined color definitions switches back and forth between defines and static values. This enables standardization.

e.g.
```
rgb_matrix_set_color_all(0, 0, 0);
rgb_matrix_set_color(41, RGB_WHITE);
```
becomes
```
rgb_matrix_set_color_all(RGB_OFF);
rgb_matrix_set_color(41, RGB_WHITE);
```

etc.

Deprecated functions have intentionally not been modified.