### PR TITLE
Add CLI command to import info.json files

### DIFF
--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -230,14 +230,22 @@ qmk list-keymaps -kb planck/ez
 
 ## `qmk new-keyboard`
 
-This command creates a new keyboard based on available templates.
+This command creates a new keyboard based on available templates or imports an existing config.
 
 This command will prompt for input to guide you though the generation process.
 
 **Usage**:
 
 ```
-qmk new-keyboard
+qmk new-keyboard [-kb KEYBOARD] [filename]
+```
+
+**Examples**:
+
+Import 
+
+```
+qmk new-keyboard info.json
 ```
 
 ## `qmk new-keymap`

--- a/docs/hardware_avr.md
+++ b/docs/hardware_avr.md
@@ -6,10 +6,10 @@ If you have not yet you should read the [Keyboard Guidelines](hardware_keyboard_
 
 ## Adding Your AVR Keyboard to QMK
 
-QMK has a number of features to simplify working with AVR keyboards. For most keyboards you don't have to write a single line of code. To get started, run the `util/new_keyboard.sh` script:
+QMK has a number of features to simplify working with AVR keyboards. For most keyboards you don't have to write a single line of code. To get started, run the `qmk new-keyboard` CLI command:
 
 ```
-$ ./util/new_keyboard.sh
+$ qmk new-keyboard
 Generating a new QMK keyboard directory
 
 Keyboard Name: mycoolkb

--- a/lib/python/qmk/cli/new/keyboard.py
+++ b/lib/python/qmk/cli/new/keyboard.py
@@ -1,11 +1,56 @@
-"""This script automates the creation of keyboards.
+"""This script automates the creation of keyboards and import of info.json into the repo.
 """
+import qmk.keymap
+import qmk.path
+import hjson
+import json
+
 from milc import cli
+from qmk.info import keyboard_validate
+from qmk.path import keyboard
 
 
+def _gen_dummy_keymap(name, info_data):
+    # Pick the first layout macro and just dump in KC_NOs or something?
+    (layout_name, layout_data), *_ = info_data["layouts"].items()
+    layout_length = len(layout_data["layout"])
+
+    keymap_data = {
+        "keyboard": name,
+        "layout": layout_name,
+        "layers": [["KC_NO" for _ in range(0, layout_length)]],
+    }
+
+    return json.dumps(keymap_data)
+
+
+def import_info_json(name, info):
+    # Validate to ensure we don't have to deal with bad data - handles stdin/file
+    info_data = hjson.load(info)
+    keyboard_validate(info_data)
+
+    kb_folder = keyboard(name)
+    keyboard_info = kb_folder / 'info.json'
+    keyboard_rules = kb_folder / 'rules.mk'
+    keyboard_keymap = kb_folder / 'keymaps' / 'default' / 'keymap.json'
+
+    # This is the deepest folder in the expected tree
+    keyboard_keymap.parent.mkdir(parents=True, exist_ok=True)
+
+    # Dump out all those lovely files
+    keyboard_info.write_text(json.dumps(info_data))
+    keyboard_rules.write_text("")
+    keyboard_keymap.write_text(_gen_dummy_keymap(name, info_data))
+
+
+@cli.argument('-kb', '--keyboard', arg_only=True, help='Specify keyboard name. Example: 1upkeyboards/1up60hse')
+@cli.argument('filename', type=qmk.path.FileType('r'), nargs='?', arg_only=True, help='info JSON file')
 @cli.subcommand('Creates a new keyboard')
 def new_keyboard(cli):
     """Creates a new keyboard
     """
-    # TODO: replace this bodge to the existing script
-    cli.run(['util/new_keyboard.sh'], capture_output=False)
+    if cli.args.filename:
+        import_info_json(cli.args.keyboard, cli.args.filename)
+    else:
+        # TODO: replace this bodge to the existing script
+        cli.run(['util/new_keyboard.sh'], capture_output=False)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

As a side project, i've been working on a replacement of kbfirmware that exports `info.json` files.

Looking at what the user does next, this cli command stubs out the `qmk new-keyboard` side of things while allowing import of `info.json` files.


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
