### PR TITLE
Adding files for dumbpad v1.1

### DIFF
--- a/keyboards/dumbpad/rev1pt1/config.h
+++ b/keyboards/dumbpad/rev1pt1/config.h
@@ -1,0 +1,232 @@
+/*
+Copyright 2019 imchipwood
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "config_common.h"
+
+/* USB Device descriptor parameter */
+#define VENDOR_ID       0xDEAF
+#define PRODUCT_ID      0x0913
+#define DEVICE_VER      0x0001
+#define MANUFACTURER    imchipwood
+#define PRODUCT         dumbpad
+
+
+/*
+ * Keyboard Matrix Assignments
+ *
+ * Change this to how you wired your keyboard
+ * COLS: AVR pins used for columns, left to right
+ * ROWS: AVR pins used for rows, top to bottom
+ * DIODE_DIRECTION: COL2ROW = COL = Anode (+), ROW = Cathode (-, marked on diode)
+ *                  ROW2COL = ROW = Anode (+), COL = Cathode (-, marked on diode)
+ *
+*/
+#define MATRIX_ROWS 4
+#define MATRIX_COLS 5
+#define MATRIX_ROW_PINS { F4, F5, F6, F7 }
+#define MATRIX_COL_PINS { C6, D7, E6, B4, B5 }
+#define LED_NUM_LOCK_PIN B6
+#define UNUSED_PINS
+
+/* COL2ROW, ROW2COL*/
+#define DIODE_DIRECTION COL2ROW
+
+/* Rotary encoder */
+#define ENCODERS_PAD_A { B2 }
+#define ENCODERS_PAD_B { D4 }
+
+/* LED layer indicators */
+#define LAYER_INDICATOR_LED_0 B3
+#define LAYER_INDICATOR_LED_1 B1
+
+/* Bootmagic - hold down rotary encoder pushbutton while plugging in to enter bootloader */
+#define BOOTMAGIC_LITE_ROW 3
+#define BOOTMAGIC_LITE_COLUMN 0
+
+
+/* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
+#define DEBOUNCE 5
+
+/* define if matrix has ghost (lacks anti-ghosting diodes) */
+//#define MATRIX_HAS_GHOST
+
+/* number of backlight levels */
+
+/* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
+//#define LOCKING_SUPPORT_ENABLE
+/* Locking resynchronize hack */
+//#define LOCKING_RESYNC_ENABLE
+
+/*
+ * Split Keyboard specific options, make sure you have 'SPLIT_KEYBOARD = yes' in your rules.mk, and define SOFT_SERIAL_PIN.
+ */
+//#define SOFT_SERIAL_PIN D0 // or D1, D2, D3, E6
+
+// #define BACKLIGHT_PIN B7
+// #define BACKLIGHT_BREATHING
+// #define BACKLIGHT_LEVELS 3
+
+// #define RGB_DI_PIN E2
+// #ifdef RGB_DI_PIN
+//   #define RGBLED_NUM 16
+//   #define RGBLIGHT_HUE_STEP 8
+//   #define RGBLIGHT_SAT_STEP 8
+//   #define RGBLIGHT_VAL_STEP 8
+//   #define RGBLIGHT_LIMIT_VAL 255 /* The maximum brightness level */
+//   #define RGBLIGHT_SLEEP  /* If defined, the RGB lighting will be switched off when the host goes to sleep */
+// /*== all animations enable ==*/
+//   #define RGBLIGHT_ANIMATIONS
+// /*== or choose animations ==*/
+//   #define RGBLIGHT_EFFECT_BREATHING
+//   #define RGBLIGHT_EFFECT_RAINBOW_MOOD
+//   #define RGBLIGHT_EFFECT_RAINBOW_SWIRL
+//   #define RGBLIGHT_EFFECT_SNAKE
+//   #define RGBLIGHT_EFFECT_KNIGHT
+//   #define RGBLIGHT_EFFECT_CHRISTMAS
+//   #define RGBLIGHT_EFFECT_STATIC_GRADIENT
+//   #define RGBLIGHT_EFFECT_RGB_TEST
+//   #define RGBLIGHT_EFFECT_ALTERNATING
+// /*== customize breathing effect ==*/
+//   /*==== (DEFAULT) use fixed table instead of exp() and sin() ====*/
+//   #define RGBLIGHT_BREATHE_TABLE_SIZE 256      // 256(default) or 128 or 64
+//   /*==== use exp() and sin() ====*/
+//   #define RGBLIGHT_EFFECT_BREATHE_CENTER 1.85  // 1 to 2.7
+//   #define RGBLIGHT_EFFECT_BREATHE_MAX    255   // 0 to 255
+// #endif
+
+/* If defined, GRAVE_ESC will always act as ESC when CTRL is held.
+ * This is userful for the Windows task manager shortcut (ctrl+shift+esc).
+ */
+// #define GRAVE_ESC_CTRL_OVERRIDE
+
+/*
+ * Force NKRO
+ *
+ * Force NKRO (nKey Rollover) to be enabled by default, regardless of the saved
+ * state in the bootmagic EEPROM settings. (Note that NKRO must be enabled in the
+ * makefile for this to work.)
+ *
+ * If forced on, NKRO can be disabled via magic key (default = LShift+RShift+N)
+ * until the next keyboard reset.
+ *
+ * NKRO may prevent your keystrokes from being detected in the BIOS, but it is
+ * fully operational during normal computer usage.
+ *
+ * For a less heavy-handed approach, enable NKRO via magic key (LShift+RShift+N)
+ * or via bootmagic (hold SPACE+N while plugging in the keyboard). Once set by
+ * bootmagic, NKRO mode will always be enabled until it is toggled again during a
+ * power-up.
+ *
+ */
+//#define FORCE_NKRO
+
+/*
+ * Magic Key Options
+ *
+ * Magic keys are hotkey commands that allow control over firmware functions of
+ * the keyboard. They are best used in combination with the HID Listen program,
+ * found here: https://www.pjrc.com/teensy/hid_listen.html
+ *
+ * The options below allow the magic key functionality to be changed. This is
+ * useful if your keyboard/keypad is missing keys and you want magic key support.
+ *
+ */
+
+/* key combination for magic key command */
+/* defined by default; to change, uncomment and set to the combination you want */
+// #define IS_COMMAND() (get_mods() == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT)))
+
+/* control how magic key switches layers */
+//#define MAGIC_KEY_SWITCH_LAYER_WITH_FKEYS  true
+//#define MAGIC_KEY_SWITCH_LAYER_WITH_NKEYS  true
+//#define MAGIC_KEY_SWITCH_LAYER_WITH_CUSTOM false
+
+/* override magic key keymap */
+//#define MAGIC_KEY_SWITCH_LAYER_WITH_FKEYS
+//#define MAGIC_KEY_SWITCH_LAYER_WITH_NKEYS
+//#define MAGIC_KEY_SWITCH_LAYER_WITH_CUSTOM
+//#define MAGIC_KEY_HELP           H
+//#define MAGIC_KEY_HELP_ALT       SLASH
+//#define MAGIC_KEY_DEBUG          D
+//#define MAGIC_KEY_DEBUG_MATRIX   X
+//#define MAGIC_KEY_DEBUG_KBD      K
+//#define MAGIC_KEY_DEBUG_MOUSE    M
+//#define MAGIC_KEY_VERSION        V
+//#define MAGIC_KEY_STATUS         S
+//#define MAGIC_KEY_CONSOLE        C
+//#define MAGIC_KEY_LAYER0         0
+//#define MAGIC_KEY_LAYER0_ALT     GRAVE
+//#define MAGIC_KEY_LAYER1         1
+//#define MAGIC_KEY_LAYER2         2
+//#define MAGIC_KEY_LAYER3         3
+//#define MAGIC_KEY_LAYER4         4
+//#define MAGIC_KEY_LAYER5         5
+//#define MAGIC_KEY_LAYER6         6
+//#define MAGIC_KEY_LAYER7         7
+//#define MAGIC_KEY_LAYER8         8
+//#define MAGIC_KEY_LAYER9         9
+//#define MAGIC_KEY_BOOTLOADER     B
+//#define MAGIC_KEY_BOOTLOADER_ALT ESC
+//#define MAGIC_KEY_LOCK           CAPS
+//#define MAGIC_KEY_EEPROM         E
+//#define MAGIC_KEY_EEPROM_CLEAR   BSPACE
+//#define MAGIC_KEY_NKRO           N
+//#define MAGIC_KEY_SLEEP_LED      Z
+
+/*
+ * Feature disable options
+ *  These options are also useful to firmware size reduction.
+ */
+
+/* disable debug print */
+//#define NO_DEBUG
+
+/* disable print */
+//#define NO_PRINT
+
+/* disable action features */
+//#define NO_ACTION_LAYER
+//#define NO_ACTION_TAPPING
+//#define NO_ACTION_ONESHOT
+//#define NO_ACTION_MACRO
+//#define NO_ACTION_FUNCTION
+
+/*
+ * MIDI options
+ */
+
+/* enable basic MIDI features:
+   - MIDI notes can be sent when in Music mode is on
+*/
+//#define MIDI_BASIC
+
+/* enable advanced MIDI features:
+   - MIDI notes can be added to the keymap
+   - Octave shift and transpose
+   - Virtual sustain, portamento, and modulation wheel
+   - etc.
+*/
+//#define MIDI_ADVANCED
+
+/* override number of MIDI tone keycodes (each octave adds 12 keycodes and allocates 12 bytes) */
+//#define MIDI_TONE_KEYCODE_OCTAVES 1
+
+/* Bootmagic Lite key configuration */
+// #define BOOTMAGIC_LITE_ROW 0
+// #define BOOTMAGIC_LITE_COLUMN 0

--- a/keyboards/dumbpad/rev1pt1/config.h
+++ b/keyboards/dumbpad/rev1pt1/config.h
@@ -48,7 +48,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define DIODE_DIRECTION COL2ROW
 
 /* Rotary encoder */
+#undef ENCODERS_PAD_A
 #define ENCODERS_PAD_A { B2 }
+#undef ENCODERS_PAD_B 
 #define ENCODERS_PAD_B { D4 }
 
 /* LED layer indicators */

--- a/keyboards/dumbpad/rev1pt1/dumbpad.c
+++ b/keyboards/dumbpad/rev1pt1/dumbpad.c
@@ -1,0 +1,83 @@
+/* Copyright 2019 Chip
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "dumbpad.h"
+
+void keyboard_pre_init_kb(void) {
+  // Set the layer LED IO as outputs
+  setPinOutput(LAYER_INDICATOR_LED_0);
+  setPinOutput(LAYER_INDICATOR_LED_1);
+  
+  keyboard_pre_init_user();
+}
+
+void shutdown_user() {
+  // Shutdown the layer LEDs
+  writePinLow(LAYER_INDICATOR_LED_0);
+  writePinLow(LAYER_INDICATOR_LED_1);
+}
+
+layer_state_t layer_state_set_kb(layer_state_t state) {
+  // Layer LEDs act as binary indication of current layer
+  uint8_t layer = biton32(state);
+  writePin(LAYER_INDICATOR_LED_0, layer & 0b1);
+  writePin(LAYER_INDICATOR_LED_1, (layer >> 1) & 0b1);
+  return layer_state_set_user(state);
+}
+
+// Optional override functions below.
+// You can leave any or all of these undefined.
+// These are only required if you want to perform custom actions.
+
+void matrix_init_kb(void) {
+  // put your keyboard start-up code here
+  // runs once when the firmware starts up
+  for (int i = 0; i < 2; i++) {
+    writePin(LAYER_INDICATOR_LED_0, true);
+    writePin(LAYER_INDICATOR_LED_1, false);
+    wait_ms(100);
+    writePin(LAYER_INDICATOR_LED_0, true);
+    writePin(LAYER_INDICATOR_LED_1, true);
+    wait_ms(100);
+    writePin(LAYER_INDICATOR_LED_0, false);
+    writePin(LAYER_INDICATOR_LED_1, true);
+    wait_ms(100);
+    writePin(LAYER_INDICATOR_LED_0, false);
+    writePin(LAYER_INDICATOR_LED_1, false);
+    wait_ms(100);
+  }
+
+  matrix_init_user();
+}
+
+void matrix_scan_kb(void) {
+  // put your looping keyboard code here
+  // runs every cycle (a lot)
+
+  matrix_scan_user();
+}
+
+bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
+  // put your per-action keyboard code here
+  // runs for every action, just before processing by the firmware
+
+  return process_record_user(keycode, record);
+}
+
+void led_set_kb(uint8_t usb_led) {
+  // put your keyboard LED indicator (ex: Caps Lock LED) toggling code here
+
+  led_set_user(usb_led);
+}

--- a/keyboards/dumbpad/rev1pt1/dumbpad.c
+++ b/keyboards/dumbpad/rev1pt1/dumbpad.c
@@ -31,7 +31,7 @@ void shutdown_user() {
 
 layer_state_t layer_state_set_kb(layer_state_t state) {
   // Layer LEDs act as binary indication of current layer
-  uint8_t layer = biton32(state);
+  uint8_t layer = get_highest_layer(state);
   writePin(LAYER_INDICATOR_LED_0, layer & 0b1);
   writePin(LAYER_INDICATOR_LED_1, (layer >> 1) & 0b1);
   return layer_state_set_user(state);
@@ -60,24 +60,4 @@ void matrix_init_kb(void) {
   }
 
   matrix_init_user();
-}
-
-void matrix_scan_kb(void) {
-  // put your looping keyboard code here
-  // runs every cycle (a lot)
-
-  matrix_scan_user();
-}
-
-bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
-  // put your per-action keyboard code here
-  // runs for every action, just before processing by the firmware
-
-  return process_record_user(keycode, record);
-}
-
-void led_set_kb(uint8_t usb_led) {
-  // put your keyboard LED indicator (ex: Caps Lock LED) toggling code here
-
-  led_set_user(usb_led);
 }

--- a/keyboards/dumbpad/rev1pt1/dumbpad.h
+++ b/keyboards/dumbpad/rev1pt1/dumbpad.h
@@ -1,0 +1,39 @@
+/* Copyright 2019 Chip
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "quantum.h"
+
+/* This a shortcut to help you visually see your layout.
+ *
+ * The first section contains all of the arguments representing the physical
+ * layout of the board and position of the keys.
+ *
+ * The second converts the arguments into a two-dimensional array which
+ * represents the switch matrix.
+ */
+#define LAYOUT( \
+         k01, k02, k03, k04, \
+         k11, k12, k13, k14, \
+         k21, k22, k23, k24, \
+    k30, k31, k32, k33, k34 \
+) \
+{ \
+    { KC_NO, k01, k02, k03, k04 }, \
+    { KC_NO, k11, k12, k13, k14 }, \
+    { KC_NO, k21, k22, k23, k24 }, \
+    { k30,   k31, k32, k33, k34 }, \
+}

--- a/keyboards/dumbpad/rev1pt1/info.json
+++ b/keyboards/dumbpad/rev1pt1/info.json
@@ -1,0 +1,30 @@
+{
+    "keyboard_name": "dumbpad", 
+    "url": "", 
+    "maintainer": "qmk", 
+    "width": 5, 
+    "height": 4, 
+    "layouts": {
+        "LAYOUT": {
+            "layout": [
+                {"label":"7", "x":1, "y":0}, 
+                {"label":"8", "x":2, "y":0}, 
+                {"label":"9", "x":3, "y":0}, 
+                {"label":"BSPC", "x":4, "y":0}, 
+                {"label":"4", "x":1, "y":1}, 
+                {"label":"5", "x":2, "y":1}, 
+                {"label":"6", "x":3, "y":1}, 
+                {"label":"ESC", "x":4, "y":1}, 
+                {"label":"1", "x":1, "y":2}, 
+                {"label":"2", "x":2, "y":2}, 
+                {"label":"3", "x":3, "y":2}, 
+                {"label":"TAB", "x":4, "y":2}, 
+                {"label":"LMOUSE", "x":0, "y":3},
+                {"label":"TT(2)", "x":1, "y":3}, 
+                {"label":"0", "x":2, "y":3}, 
+                {"label":".", "x":3, "y":3}, 
+                {"label":"ENT", "x":4, "y":3}
+            ]
+        }
+    }
+}

--- a/keyboards/dumbpad/rev1pt1/keymaps/hectoring/config.h
+++ b/keyboards/dumbpad/rev1pt1/keymaps/hectoring/config.h
@@ -1,0 +1,2 @@
+#pragma once
+#define TAPPING_TOGGLE 2

--- a/keyboards/dumbpad/rev1pt1/keymaps/hectoring/config.h
+++ b/keyboards/dumbpad/rev1pt1/keymaps/hectoring/config.h
@@ -1,2 +1,19 @@
+/* Copyright 2021 hectoring
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
 #pragma once
 #define TAPPING_TOGGLE 2

--- a/keyboards/dumbpad/rev1pt1/keymaps/hectoring/keymap.c
+++ b/keyboards/dumbpad/rev1pt1/keymaps/hectoring/keymap.c
@@ -1,0 +1,163 @@
+/* Copyright 2019 imchipwood
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include QMK_KEYBOARD_H
+
+#define _BASE     0
+#define _FN       1
+#define _DBG      2
+
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  /*
+        BASE LAYER
+   /-----------------------------------------------------`
+   |             |    7    |    8    |    9    | Numlock |
+   |             |---------|---------|---------|---------|
+   |             |    4    |    5    |    6    |    -    |
+   |             |---------|---------|---------|---------|
+   |             |    1    |    2    |    3    |    +    |
+   |-------------|---------|---------|---------|---------|
+   |  Backspace  | MO(FN)  |    0    |    .    |  Enter  |
+   \-----------------------------------------------------'
+  */
+  [_BASE] = LAYOUT(
+                   KC_P7,     KC_P8,   KC_P9,    KC_NLCK, 
+                   KC_P4,     KC_P5,   KC_P6,    KC_KP_MINUS, 
+                   KC_P1,     KC_P2,   KC_P3,    KC_KP_PLUS, 
+    KC_BSPC,       MO(_FN),   KC_P0,   KC_PDOT,  KC_KP_ENTER
+  ),
+  /*
+        SUB LAYER
+   /-----------------------------------------------------`
+   |             |         |         |         | Numlock |
+   |             |---------|---------|---------|---------|
+   |             |         |         |         |    /    |
+   |             |---------|---------|---------|---------|
+   |             |         |         |         |    *    |
+   |-------------|---------|---------|---------|---------|
+   |  Delete     |         |         |         |         |
+   \-----------------------------------------------------'
+  */
+  [_FN] = LAYOUT(
+                 _______,     _______,     _______,      KC_NLCK, 
+                 _______,     _______,     _______,      KC_PSLS, 
+                 _______,     _______,     _______,      KC_PAST, 
+    KC_DEL,      _______,     _______,     _______,      KC_TRNS
+  ),
+  /* currently unused
+        DEBUG LAYER
+   /-----------------------------------------------------`
+   |             |         |         |         |  Reset  |
+   |             |---------|---------|---------|---------|
+   |             |         |         |         |         |
+   |             |---------|---------|---------|---------|
+   |             |         |         |         |         |
+   |-------------|---------|---------|---------|---------|
+   |             |         |         |         |         |
+   \-----------------------------------------------------'
+  */
+  [_DBG] = LAYOUT(
+                 _______,     _______,     _______,      RESET, 
+                 _______,     _______,     _______,      _______, 
+                 _______,     _______,     _______,      _______, 
+    _______,     _______,     _______,     _______,      _______
+  ),
+};
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  // If console is enabled, it will print the matrix position and status of each key pressed
+/*
+#ifdef CONSOLE_ENABLE
+    uprintf("KL: kc: %u, col: %u, row: %u, pressed: %u\n", keycode, record->event.key.col, record->event.key.row, record->event.pressed);
+#endif 
+*/
+  return true;
+}
+
+void keyboard_post_init_user(void) {
+  // Customise these values to desired behaviour
+  //debug_enable = true;
+  //debug_matrix = true;
+  //debug_keyboard = true;
+  //debug_mouse = true;
+}
+
+void matrix_init_user(void) {
+
+}
+
+void matrix_scan_user(void) {
+
+}
+
+void led_set_user(uint8_t usb_led) {
+
+}
+
+
+void encoder_update_user(uint8_t index, bool clockwise) {
+  /*  Custom encoder control - handles CW/CCW turning of encoder
+   *  Cusotom behavior:
+   *    main layer:
+   *       CW: page down
+   *      CCW: page up
+   *    function layer:
+   *       CW: end
+   *      CCW: home
+   *    debug layer:
+   *       CW: brightness up
+   *      CCW: brightness down
+   */
+  if (index == 0) {
+    switch (biton32(layer_state)) {
+      case _BASE:
+        // main layer - page up/ page down
+        if (clockwise) {
+          tap_code(KC_PGDN);
+        } else {
+          tap_code(KC_PGUP);
+        }
+        break;
+
+      case _FN:
+        // function layer - home and end
+        if (clockwise) {
+          tap_code(KC_END);
+        } else {
+          tap_code(KC_HOME);
+        }
+        break;
+
+      case _DBG: 
+        // debug layer - brightness up (CW) and brightness down (CCW)
+        if (clockwise) {
+          tap_code(KC_BRIU);
+        } else {
+          tap_code(KC_BRID);
+        }
+        break;
+
+      default:
+        // any other layer (shouldn't exist..) - volume up (CW) and down (CCW)
+        if (clockwise) {
+          tap_code(KC_VOLU);
+        } else {
+          tap_code(KC_VOLD);
+        }
+        break;   
+    }
+  }
+}

--- a/keyboards/dumbpad/rev1pt1/keymaps/hectoring/keymap.c
+++ b/keyboards/dumbpad/rev1pt1/keymaps/hectoring/keymap.c
@@ -15,10 +15,11 @@
  */
 #include QMK_KEYBOARD_H
 
-#define _BASE     0
-#define _FN       1
-#define _DBG      2
-
+enum custom_layers { 
+_BASE,
+_FN,
+_DBG,
+};
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   /*

--- a/keyboards/dumbpad/rev1pt1/readme.md
+++ b/keyboards/dumbpad/rev1pt1/readme.md
@@ -1,0 +1,19 @@
+# dumbpad
+
+![dumbpad](https://i.imgur.com/sS3fq1Z.jpg)
+
+A 4x4 macro/numpad with rotary encoder.
+
+Keyboard Maintainer: [imchipwood](https://github.com/imchipwood)
+
+PCB repository: https://github.com/imchipwood/dumbpad
+
+Make example for this keyboard (after setting up your build environment):
+
+    make dumbpad:default
+
+Program with:
+
+    make dumbpad:default:avrdude
+
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).

--- a/keyboards/dumbpad/rev1pt1/rules.mk
+++ b/keyboards/dumbpad/rev1pt1/rules.mk
@@ -1,0 +1,36 @@
+# MCU name
+MCU = atmega32u4
+
+# Bootloader selection
+#   Teensy       halfkay
+#   Pro Micro    caterina
+#   Atmel DFU    atmel-dfu
+#   LUFA DFU     lufa-dfu
+#   QMK DFU      qmk-dfu
+#   ATmega32A    bootloadHID
+#   ATmega328P   USBasp
+BOOTLOADER = caterina
+
+# Build Options
+#   change yes to no to disable
+#
+BOOTMAGIC_ENABLE = lite      # Virtual DIP switch configuration
+MOUSEKEY_ENABLE = yes       # Mouse keys
+EXTRAKEY_ENABLE = yes       # Audio control and System control
+CONSOLE_ENABLE = yes        # Console for debug
+COMMAND_ENABLE = yes        # Commands for debug and configuration
+# Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
+SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
+# if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+NKRO_ENABLE = no            # USB Nkey Rollover
+BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality on B7 by default
+RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
+MIDI_ENABLE = no            # MIDI support
+UNICODE_ENABLE = no         # Unicode
+BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
+AUDIO_ENABLE = no           # Audio output on port C6
+FAUXCLICKY_ENABLE = no      # Use buzzer to emulate clicky switches
+
+ENCODER_ENABLE = yes
+MOUSEKEY_ENABLE = yes
+KEY_LOCK_ENABLE = yes


### PR DESCRIPTION
Added files for the dumbpad v1.1

## Description

The previous dumbpad firmware has different pin assignments for the rotary encoder compared to v1.1, which I've updated. 
Note: this is for the single-encoder layout; double-encoder layouts may require additional tinkering. The pin connections can be traced relatively easily from imchipwood's gerbers.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
