### PR TITLE
Fixing incorrect keymap build when switching between multiple keymap jsons

### DIFF
--- a/build_json.mk
+++ b/build_json.mk
@@ -1,22 +1,22 @@
 # Look for a json keymap file
 ifneq ("$(wildcard $(MAIN_KEYMAP_PATH_5)/keymap.json)","")
-    KEYMAP_C := $(KEYBOARD_OUTPUT)/src/keymap.c
+    KEYMAP_C := $(KEYMAP_OUTPUT)/keymap.c
     KEYMAP_JSON := $(MAIN_KEYMAP_PATH_5)/keymap.json
     KEYMAP_PATH := $(MAIN_KEYMAP_PATH_5)
 else ifneq ("$(wildcard $(MAIN_KEYMAP_PATH_4)/keymap.json)","")
-    KEYMAP_C := $(KEYBOARD_OUTPUT)/src/keymap.c
+    KEYMAP_C := $(KEYMAP_OUTPUT)/keymap.c
     KEYMAP_JSON := $(MAIN_KEYMAP_PATH_4)/keymap.json
     KEYMAP_PATH := $(MAIN_KEYMAP_PATH_4)
 else ifneq ("$(wildcard $(MAIN_KEYMAP_PATH_3)/keymap.json)","")
-    KEYMAP_C := $(KEYBOARD_OUTPUT)/src/keymap.c
+    KEYMAP_C := $(KEYMAP_OUTPUT)/keymap.c
     KEYMAP_JSON := $(MAIN_KEYMAP_PATH_3)/keymap.json
     KEYMAP_PATH := $(MAIN_KEYMAP_PATH_3)
 else ifneq ("$(wildcard $(MAIN_KEYMAP_PATH_2)/keymap.json)","")
-    KEYMAP_C := $(KEYBOARD_OUTPUT)/src/keymap.c
+    KEYMAP_C := $(KEYMAP_OUTPUT)/keymap.c
     KEYMAP_JSON := $(MAIN_KEYMAP_PATH_2)/keymap.json
     KEYMAP_PATH := $(MAIN_KEYMAP_PATH_2)
 else ifneq ("$(wildcard $(MAIN_KEYMAP_PATH_1)/keymap.json)","")
-    KEYMAP_C := $(KEYBOARD_OUTPUT)/src/keymap.c
+    KEYMAP_C := $(KEYMAP_OUTPUT)/keymap.c
     KEYMAP_JSON := $(MAIN_KEYMAP_PATH_1)/keymap.json
     KEYMAP_PATH := $(MAIN_KEYMAP_PATH_1)
 endif
@@ -27,5 +27,5 @@ ifneq ("$(wildcard $(KEYMAP_PATH))", "")
 endif
 
 # Generate the keymap.c
-$(KEYBOARD_OUTPUT)/src/keymap.c: $(KEYMAP_JSON)
+$(KEYMAP_C): $(KEYMAP_JSON)
 	$(QMK_BIN) json2c --quiet --output $(KEYMAP_C) $(KEYMAP_JSON)

--- a/build_keyboard.mk
+++ b/build_keyboard.mk
@@ -103,6 +103,15 @@ MAIN_KEYMAP_PATH_5 := $(KEYBOARD_PATH_5)/keymaps/$(KEYMAP)
 INFO_RULES_MK = $(shell $(QMK_BIN) generate-rules-mk --quiet --escape --keyboard $(KEYBOARD) --output $(KEYBOARD_OUTPUT)/src/rules.mk)
 include $(INFO_RULES_MK)
 
+ifneq ($(FORCE_LAYOUT),)
+    TARGET := $(TARGET)_$(FORCE_LAYOUT)
+endif
+
+# Object files and generated keymap directory
+#     To put object files in current directory, use a dot (.), do NOT make
+#     this an empty or blank macro!
+KEYMAP_OUTPUT := $(BUILD_DIR)/obj_$(TARGET)
+
 # Check for keymap.json first, so we can regenerate keymap.c
 include build_json.mk
 
@@ -143,10 +152,6 @@ endif
 
 ifeq ($(strip $(CONVERT_TO_PROTON_C)), yes)
     include platforms/chibios/QMK_PROTON_C/convert_to_proton_c.mk
-endif
-
-ifneq ($(FORCE_LAYOUT),)
-    TARGET := $(TARGET)_$(FORCE_LAYOUT)
 endif
 
 include quantum/mcu_selection.mk
@@ -326,11 +331,6 @@ endif
 
 # Disable features that a keyboard doesn't support
 -include disable_features.mk
-
-# Object files directory
-#     To put object files in current directory, use a dot (.), do NOT make
-#     this an empty or blank macro!
-KEYMAP_OUTPUT := $(BUILD_DIR)/obj_$(TARGET)
 
 ifneq ("$(wildcard $(KEYMAP_PATH)/config.h)","")
     CONFIG_H += $(KEYMAP_PATH)/config.h


### PR DESCRIPTION
Switching between building one keymap.json in a keyboard to another keymap.json doesn't actually regenerate a new keymap.c, and the old keymap.json/keymap.c is used in the build.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Repro:

Build a keymap based on a keymap.json:

    $ make clean
    $ make ferris/0_1:default
    $ shasum $(find .build -name keymap.c)
    9fd4e6fccca4fd2d224db7f583afb1dfd2bb54d8  .build/obj_ferris_0_1/src/keymap.c

Build another keymap.json for the same keyboard:

    $ make ferris/0_1:pierrec83
    $ shasum $(find .build -name keymap.c)
    9fd4e6fccca4fd2d224db7f583afb1dfd2bb54d8  .build/obj_ferris_0_1/src/keymap.c

*Notice that the keymap.c has not been changed, and the new build uses the wrong keymap.*

Workaround: clean build

    $ make clean
    $ make ferris/0_1:pierrec83
    $ shasum $(find .build -name keymap.c)
    95ef52001932451a0c254516dedad235226fe63e  .build/obj_ferris_0_1/src/keymap.c

A clean build will use the correct keymap.c. 

This PR aims to differentiate generated keymap.c files so that they are not named the same, and so shouldn't falsely satisfy the keymap.c make target of another keymap.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
