### PR TITLE
core: bump USB spec version in device descriptor to 2.0

### DIFF
--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -105,8 +105,6 @@ This is a C header file that is one of the first things included, and will persi
   * sets the USB polling rate in milliseconds for the keyboard, mouse, and shared (NKRO/media keys) interfaces
 * `#define USB_SUSPEND_WAKEUP_DELAY 200`
   * set the number of milliseconde to pause after sending a wakeup packet
-* `#define USB_VERSION_2`
-  * set the USB device descriptor to USB version 2.
 * `#define F_SCL 100000L`
   * sets the I2C clock rate speed for keyboards using I2C. The default is `400000L`, except for keyboards using `split_common`, where the default is `100000L`.
 

--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -105,6 +105,8 @@ This is a C header file that is one of the first things included, and will persi
   * sets the USB polling rate in milliseconds for the keyboard, mouse, and shared (NKRO/media keys) interfaces
 * `#define USB_SUSPEND_WAKEUP_DELAY 200`
   * set the number of milliseconde to pause after sending a wakeup packet
+* `#define USB_VERSION_2`
+  * set the USB device descriptor to USB version 2.
 * `#define F_SCL 100000L`
   * sets the I2C clock rate speed for keyboards using I2C. The default is `400000L`, except for keyboards using `split_common`, where the default is `100000L`.
 

--- a/tmk_core/protocol/usb_descriptor.c
+++ b/tmk_core/protocol/usb_descriptor.c
@@ -351,7 +351,11 @@ const USB_Descriptor_Device_t PROGMEM DeviceDescriptor = {
         .Size                   = sizeof(USB_Descriptor_Device_t),
         .Type                   = DTYPE_Device
     },
+#if defined(USB_VERSION_2)
+    .USBSpecification           = VERSION_BCD(2, 0, 0),
+#else
     .USBSpecification           = VERSION_BCD(1, 1, 0),
+#endif
 
 #if VIRTSER_ENABLE
     .Class                      = USB_CSCP_IADDeviceClass,

--- a/tmk_core/protocol/usb_descriptor.c
+++ b/tmk_core/protocol/usb_descriptor.c
@@ -351,11 +351,7 @@ const USB_Descriptor_Device_t PROGMEM DeviceDescriptor = {
         .Size                   = sizeof(USB_Descriptor_Device_t),
         .Type                   = DTYPE_Device
     },
-#if defined(USB_VERSION_2)
     .USBSpecification           = VERSION_BCD(2, 0, 0),
-#else
-    .USBSpecification           = VERSION_BCD(1, 1, 0),
-#endif
 
 #if VIRTSER_ENABLE
     .Class                      = USB_CSCP_IADDeviceClass,


### PR DESCRIPTION
## Description

The Teensy 4.x comes with USB 2.0 support. This change is required to make the device advertise itself as USB 2.0 in the USB device descriptor.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
