### PR TITLE
Helen80 matrix fixes

### DIFF
--- a/keyboards/playkbtw/helen80/helen80.h
+++ b/keyboards/playkbtw/helen80/helen80.h
@@ -27,7 +27,7 @@
     K50, K51, K52,                K53,                K54, K55, K56, K57,   K58, K59, K5A  \
 ) { \
     { K00,   K01,   K02,   K03,   K04,   K05,   K06,   K07,   K08,   K09,   K0A,   K0B,   K0C,   K0D,   K0E   }, \
-    { K10,   K11,   K12,   K13,   K14,   K15,   K16,   K17,   K18,   K19,   K1A,   K1B,   K1C,          K1E   }, \
+    { K10,   K11,   K12,   K13,   K14,   K15,   K16,   K17,   K18,   K19,   K1A,   K1B,   K1C,   KC_NO, K1E   }, \
     { K20,   K21,   K22,   K23,   K24,   K25,   K26,   K27,   K28,   K29,   K2A,   K2B,   K2C,   K2D,   K2E   }, \
     { K30,   K31,   K32,   K33,   K34,   K35,   K36,   K37,   K38,   K39,   K3A,   K3B,   K3C,   K3D,   K3E   }, \
     { K40,   KC_NO, K41,   K42,   K43,   K44,   K45,   K46,   K47,   K48,   K49,   K4A,   K4B,   KC_NO, K4C   }, \

--- a/keyboards/playkbtw/helen80/rules.mk
+++ b/keyboards/playkbtw/helen80/rules.mk
@@ -7,6 +7,7 @@ BOOTLOADER = atmel-dfu
 # Build Options
 #   change yes to no to disable
 #
+VIA_ENABLE = yes
 BOOTMAGIC_ENABLE = full     # Virtual DIP switch configuration
 MOUSEKEY_ENABLE = yes       # Mouse keys
 EXTRAKEY_ENABLE = yes       # Audio control and System control
@@ -16,7 +17,7 @@ COMMAND_ENABLE = no         # Commands for debug and configuration
 SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
 # if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
 NKRO_ENABLE = yes           # USB Nkey Rollover
-BACKLIGHT_ENABLE = yes      # Enable keyboard backlight functionality
+BACKLIGHT_ENABLE = no      # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = yes       # Enable keyboard RGB underglow
 BLUETOOTH_ENABLE = no       # Enable Bluetooth
 AUDIO_ENABLE = no           # Audio output

--- a/keyboards/playkbtw/helen80/rules.mk
+++ b/keyboards/playkbtw/helen80/rules.mk
@@ -7,7 +7,6 @@ BOOTLOADER = atmel-dfu
 # Build Options
 #   change yes to no to disable
 #
-VIA_ENABLE = yes
 BOOTMAGIC_ENABLE = full     # Virtual DIP switch configuration
 MOUSEKEY_ENABLE = yes       # Mouse keys
 EXTRAKEY_ENABLE = yes       # Audio control and System control


### PR DESCRIPTION
old `keyboards/playkbtw/helen80/helen80.h` matrix have wrong column
for `Backspace`, causing the key to serve no function; it should have
same column as `Scroll Lock`, in standard ANSI layout terms.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

- The original `helen80.h` missed a `KC_NO` in the macro function `LAYOUT_tkl_ansi`, which makes `Backspace` serve no function.
  - This can be verified, if VIA enabled, that the keymap is blank on which should be `Backspace` on standard ANSI boards.
  - By inspecting the board matrix, either by [PCB photos in the flickr album](https://www.flickr.com/photos/149475414@N03/albums/72157716825609963?fbclid=IwAR1Nct4xqLfo45-XUijTJGaijBjZXybpJuyntsISmfVRD4wPjSwnNvnEaXU/with/50586384146) of `Helen80`, by the `config.h`, or by `VIA`, we can see that, in standard ANSI layout terms, the keys `Backspace` and `Scroll Lock` should have same column.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
