### PR TITLE
[Keyboard] Update spiderisland/split78

### DIFF
--- a/keyboards/spiderisland/split78/config.h
+++ b/keyboards/spiderisland/split78/config.h
@@ -33,3 +33,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define BACKLIGHT_PIN D4
 #define BACKLIGHT_LEVELS 3
 #define BACKLIGHT_BREATHING
+
+#define DEBOUNCE 50

--- a/keyboards/spiderisland/split78/readme.md
+++ b/keyboards/spiderisland/split78/readme.md
@@ -9,7 +9,7 @@ It is mistakenly called "87 key" on the AliExpress title and "104 key" (?!) in t
 
 This port is based on the `split75` port which was mostly done by [Michael L. Walker](https://github.com/walkerstop).
 
-* Keyboard Maintainer: [unrelenting.technology](https://github.com/myfreeweb)
+* Keyboard Maintainer: [unrelenting.technology](https://github.com/unrelentingtech)
 * Hardware Availability: https://a.aliexpress.com/_dVJsSpR
 
 Make example for this keyboard (after setting up your build environment):

--- a/keyboards/spiderisland/split78/rules.mk
+++ b/keyboards/spiderisland/split78/rules.mk
@@ -17,6 +17,7 @@ SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
 BACKLIGHT_ENABLE = yes      # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 WS2812_DRIVER = i2c
+DEBOUNCE_TYPE = sym_eager_pr
 
 # custom matrix setup
 CUSTOM_MATRIX = lite


### PR DESCRIPTION
## Description

Updates to this keyboard:

- big debounce added, since I've been having bouncing problems with the `A` key
  - `sym_eager_pr` because split, similar to ergodox
- added code to reset the MCP23018 when I2C ops fail, so reconnecting the right side doesn't require rebooting the keyboard anymore
  - the ports are prone to interrupting the connection when moving the halves around, so this makes the keyboard much less annoying
  - ping @walkerstop — might want to import these changes back into wheatfield/split75 :)
- update my github username while here

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation