### PR TITLE
Reduce USB polling rate in FaceW PCB config.

### DIFF
--- a/keyboards/facew/config.h
+++ b/keyboards/facew/config.h
@@ -25,6 +25,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MANUFACTURER    SPRiT
 #define PRODUCT         FaceW
 
+#define USB_POLLING_INTERVAL_MS 20
+
 #define RGBLED_NUM 16
 
 #define MATRIX_ROWS 8


### PR DESCRIPTION
## Description

Increase the interval from default (currently 1ms) to 20ms. Fast polling rates can cause stability issues (possibly overheating), as first documented by GeekHack user "infiniti" https://geekhack.org/index.php?topic=58945.0.

Intervals up to at least 12 ms exhibited these issues in my testing, and so 20ms was chosen for a healthy factor of safety.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ X ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation