### PR TITLE
[Keyboard] Disable music mode on OctoPad to reduce size

### DIFF
--- a/keyboards/nightly_boards/octopad/config.h
+++ b/keyboards/nightly_boards/octopad/config.h
@@ -69,7 +69,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define B5_AUDIO
 
 #define AUDIO_CLICKY
-
+#define NO_MUSIC_MODE
 
 /* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
 #define DEBOUNCE 5
@@ -81,5 +81,3 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define LOCKING_SUPPORT_ENABLE
 /* Locking resynchronize hack */
 #define LOCKING_RESYNC_ENABLE
-
-


### PR DESCRIPTION
## Description

Is compiling too large right now, due to audio and rgblight being "fully enabled". 

Disabling music mode is a simple way to reduce the size, especially on a macropad that is unlikely to use it, due to the lack of keys available. 

## Types of Changes

- [x] Enhancement/optimization
- [x] Keyboard (addition or update)

## Issues Fixed or Closed by This PR

* Travis CI faiilures

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
