### PR TITLE
Fix AUR package name

### DIFF
--- a/docs/newbs_getting_started.md
+++ b/docs/newbs_getting_started.md
@@ -101,9 +101,9 @@ On Arch-based distros you can install the CLI from the official repositories (NO
 
     sudo pacman -S qmk
 
-You can also try the `qmk` package from AUR:
+You can also try the `qmk-git` package from AUR:
 
-    yay -S qmk
+    yay -S qmk-git
 
 ###  ** FreeBSD **
 


### PR DESCRIPTION
## Description

On Arch, `qmk` is now in the official repos, whereas only `qmk-git` is in AUR.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation