### PR TITLE
Shut off lighting layers in personal keymaps when sleeping

### DIFF
--- a/keyboards/dmqdesign/spin/keymaps/spidey3_pad/keymap.c
+++ b/keyboards/dmqdesign/spin/keymaps/spidey3_pad/keymap.c
@@ -195,7 +195,6 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     return true;
 };
 
-
 void post_process_record_user(uint16_t keycode, keyrecord_t *record) {
     switch (keycode) {
         // Acks follow...

--- a/keyboards/dmqdesign/spin/keymaps/spidey3_pad/keymap.c
+++ b/keyboards/dmqdesign/spin/keymaps/spidey3_pad/keymap.c
@@ -139,6 +139,14 @@ void shutdown_user() {
     rgblight_sethsv_noeeprom(HSV_RED);
 }
 
+void suspend_power_down_user(void) {
+    clear_rgb_layers();
+}
+
+void suspend_wakeup_init_user(void) {
+    do_rgb_layers(layer_state, LAYER_BASE, LAYER_BASE_END);
+}
+
 void spidey_glow(void) {
     rgblight_enable();
     rgblight_mode(RGBLIGHT_MODE_RAINBOW_MOOD);

--- a/users/spidey3/layer_rgb.c
+++ b/users/spidey3/layer_rgb.c
@@ -9,6 +9,9 @@ uint8_t  rgb_sat;
 uint8_t  rgb_val;
 bool     rgb_saved = 0;
 
+extern bool     spi_gflock;
+extern uint16_t spi_replace_mode;
+
 void spidey_glow(void) {
     rgblight_enable();
     rgblight_mode(RGBLIGHT_MODE_TWINKLE + 4);
@@ -201,6 +204,9 @@ void suspend_power_down_user_rgb(void) {
 void suspend_wakeup_init_user_rgb(void) {
     do_rgb_layers(default_layer_state, LAYER_BASE_DEFAULT + 1, LAYER_BASE_REGULAR);
     do_rgb_layers(layer_state, LAYER_BASE_REGULAR, LAYER_BASE_END);
+    led_update_user_rgb(host_keyboard_led_state());
+    rgblight_set_layer_state(MISC_OFFSET + 0, spi_gflock);
+    rgblight_set_layer_state(MISC_OFFSET + 1, spi_replace_mode != SPI_NORMAL);
 }
 
 layer_state_t default_layer_state_set_user_rgb(layer_state_t state) {
@@ -233,9 +239,6 @@ void rgb_layer_ack(layer_ack_t n) {
 
 extern keymap_config_t   keymap_config;
 extern rgblight_config_t rgblight_config;
-
-extern bool     spi_gflock;
-extern uint16_t spi_replace_mode;
 
 bool process_record_user_rgb(uint16_t keycode, keyrecord_t *record) {
     if (record->event.pressed) {

--- a/users/spidey3/layer_rgb.c
+++ b/users/spidey3/layer_rgb.c
@@ -194,6 +194,15 @@ void keyboard_post_init_user_rgb(void) {
     }
 }
 
+void suspend_power_down_user_rgb(void) {
+    clear_rgb_layers();
+}
+
+void suspend_wakeup_init_user_rgb(void) {
+    do_rgb_layers(default_layer_state, LAYER_BASE_DEFAULT + 1, LAYER_BASE_REGULAR);
+    do_rgb_layers(layer_state, LAYER_BASE_REGULAR, LAYER_BASE_END);
+}
+
 layer_state_t default_layer_state_set_user_rgb(layer_state_t state) {
     do_rgb_layers(state, 1u, LAYER_BASE_REGULAR);
     return state;

--- a/users/spidey3/spidey3.c
+++ b/users/spidey3/spidey3.c
@@ -333,11 +333,7 @@ bool led_update_user(led_t led_state) {
 }
 
 #ifdef RGBLIGHT_ENABLE
-void suspend_power_down_user(void) {
-    suspend_power_down_user_rgb();
-}
+void suspend_power_down_user(void) { suspend_power_down_user_rgb(); }
 
-void suspend_wakeup_init_user(void) {
-    suspend_wakeup_init_user_rgb();
-}
+void suspend_wakeup_init_user(void) { suspend_wakeup_init_user_rgb(); }
 #endif

--- a/users/spidey3/spidey3.c
+++ b/users/spidey3/spidey3.c
@@ -331,3 +331,13 @@ bool led_update_user(led_t led_state) {
     return true;
 #endif
 }
+
+#ifdef RGBLIGHT_ENABLE
+void suspend_power_down_user(void) {
+    suspend_power_down_user_rgb();
+}
+
+void suspend_wakeup_init_user(void) {
+    suspend_wakeup_init_user_rgb();
+}
+#endif

--- a/users/spidey3/spidey3.h
+++ b/users/spidey3/spidey3.h
@@ -60,6 +60,8 @@ bool          led_update_user_rgb(led_t led_state);
 void          rgb_layer_ack(layer_ack_t n);
 void          rgb_layer_ack_yn(bool yn);
 void          clear_rgb_layers(void);
+void          suspend_power_down_user_rgb(void);
+void          suspend_wakeup_init_user_rgb(void);
 #endif
 
 #ifdef UNICODEMAP_ENABLE


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I use RGBLIGHT_LAYERS_OVERRIDE_RGB_OFF, so need to explicitly turn off lighting layers so that they are turned off when the host goes to sleep.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
