### PR TITLE
Fix warning logic when running 'qmk format -a'

### DIFF
--- a/lib/python/qmk/cli/cformat.py
+++ b/lib/python/qmk/cli/cformat.py
@@ -23,8 +23,6 @@ def cformat_run(files, all_files):
         if not files:
             cli.log.warn('No changes detected. Use "qmk cformat -a" to format all files')
             return False
-        if files and all_files:
-            cli.log.warning('Filenames passed with -a, only formatting: %s', ','.join(files))
         subprocess.run(clang_format + [file for file in files], check=True)
         cli.log.info('Successfully formatted the C code.')
 
@@ -48,6 +46,8 @@ def cformat(cli):
     # Find the list of files to format
     if cli.args.files:
         files.extend(normpath(file) for file in cli.args.files)
+        if cli.args.all_files:
+            cli.log.warning('Filenames passed with -a, only formatting: %s', ','.join(map(str, files)))
     # If -a is specified
     elif cli.args.all_files:
         all_files = c_source_files(core_dirs)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Was producing the following error:
```
qmk cformat -a
<class 'TypeError'>
☒ sequence item 0: expected str instance, PosixPath found
Traceback (most recent call last):
  File "/home/zvecr/.local/lib/python3.8/site-packages/milc/milc.py", line 415, in __call__
    return self.__call__()
  File "/home/zvecr/.local/lib/python3.8/site-packages/milc/milc.py", line 420, in __call__
    return self._entrypoint(self)
  File "/home/zvecr/qmk_firmware/lib/python/qmk/cli/cformat.py", line 65, in cformat
    cformat_run(files, cli.args.all_files)
  File "/home/zvecr/qmk_firmware/lib/python/qmk/cli/cformat.py", line 27, in cformat_run
    cli.log.warning('Filenames passed with -a, only formatting: %s', ','.join(files))
```

However on further inspection the condition for when the warning should be displayed was also in the wrong place. Which triggered the warning to always print out, even when zero files were passed.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
