### PR TITLE
Fix tests on develop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -386,7 +386,7 @@ define PARSE_KEYMAP
     # Specify the variables that we are passing forward to submake
     MAKE_VARS := KEYBOARD=$$(CURRENT_KB) KEYMAP=$$(CURRENT_KM) REQUIRE_PLATFORM_KEY=$$(REQUIRE_PLATFORM_KEY)
     # And the first part of the make command
-    MAKE_CMD := $$(MAKE) -r -R -C $(ROOT_DIR) -f build_keyboard.mk $$(MAKE_TARGET)
+    MAKE_CMD := bin/qmk make -f build_keyboard.mk $$(MAKE_TARGET)
     # The message to display
     MAKE_MSG := $$(MSG_MAKE_KB)
     # We run the command differently, depending on if we want more output or not

--- a/build_keyboard.mk
+++ b/build_keyboard.mk
@@ -313,12 +313,6 @@ endif
 
 CONFIG_H += $(KEYBOARD_OUTPUT)/src/info_config.h $(KEYBOARD_OUTPUT)/src/layouts.h
 
-$(KEYBOARD_OUTPUT)/src/info_config.h: $(INFO_JSON_FILES)
-	bin/qmk generate-config-h --quiet --keyboard $(KEYBOARD) --output $(KEYBOARD_OUTPUT)/src/info_config.h
-
-$(KEYBOARD_OUTPUT)/src/layouts.h: $(INFO_JSON_FILES)
-	bin/qmk generate-layouts --quiet --keyboard $(KEYBOARD) --output $(KEYBOARD_OUTPUT)/src/layouts.h
-
 # project specific files
 SRC += $(KEYBOARD_SRC) \
     $(KEYMAP_C) \

--- a/lib/python/qmk/cli/__init__.py
+++ b/lib/python/qmk/cli/__init__.py
@@ -24,6 +24,7 @@ from . import json2c
 from . import lint
 from . import list
 from . import kle2json
+from . import make
 from . import new
 from . import pyformat
 from . import pytest

--- a/lib/python/qmk/cli/make.py
+++ b/lib/python/qmk/cli/make.py
@@ -49,11 +49,18 @@ def make(cli):
     # Generate the include files
     # FIXME(skullydazed/anyone): Instead of hard-coding a stale age we should compare the timestamp against all the info.json's involved
     config_h_file = f'{keyboard_output}/src/info_config.h'
+    if os.path.exists(config_h_file):
+        config_h_mtime = os.stat(config_h_file).st_mtime
+        config_h_age = time() - config_h_mtime
+    else:
+        config_h_age = file_stale_secs + 1
+
     layouts_h_file = f'{keyboard_output}/src/layouts.h'
-    config_h_mtime = os.stat(config_h_file).st_mtime
-    layouts_h_mtime = os.stat(layouts_h_file).st_mtime
-    config_h_age = time() - config_h_mtime
-    layouts_h_age = time() - layouts_h_mtime
+    if os.path.exists(layouts_h_file):
+        layouts_h_mtime = os.stat(layouts_h_file).st_mtime
+        layouts_h_age = time() - layouts_h_mtime
+    else:
+        layouts_h_age = file_stale_secs + 1
 
     if 'clean' not in cli.args.targets:
         config_h_cmd = ['bin/qmk', 'generate-config-h', '--keyboard', keyboard, '--output', config_h_file]
@@ -65,7 +72,7 @@ def make(cli):
         if config_h_age > file_stale_secs:
             cli.run(config_h_cmd, capture_output=False)
         if layouts_h_age > file_stale_secs:
-            cli.run(layouts_cmd, capture_output=False)
+            cli.run(layouts_h_cmd, capture_output=False)
 
     # Call make
     jobs = '1'

--- a/lib/python/qmk/cli/make.py
+++ b/lib/python/qmk/cli/make.py
@@ -1,0 +1,85 @@
+"""Generate and run a make command for building a keyboard.
+"""
+import os
+import subprocess
+from argparse import FileType
+from time import time
+
+from milc import cli
+
+from qmk.decorators import automagic_keyboard, automagic_keymap
+from qmk.commands import compile_configurator_json, create_make_command, parse_configurator_json
+
+
+file_stale_secs = 86400  # How many seconds old generated files are before being regenerated
+
+
+@cli.argument('targets', nargs='*', arg_only=True, help='Make targets to run')
+@cli.argument('-f', '--makefile', arg_only=True, default='build_keyboard.mk', help="The makefile to use")
+@cli.argument('-n', '--dry-run', arg_only=True, action='store_true', help="Don't actually build, just show the make command to be run")
+@cli.subcommand('Parse and run a QMK make command', hidden=True)
+def make(cli):
+    """Run a qmk make command.
+    """
+    # Determine the keyboard
+    silent = False
+    keyboard = None
+    build_dir = '.build'
+
+    for target in cli.args.targets:
+        if target.startswith('KEYBOARD='):
+            keyboard = target.split('=', 1)[1]
+
+        if target.startswith('BUILD_DIR='):
+            build_dir = target.split('=', 1)[1]
+
+        if target == 'SILENT=true':
+            silent = True
+
+        if target == 'SILENT=false':
+            silent = False
+
+    if not keyboard:
+        cli.log.error('Could not identify a keyboard for this compile!')
+        return False
+
+    keyboard_filesafe = keyboard.replace('/', '_')
+    keyboard_output = f'{build_dir}/obj_{keyboard_filesafe}'
+
+    # Generate the include files
+    # FIXME(skullydazed/anyone): Instead of hard-coding a stale age we should compare the timestamp against all the info.json's involved
+    config_h_file = f'{keyboard_output}/src/info_config.h'
+    layouts_h_file = f'{keyboard_output}/src/layouts.h'
+    config_h_mtime = os.stat(config_h_file).st_mtime
+    layouts_h_mtime = os.stat(layouts_h_file).st_mtime
+    config_h_age = time() - config_h_mtime
+    layouts_h_age = time() - layouts_h_mtime
+
+    if 'clean' not in cli.args.targets:
+        config_h_cmd = ['bin/qmk', 'generate-config-h', '--keyboard', keyboard, '--output', config_h_file]
+        layouts_h_cmd = ['bin/qmk', 'generate-layouts', '--keyboard', keyboard, '--output', layouts_h_file]
+        if silent:
+            config_h_cmd.append('-q')
+            layouts_h_cmd.append('-q')
+
+        if config_h_age > file_stale_secs:
+            cli.run(config_h_cmd, capture_output=False)
+        if layouts_h_age > file_stale_secs:
+            cli.run(layouts_cmd, capture_output=False)
+
+    # Call make
+    jobs = '1'
+    if '-j' in os.environ.get('MAKEFLAGS', ''):
+        for word in os.environ['MAKEFLAGS'].split():
+            if word.startswith('-j'):
+                jobs = word[2:]
+                break
+
+    shell_env = os.environ.copy()
+    for key in ('MAKEFLAGS', 'MAKELEVEL', 'MAKE_TERMERR', 'MFLAGS'):
+        if key in shell_env:
+            del shell_env[key]
+
+    make_cmd = ['make', '-j', jobs, '-r', '-R', '-f', cli.args.makefile, *cli.args.targets]
+    cli.log.debug('Running: %s', ' '.join(make_cmd))
+    cli.run(make_cmd, capture_output=False, env=shell_env)

--- a/tmk_core/rules.mk
+++ b/tmk_core/rules.mk
@@ -324,27 +324,27 @@ $1_CXXFLAGS = $$(ALL_CXXFLAGS) $$($1_DEFS) $$($1_INCFLAGS) $$($1_CONFIG_FLAGS) $
 $1_ASFLAGS = $$(ALL_ASFLAGS) $$($1_DEFS) $$($1_INCFLAGS) $$($1_CONFIG_FLAGS)
 
 # Compile: create object files from C source files.
-$1/%.o : %.c $1/%.d $1/cflags.txt $1/compiler.txt $(KEYBOARD_OUTPUT)/src/info_config.h $(KEYBOARD_OUTPUT)/src/layouts.h | $(BEGIN)
+$1/%.o : %.c $1/%.d $1/cflags.txt $1/compiler.txt | $(BEGIN)
 	@mkdir -p $$(@D)
 	@$$(SILENT) || printf "$$(MSG_COMPILING) $$<" | $$(AWK_CMD)
 	$$(eval CMD := $$(CC) -c $$($1_CFLAGS) $$(INIT_HOOK_CFLAGS) $$(GENDEPFLAGS) $$< -o $$@ && $$(MOVE_DEP))
 	@$$(BUILD_CMD)
 
 # Compile: create object files from C++ source files.
-$1/%.o : %.cpp $1/%.d $1/cxxflags.txt $1/compiler.txt $(KEYBOARD_OUTPUT)/src/info_config.h $(KEYBOARD_OUTPUT)/src/layouts.h | $(BEGIN)
+$1/%.o : %.cpp $1/%.d $1/cxxflags.txt $1/compiler.txt | $(BEGIN)
 	@mkdir -p $$(@D)
 	@$$(SILENT) || printf "$$(MSG_COMPILING_CXX) $$<" | $$(AWK_CMD)
 	$$(eval CMD=$$(CC) -c $$($1_CXXFLAGS) $$(INIT_HOOK_CFLAGS) $$(GENDEPFLAGS) $$< -o $$@ && $$(MOVE_DEP))
 	@$$(BUILD_CMD)
 
-$1/%.o : %.cc $1/%.d $1/cxxflags.txt $1/compiler.txt $(KEYBOARD_OUTPUT)/src/info_config.h $(KEYBOARD_OUTPUT)/src/layouts.h | $(BEGIN)
+$1/%.o : %.cc $1/%.d $1/cxxflags.txt $1/compiler.txt | $(BEGIN)
 	@mkdir -p $$(@D)
 	@$$(SILENT) || printf "$$(MSG_COMPILING_CXX) $$<" | $$(AWK_CMD)
 	$$(eval CMD=$$(CC) -c $$($1_CXXFLAGS) $$(INIT_HOOK_CFLAGS) $$(GENDEPFLAGS) $$< -o $$@ && $$(MOVE_DEP))
 	@$$(BUILD_CMD)
 
 # Assemble: create object files from assembler source files.
-$1/%.o : %.S $1/asflags.txt $1/compiler.txt $(KEYBOARD_OUTPUT)/src/info_config.h $(KEYBOARD_OUTPUT)/src/layouts.h | $(BEGIN)
+$1/%.o : %.S $1/asflags.txt $1/compiler.txt | $(BEGIN)
 	@mkdir -p $$(@D)
 	@$(SILENT) || printf "$$(MSG_ASSEMBLING) $$<" | $$(AWK_CMD)
 	$$(eval CMD=$$(CC) -c $$($1_ASFLAGS) $$< -o $$@)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Route around make's unique way of doing things so that we can generate header files reliably.

The tests were broken by #11412, specifically [this bit](https://github.com/qmk/qmk_firmware/pull/11412/files#diff-0109aac899f44998fbdeaff7620bf6621a348d9afe4697bb7aff8afb1bc2946b). That was added so that compiling in parallel (EG `make -j 4`) works reliably. However, it turns out that breaks `make test:basic`.

This started a long quest to find a way to generate include files while still supporting both tests and parallel make. This process has reminded me, once again, that make is a black box filled with suffering and [fondant](https://www.reddit.com/r/FondantHate/). That brings us to this monstrosity, something I fear will do great harm to my karmic balance.

This PR creates a new command, `qmk make`, which is designed to sit between `Makefile` and `build_keyboard.mk`. It generates include files based on the contents of `info.json` and then builds the keyboard/keymap in question.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [x] Enhancement/optimization

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
