### PR TITLE
Satisfaction 75 turn off oled on suspend

### DIFF
--- a/keyboards/cannonkeys/satisfaction75/led.c
+++ b/keyboards/cannonkeys/satisfaction75/led.c
@@ -19,6 +19,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "led_custom.h"
 #include "satisfaction75.h"
 
+#ifdef QWIIC_MICRO_OLED_ENABLE
+#include "micro_oled.h"
+#include "qwiic.h"
+#endif
+
 static void breathing_callback(PWMDriver *pwmp);
 
 static PWMConfig pwmCFG = {
@@ -82,6 +87,8 @@ void backlight_init_ports(void) {
 
 void suspend_power_down_user(void) {
     backlight_set(0);
+	send_command(DISPLAYOFF);      /* 0xAE */
+    oled_sleeping = true;
 }
 void suspend_wakeup_init_user(void) {
   if(kb_backlight_config.enable){


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

a0089aa34519ec4fcf7cee6a352424e4b7cba7da makes changes to the OLED, I believe this causes the OLED to freeze and stay on after host suspend, I included the snippet of code that sleeps the OLED within suspend_power_down_user to fix this issue. This may not be the best way, but in my testing it works, open to improvements.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
