### PR TITLE
TAP_DANCE_REFRESH_INTERRUPTED_KEYCODE

### DIFF
--- a/docs/feature_tap_dance.md
+++ b/docs/feature_tap_dance.md
@@ -42,6 +42,8 @@ For more complicated cases, use the third or fourth options (examples of each ar
 
 Finally, the fifth option is particularly useful if your non-Tap-Dance keys start behaving weirdly after adding the code for your Tap Dance keys. The likely problem is that you changed the `TAPPING_TERM` time to make your Tap Dance keys easier for you to use, and that this has changed the way your other keys handle interrupts.
 
+> If you are a fast typist and change layers or modifiers inside of your `on_dance_finished_fn` then add `#define TAP_DANCE_REFRESH_INTERRUPTED_KEYCODE` in `config.h` to get correctly modified key during the tapping term.
+
 ## Implementation Details :id=implementation
 
 Well, that's the bulk of it! You should now be able to work through the examples below, and to develop your own Tap Dance functionality. But if you want a deeper understanding of what's going on behind the scenes, then read on for the explanation of how it all works!

--- a/quantum/process_keycode/process_tap_dance.c
+++ b/quantum/process_keycode/process_tap_dance.c
@@ -102,23 +102,26 @@ static inline void process_tap_dance_action_on_reset(qk_tap_dance_action_t *acti
     send_keyboard_report();
 }
 
-void preprocess_tap_dance(uint16_t keycode, keyrecord_t *record) {
+bool preprocess_tap_dance(uint16_t keycode, keyrecord_t *record) {
     qk_tap_dance_action_t *action;
 
-    if (!record->event.pressed) return;
+    if (!record->event.pressed) return false;
 
-    if (highest_td == -1) return;
+    if (highest_td == -1) return false;
 
+    bool interrupted = false;
     for (int i = 0; i <= highest_td; i++) {
         action = &tap_dance_actions[i];
         if (action->state.count) {
             if (keycode == action->state.keycode && keycode == last_td) continue;
             action->state.interrupted          = true;
+            interrupted                        = true;
             action->state.interrupting_keycode = keycode;
             process_tap_dance_action_on_dance_finished(action);
             reset_tap_dance(&action->state);
         }
     }
+    return interrupted;
 }
 
 bool process_tap_dance(uint16_t keycode, keyrecord_t *record) {

--- a/quantum/process_keycode/process_tap_dance.h
+++ b/quantum/process_keycode/process_tap_dance.h
@@ -83,7 +83,7 @@ extern qk_tap_dance_action_t tap_dance_actions[];
 
 /* To be used internally */
 
-void preprocess_tap_dance(uint16_t keycode, keyrecord_t *record);
+bool preprocess_tap_dance(uint16_t keycode, keyrecord_t *record);
 bool process_tap_dance(uint16_t keycode, keyrecord_t *record);
 void matrix_scan_tap_dance(void);
 void reset_tap_dance(qk_tap_dance_state_t *state);

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -202,7 +202,13 @@ bool process_record_quantum(keyrecord_t *record) {
 #endif
 
 #ifdef TAP_DANCE_ENABLE
-    preprocess_tap_dance(keycode, record);
+    bool tap_dance_interrupted = preprocess_tap_dance(keycode, record);
+
+#ifdef TAP_DANCE_REFRESH_INTERRUPTED_KEYCODE
+    if (tap_dance_interrupted) {
+        keycode = get_record_keycode(record, true);
+    }
+#endif
 #endif
 
     if (!(


### PR DESCRIPTION
## Description

Added to docs:
> If you are a fast typist and change layers or modifiers inside of your `on_dance_finished_fn` then add `#define TAP_DANCE_REFRESH_INTERRUPTED_KEYCODE` in `config.h` to get correctly modified key during the tapping term.

I use this fix for two years with [my keyboards](https://github.com/zored/zkf) and now it's time to share it with community 😄 

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
