### PR TITLE
Fix submodule check for qmk setup

### DIFF
--- a/lib/python/qmk/cli/doctor.py
+++ b/lib/python/qmk/cli/doctor.py
@@ -107,9 +107,9 @@ def doctor(cli):
             submodules.update()
             sub_ok = check_submodules()
 
-        if CheckStatus.ERROR in sub_ok:
+        if sub_ok == CheckStatus.ERROR:
             status = CheckStatus.ERROR
-        elif CheckStatus.WARNING in sub_ok and status == CheckStatus.OK:
+        elif sub_ok == CheckStatus.WARNING and status == CheckStatus.OK:
             status = CheckStatus.WARNING
 
     # Report a summary of our findings to the user


### PR DESCRIPTION
The initialization of the submodules would succeed, but the result of the subsequent
check_submodules() run wasn't checked correctly.


## Description

When bootstrapping a `qmk_firmware` repository, according to the documentation, there is an issue when calling `qmk setup`. That is, `qmk` is being installed via `pip`, not the one under `bin/qmk`. According to the docs.

Anyhow, the setup process asks to initialize the git submodules for the user, which it does on confirmation, but the check fails with a `Not an iteratable`-Error. I deem the problem fixed by this PR, but 1. I don't code python usually, 2. I only invested the minimum time.

I'm still confused why there is a `bin/qmk` but it doesn't have `setup`, yet the one installed via `pip install` still uses the local libraries in `lib/python`. Well. I hope this PR helps, but if not, it's fine with me.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
