### PR TITLE
Fix BP_TAPO, which should be altgr’ed

### DIFF
--- a/quantum/keymap_extras/keymap_bepo.h
+++ b/quantum/keymap_extras/keymap_bepo.h
@@ -129,7 +129,7 @@
  * ├───┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─────┤
  * │     │ | │ ´ │ & │ Œ │ ` │ ¡ │ ˇ │ Ð │ / │ Ĳ │ Ə │ ˘ │     │
  * ├─────┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┐    │
- * │      │ Æ │ Ù │ ¨ │ € │   │ © │ Þ │ ẞ │ ® │ ~ │ ¯ │ ¸ │    │
+ * │      │ Æ │ Ù │ ¨ │ € │ ’ │ © │ Þ │ ẞ │ ® │ ~ │ ¯ │ ¸ │    │
  * ├────┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴───┴────┤
  * │    │   │ \ │ { │ } │ … │ ~ │ ¿ │ ° │   │ † │ ˛ │          │
  * ├────┼───┴┬──┴─┬─┴───┴───┴───┴───┴───┴──┬┴───┼───┴┬────┬────┤
@@ -168,6 +168,7 @@
 #define BP_UGRV ALGR(BP_U)    // Ù
 #define BP_DIAE ALGR(BP_I)    // ¨ (dead)
 #define BP_EURO ALGR(BP_E)    // €
+#define BP_TAPO ALGR(BP_COMM) // ’
 #define BP_COPY ALGR(BP_C)    // ©
 #define BP_THRN ALGR(BP_T)    // Þ
 #define BP_SS   ALGR(BP_S)    // ẞ
@@ -316,8 +317,7 @@
 #define BP_U_GRAVE BP_UGRV
 #define BP_DEAD_TREMA BP_DIAE
 #define BP_DTRM BP_DIAE
-#define BP_TYPOGRAPHICAL_APOSTROPHE BP_COMM
-#define BP_TAPO BP_COMM
+#define BP_TYPOGRAPHICAL_APOSTROPHE BP_TAPO
 #define BP_COPYRIGHT BP_COPY
 #define BP_CPRT BP_COPY
 #define BP_THORN BP_THRN


### PR DESCRIPTION
## Description

On Bépo v1.0 layout, the typographical apostrophe `’` is typed as `altgr+,`.

There is a Bépo v1.1 where typographical apostrophe and single quote are exchanged, but the current code is using the v1.0 layout for the single quote.

The problem was introduced in commit 0499f30f5, I found it while rebasing my keymap.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* None, should I create one?

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
