### PR TITLE
Fleuron: Remove LAYOUTS = ortho_6x16

### DIFF
--- a/keyboards/fleuron/rules.mk
+++ b/keyboards/fleuron/rules.mk
@@ -30,4 +30,5 @@ BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
 AUDIO_ENABLE = no           # Audio output on port C6
 
 RGBLIGHT_ENABLE = yes
-LAYOUTS = ortho_6x16
+
+#LAYOUTS = ortho_6x16  # Disabled because layouts directory does not have an ortho_6x16 layout set up.


### PR DESCRIPTION
## Description

Removed ortho_6x16 community layout support by commenting out the line.

This can be reversed if that layout ever gets added.

cc @ju0 (keyboard maintainer)

## Types of Changes

- [x] Enhancement/optimization
- [x] Keyboard (addition or update)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
