### PR TITLE
Studio Kestra Nue: fix info.json layout macro reference

### DIFF
--- a/keyboards/studiokestra/nue/info.json
+++ b/keyboards/studiokestra/nue/info.json
@@ -5,7 +5,7 @@
     "width": 15,
     "height": 5,
     "layouts": {
-        "LAYOUT":  {
+        "LAYOUT_all":  {
             "layout": [
                 {"x":0, "y":0}, 
                 {"x":1, "y":0}, 


### PR DESCRIPTION
## Description

Corrected the info.json file to reference LAYOUT_all instead of LAYOUT.

## Types of Changes

- [x] Enhancement/optimization
- [x] Keyboard (addition or update)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
