### PR TITLE
Convert Dip Switch callbacks to boolean functions

### DIFF
--- a/docs/feature_dip_switch.md
+++ b/docs/feature_dip_switch.md
@@ -23,8 +23,9 @@ or
 The callback functions can be inserted into your `<keyboard>.c`:
 
 ```c
-void dip_switch_update_kb(uint8_t index, bool active) { 
-    dip_switch_update_user(index, active); 
+bool dip_switch_update_kb(uint8_t index, bool active) { 
+    if !(dip_switch_update_user(index, active)) { return false; }
+    return true;
 }
 ```
 
@@ -32,7 +33,7 @@ void dip_switch_update_kb(uint8_t index, bool active) {
 or `keymap.c`:
 
 ```c
-void dip_switch_update_user(uint8_t index, bool active) { 
+bool dip_switch_update_user(uint8_t index, bool active) { 
     switch (index) {
         case 0:
             if(active) { audio_on(); } else { audio_off(); }
@@ -57,6 +58,7 @@ void dip_switch_update_user(uint8_t index, bool active) {
             }
             break;
     }
+    return true;
 }
 ```
 
@@ -64,8 +66,9 @@ Additionally, we support bit mask functions which allow for more complex handlin
 
 
 ```c
-void dip_switch_update_mask_kb(uint32_t state) { 
-    dip_switch_update_mask_user(state); 
+bool dip_switch_update_mask_kb(uint32_t state) { 
+    if (!dip_switch_update_mask_user(state)) { return false; }
+    return true;
 }
 ```
 
@@ -73,7 +76,7 @@ void dip_switch_update_mask_kb(uint32_t state) {
 or `keymap.c`:
 
 ```c
-void dip_switch_update_mask_user(uint32_t state) { 
+bool dip_switch_update_mask_user(uint32_t state) { 
     if (state & (1UL<<0) && state & (1UL<<1)) {
         layer_on(_ADJUST); // C on esc
     } else {
@@ -89,6 +92,7 @@ void dip_switch_update_mask_user(uint32_t state) {
     } else {
         layer_off(_TEST_B);
     }
+    return true;
 }
 ```
 

--- a/docs/ja/feature_dip_switch.md
+++ b/docs/ja/feature_dip_switch.md
@@ -28,8 +28,9 @@ DIP スイッチは、以下を `rules.mk` に追加することでサポート�
 コールバック関数を `<keyboard>.c` に記述することができます:
 
 ```c
-void dip_switch_update_kb(uint8_t index, bool active) { 
-    dip_switch_update_user(index, active); 
+bool dip_switch_update_kb(uint8_t index, bool active) { 
+    if !(dip_switch_update_user(index, active)) { return false; }
+    return true;
 }
 ```
 
@@ -37,7 +38,7 @@ void dip_switch_update_kb(uint8_t index, bool active) {
 あるいは `keymap.c` に記述することもできます:
 
 ```c
-void dip_switch_update_user(uint8_t index, bool active) { 
+bool dip_switch_update_user(uint8_t index, bool active) { 
     switch (index) {
         case 0:
             if(active) { audio_on(); } else { audio_off(); }
@@ -62,6 +63,7 @@ void dip_switch_update_user(uint8_t index, bool active) {
             }
             break;
     }
+    return true;
 }
 ```
 
@@ -69,8 +71,9 @@ void dip_switch_update_user(uint8_t index, bool active) {
 
 
 ```c
-void dip_switch_update_mask_kb(uint32_t state) { 
-    dip_switch_update_mask_user(state); 
+bool dip_switch_update_mask_kb(uint32_t state) { 
+    if (!dip_switch_update_mask_user(state)) { return false; }
+    return true;
 }
 ```
 
@@ -78,7 +81,7 @@ void dip_switch_update_mask_kb(uint32_t state) {
 あるいは `keymap.c` に記述することもできます:
 
 ```c
-void dip_switch_update_mask_user(uint32_t state) { 
+bool dip_switch_update_mask_user(uint32_t state) { 
     if (state & (1UL<<0) && state & (1UL<<1)) {
         layer_on(_ADJUST); // C on esc
     } else {
@@ -94,6 +97,7 @@ void dip_switch_update_mask_user(uint32_t state) {
     } else {
         layer_off(_TEST_B);
     }
+    return true;
 }
 ```
 

--- a/keyboards/abacus/keymaps/unicodemap/keymap.c
+++ b/keyboards/abacus/keymaps/unicodemap/keymap.c
@@ -108,7 +108,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 }
 
 
-void dip_switch_update_user(uint8_t index, bool active) {
+bool dip_switch_update_user(uint8_t index, bool active) {
     switch (index) {
         case 0:
             if(active) {
@@ -125,6 +125,7 @@ void dip_switch_update_user(uint8_t index, bool active) {
                 }
         }
     }
+    return true;
 }
 
 

--- a/keyboards/handwired/6key/keymaps/default/keymap.c
+++ b/keyboards/handwired/6key/keymaps/default/keymap.c
@@ -1,17 +1,17 @@
- /* Copyright 2020 Bratzworth 
-  * 
-  * This program is free software: you can redistribute it and/or modify 
-  * it under the terms of the GNU General Public License as published by 
-  * the Free Software Foundation, either version 2 of the License, or 
-  * (at your option) any later version. 
-  * 
-  * This program is distributed in the hope that it will be useful, 
-  * but WITHOUT ANY WARRANTY; without even the implied warranty of 
-  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
-  * GNU General Public License for more details. 
-  * 
-  * You should have received a copy of the GNU General Public License 
-  * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ /* Copyright 2020 Bratzworth
+  *
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 2 of the License, or
+  * (at your option) any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
   */
 #include QMK_KEYBOARD_H
 
@@ -33,7 +33,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   )
 };
 
-void dip_switch_update_user(uint8_t index, bool active) {
+bool dip_switch_update_user(uint8_t index, bool active) {
     switch (index) {
         case 0: {
             if (active) {
@@ -43,4 +43,5 @@ void dip_switch_update_user(uint8_t index, bool active) {
             }
         }
     }
+    return true;
 }

--- a/keyboards/helix/rev3_4rows/rev3_4rows.c
+++ b/keyboards/helix/rev3_4rows/rev3_4rows.c
@@ -30,7 +30,7 @@ void set_mac_mode(bool macmode) {
     eeconfig_update_keymap(keymap_config.raw);
 }
 
-void dip_switch_update_kb(uint8_t index, bool active) {
+bool dip_switch_update_kb(uint8_t index, bool active) {
     switch (index) {
     case 0:
         if(active) { // Left no.1  Helix rev3 common
@@ -43,4 +43,5 @@ void dip_switch_update_kb(uint8_t index, bool active) {
         dip_switch_update_user(index, active);
         break;
     }
+    return true;
 }

--- a/keyboards/helix/rev3_5rows/rev3_5rows.c
+++ b/keyboards/helix/rev3_5rows/rev3_5rows.c
@@ -30,7 +30,7 @@ void set_mac_mode(bool macmode) {
     eeconfig_update_keymap(keymap_config.raw);
 }
 
-void dip_switch_update_kb(uint8_t index, bool active) {
+bool dip_switch_update_kb(uint8_t index, bool active) {
     switch (index) {
     case 0:
         if(active) { // Left no.1  Helix rev3 common
@@ -43,4 +43,5 @@ void dip_switch_update_kb(uint8_t index, bool active) {
         dip_switch_update_user(index, active);
         break;
     }
+    return true;
 }

--- a/keyboards/pandora/keymaps/default/keymap.c
+++ b/keyboards/pandora/keymaps/default/keymap.c
@@ -30,7 +30,7 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
 }
 
 // Encoder click function
-void dip_switch_update_user(uint8_t index, bool active) {
+bool dip_switch_update_user(uint8_t index, bool active) {
     switch (index) {
     /* First encoder */
     case 0:
@@ -39,4 +39,5 @@ void dip_switch_update_user(uint8_t index, bool active) {
         }
         break;
     }
+    return true;
 }

--- a/keyboards/pandora/keymaps/via/keymap.c
+++ b/keyboards/pandora/keymaps/via/keymap.c
@@ -45,7 +45,7 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
 }
 
 // Encoder click function
-void dip_switch_update_user(uint8_t index, bool active) {
+bool dip_switch_update_user(uint8_t index, bool active) {
     switch (index) {
     /* First encoder */
     case 0:
@@ -54,4 +54,5 @@ void dip_switch_update_user(uint8_t index, bool active) {
         }
         break;
     }
+    return true;
 }

--- a/keyboards/planck/keymaps/abishalom/keymap.c
+++ b/keyboards/planck/keymaps/abishalom/keymap.c
@@ -254,7 +254,7 @@ bool encoder_update(bool clockwise) {
     return true;
 }
 
-void dip_switch_update_user(uint8_t index, bool active) {
+bool dip_switch_update_user(uint8_t index, bool active) {
     switch (index) {
         case 0: {
 #ifdef AUDIO_ENABLE
@@ -283,6 +283,7 @@ void dip_switch_update_user(uint8_t index, bool active) {
                 muse_mode = false;
             }
     }
+    return true;
 }
 
 void matrix_scan_user(void) {

--- a/keyboards/planck/keymaps/atreus/keymap.c
+++ b/keyboards/planck/keymaps/atreus/keymap.c
@@ -177,7 +177,7 @@ bool encoder_update(bool clockwise) {
     return true;
 }
 
-void dip_switch_update_user(uint8_t index, bool active) {
+bool dip_switch_update_user(uint8_t index, bool active) {
     switch (index) {
         case 0: {
 #ifdef AUDIO_ENABLE
@@ -206,6 +206,7 @@ void dip_switch_update_user(uint8_t index, bool active) {
                 muse_mode = false;
             }
     }
+    return true;
 }
 
 void matrix_scan_user(void) {

--- a/keyboards/planck/keymaps/dear_vehicle_owner/keymap.c
+++ b/keyboards/planck/keymaps/dear_vehicle_owner/keymap.c
@@ -296,7 +296,7 @@ bool encoder_update(bool clockwise) {
     return true;
 }
 
-void dip_switch_update_user(uint8_t index, bool active) {
+bool dip_switch_update_user(uint8_t index, bool active) {
     switch (index) {
         case 0: {
 #ifdef AUDIO_ENABLE
@@ -325,6 +325,7 @@ void dip_switch_update_user(uint8_t index, bool active) {
                 muse_mode = false;
             }
     }
+    return true;
 }
 
 void matrix_scan_user(void) {

--- a/keyboards/planck/keymaps/default/keymap.c
+++ b/keyboards/planck/keymaps/default/keymap.c
@@ -289,7 +289,7 @@ bool encoder_update(bool clockwise) {
     return true;
 }
 
-void dip_switch_update_user(uint8_t index, bool active) {
+bool dip_switch_update_user(uint8_t index, bool active) {
     switch (index) {
         case 0: {
 #ifdef AUDIO_ENABLE
@@ -318,6 +318,7 @@ void dip_switch_update_user(uint8_t index, bool active) {
                 muse_mode = false;
             }
     }
+    return true;
 }
 
 void matrix_scan_user(void) {

--- a/keyboards/planck/keymaps/gitdrik/keymap.c
+++ b/keyboards/planck/keymaps/gitdrik/keymap.c
@@ -170,7 +170,7 @@ bool encoder_update(bool clockwise) {
     return true;
 }
 
-void dip_switch_update_user(uint8_t index, bool active) {
+bool dip_switch_update_user(uint8_t index, bool active) {
     switch (index) {
         case 0: {
 #ifdef AUDIO_ENABLE
@@ -199,6 +199,7 @@ void dip_switch_update_user(uint8_t index, bool active) {
                 muse_mode = false;
             }
     }
+    return true;
 }
 
 void matrix_scan_user(void) {

--- a/keyboards/planck/keymaps/grant24/keymap.c
+++ b/keyboards/planck/keymaps/grant24/keymap.c
@@ -312,7 +312,7 @@ bool encoder_update(bool clockwise) {
     return true;
 }
 
-void dip_switch_update_user(uint8_t index, bool active) {
+bool dip_switch_update_user(uint8_t index, bool active) {
     switch (index) {
         case 0: {
 #ifdef AUDIO_ENABLE
@@ -341,6 +341,7 @@ void dip_switch_update_user(uint8_t index, bool active) {
                 muse_mode = false;
             }
     }
+    return true;
 }
 
 void matrix_scan_user(void) {

--- a/keyboards/planck/keymaps/hvp/keymap.c
+++ b/keyboards/planck/keymaps/hvp/keymap.c
@@ -122,7 +122,7 @@ bool encoder_update(bool clockwise) {
     return true;
 }
 
-void dip_switch_update_user(uint8_t index, bool active) {
+bool dip_switch_update_user(uint8_t index, bool active) {
     switch (index) {
         case 0: {
 #ifdef AUDIO_ENABLE
@@ -151,6 +151,7 @@ void dip_switch_update_user(uint8_t index, bool active) {
                 muse_mode = false;
             }
     }
+    return true;
 }
 
 void matrix_scan_user(void) {

--- a/keyboards/planck/keymaps/jdelkins/keymap.c
+++ b/keyboards/planck/keymaps/jdelkins/keymap.c
@@ -291,7 +291,7 @@ void encoder_update(bool clockwise) {
   }
 }
 
-void dip_switch_update_user(uint8_t index, bool active) {
+bool dip_switch_update_user(uint8_t index, bool active) {
     switch (index) {
         case 0: {
 #ifdef AUDIO_ENABLE
@@ -320,6 +320,7 @@ void dip_switch_update_user(uint8_t index, bool active) {
                 muse_mode = false;
             }
     }
+    return true;
 }
 
 void keyboard_post_init_keymap(void) {

--- a/keyboards/planck/keymaps/lja83/keymap.c
+++ b/keyboards/planck/keymaps/lja83/keymap.c
@@ -299,7 +299,7 @@ bool encoder_update_user(uint16_t index, bool clockwise) {
     return true;
 }
 
-void dip_switch_update_user(uint8_t index, bool active) {
+bool dip_switch_update_user(uint8_t index, bool active) {
     switch (index) {
         case 0: {
 #ifdef AUDIO_ENABLE
@@ -328,6 +328,7 @@ void dip_switch_update_user(uint8_t index, bool active) {
                 muse_mode = false;
             }
     }
+    return true;
 }
 
 void matrix_scan_user(void) {

--- a/keyboards/planck/keymaps/mjuma/keymap.c
+++ b/keyboards/planck/keymaps/mjuma/keymap.c
@@ -190,7 +190,7 @@ uint16_t muse_counter = 0;
 uint8_t muse_offset = 70;
 uint16_t muse_tempo = 50;
 
-void dip_switch_update_user(uint8_t index, bool active) {
+bool dip_switch_update_user(uint8_t index, bool active) {
     switch (index) {
         case 1:
             if (active) {
@@ -199,6 +199,7 @@ void dip_switch_update_user(uint8_t index, bool active) {
                 muse_mode = false;
             }
     }
+    return true;
 }
 
 void matrix_scan_user(void) {

--- a/keyboards/planck/keymaps/rjhilgefort/keymap.c
+++ b/keyboards/planck/keymaps/rjhilgefort/keymap.c
@@ -187,7 +187,7 @@ bool encoder_update(bool clockwise) {
     return true;
 }
 
-void dip_switch_update_user(uint8_t index, bool active) {
+bool dip_switch_update_user(uint8_t index, bool active) {
     switch (index) {
         case 0: {
 #ifdef AUDIO_ENABLE
@@ -216,6 +216,7 @@ void dip_switch_update_user(uint8_t index, bool active) {
                 muse_mode = false;
             }
     }
+    return true;
 }
 
 void matrix_scan_user(void) {

--- a/keyboards/planck/rev6/rev6.c
+++ b/keyboards/planck/rev6/rev6.c
@@ -61,10 +61,10 @@ void matrix_scan_kb(void) {
 
 #ifdef DIP_SWITCH_ENABLE
 __attribute__((weak))
-void dip_update(uint8_t index, bool active) {}
+bool dip_update(uint8_t index, bool active) { return true; }
 
 __attribute__((weak))
-void dip_switch_update_user(uint8_t index, bool active) {
-    dip_update(index, active);
+bool dip_switch_update_user(uint8_t index, bool active) {
+    return dip_update(index, active);
 }
 #endif

--- a/keyboards/planck/thk/keymaps/thk/keymap.c
+++ b/keyboards/planck/thk/keymaps/thk/keymap.c
@@ -213,7 +213,7 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
   return true;
 }
 
-void dip_switch_update_user(uint8_t index, bool active) {
+bool dip_switch_update_user(uint8_t index, bool active) {
   switch (index) {
     case 0: {
       if (active) {
@@ -237,4 +237,5 @@ void dip_switch_update_user(uint8_t index, bool active) {
       SEND_STRING("This is a Planck THK");
       break;
   }
+    return true;
 }

--- a/keyboards/preonic/keymaps/AlexDaigre/keymap.c
+++ b/keyboards/preonic/keymaps/AlexDaigre/keymap.c
@@ -276,7 +276,7 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
     return true;
 }
 
-void dip_switch_update_user(uint8_t index, bool active) {
+bool dip_switch_update_user(uint8_t index, bool active) {
     switch (index) {
         case 0:
             if (active) {
@@ -292,6 +292,7 @@ void dip_switch_update_user(uint8_t index, bool active) {
                 muse_mode = false;
             }
     }
+    return true;
 }
 
 

--- a/keyboards/preonic/keymaps/default/keymap.c
+++ b/keyboards/preonic/keymaps/default/keymap.c
@@ -263,7 +263,7 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
     return true;
 }
 
-void dip_switch_update_user(uint8_t index, bool active) {
+bool dip_switch_update_user(uint8_t index, bool active) {
     switch (index) {
         case 0:
             if (active) {
@@ -279,6 +279,7 @@ void dip_switch_update_user(uint8_t index, bool active) {
                 muse_mode = false;
             }
     }
+    return true;
 }
 
 

--- a/keyboards/preonic/keymaps/drasbeck/keymap.c
+++ b/keyboards/preonic/keymaps/drasbeck/keymap.c
@@ -190,7 +190,7 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
     return true;
 }
 
-void dip_switch_update_user(uint8_t index, bool active) {
+bool dip_switch_update_user(uint8_t index, bool active) {
     switch (index) {
         case 0:
             if (active) {
@@ -206,6 +206,7 @@ void dip_switch_update_user(uint8_t index, bool active) {
                 muse_mode = false;
             }
     }
+    return true;
 }
 
 

--- a/keyboards/preonic/keymaps/elisiano/keymap.c
+++ b/keyboards/preonic/keymaps/elisiano/keymap.c
@@ -257,7 +257,7 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
     return true;
 }
 
-void dip_switch_update_user(uint8_t index, bool active) {
+bool dip_switch_update_user(uint8_t index, bool active) {
     switch (index) {
         case 0:
             if (active) {
@@ -273,6 +273,7 @@ void dip_switch_update_user(uint8_t index, bool active) {
                 muse_mode = false;
             }
     }
+    return true;
 }
 
 

--- a/keyboards/preonic/keymaps/keelhauler/keymap.c
+++ b/keyboards/preonic/keymaps/keelhauler/keymap.c
@@ -264,7 +264,7 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
     return true;
 }
 
-void dip_switch_update_user(uint8_t index, bool active) {
+bool dip_switch_update_user(uint8_t index, bool active) {
     switch (index) {
         case 0:
             if (active) {
@@ -280,6 +280,7 @@ void dip_switch_update_user(uint8_t index, bool active) {
                 muse_mode = false;
             }
     }
+    return true;
 }
 
 

--- a/keyboards/preonic/keymaps/kjwon15/keymap.c
+++ b/keyboards/preonic/keymaps/kjwon15/keymap.c
@@ -327,7 +327,7 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
     return true;
 }
 
-void dip_switch_update_user(uint8_t index, bool active) {
+bool dip_switch_update_user(uint8_t index, bool active) {
     switch (index) {
         case 0:
             if (active) {
@@ -343,6 +343,7 @@ void dip_switch_update_user(uint8_t index, bool active) {
                 muse_mode = false;
             }
     }
+    return true;
 }
 
 void matrix_scan_user(void) {

--- a/keyboards/preonic/keymaps/laurentlaurent/keymap.c
+++ b/keyboards/preonic/keymaps/laurentlaurent/keymap.c
@@ -554,7 +554,7 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
     return true;
 }
 
-void dip_switch_update_user(uint8_t index, bool active) {
+bool dip_switch_update_user(uint8_t index, bool active) {
     switch (index) {
         case 0:
             if (active) {
@@ -570,6 +570,7 @@ void dip_switch_update_user(uint8_t index, bool active) {
                 muse_mode = false;
             }
     }
+    return true;
 }
 
 void matrix_scan_user(void) {

--- a/keyboards/preonic/keymaps/mguterl/keymap.c
+++ b/keyboards/preonic/keymaps/mguterl/keymap.c
@@ -273,7 +273,7 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
     return true;
 }
 
-void dip_switch_update_user(uint8_t index, bool active) {
+bool dip_switch_update_user(uint8_t index, bool active) {
     switch (index) {
         case 0:
             if (active) {
@@ -289,6 +289,7 @@ void dip_switch_update_user(uint8_t index, bool active) {
                 muse_mode = false;
             }
     }
+    return true;
 }
 
 

--- a/keyboards/preonic/keymaps/mverteuil/keymap.c
+++ b/keyboards/preonic/keymaps/mverteuil/keymap.c
@@ -459,7 +459,7 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
     return true;
 }
 
-void dip_switch_update_user(uint8_t index, bool active) {
+bool dip_switch_update_user(uint8_t index, bool active) {
     switch (index) {
         case 0:
             if (active) {
@@ -475,6 +475,7 @@ void dip_switch_update_user(uint8_t index, bool active) {
                 muse_mode = false;
             }
     }
+    return true;
 }
 
 void matrix_scan_user(void) {

--- a/keyboards/preonic/keymaps/mverteuil_2x2u/keymap.c
+++ b/keyboards/preonic/keymaps/mverteuil_2x2u/keymap.c
@@ -395,7 +395,7 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
     return true;
 }
 
-void dip_switch_update_user(uint8_t index, bool active) {
+bool dip_switch_update_user(uint8_t index, bool active) {
     switch (index) {
         case 0:
             if (active) {
@@ -411,4 +411,5 @@ void dip_switch_update_user(uint8_t index, bool active) {
                 muse_mode = false;
             }
     }
+    return true;
 }

--- a/keyboards/preonic/keymaps/pezhore/keymap.c
+++ b/keyboards/preonic/keymaps/pezhore/keymap.c
@@ -257,7 +257,7 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
     return true;
 }
 
-void dip_switch_update_user(uint8_t index, bool active) {
+bool dip_switch_update_user(uint8_t index, bool active) {
     switch (index) {
         case 0:
             if (active) {
@@ -273,6 +273,7 @@ void dip_switch_update_user(uint8_t index, bool active) {
                 muse_mode = false;
             }
     }
+    return true;
 }
 
 

--- a/keyboards/preonic/keymaps/senseored/keymap.c
+++ b/keyboards/preonic/keymaps/senseored/keymap.c
@@ -345,7 +345,7 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
     return true;
 }
 
-void dip_switch_update_user(uint8_t index, bool active) {
+bool dip_switch_update_user(uint8_t index, bool active) {
     switch (index) {
         case 0:
             if (active) {
@@ -361,6 +361,7 @@ void dip_switch_update_user(uint8_t index, bool active) {
                 muse_mode = false;
             }
     }
+    return true;
 }
 
 

--- a/keyboards/preonic/keymaps/via/keymap.c
+++ b/keyboards/preonic/keymaps/via/keymap.c
@@ -147,7 +147,7 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
     return true;
 }
 
-void dip_switch_update_user(uint8_t index, bool active) {
+bool dip_switch_update_user(uint8_t index, bool active) {
     switch (index) {
         case 0:
             if (active) {
@@ -163,6 +163,7 @@ void dip_switch_update_user(uint8_t index, bool active) {
                 muse_mode = false;
             }
     }
+    return true;
 }
 
 

--- a/keyboards/preonic/rev3/rev3.c
+++ b/keyboards/preonic/rev3/rev3.c
@@ -53,11 +53,11 @@ void matrix_scan_kb(void) {
 
 #ifdef DIP_SWITCH_ENABLE
  __attribute__((weak))
-void dip_update(uint8_t index, bool active) {}
+bool dip_update(uint8_t index, bool active) { return true;}
 
  __attribute__((weak))
-void dip_switch_update_user(uint8_t index, bool active) {
-    dip_update(index, active);
+bool dip_switch_update_user(uint8_t index, bool active) {
+    return dip_update(index, active);
 }
 #endif
 

--- a/layouts/community/ortho_4x12/brandonschlack/keymap.c
+++ b/layouts/community/ortho_4x12/brandonschlack/keymap.c
@@ -154,7 +154,7 @@ bool encoder_update_keymap(uint8_t index, bool clockwise) {
     return true;
 }
 
-void dip_switch_update_user(uint8_t index, bool active) {
+bool dip_switch_update_user(uint8_t index, bool active) {
     switch (index) {
         case 0: {
 #ifdef AUDIO_ENABLE
@@ -183,6 +183,7 @@ void dip_switch_update_user(uint8_t index, bool active) {
                 muse_mode = false;
             }
     }
+    return true;
 }
 
 void matrix_scan_keymap(void) {

--- a/layouts/community/ortho_4x12/mguterl/keymap.c
+++ b/layouts/community/ortho_4x12/mguterl/keymap.c
@@ -290,7 +290,7 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
     return true;
 }
 
-void dip_switch_update_user(uint8_t index, bool active) {
+bool dip_switch_update_user(uint8_t index, bool active) {
     switch (index) {
         case 0: {
 #ifdef AUDIO_ENABLE
@@ -319,6 +319,7 @@ void dip_switch_update_user(uint8_t index, bool active) {
                 muse_mode = false;
             }
     }
+    return true;
 }
 
 void matrix_scan_user(void) {

--- a/layouts/community/ortho_5x12/brandonschlack/keymap.c
+++ b/layouts/community/ortho_5x12/brandonschlack/keymap.c
@@ -149,7 +149,7 @@ bool encoder_update_keymap(uint8_t index, bool clockwise) {
     return true;
 }
 
-void dip_switch_update_user(uint8_t index, bool active) {
+bool dip_switch_update_user(uint8_t index, bool active) {
     switch (index) {
         case 0: {
 #ifdef AUDIO_ENABLE
@@ -178,6 +178,7 @@ void dip_switch_update_user(uint8_t index, bool active) {
                 muse_mode = false;
             }
     }
+    return true;
 }
 
 

--- a/quantum/dip_switch.c
+++ b/quantum/dip_switch.c
@@ -49,13 +49,13 @@ static uint16_t       scan_count;
 static bool dip_switch_state[NUMBER_OF_DIP_SWITCHES]      = {0};
 static bool last_dip_switch_state[NUMBER_OF_DIP_SWITCHES] = {0};
 
-__attribute__((weak)) void dip_switch_update_user(uint8_t index, bool active) {}
+__attribute__((weak)) bool dip_switch_update_user(uint8_t index, bool active) { return true; }
 
-__attribute__((weak)) void dip_switch_update_kb(uint8_t index, bool active) { dip_switch_update_user(index, active); }
+__attribute__((weak)) bool dip_switch_update_kb(uint8_t index, bool active) { return dip_switch_update_user(index, active); }
 
-__attribute__((weak)) void dip_switch_update_mask_user(uint32_t state) {}
+__attribute__((weak)) bool dip_switch_update_mask_user(uint32_t state) { return true; }
 
-__attribute__((weak)) void dip_switch_update_mask_kb(uint32_t state) { dip_switch_update_mask_user(state); }
+__attribute__((weak)) bool dip_switch_update_mask_kb(uint32_t state) { return dip_switch_update_mask_user(state); }
 
 void dip_switch_init(void) {
 #ifdef DIP_SWITCH_PINS

--- a/quantum/dip_switch.h
+++ b/quantum/dip_switch.h
@@ -20,10 +20,10 @@
 
 #include "quantum.h"
 
-void dip_switch_update_kb(uint8_t index, bool active);
-void dip_switch_update_user(uint8_t index, bool active);
-void dip_switch_update_mask_user(uint32_t state);
-void dip_switch_update_mask_kb(uint32_t state);
+bool dip_switch_update_kb(uint8_t index, bool active);
+bool dip_switch_update_user(uint8_t index, bool active);
+bool dip_switch_update_mask_user(uint32_t state);
+bool dip_switch_update_mask_kb(uint32_t state);
 
 void dip_switch_init(void);
 void dip_switch_read(bool forced);


### PR DESCRIPTION
## Description

Like the title says.  Changed the callbacks from void, to bool, so that kb level can be overridden. 

## Types of Changes

- [x] Core
- [x] Bugfix
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [x] Documentation


## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
