### PR TITLE
quantum/bitwise.{c,h}: use GCC's __builtin_{clz,popcount}{,l}() when available

### DIFF
--- a/quantum/bitwise.c
+++ b/quantum/bitwise.c
@@ -16,6 +16,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include "util.h"
+#include "bitwise.h"
+
+#if defined(__GNUC__) || (__has_builtin(__builtin_popcount) && __has_builtin(__builtin_popcountl))
+
+extern Q_ALWAYS_INLINE uint8_t bitpop(uint8_t bits);
+extern Q_ALWAYS_INLINE uint8_t bitpop16(uint16_t bits);
+extern Q_ALWAYS_INLINE uint8_t bitpop32(uint32_t bits);
+
+#else /* __GNUC__ || (__builtin_popcount && __builtin_popcountl) */
 
 // bit population - return number of on-bit
 Q_NEVER_INLINE uint8_t bitpop(uint8_t bits) {
@@ -39,6 +48,16 @@ uint8_t bitpop32(uint32_t bits) {
     for (c = 0; bits; c++) bits &= bits - 1;
     return c;
 }
+
+#endif /* __GNUC__ || (__builtin_popcount && __builtin_popcountl) */
+
+#if defined(__GNUC__) || (__has_builtin(__builtin_clz) && __has_builtin(__builtin_clzl))
+
+extern Q_ALWAYS_INLINE uint8_t biton(uint8_t bits);
+extern Q_ALWAYS_INLINE uint8_t biton16(uint16_t bits);
+extern Q_ALWAYS_INLINE uint8_t biton32(uint32_t bits);
+
+#else /* __GNUC__ || (__builtin_clz && __builtin_clzl) */
 
 // most significant on-bit - return highest location of on-bit
 // NOTE: return 0 when bit0 is on or all bits are off
@@ -104,6 +123,8 @@ uint8_t biton32(uint32_t bits) {
     }
     return n;
 }
+
+#endif /* __GNUC__ || (__builtin_clz && __builtin_clzl) */
 
 Q_NEVER_INLINE uint8_t bitrev(uint8_t bits) {
     bits = (bits & 0x0f) << 4 | (bits & 0xf0) >> 4;

--- a/quantum/bitwise.c
+++ b/quantum/bitwise.c
@@ -18,7 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "util.h"
 
 // bit population - return number of on-bit
-__attribute__((noinline)) uint8_t bitpop(uint8_t bits) {
+Q_NEVER_INLINE uint8_t bitpop(uint8_t bits) {
     uint8_t c;
     for (c = 0; bits; c++) bits &= bits - 1;
     return c;
@@ -42,7 +42,7 @@ uint8_t bitpop32(uint32_t bits) {
 
 // most significant on-bit - return highest location of on-bit
 // NOTE: return 0 when bit0 is on or all bits are off
-__attribute__((noinline)) uint8_t biton(uint8_t bits) {
+Q_NEVER_INLINE uint8_t biton(uint8_t bits) {
     uint8_t n = 0;
     if (bits >> 4) {
         bits >>= 4;
@@ -105,7 +105,7 @@ uint8_t biton32(uint32_t bits) {
     return n;
 }
 
-__attribute__((noinline)) uint8_t bitrev(uint8_t bits) {
+Q_NEVER_INLINE uint8_t bitrev(uint8_t bits) {
     bits = (bits & 0x0f) << 4 | (bits & 0xf0) >> 4;
     bits = (bits & 0b00110011) << 2 | (bits & 0b11001100) >> 2;
     bits = (bits & 0b01010101) << 1 | (bits & 0b10101010) >> 1;

--- a/quantum/bitwise.h
+++ b/quantum/bitwise.h
@@ -18,18 +18,39 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #pragma once
 
 #include <stdint.h>
+#include "util.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+#if defined(__GNUC__) || (__has_builtin(__builtin_popcount) && __has_builtin(__builtin_popcountl))
+
+Q_ALWAYS_INLINE uint8_t bitpop(uint8_t bits) { return (uint8_t)__builtin_popcount(bits); }
+Q_ALWAYS_INLINE uint8_t bitpop16(uint16_t bits) { return (uint8_t)__builtin_popcount(bits); }
+Q_ALWAYS_INLINE uint8_t bitpop32(uint32_t bits) { return (uint8_t)__builtin_popcountl(bits); }
+
+#else /* __GNUC__ || (__builtin_popcount && __builtin_popcountl) */
+
 uint8_t bitpop(uint8_t bits);
 uint8_t bitpop16(uint16_t bits);
 uint8_t bitpop32(uint32_t bits);
 
+#endif /* __GNUC__ || (__builtin_popcount && __builtin_popcountl) */
+
+#if defined(__GNUC__) || (__has_builtin(__builtin_clz) && __has_builtin(__builtin_clzl))
+
+Q_ALWAYS_INLINE uint8_t biton(uint8_t bits) { return (uint8_t)(bits ? 7 - __builtin_clz(bits) : 0); }
+Q_ALWAYS_INLINE uint8_t biton16(uint16_t bits) { return (uint8_t)(bits ? 15 - __builtin_clz(bits) : 0); }
+Q_ALWAYS_INLINE uint8_t biton32(uint32_t bits) { return (uint8_t)(bits ? 31 - __builtin_clzl(bits) : 0); }
+
+#else /* __GNUC__ || (__builtin_clz && __builtin_clzl) */
+
 uint8_t biton(uint8_t bits);
 uint8_t biton16(uint16_t bits);
 uint8_t biton32(uint32_t bits);
+
+#endif /* __GNUC__ || (__builtin_clz && __builtin_clzl) */
 
 uint8_t  bitrev(uint8_t bits);
 uint16_t bitrev16(uint16_t bits);

--- a/quantum/util.h
+++ b/quantum/util.h
@@ -16,6 +16,28 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #pragma once
 
+/* GCC ≥ 10 and Clang have __has_builtin() & __has_attribute(); until then… */
+
+#ifndef __has_builtin
+#    define __has_builtin(_) 0
+#endif
+
+#ifndef __has_attribute
+#    define __has_attribute(_) 0
+#endif
+
+#if defined(__GNUC__) || __has_attribute(noinline)
+#    define Q_NEVER_INLINE __attribute__((noinline))
+#else
+#    define Q_NEVER_INLINE
+#endif
+
+#if defined(__GNUC__) || __has_attribute(always_inline)
+#    define Q_ALWAYS_INLINE inline __attribute__((always_inline))
+#else
+#    define Q_ALWAYS_INLINE inline
+#endif
+
 #include "bitwise.h"
 
 // convert to L string


### PR DESCRIPTION
## Description

Just noticed we're still using our own hand-rolled bit-twiddling code. I didn't see any obvious equivalents for our `bitrev()`.

Should we just remove the `#ifndef`'d-out definitions completely?

```
commit 29e3788044e31b7e6f3e72f973f918296d096d0f (develop/bitwise)
Author: Liyang HU <git@liyang.hu>
Date:   Sun Feb 21 14:50:18 2021 +0000

    quantum/bitwise.{c,h}: use GCC's __builtin_{clz,popcount}{,l}() when available
    
    Available as of GCC 3.4.6, released on 2006-03-06.
    
    https://gcc.gnu.org/onlinedocs/gcc-3.4.6/gcc/Other-Builtins.html

commit 0a52a93b62692e59be650bd6fba1940ad0db4057
Author: Liyang HU <git@liyang.hu>
Date:   Thu Mar 4 02:44:26 2021 +0000

    quantum/bitwise.c: use `Q_NEVER_INLINE`

commit 6a6594bd8752ca765ae8e536f47d52a1d1699fa1
Author: Liyang HU <git@liyang.hu>
Date:   Thu Mar 4 02:44:26 2021 +0000

    quantum/util.h: `#define Q_NEVER_INLINE` & `Q_ALWAYS_INLINE`
    
    ‘Q’ is short for ‘QMK’. Always has been.
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] ~~Bugfix~~
- [ ] ~~New feature~~
- [x] Enhancement/optimization
- [ ] ~~Keyboard (addition or update)~~
- [ ] ~~Keymap/layout/userspace (addition or update)~~
- [ ] ~~Documentation~~

## Issues Fixed or Closed by This PR

* ~~n/a~~

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] ~~My change requires a change to the documentation.~~
- [ ] ~~I have updated the documentation accordingly.~~
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] ~~I have added tests to cover my changes.~~
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
  I've had this change on my own keyboard for the past week.