### PR TITLE
Bug in beautifier script, compound modifiers not correctly parsed

### DIFF
--- a/keyboards/ergodox_ez/util/keymap_beautifier/KeymapBeautifier.py
+++ b/keyboards/ergodox_ez/util/keymap_beautifier/KeymapBeautifier.py
@@ -361,6 +361,8 @@ class KeymapBeautifier:
                 args.append(arg.value)
             elif type(arg) is pycparser.c_ast.ID:
                 args.append(arg.name)
+            elif type(arg) is pycparser.c_ast.FuncCall:
+                args.append(self.function_expr(arg))
         return "{}({})".format(name, ",".join(args))
 
     def key_expr(self, raw):


### PR DESCRIPTION
# Description

The beautifier script did not handle cases like` LALT(LGUI(KC_D))` correctly, only parsing the first command, and thus rendering this case as `LALT()` in the beautified version. This is easily solved by recursively parsing the function call.

## Types of Changes
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [-] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [-] My change requires a change to the documentation.
- [-] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [-] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
