### PR TITLE
Matrix consistency improvements

### DIFF
--- a/keyboards/aeboards/constellation/rev2/config.h
+++ b/keyboards/aeboards/constellation/rev2/config.h
@@ -27,7 +27,7 @@
 
 /* key matrix size */
 #define MATRIX_ROWS 5
-#define MATRIX_COLS 15
+#define MATRIX_COLS 14
 
 /* key matrix pins */
 #define MATRIX_ROW_PINS { B15, A14, A2, B13, B14 }

--- a/keyboards/ai03/voyager60_alps/config.h
+++ b/keyboards/ai03/voyager60_alps/config.h
@@ -23,7 +23,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 #define PRODUCT         Voyager60-Alps
 
 #define MATRIX_ROWS 5
-#define MATRIX_COLS 15
+#define MATRIX_COLS 14
 
 #define MATRIX_ROW_PINS { B1, B2, B3, F0, F1 }
 #define MATRIX_COL_PINS { F4, F7, F5, F6, C7, C6, B6, B5, B4, D7, D6, D4, D5, D3}

--- a/keyboards/boardsource/3x4/config.h
+++ b/keyboards/boardsource/3x4/config.h
@@ -15,7 +15,7 @@
 #define MATRIX_ROWS 3
 #define MATRIX_COLS 4
 
-#define MATRIX_ROW_PINS { F7, F6, F5,}
+#define MATRIX_ROW_PINS {F7, F6, F5}
 #define MATRIX_COL_PINS {B6, B2, B3, B1}
 
 #define DIODE_DIRECTION COL2ROW

--- a/keyboards/boardsource/the_mark/config.h
+++ b/keyboards/boardsource/the_mark/config.h
@@ -41,8 +41,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
 
-#define MATRIX_ROW_PINS {B0, B1, B2, B3, B4,}
-#define MATRIX_COL_PINS { B5, B6, B7, F5, C7, D0, D1, D2, D3, D4, D5, D6, D7,F0, F1, F4}
+#define MATRIX_ROW_PINS {B0, B1, B2, B3, B4}
+#define MATRIX_COL_PINS {B5, B6, B7, F5, C7, D0, D1, D2, D3, D4, D5, D6, D7,F0, F1, F4}
 #define UNUSED_PINS
 
 /* COL2ROW, ROW2COL */

--- a/keyboards/converter/ibm_5291/config.h
+++ b/keyboards/converter/ibm_5291/config.h
@@ -25,7 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MANUFACTURER        QMK
 #define PRODUCT             5291 keyboard converter
 
-#define MATRIX_ROWS         24
+#define MATRIX_ROWS         5
 #define MATRIX_COLS         4
 
 #define MATRIX_ROW_PINS   {B2, B3, B4, B5, B6}

--- a/keyboards/converter/siemens_tastatur/config.h
+++ b/keyboards/converter/siemens_tastatur/config.h
@@ -26,11 +26,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define PRODUCT Siemens Tastatur
 
 /* key matrix size */
-#define MATRIX_ROWS 4
+#define MATRIX_ROWS 5
 #define MATRIX_COLS 19
 
 //This is all fake and not used
-#define MATRIX_COL_PINS { B11, B10, B1, B0, A7, A6, A5, A4, A3, A2, A1, A0, C15, C14 }
+#define MATRIX_COL_PINS { B11, B10, B1, B0, A7, A6, A5, A4, A3, A2, A1, A0, C15, C14, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN }
 #define MATRIX_ROW_PINS { B3, B4, B5, B6, B7 }
 #define DIODE_DIRECTION COL2ROW
 

--- a/keyboards/coseyfannitutti/mulletpad/config.h
+++ b/keyboards/coseyfannitutti/mulletpad/config.h
@@ -41,7 +41,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
 */
 #define MATRIX_ROW_PINS { F4, F1, F5, F6, F7 }
-#define MATRIX_COL_PINS { F0, C7, C6, B6, }
+#define MATRIX_COL_PINS { F0, C7, C6, B6 }
 #define UNUSED_PINS
 
 /* COL2ROW, ROW2COL */

--- a/keyboards/dc01/left/config.h
+++ b/keyboards/dc01/left/config.h
@@ -42,7 +42,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
 */
 #define MATRIX_ROW_PINS { B6, B5, B4, D7, D6 }
-#define MATRIX_COL_PINS { F4, F1, F0, F7, F6, F5 }
+#define MATRIX_COL_PINS { F4, F1, F0, F7, F6, F5, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN }
 #define UNUSED_PINS
 
 #define F_SCL 350000UL

--- a/keyboards/ggkeyboards/genesis/hotswap/config.h
+++ b/keyboards/ggkeyboards/genesis/hotswap/config.h
@@ -26,7 +26,7 @@
 #define PRODUCT         Genesis
 
 /* key matrix size */
-#define MATRIX_ROWS 7
+#define MATRIX_ROWS 6
 #define MATRIX_COLS 18
 
 /*

--- a/keyboards/ggkeyboards/genesis/solder/config.h
+++ b/keyboards/ggkeyboards/genesis/solder/config.h
@@ -26,7 +26,7 @@
 #define PRODUCT         Genesis
 
 /* key matrix size */
-#define MATRIX_ROWS 7
+#define MATRIX_ROWS 6
 #define MATRIX_COLS 18
 
 /*

--- a/keyboards/handwired/promethium/config.h
+++ b/keyboards/handwired/promethium/config.h
@@ -31,7 +31,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* key matrix size */
 #define MATRIX_COLS 6
-#define MATRIX_ROWS 9
+#define MATRIX_ROWS 3
 
 /* default pin-out */
 #define MATRIX_COL_PINS { F4, F1, F0, D6, D0, D1 }

--- a/keyboards/handwired/swiftrax/astro65/config.h
+++ b/keyboards/handwired/swiftrax/astro65/config.h
@@ -27,7 +27,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define PRODUCT         Astro65
 /* key matrix size */
 #define MATRIX_ROWS 5
-#define MATRIX_COLS 16
+#define MATRIX_COLS 15
 
 // ROWS: Top to bottom, COLS: Left to right
 

--- a/keyboards/kinesis/alvicstep/config.h
+++ b/keyboards/kinesis/alvicstep/config.h
@@ -23,7 +23,7 @@
  *
 */
 //Passed through the port multipler, so 4 pins =16
-#define MATRIX_ROW_PINS { F0,F1, F2, F3  }
+#define MATRIX_ROW_PINS { F0, F1, F2, F3, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN }
 
 // May be upside down. 
 #define MATRIX_COL_PINS { B0,B1, B2, B3, B4, B5, B6, B7 }

--- a/keyboards/kinesis/kint41/config.h
+++ b/keyboards/kinesis/kint41/config.h
@@ -58,7 +58,7 @@
             LINE_PIN2,  /* ROW_MIN */ \
             LINE_PIN17, /* ROW_ESC */ \
             LINE_PIN23, /* ROW_F1 */  \
-            LINE_PIN21, /* ROW_F2 */  \
+            LINE_PIN21 /* ROW_F2 */  \
     }
 
 #define MATRIX_COL_PINS             \

--- a/keyboards/kinesis/nguyenvietyen/config.h
+++ b/keyboards/kinesis/nguyenvietyen/config.h
@@ -19,7 +19,7 @@
  *
  */
 // Passed through the port multipler, so 4 pins =16
-#define MATRIX_ROW_PINS { D0, D1, D2, D3 }
+#define MATRIX_ROW_PINS { D0, D1, D2, D3, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN }
 #define MATRIX_COL_PINS { B6, B2, B3, B1, F7, F6, F5, F4 }
 #define UNUSED_PINS
 

--- a/keyboards/kmac/config.h
+++ b/keyboards/kmac/config.h
@@ -38,7 +38,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MATRIX_ROW_PINS \
     { D0, D1, D2, D3, D5, B7 }
 #define MATRIX_COL_PINS \
-    { B6, C6, C7, F1, F0, B5 }
+    { B6, C6, C7, F1, F0, B5, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN }
 #define UNUSED_PINS
 
 /* COL2ROW, ROW2COL*/

--- a/keyboards/lizard_trick/tenkey_plusplus/config.h
+++ b/keyboards/lizard_trick/tenkey_plusplus/config.h
@@ -41,7 +41,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
 
-#define MATRIX_ROW_PINS { B7, D4, B5, B6, C6, C7, }
+#define MATRIX_ROW_PINS { B7, D4, B5, B6, C6, C7 }
 #define MATRIX_COL_PINS { D5, D3, D2, F7 }
 #define UNUSED_PINS
 

--- a/keyboards/mechlovin/tmkl/config.h
+++ b/keyboards/mechlovin/tmkl/config.h
@@ -40,7 +40,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *                  ROW2COL = ROW = Anode (+), COL = Cathode (-, marked on diode)
  *
  */
-#define MATRIX_ROW_PINS { A8, A4, A5, A3, A2, A1, }
+#define MATRIX_ROW_PINS { A8, A4, A5, A3, A2, A1 }
 #define MATRIX_COL_PINS { B11, B10, B2, B1, B0, A7, A6, A0, C15, B4, B5, B3, C13, C14 }
 
 #define DIODE_DIRECTION COL2ROW

--- a/keyboards/meira/featherble/config.h
+++ b/keyboards/meira/featherble/config.h
@@ -32,7 +32,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #define MATRIX_ROW_PINS { F7, F6, F5, F4 }
 // Column pins to demux in LSB order
-#define MATRIX_COL_PINS { C7, B7, B6, C6 }
+#define MATRIX_COL_PINS { C7, B7, B6, C6, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN }
 #define LED_EN_PIN D2
 #define UNUSED_PINS
 

--- a/keyboards/meira/promicro/config.h
+++ b/keyboards/meira/promicro/config.h
@@ -32,7 +32,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #define MATRIX_ROW_PINS { F7, F6, F5, F4 }
 // Column pins to demux in LSB order
-#define MATRIX_COL_PINS { B1, B3, B2, B6 }
+#define MATRIX_COL_PINS { B1, B3, B2, B6, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN }
 #define LED_EN_PIN D2
 #define UNUSED_PINS
 

--- a/keyboards/orthodox/rev3/config.h
+++ b/keyboards/orthodox/rev3/config.h
@@ -38,12 +38,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // wiring of each half
 
 //REV.3 PRO MICRO
-#define MATRIX_ROW_PINS { D2, B4, B5, }
+#define MATRIX_ROW_PINS { D2, B4, B5 }
 #define MATRIX_COL_PINS { D7, F4, F5, B6, B2, B3, B1, F7, F6 }
 
 /*/
 //REV.3 TEENSY
-#define MATRIX_ROW_PINS { B0, C6, C7, }
+#define MATRIX_ROW_PINS { B0, C6, C7 }
 #define MATRIX_COL_PINS { D2, F5, F6, D6, D7, B4, B5, B6, F7 }
 /*/
 

--- a/keyboards/orthodox/rev3_teensy/config.h
+++ b/keyboards/orthodox/rev3_teensy/config.h
@@ -38,7 +38,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // wiring of each half
 
 //REV.3 TEENSY
-#define MATRIX_ROW_PINS { B0, C6, C7, }
+#define MATRIX_ROW_PINS { B0, C6, C7 }
 #define MATRIX_COL_PINS { D2, F5, F6, D6, D7, B4, B5, B6, F7 }
 
 /* COL2ROW or ROW2COL */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

While working on #13470 I noticed a lot of keyboards have `MATRIX_ROWS` and `MATRIX_COLS` that are inconsistent with the pins actually configured to be used. This PR attempts to correct that in most cases.

TODO:
* [ ] Check that boards still compile
* [ ] Check that boards that need virtual rows/cols still work with the NO_PIN addition

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bugfix
- [x] Keyboard (addition or update)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
