### PR TITLE
Fixup config template to match <> instead of "" for includes.

### DIFF
--- a/platforms/chibios/keyboard-config-templates/board.h
+++ b/platforms/chibios/keyboard-config-templates/board.h
@@ -15,6 +15,6 @@
  */
 #pragma once
 
-#include_next "board.h"
+#include_next <board.h>
 
 // #undef STM32_HSE_BYPASS

--- a/platforms/chibios/keyboard-config-templates/chconf.h
+++ b/platforms/chibios/keyboard-config-templates/chconf.h
@@ -17,4 +17,4 @@
 
 // #define CH_CFG_OPTIMIZE_SPEED TRUE
 
-#include_next "chconf.h"
+#include_next <chconf.h>

--- a/platforms/chibios/keyboard-config-templates/halconf.h
+++ b/platforms/chibios/keyboard-config-templates/halconf.h
@@ -17,4 +17,4 @@
 
 // #define HAL_USE_DAC TRUE
 
-#include_next "halconf.h"
+#include_next <halconf.h>

--- a/platforms/chibios/keyboard-config-templates/mcuconf.h
+++ b/platforms/chibios/keyboard-config-templates/mcuconf.h
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include_next "mcuconf.h"
+#include_next <mcuconf.h>
 
 // #undef STM32_HSE_ENABLED
 // #define STM32_HSE_ENABLED FALSE


### PR DESCRIPTION
## Description

Just a include search path fix for the ChibiOS config templates to match the automated conversion command.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
