### PR TITLE
Follow symlinks when listing keyboards.

### DIFF
--- a/util/list_keyboards.sh
+++ b/util/list_keyboards.sh
@@ -3,8 +3,8 @@
 #
 # This allows us to exclude keyboards by including a .noci file.
 
-find keyboards -type f -name rules.mk | grep -v keymaps | while read keyboard; do
-	keyboard=$(echo $keyboard | sed 's!keyboards/\(.*\)/rules.mk!\1!') 
+find -L keyboards -type f -name rules.mk | grep -v keymaps | while read keyboard; do
+	keyboard=$(echo $keyboard | sed 's!keyboards/\(.*\)/rules.mk!\1!')
 
 	[ "$1" = "noci" -a -e "keyboards/${keyboard}/.noci" ] || echo "$keyboard"
 done


### PR DESCRIPTION
## Description

The recent change to getting the list of keyboards broke instances where they get injected via symlink.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
