### PR TITLE
Fix the typo in ergodone 80 layout

### DIFF
--- a/keyboards/ergodone/ergodone.h
+++ b/keyboards/ergodone/ergodone.h
@@ -131,7 +131,7 @@ inline void ergodox_led_all_set(uint8_t n)              {}
     { k10,   k11, k12, k13, k14, k15, k16,      k17,   k18, k19, k1A, k1B, k1C, k1D    }, \
     { k20,   k21, k22, k23, k24, k25, KC_NO,    KC_NO, k28, k29, k2A, k2B, k2C, k2D    }, \
     { k30,   k31, k32, k33, k34, k35, k36,      k37,   k38, k39, k3A, k3B, k3C, k3D    }, \
-    { k40,   k41, k42, k43, k44, k45, k45,      k47,   k48, k49, k4A, k4B, k4C, k4D    }, \
+    { k40,   k41, k42, k43, k44, k45, k46,      k47,   k48, k49, k4A, k4B, k4C, k4D    }, \
     { KC_NO, k51, k52, k53, k54, k55, k56,      k57,   k58, k59, k5A, k5B, k5C, KC_NO  }  \
    }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
The layout has one typo for ergodone keyboard in 80 key layout which makes one key duplicates the other.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
