### PR TITLE
Add Mac centric Shift and Alt + GUI Macros

### DIFF
--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -381,27 +381,29 @@ See also: [Mouse Keys](feature_mouse_keys.md)
 
 See also: [Modifier Keys](feature_advanced_keycodes.md#modifier-keys)
 
-|Key       |Aliases                        |Description                                           |
-|----------|-------------------------------|------------------------------------------------------|
-|`LCTL(kc)`|`C(kc)`                        |Hold Left Control and press `kc`                      |
-|`LSFT(kc)`|`S(kc)`                        |Hold Left Shift and press `kc`                        |
-|`LALT(kc)`|`A(kc)`, `LOPT(kc)`            |Hold Left Alt and press `kc`                          |
-|`LGUI(kc)`|`G(kc)`, `LCMD(kc)`, `LWIN(kc)`|Hold Left GUI and press `kc`                          |
-|`RCTL(kc)`|                               |Hold Right Control and press `kc`                     |
-|`RSFT(kc)`|                               |Hold Right Shift and press `kc`                       |
-|`RALT(kc)`|`ROPT(kc)`, `ALGR(kc)`         |Hold Right Alt (AltGr) and press `kc`                 |
-|`RGUI(kc)`|`RCMD(kc)`, `LWIN(kc)`         |Hold Right GUI and press `kc`                         |
-|`SGUI(kc)`|`SCMD(kc)`, `SWIN(kc)`         |Hold Left Shift and GUI and press `kc`                |
-|`AGUI(kc)`|`ACMD(kc)`, `OCMD(kc)`         |Hold Left Alt and GUI and press `kc`                  |
-|`LCA(kc)` |                               |Hold Left Control and Alt and press `kc`              |
-|`LSA(kc)` |                               |Hold Left Shift and Left Alt and press `kc`           |
-|`RSA(kc)` |`SAGR(kc)`                     |Hold Right Shift and Right Alt (AltGr) and press `kc` |
-|`RCS(kc)` |                               |Hold Right Control and Right Shift and press `kc`     |
-|`LCAG(kc)`|                               |Hold Left Control, Alt and GUI and press `kc`         |
-|`MEH(kc)` |                               |Hold Left Control, Shift and Alt and press `kc`       |
-|`HYPR(kc)`|                               |Hold Left Control, Shift, Alt and GUI and press `kc`  |
-|`KC_MEH`  |                               |Left Control, Shift and Alt                           |
-|`KC_HYPR` |                               |Left Control, Shift, Alt and GUI                      |
+|Key       |Aliases                           |Description                                           |
+|----------|----------------------------------|------------------------------------------------------|
+|`LCTL(kc)`|`C(kc)`                           |Hold Left Control and press `kc`                      |
+|`LSFT(kc)`|`S(kc)`                           |Hold Left Shift and press `kc`                        |
+|`LALT(kc)`|`A(kc)`, `LOPT(kc)`               |Hold Left Alt and press `kc`                          |
+|`LGUI(kc)`|`G(kc)`, `LCMD(kc)`, `LWIN(kc)`   |Hold Left GUI and press `kc`                          |
+|`RCTL(kc)`|                                  |Hold Right Control and press `kc`                     |
+|`RSFT(kc)`|                                  |Hold Right Shift and press `kc`                       |
+|`RALT(kc)`|`ROPT(kc)`, `ALGR(kc)`            |Hold Right Alt (AltGr) and press `kc`                 |
+|`RGUI(kc)`|`RCMD(kc)`, `LWIN(kc)`            |Hold Right GUI and press `kc`                         |
+|`LSG(kc)` |`SGUI(kc)`, `SCMD(kc)`, `SWIN(kc)`|Hold Left Shift and Left GUI and press `kc`           |
+|`LAG(kc)` |                                  |Hold Left Alt and Left GUI and press `kc`             |
+|`RSG(kc)` |                                  |Hold Right Shift and Right GUI and press `kc`         |
+|`RAG(kc)` |                                  |Hold Right Alt and Right GUI and press `kc`           |
+|`LCA(kc)` |                                  |Hold Left Control and Alt and press `kc`              |
+|`LSA(kc)` |                                  |Hold Left Shift and Left Alt and press `kc`           |
+|`RSA(kc)` |`SAGR(kc)`                        |Hold Right Shift and Right Alt (AltGr) and press `kc` |
+|`RCS(kc)` |                                  |Hold Right Control and Right Shift and press `kc`     |
+|`LCAG(kc)`|                                  |Hold Left Control, Alt and GUI and press `kc`         |
+|`MEH(kc)` |                                  |Hold Left Control, Shift and Alt and press `kc`       |
+|`HYPR(kc)`|                                  |Hold Left Control, Shift, Alt and GUI and press `kc`  |
+|`KC_MEH`  |                                  |Left Control, Shift and Alt                           |
+|`KC_HYPR` |                                  |Left Control, Shift, Alt and GUI                      |
 
 ## Mod-Tap Keys :id=mod-tap-keys
 
@@ -418,8 +420,10 @@ See also: [Mod-Tap](mod_tap.md)
 |`RSFT_T(kc)` |                                                                 |Right Shift when held, `kc` when tapped                       |
 |`RALT_T(kc)` |`ROPT_T(kc)`, `ALGR_T(kc)`                                       |Right Alt (AltGr) when held, `kc` when tapped                 |
 |`RGUI_T(kc)` |`RCMD_T(kc)`, `RWIN_T(kc)`                                       |Right GUI when held, `kc` when tapped                         |
-|`SGUI_T(kc)` |`SCMD_T(kc)`, `SWIN_T(kc)`                                       |Left Shift and GUI when held, `kc` when tapped                |
-|`AGUI_T(kc)` |`ACMD_T(kc)`, `OCMD_T(kc)`                                       |Left Alt and GUI when held, `kc` when tapped                  |
+|`LSG_T(kc)`  |`SGUI_T(kc)`, `SCMD_T(kc)`, `SWIN_T(kc)`                         |Left Shift and GUI when held, `kc` when tapped                |
+|`LAG_T(kc)`  |                                                                 |Left Alt and GUI when held, `kc` when tapped                  |
+|`RSG_T(kc)`  |                                                                 |Right Shift and GUI when held, `kc` when tapped               |
+|`RAG_T(kc)`  |                                                                 |Right Alt and GUI when held, `kc` when tapped                 |
 |`LCA_T(kc)`  |                                                                 |Left Control and Alt when held, `kc` when tapped              |
 |`LSA_T(kc)`  |                                                                 |Left Shift and Left Alt when held, `kc` when tapped           |
 |`RSA_T(kc)`  |`SAGR_T(kc)`                                                     |Right Shift and Right Alt (AltGr) when held, `kc` when tapped |

--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -392,7 +392,7 @@ See also: [Modifier Keys](feature_advanced_keycodes.md#modifier-keys)
 |`RALT(kc)`|`ROPT(kc)`, `ALGR(kc)`         |Hold Right Alt (AltGr) and press `kc`                 |
 |`RGUI(kc)`|`RCMD(kc)`, `LWIN(kc)`         |Hold Right GUI and press `kc`                         |
 |`SGUI(kc)`|`SCMD(kc)`, `SWIN(kc)`         |Hold Left Shift and GUI and press `kc`                |
-|`AGUI(kc)`|`ACMD(kc)`, `AWIN(kc)`         |Hold Left Alt and GUI and press `kc`                  |
+|`AGUI(kc)`|`ACMD(kc)`, `OCMD(kc)`         |Hold Left Alt and GUI and press `kc`                  |
 |`LCA(kc)` |                               |Hold Left Control and Alt and press `kc`              |
 |`LSA(kc)` |                               |Hold Left Shift and Left Alt and press `kc`           |
 |`RSA(kc)` |`SAGR(kc)`                     |Hold Right Shift and Right Alt (AltGr) and press `kc` |
@@ -419,7 +419,7 @@ See also: [Mod-Tap](mod_tap.md)
 |`RALT_T(kc)` |`ROPT_T(kc)`, `ALGR_T(kc)`                                       |Right Alt (AltGr) when held, `kc` when tapped                 |
 |`RGUI_T(kc)` |`RCMD_T(kc)`, `RWIN_T(kc)`                                       |Right GUI when held, `kc` when tapped                         |
 |`SGUI_T(kc)` |`SCMD_T(kc)`, `SWIN_T(kc)`                                       |Left Shift and GUI when held, `kc` when tapped                |
-|`AGUI_T(kc)` |`ACMD_T(kc)`, `AWIN_T(kc)`                                       |Left Alt and GUI when held, `kc` when tapped                  |
+|`AGUI_T(kc)` |`ACMD_T(kc)`, `OCMD_T(kc)`                                       |Left Alt and GUI when held, `kc` when tapped                  |
 |`LCA_T(kc)`  |                                                                 |Left Control and Alt when held, `kc` when tapped              |
 |`LSA_T(kc)`  |                                                                 |Left Shift and Left Alt when held, `kc` when tapped           |
 |`RSA_T(kc)`  |`SAGR_T(kc)`                                                     |Right Shift and Right Alt (AltGr) when held, `kc` when tapped |

--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -392,6 +392,7 @@ See also: [Modifier Keys](feature_advanced_keycodes.md#modifier-keys)
 |`RALT(kc)`|`ROPT(kc)`, `ALGR(kc)`         |Hold Right Alt (AltGr) and press `kc`                 |
 |`RGUI(kc)`|`RCMD(kc)`, `LWIN(kc)`         |Hold Right GUI and press `kc`                         |
 |`SGUI(kc)`|`SCMD(kc)`, `SWIN(kc)`         |Hold Left Shift and GUI and press `kc`                |
+|`AGUI(kc)`|`ACMD(kc)`, `AWIN(kc)`         |Hold Left Alt and GUI and press `kc`                  |
 |`LCA(kc)` |                               |Hold Left Control and Alt and press `kc`              |
 |`LSA(kc)` |                               |Hold Left Shift and Left Alt and press `kc`           |
 |`RSA(kc)` |`SAGR(kc)`                     |Hold Right Shift and Right Alt (AltGr) and press `kc` |
@@ -418,6 +419,7 @@ See also: [Mod-Tap](mod_tap.md)
 |`RALT_T(kc)` |`ROPT_T(kc)`, `ALGR_T(kc)`                                       |Right Alt (AltGr) when held, `kc` when tapped                 |
 |`RGUI_T(kc)` |`RCMD_T(kc)`, `RWIN_T(kc)`                                       |Right GUI when held, `kc` when tapped                         |
 |`SGUI_T(kc)` |`SCMD_T(kc)`, `SWIN_T(kc)`                                       |Left Shift and GUI when held, `kc` when tapped                |
+|`AGUI_T(kc)` |`ACMD_T(kc)`, `AWIN_T(kc)`                                       |Left Alt and GUI when held, `kc` when tapped                  |
 |`LCA_T(kc)`  |                                                                 |Left Control and Alt when held, `kc` when tapped              |
 |`LSA_T(kc)`  |                                                                 |Left Shift and Left Alt when held, `kc` when tapped           |
 |`RSA_T(kc)`  |`SAGR_T(kc)`                                                     |Right Shift and Right Alt (AltGr) when held, `kc` when tapped |

--- a/docs/mod_tap.md
+++ b/docs/mod_tap.md
@@ -37,8 +37,10 @@ For convenience, QMK includes some Mod-Tap shortcuts to make common combinations
 |`RSFT_T(kc)`|                                                                 |Right Shift when held, `kc` when tapped                       |
 |`RALT_T(kc)`|`ROPT_T(kc)`, `ALGR_T(kc)`                                       |Right Alt when held, `kc` when tapped                         |
 |`RGUI_T(kc)`|`RCMD_T(kc)`, `RWIN_T(kc)`                                       |Right GUI when held, `kc` when tapped                         |
-|`SGUI_T(kc)`|`SCMD_T(kc)`, `SWIN_T(kc)`                                       |Left Shift and GUI when held, `kc` when tapped                |
-|`AGUI_T(kc)`|`ACMD_T(kc)`, `AWIN_T(kc)`                                       |Left Alt and GUI when held, `kc` when tapped                  |
+|`LSG_T(kc)` |`SGUI_T(kc)`, `SCMD_T(kc)`, `SWIN_T(kc)`                         |Left Shift and GUI when held, `kc` when tapped                |
+|`LAG_T(kc)` |                                                                 |Left Alt and GUI when held, `kc` when tapped                  |
+|`RSG_T(kc)` |                                                                 |Right Shift and GUI when held, `kc` when tapped               |
+|`RAG_T(kc)` |                                                                 |Right Alt and GUI when held, `kc` when tapped                 |
 |`LCA_T(kc)` |                                                                 |Left Control and Alt when held, `kc` when tapped              |
 |`LSA_T(kc)` |                                                                 |Left Shift and Alt when held, `kc` when tapped                |
 |`RSA_T(kc)` |`SAGR_T(kc)`                                                     |Right Shift and Right Alt (AltGr) when held, `kc` when tapped |

--- a/docs/mod_tap.md
+++ b/docs/mod_tap.md
@@ -38,6 +38,7 @@ For convenience, QMK includes some Mod-Tap shortcuts to make common combinations
 |`RALT_T(kc)`|`ROPT_T(kc)`, `ALGR_T(kc)`                                       |Right Alt when held, `kc` when tapped                         |
 |`RGUI_T(kc)`|`RCMD_T(kc)`, `RWIN_T(kc)`                                       |Right GUI when held, `kc` when tapped                         |
 |`SGUI_T(kc)`|`SCMD_T(kc)`, `SWIN_T(kc)`                                       |Left Shift and GUI when held, `kc` when tapped                |
+|`AGUI_T(kc)`|`ACMD_T(kc)`, `AWIN_T(kc)`                                       |Left Alt and GUI when held, `kc` when tapped                  |
 |`LCA_T(kc)` |                                                                 |Left Control and Alt when held, `kc` when tapped              |
 |`LSA_T(kc)` |                                                                 |Left Shift and Alt when held, `kc` when tapped                |
 |`RSA_T(kc)` |`SAGR_T(kc)`                                                     |Right Shift and Right Alt (AltGr) when held, `kc` when tapped |

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -538,12 +538,13 @@ enum quantum_keycodes {
 #define HYPR(kc) (QK_LCTL | QK_LSFT | QK_LALT | QK_LGUI | (kc))
 #define MEH(kc) (QK_LCTL | QK_LSFT | QK_LALT | (kc))
 #define LCAG(kc) (QK_LCTL | QK_LALT | QK_LGUI | (kc))
-#define SGUI(kc) (QK_LGUI | QK_LSFT | (kc))
-#define SCMD(kc) SGUI(kc)
-#define SWIN(kc) SGUI(kc)
-#define AGUI(kc) (QK_LGUI | QK_LALT | (kc))
-#define ACMD(kc) AGUI(kc)
-#define OCMD(kc) AGUI(kc)
+#define LSG(kc) (QK_LSFT | QK_LGUI | (kc))
+#define SGUI(kc) LSG(kc)
+#define SCMD(kc) LSG(kc)
+#define SWIN(kc) LSG(kc)
+#define LAG(kc) (QK_LALT | QK_LGUI | (kc))
+#define RSG(kc) (QK_RSFT | QK_RGUI | (kc))
+#define RAG(kc) (QK_RALT | QK_RGUI | (kc))
 #define LCA(kc) (QK_LCTL | QK_LALT | (kc))
 #define LSA(kc) (QK_LSFT | QK_LALT | (kc))
 #define RSA(kc) (QK_RSFT | QK_RALT | (kc))
@@ -768,12 +769,13 @@ enum quantum_keycodes {
 #define LCAG_T(kc) MT(MOD_LCTL | MOD_LALT | MOD_LGUI, kc)  // Left Control + Alt + GUI
 #define RCAG_T(kc) MT(MOD_RCTL | MOD_RALT | MOD_RGUI, kc)  // Right Control + Alt + GUI
 #define HYPR_T(kc) MT(MOD_LCTL | MOD_LSFT | MOD_LALT | MOD_LGUI, kc)  // see http://brettterpstra.com/2012/12/08/a-useful-caps-lock-key/
-#define SGUI_T(kc) MT(MOD_LGUI | MOD_LSFT, kc)  // Left Shift + GUI
-#define SCMD_T(kc) SGUI_T(kc)
-#define SWIN_T(kc) SGUI_T(kc)
-#define AGUI_T(kc) MT(MOD_LGUI | MOD_LALT, kc)  // Left Alt + GUI
-#define ACMD_T(kc) AGUI_T(kc)
-#define OCMD_T(kc) AGUI_T(kc)
+#define LSG_T(kc) MT(MOD_LSFT | MOD_LGUI, kc)  // Left Shift + GUI
+#define SGUI_T(kc) LSG_T(kc)
+#define SCMD_T(kc) LSG_T(kc)
+#define SWIN_T(kc) LSG_T(kc)
+#define LAG_T(kc) MT(MOD_LALT | MOD_LGUI, kc)  // Left Alt + GUI
+#define RSG_T(kc) MT(MOD_RSFT | MOD_RGUI, kc)  // Right Shift + GUI
+#define RAG_T(kc) MT(MOD_RALT | MOD_RGUI, kc)  // Right Alt + GUI
 #define LCA_T(kc) MT(MOD_LCTL | MOD_LALT, kc)  // Left Control + Alt
 #define LSA_T(kc) MT(MOD_LSFT | MOD_LALT, kc)  // Left Shift + Alt
 #define RSA_T(kc) MT(MOD_RSFT | MOD_RALT, kc)  // Right Shift + Alt

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -543,7 +543,7 @@ enum quantum_keycodes {
 #define SWIN(kc) SGUI(kc)
 #define AGUI(kc) (QK_LGUI | QK_LALT | (kc))
 #define ACMD(kc) AGUI(kc)
-#define AWIN(kc) AGUI(kc)
+#define OCMD(kc) AGUI(kc)
 #define LCA(kc) (QK_LCTL | QK_LALT | (kc))
 #define LSA(kc) (QK_LSFT | QK_LALT | (kc))
 #define RSA(kc) (QK_RSFT | QK_RALT | (kc))
@@ -773,7 +773,7 @@ enum quantum_keycodes {
 #define SWIN_T(kc) SGUI_T(kc)
 #define AGUI_T(kc) MT(MOD_LGUI | MOD_LALT, kc)  // Left Alt + GUI
 #define ACMD_T(kc) AGUI_T(kc)
-#define AWIN_T(kc) AGUI_T(kc)
+#define OCMD_T(kc) AGUI_T(kc)
 #define LCA_T(kc) MT(MOD_LCTL | MOD_LALT, kc)  // Left Control + Alt
 #define LSA_T(kc) MT(MOD_LSFT | MOD_LALT, kc)  // Left Shift + Alt
 #define RSA_T(kc) MT(MOD_RSFT | MOD_RALT, kc)  // Right Shift + Alt

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -541,6 +541,9 @@ enum quantum_keycodes {
 #define SGUI(kc) (QK_LGUI | QK_LSFT | (kc))
 #define SCMD(kc) SGUI(kc)
 #define SWIN(kc) SGUI(kc)
+#define AGUI(kc) (QK_LGUI | QK_LALT | (kc))
+#define ACMD(kc) AGUI(kc)
+#define AWIN(kc) AGUI(kc)
 #define LCA(kc) (QK_LCTL | QK_LALT | (kc))
 #define LSA(kc) (QK_LSFT | QK_LALT | (kc))
 #define RSA(kc) (QK_RSFT | QK_RALT | (kc))
@@ -768,6 +771,9 @@ enum quantum_keycodes {
 #define SGUI_T(kc) MT(MOD_LGUI | MOD_LSFT, kc)  // Left Shift + GUI
 #define SCMD_T(kc) SGUI_T(kc)
 #define SWIN_T(kc) SGUI_T(kc)
+#define AGUI_T(kc) MT(MOD_LGUI | MOD_LALT, kc)  // Left Alt + GUI
+#define ACMD_T(kc) AGUI_T(kc)
+#define AWIN_T(kc) AGUI_T(kc)
 #define LCA_T(kc) MT(MOD_LCTL | MOD_LALT, kc)  // Left Control + Alt
 #define LSA_T(kc) MT(MOD_LSFT | MOD_LALT, kc)  // Left Shift + Alt
 #define RSA_T(kc) MT(MOD_RSFT | MOD_RALT, kc)  // Right Shift + Alt


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Add macros for Option+Command (Alt + GUI) and Shift+Command (Shift + GUI) that are common shortcuts for OS X.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
