### PR TITLE
Action: Add build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,54 @@
+name: Build firmware for keyboards
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        keyboard:
+          - planck/rev6
+          - preonic/rev3
+          - ergodox_ez
+          - clueboard/60
+          - clueboard/17
+          - atreus
+        keymap:
+          - default
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+        persist-credentials: false
+        submodules: true
+
+    - name: Build
+      id: build
+      run: |
+        TARGET="${{ matrix.keyboard }}"
+
+        if [ -n "${{ matrix.keymap }}" ]; then
+           TARGET="${TARGET}:${{ matrix.keymap }}"
+        fi
+        
+        sed -i 's/run --rm -it/run --rm/' util/docker_build.sh
+        util/docker_build.sh ${TARGET}
+
+        ls
+
+        echo ::set-output name=artifact-name::${TARGET//[:<>|*?\\\/]/_}
+        echo "Artifact-name: ${{ steps.build.outputs.artifact-name }}"
+
+    - name: Archive artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: "${{ steps.build.outputs.artifact-name }}"
+        path: |
+          *.hex
+          *.bin
+      continue-on-error: true


### PR DESCRIPTION
Signed-off-by: Luigi311 <luigi311.lg@gmail.com>

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Adds a build workflow to allow users to build their keyboard firmware on Github action so they do not need to install docker or set up a build environment. The new fetch upstream feature on GitHub web will also allow users to update their firmware once their branch is set up.

Users would navigate to the .github/workflow/build.yml file and replace the matrix with the firmwares they would want to build. In my case I would be building handwired/stream_cheap/2x4:default so my matrix would be 
```
    matrix:
        keyboard:
          - handwired/stream_cheap/2x4
        keymap:
          - default
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [X] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [X] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
