### PR TITLE
[Keyboard] Set reasonable defaults for Corne keyboard

### DIFF
--- a/keyboards/crkbd/config.h
+++ b/keyboards/crkbd/config.h
@@ -21,20 +21,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "config_common.h"
 
 /* USB Device descriptor parameter */
-#define VENDOR_ID       0x4653
-#define PRODUCT_ID      0x0001
-#define DEVICE_VER      0x0001
-#define MANUFACTURER    foostan
-#define PRODUCT         Corne
+#define VENDOR_ID    0x4653
+#define PRODUCT_ID   0x0001
+#define DEVICE_VER   0x0001
+#define MANUFACTURER foostan
+#define PRODUCT      Corne
 
 /* key matrix size */
 // Rows are doubled-up
-#define MATRIX_ROWS 8
-#define MATRIX_COLS 6
-#define MATRIX_ROW_PINS { D4, C6, D7, E6 }
+#define MATRIX_ROWS  8
+#define MATRIX_COLS  6
+#define MATRIX_ROW_PINS \
+    { D4, C6, D7, E6 }
 
 // wiring of each half
-#define MATRIX_COL_PINS { F4, F5, F6, F7, B1, B3 }
+#define MATRIX_COL_PINS \
+    { F4, F5, F6, F7, B1, B3 }
 // #define MATRIX_COL_PINS { B2, B3, B1, F7, F6, F5, F4 } //uncomment this line and comment line above if you need to reverse left-to-right key order
 
 /* define if matrix has ghost */
@@ -50,7 +52,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define LOCKING_SUPPORT_ENABLE
 /* Locking resynchronize hack */
 //#define LOCKING_RESYNC_ENABLE
-
 
 /*
  * Feature disable options
@@ -73,3 +74,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define NO_ACTION_MACRO
 #define NO_ACTION_FUNCTION
+
+#define BOOTMAGIC_LITE_ROW          0
+#define BOOTMAGIC_LITE_COLUMN       1
+
+#define BOOTMAGIC_LITE_ROW_RIGHT    4
+#define BOOTMAGIC_LITE_COLUMN_RIGHT 1

--- a/keyboards/crkbd/config.h
+++ b/keyboards/crkbd/config.h
@@ -74,9 +74,3 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define NO_ACTION_MACRO
 #define NO_ACTION_FUNCTION
-
-#define BOOTMAGIC_LITE_ROW          0
-#define BOOTMAGIC_LITE_COLUMN       1
-
-#define BOOTMAGIC_LITE_ROW_RIGHT    4
-#define BOOTMAGIC_LITE_COLUMN_RIGHT 1

--- a/keyboards/crkbd/post_config.h
+++ b/keyboards/crkbd/post_config.h
@@ -1,0 +1,31 @@
+/* Copyright 2020 Christopher Courtney, aka Drashna Jael're  (@drashna) <drashna@live.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#ifndef BOOTMAGIC_LITE_ROW
+#    define BOOTMAGIC_LITE_ROW 0
+#endif
+#ifndef BOOTMAGIC_LITE_COLUMN
+#    define BOOTMAGIC_LITE_COLUMN 1
+#endif
+
+#ifndef BOOTMAGIC_LITE_ROW_RIGHT
+#    define BOOTMAGIC_LITE_ROW_RIGHT 4
+#endif
+#ifndef BOOTMAGIC_LITE_COLUMN_RIGHT
+#    define BOOTMAGIC_LITE_COLUMN_RIGHT 1
+#endif

--- a/keyboards/crkbd/readme.md
+++ b/keyboards/crkbd/readme.md
@@ -20,6 +20,12 @@ make crkbd:default
 
 See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
 
+## Bootloader
+
+The Corne PCBs have a reset button next to the TRRS jack to enter in to the bootloader.   
+
+Additionally, if you hold down the "Q" or "P" buttons when plugging in that half of the keyboard (per the default QWERTY layout), this will jump to the bootloader and reset the EEPROM (persistant storage).  This would normally be the very top corner-most position, but due to the breakaway column, it's left at Q and P for compatibilty. 
+
 ## RGB Matrix 
 The Corne Keyboard also supports using the RGB Matrix feature, in place of RGB Light.  This provids a better experience when using the keyboard, as it supports a number of per key effects properly.  If you're not using the in switch LEDs, then you may want to pass on doing this. 
 

--- a/keyboards/crkbd/readme.md
+++ b/keyboards/crkbd/readme.md
@@ -22,9 +22,9 @@ See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_to
 
 ## Bootloader
 
-The Corne PCBs have a reset button next to the TRRS jack to enter in to the bootloader.   
+The Corne PCBs have a reset button next to the TRRS jack to enter in to the bootloader.
 
-Additionally, if you hold down the "Q" or "P" buttons when plugging in that half of the keyboard (per the default QWERTY layout), this will jump to the bootloader and reset the EEPROM (persistant storage).  This would normally be the very top corner-most position, but due to the breakaway column, it's left at Q and P for compatibilty. 
+Additionally, if you hold down the "Q" or "P" buttons when plugging in that half of the keyboard (per the default QWERTY layout), this will jump to the bootloader and reset the EEPROM (persistent storage).  This would normally be the very top corner-most position, but due to the breakaway column, it's left at Q and P for compatibility. 
 
 ## RGB Matrix 
 The Corne Keyboard also supports using the RGB Matrix feature, in place of RGB Light.  This provids a better experience when using the keyboard, as it supports a number of per key effects properly.  If you're not using the in switch LEDs, then you may want to pass on doing this. 

--- a/keyboards/crkbd/rev1/config.h
+++ b/keyboards/crkbd/rev1/config.h
@@ -22,17 +22,20 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define SOFT_SERIAL_PIN D2
 
 /* ws2812 RGB LED */
-#define RGB_DI_PIN D3
+#define RGB_DI_PIN      D3
 
 #ifdef RGBLIGHT_ENABLE
-#    define RGBLED_NUM 12  // Number of LEDs
+#    define RGBLED_NUM 12 // Number of LEDs
+#    define RGBLED_SPLIT \
+        { 6, 6 }
 #    define RGBLIGHT_SPLIT
 #endif
 
 #ifdef RGB_MATRIX_ENABLE
-#    define RGBLED_NUM 54  // Number of LEDs
+#    define RGBLED_NUM       54 // Number of LEDs
 #    define DRIVER_LED_TOTAL RGBLED_NUM
-#    define RGB_MATRIX_SPLIT { 27, 27 }
+#    define RGB_MATRIX_SPLIT \
+        { 27, 27 }
 #    define SPLIT_TRANSPORT_MIRROR
 #endif
 

--- a/keyboards/crkbd/rules.mk
+++ b/keyboards/crkbd/rules.mk
@@ -2,39 +2,32 @@
 MCU = atmega32u4
 
 # Bootloader selection
-#   Teensy       halfkay
-#   Pro Micro    caterina
-#   Atmel DFU    atmel-dfu
-#   LUFA DFU     lufa-dfu
-#   QMK DFU      qmk-dfu
-#   ATmega32A    bootloadHID
-#   ATmega328P   USBasp
 BOOTLOADER = caterina
 
 # Build Options
-#   change to "no" to disable the options, or define them in the Makefile in
-#   the appropriate keymap folder that will get included automatically
-#
-BOOTMAGIC_ENABLE = no       # Virtual DIP switch configuration
+BOOTMAGIC_ENABLE = lite     # Virtual DIP switch configuration
 MOUSEKEY_ENABLE = yes       # Mouse keys
-EXTRAKEY_ENABLE = no       # Audio control and System control
+EXTRAKEY_ENABLE = yes       # Audio control and System control
 CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no        # Commands for debug and configuration
-NKRO_ENABLE = no            # Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
-BACKLIGHT_ENABLE = no      # Enable keyboard backlight functionality
+COMMAND_ENABLE = no         # Commands for debug and configuration
+NKRO_ENABLE = yes           # Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 MIDI_ENABLE = no            # MIDI controls
 AUDIO_ENABLE = no           # Audio output on port C6
 UNICODE_ENABLE = no         # Unicode
 BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
-RGBLIGHT_ENABLE = no       # Enable WS2812 RGB underlight.
+RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight.
 RGB_MATRIX_ENABLE = no
 RGB_MATRIX_DRIVER = WS2812
 
-# Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
 SLEEP_LED_ENABLE = no    # Breathing sleep LED during USB suspend
 
 # if firmware size over limit, try this option
 # LTO_ENABLE = yes
-LAYOUTS = split_3x5_3 split_3x6_3
 
 DEFAULT_FOLDER = crkbd/rev1
+
+RGBLIGHT_SUPPORTED = yes
+RGB_MATRIX_SUPPORTED = yes
+
+LAYOUTS = split_3x5_3 split_3x6_3

--- a/keyboards/crkbd/rules.mk
+++ b/keyboards/crkbd/rules.mk
@@ -12,11 +12,9 @@ CONSOLE_ENABLE = no         # Console for debug
 COMMAND_ENABLE = no         # Commands for debug and configuration
 NKRO_ENABLE = yes           # Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
 BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-MIDI_ENABLE = no            # MIDI controls
-AUDIO_ENABLE = no           # Audio output on port C6
-UNICODE_ENABLE = no         # Unicode
-BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
-RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight.
+AUDIO_ENABLE = no           # Audio output
+BLUETOOTH_ENABLE = no       # Enable Bluetooth
+RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 RGB_MATRIX_ENABLE = no
 RGB_MATRIX_DRIVER = WS2812
 

--- a/keyboards/crkbd/rules.mk
+++ b/keyboards/crkbd/rules.mk
@@ -5,20 +5,23 @@ MCU = atmega32u4
 BOOTLOADER = caterina
 
 # Build Options
+#   change yes to no to disable
+#
 BOOTMAGIC_ENABLE = lite     # Virtual DIP switch configuration
 MOUSEKEY_ENABLE = yes       # Mouse keys
 EXTRAKEY_ENABLE = yes       # Audio control and System control
 CONSOLE_ENABLE = no         # Console for debug
 COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = yes           # Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+# Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
+SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
+# if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+NKRO_ENABLE = yes           # USB Nkey Rollover
 BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-AUDIO_ENABLE = no           # Audio output
-BLUETOOTH_ENABLE = no       # Enable Bluetooth
 RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
+BLUETOOTH_ENABLE = no       # Enable Bluetooth
+AUDIO_ENABLE = no           # Audio output
 RGB_MATRIX_ENABLE = no
 RGB_MATRIX_DRIVER = WS2812
-
-SLEEP_LED_ENABLE = no    # Breathing sleep LED during USB suspend
 
 # if firmware size over limit, try this option
 # LTO_ENABLE = yes


### PR DESCRIPTION
## Description

Enables bootmagic lite and extra keys by default (because they should have been), as well as sets the keys for bootmagic lite. 

Also, auto-cformat pass due to commit hooks. 

## Types of Changes

- [x] Enhancement/optimization
- [x] Keyboard (addition or update)

## Issues Fixed or Closed by This PR

* Reasonable defaults for configurator are not set.  They are now. 

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
