### PR TITLE
LED Matrix: decouple from Backlight

### DIFF
--- a/common_features.mk
+++ b/common_features.mk
@@ -223,11 +223,10 @@ VALID_LED_MATRIX_TYPES := IS31FL3731 custom
 
 ifeq ($(strip $(LED_MATRIX_ENABLE)), yes)
     ifeq ($(filter $(LED_MATRIX_DRIVER),$(VALID_LED_MATRIX_TYPES)),)
-        $(error LED_MATRIX_DRIVER="$(LED_MATRIX_DRIVER)" is not a valid matrix type)
+        $(error "$(LED_MATRIX_DRIVER)" is not a valid matrix type)
     else
-        BACKLIGHT_ENABLE = yes
-        BACKLIGHT_DRIVER = custom
         OPT_DEFS += -DLED_MATRIX_ENABLE
+        SRC += $(QUANTUM_DIR)/process_keycode/process_backlight.c
         SRC += $(QUANTUM_DIR)/led_matrix.c
         SRC += $(QUANTUM_DIR)/led_matrix_drivers.c
     endif

--- a/quantum/led_matrix.c
+++ b/quantum/led_matrix.c
@@ -45,10 +45,6 @@ led_eeconfig_t led_matrix_eeconfig;
 #    define LED_DISABLE_WHEN_USB_SUSPENDED false
 #endif
 
-#ifndef EECONFIG_LED_MATRIX
-#    define EECONFIG_LED_MATRIX EECONFIG_RGBLIGHT
-#endif
-
 #if !defined(LED_MATRIX_MAXIMUM_BRIGHTNESS) || LED_MATRIX_MAXIMUM_BRIGHTNESS > 255
 #    define LED_MATRIX_MAXIMUM_BRIGHTNESS 255
 #endif
@@ -135,7 +131,7 @@ void led_matrix_set_suspend_state(bool state) { g_suspend_state = state; }
 void led_matrix_all_off(void) { led_matrix_set_index_value_all(0); }
 
 // Uniform brightness
-void led_matrix_uniform_brightness(void) { led_matrix_set_index_value_all(LED_MATRIX_MAXIMUM_BRIGHTNESS / BACKLIGHT_LEVELS * led_matrix_eeconfig.val); }
+void led_matrix_uniform_brightness(void) { led_matrix_set_index_value_all(LED_MATRIX_MAXIMUM_BRIGHTNESS * led_matrix_eeconfig.val); }
 
 void led_matrix_custom(void) {}
 
@@ -344,5 +340,3 @@ void led_matrix_set_value(uint8_t val) {
     led_matrix_set_value_noeeprom(val);
     eeconfig_update_led_matrix(led_matrix_eeconfig.raw);
 }
-
-void backlight_set(uint8_t val) { led_matrix_set_value(val); }

--- a/quantum/led_matrix.c
+++ b/quantum/led_matrix.c
@@ -131,7 +131,7 @@ void led_matrix_set_suspend_state(bool state) { g_suspend_state = state; }
 void led_matrix_all_off(void) { led_matrix_set_index_value_all(0); }
 
 // Uniform brightness
-void led_matrix_uniform_brightness(void) { led_matrix_set_index_value_all(LED_MATRIX_MAXIMUM_BRIGHTNESS * led_matrix_eeconfig.val); }
+void led_matrix_uniform_brightness(void) { led_matrix_set_index_value_all(led_matrix_eeconfig.val); }
 
 void led_matrix_custom(void) {}
 

--- a/quantum/led_matrix.h
+++ b/quantum/led_matrix.h
@@ -21,10 +21,6 @@
 
 #include "led_matrix_types.h"
 
-#ifndef BACKLIGHT_ENABLE
-#    error You must define BACKLIGHT_ENABLE with LED_MATRIX_ENABLE
-#endif
-
 enum led_matrix_effects {
     LED_MATRIX_UNIFORM_BRIGHTNESS = 1,
     // All new effects go above this line

--- a/quantum/process_keycode/process_backlight.c
+++ b/quantum/process_keycode/process_backlight.c
@@ -16,11 +16,35 @@
 
 #include "process_backlight.h"
 
-#include "backlight.h"
+#ifdef LED_MATRIX_ENABLE
+#    include "led_matrix.h"
+#else
+#    include "backlight.h"
+#endif
 
 bool process_backlight(uint16_t keycode, keyrecord_t *record) {
     if (record->event.pressed) {
         switch (keycode) {
+#ifdef LED_MATRIX_ENABLE
+            case BL_ON:
+                led_matrix_enable();
+                return false;
+            case BL_OFF:
+                led_matrix_disable();
+                return false;
+            case BL_DEC:
+                led_matrix_decrease_val();
+                return false;
+            case BL_INC:
+                led_matrix_increase_val();
+                return false;
+            case BL_TOGG:
+                led_matrix_toggle();
+                return false;
+            case BL_STEP:
+                led_matrix_step();
+                return false;
+#else
             case BL_ON:
                 backlight_level(BACKLIGHT_LEVELS);
                 return false;
@@ -39,10 +63,11 @@ bool process_backlight(uint16_t keycode, keyrecord_t *record) {
             case BL_STEP:
                 backlight_step();
                 return false;
-#ifdef BACKLIGHT_BREATHING
+#    ifdef BACKLIGHT_BREATHING
             case BL_BRTG:
                 backlight_toggle_breathing();
                 return false;
+#    endif
 #endif
         }
     }

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -234,7 +234,7 @@ bool process_record_quantum(keyrecord_t *record) {
 #ifdef AUDIO_ENABLE
             process_audio(keycode, record) &&
 #endif
-#ifdef BACKLIGHT_ENABLE
+#if defined(BACKLIGHT_ENABLE) || defined(LED_MATRIX_ENABLE)
             process_backlight(keycode, record) &&
 #endif
 #ifdef STENO_ENABLE
@@ -387,14 +387,13 @@ void matrix_init_quantum() {
     led_init_ports();
 #endif
 #ifdef BACKLIGHT_ENABLE
-#    ifdef LED_MATRIX_ENABLE
-    led_matrix_init();
-#    else
     backlight_init_ports();
-#    endif
 #endif
 #ifdef AUDIO_ENABLE
     audio_init();
+#endif
+#ifdef LED_MATRIX_ENABLE
+    led_matrix_init();
 #endif
 #ifdef RGB_MATRIX_ENABLE
     rgb_matrix_init();

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -30,11 +30,11 @@
 #include "keymap.h"
 
 #ifdef BACKLIGHT_ENABLE
-#    ifdef LED_MATRIX_ENABLE
-#        include "led_matrix.h"
-#    else
-#        include "backlight.h"
-#    endif
+#    include "backlight.h"
+#endif
+
+#ifdef LED_MATRIX_ENABLE
+#    include "led_matrix.h"
 #endif
 
 #if defined(RGBLIGHT_ENABLE)
@@ -98,7 +98,7 @@ extern layer_state_t layer_state;
 #    include "process_music.h"
 #endif
 
-#ifdef BACKLIGHT_ENABLE
+#if defined(BACKLIGHT_ENABLE) || defined(LED_MATRIX_ENABLE)
 #    include "process_backlight.h"
 #endif
 

--- a/tmk_core/common/eeconfig.h
+++ b/tmk_core/common/eeconfig.h
@@ -43,9 +43,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define EECONFIG_VELOCIKEY (uint8_t *)23
 
 #define EECONFIG_HAPTIC (uint32_t *)24
+
+// Mutually exclusive
+#define EECONFIG_LED_MATRIX (uint32_t *)28
 #define EECONFIG_RGB_MATRIX (uint32_t *)28
 // Speed & Flags
+#define EECONFIG_LED_MATRIX_EXTENDED (uint16_t *)32
 #define EECONFIG_RGB_MATRIX_EXTENDED (uint16_t *)32
+
 // TODO: Combine these into a single word and single block of EEPROM
 #define EECONFIG_KEYMAP_UPPER_BYTE (uint8_t *)34
 // Size of EEPROM being used, other code can refer to this for available EEPROM


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This PR removes the dependency of LED Matrix on `BACKLIGHT_ENABLE`, and moves the EEPROM config to the same addresses as RGB Matrix. It still uses `process_backlight()` though, as `process_led_matrix(uint16_t, keyrecord_t*)` already exists (matching the RGB Matrix one, it does not only handle keycode events).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
