### PR TITLE
Set some default configurations for GMMK Pro

### DIFF
--- a/keyboards/gmmk/pro/config.h
+++ b/keyboards/gmmk/pro/config.h
@@ -53,8 +53,5 @@
 /* Send up to 4 key press events per scan */
 #define QMK_KEYS_PER_SCAN 4
 
-/* Force NKRO on boot up */
-#define FORCE_NKRO 
-
 /* Set debounce time to 5ms */
 #define DEBOUNCE 5

--- a/keyboards/gmmk/pro/config.h
+++ b/keyboards/gmmk/pro/config.h
@@ -46,3 +46,15 @@
 #define LOCKING_SUPPORT_ENABLE
 /* Locking resynchronize hack */
 #define LOCKING_RESYNC_ENABLE
+
+/* 1000Hz USB polling - it's the default on stock firmware */
+#define USB_POLLING_INTERVAL_MS 1
+
+/* Send up to 4 key press events per scan */
+#define QMK_KEYS_PER_SCAN 4
+
+/* Force NKRO on boot up */
+#define FORCE_NKRO 
+
+/* Set debounce time to 5ms */
+#define DEBOUNCE 5


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Adding a few configurations as defaults for the GMMK Pro which I think make sense either because they're either
1. The defaults on the stock firmware, or
2. Useful for a keyboard focused on enthusiasts and gamers, or
3. The same as the default value on QMK, but I tried to make them explicit here

Maybe it would be up to @glorious-qmk to check if these changes make sense for the GMMK Pro, but I think at least setting `USB_POLLING_INTERVAL_MS` to 1 does.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
