### PR TITLE
tunks/ergo33: define RGBLight config at keyboard level

### DIFF
--- a/keyboards/tunks/ergo33/config.h
+++ b/keyboards/tunks/ergo33/config.h
@@ -43,6 +43,15 @@
 
 /* Underglow + top RGB configuration */
 #define RGB_DI_PIN D4
+#define RGBLIGHT_ANIMATIONS
+
+#if !defined(RGBLED_NUM)
+/* RGB LED count
+ * No external LED PCB: 10
+ * External LED PCB: 14
+ */
+#    define RGBLED_NUM 14
+#endif
 
 /* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
 //#define LOCKING_SUPPORT_ENABLE

--- a/keyboards/tunks/ergo33/keymaps/rgb/config.h
+++ b/keyboards/tunks/ergo33/keymaps/rgb/config.h
@@ -20,5 +20,8 @@
  * No external LED PCB: 10
  * External LED PCB: 14
  */
-#define RGBLED_NUM 10
+#if defined(RGBLED_NUM)
+#    undef RGBLED_NUM
+#    define RGBLED_NUM 10
+#endif
 #define RGBLIGHT_ANIMATIONS


### PR DESCRIPTION
## Description

Set up the RGBLight at keyboard level so QMK Configurator can compile the board.

@kulmajaba (keyboard maintainer)

## Types of Changes

- [x] Enhancement/optimization
- [x] Keyboard (addition or update)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
