### PR TITLE
Rework of qmk compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -398,7 +398,7 @@ define PARSE_KEYMAP
     # Specify the variables that we are passing forward to submake
     MAKE_VARS := KEYBOARD=$$(CURRENT_KB) KEYMAP=$$(CURRENT_KM) REQUIRE_PLATFORM_KEY=$$(REQUIRE_PLATFORM_KEY) QMK_BIN=$$(QMK_BIN)
     # And the first part of the make command
-    MAKE_CMD := $$(MAKE) -r -R -C $(ROOT_DIR) -f build_keyboard.mk $$(MAKE_TARGET)
+    MAKE_CMD := echo $$(MAKE) -r -R -C $(ROOT_DIR) -f build_keyboard.mk $$(MAKE_TARGET)
     # The message to display
     MAKE_MSG := $$(MSG_MAKE_KB)
     # We run the command differently, depending on if we want more output or not

--- a/Makefile
+++ b/Makefile
@@ -398,7 +398,7 @@ define PARSE_KEYMAP
     # Specify the variables that we are passing forward to submake
     MAKE_VARS := KEYBOARD=$$(CURRENT_KB) KEYMAP=$$(CURRENT_KM) REQUIRE_PLATFORM_KEY=$$(REQUIRE_PLATFORM_KEY) QMK_BIN=$$(QMK_BIN)
     # And the first part of the make command
-    MAKE_CMD := echo $$(MAKE) -r -R -C $(ROOT_DIR) -f build_keyboard.mk $$(MAKE_TARGET)
+    MAKE_CMD := $$(MAKE) -r -R -C $(ROOT_DIR) -f build_keyboard.mk $$(MAKE_TARGET)
     # The message to display
     MAKE_MSG := $$(MSG_MAKE_KB)
     # We run the command differently, depending on if we want more output or not

--- a/lib/python/qmk/c_parse.py
+++ b/lib/python/qmk/c_parse.py
@@ -1,7 +1,8 @@
 """Functions for working with config.h files.
 """
-from pathlib import Path
 import re
+from functools import lru_cache
+from pathlib import Path
 
 from milc import cli
 
@@ -12,18 +13,21 @@ single_comment_regex = re.compile(r'\s+/[/*].*$')
 multi_comment_regex = re.compile(r'/\*(.|\n)*?\*/', re.MULTILINE)
 
 
+@lru_cache(maxsize=0)
 def strip_line_comment(string):
     """Removes comments from a single line string.
     """
     return single_comment_regex.sub('', string)
 
 
+@lru_cache(maxsize=0)
 def strip_multiline_comment(string):
     """Removes comments from a single line string.
     """
     return multi_comment_regex.sub('', string)
 
 
+@lru_cache(maxsize=0)
 def c_source_files(dir_names):
     """Returns a list of all *.c, *.h, and *.cpp files for a given list of directories
 
@@ -38,6 +42,7 @@ def c_source_files(dir_names):
     return files
 
 
+@lru_cache(maxsize=0)
 def find_layouts(file):
     """Returns list of parsed LAYOUT preprocessor macros found in the supplied include file.
     """
@@ -144,6 +149,7 @@ def _default_key(label=None):
     return new_key
 
 
+@lru_cache(maxsize=0)
 def _parse_layout_macro(layout_macro):
     """Split the LAYOUT macro into its constituent parts
     """
@@ -154,6 +160,7 @@ def _parse_layout_macro(layout_macro):
     return macro_name, layout, matrix
 
 
+@lru_cache(maxsize=0)
 def _parse_matrix_locations(matrix, file, macro_name):
     """Parse raw matrix data into a dictionary keyed by the LAYOUT identifier.
     """

--- a/lib/python/qmk/cli/clean.py
+++ b/lib/python/qmk/cli/clean.py
@@ -2,7 +2,7 @@
 """
 from subprocess import DEVNULL
 
-from qmk.commands import create_make_target
+from qmk.commands import _find_make
 from milc import cli
 
 
@@ -11,4 +11,6 @@ from milc import cli
 def clean(cli):
     """Runs `make clean` (or `make distclean` if --all is passed)
     """
-    cli.run(create_make_target('distclean' if cli.args.all else 'clean'), capture_output=False, stdin=DEVNULL)
+    make_cmd = [_find_make(), 'distclean' if cli.args.all else 'clean']
+
+    cli.run(make_cmd, capture_output=False, stdin=DEVNULL)

--- a/lib/python/qmk/cli/compile.py
+++ b/lib/python/qmk/cli/compile.py
@@ -9,61 +9,14 @@ from dotty_dict import dotty
 from milc import cli
 
 import qmk.path
-from qmk.decorators import automagic_keyboard, automagic_keymap, lru_cache
-from qmk.commands import compile_configurator_json, create_make_command, parse_configurator_json
-from qmk.info import info_json
-from qmk.keyboard import keyboard_completer, is_keyboard_target, list_keyboards
-from qmk.keymap import keymap_completer, list_keymaps
-from qmk.metadata import true_values, false_values
-
-
-@lru_cache()
-def _keyboard_list():
-    """Returns a list of keyboards matching cli.config.compile.keyboard.
-    """
-    if cli.config.compile.keyboard == 'all':
-        return list_keyboards()
-
-    elif cli.config.compile.keyboard.startswith('all-'):
-        return list_keyboards()
-
-    return [cli.config.compile.keyboard]
-
-
-def keyboard_keymap_iter():
-    """Iterates over the keyboard/keymap for this command and yields a pairing of each.
-    """
-    for keyboard in _keyboard_list():
-        continue_flag = False
-        if cli.args.filter:
-            info_data = dotty(info_json(keyboard))
-            for filter in cli.args.filter:
-                if '=' in filter:
-                    key, value = filter.split('=', 1)
-                    if value in true_values:
-                        value = True
-                    elif value in false_values:
-                        value = False
-                    elif value.isdigit():
-                        value = int(value)
-                    elif '.' in value and value.replace('.').isdigit():
-                        value = float(value)
-
-                    if info_data.get(key) != value:
-                        continue_flag = True
-                        break
-
-            if continue_flag:
-                continue
-
-        if cli.config.compile.keymap == 'all':
-            for keymap in list_keymaps(keyboard):
-                yield keyboard, keymap
-        else:
-            yield keyboard, cli.config.compile.keymap
+from qmk.decorators import automagic_keyboard, automagic_keymap
+from qmk.commands import do_compile
+from qmk.keyboard import keyboard_completer, is_keyboard_target
+from qmk.keymap import keymap_completer
 
 
 @cli.argument('filename', nargs='?', arg_only=True, type=qmk.path.FileType('r'), completer=FilesCompleter('.json'), help='The configurator export to compile')
+@cli.argument('-t', '--target', help="The make target to run. By default it compiles the keyboard only.")
 @cli.argument('-kb', '--keyboard', type=is_keyboard_target, completer=keyboard_completer, help='The keyboard to build a firmware for. Ignored when a configurator export is supplied.')
 @cli.argument('-km', '--keymap', completer=keymap_completer, help='The keymap to build a firmware for. Ignored when a configurator export is supplied.')
 @cli.argument('-n', '--dry-run', arg_only=True, action='store_true', help="Don't actually build, just show the make command to be run.")
@@ -81,91 +34,4 @@ def compile(cli):
 
     If a keyboard and keymap are provided this command will build a firmware based on that.
     """
-    envs = {'REQUIRE_PLATFORM_KEY': ''}
-    if cli.config.compile.keyboard is None:
-        cli.config.compile.keyboard = ''
-
-    silent = cli.config.compile.keyboard == 'all' or cli.config.compile.keyboard.startswith('all-') or cli.config.compile.keymap == 'all'
-
-    # Setup the environment
-    for env in cli.args.env:
-        if '=' in env:
-            key, value = env.split('=', 1)
-            if key in envs:
-                cli.log.warning('Overwriting existing environment variable %s=%s with %s=%s!', key, envs[key], key, value)
-            envs[key] = value
-        else:
-            cli.log.warning('Invalid environment variable: %s', env)
-
-    if cli.config.compile.keyboard.startswith('all-'):
-        envs['REQUIRE_PLATFORM_KEY'] = cli.config.compile.keyboard[4:]
-
-    # Run clean if necessary
-    if cli.args.clean and not cli.args.filename and not cli.args.dry_run:
-        for keyboard, keymap in keyboard_keymap_iter():
-            cli.log.info('Cleaning previous build files for keyboard {fg_cyan}%s{fg_reset} keymap {fg_cyan}%s', keyboard, keymap)
-            _, _, make_cmd = create_make_command(keyboard, keymap, 'clean', cli.config.compile.parallel, silent, **envs)
-            cli.run(make_cmd, capture_output=False, stdin=DEVNULL)
-
-    # If -f has been specified without a keyboard target, assume -kb all
-    if cli.args.filter and not cli.args.keyboard:
-        cli.log.debug('--filter supplied without --keyboard, assuming --keyboard all.')
-        cli.config.compile.keyboard = 'all'
-
-    # Determine the compile command(s)
-    commands = None
-
-    if cli.args.filename:
-        # If a configurator JSON was provided generate a keymap and compile it
-        user_keymap = parse_configurator_json(cli.args.filename)
-        commands = [compile_configurator_json(user_keymap, parallel=cli.config.compile.parallel, **envs)]
-
-    elif cli.config.compile.keyboard and cli.config.compile.keymap:
-        if cli.args.filter:
-            cli.log.info('Generating the list of keyboards to compile, this may take some time.')
-
-        commands = [create_make_command(keyboard, keymap, parallel=cli.config.compile.parallel, silent=silent, **envs) for keyboard, keymap in keyboard_keymap_iter()]
-
-    elif not cli.config.compile.keyboard:
-        cli.log.error('Could not determine keyboard!')
-
-    elif not cli.config.compile.keymap:
-        cli.log.error('Could not determine keymap!')
-
-    # Compile the firmware, if we're able to
-    if commands:
-        returncodes = []
-        for keyboard, keymap, command in commands:
-            if keymap not in list_keymaps(keyboard):
-                cli.log.debug('Skipping keyboard %s, no %s keymap found.', keyboard, keymap)
-                continue
-
-            print()
-            cli.log.info('Building firmware for {fg_cyan}%s{fg_reset} with keymap {fg_cyan}%s', keyboard, keymap)
-            cli.log.debug('Running make command: {fg_blue}%s', ' '.join(command))
-
-            if not cli.args.dry_run:
-                compile = cli.run(command, capture_output=False)
-                returncodes.append(compile.returncode)
-                if compile.returncode == 0:
-                    cli.log.info('Success!')
-                else:
-                    cli.log.error('Failed!')
-
-        if any(returncodes):
-            print()
-            cli.log.error('Could not compile all targets, look above this message for more details. Failing target(s):')
-
-            for i, returncode in enumerate(returncodes):
-                if returncode != 0:
-                    keyboard, keymap, command = commands[i]
-                    cli.echo('\tkeyboard: {fg_cyan}%s{fg_reset} keymap: {fg_cyan}%s', keyboard, keymap)
-
-    elif cli.args.filter:
-        cli.log.error('No keyboards found after applying filter(s)!')
-        return False
-
-    else:
-        cli.log.error('You must supply a configurator export, both `--keyboard` and `--keymap`, or be in a directory for a keyboard or keymap.')
-        cli.print_help()
-        return False
+    do_compile(cli.config.compile.keyboard, cli.config.compile.keymap, cli.config.compile.parallel, cli.config.compile.target)

--- a/lib/python/qmk/cli/compile.py
+++ b/lib/python/qmk/cli/compile.py
@@ -5,20 +5,70 @@ You can compile a keymap already in the repo or using a QMK Configurator export.
 from subprocess import DEVNULL
 
 from argcomplete.completers import FilesCompleter
+from dotty_dict import dotty
 from milc import cli
 
 import qmk.path
-from qmk.decorators import automagic_keyboard, automagic_keymap
+from qmk.decorators import automagic_keyboard, automagic_keymap, lru_cache
 from qmk.commands import compile_configurator_json, create_make_command, parse_configurator_json
-from qmk.keyboard import keyboard_completer, keyboard_folder
-from qmk.keymap import keymap_completer
+from qmk.info import info_json
+from qmk.keyboard import keyboard_completer, is_keyboard_target, list_keyboards
+from qmk.keymap import keymap_completer, list_keymaps
+from qmk.metadata import true_values, false_values
+
+
+@lru_cache()
+def _keyboard_list():
+    """Returns a list of keyboards matching cli.config.compile.keyboard.
+    """
+    if cli.config.compile.keyboard == 'all':
+        return list_keyboards()
+
+    elif cli.config.compile.keyboard.startswith('all-'):
+        return list_keyboards()
+
+    return [cli.config.compile.keyboard]
+
+
+def keyboard_keymap_iter():
+    """Iterates over the keyboard/keymap for this command and yields a pairing of each.
+    """
+    for keyboard in _keyboard_list():
+        continue_flag = False
+        if cli.args.filter:
+            info_data = dotty(info_json(keyboard))
+            for filter in cli.args.filter:
+                if '=' in filter:
+                    key, value = filter.split('=', 1)
+                    if value in true_values:
+                        value = True
+                    elif value in false_values:
+                        value = False
+                    elif value.isdigit():
+                        value = int(value)
+                    elif '.' in value and value.replace('.').isdigit():
+                        value = float(value)
+
+                    if info_data.get(key) != value:
+                        continue_flag = True
+                        break
+
+            if continue_flag:
+                continue
+
+        if cli.config.compile.keymap == 'all':
+            for keymap in list_keymaps(keyboard):
+                yield keyboard, keymap
+        else:
+            yield keyboard, cli.config.compile.keymap
 
 
 @cli.argument('filename', nargs='?', arg_only=True, type=qmk.path.FileType('r'), completer=FilesCompleter('.json'), help='The configurator export to compile')
-@cli.argument('-kb', '--keyboard', type=keyboard_folder, completer=keyboard_completer, help='The keyboard to build a firmware for. Ignored when a configurator export is supplied.')
+@cli.argument('-kb', '--keyboard', type=is_keyboard_target, completer=keyboard_completer, help='The keyboard to build a firmware for. Ignored when a configurator export is supplied.')
 @cli.argument('-km', '--keymap', completer=keymap_completer, help='The keymap to build a firmware for. Ignored when a configurator export is supplied.')
 @cli.argument('-n', '--dry-run', arg_only=True, action='store_true', help="Don't actually build, just show the make command to be run.")
-@cli.argument('-j', '--parallel', type=int, default=1, help="Set the number of parallel make jobs; 0 means unlimited.")
+@cli.argument('-j', '--parallel', type=int, default=1, help="Set the number of parallel make jobs to run.")
+@cli.argument('-f', '--filter', arg_only=True, action='append', default=[], help="Filter your list against info.json.")
 @cli.argument('-e', '--env', arg_only=True, action='append', default=[], help="Set a variable to be passed to make. May be passed multiple times.")
 @cli.argument('-c', '--clean', arg_only=True, action='store_true', help="Remove object files before compiling.")
 @cli.subcommand('Compile a QMK Firmware.')
@@ -31,47 +81,79 @@ def compile(cli):
 
     If a keyboard and keymap are provided this command will build a firmware based on that.
     """
-    if cli.args.clean and not cli.args.filename and not cli.args.dry_run:
-        command = create_make_command(cli.config.compile.keyboard, cli.config.compile.keymap, 'clean')
-        cli.run(command, capture_output=False, stdin=DEVNULL)
+    envs = {'REQUIRE_PLATFORM_KEY': ''}
+    silent = cli.config.compile.keyboard == 'all' or cli.config.compile.keyboard.startswith('all-') or cli.config.compile.keymap == 'all'
 
-    # Build the environment vars
-    envs = {}
+    # Setup the environment
     for env in cli.args.env:
         if '=' in env:
             key, value = env.split('=', 1)
+            if key in envs:
+                cli.log.warning('Overwriting existing environment variable %s=%s with %s=%s!', key, envs[key], key, value)
             envs[key] = value
         else:
             cli.log.warning('Invalid environment variable: %s', env)
 
-    # Determine the compile command
-    command = None
+    if cli.config.compile.keyboard.startswith('all-'):
+        envs['REQUIRE_PLATFORM_KEY'] = cli.config.compile.keyboard[4:]
+
+    # Run clean if necessary
+    if cli.args.clean and not cli.args.filename and not cli.args.dry_run:
+        for keyboard, keymap in keyboard_keymap_iter():
+            cli.log.info('Cleaning previous build files for keyboard {fg_cyan}%s{fg_reset} keymap {fg_cyan}%s', keyboard, keymap)
+            _, _, make_cmd = create_make_command(keyboard, keymap, 'clean', cli.config.compile.parallel, silent, **envs)
+            cli.run(make_cmd, capture_output=False, stdin=DEVNULL)
+
+    # Determine the compile command(s)
+    commands = None
 
     if cli.args.filename:
         # If a configurator JSON was provided generate a keymap and compile it
         user_keymap = parse_configurator_json(cli.args.filename)
-        command = compile_configurator_json(user_keymap, parallel=cli.config.compile.parallel, **envs)
+        commands = [compile_configurator_json(user_keymap, parallel=cli.config.compile.parallel, **envs)]
 
-    else:
-        if cli.config.compile.keyboard and cli.config.compile.keymap:
-            # Generate the make command for a specific keyboard/keymap.
-            command = create_make_command(cli.config.compile.keyboard, cli.config.compile.keymap, parallel=cli.config.compile.parallel, **envs)
+    elif cli.config.compile.keyboard and cli.config.compile.keymap:
+        if cli.args.filter:
+            cli.log.info('Generating the list of keyboards to compile, this may take some time.')
 
-        elif not cli.config.compile.keyboard:
-            cli.log.error('Could not determine keyboard!')
-        elif not cli.config.compile.keymap:
-            cli.log.error('Could not determine keymap!')
+        commands = [create_make_command(keyboard, keymap, parallel=cli.config.compile.parallel, silent=silent, **envs) for keyboard, keymap in keyboard_keymap_iter()]
+
+    elif not cli.config.compile.keyboard:
+        cli.log.error('Could not determine keyboard!')
+
+    elif not cli.config.compile.keymap:
+        cli.log.error('Could not determine keymap!')
 
     # Compile the firmware, if we're able to
-    if command:
-        cli.log.info('Compiling keymap with {fg_cyan}%s', ' '.join(command))
-        if not cli.args.dry_run:
-            cli.echo('\n')
-            # FIXME(skullydazed/anyone): Remove text=False once milc 1.0.11 has had enough time to be installed everywhere.
-            compile = cli.run(command, capture_output=False, text=False)
-            return compile.returncode
+    if commands:
+        returncodes = []
+        for keyboard, keymap, command in commands:
+            print()
+            cli.log.info('Building firmware for {fg_cyan}%s{fg_reset} with keymap {fg_cyan}%s', keyboard, keymap)
+            cli.log.debug('Running make command: {fg_blue}%s', ' '.join(command))
+
+            if not cli.args.dry_run:
+                compile = cli.run(command, capture_output=False)
+                returncodes.append(compile.returncode)
+                if compile.returncode == 0:
+                    cli.log.info('Success!')
+                else:
+                    cli.log.error('Failed!')
+
+        if any(returncodes):
+            print()
+            cli.log.error('Could not compile all targets, look above this message for more details. Failing target(s):')
+
+            for i, returncode in enumerate(returncodes):
+                if returncode != 0:
+                    keyboard, keymap, command = commands[i]
+                    cli.echo('\tkeyboard: {fg_cyan}%s{fg_reset} keymap: {fg_cyan}%s', keyboard, keymap)
+
+    elif cli.args.filter:
+        cli.log.error('No keyboards found after applying filter(s)!')
+        return False
 
     else:
         cli.log.error('You must supply a configurator export, both `--keyboard` and `--keymap`, or be in a directory for a keyboard or keymap.')
-        cli.echo('usage: qmk compile [-h] [-b] [-kb KEYBOARD] [-km KEYMAP] [filename]')
+        cli.print_help()
         return False

--- a/lib/python/qmk/cli/compile.py
+++ b/lib/python/qmk/cli/compile.py
@@ -2,10 +2,7 @@
 
 You can compile a keymap already in the repo or using a QMK Configurator export.
 """
-from subprocess import DEVNULL
-
 from argcomplete.completers import FilesCompleter
-from dotty_dict import dotty
 from milc import cli
 
 import qmk.path

--- a/lib/python/qmk/cli/flash.py
+++ b/lib/python/qmk/cli/flash.py
@@ -10,7 +10,7 @@ from milc import cli
 
 import qmk.path
 from qmk.decorators import automagic_keyboard, automagic_keymap
-from qmk.commands import compile_configurator_json, create_make_command, parse_configurator_json
+from qmk.commands import do_compile
 from qmk.keyboard import keyboard_completer, is_keyboard_target
 
 
@@ -54,55 +54,10 @@ def flash(cli):
 
     If bootloader is omitted the make system will use the configured bootloader for that keyboard.
     """
-    if cli.args.clean and not cli.args.filename and not cli.args.dry_run:
-        command = create_make_command(cli.config.flash.keyboard, cli.config.flash.keymap, 'clean')
-        cli.run(command, capture_output=False, stdin=DEVNULL)
-
-    # Build the environment vars
-    envs = {}
-    for env in cli.args.env:
-        if '=' in env:
-            key, value = env.split('=', 1)
-            envs[key] = value
-        else:
-            cli.log.warning('Invalid environment variable: %s', env)
-
-    # Determine the compile command
-    command = ''
-
     if cli.args.bootloaders:
         # Provide usage and list bootloaders
-        cli.echo('usage: qmk flash [-h] [-b] [-n] [-kb KEYBOARD] [-km KEYMAP] [-bl BOOTLOADER] [filename]')
+        cli.print_usage()
         print_bootloader_help()
         return False
 
-    if cli.args.filename:
-        # Handle compiling a configurator JSON
-        user_keymap = parse_configurator_json(cli.args.filename)
-        keymap_path = qmk.path.keymap(user_keymap['keyboard'])
-        command = compile_configurator_json(user_keymap, cli.args.bootloader, parallel=cli.config.flash.parallel, **envs)
-
-        cli.log.info('Wrote keymap to {fg_cyan}%s/%s/keymap.c', keymap_path, user_keymap['keymap'])
-
-    else:
-        if cli.config.flash.keyboard and cli.config.flash.keymap:
-            # Generate the make command for a specific keyboard/keymap.
-            command = create_make_command(cli.config.flash.keyboard, cli.config.flash.keymap, cli.args.bootloader, parallel=cli.config.flash.parallel, **envs)
-
-        elif not cli.config.flash.keyboard:
-            cli.log.error('Could not determine keyboard!')
-        elif not cli.config.flash.keymap:
-            cli.log.error('Could not determine keymap!')
-
-    # Compile the firmware, if we're able to
-    if command:
-        cli.log.info('Compiling keymap with {fg_cyan}%s', ' '.join(command))
-        if not cli.args.dry_run:
-            cli.echo('\n')
-            compile = cli.run(command, capture_output=False, stdin=DEVNULL)
-            return compile.returncode
-
-    else:
-        cli.log.error('You must supply a configurator export, both `--keyboard` and `--keymap`, or be in a directory for a keyboard or keymap.')
-        cli.echo('usage: qmk flash [-h] [-b] [-n] [-kb KEYBOARD] [-km KEYMAP] [-bl BOOTLOADER] [filename]')
-        return False
+    return do_compile(cli.config.flash.keyboard, cli.config.flash.keymap, cli.config.flash.parallel, cli.config.flash.bootloader)

--- a/lib/python/qmk/cli/flash.py
+++ b/lib/python/qmk/cli/flash.py
@@ -11,7 +11,7 @@ from milc import cli
 import qmk.path
 from qmk.decorators import automagic_keyboard, automagic_keymap
 from qmk.commands import compile_configurator_json, create_make_command, parse_configurator_json
-from qmk.keyboard import keyboard_completer, keyboard_folder
+from qmk.keyboard import keyboard_completer, is_keyboard_target
 
 
 def print_bootloader_help():
@@ -36,7 +36,7 @@ def print_bootloader_help():
 @cli.argument('-b', '--bootloaders', action='store_true', help='List the available bootloaders.')
 @cli.argument('-bl', '--bootloader', default='flash', help='The flash command, corresponding to qmk\'s make options of bootloaders.')
 @cli.argument('-km', '--keymap', help='The keymap to build a firmware for. Use this if you dont have a configurator file. Ignored when a configurator file is supplied.')
-@cli.argument('-kb', '--keyboard', type=keyboard_folder, completer=keyboard_completer, help='The keyboard to build a firmware for. Use this if you dont have a configurator file. Ignored when a configurator file is supplied.')
+@cli.argument('-kb', '--keyboard', type=is_keyboard_target, completer=keyboard_completer, help='The keyboard to build a firmware for. Use this if you dont have a configurator file. Ignored when a configurator file is supplied.')
 @cli.argument('-n', '--dry-run', arg_only=True, action='store_true', help="Don't actually build, just show the make command to be run.")
 @cli.argument('-j', '--parallel', type=int, default=1, help="Set the number of parallel make jobs; 0 means unlimited.")
 @cli.argument('-e', '--env', arg_only=True, action='append', default=[], help="Set a variable to be passed to make. May be passed multiple times.")

--- a/lib/python/qmk/cli/flash.py
+++ b/lib/python/qmk/cli/flash.py
@@ -3,8 +3,6 @@
 You can compile a keymap already in the repo or using a QMK Configurator export.
 A bootloader must be specified.
 """
-from subprocess import DEVNULL
-
 from argcomplete.completers import FilesCompleter
 from milc import cli
 

--- a/lib/python/qmk/commands.py
+++ b/lib/python/qmk/commands.py
@@ -22,6 +22,7 @@ from qmk.keyboard import list_keyboards
 time_fmt = '%Y-%m-%d-%H:%M:%S'
 
 
+@lru_cache(maxsize=0)
 def _find_make():
     """Returns the correct make command for this environment.
     """
@@ -106,6 +107,7 @@ def create_make_command(keyboard, keymap, target=None, parallel=1, silent=False,
     return make_cmd
 
 
+@lru_cache(maxsize=0)
 def get_git_version(current_time, repo_dir='.', check_dir='.'):
     """Returns the current git version for a repo, or the current time.
     """
@@ -258,6 +260,7 @@ def compile_configurator_json(user_keymap, bootloader=None, parallel=1, **env_va
     return user_keymap['keyboard'], user_keymap['keymap'], make_command
 
 
+@lru_cache(maxsize=0)
 def parse_configurator_json(configurator_file):
     """Open and parse a configurator json export
     """

--- a/lib/python/qmk/commands.py
+++ b/lib/python/qmk/commands.py
@@ -55,7 +55,7 @@ def create_make_target(target, parallel=1, **env_vars):
     return [make_cmd, *get_make_parallel_args(parallel), *env, target]
 
 
-def create_make_command(keyboard, keymap, target=None, parallel=1, **env_vars):
+def create_make_command(keyboard, keymap, target=None, parallel=1, silent=False, **env_vars):
     """Create a make compile command
 
     Args:
@@ -79,12 +79,26 @@ def create_make_command(keyboard, keymap, target=None, parallel=1, **env_vars):
 
         A command that can be run to make the specified keyboard and keymap
     """
-    make_args = [keyboard, keymap]
+    make_cmd = [_find_make(), '--no-print-directory', '-r', '-R', '-C', './', '-f', 'build_keyboard.mk']
+
+    env_vars['KEYBOARD'] = keyboard
+    env_vars['KEYMAP'] = keymap
+    env_vars['QMK_BIN'] = 'bin/qmk' if 'DEPRECATED_BIN_QMK' in os.environ else 'qmk'
+    env_vars['VERBOSE'] = 'true' if cli.config.general.verbose else ''
+    env_vars['SILENT'] = 'true' if silent else 'false'
+    env_vars['COLOR'] = 'true' if cli.config.general.color else ''
+
+    if parallel > 1:
+        make_cmd.append('-j')
+        make_cmd.append(parallel)
 
     if target:
-        make_args.append(target)
+        make_cmd.append(target)
 
-    return create_make_target(':'.join(make_args), parallel, **env_vars)
+    for key, value in env_vars.items():
+        make_cmd.append(f'{key}={value}')
+
+    return keyboard, keymap, make_cmd
 
 
 def get_git_version(current_time, repo_dir='.', check_dir='.'):
@@ -236,7 +250,7 @@ def compile_configurator_json(user_keymap, bootloader=None, parallel=1, **env_va
         'QMK_BIN="qmk"',
     ])
 
-    return make_command
+    return user_keymap['keyboard'], user_keymap['keymap'], make_command
 
 
 def parse_configurator_json(configurator_file):

--- a/lib/python/qmk/commands.py
+++ b/lib/python/qmk/commands.py
@@ -437,7 +437,7 @@ def do_compile(keyboard, keymap, parallel, target=None, filters=None, environmen
 
             for i, returncode in enumerate(returncodes):
                 if returncode != 0:
-                    keyboard, keymap, command = commands[i]
+                    keyboard, keymap, command = returncodes[i]
                     cli.echo('\tkeyboard: {fg_cyan}%s{fg_reset} keymap: {fg_cyan}%s', keyboard, keymap)
 
     elif command:

--- a/lib/python/qmk/commands.py
+++ b/lib/python/qmk/commands.py
@@ -462,7 +462,6 @@ def _execute_compile(keyboard, keymap, command, target, returncodes=None):
         cli.log.debug('Skipping keyboard %s, no %s keymap found.', keyboard, keymap)
         return 0
 
-    print()
     if target:
         cli.log.info('Building firmware for {fg_cyan}%s{fg_reset} with keymap {fg_cyan}%s{fg_reset} and target {fg_cyan}%s', keyboard, keymap, target)
     else:
@@ -470,16 +469,15 @@ def _execute_compile(keyboard, keymap, command, target, returncodes=None):
     cli.log.debug('Running make command: {fg_blue}%s', ' '.join(command))
 
     if not cli.args.dry_run:
-        compile = cli.run(command, capture_output=False)
+        compile = cli.run(command, combined_output=True)
 
         cli.acquire_lock()
         returncodes.append(compile.returncode)
         cli.release_lock()
 
-        if compile.returncode == 0:
-            cli.log.info('Success!')
-        else:
-            cli.log.error('Failed!')
+        if compile.returncode != 0:
+            cli.log.info('Could not build firmware for {fg_cyan}%s{fg_reset} with keymap {fg_cyan}%s', keyboard, keymap)
+            print(compile.stdout)
 
 
 @lru_cache()

--- a/lib/python/qmk/commands.py
+++ b/lib/python/qmk/commands.py
@@ -96,7 +96,7 @@ def create_make_command(keyboard, keymap, target=None, parallel=1, silent=False,
 
     if parallel > 1:
         make_cmd.append('-j')
-        make_cmd.append(parallel)
+        make_cmd.append(str(parallel))
 
     if target:
         make_cmd.append(target)

--- a/lib/python/qmk/commands.py
+++ b/lib/python/qmk/commands.py
@@ -419,6 +419,8 @@ def do_compile(keyboard, keymap, parallel, target=None, filters=None, environmen
 
     # Compile the firmware, if we're able to
     if command == 'multiple':
+        cli.log.info('Building {fg_cyan}%s{fg_reset} with keymap {fg_cyan}%s', keyboard, keymap)
+
         returncodes = []
         for keyboard, keymap in keyboard_keymap_iter(keyboard, keymap, filters):
             command = create_make_command(keyboard, keymap, target=target, parallel=1, silent=multiple_compiles, **envs)
@@ -439,6 +441,11 @@ def do_compile(keyboard, keymap, parallel, target=None, filters=None, environmen
                     cli.echo('\tkeyboard: {fg_cyan}%s{fg_reset} keymap: {fg_cyan}%s', keyboard, keymap)
 
     elif command:
+        if target:
+            cli.log.info('Building {fg_cyan}%s{fg_reset} with keymap {fg_cyan}%s{fg_reset} and target {fg_cyan}%s', keyboard, keymap, target)
+        else:
+            cli.log.info('Building {fg_cyan}%s{fg_reset} with keymap {fg_cyan}%s', keyboard, keymap)
+
         if _execute_compile(keyboard, keymap, command, target) != 0:
             print()
             cli.log.error('Could not compile all targets, look above this message for more details. Failing target(s):')
@@ -462,10 +469,6 @@ def _execute_compile(keyboard, keymap, command, target, returncodes=None):
         cli.log.debug('Skipping keyboard %s, no %s keymap found.', keyboard, keymap)
         return 0
 
-    if target:
-        cli.log.info('Building firmware for {fg_cyan}%s{fg_reset} with keymap {fg_cyan}%s{fg_reset} and target {fg_cyan}%s', keyboard, keymap, target)
-    else:
-        cli.log.info('Building firmware for {fg_cyan}%s{fg_reset} with keymap {fg_cyan}%s', keyboard, keymap)
     cli.log.debug('Running make command: {fg_blue}%s', ' '.join(command))
 
     if not cli.args.dry_run:

--- a/lib/python/qmk/comment_remover.py
+++ b/lib/python/qmk/comment_remover.py
@@ -3,6 +3,7 @@
 Gratefully adapted from https://stackoverflow.com/a/241506
 """
 import re
+from functools import lru_cache
 
 comment_pattern = re.compile(r'//.*?$|/\*.*?\*/|\'(?:\\.|[^\\\'])*\'|"(?:\\.|[^\\"])*"', re.DOTALL | re.MULTILINE)
 
@@ -14,6 +15,7 @@ def _comment_stripper(match):
     return ' ' if s.startswith('/') else s
 
 
+@lru_cache(maxsize=0)
 def comment_remover(text):
     """Remove C/C++ style comments from text.
     """

--- a/lib/python/qmk/converter.py
+++ b/lib/python/qmk/converter.py
@@ -1,8 +1,10 @@
 """Functions to convert to and from QMK formats
 """
 from collections import OrderedDict
+from functools import lru_cache
 
 
+@lru_cache(maxsize=0)
 def kle2qmk(kle):
     """Convert a KLE layout to QMK's layout format.
     """

--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -12,6 +12,7 @@ from qmk.keymap import list_keymaps
 from qmk.metadata import basic_info_json, info_log_error
 
 
+@lru_cache(maxsize=None)
 def _valid_community_layout(layout):
     """Validate that a declared community list exists
     """

--- a/lib/python/qmk/json_schema.py
+++ b/lib/python/qmk/json_schema.py
@@ -10,6 +10,7 @@ import jsonschema
 from milc import cli
 
 
+@lru_cache(maxsize=0)
 def json_load(json_file):
     """Load a json file from disk.
 

--- a/lib/python/qmk/json_schema.py
+++ b/lib/python/qmk/json_schema.py
@@ -24,6 +24,8 @@ def json_load(json_file):
         exit(1)
     except Exception as e:
         cli.log.error('Unknown error attempting to load {fg_cyan}%s{fg_reset}:\n\t{fg_red}%s', json_file, e)
+        if cli.args.verbose:
+            cli.log.exception(e)
         exit(1)
 
 

--- a/lib/python/qmk/keyboard.py
+++ b/lib/python/qmk/keyboard.py
@@ -64,6 +64,17 @@ def find_readme(keyboard):
     return cur_dir / 'readme.md'
 
 
+def is_keyboard_target(keyboard_target):
+    """Checks to make sure the supplied keyboard_target is valid.
+
+    This is mainly used by commands that accept --keyboard.
+    """
+    if keyboard_target in ['all', 'all-avr', 'all-chibios', 'all-arm_atsam']:
+        return keyboard_target
+
+    return keyboard_folder(keyboard_target)
+
+
 def keyboard_folder(keyboard):
     """Returns the actual keyboard folder.
 

--- a/lib/python/qmk/keyboard.py
+++ b/lib/python/qmk/keyboard.py
@@ -1,10 +1,11 @@
 """Functions that help us work with keyboards.
 """
+import os
 from array import array
+from functools import lru_cache
+from glob import glob
 from math import ceil
 from pathlib import Path
-import os
-from glob import glob
 
 import qmk.path
 from qmk.c_parse import parse_config_h_file
@@ -217,6 +218,7 @@ def render_layout(layout_data, render_ascii, key_labels=None):
     return '\n'.join(lines)
 
 
+@lru_cache(maxsize=0)
 def render_layouts(info_json, render_ascii):
     """Renders all the layouts from an `info_json` structure.
     """

--- a/lib/python/qmk/keymap.py
+++ b/lib/python/qmk/keymap.py
@@ -1,5 +1,6 @@
 """Functions that help you work with QMK keymaps.
 """
+from functools import lru_cache
 import json
 import sys
 from pathlib import Path
@@ -306,6 +307,7 @@ def locate_keymap(keyboard, keymap):
                     return community_layout / 'keymap.c'
 
 
+@lru_cache()
 def list_keymaps(keyboard, c=True, json=True, additional_files=None, fullpath=False):
     """List the available keymaps for a keyboard.
 

--- a/lib/python/qmk/keymap.py
+++ b/lib/python/qmk/keymap.py
@@ -1,8 +1,8 @@
 """Functions that help you work with QMK keymaps.
 """
-from functools import lru_cache
 import json
 import sys
+from functools import lru_cache
 from pathlib import Path
 from subprocess import DEVNULL
 
@@ -32,6 +32,7 @@ __KEYMAP_GOES_HERE__
 """
 
 
+@lru_cache(maxsize=0)
 def template_json(keyboard):
     """Returns a `keymap.json` template for a keyboard.
 
@@ -49,6 +50,7 @@ def template_json(keyboard):
     return template
 
 
+@lru_cache(maxsize=0)
 def template_c(keyboard):
     """Returns a `keymap.c` template for a keyboard.
 
@@ -124,6 +126,7 @@ def keymap_completer(prefix, action, parser, parsed_args):
     return []
 
 
+@lru_cache(maxsize=0)
 def is_keymap_dir(keymap, c=True, json=True, additional_files=None):
     """Return True if Path object `keymap` has a keymap file inside.
 
@@ -182,6 +185,7 @@ def generate_json(keymap, keyboard, layout, layers):
     return new_keymap
 
 
+@lru_cache(maxsize=0)
 def generate_c(keyboard, layout, layers):
     """Returns a `keymap.c` or `keymap.json` for the specified keyboard, layout, and layers.
 
@@ -268,6 +272,7 @@ def write(keyboard, keymap, layout, layers):
     return write_file(keymap_file, keymap_content)
 
 
+@lru_cache(maxsize=0)
 def locate_keymap(keyboard, keymap):
     """Returns the path to a keymap for a specific keyboard.
     """
@@ -307,7 +312,7 @@ def locate_keymap(keyboard, keymap):
                     return community_layout / 'keymap.c'
 
 
-@lru_cache()
+@lru_cache(maxsize=0)
 def list_keymaps(keyboard, c=True, json=True, additional_files=None, fullpath=False):
     """List the available keymaps for a keyboard.
 
@@ -361,6 +366,7 @@ def list_keymaps(keyboard, c=True, json=True, additional_files=None, fullpath=Fa
     return sorted(names)
 
 
+@lru_cache(maxsize=0)
 def _c_preprocess(path, stdin=DEVNULL):
     """ Run a file through the C pre-processor
 
@@ -380,6 +386,7 @@ def _c_preprocess(path, stdin=DEVNULL):
     return pre_processed_keymap.stdout
 
 
+@lru_cache(maxsize=0)
 def _get_layers(keymap):  # noqa C901 : until someone has a good idea how to simplify/split up this code
     """ Find the layers in a keymap.c file.
 
@@ -500,6 +507,7 @@ def _get_layers(keymap):  # noqa C901 : until someone has a good idea how to sim
     return layers
 
 
+@lru_cache(maxsize=0)
 def parse_keymap_c(keymap_file, use_cpp=True):
     """ Parse a keymap.c file.
 
@@ -529,6 +537,7 @@ def parse_keymap_c(keymap_file, use_cpp=True):
     return keymap
 
 
+@lru_cache(maxsize=0)
 def c2json(keyboard, keymap, keymap_file, use_cpp=True):
     """ Convert keymap.c to keymap.json
 

--- a/lib/python/qmk/makefile.py
+++ b/lib/python/qmk/makefile.py
@@ -1,8 +1,10 @@
 """ Functions for working with Makefiles
 """
+from functools import lru_cache
 from pathlib import Path
 
 
+@lru_cache(maxsize=0)
 def parse_rules_mk_file(file, rules_mk=None):
     """Turn a rules.mk file into a dictionary.
 

--- a/lib/python/qmk/math.py
+++ b/lib/python/qmk/math.py
@@ -3,12 +3,22 @@
 Gratefully copied from https://stackoverflow.com/a/9558001
 """
 import ast
-import operator as op
+import operator
+from functools import lru_cache
 
 # supported operators
-operators = {ast.Add: op.add, ast.Sub: op.sub, ast.Mult: op.mul, ast.Div: op.truediv, ast.Pow: op.pow, ast.BitXor: op.xor, ast.USub: op.neg}
+operators = {
+    ast.Add: operator.add,
+    ast.Sub: operator.sub,
+    ast.Mult: operator.mul,
+    ast.Div: operator.truediv,
+    ast.Pow: operator.pow,
+    ast.BitXor: operator.xor,
+    ast.USub: operator.neg,
+}
 
 
+@lru_cache(maxsize=0)
 def compute(expr):
     """Parse a mathematical expression and return the answer.
 
@@ -22,6 +32,7 @@ def compute(expr):
     return _eval(ast.parse(expr, mode='eval').body)
 
 
+@lru_cache(maxsize=0)
 def _eval(node):
     if isinstance(node, ast.Num):  # <number>
         return node.n

--- a/lib/python/qmk/metadata.py
+++ b/lib/python/qmk/metadata.py
@@ -1,0 +1,483 @@
+"""Functions that help us generate and use info.json files.
+"""
+from functools import lru_cache
+from glob import glob
+from pathlib import Path
+
+import jsonschema
+from dotty_dict import dotty
+from milc import cli
+
+from qmk.constants import CHIBIOS_PROCESSORS, LUFA_PROCESSORS, VUSB_PROCESSORS
+from qmk.c_parse import find_layouts
+from qmk.json_schema import deep_update, json_load, validate
+from qmk.keyboard import config_h, rules_mk
+from qmk.makefile import parse_rules_mk_file
+from qmk.math import compute
+
+true_values = ['1', 'on', 'yes', 'true']
+false_values = ['0', 'off', 'no', 'false']
+
+
+@lru_cache(maxsize=None)
+def basic_info_json(keyboard):
+    """Generate a subset of info.json for a specific keyboard.
+
+    This does no validation, and should only be used as needed to avoid loops or when performance is critical.
+    """
+    cur_dir = Path('keyboards')
+    rules = parse_rules_mk_file(cur_dir / keyboard / 'rules.mk')
+
+    if 'DEFAULT_FOLDER' in rules:
+        keyboard = rules['DEFAULT_FOLDER']
+        rules = parse_rules_mk_file(cur_dir / keyboard / 'rules.mk', rules)
+
+    info_data = {
+        'keyboard_name': str(keyboard),
+        'keyboard_folder': str(keyboard),
+        'keymaps': {},
+        'layouts': {},
+        'parse_errors': [],
+        'parse_warnings': [],
+        'maintainer': 'qmk',
+    }
+
+    # Populate layout data
+    layouts, aliases = _find_all_layouts(info_data, keyboard)
+
+    if aliases:
+        info_data['layout_aliases'] = aliases
+
+    for layout_name, layout_json in layouts.items():
+        if not layout_name.startswith('LAYOUT_kc'):
+            layout_json['c_macro'] = True
+            info_data['layouts'][layout_name] = layout_json
+
+    # Merge in the data from info.json, config.h, and rules.mk
+    info_data = merge_info_jsons(keyboard, info_data)
+    info_data = _extract_config_h(info_data)
+    info_data = _extract_rules_mk(info_data)
+
+    return info_data
+
+
+def _extract_features(info_data, rules):
+    """Find all the features enabled in rules.mk.
+    """
+    # Special handling for bootmagic which also supports a "lite" mode.
+    if rules.get('BOOTMAGIC_ENABLE') == 'lite':
+        rules['BOOTMAGIC_LITE_ENABLE'] = 'on'
+        del rules['BOOTMAGIC_ENABLE']
+    if rules.get('BOOTMAGIC_ENABLE') == 'full':
+        rules['BOOTMAGIC_ENABLE'] = 'on'
+
+    # Skip non-boolean features we haven't implemented special handling for
+    for feature in 'HAPTIC_ENABLE', 'QWIIC_ENABLE':
+        if rules.get(feature):
+            del rules[feature]
+
+    # Process the rest of the rules as booleans
+    for key, value in rules.items():
+        if key.endswith('_ENABLE'):
+            key = '_'.join(key.split('_')[:-1]).lower()
+            value = True if value.lower() in true_values else False if value.lower() in false_values else value
+
+            if 'config_h_features' not in info_data:
+                info_data['config_h_features'] = {}
+
+            if 'features' not in info_data:
+                info_data['features'] = {}
+
+            if key in info_data['features']:
+                info_log_warning(info_data, 'Feature %s is specified in both info.json and rules.mk, the rules.mk value wins.' % (key,))
+
+            info_data['features'][key] = value
+            info_data['config_h_features'][key] = value
+
+    return info_data
+
+
+def _pin_name(pin):
+    """Returns the proper representation for a pin.
+    """
+    pin = pin.strip()
+
+    if not pin:
+        return None
+
+    elif pin.isdigit():
+        return int(pin)
+
+    elif pin == 'NO_PIN':
+        return None
+
+    return pin
+
+
+def _extract_pins(pins):
+    """Returns a list of pins from a comma separated string of pins.
+    """
+    return [_pin_name(pin) for pin in pins.split(',')]
+
+
+def _extract_direct_matrix(info_data, direct_pins):
+    """
+    """
+    info_data['matrix_pins'] = {}
+    direct_pin_array = []
+
+    while direct_pins[-1] != '}':
+        direct_pins = direct_pins[:-1]
+
+    for row in direct_pins.split('},{'):
+        if row.startswith('{'):
+            row = row[1:]
+
+        if row.endswith('}'):
+            row = row[:-1]
+
+        direct_pin_array.append([])
+
+        for pin in row.split(','):
+            if pin == 'NO_PIN':
+                pin = None
+
+            direct_pin_array[-1].append(pin)
+
+    return direct_pin_array
+
+
+def _extract_matrix_info(info_data, config_c):
+    """Populate the matrix information.
+    """
+    row_pins = config_c.get('MATRIX_ROW_PINS', '').replace('{', '').replace('}', '').strip()
+    col_pins = config_c.get('MATRIX_COL_PINS', '').replace('{', '').replace('}', '').strip()
+    direct_pins = config_c.get('DIRECT_PINS', '').replace(' ', '')[1:-1]
+
+    if 'MATRIX_ROWS' in config_c and 'MATRIX_COLS' in config_c:
+        if 'matrix_size' in info_data:
+            info_log_warning(info_data, 'Matrix size is specified in both info.json and config.h, the config.h values win.')
+
+        info_data['matrix_size'] = {
+            'cols': compute(config_c.get('MATRIX_COLS', '0')),
+            'rows': compute(config_c.get('MATRIX_ROWS', '0')),
+        }
+
+    if row_pins and col_pins:
+        if 'matrix_pins' in info_data:
+            info_log_warning(info_data, 'Matrix pins are specified in both info.json and config.h, the config.h values win.')
+
+        info_data['matrix_pins'] = {
+            'cols': _extract_pins(col_pins),
+            'rows': _extract_pins(row_pins),
+        }
+
+    if direct_pins:
+        if 'matrix_pins' in info_data:
+            info_log_warning(info_data, 'Direct pins are specified in both info.json and config.h, the config.h values win.')
+
+        info_data['matrix_pins']['direct'] = _extract_direct_matrix(info_data, direct_pins)
+
+    return info_data
+
+
+def _extract_config_h(info_data):
+    """Pull some keyboard information from existing config.h files
+    """
+    config_c = config_h(info_data['keyboard_folder'])
+
+    # Pull in data from the json map
+    dotty_info = dotty(info_data)
+    info_config_map = json_load(Path('data/mappings/info_config.json'))
+
+    for config_key, info_dict in info_config_map.items():
+        info_key = info_dict['info_key']
+        key_type = info_dict.get('value_type', 'str')
+
+        try:
+            if config_key in config_c and info_dict.get('to_json', True):
+                if dotty_info.get(info_key) and info_dict.get('warn_duplicate', True):
+                    info_log_warning(info_data, '%s in config.h is overwriting %s in info.json' % (config_key, info_key))
+
+                if key_type.startswith('array'):
+                    if '.' in key_type:
+                        key_type, array_type = key_type.split('.', 1)
+                    else:
+                        array_type = None
+
+                    config_value = config_c[config_key].replace('{', '').replace('}', '').strip()
+
+                    if array_type == 'int':
+                        dotty_info[info_key] = list(map(int, config_value.split(',')))
+                    else:
+                        dotty_info[info_key] = config_value.split(',')
+
+                elif key_type == 'bool':
+                    dotty_info[info_key] = config_c[config_key] in true_values
+
+                elif key_type == 'hex':
+                    dotty_info[info_key] = '0x' + config_c[config_key][2:].upper()
+
+                elif key_type == 'list':
+                    dotty_info[info_key] = config_c[config_key].split()
+
+                elif key_type == 'int':
+                    dotty_info[info_key] = int(config_c[config_key])
+
+                else:
+                    dotty_info[info_key] = config_c[config_key]
+
+        except Exception as e:
+            info_log_warning(info_data, f'{config_key}->{info_key}: {e}')
+
+    info_data.update(dotty_info)
+
+    # Pull data that easily can't be mapped in json
+    _extract_matrix_info(info_data, config_c)
+
+    return info_data
+
+
+def _extract_rules_mk(info_data):
+    """Pull some keyboard information from existing rules.mk files
+    """
+    rules = rules_mk(info_data['keyboard_folder'])
+    info_data['processor'] = rules.get('MCU', info_data.get('processor', 'atmega32u4'))
+
+    if info_data['processor'] in CHIBIOS_PROCESSORS:
+        arm_processor_rules(info_data, rules)
+
+    elif info_data['processor'] in LUFA_PROCESSORS + VUSB_PROCESSORS:
+        avr_processor_rules(info_data, rules)
+
+    else:
+        cli.log.warning("%s: Unknown MCU: %s" % (info_data['keyboard_folder'], info_data['processor']))
+        unknown_processor_rules(info_data, rules)
+
+    # Pull in data from the json map
+    dotty_info = dotty(info_data)
+    info_rules_map = json_load(Path('data/mappings/info_rules.json'))
+
+    for rules_key, info_dict in info_rules_map.items():
+        info_key = info_dict['info_key']
+        key_type = info_dict.get('value_type', 'str')
+
+        try:
+            if rules_key in rules and info_dict.get('to_json', True):
+                if dotty_info.get(info_key) and info_dict.get('warn_duplicate', True):
+                    info_log_warning(info_data, '%s in rules.mk is overwriting %s in info.json' % (rules_key, info_key))
+
+                if key_type.startswith('array'):
+                    if '.' in key_type:
+                        key_type, array_type = key_type.split('.', 1)
+                    else:
+                        array_type = None
+
+                    rules_value = rules[rules_key].replace('{', '').replace('}', '').strip()
+
+                    if array_type == 'int':
+                        dotty_info[info_key] = list(map(int, rules_value.split(',')))
+                    else:
+                        dotty_info[info_key] = rules_value.split(',')
+
+                elif key_type == 'list':
+                    dotty_info[info_key] = rules[rules_key].split()
+
+                elif key_type == 'bool':
+                    dotty_info[info_key] = rules[rules_key] in true_values
+
+                elif key_type == 'hex':
+                    dotty_info[info_key] = '0x' + rules[rules_key][2:].upper()
+
+                elif key_type == 'int':
+                    dotty_info[info_key] = int(rules[rules_key])
+
+                else:
+                    dotty_info[info_key] = rules[rules_key]
+
+        except Exception as e:
+            info_log_warning(info_data, f'{rules_key}->{info_key}: {e}')
+
+    info_data.update(dotty_info)
+
+    # Merge in config values that can't be easily mapped
+    _extract_features(info_data, rules)
+
+    return info_data
+
+
+def _search_keyboard_h(path):
+    current_path = Path('keyboards/')
+    aliases = {}
+    layouts = {}
+
+    for directory in path.parts:
+        current_path = current_path / directory
+        keyboard_h = '%s.h' % (directory,)
+        keyboard_h_path = current_path / keyboard_h
+        if keyboard_h_path.exists():
+            new_layouts, new_aliases = find_layouts(keyboard_h_path)
+            layouts.update(new_layouts)
+
+            for alias, alias_text in new_aliases.items():
+                if alias_text in layouts:
+                    aliases[alias] = alias_text
+
+    return layouts, aliases
+
+
+def _find_all_layouts(info_data, keyboard):
+    """Looks for layout macros associated with this keyboard.
+    """
+    layouts, aliases = _search_keyboard_h(Path(keyboard))
+
+    if not layouts:
+        # If we don't find any layouts from info.json or keyboard.h we widen our search. This is error prone which is why we want to encourage people to follow the standard above.
+        info_data['parse_warnings'].append('%s: Falling back to searching for KEYMAP/LAYOUT macros.' % (keyboard))
+
+        for file in glob('keyboards/%s/*.h' % keyboard):
+            if file.endswith('.h'):
+                these_layouts, these_aliases = find_layouts(file)
+
+                if these_layouts:
+                    layouts.update(these_layouts)
+
+                for alias, alias_text in these_aliases.items():
+                    if alias_text in layouts:
+                        aliases[alias] = alias_text
+
+    return layouts, aliases
+
+
+def info_log_error(info_data, message):
+    """Send an error message to both JSON and the log.
+    """
+    info_data['parse_errors'].append(message)
+    cli.log.error('%s: %s', info_data.get('keyboard_folder', 'Unknown Keyboard!'), message)
+
+
+def info_log_warning(info_data, message):
+    """Send a warning message to both JSON and the log.
+    """
+    info_data['parse_warnings'].append(message)
+    cli.log.warning('%s: %s', info_data.get('keyboard_folder', 'Unknown Keyboard!'), message)
+
+
+def arm_processor_rules(info_data, rules):
+    """Setup the default info for an ARM board.
+    """
+    info_data['processor_type'] = 'arm'
+    info_data['protocol'] = 'ChibiOS'
+
+    if 'bootloader' not in info_data:
+        if 'STM32' in info_data['processor']:
+            info_data['bootloader'] = 'stm32-dfu'
+        else:
+            info_data['bootloader'] = 'unknown'
+
+    if 'STM32' in info_data['processor']:
+        info_data['platform'] = 'STM32'
+    elif 'MCU_SERIES' in rules:
+        info_data['platform'] = rules['MCU_SERIES']
+    elif 'ARM_ATSAM' in rules:
+        info_data['platform'] = 'ARM_ATSAM'
+
+    return info_data
+
+
+def avr_processor_rules(info_data, rules):
+    """Setup the default info for an AVR board.
+    """
+    info_data['processor_type'] = 'avr'
+    info_data['platform'] = rules['ARCH'] if 'ARCH' in rules else 'unknown'
+    info_data['protocol'] = 'V-USB' if rules.get('MCU') in VUSB_PROCESSORS else 'LUFA'
+
+    if 'bootloader' not in info_data:
+        info_data['bootloader'] = 'atmel-dfu'
+
+    # FIXME(fauxpark/anyone): Eventually we should detect the protocol by looking at PROTOCOL inherited from mcu_selection.mk:
+    # info_data['protocol'] = 'V-USB' if rules.get('PROTOCOL') == 'VUSB' else 'LUFA'
+
+    return info_data
+
+
+def unknown_processor_rules(info_data, rules):
+    """Setup the default keyboard info for unknown boards.
+    """
+    info_data['bootloader'] = 'unknown'
+    info_data['platform'] = 'unknown'
+    info_data['processor'] = 'unknown'
+    info_data['processor_type'] = 'unknown'
+    info_data['protocol'] = 'unknown'
+
+    return info_data
+
+
+def merge_info_jsons(keyboard, info_data):
+    """Return a merged copy of all the info.json files for a keyboard.
+    """
+    for info_file in find_info_json(keyboard):
+        # Load and validate the JSON data
+        new_info_data = json_load(info_file)
+
+        if not isinstance(new_info_data, dict):
+            info_log_error(info_data, "Invalid file %s, root object should be a dictionary." % (str(info_file),))
+            continue
+
+        try:
+            validate(new_info_data, 'qmk.keyboard.v1')
+        except jsonschema.ValidationError as e:
+            json_path = '.'.join([str(p) for p in e.absolute_path])
+            cli.log.error('Not including data from file: %s', info_file)
+            cli.log.error('\t%s: %s', json_path, e.message)
+            continue
+
+        # Merge layout data in
+        if 'layout_aliases' in new_info_data:
+            info_data['layout_aliases'] = {**info_data.get('layout_aliases', {}), **new_info_data['layout_aliases']}
+            del new_info_data['layout_aliases']
+
+        for layout_name, layout in new_info_data.get('layouts', {}).items():
+            if layout_name in info_data.get('layout_aliases', {}):
+                info_log_warning(info_data, f"info.json uses alias name {layout_name} instead of {info_data['layout_aliases'][layout_name]}")
+                layout_name = info_data['layout_aliases'][layout_name]
+
+            if layout_name in info_data['layouts']:
+                for new_key, existing_key in zip(layout['layout'], info_data['layouts'][layout_name]['layout']):
+                    existing_key.update(new_key)
+            else:
+                layout['c_macro'] = False
+                info_data['layouts'][layout_name] = layout
+
+        # Update info_data with the new data
+        if 'layouts' in new_info_data:
+            del new_info_data['layouts']
+
+        deep_update(info_data, new_info_data)
+
+    return info_data
+
+
+def find_info_json(keyboard):
+    """Finds all the info.json files associated with a keyboard.
+    """
+    # Find the most specific first
+    base_path = Path('keyboards')
+    keyboard_path = base_path / keyboard
+    keyboard_parent = keyboard_path.parent
+    info_jsons = [keyboard_path / 'info.json']
+
+    # Add DEFAULT_FOLDER before parents, if present
+    rules = rules_mk(keyboard)
+    if 'DEFAULT_FOLDER' in rules:
+        info_jsons.append(Path(rules['DEFAULT_FOLDER']) / 'info.json')
+
+    # Add in parent folders for least specific
+    for _ in range(5):
+        info_jsons.append(keyboard_parent / 'info.json')
+        if keyboard_parent.parent == base_path:
+            break
+        keyboard_parent = keyboard_parent.parent
+
+    # Return a list of the info.json files that actually exist
+    return [info_json for info_json in info_jsons if info_json.exists()]

--- a/lib/python/qmk/path.py
+++ b/lib/python/qmk/path.py
@@ -3,12 +3,14 @@
 import logging
 import os
 import argparse
+from functools import lru_cache
 from pathlib import Path
 
 from qmk.constants import MAX_KEYBOARD_SUBFOLDERS, QMK_FIRMWARE
 from qmk.errors import NoSuchKeyboardError
 
 
+@lru_cache(maxsize=0)
 def is_keyboard(keyboard_name):
     """Returns True if `keyboard_name` is a keyboard we can compile.
     """
@@ -19,6 +21,7 @@ def is_keyboard(keyboard_name):
         return rules_mk.exists()
 
 
+@lru_cache(maxsize=0)
 def under_qmk_firmware():
     """Returns a Path object representing the relative path under qmk_firmware, or None.
     """
@@ -30,12 +33,14 @@ def under_qmk_firmware():
         return None
 
 
+@lru_cache(maxsize=0)
 def keyboard(keyboard_name):
     """Returns the path to a keyboard's directory relative to the qmk root.
     """
     return Path('keyboards') / keyboard_name
 
 
+@lru_cache(maxsize=0)
 def keymap(keyboard_name):
     """Locate the correct directory for storing a keymap.
 
@@ -56,6 +61,7 @@ def keymap(keyboard_name):
     raise NoSuchKeyboardError('Could not find keymaps directory for: %s' % keyboard_name)
 
 
+@lru_cache(maxsize=0)
 def normpath(path):
     """Returns a `pathlib.Path()` object for a given path.
 

--- a/lib/python/qmk/submodules.py
+++ b/lib/python/qmk/submodules.py
@@ -1,8 +1,10 @@
 """Functions for working with QMK's submodules.
 """
+from functools import lru_cache
 from milc import cli
 
 
+@lru_cache(maxsize=0)
 def status():
     """Returns a dictionary of submodules.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

In draft mode so people can try it out. Feature complete but refactoring to do still.

This adds a new feature to `qmk compile`: `-f <filter>`. A filter is a key/value pair that lets you select what to compile instead of using `-kb all`. They key is dotted json notation, which you can get using `qmk info -f dotted -kb <keyboard>`, which makes use of the new `dotted` format.

Example #1, compile all arm boards:

    qmk compile -km default -f processor_type=arm

Example #2, compile only arm boards that use the QMK_PROTON_C board definition:

    qmk compile -km default -f board=QMK_PROTON_C

Example #3, compile my keymap on every keyboard that supports rgblight:

    qmk compile -km skully -f features.rgblight=true

The other major change this makes is to bypass the top-level `Makefile` to use `build_keyboard.mk` directly. This is a stepping stone towards doing `qmk multibuild` with a prettier UI.

Changelist:
* New argument for `qmk compile`: `--filter`
* New argument for `qmk compile`: `--target`
* We now use `build_keyboard.mk` directly instead of going through `Makefile`

## Known Bugs

(Checked means it's been fixed.)

- [x] `qmk flash` is still the old behavior
- [x] It can take a while to search all the info.json files

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Enhancement/optimization

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
