### PR TITLE
Quefrency layout for rogthefrog

### DIFF
--- a/keyboards/keebio/quefrency/keymaps/rogthefrog/config.h
+++ b/keyboards/keebio/quefrency/keymaps/rogthefrog/config.h
@@ -1,0 +1,27 @@
+/*
+This is the c configuration file for the keymap
+
+Copyright 2012 Jun Wako <wakojun@gmail.com>
+Copyright 2015 Jack Humbert
+Copyright 2018 Danny Nguyen <danny@keeb.io>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+/* Use I2C or Serial, not both */
+
+#define USE_SERIAL
+// #define USE_I2C

--- a/keyboards/keebio/quefrency/keymaps/rogthefrog/config.h
+++ b/keyboards/keebio/quefrency/keymaps/rogthefrog/config.h
@@ -4,6 +4,7 @@ This is the c configuration file for the keymap
 Copyright 2012 Jun Wako <wakojun@gmail.com>
 Copyright 2015 Jack Humbert
 Copyright 2018 Danny Nguyen <danny@keeb.io>
+Copyright 2020 Roger Billerey-Mosier
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/keyboards/keebio/quefrency/keymaps/rogthefrog/keymap.c
+++ b/keyboards/keebio/quefrency/keymaps/rogthefrog/keymap.c
@@ -4,8 +4,12 @@
 // The underscores don't mean anything - you can have a layer called STUFF or any other name.
 // Layer names don't all need to be of the same length, obviously, and you can also skip them
 // entirely and just use numbers.
-#define _BASE 0
-#define _FN1 1
+
+enum layers {
+    _BASE,
+    _FN1,
+};
+
 
 enum custom_keycodes {
   QWERTY = SAFE_RANGE,

--- a/keyboards/keebio/quefrency/keymaps/rogthefrog/keymap.c
+++ b/keyboards/keebio/quefrency/keymaps/rogthefrog/keymap.c
@@ -29,18 +29,18 @@ enum layers {
 
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-	[_BASE] = LAYOUT_65(
-    KC_TILD, KC_1,    KC_2,    KC_3,   KC_4,     KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_NO,   KC_BSPC, KC_HOME, \
-    KC_TAB,  KC_Q,    KC_W,    KC_E,   KC_R,     KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS, KC_END, \
-    KC_ESC,  KC_A,    KC_S,    KC_D,   KC_F,     KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_ENT,  KC_PGUP, \
-    KC_LSFT, KC_Z,    KC_X,    KC_C,   KC_V,     KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RCTL, KC_UP,   KC_PGDN, \
-    KC_LCTL, KC_LGUI, KC_LALT, KC_ENT, MO(_FN1),          KC_SPC,  KC_NO,   KC_APP,  KC_PSCR, KC_DEL,  KC_LEFT, KC_DOWN, KC_RGHT \
+  [_BASE] = LAYOUT_65(
+    KC_TILD, KC_1,    KC_2,    KC_3,   KC_4,     KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_NO,   KC_BSPC, KC_HOME,
+    KC_TAB,  KC_Q,    KC_W,    KC_E,   KC_R,     KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS, KC_END,
+    KC_ESC,  KC_A,    KC_S,    KC_D,   KC_F,     KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_ENT,  KC_PGUP,
+    KC_LSFT, KC_Z,    KC_X,    KC_C,   KC_V,     KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RCTL, KC_UP,   KC_PGDN,
+    KC_LCTL, KC_LGUI, KC_LALT, KC_ENT, MO(_FN1),          KC_SPC,  KC_NO,   KC_APP,  KC_PSCR, KC_DEL,  KC_LEFT, KC_DOWN, KC_RGHT
   ), 
   [_FN1] = LAYOUT_65(
-    KC_ESC,  KC_F1,   KC_F2,   KC_F3,  KC_F4,    KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  _______,  KC_DEL, _______, \
-    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, \
-    KC_CAPS, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, \
-    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, \
-    _______, _______, _______, _______, _______,          _______, _______, _______, _______, _______, _______, _______, _______ \
+    KC_ESC,  KC_F1,   KC_F2,   KC_F3,  KC_F4,    KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  _______,  KC_DEL, _______,
+    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+    KC_CAPS, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+    _______, _______, _______, _______, _______,          _______, _______, _______, _______, _______, _______, _______, _______
   )
 };

--- a/keyboards/keebio/quefrency/keymaps/rogthefrog/keymap.c
+++ b/keyboards/keebio/quefrency/keymaps/rogthefrog/keymap.c
@@ -29,20 +29,3 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     _______, _______, _______, _______, _______,          _______, _______, _______, _______, _______, _______, _______, _______ \
   )
 };
-
-void encoder_update_user(uint8_t index, bool clockwise) {
-    if (index == 0) {
-        if (clockwise) {
-            tap_code(KC_PGDN);
-        } else {
-            tap_code(KC_PGUP);
-        }
-    }
-    else if (index == 1) {
-        if (clockwise) {
-            tap_code(KC_VOLU);
-        } else {
-            tap_code(KC_VOLD);
-        }
-    }
-}

--- a/keyboards/keebio/quefrency/keymaps/rogthefrog/keymap.c
+++ b/keyboards/keebio/quefrency/keymaps/rogthefrog/keymap.c
@@ -1,0 +1,48 @@
+#include QMK_KEYBOARD_H
+
+extern keymap_config_t keymap_config;
+
+// Each layer gets a name for readability, which is then used in the keymap matrix below.
+// The underscores don't mean anything - you can have a layer called STUFF or any other name.
+// Layer names don't all need to be of the same length, obviously, and you can also skip them
+// entirely and just use numbers.
+#define _BASE 0
+#define _FN1 1
+
+enum custom_keycodes {
+  QWERTY = SAFE_RANGE,
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+	[_BASE] = LAYOUT_65(
+    KC_TILD, KC_1,    KC_2,    KC_3,   KC_4,     KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_NO,   KC_BSPC, KC_HOME, \
+    KC_TAB,  KC_Q,    KC_W,    KC_E,   KC_R,     KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS, KC_END, \
+    KC_ESC,  KC_A,    KC_S,    KC_D,   KC_F,     KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_ENT,  KC_PGUP, \
+    KC_LSFT, KC_Z,    KC_X,    KC_C,   KC_V,     KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RCTL, KC_UP,   KC_PGDN, \
+    KC_LCTL, KC_LGUI, KC_LALT, KC_ENT, MO(_FN1),          KC_SPC,  KC_NO,   KC_APP,  KC_PSCR, KC_DEL,  KC_LEFT, KC_DOWN, KC_RGHT \
+  ), 
+  [_FN1] = LAYOUT_65(
+    KC_ESC,  KC_F1,   KC_F2,   KC_F3,  KC_F4,    KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  _______,  KC_DEL, _______, \
+    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, \
+    KC_CAPS, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, \
+    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, \
+    _______, _______, _______, _______, _______,          _______, _______, _______, _______, _______, _______, _______, _______ \
+  )
+};
+
+void encoder_update_user(uint8_t index, bool clockwise) {
+    if (index == 0) {
+        if (clockwise) {
+            tap_code(KC_PGDN);
+        } else {
+            tap_code(KC_PGUP);
+        }
+    }
+    else if (index == 1) {
+        if (clockwise) {
+            tap_code(KC_VOLU);
+        } else {
+            tap_code(KC_VOLD);
+        }
+    }
+}

--- a/keyboards/keebio/quefrency/keymaps/rogthefrog/keymap.c
+++ b/keyboards/keebio/quefrency/keymaps/rogthefrog/keymap.c
@@ -11,10 +11,6 @@ enum layers {
 };
 
 
-enum custom_keycodes {
-  QWERTY = SAFE_RANGE,
-};
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 	[_BASE] = LAYOUT_65(
     KC_TILD, KC_1,    KC_2,    KC_3,   KC_4,     KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_NO,   KC_BSPC, KC_HOME, \

--- a/keyboards/keebio/quefrency/keymaps/rogthefrog/keymap.c
+++ b/keyboards/keebio/quefrency/keymaps/rogthefrog/keymap.c
@@ -1,3 +1,20 @@
+/*
+  Copyright 2020 Roger Billerey-Mosier
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 #include QMK_KEYBOARD_H
 
 // Each layer gets a name for readability, which is then used in the keymap matrix below.

--- a/keyboards/keebio/quefrency/keymaps/rogthefrog/keymap.c
+++ b/keyboards/keebio/quefrency/keymaps/rogthefrog/keymap.c
@@ -1,7 +1,5 @@
 #include QMK_KEYBOARD_H
 
-extern keymap_config_t keymap_config;
-
 // Each layer gets a name for readability, which is then used in the keymap matrix below.
 // The underscores don't mean anything - you can have a layer called STUFF or any other name.
 // Layer names don't all need to be of the same length, obviously, and you can also skip them


### PR DESCRIPTION
## Description

Quefrency 65-key layout with space on the right side and enter on the left.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

None.

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
