### PR TITLE
[Keyboard] Allow custom OLED on Helix Rev3

### DIFF
--- a/keyboards/helix/rev3_4rows/oled_display.c
+++ b/keyboards/helix/rev3_4rows/oled_display.c
@@ -112,7 +112,7 @@ static void render_rgbled_status(bool full) {
 #endif
 }
 
-void oled_task_user(void) {
+__attribute__((weak)) void oled_task_user(void) {
   if(is_keyboard_master()){
     render_status();
   }else{

--- a/keyboards/helix/rev3_4rows/rules.mk
+++ b/keyboards/helix/rev3_4rows/rules.mk
@@ -8,4 +8,4 @@ ENCODER_ENABLE = yes
 DIP_SWITCH_ENABLE = yes
 LTO_ENABLE = yes
 
-SRC += oled_display.c
+LIB_SRC += oled_display.c

--- a/keyboards/helix/rev3_5rows/oled_display.c
+++ b/keyboards/helix/rev3_5rows/oled_display.c
@@ -112,7 +112,7 @@ static void render_rgbled_status(bool full) {
 #endif
 }
 
-void oled_task_user(void) {
+__attribute__((weak)) void oled_task_user(void) {
   if(is_keyboard_master()){
     render_status();
   }else{

--- a/keyboards/helix/rev3_5rows/rules.mk
+++ b/keyboards/helix/rev3_5rows/rules.mk
@@ -8,4 +8,4 @@ ENCODER_ENABLE = yes
 DIP_SWITCH_ENABLE = yes
 LTO_ENABLE = yes
 
-SRC += oled_display.c
+LIB_SRC += oled_display.c


### PR DESCRIPTION
## Description

The rev3 of the Helix contains the oled_user functions but with no way to override them without editing keyboard files.  This changes the functions to be weak, so that users can replace them if so desired.

## Types of Changes

- [x] Bugfix
- [x] Keyboard (addition or update)

## Issues Fixed or Closed by This PR

* convo on discord

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
