### PR TITLE
Implement NKRO for VUSB

### DIFF
--- a/keyboards/spiderisland/split78/rules.mk
+++ b/keyboards/spiderisland/split78/rules.mk
@@ -11,11 +11,12 @@ BOOTMAGIC_ENABLE = lite     # Virtual DIP switch configuration
 MOUSEKEY_ENABLE = no        # Mouse keys
 EXTRAKEY_ENABLE = yes       # Audio control and System control
 CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
+COMMAND_ENABLE = yes        # Commands for debug and configuration
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
 SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
 BACKLIGHT_ENABLE = yes      # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
+NKRO_ENABLE = yes
 WS2812_DRIVER = i2c
 
 # custom matrix setup

--- a/tmk_core/common.mk
+++ b/tmk_core/common.mk
@@ -93,9 +93,7 @@ else
 endif
 
 ifeq ($(strip $(NKRO_ENABLE)), yes)
-    ifeq ($(PROTOCOL), VUSB)
-        $(info NKRO is not currently supported on V-USB, and has been disabled.)
-    else ifeq ($(strip $(BLUETOOTH_ENABLE)), yes)
+    ifeq ($(strip $(BLUETOOTH_ENABLE)), yes)
         $(info NKRO is not currently supported with Bluetooth, and has been disabled.)
     else ifneq ($(BLUETOOTH),)
         $(info NKRO is not currently supported with Bluetooth, and has been disabled.)

--- a/tmk_core/common/report.h
+++ b/tmk_core/common/report.h
@@ -110,6 +110,9 @@ enum desktop_usages {
 #        define KEYBOARD_REPORT_BITS (NKRO_EPSIZE - 1)
 #        undef NKRO_SHARED_EP
 #        undef MOUSE_SHARED_EP
+#    elif defined(PROTOCOL_VUSB)
+#        define KEYBOARD_REPORT_BITS 15
+#        undef NKRO_SHARED_EP
 #    else
 #        error "NKRO not supported with this protocol"
 #    endif

--- a/tmk_core/protocol/vusb/vusb.h
+++ b/tmk_core/protocol/vusb/vusb.h
@@ -104,6 +104,12 @@ typedef struct usbConfigurationDescriptor {
     usbEndpointDescriptor_t  rawOUTEndpoint;
 #endif
 
+#if defined(NKRO_ENABLE)
+    usbInterfaceDescriptor_t nkroInterface;
+    usbHIDDescriptor_t       nkroHID;
+    usbEndpointDescriptor_t  nkroINEndpoint;
+#endif
+
 #if defined(SHARED_EP_ENABLE) && !defined(KEYBOARD_SHARED_EP)
     usbInterfaceDescriptor_t sharedInterface;
     usbHIDDescriptor_t       sharedHID;


### PR DESCRIPTION
V-USB is limited to 8-byte endpoints, but there is already precedent for transferring larger data by issuing multiple interrupt transfers in a row.

With a dedicated NKRO interface, we can avoid a report ID, so the report would be 16 bytes - fitting right into only two transfers.

Enabled on spiderisland/split78 where it was tested.