### PR TITLE
Update Python dependencies for Nix

### DIFF
--- a/nix/poetry.lock
+++ b/nix/poetry.lock
@@ -43,7 +43,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 name = "coverage"
 version = "5.5"
 description = "Code coverage measurement for Python"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 
@@ -65,7 +65,7 @@ setuptools_scm = "*"
 name = "flake8"
 version = "3.9.0"
 description = "the modular source code checker: pep8 pyflakes and co"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
@@ -89,7 +89,7 @@ flake8 = "*"
 name = "hid"
 version = "1.0.4"
 description = "ctypes bindings for hidapi"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -122,7 +122,7 @@ format_nongpl = ["idna", "jsonpointer (>1.13)", "webcolors", "rfc3986-validator 
 name = "mccabe"
 version = "0.6.1"
 description = "McCabe checker, plugin for flake8"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -143,7 +143,7 @@ colorama = "*"
 name = "nose2"
 version = "0.10.0"
 description = "unittest2 with plugins, the succesor to nose"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -170,7 +170,7 @@ flake8-polyfill = ">=1.0.2,<2"
 name = "pycodestyle"
 version = "2.7.0"
 description = "Python style guide checker"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
@@ -178,7 +178,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 name = "pyflakes"
 version = "2.3.1"
 description = "passive checker of Python programs"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
@@ -202,9 +202,32 @@ python-versions = ">=3.5"
 name = "pyusb"
 version = "1.1.1"
 description = "Python USB access module"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "qmk"
+version = "0.0.46"
+description = "A program to help users work with QMK Firmware."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+appdirs = "*"
+argcomplete = "*"
+colorama = "*"
+dotty-dict = "*"
+flake8 = "*"
+hid = "*"
+hjson = "*"
+jsonschema = ">=3"
+milc = ">=1.3.0"
+nose2 = "*"
+pygments = "*"
+pyusb = "*"
+yapf = "*"
 
 [[package]]
 name = "setuptools-scm"
@@ -229,14 +252,14 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 name = "yapf"
 version = "0.30.0"
 description = "A formatter for Python code."
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "a25336474bfc7ca01f208b95d529c1e5d8c82c732e1609ace4931006869ad3e8"
+content-hash = "017e7af8ce07821faa9aacd1fd04010a138a730bdebf93d80fa2d2123dc1ca5c"
 
 [metadata.files]
 appdirs = [
@@ -366,6 +389,10 @@ pyrsistent = [
 pyusb = [
     {file = "pyusb-1.1.1-py3-none-any.whl", hash = "sha256:f18eb813d3a1439918071234589162c2f209a19adbeffeb1377ce078a4aebc70"},
     {file = "pyusb-1.1.1.tar.gz", hash = "sha256:7d449ad916ce58aff60b89aae0b65ac130f289c24d6a5b7b317742eccffafc38"},
+]
+qmk = [
+    {file = "qmk-0.0.46-py2.py3-none-any.whl", hash = "sha256:55fb1145fa768ff28d2ad3c7d69432cbaea57b38977e3d20df6938e9d09328bd"},
+    {file = "qmk-0.0.46.tar.gz", hash = "sha256:f7a79ee258f7ce5111fbb019d36d85b007d83c1fda3ae54c68c5c03b0685aa2e"},
 ]
 setuptools-scm = [
     {file = "setuptools_scm-6.0.1-py3-none-any.whl", hash = "sha256:c3bd5f701c8def44a5c0bfe8d407bef3f80342217ef3492b951f3777bd2d915c"},

--- a/nix/poetry.lock
+++ b/nix/poetry.lock
@@ -86,6 +86,14 @@ python-versions = "*"
 flake8 = "*"
 
 [[package]]
+name = "hid"
+version = "1.0.4"
+description = "ctypes bindings for hidapi"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "hjson"
 version = "3.0.2"
 description = "Hjson, a user interface for JSON."
@@ -191,6 +199,14 @@ optional = false
 python-versions = ">=3.5"
 
 [[package]]
+name = "pyusb"
+version = "1.1.1"
+description = "Python USB access module"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "setuptools-scm"
 version = "6.0.1"
 description = "the blessed package to manage your versions by scm tags"
@@ -220,7 +236,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "d2f4ca3786330f60ee0964457e35e683f5babec8ce6fd61fcaf648a128fd805b"
+content-hash = "a25336474bfc7ca01f208b95d529c1e5d8c82c732e1609ace4931006869ad3e8"
 
 [metadata.files]
 appdirs = [
@@ -304,6 +320,10 @@ flake8-polyfill = [
     {file = "flake8-polyfill-1.0.2.tar.gz", hash = "sha256:e44b087597f6da52ec6393a709e7108b2905317d0c0b744cdca6208e670d8eda"},
     {file = "flake8_polyfill-1.0.2-py2.py3-none-any.whl", hash = "sha256:12be6a34ee3ab795b19ca73505e7b55826d5f6ad7230d31b18e106400169b9e9"},
 ]
+hid = [
+    {file = "hid-1.0.4-py2-none-any.whl", hash = "sha256:fba9913f07030b01059b822b24c83b370ca3f444e9e6443bd662f9f1aa3f0780"},
+    {file = "hid-1.0.4.tar.gz", hash = "sha256:f61b0382f37a334bc8ba8604bc84b94875ee4f594fbbaf82b2c3b3e827883fc1"},
+]
 hjson = [
     {file = "hjson-3.0.2-py3-none-any.whl", hash = "sha256:5546438bf4e1b52bc964c6a47c4ed10fa5fba8a1b264e22efa893e333baad2db"},
     {file = "hjson-3.0.2.tar.gz", hash = "sha256:2838fd7200e5839ea4516ece953f3a19892c41089f0d933ba3f68e596aacfcd5"},
@@ -342,6 +362,10 @@ pygments = [
 ]
 pyrsistent = [
     {file = "pyrsistent-0.17.3.tar.gz", hash = "sha256:2e636185d9eb976a18a8a8e96efce62f2905fea90041958d8cc2a189756ebf3e"},
+]
+pyusb = [
+    {file = "pyusb-1.1.1-py3-none-any.whl", hash = "sha256:f18eb813d3a1439918071234589162c2f209a19adbeffeb1377ce078a4aebc70"},
+    {file = "pyusb-1.1.1.tar.gz", hash = "sha256:7d449ad916ce58aff60b89aae0b65ac130f289c24d6a5b7b317742eccffafc38"},
 ]
 setuptools-scm = [
     {file = "setuptools_scm-6.0.1-py3-none-any.whl", hash = "sha256:c3bd5f701c8def44a5c0bfe8d407bef3f80342217ef3492b951f3777bd2d915c"},

--- a/nix/poetry.lock
+++ b/nix/poetry.lock
@@ -210,14 +210,6 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
-name = "wave"
-version = "0.0.2"
-description = "Whole Architecture Verification"
-category = "dev"
-optional = false
-python-versions = "*"
-
-[[package]]
 name = "yapf"
 version = "0.30.0"
 description = "A formatter for Python code."
@@ -228,7 +220,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "a0a964993829a7d61577278b96432145084833de06275e0cd4688e2d8cd340a7"
+content-hash = "d2f4ca3786330f60ee0964457e35e683f5babec8ce6fd61fcaf648a128fd805b"
 
 [metadata.files]
 appdirs = [
@@ -358,10 +350,6 @@ setuptools-scm = [
 six = [
     {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
     {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
-]
-wave = [
-    {file = "Wave-0.0.2.tar.gz", hash = "sha256:5a895bb85e04e38c82dba90d66a5ae8f488b50c58f3fc4df868a5bcdcabb8632"},
-    {file = "Wave-0.0.2.zip", hash = "sha256:5187f49497287d218cc83d4cd1e5299dc31485ab3ed32abbaa9e95d8f73c4095"},
 ]
 yapf = [
     {file = "yapf-0.30.0-py2.py3-none-any.whl", hash = "sha256:3abf61ba67cf603069710d30acbc88cfe565d907e16ad81429ae90ce9651e0c9"},

--- a/nix/poetry.lock
+++ b/nix/poetry.lock
@@ -228,7 +228,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "6adb87c61d9eacf55e4e80bc6c73325e4e4854a792e3881ff448b6ee1cb75091"
+content-hash = "a0a964993829a7d61577278b96432145084833de06275e0cd4688e2d8cd340a7"
 
 [metadata.files]
 appdirs = [

--- a/nix/poetry.lock
+++ b/nix/poetry.lock
@@ -8,7 +8,7 @@ python-versions = "*"
 
 [[package]]
 name = "argcomplete"
-version = "1.12.2"
+version = "1.12.3"
 description = "Bash tab completion for argparse"
 category = "main"
 optional = false
@@ -19,17 +19,17 @@ test = ["coverage", "flake8", "pexpect", "wheel"]
 
 [[package]]
 name = "attrs"
-version = "20.3.0"
+version = "21.2.0"
 description = "Classes Without Boilerplate"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "furo", "sphinx", "pre-commit"]
-docs = ["furo", "sphinx", "zope.interface"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
-tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit"]
+docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins"]
 
 [[package]]
 name = "colorama"
@@ -63,7 +63,7 @@ setuptools_scm = "*"
 
 [[package]]
 name = "flake8"
-version = "3.9.0"
+version = "3.9.2"
 description = "the modular source code checker: pep8 pyflakes and co"
 category = "main"
 optional = false
@@ -184,7 +184,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pygments"
-version = "2.8.1"
+version = "2.9.0"
 description = "Pygments is a syntax highlighting package written in Python."
 category = "main"
 optional = false
@@ -208,7 +208,7 @@ python-versions = "*"
 
 [[package]]
 name = "qmk"
-version = "0.0.46"
+version = "0.0.48"
 description = "A program to help users work with QMK Firmware."
 category = "main"
 optional = false
@@ -242,7 +242,7 @@ toml = ["toml"]
 
 [[package]]
 name = "six"
-version = "1.15.0"
+version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
 category = "main"
 optional = false
@@ -259,7 +259,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "017e7af8ce07821faa9aacd1fd04010a138a730bdebf93d80fa2d2123dc1ca5c"
+content-hash = "5e181d51536240d08c74ba6a46bd0988ee4ca72ac3d5b388965ca8023e9b9a99"
 
 [metadata.files]
 appdirs = [
@@ -267,12 +267,12 @@ appdirs = [
     {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
 ]
 argcomplete = [
-    {file = "argcomplete-1.12.2-py2.py3-none-any.whl", hash = "sha256:17f01a9b9b9ece3e6b07058eae737ad6e10de8b4e149105f84614783913aba71"},
-    {file = "argcomplete-1.12.2.tar.gz", hash = "sha256:de0e1282330940d52ea92a80fea2e4b9e0da1932aaa570f84d268939d1897b04"},
+    {file = "argcomplete-1.12.3-py2.py3-none-any.whl", hash = "sha256:291f0beca7fd49ce285d2f10e4c1c77e9460cf823eef2de54df0c0fec88b0d81"},
+    {file = "argcomplete-1.12.3.tar.gz", hash = "sha256:2c7dbffd8c045ea534921e63b0be6fe65e88599990d8dc408ac8c542b72a5445"},
 ]
 attrs = [
-    {file = "attrs-20.3.0-py2.py3-none-any.whl", hash = "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6"},
-    {file = "attrs-20.3.0.tar.gz", hash = "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"},
+    {file = "attrs-21.2.0-py2.py3-none-any.whl", hash = "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1"},
+    {file = "attrs-21.2.0.tar.gz", hash = "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"},
 ]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
@@ -336,8 +336,8 @@ dotty-dict = [
     {file = "dotty_dict-1.3.0.tar.gz", hash = "sha256:eb0035a3629ecd84397a68f1f42f1e94abd1c34577a19cd3eacad331ee7cbaf0"},
 ]
 flake8 = [
-    {file = "flake8-3.9.0-py2.py3-none-any.whl", hash = "sha256:12d05ab02614b6aee8df7c36b97d1a3b2372761222b19b58621355e82acddcff"},
-    {file = "flake8-3.9.0.tar.gz", hash = "sha256:78873e372b12b093da7b5e5ed302e8ad9e988b38b063b61ad937f26ca58fc5f0"},
+    {file = "flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"},
+    {file = "flake8-3.9.2.tar.gz", hash = "sha256:07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b"},
 ]
 flake8-polyfill = [
     {file = "flake8-polyfill-1.0.2.tar.gz", hash = "sha256:e44b087597f6da52ec6393a709e7108b2905317d0c0b744cdca6208e670d8eda"},
@@ -380,8 +380,8 @@ pyflakes = [
     {file = "pyflakes-2.3.1.tar.gz", hash = "sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db"},
 ]
 pygments = [
-    {file = "Pygments-2.8.1-py3-none-any.whl", hash = "sha256:534ef71d539ae97d4c3a4cf7d6f110f214b0e687e92f9cb9d2a3b0d3101289c8"},
-    {file = "Pygments-2.8.1.tar.gz", hash = "sha256:2656e1a6edcdabf4275f9a3640db59fd5de107d88e8663c5d4e9a0fa62f77f94"},
+    {file = "Pygments-2.9.0-py3-none-any.whl", hash = "sha256:d66e804411278594d764fc69ec36ec13d9ae9147193a1740cd34d272ca383b8e"},
+    {file = "Pygments-2.9.0.tar.gz", hash = "sha256:a18f47b506a429f6f4b9df81bb02beab9ca21d0a5fee38ed15aef65f0545519f"},
 ]
 pyrsistent = [
     {file = "pyrsistent-0.17.3.tar.gz", hash = "sha256:2e636185d9eb976a18a8a8e96efce62f2905fea90041958d8cc2a189756ebf3e"},
@@ -391,16 +391,16 @@ pyusb = [
     {file = "pyusb-1.1.1.tar.gz", hash = "sha256:7d449ad916ce58aff60b89aae0b65ac130f289c24d6a5b7b317742eccffafc38"},
 ]
 qmk = [
-    {file = "qmk-0.0.46-py2.py3-none-any.whl", hash = "sha256:55fb1145fa768ff28d2ad3c7d69432cbaea57b38977e3d20df6938e9d09328bd"},
-    {file = "qmk-0.0.46.tar.gz", hash = "sha256:f7a79ee258f7ce5111fbb019d36d85b007d83c1fda3ae54c68c5c03b0685aa2e"},
+    {file = "qmk-0.0.48-py2.py3-none-any.whl", hash = "sha256:414901c4cede03d1864f60e7d35d3d0d4c8f917706db47a3d18638c9b55838a5"},
+    {file = "qmk-0.0.48.tar.gz", hash = "sha256:3ca801d295bef68c5e51cdee68e5871d61b1a2bc75d40a13de1cacad3c7a482f"},
 ]
 setuptools-scm = [
     {file = "setuptools_scm-6.0.1-py3-none-any.whl", hash = "sha256:c3bd5f701c8def44a5c0bfe8d407bef3f80342217ef3492b951f3777bd2d915c"},
     {file = "setuptools_scm-6.0.1.tar.gz", hash = "sha256:d1925a69cb07e9b29416a275b9fadb009a23c148ace905b2fb220649a6c18e92"},
 ]
 six = [
-    {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
-    {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
 ]
 yapf = [
     {file = "yapf-0.30.0-py2.py3-none-any.whl", hash = "sha256:3abf61ba67cf603069710d30acbc88cfe565d907e16ad81429ae90ce9651e0c9"},

--- a/nix/poetry.lock
+++ b/nix/poetry.lock
@@ -86,6 +86,24 @@ python-versions = "*"
 flake8 = "*"
 
 [[package]]
+name = "halo"
+version = "0.0.31"
+description = "Beautiful terminal spinners in Python"
+category = "main"
+optional = false
+python-versions = ">=3.4"
+
+[package.dependencies]
+colorama = ">=0.3.9"
+log-symbols = ">=0.0.14"
+six = ">=1.12.0"
+spinners = ">=0.0.24"
+termcolor = ">=1.1.0"
+
+[package.extras]
+ipython = ["IPython (==5.7.0)", "ipywidgets (==7.1.0)"]
+
+[[package]]
 name = "hid"
 version = "1.0.4"
 description = "ctypes bindings for hidapi"
@@ -119,6 +137,17 @@ format = ["idna", "jsonpointer (>1.13)", "rfc3987", "strict-rfc3339", "webcolors
 format_nongpl = ["idna", "jsonpointer (>1.13)", "webcolors", "rfc3986-validator (>0.1.0)", "rfc3339-validator"]
 
 [[package]]
+name = "log-symbols"
+version = "0.0.14"
+description = "Colored symbols for various log levels for Python"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+colorama = ">=0.3.9"
+
+[[package]]
 name = "mccabe"
 version = "0.6.1"
 description = "McCabe checker, plugin for flake8"
@@ -128,7 +157,7 @@ python-versions = "*"
 
 [[package]]
 name = "milc"
-version = "1.3.0"
+version = "1.4.2"
 description = "Opinionated Batteries-Included Python 3 CLI Framework."
 category = "main"
 optional = false
@@ -138,6 +167,8 @@ python-versions = "*"
 appdirs = "*"
 argcomplete = "*"
 colorama = "*"
+halo = "*"
+spinners = "*"
 
 [[package]]
 name = "nose2"
@@ -208,22 +239,19 @@ python-versions = "*"
 
 [[package]]
 name = "qmk"
-version = "0.0.48"
+version = "0.0.51"
 description = "A program to help users work with QMK Firmware."
 category = "main"
 optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
-appdirs = "*"
-argcomplete = "*"
-colorama = "*"
 dotty-dict = "*"
 flake8 = "*"
 hid = "*"
 hjson = "*"
 jsonschema = ">=3"
-milc = ">=1.3.0"
+milc = ">=1.4.0"
 nose2 = "*"
 pygments = "*"
 pyusb = "*"
@@ -247,6 +275,22 @@ description = "Python 2 and 3 compatibility utilities"
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "spinners"
+version = "0.0.24"
+description = "Spinners for terminals"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "termcolor"
+version = "1.1.0"
+description = "ANSII Color formatting for output in terminal."
+category = "main"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "yapf"
@@ -343,6 +387,10 @@ flake8-polyfill = [
     {file = "flake8-polyfill-1.0.2.tar.gz", hash = "sha256:e44b087597f6da52ec6393a709e7108b2905317d0c0b744cdca6208e670d8eda"},
     {file = "flake8_polyfill-1.0.2-py2.py3-none-any.whl", hash = "sha256:12be6a34ee3ab795b19ca73505e7b55826d5f6ad7230d31b18e106400169b9e9"},
 ]
+halo = [
+    {file = "halo-0.0.31-py2-none-any.whl", hash = "sha256:5350488fb7d2aa7c31a1344120cee67a872901ce8858f60da7946cef96c208ab"},
+    {file = "halo-0.0.31.tar.gz", hash = "sha256:7b67a3521ee91d53b7152d4ee3452811e1d2a6321975137762eb3d70063cc9d6"},
+]
 hid = [
     {file = "hid-1.0.4-py2-none-any.whl", hash = "sha256:fba9913f07030b01059b822b24c83b370ca3f444e9e6443bd662f9f1aa3f0780"},
     {file = "hid-1.0.4.tar.gz", hash = "sha256:f61b0382f37a334bc8ba8604bc84b94875ee4f594fbbaf82b2c3b3e827883fc1"},
@@ -355,13 +403,17 @@ jsonschema = [
     {file = "jsonschema-3.2.0-py2.py3-none-any.whl", hash = "sha256:4e5b3cf8216f577bee9ce139cbe72eca3ea4f292ec60928ff24758ce626cd163"},
     {file = "jsonschema-3.2.0.tar.gz", hash = "sha256:c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a"},
 ]
+log-symbols = [
+    {file = "log_symbols-0.0.14-py3-none-any.whl", hash = "sha256:4952106ff8b605ab7d5081dd2c7e6ca7374584eff7086f499c06edd1ce56dcca"},
+    {file = "log_symbols-0.0.14.tar.gz", hash = "sha256:cf0bbc6fe1a8e53f0d174a716bc625c4f87043cc21eb55dd8a740cfe22680556"},
+]
 mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
 milc = [
-    {file = "milc-1.3.0-py2.py3-none-any.whl", hash = "sha256:a4dd8ce77f1d4ac5e08311eecc6954c349d4032d7ed4e0335822e09740514f22"},
-    {file = "milc-1.3.0.tar.gz", hash = "sha256:a9d0299aaaef7a3f00010589c3c0d0669798467e397580620a68e9290b36cdda"},
+    {file = "milc-1.4.2-py2.py3-none-any.whl", hash = "sha256:65ee004caa769b1ee144b15be7908d1f623920ab6f356e5c5c95be9457aa15d8"},
+    {file = "milc-1.4.2.tar.gz", hash = "sha256:c6b2f19e3196b00a0060f8c883533e356f2054a9f81692b7b97ccee0d01626fd"},
 ]
 nose2 = [
     {file = "nose2-0.10.0-py2.py3-none-any.whl", hash = "sha256:aa620e759f2c5018d9ba041340391913e282ecebd3c392027f1575847b093ec6"},
@@ -391,8 +443,8 @@ pyusb = [
     {file = "pyusb-1.1.1.tar.gz", hash = "sha256:7d449ad916ce58aff60b89aae0b65ac130f289c24d6a5b7b317742eccffafc38"},
 ]
 qmk = [
-    {file = "qmk-0.0.48-py2.py3-none-any.whl", hash = "sha256:414901c4cede03d1864f60e7d35d3d0d4c8f917706db47a3d18638c9b55838a5"},
-    {file = "qmk-0.0.48.tar.gz", hash = "sha256:3ca801d295bef68c5e51cdee68e5871d61b1a2bc75d40a13de1cacad3c7a482f"},
+    {file = "qmk-0.0.51-py2.py3-none-any.whl", hash = "sha256:5f676f389b2450b0956d7eb8e7e378d2e6690d5859a887c91876da0a5faf75ed"},
+    {file = "qmk-0.0.51.tar.gz", hash = "sha256:efeef209cde1df92b9823db686d9684962cd00aae9f45ba5e3d494aa5b3c6b9a"},
 ]
 setuptools-scm = [
     {file = "setuptools_scm-6.0.1-py3-none-any.whl", hash = "sha256:c3bd5f701c8def44a5c0bfe8d407bef3f80342217ef3492b951f3777bd2d915c"},
@@ -401,6 +453,13 @@ setuptools-scm = [
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+spinners = [
+    {file = "spinners-0.0.24-py3-none-any.whl", hash = "sha256:2fa30d0b72c9650ad12bbe031c9943b8d441e41b4f5602b0ec977a19f3290e98"},
+    {file = "spinners-0.0.24.tar.gz", hash = "sha256:1eb6aeb4781d72ab42ed8a01dcf20f3002bf50740d7154d12fb8c9769bf9e27f"},
+]
+termcolor = [
+    {file = "termcolor-1.1.0.tar.gz", hash = "sha256:1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b"},
 ]
 yapf = [
     {file = "yapf-0.30.0-py2.py3-none-any.whl", hash = "sha256:3abf61ba67cf603069710d30acbc88cfe565d907e16ad81429ae90ce9651e0c9"},

--- a/nix/pyproject.toml
+++ b/nix/pyproject.toml
@@ -17,6 +17,7 @@ hjson = "^3.0.2"
 jsonschema = "^3.2.0"
 milc = "^1.3.0"
 Pygments = "^2.8.0"
+qmk = "^0.0.46"
 
 [tool.poetry.dev-dependencies]
 nose2 = "^0.10.0"

--- a/nix/pyproject.toml
+++ b/nix/pyproject.toml
@@ -15,7 +15,7 @@ colorama = "^0.4.4"
 dotty-dict = "^1.3.0"
 hjson = "^3.0.2"
 jsonschema = "^3.2.0"
-milc = "^1.1.0"
+milc = "^1.3.0"
 Pygments = "^2.8.0"
 
 [tool.poetry.dev-dependencies]

--- a/nix/pyproject.toml
+++ b/nix/pyproject.toml
@@ -12,11 +12,11 @@ python = "^3.8"
 appdirs = "^1.4.4"
 argcomplete = "^1.12.2"
 colorama = "^0.4.4"
+dotty-dict = "^1.3.0"
 hjson = "^3.0.2"
+jsonschema = "^3.2.0"
 milc = "^1.1.0"
 Pygments = "^2.8.0"
-dotty-dict = "^1.3.0"
-jsonschema = "^3.2.0"
 
 [tool.poetry.dev-dependencies]
 nose2 = "^0.10.0"

--- a/nix/pyproject.toml
+++ b/nix/pyproject.toml
@@ -21,7 +21,9 @@ Pygments = "^2.8.0"
 [tool.poetry.dev-dependencies]
 nose2 = "^0.10.0"
 flake8 = "^3.8.4"
+hid = "^1.0.4"
 pep8-naming = "^0.11.1"
+pyusb = "^1.1.1"
 yapf = "^0.30.0"
 
 [build-system]

--- a/nix/pyproject.toml
+++ b/nix/pyproject.toml
@@ -2,7 +2,7 @@
 # It is particularly required by the Nix environment (see shell.nix). To update versions,
 # normally one would run "poetry update --lock"
 [tool.poetry]
-name = "qmk"
+name = "qmk_firmware"
 version = "0.1.0"
 description = ""
 authors = []

--- a/nix/pyproject.toml
+++ b/nix/pyproject.toml
@@ -23,7 +23,6 @@ nose2 = "^0.10.0"
 flake8 = "^3.8.4"
 pep8-naming = "^0.11.1"
 yapf = "^0.30.0"
-Wave = "^0.0.2"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/nix/pyproject.toml
+++ b/nix/pyproject.toml
@@ -17,7 +17,7 @@ hjson = "^3.0.2"
 jsonschema = "^3.2.0"
 milc = "^1.3.0"
 Pygments = "^2.8.0"
-qmk = "^0.0.46"
+qmk = "*"
 
 [tool.poetry.dev-dependencies]
 nose2 = "^0.10.0"

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -22,5 +22,17 @@
         "type": "tarball",
         "url": "https://github.com/NixOS/nixpkgs/archive/c0e881852006b132236cbf0301bd1939bb50867e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "poetry2nix": {
+        "branch": "master",
+        "description": "Convert poetry projects to nix automagically [maintainer=@adisbladis] ",
+        "homepage": "",
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "rev": "2d27d44397242b28c3f0081e0432e4f6c951f3a1",
+        "sha256": "06syfg150r59m4kksj5547b5kwxjxjaif5hiljcq966kb9hxsvmv",
+        "type": "tarball",
+        "url": "https://github.com/nix-community/poetry2nix/archive/2d27d44397242b28c3f0081e0432e4f6c951f3a1.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -10,6 +10,30 @@ let
   # files if the requirements*.txt files change
   pythonEnv = pkgs.poetry2nix.mkPoetryEnv {
     projectDir = ./nix;
+    overrides = pkgs.poetry2nix.overrides.withDefaults (self: super: {
+      hid = super.hid.overridePythonAttrs (old: {
+        postPatch =
+          ''
+            found=
+            for name in libhidapi-hidraw libhidapi-libusb libhidapi-iohidmanager libhidapi; do
+              full_path=${pkgs.hidapi.out}/lib/$name${pkgs.stdenv.hostPlatform.extensions.sharedLibrary}
+              if test -f $full_path; then
+                found=t
+                sed -i -e "s|'$name\..*'|'$full_path'|" hid/__init__.py
+              fi
+            done
+            test -n "$found" || { echo "ERROR: No known libraries found in ${pkgs.hidapi.out}/lib, please update/fix this build expression."; exit 1; }
+          '';
+      });
+      pyusb = super.pyusb.overridePythonAttrs (old: {
+        postPatch =
+          ''
+            libusb=${pkgs.libusb1.out}/lib/libusb-1.0${pkgs.stdenv.hostPlatform.extensions.sharedLibrary}
+            test -f $libusb || { echo "ERROR: $libusb doesn't exist, please update/fix this build expression."; exit 1; }
+            sed -i -e "s|find_library=None|find_library=lambda _:\"$libusb\"|" usb/backend/libusb1.py
+          '';
+      });
+    });
   };
 in
 


### PR DESCRIPTION
## Description

Update Python dependencies for Nix to account for the recent changes:
- The `qmk console` command implementation now requires the `hid` and `pyusb` Python modules.
- The `Wave` Python dependency was a mistake; it was already removed from `requirements-dev.txt`, but still left in `nix/pyproject.toml`.
- The build scripts now complain that `bin/qmk` is deprecated, therefore the QMK CLI should be provided in the nix-shell environment.

The `hid` and `pyusb` Python modules required adding some overrides to `shell.nix` to make them actually work (without those overrides the packages seem to build, but break at runtime, because they cannot find the needed native libraries in Nix-specific directories). The override for `pyusb` was copied from [nixpkgs](https://github.com/NixOS/nixpkgs/blob/8284fc30c84ea47e63209d1a892aca1dfcd6bdf3/pkgs/development/python-modules/pyusb/default.nix); the override for `hid` is written by me based on the `pyusb` example.

I tested these changes on NixOS (`x86_64-linux`); the override for `hid` might also work on MacOS, but I cannot actually test it. With `nix-direnv` things like `qmk compile` or `qmk info -m` transparently work in the `qmk_firmware` directory or any subdirectories without any other configuration.

There is one potential problem that I noticed: The Nix-generated wrapper for the `qmk` executable from QMK CLI prepends some directories to `$PATH` before running the actual Python code, and one of those directories contains a `python3` executable which does not have the Python module path configured to find the packages included in the Python environment. The QMK CLI itself still works because of yet another Nix-specific modification which adds the required directories to the Python path in the executable script itself; however, when that `qmk` executable finally calls `make`, any calls to `bin/qmk` from makefiles would fail, because `bin/qmk` would try to use that unconfigured `python3` interpreter instead of the one that is provided by the nix-shell environment. One such error was recently fixed in #12832; in the nix-shell environment it would be a hard error instead of just a warning. It is possible to make a workaround for this in `shell.nix`, but I'm not sure if the added complexity is worth it, especially if it's just for supporting some broken code.

Hope that other people who touched the Nix-specific code recently (@purcell, @andresilva, @pepyakin) could test and add their comments on this.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
