### PR TITLE
Add libusb-devel dependency for fedora

### DIFF
--- a/util/install/fedora.sh
+++ b/util/install/fedora.sh
@@ -9,7 +9,7 @@ _qmk_install() {
         python3 \
         avr-binutils avr-gcc avr-libc \
         arm-none-eabi-binutils-cs arm-none-eabi-gcc-cs arm-none-eabi-newlib \
-        avrdude dfu-programmer dfu-util
+        avrdude dfu-programmer dfu-util libusb-devel
 
     python3 -m pip install --user -r $QMK_FIRMWARE_DIR/requirements.txt
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
On a clean fedora 33 install, building BootloadHID fails because libusb-devel is not installed as a dependency

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
