### PR TITLE
Fix firmware size check with avr-libc 1:2.0.0+Atmel3.6.2-1.1 (Debian bullseye)

### DIFF
--- a/tmk_core/avr.mk
+++ b/tmk_core/avr.mk
@@ -295,7 +295,7 @@ ifneq ($(strip $(BOOTLOADER)), qmk-dfu)
 endif
 	make -C lib/lufa/Bootloaders/DFU/ clean
 	$(QMK_BIN) generate-dfu-header --quiet --keyboard $(KEYBOARD) --output lib/lufa/Bootloaders/DFU/Keyboard.h
-	$(eval MAX_SIZE=$(shell n=`$(CC) -E -mmcu=$(MCU) $(CFLAGS) $(OPT_DEFS) tmk_core/common/avr/bootloader_size.c 2> /dev/null | sed -ne 's/\r//;/^#/n;/^AVR_SIZE:/,$${s/^AVR_SIZE: //;p;}'` && echo $$(($$n)) || echo 0))
+	$(eval MAX_SIZE=$(shell n=`$(CC) -E -mmcu=$(MCU) -D__ASSEMBLER__ $(CFLAGS) $(OPT_DEFS) tmk_core/common/avr/bootloader_size.c 2> /dev/null | sed -ne 's/\r//;/^#/n;/^AVR_SIZE:/,$${s/^AVR_SIZE: //;p;}'` && echo $$(($$n)) || echo 0))
 	$(eval PROGRAM_SIZE_KB=$(shell n=`expr $(MAX_SIZE) / 1024` && echo $$(($$n)) || echo 0))
 	$(eval BOOT_SECTION_SIZE_KB=$(shell n=`expr  $(BOOTLOADER_SIZE) / 1024` && echo $$(($$n)) || echo 0))
 	$(eval FLASH_SIZE_KB=$(shell n=`expr $(PROGRAM_SIZE_KB) + $(BOOT_SECTION_SIZE_KB)` && echo $$(($$n)) || echo 0))

--- a/tmk_core/rules.mk
+++ b/tmk_core/rules.mk
@@ -458,7 +458,7 @@ ifeq ($(findstring avr-gcc,$(CC)),avr-gcc)
 SIZE_MARGIN = 1024
 
 check-size:
-	$(eval MAX_SIZE=$(shell n=`$(CC) -E -mmcu=$(MCU) $(CFLAGS) $(OPT_DEFS) tmk_core/common/avr/bootloader_size.c 2> /dev/null | sed -ne 's/\r//;/^#/n;/^AVR_SIZE:/,$${s/^AVR_SIZE: //;p;}'` && echo $$(($$n)) || echo 0))
+	$(eval MAX_SIZE=$(shell n=`$(CC) -E -mmcu=$(MCU) -D__ASSEMBLER__ $(CFLAGS) $(OPT_DEFS) tmk_core/common/avr/bootloader_size.c 2> /dev/null | sed -ne 's/\r//;/^#/n;/^AVR_SIZE:/,$${s/^AVR_SIZE: //;p;}'` && echo $$(($$n)) || echo 0))
 	$(eval CURRENT_SIZE=$(shell if [ -f $(BUILD_DIR)/$(TARGET).hex ]; then $(SIZE) --target=$(FORMAT) $(BUILD_DIR)/$(TARGET).hex | $(AWK) 'NR==2 {print $$4}'; else printf 0; fi))
 	$(eval FREE_SIZE=$(shell expr $(MAX_SIZE) - $(CURRENT_SIZE)))
 	$(eval OVER_SIZE=$(shell expr $(CURRENT_SIZE) - $(MAX_SIZE)))


### PR DESCRIPTION
## Description

Debian bullseye (testing at the moment, but seems close to release) has avr-libc 1:2.0.0+Atmel3.6.2-1.1 with some changes taken from the Atmel-distributed toolchain.  In particular, the `<avr/io.h>` header for ATmega32A (`avr/iom32a.h`) now defines the `FLASHEND` constant as `0x7FFFU`, and that `U` suffix breaks the firmware size check code, because the shell arithmetic expansion that is used to calculate `MAX_SIZE` does not support those C-specific suffixes.

As a workaround, add `-D__ASSEMBLER__` to the C preprocessor invocation that is used to expand those macros; in this case `avr/iom32a.h` defines `FLASHEND` without the `U` suffix, and everything works as it did before with older avr-libc versions.

The exact same code is present in two places; they are both changed, even though the code in `tmk_core/avr.mk` is actually never used for ATmega32A (and the header for ATmega32U4 does not add that `U` suffix to `FLASHEND` for some reason).

--------

The problematic code in new `avr/iom32a.h`:
```c
#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
#  define SPM_PAGESIZE 128
#  define FLASHSTART   0x0000
#  define FLASHEND     0x7FFF
#else
#  define SPM_PAGESIZE 128U
#  define FLASHSTART   0x0000U
#  define FLASHEND     0x7FFFU
#endif
```
For some reason the ATmega32U4 header does not have a similar change, therefore only boards using ATmega32A are affected. The build error for `jj40:default` looks like this:
```
Linking: .build/jj40_default.elf                                                                    [OK]
Creating load file for flashing: .build/jj40_default.hex                                            [OK]
Copying jj40_default.hex to qmk_firmware folder                                                     [OK]
sh: 1: arithmetic expression: expecting EOF: "
         0x7FFFU
                  + 1 - 4096"
expr: syntax error: unexpected argument ‘20220’
expr: syntax error: missing argument after ‘-’
expr: syntax error: missing argument after ‘/’
sh: 1: [: -gt: unexpected operator
```
Lots of other MCUs are affected, but the only one that has been used with QMK is apparently ATmega32A:
```
❯ grep -r 'FLASHEND.*U' .
./avr/io90pwm161.h:#  define FLASHEND     0x3FFFU
./avr/ioa5272.h:#  define FLASHEND     0x1FFFU
./avr/ioa5505.h:#  define FLASHEND     0x3FFFU
./avr/ioa5702m322.h:#  define FLASHEND     0xFFFFU
./avr/ioa5782.h:#  define FLASHEND     0xCFFFU
./avr/ioa5790.h:#  define FLASHEND     0x3FFFU
./avr/ioa5790n.h:#  define FLASHEND     0x3FFFU
./avr/ioa5791.h:#  define FLASHEND     0x3FFFU
./avr/ioa5795.h:#  define FLASHEND     0x1FFFU
./avr/ioa5831.h:#  define FLASHEND     0xCFFFU
./avr/ioa6285.h:#  define FLASHEND     0x1FFFU
./avr/ioa6286.h:#  define FLASHEND     0x1FFFU
./avr/ioa6612c.h:#  define FLASHEND     0x1FFFU
./avr/ioa6613c.h:#  define FLASHEND     0x3FFFU
./avr/ioa6614q.h:#  define FLASHEND     0x7FFFU
./avr/ioa6616c.h:#  define FLASHEND     0x1FFFU
./avr/ioa6617c.h:#  define FLASHEND     0x3FFFU
./avr/ioa664251.h:#  define FLASHEND     0x3FFFU
./avr/ioa8210.h:#  define FLASHEND     0xCFFFU
./avr/ioa8510.h:#  define FLASHEND     0xCFFFU
./avr/iom1284.h:#  define FLASHEND     0x1FFFFU
./avr/iom1284rfr2.h:#  define FLASHEND     0x1FFFFU
./avr/iom128a.h:#  define FLASHEND     0x1FFFFU
./avr/iom128rfr2.h:#  define FLASHEND     0x1FFFFU
./avr/iom164pa.h:#  define FLASHEND     0x3FFFU
./avr/iom165pa.h:#  define FLASHEND     0x3FFFU
./avr/iom168pa.h:#  define FLASHEND     0x3FFFU
./avr/iom168pb.h:#  define FLASHEND     0x3FFFU
./avr/iom2564rfr2.h:#  define FLASHEND     0x3FFFFU
./avr/iom256rfr2.h:#  define FLASHEND     0x3FFFFU
./avr/iom324a.h:#  define FLASHEND     0x7FFFU
./avr/iom324p.h:#  define FLASHEND     0x7FFFU
./avr/iom3250pa.h:#  define FLASHEND     0x7FFFU
./avr/iom325pa.h:#  define FLASHEND     0x7FFFU
./avr/iom3290pa.h:#  define FLASHEND     0x7FFFU
./avr/iom329p.h:#  define FLASHEND     0x7FFFU
./avr/iom32a.h:#  define FLASHEND     0x7FFFU
./avr/iom48pa.h:#  define FLASHEND     0x0FFFU
./avr/iom48pb.h:#  define FLASHEND     0x0FFFU
./avr/iom644rfr2.h:#  define FLASHEND     0xFFFFU
./avr/iom64a.h:#  define FLASHEND     0xFFFFU
./avr/iom64hve2.h:#  define FLASHEND     0xFFFFU
./avr/iom64rfr2.h:#  define FLASHEND     0xFFFFU
./avr/iom88pb.h:#  define FLASHEND     0x1FFFU
./avr/iom8a.h:#  define FLASHEND     0x1FFFU
./avr/iotn1634.h:#  define FLASHEND     0x3FFFU
./avr/iotn441.h:#  define FLASHEND     0x0FFFU
./avr/iotn828.h:#  define FLASHEND     0x1FFFU
./avr/iotn841.h:#  define FLASHEND     0x1FFFU
```

Maybe `bootloader_size.c` should be changed to `bootloader_size.S` instead (and preprocessed using assembler options); I did not try that variant yet.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
