### PR TITLE
Enforce memory allocator for ChibiOS builds with allocating debounce algorithms

### DIFF
--- a/quantum/debounce/sym_defer_pk.c
+++ b/quantum/debounce/sym_defer_pk.c
@@ -23,6 +23,12 @@ When no state changes have occured for DEBOUNCE milliseconds, we push the state.
 #include "quantum.h"
 #include <stdlib.h>
 
+#ifdef PROTOCOL_CHIBIOS
+#    if CH_CFG_USE_MEMCORE == FALSE
+#        error ChibiOS is configured without a memory allocator. Your keyboard may have set `#define CH_CFG_USE_MEMCORE FALSE`, which is incompatible with this debounce algorithm.
+#    endif
+#endif
+
 #ifndef DEBOUNCE
 #    define DEBOUNCE 5
 #endif

--- a/quantum/debounce/sym_eager_pk.c
+++ b/quantum/debounce/sym_eager_pk.c
@@ -23,6 +23,12 @@ No further inputs are accepted until DEBOUNCE milliseconds have occurred.
 #include "quantum.h"
 #include <stdlib.h>
 
+#ifdef PROTOCOL_CHIBIOS
+#    if CH_CFG_USE_MEMCORE == FALSE
+#        error ChibiOS is configured without a memory allocator. Your keyboard may have set `#define CH_CFG_USE_MEMCORE FALSE`, which is incompatible with this debounce algorithm.
+#    endif
+#endif
+
 #ifndef DEBOUNCE
 #    define DEBOUNCE 5
 #endif

--- a/quantum/debounce/sym_eager_pr.c
+++ b/quantum/debounce/sym_eager_pr.c
@@ -23,6 +23,12 @@ No further inputs are accepted until DEBOUNCE milliseconds have occurred.
 #include "quantum.h"
 #include <stdlib.h>
 
+#ifdef PROTOCOL_CHIBIOS
+#    if CH_CFG_USE_MEMCORE == FALSE
+#        error ChibiOS is configured without a memory allocator. Your keyboard may have set `#define CH_CFG_USE_MEMCORE FALSE`, which is incompatible with this debounce algorithm.
+#    endif
+#endif
+
 #ifndef DEBOUNCE
 #    define DEBOUNCE 5
 #endif


### PR DESCRIPTION
## Description

Using one of the alternate debounce algorithms requires a memory allocator.
ChibiOS allows you to disable said memory allocator.

This puts some compile-time checks to enforce that the allocator has been enabled -- during testing with it set to FALSE, the keyboard would run and function correctly from a visible standpoint, but no keypresses would register. The fun part was, if the slave side had a firmware that had an allocator enabled, the master would still report keypresses on the slave, but not itself!

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
