### PR TITLE
Allow invert of SPLIT_HAND_PIN logic

### DIFF
--- a/docs/feature_split_keyboard.md
+++ b/docs/feature_split_keyboard.md
@@ -94,7 +94,7 @@ This will read the specified pin. By default, if it's high, then the controller 
 This behaviour can be flipped by adding this to you `config.h` file:
 
 ```c
-#define	SPLIT_HAND_LOW_IS_LEFT
+#define	SPLIT_HAND_PIN_LOW_IS_LEFT
 ```
 
 #### Handedness by Matrix Pin

--- a/quantum/split_common/split_util.c
+++ b/quantum/split_common/split_util.c
@@ -77,7 +77,7 @@ __attribute__((weak)) bool is_keyboard_left(void) {
 #if defined(SPLIT_HAND_PIN)
     // Test pin SPLIT_HAND_PIN for High/Low, if low it's right hand
     setPinInput(SPLIT_HAND_PIN);
-#    ifdef SPLIT_HAND_LOW_IS_LEFT
+#    ifdef SPLIT_HAND_PIN_LOW_IS_LEFT
     return !readPin(SPLIT_HAND_PIN);
 #    else
     return readPin(SPLIT_HAND_PIN);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

Added a `#define` to allow split keyboards to use low is left, when using an input pin to set the keyboard half

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

Non

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
