### PR TITLE
Lighting Layers should be disabled when suspended

### DIFF
--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -723,8 +723,8 @@ void rgblight_suspend(void) {
 
 #    ifdef RGBLIGHT_LAYER_BLINK
         // make sure any layer blinks don't come back after suspend
-        _blinked_layer_mask = 0;
         rgblight_status.enabled_layer_mask &= ~_blinked_layer_mask;
+        _blinked_layer_mask = 0;
 #    endif
 
         rgblight_disable_noeeprom();
@@ -770,7 +770,7 @@ void rgblight_set(void) {
 
 #    ifdef RGBLIGHT_LAYERS
     if (rgblight_layers != NULL
-#        if defined(RGBLIGHT_LAYERS_OVERRIDE_RGB_OFF)
+#        if !defined(RGBLIGHT_LAYERS_OVERRIDE_RGB_OFF)
         && rgblight_config.enable
 #        elif defined(RGBLIGHT_SLEEP)
         && !is_suspended

--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -95,6 +95,11 @@ rgblight_config_t rgblight_config;
 rgblight_status_t rgblight_status         = {.timer_enabled = false};
 bool              is_rgblight_initialized = false;
 
+#ifdef RGBLIGHT_SLEEP
+static bool is_suspended;
+static bool pre_suspend_enabled;
+#endif
+
 #ifdef RGBLIGHT_USE_TIMER
 animation_status_t animation_status = {};
 #endif
@@ -708,6 +713,42 @@ void rgblight_unblink_layers(void) {
 
 #endif
 
+#ifdef RGBLIGHT_SLEEP
+
+void rgblight_suspend(void) {
+    rgblight_timer_disable();
+    if (!is_suspended) {
+        is_suspended        = true;
+        pre_suspend_enabled = rgblight_config.enable;
+
+#    ifdef RGBLIGHT_LAYER_BLINK
+        // make sure any layer blinks don't come back after suspend
+        _blinked_layer_mask = 0;
+        rgblight_status.enabled_layer_mask &= ~_blinked_layer_mask;
+#    endif
+
+        rgblight_disable_noeeprom();
+    }
+}
+
+void rgblight_wakeup(void) {
+    is_suspended = false;
+
+    if (pre_suspend_enabled) {
+        rgblight_enable_noeeprom();
+    }
+#    ifdef RGBLIGHT_LAYERS_OVERRIDE_RGB_OFF
+    // Need this or else the LEDs won't be set
+    else if (rgblight_status.enabled_layer_mask != 0) {
+        rgblight_set();
+    }
+#    endif
+
+    rgblight_timer_enable();
+}
+
+#endif
+
 __attribute__((weak)) void rgblight_call_driver(LED_TYPE *start_led, uint8_t num_leds) { ws2812_setleds(start_led, num_leds); }
 
 #ifndef RGBLIGHT_CUSTOM_DRIVER
@@ -729,8 +770,10 @@ void rgblight_set(void) {
 
 #    ifdef RGBLIGHT_LAYERS
     if (rgblight_layers != NULL
-#        ifndef RGBLIGHT_LAYERS_OVERRIDE_RGB_OFF
+#        if defined(RGBLIGHT_LAYERS_OVERRIDE_RGB_OFF)
         && rgblight_config.enable
+#        elif defined(RGBLIGHT_SLEEP)
+        && !is_suspended
 #        endif
     ) {
         rgblight_layers_write();

--- a/quantum/rgblight.h
+++ b/quantum/rgblight.h
@@ -357,6 +357,8 @@ HSV     rgblight_get_hsv(void);
 
 /* === qmk_firmware (core)internal Functions === */
 void     rgblight_init(void);
+void     rgblight_suspend(void);
+void     rgblight_wakeup(void);
 uint32_t rgblight_read_dword(void);
 void     rgblight_update_dword(uint32_t dword);
 uint32_t eeconfig_read_rgblight(void);

--- a/tmk_core/common/avr/suspend.c
+++ b/tmk_core/common/avr/suspend.c
@@ -24,9 +24,6 @@
 
 #if defined(RGBLIGHT_SLEEP) && defined(RGBLIGHT_ENABLE)
 #    include "rgblight.h"
-extern rgblight_config_t rgblight_config;
-static bool              rgblight_enabled;
-static bool              is_suspended;
 #endif
 
 /** \brief Suspend idle
@@ -104,12 +101,7 @@ static void power_down(uint8_t wdto) {
     // stop_all_notes();
 #    endif /* AUDIO_ENABLE */
 #    if defined(RGBLIGHT_SLEEP) && defined(RGBLIGHT_ENABLE)
-    rgblight_timer_disable();
-    if (!is_suspended) {
-        is_suspended     = true;
-        rgblight_enabled = rgblight_config.enable;
-        rgblight_disable_noeeprom();
-    }
+    rgblight_suspend();
 #    endif
     suspend_power_down_kb();
 
@@ -177,11 +169,7 @@ void suspend_wakeup_init(void) {
 #endif
     led_set(host_keyboard_leds());
 #if defined(RGBLIGHT_SLEEP) && defined(RGBLIGHT_ENABLE)
-    is_suspended = false;
-    if (rgblight_enabled) {
-        rgblight_enable_noeeprom();
-    }
-    rgblight_timer_enable();
+    rgblight_wakeup();
 #endif
     suspend_wakeup_init_kb();
 }

--- a/tmk_core/common/chibios/suspend.c
+++ b/tmk_core/common/chibios/suspend.c
@@ -18,9 +18,6 @@
 
 #if defined(RGBLIGHT_SLEEP) && defined(RGBLIGHT_ENABLE)
 #    include "rgblight.h"
-extern rgblight_config_t rgblight_config;
-static bool              rgblight_enabled;
-static bool              is_suspended;
 #endif
 
 /** \brief suspend idle
@@ -66,12 +63,7 @@ void suspend_power_down(void) {
     // shouldn't power down TPM/FTM if we want a breathing LED
     // also shouldn't power down USB
 #if defined(RGBLIGHT_SLEEP) && defined(RGBLIGHT_ENABLE)
-    rgblight_timer_disable();
-    if (!is_suspended) {
-        is_suspended     = true;
-        rgblight_enabled = rgblight_config.enable;
-        rgblight_disable_noeeprom();
-    }
+    rgblight_suspend();
 #endif
 
     suspend_power_down_kb();
@@ -136,11 +128,7 @@ void suspend_wakeup_init(void) {
 #endif /* BACKLIGHT_ENABLE */
     led_set(host_keyboard_leds());
 #if defined(RGBLIGHT_SLEEP) && defined(RGBLIGHT_ENABLE)
-    is_suspended = false;
-    if (rgblight_enabled) {
-        rgblight_enable_noeeprom();
-    }
-    rgblight_timer_enable();
+    rgblight_wakeup();
 #endif
     suspend_wakeup_init_kb();
 }


### PR DESCRIPTION
## Description

The current implementation of RGBLIGHT_SLEEP does not disable lighting layers on suspend if RGBLIGHT_LAYERS_OVERRIDE_RGB_OFF is defined. This was an oversight when it was originally implemented, resolved in this pull request.

I have also refactored RGBLIGHT_SLEEP somewhat to eliminate some duplicate code, and to improve encapsulation.

This change does not incur any significant change in compiled firmware size. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
