### PR TITLE
Move `SENDSTRING_BELL` code to `send_string.h`

### DIFF
--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -49,9 +49,6 @@ float goodbye_song[][2] = GOODBYE_SONG;
 #    ifdef DEFAULT_LAYER_SONGS
 float default_layer_songs[][16][2] = DEFAULT_LAYER_SONGS;
 #    endif
-#    ifdef SENDSTRING_BELL
-float bell_song[][2] = SONG(TERMINAL_SOUND);
-#    endif
 #endif
 
 #ifdef AUTO_SHIFT_ENABLE

--- a/quantum/send_string.c
+++ b/quantum/send_string.c
@@ -20,6 +20,14 @@
 
 #include "send_string.h"
 
+#if defined(AUDIO_ENABLE) && defined(SENDSTRING_BELL)
+#    include "audio.h"
+#    ifndef BELL_SOUND
+#        define BELL_SOUND TERMINAL_SOUND
+#    endif
+float bell_song[][2] = SONG(BELL_SOUND);
+#endif
+
 // clang-format off
 
 /* Bit-Packed look-up table to convert an ASCII character to whether


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I forgot to do this when I moved all the sendstring stuff out of quantum.h. Also allowed for the bell song to be overridden.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
