### PR TITLE
Deprecate `send_unicode_hex_string()`

### DIFF
--- a/docs/feature_unicode.md
+++ b/docs/feature_unicode.md
@@ -230,7 +230,7 @@ send_unicode_string("(ノಠ痊ಠ)ノ彡┻━┻");
 
 Example uses include sending Unicode strings when a key is pressed, as described in [Macros](feature_macros.md).
 
-### `send_unicode_hex_string()`
+### `send_unicode_hex_string()` (Deprecated)
 
 Similar to `send_unicode_string()`, but the characters are represented by their Unicode code points, written in hexadecimal and separated by spaces. For example, the table flip above would be achieved with:
 

--- a/keyboards/1upkeyboards/sweet16/keymaps/ridingintraffic/keymap.c
+++ b/keyboards/1upkeyboards/sweet16/keymaps/ridingintraffic/keymap.c
@@ -91,21 +91,21 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     if (record->event.pressed) {
         switch(keycode) {
-            case CLOUD:       // (っ◕‿◕)っ
+            case CLOUD:
                 if(record->event.pressed){
-                    send_unicode_hex_string("0028 3063 25D5 203F 25D5 0029 3063");
+                    send_unicode_string("(っ◕‿◕)っ");
                 }
                 return false;
                 break;
-            case FU:       // t(-_-t)
+            case FU:
                 if(record->event.pressed){
                     SEND_STRING("t(-_-t)");
                 }
                 return false;
                 break;  
-            case HAPPYFACE:       // ʘ‿ʘ 
+            case HAPPYFACE:
                 if(record->event.pressed){
-                     send_unicode_hex_string("0298 203F 0298");
+                     send_unicode_string("ʘ‿ʘ");
                 }
                 return false;
                 break; 
@@ -118,33 +118,33 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
                 }
                 return false;
                 break;  
-            case SHRUG: // ¯\_(ツ)_/¯
+            case SHRUG:
                 if (record->event.pressed) {
-                    send_unicode_hex_string("00AF 005C 005F 0028 30C4 0029 005F 002F 00AF");
+                    send_unicode_string("¯\\_(ツ)_/¯");
                 }
                 return false; 
                 break;
-            case HEARTFACE:       // ♥‿♥
+            case HEARTFACE:
                 if(record->event.pressed){
-                    send_unicode_hex_string("2665 203F 2665");
+                    send_unicode_string("♥‿♥");
                 }
                 return false;
                 break;  
-            case DISFACE:       // ಠ_ಠ 
+            case DISFACE:
                 if(record->event.pressed){
-                    send_unicode_hex_string("0CA0 005F 0CA0");
+                    send_unicode_string("ಠ_ಠ");
                 }
                 return false;
                 break;
-            case TFLIP:         // (╯°□°)╯ ︵ ┻━┻ 
+            case TFLIP:
                 if(record->event.pressed){
-                    send_unicode_hex_string("0028 256F 00B0 25A1 00B0 0029 256F 0020 FE35 0020 253B 2501 253B");
+                    send_unicode_string("(╯°□°)╯ ︵ ┻━┻");
                 }
                 return false;
                 break;
-            case TFLIP2:         // ┻━┻︵ \(°□°)/ ︵ ┻━┻  
+            case TFLIP2:
                 if(record->event.pressed){
-                    send_unicode_hex_string("253B 2501 253B FE35 0020 005C 0028 00B0 25A1 00B0 0029 002F 0020 FE35 0020 253B 2501 253B");
+                    send_unicode_string("┻━┻︵ \\(°□°)/ ︵ ┻━┻");
                 }
                 return false;
                 break;

--- a/keyboards/handwired/2x5keypad/keymaps/default_tapdance/keymap.c
+++ b/keyboards/handwired/2x5keypad/keymaps/default_tapdance/keymap.c
@@ -17,36 +17,36 @@ enum tap_codes {
     A_Y, I_I, O_C, U_U
 };
 
-#define FR_A_GRAVE  "00E0"
-#define FR_A_HAT    "00E2"
+#define FR_A_GRAVE  0x00E0 // à
+#define FR_A_HAT    0x00E2 // â
 
-#define FR_C_CIRCUM "00E7"
+#define FR_C_CIRCUM 0x00E7 // ç
 
-#define FR_E_AIGU   "00E9"
-#define FR_E_GRAVE  "00E8"
-#define FR_E_HAT    "00EA"
-#define FR_E_UMLAUT "00EB"
+#define FR_E_AIGU   0x00E9 // é
+#define FR_E_GRAVE  0x00E8 // è
+#define FR_E_HAT    0x00EA // ê
+#define FR_E_UMLAUT 0x00EB // ë
 
-#define FR_I_HAT    "00EE"
-#define FR_I_UMLAUT "00EF"
+#define FR_I_HAT    0x00EE // î
+#define FR_I_UMLAUT 0x00EF // ï
 
-#define FR_O_HAT    "00F4"
+#define FR_O_HAT    0x00F4 // ô
 
-#define FR_U_GRAVE  "00F9"
-#define FR_U_HAT    "00FB"
-#define FR_U_UMLAUT "00FC"
+#define FR_U_GRAVE  0x00F9 // ù
+#define FR_U_HAT    0x00FB // û
+#define FR_U_UMLAUT 0x00FC // ü
 
-#define FR_Y_UMLAUT "00FF"
+#define FR_Y_UMLAUT 0x00FF // ÿ
 
-#define FR_L_QUOTE  "00AB"
-#define FR_R_QUOTE  "00BB"
+#define FR_L_QUOTE  0x00AB // «
+#define FR_R_QUOTE  0x00BB // »
 
-void send_french_unicode_char(uint8_t count, char *once, char *twice)
+void send_french_unicode_char(uint8_t count, uint32_t once, uint32_t twice)
 {
     if (count <= 1)
-	send_unicode_hex_string(once);
+	register_unicode(once);
     else
-	send_unicode_hex_string(twice); 
+	register_unicode(twice);
 }
 
 void dance_a_q(qk_tap_dance_state_t *state, void *user_data)

--- a/keyboards/mechmini/v2/keymaps/wsturgiss/keymap.c
+++ b/keyboards/mechmini/v2/keymaps/wsturgiss/keymap.c
@@ -66,7 +66,7 @@ void matrix_scan_user(void) {
     //tableflip (LEADER - TF)
     SEQ_TWO_KEYS(KC_T, KC_F) {
         set_unicode_input_mode(UC_OSX);
-        send_unicode_hex_string("0028 30CE 0CA0 75CA 0CA0 0029 30CE 5F61 253B 2501 253B");
+        send_unicode_string("(ノಠ痊ಠ)ノ彡┻━┻");
     }
     //screencap (LEADER - SC)
     SEQ_TWO_KEYS(KC_S, KC_C) {
@@ -75,7 +75,7 @@ void matrix_scan_user(void) {
     //screencap (LEADER - TM)
     SEQ_TWO_KEYS(KC_T, KC_M) {
         set_unicode_input_mode(UC_OSX);
-        send_unicode_hex_string("2122");
+        register_unicode(0x2122); // ™
     }
     /*
     SEQ_THREE_KEYS(KC_D, KC_D, KC_S) {

--- a/keyboards/spaceman/2_milk/keymaps/emoji/keymap.c
+++ b/keyboards/spaceman/2_milk/keymaps/emoji/keymap.c
@@ -7,8 +7,8 @@ enum tapdance_keycodes {
 
 void dance_key_one (qk_tap_dance_state_t *state, void *user_data) {
     if (state->count == 1) {
-        send_unicode_hex_string("00AF 005C 005F 0028 30C4 0029 005F 002F 00AF"); // ¯\_(ツ)_/¯
-        SEND_STRING(SS_TAP(X_ENTER));
+        send_unicode_string("¯\\_(ツ)_/¯");
+        tap_code(KC_ENTER);
         reset_tap_dance (state);
     } else if (state->count == 2) {
         cycle_unicode_input_mode(+1);
@@ -18,24 +18,24 @@ void dance_key_one (qk_tap_dance_state_t *state, void *user_data) {
 
 void dance_key_two (qk_tap_dance_state_t *state, void *user_data) {
     if (state->count == 1) {
-        send_unicode_hex_string("0CA0 005F 0CA0"); // ಠ_ಠ
-        SEND_STRING(SS_TAP(X_ENTER));
+        send_unicode_string("ಠ_ಠ");
+        tap_code(KC_ENTER);
         reset_tap_dance (state);
     } else if (state->count == 2) {
-        send_unicode_hex_string("0028 30CE 0CA0 75CA 0CA0 0029 30CE 5F61 253B 2501 253B"); // (ノಠ痊ಠ)ノ彡┻━┻
-        SEND_STRING(SS_TAP(X_ENTER));
+        send_unicode_string("(ノಠ痊ಠ)ノ彡┻━┻");
+        tap_code(KC_ENTER);
         reset_tap_dance (state);
     } else if (state->count == 3) {
-        send_unicode_hex_string("256D 2229 256E 0028 002D 005F 002D 0029 256D 2229 256E"); // ╭∩╮(-_-)╭∩╮
-        SEND_STRING(SS_TAP(X_ENTER));
+        send_unicode_string("╭∩╮(-_-)╭∩╮");
+        tap_code(KC_ENTER);
         reset_tap_dance (state);
     } else if (state->count == 4) {
-        send_unicode_hex_string("0028 3065 FFE3 0020 00B3 FFE3 0029 3065"); // (づ￣ ³￣)づ
-        SEND_STRING(SS_TAP(X_ENTER));
+        send_unicode_string("(づ￣ ³￣)づ");
+        tap_code(KC_ENTER);
         reset_tap_dance (state);
     } else if (state->count == 5) {
-        send_unicode_hex_string("0028 FE3A FE39 FE3A 0029"); // (︺︹︺)
-        SEND_STRING(SS_TAP(X_ENTER));
+        send_unicode_string("(︺︹︺)");
+        tap_code(KC_ENTER);
         reset_tap_dance (state);
     }
 }

--- a/keyboards/yatara/drink_me/keymaps/queen/keymap.c
+++ b/keyboards/yatara/drink_me/keymaps/queen/keymap.c
@@ -11,7 +11,7 @@ enum td_keys {
 
 void td_spade_lnx (qk_tap_dance_state_t *state, void *user_data) {
     if (state->count == 1) {
-        send_unicode_hex_string("2660");
+        register_unicode(0x2660); // ♠
     } else {
         set_unicode_input_mode(UC_LNX);
     }
@@ -21,7 +21,7 @@ void td_spade_lnx (qk_tap_dance_state_t *state, void *user_data) {
 
 void td_diamond_osx (qk_tap_dance_state_t *state, void *user_data) {
     if (state->count == 1) {
-        send_unicode_hex_string("2666");
+        register_unicode(0x2666); // ♦
     } else {
         set_unicode_input_mode(UC_OSX);
     }
@@ -31,7 +31,7 @@ void td_diamond_osx (qk_tap_dance_state_t *state, void *user_data) {
 
 void td_club_win (qk_tap_dance_state_t *state, void *user_data) {
     if (state->count == 1) {
-        send_unicode_hex_string("2663");
+        register_unicode(0x2663); // ♣
     } else {
         set_unicode_input_mode(UC_WIN);
     }
@@ -41,7 +41,7 @@ void td_club_win (qk_tap_dance_state_t *state, void *user_data) {
 
 void td_heart_winc (qk_tap_dance_state_t *state, void *user_data) {
     if (state->count == 1) {
-        send_unicode_hex_string("2665");
+        register_unicode(0x2665); // ♥
     } else {
         set_unicode_input_mode(UC_WINC);
     }

--- a/users/arkag/arkag.c
+++ b/users/arkag/arkag.c
@@ -363,7 +363,7 @@ void matrix_scan_user(void) {
       surround_type(4, KC_GRAVE, true);
     }
     SEQ_ONE_KEY(KC_C) {
-      send_unicode_hex_string("00E7");
+      register_unicode(0x00E7); // ç
     }
     SEQ_TWO_KEYS(KC_A, KC_V) {
       surround_type(2, KC_QUOT, true);
@@ -384,10 +384,10 @@ void matrix_scan_user(void) {
       surround_type(6, KC_GRAVE, false);
     }
     SEQ_ONE_KEY(KC_E) {
-      send_unicode_hex_string("00E8");
+      register_unicode(0x00E8); // è
     }
     SEQ_TWO_KEYS(KC_E, KC_E) {
-      send_unicode_hex_string("00E9");
+      register_unicode(0x00E9); // é
     }
     // end format functions
 
@@ -407,8 +407,7 @@ void matrix_scan_user(void) {
 
     // start typing functions
     SEQ_TWO_KEYS(KC_T, KC_M) {
-      // ™
-      send_unicode_hex_string("2122");
+      register_unicode(0x2122); // ™
     }
     SEQ_TWO_KEYS(KC_D, KC_D) {
       SEND_STRING(".\\Administrator");
@@ -420,27 +419,22 @@ void matrix_scan_user(void) {
       tap_code(KC_ENTER);
     }
     SEQ_THREE_KEYS(KC_L, KC_O, KC_D) {
-      // ಠ__ಠ
-      send_unicode_hex_string("0CA0 005F 005F 0CA0");
+      send_unicode_string("ಠ__ಠ");
     }
     SEQ_THREE_KEYS(KC_M, KC_A, KC_P) {
       SEND_STRING("https://github.com/qmk/qmk_firmware/tree/master/users/arkag");
     }
     SEQ_TWO_KEYS(KC_F, KC_F) {
-      // (╯‵Д′)╯彡┻━┻
-      send_unicode_hex_string("0028 256F 2035 0414 2032 0029 256F 5F61 253B 2501 253B");
+      send_unicode_string("(╯‵Д′)╯彡┻━┻");
     }
     SEQ_THREE_KEYS(KC_F, KC_F, KC_F) {
-      // ┬─┬ノ( º _ º ノ)
-      send_unicode_hex_string("252C 2500 252C 30CE 0028 0020 00BA 0020 005F 0020 00BA 0020 30CE 0029");
+      send_unicode_string("┬─┬ノ( º _ º ノ)");
     }
     SEQ_THREE_KEYS(KC_L, KC_O, KC_L) {
-      // ( ͡° ͜ʖ ͡°)
-      send_unicode_hex_string("0028 0020 0361 00B0 0020 035C 0296 0020 0361 00B0 0029");
+      send_unicode_string("( ͡° ͜ʖ ͡°)");
     }
     SEQ_THREE_KEYS(KC_S, KC_S, KC_S) {
-      // ¯\_(ツ)_/¯
-      send_unicode_hex_string("00AF 005C 005F 0028 30C4 0029 005F 002F 00AF");
+      send_unicode_string("¯\\_(ツ)_/¯");
     }
     // end typing functions
 
@@ -513,7 +507,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 
   case M_DASH:
     if (record->event.pressed){
-      send_unicode_hex_string("2014");
+      register_unicode(0x2014); // —
     }
     return false;
   case M_LMHYP:

--- a/users/curry/process_records.c
+++ b/users/curry/process_records.c
@@ -46,24 +46,24 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             }
             break;
 #if defined(UNICODE_ENABLE)
-        case UC_FLIP:  // (ノಠ痊ಠ)ノ彡┻━┻
+        case UC_FLIP:
             if (record->event.pressed) {
-                send_unicode_hex_string("0028 30CE 0CA0 75CA 0CA0 0029 30CE 5F61 253B 2501 253B");
+                send_unicode_string("(ノಠ痊ಠ)ノ彡┻━┻");
             }
             break;
-        case UC_TABL:  // ┬─┬ノ( º _ ºノ)
+        case UC_TABL:
             if (record->event.pressed) {
-                send_unicode_hex_string("252C 2500 252C 30CE 0028 0020 00BA 0020 005F 0020 00BA 30CE 0029");
+                send_unicode_string("┬─┬ノ( º _ ºノ)");
             }
             break;
-        case UC_SHRG:  // ¯\_(ツ)_/¯
+        case UC_SHRG:
             if (record->event.pressed) {
-                send_unicode_hex_string("00AF 005C 005F 0028 30C4 0029 005F 002F 00AF");
+                send_unicode_string("¯\\_(ツ)_/¯");
             }
             break;
-        case UC_DISA:  // ಠ_ಠ
+        case UC_DISA:
             if (record->event.pressed) {
-                send_unicode_hex_string("0CA0 005F 0CA0");
+                send_unicode_string("ಠ_ಠ");
             }
             break;
 #endif

--- a/users/d4mation/macros.c
+++ b/users/d4mation/macros.c
@@ -45,75 +45,75 @@ bool process_record_user( uint16_t keycode, keyrecord_t *record ) {
 
     #ifdef UNICODE_ENABLE
 
-      case AMENO:  /* ༼ つ ◕_◕ ༽つ */
+      case AMENO:
 
         if ( record->event.pressed ) {
 
-          send_unicode_hex_string( "0F3C 0020 3064 0020 25D5 005F 25D5 0020 0F3D 3064" );
+          send_unicode_string( "༼ つ ◕_◕ ༽つ" );
 
         }
 
         return false;
         break;
 
-      case MAGIC:  /* (∩ ͡° ͜ʖ ͡°)⊃━☆ﾟ. * */
+      case MAGIC:
 
         if ( record->event.pressed ) {
 
-          send_unicode_hex_string( "0028 2229 0020 0361 00B0 0020 035C 0296 0020 0361 00B0 0029 2283 2501 2606 FF9F 002E 0020 002A" );
+          send_unicode_string( "(∩ ͡° ͜ʖ ͡°)⊃━☆ﾟ. *" );
 
         }
 
         return false;
         break;
 
-      case LENNY:  /* ( ͡° ͜ʖ ͡°) */
+      case LENNY:
 
         if ( record->event.pressed ) {
 
-          send_unicode_hex_string( "0028 0020 0361 00B0 0020 035C 0296 0020 0361 00b0 0029" );
+          send_unicode_string( "( ͡° ͜ʖ ͡°)" );
 
         }
 
         return false;
         break;
 
-      case DISFACE:  /* ಠ_ಠ */
+      case DISFACE:
 
         if ( record->event.pressed ) {
-          send_unicode_hex_string( "0CA0 005F 0CA0" );
+          send_unicode_string( "ಠ_ಠ" );
         }
 
         return false;
         break;
 
-      case TFLIP:  /* (╯°□°)╯ ︵ ┻━┻ */
+      case TFLIP:
 
         if ( record->event.pressed ) {
 
-          send_unicode_hex_string( "0028 256F 00b0 25A1 00B0 0029 256F FE35 253B 2501 253B" );
-
-        }
-
-        return false;
-        break;
-
-      case TPUT:  /* ┬──┬ ノ( ゜-゜ノ) */
-
-        if ( record->event.pressed ) {
-
-          send_unicode_hex_string( "252C 2500 2500 252C 0020 30CE 0028 0020 309C 002D 309C 30CE 0029" );
+          send_unicode_string( "(╯°□°)╯︵┻━┻" );
 
         }
 
         return false;
         break;
 
-      case SHRUG:  /* ¯\_(ツ)_/¯ */
+      case TPUT:
 
         if ( record->event.pressed ) {
 
-          send_unicode_hex_string( "00AF 005C 005F 0028 30C4 0029 005F 002F 00AF" );
+          send_unicode_string( "┬──┬ ノ( ゜-゜ノ)" );
+
+        }
+
+        return false;
+        break;
+
+      case SHRUG:
+
+        if ( record->event.pressed ) {
+
+          send_unicode_string( "¯\\_(ツ)_/¯" );
 
         }
 

--- a/users/kuchosauronad0/process_records.c
+++ b/users/kuchosauronad0/process_records.c
@@ -214,24 +214,24 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 
 // Unicode
 #ifdef UNICODE_ENABLE
-  case UC_FLIP: // (ノಠ痊ಠ)ノ彡┻━┻
+  case UC_FLIP:
     if (record->event.pressed) {
-      send_unicode_hex_string("0028 30CE 0CA0 75CA 0CA0 0029 30CE 5F61 253B 2501 253B");
+      send_unicode_string("(ノಠ痊ಠ)ノ彡┻━┻");
     }
     break;
-  case UC_TABL: // ┬┬ノ( º _ ºノ)
+  case UC_TABL:
     if (record->event.pressed) {
-      send_unicode_hex_string("252C 2500 252C 30CE 0028 0020 00BA 0020 005F 0020 00BA 30CE 0029");
+      send_unicode_string("┬─┬ノ( º _ ºノ)");
     }
     break;
-  case UC_SHRG: // ¯\_(ツ)_/¯
+  case UC_SHRG:
     if (record->event.pressed) {
-      send_unicode_hex_string("00AF 005C 005F 0028 30C4 0029 005F 002F 00AF");
+      send_unicode_string("¯\\_(ツ)_/¯");
     }
     break;
-  case UC_DISA: // ಠ_ಠ
+  case UC_DISA:
     if (record->event.pressed) {
-      send_unicode_hex_string("0CA0 005F 0CA0");
+      send_unicode_string("ಠ_ಠ");
     }
     break;
 #endif //!Unicode

--- a/users/kuchosauronad0/unicode.h
+++ b/users/kuchosauronad0/unicode.h
@@ -2,8 +2,6 @@
 
 #include "quantum.h"
 
-void send_unicode_hex_string(const char* str);
-
 /* use X(n) to call the  */
 #ifdef UNICODEMAP_ENABLE
 enum unicode_name {

--- a/users/ridingqwerty/process_records.c
+++ b/users/ridingqwerty/process_records.c
@@ -58,14 +58,12 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 #if defined(UNICODE_ENABLE) || defined(UNICODEMAP_ENABLE)
       case KC_A:
         if (record->event.pressed) {
-          send_unicode_hex_string("039B");
-          tap_code(KC_SPC);
+          send_unicode_string("Λ ");
         }
         return false;
       case KC_E:
         if (record->event.pressed) {
-          send_unicode_hex_string("039E");
-          tap_code(KC_SPC);
+          send_unicode_string("Ξ ");
         }
         return false;
 #else
@@ -175,154 +173,154 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
       // TRANSLATE
       case KC_A:
         if (record->event.pressed) {
-          send_unicode_hex_string("0250");
+          register_unicode(0x0250); // ɐ
           tap_code(KC_LEFT);
           return false;
         }
         break;
       case KC_C:
         if (record->event.pressed) {
-          send_unicode_hex_string("0254");
+          register_unicode(0x0254); // ɔ
           tap_code(KC_LEFT);
           return false;
         }
         break;
       case KC_E:
         if (record->event.pressed) {
-          send_unicode_hex_string("01DD");
+          register_unicode(0x01DD); // ǝ
           tap_code(KC_LEFT);
           return false;
         }
         break;
       case KC_F:
         if (record->event.pressed) {
-          send_unicode_hex_string("025F");
+          register_unicode(0x025F); // ɟ
           tap_code(KC_LEFT);
           return false;
         }
         break;
       case KC_G:
         if (record->event.pressed) {
-          send_unicode_hex_string("0183");
+          register_unicode(0x0183); // ƃ
           tap_code(KC_LEFT);
           return false;
         }
         break;
       case KC_H:
         if (record->event.pressed) {
-          send_unicode_hex_string("0265");
+          register_unicode(0x0265); // ɥ
           tap_code(KC_LEFT);
           return false;
         }
         break;
       case KC_I:
         if (record->event.pressed) {
-          send_unicode_hex_string("1D09");
+          register_unicode(0x1D09); // ᴉ
           tap_code(KC_LEFT);
           return false;
         }
         break;
       case KC_J:
         if (record->event.pressed) {
-          send_unicode_hex_string("027E");
+          register_unicode(0x027E); // ɾ
           tap_code(KC_LEFT);
           return false;
         }
         break;
       case KC_K:
         if (record->event.pressed) {
-          send_unicode_hex_string("029E");
+          register_unicode(0x029E); // ʞ
           tap_code(KC_LEFT);
           return false;
         }
         break;
       case KC_M:
         if (record->event.pressed) {
-          send_unicode_hex_string("026F");
+          register_unicode(0x026F); // ɯ
           tap_code(KC_LEFT);
           return false;
         }
         break;
       case KC_R:
         if (record->event.pressed) {
-          send_unicode_hex_string("0279");
+          register_unicode(0x0279); // ɹ
           tap_code(KC_LEFT);
           return false;
         }
         break;
       case KC_T:
         if (record->event.pressed) {
-          send_unicode_hex_string("0287");
+          register_unicode(0x0287); // ʇ
           tap_code(KC_LEFT);
           return false;
         }
         break;
       case KC_V:
         if (record->event.pressed) {
-          send_unicode_hex_string("028C");
+          register_unicode(0x028C); // ʌ
           tap_code(KC_LEFT);
           return false;
         }
         break;
       case KC_W:
         if (record->event.pressed) {
-          send_unicode_hex_string("028D");
+          register_unicode(0x028D); // ʍ
           tap_code(KC_LEFT);
           return false;
         }
         break;
       case KC_X:
         if (record->event.pressed) {
-          send_unicode_hex_string("2717");
+          register_unicode(0x2717); // ✗
           tap_code(KC_LEFT);
           return false;
         }
         break;
       case KC_Y:
         if (record->event.pressed) {
-          send_unicode_hex_string("028E");
+          register_unicode(0x028E); // ʎ
           tap_code(KC_LEFT);
           return false;
         }
         break;
       case KC_1:
         if (record->event.pressed) {
-          send_unicode_hex_string("0269");
+          register_unicode(0x0269); // ɩ
           tap_code(KC_LEFT);
           return false;
         }
         break;
       case KC_2:
         if (record->event.pressed) {
-          send_unicode_hex_string("3139");
+          register_unicode(0x3139); // ㄹ
           tap_code(KC_LEFT);
           return false;
         }
         break;
       case KC_3:
         if (record->event.pressed) {
-          send_unicode_hex_string("0190");
+          register_unicode(0x0190); // Ɛ
           tap_code(KC_LEFT);
           return false;
         }
         break;
       case KC_4:
         if (record->event.pressed) {
-          send_unicode_hex_string("3123");
+          register_unicode(0x3123); // ㄣ
           tap_code(KC_LEFT);
           return false;
         }
         break;
       case KC_5:
         if (record->event.pressed) {
-          send_unicode_hex_string("03DB");
+          register_unicode(0x03DB); // ϛ
           tap_code(KC_LEFT);
           return false;
         }
         break;
       case KC_7:
         if (record->event.pressed) {
-          send_unicode_hex_string("3125");
+          register_unicode(0x3125); // ㄥ
           tap_code(KC_LEFT);
         }
         return false;
@@ -401,7 +399,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         user_mod_state = get_mods() & MOD_MASK_ALT;
         if (user_mod_state) {
           unregister_mods(MOD_BIT(KC_RALT));
-          send_unicode_hex_string("00B0");
+          register_unicode(0x00B0); // °
           set_mods(user_mod_state);
           return false;
         }
@@ -474,7 +472,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
       if (record->event.pressed && record->event.key.col == 4 && record->event.key.row == 1) {
         if (get_mods() & MOD_BIT(KC_RALT)) {
           unregister_mods(MOD_BIT(KC_RALT));
-          //send_unicode_hex_string("262D");
+          //register_unicode(0x262D); // ☭
 	  tap_code(KC_BSPC);
           set_mods(MOD_BIT(KC_RALT));
           return false;

--- a/users/yet-another-developer/process_records.c
+++ b/users/yet-another-developer/process_records.c
@@ -162,24 +162,24 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             }
             break;
 #ifdef UNICODE_ENABLE
-        case UC_FLIP:  // (ノಠ痊ಠ)ノ彡┻━┻
+        case UC_FLIP:
             if (record->event.pressed) {
-                send_unicode_hex_string("0028 30CE 0CA0 75CA 0CA0 0029 30CE 5F61 253B 2501 253B");
+                send_unicode_string("(ノಠ痊ಠ)ノ彡┻━┻");
             }
             break;
-        case UC_TABL:  // ┬─┬ノ( º _ ºノ)
+        case UC_TABL:
             if (record->event.pressed) {
-                send_unicode_hex_string("252C 2500 252C 30CE 0028 0020 00BA 0020 005F 0020 00BA 30CE 0029");
+                send_unicode_string("┬─┬ノ( º _ ºノ)");
             }
             break;
-        case UC_SHRG:  // ¯\_(ツ)_/¯
+        case UC_SHRG:
             if (record->event.pressed) {
-                send_unicode_hex_string("00AF 005C 005F 0028 30C4 0029 005F 002F 00AF");
+                send_unicode_string("¯\\_(ツ)_/¯");
             }
             break;
-        case UC_DISA:  // ಠ_ಠ
+        case UC_DISA:
             if (record->event.pressed) {
-                send_unicode_hex_string("0CA0 005F 0CA0");
+                send_unicode_string("ಠ_ಠ");
             }
             break;
 #endif // UNICODE_ENABLE

--- a/users/yet-another-developer/unicode.h
+++ b/users/yet-another-developer/unicode.h
@@ -2,8 +2,6 @@
 
 #include "quantum.h"
 
-void send_unicode_hex_string(const char* str);
-
 /* use X(n) to call the  */
 #ifdef UNICODEMAP_ENABLE
 enum unicode_name {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

There is not much use for this function anymore, now that you can pass Unicode strings directly to `send_unicode_string()`. I've gone ahead and migrated the existing usages.

@arkag
@Curry
~~@d4mation~~
~~@jeherve~~
@kuchosauronad0
@ridingintraffic
@ridingqwerty 
@wsturgiss
@yet-another-developer

~~@josjoha your Minivan keymap has not been migrated, as its usage is a bit more complex. Would it be possible to switch to `register_unicode()` instead?~~

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
