### PR TITLE
Add Koolertron AMAG23 Keyboard

### DIFF
--- a/keyboards/amag23/amag23.c
+++ b/keyboards/amag23/amag23.c
@@ -1,0 +1,17 @@
+/* Copyright 2021
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "amag23.h"
+

--- a/keyboards/amag23/amag23.h
+++ b/keyboards/amag23/amag23.h
@@ -1,0 +1,32 @@
+/* Copyright 2021
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "quantum.h"
+
+// clang-format off
+#define LAYOUT_all( \
+    K00, K01, K02, K03, K04, K05, \
+    K10, K11, K12, K13, K14, K15, \
+    K20, K21, K22, K23, K24, K25, \
+    K30, K31, K32, K33,    K34    \
+) { \
+    { K00, K01, K02, K03, K04,   K05 }, \
+    { K10, K11, K12, K13, K14,   K15 }, \
+    { K20, K21, K22, K23, K24,   K25 }, \
+    { K30, K31, K32, K33, KC_NO, K34 }  \
+}
+// clang-format on

--- a/keyboards/amag23/config.h
+++ b/keyboards/amag23/config.h
@@ -1,0 +1,50 @@
+/* Copyright 2021
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "config_common.h"
+
+/* USB Device descriptor parameter */
+#define VENDOR_ID       0x4B54   // "KT"
+#define PRODUCT_ID      0x2323
+#define DEVICE_VER      0x0001
+#define MANUFACTURER    Koolertron
+#define PRODUCT         AMAG23
+
+/* key matrix size */
+#define MATRIX_ROWS 4
+#define MATRIX_COLS 6
+
+#define MATRIX_ROW_PINS { A0, A1, A2, A3 }
+#define MATRIX_COL_PINS { B0, B1, B2, B3, B4, B5 }
+#define UNUSED_PINS
+
+/* COL2ROW, ROW2COL*/
+#define DIODE_DIRECTION ROW2COL
+
+#define RGBLED_NUM 7
+#define RGBLIGHT_ANIMATIONS
+#define RGBLIGHT_HUE_STEP 8
+#define RGBLIGHT_SAT_STEP 8
+#define RGBLIGHT_VAL_STEP 8
+
+/* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
+#define DEBOUNCE 5
+
+/* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
+#define LOCKING_SUPPORT_ENABLE
+/* Locking resynchronize hack */
+#define LOCKING_RESYNC_ENABLE

--- a/keyboards/amag23/info.json
+++ b/keyboards/amag23/info.json
@@ -1,0 +1,36 @@
+{
+    "keyboard_name": "AMAG23",
+    "url": "http://www.koolertron.com/koolertron-one-handed-macro-mechanical-keyboard-rgb-led-backlit-portable-mini-onehanded-mechanical-gaming-keypad-23-fully-programmable-keys-blue-switches-p-874.html",
+    "maintainer": "ianmclinden",
+    "width": 6,
+    "height": 4,
+    "layouts": {
+        "LAYOUT_all": {
+            "layout": [
+              {"label":"K00", "x":0, "y":0},
+              {"label":"K01", "x":1, "y":0},
+              {"label":"K02", "x":2, "y":0},
+              {"label":"K03", "x":3, "y":0},
+              {"label":"K04", "x":4, "y":0},
+              {"label":"K05", "x":5, "y":0},
+              {"label":"K10", "x":0, "y":1},
+              {"label":"K11", "x":1, "y":1},
+              {"label":"K12", "x":2, "y":1},
+              {"label":"K13", "x":3, "y":1},
+              {"label":"K14", "x":4, "y":1},
+              {"label":"K15", "x":5, "y":1},
+              {"label":"K20", "x":0, "y":2},
+              {"label":"K21", "x":1, "y":2},
+              {"label":"K22", "x":2, "y":2},
+              {"label":"K23", "x":3, "y":2},
+              {"label":"K24", "x":4, "y":2},
+              {"label":"K25", "x":5, "y":2},
+              {"label":"K30", "x":0, "y":3},
+              {"label":"K31", "x":1, "y":3},
+              {"label":"K32", "x":2, "y":3},
+              {"label":"K33", "x":3, "y":3},
+              {"label":"K34", "x":4, "y":3, "w":2}
+            ]
+        }
+    }
+}

--- a/keyboards/amag23/keymaps/default/keymap.c
+++ b/keyboards/amag23/keymaps/default/keymap.c
@@ -1,0 +1,40 @@
+/* Copyright 2021
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include QMK_KEYBOARD_H
+
+// Defines names for use in layer keycodes and the keymap
+enum layer_names {
+    BASE,
+    FN1
+};
+
+// clang-format off
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  [BASE] = LAYOUT_all( /* Base Layer */
+      KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,
+      KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_Y,
+      MO(FN1), KC_A,    KC_S,    KC_D,    KC_F,    KC_G,
+      KC_Z,    KC_X,    KC_C,    KC_B,             KC_SPC
+  ),
+  [FN1] = LAYOUT_all( /* Function Layer */
+      KC_NO,   KC_NO,   KC_NO,   RGB_MOD, KC_NO,   KC_NO,
+      KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,
+      KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,
+      KC_NO,   KC_NO,   KC_NO,   KC_NO,            KC_NO
+  ),
+};
+// clang-format on
+

--- a/keyboards/amag23/keymaps/default/readme.md
+++ b/keyboards/amag23/keymaps/default/readme.md
@@ -1,0 +1,14 @@
+# Factory Keymap for Koolertron AMAG23
+
+## Additional Notes
+Default Keymap for AMAG23 as indicated on the original [product page](http://www.koolertron.com/koolertron-one-handed-macro-mechanical-keyboard-rgb-led-backlit-portable-mini-onehanded-mechanical-gaming-keypad-23-fully-programmable-keys-blue-switches-p-853.html).
+
+## Keymap
+
+![AMAG23 Factory Layout](https://i.imgur.com/c28RfwI.png)
+
+## Build
+
+To build the factory keymap, simply run:
+
+    make amag23:default

--- a/keyboards/amag23/keymaps/qwert/keymap.c
+++ b/keyboards/amag23/keymaps/qwert/keymap.c
@@ -1,0 +1,40 @@
+/* Copyright 2021
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include QMK_KEYBOARD_H
+
+// Defines names for use in layer keycodes and the keymap
+enum layer_names {
+    BASE,
+    FN1
+};
+
+// clang-format off
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  [BASE] = LAYOUT_all( /* Base Layer */
+      KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,
+      KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,
+      MO(FN1), KC_A,    KC_S,    KC_D,    KC_F,    KC_G,
+      KC_LSFT, KC_Z,    KC_X,    KC_C,             KC_SPC
+  ),
+  [FN1] = LAYOUT_all( /* Function Layer */
+      _______, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,
+      _______, RGB_TOG, RGB_VAI, RGB_MOD, RGB_HUI, _______,
+      _______, _______, RGB_VAD, RGB_RMOD,RGB_HUD, _______,
+      _______, _______, _______, _______,          _______
+  ),
+};
+// clang-format on
+

--- a/keyboards/amag23/keymaps/qwert/readme.md
+++ b/keyboards/amag23/keymaps/qwert/readme.md
@@ -1,0 +1,14 @@
+# QWERT Keymap for Koolertron AMAG23
+
+## Additional Notes
+QWERT keymap, based on the left hand of an ortholinear layout.
+
+## Keymap
+
+![AMAG23 QWERT Layout](https://i.imgur.com/fiDUo77.png)
+
+## Build
+
+To build the factory keymap, simply run:
+
+    make amag23:qwert

--- a/keyboards/amag23/readme.md
+++ b/keyboards/amag23/readme.md
@@ -1,0 +1,27 @@
+# AMAG23 (Koolertron)
+
+![Koolertron AMAG23](https://i.imgur.com/DakwCxk.jpg)
+
+One Handed Macro Mechanical Keyboard, 23 Key with optional RGB backlighting.
+
+- Keyboard Maintainer: [ianmclinden](https://github.com/ianmclinden)
+- Hardware Supported: AMAG23 (ATmega32A)
+- Hardware Availability:
+    - [Newegg](https://www.newegg.com/p/32K-00H1-00001)
+    - [Amazon](https://www.amazon.com/Koolertron-Mechanical-Keyboard-One-Handed-Programmable/dp/B07RM1TBR8)
+
+Make example for this keyboard (after setting up your build environment):
+
+    make amag23:default
+
+Flashing example for this keyboard ([after setting up the bootloadHID flashing environment](https://docs.qmk.fm/#/flashing_bootloadhid))
+
+    make amag23:default:flash
+
+**Reset Key**: Hold down the *Escape* key while plugging in the keyboard.
+
+**Tips**:
+- The keyboard comes with bootloadHID installed from factory.
+- The RGB leds seem to be chained together in diagonal rows. The result is that only 7 individual colors are supported, and these are striped across the keypad.
+
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).

--- a/keyboards/amag23/rules.mk
+++ b/keyboards/amag23/rules.mk
@@ -1,0 +1,19 @@
+# MCU name
+MCU = atmega32a
+
+# Bootloader selection
+BOOTLOADER = bootloadHID
+
+# Build Options
+#   change yes to no to disable
+#
+BOOTMAGIC_ENABLE = lite     # Virtual DIP switch configuration
+MOUSEKEY_ENABLE = yes       # Mouse keys
+EXTRAKEY_ENABLE = yes       # Audio control and System control
+CONSOLE_ENABLE = no         # Console for debug
+COMMAND_ENABLE = no         # Commands for debug and configuration
+# Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
+SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
+BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
+RGBLIGHT_ENABLE = yes       # Enable keyboard RGB underglow
+WS2812_DRIVER = i2c


### PR DESCRIPTION
## Description

Adds Koolertron AMAG23 - 23 Key market available macro pad, with RGB.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
