### PR TITLE
Add support to configure SPI data size

### DIFF
--- a/docs/spi_driver.md
+++ b/docs/spi_driver.md
@@ -36,6 +36,7 @@ Configuration-wise, you'll need to set up the peripheral as per your MCU's datas
 `#define SPI_MOSI_PAL_MODE` | The alternate function mode for the MOSI pin                  | `5`
 `#define SPI_MISO_PIN`      | The pin to use for the MISO                                   | `B14`
 `#define SPI_MISO_PAL_MODE` | The alternate function mode for the MISO pin                  | `5`
+`#define SPI_DATA_SIZE`     | The data length the SPI controller transfers                  | `8`
 
 ## Functions
 

--- a/drivers/chibios/spi_master.c
+++ b/drivers/chibios/spi_master.c
@@ -104,6 +104,48 @@ bool spi_start(pin_t slavePin, bool lsbFirst, uint8_t mode, uint16_t divisor) {
             break;
     }
 
+    switch (SPI_DATA_SIZE) {
+        case 4:
+            spiConfig.cr2 |= SPI_CR2_DS_1 | SPI_CR2_DS_0;
+            break;
+        case 5:
+            spiConfig.cr2 |= SPI_CR2_DS_2;
+            break;
+        case 6:
+            spiConfig.cr2 |= SPI_CR2_DS_2 | SPI_CR2_DS_0;
+            break;
+        case 7:
+            spiConfig.cr2 |= SPI_CR2_DS_2 | SPI_CR2_DS_1;
+            break;
+        case 8:
+            spiConfig.cr2 |= SPI_CR2_DS_2 | SPI_CR2_DS_1 | SPI_CR2_DS_0;
+            break;
+        case 9:
+            spiConfig.cr2 |= SPI_CR2_DS_3;
+            break;
+        case 10:
+            spiConfig.cr2 |= SPI_CR2_DS_3 | SPI_CR2_DS_0;
+            break;
+        case 11:
+            spiConfig.cr2 |= SPI_CR2_DS_3 | SPI_CR2_DS_1;
+            break;
+        case 12:
+            spiConfig.cr2 |= SPI_CR2_DS_3 | SPI_CR2_DS_1 | SPI_CR2_DS_0;
+            break;
+        case 13:
+            spiConfig.cr2 |= SPI_CR2_DS_3 | SPI_CR2_DS_2;
+            break;
+        case 14:
+            spiConfig.cr2 |= SPI_CR2_DS_3 | SPI_CR2_DS_2 | SPI_CR2_DS_0;
+            break;
+        case 15:
+            spiConfig.cr2 |= SPI_CR2_DS_3 | SPI_CR2_DS_2 | SPI_CR2_DS_1;
+            break;
+        case 16:
+            spiConfig.cr2 |= SPI_CR2_DS_3 | SPI_CR2_DS_2 | SPI_CR2_DS_1 | SPI_CR2_DS_0;
+            break;
+    }
+
     currentSlavePin  = slavePin;
     spiConfig.ssport = PAL_PORT(slavePin);
     spiConfig.sspad  = PAL_PAD(slavePin);

--- a/drivers/chibios/spi_master.h
+++ b/drivers/chibios/spi_master.h
@@ -48,6 +48,10 @@
 #    define SPI_MISO_PAL_MODE 5
 #endif
 
+#ifndef SPI_DATA_SIZE
+#    define SPI_DATA_SIZE 8
+#endif
+
 typedef int16_t spi_status_t;
 
 #define SPI_STATUS_SUCCESS (0)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Add support to configure SPI data size

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
ARM stm32 and chibios expose an interface to allow the SPI controller to shift different sizes of bits out on transactions.  This modification allows the QMK spi driver to modify the spi datasize
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
