### PR TITLE
[Keyboard] Fix default keymap for tunks/ergo33

### DIFF
--- a/keyboards/tunks/ergo33/keymaps/default/keymap.c
+++ b/keyboards/tunks/ergo33/keymaps/default/keymap.c
@@ -1,17 +1,17 @@
-/* Copyright 2020 Mika Kuitunen 
-  * 
-  * This program is free software: you can redistribute it and/or modify 
-  * it under the terms of the GNU General Public License as published by 
-  * the Free Software Foundation, either version 2 of the License, or 
-  * (at your option) any later version. 
-  * 
-  * This program is distributed in the hope that it will be useful, 
-  * but WITHOUT ANY WARRANTY; without even the implied warranty of 
-  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
-  * GNU General Public License for more details. 
-  * 
-  * You should have received a copy of the GNU General Public License 
-  * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+/* Copyright 2020 Mika Kuitunen
+  *
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 2 of the License, or
+  * (at your option) any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
   */
 
 #include QMK_KEYBOARD_H
@@ -60,7 +60,6 @@ void encoder_update_user(uint8_t index, bool clockwise) {
 
 #ifdef RGBLIGHT_LAYERS
 #define HUE_PRIMARY 10
-#define HSV_OFF 0, 0, 0
 #define HSV_CAPS HUE_PRIMARY, 255, 64
 #define HSV_LAYER_BASE HUE_PRIMARY, 255, 64
 #define HSV_LAYER_RGB 213, 255, 64

--- a/keyboards/tunks/ergo33/keymaps/prpro/keymap.c
+++ b/keyboards/tunks/ergo33/keymaps/prpro/keymap.c
@@ -1,17 +1,17 @@
-/* Copyright 2020 Mika Kuitunen 
-  * 
-  * This program is free software: you can redistribute it and/or modify 
-  * it under the terms of the GNU General Public License as published by 
-  * the Free Software Foundation, either version 2 of the License, or 
-  * (at your option) any later version. 
-  * 
-  * This program is distributed in the hope that it will be useful, 
-  * but WITHOUT ANY WARRANTY; without even the implied warranty of 
-  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
-  * GNU General Public License for more details. 
-  * 
-  * You should have received a copy of the GNU General Public License 
-  * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+/* Copyright 2020 Mika Kuitunen
+  *
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 2 of the License, or
+  * (at your option) any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
   */
 
 #include QMK_KEYBOARD_H
@@ -105,7 +105,6 @@ void encoder_update_user(uint8_t index, bool clockwise) {
 #ifdef RGBLIGHT_LAYERS
 #define HUE_PRIMARY 10
 #define HSV_PRIMARY HUE_PRIMARY, 255, 255
-#define HSV_OFF 0, 0, 0
 #define HSV_CAPS HUE_PRIMARY, 255, 64
 #define HSV_LAYER_BASE HUE_PRIMARY, 255, 64
 #define HSV_LAYER_PRPRO 213, 255, 64


### PR DESCRIPTION

## Description

`HSV_OFF` was added to core, but not removed from this keymap, causing compile errors. 


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bugfix
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)

## Issues Fixed or Closed by This PR

* CI

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
