### PR TITLE
Stop sounds when suspended

### DIFF
--- a/quantum/audio/audio.h
+++ b/quantum/audio/audio.h
@@ -83,6 +83,7 @@ void increase_tempo(uint8_t tempo_change);
 void decrease_tempo(uint8_t tempo_change);
 
 void audio_init(void);
+void audio_startup(void);
 
 #ifdef PWM_AUDIO
 void play_sample(uint8_t* s, uint16_t l, bool r);

--- a/quantum/audio/audio_avr.c
+++ b/quantum/audio/audio_avr.c
@@ -227,7 +227,9 @@ void audio_init() {
 
         audio_initialized = true;
     }
+}
 
+void audio_startup() {
     if (audio_config.enable) {
         PLAY_SONG(startup_song);
     }

--- a/quantum/audio/audio_chibios.c
+++ b/quantum/audio/audio_chibios.c
@@ -287,10 +287,14 @@ void audio_init() {
 
     audio_initialized = true;
 
+    if (!audio_config.enable) {
+        stop_all_notes();
+    }
+}
+
+void audio_startup() {
     if (audio_config.enable) {
         PLAY_SONG(startup_song);
-    } else {
-        stop_all_notes();
     }
 }
 

--- a/quantum/audio/audio_chibios.c
+++ b/quantum/audio/audio_chibios.c
@@ -274,6 +274,12 @@ void audio_init() {
     dacStart(&DACD2, &dac1cfg2);
 
     /*
+     * Start the note timer
+     */
+    gptStart(&GPTD8, &gpt8cfg1);
+    gptStartContinuous(&GPTD8, 2U);
+
+    /*
      * Starting GPT6/7 driver, it is used for triggering the DAC.
      */
     START_CHANNEL_1();
@@ -287,9 +293,7 @@ void audio_init() {
 
     audio_initialized = true;
 
-    if (!audio_config.enable) {
-        stop_all_notes();
-    }
+    stop_all_notes();
 }
 
 void audio_startup() {
@@ -634,6 +638,9 @@ bool is_playing_notes(void) { return playing_notes; }
 bool is_audio_on(void) { return (audio_config.enable != 0); }
 
 void audio_toggle(void) {
+    if (audio_config.enable) {
+        stop_all_notes();
+    }
     audio_config.enable ^= 1;
     eeconfig_update_audio(audio_config.raw);
     if (audio_config.enable) {

--- a/quantum/audio/audio_pwm.c
+++ b/quantum/audio/audio_pwm.c
@@ -29,6 +29,11 @@
 
 #define CPU_PRESCALER 8
 
+#ifndef STARTUP_SONG
+#    define STARTUP_SONG SONG(STARTUP_SOUND)
+#endif
+float startup_song[][2] = STARTUP_SONG;
+
 // Timer Abstractions
 
 // TIMSK3 - Timer/Counter #3 Interrupt Mask Register
@@ -153,6 +158,12 @@ void audio_init() {
 #endif
 
     audio_initialized = true;
+}
+
+void audio_startup() {
+    if (audio_config.enable) {
+        PLAY_SONG(startup_song);
+    }
 }
 
 void stop_all_notes() {

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -666,6 +666,23 @@ void matrix_init_quantum() {
 }
 
 void matrix_scan_quantum() {
+    // There are some tasks that need to be run a little bit
+    // after keyboard startup, or else they will not work correctly
+    // because of interaction with the USB device state, which
+    // may still be in flux...
+    static bool     delayed_tasks_run  = false;
+    static uint16_t delayed_task_timer = 0;
+    if (!delayed_tasks_run) {
+        if (!delayed_task_timer) {
+            delayed_task_timer = timer_read();
+        } else if (timer_elapsed(delayed_task_timer) > 300) {
+#if defined(AUDIO_ENABLE)
+            audio_startup();
+#endif
+            delayed_tasks_run = true;
+        }
+    }
+
 #if defined(AUDIO_ENABLE) && !defined(NO_MUSIC_MODE)
     matrix_scan_music();
 #endif

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -666,22 +666,25 @@ void matrix_init_quantum() {
 }
 
 void matrix_scan_quantum() {
+#if defined(AUDIO_ENABLE)
     // There are some tasks that need to be run a little bit
     // after keyboard startup, or else they will not work correctly
     // because of interaction with the USB device state, which
     // may still be in flux...
+    //
+    // At the moment the only feature that needs this is the
+    // startup song.
     static bool     delayed_tasks_run  = false;
     static uint16_t delayed_task_timer = 0;
     if (!delayed_tasks_run) {
         if (!delayed_task_timer) {
             delayed_task_timer = timer_read();
         } else if (timer_elapsed(delayed_task_timer) > 300) {
-#if defined(AUDIO_ENABLE)
             audio_startup();
-#endif
             delayed_tasks_run = true;
         }
     }
+#endif
 
 #if defined(AUDIO_ENABLE) && !defined(NO_MUSIC_MODE)
     matrix_scan_music();

--- a/tmk_core/common/avr/suspend.c
+++ b/tmk_core/common/avr/suspend.c
@@ -97,8 +97,7 @@ static void power_down(uint8_t wdto) {
     led_set(leds_off);
 
 #    ifdef AUDIO_ENABLE
-    // This sometimes disables the start-up noise, so it's been disabled
-    // stop_all_notes();
+    stop_all_notes();
 #    endif /* AUDIO_ENABLE */
 #    if defined(RGBLIGHT_SLEEP) && defined(RGBLIGHT_ENABLE)
     rgblight_suspend();
@@ -157,6 +156,7 @@ __attribute__((weak)) void suspend_wakeup_init_user(void) {}
  * FIXME: needs doc
  */
 __attribute__((weak)) void suspend_wakeup_init_kb(void) { suspend_wakeup_init_user(); }
+
 /** \brief run immediately after wakeup
  *
  * FIXME: needs doc

--- a/tmk_core/common/chibios/suspend.c
+++ b/tmk_core/common/chibios/suspend.c
@@ -12,6 +12,10 @@
 #include "led.h"
 #include "wait.h"
 
+#ifdef AUDIO_ENABLE
+#    include "audio.h"
+#endif /* AUDIO_ENABLE */
+
 #ifdef BACKLIGHT_ENABLE
 #    include "backlight.h"
 #endif
@@ -65,6 +69,9 @@ void suspend_power_down(void) {
 #if defined(RGBLIGHT_SLEEP) && defined(RGBLIGHT_ENABLE)
     rgblight_suspend();
 #endif
+#ifdef AUDIO_ENABLE
+    stop_all_notes();
+#endif /* AUDIO_ENABLE */
 
     suspend_power_down_kb();
     // on AVR, this enables the watchdog for 15ms (max), and goes to


### PR DESCRIPTION
## Description

The code to stop sounds when suspending was commented out long ago, because it interfered with the startup sound working correctly. The problem was that at the time of `audio_init()` the USB device status might still be in flux, passing through the Suspended state, which would call `stop_all_notes()`.

The solution is to move the playing of the startup song into a routine that is run 300ms after startup, giving enough time for the USB state to settle.

Note: This has been tested thoroughly on AVR. I have provided code for ARM, but it is not as well tested. I understand that the state of audio on ARM is limited to Proton-C; I'd appreciate if someone with that architecture could test this before it is merged.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Fixes issues

Fixes #8167

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
