### PR TITLE
Force `SKIP_VERSION = yes` when the target is `check-md5`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -561,9 +561,16 @@ else
 BUILD_DATE := 2020-01-01-00:00:00
 endif
 
-$(shell echo '#define QMK_VERSION "$(GIT_VERSION)"' > $(ROOT_DIR)/quantum/version.h)
-$(shell echo '#define QMK_BUILDDATE "$(BUILD_DATE)"' >> $(ROOT_DIR)/quantum/version.h)
-$(shell echo '#define CHIBIOS_VERSION "$(CHIBIOS_VERSION)"' >> $(ROOT_DIR)/quantum/version.h)
-$(shell echo '#define CHIBIOS_CONTRIB_VERSION "$(CHIBIOS_CONTRIB_VERSION)"' >> $(ROOT_DIR)/quantum/version.h)
+$(shell echo '#ifndef SKIP_VERSION' > $(ROOT_DIR)/quantum/version.h)
+$(shell echo '#  define QMK_VERSION "$(GIT_VERSION)"' >> $(ROOT_DIR)/quantum/version.h)
+$(shell echo '#  define QMK_BUILDDATE "$(BUILD_DATE)"' >> $(ROOT_DIR)/quantum/version.h)
+$(shell echo '#  define CHIBIOS_VERSION "$(CHIBIOS_VERSION)"' >> $(ROOT_DIR)/quantum/version.h)
+$(shell echo '#  define CHIBIOS_CONTRIB_VERSION "$(CHIBIOS_CONTRIB_VERSION)"' >> $(ROOT_DIR)/quantum/version.h)
+$(shell echo '#else' >> $(ROOT_DIR)/quantum/version.h)
+$(shell echo '#  define QMK_VERSION "NA"' >> $(ROOT_DIR)/quantum/version.h)
+$(shell echo '#  define QMK_BUILDDATE "2020-01-01-00:00:00"' >> $(ROOT_DIR)/quantum/version.h)
+$(shell echo '#  define CHIBIOS_VERSION "NA"' >> $(ROOT_DIR)/quantum/version.h)
+$(shell echo '#  define CHIBIOS_CONTRIB_VERSION "NA"' >> $(ROOT_DIR)/quantum/version.h)
+$(shell echo '#endif' >> $(ROOT_DIR)/quantum/version.h)
 
 include $(ROOT_DIR)/testlist.mk

--- a/build_keyboard.mk
+++ b/build_keyboard.mk
@@ -34,6 +34,10 @@ $(error MASTER does not have a valid value(left/right))
     endif
 endif
 
+ifneq ($(filter check-md5,$(strip $(MAKECMDGOALS))),)
+   SKIP_VERSION = yes
+endif
+
 ifdef SKIP_VERSION
     OPT_DEFS += -DSKIP_VERSION
 endif


### PR DESCRIPTION
## Description

When building the exact same source file, the `check-md5` target should have the same result, but in some cases it wasn't, so I fixed it. (#11338)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #12123

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
