### PR TITLE
Lazy-load "qmk console" dependencies

### DIFF
--- a/lib/python/qmk/cli/console.py
+++ b/lib/python/qmk/cli/console.py
@@ -6,9 +6,6 @@ from pathlib import Path
 from threading import Thread
 from time import sleep, strftime
 
-import hid
-import usb.core
-
 from milc import cli
 
 LOG_COLOR = {
@@ -262,6 +259,12 @@ def list_devices(device_finder):
 def console(cli):
     """Acquire debugging information from usb hid devices
     """
+
+    global hid
+    global usb
+    import hid
+    import usb.core
+
     vid = None
     pid = None
     index = 1


### PR DESCRIPTION
## Description

This keeps the rest of the cli usable even when `hidapi` and `pyusb` are not installed.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## PR checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
