### PR TITLE
Add RGB matrix support for Kyria

### DIFF
--- a/keyboards/splitkb/kyria/rev1/config.h
+++ b/keyboards/splitkb/kyria/rev1/config.h
@@ -79,7 +79,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    define DRIVER_LED_TOTAL RGBLED_NUM // Number of LEDs
 #    define RGB_MATRIX_SPLIT { 10, 10 }
 #    define RGB_MATRIX_MAXIMUM_BRIGHTNESS 170
-#    ifndef RGB_DISABLE_WHEN_USB_SUSPENDED
-#        define RGB_DISABLE_WHEN_USB_SUSPENDED true
-#    endif
+#    define RGB_DISABLE_WHEN_USB_SUSPENDED
 #endif

--- a/keyboards/splitkb/kyria/rev1/config.h
+++ b/keyboards/splitkb/kyria/rev1/config.h
@@ -72,3 +72,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifdef OLED_DRIVER_ENABLE
 #    define OLED_DISPLAY_128X64
 #endif
+
+/* RGB matrix support */
+#ifdef RGB_MATRIX_ENABLE
+#    define SPLIT_TRANSPORT_MIRROR
+#    define DRIVER_LED_TOTAL RGBLED_NUM // Number of LEDs
+#    define RGB_MATRIX_SPLIT { 10, 10 }
+#    define RGB_MATRIX_MAXIMUM_BRIGHTNESS 170
+#    ifndef RGB_DISABLE_WHEN_USB_SUSPENDED
+#        define RGB_DISABLE_WHEN_USB_SUSPENDED true
+#    endif
+#endif

--- a/keyboards/splitkb/kyria/rev1/rev1.c
+++ b/keyboards/splitkb/kyria/rev1/rev1.c
@@ -30,6 +30,31 @@ __attribute__ ((weak)) const keypos_t PROGMEM hand_swap_config[MATRIX_ROWS][MATR
 // clang-format on
 #endif
 
+#ifdef RGB_MATRIX_ENABLE
+/* Map physical under glow LEDs for RGB matrix support */
+led_config_t g_led_config = { {
+    // Key Matrix to LED Index
+    { NO_LED, NO_LED, NO_LED, 4,      NO_LED, NO_LED, 5,      9     },
+    { NO_LED, NO_LED, 3,      NO_LED, NO_LED, NO_LED, NO_LED, NO_LED },
+    { NO_LED, 0,      NO_LED, NO_LED, NO_LED, 7,      6,      8      },
+    { NO_LED, NO_LED, 1,      2,      NO_LED, NO_LED, NO_LED, NO_LED },
+    { NO_LED, NO_LED, NO_LED, 14,     NO_LED, NO_LED, 15,     19     },
+    { NO_LED, NO_LED, 13,     NO_LED, NO_LED, NO_LED, NO_LED, NO_LED },
+    { NO_LED, 10,     NO_LED, NO_LED, NO_LED, 17,     16,     18     },
+    { NO_LED, NO_LED, 11,     12,     NO_LED, NO_LED, NO_LED, NO_LED },
+}, {
+    // LED Index to Physical Position
+    {91,40}, {77,56}, {63,56}, {77,24}, {63,8}, {21,8}, {21,40}, {35,40}, {7,40}, {7,8},
+    {133,40}, {147,56}, {161,56}, {147,24}, {161,8}, {203,8}, {203,40}, {189,40}, {217,40}, {217,8}
+}, {
+    // LED Index to Flag
+    LED_FLAG_ALL, LED_FLAG_ALL, LED_FLAG_ALL, LED_FLAG_ALL, LED_FLAG_ALL,
+    LED_FLAG_ALL, LED_FLAG_ALL, LED_FLAG_ALL, LED_FLAG_ALL, LED_FLAG_ALL,
+    LED_FLAG_ALL, LED_FLAG_ALL, LED_FLAG_ALL, LED_FLAG_ALL, LED_FLAG_ALL,
+    LED_FLAG_ALL, LED_FLAG_ALL, LED_FLAG_ALL, LED_FLAG_ALL, LED_FLAG_ALL
+} };
+#endif
+
 #ifdef OLED_DRIVER_ENABLE
 __attribute__((weak)) oled_rotation_t oled_init_user(oled_rotation_t rotation) { return OLED_ROTATION_180; }
 

--- a/keyboards/splitkb/kyria/rev1/rules.mk
+++ b/keyboards/splitkb/kyria/rev1/rules.mk
@@ -1,3 +1,5 @@
 OLED_DRIVER_ENABLE = yes   # Enables the use of OLED displays
 ENCODER_ENABLE = yes       # ENables the use of one or more encoders
 RGBLIGHT_ENABLE = yes      # Enable keyboard RGB underglow
+RGB_MATRIX_ENABLE = no     # Enable keyboard RGB matrix (do not use together with RGBLIGHT_ENABLE)
+RGB_MATRIX_DRIVER = WS2812 # RGB matrix driver support

--- a/keyboards/splitkb/kyria/rev1/rules.mk
+++ b/keyboards/splitkb/kyria/rev1/rules.mk
@@ -3,3 +3,5 @@ ENCODER_ENABLE = yes       # ENables the use of one or more encoders
 RGBLIGHT_ENABLE = yes      # Enable keyboard RGB underglow
 RGB_MATRIX_ENABLE = no     # Enable keyboard RGB matrix (do not use together with RGBLIGHT_ENABLE)
 RGB_MATRIX_DRIVER = WS2812 # RGB matrix driver support
+
+RGB_MATRIX_SUPPORTED = yes


### PR DESCRIPTION
## Description

This change adds `g_led_config` struct to Kyria, allowing LEDs to be addressed by `RGB_MATRIX_ENABLE` features if users enable support in their own configuration.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
