### PR TITLE
Add support to Kyria for the 2 x 2u layout

### DIFF
--- a/keyboards/kyria/kyria.h
+++ b/keyboards/kyria/kyria.h
@@ -64,7 +64,7 @@
     { R45,   R46,   R47,   R48,   R49,   KC_NO, KC_NO, KC_NO }, \
 }
 
-#define LAYOUT_2x2u( \
+#define LAYOUT_split_3x6_5( \
     L00, L01, L02, L03, L04, L05,                     R06, R07, R08, R09, R10, R11, \
     L12, L13, L14, L15, L16, L17,                     R18, R19, R20, R21, R22, R23, \
     L24, L25, L26, L27, L28, L29,                     R34, R35, R36, R37, R38, R39, \

--- a/keyboards/kyria/kyria.h
+++ b/keyboards/kyria/kyria.h
@@ -63,3 +63,20 @@
     { R32,   R33,   R34,   R35,   R36,   R37,   R38,   R39   }, \
     { R45,   R46,   R47,   R48,   R49,   KC_NO, KC_NO, KC_NO }, \
 }
+
+#define LAYOUT_2x2u( \
+    L00, L01, L02, L03, L04, L05,                     R06, R07, R08, R09, R10, R11, \
+    L12, L13, L14, L15, L16, L17,                     R18, R19, R20, R21, R22, R23, \
+    L24, L25, L26, L27, L28, L29,                     R34, R35, R36, R37, R38, R39, \
+                   L40, L41, L42, L43, L44, R45, R46, R47, R48, R49 \
+) \
+{ \
+    { KC_NO, KC_NO, L05,   L04,   L03,   L02,   L01,   L00   }, \
+    { KC_NO, KC_NO, L17,   L16,   L15,   L14,   L13,   L12   }, \
+    { KC_NO, KC_NO, L29,   L28,   L27,   L26,   L25,   L24   }, \
+    { L44,   L43,   L42,   L41,   L40,   KC_NO, KC_NO, KC_NO }, \
+    { KC_NO, KC_NO, R06,   R07,   R08,   R09,   R10,   R11   }, \
+    { KC_NO, KC_NO, R18,   R19,   R20,   R21,   R22,   R23   }, \
+    { KC_NO, KC_NO, R34,   R35,   R36,   R37,   R38,   R39   }, \
+    { R45,   R46,   R47,   R48,   R49,   KC_NO, KC_NO, KC_NO }, \
+}


### PR DESCRIPTION
## Description

This adds a macro to support the 2 x 2u layout which facilitates
a cleaner looking layout configuration for the people using it.

I did check with Thomas beforehand and he seemed fine with this addition.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
