### PR TITLE
Remove more cruft from Lily58 default keymap

### DIFF
--- a/keyboards/lily58/keymaps/default/config.h
+++ b/keyboards/lily58/keymaps/default/config.h
@@ -20,15 +20,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
-//#define USE_MATRIX_I2C
-
 /* Select hand configuration */
 
 #define MASTER_LEFT
 // #define MASTER_RIGHT
 // #define EE_HANDS
-
-// #define SSD1306OLED
 
 #define USE_SERIAL_PD2
 

--- a/keyboards/lily58/keymaps/default/config.h
+++ b/keyboards/lily58/keymaps/default/config.h
@@ -26,7 +26,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // #define MASTER_RIGHT
 // #define EE_HANDS
 
-
 #define TAPPING_FORCE_HOLD
 #define TAPPING_TERM 100
 

--- a/keyboards/lily58/keymaps/default/config.h
+++ b/keyboards/lily58/keymaps/default/config.h
@@ -26,7 +26,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // #define MASTER_RIGHT
 // #define EE_HANDS
 
-#define USE_SERIAL_PD2
 
 #define TAPPING_FORCE_HOLD
 #define TAPPING_TERM 100

--- a/keyboards/lily58/keymaps/default/keymap.c
+++ b/keyboards/lily58/keymaps/default/keymap.c
@@ -1,13 +1,5 @@
 #include QMK_KEYBOARD_H
 
-#ifdef PROTOCOL_LUFA
-  #include "lufa.h"
-  #include "split_util.h"
-#endif
-#ifdef SSD1306OLED
-  #include "ssd1306.h"
-#endif
-
 enum layer_number {
   _QWERTY = 0,
   _LOWER,


### PR DESCRIPTION
## Description

This change removes some extraneous code leftover from PR #6260 which migrated the Lily58 config to use `split_common`. This code is a no-op at the moment, and likely confusing for new Lily58 users trying to customize their keymaps.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
