### PR TITLE
Keep track of encoder activity

### DIFF
--- a/quantum/encoder.h
+++ b/quantum/encoder.h
@@ -20,7 +20,7 @@
 #include "quantum.h"
 
 void encoder_init(void);
-void encoder_read(void);
+bool encoder_read(void);
 
 void encoder_update_kb(int8_t index, bool clockwise);
 void encoder_update_user(int8_t index, bool clockwise);

--- a/tmk_core/common/keyboard.c
+++ b/tmk_core/common/keyboard.c
@@ -348,6 +348,9 @@ void keyboard_task(void) {
 #ifdef QMK_KEYS_PER_SCAN
     uint8_t keys_processed = 0;
 #endif
+#ifdef ENCODER_ENABLE
+    bool encoders_changed = false;
+#endif
 
     housekeeping_task_kb();
     housekeeping_task_user();
@@ -409,7 +412,7 @@ MATRIX_LOOP_END:
 #endif
 
 #ifdef ENCODER_ENABLE
-    bool encoders_changed = encoder_read();
+    encoders_changed = encoder_read();
     if (encoders_changed) last_encoder_activity_trigger();
 #endif
 
@@ -420,8 +423,12 @@ MATRIX_LOOP_END:
 #ifdef OLED_DRIVER_ENABLE
     oled_task();
 #    ifndef OLED_DISABLE_TIMEOUT
-    // Wake up oled if user is using those fabulous keys!
+    // Wake up oled if user is using those fabulous keys or spinning those encoders!
+#        ifdef ENCODER_ENABLE
     if (matrix_changed || encoders_changed) oled_on();
+#        else
+    if (matrix_changed) oled_on();
+#        endif
 #    endif
 #endif
 

--- a/tmk_core/common/keyboard.h
+++ b/tmk_core/common/keyboard.h
@@ -73,8 +73,14 @@ void keyboard_post_init_user(void);
 void housekeeping_task_kb(void);
 void housekeeping_task_user(void);
 
+uint32_t last_input_activity_time(void);     // Timestamp of the last matrix or encoder activity
+uint32_t last_input_activity_elapsed(void);  // Number of milliseconds since the last matrix or encoder activity
+
 uint32_t last_matrix_activity_time(void);     // Timestamp of the last matrix activity
 uint32_t last_matrix_activity_elapsed(void);  // Number of milliseconds since the last matrix activity
+
+uint32_t last_encoder_activity_time(void);     // Timestamp of the last encoder activity
+uint32_t last_encoder_activity_elapsed(void);  // Number of milliseconds since the last encoder activity
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Description

Addition to the "last matrix activity" PR, this time around it keeps track of encoder activity too.

Adds four new APIs:
```c
uint32_t last_input_activity_time(void);     // Timestamp of the last matrix or encoder activity
uint32_t last_input_activity_elapsed(void);  // Number of milliseconds since the last matrix or encoder activity

uint32_t last_encoder_activity_time(void);     // Timestamp of the last encoder activity
uint32_t last_encoder_activity_elapsed(void);  // Number of milliseconds since the last encoder activity
```

Tested on the Djinn rev1.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
