### PR TITLE
Fix midi for CRKBD

### DIFF
--- a/keyboards/crkbd/config.h
+++ b/keyboards/crkbd/config.h
@@ -25,6 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define PRODUCT_ID      0x0001
 #define DEVICE_VER      0x0001
 #define MANUFACTURER    foostan
+#define PRODUCT         Corne
 
 /* key matrix size */
 // Rows are doubled-up

--- a/keyboards/crkbd/rev1/common/config.h
+++ b/keyboards/crkbd/rev1/common/config.h
@@ -18,8 +18,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
-#define PRODUCT         Corne Keyboard Rev.1 (Split Common)
-
 #define USE_SERIAL
 #define SOFT_SERIAL_PIN D2
 

--- a/keyboards/crkbd/rev1/legacy/config.h
+++ b/keyboards/crkbd/rev1/legacy/config.h
@@ -20,4 +20,3 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "serial_config.h"
 
-#define PRODUCT         Corne Keyboard Rev.1 (Legacy Split)


### PR DESCRIPTION
## Description

By simplifing the PRODUCT string of the CRKBD, I've fixed issues I had with MIDI on this keyboard. I can't really explain why as I'm not an expert. If anyone have an explanation, I would love to have it, but for now, I want to share with you my fix if anyone needs it. If you want to test it, use the keycode `MI_C_1` in one of your keys and test with MIDI-OX or any DAW that your keyboard is correctly recognized as a MIDI input.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [X] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
