### PR TITLE
Do not leak weak mods from tap dance to the interrupting keypress

### DIFF
--- a/quantum/process_keycode/process_tap_dance.c
+++ b/quantum/process_keycode/process_tap_dance.c
@@ -117,6 +117,10 @@ void preprocess_tap_dance(uint16_t keycode, keyrecord_t *record) {
             action->state.interrupting_keycode = keycode;
             process_tap_dance_action_on_dance_finished(action);
             reset_tap_dance(&action->state);
+
+            // Tap dance actions can leave some weak mods active (e.g., if the tap dance is mapped to a keycode with
+            // modifiers), but these weak mods should not affect the keypress which interrupted the tap dance.
+            clear_weak_mods();
         }
     }
 }


### PR DESCRIPTION
## Description

Tap dance callbacks may register weak mods; one case when it happens is when a tap dance registers a key with modifiers.  When the tap dance is interrupted by pressing another key, these weak mods could affect the interrupting key (normally any stale weak mods are cleared at the start of `action_exec()` when handling a keypress event, but the  tap dance interrupt check code is called later, and the weak mods left by that code were not cleared).  Add another `clear_weak_mods()` call to `preprocess_tap_dance()` to make sure that the interrupting keypress is not affected by unrelated weak mods from the previous tap dance.

One example of a tap dance which exhibits the problem and can be used with the US QWERTY layout (unlike the example from #12445, which assumes the US International layout):
```c
    [TD_LBRC] = ACTION_TAP_DANCE_DOUBLE(KC_LPRN, KC_LBRC),
```
Before the fix, pressing that tap dance key and then immediately pressing another key without releasing the tap dance key would result in the Shift modifier from `KC_LPRN` (which is actually `S(KC_9)`) getting applied to the second key.

This use case was broken by PR #9941, but just reverting that PR is not the correct solution, because it fixed another set of problems with weak mods. In particular, a reset before `preprocess_tap_dance()` is also required, so that any stale weak mods won't affect the keys which are registered by the tap dance itself.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #12445

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
