### PR TITLE
RGB Matrix eeprom write limiting

### DIFF
--- a/quantum/led_matrix.c
+++ b/quantum/led_matrix.c
@@ -33,11 +33,13 @@ const led_point_t k_led_matrix_center = {112, 32};
 const led_point_t k_led_matrix_center = LED_MATRIX_CENTER;
 #endif
 
+// clang-format off
 #ifndef LED_MATRIX_IMMEDIATE_EEPROM
 #    define led_eeconfig_update(v) led_update_eeprom |= v
 #else
 #    define led_eeconfig_update(v) if (v) eeconfig_update_led_matrix()
 #endif
+// clang-format on
 
 // Generic effect runners
 #include "led_matrix_runners/effect_runner_dx_dy_dist.h"

--- a/quantum/led_matrix.c
+++ b/quantum/led_matrix.c
@@ -33,6 +33,12 @@ const led_point_t k_led_matrix_center = {112, 32};
 const led_point_t k_led_matrix_center = LED_MATRIX_CENTER;
 #endif
 
+#ifndef LED_MATRIX_IMMEDIATE_EEPROM
+#    define led_eeconfig_update(v) led_update_eeprom |= v
+#else
+#    define led_eeconfig_update(v) if (v) eeconfig_update_led_matrix()
+#endif
+
 // Generic effect runners
 #include "led_matrix_runners/effect_runner_dx_dy_dist.h"
 #include "led_matrix_runners/effect_runner_dx_dy.h"
@@ -104,6 +110,7 @@ last_hit_t g_last_hit_tracker;
 
 // internals
 static bool            suspend_state     = false;
+static bool            led_update_eeprom = false;
 static uint8_t         led_last_enable   = UINT8_MAX;
 static uint8_t         led_last_effect   = UINT8_MAX;
 static effect_params_t led_effect_params = {0, LED_FLAG_ALL, false};
@@ -276,6 +283,7 @@ static void led_task_timers(void) {
 
 static void led_task_sync(void) {
     // next task
+    if (led_update_eeprom) eeconfig_update_led_matrix();
     if (sync_timer_elapsed32(g_led_timer) >= LED_MATRIX_LED_FLUSH_LIMIT) led_task_state = STARTING;
 }
 
@@ -465,9 +473,7 @@ bool led_matrix_get_suspend_state(void) { return suspend_state; }
 void led_matrix_toggle_eeprom_helper(bool write_to_eeprom) {
     led_matrix_eeconfig.enable ^= 1;
     led_task_state = STARTING;
-    if (write_to_eeprom) {
-        eeconfig_update_led_matrix();
-    }
+    led_eeconfig_update(write_to_eeprom);
     dprintf("led matrix toggle [%s]: led_matrix_eeconfig.enable = %u\n", (write_to_eeprom) ? "EEPROM" : "NOEEPROM", led_matrix_eeconfig.enable);
 }
 void led_matrix_toggle_noeeprom(void) { led_matrix_toggle_eeprom_helper(false); }
@@ -475,7 +481,7 @@ void led_matrix_toggle(void) { led_matrix_toggle_eeprom_helper(true); }
 
 void led_matrix_enable(void) {
     led_matrix_enable_noeeprom();
-    eeconfig_update_led_matrix();
+    led_eeconfig_update(true);
 }
 
 void led_matrix_enable_noeeprom(void) {
@@ -485,7 +491,7 @@ void led_matrix_enable_noeeprom(void) {
 
 void led_matrix_disable(void) {
     led_matrix_disable_noeeprom();
-    eeconfig_update_led_matrix();
+    led_eeconfig_update(true);
 }
 
 void led_matrix_disable_noeeprom(void) {
@@ -507,9 +513,7 @@ void led_matrix_mode_eeprom_helper(uint8_t mode, bool write_to_eeprom) {
         led_matrix_eeconfig.mode = mode;
     }
     led_task_state = STARTING;
-    if (write_to_eeprom) {
-        eeconfig_update_led_matrix();
-    }
+    led_eeconfig_update(write_to_eeprom);
     dprintf("led matrix mode [%s]: %u\n", (write_to_eeprom) ? "EEPROM" : "NOEEPROM", led_matrix_eeconfig.mode);
 }
 void led_matrix_mode_noeeprom(uint8_t mode) { led_matrix_mode_eeprom_helper(mode, false); }
@@ -536,9 +540,7 @@ void led_matrix_set_val_eeprom_helper(uint8_t val, bool write_to_eeprom) {
         return;
     }
     led_matrix_eeconfig.val = (val > LED_MATRIX_MAXIMUM_BRIGHTNESS) ? LED_MATRIX_MAXIMUM_BRIGHTNESS : val;
-    if (write_to_eeprom) {
-        eeconfig_update_led_matrix();
-    }
+    led_eeconfig_update(write_to_eeprom);
     dprintf("led matrix set val [%s]: %u\n", (write_to_eeprom) ? "EEPROM" : "NOEEPROM", led_matrix_eeconfig.val);
 }
 void led_matrix_set_val_noeeprom(uint8_t val) { led_matrix_set_val_eeprom_helper(val, false); }
@@ -556,9 +558,7 @@ void led_matrix_decrease_val(void) { led_matrix_decrease_val_helper(true); }
 
 void led_matrix_set_speed_eeprom_helper(uint8_t speed, bool write_to_eeprom) {
     led_matrix_eeconfig.speed = speed;
-    if (write_to_eeprom) {
-        eeconfig_update_led_matrix();
-    }
+    led_eeconfig_update(write_to_eeprom);
     dprintf("led matrix set speed [%s]: %u\n", (write_to_eeprom) ? "EEPROM" : "NOEEPROM", led_matrix_eeconfig.speed);
 }
 void led_matrix_set_speed_noeeprom(uint8_t speed) { led_matrix_set_speed_eeprom_helper(speed, false); }

--- a/quantum/rgb_matrix.c
+++ b/quantum/rgb_matrix.c
@@ -31,6 +31,12 @@ const led_point_t k_rgb_matrix_center = {112, 32};
 const led_point_t k_rgb_matrix_center = RGB_MATRIX_CENTER;
 #endif
 
+#ifndef RGB_MATRIX_IMMEDIATE_EEPROM
+#define rgb_eeconfig_update(v) rgb_update_eeprom |= v
+#else
+#define rgb_eeconfig_update(v) eeconfig_update_rgb_matrix()
+#endif
+
 __attribute__((weak)) RGB rgb_matrix_hsv_to_rgb(HSV hsv) { return hsv_to_rgb(hsv); }
 
 // Generic effect runners
@@ -125,6 +131,7 @@ last_hit_t g_last_hit_tracker;
 
 // internals
 static bool            suspend_state     = false;
+static bool            rgb_update_eeprom = false;
 static uint8_t         rgb_last_enable   = UINT8_MAX;
 static uint8_t         rgb_last_effect   = UINT8_MAX;
 static effect_params_t rgb_effect_params = {0, LED_FLAG_ALL, false};
@@ -311,6 +318,7 @@ static void rgb_task_timers(void) {
 
 static void rgb_task_sync(void) {
     // next task
+    if (rgb_update_eeprom) eeconfig_update_rgb_matrix();
     if (sync_timer_elapsed32(g_rgb_timer) >= RGB_MATRIX_LED_FLUSH_LIMIT) rgb_task_state = STARTING;
 }
 
@@ -507,9 +515,7 @@ bool rgb_matrix_get_suspend_state(void) { return suspend_state; }
 void rgb_matrix_toggle_eeprom_helper(bool write_to_eeprom) {
     rgb_matrix_config.enable ^= 1;
     rgb_task_state = STARTING;
-    if (write_to_eeprom) {
-        eeconfig_update_rgb_matrix();
-    }
+    rgb_eeconfig_update(write_to_eeprom);
     dprintf("rgb matrix toggle [%s]: rgb_matrix_config.enable = %u\n", (write_to_eeprom) ? "EEPROM" : "NOEEPROM", rgb_matrix_config.enable);
 }
 void rgb_matrix_toggle_noeeprom(void) { rgb_matrix_toggle_eeprom_helper(false); }
@@ -517,7 +523,7 @@ void rgb_matrix_toggle(void) { rgb_matrix_toggle_eeprom_helper(true); }
 
 void rgb_matrix_enable(void) {
     rgb_matrix_enable_noeeprom();
-    eeconfig_update_rgb_matrix();
+    rgb_eeconfig_update(true);
 }
 
 void rgb_matrix_enable_noeeprom(void) {
@@ -527,7 +533,7 @@ void rgb_matrix_enable_noeeprom(void) {
 
 void rgb_matrix_disable(void) {
     rgb_matrix_disable_noeeprom();
-    eeconfig_update_rgb_matrix();
+    rgb_eeconfig_update(true);
 }
 
 void rgb_matrix_disable_noeeprom(void) {
@@ -549,9 +555,7 @@ void rgb_matrix_mode_eeprom_helper(uint8_t mode, bool write_to_eeprom) {
         rgb_matrix_config.mode = mode;
     }
     rgb_task_state = STARTING;
-    if (write_to_eeprom) {
-        eeconfig_update_rgb_matrix();
-    }
+    rgb_eeconfig_update(write_to_eeprom);
     dprintf("rgb matrix mode [%s]: %u\n", (write_to_eeprom) ? "EEPROM" : "NOEEPROM", rgb_matrix_config.mode);
 }
 void rgb_matrix_mode_noeeprom(uint8_t mode) { rgb_matrix_mode_eeprom_helper(mode, false); }
@@ -580,9 +584,7 @@ void rgb_matrix_sethsv_eeprom_helper(uint16_t hue, uint8_t sat, uint8_t val, boo
     rgb_matrix_config.hsv.h = hue;
     rgb_matrix_config.hsv.s = sat;
     rgb_matrix_config.hsv.v = (val > RGB_MATRIX_MAXIMUM_BRIGHTNESS) ? RGB_MATRIX_MAXIMUM_BRIGHTNESS : val;
-    if (write_to_eeprom) {
-        eeconfig_update_rgb_matrix();
-    }
+    rgb_eeconfig_update(write_to_eeprom);
     dprintf("rgb matrix set hsv [%s]: %u,%u,%u\n", (write_to_eeprom) ? "EEPROM" : "NOEEPROM", rgb_matrix_config.hsv.h, rgb_matrix_config.hsv.s, rgb_matrix_config.hsv.v);
 }
 void rgb_matrix_sethsv_noeeprom(uint16_t hue, uint8_t sat, uint8_t val) { rgb_matrix_sethsv_eeprom_helper(hue, sat, val, false); }
@@ -619,9 +621,7 @@ void rgb_matrix_decrease_val(void) { rgb_matrix_decrease_val_helper(true); }
 
 void rgb_matrix_set_speed_eeprom_helper(uint8_t speed, bool write_to_eeprom) {
     rgb_matrix_config.speed = speed;
-    if (write_to_eeprom) {
-        eeconfig_update_rgb_matrix();
-    }
+    rgb_eeconfig_update(write_to_eeprom);
     dprintf("rgb matrix set speed [%s]: %u\n", (write_to_eeprom) ? "EEPROM" : "NOEEPROM", rgb_matrix_config.speed);
 }
 void rgb_matrix_set_speed_noeeprom(uint8_t speed) { rgb_matrix_set_speed_eeprom_helper(speed, false); }

--- a/quantum/rgb_matrix.c
+++ b/quantum/rgb_matrix.c
@@ -31,11 +31,13 @@ const led_point_t k_rgb_matrix_center = {112, 32};
 const led_point_t k_rgb_matrix_center = RGB_MATRIX_CENTER;
 #endif
 
+// clang-format off
 #ifndef RGB_MATRIX_IMMEDIATE_EEPROM
 #    define rgb_eeconfig_update(v) rgb_update_eeprom |= v
 #else
 #    define rgb_eeconfig_update(v) if (v) eeconfig_update_rgb_matrix()
 #endif
+// clang-format on
 
 __attribute__((weak)) RGB rgb_matrix_hsv_to_rgb(HSV hsv) { return hsv_to_rgb(hsv); }
 

--- a/quantum/rgb_matrix.c
+++ b/quantum/rgb_matrix.c
@@ -32,9 +32,9 @@ const led_point_t k_rgb_matrix_center = RGB_MATRIX_CENTER;
 #endif
 
 #ifndef RGB_MATRIX_IMMEDIATE_EEPROM
-#define rgb_eeconfig_update(v) rgb_update_eeprom |= v
+#    define rgb_eeconfig_update(v) rgb_update_eeprom |= v
 #else
-#define rgb_eeconfig_update(v) eeconfig_update_rgb_matrix()
+#    define rgb_eeconfig_update(v) eeconfig_update_rgb_matrix()
 #endif
 
 __attribute__((weak)) RGB rgb_matrix_hsv_to_rgb(HSV hsv) { return hsv_to_rgb(hsv); }

--- a/quantum/rgb_matrix.c
+++ b/quantum/rgb_matrix.c
@@ -34,7 +34,7 @@ const led_point_t k_rgb_matrix_center = RGB_MATRIX_CENTER;
 #ifndef RGB_MATRIX_IMMEDIATE_EEPROM
 #    define rgb_eeconfig_update(v) rgb_update_eeprom |= v
 #else
-#    define rgb_eeconfig_update(v) eeconfig_update_rgb_matrix()
+#    define rgb_eeconfig_update(v) if (v) eeconfig_update_rgb_matrix()
 #endif
 
 __attribute__((weak)) RGB rgb_matrix_hsv_to_rgb(HSV hsv) { return hsv_to_rgb(hsv); }


### PR DESCRIPTION
## Description

Adds a limiter to updating the eeprom for rgb matrix to once every full rgb matrix loop. This helps reduce lagging / frequent writes due to rapid controlling of the rgb keycodes via encoders or such.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
