### PR TITLE
Fix Bug with (RGB|LED)_DISABLE_WHEN_USB_SUSPENDED define 

### DIFF
--- a/quantum/led_matrix.c
+++ b/quantum/led_matrix.c
@@ -67,7 +67,7 @@ const led_point_t k_led_matrix_center = LED_MATRIX_CENTER;
 #    define LED_DISABLE_TIMEOUT 0
 #endif
 
-#if LED_DISABLE_WHEN_USB_SUSPENDED == false
+#if LED_DISABLE_WHEN_USB_SUSPENDED != 1
 #    undef LED_DISABLE_WHEN_USB_SUSPENDED
 #endif
 

--- a/quantum/rgb_matrix.c
+++ b/quantum/rgb_matrix.c
@@ -67,7 +67,7 @@ __attribute__((weak)) RGB rgb_matrix_hsv_to_rgb(HSV hsv) { return hsv_to_rgb(hsv
 #    define RGB_DISABLE_TIMEOUT 0
 #endif
 
-#if RGB_DISABLE_WHEN_USB_SUSPENDED == false
+#if RGB_DISABLE_WHEN_USB_SUSPENDED != 1
 #    undef RGB_DISABLE_WHEN_USB_SUSPENDED
 #endif
 


### PR DESCRIPTION
# Description

The check actually errors out if not set to anything (just defined, per docs)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix


## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
