### PR TITLE
[BUG] Massdrop develop rgb fix

### DIFF
--- a/keyboards/massdrop/ctrl/config_led.c
+++ b/keyboards/massdrop/ctrl/config_led.c
@@ -79,4 +79,4 @@ void rgb_matrix_indicators_kb(void)
 }
 #endif // USB_LED_INDICATOR_ENABLE
 
-#endif
+#endif // RGB_MATRIX_ENABLE

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -621,6 +621,9 @@ void matrix_init_quantum() {
 #ifdef AUDIO_ENABLE
     audio_init();
 #endif
+#ifdef RGB_MATRIX_ENABLE
+    rgb_matrix_init();
+#endif
 #if defined(UNICODE_ENABLE) || defined(UNICODEMAP_ENABLE) || defined(UCIS_ENABLE)
     unicode_input_mode_init();
 #endif

--- a/tmk_core/common/keyboard.c
+++ b/tmk_core/common/keyboard.c
@@ -307,9 +307,6 @@ void keyboard_init(void) {
 #ifdef RGBLIGHT_ENABLE
     rgblight_init();
 #endif
-#ifdef RGB_MATRIX_ENABLE
-    rgb_matrix_init();
-#endif
 #ifdef ENCODER_ENABLE
     encoder_init();
 #endif

--- a/tmk_core/protocol/arm_atsam/md_rgb_matrix.c
+++ b/tmk_core/protocol/arm_atsam/md_rgb_matrix.c
@@ -197,7 +197,7 @@ void md_rgb_matrix_prepare(void) {
     }
 }
 
-void led_set_one(int i, uint8_t r, uint8_t g, uint8_t b) {
+static void led_set_one(int i, uint8_t r, uint8_t g, uint8_t b) {
     if (i < ISSI3733_LED_COUNT) {
 #ifdef USE_MASSDROP_CONFIGURATOR
         md_rgb_matrix_config_override(i);
@@ -209,13 +209,13 @@ void led_set_one(int i, uint8_t r, uint8_t g, uint8_t b) {
     }
 }
 
-void led_set_all(uint8_t r, uint8_t g, uint8_t b) {
+static void led_set_all(uint8_t r, uint8_t g, uint8_t b) {
     for (uint8_t i = 0; i < ISSI3733_LED_COUNT; i++) {
         led_set_one(i, r, g, b);
     }
 }
 
-void init(void) {
+static void init(void) {
     DBGC(DC_LED_MATRIX_INIT_BEGIN);
 
     issi3733_prepare_arrays();
@@ -228,7 +228,7 @@ void init(void) {
     DBGC(DC_LED_MATRIX_INIT_COMPLETE);
 }
 
-void flush(void) {
+static void flush(void) {
 #ifdef USE_MASSDROP_CONFIGURATOR
     if (!led_enabled) {
         return;

--- a/tmk_core/protocol/arm_atsam/md_rgb_matrix.c
+++ b/tmk_core/protocol/arm_atsam/md_rgb_matrix.c
@@ -15,6 +15,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#ifdef RGB_MATRIX_ENABLE
 #include "arm_atsam_protocol.h"
 #include "led.h"
 #include "rgb_matrix.h"
@@ -470,3 +471,4 @@ static void md_rgb_matrix_config_override(int i) {
 }
 
 #endif  // USE_MASSDROP_CONFIGURATOR
+#endif  // RGB_MATRIX_ENABLE

--- a/tmk_core/protocol/arm_atsam/md_rgb_matrix_programs.c
+++ b/tmk_core/protocol/arm_atsam/md_rgb_matrix_programs.c
@@ -15,6 +15,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#ifdef RGB_MATRIX_ENABLE
 #ifdef USE_MASSDROP_CONFIGURATOR
 
 #    include "md_rgb_matrix.h"
@@ -96,4 +97,5 @@ void *led_setups[] = {leds_rainbow_s, leds_rainbow_ns, leds_teal_salmon, leds_ye
 
 const uint8_t led_setups_count = sizeof(led_setups) / sizeof(led_setups[0]);
 
-#endif
+#endif  // USE_MASSDROP_CONFIGURATOR
+#endif  // RGB_MATRIX_ENABLE


### PR DESCRIPTION
## Description

Massdrop boards weren't initialising correctly. This PR fixes things.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
