### PR TITLE
Separate `oled_task_user()` from `drivers/oled/oled_driver.c`.

### DIFF
--- a/common_features.mk
+++ b/common_features.mk
@@ -557,6 +557,7 @@ ifeq ($(strip $(OLED_DRIVER_ENABLE)), yes)
     OPT_DEFS += -DOLED_DRIVER_ENABLE
     COMMON_VPATH += $(DRIVER_PATH)/oled
     QUANTUM_LIB_SRC += i2c_master.c
+    QUANTUM_LIB_SRC += oled_driver_user_task.c
     SRC += oled_driver.c
 endif
 

--- a/docs/feature_oled_driver.md
+++ b/docs/feature_oled_driver.md
@@ -315,7 +315,8 @@ uint8_t oled_get_brightness(void);
 // Basically it's oled_render, but with timeout management and oled_task_user calling!
 void oled_task(void);
 
-// Function to be implemented by the user, called at the start of the oled_task.
+// Called at the start of oled_task, The user can implement this function, otherwise
+// the default empty implementation will be linked.
 void oled_task_user(void);
 
 // Set the specific 8 lines rows of the screen to scroll.

--- a/docs/feature_oled_driver.md
+++ b/docs/feature_oled_driver.md
@@ -315,7 +315,7 @@ uint8_t oled_get_brightness(void);
 // Basically it's oled_render, but with timeout management and oled_task_user calling!
 void oled_task(void);
 
-// Called at the start of oled_task, weak function overridable by the user
+// Function to be implemented by the user, called at the start of the oled_task.
 void oled_task_user(void);
 
 // Set the specific 8 lines rows of the screen to scroll.

--- a/drivers/oled/oled_driver.c
+++ b/drivers/oled/oled_driver.c
@@ -721,5 +721,3 @@ void oled_task(void) {
     }
 #endif
 }
-
-__attribute__((weak)) void oled_task_user(void) {}

--- a/drivers/oled/oled_driver_user_task.c
+++ b/drivers/oled/oled_driver_user_task.c
@@ -1,0 +1,3 @@
+#include "oled_driver.h"
+
+void oled_task_user(void) { }

--- a/drivers/oled/oled_driver_user_task.c
+++ b/drivers/oled/oled_driver_user_task.c
@@ -1,3 +1,2 @@
-#include "oled_driver.h"
-
+/* if user code dose not define oled_task_user(), this will be linked */
 void oled_task_user(void) { }

--- a/keyboards/spacetime/rev2/rev2.c
+++ b/keyboards/spacetime/rev2/rev2.c
@@ -42,7 +42,3 @@ void led_set_kb(uint8_t usb_led) {
 
 	led_set_user(usb_led);
 }
-
-#ifdef OLED_DRIVER_ENABLE
-__attribute__((weak)) void oled_task_user(void) {}
-#endif

--- a/keyboards/spacetime/rev2/rev2.c
+++ b/keyboards/spacetime/rev2/rev2.c
@@ -42,3 +42,7 @@ void led_set_kb(uint8_t usb_led) {
 
 	led_set_user(usb_led);
 }
+
+#ifdef OLED_DRIVER_ENABLE
+__attribute__((weak)) void oled_task_user(void) {}
+#endif


### PR DESCRIPTION
## Description

Separate `oled_task_user()` from `drivers/oled/oled_driver.c` into a library that is linked as needed.

**This change is required by #12041.**

Delete the following line at the end of `drivers/oled/oled_driver.c`. ~~Because `oled_task_user()` is a function that the user must implement, not an option. If `oled_task_user()` is not defined, the build must fail.~~

```c
__attribute__((weak)) void oled_task_user(void) {}
```

And add drivers/oled/oled_driver_user_task.c that have empty `oled_task_user()`. This will be a library as shown below and will be linked if the user did not define `oled_task_user()`.

```makefile
// $(TOP)/common_features.mk
ifeq ($(strip $(OLED_DRIVER_ENABLE)), yes)
    OPT_DEFS += -DOLED_DRIVER_ENABLE
    COMMON_VPATH += $(DRIVER_PATH)/oled
    QUANTUM_LIB_SRC += i2c_master.c
    QUANTUM_LIB_SRC += oled_driver_user_task.c
    SRC += oled_driver.c
endif
```

This change provides more ways to provide the keyboard-level default oled_task_user(). See https://github.com/qmk/qmk_firmware/pull/12113#issuecomment-791944270 and https://github.com/qmk/qmk_firmware/pull/12041#issuecomment-788925669 for details.


Tagging: @XScorpion2 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
