### PR TITLE
Fixing adjust layer issue with the lily58 default keymap

### DIFF
--- a/keyboards/lily58/keymaps/default/keymap.c
+++ b/keyboards/lily58/keymaps/default/keymap.c
@@ -107,13 +107,8 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   )
 };
 
-// Setting ADJUST layer RGB back to default
-void update_tri_layer_RGB(uint8_t layer1, uint8_t layer2, uint8_t layer3) {
-  if (IS_LAYER_ON(layer1) && IS_LAYER_ON(layer2)) {
-    layer_on(layer3);
-  } else {
-    layer_off(layer3);
-  }
+layer_state_t layer_state_set_user(layer_state_t state) {
+  return update_tri_layer_state(state, _RAISE, _LOWER, _ADJUST);
 }
 
 //SSD1306 OLED update loop, make sure to enable OLED_DRIVER_ENABLE=yes in rules.mk

--- a/keyboards/lily58/keymaps/default/keymap.c
+++ b/keyboards/lily58/keymaps/default/keymap.c
@@ -8,8 +8,6 @@
   #include "ssd1306.h"
 #endif
 
-extern uint8_t is_master;
-
 enum layer_number {
   _QWERTY = 0,
   _LOWER,

--- a/keyboards/lily58/keymaps/default/keymap.c
+++ b/keyboards/lily58/keymaps/default/keymap.c
@@ -106,7 +106,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 };
 
 layer_state_t layer_state_set_user(layer_state_t state) {
-  return update_tri_layer_state(state, _RAISE, _LOWER, _ADJUST);
+  return update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
 }
 
 //SSD1306 OLED update loop, make sure to enable OLED_DRIVER_ENABLE=yes in rules.mk


### PR DESCRIPTION
## Description

Fixed triggering of the adjust layer in the lily58 keymap. This was broken during cleanup in pull #9979 which ended up orphaning the `update_tri_layer_RGB` function. I've updated this to use `update_tri_layer_state`, and removed an unused extern declaration.

FYI to @kata0510, maintainer of the lily58 keyboard

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
