### PR TITLE
Add missing Debian/Ubuntu dependency to the install script

### DIFF
--- a/util/install/debian.sh
+++ b/util/install/debian.sh
@@ -16,7 +16,7 @@ _qmk_install() {
         python3-pip \
         binutils-avr gcc-avr avr-libc \
         binutils-arm-none-eabi gcc-arm-none-eabi libnewlib-arm-none-eabi \
-        avrdude dfu-programmer dfu-util teensy-loader-cli
+        avrdude dfu-programmer dfu-util teensy-loader-cli libusb-dev
 
     python3 -m pip install --user -r $QMK_FIRMWARE_DIR/requirements.txt
 }


### PR DESCRIPTION
To successfully compile bootloadHID, we must have the libusb-config tool, which comes from the libusb-dev package. This package is available in both Ubuntu Groovy and Debian Buster