### PR TITLE
Fix for gcc10 teensy_lc eeprom build warning

### DIFF
--- a/tmk_core/common/chibios/eeprom_teensy.c
+++ b/tmk_core/common/chibios/eeprom_teensy.c
@@ -363,7 +363,7 @@ void eeprom_initialize(void) {
             return;
         }
     } while (p < (uint16_t *)SYMVAL(__eeprom_workarea_end__));
-    flashend = (uint32_t)((uint16_t *)SYMVAL(__eeprom_workarea_end__) - 1);
+    flashend = (uint32_t)(p - 1);
 }
 
 uint8_t eeprom_read_byte(const uint8_t *addr) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

```console
make clean handwired/onekey/teensy_lc:default
QMK Firmware 0.12.34
Deleting .build/ ... done.
Making handwired/onekey/teensy_lc with keymap default

arm-none-eabi-gcc (Arch Repository) 10.2.0
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Compiling: keyboards/handwired/onekey/keymaps/default/keymap.c                                     Compiling: quantum/send_string.c                                                                   Compiling: keyboards/handwired/onekey/onekey.c                                                     Compiling: quantum/quantum.c                                                                       Compiling: quantum/bitwise.c                                                                       Compiling: quantum/keymap_common.c                                                                 Compiling: quantum/led.c                                                                           Compiling: quantum/keycode_config.c                                                                 [OK]
 [OK]
 [OK]
Compiling: quantum/matrix_common.c                                                                 Compiling: quantum/matrix.c                                                                         [OK]
Compiling: quantum/debounce/sym_defer_g.c                                                           [OK]
Compiling: quantum/mousekey.c                                                                      Compiling: tmk_core/common/chibios/eeprom_teensy.c                                                  [OK]
Compiling: quantum/process_keycode/process_space_cadet.c                                            [OK]
 [OK]
tmk_core/common/chibios/eeprom_teensy.c: In function 'eeprom_initialize':
tmk_core/common/chibios/eeprom_teensy.c:367:29: error: array subscript 0 is outside array bounds of 'uint32_t[1]' {aka 'long unsigned int[1]'} [-Werror=array-bounds]
  367 |     flashend = (uint32_t)(q - 1);
      |                          ~~~^~~~
tmk_core/common/chibios/eeprom_teensy.c:351:17: note: while referencing '__eeprom_workarea_end__'
  351 | extern uint32_t __eeprom_workarea_end__;
      |                 ^~~~~~~~~~~~~~~~~~~~~~~
Compiling: quantum/process_keycode/process_magic.c 
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
