### PR TITLE
Add option to set the encoder A and B pins on the MCU to use internal pull-down, pull-up, or leave floating

### DIFF
--- a/docs/feature_encoders.md
+++ b/docs/feature_encoders.md
@@ -50,13 +50,13 @@ If you are using different pinouts for the encoders on each half of a split keyb
 
 ## Configuring Input Pins
 
-Rarely, you may want to set the MCU pin hooked up to the encoder to use its internal pull-down or be left floating, instead of the default which is to use an internal pull-up. This is mainly relevant for non-mechanical encoders, such as optical or hall effect. These options can be configured by placing these `#define`s in your `config.h`:
+Rarely, you may want to set the MCU pin hooked up to the encoder to be left floating or use an internal pull down (not available on AVR), instead of the default which is to use an internal pull-up. This is mainly relevant for non-mechanical encoders, such as optical or hall effect. To use this feature `#define` ENCODER_PINS in your `config.h` as one of the following:
 
 |Define         |Description                                                                                              |
 |---------------|---------------------------------------------------------------------------------------------------------|
-|`ENC_PUP`      |Toggles on the internal pull-up                                                                          |
-|`ENC_PDOWN `   |Toggles on the internal pull-down                                                                        |
-|`ENC_FLOAT`    |Leaves the pin as floating                                                                               |
+|`PULL_UP`      |Toggles on the internal pull-up (default behavior)                                                       |
+|`PULL_DOWN`    |Toggles on the internal pull-down (not on AVR)                                                           |
+|`FLOAT`        |Leaves the pin as floating                                                                               |
 
 ## Callbacks
 

--- a/docs/feature_encoders.md
+++ b/docs/feature_encoders.md
@@ -48,6 +48,16 @@ If you are using different pinouts for the encoders on each half of a split keyb
 #define ENCODER_RESOLUTIONS_RIGHT { 2, 4 }
 ```
 
+## Configuring Input Pins
+
+Rarely, you may want to set the MCU pin hooked up to the encoder to use its internal pull-down or be left floating, instead of the default which is to use an internal pull-up. This is mainly relevant for non-mechanical encoders, such as optical or hall effect. These options can be configured by placing these `#define`s in your `config.h`:
+
+|Define         |Description                                                                                              |
+|---------------|---------------------------------------------------------------------------------------------------------|
+|`ENC_PUP`      |Toggles on the internal pull-up                                                                          |
+|`ENC_PDOWN `   |Toggles on the internal pull-down                                                                        |
+|`ENC_FLOAT`    |Leaves the pin as floating                                                                               |
+
 ## Callbacks
 
 The callback functions can be inserted into your `<keyboard>.c`:

--- a/quantum/encoder.c
+++ b/quantum/encoder.c
@@ -82,6 +82,9 @@ void encoder_init(void) {
 #endif
 
 #ifdef ENCODER_PINS
+#    define PULL_DOWN 1
+#    define PULL_UP 2
+#    define FLOAT 3
 #    if (ENCODER_PINS == PULL_DOWN)
 #        ifdef __AVR__
 #            error Pull Down is not supported on AVR

--- a/quantum/encoder.c
+++ b/quantum/encoder.c
@@ -81,35 +81,29 @@ void encoder_init(void) {
     }
 #endif
 
-#ifdef ENC_PUP
-    for (int i = 0; i < NUMBER_OF_ENCODERS; i++) {
-        setPinInputHigh(encoders_pad_a[i]);
-        setPinInputHigh(encoders_pad_b[i]);
-
-        encoder_state[i] = (readPin(encoders_pad_a[i]) << 0) | (readPin(encoders_pad_b[i]) << 1);
-    }
-#elif ENC_PDOWN
-    for (int i = 0; i < NUMBER_OF_ENCODERS; i++) {
-        setPinInputLow(encoders_pad_a[i]);
-        setPinInputLow(encoders_pad_b[i]);
-
-        encoder_state[i] = (readPin(encoders_pad_a[i]) << 0) | (readPin(encoders_pad_b[i]) << 1);
-    }
-#elif ENC_FLOAT
-    for (int i = 0; i < NUMBER_OF_ENCODERS; i++) {
-        setPinInput(encoders_pad_a[i]);
-        setPinInput(encoders_pad_b[i]);
-
-        encoder_state[i] = (readPin(encoders_pad_a[i]) << 0) | (readPin(encoders_pad_b[i]) << 1);
-    }
+#ifdef ENCODER_PINS
+#    if (ENCODER_PINS == PULL_DOWN)
+#        ifdef __AVR__
+#            error Pull Down is not supported on AVR
+#        endif
+#        define setEncPinInput(x) setPinInputLow(x)
+#    elif (ENCODER_PINS == PULL_UP)
+#        define setEncPinInput(x) setPinInputHigh(x)
+#    elif (ENCODER_PINS == FLOAT)
+#        define setEncPinInput(x) setPinInput(x)
+#    else
+#        error ENCODER_PINS must be PULL_UP, PULL_DOWN, or FLOAT
+#        define setEncPinInput(x) setPinInputHigh(x)
 #else
-    for (int i = 0; i < NUMBER_OF_ENCODERS; i++) {
-        setPinInputHigh(encoders_pad_a[i]);
-        setPinInputHigh(encoders_pad_b[i]);
-
-        encoder_state[i] = (readPin(encoders_pad_a[i]) << 0) | (readPin(encoders_pad_b[i]) << 1);
-    }
+#    define setEncPinInput(x) setPinInputHigh(x)
 #endif
+
+for (int i = 0; i < NUMBER_OF_ENCODERS; i++) {
+    setEncPinInput(encoders_pad_a[i]);
+    setEncPinInput(encoders_pad_b[i]);
+
+    encoder_state[i] = (readPin(encoders_pad_a[i]) << 0) | (readPin(encoders_pad_b[i]) << 1);
+}
 
 #ifdef SPLIT_KEYBOARD
     thisHand = isLeftHand ? 0 : NUMBER_OF_ENCODERS;

--- a/quantum/encoder.c
+++ b/quantum/encoder.c
@@ -94,6 +94,7 @@ void encoder_init(void) {
 #    else
 #        error ENCODER_PINS must be PULL_UP, PULL_DOWN, or FLOAT
 #        define setEncPinInput(x) setPinInputHigh(x)
+#    endif
 #else
 #    define setEncPinInput(x) setPinInputHigh(x)
 #endif

--- a/quantum/encoder.c
+++ b/quantum/encoder.c
@@ -81,12 +81,35 @@ void encoder_init(void) {
     }
 #endif
 
+#ifdef ENC_PUP
     for (int i = 0; i < NUMBER_OF_ENCODERS; i++) {
         setPinInputHigh(encoders_pad_a[i]);
         setPinInputHigh(encoders_pad_b[i]);
 
         encoder_state[i] = (readPin(encoders_pad_a[i]) << 0) | (readPin(encoders_pad_b[i]) << 1);
     }
+#elif ENC_PDOWN
+    for (int i = 0; i < NUMBER_OF_ENCODERS; i++) {
+        setPinInputLow(encoders_pad_a[i]);
+        setPinInputLow(encoders_pad_b[i]);
+
+        encoder_state[i] = (readPin(encoders_pad_a[i]) << 0) | (readPin(encoders_pad_b[i]) << 1);
+    }
+#elif ENC_FLOAT
+    for (int i = 0; i < NUMBER_OF_ENCODERS; i++) {
+        setPinInput(encoders_pad_a[i]);
+        setPinInput(encoders_pad_b[i]);
+
+        encoder_state[i] = (readPin(encoders_pad_a[i]) << 0) | (readPin(encoders_pad_b[i]) << 1);
+    }
+#else
+    for (int i = 0; i < NUMBER_OF_ENCODERS; i++) {
+        setPinInputHigh(encoders_pad_a[i]);
+        setPinInputHigh(encoders_pad_b[i]);
+
+        encoder_state[i] = (readPin(encoders_pad_a[i]) << 0) | (readPin(encoders_pad_b[i]) << 1);
+    }
+#endif
 
 #ifdef SPLIT_KEYBOARD
     thisHand = isLeftHand ? 0 : NUMBER_OF_ENCODERS;


### PR DESCRIPTION
## Description

Added 3 toggles: ENC_PUP, ENC_PDOWN, and ENC_FLOAT. When ENC_PUP is defined, it sets the internal resistor on the encoder pins to be pulled up, and the same sort of behavior for the others. If none of these are defined, then it defaults to the current behavior of having the internal pull-up.

My optical encoder needs a pull down on these pins to work right, and the values also need to be finely tuned which might be possible even with an internal pull-up, but it's way easier if I can just set the pin to be floating.

I'm not much of a coder, so while I did test it and it works on my hardware, it looks super inelegant and I'm sure theres like a billion ways to optimize the code. I'm also not married to the names of those toggle things.

I also tried my hand at putting in some documentation based on existing docs.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
