### PR TITLE
Add clarification on use of custom RGB Matrix effect

### DIFF
--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -308,9 +308,9 @@ To declare new effects, create a new `rgb_matrix_user/kb.inc` that looks somethi
 
 To use custom effects in your code, simply prepend `RGB_MATRIX_CUSTOM_` to the effect name specified in `RGB_MATRIX_EFFECT()`. For example, an effect declared as `RGB_MATRIX_EFFECT(my_cool_effect)` would be referenced with:
 
-\`\`\`c
+```c
 rgb_matrix_mode(RGB_MATRIX_CUSTOM_my_cool_effect);
-\`\`\`
+```
 
 ```c
 // !!! DO NOT ADD #pragma once !!! //

--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -306,6 +306,10 @@ To declare new effects, create a new `rgb_matrix_user/kb.inc` that looks somethi
 `rgb_matrix_user.inc` should go in the root of the keymap directory.
 `rgb_matrix_kb.inc` should go in the root of the keyboard directory.
 
+To use the newly created custom effect outside of the `rgb_matrix_user/kb.inc` file, it has to be appended to the prefix `RGB_MATRIX_CUSTOM_`.
+As an example, to change the current effect with the new custom effect `my_cool_effect` write:
+`rgb_matrix_mode(RGB_MATRIX_CUSTOM_my_cool_effect);`
+
 ```c
 // !!! DO NOT ADD #pragma once !!! //
 

--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -306,9 +306,11 @@ To declare new effects, create a new `rgb_matrix_user/kb.inc` that looks somethi
 `rgb_matrix_user.inc` should go in the root of the keymap directory.
 `rgb_matrix_kb.inc` should go in the root of the keyboard directory.
 
-To use the newly created custom effect outside of the `rgb_matrix_user/kb.inc` file, it has to be appended to the prefix `RGB_MATRIX_CUSTOM_`.
-As an example, to change the current effect with the new custom effect `my_cool_effect` write:
-`rgb_matrix_mode(RGB_MATRIX_CUSTOM_my_cool_effect);`
+To use custom effects in your code, simply prepend `RGB_MATRIX_CUSTOM_` to the effect name specified in `RGB_MATRIX_EFFECT()`. For example, an effect declared as `RGB_MATRIX_EFFECT(my_cool_effect)` would be referenced with:
+
+\`\`\`c
+rgb_matrix_mode(RGB_MATRIX_CUSTOM_my_cool_effect);
+\`\`\`
 
 ```c
 // !!! DO NOT ADD #pragma once !!! //


### PR DESCRIPTION
Added more clarification on how to use a newly created rgb effect as it was unclear that the prefix 'RGB_MATRIX_CUSTOM_' had to be added.
Also included an example consistent with the documentation example.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation
