### PR TITLE
Fix incorrect RGBLED_NUM value

### DIFF
--- a/keyboards/kbdfans/kbd67/rev2/config.h
+++ b/keyboards/kbdfans/kbd67/rev2/config.h
@@ -55,7 +55,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGB_DI_PIN E2
 #ifdef RGB_DI_PIN
 #define RGBLIGHT_ANIMATIONS
-#define RGBLED_NUM 20
+#define RGBLED_NUM 16
 #define RGBLIGHT_HUE_STEP 8
 #define RGBLIGHT_SAT_STEP 8
 #define RGBLIGHT_VAL_STEP 8


### PR DESCRIPTION
## Description

Corrects the number of underside LEDs to 16.
I'm not sure if there has been an unannounced revision to the PCB, but there are not 20 LEDs on the KBD67 Rev 2 that is currently available.
#6148 previously changed it, but the current revision only has 16. See https://kbdfans.com/products/kbd65-65-custom-mechanical-keyboard-pcb?variant=21778664357936

I'm not sure if there has been an unannounced revision to the PCB, but there are not 20 LEDs on the KBD67 Rev 2 that is currently available. I suspect that @JimmyMultani has a KBD65 PCB and that the KBD65 PCB actually does differ, unlike the readme suggests. See https://www.amazon.com/Interface-Support-firmware-Mechanical-Keyboard/dp/B07M9DRZ7K

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #6148

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

I have not been able to test my changes, as I'm running into some WSL-related issues, however I've done my due diligence in trying to identify any potential alternative board iterations.
