### PR TITLE
Fix incorrect search order for `rgblight_breathe_table.h` that `rgblight.c` includes.

### DIFF
--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -983,7 +983,7 @@ void rgblight_task(void) {
 #        ifndef RGBLIGHT_BREATHE_TABLE_SIZE
 #            define RGBLIGHT_BREATHE_TABLE_SIZE 256  // 256 or 128 or 64
 #        endif
-#        include "rgblight_breathe_table.h"
+#        include <rgblight_breathe_table.h>
 #    endif
 
 __attribute__((weak)) const uint8_t RGBLED_BREATHING_INTERVALS[] PROGMEM = {30, 20, 10, 5};


### PR DESCRIPTION
## Description

When `rgblight.c` includes `rgblight_breathe_table.h`, the search order should be as follows.

* `keyboards/KEYBOARD/keymaps/USER/rgblight_breathe_table.h`
* `users/USER/rgblight_breathe_table.h`
* `quantum/rgblight_breathe_table.h`

However, the current implementation was wrong, so I fixed it.

### Scope of impact of this PR change

Currently, there are only two custom rgblight_breathe_table.h

* `users/drashna/rgblight_breathe_table.h`
* `users/curry/rgblight_breathe_table.h`

At first glance, `curry` does not seem to be alive at present. The following command will result in an error regardless of this PR.
```
make all:curry
```

Therefore, only `users/drashna` is affected by this PR.  (Tag @drashna)

This PR will be merged into `master`, since the affected area is clear.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
