### PR TITLE
For chibiOS I2C drive, move i2cconfig declaration in header file

### DIFF
--- a/drivers/chibios/i2c_master.c
+++ b/drivers/chibios/i2c_master.c
@@ -31,20 +31,6 @@
 
 static uint8_t i2c_address;
 
-static const I2CConfig i2cconfig = {
-#if defined(USE_I2CV1_CONTRIB)
-    I2C1_CLOCK_SPEED,
-#elif defined(USE_I2CV1)
-    I2C1_OPMODE,
-    I2C1_CLOCK_SPEED,
-    I2C1_DUTY_CYCLE,
-#else
-    // This configures the I2C clock to 400khz assuming a 72Mhz clock
-    // For more info : https://www.st.com/en/embedded-software/stsw-stm32126.html
-    STM32_TIMINGR_PRESC(I2C1_TIMINGR_PRESC) | STM32_TIMINGR_SCLDEL(I2C1_TIMINGR_SCLDEL) | STM32_TIMINGR_SDADEL(I2C1_TIMINGR_SDADEL) | STM32_TIMINGR_SCLH(I2C1_TIMINGR_SCLH) | STM32_TIMINGR_SCLL(I2C1_TIMINGR_SCLL), 0, 0
-#endif
-};
-
 static i2c_status_t chibios_to_qmk(const msg_t* status) {
     switch (*status) {
         case I2C_NO_ERROR:

--- a/drivers/chibios/i2c_master.h
+++ b/drivers/chibios/i2c_master.h
@@ -98,6 +98,20 @@
 #    endif
 #endif
 
+static const I2CConfig i2cconfig = {
+#if defined(USE_I2CV1_CONTRIB)
+    I2C1_CLOCK_SPEED,
+#elif defined(USE_I2CV1)
+    I2C1_OPMODE,
+    I2C1_CLOCK_SPEED,
+    I2C1_DUTY_CYCLE,
+#else
+    // This configures the I2C clock to 400khz assuming a 72Mhz clock
+    // For more info : https://www.st.com/en/embedded-software/stsw-stm32126.html
+    STM32_TIMINGR_PRESC(I2C1_TIMINGR_PRESC) | STM32_TIMINGR_SCLDEL(I2C1_TIMINGR_SCLDEL) | STM32_TIMINGR_SDADEL(I2C1_TIMINGR_SDADEL) | STM32_TIMINGR_SCLH(I2C1_TIMINGR_SCLH) | STM32_TIMINGR_SCLL(I2C1_TIMINGR_SCLL), 0, 0
+#endif
+};
+
 typedef int16_t i2c_status_t;
 
 #define I2C_STATUS_SUCCESS (0)


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
In some complex scenarios the qmk i2c functions are not enough and falling back to the chibiOS i2c functions is needed. To do this for a single configuration, one can reused the i2cconfig already defined.
Currently it lives in the .c file which makes it non usable outside the i2c_master library.
Moving it to the header file seems more correct.
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
