### PR TITLE
[Keymap] fix and update helix/rev3_5rows:five_rows

### DIFF
--- a/keyboards/helix/rev3_5rows/keymaps/five_rows/config.h
+++ b/keyboards/helix/rev3_5rows/keymaps/five_rows/config.h
@@ -69,3 +69,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #endif
 
 #endif /* CONFIG_USER_H */
+
+#ifdef DEBUG_CONFIG
+#  include "debug_config.h"
+#endif

--- a/keyboards/helix/rev3_5rows/keymaps/five_rows/config.h
+++ b/keyboards/helix/rev3_5rows/keymaps/five_rows/config.h
@@ -22,6 +22,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef CONFIG_USER_H
 #define CONFIG_USER_H
 
+#undef OLED_UPDATE_INTERVAL
+#define OLED_UPDATE_INTERVAL 100
+
 #undef TAPPING_TERM
 #define TAPPING_TERM 300
 #define PERMISSIVE_HOLD

--- a/keyboards/helix/rev3_5rows/keymaps/five_rows/config.h
+++ b/keyboards/helix/rev3_5rows/keymaps/five_rows/config.h
@@ -48,7 +48,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #undef RGBLIGHT_EFFECT_ALTERNATING
 
 #if defined(LED_ANIMATIONS)
-#  if LED_ANIMATIONS > 1
+#  if LED_ANIMATIONS_LEVEL > 1
    #define RGBLIGHT_EFFECT_BREATHING
    #define RGBLIGHT_EFFECT_RAINBOW_MOOD
    #define RGBLIGHT_EFFECT_RAINBOW_SWIRL

--- a/keyboards/helix/rev3_5rows/keymaps/five_rows/config.h
+++ b/keyboards/helix/rev3_5rows/keymaps/five_rows/config.h
@@ -23,7 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define CONFIG_USER_H
 
 #undef OLED_UPDATE_INTERVAL
-#define OLED_UPDATE_INTERVAL 100
+#define OLED_UPDATE_INTERVAL 50
 
 #undef TAPPING_TERM
 #define TAPPING_TERM 300

--- a/keyboards/helix/rev3_5rows/keymaps/five_rows/config.h
+++ b/keyboards/helix/rev3_5rows/keymaps/five_rows/config.h
@@ -33,7 +33,19 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // If you need more program area, try select and reduce rgblight modes to use.
 
 // Selection of RGBLIGHT MODE to use.
+#undef RGBLIGHT_ANIMATIONS
+#undef RGBLIGHT_EFFECT_BREATHING
+#undef RGBLIGHT_EFFECT_RAINBOW_MOOD
+#undef RGBLIGHT_EFFECT_RAINBOW_SWIRL
+#undef RGBLIGHT_EFFECT_SNAKE
+#undef RGBLIGHT_EFFECT_KNIGHT
+#undef RGBLIGHT_EFFECT_CHRISTMAS
+#undef RGBLIGHT_EFFECT_STATIC_GRADIENT
+#undef RGBLIGHT_EFFECT_RGB_TEST
+#undef RGBLIGHT_EFFECT_ALTERNATING
+
 #if defined(LED_ANIMATIONS)
+#  if LED_ANIMATIONS > 1
    #define RGBLIGHT_EFFECT_BREATHING
    #define RGBLIGHT_EFFECT_RAINBOW_MOOD
    #define RGBLIGHT_EFFECT_RAINBOW_SWIRL
@@ -43,6 +55,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
    #define RGBLIGHT_EFFECT_STATIC_GRADIENT
    //#define RGBLIGHT_EFFECT_RGB_TEST
    //#define RGBLIGHT_EFFECT_ALTERNATING
+#  else
+   #define RGBLIGHT_EFFECT_BREATHING
+   #define RGBLIGHT_EFFECT_RAINBOW_MOOD
+   //#define RGBLIGHT_EFFECT_RAINBOW_SWIRL
+   //#define RGBLIGHT_EFFECT_SNAKE
+   //#define RGBLIGHT_EFFECT_KNIGHT
+   //#define RGBLIGHT_EFFECT_CHRISTMAS
+   #define RGBLIGHT_EFFECT_STATIC_GRADIENT
+   //#define RGBLIGHT_EFFECT_RGB_TEST
+   //#define RGBLIGHT_EFFECT_ALTERNATING
+#  endif
 #endif
 
 #endif /* CONFIG_USER_H */

--- a/keyboards/helix/rev3_5rows/keymaps/five_rows/keyboard_post_init_user_scan.c
+++ b/keyboards/helix/rev3_5rows/keymaps/five_rows/keyboard_post_init_user_scan.c
@@ -1,7 +1,0 @@
-#include QMK_KEYBOARD_H
-
-void keyboard_post_init_user(void) {
-#if defined(DEBUG_MATRIX_SCAN_RATE)
-    debug_enable = true;
-#endif
-}

--- a/keyboards/helix/rev3_5rows/keymaps/five_rows/rules.mk
+++ b/keyboards/helix/rev3_5rows/keymaps/five_rows/rules.mk
@@ -71,11 +71,13 @@ ifneq ($(strip $(HELIX)),)
 endif
 
 ifeq ($(strip $(LED_ANIMATIONS)), yes)
-    OPT_DEFS += -DLED_ANIMATIONS=2
+    OPT_DEFS += -DLED_ANIMATIONS
+    OPT_DEFS += -DLED_ANIMATIONS_LEVEL=2
 endif
 
 ifeq ($(strip $(LED_ANIMATIONS)), mini)
-    OPT_DEFS += -DLED_ANIMATIONS=1
+    OPT_DEFS += -DLED_ANIMATIONS
+    OPT_DEFS += -DLED_ANIMATIONS_LEVEL=1
 endif
 
 ifeq ($(strip $(DEBUG_CONFIG)), yes)

--- a/keyboards/helix/rev3_5rows/keymaps/five_rows/rules.mk
+++ b/keyboards/helix/rev3_5rows/keymaps/five_rows/rules.mk
@@ -10,12 +10,13 @@
  #      yes, no  +1500
  #      yes, yes +3200
  #      no,  yes +400
+ENCODER_ENABLE = no
 LTO_ENABLE = no  # if firmware size over limit, try this option
 LED_ANIMATIONS = yes
 
 ifneq ($(strip $(HELIX)),)
   define KEYMAP_OPTION_PARSE
-    # parse 'dispoff', 'consle', 'back', 'oled', 'no-ani', 'mini-ani', 'lto', 'no-lto', 'scan'
+    # parse 'dispoff', 'consle', 'back', 'oled', 'no-ani', 'mini-ani', 'lto', 'no-lto', 'no-enc', 'scan'
     $(if $(SHOW_PARCE),$(info parse .$1.))  #debug
     ifeq ($(strip $1),dispoff)
         OLED_DRIVER_ENABLE = no
@@ -23,6 +24,12 @@ ifneq ($(strip $(HELIX)),)
     endif
     ifeq ($(strip $1),console)
         CONSOLE_ENABLE = yes
+    endif
+    ifneq ($(filter enc,$(strip $1)),)
+        ENCODER_ENABLE = yes
+    endif
+    ifneq ($(filter noenc no-enc no_enc,$(strip $1)),)
+        ENCODER_ENABLE = no
     endif
     ifeq ($(strip $1),oled)
         OLED_DRIVER_ENABLE = yes

--- a/keyboards/helix/rev3_5rows/keymaps/five_rows/rules.mk
+++ b/keyboards/helix/rev3_5rows/keymaps/five_rows/rules.mk
@@ -11,11 +11,12 @@
  #      yes, yes +3200
  #      no,  yes +400
 LTO_ENABLE = no  # if firmware size over limit, try this option
+LED_ANIMATIONS = yes
 
 ifneq ($(strip $(HELIX)),)
   define KEYMAP_OPTION_PARSE
-    # $xinfo .$1.x #debug
-    # parse  'dispoff', 'consle', 'back', 'oled'
+    # parse 'dispoff', 'consle', 'back', 'oled', 'no-ani', 'mini-ani', 'lto', 'no-lto', 'scan'
+    $(if $(SHOW_PARCE),$(info parse .$1.))  #debug
     ifeq ($(strip $1),dispoff)
         OLED_DRIVER_ENABLE = no
         RGBLIGHT_ENABLE = no
@@ -29,16 +30,37 @@ ifneq ($(strip $(HELIX)),)
     ifeq ($(strip $1),back)
         RGBLIGHT_ENABLE = yes
     endif
+    ifneq ($(filter na no_ani no-ani,$(strip $1)),)
+        LED_ANIMATIONS = no
+    endif
+    ifneq ($(filter mini-ani mini_ani,$(strip $1)),)
+        LED_ANIMATIONS = mini
+    endif
+    ifneq ($(filter ani animation,$(strip $1)),)
+        LED_ANIMATIONS = yes
+    endif
+    ifeq ($(strip $1),lto)
+        LTO_ENABLE = yes
+    endif
+    ifneq ($(filter nolto no-lto no_lto,$(strip $1)),)
+        LTO_ENABLE = no
+    endif
     ifeq ($(strip $1),scan)
         # use DEBUG_MATRIX_SCAN_RATE
         # see docs/newbs_testing_debugging.md
-        OPT_DEFS +=  -DDEBUG_MATRIX_SCAN_RATE
-        CONSOLE_ENABLE = yes
-        SRC += keyboard_post_init_user_scan.c
+        DEBUG_MATRIX_SCAN_RATE_ENABLE = yes
     endif
   endef # end of KEYMAP_OPTION_PARSE
 
   COMMA=,
   $(eval $(foreach A_OPTION_NAME,$(subst $(COMMA), ,$(HELIX)),  \
       $(call KEYMAP_OPTION_PARSE,$(A_OPTION_NAME))))
+endif
+
+ifeq ($(strip $(LED_ANIMATIONS)), yes)
+    OPT_DEFS += -DLED_ANIMATIONS=2
+endif
+
+ifeq ($(strip $(LED_ANIMATIONS)), mini)
+    OPT_DEFS += -DLED_ANIMATIONS=1
 endif

--- a/keyboards/helix/rev3_5rows/keymaps/five_rows/rules.mk
+++ b/keyboards/helix/rev3_5rows/keymaps/five_rows/rules.mk
@@ -25,6 +25,12 @@ ifneq ($(strip $(HELIX)),)
     ifeq ($(strip $1),console)
         CONSOLE_ENABLE = yes
     endif
+    ifeq ($(strip $1),debug)
+        DEBUG_CONFIG = yes
+    endif
+    ifneq ($(filter nodebug no-debug no_debug,$(strip $1)),)
+        DEBUG_CONFIG = no
+    endif
     ifneq ($(filter enc,$(strip $1)),)
         ENCODER_ENABLE = yes
     endif
@@ -70,4 +76,8 @@ endif
 
 ifeq ($(strip $(LED_ANIMATIONS)), mini)
     OPT_DEFS += -DLED_ANIMATIONS=1
+endif
+
+ifeq ($(strip $(DEBUG_CONFIG)), yes)
+    OPT_DEFS += -DDEBUG_CONFIG
 endif


### PR DESCRIPTION
## Description

fix and update helix/rev3_5rows:five_rows

* fix rgblight animation selection
* use `DEBUG_MATRIX_SCAN_RATE_ENABLE` insted of keyboard_post_init_user_scan.c
* Change the initial value of the ENCODER_ENABLE to 'no' in 'rev3_5rows/keymaps/five_rows/rules.mk'
* Add '#define OLED_UPDATE_INTERVAL 100'  into 'rev3_5rows/keymaps/five_rows/config.h'


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
