### PR TITLE
Slightly more prominent LUFA Mass-storage bootloader warning.

### DIFF
--- a/bootloader.mk
+++ b/bootloader.mk
@@ -92,10 +92,14 @@ ifeq ($(strip $(BOOTLOADER)), lufa-ms)
     OPT_DEFS += -DBOOTLOADER_MS
     BOOTLOADER_SIZE = 6144
     FIRMWARE_FORMAT = bin
-    $(info LUFA MASS STORAGE Bootloader selected)
-    $(info DO NOT USE THIS BOOTLOADER IN NEW PROJECTS!)
-    $(info It is extremely prone to bricking, and is only included to support existing boards.)
-    $(info )
+cpfirmware: lufa_warning
+.INTERMEDIATE: lufa_warning
+lufa_warning: $(FIRMWARE_FORMAT)
+	$(info @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@)
+	$(info LUFA MASS STORAGE Bootloader selected)
+	$(info DO NOT USE THIS BOOTLOADER IN NEW PROJECTS!)
+	$(info It is extremely prone to bricking, and is only included to support existing boards.)
+	$(info @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@)
 endif
 ifdef BOOTLOADER_SIZE
     OPT_DEFS += -DBOOTLOADER_SIZE=$(strip $(BOOTLOADER_SIZE))


### PR DESCRIPTION
## Description

Makes the lufa-ms bootloader warning a bit more prominent, as well as putting it at the end of the build.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
