### PR TITLE
VIA support with top facing LEDs and underglow

### DIFF
--- a/keyboards/sofle/keymaps/via/config.h
+++ b/keyboards/sofle/keymaps/via/config.h
@@ -1,19 +1,19 @@
  /* Copyright 2020 Josef Adamcik
   * Modification for VIA support and RGB underglow by Jens Bonk-Wiltfang
-  * 
-  * This program is free software: you can redistribute it and/or modify 
-  * it under the terms of the GNU General Public License as published by 
-  * the Free Software Foundation, either version 2 of the License, or 
-  * (at your option) any later version. 
-  * 
-  * This program is distributed in the hope that it will be useful, 
-  * but WITHOUT ANY WARRANTY; without even the implied warranty of 
-  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
-  * GNU General Public License for more details. 
-  * 
-  * You should have received a copy of the GNU General Public License 
-  * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
-  */ 
+  *
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 2 of the License, or
+  * (at your option) any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  */
 
 #pragma once
 
@@ -22,8 +22,16 @@ see https://docs.qmk.fm/#/feature_split_keyboard?id=setting-handedness
 for more options.
 */
 
-//Add RGB underglow
+//Add RGB underglow and top facil lighting
 #define RGB_DI_PIN D3
-#define RGBLED_NUM 14
-#define RGBLED_SPLIT {7,7}
+#ifdef RGB_MATRIX_ENABLE
+#define RGBLED_NUM 36    // Number of LEDs
+#define DRIVER_LED_TOTAL RGBLED_NUM
+#endif
+#define RGBLED_NUM 70
+#define RGBLED_SPLIT {36,36}
 #define RGBLIGHT_ANIMATIONS
+#define RGBLIGHT_LIMIT_VAL 120
+#define RGBLIGHT_HUE_STEP 10
+#define RGBLIGHT_SAT_STEP 17
+#define RGBLIGHT_VAL_STEP 17

--- a/keyboards/sofle/keymaps/via/config.h
+++ b/keyboards/sofle/keymaps/via/config.h
@@ -22,7 +22,7 @@ see https://docs.qmk.fm/#/feature_split_keyboard?id=setting-handedness
 for more options.
 */
 
-//Add RGB underglow and top facil lighting
+//Add RGB underglow and top facing lighting
 #define RGB_DI_PIN D3
 #ifdef RGB_MATRIX_ENABLE
 #define RGBLED_NUM 36    // Number of LEDs


### PR DESCRIPTION
## Description

Added VIA support for the top facing RGB LEDs on top of the existing underglow.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
