### PR TITLE
Address wake from sleep instability

### DIFF
--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -97,6 +97,8 @@ This is a C header file that is one of the first things included, and will persi
   * sets the maximum power (in mA) over USB for the device (default: 500)
 * `#define USB_POLLING_INTERVAL_MS 10`
   * sets the USB polling rate in milliseconds for the keyboard, mouse, and shared (NKRO/media keys) interfaces
+* `#define USB_SUSPEND_WAKEUP_DELAY 200`
+  * set the number of milliseconde to pause after sending a wakeup packet
 * `#define F_SCL 100000L`
   * sets the I2C clock rate speed for keyboards using I2C. The default is `400000L`, except for keyboards using `split_common`, where the default is `100000L`.
 

--- a/tmk_core/common/avr/suspend.c
+++ b/tmk_core/common/avr/suspend.c
@@ -102,7 +102,6 @@ static void power_down(uint8_t wdto) {
 #    if defined(RGBLIGHT_SLEEP) && defined(RGBLIGHT_ENABLE)
     rgblight_suspend();
 #    endif
-    suspend_power_down_kb();
 
     // TODO: more power saving
     // See PicoPower application note

--- a/tmk_core/common/suspend.h
+++ b/tmk_core/common/suspend.h
@@ -12,3 +12,7 @@ void suspend_wakeup_init_user(void);
 void suspend_wakeup_init_kb(void);
 void suspend_power_down_user(void);
 void suspend_power_down_kb(void);
+
+#ifndef USB_SUSPEND_WAKEUP_DELAY
+#    define USB_SUSPEND_WAKEUP_DELAY 200
+#endif

--- a/tmk_core/protocol/chibios/main.c
+++ b/tmk_core/protocol/chibios/main.c
@@ -239,6 +239,15 @@ int main(void) {
                 /* Remote wakeup */
                 if (suspend_wakeup_condition()) {
                     usbWakeupHost(&USB_DRIVER);
+
+                    // Some hubs, kvm switches, and monitors do
+                    // weird things, with USB device state bouncing
+                    // around wildly on wakeup, yielding race
+                    // conditions that can corrupt the keyboard state.
+                    //
+                    // Pause for a while to let things settle...
+                    wait_ms(100);
+
                     restart_usb_driver(&USB_DRIVER);
                 }
             }

--- a/tmk_core/protocol/chibios/main.c
+++ b/tmk_core/protocol/chibios/main.c
@@ -239,17 +239,6 @@ int main(void) {
                 /* Remote wakeup */
                 if (suspend_wakeup_condition()) {
                     usbWakeupHost(&USB_DRIVER);
-
-#    if USB_SUSPEND_WAKEUP_DELAY > 0
-                    // Some hubs, kvm switches, and monitors do
-                    // weird things, with USB device state bouncing
-                    // around wildly on wakeup, yielding race
-                    // conditions that can corrupt the keyboard state.
-                    //
-                    // Pause for a while to let things settle...
-                    wait_ms(USB_SUSPEND_WAKEUP_DELAY);
-#    endif
-
                     restart_usb_driver(&USB_DRIVER);
                 }
             }

--- a/tmk_core/protocol/chibios/main.c
+++ b/tmk_core/protocol/chibios/main.c
@@ -240,13 +240,15 @@ int main(void) {
                 if (suspend_wakeup_condition()) {
                     usbWakeupHost(&USB_DRIVER);
 
+#    if USB_SUSPEND_WAKEUP_DELAY > 0
                     // Some hubs, kvm switches, and monitors do
                     // weird things, with USB device state bouncing
                     // around wildly on wakeup, yielding race
                     // conditions that can corrupt the keyboard state.
                     //
                     // Pause for a while to let things settle...
-                    wait_ms(100);
+                    wait_ms(USB_SUSPEND_WAKEUP_DELAY);
+#    endif
 
                     restart_usb_driver(&USB_DRIVER);
                 }

--- a/tmk_core/protocol/chibios/usb_main.c
+++ b/tmk_core/protocol/chibios/usb_main.c
@@ -708,6 +708,17 @@ void init_usb_driver(USBDriver *usbp) {
 void restart_usb_driver(USBDriver *usbp) {
     usbStop(usbp);
     usbDisconnectBus(usbp);
+
+#if USB_SUSPEND_WAKEUP_DELAY > 0
+    // Some hubs, kvm switches, and monitors do
+    // weird things, with USB device state bouncing
+    // around wildly on wakeup, yielding race
+    // conditions that can corrupt the keyboard state.
+    //
+    // Pause for a while to let things settle...
+    wait_ms(USB_SUSPEND_WAKEUP_DELAY);
+#endif
+
     usbStart(usbp, &usbcfg);
     usbConnectBus(usbp);
 }

--- a/tmk_core/protocol/lufa/lufa.c
+++ b/tmk_core/protocol/lufa/lufa.c
@@ -1089,7 +1089,7 @@ int main(void) {
                     // conditions that can corrupt the keyboard state.
                     //
                     // Pause for a while to let things settle...
-                    wait_ms(200);
+                    wait_ms(100);
                 }
             }
             suspend_wakeup_init();

--- a/tmk_core/protocol/lufa/lufa.c
+++ b/tmk_core/protocol/lufa/lufa.c
@@ -435,7 +435,9 @@ void EVENT_USB_Device_Suspend() {
  */
 void EVENT_USB_Device_WakeUp() {
     print("[W]");
+#if defined(NO_USB_STARTUP_CHECK)
     suspend_wakeup_init();
+#endif
 
 #ifdef SLEEP_LED_ENABLE
     sleep_led_disable();
@@ -1078,6 +1080,10 @@ int main(void) {
             suspend_power_down();
             if (USB_Device_RemoteWakeupEnabled && suspend_wakeup_condition()) {
                 USB_Device_SendRemoteWakeup();
+            }
+            if (USB_DeviceState != DEVICE_STATE_Suspended) {
+                printf("USB_DeviceState = %u\n", USB_DeviceState);
+                suspend_wakeup_init();
             }
         }
 #endif

--- a/tmk_core/protocol/lufa/lufa.c
+++ b/tmk_core/protocol/lufa/lufa.c
@@ -1085,6 +1085,15 @@ int main(void) {
             }
             if (USB_Device_RemoteWakeupEnabled && suspend_wakeup_condition()) {
                 USB_Device_SendRemoteWakeup();
+                clear_keyboard();
+
+                // Some hubs, kvm switches, and monitors do
+                // weird things, with USB device state bouncing
+                // around wildly on wakeup, yielding race
+                // conditions that can corrupt the keyboard state.
+                //
+                // Pause for a while to let things settle...
+                wait_ms(200);
             }
         }
 

--- a/tmk_core/protocol/lufa/lufa.c
+++ b/tmk_core/protocol/lufa/lufa.c
@@ -1083,13 +1083,15 @@ int main(void) {
                     USB_Device_SendRemoteWakeup();
                     clear_keyboard();
 
+#    if USB_SUSPEND_WAKEUP_DELAY > 0
                     // Some hubs, kvm switches, and monitors do
                     // weird things, with USB device state bouncing
                     // around wildly on wakeup, yielding race
                     // conditions that can corrupt the keyboard state.
                     //
                     // Pause for a while to let things settle...
-                    wait_ms(100);
+                    wait_ms(USB_SUSPEND_WAKEUP_DELAY);
+#    endif
                 }
             }
             suspend_wakeup_init();

--- a/tmk_core/protocol/lufa/lufa.c
+++ b/tmk_core/protocol/lufa/lufa.c
@@ -1073,18 +1073,24 @@ int main(void) {
 #endif
 
     print("Keyboard start.\n");
+    bool was_suspended = false;
+
     while (1) {
 #if !defined(NO_USB_STARTUP_CHECK)
         while (USB_DeviceState == DEVICE_STATE_Suspended) {
-            print("[s]");
-            suspend_power_down();
+            if (!was_suspended) {
+                print("[s]");
+                suspend_power_down();
+                was_suspended = true;
+            }
             if (USB_Device_RemoteWakeupEnabled && suspend_wakeup_condition()) {
                 USB_Device_SendRemoteWakeup();
             }
-            if (USB_DeviceState != DEVICE_STATE_Suspended) {
-                printf("USB_DeviceState = %u\n", USB_DeviceState);
-                suspend_wakeup_init();
-            }
+        }
+
+        if (was_suspended) {
+            suspend_wakeup_init();
+            was_suspended = false;
         }
 #endif
 

--- a/tmk_core/protocol/lufa/lufa.c
+++ b/tmk_core/protocol/lufa/lufa.c
@@ -1075,28 +1075,24 @@ int main(void) {
     print("Keyboard start.\n");
     while (1) {
 #if !defined(NO_USB_STARTUP_CHECK)
-        bool was_suspended = false;
-        while (USB_DeviceState == DEVICE_STATE_Suspended) {
+        if (USB_DeviceState == DEVICE_STATE_Suspended) {
             print("[s]");
-            suspend_power_down();
-            was_suspended = true;
-            if (USB_Device_RemoteWakeupEnabled && suspend_wakeup_condition()) {
-                USB_Device_SendRemoteWakeup();
-                clear_keyboard();
+            while (USB_DeviceState == DEVICE_STATE_Suspended) {
+                suspend_power_down();
+                if (USB_Device_RemoteWakeupEnabled && suspend_wakeup_condition()) {
+                    USB_Device_SendRemoteWakeup();
+                    clear_keyboard();
 
-                // Some hubs, kvm switches, and monitors do
-                // weird things, with USB device state bouncing
-                // around wildly on wakeup, yielding race
-                // conditions that can corrupt the keyboard state.
-                //
-                // Pause for a while to let things settle...
-                wait_ms(200);
+                    // Some hubs, kvm switches, and monitors do
+                    // weird things, with USB device state bouncing
+                    // around wildly on wakeup, yielding race
+                    // conditions that can corrupt the keyboard state.
+                    //
+                    // Pause for a while to let things settle...
+                    wait_ms(200);
+                }
             }
-        }
-
-        if (was_suspended) {
             suspend_wakeup_init();
-            was_suspended = false;
         }
 #endif
 

--- a/tmk_core/protocol/lufa/lufa.c
+++ b/tmk_core/protocol/lufa/lufa.c
@@ -1073,16 +1073,13 @@ int main(void) {
 #endif
 
     print("Keyboard start.\n");
-    bool was_suspended = false;
-
     while (1) {
 #if !defined(NO_USB_STARTUP_CHECK)
+        bool was_suspended = false;
         while (USB_DeviceState == DEVICE_STATE_Suspended) {
-            if (!was_suspended) {
-                print("[s]");
-                suspend_power_down();
-                was_suspended = true;
-            }
+            print("[s]");
+            suspend_power_down();
+            was_suspended = true;
             if (USB_Device_RemoteWakeupEnabled && suspend_wakeup_condition()) {
                 USB_Device_SendRemoteWakeup();
                 clear_keyboard();


### PR DESCRIPTION
## Description

My work-from-home setup is a complicated mess of KVM switches, USB hubs, etc. Sleep / wake works fine when the keyboard is plugged directly into the computer, but through the switches / hubs it becomes unreliable, with the keyboard hanging sometimes on wake, or lighting being wrong after wakeup. Other people have reported similar experiences, especially when using KVM switches or when using pass-through USB on a USB-C or HDMI connected monitor.

Debugging showed that when a key is tapped to wake the board / host, if it goes through the switch, instead of USB device state going smoothly from Suspended to Configured, it goes back and forth a few times before settling on Configured.  When that happens, sometimes, the keyboard hangs. Other times the host just doesn't stay awake.

After spending some time looking into this, I've applied a few targeted changes:

- Removed a duplicate call to `suspend_power_down_kb()` (it was called twice for each suspend cycle).
- Added a short (200ms) delay after sending the RemoteWakeup packet to allow USB Device State to "settle" before continuing the loop.
- ~~At present, the suspend code is called repeatedly in a tight loop during suspend. I've made a change so that it is only called once on the transition to Suspended state.~~ [It turns out that the repeated calls are required, as that is where the low-power sleep cycle is implemented, so this has been restored.]

At the moment this is a draft, as I've only been able to test it on a few boards, and only for a few days.  Help testing this would be greatly appreciated.
- It's been tested thoroughly on atmega32u4, and on at90usb1286
- It should be good on AVR in general, but I'd appreciate folks testing on other AVR MCUs.
- ~~Code has been written for ARM / chibiOS, but is has not been tested at all yet.~~
- It has been tested on ARM / chibiOS with STM32F103 (bluepill) and STM32F303 (proton c).

Note that I am targeting the _develop_ branch, as this seems a bit too deep and critical to go directly to _master_...

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
