### PR TITLE
Convert CTRL to custom matrix lite to fix double-presses

### DIFF
--- a/keyboards/massdrop/ctrl/rules.mk
+++ b/keyboards/massdrop/ctrl/rules.mk
@@ -6,7 +6,7 @@ SRC += config_led.c
 ARM_ATSAM = SAMD51J18A
 MCU = cortex-m4
 
-CUSTOM_MATRIX = yes
+CUSTOM_MATRIX = lite
 
 # Build Options
 #   comment out to disable the options.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Convert Massdrop (aka Drop) CTRL to the custom matrix lite API.

Notably this replaces the custom debounce with the common debounce API
which in turn resolves key double-pressing issues.

The original debounce sets a timer when any key changes then stops all
scanning until the timer expires. Since it is not scanning, the code
cannot suppress long bounces or multiple keys bouncing at once.

As a result, those events cause unwanted double presses.

This fix could have patched the buggy debounce or integrated the
debounce API, but converting to the lite API is simpler and reduces the
amount of custom code to maintain.

In theory this board doesn't strictly need any custom matrix code at all
except that this platform lacks proper library support (see #11119).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [X] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

None known

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
- [X] I acknowledge #11119 and want to make things better.

Tested successfully on actual keyboard. After patching I have observed no double-press events.

I acknowledge that I've read the coding conventions, but deliberately choose to follow existing style in this file.