### PR TITLE
fix: Add missing python dependencies to shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -38,13 +38,31 @@ let
     doCheck = false;
   };
 
+  dotty-dict = with pkgs.python3Packages; buildPythonPackage rec {
+    pname = "dotty_dict";
+    version = "1.3.0";
+
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "6wA1o2KezYQ5emjx9C8elKvRw0V3oZzT6srTMe58uvA=";
+    };
+
+    propagatedBuildInputs = [
+      setuptools_scm
+    ];
+
+    doCheck = false;
+  };
+
   pythonEnv = pkgs.python3.withPackages (p: with p; [
     # requirements.txt
     appdirs
     argcomplete
     colorama
     hjson
+    dotty-dict
     milc
+    jsonschema
     pygments
     # requirements-dev.txt
     nose2


### PR DESCRIPTION
## Description

The packages `dotty-dict` and `jsonschemam` were added to the
requirements.txt file but were not added to the shell.nix file.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #12050 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
