### PR TITLE
Fix overrun in st7565_write_raw when not at (0, 0)

### DIFF
--- a/drivers/lcd/st7565.c
+++ b/drivers/lcd/st7565.c
@@ -336,8 +336,9 @@ void st7565_write_raw(const char *data, uint16_t size) {
     uint16_t cursor_start_index = st7565_cursor - &st7565_buffer[0];
     if ((size + cursor_start_index) > ST7565_MATRIX_SIZE) size = ST7565_MATRIX_SIZE - cursor_start_index;
     for (uint16_t i = cursor_start_index; i < cursor_start_index + size; i++) {
-        if (st7565_buffer[i] == data[i]) continue;
-        st7565_buffer[i] = data[i];
+        uint8_t c = *data++;
+        if (st7565_buffer[i] == c) continue;
+        st7565_buffer[i] = c;
         st7565_dirty |= ((ST7565_BLOCK_TYPE)1 << (i / ST7565_BLOCK_SIZE));
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Takes the OLED fix from #13204 in `master` and applies it to ST7565 in `develop`, as requested in a comment on that PR.

I don't have the requisite hardware to test this, but at least I don't see any new build errors introduced in the `make all:default`.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [X] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Related to #13203.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
