### PR TITLE
Enable g_is31_leds PROGMEM for RGB Matrix IS31FL3737 driver

### DIFF
--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -171,7 +171,7 @@ Currently only a single drivers is supported, but it would be trivial to support
 Define these arrays listing all the LEDs in your `<keyboard>.c`:
 
 ```c
-const is31_led g_is31_leds[DRIVER_LED_TOTAL] = {
+const is31_led PROGMEM g_is31_leds[DRIVER_LED_TOTAL] = {
 /* Refer to IS31 manual for these locations
  *   driver
  *   |  R location

--- a/drivers/issi/is31fl3737.c
+++ b/drivers/issi/is31fl3737.c
@@ -153,7 +153,7 @@ void IS31FL3737_init(uint8_t addr) {
 
 void IS31FL3737_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
     if (index >= 0 && index < DRIVER_LED_TOTAL) {
-        // set the led ptr to the led config in progmem
+        // copy the led config from progmem to SRAM
         is31_led led;
         memcpy_P(&led, (&g_is31_leds[index]), sizeof(led));
 
@@ -171,7 +171,7 @@ void IS31FL3737_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {
 }
 
 void IS31FL3737_set_led_control_register(uint8_t index, bool red, bool green, bool blue) {
-    // set the led ptr to the led config in progmem
+    // copy the led config from progmem to SRAM
     is31_led led;
     memcpy_P(&led, (&g_is31_leds[index]), sizeof(led));
 

--- a/drivers/issi/is31fl3737.c
+++ b/drivers/issi/is31fl3737.c
@@ -153,7 +153,9 @@ void IS31FL3737_init(uint8_t addr) {
 
 void IS31FL3737_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
     if (index >= 0 && index < DRIVER_LED_TOTAL) {
-        is31_led led = g_is31_leds[index];
+        // set the led ptr to the led config in progmem
+        is31_led led;
+        memcpy_P(&led, (&g_is31_leds[index]), sizeof(led));
 
         g_pwm_buffer[led.driver][led.r] = red;
         g_pwm_buffer[led.driver][led.g] = green;
@@ -169,7 +171,9 @@ void IS31FL3737_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {
 }
 
 void IS31FL3737_set_led_control_register(uint8_t index, bool red, bool green, bool blue) {
-    is31_led led = g_is31_leds[index];
+    // set the led ptr to the led config in progmem
+    is31_led led;
+    memcpy_P(&led, (&g_is31_leds[index]), sizeof(led));
 
     uint8_t control_register_r = led.r / 8;
     uint8_t control_register_g = led.g / 8;

--- a/drivers/issi/is31fl3737.c
+++ b/drivers/issi/is31fl3737.c
@@ -19,6 +19,7 @@
 #include "is31fl3737.h"
 #include "i2c_master.h"
 #include "wait.h"
+#include "progmem.h"
 
 // This is a 7-bit address, that gets left-shifted and bit 0
 // set to 0 for write, 1 for read (as per I2C protocol)

--- a/keyboards/mt84/mt84.c
+++ b/keyboards/mt84/mt84.c
@@ -1,22 +1,22 @@
- /* Copyright 2020 MT<704340378@qq.com> 
-  * 
-  * This program is free software: you can redistribute it and/or modify 
-  * it under the terms of the GNU General Public License as published by 
-  * the Free Software Foundation, either version 2 of the License, or 
-  * (at your option) any later version. 
-  * 
-  * This program is distributed in the hope that it will be useful, 
-  * but WITHOUT ANY WARRANTY; without even the implied warranty of 
-  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
-  * GNU General Public License for more details. 
-  * 
-  * You should have received a copy of the GNU General Public License 
-  * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
-  */ 
+ /* Copyright 2020 MT<704340378@qq.com>
+  *
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 2 of the License, or
+  * (at your option) any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  */
 #include "mt84.h"
 
 #ifdef RGB_MATRIX_ENABLE
-const is31_led g_is31_leds[DRIVER_LED_TOTAL] = {
+const is31_led PROGMEM g_is31_leds[DRIVER_LED_TOTAL] = {
  /* Refer to IS31 manual for these locations
  *   driver
  *   |  R location
@@ -40,7 +40,7 @@ const is31_led g_is31_leds[DRIVER_LED_TOTAL] = {
    {1, D_12,   E_12,   F_12},
    {1, G_12,   H_12,   I_12},
    {1, J_12,   K_12,   L_12},
-       
+
    {0, A_1,   B_1,   C_1},
    {0, D_1,   E_1,   F_1},
    {0, G_1,   H_1,   I_1},
@@ -72,7 +72,7 @@ const is31_led g_is31_leds[DRIVER_LED_TOTAL] = {
    {1, A_7,   B_7,   C_7},
    {1, D_7,   E_7,   F_7},
    {1, G_7,   H_7,   I_7},
-       
+
    {0, A_3,   B_3,   C_3},
    {0, D_3,   E_3,   F_3},
    {0, G_3,   H_3,   I_3},
@@ -87,7 +87,7 @@ const is31_led g_is31_leds[DRIVER_LED_TOTAL] = {
    {1, J_3,   K_3,   L_3},
    {1, A_8,   B_8,   C_8},
    {1, G_8,   H_8,   I_8},
-       
+
    {0, A_4,   B_4,   C_4},
    {0, D_4,   E_4,   F_4},
    {0, G_4,   H_4,   I_4},
@@ -130,7 +130,7 @@ led_config_t g_led_config = {{
     {   9, 52 }, {  27, 52 }, {  43, 52 }, {  59, 52 }, {  75, 52 }, { 91, 52 }, { 107, 52 }, { 123, 52 }, { 139, 52 }, { 155, 52 }, { 171, 52 }, { 187, 52 }, { 212,  52 }, { 224,  52 },
 {   2, 64 }, {  18, 64 }, {  33, 64 },                 {  93, 64 },                                                                              { 150, 64 }, { 165,  64 }, { 180, 64 }, { 195, 64 }, { 210, 64 }, { 224, 64 }
 }, {
-    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
     1, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 1,
     1, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 1,
     1, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 1,

--- a/keyboards/planck/ez/ez.c
+++ b/keyboards/planck/ez/ez.c
@@ -19,7 +19,7 @@
 
 keyboard_config_t keyboard_config;
 #ifdef RGB_MATRIX_ENABLE
-const is31_led g_is31_leds[DRIVER_LED_TOTAL] = {
+const is31_led PROGMEM g_is31_leds[DRIVER_LED_TOTAL] = {
 /* Refer to IS31 manual for these locations
  *   driver
  *   |  R location

--- a/tmk_core/common/progmem.h
+++ b/tmk_core/common/progmem.h
@@ -3,6 +3,7 @@
 #if defined(__AVR__)
 #    include <avr/pgmspace.h>
 #else
+#    include <string.h>
 #    define PROGMEM
 #    define PSTR(x) x
 #    define PGM_P const char*


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Moves the RGB Matrix g_is31_leds led config array to PROGMEM when using the issi/IS31FL3737 driver.
This array uses ~3bytes per rgb led and this change frees up considerable SRAM for the average rgb matrix keyboard.
Implementing this change to other issi drivers is trivial

This is a Break Change.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [X] Core
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [X] Documentation

## Issues Fixed or Closed by This PR
#13443
* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
