### PR TITLE
Add a VIA Configurator compatibility keymap for Mitosis.

### DIFF
--- a/keyboards/mitosis/config.h
+++ b/keyboards/mitosis/config.h
@@ -22,10 +22,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* USB Device descriptor parameter */
 
-#define VENDOR_ID       0xFEED
-#define PRODUCT_ID      0x6060
+#define VENDOR_ID       0x5242  // RB for /u/reverse_bias
+#define PRODUCT_ID      0x4d54  // MT for Mitosis
 #define DEVICE_VER      0x0001
-#define MANUFACTURER    Unknown
+#define MANUFACTURER    /u/reverse_bias
 #define PRODUCT         Mitosis
 
 /* key matrix size */

--- a/keyboards/mitosis/keymaps/default/keymap.c
+++ b/keyboards/mitosis/keymaps/default/keymap.c
@@ -1,5 +1,5 @@
-// this is the style you want to emulate.
 // This is the canonical layout file for the Quantum project. If you want to add another keyboard,
+// this is the style you want to emulate.
 
 #include QMK_KEYBOARD_H
 

--- a/keyboards/mitosis/keymaps/via/README.md
+++ b/keyboards/mitosis/keymaps/via/README.md
@@ -1,0 +1,13 @@
+# VIA Configurator Support Layout
+
+This "keymap" provides support for the [VIA
+Configurator](http://www.caniusevia.com).  The layout defined by the included
+keymap.c is used only as the default to initialize the VIA layout on a
+newly-flashed board, and should not contain any custom keycodes, since they
+show up as not-very-user-friendly opaque hex codes in VIA.  Since its purpose
+is to make the keyboard more or less work until the user can configure it with
+VIA, it should also be a fairly "normal" layout, i.e. QWERTY with minimal bells
+and whistles.  So, the keymap.c is derived from carvac\_dv, which provides a
+QWERTY layout for the main keys and doesn't use any custom keycodes.  The only
+modification is that it adds an empty fourth layer, because VIA expects to use
+four layers, and will see uninitialized garbage otherwise.

--- a/keyboards/mitosis/keymaps/via/keymap.c
+++ b/keyboards/mitosis/keymaps/via/keymap.c
@@ -1,0 +1,136 @@
+/* Copyright 2020-2021 Andrew Pritchard
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// This is the VIA Configurator compatibility layout, derived from carvac_dv.
+
+#include QMK_KEYBOARD_H
+
+enum mitosis_layers
+{
+    _STD,
+    _NUM,
+    _FN,
+    _EXTRA
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+  /* QWERTY
+   * .--------------------------------------------..--------------------------------------------.
+   * | Q      | W      | E      | R      | T      || Y      | U      | I      | O      | P      |
+   * |--------+--------+--------+--------+--------||--------+--------+--------+--------+--------|
+   * | A      | S      | D      | F      | G      || J      | H      | K      | L      | ;      |
+   * |--------+--------+--------+--------+--------||--------+--------+--------+--------+--------|
+   * | Z      | X      | C      | V      | B      || N      | M      | ,      | .      | /      |
+   * '--------+--------+--------+--------+--------||--------+--------+--------+--------+--------'
+   *          | PGUP   | TAB    | LCTRL  | SPACE  || LSHIFT | ENTER  | UP     | PSCR   |
+   *          |--------+--------+--------+--------||--------+--------+--------+--------|
+   *          | PGDN   | LGUI   | LALT   | FN     || NUM    | LEFT   | DOWN   | RIGHT  |
+   *          '-----------------------------------''-----------------------------------'
+   */
+  [_STD] = LAYOUT( /* Standard; as compatible with dvorak and qwerty as possible */
+    KC_Q, KC_W,    KC_E,    KC_R,    KC_T,      KC_Y,      KC_U,    KC_I,    KC_O,    KC_P,
+    KC_A, KC_S,    KC_D,    KC_F,    KC_G,      KC_H,      KC_J,    KC_K,    KC_L,    KC_SCLN,
+    KC_Z, KC_X,    KC_C,    KC_V,    KC_B,      KC_N,      KC_M,    KC_COMM, KC_DOT,  KC_SLSH,
+          KC_PGUP, KC_TAB,  KC_LCTL, KC_SPC,    KC_LSFT,  KC_ENT,  KC_UP,   KC_PSCR,
+          KC_PGDN, KC_LGUI, KC_LALT, MO(_FN),   MO(_NUM), KC_LEFT, KC_DOWN, KC_RGHT
+  ),
+
+  /* Number layout, for data entry and programming purposes (Dvorak result in parens)
+   * .--------------------------------------------..--------------------------------------------.
+   * | TAB    |   (,<) |   (.>) | - ([{) | = (]}) || ] (=+) | pad *  | pad +  | pad -  | [ (/?) |
+   * |--------+--------+--------+--------+--------||--------+--------+--------+--------+--------|
+   * | 1      | 2      | 3      | 4      | 5      || 6      | 7      | 8      | 9      | 0      |
+   * |--------+--------+--------+--------+--------||--------+--------+--------+--------+--------|
+   * | F1     | F2     | F3     | F4     | F5     || F6     | F7     | F8     | F9     | F10    |
+   * '--------+--------+--------+--------+--------||--------+--------+--------+--------+--------'
+   *          | F11    | F12    |        |        ||        |        |        |        |
+   *          |--------+--------+--------+--------||--------+--------+--------+--------|
+   *          |        |        |        |        ||        |        |        |        |
+   *          '-----------------------------------''-----------------------------------'
+   */
+  [_NUM] = LAYOUT( /* Number layout along the home row for maximum speed*/
+    KC_TAB,  _______, _______, KC_MINS, KC_EQL,        KC_RBRC, KC_PAST, KC_PPLS, KC_PMNS, KC_LBRC,
+    KC_1,    KC_2,    KC_3,    KC_4,    KC_5,          KC_6,    KC_7,    KC_8,    KC_9,    KC_0,
+    KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,         KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,
+             KC_F11,  KC_F12,  _______, _______,       _______, _______, _______, _______,
+             _______, _______, _______, _______,       _______, _______, _______, _______
+  ),
+
+  /* Fn layout, for typing purposes (Dvorak result in parens)
+   * .--------------------------------------------..--------------------------------------------.
+   * | `      |        | MS_U   |        |        || WH_U   | WH_L   | BTN3   | WH_R   | [ (/?) |
+   * |--------+--------+--------+--------+--------||--------+--------+--------+--------+--------|
+   * | ESC    | MS_L   | MS_D   | MS_R   |        || WH_D   | BTN1   | BTN2   |        | ' (-_) |
+   * |--------+--------+--------+--------+--------||--------+--------+--------+--------+--------|
+   * | APP    | MPRV   | MPLY   | MSTP   | MNXT   ||        | BSPC   | DEL    | INS    | \      |
+   * '--------+--------+--------+--------+--------||--------+--------+--------+--------+--------'
+   *          | VOLU   |        |        |        ||        |        | PGUP   |        |
+   *          |--------+--------+--------+--------||--------+--------+--------+--------|
+   *          | VOLD   |        |        |        ||        | HOME   | PGDN   | END    |
+   *          '-----------------------------------''-----------------------------------'
+   */
+  [_FN] = LAYOUT( /* Function Layer, primary alternative layer featuring numpad on right hand,
+                                     cursor keys on left hand, and all symbols*/
+    KC_GRV,  _______, KC_MS_U, _______, _______,       KC_WH_U, KC_WH_L, KC_BTN3, KC_WH_R, KC_LBRC,
+    KC_ESC,  KC_MS_L, KC_MS_D, KC_MS_R, _______,       KC_WH_D, KC_BTN1, KC_BTN2, _______, KC_QUOT,
+    KC_APP,  KC_MPRV, KC_MPLY, KC_MSTP, KC_MNXT,       _______, KC_BSPC, KC_DEL,  KC_INS,  KC_BSLS,
+             KC_VOLU, _______, _______, _______,       _______, _______, KC_PGUP, _______,
+             KC_VOLD, _______, _______, _______,       _______, KC_HOME, KC_PGDN, KC_END
+  ),
+
+  /* VIA prefers to have four layers to avoid uninitialized EEPROM, so we
+   * provide a blank layer even though it's not enabled by any currently-mapped
+   * keys.
+   * .--------------------------------------------..--------------------------------------------.
+   * |        |        |        |        |        ||        |        |        |        |        |
+   * |--------+--------+--------+--------+--------||--------+--------+--------+--------+--------|
+   * |        |        |        |        |        ||        |        |        |        |        |
+   * |--------+--------+--------+--------+--------||--------+--------+--------+--------+--------|
+   * |        |        |        |        |        ||        |        |        |        |        |
+   * '--------+--------+--------+--------+--------||--------+--------+--------+--------+--------'
+   *          |        |        |        |        ||        |        |        |        |
+   *          |--------+--------+--------+--------||--------+--------+--------+--------|
+   *          |        |        |        |        ||        |        |        |        |
+   *          '-----------------------------------''-----------------------------------'
+   */
+  [_EXTRA] = LAYOUT(
+    _______,  _______, _______, _______, _______,       _______, _______, _______, _______, _______,
+    _______,  _______, _______, _______, _______,       _______, _______, _______, _______, _______,
+    _______,  _______, _______, _______, _______,       _______, _______, _______, _______, _______,
+              _______, _______, _______, _______,       _______, _______, _______, _______,
+              _______, _______, _______, _______,       _______, _______, _______, _______
+  ),
+};
+
+void matrix_scan_user(void) {
+    uint8_t layer = biton32(layer_state);
+
+    switch (layer) {
+        case _STD:
+            set_led_off;
+            break;
+        case _FN:
+            set_led_blue;
+            break;
+        case _NUM:
+            set_led_red;
+            break;
+        default:
+            break;
+    }
+};
+

--- a/keyboards/mitosis/keymaps/via/rules.mk
+++ b/keyboards/mitosis/keymaps/via/rules.mk
@@ -1,0 +1,2 @@
+VIA_ENABLE = yes
+LTO_ENABLE = yes


### PR DESCRIPTION
## Description

This involves a few changes to the core Mitosis configuration:

* Enable LTO, to trim down firmware size.  This could be done only for
  the VIA keymap, but it may as well be enabled everywhere.
* Set a non-conflicting USB vendor and product ID.  VIA identifies
  keyboards by their USB IDs, so they need to be unique.  I chose ASCII
  "RB" for the vendor (short for /u/reverse_bias) and "MT" for the
  product.
* Change the manufacturer field to /u/reverse_bias.  No particular
  reason for this other than aesthetics under lsusb: "Unknown Mitosis"
  looked a bit unfinished.

The default layout for the VIA keymap is identical to carvac_dv, since
it's a fairly normal QWERTY layout without many bells and whistles
(particularly, no custom keycodes, which don't go great with VIA).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
