### PR TITLE
enable rgb underglow for VIA-firmware

### DIFF
--- a/keyboards/4pplet/aekiso60/keymaps/via/rules.mk
+++ b/keyboards/4pplet/aekiso60/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+RGBLIGHT_ENABLE = yes

--- a/keyboards/4pplet/steezy60/keymaps/via/rules.mk
+++ b/keyboards/4pplet/steezy60/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+RGBLIGHT_ENABLE = yes


### PR DESCRIPTION
Setting rgb underglow enabled by default for VIA firmware

## Description

Setting rgb underglow enabled by default for VIA firmware

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

No rgb underglow function in precompiled via hex.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
