### PR TITLE
keyboards/kint*: update debounce time to 20ms to fix ghost key presses

### DIFF
--- a/keyboards/kinesis/kint2pp/config.h
+++ b/keyboards/kinesis/kint2pp/config.h
@@ -32,8 +32,12 @@
 #define LED_COMPOSE_PIN C3
 #define LED_PIN_ON_STATE 0
 
-/* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
-#define DEBOUNCE 5
+/* Well-worn Cherry MX key switches can bounce for up to 20ms, despite the
+ * Cherry data sheet specifying 5ms. Because we use the sym_eager_pk debounce
+ * algorithm, this debounce latency only affects key releases (not key
+ * presses). */
+#undef DEBOUNCE
+#define DEBOUNCE 20
 
 #define IGNORE_MOD_TAP_INTERRUPT
 

--- a/keyboards/kinesis/kint36/config.h
+++ b/keyboards/kinesis/kint36/config.h
@@ -50,8 +50,12 @@
 /* COL2ROW or ROW2COL */
 #define DIODE_DIRECTION COL2ROW
 
-/* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
-#define DEBOUNCE 5
+/* Well-worn Cherry MX key switches can bounce for up to 20ms, despite the
+ * Cherry data sheet specifying 5ms. Because we use the sym_eager_pk debounce
+ * algorithm, this debounce latency only affects key releases (not key
+ * presses). */
+#undef DEBOUNCE
+#define DEBOUNCE 20
 
 #define IGNORE_MOD_TAP_INTERRUPT
 


### PR DESCRIPTION


## Description

We have multiple user reports (https://github.com/kinx-project/kint/issues/39 and https://github.com/qmk/qmk_firmware/pull/12626) of ghost key press issues due to the short default debounce time of 5ms.

As the comment states, well-worn Cherry MX key switches as used in the Kinesis Advantage keyboards can produce noise for more than the 5ms specified in the Cherry data sheets.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/kinx-project/kint/issues/39

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
