### PR TITLE
Add support for up to 4 IS31FL3733 drivers

### DIFF
--- a/docs/feature_led_matrix.md
+++ b/docs/feature_led_matrix.md
@@ -15,7 +15,20 @@ LED_MATRIX_ENABLE = yes
 LED_MATRIX_DRIVER = IS31FL3731
 ```
 
-Configure the hardware via your `config.h`:
+You can use between 1 and 4 IS31FL3731 IC's. Do not specify `LED_DRIVER_ADDR_<N>` defines for IC's that are not present on your keyboard. You can define the following items in `config.h`:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `ISSI_TIMEOUT` | (Optional) How long to wait for i2c messages, in milliseconds | 100 |
+| `ISSI_PERSISTENCE` | (Optional) Retry failed messages this many times | 0 |
+| `LED_DRIVER_COUNT` | (Required) How many LED driver IC's are present | |
+| `DRIVER_LED_TOTAL` | (Required) How many LED lights are present across all drivers | |
+| `LED_DRIVER_ADDR_1` | (Required) Address for the first LED driver | |
+| `LED_DRIVER_ADDR_2` | (Optional) Address for the second LED driver | |
+| `LED_DRIVER_ADDR_3` | (Optional) Address for the third LED driver | |
+| `LED_DRIVER_ADDR_4` | (Optional) Address for the fourth LED driver | |
+
+Here is an example using 2 drivers.
 
 ```c
 // This is a 7-bit address, that gets left-shifted and bit 0
@@ -25,18 +38,16 @@ Configure the hardware via your `config.h`:
 // 0b1110111 AD <-> VCC
 // 0b1110101 AD <-> SCL
 // 0b1110110 AD <-> SDA
-#define DRIVER_ADDR_1 0b1110100
-#define DRIVER_ADDR_2 0b1110110
+#define LED_DRIVER_ADDR_1 0b1110100
+#define LED_DRIVER_ADDR_2 0b1110110
 
-#define DRIVER_COUNT 2
-#define DRIVER_1_LED_TOTAL 25
-#define DRIVER_2_LED_TOTAL 24
-#define DRIVER_LED_TOTAL (DRIVER_1_LED_TOTAL + DRIVER_2_LED_TOTAL)
+#define LED_DRIVER_COUNT 2
+#define LED_DRIVER_1_LED_TOTAL 25
+#define LED_DRIVER_2_LED_TOTAL 24
+#define DRIVER_LED_TOTAL (LED_DRIVER_1_LED_TOTAL + LED_DRIVER_2_LED_TOTAL)
 ```
 
-!> Note the parentheses, this is so when `DRIVER_LED_TOTAL` is used in code and expanded, the values are added together before any additional math is applied to them. As an example, `rand() % (DRIVER_1_LED_TOTAL + DRIVER_2_LED_TOTAL)` will give very different results than `rand() % DRIVER_1_LED_TOTAL + DRIVER_2_LED_TOTAL`.
-
-Currently only 2 drivers are supported, but it would be trivial to support all 4 combinations.
+!> Note the parentheses, this is so when `LED_DRIVER_LED_TOTAL` is used in code and expanded, the values are added together before any additional math is applied to them. As an example, `rand() % (LED_DRIVER_1_LED_TOTAL + LED_DRIVER_2_LED_TOTAL)` will give very different results than `rand() % LED_DRIVER_1_LED_TOTAL + LED_DRIVER_2_LED_TOTAL`.
 
 Define these arrays listing all the LEDs in your `<keyboard>.c`:
 

--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -80,7 +80,7 @@ You can use between 1 and 4 IS31FL3733 IC's. Do not specify `DRIVER_ADDR_<N>` de
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `ISSI_TIMEOUT` | (Optional) How long to wait for i2c messages | 100ms |
+| `ISSI_TIMEOUT` | (Optional) How long to wait for i2c messages, in milliseconds | 100 |
 | `ISSI_PERSISTENCE` | (Optional) Retry failed messages this many times | 0 |
 | `DRIVER_COUNT` | (Required) How many RGB driver IC's are present | |
 | `DRIVER_LED_TOTAL` | (Required) How many RGB lights are present across all drivers | |

--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -19,7 +19,7 @@ You can use between 1 and 4 IS31FL3731 IC's. Do not specify `DRIVER_ADDR_<N>` de
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `ISSI_TIMEOUT` | (Optional) How long to wait for i2c messages | 100ms |
+| `ISSI_TIMEOUT` | (Optional) How long to wait for i2c messages, in milliseconds | 100 |
 | `ISSI_PERSISTENCE` | (Optional) Retry failed messages this many times | 0 |
 | `DRIVER_COUNT` | (Required) How many RGB driver IC's are present | |
 | `DRIVER_LED_TOTAL` | (Required) How many RGB lights are present across all drivers | |

--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -15,7 +15,20 @@ RGB_MATRIX_ENABLE = yes
 RGB_MATRIX_DRIVER = IS31FL3731
 ```
 
-Configure the hardware via your `config.h`:
+You can use between 1 and 4 IS31FL3731 IC's. Do not specify `DRIVER_ADDR_<N>` defines for IC's that are not present on your keyboard. You can define the following items in `config.h`:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `ISSI_TIMEOUT` | (Optional) How long to wait for i2c messages | 100 |
+| `ISSI_PERSISTENCE` | (Optional) Retry failed messages this many times | 0 |
+| `DRIVER_COUNT` | (Required) How many RGB driver IC's are present | |
+| `DRIVER_LED_TOTAL` | (Required) How many RGB lights are present across all drivers | |
+| `DRIVER_ADDR_1` | (Required) Address for the first RGB driver | |
+| `DRIVER_ADDR_2` | (Optional) Address for the second RGB driver | |
+| `DRIVER_ADDR_3` | (Optional) Address for the third RGB driver | |
+| `DRIVER_ADDR_4` | (Optional) Address for the fourth RGB driver | |
+
+Here is an example using 2 drivers.
 
 ```c
 // This is a 7-bit address, that gets left-shifted and bit 0
@@ -36,8 +49,6 @@ Configure the hardware via your `config.h`:
 
 !> Note the parentheses, this is so when `DRIVER_LED_TOTAL` is used in code and expanded, the values are added together before any additional math is applied to them. As an example, `rand() % (DRIVER_1_LED_TOTAL + DRIVER_2_LED_TOTAL)` will give very different results than `rand() % DRIVER_1_LED_TOTAL + DRIVER_2_LED_TOTAL`.
 
-Currently only 2 drivers are supported, but it would be trivial to support all 4 combinations.
-
 Define these arrays listing all the LEDs in your `<keyboard>.c`:
 
 ```c
@@ -53,12 +64,10 @@ const is31_led g_is31_leds[DRIVER_LED_TOTAL] = {
 }
 ```
 
-Where `Cx_y` is the location of the LED in the matrix defined by [the datasheet](https://www.issi.com/WW/pdf/31FL3731.pdf) and the header file `drivers/issi/is31fl3731.h`. The `driver` is the index of the driver you defined in your `config.h` (`0` or `1` right now).
+Where `Cx_y` is the location of the LED in the matrix defined by [the datasheet](https://www.issi.com/WW/pdf/31FL3731.pdf) and the header file `drivers/issi/is31fl3731.h`. The `driver` is the index of the driver you defined in your `config.h` (`0`, `1`, `2`, or `3`).
 
 ---
-### IS31FL3733/IS31FL3737 :id=is31fl3733is31fl3737
-
-!> For the IS31FL3737, replace all instances of `IS31FL3733` below with `IS31FL3737`.
+### IS31FL3733 :id=is31fl3733
 
 There is basic support for addressable RGB matrix lighting with the I2C IS31FL3733 RGB controller. To enable it, add this to your `rules.mk`:
 
@@ -67,7 +76,24 @@ RGB_MATRIX_ENABLE = yes
 RGB_MATRIX_DRIVER = IS31FL3733
 ```
 
-Configure the hardware via your `config.h`:
+You can use between 1 and 4 IS31FL3733 IC's. Do not specify `DRIVER_ADDR_<N>` defines for IC's that are not present on your keyboard. You can define the following items in `config.h`:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `ISSI_TIMEOUT` | (Optional) How long to wait for i2c messages | 100 |
+| `ISSI_PERSISTENCE` | (Optional) Retry failed messages this many times | 0 |
+| `DRIVER_COUNT` | (Required) How many RGB driver IC's are present | |
+| `DRIVER_LED_TOTAL` | (Required) How many RGB lights are present across all drivers | |
+| `DRIVER_ADDR_1` | (Required) Address for the first RGB driver | |
+| `DRIVER_ADDR_2` | (Optional) Address for the second RGB driver | |
+| `DRIVER_ADDR_3` | (Optional) Address for the third RGB driver | |
+| `DRIVER_ADDR_4` | (Optional) Address for the fourth RGB driver | |
+| `DRIVER_SYNC_1` | (Optional) Sync configuration for the first RGB driver | 0 |
+| `DRIVER_SYNC_2` | (Optional) Sync configuration for the second RGB driver | 0 |
+| `DRIVER_SYNC_3` | (Optional) Sync configuration for the third RGB driver | 0 |
+| `DRIVER_SYNC_4` | (Optional) Sync configuration for the fourth RGB driver | 0 |
+
+Here is an example using 2 drivers.
 
 ```c
 // This is a 7-bit address, that gets left-shifted and bit 0
@@ -80,6 +106,58 @@ Configure the hardware via your `config.h`:
 // ADDR1 represents A1:A0 of the 7-bit address.
 // ADDR2 represents A3:A2 of the 7-bit address.
 // The result is: 0b101(ADDR2)(ADDR1)
+#define DRIVER_ADDR_1 0b1010000
+#define DRIVER_ADDR_2 0b1010011
+
+#define DRIVER_COUNT 2
+#define DRIVER_1_LED_TOTAL 58
+#define DRIVER_2_LED_TOTAL 10
+#define DRIVER_LED_TOTAL (DRIVER_1_LED_TOTAL + DRIVER_2_LED_TOTAL)
+```
+
+!> Note the parentheses, this is so when `DRIVER_LED_TOTAL` is used in code and expanded, the values are added together before any additional math is applied to them. As an example, `rand() % (DRIVER_1_LED_TOTAL + DRIVER_2_LED_TOTAL)` will give very different results than `rand() % DRIVER_1_LED_TOTAL + DRIVER_2_LED_TOTAL`.
+
+Currently only 4 drivers are supported, but it would be trivial to support all 8 combinations.
+
+Define these arrays listing all the LEDs in your `<keyboard>.c`:
+
+```c
+const is31_led g_is31_leds[DRIVER_LED_TOTAL] = {
+/* Refer to IS31 manual for these locations
+ *   driver
+ *   |  R location
+ *   |  |       G location
+ *   |  |       |       B location
+ *   |  |       |       | */
+    {0, B_1,    A_1,    C_1},
+    ....
+}
+```
+
+Where `X_Y` is the location of the LED in the matrix defined by [the datasheet](https://www.issi.com/WW/pdf/31FL3733.pdf) and the header file `drivers/issi/is31fl3733.h`. The `driver` is the index of the driver you defined in your `config.h` (`0`, `1`, `2`, or `3` for now).
+
+---
+### IS31FL3737 :id=is31fl3737
+
+There is basic support for addressable RGB matrix lighting with the I2C IS31FL3737 RGB controller. To enable it, add this to your `rules.mk`:
+
+```makefile
+RGB_MATRIX_ENABLE = yes
+RGB_MATRIX_DRIVER = IS31FL3737
+```
+
+Configure the hardware via your `config.h`:
+
+```c
+// This is a 7-bit address, that gets left-shifted and bit 0
+// set to 0 for write, 1 for read (as per I2C protocol)
+// The address will vary depending on your wiring:
+// 0000 <-> GND
+// 0101 <-> SCL
+// 1010 <-> SDA
+// 1111 <-> VCC
+// ADDR represents A3:A0 of the 7-bit address.
+// The result is: 0b101(ADDR)
 #define DRIVER_ADDR_1 0b1010000
 #define DRIVER_ADDR_2 0b1010000 // this is here for compliancy reasons.
 
@@ -105,7 +183,7 @@ const is31_led g_is31_leds[DRIVER_LED_TOTAL] = {
 }
 ```
 
-Where `X_Y` is the location of the LED in the matrix defined by [the datasheet](https://www.issi.com/WW/pdf/31FL3733.pdf) and the header file `drivers/issi/is31fl3733.h`. The `driver` is the index of the driver you defined in your `config.h` (Only `0` right now).
+Where `X_Y` is the location of the LED in the matrix defined by [the datasheet](https://www.issi.com/WW/pdf/31FL3737.pdf) and the header file `drivers/issi/is31fl3737.h`. The `driver` is the index of the driver you defined in your `config.h` (Only `0` right now).
 
 ---
 

--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -19,7 +19,7 @@ You can use between 1 and 4 IS31FL3731 IC's. Do not specify `DRIVER_ADDR_<N>` de
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `ISSI_TIMEOUT` | (Optional) How long to wait for i2c messages | 100 |
+| `ISSI_TIMEOUT` | (Optional) How long to wait for i2c messages | 100ms |
 | `ISSI_PERSISTENCE` | (Optional) Retry failed messages this many times | 0 |
 | `DRIVER_COUNT` | (Required) How many RGB driver IC's are present | |
 | `DRIVER_LED_TOTAL` | (Required) How many RGB lights are present across all drivers | |
@@ -80,7 +80,7 @@ You can use between 1 and 4 IS31FL3733 IC's. Do not specify `DRIVER_ADDR_<N>` de
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `ISSI_TIMEOUT` | (Optional) How long to wait for i2c messages | 100 |
+| `ISSI_TIMEOUT` | (Optional) How long to wait for i2c messages | 100ms |
 | `ISSI_PERSISTENCE` | (Optional) Retry failed messages this many times | 0 |
 | `DRIVER_COUNT` | (Required) How many RGB driver IC's are present | |
 | `DRIVER_LED_TOTAL` | (Required) How many RGB lights are present across all drivers | |

--- a/drivers/issi/is31fl3733.c
+++ b/drivers/issi/is31fl3733.c
@@ -68,7 +68,7 @@ uint8_t g_twi_transfer_buffer[20];
 uint8_t g_pwm_buffer[DRIVER_COUNT][192];
 bool    g_pwm_buffer_update_required[DRIVER_COUNT] = {false};
 
-uint8_t g_led_control_registers[DRIVER_COUNT][24]             = {{0}, {0}};
+uint8_t g_led_control_registers[DRIVER_COUNT][24]             = {0};
 bool    g_led_control_registers_update_required[DRIVER_COUNT] = {false};
 
 bool IS31FL3733_write_register(uint8_t addr, uint8_t reg, uint8_t data) {

--- a/quantum/led_matrix_drivers.c
+++ b/quantum/led_matrix_drivers.c
@@ -46,16 +46,28 @@ static void init(void) {
 #        endif
 #    else
 #        ifdef LED_DRIVER_ADDR_1
-    IS31FL3733_init(LED_DRIVER_ADDR_1, 0);
+#            ifndef LED_DRIVER_SYNC_1
+#                define LED_DRIVER_SYNC_1 0
+#            endif
+    IS31FL3733_init(LED_DRIVER_ADDR_1, LED_DRIVER_SYNC_1);
 #        endif
 #        ifdef LED_DRIVER_ADDR_2
-    IS31FL3733_init(LED_DRIVER_ADDR_2, 0);
+#            ifndef LED_DRIVER_SYNC_2
+#                define LED_DRIVER_SYNC_2 0
+#            endif
+    IS31FL3733_init(LED_DRIVER_ADDR_2, LED_DRIVER_SYNC_2);
 #        endif
 #        ifdef LED_DRIVER_ADDR_3
-    IS31FL3733_init(LED_DRIVER_ADDR_3, 0);
+#            ifndef LED_DRIVER_SYNC_3
+#                define LED_DRIVER_SYNC_3 0
+#            endif
+    IS31FL3733_init(LED_DRIVER_ADDR_3, LED_DRIVER_SYNC_3);
 #        endif
 #        ifdef LED_DRIVER_ADDR_4
-    IS31FL3733_init(LED_DRIVER_ADDR_4, 0);
+#            ifndef LED_DRIVER_SYNC_4
+#                define LED_DRIVER_SYNC_4 0
+#            endif
+    IS31FL3733_init(LED_DRIVER_ADDR_4, LED_DRIVER_SYNC_4);
 #        endif
 #    endif
 
@@ -133,7 +145,7 @@ const led_matrix_driver_t led_matrix_driver = {
     .set_value     = IS31FL3731_set_value,
     .set_value_all = IS31FL3731_set_value_all,
 #    else
-    .set_value = IS31FL3733_set_value,
+    .set_value     = IS31FL3733_set_value,
     .set_value_all = IS31FL3733_set_value_all,
 #    endif
 };

--- a/quantum/rgb_matrix_drivers.c
+++ b/quantum/rgb_matrix_drivers.c
@@ -41,7 +41,28 @@ static void init(void) {
     IS31FL3731_init(DRIVER_ADDR_4);
 #        endif
 #    elif defined(IS31FL3733)
-    IS31FL3733_init(DRIVER_ADDR_1, 0);
+#        ifndef DRIVER_SYNC_1
+#            define DRIVER_SYNC_1 0
+#        endif
+    IS31FL3733_init(DRIVER_ADDR_1, DRIVER_SYNC_1);
+#        if defined DRIVER_ADDR_2 && (DRIVER_ADDR_1 != DRIVER_ADDR_2)
+#            ifndef DRIVER_SYNC_2
+#                define DRIVER_SYNC_2 0
+#            endif
+    IS31FL3733_init(DRIVER_ADDR_2, DRIVER_SYNC_2);
+#        endif
+#        ifdef DRIVER_ADDR_3
+#            ifndef DRIVER_SYNC_3
+#                define DRIVER_SYNC_3 0
+#            endif
+    IS31FL3733_init(DRIVER_ADDR_3, DRIVER_SYNC_3);
+#        endif
+#        ifdef DRIVER_ADDR_4
+#            ifndef DRIVER_SYNC_4
+#                define DRIVER_SYNC_4 0
+#            endif
+    IS31FL3733_init(DRIVER_ADDR_4, DRIVER_SYNC_4);
+#        endif
 #    elif defined(IS31FL3737)
     IS31FL3737_init(DRIVER_ADDR_1);
 #    else
@@ -74,7 +95,15 @@ static void init(void) {
 #        endif
 #    elif defined(IS31FL3733)
     IS31FL3733_update_led_control_registers(DRIVER_ADDR_1, 0);
+#        ifdef DRIVER_ADDR_2
     IS31FL3733_update_led_control_registers(DRIVER_ADDR_2, 1);
+#        endif
+#        ifdef DRIVER_ADDR_3
+    IS31FL3733_update_led_control_registers(DRIVER_ADDR_3, 2);
+#        endif
+#        ifdef DRIVER_ADDR_4
+    IS31FL3733_update_led_control_registers(DRIVER_ADDR_4, 3);
+#        endif
 #    elif defined(IS31FL3737)
     IS31FL3737_update_led_control_registers(DRIVER_ADDR_1, DRIVER_ADDR_2);
 #    else
@@ -105,13 +134,21 @@ const rgb_matrix_driver_t rgb_matrix_driver = {
 #    elif defined(IS31FL3733)
 static void flush(void) {
     IS31FL3733_update_pwm_buffers(DRIVER_ADDR_1, 0);
+#        ifdef DRIVER_ADDR_2
     IS31FL3733_update_pwm_buffers(DRIVER_ADDR_2, 1);
+#        endif
+#        ifdef DRIVER_ADDR_3
+    IS31FL3733_update_pwm_buffers(DRIVER_ADDR_3, 2);
+#        endif
+#        ifdef DRIVER_ADDR_4
+    IS31FL3733_update_pwm_buffers(DRIVER_ADDR_4, 3);
+#        endif
 }
 
 const rgb_matrix_driver_t rgb_matrix_driver = {
-    .init = init,
-    .flush = flush,
-    .set_color = IS31FL3733_set_color,
+    .init          = init,
+    .flush         = flush,
+    .set_color     = IS31FL3733_set_color,
     .set_color_all = IS31FL3733_set_color_all,
 };
 #    elif defined(IS31FL3737)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

Add support for up to 4 IS31FL3733 drivers

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This change allows configuring up to 4 IS31FL3733 rgb matrix drivers.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
