### PR TITLE
handwired/freoduo: define RGBLight config at keyboard level

### DIFF
--- a/keyboards/handwired/freoduo/config.h
+++ b/keyboards/handwired/freoduo/config.h
@@ -45,6 +45,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D4
+#if !defined(RGBLED_NUM)
+#    define RGBLED_NUM 18
+#    define RGBLIGHT_SPLIT
+#    define RGBLED_SPLIT { 9, 9 }
+// Switch RGB sides with LED MAP.
+#    define RGBLIGHT_LED_MAP { 8, 7, 6, 5, 4, 3, 2, 1, 0, 17, 16, 15, 14, 13, 12, 11, 10, 9}
+#    define RGBLIGHT_LAYERS
+#endif
 #define RGBLIGHT_ANIMATIONS
 #define RGBLIGHT_SLEEP
 #define RGBLIGHT_HUE_STEP 16


### PR DESCRIPTION
## Description

Configurator compiles fail without the number of LEDs defined here. Included the rest to match the default keymap's settings.

cc @FilipParyz


## Types of Changes

- [x] Enhancement/optimization
- [x] Keyboard (addition or update)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
