### PR TITLE
Bug: only integers can be used to identify layers

### DIFF
--- a/keyboards/ergodox_ez/util/keymap_beautifier/KeymapBeautifier.py
+++ b/keyboards/ergodox_ez/util/keymap_beautifier/KeymapBeautifier.py
@@ -164,7 +164,16 @@ class KeymapBeautifier:
                 key_symbols = [key_symbols[i] for i in self.index_conversion_map_reversed(self.INDEX_CONVERSTION_LAYOUT_ergodox_pretty_to_LAYOUT_ergodox)]
 
             padded_key_symbols = self.pad_key_symbols(key_symbols, input_layout)
-            current_pretty_output_layer = self.pretty_output_layer(layer.name[0].value, padded_key_symbols)
+           
+            layer_identifier = None
+            if hasattr(layer.name[0], "value"):
+                layer_identifier = layer.name[0].value
+            elif hasattr(layer.name[0], "name"):
+                layer_identifier = layer.name[0].name
+            else:
+                raise AttributeError("Layer is missing both index and name (e.g., [BASE] = LAYOUT_ergodox(...))")
+
+            current_pretty_output_layer = self.pretty_output_layer(layer_identifier, padded_key_symbols)
             # strip trailing spaces from padding
             layer_output.append(re.sub(r" +\n", "\n", current_pretty_output_layer))
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
If one wishes to identify the different layers in a keymap using macro identifiers (`#define`), the `KeymapBeautifier` script for `ergodox_ez` will crash due to a missing integer, e.g.: 
```
#define L_BASE 0
const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
[L_BASE] = LAYOUT_ergodox_pretty(...
```
The script is unable to regenerate the pretty version of the layer, since it expects an integer, `[0] =  LAYOUT_..` rather than 
`[L_BASE] =  LAYOUT_..`
<!--- Describe your changes in detail here. -->
Solved by checking if the parsed data contains an integer value, or a name, and using the one that has been parsed.
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
