### PR TITLE
[Keyboard] PloopyCo VIA updates

### DIFF
--- a/keyboards/ploopyco/mouse/keymaps/drag_scroll/keymap.c
+++ b/keyboards/ploopyco/mouse/keymaps/drag_scroll/keymap.c
@@ -17,46 +17,11 @@
  */
 #include QMK_KEYBOARD_H
 
-// used for tracking the state
-bool is_drag_scroll = false;
-
-enum custom_keycodes {
-    DRAG_SCROLL = PLOOPY_SAFE_RANGE,
-};
-
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [0] = LAYOUT(/* Base */
-                 C(KC_C), KC_BTN1, KC_BTN3, KC_BTN2, C(KC_V), KC_BTN4, KC_BTN5, DPI_CONFIG)
+                 C(KC_C), KC_BTN1, KC_BTN3, LT(1, KC_BTN2), C(KC_V), KC_BTN4, KC_BTN5, DPI_CONFIG),
+    [1] = LAYOUT(/* Base */
+                 _______, DRAG_SCROLL, _______, _______, _______, _______, _______, RESET),
+
 };
-
-
-bool process_record_user(uint16_t keycode, keyrecord_t *record) {
-    switch (keycode) {
-        case DRAG_SCROLL:
-            if (record->event.pressed) {
-                // this toggles the state each time you tap it
-                is_drag_scroll ^= 1;
-            }
-            break;
-    }
-    return true;
-}
-
-// The real magic is here.
-// This function is called to translate the processed sensor movement
-// from the mouse sensor and translates it into x and y movement for
-// the mouse report. Normally.  So if "drag scroll" is toggled on,
-// moving the ball scrolls instead.  You could remove the  x or y here
-//  to only scroll in one direction, if you wanted, as well. In fact,
-// there is no reason that you need to send this to the mouse report.
-// You could have it register a key, instead.
-void process_mouse_user(report_mouse_t* mouse_report, int16_t x, int16_t y) {
-    if (is_drag_scroll) {
-        mouse_report->h = x;
-        mouse_report->v = y;
-    } else {
-        mouse_report->x = x;
-        mouse_report->y = y;
-    }
-}

--- a/keyboards/ploopyco/mouse/keymaps/via/keymap.c
+++ b/keyboards/ploopyco/mouse/keymaps/via/keymap.c
@@ -18,7 +18,7 @@
 #include QMK_KEYBOARD_H
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    [0] = LAYOUT(C(KC_C), KC_BTN1, KC_BTN3, KC_BTN2, C(KC_V), KC_BTN4, KC_BTN5, C(KC_Z)),
+    [0] = LAYOUT(C(KC_C), KC_BTN1, KC_BTN3, KC_BTN2, C(KC_V), KC_BTN4, KC_BTN5, DPI_CONFIG),
     [1] = LAYOUT(_______, _______, _______, _______, _______, _______, _______, _______),
     [2] = LAYOUT(_______, _______, _______, _______, _______, _______, _______, _______),
     [3] = LAYOUT(_______, _______, _______, _______, _______, _______, _______, _______),

--- a/keyboards/ploopyco/mouse/mouse.c
+++ b/keyboards/ploopyco/mouse/mouse.c
@@ -41,7 +41,7 @@
 #endif
 
 keyboard_config_t keyboard_config;
-uint16_t dpi_array[] = PLOOPY_DPI_OPTIONS;
+uint16_t          dpi_array[] = PLOOPY_DPI_OPTIONS;
 #define DPI_OPTION_SIZE (sizeof(dpi_array) / sizeof(uint16_t))
 
 // TODO: Implement libinput profiles
@@ -57,6 +57,7 @@ uint16_t lastScroll        = 0;      // Previous confirmed wheel event
 uint16_t lastMidClick      = 0;      // Stops scrollwheel from being read if it was pressed
 uint8_t  OptLowPin         = OPT_ENC1;
 bool     debug_encoder     = false;
+bool     is_drag_scroll    = false;
 
 __attribute__((weak)) void process_wheel_user(report_mouse_t* mouse_report, int16_t h, int16_t v) {
     mouse_report->h = h;
@@ -151,17 +152,28 @@ bool process_record_kb(uint16_t keycode, keyrecord_t* record) {
 
     // Update Timer to prevent accidental scrolls
     if ((record->event.key.col == 1) && (record->event.key.row == 0)) {
-        lastMidClick = timer_read();
+        lastMidClick      = timer_read();
         is_scroll_clicked = record->event.pressed;
     }
 
-    if (!process_record_user(keycode, record)) { return false; }
+    if (!process_record_user(keycode, record)) {
+        return false;
+    }
 
     if (keycode == DPI_CONFIG && record->event.pressed) {
         keyboard_config.dpi_config = (keyboard_config.dpi_config + 1) % DPI_OPTION_SIZE;
         eeconfig_update_kb(keyboard_config.raw);
         pmw_set_cpi(dpi_array[keyboard_config.dpi_config]);
     }
+
+    if (keycode == DRAG_SCROLL) {
+        if (record->event.pressed) {
+            // this toggles the state each time you tap it
+            is_drag_scroll ^= 1;
+        }
+        pmw_set_cpi(is_drag_scroll ? (dpi_array[keyboard_config.dpi_config] * 0.75) : dpi_array[keyboard_config.dpi_config]);
+    }
+
 /* If Mousekeys is disabled, then use handle the mouse button
  * keycodes.  This makes things simpler, and allows usage of
  * the keycodes in a consistent manner.  But only do this if
@@ -223,24 +235,40 @@ void pointing_device_init(void) {
     opt_encoder_init();
 }
 
-bool has_report_changed (report_mouse_t first, report_mouse_t second) {
-    return !(
-        (!first.buttons && first.buttons == second.buttons) &&
-        (!first.x && first.x == second.x) &&
-        (!first.y && first.y == second.y) &&
-        (!first.h && first.h == second.h) &&
-        (!first.v && first.v == second.v) );
-}
+bool has_report_changed(report_mouse_t new, report_mouse_t old) { return (new.buttons != old.buttons) || (new.x&& new.x != old.x) || (new.y&& new.y != old.y) || (new.h&& new.h != old.h) || (new.v&& new.v != old.v); }
 
 void pointing_device_task(void) {
     report_mouse_t mouse_report = pointing_device_get_report();
     process_wheel(&mouse_report);
     process_mouse(&mouse_report);
 
-    pointing_device_set_report(mouse_report);
-    if (has_report_changed(mouse_report, pointing_device_get_report())) {
-        pointing_device_send();
+    if (is_drag_scroll) {
+        mouse_report.h = mouse_report.x;
+        mouse_report.v = mouse_report.y;
+        mouse_report.x = 0;
+        mouse_report.y = 0;
     }
+
+    pointing_device_set_report(mouse_report);
+    pointing_device_send();
+}
+
+void pointing_device_send(void) {
+    static report_mouse_t old_report  = {};
+    report_mouse_t        mouseReport = pointing_device_get_report();
+
+    // If you need to do other things, like debugging, this is the place to do it.
+    if (has_report_changed(mouseReport, old_report)) {
+        host_mouse_send(&mouseReport);
+    }
+
+    // send it and 0 it out except for buttons, so those stay until they are explicity over-ridden using update_pointing_device
+    mouseReport.x = 0;
+    mouseReport.y = 0;
+    mouseReport.v = 0;
+    mouseReport.h = 0;
+    pointing_device_set_report(mouseReport);
+    old_report = mouseReport;
 }
 
 void eeconfig_init_kb(void) {

--- a/keyboards/ploopyco/mouse/mouse.c
+++ b/keyboards/ploopyco/mouse/mouse.c
@@ -235,7 +235,7 @@ void pointing_device_init(void) {
     opt_encoder_init();
 }
 
-bool has_report_changed(report_mouse_t new, report_mouse_t old) { return (new.buttons != old.buttons) || (new.x&& new.x != old.x) || (new.y&& new.y != old.y) || (new.h&& new.h != old.h) || (new.v&& new.v != old.v); }
+bool has_report_changed(report_mouse_t new, report_mouse_t old) { return (new.buttons != old.buttons) || (new.x && new.x != old.x) || (new.y && new.y != old.y) || (new.h && new.h != old.h) || (new.v && new.v != old.v); }
 
 void pointing_device_task(void) {
     report_mouse_t mouse_report = pointing_device_get_report();

--- a/keyboards/ploopyco/mouse/mouse.c
+++ b/keyboards/ploopyco/mouse/mouse.c
@@ -39,6 +39,18 @@
 #ifndef PLOOPY_DPI_DEFAULT
 #    define PLOOPY_DPI_DEFAULT 0
 #endif
+#ifndef PLOOPY_DRAGSCROLL_MOMENTARY
+#    define PLOOPY_DRAGSCROLL_MOMENTARY 0 // 0 -> Toggle, 1 -> Momentary
+#endif
+#ifndef PLOOPY_DRAGSCROLL_FIXED
+#    define PLOOPY_DRAGSCROLL_FIXED 0 // 0 -> Variable-DPI Drag Scroll, 1 -> Fixed-DPI Drag Scroll
+#endif
+#ifndef PLOOPY_DRAGSCROLL_DPI
+#    define PLOOPY_DRAGSCROLL_DPI 100 // Fixed-DPI Drag Scroll
+#endif
+#ifndef PLOOPY_DRAGSCROLL_MULTIPLIER
+#    define PLOOPY_DRAGSCROLL_MULTIPLIER 0.75 // Variable-DPI Drag Scroll
+#endif
 
 keyboard_config_t keyboard_config;
 uint16_t          dpi_array[] = PLOOPY_DPI_OPTIONS;
@@ -167,11 +179,19 @@ bool process_record_kb(uint16_t keycode, keyrecord_t* record) {
     }
 
     if (keycode == DRAG_SCROLL) {
+#if PLOOPY_DRAGSCROLL_MOMENTARY==1
+        is_drag_scroll ^= 1;
+#else
         if (record->event.pressed) {
             // this toggles the state each time you tap it
             is_drag_scroll ^= 1;
         }
-        pmw_set_cpi(is_drag_scroll ? (dpi_array[keyboard_config.dpi_config] * 0.75) : dpi_array[keyboard_config.dpi_config]);
+#endif
+#if PLOOPY_DRAGSCROLL_FIXED==1
+        pmw_set_cpi(is_drag_scroll ? PLOOPY_DRAGSCROLL_DPI : dpi_array[keyboard_config.dpi_config]);
+#else
+        pmw_set_cpi(is_drag_scroll ? (dpi_array[keyboard_config.dpi_config] * PLOOPY_DRAGSCROLL_MULTIPLIER) : dpi_array[keyboard_config.dpi_config]);
+#endif
     }
 
 /* If Mousekeys is disabled, then use handle the mouse button

--- a/keyboards/ploopyco/mouse/mouse.c
+++ b/keyboards/ploopyco/mouse/mouse.c
@@ -39,12 +39,6 @@
 #ifndef PLOOPY_DPI_DEFAULT
 #    define PLOOPY_DPI_DEFAULT 0
 #endif
-#ifndef PLOOPY_DRAGSCROLL_MOMENTARY
-#    define PLOOPY_DRAGSCROLL_MOMENTARY 0 // 0 -> Toggle, 1 -> Momentary
-#endif
-#ifndef PLOOPY_DRAGSCROLL_FIXED
-#    define PLOOPY_DRAGSCROLL_FIXED 0 // 0 -> Variable-DPI Drag Scroll, 1 -> Fixed-DPI Drag Scroll
-#endif
 #ifndef PLOOPY_DRAGSCROLL_DPI
 #    define PLOOPY_DRAGSCROLL_DPI 100 // Fixed-DPI Drag Scroll
 #endif
@@ -179,15 +173,13 @@ bool process_record_kb(uint16_t keycode, keyrecord_t* record) {
     }
 
     if (keycode == DRAG_SCROLL) {
-#if PLOOPY_DRAGSCROLL_MOMENTARY==1
-        is_drag_scroll ^= 1;
-#else
-        if (record->event.pressed) {
-            // this toggles the state each time you tap it
+#ifndef PLOOPY_DRAGSCROLL_MOMENTARY
+        if (record->event.pressed)
+#endif
+        {
             is_drag_scroll ^= 1;
         }
-#endif
-#if PLOOPY_DRAGSCROLL_FIXED==1
+#ifdef PLOOPY_DRAGSCROLL_FIXED
         pmw_set_cpi(is_drag_scroll ? PLOOPY_DRAGSCROLL_DPI : dpi_array[keyboard_config.dpi_config]);
 #else
         pmw_set_cpi(is_drag_scroll ? (dpi_array[keyboard_config.dpi_config] * PLOOPY_DRAGSCROLL_MULTIPLIER) : dpi_array[keyboard_config.dpi_config]);

--- a/keyboards/ploopyco/mouse/mouse.h
+++ b/keyboards/ploopyco/mouse/mouse.h
@@ -49,6 +49,15 @@ typedef union {
 extern keyboard_config_t keyboard_config;
 
 enum ploopy_keycodes {
+#ifdef VIA_ENABLE
+    DPI_CONFIG = USER00,
+#else
     DPI_CONFIG = SAFE_RANGE,
+#endif
+    DRAG_SCROLL,
+#ifdef VIA_ENABLE
+    PLOOPY_SAFE_RANGE = SAFE_RANGE,
+#else
     PLOOPY_SAFE_RANGE,
+#endif
 };

--- a/keyboards/ploopyco/mouse/mouse.h
+++ b/keyboards/ploopyco/mouse/mouse.h
@@ -47,6 +47,7 @@ typedef union {
 } keyboard_config_t;
 
 extern keyboard_config_t keyboard_config;
+extern uint16_t          dpi_array[];
 
 enum ploopy_keycodes {
 #ifdef VIA_ENABLE

--- a/keyboards/ploopyco/mouse/rules.mk
+++ b/keyboards/ploopyco/mouse/rules.mk
@@ -12,8 +12,8 @@ BOOTLOADER = atmel-dfu
 #
 BOOTMAGIC_ENABLE = lite     # Virtual DIP switch configuration
 EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = yes         # Console for debug
-COMMAND_ENABLE = no        # Commands for debug and configuration
+CONSOLE_ENABLE = no         # Console for debug
+COMMAND_ENABLE = no         # Commands for debug and configuration
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
 SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
 # if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
@@ -24,7 +24,7 @@ UNICODE_ENABLE = no         # Unicode
 BLUETOOTH_ENABLE = no       # Enable Bluetooth
 AUDIO_ENABLE = no           # Audio output
 POINTING_DEVICE_ENABLE = yes
-MOUSEKEY_ENABLE = no        # Mouse keys
+MOUSEKEY_ENABLE = yes       # Mouse keys
 
 QUANTUM_LIB_SRC += analog.c spi_master.c
 SRC += pmw3360.c opt_encoder.c

--- a/keyboards/ploopyco/trackball/keymaps/drag_scroll/keymap.c
+++ b/keyboards/ploopyco/trackball/keymaps/drag_scroll/keymap.c
@@ -17,42 +17,6 @@
  */
 #include QMK_KEYBOARD_H
 
-// used for tracking the state
-bool is_drag_scroll = false;
-
-enum custom_keycodes {
-    DRAG_SCROLL = PLOOPY_SAFE_RANGE,
-};
-
-bool process_record_user(uint16_t keycode, keyrecord_t *record) {
-    switch (keycode) {
-        case DRAG_SCROLL:
-            if (record->event.pressed) {
-                // this toggles the state each time you tap it
-                is_drag_scroll ^= 1;
-            }
-            break;
-    }
-    return true;
-}
-
-// The real magic is here.
-// This function is called to translate the processed sensor movement
-// from the mouse sensor and translates it into x and y movement for
-// the mouse report. Normally.  So if "drag scroll" is toggled on,
-// moving the ball scrolls instead.  You could remove the  x or y here
-//  to only scroll in one direction, if you wanted, as well. In fact,
-// there is no reason that you need to send this to the mouse report.
-// You could have it register a key, instead.
-void process_mouse_user(report_mouse_t* mouse_report, int16_t x, int16_t y) {
-    if (is_drag_scroll) {
-        mouse_report->h = x;
-        mouse_report->v = y;
-    } else {
-        mouse_report->x = x;
-        mouse_report->y = y;
-    }
-}
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [0] = LAYOUT( /* Base */

--- a/keyboards/ploopyco/trackball/rev1/readme.md
+++ b/keyboards/ploopyco/trackball/rev1/readme.md
@@ -13,8 +13,8 @@ Once you have that, you'll need to [ISP Flash](https://docs.qmk.fm/#/isp_flashin
 
 | Fuse     | Setting          |
 |----------|------------------|
-| Low      | `0xDF`           |
-| High     | `0xD8` or `0x98` |
+| Low      | `0x52`           |
+| High     | `0x99`           |
 | Extended | `0xCB`           |
 
 Original (Caterina) settings: 

--- a/keyboards/ploopyco/trackball/rules.mk
+++ b/keyboards/ploopyco/trackball/rules.mk
@@ -9,8 +9,8 @@ F_CPU = 8000000
 #
 BOOTMAGIC_ENABLE = lite     # Virtual DIP switch configuration
 EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = yes         # Console for debug
-COMMAND_ENABLE = no        # Commands for debug and configuration
+CONSOLE_ENABLE = no         # Console for debug
+COMMAND_ENABLE = no         # Commands for debug and configuration
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
 SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
 # if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
@@ -21,7 +21,7 @@ UNICODE_ENABLE = no         # Unicode
 BLUETOOTH_ENABLE = no       # Enable Bluetooth
 AUDIO_ENABLE = no           # Audio output
 POINTING_DEVICE_ENABLE = yes
-MOUSEKEY_ENABLE = no        # Mouse keys
+MOUSEKEY_ENABLE = yes       # Mouse keys
 
 QUANTUM_LIB_SRC += analog.c spi_master.c
 SRC += pmw3360.c opt_encoder.c

--- a/keyboards/ploopyco/trackball/trackball.c
+++ b/keyboards/ploopyco/trackball/trackball.c
@@ -234,7 +234,7 @@ void pointing_device_init(void) {
     opt_encoder_init();
 }
 
-bool has_report_changed(report_mouse_t new, report_mouse_t old) { return (new.buttons != old.buttons) || (new.x&& new.x != old.x) || (new.y&& new.y != old.y) || (new.h&& new.h != old.h) || (new.v&& new.v != old.v); }
+bool has_report_changed(report_mouse_t new, report_mouse_t old) { return (new.buttons != old.buttons) || (new.x && new.x != old.x) || (new.y && new.y != old.y) || (new.h && new.h != old.h) || (new.v && new.v != old.v); }
 
 void pointing_device_task(void) {
     report_mouse_t mouse_report = pointing_device_get_report();

--- a/keyboards/ploopyco/trackball/trackball.c
+++ b/keyboards/ploopyco/trackball/trackball.c
@@ -41,7 +41,7 @@
 #endif
 
 keyboard_config_t keyboard_config;
-uint16_t dpi_array[] = PLOOPY_DPI_OPTIONS;
+uint16_t          dpi_array[] = PLOOPY_DPI_OPTIONS;
 #define DPI_OPTION_SIZE (sizeof(dpi_array) / sizeof(uint16_t))
 
 // TODO: Implement libinput profiles
@@ -57,6 +57,7 @@ uint16_t lastScroll        = 0;      // Previous confirmed wheel event
 uint16_t lastMidClick      = 0;      // Stops scrollwheel from being read if it was pressed
 uint8_t  OptLowPin         = OPT_ENC1;
 bool     debug_encoder     = false;
+bool     is_drag_scroll    = false;
 
 __attribute__((weak)) void process_wheel_user(report_mouse_t* mouse_report, int16_t h, int16_t v) {
     mouse_report->h = h;
@@ -151,16 +152,26 @@ bool process_record_kb(uint16_t keycode, keyrecord_t* record) {
 
     // Update Timer to prevent accidental scrolls
     if ((record->event.key.col == 1) && (record->event.key.row == 0)) {
-        lastMidClick = timer_read();
+        lastMidClick      = timer_read();
         is_scroll_clicked = record->event.pressed;
     }
 
-    if (!process_record_user(keycode, record)) { return false; }
+    if (!process_record_user(keycode, record)) {
+        return false;
+    }
 
     if (keycode == DPI_CONFIG && record->event.pressed) {
         keyboard_config.dpi_config = (keyboard_config.dpi_config + 1) % DPI_OPTION_SIZE;
         eeconfig_update_kb(keyboard_config.raw);
         pmw_set_cpi(dpi_array[keyboard_config.dpi_config]);
+    }
+
+    if (keycode == DRAG_SCROLL) {
+        if (record->event.pressed) {
+            // this toggles the state each time you tap it
+            is_drag_scroll ^= 1;
+        }
+        pmw_set_cpi(is_drag_scroll ? (dpi_array[keyboard_config.dpi_config] * 0.75) : dpi_array[keyboard_config.dpi_config]);
     }
 
 /* If Mousekeys is disabled, then use handle the mouse button
@@ -223,24 +234,40 @@ void pointing_device_init(void) {
     opt_encoder_init();
 }
 
-bool has_report_changed (report_mouse_t first, report_mouse_t second) {
-    return !(
-        (!first.buttons && first.buttons == second.buttons) &&
-        (!first.x && first.x == second.x) &&
-        (!first.y && first.y == second.y) &&
-        (!first.h && first.h == second.h) &&
-        (!first.v && first.v == second.v) );
-}
+bool has_report_changed(report_mouse_t new, report_mouse_t old) { return (new.buttons != old.buttons) || (new.x&& new.x != old.x) || (new.y&& new.y != old.y) || (new.h&& new.h != old.h) || (new.v&& new.v != old.v); }
 
 void pointing_device_task(void) {
     report_mouse_t mouse_report = pointing_device_get_report();
     process_wheel(&mouse_report);
     process_mouse(&mouse_report);
 
-    pointing_device_set_report(mouse_report);
-    if (has_report_changed(mouse_report, pointing_device_get_report())) {
-        pointing_device_send();
+    if (is_drag_scroll) {
+        mouse_report.h = mouse_report.x;
+        mouse_report.v = mouse_report.y;
+        mouse_report.x = 0;
+        mouse_report.y = 0;
     }
+
+    pointing_device_set_report(mouse_report);
+    pointing_device_send();
+}
+
+void pointing_device_send(void) {
+    static report_mouse_t old_report  = {};
+    report_mouse_t        mouseReport = pointing_device_get_report();
+
+    // If you need to do other things, like debugging, this is the place to do it.
+    if (has_report_changed(mouseReport, old_report)) {
+        host_mouse_send(&mouseReport);
+    }
+
+    // send it and 0 it out except for buttons, so those stay until they are explicity over-ridden using update_pointing_device
+    mouseReport.x = 0;
+    mouseReport.y = 0;
+    mouseReport.v = 0;
+    mouseReport.h = 0;
+    pointing_device_set_report(mouseReport);
+    old_report = mouseReport;
 }
 
 void eeconfig_init_kb(void) {

--- a/keyboards/ploopyco/trackball/trackball.c
+++ b/keyboards/ploopyco/trackball/trackball.c
@@ -39,6 +39,18 @@
 #ifndef PLOOPY_DPI_DEFAULT
 #    define PLOOPY_DPI_DEFAULT 0
 #endif
+#ifndef PLOOPY_DRAGSCROLL_MOMENTARY
+#    define PLOOPY_DRAGSCROLL_MOMENTARY 0 // 0 -> Toggle, 1 -> Momentary
+#endif
+#ifndef PLOOPY_DRAGSCROLL_FIXED
+#    define PLOOPY_DRAGSCROLL_FIXED 0 // 0 -> Variable-DPI Drag Scroll, 1 -> Fixed-DPI Drag Scroll
+#endif
+#ifndef PLOOPY_DRAGSCROLL_DPI
+#    define PLOOPY_DRAGSCROLL_DPI 100 // Fixed-DPI Drag Scroll
+#endif
+#ifndef PLOOPY_DRAGSCROLL_MULTIPLIER
+#    define PLOOPY_DRAGSCROLL_MULTIPLIER 0.75 // Variable-DPI Drag Scroll
+#endif
 
 keyboard_config_t keyboard_config;
 uint16_t          dpi_array[] = PLOOPY_DPI_OPTIONS;
@@ -167,11 +179,19 @@ bool process_record_kb(uint16_t keycode, keyrecord_t* record) {
     }
 
     if (keycode == DRAG_SCROLL) {
+#if PLOOPY_DRAGSCROLL_MOMENTARY==1
+        is_drag_scroll ^= 1;
+#else
         if (record->event.pressed) {
             // this toggles the state each time you tap it
             is_drag_scroll ^= 1;
         }
-        pmw_set_cpi(is_drag_scroll ? (dpi_array[keyboard_config.dpi_config] * 0.75) : dpi_array[keyboard_config.dpi_config]);
+#endif
+#if PLOOPY_DRAGSCROLL_FIXED==1
+        pmw_set_cpi(is_drag_scroll ? PLOOPY_DRAGSCROLL_DPI : dpi_array[keyboard_config.dpi_config]);
+#else
+        pmw_set_cpi(is_drag_scroll ? (dpi_array[keyboard_config.dpi_config] * PLOOPY_DRAGSCROLL_MULTIPLIER) : dpi_array[keyboard_config.dpi_config]);
+#endif
     }
 
 /* If Mousekeys is disabled, then use handle the mouse button

--- a/keyboards/ploopyco/trackball/trackball.c
+++ b/keyboards/ploopyco/trackball/trackball.c
@@ -39,12 +39,6 @@
 #ifndef PLOOPY_DPI_DEFAULT
 #    define PLOOPY_DPI_DEFAULT 0
 #endif
-#ifndef PLOOPY_DRAGSCROLL_MOMENTARY
-#    define PLOOPY_DRAGSCROLL_MOMENTARY 0 // 0 -> Toggle, 1 -> Momentary
-#endif
-#ifndef PLOOPY_DRAGSCROLL_FIXED
-#    define PLOOPY_DRAGSCROLL_FIXED 0 // 0 -> Variable-DPI Drag Scroll, 1 -> Fixed-DPI Drag Scroll
-#endif
 #ifndef PLOOPY_DRAGSCROLL_DPI
 #    define PLOOPY_DRAGSCROLL_DPI 100 // Fixed-DPI Drag Scroll
 #endif
@@ -179,15 +173,13 @@ bool process_record_kb(uint16_t keycode, keyrecord_t* record) {
     }
 
     if (keycode == DRAG_SCROLL) {
-#if PLOOPY_DRAGSCROLL_MOMENTARY==1
-        is_drag_scroll ^= 1;
-#else
-        if (record->event.pressed) {
-            // this toggles the state each time you tap it
+#ifndef PLOOPY_DRAGSCROLL_MOMENTARY
+        if (record->event.pressed)
+#endif
+        {
             is_drag_scroll ^= 1;
         }
-#endif
-#if PLOOPY_DRAGSCROLL_FIXED==1
+#ifdef PLOOPY_DRAGSCROLL_FIXED
         pmw_set_cpi(is_drag_scroll ? PLOOPY_DRAGSCROLL_DPI : dpi_array[keyboard_config.dpi_config]);
 #else
         pmw_set_cpi(is_drag_scroll ? (dpi_array[keyboard_config.dpi_config] * PLOOPY_DRAGSCROLL_MULTIPLIER) : dpi_array[keyboard_config.dpi_config]);

--- a/keyboards/ploopyco/trackball/trackball.h
+++ b/keyboards/ploopyco/trackball/trackball.h
@@ -45,15 +45,24 @@ void process_wheel_user(report_mouse_t* mouse_report, int16_t h, int16_t v);
     { {BL, BM, BR, BF, BB}, }
 
 typedef union {
-  uint32_t raw;
-  struct {
-    uint8_t    dpi_config;
-  };
+    uint32_t raw;
+    struct {
+        uint8_t dpi_config;
+    };
 } keyboard_config_t;
 
 extern keyboard_config_t keyboard_config;
 
 enum ploopy_keycodes {
+#ifdef VIA_ENABLE
+    DPI_CONFIG = USER00,
+#else
     DPI_CONFIG = SAFE_RANGE,
+#endif
+    DRAG_SCROLL,
+#ifdef VIA_ENABLE
+    PLOOPY_SAFE_RANGE = SAFE_RANGE,
+#else
     PLOOPY_SAFE_RANGE,
+#endif
 };

--- a/keyboards/ploopyco/trackball/trackball.h
+++ b/keyboards/ploopyco/trackball/trackball.h
@@ -52,6 +52,7 @@ typedef union {
 } keyboard_config_t;
 
 extern keyboard_config_t keyboard_config;
+extern uint16_t          dpi_array[];
 
 enum ploopy_keycodes {
 #ifdef VIA_ENABLE


### PR DESCRIPTION
## Description

- Updates the devices to use the completely undocumented User keycodes for VIA. 
- Additionally, moves the drag scoll keycode into the keyboard code. 
- Enables mousekeys, so that LT/MT will work with mouse buttons. 


## Types of Changes

- [x] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)


## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
