### PR TITLE
allow LINE_PINxx for Teensy 4.x pins for indicator LEDs as well

### DIFF
--- a/data/schemas/keyboard.jsonschema
+++ b/data/schemas/keyboard.jsonschema
@@ -70,15 +70,15 @@
             "properties": {
                 "caps_lock": {
                     "type": "string",
-                    "pattern": "^[A-K]\\d{1,2}$"
+                    "pattern": "^([A-K]\\d{1,2}|LINE_PIN\\d{1,2})$"
                 },
                 "num_lock": {
                     "type": "string",
-                    "pattern": "^[A-K]\\d{1,2}$"
+                    "pattern": "^([A-K]\\d{1,2}|LINE_PIN\\d{1,2})$"
                 },
                 "scroll_lock": {
                     "type": "string",
-                    "pattern": "^[A-K]\\d{1,2}$"
+                    "pattern": "^([A-K]\\d{1,2}|LINE_PIN\\d{1,2})$"
                 }
             }
         },


### PR DESCRIPTION

## Description

This is the same change as #13247, but for the indicator LEDs (caps lock etc.).
 
I only noticed this was missing while preparing another pull request.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/qmk/qmk_firmware/issues/13052

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
