### PR TITLE
[FIX] VIA Hex Generation Fix

### DIFF
--- a/keyboards/merge/um70/keymaps/via/config.h
+++ b/keyboards/merge/um70/keymaps/via/config.h
@@ -1,16 +1,16 @@
-/* Copyright 2021 duoshock 
- * 
- * This program is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 2 of the License, or 
- * (at your option) any later version. 
- * 
- * This program is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
+/* Copyright 2021 duoshock
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
@@ -18,3 +18,6 @@
 #define RGBLIGHT_EFFECT_RAINBOW_MOOD
 #define RGBLIGHT_EFFECT_RAINBOW_SWIRL
 #define RGBLIGHT_EFFECT_SNAKE
+
+#define LAYER_STATE_8BIT
+

--- a/keyboards/merge/um70/keymaps/via/config.h
+++ b/keyboards/merge/um70/keymaps/via/config.h
@@ -21,3 +21,10 @@
 
 #define LAYER_STATE_8BIT
 
+/* Disable unused and unneeded features to reduce on firmware size */
+#ifdef LOCKING_SUPPORT_ENABLE
+#    undef LOCKING_SUPPORT_ENABLE
+#endif
+#ifdef LOCKING_RESYNC_ENABLE
+#    undef LOCKING_RESYNC_ENABLE
+#endif

--- a/keyboards/merge/um70/keymaps/via/rules.mk
+++ b/keyboards/merge/um70/keymaps/via/rules.mk
@@ -1,3 +1,5 @@
 VIA_ENABLE = yes
 WPM_ENABLE = yes
 LTO_ENABLE = yes
+
+NKRO_ENABLE = no


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

merge/um70:via did not previously compile as it was over the size limit. 
https://github.com/Xelus22/QMK-VIA-Hex/runs/2588296374?check_suite_focus=true#step:658:659

On AVR-GCC 8.3.0
```
Linking: .build/merge_um70_via.elf                                                                  [OK]
Creating load file for flashing: .build/merge_um70_via.hex                                          [OK]
Copying merge_um70_via.hex to qmk_firmware folder                                                   [OK]
Checking file size of merge_um70_via.hex                                                            [WARNINGS]

 * The firmware size is approaching the maximum - 28558/28672 (99%, 114 bytes free)
```
Travis uses 5.4.0

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Compile under size by removing NKRO and enable `LAYER_STATE_8BIT`

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
