### PR TITLE
Add support for out-of-tree userspace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -355,7 +355,12 @@ define PARSE_KEYBOARD
     # Look for out-of-tree keymaps
     # Both keyboard- and layout-specific keymaps are supported
     ifneq ("$(EXTERNAL_USERSPACE)", "")
-        EXT_KEYMAPS := $$(notdir $$(patsubst %/.,%,$$(wildcard $(EXTERNAL_USERSPACE)/keyboards/$$(CURRENT_KB)/*/.)))
+        EXT_KEYMAPS :=
+        EXT_KEYMAPS += $$(notdir $$(patsubst %/.,%,$$(wildcard $(EXTERNAL_USERSPACE)/keyboards/$$(KEYBOARD_FOLDER_PATH_1)/*/.)))
+        EXT_KEYMAPS += $$(notdir $$(patsubst %/.,%,$$(wildcard $(EXTERNAL_USERSPACE)/keyboards/$$(KEYBOARD_FOLDER_PATH_2)/*/.)))
+        EXT_KEYMAPS += $$(notdir $$(patsubst %/.,%,$$(wildcard $(EXTERNAL_USERSPACE)/keyboards/$$(KEYBOARD_FOLDER_PATH_3)/*/.)))
+        EXT_KEYMAPS += $$(notdir $$(patsubst %/.,%,$$(wildcard $(EXTERNAL_USERSPACE)/keyboards/$$(KEYBOARD_FOLDER_PATH_4)/*/.)))
+        EXT_KEYMAPS += $$(notdir $$(patsubst %/.,%,$$(wildcard $(EXTERNAL_USERSPACE)/keyboards/$$(KEYBOARD_FOLDER_PATH_5)/*/.)))
 
         EXT_LAYOUT_KEYMAPS :=
         $$(foreach LAYOUT,$$(KEYBOARD_LAYOUTS),$$(eval EXT_LAYOUT_KEYMAPS += $$(notdir $$(patsubst %/.,%,$$(wildcard $(EXTERNAL_USERSPACE)/layouts/$$(LAYOUT)/*/.)))))

--- a/Makefile
+++ b/Makefile
@@ -352,7 +352,16 @@ define PARSE_KEYBOARD
     LAYOUT_KEYMAPS :=
     $$(foreach LAYOUT,$$(KEYBOARD_LAYOUTS),$$(eval LAYOUT_KEYMAPS += $$(notdir $$(patsubst %/.,%,$$(wildcard $(ROOT_DIR)/layouts/*/$$(LAYOUT)/*/.)))))
 
-    KEYMAPS := $$(sort $$(KEYMAPS) $$(LAYOUT_KEYMAPS))
+    # Look for out-of-tree keymaps
+    # Both keyboard- and layout-specific keymaps are supported
+    ifneq ("$(EXTERNAL_USERSPACE)", "")
+        EXT_KEYMAPS := $$(notdir $$(patsubst %/.,%,$$(wildcard $(EXTERNAL_USERSPACE)/keyboards/$$(CURRENT_KB)/keymaps/*/.)))
+
+        EXT_LAYOUT_KEYMAPS :=
+        $$(foreach LAYOUT,$$(KEYBOARD_LAYOUTS),$$(eval EXT_LAYOUT_KEYMAPS += $$(notdir $$(patsubst %/.,%,$$(wildcard $(EXTERNAL_USERSPACE)/layouts/$$(LAYOUT)/*/.)))))
+    endif
+
+    KEYMAPS := $$(sort $$(KEYMAPS) $$(LAYOUT_KEYMAPS) $$(EXT_KEYMAPS) $$(EXT_LAYOUT_KEYMAPS))
 
     # if the rule after removing the start of it is empty (we haven't specified a kemap or target)
     # compile all the keymaps

--- a/Makefile
+++ b/Makefile
@@ -355,7 +355,7 @@ define PARSE_KEYBOARD
     # Look for out-of-tree keymaps
     # Both keyboard- and layout-specific keymaps are supported
     ifneq ("$(EXTERNAL_USERSPACE)", "")
-        EXT_KEYMAPS := $$(notdir $$(patsubst %/.,%,$$(wildcard $(EXTERNAL_USERSPACE)/keyboards/$$(CURRENT_KB)/keymaps/*/.)))
+        EXT_KEYMAPS := $$(notdir $$(patsubst %/.,%,$$(wildcard $(EXTERNAL_USERSPACE)/keyboards/$$(CURRENT_KB)/*/.)))
 
         EXT_LAYOUT_KEYMAPS :=
         $$(foreach LAYOUT,$$(KEYBOARD_LAYOUTS),$$(eval EXT_LAYOUT_KEYMAPS += $$(notdir $$(patsubst %/.,%,$$(wildcard $(EXTERNAL_USERSPACE)/layouts/$$(LAYOUT)/*/.)))))

--- a/build_json.mk
+++ b/build_json.mk
@@ -51,6 +51,10 @@ endif
 # Load the keymap-level rules.mk if exists
 ifneq ("$(wildcard $(KEYMAP_PATH))", "")
     -include $(KEYMAP_PATH)/rules.mk
+    # If EXT_SRC exists, add all files to SRC with the EXT_KM_PATH prefix so make can find it
+    ifneq ($(EXT_SRC), )
+        $(foreach SOURCE, $(EXT_SRC), $(eval SRC += $(KEYMAP_PATH)/$(SOURCE)))
+    endif
 endif
 
 # Generate the keymap.c

--- a/build_json.mk
+++ b/build_json.mk
@@ -1,24 +1,36 @@
-# Look for a json keymap file
-ifneq ("$(wildcard $(MAIN_KEYMAP_PATH_5)/keymap.json)","")
-    KEYMAP_C := $(KEYBOARD_OUTPUT)/src/keymap.c
-    KEYMAP_JSON := $(MAIN_KEYMAP_PATH_5)/keymap.json
-    KEYMAP_PATH := $(MAIN_KEYMAP_PATH_5)
-else ifneq ("$(wildcard $(MAIN_KEYMAP_PATH_4)/keymap.json)","")
-    KEYMAP_C := $(KEYBOARD_OUTPUT)/src/keymap.c
-    KEYMAP_JSON := $(MAIN_KEYMAP_PATH_4)/keymap.json
-    KEYMAP_PATH := $(MAIN_KEYMAP_PATH_4)
-else ifneq ("$(wildcard $(MAIN_KEYMAP_PATH_3)/keymap.json)","")
-    KEYMAP_C := $(KEYBOARD_OUTPUT)/src/keymap.c
-    KEYMAP_JSON := $(MAIN_KEYMAP_PATH_3)/keymap.json
-    KEYMAP_PATH := $(MAIN_KEYMAP_PATH_3)
-else ifneq ("$(wildcard $(MAIN_KEYMAP_PATH_2)/keymap.json)","")
-    KEYMAP_C := $(KEYBOARD_OUTPUT)/src/keymap.c
-    KEYMAP_JSON := $(MAIN_KEYMAP_PATH_2)/keymap.json
-    KEYMAP_PATH := $(MAIN_KEYMAP_PATH_2)
-else ifneq ("$(wildcard $(MAIN_KEYMAP_PATH_1)/keymap.json)","")
-    KEYMAP_C := $(KEYBOARD_OUTPUT)/src/keymap.c
-    KEYMAP_JSON := $(MAIN_KEYMAP_PATH_1)/keymap.json
-    KEYMAP_PATH := $(MAIN_KEYMAP_PATH_1)
+ifneq ($(EXTERNAL_USERSPACE),)
+    # Look for out-of-tree json keymap file
+    EXT_KM_PATH := $(EXTERNAL_USERSPACE)/keyboards/$(KEYBOARD)/keymaps/$(KEYMAP)
+    ifneq ("$(wildcard $(EXT_KM_PATH)/keymap.json)", "")
+        KEYMAP_C := $(KEYBOARD_OUTPUT)/src/keymap.c
+        KEYMAP_JSON := $(EXT_KM_PATH)/keymap.json
+        KEYMAP_PATH := $(EXT_KM_PATH)
+    endif
+endif
+
+ifeq ("$(wildcard $(KEYMAP_PATH))", "")
+    # Look for in-tree json keymap file
+    ifneq ("$(wildcard $(MAIN_KEYMAP_PATH_5)/keymap.json)","")
+        KEYMAP_C := $(KEYBOARD_OUTPUT)/src/keymap.c
+        KEYMAP_JSON := $(MAIN_KEYMAP_PATH_5)/keymap.json
+        KEYMAP_PATH := $(MAIN_KEYMAP_PATH_5)
+    else ifneq ("$(wildcard $(MAIN_KEYMAP_PATH_4)/keymap.json)","")
+        KEYMAP_C := $(KEYBOARD_OUTPUT)/src/keymap.c
+        KEYMAP_JSON := $(MAIN_KEYMAP_PATH_4)/keymap.json
+        KEYMAP_PATH := $(MAIN_KEYMAP_PATH_4)
+    else ifneq ("$(wildcard $(MAIN_KEYMAP_PATH_3)/keymap.json)","")
+        KEYMAP_C := $(KEYBOARD_OUTPUT)/src/keymap.c
+        KEYMAP_JSON := $(MAIN_KEYMAP_PATH_3)/keymap.json
+        KEYMAP_PATH := $(MAIN_KEYMAP_PATH_3)
+    else ifneq ("$(wildcard $(MAIN_KEYMAP_PATH_2)/keymap.json)","")
+        KEYMAP_C := $(KEYBOARD_OUTPUT)/src/keymap.c
+        KEYMAP_JSON := $(MAIN_KEYMAP_PATH_2)/keymap.json
+        KEYMAP_PATH := $(MAIN_KEYMAP_PATH_2)
+    else ifneq ("$(wildcard $(MAIN_KEYMAP_PATH_1)/keymap.json)","")
+        KEYMAP_C := $(KEYBOARD_OUTPUT)/src/keymap.c
+        KEYMAP_JSON := $(MAIN_KEYMAP_PATH_1)/keymap.json
+        KEYMAP_PATH := $(MAIN_KEYMAP_PATH_1)
+    endif
 endif
 
 # Load the keymap-level rules.mk if exists

--- a/build_json.mk
+++ b/build_json.mk
@@ -1,10 +1,25 @@
-ifneq ($(EXTERNAL_USERSPACE),)
+ifneq ($(EXTERNAL_USERSPACE), )
     # Look for out-of-tree json keymap file
-    EXT_KM_PATH := $(EXTERNAL_USERSPACE)/keyboards/$(KEYBOARD)/keymaps/$(KEYMAP)
-    ifneq ("$(wildcard $(EXT_KM_PATH)/keymap.json)", "")
+    ifneq ("$(wildcard $(EXTERNAL_USERSPACE)/keyboards/$(KEYBOARD_FOLDER_PATH_5)/$(KEYMAP)/keymap.json)", "")
         KEYMAP_C := $(KEYBOARD_OUTPUT)/src/keymap.c
-        KEYMAP_JSON := $(EXT_KM_PATH)/keymap.json
-        KEYMAP_PATH := $(EXT_KM_PATH)
+        KEYMAP_JSON := $(EXTERNAL_USERSPACE)/keyboards/$(KEYBOARD_FOLDER_PATH_5)/$(KEYMAP)/keymap.json
+        KEYMAP_PATH := $(EXTERNAL_USERSPACE)/keyboards/$(KEYBOARD_FOLDER_PATH_5)/$(KEYMAP)
+    else ifneq ("$(wildcard $(EXTERNAL_USERSPACE)/keyboards/$(KEYBOARD_FOLDER_PATH_4)/$(KEYMAP)/keymap.json)", "")
+        KEYMAP_C := $(KEYBOARD_OUTPUT)/src/keymap.c
+        KEYMAP_JSON := $(EXTERNAL_USERSPACE)/keyboards/$(KEYBOARD_FOLDER_PATH_4)/$(KEYMAP)/keymap.json
+        KEYMAP_PATH := $(EXTERNAL_USERSPACE)/keyboards/$(KEYBOARD_FOLDER_PATH_4)/$(KEYMAP)
+    else ifneq ("$(wildcard $(EXTERNAL_USERSPACE)/keyboards/$(KEYBOARD_FOLDER_PATH_3)/$(KEYMAP)/keymap.json)", "")
+        KEYMAP_C := $(KEYBOARD_OUTPUT)/src/keymap.c
+        KEYMAP_JSON := $(EXTERNAL_USERSPACE)/keyboards/$(KEYBOARD_FOLDER_PATH_3)/$(KEYMAP)/keymap.json
+        KEYMAP_PATH := $(EXTERNAL_USERSPACE)/keyboards/$(KEYBOARD_FOLDER_PATH_3)/$(KEYMAP)
+    else ifneq ("$(wildcard $(EXTERNAL_USERSPACE)/keyboards/$(KEYBOARD_FOLDER_PATH_2)/$(KEYMAP)/keymap.json)", "")
+        KEYMAP_C := $(KEYBOARD_OUTPUT)/src/keymap.c
+        KEYMAP_JSON := $(EXTERNAL_USERSPACE)/keyboards/$(KEYBOARD_FOLDER_PATH_2)/$(KEYMAP)/keymap.json
+        KEYMAP_PATH := $(EXTERNAL_USERSPACE)/keyboards/$(KEYBOARD_FOLDER_PATH_2)/$(KEYMAP)
+    else ifneq ("$(wildcard $(EXTERNAL_USERSPACE)/keyboards/$(KEYBOARD_FOLDER_PATH_1)/$(KEYMAP)/keymap.json)", "")
+        KEYMAP_C := $(KEYBOARD_OUTPUT)/src/keymap.c
+        KEYMAP_JSON := $(EXTERNAL_USERSPACE)/keyboards/$(KEYBOARD_FOLDER_PATH_1)/$(KEYMAP)/keymap.json
+        KEYMAP_PATH := $(EXTERNAL_USERSPACE)/keyboards/$(KEYBOARD_FOLDER_PATH_1)/$(KEYMAP)
     endif
 endif
 

--- a/build_keyboard.mk
+++ b/build_keyboard.mk
@@ -100,17 +100,32 @@ MAIN_KEYMAP_PATH_5 := $(KEYBOARD_PATH_5)/keymaps/$(KEYMAP)
 # Check for keymap.json first, so we can regenerate keymap.c
 include build_json.mk
 
+
 ifneq ($(EXTERNAL_USERSPACE), )
     # Look for out-of-tree keyboard-specific keymap
-    EXT_KM_PATH := $(EXTERNAL_USERSPACE)/keyboards/$(KEYBOARD)/$(KEYMAP)
-    ifneq ("$(wildcard $(EXT_KM_PATH)/keymap.c)", "")
-        -include $(EXT_KM_PATH)/rules.mk
+    ifneq ("$(wildcard $(EXTERNAL_USERSPACE)/keyboards/$(KEYBOARD_FOLDER_PATH_5)/$(KEYMAP)/keymap.c)", "")
+        KEYMAP_PATH := $(EXTERNAL_USERSPACE)/keyboards/$(KEYBOARD_FOLDER_PATH_5)/$(KEYMAP)
+        KEYMAP_C := $(EXTERNAL_USERSPACE)/keyboards/$(KEYBOARD_FOLDER_PATH_5)/$(KEYMAP)/keymap.c
+    else ifneq ("$(wildcard $(EXTERNAL_USERSPACE)/keyboards/$(KEYBOARD_FOLDER_PATH_4)/$(KEYMAP)/keymap.c)", "")
+        KEYMAP_PATH := $(EXTERNAL_USERSPACE)/keyboards/$(KEYBOARD_FOLDER_PATH_4)/$(KEYMAP)
+        KEYMAP_C := $(EXTERNAL_USERSPACE)/keyboards/$(KEYBOARD_FOLDER_PATH_4)/$(KEYMAP)/keymap.c
+    else ifneq ("$(wildcard $(EXTERNAL_USERSPACE)/keyboards/$(KEYBOARD_FOLDER_PATH_3)/$(KEYMAP)/keymap.c)", "")
+        KEYMAP_PATH := $(EXTERNAL_USERSPACE)/keyboards/$(KEYBOARD_FOLDER_PATH_3)/$(KEYMAP)
+        KEYMAP_C := $(EXTERNAL_USERSPACE)/keyboards/$(KEYBOARD_FOLDER_PATH_3)/$(KEYMAP)/keymap.c
+    else ifneq ("$(wildcard $(EXTERNAL_USERSPACE)/keyboards/$(KEYBOARD_FOLDER_PATH_2)/$(KEYMAP)/keymap.c)", "")
+        KEYMAP_PATH := $(EXTERNAL_USERSPACE)/keyboards/$(KEYBOARD_FOLDER_PATH_2)/$(KEYMAP)
+        KEYMAP_C := $(EXTERNAL_USERSPACE)/keyboards/$(KEYBOARD_FOLDER_PATH_2)/$(KEYMAP)/keymap.c
+    else ifneq ("$(wildcard $(EXTERNAL_USERSPACE)/keyboards/$(KEYBOARD_FOLDER_PATH_1)/$(KEYMAP)/keymap.c)", "")
+        KEYMAP_PATH := $(EXTERNAL_USERSPACE)/keyboards/$(KEYBOARD_FOLDER_PATH_1)/$(KEYMAP)
+        KEYMAP_C := $(EXTERNAL_USERSPACE)/keyboards/$(KEYBOARD_FOLDER_PATH_1)/$(KEYMAP)/keymap.c
+    endif
+
+    ifneq ("$(wildcard $(KEYMAP_PATH))", "")
+        -include $(KEYMAP_PATH)/rules.mk
         # If EXT_SRC exists, add all files to SRC with the EXT_KM_PATH prefix so make can find it
         ifneq ($(EXT_SRC), )
-            $(foreach SOURCE, $(EXT_SRC), $(eval SRC += $(EXT_KM_PATH)/$(SOURCE)))
+            $(foreach SOURCE, $(EXT_SRC), $(eval SRC += $(KEYMAP_PATH)/$(SOURCE)))
         endif
-        KEYMAP_PATH := $(EXT_KM_PATH)
-        KEYMAP_C := $(EXT_KM_PATH)/keymap.c
     endif
 endif
 

--- a/build_keyboard.mk
+++ b/build_keyboard.mk
@@ -100,6 +100,20 @@ MAIN_KEYMAP_PATH_5 := $(KEYBOARD_PATH_5)/keymaps/$(KEYMAP)
 # Check for keymap.json first, so we can regenerate keymap.c
 include build_json.mk
 
+ifneq ($(EXTERNAL_USERSPACE), )
+    # Look for out-of-tree keyboard-specific keymap
+    EXT_KM_PATH := $(EXTERNAL_USERSPACE)/keyboards/$(KEYBOARD)/keymaps/$(KEYMAP)
+    ifneq ("$(wildcard $(EXT_KM_PATH)/keymap.c)", "")
+        -include $(EXT_KM_PATH)/rules.mk
+        # If EXT_SRC exists, add all files to SRC with the EXT_KM_PATH prefix so make can find it
+        ifneq ($(EXT_SRC), )
+            $(foreach SOURCE, $(EXT_SRC), $(eval SRC += $(EXT_KM_PATH)/$(SOURCE)))
+        endif
+        KEYMAP_PATH := $(EXT_KM_PATH)
+        KEYMAP_C := $(EXT_KM_PATH)/keymap.c
+    endif
+endif
+
 ifeq ("$(wildcard $(KEYMAP_PATH))", "")
     # Look through the possible keymap folders until we find a matching keymap.c
     ifneq ("$(wildcard $(MAIN_KEYMAP_PATH_5)/keymap.c)","")
@@ -281,6 +295,19 @@ USER_PATH := users/$(USER_NAME)
 -include $(USER_PATH)/rules.mk
 ifneq ("$(wildcard $(USER_PATH)/config.h)","")
     CONFIG_H += $(USER_PATH)/config.h
+endif
+
+ifneq ($(EXTERNAL_USERSPACE), )
+    # Look for out-of-tree userspace stuff, if set up
+    COMMON_PATH := $(EXTERNAL_USERSPACE)/common
+    -include $(COMMON_PATH)/rules.mk
+    # If EXT_SRC exists, add all files to SRC with the EXT_KM_PATH prefix so make can find it
+    ifneq ($(EXT_SRC), )
+        $(foreach SOURCE, $(EXT_SRC), $(eval SRC += $(COMMON_PATH)/$(SOURCE))) 
+    endif
+    ifneq ("$(wildcard $(COMMON_PATH)/config.h)","")
+        CONFIG_H += $(COMMON_PATH)/config.h
+    endif
 endif
 
 # Object files directory

--- a/build_keyboard.mk
+++ b/build_keyboard.mk
@@ -102,7 +102,7 @@ include build_json.mk
 
 ifneq ($(EXTERNAL_USERSPACE), )
     # Look for out-of-tree keyboard-specific keymap
-    EXT_KM_PATH := $(EXTERNAL_USERSPACE)/keyboards/$(KEYBOARD)/keymaps/$(KEYMAP)
+    EXT_KM_PATH := $(EXTERNAL_USERSPACE)/keyboards/$(KEYBOARD)/$(KEYMAP)
     ifneq ("$(wildcard $(EXT_KM_PATH)/keymap.c)", "")
         -include $(EXT_KM_PATH)/rules.mk
         # If EXT_SRC exists, add all files to SRC with the EXT_KM_PATH prefix so make can find it

--- a/build_layout.mk
+++ b/build_layout.mk
@@ -1,5 +1,11 @@
+# Load the out-of-tree layout-specific keymap, if requested
+ifneq ($(EXTERNAL_USERSPACE),)
+    LAYOUTS_PATH := $(EXTERNAL_USERSPACE)/layouts
+    LAYOUTS_REPOS := $(patsubst %/,%,$(sort $(dir $(wildcard $(LAYOUTS_PATH)/))))
+endif
+
 LAYOUTS_PATH := layouts
-LAYOUTS_REPOS := $(patsubst %/,%,$(sort $(dir $(wildcard $(LAYOUTS_PATH)/*/))))
+LAYOUTS_REPOS += $(patsubst %/,%,$(sort $(dir $(wildcard $(LAYOUTS_PATH)/*/))))
 
 define SEARCH_LAYOUTS_REPO
     LAYOUT_KEYMAP_PATH := $$(LAYOUTS_REPO)/$$(LAYOUT)/$$(KEYMAP)

--- a/docs/_summary.md
+++ b/docs/_summary.md
@@ -87,6 +87,7 @@
     * [Terminal](feature_terminal.md)
     * [Unicode](feature_unicode.md)
     * [Userspace](feature_userspace.md)
+    * [External Userspace](feature_external_userspace.md)
     * [WPM Calculation](feature_wpm.md)
 
   * Hardware Features

--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -312,6 +312,8 @@ This is a [make](https://www.gnu.org/software/make/manual/make.html) file that i
   * Defines which format (bin, hex) is copied to the root `qmk_firmware` folder after building.
 * `SRC`
   * Used to add files to the compilation/linking list.
+* `EXT_SRC`
+  * Used to add files to the compilation/linking list. (used with [External Userspace](feature_external_userspace.md))
 * `LIB_SRC`
   * Used to add files as a library to the compilation/linking list.  
     The files specified by `LIB_SRC` is linked after the files specified by `SRC`.  

--- a/docs/feature_external_userspace.md
+++ b/docs/feature_external_userspace.md
@@ -1,0 +1,69 @@
+# External Userspace: Store your code outside the QMK repo
+
+Store your [keymaps](keymap.md),  [community layouts](feature_layouts.md) and [userspace](feature_userspace.md) outside the `qmk_firmware` repository and automatically link it during build time.
+This allows you to store your code in a separate `git` repository and manage it separately.
+Updating the QMK repo should be easier as well, as the chance of code conflict is basically non-existent.
+
+## Directory structure
+*Note*: all directories and files are optional, create only what you actually need
+
+* `/my_qmk_stuff/` (put it anywhere you'd like and name is whatever you want (no whitespaces, please))
+  * `common/` (content will be always included, equivalent of [userspace](feature_userspace.md)))
+    * `rules.mk`
+    * `config.h`
+    * `<name>.h`
+    * `<name>.c`
+    * `cool_rgb_stuff.c`
+    * `cool_rgb_stuff.h`
+  * `keyboards/` (keyboard-specific [keymaps](keymap.md))
+    * `planck/`
+      * `my_planck_keymap/` (keymaps for all Planck revisions)
+        * `keymap.c`
+        * `config.h`
+      * `rev6` (keymaps only for the `planck/rev6`)
+        * `my_rev6_keymap/`
+          * `keymap.json`
+          * `rules.mk` 
+  * `layouts/` (layout specific keymaps, equivalent of [community layouts](feature_layouts.md))
+    * `ortho_4x12/`
+      * `my_grid_keymap/`
+        * `keymap.c`
+
+## Configuration
+
+    qmk config user.userspace=/path/to/external_userspace
+
+**Note**: It's important to specify absolute path.
+
+*Example*: I created my external userspace in `/home/erovia/qmk/my_qmk_stuff`, so I have to run this command:
+
+    qmk config user.userspace=/home/erovia/qmk/my_qmk/stuff
+
+`qmk doctor` will check if the directory exists and if the provided path is an absolute one.
+
+## Additional source files
+
+You can add additional source files to the compilation with the EXT_SRC option, which is very similar to [SRC](config_options?id=build-options) used in in-tree keymaps.
+You need to add the EXT_SRC in `rules.mk` like this:
+
+    EXT_SRC += <filename>.c
+
+Additional files may be added in the same way.
+
+Similarly to [userspace](feature_userspace.md), the `common/rules.mk` file will be included in the build _after_ the `rules.mk` from your keymap. This allows you to have features in your userspace `rules.mk` that depend on individual QMK features that may or may not be available on a specific keyboard. 
+
+For example, if you have RGB control features shared between all your keyboards that support RGB lighting, you can add support for that if the RGBLIGHT feature is enabled:
+```make
+ifeq ($(strip $(RGBLIGHT_ENABLE)), yes)
+  # Include my fancy rgb functions source here
+  EXT_SRC += cool_rgb_stuff.c
+endif
+```
+
+Alternatively, you can `define RGB_ENABLE` in your keymap's `rules.mk` and then check for the variable in your userspace's `rules.mk` like this:
+```make
+ifdef RGB_ENABLE
+  # Include my fancy rgb functions source here
+  EXT_SRC += cool_rgb_stuff.c
+endif
+```

--- a/lib/python/qmk/cli/doctor.py
+++ b/lib/python/qmk/cli/doctor.py
@@ -28,6 +28,17 @@ def os_tests():
         return CheckStatus.WARNING
 
 
+def check_userspace():
+    if cli.config.user.userspace:
+        userspace_path = Path(cli.config.user.userspace)
+        if not userspace_path.exists():
+            cli.log.error('External userspace: {fg_red}%s does not exists', userspace_path)
+        elif not userspace_path.is_absolute():
+            cli.log.warning('External userspace: {fg_yellow}%s is not an absolute path', userspace_path)
+        else:
+            cli.log.info('External userspace: {fg_cyan}%s', userspace_path)
+
+
 def os_test_linux():
     """Run the Linux specific tests.
     """
@@ -69,6 +80,7 @@ def doctor(cli):
     status = os_tests()
 
     cli.log.info('QMK home: {fg_cyan}%s', QMK_FIRMWARE)
+    check_userspace()
 
     # Make sure our QMK home is a Git repo
     git_ok = check_git_repo()

--- a/lib/python/qmk/commands.py
+++ b/lib/python/qmk/commands.py
@@ -7,6 +7,8 @@ import subprocess
 import shlex
 import shutil
 
+from milc import cli
+
 import qmk.keymap
 
 
@@ -34,7 +36,12 @@ def create_make_command(keyboard, keymap, target=None):
     if target:
         make_args.append(target)
 
-    return [make_cmd, ':'.join(make_args)]
+    make_command = [make_cmd, ':'.join(make_args)]
+
+    if cli.config.user.userspace:
+        make_command.append('EXTERNAL_USERSPACE=%s' % cli.config.user.userspace)
+
+    return make_command
 
 
 def compile_configurator_json(user_keymap, bootloader=None):

--- a/lib/python/qmk/os_helpers/__init__.py
+++ b/lib/python/qmk/os_helpers/__init__.py
@@ -4,6 +4,7 @@ from enum import Enum
 import re
 import shutil
 import subprocess
+from pathlib import Path
 
 from milc import cli
 from qmk.commands import run
@@ -163,3 +164,21 @@ def check_git_repo():
     dot_git_dir = QMK_FIRMWARE / '.git'
 
     return CheckStatus.OK if dot_git_dir.is_dir() else CheckStatus.WARNING
+
+
+def check_userspace():
+    """Checks if directory configured as external userpace
+
+    If the configured path does not exist or
+    not an absolute path, compilation might fail.
+    """
+    userspace_path = Path(cli.config.user.userspace)
+    if not userspace_path.exists():
+        cli.log.error('External userspace: {fg_red}%s does not exists', userspace_path)
+        return CheckStatus.ERROR
+    elif not userspace_path.is_absolute():
+        cli.log.warning('External userspace: {fg_yellow}%s is not an absolute path', userspace_path)
+        return CheckStatus.WARNING
+    else:
+        cli.log.info('External userspace: {fg_cyan}%s', userspace_path)
+        return CheckStatus.OK

--- a/lib/python/qmk/os_helpers/__init__.py
+++ b/lib/python/qmk/os_helpers/__init__.py
@@ -172,13 +172,14 @@ def check_userspace():
     If the configured path does not exist or
     not an absolute path, compilation might fail.
     """
-    userspace_path = Path(cli.config.user.userspace)
-    if not userspace_path.exists():
-        cli.log.error('External userspace: {fg_red}%s does not exists', userspace_path)
-        return CheckStatus.ERROR
-    elif not userspace_path.is_absolute():
-        cli.log.warning('External userspace: {fg_yellow}%s is not an absolute path', userspace_path)
-        return CheckStatus.WARNING
-    else:
-        cli.log.info('External userspace: {fg_cyan}%s', userspace_path)
-        return CheckStatus.OK
+    if cli.config.user.userspace:
+        userspace_path = Path(cli.config.user.userspace)
+        if not userspace_path.exists():
+            cli.log.error('External userspace: {fg_red}%s does not exists', userspace_path)
+            return CheckStatus.ERROR
+        elif not userspace_path.is_absolute():
+            cli.log.warning('External userspace: {fg_yellow}%s is not an absolute path', userspace_path)
+            return CheckStatus.WARNING
+        else:
+            cli.log.info('External userspace: {fg_cyan}%s', userspace_path)
+            return CheckStatus.OK


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Allow users to use out-of-tree keymaps/layouts.

Set the **absolute** path with `qmk config user.userspace=/path/to/external/userspace` and use `qmk compile` as usual.

**TODO**: ~~Documentation~~

~~Opened as draft to get feedback and maybe help with writing the documentation.~~
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
