### PR TITLE
RGB Timeout added to userspace

### DIFF
--- a/keyboards/kiwikey/wanderland/keymaps/stanrc85/keymap.c
+++ b/keyboards/kiwikey/wanderland/keymaps/stanrc85/keymap.c
@@ -83,39 +83,3 @@ void oled_task_user(void) {
     oled_write_P(led_state.scroll_lock ? PSTR("SCR ") : PSTR("    "), false);
 }
 #endif
-
-// Backlight timeout feature
-#define BACKLIGHT_TIMEOUT 20   // in minutes
-static uint16_t idle_timer = 0;
-static uint8_t halfmin_counter = 0;
-static bool led_on = true;
-static bool rgb_on = true;
-
-void matrix_scan_user(void) {
-  // idle_timer needs to be set one time
-    if (idle_timer == 0) idle_timer = timer_read();
-        if ( (led_on && timer_elapsed(idle_timer) > 30000) || (rgb_on && timer_elapsed(idle_timer) > 30000)) {
-            halfmin_counter++;
-            idle_timer = timer_read();
-        }
-
-        if ( (led_on && halfmin_counter >= BACKLIGHT_TIMEOUT * 2) || (rgb_on && halfmin_counter >= BACKLIGHT_TIMEOUT * 2)) {
-            rgblight_disable_noeeprom();
-            led_on = false;
-            rgb_on = false;
-            halfmin_counter = 0;
-        }
-};
-
-bool process_record_keymap(uint16_t keycode, keyrecord_t *record) {
-    if (record->event.pressed) {
-            if (led_on == false || rgb_on == false ) {
-        rgblight_enable_noeeprom();
-                led_on = true;
-        rgb_on = true;
-            }
-        idle_timer = timer_read();
-        halfmin_counter = 0;
-    }
-    return true;
-}

--- a/users/stanrc85/rgb_timeout.c
+++ b/users/stanrc85/rgb_timeout.c
@@ -1,0 +1,62 @@
+/*
+Copyright 2021 Stanrc85
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "stanrc85.h"
+
+// Backlight timeout feature
+// Modified from https://www.reddit.com/r/MechanicalKeyboards/comments/ix65z0/looking_for_qmk_led_idle_timeout_info/g64yov7/
+#define BACKLIGHT_TIMEOUT 10 // in minutes
+static uint16_t idle_timer = 0;
+static uint8_t halfmin_counter = 0;
+static bool led_on = true;
+static bool rgb_on = true;
+static bool rgb_was_on = false;
+
+void matrix_scan_user(void) {
+  // idle_timer needs to be set one time
+    if (idle_timer == 0) idle_timer = timer_read();
+        if ( (led_on && timer_elapsed(idle_timer) > 30000) || (rgb_on && timer_elapsed(idle_timer) > 30000)) {
+            halfmin_counter++;
+            idle_timer = timer_read();
+        }
+
+        if ( (led_on && halfmin_counter >= BACKLIGHT_TIMEOUT * 2) || (rgb_on && halfmin_counter >= BACKLIGHT_TIMEOUT * 2)) {
+            if(rgblight_is_enabled()) {
+                rgb_was_on = true;
+                rgblight_disable_noeeprom();
+                led_on = false;
+                rgb_on = false;
+            } else {
+                rgb_was_on = false;
+            }
+            halfmin_counter = 0;
+        }
+};
+
+bool process_record_keymap(uint16_t keycode, keyrecord_t *record) {
+    if (record->event.pressed) {
+            if (led_on == false || rgb_on == false ) {
+                if (rgb_was_on) {
+                    rgblight_enable_noeeprom();
+                    led_on = true;
+                    rgb_on = true;
+                }
+            }
+        idle_timer = timer_read();
+        halfmin_counter = 0;
+    }
+    return true;
+}

--- a/users/stanrc85/rules.mk
+++ b/users/stanrc85/rules.mk
@@ -36,3 +36,9 @@ ifeq ($(strip $(KEYBOARD)), jacky_studio/bear_65)
   RGB_MATRIX_ENABLE = yes
   RGBLIGHT_ENABLE = no
 endif
+ifeq ($(strip $(KEYBOARD)), tkc/portico)
+  SRC += rgb_timeout.c
+endif
+ifeq ($(strip $(KEYBOARD)), kiwikey/wanderland)
+  SRC += rgb_timeout.c
+endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
I had RGB timeout code in a single keyboards keymap file, I've taken it out of there and moved it to my userspace in its own .c file so that multiple keyboards I use can have that feature.
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
