### PR TITLE
Set OLED_DISPLAY_128X64 for Arch-36

### DIFF
--- a/keyboards/arch_36/config.h
+++ b/keyboards/arch_36/config.h
@@ -55,4 +55,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                            11, 10,  9,  8,  7,  6 }
 #endif
 
+#ifdef OLED_DRIVER_ENABLE
+  #define OLED_DISPLAY_128X64
+#endif
+
 #define EE_HANDS

--- a/keyboards/arch_36/config.h
+++ b/keyboards/arch_36/config.h
@@ -55,8 +55,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                            11, 10,  9,  8,  7,  6 }
 #endif
 
-#ifdef OLED_DRIVER_ENABLE
-  #define OLED_DISPLAY_128X64
-#endif
+#define OLED_DISPLAY_128X64
 
 #define EE_HANDS


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Just a missing declaration as this keyboard was designed to use the 128x64 OLED displays.
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
