### PR TITLE
[Update] Allow APM32 on TrinityXTtkl

### DIFF
--- a/keyboards/xelus/trinityxttkl/rules.mk
+++ b/keyboards/xelus/trinityxttkl/rules.mk
@@ -18,3 +18,6 @@ RGBLIGHT_ENABLE = no
 
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
+
+# Wildcard to allow APM32 MCU 
+DFU_SUFFIX_ARGS = -p FFFF -v FFFF

--- a/keyboards/xelus/trinityxttkl/rules.mk
+++ b/keyboards/xelus/trinityxttkl/rules.mk
@@ -5,13 +5,13 @@ MCU = STM32F072
 #   comment out to disable the options.
 #
 
-BOOTMAGIC_ENABLE = lite	# Virtual DIP switch configuration
-MOUSEKEY_ENABLE = yes	# Mouse keys
-EXTRAKEY_ENABLE = yes	# Audio control and System control
-CONSOLE_ENABLE = yes 	# Console for debug
+BOOTMAGIC_ENABLE = lite # Virtual DIP switch configuration
+MOUSEKEY_ENABLE = yes   # Mouse keys
+EXTRAKEY_ENABLE = yes   # Audio control and System control
+CONSOLE_ENABLE = yes    # Console for debug
 COMMAND_ENABLE = no     # Commands for debug and configuration
 SLEEP_LED_ENABLE = no   # Breathing sleep LED during USB suspend
-NKRO_ENABLE = yes	    # USB Nkey Rollover
+NKRO_ENABLE = yes       # USB Nkey Rollover
 BACKLIGHT_ENABLE = no
 RGBLIGHT_ENABLE = no
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Allows for usage of APM32. Since there are two variants, one with STM32 and one with APM32.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Allow APM32 MCU

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
