### PR TITLE
Backport ChibiOS Audio changes from ZSA

### DIFF
--- a/quantum/audio/audio_chibios.c
+++ b/quantum/audio/audio_chibios.c
@@ -86,13 +86,21 @@ static void gpt_cb8(GPTDriver *gptp);
 
 #define START_CHANNEL_1()        \
     gptStart(&GPTD6, &gpt6cfg1); \
-    gptStartContinuous(&GPTD6, 2U)
+    gptStartContinuous(&GPTD6, 2U); \
+    palSetPadMode(GPIOA, 4, PAL_MODE_INPUT_ANALOG)
 #define START_CHANNEL_2()        \
     gptStart(&GPTD7, &gpt7cfg1); \
-    gptStartContinuous(&GPTD7, 2U)
-#define STOP_CHANNEL_1() gptStopTimer(&GPTD6)
-#define STOP_CHANNEL_2() gptStopTimer(&GPTD7)
-#define RESTART_CHANNEL_1() \
+    gptStartContinuous(&GPTD7, 2U); \
+    palSetPadMode(GPIOA, 5, PAL_MODE_INPUT_ANALOG)
+#define STOP_CHANNEL_1()          \
+    gptStopTimer(&GPTD6);         \
+    palSetPadMode(GPIOA, 4, PAL_MODE_OUTPUT_PUSHPULL); \
+    palSetPad(GPIOA, 4)
+#define STOP_CHANNEL_2()         \
+    gptStopTimer(&GPTD7);        \
+    palSetPadMode(GPIOA, 5, PAL_MODE_OUTPUT_PUSHPULL); \
+    palSetPad(GPIOA, 5)
+    #define RESTART_CHANNEL_1() \
     STOP_CHANNEL_1();       \
     START_CHANNEL_1()
 #define RESTART_CHANNEL_2() \

--- a/quantum/audio/musical_notes.h
+++ b/quantum/audio/musical_notes.h
@@ -17,7 +17,9 @@
 #pragma once
 
 // Tempo Placeholder
-#define TEMPO_DEFAULT 100
+#ifndef TEMPO_DEFAULT
+#    define TEMPO_DEFAULT 100
+#endif
 
 #define SONG(notes...) \
     { notes }
@@ -60,8 +62,9 @@
 #define TIMBRE_25 0.250f
 #define TIMBRE_50 0.500f
 #define TIMBRE_75 0.750f
-#define TIMBRE_DEFAULT TIMBRE_50
-
+#ifndef TIMBRE_DEFAULT
+#    define TIMBRE_DEFAULT TIMBRE_50
+#endif
 // Notes - # = Octave
 
 #ifdef __arm__


### PR DESCRIPTION
## Description

Should disable the pins for audio when not in use (playing notes).  Added due to issues found with the Planck EZ.  

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Enhancement/optimization

## Issues Fixed or Closed by This PR

* Issues found on planck ez.

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
