### PR TITLE
matrix: Save some SRAM, and PROGMEM bytes

### DIFF
--- a/quantum/matrix.c
+++ b/quantum/matrix.c
@@ -22,10 +22,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "quantum.h"
 
 #ifdef DIRECT_PINS
-static pin_t direct_pins[MATRIX_ROWS][MATRIX_COLS] = DIRECT_PINS;
+static const pin_t direct_pins[MATRIX_ROWS][MATRIX_COLS] PROGMEM = DIRECT_PINS;
 #elif (DIODE_DIRECTION == ROW2COL) || (DIODE_DIRECTION == COL2ROW)
-static const pin_t row_pins[MATRIX_ROWS] = MATRIX_ROW_PINS;
-static const pin_t col_pins[MATRIX_COLS] = MATRIX_COL_PINS;
+static const pin_t row_pins[MATRIX_ROWS] PROGMEM = MATRIX_ROW_PINS;
+static const pin_t col_pins[MATRIX_COLS] PROGMEM = MATRIX_COL_PINS;
 #endif
 
 /* matrix state(1:on, 0:off) */
@@ -50,7 +50,7 @@ static inline void setPinInputHigh_atomic(pin_t pin) {
 static void init_pins(void) {
     for (int row = 0; row < MATRIX_ROWS; row++) {
         for (int col = 0; col < MATRIX_COLS; col++) {
-            pin_t pin = direct_pins[row][col];
+            pin_t pin = pgm_read_pin_t(&direct_pins[row][col]);
             if (pin != NO_PIN) {
                 setPinInputHigh(pin);
             }
@@ -63,7 +63,7 @@ static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
     matrix_row_t current_row_value = 0;
 
     for (uint8_t col_index = 0; col_index < MATRIX_COLS; col_index++) {
-        pin_t pin = direct_pins[current_row][col_index];
+        pin_t pin = pgm_read_pin_t(&direct_pins[current_row][col_index]);
         if (pin != NO_PIN) {
             current_row_value |= readPin(pin) ? 0 : (MATRIX_ROW_SHIFTER << col_index);
         }
@@ -80,20 +80,20 @@ static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
 #elif defined(DIODE_DIRECTION)
 #    if (DIODE_DIRECTION == COL2ROW)
 
-static void select_row(uint8_t row) { setPinOutput_writeLow(row_pins[row]); }
+static void select_row(uint8_t row) { setPinOutput_writeLow(pgm_read_pin_t(&row_pins[row])); }
 
-static void unselect_row(uint8_t row) { setPinInputHigh_atomic(row_pins[row]); }
+static void unselect_row(uint8_t row) { setPinInputHigh_atomic(pgm_read_pin_t(&row_pins[row])); }
 
 static void unselect_rows(void) {
     for (uint8_t x = 0; x < MATRIX_ROWS; x++) {
-        setPinInputHigh_atomic(row_pins[x]);
+        setPinInputHigh_atomic(pgm_read_pin_t(&row_pins[x]));
     }
 }
 
 static void init_pins(void) {
     unselect_rows();
     for (uint8_t x = 0; x < MATRIX_COLS; x++) {
-        setPinInputHigh_atomic(col_pins[x]);
+        setPinInputHigh_atomic(pgm_read_pin_t(&col_pins[x]));
     }
 }
 
@@ -108,7 +108,7 @@ static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
     // For each col...
     for (uint8_t col_index = 0; col_index < MATRIX_COLS; col_index++) {
         // Select the col pin to read (active low)
-        uint8_t pin_state = readPin(col_pins[col_index]);
+        uint8_t pin_state = readPin(pgm_read_pin_t(&col_pins[col_index]));
 
         // Populate the matrix row with the state of the col pin
         current_row_value |= pin_state ? 0 : (MATRIX_ROW_SHIFTER << col_index);
@@ -130,20 +130,20 @@ static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
 
 #    elif (DIODE_DIRECTION == ROW2COL)
 
-static void select_col(uint8_t col) { setPinOutput_writeLow(col_pins[col]); }
+static void select_col(uint8_t col) { setPinOutput_writeLow(pgm_read_pin_t(&col_pins[col])); }
 
-static void unselect_col(uint8_t col) { setPinInputHigh_atomic(col_pins[col]); }
+static void unselect_col(uint8_t col) { setPinInputHigh_atomic(pgm_read_pin_t(&col_pins[col])); }
 
 static void unselect_cols(void) {
     for (uint8_t x = 0; x < MATRIX_COLS; x++) {
-        setPinInputHigh_atomic(col_pins[x]);
+        setPinInputHigh_atomic(pgm_read_pin_t(&col_pins[x]));
     }
 }
 
 static void init_pins(void) {
     unselect_cols();
     for (uint8_t x = 0; x < MATRIX_ROWS; x++) {
-        setPinInputHigh_atomic(row_pins[x]);
+        setPinInputHigh_atomic(pgm_read_pin_t(&row_pins[x]));
     }
 }
 
@@ -161,7 +161,7 @@ static bool read_rows_on_col(matrix_row_t current_matrix[], uint8_t current_col)
         matrix_row_t current_row_value = last_row_value;
 
         // Check row pin state
-        if (readPin(row_pins[row_index]) == 0) {
+        if (readPin(pgm_read_pin_t(&row_pins[row_index])) == 0) {
             // Pin LO, set col bit
             current_row_value |= (MATRIX_ROW_SHIFTER << current_col);
         } else {

--- a/tmk_core/common/progmem.h
+++ b/tmk_core/common/progmem.h
@@ -2,6 +2,7 @@
 
 #if defined(__AVR__)
 #    include <avr/pgmspace.h>
+#    define pgm_read_pin_t(address_short) pgm_read_byte(address_short)
 #else
 #    define PROGMEM
 #    define PSTR(x) x
@@ -14,4 +15,5 @@
 #    define strcmp_P(s1, s2) strcmp(s1, s2)
 #    define strcpy_P(dest, src) strcpy(dest, src)
 #    define strlen_P(src) strlen(src)
+#    define pgm_read_pin_t(address_short) (*((pin_t*)(address_short)))
 #endif


### PR DESCRIPTION
...by moving the MATRIX_ROW/COL_PINS and MATRIX_DIRECT_PINS arrays into PROGMEM**

## Description

I used the mt64rgb keyboard build to evaluate the effects of this changeset, because it is already low on PROGMEM.

- Size of .data section (which occupies both SRAM and PROGMEM) goes from 0x2e4 -> 0x2d0, **saving 20 bytes of SRAM** (expected to save only 19 bytes, but the extra byte was probably saved because of alignment)
- Size of .text section goes from 0x6c16 -> 0x6c18, gowing by 2 bytes (expected more growth, but looking at the disassembly it seems like the compiler chooses to not do some loop-unrolling in some of the code, so I think that's the reason it only grows by 2)
- The "firmware size is approaching the maximum" message printed by make goes from 28410 -> 28392, (firmware size is the sum of the size of the .text and .data sections): **saving a total of 18 bytes of PROGMEM**

- I also tested compiling a 2x4 DIRECT_PINS keyboard. Firmware size decreased by 8 bytes.
- I also tested compiling the "id87" (which is a ROW2COL keyboard), **firmware size _increased_ by 4 bytes**. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
   - **NOTE:
      - I tested compiling a COL2ROW, a ROW2COL, and a DIRECT_PINS keyboard. All compile fine.
      - I could not test running my changes on a keyboard, since all my QMK compatible keyboards have a custom matrix, and so the code in which I made the changes doesn't run on my current keyboards.**
