### PR TITLE
Fix linker error when rgblight and RGB Matrix are both enabled

### DIFF
--- a/common_features.mk
+++ b/common_features.mk
@@ -233,9 +233,9 @@ endif
     COMMON_VPATH += $(QUANTUM_DIR)/led_matrix
     COMMON_VPATH += $(QUANTUM_DIR)/led_matrix/animations
     COMMON_VPATH += $(QUANTUM_DIR)/led_matrix/animations/runners
-    SRC += process_backlight.c
-    SRC += led_matrix.c
-    SRC += led_matrix_drivers.c
+    SRC += $(QUANTUM_DIR)/process_keycode/process_backlight.c
+    SRC += $(QUANTUM_DIR)/led_matrix/led_matrix.c
+    SRC += $(QUANTUM_DIR)/led_matrix/led_matrix_drivers.c
     CIE1931_CURVE := yes
 
     ifeq ($(strip $(LED_MATRIX_DRIVER)), IS31FL3731)
@@ -261,9 +261,9 @@ endif
     COMMON_VPATH += $(QUANTUM_DIR)/rgb_matrix
     COMMON_VPATH += $(QUANTUM_DIR)/rgb_matrix/animations
     COMMON_VPATH += $(QUANTUM_DIR)/rgb_matrix/animations/runners
-    SRC += color.c
-    SRC += rgb_matrix.c
-    SRC += rgb_matrix_drivers.c
+    SRC += $(QUANTUM_DIR)/color.c
+    SRC += $(QUANTUM_DIR)/rgb_matrix/rgb_matrix.c
+    SRC += $(QUANTUM_DIR)/rgb_matrix/rgb_matrix_drivers.c
     CIE1931_CURVE := yes
     RGB_KEYCODES_ENABLE := yes
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

```
 | 
 | /usr/local/opt/avr-binutils/bin/avr-ld: .build/obj_planck_light_drashna/color.o (symbol from plugin): in function `hsv_to_rgb_impl':
 | (.text+0x0): multiple definition of `hsv_to_rgb_impl'; .build/obj_planck_light_drashna/quantum/color.o (symbol from plugin):(.text+0x0): first defined here
 | /usr/local/opt/avr-binutils/bin/avr-ld: .build/obj_planck_light_drashna/color.o (symbol from plugin): in function `hsv_to_rgb_impl':
 | (.text+0x0): multiple definition of `hsv_to_rgb'; .build/obj_planck_light_drashna/quantum/color.o (symbol from plugin):(.text+0x0): first defined here
 | /usr/local/opt/avr-binutils/bin/avr-ld: .build/obj_planck_light_drashna/color.o (symbol from plugin): in function `hsv_to_rgb_impl':
 | (.text+0x0): multiple definition of `hsv_to_rgb_nocie'; .build/obj_planck_light_drashna/quantum/color.o (symbol from plugin):(.text+0x0): first defined here
 | collect2: error: ld returned 1 exit status
```

Presumably caused by the creation of two object files from color.c in different build directories.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
