### PR TITLE
Fix QMK Configurator compilation for Kingly Keys Ave

### DIFF
--- a/keyboards/kingly_keys/ave/config.h
+++ b/keyboards/kingly_keys/ave/config.h
@@ -41,6 +41,12 @@
 /* COL2ROW or ROW2COL */
 #define DIODE_DIRECTION COL2ROW
 
+#define RGB_DI_PIN B7
+#if defined(RGBLIGHT_ENABLE)
+#    define RGBLED_NUM 2
+#    define RGBLIGHT_EFFECT_BREATHING
+#endif
+
 /* Set 0 if debouncing isn't needed */
 #define DEBOUNCE 5
 

--- a/keyboards/kingly_keys/ave/ortho/keymaps/default/config.h
+++ b/keyboards/kingly_keys/ave/ortho/keymaps/default/config.h
@@ -18,15 +18,3 @@
 #pragma once
 
 #define TAPPING_TERM_PER_KEY
-
-#ifdef RGBLIGHT_ENABLE
-    /* ws2812 RGB LED */
-    #define RGB_DI_PIN B7
-    #define RGBLED_NUM 2   // Number of LEDs
-    
-    #define RGBLIGHT_EFFECT_BREATHING
-/*  #define RGBLIGHT_HUE_STEP 6
-*   #define RGBLIGHT_SAT_STEP 4
-*   #define RGBLIGHT_VAL_STEP 4
-*/
-#endif

--- a/keyboards/kingly_keys/ave/staggered/keymaps/default/config.h
+++ b/keyboards/kingly_keys/ave/staggered/keymaps/default/config.h
@@ -18,15 +18,3 @@
 #pragma once
 
 #define TAPPING_TERM_PER_KEY
-
-#ifdef RGBLIGHT_ENABLE
-    /* ws2812 RGB LED */
-    #define RGB_DI_PIN B7
-    #define RGBLED_NUM 2   // Number of LEDs
-    
-    #define RGBLIGHT_EFFECT_BREATHING
-/*  #define RGBLIGHT_HUE_STEP 6
-*   #define RGBLIGHT_SAT_STEP 4
-*   #define RGBLIGHT_VAL_STEP 4
-*/
-#endif


### PR DESCRIPTION
## Description

QMK Configurator's API can't use the RGBLight configurator when it's defined at keymap level.

cc @The-Royal (keyboard maintainer)

## Types of Changes

- [x] Enhancement/optimization
- [x] Keyboard (addition or update)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
