### PR TITLE
Correct encoder pins on BDN9v2

### DIFF
--- a/keyboards/keebio/bdn9/rev2/config.h
+++ b/keyboards/keebio/bdn9/rev2/config.h
@@ -40,7 +40,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // Left, Right, Middle
 #define ENCODERS_PAD_A { A8, B3, A10 }
-#define ENCODERS_PAD_B { B11, A15, A9 }
+#define ENCODERS_PAD_B { A4, A15, A9 }
 
 #define RGB_DI_PIN B15
 #ifdef RGB_DI_PIN

--- a/keyboards/keebio/bdn9/rev2/config.h
+++ b/keyboards/keebio/bdn9/rev2/config.h
@@ -41,6 +41,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // Left, Right, Middle
 #define ENCODERS_PAD_A { A8, B3, A10 }
 #define ENCODERS_PAD_B { A4, A15, A9 }
+#define TAP_CODE_DELAY 10
 
 #define RGB_DI_PIN B15
 #ifdef RGB_DI_PIN


### PR DESCRIPTION
Wrong pin used for the left encoder, should be A4
This resulted in the left encoder not working correctly on a newly built BDN9v2
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
