### PR TITLE
[WIP] Refactor `tmk_core/common/{command,mousekey}.*` for code size & {read,maintain}ability

### DIFF
--- a/quantum/command.c
+++ b/quantum/command.c
@@ -644,7 +644,7 @@ static bool mousekey_console(uint8_t code) {
             mousekey_param_print();
             break;
         case KC_1 ... KC_6:
-            param = numkey2num(code);
+            param = 1 + code - KC_1;
 #           define PARAM(n, v) case n: pp = &(v); desc = #v; break
             switch (param) {
                 PARAM(1, mk_delay);
@@ -697,31 +697,6 @@ static bool mousekey_console(uint8_t code) {
 /***********************************************************
  * Utilities
  ***********************************************************/
-uint8_t numkey2num(uint8_t code) {
-    switch (code) {
-        case KC_1:
-            return 1;
-        case KC_2:
-            return 2;
-        case KC_3:
-            return 3;
-        case KC_4:
-            return 4;
-        case KC_5:
-            return 5;
-        case KC_6:
-            return 6;
-        case KC_7:
-            return 7;
-        case KC_8:
-            return 8;
-        case KC_9:
-            return 9;
-        case KC_0:
-            return 0;
-    }
-    return 0;
-}
 
 static void switch_default_layer(uint8_t layer) {
     xprintf("L%d\n", layer);

--- a/quantum/command.c
+++ b/quantum/command.c
@@ -218,95 +218,98 @@ static void print_version(void) {
 }
 
 static void print_status(void) {
-    print("\n\t- Status -\n");
+    xprintf("\n\t- Status -\n"
 
-    print_val_hex8(host_keyboard_leds());
+        "host_keyboard_leds(): %02X\n"
 #ifndef PROTOCOL_VUSB
-    // these aren't set on the V-USB protocol, so we just ignore them for now
-    print_val_hex8(keyboard_protocol);
-    print_val_hex8(keyboard_idle);
+        "keyboard_protocol: %02X\n"
+        "keyboard_idle: %02X\n"
 #endif
 #ifdef NKRO_ENABLE
-    print_val_hex8(keymap_config.nkro);
+        "keymap_config.nkro: %02X\n"
 #endif
-    print_val_hex32(timer_read32());
-    return;
+        "timer_read32(): %08lX\n"
+
+        , host_keyboard_leds()
+#ifndef PROTOCOL_VUSB // these aren't set on the V-USB protocol, so we just ignore them for now
+        , keyboard_protocol
+        , keyboard_idle
+#endif
+#ifdef NKRO_ENABLE
+        , keymap_config.nkro
+#endif
+        , timer_read32()
+
+    );
 }
 
 static void print_eeconfig(void) {
 // Print these variables if NO_PRINT or USER_PRINT are not defined.
 #if !defined(NO_PRINT) && !defined(USER_PRINT)
 
-    print("default_layer: ");
-    print_dec(eeconfig_read_default_layer());
-    print("\n");
+    xprintf("eeconfig:\n"
+        "default_layer: %u\n"
+        , eeconfig_read_default_layer()
+        );
 
     debug_config_t dc;
     dc.raw = eeconfig_read_debug();
-    print("debug_config.raw: ");
-    print_hex8(dc.raw);
-    print("\n");
-    print(".enable: ");
-    print_dec(dc.enable);
-    print("\n");
-    print(".matrix: ");
-    print_dec(dc.matrix);
-    print("\n");
-    print(".keyboard: ");
-    print_dec(dc.keyboard);
-    print("\n");
-    print(".mouse: ");
-    print_dec(dc.mouse);
-    print("\n");
+    xprintf(
+
+        "debug_config.raw: %02X\n"
+        ".enable: %u\n"
+        ".matrix: %u\n"
+        ".keyboard: %u\n"
+        ".mouse: %u\n"
+
+        , dc.raw
+        , dc.enable
+        , dc.matrix
+        , dc.keyboard
+        , dc.mouse
+    );
 
     keymap_config_t kc;
     kc.raw = eeconfig_read_keymap();
-    print("keymap_config.raw: ");
-    print_hex8(kc.raw);
-    print("\n");
-    print(".swap_control_capslock: ");
-    print_dec(kc.swap_control_capslock);
-    print("\n");
-    print(".capslock_to_control: ");
-    print_dec(kc.capslock_to_control);
-    print("\n");
-    print(".swap_lctl_lgui: ");
-    print_dec(kc.swap_lctl_lgui);
-    print("\n");
-    print(".swap_rctl_rgui: ");
-    print_dec(kc.swap_rctl_rgui);
-    print("\n");
-    print(".swap_lalt_lgui: ");
-    print_dec(kc.swap_lalt_lgui);
-    print("\n");
-    print(".swap_ralt_rgui: ");
-    print_dec(kc.swap_ralt_rgui);
-    print("\n");
-    print(".no_gui: ");
-    print_dec(kc.no_gui);
-    print("\n");
-    print(".swap_grave_esc: ");
-    print_dec(kc.swap_grave_esc);
-    print("\n");
-    print(".swap_backslash_backspace: ");
-    print_dec(kc.swap_backslash_backspace);
-    print("\n");
-    print(".nkro: ");
-    print_dec(kc.nkro);
-    print("\n");
+    xprintf(
+        "keymap_config.raw: %02X\n"
+        ".swap_control_capslock: %u\n"
+        ".capslock_to_control: %u\n"
+        ".swap_lctl_lgui: %u\n"
+        ".swap_rctl_rgui: %u\n"
+        ".swap_lalt_lgui: %u\n"
+        ".swap_ralt_rgui: %u\n"
+        ".no_gui: %u\n"
+        ".swap_grave_esc: %u\n"
+        ".swap_backslash_backspace: %u\n"
+        ".nkro: %u\n"
+
+        , kc.raw
+        , kc.swap_control_capslock
+        , kc.capslock_to_control
+        , kc.swap_lctl_lgui
+        , kc.swap_rctl_rgui
+        , kc.swap_lalt_lgui
+        , kc.swap_ralt_rgui
+        , kc.no_gui
+        , kc.swap_grave_esc
+        , kc.swap_backslash_backspace
+        , kc.nkro
+    );
 
 #    ifdef BACKLIGHT_ENABLE
     backlight_config_t bc;
     bc.raw = eeconfig_read_backlight();
-    print("backlight_config.raw: ");
-    print_hex8(bc.raw);
-    print("\n");
-    print(".enable: ");
-    print_dec(bc.enable);
-    print("\n");
-    print(".level: ");
-    print_dec(bc.level);
-    print("\n");
+
+    xprintf(
+        "backlight_config.raw: %02X\n"
+        ".enable: %u\n"
+        ".level: %u\n"
+
+        , bc.raw
+        , bc.enable
+        , bc.level
+    );
 #    endif /* BACKLIGHT_ENABLE */
 
 #endif /* !NO_PRINT */
@@ -330,7 +333,6 @@ static bool command_common(uint8_t code) {
 
         // print stored eeprom config
         case MAGIC_KC(MAGIC_KEY_EEPROM):
-            print("eeconfig:\n");
             print_eeconfig();
             break;
 
@@ -543,7 +545,8 @@ static bool command_console(uint8_t code) {
         case KC_H:
         case KC_SLASH: /* ? */
             command_console_help();
-            break;
+            print("C> ");
+            return true;
         case KC_Q:
         case KC_ESC:
             command_state = ONESHOT;
@@ -559,8 +562,6 @@ static bool command_console(uint8_t code) {
             print("?");
             return false;
     }
-    print("C> ");
-    return true;
 }
 
 #if defined(MOUSEKEY_ENABLE) && !defined(MK_3_SPEED)
@@ -572,25 +573,23 @@ static uint8_t mousekey_param = 0;
 static void mousekey_param_print(void) {
 // Print these variables if NO_PRINT or USER_PRINT are not defined.
 #    if !defined(NO_PRINT) && !defined(USER_PRINT)
-    print("\n\t- Values -\n");
-    print("1: delay(*10ms): ");
-    pdec(mk_delay);
-    print("\n");
-    print("2: interval(ms): ");
-    pdec(mk_interval);
-    print("\n");
-    print("3: max_speed: ");
-    pdec(mk_max_speed);
-    print("\n");
-    print("4: time_to_max: ");
-    pdec(mk_time_to_max);
-    print("\n");
-    print("5: wheel_max_speed: ");
-    pdec(mk_wheel_max_speed);
-    print("\n");
-    print("6: wheel_time_to_max: ");
-    pdec(mk_wheel_time_to_max);
-    print("\n");
+    xprintf("\n\t- Values -\n"
+
+        "1: delay(*10ms): %u\n"
+        "2: interval(ms): %u\n"
+        "3: max_speed: %u\n"
+        "4: time_to_max: %u\n"
+        "5: wheel_max_speed: %u\n"
+        "6: wheel_time_to_max: %u\n"
+
+        , mk_delay
+        , mk_interval
+        , mk_max_speed
+        , mk_time_to_max
+        , mk_wheel_max_speed
+        , mk_wheel_time_to_max
+
+        );
 #    endif /* !NO_PRINT */
 }
 

--- a/quantum/command.c
+++ b/quantum/command.c
@@ -104,93 +104,117 @@ bool command_console_extra(uint8_t code) {
  * Command common
  ***********************************************************/
 static void command_common_help(void) {
-    print("\n\t- Magic -\n" STR(MAGIC_KEY_DEBUG) ":	Debug Message Toggle\n" STR(MAGIC_KEY_DEBUG_MATRIX) ":	Matrix Debug Mode Toggle - Show keypresses in matrix grid\n" STR(MAGIC_KEY_DEBUG_KBD) ":	Keyboard Debug Toggle - Show keypress report\n" STR(MAGIC_KEY_DEBUG_MOUSE) ":	Debug Mouse Toggle\n" STR(MAGIC_KEY_VERSION) ":	Version\n" STR(MAGIC_KEY_STATUS) ":	Status\n" STR(MAGIC_KEY_CONSOLE) ":	Activate Console Mode\n"
+    print("\n\t- Magic -\n"
+
+        STR(MAGIC_KEY_DEBUG) ":	Debug Message Toggle\n"
+        STR(MAGIC_KEY_DEBUG_MATRIX) ":	Matrix Debug Mode Toggle"
+            " - Show keypresses in matrix grid\n"
+        STR(MAGIC_KEY_DEBUG_KBD) ":	Keyboard Debug Toggle"
+            " - Show keypress report\n"
+        STR(MAGIC_KEY_DEBUG_MOUSE) ":	Debug Mouse Toggle\n"
+        STR(MAGIC_KEY_VERSION) ":	Version\n"
+        STR(MAGIC_KEY_STATUS) ":	Status\n"
+        STR(MAGIC_KEY_CONSOLE) ":	Activate Console Mode\n"
 
 #if MAGIC_KEY_SWITCH_LAYER_WITH_CUSTOM
-          STR(MAGIC_KEY_LAYER0) ":	Switch to Layer 0\n" STR(MAGIC_KEY_LAYER1) ":	Switch to Layer 1\n" STR(MAGIC_KEY_LAYER2) ":	Switch to Layer 2\n" STR(MAGIC_KEY_LAYER3) ":	Switch to Layer 3\n" STR(MAGIC_KEY_LAYER4) ":	Switch to Layer 4\n" STR(MAGIC_KEY_LAYER5) ":	Switch to Layer 5\n" STR(MAGIC_KEY_LAYER6) ":	Switch to Layer 6\n" STR(MAGIC_KEY_LAYER7) ":	Switch to Layer 7\n" STR(MAGIC_KEY_LAYER8) ":	Switch to Layer 8\n" STR(MAGIC_KEY_LAYER9) ":	Switch to Layer 9\n"
+        STR(MAGIC_KEY_LAYER0) ":	Switch to Layer 0\n"
+        STR(MAGIC_KEY_LAYER1) ":	Switch to Layer 1\n"
+        STR(MAGIC_KEY_LAYER2) ":	Switch to Layer 2\n"
+        STR(MAGIC_KEY_LAYER3) ":	Switch to Layer 3\n"
+        STR(MAGIC_KEY_LAYER4) ":	Switch to Layer 4\n"
+        STR(MAGIC_KEY_LAYER5) ":	Switch to Layer 5\n"
+        STR(MAGIC_KEY_LAYER6) ":	Switch to Layer 6\n"
+        STR(MAGIC_KEY_LAYER7) ":	Switch to Layer 7\n"
+        STR(MAGIC_KEY_LAYER8) ":	Switch to Layer 8\n"
+        STR(MAGIC_KEY_LAYER9) ":	Switch to Layer 9\n"
 #endif
 
 #if MAGIC_KEY_SWITCH_LAYER_WITH_FKEYS
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                               "F1-F10:	Switch to Layer 0-9 (F10 = L0)\n"
+        "F1-F10:	Switch to Layer 0-9 (F10 = L0)\n"
 #endif
 
 #if MAGIC_KEY_SWITCH_LAYER_WITH_NKEYS
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                               "0-9:	Switch to Layer 0-9\n"
+        "0-9:	Switch to Layer 0-9\n"
 #endif
 
-          STR(MAGIC_KEY_LAYER0_ALT) ":	Switch to Layer 0 (alternate)\n"
+        STR(MAGIC_KEY_LAYER0_ALT) ":	Switch to Layer 0 (alternate)\n"
 
-          STR(MAGIC_KEY_BOOTLOADER) ":	Jump to Bootloader\n" STR(MAGIC_KEY_BOOTLOADER_ALT) ":	Jump to Bootloader (alternate)\n"
+        STR(MAGIC_KEY_BOOTLOADER) ":	Jump to Bootloader\n"
+        STR(MAGIC_KEY_BOOTLOADER_ALT) ":	Jump to Bootloader (alternate)\n"
 
 #ifdef KEYBOARD_LOCK_ENABLE
-          STR(MAGIC_KEY_LOCK) ":	Lock Keyboard\n"
+        STR(MAGIC_KEY_LOCK) ":	Lock Keyboard\n"
 #endif
 
-          STR(MAGIC_KEY_EEPROM) ":	Print EEPROM Settings\n" STR(MAGIC_KEY_EEPROM_CLEAR) ":	Clear EEPROM\n"
+        STR(MAGIC_KEY_EEPROM) ":	Print EEPROM Settings\n"
+        STR(MAGIC_KEY_EEPROM_CLEAR) ":	Clear EEPROM\n"
 
 #ifdef NKRO_ENABLE
-          STR(MAGIC_KEY_NKRO) ":	NKRO Toggle\n"
+        STR(MAGIC_KEY_NKRO) ":	NKRO Toggle\n"
 #endif
 
 #ifdef SLEEP_LED_ENABLE
-          STR(MAGIC_KEY_SLEEP_LED) ":	Sleep LED Test\n"
+        STR(MAGIC_KEY_SLEEP_LED) ":	Sleep LED Test\n"
 #endif
     );
 }
 
 static void print_version(void) {
     // print version & information
-    print("\n\t- Version -\n");
-    print("VID: " STR(VENDOR_ID) "(" STR(MANUFACTURER) ") "
-                                                       "PID: " STR(PRODUCT_ID) "(" STR(PRODUCT) ") "
-                                                                                                "VER: " STR(DEVICE_VER) "\n");
-    print("BUILD:  (" __DATE__ ")\n");
+    print("\n\t- Version -\n"
+        "VID: " STR(VENDOR_ID) "(" STR(MANUFACTURER) ") "
+        "PID: " STR(PRODUCT_ID) "(" STR(PRODUCT) ") "
+        "VER: " STR(DEVICE_VER) "\n"
+        "BUILD:  (" __DATE__ ")\n"
 #ifndef SKIP_VERSION
 #    ifdef PROTOCOL_CHIBIOS
-    print("CHIBIOS: " STR(CHIBIOS_VERSION) ", CONTRIB: " STR(CHIBIOS_CONTRIB_VERSION) "\n");
+        "CHIBIOS: " STR(CHIBIOS_VERSION)
+            ", CONTRIB: " STR(CHIBIOS_CONTRIB_VERSION) "\n"
 #    endif
 #endif
 
     /* build options */
-    print("OPTIONS:"
+        "OPTIONS:"
 
 #ifdef PROTOCOL_LUFA
-          " LUFA"
+        " LUFA"
 #endif
 #ifdef PROTOCOL_VUSB
-          " VUSB"
+        " VUSB"
 #endif
 #ifdef BOOTMAGIC_ENABLE
-          " BOOTMAGIC"
+        " BOOTMAGIC"
 #endif
 #ifdef MOUSEKEY_ENABLE
-          " MOUSEKEY"
+        " MOUSEKEY"
 #endif
 #ifdef EXTRAKEY_ENABLE
-          " EXTRAKEY"
+        " EXTRAKEY"
 #endif
 #ifdef CONSOLE_ENABLE
-          " CONSOLE"
+        " CONSOLE"
 #endif
 #ifdef COMMAND_ENABLE
-          " COMMAND"
+        " COMMAND"
 #endif
 #ifdef NKRO_ENABLE
-          " NKRO"
+        " NKRO"
 #endif
 #ifdef LTO_ENABLE
-          " LTO"
+        " LTO"
 #endif
 
-          " " STR(BOOTLOADER_SIZE) "\n");
+        " " STR(BOOTLOADER_SIZE) "\n"
 
-    print("GCC: " STR(__GNUC__) "." STR(__GNUC_MINOR__) "." STR(__GNUC_PATCHLEVEL__)
+        "GCC: " STR(__GNUC__)
+            "." STR(__GNUC_MINOR__)
+            "." STR(__GNUC_PATCHLEVEL__)
 #if defined(__AVR__)
-              " AVR-LIBC: " __AVR_LIBC_VERSION_STRING__ " AVR_ARCH: avr" STR(__AVR_ARCH__)
+        " AVR-LIBC: " __AVR_LIBC_VERSION_STRING__
+        " AVR_ARCH: avr" STR(__AVR_ARCH__)
 #endif
-                  "\n");
-
-    return;
+        "\n"
+    );
 }
 
 static void print_status(void) {

--- a/quantum/command.c
+++ b/quantum/command.c
@@ -581,12 +581,12 @@ static void mousekey_param_print(void) {
         "5: wheel_max_speed: %u\n"
         "6: wheel_time_to_max: %u\n"
 
-        , mk_delay
-        , mk_interval
-        , mk_max_speed
-        , mk_time_to_max
-        , mk_wheel_max_speed
-        , mk_wheel_time_to_max
+        , mouse.delay
+        , mouse.interval
+        , mouse.max_speed
+        , mouse.time_to_max
+        , wheel.max_speed
+        , wheel.time_to_max
 
         );
 #    endif /* !NO_PRINT */
@@ -647,12 +647,12 @@ static bool mousekey_console(uint8_t code) {
             param = 1 + code - KC_1;
 #           define PARAM(n, v) case n: pp = &(v); desc = #v; break
             switch (param) {
-                PARAM(1, mk_delay);
-                PARAM(2, mk_interval);
-                PARAM(3, mk_max_speed);
-                PARAM(4, mk_time_to_max);
-                PARAM(5, mk_wheel_max_speed);
-                PARAM(6, mk_wheel_time_to_max);
+                PARAM(1, mouse.delay);
+                PARAM(2, mouse.interval);
+                PARAM(3, mouse.max_speed);
+                PARAM(4, mouse.time_to_max);
+                PARAM(5, wheel.max_speed);
+                PARAM(6, wheel.time_to_max);
             }
 #           undef PARAM
             break;
@@ -661,12 +661,12 @@ static bool mousekey_console(uint8_t code) {
         case KC_PGUP: change = +10; break;
         case KC_PGDN: change = -10; break;
         case KC_D:
-            mk_delay             = MOUSEKEY_DELAY / 10;
-            mk_interval          = MOUSEKEY_INTERVAL;
-            mk_max_speed         = MOUSEKEY_MAX_SPEED;
-            mk_time_to_max       = MOUSEKEY_TIME_TO_MAX;
-            mk_wheel_max_speed   = MOUSEKEY_WHEEL_MAX_SPEED;
-            mk_wheel_time_to_max = MOUSEKEY_WHEEL_TIME_TO_MAX;
+            mouse.delay       = MOUSEKEY_DELAY / 10;
+            mouse.interval    = MOUSEKEY_INTERVAL;
+            mouse.max_speed   = MOUSEKEY_MAX_SPEED;
+            mouse.time_to_max = MOUSEKEY_TIME_TO_MAX;
+            wheel.max_speed   = MOUSEKEY_WHEEL_MAX_SPEED;
+            wheel.time_to_max = MOUSEKEY_WHEEL_TIME_TO_MAX;
             print("set default\n");
             break;
         default:

--- a/quantum/command.h
+++ b/quantum/command.h
@@ -28,7 +28,6 @@ bool command_extra(uint8_t code);
 bool command_console_extra(uint8_t code);
 
 #ifdef COMMAND_ENABLE
-uint8_t numkey2num(uint8_t code);
 bool    command_proc(uint8_t code);
 #else
 #    define command_proc(code) false

--- a/tmk_core/common/mousekey.c
+++ b/tmk_core/common/mousekey.c
@@ -49,19 +49,8 @@ static uint16_t last_timer_w = 0;
  *  speed = delta * max_speed * (repeat / time_to_max)**((1000+curve)/1000)
  */
 
-mousekey_t mouse = {
-    .delay       = MOUSEKEY_DELAY / 10,
-    .interval    = MOUSEKEY_INTERVAL,
-    .max_speed   = MOUSEKEY_MAX_SPEED,
-    .time_to_max = MOUSEKEY_TIME_TO_MAX
-};
-
-mousekey_t wheel = {
-    .delay       = MOUSEKEY_WHEEL_DELAY / 10,
-    .interval    = MOUSEKEY_WHEEL_INTERVAL,
-    .max_speed   = MOUSEKEY_WHEEL_MAX_SPEED,
-    .time_to_max = MOUSEKEY_WHEEL_TIME_TO_MAX
-};
+mousekey_t mouse = MOUSEKEY_MOUSE_DEFAULT;
+mousekey_t wheel = MOUSEKEY_WHEEL_DEFAULT;
 
 // G G G G-Unit!
 static uint16_t g_unit(const mousekey_t *what, uint8_t repeat, uint8_t delta) {

--- a/tmk_core/common/mousekey.c
+++ b/tmk_core/common/mousekey.c
@@ -48,40 +48,37 @@ static uint16_t last_timer_w = 0;
  *
  *  speed = delta * max_speed * (repeat / time_to_max)**((1000+curve)/1000)
  */
-/* milliseconds between the initial key press and first repeated motion event (0-2550) */
-uint8_t mk_delay = MOUSEKEY_DELAY / 10;
-/* milliseconds between repeated motion events (0-255) */
-uint8_t mk_interval = MOUSEKEY_INTERVAL;
-/* steady speed (in action_delta units) applied each event (0-255) */
-uint8_t mk_max_speed = MOUSEKEY_MAX_SPEED;
-/* number of events (count) accelerating to steady speed (0-255) */
-uint8_t mk_time_to_max = MOUSEKEY_TIME_TO_MAX;
-/* ramp used to reach maximum pointer speed (NOT SUPPORTED) */
-// int8_t mk_curve = 0;
-/* wheel params */
-/* milliseconds between the initial key press and first repeated motion event (0-2550) */
-uint8_t mk_wheel_delay = MOUSEKEY_WHEEL_DELAY / 10;
-/* milliseconds between repeated motion events (0-255) */
-uint8_t mk_wheel_interval    = MOUSEKEY_WHEEL_INTERVAL;
-uint8_t mk_wheel_max_speed   = MOUSEKEY_WHEEL_MAX_SPEED;
-uint8_t mk_wheel_time_to_max = MOUSEKEY_WHEEL_TIME_TO_MAX;
+
+mousekey_t mouse = {
+    .delay       = MOUSEKEY_DELAY / 10,
+    .interval    = MOUSEKEY_INTERVAL,
+    .max_speed   = MOUSEKEY_MAX_SPEED,
+    .time_to_max = MOUSEKEY_TIME_TO_MAX
+};
+
+mousekey_t wheel = {
+    .delay       = MOUSEKEY_WHEEL_DELAY / 10,
+    .interval    = MOUSEKEY_WHEEL_INTERVAL,
+    .max_speed   = MOUSEKEY_WHEEL_MAX_SPEED,
+    .time_to_max = MOUSEKEY_WHEEL_TIME_TO_MAX
+};
 
 #    ifndef MK_COMBINED
 
 static uint8_t move_unit(void) {
     uint16_t unit;
     if (mousekey_accel & (1 << 0)) {
-        unit = (MOUSEKEY_MOVE_DELTA * mk_max_speed) / 4;
+        unit = (MOUSEKEY_MOVE_DELTA * mouse.max_speed) / 4;
     } else if (mousekey_accel & (1 << 1)) {
-        unit = (MOUSEKEY_MOVE_DELTA * mk_max_speed) / 2;
+        unit = (MOUSEKEY_MOVE_DELTA * mouse.max_speed) / 2;
     } else if (mousekey_accel & (1 << 2)) {
-        unit = (MOUSEKEY_MOVE_DELTA * mk_max_speed);
+        unit = (MOUSEKEY_MOVE_DELTA * mouse.max_speed);
     } else if (mousekey_repeat == 0) {
         unit = MOUSEKEY_MOVE_DELTA;
-    } else if (mousekey_repeat >= mk_time_to_max) {
-        unit = MOUSEKEY_MOVE_DELTA * mk_max_speed;
+    } else if (mousekey_repeat >= mouse.time_to_max) {
+        unit = MOUSEKEY_MOVE_DELTA * mouse.max_speed;
     } else {
-        unit = (MOUSEKEY_MOVE_DELTA * mk_max_speed * mousekey_repeat) / mk_time_to_max;
+        unit = (MOUSEKEY_MOVE_DELTA * mouse.max_speed * mousekey_repeat) / mouse.time_to_max;
     }
     return (unit > MOUSEKEY_MOVE_MAX ? MOUSEKEY_MOVE_MAX : (unit == 0 ? 1 : unit));
 }
@@ -89,17 +86,17 @@ static uint8_t move_unit(void) {
 static uint8_t wheel_unit(void) {
     uint16_t unit;
     if (mousekey_accel & (1 << 0)) {
-        unit = (MOUSEKEY_WHEEL_DELTA * mk_wheel_max_speed) / 4;
+        unit = (MOUSEKEY_WHEEL_DELTA * wheel.max_speed) / 4;
     } else if (mousekey_accel & (1 << 1)) {
-        unit = (MOUSEKEY_WHEEL_DELTA * mk_wheel_max_speed) / 2;
+        unit = (MOUSEKEY_WHEEL_DELTA * wheel.max_speed) / 2;
     } else if (mousekey_accel & (1 << 2)) {
-        unit = (MOUSEKEY_WHEEL_DELTA * mk_wheel_max_speed);
+        unit = (MOUSEKEY_WHEEL_DELTA * wheel.max_speed);
     } else if (mousekey_wheel_repeat == 0) {
         unit = MOUSEKEY_WHEEL_DELTA;
-    } else if (mousekey_wheel_repeat >= mk_wheel_time_to_max) {
-        unit = MOUSEKEY_WHEEL_DELTA * mk_wheel_max_speed;
+    } else if (mousekey_wheel_repeat >= wheel.time_to_max) {
+        unit = MOUSEKEY_WHEEL_DELTA * wheel.max_speed;
     } else {
-        unit = (MOUSEKEY_WHEEL_DELTA * mk_wheel_max_speed * mousekey_wheel_repeat) / mk_wheel_time_to_max;
+        unit = (MOUSEKEY_WHEEL_DELTA * wheel.max_speed * mousekey_wheel_repeat) / wheel.time_to_max;
     }
     return (unit > MOUSEKEY_WHEEL_MAX ? MOUSEKEY_WHEEL_MAX : (unit == 0 ? 1 : unit));
 }
@@ -111,15 +108,15 @@ static uint8_t move_unit(void) {
     if (mousekey_accel & (1 << 0)) {
         unit = 1;
     } else if (mousekey_accel & (1 << 1)) {
-        unit = (MOUSEKEY_MOVE_DELTA * mk_max_speed) / 2;
+        unit = (MOUSEKEY_MOVE_DELTA * mouse.max_speed) / 2;
     } else if (mousekey_accel & (1 << 2)) {
         unit = MOUSEKEY_MOVE_MAX;
     } else if (mousekey_repeat == 0) {
         unit = MOUSEKEY_MOVE_DELTA;
-    } else if (mousekey_repeat >= mk_time_to_max) {
-        unit = MOUSEKEY_MOVE_DELTA * mk_max_speed;
+    } else if (mousekey_repeat >= mouse.time_to_max) {
+        unit = MOUSEKEY_MOVE_DELTA * mouse.max_speed;
     } else {
-        unit = (MOUSEKEY_MOVE_DELTA * mk_max_speed * mousekey_repeat) / mk_time_to_max;
+        unit = (MOUSEKEY_MOVE_DELTA * mouse.max_speed * mousekey_repeat) / mouse.time_to_max;
     }
     return (unit > MOUSEKEY_MOVE_MAX ? MOUSEKEY_MOVE_MAX : (unit == 0 ? 1 : unit));
 }
@@ -129,15 +126,15 @@ static uint8_t wheel_unit(void) {
     if (mousekey_accel & (1 << 0)) {
         unit = 1;
     } else if (mousekey_accel & (1 << 1)) {
-        unit = (MOUSEKEY_WHEEL_DELTA * mk_wheel_max_speed) / 2;
+        unit = (MOUSEKEY_WHEEL_DELTA * wheel.max_speed) / 2;
     } else if (mousekey_accel & (1 << 2)) {
         unit = MOUSEKEY_WHEEL_MAX;
     } else if (mousekey_repeat == 0) {
         unit = MOUSEKEY_WHEEL_DELTA;
-    } else if (mousekey_repeat >= mk_wheel_time_to_max) {
-        unit = MOUSEKEY_WHEEL_DELTA * mk_wheel_max_speed;
+    } else if (mousekey_repeat >= wheel.time_to_max) {
+        unit = MOUSEKEY_WHEEL_DELTA * wheel.max_speed;
     } else {
-        unit = (MOUSEKEY_WHEEL_DELTA * mk_wheel_max_speed * mousekey_repeat) / mk_wheel_time_to_max;
+        unit = (MOUSEKEY_WHEEL_DELTA * wheel.max_speed * mousekey_repeat) / wheel.time_to_max;
     }
     return (unit > MOUSEKEY_WHEEL_MAX ? MOUSEKEY_WHEEL_MAX : (unit == 0 ? 1 : unit));
 }
@@ -153,7 +150,7 @@ void mousekey_task(void) {
     mouse_report.v = 0;
     mouse_report.h = 0;
 
-    if ((tmpmr.x || tmpmr.y) && timer_elapsed(last_timer_c) > (mousekey_repeat ? mk_interval : mk_delay * 10)) {
+    if ((tmpmr.x || tmpmr.y) && timer_elapsed(last_timer_c) > (mousekey_repeat ? mouse.interval : mouse.delay * 10)) {
         if (mousekey_repeat != UINT8_MAX) mousekey_repeat++;
         if (tmpmr.x != 0) mouse_report.x = move_unit() * ((tmpmr.x > 0) ? 1 : -1);
         if (tmpmr.y != 0) mouse_report.y = move_unit() * ((tmpmr.y > 0) ? 1 : -1);
@@ -170,7 +167,7 @@ void mousekey_task(void) {
             }
         }
     }
-    if ((tmpmr.v || tmpmr.h) && timer_elapsed(last_timer_w) > (mousekey_wheel_repeat ? mk_wheel_interval : mk_wheel_delay * 10)) {
+    if ((tmpmr.v || tmpmr.h) && timer_elapsed(last_timer_w) > (mousekey_wheel_repeat ? wheel.interval : wheel.delay * 10)) {
         if (mousekey_wheel_repeat != UINT8_MAX) mousekey_wheel_repeat++;
         if (tmpmr.v != 0) mouse_report.v = wheel_unit() * ((tmpmr.v > 0) ? 1 : -1);
         if (tmpmr.h != 0) mouse_report.h = wheel_unit() * ((tmpmr.h > 0) ? 1 : -1);

--- a/tmk_core/common/mousekey.c
+++ b/tmk_core/common/mousekey.c
@@ -31,16 +31,115 @@ inline int8_t times_inv_sqrt2(int8_t x) {
     return (x * 181) >> 8;
 }
 
-static report_mouse_t mouse_report = {0};
-static void           mousekey_debug(void);
-static uint8_t        mousekey_accel        = 0;
-static uint8_t        mousekey_repeat       = 0;
-static uint8_t        mousekey_wheel_repeat = 0;
+typedef struct {
+    int8_t x, y;
+} move_t;
+
+static move_t bishop(const move_t sm, const int8_t unit) {
+    move_t m = {};
+    int8_t sig_x = 0;
+    int8_t sig_y = 0;
+
+    if (sm.x > 0) { m.x =  unit; sig_x =  1; }
+    if (sm.x < 0) { m.x = -unit; sig_x = -1; }
+    if (sm.y > 0) { m.y =  unit; sig_y =  1; }
+    if (sm.y < 0) { m.y = -unit; sig_y = -1; }
+
+    if (m.x && m.y) {
+        /* diagonal move [1/sqrt(2)] */
+        /* valid only when |x| ≡ |y| */
+        /* which is true for us here */
+        /* ensure we move at least 1 */
+        m.x = times_inv_sqrt2(m.x);
+        if (m.x == 0) m.x = sig_x;
+        m.y = times_inv_sqrt2(m.y);
+        if (m.y == 0) m.y = sig_y;
+    }
+
+    return m;
+}
+
+typedef struct {
+    uint16_t last_timer;
+    // move is {,re}set by mousekey_o{n,ff}(),
+    // but never updated by mousekey_task().
+    move_t move;
+#ifndef MK_3_SPEED
+    uint8_t repeat;
+#endif
+} state_t;
+
+static state_t mouse_state = {};
+static state_t wheel_state = {};
+static uint8_t buttons_state = 0;
 
 #ifndef MK_3_SPEED
 
-static uint16_t last_timer_c = 0;
-static uint16_t last_timer_w = 0;
+static uint8_t mousekey_accel = 0;
+mousekey_t mouse = MOUSEKEY_MOUSE_DEFAULT;
+mousekey_t wheel = MOUSEKEY_WHEEL_DEFAULT;
+
+#else // #ifndef MK_3_SPEED
+
+enum { mkspd_unmod, mkspd_0, mkspd_1, mkspd_2, mkspd_COUNT };
+#    ifndef MK_MOMENTARY_ACCEL
+static uint8_t mk_speed = mkspd_1;
+#    else
+static uint8_t mk_speed = mkspd_unmod;
+#    endif
+
+const int8_t c_offsets[mkspd_COUNT] = {MK_C_OFFSET_UNMOD, MK_C_OFFSET_0, MK_C_OFFSET_1, MK_C_OFFSET_2};
+const int8_t w_offsets[mkspd_COUNT] = {MK_W_OFFSET_UNMOD, MK_W_OFFSET_0, MK_W_OFFSET_1, MK_W_OFFSET_2};
+
+const uint16_t c_intervals[mkspd_COUNT] = {MK_C_INTERVAL_UNMOD, MK_C_INTERVAL_0, MK_C_INTERVAL_1, MK_C_INTERVAL_2};
+const uint16_t w_intervals[mkspd_COUNT] = {MK_W_INTERVAL_UNMOD, MK_W_INTERVAL_0, MK_W_INTERVAL_1, MK_W_INTERVAL_2};
+
+#endif // #ifndef MK_3_SPEED
+
+static void send_move(uint8_t btn, move_t m, move_t w) {
+    if (debug_mouse) {
+        xprintf("mousekey btn: %08b"
+                ", mouse x:%+3d y:%+3d"
+                ", wheel h:%+3d v:%+3d"
+#               ifndef MK_3_SPEED
+                ", repeat m:%2u w:%2u"
+                ", accel: %03b"
+#               else
+                ", speed: %u"
+#               endif
+            , btn
+            , m.x, m.y
+            , w.x, w.y
+
+#           ifndef MK_3_SPEED
+            , mouse_state.repeat
+            , wheel_state.repeat
+            , mousekey_accel
+#           else
+            , mk_speed
+#           endif
+            );
+    }
+
+    uint16_t time = timer_read();
+    if (m.x || m.y) mouse_state.last_timer = time;
+    if (w.x || w.y) wheel_state.last_timer = time;
+
+    report_mouse_t report = {
+        .buttons = buttons_state,
+        .x = mouse_state.move.x,
+        .y = mouse_state.move.y,
+        .h = wheel_state.move.x,
+        .v = wheel_state.move.y
+    };
+    host_mouse_send(&report);
+}
+
+void mousekey_send(void) {
+    send_move(buttons_state, mouse_state.move, wheel_state.move);
+}
+
+#ifndef MK_3_SPEED
 
 /*
  * Mouse keys  acceleration algorithm
@@ -48,9 +147,6 @@ static uint16_t last_timer_w = 0;
  *
  *  speed = delta * max_speed * (repeat / time_to_max)**((1000+curve)/1000)
  */
-
-mousekey_t mouse = MOUSEKEY_MOUSE_DEFAULT;
-mousekey_t wheel = MOUSEKEY_WHEEL_DEFAULT;
 
 // G G G G-Unit!
 static uint16_t g_unit(const mousekey_t *what, uint8_t repeat, uint8_t delta) {
@@ -83,306 +179,157 @@ static inline uint8_t clamp(uint8_t n, uint8_t min, uint8_t max) {
     return n;
 }
 
-#define move_unit()  clamp(g_unit(&mouse, mousekey_repeat,       MOUSEKEY_MOVE_DELTA),  1, MOUSEKEY_MOVE_MAX)
-#define wheel_unit() clamp(g_unit(&wheel, mousekey_wheel_repeat, MOUSEKEY_WHEEL_DELTA), 1, MOUSEKEY_WHEEL_MAX)
+static move_t mousekey_step(const mousekey_t * what, state_t * state, uint8_t delta, uint8_t max) {
+    if (!state->move.x && !state->move.y) return (move_t){};
+
+    uint16_t dur = state->repeat ? what->interval : what->delay * 10;
+    if (timer_elapsed(state->last_timer) < dur) return (move_t){};
+
+    if (state->repeat < UINT8_MAX)
+        state->repeat++;
+
+    int8_t unit = clamp(g_unit(what, state->repeat, delta), 1, max);
+    return bishop(state->move, unit);
+}
+
+#else // #ifndef MK_3_SPEED
+
+static move_t mousekey_step(state_t * state, uint16_t interval) {
+    if (state->move.x || state->move.y)
+    {
+        if (timer_elapsed(state->last_timer) > interval)
+            return state->move;
+    }
+    return (move_t){};
+}
+
+static void adjust_speed(void) {
+    mouse_state.move = bishop(mouse_state.move, c_offsets[mk_speed]);
+    wheel_state.move = bishop(wheel_state.move, w_offsets[mk_speed]);
+}
+
+#endif // #ifndef MK_3_SPEED
+
 
 void mousekey_task(void) {
-    // report cursor and scroll movement independently
-    report_mouse_t const tmpmr = mouse_report;
-
-    mouse_report.x = 0;
-    mouse_report.y = 0;
-    mouse_report.v = 0;
-    mouse_report.h = 0;
-
-    if ((tmpmr.x || tmpmr.y) && timer_elapsed(last_timer_c) > (mousekey_repeat ? mouse.interval : mouse.delay * 10)) {
-        if (mousekey_repeat != UINT8_MAX) mousekey_repeat++;
-        if (tmpmr.x != 0) mouse_report.x = move_unit() * ((tmpmr.x > 0) ? 1 : -1);
-        if (tmpmr.y != 0) mouse_report.y = move_unit() * ((tmpmr.y > 0) ? 1 : -1);
-
-        /* diagonal move [1/sqrt(2)] */
-        if (mouse_report.x && mouse_report.y) {
-            mouse_report.x = times_inv_sqrt2(mouse_report.x);
-            if (mouse_report.x == 0) {
-                mouse_report.x = 1;
-            }
-            mouse_report.y = times_inv_sqrt2(mouse_report.y);
-            if (mouse_report.y == 0) {
-                mouse_report.y = 1;
-            }
-        }
-    }
-    if ((tmpmr.v || tmpmr.h) && timer_elapsed(last_timer_w) > (mousekey_wheel_repeat ? wheel.interval : wheel.delay * 10)) {
-        if (mousekey_wheel_repeat != UINT8_MAX) mousekey_wheel_repeat++;
-        if (tmpmr.v != 0) mouse_report.v = wheel_unit() * ((tmpmr.v > 0) ? 1 : -1);
-        if (tmpmr.h != 0) mouse_report.h = wheel_unit() * ((tmpmr.h > 0) ? 1 : -1);
-
-        /* diagonal move [1/sqrt(2)] */
-        if (mouse_report.v && mouse_report.h) {
-            mouse_report.v = times_inv_sqrt2(mouse_report.v);
-            if (mouse_report.v == 0) {
-                mouse_report.v = 1;
-            }
-            mouse_report.h = times_inv_sqrt2(mouse_report.h);
-            if (mouse_report.h == 0) {
-                mouse_report.h = 1;
-            }
-        }
-    }
-
-    if (mouse_report.x || mouse_report.y || mouse_report.v || mouse_report.h) mousekey_send();
-    mouse_report = tmpmr;
+#ifndef MK_3_SPEED
+    move_t m = mousekey_step(&mouse, &mouse_state, MOUSEKEY_MOVE_DELTA,  MOUSEKEY_MOVE_MAX);
+    move_t w = mousekey_step(&wheel, &wheel_state, MOUSEKEY_WHEEL_DELTA, MOUSEKEY_WHEEL_MAX);
+#else
+    move_t m = mousekey_step(&mouse_state, c_intervals[mk_speed]);
+    move_t w = mousekey_step(&wheel_state, w_intervals[mk_speed]);
+#endif
+    if (m.x || m.y || w.x || w.y) send_move(0, m, w);
 }
+
+#define MOUSE_M mouse_state.move
+#define WHEEL_M wheel_state.move
 
 void mousekey_on(uint8_t code) {
-    if (code == KC_MS_UP)
-        mouse_report.y = move_unit() * -1;
-    else if (code == KC_MS_DOWN)
-        mouse_report.y = move_unit();
-    else if (code == KC_MS_LEFT)
-        mouse_report.x = move_unit() * -1;
-    else if (code == KC_MS_RIGHT)
-        mouse_report.x = move_unit();
-    else if (code == KC_MS_WH_UP)
-        mouse_report.v = wheel_unit();
-    else if (code == KC_MS_WH_DOWN)
-        mouse_report.v = wheel_unit() * -1;
-    else if (code == KC_MS_WH_LEFT)
-        mouse_report.h = wheel_unit() * -1;
-    else if (code == KC_MS_WH_RIGHT)
-        mouse_report.h = wheel_unit();
-    else if (code == KC_MS_BTN1)
-        mouse_report.buttons |= MOUSE_BTN1;
-    else if (code == KC_MS_BTN2)
-        mouse_report.buttons |= MOUSE_BTN2;
-    else if (code == KC_MS_BTN3)
-        mouse_report.buttons |= MOUSE_BTN3;
-    else if (code == KC_MS_BTN4)
-        mouse_report.buttons |= MOUSE_BTN4;
-    else if (code == KC_MS_BTN5)
-        mouse_report.buttons |= MOUSE_BTN5;
-    else if (code == KC_MS_ACCEL0)
-        mousekey_accel |= (1 << 0);
-    else if (code == KC_MS_ACCEL1)
-        mousekey_accel |= (1 << 1);
-    else if (code == KC_MS_ACCEL2)
-        mousekey_accel |= (1 << 2);
-}
-
-void mousekey_off(uint8_t code) {
-    if (code == KC_MS_UP && mouse_report.y < 0)
-        mouse_report.y = 0;
-    else if (code == KC_MS_DOWN && mouse_report.y > 0)
-        mouse_report.y = 0;
-    else if (code == KC_MS_LEFT && mouse_report.x < 0)
-        mouse_report.x = 0;
-    else if (code == KC_MS_RIGHT && mouse_report.x > 0)
-        mouse_report.x = 0;
-    else if (code == KC_MS_WH_UP && mouse_report.v > 0)
-        mouse_report.v = 0;
-    else if (code == KC_MS_WH_DOWN && mouse_report.v < 0)
-        mouse_report.v = 0;
-    else if (code == KC_MS_WH_LEFT && mouse_report.h < 0)
-        mouse_report.h = 0;
-    else if (code == KC_MS_WH_RIGHT && mouse_report.h > 0)
-        mouse_report.h = 0;
-    else if (code == KC_MS_BTN1)
-        mouse_report.buttons &= ~MOUSE_BTN1;
-    else if (code == KC_MS_BTN2)
-        mouse_report.buttons &= ~MOUSE_BTN2;
-    else if (code == KC_MS_BTN3)
-        mouse_report.buttons &= ~MOUSE_BTN3;
-    else if (code == KC_MS_BTN4)
-        mouse_report.buttons &= ~MOUSE_BTN4;
-    else if (code == KC_MS_BTN5)
-        mouse_report.buttons &= ~MOUSE_BTN5;
-    else if (code == KC_MS_ACCEL0)
-        mousekey_accel &= ~(1 << 0);
-    else if (code == KC_MS_ACCEL1)
-        mousekey_accel &= ~(1 << 1);
-    else if (code == KC_MS_ACCEL2)
-        mousekey_accel &= ~(1 << 2);
-    if (mouse_report.x == 0 && mouse_report.y == 0) mousekey_repeat = 0;
-    if (mouse_report.v == 0 && mouse_report.h == 0) mousekey_wheel_repeat = 0;
-}
-
-#else /* #ifndef MK_3_SPEED */
-
-enum { mkspd_unmod, mkspd_0, mkspd_1, mkspd_2, mkspd_COUNT };
-#    ifndef MK_MOMENTARY_ACCEL
-static uint8_t  mk_speed                 = mkspd_1;
-#    else
-static uint8_t mk_speed      = mkspd_unmod;
-static uint8_t mkspd_DEFAULT = mkspd_unmod;
-#    endif
-static uint16_t last_timer_c             = 0;
-static uint16_t last_timer_w             = 0;
-uint16_t        c_offsets[mkspd_COUNT]   = {MK_C_OFFSET_UNMOD, MK_C_OFFSET_0, MK_C_OFFSET_1, MK_C_OFFSET_2};
-uint16_t        c_intervals[mkspd_COUNT] = {MK_C_INTERVAL_UNMOD, MK_C_INTERVAL_0, MK_C_INTERVAL_1, MK_C_INTERVAL_2};
-uint16_t        w_offsets[mkspd_COUNT]   = {MK_W_OFFSET_UNMOD, MK_W_OFFSET_0, MK_W_OFFSET_1, MK_W_OFFSET_2};
-uint16_t        w_intervals[mkspd_COUNT] = {MK_W_INTERVAL_UNMOD, MK_W_INTERVAL_0, MK_W_INTERVAL_1, MK_W_INTERVAL_2};
-
-void mousekey_task(void) {
-    // report cursor and scroll movement independently
-    report_mouse_t const tmpmr = mouse_report;
-    mouse_report.x             = 0;
-    mouse_report.y             = 0;
-    mouse_report.v             = 0;
-    mouse_report.h             = 0;
-
-    if ((tmpmr.x || tmpmr.y) && timer_elapsed(last_timer_c) > c_intervals[mk_speed]) {
-        mouse_report.x = tmpmr.x;
-        mouse_report.y = tmpmr.y;
-    }
-    if ((tmpmr.h || tmpmr.v) && timer_elapsed(last_timer_w) > w_intervals[mk_speed]) {
-        mouse_report.v = tmpmr.v;
-        mouse_report.h = tmpmr.h;
-    }
-
-    if (mouse_report.x || mouse_report.y || mouse_report.v || mouse_report.h) mousekey_send();
-    mouse_report = tmpmr;
-}
-
-void adjust_speed(void) {
-    uint16_t const c_offset = c_offsets[mk_speed];
-    uint16_t const w_offset = w_offsets[mk_speed];
-    if (mouse_report.x > 0) mouse_report.x = c_offset;
-    if (mouse_report.x < 0) mouse_report.x = c_offset * -1;
-    if (mouse_report.y > 0) mouse_report.y = c_offset;
-    if (mouse_report.y < 0) mouse_report.y = c_offset * -1;
-    if (mouse_report.h > 0) mouse_report.h = w_offset;
-    if (mouse_report.h < 0) mouse_report.h = w_offset * -1;
-    if (mouse_report.v > 0) mouse_report.v = w_offset;
-    if (mouse_report.v < 0) mouse_report.v = w_offset * -1;
-    // adjust for diagonals
-    if (mouse_report.x && mouse_report.y) {
-        mouse_report.x = times_inv_sqrt2(mouse_report.x);
-        if (mouse_report.x == 0) {
-            mouse_report.x = 1;
-        }
-        mouse_report.y = times_inv_sqrt2(mouse_report.y);
-        if (mouse_report.y == 0) {
-            mouse_report.y = 1;
-        }
-    }
-    if (mouse_report.h && mouse_report.v) {
-        mouse_report.h = times_inv_sqrt2(mouse_report.h);
-        mouse_report.v = times_inv_sqrt2(mouse_report.v);
-    }
-}
-
-void mousekey_on(uint8_t code) {
-    uint16_t const c_offset  = c_offsets[mk_speed];
-    uint16_t const w_offset  = w_offsets[mk_speed];
+#   ifdef MK_3_SPEED
     uint8_t const  old_speed = mk_speed;
-    if (code == KC_MS_UP)
-        mouse_report.y = c_offset * -1;
-    else if (code == KC_MS_DOWN)
-        mouse_report.y = c_offset;
-    else if (code == KC_MS_LEFT)
-        mouse_report.x = c_offset * -1;
-    else if (code == KC_MS_RIGHT)
-        mouse_report.x = c_offset;
-    else if (code == KC_MS_WH_UP)
-        mouse_report.v = w_offset;
-    else if (code == KC_MS_WH_DOWN)
-        mouse_report.v = w_offset * -1;
-    else if (code == KC_MS_WH_LEFT)
-        mouse_report.h = w_offset * -1;
-    else if (code == KC_MS_WH_RIGHT)
-        mouse_report.h = w_offset;
-    else if (code == KC_MS_BTN1)
-        mouse_report.buttons |= MOUSE_BTN1;
-    else if (code == KC_MS_BTN2)
-        mouse_report.buttons |= MOUSE_BTN2;
-    else if (code == KC_MS_BTN3)
-        mouse_report.buttons |= MOUSE_BTN3;
-    else if (code == KC_MS_BTN4)
-        mouse_report.buttons |= MOUSE_BTN4;
-    else if (code == KC_MS_BTN5)
-        mouse_report.buttons |= MOUSE_BTN5;
-    else if (code == KC_MS_ACCEL0)
-        mk_speed = mkspd_0;
-    else if (code == KC_MS_ACCEL1)
-        mk_speed = mkspd_1;
-    else if (code == KC_MS_ACCEL2)
-        mk_speed = mkspd_2;
+#   endif
+
+    switch (code)
+    {
+
+#   ifndef MK_3_SPEED
+#       define MOUSE_UNIT clamp(g_unit(&mouse, mouse_state.repeat, MOUSEKEY_MOVE_DELTA),  1, MOUSEKEY_MOVE_MAX)
+#       define WHEEL_UNIT clamp(g_unit(&wheel, wheel_state.repeat, MOUSEKEY_WHEEL_DELTA), 1, MOUSEKEY_WHEEL_MAX)
+#   else
+#       define MOUSE_UNIT c_offsets[mk_speed]
+#       define WHEEL_UNIT w_offsets[mk_speed]
+#   endif
+
+        case KC_MS_UP:       MOUSE_M.y = -MOUSE_UNIT; break;
+        case KC_MS_DOWN:     MOUSE_M.y =  MOUSE_UNIT; break;
+        case KC_MS_LEFT:     MOUSE_M.x = -MOUSE_UNIT; break;
+        case KC_MS_RIGHT:    MOUSE_M.x =  MOUSE_UNIT; break;
+
+        case KC_MS_WH_UP:    WHEEL_M.y =  WHEEL_UNIT; break;
+        case KC_MS_WH_DOWN:  WHEEL_M.y = -WHEEL_UNIT; break;
+        case KC_MS_WH_LEFT:  WHEEL_M.x = -WHEEL_UNIT; break;
+        case KC_MS_WH_RIGHT: WHEEL_M.x =  WHEEL_UNIT; break;
+
+#undef MOUSE_UNIT
+#undef WHEEL_UNIT
+
+        case KC_MS_BTN1: buttons_state |=  MOUSE_BTN1; break;
+        case KC_MS_BTN2: buttons_state |=  MOUSE_BTN2; break;
+        case KC_MS_BTN3: buttons_state |=  MOUSE_BTN3; break;
+        case KC_MS_BTN4: buttons_state |=  MOUSE_BTN4; break;
+        case KC_MS_BTN5: buttons_state |=  MOUSE_BTN5; break;
+
+#       ifndef MK_3_SPEED
+        case KC_MS_ACCEL0: mousekey_accel |=  (1 << 0); break;
+        case KC_MS_ACCEL1: mousekey_accel |=  (1 << 1); break;
+        case KC_MS_ACCEL2: mousekey_accel |=  (1 << 2); break;
+#       else
+        case KC_MS_ACCEL0: mk_speed = mkspd_0;
+        case KC_MS_ACCEL1: mk_speed = mkspd_1;
+        case KC_MS_ACCEL2: mk_speed = mkspd_2;
+#       endif
+
+    }
+
+#   ifdef MK_3_SPEED
     if (mk_speed != old_speed) adjust_speed();
+#   endif
+
 }
 
 void mousekey_off(uint8_t code) {
-#    ifdef MK_MOMENTARY_ACCEL
+#   if defined(MK_3_SPEED) && defined(MK_MOMENTARY_ACCEL)
     uint8_t const old_speed = mk_speed;
-#    endif
-    if (code == KC_MS_UP && mouse_report.y < 0)
-        mouse_report.y = 0;
-    else if (code == KC_MS_DOWN && mouse_report.y > 0)
-        mouse_report.y = 0;
-    else if (code == KC_MS_LEFT && mouse_report.x < 0)
-        mouse_report.x = 0;
-    else if (code == KC_MS_RIGHT && mouse_report.x > 0)
-        mouse_report.x = 0;
-    else if (code == KC_MS_WH_UP && mouse_report.v > 0)
-        mouse_report.v = 0;
-    else if (code == KC_MS_WH_DOWN && mouse_report.v < 0)
-        mouse_report.v = 0;
-    else if (code == KC_MS_WH_LEFT && mouse_report.h < 0)
-        mouse_report.h = 0;
-    else if (code == KC_MS_WH_RIGHT && mouse_report.h > 0)
-        mouse_report.h = 0;
-    else if (code == KC_MS_BTN1)
-        mouse_report.buttons &= ~MOUSE_BTN1;
-    else if (code == KC_MS_BTN2)
-        mouse_report.buttons &= ~MOUSE_BTN2;
-    else if (code == KC_MS_BTN3)
-        mouse_report.buttons &= ~MOUSE_BTN3;
-    else if (code == KC_MS_BTN4)
-        mouse_report.buttons &= ~MOUSE_BTN4;
-    else if (code == KC_MS_BTN5)
-        mouse_report.buttons &= ~MOUSE_BTN5;
-#    ifdef MK_MOMENTARY_ACCEL
-    else if (code == KC_MS_ACCEL0)
-        mk_speed = mkspd_DEFAULT;
-    else if (code == KC_MS_ACCEL1)
-        mk_speed = mkspd_DEFAULT;
-    else if (code == KC_MS_ACCEL2)
-        mk_speed = mkspd_DEFAULT;
+#   endif
+
+    switch (code)
+    {
+
+        case KC_MS_UP:       if (MOUSE_M.y < 0) MOUSE_M.y = 0; break;
+        case KC_MS_DOWN:     if (MOUSE_M.y > 0) MOUSE_M.y = 0; break;
+        case KC_MS_LEFT:     if (MOUSE_M.x < 0) MOUSE_M.x = 0; break;
+        case KC_MS_RIGHT:    if (MOUSE_M.x > 0) MOUSE_M.x = 0; break;
+
+        case KC_MS_WH_UP:    if (WHEEL_M.y > 0) WHEEL_M.y = 0; break;
+        case KC_MS_WH_DOWN:  if (WHEEL_M.y < 0) WHEEL_M.y = 0; break;
+        case KC_MS_WH_LEFT:  if (WHEEL_M.x < 0) WHEEL_M.x = 0; break;
+        case KC_MS_WH_RIGHT: if (WHEEL_M.x > 0) WHEEL_M.x = 0; break;
+
+        case KC_MS_BTN1: buttons_state &= ~MOUSE_BTN1; break;
+        case KC_MS_BTN2: buttons_state &= ~MOUSE_BTN2; break;
+        case KC_MS_BTN3: buttons_state &= ~MOUSE_BTN3; break;
+        case KC_MS_BTN4: buttons_state &= ~MOUSE_BTN4; break;
+        case KC_MS_BTN5: buttons_state &= ~MOUSE_BTN5; break;
+
+#       ifndef MK_3_SPEED
+        case KC_MS_ACCEL0: mousekey_accel &= ~(1 << 0); break;
+        case KC_MS_ACCEL1: mousekey_accel &= ~(1 << 1); break;
+        case KC_MS_ACCEL2: mousekey_accel &= ~(1 << 2); break;
+#       elif defined(MK_MOMENTARY_ACCEL)
+        case KC_MS_ACCEL0 ... KC_MS_ACCEL2: mk_speed = mkspd_unmod; break;
+#       endif
+    }
+
+#   ifndef MK_3_SPEED
+    if (MOUSE_M.x == 0 && MOUSE_M.y == 0) mouse_state.repeat = 0;
+    if (WHEEL_M.x == 0 && WHEEL_M.y == 0) wheel_state.repeat = 0;
+#   elif defined(MK_MOMENTARY_ACCEL)
     if (mk_speed != old_speed) adjust_speed();
-#    endif
+#   endif
 }
 
-#endif /* #ifndef MK_3_SPEED */
-
-void mousekey_send(void) {
-    mousekey_debug();
-    uint16_t time = timer_read();
-    if (mouse_report.x || mouse_report.y) last_timer_c = time;
-    if (mouse_report.v || mouse_report.h) last_timer_w = time;
-    host_mouse_send(&mouse_report);
-}
+#undef MOUSE_M
+#undef WHEEL_M
 
 void mousekey_clear(void) {
-    mouse_report          = (report_mouse_t){};
-    mousekey_repeat       = 0;
-    mousekey_wheel_repeat = 0;
-    mousekey_accel        = 0;
+    // old behaviour was to preserve .last_timer
+    mouse_state.move   = (move_t){};
+    wheel_state.move   = (move_t){};
+#   ifndef MK_3_SPEED
+    mouse_state.repeat = 0;
+    wheel_state.repeat = 0;
+    mousekey_accel     = 0;
+#   endif
 }
 
-static void mousekey_debug(void) {
-    if (!debug_mouse) return;
-    print("mousekey [btn|x y v h](rep/acl): [");
-    phex(mouse_report.buttons);
-    print("|");
-    print_decs(mouse_report.x);
-    print(" ");
-    print_decs(mouse_report.y);
-    print(" ");
-    print_decs(mouse_report.v);
-    print(" ");
-    print_decs(mouse_report.h);
-    print("](");
-    print_dec(mousekey_repeat);
-    print("/");
-    print_dec(mousekey_accel);
-    print(")\n");
-}

--- a/tmk_core/common/mousekey.h
+++ b/tmk_core/common/mousekey.h
@@ -137,6 +137,22 @@ typedef struct {
     // int8_t curve = 0;
 } mousekey_t;
 
+#define MOUSEKEY_MOUSE_DEFAULT \
+{ \
+    .delay       = MOUSEKEY_DELAY / 10, \
+    .interval    = MOUSEKEY_INTERVAL, \
+    .max_speed   = MOUSEKEY_MAX_SPEED, \
+    .time_to_max = MOUSEKEY_TIME_TO_MAX \
+}
+
+#define MOUSEKEY_WHEEL_DEFAULT \
+{ \
+    .delay       = MOUSEKEY_WHEEL_DELAY / 10, \
+    .interval    = MOUSEKEY_WHEEL_INTERVAL, \
+    .max_speed   = MOUSEKEY_WHEEL_MAX_SPEED, \
+    .time_to_max = MOUSEKEY_WHEEL_TIME_TO_MAX \
+}
+
 extern mousekey_t mouse, wheel;
 
 void mousekey_task(void);

--- a/tmk_core/common/mousekey.h
+++ b/tmk_core/common/mousekey.h
@@ -124,12 +124,20 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 extern "C" {
 #endif
 
-extern uint8_t mk_delay;
-extern uint8_t mk_interval;
-extern uint8_t mk_max_speed;
-extern uint8_t mk_time_to_max;
-extern uint8_t mk_wheel_max_speed;
-extern uint8_t mk_wheel_time_to_max;
+typedef struct {
+    /* milliseconds between the initial key press and first repeated motion event (0-2550) */
+    uint8_t delay;
+    /* milliseconds between repeated motion events (0-255) */
+    uint8_t interval;
+    /* steady speed (in action_delta units) applied each event (0-255) */
+    uint8_t max_speed;
+    /* number of events (count) accelerating to steady speed (0-255) */
+    uint8_t time_to_max;
+    /* ramp used to reach maximum pointer speed (NOT SUPPORTED) */
+    // int8_t curve = 0;
+} mousekey_t;
+
+extern mousekey_t mouse, wheel;
 
 void mousekey_task(void);
 void mousekey_on(uint8_t code);

--- a/tmk_core/common/print.h
+++ b/tmk_core/common/print.h
@@ -149,17 +149,6 @@ extern "C"
 #        define print_bin_reverse8(data)
 #        define print_bin_reverse16(data)
 #        define print_bin_reverse32(data)
-#        define print_val_dec(v)
-#        define print_val_decs(v)
-#        define print_val_hex8(v)
-#        define print_val_hex16(v)
-#        define print_val_hex32(v)
-#        define print_val_bin8(v)
-#        define print_val_bin16(v)
-#        define print_val_bin32(v)
-#        define print_val_bin_reverse8(v)
-#        define print_val_bin_reverse16(v)
-#        define print_val_bin_reverse32(v)
 
 #    else /* NORMAL_PRINT */
 
@@ -180,18 +169,6 @@ extern "C"
 #        define print_bin_reverse8(i) xprintf("%08b", bitrev(i))
 #        define print_bin_reverse16(i) xprintf("%016b", bitrev16(i))
 #        define print_bin_reverse32(i) xprintf("%032lb", bitrev32(i))
-/* print value utility */
-#        define print_val_dec(v) xprintf(#        v ": %u\n", v)
-#        define print_val_decs(v) xprintf(#        v ": %d\n", v)
-#        define print_val_hex8(v) xprintf(#        v ": %X\n", v)
-#        define print_val_hex16(v) xprintf(#        v ": %02X\n", v)
-#        define print_val_hex32(v) xprintf(#        v ": %04lX\n", v)
-#        define print_val_bin8(v) xprintf(#        v ": %08b\n", v)
-#        define print_val_bin16(v) xprintf(#        v ": %016b\n", v)
-#        define print_val_bin32(v) xprintf(#        v ": %032lb\n", v)
-#        define print_val_bin_reverse8(v) xprintf(#        v ": %08b\n", bitrev(v))
-#        define print_val_bin_reverse16(v) xprintf(#        v ": %016b\n", bitrev16(v))
-#        define print_val_bin_reverse32(v) xprintf(#        v ": %032lb\n", bitrev32(v))
 
 #    endif /* USER_PRINT / NORMAL_PRINT */
 
@@ -213,18 +190,6 @@ extern "C"
 #    define uprint_bin_reverse8(i) uprintf("%08b", bitrev(i))
 #    define uprint_bin_reverse16(i) uprintf("%016b", bitrev16(i))
 #    define uprint_bin_reverse32(i) uprintf("%032lb", bitrev32(i))
-/* print value utility */
-#    define uprint_val_dec(v) uprintf(#    v ": %u\n", v)
-#    define uprint_val_decs(v) uprintf(#    v ": %d\n", v)
-#    define uprint_val_hex8(v) uprintf(#    v ": %X\n", v)
-#    define uprint_val_hex16(v) uprintf(#    v ": %02X\n", v)
-#    define uprint_val_hex32(v) uprintf(#    v ": %04lX\n", v)
-#    define uprint_val_bin8(v) uprintf(#    v ": %08b\n", v)
-#    define uprint_val_bin16(v) uprintf(#    v ": %016b\n", v)
-#    define uprint_val_bin32(v) uprintf(#    v ": %032lb\n", v)
-#    define uprint_val_bin_reverse8(v) uprintf(#    v ": %08b\n", bitrev(v))
-#    define uprint_val_bin_reverse16(v) uprintf(#    v ": %016b\n", bitrev16(v))
-#    define uprint_val_bin_reverse32(v) uprintf(#    v ": %032lb\n", bitrev32(v))
 
 #else /* NO_PRINT */
 
@@ -245,17 +210,6 @@ extern "C"
 #    define print_bin_reverse8(data)
 #    define print_bin_reverse16(data)
 #    define print_bin_reverse32(data)
-#    define print_val_dec(v)
-#    define print_val_decs(v)
-#    define print_val_hex8(v)
-#    define print_val_hex16(v)
-#    define print_val_hex32(v)
-#    define print_val_bin8(v)
-#    define print_val_bin16(v)
-#    define print_val_bin32(v)
-#    define print_val_bin_reverse8(v)
-#    define print_val_bin_reverse16(v)
-#    define print_val_bin_reverse32(v)
 
 #endif /* NO_PRINT */
 


### PR DESCRIPTION
## Description

**This is a WIP. I'll remove the [WIP] tag & poke relevant reviewers when ready.**

I accidentally a huge refactor. It improves the code size & {read,maintain}ability significantly.

Setting `MOUSEKEY_ENABLE` to `yes` _increases_ the firmware size on my ATmega32 as follows:

Code | [Mouse keys](http://en.wikipedia.org/wiki/Mouse_keys) | `MK_3_SPEED`
---- | ---- | ----
Pre-refactor | 3958B | 1612B
Post-refactor | 2532B | 1386B

`CONSOLE_ENABLE` and `COMMAND_ENABLE` are `yes` in all cases.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

Each commit has detailed comments, and I recommend reading them one-by-one. The entire PR diff might be a bit difficult to digest.

## Issues Fixed or Closed by This PR

* The `diagonal move [1/sqrt(2)]` code failed to preserve the sign of the move if `times_inv_sqrt2()` returns `0`.
* Fix `mousekey_console()`'s lack of awareness of `mk_wheel_{delay,interval}`. It was never updated after the “report cursor and scroll movement independently” changes.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
   - [ ] Run `clang-format`
   - [ ] Mandatory braces
   - [ ] `/* C-style */` comments
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
   - [ ] Rebase onto `develop` branch: conflict with `MK_KINETIC_SPEED` needs carefulling
- [ ] ~~My change requires a change to the documentation.~~
- [ ] ~~I have updated the documentation accordingly.~~
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] ~~I have added tests to cover my changes.~~
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
