### PR TITLE
CLI: Use BASH if SHELL variable is not set (Windows)

### DIFF
--- a/lib/python/qmk/commands.py
+++ b/lib/python/qmk/commands.py
@@ -238,6 +238,6 @@ def run(command, *args, **kwargs):
         safecmd = map(str, command)
         safecmd = map(shlex.quote, safecmd)
         safecmd = ' '.join(safecmd)
-        command = [os.environ['SHELL'], '-c', safecmd]
+        command = [os.environ.get('SHELL', '/usr/bin/bash'), '-c', safecmd]
 
     return subprocess.run(command, *args, **kwargs)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

It's possible that the `$SHELL` env var is not set in MSYS so instead of erroring out, fall back to BASH.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
