### PR TITLE
Fix US_RDQU keycode

### DIFF
--- a/quantum/keymap_extras/keymap_us_extended.h
+++ b/quantum/keymap_extras/keymap_us_extended.h
@@ -214,7 +214,7 @@
 #define US_DIV  S(ALGR(US_EQL))  // ÷
 // Row 2
 #define US_LDQU S(ALGR(US_LBRC)) // “
-#define US_RDQU S(ALGR(US_LBRC)) // ”
+#define US_RDQU S(ALGR(US_RBRC)) // ”
 #define US_BRKP S(ALGR(US_BSLS)) // ¦
 // Row 3
 #define US_SECT S(ALGR(US_S))    // §

--- a/quantum/keymap_extras/keymap_us_international_linux.h
+++ b/quantum/keymap_extras/keymap_us_international_linux.h
@@ -212,7 +212,7 @@
 #define US_DIV  S(ALGR(US_EQL))  // ÷
 // Row 2
 #define US_LDQU S(ALGR(US_LBRC)) // “
-#define US_RDQU S(ALGR(US_LBRC)) // ”
+#define US_RDQU S(ALGR(US_RBRC)) // ”
 #define US_BRKP S(ALGR(US_BSLS)) // ¦
 // Row 3
 #define US_SECT S(ALGR(US_S))    // §


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

`US_RDQU` and `US_LDQU` were aliased to the same keycode. `US_RDQU` should use the right bracket.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
