### PR TITLE
Relocate RGB/HSV color defs to a more fitting place

### DIFF
--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -554,28 +554,29 @@ For inspiration and examples, check out the built-in effects under `quantum/rgb_
 
 These are shorthands to popular colors. The `RGB` ones can be passed to the `setrgb` functions, while the `HSV` ones to the `sethsv` functions.
 
-|RGB                |HSV                |
-|-------------------|-------------------|
-|`RGB_WHITE`        |`HSV_WHITE`        |
-|`RGB_RED`          |`HSV_RED`          |
-|`RGB_CORAL`        |`HSV_CORAL`        |
-|`RGB_ORANGE`       |`HSV_ORANGE`       |
-|`RGB_GOLDENROD`    |`HSV_GOLDENROD`    |
-|`RGB_GOLD`         |`HSV_GOLD`         |
-|`RGB_YELLOW`       |`HSV_YELLOW`       |
-|`RGB_CHARTREUSE`   |`HSV_CHARTREUSE`   |
-|`RGB_GREEN`        |`HSV_GREEN`        |
-|`RGB_SPRINGGREEN`  |`HSV_SPRINGGREEN`  |
-|`RGB_TURQUOISE`    |`HSV_TURQUOISE`    |
-|`RGB_TEAL`         |`HSV_TEAL`         |
-|`RGB_CYAN`         |`HSV_CYAN`         |
-|`RGB_AZURE`        |`HSV_AZURE`        |
-|`RGB_BLUE`         |`HSV_BLUE`         |
-|`RGB_PURPLE`       |`HSV_PURPLE`       |
-|`RGB_MAGENTA`      |`HSV_MAGENTA`      |
-|`RGB_PINK`         |`HSV_PINK`         |
+|RGB                  |HSV                  |
+|---------------------|---------------------|
+|`RGB_AZURE`          |`HSV_AZURE`          |
+|`RGB_BLACK`/`RGB_OFF`|`HSV_BLACK`/`HSV_OFF`|
+|`RGB_BLUE`           |`HSV_BLUE`           |
+|`RGB_CHARTREUSE`     |`HSV_CHARTREUSE`     |
+|`RGB_CORAL`          |`HSV_CORAL`          |
+|`RGB_CYAN`           |`HSV_CYAN`           |
+|`RGB_GOLD`           |`HSV_GOLD`           |
+|`RGB_GOLDENROD`      |`HSV_GOLDENROD`      |
+|`RGB_GREEN`          |`HSV_GREEN`          |
+|`RGB_MAGENTA`        |`HSV_MAGENTA`        |
+|`RGB_ORANGE`         |`HSV_ORANGE`         |
+|`RGB_PINK`           |`HSV_PINK`           |
+|`RGB_PURPLE`         |`HSV_PURPLE`         |
+|`RGB_RED`            |`HSV_RED`            |
+|`RGB_SPRINGGREEN`    |`HSV_SPRINGGREEN`    |
+|`RGB_TEAL`           |`HSV_TEAL`           |
+|`RGB_TURQUOISE`      |`HSV_TURQUOISE`      |
+|`RGB_WHITE`          |`HSV_WHITE`          |
+|`RGB_YELLOW`         |`HSV_YELLOW`         |
 
-These are defined in [`rgblight_list.h`](https://github.com/qmk/qmk_firmware/blob/master/quantum/rgblight_list.h). Feel free to add to this list!
+These are defined in [`color.h`](https://github.com/qmk/qmk_firmware/blob/master/quantum/color.h). Feel free to add to this list!
 
 
 ## Additional `config.h` Options :id=additional-configh-options

--- a/docs/feature_rgblight.md
+++ b/docs/feature_rgblight.md
@@ -449,26 +449,27 @@ rgblight_sethsv_at(HSV_GREEN, 2); // led 2
 
 These are shorthands to popular colors. The `RGB` ones can be passed to the `setrgb` functions, while the `HSV` ones to the `sethsv` functions.
 
-|RGB                |HSV                |
-|-------------------|-------------------|
-|`RGB_WHITE`        |`HSV_WHITE`        |
-|`RGB_RED`          |`HSV_RED`          |
-|`RGB_CORAL`        |`HSV_CORAL`        |
-|`RGB_ORANGE`       |`HSV_ORANGE`       |
-|`RGB_GOLDENROD`    |`HSV_GOLDENROD`    |
-|`RGB_GOLD`         |`HSV_GOLD`         |
-|`RGB_YELLOW`       |`HSV_YELLOW`       |
-|`RGB_CHARTREUSE`   |`HSV_CHARTREUSE`   |
-|`RGB_GREEN`        |`HSV_GREEN`        |
-|`RGB_SPRINGGREEN`  |`HSV_SPRINGGREEN`  |
-|`RGB_TURQUOISE`    |`HSV_TURQUOISE`    |
-|`RGB_TEAL`         |`HSV_TEAL`         |
-|`RGB_CYAN`         |`HSV_CYAN`         |
-|`RGB_AZURE`        |`HSV_AZURE`        |
-|`RGB_BLUE`         |`HSV_BLUE`         |
-|`RGB_PURPLE`       |`HSV_PURPLE`       |
-|`RGB_MAGENTA`      |`HSV_MAGENTA`      |
-|`RGB_PINK`         |`HSV_PINK`         |
+|RGB                  |HSV                  |
+|---------------------|---------------------|
+|`RGB_AZURE`          |`HSV_AZURE`          |
+|`RGB_BLACK`/`RGB_OFF`|`HSV_BLACK`/`HSV_OFF`|
+|`RGB_BLUE`           |`HSV_BLUE`           |
+|`RGB_CHARTREUSE`     |`HSV_CHARTREUSE`     |
+|`RGB_CORAL`          |`HSV_CORAL`          |
+|`RGB_CYAN`           |`HSV_CYAN`           |
+|`RGB_GOLD`           |`HSV_GOLD`           |
+|`RGB_GOLDENROD`      |`HSV_GOLDENROD`      |
+|`RGB_GREEN`          |`HSV_GREEN`          |
+|`RGB_MAGENTA`        |`HSV_MAGENTA`        |
+|`RGB_ORANGE`         |`HSV_ORANGE`         |
+|`RGB_PINK`           |`HSV_PINK`           |
+|`RGB_PURPLE`         |`HSV_PURPLE`         |
+|`RGB_RED`            |`HSV_RED`            |
+|`RGB_SPRINGGREEN`    |`HSV_SPRINGGREEN`    |
+|`RGB_TEAL`           |`HSV_TEAL`           |
+|`RGB_TURQUOISE`      |`HSV_TURQUOISE`      |
+|`RGB_WHITE`          |`HSV_WHITE`          |
+|`RGB_YELLOW`         |`HSV_YELLOW`         |
 
 ```c
 rgblight_setrgb(RGB_ORANGE);
@@ -477,7 +478,7 @@ rgblight_setrgb_at(RGB_GOLD, 3);
 rgblight_sethsv_range(HSV_WHITE, 0, 6);
 ```
 
-These are defined in [`rgblight_list.h`](https://github.com/qmk/qmk_firmware/blob/master/quantum/rgblight_list.h). Feel free to add to this list!
+These are defined in [`color.h`](https://github.com/qmk/qmk_firmware/blob/master/quantum/color.h). Feel free to add to this list!
 
 
 ## Changing the order of the LEDs

--- a/quantum/color.h
+++ b/quantum/color.h
@@ -19,6 +19,60 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+// clang-format off
+
+/*
+ * RGB Colors
+ */
+#define RGB_AZURE       0x99, 0xF5, 0xFF
+#define RGB_BLACK       0x00, 0x00, 0x00
+#define RGB_BLUE        0x00, 0x00, 0xFF
+#define RGB_CHARTREUSE  0x80, 0xFF, 0x00
+#define RGB_CORAL       0xFF, 0x7C, 0x4D
+#define RGB_CYAN        0x00, 0xFF, 0xFF
+#define RGB_GOLD        0xFF, 0xD9, 0x00
+#define RGB_GOLDENROD   0xD9, 0xA5, 0x21
+#define RGB_GREEN       0x00, 0xFF, 0x00
+#define RGB_MAGENTA     0xFF, 0x00, 0xFF
+#define RGB_ORANGE      0xFF, 0x80, 0x00
+#define RGB_PINK        0xFF, 0x80, 0xBF
+#define RGB_PURPLE      0x7A, 0x00, 0xFF
+#define RGB_RED         0xFF, 0x00, 0x00
+#define RGB_SPRINGGREEN 0x00, 0xFF, 0x80
+#define RGB_TEAL        0x00, 0x80, 0x80
+#define RGB_TURQUOISE   0x47, 0x6E, 0x6A
+#define RGB_WHITE       0xFF, 0xFF, 0xFF
+#define RGB_YELLOW      0xFF, 0xFF, 0x00
+#define RGB_OFF         RGB_BLACK
+
+/*
+ * HSV Colors
+ *
+ * All values (including hue) are scaled to 0-255
+ */
+#define HSV_AZURE       132, 102, 255
+#define HSV_BLACK         0,   0,   0
+#define HSV_BLUE        170, 255, 255
+#define HSV_CHARTREUSE   64, 255, 255
+#define HSV_CORAL        11, 176, 255
+#define HSV_CYAN        128, 255, 255
+#define HSV_GOLD         36, 255, 255
+#define HSV_GOLDENROD    30, 218, 218
+#define HSV_GREEN        85, 255, 255
+#define HSV_MAGENTA     213, 255, 255
+#define HSV_ORANGE       28, 255, 255
+#define HSV_PINK        234, 128, 255
+#define HSV_PURPLE      191, 255, 255
+#define HSV_RED           0, 255, 255
+#define HSV_SPRINGGREEN 106, 255, 255
+#define HSV_TEAL        128, 255, 128
+#define HSV_TURQUOISE   123,  90, 112
+#define HSV_WHITE         0,   0, 255
+#define HSV_YELLOW       43, 255, 255
+#define HSV_OFF         HSV_BLACK
+
+// clang-format on
+
 #if defined(__GNUC__)
 #    define PACKED __attribute__((__packed__))
 #else

--- a/quantum/rgblight/rgblight_list.h
+++ b/quantum/rgblight/rgblight_list.h
@@ -15,49 +15,7 @@
  */
 #pragma once
 
-/*              RGB COLORS             */
-#define RGB_WHITE 0xFF, 0xFF, 0xFF
-#define RGB_RED 0xFF, 0x00, 0x00
-#define RGB_CORAL 0xFF, 0x7C, 0x4D
-#define RGB_ORANGE 0xFF, 0x80, 0x00
-#define RGB_GOLDENROD 0xD9, 0xA5, 0x21
-#define RGB_GOLD 0xFF, 0xD9, 0x00
-#define RGB_YELLOW 0xFF, 0xFF, 0x00
-#define RGB_CHARTREUSE 0x80, 0xFF, 0x00
-#define RGB_GREEN 0x00, 0xFF, 0x00
-#define RGB_SPRINGGREEN 0x00, 0xFF, 0x80
-#define RGB_TURQUOISE 0x47, 0x6E, 0x6A
-#define RGB_TEAL 0x00, 0x80, 0x80
-#define RGB_CYAN 0x00, 0xFF, 0xFF
-#define RGB_AZURE 0x99, 0xf5, 0xFF
-#define RGB_BLUE 0x00, 0x00, 0xFF
-#define RGB_PURPLE 0x7A, 0x00, 0xFF
-#define RGB_MAGENTA 0xFF, 0x00, 0xFF
-#define RGB_PINK 0xFF, 0x80, 0xBF
-#define RGB_BLACK 0x00, 0x00, 0x00
-#define RGB_OFF RGB_BLACK
-
-/*            HSV COLORS            */
-#define HSV_WHITE 0, 0, 255
-#define HSV_RED 0, 255, 255
-#define HSV_CORAL 11, 176, 255
-#define HSV_ORANGE 28, 255, 255
-#define HSV_GOLDENROD 30, 218, 218
-#define HSV_GOLD 36, 255, 255
-#define HSV_YELLOW 43, 255, 255
-#define HSV_CHARTREUSE 64, 255, 255
-#define HSV_GREEN 85, 255, 255
-#define HSV_SPRINGGREEN 106, 255, 255
-#define HSV_TURQUOISE 123, 90, 112
-#define HSV_TEAL 128, 255, 128
-#define HSV_CYAN 128, 255, 255
-#define HSV_AZURE 132, 102, 255
-#define HSV_BLUE 170, 255, 255
-#define HSV_PURPLE 191, 255, 255
-#define HSV_MAGENTA 213, 255, 255
-#define HSV_PINK 234, 128, 255
-#define HSV_BLACK 0, 0, 0
-#define HSV_OFF HSV_BLACK
+#include "color.h"
 
 /*
 ########################################################################################
@@ -66,7 +24,7 @@
 ##                                                                                    ##
 ##  The functions below have been deprecated and may be removed in a future release.  ##
 ##                                                                                    ##
-##                Please use the values above with the RGB functions.                 ##
+##              Please use the values in color.h with the RGB functions.              ##
 ##                                                                                    ##
 ##                                                                                    ##
 ##                                                                                    ##


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Allows for rgblight_list.h to eventually be removed.

Both `rgb_matrix.h` and `rgblight.h` include `color.h`, and are included by `quantum.h`, so these defines should still be visible to keymaps.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
