### PR TITLE
ARM WS2812 SPI config (baudrate and circular buffer)

### DIFF
--- a/docs/ws2812_driver.md
+++ b/docs/ws2812_driver.md
@@ -77,6 +77,25 @@ Configure the hardware via your config.h:
 
 You must also turn on the SPI feature in your halconf.h and mcuconf.h
 
+#### Circular Buffer Mode
+Some boards may flicker while in the normal buffer mode. To fix this issue, circular buffer mode may be used to rectify the issue. 
+
+By default, the circular buffer mode is disabled.
+
+To enable this alternative buffer mode, place this into your `config.h` file:
+```c
+#define WS2812_SPI_USE_CIRCULAR_BUFFER
+```
+
+#### Setting baudrate with divisor
+To adjust the baudrate at which the SPI peripheral is configured, users will need to derive the target baudrate from the clock tree provided by STM32CubeMX.
+
+Only divisors of 2, 4, 8, 16, 32, 64, 128 and 256 are supported by hardware.
+
+|Define              |Default|Description                          |
+|--------------------|-------|-------------------------------------|
+|`WS2812_SPI_DIVISOR`|`16`   |SPI source clock peripheral divisor  |
+
 #### Testing Notes
 
 While not an exhaustive list, the following table provides the scenarios that have been partially validated:

--- a/drivers/chibios/ws2812_spi.c
+++ b/drivers/chibios/ws2812_spi.c
@@ -38,6 +38,7 @@
 #        define WS2812_SPI_DIVISOR (SPI_CR1_BR_2)    // fpclk/32
 #    else
 #        define WS2812_SPI_DIVISOR (SPI_CR1_BR_1 | SPI_CR1_BR_0)    // fpclk/16
+#    endif
 #endif
 
 // Define SPI circular buffer
@@ -46,6 +47,7 @@
 #        define WS2812_SPI_CIRCULAR_BUFFER 1
 #    else
 #        define WS2812_SPI_CIRCULAR_BUFFER 0
+#    endif
 #endif
 
 #define BYTES_FOR_LED_BYTE 4

--- a/drivers/chibios/ws2812_spi.c
+++ b/drivers/chibios/ws2812_spi.c
@@ -40,6 +40,14 @@
 #        define WS2812_SPI_DIVISOR (SPI_CR1_BR_1 | SPI_CR1_BR_0)    // fpclk/16
 #endif
 
+// Define SPI circular buffer
+#ifndef WS2812_SPI_CIRCULAR_BUFFER
+#    if defined(STM32L4XX)
+#        define WS2812_SPI_CIRCULAR_BUFFER 1
+#    else
+#        define WS2812_SPI_CIRCULAR_BUFFER 0
+#endif
+
 #define BYTES_FOR_LED_BYTE 4
 #define NB_COLORS 3
 #define BYTES_FOR_LED (BYTES_FOR_LED_BYTE * NB_COLORS)
@@ -90,7 +98,7 @@ void ws2812_init(void) {
 
     // TODO: more dynamic baudrate
     static const SPIConfig spicfg = {
-        0, NULL, PAL_PORT(RGB_DI_PIN), PAL_PAD(RGB_DI_PIN),
+        WS2812_SPI_CIRCULAR_BUFFER, NULL, PAL_PORT(RGB_DI_PIN), PAL_PAD(RGB_DI_PIN),
         WS2812_SPI_DIVISOR  // baudrate : fpclk / 8 => 1tick is 0.32us (2.25 MHz)
     };
 

--- a/drivers/chibios/ws2812_spi.c
+++ b/drivers/chibios/ws2812_spi.c
@@ -33,6 +33,9 @@
 #endif
 
 // Define SPI config speed
+// baudrate should target 3.2MHz
+// F072 fpclk = 48MHz 
+// 48/16 = 3Mhz
 #ifndef WS2812_SPI_DIVISOR
 #    if defined(STM32L4XX)
 #        define WS2812_SPI_DIVISOR (SPI_CR1_BR_2)    // fpclk/32
@@ -101,7 +104,7 @@ void ws2812_init(void) {
     // TODO: more dynamic baudrate
     static const SPIConfig spicfg = {
         WS2812_SPI_CIRCULAR_BUFFER, NULL, PAL_PORT(RGB_DI_PIN), PAL_PAD(RGB_DI_PIN),
-        WS2812_SPI_DIVISOR  // baudrate : fpclk / 8 => 1tick is 0.32us (2.25 MHz)
+        WS2812_SPI_DIVISOR
     };
 
     spiAcquireBus(&WS2812_SPI);     /* Acquire ownership of the bus.    */

--- a/drivers/chibios/ws2812_spi.c
+++ b/drivers/chibios/ws2812_spi.c
@@ -138,10 +138,10 @@ void ws2812_setleds(LED_TYPE* ledarray, uint16_t leds) {
 
     // Send async - each led takes ~0.03ms, 50 leds ~1.5ms, animations flushing faster than send will cause issues.
     // Instead spiSend can be used to send synchronously (or the thread logic can be added back).
-#ifdef WS2812_SPI_SYNC
+#ifndef WS2812_SPI_USE_CIRCULAR_BUFFER
+#    ifdef WS2812_SPI_SYNC
     spiSend(&WS2812_SPI, sizeof(txbuf) / sizeof(txbuf[0]), txbuf);
-#else
-#    ifndef WS2812_SPI_USE_CIRCULAR_BUFFER 
+#    else
     spiStartSend(&WS2812_SPI, sizeof(txbuf) / sizeof(txbuf[0]), txbuf);
 #    endif
 #endif

--- a/drivers/chibios/ws2812_spi.c
+++ b/drivers/chibios/ws2812_spi.c
@@ -32,6 +32,14 @@
 #    endif
 #endif
 
+// Define SPI config speed
+#ifndef WS2812_SPI_DIVISOR
+#    if defined(STM32L4XX)
+#        define WS2812_SPI_DIVISOR (SPI_CR1_BR_2)    // fpclk/32
+#    else
+#        define WS2812_SPI_DIVISOR (SPI_CR1_BR_1 | SPI_CR1_BR_0)    // fpclk/16
+#endif
+
 #define BYTES_FOR_LED_BYTE 4
 #define NB_COLORS 3
 #define BYTES_FOR_LED (BYTES_FOR_LED_BYTE * NB_COLORS)
@@ -83,7 +91,7 @@ void ws2812_init(void) {
     // TODO: more dynamic baudrate
     static const SPIConfig spicfg = {
         0, NULL, PAL_PORT(RGB_DI_PIN), PAL_PAD(RGB_DI_PIN),
-        SPI_CR1_BR_1 | SPI_CR1_BR_0  // baudrate : fpclk / 8 => 1tick is 0.32us (2.25 MHz)
+        WS2812_SPI_DIVISOR  // baudrate : fpclk / 8 => 1tick is 0.32us (2.25 MHz)
     };
 
     spiAcquireBus(&WS2812_SPI);     /* Acquire ownership of the bus.    */

--- a/drivers/chibios/ws2812_spi.c
+++ b/drivers/chibios/ws2812_spi.c
@@ -107,6 +107,9 @@ void ws2812_init(void) {
     spiAcquireBus(&WS2812_SPI);     /* Acquire ownership of the bus.    */
     spiStart(&WS2812_SPI, &spicfg); /* Setup transfer parameters.       */
     spiSelect(&WS2812_SPI);         /* Slave Select assertion.          */
+#if WS2812_SPI_CIRCULAR_BUFFER == 1
+    spiStartSend(&WS2812_SPI, sizeof(txbuf) / sizeof(txbuf[0]), txbuf);
+#endif
 }
 
 void ws2812_setleds(LED_TYPE* ledarray, uint16_t leds) {
@@ -125,6 +128,8 @@ void ws2812_setleds(LED_TYPE* ledarray, uint16_t leds) {
 #ifdef WS2812_SPI_SYNC
     spiSend(&WS2812_SPI, sizeof(txbuf) / sizeof(txbuf[0]), txbuf);
 #else
+#    if WS2812_SPI_CIRCULAR_BUFFER == 0 
     spiStartSend(&WS2812_SPI, sizeof(txbuf) / sizeof(txbuf[0]), txbuf);
+#    endif
 #endif
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Enable the divisor to be changed on different platforms due to different clock sources.
Also enable circular buffer so that SCK and MISO do not need to be defined (issue on STM32L433).

Edit: Tested and working on L433 and F072

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Enable the divisor to be changed on different platforms.
* Enable optional circular buffer configuration

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
