### PR TITLE
Add script to perform parallel builds.

### DIFF
--- a/lib/python/qmk/cli/__init__.py
+++ b/lib/python/qmk/cli/__init__.py
@@ -6,7 +6,6 @@ import sys
 
 from milc import cli, __VERSION__
 
-from . import buildall
 from . import c2json
 from . import cformat
 from . import chibios
@@ -25,6 +24,7 @@ from . import json2c
 from . import lint
 from . import list
 from . import kle2json
+from . import multibuild
 from . import new
 from . import pyformat
 from . import pytest

--- a/lib/python/qmk/cli/__init__.py
+++ b/lib/python/qmk/cli/__init__.py
@@ -6,6 +6,7 @@ import sys
 
 from milc import cli, __VERSION__
 
+from . import buildall
 from . import c2json
 from . import cformat
 from . import chibios

--- a/lib/python/qmk/cli/buildall.py
+++ b/lib/python/qmk/cli/buildall.py
@@ -1,0 +1,57 @@
+"""Compile all keyboards.
+
+This will compile everything in parallel, for testing purposes.
+"""
+from pathlib import Path
+
+from milc import cli
+
+from qmk.constants import QMK_FIRMWARE
+from qmk.commands import _find_make
+import qmk.keyboard
+
+
+def _determine_default_folder(keyboard_name):
+    conf = qmk.keyboard.config_h(keyboard_name)
+    print(f"""\
+{keyboard_name}:
+{conf}
+""")
+    return keyboard_name
+
+
+@cli.argument('-j', '--parallel', type=int, default=1, help="Set the number of parallel make jobs to run.")
+@cli.argument('-c', '--clean', arg_only=True, action='store_true', help="Remove object files before compiling.")
+@cli.subcommand('Compile QMK Firmware for all keyboards.', hidden=False if cli.config.user.developer else True)
+def buildall(cli):
+    """Compile QMK Firmware against all keyboards.
+    """
+
+    make_cmd = _find_make()
+    if cli.args.clean:
+        cli.run([make_cmd, 'clean'], capture_output=False, text=False)
+
+    builddir = Path(QMK_FIRMWARE) / '.build'
+    makefile = builddir / 'parallel_kb_builds.mk'
+
+    builddir.mkdir(parents=True, exist_ok=True)
+    with open(makefile, "w") as f:
+        for keyboard_name in qmk.keyboard.list_keyboards():
+            keyboard_safe = keyboard_name.replace('/', '_')
+            f.write(
+                f"""\
+all: {keyboard_safe}_binary
+{keyboard_safe}_binary:
+	@rm -f "{QMK_FIRMWARE}/.build/failed.log.{keyboard_safe}" || true
+	+@$(MAKE) -C "{QMK_FIRMWARE}" -f "{QMK_FIRMWARE}/build_keyboard.mk" KEYBOARD="{keyboard_name}" KEYMAP="default" REQUIRE_PLATFORM_KEY= COLOR=true SILENT=false \\
+		>>"{QMK_FIRMWARE}/.build/build.log.{keyboard_safe}" 2>&1 \\
+		|| cp "{QMK_FIRMWARE}/.build/build.log.{keyboard_safe}" "{QMK_FIRMWARE}/.build/failed.log.{keyboard_safe}"
+	@{{ grep '\[ERRORS\]' "{QMK_FIRMWARE}/.build/build.log.{keyboard_safe}" >/dev/null 2>&1 && printf "Build %-64s \e[1;31m[ERRORS]\e[0m\\n" "{keyboard_safe}:default" ; }} \\
+		|| {{ grep '\[WARNINGS\]' "{QMK_FIRMWARE}/.build/build.log.{keyboard_safe}" >/dev/null 2>&1 && printf "Build %-64s \e[1;33m[WARNINGS]\e[0m\\n" "{keyboard_safe}:default" ; }} \\
+		|| printf "Build %-64s \e[1;32m[OK]\e[0m\\n" "{keyboard_safe}:default"
+	@rm -f "{QMK_FIRMWARE}/.build/build.log.{keyboard_safe}" || true
+
+"""
+            )
+
+    cli.run([make_cmd, '-j', str(cli.args.parallel), '-f', makefile, 'all'], capture_output=False, text=False)

--- a/lib/python/qmk/cli/buildall.py
+++ b/lib/python/qmk/cli/buildall.py
@@ -45,6 +45,11 @@ def buildall(cli):
     if cli.args.mcu != '':
         keyboard_list = filter(_make_mcu_filter(cli.args.mcu), keyboard_list)
 
+    keyboard_list = list(keyboard_list)
+
+    if len(keyboard_list) == 0:
+        return
+
     builddir.mkdir(parents=True, exist_ok=True)
     with open(makefile, "w") as f:
         for keyboard_name in keyboard_list:

--- a/lib/python/qmk/cli/buildall.py
+++ b/lib/python/qmk/cli/buildall.py
@@ -26,7 +26,7 @@ def _is_split(keyboard_name):
 
 @cli.argument('-j', '--parallel', type=int, default=1, help="Set the number of parallel make jobs to run.")
 @cli.argument('-c', '--clean', arg_only=True, action='store_true', help="Remove object files before compiling.")
-@cli.argument('-f', '--filter', arg_only=True, action='append', default=[], help="Filter the list of keyboards based on the supplied value in rules.mk. Supported format is 'SPLIT_KEYBOARD=yes'.")
+@cli.argument('-f', '--filter', arg_only=True, action='append', default=[], help="Filter the list of keyboards based on the supplied value in rules.mk. Supported format is 'SPLIT_KEYBOARD=yes'. May be passed multiple times.")
 @cli.subcommand('Compile QMK Firmware for all keyboards.', hidden=False if cli.config.user.developer else True)
 def buildall(cli):
     """Compile QMK Firmware against all keyboards.

--- a/lib/python/qmk/cli/buildall.py
+++ b/lib/python/qmk/cli/buildall.py
@@ -11,17 +11,14 @@ from qmk.commands import _find_make
 import qmk.keyboard
 
 
-def _determine_default_folder(keyboard_name):
-    conf = qmk.keyboard.config_h(keyboard_name)
-    print(f"""\
-{keyboard_name}:
-{conf}
-""")
-    return keyboard_name
+def _is_split(keyboard_name):
+    rules_mk = qmk.keyboard.rules_mk(keyboard_name)
+    return True if 'SPLIT_KEYBOARD' in rules_mk and rules_mk['SPLIT_KEYBOARD'] == 'yes' else False
 
 
 @cli.argument('-j', '--parallel', type=int, default=1, help="Set the number of parallel make jobs to run.")
 @cli.argument('-c', '--clean', arg_only=True, action='store_true', help="Remove object files before compiling.")
+@cli.argument('-s', '--split-only', arg_only=True, action='store_true', help="Only builds boards with 'SPLIT_KEYBOARD = yes' specified in their rules.mk.")
 @cli.subcommand('Compile QMK Firmware for all keyboards.', hidden=False if cli.config.user.developer else True)
 def buildall(cli):
     """Compile QMK Firmware against all keyboards.
@@ -34,9 +31,13 @@ def buildall(cli):
     builddir = Path(QMK_FIRMWARE) / '.build'
     makefile = builddir / 'parallel_kb_builds.mk'
 
+    keyboard_list = qmk.keyboard.list_keyboards()
+    if bool(cli.args.split_only):
+        keyboard_list = filter(_is_split, keyboard_list)
+
     builddir.mkdir(parents=True, exist_ok=True)
     with open(makefile, "w") as f:
-        for keyboard_name in qmk.keyboard.list_keyboards():
+        for keyboard_name in keyboard_list:
             keyboard_safe = keyboard_name.replace('/', '_')
             f.write(
                 f"""\
@@ -46,9 +47,9 @@ all: {keyboard_safe}_binary
 	+@$(MAKE) -C "{QMK_FIRMWARE}" -f "{QMK_FIRMWARE}/build_keyboard.mk" KEYBOARD="{keyboard_name}" KEYMAP="default" REQUIRE_PLATFORM_KEY= COLOR=true SILENT=false \\
 		>>"{QMK_FIRMWARE}/.build/build.log.{keyboard_safe}" 2>&1 \\
 		|| cp "{QMK_FIRMWARE}/.build/build.log.{keyboard_safe}" "{QMK_FIRMWARE}/.build/failed.log.{keyboard_safe}"
-	@{{ grep '\[ERRORS\]' "{QMK_FIRMWARE}/.build/build.log.{keyboard_safe}" >/dev/null 2>&1 && printf "Build %-64s \e[1;31m[ERRORS]\e[0m\\n" "{keyboard_safe}:default" ; }} \\
-		|| {{ grep '\[WARNINGS\]' "{QMK_FIRMWARE}/.build/build.log.{keyboard_safe}" >/dev/null 2>&1 && printf "Build %-64s \e[1;33m[WARNINGS]\e[0m\\n" "{keyboard_safe}:default" ; }} \\
-		|| printf "Build %-64s \e[1;32m[OK]\e[0m\\n" "{keyboard_safe}:default"
+	@{{ grep '\[ERRORS\]' "{QMK_FIRMWARE}/.build/build.log.{keyboard_safe}" >/dev/null 2>&1 && printf "Build %-64s \e[1;31m[ERRORS]\e[0m\\n" "{keyboard_name}:default" ; }} \\
+		|| {{ grep '\[WARNINGS\]' "{QMK_FIRMWARE}/.build/build.log.{keyboard_safe}" >/dev/null 2>&1 && printf "Build %-64s \e[1;33m[WARNINGS]\e[0m\\n" "{keyboard_name}:default" ; }} \\
+		|| printf "Build %-64s \e[1;32m[OK]\e[0m\\n" "{keyboard_name}:default"
 	@rm -f "{QMK_FIRMWARE}/.build/build.log.{keyboard_safe}" || true
 
 """

--- a/lib/python/qmk/cli/info.py
+++ b/lib/python/qmk/cli/info.py
@@ -10,7 +10,7 @@ from milc import cli
 from qmk.json_encoders import InfoJSONEncoder
 from qmk.constants import COL_LETTERS, ROW_LETTERS
 from qmk.decorators import automagic_keyboard, automagic_keymap
-from qmk.keyboard import keyboard_completer, keyboard_folder, render_layouts, render_layout
+from qmk.keyboard import keyboard_completer, keyboard_folder, render_layouts, render_layout, rules_mk
 from qmk.keymap import locate_keymap
 from qmk.info import info_json
 from qmk.path import is_keyboard
@@ -124,12 +124,20 @@ def print_text_output(kb_info_json):
         show_keymap(kb_info_json, False)
 
 
+def print_parsed_rules_mk(keyboard_name):
+    rules = rules_mk(keyboard_name)
+    for k in sorted(rules.keys()):
+        print('%s = %s' % (k, rules[k]))
+    return
+
+
 @cli.argument('-kb', '--keyboard', type=keyboard_folder, completer=keyboard_completer, help='Keyboard to show info for.')
 @cli.argument('-km', '--keymap', help='Show the layers for a JSON keymap too.')
 @cli.argument('-l', '--layouts', action='store_true', help='Render the layouts.')
 @cli.argument('-m', '--matrix', action='store_true', help='Render the layouts with matrix information.')
 @cli.argument('-f', '--format', default='friendly', arg_only=True, help='Format to display the data in (friendly, text, json) (Default: friendly).')
 @cli.argument('--ascii', action='store_true', default=not UNICODE_SUPPORT, help='Render layout box drawings in ASCII only.')
+@cli.argument('-r', '--rules-mk', action='store_true', help='Render the parsed values of the keyboard\'s rules.mk file.')
 @cli.subcommand('Keyboard information.')
 @automagic_keyboard
 @automagic_keymap
@@ -144,6 +152,10 @@ def info(cli):
 
     if not is_keyboard(cli.config.info.keyboard):
         cli.log.error('Invalid keyboard: "%s"', cli.config.info.keyboard)
+        return False
+
+    if bool(cli.args.rules_mk):
+        print_parsed_rules_mk(cli.config.info.keyboard)
         return False
 
     # Build the info.json file

--- a/lib/python/qmk/cli/multibuild.py
+++ b/lib/python/qmk/cli/multibuild.py
@@ -69,7 +69,7 @@ all: {keyboard_safe}_binary
 		|| printf "Build %-64s \e[1;32m[OK]\e[0m\\n" "{keyboard_name}:default"
 	@rm -f "{QMK_FIRMWARE}/.build/build.log.{keyboard_safe}" || true
 
-"""
+""" # noqa: yapf should not care about the formatting of the Makefile
             )
 
     cli.run([make_cmd, '-j', str(cli.args.parallel), '-f', makefile, 'all'], capture_output=False, text=False)

--- a/lib/python/qmk/cli/multibuild.py
+++ b/lib/python/qmk/cli/multibuild.py
@@ -28,7 +28,7 @@ def _is_split(keyboard_name):
 @cli.argument('-c', '--clean', arg_only=True, action='store_true', help="Remove object files before compiling.")
 @cli.argument('-f', '--filter', arg_only=True, action='append', default=[], help="Filter the list of keyboards based on the supplied value in rules.mk. Supported format is 'SPLIT_KEYBOARD=yes'. May be passed multiple times.")
 @cli.subcommand('Compile QMK Firmware for all keyboards.', hidden=False if cli.config.user.developer else True)
-def buildall(cli):
+def multibuild(cli):
     """Compile QMK Firmware against all keyboards.
     """
 


### PR DESCRIPTION
## Description

Adds a helper script that performs all builds in a parallel fashion, instead of serially.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
