### PR TITLE
Updated Raw HID docs to clarify packet/report length

### DIFF
--- a/docs/feature_rawhid.md
+++ b/docs/feature_rawhid.md
@@ -29,7 +29,7 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
 }
 ```
 
-`raw_hid_receive` can receive variable size packets from host with maximum length `RAW_EPSIZE`. `raw_hid_send` on the other hand can send packets to host of exactly `RAW_EPSIZE` length, therefore it should be used with data of length `RAW_EPSIZE`.
+`raw_hid_receive` can receive variable size packets from host with maximum length `RAW_EPSIZE` and minimum length of 32 bytes. `raw_hid_send` on the other hand can send packets to host of exactly `RAW_EPSIZE` length, therefore it should be used with data of length `RAW_EPSIZE`.
 
 Make sure to flash raw enabled firmware before proceeding with working on the host side.
 

--- a/docs/feature_rawhid.md
+++ b/docs/feature_rawhid.md
@@ -29,7 +29,7 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
 }
 ```
 
-`raw_hid_receive` can receive variable size packets from host with maximum length `RAW_EPSIZE` and minimum length of 32 bytes. `raw_hid_send` on the other hand can send packets to host of exactly `RAW_EPSIZE` length, therefore it should be used with data of length `RAW_EPSIZE`.
+These two functions can receive and send respectively packets from and to the host with length `RAW_EPSIZE` bytes (32 on LUFA/ChibiOS/V-USB, 64 on ATSAM).
 
 Make sure to flash raw enabled firmware before proceeding with working on the host side.
 

--- a/docs/feature_rawhid.md
+++ b/docs/feature_rawhid.md
@@ -29,7 +29,7 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
 }
 ```
 
-These two functions can receive and send respectively packets from and to the host with length `RAW_EPSIZE` bytes (32 on LUFA/ChibiOS/V-USB, 64 on ATSAM).
+These two functions send and receive packets of length `RAW_EPSIZE` bytes to and from the host (32 on LUFA/ChibiOS/V-USB, 64 on ATSAM).
 
 Make sure to flash raw enabled firmware before proceeding with working on the host side.
 

--- a/tmk_core/protocol/arm_atsam/usb/udi_hid_kbd.c
+++ b/tmk_core/protocol/arm_atsam/usb/udi_hid_kbd.c
@@ -722,7 +722,6 @@ static void udi_hid_raw_setreport_valid(void) {}
 
 void raw_hid_send(uint8_t *data, uint8_t length) {
     if (main_b_raw_enable && !udi_hid_raw_b_report_trans_ongoing && length == UDI_HID_RAW_REPORT_SIZE) {
-        memset(udi_hid_raw_report, 0, UDI_HID_RAW_REPORT_SIZE);
         memcpy(udi_hid_raw_report, data, UDI_HID_RAW_REPORT_SIZE);
         udi_hid_raw_send_report();
     }

--- a/tmk_core/protocol/arm_atsam/usb/udi_hid_kbd.c
+++ b/tmk_core/protocol/arm_atsam/usb/udi_hid_kbd.c
@@ -722,6 +722,7 @@ static void udi_hid_raw_setreport_valid(void) {}
 
 void raw_hid_send(uint8_t *data, uint8_t length) {
     if (main_b_raw_enable && !udi_hid_raw_b_report_trans_ongoing && length == UDI_HID_RAW_REPORT_SIZE) {
+        memset(udi_hid_raw_report, 0, UDI_HID_RAW_REPORT_SIZE);
         memcpy(udi_hid_raw_report, data, UDI_HID_RAW_REPORT_SIZE);
         udi_hid_raw_send_report();
     }
@@ -738,8 +739,8 @@ bool udi_hid_raw_receive_report(void) {
 static void udi_hid_raw_report_rcvd(udd_ep_status_t status, iram_size_t nb_rcvd, udd_ep_id_t ep) {
     UNUSED(ep);
 
-    if (status == UDD_EP_TRANSFER_OK && nb_rcvd <= UDI_HID_RAW_REPORT_SIZE) {
-        UDI_HID_RAW_RECEIVE(udi_hid_raw_report_recv, UDI_HID_RAW_REPORT_SIZE);
+    if (status == UDD_EP_TRANSFER_OK) {
+        UDI_HID_RAW_RECEIVE(udi_hid_raw_report_recv, (uint8_t)nb_rcvd);
     }
 }
 

--- a/tmk_core/protocol/arm_atsam/usb/udi_hid_kbd.c
+++ b/tmk_core/protocol/arm_atsam/usb/udi_hid_kbd.c
@@ -738,7 +738,7 @@ bool udi_hid_raw_receive_report(void) {
 static void udi_hid_raw_report_rcvd(udd_ep_status_t status, iram_size_t nb_rcvd, udd_ep_id_t ep) {
     UNUSED(ep);
 
-    if (status == UDD_EP_TRANSFER_OK) {
+    if (status == UDD_EP_TRANSFER_OK && nb_rcvd >= 32) {
         UDI_HID_RAW_RECEIVE(udi_hid_raw_report_recv, (uint8_t)nb_rcvd);
     }
 }

--- a/tmk_core/protocol/arm_atsam/usb/udi_hid_kbd.c
+++ b/tmk_core/protocol/arm_atsam/usb/udi_hid_kbd.c
@@ -738,7 +738,7 @@ bool udi_hid_raw_receive_report(void) {
 static void udi_hid_raw_report_rcvd(udd_ep_status_t status, iram_size_t nb_rcvd, udd_ep_id_t ep) {
     UNUSED(ep);
 
-    if (status == UDD_EP_TRANSFER_OK && nb_rcvd == UDI_HID_RAW_REPORT_SIZE) {
+    if (status == UDD_EP_TRANSFER_OK && nb_rcvd <= UDI_HID_RAW_REPORT_SIZE) {
         UDI_HID_RAW_RECEIVE(udi_hid_raw_report_recv, UDI_HID_RAW_REPORT_SIZE);
     }
 }

--- a/tmk_core/protocol/arm_atsam/usb/udi_hid_kbd.c
+++ b/tmk_core/protocol/arm_atsam/usb/udi_hid_kbd.c
@@ -738,8 +738,8 @@ bool udi_hid_raw_receive_report(void) {
 static void udi_hid_raw_report_rcvd(udd_ep_status_t status, iram_size_t nb_rcvd, udd_ep_id_t ep) {
     UNUSED(ep);
 
-    if (status == UDD_EP_TRANSFER_OK && nb_rcvd >= 32) {
-        UDI_HID_RAW_RECEIVE(udi_hid_raw_report_recv, (uint8_t)nb_rcvd);
+    if (status == UDD_EP_TRANSFER_OK && nb_rcvd == UDI_HID_RAW_REPORT_SIZE) {
+        UDI_HID_RAW_RECEIVE(udi_hid_raw_report_recv, UDI_HID_RAW_REPORT_SIZE);
     }
 }
 


### PR DESCRIPTION
## Description


The issue stems from the documentation mentioning the following:

```
`raw_hid_receive` can receive variable size packets from host with maximum length `RAW_EPSIZE`.
```

However, the current implementation of the `udi_hid_raw_report_rcvd` is that the incoming report needs to be `UDI_HID_RAW_REPORT_SIZE` otherwise it is ignored and thrown away. @fauxpark pointed out this out as I was having difficulties having my keyboard respond to the data I was sending it.

## Types of Changes


- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
