### PR TITLE
Fix F303 audio output on A4 with the dac_basic driver

### DIFF
--- a/quantum/audio/driver_chibios_dac_basic.c
+++ b/quantum/audio/driver_chibios_dac_basic.c
@@ -101,7 +101,7 @@ static const DACConversionGroup dac_conv_grp_ch2 = {.num_channels = 1U, .trigger
 void channel_1_start(void) {
     gptStart(&GPTD6, &gpt6cfg1);
     gptStartContinuous(&GPTD6, 2U);
-    palSetPadMode(GPIOA, 5, PAL_MODE_INPUT_ANALOG);
+    palSetPadMode(GPIOA, 4, PAL_MODE_INPUT_ANALOG);
 }
 
 void channel_1_stop(void) {


### PR DESCRIPTION
## Description

The `dac_basic` audio driver did not work properly with `#define AUDIO_PIN A4` (instead of configuring the **A4** pin, the driver actually was switching the **A5** pin to analog mode, breaking any other usage of that pin in addition to emitting a distorted signal on the improperly configured **A4** pin).  Fix the code to configure the **A4** pin as intended.

Tested on STM32F303CCT6. Without the fix an attempt to enable audio with `#define AUDIO_PIN A4` also broke the basic keyboard functionality with `#define MATRIX_COL_PINS { A5 }` (the column pin was always seen as active); after applying the fix the **A5** pin started working in the matrix again.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* No Github issue; the problem was reported by `@GKD#3464` in the QMK Discord.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
