### PR TITLE
[Core] ChibiOS fix O3 and LTO breakage of extra keys and joystick

### DIFF
--- a/tmk_core/protocol/chibios/usb_main.c
+++ b/tmk_core/protocol/chibios/usb_main.c
@@ -103,7 +103,7 @@ static const USBDescriptor *usb_get_descriptor_cb(USBDriver *usbp, uint8_t dtype
     static USBDescriptor desc;
     uint16_t             wValue = ((uint16_t)dtype << 8) | dindex;
     desc.ud_string              = NULL;
-    desc.ud_size                = get_usb_descriptor(wValue, wIndex, (const void **const) & desc.ud_string);
+    desc.ud_size                = get_usb_descriptor(wValue, wIndex, (const void **const)&desc.ud_string);
     if (desc.ud_string == NULL)
         return NULL;
     else
@@ -903,7 +903,8 @@ static void send_extra(uint8_t report_id, uint16_t data) {
         return;
     }
 
-    report_extra_t report = {.report_id = report_id, .usage = data};
+    static report_extra_t report;
+    report = (report_extra_t){.report_id = report_id, .usage = data};
 
     usbStartTransmitI(&USB_DRIVER, SHARED_IN_EPNUM, (uint8_t *)&report, sizeof(report_extra_t));
     osalSysUnlock();
@@ -1051,45 +1052,44 @@ void virtser_task(void) {
 #ifdef JOYSTICK_ENABLE
 
 void send_joystick_packet(joystick_t *joystick) {
-    joystick_report_t rep = {
+    static joystick_report_t rep;
+    rep = (joystick_report_t) {
 #    if JOYSTICK_AXES_COUNT > 0
         .axes =
-            {
-                joystick->axes[0],
+        { joystick->axes[0],
 
 #        if JOYSTICK_AXES_COUNT >= 2
-                joystick->axes[1],
+          joystick->axes[1],
 #        endif
 #        if JOYSTICK_AXES_COUNT >= 3
-                joystick->axes[2],
+          joystick->axes[2],
 #        endif
 #        if JOYSTICK_AXES_COUNT >= 4
-                joystick->axes[3],
+          joystick->axes[3],
 #        endif
 #        if JOYSTICK_AXES_COUNT >= 5
-                joystick->axes[4],
+          joystick->axes[4],
 #        endif
 #        if JOYSTICK_AXES_COUNT >= 6
-                joystick->axes[5],
+          joystick->axes[5],
 #        endif
-            },
+        },
 #    endif  // JOYSTICK_AXES_COUNT>0
 
 #    if JOYSTICK_BUTTON_COUNT > 0
-        .buttons =
-            {
-                joystick->buttons[0],
+        .buttons = {
+            joystick->buttons[0],
 
 #        if JOYSTICK_BUTTON_COUNT > 8
-                joystick->buttons[1],
+            joystick->buttons[1],
 #        endif
 #        if JOYSTICK_BUTTON_COUNT > 16
-                joystick->buttons[2],
+            joystick->buttons[2],
 #        endif
 #        if JOYSTICK_BUTTON_COUNT > 24
-                joystick->buttons[3],
+            joystick->buttons[3],
 #        endif
-            }
+        }
 #    endif  // JOYSTICK_BUTTON_COUNT>0
     };
 

--- a/tmk_core/protocol/chibios/usb_main.c
+++ b/tmk_core/protocol/chibios/usb_main.c
@@ -103,7 +103,7 @@ static const USBDescriptor *usb_get_descriptor_cb(USBDriver *usbp, uint8_t dtype
     static USBDescriptor desc;
     uint16_t             wValue = ((uint16_t)dtype << 8) | dindex;
     desc.ud_string              = NULL;
-    desc.ud_size                = get_usb_descriptor(wValue, wIndex, (const void **const)&desc.ud_string);
+    desc.ud_size                = get_usb_descriptor(wValue, wIndex, (const void **const) & desc.ud_string);
     if (desc.ud_string == NULL)
         return NULL;
     else

--- a/tmk_core/protocol/lufa/lufa.c
+++ b/tmk_core/protocol/lufa/lufa.c
@@ -314,45 +314,44 @@ static void Console_Task(void) {
 void send_joystick_packet(joystick_t *joystick) {
     uint8_t timeout = 255;
 
-    joystick_report_t r = {
+    static joystick_report_t;
+    r = (joystick_report_t) {
 #    if JOYSTICK_AXES_COUNT > 0
         .axes =
-            {
-                joystick->axes[0],
+        { joystick->axes[0],
 
 #        if JOYSTICK_AXES_COUNT >= 2
-                joystick->axes[1],
+          joystick->axes[1],
 #        endif
 #        if JOYSTICK_AXES_COUNT >= 3
-                joystick->axes[2],
+          joystick->axes[2],
 #        endif
 #        if JOYSTICK_AXES_COUNT >= 4
-                joystick->axes[3],
+          joystick->axes[3],
 #        endif
 #        if JOYSTICK_AXES_COUNT >= 5
-                joystick->axes[4],
+          joystick->axes[4],
 #        endif
 #        if JOYSTICK_AXES_COUNT >= 6
-                joystick->axes[5],
+          joystick->axes[5],
 #        endif
-            },
+        },
 #    endif  // JOYSTICK_AXES_COUNT>0
 
 #    if JOYSTICK_BUTTON_COUNT > 0
-        .buttons =
-            {
-                joystick->buttons[0],
+        .buttons = {
+            joystick->buttons[0],
 
 #        if JOYSTICK_BUTTON_COUNT > 8
-                joystick->buttons[1],
+            joystick->buttons[1],
 #        endif
 #        if JOYSTICK_BUTTON_COUNT > 16
-                joystick->buttons[2],
+            joystick->buttons[2],
 #        endif
 #        if JOYSTICK_BUTTON_COUNT > 24
-                joystick->buttons[3],
+            joystick->buttons[3],
 #        endif
-            }
+        }
 #    endif  // JOYSTICK_BUTTON_COUNT>0
     };
 
@@ -768,7 +767,8 @@ static void send_extra(uint8_t report_id, uint16_t data) {
 
     if (USB_DeviceState != DEVICE_STATE_Configured) return;
 
-    report_extra_t r = {.report_id = report_id, .usage = data};
+    static report_extra_t r;
+    r = (report_extra_t) {.report_id = report_id, .usage = data};
     Endpoint_SelectEndpoint(SHARED_IN_EPNUM);
 
     /* Check if write ready for a polling interval around 10ms */

--- a/tmk_core/protocol/lufa/lufa.c
+++ b/tmk_core/protocol/lufa/lufa.c
@@ -768,7 +768,7 @@ static void send_extra(uint8_t report_id, uint16_t data) {
     if (USB_DeviceState != DEVICE_STATE_Configured) return;
 
     static report_extra_t r;
-    r = (report_extra_t) {.report_id = report_id, .usage = data};
+    r = (report_extra_t){.report_id = report_id, .usage = data};
     Endpoint_SelectEndpoint(SHARED_IN_EPNUM);
 
     /* Check if write ready for a polling interval around 10ms */

--- a/tmk_core/protocol/vusb/vusb.c
+++ b/tmk_core/protocol/vusb/vusb.c
@@ -272,7 +272,8 @@ static void send_extra(uint8_t report_id, uint16_t data) {
     last_id   = report_id;
     last_data = data;
 
-    report_extra_t report = {.report_id = report_id, .usage = data};
+    static report_extra_t report;
+    report = (report_extra_t){.report_id = report_id, .usage = data};
     if (usbInterruptIsReadyShared()) {
         usbSetInterruptShared((void *)&report, sizeof(report_extra_t));
     }


### PR DESCRIPTION
## Description

Empty extra key reports where send (observed with Wireshark) form the keyboard when O3 optimizations with LTO where enabled on GCC 10.2 (RISC-V). The root cause should be the pointer to an stack allocated report object which is invalid by the time the report is send. The fix is simple enough, the reports are allocated with a static lifetime, so pointers to them are never invalid. Joystick reports got the same treatment as the pattern is exactly the same.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* ?

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
