### PR TITLE
Allow flash/compile to accept relative json paths

### DIFF
--- a/lib/python/qmk/cli/compile.py
+++ b/lib/python/qmk/cli/compile.py
@@ -2,15 +2,14 @@
 
 You can compile a keymap already in the repo or using a QMK Configurator export.
 """
-from argparse import FileType
-
 from milc import cli
 
+import qmk.path
 from qmk.decorators import automagic_keyboard, automagic_keymap
 from qmk.commands import compile_configurator_json, create_make_command, parse_configurator_json
 
 
-@cli.argument('filename', nargs='?', arg_only=True, type=FileType('r'), help='The configurator export to compile')
+@cli.argument('filename', nargs='?', arg_only=True, type=qmk.path.FileType('r'), help='The configurator export to compile')
 @cli.argument('-kb', '--keyboard', help='The keyboard to build a firmware for. Ignored when a configurator export is supplied.')
 @cli.argument('-km', '--keymap', help='The keymap to build a firmware for. Ignored when a configurator export is supplied.')
 @cli.argument('-n', '--dry-run', arg_only=True, action='store_true', help="Don't actually build, just show the make command to be run.")

--- a/lib/python/qmk/cli/flash.py
+++ b/lib/python/qmk/cli/flash.py
@@ -3,7 +3,6 @@
 You can compile a keymap already in the repo or using a QMK Configurator export.
 A bootloader must be specified.
 """
-from argparse import FileType
 
 from milc import cli
 
@@ -30,7 +29,7 @@ def print_bootloader_help():
     cli.echo('For more info, visit https://docs.qmk.fm/#/flashing')
 
 
-@cli.argument('filename', nargs='?', arg_only=True, type=FileType('r'), help='The configurator export JSON to compile.')
+@cli.argument('filename', nargs='?', arg_only=True, type=qmk.path.FileType('r'), help='The configurator export JSON to compile.')
 @cli.argument('-b', '--bootloaders', action='store_true', help='List the available bootloaders.')
 @cli.argument('-bl', '--bootloader', default='flash', help='The flash command, corresponding to qmk\'s make options of bootloaders.')
 @cli.argument('-km', '--keymap', help='The keymap to build a firmware for. Use this if you dont have a configurator file. Ignored when a configurator file is supplied.')

--- a/lib/python/qmk/cli/json2c.py
+++ b/lib/python/qmk/cli/json2c.py
@@ -1,7 +1,6 @@
 """Generate a keymap.c from a configurator export.
 """
 import json
-import sys
 
 from milc import cli
 

--- a/lib/python/qmk/cli/json2c.py
+++ b/lib/python/qmk/cli/json2c.py
@@ -11,7 +11,7 @@ import qmk.path
 
 @cli.argument('-o', '--output', arg_only=True, type=qmk.path.normpath, help='File to write to')
 @cli.argument('-q', '--quiet', arg_only=True, action='store_true', help="Quiet mode, only output error messages")
-@cli.argument('filename', type=qmk.path.normpath, arg_only=True, help='Configurator JSON file')
+@cli.argument('filename', type=qmk.path.FileType('r'), arg_only=True, help='Configurator JSON file')
 @cli.subcommand('Creates a keymap.c from a QMK Configurator export.')
 def json2c(cli):
     """Generate a keymap.c from a configurator export.
@@ -20,19 +20,8 @@ def json2c(cli):
     """
 
     try:
-        # Parse the configurator from stdin
-        if cli.args.filename and cli.args.filename.name == '-':
-            user_keymap = json.load(sys.stdin)
-
-        else:
-            # Error checking
-            if not cli.args.filename.exists():
-                cli.log.error('JSON file does not exist!')
-                return False
-
-            # Parse the configurator json file
-            else:
-                user_keymap = json.loads(cli.args.filename.read_text())
+        # Parse the configurator from json file (or stdin)
+        user_keymap = json.load(cli.args.filename)
 
     except json.decoder.JSONDecodeError as ex:
         cli.log.error('The JSON input does not appear to be valid.')

--- a/lib/python/qmk/path.py
+++ b/lib/python/qmk/path.py
@@ -70,7 +70,4 @@ def normpath(path):
 
 class FileType(argparse.FileType):
     def __call__(self, string):
-        maybe_relative = normpath(string)
-        if maybe_relative.exists():
-            string = maybe_relative.resolve()
-        return super().__call__(string)
+        return super().__call__(normpath(string))

--- a/lib/python/qmk/path.py
+++ b/lib/python/qmk/path.py
@@ -2,8 +2,8 @@
 """
 import logging
 import os
+import argparse
 from pathlib import Path
-from argparse import FileType as _FileType
 
 from qmk.constants import MAX_KEYBOARD_SUBFOLDERS, QMK_FIRMWARE
 from qmk.errors import NoSuchKeyboardError
@@ -68,9 +68,9 @@ def normpath(path):
     return Path(os.environ['ORIG_CWD']) / path
 
 
-class FileType(_FileType):
+class FileType(argparse.FileType):
     def __call__(self, string):
-        maybe_relative = Path(os.environ['ORIG_CWD'], string)
+        maybe_relative = normpath(string)
         if maybe_relative.exists():
             string = maybe_relative.resolve()
         return super().__call__(string)

--- a/lib/python/qmk/path.py
+++ b/lib/python/qmk/path.py
@@ -3,6 +3,7 @@
 import logging
 import os
 from pathlib import Path
+from argparse import FileType as _FileType
 
 from qmk.constants import MAX_KEYBOARD_SUBFOLDERS, QMK_FIRMWARE
 from qmk.errors import NoSuchKeyboardError
@@ -65,3 +66,11 @@ def normpath(path):
         return path
 
     return Path(os.environ['ORIG_CWD']) / path
+
+
+class FileType(_FileType):
+    def __call__(self, string):
+        maybe_relative = Path(os.environ['ORIG_CWD'], string)
+        if maybe_relative.exists():
+            string = maybe_relative.resolve()
+        return super().__call__(string)

--- a/lib/python/qmk/path.py
+++ b/lib/python/qmk/path.py
@@ -70,4 +70,8 @@ def normpath(path):
 
 class FileType(argparse.FileType):
     def __call__(self, string):
-        return super().__call__(normpath(string))
+        """normalize and check exists
+            otherwise magic strings like '-' for stdin resolve to bad paths
+        """
+        norm = normpath(string)
+        return super().__call__(norm if norm.exists() else string)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Common issue that gets reported in the Discord, where the initial `cd qmk_firmware` within cli changes the assumption of where the relative path is to.


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
