### PR TITLE
[Keymap] update rules.mk and config.h of `helix/rev2:five_rows`

### DIFF
--- a/keyboards/helix/rev2/keymaps/five_rows/config.h
+++ b/keyboards/helix/rev2/keymaps/five_rows/config.h
@@ -72,3 +72,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #endif
 
 #endif /* CONFIG_USER_H */
+
+#ifdef DEBUG_CONFIG
+#  include "debug_config.h"
+#endif

--- a/keyboards/helix/rev2/keymaps/five_rows/config.h
+++ b/keyboards/helix/rev2/keymaps/five_rows/config.h
@@ -28,6 +28,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* when TAPPING_TERM >= 500 same effect PERMISSIVE_HOLD.
    see tmk_core/common/action_tapping.c */
 
+#undef OLED_UPDATE_INTERVAL
+#define OLED_UPDATE_INTERVAL 50
+
 // place overrides here
 
 // If you need more program area, try select and reduce rgblight modes to use.

--- a/keyboards/helix/rev2/keymaps/five_rows/config.h
+++ b/keyboards/helix/rev2/keymaps/five_rows/config.h
@@ -3,6 +3,7 @@ This is the c configuration file for the keymap
 
 Copyright 2012 Jun Wako <wakojun@gmail.com>
 Copyright 2015 Jack Humbert
+Copyright 2020 mtei
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -32,7 +33,19 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // If you need more program area, try select and reduce rgblight modes to use.
 
 // Selection of RGBLIGHT MODE to use.
+#undef RGBLIGHT_ANIMATIONS
+#undef RGBLIGHT_EFFECT_BREATHING
+#undef RGBLIGHT_EFFECT_RAINBOW_MOOD
+#undef RGBLIGHT_EFFECT_RAINBOW_SWIRL
+#undef RGBLIGHT_EFFECT_SNAKE
+#undef RGBLIGHT_EFFECT_KNIGHT
+#undef RGBLIGHT_EFFECT_CHRISTMAS
+#undef RGBLIGHT_EFFECT_STATIC_GRADIENT
+#undef RGBLIGHT_EFFECT_RGB_TEST
+#undef RGBLIGHT_EFFECT_ALTERNATING
+
 #if defined(LED_ANIMATIONS)
+#  if LED_ANIMATIONS_LEVEL > 1
    #define RGBLIGHT_EFFECT_BREATHING
    #define RGBLIGHT_EFFECT_RAINBOW_MOOD
    #define RGBLIGHT_EFFECT_RAINBOW_SWIRL
@@ -42,6 +55,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
    #define RGBLIGHT_EFFECT_STATIC_GRADIENT
    //#define RGBLIGHT_EFFECT_RGB_TEST
    //#define RGBLIGHT_EFFECT_ALTERNATING
+#  else
+   #define RGBLIGHT_EFFECT_BREATHING
+   #define RGBLIGHT_EFFECT_RAINBOW_MOOD
+   //#define RGBLIGHT_EFFECT_RAINBOW_SWIRL
+   //#define RGBLIGHT_EFFECT_SNAKE
+   //#define RGBLIGHT_EFFECT_KNIGHT
+   //#define RGBLIGHT_EFFECT_CHRISTMAS
+   #define RGBLIGHT_EFFECT_STATIC_GRADIENT
+   //#define RGBLIGHT_EFFECT_RGB_TEST
+   //#define RGBLIGHT_EFFECT_ALTERNATING
+#  endif
 #endif
 
 #endif /* CONFIG_USER_H */

--- a/keyboards/helix/rev2/keymaps/five_rows/oled_display.c
+++ b/keyboards/helix/rev2/keymaps/five_rows/oled_display.c
@@ -163,6 +163,10 @@ void render_status(void) {
 }
 
 #    ifdef SSD1306OLED
+#        if OLED_UPDATE_INTERVAL > 0
+uint16_t oled_update_timeout;
+#        endif
+
 void iota_gfx_task_user(void) {
     struct CharacterMatrix matrix;
 
@@ -172,6 +176,12 @@ void iota_gfx_task_user(void) {
     }
 #        endif
 
+#if      OLED_UPDATE_INTERVAL > 0
+    if (timer_elapsed(oled_update_timeout) < OLED_UPDATE_INTERVAL) {
+        return;
+    }
+    oled_update_timeout = timer_read();
+#endif
     matrix_clear(&matrix);
     if (is_keyboard_master()) {
         render_status(&matrix);

--- a/keyboards/helix/rev2/keymaps/five_rows/rules.mk
+++ b/keyboards/helix/rev2/keymaps/five_rows/rules.mk
@@ -12,6 +12,7 @@
  #      yes, yes +3200
  #      no,  yes +400
 LTO_ENABLE = no  # if firmware size over limit, try this option
+LED_ANIMATIONS = yes
 
 # Helix Spacific Build Options
 # you can uncomment and edit follows 7 Variables
@@ -26,8 +27,8 @@ HELIX_ROWS = 5              # Helix Rows is 4 or 5
 
 ifneq ($(strip $(HELIX)),)
   define KEYMAP_OPTION_PARSE
-    # $xinfo .$1.x #debug
-    # parse  'dispoff', 'consle', 'stdole', 'oled', 'sc'
+    # parse  'dispoff', 'consloe', 'na', 'ani', 'mini-ani'
+    $(if $(SHOW_PARCE),$(info parse -$1-))  #debug
     ifeq ($(strip $1),dispoff)
         OLED_ENABLE = no
         OLED_DRIVER_ENABLE = no
@@ -37,19 +38,20 @@ ifneq ($(strip $(HELIX)),)
     ifeq ($(strip $1),console)
         CONSOLE_ENABLE = yes
     endif
-    ifeq ($(strip $1),stdole)
-        ## make HELIX=stdole helix:five_rows -- use TOP/drivers/oled/oled_driver.c
-        OLED_ENABLE = new
+    ifneq ($(filter na no_ani no-ani,$(strip $1)),)
+        LED_ANIMATIONS = no
     endif
-    ifeq ($(strip $1),oled)
-         ## make HELIX=oled helix:five_rows -- use helix/local_drivers/ssd1306.c
-        OLED_ENABLE = yes
+    ifneq ($(filter mini-ani mini_ani,$(strip $1)),)
+        LED_ANIMATIONS = mini
     endif
-    ifeq ($(strip $1),back)
-        LED_BACK_ENABLE = yes
+    ifneq ($(filter ani animation,$(strip $1)),)
+        LED_ANIMATIONS = yes
     endif
-    ifeq ($(strip $1),sc)
-        SPLIT_KEYBOARD = yes
+    ifeq ($(strip $1),lto)
+        LTO_ENABLE = yes
+    endif
+    ifneq ($(filter nolto no-lto no_lto,$(strip $1)),)
+        LTO_ENABLE = no
     endif
   endef # end of KEYMAP_OPTION_PARSE
 
@@ -58,20 +60,19 @@ ifneq ($(strip $(HELIX)),)
       $(call KEYMAP_OPTION_PARSE,$(A_OPTION_NAME))))
 endif
 
-ifeq ($(strip $(OLED_ENABLE)), new)
-    OLED_DRIVER_ENABLE = yes
-    OLED_ENABLE = no
-    SRC += oled_display.c
-    ifeq ($(strip $(LOCAL_GLCDFONT)), yes)
-       OPT_DEFS += -DOLED_FONT_H=\<helixfont.h\>
-    else
-       OPT_DEFS += -DOLED_FONT_H=\"common/glcdfont.c\"
-    endif
+ifeq ($(strip $(LED_ANIMATIONS)), yes)
+    OPT_DEFS += -DLED_ANIMATIONS_LEVEL=2
 endif
-ifeq ($(strip $(OLED_ENABLE)), yes)
-    SRC += oled_display.c
+
+ifeq ($(strip $(LED_ANIMATIONS)), mini)
+    OPT_DEFS += -DLED_ANIMATIONS_LEVEL=1
+    LED_ANIMATIONS = yes
 endif
 
 # convert Helix-specific options (that represent combinations of standard options)
 #   into QMK standard options.
 include $(strip $(KEYBOARD_LOCAL_FEATURES_MK))
+
+ifeq ($(strip $(OLED_ENABLE)), yes)
+    SRC += oled_display.c
+endif

--- a/keyboards/helix/rev2/keymaps/five_rows/rules.mk
+++ b/keyboards/helix/rev2/keymaps/five_rows/rules.mk
@@ -38,6 +38,12 @@ ifneq ($(strip $(HELIX)),)
     ifeq ($(strip $1),console)
         CONSOLE_ENABLE = yes
     endif
+    ifeq ($(strip $1),debug)
+        DEBUG_CONFIG = yes
+    endif
+    ifneq ($(filter nodebug no-debug no_debug,$(strip $1)),)
+        DEBUG_CONFIG = no
+    endif
     ifneq ($(filter na no_ani no-ani,$(strip $1)),)
         LED_ANIMATIONS = no
     endif
@@ -67,6 +73,10 @@ endif
 ifeq ($(strip $(LED_ANIMATIONS)), mini)
     OPT_DEFS += -DLED_ANIMATIONS_LEVEL=1
     LED_ANIMATIONS = yes
+endif
+
+ifeq ($(strip $(DEBUG_CONFIG)), yes)
+    OPT_DEFS += -DDEBUG_CONFIG
 endif
 
 # convert Helix-specific options (that represent combinations of standard options)


### PR DESCRIPTION
## Description

Update rules.mk and config.h of `helix/rev2:five_rows`

* align rgblight animation selection method to `rev3_5rows/keymap/five_rows`.
* align OLED driver selection method to `rev2/keymap/default`.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
