### PR TITLE
Remove dfu-util arguments from mcu_selection

### DIFF
--- a/quantum/mcu_selection.mk
+++ b/quantum/mcu_selection.mk
@@ -136,10 +136,6 @@ ifneq ($(findstring STM32F042, $(MCU)),)
 
   USE_FPU ?= no
 
-  # Options to pass to dfu-util when flashing
-  DFU_ARGS ?= -d 0483:DF11 -a 0 -s 0x08000000:leave
-  DFU_SUFFIX_ARGS ?= -v 0483 -p DF11
-
   # UF2 settings
   UF2_FAMILY ?= STM32F0
 endif
@@ -171,10 +167,6 @@ ifneq ($(findstring STM32F072, $(MCU)),)
   BOARD ?= GENERIC_STM32_F072XB
 
   USE_FPU ?= no
-
-  # Options to pass to dfu-util when flashing
-  DFU_ARGS ?= -d 0483:DF11 -a 0 -s 0x08000000:leave
-  DFU_SUFFIX_ARGS ?= -v 0483 -p DF11
 
   # UF2 settings
   UF2_FAMILY ?= STM32F0
@@ -208,10 +200,6 @@ ifneq ($(findstring STM32F103, $(MCU)),)
 
   USE_FPU ?= no
 
-  # Options to pass to dfu-util when flashing
-  DFU_ARGS ?= -d 0483:DF11 -a 0 -s 0x08000000:leave
-  DFU_SUFFIX_ARGS ?= -v 0483 -p DF11
-
   # UF2 settings
   UF2_FAMILY ?= STM32F1
 endif
@@ -244,10 +232,6 @@ ifneq ($(findstring STM32F303, $(MCU)),)
 
   USE_FPU ?= yes
 
-  # Options to pass to dfu-util when flashing
-  DFU_ARGS ?= -d 0483:DF11 -a 0 -s 0x08000000:leave
-  DFU_SUFFIX_ARGS ?= -v 0483 -p DF11
-
   # UF2 settings
   UF2_FAMILY ?= STM32F3
 endif
@@ -279,10 +263,6 @@ ifneq ($(findstring STM32F401, $(MCU)),)
   BOARD ?= BLACKPILL_STM32_F401
 
   USE_FPU ?= yes
-
-  # Options to pass to dfu-util when flashing
-  DFU_ARGS ?= -d 0483:DF11 -a 0 -s 0x08000000:leave
-  DFU_SUFFIX_ARGS ?= -v 0483 -p DF11
 
   # UF2 settings
   UF2_FAMILY ?= STM32F4
@@ -321,10 +301,6 @@ ifneq ($(findstring STM32F411, $(MCU)),)
 
   USE_FPU ?= yes
 
-  # Options to pass to dfu-util when flashing
-  DFU_ARGS ?= -d 0483:DF11 -a 0 -s 0x08000000:leave
-  DFU_SUFFIX_ARGS ?= -v 0483 -p DF11
-
   # UF2 settings
   UF2_FAMILY ?= STM32F4
 endif
@@ -357,10 +333,6 @@ ifneq ($(findstring STM32F446, $(MCU)),)
   BOARD ?= GENERIC_STM32_F446XE
 
   USE_FPU ?= yes
-
-  # Options to pass to dfu-util when flashing
-  DFU_ARGS ?= -d 0483:DF11 -a 0 -s 0x08000000:leave
-  DFU_SUFFIX_ARGS ?= -v 0483 -p DF11
 endif
 
 ifneq ($(findstring STM32G431, $(MCU)),)
@@ -390,10 +362,6 @@ ifneq ($(findstring STM32G431, $(MCU)),)
   BOARD ?= GENERIC_STM32_G431XB
 
   USE_FPU ?= yes
-
-  # Options to pass to dfu-util when flashing
-  DFU_ARGS ?= -d 0483:DF11 -a 0 -s 0x08000000:leave
-  DFU_SUFFIX_ARGS ?= -v 0483 -p DF11
 
   # UF2 settings
   UF2_FAMILY ?= STM32G4
@@ -426,10 +394,6 @@ ifneq ($(findstring STM32G474, $(MCU)),)
   BOARD ?= GENERIC_STM32_G474XE
 
   USE_FPU ?= yes
-
-  # Options to pass to dfu-util when flashing
-  DFU_ARGS ?= -d 0483:DF11 -a 0 -s 0x08000000:leave
-  DFU_SUFFIX_ARGS ?= -v 0483 -p DF11
 
   # UF2 settings
   UF2_FAMILY ?= STM32G4
@@ -464,10 +428,6 @@ ifneq (,$(filter $(MCU),STM32L433 STM32L443))
   PLATFORM_NAME ?= platform_l432
 
   USE_FPU ?= yes
-
-  # Options to pass to dfu-util when flashing
-  DFU_ARGS ?= -d 0483:DF11 -a 0 -s 0x08000000:leave
-  DFU_SUFFIX_ARGS ?= -v 0483 -p DF11
 
   # UF2 settings
   UF2_FAMILY ?= STM32L4


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This can now be done by simply setting `BOOTLOADER = stm32-dfu`.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
