### PR TITLE
[Keyboard] Fix revision issues with Kyria

### DIFF
--- a/keyboards/kyria/kyria.h
+++ b/keyboards/kyria/kyria.h
@@ -17,6 +17,10 @@
 
 #include "quantum.h"
 
+#if defined(KEYBOARD_kyria_rev1)
+#    include "rev1.h"
+#endif
+
 /* This a shortcut to help you visually see your layout.
  *
  * The first section contains all of the arguments representing the physical
@@ -25,58 +29,3 @@
  * The second converts the arguments into a two-dimensional array which
  * represents the switch matrix.
  */
-#define LAYOUT( \
-    L00, L01, L02, L03, L04, L05,                     R06, R07, R08, R09, R10, R11, \
-    L12, L13, L14, L15, L16, L17,                     R18, R19, R20, R21, R22, R23, \
-    L24, L25, L26, L27, L28, L29, L30, L31, R32, R33, R34, R35, R36, R37, R38, R39, \
-                   L40, L41, L42, L43, L44, R45, R46, R47, R48, R49 \
-) \
-{ \
-    { KC_NO, KC_NO, L05,   L04,   L03,   L02,   L01,   L00   }, \
-    { KC_NO, KC_NO, L17,   L16,   L15,   L14,   L13,   L12   }, \
-    { L31,   L30,   L29,   L28,   L27,   L26,   L25,   L24   }, \
-    { L44,   L43,   L42,   L41,   L40,   KC_NO, KC_NO, KC_NO }, \
-    { KC_NO, KC_NO, R06,   R07,   R08,   R09,   R10,   R11   }, \
-    { KC_NO, KC_NO, R18,   R19,   R20,   R21,   R22,   R23   }, \
-    { R32,   R33,   R34,   R35,   R36,   R37,   R38,   R39   }, \
-    { R45,   R46,   R47,   R48,   R49,   KC_NO, KC_NO, KC_NO }, \
-}
-
-#define LAYOUT_stack(                               \
-    L00, L01, L02, L03, L04, L05,                   \
-    L12, L13, L14, L15, L16, L17,                   \
-    L24, L25, L26, L27, L28, L29, L30, L31,         \
-                   L40, L41, L42, L43, L44,         \
-                                                    \
-                  R06, R07, R08, R09, R10, R11,     \
-                  R18, R19, R20, R21, R22, R23,     \
-        R32, R33, R34, R35, R36, R37, R38, R39,     \
-        R45, R46, R47, R48, R49                     \
-)                                               \
-{                                               \
-    { KC_NO, KC_NO, L05,   L04,   L03,   L02,   L01,   L00   }, \
-    { KC_NO, KC_NO, L17,   L16,   L15,   L14,   L13,   L12   }, \
-    { L31,   L30,   L29,   L28,   L27,   L26,   L25,   L24   }, \
-    { L44,   L43,   L42,   L41,   L40,   KC_NO, KC_NO, KC_NO }, \
-    { KC_NO, KC_NO, R06,   R07,   R08,   R09,   R10,   R11   }, \
-    { KC_NO, KC_NO, R18,   R19,   R20,   R21,   R22,   R23   }, \
-    { R32,   R33,   R34,   R35,   R36,   R37,   R38,   R39   }, \
-    { R45,   R46,   R47,   R48,   R49,   KC_NO, KC_NO, KC_NO }, \
-}
-
-#define LAYOUT_split_3x6_5( \
-    L00, L01, L02, L03, L04, L05,                     R06, R07, R08, R09, R10, R11, \
-    L12, L13, L14, L15, L16, L17,                     R18, R19, R20, R21, R22, R23, \
-    L24, L25, L26, L27, L28, L29,                     R34, R35, R36, R37, R38, R39, \
-                   L40, L41, L42, L43, L44, R45, R46, R47, R48, R49 \
-) \
-{ \
-    { KC_NO, KC_NO, L05,   L04,   L03,   L02,   L01,   L00   }, \
-    { KC_NO, KC_NO, L17,   L16,   L15,   L14,   L13,   L12   }, \
-    { KC_NO, KC_NO, L29,   L28,   L27,   L26,   L25,   L24   }, \
-    { L44,   L43,   L42,   L41,   L40,   KC_NO, KC_NO, KC_NO }, \
-    { KC_NO, KC_NO, R06,   R07,   R08,   R09,   R10,   R11   }, \
-    { KC_NO, KC_NO, R18,   R19,   R20,   R21,   R22,   R23   }, \
-    { KC_NO, KC_NO, R34,   R35,   R36,   R37,   R38,   R39   }, \
-    { R45,   R46,   R47,   R48,   R49,   KC_NO, KC_NO, KC_NO }, \
-}

--- a/keyboards/kyria/rev1/rev1.h
+++ b/keyboards/kyria/rev1/rev1.h
@@ -41,3 +41,42 @@
     { R32,   R33,   R34,   R35,   R36,   R37,   R38,   R39   }, \
     { R45,   R46,   R47,   R48,   R49,   KC_NO, KC_NO, KC_NO }, \
 }
+
+#define LAYOUT_stack(                               \
+    L00, L01, L02, L03, L04, L05,                   \
+    L12, L13, L14, L15, L16, L17,                   \
+    L24, L25, L26, L27, L28, L29, L30, L31,         \
+                   L40, L41, L42, L43, L44,         \
+                                                    \
+                  R06, R07, R08, R09, R10, R11,     \
+                  R18, R19, R20, R21, R22, R23,     \
+        R32, R33, R34, R35, R36, R37, R38, R39,     \
+        R45, R46, R47, R48, R49                     \
+)                                               \
+{                                               \
+    { KC_NO, KC_NO, L05,   L04,   L03,   L02,   L01,   L00   }, \
+    { KC_NO, KC_NO, L17,   L16,   L15,   L14,   L13,   L12   }, \
+    { L31,   L30,   L29,   L28,   L27,   L26,   L25,   L24   }, \
+    { L44,   L43,   L42,   L41,   L40,   KC_NO, KC_NO, KC_NO }, \
+    { KC_NO, KC_NO, R06,   R07,   R08,   R09,   R10,   R11   }, \
+    { KC_NO, KC_NO, R18,   R19,   R20,   R21,   R22,   R23   }, \
+    { R32,   R33,   R34,   R35,   R36,   R37,   R38,   R39   }, \
+    { R45,   R46,   R47,   R48,   R49,   KC_NO, KC_NO, KC_NO }, \
+}
+
+#define LAYOUT_split_3x6_5( \
+    L00, L01, L02, L03, L04, L05,                     R06, R07, R08, R09, R10, R11, \
+    L12, L13, L14, L15, L16, L17,                     R18, R19, R20, R21, R22, R23, \
+    L24, L25, L26, L27, L28, L29,                     R34, R35, R36, R37, R38, R39, \
+                   L40, L41, L42, L43, L44, R45, R46, R47, R48, R49 \
+) \
+{ \
+    { KC_NO, KC_NO, L05,   L04,   L03,   L02,   L01,   L00   }, \
+    { KC_NO, KC_NO, L17,   L16,   L15,   L14,   L13,   L12   }, \
+    { KC_NO, KC_NO, L29,   L28,   L27,   L26,   L25,   L24   }, \
+    { L44,   L43,   L42,   L41,   L40,   KC_NO, KC_NO, KC_NO }, \
+    { KC_NO, KC_NO, R06,   R07,   R08,   R09,   R10,   R11   }, \
+    { KC_NO, KC_NO, R18,   R19,   R20,   R21,   R22,   R23   }, \
+    { KC_NO, KC_NO, R34,   R35,   R36,   R37,   R38,   R39   }, \
+    { R45,   R46,   R47,   R48,   R49,   KC_NO, KC_NO, KC_NO }, \
+}

--- a/keyboards/kyria/rules.mk
+++ b/keyboards/kyria/rules.mk
@@ -2,7 +2,6 @@
 MCU = atmega32u4
 
 # Bootloader selection
-
 BOOTLOADER = atmel-dfu
 
 # Build Options

--- a/keyboards/kyria/rules.mk
+++ b/keyboards/kyria/rules.mk
@@ -2,13 +2,7 @@
 MCU = atmega32u4
 
 # Bootloader selection
-#   Teensy       halfkay
-#   Pro Micro    caterina
-#   Atmel DFU    atmel-dfu
-#   LUFA DFU     lufa-dfu
-#   QMK DFU      qmk-dfu
-#   ATmega32A    bootloadHID
-#   ATmega328P   USBasp
+
 BOOTLOADER = atmel-dfu
 
 # Build Options


### PR DESCRIPTION
## Description

This is a hidden bug, as it doesn't show up, because somebody got clever. 

However, the keyboard header files will cause issues if the `LAYOUT` macro is changed, and the rev3.h file is not properly included, either. 

This fixes the issues and moves the layout macros into the rev1.h file. 

There is NO functional change here, and this should be invisible to users. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bugfix
- [x] Keyboard (addition or update)

## Issues Fixed or Closed by This PR

*  Compiler issue 

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
