### PR TITLE
Tidy up spi_master includes

### DIFF
--- a/drivers/avr/spi_master.c
+++ b/drivers/avr/spi_master.c
@@ -14,10 +14,8 @@
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include <avr/io.h>
-
 #include "spi_master.h"
-#include "quantum.h"
+
 #include "timer.h"
 
 #if defined(__AVR_AT90USB162__) || defined(__AVR_ATmega16U2__) || defined(__AVR_ATmega32U2__) || defined(__AVR_ATmega16U4__) || defined(__AVR_ATmega32U4__) || defined(__AVR_AT90USB646__) || defined(__AVR_AT90USB647__) || defined(__AVR_AT90USB1286__) || defined(__AVR_AT90USB1287__)

--- a/drivers/avr/spi_master.h
+++ b/drivers/avr/spi_master.h
@@ -16,7 +16,9 @@
 
 #pragma once
 
-#include "quantum.h"
+#include <stdbool.h>
+
+#include "gpio.h"
 
 typedef int16_t spi_status_t;
 

--- a/drivers/chibios/spi_master.c
+++ b/drivers/chibios/spi_master.c
@@ -15,7 +15,7 @@
  */
 
 #include "spi_master.h"
-#include "quantum.h"
+
 #include "timer.h"
 
 static pin_t     currentSlavePin = NO_PIN;

--- a/drivers/chibios/spi_master.h
+++ b/drivers/chibios/spi_master.h
@@ -18,7 +18,9 @@
 
 #include <ch.h>
 #include <hal.h>
-#include "quantum.h"
+#include <stdbool.h>
+
+#include "gpio.h"
 
 #ifndef SPI_DRIVER
 #    define SPI_DRIVER SPID2


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

A lot of things really do not need to include all of `quantum.h` now that the GPIO stuff has been refactored out. This change is needed for the ST7565 driver (adapted from the OLED driver) to work; some kind of circular dependency occurs otherwise, and it fails to compile:

![image](https://user-images.githubusercontent.com/4781841/120153695-61ce5e80-c232-11eb-9cdf-670907576caf.png)

There are a lot more places I think this should be done, though it'll be tricky to test.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
