### PR TITLE
Remove stale references to "handwired/ferris"

### DIFF
--- a/keyboards/ferris/keymaps/default/keymap.json
+++ b/keyboards/ferris/keymaps/default/keymap.json
@@ -1,7 +1,7 @@
 {    "version": 1,
     "notes": "My awesome keymap",
     "documentation": "\"This file is a QMK Configurator export. You can import this at <https://config.qmk.fm>. It can also be used directly with QMK's source code.\n\nTo setup your QMK environment check out the tutorial: <https://docs.qmk.fm/#/newbs>\n\nYou can convert this file to a keymap.c using this command: `qmk json2c {keymap}`\n\nYou can compile this keymap using this command: `qmk compile {keymap}`\"\n",
-    "keyboard": "handwired/ferris",
+    "keyboard": "ferris/0_1",
     "keymap": "default",
     "layout": "LAYOUT",
     "layers": [

--- a/keyboards/ferris/keymaps/default/readme.md
+++ b/keyboards/ferris/keymaps/default/readme.md
@@ -111,7 +111,7 @@ To edit it, you may:
 If you decide to use the latter workflow, here are the steps to follow:
 
 * From the qmk configurator, hit the "import QMK keymap json file" button (it has a drawing with an up arrow on it).
-* Browse to the location of your keymap (for example, `<your qmk repo>/keyboards/handwired/ferris/keymaps/default/keymap.json`)
+* Browse to the location of your keymap (for example, `<your qmk repo>/keyboards/ferris/keymaps/default/keymap.json`)
 * Perform any modification to the keymap in the web UI
 * Export the keymap to your downloads folder, by hitting the "Export QMK keymap json file" button (it has a drawing with a down arrow on it)
 * Override your original keymap with the output of formatting the exported keymap by running a command such as this one from the root of your qmk repo:

--- a/keyboards/ferris/keymaps/pierrec83/keymap.json
+++ b/keyboards/ferris/keymaps/pierrec83/keymap.json
@@ -1,7 +1,7 @@
 {    "version": 1,
     "notes": "My awesome keymap",
     "documentation": "\"This file is a QMK Configurator export. You can import this at <https://config.qmk.fm>. It can also be used directly with QMK's source code.\n\nTo setup your QMK environment check out the tutorial: <https://docs.qmk.fm/#/newbs>\n\nYou can convert this file to a keymap.c using this command: `qmk json2c {keymap}`\n\nYou can compile this keymap using this command: `qmk compile {keymap}`\"\n",
-    "keyboard": "handwired/ferris",
+    "keyboard": "ferris/0_1",
     "keymap": "pierrec83",
     "layout": "LAYOUT",
     "layers": [


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
The code was moved to the "ferris" directory.

Fixes the following commands:
```
qmk compile ~/qmk_firmware/keyboards/ferris/keymaps/default/keymap.json
qmk compile ~/qmk_firmware/keyboards/ferris/keymaps/pierrec83/keymap.json
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/pierrechevalier83/ferris/issues/5

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
