### PR TITLE
Add BGR byte order for WS2812 drivers

### DIFF
--- a/docs/ws2812_driver.md
+++ b/docs/ws2812_driver.md
@@ -33,11 +33,11 @@ The default setting is 280 µs, which should work for most cases, but this can b
 Some variants of the WS2812 may have their color components in a different physical or logical order. For example, the WS2812B-2020 has physically swapped red and green LEDs, which causes the wrong color to be displayed, because the default order of the bytes sent over the wire is defined as GRB.
 In this case, you can change the byte order by defining `WS2812_BYTE_ORDER` as one of the following values:
 
-| Byte order                        | Known devices                         |
-|-----------------------------------|---------------------------------------|
-| `WS2812_BYTE_ORDER_GRB` (default) | Most WS2812's, SK6812, SK6805         |
-| `WS2812_BYTE_ORDER_RGB`           | WS2812B-2020                          |
-| `WS2812_BYTE_ORDER_BGR`           | TM1812 and similar                    |
+|Byte order                       |Known devices                |
+|---------------------------------|-----------------------------|
+|`WS2812_BYTE_ORDER_GRB` (default)|Most WS2812's, SK6812, SK6805|
+|`WS2812_BYTE_ORDER_RGB`          |WS2812B-2020                 |
+|`WS2812_BYTE_ORDER_BGR`          |TM1812                       |
 
 
 ### Bitbang

--- a/docs/ws2812_driver.md
+++ b/docs/ws2812_driver.md
@@ -33,10 +33,11 @@ The default setting is 280 µs, which should work for most cases, but this can b
 Some variants of the WS2812 may have their color components in a different physical or logical order. For example, the WS2812B-2020 has physically swapped red and green LEDs, which causes the wrong color to be displayed, because the default order of the bytes sent over the wire is defined as GRB.
 In this case, you can change the byte order by defining `WS2812_BYTE_ORDER` as one of the following values:
 
-| Byte order                        | Known devices                 |
-|-----------------------------------|-------------------------------|
-| `WS2812_BYTE_ORDER_GRB` (default) | Most WS2812's, SK6812, SK6805 |
-| `WS2812_BYTE_ORDER_RGB`           | WS2812B-2020                  |
+| Byte order                        | Known devices                         |
+|-----------------------------------|---------------------------------------|
+| `WS2812_BYTE_ORDER_GRB` (default) | Most WS2812's, SK6812, SK6805         |
+| `WS2812_BYTE_ORDER_RGB`           | WS2812B-2020                          |
+| `WS2812_BYTE_ORDER_BGR`           | some custom keyboard PCBs (MatrixLabs)|
 
 
 ### Bitbang

--- a/docs/ws2812_driver.md
+++ b/docs/ws2812_driver.md
@@ -37,7 +37,7 @@ In this case, you can change the byte order by defining `WS2812_BYTE_ORDER` as o
 |-----------------------------------|---------------------------------------|
 | `WS2812_BYTE_ORDER_GRB` (default) | Most WS2812's, SK6812, SK6805         |
 | `WS2812_BYTE_ORDER_RGB`           | WS2812B-2020                          |
-| `WS2812_BYTE_ORDER_BGR`           | some custom keyboard PCBs (MatrixLabs)|
+| `WS2812_BYTE_ORDER_BGR`           | TM1812 and similar                    |
 
 
 ### Bitbang

--- a/drivers/chibios/ws2812.c
+++ b/drivers/chibios/ws2812.c
@@ -97,6 +97,10 @@ void ws2812_setleds(LED_TYPE *ledarray, uint16_t leds) {
         sendByte(ledarray[i].r);
         sendByte(ledarray[i].g);
         sendByte(ledarray[i].b);
+#elif (WS2812_BYTE_ORDER == WS2812_BYTE_ORDER_BGR)
+        sendByte(ledarray[i].b);
+        sendByte(ledarray[i].g);
+        sendByte(ledarray[i].r);
 #endif
 
 #ifdef RGBW

--- a/drivers/chibios/ws2812_pwm.c
+++ b/drivers/chibios/ws2812_pwm.c
@@ -180,6 +180,43 @@
  * @return                          The bit index
  */
 #    define WS2812_BLUE_BIT(led, bit) WS2812_BIT((led), 2, (bit))
+
+#elif (WS2812_BYTE_ORDER == WS2812_BYTE_ORDER_BGR)
+/**
+ * @brief   Determine the index in @ref ws2812_frame_buffer "the frame buffer" of a given red bit
+ *
+ * @note    The red byte is the middle byte in the color packet
+ *
+ * @param[in] led:                  The led index [0, @ref RGBLED_NUM)
+ * @param[in] bit:                  The bit number [0, 7]
+ *
+ * @return                          The bit index
+ */
+#    define WS2812_RED_BIT(led, bit) WS2812_BIT((led), 2, (bit))
+
+/**
+ * @brief   Determine the index in @ref ws2812_frame_buffer "the frame buffer" of a given green bit
+ *
+ * @note    The red byte is the first byte in the color packet
+ *
+ * @param[in] led:                  The led index [0, @ref RGBLED_NUM)
+ * @param[in] bit:                  The bit number [0, 7]
+ *
+ * @return                          The bit index
+ */
+#    define WS2812_GREEN_BIT(led, bit) WS2812_BIT((led), 1, (bit))
+
+/**
+ * @brief   Determine the index in @ref ws2812_frame_buffer "the frame buffer" of a given blue bit
+ *
+ * @note    The red byte is the last byte in the color packet
+ *
+ * @param[in] led:                  The led index [0, @ref RGBLED_NUM)
+ * @param[in] bit:                  The bit index [0, 7]
+ *
+ * @return                          The bit index
+ */
+#    define WS2812_BLUE_BIT(led, bit) WS2812_BIT((led), 0, (bit))
 #endif
 
 /* --- PRIVATE VARIABLES ---------------------------------------------------- */

--- a/drivers/chibios/ws2812_spi.c
+++ b/drivers/chibios/ws2812_spi.c
@@ -70,6 +70,10 @@ static void set_led_color_rgb(LED_TYPE color, int pos) {
     for (int j = 0; j < 4; j++) tx_start[BYTES_FOR_LED * pos + j] = get_protocol_eq(color.r, j);
     for (int j = 0; j < 4; j++) tx_start[BYTES_FOR_LED * pos + BYTES_FOR_LED_BYTE + j] = get_protocol_eq(color.g, j);
     for (int j = 0; j < 4; j++) tx_start[BYTES_FOR_LED * pos + BYTES_FOR_LED_BYTE * 2 + j] = get_protocol_eq(color.b, j);
+#elif (WS2812_BYTE_ORDER == WS2812_BYTE_ORDER_BGR)
+    for (int j = 0; j < 4; j++) tx_start[BYTES_FOR_LED * pos + j] = get_protocol_eq(color.b, j);
+    for (int j = 0; j < 4; j++) tx_start[BYTES_FOR_LED * pos + BYTES_FOR_LED_BYTE + j] = get_protocol_eq(color.g, j);
+    for (int j = 0; j < 4; j++) tx_start[BYTES_FOR_LED * pos + BYTES_FOR_LED_BYTE * 2 + j] = get_protocol_eq(color.r, j);
 #endif
 }
 

--- a/quantum/color.h
+++ b/quantum/color.h
@@ -37,6 +37,7 @@
 
 #define WS2812_BYTE_ORDER_RGB 0
 #define WS2812_BYTE_ORDER_GRB 1
+#define WS2812_BYTE_ORDER_BGR 2
 
 #ifndef WS2812_BYTE_ORDER
 #    define WS2812_BYTE_ORDER WS2812_BYTE_ORDER_GRB
@@ -51,6 +52,10 @@ typedef struct PACKED {
     uint8_t r;
     uint8_t g;
     uint8_t b;
+#elif (WS2812_BYTE_ORDER == WS2812_BYTE_ORDER_BGR)
+    uint8_t b;
+    uint8_t g;
+    uint8_t r;
 #endif
 } cRGB;
 
@@ -66,6 +71,10 @@ typedef struct PACKED {
     uint8_t r;
     uint8_t g;
     uint8_t b;
+#elif (WS2812_BYTE_ORDER == WS2812_BYTE_ORDER_BGR)
+    uint8_t b;
+    uint8_t g;
+    uint8_t r;
 #endif
     uint8_t w;
 } cRGBW;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Some custom keyboard PCBs (the MatrixLabs ones for example) have RGB strip modules that use standard RGB LEDs with a WS2812 compatible controller (TM1812 in most cases).
Unfortunately some of these PCBs have the LEDs wired up in reverse which requires the byte order to be in reverse as well for the colors to be correct.

In normal QMK it's not really noticable but when setting the color in a GUI tool like VIA it can be confusing because the wrong colors light up on the board.

I added a new byte order for this to the WS2812 drivers with reversed byte order (BGR).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
