### PR TITLE
Added RGBMATRIX_INDICATORS_OVERRIDE_RGB_OFF config macro

### DIFF
--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -211,6 +211,8 @@ If you define these options you will enable the associated feature, which may in
   * Adds ability to [blink](feature_rgblight.md?id=lighting-layer-blink) a lighting layer for a specified number of milliseconds (e.g. to acknowledge an action).
 * `#define RGBLIGHT_LAYERS_OVERRIDE_RGB_OFF`
   * If defined, then [lighting layers](feature_rgblight?id=overriding-rgb-lighting-onoff-status) will be shown even if RGB Light is off.
+* `#define RGBMATRIX_INDICATORS_OVERRIDE_RGB_OFF`
+  * If defined, then [matrix indicators](feature_rgb_matrix?id=overriding-rgb-matrix-onoff-status) will be shown even if RGB Matrix is off.
 * `#define RGBLED_NUM 12`
   * number of LEDs
 * `#define RGBLIGHT_SPLIT`

--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -694,6 +694,10 @@ void rgb_matrix_indicators_advanced_user(uint8_t led_min, uint8_t led_max) {
 }
 ```
 
+#### Overriding RGB Matrix on/off status
+Normally lighting indicators are not shown when the RGB Matrix is disabled (e.g. through `RGB_TOG`, etc.). If you would like indicators to work even when the RGB Matrix is otherwise off, add `#define RGBMATRIX_INIDACTORS_OVERRIDE_RGB_OFF` to your `config.h`
+
+
 ### Suspended state :id=suspended-state
 To use the suspend feature, make sure that `#define RGB_DISABLE_WHEN_USB_SUSPENDED true` is added to the `config.h` file. 
 

--- a/quantum/rgb_matrix/rgb_matrix.c
+++ b/quantum/rgb_matrix/rgb_matrix.c
@@ -387,10 +387,12 @@ static void rgb_task_render(uint8_t effect) {
     // next task
     if (!rendering) {
         rgb_task_state = FLUSHING;
+#ifndef RGBMATRIX_INDICATORS_OVERRIDE_RGB_OFF
         if (!rgb_effect_params.init && effect == RGB_MATRIX_NONE) {
             // We only need to flush once if we are RGB_MATRIX_NONE
             rgb_task_state = SYNCING;
         }
+#endif
     }
 }
 
@@ -425,7 +427,10 @@ void rgb_matrix_task(void) {
             break;
         case RENDERING:
             rgb_task_render(effect);
-            if (effect) {
+#ifndef RGBMATRIX_INDICATORS_OVERRIDE_RGB_OFF
+            if (effect)
+#endif
+            {
                 rgb_matrix_indicators();
                 rgb_matrix_indicators_advanced(&rgb_effect_params);
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Added config macro to enable rgb matrix indicator leds to stay on when rgb matrix is disabled

docs/config_options.md: Added documentation for `RGBMATRIX_INDICATORS_OVERRIDE_RGB_OFF`
docs/feature_rgb_matrix.md: Added documentation for `RGBMATRIX_INDICATORS_OVERRIDE_RGB_OFF`
quantum/rgb_matrix/rgb_matrix.c: If `RGBMATRIX_INDICATORS_OVERRIDE_RGB_OFF` is defined, call `rgb_matrix_indicators` and `rgb_matrix_indicators_advanced` even if RGB matrix is turned off. Continually flush for RGB_MATRIX_NONE effect if `RGBMATRIX_INDICATORS_OVERRIDE_RGB_OFF` is defined

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
