### PR TITLE
Fix spelling mistake regarding LED Matrix in split_common.

### DIFF
--- a/quantum/split_common/transport.c
+++ b/quantum/split_common/transport.c
@@ -392,7 +392,7 @@ bool transport_master(matrix_row_t master_matrix[], matrix_row_t slave_matrix[])
 #    endif
 
 #    if defined(LED_MATRIX_ENABLE) && defined(LED_MATRIX_SPLIT)
-    serial_m2s_buffer.led_matrix        = led_matrix_econfig;
+    serial_m2s_buffer.led_matrix        = led_matrix_eeconfig;
     serial_m2s_buffer.led_suspend_state = led_matrix_get_suspend_state();
 #    endif
 #    if defined(RGB_MATRIX_ENABLE) && defined(RGB_MATRIX_SPLIT)


### PR DESCRIPTION
## Description

A mistake (one missed 'e') in #12633 caused a compilation error in split_common/transport.c

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
