### PR TITLE
[Keyboard] Enable RGB Matrix for Corne

### DIFF
--- a/keyboards/crkbd/rev1/common/config.h
+++ b/keyboards/crkbd/rev1/common/config.h
@@ -23,6 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #ifdef RGB_MATRIX_ENABLE
 #    define RGB_MATRIX_SPLIT { 27, 27 }
+#    define SPLIT_TRANSPORT_MIRROR
 #endif
 
 #define DIODE_DIRECTION COL2ROW

--- a/keyboards/crkbd/rev1/common/rules.mk
+++ b/keyboards/crkbd/rev1/common/rules.mk
@@ -1,2 +1,1 @@
 SPLIT_KEYBOARD = yes
-SPLIT_TRANSPORT = mirror    # for when Split Mirroring drops, it will maintain mirroring functionality

--- a/keyboards/crkbd/rev1/rev1.c
+++ b/keyboards/crkbd/rev1/rev1.c
@@ -87,7 +87,7 @@ led_config_t g_led_config = { {
 
 void matrix_init_kb(void) {
 
-#ifdef RGB_MATRIX_ENABLE
+#if defined(RGB_MATRIX_ENABLE) && !defined(RGB_MATRIX_SPLIT)
     if (!isLeftHand) {
         g_led_config = (led_config_t){ {
             {  51,  50,  45,  44,  37,  36 },


### PR DESCRIPTION
## Description

Since the RGB Matrix Split stuff has landed, add support for it in the corne keyboard. 

## Types of Changes

- [x] Keyboard (addition or update)


## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
