### PR TITLE
Added support for the older no_led revision infinity60

### DIFF
--- a/keyboards/infinity60/config.h
+++ b/keyboards/infinity60/config.h
@@ -28,20 +28,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MATRIX_ROWS 7
 #define MATRIX_COLS 9
 
-/*
- * Keyboard Matrix Assignments
- *
- * Change this to how you wired your keyboard
- * COLS: AVR pins used for columns, left to right
- * ROWS: AVR pins used for rows, top to bottom
- * DIODE_DIRECTION: COL2ROW = COL = Anode (+), ROW = Cathode (-, marked on diode)
- *                  ROW2COL = ROW = Anode (+), COL = Cathode (-, marked on diode)
- *
- */
-#define MATRIX_ROW_PINS { D1, D2, D3, D4, D5, D6, D7 }
-#define MATRIX_COL_PINS { C0, C1, C2, C3, C4, C5, C6, C7, D0 }
-#define UNUSED_PINS
-
 /* COL2ROW, ROW2COL */
 #define DIODE_DIRECTION COL2ROW
 

--- a/keyboards/infinity60/led/config.h
+++ b/keyboards/infinity60/led/config.h
@@ -1,0 +1,23 @@
+/*
+Copyright 2015 Jun Wako <wakojun@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+// Keyboard Matrix Assignments
+#define MATRIX_ROW_PINS { D1, D2, D3, D4, D5, D6, D7 }
+#define MATRIX_COL_PINS { C0, C1, C2, C3, C4, C5, C6, C7, D0 }
+#define UNUSED_PINS

--- a/keyboards/infinity60/led/readme.md
+++ b/keyboards/infinity60/led/readme.md
@@ -1,0 +1,3 @@
+## Infinity 60% LED
+
+This revision is for the version of the infinity 60 with LEDs (rev 1.1a)

--- a/keyboards/infinity60/led/rules.mk
+++ b/keyboards/infinity60/led/rules.mk
@@ -1,0 +1,3 @@
+# project specific files
+SRC += led.c \
+       led_controller.c

--- a/keyboards/infinity60/rev1/config.h
+++ b/keyboards/infinity60/rev1/config.h
@@ -1,0 +1,25 @@
+/*
+Copyright 2015 Jun Wako <wakojun@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+// Keyboard Matrix Assignments
+#define MATRIX_ROW_PINS { D1, D2, D3, D4, D5, D6, D7 }
+#define MATRIX_COL_PINS { B0, B1, B2, B3, B16, B17, C4, C5, D0 }
+#define UNUSED_PINS
+
+

--- a/keyboards/infinity60/rev1/readme.md
+++ b/keyboards/infinity60/rev1/readme.md
@@ -1,0 +1,2 @@
+## Infinity 60, initial massdrop release
+This is for the initial massdrop PCBs that don't support LEDs (rev 1.03a)

--- a/keyboards/infinity60/rules.mk
+++ b/keyboards/infinity60/rules.mk
@@ -30,9 +30,7 @@ RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 BLUETOOTH_ENABLE = no       # Enable Bluetooth
 AUDIO_ENABLE = no           # Audio output
 
-# project specific files
-SRC += led.c \
-       led_controller.c
+DEFAULT_FOLDER = infinity60/led
 
 LAYOUTS = 60_ansi_split_bs_rshift
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Added support for the differently pinned no led version of infinity 60

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The initial code for the infinity60 was a bit rough, and a nice refactor was done to make it all QMKy and easy to maintain.
This however also removed support for the older boards without LEDs which have a different column pinout, as these older boards were simply called "prototypes" in the old implementation.
They were in fact not prototypes, but the first drops on massdrop of the board.

I've broken the pin definitions out into revision sub-folders, and set the led folder to be the default :)
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
