### PR TITLE
Retain brightness with lighting layers

### DIFF
--- a/docs/feature_rgblight.md
+++ b/docs/feature_rgblight.md
@@ -326,6 +326,10 @@ would turn the layer 0 (or 1) on and off again three times when `DEBUG` is press
 
 Normally lighting layers are not shown when RGB Lighting is disabled (e.g. with `RGB_TOG` keycode). If you would like lighting layers to work even when the RGB Lighting is otherwise off, add `#define RGBLIGHT_LAYERS_OVERRIDE_RGB_OFF` to your `config.h`.
 
+### Retain brightness
+
+Usually lighting layers apply their configured brightness once activated. If you would like lighting layers to retain the currently used brightness (as returned by `rgblight_get_val()`), add `#define RGBLIGHT_LAYERS_RETAIN_VAL` to your `config.h`.
+
 ## Functions
 
 If you need to change your RGB lighting in code, for example in a macro to change the color whenever you switch layers, QMK provides a set of functions to assist you. See [`rgblight.h`](https://github.com/qmk/qmk_firmware/blob/master/quantum/rgblight/rgblight.h) for the full list, but the most commonly used functions include:

--- a/quantum/rgblight/rgblight.c
+++ b/quantum/rgblight/rgblight.c
@@ -694,6 +694,9 @@ bool rgblight_get_layer_state(uint8_t layer) {
 
 // Write any enabled LED layers into the buffer
 static void rgblight_layers_write(void) {
+#    ifdef RGBLIGHT_LAYERS_RETAIN_VAL
+    uint8_t current_val = rgblight_get_val();
+#    endif
     uint8_t i = 0;
     // For each layer
     for (const rgblight_segment_t *const *layer_ptr = rgblight_layers; i < RGBLIGHT_MAX_LAYERS; layer_ptr++, i++) {
@@ -714,7 +717,11 @@ static void rgblight_layers_write(void) {
             // Write segment.count LEDs
             LED_TYPE *const limit = &led[MIN(segment.index + segment.count, RGBLED_NUM)];
             for (LED_TYPE *led_ptr = &led[segment.index]; led_ptr < limit; led_ptr++) {
+#    ifdef RGBLIGHT_LAYERS_RETAIN_VAL
+                sethsv(segment.hue, segment.sat, current_val, led_ptr);
+#    else
                 sethsv(segment.hue, segment.sat, segment.val, led_ptr);
+#    endif
             }
             segment_ptr++;
         }


### PR DESCRIPTION
Add guard `RGBLIGHT_LAYERS_RETAIN_VAL` to retain the currently used val (as returned by `rgblight_get_val()`)
when applying lighting layers.

- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
