### PR TITLE
Add initial support for tinyuf2 bootloader (when hosted on F411 blackpill)

### DIFF
--- a/bootloader.mk
+++ b/bootloader.mk
@@ -137,3 +137,6 @@ ifeq ($(strip $(BOOTLOADER)), stm32duino)
     DFU_ARGS = -d 1EAF:0003 -a 2 -R
     DFU_SUFFIX_ARGS = -v 1EAF -p 0003
 endif
+ifeq ($(strip $(BOOTLOADER)), tinyuf2)
+    OPT_DEFS += -DBOOTLOADER_TINYUF2
+endif

--- a/data/schemas/keyboard.jsonschema
+++ b/data/schemas/keyboard.jsonschema
@@ -34,7 +34,7 @@
         },
         "bootloader": {
             "type": "string",
-            "enum": ["atmel-dfu", "bootloadHID", "caterina", "halfkay", "kiibohd", "lufa-dfu", "lufa-ms", "micronucleus", "qmk-dfu", "stm32-dfu", "stm32duino", "unknown", "USBasp"]
+            "enum": ["atmel-dfu", "bootloadHID", "caterina", "halfkay", "kiibohd", "lufa-dfu", "lufa-ms", "micronucleus", "qmk-dfu", "stm32-dfu", "stm32duino", "unknown", "USBasp", "tinyuf2"]
         },
         "diode_direction": {
             "type": "string",

--- a/docs/flashing.md
+++ b/docs/flashing.md
@@ -249,3 +249,29 @@ Flashing sequence:
 2. Wait for the OS to detect the device
 3. Flash a .bin file
 4. Reset the device into application mode (may be done automatically)
+
+## tinyuf2
+
+Keyboards may opt into supporting the tinyuf2 bootloader. This is currently only supported on the F411 blackpill.
+
+The `rules.mk` setting for this bootloader is `tinyuf2`, and can be specified at the keymap or user level.
+
+To ensure compatibility with the tinyuf2 bootloader, make sure this block is present in your `rules.mk`:
+
+```make
+# Bootloader selection
+BOOTLOADER = tinyuf2
+```
+
+Compatible flashers:
+
+* Any application able to copy a file from one place to another, such as _macOS Finder_ or _Windows Explorer_.
+
+Flashing sequence:
+
+1. Enter the bootloader using any of the following methods:
+    * Tap the `RESET` keycode (this may only enter the MCU into a "secure" bootloader mode; see https://github.com/qmk/qmk_firmware/issues/6112)
+    * Double-tap the `nRST` button on the PCB.
+2. Wait for the OS to detect the device
+3. Copy the .uf2 file to the new USB disk
+4. Wait for the keyboard to become available

--- a/docs/flashing.md
+++ b/docs/flashing.md
@@ -270,7 +270,7 @@ Compatible flashers:
 Flashing sequence:
 
 1. Enter the bootloader using any of the following methods:
-    * Tap the `RESET` keycode (this may only enter the MCU into a "secure" bootloader mode; see https://github.com/qmk/qmk_firmware/issues/6112)
+    * Tap the `RESET` keycode
     * Double-tap the `nRST` button on the PCB.
 2. Wait for the OS to detect the device
 3. Copy the .uf2 file to the new USB disk

--- a/keyboards/handwired/onekey/blackpill_f411_tinyuf2/chconf.h
+++ b/keyboards/handwired/onekey/blackpill_f411_tinyuf2/chconf.h
@@ -1,0 +1,21 @@
+/* Copyright 2020 QMK
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define CH_CFG_ST_FREQUENCY 10000
+
+#include_next <chconf.h>

--- a/keyboards/handwired/onekey/blackpill_f411_tinyuf2/chconf.h
+++ b/keyboards/handwired/onekey/blackpill_f411_tinyuf2/chconf.h
@@ -1,4 +1,4 @@
-/* Copyright 2020 QMK
+/* Copyright 2021 QMK
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/keyboards/handwired/onekey/blackpill_f411_tinyuf2/config.h
+++ b/keyboards/handwired/onekey/blackpill_f411_tinyuf2/config.h
@@ -1,0 +1,31 @@
+/* Copyright 2019
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "config_common.h"
+
+#define MATRIX_COL_PINS { B0 }
+#define MATRIX_ROW_PINS { A7 }
+#define UNUSED_PINS
+
+#define BACKLIGHT_PIN           A0
+#define BACKLIGHT_PWM_DRIVER    PWMD5
+#define BACKLIGHT_PWM_CHANNEL   1
+
+#define RGB_DI_PIN A1
+
+#define ADC_PIN A0

--- a/keyboards/handwired/onekey/blackpill_f411_tinyuf2/config.h
+++ b/keyboards/handwired/onekey/blackpill_f411_tinyuf2/config.h
@@ -1,4 +1,4 @@
-/* Copyright 2019
+/* Copyright 2021 QMK
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/keyboards/handwired/onekey/blackpill_f411_tinyuf2/halconf.h
+++ b/keyboards/handwired/onekey/blackpill_f411_tinyuf2/halconf.h
@@ -1,0 +1,22 @@
+/* Copyright 2020 QMK
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define HAL_USE_I2C TRUE
+#define HAL_USE_PWM TRUE
+
+#include_next <halconf.h>

--- a/keyboards/handwired/onekey/blackpill_f411_tinyuf2/halconf.h
+++ b/keyboards/handwired/onekey/blackpill_f411_tinyuf2/halconf.h
@@ -1,4 +1,4 @@
-/* Copyright 2020 QMK
+/* Copyright 2021 QMK
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/keyboards/handwired/onekey/blackpill_f411_tinyuf2/mcuconf.h
+++ b/keyboards/handwired/onekey/blackpill_f411_tinyuf2/mcuconf.h
@@ -1,0 +1,24 @@
+/* Copyright 2020 Nick Brassel (tzarc)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include_next "mcuconf.h"
+
+#undef STM32_I2C_USE_I2C1
+#define STM32_I2C_USE_I2C1 TRUE
+
+#undef STM32_PWM_USE_TIM5
+#define STM32_PWM_USE_TIM5 TRUE

--- a/keyboards/handwired/onekey/blackpill_f411_tinyuf2/mcuconf.h
+++ b/keyboards/handwired/onekey/blackpill_f411_tinyuf2/mcuconf.h
@@ -1,4 +1,4 @@
-/* Copyright 2020 Nick Brassel (tzarc)
+/* Copyright 2021 QMK
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/keyboards/handwired/onekey/blackpill_f411_tinyuf2/readme.md
+++ b/keyboards/handwired/onekey/blackpill_f411_tinyuf2/readme.md
@@ -1,0 +1,9 @@
+# f411 blackpill onekey
+
+Supported Hardware: *STM32F411CEU6 WeAct v1.3*.
+
+To trigger keypress, short together pins *B0* and *A7*.
+
+This variant requires the TinyUF2 bootloader to be installed. This can be downloaded from the [tinyuf2 releases page](https://github.com/adafruit/tinyuf2/releases). The F401 blackpill binary works for both F401- and F411-based blackpill devices.
+
+Double-tap reset to enter bootloader mode. Copy the built uf2 file to the device by dragging the file to the new USB disk.

--- a/keyboards/handwired/onekey/blackpill_f411_tinyuf2/rules.mk
+++ b/keyboards/handwired/onekey/blackpill_f411_tinyuf2/rules.mk
@@ -1,0 +1,10 @@
+# MCU name
+MCU = STM32F411
+
+# Build Options
+#   change yes to no to disable
+#
+KEYBOARD_SHARED_EP       = yes
+
+# We want to use the tinyuf2 bootloader...
+BOOTLOADER = tinyuf2

--- a/platforms/chibios/BLACKPILL_STM32_F411/ld/STM32F411xC_tinyuf2.ld
+++ b/platforms/chibios/BLACKPILL_STM32_F411/ld/STM32F411xC_tinyuf2.ld
@@ -1,0 +1,89 @@
+/*
+    ChibiOS - Copyright (C) 2006..2018 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/*
+ * STM32F411xC memory setup.
+ */
+MEMORY
+{
+    flash0 (rx) : org = 0x08000000 + 64k, len = 256k - 64k /* tinyuf2 bootloader requires app to be located at 64k offset for this MCU */
+    flash1 (rx) : org = 0x00000000, len = 0
+    flash2 (rx) : org = 0x00000000, len = 0
+    flash3 (rx) : org = 0x00000000, len = 0
+    flash4 (rx) : org = 0x00000000, len = 0
+    flash5 (rx) : org = 0x00000000, len = 0
+    flash6 (rx) : org = 0x00000000, len = 0
+    flash7 (rx) : org = 0x00000000, len = 0
+    ram0   (wx) : org = 0x20000000, len = 128k
+    ram1   (wx) : org = 0x00000000, len = 0
+    ram2   (wx) : org = 0x00000000, len = 0
+    ram3   (wx) : org = 0x00000000, len = 0
+    ram4   (wx) : org = 0x00000000, len = 0
+    ram5   (wx) : org = 0x00000000, len = 0
+    ram6   (wx) : org = 0x00000000, len = 0
+    ram7   (wx) : org = 0x00000000, len = 0
+}
+
+/* For each data/text section two region are defined, a virtual region
+   and a load region (_LMA suffix).*/
+
+/* Flash region to be used for exception vectors.*/
+REGION_ALIAS("VECTORS_FLASH", flash0);
+REGION_ALIAS("VECTORS_FLASH_LMA", flash0);
+
+/* Flash region to be used for constructors and destructors.*/
+REGION_ALIAS("XTORS_FLASH", flash0);
+REGION_ALIAS("XTORS_FLASH_LMA", flash0);
+
+/* Flash region to be used for code text.*/
+REGION_ALIAS("TEXT_FLASH", flash0);
+REGION_ALIAS("TEXT_FLASH_LMA", flash0);
+
+/* Flash region to be used for read only data.*/
+REGION_ALIAS("RODATA_FLASH", flash0);
+REGION_ALIAS("RODATA_FLASH_LMA", flash0);
+
+/* Flash region to be used for various.*/
+REGION_ALIAS("VARIOUS_FLASH", flash0);
+REGION_ALIAS("VARIOUS_FLASH_LMA", flash0);
+
+/* Flash region to be used for RAM(n) initialization data.*/
+REGION_ALIAS("RAM_INIT_FLASH_LMA", flash0);
+
+/* RAM region to be used for Main stack. This stack accommodates the processing
+   of all exceptions and interrupts.*/
+REGION_ALIAS("MAIN_STACK_RAM", ram0);
+
+/* RAM region to be used for the process stack. This is the stack used by
+   the main() function.*/
+REGION_ALIAS("PROCESS_STACK_RAM", ram0);
+
+/* RAM region to be used for data segment.*/
+REGION_ALIAS("DATA_RAM", ram0);
+REGION_ALIAS("DATA_RAM_LMA", flash0);
+
+/* RAM region to be used for BSS segment.*/
+REGION_ALIAS("BSS_RAM", ram0);
+
+/* RAM region to be used for the default heap.*/
+REGION_ALIAS("HEAP_RAM", ram0);
+
+/* Generic rules inclusion.*/
+INCLUDE rules.ld
+
+/* TinyUF2 bootloader reset support */
+_board_dfu_dbl_tap = ORIGIN(ram0) + 64k - 4; /* this is based off the linker file for tinyuf2 */
+

--- a/platforms/chibios/BLACKPILL_STM32_F411/ld/STM32F411xE_tinyuf2.ld
+++ b/platforms/chibios/BLACKPILL_STM32_F411/ld/STM32F411xE_tinyuf2.ld
@@ -1,0 +1,89 @@
+/*
+    ChibiOS - Copyright (C) 2006..2018 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/*
+ * STM32F411xE memory setup.
+ */
+MEMORY
+{
+    flash0 (rx) : org = 0x08000000 + 64k, len = 512k - 64k /* tinyuf2 bootloader requires app to be located at 64k offset for this MCU */
+    flash1 (rx) : org = 0x00000000, len = 0
+    flash2 (rx) : org = 0x00000000, len = 0
+    flash3 (rx) : org = 0x00000000, len = 0
+    flash4 (rx) : org = 0x00000000, len = 0
+    flash5 (rx) : org = 0x00000000, len = 0
+    flash6 (rx) : org = 0x00000000, len = 0
+    flash7 (rx) : org = 0x00000000, len = 0
+    ram0   (wx) : org = 0x20000000, len = 128k
+    ram1   (wx) : org = 0x00000000, len = 0
+    ram2   (wx) : org = 0x00000000, len = 0
+    ram3   (wx) : org = 0x00000000, len = 0
+    ram4   (wx) : org = 0x00000000, len = 0
+    ram5   (wx) : org = 0x00000000, len = 0
+    ram6   (wx) : org = 0x00000000, len = 0
+    ram7   (wx) : org = 0x00000000, len = 0
+}
+
+/* For each data/text section two region are defined, a virtual region
+   and a load region (_LMA suffix).*/
+
+/* Flash region to be used for exception vectors.*/
+REGION_ALIAS("VECTORS_FLASH", flash0);
+REGION_ALIAS("VECTORS_FLASH_LMA", flash0);
+
+/* Flash region to be used for constructors and destructors.*/
+REGION_ALIAS("XTORS_FLASH", flash0);
+REGION_ALIAS("XTORS_FLASH_LMA", flash0);
+
+/* Flash region to be used for code text.*/
+REGION_ALIAS("TEXT_FLASH", flash0);
+REGION_ALIAS("TEXT_FLASH_LMA", flash0);
+
+/* Flash region to be used for read only data.*/
+REGION_ALIAS("RODATA_FLASH", flash0);
+REGION_ALIAS("RODATA_FLASH_LMA", flash0);
+
+/* Flash region to be used for various.*/
+REGION_ALIAS("VARIOUS_FLASH", flash0);
+REGION_ALIAS("VARIOUS_FLASH_LMA", flash0);
+
+/* Flash region to be used for RAM(n) initialization data.*/
+REGION_ALIAS("RAM_INIT_FLASH_LMA", flash0);
+
+/* RAM region to be used for Main stack. This stack accommodates the processing
+   of all exceptions and interrupts.*/
+REGION_ALIAS("MAIN_STACK_RAM", ram0);
+
+/* RAM region to be used for the process stack. This is the stack used by
+   the main() function.*/
+REGION_ALIAS("PROCESS_STACK_RAM", ram0);
+
+/* RAM region to be used for data segment.*/
+REGION_ALIAS("DATA_RAM", ram0);
+REGION_ALIAS("DATA_RAM_LMA", flash0);
+
+/* RAM region to be used for BSS segment.*/
+REGION_ALIAS("BSS_RAM", ram0);
+
+/* RAM region to be used for the default heap.*/
+REGION_ALIAS("HEAP_RAM", ram0);
+
+/* Generic rules inclusion.*/
+INCLUDE rules.ld
+
+/* TinyUF2 bootloader reset support */
+_board_dfu_dbl_tap = ORIGIN(ram0) + 64k - 4; /* this is based off the linker file for tinyuf2 */
+

--- a/quantum/mcu_selection.mk
+++ b/quantum/mcu_selection.mk
@@ -304,7 +304,12 @@ ifneq ($(findstring STM32F411, $(MCU)),)
   # Linker script to use
   # - it should exist either in <chibios>/os/common/ports/ARMCMx/compilers/GCC/ld/
   #   or <keyboard_dir>/ld/
-  MCU_LDSCRIPT ?= STM32F411xE
+  ifeq ($(strip $(BOOTLOADER)), tinyuf2)
+    MCU_LDSCRIPT ?= STM32F411xE_tinyuf2
+    FIRMWARE_FORMAT ?= uf2
+  else
+    MCU_LDSCRIPT ?= STM32F411xE
+  endif
 
   # Startup code to use
   #  - it should exist in <chibios>/os/common/startup/ARMCMx/compilers/GCC/mk/

--- a/tmk_core/chibios.mk
+++ b/tmk_core/chibios.mk
@@ -190,6 +190,8 @@ else ifneq ("$(wildcard $(KEYBOARD_PATH_2)/ld/$(MCU_LDSCRIPT).ld)","")
     LDSCRIPT = $(KEYBOARD_PATH_2)/ld/$(MCU_LDSCRIPT).ld
 else ifneq ("$(wildcard $(KEYBOARD_PATH_1)/ld/$(MCU_LDSCRIPT).ld)","")
     LDSCRIPT = $(KEYBOARD_PATH_1)/ld/$(MCU_LDSCRIPT).ld
+else ifneq ("$(wildcard $(TOP_DIR)/platforms/chibios/$(BOARD)/ld/$(MCU_LDSCRIPT).ld)","")
+    LDSCRIPT = $(TOP_DIR)/platforms/chibios/$(BOARD)/ld/$(MCU_LDSCRIPT).ld
 else ifneq ("$(wildcard $(TOP_DIR)/platforms/chibios/common/ld/$(MCU_LDSCRIPT).ld)","")
     LDSCRIPT = $(TOP_DIR)/platforms/chibios/common/ld/$(MCU_LDSCRIPT).ld
 else ifneq ("$(wildcard $(STARTUPLD_CONTRIB)/$(MCU_LDSCRIPT).ld)","")

--- a/tmk_core/common/chibios/bootloader.c
+++ b/tmk_core/common/chibios/bootloader.c
@@ -13,7 +13,22 @@
 #    define STM32_BOOTLOADER_DUAL_BANK FALSE
 #endif
 
-#if STM32_BOOTLOADER_DUAL_BANK
+#ifdef BOOTLOADER_TINYUF2
+
+#    define DBL_TAP_MAGIC 0xf01669ef  // From tinyuf2's board_api.h
+
+// defined by linker script
+extern uint32_t _board_dfu_dbl_tap[];
+#    define DBL_TAP_REG _board_dfu_dbl_tap[0]
+
+void bootloader_jump(void) {
+    DBL_TAP_REG = DBL_TAP_MAGIC;
+    NVIC_SystemReset();
+}
+
+void enter_bootloader_mode_if_requested(void) { /* not needed, no two-stage reset */ }
+
+#elif STM32_BOOTLOADER_DUAL_BANK
 
 // Need pin definitions
 #    include "config_common.h"


### PR DESCRIPTION
## Description

Building UF2-formatted binaries already exists in QMK, but there's no example project to point people towards, nor is there support for jumping to one of the more well-known bootloaders -- Adafruit's tinyuf2.

The tinyuf2 bootloader can be downloaded from the [tinyuf2 releases page](https://github.com/adafruit/tinyuf2/releases). The F401 blackpill binary works for both F401- and F411-based blackpill devices.

This PR subsequently adds support for F411 blackpills to target the tinyuf2 bootloader, by providing appropriate ldscript files as well as adding support for jumping to bootloader.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
