### PR TITLE
CLI/c2json: Print 'cpp' error when executed in verbose mode

### DIFF
--- a/lib/python/qmk/cli/c2json.py
+++ b/lib/python/qmk/cli/c2json.py
@@ -43,7 +43,7 @@ def c2json(cli):
     except CppError as e:
         if cli.config.general.verbose:
             cli.log.debug('The C pre-processor ran into a fatal error: %s', e)
-        cli.log.error('Try to use --no-cpp.')
+        cli.log.error('Something went wrong. Try to use --no-cpp.\nUse the CLI in verbose mode to find out more.')
         return False
 
     # Generate the keymap.json

--- a/lib/python/qmk/cli/c2json.py
+++ b/lib/python/qmk/cli/c2json.py
@@ -9,6 +9,7 @@ import qmk.keymap
 import qmk.path
 from qmk.json_encoders import InfoJSONEncoder
 from qmk.keyboard import keyboard_completer, keyboard_folder
+from qmk.errors import CppError
 
 
 @cli.argument('--no-cpp', arg_only=True, action='store_false', help='Do not use \'cpp\' on keymap.c')
@@ -37,7 +38,13 @@ def c2json(cli):
         cli.args.output = None
 
     # Parse the keymap.c
-    keymap_json = qmk.keymap.c2json(cli.args.keyboard, cli.args.keymap, cli.args.filename, use_cpp=cli.args.no_cpp)
+    try:
+        keymap_json = qmk.keymap.c2json(cli.args.keyboard, cli.args.keymap, cli.args.filename, use_cpp=cli.args.no_cpp)
+    except CppError as e:
+        if cli.config.general.verbose:
+            cli.log.debug('The C pre-processor run into a fatal error: %s', e)
+        cli.log.error('Try to use --no-cpp.')
+        return False
 
     # Generate the keymap.json
     try:

--- a/lib/python/qmk/cli/c2json.py
+++ b/lib/python/qmk/cli/c2json.py
@@ -42,7 +42,7 @@ def c2json(cli):
         keymap_json = qmk.keymap.c2json(cli.args.keyboard, cli.args.keymap, cli.args.filename, use_cpp=cli.args.no_cpp)
     except CppError as e:
         if cli.config.general.verbose:
-            cli.log.debug('The C pre-processor run into a fatal error: %s', e)
+            cli.log.debug('The C pre-processor ran into a fatal error: %s', e)
         cli.log.error('Try to use --no-cpp.')
         return False
 

--- a/lib/python/qmk/errors.py
+++ b/lib/python/qmk/errors.py
@@ -3,3 +3,10 @@ class NoSuchKeyboardError(Exception):
     """
     def __init__(self, message):
         self.message = message
+
+
+class CppError(Exception):
+    """Raised when 'cpp' cannot process a file.
+    """
+    def __init__(self, message):
+        self.message = message

--- a/lib/python/qmk/keymap.py
+++ b/lib/python/qmk/keymap.py
@@ -13,6 +13,7 @@ from pygments import lex
 
 import qmk.path
 from qmk.keyboard import find_keyboard_from_dir, rules_mk
+from qmk.errors import CppError
 
 # The `keymap.c` template to use when a keyboard doesn't have its own
 DEFAULT_KEYMAP_C = """#include QMK_KEYBOARD_H
@@ -372,7 +373,10 @@ def _c_preprocess(path, stdin=DEVNULL):
     """
     cmd = ['cpp', str(path)] if path else ['cpp']
     pre_processed_keymap = cli.run(cmd, stdin=stdin)
-
+    if 'fatal error' in pre_processed_keymap.stderr:
+        for line in pre_processed_keymap.stderr.split('\n'):
+            if 'fatal error' in line:
+                raise (CppError(line))
     return pre_processed_keymap.stdout
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Print the "fatal errors" from `cpp` if the `-v` argument is passed to `c2json`.
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
