### PR TITLE
Add missing LED Matrix suspend code to suspend.c

### DIFF
--- a/tmk_core/common/avr/suspend.c
+++ b/tmk_core/common/avr/suspend.c
@@ -163,12 +163,12 @@ void suspend_power_down(void) {
     rgblight_suspend();
 #    endif
 
-#    if defined(RGB_MATRIX_ENABLE)
-    rgb_matrix_set_suspend_state(true);
-#    endif
-
 #    if defined(LED_MATRIX_ENABLE)
     led_matrix_set_suspend_state(true);
+#    endif
+
+#    if defined(RGB_MATRIX_ENABLE)
+    rgb_matrix_set_suspend_state(true);
 #    endif
 
     // Enter sleep state if possible (ie, the MCU has a watchdog timeout interrupt)
@@ -222,12 +222,11 @@ void suspend_wakeup_init(void) {
 #if defined(RGBLIGHT_SLEEP) && defined(RGBLIGHT_ENABLE)
     rgblight_wakeup();
 #endif
-#if defined(RGB_MATRIX_ENABLE)
-    rgb_matrix_set_suspend_state(false);
-#endif
-
 #if defined(LED_MATRIX_ENABLE)
     led_matrix_set_suspend_state(false);
+#endif
+#if defined(RGB_MATRIX_ENABLE)
+    rgb_matrix_set_suspend_state(false);
 #endif
 
     suspend_wakeup_init_kb();

--- a/tmk_core/common/avr/suspend.c
+++ b/tmk_core/common/avr/suspend.c
@@ -166,7 +166,6 @@ void suspend_power_down(void) {
 #    if defined(LED_MATRIX_ENABLE)
     led_matrix_set_suspend_state(true);
 #    endif
-
 #    if defined(RGB_MATRIX_ENABLE)
     rgb_matrix_set_suspend_state(true);
 #    endif
@@ -222,6 +221,7 @@ void suspend_wakeup_init(void) {
 #if defined(RGBLIGHT_SLEEP) && defined(RGBLIGHT_ENABLE)
     rgblight_wakeup();
 #endif
+
 #if defined(LED_MATRIX_ENABLE)
     led_matrix_set_suspend_state(false);
 #endif

--- a/tmk_core/common/avr/suspend.c
+++ b/tmk_core/common/avr/suspend.c
@@ -167,6 +167,10 @@ void suspend_power_down(void) {
     rgb_matrix_set_suspend_state(true);
 #    endif
 
+#    if defined(LED_MATRIX_ENABLE)
+    led_matrix_set_suspend_state(true);
+#    endif
+
     // Enter sleep state if possible (ie, the MCU has a watchdog timeout interrupt)
 #    if defined(WDT_vect)
     power_down(WDTO_15MS);
@@ -220,6 +224,10 @@ void suspend_wakeup_init(void) {
 #endif
 #if defined(RGB_MATRIX_ENABLE)
     rgb_matrix_set_suspend_state(false);
+#endif
+
+#if defined(LED_MATRIX_ENABLE)
+    led_matrix_set_suspend_state(false);
 #endif
 
     suspend_wakeup_init_kb();

--- a/tmk_core/common/chibios/suspend.c
+++ b/tmk_core/common/chibios/suspend.c
@@ -83,13 +83,12 @@ void suspend_power_down(void) {
 #if defined(RGBLIGHT_SLEEP) && defined(RGBLIGHT_ENABLE)
     rgblight_suspend();
 #endif
-#if defined(RGB_MATRIX_ENABLE)
-    rgb_matrix_set_suspend_state(true);
-#endif
 #if defined(LED_MATRIX_ENABLE)
     led_matrix_set_suspend_state(true);
 #endif
-
+#if defined(RGB_MATRIX_ENABLE)
+    rgb_matrix_set_suspend_state(true);
+#endif
 #ifdef AUDIO_ENABLE
     stop_all_notes();
 #endif /* AUDIO_ENABLE */
@@ -158,11 +157,11 @@ void suspend_wakeup_init(void) {
 #if defined(RGBLIGHT_SLEEP) && defined(RGBLIGHT_ENABLE)
     rgblight_wakeup();
 #endif
-#if defined(RGB_MATRIX_ENABLE)
-    rgb_matrix_set_suspend_state(false);
-#endif
 #if defined(LED_MATRIX_ENABLE)
     led_matrix_set_suspend_state(false);
+#endif
+#if defined(RGB_MATRIX_ENABLE)
+    rgb_matrix_set_suspend_state(false);
 #endif
     suspend_wakeup_init_kb();
 }

--- a/tmk_core/common/chibios/suspend.c
+++ b/tmk_core/common/chibios/suspend.c
@@ -83,6 +83,7 @@ void suspend_power_down(void) {
 #if defined(RGBLIGHT_SLEEP) && defined(RGBLIGHT_ENABLE)
     rgblight_suspend();
 #endif
+
 #if defined(LED_MATRIX_ENABLE)
     led_matrix_set_suspend_state(true);
 #endif
@@ -157,6 +158,7 @@ void suspend_wakeup_init(void) {
 #if defined(RGBLIGHT_SLEEP) && defined(RGBLIGHT_ENABLE)
     rgblight_wakeup();
 #endif
+
 #if defined(LED_MATRIX_ENABLE)
     led_matrix_set_suspend_state(false);
 #endif

--- a/tmk_core/common/chibios/suspend.c
+++ b/tmk_core/common/chibios/suspend.c
@@ -86,6 +86,10 @@ void suspend_power_down(void) {
 #if defined(RGB_MATRIX_ENABLE)
     rgb_matrix_set_suspend_state(true);
 #endif
+#if defined(LED_MATRIX_ENABLE)
+    led_matrix_set_suspend_state(true);
+#endif
+
 #ifdef AUDIO_ENABLE
     stop_all_notes();
 #endif /* AUDIO_ENABLE */
@@ -156,6 +160,9 @@ void suspend_wakeup_init(void) {
 #endif
 #if defined(RGB_MATRIX_ENABLE)
     rgb_matrix_set_suspend_state(false);
+#endif
+#if defined(LED_MATRIX_ENABLE)
+    led_matrix_set_suspend_state(false);
 #endif
     suspend_wakeup_init_kb();
 }


### PR DESCRIPTION
## Description

Realized that I never added the suspend function calls for LED Matrix.  Whoops. 

## Types of Changes

- [x] Core
- [x] Bugfix

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
