### PR TITLE
haptic: Feature to disable haptic feedback when USB is not configured or suspended

### DIFF
--- a/common_features.mk
+++ b/common_features.mk
@@ -21,7 +21,8 @@ QUANTUM_SRC += \
     $(QUANTUM_DIR)/bitwise.c \
     $(QUANTUM_DIR)/led.c \
     $(QUANTUM_DIR)/keymap_common.c \
-    $(QUANTUM_DIR)/keycode_config.c
+    $(QUANTUM_DIR)/keycode_config.c \
+    $(QUANTUM_DIR)/power.c
 
 ifeq ($(strip $(DEBUG_MATRIX_SCAN_RATE_ENABLE)), yes)
     OPT_DEFS += -DDEBUG_MATRIX_SCAN_RATE

--- a/docs/feature_haptic_feedback.md
+++ b/docs/feature_haptic_feedback.md
@@ -8,6 +8,16 @@ The following options are currently available for haptic feedback in `rules.mk`:
 
 `HAPTIC_ENABLE += SOLENOID`
 
+The following `config.h` settings are available for all types of haptic feedback:
+
+| Settings                             | Default       | Description                                                                                                   |
+|--------------------------------------|---------------|---------------------------------------------------------------------------------------------------------------|
+|`HAPTIC_ENABLE_PIN`                   | *Not defined* |Configures a pin to enable a boost converter for some haptic solution, often used with solenoid drivers.       |
+|`HAPTIC_ENABLE_PIN_ACTIVE_LOW`        | *Not defined* |If defined then the haptic enable pin is active-low.                                                           |
+|`HAPTIC_ENABLE_STATUS_LED`            | *Not defined* |Configures a pin to reflect the current enabled/disabled status of haptic feedback.                            |
+|`HAPTIC_ENABLE_STATUS_LED_ACTIVE_LOW` | *Not defined* |If defined then the haptic status led will be active-low.                                                      |
+|`HAPTIC_OFF_IN_LOW_POWER`             | `0`           |If set to `1`, haptic feedback is disabled before the device is configured, and while the device is suspended. |
+
 ## Known Supported Hardware
 
 | Name               | Description                                     |
@@ -45,6 +55,7 @@ First you will need a build a circuit to drive the solenoid through a mosfet as 
 | Settings                   | Default              | Description                                           |
 |----------------------------|----------------------|-------------------------------------------------------|
 |`SOLENOID_PIN`              | *Not defined*        |Configures the pin that the Solenoid is connected to.  |
+|`SOLENOID_PIN_ACTIVE_LOW`   | *Not defined*        |If defined then the solenoid trigger pin is active low.|
 |`SOLENOID_DEFAULT_DWELL`    | `12` ms              |Configures the default dwell time for the solenoid.    |
 |`SOLENOID_MIN_DWELL`        | `4` ms               |Sets the lower limit for the dwell.                    |
 |`SOLENOID_MAX_DWELL`        | `100` ms             |Sets the upper limit for the dwell.                    |

--- a/drivers/haptic/solenoid.c
+++ b/drivers/haptic/solenoid.c
@@ -18,6 +18,7 @@
 #include "timer.h"
 #include "solenoid.h"
 #include "haptic.h"
+#include "power.h"
 
 bool     solenoid_on      = false;
 bool     solenoid_buzzing = false;
@@ -35,7 +36,7 @@ void solenoid_set_buzz(int buzz) { haptic_set_buzz(buzz); }
 void solenoid_set_dwell(uint8_t dwell) { solenoid_dwell = dwell; }
 
 void solenoid_stop(void) {
-    writePinLow(SOLENOID_PIN);
+    SOLENOID_PIN_WRITE_INACTIVE();
     solenoid_on      = false;
     solenoid_buzzing = false;
 }
@@ -47,7 +48,7 @@ void solenoid_fire(void) {
     solenoid_on      = true;
     solenoid_buzzing = true;
     solenoid_start   = timer_read();
-    writePinHigh(SOLENOID_PIN);
+    SOLENOID_PIN_WRITE_ACTIVE();
 }
 
 void solenoid_check(void) {
@@ -68,20 +69,23 @@ void solenoid_check(void) {
         if ((elapsed % (SOLENOID_BUZZ_ACTUATED + SOLENOID_BUZZ_NONACTUATED)) < SOLENOID_BUZZ_ACTUATED) {
             if (!solenoid_buzzing) {
                 solenoid_buzzing = true;
-                writePinHigh(SOLENOID_PIN);
+                SOLENOID_PIN_WRITE_ACTIVE();
             }
         } else {
             if (solenoid_buzzing) {
                 solenoid_buzzing = false;
-                writePinLow(SOLENOID_PIN);
+                SOLENOID_PIN_WRITE_INACTIVE();
             }
         }
     }
 }
 
 void solenoid_setup(void) {
+    SOLENOID_PIN_WRITE_INACTIVE();
     setPinOutput(SOLENOID_PIN);
-    solenoid_fire();
+    if ((!HAPTIC_OFF_IN_LOW_POWER) || high_power_state) {
+        solenoid_fire();
+    }
 }
 
-void solenoid_shutdown(void) { writePinLow(SOLENOID_PIN); }
+void solenoid_shutdown(void) { SOLENOID_PIN_WRITE_INACTIVE(); }

--- a/drivers/haptic/solenoid.h
+++ b/drivers/haptic/solenoid.h
@@ -49,6 +49,14 @@
 #    error SOLENOID_PIN not defined
 #endif
 
+#ifdef SOLENOID_PIN_ACTIVE_LOW
+#    define SOLENOID_PIN_WRITE_ACTIVE() writePinLow(SOLENOID_PIN)
+#    define SOLENOID_PIN_WRITE_INACTIVE() writePinHigh(SOLENOID_PIN)
+#else
+#    define SOLENOID_PIN_WRITE_ACTIVE() writePinHigh(SOLENOID_PIN)
+#    define SOLENOID_PIN_WRITE_INACTIVE() writePinLow(SOLENOID_PIN)
+#endif
+
 void solenoid_buzz_on(void);
 void solenoid_buzz_off(void);
 void solenoid_set_buzz(int buzz);

--- a/quantum/power.c
+++ b/quantum/power.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2021 Andrei Purdea <andrei@purdea.ro>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "power.h"
+#if defined(HAPTIC_ENABLE)
+#include "haptic.h"
+extern haptic_config_t haptic_config;
+#endif
+
+bool high_power_state;
+
+static void update_haptic_config_enable_and_status_pins(void)
+{
+#if defined(HAPTIC_ENABLE)
+    if (haptic_config.enable && ((HAPTIC_OFF_IN_LOW_POWER != 0) || high_power_state)) {
+#    if defined(HAPTIC_ENABLE_PIN)
+        HAPTIC_ENABLE_PIN_WRITE_ACTIVE();
+#    endif
+#    if defined(HAPTIC_ENABLE_STATUS_LED)
+        HAPTIC_ENABLE_STATUS_LED_WRITE_ACTIVE();
+#    endif
+    } else {
+#    if defined(HAPTIC_ENABLE_PIN)
+        HAPTIC_ENABLE_PIN_WRITE_INACTIVE();
+#    endif
+#    if defined(HAPTIC_ENABLE_STATUS_LED)
+        HAPTIC_ENABLE_STATUS_LED_WRITE_INACTIVE();
+#    endif
+    }
+#endif
+}
+
+void power_set_configuration(bool isConfigured, uint8_t configurationNumber)
+{
+    high_power_state = isConfigured;
+    update_haptic_config_enable_and_status_pins();
+}
+
+void power_set_suspend(bool isConfigured, uint8_t configurationNumber)
+{
+    high_power_state = false;
+    update_haptic_config_enable_and_status_pins();
+}
+
+void power_set_resume(bool isConfigured, uint8_t configurationNumber)
+{
+    high_power_state = isConfigured;
+    update_haptic_config_enable_and_status_pins();
+}
+
+void power_set_reset(void)
+{
+    high_power_state = false;
+    update_haptic_config_enable_and_status_pins();
+}
+
+void power_init(void)
+{
+    high_power_state = false;
+    update_haptic_config_enable_and_status_pins();
+#if defined(HAPTIC_ENABLE_PIN)
+    setPinOutput(HAPTIC_ENABLE_PIN);
+#endif
+#if defined(HAPTIC_ENABLE_STATUS_LED)
+    setPinOutput(HAPTIC_ENABLE_STATUS_LED);
+#endif
+}

--- a/quantum/power.h
+++ b/quantum/power.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 Andrei Purdea <andrei@purdea.ro>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "quantum.h"
+
+void power_set_configuration(bool isConfigured, uint8_t configurationNumber);
+void power_set_suspend(bool isConfigured, uint8_t configurationNumber);
+void power_set_resume(bool isConfigured, uint8_t configurationNumber);
+void power_set_reset(void);
+void power_init(void);
+
+extern bool high_power_state;
+
+#ifdef HAPTIC_ENABLE_PIN_ACTIVE_LOW
+#    ifndef HAPTIC_ENABLE_PIN
+#        error HAPTIC_ENABLE_PIN not defined
+#    endif
+#    define HAPTIC_ENABLE_PIN_WRITE_ACTIVE() writePinLow(HAPTIC_ENABLE_PIN)
+#    define HAPTIC_ENABLE_PIN_WRITE_INACTIVE() writePinHigh(HAPTIC_ENABLE_PIN)
+#else
+#    define HAPTIC_ENABLE_PIN_WRITE_ACTIVE() writePinHigh(HAPTIC_ENABLE_PIN)
+#    define HAPTIC_ENABLE_PIN_WRITE_INACTIVE() writePinLow(HAPTIC_ENABLE_PIN)
+#endif
+
+#ifdef HAPTIC_ENABLE_STATUS_LED_ACTIVE_LOW
+#    ifndef HAPTIC_ENABLE_STATUS_LED
+#        error HAPTIC_ENABLE_STATUS_LED not defined
+#    endif
+#    define HAPTIC_ENABLE_STATUS_LED_WRITE_ACTIVE() writePinLow(HAPTIC_ENABLE_STATUS_LED)
+#    define HAPTIC_ENABLE_STATUS_LED_WRITE_INACTIVE() writePinHigh(HAPTIC_ENABLE_STATUS_LED)
+#else
+#    define HAPTIC_ENABLE_STATUS_LED_WRITE_ACTIVE() writePinHigh(HAPTIC_ENABLE_STATUS_LED)
+#    define HAPTIC_ENABLE_STATUS_LED_WRITE_INACTIVE() writePinLow(HAPTIC_ENABLE_STATUS_LED)
+#endif
+
+#ifndef HAPTIC_OFF_IN_LOW_POWER
+#    define HAPTIC_OFF_IN_LOW_POWER 0
+#endif

--- a/tmk_core/protocol/chibios/main.c
+++ b/tmk_core/protocol/chibios/main.c
@@ -27,6 +27,7 @@
 #include "keyboard.h"
 #include "action.h"
 #include "action_util.h"
+#include "power.h"
 #include "mousekey.h"
 #include "led.h"
 #include "sendchar.h"
@@ -156,6 +157,8 @@ int main(void) {
 #ifdef EEPROM_DRIVER
     eeprom_driver_init();
 #endif
+
+    power_init();
 
     // TESTING
     // chThdCreateStatic(waThread1, sizeof(waThread1), NORMALPRIO, Thread1, NULL);

--- a/tmk_core/protocol/lufa/lufa.c
+++ b/tmk_core/protocol/lufa/lufa.c
@@ -52,6 +52,7 @@
 #include "usb_descriptor.h"
 #include "lufa.h"
 #include "quantum.h"
+#include "power.h"
 #include <util/atomic.h>
 
 #ifdef NKRO_ENABLE
@@ -416,7 +417,10 @@ void EVENT_USB_Device_Disconnect(void) {
  *
  * FIXME: Needs doc
  */
-void EVENT_USB_Device_Reset(void) { print("[R]"); }
+void EVENT_USB_Device_Reset(void) {
+    print("[R]");
+    power_set_reset();
+}
 
 /** \brief Event USB Device Connect
  *
@@ -424,6 +428,8 @@ void EVENT_USB_Device_Reset(void) { print("[R]"); }
  */
 void EVENT_USB_Device_Suspend() {
     print("[S]");
+    power_set_suspend(USB_Device_ConfigurationNumber != 0, USB_Device_ConfigurationNumber);
+
 #ifdef SLEEP_LED_ENABLE
     sleep_led_enable();
 #endif
@@ -438,6 +444,8 @@ void EVENT_USB_Device_WakeUp() {
 #if defined(NO_USB_STARTUP_CHECK)
     suspend_wakeup_init();
 #endif
+
+    power_set_resume(USB_DeviceState == DEVICE_STATE_Configured, USB_Device_ConfigurationNumber);
 
 #ifdef SLEEP_LED_ENABLE
     sleep_led_disable();
@@ -526,6 +534,8 @@ void EVENT_USB_Device_ConfigurationChanged(void) {
     /* Setup joystick endpoint */
     ConfigSuccess &= Endpoint_ConfigureEndpoint((JOYSTICK_IN_EPNUM | ENDPOINT_DIR_IN), EP_TYPE_INTERRUPT, JOYSTICK_EPSIZE, 1);
 #endif
+
+    power_set_configuration(USB_DeviceState == DEVICE_STATE_Configured, USB_Device_ConfigurationNumber);
 }
 
 /* FIXME: Expose this table in the docs somehow
@@ -1023,6 +1033,7 @@ int main(void) {
 #endif
 
     setup_mcu();
+    power_init();
     keyboard_setup();
     setup_usb();
     sei();


### PR DESCRIPTION
+ also haptic status led pin feature.

## Description

Please review, mostly for code organization issues, this is not yet tested, so not yet ready to be merged.
(Will test it an an AVR keyboard next weekend)
Note: in chibios land I used USB_DRIVER macro which points to a global variable.
In order to use a "usbp" pointer I'd have to refactor the code to also store a usbp pointer in the queue.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix  (technically a bugfix, cause we likely aren't respecting USB specs, with haptic feedback enabled in low power states)
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
Not yet tested, and not yet ready to merge, **but please review.**
