### PR TITLE
Add missing RGB_MODE_TWINKLE / RGB_M_TW keycodes

### DIFF
--- a/docs/feature_rgblight.md
+++ b/docs/feature_rgblight.md
@@ -74,6 +74,7 @@ Changing the **Value** sets the overall brightness.<br>
 |`RGB_MODE_XMAS`    |`RGB_M_X` |Christmas animation mode                                            |
 |`RGB_MODE_GRADIENT`|`RGB_M_G` |Static gradient animation mode                                      |
 |`RGB_MODE_RGBTEST` |`RGB_M_T` |Red, Green, Blue test animation mode                                |
+|`RGB_MODE_TWINKLE` |`RGB_M_TW`|Twinkle animation mode                                              |
 
 !> By default, if you have both the RGB Light and the [RGB Matrix](feature_rgb_matrix.md) feature enabled, these keycodes will work for both features, at the same time. You can disable the keycode functionality by defining the `*_DISABLE_KEYCODES` option for the specific feature.
 

--- a/quantum/process_keycode/process_rgb.c
+++ b/quantum/process_keycode/process_rgb.c
@@ -207,6 +207,11 @@ bool process_rgb(const uint16_t keycode, const keyrecord_t *record) {
                 rgblight_mode(RGBLIGHT_MODE_RGB_TEST);
 #endif
                 return false;
+            case RGB_MODE_TWINKLE:
+#if defined(RGBLIGHT_ENABLE) && !defined(RGBLIGHT_DISABLE_KEYCODES) && defined(RGBLIGHT_EFFECT_TWINKLE)
+                handleKeycodeRGBMode(RGBLIGHT_MODE_TWINKLE, RGBLIGHT_MODE_TWINKLE_end);
+#endif
+                return false;
         }
     }
 

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -511,6 +511,9 @@ enum quantum_keycodes {
     ONESHOT_DISABLE,
     ONESHOT_TOGGLE,
 
+    // Miscellaneous recent additions
+    RGB_MODE_TWINKLE,
+
     // Start of custom keycode range for keyboards and keymaps - always leave at the end
     SAFE_RANGE
 };
@@ -654,6 +657,7 @@ enum quantum_keycodes {
 #define RGB_M_X RGB_MODE_XMAS
 #define RGB_M_G RGB_MODE_GRADIENT
 #define RGB_M_T RGB_MODE_RGBTEST
+#define RGB_M_TW RGB_MODE_TWINKLE
 
 // Magic aliases
 #define CL_SWAP MAGIC_SWAP_CONTROL_CAPSLOCK

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -511,7 +511,7 @@ enum quantum_keycodes {
     ONESHOT_DISABLE,
     ONESHOT_TOGGLE,
 
-    // Miscellaneous recent additions
+    // RGB underglow/matrix (continued)
     RGB_MODE_TWINKLE,
 
     // Start of custom keycode range for keyboards and keymaps - always leave at the end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

When the Twinkle effect was implemented, keycodes were not created to select it.
This adds them.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
