### PR TITLE
Refactor `quantum/command.{c,h}` for code size & {read,maintain}ability

### DIFF
--- a/quantum/command.c
+++ b/quantum/command.c
@@ -220,99 +220,103 @@ static void print_version(void) {
 }
 
 static void print_status(void) {
-    print("\n\t- Status -\n");
+    xprintf(/* clang-format off */
+        "\n\t- Status -\n"
 
-    print_val_hex8(host_keyboard_leds());
+        "host_keyboard_leds(): %02X\n"
 #ifndef PROTOCOL_VUSB
-    // these aren't set on the V-USB protocol, so we just ignore them for now
-    print_val_hex8(keyboard_protocol);
-    print_val_hex8(keyboard_idle);
+        "keyboard_protocol: %02X\n"
+        "keyboard_idle: %02X\n"
 #endif
 #ifdef NKRO_ENABLE
-    print_val_hex8(keymap_config.nkro);
+        "keymap_config.nkro: %02X\n"
 #endif
-    print_val_hex32(timer_read32());
-    return;
+        "timer_read32(): %08lX\n"
+
+        , host_keyboard_leds()
+#ifndef PROTOCOL_VUSB
+        /* these aren't set on the V-USB protocol, so we just ignore them for now */
+        , keyboard_protocol
+        , keyboard_idle
+#endif
+#ifdef NKRO_ENABLE
+        , keymap_config.nkro
+#endif
+        , timer_read32()
+
+    ); /* clang-format on */
 }
 
-static void print_eeconfig(void) {
-// Print these variables if NO_PRINT or USER_PRINT are not defined.
 #if !defined(NO_PRINT) && !defined(USER_PRINT)
-
-    print("default_layer: ");
-    print_dec(eeconfig_read_default_layer());
-    print("\n");
+static void print_eeconfig(void) {
+    xprintf("eeconfig:\ndefault_layer: %u\n", eeconfig_read_default_layer());
 
     debug_config_t dc;
     dc.raw = eeconfig_read_debug();
-    print("debug_config.raw: ");
-    print_hex8(dc.raw);
-    print("\n");
-    print(".enable: ");
-    print_dec(dc.enable);
-    print("\n");
-    print(".matrix: ");
-    print_dec(dc.matrix);
-    print("\n");
-    print(".keyboard: ");
-    print_dec(dc.keyboard);
-    print("\n");
-    print(".mouse: ");
-    print_dec(dc.mouse);
-    print("\n");
+    xprintf(/* clang-format off */
+
+        "debug_config.raw: %02X\n"
+        ".enable: %u\n"
+        ".matrix: %u\n"
+        ".keyboard: %u\n"
+        ".mouse: %u\n"
+
+        , dc.raw
+        , dc.enable
+        , dc.matrix
+        , dc.keyboard
+        , dc.mouse
+    ); /* clang-format on */
 
     keymap_config_t kc;
     kc.raw = eeconfig_read_keymap();
-    print("keymap_config.raw: ");
-    print_hex8(kc.raw);
-    print("\n");
-    print(".swap_control_capslock: ");
-    print_dec(kc.swap_control_capslock);
-    print("\n");
-    print(".capslock_to_control: ");
-    print_dec(kc.capslock_to_control);
-    print("\n");
-    print(".swap_lctl_lgui: ");
-    print_dec(kc.swap_lctl_lgui);
-    print("\n");
-    print(".swap_rctl_rgui: ");
-    print_dec(kc.swap_rctl_rgui);
-    print("\n");
-    print(".swap_lalt_lgui: ");
-    print_dec(kc.swap_lalt_lgui);
-    print("\n");
-    print(".swap_ralt_rgui: ");
-    print_dec(kc.swap_ralt_rgui);
-    print("\n");
-    print(".no_gui: ");
-    print_dec(kc.no_gui);
-    print("\n");
-    print(".swap_grave_esc: ");
-    print_dec(kc.swap_grave_esc);
-    print("\n");
-    print(".swap_backslash_backspace: ");
-    print_dec(kc.swap_backslash_backspace);
-    print("\n");
-    print(".nkro: ");
-    print_dec(kc.nkro);
-    print("\n");
+    xprintf(/* clang-format off */
+
+        "keymap_config.raw: %02X\n"
+        ".swap_control_capslock: %u\n"
+        ".capslock_to_control: %u\n"
+        ".swap_lctl_lgui: %u\n"
+        ".swap_rctl_rgui: %u\n"
+        ".swap_lalt_lgui: %u\n"
+        ".swap_ralt_rgui: %u\n"
+        ".no_gui: %u\n"
+        ".swap_grave_esc: %u\n"
+        ".swap_backslash_backspace: %u\n"
+        ".nkro: %u\n"
+
+        , kc.raw
+        , kc.swap_control_capslock
+        , kc.capslock_to_control
+        , kc.swap_lctl_lgui
+        , kc.swap_rctl_rgui
+        , kc.swap_lalt_lgui
+        , kc.swap_ralt_rgui
+        , kc.no_gui
+        , kc.swap_grave_esc
+        , kc.swap_backslash_backspace
+        , kc.nkro
+    ); /* clang-format on */
 
 #    ifdef BACKLIGHT_ENABLE
+
     backlight_config_t bc;
     bc.raw = eeconfig_read_backlight();
-    print("backlight_config.raw: ");
-    print_hex8(bc.raw);
-    print("\n");
-    print(".enable: ");
-    print_dec(bc.enable);
-    print("\n");
-    print(".level: ");
-    print_dec(bc.level);
-    print("\n");
-#    endif /* BACKLIGHT_ENABLE */
+    xprintf(/* clang-format off */
+        "backlight_config"
 
-#endif /* !NO_PRINT */
+        ".raw: %02X\n"
+        ".enable: %u\n"
+        ".level: %u\n"
+
+        , bc.raw
+        , bc.enable
+        , bc.level
+
+    ); /* clang-format on */
+
+#    endif /* BACKLIGHT_ENABLE */
 }
+#endif /* !NO_PRINT && !USER_PRINT */
 
 static bool command_common(uint8_t code) {
 #ifdef KEYBOARD_LOCK_ENABLE
@@ -332,8 +336,9 @@ static bool command_common(uint8_t code) {
 
         // print stored eeprom config
         case MAGIC_KC(MAGIC_KEY_EEPROM):
-            print("eeconfig:\n");
+#if !defined(NO_PRINT) && !defined(USER_PRINT)
             print_eeconfig();
+#endif /* !NO_PRINT && !USER_PRINT */
             break;
 
         // clear eeprom
@@ -545,7 +550,8 @@ static bool command_console(uint8_t code) {
         case KC_H:
         case KC_SLASH: /* ? */
             command_console_help();
-            break;
+            print("C> ");
+            return true;
         case KC_Q:
         case KC_ESC:
             command_state = ONESHOT;
@@ -561,8 +567,6 @@ static bool command_console(uint8_t code) {
             print("?");
             return false;
     }
-    print("C> ");
-    return true;
 }
 
 #if defined(MOUSEKEY_ENABLE) && !defined(MK_3_SPEED)
@@ -571,30 +575,28 @@ static bool command_console(uint8_t code) {
  ***********************************************************/
 static uint8_t mousekey_param = 0;
 
-static void mousekey_param_print(void) {
-// Print these variables if NO_PRINT or USER_PRINT are not defined.
 #    if !defined(NO_PRINT) && !defined(USER_PRINT)
-    print("\n\t- Values -\n");
-    print("1: delay(*10ms): ");
-    print_dec(mk_delay);
-    print("\n");
-    print("2: interval(ms): ");
-    print_dec(mk_interval);
-    print("\n");
-    print("3: max_speed: ");
-    print_dec(mk_max_speed);
-    print("\n");
-    print("4: time_to_max: ");
-    print_dec(mk_time_to_max);
-    print("\n");
-    print("5: wheel_max_speed: ");
-    print_dec(mk_wheel_max_speed);
-    print("\n");
-    print("6: wheel_time_to_max: ");
-    print_dec(mk_wheel_time_to_max);
-    print("\n");
-#    endif /* !NO_PRINT */
+static void mousekey_param_print(void) {
+    xprintf(/* clang-format off */
+        "\n\t- Values -\n"
+
+        "1: delay(*10ms): %u\n"
+        "2: interval(ms): %u\n"
+        "3: max_speed: %u\n"
+        "4: time_to_max: %u\n"
+        "5: wheel_max_speed: %u\n"
+        "6: wheel_time_to_max: %u\n"
+
+        , mk_delay
+        , mk_interval
+        , mk_max_speed
+        , mk_time_to_max
+        , mk_wheel_max_speed
+        , mk_wheel_time_to_max
+
+    ); /* clang-format on */
 }
+#    endif /* !NO_PRINT && !USER_PRINT */
 
 //#define PRINT_SET_VAL(v)  print(#v " = "); print_dec(v); print("\n");
 #    define PRINT_SET_VAL(v) xprintf(#    v " = %d\n", (v))
@@ -732,7 +734,9 @@ static bool mousekey_console(uint8_t code) {
             }
             break;
         case KC_P:
+#    if !defined(NO_PRINT) && !defined(USER_PRINT)
             mousekey_param_print();
+#    endif
             break;
         case KC_1:
         case KC_2:

--- a/quantum/command.c
+++ b/quantum/command.c
@@ -103,94 +103,120 @@ bool command_console_extra(uint8_t code) {
 /***********************************************************
  * Command common
  ***********************************************************/
+
 static void command_common_help(void) {
-    print("\n\t- Magic -\n" STR(MAGIC_KEY_DEBUG) ":	Debug Message Toggle\n" STR(MAGIC_KEY_DEBUG_MATRIX) ":	Matrix Debug Mode Toggle - Show keypresses in matrix grid\n" STR(MAGIC_KEY_DEBUG_KBD) ":	Keyboard Debug Toggle - Show keypress report\n" STR(MAGIC_KEY_DEBUG_MOUSE) ":	Debug Mouse Toggle\n" STR(MAGIC_KEY_VERSION) ":	Version\n" STR(MAGIC_KEY_STATUS) ":	Status\n" STR(MAGIC_KEY_CONSOLE) ":	Activate Console Mode\n"
+    print(/* clang-format off */
+        "\n\t- Magic -\n"
+
+        STR(MAGIC_KEY_DEBUG) ":	Debug Message Toggle\n"
+        STR(MAGIC_KEY_DEBUG_MATRIX) ":	Matrix Debug Mode Toggle"
+            " - Show keypresses in matrix grid\n"
+        STR(MAGIC_KEY_DEBUG_KBD) ":	Keyboard Debug Toggle"
+            " - Show keypress report\n"
+        STR(MAGIC_KEY_DEBUG_MOUSE) ":	Debug Mouse Toggle\n"
+        STR(MAGIC_KEY_VERSION) ":	Version\n"
+        STR(MAGIC_KEY_STATUS) ":	Status\n"
+        STR(MAGIC_KEY_CONSOLE) ":	Activate Console Mode\n"
 
 #if MAGIC_KEY_SWITCH_LAYER_WITH_CUSTOM
-          STR(MAGIC_KEY_LAYER0) ":	Switch to Layer 0\n" STR(MAGIC_KEY_LAYER1) ":	Switch to Layer 1\n" STR(MAGIC_KEY_LAYER2) ":	Switch to Layer 2\n" STR(MAGIC_KEY_LAYER3) ":	Switch to Layer 3\n" STR(MAGIC_KEY_LAYER4) ":	Switch to Layer 4\n" STR(MAGIC_KEY_LAYER5) ":	Switch to Layer 5\n" STR(MAGIC_KEY_LAYER6) ":	Switch to Layer 6\n" STR(MAGIC_KEY_LAYER7) ":	Switch to Layer 7\n" STR(MAGIC_KEY_LAYER8) ":	Switch to Layer 8\n" STR(MAGIC_KEY_LAYER9) ":	Switch to Layer 9\n"
+        STR(MAGIC_KEY_LAYER0) ":	Switch to Layer 0\n"
+        STR(MAGIC_KEY_LAYER1) ":	Switch to Layer 1\n"
+        STR(MAGIC_KEY_LAYER2) ":	Switch to Layer 2\n"
+        STR(MAGIC_KEY_LAYER3) ":	Switch to Layer 3\n"
+        STR(MAGIC_KEY_LAYER4) ":	Switch to Layer 4\n"
+        STR(MAGIC_KEY_LAYER5) ":	Switch to Layer 5\n"
+        STR(MAGIC_KEY_LAYER6) ":	Switch to Layer 6\n"
+        STR(MAGIC_KEY_LAYER7) ":	Switch to Layer 7\n"
+        STR(MAGIC_KEY_LAYER8) ":	Switch to Layer 8\n"
+        STR(MAGIC_KEY_LAYER9) ":	Switch to Layer 9\n"
 #endif
 
 #if MAGIC_KEY_SWITCH_LAYER_WITH_FKEYS
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                               "F1-F10:	Switch to Layer 0-9 (F10 = L0)\n"
+        "F1-F10:	Switch to Layer 0-9 (F10 = L0)\n"
 #endif
 
 #if MAGIC_KEY_SWITCH_LAYER_WITH_NKEYS
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                               "0-9:	Switch to Layer 0-9\n"
+        "0-9:	Switch to Layer 0-9\n"
 #endif
 
-          STR(MAGIC_KEY_LAYER0_ALT) ":	Switch to Layer 0 (alternate)\n"
+        STR(MAGIC_KEY_LAYER0_ALT) ":	Switch to Layer 0 (alternate)\n"
 
-          STR(MAGIC_KEY_BOOTLOADER) ":	Jump to Bootloader\n" STR(MAGIC_KEY_BOOTLOADER_ALT) ":	Jump to Bootloader (alternate)\n"
+        STR(MAGIC_KEY_BOOTLOADER) ":	Jump to Bootloader\n"
+        STR(MAGIC_KEY_BOOTLOADER_ALT) ":	Jump to Bootloader (alternate)\n"
 
 #ifdef KEYBOARD_LOCK_ENABLE
-          STR(MAGIC_KEY_LOCK) ":	Lock Keyboard\n"
+        STR(MAGIC_KEY_LOCK) ":	Lock Keyboard\n"
 #endif
 
-          STR(MAGIC_KEY_EEPROM) ":	Print EEPROM Settings\n" STR(MAGIC_KEY_EEPROM_CLEAR) ":	Clear EEPROM\n"
+        STR(MAGIC_KEY_EEPROM) ":	Print EEPROM Settings\n"
+        STR(MAGIC_KEY_EEPROM_CLEAR) ":	Clear EEPROM\n"
 
 #ifdef NKRO_ENABLE
-          STR(MAGIC_KEY_NKRO) ":	NKRO Toggle\n"
+        STR(MAGIC_KEY_NKRO) ":	NKRO Toggle\n"
 #endif
 
 #ifdef SLEEP_LED_ENABLE
-          STR(MAGIC_KEY_SLEEP_LED) ":	Sleep LED Test\n"
+        STR(MAGIC_KEY_SLEEP_LED) ":	Sleep LED Test\n"
 #endif
-    );
+    ); /* clang-format on */
 }
 
 static void print_version(void) {
-    // print version & information
-    print("\n\t- Version -\n");
-    print("VID: " STR(VENDOR_ID) "(" STR(MANUFACTURER) ") "
-                                                       "PID: " STR(PRODUCT_ID) "(" STR(PRODUCT) ") "
-                                                                                                "VER: " STR(DEVICE_VER) "\n");
-    print("BUILD:  (" __DATE__ ")\n");
+    print(/* clang-format off */
+        "\n\t- Version -\n"
+        "VID: " STR(VENDOR_ID) "(" STR(MANUFACTURER) ") "
+        "PID: " STR(PRODUCT_ID) "(" STR(PRODUCT) ") "
+        "VER: " STR(DEVICE_VER) "\n"
+        "BUILD:  (" __DATE__ ")\n"
 #ifndef SKIP_VERSION
 #    ifdef PROTOCOL_CHIBIOS
-    print("CHIBIOS: " STR(CHIBIOS_VERSION) ", CONTRIB: " STR(CHIBIOS_CONTRIB_VERSION) "\n");
+        "CHIBIOS: " STR(CHIBIOS_VERSION)
+            ", CONTRIB: " STR(CHIBIOS_CONTRIB_VERSION) "\n"
 #    endif
 #endif
 
     /* build options */
-    print("OPTIONS:"
+        "OPTIONS:"
 
 #ifdef PROTOCOL_LUFA
-          " LUFA"
+        " LUFA"
 #endif
 #ifdef PROTOCOL_VUSB
-          " VUSB"
+        " VUSB"
 #endif
 #ifdef BOOTMAGIC_ENABLE
-          " BOOTMAGIC"
+        " BOOTMAGIC"
 #endif
 #ifdef MOUSEKEY_ENABLE
-          " MOUSEKEY"
+        " MOUSEKEY"
 #endif
 #ifdef EXTRAKEY_ENABLE
-          " EXTRAKEY"
+        " EXTRAKEY"
 #endif
 #ifdef CONSOLE_ENABLE
-          " CONSOLE"
+        " CONSOLE"
 #endif
 #ifdef COMMAND_ENABLE
-          " COMMAND"
+        " COMMAND"
 #endif
 #ifdef NKRO_ENABLE
-          " NKRO"
+        " NKRO"
 #endif
 #ifdef LTO_ENABLE
-          " LTO"
+        " LTO"
 #endif
 
-          " " STR(BOOTLOADER_SIZE) "\n");
+        " " STR(BOOTLOADER_SIZE) "\n"
 
-    print("GCC: " STR(__GNUC__) "." STR(__GNUC_MINOR__) "." STR(__GNUC_PATCHLEVEL__)
+        "GCC: " STR(__GNUC__)
+            "." STR(__GNUC_MINOR__)
+            "." STR(__GNUC_PATCHLEVEL__)
 #if defined(__AVR__)
-              " AVR-LIBC: " __AVR_LIBC_VERSION_STRING__ " AVR_ARCH: avr" STR(__AVR_ARCH__)
+        " AVR-LIBC: " __AVR_LIBC_VERSION_STRING__
+        " AVR_ARCH: avr" STR(__AVR_ARCH__)
 #endif
-                  "\n");
-
-    return;
+        "\n"
+    ); /* clang-format on */
 }
 
 static void print_status(void) {

--- a/quantum/command.c
+++ b/quantum/command.c
@@ -55,7 +55,6 @@ static bool command_console(uint8_t code);
 static void command_console_help(void);
 #if defined(MOUSEKEY_ENABLE) && !defined(MK_3_SPEED)
 static bool mousekey_console(uint8_t code);
-static void mousekey_console_help(void);
 #endif
 
 static void switch_default_layer(uint8_t layer);
@@ -556,11 +555,10 @@ static bool command_console(uint8_t code) {
         case KC_ESC:
             command_state = ONESHOT;
             return false;
-#if defined(MOUSEKEY_ENABLE) && !defined(MK_3_SPEED)
+#if defined(MOUSEKEY_ENABLE)
         case KC_M:
-            mousekey_console_help();
-            print("M> ");
             command_state = MOUSEKEY;
+            mousekey_console(KC_SLASH /* ? */);
             return true;
 #endif
         default:
@@ -569,23 +567,23 @@ static bool command_console(uint8_t code) {
     }
 }
 
-#if defined(MOUSEKEY_ENABLE) && !defined(MK_3_SPEED)
 /***********************************************************
  * Mousekey console
  ***********************************************************/
-static uint8_t mousekey_param = 0;
+
+#if defined(MOUSEKEY_ENABLE)
 
 #    if !defined(NO_PRINT) && !defined(USER_PRINT)
 static void mousekey_param_print(void) {
     xprintf(/* clang-format off */
-        "\n\t- Values -\n"
 
-        "1: delay(*10ms): %u\n"
-        "2: interval(ms): %u\n"
-        "3: max_speed: %u\n"
-        "4: time_to_max: %u\n"
-        "5: wheel_max_speed: %u\n"
-        "6: wheel_time_to_max: %u\n"
+#ifndef MK_3_SPEED
+        "1:	delay(*10ms): %u\n"
+        "2:	interval(ms): %u\n"
+        "3:	max_speed: %u\n"
+        "4:	time_to_max: %u\n"
+        "5:	wheel_max_speed: %u\n"
+        "6:	wheel_time_to_max: %u\n"
 
         , mk_delay
         , mk_interval
@@ -593,221 +591,154 @@ static void mousekey_param_print(void) {
         , mk_time_to_max
         , mk_wheel_max_speed
         , mk_wheel_time_to_max
+#else
+        "no knobs sorry\n"
+#endif
 
     ); /* clang-format on */
 }
 #    endif /* !NO_PRINT && !USER_PRINT */
 
-//#define PRINT_SET_VAL(v)  print(#v " = "); print_dec(v); print("\n");
-#    define PRINT_SET_VAL(v) xprintf(#    v " = %d\n", (v))
-static void mousekey_param_inc(uint8_t param, uint8_t inc) {
-    switch (param) {
-        case 1:
-            if (mk_delay + inc < UINT8_MAX)
-                mk_delay += inc;
-            else
-                mk_delay = UINT8_MAX;
-            PRINT_SET_VAL(mk_delay);
-            break;
-        case 2:
-            if (mk_interval + inc < UINT8_MAX)
-                mk_interval += inc;
-            else
-                mk_interval = UINT8_MAX;
-            PRINT_SET_VAL(mk_interval);
-            break;
-        case 3:
-            if (mk_max_speed + inc < UINT8_MAX)
-                mk_max_speed += inc;
-            else
-                mk_max_speed = UINT8_MAX;
-            PRINT_SET_VAL(mk_max_speed);
-            break;
-        case 4:
-            if (mk_time_to_max + inc < UINT8_MAX)
-                mk_time_to_max += inc;
-            else
-                mk_time_to_max = UINT8_MAX;
-            PRINT_SET_VAL(mk_time_to_max);
-            break;
-        case 5:
-            if (mk_wheel_max_speed + inc < UINT8_MAX)
-                mk_wheel_max_speed += inc;
-            else
-                mk_wheel_max_speed = UINT8_MAX;
-            PRINT_SET_VAL(mk_wheel_max_speed);
-            break;
-        case 6:
-            if (mk_wheel_time_to_max + inc < UINT8_MAX)
-                mk_wheel_time_to_max += inc;
-            else
-                mk_wheel_time_to_max = UINT8_MAX;
-            PRINT_SET_VAL(mk_wheel_time_to_max);
-            break;
-    }
-}
-
-static void mousekey_param_dec(uint8_t param, uint8_t dec) {
-    switch (param) {
-        case 1:
-            if (mk_delay > dec)
-                mk_delay -= dec;
-            else
-                mk_delay = 0;
-            PRINT_SET_VAL(mk_delay);
-            break;
-        case 2:
-            if (mk_interval > dec)
-                mk_interval -= dec;
-            else
-                mk_interval = 0;
-            PRINT_SET_VAL(mk_interval);
-            break;
-        case 3:
-            if (mk_max_speed > dec)
-                mk_max_speed -= dec;
-            else
-                mk_max_speed = 0;
-            PRINT_SET_VAL(mk_max_speed);
-            break;
-        case 4:
-            if (mk_time_to_max > dec)
-                mk_time_to_max -= dec;
-            else
-                mk_time_to_max = 0;
-            PRINT_SET_VAL(mk_time_to_max);
-            break;
-        case 5:
-            if (mk_wheel_max_speed > dec)
-                mk_wheel_max_speed -= dec;
-            else
-                mk_wheel_max_speed = 0;
-            PRINT_SET_VAL(mk_wheel_max_speed);
-            break;
-        case 6:
-            if (mk_wheel_time_to_max > dec)
-                mk_wheel_time_to_max -= dec;
-            else
-                mk_wheel_time_to_max = 0;
-            PRINT_SET_VAL(mk_wheel_time_to_max);
-            break;
-    }
-}
-
+#    if !defined(NO_PRINT) && !defined(USER_PRINT)
 static void mousekey_console_help(void) {
-    print("\n\t- Mousekey -\n"
-          "ESC/q:	quit\n"
-          "1:	delay(*10ms)\n"
-          "2:	interval(ms)\n"
-          "3:	max_speed\n"
-          "4:	time_to_max\n"
-          "5:	wheel_max_speed\n"
-          "6:	wheel_time_to_max\n"
-          "\n"
-          "p:	print values\n"
-          "d:	set defaults\n"
-          "up:	+1\n"
-          "down:	-1\n"
-          "pgup:	+10\n"
-          "pgdown:	-10\n"
-          "\n"
-          "speed = delta * max_speed * (repeat / time_to_max)\n");
-    xprintf("where delta: cursor=%d, wheel=%d\n"
-            "See http://en.wikipedia.org/wiki/Mouse_keys\n",
-            MOUSEKEY_MOVE_DELTA, MOUSEKEY_WHEEL_DELTA);
-}
+    mousekey_param_print();
+    xprintf(/* clang-format off */
+        "p:	print values\n"
+        "d:	set defaults\n"
+        "up:	+1\n"
+        "dn:	-1\n"
+        "lt:	+10\n"
+        "rt:	-10\n"
+        "ESC/q:	quit\n"
 
-static bool mousekey_console(uint8_t code) {
+#ifndef MK_3_SPEED
+        "\n"
+        "speed = delta * max_speed * (repeat / time_to_max)\n"
+        "where delta: cursor=%d, wheel=%d\n"
+        "See http://en.wikipedia.org/wiki/Mouse_keys\n"
+        , MOUSEKEY_MOVE_DELTA, MOUSEKEY_WHEEL_DELTA
+#endif
+
+    ); /* clang-format on */
+}
+#    endif /* !NO_PRINT && !USER_PRINT */
+
+/* Only used by `quantum/command.c` / `command_proc()`. To avoid
+ * any doubt: we return `false` to return to the main console,
+ * which differs from the `bool` that `command_proc()` returns. */
+bool mousekey_console(uint8_t code) {
+    static uint8_t  param = 0;
+    static uint8_t *pp    = NULL;
+    static char *   desc  = NULL;
+
+#    if defined(NO_PRINT) || defined(USER_PRINT) /* -Wunused-parameter */
+    (void)desc;
+#    endif
+
+    int8_t change = 0;
+
     switch (code) {
         case KC_H:
         case KC_SLASH: /* ? */
+#    if !defined(NO_PRINT) && !defined(USER_PRINT)
+            print("\n\t- Mousekey -\n");
             mousekey_console_help();
+#    endif
             break;
+
         case KC_Q:
         case KC_ESC:
-            if (mousekey_param) {
-                mousekey_param = 0;
-            } else {
-                print("C> ");
-                command_state = CONSOLE;
-                return false;
-            }
+            print("q\n");
+            if (!param) return false;
+            param = 0;
+            pp    = NULL;
+            desc  = NULL;
             break;
+
         case KC_P:
 #    if !defined(NO_PRINT) && !defined(USER_PRINT)
+            print("\n\t- Values -\n");
             mousekey_param_print();
 #    endif
             break;
-        case KC_1:
-        case KC_2:
-        case KC_3:
-        case KC_4:
-        case KC_5:
-        case KC_6:
-            mousekey_param = numkey2num(code);
+
+        case KC_1 ... KC_0: /* KC_0 gives param = 10 */
+            param = 1 + code - KC_1;
+            switch (param) { /* clang-format off */
+#               define PARAM(n, v) case n: pp = &(v); desc = #v; break
+
+#ifndef MK_3_SPEED
+                PARAM(1, mk_delay);
+                PARAM(2, mk_interval);
+                PARAM(3, mk_max_speed);
+                PARAM(4, mk_time_to_max);
+                PARAM(5, mk_wheel_max_speed);
+                PARAM(6, mk_wheel_time_to_max);
+#endif /* MK_3_SPEED */
+
+#               undef PARAM
+                default:
+                    param = 0;
+                    print("?\n");
+                    break;
+            } /* clang-format on */
+            if (param) xprintf("%u\n", param);
             break;
-        case KC_UP:
-            mousekey_param_inc(mousekey_param, 1);
-            break;
-        case KC_DOWN:
-            mousekey_param_dec(mousekey_param, 1);
-            break;
-        case KC_PGUP:
-            mousekey_param_inc(mousekey_param, 10);
-            break;
-        case KC_PGDN:
-            mousekey_param_dec(mousekey_param, 10);
-            break;
+
+            /* clang-format off */
+        case KC_UP:    change =  +1; break;
+        case KC_DOWN:  change =  -1; break;
+        case KC_LEFT:  change = -10; break;
+        case KC_RIGHT: change = +10; break;
+            /* clang-format on */
+
         case KC_D:
+
+#    ifndef MK_3_SPEED
             mk_delay             = MOUSEKEY_DELAY / 10;
             mk_interval          = MOUSEKEY_INTERVAL;
             mk_max_speed         = MOUSEKEY_MAX_SPEED;
             mk_time_to_max       = MOUSEKEY_TIME_TO_MAX;
             mk_wheel_max_speed   = MOUSEKEY_WHEEL_MAX_SPEED;
             mk_wheel_time_to_max = MOUSEKEY_WHEEL_TIME_TO_MAX;
-            print("set default\n");
+#    endif /* MK_3_SPEED */
+
+            print("defaults\n");
             break;
+
         default:
-            print("?");
-            return false;
+            print("?\n");
+            break;
     }
-    if (mousekey_param) {
-        xprintf("M%d> ", mousekey_param);
+
+    if (change) {
+        if (pp) {
+            int16_t val = *pp + change;
+            if (val > (int16_t)UINT8_MAX)
+                *pp = UINT8_MAX;
+            else if (val < 0)
+                *pp = 0;
+            else
+                *pp = (uint8_t)val;
+            xprintf("= %u\n", *pp);
+        } else {
+            print("?\n");
+        }
+    }
+
+    if (param) {
+        xprintf("M%u:%s> ", param, desc ? desc : "???");
     } else {
-        print("M>");
+        print("M> ");
     }
     return true;
 }
-#endif
+
+#endif /* MOUSEKEY_ENABLE */
 
 /***********************************************************
  * Utilities
  ***********************************************************/
-uint8_t numkey2num(uint8_t code) {
-    switch (code) {
-        case KC_1:
-            return 1;
-        case KC_2:
-            return 2;
-        case KC_3:
-            return 3;
-        case KC_4:
-            return 4;
-        case KC_5:
-            return 5;
-        case KC_6:
-            return 6;
-        case KC_7:
-            return 7;
-        case KC_8:
-            return 8;
-        case KC_9:
-            return 9;
-        case KC_0:
-            return 0;
-    }
-    return 0;
-}
 
 static void switch_default_layer(uint8_t layer) {
     xprintf("L%d\n", layer);

--- a/quantum/command.h
+++ b/quantum/command.h
@@ -28,8 +28,7 @@ bool command_extra(uint8_t code);
 bool command_console_extra(uint8_t code);
 
 #ifdef COMMAND_ENABLE
-uint8_t numkey2num(uint8_t code);
-bool    command_proc(uint8_t code);
+bool command_proc(uint8_t code);
 #else
 #    define command_proc(code) false
 #endif


### PR DESCRIPTION
I accidentally a huge refactor. (This is part 1 of n.) It improves the code size & {read,maintain}ability significantly.

This PR reduces the firmware size by ~1.5kB on my ATmega32, when built with `CONSOLE_ENABLE` and `COMMAND_ENABLE` set to `yes`.

If possible, could this PR be merged rather than squashed?

## Description

Because the last commit moves `mousekey_console()` to `mousekey.c` (verbatim, trust me :), I recommend reading the penultimate commit separately to see the changes to `mousekey_console()` itself.

```
commit 3ec12a579518e1dda45b3163d042d4d781a6850c
Author: Liyang HU <git@liyang.hu>
Date:   Sun Feb 7 16:19:52 2021 +0000

    quantum/command.c: optimise `mousekey_console()` for size & legibility

    Made various tweaks to the interface, but still functionally identical.

    Assume `KC_1`…`KC_0` to be contiguous, and removed `numkey2num(…)` entirely.
    It was exported in `command.h` by 1a0bac8bcc for no obvious reason, before
    which it was `static`. I doubt anyone uses it.

    `mousekey_console()` is now enabled regardless of `MK_3_SPEED`.
    Needs fleshing out for things other than the X11 variant though.

    This commit saves 638 bytes on my ATmega32.

commit 003835288cb193ffda71671bb379bab716c01f2f
Author: Liyang HU <git@liyang.hu>
Date:   Mon Feb 8 11:58:48 2021 +0000

    quantum/command.c: replace `print(…); print_{,val_}{dec,hex}*(…);` sequences with single `xprintf(…)`

    `print_{dec,hex}*(…)` are just `#define`s for `xprintf(…)` anyway.

    Each additional `xprintf(…)` costs ~8 bytes: the call instructions,
    plus an additional NUL terminator.

    This _really_ adds up: this commit saves 814 bytes on my ATmega32.

commit ea79897bb1e957a69e5f26ce67c30996c7882051
Author: Liyang HU <git@liyang.hu>
Date:   Sun Feb 7 13:46:23 2021 +0000

    quantum/command.c: coalesce `print()`s in `command_common_help()` & `print_version()`

    Also undo some damage by clang-format in b624f32f94
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* ~~n/a~~

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] ~~My change requires a change to the documentation.~~
- [ ] ~~I have updated the documentation accordingly.~~
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] ~~I have added tests to cover my changes.~~
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
