### PR TITLE
Add WSL specific logic for avrdude device detection

### DIFF
--- a/tmk_core/avr.mk
+++ b/tmk_core/avr.mk
@@ -154,38 +154,43 @@ dfu-split-left: $(BUILD_DIR)/$(TARGET).hex cpfirmware check-size
 dfu-split-right: $(BUILD_DIR)/$(TARGET).hex cpfirmware check-size
 	$(call EXEC_DFU,eeprom-righthand.eep)
 
+AVRDUDE_PROGRAMMER ?= avrdude
+
 define EXEC_AVRDUDE
-	USB= ;\
-	if $(GREP) -q -s Microsoft /proc/version; then \
-		echo 'ERROR: AVR flashing cannot be automated within the Windows Subsystem for Linux (WSL) currently. Instead, take the .hex file generated and flash it using QMK Toolbox, AVRDUDE, AVRDUDESS, or XLoader.'; \
-	else \
-		printf "Detecting USB port, reset your controller now."; \
-		TMP1=`mktemp`; \
-		TMP2=`mktemp`; \
-		ls /dev/tty* > $$TMP1; \
-		while [ -z $$USB ]; do \
-			sleep 0.5; \
-			printf "."; \
-			ls /dev/tty* > $$TMP2; \
-			USB=`comm -13 $$TMP1 $$TMP2 | $(GREP) -o '/dev/tty.*'`; \
-			mv $$TMP2 $$TMP1; \
-		done; \
-		rm $$TMP1; \
-		echo ""; \
-		echo "Device $$USB has appeared; assuming it is the controller."; \
-		if $(GREP) -q -s 'MINGW\|MSYS' /proc/version; then \
-			USB=`echo "$$USB" | perl -pne 's/\/dev\/ttyS(\d+)/COM.($$1+1)/e'`; \
-			echo "Remapped MSYS2 USB port to $$USB"; \
-			sleep 1; \
+	list_devices() { \
+		if $(GREP) -q -s icrosoft /proc/version; then \
+		    wmic.exe path Win32_SerialPort get DeviceID 2>/dev/null | LANG=C perl -pne 's/COM(\d+)/COM.($$1-1)/e' | sed 's!COM!/dev/ttyS!' | xargs echo -n | sort; \
 		else \
-			printf "Waiting for $$USB to become writable."; \
-			while [ ! -w "$$USB" ]; do sleep 0.5; printf "."; done; echo ""; \
+			ls /dev/tty*; \
 		fi; \
-		if [ -z "$(1)" ]; then \
-			avrdude -p $(MCU) -c avr109 -P $$USB -U flash:w:$(BUILD_DIR)/$(TARGET).hex; \
-		else \
-			avrdude -p $(MCU) -c avr109 -P $$USB -U flash:w:$(BUILD_DIR)/$(TARGET).hex -U eeprom:w:$(QUANTUM_PATH)/split_common/$(1); \
-		fi \
+	}; \
+	USB= ;\
+	printf "Detecting USB port, reset your controller now."; \
+	TMP1=`mktemp`; \
+	TMP2=`mktemp`; \
+	list_devices > $$TMP1; \
+	while [ -z $$USB ]; do \
+		sleep 0.5; \
+		printf "."; \
+		list_devices > $$TMP2; \
+		USB=`comm -13 $$TMP1 $$TMP2 | $(GREP) -o '/dev/tty.*'`; \
+		mv $$TMP2 $$TMP1; \
+	done; \
+	rm $$TMP1; \
+	echo ""; \
+	echo "Device $$USB has appeared; assuming it is the controller."; \
+	if $(GREP) -q -s 'MINGW\|MSYS\|icrosoft' /proc/version; then \
+		USB=`echo "$$USB" | LANG=C perl -pne 's/\/dev\/ttyS(\d+)/COM.($$1+1)/e'`; \
+		echo "Remapped USB port to $$USB"; \
+		sleep 1; \
+	else \
+		printf "Waiting for $$USB to become writable."; \
+		while [ ! -w "$$USB" ]; do sleep 0.5; printf "."; done; echo ""; \
+	fi; \
+	if [ -z "$(1)" ]; then \
+		$(AVRDUDE_PROGRAMMER) -p $(MCU) -c avr109 -P $$USB -U flash:w:$(BUILD_DIR)/$(TARGET).hex; \
+	else \
+		$(AVRDUDE_PROGRAMMER) -p $(MCU) -c avr109 -P $$USB -U flash:w:$(BUILD_DIR)/$(TARGET).hex -U eeprom:w:$(QUANTUM_PATH)/split_common/$(1); \
 	fi
 endef
 
@@ -204,7 +209,7 @@ avrdude-split-right: $(BUILD_DIR)/$(TARGET).hex check-size cpfirmware
 	$(call EXEC_AVRDUDE,eeprom-righthand.eep)
 
 define EXEC_USBASP
-	avrdude -p $(AVRDUDE_MCU) -c usbasp -U flash:w:$(BUILD_DIR)/$(TARGET).hex
+	$(AVRDUDE_PROGRAMMER) -p $(AVRDUDE_MCU) -c usbasp -U flash:w:$(BUILD_DIR)/$(TARGET).hex
 endef
 
 usbasp: $(BUILD_DIR)/$(TARGET).hex check-size cpfirmware


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

None of the other flashers currently spit out any WSL specific errors, so ive not kept that logic for avrdude. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
