### PR TITLE
Add friendly error message when QMK_KEYBOARD_H is empty

### DIFF
--- a/build_keyboard.mk
+++ b/build_keyboard.mk
@@ -221,6 +221,10 @@ ifneq ("$(wildcard $(KEYBOARD_PATH_5)/$(KEYBOARD_FOLDER_5).h)","")
     QMK_KEYBOARD_H = $(KEYBOARD_FOLDER_5).h
 endif
 
+ifeq ("$(wildcard QMK_KEYBOARD_H)","")
+    $(error QMK_KEYBOARD_H is empty! Make sure <keyboard>/<keyboard>.[ch] exist and are named correctly)
+endif
+
 # Determine and set parameters based on the keyboard's processor family.
 # We can assume a ChibiOS target When MCU_FAMILY is defined since it's
 # not used for LUFA


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Currently, with the `<keyboard>.[ch]` files not matching the keyboard folder name:
```
Compiling: keyboards/0_sixty/keymaps/default/keymap.c                                              <command-line>: error: empty filename in #include
keyboards/0_sixty/keymaps/default/keymap.c:35:24: error: expected '=', ',', ';', 'asm' or '__attribute__' before 'keymaps'
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
                        ^~~~~~~
keyboards/0_sixty/keymaps/default/keymap.c:166:1: error: unknown type name 'layer_state_t'
 layer_state_t layer_state_set_user(layer_state_t state) {
 ^~~~~~~~~~~~~
keyboards/0_sixty/keymaps/default/keymap.c:166:36: error: unknown type name 'layer_state_t'
 layer_state_t layer_state_set_user(layer_state_t state) {
                                    ^~~~~~~~~~~~~
 [ERRORS]
 |
 |
 |
make[1]: *** [tmk_core/rules.mk:417: .build/obj_0_sixty_default/keyboards/0_sixty/keymaps/default/keymap.o] Error 1
Make finished with errors
make: *** [Makefile:523: 0_sixty:default] Error 1
```

Now: 

```
Making 0_sixty with keymap default

build_keyboard.mk:225: *** QMK_KEYBOARD_H is empty! Make sure <keyboard>/<keyboard>.[ch] exist and are named correctly.  Stop.
Make finished with errors
make: *** [Makefile:523: 0_sixty:default] Error 1
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
