### PR TITLE
Preserve signedness from opt_encoder_handler for scroll data on Ploopy devices

### DIFF
--- a/keyboards/ploopyco/mouse/mouse.c
+++ b/keyboards/ploopyco/mouse/mouse.c
@@ -96,7 +96,7 @@ __attribute__((weak)) void process_wheel(report_mouse_t* mouse_report) {
     uint16_t p2 = adc_read(OPT_ENC2_MUX);
     if (debug_encoder) dprintf("OPT1: %d, OPT2: %d\n", p1, p2);
 
-    uint8_t dir = opt_encoder_handler(p1, p2);
+    int dir = opt_encoder_handler(p1, p2);
 
     if (dir == 0) return;
     process_wheel_user(mouse_report, mouse_report->h, (int)(mouse_report->v + (dir * OPT_SCALE)));

--- a/keyboards/ploopyco/trackball/trackball.c
+++ b/keyboards/ploopyco/trackball/trackball.c
@@ -96,7 +96,7 @@ __attribute__((weak)) void process_wheel(report_mouse_t* mouse_report) {
     uint16_t p2 = adc_read(OPT_ENC2_MUX);
     if (debug_encoder) dprintf("OPT1: %d, OPT2: %d\n", p1, p2);
 
-    uint8_t dir = opt_encoder_handler(p1, p2);
+    int dir = opt_encoder_handler(p1, p2);
 
     if (dir == 0) return;
     process_wheel_user(mouse_report, mouse_report->h, (int)(mouse_report->v + (dir * OPT_SCALE)));


### PR DESCRIPTION
This is a bugfix for Ploopy devices (trackball and mouse).

Ploopy devices use an optical encoder to produce scroll information. The `opt_encoder_handler` returns a value of `1`, `-1` or `0` depending on direction of scroll. This was being coerced into a `uint8_t`, discarding the sign. The problem was masked by the coercion happening when the value is put into the mouse descriptor's `int8_t`.

It's not clear to me why `process_wheel_user` uses `int16_t` for its `h` and `v` parameters, when the `mouse_report` values are only `int8_t`, and `dir` only takes values of `1`, `-1` and `0`. Perhaps `int8_t` is more appropriate for the `dir` variable? Maybe even `opt_encoder_handler`? I matched the `dir` type to the function which produces it, and changed nothing that didn't strictly need to change.