### PR TITLE
Fix two out of bounds accesses from #13330.

### DIFF
--- a/quantum/matrix.c
+++ b/quantum/matrix.c
@@ -149,7 +149,7 @@ static void unselect_row(uint8_t row) {
 }
 
 static void unselect_rows(void) {
-    for (uint8_t x = 0; x < MATRIX_ROWS; x++) {
+    for (uint8_t x = 0; x < ROWS_PER_HAND; x++) {
         unselect_row(x);
     }
 }
@@ -214,7 +214,7 @@ static void unselect_cols(void) {
 
 __attribute__((weak)) void matrix_init_pins(void) {
     unselect_cols();
-    for (uint8_t x = 0; x < MATRIX_ROWS; x++) {
+    for (uint8_t x = 0; x < ROWS_PER_HAND; x++) {
         if (row_pins[x] != NO_PIN) {
             setPinInputHigh_atomic(row_pins[x]);
         }


### PR DESCRIPTION
## Description

Two occurrences of `MATRIX_ROWS` weren't properly changed to `ROWS_PER_HAND` in #13330, causing a crash during boot on at least my Ergodox Infinity (including #13481).

(Only the `matrix_init_pins()` one, for `ROW2COL`, caused the crash on my Ergodox Infinity, but I found both these differences by comparing quantum/matrix.c after the change and quantum/split_common/matrix.c before the change, so both changes should be correct.)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
