### PR TITLE
Add dire message about lufa ms bootloader

### DIFF
--- a/bootloader.mk
+++ b/bootloader.mk
@@ -89,11 +89,13 @@ ifeq ($(strip $(BOOTLOADER)), USBasp)
     BOOTLOADER_SIZE = 4096
 endif
 ifeq ($(strip $(BOOTLOADER)), lufa-ms)
-    # DO NOT USE THIS BOOTLOADER IN NEW PROJECTS!
-    # It is extremely prone to bricking, and is only included to support existing boards.
     OPT_DEFS += -DBOOTLOADER_MS
     BOOTLOADER_SIZE = 6144
     FIRMWARE_FORMAT = bin
+    $(info LUFA MASS STORAGE Bootloader selected)
+    $(info DO NOT USE THIS BOOTLOADER IN NEW PROJECTS!)
+    $(info It is extremely prone to bricking, and is only included to support existing boards.)
+    $(info )
 endif
 ifdef BOOTLOADER_SIZE
     OPT_DEFS += -DBOOTLOADER_SIZE=$(strip $(BOOTLOADER_SIZE))


### PR DESCRIPTION
## Description

Instead of just having a comment for the LUFA mass storage bootloader in the makefile, this prints it out to the console, too.

Couldn't get it to print all pretty. So ... 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
