### PR TITLE
Fix CRC for AVR and enable again.

### DIFF
--- a/common_features.mk
+++ b/common_features.mk
@@ -530,6 +530,7 @@ endif
 ifeq ($(strip $(SPLIT_KEYBOARD)), yes)
     POST_CONFIG_H += $(QUANTUM_DIR)/split_common/post_config.h
     OPT_DEFS += -DSPLIT_KEYBOARD
+	CRC_ENABLE := yes
 
     # Include files used by all split keyboards
     QUANTUM_SRC += $(QUANTUM_DIR)/split_common/split_util.c
@@ -563,7 +564,7 @@ endif
 
 ifeq ($(strip $(CRC_ENABLE)), yes)
     OPT_DEFS += -DCRC_ENABLE
-    QUANTUM_LIB_SRC += crc.c
+    SRC += crc.c
 endif
 
 HAPTIC_ENABLE ?= no

--- a/common_features.mk
+++ b/common_features.mk
@@ -530,7 +530,7 @@ endif
 ifeq ($(strip $(SPLIT_KEYBOARD)), yes)
     POST_CONFIG_H += $(QUANTUM_DIR)/split_common/post_config.h
     OPT_DEFS += -DSPLIT_KEYBOARD
-	CRC_ENABLE := yes
+    CRC_ENABLE := yes
 
     # Include files used by all split keyboards
     QUANTUM_SRC += $(QUANTUM_DIR)/split_common/split_util.c


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
I don't really understand the implications of QUANTUM_LIB_SRC vs SRC. 

I noticed removing the weak attribute on crc_init() threw up a undefined error in keyboard.c, so assumed it wasn't getting included correctly.

I've flashed this on a spare promicro and it seems to work correctly with the crkbd and kyria default keymaps. Might be good for someone else to confirm.


<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
