### PR TITLE
Fix handling of RV_LOCK and RV_SNAP for windows

### DIFF
--- a/users/rverst/rverst.c
+++ b/users/rverst/rverst.c
@@ -197,15 +197,9 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         // Lock computer
         case RV_LOCK:
             if (mode == MAC || mode == MAC_UNI) {
-                register_code(KC_LGUI);
-                register_code(KC_LCTL);
-                tap_code(KC_Q);
-                unregister_code(KC_LCTL);
-                unregister_code(KC_LGUI);
+                tap_code16(G(S(KC_Q)));
             } else if (mode == WINDOWS || mode == WINDOWS_UNI) {
-                register_code(KC_LGUI);
-                tap_code(KC_L);
-                unregister_code(KC_LGUI);
+                tap_code16(G(KC_L));
             }
             return false;
 
@@ -215,23 +209,15 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
                 if (ls) unregister_code(KC_LSFT);
                 if (rs) unregister_code(KC_RSFT);
 
-                register_code(KC_LGUI);
-                register_code(KC_LSFT);
                 if (as)
-                    tap_code(KC_5);
+                    tap_code16(G(S(KC_5)));
                 else
-                    tap_code(KC_4);
-                unregister_code(KC_LSFT);
-                unregister_code(KC_LGUI);
+                    tap_code16(G(S(KC_4)));
 
                 if (ls) register_code(KC_LSFT);
                 if (rs) register_code(KC_RSFT);
             } else if (mode == WINDOWS || mode == WINDOWS_UNI) {
-                register_code(KC_LGUI);
-                register_code(KC_LSFT);
-                tap_code(KC_S);
-                unregister_code(KC_LSFT);
-                unregister_code(KC_LGUI);
+                tap_code16(G(S(KC_S)));
             }
             return false;
 
@@ -260,9 +246,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
                 if (ls) unregister_code(KC_LSFT);
                 if (rs) unregister_code(KC_RSFT);
 
-                register_code(KC_LALT);
-                tap_code(KC_U);
-                unregister_code(KC_LALT);
+                tap_code16(A(KC_U));
 
                 if (as) register_code(KC_LSFT);
                 if (keycode == RV_AUML) {
@@ -318,11 +302,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             if (is_unicode(mode)) {
                 send_unicode_string("€");
             } else if (mode == MAC) {
-                register_code(KC_LALT);
-                register_code(KC_LSFT);
-                tap_code(KC_2);
-                unregister_code(KC_LSFT);
-                unregister_code(KC_LALT);
+                tap_code16(S(A(KC_2)));
             } else if (mode == WINDOWS) {
                 register_code(KC_RALT);
                 tap_code(KC_0);
@@ -343,9 +323,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
                     send_unicode_string("ß");
                 }
             } else if (mode == MAC) {
-                register_code(KC_LALT);
-                tap_code(KC_S);
-                unregister_code(KC_LALT);
+                tap_code16(A(KC_S));
             } else if (mode == WINDOWS) {
                 register_code(KC_RALT);
                 tap_code(KC_2);

--- a/users/rverst/rverst.c
+++ b/users/rverst/rverst.c
@@ -197,7 +197,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         // Lock computer
         case RV_LOCK:
             if (mode == MAC || mode == MAC_UNI) {
-                tap_code16(G(S(KC_Q)));
+                tap_code16(G(C(KC_Q)));
             } else if (mode == WINDOWS || mode == WINDOWS_UNI) {
                 tap_code16(G(KC_L));
             }
@@ -210,9 +210,9 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
                 if (rs) unregister_code(KC_RSFT);
 
                 if (as)
-                    tap_code16(G(S(KC_5)));
-                else
                     tap_code16(G(S(KC_4)));
+                else
+                    tap_code16(G(S(KC_5)));
 
                 if (ls) register_code(KC_LSFT);
                 if (rs) register_code(KC_RSFT);

--- a/users/rverst/rverst.c
+++ b/users/rverst/rverst.c
@@ -209,10 +209,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
                 if (ls) unregister_code(KC_LSFT);
                 if (rs) unregister_code(KC_RSFT);
 
-                if (as)
-                    tap_code16(G(S(KC_4)));
-                else
-                    tap_code16(G(S(KC_5)));
+                tap_code16(G(S(as ? KC_4 : KC_5)));
 
                 if (ls) register_code(KC_LSFT);
                 if (rs) register_code(KC_RSFT);

--- a/users/rverst/rverst.c
+++ b/users/rverst/rverst.c
@@ -205,7 +205,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             } else if (mode == WINDOWS || mode == WINDOWS_UNI) {
                 register_code(KC_LGUI);
                 tap_code(KC_L);
-                register_code(KC_LGUI);
+                unregister_code(KC_LGUI);
             }
             return false;
 
@@ -230,8 +230,8 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
                 register_code(KC_LGUI);
                 register_code(KC_LSFT);
                 tap_code(KC_S);
-                register_code(KC_LSFT);
-                register_code(KC_LGUI);
+                unregister_code(KC_LSFT);
+                unregister_code(KC_LGUI);
             }
             return false;
 


### PR DESCRIPTION
- keys were not unregistered properly

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
