### PR TITLE
Documentation changes SPLIT_USB_DETECT and hid_listen udev rules

### DIFF
--- a/docs/faq_debug.md
+++ b/docs/faq_debug.md
@@ -110,6 +110,19 @@ If you can't get this 'Listening:' message try building with `CONSOLE_ENABLE=yes
 You may need privilege to access the device on OS like Linux.
 - try `sudo hid_listen`
 
+On many Linux distros you can avoid having to run hid_listen as root
+by creating a file called `/etc/udev/rules.d/70-hid-listen.rules` with
+the following content:
+
+```
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="abcd", ATTRS{idProduct}=="def1", TAG+="uaccess", RUN{builtin}+="uaccess"
+```
+
+Replace abcd and def1 with your keyboard's vendor and product id,
+letters must be lowercase. The `RUN{builtin}+="uaccess"` part is only
+needed for older distros.
+
+
 ## Can't Get Message on Console
 Check:
 - *hid_listen* finds your device. See above.

--- a/docs/feature_split_keyboard.md
+++ b/docs/feature_split_keyboard.md
@@ -223,7 +223,12 @@ This sets how many LEDs are directly connected to each controller.  The first nu
 ```c
 #define SPLIT_USB_DETECT
 ```
-This option changes the startup behavior to detect an active USB connection when delegating master/slave. If this operation times out, then the half is assume to be a slave. This is the default behavior for ARM, and required for AVR Teensy boards (due to hardware limitations).
+
+Enabling this option changes the startup behavior to listen for an active USB communication to delegate which part is master and which is slave. With this option enabled and theres's USB communication, then that half assumes it is the master, otherwise it assumes it is the slave.
+
+Without this option, the master is the half that can detect voltage on the physical USB connection (VBUS detection).
+
+Enabled by default on ChibiOS/ARM.
 
 ?> This setting will stop the ability to demo using battery packs.
 
@@ -239,9 +244,13 @@ This sets the poll frequency when detecting master/slave when using `SPLIT_USB_D
 
 ## Hardware Considerations and Mods
 
-While most any Pro Micro can be used, micro controllers like the AVR Teensys and most (if not all) ARM boards require the Split USB Detect.
+Master/slave delegation is made either by detecting voltage on VBUS connection or waiting for USB communication (`SPLIT_USB_DETECT`). Pro Micro boards can use VBUS detection out of the box and be used with or without `SPLIT_USB_DETECT`.
 
-However, with the Teensy 2.0 and Teensy++ 2.0, there is a simple hardware mod that you can perform to add VBUS detection, so you don't need the Split USB detection option.
+Many ARM boards, but not all, do not support VBUS detection. Because it is common that ARM boards lack VBUS detection, `SPLIT_USB_DETECT` is automatically defined on ARM targets (technically when ChibiOS is targetted).
+
+### Teensy boards
+
+Teensy boards lack VBUS detection out of the box and must have `SPLIT_USB_DETECT` defined. With the Teensy 2.0 and Teensy++ 2.0, there is a simple hardware mod that you can perform to add VBUS detection, so you don't need the `SPLIT_USB_DETECT` option.
 
 You'll only need a few things:
 


### PR DESCRIPTION
## Description

- Clearify how (lack of) SPLIT_USB_DETECT affects Micro Pro vs Teensy/ARM.
- Add HID Listen udev rules tip.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
