### PR TITLE
Use bin/qmk if qmk is not in the path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ endif
 endif
 
 # Determine which qmk cli to use
-ifeq (, $(shell which qmk))
+ifeq ($(shell which qmk),)
     QMK_BIN = bin/qmk
 else
     QMK_BIN = qmk

--- a/build_keyboard.mk
+++ b/build_keyboard.mk
@@ -13,7 +13,11 @@ endif
 include common.mk
 
 # Set the qmk cli to use
-QMK_BIN ?= qmk
+ifeq ($(shell which qmk),)
+    QMK_BIN ?= bin/qmk
+else
+    QMK_BIN ?= qmk
+endif
 
 # Set the filename for the final firmware binary
 KEYBOARD_FILESAFE := $(subst /,_,$(KEYBOARD))


### PR DESCRIPTION
## Description

Builds don't work if qmk is not in the path.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
