### PR TITLE
fix: ryloo studio m0110 layout 60 ansi fixed

### DIFF
--- a/keyboards/ryloo_studio/m0110/m0110.h
+++ b/keyboards/ryloo_studio/m0110/m0110.h
@@ -58,7 +58,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  * ├──────┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴────────┤
  * │30      │32 │33 │34 │35 │36 │37 │38 │39 │3a │3b │3d        │
  * ├────┬───┴┬──┴─┬─┴───┴───┴───┴───┴───┴──┬┴───┼───┴┬────┬────┤
- * │40  │41  │42  │46                      │49  │4a  │4c  │4d  │
+ * │40  │41  │42  │47                      │49  │4a  │4c  │4d  │
  * └────┴────┴────┴────────────────────────┴────┴────┴────┴────┘
 */
 #define LAYOUT_60_ansi( \
@@ -66,13 +66,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     k10, k11, k12, k13, k14, k15, k16, k17, k18, k19, k1a, k1b, k1c, k1d,      \
     k20, k21, k22, k23, k24, k25, k26, k27, k28, k29, k2a, k2b,      k2d,      \
     k30,      k32, k33, k34, k35, k36, k37, k38, k39, k3a, k3b,      k3d,      \
-    k40, k41, k42,                k46,           k49, k4a,           k4c, k4d  \
+    k40, k41, k42,                     k47,      k49, k4a,           k4c, k4d  \
 ) { \
     { k00,  k01,   k02,  k03,   k04,   k05,   k06,  k07,   k08,   k09,  k0a,  k0b,   k0c,   KC_NO, k0e   }, \
     { k10,  k11,   k12,  k13,   k14,   k15,   k16,   k17,  k18,   k19,  k1a,  k1b,   k1c,   k1d,   KC_NO }, \
     { k20,  k21,   k22,  k23,   k24,   k25,   k26,   k27,  k28,   k29,  k2a,  k2b,   KC_NO, k2d,   KC_NO }, \
     { k30,  KC_NO, k32,  k33,   k34,   k35,   k36,   k37,  k38,   k39,  k3a,  k3b,   KC_NO, k3d,   KC_NO }, \
-    { k40,  k41,   k42,  KC_NO, KC_NO, KC_NO, k46,  KC_NO, KC_NO, k49,  k4a,  KC_NO, k4c,   k4d,   KC_NO }  \
+    { k40,  k41,   k42,  KC_NO, KC_NO, KC_NO, KC_NO, k47,  KC_NO, k49,  k4a,  KC_NO, k4c,   k4d,   KC_NO }  \
 }
 
 /* LAYOUT_60_hhkb


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Fixed LAYOUT_60_ansi for the ryloo_studio/m0110 keyboard - space key is correctly mapped now. 

I have this keyboard so I tested this manually and the space key works now 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
