### PR TITLE
nix-shell: add missing dotty-dict and jsonschema

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -38,6 +38,20 @@ let
     doCheck = false;
   };
 
+  dotty-dict = with pkgs.python3Packages; buildPythonPackage rec {
+    pname = "dotty_dict";
+    version = "1.3.0";
+
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "sha256-6wA1o2KezYQ5emjx9C8elKvRw0V3oZzT6srTMe58uvA=";
+    };
+
+    propagatedBuildInputs = [ setuptools_scm ];
+
+    doCheck = false;
+  };
+
   pythonEnv = pkgs.python3.withPackages (p: with p; [
     # requirements.txt
     appdirs
@@ -46,6 +60,8 @@ let
     hjson
     milc
     pygments
+    dotty-dict
+    jsonschema
     # requirements-dev.txt
     nose2
     flake8


### PR DESCRIPTION
add missing python dependencies in shell.nix

## Types of Changes

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
