### PR TITLE
rewrote some of the logic to save code size

### DIFF
--- a/quantum/encoder.c
+++ b/quantum/encoder.c
@@ -45,6 +45,7 @@ static uint8_t encoder_resolutions[] = ENCODER_RESOLUTIONS;
 #    define ENCODER_CLOCKWISE false
 #    define ENCODER_COUNTER_CLOCKWISE true
 #endif
+static int8_t encoder_LUT[] = {0, -1, 1, 0, 1, 0, 0, -1};
 
 static uint8_t encoder_state[NUMBER_OF_ENCODERS]  = {0};
 static int8_t  encoder_pulses[NUMBER_OF_ENCODERS] = {0};
@@ -97,16 +98,6 @@ static uint8_t encoder_update(int8_t index, uint8_t state) {
     if (state & 0x8) {
         state = state ^ 0xF;
     }
-    //static int8_t encoder_LUT[] = {0, -1, 1, 0, 1, 0, 0, -1, <-- mirror --> -1, 0, 0, 1, 0, 1, -1, 0};
-
-    int8_t pulse;
-    switch (state) {
-        case 1: 
-        case 7: pulse = -1; break;
-        case 2: 
-        case 4: pulse = 1; break;
-        default: return 0;
-    }
 
     uint8_t i  = index;
 
@@ -118,7 +109,9 @@ static uint8_t encoder_update(int8_t index, uint8_t state) {
 
 #ifdef SPLIT_KEYBOARD
     index += thisHand;
-#endif  
+#endif
+
+    int8_t pulse = encoder_LUT[state];
     encoder_pulses[i] += pulse;
     if (encoder_pulses[i] >= resolution) {
         encoder_pulses[i] -= resolution;


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail here. -->
The ```encoder.c``` implementation was used by me to check ATMega32u4 assembly on godbolt.org. When studying the assembly and comparing it with the C code I noticed a lot of bloat. So some tweaking started and resulted in a ~70 bytes reduction in firmware size.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

  - [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
