### PR TITLE
Update NIBBLE ISO keymap to fix flipped enter and backslash key.

### DIFF
--- a/keyboards/nullbitsco/nibble/keymaps/iso/keymap.c
+++ b/keyboards/nullbitsco/nibble/keymaps/iso/keymap.c
@@ -24,7 +24,7 @@ enum custom_keycodes {
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   [_MA] = LAYOUT_iso(
-             KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_TILD,
+             KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_HOME,
     KC_F13,  KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC,          KC_DEL,
     KC_F14,  KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_NUHS, KC_ENT,  KC_PGUP,
     KC_F15,  KC_LSFT, KC_NUBS, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT, KC_UP,   KC_PGDN,
@@ -68,7 +68,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
       if (record->event.pressed) {
       }
     break;
-    
+
   }
 return true;
 }
@@ -100,7 +100,7 @@ void change_RGB(bool clockwise) {
         } else {
             rgblight_step_reverse();
         }
-    } 
+    }
 }
 
 void encoder_update_kb(uint8_t index, bool clockwise) {
@@ -113,7 +113,7 @@ void encoder_update_kb(uint8_t index, bool clockwise) {
       tap_code(KC_VOLU);
   } else {
       tap_code(KC_VOLD);
-    }  
+    }
   }
 }
 

--- a/keyboards/nullbitsco/nibble/nibble.h
+++ b/keyboards/nullbitsco/nibble/nibble.h
@@ -51,7 +51,7 @@
 #define LAYOUT_iso( \
           K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C, K0D, K0E, K0F, K0G, \
     K11,  K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, K1C, K1D, K1E,      K1G, \
-    K21,  K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B, K2C, K2D, K1F, K2F, K2G, \
+    K21,  K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B, K2C, K2D, K2F, K1F, K2G, \
     K31,  K32, K01, K33, K34, K35, K36, K37, K38, K39, K3A, K3B, K3C, K3D, K3F, K3G, \
     K41,  K42, K43, K44,                K47,           K4A, K4B, K4C, K4D, K4F, K4G  \
 ) { \


### PR DESCRIPTION
## Description

Enter and backslash keys were accidentally flipped on the ISO keymap, this PR corrects that. Tested and confirmed with an ISO build. Replaced Tilde with Home in the ISO keymap to make it better match the documentation.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
