### PR TITLE
Remove the #10088 hotfix for Teensy 3.1-like Input:Club keyboards

### DIFF
--- a/keyboards/ergodox_infinity/rules.mk
+++ b/keyboards/ergodox_infinity/rules.mk
@@ -6,11 +6,9 @@ BOOTLOADER = kiibohd
 
 # Board: it should exist either in <chibios>/os/hal/boards/
 #  or <this_dir>/boards
-# - BOARD =
-#   - PJRC_TEENSY_LC for Teensy LC
-#   - PJRC_TEENSY_3 for Teensy 3.0
-#   - PJRC_TEENSY_3_1 for Teensy 3.1 or 3.2
-#   - MCHCK_K20 for Infinity KB
+# This board was copied from PJRC_TEENSY_3_1. The only difference should be a
+# hack to ensure the watchdog has started before trying to disable it, and an
+# override to disable restart of USB driver after returning from suspend.
 BOARD = IC_TEENSY_3_1
 
 # Build Options

--- a/keyboards/ergodox_infinity/rules.mk
+++ b/keyboards/ergodox_infinity/rules.mk
@@ -4,6 +4,15 @@ MCU = MK20DX256
 # Bootloader selection
 BOOTLOADER = kiibohd
 
+# Board: it should exist either in <chibios>/os/hal/boards/
+#  or <this_dir>/boards
+# - BOARD =
+#   - PJRC_TEENSY_LC for Teensy LC
+#   - PJRC_TEENSY_3 for Teensy 3.0
+#   - PJRC_TEENSY_3_1 for Teensy 3.1 or 3.2
+#   - MCHCK_K20 for Infinity KB
+BOARD = IC_TEENSY_3_1
+
 # Build Options
 #   comment out to disable the options.
 #

--- a/keyboards/k_type/rules.mk
+++ b/keyboards/k_type/rules.mk
@@ -7,7 +7,8 @@ BOOTLOADER = kiibohd
 # Board: it should exist either in <chibios>/os/hal/boards/
 #  or <this_dir>/boards
 # This board was copied from PJRC_TEENSY_3_1. The only difference should be a
-# hack to ensure the watchdog has started before trying to disable it.
+# hack to ensure the watchdog has started before trying to disable it, and an
+# override to disable restart of USB driver after returning from suspend.
 BOARD = IC_TEENSY_3_1
 
 # Build Options

--- a/keyboards/whitefox/rules.mk
+++ b/keyboards/whitefox/rules.mk
@@ -6,11 +6,9 @@ BOOTLOADER = kiibohd
 
 # Board: it should exist either in <chibios>/os/hal/boards/
 #  or <this_dir>/boards
-# - BOARD =
-#   - PJRC_TEENSY_LC for Teensy LC
-#   - PJRC_TEENSY_3 for Teensy 3.0
-#   - PJRC_TEENSY_3_1 for Teensy 3.1 or 3.2
-#   - MCHCK_K20 for Infinity KB
+# This board was copied from PJRC_TEENSY_3_1. The only difference should be a
+# hack to ensure the watchdog has started before trying to disable it, and an
+# override to disable restart of USB driver after returning from suspend.
 BOARD = IC_TEENSY_3_1
 
 # Build Options

--- a/platforms/chibios/IC_TEENSY_3_1/board/board.c
+++ b/platforms/chibios/IC_TEENSY_3_1/board/board.c
@@ -144,3 +144,8 @@ void __early_init(void) {
  * @todo    Add your board-specific code, if any.
  */
 void boardInit(void) {}
+
+
+void restart_usb_driver(USBDriver *usbp) {
+    // Do nothing. Restarting the USB driver on these boards breaks it.
+}

--- a/tmk_core/protocol/chibios/main.c
+++ b/tmk_core/protocol/chibios/main.c
@@ -226,7 +226,9 @@ int main(void) {
                 /* Remote wakeup */
                 if (suspend_wakeup_condition()) {
                     usbWakeupHost(&USB_DRIVER);
+#    ifndef K20x
                     restart_usb_driver(&USB_DRIVER);
+#    endif
                 }
             }
             /* Woken up */

--- a/tmk_core/protocol/chibios/main.c
+++ b/tmk_core/protocol/chibios/main.c
@@ -226,9 +226,7 @@ int main(void) {
                 /* Remote wakeup */
                 if (suspend_wakeup_condition()) {
                     usbWakeupHost(&USB_DRIVER);
-#    ifndef K20x
                     restart_usb_driver(&USB_DRIVER);
-#    endif
                 }
             }
             /* Woken up */

--- a/tmk_core/protocol/chibios/usb_main.c
+++ b/tmk_core/protocol/chibios/usb_main.c
@@ -705,7 +705,7 @@ void init_usb_driver(USBDriver *usbp) {
     chVTObjectInit(&keyboard_idle_timer);
 }
 
-void restart_usb_driver(USBDriver *usbp) {
+__attribute__((weak)) void restart_usb_driver(USBDriver *usbp) {
     usbStop(usbp);
     usbDisconnectBus(usbp);
 


### PR DESCRIPTION
## Description

On at least my Ergodox Infinity, the #10088 hotfix _causes_ the issue it intended to solve. That is, waking the keyboard from suspend after the keyboard has caused the host to wake works fine _without_ the #10088 hotfix, but _with_ it, the keyboard gets stuck sleeping.

This PR removes the #10088 hotfix for Ergodox Infinity, K-Type and Whitefox (all using the same MK20DX256 MCU).

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
