### PR TITLE
fix broken activation of kinetic mouse mode

### DIFF
--- a/tmk_core/common/mousekey.c
+++ b/tmk_core/common/mousekey.c
@@ -65,11 +65,16 @@ uint8_t mk_time_to_max = MOUSEKEY_TIME_TO_MAX;
 /* milliseconds between the initial key press and first repeated motion event (0-2550) */
 uint8_t mk_wheel_delay = MOUSEKEY_WHEEL_DELAY / 10;
 /* milliseconds between repeated motion events (0-255) */
+#ifndef MK_KINETIC_SPEED
 uint8_t mk_wheel_interval    = MOUSEKEY_WHEEL_INTERVAL;
+#else /* #ifndef MK_KINETIC_SPEED */
+float mk_wheel_interval = 1000.0f / MOUSEKEY_WHEEL_INITIAL_MOVEMENTS;
+#endif /* #ifndef MK_KINETIC_SPEED */
 uint8_t mk_wheel_max_speed   = MOUSEKEY_WHEEL_MAX_SPEED;
 uint8_t mk_wheel_time_to_max = MOUSEKEY_WHEEL_TIME_TO_MAX;
 
 #    ifndef MK_COMBINED
+#        ifndef MK_KINETIC_SPEED
 
 static uint8_t move_unit(void) {
     uint16_t unit;
@@ -107,8 +112,7 @@ static uint8_t wheel_unit(void) {
     return (unit > MOUSEKEY_WHEEL_MAX ? MOUSEKEY_WHEEL_MAX : (unit == 0 ? 1 : unit));
 }
 
-#    else /* #ifndef MK_COMBINED */
-#        ifndef MK_KINETIC_SPEED
+#        else /* #ifndef MK_KINETIC_SPEED */
 
 /*
  * Kinetic movement  acceleration algorithm
@@ -126,10 +130,10 @@ const uint16_t mk_accelerated_speed = MOUSEKEY_ACCELERATED_SPEED;
 const uint16_t mk_base_speed        = MOUSEKEY_BASE_SPEED;
 const uint16_t mk_decelerated_speed = MOUSEKEY_DECELERATED_SPEED;
 const uint16_t mk_initial_speed     = MOUSEKEY_INITIAL_SPEED;
+float speed = mk_initial_speed;
+
 
 static uint8_t move_unit(void) {
-    float speed = mk_initial_speed;
-
     if (mousekey_accel & ((1 << 0) | (1 << 2))) {
         speed = mousekey_accel & (1 << 2) ? mk_accelerated_speed : mk_decelerated_speed;
     } else if (mousekey_repeat && mouse_timer) {
@@ -145,8 +149,6 @@ static uint8_t move_unit(void) {
 
     return speed > MOUSEKEY_MOVE_MAX ? MOUSEKEY_MOVE_MAX : speed;
 }
-
-float mk_wheel_interval = 1000.0f / MOUSEKEY_WHEEL_INITIAL_MOVEMENTS;
 
 static uint8_t wheel_unit(void) {
     float speed = MOUSEKEY_WHEEL_INITIAL_MOVEMENTS;
@@ -166,7 +168,9 @@ static uint8_t wheel_unit(void) {
     return 1;
 }
 
-#        else /* #ifndef MK_KINETIC_SPEED */
+#        endif /* #ifndef MK_KINETIC_SPEED */
+
+#    else /* #ifndef MK_COMBINED */
 
 static uint8_t move_unit(void) {
     uint16_t unit;
@@ -204,7 +208,6 @@ static uint8_t wheel_unit(void) {
     return (unit > MOUSEKEY_WHEEL_MAX ? MOUSEKEY_WHEEL_MAX : (unit == 0 ? 1 : unit));
 }
 
-#        endif /* #ifndef MK_KINETIC_SPEED */
 #    endif     /* #ifndef MK_COMBINED */
 
 void mousekey_task(void) {

--- a/tmk_core/common/mousekey.c
+++ b/tmk_core/common/mousekey.c
@@ -130,10 +130,10 @@ const uint16_t mk_accelerated_speed = MOUSEKEY_ACCELERATED_SPEED;
 const uint16_t mk_base_speed        = MOUSEKEY_BASE_SPEED;
 const uint16_t mk_decelerated_speed = MOUSEKEY_DECELERATED_SPEED;
 const uint16_t mk_initial_speed     = MOUSEKEY_INITIAL_SPEED;
-float speed = mk_initial_speed;
-
 
 static uint8_t move_unit(void) {
+    float speed = (float)mk_initial_speed;
+    
     if (mousekey_accel & ((1 << 0) | (1 << 2))) {
         speed = mousekey_accel & (1 << 2) ? mk_accelerated_speed : mk_decelerated_speed;
     } else if (mousekey_repeat && mouse_timer) {


### PR DESCRIPTION
## Description

Fix the activation of the kinetic mouse movement mode.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* no issue filed yet. Defining `MK_KINETIC_SPEED` according to the documentation didn't work because the if/else define blocks weren't arranged properly.

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
