### PR TITLE
Make the size of MATRIX_ROW_PINS and MATRIX_ROW_PINS_RIGHT the same

### DIFF
--- a/keyboards/choco60/rev2/config.h
+++ b/keyboards/choco60/rev2/config.h
@@ -29,7 +29,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #define MATRIX_ROW_PINS { C5, C4, B6, B7, C7 }
 #define MATRIX_ROW_PINS_RIGHT { D3, D2, D5, D6, B0 }
-#define MATRIX_COL_PINS { C6, B4, B3, B2, B1, B0 }
+/* The last B1, B2, and B3 are dummies to make the same size as MATRIX_ROW_PINS_RIGHT. */
+#define MATRIX_COL_PINS { C6, B4, B3, B2, B1, B0, B1, B2, B3 }
 #define MATRIX_COL_PINS_RIGHT { C7, B7, B6, B5, B4, B3, B2, C6, D4 }
 #define UNUSED_PINS
 

--- a/keyboards/choco60/rev2/config.h
+++ b/keyboards/choco60/rev2/config.h
@@ -29,8 +29,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #define MATRIX_ROW_PINS { C5, C4, B6, B7, C7 }
 #define MATRIX_ROW_PINS_RIGHT { D3, D2, D5, D6, B0 }
-/* The last B1, B2, and B3 are dummies to make the same size as MATRIX_ROW_PINS_RIGHT. */
-#define MATRIX_COL_PINS { C6, B4, B3, B2, B1, B0, B1, B2, B3 }
+/* The last three NO_PIN are dummies to make the same size as MATRIX_ROW_PINS_RIGHT. */
+#define MATRIX_COL_PINS { C6, B4, B3, B2, B1, B0, NO_PIN, NO_PIN, NO_PIN }
 #define MATRIX_COL_PINS_RIGHT { C7, B7, B6, B5, B4, B3, B2, C6, D4 }
 #define UNUSED_PINS
 


### PR DESCRIPTION
## Description

As described in [this documentation](https://docs.qmk.fm/#/config_options?id=other-options), the size of MATRIX_ROW_PINS and MATRIX_ROW_PINS_RIGHT must be the same.

> Currently, the size of MATRIX_ROW_PINS must be the same as MATRIX_ROW_PINS_RIGHT and likewise for the definition of columns.

This PR will fix the problem.

Related PR: #12111

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [X] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
