### PR TITLE
Change PRODUCT_ID descriptors for M80S and M80H

### DIFF
--- a/keyboards/mode/eighty/config.h
+++ b/keyboards/mode/eighty/config.h
@@ -18,7 +18,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* USB Device descriptor parameter */
 #define VENDOR_ID       0x00DE
-#define PRODUCT_ID      0x0080
 #define MANUFACTURER    Mode
 #define PRODUCT         Eighty
 

--- a/keyboards/mode/eighty/config.h
+++ b/keyboards/mode/eighty/config.h
@@ -18,10 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* USB Device descriptor parameter */
 #define VENDOR_ID       0x00DE
-<<<<<<< HEAD
-=======
 #define PRODUCT_ID      0x0080
->>>>>>> 10096fc42e52e5b22acd6ceef941816401468998
 #define MANUFACTURER    Mode
 #define PRODUCT         Eighty
 

--- a/keyboards/mode/eighty/config.h
+++ b/keyboards/mode/eighty/config.h
@@ -18,7 +18,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* USB Device descriptor parameter */
 #define VENDOR_ID       0x00DE
+<<<<<<< HEAD
+=======
 #define PRODUCT_ID      0x0080
+>>>>>>> 10096fc42e52e5b22acd6ceef941816401468998
 #define MANUFACTURER    Mode
 #define PRODUCT         Eighty
 

--- a/keyboards/mode/eighty/m80h/config.h
+++ b/keyboards/mode/eighty/m80h/config.h
@@ -18,4 +18,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #pragma once
 
 /* USB Device descriptor parameter */
+<<<<<<< HEAD
+#define PRODUCT_ID      0x0081
+=======
+>>>>>>> 10096fc42e52e5b22acd6ceef941816401468998
 #define DEVICE_VER      0x0072 //H for hotswap version

--- a/keyboards/mode/eighty/m80h/config.h
+++ b/keyboards/mode/eighty/m80h/config.h
@@ -18,8 +18,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #pragma once
 
 /* USB Device descriptor parameter */
-<<<<<<< HEAD
 #define PRODUCT_ID      0x0081
-=======
->>>>>>> 10096fc42e52e5b22acd6ceef941816401468998
 #define DEVICE_VER      0x0072 //H for hotswap version

--- a/keyboards/mode/eighty/m80s/config.h
+++ b/keyboards/mode/eighty/m80s/config.h
@@ -18,4 +18,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #pragma once
 
 /* USB Device descriptor parameter */
+<<<<<<< HEAD
+#define PRODUCT_ID      0x0080
+=======
+>>>>>>> 10096fc42e52e5b22acd6ceef941816401468998
 #define DEVICE_VER      0x0083 //S for solderable version

--- a/keyboards/mode/eighty/m80s/config.h
+++ b/keyboards/mode/eighty/m80s/config.h
@@ -18,8 +18,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #pragma once
 
 /* USB Device descriptor parameter */
-<<<<<<< HEAD
 #define PRODUCT_ID      0x0080
-=======
->>>>>>> 10096fc42e52e5b22acd6ceef941816401468998
 #define DEVICE_VER      0x0083 //S for solderable version


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

Make M80S and M80H have different PRODUCT_ID descriptors for VIA reasons. This PR substitutes #11370  because I'm dumb and my mom probably cries in the shower because of it.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Since M80S and M80H have different layout topologies -- M80S supporting more alternate layouts like split backspace and split right shift -- both need different VIA json files and hence they need different PRODUCT_ID descriptors so VIA can detect them uniquely. This PR makes M80S with 0x0080 and M80H with 0x0081.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
