### PR TITLE
Illusion Rosa: correct layout macro names

### DIFF
--- a/keyboards/illusion/rosa/info.json
+++ b/keyboards/illusion/rosa/info.json
@@ -5,7 +5,7 @@
     "width": 15, 
     "height": 5, 
     "layouts": {
-        "LAYOUT_60_ansi": {
+        "LAYOUT_60_ansi_tsangan": {
             "layout": [
                 {"label":"Esc", "x":0, "y":0},
                 {"label":"!", "x":1, "y":0}, 
@@ -73,7 +73,7 @@
                 {"label":"Ctrl", "x":13.5, "y":4, "w":1.5}
             ]
         },
-        "LAYOUT_60_ansi_split_rshift": {
+        "LAYOUT_60_ansi_tsangan_split_rshift": {
             "layout": [
                 {"label":"Esc", "x":0, "y":0},
                 {"label":"1", "x":1, "y":0},
@@ -141,7 +141,7 @@
                 {"label":"Win", "x":12.5, "y":4}, 
                 {"label":"Ctrl", "x":13.5, "y":4, "w":1.5}]
         },
-        "LAYOUT_60_ansi_split_bs_rshift": {
+        "LAYOUT_60_ansi_tsangan_split_bs_rshift": {
             "layout": [
                 {"label":"Esc", "x":0, "y":0}, 
                 {"label":"1", "x":1, "y":0}, 

--- a/keyboards/illusion/rosa/keymaps/default/keymap.c
+++ b/keyboards/illusion/rosa/keymaps/default/keymap.c
@@ -23,7 +23,7 @@ enum layer_names {
 };
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    [_BASE] = LAYOUT_60_ansi(
+    [_BASE] = LAYOUT_60_ansi_tsangan(
         KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,     KC_MINS,    KC_EQL,     KC_BSPC,
         KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,     KC_LBRC,    KC_RBRC,    KC_BSLS,
         KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN,  KC_QUOT,    KC_ENT,

--- a/keyboards/illusion/rosa/keymaps/oggi/keymap.c
+++ b/keyboards/illusion/rosa/keymaps/oggi/keymap.c
@@ -23,14 +23,14 @@ enum layer_names {
 };
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    [_BASE] = LAYOUT_60_ansi_split_rshift(
+    [_BASE] = LAYOUT_60_ansi_tsangan_split_rshift(
         KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,     KC_MINS,    KC_EQL,     KC_BSPC,
         KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,     KC_LBRC,    KC_RBRC,    KC_BSLS,
         KC_LCTL, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN,  KC_QUOT,    KC_ENT,
         KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH,  KC_RSFT,    MO(1),
         KC_LGUI, KC_TRNS, KC_LALT,                                    KC_SPC,                                      KC_RALT, KC_TRNS, KC_RCTL
     ),
-    [_FN] = LAYOUT_60_ansi_split_rshift(
+    [_FN] = LAYOUT_60_ansi_tsangan_split_rshift(
         KC_TRNS, KC_F1, KC_F2,  KC_F3, KC_F4, KC_F5, KC_F6, KC_F7, KC_F8, KC_F9, KC_F10, KC_F11, KC_F12, KC_DEL,
         KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, RESET,   KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_UP, KC_TRNS, KC_TRNS,
         KC_CAPS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_LEFT, KC_RIGHT, KC_TRNS,

--- a/keyboards/illusion/rosa/keymaps/split_bs_rshift/keymap.c
+++ b/keyboards/illusion/rosa/keymaps/split_bs_rshift/keymap.c
@@ -23,14 +23,14 @@ enum layer_names {
 };
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    [_BASE] = LAYOUT_60_ansi_split_bs_rshift(
+    [_BASE] = LAYOUT_60_ansi_tsangan_split_bs_rshift(
         KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,     KC_MINS,    KC_EQL,     KC_BSLS,  KC_GRV,
         KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,     KC_LBRC,    KC_RBRC,    KC_BSPC,
         KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN,  KC_QUOT,    KC_ENT,
         KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH,  KC_RSFT,     MO(1),
         KC_LCTL, KC_LGUI, KC_LALT,                                    KC_SPC,                                      KC_RALT, KC_RGUI, KC_RCTL
     ),
-    [_FN] = LAYOUT_60_ansi_split_bs_rshift(
+    [_FN] = LAYOUT_60_ansi_tsangan_split_bs_rshift(
         KC_TRNS, KC_F1, KC_F2,  KC_F3, KC_F4, KC_F5, KC_F6, KC_F7, KC_F8, KC_F9, KC_F10, KC_F11, KC_F12, KC_TRNS, KC_TRNS,
         KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, RESET,   KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_DEL,
         KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,

--- a/keyboards/illusion/rosa/keymaps/split_rshift/keymap.c
+++ b/keyboards/illusion/rosa/keymaps/split_rshift/keymap.c
@@ -23,14 +23,14 @@ enum layer_names {
 };
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    [_BASE] = LAYOUT_60_ansi_split_rshift(
+    [_BASE] = LAYOUT_60_ansi_tsangan_split_rshift(
         KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,     KC_MINS,    KC_EQL,     KC_BSPC,
         KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,     KC_LBRC,    KC_RBRC,    KC_BSLS,
         KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN,  KC_QUOT,    KC_ENT,
         KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH,  KC_RSFT,    MO(1),
         KC_LCTL, KC_LGUI, KC_LALT,                                    KC_SPC,                                      KC_RALT, KC_RGUI, KC_RCTL
     ),
-    [_FN] = LAYOUT_60_ansi_split_rshift(
+    [_FN] = LAYOUT_60_ansi_tsangan_split_rshift(
         KC_TRNS, KC_F1, KC_F2,  KC_F3, KC_F4, KC_F5, KC_F6, KC_F7, KC_F8, KC_F9, KC_F10, KC_F11, KC_F12, KC_DEL,
         KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, RESET,   KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
         KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,

--- a/keyboards/illusion/rosa/keymaps/via/keymap.c
+++ b/keyboards/illusion/rosa/keymaps/via/keymap.c
@@ -25,28 +25,28 @@ enum layer_names {
 };
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    [_BASE] = LAYOUT_60_ansi(
+    [_BASE] = LAYOUT_60_ansi_tsangan(
         KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,     KC_MINS,    KC_EQL,     KC_BSPC,
         KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,     KC_LBRC,    KC_RBRC,    KC_BSLS,
         KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN,  KC_QUOT,    KC_ENT,
         KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH,  KC_RSFT,
         KC_LCTL, KC_LGUI, KC_LALT,                                    KC_SPC,                                      KC_RALT, KC_RGUI, KC_RCTL
     ),
-    [_FN1] = LAYOUT_60_ansi(
+    [_FN1] = LAYOUT_60_ansi_tsangan(
         KC_TRNS, KC_F1, KC_F2,  KC_F3, KC_F4, KC_F5, KC_F6, KC_F7, KC_F8, KC_F9, KC_F10, KC_F11, KC_F12, KC_DEL,
         KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, RESET,   KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
         KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
         KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
         KC_TRNS, KC_TRNS, KC_TRNS,                                    KC_TRNS,                                      KC_TRNS, KC_TRNS, KC_TRNS
     ),
-    [_FN2] = LAYOUT_60_ansi(
+    [_FN2] = LAYOUT_60_ansi_tsangan(
         KC_TRNS, KC_TRNS, KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
         KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,   KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
         KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
         KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
         KC_TRNS, KC_TRNS, KC_TRNS,                                    KC_TRNS,                                      KC_TRNS, KC_TRNS, KC_TRNS
     ),
-    [_FN3] = LAYOUT_60_ansi(
+    [_FN3] = LAYOUT_60_ansi_tsangan(
         KC_TRNS, KC_TRNS, KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
         KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,   KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
         KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,

--- a/keyboards/illusion/rosa/rosa.h
+++ b/keyboards/illusion/rosa/rosa.h
@@ -33,7 +33,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     { K400, K401, K402, KC_NO, KC_NO, KC_NO, K406, KC_NO, KC_NO, KC_NO, K410, K411, KC_NO, K413} \
 }
 
-#define LAYOUT_60_ansi(\
+#define LAYOUT_60_ansi_tsangan(\
     K000, K001, K002, K003, K004, K005, K006, K007, K008, K009, K010, K011, K012, K013, \
     K100, K101, K102, K103, K104, K105, K106, K107, K108, K109, K110, K111, K112, K113, \
     K200, K201, K202, K203, K204, K205, K206, K207, K208, K209, K210, K211, K212,       \
@@ -47,7 +47,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     { K400, K401, K402, KC_NO, KC_NO, KC_NO, K406, KC_NO, KC_NO, KC_NO, K410, K411, KC_NO, K413 } \
 }
 
-#define LAYOUT_60_ansi_split_rshift(\
+#define LAYOUT_60_ansi_tsangan_split_rshift(\
     K000, K001, K002, K003, K004, K005, K006, K007, K008, K009, K010, K011, K012, K013, \
     K100, K101, K102, K103, K104, K105, K106, K107, K108, K109, K110, K111, K112, K113, \
     K200, K201, K202, K203, K204, K205, K206, K207, K208, K209, K210, K211, K212,       \
@@ -61,7 +61,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     { K400, K401, K402, KC_NO, KC_NO, KC_NO, K406, KC_NO, KC_NO, KC_NO, K410, K411, KC_NO, K413 } \
 }
 
-#define LAYOUT_60_ansi_split_bs_rshift(\
+#define LAYOUT_60_ansi_tsangan_split_bs_rshift(\
     K000, K001, K002, K003, K004, K005, K006, K007, K008, K009, K010, K011, K012, K013, K213, \
     K100, K101, K102, K103, K104, K105, K106, K107, K108, K109, K110, K111, K112, K113,       \
     K200, K201, K202, K203, K204, K205, K206, K207, K208, K209, K210, K211, K212,             \

--- a/keyboards/illusion/rosa/rules.mk
+++ b/keyboards/illusion/rosa/rules.mk
@@ -20,3 +20,5 @@ BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 BLUETOOTH_ENABLE = no       # Enable Bluetooth
 AUDIO_ENABLE = no           # Audio output
+
+LAYOUTS = 60_ansi_tsangan


### PR DESCRIPTION
## Description

The Rosa PCB only supports Tsangan bottom row. This commit renames all the community layout macros to include the `tsangan` descriptor.

cc @bleeCS (keyboard maintainer)

## Types of Changes

- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
