### PR TITLE
kint2pp: reduce input latency by ≈10ms

### DIFF
--- a/keyboards/kinesis/kint2pp/config.h
+++ b/keyboards/kinesis/kint2pp/config.h
@@ -36,3 +36,7 @@
 #define DEBOUNCE 5
 
 #define IGNORE_MOD_TAP_INTERRUPT
+
+// Reduce input latency by lowering the USB polling interval
+// from its 10ms default to the 1ms minimum that USB 1.x (Full Speed) allows:
+#define USB_POLLING_INTERVAL_MS 1

--- a/keyboards/kinesis/kint2pp/rules.mk
+++ b/keyboards/kinesis/kint2pp/rules.mk
@@ -1,0 +1,3 @@
+# Debounce eagerly (report change immediately), keep per-key timers. We can use
+# this because the kinT does not have to deal with noise.
+DEBOUNCE_TYPE = sym_eager_pk


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

See the two individual commits and the added comments for details. In summary, increasing the USB polling interval from the overly-conservative 10ms USB 1.1 default to 1ms (USB 1.1 minimum) and switching to an eager debounce algorithm brings down the input latency significantly.

Before, I measured values above 10ms. With these changes, I measure an input latency of 3.27ms ±32%.

(Will publish more details on the test method in an upcoming blog post.)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
