### PR TITLE
Turn off the oled display on usb suspend

### DIFF
--- a/keyboards/torn/rules.mk
+++ b/keyboards/torn/rules.mk
@@ -29,3 +29,6 @@ SRC += matrix.c \
     torn_encoder.c
 
 QUANTUM_LIB_SRC += i2c_master.c
+
+# We use our own SLEEP_LED_ENABLE to turn off the OLED display when connected to a powered usb hub
+OPT_DEFS += -DSLEEP_LED_ENABLE

--- a/keyboards/torn/torn.c
+++ b/keyboards/torn/torn.c
@@ -49,6 +49,16 @@ void torn_set_led(uint8_t led, bool state) {
     mcp23018_writeReg(IODIRB, &iodir, 1);
 }
 
+void sleep_led_init(void) {
+}
+
+void sleep_led_enable(void) {
+    oled_off();
+}
+
+void sleep_led_disable(void) {
+}
+
 // clang-format off
 const char PROGMEM bongocat_logo[] = {
   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf8, 0xf8, 0x98, 0x98, 0x98, 0x98, 0x98, 0x18, 0x18, 0x98,


### PR DESCRIPTION
When connected to a powered usb hub the oled display would never
turn off. It looks like the vusb main loop is blocked, maybe
because the irq handler is running continually. Now the oled is
turned off when the usb is disconnected.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
