### PR TITLE
Add convenience method for setting NIbble's big LED RGB

### DIFF
--- a/keyboards/nullbitsco/nibble/big_led.c
+++ b/keyboards/nullbitsco/nibble/big_led.c
@@ -15,6 +15,12 @@
  */
 #include "big_led.h"
 
+void set_big_LED_rgb(uint8_t r_mode, uint8_t g_mode, uint8_t b_mode) {
+    set_big_LED_r(r_mode);
+    set_big_LED_g(g_mode);
+    set_big_LED_b(b_mode);
+}
+
 void set_big_LED_r(uint8_t mode) {
     switch(mode) {
         case LED_ON:

--- a/keyboards/nullbitsco/nibble/big_led.h
+++ b/keyboards/nullbitsco/nibble/big_led.h
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include "quantum.h" 
+#include "quantum.h"
 
 /* Optional big LED pins */
 #define BIG_LED_R_PIN D7
@@ -29,6 +29,7 @@
 #define GPIO_STATE_HIGH 1
 
 void
+  set_big_LED_rgb(uint8_t r_mode, uint8_t g_mode, uint8_t b_mode),
   set_big_LED_r(uint8_t mode),
   set_big_LED_g(uint8_t mode),
   set_big_LED_b(uint8_t mode);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->
I wrote a simple convenience method for the Nibble's big LED to make setting custom RGB combos easier, and figured I'd upstream it.

## Description

Currently the Nibble provides three methods in `big_led.h`: `set_big_LED_r`, `set_big_LED_g` and `set_big_LED_b`. If you want to turn on two of these, it's a bit annoying that you have to call two methods, so I wrote `set_big_LED_rgb` as a convenience method to delegate this out.
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
