### PR TITLE
Disable VIA protocol's EEPROM reset and bootloader jump commands

### DIFF
--- a/quantum/via.c
+++ b/quantum/via.c
@@ -371,16 +371,20 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
             break;
         }
         case id_eeprom_reset: {
+#ifdef VIA_YES_I_UNDERSTAND_THIS_IS_AN_ATTACK_VECTOR
             via_eeprom_reset();
+#endif  // VIA_YES_I_UNDERSTAND_THIS_IS_AN_ATTACK_VECTOR
             break;
         }
         case id_bootloader_jump: {
+#ifdef VIA_YES_I_UNDERSTAND_THIS_IS_AN_ATTACK_VECTOR
             // Need to send data back before the jump
             // Informs host that the command is handled
             raw_hid_send(data, length);
             // Give host time to read it
             wait_ms(100);
             bootloader_jump();
+#endif  // VIA_YES_I_UNDERSTAND_THIS_IS_AN_ATTACK_VECTOR
             break;
         }
         default: {

--- a/quantum/via.c
+++ b/quantum/via.c
@@ -370,23 +370,6 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
             dynamic_keymap_set_buffer(offset, size, &command_data[3]);
             break;
         }
-        case id_eeprom_reset: {
-#ifdef VIA_YES_I_UNDERSTAND_THIS_IS_AN_ATTACK_VECTOR
-            via_eeprom_reset();
-#endif  // VIA_YES_I_UNDERSTAND_THIS_IS_AN_ATTACK_VECTOR
-            break;
-        }
-        case id_bootloader_jump: {
-#ifdef VIA_YES_I_UNDERSTAND_THIS_IS_AN_ATTACK_VECTOR
-            // Need to send data back before the jump
-            // Informs host that the command is handled
-            raw_hid_send(data, length);
-            // Give host time to read it
-            wait_ms(100);
-            bootloader_jump();
-#endif  // VIA_YES_I_UNDERSTAND_THIS_IS_AN_ATTACK_VECTOR
-            break;
-        }
         default: {
             // The command ID is not known
             // Return the unhandled state


### PR DESCRIPTION
## Description

Entry to bootloader through the rawhid endpoint is a potential attack vector. This PR disables those commands by default, turning them into no-ops, but allows reinstating them through the use of `#define VIA_YES_I_UNDERSTAND_THIS_IS_AN_ATTACK_VECTOR`.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
