### PR TITLE
Fix CLI incorrectly following `DEFAULT_FOLDER`

### DIFF
--- a/lib/python/qmk/keyboard.py
+++ b/lib/python/qmk/keyboard.py
@@ -68,8 +68,15 @@ def list_keyboards():
     kb_wildcard = os.path.join(base_path, "**", "rules.mk")
     paths = [path for path in glob(kb_wildcard, recursive=True) if 'keymaps' not in path]
 
-    return sorted(map(_find_name, paths))
+    return sorted(set(map(resolve_keyboard,map(_find_name, paths))))
 
+def resolve_keyboard(keyboard):
+    cur_dir = Path('keyboards')
+    rules = parse_rules_mk_file(cur_dir / keyboard / 'rules.mk')
+    while 'DEFAULT_FOLDER' in rules and keyboard != rules['DEFAULT_FOLDER']:
+        keyboard = rules['DEFAULT_FOLDER']
+        rules = parse_rules_mk_file(cur_dir / keyboard / 'rules.mk')
+    return keyboard
 
 def config_h(keyboard):
     """Parses all the config.h files for a keyboard.
@@ -82,8 +89,8 @@ def config_h(keyboard):
     """
     config = {}
     cur_dir = Path('keyboards')
+    keyboard = Path(resolve_keyboard(keyboard))
     rules = rules_mk(keyboard)
-    keyboard = Path(rules['DEFAULT_FOLDER'] if 'DEFAULT_FOLDER' in rules else keyboard)
 
     for dir in keyboard.parts:
         cur_dir = cur_dir / dir
@@ -101,12 +108,9 @@ def rules_mk(keyboard):
     Returns:
         a dictionary representing the content of the entire rules.mk tree for a keyboard
     """
-    keyboard = Path(keyboard)
     cur_dir = Path('keyboards')
+    keyboard = Path(resolve_keyboard(keyboard))
     rules = parse_rules_mk_file(cur_dir / keyboard / 'rules.mk')
-
-    if 'DEFAULT_FOLDER' in rules:
-        keyboard = Path(rules['DEFAULT_FOLDER'])
 
     for i, dir in enumerate(keyboard.parts):
         cur_dir = cur_dir / dir

--- a/lib/python/qmk/keyboard.py
+++ b/lib/python/qmk/keyboard.py
@@ -70,6 +70,7 @@ def list_keyboards():
 
     return sorted(set(map(resolve_keyboard,map(_find_name, paths))))
 
+
 def resolve_keyboard(keyboard):
     cur_dir = Path('keyboards')
     rules = parse_rules_mk_file(cur_dir / keyboard / 'rules.mk')
@@ -77,6 +78,7 @@ def resolve_keyboard(keyboard):
         keyboard = rules['DEFAULT_FOLDER']
         rules = parse_rules_mk_file(cur_dir / keyboard / 'rules.mk')
     return keyboard
+
 
 def config_h(keyboard):
     """Parses all the config.h files for a keyboard.
@@ -90,7 +92,6 @@ def config_h(keyboard):
     config = {}
     cur_dir = Path('keyboards')
     keyboard = Path(resolve_keyboard(keyboard))
-    rules = rules_mk(keyboard)
 
     for dir in keyboard.parts:
         cur_dir = cur_dir / dir

--- a/lib/python/qmk/keyboard.py
+++ b/lib/python/qmk/keyboard.py
@@ -68,7 +68,7 @@ def list_keyboards():
     kb_wildcard = os.path.join(base_path, "**", "rules.mk")
     paths = [path for path in glob(kb_wildcard, recursive=True) if 'keymaps' not in path]
 
-    return sorted(set(map(resolve_keyboard,map(_find_name, paths))))
+    return sorted(set(map(resolve_keyboard, map(_find_name, paths))))
 
 
 def resolve_keyboard(keyboard):


### PR DESCRIPTION
## Description

CLI's resolving of `config.h` and `rules.mk` files was following `DEFAULT_FOLDER` unconditionally, and in cases where a keyboard was not the default, parsed and generated data came from the default instead, even if fully qualified.

This fixes the logic to resolve the resulting keyboard based on `DEFAULT_FOLDER` first, then performing full parsing based off the final keyboard path.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
