### PR TITLE
mousekey: expose current report to users

### DIFF
--- a/quantum/mousekey.c
+++ b/quantum/mousekey.c
@@ -486,3 +486,5 @@ static void mousekey_debug(void) {
     print_dec(mousekey_accel);
     print(")\n");
 }
+
+report_mouse_t mousekey_get_report(void) { return mouse_report; }

--- a/quantum/mousekey.h
+++ b/quantum/mousekey.h
@@ -168,11 +168,12 @@ extern uint8_t mk_time_to_max;
 extern uint8_t mk_wheel_max_speed;
 extern uint8_t mk_wheel_time_to_max;
 
-void mousekey_task(void);
-void mousekey_on(uint8_t code);
-void mousekey_off(uint8_t code);
-void mousekey_clear(void);
-void mousekey_send(void);
+void           mousekey_task(void);
+void           mousekey_on(uint8_t code);
+void           mousekey_off(uint8_t code);
+void           mousekey_clear(void);
+void           mousekey_send(void);
+report_mouse_t mousekey_get_report(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Description

This exposes the current mousekey report to the keymap code.
The keymap code can then make decisions based on that, for example to toggle buttons.
For other subsystems like the normal keyboard and pointing devices the report is exposed in a similar way.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
