### PR TITLE
Improve the compile and flash subcommands

### DIFF
--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -11,13 +11,13 @@ This command is directory aware. It will automatically fill in KEYBOARD and/or K
 **Usage for Configurator Exports**:
 
 ```
-qmk compile <configuratorExport.json>
+qmk compile [-c] <configuratorExport.json>
 ```
 
 **Usage for Keymaps**:
 
 ```
-qmk compile -kb <keyboard_name> -km <keymap_name>
+qmk compile [-c] [-e <var>=<value>] -kb <keyboard_name> -km <keymap_name>
 ```
 
 **Usage in Keyboard Directory**:  
@@ -82,13 +82,13 @@ This command is directory aware. It will automatically fill in KEYBOARD and/or K
 **Usage for Configurator Exports**:
 
 ```
-qmk flash <configuratorExport.json> -bl <bootloader>
+qmk flash [-bl <bootloader>] [-c] [-e <var>=<value>] <configuratorExport.json>
 ```
 
 **Usage for Keymaps**:
 
 ```
-qmk flash -kb <keyboard_name> -km <keymap_name> -bl <bootloader>
+qmk flash -kb <keyboard_name> -km <keymap_name> [-bl <bootloader>] [-c] [-e <var>=<value>]
 ```
 
 **Listing the Bootloaders**

--- a/lib/python/qmk/cli/chibios/confmigrate.py
+++ b/lib/python/qmk/cli/chibios/confmigrate.py
@@ -13,7 +13,7 @@ def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
 
 
-fileHeader = """\
+file_header = """\
 /* Copyright 2020 QMK
  *
  * This program is free software: you can redistribute it and/or modify
@@ -77,7 +77,7 @@ def check_diffs(input_defs, reference_defs):
 
 
 def migrate_chconf_h(to_override, outfile):
-    print(fileHeader.format(cli.args.input.relative_to(QMK_FIRMWARE), cli.args.reference.relative_to(QMK_FIRMWARE)), file=outfile)
+    print(file_header.format(cli.args.input.relative_to(QMK_FIRMWARE), cli.args.reference.relative_to(QMK_FIRMWARE)), file=outfile)
 
     for override in to_override:
         print("#define %s %s" % (override[0], override[1]), file=outfile)
@@ -87,7 +87,7 @@ def migrate_chconf_h(to_override, outfile):
 
 
 def migrate_halconf_h(to_override, outfile):
-    print(fileHeader.format(cli.args.input.relative_to(QMK_FIRMWARE), cli.args.reference.relative_to(QMK_FIRMWARE)), file=outfile)
+    print(file_header.format(cli.args.input.relative_to(QMK_FIRMWARE), cli.args.reference.relative_to(QMK_FIRMWARE)), file=outfile)
 
     for override in to_override:
         print("#define %s %s" % (override[0], override[1]), file=outfile)
@@ -97,7 +97,7 @@ def migrate_halconf_h(to_override, outfile):
 
 
 def migrate_mcuconf_h(to_override, outfile):
-    print(fileHeader.format(cli.args.input.relative_to(QMK_FIRMWARE), cli.args.reference.relative_to(QMK_FIRMWARE)), file=outfile)
+    print(file_header.format(cli.args.input.relative_to(QMK_FIRMWARE), cli.args.reference.relative_to(QMK_FIRMWARE)), file=outfile)
 
     print("#include_next <mcuconf.h>\n", file=outfile)
 

--- a/lib/python/qmk/cli/compile.py
+++ b/lib/python/qmk/cli/compile.py
@@ -45,7 +45,7 @@ def compile(cli):
     if cli.args.filename:
         # If a configurator JSON was provided generate a keymap and compile it
         user_keymap = parse_configurator_json(cli.args.filename)
-        command = compile_configurator_json(user_keymap)
+        command = compile_configurator_json(user_keymap, **envs)
 
     else:
         if cli.config.compile.keyboard and cli.config.compile.keymap:

--- a/lib/python/qmk/cli/compile.py
+++ b/lib/python/qmk/cli/compile.py
@@ -2,7 +2,6 @@
 
 You can compile a keymap already in the repo or using a QMK Configurator export.
 """
-import subprocess
 from argparse import FileType
 
 from milc import cli
@@ -15,6 +14,7 @@ from qmk.commands import compile_configurator_json, create_make_command, parse_c
 @cli.argument('-kb', '--keyboard', help='The keyboard to build a firmware for. Ignored when a configurator export is supplied.')
 @cli.argument('-km', '--keymap', help='The keymap to build a firmware for. Ignored when a configurator export is supplied.')
 @cli.argument('-n', '--dry-run', arg_only=True, action='store_true', help="Don't actually build, just show the make command to be run.")
+@cli.argument('-c', '--clean', arg_only=True, action='store_true', help="Remove object files before compiling.")
 @cli.subcommand('Compile a QMK Firmware.')
 @automagic_keyboard
 @automagic_keymap
@@ -25,6 +25,10 @@ def compile(cli):
 
     If a keyboard and keymap are provided this command will build a firmware based on that.
     """
+    if cli.args.clean and not cli.args.filename and not cli.args.dry_run:
+        command = create_make_command(cli.config.compile.keyboard, cli.config.compile.keymap, 'clean')
+        cli.run(command, capture_output=False)
+
     command = None
 
     if cli.args.filename:
@@ -48,7 +52,7 @@ def compile(cli):
         cli.log.info('Compiling keymap with {fg_cyan}%s', ' '.join(command))
         if not cli.args.dry_run:
             cli.echo('\n')
-            compile = subprocess.run(command)
+            compile = cli.run(command, capture_output=False, text=False)
             return compile.returncode
 
     else:

--- a/lib/python/qmk/cli/compile.py
+++ b/lib/python/qmk/cli/compile.py
@@ -14,6 +14,7 @@ from qmk.commands import compile_configurator_json, create_make_command, parse_c
 @cli.argument('-kb', '--keyboard', help='The keyboard to build a firmware for. Ignored when a configurator export is supplied.')
 @cli.argument('-km', '--keymap', help='The keymap to build a firmware for. Ignored when a configurator export is supplied.')
 @cli.argument('-n', '--dry-run', arg_only=True, action='store_true', help="Don't actually build, just show the make command to be run.")
+@cli.argument('-j', '--parallel', type=int, default=1, help="Set the number of parallel make jobs to run.")
 @cli.argument('-e', '--env', arg_only=True, action='append', default=[], help="Set a variable to be passed to make. May be passed multiple times.")
 @cli.argument('-c', '--clean', arg_only=True, action='store_true', help="Remove object files before compiling.")
 @cli.subcommand('Compile a QMK Firmware.')
@@ -46,12 +47,12 @@ def compile(cli):
     if cli.args.filename:
         # If a configurator JSON was provided generate a keymap and compile it
         user_keymap = parse_configurator_json(cli.args.filename)
-        command = compile_configurator_json(user_keymap, **envs)
+        command = compile_configurator_json(user_keymap, parallel=cli.config.compile.parallel, **envs)
 
     else:
         if cli.config.compile.keyboard and cli.config.compile.keymap:
             # Generate the make command for a specific keyboard/keymap.
-            command = create_make_command(cli.config.compile.keyboard, cli.config.compile.keymap, **envs)
+            command = create_make_command(cli.config.compile.keyboard, cli.config.compile.keymap, parallel=cli.config.compile.parallel, **envs)
 
         elif not cli.config.compile.keyboard:
             cli.log.error('Could not determine keyboard!')

--- a/lib/python/qmk/cli/compile.py
+++ b/lib/python/qmk/cli/compile.py
@@ -28,7 +28,8 @@ def compile(cli):
     """
     if cli.args.clean and not cli.args.filename and not cli.args.dry_run:
         command = create_make_command(cli.config.compile.keyboard, cli.config.compile.keymap, 'clean')
-        cli.run(command, capture_output=False)
+        # FIXME(skullydazed/anyone): Remove text=False once milc 1.0.11 has had enough time to be installed everywhere.
+        cli.run(command, capture_output=False, text=False)
 
     # Build the environment vars
     envs = {}
@@ -62,6 +63,7 @@ def compile(cli):
         cli.log.info('Compiling keymap with {fg_cyan}%s', ' '.join(command))
         if not cli.args.dry_run:
             cli.echo('\n')
+            # FIXME(skullydazed/anyone): Remove text=False once milc 1.0.11 has had enough time to be installed everywhere.
             compile = cli.run(command, capture_output=False, text=False)
             return compile.returncode
 

--- a/lib/python/qmk/cli/flash.py
+++ b/lib/python/qmk/cli/flash.py
@@ -36,6 +36,7 @@ def print_bootloader_help():
 @cli.argument('-km', '--keymap', help='The keymap to build a firmware for. Use this if you dont have a configurator file. Ignored when a configurator file is supplied.')
 @cli.argument('-kb', '--keyboard', help='The keyboard to build a firmware for. Use this if you dont have a configurator file. Ignored when a configurator file is supplied.')
 @cli.argument('-n', '--dry-run', arg_only=True, action='store_true', help="Don't actually build, just show the make command to be run.")
+@cli.argument('-j', '--parallel', type=int, default=1, help="Set the number of parallel make jobs to run.")
 @cli.argument('-e', '--env', arg_only=True, action='append', default=[], help="Set a variable to be passed to make. May be passed multiple times.")
 @cli.argument('-c', '--clean', arg_only=True, action='store_true', help="Remove object files before compiling.")
 @cli.subcommand('QMK Flash.')
@@ -75,7 +76,7 @@ def flash(cli):
 
     if cli.args.filename:
         # Handle compiling a configurator JSON
-        user_keymap = parse_configurator_json(cli.args.filename)
+        user_keymap = parse_configurator_json(cli.args.filename, parallel=cli.config.flash.parallel)
         keymap_path = qmk.path.keymap(user_keymap['keyboard'])
         command = compile_configurator_json(user_keymap, cli.args.bootloader, **envs)
 
@@ -84,7 +85,7 @@ def flash(cli):
     else:
         if cli.config.flash.keyboard and cli.config.flash.keymap:
             # Generate the make command for a specific keyboard/keymap.
-            command = create_make_command(cli.config.flash.keyboard, cli.config.flash.keymap, cli.args.bootloader, **envs)
+            command = create_make_command(cli.config.flash.keyboard, cli.config.flash.keymap, cli.args.bootloader, parallel=cli.config.flash.parallel, **envs)
 
         elif not cli.config.flash.keyboard:
             cli.log.error('Could not determine keyboard!')

--- a/lib/python/qmk/cli/flash.py
+++ b/lib/python/qmk/cli/flash.py
@@ -37,6 +37,7 @@ def print_bootloader_help():
 @cli.argument('-km', '--keymap', help='The keymap to build a firmware for. Use this if you dont have a configurator file. Ignored when a configurator file is supplied.')
 @cli.argument('-kb', '--keyboard', help='The keyboard to build a firmware for. Use this if you dont have a configurator file. Ignored when a configurator file is supplied.')
 @cli.argument('-n', '--dry-run', arg_only=True, action='store_true', help="Don't actually build, just show the make command to be run.")
+@cli.argument('-c', '--clean', arg_only=True, action='store_true', help="Remove object files before compiling.")
 @cli.subcommand('QMK Flash.')
 @automagic_keyboard
 @automagic_keymap
@@ -50,6 +51,10 @@ def flash(cli):
 
     If bootloader is omitted the make system will use the configured bootloader for that keyboard.
     """
+    if cli.args.clean and not cli.args.filename and not cli.args.dry_run:
+        command = create_make_command(cli.config.flash.keyboard, cli.config.flash.keymap, 'clean')
+        cli.run(command, capture_output=False)
+
     command = ''
 
     if cli.args.bootloaders:
@@ -81,7 +86,7 @@ def flash(cli):
         cli.log.info('Compiling keymap with {fg_cyan}%s', ' '.join(command))
         if not cli.args.dry_run:
             cli.echo('\n')
-            compile = subprocess.run(command)
+            compile = cli.run(command, capture_output=False, text=True)
             return compile.returncode
 
     else:

--- a/lib/python/qmk/cli/flash.py
+++ b/lib/python/qmk/cli/flash.py
@@ -77,7 +77,7 @@ def flash(cli):
         # Handle compiling a configurator JSON
         user_keymap = parse_configurator_json(cli.args.filename)
         keymap_path = qmk.path.keymap(user_keymap['keyboard'])
-        command = compile_configurator_json(user_keymap, cli.args.bootloader)
+        command = compile_configurator_json(user_keymap, cli.args.bootloader, **envs)
 
         cli.log.info('Wrote keymap to {fg_cyan}%s/%s/keymap.c', keymap_path, user_keymap['keymap'])
 

--- a/lib/python/qmk/commands.py
+++ b/lib/python/qmk/commands.py
@@ -80,8 +80,10 @@ def compile_configurator_json(user_keymap):
     color = 'true' if cli.config.general.color else 'false'
     make_command = [
         'make',
-        '-r', '-R',
-        '-f', 'build_keyboard.mk',
+        '-r',
+        '-R',
+        '-f',
+        'build_keyboard.mk',
         f'KEYBOARD={user_keymap["keyboard"]}',
         f'KEYMAP={user_keymap["keymap"]}',
         f'KEYBOARD_FILESAFE={keyboard_filesafe}',
@@ -97,7 +99,7 @@ def compile_configurator_json(user_keymap):
         f'KEYMAP_PATH={keymap_dir}',
         f'VERBOSE={verbose}',
         f'COLOR={color}',
-        'SILENT=false'
+        'SILENT=false',
     ]
 
     return make_command

--- a/lib/python/qmk/commands.py
+++ b/lib/python/qmk/commands.py
@@ -6,11 +6,15 @@ import platform
 import subprocess
 import shlex
 import shutil
+from pathlib import Path
+
+from milc import cli
 
 import qmk.keymap
+from qmk.constants import KEYBOARD_OUTPUT_PREFIX
 
 
-def create_make_command(keyboard, keymap, target=None):
+def create_make_command(keyboard, keymap, target=None, **env_vars):
     """Create a make compile command
 
     Args:
@@ -24,26 +28,33 @@ def create_make_command(keyboard, keymap, target=None):
         target
             Usually a bootloader.
 
+        **env_vars
+            Environment variables to be passed to make.
+
     Returns:
 
         A command that can be run to make the specified keyboard and keymap
     """
+    env = []
     make_args = [keyboard, keymap]
     make_cmd = 'gmake' if shutil.which('gmake') else 'make'
 
     if target:
         make_args.append(target)
 
-    return [make_cmd, ':'.join(make_args)]
+    for key, value in env_vars.items():
+        env.append(f'{key}={value}')
+
+    return [make_cmd, *env, ':'.join(make_args)]
 
 
-def compile_configurator_json(user_keymap, bootloader=None):
-    """Convert a configurator export JSON file into a C file
+def compile_configurator_json(user_keymap):
+    """Convert a configurator export JSON file into a C file and then compile it.
 
     Args:
 
-        configurator_filename
-            The configurator JSON export file
+        user_keymap
+            A deserialized keymap export
 
         bootloader
             A bootloader to flash
@@ -52,13 +63,44 @@ def compile_configurator_json(user_keymap, bootloader=None):
 
         A command to run to compile and flash the C file.
     """
-    # Write the keymap C file
-    qmk.keymap.write(user_keymap['keyboard'], user_keymap['keymap'], user_keymap['layout'], user_keymap['layers'])
+    # Write the keymap.c file
+    keyboard_filesafe = user_keymap['keyboard'].replace('/', '_')
+    target = f'{keyboard_filesafe}_{user_keymap["keymap"]}'
+    keyboard_output = Path(f'{KEYBOARD_OUTPUT_PREFIX}{keyboard_filesafe}')
+    keymap_output = Path(f'{keyboard_output}_{user_keymap["keymap"]}')
+    c_text = qmk.keymap.generate_c(user_keymap['keyboard'], user_keymap['layout'], user_keymap['layers'])
+    keymap_dir = keymap_output / 'src'
+    keymap_c = keymap_dir / 'keymap.c'
+
+    keymap_dir.mkdir(exist_ok=True, parents=True)
+    keymap_c.write_text(c_text)
 
     # Return a command that can be run to make the keymap and flash if given
-    if bootloader is None:
-        return create_make_command(user_keymap['keyboard'], user_keymap['keymap'])
-    return create_make_command(user_keymap['keyboard'], user_keymap['keymap'], bootloader)
+    verbose = 'true' if cli.config.general.verbose else 'false'
+    color = 'true' if cli.config.general.color else 'false'
+    make_command = [
+        'make',
+        '-r', '-R',
+        '-f', 'build_keyboard.mk',
+        f'KEYBOARD={user_keymap["keyboard"]}',
+        f'KEYMAP={user_keymap["keymap"]}',
+        f'KEYBOARD_FILESAFE={keyboard_filesafe}',
+        f'TARGET={target}',
+        f'KEYBOARD_OUTPUT={keyboard_output}',
+        f'KEYMAP_OUTPUT={keymap_output}',
+        f'MAIN_KEYMAP_PATH_1={keymap_output}',
+        f'MAIN_KEYMAP_PATH_2={keymap_output}',
+        f'MAIN_KEYMAP_PATH_3={keymap_output}',
+        f'MAIN_KEYMAP_PATH_4={keymap_output}',
+        f'MAIN_KEYMAP_PATH_5={keymap_output}',
+        f'KEYMAP_C={keymap_c}',
+        f'KEYMAP_PATH={keymap_dir}',
+        f'VERBOSE={verbose}',
+        f'COLOR={color}',
+        'SILENT=false'
+    ]
+
+    return make_command
 
 
 def parse_configurator_json(configurator_file):

--- a/lib/python/qmk/commands.py
+++ b/lib/python/qmk/commands.py
@@ -48,7 +48,7 @@ def create_make_command(keyboard, keymap, target=None, **env_vars):
     return [make_cmd, *env, ':'.join(make_args)]
 
 
-def compile_configurator_json(user_keymap):
+def compile_configurator_json(user_keymap, **env_vars):
     """Convert a configurator export JSON file into a C file and then compile it.
 
     Args:
@@ -84,6 +84,12 @@ def compile_configurator_json(user_keymap):
         '-R',
         '-f',
         'build_keyboard.mk',
+    ]
+
+    for key, value in env_vars.items():
+        make_command.append(f'{key}={value}')
+
+    make_command.extend([
         f'KEYBOARD={user_keymap["keyboard"]}',
         f'KEYMAP={user_keymap["keymap"]}',
         f'KEYBOARD_FILESAFE={keyboard_filesafe}',
@@ -100,7 +106,7 @@ def compile_configurator_json(user_keymap):
         f'VERBOSE={verbose}',
         f'COLOR={color}',
         'SILENT=false',
-    ]
+    ])
 
     return make_command
 

--- a/lib/python/qmk/commands.py
+++ b/lib/python/qmk/commands.py
@@ -25,7 +25,7 @@ def _find_make():
     return make_cmd
 
 
-def create_make_command(keyboard, keymap, target=None, **env_vars):
+def create_make_command(keyboard, keymap, target=None, parallel=1, **env_vars):
     """Create a make compile command
 
     Args:
@@ -38,6 +38,9 @@ def create_make_command(keyboard, keymap, target=None, **env_vars):
 
         target
             Usually a bootloader.
+
+        parallel
+            The number of make jobs to run in parallel
 
         **env_vars
             Environment variables to be passed to make.
@@ -56,10 +59,10 @@ def create_make_command(keyboard, keymap, target=None, **env_vars):
     for key, value in env_vars.items():
         env.append(f'{key}={value}')
 
-    return [make_cmd, *env, ':'.join(make_args)]
+    return [make_cmd, '-j', str(parallel), *env, ':'.join(make_args)]
 
 
-def compile_configurator_json(user_keymap, **env_vars):
+def compile_configurator_json(user_keymap, parallel=1, **env_vars):
     """Convert a configurator export JSON file into a C file and then compile it.
 
     Args:
@@ -69,6 +72,9 @@ def compile_configurator_json(user_keymap, **env_vars):
 
         bootloader
             A bootloader to flash
+
+        parallel
+            The number of make jobs to run in parallel
 
     Returns:
 
@@ -91,6 +97,8 @@ def compile_configurator_json(user_keymap, **env_vars):
     color = 'true' if cli.config.general.color else 'false'
     make_command = [
         _find_make(),
+        '-j',
+        str(parallel),
         '-r',
         '-R',
         '-f',

--- a/lib/python/qmk/commands.py
+++ b/lib/python/qmk/commands.py
@@ -14,6 +14,17 @@ import qmk.keymap
 from qmk.constants import KEYBOARD_OUTPUT_PREFIX
 
 
+def _find_make():
+    """Returns the correct make command for this environment.
+    """
+    make_cmd = os.environ.get('MAKE')
+
+    if not make_cmd:
+        make_cmd = 'gmake' if shutil.which('gmake') else 'make'
+
+    return make_cmd
+
+
 def create_make_command(keyboard, keymap, target=None, **env_vars):
     """Create a make compile command
 
@@ -37,7 +48,7 @@ def create_make_command(keyboard, keymap, target=None, **env_vars):
     """
     env = []
     make_args = [keyboard, keymap]
-    make_cmd = 'gmake' if shutil.which('gmake') else 'make'
+    make_cmd = _find_make()
 
     if target:
         make_args.append(target)
@@ -79,7 +90,7 @@ def compile_configurator_json(user_keymap, **env_vars):
     verbose = 'true' if cli.config.general.verbose else 'false'
     color = 'true' if cli.config.general.color else 'false'
     make_command = [
-        'make',
+        _find_make(),
         '-r',
         '-R',
         '-f',

--- a/lib/python/qmk/constants.py
+++ b/lib/python/qmk/constants.py
@@ -1,5 +1,6 @@
 """Information that should be available to the python library.
 """
+from os import environ
 from pathlib import Path
 
 # The root of the qmk_firmware tree.
@@ -17,3 +18,7 @@ VUSB_PROCESSORS = 'atmega32a', 'atmega328p', 'atmega328', 'attiny85'
 DATE_FORMAT = '%Y-%m-%d'
 DATETIME_FORMAT = '%Y-%m-%d %H:%M:%S %Z'
 TIME_FORMAT = '%H:%M:%S'
+
+# Constants that should match their counterparts in make
+BUILD_DIR = environ.get('BUILD_DIR', '.build')
+KEYBOARD_OUTPUT_PREFIX = f'{BUILD_DIR}/obj_'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This adds two new features to `qmk compile` and `qmk flash`, as well as enhancing JSON keymaps so they don't pollute the tree:

* `--clean` flag: remove the build directory for a keyboard before compiling
* `--env` flag: pass environment variables down to make
* JSON keymaps no longer write to the keymaps directory, but instead write into the `$(KEYMAP_OUTPUT)/src` directory.
* Make flake8 happy with unrelated files

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
