### PR TITLE
Fix for LEDs on PocketType

### DIFF
--- a/keyboards/evyd13/pockettype/pockettype.c
+++ b/keyboards/evyd13/pockettype/pockettype.c
@@ -22,6 +22,10 @@ void matrix_init_kb(void) {
 };
 
 void led_init_ports(void) {
+    // * Enable LED anodes (Vbus pin is replaced by B0 on some boards)
+    setPinOutput(B0);
+    writePinHigh(B0);
+
     // * Set our LED pins as output and high
     setPinOutput(F5);
     writePinHigh(F5);


### PR DESCRIPTION
## Description

The LED anodes of the pockettype are connected to the bus voltage when a pro micro is used, but other controllers like the Elite-C connect this pin to GPIO B0. This means that LEDs do not work by default for those controllers.

After consulting with the maintainer @evyd13, a fix was implemented that simply writes the B0 pin high.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
