### PR TITLE
YMD75 rev 3:  fix BACKLIGHT_PIN

### DIFF
--- a/keyboards/ymd75/config.h
+++ b/keyboards/ymd75/config.h
@@ -27,7 +27,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MANUFACTURER    YMDK
 #define PRODUCT         YMD75 / MT84
 
-#define BACKLIGHT_PIN D4
 #define BACKLIGHT_LEVELS 12
 
 #define RGB_DI_PIN E2

--- a/keyboards/ymd75/rev1/config.h
+++ b/keyboards/ymd75/rev1/config.h
@@ -24,5 +24,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MATRIX_COLS 15
 #define MATRIX_ROW_PINS { B0, B1, B2, B3, B4, B5, B6, B7 }
 #define MATRIX_COL_PINS { A0, A1, A2, A3, A4, A5, A6, A7, C7, C6, C5, C4, C3, C2, D7 }
+#define BACKLIGHT_PIN D4
 #define DIODE_DIRECTION COL2ROW
 #define DEVICE_VER      0x0100

--- a/keyboards/ymd75/rev2/config.h
+++ b/keyboards/ymd75/rev2/config.h
@@ -5,5 +5,6 @@
 #define MATRIX_COLS 15
 #define MATRIX_ROW_PINS { B7, B6, B5, B4, B3, B0 }
 #define MATRIX_COL_PINS { A0, A1, A2, A3, A4, A5, A6, A7, C7, C6, C5, C4, C3, C2, D7 }
+#define BACKLIGHT_PIN D4
 #define DIODE_DIRECTION COL2ROW
 #define DEVICE_VER      0x0200

--- a/keyboards/ymd75/rev3/config.h
+++ b/keyboards/ymd75/rev3/config.h
@@ -4,8 +4,8 @@
 #define MATRIX_COLS 9
 #define MATRIX_ROW_PINS { B7, B3, B2, B1, B0, E6, F0, F1, F4, F5, F6, F7 }
 #define MATRIX_COL_PINS { D0, D1, D2, D3, D5, D4, D6, D7, B4 }
-#undef BACKLIGHT_PIN // undefine the p
-#define BACKLIGHT_PIN B6 // backlight pin has since changed in Rev 3
+#undef BACKLIGHT_PIN // undefine the macro set in /keyboards/ymd75/config.h
+#define BACKLIGHT_PIN B6 // change the backlight pin that has since changed in Rev 3
 #define DIODE_DIRECTION ROW2COL
 #define DEVICE_VER      0x0300
 #define RGBLIGHT_EFFECT_KNIGHT_OFFSET 4

--- a/keyboards/ymd75/rev3/config.h
+++ b/keyboards/ymd75/rev3/config.h
@@ -4,6 +4,8 @@
 #define MATRIX_COLS 9
 #define MATRIX_ROW_PINS { B7, B3, B2, B1, B0, E6, F0, F1, F4, F5, F6, F7 }
 #define MATRIX_COL_PINS { D0, D1, D2, D3, D5, D4, D6, D7, B4 }
+#undef BACKLIGHT_PIN // undefine the p
+#define BACKLIGHT_PIN B6 // backlight pin has since changed in Rev 3
 #define DIODE_DIRECTION ROW2COL
 #define DEVICE_VER      0x0300
 #define RGBLIGHT_EFFECT_KNIGHT_OFFSET 4

--- a/keyboards/ymd75/rev3/config.h
+++ b/keyboards/ymd75/rev3/config.h
@@ -4,7 +4,6 @@
 #define MATRIX_COLS 9
 #define MATRIX_ROW_PINS { B7, B3, B2, B1, B0, E6, F0, F1, F4, F5, F6, F7 }
 #define MATRIX_COL_PINS { D0, D1, D2, D3, D5, D4, D6, D7, B4 }
-#undef BACKLIGHT_PIN // undefine the macro set in /keyboards/ymd75/config.h
 #define BACKLIGHT_PIN B6 // change the backlight pin that has since changed in Rev 3
 #define DIODE_DIRECTION ROW2COL
 #define DEVICE_VER      0x0300


### PR DESCRIPTION
## Description
Since the change from the Atmega32a to Atmega32u4. The pin for the per-key LED backlight has changed. As a result, the pin that worked on the older versions does not work on this model anymore.

Hope this change could help some troubled users who are trying to flash the default YMD75 rev 3 firmware.

Source (where I found the correct pin): `http://mtkeyboard.vip`

<!--- Describe your changes in detail here. -->

## Types of Changes

- add new BACKLIGHT_PIN in the default layout for YMD75/rev 3

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
