### PR TITLE
BOCC keyboard "config.h" had the incorrect amount of LEDs listed. Original code listed 16 rather than 20.

### DIFF
--- a/keyboards/dztech/bocc/config.h
+++ b/keyboards/dztech/bocc/config.h
@@ -51,7 +51,7 @@
 #define RGB_DI_PIN E2
 #ifdef RGB_DI_PIN
 #    define RGBLIGHT_ANIMATIONS
-#    define RGBLED_NUM 16
+#    define RGBLED_NUM 20
 #    define RGBLIGHT_HUE_STEP 8
 #    define RGBLIGHT_SAT_STEP 8
 #    define RGBLIGHT_VAL_STEP 8


### PR DESCRIPTION
## Description

BOCC keyboard "config.h" had the incorrect amount of LEDs listed. Original code listed 16 rather than 20.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

Evidence from Discord about the issue:
![Screen Shot 2021-06-10 at 2 22 08 PM](https://user-images.githubusercontent.com/4721145/121602115-af4d8700-c9fb-11eb-965d-2c639282b944.png)
![Screen Shot 2021-06-10 at 2 22 26 PM](https://user-images.githubusercontent.com/4721145/121602122-b07eb400-c9fb-11eb-8d3e-fb6c14f605b6.png)

Successful `make` output:
[bocc_success_make_output.txt](https://github.com/qmk/qmk_firmware/files/6634624/bocc_success_make_output.txt)
