### PR TITLE
Fix audio on WT60-XT

### DIFF
--- a/keyboards/wilba_tech/wt60_xt/wt60_xt.c
+++ b/keyboards/wilba_tech/wt60_xt/wt60_xt.c
@@ -65,32 +65,29 @@ bool led_update_kb(led_t led_state) {
 
     wait_ms(10); // gets rid of tick
 
-    if (!is_playing_notes())
+    if (led_state.caps_lock && !old_led_state.caps_lock)
     {
-        if (led_state.caps_lock && !old_led_state.caps_lock)
-        {
-            PLAY_SONG(tone_caps_on);
-        }
-        else if (!led_state.caps_lock && old_led_state.caps_lock)
-        {
-            PLAY_SONG(tone_caps_off);
-        }
-        else if (led_state.num_lock && !old_led_state.num_lock)
-        {
-            PLAY_SONG(tone_numlk_on);
-        }
-        else if (!led_state.num_lock && old_led_state.num_lock)
-        {
-            PLAY_SONG(tone_numlk_off);
-        }
-        else if (led_state.scroll_lock && !old_led_state.scroll_lock)
-        {
-            PLAY_SONG(tone_scroll_on);
-        }
-        else if (!led_state.scroll_lock && old_led_state.scroll_lock)
-        {
-            PLAY_SONG(tone_scroll_off);
-        }
+        PLAY_SONG(tone_caps_on);
+    }
+    else if (!led_state.caps_lock && old_led_state.caps_lock)
+    {
+        PLAY_SONG(tone_caps_off);
+    }
+    else if (led_state.num_lock && !old_led_state.num_lock)
+    {
+        PLAY_SONG(tone_numlk_on);
+    }
+    else if (!led_state.num_lock && old_led_state.num_lock)
+    {
+        PLAY_SONG(tone_numlk_off);
+    }
+    else if (led_state.scroll_lock && !old_led_state.scroll_lock)
+    {
+        PLAY_SONG(tone_scroll_on);
+    }
+    else if (!led_state.scroll_lock && old_led_state.scroll_lock)
+    {
+        PLAY_SONG(tone_scroll_off);
     }
 
     old_led_state = led_state;


### PR DESCRIPTION
## Description

`is_playing_notes()` was broken recently, now always returns true. Probably not needed anymore, so took it out here.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
