### PR TITLE
Allow user override of RGB_DISABLE_WHEN_USB_SUSPENDED for BM40 keyboard

### DIFF
--- a/keyboards/bm40hsrgb/config.h
+++ b/keyboards/bm40hsrgb/config.h
@@ -50,6 +50,6 @@
 #ifdef RGB_DI_PIN
     #define RGB_MATRIX_KEYPRESSES // reacts to keypresses
 #endif
-#ifdef RGB_MATRIX_ENABLE
+#ifndef RGB_DISABLE_WHEN_USB_SUSPENDED
 #    define RGB_DISABLE_WHEN_USB_SUSPENDED true // turn off effects when suspended
 #endif

--- a/keyboards/bm40hsrgb/config.h
+++ b/keyboards/bm40hsrgb/config.h
@@ -51,5 +51,5 @@
     #define RGB_MATRIX_KEYPRESSES // reacts to keypresses
 #endif
 #ifndef RGB_DISABLE_WHEN_USB_SUSPENDED
-#    define RGB_DISABLE_WHEN_USB_SUSPENDED // turn off effects when suspended
+#    define RGB_DISABLE_WHEN_USB_SUSPENDED true // turn off effects when suspended
 #endif

--- a/keyboards/bm40hsrgb/config.h
+++ b/keyboards/bm40hsrgb/config.h
@@ -51,5 +51,5 @@
     #define RGB_MATRIX_KEYPRESSES // reacts to keypresses
 #endif
 #ifndef RGB_DISABLE_WHEN_USB_SUSPENDED
-#    define RGB_DISABLE_WHEN_USB_SUSPENDED true // turn off effects when suspended
+#    define RGB_DISABLE_WHEN_USB_SUSPENDED // turn off effects when suspended
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Allow user override to the `RGB_DISABLE_WHEN_USB_SUSPENDED` setting, based on @tzarc's suggestion in #12290

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
