### PR TITLE
[Keymap] ANAVI Macro Pad 2 add MS Teams keymap

### DIFF
--- a/keyboards/anavi/macropad2/keymaps/msteams/keymap.c
+++ b/keyboards/anavi/macropad2/keymaps/msteams/keymap.c
@@ -1,0 +1,41 @@
+/* Copyright 2021 Leon Anavi <leon@anavi.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include QMK_KEYBOARD_H
+
+/*
+ * This keymap contains the following shortcuts for Microsoft Teams
+ * on MS Windows and GNU/Linux distributions:
+ *
+ * Ctrl+Shift+M: Toggle mute
+ * Ctrl+Shift+O: Toggle video (doesn't work in a web browser)
+ *
+ * NOTE: Mac users should replace Ctrl with Command in all
+ * shortcuts
+ */
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  [0] = LAYOUT(
+    LCTL(LSFT(KC_M)),  LCTL(LSFT(KC_O))
+  )
+};
+
+const uint16_t PROGMEM test_combo[] = {LCTL(LSFT(KC_M)), LCTL(LSFT(KC_O)), COMBO_END};
+combo_t key_combos[COMBO_COUNT] = {COMBO_ACTION(test_combo)};
+
+void process_combo_event(uint16_t combo_index, bool pressed) {
+	backlight_step();
+}

--- a/keyboards/anavi/macropad2/keymaps/msteams/rules.mk
+++ b/keyboards/anavi/macropad2/keymaps/msteams/rules.mk
@@ -1,0 +1,1 @@
+COMBO_ENABLE = yes


### PR DESCRIPTION
This keymap contains the following shortcuts for Microsoft Teams
on MS Windows and GNU/Linux distributions:

- Ctrl+Shift+M: Toggle mute
- Ctrl+Shift+O: Toggle video (doesn't work in a web browser)

NOTE: Mac users should replace Ctrl with Command in all shortcuts

Signed-off-by: Leon Anavi <leon@anavi.org>

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

This keymap contains the following shortcuts for Microsoft Teams
on MS Windows and GNU/Linux distributions:

- Ctrl+Shift+M: Toggle mute
- Ctrl+Shift+O: Toggle video (doesn't work in a web browser)

NOTE: Mac users should replace Ctrl with Command in all shortcuts

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
