### PR TITLE
le_chiffre.c conditional led_config

### DIFF
--- a/keyboards/le_chiffre/le_chiffre.c
+++ b/keyboards/le_chiffre/le_chiffre.c
@@ -15,6 +15,7 @@
  */
 #include "le_chiffre.h"
 
+#ifdef RGB_MATRIX_ENABLE
 led_config_t g_led_config = { {
   // Key Matrix to LED Index
   { 3, 4, NO_LED, 5, 6 },
@@ -29,3 +30,4 @@ led_config_t g_led_config = { {
 
   2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2
 } };
+#endif


### PR DESCRIPTION
## Description
disabling RGB_MATRIX_ENABLE causes led_config to fail during compile. Setting this conditional allows you to turn off RGB

## Types of Changes

- [ ] Core
- [X] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [X] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
