### PR TITLE
[Bug Fix] Mechlovin Infinity87 Rev1 - fix default folder

### DIFF
--- a/keyboards/mechlovin/infinity87/rev1/rules.mk
+++ b/keyboards/mechlovin/infinity87/rev1/rules.mk
@@ -2,3 +2,5 @@ MCU = STM32F303
 BOARD = QMK_PROTON_C
 
 BACKLIGHT_ENABLE  = yes     # Enable keyboard backlight functionality
+
+DEFAULT_FOLDER = mechlovin/infinity87/rev1/standard


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Fix default folder of Mechlovin Infinity87 Rev1 to point to the standard otherwise it errors out and attempts to build the keyboard alone without any other #define's that are in standard/rogue/rouge versions.
https://github.com/Xelus22/QMK-VIA-Hex/runs/2443537176?check_suite_focus=true

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fix default folder of Mechlovin Infinity87 Rev1 to point to the standard otherwise it errors out.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
