### PR TITLE
Allow MAKE environment override for 'qmk clean'

### DIFF
--- a/lib/python/qmk/cli/clean.py
+++ b/lib/python/qmk/cli/clean.py
@@ -1,9 +1,7 @@
 """Clean the QMK firmware folder of build artifacts.
 """
-from qmk.commands import run
+from qmk.commands import run, create_make_target
 from milc import cli
-
-import shutil
 
 
 @cli.argument('-a', '--all', arg_only=True, action='store_true', help='Remove *.hex and *.bin files in the QMK root as well.')
@@ -11,6 +9,4 @@ import shutil
 def clean(cli):
     """Runs `make clean` (or `make distclean` if --all is passed)
     """
-    make_cmd = 'gmake' if shutil.which('gmake') else 'make'
-
-    run([make_cmd, 'distclean' if cli.args.all else 'clean'])
+    run(create_make_target('distclean' if cli.args.all else 'clean'))

--- a/lib/python/qmk/commands.py
+++ b/lib/python/qmk/commands.py
@@ -35,7 +35,7 @@ def create_make_target(target, parallel=1, **env_vars):
     Args:
 
         target
-            Usually a bootloader.
+            Usually a make rule, such as 'clean' or 'all'.
 
         parallel
             The number of make jobs to run in parallel

--- a/lib/python/qmk/commands.py
+++ b/lib/python/qmk/commands.py
@@ -29,6 +29,33 @@ def _find_make():
     return make_cmd
 
 
+def create_make_target(target, parallel=1, **env_vars):
+    """Create a make command
+
+    Args:
+
+        target
+            Usually a bootloader.
+
+        parallel
+            The number of make jobs to run in parallel
+
+        **env_vars
+            Environment variables to be passed to make.
+
+    Returns:
+
+        A command that can be run to make the specified keyboard and keymap
+    """
+    env = []
+    make_cmd = _find_make()
+
+    for key, value in env_vars.items():
+        env.append(f'{key}={value}')
+
+    return [make_cmd, '-j', str(parallel), *env, target]
+
+
 def create_make_command(keyboard, keymap, target=None, parallel=1, **env_vars):
     """Create a make compile command
 
@@ -53,17 +80,12 @@ def create_make_command(keyboard, keymap, target=None, parallel=1, **env_vars):
 
         A command that can be run to make the specified keyboard and keymap
     """
-    env = []
     make_args = [keyboard, keymap]
-    make_cmd = _find_make()
 
     if target:
         make_args.append(target)
 
-    for key, value in env_vars.items():
-        env.append(f'{key}={value}')
-
-    return [make_cmd, '-j', str(parallel), *env, ':'.join(make_args)]
+    return create_make_target(':'.join(make_args), parallel, **env_vars)
 
 
 def get_git_version(repo_dir='.', check_dir='.'):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Due to the way the path is available within WSL and MSYS2, there can be scenarios where `gmake` is incorrectly picked up.

The `MAKE` environment override works for compile/flash, but not for clean due to using its own implementation of the logic.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
