### PR TITLE
point_t disambiguation

### DIFF
--- a/quantum/rgb_matrix.c
+++ b/quantum/rgb_matrix.c
@@ -26,9 +26,9 @@
 #include <lib/lib8tion/lib8tion.h>
 
 #ifndef RGB_MATRIX_CENTER
-const point_t k_rgb_matrix_center = {112, 32};
+const rgb_point_t k_rgb_matrix_center = {112, 32};
 #else
-const point_t k_rgb_matrix_center = RGB_MATRIX_CENTER;
+const rgb_point_t k_rgb_matrix_center = RGB_MATRIX_CENTER;
 #endif
 
 __attribute__((weak)) RGB rgb_matrix_hsv_to_rgb(HSV hsv) { return hsv_to_rgb(hsv); }

--- a/quantum/rgb_matrix_types.h
+++ b/quantum/rgb_matrix_types.h
@@ -62,7 +62,7 @@ typedef struct PACKED {
 typedef struct PACKED {
     uint8_t x;
     uint8_t y;
-} point_t;
+} rgb_point_t;
 
 #define HAS_FLAGS(bits, flags) ((bits & flags) == flags)
 #define HAS_ANY_FLAGS(bits, flags) ((bits & flags) != 0x00)
@@ -78,7 +78,7 @@ typedef struct PACKED {
 
 typedef struct PACKED {
     uint8_t matrix_co[MATRIX_ROWS][MATRIX_COLS];
-    point_t point[DRIVER_LED_TOTAL];
+    rgb_point_t point[DRIVER_LED_TOTAL];
     uint8_t flags[DRIVER_LED_TOTAL];
 } led_config_t;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Because my keyboard has both an RGB LED matrix and an LCD, I need to enable both visualizer and rgb_matrix. They both contain a `point_t` with [different](https://github.com/qmk/qmk_firmware/blob/master/quantum/rgb_matrix_types.h#L62-L65) [definitions](https://github.com/qmk/uGFX/blob/40b48f470addad6a4fb1177de1a69a181158739b/src/gdisp/gdisp.h#L1237) and so wouldn't compile. ugfx is vendored, so I made my small change in the rgb_matrix library. 

A quick grep indicates that point_t wasn't used anywhere outside rgb_matrix*, so this shouldn't be a breaking change.

I didn't change the LED matrix, as I'm not using that, but I could add a commit for that as well. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
