### PR TITLE
Enable LTO to bring nightlyboards/octopad size down

### DIFF
--- a/keyboards/nightly_boards/octopad/rules.mk
+++ b/keyboards/nightly_boards/octopad/rules.mk
@@ -15,6 +15,7 @@ COMMAND_ENABLE = no           # Commands for debug and configuration
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
 SLEEP_LED_ENABLE = no         # Breathing sleep LED during USB suspend
 # if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+LTO_ENABLE = yes              # Link Time Optimization, makes the firmware smaller but some features may not work
 NKRO_ENABLE = no              # USB Nkey Rollover
 BACKLIGHT_ENABLE = no         # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = yes         # Enable keyboard RGB underglow


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This make the compiled `nightly_boards/octopad` firmware small enough to flash. I have not tested this on an actual octopad but the via keymap already has this enabled so it should be safe enough.

Before this PR:

```
Checking file size of nightly_boards_octopad_default.hex
 * The firmware is too large! 29582/28672 (910 bytes over)
```

After this PR:

```
Checking file size of nightly_boards_octopad_default.hex
 * The firmware size is fine - 26210/28672 (91%, 2462 bytes free)
```
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
