### PR TITLE
Fix Permissive Hold when TAPPING_TERM_PER_KEY is defined

### DIFF
--- a/tmk_core/common/action_tapping.c
+++ b/tmk_core/common/action_tapping.c
@@ -121,12 +121,20 @@ bool process_tapping(keyrecord_t *keyp) {
                  */
 #    if defined(TAPPING_TERM_PER_KEY) || (TAPPING_TERM >= 500) || defined(PERMISSIVE_HOLD) || defined(PERMISSIVE_HOLD_PER_KEY)
                 else if (
+                    ((
 #        ifdef TAPPING_TERM_PER_KEY
-                    (get_tapping_term(get_event_keycode(tapping_key.event, false), keyp) >= 500) &&
+                        get_tapping_term(get_event_keycode(tapping_key.event, false), keyp)
+#        else
+                        TAPPING_TERM
 #        endif
+                        >= 500 )
+
 #        ifdef PERMISSIVE_HOLD_PER_KEY
-                    !get_permissive_hold(get_event_keycode(tapping_key.event, false), keyp) &&
+                        || get_permissive_hold(get_event_keycode(tapping_key.event, false), keyp)
+#        elif defined(PERMISSIVE_HOLD)
+                        || true
 #        endif
+                    ) &&
                     IS_RELEASED(event) && waiting_buffer_typed(event)) {
                     debug("Tapping: End. No tap. Interfered by typing key\n");
                     process_record(&tapping_key);


### PR DESCRIPTION
The logic for TAPPING_TERM_PER_KEY and PERMISSIVE_HOLD_PER_KEY has been updated to reflect the behavior as described in the document.

## Description

Issue [#10587](https://github.com/qmk/qmk_firmware/issues/10587):  When TAPPING_TERM_PER_KEY is defined and TAPPING_TERM is less than 500, permissive hold would not work/be active, regardless of whether PERMISSIVE_HOLD or PERMISSIVE_HOLD_PER_KEY is defined.  When both _PER_KEY macros are defined, we currently have:
 
`if ( (get_tapping_term(...) >= 500) && !get_permissive_hold(...) && ... ) { ... }`

If get_tapping_term() returns anything smaller than 500, the if-clause condition would be false regardless of get_permissive_hold, or the rest of the conditions.  This needs to be changed to:

`if (( (get_tapping_term(...) >= 500) || get_permissive_hold(...) ) && ... ) { ... }`

Note that the NOT (!) operator in front of get_permissive_hold() is removed here.  This is reported in issue [#8999](https://github.com/qmk/qmk_firmware/issues/8999).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* (1) When TAPPING_TERM_PER_KEY is defined and TAPPING_TERM is less than 500, the values of PERMISSIVE_HOLD and PERMISSIVE_HOLD_PER_KEY are ignore; i.e., permissive hold will never happen.  Issue [#10587](https://github.com/qmk/qmk_firmware/issues/10587)
* (2) When get_permissive_hold() returns true for a keycode, it prevents permissive hold for that keycode instead.  Issue [#8999](https://github.com/qmk/qmk_firmware/issues/8999)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
