### PR TITLE
Change Lufa-MS size

### DIFF
--- a/bootloader.mk
+++ b/bootloader.mk
@@ -90,7 +90,7 @@ ifeq ($(strip $(BOOTLOADER)), USBasp)
 endif
 ifeq ($(strip $(BOOTLOADER)), lufa-ms)
     OPT_DEFS += -DBOOTLOADER_MS
-    BOOTLOADER_SIZE = 8192
+    BOOTLOADER_SIZE ?= 6144
     FIRMWARE_FORMAT = bin
 cpfirmware: lufa_warning
 .INTERMEDIATE: lufa_warning

--- a/bootloader.mk
+++ b/bootloader.mk
@@ -90,7 +90,7 @@ ifeq ($(strip $(BOOTLOADER)), USBasp)
 endif
 ifeq ($(strip $(BOOTLOADER)), lufa-ms)
     OPT_DEFS += -DBOOTLOADER_MS
-    BOOTLOADER_SIZE ?= 6144
+    BOOTLOADER_SIZE ?= 8192
     FIRMWARE_FORMAT = bin
 cpfirmware: lufa_warning
 .INTERMEDIATE: lufa_warning

--- a/bootloader.mk
+++ b/bootloader.mk
@@ -90,7 +90,7 @@ ifeq ($(strip $(BOOTLOADER)), USBasp)
 endif
 ifeq ($(strip $(BOOTLOADER)), lufa-ms)
     OPT_DEFS += -DBOOTLOADER_MS
-    BOOTLOADER_SIZE = 6144
+    BOOTLOADER_SIZE = 8192
     FIRMWARE_FORMAT = bin
 cpfirmware: lufa_warning
 .INTERMEDIATE: lufa_warning

--- a/keyboards/gray_studio/cod67/rules.mk
+++ b/keyboards/gray_studio/cod67/rules.mk
@@ -11,6 +11,9 @@ MCU = atmega32u4
 #   ATmega328P   USBasp
 BOOTLOADER = lufa-ms
 
+# This board uses the older unsafe 6k version of lufa-ms
+BOOTLOADER_SIZE = 6144
+
 # Build Options
 #   change yes to no to disable
 #

--- a/keyboards/tada68/rules.mk
+++ b/keyboards/tada68/rules.mk
@@ -11,6 +11,9 @@ MCU = atmega32u4
 #   ATmega328P   USBasp
 BOOTLOADER = lufa-ms
 
+# This board uses the older unsafe 6k version of lufa-ms
+BOOTLOADER_SIZE = 6144
+
 # Build Options
 #   change yes to no to disable
 #


### PR DESCRIPTION
## Description

Increased the size of the Lufa-MS bootloader to 8k

Reason stated here:  
https://github.com/abcminiuser/lufa/commit/5ada54b43299564d5fa52d62abfa9648a4b6c207#diff-15ef1ada160ea767f8b2d21026d94de985fcc1641b8b83d69377053ccd6bfddf

The new version also fixed the issue of oversized firmware files overwriting parts of the bootloader and thus softbricking the MCU. 
Writing oversized files to the flashdrive still works to an extent (it will show an error if the file is vastly oversized) but it just results in the keyboard not starting up. It can still be put back into bootloader mode afterwards without problems.
Throwing random files into the flash drive (like the MacOS typical .DS_Store) also doesn't hurt the bootloader anymore.

I guess we could remove the warning for the Lufa-MS bootloader now since it should be safe to use? 

Relevant commit:  
https://github.com/abcminiuser/lufa/commit/ba6d9c1a971db3c42bf0b054ebb64f72b3e3ddba#diff-15ef1ada160ea767f8b2d21026d94de985fcc1641b8b83d69377053ccd6bfddf

Changes for the bootloader were tested on a dummy Arduino Pro Micro with the latest Lufa-MS bootloader.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
