### PR TITLE
GCC 10 compatibility for Ploopy optical encoder

### DIFF
--- a/keyboards/ploopyco/opt_encoder.c
+++ b/keyboards/ploopyco/opt_encoder.c
@@ -16,6 +16,34 @@
  */
 #include "opt_encoder.h"
 
+enum State state;
+
+/* Variables used for scroll wheel functionality. */
+bool lohif;
+bool hilof;
+int  lowA;
+int  highA;
+bool cLowA;
+bool cHighA;
+int  lowIndexA;
+int  highIndexA;
+bool lowOverflowA;
+bool highOverflowA;
+int  lowB;
+int  highB;
+bool cLowB;
+bool cHighB;
+int  lowIndexB;
+int  highIndexB;
+bool lowOverflowB;
+bool highOverflowB;
+int  scrollThresholdA;
+int  scrollThresholdB;
+int  arLowA[SCROLLER_AR_SIZE];
+int  arHighA[SCROLLER_AR_SIZE];
+int  arLowB[SCROLLER_AR_SIZE];
+int  arHighB[SCROLLER_AR_SIZE];
+
 /* Setup function for the scroll wheel. Initializes
    the relevant variables. */
 void opt_encoder_init(void) {

--- a/keyboards/ploopyco/opt_encoder.h
+++ b/keyboards/ploopyco/opt_encoder.h
@@ -28,33 +28,33 @@
 
 enum State { HIHI, HILO, LOLO, LOHI };
 
-enum State state;
+extern enum State state;
 
 /* Variables used for scroll wheel functionality. */
-bool lohif;
-bool hilof;
-int  lowA;
-int  highA;
-bool cLowA;
-bool cHighA;
-int  lowIndexA;
-int  highIndexA;
-bool lowOverflowA;
-bool highOverflowA;
-int  lowB;
-int  highB;
-bool cLowB;
-bool cHighB;
-int  lowIndexB;
-int  highIndexB;
-bool lowOverflowB;
-bool highOverflowB;
-int  scrollThresholdA;
-int  scrollThresholdB;
-int  arLowA[SCROLLER_AR_SIZE];
-int  arHighA[SCROLLER_AR_SIZE];
-int  arLowB[SCROLLER_AR_SIZE];
-int  arHighB[SCROLLER_AR_SIZE];
+extern bool lohif;
+extern bool hilof;
+extern int  lowA;
+extern int  highA;
+extern bool cLowA;
+extern bool cHighA;
+extern int  lowIndexA;
+extern int  highIndexA;
+extern bool lowOverflowA;
+extern bool highOverflowA;
+extern int  lowB;
+extern int  highB;
+extern bool cLowB;
+extern bool cHighB;
+extern int  lowIndexB;
+extern int  highIndexB;
+extern bool lowOverflowB;
+extern bool highOverflowB;
+extern int  scrollThresholdA;
+extern int  scrollThresholdB;
+extern int  arLowA[SCROLLER_AR_SIZE];
+extern int  arHighA[SCROLLER_AR_SIZE];
+extern int  arLowB[SCROLLER_AR_SIZE];
+extern int  arHighB[SCROLLER_AR_SIZE];
 
 void calculateThresholdA(int curA);
 void calculateThresholdB(int curB);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Mark the variables used by the optical encoder as extern, resolving the errors of 'multiple definition of `x`'

```/usr/bin/avr-ld: .build/obj_ploopyco_trackball_rev1_005_drag_scroll/keyboards/ploopyco/trackball/keymaps/drag_scroll/keymap.o:/qmk_firmware/keyboards/ploopyco/opt_encoder.h:31: multiple definition of `state'; .build/obj_ploopyco_trackball_rev1_005_drag_scroll/opt_encoder.o:/qmk_firmware/keyboards/ploopyco/opt_encoder.h:31: first defined here```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Similar to #9268 - Default keymap for Ploopy does not compile with GCC10

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
