### PR TITLE
Fix wrong key(music), when "Music Map" is used with MAJOR_MODE.

### DIFF
--- a/quantum/process_keycode/process_music.c
+++ b/quantum/process_keycode/process_music.c
@@ -191,7 +191,7 @@ bool process_music(uint16_t keycode, keyrecord_t *record) {
             note = music_starting_note + music_offset + 36 + music_map[record->event.key.row][record->event.key.col];
         } else {
             uint8_t position = music_map[record->event.key.row][record->event.key.col];
-            note             = music_starting_note + music_offset + 36 + SCALE[position % 12] + (position / 12) * 12;
+            note             = music_starting_note + music_offset + 36 + SCALE[position % 7] + (position / 7) * 12;
         }
 #    else
         if (music_mode == MUSIC_MODE_CHROMATIC)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

When "Music Map" is used with MAJOR_MODE, key(music) rolls back 5th lower at each position of multiple of 12 in music_map.

When positions are set in music_map as below :

```
 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14 ...
```

Expected keys :

```
C0, D0, E0, F0, G0, A0, B0, C1, D1, E1, F1, G1, A1, B1, C2 ...
```

Actual keys (BUG):

```
C0, D0, E0, F0, G0, A0, B0, C1, D1, E1, F1, G1, C1, D1, E1 ...
```

At position 12, key rolls back 5th lower, A1 --> C1.  
This happens at each position of multiple of 12. (12, 24, 36 ...)

With MAJOR_MODE (= major scale), keys in one octave is not 12 but 7.  
So, change divisor number from 12 to 7 at %(Modulo) and /(Division) to solve this issue.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ x ] Core
- [ x ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* none

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ x ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ x ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
