### PR TITLE
Update bcat's split_3x6_3 for Crkbd legacy removal

### DIFF
--- a/layouts/community/split_3x6_3/bcat/config.h
+++ b/layouts/community/split_3x6_3/bcat/config.h
@@ -16,15 +16,8 @@
 
 #pragma once
 
-#if defined(KEYBOARD_crkbd_rev1_common) || defined(KEYBOARD_crkbd_rev1_legacy)
+#if defined(KEYBOARD_crkbd_rev1)
 #    define EE_HANDS
-
-#    if defined(RGBLIGHT_ENABLE)
-/* Configure RGB for underglow only (first six LEDs on each side). */
-#        undef RGBLED_SPLIT
-#        define RGBLED_SPLIT \
-            { 6, 6 }
-#    endif
 
 #    if defined(RGB_MATRIX_ENABLE)
 /* Limit max RGB LED current to avoid tripping controller fuse. */

--- a/layouts/community/split_3x6_3/bcat/rules.mk
+++ b/layouts/community/split_3x6_3/bcat/rules.mk
@@ -1,9 +1,4 @@
-ifeq ($(strip $(KEYBOARD)), crkbd/rev1/common)
-	BOOTLOADER = atmel-dfu  # Elite-C
-
-	# Enable underglow only. (Split Common doesn't support RGB matrix on slave.)
-	RGBLIGHT_ENABLE = yes
-else ifeq ($(strip $(KEYBOARD)), crkbd/rev1/legacy)
+ifeq ($(strip $(KEYBOARD)), crkbd/rev1)
 	BOOTLOADER = atmel-dfu  # Elite-C
 
 	RGB_MATRIX_ENABLE = yes  # per-key RGB and underglow


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Just updating my `split_3x6_3` community layout to account for the recent deletion of the legacy Crkbd revision and the universal use of Split Common for Crkbd.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [X] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
