### PR TITLE
[Keymap] fix keyboards/helix/rev2/keymaps/default/oled_display.c

### DIFF
--- a/keyboards/helix/rev2/keymaps/default/oled_display.c
+++ b/keyboards/helix/rev2/keymaps/default/oled_display.c
@@ -135,6 +135,7 @@ static void render_layer_status(void) {
         snprintf(buf,sizeof(buf), "%ld", layer_state);
         oled_write(buf, false);
     }
+    oled_write_P(PSTR("\n"), false);
 }
 
 #    ifdef SSD1306OLED
@@ -160,7 +161,6 @@ void render_status(void) {
 #    else
     render_layer_status();
 #    endif
-    oled_write_P(PSTR("\n"), false);
 
     // Host Keyboard LED Status
     led_t led_state = host_keyboard_led_state();


### PR DESCRIPTION
## Description

In the `helix:default` keymap, the OLED display on the right side was showing garbage, which has been fixed.
`helix:default`の右側のOLEDディスプレイにゴミが表示されていたのを修正しました。

@MakotoKurauchi, could you please review this? 
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
