### PR TITLE
Ortho 5x14 handwired info.json correction

### DIFF
--- a/keyboards/handwired/ortho5x14/info.json
+++ b/keyboards/handwired/ortho5x14/info.json
@@ -80,7 +80,7 @@
                 {"label":"Alt", "x":10, "y":4},
                 {"label":"Prop", "x":11, "y":4},
                 {"label":"Ctrl", "x":12, "y":4},
-                {"label":"Esc", "x":13, "y":0}
+                {"label":"Esc", "x":13, "y":4}
             ]
         }
     }

--- a/keyboards/handwired/ortho5x14/readme.md
+++ b/keyboards/handwired/ortho5x14/readme.md
@@ -1,4 +1,4 @@
-# ortho5x13 handwired
+# ortho5x14 handwired
 
 Custom handwired ortho5x14 keyboard.
 


### PR DESCRIPTION
## Description

Fixes the visual position of the last key, and fixes a typo in the readme file.

![image](https://user-images.githubusercontent.com/18669334/125488430-582666d1-6e28-499d-b346-46a505cbfe5b.png)

cc @Antebios (keyboard maintainer)

## Types of Changes

- [x] Enhancement/optimization
- [x] Keyboard (addition or update)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
