### PR TITLE
Add function to allow repeated blinking of one layer

### DIFF
--- a/docs/feature_rgblight.md
+++ b/docs/feature_rgblight.md
@@ -309,6 +309,18 @@ void post_process_record_user(uint16_t keycode, keyrecord_t *record) {
 }
 ```
 
+You can also use `rgblight_blink_layer_repeat` to specify the amount of times the layer is supposed to blink. Using the layers from above,
+```c
+void post_process_record_user(uint16_t keycode, keyrecord_t *record) {
+    switch (keycode) {
+        case DEBUG:
+            rgblight_blink_layer_repeat(debug_enable ? 0 : 1, 200, 3);
+            break;
+    }
+}
+```
+would turn the layer 0 (or 1) on and off again three times when `DEBUG` is pressed.
+
 ### Overriding RGB Lighting on/off status
 
 Normally lighting layers are not shown when RGB Lighting is disabled (e.g. with `RGB_TOG` keycode). If you would like lighting layers to work even when the RGB Lighting is otherwise off, add `#define RGBLIGHT_LAYERS_OVERRIDE_RGB_OFF` to your `config.h`.

--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -725,10 +725,18 @@ static void rgblight_layers_write(void) {
 rgblight_layer_mask_t _blinked_layer_mask = 0;
 static uint16_t       _blink_timer;
 
+rgblight_layer_mask_t _repeating_layer_mask = 0;
+static uint16_t       _repeat_timer;
+static uint8_t        _times_remaining = 1;
+static uint16_t       _dur;
+
 void rgblight_blink_layer(uint8_t layer, uint16_t duration_ms) {
     rgblight_set_layer_state(layer, true);
     _blinked_layer_mask |= (rgblight_layer_mask_t)1 << layer;
     _blink_timer = sync_timer_read() + duration_ms;
+    if (_repeat_timer) {
+        _repeat_timer = sync_timer_read() + 2 * duration_ms;
+    }
 }
 
 void rgblight_unblink_layers(void) {
@@ -739,6 +747,29 @@ void rgblight_unblink_layers(void) {
             }
         }
         _blinked_layer_mask = 0;
+    }
+}
+
+void rgblight_blink_layer_repeat(uint8_t layer, uint16_t duration_ms, uint8_t times) {
+    _times_remaining = times;
+    _repeating_layer_mask |= (rgblight_layer_mask_t)1 << layer;
+    _repeat_timer = sync_timer_read() + 2 * duration_ms;
+    _dur = duration_ms;
+    _times_remaining--;
+    rgblight_blink_layer(layer, duration_ms);
+}
+
+void rgblight_blink_layer_repeat_helper(void) {
+    if (_repeating_layer_mask != 0 && timer_expired(sync_timer_read(), _repeat_timer)) {
+        for (uint8_t layer = 0; layer < RGBLIGHT_MAX_LAYERS; layer++) {
+            if ((_repeating_layer_mask & (rgblight_layer_mask_t)1 << layer) != 0 && _times_remaining > 0) {
+                _times_remaining--;
+                rgblight_blink_layer(layer, _dur);
+            }
+        }
+        if (_times_remaining <= 0) {
+            _repeating_layer_mask = 0;
+        }
     }
 }
 #    endif
@@ -757,6 +788,7 @@ void rgblight_suspend(void) {
         // make sure any layer blinks don't come back after suspend
         rgblight_status.enabled_layer_mask &= ~_blinked_layer_mask;
         _blinked_layer_mask = 0;
+        _repeating_layer_mask = 0;
 #    endif
 
         rgblight_disable_noeeprom();
@@ -1047,6 +1079,7 @@ void rgblight_task(void) {
 
 #    ifdef RGBLIGHT_LAYER_BLINK
     rgblight_unblink_layers();
+    rgblight_blink_layer_repeat_helper();
 #    endif
 }
 

--- a/quantum/rgblight.h
+++ b/quantum/rgblight.h
@@ -225,6 +225,7 @@ extern const rgblight_segment_t *const *rgblight_layers;
 #        ifdef RGBLIGHT_LAYER_BLINK
 #            define RGBLIGHT_USE_TIMER
 void rgblight_blink_layer(uint8_t layer, uint16_t duration_ms);
+void rgblight_blink_layer_repeat(uint8_t layer, uint16_t duration_ms, uint8_t times);
 #        endif
 
 #    endif


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Added the functions `rgblight_blink_layer_repeat` and `rgblight_blink_layer_repeat_helper`. When `rgblight_blink_layer_repeat` is called, it stores the number of repeats in a counter which is decremented every time a layer is turned on again. `rgblight_blink_layer_repeat_helper` is called after `rgblight_unblink_layers` to check if a lighting layer needs to be enabled again. Both functions call `rgblight_blink_layer` to turn on a layer.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] New feature
- [ ] Core
- [ ] Bugfix
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
