### PR TITLE
kint36: switch to sym_eager_pk debouncing

### DIFF
--- a/keyboards/kinesis/kint36/rules.mk
+++ b/keyboards/kinesis/kint36/rules.mk
@@ -1,2 +1,6 @@
 BOARD = PJRC_TEENSY_3_6
 MCU   = MK66F18
+
+# Debounce eagerly (report change immediately), keep per-key timers. We can use
+# this because the kinT does not have to deal with noise.
+DEBOUNCE_TYPE = sym_eager_pk


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This change shaves off ≈5ms of input latency by switching to eager debouncing.

Before:
```
% benchstat screenlog-kint36.0
name                 time/op
KeypressToLEDReport  7.61ms ± 8%
```

After:
```
% benchstat screenlog-kint36-eager.0
name                 time/op
KeypressToLEDReport  2.12ms ±16%
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
