### PR TITLE
Update config.h to add missing comment closing characters  */

### DIFF
--- a/keyboards/handwired/split89/config.h
+++ b/keyboards/handwired/split89/config.h
@@ -50,7 +50,7 @@ COLS = number of cols per side which curently needs to be equal so there are bla
 #define MATRIX_ROW_PINS_RIGHT { F6, F7, B1, B3, B2, B6 }
 #define MATRIX_COL_PINS_RIGHT { F5, F4, B5, B4, E6, D7, C6, D4, D2, D3 }
 
-/* this will be tied to high (VCC with a 2k to 10k resistor) on the left keyboard half and tied to low (GND using a wire jumper only) on the right keyboard half.  This allows a user to plug in a USB cable to either side and function correctly with or without a TRS/TRRS cable with a single hex file.
+/* this will be tied to high (VCC with a 2k to 10k resistor) on the left keyboard half and tied to low (GND using a wire jumper only) on the right keyboard half.  This allows a user to plug in a USB cable to either side and function correctly with or without a TRS/TRRS cable with a single hex file. */
 #define SPLIT_HAND_PIN D1
 
 /* COL2ROW, ROW2COL */


### PR DESCRIPTION
Added missing closing comment bit */

This seems to cause the QMK configurator to break when clicking the compile button:

Compiling: keyboards/handwired/split89/split89.c                                                   In file included from [K:
ent]
 /* COL2ROW, ROW2COL */
[K
cc1: all warnings being treated as errors
 
 |
 |
 |
make: *** ine/keyboards/handwired/split89/split89.o] Error 1

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
