### PR TITLE
Add Per Key functionality for AutoShift

### DIFF
--- a/docs/feature_auto_shift.md
+++ b/docs/feature_auto_shift.md
@@ -109,6 +109,33 @@ Do not Auto Shift numeric keys, zero through nine.
 
 Do not Auto Shift alpha characters, which include A through Z.
 
+### Auto Shift Per Key 
+
+This is a function that allows you to determine which keys shold be autoshifted, much like the tap-hold keys. 
+
+The default function looks like this: 
+
+```c
+bool get_auto_shifted_key(uint16_t keycode, keyrecord_t *record) {
+    switch (keycode) {
+#    ifndef NO_AUTO_SHIFT_ALPHA
+        case KC_A ... KC_Z:
+#    endif
+#    ifndef NO_AUTO_SHIFT_NUMERIC
+        case KC_1 ... KC_0:
+#    endif
+#    ifndef NO_AUTO_SHIFT_SPECIAL
+        case KC_TAB:
+        case KC_MINUS ... KC_SLASH:
+        case KC_NONUS_BSLASH:
+#    endif
+            return true;
+    }
+    return false;
+}
+```
+This functionality is enabled by default, and does not need a define.
+
 ### AUTO_SHIFT_REPEAT (simple define)
 
 Enables keyrepeat.

--- a/quantum/process_keycode/process_auto_shift.c
+++ b/quantum/process_keycode/process_auto_shift.c
@@ -216,7 +216,18 @@ bool process_auto_shift(uint16_t keycode, keyrecord_t *record) {
 #    endif
         }
     }
+    if (get_auto_shifted_key(keycode, record)) {
+        if (record->event.pressed) {
+            return autoshift_press(keycode, now, record);
+        } else {
+            autoshift_end(keycode, now, false);
+            return false;
+        }
+    }
+    return true;
+}
 
+__attribute__((weak)) bool get_auto_shifted_key(uint16_t keycode, keyrecord_t *record) {
     switch (keycode) {
 #    ifndef NO_AUTO_SHIFT_ALPHA
         case KC_A ... KC_Z:
@@ -229,14 +240,9 @@ bool process_auto_shift(uint16_t keycode, keyrecord_t *record) {
         case KC_MINUS ... KC_SLASH:
         case KC_NONUS_BSLASH:
 #    endif
-            if (record->event.pressed) {
-                return autoshift_press(keycode, now, record);
-            } else {
-                autoshift_end(keycode, now, false);
-                return false;
-            }
+            return true;
     }
-    return true;
+    return false;
 }
 
 #endif

--- a/quantum/process_keycode/process_auto_shift.h
+++ b/quantum/process_keycode/process_auto_shift.h
@@ -31,4 +31,4 @@ bool     get_autoshift_state(void);
 uint16_t get_autoshift_timeout(void);
 void     set_autoshift_timeout(uint16_t timeout);
 void     autoshift_matrix_scan(void);
-bool get_auto_shifted_key(uint16_t keycode, keyrecord_t *record);
+bool     get_auto_shifted_key(uint16_t keycode, keyrecord_t *record);

--- a/quantum/process_keycode/process_auto_shift.h
+++ b/quantum/process_keycode/process_auto_shift.h
@@ -31,3 +31,4 @@ bool     get_autoshift_state(void);
 uint16_t get_autoshift_timeout(void);
 void     set_autoshift_timeout(uint16_t timeout);
 void     autoshift_matrix_scan(void);
+bool get_auto_shifted_key(uint16_t keycode, keyrecord_t *record);


### PR DESCRIPTION

## Description

This adds a "per key" function for checking if a key should be auto-shifted or not. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

* Closes #11533

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
