### PR TITLE
Limit RGB brightness for crkbd when not defined.

### DIFF
--- a/keyboards/crkbd/post_config.h
+++ b/keyboards/crkbd/post_config.h
@@ -29,3 +29,15 @@
 #ifndef BOOTMAGIC_LITE_COLUMN_RIGHT
 #    define BOOTMAGIC_LITE_COLUMN_RIGHT 1
 #endif
+
+#ifdef RGBLIGHT_ENABLE
+#    ifndef RGBLIGHT_LIMIT_VAL
+#        define RGBLIGHT_LIMIT_VAL 120
+#    endif
+#endif
+
+#ifdef RGB_MATRIX_ENABLE
+#    ifndef RGB_MATRIX_MAXIMUM_BRIGHTNESS
+#        define RGB_MATRIX_MAXIMUM_BRIGHTNESS 120
+#    endif
+#endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Limits rgblight value or rgb matrix brightness if not defined.

Without a sensible limit the leds can draw over the 500mA fuse on a promicro, this results in the keyboard locking up or the secondary side not responding. This issue comes up fairly frequently in Discord.

120 may be a little conservative but should be safe when set to all white, it can vary between setups. 

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
