### PR TITLE
Enable syncing of Host LEDs on Split Common

### DIFF
--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -300,13 +300,19 @@ There are a few different ways to set handedness for split keyboards (listed in 
 * `#define SPLIT_USB_DETECT`
   * Detect (with timeout) USB connection when delegating master/slave
   * Default behavior for ARM
-  * Required for AVR Teensy
+  * Required for AVR Teensy (without hardware mods)
 
 * `#define SPLIT_USB_TIMEOUT 2000`
   * Maximum timeout when detecting master/slave when using `SPLIT_USB_DETECT`
 
 * `#define SPLIT_USB_TIMEOUT_POLL 10`
   * Poll frequency when detecting master/slave when using `SPLIT_USB_DETECT`
+
+* `#define SPLIT_MODS_ENABLE`
+  * Allows mod status to be sent to slave side
+  
+* `#define SPLIT_HOST_SYNC_ENABLE`
+  * Syncs the Host LED (caps, num lock, etc) between master/slave.
 
 # The `rules.mk` File
 

--- a/docs/feature_split_keyboard.md
+++ b/docs/feature_split_keyboard.md
@@ -205,7 +205,7 @@ This mirrors the master side matrix to the slave side for features that react or
 #define SPLIT_HOST_SYNC_ENABLE
 ```
 
-This enables syncingo of the Host LED status (caps lock, num lock, etc) betwen both halves of the split keyboard. The main purpose of this feature is to enable support for use of things like OLED display of the Host LED status. 
+This enables syncing of the Host LED status (caps lock, num lock, etc) betwen both halves of the split keyboard. The main purpose of this feature is to enable support for use of things like OLED display of the Host LED status. 
 
 ###  Hardware Configuration Options
 

--- a/docs/feature_split_keyboard.md
+++ b/docs/feature_split_keyboard.md
@@ -201,6 +201,12 @@ displaying status on an OLED screen).
 
 This mirrors the master side matrix to the slave side for features that react or require knowledge of master side key presses on the slave side.  This adds a few bytes of data to the split communication protocol and may impact the matrix scan speed when enabled. The purpose of this feature is to support cosmetic use of key events (e.g. RGB reacting to Keypresses).
 
+```c
+#define SPLIT_HOST_SYNC_ENABLE
+```
+
+This enables syncingo of the Host LED status (caps lock, num lock, etc) betwen both halves of the split keyboard. The main purpose of this feature is to enable support for use of things like OLED display of the Host LED status. 
+
 ###  Hardware Configuration Options
 
 There are some settings that you may need to configure, based on how the hardware is set up. 

--- a/quantum/split_common/split_util.c
+++ b/quantum/split_common/split_util.c
@@ -138,3 +138,14 @@ void split_post_init(void) {
         transport_slave_init();
     }
 }
+
+// for syncing host LEDs between halves
+static uint8_t slave_host_leds;
+void set_slave_host_leds(uint8_t host_leds) {
+    slave_host_leds = host_leds;
+    led_set(host_leds);
+}
+
+uint8_t get_slave_host_leds(void) {
+    return slave_host_leds;
+}

--- a/quantum/split_common/split_util.c
+++ b/quantum/split_common/split_util.c
@@ -140,12 +140,15 @@ void split_post_init(void) {
 }
 
 // for syncing host LEDs between halves
-static uint8_t slave_host_leds;
-void set_slave_host_leds(uint8_t host_leds) {
-    slave_host_leds = host_leds;
-    led_set(host_leds);
+static uint8_t split_host_leds;
+
+void set_split_host_leds(uint8_t host_leds) {
+    if (split_host_leds != host_leds) {
+        split_host_leds = host_leds;
+        led_set(host_leds);
+    }
 }
 
-uint8_t get_slave_host_leds(void) {
-    return slave_host_leds;
+uint8_t get_split_host_leds(void) {
+    return split_host_leds;
 }

--- a/quantum/split_common/split_util.c
+++ b/quantum/split_common/split_util.c
@@ -141,16 +141,16 @@ void split_post_init(void) {
 
 // for syncing host LEDs between halves
 #ifdef SPLIT_HOST_SYNC_ENABLE
-static uint8_t split_host_leds;
+static uint8_t split_host_indicators;
 
-void set_split_host_leds(uint8_t host_leds) {
-    if (split_host_leds != host_leds) {
-        split_host_leds = host_leds;
+void set_split_host_indicators(uint8_t host_leds) {
+    if (split_host_indicators != host_leds) {
+        split_host_indicators = host_leds;
         led_set(host_leds);
     }
 }
 
-uint8_t get_split_host_leds(void) {
-    return split_host_leds;
+uint8_t get_split_host_indicators(void) {
+    return split_host_indicators;
 }
 #endif

--- a/quantum/split_common/split_util.c
+++ b/quantum/split_common/split_util.c
@@ -140,6 +140,7 @@ void split_post_init(void) {
 }
 
 // for syncing host LEDs between halves
+#ifdef SPLIT_HOST_SYNC_ENABLE
 static uint8_t split_host_leds;
 
 void set_split_host_leds(uint8_t host_leds) {
@@ -152,3 +153,4 @@ void set_split_host_leds(uint8_t host_leds) {
 uint8_t get_split_host_leds(void) {
     return split_host_leds;
 }
+#endif

--- a/quantum/split_common/split_util.h
+++ b/quantum/split_common/split_util.h
@@ -13,3 +13,4 @@ void split_post_init(void);
 
 void set_slave_host_leds(uint8_t host_leds);
 uint8_t get_slave_host_leds(void);
+bool is_keyboard_master(void);

--- a/quantum/split_common/split_util.h
+++ b/quantum/split_common/split_util.h
@@ -10,3 +10,6 @@ extern volatile bool isLeftHand;
 void matrix_master_OLED_init(void);
 void split_pre_init(void);
 void split_post_init(void);
+
+void set_slave_host_leds(uint8_t host_leds);
+uint8_t get_slave_host_leds(void);

--- a/quantum/split_common/split_util.h
+++ b/quantum/split_common/split_util.h
@@ -11,5 +11,5 @@ void matrix_master_OLED_init(void);
 void split_pre_init(void);
 void split_post_init(void);
 
-void set_split_host_leds(uint8_t host_leds);
-uint8_t get_split_host_leds(void);
+void set_split_host_indicators(uint8_t host_leds);
+uint8_t get_split_host_indicators(void);

--- a/quantum/split_common/split_util.h
+++ b/quantum/split_common/split_util.h
@@ -11,6 +11,5 @@ void matrix_master_OLED_init(void);
 void split_pre_init(void);
 void split_post_init(void);
 
-void set_slave_host_leds(uint8_t host_leds);
-uint8_t get_slave_host_leds(void);
-bool is_keyboard_master(void);
+void set_split_host_leds(uint8_t host_leds);
+uint8_t get_split_host_leds(void);

--- a/quantum/split_common/transport.c
+++ b/quantum/split_common/transport.c
@@ -29,7 +29,9 @@ static pin_t encoders_pad[] = ENCODERS_PAD_A;
 #    include "rgb_matrix.h"
 #endif
 
+#ifdef SPLIT_HOST_SYNC_ENABLE
 void set_split_host_leds(uint8_t host_leds);
+#endif
 
 #if defined(USE_I2C)
 
@@ -71,7 +73,9 @@ typedef struct _I2C_slave_buffer_t {
     rgb_config_t rgb_matrix;
     bool         rgb_suspend_state;
 #    endif
+#    ifdef SPLIT_HOST_SYNC_ENABLE
     uint8_t host_leds;
+#    endif
 } I2C_slave_buffer_t;
 
 static I2C_slave_buffer_t *const i2c_buffer = (I2C_slave_buffer_t *)i2c_slave_reg;
@@ -139,11 +143,13 @@ bool transport_master(matrix_row_t master_matrix[], matrix_row_t slave_matrix[])
     }
 #    endif
 
+#    ifdef SPLIT_HOST_SYNC_ENABLE
     uint8_t host_leds = host_keyboard_leds();
     set_split_host_leds(host_leds);
     if (i2c_writeReg(SLAVE_I2C_ADDRESS, I2C_HOST_LED_START, (void *)&host_leds, sizeof(host_leds), TIMEOUT) >= 0) {
         i2c_buffer->host_leds = host_leds;
     }
+#    endif
 
 #    ifdef SPLIT_MODS_ENABLE
     uint8_t real_mods = get_mods();
@@ -220,7 +226,9 @@ void transport_slave(matrix_row_t master_matrix[], matrix_row_t slave_matrix[]) 
     set_current_wpm(i2c_buffer->current_wpm);
 #    endif
 
+#    ifdef SPLIT_HOST_SYNC_ENABLE
     set_split_host_leds(i2c_buffer->host_leds);
+#    endif
 
 #    ifdef SPLIT_MODS_ENABLE
     set_mods(i2c_buffer->real_mods);
@@ -286,7 +294,9 @@ typedef struct _Serial_m2s_buffer_t {
     rgb_config_t   rgb_matrix;
     bool           rgb_suspend_state;
 #    endif
+#    ifdef SPLIT_HOST_SYNC_ENABLE
     uint8_t host_leds;
+#    endif
 } Serial_m2s_buffer_t;
 
 #    if defined(RGBLIGHT_ENABLE) && defined(RGBLIGHT_SPLIT)
@@ -418,8 +428,10 @@ bool transport_master(matrix_row_t master_matrix[], matrix_row_t slave_matrix[])
     serial_m2s_buffer.sync_timer        = sync_timer_read32() + SYNC_TIMER_OFFSET;
 #    endif
 
+#    ifdef SPLIT_HOST_SYNC_ENABLE
     serial_m2s_buffer.host_leds = host_keyboard_leds_raw();
     set_split_host_leds(serial_m2s_buffer.host_leds);
+#    endif
 
     return true;
 }
@@ -449,7 +461,9 @@ void transport_slave(matrix_row_t master_matrix[], matrix_row_t slave_matrix[]) 
     set_current_wpm(serial_m2s_buffer.current_wpm);
 #    endif
 
+#    ifdef SPLIT_HOST_SYNC_ENABLE
     set_split_host_leds(serial_m2s_buffer.host_leds);
+#    endif
 
 #    ifdef SPLIT_MODS_ENABLE
     set_mods(serial_m2s_buffer.real_mods);

--- a/quantum/split_common/transport.c
+++ b/quantum/split_common/transport.c
@@ -29,7 +29,7 @@ static pin_t encoders_pad[] = ENCODERS_PAD_A;
 #    include "rgb_matrix.h"
 #endif
 
-void set_slave_host_leds(uint8_t host_leds);
+void set_split_host_leds(uint8_t host_leds);
 
 #if defined(USE_I2C)
 
@@ -140,10 +140,9 @@ bool transport_master(matrix_row_t master_matrix[], matrix_row_t slave_matrix[])
 #    endif
 
     uint8_t host_leds = host_keyboard_leds();
-    if (host_leds != i2c_buffer->host_leds) {
-        if (i2c_writeReg(SLAVE_I2C_ADDRESS, I2C_HOST_LED_START, (void *)&host_leds, sizeof(host_leds), TIMEOUT) >= 0) {
-            i2c_buffer->host_leds = host_leds;
-        }
+    set_split_host_leds(host_leds);
+    if (i2c_writeReg(SLAVE_I2C_ADDRESS, I2C_HOST_LED_START, (void *)&host_leds, sizeof(host_leds), TIMEOUT) >= 0) {
+        i2c_buffer->host_leds = host_leds;
     }
 
 #    ifdef SPLIT_MODS_ENABLE
@@ -221,7 +220,7 @@ void transport_slave(matrix_row_t master_matrix[], matrix_row_t slave_matrix[]) 
     set_current_wpm(i2c_buffer->current_wpm);
 #    endif
 
-    set_slave_host_leds(i2c_buffer->host_leds);
+    set_split_host_leds(i2c_buffer->host_leds);
 
 #    ifdef SPLIT_MODS_ENABLE
     set_mods(i2c_buffer->real_mods);
@@ -418,7 +417,9 @@ bool transport_master(matrix_row_t master_matrix[], matrix_row_t slave_matrix[])
 #    ifndef DISABLE_SYNC_TIMER
     serial_m2s_buffer.sync_timer        = sync_timer_read32() + SYNC_TIMER_OFFSET;
 #    endif
-    serial_m2s_buffer.host_leds = host_keyboard_leds();
+
+    serial_m2s_buffer.host_leds = host_keyboard_leds_raw();
+    set_split_host_leds(serial_m2s_buffer.host_leds);
 
     return true;
 }
@@ -448,7 +449,7 @@ void transport_slave(matrix_row_t master_matrix[], matrix_row_t slave_matrix[]) 
     set_current_wpm(serial_m2s_buffer.current_wpm);
 #    endif
 
-    set_slave_host_leds(serial_m2s_buffer.host_leds);
+    set_split_host_leds(serial_m2s_buffer.host_leds);
 
 #    ifdef SPLIT_MODS_ENABLE
     set_mods(serial_m2s_buffer.real_mods);

--- a/quantum/split_common/transport.c
+++ b/quantum/split_common/transport.c
@@ -30,7 +30,7 @@ static pin_t encoders_pad[] = ENCODERS_PAD_A;
 #endif
 
 #ifdef SPLIT_HOST_SYNC_ENABLE
-void set_split_host_leds(uint8_t host_leds);
+void set_split_host_indicators(uint8_t host_leds);
 #endif
 
 #if defined(USE_I2C)
@@ -74,7 +74,7 @@ typedef struct _I2C_slave_buffer_t {
     bool         rgb_suspend_state;
 #    endif
 #    ifdef SPLIT_HOST_SYNC_ENABLE
-    uint8_t host_leds;
+    uint8_t host_indicators;
 #    endif
 } I2C_slave_buffer_t;
 
@@ -94,7 +94,7 @@ static I2C_slave_buffer_t *const i2c_buffer = (I2C_slave_buffer_t *)i2c_slave_re
 #    define I2C_LED_SUSPEND_START offsetof(I2C_slave_buffer_t, led_suspend_state)
 #    define I2C_RGB_MATRIX_START offsetof(I2C_slave_buffer_t, rgb_matrix)
 #    define I2C_RGB_SUSPEND_START offsetof(I2C_slave_buffer_t, rgb_suspend_state)
-#    define I2C_HOST_LED_START offsetof(I2C_slave_buffer_t, host_leds)
+#    define I2C_HOST_INDICATORS_START offsetof(I2C_slave_buffer_t, host_indicators)
 
 #    define TIMEOUT 100
 
@@ -144,10 +144,10 @@ bool transport_master(matrix_row_t master_matrix[], matrix_row_t slave_matrix[])
 #    endif
 
 #    ifdef SPLIT_HOST_SYNC_ENABLE
-    uint8_t host_leds = host_keyboard_leds();
-    set_split_host_leds(host_leds);
-    if (i2c_writeReg(SLAVE_I2C_ADDRESS, I2C_HOST_LED_START, (void *)&host_leds, sizeof(host_leds), TIMEOUT) >= 0) {
-        i2c_buffer->host_leds = host_leds;
+    uint8_t host_indicators = host_keyboard_leds();
+    set_split_host_indicators(host_indicators);
+    if (i2c_writeReg(SLAVE_I2C_ADDRESS, I2C_HOST_LED_START, (void *)&host_indicators, sizeof(host_indicators), TIMEOUT) >= 0) {
+        i2c_buffer->host_indicators = host_indicators;
     }
 #    endif
 
@@ -227,7 +227,7 @@ void transport_slave(matrix_row_t master_matrix[], matrix_row_t slave_matrix[]) 
 #    endif
 
 #    ifdef SPLIT_HOST_SYNC_ENABLE
-    set_split_host_leds(i2c_buffer->host_leds);
+    set_split_host_indicators(i2c_buffer->host_indicators);
 #    endif
 
 #    ifdef SPLIT_MODS_ENABLE
@@ -295,7 +295,7 @@ typedef struct _Serial_m2s_buffer_t {
     bool           rgb_suspend_state;
 #    endif
 #    ifdef SPLIT_HOST_SYNC_ENABLE
-    uint8_t host_leds;
+    uint8_t      host_indicators;
 #    endif
 } Serial_m2s_buffer_t;
 
@@ -429,8 +429,8 @@ bool transport_master(matrix_row_t master_matrix[], matrix_row_t slave_matrix[])
 #    endif
 
 #    ifdef SPLIT_HOST_SYNC_ENABLE
-    serial_m2s_buffer.host_leds = host_keyboard_leds_raw();
-    set_split_host_leds(serial_m2s_buffer.host_leds);
+    serial_m2s_buffer.host_indicators = host_keyboard_leds_raw();
+    set_split_host_indicators(serial_m2s_buffer.host_indicators);
 #    endif
 
     return true;
@@ -462,7 +462,7 @@ void transport_slave(matrix_row_t master_matrix[], matrix_row_t slave_matrix[]) 
 #    endif
 
 #    ifdef SPLIT_HOST_SYNC_ENABLE
-    set_split_host_leds(serial_m2s_buffer.host_leds);
+    set_split_host_indicators(serial_m2s_buffer.host_indicators);
 #    endif
 
 #    ifdef SPLIT_MODS_ENABLE

--- a/tmk_core/common/host.c
+++ b/tmk_core/common/host.c
@@ -21,6 +21,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "host.h"
 #include "util.h"
 #include "debug.h"
+#ifdef SPLIT_KEYBOARD
+#    include "split_util.h"
+#endif
 
 #ifdef NKRO_ENABLE
 #    include "keycode_config.h"
@@ -36,13 +39,21 @@ void host_set_driver(host_driver_t *d) { driver = d; }
 host_driver_t *host_get_driver(void) { return driver; }
 
 uint8_t host_keyboard_leds(void) {
-    if (!driver) return 0;
-    return (*driver->keyboard_leds)();
+    if (is_keyboard_master()) {
+         if (!driver) return 0;
+        return (*driver->keyboard_leds)();
+    } else {
+        return get_slave_host_leds();
+    }
 }
 
 led_t host_keyboard_led_state(void) {
-    if (!driver) return (led_t){0};
-    return (led_t)((*driver->keyboard_leds)());
+    if (is_keyboard_master()) {
+        if (!driver) return (led_t){0};
+        return (led_t)((*driver->keyboard_leds)());
+    } else {
+        return (led_t)get_slave_host_leds();
+    }
 }
 
 /* send report */

--- a/tmk_core/common/host.c
+++ b/tmk_core/common/host.c
@@ -38,22 +38,25 @@ void host_set_driver(host_driver_t *d) { driver = d; }
 
 host_driver_t *host_get_driver(void) { return driver; }
 
+uint8_t host_keyboard_leds_raw(void) {
+    if (!driver) return 0;
+    return (*driver->keyboard_leds)();
+}
+
 uint8_t host_keyboard_leds(void) {
-    if (is_keyboard_master()) {
-         if (!driver) return 0;
-        return (*driver->keyboard_leds)();
-    } else {
-        return get_slave_host_leds();
-    }
+#ifndef SPLIT_KEYBOARD
+    return host_keyboard_leds_raw();;
+#else
+    return get_split_host_leds();
+#endif
 }
 
 led_t host_keyboard_led_state(void) {
-    if (is_keyboard_master()) {
-        if (!driver) return (led_t){0};
-        return (led_t)((*driver->keyboard_leds)());
-    } else {
-        return (led_t)get_slave_host_leds();
-    }
+#ifndef SPLIT_KEYBOARD
+    return (led_t)host_keyboard_leds_raw();
+#else
+    return (led_t)get_split_host_leds();
+#endif
 }
 
 /* send report */

--- a/tmk_core/common/host.c
+++ b/tmk_core/common/host.c
@@ -45,7 +45,7 @@ uint8_t host_keyboard_leds_raw(void) {
 
 uint8_t host_keyboard_leds(void) {
 #if defined(SPLIT_KEYBOARD) && defined(SPLIT_HOST_SYNC_ENABLE)
-    return get_split_host_leds();
+    return get_split_host_indicators();
 #else
     return host_keyboard_leds_raw();
 #endif
@@ -53,7 +53,7 @@ uint8_t host_keyboard_leds(void) {
 
 led_t host_keyboard_led_state(void) {
 #if defined(SPLIT_KEYBOARD) && defined(SPLIT_HOST_SYNC_ENABLE)
-    return (led_t)get_split_host_leds();
+    return (led_t)get_split_host_indicators();
 #else
     return (led_t)host_keyboard_leds_raw();
 #endif

--- a/tmk_core/common/host.c
+++ b/tmk_core/common/host.c
@@ -21,7 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "host.h"
 #include "util.h"
 #include "debug.h"
-#ifdef SPLIT_KEYBOARD
+#if defined(SPLIT_KEYBOARD) && defined(SPLIT_HOST_SYNC_ENABLE)
 #    include "split_util.h"
 #endif
 
@@ -44,18 +44,18 @@ uint8_t host_keyboard_leds_raw(void) {
 }
 
 uint8_t host_keyboard_leds(void) {
-#ifndef SPLIT_KEYBOARD
-    return host_keyboard_leds_raw();;
-#else
+#if defined(SPLIT_KEYBOARD) && defined(SPLIT_HOST_SYNC_ENABLE)
     return get_split_host_leds();
+#else
+    return host_keyboard_leds_raw();
 #endif
 }
 
 led_t host_keyboard_led_state(void) {
-#ifndef SPLIT_KEYBOARD
-    return (led_t)host_keyboard_leds_raw();
-#else
+#if defined(SPLIT_KEYBOARD) && defined(SPLIT_HOST_SYNC_ENABLE)
     return (led_t)get_split_host_leds();
+#else
+    return (led_t)host_keyboard_leds_raw();
 #endif
 }
 

--- a/tmk_core/common/host.h
+++ b/tmk_core/common/host.h
@@ -42,6 +42,7 @@ host_driver_t *host_get_driver(void);
 
 /* host driver interface */
 uint8_t host_keyboard_leds(void);
+uint8_t host_keyboard_leds_raw(void);
 led_t   host_keyboard_led_state(void);
 void    host_keyboard_send(report_keyboard_t *report);
 void    host_mouse_send(report_mouse_t *report);

--- a/tmk_core/common/keyboard.c
+++ b/tmk_core/common/keyboard.c
@@ -100,6 +100,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifdef EEPROM_DRIVER
 #    include "eeprom_driver.h"
 #endif
+#ifdef SPLIT_KEYBOARD
+#    include "split_util.h"
+#endif
 
 static uint32_t last_input_modification_time = 0;
 uint32_t        last_input_activity_time(void) { return last_input_modification_time; }
@@ -508,9 +511,16 @@ MATRIX_LOOP_END:
 #endif
 
     // update LED
-    if (led_status != host_keyboard_leds()) {
-        led_status = host_keyboard_leds();
-        keyboard_set_leds(led_status);
+    if (is_keyboard_master()) {
+        if (led_status != host_keyboard_leds()) {
+            led_status = host_keyboard_leds();
+            keyboard_set_leds(led_status);
+        }
+    } else {
+        if (led_status != get_slave_host_leds()) {
+            led_status = get_slave_host_leds();
+            keyboard_set_leds(led_status);
+        }
     }
 }
 

--- a/tmk_core/common/keyboard.c
+++ b/tmk_core/common/keyboard.c
@@ -511,16 +511,9 @@ MATRIX_LOOP_END:
 #endif
 
     // update LED
-    if (is_keyboard_master()) {
-        if (led_status != host_keyboard_leds()) {
-            led_status = host_keyboard_leds();
-            keyboard_set_leds(led_status);
-        }
-    } else {
-        if (led_status != get_slave_host_leds()) {
-            led_status = get_slave_host_leds();
-            keyboard_set_leds(led_status);
-        }
+    if (led_status != host_keyboard_leds()) {
+        led_status = host_keyboard_leds();
+        keyboard_set_leds(led_status);
     }
 }
 


### PR DESCRIPTION
## Description

This enables syncing of the host LEDs (caps/num/etc) between halves of split keyboard. 
This allows for things like OLED displays to pull the status. 

## Types of Changes

- [x] Core
- [x] Enhancement/optimization

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
