### PR TITLE
Remove `wave` from requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,4 +6,3 @@ nose2
 flake8
 pep8-naming
 yapf
-wave


### PR DESCRIPTION
## Description

The PyPI `wave` package resolves to <https://pypi.org/project/Wave/>, but the places where it is imported make it clear that the standard library module <https://docs.python.org/3/library/wave.html> was intended instead.

Was originally added in #11820 and used in the following files:
* [`util/sample_parser.py`](https://github.com/qmk/qmk_firmware/blob/master/util/sample_parser.py#L19)
* [`util/wavetable_parser.py`](https://github.com/qmk/qmk_firmware/blob/master/util/wavetable_parser.py#L19)

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* None

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).