### PR TITLE
add get_matrix_scan_rate() to tmk_core/common/keyboard.c

### DIFF
--- a/common_features.mk
+++ b/common_features.mk
@@ -24,6 +24,8 @@ QUANTUM_SRC += \
 ifeq ($(strip $(DEBUG_MATRIX_SCAN_RATE_ENABLE)), yes)
     OPT_DEFS += -DDEBUG_MATRIX_SCAN_RATE
     CONSOLE_ENABLE = yes
+else ifeq ($(strip $(DEBUG_MATRIX_SCAN_RATE_ENABLE)), api)
+    OPT_DEFS += -DDEBUG_MATRIX_SCAN_RATE
 endif
 
 ifeq ($(strip $(API_SYSEX_ENABLE)), yes)

--- a/tmk_core/common/keyboard.c
+++ b/tmk_core/common/keyboard.c
@@ -97,20 +97,27 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #endif
 
 // Only enable this if console is enabled to print to
-#if defined(DEBUG_MATRIX_SCAN_RATE) && defined(CONSOLE_ENABLE)
+#if defined(DEBUG_MATRIX_SCAN_RATE)
 static uint32_t matrix_timer      = 0;
 static uint32_t matrix_scan_count = 0;
+static uint32_t last_matrix_scan_count = 0;
 
 void matrix_scan_perf_task(void) {
     matrix_scan_count++;
 
     uint32_t timer_now = timer_read32();
     if (TIMER_DIFF_32(timer_now, matrix_timer) > 1000) {
+#    if defined(CONSOLE_ENABLE)
         dprintf("matrix scan frequency: %d\n", matrix_scan_count);
-
+#    endif
+        last_matrix_scan_count = matrix_scan_count;
         matrix_timer      = timer_now;
         matrix_scan_count = 0;
     }
+}
+
+uint32_t get_matrix_scan_rate(void) {
+    return last_matrix_scan_count;
 }
 #else
 #    define matrix_scan_perf_task()

--- a/tmk_core/common/keyboard.h
+++ b/tmk_core/common/keyboard.h
@@ -73,6 +73,8 @@ void keyboard_post_init_user(void);
 void housekeeping_task_kb(void);
 void housekeeping_task_user(void);
 
+uint32_t get_matrix_scan_rate(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Description

Added `get_matrix_scan_rate ()` to make it easier for keymap level code to get the matrix scan rate.

Example:
```diff
diff --git a/keyboards/helix/rev2/keymaps/five_rows/oled_display.c b/keyboards/helix/rev2/keymaps/five_rows/oled_display.c
index 689efe4c8..ff2f05e29 100644
--- a/keyboards/helix/rev2/keymaps/five_rows/oled_display.c
+++ b/keyboards/helix/rev2/keymaps/five_rows/oled_display.c
@@ -142,6 +142,11 @@ void render_status(void) {
     int name_num;
     uint32_t lstate;
     oled_write_P(layer_names[current_default_layer], false);
+#ifdef DEBUG_MATRIX_SCAN_RATE
+    char num[10];
+    snprintf(num, sizeof(num), " %ld ", get_matrix_scan_rate());
+    oled_write(num, false);
+#endif
     oled_write_P(PSTR("\n"), false);
     for (lstate = layer_state, name_num = 0;
          lstate && name_num < sizeof(layer_names)/sizeof(char *);
```

```shell
make DEBUG_MATRIX_SCAN_RATE_ENABLE=api helix/rev2/back:five_rows
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
