### PR TITLE
Add support for sync_timer over serial_link (i.e. Ergodox Infinity).

### DIFF
--- a/quantum/serial_link/system/serial_link.c
+++ b/quantum/serial_link/system/serial_link.c
@@ -29,9 +29,12 @@ SOFTWARE.
 #include "serial_link/protocol/transport.h"
 #include "serial_link/protocol/frame_router.h"
 #include "matrix.h"
+#include "sync_timer.h"
 #include <stdbool.h>
 #include "print.h"
 #include "config.h"
+
+#define SYNC_TIMER_OFFSET 2
 
 static event_source_t new_data_event;
 static bool           serial_link_connected;
@@ -159,10 +162,16 @@ static matrix_object_t last_matrix = {};
 
 SLAVE_TO_MASTER_OBJECT(keyboard_matrix, matrix_object_t);
 MASTER_TO_ALL_SLAVES_OBJECT(serial_link_connected, bool);
+#ifndef DISABLE_SYNC_TIMER
+MASTER_TO_ALL_SLAVES_OBJECT(sync_timer, uint32_t);
+#endif
 
 static remote_object_t* remote_objects[] = {
     REMOTE_OBJECT(serial_link_connected),
     REMOTE_OBJECT(keyboard_matrix),
+#ifndef DISABLE_SYNC_TIMER
+    REMOTE_OBJECT(sync_timer),
+#endif
 };
 
 void init_serial_link(void) {
@@ -200,14 +209,27 @@ void serial_link_update(void) {
             m->rows[i] = matrix.rows[i];
         }
         end_write_keyboard_matrix();
+
         *begin_write_serial_link_connected() = true;
         end_write_serial_link_connected();
+
+#ifndef DISABLE_SYNC_TIMER
+        *begin_write_sync_timer() = sync_timer_read32() + SYNC_TIMER_OFFSET;
+        end_write_sync_timer();
+#endif
     }
 
     matrix_object_t* m = read_keyboard_matrix(0);
     if (m) {
         matrix_set_remote(m->rows, 0);
     }
+
+#ifndef DISABLE_SYNC_TIMER
+    uint32_t* t = read_sync_timer();
+    if (t) {
+        sync_timer_update(*t);
+    }
+#endif
 }
 
 void signal_data_written(void) { chEvtBroadcast(&new_data_event); }

--- a/tmk_core/common/sync_timer.c
+++ b/tmk_core/common/sync_timer.c
@@ -26,7 +26,7 @@ SOFTWARE.
 #include "sync_timer.h"
 #include "keyboard.h"
 
-#if defined(SPLIT_KEYBOARD) && !defined(DISABLE_SYNC_TIMER)
+#if (defined(SPLIT_KEYBOARD) || defined(SERIAL_LINK_ENABLE)) && !defined(DISABLE_SYNC_TIMER)
 volatile int32_t sync_timer_ms;
 
 void sync_timer_init(void) { sync_timer_ms = 0; }

--- a/tmk_core/common/sync_timer.h
+++ b/tmk_core/common/sync_timer.h
@@ -32,7 +32,7 @@ SOFTWARE.
 extern "C" {
 #endif
 
-#if defined(SPLIT_KEYBOARD) && !defined(DISABLE_SYNC_TIMER)
+#if (defined(SPLIT_KEYBOARD) || defined(SERIAL_LINK_ENABLE)) && !defined(DISABLE_SYNC_TIMER)
 void     sync_timer_init(void);
 void     sync_timer_update(uint32_t time);
 uint16_t sync_timer_read(void);


### PR DESCRIPTION
Add ability to sync the sync_timer over the serial_link system used by Ergodox Infinity.

More or less just a port from split_common/transport.c and some tweaked `#if`s in sync_timer.[ch].

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
