### PR TITLE
eeprom_i2c driver: added EXTERNAL_EEPROM_WP_PIN configuration option.

### DIFF
--- a/docs/eeprom_driver.md
+++ b/docs/eeprom_driver.md
@@ -33,6 +33,8 @@ Currently QMK supports 24xx-series chips over I2C. As such, requires a working i
 `#define EXTERNAL_EEPROM_WRITE_TIME`        | Write cycle time of the EEPROM, as specified in the datasheet                       | 5
 `#define EXTERNAL_EEPROM_WP_PIN`            | If defined the WP pin will be toggled appropriately when writing to the EEPROM.     | _none_
 
+Some I2C EEPROM manufacturers explicitly recommend against hardcoding the WP pin to ground. This is in order to protect the eeprom memory content during power-up/power-down/brown-out conditions at low voltage where the eeprom is still operational, but the i2c master output might be unpredictable. If a WP pin is configured, then having an external pull-up on the WP pin is recommended.
+
 Default values and extended descriptions can be found in `drivers/eeprom/eeprom_i2c.h`.
 
 Alternatively, there are pre-defined hardware configurations for available chips/modules:

--- a/docs/eeprom_driver.md
+++ b/docs/eeprom_driver.md
@@ -31,6 +31,7 @@ Currently QMK supports 24xx-series chips over I2C. As such, requires a working i
 `#define EXTERNAL_EEPROM_PAGE_SIZE`         | Page size of the EEPROM in bytes, as specified in the datasheet                     | 32
 `#define EXTERNAL_EEPROM_ADDRESS_SIZE`      | The number of bytes to transmit for the memory location within the EEPROM           | 2
 `#define EXTERNAL_EEPROM_WRITE_TIME`        | Write cycle time of the EEPROM, as specified in the datasheet                       | 5
+`#define EXTERNAL_EEPROM_WP_PIN`            | If defined the WP pin will be toggled appropriately when writing to the EEPROM.     | _none_
 
 Default values and extended descriptions can be found in `drivers/eeprom/eeprom_i2c.h`.
 

--- a/drivers/eeprom/eeprom_i2c.c
+++ b/drivers/eeprom/eeprom_i2c.c
@@ -56,6 +56,8 @@ static inline void fill_target_address(uint8_t *buffer, const void *addr) {
 void eeprom_driver_init(void) {
     i2c_init();
 #if defined(EXTERNAL_EEPROM_WP_PIN)
+    /* We are setting the WP pin to high in a way that requires at least two bit-flips to change back to 0 */
+    writePin(EXTERNAL_EEPROM_WP_PIN, 1);
     setPinInputHigh(EXTERNAL_EEPROM_WP_PIN);
 #endif
 }
@@ -131,6 +133,8 @@ void eeprom_write_block(const void *buf, void *addr, size_t len) {
     }
 
 #if defined(EXTERNAL_EEPROM_WP_PIN)
+    /* We are setting the WP pin to high in a way that requires at least two bit-flips to change back to 0 */
+    writePin(EXTERNAL_EEPROM_WP_PIN, 1);
     setPinInputHigh(EXTERNAL_EEPROM_WP_PIN);
 #endif
 }

--- a/drivers/eeprom/eeprom_i2c.c
+++ b/drivers/eeprom/eeprom_i2c.c
@@ -57,7 +57,6 @@ void eeprom_driver_init(void) {
     i2c_init();
 #if defined(EXTERNAL_EEPROM_WP_PIN)
     setPinInputHigh(EXTERNAL_EEPROM_WP_PIN);
-    /* Note: it's expected that the WP pin would have an external pull-up. */
 #endif
 }
 
@@ -133,6 +132,5 @@ void eeprom_write_block(const void *buf, void *addr, size_t len) {
 
 #if defined(EXTERNAL_EEPROM_WP_PIN)
     setPinInputHigh(EXTERNAL_EEPROM_WP_PIN);
-    /* Note: it's expected that the WP pin would have an external pull-up. */
 #endif
 }


### PR DESCRIPTION
## Description

This is for boards that follow eeprom manufacturer recommendations,
to not hardcode the WP pin, but to deassert it only during writes,
to protect eeprom content during power-up/power-down/brown-out conditions.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
