### PR TITLE
Fixed for iso keyboard format

### DIFF
--- a/keyboards/coseyfannitutti/mysterium/mysterium.h
+++ b/keyboards/coseyfannitutti/mysterium/mysterium.h
@@ -54,20 +54,37 @@
     { K50, K51, K52, _x_, _x_, _x_, K56, _x_, _x_, _x_, K5A, _x_, K5C, _x_, K5E, K5F, K5G, K5H }  \
 }
 
-#define LAYOUT_tkl_iso( \
+#define LAYOUT_tkl_ansi_7u( \
     K00,      K02, K03, K04, K05, K06, K07, K08, K09,      K0B, K0C, K0D, K0E, K0F, K0G, K0H, \
     K10, K11, K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, K1C, K1D,      K1F, K1G, K1H, \
-    K20, K21, K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B, K2C,           K2F, K2G, K2H, \
-    K30, K31, K32, K33, K34, K35, K36, K37, K38, K39, K3A, K3B, K3D, K2D,                     \
-    K40, K01, K41, K42, K43, K44, K45, K46, K47, K48, K49, K4A,      K4D,           K4G,      \
-    K50, K51, K52,                K56,           K59, K5A,      K5C,      K5E, K5F, K5G, K5H  \
+    K20, K21, K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B, K2C, K2D,      K2F, K2G, K2H, \
+    K30, K31, K32, K33, K34, K35, K36, K37, K38, K39, K3A, K3B,      K3D,                     \
+    K40, K41, K42, K43, K44, K45, K46, K47, K48, K49, K4A,           K4D,           K4G,      \
+    K50, K51, K52,                K56,                K5A,      K5C,      K5E, K5F, K5G, K5H  \
 ) \
 { \
-    { K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, _x_, K0B, K0C, K0D, K0E, K0F, K0G, K0H }, \
+    { K00, _x_, K02, K03, K04, K05, K06, K07, K08, K09, _x_, K0B, K0C, K0D, K0E, K0F, K0G, K0H }, \
     { K10, K11, K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, K1C, K1D, _x_, K1F, K1G, K1H }, \
     { K20, K21, K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B, K2C, K2D, _x_, K2F, K2G, K2H }, \
     { K30, K31, K32, K33, K34, K35, K36, K37, K38, K39, K3A, K3B, _x_, K3D, _x_, _x_, _x_, _x_ }, \
     { K40, K41, K42, K43, K44, K45, K46, K47, K48, K49, K4A, _x_, _x_, K4D, _x_, _x_, K4G, _x_ }, \
+    { K50, K51, K52, _x_, _x_, _x_, K56, _x_, _x_, _x_, K5A, _x_, K5C, _x_, K5E, K5F, K5G, K5H }  \
+}
+
+#define LAYOUT_tkl_iso( \
+    K00,      K02, K03, K04, K05, K06, K07, K08, K09,      K0B, K0C, K0D, K0E, K0F, K0G, K0H, \
+    K10, K11, K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, K1C, K1D,      K1F, K1G, K1H, \
+    K20, K21, K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B, K2C,           K2F, K2G, K2H, \
+    K30, K31, K32, K33, K34, K35, K36, K37, K38, K39, K3A, K3B, K2D, K3D,                     \
+    K40, K01, K41, K42, K43, K44, K45, K46, K47, K48, K49, K4A,      K4D,           K4G,      \
+    K50, K51, K52,                K56,           K59, K5A,      K5C,      K5E, K5F, K5G, K5H  \
+) \
+{ \
+    { K00, _x_, K02, K03, K04, K05, K06, K07, K08, K09, _x_, K0B, K0C, K0D, K0E, K0F, K0G, K0H }, \
+    { K10, K11, K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, K1C, K1D, _x_, K1F, K1G, K1H }, \
+    { K20, K21, K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B, K2C, K2D, _x_, K2F, K2G, K2H }, \
+    { K30, K31, K32, K33, K34, K35, K36, K37, K38, K39, K3A, K3B, _x_, K3D, _x_, _x_, _x_, _x_ }, \
+    { K40, K41, K42, K43, K44, K45, K46, K47, K48, K49, K4A, K01, _x_, K4D, _x_, _x_, K4G, _x_ }, \
     { K50, K51, K52, _x_, _x_, _x_, K56, _x_, _x_, K59, K5A, _x_, K5C, _x_, K5E, K5F, K5G, K5H }  \
 }
 
@@ -84,6 +101,6 @@
     { K10, K11, K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, K1C, K1D, _x_, K1F, K1G, K1H }, \
     { K20, K21, K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B, K2C, K2D, _x_, K2F, K2G, K2H }, \
     { K30, K31, K32, K33, K34, K35, K36, K37, K38, K39, K3A, K3B, _x_, K3D, _x_, _x_, _x_, _x_ }, \
-    { K40, K41, K42, K43, K44, K45, K46, K47, K48, K49, K4A, _x_, _x_, K4D, _x_, _x_, K4G, _x_ }, \
+    { K40, K41, K42, K43, K44, K45, K46, K47, K48, K49, K4A, K01, _x_, K4D, _x_, _x_, K4G, _x_ }, \
     { K50, K51, K52, _x_, _x_, _x_, K56, _x_, _x_, _x_, K5A, _x_, K5C, _x_, K5E, K5F, K5G, K5H }  \
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Found an issue with the iso keyboard mapping on the mysterium rev1.1 keyboard. It was missing the left \ key. move the mapping around and know functions on my mysterium iso keyboards. Same change applied to the 7u mapping, untested but should work.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
