### PR TITLE
Prime_E refactor

### DIFF
--- a/keyboards/primekb/prime_e/config.h
+++ b/keyboards/primekb/prime_e/config.h
@@ -34,6 +34,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* COL2ROW, ROW2COL */
 #define DIODE_DIRECTION COL2ROW
 
+#define LED_NUM_LOCK_PIN B2
+#define LED_CAPS_LOCK_PIN B1
+#define LED_SCROLL_LOCK_PIN B3
+
 /* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
 #define DEBOUNCE 5
 

--- a/keyboards/primekb/prime_e/keymaps/default/keymap.c
+++ b/keyboards/primekb/prime_e/keymaps/default/keymap.c
@@ -57,11 +57,6 @@ void matrix_init_user(void) {
   writePinLow(B3);
 }
 
-void matrix_scan_user(void) {
-
-}
-
-
 void led_set_user(uint8_t usb_led) {
   if (IS_LED_ON(usb_led, USB_LED_NUM_LOCK)) {
     writePinHigh(B2);

--- a/keyboards/primekb/prime_e/keymaps/default/keymap.c
+++ b/keyboards/primekb/prime_e/keymaps/default/keymap.c
@@ -45,37 +45,6 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     )
 };
 
-void matrix_init_user(void) {
-    // set CapsLock LED to output and low
-    setPinOutput(B1);
-    writePinLow(B1);
-    // set NumLock LED to output and low
-    setPinOutput(B2);
-    writePinLow(B2);
-    // set ScrollLock LED to output and low
-    setPinOutput(B3);
-    writePinLow(B3);
-}
-
-void led_set_user(uint8_t usb_led) {
-    if (IS_LED_ON(usb_led, USB_LED_NUM_LOCK)) {
-        writePinHigh(B2);
-    } else {
-        writePinLow(B2);
-    }
-    if (IS_LED_ON(usb_led, USB_LED_CAPS_LOCK)) {
-        writePinHigh(B1);
-    } else {
-        writePinLow(B1);
-    }
-    /*
-      if (IS_LED_ON(usb_led, USB_LED_SCROLL_LOCK)) {
-        writePinHigh(B3);
-      } else {
-        writePinLow(B3);
-      }*/
-}
-
 // function for layer indicator LED
 layer_state_t layer_state_set_user(layer_state_t state) {
     if (get_highest_layer(state) == 1) {

--- a/keyboards/primekb/prime_e/keymaps/default/keymap.c
+++ b/keyboards/primekb/prime_e/keymaps/default/keymap.c
@@ -46,44 +46,42 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 };
 
 void matrix_init_user(void) {
-  // set CapsLock LED to output and low
-  setPinOutput(B1);
-  writePinLow(B1);
-  // set NumLock LED to output and low
-  setPinOutput(B2);
-  writePinLow(B2);
-  // set ScrollLock LED to output and low
-  setPinOutput(B3);
-  writePinLow(B3);
+    // set CapsLock LED to output and low
+    setPinOutput(B1);
+    writePinLow(B1);
+    // set NumLock LED to output and low
+    setPinOutput(B2);
+    writePinLow(B2);
+    // set ScrollLock LED to output and low
+    setPinOutput(B3);
+    writePinLow(B3);
 }
 
 void led_set_user(uint8_t usb_led) {
-  if (IS_LED_ON(usb_led, USB_LED_NUM_LOCK)) {
-    writePinHigh(B2);
-  } else {
-    writePinLow(B2);
-  }
-  if (IS_LED_ON(usb_led, USB_LED_CAPS_LOCK)) {
-    writePinHigh(B1);
-  } else {
-    writePinLow(B1);
-  }
-/*
-  if (IS_LED_ON(usb_led, USB_LED_SCROLL_LOCK)) {
-    writePinHigh(B3);
-  } else {
-    writePinLow(B3);
-  }*/
-
+    if (IS_LED_ON(usb_led, USB_LED_NUM_LOCK)) {
+        writePinHigh(B2);
+    } else {
+        writePinLow(B2);
+    }
+    if (IS_LED_ON(usb_led, USB_LED_CAPS_LOCK)) {
+        writePinHigh(B1);
+    } else {
+        writePinLow(B1);
+    }
+    /*
+      if (IS_LED_ON(usb_led, USB_LED_SCROLL_LOCK)) {
+        writePinHigh(B3);
+      } else {
+        writePinLow(B3);
+      }*/
 }
 
-//function for layer indicator LED
-layer_state_t layer_state_set_user(layer_state_t state)
-{
+// function for layer indicator LED
+layer_state_t layer_state_set_user(layer_state_t state) {
     if (get_highest_layer(state) == 1) {
-    writePinHigh(B3);
-	} else {
-		writePinLow(B3);
+        writePinHigh(B3);
+    } else {
+        writePinLow(B3);
     }
     return state;
 }

--- a/keyboards/primekb/prime_e/keymaps/via/keymap.c
+++ b/keyboards/primekb/prime_e/keymaps/via/keymap.c
@@ -73,43 +73,6 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     )
 };
 
-void matrix_init_user(void) {
-  // set CapsLock LED to output and low
-  setPinOutput(B1);
-  writePinLow(B1);
-  // set NumLock LED to output and low
-  setPinOutput(B2);
-  writePinLow(B2);
-  // set ScrollLock LED to output and low
-  setPinOutput(B3);
-  writePinLow(B3);
-}
-
-void matrix_scan_user(void) {
-
-}
-
-
-void led_set_user(uint8_t usb_led) {
-  if (IS_LED_ON(usb_led, USB_LED_NUM_LOCK)) {
-    writePinHigh(B2);
-  } else {
-    writePinLow(B2);
-  }
-  if (IS_LED_ON(usb_led, USB_LED_CAPS_LOCK)) {
-    writePinHigh(B1);
-  } else {
-    writePinLow(B1);
-  }
-/*
-  if (IS_LED_ON(usb_led, USB_LED_SCROLL_LOCK)) {
-    writePinHigh(B3);
-  } else {
-    writePinLow(B3);
-  }*/
-
-}
-
 //function for layer indicator LED
 uint32_t layer_state_set_user(uint32_t state)
 {

--- a/keyboards/primekb/prime_e/keymaps/via/keymap.c
+++ b/keyboards/primekb/prime_e/keymaps/via/keymap.c
@@ -73,13 +73,12 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     )
 };
 
-//function for layer indicator LED
-uint32_t layer_state_set_user(uint32_t state)
-{
+// function for layer indicator LED
+uint32_t layer_state_set_user(uint32_t state) {
     if (biton32(state) == 1) {
-    writePinHigh(B3);
-	} else {
-		writePinLow(B3);
+        writePinHigh(B3);
+    } else {
+        writePinLow(B3);
     }
     return state;
 }

--- a/keyboards/primekb/prime_e/prime_e.c
+++ b/keyboards/primekb/prime_e/prime_e.c
@@ -15,8 +15,38 @@
  */
 #include "prime_e.h"
 
-void led_set_kb(uint8_t usb_led) {
-	// put your keyboard LED indicator (ex: Caps Lock LED) toggling code here
+void matrix_init_kb(void) {
+    // set CapsLock LED to output and low
+    setPinOutput(B1);
+    writePinLow(B1);
+    // set NumLock LED to output and low
+    setPinOutput(B2);
+    writePinLow(B2);
+    // set ScrollLock LED to output and low
+    setPinOutput(B3);
+    writePinLow(B3);
 
-	led_set_user(usb_led);
+    matrix_init_user();
+}
+
+void led_set_kb(uint8_t usb_led) {
+    // put your keyboard LED indicator (ex: Caps Lock LED) toggling code here
+    if (IS_LED_ON(usb_led, USB_LED_NUM_LOCK)) {
+        writePinHigh(B2);
+    } else {
+        writePinLow(B2);
+    }
+    if (IS_LED_ON(usb_led, USB_LED_CAPS_LOCK)) {
+        writePinHigh(B1);
+    } else {
+        writePinLow(B1);
+    }
+    /*
+      if (IS_LED_ON(usb_led, USB_LED_SCROLL_LOCK)) {
+        writePinHigh(B3);
+      } else {
+        writePinLow(B3);
+      }*/
+
+    led_set_user(usb_led);
 }

--- a/keyboards/primekb/prime_e/prime_e.c
+++ b/keyboards/primekb/prime_e/prime_e.c
@@ -14,21 +14,3 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "prime_e.h"
-
-void keyboard_pre_init_kb(void) {
-    setPinOutput(B2);
-    setPinOutput(B1);
-    setPinOutput(B3);
-
-    keyboard_pre_init_user();
-}
-
-bool led_update_kb(led_t led_state) {
-    bool res = led_update_user(led_state);
-    if(res) {
-        writePin(B2, led_state.num_lock);
-        writePin(B1, led_state.caps_lock);
-        writePin(B3, led_state.scroll_lock);
-    }
-    return res;
-}

--- a/keyboards/primekb/prime_e/prime_e.c
+++ b/keyboards/primekb/prime_e/prime_e.c
@@ -15,38 +15,20 @@
  */
 #include "prime_e.h"
 
-void matrix_init_kb(void) {
-    // set CapsLock LED to output and low
-    setPinOutput(B1);
-    writePinLow(B1);
-    // set NumLock LED to output and low
+void keyboard_pre_init_kb(void) {
     setPinOutput(B2);
-    writePinLow(B2);
-    // set ScrollLock LED to output and low
+    setPinOutput(B1);
     setPinOutput(B3);
-    writePinLow(B3);
 
-    matrix_init_user();
+    keyboard_pre_init_user();
 }
 
-void led_set_kb(uint8_t usb_led) {
-    // put your keyboard LED indicator (ex: Caps Lock LED) toggling code here
-    if (IS_LED_ON(usb_led, USB_LED_NUM_LOCK)) {
-        writePinHigh(B2);
-    } else {
-        writePinLow(B2);
+bool led_update_kb(led_t led_state) {
+    bool res = led_update_user(led_state);
+    if(res) {
+        writePin(B2, led_state.num_lock);
+        writePin(B1, led_state.caps_lock);
+        writePin(B3, led_state.scroll_lock);
     }
-    if (IS_LED_ON(usb_led, USB_LED_CAPS_LOCK)) {
-        writePinHigh(B1);
-    } else {
-        writePinLow(B1);
-    }
-    /*
-      if (IS_LED_ON(usb_led, USB_LED_SCROLL_LOCK)) {
-        writePinHigh(B3);
-      } else {
-        writePinLow(B3);
-      }*/
-
-    led_set_user(usb_led);
+    return res;
 }

--- a/keyboards/primekb/prime_e/readme.md
+++ b/keyboards/primekb/prime_e/readme.md
@@ -1,20 +1,34 @@
 # Prime_E
 
-![Prime_E](https://imgur.com/7Rl4JOA.jpg)
+![Prime_E](https://imgur.com/7Rl4JOAl.jpg)
 
-An ergonomic 45%. 
+An ergonomic 45%.
 
-*Keyboard Maintainer: [Holtenc](https://github.com/holtenc/)  
-*Hardware Supported:
+* Keyboard Maintainer: [Holtenc](https://github.com/holtenc/)
+* Hardware Supported:
     * [Prime_E Standard](std/) PCBs, ATmega32u4 (in switch LED backlights)
     * [Prime_E RGB](rgb/) PCBs, Atmega32u4 (RGB underglow)
-*Hardware Availability: [Store Link](https://www.primekb.com)
+* Hardware Availability: [Store Link](https://www.primekb.com)
 
-Make example for this keyboard (after setting up your build environment):
+Make examples for this keyboard (after setting up your build environment):
 
-    *make primekb/prime_e/std:default
-    *make primekb/prime_e/rgb:default
-    *make primekb/prime_e/std:via
-    *make primekb/prime_e/rgb:via
+    make primekb/prime_e/std:default
+    make primekb/prime_e/rgb:default
+    make primekb/prime_e/std:via
+    make primekb/prime_e/rgb:via
+
+Flashing examples for this keyboard:
+
+    make primekb/prime_e/std:default:flash
+    make primekb/prime_e/rgb:default:flash
+    make primekb/prime_e/std:via:flash
+    make primekb/prime_e/rgb:via:flash
+
+## Accessing Bootloader Mode
+
+To access Bootloader Mode, do one of the following:
+
+* Tap the Reset switch mounted on the bottom side of the PCB
+* Hold the Space and B keys while connecting the USB cable
 
 See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).

--- a/keyboards/primekb/prime_e/rgb/readme.md
+++ b/keyboards/primekb/prime_e/rgb/readme.md
@@ -1,8 +1,8 @@
 # Prime_E
 
-![Prime_E](https://imgur.com/7Rl4JOA.jpg)
+![Prime_E](https://imgur.com/7Rl4JOAl.jpg)
 
-An ergonomic 45%. 
+An ergonomic 45%.
 
 * Keyboard Maintainer: [Holtenc](https://github.com/holtenc/)
 * Hardware Supported:Prime_E RGB PCBs, ATmega32u4
@@ -11,5 +11,16 @@ An ergonomic 45%.
 Make example for this keyboard (after setting up your build environment):
 
     make primekb/prime_e/rgb:default
+
+Flashing examples for this keyboard:
+
+    make primekb/prime_e/rgb:default:flash
+
+## Accessing Bootloader Mode
+
+To access Bootloader Mode, do one of the following:
+
+* Tap the Reset switch mounted on the bottom side of the PCB
+* Hold the Space and B keys while connecting the USB cable
 
 See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).

--- a/keyboards/primekb/prime_e/rules.mk
+++ b/keyboards/primekb/prime_e/rules.mk
@@ -2,27 +2,20 @@
 MCU = atmega32u4
 
 # Bootloader selection
-#   Teensy       halfkay
-#   Pro Micro    caterina
-#   Atmel DFU    atmel-dfu
-#   LUFA DFU     lufa-dfu
-#   QMK DFU      qmk-dfu
-#   ATmega32A    bootloadHID
-#   ATmega328P   USBasp
 BOOTLOADER = atmel-dfu
 
 # Build Options
 #   change yes to no to disable
 #
 BOOTMAGIC_ENABLE = yes      # Virtual DIP switch configuration
-MOUSEKEY_ENABLE = no       # Mouse keys
+MOUSEKEY_ENABLE = no        # Mouse keys
 EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no        # Console for debug
-COMMAND_ENABLE = no        # Commands for debug and configuration
+CONSOLE_ENABLE = no         # Console for debug
+COMMAND_ENABLE = no         # Commands for debug and configuration
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
 SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
 # if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
-NKRO_ENABLE = yes            # USB Nkey Rollover
+NKRO_ENABLE = yes           # USB Nkey Rollover
 BLUETOOTH_ENABLE = no       # Enable Bluetooth
 AUDIO_ENABLE = no           # Audio output
 

--- a/keyboards/primekb/prime_e/std/readme.md
+++ b/keyboards/primekb/prime_e/std/readme.md
@@ -1,8 +1,8 @@
 # Prime_E
 
-![Prime_E](https://imgur.com/7Rl4JOA.jpg)
+![Prime_E](https://imgur.com/7Rl4JOAl.jpg)
 
-An ergonomic 45%. 
+An ergonomic 45%.
 
 * Keyboard Maintainer: [Holtenc](https://github.com/holtenc/)
 * Hardware Supported: Prime_E Standard PCBs, Atmega32u4
@@ -11,5 +11,16 @@ An ergonomic 45%.
 Make example for this keyboard (after setting up your build environment):
 
     make primekb/prime_e/std:default
+
+Flashing examples for this keyboard:
+
+    make primekb/prime_e/std:default:flash
+
+## Accessing Bootloader Mode
+
+To access Bootloader Mode, do one of the following:
+
+* Tap the Reset switch mounted on the bottom side of the PCB
+* Hold the Space and B keys while connecting the USB cable
 
 See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).


### PR DESCRIPTION
## Description

Moves the LED indicator code to keyboard level so it works with Configurator compiles, and some tidying up of the default and via keymaps, and the readme files as well.

cc @holtenc (keyboard maintainer)

## Types of Changes

- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)


## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
