### PR TITLE
Fix issues with VIA EEPROM initialization and bring more in line with rest of eeconfig functionality

### DIFF
--- a/quantum/bootmagic/bootmagic_lite.c
+++ b/quantum/bootmagic/bootmagic_lite.c
@@ -19,9 +19,7 @@
  *
  * ...just incase someone wants to only change the eeprom behaviour
  */
-__attribute__((weak)) void bootmagic_lite_reset_eeprom(void) {
-    eeconfig_disable();
-}
+__attribute__((weak)) void bootmagic_lite_reset_eeprom(void) { eeconfig_disable(); }
 
 /** \brief The lite version of TMK's bootmagic based on Wilba.
  *

--- a/quantum/bootmagic/bootmagic_lite.c
+++ b/quantum/bootmagic/bootmagic_lite.c
@@ -20,11 +20,7 @@
  * ...just incase someone wants to only change the eeprom behaviour
  */
 __attribute__((weak)) void bootmagic_lite_reset_eeprom(void) {
-#if defined(VIA_ENABLE)
-    via_eeprom_reset();
-#else
     eeconfig_disable();
-#endif
 }
 
 /** \brief The lite version of TMK's bootmagic based on Wilba.

--- a/quantum/eeconfig.c
+++ b/quantum/eeconfig.c
@@ -17,6 +17,10 @@
 #    include "haptic.h"
 #endif
 
+#if defined(VIA_ENABLE)
+void via_eeprom_set_valid(bool valid);
+#endif
+
 /** \brief eeconfig enable
  *
  * FIXME: needs doc
@@ -76,6 +80,9 @@ void eeconfig_init_quantum(void) {
     // in the haptic configuration eeprom. All zero will trigger a haptic_reset
     // when a haptic-enabled firmware is loaded onto the keyboard.
     eeprom_update_dword(EECONFIG_HAPTIC, 0);
+#endif
+#if defined(VIA_ENABLE)
+    via_eeprom_set_valid(false);
 #endif
 
     eeconfig_init_kb();

--- a/quantum/eeconfig.c
+++ b/quantum/eeconfig.c
@@ -146,94 +146,95 @@ bool eeconfig_is_disabled(void) {
     }
 #endif
     return is_eeprom_disabled;
+}
 
-    /** \brief eeconfig read debug
-     *
-     * FIXME: needs doc
-     */
-    uint8_t eeconfig_read_debug(void) { return eeprom_read_byte(EECONFIG_DEBUG); }
-    /** \brief eeconfig update debug
-     *
-     * FIXME: needs doc
-     */
-    void eeconfig_update_debug(uint8_t val) { eeprom_update_byte(EECONFIG_DEBUG, val); }
+/** \brief eeconfig read debug
+ *
+ * FIXME: needs doc
+ */
+uint8_t eeconfig_read_debug(void) { return eeprom_read_byte(EECONFIG_DEBUG); }
+/** \brief eeconfig update debug
+ *
+ * FIXME: needs doc
+ */
+void eeconfig_update_debug(uint8_t val) { eeprom_update_byte(EECONFIG_DEBUG, val); }
 
-    /** \brief eeconfig read default layer
-     *
-     * FIXME: needs doc
-     */
-    uint8_t eeconfig_read_default_layer(void) { return eeprom_read_byte(EECONFIG_DEFAULT_LAYER); }
-    /** \brief eeconfig update default layer
-     *
-     * FIXME: needs doc
-     */
-    void eeconfig_update_default_layer(uint8_t val) { eeprom_update_byte(EECONFIG_DEFAULT_LAYER, val); }
+/** \brief eeconfig read default layer
+ *
+ * FIXME: needs doc
+ */
+uint8_t eeconfig_read_default_layer(void) { return eeprom_read_byte(EECONFIG_DEFAULT_LAYER); }
+/** \brief eeconfig update default layer
+ *
+ * FIXME: needs doc
+ */
+void eeconfig_update_default_layer(uint8_t val) { eeprom_update_byte(EECONFIG_DEFAULT_LAYER, val); }
 
-    /** \brief eeconfig read keymap
-     *
-     * FIXME: needs doc
-     */
-    uint16_t eeconfig_read_keymap(void) { return (eeprom_read_byte(EECONFIG_KEYMAP_LOWER_BYTE) | (eeprom_read_byte(EECONFIG_KEYMAP_UPPER_BYTE) << 8)); }
-    /** \brief eeconfig update keymap
-     *
-     * FIXME: needs doc
-     */
-    void eeconfig_update_keymap(uint16_t val) {
-        eeprom_update_byte(EECONFIG_KEYMAP_LOWER_BYTE, val & 0xFF);
-        eeprom_update_byte(EECONFIG_KEYMAP_UPPER_BYTE, (val >> 8) & 0xFF);
-    }
+/** \brief eeconfig read keymap
+ *
+ * FIXME: needs doc
+ */
+uint16_t eeconfig_read_keymap(void) { return (eeprom_read_byte(EECONFIG_KEYMAP_LOWER_BYTE) | (eeprom_read_byte(EECONFIG_KEYMAP_UPPER_BYTE) << 8)); }
+/** \brief eeconfig update keymap
+ *
+ * FIXME: needs doc
+ */
+void eeconfig_update_keymap(uint16_t val) {
+    eeprom_update_byte(EECONFIG_KEYMAP_LOWER_BYTE, val & 0xFF);
+    eeprom_update_byte(EECONFIG_KEYMAP_UPPER_BYTE, (val >> 8) & 0xFF);
+}
 
-    /** \brief eeconfig read audio
-     *
-     * FIXME: needs doc
-     */
-    uint8_t eeconfig_read_audio(void) { return eeprom_read_byte(EECONFIG_AUDIO); }
-    /** \brief eeconfig update audio
-     *
-     * FIXME: needs doc
-     */
-    void eeconfig_update_audio(uint8_t val) { eeprom_update_byte(EECONFIG_AUDIO, val); }
+/** \brief eeconfig read audio
+ *
+ * FIXME: needs doc
+ */
+uint8_t eeconfig_read_audio(void) { return eeprom_read_byte(EECONFIG_AUDIO); }
+/** \brief eeconfig update audio
+ *
+ * FIXME: needs doc
+ */
+void eeconfig_update_audio(uint8_t val) { eeprom_update_byte(EECONFIG_AUDIO, val); }
 
-    /** \brief eeconfig read kb
-     *
-     * FIXME: needs doc
-     */
-    uint32_t eeconfig_read_kb(void) { return eeprom_read_dword(EECONFIG_KEYBOARD); }
-    /** \brief eeconfig update kb
-     *
-     * FIXME: needs doc
-     */
-    void eeconfig_update_kb(uint32_t val) { eeprom_update_dword(EECONFIG_KEYBOARD, val); }
+/** \brief eeconfig read kb
+ *
+ * FIXME: needs doc
+ */
+uint32_t eeconfig_read_kb(void) { return eeprom_read_dword(EECONFIG_KEYBOARD); }
+/** \brief eeconfig update kb
+ *
+ * FIXME: needs doc
+ */
+void eeconfig_update_kb(uint32_t val) { eeprom_update_dword(EECONFIG_KEYBOARD, val); }
 
-    /** \brief eeconfig read user
-     *
-     * FIXME: needs doc
-     */
-    uint32_t eeconfig_read_user(void) { return eeprom_read_dword(EECONFIG_USER); }
-    /** \brief eeconfig update user
-     *
-     * FIXME: needs doc
-     */
-    void eeconfig_update_user(uint32_t val) { eeprom_update_dword(EECONFIG_USER, val); }
+/** \brief eeconfig read user
+ *
+ * FIXME: needs doc
+ */
+uint32_t eeconfig_read_user(void) { return eeprom_read_dword(EECONFIG_USER); }
+/** \brief eeconfig update user
+ *
+ * FIXME: needs doc
+ */
+void eeconfig_update_user(uint32_t val) { eeprom_update_dword(EECONFIG_USER, val); }
 
-    /** \brief eeconfig read haptic
-     *
-     * FIXME: needs doc
-     */
-    uint32_t eeconfig_read_haptic(void) { return eeprom_read_dword(EECONFIG_HAPTIC); }
-    /** \brief eeconfig update haptic
-     *
-     * FIXME: needs doc
-     */
-    void eeconfig_update_haptic(uint32_t val) { eeprom_update_dword(EECONFIG_HAPTIC, val); }
+/** \brief eeconfig read haptic
+ *
+ * FIXME: needs doc
+ */
+uint32_t eeconfig_read_haptic(void) { return eeprom_read_dword(EECONFIG_HAPTIC); }
+/** \brief eeconfig update haptic
+ *
+ * FIXME: needs doc
+ */
+void eeconfig_update_haptic(uint32_t val) { eeprom_update_dword(EECONFIG_HAPTIC, val); }
 
-    /** \brief eeconfig read split handedness
-     *
-     * FIXME: needs doc
-     */
-    bool eeconfig_read_handedness(void) { return !!eeprom_read_byte(EECONFIG_HANDEDNESS); }
-    /** \brief eeconfig update split handedness
-     *
-     * FIXME: needs doc
-     */
-    void eeconfig_update_handedness(bool val) { eeprom_update_byte(EECONFIG_HANDEDNESS, !!val); }
+/** \brief eeconfig read split handedness
+ *
+ * FIXME: needs doc
+ */
+bool eeconfig_read_handedness(void) { return !!eeprom_read_byte(EECONFIG_HANDEDNESS); }
+/** \brief eeconfig update split handedness
+ *
+ * FIXME: needs doc
+ */
+void eeconfig_update_handedness(bool val) { eeprom_update_byte(EECONFIG_HANDEDNESS, !!val); }

--- a/quantum/eeconfig.c
+++ b/quantum/eeconfig.c
@@ -18,6 +18,7 @@
 #endif
 
 #if defined(VIA_ENABLE)
+void via_eeprom_set_valid(bool valid);
 void eeconfig_init_via(void);
 #endif
 
@@ -82,6 +83,10 @@ void eeconfig_init_quantum(void) {
     eeprom_update_dword(EECONFIG_HAPTIC, 0);
 #endif
 #if defined(VIA_ENABLE)
+    // Invalidate VIA eeprom config, and then reset.
+    // Just in case if power is lost mid init, this makes sure that it pets
+    // properly re-initialized.
+    via_eeprom_set_valid(false);
     eeconfig_init_via();
 #endif
 

--- a/quantum/eeconfig.c
+++ b/quantum/eeconfig.c
@@ -18,7 +18,7 @@
 #endif
 
 #if defined(VIA_ENABLE)
-void via_eeprom_set_valid(bool valid);
+void eeconfig_init_via(void);
 #endif
 
 /** \brief eeconfig enable
@@ -82,7 +82,7 @@ void eeconfig_init_quantum(void) {
     eeprom_update_dword(EECONFIG_HAPTIC, 0);
 #endif
 #if defined(VIA_ENABLE)
-    via_eeprom_set_valid(false);
+    eeconfig_init_via();
 #endif
 
     eeconfig_init_kb();

--- a/quantum/eeconfig.c
+++ b/quantum/eeconfig.c
@@ -18,6 +18,7 @@
 #endif
 
 #if defined(VIA_ENABLE)
+bool via_eeprom_is_valid(void);
 void via_eeprom_set_valid(bool valid);
 void eeconfig_init_via(void);
 #endif
@@ -123,101 +124,116 @@ void eeconfig_disable(void) {
  *
  * FIXME: needs doc
  */
-bool eeconfig_is_enabled(void) { return (eeprom_read_word(EECONFIG_MAGIC) == EECONFIG_MAGIC_NUMBER); }
+bool eeconfig_is_enabled(void) {
+    bool is_eeprom_enabled = (eeprom_read_word(EECONFIG_MAGIC) == EECONFIG_MAGIC_NUMBER);
+#ifdef VIA_ENABLE
+    if (is_eeprom_enabled) {
+        is_eeprom_enabled = via_eeprom_is_valid();
+    }
+#endif
+    return is_eeprom_enabled;
+}
 
 /** \brief eeconfig is disabled
  *
  * FIXME: needs doc
  */
-bool eeconfig_is_disabled(void) { return (eeprom_read_word(EECONFIG_MAGIC) == EECONFIG_MAGIC_NUMBER_OFF); }
+bool eeconfig_is_disabled(void) {
+    bool is_eeprom_disabled = (eeprom_read_word(EECONFIG_MAGIC) == EECONFIG_MAGIC_NUMBER_OFF);
+#ifdef VIA_ENABLE
+    if (!is_eeprom_disabled) {
+        is_eeprom_disabled = !via_eeprom_is_valid();
+    }
+#endif
+    return is_eeprom_disabled;
 
-/** \brief eeconfig read debug
- *
- * FIXME: needs doc
- */
-uint8_t eeconfig_read_debug(void) { return eeprom_read_byte(EECONFIG_DEBUG); }
-/** \brief eeconfig update debug
- *
- * FIXME: needs doc
- */
-void eeconfig_update_debug(uint8_t val) { eeprom_update_byte(EECONFIG_DEBUG, val); }
+    /** \brief eeconfig read debug
+     *
+     * FIXME: needs doc
+     */
+    uint8_t eeconfig_read_debug(void) { return eeprom_read_byte(EECONFIG_DEBUG); }
+    /** \brief eeconfig update debug
+     *
+     * FIXME: needs doc
+     */
+    void eeconfig_update_debug(uint8_t val) { eeprom_update_byte(EECONFIG_DEBUG, val); }
 
-/** \brief eeconfig read default layer
- *
- * FIXME: needs doc
- */
-uint8_t eeconfig_read_default_layer(void) { return eeprom_read_byte(EECONFIG_DEFAULT_LAYER); }
-/** \brief eeconfig update default layer
- *
- * FIXME: needs doc
- */
-void eeconfig_update_default_layer(uint8_t val) { eeprom_update_byte(EECONFIG_DEFAULT_LAYER, val); }
+    /** \brief eeconfig read default layer
+     *
+     * FIXME: needs doc
+     */
+    uint8_t eeconfig_read_default_layer(void) { return eeprom_read_byte(EECONFIG_DEFAULT_LAYER); }
+    /** \brief eeconfig update default layer
+     *
+     * FIXME: needs doc
+     */
+    void eeconfig_update_default_layer(uint8_t val) { eeprom_update_byte(EECONFIG_DEFAULT_LAYER, val); }
 
-/** \brief eeconfig read keymap
- *
- * FIXME: needs doc
- */
-uint16_t eeconfig_read_keymap(void) { return (eeprom_read_byte(EECONFIG_KEYMAP_LOWER_BYTE) | (eeprom_read_byte(EECONFIG_KEYMAP_UPPER_BYTE) << 8)); }
-/** \brief eeconfig update keymap
- *
- * FIXME: needs doc
- */
-void eeconfig_update_keymap(uint16_t val) {
-    eeprom_update_byte(EECONFIG_KEYMAP_LOWER_BYTE, val & 0xFF);
-    eeprom_update_byte(EECONFIG_KEYMAP_UPPER_BYTE, (val >> 8) & 0xFF);
-}
+    /** \brief eeconfig read keymap
+     *
+     * FIXME: needs doc
+     */
+    uint16_t eeconfig_read_keymap(void) { return (eeprom_read_byte(EECONFIG_KEYMAP_LOWER_BYTE) | (eeprom_read_byte(EECONFIG_KEYMAP_UPPER_BYTE) << 8)); }
+    /** \brief eeconfig update keymap
+     *
+     * FIXME: needs doc
+     */
+    void eeconfig_update_keymap(uint16_t val) {
+        eeprom_update_byte(EECONFIG_KEYMAP_LOWER_BYTE, val & 0xFF);
+        eeprom_update_byte(EECONFIG_KEYMAP_UPPER_BYTE, (val >> 8) & 0xFF);
+    }
 
-/** \brief eeconfig read audio
- *
- * FIXME: needs doc
- */
-uint8_t eeconfig_read_audio(void) { return eeprom_read_byte(EECONFIG_AUDIO); }
-/** \brief eeconfig update audio
- *
- * FIXME: needs doc
- */
-void eeconfig_update_audio(uint8_t val) { eeprom_update_byte(EECONFIG_AUDIO, val); }
+    /** \brief eeconfig read audio
+     *
+     * FIXME: needs doc
+     */
+    uint8_t eeconfig_read_audio(void) { return eeprom_read_byte(EECONFIG_AUDIO); }
+    /** \brief eeconfig update audio
+     *
+     * FIXME: needs doc
+     */
+    void eeconfig_update_audio(uint8_t val) { eeprom_update_byte(EECONFIG_AUDIO, val); }
 
-/** \brief eeconfig read kb
- *
- * FIXME: needs doc
- */
-uint32_t eeconfig_read_kb(void) { return eeprom_read_dword(EECONFIG_KEYBOARD); }
-/** \brief eeconfig update kb
- *
- * FIXME: needs doc
- */
-void eeconfig_update_kb(uint32_t val) { eeprom_update_dword(EECONFIG_KEYBOARD, val); }
+    /** \brief eeconfig read kb
+     *
+     * FIXME: needs doc
+     */
+    uint32_t eeconfig_read_kb(void) { return eeprom_read_dword(EECONFIG_KEYBOARD); }
+    /** \brief eeconfig update kb
+     *
+     * FIXME: needs doc
+     */
+    void eeconfig_update_kb(uint32_t val) { eeprom_update_dword(EECONFIG_KEYBOARD, val); }
 
-/** \brief eeconfig read user
- *
- * FIXME: needs doc
- */
-uint32_t eeconfig_read_user(void) { return eeprom_read_dword(EECONFIG_USER); }
-/** \brief eeconfig update user
- *
- * FIXME: needs doc
- */
-void eeconfig_update_user(uint32_t val) { eeprom_update_dword(EECONFIG_USER, val); }
+    /** \brief eeconfig read user
+     *
+     * FIXME: needs doc
+     */
+    uint32_t eeconfig_read_user(void) { return eeprom_read_dword(EECONFIG_USER); }
+    /** \brief eeconfig update user
+     *
+     * FIXME: needs doc
+     */
+    void eeconfig_update_user(uint32_t val) { eeprom_update_dword(EECONFIG_USER, val); }
 
-/** \brief eeconfig read haptic
- *
- * FIXME: needs doc
- */
-uint32_t eeconfig_read_haptic(void) { return eeprom_read_dword(EECONFIG_HAPTIC); }
-/** \brief eeconfig update haptic
- *
- * FIXME: needs doc
- */
-void eeconfig_update_haptic(uint32_t val) { eeprom_update_dword(EECONFIG_HAPTIC, val); }
+    /** \brief eeconfig read haptic
+     *
+     * FIXME: needs doc
+     */
+    uint32_t eeconfig_read_haptic(void) { return eeprom_read_dword(EECONFIG_HAPTIC); }
+    /** \brief eeconfig update haptic
+     *
+     * FIXME: needs doc
+     */
+    void eeconfig_update_haptic(uint32_t val) { eeprom_update_dword(EECONFIG_HAPTIC, val); }
 
-/** \brief eeconfig read split handedness
- *
- * FIXME: needs doc
- */
-bool eeconfig_read_handedness(void) { return !!eeprom_read_byte(EECONFIG_HANDEDNESS); }
-/** \brief eeconfig update split handedness
- *
- * FIXME: needs doc
- */
-void eeconfig_update_handedness(bool val) { eeprom_update_byte(EECONFIG_HANDEDNESS, !!val); }
+    /** \brief eeconfig read split handedness
+     *
+     * FIXME: needs doc
+     */
+    bool eeconfig_read_handedness(void) { return !!eeprom_read_byte(EECONFIG_HANDEDNESS); }
+    /** \brief eeconfig update split handedness
+     *
+     * FIXME: needs doc
+     */
+    void eeconfig_update_handedness(bool val) { eeprom_update_byte(EECONFIG_HANDEDNESS, !!val); }

--- a/quantum/keyboard.c
+++ b/quantum/keyboard.c
@@ -309,12 +309,12 @@ void housekeeping_task(void) {
 void keyboard_init(void) {
     timer_init();
     sync_timer_init();
+#ifdef VIA_ENABLE
+    via_init();
+#endif
     matrix_init();
 #if defined(CRC_ENABLE)
     crc_init();
-#endif
-#ifdef VIA_ENABLE
-    via_init();
 #endif
 #ifdef QWIIC_ENABLE
     qwiic_init();

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -319,6 +319,9 @@ bool process_record_quantum(keyrecord_t *record) {
                 return false;
             case EEPROM_RESET:
                 eeconfig_init();
+#if defined(VIA_ENABLE)
+                via_init();
+#endif
                 return false;
 #ifdef VELOCIKEY_ENABLE
             case VLK_TOG:

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -319,9 +319,6 @@ bool process_record_quantum(keyrecord_t *record) {
                 return false;
             case EEPROM_RESET:
                 eeconfig_init();
-#if defined(VIA_ENABLE)
-                via_init();
-#endif
                 return false;
 #ifdef VELOCIKEY_ENABLE
             case VLK_TOG:

--- a/quantum/via.c
+++ b/quantum/via.c
@@ -93,6 +93,9 @@ __attribute__((weak)) void via_init_kb(void) {}
 
 // Called by QMK core to initialize dynamic keymaps etc.
 void via_init(void) {
+
+    via_init_kb();
+    
     // If the EEPROM has the magic, the data is good.
     // OK to load from EEPROM.
     if (!via_eeprom_is_valid()) {

--- a/quantum/via.c
+++ b/quantum/via.c
@@ -93,24 +93,24 @@ __attribute__((weak)) void via_init_kb(void) {}
 
 // Called by QMK core to initialize dynamic keymaps etc.
 void via_init(void) {
-    // Let keyboard level test EEPROM valid state,
-    // but not set it valid, it is done here.
-    via_init_kb();
-
     // If the EEPROM has the magic, the data is good.
     // OK to load from EEPROM.
-    if (via_eeprom_is_valid()) {
-    } else {
-        // This resets the layout options
-        via_set_layout_options(VIA_EEPROM_LAYOUT_OPTIONS_DEFAULT);
-        // This resets the keymaps in EEPROM to what is in flash.
-        dynamic_keymap_reset();
-        // This resets the macros in EEPROM to nothing.
-        dynamic_keymap_macro_reset();
-        // Save the magic number last, in case saving was interrupted
-        via_eeprom_set_valid(true);
+    if (!via_eeprom_is_valid()) {
+        eeconfig_init_via();
     }
 }
+
+void eeconfig_init_via(void) {
+    // This resets the layout options
+    via_set_layout_options(VIA_EEPROM_LAYOUT_OPTIONS_DEFAULT);
+    // This resets the keymaps in EEPROM to what is in flash.
+    dynamic_keymap_reset();
+    // This resets the macros in EEPROM to nothing.
+    dynamic_keymap_macro_reset();
+    // Save the magic number last, in case saving was interrupted
+    via_eeprom_set_valid(true);
+}
+
 
 // This is generalized so the layout options EEPROM usage can be
 // variable, between 1 and 4 bytes.

--- a/quantum/via.c
+++ b/quantum/via.c
@@ -111,7 +111,6 @@ void eeconfig_init_via(void) {
     via_eeprom_set_valid(true);
 }
 
-
 // This is generalized so the layout options EEPROM usage can be
 // variable, between 1 and 4 bytes.
 uint32_t via_get_layout_options(void) {
@@ -331,7 +330,7 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
             break;
         }
         case id_dynamic_keymap_macro_get_buffer_size: {
-            uint16_t size   = dynamic_keymap_macro_get_buffer_size();
+            uint16_t size   = dynamic_keymap_macroi_get_buffer_size();
             command_data[0] = size >> 8;
             command_data[1] = size & 0xFF;
             break;

--- a/quantum/via.c
+++ b/quantum/via.c
@@ -83,16 +83,6 @@ void via_eeprom_set_valid(bool valid) {
     eeprom_update_byte((void *)VIA_EEPROM_MAGIC_ADDR + 2, valid ? magic2 : 0xFF);
 }
 
-// Flag QMK and VIA/keyboard level EEPROM as invalid.
-// Used in bootmagic_lite() and VIA command handler.
-// Keyboard level code should not need to call this.
-void via_eeprom_reset(void) {
-    // Set the VIA specific EEPROM state as invalid.
-    via_eeprom_set_valid(false);
-    // Set the TMK/QMK EEPROM state as invalid.
-    eeconfig_disable();
-}
-
 // Override this at the keyboard code level to check
 // VIA's EEPROM valid state and reset to defaults as needed.
 // Used by keyboards that store their own state in EEPROM,

--- a/quantum/via.c
+++ b/quantum/via.c
@@ -95,7 +95,7 @@ __attribute__((weak)) void via_init_kb(void) {}
 void via_init(void) {
 
     via_init_kb();
-    
+
     // If the EEPROM has the magic, the data is good.
     // OK to load from EEPROM.
     if (!via_eeprom_is_valid()) {
@@ -104,6 +104,8 @@ void via_init(void) {
 }
 
 void eeconfig_init_via(void) {
+    // set the magic number to false, in case this gets interrupted
+    via_eeprom_set_valid(false);
     // This resets the layout options
     via_set_layout_options(VIA_EEPROM_LAYOUT_OPTIONS_DEFAULT);
     // This resets the keymaps in EEPROM to what is in flash.

--- a/quantum/via.c
+++ b/quantum/via.c
@@ -330,7 +330,7 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
             break;
         }
         case id_dynamic_keymap_macro_get_buffer_size: {
-            uint16_t size   = dynamic_keymap_macroi_get_buffer_size();
+            uint16_t size   = dynamic_keymap_macro_get_buffer_size();
             command_data[0] = size >> 8;
             command_data[1] = size & 0xFF;
             break;

--- a/quantum/via.c
+++ b/quantum/via.c
@@ -319,6 +319,10 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
 #endif
             break;
         }
+        case id_eeprom_reset: {
+            eeconfig_init_via();
+            break;
+        }
         case id_dynamic_keymap_macro_get_count: {
             command_data[0] = dynamic_keymap_macro_get_count();
             break;

--- a/quantum/via.c
+++ b/quantum/via.c
@@ -93,7 +93,8 @@ __attribute__((weak)) void via_init_kb(void) {}
 
 // Called by QMK core to initialize dynamic keymaps etc.
 void via_init(void) {
-
+    // Let keyboard level test EEPROM valid state,
+    // but not set it valid, it is done here.
     via_init_kb();
 
     // If the EEPROM has the magic, the data is good.

--- a/quantum/via.c
+++ b/quantum/via.c
@@ -319,11 +319,13 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
 #endif
             break;
         }
+#ifdef VIA_EEPROM_ALLOW_RESET
         case id_eeprom_reset: {
             via_eeprom_set_valid(false);
             eeconfig_init_via();
             break;
         }
+#endif
         case id_dynamic_keymap_macro_get_count: {
             command_data[0] = dynamic_keymap_macro_get_count();
             break;

--- a/quantum/via.c
+++ b/quantum/via.c
@@ -320,6 +320,7 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
             break;
         }
         case id_eeprom_reset: {
+            via_eeprom_set_valid(false);
             eeconfig_init_via();
             break;
         }

--- a/quantum/via.h
+++ b/quantum/via.h
@@ -152,12 +152,8 @@ bool via_eeprom_is_valid(void);
 // Keyboard level code (eg. via_init_kb()) should not call this
 void via_eeprom_set_valid(bool valid);
 
-// Flag QMK and VIA/keyboard level EEPROM as invalid.
-// Used in bootmagic_lite() and VIA command handler.
-// Keyboard level code should not need to call this.
-void via_eeprom_reset(void);
-
 // Called by QMK core to initialize dynamic keymaps etc.
+void eeconfig_init_via(void);
 void via_init(void);
 
 // Used by VIA to store and retrieve the layout options.


### PR DESCRIPTION
## Description

VIA EEPROM checks and initialization isn't touched by `eeconfig_init`.  So, it's possible that it can be ignore.  This actively happens when the EEP_RST key is hit, as well as full bootmagic's eeprom reset.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [x] Enhancement/optimization

## Issues Fixed or Closed by This PR

* issue reported on discord

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
