### PR TITLE
Revert "Add rgblight to RGB Matrix VPATH"

### DIFF
--- a/common_features.mk
+++ b/common_features.mk
@@ -262,9 +262,6 @@ endif
     COMMON_VPATH += $(QUANTUM_DIR)/rgb_matrix
     COMMON_VPATH += $(QUANTUM_DIR)/rgb_matrix/animations
     COMMON_VPATH += $(QUANTUM_DIR)/rgb_matrix/animations/runners
-    # Get rid of this!
-    COMMON_VPATH += $(QUANTUM_DIR)/rgblight
-
     SRC += $(QUANTUM_DIR)/color.c
     SRC += $(QUANTUM_DIR)/rgb_matrix/rgb_matrix.c
     SRC += $(QUANTUM_DIR)/rgb_matrix/rgb_matrix_drivers.c

--- a/quantum/rgb_matrix/rgb_matrix.h
+++ b/quantum/rgb_matrix/rgb_matrix.h
@@ -23,7 +23,6 @@
 #include "rgb_matrix_types.h"
 #include "color.h"
 #include "quantum.h"
-#include "rgblight_list.h"
 
 #ifdef IS31FL3731
 #    include "is31fl3731.h"


### PR DESCRIPTION
Reverts qmk/qmk_firmware#13371

With #13555 and #13509, this should theoretically not be needed anymore.