### PR TITLE
Add millipad keypad and default keymap

### DIFF
--- a/keyboards/millipad/config.h
+++ b/keyboards/millipad/config.h
@@ -91,4 +91,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define ENCODERS_PAD_A { D3 }
 #define ENCODERS_PAD_B { D2 }
-#define ENCODER_RESOLUTION 3
+#define ENCODER_RESOLUTION 4

--- a/keyboards/millipad/config.h
+++ b/keyboards/millipad/config.h
@@ -1,0 +1,94 @@
+/*
+Copyright 2021 Jirou
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "config_common.h"
+
+/* USB Device descriptor parameter */
+#define VENDOR_ID    0xFEED
+#define PRODUCT_ID   0x1A1B
+#define DEVICE_VER   0x0001
+#define MANUFACTURER Jirou
+#define PRODUCT      millipad
+
+/* key matrix size */
+#define MATRIX_ROWS 2
+#define MATRIX_COLS 6
+
+/*
+ * Keyboard Matrix Assignments
+ *
+ * Change this to how you wired your keyboard
+ * COLS: AVR pins used for columns, left to right
+ * ROWS: AVR pins used for rows, top to bottom
+ * DIODE_DIRECTION: COL2ROW = COL = Anode (+), ROW = Cathode (-, marked on diode)
+ *                  ROW2COL = ROW = Anode (+), COL = Cathode (-, marked on diode)
+ *
+ */
+#define MATRIX_ROW_PINS { C6, C7 }
+#define MATRIX_COL_PINS { F0, F1, F4, D7, D6, D4 }
+#define UNUSED_PINS
+
+/* COL2ROW, ROW2COL */
+#define DIODE_DIRECTION COL2ROW
+
+
+
+/* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
+#define DEBOUNCE 5
+
+
+#define LOCKING_RESYNC_ENABLE
+
+
+/*
+ * Force NKRO
+ *
+ * Force NKRO (nKey Rollover) to be enabled by default, regardless of the saved
+ * state in the bootmagic EEPROM settings. (Note that NKRO must be enabled in the
+ * makefile for this to work.)
+ *
+ * If forced on, NKRO can be disabled via magic key (default = LShift+RShift+N)
+ * until the next keyboard reset.
+ *
+ * NKRO may prevent your keystrokes from being detected in the BIOS, but it is
+ * fully operational during normal computer usage.
+ *
+ * For a less heavy-handed approach, enable NKRO via magic key (LShift+RShift+N)
+ * or via bootmagic (hold SPACE+N while plugging in the keyboard). Once set by
+ * bootmagic, NKRO mode will always be enabled until it is toggled again during a
+ * power-up.
+ *
+ */
+#define FORCE_NKRO
+
+
+
+/* disable these deprecated features by default */
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION
+
+/* Bootmagic Lite key configuration */
+//#define BOOTMAGIC_LITE_ROW 0
+//#define BOOTMAGIC_LITE_COLUMN 0
+
+/* Encoder Definitions */
+
+#define ENCODERS_PAD_A { D3 }
+#define ENCODERS_PAD_B { D2 }
+#define ENCODER_RESOLUTION 3

--- a/keyboards/millipad/info.json
+++ b/keyboards/millipad/info.json
@@ -1,0 +1,26 @@
+{
+    "keyboard_name": "millipad",
+    "url": "",
+    "maintainer": "Jirou",
+    "width": 6,
+    "height": 2,
+    "layouts": {
+        "LAYOUT": {
+            "layout": [
+                {"label": "k00", "x": 0, "y": 0},
+                {"label": "k01", "x": 1, "y": 0},
+                {"label": "k02", "x": 2, "y": 0},
+				{"label": "k03", "x": 3, "y": 0},
+				{"label": "k04", "x": 4, "y": 0},
+				{"label": "k05", "x": 5, "y": 0},
+				
+				{"label": "k10", "x": 0, "y": 1},
+				{"label": "k11", "x": 1, "y": 1},
+				{"label": "k12", "x": 2, "y": 1},
+				{"label": "k13", "x": 3, "y": 1},
+				{"label": "k14", "x": 4, "y": 1},
+				{"label": "k15", "x": 5, "y": 1}
+            ]
+        }
+    }
+}

--- a/keyboards/millipad/info.json
+++ b/keyboards/millipad/info.json
@@ -1,6 +1,6 @@
 {
     "keyboard_name": "millipad",
-    "url": "",
+    "url": "https://github.com/GLozares/millipad",
     "maintainer": "Jirou",
     "width": 6,
     "height": 2,

--- a/keyboards/millipad/keymaps/default/keymap.c
+++ b/keyboards/millipad/keymaps/default/keymap.c
@@ -20,41 +20,15 @@ enum layer_names {
     _BASE
 };
 
-// Defines the keycodes used by our macros in process_record_user
-enum custom_keycodes {
-    QMKBEST = SAFE_RANGE,
-    QMKURL
-};
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    /* Base */
+    
     [_BASE] = LAYOUT(
         KC_F1, KC_F2, KC_F3, KC_F4, KC_F5, KC_F11,
 		KC_F6, KC_F7, KC_F8, KC_F9, KC_F10, KC_F12
     )
 };
 
-bool process_record_user(uint16_t keycode, keyrecord_t *record) {
-    switch (keycode) {
-        case QMKBEST:
-            if (record->event.pressed) {
-                // when keycode QMKBEST is pressed
-                SEND_STRING("QMK is the best thing ever!");
-            } else {
-                // when keycode QMKBEST is released
-            }
-            break;
-        case QMKURL:
-            if (record->event.pressed) {
-                // when keycode QMKURL is pressed
-                SEND_STRING("https://qmk.fm/\n");
-            } else {
-                // when keycode QMKURL is released
-            }
-            break;
-    }
-    return true;
-}
 
 void encoder_update_user(uint8_t index, bool clockwise) {
     if (index == 0) { /* First encoder */

--- a/keyboards/millipad/keymaps/default/keymap.c
+++ b/keyboards/millipad/keymaps/default/keymap.c
@@ -1,0 +1,67 @@
+/* Copyright 2021 Jirou
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include QMK_KEYBOARD_H
+
+// Defines names for use in layer keycodes and the keymap
+enum layer_names {
+    _BASE
+};
+
+// Defines the keycodes used by our macros in process_record_user
+enum custom_keycodes {
+    QMKBEST = SAFE_RANGE,
+    QMKURL
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    /* Base */
+    [_BASE] = LAYOUT(
+        KC_F1, KC_F2, KC_F3, KC_F4, KC_F5, KC_F11,
+		KC_F6, KC_F7, KC_F8, KC_F9, KC_F10, KC_F12
+    )
+};
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    switch (keycode) {
+        case QMKBEST:
+            if (record->event.pressed) {
+                // when keycode QMKBEST is pressed
+                SEND_STRING("QMK is the best thing ever!");
+            } else {
+                // when keycode QMKBEST is released
+            }
+            break;
+        case QMKURL:
+            if (record->event.pressed) {
+                // when keycode QMKURL is pressed
+                SEND_STRING("https://qmk.fm/\n");
+            } else {
+                // when keycode QMKURL is released
+            }
+            break;
+    }
+    return true;
+}
+
+void encoder_update_user(uint8_t index, bool clockwise) {
+    if (index == 0) { /* First encoder */
+        if (clockwise) {
+            tap_code(KC_VOLU);
+        } else {
+            tap_code(KC_VOLD);
+        }
+    }
+}

--- a/keyboards/millipad/keymaps/default/readme.md
+++ b/keyboards/millipad/keymaps/default/readme.md
@@ -1,0 +1,1 @@
+# The default keymap for millipad

--- a/keyboards/millipad/millipad.c
+++ b/keyboards/millipad/millipad.c
@@ -1,0 +1,17 @@
+/* Copyright 2021 Jirou
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "millipad.h"

--- a/keyboards/millipad/millipad.h
+++ b/keyboards/millipad/millipad.h
@@ -1,0 +1,35 @@
+/* Copyright 2021 Jirou
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "quantum.h"
+
+/* This is a shortcut to help you visually see your layout.
+ *
+ * The first section contains all of the arguments representing the physical
+ * layout of the board and position of the keys.
+ *
+ * The second converts the arguments into a two-dimensional array which
+ * represents the switch matrix.
+ */
+#define LAYOUT( \
+    k00, k01, k02, k03, k04, k05, \
+    k10, k11, k12, k13, k14, k15    \
+) { \
+    { k00, k01, k02, k03, k04, k05 }, \
+    { k10, k11, k12, k13, k14, k15 }  \
+}

--- a/keyboards/millipad/readme.md
+++ b/keyboards/millipad/readme.md
@@ -1,14 +1,14 @@
 # millipad
 
-![millipad](https://i.imgur.com/ZM2qel5.jpg)
+![millipad](https://i.imgur.com/ZM2qel5h.jpg)
 
 An open source 2x6 macropad with rotary encoder. Designed to be cheap and simple.
 
 
 ## More Pictures:
 ![PCB Layout](https://i.imgur.com/ilhfBfQ.png)
-![Front of PCB](https://i.imgur.com/UiQkmuv.jpg)
-![Back of PCB](https://i.imgur.com/Inh6UTL.jpg)
+![Front of PCB](https://i.imgur.com/UiQkmuvh.jpg)
+![Back of PCB](https://i.imgur.com/Inh6UTLh.jpg)
 
 
 * Keyboard Maintainer: [Jirou](https://github.com/GLozares)

--- a/keyboards/millipad/readme.md
+++ b/keyboards/millipad/readme.md
@@ -2,11 +2,20 @@
 
 ![millipad](https://i.imgur.com/ZM2qel5.jpg)
 
-A 2x6 Macropad with Rotary Encoder. Designed to be cheap and usable.
+An open source 2x6 macropad with rotary encoder. Designed to be cheap and simple.
+
+** Bootloader Mode: 
+Press the hardware reset button located to the left of the rotary encoder.
+
+** More Pictures:
+![PCB Layout](https://i.imgur.com/ilhfBfQ.png)
+![Front of PCB](https://i.imgur.com/UiQkmuv.jpg)
+![Back of PCB](https://i.imgur.com/Inh6UTL.jpg)
+
 
 * Keyboard Maintainer: [Jirou](https://github.com/GLozares)
 * Hardware Supported: Jirou.Design Millipad
-* Hardware Availability: Sag#0001
+* Hardware Availability: Open Source at https://github.com/GLozares/millipad
 
 Make example for this keyboard (after setting up your build environment):
 

--- a/keyboards/millipad/readme.md
+++ b/keyboards/millipad/readme.md
@@ -4,8 +4,6 @@
 
 An open source 2x6 macropad with rotary encoder. Designed to be cheap and simple.
 
-## Bootloader Mode: 
-Press the hardware reset button located to the left of the rotary encoder.
 
 ## More Pictures:
 ![PCB Layout](https://i.imgur.com/ilhfBfQ.png)
@@ -16,6 +14,9 @@ Press the hardware reset button located to the left of the rotary encoder.
 * Keyboard Maintainer: [Jirou](https://github.com/GLozares)
 * Hardware Supported: Jirou.Design Millipad
 * Hardware Availability: Open Source at https://github.com/GLozares/millipad
+
+## Bootloader Mode (Flashing Hex Files): 
+To flash a new hex file, press the hardware reset button located to the left of the rotary encoder to enter Bootloader mode.
 
 Make example for this keyboard (after setting up your build environment):
 

--- a/keyboards/millipad/readme.md
+++ b/keyboards/millipad/readme.md
@@ -4,10 +4,10 @@
 
 An open source 2x6 macropad with rotary encoder. Designed to be cheap and simple.
 
-** Bootloader Mode: 
+## Bootloader Mode: 
 Press the hardware reset button located to the left of the rotary encoder.
 
-** More Pictures:
+## More Pictures:
 ![PCB Layout](https://i.imgur.com/ilhfBfQ.png)
 ![Front of PCB](https://i.imgur.com/UiQkmuv.jpg)
 ![Back of PCB](https://i.imgur.com/Inh6UTL.jpg)

--- a/keyboards/millipad/readme.md
+++ b/keyboards/millipad/readme.md
@@ -1,0 +1,19 @@
+# millipad
+
+![millipad](https://i.imgur.com/ZM2qel5.jpg)
+
+A 2x6 Macropad with Rotary Encoder. Designed to be cheap and usable.
+
+* Keyboard Maintainer: [Jirou](https://github.com/GLozares)
+* Hardware Supported: Jirou.Design Millipad
+* Hardware Availability: Sag#0001
+
+Make example for this keyboard (after setting up your build environment):
+
+    make millipad:default
+
+Flashing example for this keyboard:
+
+    make millipad:default:flash
+
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).

--- a/keyboards/millipad/rules.mk
+++ b/keyboards/millipad/rules.mk
@@ -1,0 +1,23 @@
+# MCU name
+MCU = atmega32u4
+
+# Bootloader selection
+BOOTLOADER = atmel-dfu
+
+# Build Options
+#   change yes to no to disable
+#
+BOOTMAGIC_ENABLE = lite     # Virtual DIP switch configuration
+MOUSEKEY_ENABLE = no       # Mouse keys
+EXTRAKEY_ENABLE = yes       # Audio control and System control
+CONSOLE_ENABLE = no         # Console for debug
+COMMAND_ENABLE = no         # Commands for debug and configuration
+# Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
+SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
+# if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+NKRO_ENABLE = no            # USB Nkey Rollover
+BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
+RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
+BLUETOOTH_ENABLE = no       # Enable Bluetooth
+AUDIO_ENABLE = no           # Audio output
+ENCODER_ENABLE = yes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Added qmk support for my custom keypad "millipad". This keypad is open source and is available on my github. There is a private group buy going on between my friends and I, but it is still open source.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ x ] Keyboard (addition or update)
- [ x ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ x ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
