### PR TITLE
[Keymap] Add peej userspace and keymaps

### DIFF
--- a/layouts/community/ortho_4x12/peej/keymap.c
+++ b/layouts/community/ortho_4x12/peej/keymap.c
@@ -1,0 +1,73 @@
+/* Copyright 2020 Paul James
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define USE_2U_SPACE 1
+
+#include QMK_KEYBOARD_H
+#include "peej.h"
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+[_BASE] = LAYOUT_PEEJ(
+    BASE_ROW_2,
+    BASE_ROW_3,
+    BASE_ROW_4,
+    BASE_ROW_5
+),
+
+[_SYMBOL] = LAYOUT_PEEJ(
+    SYMBOL_ROW_2,
+    SYMBOL_ROW_3,
+    SYMBOL_ROW_4,
+    SYMBOL_ROW_5
+),
+
+[_FUNCTION] = LAYOUT_PEEJ(
+    FUNCTION_ROW_2,
+    FUNCTION_ROW_3,
+    FUNCTION_ROW_4,
+    FUNCTION_ROW_5
+),
+
+[_ADJUST] = LAYOUT_PEEJ(
+    ADJUST_ROW_2,
+    ADJUST_ROW_3,
+    ADJUST_ROW_4,
+    ADJUST_ROW_5
+)
+
+};
+
+layer_state_t layer_state_set_user(layer_state_t state) {
+#if defined(LED_RED) && defined(LED_GREEN)
+    writePinLow(LED_RED);
+    writePinLow(LED_GREEN);
+
+    switch (biton32(state)) {
+    case _FUNCTION:
+        writePinHigh(LED_RED);
+        break;
+    case _SYMBOL:
+        writePinHigh(LED_GREEN);
+        break;
+    case _ADJUST:
+        writePinHigh(LED_RED);
+        writePinHigh(LED_GREEN);
+        break;
+    }
+#endif
+    return state;
+}

--- a/layouts/community/ortho_5x12/peej/keymap.c
+++ b/layouts/community/ortho_5x12/peej/keymap.c
@@ -1,0 +1,54 @@
+/* Copyright 2020 Paul James
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include QMK_KEYBOARD_H
+#include "peej.h"
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+[_BASE] = LAYOUT_PEEJ(
+    BASE_ROW_1,
+    BASE_ROW_2,
+    BASE_ROW_3,
+    BASE_ROW_4,
+    BASE_ROW_5
+),
+
+[_SYMBOL] = LAYOUT_PEEJ(
+    SYMBOL_ROW_1,
+    SYMBOL_ROW_2,
+    SYMBOL_ROW_3,
+    SYMBOL_ROW_4,
+    SYMBOL_ROW_5
+),
+
+[_FUNCTION] = LAYOUT_PEEJ(
+    FUNCTION_ROW_1,
+    FUNCTION_ROW_2,
+    FUNCTION_ROW_3,
+    FUNCTION_ROW_4,
+    FUNCTION_ROW_5
+),
+
+[_ADJUST] = LAYOUT_PEEJ(
+    ADJUST_ROW_1,
+    ADJUST_ROW_2,
+    ADJUST_ROW_3,
+    ADJUST_ROW_4,
+    ADJUST_ROW_5
+)
+
+};

--- a/layouts/community/ortho_5x14/peej/keymap.c
+++ b/layouts/community/ortho_5x14/peej/keymap.c
@@ -1,0 +1,88 @@
+/* Copyright 2020 Paul James
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include QMK_KEYBOARD_H
+#include "peej.h"
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+#define MODS KC_LCTL, KC_LALT, KC_LGUI, FUNCT
+#define ARROWS KC_LEFT, KC_DOWN, KC_UP, KC_RIGHT
+
+/*
+ * ,-----------------------------------------------------------------------------------------------------------------------------.
+ * | ESC    | 1      | 2      | 3      | 4      | 5      | -      | =      | 6      | 7      | 8      | 9      | 0      | BACK   |
+ * |--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------|
+ * | TAB    | Q      | W      | E      | R      | T      | [      | ]      | Y      | U      | I      | O      | P      | \      |
+ * |--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------|
+ * | ESC    | A      | S      | D      | F      | G      | {      | }      | H      | J      | K      | L      | ;      | '      |
+ * |--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------|
+ * | SHIFT  | Z      | X      | C      | V      | B      | (      | )      | N      | M      | ,      | .      | /      | ENTER  |
+ * `--------+--------+--------+--------+--------+-----------------+-----------------+--------+--------+--------+--------+--------'
+ *          | CTRL   | ALT    | CMD    | FUNC   |      SPACE      |    BACKSPACE    | LEFT   | DOWN   | UP     | RIGHT  |
+ *          `-----------------------------------------------------------------------------------------------------------'
+*/
+[_BASE] = LAYOUT_PEEJ_hhkb(
+    KC_GESC, BASE_ROW_1_L, BASE_ROW_1_M,    BASE_ROW_1_R, KC_BSPC,
+    KC_TAB,  BASE_ROW_2_L, BASE_ROW_2_M,    BASE_ROW_2_R, KC_BSLS,
+    CTLESC,  BASE_ROW_3_L, BASE_ROW_3_M,    BASE_ROW_3_R, KC_QUOT,
+    KC_LSFT, BASE_ROW_4_L, BASE_ROW_4_M,    BASE_ROW_4_R, KC_ENT,
+             MODS,         KC_SPC, KC_BSPC, ARROWS
+),
+
+/*
+ * ,-----------------------------------------------------------------------------------------------------------------------------.
+ * | LOCK   | F1     | F2     | F3     | F4     | F5     | F11    | F12    | F6     | F7     | F8     | F9     | F10    |  DEL   |
+ * |--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------|
+ * | ADJUST |        |        |        |        |        |        |        |        | HOME   | UP     | PGUP   |        |        |
+ * |--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------|
+ * | SHIFT  | CTRL   | ALT    | CMD    |        |        |        |        |        | LEFT   | DOWN   | RIGHT  |        |        |
+ * |--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------|
+ * |        |        |        |        |        |        |        |        |        | END    | SHIFT  | PGDN   |        |        |
+ * `--------+--------+--------+--------+--------+-----------------+-----------------+--------+--------+--------+--------+--------'
+ *          |        |        |        |        |                 |      ENTER      | HOME   | PGDN   | PGUP   | END    |
+ *          `-----------------------------------------------------------------------------------------------------------'
+ */
+[_FUNCTION] = LAYOUT_PEEJ_hhkb(
+    LOCK,    FUNCTION_ROW_1_L, ______2,         FUNCTION_ROW_1_R, KC_DEL,
+    ADJUST,  ______5,          ______2,         FUNCTION_ROW_2_R, _______,
+    KC_LSFT, FUNCTION_ROW_3_L, ______2,         FUNCTION_ROW_3_R, _______,
+    _______, ______5,          ______2,         FUNCTION_ROW_4_R, _______,
+             ______4,          _______, KC_ENT, ______4
+),
+
+/*
+ * ,----------------------------------------Backlight-------------------------RGB-----Bright---Sat------Hue----------------------.
+ * | LOCK   | RESET  |        |        | STEP   | TOGGLE |        |        | TOGGLE | UP     | UP     | UP     |        | LOCK   |
+ * |--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------|
+ * |        |        |        |        |        |        |        |        | MODE   | DOWN   | DOWN   | DOWN   |        |        |
+ * |--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------|
+ * |        |        |        |        |        |        |        |        |        |        |        |        |        |        |
+ * |--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------|
+ * |        | Norm   | Swap   |        |        |        |        |        |        |        |        |        |        |        |
+ * `--------+--------+--------+--------+--------+-----------------+-----------------+--------+--------+--------+--------+--------'
+ *          |        |        |        |        |                 |                 |        |        |        |        |
+ *          `-----------------------------------------------------------------------------------------------------------'
+ */
+[_ADJUST] = LAYOUT_PEEJ_hhkb(
+    LOCK,    ADJUST_ROW_2_L,                              XXXXXXX, XXXXXXX, ADJUST_ROW_2_R,                              LOCK,
+    XXXXXXX, EMPTY_ROW,                                   XXXXXXX, XXXXXXX, ADJUST_ROW_3_R,                              XXXXXXX,
+    XXXXXXX, EMPTY_ROW,                                   KC_MPLY, KC_MUTE, EMPTY_ROW,                                   XXXXXXX,
+    XXXXXXX, ADJUST_ROW_4_L,                              KC_VOLD, KC_VOLU, EMPTY_ROW,                                   _______,
+             XXXXXXX, XXXXXXX, _______, XXXXXXX, XXXXXXX, XXXXXXX,          XXXXXXX,          XXXXXXX, XXXXXXX, XXXXXXX
+)
+
+};

--- a/users/peej/layout.h
+++ b/users/peej/layout.h
@@ -1,0 +1,150 @@
+/* Copyright 2020 Paul James
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Base layer
+ * ,-----------------------------------------. ,-------------. ,-----------------------------------------.
+ * | Esc  |  1   |  2   |  3   |  4   |  5   | |  -   |  =   | |  6   |  7   |  8   |  9   |  0   | Del  |
+ * |------+------+------+------+------+------| |------+------| |------+------+------+------+------+------|
+ * | Tab  |  Q   |  W   |  E   |  R   |  T   | |  [   |  ]   | |  Y   |  U   |  I   |  O   |  P   | Bksp |
+ * |------+------+------+------+------+------| |------+------| |------+------+------+------+------+------|
+ * | Esc  |  A   |  S   |  D   |  F   |  G   | |  {   |  }   | |  H   |  J   |  K   |  L   |  ;   |  '   |
+ * |------+------+------+------+------+------| |------+------| |------+------+------+------+------+------|
+ * | Shft |  Z   |  X   |  C   |  V   |  B   | |  (   |  )   | |  N   |  M   |  ,   |  .   |  /   | Entr |
+ * |------+------+------+------+------+------| |------+------| |------+------+------+------+------+------|
+ * | Ctrl | Symb | Alt  | Cmd  | Symb | Spce | |      |      | | Spce |  Fn  | Left | Down |  Up  | Rght |
+ * `-----------------------------------------' `-------------' `-----------------------------------------'
+ */
+#define BASE_ROW_1_L KC_1,    KC_2,   KC_3,    KC_4,    KC_5
+#define BASE_ROW_2_L KC_Q,    KC_W,   KC_E,    KC_R,    KC_T
+#define BASE_ROW_3_L KC_A,    KC_S,   KC_D,    FN_F,    KC_G
+#define BASE_ROW_4_L KC_Z,    KC_X,   KC_C,    KC_V,    KC_B
+#define BASE_ROW_5_L KC_LCTL, SYMBOL, KC_LALT, KC_LGUI, SYMBOL, KC_SPC
+
+#define BASE_ROW_1_R KC_6, KC_7, KC_8, KC_9, KC_0
+#define BASE_ROW_2_R KC_Y, KC_U, KC_I, KC_O, KC_P
+#define BASE_ROW_3_R KC_H, SY_J, KC_K, KC_L, KC_SCLN
+#ifdef ARROW_LAYOUT
+    #define BASE_ROW_4_R KC_N,   KC_M,   KC_COMM, KC_DOT,  KC_UP
+    #define BASE_ROW_5_R KC_SPC, FN_SPC, KC_SLSH, KC_LEFT, KC_DOWN, KC_RGHT
+#else
+    #define BASE_ROW_4_R KC_N,   KC_M,   KC_COMM, KC_DOT,  KC_SLSH
+    #define BASE_ROW_5_R KC_SPC, FUNCT,  KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT
+#endif
+
+#define BASE_ROW_1_M KC_MINS, KC_EQL
+#define BASE_ROW_2_M KC_LBRC, KC_RBRC
+#define BASE_ROW_3_M KC_LCBR, KC_RCBR
+#define BASE_ROW_4_M KC_LPRN, KC_RPRN
+
+#define BASE_ROW_1 KC_GESC, BASE_ROW_1_L, BASE_ROW_1_R, KC_DEL
+#define BASE_ROW_2 KC_TAB,  BASE_ROW_2_L, BASE_ROW_2_R, KC_BSPC
+#define BASE_ROW_3 KC_GESC, BASE_ROW_3_L, BASE_ROW_3_R, KC_QUOT
+#define BASE_ROW_4 KC_LSFT, BASE_ROW_4_L, BASE_ROW_4_R, KC_ENTER
+#define BASE_ROW_5          BASE_ROW_5_L, BASE_ROW_5_R
+
+
+/* Function layer
+ * ,-----------------------------------------. ,-----------------------------------------.
+ * |      |  F1  |  F2  |  F3  |  F4  |  F5  | |  F6  |  F7  |  F8  |  F9  | F10  | Lock |
+ * |------+------+------+------+------+------| |------+------+------+------+------+------|
+ * | Adju |  F1  |  F2  |  F3  |  F4  |  F5  | |      | Home |  Up  | PgUp |   \  |      |
+ * |------+------+------+------+------+------| |------+------+------+------+------+------|
+ * | Shft | Ctrl | Alt  | Cmd  |      |      | |      | Left | Down | Rght |      |   `  |
+ * |------+------+------+------+------+------| |------+------+------+------+------+------|
+ * |      |  F6  |  F7  |  F8  |  F9  | F10  | |      | End  | Shft | PgDn |   \  |      |
+ * |------+------+------+------+------+------| |------+------+------+------+------+------|
+ * |      |      |      |      | Adju | BkSp | |      |      | Home | PgDn | PgUp | End  |
+ * `-----------------------------------------' `-----------------------------------------'
+ */
+#define FUNCTION_ROW_1_L KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5
+#define FUNCTION_ROW_2_L KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5
+#define FUNCTION_ROW_3_L KC_LCTL, KC_LALT, KC_LGUI, _______, _______
+#define FUNCTION_ROW_4_L KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10
+#define FUNCTION_ROW_5_L _______, _______, _______, _______, ADJUST, KC_BSPC
+
+#define FUNCTION_ROW_1_R KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10
+#define FUNCTION_ROW_2_R _______, KC_HOME, KC_UP,   KC_PGUP, KC_BSLS
+#define FUNCTION_ROW_3_R _______, KC_LEFT, KC_DOWN, KC_RGHT, _______
+#ifdef ARROW_LAYOUT
+    #define FUNCTION_ROW_4_R _______, KC_END,  KC_LSFT, KC_PGDN, KC_PGUP
+    #define FUNCTION_ROW_5_R _______, _______, KC_BSLS, KC_HOME, KC_PGUP, KC_END
+#else
+    #define FUNCTION_ROW_4_R _______, KC_END,  KC_LSFT, KC_PGDN, KC_BSLS
+    #define FUNCTION_ROW_5_R _______, _______, KC_HOME, KC_PGDN, KC_PGUP, KC_END
+#endif
+
+#define FUNCTION_ROW_1 _______, FUNCTION_ROW_1_L, FUNCTION_ROW_1_R, LOCK
+#define FUNCTION_ROW_2 ADJUST,  FUNCTION_ROW_2_L, FUNCTION_ROW_2_R, _______
+#define FUNCTION_ROW_3 KC_LSFT, FUNCTION_ROW_3_L, FUNCTION_ROW_3_R, KC_GRV
+#define FUNCTION_ROW_4 _______, FUNCTION_ROW_4_L, FUNCTION_ROW_4_R, _______
+#define FUNCTION_ROW_5          FUNCTION_ROW_5_L, FUNCTION_ROW_5_R
+
+
+/* Symbol layer
+ * ,-----------------------------------------. ,-----------------------------------------.
+ * |      |  F1  |  F2  |  F3  |  F4  |  F5  | |  F6  |  F7  |  F8  |  F9  | F10  | Lock |
+ * |------+------+------+------+------+------| |------+------+------+------+------+------|
+ * |      |   1  |   2  |   3  |   4  |   5  | |   6  |   7  |   8  |   9  |   0  |      |
+ * |------+------+------+------+------+------| |------+------+------+------+------+------|
+ * | Shft |   _  |   +  |   (  |   {  |   [  | |   ]  |      | Shft |   {  |   }  |   `  |
+ * |------+------+------+------+------+------| |------+------+------+------+------+------|
+ * |      |   -  |   =  |  =>  |  ->  |   -  | |   =  |  ==  |  === |   [  |   ]  |      |
+ * |------+------+------+------+------+------| |------+------+------+------+------+------|
+ * |      |      |      |      |      |      | | Del  | Adju | Home | PgDn | PgUp | End  |
+ * `-----------------------------------------' `-----------------------------------------'
+ */
+#define SYMBOL_ROW_2_L KC_1,    KC_2,    KC_3,    KC_4,    KC_5
+#define SYMBOL_ROW_3_L KC_UNDS, KC_PLUS, KC_LPRN, KC_LCBR, KC_LBRC
+#define SYMBOL_ROW_4_L KC_MINS, KC_EQL,  MC_DARR, MC_ARR,  KC_MINS
+#define SYMBOL_ROW_5_L _______, _______, _______, _______, _______, _______
+
+#define SYMBOL_ROW_2_R KC_6,    KC_7,    KC_8,    KC_9,    KC_0
+#define SYMBOL_ROW_3_R KC_RBRC, _______, KC_RSFT, KC_LCBR, KC_RCBR
+#ifdef ARROW_LAYOUT
+    #define SYMBOL_ROW_4_R KC_EQL, MC_DEQL, MC_TEQL, KC_LBRC, KC_PGUP
+    #define SYMBOL_ROW_5_R KC_DEL, ADJUST,  KC_BSLS, KC_HOME, KC_PGUP, KC_END
+#else
+    #define SYMBOL_ROW_4_R KC_EQL, MC_DEQL, MC_TEQL, KC_LBRC, KC_RBRC
+    #define SYMBOL_ROW_5_R KC_DEL, ADJUST,  KC_HOME, KC_PGDN, KC_PGUP, KC_END
+#endif
+
+#define SYMBOL_ROW_1 _______, FUNCTION_ROW_1_L, FUNCTION_ROW_1_R, LOCK
+#define SYMBOL_ROW_2 _______, SYMBOL_ROW_2_L,   SYMBOL_ROW_2_R,   _______
+#define SYMBOL_ROW_3 KC_LSFT, SYMBOL_ROW_3_L,   SYMBOL_ROW_3_R,   KC_GRV
+#define SYMBOL_ROW_4 _______, SYMBOL_ROW_4_L,   SYMBOL_ROW_4_R,   _______
+#define SYMBOL_ROW_5          SYMBOL_ROW_5_L,   SYMBOL_ROW_5_R
+
+
+/* Adjust layer */
+#define ADJUST_ROW_2_L KC_RESET, XXXXXXX, XXXXXXX, BL_STEP, BL_TOGG
+#define ADJUST_ROW_2_R RGB_TOG,  RGB_VAI, RGB_SAI, RGB_HUI, XXXXXXX
+
+#define ADJUST_ROW_3_L XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX
+#define ADJUST_ROW_3_R RGB_MOD, RGB_VAD, RGB_SAD, RGB_HUD, XXXXXXX
+
+#define ADJUST_ROW_4_L AG_NORM, AG_SWAP, XXXXXXX, XXXXXXX, XXXXXXX
+#define ADJUST_ROW_4_R RGB_M_P, RGB_M_B, RGB_M_R, RGB_M_G, RGB_M_T
+
+#define ADJUST_ROW_5_L XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, _______, XXXXXXX
+#define ADJUST_ROW_5_R XXXXXXX, _______, KC_MPLY, KC_VOLD, KC_VOLU, KC_MUTE
+
+#define ADJUST_ROW_1 LOCK,    ADJUST_ROW_2_L, ADJUST_ROW_2_R, LOCK
+#define ADJUST_ROW_2 _______, ADJUST_ROW_2_L, ADJUST_ROW_2_R, LOCK
+#define ADJUST_ROW_3 XXXXXXX, ADJUST_ROW_3_L, ADJUST_ROW_3_R, XXXXXXX
+#define ADJUST_ROW_4 XXXXXXX, ADJUST_ROW_4_L, ADJUST_ROW_4_R, XXXXXXX
+#define ADJUST_ROW_5          ADJUST_ROW_5_L, ADJUST_ROW_5_R
+
+#define EMPTY_ROW    XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX

--- a/users/peej/peej.c
+++ b/users/peej/peej.c
@@ -1,0 +1,68 @@
+/* Copyright 2020 Paul James
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "peej.h"
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    bool is_shifted = get_mods() & MOD_LSFT;
+
+    if (record->event.pressed) {
+        switch(keycode) {
+            case MC_ARR:
+                if (is_shifted) {
+                    unregister_mods(MOD_LSFT);
+                    SEND_STRING("=>");
+                    register_mods(MOD_LSFT);
+                } else {
+                    SEND_STRING("->");
+                }
+                break;
+            case MC_DARR:
+                unregister_mods(MOD_LSFT);
+                SEND_STRING("=>");
+                if (is_shifted) register_mods(MOD_LSFT);
+                break;
+            case MC_DEQL:
+                if (is_shifted) {
+                    unregister_mods(MOD_LSFT);
+                    SEND_STRING("!=");
+                    register_mods(MOD_LSFT);
+                } else {
+                    SEND_STRING("==");
+                }
+                break;
+            case MC_TEQL:
+                if (is_shifted) {
+                    unregister_mods(MOD_LSFT);
+                    SEND_STRING("!==");
+                    register_mods(MOD_LSFT);
+                } else {
+                    SEND_STRING("===");
+                }
+                break;
+            case KC_RESET:
+                #ifdef RGBLIGHT_ENABLE
+                    rgblight_enable_noeeprom();
+                    rgblight_mode_noeeprom(1);
+                    rgblight_setrgb_red();
+                #endif
+                reset_keyboard();
+                break;
+        }
+    }
+
+    return true;
+};

--- a/users/peej/peej.h
+++ b/users/peej/peej.h
@@ -1,0 +1,78 @@
+/* Copyright 2020 Paul James
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include QMK_KEYBOARD_H
+
+#include "eeconfig.h"
+
+enum custom_layers {
+    _BASE = 0,
+    _SYMBOL,
+    _FUNCTION,
+    _ADJUST,
+};
+
+// Fillers to make layering more clear
+#define ______2 KC_TRNS, KC_TRNS
+#define ______3 KC_TRNS, KC_TRNS, KC_TRNS
+#define ______4 KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS
+#define ______5 KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS
+
+enum custom_keycodes {
+    MC_ARR = SAFE_RANGE,
+    MC_DARR,
+    MC_DEQL,
+    MC_TEQL,
+    KC_RESET
+};
+
+#define SYMBOL MO(_SYMBOL)
+#define FUNCT MO(_FUNCTION)
+#define ADJUST MO(_ADJUST)
+
+#define FN_SPC LT(_FUNCTION, KC_SPC)
+#define SY_SPC LT(_SYMBOL, KC_SPC)
+#define FN_F LT(_FUNCTION, KC_F)
+#define SY_J LT(_SYMBOL, KC_J)
+
+#define CTLESC LCTL_T(KC_ESC)
+#define SFTENT RSFT_T(KC_ENT)
+#define LOCK LCTL(LGUI(KC_Q))
+#define BACK LGUI(KC_LBRC)
+#define FORWARD LGUI(KC_RBRC)
+#define NXTFUNC LCTL(KC_DOWN)
+#define PRVFUNC LCTL(KC_UP)
+#define TOP LGUI(KC_UP)
+#define BOTTOM LGUI(KC_DOWN)
+
+#ifdef LAYOUT_ortho_4x12
+    #define LAYOUT_PEEJ(...) LAYOUT_ortho_4x12(__VA_ARGS__)
+#endif
+
+#ifdef LAYOUT_ortho_5x12
+    #define LAYOUT_PEEJ(...) LAYOUT_ortho_5x12(__VA_ARGS__)
+#endif
+
+#ifdef LAYOUT_ortho_hhkb
+    #define LAYOUT_PEEJ_hhkb(...) LAYOUT_ortho_hhkb(__VA_ARGS__)
+#endif
+
+#ifdef LAYOUT_ortho_7u
+    #define LAYOUT_PEEJ_7u(...) LAYOUT_ortho_7u(__VA_ARGS__)
+#endif
+
+#include "layout.h"

--- a/users/peej/rules.mk
+++ b/users/peej/rules.mk
@@ -1,0 +1,1 @@
+SRC += peej.c


### PR DESCRIPTION
Add personal userspace functions and keymaps for boardwalk, lets split, plaid, and planck keyboards.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
