### PR TITLE
Add Ploopy nano scrollball feature

### DIFF
--- a/keyboards/ploopyco/trackball_nano/keymaps/scrollball/config.h
+++ b/keyboards/ploopyco/trackball_nano/keymaps/scrollball/config.h
@@ -1,3 +1,19 @@
+ /* Copyright 2021 Dustin Bosveld
+  *
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 2 of the License, or
+  * (at your option) any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  */
+
 #pragma once
 
 //turn on scroll ball

--- a/keyboards/ploopyco/trackball_nano/keymaps/scrollball/config.h
+++ b/keyboards/ploopyco/trackball_nano/keymaps/scrollball/config.h
@@ -1,0 +1,5 @@
+#pragma once
+
+//turn on scroll ball
+#define PLOOPY_SCROLL_BALL true
+#define PLOOPY_DPI_DEFAULT 1

--- a/keyboards/ploopyco/trackball_nano/keymaps/scrollball/keymap.c
+++ b/keyboards/ploopyco/trackball_nano/keymaps/scrollball/keymap.c
@@ -1,0 +1,23 @@
+/* Copyright 2021 Colin Lam (Ploopy Corporation)
+ * Copyright 2020 Christopher Courtney, aka Drashna Jael're  (@drashna) <drashna@live.com>
+ * Copyright 2019 Sunjun Kim
+ * Copyright 2019 Hiroyuki Okada
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include QMK_KEYBOARD_H
+
+// safe range starts at `PLOOPY_SAFE_RANGE` instead.
+
+// placeholder file so it will compile

--- a/keyboards/ploopyco/trackball_nano/keymaps/scrollball/readme.md
+++ b/keyboards/ploopyco/trackball_nano/keymaps/scrollball/readme.md
@@ -1,0 +1,3 @@
+The default keymap for the Ploopy Trackball Mini.
+
+Note that kits bought from PloopyCo actually ship with the VIA keymap, not this one.

--- a/keyboards/ploopyco/trackball_nano/keymaps/scrollball/readme.md
+++ b/keyboards/ploopyco/trackball_nano/keymaps/scrollball/readme.md
@@ -1,3 +1,1 @@
-The default keymap for the Ploopy Trackball Mini.
-
-Note that kits bought from PloopyCo actually ship with the VIA keymap, not this one.
+The scrollball keymap for the Ploopy Trackball nano.

--- a/keyboards/ploopyco/trackball_nano/trackball_nano.c
+++ b/keyboards/ploopyco/trackball_nano/trackball_nano.c
@@ -46,6 +46,10 @@
 #    define PLOOPY_DPI_DEFAULT 1
 #endif
 
+#ifndef PLOOPY_SCROLL_BALL
+#    define PLOOPY_SCROLL_BALL false
+#endif
+
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = { };
 
 // Transformation constants for delta-X and delta-Y
@@ -69,6 +73,7 @@ uint16_t lastScroll = 0;  // Previous confirmed wheel event
 uint16_t lastMidClick = 0;  // Stops scrollwheel from being read if it was pressed
 uint8_t OptLowPin = OPT_ENC1;
 bool debug_encoder = false;
+bool is_scroll = PLOOPY_SCROLL_BALL;
 
 __attribute__((weak)) void process_wheel_user(report_mouse_t* mouse_report, int16_t h, int16_t v) {
     // There's no scroller on this device.
@@ -184,6 +189,19 @@ void pointing_device_task(void) {
     report_mouse_t mouse_report = pointing_device_get_report();
     process_wheel(&mouse_report);
     process_mouse(&mouse_report);
+
+    if (is_scroll) {
+        mouse_report.h = mouse_report.x;
+#ifdef PLOOPY_SCROLL_INVERT
+        // Invert vertical scroll direction
+        mouse_report.v = -mouse_report.y;
+#else
+        mouse_report.v = mouse_report.y;
+#endif
+        mouse_report.x = 0;
+        mouse_report.y = 0;
+    }
+
     pointing_device_set_report(mouse_report);
     pointing_device_send();
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
I have seen many musings about adding a scrolling 'keymap' for the Ploopy nano so I decided to give it a go implement a scrollball keymap.
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This feature re-implements the drag scroll code from the full size ploopy trackball and exposes a variable `#PLOOPY_SCROLL_BALL` to enable the drag scroll functionality as there are no physical buttons on the Ploopy nano trackball.
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
