### PR TITLE
Resolve recent API errors due to data driven efforts

### DIFF
--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -43,7 +43,7 @@ def info_json(keyboard):
         info_data['keymaps'][keymap.name] = {'url': f'https://raw.githubusercontent.com/qmk/qmk_firmware/master/{keymap}/keymap.json'}
 
     # Populate layout data
-    layouts, aliases = _find_all_layouts(info_data, keyboard)
+    layouts, aliases = _search_keyboard_h(Path(keyboard))
 
     if aliases:
         info_data['layout_aliases'] = aliases
@@ -362,6 +362,8 @@ def _merge_layouts(info_data, new_info_data):
 
 
 def _search_keyboard_h(path):
+    """Looks for layout macros associated with this keyboard.
+    """
     current_path = Path('keyboards/')
     aliases = {}
     layouts = {}
@@ -377,29 +379,6 @@ def _search_keyboard_h(path):
             for alias, alias_text in new_aliases.items():
                 if alias_text in layouts:
                     aliases[alias] = alias_text
-
-    return layouts, aliases
-
-
-def _find_all_layouts(info_data, keyboard):
-    """Looks for layout macros associated with this keyboard.
-    """
-    layouts, aliases = _search_keyboard_h(Path(keyboard))
-
-    if not layouts:
-        # If we don't find any layouts from info.json or keyboard.h we widen our search. This is error prone which is why we want to encourage people to follow the standard above.
-        info_data['parse_warnings'].append('%s: Falling back to searching for KEYMAP/LAYOUT macros.' % (keyboard))
-
-        for file in glob('keyboards/%s/*.h' % keyboard):
-            if file.endswith('.h'):
-                these_layouts, these_aliases = find_layouts(file)
-
-                if these_layouts:
-                    layouts.update(these_layouts)
-
-                for alias, alias_text in these_aliases.items():
-                    if alias_text in layouts:
-                        aliases[alias] = alias_text
 
     return layouts, aliases
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
As a jumping off point to resolve the many `Falling back to searching for KEYMAP/LAYOUT macros` errors from recent info.json data driven efforts.

> This is error prone which is why we want to encourage people to follow the standard above.

Part of the issue resides in the fact that info.json files are not processed by the point layout macros are searched.
What better way to encourage people, than to not support the functionality? If still required, maybe it would be safe to resolve the .h files after info.json? 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
