### PR TITLE
[Keymap] Updates to personal Drop ALT keymap

### DIFF
--- a/keyboards/massdrop/alt/keymaps/ewersp/README.md
+++ b/keyboards/massdrop/alt/keymaps/ewersp/README.md
@@ -6,11 +6,13 @@ This keymap is very similar to the default keymap for the Drop ALT, but it overl
 
 ### For example:
 ```
-LeftAlt + 1...N      -> F1...FN
-LeftAlt + L/R Arrows -> Home/End
-LeftAlt + Home       -> End
-LeftAlt + Backspace  -> Delete
-LeftAlt + Esc        -> Backtick (`)
+LeftAlt + 1...N         -> F1...FN
+LeftAlt + L/R Arrows    -> Home/End
+LeftAlt + Home          -> End
+LeftAlt + Backspace     -> Delete
+LeftAlt + Esc           -> Backtick (`)
+LeftAlt + Shift + Esc   -> Tilde (~)
+LeftAlt + LeftShift + 4 -> Alt+F4
 ```
 
 The novel part of this keymap is that it **preserves the default functionality** of the left alt key, so ```'alt + tab', 'ctrl + alt + del', 'alt + f4'```, etc. all work as expected without using any janky timers.
@@ -22,8 +24,6 @@ This **'super alt'** keymap will feel very familiar for anyone **coming from mac
 And finally, the original alt key functionality can be toggled at any time by pressing **```'Fn + period'```** so even if you don't like it, you can turn it off.
 
 This keymap was based on the 'default' Drop ALT keymap (and _not_ 'default_md') which means it supports all the fancy QMK RGB patterns, and isn't limited to the stock options that come with the board.
-
-It's also worth noting that this keymap fixes an outstanding issue where the caps lock LED flickers when the RGB mode is keylight or underglow. I could not find a general purpose fix, but the one included here works quite well.
 
 If you have any questions, feel free to reach out to me at: ewersp [at] gmail [dot] com.
 

--- a/keyboards/massdrop/alt/keymaps/ewersp/keymap.c
+++ b/keyboards/massdrop/alt/keymaps/ewersp/keymap.c
@@ -38,7 +38,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         KC_GRV,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  _______, KC_MUTE,
         _______, RGB_SPD, RGB_VAI, RGB_SPI, RGB_HUI, RGB_SAI, _______, U_T_AUTO,U_T_AGCR,_______, KC_PSCR, KC_SLCK, KC_PAUS, _______, KC_END,
         _______, RGB_RMOD,RGB_VAD, RGB_MOD, RGB_HUD, RGB_SAD, _______, _______, _______, _______, _______, _______,          _______, KC_VOLU,
-        _______, RGB_TOG, _______, _______, _______, MD_BOOT, NK_TOGG, DBG_TOG, _______, TG(ALT), _______, _______,          KC_PGUP, KC_VOLD,
+        _______, RGB_TOG, _______, _______, EEP_RST, MD_BOOT, NK_TOGG, DBG_TOG, _______, TG(ALT), _______, _______,          KC_PGUP, KC_VOLD,
         _______, _______, KC_LALT,                            _______,                            _______, _______, KC_HOME, KC_PGDN, KC_END
     ),
     [SUPR] = LAYOUT_65_ansi_blocker(
@@ -50,11 +50,46 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     )
 };
 
-// If the super alt layer is the active layer
-bool super_alt_layer_active = false;
+// EEPROM storage mode
+enum alt_rgb_mode {
+    RGB_MODE_ALL,
+    RGB_MODE_KEYLIGHT,
+    RGB_MODE_UNDERGLOW,
+    RGB_MODE_NONE,
+};
 
-// If we need to unregister alt when leaving the super alt layer
-bool need_to_unregister_alt = false;
+// EEPROM storage type
+typedef union {
+    uint32_t raw;
+    struct {
+        uint8_t rgb_mode :8;
+    };
+} alt_config_t;
+
+alt_config_t alt_config;
+
+// Read from EEPROM on init to load the last saved mode
+void keyboard_post_init_kb(void) {
+    alt_config.raw = eeconfig_read_user();
+    switch (alt_config.rgb_mode) {
+        case RGB_MODE_ALL:
+            rgb_matrix_set_flags(LED_FLAG_ALL);
+            rgb_matrix_enable_noeeprom();
+            break;
+        case RGB_MODE_KEYLIGHT:
+            rgb_matrix_set_flags(LED_FLAG_KEYLIGHT);
+            rgb_matrix_set_color_all(0, 0, 0);
+            break;
+        case RGB_MODE_UNDERGLOW:
+            rgb_matrix_set_flags(LED_FLAG_UNDERGLOW);
+            rgb_matrix_set_color_all(0, 0, 0);
+            break;
+        case RGB_MODE_NONE:
+            rgb_matrix_set_flags(LED_FLAG_NONE);
+            rgb_matrix_disable_noeeprom();
+            break;
+    }
+}
 
 #define MODS_SHIFT  (get_mods() & MOD_BIT(KC_LSHIFT) || get_mods() & MOD_BIT(KC_RSHIFT))
 #define MODS_CTRL  (get_mods() & MOD_BIT(KC_LCTL) || get_mods() & MOD_BIT(KC_RCTRL))
@@ -62,6 +97,12 @@ bool need_to_unregister_alt = false;
 
 // Taken from 'g_led_config' in config_led.c
 #define CAPS_LOCK_LED_ID 30
+
+// If the super alt layer is the active layer
+bool super_alt_layer_active = false;
+
+// If we need to unregister alt when leaving the super alt layer
+bool need_to_unregister_alt = false;
 
 // This runs every matrix scan (every 'frame')
 void rgb_matrix_indicators_user(void) {
@@ -174,30 +215,44 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
                 }
             }
             return false;
+        case EEP_RST:
+            if (record->event.pressed) {
+                key_timer = timer_read32();
+            } else {
+                if (timer_elapsed32(key_timer) >= 500) {
+                    eeconfig_init();
+                }
+            }
+            return false;
         case RGB_TOG:
             if (record->event.pressed) {
-              switch (rgb_matrix_get_flags()) {
-                case LED_FLAG_ALL: {
-                    rgb_matrix_set_flags(LED_FLAG_KEYLIGHT);
-                    rgb_matrix_set_color_all(0, 0, 0);
-                  }
-                  break;
-                case LED_FLAG_KEYLIGHT: {
-                    rgb_matrix_set_flags(LED_FLAG_UNDERGLOW);
-                    rgb_matrix_set_color_all(0, 0, 0);
-                  }
-                  break;
-                case LED_FLAG_UNDERGLOW: {
-                    rgb_matrix_set_flags(LED_FLAG_NONE);
-                    rgb_matrix_disable_noeeprom();
-                  }
-                  break;
-                default: {
-                    rgb_matrix_set_flags(LED_FLAG_ALL);
-                    rgb_matrix_enable_noeeprom();
-                  }
-                  break;
-              }
+                switch (rgb_matrix_get_flags()) {
+                    case LED_FLAG_ALL: {
+                        alt_config.rgb_mode = RGB_MODE_KEYLIGHT;
+                        rgb_matrix_set_flags(LED_FLAG_KEYLIGHT);
+                        rgb_matrix_set_color_all(0, 0, 0);
+                        break;
+                    }
+                    case LED_FLAG_KEYLIGHT: {
+                        alt_config.rgb_mode = RGB_MODE_UNDERGLOW;
+                        rgb_matrix_set_flags(LED_FLAG_UNDERGLOW);
+                        rgb_matrix_set_color_all(0, 0, 0);
+                        break;
+                    }
+                    case LED_FLAG_UNDERGLOW: {
+                        alt_config.rgb_mode = RGB_MODE_NONE;
+                        rgb_matrix_set_flags(LED_FLAG_NONE);
+                        rgb_matrix_disable_noeeprom();
+                        break;
+                    }
+                    default: {
+                        alt_config.rgb_mode = RGB_MODE_ALL;
+                        rgb_matrix_set_flags(LED_FLAG_ALL);
+                        rgb_matrix_enable_noeeprom();
+                        break;
+                    }
+                }
+                eeconfig_update_user(alt_config.raw);
             }
             return false;
         default:

--- a/keyboards/massdrop/alt/keymaps/ewersp/keymap.c
+++ b/keyboards/massdrop/alt/keymaps/ewersp/keymap.c
@@ -95,30 +95,11 @@ void keyboard_post_init_kb(void) {
 #define MODS_CTRL  (get_mods() & MOD_BIT(KC_LCTL) || get_mods() & MOD_BIT(KC_RCTRL))
 #define MODS_ALT  (get_mods() & MOD_BIT(KC_LALT) || get_mods() & MOD_BIT(KC_RALT))
 
-// Taken from 'g_led_config' in config_led.c
-#define CAPS_LOCK_LED_ID 30
-
 // If the super alt layer is the active layer
 bool super_alt_layer_active = false;
 
 // If we need to unregister alt when leaving the super alt layer
 bool need_to_unregister_alt = false;
-
-// This runs every matrix scan (every 'frame')
-void rgb_matrix_indicators_user(void) {
-    led_flags_t flags = rgb_matrix_get_flags();
-
-    // If we're in either keylight or underglow modes (but not both simultaneously)
-    if (HAS_FLAGS(flags, LED_FLAG_KEYLIGHT) != HAS_FLAGS(flags, LED_FLAG_UNDERGLOW)) {
-
-        // This fixes a bug where the caps lock LED flickers when toggled in either keylight or underglow modes
-        if (host_keyboard_leds() & (1 << USB_LED_CAPS_LOCK)) {
-            rgb_matrix_set_color(CAPS_LOCK_LED_ID, RGB_WHITE);
-        } else {
-            rgb_matrix_set_color(CAPS_LOCK_LED_ID, 0, 0, 0);
-        }
-    }
-}
 
 // This runs code every time that the layers get changed
 layer_state_t layer_state_set_user(layer_state_t state) {
@@ -228,27 +209,27 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             if (record->event.pressed) {
                 switch (rgb_matrix_get_flags()) {
                     case LED_FLAG_ALL: {
-                        alt_config.rgb_mode = RGB_MODE_KEYLIGHT;
-                        rgb_matrix_set_flags(LED_FLAG_KEYLIGHT);
+                        rgb_matrix_set_flags(LED_FLAG_KEYLIGHT | LED_FLAG_MODIFIER | LED_FLAG_INDICATOR);
                         rgb_matrix_set_color_all(0, 0, 0);
+                        alt_config.rgb_mode = RGB_MODE_KEYLIGHT;
                         break;
                     }
-                    case LED_FLAG_KEYLIGHT: {
-                        alt_config.rgb_mode = RGB_MODE_UNDERGLOW;
+                    case (LED_FLAG_KEYLIGHT | LED_FLAG_MODIFIER | LED_FLAG_INDICATOR): {
                         rgb_matrix_set_flags(LED_FLAG_UNDERGLOW);
                         rgb_matrix_set_color_all(0, 0, 0);
+                        alt_config.rgb_mode = RGB_MODE_UNDERGLOW;
                         break;
                     }
                     case LED_FLAG_UNDERGLOW: {
-                        alt_config.rgb_mode = RGB_MODE_NONE;
                         rgb_matrix_set_flags(LED_FLAG_NONE);
                         rgb_matrix_disable_noeeprom();
+                        alt_config.rgb_mode = RGB_MODE_NONE;
                         break;
                     }
                     default: {
-                        alt_config.rgb_mode = RGB_MODE_ALL;
                         rgb_matrix_set_flags(LED_FLAG_ALL);
                         rgb_matrix_enable_noeeprom();
+                        alt_config.rgb_mode = RGB_MODE_ALL;
                         break;
                     }
                 }

--- a/keyboards/massdrop/alt/keymaps/ewersp/keymap.c
+++ b/keyboards/massdrop/alt/keymaps/ewersp/keymap.c
@@ -118,6 +118,16 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             }
             // We still want to process the keycode normally
             return true;
+        case KC_F4:
+            // Map alt+shift+4 to alt+f4
+            if (super_alt_layer_active && (get_mods() & MOD_BIT(KC_LSHIFT))) {
+                if (record->event.pressed) {
+                    register_code(KC_LALT);
+                } else {
+                    unregister_code(KC_LALT);
+                }
+            }
+            return true;
         case ALT_DEL:
             if (record->event.pressed) {
                 register_code(KC_DEL);


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail here. -->
This PR contains small updates to my personal keymap for the Drop ALT keyboard. Primarily the changes are to enable EEPROM persistence for the RGB mode, to avoid having to reset the RGB pattern every time the board loses power.

It's worth noting that EEPROM is still disabled by default for the Drop ALT, so for this to actually work changes are also needed from https://github.com/qmk/qmk_firmware/pull/6068 which is unfortunately stuck in limbo.

I'd still like to get these keymap changes into mainline though, as they compile and run fine on their own.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
