### PR TITLE
atreus/keymap/ardumont: Fix substitute keycode reset step

### DIFF
--- a/keyboards/keyboardio/atreus/keymaps/ardumont/keymap.c
+++ b/keyboards/keyboardio/atreus/keymaps/ardumont/keymap.c
@@ -97,14 +97,19 @@ bool substitute_keycode(uint16_t keycode, keyrecord_t *record, uint8_t mod_state
             // Do not let QMK process the keycode further
             return false;
         } else {
-            // In case substitude_keycode is still being sent even after the release of
-            // the key
+            // In case substitude_keycode is still even after release of the key
             if (key_registered) {
                 unregister_code(substitute_keycode);
                 key_registered = false;
                 // Do not let QMK process the keycode further
                 return false;
             }
+        }
+    } else { // ctrl got released
+        // In case substitude_keycode is still sent after release of the ctrl key
+        if (key_registered) {
+            unregister_code(substitute_keycode);
+            key_registered = false;
         }
     }
     // Else, let QMK process the keycode as usual


### PR DESCRIPTION
It so happens that when releasing the control key prior to the main key (C-h, C-i, C-n,
...), the substituted keycode was continuously sent in a loop after that (even when
releasing said key). The workaround so far was to type any other key to stop the loop.

This commit fixes such behavior by resetting the substitution keycode sent when the ctrl
released situation conditional is detected (and that the substitution keycode was on).


<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix (edge case)
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap (update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).