### PR TITLE
Correct layout macro name in Cannonkeys Ortho75 info.json

### DIFF
--- a/keyboards/cannonkeys/ortho75/info.json
+++ b/keyboards/cannonkeys/ortho75/info.json
@@ -5,7 +5,7 @@
   "width": 15,
   "height": 5,
   "layouts": {
-    "LAYOUT_ortho_5x12": {
+    "LAYOUT_ortho_5x15": {
       "layout": [
         {"label":"`", "x":0, "y":0},
         {"label":"1", "x":1, "y":0},


### PR DESCRIPTION
## Description

`info.json` is referencing an incorrect layout macro name.

cc @awkannan (keyboard maintainer)

## Types of Changes

- [x] Enhancement/optimization
- [x] Keyboard (addition or update)

## Issues Fixed or Closed by This PR

* https://github.com/qmk/qmk_configurator/issues/907

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
