### PR TITLE
tmk_core/common/action.c: refactor for code size; merge multiple `case`s into one

### DIFF
--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -410,74 +410,22 @@ void process_action(keyrecord_t *record, action_t action) {
         case ACT_MOUSEKEY:
             if (event.pressed) {
                 mousekey_on(action.key.code);
-                switch (action.key.code) {
-#    if defined(PS2_MOUSE_ENABLE) || defined(POINTING_DEVICE_ENABLE)
-                    case KC_MS_BTN1:
-                        register_button(true, MOUSE_BTN1);
-                        break;
-                    case KC_MS_BTN2:
-                        register_button(true, MOUSE_BTN2);
-                        break;
-                    case KC_MS_BTN3:
-                        register_button(true, MOUSE_BTN3);
-                        break;
-#    endif
-#    ifdef POINTING_DEVICE_ENABLE
-                    case KC_MS_BTN4:
-                        register_button(true, MOUSE_BTN4);
-                        break;
-                    case KC_MS_BTN5:
-                        register_button(true, MOUSE_BTN5);
-                        break;
-                    case KC_MS_BTN6:
-                        register_button(true, MOUSE_BTN6);
-                        break;
-                    case KC_MS_BTN7:
-                        register_button(true, MOUSE_BTN7);
-                        break;
-                    case KC_MS_BTN8:
-                        register_button(true, MOUSE_BTN8);
-                        break;
-#    endif
-                    default:
-                        mousekey_send();
-                        break;
-                }
             } else {
                 mousekey_off(action.key.code);
-                switch (action.key.code) {
+            }
+            switch (action.key.code) {
 #    if defined(PS2_MOUSE_ENABLE) || defined(POINTING_DEVICE_ENABLE)
-                    case KC_MS_BTN1:
-                        register_button(false, MOUSE_BTN1);
-                        break;
-                    case KC_MS_BTN2:
-                        register_button(false, MOUSE_BTN2);
-                        break;
-                    case KC_MS_BTN3:
-                        register_button(false, MOUSE_BTN3);
-                        break;
+#        ifdef POINTING_DEVICE_ENABLE
+                case KC_MS_BTN1 ... KC_MS_BTN8:
+#        else
+                case KC_MS_BTN1 ... KC_MS_BTN3:
+#        endif
+                    register_button(event.pressed, MOUSE_BTN_MASK(action.key.code - KC_MS_BTN1));
+                    break;
 #    endif
-#    ifdef POINTING_DEVICE_ENABLE
-                    case KC_MS_BTN4:
-                        register_button(false, MOUSE_BTN4);
-                        break;
-                    case KC_MS_BTN5:
-                        register_button(false, MOUSE_BTN5);
-                        break;
-                    case KC_MS_BTN6:
-                        register_button(false, MOUSE_BTN6);
-                        break;
-                    case KC_MS_BTN7:
-                        register_button(false, MOUSE_BTN7);
-                        break;
-                    case KC_MS_BTN8:
-                        register_button(false, MOUSE_BTN8);
-                        break;
-#    endif
-                    default:
-                        mousekey_send();
-                        break;
-                }
+                default:
+                    mousekey_send();
+                    break;
             }
             break;
 #endif

--- a/tmk_core/common/report.h
+++ b/tmk_core/common/report.h
@@ -34,15 +34,16 @@ enum hid_report_ids {
 };
 
 /* Mouse buttons */
+#define MOUSE_BTN_MASK(n) (1 << (n))
 enum mouse_buttons {
-    MOUSE_BTN1 = (1 << 0),
-    MOUSE_BTN2 = (1 << 1),
-    MOUSE_BTN3 = (1 << 2),
-    MOUSE_BTN4 = (1 << 3),
-    MOUSE_BTN5 = (1 << 4),
-    MOUSE_BTN6 = (1 << 5),
-    MOUSE_BTN7 = (1 << 6),
-    MOUSE_BTN8 = (1 << 7)
+    MOUSE_BTN1 = MOUSE_BTN_MASK(0),
+    MOUSE_BTN2 = MOUSE_BTN_MASK(1),
+    MOUSE_BTN3 = MOUSE_BTN_MASK(2),
+    MOUSE_BTN4 = MOUSE_BTN_MASK(3),
+    MOUSE_BTN5 = MOUSE_BTN_MASK(4),
+    MOUSE_BTN6 = MOUSE_BTN_MASK(5),
+    MOUSE_BTN7 = MOUSE_BTN_MASK(6),
+    MOUSE_BTN8 = MOUSE_BTN_MASK(7)
 };
 
 /* Consumer Page (0x0C)


### PR DESCRIPTION
Refactor for code size & maintainability; save ~134 bytes on ATmega32.

## Description

```
commit 03ddd855d28dca2804e6b3e2a078b484e8fb1daa (origin/develop/action-mouse, develop/action-mouse)
Author: Liyang HU <git@liyang.hu>
Date:   Tue Feb 16 14:38:16 2021 +0000

    tmk_core/common/action.c: collapse multiple `case KC_MS_BTN[1-8]:` into single `MOUSE_BTN_MASK(action.key.code - KC_MS_BTN1)`

    This saves ~134 bytes on my ATmega32.

commit 1be62c75368575e09c8aa29a4252d02945167f83
Author: Liyang HU <git@liyang.hu>
Date:   Tue Feb 16 14:06:30 2021 +0000

    tmk_core/common/report.h: define `enum mouse_buttons` in terms of `#define MOUSE_BTN_MASK()`
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] ~~Bugfix~~
- [ ] ~~New feature~~
- [x] Enhancement/optimization
- [ ] ~~Keyboard (addition or update)~~
- [ ] ~~Keymap/layout/userspace (addition or update)~~
- [ ] ~~Documentation~~

## Issues Fixed or Closed by This PR

* ~~n/a~~

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] ~~My change requires a change to the documentation.~~
- [ ] ~~I have updated the documentation accordingly.~~
- [ ] ~~I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).~~
- [ ] ~~I have added tests to cover my changes.~~
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
