### PR TITLE
Allow limiting the multibuild based on keymap name.

### DIFF
--- a/lib/python/qmk/cli/multibuild.py
+++ b/lib/python/qmk/cli/multibuild.py
@@ -2,6 +2,7 @@
 
 This will compile everything in parallel, for testing purposes.
 """
+import os
 import re
 from pathlib import Path
 from subprocess import DEVNULL
@@ -11,6 +12,7 @@ from milc import cli
 from qmk.constants import QMK_FIRMWARE
 from qmk.commands import _find_make
 import qmk.keyboard
+import qmk.keymap
 
 
 def _make_rules_mk_filter(key, value):
@@ -29,6 +31,7 @@ def _is_split(keyboard_name):
 @cli.argument('-j', '--parallel', type=int, default=1, help="Set the number of parallel make jobs to run.")
 @cli.argument('-c', '--clean', arg_only=True, action='store_true', help="Remove object files before compiling.")
 @cli.argument('-f', '--filter', arg_only=True, action='append', default=[], help="Filter the list of keyboards based on the supplied value in rules.mk. Supported format is 'SPLIT_KEYBOARD=yes'. May be passed multiple times.")
+@cli.argument('-km', '--keymap', type=str, default='default', help="The keymap name to build. Default is 'default'.")
 @cli.subcommand('Compile QMK Firmware for all keyboards.', hidden=False if cli.config.user.developer else True)
 def multibuild(cli):
     """Compile QMK Firmware against all keyboards.
@@ -57,23 +60,29 @@ def multibuild(cli):
     builddir.mkdir(parents=True, exist_ok=True)
     with open(makefile, "w") as f:
         for keyboard_name in keyboard_list:
-            keyboard_safe = keyboard_name.replace('/', '_')
-            # yapf: disable
-            f.write(
-                f"""\
+            if qmk.keymap.locate_keymap(keyboard_name, cli.args.keymap) is not None:
+                keyboard_safe = keyboard_name.replace('/', '_')
+                # yapf: disable
+                f.write(
+                    f"""\
 all: {keyboard_safe}_binary
 {keyboard_safe}_binary:
 	@rm -f "{QMK_FIRMWARE}/.build/failed.log.{keyboard_safe}" || true
-	+@$(MAKE) -C "{QMK_FIRMWARE}" -f "{QMK_FIRMWARE}/build_keyboard.mk" KEYBOARD="{keyboard_name}" KEYMAP="default" REQUIRE_PLATFORM_KEY= COLOR=true SILENT=false \\
-		>>"{QMK_FIRMWARE}/.build/build.log.{keyboard_safe}" 2>&1 \\
-		|| cp "{QMK_FIRMWARE}/.build/build.log.{keyboard_safe}" "{QMK_FIRMWARE}/.build/failed.log.{keyboard_safe}"
-	@{{ grep '\[ERRORS\]' "{QMK_FIRMWARE}/.build/build.log.{keyboard_safe}" >/dev/null 2>&1 && printf "Build %-64s \e[1;31m[ERRORS]\e[0m\\n" "{keyboard_name}:default" ; }} \\
-		|| {{ grep '\[WARNINGS\]' "{QMK_FIRMWARE}/.build/build.log.{keyboard_safe}" >/dev/null 2>&1 && printf "Build %-64s \e[1;33m[WARNINGS]\e[0m\\n" "{keyboard_name}:default" ; }} \\
-		|| printf "Build %-64s \e[1;32m[OK]\e[0m\\n" "{keyboard_name}:default"
-	@rm -f "{QMK_FIRMWARE}/.build/build.log.{keyboard_safe}" || true
+	+@$(MAKE) -C "{QMK_FIRMWARE}" -f "{QMK_FIRMWARE}/build_keyboard.mk" KEYBOARD="{keyboard_name}" KEYMAP="{cli.args.keymap}" REQUIRE_PLATFORM_KEY= COLOR=true SILENT=false \\
+		>>"{QMK_FIRMWARE}/.build/build.log.{os.getpid()}.{keyboard_safe}" 2>&1 \\
+		|| cp "{QMK_FIRMWARE}/.build/build.log.{os.getpid()}.{keyboard_safe}" "{QMK_FIRMWARE}/.build/failed.log.{os.getpid()}.{keyboard_safe}"
+	@{{ grep '\[ERRORS\]' "{QMK_FIRMWARE}/.build/build.log.{os.getpid()}.{keyboard_safe}" >/dev/null 2>&1 && printf "Build %-64s \e[1;31m[ERRORS]\e[0m\\n" "{keyboard_name}:{cli.args.keymap}" ; }} \\
+		|| {{ grep '\[WARNINGS\]' "{QMK_FIRMWARE}/.build/build.log.{os.getpid()}.{keyboard_safe}" >/dev/null 2>&1 && printf "Build %-64s \e[1;33m[WARNINGS]\e[0m\\n" "{keyboard_name}:{cli.args.keymap}" ; }} \\
+		|| printf "Build %-64s \e[1;32m[OK]\e[0m\\n" "{keyboard_name}:{cli.args.keymap}"
+	@rm -f "{QMK_FIRMWARE}/.build/build.log.{os.getpid()}.{keyboard_safe}" || true
 
 """# noqa
-            )
-            # yapf: enable
+                )
+                # yapf: enable
 
     cli.run([make_cmd, '-j', str(cli.args.parallel), '-f', makefile.as_posix(), 'all'], capture_output=False, stdin=DEVNULL)
+
+    # Check for failures
+    failures = [f for f in builddir.glob(f'failed.log.{os.getpid()}.*')]
+    if len(failures) > 0:
+        return False


### PR DESCRIPTION
## Description

Adds support for specifying keymap name for `qmk multibuild`. Intentionally does not use decorators, as we don't want to use the user-configured one by default -- intent of the command is to build everything in the repository.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
