### PR TITLE
Add rgblight_reload_from_eeprom()

### DIFF
--- a/docs/feature_rgblight.md
+++ b/docs/feature_rgblight.md
@@ -352,7 +352,7 @@ rgblight_sethsv(HSV_GREEN, 2); // led 2
 |`rgblight_step_noeeprom()`                  |Change the mode to the next RGB animation in the list of enabled RGB animations (not written to EEPROM) |
 |`rgblight_step_reverse()`                   |Change the mode to the previous RGB animation in the list of enabled RGB animations |
 |`rgblight_step_reverse_noeeprom()`          |Change the mode to the previous RGB animation in the list of enabled RGB animations (not written to EEPROM) |
-|`rgblight_reset_from_eeprom()`              |Reload the effect configuration (enabled, mode and color) from EEPROM |
+|`rgblight_reload_from_eeprom()`             |Reload the effect configuration (enabled, mode and color) from EEPROM |
 
 #### effects mode disable/enable
 |Function                                    |Description  |

--- a/docs/feature_rgblight.md
+++ b/docs/feature_rgblight.md
@@ -352,6 +352,7 @@ rgblight_sethsv(HSV_GREEN, 2); // led 2
 |`rgblight_step_noeeprom()`                  |Change the mode to the next RGB animation in the list of enabled RGB animations (not written to EEPROM) |
 |`rgblight_step_reverse()`                   |Change the mode to the previous RGB animation in the list of enabled RGB animations |
 |`rgblight_step_reverse_noeeprom()`          |Change the mode to the previous RGB animation in the list of enabled RGB animations (not written to EEPROM) |
+|`rgblight_reset_from_eeprom()`              |Reload the effect configuration (enabled, mode and color) from EEPROM |
 
 #### effects mode disable/enable
 |Function                                    |Description  |

--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -234,6 +234,17 @@ void rgblight_init(void) {
     is_rgblight_initialized = true;
 }
 
+void rgblight_reset_from_eeprom(void) {
+    /* Reset back to what we have in eeprom */
+    rgblight_config.raw = eeconfig_read_rgblight();
+    RGBLIGHT_SPLIT_SET_CHANGE_MODEHSVS;
+    rgblight_check_config();
+    eeconfig_debug_rgblight();  // display current eeprom values
+    if (rgblight_config.enable) {
+        rgblight_mode_noeeprom(rgblight_config.mode);
+    }
+}
+
 uint32_t rgblight_read_dword(void) { return rgblight_config.raw; }
 
 void rgblight_update_dword(uint32_t dword) {

--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -234,7 +234,7 @@ void rgblight_init(void) {
     is_rgblight_initialized = true;
 }
 
-void rgblight_reset_from_eeprom(void) {
+void rgblight_reload_from_eeprom(void) {
     /* Reset back to what we have in eeprom */
     rgblight_config.raw = eeconfig_read_rgblight();
     RGBLIGHT_SPLIT_SET_CHANGE_MODEHSVS;

--- a/quantum/rgblight.h
+++ b/quantum/rgblight.h
@@ -347,6 +347,9 @@ uint8_t rgblight_get_speed(void);
 void    rgblight_set_speed(uint8_t speed);
 void    rgblight_set_speed_noeeprom(uint8_t speed);
 
+/*   reset */
+void rgblight_reset_from_eeprom(void);
+
 /*       query */
 uint8_t rgblight_get_mode(void);
 uint8_t rgblight_get_hue(void);

--- a/quantum/rgblight.h
+++ b/quantum/rgblight.h
@@ -348,7 +348,7 @@ void    rgblight_set_speed(uint8_t speed);
 void    rgblight_set_speed_noeeprom(uint8_t speed);
 
 /*   reset */
-void rgblight_reset_from_eeprom(void);
+void rgblight_reload_from_eeprom(void);
 
 /*       query */
 uint8_t rgblight_get_mode(void);


### PR DESCRIPTION
## Description

Add `rgblight_reload_from_eeprom()` to allow a way to atomically reset the rgblight settings back to those which are currently stored in EEPROM. This is helpful when coding startup and acknowledgement animations, to restore the user's desired effects settings after the animation has completed. 

While it is possible at present to do this by storing local copies of the state before the animation started, there is no way to restore that state without ugly flashes of light, because there is no way to atomically set enabled/enabled, hsv, and effect mode. Note that `rgblight_mode_noeeprom()` and `rgblight_sethsv_noeeprom()` are both no-ops when rgblight is not enabled.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
