### PR TITLE
Use string literals for `SERIAL_NUMBER`

### DIFF
--- a/tmk_core/protocol/usb_descriptor.c
+++ b/tmk_core/protocol/usb_descriptor.c
@@ -953,10 +953,10 @@ const USB_Descriptor_String_t PROGMEM ProductString = {
 #if defined(SERIAL_NUMBER)
 const USB_Descriptor_String_t PROGMEM SerialNumberString = {
     .Header = {
-        .Size                   = USB_STRING_LEN(sizeof(STR(SERIAL_NUMBER)) - 1), // Subtract 1 for null terminator
+        .Size                   = USB_STRING_LEN(sizeof(SERIAL_NUMBER) - 1), // Subtract 1 for null terminator
         .Type                   = DTYPE_String
     },
-    .UnicodeString              = LSTR(SERIAL_NUMBER)
+    .UnicodeString              = USBSTR(SERIAL_NUMBER)
 };
 #endif
 

--- a/tmk_core/protocol/usb_descriptor_common.h
+++ b/tmk_core/protocol/usb_descriptor_common.h
@@ -17,7 +17,7 @@
 #pragma once
 
 // Prefix string literal with L for descriptors
-#define USBCONCAT(a, b) a ## b
+#define USBCONCAT(a, b) a##b
 #define USBSTR(s) USBCONCAT(L, s)
 
 /////////////////////

--- a/tmk_core/protocol/usb_descriptor_common.h
+++ b/tmk_core/protocol/usb_descriptor_common.h
@@ -16,6 +16,10 @@
 
 #pragma once
 
+// Prefix string literal with L for descriptors
+#define USBCONCAT(a, b) a ## b
+#define USBSTR(s) USBCONCAT(L, s)
+
 /////////////////////
 // RAW Usage page and ID configuration
 

--- a/tmk_core/protocol/vusb/vusb.c
+++ b/tmk_core/protocol/vusb/vusb.c
@@ -599,10 +599,10 @@ const PROGMEM usbStringDescriptor_t usbStringDescriptorProduct = {
 #if defined(SERIAL_NUMBER)
 const PROGMEM usbStringDescriptor_t usbStringDescriptorSerial = {
     .header = {
-        .bLength         = USB_STRING_LEN(sizeof(STR(SERIAL_NUMBER)) - 1),
+        .bLength         = USB_STRING_LEN(sizeof(SERIAL_NUMBER) - 1),
         .bDescriptorType = USBDESCR_STRING
     },
-    .bString             = LSTR(SERIAL_NUMBER)
+    .bString             = USBSTR(SERIAL_NUMBER)
 };
 #endif
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This is safe to do as literally 0 boards currently in the repo make use of `SERIAL_NUMBER`. This makes a good demo for doing the same to `MANUFACTURER` and `PRODUCT` so that things like:
https://github.com/qmk/qmk_firmware/blob/master/keyboards/exclusive/e6v2/le/config.h#L28
evaluate correctly (or rather, aren't evaluated at all).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
