### PR TITLE
[Keyboard] Fix bootloader rule for meishi2 keyboard

### DIFF
--- a/keyboards/meishi2/rules.mk
+++ b/keyboards/meishi2/rules.mk
@@ -9,7 +9,7 @@ MCU = atmega32u4
 #   QMK DFU      qmk-dfu
 #   ATmega32A    bootloadHID
 #   ATmega328P   USBasp
-BOOTLOADER = atmel-dfu
+BOOTLOADER = caterina
 
 # Build Options
 #   change yes to no to disable


### PR DESCRIPTION
This fix enables flash command like `qmk flash -kb meishi2 -km default` .

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] ~My change requires a change to the documentation.~
- [ ] ~I have updated the documentation accordingly.~
- [ ] ~I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).~
- [ ] ~I have added tests to cover my changes.~
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
