### PR TITLE
added dual driver support for IS31FL3737

### DIFF
--- a/drivers/issi/is31fl3737.c
+++ b/drivers/issi/is31fl3737.c
@@ -66,10 +66,10 @@ uint8_t g_twi_transfer_buffer[20];
 // buffers and the transfers in IS31FL3737_write_pwm_buffer() but it's
 // probably not worth the extra complexity.
 uint8_t g_pwm_buffer[DRIVER_COUNT][192];
-bool    g_pwm_buffer_update_required = false;
+bool    g_pwm_buffer_update_required[DRIVER_COUNT] = {false};
 
-uint8_t g_led_control_registers[DRIVER_COUNT][24] = {{0}};
-bool    g_led_control_registers_update_required   = false;
+uint8_t g_led_control_registers[DRIVER_COUNT][24] = {0}; //{{0}};
+bool    g_led_control_registers_update_required[DRIVER_COUNT] = {false};
 
 void IS31FL3737_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
     g_twi_transfer_buffer[0] = reg;
@@ -158,7 +158,7 @@ void IS31FL3737_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
         g_pwm_buffer[led.driver][led.r] = red;
         g_pwm_buffer[led.driver][led.g] = green;
         g_pwm_buffer[led.driver][led.b] = blue;
-        g_pwm_buffer_update_required    = true;
+        g_pwm_buffer_update_required[led.driver] = true;
     }
 }
 
@@ -194,30 +194,30 @@ void IS31FL3737_set_led_control_register(uint8_t index, bool red, bool green, bo
         g_led_control_registers[led.driver][control_register_b] &= ~(1 << bit_b);
     }
 
-    g_led_control_registers_update_required = true;
+    g_led_control_registers_update_required[led.driver] = true;
 }
 
-void IS31FL3737_update_pwm_buffers(uint8_t addr1, uint8_t addr2) {
-    if (g_pwm_buffer_update_required) {
+void IS31FL3737_update_pwm_buffers(uint8_t addr, uint8_t index) {
+    if (g_pwm_buffer_update_required[index]) {
         // Firstly we need to unlock the command register and select PG1
-        IS31FL3737_write_register(addr1, ISSI_COMMANDREGISTER_WRITELOCK, 0xC5);
-        IS31FL3737_write_register(addr1, ISSI_COMMANDREGISTER, ISSI_PAGE_PWM);
+        IS31FL3737_write_register(addr, ISSI_COMMANDREGISTER_WRITELOCK, 0xC5);
+        IS31FL3737_write_register(addr, ISSI_COMMANDREGISTER, ISSI_PAGE_PWM);
 
-        IS31FL3737_write_pwm_buffer(addr1, g_pwm_buffer[0]);
+        IS31FL3737_write_pwm_buffer(addr, g_pwm_buffer[index]);
         // IS31FL3737_write_pwm_buffer(addr2, g_pwm_buffer[1]);
     }
-    g_pwm_buffer_update_required = false;
+    g_pwm_buffer_update_required[index] = false;
 }
 
-void IS31FL3737_update_led_control_registers(uint8_t addr1, uint8_t addr2) {
-    if (g_led_control_registers_update_required) {
+void IS31FL3737_update_led_control_registers(uint8_t addr, uint8_t index) {
+    if (g_led_control_registers_update_required[index]) {
         // Firstly we need to unlock the command register and select PG0
-        IS31FL3737_write_register(addr1, ISSI_COMMANDREGISTER_WRITELOCK, 0xC5);
-        IS31FL3737_write_register(addr1, ISSI_COMMANDREGISTER, ISSI_PAGE_LEDCONTROL);
+        IS31FL3737_write_register(addr, ISSI_COMMANDREGISTER_WRITELOCK, 0xC5);
+        IS31FL3737_write_register(addr, ISSI_COMMANDREGISTER, ISSI_PAGE_LEDCONTROL);
         for (int i = 0; i < 24; i++) {
-            IS31FL3737_write_register(addr1, i, g_led_control_registers[0][i]);
+            IS31FL3737_write_register(addr, i, g_led_control_registers[index][i]);
             // IS31FL3737_write_register(addr2, i, g_led_control_registers[1][i]);
         }
-        g_led_control_registers_update_required = false;
+        g_led_control_registers_update_required[index] = false;
     }
 }

--- a/drivers/issi/is31fl3737.c
+++ b/drivers/issi/is31fl3737.c
@@ -68,7 +68,7 @@ uint8_t g_twi_transfer_buffer[20];
 uint8_t g_pwm_buffer[DRIVER_COUNT][192];
 bool    g_pwm_buffer_update_required[DRIVER_COUNT] = {false};
 
-uint8_t g_led_control_registers[DRIVER_COUNT][24] = {0}; //{{0}};
+uint8_t g_led_control_registers[DRIVER_COUNT][24] = {0};
 bool    g_led_control_registers_update_required[DRIVER_COUNT] = {false};
 
 void IS31FL3737_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
@@ -218,6 +218,6 @@ void IS31FL3737_update_led_control_registers(uint8_t addr, uint8_t index) {
             IS31FL3737_write_register(addr, i, g_led_control_registers[index][i]);
             // IS31FL3737_write_register(addr2, i, g_led_control_registers[1][i]);
         }
-        g_led_control_registers_update_required[index] = false;
     }
+    g_led_control_registers_update_required[index] = false;
 }

--- a/quantum/rgb_matrix_drivers.c
+++ b/quantum/rgb_matrix_drivers.c
@@ -65,6 +65,9 @@ static void init(void) {
 #        endif
 #    elif defined(IS31FL3737)
     IS31FL3737_init(DRIVER_ADDR_1);
+#       ifdef DRIVER_ADDR_2
+    IS31FL3737_init(DRIVER_ADDR_2);
+#       endif
 #    else
     IS31FL3741_init(DRIVER_ADDR_1);
 #    endif
@@ -105,7 +108,10 @@ static void init(void) {
     IS31FL3733_update_led_control_registers(DRIVER_ADDR_4, 3);
 #        endif
 #    elif defined(IS31FL3737)
-    IS31FL3737_update_led_control_registers(DRIVER_ADDR_1, DRIVER_ADDR_2);
+    IS31FL3737_update_led_control_registers(DRIVER_ADDR_1, 0);
+#        ifdef DRIVER_ADDR_2
+    IS31FL3737_update_led_control_registers(DRIVER_ADDR_2, 1);
+#        endif
 #    else
     IS31FL3741_update_led_control_registers(DRIVER_ADDR_1, 0);
 #    endif
@@ -152,7 +158,12 @@ const rgb_matrix_driver_t rgb_matrix_driver = {
     .set_color_all = IS31FL3733_set_color_all,
 };
 #    elif defined(IS31FL3737)
-static void flush(void) { IS31FL3737_update_pwm_buffers(DRIVER_ADDR_1, DRIVER_ADDR_2); }
+static void flush(void) {
+    IS31FL3737_update_pwm_buffers(DRIVER_ADDR_1, 0);
+#        ifdef DRIVER_ADDR_2
+    IS31FL3737_update_pwm_buffers(DRIVER_ADDR_2, 1);
+#        endif
+}
 
 const rgb_matrix_driver_t rgb_matrix_driver = {
     .init = init,


### PR DESCRIPTION
Added dual driver support for RGB Matrix Driver IS31FL3737
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Changed IS31FL3737 drive config to mirror that of IS31FL3733.
IS31FL3737 now support DRIVER_COUNT 2 with ADDR1 and ADDR2.

if only one Driver is required the config.h file should now NOT include DRIVER_ADDR_2 and have DRIVER_COUNT = 1.    
Previously the code required DRIVER_ADDR_2 = DRIVER_ADDR_1 in order to compile and only one Driver was supported.

if two Drivers are required set DRIVER_COUNT = 2 and set DRIVER_ADDR_1 and DRIVER_ADDR_2 

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

Documentation has not been updated but happy to update.