### PR TITLE
Fix zero condition of reactive runners that will suspend RGB animation

### DIFF
--- a/quantum/rgb_matrix_runners/effect_runner_i.h
+++ b/quantum/rgb_matrix_runners/effect_runner_i.h
@@ -5,7 +5,7 @@ typedef HSV (*i_f)(HSV hsv, uint8_t i, uint8_t time);
 bool effect_runner_i(effect_params_t* params, i_f effect_func) {
     RGB_MATRIX_USE_LIMITS(led_min, led_max);
 
-    uint8_t time = scale16by8(g_rgb_timer, rgb_matrix_config.speed / 4);
+    uint8_t time = scale16by8(g_rgb_timer, qadd8(rgb_matrix_config.speed / 4, 1));
     for (uint8_t i = led_min; i < led_max; i++) {
         RGB_MATRIX_TEST_LED_FLAGS();
         RGB rgb = rgb_matrix_hsv_to_rgb(effect_func(rgb_matrix_config.hsv, i, time));

--- a/quantum/rgb_matrix_runners/effect_runner_reactive.h
+++ b/quantum/rgb_matrix_runners/effect_runner_reactive.h
@@ -7,7 +7,7 @@ typedef HSV (*reactive_f)(HSV hsv, uint16_t offset);
 bool effect_runner_reactive(effect_params_t* params, reactive_f effect_func) {
     RGB_MATRIX_USE_LIMITS(led_min, led_max);
 
-    uint16_t max_tick = 65535 / rgb_matrix_config.speed;
+    uint16_t max_tick = 65535 / qadd8(rgb_matrix_config.speed, 1);
     for (uint8_t i = led_min; i < led_max; i++) {
         RGB_MATRIX_TEST_LED_FLAGS();
         uint16_t tick = max_tick;
@@ -19,7 +19,7 @@ bool effect_runner_reactive(effect_params_t* params, reactive_f effect_func) {
             }
         }
 
-        uint16_t offset = scale16by8(tick, rgb_matrix_config.speed);
+        uint16_t offset = scale16by8(tick, qadd8(rgb_matrix_config.speed, 1));
         RGB      rgb    = rgb_matrix_hsv_to_rgb(effect_func(rgb_matrix_config.hsv, offset));
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
     }

--- a/quantum/rgb_matrix_runners/effect_runner_reactive_splash.h
+++ b/quantum/rgb_matrix_runners/effect_runner_reactive_splash.h
@@ -16,7 +16,7 @@ bool effect_runner_reactive_splash(uint8_t start, effect_params_t* params, react
             int16_t  dx   = g_led_config.point[i].x - g_last_hit_tracker.x[j];
             int16_t  dy   = g_led_config.point[i].y - g_last_hit_tracker.y[j];
             uint8_t  dist = sqrt16(dx * dx + dy * dy);
-            uint16_t tick = scale16by8(g_last_hit_tracker.tick[j], rgb_matrix_config.speed);
+            uint16_t tick = scale16by8(g_last_hit_tracker.tick[j], qadd8(rgb_matrix_config.speed, 1));
             hsv           = effect_func(hsv, dx, dy, dist, tick);
         }
         hsv.v   = scale8(hsv.v, rgb_matrix_config.hsv.v);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

If user keyboard's RGB speed setting (`rgb_matrix_config.speed`) is at zero, key press animation will remain static. Reactive runners will keep one key or entire keyboard lit.

This change avoid both conditions with a minimum value to the `tick` variable. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
