### PR TITLE
Apply the "NO_LIMITED_CONTROLLER_CONNECT" fix to atmega16u2 too (and …

### DIFF
--- a/tmk_core/protocol/lufa.mk
+++ b/tmk_core/protocol/lufa.mk
@@ -67,8 +67,10 @@ LUFA_OPTS += -DFIXED_CONTROL_ENDPOINT_SIZE=8
 LUFA_OPTS += -DFIXED_CONTROL_ENDPOINT_SIZE=8
 LUFA_OPTS += -DFIXED_NUM_CONFIGURATIONS=1
 
-# Remote wakeup fix for ATmega32U2 (and also some other series 2 and xmega chips)        https://github.com/tmk/tmk_keyboard/issues/361
-LUFA_OPTS += -DNO_LIMITED_CONTROLLER_CONNECT
+# Remote wakeup fix for ATmega16/32U2        https://github.com/tmk/tmk_keyboard/issues/361
+ifneq (,$(filter $(MCU), at90usb162 atmega16u2 atmega32u2))
+	LUFA_OPTS += -DNO_LIMITED_CONTROLLER_CONNECT
+endif
 
 OPT_DEFS += -DF_USB=$(F_USB)UL
 OPT_DEFS += -DARCH=ARCH_$(ARCH)

--- a/tmk_core/protocol/lufa.mk
+++ b/tmk_core/protocol/lufa.mk
@@ -67,10 +67,8 @@ LUFA_OPTS += -DFIXED_CONTROL_ENDPOINT_SIZE=8
 LUFA_OPTS += -DFIXED_CONTROL_ENDPOINT_SIZE=8
 LUFA_OPTS += -DFIXED_NUM_CONFIGURATIONS=1
 
-# Remote wakeup fix for ATmega32U2        https://github.com/tmk/tmk_keyboard/issues/361
-ifeq ($(MCU),atmega32u2)
-	LUFA_OPTS += -DNO_LIMITED_CONTROLLER_CONNECT
-endif
+# Remote wakeup fix for ATmega32U2 (and also some other series 2 and xmega chips)        https://github.com/tmk/tmk_keyboard/issues/361
+LUFA_OPTS += -DNO_LIMITED_CONTROLLER_CONNECT
 
 OPT_DEFS += -DF_USB=$(F_USB)UL
 OPT_DEFS += -DARCH=ARCH_$(ARCH)


### PR DESCRIPTION
## Description

I noticed while browsing code, that this modifier macro is applied only to the atmega32u2 mcu,
however looking at LUFA code it is something that applies to all Series 2 and Xmega AVRs too.

Looking at LUFA code this macro is tested for in very few places, and looks like it is only tested
in the case of MCUs for which it matters, so it's okay for it to be indiscriminately defined.

So looking at what keyboards we have I found we have two atmega16u2 keyboards in our keyboards folder:
 - sixkeyboard
 - xd004/v1

These keyboards are most likely benefited by this change.

Tested by @SidneyBovet

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
Tested by @SidneyBovet