### PR TITLE
Jump to reset address for lufa-ms

### DIFF
--- a/tmk_core/common/avr/bootloader.c
+++ b/tmk_core/common/avr/bootloader.c
@@ -55,7 +55,7 @@
  */
 #define FLASH_SIZE (FLASHEND + 1L)
 
-#if !defined(BOOTLOADER_SIZE)
+#if !defined(BOOTLOADER_SIZE) || defined(BOOTLOADER_MS)
 uint16_t bootloader_start;
 #endif
 
@@ -78,7 +78,7 @@ uint32_t reset_key __attribute__((section(".noinit,\"aw\",@nobits;")));
  * FIXME: needs doc
  */
 __attribute__((weak)) void bootloader_jump(void) {
-#if !defined(BOOTLOADER_SIZE)
+#if !defined(BOOTLOADER_SIZE) || defined(BOOTLOADER_MS)
     uint8_t high_fuse = boot_lock_fuse_bits_get(GET_HIGH_FUSE_BITS);
 
     if (high_fuse & ~(FUSE_BOOTSZ0 & FUSE_BOOTSZ1)) {
@@ -283,7 +283,7 @@ void bootloader_jump_after_watchdog_reset(void) {
         wdt_disable();
 
 // This is compled into 'icall', address should be in word unit, not byte.
-#    ifdef BOOTLOADER_SIZE
+#    if defined(BOOTLOADER_SIZE) && !defined(BOOTLOADER_MS)
         ((void (*)(void))((FLASH_SIZE - BOOTLOADER_SIZE) >> 1))();
 #    else
         asm("ijmp" ::"z"(bootloader_start));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Instead of jumping to the Boot_AUX_Trampoline address, jump to the reset vector. Lufa-ms allows for entry at the reset vector using HWBE or BOOTRST. 

This allows BOOTLOADER_SIZE to be incorrect for lufa-ms and still enter the bootloader correctly via a reset keycode or bootmagic.

I've tested both the older 6KB and newer 8KB lufa-ms bootloaders with this change on a promicro.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
