### PR TITLE
Change RGB/LED Matrix to use a simple define for USB suspend

### DIFF
--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -437,7 +437,7 @@ These are defined in [`rgblight_list.h`](https://github.com/qmk/qmk_firmware/blo
 #define RGB_MATRIX_KEYRELEASES // reacts to keyreleases (instead of keypresses)
 #define RGB_DISABLE_TIMEOUT 0 // number of milliseconds to wait until rgb automatically turns off
 #define RGB_DISABLE_AFTER_TIMEOUT 0 // OBSOLETE: number of ticks to wait until disabling effects
-#define RGB_DISABLE_WHEN_USB_SUSPENDED false // turn off effects when suspended
+#define RGB_DISABLE_WHEN_USB_SUSPENDED // turn off effects when suspended
 #define RGB_MATRIX_LED_PROCESS_LIMIT (DRIVER_LED_TOTAL + 4) / 5 // limits the number of LEDs to process in an animation per task run (increases keyboard responsiveness)
 #define RGB_MATRIX_LED_FLUSH_LIMIT 16 // limits in milliseconds how frequently an animation will update the LEDs. 16 (16ms) is equivalent to limiting to 60fps (increases keyboard responsiveness)
 #define RGB_MATRIX_MAXIMUM_BRIGHTNESS 200 // limits maximum brightness of LEDs to 200 out of 255. If not defined maximum brightness is set to 255

--- a/keyboards/mt64rgb/keymaps/default/keymap.c
+++ b/keyboards/mt64rgb/keymaps/default/keymap.c
@@ -1,18 +1,18 @@
-/* Copyright 2020 MT 
-  * 
-  * This program is free software: you can redistribute it and/or modify 
-  * it under the terms of the GNU General Public License as published by 
-  * the Free Software Foundation, either version 2 of the License, or 
-  * (at your option) any later version. 
-  * 
-  * This program is distributed in the hope that it will be useful, 
-  * but WITHOUT ANY WARRANTY; without even the implied warranty of 
-  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
-  * GNU General Public License for more details. 
-  * 
-  * You should have received a copy of the GNU General Public License 
-  * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
-  */ 
+/* Copyright 2020 MT
+  *
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 2 of the License, or
+  * (at your option) any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  */
 #include QMK_KEYBOARD_H
 
 
@@ -37,7 +37,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 };
 
 void rgb_matrix_indicators_user(void) {
-    if (!g_suspend_state && layer_state_is(1)) {
+    if (layer_state_is(1)) {
         rgb_matrix_set_color(77,0xFF, 0x80, 0x00);
     }
     if (host_keyboard_led_state().caps_lock) {

--- a/keyboards/mt84/keymaps/default/keymap.c
+++ b/keyboards/mt84/keymaps/default/keymap.c
@@ -1,18 +1,18 @@
  /* Copyright 2020 mt<704340378@qq.com>
-  * 
-  * This program is free software: you can redistribute it and/or modify 
-  * it under the terms of the GNU General Public License as published by 
-  * the Free Software Foundation, either version 2 of the License, or 
-  * (at your option) any later version. 
-  * 
-  * This program is distributed in the hope that it will be useful, 
-  * but WITHOUT ANY WARRANTY; without even the implied warranty of 
-  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
-  * GNU General Public License for more details. 
-  * 
-  * You should have received a copy of the GNU General Public License 
-  * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
-  */ 
+  *
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 2 of the License, or
+  * (at your option) any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  */
 #include QMK_KEYBOARD_H
 
 
@@ -44,12 +44,10 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 void rgb_matrix_indicators_user(void) {
 	led_t led_state = host_keyboard_led_state();
-	  if (!g_suspend_state) {
 	    switch (get_highest_layer(layer_state)) {
 	      case _FN:
 	        rgb_matrix_set_color(77,0xFF, 0x80, 0x00);
           break;
-      }
     }
     if (led_state.caps_lock) {
           rgb_matrix_set_color(46, 0xFF, 0xFF, 0xFF);

--- a/quantum/led_matrix.c
+++ b/quantum/led_matrix.c
@@ -75,7 +75,7 @@ last_hit_t g_last_hit_tracker;
 #endif  // LED_MATRIX_KEYREACTIVE_ENABLED
 
 // internals
-static bool            g_suspend_state   = false;
+static bool            suspend_state   = false;
 static uint8_t         led_last_enable   = UINT8_MAX;
 static uint8_t         led_last_effect   = UINT8_MAX;
 static effect_params_t led_effect_params = {0, LED_FLAG_ALL, false};
@@ -325,7 +325,7 @@ void led_matrix_task(void) {
     // Ideally we would also stop sending zeros to the LED driver PWM buffers
     // while suspended and just do a software shutdown. This is a cheap hack for now.
     bool suspend_backlight =
-        g_suspend_state ||
+        suspend_state ||
 #if LED_DISABLE_TIMEOUT > 0
         (led_anykey_timer > (uint32_t)LED_DISABLE_TIMEOUT) ||
 #endif  // LED_DISABLE_TIMEOUT > 0
@@ -418,11 +418,11 @@ void led_matrix_set_suspend_state(bool state) {
     if (state) {
         led_matrix_set_value_all(0);  // turn off all LEDs when suspending
     }
-    g_suspend_state = state;
+    suspend_state = state;
 #endif
 }
 
-bool led_matrix_get_suspend_state(void) { return g_suspend_state; }
+bool led_matrix_get_suspend_state(void) { return suspend_state; }
 
 void led_matrix_toggle_eeprom_helper(bool write_to_eeprom) {
     led_matrix_eeconfig.enable ^= 1;

--- a/quantum/led_matrix.c
+++ b/quantum/led_matrix.c
@@ -35,8 +35,8 @@
 #    define LED_DISABLE_TIMEOUT 0
 #endif
 
-#ifndef LED_DISABLE_WHEN_USB_SUSPENDED
-#    define LED_DISABLE_WHEN_USB_SUSPENDED false
+#if LED_DISABLE_WHEN_USB_SUSPENDED == false
+#    undef LED_DISABLE_WHEN_USB_SUSPENDED
 #endif
 
 #if !defined(LED_MATRIX_MAXIMUM_BRIGHTNESS) || LED_MATRIX_MAXIMUM_BRIGHTNESS > UINT8_MAX
@@ -65,7 +65,6 @@
 #endif
 
 // globals
-bool           g_suspend_state = false;
 led_eeconfig_t led_matrix_eeconfig;  // TODO: would like to prefix this with g_ for global consistancy, do this in another pr
 uint32_t       g_led_timer;
 #ifdef LED_MATRIX_FRAMEBUFFER_EFFECTS
@@ -76,6 +75,7 @@ last_hit_t g_last_hit_tracker;
 #endif  // LED_MATRIX_KEYREACTIVE_ENABLED
 
 // internals
+static bool            g_suspend_state   = false;
 static uint8_t         led_last_enable   = UINT8_MAX;
 static uint8_t         led_last_effect   = UINT8_MAX;
 static effect_params_t led_effect_params = {0, LED_FLAG_ALL, false};
@@ -325,9 +325,7 @@ void led_matrix_task(void) {
     // Ideally we would also stop sending zeros to the LED driver PWM buffers
     // while suspended and just do a software shutdown. This is a cheap hack for now.
     bool suspend_backlight =
-#if LED_DISABLE_WHEN_USB_SUSPENDED == true
         g_suspend_state ||
-#endif  // LED_DISABLE_WHEN_USB_SUSPENDED == true
 #if LED_DISABLE_TIMEOUT > 0
         (led_anykey_timer > (uint32_t)LED_DISABLE_TIMEOUT) ||
 #endif  // LED_DISABLE_TIMEOUT > 0
@@ -416,10 +414,12 @@ void led_matrix_init(void) {
 }
 
 void led_matrix_set_suspend_state(bool state) {
-    if (LED_DISABLE_WHEN_USB_SUSPENDED && state) {
+#ifdef LED_DISABLE_WHEN_USB_SUSPENDED
+    if (state) {
         led_matrix_set_value_all(0);  // turn off all LEDs when suspending
     }
     g_suspend_state = state;
+#endif
 }
 
 bool led_matrix_get_suspend_state(void) { return g_suspend_state; }

--- a/quantum/led_matrix.h
+++ b/quantum/led_matrix.h
@@ -134,7 +134,6 @@ extern const led_matrix_driver_t led_matrix_driver;
 
 extern led_eeconfig_t led_matrix_eeconfig;
 
-extern bool         g_suspend_state;
 extern uint32_t     g_led_timer;
 extern led_config_t g_led_config;
 #ifdef LED_MATRIX_KEYREACTIVE_ENABLED

--- a/quantum/rgb_matrix.c
+++ b/quantum/rgb_matrix.c
@@ -128,7 +128,7 @@ last_hit_t g_last_hit_tracker;
 #endif  // RGB_MATRIX_KEYREACTIVE_ENABLED
 
 // internals
-static bool            g_suspend_state   = false;
+static bool            suspend_state   = false;
 static uint8_t         rgb_last_enable   = UINT8_MAX;
 static uint8_t         rgb_last_effect   = UINT8_MAX;
 static effect_params_t rgb_effect_params = {0, LED_FLAG_ALL, false};
@@ -410,7 +410,7 @@ void rgb_matrix_task(void) {
     // Ideally we would also stop sending zeros to the LED driver PWM buffers
     // while suspended and just do a software shutdown. This is a cheap hack for now.
     bool suspend_backlight =
-        g_suspend_state ||
+        suspend_state ||
 #if RGB_DISABLE_TIMEOUT > 0
         (rgb_anykey_timer > (uint32_t)RGB_DISABLE_TIMEOUT) ||
 #endif  // RGB_DISABLE_TIMEOUT > 0
@@ -503,11 +503,11 @@ void rgb_matrix_set_suspend_state(bool state) {
     if (state) {
         rgb_matrix_set_color_all(0, 0, 0);  // turn off all LEDs when suspending
     }
-    g_suspend_state = state;
+    suspend_state = state;
 #endif
 }
 
-bool rgb_matrix_get_suspend_state(void) { return g_suspend_state; }
+bool rgb_matrix_get_suspend_state(void) { return suspend_state; }
 
 void rgb_matrix_toggle_eeprom_helper(bool write_to_eeprom) {
     rgb_matrix_config.enable ^= 1;

--- a/quantum/rgb_matrix.c
+++ b/quantum/rgb_matrix.c
@@ -67,8 +67,8 @@ __attribute__((weak)) RGB rgb_matrix_hsv_to_rgb(HSV hsv) { return hsv_to_rgb(hsv
 #    define RGB_DISABLE_TIMEOUT 0
 #endif
 
-#ifndef RGB_DISABLE_WHEN_USB_SUSPENDED
-#    define RGB_DISABLE_WHEN_USB_SUSPENDED false
+#if RGB_DISABLE_WHEN_USB_SUSPENDED == false
+#    undef RGB_DISABLE_WHEN_USB_SUSPENDED
 #endif
 
 #if !defined(RGB_MATRIX_MAXIMUM_BRIGHTNESS) || RGB_MATRIX_MAXIMUM_BRIGHTNESS > UINT8_MAX
@@ -118,7 +118,6 @@ __attribute__((weak)) RGB rgb_matrix_hsv_to_rgb(HSV hsv) { return hsv_to_rgb(hsv
 #endif
 
 // globals
-bool         g_suspend_state = false;
 rgb_config_t rgb_matrix_config;  // TODO: would like to prefix this with g_ for global consistancy, do this in another pr
 uint32_t     g_rgb_timer;
 #ifdef RGB_MATRIX_FRAMEBUFFER_EFFECTS
@@ -129,6 +128,7 @@ last_hit_t g_last_hit_tracker;
 #endif  // RGB_MATRIX_KEYREACTIVE_ENABLED
 
 // internals
+static bool            g_suspend_state   = false;
 static uint8_t         rgb_last_enable   = UINT8_MAX;
 static uint8_t         rgb_last_effect   = UINT8_MAX;
 static effect_params_t rgb_effect_params = {0, LED_FLAG_ALL, false};
@@ -410,9 +410,7 @@ void rgb_matrix_task(void) {
     // Ideally we would also stop sending zeros to the LED driver PWM buffers
     // while suspended and just do a software shutdown. This is a cheap hack for now.
     bool suspend_backlight =
-#if RGB_DISABLE_WHEN_USB_SUSPENDED == true
         g_suspend_state ||
-#endif  // RGB_DISABLE_WHEN_USB_SUSPENDED == true
 #if RGB_DISABLE_TIMEOUT > 0
         (rgb_anykey_timer > (uint32_t)RGB_DISABLE_TIMEOUT) ||
 #endif  // RGB_DISABLE_TIMEOUT > 0
@@ -501,10 +499,12 @@ void rgb_matrix_init(void) {
 }
 
 void rgb_matrix_set_suspend_state(bool state) {
-    if (RGB_DISABLE_WHEN_USB_SUSPENDED && state) {
+#ifdef RGB_DISABLE_WHEN_USB_SUSPENDED
+    if (state) {
         rgb_matrix_set_color_all(0, 0, 0);  // turn off all LEDs when suspending
     }
     g_suspend_state = state;
+#endif
 }
 
 bool rgb_matrix_get_suspend_state(void) { return g_suspend_state; }

--- a/quantum/rgb_matrix.h
+++ b/quantum/rgb_matrix.h
@@ -216,7 +216,6 @@ extern const rgb_matrix_driver_t rgb_matrix_driver;
 
 extern rgb_config_t rgb_matrix_config;
 
-extern bool         g_suspend_state;
 extern uint32_t     g_rgb_timer;
 extern led_config_t g_led_config;
 #ifdef RGB_MATRIX_KEYREACTIVE_ENABLED

--- a/tmk_core/common/avr/suspend.c
+++ b/tmk_core/common/avr/suspend.c
@@ -163,6 +163,10 @@ void suspend_power_down(void) {
     rgblight_suspend();
 #    endif
 
+#    if defined(RGB_MATRIX_ENABLE)
+    rgb_matrix_set_suspend_state(true);
+#    endif
+
     // Enter sleep state if possible (ie, the MCU has a watchdog timeout interrupt)
 #    if defined(WDT_vect)
     power_down(WDTO_15MS);
@@ -214,6 +218,9 @@ void suspend_wakeup_init(void) {
 #if defined(RGBLIGHT_SLEEP) && defined(RGBLIGHT_ENABLE)
     rgblight_wakeup();
 #endif
+#    if defined(RGB_MATRIX_ENABLE)
+    rgb_matrix_set_suspend_state(false);
+#    endif
 
     suspend_wakeup_init_kb();
 }

--- a/tmk_core/common/chibios/suspend.c
+++ b/tmk_core/common/chibios/suspend.c
@@ -155,7 +155,7 @@ void suspend_wakeup_init(void) {
     rgblight_wakeup();
 #endif
 #    if defined(RGB_MATRIX_ENABLE)
-    rgb_matrix_set_suspend_state(true);
+    rgb_matrix_set_suspend_state(false);
 #    endif
     suspend_wakeup_init_kb();
 }

--- a/tmk_core/common/chibios/suspend.c
+++ b/tmk_core/common/chibios/suspend.c
@@ -83,6 +83,9 @@ void suspend_power_down(void) {
 #if defined(RGBLIGHT_SLEEP) && defined(RGBLIGHT_ENABLE)
     rgblight_suspend();
 #endif
+#    if defined(RGB_MATRIX_ENABLE)
+    rgb_matrix_set_suspend_state(true);
+#    endif
 #ifdef AUDIO_ENABLE
     stop_all_notes();
 #endif /* AUDIO_ENABLE */
@@ -151,5 +154,8 @@ void suspend_wakeup_init(void) {
 #if defined(RGBLIGHT_SLEEP) && defined(RGBLIGHT_ENABLE)
     rgblight_wakeup();
 #endif
+#    if defined(RGB_MATRIX_ENABLE)
+    rgb_matrix_set_suspend_state(true);
+#    endif
     suspend_wakeup_init_kb();
 }


### PR DESCRIPTION
## Description

Like the title says. 
But more specifically, instead of using a bool for the define, it changes it to be a simple define. If present, then enables the functionality, if not defined, then it stays running when USB suspends. 
Also makes the g_suspend_state variable static to not conflict between rgb matrix and led matrix.

And adds a check to make sure it's properly handled. 

Does not touch existing keyboards, just changes how the define works. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Enhancement/optimization
- [x] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
