### PR TITLE
Fix overflows in WPM calculations

### DIFF
--- a/quantum/wpm.c
+++ b/quantum/wpm.c
@@ -69,14 +69,22 @@ __attribute__((weak)) uint8_t wpm_regress_count(uint16_t keycode) {
 void update_wpm(uint16_t keycode) {
     if (wpm_keycode(keycode)) {
         if (wpm_timer > 0) {
-            current_wpm += ((60000 / timer_elapsed(wpm_timer) / WPM_ESTIMATED_WORD_SIZE) - current_wpm) * wpm_smoothing;
+            uint16_t latest_wpm = 60000 / timer_elapsed(wpm_timer) / WPM_ESTIMATED_WORD_SIZE;
+            if (latest_wpm > UINT8_MAX) {
+                latest_wpm = UINT8_MAX;
+            }
+            current_wpm += (latest_wpm - current_wpm) * wpm_smoothing;
         }
         wpm_timer = timer_read();
     }
 #ifdef WPM_ALLOW_COUNT_REGRESSION
     uint8_t regress = wpm_regress_count(keycode);
     if (regress) {
-        current_wpm -= regress;
+        if (current_wpm < regress) {
+            current_wpm = 0;
+        } else {
+            current_wpm -= regress;
+        }
         wpm_timer = timer_read();
     }
 #endif

--- a/quantum/wpm.c
+++ b/quantum/wpm.c
@@ -17,6 +17,8 @@
 
 #include "wpm.h"
 
+#include <math.h>
+
 // WPM Stuff
 static uint8_t  current_wpm = 0;
 static uint16_t wpm_timer   = 0;
@@ -73,7 +75,7 @@ void update_wpm(uint16_t keycode) {
             if (latest_wpm > UINT8_MAX) {
                 latest_wpm = UINT8_MAX;
             }
-            current_wpm += (latest_wpm - current_wpm) * wpm_smoothing;
+            current_wpm += ceilf((latest_wpm - current_wpm) * wpm_smoothing);
         }
         wpm_timer = timer_read();
     }


### PR DESCRIPTION
Fix two possible overflows in WPM calculations.

## Description
First, the "fresh" WPM calculation could end up being up to 12000 (with default `WPM_ESTIMATED_WORD_SIZE`) if keys were pressed more or less simultaneously. This value has now been clamped down to 255, in effect clamping WPM to its max value of 255. Before #11727, the intermediate value in question was limited by being stored in a uint8_t (causing slightly random values after overflows).

Second, with `WPM_ALLOW_COUNT_REGRESSION` enabled, it was possible to regress the WPM below 0 (i.e. to 255) by just repeatedly pressing backspace.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
