### PR TITLE
[Keymap] Update Program Yoink Ortho Split Layout

### DIFF
--- a/keyboards/program_yoink/ortho/keymaps/ortho_split/keymap.c
+++ b/keyboards/program_yoink/ortho/keymaps/ortho_split/keymap.c
@@ -29,10 +29,10 @@ enum combo_events {
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [_BASE] = LAYOUT_ortho_split(
-        KC_ESC,        KC_Q,    KC_W, KC_E, KC_R, KC_T, KC_Y, KC_U, KC_I,    KC_O,   KC_P,    KC_BSPC, KC_MPLY,
-        CTL_T(KC_TAB), KC_A,    KC_S, KC_D, KC_F, KC_G, KC_H, KC_J, KC_K,    KC_L,   KC_QUOT, KC_ENT,  KC_PGUP,
-        KC_LSFT,       KC_Z,    KC_X, KC_C, KC_V, KC_B, KC_N, KC_M, KC_COMM, KC_DOT, KC_UP, KC_SLSH,   KC_PGDN,
-        KC_LCTL,       KC_LALT, MO(_LAYER2),  KC_BSPC,  LT(_LAYER1, KC_SPC), KC_RGUI, KC_RALT,  KC_LEFT, KC_DOWN, KC_RGHT
+        KC_ESC,        KC_Q,    KC_W, KC_E, KC_R, KC_T, KC_Y, KC_U, KC_I,    KC_O,    KC_P,    KC_BSPC, KC_MPLY,
+        CTL_T(KC_TAB), KC_A,    KC_S, KC_D, KC_F, KC_G, KC_H, KC_J, KC_K,    KC_L,    KC_QUOT, KC_ENT,  KC_PGUP,
+        KC_LSFT,       KC_Z,    KC_X, KC_C, KC_V, KC_B, KC_N, KC_M, KC_COMM, KC_DOT,  KC_SLSH, KC_UP,   KC_PGDN,
+        KC_LCTL,       KC_LALT, MO(_LAYER2),  KC_BSPC,  LT(_LAYER1, KC_SPC), KC_RGUI, KC_RALT, KC_LEFT, KC_DOWN, KC_RGHT
     ),
 
     [_LAYER1] = LAYOUT_ortho_split(


### PR DESCRIPTION
Revise ortho split bar default keymap to swap `slash` and  `up`

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
