### PR TITLE
Steno combinedkeys

### DIFF
--- a/docs/feature_stenography.md
+++ b/docs/feature_stenography.md
@@ -128,3 +128,18 @@ As defined in `keymap_steno.h`.
 |`STN_RES1`||(GeminiPR only)|
 |`STN_RES2`||(GeminiPR only)|
 |`STN_PWR`||(GeminiPR only)|
+
+If you do not want to hit two keys with one finger combined keycodes can be used. These are also defined in `keymap_steno.h`, and causes both keys to be reported as pressed or released. To use these keycodes define `STENO_COMBINEDMAP` in your `config.h` file 
+|Combined key   | Key1   | Key 2    |
+|---------------|--------|----------|
+|STN_S3         | STN_S1 | STN_S2   |
+|STN_TKL        | STN_TL | STN_KL   |
+|STN_PWL        | STN_PL | STN_WL   |
+|STN_HRL        | STN_HL | STN_RL   |
+|STN_FRR        | STN_FR | STN_RR   |
+|STN_PBR        | STN_PR | STN_BR   |
+|STN_LGR        | STN_LR | STN_GR   |
+|STN_TSR        | STN_TR | STN_SR   |
+|STN_DZR        | STN_DR | STN_ZR   |
+|STN_AO         | STN_A  | STN_O    |
+|STN_EU         | STN_E  | STN_U    |

--- a/quantum/keymap_extras/keymap_steno.h
+++ b/quantum/keymap_extras/keymap_steno.h
@@ -72,3 +72,21 @@ enum steno_keycodes {
     STN_ZR,
     STN__MAX = STN_ZR,  // must be less than QK_STENO_BOLT
 };
+
+#ifdef STENO_COMBINEDMAP
+enum steno_combined_keycodes
+{
+    STN_S3 = QK_STENO_COMB,
+    STN_TKL,
+    STN_PWL,
+    STN_HRL,
+    STN_FRR,
+    STN_PBR,
+    STN_LGR,
+    STN_TSR,
+    STN_DZR,
+    STN_AO,
+    STN_EU,
+    STN_COMB_MAX = STN_EU,
+};
+#endif

--- a/quantum/process_keycode/process_steno.c
+++ b/quantum/process_keycode/process_steno.c
@@ -65,6 +65,12 @@ static steno_mode_t mode;
 
 static const uint8_t boltmap[64] PROGMEM = {TXB_NUL, TXB_NUM, TXB_NUM, TXB_NUM, TXB_NUM, TXB_NUM, TXB_NUM, TXB_S_L, TXB_S_L, TXB_T_L, TXB_K_L, TXB_P_L, TXB_W_L, TXB_H_L, TXB_R_L, TXB_A_L, TXB_O_L, TXB_STR, TXB_STR, TXB_NUL, TXB_NUL, TXB_NUL, TXB_STR, TXB_STR, TXB_E_R, TXB_U_R, TXB_F_R, TXB_R_R, TXB_P_R, TXB_B_R, TXB_L_R, TXB_G_R, TXB_T_R, TXB_S_R, TXB_D_R, TXB_NUM, TXB_NUM, TXB_NUM, TXB_NUM, TXB_NUM, TXB_NUM, TXB_Z_R};
 
+#ifdef STENO_COMBINEDMAP
+/* Used to look up when pressing the middle row key to combine two consonant or vowel keys */
+static const uint16_t combinedmap_first[] PROGMEM = {STN_S1, STN_TL, STN_PL, STN_HL, STN_FR, STN_PR, STN_LR, STN_TR, STN_DR, STN_A, STN_E};
+static const uint16_t combinedmap_second[] PROGMEM = {STN_S2, STN_KL, STN_WL, STN_RL, STN_RR, STN_BR, STN_GR, STN_SR, STN_ZR, STN_O, STN_U};
+#endif
+
 static void steno_clear_state(void) {
     memset(state, 0, sizeof(state));
     memset(chord, 0, sizeof(chord));
@@ -167,6 +173,15 @@ bool process_steno(uint16_t keycode, keyrecord_t *record) {
             }
             return false;
 
+#ifdef STENO_COMBINEDMAP
+        case QK_STENO_COMB ... QK_STENO_COMB_MAX:
+        {
+            uint8_t result;
+            result = process_steno(combinedmap_first[keycode-QK_STENO_COMB], record);
+            result &= process_steno(combinedmap_second[keycode-QK_STENO_COMB], record);
+            return result;
+        }
+#endif
         case STN__MIN ... STN__MAX:
             if (!process_steno_user(keycode, record)) {
                 return false;

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -66,6 +66,8 @@ enum quantum_keycodes {
     QK_STENO                = 0x5A00,
     QK_STENO_BOLT           = 0x5A30,
     QK_STENO_GEMINI         = 0x5A31,
+    QK_STENO_COMB           = 0x5A32,
+    QK_STENO_COMB_MAX       = 0x5A3C,
     QK_STENO_MAX            = 0x5A3F,
     // 0x5C00 - 0x5FFF are reserved, see below
     QK_MOD_TAP             = 0x6000,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Makes it possible to press one key instead of trying to hit multiple keys with one finger when inputting steno graphical chords on a keyboard. For example see the second row in the keymap below, combining the key on the keyboard row above and below into one key.
<!--- Describe your changes in detail here. -->
Example layer (for planck) using the combined consonant keys.
`[0] = LAYOUT_ortho_4x12(
  STN_FN,  STN_S1,  STN_TL,  STN_PL,  STN_HL,  STN_ST1, STN_ST3, STN_FR,  STN_PR,  STN_LR,  STN_TR,  STN_DR ,
  STN_FN,  STN_S3,  STN_TKL,  STN_PWL,  STN_HRL,  STN_ST1, STN_ST3, STN_FRR,  STN_PBR,  STN_LGR,  STN_TSR,  STN_DZR ,
  XXXXXXX, STN_S2,  STN_KL,  STN_WL,  STN_RL,  STN_ST2, STN_ST4, STN_RR,  STN_BR,  STN_GR,  STN_SR,  STN_ZR ,
  TG(10), ST_BOLT,  ST_GEM, STN_NA,   STN_A,  STN_O,   STN_E,    STN_U, STN_NB, STN_PWR, STN_RE1, STN_RE2),

};`
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x]  Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
I tried to find some steno tests to extend, but i couldn't find any.
- [x]  I have tested the changes and verified that they work and don't break anything (as well as I can manage).
