### PR TITLE
matrix: wait for row signal to go HIGH for every row

### DIFF
--- a/quantum/matrix.c
+++ b/quantum/matrix.c
@@ -116,9 +116,7 @@ static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
 
     // Unselect row
     unselect_row(current_row);
-    if (current_row + 1 < MATRIX_ROWS) {
-        matrix_output_unselect_delay();  // wait for row signal to go HIGH
-    }
+    matrix_output_unselect_delay();  // wait for all Col signals to go HIGH
 
     // If the row has changed, store the row and return the changed flag.
     if (current_matrix[current_row] != current_row_value) {
@@ -178,9 +176,7 @@ static bool read_rows_on_col(matrix_row_t current_matrix[], uint8_t current_col)
 
     // Unselect col
     unselect_col(current_col);
-    if (current_col + 1 < MATRIX_COLS) {
-        matrix_output_unselect_delay();  // wait for col signal to go HIGH
-    }
+    matrix_output_unselect_delay();  // wait for all Row signals to go HIGH
 
     return matrix_changed;
 }

--- a/quantum/split_common/matrix.c
+++ b/quantum/split_common/matrix.c
@@ -130,9 +130,7 @@ static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
 
     // Unselect row
     unselect_row(current_row);
-    if (current_row + 1 < MATRIX_ROWS) {
-        matrix_output_unselect_delay();  // wait for row signal to go HIGH
-    }
+    matrix_output_unselect_delay();  // wait for all Col signals to go HIGH
 
     // If the row has changed, store the row and return the changed flag.
     if (current_matrix[current_row] != current_row_value) {
@@ -192,9 +190,7 @@ static bool read_rows_on_col(matrix_row_t current_matrix[], uint8_t current_col)
 
     // Unselect col
     unselect_col(current_col);
-    if (current_col + 1 < MATRIX_COLS) {
-        matrix_output_unselect_delay();  // wait for col signal to go HIGH
-    }
+    matrix_output_unselect_delay();  // wait for all Row signals to go HIGH
 
     return matrix_changed;
 }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I noticed this discrepancy (last row of the matrix treated differently than the
others) when optimizing the input latency of my keyboard controller, see also
https://michael.stapelberg.ch/posts/2021-05-08-keyboard-input-latency-qmk-kinesis/

Before this commit, when tuning the delays I noticed ghost key presses when
pressing the F2 key, which is on the last row of the keyboard matrix: the
dead_grave key, which is on the first row of the keyboard matrix, would be
incorrectly detected as pressed.

After this commit, all keyboard matrix rows are interpreted correctly.

I suspect that my setup is more susceptible to this nuance than others because I
use GPIO_INPUT_PIN_DELAY=0 and hence don’t have another delay that might mask
the problem.
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
