### PR TITLE
Homebrew install: ignore pinned formulae in `brew upgrade`

### DIFF
--- a/util/install/macos.sh
+++ b/util/install/macos.sh
@@ -9,7 +9,7 @@ _qmk_install_prepare() {
         return 1
     fi
 
-    brew update && brew upgrade
+    brew update && brew upgrade --ignore-pinned
 }
 
 _qmk_install() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

If a user has pinned formulae in Homebrew, `brew upgrade` will return nonzero:

```
Already up-to-date.
Error: Not upgrading 1 pinned package:
mysql 8.0.22_1
==> No packages to upgrade
```

 As this is the last thing that is run during `_qmk_install_prepare()`, it provides the return code of the function, which is then checked in `qmk_install.sh` - if nonzero, the script does not proceed with `_qmk_install()`. So we must add the `--ignore-pinned` flag:

```
      --ignore-pinned              Set a successful exit status even if pinned
                                   formulae are not upgraded.
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://old.reddit.com/r/olkb/comments/koww09/qmk_setup_troubles_cant_find_in_path_during_qmk/

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
