### PR TITLE
Fix broken Lighting Layers when RGBLIGHT_MAX_LAYERS > 16 (layer>=16 not operable)

### DIFF
--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -628,7 +628,7 @@ void rgblight_sethsv_slave(uint8_t hue, uint8_t sat, uint8_t val) { rgblight_set
 
 #ifdef RGBLIGHT_LAYERS
 void rgblight_set_layer_state(uint8_t layer, bool enabled) {
-    rgblight_layer_mask_t mask = 1UL << layer;
+    rgblight_layer_mask_t mask = (rgblight_layer_mask_t)1 << layer;
     if (enabled) {
         rgblight_status.enabled_layer_mask |= mask;
     } else {
@@ -649,7 +649,7 @@ void rgblight_set_layer_state(uint8_t layer, bool enabled) {
 }
 
 bool rgblight_get_layer_state(uint8_t layer) {
-    rgblight_layer_mask_t mask = 1UL << layer;
+    rgblight_layer_mask_t mask = (rgblight_layer_mask_t)1 << layer;
     return (rgblight_status.enabled_layer_mask & mask) != 0;
 }
 
@@ -689,7 +689,7 @@ static uint16_t       _blink_timer;
 
 void rgblight_blink_layer(uint8_t layer, uint16_t duration_ms) {
     rgblight_set_layer_state(layer, true);
-_blinked_layer_mask |= 1UL << layer;
+_blinked_layer_mask |= (rgblight_layer_mask_t)1 << layer;
     _blink_timer    = timer_read();
     _blink_duration = duration_ms;
 }
@@ -697,7 +697,7 @@ _blinked_layer_mask |= 1UL << layer;
 void rgblight_unblink_layers(void) {
     if (_blinked_layer_mask != 0 && timer_elapsed(_blink_timer) > _blink_duration) {
         for (uint8_t layer = 0; layer < RGBLIGHT_MAX_LAYERS; layer++) {
-            if ((_blinked_layer_mask & 1UL << layer) != 0) {
+            if ((_blinked_layer_mask & (rgblight_layer_mask_t)1 << layer) != 0) {
                 rgblight_set_layer_state(layer, false);
             }
         }

--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -628,7 +628,7 @@ void rgblight_sethsv_slave(uint8_t hue, uint8_t sat, uint8_t val) { rgblight_set
 
 #ifdef RGBLIGHT_LAYERS
 void rgblight_set_layer_state(uint8_t layer, bool enabled) {
-    rgblight_layer_mask_t mask = (rgblight_layer_mask_t)1UL << layer;
+    rgblight_layer_mask_t mask = 1UL << layer;
     if (enabled) {
         rgblight_status.enabled_layer_mask |= mask;
     } else {
@@ -649,7 +649,7 @@ void rgblight_set_layer_state(uint8_t layer, bool enabled) {
 }
 
 bool rgblight_get_layer_state(uint8_t layer) {
-    rgblight_layer_mask_t mask = (rgblight_layer_mask_t)1UL << layer;
+    rgblight_layer_mask_t mask = 1UL << layer;
     return (rgblight_status.enabled_layer_mask & mask) != 0;
 }
 
@@ -689,7 +689,7 @@ static uint16_t       _blink_timer;
 
 void rgblight_blink_layer(uint8_t layer, uint16_t duration_ms) {
     rgblight_set_layer_state(layer, true);
-    _blinked_layer_mask |= (rgblight_layer_mask_t)1UL << layer;
+_blinked_layer_mask |= 1UL << layer;
     _blink_timer    = timer_read();
     _blink_duration = duration_ms;
 }
@@ -697,7 +697,7 @@ void rgblight_blink_layer(uint8_t layer, uint16_t duration_ms) {
 void rgblight_unblink_layers(void) {
     if (_blinked_layer_mask != 0 && timer_elapsed(_blink_timer) > _blink_duration) {
         for (uint8_t layer = 0; layer < RGBLIGHT_MAX_LAYERS; layer++) {
-            if ((_blinked_layer_mask & (rgblight_layer_mask_t)1UL << layer) != 0) {
+            if ((_blinked_layer_mask & 1UL << layer) != 0) {
                 rgblight_set_layer_state(layer, false);
             }
         }

--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -628,7 +628,7 @@ void rgblight_sethsv_slave(uint8_t hue, uint8_t sat, uint8_t val) { rgblight_set
 
 #ifdef RGBLIGHT_LAYERS
 void rgblight_set_layer_state(uint8_t layer, bool enabled) {
-    rgblight_layer_mask_t mask = 1 << layer;
+    rgblight_layer_mask_t mask = (rgblight_layer_mask_t)1UL << layer;
     if (enabled) {
         rgblight_status.enabled_layer_mask |= mask;
     } else {
@@ -649,7 +649,7 @@ void rgblight_set_layer_state(uint8_t layer, bool enabled) {
 }
 
 bool rgblight_get_layer_state(uint8_t layer) {
-    rgblight_layer_mask_t mask = 1 << layer;
+    rgblight_layer_mask_t mask = (rgblight_layer_mask_t)1UL << layer;
     return (rgblight_status.enabled_layer_mask & mask) != 0;
 }
 
@@ -689,7 +689,7 @@ static uint16_t       _blink_timer;
 
 void rgblight_blink_layer(uint8_t layer, uint16_t duration_ms) {
     rgblight_set_layer_state(layer, true);
-    _blinked_layer_mask |= 1 << layer;
+    _blinked_layer_mask |= (rgblight_layer_mask_t)1UL << layer;
     _blink_timer    = timer_read();
     _blink_duration = duration_ms;
 }
@@ -697,7 +697,7 @@ void rgblight_blink_layer(uint8_t layer, uint16_t duration_ms) {
 void rgblight_unblink_layers(void) {
     if (_blinked_layer_mask != 0 && timer_elapsed(_blink_timer) > _blink_duration) {
         for (uint8_t layer = 0; layer < RGBLIGHT_MAX_LAYERS; layer++) {
-            if ((_blinked_layer_mask & 1 << layer) != 0) {
+            if ((_blinked_layer_mask & (rgblight_layer_mask_t)1UL << layer) != 0) {
                 rgblight_set_layer_state(layer, false);
             }
         }

--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -689,7 +689,7 @@ static uint16_t       _blink_timer;
 
 void rgblight_blink_layer(uint8_t layer, uint16_t duration_ms) {
     rgblight_set_layer_state(layer, true);
-_blinked_layer_mask |= (rgblight_layer_mask_t)1 << layer;
+    _blinked_layer_mask |= (rgblight_layer_mask_t)1 << layer;
     _blink_timer    = timer_read();
     _blink_duration = duration_ms;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This fixes a bug that occurred if there were more than 16 lighting layers in use. Layers 16 and above could not be enabled due to an error in the bitwise arithmetic used to update `rgblight_status.enabled_layer_mask`.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
