### PR TITLE
[Keymap] Fix DVORAK/QWERTY status output for kzar keymap

### DIFF
--- a/keyboards/kinesis/kint36/keymaps/kzar/keymap.c
+++ b/keyboards/kinesis/kint36/keymaps/kzar/keymap.c
@@ -375,7 +375,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
                 SEND_STRING("Keyboard> " QMK_KEYBOARD "\n");
                 SEND_STRING("Keymap> " QMK_KEYMAP "\n");
 
-                if (layer_state_is(_QWERTY))
+                if (layer_state_cmp(default_layer_state, _QWERTY))
                     SEND_STRING("Layout> QWERTY\n");
                 else
                     SEND_STRING("Layout> DVORAK\n");


### PR DESCRIPTION
## Description

The kzar keymap for the Kinesis keyboard output's the keyboard's status when the STATUS key is pressed. Unfortunately there is a bug whereby the status output declares the current layout to be DVORAK instead of QWERTY. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/kinx-project/kint/issues/28

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
