### PR TITLE
[Core] Use CRC calculation subsystem for split_common

### DIFF
--- a/quantum/split_common/transactions.c
+++ b/quantum/split_common/transactions.c
@@ -17,6 +17,7 @@
 #include <string.h>
 #include <stddef.h>
 
+#include "crc.h"
 #include "debug.h"
 #include "matrix.h"
 #include "quantum.h"
@@ -42,22 +43,6 @@
 
 #define transport_write(id, data, length) transport_execute_transaction(id, data, length, NULL, 0)
 #define transport_read(id, data, length) transport_execute_transaction(id, NULL, 0, data, length)
-
-static uint8_t crc8(const void *data, size_t len) {
-    const uint8_t *p   = (const uint8_t *)data;
-    uint8_t        crc = 0xff;
-    size_t         i, j;
-    for (i = 0; i < len; i++) {
-        crc ^= p[i];
-        for (j = 0; j < 8; j++) {
-            if ((crc & 0x80) != 0)
-                crc = (uint8_t)((crc << 1) ^ 0x31);
-            else
-                crc <<= 1;
-        }
-    }
-    return crc;
-}
 
 #if defined(SPLIT_TRANSACTION_IDS_KB) || defined(SPLIT_TRANSACTION_IDS_USER)
 // Forward-declare the RPC callback handlers


### PR DESCRIPTION
## Description

Now that the compilation bugs have been cleared out in #13253 switch the new transaction system implemented in #13353 to use the CRC functions added in #12641.

@XScorpion2 had issues with stripped `crc8` functions in their build. So I compiled both an AVR build of CRKBD and an ARM build of zvecr's split blackpill with and without LTO enabled. The functions are present under all configurations. This is the disassembly of the ELF files for the `crc8` functions:

**AVR GCC 5.4.0**
1. `make crkbd/rev1:default`
2. `avr-gdb -batch -ex "disassemble/rs 'crc8.constprop.13'" crkbd_rev1_default.elf`

<details>

<summary>ASM DUMP</summary>

```
Dump of assembler code for function crc8.constprop.13:
quantum/crc.c:
43      __attribute__((weak)) uint8_t crc8(const void *data, size_t data_len) {
   0x0000390e <+0>:     fc 01   movw    r30, r24
   0x00003910 <+2>:     ac 01   movw    r20, r24
   0x00003912 <+4>:     4c 5f   subi    r20, 0xFC       ; 252
   0x00003914 <+6>:     5f 4f   sbci    r21, 0xFF       ; 255

44          const uint8_t *d   = (const uint8_t *)data;
45          crc_t          crc = 0xff;
   0x00003916 <+8>:     8f ef   ldi     r24, 0xFF       ; 255

52                      crc = (crc_t)((crc << 1) ^ 0x31);
   0x00003918 <+10>:    91 e3   ldi     r25, 0x31       ; 49

49              crc ^= d[i];
   0x0000391a <+12>:    21 91   ld      r18, Z+
   0x0000391c <+14>:    82 27   eor     r24, r18
   0x0000391e <+16>:    28 e0   ldi     r18, 0x08       ; 8
   0x00003920 <+18>:    30 e0   ldi     r19, 0x00       ; 0

51                  if ((crc & 0x80) != 0)
   0x00003922 <+20>:    87 ff   sbrs    r24, 7
   0x00003924 <+22>:    03 c0   rjmp    .+6             ;  0x392c <crc8.constprop.13+30>

52                      crc = (crc_t)((crc << 1) ^ 0x31);
   0x00003926 <+24>:    88 0f   add     r24, r24
   0x00003928 <+26>:    89 27   eor     r24, r25
   0x0000392a <+28>:    01 c0   rjmp    .+2             ;  0x392e <crc8.constprop.13+32>

53                  else
54                      crc <<= 1;
   0x0000392c <+30>:    88 0f   add     r24, r24
   0x0000392e <+32>:    21 50   subi    r18, 0x01       ; 1
   0x00003930 <+34>:    31 09   sbc     r19, r1

50              for (j = 0; j < 8; j++) {
   0x00003932 <+36>:    b9 f7   brne    .-18            ;  0x3922 <crc8.constprop.13+20>

48          for (i = 0; i < data_len; i++) {
   0x00003934 <+38>:    e4 17   cp      r30, r20
   0x00003936 <+40>:    f5 07   cpc     r31, r21
   0x00003938 <+42>:    81 f7   brne    .-32            ;  0x391a <crc8.constprop.13+12>

55              }
56          }
57          return crc;
58      }
   0x0000393a <+44>:    08 95   ret
End of assembler dump.
```

</details>

**ARM GCC 10.2.1**
1. `make zvecr/split_blackpill:default`
2. `gdb-multiarch -batch -ex "disassemble/rs crc8" zvecr_split_blackpill_default.elf`
<details>

<summary>ASM DUMP</summary>

```
Dump of assembler code for function crc8:
quantum/crc.c:
43      __attribute__((weak)) uint8_t crc8(const void *data, size_t data_len) {
   0x0800398c <+0>:     42 1e   subs    r2, r0, #1
   0x0800398e <+2>:     c3 1c   adds    r3, r0, #3

44          const uint8_t *d   = (const uint8_t *)data;
45          crc_t          crc = 0xff;
   0x08003990 <+4>:     ff 20   movs    r0, #255        ; 0xff

49              crc ^= d[i];
   0x08003992 <+6>:     12 f8 01 1f     ldrb.w  r1, [r2, #1]!
   0x08003996 <+10>:    48 40   eors    r0, r1
   0x08003998 <+12>:    08 21   movs    r1, #8

51                  if ((crc & 0x80) != 0)
   0x0800399a <+14>:    10 f0 80 0f     tst.w   r0, #128        ; 0x80
   0x0800399e <+18>:    4f ea 40 00     mov.w   r0, r0, lsl #1

52                      crc = (crc_t)((crc << 1) ^ 0x31);
   0x080039a2 <+22>:    18 bf   it      ne
   0x080039a4 <+24>:    80 f0 31 00     eorne.w r0, r0, #49     ; 0x31

50              for (j = 0; j < 8; j++) {
   0x080039a8 <+28>:    01 39   subs    r1, #1

53                  else
54                      crc <<= 1;
   0x080039aa <+30>:    c0 b2   uxtb    r0, r0

50              for (j = 0; j < 8; j++) {
   0x080039ac <+32>:    f5 d1   bne.n   0x800399a <crc8+14>

48          for (i = 0; i < data_len; i++) {
   0x080039ae <+34>:    9a 42   cmp     r2, r3
   0x080039b0 <+36>:    ef d1   bne.n   0x8003992 <crc8+6>

55              }
56          }
57          return crc;
58      }
   0x080039b2 <+38>:    70 47   bx      lr
End of assembler dump.
```

</details>

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
