### PR TITLE
Fix Ergosaurus default RGB_DI_PIN

### DIFF
--- a/keyboards/ergosaurus/config.h
+++ b/keyboards/ergosaurus/config.h
@@ -58,7 +58,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // #define BACKLIGHT_BREATHING
 // #define BACKLIGHT_LEVELS 3
 
-// #define RGB_DI_PIN E2
+// #define RGB_DI_PIN B6
 // #ifdef RGB_DI_PIN
 //   #define RGBLED_NUM 16
 //   #define RGBLIGHT_HUE_STEP 8

--- a/keyboards/ergosaurus/config.h
+++ b/keyboards/ergosaurus/config.h
@@ -58,8 +58,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // #define BACKLIGHT_BREATHING
 // #define BACKLIGHT_LEVELS 3
 
-// #define RGB_DI_PIN B6
-// #ifdef RGB_DI_PIN
+// #ifdef RGBLIGHT_ENABLE
+//   #define RGB_DI_PIN B6
 //   #define RGBLED_NUM 16
 //   #define RGBLIGHT_HUE_STEP 8
 //   #define RGBLIGHT_SAT_STEP 8


### PR DESCRIPTION
## Description

The correct breakout pin used for RGB underglow is B6, not E2 (which seems to have been overlooked when generating the firmware).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
