### PR TITLE
Reduce `merge/um70:via` firmware size to make it fit

### DIFF
--- a/keyboards/merge/um70/keymaps/via/keymap.c
+++ b/keyboards/merge/um70/keymaps/via/keymap.c
@@ -15,7 +15,6 @@
  */
 
 #include QMK_KEYBOARD_H
-#include <stdio.h>
 
 enum layer_names {
     _BASE,
@@ -122,7 +121,7 @@ static const char PROGMEM merge_logo[] = {
     0x01, 0x00, 0x01, 0x01, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00
 };
 
-int current_wpm = 0;
+uint8_t current_wpm = 0;
 
 static void print_status_narrow(void) {
     oled_set_cursor(0,1);
@@ -158,10 +157,15 @@ static void print_status_narrow(void) {
     //oled_write_ln_P(PSTR(" "), false);
     oled_write_P(PSTR("-----"), false);
 
-    // WPM counter Start (Need #include <stdio.h> to work)
-    char wpm_str[8];
+    // WPM counter Start
+    char wpm_str[5];
     oled_set_cursor(0,13);
-    sprintf(wpm_str, " %03d", current_wpm);
+    wpm_str[4] = '\0';
+    uint8_t n = current_wpm;
+    wpm_str[3] = '0' + n % 10;
+    wpm_str[2] = '0' + (n /= 10) % 10;
+    wpm_str[1] = '0' + n / 10;
+    wpm_str[0] = ' ';
     oled_write(wpm_str, false);
     oled_set_cursor(0,14);
     oled_write(" WPM ", false);


### PR DESCRIPTION
## Description

The code using `sprintf()` did not fit into flash when `merge/um70:via` was compiled with avr-gcc 5.4.0:

     * The firmware is too large! 29756/28672 (1084 bytes over)

Replacing `sprintf(wpm_str, " %03d", current_wpm);` with custom formatting code reduces the firmware size by 1504 bytes, which is enough to make the `merge/um70:via` firmware fit:

    * The firmware size is approaching the maximum - 28252/28672 (98%, 420 bytes free)

(I also tried to use `itoa()`, but the resulting code was larger, and needed some not really nice looking code to add zero padding — keeping the output string length constant is needed to make the OLED updates work properly.)

Tested on Pro Micro with OLED.

Unlike #12908, this PR does not disable features like NKRO which could be useful for some people.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
