### PR TITLE
AW20216 use register increment for framebuffer flushes

### DIFF
--- a/drivers/awinic/aw20216.c
+++ b/drivers/awinic/aw20216.c
@@ -68,7 +68,7 @@
 #endif
 
 uint8_t g_spi_transfer_buffer[3] = {0};
-uint8_t  g_pwm_buffer[DRIVER_COUNT][AW_PWM_REGISTER_COUNT];
+uint8_t g_pwm_buffer[DRIVER_COUNT][AW_PWM_REGISTER_COUNT];
 bool    g_pwm_buffer_update_required[DRIVER_COUNT] = {false};
 
 bool AW20216_write_register(pin_t slave_pin, uint8_t page, uint8_t reg, uint8_t data) {
@@ -151,10 +151,10 @@ void AW20216_init(void) {
 }
 
 void AW20216_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
-    aw_led led = g_aw_leds[index];
-    g_pwm_buffer[led.driver][led.r] = red;
-    g_pwm_buffer[led.driver][led.g] = green;
-    g_pwm_buffer[led.driver][led.b] = blue;
+    aw_led led                               = g_aw_leds[index];
+    g_pwm_buffer[led.driver][led.r]          = red;
+    g_pwm_buffer[led.driver][led.g]          = green;
+    g_pwm_buffer[led.driver][led.b]          = blue;
     g_pwm_buffer_update_required[led.driver] = true;
     return;
 }
@@ -180,4 +180,3 @@ void AW20216_update_pwm_buffers(void) {
 #endif
     return;
 }
-

--- a/drivers/awinic/aw20216.c
+++ b/drivers/awinic/aw20216.c
@@ -43,6 +43,10 @@
 #define AW_CONFIG_DEFAULT 0b10110000
 #define AW_CHIPEN 1
 
+#define AW_PWM_REGISTER_COUNT 216
+
+#define AW_SPI_START(PIN) spi_start(PIN, false, 0, AW_SPI_DIVISOR)
+
 #ifndef AW_SCALING_MAX
 #    define AW_SCALING_MAX 150
 #endif
@@ -63,13 +67,13 @@
 #    define AW_SPI_DIVISOR 4
 #endif
 
-uint8_t g_spi_transfer_buffer[20] = {0};
-aw_led  g_pwm_buffer[DRIVER_LED_TOTAL];
-bool    g_pwm_buffer_update_required[DRIVER_LED_TOTAL];
+uint8_t g_spi_transfer_buffer[3] = {0};
+uint8_t  g_pwm_buffer[DRIVER_COUNT][AW_PWM_REGISTER_COUNT];
+bool    g_pwm_buffer_update_required[DRIVER_COUNT] = {false};
 
 bool AW20216_write_register(pin_t slave_pin, uint8_t page, uint8_t reg, uint8_t data) {
     // Do we need to call spi_stop() if this fails?
-    if (!spi_start(slave_pin, false, 0, AW_SPI_DIVISOR)) {
+    if (!AW_SPI_START(slave_pin)) {
         return false;
     }
 
@@ -147,10 +151,11 @@ void AW20216_init(void) {
 }
 
 void AW20216_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
-    g_pwm_buffer[index].r               = red;
-    g_pwm_buffer[index].g               = green;
-    g_pwm_buffer[index].b               = blue;
-    g_pwm_buffer_update_required[index] = true;
+    aw_led led = g_aw_leds[index];
+    g_pwm_buffer[led.driver][led.r] = red;
+    g_pwm_buffer[led.driver][led.g] = green;
+    g_pwm_buffer[led.driver][led.b] = blue;
+    g_pwm_buffer_update_required[led.driver] = true;
     return;
 }
 void AW20216_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {
@@ -159,12 +164,20 @@ void AW20216_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {
     }
     return;
 }
+
+void AW20216_write_pwm_buffer(pin_t slave_pin, uint8_t buffer_idx) {
+    AW_SPI_START(slave_pin);
+    spi_write((AWINIC_ID | AW_PAGE_PWM | AW_WRITE));
+    spi_write(0);
+    spi_transmit(g_pwm_buffer[buffer_idx], AW_PWM_REGISTER_COUNT);
+    spi_stop();
+}
+
 void AW20216_update_pwm_buffers(void) {
-    for (uint8_t i = 0; i < DRIVER_LED_TOTAL; i++) {
-        if (g_pwm_buffer_update_required[i]) {
-            AW20216_update_pwm(i, g_pwm_buffer[i].r, g_pwm_buffer[i].g, g_pwm_buffer[i].b);
-            g_pwm_buffer_update_required[i] = false;
-        }
-    }
+    AW20216_write_pwm_buffer(DRIVER_1_CS, 0);
+#ifdef DRIVER_2_CS
+    AW20216_write_pwm_buffer(DRIVER_2_CS, 1);
+#endif
     return;
 }
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This PR updates `aw20216.c` to take advantage of register address auto increment similar to some of the ISSI drivers.

This effectively obsoletes #13173, which contains a similar implementation.

I've done some testing using @KarlK90's [debug trace prototype](https://hackmd.io/OY0oEy8LTQ6_zvZZy1Ws5w#Tracing-prototype) and this seems to be orders of magnitude faster than the existing code (pre and post update refers to before and after the commits in this PR):

![data](https://user-images.githubusercontent.com/10356230/124353896-1bb44400-dbbe-11eb-9ee3-cac7316915e8.png)


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
