### PR TITLE
Add target 'check-md5' to `build_keyboard.mk`

### DIFF
--- a/build_keyboard.mk
+++ b/build_keyboard.mk
@@ -368,14 +368,8 @@ endif
 
 build: elf cpfirmware
 check-size: build
+check-md5: build
 objs-size: build
-build-for-compare: SKIP_GIT = yes
-build-for-compare: SKIP_VERSION = yes
-build-for-compare: SKIP_DEBUG_INFO = yes
-build-for-compare: build check-md5
-#	$(info SKIP_GIT=$(SKIP_GIT))
-#	$(info SKIP_VERSION=$(SKIP_VERSION))
-#	$(info SKIP_DEBUG_INFO=$(SKIP_DEBUG_INFO))
 
 include show_options.mk
 include $(TMK_PATH)/rules.mk

--- a/build_keyboard.mk
+++ b/build_keyboard.mk
@@ -369,6 +369,13 @@ endif
 build: elf cpfirmware
 check-size: build
 objs-size: build
+build-for-compare: SKIP_GIT = yes
+build-for-compare: SKIP_VERSION = yes
+build-for-compare: SKIP_DEBUG_INFO = yes
+build-for-compare: build check-md5
+#	$(info SKIP_GIT=$(SKIP_GIT))
+#	$(info SKIP_VERSION=$(SKIP_VERSION))
+#	$(info SKIP_DEBUG_INFO=$(SKIP_DEBUG_INFO))
 
 include show_options.mk
 include $(TMK_PATH)/rules.mk

--- a/tmk_core/common/command.c
+++ b/tmk_core/common/command.c
@@ -144,10 +144,8 @@ static void print_version(void) {
     print("VID: " STR(VENDOR_ID) "(" STR(MANUFACTURER) ") "
                                                        "PID: " STR(PRODUCT_ID) "(" STR(PRODUCT) ") "
                                                                                                 "VER: " STR(DEVICE_VER) "\n");
-#ifdef SKIP_VERSION
     print("BUILD:  (" __DATE__ ")\n");
-#else
-    print("BUILD: " STR(QMK_VERSION) " (" __TIME__ " " __DATE__ ")\n");
+#ifndef SKIP_VERSION
 #    ifdef PROTOCOL_CHIBIOS
     print("CHIBIOS: " STR(CHIBIOS_VERSION) ", CONTRIB: " STR(CHIBIOS_CONTRIB_VERSION) "\n");
 #    endif

--- a/tmk_core/rules.mk
+++ b/tmk_core/rules.mk
@@ -79,7 +79,10 @@ CSTANDARD = -std=gnu99
 #  -Wall...:     warning level
 #  -Wa,...:      tell GCC to pass this to the assembler.
 #    -adhlns...: create assembler listing
-ifndef SKIP_DEBUG_INFO
+ifdef SKIP_DEBUG_INFO
+  undefine DEBUG_ENABLE
+endif
+ifdef DEBUG_ENABLE
   CFLAGS += -g$(DEBUG)
 endif
 CFLAGS += $(CDEFS)
@@ -110,7 +113,7 @@ CFLAGS += $(CSTANDARD)
 #  -Wall...:     warning level
 #  -Wa,...:      tell GCC to pass this to the assembler.
 #    -adhlns...: create assembler listing
-ifndef SKIP_DEBUG_INFO
+ifdef DEBUG_ENABLE
   CXXFLAGS += -g$(DEBUG)
 endif
 CXXFLAGS += $(CXXDEFS)
@@ -140,7 +143,7 @@ CXXFLAGS += -Wa,-adhlns=$(@:%.o=%.lst)
 #  -listing-cont-lines: Sets the maximum number of continuation lines of hex
 #       dump that will be displayed for a given single line of source input.
 ASFLAGS += $(ADEFS)
-ifndef SKIP_DEBUG_INFO
+ifdef DEBUG_ENABLE
   ASFLAGS += -Wa,-adhlns=$(@:%.o=%.lst),-gstabs,--listing-cont-lines=100
 else
   ASFLAGS += -Wa,-adhlns=$(@:%.o=%.lst),--listing-cont-lines=100

--- a/tmk_core/rules.mk
+++ b/tmk_core/rules.mk
@@ -431,14 +431,18 @@ check-size:
 		    fi \
 		fi \
 	fi
-check-md5:
-	md5 $(BUILD_DIR)/$(TARGET).hex
 else
 check-size:
 	$(SILENT) || echo "(Firmware size check does not yet support $(MCU) microprocessors; skipping.)"
-check-md5:
-	md5 $(BUILD_DIR)/$(TARGET).bin
 endif
+
+MD5SUM_CMD = md5sum
+ifneq ($(filter Darwin FreeBSD,$(shell uname -s)),)
+  MD5SUM_CMD = md5
+endif
+
+check-md5:
+	$(MD5SUM_CMD) $(BUILD_DIR)/$(TARGET).$(FIRMWARE_FORMAT)
 
 # Create build directory
 $(shell mkdir -p $(BUILD_DIR) 2>/dev/null)

--- a/tmk_core/rules.mk
+++ b/tmk_core/rules.mk
@@ -207,7 +207,10 @@ REMOVEDIR = rmdir
 COPY = cp
 WINSHELL = cmd
 SECHO = $(SILENT) || echo
-
+MD5SUM ?= md5sum
+ifneq ($(filter Darwin FreeBSD,$(shell uname -s)),)
+  MD5SUM = md5
+endif
 
 # Compiler flags to generate dependency files.
 #GENDEPFLAGS = -MMD -MP -MF .dep/$(@F).d
@@ -434,11 +437,6 @@ check-size:
 else
 check-size:
 	$(SILENT) || echo "(Firmware size check does not yet support $(MCU) microprocessors; skipping.)"
-endif
-
-MD5SUM ?= md5sum
-ifneq ($(filter Darwin FreeBSD,$(shell uname -s)),)
-  MD5SUM = md5
 endif
 
 check-md5:

--- a/tmk_core/rules.mk
+++ b/tmk_core/rules.mk
@@ -79,10 +79,12 @@ CSTANDARD = -std=gnu99
 #  -Wall...:     warning level
 #  -Wa,...:      tell GCC to pass this to the assembler.
 #    -adhlns...: create assembler listing
-ifdef SKIP_DEBUG_INFO
-  undefine DEBUG_ENABLE
+DEBUG_ENABLE ?= yes
+ifeq ($(strip $(SKIP_DEBUG_INFO)),yes)
+  DEBUG_ENABLE=no
 endif
-ifdef DEBUG_ENABLE
+
+ifeq ($(strip $(DEBUG_ENABLE)),yes)
   CFLAGS += -g$(DEBUG)
 endif
 CFLAGS += $(CDEFS)
@@ -113,7 +115,7 @@ CFLAGS += $(CSTANDARD)
 #  -Wall...:     warning level
 #  -Wa,...:      tell GCC to pass this to the assembler.
 #    -adhlns...: create assembler listing
-ifdef DEBUG_ENABLE
+ifeq ($(strip $(DEBUG_ENABLE)),yes)
   CXXFLAGS += -g$(DEBUG)
 endif
 CXXFLAGS += $(CXXDEFS)
@@ -143,7 +145,7 @@ CXXFLAGS += -Wa,-adhlns=$(@:%.o=%.lst)
 #  -listing-cont-lines: Sets the maximum number of continuation lines of hex
 #       dump that will be displayed for a given single line of source input.
 ASFLAGS += $(ADEFS)
-ifdef DEBUG_ENABLE
+ifeq ($(strip $(DEBUG_ENABLE)),yes)
   ASFLAGS += -Wa,-adhlns=$(@:%.o=%.lst),-gstabs,--listing-cont-lines=100
 else
   ASFLAGS += -Wa,-adhlns=$(@:%.o=%.lst),--listing-cont-lines=100

--- a/tmk_core/rules.mk
+++ b/tmk_core/rules.mk
@@ -440,7 +440,7 @@ check-size:
 endif
 
 check-md5:
-	$(MD5SUM_CMD) $(BUILD_DIR)/$(TARGET).$(FIRMWARE_FORMAT)
+	$(MD5SUM) $(BUILD_DIR)/$(TARGET).$(FIRMWARE_FORMAT)
 
 # Create build directory
 $(shell mkdir -p $(BUILD_DIR) 2>/dev/null)

--- a/tmk_core/rules.mk
+++ b/tmk_core/rules.mk
@@ -436,9 +436,9 @@ check-size:
 	$(SILENT) || echo "(Firmware size check does not yet support $(MCU) microprocessors; skipping.)"
 endif
 
-MD5SUM_CMD = md5sum
+MD5SUM ?= md5sum
 ifneq ($(filter Darwin FreeBSD,$(shell uname -s)),)
-  MD5SUM_CMD = md5
+  MD5SUM = md5
 endif
 
 check-md5:

--- a/tmk_core/rules.mk
+++ b/tmk_core/rules.mk
@@ -426,9 +426,13 @@ check-size:
 		    fi \
 		fi \
 	fi
+check-md5:
+	md5 $(BUILD_DIR)/$(TARGET).hex
 else
 check-size:
 	$(SILENT) || echo "(Firmware size check does not yet support $(MCU) microprocessors; skipping.)"
+check-md5:
+	md5 $(BUILD_DIR)/$(TARGET).bin
 endif
 
 # Create build directory


### PR DESCRIPTION
## Description

The `check-md5` target provides an easy way to check the md5 checksum of the generated binary.  This target will generate the binary and then display its md5 checksum.

~The `build-for-compare` target provides an easy way to check the md5 checksum of the generated binary. This target generates a binary without embedding the git version and qmk version, and then displays the md5 checksum for that binary.~

You can easily see if there is any change in the generated binaries between the two versions, as in the example below.

```
$ git checkout 0.11.0
M	build_keyboard.mk
M	tmk_core/rules.mk
Note: checking out '0.11.0'.
HEAD is now at c66df1664 2020 November 28 Breaking Changes Update (#11053)

$ make clean
$ make helix:all:check-md5 | grep ^MD5
MD5 (.build/helix_rev2_default.hex) = 5c3606562c944bb4d18832e601b45d4a
MD5 (.build/helix_rev2_edvorakjp.hex) = 9e43d13d389d518ba7e99cd7337e28d6
MD5 (.build/helix_rev2_five_rows.hex) = 8bcb61c2fd5d237c2997f2fa007d4934
MD5 (.build/helix_rev2_five_rows_jis.hex) = b97cd818d52f73ca2d4e78c86d90a791
MD5 (.build/helix_rev2_froggy.hex) = c492172364188f4e2918b10bf0f3a0a6
MD5 (.build/helix_rev2_froggy_106.hex) = b0861fd735a8f81881a8c02730641a2b
MD5 (.build/helix_rev2_led_test.hex) = 5c97d982a5da5cfb3dacb28a8934b81d
MD5 (.build/helix_rev2_xulkal.hex) = 01f603dc46bcf9094d7e106831d8f5b1
MD5 (.build/helix_rev2_yshrsmz.hex) = 5a008bca2d0c5790a151c02834c529ba

$ git checkout 0.11.1
M	build_keyboard.mk
M	tmk_core/rules.mk
Previous HEAD position was c66df1664 2020 November 28 Breaking Changes Update (#11053)
HEAD is now at cc08e3082 nix-shell: add milc dependency (#11086)

$ make clean
$ make helix:all:check-md5 | grep ^MD5
MD5 (.build/helix_rev2_default.hex) = 5c3606562c944bb4d18832e601b45d4a
MD5 (.build/helix_rev2_edvorakjp.hex) = 9e43d13d389d518ba7e99cd7337e28d6
MD5 (.build/helix_rev2_five_rows.hex) = 8bcb61c2fd5d237c2997f2fa007d4934
MD5 (.build/helix_rev2_five_rows_jis.hex) = b97cd818d52f73ca2d4e78c86d90a791
MD5 (.build/helix_rev2_froggy.hex) = c492172364188f4e2918b10bf0f3a0a6
MD5 (.build/helix_rev2_froggy_106.hex) = b0861fd735a8f81881a8c02730641a2b
MD5 (.build/helix_rev2_led_test.hex) = 5c97d982a5da5cfb3dacb28a8934b81d
MD5 (.build/helix_rev2_xulkal.hex) = d848383adfd7463b138c6da179cf1436
MD5 (.build/helix_rev2_yshrsmz.hex) = 5a008bca2d0c5790a151c02834c529ba
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
