### PR TITLE
sync layer state between two halves of a split keyboard

### DIFF
--- a/docs/feature_split_keyboard.md
+++ b/docs/feature_split_keyboard.md
@@ -192,8 +192,14 @@ If you're having issues with serial communication, you can change this value, as
 This enables transmitting modifier state (normal, weak and oneshot) to the non
 primary side of the split keyboard.  This adds a few bytes of data to the split
 communication protocol and may impact the matrix scan speed when enabled.
-The purpose of this feature is to support cosmetic use of modifer state (e.g.
+The purpose of this feature is to support cosmetic use of modifier state (e.g.
 displaying status on an OLED screen).
+
+```c
+#define SPLIT_LAYERS_ENABLE
+```
+
+This enables transmitting the layer state to the non primary side of the split keyboard.  This adds a few bytes of data to the split communication protocol and may impact the matrix scan speed when enabled. The purpose of this feature is to support cosmetic use of modifier state (e.g. displaying layer status on an OLED screen).
 
 ```c
 #define SPLIT_TRANSPORT_MIRROR


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
sync layer state between two halves of a split keyboard
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
On a split keyboard, the state of the layers was not transported from the primary to the secondary half. As a result, the state of the layers could not be displayed on an oled screen on the secondary half.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
