### PR TITLE
Remove `MIDI_ENABLE_STRICT` from user keymaps

### DIFF
--- a/keyboards/clueboard/66/keymaps/magicmonty/config.h
+++ b/keyboards/clueboard/66/keymaps/magicmonty/config.h
@@ -4,9 +4,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
   #define MIDI_BASIC

--- a/keyboards/contra/keymaps/alper/config.h
+++ b/keyboards/contra/keymaps/alper/config.h
@@ -17,9 +17,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/contra/keymaps/deastiny/config.h
+++ b/keyboards/contra/keymaps/deastiny/config.h
@@ -16,9 +16,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/contra/keymaps/msiu/config.h
+++ b/keyboards/contra/keymaps/msiu/config.h
@@ -16,9 +16,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/contra/keymaps/ryanm101/config.h
+++ b/keyboards/contra/keymaps/ryanm101/config.h
@@ -21,9 +21,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/converter/usb_usb/keymaps/narze/config.h
+++ b/keyboards/converter/usb_usb/keymaps/narze/config.h
@@ -4,9 +4,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/keebio/levinson/keymaps/xtonhasvim/config.h
+++ b/keyboards/keebio/levinson/keymaps/xtonhasvim/config.h
@@ -8,9 +8,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/niu_mini/keymaps/framtava/config.h
+++ b/keyboards/niu_mini/keymaps/framtava/config.h
@@ -9,9 +9,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/niu_mini/keymaps/planck/config.h
+++ b/keyboards/niu_mini/keymaps/planck/config.h
@@ -9,9 +9,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/niu_mini/keymaps/tobias/config.h
+++ b/keyboards/niu_mini/keymaps/tobias/config.h
@@ -8,9 +8,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/niu_mini/keymaps/xtonhasvim/config.h
+++ b/keyboards/niu_mini/keymaps/xtonhasvim/config.h
@@ -9,9 +9,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/abishalom/config.h
+++ b/keyboards/planck/keymaps/abishalom/config.h
@@ -14,9 +14,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/am/config.h
+++ b/keyboards/planck/keymaps/am/config.h
@@ -14,9 +14,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/andylikescandy/config.h
+++ b/keyboards/planck/keymaps/andylikescandy/config.h
@@ -21,9 +21,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/atreus/config.h
+++ b/keyboards/planck/keymaps/atreus/config.h
@@ -30,9 +30,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/aviator/config.h
+++ b/keyboards/planck/keymaps/aviator/config.h
@@ -24,9 +24,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/brandon/config.h
+++ b/keyboards/planck/keymaps/brandon/config.h
@@ -7,9 +7,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/charlesrocket/config.h
+++ b/keyboards/planck/keymaps/charlesrocket/config.h
@@ -8,9 +8,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/circuit/config.h
+++ b/keyboards/planck/keymaps/circuit/config.h
@@ -7,9 +7,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/coloneljesus/config.h
+++ b/keyboards/planck/keymaps/coloneljesus/config.h
@@ -19,9 +19,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/corvec/config.h
+++ b/keyboards/planck/keymaps/corvec/config.h
@@ -19,9 +19,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/dbroqua/config.h
+++ b/keyboards/planck/keymaps/dbroqua/config.h
@@ -7,9 +7,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/dcompact/config.h
+++ b/keyboards/planck/keymaps/dcompact/config.h
@@ -18,9 +18,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/deft/config.h
+++ b/keyboards/planck/keymaps/deft/config.h
@@ -14,9 +14,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/dlaroe/config.h
+++ b/keyboards/planck/keymaps/dlaroe/config.h
@@ -7,9 +7,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/dr0ck/config.h
+++ b/keyboards/planck/keymaps/dr0ck/config.h
@@ -19,9 +19,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/dr_notsokind/config.h
+++ b/keyboards/planck/keymaps/dr_notsokind/config.h
@@ -7,9 +7,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/dudeofawesome/config.h
+++ b/keyboards/planck/keymaps/dudeofawesome/config.h
@@ -21,9 +21,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/emiller/config.h
+++ b/keyboards/planck/keymaps/emiller/config.h
@@ -17,9 +17,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/emilyh/config.h
+++ b/keyboards/planck/keymaps/emilyh/config.h
@@ -19,9 +19,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/eosti/config.h
+++ b/keyboards/planck/keymaps/eosti/config.h
@@ -30,9 +30,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/eshesh2/config.h
+++ b/keyboards/planck/keymaps/eshesh2/config.h
@@ -28,9 +28,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/experimental/config.h
+++ b/keyboards/planck/keymaps/experimental/config.h
@@ -17,9 +17,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/fabian/config.h
+++ b/keyboards/planck/keymaps/fabian/config.h
@@ -14,9 +14,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/fsck/config.h
+++ b/keyboards/planck/keymaps/fsck/config.h
@@ -18,9 +18,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/gitdrik/config.h
+++ b/keyboards/planck/keymaps/gitdrik/config.h
@@ -32,9 +32,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/grahampheath/config.h
+++ b/keyboards/planck/keymaps/grahampheath/config.h
@@ -16,9 +16,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/gunp/config.h
+++ b/keyboards/planck/keymaps/gunp/config.h
@@ -19,9 +19,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/hvp/config.h
+++ b/keyboards/planck/keymaps/hvp/config.h
@@ -15,9 +15,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/impossible/config.h
+++ b/keyboards/planck/keymaps/impossible/config.h
@@ -7,9 +7,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/jeebak/config.h
+++ b/keyboards/planck/keymaps/jeebak/config.h
@@ -7,9 +7,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/jetpacktuxedo/config.h
+++ b/keyboards/planck/keymaps/jetpacktuxedo/config.h
@@ -9,9 +9,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/jhenahan/config.h
+++ b/keyboards/planck/keymaps/jhenahan/config.h
@@ -11,9 +11,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/jirgn/config.h
+++ b/keyboards/planck/keymaps/jirgn/config.h
@@ -19,9 +19,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/kelorean/config.h
+++ b/keyboards/planck/keymaps/kelorean/config.h
@@ -19,9 +19,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/khord/config.h
+++ b/keyboards/planck/keymaps/khord/config.h
@@ -23,9 +23,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/kifinnsson/config.h
+++ b/keyboards/planck/keymaps/kifinnsson/config.h
@@ -14,9 +14,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/kloki/config.h
+++ b/keyboards/planck/keymaps/kloki/config.h
@@ -19,9 +19,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/kmontag42/config.h
+++ b/keyboards/planck/keymaps/kmontag42/config.h
@@ -19,9 +19,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/mattly/config.h
+++ b/keyboards/planck/keymaps/mattly/config.h
@@ -14,9 +14,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/mgalisa/config.h
+++ b/keyboards/planck/keymaps/mgalisa/config.h
@@ -14,9 +14,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/mikethetiger/config.h
+++ b/keyboards/planck/keymaps/mikethetiger/config.h
@@ -14,9 +14,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/mjt/config.h
+++ b/keyboards/planck/keymaps/mjt/config.h
@@ -7,9 +7,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/mjtnumsym/config.h
+++ b/keyboards/planck/keymaps/mjtnumsym/config.h
@@ -7,9 +7,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/motform/config.h
+++ b/keyboards/planck/keymaps/motform/config.h
@@ -14,9 +14,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/msiu/config.h
+++ b/keyboards/planck/keymaps/msiu/config.h
@@ -15,9 +15,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/muzfuz/config.h
+++ b/keyboards/planck/keymaps/muzfuz/config.h
@@ -16,9 +16,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/mwpeterson/config.h
+++ b/keyboards/planck/keymaps/mwpeterson/config.h
@@ -16,9 +16,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/myoung34/config.h
+++ b/keyboards/planck/keymaps/myoung34/config.h
@@ -22,9 +22,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/narze/config.h
+++ b/keyboards/planck/keymaps/narze/config.h
@@ -4,9 +4,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/navi/config.h
+++ b/keyboards/planck/keymaps/navi/config.h
@@ -14,9 +14,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/paget/config.h
+++ b/keyboards/planck/keymaps/paget/config.h
@@ -19,9 +19,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/palleiko/config.h
+++ b/keyboards/planck/keymaps/palleiko/config.h
@@ -19,9 +19,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/pascamel/config.h
+++ b/keyboards/planck/keymaps/pascamel/config.h
@@ -14,9 +14,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/pevecyan/config.h
+++ b/keyboards/planck/keymaps/pevecyan/config.h
@@ -14,9 +14,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/phreed/config.h
+++ b/keyboards/planck/keymaps/phreed/config.h
@@ -19,9 +19,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/pickle_jr/config.h
+++ b/keyboards/planck/keymaps/pickle_jr/config.h
@@ -14,9 +14,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/pok3r/config.h
+++ b/keyboards/planck/keymaps/pok3r/config.h
@@ -19,9 +19,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/premek/config.h
+++ b/keyboards/planck/keymaps/premek/config.h
@@ -8,9 +8,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/ptillemans/config.h
+++ b/keyboards/planck/keymaps/ptillemans/config.h
@@ -14,9 +14,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/pvc/config.h
+++ b/keyboards/planck/keymaps/pvc/config.h
@@ -35,9 +35,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/raffle/config.h
+++ b/keyboards/planck/keymaps/raffle/config.h
@@ -14,9 +14,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/rjhilgefort/config.h
+++ b/keyboards/planck/keymaps/rjhilgefort/config.h
@@ -14,9 +14,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/sean/config.h
+++ b/keyboards/planck/keymaps/sean/config.h
@@ -7,9 +7,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/sgoodwin/config.h
+++ b/keyboards/planck/keymaps/sgoodwin/config.h
@@ -7,9 +7,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/sigul/config.h
+++ b/keyboards/planck/keymaps/sigul/config.h
@@ -14,9 +14,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/skug/config.h
+++ b/keyboards/planck/keymaps/skug/config.h
@@ -20,9 +20,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/smt/config.h
+++ b/keyboards/planck/keymaps/smt/config.h
@@ -7,9 +7,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/snowkuma/config.h
+++ b/keyboards/planck/keymaps/snowkuma/config.h
@@ -14,9 +14,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/steno/config.h
+++ b/keyboards/planck/keymaps/steno/config.h
@@ -19,9 +19,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/tehwalris/config.h
+++ b/keyboards/planck/keymaps/tehwalris/config.h
@@ -19,9 +19,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/tom/config.h
+++ b/keyboards/planck/keymaps/tom/config.h
@@ -14,9 +14,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/unagi/config.h
+++ b/keyboards/planck/keymaps/unagi/config.h
@@ -17,9 +17,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/unicode/config.h
+++ b/keyboards/planck/keymaps/unicode/config.h
@@ -7,9 +7,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/vaire/config.h
+++ b/keyboards/planck/keymaps/vaire/config.h
@@ -7,9 +7,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/vifon/config.h
+++ b/keyboards/planck/keymaps/vifon/config.h
@@ -7,9 +7,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/winternebs/config.h
+++ b/keyboards/planck/keymaps/winternebs/config.h
@@ -30,9 +30,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/zach/config.h
+++ b/keyboards/planck/keymaps/zach/config.h
@@ -7,9 +7,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/planck/keymaps/zrichard/config.h
+++ b/keyboards/planck/keymaps/zrichard/config.h
@@ -32,9 +32,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define UNUSED_PINS
 #endif
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/preonic/keymaps/AlexDaigre/config.h
+++ b/keyboards/preonic/keymaps/AlexDaigre/config.h
@@ -16,9 +16,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/preonic/keymaps/CMD-Preonic/config.h
+++ b/keyboards/preonic/keymaps/CMD-Preonic/config.h
@@ -7,9 +7,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/preonic/keymaps/blake-newman/config.h
+++ b/keyboards/preonic/keymaps/blake-newman/config.h
@@ -19,9 +19,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/preonic/keymaps/boy314/config.h
+++ b/keyboards/preonic/keymaps/boy314/config.h
@@ -16,9 +16,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/preonic/keymaps/choromanski/config.h
+++ b/keyboards/preonic/keymaps/choromanski/config.h
@@ -24,9 +24,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/preonic/keymaps/cranium/config.h
+++ b/keyboards/preonic/keymaps/cranium/config.h
@@ -17,9 +17,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/preonic/keymaps/dlaroe/config.h
+++ b/keyboards/preonic/keymaps/dlaroe/config.h
@@ -7,9 +7,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/preonic/keymaps/drasbeck/config.h
+++ b/keyboards/preonic/keymaps/drasbeck/config.h
@@ -28,9 +28,6 @@ Attribution-ShareAlike 4.0 International (CC BY-SA 4.0) 2020 Max Drasbeck
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/preonic/keymaps/dudeofawesome/config.h
+++ b/keyboards/preonic/keymaps/dudeofawesome/config.h
@@ -23,9 +23,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/preonic/keymaps/egstad/config.h
+++ b/keyboards/preonic/keymaps/egstad/config.h
@@ -69,9 +69,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/preonic/keymaps/ekis_isa/config.h
+++ b/keyboards/preonic/keymaps/ekis_isa/config.h
@@ -19,9 +19,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/preonic/keymaps/elisiano/config.h
+++ b/keyboards/preonic/keymaps/elisiano/config.h
@@ -16,9 +16,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/preonic/keymaps/fig-r/config.h
+++ b/keyboards/preonic/keymaps/fig-r/config.h
@@ -19,9 +19,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/preonic/keymaps/fsck/config.h
+++ b/keyboards/preonic/keymaps/fsck/config.h
@@ -16,9 +16,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/preonic/keymaps/keelhauler/config.h
+++ b/keyboards/preonic/keymaps/keelhauler/config.h
@@ -16,9 +16,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/preonic/keymaps/kjwon15/config.h
+++ b/keyboards/preonic/keymaps/kjwon15/config.h
@@ -45,9 +45,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/preonic/keymaps/kuatsure/config.h
+++ b/keyboards/preonic/keymaps/kuatsure/config.h
@@ -20,9 +20,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/preonic/keymaps/laurentlaurent/config.h
+++ b/keyboards/preonic/keymaps/laurentlaurent/config.h
@@ -16,9 +16,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/preonic/keymaps/mguterl/config.h
+++ b/keyboards/preonic/keymaps/mguterl/config.h
@@ -16,9 +16,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/preonic/keymaps/mikethetiger/config.h
+++ b/keyboards/preonic/keymaps/mikethetiger/config.h
@@ -16,9 +16,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/preonic/keymaps/muzfuz/config.h
+++ b/keyboards/preonic/keymaps/muzfuz/config.h
@@ -16,9 +16,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/preonic/keymaps/mverteuil/config.h
+++ b/keyboards/preonic/keymaps/mverteuil/config.h
@@ -18,9 +18,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/preonic/keymaps/mverteuil_2x2u/config.h
+++ b/keyboards/preonic/keymaps/mverteuil_2x2u/config.h
@@ -18,9 +18,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/preonic/keymaps/nikchi/config.h
+++ b/keyboards/preonic/keymaps/nikchi/config.h
@@ -7,9 +7,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/preonic/keymaps/pcurt854/config.h
+++ b/keyboards/preonic/keymaps/pcurt854/config.h
@@ -53,9 +53,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/preonic/keymaps/pezhore/config.h
+++ b/keyboards/preonic/keymaps/pezhore/config.h
@@ -32,9 +32,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/preonic/keymaps/pitty/config.h
+++ b/keyboards/preonic/keymaps/pitty/config.h
@@ -17,9 +17,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/preonic/keymaps/pvillano/config.h
+++ b/keyboards/preonic/keymaps/pvillano/config.h
@@ -11,9 +11,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/preonic/keymaps/senseored/config.h
+++ b/keyboards/preonic/keymaps/senseored/config.h
@@ -16,9 +16,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/preonic/keymaps/shwilliam/config.h
+++ b/keyboards/preonic/keymaps/shwilliam/config.h
@@ -7,9 +7,6 @@
 
 #define MUSIC_MASK (keycode != KC_NO)
 
-/* prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 #define MIDI_BASIC
 
 /* enable advanced MIDI features */

--- a/keyboards/preonic/keymaps/smt/config.h
+++ b/keyboards/preonic/keymaps/smt/config.h
@@ -7,9 +7,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/keyboards/sentraq/s60_x/keymaps/bluebear/config.h
+++ b/keyboards/sentraq/s60_x/keymaps/bluebear/config.h
@@ -78,9 +78,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/layouts/community/ortho_4x12/bocaj/config.h
+++ b/layouts/community/ortho_4x12/bocaj/config.h
@@ -41,9 +41,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/layouts/community/ortho_4x12/brandonschlack/config.h
+++ b/layouts/community/ortho_4x12/brandonschlack/config.h
@@ -30,9 +30,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/layouts/community/ortho_4x12/drashna/config.h
+++ b/layouts/community/ortho_4x12/drashna/config.h
@@ -87,9 +87,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/layouts/community/ortho_4x12/jackhumbert/config.h
+++ b/layouts/community/ortho_4x12/jackhumbert/config.h
@@ -30,9 +30,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/layouts/community/ortho_4x12/juno/config.h
+++ b/layouts/community/ortho_4x12/juno/config.h
@@ -14,9 +14,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/layouts/community/ortho_4x12/junonum/config.h
+++ b/layouts/community/ortho_4x12/junonum/config.h
@@ -14,9 +14,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/layouts/community/ortho_4x12/mguterl/config.h
+++ b/layouts/community/ortho_4x12/mguterl/config.h
@@ -14,9 +14,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/layouts/community/ortho_5x12/brandonschlack/config.h
+++ b/layouts/community/ortho_5x12/brandonschlack/config.h
@@ -30,9 +30,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */

--- a/users/ishtob/config.h
+++ b/users/ishtob/config.h
@@ -50,9 +50,6 @@
  * MIDI options
  */
 
-/* Prevent use of disabled MIDI features in the keymap */
-//#define MIDI_ENABLE_STRICT 1
-
 /* enable basic MIDI features:
    - MIDI notes can be sent when in Music mode is on
 */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
