### PR TITLE
Make sure 'cformat' only runs on core files

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -34,7 +34,7 @@ jobs:
     - name: Run qmk cformat and qmk pyformat
       shell: 'bash {0}'
       run: |
-        qmk cformat -n $(< ~/files.txt)
+        qmk cformat --core-only -n $(< ~/files.txt)
         cformat_exit=$?
         qmk pyformat -n
         pyformat_exit=$?

--- a/lib/python/qmk/cli/cformat.py
+++ b/lib/python/qmk/cli/cformat.py
@@ -78,8 +78,8 @@ def filter_files(files, core_only=False):
                 files[index] = None
                 cli.log.debug("Skipping non-core file %s, as '--core-only' is used.", file)
 
-    for file in [file for file in files if file is not None]:
-        if file.name.split('.')[-1] in c_file_suffixes:
+    for file in files:
+        if file and file.name.split('.')[-1] in c_file_suffixes:
             yield file
         else:
             cli.log.debug('Skipping file %s', file)

--- a/lib/python/qmk/cli/cformat.py
+++ b/lib/python/qmk/cli/cformat.py
@@ -65,10 +65,20 @@ def cformat_run(files):
         return False
 
 
-def filter_files(files):
+def filter_files(files, force=False):
     """Yield only files to be formatted and skip the rest
     """
-    for file in files:
+    if not force:
+        # Filter non-core files, if not forced
+        for index, file in enumerate(files):
+            # The following statement checks each file to see if the file path is
+            # - in the core directories
+            # - not in the ignored directories
+            if not any(i in str(file) for i in core_dirs) or any(i in str(file) for i in ignored):
+                files[index] = None
+                cli.log.debug("Skipping non-core file %s, as '-f' is not used.", file)
+
+    for file in [file for file in files if file is not None]:
         if file.name.split('.')[-1] in c_file_suffixes:
             yield file
         else:
@@ -78,6 +88,7 @@ def filter_files(files):
 @cli.argument('-n', '--dry-run', arg_only=True, action='store_true', help="Flag only, don't automatically format.")
 @cli.argument('-b', '--base-branch', default='origin/master', help='Branch to compare to diffs to.')
 @cli.argument('-a', '--all-files', arg_only=True, action='store_true', help='Format all core files.')
+@cli.argument('-f', '--force', arg_only=True, action='store_true', help='Force formatting of non-core files.')
 @cli.argument('files', nargs='*', arg_only=True, type=normpath, completer=FilesCompleter('.c'), help='Filename(s) to format.')
 @cli.subcommand("Format C code according to QMK's style.", hidden=False if cli.config.user.developer else True)
 def cformat(cli):
@@ -85,7 +96,7 @@ def cformat(cli):
     """
     # Find the list of files to format
     if cli.args.files:
-        files = list(filter_files(cli.args.files))
+        files = list(filter_files(cli.args.files, cli.args.force))
 
         if not files:
             cli.log.error('No C files in filelist: %s', ', '.join(map(str, cli.args.files)))
@@ -96,8 +107,7 @@ def cformat(cli):
 
     elif cli.args.all_files:
         all_files = c_source_files(core_dirs)
-        # The following statement checks each file to see if the file path is in the ignored directories.
-        files = [file for file in all_files if not any(i in str(file) for i in ignored)]
+        files = list(filter_files(all_files, cli.args.force))
 
     else:
         git_diff_cmd = ['git', 'diff', '--name-only', cli.args.base_branch, *core_dirs]


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The 'cformat' subcommand should only run on "core" files when executed by the CI.
CI now should use the new `--core-only` argument.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
