### PR TITLE
Fix F13 LED issue for WT75-B, WT75-C

### DIFF
--- a/keyboards/wilba_tech/wt75_b/config.h
+++ b/keyboards/wilba_tech/wt75_b/config.h
@@ -178,9 +178,6 @@
 // enable the mono backlight
 #define MONO_BACKLIGHT_ENABLED 1
 
-// enable the RGB indicator for WT75-A
-#define MONO_BACKLIGHT_WT75_A
-
 // disable backlight when USB suspended (PC sleep/hibernate/shutdown)
 #define MONO_BACKLIGHT_DISABLE_WHEN_USB_SUSPENDED 0
 

--- a/keyboards/wilba_tech/wt75_c/config.h
+++ b/keyboards/wilba_tech/wt75_c/config.h
@@ -178,9 +178,6 @@
 // enable the mono backlight
 #define MONO_BACKLIGHT_ENABLED 1
 
-// enable the RGB indicator for WT75-A
-#define MONO_BACKLIGHT_WT75_A
-
 // disable backlight when USB suspended (PC sleep/hibernate/shutdown)
 #define MONO_BACKLIGHT_DISABLE_WHEN_USB_SUSPENDED 0
 


### PR DESCRIPTION
## Description

The code for handling the RGB indicator on WT75-A was being enabled for WT75-B and WT75-C which doesn't have an RGB indicator, causing the F13 LED to always be lit.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
