### PR TITLE
Add readPort() and some API to 'tmk_core/common/*/gpio.h'

### DIFF
--- a/tmk_core/common/avr/gpio.h
+++ b/tmk_core/common/avr/gpio.h
@@ -37,6 +37,8 @@ typedef uint8_t pin_t;
 
 /* Operation of GPIO by port. */
 
+typedef uint8_t port_data_t;
+
 #define readPort(port) PINx_ADDRESS(port)
 
 #define setPortBitInput(port, bit) (DDRx_ADDRESS(port) &= ~_BV((bit)&0xF), PORTx_ADDRESS(port) &= ~_BV((bit)&0xF))

--- a/tmk_core/common/avr/gpio.h
+++ b/tmk_core/common/avr/gpio.h
@@ -20,6 +20,8 @@
 
 typedef uint8_t pin_t;
 
+/* Operation of GPIO by pin. */
+
 #define setPinInput(pin) (DDRx_ADDRESS(pin) &= ~_BV((pin)&0xF), PORTx_ADDRESS(pin) &= ~_BV((pin)&0xF))
 #define setPinInputHigh(pin) (DDRx_ADDRESS(pin) &= ~_BV((pin)&0xF), PORTx_ADDRESS(pin) |= _BV((pin)&0xF))
 #define setPinInputLow(pin) _Static_assert(0, "AVR processors cannot implement an input as pull low")
@@ -32,3 +34,14 @@ typedef uint8_t pin_t;
 #define readPin(pin) ((bool)(PINx_ADDRESS(pin) & _BV((pin)&0xF)))
 
 #define togglePin(pin) (PORTx_ADDRESS(pin) ^= _BV((pin)&0xF))
+
+/* Operation of GPIO by port. */
+
+#define readPort(port) PINx_ADDRESS(port)
+
+#define setPortBitInput(port, bit) (DDRx_ADDRESS(port) &= ~_BV((bit)&0xF), PORTx_ADDRESS(port) &= ~_BV((bit)&0xF))
+#define setPortBitInputHigh(port, bit) (DDRx_ADDRESS(port) &= ~_BV((bit)&0xF), PORTx_ADDRESS(port) |= _BV((bit)&0xF))
+#define setPortBitOutput(port, bit) (DDRx_ADDRESS(port) |= _BV((bit)&0xF))
+
+#define writePortBitLow(port, bit) (PORTx_ADDRESS(port) &= ~_BV((bit)&0xF))
+#define writePortBitHigh(port, bit) (PORTx_ADDRESS(port) |= _BV((bit)&0xF))

--- a/tmk_core/common/chibios/gpio.h
+++ b/tmk_core/common/chibios/gpio.h
@@ -39,12 +39,12 @@ typedef ioline_t pin_t;
 
 typedef uint16_t port_data_t;
 
-#define readPort(qmk_pin) palReadPort(PAL_PORT(qmk_pin))
+#define readPort(pin) palReadPort(PAL_PORT(pin))
 
-#define setPortBitInput(qmk_pin, bit) palSetPadMode(PAL_PORT(qmk_pin), bit, PAL_MODE_INPUT)
-#define setPortBitInputHigh(qmk_pin, bit) palSetPadMode(PAL_PORT(qmk_pin), bit, PAL_MODE_INPUT_PULLUP)
-#define setPortBitInputLow(qmk_pin, bit) palSetPadMode(PAL_PORT(qmk_pin), bit, PAL_MODE_INPUT_PULLDOWN)
-#define setPortBitOutput(qmk_pin, bit) palSetPadMode(PAL_PORT(qmk_pin), bit, PAL_MODE_OUTPUT_PUSHPULL)
+#define setPortBitInput(pin, bit) palSetPadMode(PAL_PORT(pin), bit, PAL_MODE_INPUT)
+#define setPortBitInputHigh(pin, bit) palSetPadMode(PAL_PORT(pin), bit, PAL_MODE_INPUT_PULLUP)
+#define setPortBitInputLow(pin, bit) palSetPadMode(PAL_PORT(pin), bit, PAL_MODE_INPUT_PULLDOWN)
+#define setPortBitOutput(pin, bit) palSetPadMode(PAL_PORT(pin), bit, PAL_MODE_OUTPUT_PUSHPULL)
 
-#define writePortBitLow(qmk_pin, bit) palClearLine(PAL_LINE(PAL_PORT(qmk_pin), bit))
-#define writePortBitHigh(qmk_pin, bit) palSetLine(PAL_LINE(PAL_PORT(qmk_pin), bit))
+#define writePortBitLow(pin, bit) palClearLine(PAL_LINE(PAL_PORT(pin), bit))
+#define writePortBitHigh(pin, bit) palSetLine(PAL_LINE(PAL_PORT(pin), bit))

--- a/tmk_core/common/chibios/gpio.h
+++ b/tmk_core/common/chibios/gpio.h
@@ -20,6 +20,8 @@
 
 typedef ioline_t pin_t;
 
+/* Operation of GPIO by pin. */
+
 #define setPinInput(pin) palSetLineMode(pin, PAL_MODE_INPUT)
 #define setPinInputHigh(pin) palSetLineMode(pin, PAL_MODE_INPUT_PULLUP)
 #define setPinInputLow(pin) palSetLineMode(pin, PAL_MODE_INPUT_PULLDOWN)
@@ -32,3 +34,15 @@ typedef ioline_t pin_t;
 #define readPin(pin) palReadLine(pin)
 
 #define togglePin(pin) palToggleLine(pin)
+
+/* Operation of GPIO by port. */
+
+#define readPort(qmk_pin) palReadPort(PAL_PORT(qmk_pin))
+
+#define setPortBitInput(qmk_pin, bit) palSetPadMode(PAL_PORT(qmk_pin), bit, PAL_MODE_INPUT)
+#define setPortBitInputHigh(qmk_pin, bit) palSetPadMode(PAL_PORT(qmk_pin), bit, PAL_MODE_INPUT_PULLUP)
+#define setPortBitInputLow(qmk_pin, bit) palSetPadMode(PAL_PORT(qmk_pin), bit, PAL_MODE_INPUT_PULLDOWN)
+#define setPortBitOutput(qmk_pin, bit) palSetPadMode(PAL_PORT(qmk_pin), bit, PAL_MODE_OUTPUT_PUSHPULL)
+
+#define writePortBitLow(qmk_pin, bit) palClearLine(PAL_LINE(PAL_PORT(qmk_pin), bit))
+#define writePortBitHigh(qmk_pin, bit) palSetLine(PAL_LINE(PAL_PORT(qmk_pin), bit))

--- a/tmk_core/common/chibios/gpio.h
+++ b/tmk_core/common/chibios/gpio.h
@@ -37,6 +37,8 @@ typedef ioline_t pin_t;
 
 /* Operation of GPIO by port. */
 
+typedef uint16_t port_data_t;
+
 #define readPort(qmk_pin) palReadPort(PAL_PORT(qmk_pin))
 
 #define setPortBitInput(qmk_pin, bit) palSetPadMode(PAL_PORT(qmk_pin), bit, PAL_MODE_INPUT)


### PR DESCRIPTION
## Description

The following macros have been added to gpio.h.

* readPort(port)
* setPortBitInput(port, bit)
* setPortBitInputHigh(port, bit)
* setPortBitOutput(port, bit)
* writePortBitLow(port, bit)
* writePortBitHigh(port, bit)

<details>
<summary><strong>Effects of using `readPort()`.  (click)</strong></summary>

### Pro Micro, current matrix.c (MATRIX_IO_DELAY=0)
* Processing time for Row0: 75.2us

![DS1Z_QuickPrint38](https://user-images.githubusercontent.com/2170248/116728162-8ad7b580-aa20-11eb-816a-eb62b0d8fc49.png)

### Pro Micro, optimized the reading procedure using 'readPort()'.
* Processing time for Row0: 12.8us

![DS1Z_QuickPrint37](https://user-images.githubusercontent.com/2170248/116728184-91fec380-aa20-11eb-9e59-5114035cbc78.png)

### Proton C, current matrix.c  (MATRIX_IO_DELAY=0)
* Processing time for Row0: 14.2us

![DS1Z_QuickPrint39](https://user-images.githubusercontent.com/2170248/116728214-9925d180-aa20-11eb-8514-1eed2657f4f1.png)

### Proton C, optimized the reading procedure using 'readPort()'.
* Processing time for Row0: 9.2us

![DS1Z_QuickPrint40](https://user-images.githubusercontent.com/2170248/116728227-9d51ef00-aa20-11eb-916d-5f6231f3f24f.png)

</details>

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
