### PR TITLE
Fix qmk flash on FreeBSD

### DIFF
--- a/tmk_core/avr.mk
+++ b/tmk_core/avr.mk
@@ -160,6 +160,8 @@ define EXEC_AVRDUDE
 	list_devices() { \
 		if $(GREP) -q -s icrosoft /proc/version; then \
 		    wmic.exe path Win32_SerialPort get DeviceID 2>/dev/null | LANG=C perl -pne 's/COM(\d+)/COM.($$1-1)/e' | sed 's!COM!/dev/ttyS!' | xargs echo -n | sort; \
+		elif [ "`uname`" = "FreeBSD" ]; then \
+			ls /dev/tty* | grep -v '\.lock$$' | grep -v '\.init$$'; \
 		else \
 			ls /dev/tty*; \
 		fi; \
@@ -169,7 +171,7 @@ define EXEC_AVRDUDE
 	TMP1=`mktemp`; \
 	TMP2=`mktemp`; \
 	list_devices > $$TMP1; \
-	while [ -z $$USB ]; do \
+	while [ -z "$$USB" ]; do \
 		sleep 0.5; \
 		printf "."; \
 		list_devices > $$TMP2; \


### PR DESCRIPTION
## Description

When the USB device is connected, FreeBSD creates not one, but three
device nodes in /dev, e.g.: /dev/ttyU0, /dev/ttyU0.init, and
/dev/ttyU0.lock.

As a result, this leads to the USB variable containing 3 paths
(and therefore, whitespace) and messages like this one:

    Device /dev/ttyU0
    /dev/ttyU0.init
    /dev/ttyU0.lock has appeared; assuming it is the controller.

This changes fixes the use of the -z flag of "[" (see test(1)). Also, it
removes undesired paths from the USB variable, (hopefully) leaving only
one path there (e.g., "/dev/ttyU0").

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

<!---
## Issues Fixed or Closed by This PR


-->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] ~~My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)~~
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] ~~I have updated the documentation accordingly.~~
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] ~~I have added tests to cover my changes.~~
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
