### PR TITLE
[BUG] Fix pointer error with Split Transport and LED/RGB Matrix

### DIFF
--- a/quantum/split_common/transport.c
+++ b/quantum/split_common/transport.c
@@ -218,11 +218,11 @@ void transport_slave(matrix_row_t master_matrix[], matrix_row_t slave_matrix[]) 
 #    endif
 
 #    if defined(LED_MATRIX_ENABLE) && defined(LED_MATRIX_SPLIT)
-    memcpy((void *)&i2c_buffer->led_matrix, (void *)&led_matrix_eeconfig, sizeof(i2c_buffer->led_matrix));
+    memcpy((void *)&led_matrix_eeconfig, (void *)&i2c_buffer->led_matrix, sizeof(i2c_buffer->led_matrix));
     led_matrix_set_suspend_state(i2c_buffer->led_suspend_state);
 #    endif
 #    if defined(RGB_MATRIX_ENABLE) && defined(RGB_MATRIX_SPLIT)
-    memcpy((void *)&i2c_buffer->rgb_matrix, (void *)&rgb_matrix_config, sizeof(i2c_buffer->rgb_matrix));
+    memcpy((void *)&rgb_matrix_config, (void *)&i2c_buffer->rgb_matrix, sizeof(i2c_buffer->rgb_matrix));
     rgb_matrix_set_suspend_state(i2c_buffer->rgb_suspend_state);
 #    endif
 }

--- a/quantum/split_common/transport.c
+++ b/quantum/split_common/transport.c
@@ -240,38 +240,38 @@ typedef struct _Serial_s2m_buffer_t {
     matrix_row_t smatrix[ROWS_PER_HAND];
 
 #    ifdef ENCODER_ENABLE
-    uint8_t encoder_state[NUMBER_OF_ENCODERS];
+    uint8_t      encoder_state[NUMBER_OF_ENCODERS];
 #    endif
 
 } Serial_s2m_buffer_t;
 
 typedef struct _Serial_m2s_buffer_t {
 #    ifdef SPLIT_MODS_ENABLE
-    uint8_t real_mods;
-    uint8_t weak_mods;
+    uint8_t        real_mods;
+    uint8_t        weak_mods;
 #        ifndef NO_ACTION_ONESHOT
-    uint8_t oneshot_mods;
+    uint8_t        oneshot_mods;
 #        endif
 #    endif
 #    ifndef DISABLE_SYNC_TIMER
-    uint32_t sync_timer;
+    uint32_t       sync_timer;
 #    endif
 #    ifdef SPLIT_TRANSPORT_MIRROR
-    matrix_row_t mmatrix[ROWS_PER_HAND];
+    matrix_row_t   mmatrix[ROWS_PER_HAND];
 #    endif
 #    ifdef BACKLIGHT_ENABLE
-    uint8_t backlight_level;
+    uint8_t        backlight_level;
 #    endif
 #    ifdef WPM_ENABLE
-    uint8_t current_wpm;
+    uint8_t        current_wpm;
 #    endif
 #    if defined(LED_MATRIX_ENABLE) && defined(LED_MATRIX_SPLIT)
     led_eeconfig_t led_matrix;
     bool           led_suspend_state;
 #    endif
 #    if defined(RGB_MATRIX_ENABLE) && defined(RGB_MATRIX_SPLIT)
-    rgb_config_t rgb_matrix;
-    bool         rgb_suspend_state;
+    rgb_config_t   rgb_matrix;
+    bool           rgb_suspend_state;
 #    endif
 } Serial_m2s_buffer_t;
 
@@ -363,7 +363,7 @@ bool transport_master(matrix_row_t master_matrix[], matrix_row_t slave_matrix[])
 
     // TODO:  if MATRIX_COLS > 8 change to unpack()
     for (int i = 0; i < ROWS_PER_HAND; ++i) {
-        slave_matrix[i] = serial_s2m_buffer.smatrix[i];
+        slave_matrix[i]              = serial_s2m_buffer.smatrix[i];
 #    ifdef SPLIT_TRANSPORT_MIRROR
         serial_m2s_buffer.mmatrix[i] = master_matrix[i];
 #    endif
@@ -380,28 +380,28 @@ bool transport_master(matrix_row_t master_matrix[], matrix_row_t slave_matrix[])
 
 #    ifdef WPM_ENABLE
     // Write wpm to slave
-    serial_m2s_buffer.current_wpm = get_current_wpm();
+    serial_m2s_buffer.current_wpm       = get_current_wpm();
 #    endif
 
 #    ifdef SPLIT_MODS_ENABLE
-    serial_m2s_buffer.real_mods = get_mods();
-    serial_m2s_buffer.weak_mods = get_weak_mods();
+    serial_m2s_buffer.real_mods         = get_mods();
+    serial_m2s_buffer.weak_mods         = get_weak_mods();
 #        ifndef NO_ACTION_ONESHOT
-    serial_m2s_buffer.oneshot_mods = get_oneshot_mods();
+    serial_m2s_buffer.oneshot_mods      = get_oneshot_mods();
 #        endif
 #    endif
 
 #    if defined(LED_MATRIX_ENABLE) && defined(LED_MATRIX_SPLIT)
-    serial_m2s_buffer.led_matrix.raw        = led_matrix_eeconfig.raw;
+    serial_m2s_buffer.led_matrix.raw    = led_matrix_eeconfig.raw;
     serial_m2s_buffer.led_suspend_state = led_matrix_get_suspend_state();
 #    endif
 #    if defined(RGB_MATRIX_ENABLE) && defined(RGB_MATRIX_SPLIT)
-    serial_m2s_buffer.rgb_matrix.raw        = rgb_matrix_config.raw;
+    serial_m2s_buffer.rgb_matrix.raw    = rgb_matrix_config.raw;
     serial_m2s_buffer.rgb_suspend_state = rgb_matrix_get_suspend_state();
 #    endif
 
 #    ifndef DISABLE_SYNC_TIMER
-    serial_m2s_buffer.sync_timer = sync_timer_read32() + SYNC_TIMER_OFFSET;
+    serial_m2s_buffer.sync_timer        = sync_timer_read32() + SYNC_TIMER_OFFSET;
 #    endif
     return true;
 }
@@ -416,7 +416,7 @@ void transport_slave(matrix_row_t master_matrix[], matrix_row_t slave_matrix[]) 
     for (int i = 0; i < ROWS_PER_HAND; ++i) {
         serial_s2m_buffer.smatrix[i] = slave_matrix[i];
 #    ifdef SPLIT_TRANSPORT_MIRROR
-        master_matrix[i] = serial_m2s_buffer.mmatrix[i];
+        master_matrix[i]             = serial_m2s_buffer.mmatrix[i];
 #    endif
     }
 #    ifdef BACKLIGHT_ENABLE

--- a/quantum/split_common/transport.c
+++ b/quantum/split_common/transport.c
@@ -161,12 +161,12 @@ bool transport_master(matrix_row_t master_matrix[], matrix_row_t slave_matrix[])
 #    endif
 
 #    if defined(LED_MATRIX_ENABLE) && defined(LED_MATRIX_SPLIT)
-    i2c_writeReg(SLAVE_I2C_ADDRESS, I2C_LED_MATRIX_START, (void *)led_matrix_eeconfig, sizeof(i2c_buffer->led_matrix), TIMEOUT);
+    i2c_writeReg(SLAVE_I2C_ADDRESS, I2C_LED_MATRIX_START, (void *)led_matrix_eeconfig.raw, sizeof(i2c_buffer->led_matrix.raw), TIMEOUT);
     bool suspend_state = led_matrix_get_suspend_state();
     i2c_writeReg(SLAVE_I2C_ADDRESS, I2C_LED_SUSPEND_START, (void *)suspend_state, sizeof(i2c_buffer->led_suspend_state), TIMEOUT);
 #    endif
 #    if defined(RGB_MATRIX_ENABLE) && defined(RGB_MATRIX_SPLIT)
-    i2c_writeReg(SLAVE_I2C_ADDRESS, I2C_RGB_MATRIX_START, (void *)rgb_matrix_config, sizeof(i2c_buffer->rgb_matrix), TIMEOUT);
+    i2c_writeReg(SLAVE_I2C_ADDRESS, I2C_RGB_MATRIX_START, (void *)rgb_matrix_config.raw, sizeof(i2c_buffer->rgb_matrix.raw), TIMEOUT);
     bool suspend_state = rgb_matrix_get_suspend_state();
     i2c_writeReg(SLAVE_I2C_ADDRESS, I2C_RGB_SUSPEND_START, (void *)suspend_state, sizeof(i2c_buffer->rgb_suspend_state), TIMEOUT);
 #    endif
@@ -218,11 +218,11 @@ void transport_slave(matrix_row_t master_matrix[], matrix_row_t slave_matrix[]) 
 #    endif
 
 #    if defined(LED_MATRIX_ENABLE) && defined(LED_MATRIX_SPLIT)
-    memcpy((void *)i2c_buffer->led_matrix, (void *)led_matrix_eeconfig, sizeof(i2c_buffer->led_matrix));
+    memcpy((void *)i2c_buffer->led_matrix.raw, (void *)led_matrix_eeconfig.raw, sizeof(i2c_buffer->led_matrix.raw));
     led_matrix_set_suspend_state(i2c_buffer->led_suspend_state);
 #    endif
 #    if defined(RGB_MATRIX_ENABLE) && defined(RGB_MATRIX_SPLIT)
-    memcpy((void *)i2c_buffer->rgb_matrix, (void *)rgb_matrix_config, sizeof(i2c_buffer->rgb_matrix));
+    memcpy((void *)i2c_buffer->rgb_matrix.raw, (void *)rgb_matrix_config.raw, sizeof(i2c_buffer->rgb_matrix.raw));
     rgb_matrix_set_suspend_state(i2c_buffer->rgb_suspend_state);
 #    endif
 }
@@ -392,11 +392,11 @@ bool transport_master(matrix_row_t master_matrix[], matrix_row_t slave_matrix[])
 #    endif
 
 #    if defined(LED_MATRIX_ENABLE) && defined(LED_MATRIX_SPLIT)
-    serial_m2s_buffer.led_matrix        = led_matrix_eeconfig;
+    serial_m2s_buffer.led_matrix.raw        = led_matrix_eeconfig.raw;
     serial_m2s_buffer.led_suspend_state = led_matrix_get_suspend_state();
 #    endif
 #    if defined(RGB_MATRIX_ENABLE) && defined(RGB_MATRIX_SPLIT)
-    serial_m2s_buffer.rgb_matrix        = rgb_matrix_config;
+    serial_m2s_buffer.rgb_matrix.raw        = rgb_matrix_config.raw;
     serial_m2s_buffer.rgb_suspend_state = rgb_matrix_get_suspend_state();
 #    endif
 
@@ -440,11 +440,11 @@ void transport_slave(matrix_row_t master_matrix[], matrix_row_t slave_matrix[]) 
 #    endif
 
 #    if defined(LED_MATRIX_ENABLE) && defined(LED_MATRIX_SPLIT)
-    led_matrix_eeconfig = serial_m2s_buffer.led_matrix;
+    led_matrix_eeconfig.raw = serial_m2s_buffer.led_matrix.raw;
     led_matrix_set_suspend_state(serial_m2s_buffer.led_suspend_state);
 #    endif
 #    if defined(RGB_MATRIX_ENABLE) && defined(RGB_MATRIX_SPLIT)
-    rgb_matrix_config = serial_m2s_buffer.rgb_matrix;
+    rgb_matrix_config.raw = serial_m2s_buffer.rgb_matrix.raw;
     rgb_matrix_set_suspend_state(serial_m2s_buffer.rgb_suspend_state);
 #    endif
 }

--- a/quantum/split_common/transport.c
+++ b/quantum/split_common/transport.c
@@ -161,14 +161,14 @@ bool transport_master(matrix_row_t master_matrix[], matrix_row_t slave_matrix[])
 #    endif
 
 #    if defined(LED_MATRIX_ENABLE) && defined(LED_MATRIX_SPLIT)
-    i2c_writeReg(SLAVE_I2C_ADDRESS, I2C_LED_MATRIX_START, (void *)led_matrix_eeconfig.raw, sizeof(i2c_buffer->led_matrix.raw), TIMEOUT);
+    i2c_writeReg(SLAVE_I2C_ADDRESS, I2C_LED_MATRIX_START, (void *)&led_matrix_eeconfig.raw, sizeof(i2c_buffer->led_matrix.raw), TIMEOUT);
     bool suspend_state = led_matrix_get_suspend_state();
-    i2c_writeReg(SLAVE_I2C_ADDRESS, I2C_LED_SUSPEND_START, (void *)suspend_state, sizeof(i2c_buffer->led_suspend_state), TIMEOUT);
+    i2c_writeReg(SLAVE_I2C_ADDRESS, I2C_LED_SUSPEND_START, (void *)&suspend_state, sizeof(i2c_buffer->led_suspend_state), TIMEOUT);
 #    endif
 #    if defined(RGB_MATRIX_ENABLE) && defined(RGB_MATRIX_SPLIT)
-    i2c_writeReg(SLAVE_I2C_ADDRESS, I2C_RGB_MATRIX_START, (void *)rgb_matrix_config.raw, sizeof(i2c_buffer->rgb_matrix.raw), TIMEOUT);
+    i2c_writeReg(SLAVE_I2C_ADDRESS, I2C_RGB_MATRIX_START, (void *)&rgb_matrix_config.raw, sizeof(i2c_buffer->rgb_matrix.raw), TIMEOUT);
     bool suspend_state = rgb_matrix_get_suspend_state();
-    i2c_writeReg(SLAVE_I2C_ADDRESS, I2C_RGB_SUSPEND_START, (void *)suspend_state, sizeof(i2c_buffer->rgb_suspend_state), TIMEOUT);
+    i2c_writeReg(SLAVE_I2C_ADDRESS, I2C_RGB_SUSPEND_START, (void *)&suspend_state, sizeof(i2c_buffer->rgb_suspend_state), TIMEOUT);
 #    endif
 
 #    ifndef DISABLE_SYNC_TIMER
@@ -218,11 +218,11 @@ void transport_slave(matrix_row_t master_matrix[], matrix_row_t slave_matrix[]) 
 #    endif
 
 #    if defined(LED_MATRIX_ENABLE) && defined(LED_MATRIX_SPLIT)
-    memcpy((void *)i2c_buffer->led_matrix.raw, (void *)led_matrix_eeconfig.raw, sizeof(i2c_buffer->led_matrix.raw));
+    memcpy((void *)&i2c_buffer->led_matrix.raw, (void *)&led_matrix_eeconfig.raw, sizeof(i2c_buffer->led_matrix.raw));
     led_matrix_set_suspend_state(i2c_buffer->led_suspend_state);
 #    endif
 #    if defined(RGB_MATRIX_ENABLE) && defined(RGB_MATRIX_SPLIT)
-    memcpy((void *)i2c_buffer->rgb_matrix.raw, (void *)rgb_matrix_config.raw, sizeof(i2c_buffer->rgb_matrix.raw));
+    memcpy((void *)&i2c_buffer->rgb_matrix.raw, (void *)&rgb_matrix_config.raw, sizeof(i2c_buffer->rgb_matrix.raw));
     rgb_matrix_set_suspend_state(i2c_buffer->rgb_suspend_state);
 #    endif
 }

--- a/quantum/split_common/transport.c
+++ b/quantum/split_common/transport.c
@@ -161,12 +161,12 @@ bool transport_master(matrix_row_t master_matrix[], matrix_row_t slave_matrix[])
 #    endif
 
 #    if defined(LED_MATRIX_ENABLE) && defined(LED_MATRIX_SPLIT)
-    i2c_writeReg(SLAVE_I2C_ADDRESS, I2C_LED_MATRIX_START, (void *)&led_matrix_eeconfig.raw, sizeof(i2c_buffer->led_matrix.raw), TIMEOUT);
+    i2c_writeReg(SLAVE_I2C_ADDRESS, I2C_LED_MATRIX_START, (void *)&led_matrix_eeconfig, sizeof(i2c_buffer->led_matrix), TIMEOUT);
     bool suspend_state = led_matrix_get_suspend_state();
     i2c_writeReg(SLAVE_I2C_ADDRESS, I2C_LED_SUSPEND_START, (void *)&suspend_state, sizeof(i2c_buffer->led_suspend_state), TIMEOUT);
 #    endif
 #    if defined(RGB_MATRIX_ENABLE) && defined(RGB_MATRIX_SPLIT)
-    i2c_writeReg(SLAVE_I2C_ADDRESS, I2C_RGB_MATRIX_START, (void *)&rgb_matrix_config.raw, sizeof(i2c_buffer->rgb_matrix.raw), TIMEOUT);
+    i2c_writeReg(SLAVE_I2C_ADDRESS, I2C_RGB_MATRIX_START, (void *)&rgb_matrix_config, sizeof(i2c_buffer->rgb_matrix), TIMEOUT);
     bool suspend_state = rgb_matrix_get_suspend_state();
     i2c_writeReg(SLAVE_I2C_ADDRESS, I2C_RGB_SUSPEND_START, (void *)&suspend_state, sizeof(i2c_buffer->rgb_suspend_state), TIMEOUT);
 #    endif
@@ -218,11 +218,11 @@ void transport_slave(matrix_row_t master_matrix[], matrix_row_t slave_matrix[]) 
 #    endif
 
 #    if defined(LED_MATRIX_ENABLE) && defined(LED_MATRIX_SPLIT)
-    memcpy((void *)&i2c_buffer->led_matrix.raw, (void *)&led_matrix_eeconfig.raw, sizeof(i2c_buffer->led_matrix.raw));
+    memcpy((void *)&i2c_buffer->led_matrix, (void *)&led_matrix_eeconfig, sizeof(i2c_buffer->led_matrix));
     led_matrix_set_suspend_state(i2c_buffer->led_suspend_state);
 #    endif
 #    if defined(RGB_MATRIX_ENABLE) && defined(RGB_MATRIX_SPLIT)
-    memcpy((void *)&i2c_buffer->rgb_matrix.raw, (void *)&rgb_matrix_config.raw, sizeof(i2c_buffer->rgb_matrix.raw));
+    memcpy((void *)&i2c_buffer->rgb_matrix, (void *)&rgb_matrix_config, sizeof(i2c_buffer->rgb_matrix));
     rgb_matrix_set_suspend_state(i2c_buffer->rgb_suspend_state);
 #    endif
 }


### PR DESCRIPTION
## Description

If i2c is enabled for the split transport, and RGB Matrix or LED Matrix is enabled, it cannot convert the pointer type, and errors out. 

Fortunately, both are unions, and we can use the "raw" property to work around this. 

Same change applied to serial, just to be safe.

## Types of Changes

- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* Fixes #13218

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
