### PR TITLE
Fix rgbkb/sol/rev2/config.h after changes introduced in #13349

### DIFF
--- a/keyboards/rgbkb/sol/rev2/config.h
+++ b/keyboards/rgbkb/sol/rev2/config.h
@@ -30,19 +30,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // Underglow / DIY Tent Glow are parallel to the top row leds, no separate define
 #ifdef FULLHAND_ENABLE
+  #define FULLHAND_LEDS 24
   #ifdef LED_MIRRORED
     #define RGBLED_NUM 74
   #else
     #define RGBLED_NUM 148
   #endif
 #elif SF_ENABLE
+  #define FULLHAND_LEDS 38
   #ifdef LED_MIRRORED
     #define RGBLED_NUM 81
   #else
     #define RGBLED_NUM 162
   #endif
 #else
-  #define RGBLED_NUM 0
+  #define FULLHAND_LEDS 0
+  #define RGBLED_NUM 124
 #endif
 
 #define DRIVER_LED_TOTAL  RGBLED_NUM


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Fixed rgbkb/sol/rev2/config.h config.h. It was not building after changes from #13349 where defines were streamlined to eliminate a compile warning.

* reintroduced FULLHAND_LEDS define (required in rev2.c to calculate LED position offset)
* change default RGBLED_NUM when neither FULLHAND nor SF is enabled (was 0 instead of 124)

Personally think that the previous version that was using expressions in the defines was a bit nicer. Less mental math to make mistakes in. Unfortunately I don't think there is a way to do that without having the linter complain about an 'invalid literal for int() with base 10'.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
