### PR TITLE
wheatfield/split75 with ISO layout

### DIFF
--- a/keyboards/wheatfield/split75/keymaps/default/keymap.c
+++ b/keyboards/wheatfield/split75/keymaps/default/keymap.c
@@ -27,6 +27,6 @@ KC_8,  KC_9,    KC_GRAVE, KC_1,    KC_2,    KC_3,   KC_4,   KC_5,   KC_6,       
 KC_6,  KC_7,    KC_TAB,   KC_Q,    KC_W,    KC_E,   KC_R,   KC_T,                 KC_Y,   KC_U,   KC_I,    KC_O,   KC_P,    KC_LBRC,  KC_RBRC,  KC_BSLS,           KC_PGUP,
 KC_4,  KC_5,    KC_CAPS,  KC_A,    KC_S,    KC_D,   KC_F,   KC_G,                 KC_H,   KC_J,   KC_K,    KC_L,   KC_SCLN, KC_QUOT,  KC_ENTER,                    KC_PGDN,
 KC_2,  KC_3,    KC_LSFT,  KC_Z,    KC_X,    KC_C,   KC_V,   KC_B,                 KC_N,   KC_M,   KC_COMM, KC_DOT, KC_SLSH,                     KC_RSFT,  KC_UP,   KC_END,
-KC_0,  KC_1,    KC_LCTL,  KC_LGUI, KC_LALT, KC_SPC, KC_SPC,                       KC_SPC,         KC_RALT, _______,KC_RCTL,               KC_LEFT,  KC_DOWN, KC_RIGHT
+KC_0,  KC_1,    KC_LCTL,  KC_LGUI, KC_LALT, KC_SPC, KC_SPC,                       KC_SPC,         KC_RALT, _______,KC_RCTL,                     KC_LEFT,  KC_DOWN, KC_RIGHT
   )
 };

--- a/keyboards/wheatfield/split75/keymaps/iso/keymap.c
+++ b/keyboards/wheatfield/split75/keymaps/iso/keymap.c
@@ -1,0 +1,48 @@
+/* Copyright 2020 Johannes Krude
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include QMK_KEYBOARD_H
+
+enum layer_names {
+  BASE
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+  /* Base          ,-----------------------------------------.     ,-----------------------------------------------------.
+  *                | ESC | F1  | F2  | F3  | F4  | F5  | F6  |     | F7  | F8  | F9  | F10 | F11 | F12 |Print| Ins | Del |
+  * ,-----------.  |-----+-----+-----+-----+-----+-----+-----|     |-----+-----+-----+-----+-----+-----+-----------+-----|
+  * |  8  |  9  |  |  ~  |  1  |  2  |  3  |  4  |  5  |  6  |     |  7  |  8  |  9  |  0  |  -  |  =  | Backspac  | Home|
+  * |-----+-----|  |-----------------------------------------'  ,--------------------------------------------------+-----|
+  * |  6  |  7  |  | Tab   |  Q  |  W  |  E  |  R  |  T  |     |  Y  |  U  |  I  |  O  |  P  |  [  |  ]  |         | PgUp|
+  * |-----+-----|  |---------------------------------------.    `------------------------------------------+ Enter +-----|
+  * |  4  |  5  |  | Caps    |  A  |  S  |  D  |  F  |  G  |     |  H  |  J  |  K  |  L  |  ;  |  '  |  #  |       | PgDn|
+  * |-----+-----|  |-----------------------------------------.   `-------------------------------------------------+-----|
+  * |  2  |  3  |  | Shift | > |  Z  |  X  |  C  |  V  |  B  |     |  N  |  M  |  ,  |  .  |   /   |  Shift  | Up  | End |
+  * |-----+-----|  |-----------------------------------------'   ,-------------------------------------------+-----+-----|
+  * |  0  |  1  |  | Ctrl  |  GUI |  Alt |   Space   |Space|     | Space         |  Alt  | APP | Ctrl  | Left| Down|Right|
+  * `-----------'  `---------------------------------------'     `-------------------------------------------------------'
+  */
+  [BASE] = LAYOUT_iso(
+//--------------------------------Left Hand-----------------------------------| |--------------------------------Right Hand------------------------------------------------
+                KC_ESC,   KC_F1,   KC_F2,   KC_F3,  KC_F4,  KC_F5,  KC_F6,                KC_F7,  KC_F8,   KC_F9,  KC_F10,  KC_F11,   KC_F12,   KC_PSCR,  KC_INS,  KC_DEL,
+KC_8,  KC_9,    KC_GRAVE, KC_1,    KC_2,    KC_3,   KC_4,   KC_5,   KC_6,                 KC_7,   KC_8,    KC_9,   KC_0,    KC_MINUS, KC_EQUAL, KC_BSPC,           KC_HOME,
+KC_6,  KC_7,    KC_TAB,   KC_Q,    KC_W,    KC_E,   KC_R,   KC_T,                 KC_Y,   KC_U,   KC_I,    KC_O,   KC_P,    KC_LBRC,  KC_RBRC,                     KC_PGUP,
+KC_4,  KC_5,    KC_CAPS,  KC_A,    KC_S,    KC_D,   KC_F,   KC_G,                 KC_H,   KC_J,   KC_K,    KC_L,   KC_SCLN, KC_QUOT,  KC_NUHS,  KC_ENTER,          KC_PGDN,
+KC_2,  KC_3,    KC_LSFT,  KC_NUBS, KC_Z,    KC_X,   KC_C,   KC_V,   KC_B,                 KC_N,   KC_M,   KC_COMM, KC_DOT,  KC_SLSH,            KC_RSFT,  KC_UP,   KC_END,
+KC_0,  KC_1,    KC_LCTL,  KC_LGUI, KC_LALT, KC_SPC, KC_SPC,                       KC_SPC,         KC_RALT, KC_APP ,KC_RCTL,                     KC_LEFT,  KC_DOWN, KC_RIGHT
+  )
+};

--- a/keyboards/wheatfield/split75/split75.h
+++ b/keyboards/wheatfield/split75/split75.h
@@ -28,6 +28,24 @@
   { K07,    K17,    K27,    K37,    K47,    KC_NO,  KC_NO,  KC_NO,  K87,    K97,    K107,   K117,   K127,   K137 }  \
 }
 
+#define LAYOUT_iso( \
+            K05, K15, K25, K35, K45, K55, K65, K75, K85, K95, K105, K115, K125, K135, K86, K87, \
+  K47, K46, K04, K14, K24, K34, K44, K54, K64, K74, K84, K94, K104, K114, K124,       K96, K97, \
+  K37, K36, K03, K13, K23, K33, K43, K53,      K73, K83, K93, K103, K113, K123, K133,       K107, \
+  K27, K26, K02, K12, K22, K32, K42, K52,      K72, K82, K92, K102, K112, K122, K132, K116, K117, \
+  K17, K16, K01, K11, K21, K31, K41, K51, K61, K71, K81, K91, K101, K111,       K131, K126, K127, \
+  K07, K06, K00, K10, K20, K30, K40,           K70,           K100, K110, K120, K130, K136, K137  \
+){ \
+  { K00,    K10,    K20,    K30,    K40,    KC_NO,  KC_NO,  K70,    KC_NO,  KC_NO,  K100,   K110,   K120,   K130 }, \
+  { K01,    K11,    K21,    K31,    K41,    K51,    K61,    K71,    K81,    K91,    K101,   K111,   KC_NO,  K131 }, \
+  { K02,    K12,    K22,    K32,    K42,    K52,    KC_NO,  K72,    K82,    K92,    K102,   K112,   K122,   K132 }, \
+  { K03,    K13,    K23,    K33,    K43,    K53,    KC_NO,  K73,    K83,    K93,    K103,   K113,   K123,   K133 }, \
+  { K04,    K14,    K24,    K34,    K44,    K54,    K64,    K74,    K84,    K94,    K104,   K114,   K124,        }, \
+  { K05,    K15,    K25,    K35,    K45,    K55,    K65,    K75,    K85,    K95,    K105,   K115,   K125,   K135 }, \
+  { K06,    K16,    K26,    K36,    K46,    KC_NO,  KC_NO,  KC_NO,  K86,    K96,    KC_NO,  K116,   K126,   K136 }, \
+  { K07,    K17,    K27,    K37,    K47,    KC_NO,  KC_NO,  KC_NO,  K87,    K97,    K107,   K117,   K127,   K137 }  \
+}
+
 #define NUMLOCK_LED_PIN D0
 #define CAPSLOCK_LED_PIN D1
 #define SCROLLLOCK_LED_PIN D6


### PR DESCRIPTION
The pcb used for wheatfield/split75 supports ANSI and ISO layout. This
commit adds the ISO variant.