### PR TITLE
Add I2C configuration defines for STM32

### DIFF
--- a/platforms/chibios/BLACKPILL_STM32_F401/configs/i2c_defs.h
+++ b/platforms/chibios/BLACKPILL_STM32_F401/configs/i2c_defs.h
@@ -1,0 +1,95 @@
+/* Copyright 2021 Dasky
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+/* F401 no i2c2/i2c3 alt pins*/
+
+#if defined(USE_I2C1_400KHZ) || defined(USE_I2C1_100KHZ)
+#    define I2C_DRIVER I2CD1
+#    if defined(USE_I2C1_400KHZ)
+#        define I2C1_OPMODE OPMODE_I2C
+#        define I2C1_CLOCK_SPEED 400000
+#        define I2C1_DUTY_CYCLE FAST_DUTY_CYCLE_2
+#    elif defined(USE_I2C1_100KHZ)
+#        define I2C1_OPMODE OPMODE_I2C
+#        define I2C1_CLOCK_SPEED 100000
+#        define I2C1_DUTY_CYCLE STD_DUTY_CYCLE
+#    endif
+#    if (defined USE_I2C1_SCL_ALT)
+#        define I2C1_SCL_BANK GPIOB
+#        define I2C1_SCL 6
+#        define I2C1_SCL_PAL_MODE 4
+#    elif !(defined I2C1_SCL)
+#        define I2C1_SCL_BANK GPIOB
+#        define I2C1_SCL 8
+#        define I2C1_SCL_PAL_MODE 4
+#    endif
+#    if (defined USE_I2C1_SDA_ALT)
+#        define I2C1_SDA_BANK GPIOB
+#        define I2C1_SDA 7
+#        define I2C1_SDA_PAL_MODE 4
+#    elif !(defined I2C1_SDA)
+#        define I2C1_SDA_BANK GPIOB
+#        define I2C1_SDA 9
+#        define I2C1_SDA_PAL_MODE 4
+#    endif
+#endif
+
+#if defined(USE_I2C2_400KHZ) || defined(USE_I2C2_100KHZ)
+#    define I2C_DRIVER I2CD2
+#    if defined(USE_I2C2_400KHZ)
+#        define I2C1_OPMODE OPMODE_I2C
+#        define I2C1_CLOCK_SPEED 400000
+#        define I2C1_DUTY_CYCLE FAST_DUTY_CYCLE_2
+#    elif defined(USE_I2C2_100KHZ)
+#        define I2C1_OPMODE OPMODE_I2C
+#        define I2C1_CLOCK_SPEED 100000
+#        define I2C1_DUTY_CYCLE STD_DUTY_CYCLE
+#    endif
+#    if !(defined I2C1_SCL)
+#        define I2C1_SCL_BANK GPIOB
+#        define I2C1_SCL 10
+#        define I2C1_SCL_PAL_MODE 4
+#    endif
+#    if !(defined I2C1_SDA)
+#        define I2C1_SDA_BANK GPIOB
+#        define I2C1_SDA 3
+#        define I2C1_SDA_PAL_MODE 9
+#    endif
+#endif
+
+#if defined(USE_I2C3_400KHZ) || defined(USE_I2C3_100KHZ)
+#    define I2C_DRIVER I2CD3
+#    if defined(USE_I2C3_400KHZ)
+#        define I2C1_OPMODE OPMODE_I2C
+#        define I2C1_CLOCK_SPEED 400000
+#        define I2C1_DUTY_CYCLE FAST_DUTY_CYCLE_2
+#    elif defined(USE_I2C3_100KHZ)
+#        define I2C1_OPMODE OPMODE_I2C
+#        define I2C1_CLOCK_SPEED 100000
+#        define I2C1_DUTY_CYCLE STD_DUTY_CYCLE
+#    endif
+#    if !(defined I2C1_SCL)
+#        define I2C1_SCL_BANK GPIOA
+#        define I2C1_SCL 8
+#        define I2C1_SCL_PAL_MODE 4
+#    endif
+#    if !(defined I2C1_SDA)
+#        define I2C1_SDA_BANK GPIOB
+#        define I2C1_SDA 4
+#        define I2C1_SDA_PAL_MODE 9
+#    endif
+#endif

--- a/platforms/chibios/BLACKPILL_STM32_F411/configs/config.h
+++ b/platforms/chibios/BLACKPILL_STM32_F411/configs/config.h
@@ -23,3 +23,5 @@
 #ifndef EARLY_INIT_PERFORM_BOOTLOADER_JUMP
 #    define EARLY_INIT_PERFORM_BOOTLOADER_JUMP TRUE
 #endif
+
+#include "i2c_defs.h"

--- a/platforms/chibios/BLACKPILL_STM32_F411/configs/i2c_defs.h
+++ b/platforms/chibios/BLACKPILL_STM32_F411/configs/i2c_defs.h
@@ -1,0 +1,103 @@
+/* Copyright 2021 Dasky
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+/* F411 sda only i2c2/i2c3 alt pins*/
+
+#if defined(USE_I2C1_400KHZ) || defined(USE_I2C1_100KHZ)
+#    define I2C_DRIVER I2CD1
+#    if defined(USE_I2C1_400KHZ)
+#        define I2C1_OPMODE OPMODE_I2C
+#        define I2C1_CLOCK_SPEED 400000
+#        define I2C1_DUTY_CYCLE FAST_DUTY_CYCLE_2
+#    elif defined(USE_I2C1_100KHZ)
+#        define I2C1_OPMODE OPMODE_I2C
+#        define I2C1_CLOCK_SPEED 100000
+#        define I2C1_DUTY_CYCLE STD_DUTY_CYCLE
+#    endif
+#    if (defined USE_I2C1_SCL_ALT)
+#        define I2C1_SCL_BANK GPIOB
+#        define I2C1_SCL 6
+#        define I2C1_SCL_PAL_MODE 4
+#    elif !(defined I2C1_SCL)
+#        define I2C1_SCL_BANK GPIOB
+#        define I2C1_SCL 8
+#        define I2C1_SCL_PAL_MODE 4
+#    endif
+#    if (defined USE_I2C1_SDA_ALT)
+#        define I2C1_SDA_BANK GPIOB
+#        define I2C1_SDA 7
+#        define I2C1_SDA_PAL_MODE 4
+#    elif !(defined I2C1_SDA)
+#        define I2C1_SDA_BANK GPIOB
+#        define I2C1_SDA 9
+#        define I2C1_SDA_PAL_MODE 4
+#    endif
+#endif
+
+#if defined(USE_I2C2_400KHZ) || defined(USE_I2C2_100KHZ)
+#    define I2C_DRIVER I2CD2
+#    if defined(USE_I2C2_400KHZ)
+#        define I2C1_OPMODE OPMODE_I2C
+#        define I2C1_CLOCK_SPEED 400000
+#        define I2C1_DUTY_CYCLE FAST_DUTY_CYCLE_2
+#    elif defined(USE_I2C2_100KHZ)
+#        define I2C1_OPMODE OPMODE_I2C
+#        define I2C1_CLOCK_SPEED 100000
+#        define I2C1_DUTY_CYCLE STD_DUTY_CYCLE
+#    endif
+#    if !(defined I2C1_SCL)
+#        define I2C1_SCL_BANK GPIOB
+#        define I2C1_SCL 10
+#        define I2C1_SCL_PAL_MODE 4
+#    endif
+#    if (defined USE_I2C2_SDA_ALT)
+#        define I2C1_SDA_BANK GPIOB
+#        define I2C1_SDA 9
+#        define I2C1_SDA_PAL_MODE 9
+#    elif !(defined I2C1_SDA)
+#        define I2C1_SDA_BANK GPIOB
+#        define I2C1_SDA 3
+#        define I2C1_SDA_PAL_MODE 9
+#    endif
+#endif
+
+#if defined(USE_I2C3_400KHZ) || defined(USE_I2C3_100KHZ)
+#    define I2C_DRIVER I2CD3
+#    if defined(USE_I2C3_400KHZ)
+#        define I2C1_OPMODE OPMODE_I2C
+#        define I2C1_CLOCK_SPEED 400000
+#        define I2C1_DUTY_CYCLE FAST_DUTY_CYCLE_2
+#    elif defined(USE_I2C3_100KHZ)
+#        define I2C1_OPMODE OPMODE_I2C
+#        define I2C1_CLOCK_SPEED 100000
+#        define I2C1_DUTY_CYCLE STD_DUTY_CYCLE
+#    endif
+#    if !(defined I2C1_SCL)
+#        define I2C1_SCL_BANK GPIOA
+#        define I2C1_SCL 8
+#        define I2C1_SCL_PAL_MODE 4
+#    endif
+#    if (defined USE_I2C3_SDA_ALT)
+#        define I2C1_SDA_BANK GPIOB
+#        define I2C1_SDA 8
+#        define I2C1_SDA_PAL_MODE 9
+#    elif !(defined I2C1_SDA)
+#        define I2C1_SDA_BANK GPIOB
+#        define I2C1_SDA 4
+#        define I2C1_SDA_PAL_MODE 9
+#    endif
+#endif

--- a/platforms/chibios/GENERIC_STM32_F042X6/configs/config.h
+++ b/platforms/chibios/GENERIC_STM32_F042X6/configs/config.h
@@ -18,3 +18,5 @@
 #ifndef EARLY_INIT_PERFORM_BOOTLOADER_JUMP
 #    define EARLY_INIT_PERFORM_BOOTLOADER_JUMP TRUE
 #endif
+
+#include "i2c_defs.h"

--- a/platforms/chibios/GENERIC_STM32_F042X6/configs/i2c_defs.h
+++ b/platforms/chibios/GENERIC_STM32_F042X6/configs/i2c_defs.h
@@ -1,0 +1,53 @@
+/* Copyright 2021 Dasky
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+/* F042 - i2c1 only */
+
+#if defined(USE_I2C1_400KHZ) || defined(USE_I2C1_100KHZ)
+#    define I2C_DRIVER I2CD1
+#    if defined(USE_I2C1_400KHZ)
+#        define I2C1_TIMINGR_PRESC 0U
+#        define I2C1_TIMINGR_SCLDEL 0U
+#        define I2C1_TIMINGR_SDADEL 0U
+#        define I2C1_TIMINGR_SCLH 2U
+#        define I2C1_TIMINGR_SCLL 11U
+#    elif defined(USE_I2C1_100KHZ)
+#        define I2C1_TIMINGR_PRESC 2U
+#        define I2C1_TIMINGR_SCLDEL 0U
+#        define I2C1_TIMINGR_SDADEL 0U
+#        define I2C1_TIMINGR_SCLH 9U
+#        define I2C1_TIMINGR_SCLL 14U
+#    endif
+#    if (defined USE_I2C1_SCL_ALT)
+#        define I2C1_SCL_BANK GPIOB
+#        define I2C1_SCL 8
+#        define I2C1_SCL_PAL_MODE 1
+#    elif !(defined I2C1_SCL)
+#        define I2C1_SCL_BANK GPIOB
+#        define I2C1_SCL 6
+#        define I2C1_SCL_PAL_MODE 1
+#    endif
+#    if (defined USE_I2C1_SDA_ALT)
+#        define I2C1_SDA_BANK GPIOB
+#        define I2C1_SDA 9
+#        define I2C1_SDA_PAL_MODE 1
+#    elif !(defined I2C1_SDA)
+#        define I2C1_SDA_BANK GPIOB
+#        define I2C1_SDA 7
+#        define I2C1_SDA_PAL_MODE 1
+#    endif
+#endif

--- a/platforms/chibios/GENERIC_STM32_F072XB/configs/config.h
+++ b/platforms/chibios/GENERIC_STM32_F072XB/configs/config.h
@@ -18,3 +18,5 @@
 #ifndef EARLY_INIT_PERFORM_BOOTLOADER_JUMP
 #    define EARLY_INIT_PERFORM_BOOTLOADER_JUMP TRUE
 #endif
+
+#include "i2c_defs.h"

--- a/platforms/chibios/GENERIC_STM32_F072XB/configs/i2c_defs.h
+++ b/platforms/chibios/GENERIC_STM32_F072XB/configs/i2c_defs.h
@@ -1,0 +1,88 @@
+/* Copyright 2021 Dasky
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+/* F072 */
+
+#if defined(USE_I2C1_400KHZ) || defined(USE_I2C1_100KHZ)
+#    define I2C_DRIVER I2CD1
+#    if defined(USE_I2C1_400KHZ)
+#        define I2C1_TIMINGR_PRESC 0U
+#        define I2C1_TIMINGR_SCLDEL 0U
+#        define I2C1_TIMINGR_SDADEL 0U
+#        define I2C1_TIMINGR_SCLH 2U
+#        define I2C1_TIMINGR_SCLL 11U
+#    elif defined(USE_I2C1_100KHZ)
+#        define I2C1_TIMINGR_PRESC 2U
+#        define I2C1_TIMINGR_SCLDEL 0U
+#        define I2C1_TIMINGR_SDADEL 0U
+#        define I2C1_TIMINGR_SCLH 9U
+#        define I2C1_TIMINGR_SCLL 14U
+#    endif
+#    if (defined USE_I2C1_SCL_ALT)
+#        define I2C1_SCL_BANK GPIOB
+#        define I2C1_SCL 8
+#        define I2C1_SCL_PAL_MODE 1
+#    elif !(defined I2C1_SCL)
+#        define I2C1_SCL_BANK GPIOB
+#        define I2C1_SCL 6
+#        define I2C1_SCL_PAL_MODE 1
+#    endif
+#    if (defined USE_I2C1_SDA_ALT)
+#        define I2C1_SDA_BANK GPIOB
+#        define I2C1_SDA 9
+#        define I2C1_SDA_PAL_MODE 1
+#    elif !(defined I2C1_SDA)
+#        define I2C1_SDA_BANK GPIOB
+#        define I2C1_SDA 7
+#        define I2C1_SDA_PAL_MODE 1
+#    endif
+#endif
+
+#if defined(USE_I2C2_400KHZ) || defined(USE_I2C2_100KHZ)
+#    define I2C_DRIVER I2CD2
+#    if defined(USE_I2C2_400KHZ)
+#        define I2C1_TIMINGR_PRESC 2U
+#        define I2C1_TIMINGR_SCLDEL 1U
+#        define I2C1_TIMINGR_SDADEL 0U
+#        define I2C1_TIMINGR_SCLH 9U
+#        define I2C1_TIMINGR_SCLL 26U
+#    elif defined(USE_I2C2_100KHZ)
+#        define I2C1_TIMINGR_PRESC 2U
+#        define I2C1_TIMINGR_SCLDEL 3U
+#        define I2C1_TIMINGR_SDADEL 0U
+#        define I2C1_TIMINGR_SCLH 62U
+#        define I2C1_TIMINGR_SCLL 93U
+#    endif
+#    if (defined USE_I2C2_SCL_ALT)
+#        define I2C1_SCL_BANK GPIOB
+#        define I2C1_SCL 13
+#        define I2C1_SCL_PAL_MODE 5
+#    elif !(defined I2C1_SCL)
+#        define I2C1_SCL_BANK GPIOB
+#        define I2C1_SCL 10
+#        define I2C1_SCL_PAL_MODE 1
+#    endif
+#    if (defined USE_I2C2_SDA_ALT)
+#        define I2C1_SDA_BANK GPIOB
+#        define I2C1_SDA 14
+#        define I2C1_SDA_PAL_MODE 5
+#    elif !(defined I2C1_SDA)
+#        define I2C1_SDA_BANK GPIOB
+#        define I2C1_SDA 11
+#        define I2C1_SDA_PAL_MODE 1
+#    endif
+#endif

--- a/platforms/chibios/GENERIC_STM32_F303XC/configs/config.h
+++ b/platforms/chibios/GENERIC_STM32_F303XC/configs/config.h
@@ -18,3 +18,5 @@
 #ifndef EARLY_INIT_PERFORM_BOOTLOADER_JUMP
 #    define EARLY_INIT_PERFORM_BOOTLOADER_JUMP TRUE
 #endif
+
+#include "i2c_defs.h"

--- a/platforms/chibios/GENERIC_STM32_F303XC/configs/i2c_defs.h
+++ b/platforms/chibios/GENERIC_STM32_F303XC/configs/i2c_defs.h
@@ -1,0 +1,53 @@
+/* Copyright 2021 Dasky
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+/* PROTON C/F303 - using proton c pinout to set default pins, i2c2 alt pins are osc f0/f1 */
+
+#if defined(USE_I2C1_400KHZ) || defined(USE_I2C1_100KHZ)
+#    define I2C_DRIVER I2CD1
+#    if defined(USE_I2C1_400KHZ)
+#        define I2C1_TIMINGR_PRESC 0U
+#        define I2C1_TIMINGR_SCLDEL 7U
+#        define I2C1_TIMINGR_SDADEL 0U
+#        define I2C1_TIMINGR_SCLH 38U
+#        define I2C1_TIMINGR_SCLL 129U
+#    elif defined(USE_I2C1_100KHZ)
+#        define I2C1_TIMINGR_PRESC 1U
+#        define I2C1_TIMINGR_SCLDEL 8U
+#        define I2C1_TIMINGR_SDADEL 0U
+#        define I2C1_TIMINGR_SCLH 141U
+#        define I2C1_TIMINGR_SCLL 211U
+#    endif
+#    if (defined USE_I2C1_SCL_ALT)
+#        define I2C1_SCL_BANK GPIOB
+#        define I2C1_SCL 8
+#        define I2C1_SCL_PAL_MODE 4
+#    elif !(defined I2C1_SCL)
+#        define I2C1_SCL_BANK GPIOB
+#        define I2C1_SCL 6
+#        define I2C1_SCL_PAL_MODE 4
+#    endif
+#    if (defined USE_I2C1_SDA_ALT)
+#        define I2C1_SDA_BANK GPIOB
+#        define I2C1_SDA 9
+#        define I2C1_SDA_PAL_MODE 4
+#    elif !(defined I2C1_SDA)
+#        define I2C1_SDA_BANK GPIOB
+#        define I2C1_SDA 7
+#        define I2C1_SDA_PAL_MODE 4
+#    endif
+#endif

--- a/platforms/chibios/GENERIC_STM32_G431XB/configs/config.h
+++ b/platforms/chibios/GENERIC_STM32_G431XB/configs/config.h
@@ -21,3 +21,5 @@
  *  <tmk_dir>/tmk_core/tool/chibios/ch-bootloader-jump.patch
  */
 #define STM32_BOOTLOADER_ADDRESS 0x1FFF0000
+
+#include "i2c_defs.h"

--- a/platforms/chibios/GENERIC_STM32_G431XB/configs/i2c_defs.h
+++ b/platforms/chibios/GENERIC_STM32_G431XB/configs/i2c_defs.h
@@ -1,0 +1,98 @@
+/* Copyright 2021 Dasky
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+/* G431 - All i2c run from pclk1*/
+
+#if defined(USE_I2C1_400KHZ) || defined(USE_I2C2_400KHZ) || defined(USE_I2C3_400KHZ)
+#    define I2C1_TIMINGR_PRESC 0U
+#    define I2C1_TIMINGR_SCLDEL 15U
+#    define I2C1_TIMINGR_SDADEL 0U
+#    define I2C1_TIMINGR_SCLH 123U
+#    define I2C1_TIMINGR_SCLL 255U
+#elif defined(USE_I2C1_100KHZ) || defined(USE_I2C2_100KHZ) || defined(USE_I2C3_100KHZ)
+#    define I2C1_TIMINGR_PRESC 3U
+#    define I2C1_TIMINGR_SCLDEL 9U
+#    define I2C1_TIMINGR_SDADEL 0U
+#    define I2C1_TIMINGR_SCLH 157U
+#    define I2C1_TIMINGR_SCLL 236U
+#endif
+
+#if defined(USE_I2C1_400KHZ) || defined(USE_I2C1_100KHZ)
+#    define I2C_DRIVER I2CD1
+#    if (defined USE_I2C1_SCL_ALT)
+#        define I2C1_SCL_BANK GPIOA
+#        define I2C1_SCL 13
+#        define I2C1_SCL_PAL_MODE 4
+#    elif !(defined I2C1_SCL)
+#        define I2C1_SCL_BANK GPIOA
+#        define I2C1_SCL 15
+#        define I2C1_SCL_PAL_MODE 4
+#    endif
+#    if (defined USE_I2C1_SDA_ALT)
+#        define I2C1_SDA_BANK GPIOB
+#        define I2C1_SDA 9
+#        define I2C1_SDA_PAL_MODE 4
+#    elif !(defined I2C1_SDA)
+#        define I2C1_SDA_BANK GPIOB
+#        define I2C1_SDA 7
+#        define I2C1_SDA_PAL_MODE 4
+#    endif
+#endif
+
+#if defined(USE_I2C2_400KHZ) || defined(USE_I2C2_100KHZ)
+#    define I2C_DRIVER I2CD2
+#    if (defined USE_I2C2_SCL_ALT)
+#        define I2C1_SCL_BANK GPIOA
+#        define I2C1_SCL 9
+#        define I2C1_SCL_PAL_MODE 4
+#    elif !(defined I2C1_SCL)
+#        define I2C1_SCL_BANK GPIOC
+#        define I2C1_SCL 4
+#        define I2C1_SCL_PAL_MODE 4
+#    endif
+#    if (defined USE_I2C2_SDA_ALT)
+#        define I2C1_SDA_BANK GPIOA
+#        define I2C1_SDA 8
+#        define I2C1_SDA_PAL_MODE 4
+#    elif !(defined I2C1_SDA)
+#        define I2C1_SDA_BANK GPIOF
+#        define I2C1_SDA 0
+#        define I2C1_SDA_PAL_MODE 4
+#    endif
+#endif
+
+#if defined(USE_I2C3_400KHZ) || defined(USE_I2C3_100KHZ)
+#    define I2C_DRIVER I2CD3
+#    if (defined USE_I2C3_SCL_ALT)
+#        define I2C1_SCL_BANK GPIOA
+#        define I2C1_SCL 8
+#        define I2C1_SCL_PAL_MODE 2
+#    elif !(defined I2C1_SCL)
+#        define I2C1_SCL_BANK GPIOC
+#        define I2C1_SCL 8
+#        define I2C1_SCL_PAL_MODE 8
+#    endif
+#    if (defined USE_I2C3_SDA_ALT)
+#        define I2C1_SDA_BANK GPIOC
+#        define I2C1_SDA 11
+#        define I2C1_SDA_PAL_MODE 8
+#    elif !(defined I2C1_SDA)
+#        define I2C1_SDA_BANK GPIOC
+#        define I2C1_SDA 9
+#        define I2C1_SDA_PAL_MODE 8
+#    endif
+#endif

--- a/platforms/chibios/GENERIC_STM32_G474XE/configs/config.h
+++ b/platforms/chibios/GENERIC_STM32_G474XE/configs/config.h
@@ -25,6 +25,8 @@
 // Insert these two lines into your keyboard's `config.h` file.
 // In the case below, PB7 is selected to charge.
 #if 0
-#define STM32_BOOTLOADER_DUAL_BANK TRUE
-#define STM32_BOOTLOADER_DUAL_BANK_GPIO B7
+#    define STM32_BOOTLOADER_DUAL_BANK TRUE
+#    define STM32_BOOTLOADER_DUAL_BANK_GPIO B7
 #endif
+
+#include "i2c_defs.h"

--- a/platforms/chibios/GENERIC_STM32_G474XE/configs/i2c_defs.h
+++ b/platforms/chibios/GENERIC_STM32_G474XE/configs/i2c_defs.h
@@ -1,0 +1,120 @@
+/* Copyright 2021 Dasky
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+/* G474 - All i2c run from pclk1*/
+
+#if defined(USE_I2C1_400KHZ) || defined(USE_I2C2_400KHZ) || defined(USE_I2C3_400KHZ) || defined(USE_I2C4_400KHZ)
+#    define I2C1_TIMINGR_PRESC 0U
+#    define I2C1_TIMINGR_SCLDEL 15U
+#    define I2C1_TIMINGR_SDADEL 0U
+#    define I2C1_TIMINGR_SCLH 123U
+#    define I2C1_TIMINGR_SCLL 255U
+#elif defined(USE_I2C1_100KHZ) || defined(USE_I2C2_100KHZ) || defined(USE_I2C3_100KHZ) || defined(USE_I2C4_100KHZ)
+#    define I2C1_TIMINGR_PRESC 3U
+#    define I2C1_TIMINGR_SCLDEL 9U
+#    define I2C1_TIMINGR_SDADEL 0U
+#    define I2C1_TIMINGR_SCLH 157U
+#    define I2C1_TIMINGR_SCLL 236U
+#endif
+
+#if defined(USE_I2C1_400KHZ) || defined(USE_I2C1_100KHZ)
+#    define I2C_DRIVER I2CD1
+#    if (defined USE_I2C1_SCL_ALT)
+#        define I2C1_SCL_BANK GPIOA
+#        define I2C1_SCL 13
+#        define I2C1_SCL_PAL_MODE 4
+#    elif !(defined I2C1_SCL)
+#        define I2C1_SCL_BANK GPIOA
+#        define I2C1_SCL 15
+#        define I2C1_SCL_PAL_MODE 4
+#    endif
+#    if (defined USE_I2C1_SDA_ALT)
+#        define I2C1_SDA_BANK GPIOB
+#        define I2C1_SDA 9
+#        define I2C1_SDA_PAL_MODE 4
+#    elif !(defined I2C1_SDA)
+#        define I2C1_SDA_BANK GPIOB
+#        define I2C1_SDA 7
+#        define I2C1_SDA_PAL_MODE 4
+#    endif
+#endif
+
+#if defined(USE_I2C2_400KHZ) || defined(USE_I2C2_100KHZ)
+#    define I2C_DRIVER I2CD2
+#    if (defined USE_I2C2_SCL_ALT)
+#        define I2C1_SCL_BANK GPIOA
+#        define I2C1_SCL 9
+#        define I2C1_SCL_PAL_MODE 4
+#    elif !(defined I2C1_SCL)
+#        define I2C1_SCL_BANK GPIOC
+#        define I2C1_SCL 4
+#        define I2C1_SCL_PAL_MODE 4
+#    endif
+#    if (defined USE_I2C2_SDA_ALT)
+#        define I2C1_SDA_BANK GPIOA
+#        define I2C1_SDA 8
+#        define I2C1_SDA_PAL_MODE 4
+#    elif !(defined I2C1_SDA)
+#        define I2C1_SDA_BANK GPIOF
+#        define I2C1_SDA 0
+#        define I2C1_SDA_PAL_MODE 4
+#    endif
+#endif
+
+#if defined(USE_I2C3_400KHZ) || defined(USE_I2C3_100KHZ)
+#    define I2C_DRIVER I2CD3
+#    if (defined USE_I2C3_SCL_ALT)
+#        define I2C1_SCL_BANK GPIOA
+#        define I2C1_SCL 8
+#        define I2C1_SCL_PAL_MODE 2
+#    elif !(defined I2C1_SCL)
+#        define I2C1_SCL_BANK GPIOC
+#        define I2C1_SCL 8
+#        define I2C1_SCL_PAL_MODE 8
+#    endif
+#    if (defined USE_I2C3_SDA_ALT)
+#        define I2C1_SDA_BANK GPIOC
+#        define I2C1_SDA 11
+#        define I2C1_SDA_PAL_MODE 8
+#    elif !(defined I2C1_SDA)
+#        define I2C1_SDA_BANK GPIOC
+#        define I2C1_SDA 9
+#        define I2C1_SDA_PAL_MODE 8
+#    endif
+#endif
+
+#if defined(USE_I2C4_400KHZ) || defined(USE_I2C4_100KHZ)
+#    define I2C_DRIVER I2CD4
+#    if (defined USE_I2C4_SCL_ALT)
+#        define I2C1_SCL_BANK GPIOA
+#        define I2C1_SCL 13
+#        define I2C1_SCL_PAL_MODE 3
+#    elif !(defined I2C1_SCL)
+#        define I2C1_SCL_BANK GPIOC
+#        define I2C1_SCL 6
+#        define I2C1_SCL_PAL_MODE 8
+#    endif
+#    if (defined USE_I2C4_SDA_ALT)
+#        define I2C1_SDA_BANK GPIOB
+#        define I2C1_SDA 7
+#        define I2C1_SDA_PAL_MODE 3
+#    elif !(defined I2C1_SDA)
+#        define I2C1_SDA_BANK GPIOC
+#        define I2C1_SDA 7
+#        define I2C1_SDA_PAL_MODE 8
+#    endif
+#endif

--- a/platforms/chibios/QMK_PROTON_C/configs/config.h
+++ b/platforms/chibios/QMK_PROTON_C/configs/config.h
@@ -18,3 +18,5 @@
 #ifndef EARLY_INIT_PERFORM_BOOTLOADER_JUMP
 #    define EARLY_INIT_PERFORM_BOOTLOADER_JUMP TRUE
 #endif
+
+#include "i2c_defs.h"

--- a/platforms/chibios/QMK_PROTON_C/configs/i2c_defs.h
+++ b/platforms/chibios/QMK_PROTON_C/configs/i2c_defs.h
@@ -1,0 +1,80 @@
+/* Copyright 2021 Dasky
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+/* PROTON C/F303 - using proton c pinout to set default pins, i2c2 alt pins are osc f0/f1 */
+
+#if defined(USE_I2C1_400KHZ) || defined(USE_I2C1_100KHZ)
+#    define I2C_DRIVER I2CD1
+#    if defined(USE_I2C1_400KHZ)
+#        define I2C1_TIMINGR_PRESC 0U
+#        define I2C1_TIMINGR_SCLDEL 7U
+#        define I2C1_TIMINGR_SDADEL 0U
+#        define I2C1_TIMINGR_SCLH 38U
+#        define I2C1_TIMINGR_SCLL 129U
+#    elif defined(USE_I2C1_100KHZ)
+#        define I2C1_TIMINGR_PRESC 1U
+#        define I2C1_TIMINGR_SCLDEL 8U
+#        define I2C1_TIMINGR_SDADEL 0U
+#        define I2C1_TIMINGR_SCLH 141U
+#        define I2C1_TIMINGR_SCLL 211U
+#    endif
+#    if (defined USE_I2C1_SCL_ALT)
+#        define I2C1_SCL_BANK GPIOB
+#        define I2C1_SCL 8
+#        define I2C1_SCL_PAL_MODE 4
+#    elif !(defined I2C1_SCL)
+#        define I2C1_SCL_BANK GPIOB
+#        define I2C1_SCL 6
+#        define I2C1_SCL_PAL_MODE 4
+#    endif
+#    if (defined USE_I2C1_SDA_ALT)
+#        define I2C1_SDA_BANK GPIOB
+#        define I2C1_SDA 9
+#        define I2C1_SDA_PAL_MODE 4
+#    elif !(defined I2C1_SDA)
+#        define I2C1_SDA_BANK GPIOB
+#        define I2C1_SDA 7
+#        define I2C1_SDA_PAL_MODE 4
+#    endif
+#endif
+
+#if defined(USE_I2C2_400KHZ) || defined(USE_I2C2_100KHZ)
+#    define I2C_DRIVER I2CD2
+#    if defined(USE_I2C2_400KHZ)
+#        define I2C1_TIMINGR_PRESC 0U
+#        define I2C1_TIMINGR_SCLDEL 7U
+#        define I2C1_TIMINGR_SDADEL 0U
+#        define I2C1_TIMINGR_SCLH 38U
+#        define I2C1_TIMINGR_SCLL 129U
+#    elif defined(USE_I2C2_100KHZ)
+#        define I2C1_TIMINGR_PRESC 1U
+#        define I2C1_TIMINGR_SCLDEL 8U
+#        define I2C1_TIMINGR_SDADEL 0U
+#        define I2C1_TIMINGR_SCLH 141U
+#        define I2C1_TIMINGR_SCLL 211U
+#    endif
+#    if !(defined I2C1_SCL)
+#        define I2C1_SCL_BANK GPIOA
+#        define I2C1_SCL 9
+#        define I2C1_SCL_PAL_MODE 4
+#    endif
+#    if !(defined I2C1_SDA)
+#        define I2C1_SDA_BANK GPIOA
+#        define I2C1_SDA 10
+#        define I2C1_SDA_PAL_MODE 4
+#    endif
+#endif

--- a/platforms/chibios/STM32_F103_STM32DUINO/configs/config.h
+++ b/platforms/chibios/STM32_F103_STM32DUINO/configs/config.h
@@ -1,4 +1,4 @@
-/* Copyright 2020 Nick Brassel (tzarc)
+/* Copyright 2021 Dasky
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -14,14 +14,5 @@
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #pragma once
-
-#define BOARD_OTG_NOVBUSSENS 1
-
-#define STM32_LSECLK 32768U
-#define STM32_HSECLK 25000000U
-
-#ifndef EARLY_INIT_PERFORM_BOOTLOADER_JUMP
-#    define EARLY_INIT_PERFORM_BOOTLOADER_JUMP TRUE
-#endif
 
 #include "i2c_defs.h"

--- a/platforms/chibios/STM32_F103_STM32DUINO/configs/i2c_defs.h
+++ b/platforms/chibios/STM32_F103_STM32DUINO/configs/i2c_defs.h
@@ -1,0 +1,64 @@
+/* Copyright 2021 Dasky
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+/* F103 */
+
+#if defined(USE_I2C1_400KHZ) || defined(USE_I2C1_100KHZ)
+#    define I2C_DRIVER I2CD1
+#    if defined(USE_I2C1_400KHZ)
+#        define I2C1_OPMODE OPMODE_I2C
+#        define I2C1_CLOCK_SPEED 400000
+#        define I2C1_DUTY_CYCLE FAST_DUTY_CYCLE_2
+#    elif defined(USE_I2C1_100KHZ)
+#        define I2C1_OPMODE OPMODE_I2C
+#        define I2C1_CLOCK_SPEED 100000
+#        define I2C1_DUTY_CYCLE STD_DUTY_CYCLE
+#    endif
+#    if !(defined I2C1_SCL)
+#        define I2C1_SCL_BANK GPIOB
+#        define I2C1_SCL 6
+#        define I2C1_SCL_PAL_MODE PAL_MODE_STM32_ALTERNATE_OPENDRAIN
+#    endif
+#    if !(defined I2C1_SDA)
+#        define I2C1_SDA_BANK GPIOB
+#        define I2C1_SDA 7
+#        define I2C1_SDA_PAL_MODE PAL_MODE_STM32_ALTERNATE_OPENDRAIN
+#    endif
+#endif
+
+#if defined(USE_I2C2_400KHZ) || defined(USE_I2C2_100KHZ)
+#    define I2C_DRIVER I2CD2
+#    if defined(USE_I2C2_400KHZ)
+#        define I2C1_OPMODE OPMODE_I2C
+#        define I2C1_CLOCK_SPEED 400000
+#        define I2C1_DUTY_CYCLE FAST_DUTY_CYCLE_2
+#    elif defined(USE_I2C2_100KHZ)
+#        define I2C1_OPMODE OPMODE_I2C
+#        define I2C1_CLOCK_SPEED 100000
+#        define I2C1_DUTY_CYCLE STD_DUTY_CYCLE
+#    endif
+#    if !(defined I2C1_SCL)
+#        define I2C1_SCL_BANK GPIOB
+#        define I2C1_SCL 10
+#        define I2C1_SCL_PAL_MODE PAL_MODE_STM32_ALTERNATE_OPENDRAIN
+#    endif
+#    if !(defined I2C1_SDA)
+#        define I2C1_SDA_BANK GPIOB
+#        define I2C1_SDA 11
+#        define I2C1_SDA_PAL_MODE PAL_MODE_STM32_ALTERNATE_OPENDRAIN
+#    endif
+#endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This adds default configurations for the STM32 I2C peripherals.

I've opened this for some eyes on the configurations, I also don't have hardware to test all of them. I'm hoping some kind people might help out. 

After a brief chat with tzarc it seems like the defines might want renaming and/or restructuring with the possibility of adding all alternative pins for a given I2C peripheral. (at the moment it only provides one where available)

The clock configurations should be valid for the default mcuconf clock setup for each platform. I need to triple check but was aiming to do this when writing the documentation. The rise and fall time is set to 0ns in STMCubeMX which is the current setup in i2c_master for f303. (I guess this may be an issue?)

Any help testing any of there configurations would be greatly appreciated, I suspect some might need additional work.


<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
