### PR TITLE
make list_keyboards.sh faster

### DIFF
--- a/util/list_keyboards.sh
+++ b/util/list_keyboards.sh
@@ -3,8 +3,6 @@
 #
 # This allows us to exclude keyboards by including a .noci file.
 
-find -L keyboards -type f -name rules.mk | grep -v keymaps | while read keyboard; do
-	keyboard=$(echo $keyboard | sed 's!keyboards/\(.*\)/rules.mk!\1!')
-
+find -L keyboards -type f -name rules.mk | grep -v keymaps | sed 's!keyboards/\(.*\)/rules.mk!\1!' | while read keyboard; do
 	[ "$1" = "noci" -a -e "keyboards/${keyboard}/.noci" ] || echo "$keyboard"
 done


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

This PR makes utils/list_keyboards.sh speed up.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

`utils/list_keyboards.sh` invokes `sed` for each keyboards/*/rules.mk lines, it takes long time.
but it could be replaced by only one `sed` invoke.
This PR does it.

It improves on especially Windows, x12 faster on my environment.

```console
$ time ./util/list_keyboards.before.sh | md5sum
4875b109258156499fbc26095e8c1f53 *-

real    1m3.038s
user    0m14.086s
sys     0m44.983s
```

```console
$ time ./util/list_keyboards.sh | md5sum
4875b109258156499fbc26095e8c1f53 *-

real    0m4.908s
user    0m0.482s
sys     0m4.496s
```

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

nothings.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
