### PR TITLE
Fix DEBUG_MATRIX_SCAN_RATE on chibiOS when console is enabled

### DIFF
--- a/tmk_core/common/keyboard.c
+++ b/tmk_core/common/keyboard.c
@@ -108,7 +108,7 @@ void matrix_scan_perf_task(void) {
     uint32_t timer_now = timer_read32();
     if (TIMER_DIFF_32(timer_now, matrix_timer) > 1000) {
 #    if defined(CONSOLE_ENABLE)
-        dprintf("matrix scan frequency: %d\n", matrix_scan_count);
+        dprintf("matrix scan frequency: %ld\n", matrix_scan_count);
 #    endif
         last_matrix_scan_count = matrix_scan_count;
         matrix_timer      = timer_now;

--- a/tmk_core/common/keyboard.c
+++ b/tmk_core/common/keyboard.c
@@ -108,7 +108,7 @@ void matrix_scan_perf_task(void) {
     uint32_t timer_now = timer_read32();
     if (TIMER_DIFF_32(timer_now, matrix_timer) > 1000) {
 #    if defined(CONSOLE_ENABLE)
-        dprintf("matrix scan frequency: %ld\n", matrix_scan_count);
+        dprintf("matrix scan frequency: %lu\n", matrix_scan_count);
 #    endif
         last_matrix_scan_count = matrix_scan_count;
         matrix_timer      = timer_now;


### PR DESCRIPTION
## Description

Fixes compiler issues when enabling this on chibiOS boards. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

```
Compiling: tmk_core/common/keyboard.c                                                              In file included from quantum/keymap.h:34,
                 from tmk_core/common/keyboard.c:21:
tmk_core/common/keyboard.c: In function 'matrix_scan_perf_task':
tmk_core/common/keyboard.c:118:17: error: format '%d' expects argument of type 'int', but argument 2 has type 'uint32_t' {aka 'long unsigned int'} [-Werror=format=]
         dprintf("matrix scan frequency: %d\n", matrix_scan_count);
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~~~~~~~~
tmk_core/common/debug.h:68:39: note: in definition of macro 'dprintf'
             if (debug_enable) xprintf(fmt, ##__VA_ARGS__); \
```


## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
