### PR TITLE
fix info.json layout name for boardsource/5x12

### DIFF
--- a/keyboards/boardsource/5x12/info.json
+++ b/keyboards/boardsource/5x12/info.json
@@ -5,7 +5,7 @@
     "width": 12,
     "height": 5,
     "layouts": {
-        "LAYOUT": {
+        "LAYOUT_ortho_5x12": {
             "layout": [
                 { "label": "K01", "x": 0, "y": 0 },
                 { "label": "K02", "x": 1, "y": 0 },


### PR DESCRIPTION
The layout name in info.json didn't match the name elsewhere in the code, so I couldn't load keymaps in properly

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
