### PR TITLE
Added german_gaming keymap for hidtech/bastyl

### DIFF
--- a/keyboards/hidtech/bastyl/keymaps/german_gaming/keymap.c
+++ b/keyboards/hidtech/bastyl/keymaps/german_gaming/keymap.c
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2021 Joschua Gandert
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include QMK_KEYBOARD_H
+#include "keymap_german.h"
+
+
+#define _BASE 0
+#define _GAME 1 /* WASD shifted right once  */
+#define _LOWER 2
+#define _RAISE 3
+#define _ADJUST 4 /* when both LOWER and RAISE pressed */
+
+#define RAISE MO(_RAISE)
+#define LOWER MO(_LOWER)
+
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  [_BASE] = LAYOUT(
+    KC_ESC , KC_1  ,  KC_2  ,  KC_3  , KC_4  , KC_5  ,              KC_6  , KC_7  , KC_8   , KC_9  , KC_0   , DE_SS  ,
+    KC_TAB , KC_Q  ,  KC_W  ,  KC_E  , KC_R  , KC_T  ,              DE_Z  , KC_U  , KC_I   , KC_O  , KC_P   , DE_UDIA,
+    KC_LSFT, KC_A  ,  KC_S  ,  KC_D  , KC_F  , KC_G  ,              KC_H  , KC_J  , KC_K   , KC_L  , DE_ODIA, DE_ADIA,
+    KC_LCTL, DE_Y  ,  KC_X  ,  KC_C  , KC_V  , KC_B  ,              KC_N  , KC_M  , KC_COMM, KC_DOT, DE_MINS, DE_PLUS,
+
+                                  RAISE,  KC_SPC,   KC_LCTL,    KC_RALT,  KC_BSPC,  LOWER,
+                                          KC_ENT,   KC_LALT,    KC_LGUI,  KC_RSFT
+  ),
+
+  [_GAME] = LAYOUT(
+    _______, _______, _______, _______, _______, _______,           _______, _______, _______, _______, _______, _______,
+    KC_T   , KC_TAB , KC_Q   , KC_W   , KC_E   , KC_R   ,           _______, _______, KC_UP,   _______, _______, _______,
+    KC_G   , KC_LSFT, KC_A   , KC_S   , KC_D   , KC_F   ,           _______, KC_LEFT, KC_DOWN, KC_RGHT, _______, _______,
+    KC_B   , KC_LCTL, DE_Y   , KC_X   , KC_C   , KC_V   ,           _______, _______, _______, _______, _______, _______,
+
+                                  _______, _______, _______,    _______, _______, _______,
+                                           _______, _______,    _______, _______
+  ),
+
+  [_LOWER] = LAYOUT(
+    KC_TILD, KC_EXLM, KC_AT  , KC_HASH, KC_DLR , KC_PERC,           KC_CIRC, KC_AMPR, KC_PSLS, KC_PAST, KC_PMNS, KC_DEL     ,
+    _______, DE_HASH, DE_CIRC, KC_PGUP, DE_LABK, _______,           _______, KC_P7  , KC_P8  , KC_P9  , KC_PPLS, KC_BSPC    ,
+    _______, DE_ACUT, KC_HOME, KC_PGDN, KC_END , KC_LPRN,           KC_RPRN, KC_P4  , KC_P5  , KC_P6  , KC_PDOT, _______    ,
+    _______, KC_PLUS, KC_PIPE, KC_UNDS, _______, _______,           KC_P0  , KC_P1  , KC_P2  , KC_P3  , KC_PENT, KC_KP_EQUAL,
+
+                                  _______, KC_RGHT, _______,    _______, _______, _______,
+                                           KC_LEFT, _______,    RESET  , _______
+  ),
+
+  [_RAISE] = LAYOUT(
+    KC_F12 , KC_F1  ,  KC_F2 ,   KC_F3 ,  KC_F4 ,  KC_F5 ,          KC_F6  , KC_F7   , KC_F8   ,  KC_F9  , KC_F10    , KC_F11 ,
+    _______, _______, _______,  KC_UP  , _______, _______,          KC_LALT, KC_INS  , KC_NLCK ,  KC_CALC, KC_PSCREEN, KC_MUTE,
+    _______, _______, KC_LEFT,  KC_DOWN, KC_RGHT, KC_ENT ,          KC_MSEL, KC_MPRV , KC_MPLY ,  KC_MNXT, _______   , KC_VOLU,
+    _______, _______, _______,  _______, _______, _______,          DE_HASH, KC_MYCM , _______ ,  _______, KC_SLCK   , KC_VOLD,
+
+                                  _______, _______, _______,    _______, KC_UP  , _______,
+                                           _______, _______,    _______, KC_DOWN
+  ),
+
+  [_ADJUST] = LAYOUT(
+    _______, _______, _______, _______, _______, _______,           _______, _______, _______, _______, _______, _______,
+    _______, _______, _______, _______, RESET  , _______,           _______, _______, _______, _______, _______, _______,
+    _______, _______, _______, _______, _______, DF(_GAME),         _______, _______, _______, _______, _______, _______,
+    _______, _______, _______, _______, _______, DF(_BASE),         _______, _______, _______, _______, _______, _______,
+
+                                   _______, _______, _______,    _______, _______, _______,
+                                            _______, _______,    _______, _______
+  ),
+};
+
+
+layer_state_t layer_state_set_user(layer_state_t state) {
+  return update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
+}

--- a/keyboards/hidtech/bastyl/keymaps/german_gaming/keymap.c
+++ b/keyboards/hidtech/bastyl/keymaps/german_gaming/keymap.c
@@ -20,11 +20,12 @@
 #include "keymap_german.h"
 
 
-#define _BASE 0
-#define _GAME 1 /* WASD shifted right once  */
-#define _LOWER 2
-#define _RAISE 3
-#define _ADJUST 4 /* when both LOWER and RAISE pressed */
+enum layer_names {
+    _BASE,
+    _GAME, /* WASD shifted right once  */
+    _LOWER,
+    _RAISE,
+    _ADJUST /* when both LOWER and RAISE pressed */
 
 #define RAISE MO(_RAISE)
 #define LOWER MO(_LOWER)

--- a/keyboards/hidtech/bastyl/keymaps/german_gaming/keymap.c
+++ b/keyboards/hidtech/bastyl/keymaps/german_gaming/keymap.c
@@ -26,6 +26,7 @@ enum layer_names {
     _LOWER,
     _RAISE,
     _ADJUST /* when both LOWER and RAISE pressed */
+};
 
 #define RAISE MO(_RAISE)
 #define LOWER MO(_LOWER)

--- a/keyboards/hidtech/bastyl/keymaps/german_gaming/readme.md
+++ b/keyboards/hidtech/bastyl/keymaps/german_gaming/readme.md
@@ -1,0 +1,24 @@
+![German Gaming Layout Image](https://i.imgur.com/0y938rG.png)
+
+Despite being less accurate, the columns in the image are shifted up and down to avoid the [Hermann grid illusion](https://en.wikipedia.org/wiki/Grid_illusion).
+​
+
+# German Gaming Layout
+​
+This layout was build with gaming in mind for a german user. As a result I added a "game" layer that shifts the keys of the left side (below the number row) one to the right, so that <kbd>WASD</kbd> is on the <kbd>ESDF</kbd> keys. The reason this layer was added is that using <kbd>WASD</kbd> is less comfortable with a contoured Dactyl-style keyboard, where each column is adjusted for the respective fingers. <kbd>ESDF</kbd> also has the upside of allowing one to stay in the home row. Note that the rightmost column of the default layer, so <kbd>TGB</kbd>, ends up in the leftmost position.
+
+Of course, one could just be forced to reconfigure every game, but that wouldn't be very user-friendly and likely reduce satisfaction with the layout. When in game mode, the right side of keys also features arrow keys on <kbd>IJKL</kbd>.
+
+
+## Raise and Lower layer
+
+Additionally, via the RAISE layer, it's always possible to access the arrow keys, which are often used in game menues. On the exact same position one can access <kbd>Home</kbd>, <kbd>End</kbd>, <kbd>Page Down</kbd> and <kbd>Page Up</kbd> via the LOWER layer. The left side of the LOWER layer also contains the few characters that would usually have their own key in a traditional german keyboard.
+
+The right side features various media keys in the RAISE layer, and a numpad in the LOWER layer.
+
+
+## Firmware
+
+The keyboard can be put into Reset mode (for flashing a keymap) by pressing <kbd>**LOWER**</kbd> + <kbd>Super</kbd> (also known as Windows key), or by pressing <kbd>**LOWER**</kbd> + <kbd>**RAISE**</kbd> + <kbd>R</kbd>.
+
+`MOUSEKEY_ENABLE` was set to `no` for this keymap, since it wasn't used and the size of the firmware ended up being too large.

--- a/keyboards/hidtech/bastyl/keymaps/german_gaming/rules.mk
+++ b/keyboards/hidtech/bastyl/keymaps/german_gaming/rules.mk
@@ -1,0 +1,6 @@
+
+# Build Options
+#   change to "no" to disable the options, or define them in the Makefile in
+#   the appropriate keymap folder that will get included automatically
+#
+MOUSEKEY_ENABLE = no       # Mouse keys(+4700)

--- a/keyboards/hidtech/bastyl/keymaps/german_gaming/rules.mk
+++ b/keyboards/hidtech/bastyl/keymaps/german_gaming/rules.mk
@@ -1,6 +1,1 @@
-
-# Build Options
-#   change to "no" to disable the options, or define them in the Makefile in
-#   the appropriate keymap folder that will get included automatically
-#
-MOUSEKEY_ENABLE = no       # Mouse keys(+4700)
+MOUSEKEY_ENABLE = no


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Added a german gaming keymap for @HID-Technologies' Bastyl. 

`MOUSEKEY_ENABLE` was set to `no` for this keymap, since I'm not using it, and IIRC the size of the firmware ended up being too large.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
