### PR TITLE
Dynamic Brightness Limit RGB Matrix

### DIFF
--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -272,6 +272,7 @@ As mentioned earlier, the center of the keyboard by default is expected to be `{
 |`LED_FLAG_UNDERGLOW`        |`0x02`|If the LED is for underglow                      |
 |`LED_FLAG_KEYLIGHT`         |`0x04`|If the LED is for key backlight                  |
 |`LED_FLAG_INDICATOR`        |`0x08`|If the LED is for keyboard state indication      |
+|`LED_FLAG_LIMITED`          |`0x10`|Limit the brightness to a lower value            |
 
 ## Keycodes :id=keycodes
 
@@ -519,10 +520,11 @@ These are defined in [`rgblight_list.h`](https://github.com/qmk/qmk_firmware/blo
 #define RGB_MATRIX_LED_PROCESS_LIMIT (DRIVER_LED_TOTAL + 4) / 5 // limits the number of LEDs to process in an animation per task run (increases keyboard responsiveness)
 #define RGB_MATRIX_LED_FLUSH_LIMIT 16 // limits in milliseconds how frequently an animation will update the LEDs. 16 (16ms) is equivalent to limiting to 60fps (increases keyboard responsiveness)
 #define RGB_MATRIX_MAXIMUM_BRIGHTNESS 200 // limits maximum brightness of LEDs to 200 out of 255. If not defined maximum brightness is set to 255
+#define RGB_MATRIX_LIMIT_BRIGHTNESS   100 // a lower limited maximum brightness when LED_FLAG_LIMITED is used. If not defined limit brightness is set to RGB_MATRIX_MAXIMUM_BRIGHTNESS
 #define RGB_MATRIX_STARTUP_MODE RGB_MATRIX_CYCLE_LEFT_RIGHT // Sets the default mode, if none has been set
 #define RGB_MATRIX_STARTUP_HUE 0 // Sets the default hue value, if none has been set
 #define RGB_MATRIX_STARTUP_SAT 255 // Sets the default saturation value, if none has been set
-#define RGB_MATRIX_STARTUP_VAL RGB_MATRIX_MAXIMUM_BRIGHTNESS // Sets the default brightness value, if none has been set
+#define RGB_MATRIX_STARTUP_VAL RGB_MATRIX_LIMIT_BRIGHTNESS // Sets the default brightness value, if none has been set
 #define RGB_MATRIX_STARTUP_SPD 127 // Sets the default animation speed, if none has been set
 #define RGB_MATRIX_DISABLE_KEYCODES // disables control of rgb matrix by keycodes (must use code functions to control the feature)
 #define RGB_MATRIX_SPLIT { X, Y } 	// (Optional) For split keyboards, the number of LEDs connected on each half. X = left, Y = Right.
@@ -602,6 +604,37 @@ Where `28` is an unused index from `eeconfig.h`.
 |`rgb_matrix_get_hsv()`           |Gets hue, sat, and val and returns a [`HSV` structure](https://github.com/qmk/qmk_firmware/blob/7ba6456c0b2e041bb9f97dbed265c5b8b4b12192/quantum/color.h#L56-L61)|
 |`rgb_matrix_get_speed()`         |Gets current speed         |
 |`rgb_matrix_get_suspend_state()` |Gets current suspend state |
+
+### Update flags :id=update-flags
+
+Global flags are used to affect the complete RGB Matrix state, only lighting LEDs matching a certain flag, or with `LED_FLAG_LIMIT_BRIGHTNESS` lowering the maximum brightness for the keyboard.
+
+|Function                           |Description                |
+|rgb_matrix_set_flags(flags)        |Set the global flags       |
+|rgb_matrix_set_flag(flag)          |Enable a single flag       |
+|rgb_matrix_unset_flag(flag)        |Disable a single flag      |
+
+For example, you could put a DIP switch on your keyboard to toggle between the limited or full brightness.
+
+```c
+// config.h
+#define RGB_MATRIX_LIMIT_BRIGHTNESS   128
+#define RGB_MATRIX_MAXIMUM_BRIGHTNESS 255
+
+// keyboard.c
+void dip_switch_update_kb(uint8_t index, bool active) {
+#ifdef RGB_MATRIX_ENABLE
+    if (active)
+        rgb_matrix_set_flag( LED_FLAG_LIMIT_BRIGHTNESS );
+    else
+        rgb_matrix_unset_flag( LED_FLAG_LIMIT_BRIGHTNESS );
+    
+    rgb_matrix_sethsv(rgb_matrix_get_hue(), rgb_matrix_get_sat(), rgb_matrix_get_val());
+#endif
+
+    dip_switch_update_user(index, active);
+}
+```
 
 ## Callbacks :id=callbacks
 

--- a/quantum/rgb_matrix.h
+++ b/quantum/rgb_matrix.h
@@ -157,6 +157,8 @@ void        rgb_matrix_decrease_speed(void);
 void        rgb_matrix_decrease_speed_noeeprom(void);
 led_flags_t rgb_matrix_get_flags(void);
 void        rgb_matrix_set_flags(led_flags_t flags);
+void        rgb_matrix_set_flag(led_flags_t flag);
+void        rgb_matrix_unset_flag(led_flags_t flag);
 
 #ifndef RGBLIGHT_ENABLE
 #    define eeconfig_update_rgblight_current eeconfig_update_rgb_matrix

--- a/quantum/rgb_matrix_types.h
+++ b/quantum/rgb_matrix_types.h
@@ -67,12 +67,13 @@ typedef struct PACKED {
 #define HAS_FLAGS(bits, flags) ((bits & flags) == flags)
 #define HAS_ANY_FLAGS(bits, flags) ((bits & flags) != 0x00)
 
-#define LED_FLAG_ALL 0xFF
-#define LED_FLAG_NONE 0x00
-#define LED_FLAG_MODIFIER 0x01
-#define LED_FLAG_UNDERGLOW 0x02
-#define LED_FLAG_KEYLIGHT 0x04
-#define LED_FLAG_INDICATOR 0x08
+#define LED_FLAG_ALL              0xFF
+#define LED_FLAG_NONE             0x00
+#define LED_FLAG_MODIFIER         0x01
+#define LED_FLAG_UNDERGLOW        0x02
+#define LED_FLAG_KEYLIGHT         0x04
+#define LED_FLAG_INDICATOR        0x08
+#define LED_FLAG_LIMIT_BRIGHTNESS 0x10
 
 #define NO_LED 255
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Added a define to add a secondary brightness limit to RGB Matrix to allow for things such as a hotkey or dipswitch to limit the brightness to a different value from normal. Think full bright, then half bright for pc's that can't handle it.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
