### PR TITLE
Add community layout support to torn keyboard

### DIFF
--- a/keyboards/torn/rules.mk
+++ b/keyboards/torn/rules.mk
@@ -21,6 +21,8 @@ OLED_DRIVER_ENABLE = yes
 WPM_ENABLE = yes
 CUSTOM_MATRIX = lite
 
+LAYOUTS = split_3x6_4
+
 SRC += matrix.c \
     bongocat.c \
     mcp23018.c \


### PR DESCRIPTION
Fixes the torn keyboard to allow using layouts.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
