### PR TITLE
Fixup declaration for _kill, add other missing syscalls, populate errno.

### DIFF
--- a/tmk_core/common/chibios/syscall-fallbacks.c
+++ b/tmk_core/common/chibios/syscall-fallbacks.c
@@ -14,76 +14,89 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <errno.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 
 #pragma GCC diagnostic ignored "-Wmissing-prototypes"
 
-__attribute__((weak, used)) int _read_r(struct _reent *r, int file, char *ptr, int len) {
-    (void)r;
-    (void)file;
-    (void)ptr;
-    (void)len;
+__attribute__((weak, used)) int _open_r(struct _reent *r, const char *path, int flag, int m) {
+    __errno_r(r) = ENOENT;
     return -1;
 }
 
 __attribute__((weak, used)) int _lseek_r(struct _reent *r, int file, int ptr, int dir) {
-    (void)r;
-    (void)file;
-    (void)ptr;
-    (void)dir;
-    return 0;
+    __errno_r(r) = EBADF;
+    return -1;
+}
+
+__attribute__((weak, used)) int _read_r(struct _reent *r, int file, char *ptr, int len) {
+    __errno_r(r) = EBADF;
+    return -1;
 }
 
 __attribute__((weak, used)) int _write_r(struct _reent *r, int file, char *ptr, int len) {
-    (void)r;
-    (void)file;
-    (void)ptr;
-    return len;
+    __errno_r(r) = EBADF;
+    return -1;
 }
 
 __attribute__((weak, used)) int _close_r(struct _reent *r, int file) {
-    (void)r;
-    (void)file;
+    __errno_r(r) = EBADF;
+    return -1;
+}
+
+__attribute__((weak, used)) int _link_r(struct _reent *r, const char *oldpath, const char *newpath) {
+    __errno_r(r) = EPERM;
+    return -1;
+}
+
+__attribute__((weak, used)) int _unlink_r(struct _reent *r, const char *path) {
+    __errno_r(r) = EPERM;
+    return -1;
+}
+
+__attribute__((weak, used)) clock_t _times_r(struct _reent *r, void *t) {
+    __errno_r(r) = EFAULT;
+    return -1;
+}
+
+__attribute__((weak, used)) int _fstat_r(struct _reent *r, int file, struct stat *st) {
+    __errno_r(r) = EBADF;
+    return -1;
+}
+
+__attribute__((weak, used)) int _isatty_r(struct _reent *r, int fd) {
+    __errno_r(r) = EBADF;
     return 0;
 }
 
 __attribute__((weak, used)) caddr_t _sbrk_r(struct _reent *r, int incr) {
-    (void)r;
-    (void)incr;
+    __errno_r(r) = ENOMEM;
     return (caddr_t)-1;
 }
 
-__attribute__((weak, used)) int _fstat_r(struct _reent *r, int file, struct stat *st) {
-    (void)r;
-    (void)file;
-    (void)st;
-    return 0;
+__attribute__((weak, used)) int _kill(int pid, int sig) {
+    errno = EPERM;
+    return -1;
 }
-
-__attribute__((weak, used)) int _isatty_r(struct _reent *r, int fd) {
-    (void)r;
-    (void)fd;
-    return 1;
-}
-
-__attribute__((weak, used)) void _fini(void) { return; }
 
 __attribute__((weak, used)) pid_t _getpid(void) { return 1; }
 
-__attribute__((weak, noreturn)) void _exit(int i) {
-    (void)i;
+__attribute__((weak, used)) void _fini(void) { return; }
+
+__attribute__((weak, used, noreturn)) void _exit(int i) {
     while (1)
         ;
 }
 
-__attribute__((weak)) void _kill(void) {}
+__attribute__((weak, used)) int _gettimeofday_r(struct _reent *r, struct timeval *t, void *tzp) {
+    __errno_r(r) = EPERM;
+    return -1;
+}
 
-__attribute__((weak)) void *__dso_handle;
+__attribute__((weak, used)) void *__dso_handle;
 
-void __cxa_pure_virtual(void);
-
-__attribute__((weak)) void __cxa_pure_virtual() {
+__attribute__((weak, used)) void __cxa_pure_virtual(void) {
     while (1)
         ;
 }


### PR DESCRIPTION
## Description

Just some "proper" handling of `errno`, as well as adding a few more syscalls that were originally missed.
Rationale for all the `errno` handling is that these are the base functions invoked by newlib -- user-code never invokes these directly and it's likely we need to act "proper" in order for the assumptions newlib have made in the C library to correctly function.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
