### PR TITLE
Fix Kinetic speed condition

### DIFF
--- a/quantum/mousekey.c
+++ b/quantum/mousekey.c
@@ -108,7 +108,7 @@ static uint8_t wheel_unit(void) {
 }
 
 #    else /* #ifndef MK_COMBINED */
-#        ifndef MK_KINETIC_SPEED
+#        ifdef MK_KINETIC_SPEED
 
 /*
  * Kinetic movement  acceleration algorithm


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR
In `#define MK_COMBINED`, this compile error is shown:
```c
quantum/mousekey.c: In function 'move_unit':
quantum/mousekey.c:135:35: error: 'mouse_timer' undeclared (first use in this function)
  135 |     } else if (mousekey_repeat && mouse_timer) {
      |                                   ^~~~~~~~~~~
quantum/mousekey.c:135:35: note: each undeclared identifier is reported only once for each function it appears in
quantum/mousekey.c: At top level:
quantum/mousekey.c:149:7: error: conflicting types for 'mk_wheel_interval'
  149 | float mk_wheel_interval = 1000.0f / MOUSEKEY_WHEEL_INITIAL_MOVEMENTS;
      |       ^~~~~~~~~~~~~~~~~
quantum/mousekey.c:68:9: note: previous definition of 'mk_wheel_interval' was here
   68 | uint8_t mk_wheel_interval    = MOUSEKEY_WHEEL_INTERVAL;
      |         ^~~~~~~~~~~~~~~~~
quantum/mousekey.c: In function 'wheel_unit':
quantum/mousekey.c:156:35: error: 'mouse_timer' undeclared (first use in this function)
  156 |     } else if (mousekey_repeat && mouse_timer) {
      |                                   ^~~~~~~~~~~
```

And the `mouse_timer` is defined at `#ifdef MK_KINETIC_SPEED`:
https://github.com/qmk/qmk_firmware/blob/788b1854b42a916919c3e8efc77b366ba03d2d8c/quantum/mousekey.c#L39-L41

But, if I read correctly, `mouse_timer` is only used when `#ifndef MK_KINETIC_SPEED`.

This PR fixes this by flipping the condition.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
