### PR TITLE
Add Fractal RGB matrix effects

### DIFF
--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -474,7 +474,7 @@ You can disable a single effect by defining `DISABLE_[EFFECT_NAME]` in your `con
 |`#define DISABLE_RGB_MATRIX_JELLYBEAN_RAINDROPS`       |Disables `RGB_MATRIX_JELLYBEAN_RAINDROPS`      |
 |`#define DISABLE_RGB_MATRIX_HUE_BREATHING`             |Disables `RGB_MATRIX_HUE_BREATHING`            |
 |`#define DISABLE_RGB_MATRIX_HUE_PENDULUM`              |Disables `RGB_MATRIX_HUE_PENDULUM`             |
-|`#define DISABLE_RGB_MATRIX_HUE_WAVE`                  |Disables `RGB_MATRIX_HUE_WAVE `                |
+|`#define DISABLE_RGB_MATRIX_HUE_WAVE`                  |Disables `RGB_MATRIX_HUE_WAVE`                 |
 |`#define DISABLE_RGB_MATRIX_FRACTAL`                   |Disables `RGB_MATRIX_FRACTAL`                  |
 |`#define DISABLE_RGB_MATRIX_TYPING_HEATMAP`            |Disables `RGB_MATRIX_TYPING_HEATMAP`           |
 |`#define DISABLE_RGB_MATRIX_DIGITAL_RAIN`              |Disables `RGB_MATRIX_DIGITAL_RAIN`             |

--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -474,8 +474,8 @@ You can disable a single effect by defining `DISABLE_[EFFECT_NAME]` in your `con
 |`#define DISABLE_RGB_MATRIX_JELLYBEAN_RAINDROPS`       |Disables `RGB_MATRIX_JELLYBEAN_RAINDROPS`      |
 |`#define DISABLE_RGB_MATRIX_HUE_BREATHING`             |Disables `RGB_MATRIX_HUE_BREATHING`            |
 |`#define DISABLE_RGB_MATRIX_HUE_PENDULUM`              |Disables `RGB_MATRIX_HUE_PENDULUM`             |
-|`#define DISABLE_RGB_MATRIX_HUE_WAVE `                 |Disables `RGB_MATRIX_HUE_WAVE `                |
-|`#define DISABLE_RGB_MATRIX_FRACTAL `                  |Disables `RGB_MATRIX_FRACTAL`                  |
+|`#define DISABLE_RGB_MATRIX_HUE_WAVE`                  |Disables `RGB_MATRIX_HUE_WAVE `                |
+|`#define DISABLE_RGB_MATRIX_FRACTAL`                   |Disables `RGB_MATRIX_FRACTAL`                  |
 |`#define DISABLE_RGB_MATRIX_TYPING_HEATMAP`            |Disables `RGB_MATRIX_TYPING_HEATMAP`           |
 |`#define DISABLE_RGB_MATRIX_DIGITAL_RAIN`              |Disables `RGB_MATRIX_DIGITAL_RAIN`             |
 |`#define DISABLE_RGB_MATRIX_SOLID_REACTIVE_SIMPLE`     |Disables `RGB_MATRIX_SOLID_REACTIVE_SIMPLE`    |

--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -397,10 +397,10 @@ enum rgb_matrix_effects {
     RGB_MATRIX_SOLID_COLOR = 1,     // Static single hue, no speed support
     RGB_MATRIX_ALPHAS_MODS,         // Static dual hue, speed is hue for secondary hue
     RGB_MATRIX_GRADIENT_UP_DOWN,    // Static gradient top to bottom, speed controls how much gradient changes
-    RGB_MATRIX_GRADIENT_LEFT_RIGHT, // Static gradient left to right, speed controls how much gradient changes
+    RGB_MATRIX_GRADIENT_LEFT_RIGHT,    // Static gradient left to right, speed controls how much gradient changes
     RGB_MATRIX_BREATHING,           // Single hue brightness cycling animation
-    RGB_MATRIX_BAND_SAT,            // Single hue band fading saturation scrolling left to right
-    RGB_MATRIX_BAND_VAL,            // Single hue band fading brightness scrolling left to right
+    RGB_MATRIX_BAND_SAT,        // Single hue band fading saturation scrolling left to right
+    RGB_MATRIX_BAND_VAL,        // Single hue band fading brightness scrolling left to right
     RGB_MATRIX_BAND_PINWHEEL_SAT,   // Single hue 3 blade spinning pinwheel fades saturation
     RGB_MATRIX_BAND_PINWHEEL_VAL,   // Single hue 3 blade spinning pinwheel fades brightness
     RGB_MATRIX_BAND_SPIRAL_SAT,     // Single hue spinning spiral fades saturation
@@ -421,16 +421,14 @@ enum rgb_matrix_effects {
     RGB_MATRIX_HUE_BREATHING,       // Hue shifts up a slight ammount at the same time, then shifts back
     RGB_MATRIX_HUE_PENDULUM,        // Hue shifts up a slight ammount in a wave to the right, then back to the left
     RGB_MATRIX_HUE_WAVE,            // Hue shifts up a slight ammount and then back down in a wave to the right 
-    RGB_MATRIX_FRACTAL,             // Fractal filled keys with single hue pulsing horizontally to edges
-    RGB_MATRIX_PIXEL_RAIN,          // Random keys toggled with random hues
-    RGB_MATRIX_PIXEL_FLOW,          // Random keys toggled with random hues pulsing along LED wiring direction
+    RGB_MATRIX_FRACTAL,             // Single hue fractal filled keys pulsing horizontally out to edges
 #if define(RGB_MATRIX_FRAMEBUFFER_EFFECTS)
     RGB_MATRIX_TYPING_HEATMAP,      // How hot is your WPM!
     RGB_MATRIX_DIGITAL_RAIN,        // That famous computer simulation
 #endif
 #if defined(RGB_MATRIX_KEYPRESSES) || defined(RGB_MATRIX_KEYRELEASES)
-    RGB_MATRIX_SOLID_REACTIVE_SIMPLE,    // Pulses keys hit to hue & value then fades value out
-    RGB_MATRIX_SOLID_REACTIVE,           // Static single hue, pulses keys hit to shifted hue then fades to current hue
+    RGB_MATRIX_SOLID_REACTIVE_SIMPLE,   // Pulses keys hit to hue & value then fades value out
+    RGB_MATRIX_SOLID_REACTIVE,      // Static single hue, pulses keys hit to shifted hue then fades to current hue
     RGB_MATRIX_SOLID_REACTIVE_WIDE       // Hue & value pulse near a single key hit then fades value out
     RGB_MATRIX_SOLID_REACTIVE_MULTIWIDE  // Hue & value pulse near multiple key hits then fades value out
     RGB_MATRIX_SOLID_REACTIVE_CROSS      // Hue & value pulse the same column and row of a single key hit then fades value out

--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -397,10 +397,10 @@ enum rgb_matrix_effects {
     RGB_MATRIX_SOLID_COLOR = 1,     // Static single hue, no speed support
     RGB_MATRIX_ALPHAS_MODS,         // Static dual hue, speed is hue for secondary hue
     RGB_MATRIX_GRADIENT_UP_DOWN,    // Static gradient top to bottom, speed controls how much gradient changes
-    RGB_MATRIX_GRADIENT_LEFT_RIGHT,    // Static gradient left to right, speed controls how much gradient changes
+    RGB_MATRIX_GRADIENT_LEFT_RIGHT, // Static gradient left to right, speed controls how much gradient changes
     RGB_MATRIX_BREATHING,           // Single hue brightness cycling animation
-    RGB_MATRIX_BAND_SAT,        // Single hue band fading saturation scrolling left to right
-    RGB_MATRIX_BAND_VAL,        // Single hue band fading brightness scrolling left to right
+    RGB_MATRIX_BAND_SAT,            // Single hue band fading saturation scrolling left to right
+    RGB_MATRIX_BAND_VAL,            // Single hue band fading brightness scrolling left to right
     RGB_MATRIX_BAND_PINWHEEL_SAT,   // Single hue 3 blade spinning pinwheel fades saturation
     RGB_MATRIX_BAND_PINWHEEL_VAL,   // Single hue 3 blade spinning pinwheel fades brightness
     RGB_MATRIX_BAND_SPIRAL_SAT,     // Single hue spinning spiral fades saturation
@@ -421,13 +421,16 @@ enum rgb_matrix_effects {
     RGB_MATRIX_HUE_BREATHING,       // Hue shifts up a slight ammount at the same time, then shifts back
     RGB_MATRIX_HUE_PENDULUM,        // Hue shifts up a slight ammount in a wave to the right, then back to the left
     RGB_MATRIX_HUE_WAVE,            // Hue shifts up a slight ammount and then back down in a wave to the right 
+    RGB_MATRIX_FRACTAL,             // Fractal filled keys with single hue pulsing horizontally to edges
+    RGB_MATRIX_PIXEL_RAIN,          // Random keys toggled with random hues
+    RGB_MATRIX_PIXEL_FLOW,          // Random keys toggled with random hues pulsing along LED wiring direction
 #if define(RGB_MATRIX_FRAMEBUFFER_EFFECTS)
     RGB_MATRIX_TYPING_HEATMAP,      // How hot is your WPM!
     RGB_MATRIX_DIGITAL_RAIN,        // That famous computer simulation
 #endif
 #if defined(RGB_MATRIX_KEYPRESSES) || defined(RGB_MATRIX_KEYRELEASES)
-    RGB_MATRIX_SOLID_REACTIVE_SIMPLE,   // Pulses keys hit to hue & value then fades value out
-    RGB_MATRIX_SOLID_REACTIVE,      // Static single hue, pulses keys hit to shifted hue then fades to current hue
+    RGB_MATRIX_SOLID_REACTIVE_SIMPLE,    // Pulses keys hit to hue & value then fades value out
+    RGB_MATRIX_SOLID_REACTIVE,           // Static single hue, pulses keys hit to shifted hue then fades to current hue
     RGB_MATRIX_SOLID_REACTIVE_WIDE       // Hue & value pulse near a single key hit then fades value out
     RGB_MATRIX_SOLID_REACTIVE_MULTIWIDE  // Hue & value pulse near multiple key hits then fades value out
     RGB_MATRIX_SOLID_REACTIVE_CROSS      // Hue & value pulse the same column and row of a single key hit then fades value out
@@ -474,6 +477,7 @@ You can disable a single effect by defining `DISABLE_[EFFECT_NAME]` in your `con
 |`#define DISABLE_RGB_MATRIX_HUE_BREATHING`             |Disables `RGB_MATRIX_HUE_BREATHING`            |
 |`#define DISABLE_RGB_MATRIX_HUE_PENDULUM`              |Disables `RGB_MATRIX_HUE_PENDULUM`             |
 |`#define DISABLE_RGB_MATRIX_HUE_WAVE `                 |Disables `RGB_MATRIX_HUE_WAVE `                |
+|`#define DISABLE_RGB_MATRIX_FRACTAL `                  |Disables `RGB_MATRIX_FRACTAL`                   |
 |`#define DISABLE_RGB_MATRIX_TYPING_HEATMAP`            |Disables `RGB_MATRIX_TYPING_HEATMAP`           |
 |`#define DISABLE_RGB_MATRIX_DIGITAL_RAIN`              |Disables `RGB_MATRIX_DIGITAL_RAIN`             |
 |`#define DISABLE_RGB_MATRIX_SOLID_REACTIVE_SIMPLE`     |Disables `RGB_MATRIX_SOLID_REACTIVE_SIMPLE`    |

--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -397,10 +397,10 @@ enum rgb_matrix_effects {
     RGB_MATRIX_SOLID_COLOR = 1,     // Static single hue, no speed support
     RGB_MATRIX_ALPHAS_MODS,         // Static dual hue, speed is hue for secondary hue
     RGB_MATRIX_GRADIENT_UP_DOWN,    // Static gradient top to bottom, speed controls how much gradient changes
-    RGB_MATRIX_GRADIENT_LEFT_RIGHT, // Static gradient left to right, speed controls how much gradient changes
+    RGB_MATRIX_GRADIENT_LEFT_RIGHT,    // Static gradient left to right, speed controls how much gradient changes
     RGB_MATRIX_BREATHING,           // Single hue brightness cycling animation
-    RGB_MATRIX_BAND_SAT,            // Single hue band fading saturation scrolling left to right
-    RGB_MATRIX_BAND_VAL,            // Single hue band fading brightness scrolling left to right
+    RGB_MATRIX_BAND_SAT,        // Single hue band fading saturation scrolling left to right
+    RGB_MATRIX_BAND_VAL,        // Single hue band fading brightness scrolling left to right
     RGB_MATRIX_BAND_PINWHEEL_SAT,   // Single hue 3 blade spinning pinwheel fades saturation
     RGB_MATRIX_BAND_PINWHEEL_VAL,   // Single hue 3 blade spinning pinwheel fades brightness
     RGB_MATRIX_BAND_SPIRAL_SAT,     // Single hue spinning spiral fades saturation
@@ -427,8 +427,8 @@ enum rgb_matrix_effects {
     RGB_MATRIX_DIGITAL_RAIN,        // That famous computer simulation
 #endif
 #if defined(RGB_MATRIX_KEYPRESSES) || defined(RGB_MATRIX_KEYRELEASES)
-    RGB_MATRIX_SOLID_REACTIVE_SIMPLE,    // Pulses keys hit to hue & value then fades value out
-    RGB_MATRIX_SOLID_REACTIVE,           // Static single hue, pulses keys hit to shifted hue then fades to current hue
+    RGB_MATRIX_SOLID_REACTIVE_SIMPLE,   // Pulses keys hit to hue & value then fades value out
+    RGB_MATRIX_SOLID_REACTIVE,      // Static single hue, pulses keys hit to shifted hue then fades to current hue
     RGB_MATRIX_SOLID_REACTIVE_WIDE       // Hue & value pulse near a single key hit then fades value out
     RGB_MATRIX_SOLID_REACTIVE_MULTIWIDE  // Hue & value pulse near multiple key hits then fades value out
     RGB_MATRIX_SOLID_REACTIVE_CROSS      // Hue & value pulse the same column and row of a single key hit then fades value out

--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -397,10 +397,10 @@ enum rgb_matrix_effects {
     RGB_MATRIX_SOLID_COLOR = 1,     // Static single hue, no speed support
     RGB_MATRIX_ALPHAS_MODS,         // Static dual hue, speed is hue for secondary hue
     RGB_MATRIX_GRADIENT_UP_DOWN,    // Static gradient top to bottom, speed controls how much gradient changes
-    RGB_MATRIX_GRADIENT_LEFT_RIGHT,    // Static gradient left to right, speed controls how much gradient changes
+    RGB_MATRIX_GRADIENT_LEFT_RIGHT, // Static gradient left to right, speed controls how much gradient changes
     RGB_MATRIX_BREATHING,           // Single hue brightness cycling animation
-    RGB_MATRIX_BAND_SAT,        // Single hue band fading saturation scrolling left to right
-    RGB_MATRIX_BAND_VAL,        // Single hue band fading brightness scrolling left to right
+    RGB_MATRIX_BAND_SAT,            // Single hue band fading saturation scrolling left to right
+    RGB_MATRIX_BAND_VAL,            // Single hue band fading brightness scrolling left to right
     RGB_MATRIX_BAND_PINWHEEL_SAT,   // Single hue 3 blade spinning pinwheel fades saturation
     RGB_MATRIX_BAND_PINWHEEL_VAL,   // Single hue 3 blade spinning pinwheel fades brightness
     RGB_MATRIX_BAND_SPIRAL_SAT,     // Single hue spinning spiral fades saturation
@@ -427,8 +427,8 @@ enum rgb_matrix_effects {
     RGB_MATRIX_DIGITAL_RAIN,        // That famous computer simulation
 #endif
 #if defined(RGB_MATRIX_KEYPRESSES) || defined(RGB_MATRIX_KEYRELEASES)
-    RGB_MATRIX_SOLID_REACTIVE_SIMPLE,   // Pulses keys hit to hue & value then fades value out
-    RGB_MATRIX_SOLID_REACTIVE,      // Static single hue, pulses keys hit to shifted hue then fades to current hue
+    RGB_MATRIX_SOLID_REACTIVE_SIMPLE,    // Pulses keys hit to hue & value then fades value out
+    RGB_MATRIX_SOLID_REACTIVE,           // Static single hue, pulses keys hit to shifted hue then fades to current hue
     RGB_MATRIX_SOLID_REACTIVE_WIDE       // Hue & value pulse near a single key hit then fades value out
     RGB_MATRIX_SOLID_REACTIVE_MULTIWIDE  // Hue & value pulse near multiple key hits then fades value out
     RGB_MATRIX_SOLID_REACTIVE_CROSS      // Hue & value pulse the same column and row of a single key hit then fades value out
@@ -475,7 +475,7 @@ You can disable a single effect by defining `DISABLE_[EFFECT_NAME]` in your `con
 |`#define DISABLE_RGB_MATRIX_HUE_BREATHING`             |Disables `RGB_MATRIX_HUE_BREATHING`            |
 |`#define DISABLE_RGB_MATRIX_HUE_PENDULUM`              |Disables `RGB_MATRIX_HUE_PENDULUM`             |
 |`#define DISABLE_RGB_MATRIX_HUE_WAVE `                 |Disables `RGB_MATRIX_HUE_WAVE `                |
-|`#define DISABLE_RGB_MATRIX_FRACTAL `                  |Disables `RGB_MATRIX_FRACTAL`                   |
+|`#define DISABLE_RGB_MATRIX_FRACTAL `                  |Disables `RGB_MATRIX_FRACTAL`                  |
 |`#define DISABLE_RGB_MATRIX_TYPING_HEATMAP`            |Disables `RGB_MATRIX_TYPING_HEATMAP`           |
 |`#define DISABLE_RGB_MATRIX_DIGITAL_RAIN`              |Disables `RGB_MATRIX_DIGITAL_RAIN`             |
 |`#define DISABLE_RGB_MATRIX_SOLID_REACTIVE_SIMPLE`     |Disables `RGB_MATRIX_SOLID_REACTIVE_SIMPLE`    |

--- a/quantum/rgb_matrix/animations/fractal_anim.h
+++ b/quantum/rgb_matrix/animations/fractal_anim.h
@@ -1,0 +1,61 @@
+/* Copyright (C) 2021 @filterpaper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Inspired from 4x12 fractal created by @schwarzgrau
+
+#ifdef ENABLE_RGB_MATRIX_FRACTAL
+RGB_MATRIX_EFFECT(FRACTAL)
+#   ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
+
+static bool FRACTAL(effect_params_t* params) {
+    #define MID_COL MATRIX_COLS / 2
+    static bool led[MATRIX_ROWS][MATRIX_COLS];
+
+    static uint32_t wait_timer = 0;
+    if (wait_timer > g_rgb_timer) { return false; }
+
+    inline uint32_t interval(void) { return 3000 / scale16by8(qadd8(rgb_matrix_config.speed, 16), 16); }
+
+    RGB rgb = rgb_matrix_hsv_to_rgb(rgb_matrix_config.hsv);
+    for (uint8_t h = 0; h < MATRIX_ROWS; ++h) {
+
+        for (uint8_t l = 0; l < MID_COL-1; ++l) {           // Light and move left columns outwards
+            if (led[h][l]) { rgb_matrix_set_color(g_led_config.matrix_co[h][l], rgb.r, rgb.g, rgb.b); }
+            else { rgb_matrix_set_color(g_led_config.matrix_co[h][l], 0, 0, 0); }
+            led[h][l] = led[h][l+1];
+        }
+
+        for (uint8_t r = MATRIX_COLS-1; r > MID_COL; --r) { // Light and move right columns outwards
+            if (led[h][r]) { rgb_matrix_set_color(g_led_config.matrix_co[h][r], rgb.r, rgb.g, rgb.b); }
+            else { rgb_matrix_set_color(g_led_config.matrix_co[h][r], 0, 0, 0); }
+            led[h][r] = led[h][r-1];
+        }
+
+        // Light both middle columns
+        if (led[h][MID_COL]) { rgb_matrix_set_color(g_led_config.matrix_co[h][MID_COL], rgb.r, rgb.g, rgb.b); }
+        else { rgb_matrix_set_color(g_led_config.matrix_co[h][MID_COL], 0, 0, 0); }
+        if (led[h][MID_COL-1]) { rgb_matrix_set_color(g_led_config.matrix_co[h][MID_COL-1], rgb.r, rgb.g, rgb.b); }
+        else { rgb_matrix_set_color(g_led_config.matrix_co[h][MID_COL-1], 0, 0, 0); }
+
+        // Generate new random fractal columns
+        led[h][MID_COL] = led[h][MID_COL-1] = (random8() & 3) ? false : true;
+    }
+
+    wait_timer = g_rgb_timer + interval();
+    return false;
+}
+#   endif // RGB_MATRIX_CUSTOM_EFFECT_IMPLS
+#endif    // ENABLE_RGB_MATRIX_FRACTAL

--- a/quantum/rgb_matrix/animations/rgb_matrix_effects.inc
+++ b/quantum/rgb_matrix/animations/rgb_matrix_effects.inc
@@ -26,6 +26,7 @@
 #include "hue_breathing_anim.h"
 #include "hue_pendulum_anim.h"
 #include "hue_wave_anim.h"
+#include "fractal_anim.h"
 #include "typing_heatmap_anim.h"
 #include "digital_rain_anim.h"
 #include "solid_reactive_simple_anim.h"


### PR DESCRIPTION
## Description

Here is a Fractal RGB matrix effect that generates randomly lit keys on middle columns and pulse outwards, creating a horizontal fractal pattern. Animation speed is user adjustable.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
