### PR TITLE
Fix includes for pmw3360 driver

### DIFF
--- a/keyboards/handwired/dactyl_manuform/5x6_right_trackball/pmw3360.c
+++ b/keyboards/handwired/dactyl_manuform/5x6_right_trackball/pmw3360.c
@@ -18,12 +18,12 @@
 
 #ifdef POINTING_DEVICE_ENABLE
 
+#include "wait.h"
+#include "debug.h"
+#include "print.h"
 #include "pmw3360.h"
 #include "pmw3360_firmware.h"
 
-#ifdef CONSOLE_ENABLE
-#    include "print.h"
-#endif
 bool _inBurst = false;
 
 #ifndef PMW_CPI
@@ -36,10 +36,7 @@ bool _inBurst = false;
 #    define ROTATIONAL_TRANSFORM_ANGLE 0x00
 #endif
 
-#ifdef CONSOLE_ENABLE
 void print_byte(uint8_t byte) { dprintf("%c%c%c%c%c%c%c%c|", (byte & 0x80 ? '1' : '0'), (byte & 0x40 ? '1' : '0'), (byte & 0x20 ? '1' : '0'), (byte & 0x10 ? '1' : '0'), (byte & 0x08 ? '1' : '0'), (byte & 0x04 ? '1' : '0'), (byte & 0x02 ? '1' : '0'), (byte & 0x01 ? '1' : '0')); }
-#endif
-
 
 bool spi_start_adv(void) {
     bool status = spi_start(SPI_SS_PIN, false, 3, SPI_DIVISOR);
@@ -173,9 +170,7 @@ bool pmw_check_signature(void) {
 
 report_pmw_t pmw_read_burst(void) {
     if (!_inBurst) {
-#ifdef CONSOLE_ENABLE
         dprintf("burst on");
-#endif
         spi_write_adv(REG_Motion_Burst, 0x00);
         _inBurst = true;
     }
@@ -200,14 +195,12 @@ report_pmw_t pmw_read_burst(void) {
 
     spi_stop();
 
-#ifdef CONSOLE_ENABLE
     print_byte(data.motion);
     print_byte(data.dx);
     print_byte(data.mdx);
     print_byte(data.dy);
     print_byte(data.mdy);
     dprintf("\n");
-#endif
 
     data.isMotion    = (data.motion & 0x80) != 0;
     data.isOnSurface = (data.motion & 0x08) == 0;

--- a/keyboards/ploopyco/pmw3360.c
+++ b/keyboards/ploopyco/pmw3360.c
@@ -16,13 +16,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
+#include "wait.h"
+#include "debug.h"
+#include "print.h"
 #include "pmw3360.h"
 #include "pmw3360_firmware.h"
 
-#ifdef CONSOLE_ENABLE
-#    include "print.h"
-#endif
 bool _inBurst = false;
 
 #ifndef PMW_CPI
@@ -35,9 +34,7 @@ bool _inBurst = false;
 #    define ROTATIONAL_TRANSFORM_ANGLE 0x00
 #endif
 
-#ifdef CONSOLE_ENABLE
 void print_byte(uint8_t byte) { dprintf("%c%c%c%c%c%c%c%c|", (byte & 0x80 ? '1' : '0'), (byte & 0x40 ? '1' : '0'), (byte & 0x20 ? '1' : '0'), (byte & 0x10 ? '1' : '0'), (byte & 0x08 ? '1' : '0'), (byte & 0x04 ? '1' : '0'), (byte & 0x02 ? '1' : '0'), (byte & 0x01 ? '1' : '0')); }
-#endif
 
 
 bool spi_start_adv(void) {
@@ -172,9 +169,7 @@ bool pmw_check_signature(void) {
 
 report_pmw_t pmw_read_burst(void) {
     if (!_inBurst) {
-#ifdef CONSOLE_ENABLE
         dprintf("burst on");
-#endif
         spi_write_adv(REG_Motion_Burst, 0x00);
         _inBurst = true;
     }
@@ -199,14 +194,12 @@ report_pmw_t pmw_read_burst(void) {
 
     spi_stop();
 
-#ifdef CONSOLE_ENABLE
     print_byte(data.motion);
     print_byte(data.dx);
     print_byte(data.mdx);
     print_byte(data.dy);
     print_byte(data.mdy);
     dprintf("\n");
-#endif
 
     data.isMotion    = (data.motion & 0x80) != 0;
     data.isOnSurface = (data.motion & 0x08) == 0;


### PR DESCRIPTION

## Description

#13053 broke the includes for the pmw3360.c files.  This fixes them.  

## Types of Changes

- [x] Keyboard (addition or update)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
