### PR TITLE
Adding keyboard support for 1x4p1 by Array Peripherals

### DIFF
--- a/keyboards/arrayperipherals/1x4p1/1x4p1.c
+++ b/keyboards/arrayperipherals/1x4p1/1x4p1.c
@@ -1,0 +1,22 @@
+/*
+Copyright 2020 David Doan
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "1x4p1.h"
+
+void matrix_init_kb(void) {
+	matrix_init_user();
+}

--- a/keyboards/arrayperipherals/1x4p1/1x4p1.h
+++ b/keyboards/arrayperipherals/1x4p1/1x4p1.h
@@ -1,0 +1,28 @@
+/*
+Copyright 2020 David Doan
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "quantum.h"
+
+#define LAYOUT_ortho_1x5( \
+    k01, k02, k03, k04, k05\
+  ) { \
+    { k01, k02, k03, k04, k05} \
+}
+
+#define LAYOUT LAYOUT_ortho_1x5

--- a/keyboards/arrayperipherals/1x4p1/config.h
+++ b/keyboards/arrayperipherals/1x4p1/config.h
@@ -1,0 +1,47 @@
+/*
+Copyright 2020 David Doan
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "config_common.h"
+
+/* USB Device descriptor parameter */
+#define VENDOR_ID       0xFEED
+#define PRODUCT_ID      0x4F46 // "OF"
+#define DEVICE_VER      0x0001
+#define MANUFACTURER    Array Peripherals
+#define PRODUCT         [1x4] + 1 Macropad
+
+/* key matrix size */
+#define MATRIX_ROWS 1
+#define MATRIX_COLS 5
+
+
+#define DIRECT_PINS {   \
+    { C7, B7, D6, F5, F7} \
+}
+//speed for double tap
+#define TAPPING_TERM 200
+#define UNUSED_PINS
+
+/* rotary encoder*/
+#define ENCODERS_PAD_A {F0}
+#define ENCODERS_PAD_B {F1}
+#define ENCODER_RESOLUTION 4 //default/suggested
+
+//This is for VIA configurator
+#define DYNAMIC_KEYMAP_LAYER_COUNT 2

--- a/keyboards/arrayperipherals/1x4p1/info.json
+++ b/keyboards/arrayperipherals/1x4p1/info.json
@@ -1,0 +1,18 @@
+{
+  "keyboard_name": "[1 x 4] + 1 Macropad",
+  "url": "https://github.com/daviddoan",
+  "maintainer": "David Doan",
+  "width": 5,
+  "height": 1,
+  "layouts": {
+    "LAYOUT": {
+      "layout": [
+        {"label": "K01", "x":0, "y":0}, 
+        {"label": "K02", "x":1, "y":0},
+        {"label": "K03", "x":2, "y":0},
+        {"label": "K04", "x":3, "y":0},
+        {"label": "K05", "x":4, "y":0}
+      ]
+    }
+  }
+}

--- a/keyboards/arrayperipherals/1x4p1/keymaps/default/keymap.c
+++ b/keyboards/arrayperipherals/1x4p1/keymaps/default/keymap.c
@@ -1,0 +1,41 @@
+/*
+Copyright 2020 David Doan
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include QMK_KEYBOARD_H
+
+#define _MAIN 0
+
+void encoder_update_user(uint8_t index, bool clockwise) {
+  if (index == 0) { /* First encoder */
+    if (clockwise) {
+      tap_code(KC_MS_WH_UP);
+    } else {
+      tap_code(KC_MS_WH_DOWN);
+    }
+  }
+}
+
+//
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = { //button closest to usb is first
+  [_MAIN] = LAYOUT(
+     KC_ESC, KC_TAB, KC_LSHIFT, KC_LCTRL, TG(1)
+   ),
+
+  [1] = LAYOUT(
+  	 KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, TG(1)
+  )
+};

--- a/keyboards/arrayperipherals/1x4p1/keymaps/default/readme.md
+++ b/keyboards/arrayperipherals/1x4p1/keymaps/default/readme.md
@@ -1,0 +1,5 @@
+![[1x4] + 1 Macropad Layout](https://i.imgur.com/ZdXuIwb.png)
+
+# Default [1x4] + 1 Macropad Layout
+
+This is the default layout that comes flashed on every [1x4] + 1 Macropad. The right most key (red) is the rotary and the key is binded to layer switching. The second layer is left blank for the user.

--- a/keyboards/arrayperipherals/1x4p1/keymaps/via/keymap.c
+++ b/keyboards/arrayperipherals/1x4p1/keymaps/via/keymap.c
@@ -1,0 +1,41 @@
+/*
+Copyright 2020 David Doan
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include QMK_KEYBOARD_H
+
+#define _MAIN 0
+
+void encoder_update_user(uint8_t index, bool clockwise) {
+  if (index == 0) { /* First encoder */
+    if (clockwise) {
+      tap_code(KC_MS_WH_UP);
+    } else {
+      tap_code(KC_MS_WH_DOWN);
+    }
+  }
+}
+
+//
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = { //button closest to usb is first
+  [_MAIN] = LAYOUT(
+     KC_ESC, KC_TAB, KC_LSHIFT, KC_LCTRL, TG(1)
+   ),
+
+  [1] = LAYOUT(
+     KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, TG(1)
+  )
+};

--- a/keyboards/arrayperipherals/1x4p1/keymaps/via/rules.mk
+++ b/keyboards/arrayperipherals/1x4p1/keymaps/via/rules.mk
@@ -1,0 +1,1 @@
+VIA_ENABLE = yes

--- a/keyboards/arrayperipherals/1x4p1/readme.md
+++ b/keyboards/arrayperipherals/1x4p1/readme.md
@@ -1,0 +1,16 @@
+# [1x4] + 1 Macropad
+
+![[1x4] + 1 Macropad](https://images.squarespace-cdn.com/content/v1/5f5e7d5dc43c166c56c0ae39/1606977576841-KIT0TOI6L3FO8FTS4ZHB/ke17ZwdGBToddI8pDm48kDk1dm1oSR9gCa1mX4KqzjN7gQa3H78H3Y0txjaiv_0fDoOvxcdMmMKkDsyUqMSsMWxHk725yiiHCCLfrh8O1z4YTzHvnKhyp6Da-NYroOW3ZGjoBKy3azqku80C789l0luj0xCD0oh5KMc0gpox0u-wQWxfQHg04OxgQwaUq2yiAcNt5Kg2tE9yEtYfM4xwaw/DSC_0116.jpg)
+
+A macropad with a 1x4 matrix array with an additional rotary that also functions as a button. [More info at arrayperipherals.com](https://www.arrayperipherals.com/)
+
+* Keyboard Maintainer: [David Doan](https://github.com/daviddoan)
+* Hardware Supported: Adafruit ItsyBitsy 32u4
+* Hardware Availability: [arrayperipherals.com](https://www.arrayperipherals.com/)
+
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
+
+## Resetting macropad into bootloader mode.
+
+The stock version of the macropad has bootmagic lite enabled. To trigger the bootloader, the first key (key furthest way from the rotary) needs to be held down when plugging the keyboard in. 
+NOTE: Using bootmagic lite will always reset the EEPROM, so you will lose any settings that have been saved.

--- a/keyboards/arrayperipherals/1x4p1/rules.mk
+++ b/keyboards/arrayperipherals/1x4p1/rules.mk
@@ -1,0 +1,25 @@
+# MCU name
+MCU = atmega32u4
+
+BOOTLOADER = caterina
+
+# Build Options
+#   change to "no" to disable the options, or define them in the Makefile in
+#   the appropriate keymap folder that will get included automatically
+#
+BOOTMAGIC_ENABLE = lite       # Virtual DIP switch configuration
+ENCODER_ENABLE = yes		#enable rotary encoders
+MOUSEKEY_ENABLE = yes      # Mouse keys
+EXTRAKEY_ENABLE = yes       # Audio control and System control
+CONSOLE_ENABLE = no         # Console for debug
+COMMAND_ENABLE = no         # Commands for debug and configuration
+NKRO_ENABLE = yes           # Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
+AUDIO_ENABLE = no           # Audio output on port C6
+UNICODE_ENABLE = yes        # Unicode
+BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
+RGBLIGHT_ENABLE = no       # Enable WS2812 RGB underlight.
+TAP_DANCE_ENABLE = no      # Double press does something different
+
+# Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
+SLEEP_LED_ENABLE = no    # Breathing sleep LED during USB suspend

--- a/keyboards/arrayperipherals/readme.md
+++ b/keyboards/arrayperipherals/readme.md
@@ -1,0 +1,5 @@
+# Array Peripherals 
+
+Array Peripherals is a small company operating out of an apartment by two brothers located in Northern California.
+
+Website: [Array Peripherals](www.arrayperipherals.com)  


### PR DESCRIPTION
## Description

Added a new macropad ([1x4]+1 Macropad), designed by Array Peripherals.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
