### PR TITLE
Big quantum_keycodes cleanup

### DIFF
--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -71,6 +71,7 @@ enum quantum_keycodes {
     QK_STENO_BOLT           = 0x5A30,
     QK_STENO_GEMINI         = 0x5A31,
     QK_STENO_MAX            = 0x5A3F,
+    // 0x5C00 - 0x5FFF are reserved, see below
     QK_MOD_TAP              = 0x6000,
     QK_MOD_TAP_MAX          = 0x7FFF,
     QK_UNICODE              = 0x8000,

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -16,18 +16,10 @@
 
 #pragma once
 
-#if defined(SEQUENCER_ENABLE)
-#    include "sequencer.h"
-#endif
+#include "sequencer.h"
 
-#ifndef MIDI_ENABLE_STRICT
-#    define MIDI_ENABLE_STRICT 0
-#endif
-
-#if !MIDI_ENABLE_STRICT || (defined(MIDI_ENABLE) && defined(MIDI_ADVANCED))
-#    ifndef MIDI_TONE_KEYCODE_OCTAVES
-#        define MIDI_TONE_KEYCODE_OCTAVES 3
-#    endif
+#ifndef MIDI_TONE_KEYCODE_OCTAVES
+#    define MIDI_TONE_KEYCODE_OCTAVES 3
 #endif
 
 // Fillers to make layering more clear
@@ -67,6 +59,8 @@ enum quantum_keycodes {
     QK_ONE_SHOT_LAYER_MAX   = 0x54FF,
     QK_ONE_SHOT_MOD         = 0x5500,
     QK_ONE_SHOT_MOD_MAX     = 0x55FF,
+    QK_SWAP_HANDS           = 0x5600,
+    QK_SWAP_HANDS_MAX       = 0x56FF,
     QK_TAP_DANCE            = 0x5700,
     QK_TAP_DANCE_MAX        = 0x57FF,
     QK_LAYER_TAP_TOGGLE     = 0x5800,
@@ -77,8 +71,6 @@ enum quantum_keycodes {
     QK_STENO_BOLT           = 0x5A30,
     QK_STENO_GEMINI         = 0x5A31,
     QK_STENO_MAX            = 0x5A3F,
-    QK_SWAP_HANDS           = 0x5B00,
-    QK_SWAP_HANDS_MAX       = 0x5BFF,
     QK_MOD_TAP              = 0x6000,
     QK_MOD_TAP_MAX          = 0x7FFF,
     QK_UNICODE              = 0x8000,
@@ -90,498 +82,443 @@ enum quantum_keycodes {
 
     // Loose keycodes - to be used directly
     RESET = 0x5C00,
-    DEBUG,
-    MAGIC_SWAP_CONTROL_CAPSLOCK,
-    MAGIC_CAPSLOCK_TO_CONTROL,
-    MAGIC_SWAP_LALT_LGUI,
-    MAGIC_SWAP_RALT_RGUI,
-    MAGIC_NO_GUI,
-    MAGIC_SWAP_GRAVE_ESC,
-    MAGIC_SWAP_BACKSLASH_BACKSPACE,
-    MAGIC_HOST_NKRO,
-    MAGIC_SWAP_ALT_GUI,
-    MAGIC_UNSWAP_CONTROL_CAPSLOCK,
-    MAGIC_UNCAPSLOCK_TO_CONTROL,
-    MAGIC_UNSWAP_LALT_LGUI,
-    MAGIC_UNSWAP_RALT_RGUI,
-    MAGIC_UNNO_GUI,
-    MAGIC_UNSWAP_GRAVE_ESC,
-    MAGIC_UNSWAP_BACKSLASH_BACKSPACE,
-    MAGIC_UNHOST_NKRO,
-    MAGIC_UNSWAP_ALT_GUI,
-    MAGIC_TOGGLE_NKRO,
-    MAGIC_TOGGLE_ALT_GUI,
-    GRAVE_ESC,
+    DEBUG,  // 5C01
 
-// Leader key
-#ifdef LEADER_ENABLE
-    KC_LEAD,
-#endif
+    // Magic
+    MAGIC_SWAP_CONTROL_CAPSLOCK,       // 5C02
+    MAGIC_CAPSLOCK_TO_CONTROL,         // 5C03
+    MAGIC_SWAP_LALT_LGUI,              // 5C04
+    MAGIC_SWAP_RALT_RGUI,              // 5C05
+    MAGIC_NO_GUI,                      // 5C06
+    MAGIC_SWAP_GRAVE_ESC,              // 5C07
+    MAGIC_SWAP_BACKSLASH_BACKSPACE,    // 5C08
+    MAGIC_HOST_NKRO,                   // 5C09
+    MAGIC_SWAP_ALT_GUI,                // 5C0A
+    MAGIC_UNSWAP_CONTROL_CAPSLOCK,     // 5C0B
+    MAGIC_UNCAPSLOCK_TO_CONTROL,       // 5C0C
+    MAGIC_UNSWAP_LALT_LGUI,            // 5C0D
+    MAGIC_UNSWAP_RALT_RGUI,            // 5C0E
+    MAGIC_UNNO_GUI,                    // 5C0F
+    MAGIC_UNSWAP_GRAVE_ESC,            // 5C10
+    MAGIC_UNSWAP_BACKSLASH_BACKSPACE,  // 5C11
+    MAGIC_UNHOST_NKRO,                 // 5C12
+    MAGIC_UNSWAP_ALT_GUI,              // 5C13
+    MAGIC_TOGGLE_NKRO,                 // 5C14
+    MAGIC_TOGGLE_ALT_GUI,              // 5C15
 
-// Auto Shift setup
-#ifndef AUTO_SHIFT_NO_SETUP
-    KC_ASUP,
-    KC_ASDN,
-    KC_ASRP,
-#endif
-    KC_ASTG,
-    KC_ASON,
-    KC_ASOFF,
+    // Grave Escape
+    GRAVE_ESC,  // 5C16
 
-    // Audio on/off/toggle
-    AU_ON,
-    AU_OFF,
-    AU_TOG,
+    // Auto Shift
+    KC_ASUP,   // 5C17
+    KC_ASDN,   // 5C18
+    KC_ASRP,   // 5C19
+    KC_ASTG,   // 5C1A
+    KC_ASON,   // 5C1B
+    KC_ASOFF,  // 5C1C
 
-    // Faux clicky as part of main audio feature
-    CLICKY_TOGGLE,
-    CLICKY_ENABLE,
-    CLICKY_DISABLE,
-    CLICKY_UP,
-    CLICKY_DOWN,
-    CLICKY_RESET,
+    // Audio
+    AU_ON,   // 5C1D
+    AU_OFF,  // 5C1E
+    AU_TOG,  // 5C1F
 
-    // Music mode on/off/toggle
-    MU_ON,
-    MU_OFF,
-    MU_TOG,
+    // Audio Clicky
+    CLICKY_TOGGLE,   // 5C20
+    CLICKY_ENABLE,   // 5C21
+    CLICKY_DISABLE,  // 5C22
+    CLICKY_UP,       // 5C23
+    CLICKY_DOWN,     // 5C24
+    CLICKY_RESET,    // 5C25
 
-    // Music mode cycle
-    MU_MOD,
+    // Music mode
+    MU_ON,   // 5C26
+    MU_OFF,  // 5C27
+    MU_TOG,  // 5C28
+    MU_MOD,  // 5C29
+    MUV_IN,  // 5C2A
+    MUV_DE,  // 5C2B
 
-    // Music voice iterate
-    MUV_IN,
-    MUV_DE,
+    // MIDI
+    MI_ON,   // 5C2C
+    MI_OFF,  // 5C2D
+    MI_TOG,  // 5C2E
 
-// Midi
-#if !MIDI_ENABLE_STRICT || (defined(MIDI_ENABLE) && defined(MIDI_BASIC))
-    MI_ON,
-    MI_OFF,
-    MI_TOG,
-#endif
-
-#if !MIDI_ENABLE_STRICT || (defined(MIDI_ENABLE) && defined(MIDI_ADVANCED))
-    MIDI_TONE_MIN,
-
-#    if !MIDI_ENABLE_STRICT || MIDI_TONE_KEYCODE_OCTAVES > 0
-    MI_C = MIDI_TONE_MIN,
-    MI_Cs,
+    MI_C,   // 5C2F
+    MI_Cs,  // 5C30
     MI_Db = MI_Cs,
-    MI_D,
-    MI_Ds,
+    MI_D,   // 5C31
+    MI_Ds,  // 5C32
     MI_Eb = MI_Ds,
-    MI_E,
-    MI_F,
-    MI_Fs,
+    MI_E,   // 5C33
+    MI_F,   // 5C34
+    MI_Fs,  // 5C35
     MI_Gb = MI_Fs,
-    MI_G,
-    MI_Gs,
+    MI_G,   // 5C36
+    MI_Gs,  // 5C37
     MI_Ab = MI_Gs,
-    MI_A,
-    MI_As,
+    MI_A,   // 5C38
+    MI_As,  // 5C39
     MI_Bb = MI_As,
-    MI_B,
-#    endif
+    MI_B,  // 5C3A
 
-#    if !MIDI_ENABLE_STRICT || MIDI_TONE_KEYCODE_OCTAVES > 1
-    MI_C_1,
-    MI_Cs_1,
+    MI_C_1,   // 5C3B
+    MI_Cs_1,  // 5C3C
     MI_Db_1 = MI_Cs_1,
-    MI_D_1,
-    MI_Ds_1,
+    MI_D_1,   // 5C3D
+    MI_Ds_1,  // 5C3E
     MI_Eb_1 = MI_Ds_1,
-    MI_E_1,
-    MI_F_1,
-    MI_Fs_1,
+    MI_E_1,   // 5C3F
+    MI_F_1,   // 5C40
+    MI_Fs_1,  // 5C41
     MI_Gb_1 = MI_Fs_1,
-    MI_G_1,
-    MI_Gs_1,
+    MI_G_1,   // 5C42
+    MI_Gs_1,  // 5C43
     MI_Ab_1 = MI_Gs_1,
-    MI_A_1,
-    MI_As_1,
+    MI_A_1,   // 5C44
+    MI_As_1,  // 5C45
     MI_Bb_1 = MI_As_1,
-    MI_B_1,
-#    endif
+    MI_B_1,  // 5C46
 
-#    if !MIDI_ENABLE_STRICT || MIDI_TONE_KEYCODE_OCTAVES > 2
-    MI_C_2,
-    MI_Cs_2,
+    MI_C_2,   // 5C47
+    MI_Cs_2,  // 5C48
     MI_Db_2 = MI_Cs_2,
-    MI_D_2,
-    MI_Ds_2,
+    MI_D_2,   // 5C49
+    MI_Ds_2,  // 5C4A
     MI_Eb_2 = MI_Ds_2,
-    MI_E_2,
-    MI_F_2,
-    MI_Fs_2,
+    MI_E_2,   // 5C4B
+    MI_F_2,   // 5C4C
+    MI_Fs_2,  // 5C4D
     MI_Gb_2 = MI_Fs_2,
-    MI_G_2,
-    MI_Gs_2,
+    MI_G_2,   // 5C4E
+    MI_Gs_2,  // 5C4F
     MI_Ab_2 = MI_Gs_2,
-    MI_A_2,
-    MI_As_2,
+    MI_A_2,   // 5C50
+    MI_As_2,  // 5C51
     MI_Bb_2 = MI_As_2,
-    MI_B_2,
-#    endif
+    MI_B_2,  // 5C52
 
-#    if !MIDI_ENABLE_STRICT || MIDI_TONE_KEYCODE_OCTAVES > 3
-    MI_C_3,
-    MI_Cs_3,
+    MI_C_3,   // 5C53
+    MI_Cs_3,  // 5C54
     MI_Db_3 = MI_Cs_3,
-    MI_D_3,
-    MI_Ds_3,
+    MI_D_3,   // 5C55
+    MI_Ds_3,  // 5C56
     MI_Eb_3 = MI_Ds_3,
-    MI_E_3,
-    MI_F_3,
-    MI_Fs_3,
+    MI_E_3,   // 5C57
+    MI_F_3,   // 5C58
+    MI_Fs_3,  // 5C59
     MI_Gb_3 = MI_Fs_3,
-    MI_G_3,
-    MI_Gs_3,
+    MI_G_3,   // 5C5A
+    MI_Gs_3,  // 5C5B
     MI_Ab_3 = MI_Gs_3,
-    MI_A_3,
-    MI_As_3,
+    MI_A_3,   // 5C5C
+    MI_As_3,  // 5C5D
     MI_Bb_3 = MI_As_3,
-    MI_B_3,
-#    endif
+    MI_B_3,  // 5C5E
 
-#    if !MIDI_ENABLE_STRICT || MIDI_TONE_KEYCODE_OCTAVES > 4
-    MI_C_4,
-    MI_Cs_4,
+    MI_C_4,   // 5C5F
+    MI_Cs_4,  // 5C60
     MI_Db_4 = MI_Cs_4,
-    MI_D_4,
-    MI_Ds_4,
+    MI_D_4,   // 5C61
+    MI_Ds_4,  // 5C62
     MI_Eb_4 = MI_Ds_4,
-    MI_E_4,
-    MI_F_4,
-    MI_Fs_4,
+    MI_E_4,   // 5C63
+    MI_F_4,   // 5C64
+    MI_Fs_4,  // 5C65
     MI_Gb_4 = MI_Fs_4,
-    MI_G_4,
-    MI_Gs_4,
+    MI_G_4,   // 5C66
+    MI_Gs_4,  // 5C67
     MI_Ab_4 = MI_Gs_4,
-    MI_A_4,
-    MI_As_4,
+    MI_A_4,   // 5C68
+    MI_As_4,  // 5C69
     MI_Bb_4 = MI_As_4,
-    MI_B_4,
-#    endif
+    MI_B_4,  // 5C6A
 
-#    if !MIDI_ENABLE_STRICT || MIDI_TONE_KEYCODE_OCTAVES > 5
-    MI_C_5,
-    MI_Cs_5,
+    MI_C_5,   // 5C6B
+    MI_Cs_5,  // 5C6C
     MI_Db_5 = MI_Cs_5,
-    MI_D_5,
-    MI_Ds_5,
+    MI_D_5,   // 5C6D
+    MI_Ds_5,  // 5C6E
     MI_Eb_5 = MI_Ds_5,
-    MI_E_5,
-    MI_F_5,
-    MI_Fs_5,
+    MI_E_5,   // 5C6F
+    MI_F_5,   // 5C70
+    MI_Fs_5,  // 5C71
     MI_Gb_5 = MI_Fs_5,
-    MI_G_5,
-    MI_Gs_5,
+    MI_G_5,   // 5C72
+    MI_Gs_5,  // 5C73
     MI_Ab_5 = MI_Gs_5,
-    MI_A_5,
-    MI_As_5,
+    MI_A_5,   // 5C74
+    MI_As_5,  // 5C75
     MI_Bb_5 = MI_As_5,
-    MI_B_5,
-#    endif
+    MI_B_5,  // 5C76
 
-#    if !MIDI_ENABLE_STRICT || MIDI_TONE_KEYCODE_OCTAVES > 5
-    MIDI_TONE_MAX = MI_B_5,
-#    elif MIDI_TONE_KEYCODE_OCTAVES > 4
-    MIDI_TONE_MAX = MI_B_4,
-#    elif MIDI_TONE_KEYCODE_OCTAVES > 3
-    MIDI_TONE_MAX = MI_B_3,
-#    elif MIDI_TONE_KEYCODE_OCTAVES > 2
-    MIDI_TONE_MAX = MI_B_2,
-#    elif MIDI_TONE_KEYCODE_OCTAVES > 1
-    MIDI_TONE_MAX = MI_B_1,
-#    elif MIDI_TONE_KEYCODE_OCTAVES > 0
-    MIDI_TONE_MAX = MI_B,
-#    endif
+    MI_OCT_N2,  // 5C77
+    MI_OCT_N1,  // 5C78
+    MI_OCT_0,   // 5C79
+    MI_OCT_1,   // 5C7A
+    MI_OCT_2,   // 5C7B
+    MI_OCT_3,   // 5C7C
+    MI_OCT_4,   // 5C7D
+    MI_OCT_5,   // 5C7E
+    MI_OCT_6,   // 5C7F
+    MI_OCT_7,   // 5C80
+    MI_OCTD,    // 5C81
+    MI_OCTU,    // 5C82
 
-    MIDI_OCTAVE_MIN,
-    MI_OCT_N2 = MIDI_OCTAVE_MIN,
-    MI_OCT_N1,
-    MI_OCT_0,
-    MI_OCT_1,
-    MI_OCT_2,
-    MI_OCT_3,
-    MI_OCT_4,
-    MI_OCT_5,
-    MI_OCT_6,
-    MI_OCT_7,
-    MIDI_OCTAVE_MAX = MI_OCT_7,
-    MI_OCTD,  // octave down
-    MI_OCTU,  // octave up
+    MI_TRNS_N6,  // 5C83
+    MI_TRNS_N5,  // 5C84
+    MI_TRNS_N4,  // 5C85
+    MI_TRNS_N3,  // 5C86
+    MI_TRNS_N2,  // 5C87
+    MI_TRNS_N1,  // 5C88
+    MI_TRNS_0,   // 5C89
+    MI_TRNS_1,   // 5C8A
+    MI_TRNS_2,   // 5C8B
+    MI_TRNS_3,   // 5C8C
+    MI_TRNS_4,   // 5C8D
+    MI_TRNS_5,   // 5C8E
+    MI_TRNS_6,   // 5C8F
+    MI_TRNSD,    // 5C90
+    MI_TRNSU,    // 5C91
 
-    MIDI_TRANSPOSE_MIN,
-    MI_TRNS_N6 = MIDI_TRANSPOSE_MIN,
-    MI_TRNS_N5,
-    MI_TRNS_N4,
-    MI_TRNS_N3,
-    MI_TRNS_N2,
-    MI_TRNS_N1,
-    MI_TRNS_0,
-    MI_TRNS_1,
-    MI_TRNS_2,
-    MI_TRNS_3,
-    MI_TRNS_4,
-    MI_TRNS_5,
-    MI_TRNS_6,
-    MIDI_TRANSPOSE_MAX = MI_TRNS_6,
-    MI_TRNSD,  // transpose down
-    MI_TRNSU,  // transpose up
-
-    MIDI_VELOCITY_MIN,
-    MI_VEL_0 = MIDI_VELOCITY_MIN,
-#    ifdef VIA_ENABLE
-    MI_VEL_1 = MIDI_VELOCITY_MIN,
-#    else
-    MI_VEL_1,
-#    endif
-    MI_VEL_2,
-    MI_VEL_3,
-    MI_VEL_4,
-    MI_VEL_5,
-    MI_VEL_6,
-    MI_VEL_7,
-    MI_VEL_8,
-    MI_VEL_9,
-    MI_VEL_10,
-    MIDI_VELOCITY_MAX = MI_VEL_10,
-    MI_VELD,  // velocity down
-    MI_VELU,  // velocity up
-
-    MIDI_CHANNEL_MIN,
-    MI_CH1 = MIDI_CHANNEL_MIN,
-    MI_CH2,
-    MI_CH3,
-    MI_CH4,
-    MI_CH5,
-    MI_CH6,
-    MI_CH7,
-    MI_CH8,
-    MI_CH9,
-    MI_CH10,
-    MI_CH11,
-    MI_CH12,
-    MI_CH13,
-    MI_CH14,
-    MI_CH15,
-    MI_CH16,
-    MIDI_CHANNEL_MAX = MI_CH16,
-    MI_CHD,  // previous channel
-    MI_CHU,  // next channel
-
-    MI_ALLOFF,  // all notes off
-
-    MI_SUS,   // sustain
-    MI_PORT,  // portamento
-    MI_SOST,  // sostenuto
-    MI_SOFT,  // soft pedal
-    MI_LEG,   // legato
-
-    MI_MOD,    // modulation
-    MI_MODSD,  // decrease modulation speed
-    MI_MODSU,  // increase modulation speed
-
-    MI_BENDD,  // Bend down
-    MI_BENDU,  // Bend up
-#endif         // MIDI_ADVANCED
-
-    // Backlight functionality
-    BL_ON,
-    BL_OFF,
-    BL_DEC,
-    BL_INC,
-    BL_TOGG,
-    BL_STEP,
-    BL_BRTG,
-
-    // RGB functionality
-    RGB_TOG,
-    RGB_MODE_FORWARD,
-    RGB_MODE_REVERSE,
-    RGB_HUI,
-    RGB_HUD,
-    RGB_SAI,
-    RGB_SAD,
-    RGB_VAI,
-    RGB_VAD,
-    RGB_SPI,
-    RGB_SPD,
-    RGB_MODE_PLAIN,
-    RGB_MODE_BREATHE,
-    RGB_MODE_RAINBOW,
-    RGB_MODE_SWIRL,
-    RGB_MODE_SNAKE,
-    RGB_MODE_KNIGHT,
-    RGB_MODE_XMAS,
-    RGB_MODE_GRADIENT,
-    RGB_MODE_RGBTEST,
-
-    // Momentum matching toggle
-    VLK_TOG,
-
-    // Left shift, open paren
-    KC_LSPO,
-
-    // Right shift, close paren
-    KC_RSPC,
-
-    // Shift, Enter
-    KC_SFTENT,
-
-    // Printing
-    PRINT_ON,
-    PRINT_OFF,
-
-    // output selection
-    OUT_AUTO,
-    OUT_USB,
-#ifdef BLUETOOTH_ENABLE
-    OUT_BT,
+    MI_VEL_0,   // 5C92
+#ifdef VIA_ENABLE
+    MI_VEL_1 = MI_VEL_0,
+#else
+    MI_VEL_1,   // 5C93
 #endif
+    MI_VEL_2,   // 5C94
+    MI_VEL_3,   // 5C95
+    MI_VEL_4,   // 5C96
+    MI_VEL_5,   // 5C97
+    MI_VEL_6,   // 5C98
+    MI_VEL_7,   // 5C99
+    MI_VEL_8,   // 5C9A
+    MI_VEL_9,   // 5C9B
+    MI_VEL_10,  // 5C9C
+    MI_VELD,    // 5C9D
+    MI_VELU,    // 5C9E
 
-#ifdef KEY_LOCK_ENABLE
-    KC_LOCK,
-#endif
+    MI_CH1,   // 5C9F
+    MI_CH2,   // 5CA0
+    MI_CH3,   // 5CA1
+    MI_CH4,   // 5CA2
+    MI_CH5,   // 5CA3
+    MI_CH6,   // 5CA4
+    MI_CH7,   // 5CA5
+    MI_CH8,   // 5CA6
+    MI_CH9,   // 5CA7
+    MI_CH10,  // 5CA8
+    MI_CH11,  // 5CA9
+    MI_CH12,  // 5CAA
+    MI_CH13,  // 5CAB
+    MI_CH14,  // 5CAC
+    MI_CH15,  // 5CAD
+    MI_CH16,  // 5CAE
+    MI_CHD,   // 5CAF
+    MI_CHU,   // 5CB0
 
-#ifdef TERMINAL_ENABLE
-    TERM_ON,
-    TERM_OFF,
-#endif
+    MI_ALLOFF,  // 5CB1
 
-    EEPROM_RESET,
+    MI_SUS,   // 5CB2
+    MI_PORT,  // 5CB3
+    MI_SOST,  // 5CB4
+    MI_SOFT,  // 5CB5
+    MI_LEG,   // 5CB6
 
-    UNICODE_MODE_FORWARD,
-    UNICODE_MODE_REVERSE,
-    UNICODE_MODE_MAC,
-    UNICODE_MODE_LNX,
-    UNICODE_MODE_WIN,
-    UNICODE_MODE_BSD,
-    UNICODE_MODE_WINC,
+    MI_MOD,    // 5CB7
+    MI_MODSD,  // 5CB8
+    MI_MODSU,  // 5CB9
 
-    HPT_ON,
-    HPT_OFF,
-    HPT_TOG,
-    HPT_RST,
-    HPT_FBK,
-    HPT_BUZ,
-    HPT_MODI,
-    HPT_MODD,
-    HPT_CONT,
-    HPT_CONI,
-    HPT_COND,
-    HPT_DWLI,
-    HPT_DWLD,
+    MI_BENDD,  // 5CBA
+    MI_BENDU,  // 5CBB
 
-    // Left control, open paren
-    KC_LCPO,
+    // Backlight
+    BL_ON,    // 5CBC
+    BL_OFF,   // 5CBD
+    BL_DEC,   // 5CBE
+    BL_INC,   // 5CBF
+    BL_TOGG,  // 5CC0
+    BL_STEP,  // 5CC1
+    BL_BRTG,  // 5CC2
 
-    // Right control, close paren
-    KC_RCPC,
+    // RGB underglow/matrix
+    RGB_TOG,            // 5CC3
+    RGB_MODE_FORWARD,   // 5CC4
+    RGB_MODE_REVERSE,   // 5CC5
+    RGB_HUI,            // 5CC6
+    RGB_HUD,            // 5CC7
+    RGB_SAI,            // 5CC8
+    RGB_SAD,            // 5CC9
+    RGB_VAI,            // 5CCA
+    RGB_VAD,            // 5CCB
+    RGB_SPI,            // 5CCC
+    RGB_SPD,            // 5CCD
+    RGB_MODE_PLAIN,     // 5CCE
+    RGB_MODE_BREATHE,   // 5CCF
+    RGB_MODE_RAINBOW,   // 5CD0
+    RGB_MODE_SWIRL,     // 5CD1
+    RGB_MODE_SNAKE,     // 5CD2
+    RGB_MODE_KNIGHT,    // 5CD3
+    RGB_MODE_XMAS,      // 5CD4
+    RGB_MODE_GRADIENT,  // 5CD5
+    RGB_MODE_RGBTEST,   // 5CD6
 
-    // Left control, open paren
-    KC_LAPO,
+    // Velocikey
+    VLK_TOG,  // 5CD7
 
-    // Right control, close paren
-    KC_RAPC,
+    // Space Cadet
+    KC_LSPO,    // 5CD8
+    KC_RSPC,    // 5CD9
+    KC_SFTENT,  // 5CDA
 
-    CMB_ON,
-    CMB_OFF,
-    CMB_TOG,
+    // Thermal Printer
+    PRINT_ON,   // 5CDB
+    PRINT_OFF,  // 5CDC
 
-    MAGIC_SWAP_LCTL_LGUI,
-    MAGIC_SWAP_RCTL_RGUI,
-    MAGIC_UNSWAP_LCTL_LGUI,
-    MAGIC_UNSWAP_RCTL_RGUI,
-    MAGIC_SWAP_CTL_GUI,
-    MAGIC_UNSWAP_CTL_GUI,
-    MAGIC_TOGGLE_CTL_GUI,
-    MAGIC_EE_HANDS_LEFT,
-    MAGIC_EE_HANDS_RIGHT,
+    // Bluetooth: output selection
+    OUT_AUTO,  // 5CDD
+    OUT_USB,   // 5CDE
+
+    // Clear EEPROM
+    EEPROM_RESET,  // 5CDF
+
+    // Unicode
+    UNICODE_MODE_FORWARD,  // 5CE0
+    UNICODE_MODE_REVERSE,  // 5CE1
+    UNICODE_MODE_MAC,      // 5CE2
+    UNICODE_MODE_LNX,      // 5CE3
+    UNICODE_MODE_WIN,      // 5CE4
+    UNICODE_MODE_BSD,      // 5CE5
+    UNICODE_MODE_WINC,     // 5CE6
+
+    // Haptic
+    HPT_ON,    // 5CE7
+    HPT_OFF,   // 5CE8
+    HPT_TOG,   // 5CE9
+    HPT_RST,   // 5CEA
+    HPT_FBK,   // 5CEB
+    HPT_BUZ,   // 5CEC
+    HPT_MODI,  // 5CED
+    HPT_MODD,  // 5CEE
+    HPT_CONT,  // 5CEF
+    HPT_CONI,  // 5CF0
+    HPT_COND,  // 5CF1
+    HPT_DWLI,  // 5CF2
+    HPT_DWLD,  // 5CF3
+
+    // Space Cadet (continued)
+    KC_LCPO,  // 5CF4
+    KC_RCPC,  // 5CF5
+    KC_LAPO,  // 5CF6
+    KC_RAPC,  // 5CF7
+
+    // Combos
+    CMB_ON,   // 5CF8
+    CMB_OFF,  // 5CF9
+    CMB_TOG,  // 5CFA
+
+    // Magic (continued)
+    MAGIC_SWAP_LCTL_LGUI,    // 5CFB
+    MAGIC_SWAP_RCTL_RGUI,    // 5CFC
+    MAGIC_UNSWAP_LCTL_LGUI,  // 5CFD
+    MAGIC_UNSWAP_RCTL_RGUI,  // 5CFE
+    MAGIC_SWAP_CTL_GUI,      // 5CFF
+    MAGIC_UNSWAP_CTL_GUI,    // 5D00
+    MAGIC_TOGGLE_CTL_GUI,    // 5D01
+    MAGIC_EE_HANDS_LEFT,     // 5D02
+    MAGIC_EE_HANDS_RIGHT,    // 5D03
 
     // Dynamic Macros
-    DYN_REC_START1,
-    DYN_REC_START2,
-    DYN_REC_STOP,
-    DYN_MACRO_PLAY1,
-    DYN_MACRO_PLAY2,
+    DYN_REC_START1,   // 5D04
+    DYN_REC_START2,   // 5D05
+    DYN_REC_STOP,     // 5D06
+    DYN_MACRO_PLAY1,  // 5D07
+    DYN_MACRO_PLAY2,  // 5D08
 
-    JS_BUTTON0,
-    JS_BUTTON_MIN = JS_BUTTON0,
-    JS_BUTTON1,
-    JS_BUTTON2,
-    JS_BUTTON3,
-    JS_BUTTON4,
-    JS_BUTTON5,
-    JS_BUTTON6,
-    JS_BUTTON7,
-    JS_BUTTON8,
-    JS_BUTTON9,
-    JS_BUTTON10,
-    JS_BUTTON11,
-    JS_BUTTON12,
-    JS_BUTTON13,
-    JS_BUTTON14,
-    JS_BUTTON15,
-    JS_BUTTON16,
-    JS_BUTTON17,
-    JS_BUTTON18,
-    JS_BUTTON19,
-    JS_BUTTON20,
-    JS_BUTTON21,
-    JS_BUTTON22,
-    JS_BUTTON23,
-    JS_BUTTON24,
-    JS_BUTTON25,
-    JS_BUTTON26,
-    JS_BUTTON27,
-    JS_BUTTON28,
-    JS_BUTTON29,
-    JS_BUTTON30,
-    JS_BUTTON31,
-    JS_BUTTON_MAX = JS_BUTTON31,
+    // Joystick
+    JS_BUTTON0,   // 5D09
+    JS_BUTTON1,   // 5D0A
+    JS_BUTTON2,   // 5D0B
+    JS_BUTTON3,   // 5D0C
+    JS_BUTTON4,   // 5D0D
+    JS_BUTTON5,   // 5D0E
+    JS_BUTTON6,   // 5D0F
+    JS_BUTTON7,   // 5D10
+    JS_BUTTON8,   // 5D11
+    JS_BUTTON9,   // 5D12
+    JS_BUTTON10,  // 5D13
+    JS_BUTTON11,  // 5D14
+    JS_BUTTON12,  // 5D15
+    JS_BUTTON13,  // 5D16
+    JS_BUTTON14,  // 5D17
+    JS_BUTTON15,  // 5D18
+    JS_BUTTON16,  // 5D19
+    JS_BUTTON17,  // 5D1A
+    JS_BUTTON18,  // 5D1B
+    JS_BUTTON19,  // 5D1C
+    JS_BUTTON20,  // 5D1D
+    JS_BUTTON21,  // 5D1E
+    JS_BUTTON22,  // 5D1F
+    JS_BUTTON23,  // 5D20
+    JS_BUTTON24,  // 5D21
+    JS_BUTTON25,  // 5D22
+    JS_BUTTON26,  // 5D23
+    JS_BUTTON27,  // 5D24
+    JS_BUTTON28,  // 5D25
+    JS_BUTTON29,  // 5D26
+    JS_BUTTON30,  // 5D27
+    JS_BUTTON31,  // 5D28
 
-#if defined(SEQUENCER_ENABLE)
-    SQ_ON,
-    SQ_OFF,
-    SQ_TOG,
+    // Leader Key
+    KC_LEAD,  // 5D29
 
-    SQ_TMPD,  // Decrease tempo
-    SQ_TMPU,  // Increase tempo
+    // Bluetooth: output selection (continued)
+    OUT_BT,  // 5D2A
+
+    // Lock Key
+    KC_LOCK,  // 5D2B
+
+    // Terminal
+    TERM_ON,   // 5D2C
+    TERM_OFF,  // 5D2D
+
+    // Sequencer
+    SQ_ON,  // 5D2E
+    SQ_OFF,  // 5D2F
+    SQ_TOG,  // 5D30
+
+    SQ_TMPD,  // 5D31
+    SQ_TMPU,  // 5D32
+
+    SQ_RESD,  // 5D33
+    SQ_RESU,  // 5D34
+
+    SQ_SALL,  // 5D35
+    SQ_SCLR,  // 5D36
+
+    SEQUENCER_STEP_MIN,  // 5D37
+    SEQUENCER_STEP_MAX = SEQUENCER_STEP_MIN + SEQUENCER_STEPS,
 
     SEQUENCER_RESOLUTION_MIN,
     SEQUENCER_RESOLUTION_MAX = SEQUENCER_RESOLUTION_MIN + SEQUENCER_RESOLUTIONS,
-    SQ_RESD,  // Decrease resolution
-    SQ_RESU,  // Increase resolution
-
-    SQ_SALL,  // All steps on
-    SQ_SCLR,  // All steps off
-    SEQUENCER_STEP_MIN,
-    SEQUENCER_STEP_MAX = SEQUENCER_STEP_MIN + SEQUENCER_STEPS,
 
     SEQUENCER_TRACK_MIN,
     SEQUENCER_TRACK_MAX = SEQUENCER_TRACK_MIN + SEQUENCER_TRACKS,
 
-/**
- * Helpers to assign a keycode to a step, a resolution, or a track.
- * Falls back to NOOP if n is out of range.
- */
-#    define SQ_S(n) (n < SEQUENCER_STEPS ? SEQUENCER_STEP_MIN + n : XXXXXXX)
-#    define SQ_R(n) (n < SEQUENCER_RESOLUTIONS ? SEQUENCER_RESOLUTION_MIN + n : XXXXXXX)
-#    define SQ_T(n) (n < SEQUENCER_TRACKS ? SEQUENCER_TRACK_MIN + n : XXXXXXX)
+#define SQ_S(n) (n < SEQUENCER_STEPS ? SEQUENCER_STEP_MIN + n : KC_NO)
+#define SQ_R(n) (n < SEQUENCER_RESOLUTIONS ? SEQUENCER_RESOLUTION_MIN + n : KC_NO)
+#define SQ_T(n) (n < SEQUENCER_TRACKS ? SEQUENCER_TRACK_MIN + n : KC_NO)
 
-#endif
-
+    // One Shot
     ONESHOT_ENABLE,
     ONESHOT_DISABLE,
     ONESHOT_TOGGLE,
 
-    // always leave at the end
+    // Start of custom keycode range for keyboards and keymaps - always leave at the end
     SAFE_RANGE
 };
 
-// Ability to use mods in layouts
+// Keycode modifiers & aliases
 #define LCTL(kc) (QK_LCTL | (kc))
 #define LSFT(kc) (QK_LSFT | (kc))
 #define LALT(kc) (QK_LALT | (kc))
@@ -613,11 +550,7 @@ enum quantum_keycodes {
 #define MOD_HYPR 0xF
 #define MOD_MEH 0x7
 
-// Aliases for shifted symbols
-// Each key has a 4-letter code, and some have longer aliases too.
-// While the long aliases are descriptive, the 4-letter codes
-// make for nicer grid layouts (everything lines up), and are
-// the preferred style for Quantum.
+// US ANSI shifted keycode aliases
 #define KC_TILD LSFT(KC_GRV)  // ~
 #define KC_TILDE KC_TILD
 
@@ -684,15 +617,15 @@ enum quantum_keycodes {
 
 #define KC_DELT KC_DELETE  // Del key (four letter code)
 
-// Aliases
+// Modified keycode aliases
 #define C(kc) LCTL(kc)
 #define S(kc) LSFT(kc)
 #define A(kc) LALT(kc)
 #define G(kc) LGUI(kc)
 
+// Deprecated - do not use
 #define F(kc) (QK_FUNCTION | (kc))
 #define M(kc) (QK_MACRO | (kc))
-
 #define MACROTAP(kc) (QK_MACRO | (FUNC_TAP << 8) | (kc))
 #define MACRODOWN(...) (record->event.pressed ? MACRO(__VA_ARGS__) : MACRO_NONE)
 
@@ -700,19 +633,21 @@ enum quantum_keycodes {
 
 #define EEP_RST EEPROM_RESET
 
+// Audio Clicky aliases
 #define CK_TOGG CLICKY_TOGGLE
 #define CK_RST CLICKY_RESET
 #define CK_UP CLICKY_UP
 #define CK_DOWN CLICKY_DOWN
 #define CK_ON CLICKY_ENABLE
 #define CK_OFF CLICKY_DISABLE
+// Fauxclicky (deprecated) redirects to Audio Clicky
 #define FC_ON CLICKY_ENABLE
 #define FC_OFF CLICKY_DISABLE
 #define FC_TOGG CLICKY_TOGGLE
 
+// RGB aliases
 #define RGB_MOD RGB_MODE_FORWARD
 #define RGB_RMOD RGB_MODE_REVERSE
-
 #define RGB_M_P RGB_MODE_PLAIN
 #define RGB_M_B RGB_MODE_BREATHE
 #define RGB_M_R RGB_MODE_RAINBOW
@@ -723,9 +658,7 @@ enum quantum_keycodes {
 #define RGB_M_G RGB_MODE_GRADIENT
 #define RGB_M_T RGB_MODE_RGBTEST
 
-// L-ayer, T-ap - 256 keycode max, 16 layer max
-#define LT(layer, kc) (QK_LAYER_TAP | (((layer)&0xF) << 8) | ((kc)&0xFF))
-
+// Magic aliases
 #define CL_SWAP MAGIC_SWAP_CONTROL_CAPSLOCK
 #define CL_NORM MAGIC_UNSWAP_CONTROL_CAPSLOCK
 #define CL_CTRL MAGIC_CAPSLOCK_TO_CONTROL
@@ -794,6 +727,9 @@ enum quantum_keycodes {
 // Layer tap-toggle
 #define TT(layer) (QK_LAYER_TAP_TOGGLE | ((layer)&0xFF))
 
+// L-ayer, T-ap - 256 keycode max, 16 layer max
+#define LT(layer, kc) (QK_LAYER_TAP | (((layer)&0xF) << 8) | ((kc)&0xFF))
+
 // M-od, T-ap - 256 keycode max
 #define MT(mod, kc) (QK_MOD_TAP | (((mod)&0x1F) << 8) | ((kc)&0xFF))
 
@@ -843,6 +779,7 @@ enum quantum_keycodes {
 #define KC_HYPR HYPR(KC_NO)
 #define KC_MEH MEH(KC_NO)
 
+// Unicode aliases
 // UNICODE_ENABLE - Allows Unicode input up to 0x7FFF
 #define UC(c) (QK_UNICODE | (c))
 // UNICODEMAP_ENABLE - Allows Unicode input up to 0x10FFFF, requires unicode_map
@@ -860,6 +797,7 @@ enum quantum_keycodes {
 #define UC_M_BS UNICODE_MODE_BSD
 #define UC_M_WC UNICODE_MODE_WINC
 
+// Swap Hands
 #define SH_T(kc) (QK_SWAP_HANDS | (kc))
 #define SH_TG (QK_SWAP_HANDS | OP_SH_TOGGLE)
 #define SH_TT (QK_SWAP_HANDS | OP_SH_TAP_TOGGLE)
@@ -869,6 +807,30 @@ enum quantum_keycodes {
 #define SH_ON (QK_SWAP_HANDS | OP_SH_ON)
 #define SH_OFF (QK_SWAP_HANDS | OP_SH_OFF)
 
+// MIDI aliases
+#define MIDI_TONE_MIN MI_C
+#if MIDI_TONE_KEYCODE_OCTAVES > 5
+#    define MIDI_TONE_MAX MI_B_5
+#elif MIDI_TONE_KEYCODE_OCTAVES > 4
+#    define MIDI_TONE_MAX MI_B_4
+#elif MIDI_TONE_KEYCODE_OCTAVES > 3
+#    define MIDI_TONE_MAX MI_B_3
+#elif MIDI_TONE_KEYCODE_OCTAVES > 2
+#    define MIDI_TONE_MAX MI_B_2
+#elif MIDI_TONE_KEYCODE_OCTAVES > 1
+#    define MIDI_TONE_MAX MI_B_1
+#else
+#    define MIDI_TONE_MAX MI_B
+#endif
+#define MIDI_OCTAVE_MIN MI_OCT_N2
+#define MIDI_OCTAVE_MAX MI_OCT_7
+#define MIDI_TRANSPOSE_MIN MI_TRNS_N6
+#define MIDI_TRANSPOSE_MAX MI_TRNS_6
+#define MIDI_VELOCITY_MIN MI_VEL_0
+#define MIDI_VELOCITY_MAX MI_VEL_10
+#define MIDI_CHANNEL_MIN MI_CH1
+#define MIDI_CHANNEL_MAX MI_CH16
+
 // Dynamic Macros aliases
 #define DM_REC1 DYN_REC_START1
 #define DM_REC2 DYN_REC_START2
@@ -876,7 +838,11 @@ enum quantum_keycodes {
 #define DM_PLY1 DYN_MACRO_PLAY1
 #define DM_PLY2 DYN_MACRO_PLAY2
 
-// One Shot toggle
+// Joystick aliases
+#define JS_BUTTON_MIN JS_BUTTON0
+#define JS_BUTTON_MAX JS_BUTTON31
+
+// One Shot aliases
 #define OS_TOGG ONESHOT_TOGGLE
 #define OS_ON ONESHOT_ENABLE
 #define OS_OFF ONESHOT_DISABLE

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -18,10 +18,6 @@
 
 #include "sequencer.h"
 
-#ifndef MIDI_TONE_KEYCODE_OCTAVES
-#    define MIDI_TONE_KEYCODE_OCTAVES 3
-#endif
-
 // Fillers to make layering more clear
 #define _______ KC_TRNS
 #define XXXXXXX KC_NO
@@ -810,19 +806,7 @@ enum quantum_keycodes {
 
 // MIDI aliases
 #define MIDI_TONE_MIN MI_C
-#if MIDI_TONE_KEYCODE_OCTAVES > 5
-#    define MIDI_TONE_MAX MI_B_5
-#elif MIDI_TONE_KEYCODE_OCTAVES > 4
-#    define MIDI_TONE_MAX MI_B_4
-#elif MIDI_TONE_KEYCODE_OCTAVES > 3
-#    define MIDI_TONE_MAX MI_B_3
-#elif MIDI_TONE_KEYCODE_OCTAVES > 2
-#    define MIDI_TONE_MAX MI_B_2
-#elif MIDI_TONE_KEYCODE_OCTAVES > 1
-#    define MIDI_TONE_MAX MI_B_1
-#else
-#    define MIDI_TONE_MAX MI_B
-#endif
+#define MIDI_TONE_MAX MI_B_5
 #define MIDI_OCTAVE_MIN MI_OCT_N2
 #define MIDI_OCTAVE_MAX MI_OCT_7
 #define MIDI_TRANSPOSE_MIN MI_TRNS_N6


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Hoo boy.

* Moved Swap Hands range to 0x5600, just to fill in that gap
* Pulled range aliases (MIDI velocity min/max etc.) out of the enum and into defines at the end of the file
* Annotated every keycode with its value in hex, up to the Sequencer keycodes - they still have yet to be made static, but at least they're at the end, for now
* Removed *all* the ifdefs! And via_ensure_keycode.h doesn't complain! This does mean that everything guarded by an ifdef had to be moved to the end of the enum, though
* Tweaked/added/improved some comments

As mentioned, this doesn't break VIA, but it does shuffle some values around, so perhaps this should go into develop instead?

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
