### PR TITLE
allow LINE_PINxx for Teensy 4.x pins

### DIFF
--- a/data/schemas/keyboard.jsonschema
+++ b/data/schemas/keyboard.jsonschema
@@ -180,6 +180,10 @@
                                     "pattern": "^[A-K]\\d{1,2}$"
                                 },
                                 {
+                                    "type": "string",
+                                    "pattern": "^LINE_PIN\\d{1,2}$"
+                                },
+                                {
                                     "type": "number",
                                     "multipleOf": 1
                                 },
@@ -199,6 +203,10 @@
                                 "pattern": "^[A-K]\\d{1,2}$"
                             },
                             {
+                                "type": "string",
+                                "pattern": "^LINE_PIN\\d{1,2}$"
+                            },
+                            {
                                 "type": "number",
                                 "multipleOf": 1
                             },
@@ -215,6 +223,10 @@
                             {
                                 "type": "string",
                                 "pattern": "^[A-K]\\d{1,2}$"
+                            },
+                            {
+                                "type": "string",
+                                "pattern": "^LINE_PIN\\d{1,2}$"
                             },
                             {
                                 "type": "number",
@@ -261,7 +273,7 @@
                 },
                 "pin": {
                     "type": "string",
-                    "pattern": "^[A-K]\\d{1,2}$"
+                    "pattern": "^([A-K]\\d{1,2}|LINE_PIN\\d{1,2})$"
                 },
                 "saturation_steps": {
                     "type": "number",

--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -146,6 +146,9 @@ def _pin_name(pin):
     elif pin[0] in 'ABCDEFGHIJK' and pin[1].isdigit():
         return pin
 
+    elif pin.startswith('LINE_PIN'):
+        return pin
+
     raise ValueError(f'Invalid pin: {pin}')
 
 


### PR DESCRIPTION
## Description

As discussed in https://github.com/qmk/qmk_firmware/issues/13052, we should use LINE_PINxx on Teensy 4.x. This PR makes that possible.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* fixes https://github.com/qmk/qmk_firmware/issues/13052

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
