### PR TITLE
Create an option for the PloopyCo Trackball that inverts the DRAG_SCROLL mode's vertical scroll direction.

### DIFF
--- a/keyboards/ploopyco/trackball/trackball.c
+++ b/keyboards/ploopyco/trackball/trackball.c
@@ -255,7 +255,12 @@ void pointing_device_task(void) {
 
     if (is_drag_scroll) {
         mouse_report.h = mouse_report.x;
+#ifdef PLOOPY_DRAGSCROLL_INVERT
+        // Invert vertical scroll direction
+        mouse_report.v = -mouse_report.y;
+#else
         mouse_report.v = mouse_report.y;
+#endif
         mouse_report.x = 0;
         mouse_report.y = 0;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
The PloopyCo Trackball has a feature called "drag scroll" that lets the user press a button to enter a mode where scrolling is done with the trackball instead of the scroll wheel. The default behavior of the PloopyCo Trackball's drag scroll feature is for the vertical axis to scroll opposite to the direction the trackball is rolling (i.e. rolling the trackball up scrolls down and vice versa), while the horizontal axis scrolls in the same direction as the trackball. Personally, I find this a bit unintuitive, so I have added a configuration option called PLOOPY_DRAGSCROLL_INVERT that makes the vertical axis scroll in the same direction as the trackball's movement.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
