### PR TITLE
Removed unused RGBLED_TIMER_TOP and F_CPU macros from quantum/rgblight.[ch]

### DIFF
--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -884,22 +884,6 @@ typedef void (*effect_func_t)(animation_status_t *anim);
 
 // Animation timer -- use system timer (AVR Timer0)
 void rgblight_timer_init(void) {
-    // OLD!!!! Animation timer -- AVR Timer3
-    // static uint8_t rgblight_timer_is_init = 0;
-    // if (rgblight_timer_is_init) {
-    //   return;
-    // }
-    // rgblight_timer_is_init = 1;
-    // /* Timer 3 setup */
-    // TCCR3B = _BV(WGM32) // CTC mode OCR3A as TOP
-    //       | _BV(CS30); // Clock selelct: clk/1
-    // /* Set TOP value */
-    // uint8_t sreg = SREG;
-    // cli();
-    // OCR3AH = (RGBLED_TIMER_TOP >> 8) & 0xff;
-    // OCR3AL = RGBLED_TIMER_TOP & 0xff;
-    // SREG = sreg;
-
     rgblight_status.timer_enabled = false;
     RGBLIGHT_SPLIT_SET_CHANGE_TIMER_ENABLE;
 }

--- a/quantum/rgblight.h
+++ b/quantum/rgblight.h
@@ -170,9 +170,6 @@ enum RGBLIGHT_EFFECT_MODE {
 #        define RGBLIGHT_LIMIT_VAL 255
 #    endif
 
-#    define RGBLED_TIMER_TOP F_CPU / (256 * 64)
-// #define RGBLED_TIMER_TOP 0xFF10
-
 #    include <stdint.h>
 #    include <stdbool.h>
 #    include "eeconfig.h"


### PR DESCRIPTION
## Description

There is no change in compilation result binary.

* Befor:
```
% find quantum tmk_core keyboards -name '*.[ch]' | xargs grep RGBLED_TIMER_TOP
quantum/rgblight.c:    // OCR3AH = (RGBLED_TIMER_TOP >> 8) & 0xff;
quantum/rgblight.c:    // OCR3AL = RGBLED_TIMER_TOP & 0xff;
quantum/rgblight.h:#    define RGBLED_TIMER_TOP F_CPU / (256 * 64)
quantum/rgblight.h:// #define RGBLED_TIMER_TOP 0xFF10
keyboards/mxss/rgblight.c:    // OCR3AH = (RGBLED_TIMER_TOP >> 8) & 0xff;
keyboards/mxss/rgblight.c:    // OCR3AL = RGBLED_TIMER_TOP & 0xff;
```
* After
```
% find quantum tmk_core keyboards -name '*.[ch]' | xargs grep RGBLED_TIMER_TOP
keyboards/mxss/rgblight.c:    // OCR3AH = (RGBLED_TIMER_TOP >> 8) & 0xff;
keyboards/mxss/rgblight.c:    // OCR3AL = RGBLED_TIMER_TOP & 0xff;
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
