### PR TITLE
Xealous Brown handwired Refactor

### DIFF
--- a/keyboards/handwired/xealousbrown/info.json
+++ b/keyboards/handwired/xealousbrown/info.json
@@ -5,7 +5,7 @@
   "width": 15,
   "height": 5,
   "layouts": {
-    "LAYOUT": {
+    "LAYOUT_60_ansi": {
       "layout": [
         {"label":"`", "x":0, "y":0},
         {"label":"1", "x":1, "y":0},

--- a/keyboards/handwired/xealousbrown/keymaps/default/keymap.c
+++ b/keyboards/handwired/xealousbrown/keymaps/default/keymap.c
@@ -1,3 +1,18 @@
+/* Copyright 2019 Alex Ong
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 #include QMK_KEYBOARD_H
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {

--- a/keyboards/handwired/xealousbrown/keymaps/default/keymap.c
+++ b/keyboards/handwired/xealousbrown/keymaps/default/keymap.c
@@ -1,18 +1,18 @@
 #include QMK_KEYBOARD_H
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-  [0] = LAYOUT( /* Main layer */
-      KC_ESC,        KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL, \
-      KC_TAB,        KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC,\
-      MO(1),         KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_ENTER, \
-      KC_LSFT,       KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT, KC_BSLS,
-      KC_LCTL,       KC_LGUI, KC_LALT,                 KC_SPC,    KC_RALT, MO(1),    KC_APP,  KC_RCTL, KC_BSPC    \
-  ),
-  [1] = LAYOUT( /* FN_Layer */
-      KC_GRV,        KC_F1,   KC_F2,   KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,    KC_F11, KC_F12, \
-      KC_CAPS,       KC_PGUP, KC_UP,   KC_PGDN,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_PGUP,  KC_UP,    KC_PGDN,  KC_PSCR,   KC_SLCK,KC_PAUS,\
-      KC_TRNS,       KC_LEFT, KC_DOWN, KC_RGHT,  KC_TRNS,  KC_HOME,  KC_HOME,  KC_LEFT,  KC_DOWN,  KC_RGHT,  KC_INS,    KC_DEL, KC_TRNS, \
-      KC_TRNS,       KC_TRNS, KC_TRNS, KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_END,   KC_TRNS,  KC_VOLD,  KC_VOLU,  KC_MUTE,   KC_TRNS,KC_TRNS,
-      KC_TRNS,       KC_TRNS, KC_TRNS,                 KC_TRNS,      KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,                     KC_DEL    \
-  )
+    [0] = LAYOUT( /* Main layer */
+        KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC,
+        KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS,
+        MO(1),   KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,          KC_ENT,
+        KC_LSFT,          KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH,          KC_RSFT,
+        KC_LCTL, KC_LGUI, KC_LALT,                            KC_SPC,                             KC_RALT, MO(1),   KC_APP,  KC_RCTL
+    ),
+    [1] = LAYOUT( /* FN_Layer */
+        KC_GRV,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_DEL,
+        KC_CAPS, KC_PGUP, KC_UP,   KC_PGDN, KC_TRNS, KC_TRNS, KC_TRNS, KC_PGUP, KC_UP,   KC_PGDN, KC_PSCR, KC_SLCK, KC_PAUS, KC_TRNS,
+        KC_TRNS, KC_LEFT, KC_DOWN, KC_RGHT, KC_TRNS, KC_HOME, KC_HOME, KC_LEFT, KC_DOWN, KC_RGHT, KC_INS,  KC_DEL,           KC_TRNS,
+        KC_TRNS,          KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_END,  KC_TRNS, KC_VOLD, KC_VOLU, KC_MUTE,          KC_TRNS,
+        KC_TRNS, KC_TRNS, KC_TRNS,                            KC_TRNS,                            KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS
+    )
 };

--- a/keyboards/handwired/xealousbrown/keymaps/default/keymap.c
+++ b/keyboards/handwired/xealousbrown/keymaps/default/keymap.c
@@ -1,14 +1,14 @@
 #include QMK_KEYBOARD_H
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    [0] = LAYOUT( /* Main layer */
+    [0] = LAYOUT_60_ansi( /* Main layer */
         KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC,
         KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS,
         MO(1),   KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,          KC_ENT,
         KC_LSFT,          KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH,          KC_RSFT,
         KC_LCTL, KC_LGUI, KC_LALT,                            KC_SPC,                             KC_RALT, MO(1),   KC_APP,  KC_RCTL
     ),
-    [1] = LAYOUT( /* FN_Layer */
+    [1] = LAYOUT_60_ansi( /* FN_Layer */
         KC_GRV,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_DEL,
         KC_CAPS, KC_PGUP, KC_UP,   KC_PGDN, KC_TRNS, KC_TRNS, KC_TRNS, KC_PGUP, KC_UP,   KC_PGDN, KC_PSCR, KC_SLCK, KC_PAUS, KC_TRNS,
         KC_TRNS, KC_LEFT, KC_DOWN, KC_RGHT, KC_TRNS, KC_HOME, KC_HOME, KC_LEFT, KC_DOWN, KC_RGHT, KC_INS,  KC_DEL,           KC_TRNS,

--- a/keyboards/handwired/xealousbrown/readme.md
+++ b/keyboards/handwired/xealousbrown/readme.md
@@ -5,6 +5,9 @@ My first handwired keyboard. Originally used TMK, now ported in full glory to QM
 Build log at:
 https://sites.google.com/site/xaelous/keyboards/handwired-keyboard
 
+* Keyboard Maintainer: [alex-ong](https://github.com/alex-ong)
+* Hardware Supported: Arduino Pro Micro or clone
+
 Make example for this keyboard (after setting up your build environment):
 
     make handwired/xealousbrown:default
@@ -15,3 +18,5 @@ The brief list of speedhacks to make this keyboard blazing fast:
 2) Compiling with a few extra flags
 3) Eager-per-key Debouncing algorithm (no 5ms delay before message is sent)
 4) 1000hz polling
+
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).

--- a/keyboards/handwired/xealousbrown/rules.mk
+++ b/keyboards/handwired/xealousbrown/rules.mk
@@ -30,6 +30,7 @@ BLUETOOTH_ENABLE = no               # Enable Bluetooth with the Adafruit EZ-Key 
 AUDIO_ENABLE = no                   # Audio output on port C6
 SPACE_CADET_ENABLE = no             # Unneeded feature.
 
+LAYOUTS = 60_ansi
 
 # special sauce for this keyboard
 DEBOUNCE_TYPE = eager_pk            # Debounce using eager_pk.

--- a/keyboards/handwired/xealousbrown/rules.mk
+++ b/keyboards/handwired/xealousbrown/rules.mk
@@ -2,40 +2,32 @@
 MCU = atmega32u4
 
 # Bootloader selection
-#   Teensy       halfkay
-#   Pro Micro    caterina
-#   Atmel DFU    atmel-dfu
-#   LUFA DFU     lufa-dfu
-#   QMK DFU      qmk-dfu
-#   ATmega32A    bootloadHID
-#   ATmega328P   USBasp
 BOOTLOADER = caterina
 
 # Build Options
 #   change yes to no to disable
 #
-BOOTMAGIC_ENABLE = full             # Virtual DIP switch configuration
-MOUSEKEY_ENABLE = no                # Mouse keys
-EXTRAKEY_ENABLE = yes               # Audio control and System control
-CONSOLE_ENABLE = yes                # Console for debug
-COMMAND_ENABLE = yes                 # Commands for debug and configuration
+BOOTMAGIC_ENABLE = full     # Virtual DIP switch configuration
+MOUSEKEY_ENABLE = no        # Mouse keys
+EXTRAKEY_ENABLE = yes       # Audio control and System control
+CONSOLE_ENABLE = yes        # Console for debug
+COMMAND_ENABLE = yes        # Commands for debug and configuration
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
-SLEEP_LED_ENABLE = no               # Breathing sleep LED during USB suspend
+SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
 # if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
-NKRO_ENABLE = yes                   # USB Nkey Rollover
-BACKLIGHT_ENABLE = no               # Enable keyboard backlight functionality on B7 by default
-MIDI_ENABLE = no                    # MIDI controls
-UNICODE_ENABLE = no                 # Unicode
-BLUETOOTH_ENABLE = no               # Enable Bluetooth with the Adafruit EZ-Key HID
-AUDIO_ENABLE = no                   # Audio output on port C6
-SPACE_CADET_ENABLE = no             # Unneeded feature.
+NKRO_ENABLE = yes           # USB Nkey Rollover
+BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
+RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
+BLUETOOTH_ENABLE = no       # Enable Bluetooth
+AUDIO_ENABLE = no           # Audio output
+SPACE_CADET_ENABLE = no     # Unneeded feature.
 
 LAYOUTS = 60_ansi
 
 # special sauce for this keyboard
-DEBOUNCE_TYPE = eager_pk            # Debounce using eager_pk.
-CUSTOM_MATRIX = lite                # Custom matrix that polls at 7000hz instead of a measly 2000hz.
-LTO_ENABLE = yes                    # smaller binary
+DEBOUNCE_TYPE = eager_pk    # Debounce using eager_pk.
+CUSTOM_MATRIX = lite        # Custom matrix that polls at 7000hz instead of a measly 2000hz.
+LTO_ENABLE = yes            # smaller binary
 SRC += matrix.c
 
 # Also remember to open tmk's rules.mk and set compilation optimization to 3

--- a/keyboards/handwired/xealousbrown/xealousbrown.c
+++ b/keyboards/handwired/xealousbrown/xealousbrown.c
@@ -1,3 +1,18 @@
+/* Copyright 2019 Alex Ong
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 #include "xealousbrown.h"
 
 void matrix_init_kb(void) {

--- a/keyboards/handwired/xealousbrown/xealousbrown.h
+++ b/keyboards/handwired/xealousbrown/xealousbrown.h
@@ -1,5 +1,4 @@
-#ifndef XEALOUSBROWN_H
-#define XEALOUSBROWN_H
+#pragma once
 
 #include "quantum.h"
 
@@ -16,5 +15,3 @@
   {  K30,  K31,  K32,  K33,    K34,    K35,  K36,    K37,    K38,    K39,    K3A,    K3B,    K3C }, \
   {  K40,  K41,  K42,  KC_NO,  KC_NO,  K45,  K46,    K47,    K48,    K49,    KC_NO,  KC_NO,  K4C }  \
 }
-
-#endif

--- a/keyboards/handwired/xealousbrown/xealousbrown.h
+++ b/keyboards/handwired/xealousbrown/xealousbrown.h
@@ -1,3 +1,18 @@
+/* Copyright 2019 Alex Ong
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 #pragma once
 
 #include "quantum.h"

--- a/keyboards/handwired/xealousbrown/xealousbrown.h
+++ b/keyboards/handwired/xealousbrown/xealousbrown.h
@@ -2,7 +2,7 @@
 
 #include "quantum.h"
 
-#define LAYOUT( \
+#define LAYOUT_60_ansi( \
     K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C, K4C, \
     K10, K11, K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, K1C, K3C, \
     K20, K21, K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B,      K2C, \

--- a/keyboards/handwired/xealousbrown/xealousbrown.h
+++ b/keyboards/handwired/xealousbrown/xealousbrown.h
@@ -3,11 +3,11 @@
 #include "quantum.h"
 
 #define LAYOUT( \
-    K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C, \
-    K10, K11, K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, K1C, \
-    K20, K21, K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B, K2C, \
-    K30, K31, K32, K33, K34, K35, K36, K37, K38, K39, K3A, K3B, K3C, \
-    K40, K41, K42,           K45, K46, K47, K48, K49,           K4C \
+    K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C, K4C, \
+    K10, K11, K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, K1C, K3C, \
+    K20, K21, K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B,      K2C, \
+    K30,      K31, K32, K33, K34, K35, K36, K37, K38, K39, K3A,      K3B, \
+    K40, K41, K42,                K45,                K46, K47, K48, K49  \
     ) { \
   {  K00,  K01,  K02,  K03,    K04,    K05,  K06,    K07,    K08,    K09,    K0A,    K0B,    K0C }, \
   {  K10,  K11,  K12,  K13,    K14,    K15,  K16,    K17,    K18,    K19,    K1A,    K1B,    K1C }, \


### PR DESCRIPTION
## Description

A long-overdue refactor of @alex-ong's handwired 60%.

Reference: https://github.com/qmk/qmk_firmware/pull/8215#issuecomment-617011359

@alex-ong, please note that the layout macro name changes from `LAYOUT` to `LAYOUT_60_ansi` with this pull request.

## Types of Changes

- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
