### PR TITLE
Fix connection issue in split keyboards when slave and OLED display are connected via I2C, fix #9335

### DIFF
--- a/drivers/oled/oled_driver.c
+++ b/drivers/oled/oled_driver.c
@@ -24,6 +24,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "progmem.h"
 
+#include "keyboard.h"
+
 // Used commands from spec sheet: https://cdn-shop.adafruit.com/datasheets/SSD1306.pdf
 // for SH1106: https://www.velleman.eu/downloads/29/infosheets/sh1106_datasheet.pdf
 
@@ -152,6 +154,10 @@ static void InvertCharacter(uint8_t *cursor) {
 }
 
 bool oled_init(uint8_t rotation) {
+#ifdef USE_I2C
+   if (!is_keyboard_master()) { return true; }
+#endif
+
     oled_rotation = oled_init_user(rotation);
     if (!HAS_FLAGS(oled_rotation, OLED_ROTATION_90)) {
         oled_rotation_width = OLED_DISPLAY_WIDTH;

--- a/drivers/oled/oled_driver.c
+++ b/drivers/oled/oled_driver.c
@@ -154,7 +154,7 @@ static void InvertCharacter(uint8_t *cursor) {
 }
 
 bool oled_init(uint8_t rotation) {
-#ifdef USE_I2C
+#if defined(USE_I2C) && defined(SPLIT_KEYBOARD)
    if (!is_keyboard_master()) { return true; }
 #endif
 

--- a/tmk_core/common/keyboard.c
+++ b/tmk_core/common/keyboard.c
@@ -263,7 +263,13 @@ void keyboard_init(void) {
     qwiic_init();
 #endif
 #ifdef OLED_DRIVER_ENABLE
+#if defined(SPLIT_KEYBOARD) && defined(USE_I2C)
+    if (is_keyboard_master()) {
+        oled_init(OLED_ROTATION_0);
+    }
+#else
     oled_init(OLED_ROTATION_0);
+#endif
 #endif
 #ifdef PS2_MOUSE_ENABLE
     ps2_mouse_init();
@@ -404,11 +410,21 @@ MATRIX_LOOP_END:
 #endif
 
 #ifdef OLED_DRIVER_ENABLE
+#if defined(SPLIT_KEYBOARD) && defined(USE_I2C)
+    if (is_keyboard_master()) {
+    oled_task();
+    #ifndef OLED_DISABLE_TIMEOUT
+    // Wake up oled if user is using those fabulous keys!
+        if (ret) oled_on();
+    #endif
+    }
+#else
     oled_task();
 #    ifndef OLED_DISABLE_TIMEOUT
     // Wake up oled if user is using those fabulous keys!
     if (ret) oled_on();
 #    endif
+#endif
 #endif
 
 #ifdef MOUSEKEY_ENABLE

--- a/tmk_core/common/keyboard.c
+++ b/tmk_core/common/keyboard.c
@@ -263,13 +263,7 @@ void keyboard_init(void) {
     qwiic_init();
 #endif
 #ifdef OLED_DRIVER_ENABLE
-#if defined(SPLIT_KEYBOARD) && defined(USE_I2C)
-    if (is_keyboard_master()) {
-        oled_init(OLED_ROTATION_0);
-    }
-#else
     oled_init(OLED_ROTATION_0);
-#endif
 #endif
 #ifdef PS2_MOUSE_ENABLE
     ps2_mouse_init();
@@ -410,21 +404,11 @@ MATRIX_LOOP_END:
 #endif
 
 #ifdef OLED_DRIVER_ENABLE
-#if defined(SPLIT_KEYBOARD) && defined(USE_I2C)
-    if (is_keyboard_master()) {
-    oled_task();
-    #ifndef OLED_DISABLE_TIMEOUT
-    // Wake up oled if user is using those fabulous keys!
-        if (ret) oled_on();
-    #endif
-    }
-#else
     oled_task();
 #    ifndef OLED_DISABLE_TIMEOUT
     // Wake up oled if user is using those fabulous keys!
     if (ret) oled_on();
 #    endif
-#endif
 #endif
 
 #ifdef MOUSEKEY_ENABLE


### PR DESCRIPTION
## Description

Now in split keyboards it is impossble to use I2C OLED display and I2C for communication beetween halves.
This described in #9335

PR disables calls to OLED display from slave half in case I2C used for OLED display and for communication beetwen halves. This restores normal communication between halves.
PR addresses the case when only one OLED display is used in split keyboard. When using two OLED displays on both halves of keyboard it is impossible to use I2C. Serial commmunication between halves should be used.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #9335

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
