### PR TITLE
Fix issues when manually shifting characters and Auto Shift

### DIFF
--- a/quantum/process_keycode/process_auto_shift.c
+++ b/quantum/process_keycode/process_auto_shift.c
@@ -46,7 +46,7 @@ static bool autoshift_press(uint16_t keycode, uint16_t now, keyrecord_t *record)
     }
 
 #    ifndef AUTO_SHIFT_MODIFIERS
-    if (get_mods() & (~MOD_BIT(KC_LSFT))) {
+    if (get_mods()) {
         return true;
     }
 #    endif


### PR DESCRIPTION
Specifically, when using the Auto-Shift feature, if you hold and roll shift, it would not actually shift the character that you hit after the shift.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* Reported from ZSA

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
