### PR TITLE
Backlight: add defines for default level and breathing state

### DIFF
--- a/docs/feature_backlight.md
+++ b/docs/feature_backlight.md
@@ -62,15 +62,17 @@ Valid driver values are `pwm`, `software`, `custom` or `no`. See below for help 
 
 To configure the backlighting, `#define` these in your `config.h`:
 
-| Define                 | Default       | Description                                                                                                       |
-|------------------------|---------------|-------------------------------------------------------------------------------------------------------------------|
-| `BACKLIGHT_PIN`        | *Not defined* | The pin that controls the LED(s)                                                                                  |
-| `BACKLIGHT_LEVELS`     | `3`           | The number of brightness levels (maximum 31 excluding off)                                                        |
-| `BACKLIGHT_CAPS_LOCK`  | *Not defined* | Enable Caps Lock indicator using backlight (for keyboards without dedicated LED)                                  |
-| `BACKLIGHT_BREATHING`  | *Not defined* | Enable backlight breathing, if supported                                                                          |
-| `BREATHING_PERIOD`     | `6`           | The length of one backlight "breath" in seconds                                                                   |
-| `BACKLIGHT_ON_STATE`   | `1`           | The state of the backlight pin when the backlight is "on" - `1` for high, `0` for low                             |
-| `BACKLIGHT_LIMIT_VAL ` | `255`         | The maximum duty cycle of the backlight -- `255` allows for full brightness, any lower will decrease the maximum. |
+|Define                       |Default           |Description                                                                                                      |
+|-----------------------------|------------------|-----------------------------------------------------------------------------------------------------------------|
+|`BACKLIGHT_PIN`              |*Not defined*     |The pin that controls the LED(s)                                                                                 |
+|`BACKLIGHT_LEVELS`           |`3`               |The number of brightness levels (maximum 31 excluding off)                                                       |
+|`BACKLIGHT_CAPS_LOCK`        |*Not defined*     |Enable Caps Lock indicator using backlight (for keyboards without dedicated LED)                                 |
+|`BACKLIGHT_BREATHING`        |*Not defined*     |Enable backlight breathing, if supported                                                                         |
+|`BREATHING_PERIOD`           |`6`               |The length of one backlight "breath" in seconds                                                                  |
+|`BACKLIGHT_ON_STATE`         |`1`               |The state of the backlight pin when the backlight is "on" - `1` for high, `0` for low                            |
+|`BACKLIGHT_LIMIT_VAL`        |`255`             |The maximum duty cycle of the backlight -- `255` allows for full brightness, any lower will decrease the maximum.|
+|`BACKLIGHT_DEFAULT_LEVEL`    |`BACKLIGHT_LEVELS`|The default backlight level to use upon clearing the EEPROM                                                      |
+|`BACKLIGHT_DEFAULT_BREATHING`|*Not defined*     |Whether to enable backlight breathing upon clearing the EEPROM                                                   |
 
 Unless you are designing your own keyboard, you generally should not need to change the `BACKLIGHT_PIN` or `BACKLIGHT_ON_STATE`.
 

--- a/quantum/backlight/backlight.c
+++ b/quantum/backlight/backlight.c
@@ -22,6 +22,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 backlight_config_t backlight_config;
 
+#ifndef BACKLIGHT_DEFAULT_LEVEL
+#    define BACKLIGHT_DEFAULT_LEVEL BACKLIGHT_LEVELS
+#endif
+
 #ifdef BACKLIGHT_BREATHING
 // TODO: migrate to backlight_config_t
 static uint8_t breathing_period = BREATHING_PERIOD;
@@ -35,6 +39,7 @@ void backlight_init(void) {
     /* check signature */
     if (!eeconfig_is_enabled()) {
         eeconfig_init();
+        eeconfig_update_backlight_default();
     }
     backlight_config.raw = eeconfig_read_backlight();
     if (backlight_config.level > BACKLIGHT_LEVELS) {
@@ -152,10 +157,22 @@ void backlight_level(uint8_t level) {
     eeconfig_update_backlight(backlight_config.raw);
 }
 
-/** \brief Update current backlight state to EEPROM
- *
- */
+uint8_t eeconfig_read_backlight(void) { return eeprom_read_byte(EECONFIG_BACKLIGHT); }
+
+void eeconfig_update_backlight(uint8_t val) { eeprom_update_byte(EECONFIG_BACKLIGHT, val); }
+
 void eeconfig_update_backlight_current(void) { eeconfig_update_backlight(backlight_config.raw); }
+
+void eeconfig_update_backlight_default(void) {
+    backlight_config.enable = 1;
+#ifdef BACKLIGHT_DEFAULT_BREATHING
+    backlight_config.breathing = 1;
+#else
+    backlight_config.breathing = 0;
+#endif
+    backlight_config.level = BACKLIGHT_DEFAULT_LEVEL;
+    eeconfig_update_backlight(backlight_config.raw);
+}
 
 /** \brief Get backlight level
  *

--- a/quantum/backlight/backlight.h
+++ b/quantum/backlight/backlight.h
@@ -55,7 +55,11 @@ void    backlight_decrease(void);
 void    backlight_level_noeeprom(uint8_t level);
 void    backlight_level(uint8_t level);
 uint8_t get_backlight_level(void);
+
+uint8_t eeconfig_read_backlight(void);
+void    eeconfig_update_backlight(uint8_t val);
 void    eeconfig_update_backlight_current(void);
+void    eeconfig_update_backlight_default(void);
 
 // implementation specific
 void backlight_init_ports(void);

--- a/tmk_core/common/eeconfig.c
+++ b/tmk_core/common/eeconfig.c
@@ -155,17 +155,6 @@ void eeconfig_update_keymap(uint16_t val) {
     eeprom_update_byte(EECONFIG_KEYMAP_UPPER_BYTE, (val >> 8) & 0xFF);
 }
 
-/** \brief eeconfig read backlight
- *
- * FIXME: needs doc
- */
-uint8_t eeconfig_read_backlight(void) { return eeprom_read_byte(EECONFIG_BACKLIGHT); }
-/** \brief eeconfig update backlight
- *
- * FIXME: needs doc
- */
-void eeconfig_update_backlight(uint8_t val) { eeprom_update_byte(EECONFIG_BACKLIGHT, val); }
-
 /** \brief eeconfig read audio
  *
  * FIXME: needs doc

--- a/tmk_core/common/eeconfig.h
+++ b/tmk_core/common/eeconfig.h
@@ -88,11 +88,6 @@ void    eeconfig_update_default_layer(uint8_t val);
 uint16_t eeconfig_read_keymap(void);
 void     eeconfig_update_keymap(uint16_t val);
 
-#ifdef BACKLIGHT_ENABLE
-uint8_t eeconfig_read_backlight(void);
-void    eeconfig_update_backlight(uint8_t val);
-#endif
-
 #ifdef AUDIO_ENABLE
 uint8_t eeconfig_read_audio(void);
 void    eeconfig_update_audio(uint8_t val);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Similar to #11912 but for backlight. `#define BACKLIGHT_DEFAULT_LEVEL x` and `BACKLIGHT_DEFAULT_BREATHING` control the backlight level and breathing state to set upon clearing the EEPROM. Moved the backlight eeconfig functions into backlight.c to match the other lighting systems' APIs.

I should note that this PR doesn't actually do anything! `backlight_init()` never calls `eeconfig_update_backlight_default()` because at this point, no matter how the EEPROM was cleared, it has already been initialised. However, calling it manually in a custom keycode and replugging the board does as expected.

It works properly for RGBLight and LED/RGB Matrix due to an additional check on the mode (0 is invalid). This seems a little inefficient as their EEPROM sections will be written twice upon clear, so I am thinking `eeconfig_init()` should be calling these `_default()` functions directly rather than zeroing everything out.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
