### PR TITLE
Boston: correct LAYOUT macro data

### DIFF
--- a/keyboards/boston/info.json
+++ b/keyboards/boston/info.json
@@ -1,12 +1,13 @@
 {
-    "keyboard_name": "boston", 
-    "url": "https://github.com/bluepylons/Boston", 
-    "maintainer": "Pylon", 
-    "width": 20.5, 
-    "height": 7.75, 
+    "keyboard_name": "boston",
+    "url": "https://github.com/bluepylons/Boston",
+    "maintainer": "bluepylons",
+    "width": 20.5,
+    "height": 7.75,
     "layouts": {
-        "LAYOUT": {
+        "LAYOUT_all": {
             "layout": [
+                {"label":"Encoder", "x":0, "y":0},
                 {"label":"P1", "x":1.5, "y":0},
                 {"label":"P2", "x":2.5, "y":0},
                 {"label":"P3", "x":3.5, "y":0},
@@ -25,6 +26,7 @@
                 {"label":"Insert", "x":17.5, "y":0},
                 {"label":"Home", "x":18.5, "y":0},
                 {"label":"PgUp", "x":19.5, "y":0},
+
                 {"label":"Esc", "x":0, "y":1},
                 {"label":"F1", "x":1.5, "y":1},
                 {"label":"F2", "x":2.5, "y":1},
@@ -56,11 +58,11 @@
                 {"label":"*", "x":8, "y":2.5},
                 {"label":"(", "x":9, "y":2.5},
                 {"label":")", "x":10, "y":2.5},
-                {"label":"_", "x":11, "y":2.5}, 
-                {"label":"+", "x":12, "y":2.5}, 
-                {"label":"Backspace", "x":13, "y":2.5}, 
-                {"label":"Backspace", "x":14, "y":2.5}, 
-                {"label":"P16", "x":15.25, "y":2.5}, 
+                {"label":"_", "x":11, "y":2.5},
+                {"label":"+", "x":12, "y":2.5},
+                {"label":"Backspace", "x":13, "y":2.5},
+                {"label":"Backspace", "x":14, "y":2.5},
+                {"label":"P16", "x":15.25, "y":2.5},
                 {"label":"Num Lock", "x":16.5, "y":2.5},
                 {"label":"/", "x":17.5, "y":2.5},
                 {"label":"*", "x":18.5, "y":2.5},
@@ -119,12 +121,11 @@
                 {"label":">", "x":10.25, "y":5.5},
                 {"label":"?", "x":11.25, "y":5.5},
                 {"label":"Right Shift", "x":12.25, "y":5.5, "w":1.75},
-                {"label":"Up", "x":14.25, "y":5.75}, 
+                {"label":"Up", "x":14.25, "y":5.75},
                 {"label":"1", "x":16.5, "y":5.5},
                 {"label":"2", "x":17.5, "y":5.5},
                 {"label":"3", "x":18.5, "y":5.5},
                 {"label":"Enter", "x":19.5, "y":5.5, "h":2},
-
 
                 {"label":"Ctrl", "x":0, "y":6.5, "w":1.25},
                 {"label":"OS", "x":1.25, "y":6.5, "w":1.25},


### PR DESCRIPTION
## Description

Fixes an issue with the QMK Configurator data for the Boston keyboard that was causing two layouts to be presented even though there is only one layout in the code.

- correct macro reference
- add missing encoder position
- correct maintainer value to reference keyboard maintainer's GitHub account
- remove trailing whitespace

cc @bluepylons

## Types of Changes

- [x] Bugfix
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
