### PR TITLE
Set default for USB_SUSPEND_WAKEUP_DELAY to 0/disabled

### DIFF
--- a/tmk_core/common/suspend.h
+++ b/tmk_core/common/suspend.h
@@ -14,5 +14,5 @@ void suspend_power_down_user(void);
 void suspend_power_down_kb(void);
 
 #ifndef USB_SUSPEND_WAKEUP_DELAY
-#    define USB_SUSPEND_WAKEUP_DELAY 200
+#    define USB_SUSPEND_WAKEUP_DELAY 0
 #endif


### PR DESCRIPTION

## Description

While I feel that this feature is a good change, and can benefit people, it seems that it does also cause issues. 

Have seen a couple of reports on discord of this causing problems, but ZSA has had a bunch of customers seeing issues with this change.

## Types of Changes

- [X] Core
- [X] Bugfix


## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
