### PR TITLE
[Keymap] Portuguese Mac layout ISO enhancement

### DIFF
--- a/quantum/keymap_extras/keymap_portuguese_osx_iso.h
+++ b/quantum/keymap_extras/keymap_portuguese_osx_iso.h
@@ -125,7 +125,7 @@
 #define PT_COLN S(PT_DOT)  // :
 #define PT_UNDS S(PT_MINS) // _
 
-/* Alted symbols
+/* AltGr symbols
  * ┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬─────┐
  * │   │  │ @ │ € │ £ │ ‰ │ ¶ │ ÷ │ [ │ ] │ ≠ │   │   │     │
  * ├───┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬───┤
@@ -139,56 +139,56 @@
  * └─────┴────┴─────┴───────────────────────┴─────┴────┴─────┘
  */
 // Row 1
-#define PT_APPL A(PT_1)    //  (Apple logo)
-#define PT_AT   A(PT_2)    // @
-#define PT_EURO A(PT_3)    // €
-#define PT_PND  A(PT_4)    // £
-#define PT_PERM A(PT_5)    // ‰
-#define PT_PILC A(PT_6)    // ¶
-#define PT_DIV  A(PT_7)    // ÷
-#define PT_LBRC A(PT_8)    // [
-#define PT_RBRC A(PT_9)    // ]
-#define PT_NEQL A(PT_0)    // ≠
+#define PT_APPL ALGR(PT_1)    //  (Apple logo)
+#define PT_AT   ALGR(PT_2)    // @
+#define PT_EURO ALGR(PT_3)    // €
+#define PT_PND  ALGR(PT_4)    // £
+#define PT_PERM ALGR(PT_5)    // ‰
+#define PT_PILC ALGR(PT_6)    // ¶
+#define PT_DIV  ALGR(PT_7)    // ÷
+#define PT_LBRC ALGR(PT_8)    // [
+#define PT_RBRC ALGR(PT_9)    // ]
+#define PT_NEQL ALGR(PT_0)    // ≠
 // Row 2
-#define PT_OE   A(PT_Q)    // Œ
-#define PT_NARS A(PT_W)    // ∑
-#define PT_AE   A(PT_E)    // Æ
-#define PT_REGD A(PT_R)    // ®
-#define PT_TM   A(PT_T)    // ™
-#define PT_YEN  A(PT_Y)    // ¥
-#define PT_DAGG A(PT_U)    // †
-#define PT_DLSI A(PT_I)    // ı
-#define PT_OSTR A(PT_O)    // Ø
-#define PT_PI   A(PT_P)    // π
-#define PT_DEG  A(PT_MORD) // °
-#define PT_DIAE A(PT_ACUT) // ¨ (dead)
+#define PT_OE   ALGR(PT_Q)    // Œ
+#define PT_NARS ALGR(PT_W)    // ∑
+#define PT_AE   ALGR(PT_E)    // Æ
+#define PT_REGD ALGR(PT_R)    // ®
+#define PT_TM   ALGR(PT_T)    // ™
+#define PT_YEN  ALGR(PT_Y)    // ¥
+#define PT_DAGG ALGR(PT_U)    // †
+#define PT_DLSI ALGR(PT_I)    // ı
+#define PT_OSTR ALGR(PT_O)    // Ø
+#define PT_PI   ALGR(PT_P)    // π
+#define PT_DEG  ALGR(PT_MORD) // °
+#define PT_DIAE ALGR(PT_ACUT) // ¨ (dead)
 // Row 3
-#define PT_ARNG A(PT_A)    // å
-#define PT_SS   A(PT_S)    // ß
-#define PT_PDIF A(PT_D)    // ∂
-#define PT_FHK  A(PT_F)    // ƒ
-#define PT_DOTA A(PT_G)    // ˙
-#define PT_CARN A(PT_H)    // ˇ
-#define PT_MACR A(PT_J)    // ¯
-#define PT_DLQU A(PT_K)    // „
-#define PT_LSQU A(PT_L)    // ‘
-#define PT_CEDL A(PT_CCED) // ¸
-#define PT_STIL A(PT_TILD) // ˜ (dead)
-#define PT_LSAQ A(PT_BSLS) // ‹
+#define PT_ARNG ALGR(PT_A)    // å
+#define PT_SS   ALGR(PT_S)    // ß
+#define PT_PDIF ALGR(PT_D)    // ∂
+#define PT_FHK  ALGR(PT_F)    // ƒ
+#define PT_DOTA ALGR(PT_G)    // ˙
+#define PT_CARN ALGR(PT_H)    // ˇ
+#define PT_MACR ALGR(PT_J)    // ¯
+#define PT_DLQU ALGR(PT_K)    // „
+#define PT_LSQU ALGR(PT_L)    // ‘
+#define PT_CEDL ALGR(PT_CCED) // ¸
+#define PT_STIL ALGR(PT_TILD) // ˜ (dead)
+#define PT_LSAQ ALGR(PT_BSLS) // ‹
 // Row 4
-#define PT_LTEQ A(PT_LABK) // ≤
-#define PT_OMEG A(PT_Z)    // Ω
-#define PT_LDAQ A(PT_X)    // «
-#define PT_COPY A(PT_C)    // ©
-#define PT_SQRT A(PT_V)    // √
-#define PT_INTG A(PT_B)    // ∫
-#define PT_NOT  A(PT_N)    // ¬
-#define PT_MICR A(PT_M)    // µ
-#define PT_LDQU A(PT_COMM) // “
-#define PT_ELLP A(PT_DOT)  // …
-#define PT_MDSH A(PT_MINS) // —
+#define PT_LTEQ ALGR(PT_LABK) // ≤
+#define PT_OMEG ALGR(PT_Z)    // Ω
+#define PT_LDAQ ALGR(PT_X)    // «
+#define PT_COPY ALGR(PT_C)    // ©
+#define PT_SQRT ALGR(PT_V)    // √
+#define PT_INTG ALGR(PT_B)    // ∫
+#define PT_NOT  ALGR(PT_N)    // ¬
+#define PT_MICR ALGR(PT_M)    // µ
+#define PT_LDQU ALGR(PT_COMM) // “
+#define PT_ELLP ALGR(PT_DOT)  // …
+#define PT_MDSH ALGR(PT_MINS) // —
 
-/* Shift+Alted symbols
+/* Shift+AltGr symbols
  * ┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬─────┐
  * │   │ ¡ │ ﬁ │ ﬂ │ ¢ │ ∞ │ • │ ⁄ │ { │ } │ ≈ │ ¿ │ ◊ │     │
  * ├───┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬───┤
@@ -202,33 +202,33 @@
  * └─────┴────┴─────┴───────────────────────┴─────┴────┴─────┘
  */
 // Row 1
-#define PT_IEXL S(A(PT_1))    // ¡
-#define PT_FI   S(A(PT_2))    // ﬁ
-#define PT_FL   S(A(PT_3))    // ﬂ
-#define PT_CENT S(A(PT_4))    // ¢
-#define PT_INFN S(A(PT_5))    // ∞
-#define PT_BULT S(A(PT_6))    // •
-#define PT_FRSL S(A(PT_7))    // ⁄
-#define PT_LCBR S(A(PT_8))    // {
-#define PT_RCBR S(A(PT_9))    // }
-#define PT_AEQL S(A(PT_0))    // ≈
-#define PT_IQUE S(A(PT_QUOT)) // ¿
-#define PT_LOZN S(A(PT_PLUS)) // ◊
+#define PT_IEXL S(ALGR(PT_1))    // ¡
+#define PT_FI   S(ALGR(PT_2))    // ﬁ
+#define PT_FL   S(ALGR(PT_3))    // ﬂ
+#define PT_CENT S(ALGR(PT_4))    // ¢
+#define PT_INFN S(ALGR(PT_5))    // ∞
+#define PT_BULT S(ALGR(PT_6))    // •
+#define PT_FRSL S(ALGR(PT_7))    // ⁄
+#define PT_LCBR S(ALGR(PT_8))    // {
+#define PT_RCBR S(ALGR(PT_9))    // }
+#define PT_AEQL S(ALGR(PT_0))    // ≈
+#define PT_IQUE S(ALGR(PT_QUOT)) // ¿
+#define PT_LOZN S(ALGR(PT_PLUS)) // ◊
 // Row 2
-#define PT_DDAG S(A(PT_U))    // ‡
-#define PT_RNGA S(A(PT_I))    // ˚
-#define PT_NARP S(A(PT_P))    // ∏
-#define PT_DACU S(A(PT_ACUT)) // ˝
+#define PT_DDAG S(ALGR(PT_U))    // ‡
+#define PT_RNGA S(ALGR(PT_I))    // ˚
+#define PT_NARP S(ALGR(PT_P))    // ∏
+#define PT_DACU S(ALGR(PT_ACUT)) // ˝
 // Row 3
-#define PT_INCR S(A(PT_D))    // ∆
-#define PT_SLQU S(A(PT_K))    // ‚
-#define PT_RSQU S(A(PT_L))    // ’
-#define PT_OGON S(A(PT_CCED)) // ˛
-#define PT_DCIR S(A(PT_TILD)) // ˆ (dead)
-#define PT_RSAQ S(A(PT_BSLS)) // ›
+#define PT_INCR S(ALGR(PT_D))    // ∆
+#define PT_SLQU S(ALGR(PT_K))    // ‚
+#define PT_RSQU S(ALGR(PT_L))    // ’
+#define PT_OGON S(ALGR(PT_CCED)) // ˛
+#define PT_DCIR S(ALGR(PT_TILD)) // ˆ (dead)
+#define PT_RSAQ S(ALGR(PT_BSLS)) // ›
 // Row 4
-#define PT_GTEQ S(A(PT_LABK)) // ≥
-#define PT_RDAQ S(A(PT_X))    // »
-#define PT_RDQU S(A(PT_COMM)) // ”
-#define PT_MDDT S(A(PT_DOT))  // ·
-#define PT_NDSH S(A(PT_MINS)) // –
+#define PT_GTEQ S(ALGR(PT_LABK)) // ≥
+#define PT_RDAQ S(ALGR(PT_X))    // »
+#define PT_RDQU S(ALGR(PT_COMM)) // ”
+#define PT_MDDT S(ALGR(PT_DOT))  // ·
+#define PT_NDSH S(ALGR(PT_MINS)) // –


### PR DESCRIPTION
On MacOS both Alt and AltGr can be used to enter the new
shift level. However, in Linux and Windows they only use
AltGr by default. Changing the layout to use AltGr makes
is easier to use the Mac layout also on Linux/Windows.