### PR TITLE
Fix clang unit tests

### DIFF
--- a/tmk_core/native.mk
+++ b/tmk_core/native.mk
@@ -1,4 +1,5 @@
 SYSTEM_TYPE := $(shell gcc -dumpmachine)
+GCC_VERSION := $(shell gcc --version 2>/dev/null)
 
 CC = gcc
 OBJCOPY =
@@ -12,7 +13,9 @@ BIN =
 
 
 COMPILEFLAGS += -funsigned-char
+ifeq ($(findstring clang, ${GCC_VERSION}),)
 COMPILEFLAGS += -funsigned-bitfields
+endif
 COMPILEFLAGS += -ffunction-sections
 COMPILEFLAGS += -fdata-sections
 COMPILEFLAGS += -fshort-enums
@@ -21,7 +24,9 @@ COMPILEFLAGS += -mno-ms-bitfields
 endif
 
 CFLAGS += $(COMPILEFLAGS)
+ifeq ($(findstring clang, ${GCC_VERSION}),)
 CFLAGS += -fno-inline-small-functions
+endif
 CFLAGS += -fno-strict-aliasing
 
 CXXFLAGS += $(COMPILEFLAGS)

--- a/tmk_core/rules.mk
+++ b/tmk_core/rules.mk
@@ -105,7 +105,10 @@ endif
 #CFLAGS += -Wundef
 #CFLAGS += -Wunreachable-code
 #CFLAGS += -Wsign-compare
+GCC_VERSION := $(shell gcc --version 2>/dev/null)
+ifeq ($(findstring clang, ${GCC_VERSION}),)
 CFLAGS += -Wa,-adhlns=$(@:%.o=%.lst)
+endif
 CFLAGS += $(CSTANDARD)
 
 # This fixes lots of keyboards linking errors but SHOULDN'T BE A FINAL SOLUTION
@@ -137,7 +140,9 @@ endif
 #CXXFLAGS += -Wstrict-prototypes
 #CXXFLAGS += -Wunreachable-code
 #CXXFLAGS += -Wsign-compare
+ifeq ($(findstring clang, ${GCC_VERSION}),)
 CXXFLAGS += -Wa,-adhlns=$(@:%.o=%.lst)
+endif
 #CXXFLAGS += $(CSTANDARD)
 
 #---------------- Assembler Options ----------------
@@ -150,10 +155,12 @@ CXXFLAGS += -Wa,-adhlns=$(@:%.o=%.lst)
 #  -listing-cont-lines: Sets the maximum number of continuation lines of hex
 #       dump that will be displayed for a given single line of source input.
 ASFLAGS += $(ADEFS)
+ifeq ($(findstring clang, ${GCC_VERSION}),)
 ifeq ($(strip $(DEBUG_ENABLE)),yes)
   ASFLAGS += -Wa,-adhlns=$(@:%.o=%.lst),-gstabs,--listing-cont-lines=100
 else
   ASFLAGS += -Wa,-adhlns=$(@:%.o=%.lst),--listing-cont-lines=100
+endif
 endif
 ifeq ($(VERBOSE_AS_CMD),yes)
 	ASFLAGS += -v


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

On Mac, clang errors out on some flags when attempting to run tests.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

On Mac, clang errors out on some flags when attempting to run tests:
`clang: error: the clang compiler does not support '-funsigned-bitfields' [-Werror]`
`clang: error: optimization flag '-fno-inline-small-functions' is not supported [-Werror,-Wignored-optimization-argument]`
`clang: error: unsupported argument '-adhlns=.build/test_obj/eeprom_stm32/tmk_core/common/test/flash_stm32_mock.lst' to option 'Wa,'`

Steps to reproduce:
* On a system using clang, run `make test:debounce_sym_defer_g`

This change skips including a few non-compatible compiler flags when using clang.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
