### PR TITLE
Set default OLED Update Interval for Split Keyboards

### DIFF
--- a/drivers/oled/oled_driver.h
+++ b/drivers/oled/oled_driver.h
@@ -158,6 +158,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    define OLED_I2C_TIMEOUT 100
 #endif
 
+#if !defined(OLED_UPDATE_INTERVAL) && defined(SPLIT_KEYBOARD)
+#    define OLED_UPDATE_INTERVAL 50
+#endif
+
 typedef struct __attribute__((__packed__)) {
     uint8_t *current_element;
     uint16_t remaining_element_count;


### PR DESCRIPTION
Because the matrix scanning is slower for splits, in general,
the frequent updating of the OLEDs can slow down the matrix scanning.
To help prevent that, set the update interval for the OLEDs to not
update as frequently.


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Enhancement/optimization

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
