### PR TITLE
Allow settable SPI divisor for AW20216 driver, set default to 4

### DIFF
--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -250,6 +250,7 @@ You can use up to 2 AW20216 IC's. Do not specify `DRIVER_<N>_xxx` defines for IC
 | `DRIVER_LED_TOTAL` | (Required) How many RGB lights are present across all drivers | |
 | `AW_SCALING_MAX` | (Optional) LED current scaling value (0-255, higher values mean LED is brighter at full PWM) | 150 |
 | `AW_GLOBAL_CURRENT_MAX` | (Optional) Driver global current limit (0-255, higher values means the driver may consume more power) | 150 |
+| `AW_SPI_DIVISOR` | (Optional) Clock divisor for SPI communication (powers of 2, smaller numbers means faster communication, should not be less than 4) | 4 |
 
 Here is an example using 2 drivers.
 

--- a/drivers/awinic/aw20216.c
+++ b/drivers/awinic/aw20216.c
@@ -59,13 +59,17 @@
 #    define DRIVER_1_EN C13
 #endif
 
+#ifndef AW_SPI_DIVISOR
+#    define AW_SPI_DIVISOR 4
+#endif
+
 uint8_t g_spi_transfer_buffer[20] = {0};
 aw_led  g_pwm_buffer[DRIVER_LED_TOTAL];
 bool    g_pwm_buffer_update_required[DRIVER_LED_TOTAL];
 
 bool AW20216_write_register(pin_t slave_pin, uint8_t page, uint8_t reg, uint8_t data) {
     // Do we need to call spi_stop() if this fails?
-    if (!spi_start(slave_pin, false, 0, 16)) {
+    if (!spi_start(slave_pin, false, 0, AW_SPI_DIVISOR)) {
         return false;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Allow user to set SPI divisor for communicating to AW20216 RGB driver, default to 4.

Testing with a 480 fps video doesn't really show any tangible improvement, full matrix update still takes approx 15ms, I suspect the bottleneck is in the actual driver code.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
