### PR TITLE
Fixed the Helix keymap 'fraanrosi' compile issues

### DIFF
--- a/keyboards/helix/rev2/keymaps/fraanrosi/rules.mk
+++ b/keyboards/helix/rev2/keymaps/fraanrosi/rules.mk
@@ -20,6 +20,9 @@ EXTRAKEY_ENABLE = yes    # Audio control and System control
 LED_ANIMATIONS = yes        # LED animations
 # IOS_DEVICE_ENABLE = no      # connect to IOS device (iPad,iPhone)
 
+LED_BACK_ENABLE = no
+LED_UNDERGLOW_ENABLE = yes
+
 # convert Helix-specific options (that represent combinations of standard options)
 #   into QMK standard options.
 include $(strip $(KEYBOARD_LOCAL_FEATURES_MK))


### PR DESCRIPTION
## Description

According to `helix/rev2/keymaps/fraanrosi/readme.md`, this keymap should be compiled with the following command:

```
make helix/rev2/under:fraanrosi
```

Therefore, when compiling all helix keymaps with the following command, an error occurs when compiling `fraanrosi`.

```
make helix:all
```

Therefore, add `LED_UNDERGLOW_ENABLE = yes` to `keymaps/fraanrosi/rules.mk` to suppress the error.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
