### PR TITLE
Add RGB Matrix support for The Mark:65 keyboard

### DIFF
--- a/keyboards/boardsource/the_mark/config.h
+++ b/keyboards/boardsource/the_mark/config.h
@@ -52,9 +52,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifdef RGBLIGHT_ENABLE
 #define RGBLED_NUM 24    // Number of LEDs
 #endif
+
+/* RGB matrix spport */
 #ifdef RGB_MATRIX_ENABLE
-#define RGBLED_NUM 24    // Number of LEDs
-#define DRIVER_LED_TOTAL 24
+#define DRIVER_LED_TOTAL 24 // Number of LEDs
 #endif
 
 /*

--- a/keyboards/boardsource/the_mark/config.h
+++ b/keyboards/boardsource/the_mark/config.h
@@ -53,7 +53,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGBLED_NUM 24    // Number of LEDs
 #endif
 
-/* RGB matrix spport */
+/* RGB matrix support */
 #ifdef RGB_MATRIX_ENABLE
 #define DRIVER_LED_TOTAL 24 // Number of LEDs
 #endif

--- a/keyboards/boardsource/the_mark/config.h
+++ b/keyboards/boardsource/the_mark/config.h
@@ -54,6 +54,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #endif
 #ifdef RGB_MATRIX_ENABLE
 #define RGBLED_NUM 24    // Number of LEDs
+#define DRIVER_LED_TOTAL 24
 #endif
 
 /*

--- a/keyboards/boardsource/the_mark/config.h
+++ b/keyboards/boardsource/the_mark/config.h
@@ -52,6 +52,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifdef RGBLIGHT_ENABLE
 #define RGBLED_NUM 24    // Number of LEDs
 #endif
+#ifdef RGB_MATRIX_ENABLE
+#define RGBLED_NUM 24    // Number of LEDs
+#endif
 
 /*
  * Split Keyboard specific options, make sure you have 'SPLIT_KEYBOARD = yes' in your rules.mk, and define SOFT_SERIAL_PIN.

--- a/keyboards/boardsource/the_mark/rules.mk
+++ b/keyboards/boardsource/the_mark/rules.mk
@@ -20,5 +20,5 @@ BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = yes       # Enable keyboard RGB underglow
 BLUETOOTH_ENABLE = no       # Enable Bluetooth
 AUDIO_ENABLE = no           # Audio output
-RGB_MATRIX_ENABLE = no		# Enable keyboard RGB matrix lighting
+RGB_MATRIX_ENABLE = no		# Enable keyboard RGB matrix (do not use together with RGBLIGHT_ENABLE)
 RGB_MATRIX_DRIVER = WS2812	# RGB matrix driver support

--- a/keyboards/boardsource/the_mark/rules.mk
+++ b/keyboards/boardsource/the_mark/rules.mk
@@ -20,3 +20,5 @@ BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = yes       # Enable keyboard RGB underglow
 BLUETOOTH_ENABLE = no       # Enable Bluetooth
 AUDIO_ENABLE = no           # Audio output
+RGB_MATRIX_ENABLE = no		# Enable keyboard RGB matrix lighting
+RGB_MATRIX_DRIVER = WS2812	# RGB matrix driver support

--- a/keyboards/boardsource/the_mark/the_mark.c
+++ b/keyboards/boardsource/the_mark/the_mark.c
@@ -15,3 +15,24 @@
  */
 
 #include "the_mark.h"
+
+/* Map physical under glow LEDs for RGB matrix support */
+#ifdef RGB_MATRIX_ENABLE
+led_config_t g_led_config = { {
+	// Key Matrix to LED Index
+	{ NO_LED, 10    , 9     , NO_LED, 8     , 7     , NO_LED, 6     , 5     , NO_LED, 4     , 3     , NO_LED, 2     , 1     , NO_LED },
+	{ NO_LED, 11    , NO_LED, NO_LED, NO_LED, NO_LED, NO_LED, NO_LED, NO_LED, NO_LED, NO_LED, NO_LED, NO_LED, NO_LED, 0     , NO_LED },
+	{ NO_LED, 12    , NO_LED, NO_LED, NO_LED, NO_LED, NO_LED, NO_LED, NO_LED, NO_LED, NO_LED, NO_LED, NO_LED, NO_LED, 23    , NO_LED },
+	{ NO_LED, 13    , 14    , NO_LED, 15    , 16    , NO_LED, 17    , 18    , NO_LED, 19    , 20    , NO_LED, 21    , 22    , NO_LED },
+	{ NO_LED, NO_LED, NO_LED, NO_LED, NO_LED, NO_LED, NO_LED, NO_LED, NO_LED, NO_LED, NO_LED, NO_LED, NO_LED, NO_LED, NO_LED, NO_LED },
+}, {
+	// LED Index to Physical Position
+	{224, 42}, {224, 21}, {209, 21}, {179, 21}, {164, 21}, {134, 21}, {119, 21}, {89, 21}, {74, 21}, {45, 21}, {30, 21}, {30, 42},
+	{30, 64}, {30, 85}, {45, 85}, {74, 85}, {89, 85}, {119, 85}, {134, 85}, {164, 85}, {179, 85}, {209, 85}, {224, 85}, {224, 64}
+}, {
+	// LED Index to Flag
+	LED_FLAG_ALL, LED_FLAG_ALL, LED_FLAG_ALL, LED_FLAG_ALL, LED_FLAG_ALL, LED_FLAG_ALL, LED_FLAG_ALL, LED_FLAG_ALL,
+	LED_FLAG_ALL, LED_FLAG_ALL, LED_FLAG_ALL, LED_FLAG_ALL, LED_FLAG_ALL, LED_FLAG_ALL, LED_FLAG_ALL, LED_FLAG_ALL,
+	LED_FLAG_ALL, LED_FLAG_ALL, LED_FLAG_ALL, LED_FLAG_ALL, LED_FLAG_ALL, LED_FLAG_ALL, LED_FLAG_ALL, LED_FLAG_ALL
+} };
+#endif


### PR DESCRIPTION
## Description

Add physical under glow LED light mapping to support RGB matrix features.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
