### PR TITLE
kb: mb44 - Update info.json and encoder

### DIFF
--- a/keyboards/mb44/info.json
+++ b/keyboards/mb44/info.json
@@ -52,7 +52,7 @@
                 {"x":11.75, "y":3}
             ]
         },
-        "LAYOUT_2u_split": {
+        "LAYOUT_2u_space": {
             "layout": [
                 {"x":0, "y":0},
                 {"x":1, "y":0},
@@ -101,7 +101,7 @@
                 {"x":11.75, "y":3}
             ]
         },
-        "LAYOUT_2u1u_split": {
+        "LAYOUT_2u1u_space": {
             "layout": [
                 {"x":0, "y":0},
                 {"x":1, "y":0},
@@ -150,7 +150,7 @@
                 {"x":11.75, "y":3}
             ]
         },
-        "LAYOUT_3u_split": {
+        "LAYOUT_3u_space": {
             "layout": [
                 {"x":0, "y":0},
                 {"x":1, "y":0},

--- a/keyboards/mb44/keymaps/2u1u_space/keymap.c
+++ b/keyboards/mb44/keymaps/2u1u_space/keymap.c
@@ -48,7 +48,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 };
 
 // Rotary Encoder Functions
-void encoder_update_user(uint8_t index, bool clockwise) {
+bool encoder_update_user(uint8_t index, bool clockwise) {
     if (index == 0) { /* First encoder */
         if (clockwise) {
             tap_code(KC_VOLD);
@@ -56,4 +56,5 @@ void encoder_update_user(uint8_t index, bool clockwise) {
             tap_code(KC_VOLU);
         }
     }
+    return true;
 }

--- a/keyboards/mb44/keymaps/2u_space/keymap.c
+++ b/keyboards/mb44/keymaps/2u_space/keymap.c
@@ -48,7 +48,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 };
 
 // Rotary Encoder Functions
-void encoder_update_user(uint8_t index, bool clockwise) {
+bool encoder_update_user(uint8_t index, bool clockwise) {
     if (index == 0) { /* First encoder */
         if (clockwise) {
             tap_code(KC_VOLD);
@@ -56,4 +56,5 @@ void encoder_update_user(uint8_t index, bool clockwise) {
             tap_code(KC_VOLU);
         }
     }
+    return true;
 }

--- a/keyboards/mb44/keymaps/3u_space/keymap.c
+++ b/keyboards/mb44/keymaps/3u_space/keymap.c
@@ -56,7 +56,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 };
 
 // Rotary Encoder Functions
-void encoder_update_user(uint8_t index, bool clockwise) {
+bool encoder_update_user(uint8_t index, bool clockwise) {
     if (index == 0) { /* First encoder */
         if (clockwise) {
             tap_code(KC_VOLD);
@@ -64,4 +64,5 @@ void encoder_update_user(uint8_t index, bool clockwise) {
             tap_code(KC_VOLU);
         }
     }
+    return true;
 }

--- a/keyboards/mb44/keymaps/default/keymap.c
+++ b/keyboards/mb44/keymaps/default/keymap.c
@@ -50,7 +50,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 
 // Rotary Encoder Functions
-void encoder_update_user(uint8_t index, bool clockwise) {
+bool encoder_update_user(uint8_t index, bool clockwise) {
     if (index == 0) { /* First encoder */
         if (clockwise) {
             tap_code(KC_VOLD);
@@ -58,4 +58,5 @@ void encoder_update_user(uint8_t index, bool clockwise) {
             tap_code(KC_VOLU);
         }
     }
+    return true;
 }


### PR DESCRIPTION
Updated info.json to match mb44.h and rotary encoder callbacks in `keymap.c

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
* Due to having different layout names between `info.json` and  `mb44.h`, configurator was showing both the incorrect and correct named layouts. This PR revises the layout names in `info.json` to match `mb44.h`.

* Updated rotary encoder callback in keymap.c to conform to `bool`.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* See Description above.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
