### PR TITLE
Update oled_bongocat to match VIA keymap

### DIFF
--- a/keyboards/nullbitsco/nibble/keymaps/oled_bongocat/keymap.c
+++ b/keyboards/nullbitsco/nibble/keymaps/oled_bongocat/keymap.c
@@ -21,31 +21,74 @@
 
 
 enum layer_names {
-  _MA,
-  _FN
+  _BASE,
+  _VIA1,
+  _VIA2,
+  _VIA3
 };
+
+#define KC_DISC_MUTE KC_F23
+#define KC_DISC_DEAF KC_F24
+#define NUM_CUST_KEYCODES (_NUM_CUST_KCS - SAFE_RANGE)
+#define VIA_KEYCODE_RANGE 0x5F80
 
 enum custom_keycodes {
-    KC_CUST = SAFE_RANGE,
+  PROG = SAFE_RANGE,
+  DISC_MUTE,
+  DISC_DEAF,
+  SUPER_ALT_TAB,
+  _NUM_CUST_KCS,
 };
+
+// Macro variables
+bool is_alt_tab_active = false;
+uint16_t alt_tab_timer = 0;
+bool muted = false;
+bool deafened = false;
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-  [_MA] = LAYOUT_ansi(
-            KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_HOME,
-    KC_F13, KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS, KC_DEL,
-    KC_F14, KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,          KC_ENT,  KC_PGUP,
-    KC_F15, KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT,          KC_UP,   KC_PGDN,
-    KC_F16, KC_LCTL, KC_LGUI, KC_LALT,                   KC_SPC,                    MO(_FN), KC_RALT, KC_RCTL, KC_LEFT,          KC_DOWN, KC_RGHT
+  [_BASE] = LAYOUT_all(
+              KC_GESC, KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_HOME,
+    KC_F13,   KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS, KC_DEL,
+    KC_F14,   KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,          KC_ENT,  KC_PGUP,
+    KC_F15,   KC_LSFT, KC_NUBS, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT, KC_UP,   KC_PGDN,
+    KC_F16,   KC_LCTL, KC_LGUI, KC_LALT,                            KC_SPC,                  MO(_VIA1), KC_RALT, KC_RCTL, KC_LEFT, KC_DOWN, KC_RGHT
   ),
-  [_FN] = LAYOUT_ansi(
-               RESET,   KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,  KC_F10,  KC_F11,  KC_F12, _______,  KC_END,
-    RGB_TOG, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
-    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          _______, _______,
-    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          _______, _______,
-    _______, _______, _______, _______,                   _______,                   _______, _______, _______, _______,          _______, _______
+
+  [_VIA1] = LAYOUT_all(
+              RESET,   KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  _______,  KC_END,
+    RGB_TOG,  _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+    _______,  _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          _______, _______,
+    _______,  _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+    _______,  _______, _______, _______,                            _______,                   _______, _______, _______, KC_MPRV, KC_MPLY, KC_MNXT
+  ),
+
+  [_VIA2] = LAYOUT_all(
+              _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+    _______,  _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+    _______,  _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          _______, _______,
+    _______,  _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+    _______,  _______, _______, _______,                            _______,                   _______, _______, _______, _______, _______, _______
+  ),
+
+  [_VIA3] = LAYOUT_all(
+              _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+    _______,  _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+    _______,  _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          _______, _______,
+    _______,  _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+    _______,  _______, _______, _______,                            _______,                   _______, _______, _______, _______, _______, _______
   ),
 
 };
+
+void map_via_keycode(uint16_t * keycode) {
+  if (abs(*keycode - VIA_KEYCODE_RANGE) < NUM_CUST_KEYCODES) { //make into macro?
+    dprintf("VIA custom keycode found, mapping to QMK keycode.\n");
+    uint16_t new_keycode = (*keycode - VIA_KEYCODE_RANGE) + SAFE_RANGE;
+    dprintf("VIA KC: %u QMK KC: %u\n", *keycode, new_keycode);
+    *keycode = new_keycode;
+  }
+}
 
 void encoder_update_kb(uint8_t index, bool clockwise) {
     if (clockwise) {
@@ -58,7 +101,7 @@ void encoder_update_kb(uint8_t index, bool clockwise) {
 #ifdef OLED_DRIVER_ENABLE
 #define IDLE_FRAME_DURATION 200 // Idle animation iteration rate in ms
 
-oled_rotation_t oled_init_user(oled_rotation_t rotation) { return OLED_ROTATION_90; }
+oled_rotation_t oled_init_user(oled_rotation_t rotation) { return OLED_ROTATION_270; }
 
 uint32_t anim_timer         = 0;
 uint32_t anim_sleep         = 0;
@@ -125,8 +168,19 @@ static void render_anim(void) {
     }
 }
 
+void oled_task_user(void) {
+    render_anim();
+    oled_set_cursor(0, 14);
+    sprintf(wpm_str, ">%04d", get_current_wpm());
+    oled_write_ln(wpm_str, false);
+}
+#endif
+
 // Animate tap
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    map_via_keycode(&keycode);
+
+    #ifdef OLED_DRIVER_ENABLE
     // Check if non-mod
     if ((keycode >= KC_A && keycode <= KC_0) || (keycode >= KC_TAB && keycode <= KC_SLASH)) {
         if (record->event.pressed) {
@@ -139,13 +193,76 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             #endif
         }
     }
+    #endif
+
+    switch(keycode) {
+        case PROG:
+          if (record->event.pressed) {
+            rgblight_disable_noeeprom();
+            #ifdef OLED_DRIVER_ENABLE
+            oled_off();
+            #endif
+            bootloader_jump();
+          }
+        break;
+
+        case DISC_MUTE:
+          if (record->event.pressed) {
+            tap_code(KC_DISC_MUTE);
+            if (!rgblight_is_enabled()) break;
+
+            if (muted) {
+              rgblight_enable_noeeprom();
+            } else {
+              rgblight_timer_disable();
+              uint8_t val = rgblight_get_val();
+              rgblight_sethsv_range(255, 255, val, 0, 1);
+            }
+            muted = !muted;
+          }
+        break;
+
+        case DISC_DEAF:
+          if (record->event.pressed) {
+            tap_code(KC_DISC_DEAF);
+            if (!rgblight_is_enabled()) break;
+
+            if (deafened) {
+              rgblight_enable_noeeprom();
+            } else {
+              rgblight_timer_disable();
+              uint8_t val = rgblight_get_val();
+              rgblight_sethsv_range(255, 255, val, 0, RGBLED_NUM-1);
+            }
+            deafened = !deafened;
+          }
+        break;
+
+        case SUPER_ALT_TAB:
+          if (record->event.pressed) {
+            if (!is_alt_tab_active) {
+              is_alt_tab_active = true;
+              register_code(KC_LALT);
+            }
+            alt_tab_timer = timer_read();
+            register_code(KC_TAB);
+          } else {
+            unregister_code(KC_TAB);
+          }
+          break;
+
+        default:
+        break;
+    }
+
     return true;
 }
 
-void oled_task_user(void) {
-    render_anim();
-    oled_set_cursor(0, 14);
-    sprintf(wpm_str, ">%04d", get_current_wpm());
-    oled_write_ln(wpm_str, false);
+void matrix_scan_user(void) {
+  if (is_alt_tab_active) {
+    if (timer_elapsed(alt_tab_timer) > 1000) {
+      unregister_code(KC_LALT);
+      is_alt_tab_active = false;
+    }
+  }
 }
-#endif

--- a/keyboards/nullbitsco/nibble/keymaps/oled_bongocat/keymap.c
+++ b/keyboards/nullbitsco/nibble/keymaps/oled_bongocat/keymap.c
@@ -29,11 +29,9 @@ enum layer_names {
 
 #define KC_DISC_MUTE KC_F23
 #define KC_DISC_DEAF KC_F24
-#define NUM_CUST_KEYCODES (_NUM_CUST_KCS - SAFE_RANGE)
-#define VIA_KEYCODE_RANGE 0x5F80
 
 enum custom_keycodes {
-  PROG = SAFE_RANGE,
+  PROG = USER00,
   DISC_MUTE,
   DISC_DEAF,
   SUPER_ALT_TAB,
@@ -80,15 +78,6 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   ),
 
 };
-
-void map_via_keycode(uint16_t * keycode) {
-  if (abs(*keycode - VIA_KEYCODE_RANGE) < NUM_CUST_KEYCODES) { //make into macro?
-    dprintf("VIA custom keycode found, mapping to QMK keycode.\n");
-    uint16_t new_keycode = (*keycode - VIA_KEYCODE_RANGE) + SAFE_RANGE;
-    dprintf("VIA KC: %u QMK KC: %u\n", *keycode, new_keycode);
-    *keycode = new_keycode;
-  }
-}
 
 void encoder_update_kb(uint8_t index, bool clockwise) {
     if (clockwise) {
@@ -178,8 +167,6 @@ void oled_task_user(void) {
 
 // Animate tap
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
-    map_via_keycode(&keycode);
-
     #ifdef OLED_DRIVER_ENABLE
     // Check if non-mod
     if ((keycode >= KC_A && keycode <= KC_0) || (keycode >= KC_TAB && keycode <= KC_SLASH)) {


### PR DESCRIPTION
## Description

The original version of this keymap was missing layers 3 and 4, which messed with VIA support.
The "extra" macros from the default keymap were also added (Discord mute, super alt-tab, etc).

Tested locally on a NIBBLE keyboard with OLED display.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
