### PR TITLE
Support right modifiers with LM()

### DIFF
--- a/docs/feature_layers.md
+++ b/docs/feature_layers.md
@@ -10,7 +10,7 @@ These functions allow you to activate layers in various ways. Note that layers a
 
 * `DF(layer)` - switches the default layer. The default layer is the always-active base layer that other layers stack on top of. See below for more about the default layer. This might be used to switch from QWERTY to Dvorak layout. (Note that this is a temporary switch that only persists until the keyboard loses power. To modify the default layer in a persistent way requires deeper customization, such as calling the `set_single_persistent_default_layer` function inside of [process_record_user](custom_quantum_functions.md#programming-the-behavior-of-any-keycode).)
 * `MO(layer)` - momentarily activates *layer*. As soon as you let go of the key, the layer is deactivated. 
-* `LM(layer, mod)` - Momentarily activates *layer* (like `MO`), but with modifier(s) *mod* active. Only supports layers 0-15 and the left modifiers: `MOD_LCTL`, `MOD_LSFT`, `MOD_LALT`, `MOD_LGUI` (note the use of `MOD_` constants instead of `KC_`). These modifiers can be combined using bitwise OR, e.g. `LM(_RAISE, MOD_LCTL | MOD_LALT)`.
+* `LM(layer, mod)` - Momentarily activates *layer* (like `MO`), but with modifier(s) *mod* active. Only supports layers 0-15 and either the left or right modifiers: `MOD_LCTL`, `MOD_LSFT`, `MOD_LALT`, `MOD_LGUI` or `MOD_RCTL`, `MOD_RSFT`, `MOD_RALT`, `MOD_RGUI` (note the use of `MOD_` constants instead of `KC_`). These modifiers can be combined using bitwise OR, e.g. `LM(_RAISE, MOD_LCTL | MOD_LALT)` or `LM(_RAISE, MOD_RCTL | MOD_RALT)`.
 * `LT(layer, kc)` - momentarily activates *layer* when held, and sends *kc* when tapped. Only supports layers 0-15.
 * `OSL(layer)` - momentarily activates *layer* until the next key is pressed. See [One Shot Keys](one_shot_keys.md) for details and additional functionality.
 * `TG(layer)` - toggles *layer*, activating it if it's inactive and vice versa
@@ -23,7 +23,7 @@ Currently, `LT()` and `MT()` are limited to the [Basic Keycode set](keycodes_bas
 
 Expanding this would be complicated, at best. Moving to a 32-bit keycode would solve a lot of this, but would double the amount of space that the keymap matrix uses. And it could potentially cause issues, too. If you need to apply modifiers to your tapped keycode, [Tap Dance](feature_tap_dance.md#example-5-using-tap-dance-for-advanced-mod-tap-and-layer-tap-keys) can be used to accomplish this.
 
-Additionally, if at least one right-handed modifier is specified in a Mod Tap or Layer Tap, it will cause all modifiers specified to become right-handed, so it is not possible to mix and match the two.
+Additionally, if at least one right-handed modifier is specified in a Layer Mod, Mod Tap or Layer Tap, it will cause all modifiers specified to become right-handed, so it is not possible to mix and match the two.
 
 ## Working with Layers :id=working-with-layers
 

--- a/quantum/keymap_common.c
+++ b/quantum/keymap_common.c
@@ -146,6 +146,11 @@ action_t action_for_key(uint8_t layer, keypos_t key) {
             action_layer = (keycode >> 4) & 0xF;
             action.code  = ACTION_LAYER_MODS(action_layer, mod);
             break;
+        case QK_LAYER_MOD_R ... QK_LAYER_MOD_R_MAX:
+            mod          = mod_config(MOD_R_BIT | (keycode & 0xF));
+            action_layer = (keycode >> 4) & 0xF;
+            action.code  = ACTION_LAYER_MODS(action_layer, (mod & 0xF) << 4);
+            break;
 #endif
 #ifndef NO_ACTION_TAPPING
         case QK_MOD_TAP ... QK_MOD_TAP_MAX:

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -85,6 +85,7 @@ enum quantum_keycodes {
     QK_SWAP_HANDS     = 0x5B00,
     QK_SWAP_HANDS_MAX = 0x5BFF,
 #endif
+    // Warning: 0x5C00+ are not free to use (see below)
     QK_MOD_TAP     = 0x6000,
     QK_MOD_TAP_MAX = 0x7FFF,
 #ifdef UNICODE_ENABLE

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -67,6 +67,8 @@ enum quantum_keycodes {
     QK_ONE_SHOT_LAYER_MAX   = 0x54FF,
     QK_ONE_SHOT_MOD         = 0x5500,
     QK_ONE_SHOT_MOD_MAX     = 0x55FF,
+    QK_LAYER_MOD_R          = 0x5600,
+    QK_LAYER_MOD_R_MAX      = 0x56FF,
     QK_TAP_DANCE            = 0x5700,
     QK_TAP_DANCE_MAX        = 0x57FF,
     QK_LAYER_TAP_TOGGLE     = 0x5800,
@@ -789,8 +791,8 @@ enum quantum_keycodes {
 // One-shot layer - 256 layer max
 #define OSL(layer) (QK_ONE_SHOT_LAYER | ((layer)&0xFF))
 
-// L-ayer M-od: Momentary switch layer with modifiers active - 16 layer max, left mods only
-#define LM(layer, mod) (QK_LAYER_MOD | (((layer)&0xF) << 4) | ((mod)&0xF))
+// L-ayer M-od: Momentary switch layer with modifiers active - 16 layer max, left or right mods only
+#define LM(layer, mod) ((((mod)&MOD_R_BIT) ? QK_LAYER_MOD_R : QK_LAYER_MOD) | (((layer)&0xF) << 4) | ((mod)&0xF))
 
 // One-shot mod
 #define OSM(mod) (QK_ONE_SHOT_MOD | ((mod)&0xFF))

--- a/tmk_core/common/action_code.h
+++ b/tmk_core/common/action_code.h
@@ -200,6 +200,7 @@ enum mods_bit {
     MOD_RALT = 0x14,
     MOD_RGUI = 0x18,
 };
+#define MOD_R_BIT 0x10
 enum mods_codes {
     MODS_ONESHOT    = 0x00,
     MODS_TAP_TOGGLE = 0x01,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Not being able to use LM() with RALT means that AltGr can't be used to activate a layer on ISO layouts.
    
Add support for right modifiers too. It's not possible to mix left and right modifiers but this makes it possible to keep RCTL/RSFT/RALT/RGUI as normal and activate a layer when held.

I'm doing this so I can have `KC_MPLY` instead of `KC_PAUS` in the default layer but automatically revert to the standard key when any modifier is pressed, e.g. `MOD_LGUI`/`MOD_RGUI`. Currently I'd have to give up the right modifiers to do this.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
