### PR TITLE
Align ChibiOS spi_master behaviour with AVR

### DIFF
--- a/drivers/chibios/spi_master.c
+++ b/drivers/chibios/spi_master.c
@@ -130,32 +130,12 @@ spi_status_t spi_read(void) {
 }
 
 spi_status_t spi_transmit(const uint8_t *data, uint16_t length) {
-    spi_status_t status;
-
-    for (uint16_t i = 0; i < length; i++) {
-        status = spi_write(data[i]);
-
-        if (status < 0) {
-            return status;
-        }
-    }
-
+    spiSend(&SPI_DRIVER, length, data);
     return SPI_STATUS_SUCCESS;
 }
 
 spi_status_t spi_receive(uint8_t *data, uint16_t length) {
-    spi_status_t status;
-
-    for (uint16_t i = 0; i < length; i++) {
-        status = spi_read();
-
-        if (status >= 0) {
-            data[i] = status;
-        } else {
-            return status;
-        }
-    }
-
+    spiReceive(&SPI_DRIVER, length, data);
     return SPI_STATUS_SUCCESS;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

In the AVR SPI driver, `spi_write()` performs a simultaneous write and read due to how the SPI protocol works. Thus you can transmit a byte and get a "response" back with the same function call.

The Bluefruit LE code does just this - it sends the first byte of a packet and reads the simultaneous response back from the module to check if it is ready to accept data. If not, we back off and try again later:
![image](https://user-images.githubusercontent.com/4781841/103456832-fe590700-4d4d-11eb-945e-7ad1884cd2fe.png)
(example from Pro Micro; the top three lines are MISO, bottom three are MOSI)

Except when I tested this on a Proton-C, it looked like this "not ready" signal was being ignored...
![image](https://user-images.githubusercontent.com/4781841/103456847-2183b680-4d4e-11eb-8beb-3c4c8d19c0ac.png)

So, I ~~rewrote the `spi_transmit()` and `spi_receive()` functions to match the AVR driver, and~~ called `spiExchange()` in `spi_write()` instead.

I can now type over Bluetooth on a Proton-C :)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
