### PR TITLE
haptic: correct size of reserved field in the haptic structure. This saves 1 byte of wasted SRAM.

### DIFF
--- a/drivers/haptic/haptic.h
+++ b/drivers/haptic/haptic.h
@@ -41,7 +41,7 @@ typedef union {
         uint8_t  dwell : 7;
         bool     cont : 1;
         uint8_t  amplitude : 8;
-        uint16_t reserved : 7;
+        uint16_t reserved : 5;
     };
 } haptic_config_t;
 

--- a/drivers/haptic/haptic.h
+++ b/drivers/haptic/haptic.h
@@ -41,7 +41,7 @@ typedef union {
         uint8_t  dwell : 7;
         bool     cont : 1;
         uint8_t  amplitude : 8;
-        uint16_t reserved : 5;
+        uint8_t reserved : 5;
     };
 } haptic_config_t;
 


### PR DESCRIPTION
## Description

Title says it almost all.
Sum of size of bitfields was 34 before, which is larger than the raw value.
The last bitfield is reserved, so its size clearly wasn't updated only by accident.
**NOT TESTED**

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
**NOT TESTED**