### PR TITLE
Fixes an issue where custom keycodes were not possible in Torn

### DIFF
--- a/keyboards/torn/bongocat.c
+++ b/keyboards/torn/bongocat.c
@@ -373,7 +373,7 @@ void oled_task_user(void) {
 
 bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
   sleep_timer = timer_read32();
-  return true;
+  return process_record_user(keycode, record);
 }
 
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I was implementing a keymap for Torn and noticed that `process_record_user` was never called. 

After speaking to Torn's creator, @rtitmuss, this was identified as the fix.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation
- [ ] 
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
