### PR TITLE
CLI: Add git and venv info to doctor's output

### DIFF
--- a/lib/python/qmk/constants.py
+++ b/lib/python/qmk/constants.py
@@ -6,6 +6,9 @@ from pathlib import Path
 # The root of the qmk_firmware tree.
 QMK_FIRMWARE = Path.cwd()
 
+# Upstream repo url
+QMK_FIRMWARE_UPSTREAM = 'qmk/qmk_firmware'
+
 # This is the number of directories under `qmk_firmware/keyboards` that will be traversed. This is currently a limitation of our make system.
 MAX_KEYBOARD_SUBFOLDERS = 5
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Add `git`-related information such as branch, dirty-ness and deviation from master/develop to the output of `qmk doctor`.
Most of the checks are saved from zvecr's retired 'up/status' subcommand PR.

Although the end-goal for these checks to be used for the upcoming `update` subcommand, I think they are useful for assessing users' environment during debugging.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
