### PR TITLE
Fix building layouts from JSON

### DIFF
--- a/build_layout.mk
+++ b/build_layout.mk
@@ -7,7 +7,7 @@ define SEARCH_LAYOUTS_REPO
     LAYOUT_KEYMAP_C := $$(LAYOUT_KEYMAP_PATH)/keymap.c
     ifneq ("$$(wildcard $$(LAYOUT_KEYMAP_JSON))","")
         -include $$(LAYOUT_KEYMAP_PATH)/rules.mk
-        KEYMAP_C := $(KEYBOARD_OUTPUT)/src/keymap.c
+        KEYMAP_C := $(KEYMAP_OUTPUT)/keymap.c
         KEYMAP_JSON := $$(LAYOUT_KEYMAP_JSON)
         KEYMAP_PATH := $$(LAYOUT_KEYMAP_PATH)
     else ifneq ("$$(wildcard $$(LAYOUT_KEYMAP_C))","")
@@ -33,4 +33,5 @@ endif
 $(foreach LAYOUT,$(LAYOUTS),$(eval $(call SEARCH_LAYOUTS)))
 
 # Use rule from build_json.mk, but update prerequisite in case KEYMAP_JSON was updated
-$(KEYBOARD_OUTPUT)/src/keymap.c: $(KEYMAP_JSON)
+$(KEYMAP_C): $(KEYMAP_JSON)
+	$(QMK_BIN) json2c --quiet --output $(KEYMAP_C) $(KEYMAP_JSON)


### PR DESCRIPTION
## Description
This commit fixes usage of keymap.json files in the layouts directory.
Support for this was added in #9553, but was recently broken by #12632.

Due to the changes introduced in #12632, it was now necessary to duplicate the json2c command in build_layout.mk. I'm not sure if there's a cleaner way to solve this, but I'm by no means a Makefile guru.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
