### PR TITLE
Fix data buffer overrun and OLED corruption bug in oled_write_raw when cursor not at origin (0, 0)

### DIFF
--- a/drivers/oled/oled_driver.c
+++ b/drivers/oled/oled_driver.c
@@ -491,8 +491,9 @@ void oled_write_raw(const char *data, uint16_t size) {
     uint16_t cursor_start_index = oled_cursor - &oled_buffer[0];
     if ((size + cursor_start_index) > OLED_MATRIX_SIZE) size = OLED_MATRIX_SIZE - cursor_start_index;
     for (uint16_t i = cursor_start_index; i < cursor_start_index + size; i++) {
-        if (oled_buffer[i] == data[i]) continue;
-        oled_buffer[i] = data[i];
+        uint8_t c = *data++;
+        if (oled_buffer[i] == c) continue;
+        oled_buffer[i] = c;
         oled_dirty |= ((OLED_BLOCK_TYPE)1 << (i / OLED_BLOCK_SIZE));
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

See #13203 for details on the bug itself. For simplicity, I updated `oled_write_raw` to follow the (non-buggy) pattern that `oled_write_raw_P` already uses for reads (incrementing the `data` pointer rather than indexing into it using array syntax).

Verified this fixes the display corruption bug for OLED on ARM. See [before](https://i.imgur.com/9uMvT0D.png) (with corruption) and [after](https://i.imgur.com/TyZUpkG.png) (without corruption) this fix.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #13203.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
