### PR TITLE
Add build debug option to tmk_core/rules.mk

### DIFF
--- a/tmk_core/rules.mk
+++ b/tmk_core/rules.mk
@@ -329,10 +329,10 @@ $1/%.o : %.c $1/%.d $1/cflags.txt $1/compiler.txt | $(BEGIN)
 	@$$(SILENT) || printf "$$(MSG_COMPILING) $$<" | $$(AWK_CMD)
 	$$(eval CMD := $$(CC) -c $$($1_CFLAGS) $$(INIT_HOOK_CFLAGS) $$(GENDEPFLAGS) $$< -o $$@ && $$(MOVE_DEP))
 	@$$(BUILD_CMD)
-ifeq ($(DUMP_C_MACROS),yes)
+  ifneq ($$(DUMP_C_MACROS),)
 	$$(eval CMD := $$(CC) -E -dM $$($1_CFLAGS) $$(INIT_HOOK_CFLAGS) $$(GENDEPFLAGS) $$<)
-	@$$(BUILD_CMD)
-endif
+	@$$(if $$(filter $$(DUMP_C_MACROS),$$(notdir $$<)),$$(BUILD_CMD))
+  endif
 
 # Compile: create object files from C++ source files.
 $1/%.o : %.cpp $1/%.d $1/cxxflags.txt $1/compiler.txt | $(BEGIN)

--- a/tmk_core/rules.mk
+++ b/tmk_core/rules.mk
@@ -150,6 +150,9 @@ ifeq ($(strip $(DEBUG_ENABLE)),yes)
 else
   ASFLAGS += -Wa,-adhlns=$(@:%.o=%.lst),--listing-cont-lines=100
 endif
+ifeq ($(VERBOSE_AS_CMD),yes)
+	ASFLAGS += -v
+endif
 
 #---------------- Library Options ----------------
 # Minimalistic printf version
@@ -191,6 +194,9 @@ CREATE_MAP ?= yes
 
 ifeq ($(CREATE_MAP),yes)
 	LDFLAGS += -Wl,-Map=$(BUILD_DIR)/$(TARGET).map,--cref
+endif
+ifeq ($(VERBOSE_LD_CMD),yes)
+	LDFLAGS += -v
 endif
 #LDFLAGS += -Wl,--relax
 LDFLAGS += $(EXTMEMOPTS)

--- a/tmk_core/rules.mk
+++ b/tmk_core/rules.mk
@@ -329,6 +329,10 @@ $1/%.o : %.c $1/%.d $1/cflags.txt $1/compiler.txt | $(BEGIN)
 	@$$(SILENT) || printf "$$(MSG_COMPILING) $$<" | $$(AWK_CMD)
 	$$(eval CMD := $$(CC) -c $$($1_CFLAGS) $$(INIT_HOOK_CFLAGS) $$(GENDEPFLAGS) $$< -o $$@ && $$(MOVE_DEP))
 	@$$(BUILD_CMD)
+ifeq ($(DUMP_C_MACROS),yes)
+	$$(eval CMD := $$(CC) -E -dM $$($1_CFLAGS) $$(INIT_HOOK_CFLAGS) $$(GENDEPFLAGS) $$<)
+	@$$(BUILD_CMD)
+endif
 
 # Compile: create object files from C++ source files.
 $1/%.o : %.cpp $1/%.d $1/cxxflags.txt $1/compiler.txt | $(BEGIN)

--- a/tmk_core/rules.mk
+++ b/tmk_core/rules.mk
@@ -333,12 +333,19 @@ $1_ASFLAGS = $$(ALL_ASFLAGS) $$($1_DEFS) $$($1_INCFLAGS) $$($1_CONFIG_FLAGS)
 $1/%.o : %.c $1/%.d $1/cflags.txt $1/compiler.txt | $(BEGIN)
 	@mkdir -p $$(@D)
 	@$$(SILENT) || printf "$$(MSG_COMPILING) $$<" | $$(AWK_CMD)
-	$$(eval CMD := $$(CC) -c $$($1_CFLAGS) $$(INIT_HOOK_CFLAGS) $$(GENDEPFLAGS) $$< -o $$@ && $$(MOVE_DEP))
+	$$(eval CC_EXEC := $$(CC))
+    ifneq ($$(VERBOSE_C_CMD),)
+	$$(if $$(filter $$(VERBOSE_C_CMD),$$(notdir $$<)),$$(eval CC_EXEC += -v))
+    endif
+    ifneq ($$(VERBOSE_C_INCLUDE),)
+	$$(if $$(filter $$(VERBOSE_C_INCLUDE),$$(notdir $$<)),$$(eval CC_EXEC += -H))
+    endif
+	$$(eval CMD := $$(CC_EXEC) -c $$($1_CFLAGS) $$(INIT_HOOK_CFLAGS) $$(GENDEPFLAGS) $$< -o $$@ && $$(MOVE_DEP))
 	@$$(BUILD_CMD)
-  ifneq ($$(DUMP_C_MACROS),)
+    ifneq ($$(DUMP_C_MACROS),)
 	$$(eval CMD := $$(CC) -E -dM $$($1_CFLAGS) $$(INIT_HOOK_CFLAGS) $$(GENDEPFLAGS) $$<)
 	@$$(if $$(filter $$(DUMP_C_MACROS),$$(notdir $$<)),$$(BUILD_CMD))
-  endif
+    endif
 
 # Compile: create object files from C++ source files.
 $1/%.o : %.cpp $1/%.d $1/cxxflags.txt $1/compiler.txt | $(BEGIN)

--- a/tmk_core/rules.mk
+++ b/tmk_core/rules.mk
@@ -335,16 +335,16 @@ $1/%.o : %.c $1/%.d $1/cflags.txt $1/compiler.txt | $(BEGIN)
 	@$$(SILENT) || printf "$$(MSG_COMPILING) $$<" | $$(AWK_CMD)
 	$$(eval CC_EXEC := $$(CC))
     ifneq ($$(VERBOSE_C_CMD),)
-	$$(if $$(filter $$(VERBOSE_C_CMD),$$(notdir $$<)),$$(eval CC_EXEC += -v))
+	$$(if $$(filter $$(notdir $$(VERBOSE_C_CMD)),$$(notdir $$<)),$$(eval CC_EXEC += -v))
     endif
     ifneq ($$(VERBOSE_C_INCLUDE),)
-	$$(if $$(filter $$(VERBOSE_C_INCLUDE),$$(notdir $$<)),$$(eval CC_EXEC += -H))
+	$$(if $$(filter $$(notdir $$(VERBOSE_C_INCLUDE)),$$(notdir $$<)),$$(eval CC_EXEC += -H))
     endif
 	$$(eval CMD := $$(CC_EXEC) -c $$($1_CFLAGS) $$(INIT_HOOK_CFLAGS) $$(GENDEPFLAGS) $$< -o $$@ && $$(MOVE_DEP))
 	@$$(BUILD_CMD)
     ifneq ($$(DUMP_C_MACROS),)
 	$$(eval CMD := $$(CC) -E -dM $$($1_CFLAGS) $$(INIT_HOOK_CFLAGS) $$(GENDEPFLAGS) $$<)
-	@$$(if $$(filter $$(DUMP_C_MACROS),$$(notdir $$<)),$$(BUILD_CMD))
+	@$$(if $$(filter $$(notdir $$(DUMP_C_MACROS)),$$(notdir $$<)),$$(BUILD_CMD))
     endif
 
 # Compile: create object files from C++ source files.


### PR DESCRIPTION
## Description

The following variables have been added to `tmk_core/rules.mk` for build debugging.

* DUMP_C_MACROS
* VERBOSE_LD_CMD
* VERBOSE_AS_CMD
* VERBOSE_C_CMD
* VERBOSE_C_INCLUDE

### DUMP_C_MACROS variable

If you specify the source file name in this `DUMP_C_MACROS` Makefile variable, you can observe the definition of the C macro that is finalized at compile time.

Usage:
```
% make lets_split/rev2:mjt:clean
% make DUMP_C_MACROS=keymap.c lets_split/rev2:mjt > /tmp/macrolog
% grep RGBLIGHT /tmp/macrolog
```
<details>
<summary><strong>The result is as follows:(click)</strong></summary>

```
 | #define RGBLIGHT_EFFECT_KNIGHT 
 | #define RGBLIGHT_SAT_STEP 17
 | #define RGBLIGHT_EFFECT_SNAKE_LENGTH 4
 | #define RGBLIGHT_EFFECT_ALTERNATING 
 | #define RGBLIGHT_EFFECT_CHRISTMAS_STEP 2
 | #define RGBLIGHT_EFFECT_TWINKLE_PROBABILITY 1 / 127
 | #define RGBLIGHT_EFFECT_RGB_TEST 
 | #define RGBLIGHT_EFFECT_RAINBOW_MOOD 
 | #define RGBLIGHT_EFFECT_KNIGHT_OFFSET 0
 | #define RGBLIGHT_EFFECT_SNAKE 
 | #define RGBLIGHT_LIMIT_VAL 255
 | #define RGBLIGHT_EFFECT_CHRISTMAS_INTERVAL 40
 | #define RGBLIGHT_ANIMATIONS 
 | #define RGBLIGHT_EFFECT_KNIGHT_LED_NUM (rgblight_ranges.effect_num_leds)
 | #define RGBLIGHT_EFFECT_STATIC_GRADIENT 
 | #define RGBLIGHT_ENABLE 1
 | #define RGBLIGHT_HUE_STEP 8
 | #define RGBLIGHT_EFFECT_CHRISTMAS 
 | #define RGBLIGHT_EFFECT_RAINBOW_SWIRL 
 | #define RGBLIGHT_EFFECT_TWINKLE 
 | #define RGBLIGHT_EFFECT_KNIGHT_LENGTH 3
 | #define RGBLIGHT_MODES (RGBLIGHT_MODE_last - 1)
 | #define RGBLIGHT_VAL_STEP 17
 | #define RGBLIGHT_USE_TIMER 
 | #define RGBLIGHT_EFFECT_TWINKLE_LIFE 75
 | #define RGBLIGHT_EFFECT_BREATHING 
 | #define EECONFIG_RGBLIGHT (uint32_t *)8
 | #define RGBLIGHT_EFFECT_BREATHE_MAX 255
```
</details>

### VERBOSE_LD_CMD variable

You can run the link command with the -v option by setting the `VERBOSE_LD_CMD` variable to yes.

Usage:
```
% make lets_split/rev2:mjt:clean
% make VERBOSE_LD_CMD=yes lets_split/rev2:mjt
```

<details>
<summary><strong>The result is as follows:(click)</strong></summary>

```
....skip......
Compiling: lib/lufa/LUFA/Drivers/USB/Core/HostStandardReq.c           [OK]
Compiling: lib/lufa/LUFA/Drivers/USB/Core/USBTask.c                   [OK]
Linking: .build/lets_split_rev2_mjt.elf                               [WARNINGS]
 | 
 | Using built-in specs.
 | Reading specs from /usr/local/Cellar/avr-gcc@8/8.4.0/lib/avr-gcc/8/gcc/avr/8.4.0/device-specs/specs-atmega32u4
 | COLLECT_GCC=avr-gcc
 | COLLECT_LTO_WRAPPER=/usr/local/Cellar/avr-gcc@8/8.4.0/libexec/gcc/avr/8.4.0/lto-wrapper
 | Target: avr
 | Configured with: ../configure --target=avr --prefix=/usr/local/Cellar/avr-gcc@8/8.4.0 --libdir=/usr/local/Cellar/avr-gcc@8/8.4.0/lib/avr-gcc/8 --enable-languages=c,c++ --with-ld=/usr/local/opt/avr-binutils/bin/avr-ld --with-as=/usr/local/opt/avr-binutils/bin/avr-as --disable-nls --disable-libssp --disable-shared --disable-threads --disable-libgomp --with-dwarf2 --with-avrlibc --with-pkgversion='Homebrew AVR GCC 8.4.0' --with-bugurl=https://github.com/osx-cross/homebrew-avr/issues
 | Thread model: single
 | gcc version 8.4.0 (Homebrew AVR GCC 8.4.0) 
 | COMPILER_PATH=/usr/local/Cellar/avr-gcc@8/8.4.0/libexec/gcc/avr/8.4.0/:/usr/local/Cellar/avr-gcc@8/8.4.0/libexec/gcc/avr/8.4.0/:/usr/local/Cellar/avr-gcc@8/8.4.0/libexec/gcc/avr/:/usr/local/Cellar/avr-gcc@8/8.4.0/lib/avr-gcc/8/gcc/avr/8.4.0/:/usr/local/Cellar/avr-gcc@8/8.4.0/lib/avr-gcc/8/gcc/avr/
 | LIBRARY_PATH=/usr/local/Cellar/avr-gcc@8/8.4.0/lib/avr-gcc/8/gcc/avr/8.4.0/avr5/:/usr/local/Cellar/avr-gcc@8/8.4.0/lib/avr-gcc/8/gcc/avr/8.4.0/../../../../../../avr/lib/avr5/:/usr/local/Cellar/avr-gcc@8/8.4.0/lib/avr-gcc/8/gcc/avr/8.4.0/:/usr/local/Cellar/avr-gcc@8/8.4.0/lib/avr-gcc/8/gcc/avr/8.4.0/../../../../../../avr/lib/
 | COLLECT_GCC_OPTIONS='-fdiagnostics-color=always'  '-funsigned-char' '-funsigned-bitfields' '-ffunction-sections' '-fdata-sections' '-fpack-struct' '-fshort-enums' '-fno-inline-small-functions' '-fno-strict-aliasing' '-gdwarf-2' '-Os' '-Wall' '-Wstrict-prototypes' '-Werror' '-std=gnu99' '-o' '.build/lets_split_rev2_mjt.elf' '-v' '-specs=device-specs/specs-atmega32u4' '-mmcu=avr5'
....skip......

```
</details>

### VERBOSE_AS_CMD variable

You can run the as command with the -v option by setting the `VERBOSE_AS_CMD` variable to yes.

Usage:
```
% make lets_split/rev2:mjt:clean
% make VERBOSE_AS_CMD=yes lets_split/rev2:mjt
```

<details>
<summary><strong>The result is as follows:(click)</strong></summary>

```
....skip......
Compiling: tmk_core/common/avr/suspend.c                        [OK]
Compiling: tmk_core/common/avr/timer.c                          [OK]
Compiling: tmk_core/common/avr/bootloader.c                     [OK]
Assembling: tmk_core/common/avr/xprintf.S                       [WARNINGS]
 | 
 | Using built-in specs.
 | Reading specs from /usr/local/Cellar/avr-gcc@8/8.4.0/lib/avr-gcc/8/gcc/avr/8.4.0/device-specs/specs-atmega32u4
 | COLLECT_GCC=avr-gcc
 | Target: avr
 | Configured with: ../configure --target=avr --prefix=/usr/local/Cellar/avr-gcc@8/8.4.0 --libdir=/usr/local/Cellar/avr-gcc@8/8.4.0/lib/avr-gcc/8 --enable-languages=c,c++ --with-ld=/usr/local/opt/avr-binutils/bin/avr-ld --with-as=/usr/local/opt/avr-binutils/bin/avr-as --disable-nls --disable-libssp --disable-shared --disable-threads --disable-libgomp --with-dwarf2 --with-avrlibc --with-pkgversion='Homebrew AVR GCC 8.4.0' --with-bugurl=https://github.com/osx-cross/homebrew-avr/issues
 | Thread model: single
 | gcc version 8.4.0 (Homebrew AVR GCC 8.4.0) 
 | COLLECT_GCC_OPTIONS='-c'  '-v' '-D' 'INTERRUPT_CONTROL_ENDPOINT' '-D' 'KEYBOARD_' '-D' 'KEYBOARD_' '-D' 'KEYBOARD_' '-D' 'KEYBOARD_lets_split' '-D' 'KEYBOARD_lets_split_rev2' '-D' 'EEPROM_ENABLE' '-D' 'EEPROM_VENDOR' '-D' 'RGBLIGHT_ENABLE' '-D' 'WS2812_DRIVER_BITBANG' '-D' 'USE_CIE1931_CURVE' '-D' 'SPLIT_KEYBOARD' '-D' 'SERIAL_DRIVER_BITBANG' '-D' 'SPACE_CADET_ENABLE' '-D' 'MAGIC_KEYCODE_ENABLE' '-D' 'GRAVE_ESC_ENABLE' '-D' 'BOOTLOADER_CATERINA' '-D' 'BOOTLOADER_SIZE=4096' '-D' 'MAGIC_ENABLE' '-D' 'MOUSEKEY_ENABLE' '-D' 'MOUSE_ENABLE' '-D' 'MOUSE_SHARED_EP' '-D' 'EXTRAKEY_ENABLE' '-D' 'NO_PRINT' '-D' 'NO_DEBUG' '-D' 'NKRO_ENABLE' '-D' 'SHARED_EP_ENABLE' '-D' 'F_CPU=16000000UL' '-D' 'F_USB=16000000UL' '-D' 'ARCH=ARCH_AVR8' '-D' 'USB_DEVICE_ONLY' '-D' 'USE_FLASH_DESCRIPTORS' '-D' 'USE_STATIC_OPTIONS=(USB_DEVICE_OPT_FULLSPEED | USB_OPT_REG_ENABLED | USB_OPT_AUTO_PLL)' '-D' 'FIXED_CONTROL_ENDPOINT_SIZE=8' '-D' 'FIXED_CONTROL_ENDPOINT_SIZE=8' '-D' 'FIXED_NUM_CONFIGURATIONS=1' '-D' 'PROTOCOL_LUFA' '-D' 'QMK_KEYBOARD="lets_split/rev2"' '-D' 'QMK_KEYBOARD_H="lets_split.h"' '-D' 'QMK_KEYBOARD_CONFIG_H="keyboards/lets_split/rev2/config.h"' '-D' 'QMK_KEYMAP="mjt"' '-D' 'QMK_KEYMAP_H="mjt.h"' '-D' 'QMK_KEYMAP_CONFIG_H="keyboards/lets_split/keymaps/mjt/config.h"' '-D' 'QMK_SUBPROJECT' '-D' 'QMK_SUBPROJECT_H' '-D' 'QMK_SUBPROJECT_CONFIG_H' '-I' 'keyboards/lets_split/keymaps/mjt' '-I' 'users/mjt' '-I' 'keyboards/.' '-I' 'keyboards/.' '-I' 'keyboards/.' '-I' 'keyboards/lets_split' '-I' 'keyboards/lets_split/rev2' '-I' '.' '-I' 'tmk_core' '-I' 'quantum' '-I' 'quantum/keymap_extras' '-I' 'quantum/audio' '-I' 'quantum/process_keycode' '-I' 'quantum/api' '-I' 'quantum/sequencer' '-I' 'drivers' '-I' 'quantum/split_common' '-I' 'drivers/avr' '-I' 'tmk_core/protocol' '-I' 'tmk_core/common' '-I' 'tmk_core/common/avr' '-I' 'tmk_core/protocol/lufa' '-I' 'lib/lufa' '-I' 'drivers/avr' '-include' 'keyboards/lets_split/config.h' '-include' 'keyboards/lets_split/rev2/config.h' '-include' 'keyboards/lets_split/keymaps/mjt/config.h' '-include' 'quantum/rgblight_post_config.h' '-include' 'quantum/split_common/post_config.h' '-o' '.build/obj_lets_split_rev2_mjt/common/avr/xprintf.o' '-specs=device-specs/specs-atmega32u4' '-mmcu=avr5'
....skip......
Compiling: tmk_core/common/magic.c                              [OK]
Compiling: tmk_core/common/mousekey.c                           [OK]
Compiling: tmk_core/protocol/lufa/lufa.c                        [OK]
Compiling: tmk_core/protocol/usb_descriptor.c                   [OK]
....skip......
```
</details>

### VERBOSE_C_CMD variable

If you specify the source file name in this VERBOSE_C_CMD Makefile variable, You can run the gcc command with the -v option.

Usage:
```
% make lets_split/rev2:mjt:clean
% make VERBOSE_C_CMD=keymap.c lets_split/rev2:mjt
```

<details>
<summary><strong>The result is as follows:(click)</strong></summary>

```
....skip......
Compiling: keyboards/lets_split/lets_split.c              [OK]
Compiling: keyboards/lets_split/rev2/rev2.c               [OK]
Compiling: keyboards/lets_split/keymaps/mjt/keymap.c                                               Using built-in specs.
Reading specs from /usr/local/Cellar/avr-gcc@8/8.4.0/lib/avr-gcc/8/gcc/avr/8.4.0/device-specs/specs-atmega32u4
COLLECT_GCC=avr-gcc
Target: avr
Configured with: ../configure --target=avr --prefix=/usr/local/Cellar/avr-gcc@8/8.4.0 --libdir=/usr/local/Cellar/avr-gcc@8/8.4.0/lib/avr-gcc/8 --enable-languages=c,c++ --with-ld=/usr/local/opt/avr-binutils/bin/avr-ld --with-as=/usr/local/opt/avr-binutils/bin/avr-as --disable-nls --disable-libssp --disable-shared --disable-threads --disable-libgomp --with-dwarf2 --with-avrlibc --with-pkgversion='Homebrew AVR GCC 8.4.0' --with-bugurl=https://github.com/osx-cross/homebrew-avr/issues
Thread model: single
gcc version 8.4.0 (Homebrew AVR GCC 8.4.0) 
COLLECT_GCC_OPTIONS='-fdiagnostics-color=always' '-v' '-c'  '-funsigned-char' '-funsigned-bitfields' '-ffunction-sections' '-fdata-sections' '-fpack-struct' '-fshort-enums' '-fno-inline-small-functions' '-fno-strict-aliasing' '-gdwarf-2' '-Os' '-Wall' '-Wstrict-prototypes' '-Werror' '-std=gnu99' '-D' 'INTERRUPT_CONTROL_ENDPOINT' '-D' 'KEYBOARD_' '-D' 'KEYBOARD_' '-D' 'KEYBOARD_' '-D' 'KEYBOARD_lets_split' '-D' 'KEYBOARD_lets_split_rev2' '-D' 'EEPROM_ENABLE' '-D' 'EEPROM_VENDOR' '-D' 'RGBLIGHT_ENABLE' '-D' 'WS2812_DRIVER_BITBANG' '-D' 'USE_CIE1931_CURVE' '-D' 'SPLIT_KEYBOARD' '-D' 'SERIAL_DRIVER_BITBANG' '-D' 'SPACE_CADET_ENABLE' '-D' 'MAGIC_KEYCODE_ENABLE' '-D' 'GRAVE_ESC_ENABLE' '-D' 'BOOTLOADER_CATERINA' '-D' 'BOOTLOADER_SIZE=4096' '-D' 'MAGIC_ENABLE' '-D' 'MOUSEKEY_ENABLE' '-D' 'MOUSE_ENABLE' '-D' 'MOUSE_SHARED_EP' '-D' 'EXTRAKEY_ENABLE' '-D' 'NO_PRINT' '-D' 'NO_DEBUG' '-D' 'NKRO_ENABLE' '-D' 'SHARED_EP_ENABLE' '-D' 'F_CPU=16000000UL' '-D' 'F_USB=16000000UL' '-D' 'ARCH=ARCH_AVR8' '-D' 'USB_DEVICE_ONLY' '-D' 'USE_FLASH_DESCRIPTORS' '-D' 'USE_STATIC_OPTIONS=(USB_DEVICE_OPT_FULLSPEED | USB_OPT_REG_ENABLED | USB_OPT_AUTO_PLL)' '-D' 'FIXED_CONTROL_ENDPOINT_SIZE=8' '-D' 'FIXED_CONTROL_ENDPOINT_SIZE=8' '-D' 'FIXED_NUM_CONFIGURATIONS=1' '-D' 'PROTOCOL_LUFA' '-D' 'QMK_KEYBOARD="lets_split/rev2"' '-D' 'QMK_KEYBOARD_H="lets_split.h"' '-D' 'QMK_KEYBOARD_CONFIG_H="keyboards/lets_split/rev2/config.h"' '-D' 'QMK_KEYMAP="mjt"' '-D' 'QMK_KEYMAP_H="mjt.h"' '-D' 'QMK_KEYMAP_CONFIG_H="keyboards/lets_split/keymaps/mjt/config.h"' '-D' 'QMK_SUBPROJECT' '-D' 'QMK_SUBPROJECT_H' '-D' 'QMK_SUBPROJECT_CONFIG_H' '-I' 'keyboards/lets_split/keymaps/mjt' '-I' 'users/mjt' '-I' 'keyboards/.' '-I' 'keyboards/.' '-I' 'keyboards/.' '-I' 'keyboards/lets_split' '-I' 'keyboards/lets_split/rev2' '-I' '.' '-I' 'tmk_core' '-I' 'quantum' '-I' 'quantum/keymap_extras' '-I' 'quantum/audio' '-I' 'quantum/process_keycode' '-I' 'quantum/api' '-I' 'quantum/sequencer' '-I' 'drivers' '-I' 'quantum/split_common' '-I' 'drivers/avr' '-I' 'tmk_core/protocol' '-I' 'tmk_core/common' '-I' 'tmk_core/common/avr' '-I' 'tmk_core/protocol/lufa' '-I' 'lib/lufa' '-I' 'drivers/avr' '-include' 'keyboards/lets_split/config.h' '-include' 'keyboards/lets_split/rev2/config.h' '-include' 'keyboards/lets_split/keymaps/mjt/config.h' '-include' 'quantum/rgblight_post_config.h' '-include' 'quantum/split_common/post_config.h' '-MMD' '-MP' '-MF' '.build/obj_lets_split_rev2_mjt/keyboards/lets_split/keymaps/mjt/keymap.td' '-o' '.build/obj_lets_split_rev2_mjt/keyboards/lets_split/keymaps/mjt/keymap.o' '-specs=device-specs/specs-atmega32u4' '-mmcu=avr5'
....skip......
Compiling: quantum/quantum.c                              [OK]
Compiling: quantum/led.c                                  [OK]
Compiling: quantum/keymap_common.c                        [OK]
Compiling: quantum/keycode_config.c                       [OK]
....skip......
```
</details>

### VERBOSE_C_INCLUDE variable

If you specify the source file name in this VERBOSE_C_INCLUDE Makefile variable, you can check the file name included at compile time.

Usage:
```
% make lets_split/rev2:mjt:clean
% make VERBOSE_C_INCLUDE=keymap.c lets_split/rev2:mjt
```

<details>
<summary><strong>The result is as follows:(click)</strong></summary>

```
....skip......
Compiling: keyboards/lets_split/lets_split.c              [OK]
Compiling: keyboards/lets_split/rev2/rev2.c               [OK]
Compiling: keyboards/lets_split/keymaps/mjt/keymap.c
. keyboards/lets_split/lets_split.h
.. quantum/quantum.h
... /usr/local/Cellar/avr-gcc@8/8.4.0/avr/include/avr/pgmspace.h
.... /usr/local/Cellar/avr-gcc@8/8.4.0/lib/avr-gcc/8/gcc/avr/8.4.0/include/stddef.h
... /usr/local/Cellar/avr-gcc@8/8.4.0/avr/include/avr/interrupt.h
... tmk_core/common/wait.h
.... /usr/local/Cellar/avr-gcc@8/8.4.0/avr/include/util/delay.h
..... /usr/local/Cellar/avr-gcc@8/8.4.0/avr/include/util/delay_basic.h
..... /usr/local/Cellar/avr-gcc@8/8.4.0/avr/include/math.h
... tmk_core/common/matrix.h
.... /usr/local/Cellar/avr-gcc@8/8.4.0/lib/avr-gcc/8/gcc/avr/8.4.0/include/stdbool.h
... quantum/keymap.h
.... tmk_core/common/action.h
..... tmk_core/common/keyboard.h
..... tmk_core/common/keycode.h
..... tmk_core/common/action_code.h
..... tmk_core/common/action_macro.h
...... tmk_core/common/progmem.h
.... tmk_core/common/report.h
..... tmk_core/protocol/usb_descriptor.h
...... lib/lufa/LUFA/Drivers/USB/USB.h
....... lib/lufa/LUFA/Drivers/USB/../../Common/Common.h
........ /usr/local/Cellar/avr-gcc@8/8.4.0/avr/include/string.h
......... /usr/local/Cellar/avr-gcc@8/8.4.0/lib/avr-gcc/8/gcc/avr/8.4.0/include/stddef.h
........ /usr/local/Cellar/avr-gcc@8/8.4.0/lib/avr-gcc/8/gcc/avr/8.4.0/include/stddef.h
........ lib/lufa/LUFA/Drivers/USB/../../Common/Architectures.h
........ lib/lufa/LUFA/Drivers/USB/../../Common/BoardTypes.h
........ lib/lufa/LUFA/Drivers/USB/../../Common/ArchitectureSpecific.h
........ lib/lufa/LUFA/Drivers/USB/../../Common/CompilerSpecific.h
........ lib/lufa/LUFA/Drivers/USB/../../Common/Attributes.h
........ /usr/local/Cellar/avr-gcc@8/8.4.0/avr/include/avr/eeprom.h
......... /usr/local/Cellar/avr-gcc@8/8.4.0/lib/avr-gcc/8/gcc/avr/8.4.0/include/stddef.h
........ /usr/local/Cellar/avr-gcc@8/8.4.0/avr/include/avr/boot.h
......... /usr/local/Cellar/avr-gcc@8/8.4.0/lib/avr-gcc/8/gcc/avr/8.4.0/include-fixed/limits.h
........ lib/lufa/LUFA/Drivers/USB/../../Common/Endianness.h
....... lib/lufa/LUFA/Drivers/USB/Core/USBMode.h
........ lib/lufa/LUFA/Drivers/USB/Core/../../../Common/Common.h
....... lib/lufa/LUFA/Drivers/USB/Core/USBTask.h
........ lib/lufa/LUFA/Drivers/USB/Core/USBMode.h
........ lib/lufa/LUFA/Drivers/USB/Core/USBController.h
......... lib/lufa/LUFA/Drivers/USB/Core/AVR8/USBController_AVR8.h
.......... lib/lufa/LUFA/Drivers/USB/Core/AVR8/../../../../Common/Common.h
.......... lib/lufa/LUFA/Drivers/USB/Core/AVR8/../USBMode.h
.......... lib/lufa/LUFA/Drivers/USB/Core/AVR8/../Events.h
........... lib/lufa/LUFA/Drivers/USB/Core/AVR8/../../../../Common/Common.h
........... lib/lufa/LUFA/Drivers/USB/Core/AVR8/../USBMode.h
.......... lib/lufa/LUFA/Drivers/USB/Core/AVR8/../USBTask.h
.......... lib/lufa/LUFA/Drivers/USB/Core/AVR8/../USBInterrupt.h
........... lib/lufa/LUFA/Drivers/USB/Core/AVR8/../AVR8/USBInterrupt_AVR8.h
............ lib/lufa/LUFA/Drivers/USB/Core/AVR8/../AVR8/../../../../Common/Common.h
............ lib/lufa/LUFA/Drivers/USB/Core/AVR8/../AVR8/../USBMode.h
............ lib/lufa/LUFA/Drivers/USB/Core/AVR8/../AVR8/../Events.h
............ lib/lufa/LUFA/Drivers/USB/Core/AVR8/../AVR8/../USBController.h
.......... lib/lufa/LUFA/Drivers/USB/Core/AVR8/../Device.h
........... lib/lufa/LUFA/Drivers/USB/Core/AVR8/../StdDescriptors.h
............ lib/lufa/LUFA/Drivers/USB/Core/AVR8/../Events.h
........... lib/lufa/LUFA/Drivers/USB/Core/AVR8/../USBInterrupt.h
........... lib/lufa/LUFA/Drivers/USB/Core/AVR8/../Endpoint.h
............ lib/lufa/LUFA/Drivers/USB/Core/AVR8/../AVR8/Endpoint_AVR8.h
............. lib/lufa/LUFA/Drivers/USB/Core/AVR8/../AVR8/../USBTask.h
............. lib/lufa/LUFA/Drivers/USB/Core/AVR8/../AVR8/../USBInterrupt.h
........... lib/lufa/LUFA/Drivers/USB/Core/AVR8/../AVR8/Device_AVR8.h
............ lib/lufa/LUFA/Drivers/USB/Core/AVR8/../AVR8/../StdDescriptors.h
............ lib/lufa/LUFA/Drivers/USB/Core/AVR8/../AVR8/../Endpoint.h
.......... lib/lufa/LUFA/Drivers/USB/Core/AVR8/../Endpoint.h
.......... lib/lufa/LUFA/Drivers/USB/Core/AVR8/../DeviceStandardReq.h
........... lib/lufa/LUFA/Drivers/USB/Core/AVR8/../StdRequestType.h
........... lib/lufa/LUFA/Drivers/USB/Core/AVR8/../USBTask.h
........... lib/lufa/LUFA/Drivers/USB/Core/AVR8/../USBController.h
.......... lib/lufa/LUFA/Drivers/USB/Core/AVR8/../EndpointStream.h
........... lib/lufa/LUFA/Drivers/USB/Core/AVR8/../AVR8/EndpointStream_AVR8.h
........ lib/lufa/LUFA/Drivers/USB/Core/Events.h
........ lib/lufa/LUFA/Drivers/USB/Core/StdRequestType.h
........ lib/lufa/LUFA/Drivers/USB/Core/StdDescriptors.h
........ lib/lufa/LUFA/Drivers/USB/Core/DeviceStandardReq.h
....... lib/lufa/LUFA/Drivers/USB/Core/Events.h
....... lib/lufa/LUFA/Drivers/USB/Core/StdDescriptors.h
....... lib/lufa/LUFA/Drivers/USB/Core/ConfigDescriptors.h
........ lib/lufa/LUFA/Drivers/USB/Core/HostStandardReq.h
....... lib/lufa/LUFA/Drivers/USB/Core/USBController.h
....... lib/lufa/LUFA/Drivers/USB/Core/USBInterrupt.h
....... lib/lufa/LUFA/Drivers/USB/Core/Device.h
....... lib/lufa/LUFA/Drivers/USB/Core/Endpoint.h
....... lib/lufa/LUFA/Drivers/USB/Core/DeviceStandardReq.h
....... lib/lufa/LUFA/Drivers/USB/Core/EndpointStream.h
....... lib/lufa/LUFA/Drivers/USB/Class/AndroidAccessoryClass.h
........ lib/lufa/LUFA/Drivers/USB/Class/../Core/USBMode.h
....... lib/lufa/LUFA/Drivers/USB/Class/AudioClass.h
........ lib/lufa/LUFA/Drivers/USB/Class/Device/AudioClassDevice.h
......... lib/lufa/LUFA/Drivers/USB/Class/Device/../../USB.h
......... lib/lufa/LUFA/Drivers/USB/Class/Device/../Common/AudioClassCommon.h
.......... lib/lufa/LUFA/Drivers/USB/Class/Device/../Common/../../Core/StdDescriptors.h
....... lib/lufa/LUFA/Drivers/USB/Class/CCIDClass.h
........ lib/lufa/LUFA/Drivers/USB/Class/Device/CCIDClassDevice.h
......... lib/lufa/LUFA/Drivers/USB/Class/Device/../Common/CCIDClassCommon.h
....... lib/lufa/LUFA/Drivers/USB/Class/CDCClass.h
........ lib/lufa/LUFA/Drivers/USB/Class/Device/CDCClassDevice.h
......... lib/lufa/LUFA/Drivers/USB/Class/Device/../Common/CDCClassCommon.h
......... /usr/local/Cellar/avr-gcc@8/8.4.0/avr/include/stdio.h
.......... /usr/local/Cellar/avr-gcc@8/8.4.0/lib/avr-gcc/8/gcc/avr/8.4.0/include/stdarg.h
.......... /usr/local/Cellar/avr-gcc@8/8.4.0/lib/avr-gcc/8/gcc/avr/8.4.0/include/stddef.h
....... lib/lufa/LUFA/Drivers/USB/Class/HIDClass.h
........ lib/lufa/LUFA/Drivers/USB/Class/Device/HIDClassDevice.h
......... lib/lufa/LUFA/Drivers/USB/Class/Device/../Common/HIDClassCommon.h
.......... lib/lufa/LUFA/Drivers/USB/Class/Device/../Common/HIDParser.h
........... lib/lufa/LUFA/Drivers/USB/Class/Device/../Common/../../../../Common/Common.h
........... lib/lufa/LUFA/Drivers/USB/Class/Device/../Common/HIDReportData.h
........... lib/lufa/LUFA/Drivers/USB/Class/Device/../Common/HIDClassCommon.h
....... lib/lufa/LUFA/Drivers/USB/Class/MassStorageClass.h
........ lib/lufa/LUFA/Drivers/USB/Class/Device/MassStorageClassDevice.h
......... lib/lufa/LUFA/Drivers/USB/Class/Device/../Common/MassStorageClassCommon.h
....... lib/lufa/LUFA/Drivers/USB/Class/MIDIClass.h
........ lib/lufa/LUFA/Drivers/USB/Class/Device/MIDIClassDevice.h
......... lib/lufa/LUFA/Drivers/USB/Class/Device/../Common/MIDIClassCommon.h
.......... lib/lufa/LUFA/Drivers/USB/Class/Device/../Common/AudioClassCommon.h
....... lib/lufa/LUFA/Drivers/USB/Class/PrinterClass.h
........ lib/lufa/LUFA/Drivers/USB/Class/Device/PrinterClassDevice.h
......... lib/lufa/LUFA/Drivers/USB/Class/Device/../Common/PrinterClassCommon.h
....... lib/lufa/LUFA/Drivers/USB/Class/RNDISClass.h
........ lib/lufa/LUFA/Drivers/USB/Class/Device/RNDISClassDevice.h
......... lib/lufa/LUFA/Drivers/USB/Class/Device/../Common/RNDISClassCommon.h
.......... lib/lufa/LUFA/Drivers/USB/Class/Device/../Common/CDCClassCommon.h
....... lib/lufa/LUFA/Drivers/USB/Class/StillImageClass.h
.... tmk_core/common/host.h
..... tmk_core/common/host_driver.h
..... tmk_core/common/led.h
.... tmk_core/common/debug.h
..... tmk_core/common/print.h
...... tmk_core/common/util.h
.... quantum/keycode_config.h
..... tmk_core/common/eeconfig.h
.... quantum/quantum_keycodes.h
... quantum/rgblight.h
.... quantum/rgblight_modes.h
.... drivers/ws2812.h
..... ./quantum/color.h
.... quantum/rgblight_list.h
... tmk_core/common/action_layer.h
... tmk_core/common/bootloader.h
... tmk_core/common/timer.h
.... tmk_core/common/avr/timer_avr.h
... tmk_core/common/action_util.h
... quantum/send_string_keycodes.h
... tmk_core/common/suspend.h
... /usr/local/Cellar/avr-gcc@8/8.4.0/lib/avr-gcc/8/gcc/avr/8.4.0/include/stddef.h
... /usr/local/Cellar/avr-gcc@8/8.4.0/avr/include/stdlib.h
.... /usr/local/Cellar/avr-gcc@8/8.4.0/lib/avr-gcc/8/gcc/avr/8.4.0/include/stddef.h
... quantum/process_keycode/process_terminal_nop.h
... quantum/process_keycode/process_space_cadet.h
... quantum/process_keycode/process_magic.h
... quantum/process_keycode/process_grave_esc.h
... quantum/process_keycode/process_rgb.h
... /usr/local/Cellar/avr-gcc@8/8.4.0/avr/include/util/atomic.h
.. keyboards/lets_split/rev2/rev2.h
Multiple include guards may be useful for:
./keyboards/lets_split/keymaps/mjt/config.h
./quantum/rgblight_post_config.h
./quantum/split_common/post_config.h
/usr/local/Cellar/avr-gcc@8/8.4.0/avr/include/avr/iom32u4.h
quantum/rgblight_modes.h

Compiling: quantum/quantum.c                              [OK]
Compiling: quantum/led.c                                  [OK]
Compiling: quantum/keymap_common.c                        [OK]
Compiling: quantum/keycode_config.c                       [OK]
....skip......
```
</details>

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
