### PR TITLE
Add velocikey support to split keyboards

### DIFF
--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -829,6 +829,18 @@ void rgblight_update_sync(rgblight_syncinfo_t *syncinfo, bool write_to_eeprom) {
         rgblight_sethsv_eeprom_helper(syncinfo->config.hue, syncinfo->config.sat, syncinfo->config.val, write_to_eeprom);
         // rgblight_config.speed = config->speed; // NEED???
     }
+#    if defined(VELOCIKEY_ENABLE)
+    bool velocikey_is_enabled = velocikey_enabled();
+    // Toggle velocikey on slave based on typing speed value
+    if (syncinfo->status.typing_speed) {
+        if (!velocikey_is_enabled) {
+            velocikey_toggle();
+        }
+        velocikey_set_typing_speed(syncinfo->status.typing_speed);
+    } else if (velocikey_is_enabled) {
+        velocikey_toggle();
+    }
+#    endif
 #    ifdef RGBLIGHT_USE_TIMER
     if (syncinfo->status.change_flags & RGBLIGHT_STATUS_CHANGE_TIMER) {
         if (syncinfo->status.timer_enabled) {

--- a/quantum/rgblight.h
+++ b/quantum/rgblight.h
@@ -258,6 +258,9 @@ typedef struct _rgblight_status_t {
     bool    timer_enabled;
 #    ifdef RGBLIGHT_SPLIT
     uint8_t change_flags;
+#    ifdef VELOCIKEY_ENABLE
+    uint8_t typing_speed;
+#    endif
 #    endif
 #    ifdef RGBLIGHT_LAYERS
     rgblight_layer_mask_t enabled_layer_mask;

--- a/quantum/velocikey.c
+++ b/quantum/velocikey.c
@@ -22,6 +22,14 @@ void velocikey_toggle(void) {
         eeprom_update_byte(EECONFIG_VELOCIKEY, 1);
 }
 
+void velocikey_set_typing_speed(uint8_t new_typing_speed) {
+    typing_speed = new_typing_speed;
+}
+
+uint8_t velocikey_get_typing_speed(void) {
+    return typing_speed;
+}
+
 void velocikey_accelerate(void) {
     if (typing_speed < TYPING_SPEED_MAX_VALUE) typing_speed += (TYPING_SPEED_MAX_VALUE / 100);
 }

--- a/quantum/velocikey.h
+++ b/quantum/velocikey.h
@@ -5,6 +5,8 @@
 
 bool    velocikey_enabled(void);
 void    velocikey_toggle(void);
+void    velocikey_set_typing_speed(uint8_t new_typing_speed);
+uint8_t velocikey_get_typing_speed(void);
 void    velocikey_accelerate(void);
 void    velocikey_decelerate(void);
 uint8_t velocikey_match_speed(uint8_t minValue, uint8_t maxValue);


### PR DESCRIPTION
Velocikey synchronization over serial for split keyboards.

## Description

This patch synchronize the typing speed of velocikey from the master to the slave using serial transmission.
Only serial transmission has been patched to support it.
The changes has been compiled and applied successfully on a dactyl manuform using a pro micro.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/qmk/qmk_firmware/issues/5916

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
