### PR TITLE
Add a keymap with a scrolling mode for the Ploopy Nano trackball

### DIFF
--- a/keyboards/ploopyco/trackball_nano/keymaps/maddie/keymap.c
+++ b/keyboards/ploopyco/trackball_nano/keymaps/maddie/keymap.c
@@ -20,7 +20,7 @@
 
 // safe range starts at `PLOOPY_SAFE_RANGE` instead.
 uint8_t scroll_enabled = 0;
-uint8_t lock_state = 5;
+uint8_t lock_state = 0;
 int16_t delta_x = 0;
 int16_t delta_y = 0;
 

--- a/keyboards/ploopyco/trackball_nano/keymaps/maddie/keymap.c
+++ b/keyboards/ploopyco/trackball_nano/keymaps/maddie/keymap.c
@@ -34,8 +34,7 @@ void process_mouse_user(report_mouse_t *mouse_report, int16_t x, int16_t y) {
 		if (delta_x > 60) {
 			mouse_report->h = 1;
 			delta_x = 0;
-		}
-		else if (delta_x < -60) {
+		} else if (delta_x < -60) {
 			mouse_report->h = -1;
 			delta_x = 0;
 		}
@@ -43,13 +42,11 @@ void process_mouse_user(report_mouse_t *mouse_report, int16_t x, int16_t y) {
 		if (delta_y > 15) {
 			mouse_report->v = -1;
 			delta_y = 0;
-		}
-		else if (delta_y < -15) {
+		} else if (delta_y < -15) {
 			mouse_report->v = 1;
 			delta_y = 0;
 		}
-	}
-	else {
+	} else {
 		mouse_report->x = x;
 		mouse_report->y = y;
 	}

--- a/keyboards/ploopyco/trackball_nano/keymaps/maddie/keymap.c
+++ b/keyboards/ploopyco/trackball_nano/keymaps/maddie/keymap.c
@@ -1,0 +1,84 @@
+/* Copyright 2021 Colin Lam (Ploopy Corporation)
+ * Copyright 2020 Christopher Courtney, aka Drashna Jael're  (@drashna) <drashna@live.com>
+ * Copyright 2019 Sunjun Kim
+ * Copyright 2019 Hiroyuki Okada
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include QMK_KEYBOARD_H
+
+// safe range starts at `PLOOPY_SAFE_RANGE` instead.
+uint8_t scroll_enabled = 0;
+uint8_t lock_state = 5;
+int16_t delta_x = 0;
+int16_t delta_y = 0;
+
+void process_mouse_user(report_mouse_t *mouse_report, int16_t x, int16_t y) {
+	if (scroll_enabled) {
+		mouse_report->x = 0;
+		mouse_report->y = 0;
+		delta_x += x;
+		delta_y += y;
+		
+		if (delta_x > 60) {
+			mouse_report->h = 1;
+			delta_x = 0;
+		}
+		else if (delta_x < -60) {
+			mouse_report->h = -1;
+			delta_x = 0;
+		}
+
+		if (delta_y > 15) {
+			mouse_report->v = -1;
+			delta_y = 0;
+		}
+		else if (delta_y < -15) {
+			mouse_report->v = 1;
+			delta_y = 0;
+		}
+	}
+	else {
+		mouse_report->x = x;
+		mouse_report->y = y;
+	}
+}
+
+void keyboard_post_init_user(void) {
+	lock_state = host_keyboard_led_state().num_lock;
+}
+
+bool led_update_user(led_t led_state) {
+	static uint8_t lock_count = 0;
+	static uint16_t scroll_timer = 0;
+
+	if (timer_elapsed(scroll_timer) > 25) {
+		scroll_timer = timer_read();
+		lock_count = 0;
+	}
+    
+	if (led_state.num_lock != lock_state) {
+		lock_count++;
+
+		if (lock_count == 2) {
+			scroll_enabled = !scroll_enabled;
+			lock_count = 0;
+			delta_x = 0;
+			delta_y = 0;
+		}
+	}
+    
+	lock_state = led_state.num_lock;
+	return true;
+}

--- a/keyboards/ploopyco/trackball_nano/keymaps/maddie/keymap.c
+++ b/keyboards/ploopyco/trackball_nano/keymaps/maddie/keymap.c
@@ -26,8 +26,6 @@ int16_t delta_y = 0;
 
 void process_mouse_user(report_mouse_t *mouse_report, int16_t x, int16_t y) {
 	if (scroll_enabled) {
-		mouse_report->x = 0;
-		mouse_report->y = 0;
 		delta_x += x;
 		delta_y += y;
 		

--- a/keyboards/ploopyco/trackball_nano/keymaps/maddie/readme.md
+++ b/keyboards/ploopyco/trackball_nano/keymaps/maddie/readme.md
@@ -1,0 +1,1 @@
+toggles scroll mode when numlock is double-tapped within 25ms. add a macro or something, unless you have ungodly fast fingers.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
This keymap adds a scrolling mode for the Ploopy Nano, accessed by toggling numlock twice within 25ms.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
