### PR TITLE
Fix for xt_usb converter

### DIFF
--- a/keyboards/converter/xt_usb/matrix.c
+++ b/keyboards/converter/xt_usb/matrix.c
@@ -162,6 +162,7 @@ uint8_t matrix_scan(void)
             switch (code) {
                 case 0x45:
                     matrix_make(0x55);
+                    state = XT_STATE_INIT;
                     break;
                 default:
                     state = XT_STATE_INIT;
@@ -170,8 +171,9 @@ uint8_t matrix_scan(void)
             break;
         case XT_STATE_E1_9D:
             switch (code) {
-                case 0x45:
+                case 0xC5:
                     matrix_break(0x55);
+                    state = XT_STATE_INIT;
                     break;
                 default:
                     state = XT_STATE_INIT;


### PR DESCRIPTION
This is a backport of a few changes hasu made in his TMK firmware to fix general functionality issues that made the firmware pretty much unusable. This code needs to be tested to be certain of its functionality fixes in it's conversion to QMK.