### PR TITLE
Update correct layout name for online configurator

### DIFF
--- a/keyboards/bastardkb/tbk/info.json
+++ b/keyboards/bastardkb/tbk/info.json
@@ -5,7 +5,7 @@
     "width": 17,
     "height": 8,
     "layouts": {
-        "LAYOUT": {
+        "LAYOUT_split_4x6_5": {
             "layout": [
                 {"label":"L00", "x":0, "y":0},
                 {"label":"L01", "x":1, "y":0},


### PR DESCRIPTION
## Description

Change the layout name so it is displayed correctly in the online configurator

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
