### PR TITLE
Fixed key switch issue in PT mac layout

### DIFF
--- a/quantum/keymap_extras/keymap_portuguese_osx_iso.h
+++ b/quantum/keymap_extras/keymap_portuguese_osx_iso.h
@@ -34,7 +34,7 @@
  * └─────┴────┴─────┴───────────────────────┴─────┴────┴─────┘
  */
 // Row 1
-#define PT_SECT KC_GRV  // §
+#define PT_SECT KC_NUBS // §
 #define PT_1    KC_1    // 1
 #define PT_2    KC_2    // 2
 #define PT_3    KC_3    // 3
@@ -74,7 +74,7 @@
 #define PT_TILD KC_QUOT // ~ (dead)
 #define PT_BSLS KC_NUHS // (backslash)
 // Row 4
-#define PT_LABK KC_NUBS // <
+#define PT_LABK KC_GRV  // <
 #define PT_Z    KC_Z    // Z
 #define PT_X    KC_X    // X
 #define PT_C    KC_C    // C


### PR DESCRIPTION
Apple keyboards have § and < switched.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The keymap merged in https://github.com/qmk/qmk_firmware/pull/11260 had two keys switched.

/cc @fauxpark @drashna 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
