### PR TITLE
remove `RGBLIGHT_H_DUMMY_DEFINE` macro from rgblight.h

### DIFF
--- a/quantum/rgblight.h
+++ b/quantum/rgblight.h
@@ -115,73 +115,71 @@ enum RGBLIGHT_EFFECT_MODE {
     RGBLIGHT_MODE_last
 };
 
-#ifndef RGBLIGHT_H_DUMMY_DEFINE
-
-#    define RGBLIGHT_MODES (RGBLIGHT_MODE_last - 1)
+#define RGBLIGHT_MODES (RGBLIGHT_MODE_last - 1)
 
 // sample: #define RGBLIGHT_EFFECT_BREATHE_CENTER   1.85
 
-#    ifndef RGBLIGHT_EFFECT_BREATHE_MAX
-#        define RGBLIGHT_EFFECT_BREATHE_MAX 255  // 0-255
-#    endif
+#ifndef RGBLIGHT_EFFECT_BREATHE_MAX
+#    define RGBLIGHT_EFFECT_BREATHE_MAX 255  // 0-255
+#endif
 
-#    ifndef RGBLIGHT_EFFECT_SNAKE_LENGTH
-#        define RGBLIGHT_EFFECT_SNAKE_LENGTH 4
-#    endif
+#ifndef RGBLIGHT_EFFECT_SNAKE_LENGTH
+#    define RGBLIGHT_EFFECT_SNAKE_LENGTH 4
+#endif
 
-#    ifndef RGBLIGHT_EFFECT_KNIGHT_LENGTH
-#        define RGBLIGHT_EFFECT_KNIGHT_LENGTH 3
-#    endif
+#ifndef RGBLIGHT_EFFECT_KNIGHT_LENGTH
+#    define RGBLIGHT_EFFECT_KNIGHT_LENGTH 3
+#endif
 
-#    ifndef RGBLIGHT_EFFECT_KNIGHT_OFFSET
-#        define RGBLIGHT_EFFECT_KNIGHT_OFFSET 0
-#    endif
+#ifndef RGBLIGHT_EFFECT_KNIGHT_OFFSET
+#    define RGBLIGHT_EFFECT_KNIGHT_OFFSET 0
+#endif
 
-#    ifndef RGBLIGHT_EFFECT_KNIGHT_LED_NUM
-#        define RGBLIGHT_EFFECT_KNIGHT_LED_NUM (rgblight_ranges.effect_num_leds)
-#    endif
+#ifndef RGBLIGHT_EFFECT_KNIGHT_LED_NUM
+#    define RGBLIGHT_EFFECT_KNIGHT_LED_NUM (rgblight_ranges.effect_num_leds)
+#endif
 
-#    ifndef RGBLIGHT_EFFECT_CHRISTMAS_INTERVAL
-#        define RGBLIGHT_EFFECT_CHRISTMAS_INTERVAL 40
-#    endif
+#ifndef RGBLIGHT_EFFECT_CHRISTMAS_INTERVAL
+#    define RGBLIGHT_EFFECT_CHRISTMAS_INTERVAL 40
+#endif
 
-#    ifndef RGBLIGHT_EFFECT_CHRISTMAS_STEP
-#        define RGBLIGHT_EFFECT_CHRISTMAS_STEP 2
-#    endif
+#ifndef RGBLIGHT_EFFECT_CHRISTMAS_STEP
+#    define RGBLIGHT_EFFECT_CHRISTMAS_STEP 2
+#endif
 
-#    ifndef RGBLIGHT_EFFECT_TWINKLE_LIFE
-#        define RGBLIGHT_EFFECT_TWINKLE_LIFE 200
-#    endif
+#ifndef RGBLIGHT_EFFECT_TWINKLE_LIFE
+#    define RGBLIGHT_EFFECT_TWINKLE_LIFE 200
+#endif
 
-#    ifndef RGBLIGHT_EFFECT_TWINKLE_PROBABILITY
-#        define RGBLIGHT_EFFECT_TWINKLE_PROBABILITY 1 / 127
-#    endif
+#ifndef RGBLIGHT_EFFECT_TWINKLE_PROBABILITY
+#    define RGBLIGHT_EFFECT_TWINKLE_PROBABILITY 1 / 127
+#endif
 
-#    ifndef RGBLIGHT_HUE_STEP
-#        define RGBLIGHT_HUE_STEP 8
-#    endif
-#    ifndef RGBLIGHT_SAT_STEP
-#        define RGBLIGHT_SAT_STEP 17
-#    endif
-#    ifndef RGBLIGHT_VAL_STEP
-#        define RGBLIGHT_VAL_STEP 17
-#    endif
-#    ifndef RGBLIGHT_LIMIT_VAL
-#        define RGBLIGHT_LIMIT_VAL 255
-#    endif
+#ifndef RGBLIGHT_HUE_STEP
+#    define RGBLIGHT_HUE_STEP 8
+#endif
+#ifndef RGBLIGHT_SAT_STEP
+#    define RGBLIGHT_SAT_STEP 17
+#endif
+#ifndef RGBLIGHT_VAL_STEP
+#    define RGBLIGHT_VAL_STEP 17
+#endif
+#ifndef RGBLIGHT_LIMIT_VAL
+#    define RGBLIGHT_LIMIT_VAL 255
+#endif
 
-#    include <stdint.h>
-#    include <stdbool.h>
-#    include "eeconfig.h"
-#    include "ws2812.h"
-#    include "color.h"
-#    include "rgblight_list.h"
+#include <stdint.h>
+#include <stdbool.h>
+#include "eeconfig.h"
+#include "ws2812.h"
+#include "color.h"
+#include "rgblight_list.h"
 
-#    if defined(__AVR__)
-#        include <avr/pgmspace.h>
-#    endif
+#if defined(__AVR__)
+#    include <avr/pgmspace.h>
+#endif
 
-#    ifdef RGBLIGHT_LAYERS
+#ifdef RGBLIGHT_LAYERS
 typedef struct {
     uint8_t index;  // The first LED to light
     uint8_t count;  // The number of LEDs to light
@@ -190,27 +188,27 @@ typedef struct {
     uint8_t val;
 } rgblight_segment_t;
 
-#        define RGBLIGHT_END_SEGMENT_INDEX (255)
-#        define RGBLIGHT_END_SEGMENTS \
-            { RGBLIGHT_END_SEGMENT_INDEX, 0, 0, 0 }
-#        ifndef RGBLIGHT_MAX_LAYERS
-#            define RGBLIGHT_MAX_LAYERS 8
-#        endif
-#        if RGBLIGHT_MAX_LAYERS <= 0
-#            error invalid RGBLIGHT_MAX_LAYERS value (must be >= 1)
-#        elif RGBLIGHT_MAX_LAYERS <= 8
+#    define RGBLIGHT_END_SEGMENT_INDEX (255)
+#    define RGBLIGHT_END_SEGMENTS \
+        { RGBLIGHT_END_SEGMENT_INDEX, 0, 0, 0 }
+#    ifndef RGBLIGHT_MAX_LAYERS
+#        define RGBLIGHT_MAX_LAYERS 8
+#    endif
+#    if RGBLIGHT_MAX_LAYERS <= 0
+#        error invalid RGBLIGHT_MAX_LAYERS value (must be >= 1)
+#    elif RGBLIGHT_MAX_LAYERS <= 8
 typedef uint8_t rgblight_layer_mask_t;
-#        elif RGBLIGHT_MAX_LAYERS <= 16
+#    elif RGBLIGHT_MAX_LAYERS <= 16
 typedef uint16_t rgblight_layer_mask_t;
-#        elif RGBLIGHT_MAX_LAYERS <= 32
+#    elif RGBLIGHT_MAX_LAYERS <= 32
 typedef uint32_t rgblight_layer_mask_t;
-#        else
-#            error invalid RGBLIGHT_MAX_LAYERS value (must be <= 32)
-#        endif
-#        define RGBLIGHT_LAYER_SEGMENTS(...) \
-            { __VA_ARGS__, RGBLIGHT_END_SEGMENTS }
-#        define RGBLIGHT_LAYERS_LIST(...) \
-            { __VA_ARGS__, NULL }
+#    else
+#        error invalid RGBLIGHT_MAX_LAYERS value (must be <= 32)
+#    endif
+#    define RGBLIGHT_LAYER_SEGMENTS(...) \
+        { __VA_ARGS__, RGBLIGHT_END_SEGMENTS }
+#    define RGBLIGHT_LAYERS_LIST(...) \
+        { __VA_ARGS__, NULL }
 
 // Get/set enabled rgblight layers
 void rgblight_set_layer_state(uint8_t layer, bool enabled);
@@ -219,13 +217,13 @@ bool rgblight_get_layer_state(uint8_t layer);
 // Point this to an array of rgblight_segment_t arrays in keyboard_post_init_user to use rgblight layers
 extern const rgblight_segment_t *const *rgblight_layers;
 
-#        ifdef RGBLIGHT_LAYER_BLINK
-#            define RGBLIGHT_USE_TIMER
+#    ifdef RGBLIGHT_LAYER_BLINK
+#        define RGBLIGHT_USE_TIMER
 void rgblight_blink_layer(uint8_t layer, uint16_t duration_ms);
 void rgblight_blink_layer_repeat(uint8_t layer, uint16_t duration_ms, uint8_t times);
-#        endif
-
 #    endif
+
+#endif
 
 extern LED_TYPE led[RGBLED_NUM];
 
@@ -254,12 +252,12 @@ typedef union {
 typedef struct _rgblight_status_t {
     uint8_t base_mode;
     bool    timer_enabled;
-#    ifdef RGBLIGHT_SPLIT
+#ifdef RGBLIGHT_SPLIT
     uint8_t change_flags;
-#    endif
-#    ifdef RGBLIGHT_LAYERS
+#endif
+#ifdef RGBLIGHT_LAYERS
     rgblight_layer_mask_t enabled_layer_mask;
-#    endif
+#endif
 } rgblight_status_t;
 
 /*
@@ -295,12 +293,12 @@ void rgblight_setrgb_range(uint8_t r, uint8_t g, uint8_t b, uint8_t start, uint8
 void rgblight_sethsv_range(uint8_t hue, uint8_t sat, uint8_t val, uint8_t start, uint8_t end);
 void rgblight_setrgb(uint8_t r, uint8_t g, uint8_t b);
 
-#    ifndef RGBLIGHT_SPLIT
+#ifndef RGBLIGHT_SPLIT
 void rgblight_setrgb_master(uint8_t r, uint8_t g, uint8_t b);
 void rgblight_setrgb_slave(uint8_t r, uint8_t g, uint8_t b);
 void rgblight_sethsv_master(uint8_t hue, uint8_t sat, uint8_t val);
 void rgblight_sethsv_slave(uint8_t hue, uint8_t sat, uint8_t val);
-#    endif
+#endif
 
 /*   effect mode change */
 void rgblight_mode(uint8_t mode);
@@ -374,29 +372,29 @@ void rgb_matrix_decrease(void);
 void rgblight_sethsv_eeprom_helper(uint8_t hue, uint8_t sat, uint8_t val, bool write_to_eeprom);
 void rgblight_mode_eeprom_helper(uint8_t mode, bool write_to_eeprom);
 
-#    define EZ_RGB(val) rgblight_show_solid_color((val >> 16) & 0xFF, (val >> 8) & 0xFF, val & 0xFF)
+#define EZ_RGB(val) rgblight_show_solid_color((val >> 16) & 0xFF, (val >> 8) & 0xFF, val & 0xFF)
 void rgblight_show_solid_color(uint8_t r, uint8_t g, uint8_t b);
 
-#    ifdef RGBLIGHT_USE_TIMER
+#ifdef RGBLIGHT_USE_TIMER
 void rgblight_task(void);
 void rgblight_timer_init(void);
 void rgblight_timer_enable(void);
 void rgblight_timer_disable(void);
 void rgblight_timer_toggle(void);
-#    else
-#        define rgblight_task()
-#        define rgblight_timer_init()
-#        define rgblight_timer_enable()
-#        define rgblight_timer_disable()
-#        define rgblight_timer_toggle()
-#    endif
+#else
+#    define rgblight_task()
+#    define rgblight_timer_init()
+#    define rgblight_timer_enable()
+#    define rgblight_timer_disable()
+#    define rgblight_timer_toggle()
+#endif
 
-#    ifdef RGBLIGHT_SPLIT
-#        define RGBLIGHT_STATUS_CHANGE_MODE (1 << 0)
-#        define RGBLIGHT_STATUS_CHANGE_HSVS (1 << 1)
-#        define RGBLIGHT_STATUS_CHANGE_TIMER (1 << 2)
-#        define RGBLIGHT_STATUS_ANIMATION_TICK (1 << 3)
-#        define RGBLIGHT_STATUS_CHANGE_LAYERS (1 << 4)
+#ifdef RGBLIGHT_SPLIT
+#    define RGBLIGHT_STATUS_CHANGE_MODE (1 << 0)
+#    define RGBLIGHT_STATUS_CHANGE_HSVS (1 << 1)
+#    define RGBLIGHT_STATUS_CHANGE_TIMER (1 << 2)
+#    define RGBLIGHT_STATUS_ANIMATION_TICK (1 << 3)
+#    define RGBLIGHT_STATUS_CHANGE_LAYERS (1 << 4)
 
 typedef struct _rgblight_syncinfo_t {
     rgblight_config_t config;
@@ -409,9 +407,9 @@ void    rgblight_clear_change_flags(void);
 void    rgblight_get_syncinfo(rgblight_syncinfo_t *syncinfo);
 /* for split keyboard slave side */
 void rgblight_update_sync(rgblight_syncinfo_t *syncinfo, bool write_to_eeprom);
-#    endif
+#endif
 
-#    ifdef RGBLIGHT_USE_TIMER
+#ifdef RGBLIGHT_USE_TIMER
 
 typedef struct _animation_status_t {
     uint16_t last_timer;
@@ -437,6 +435,4 @@ void rgblight_effect_rgbtest(animation_status_t *anim);
 void rgblight_effect_alternating(animation_status_t *anim);
 void rgblight_effect_twinkle(animation_status_t *anim);
 
-#    endif
-
-#endif  // #ifndef RGBLIGHT_H_DUMMY_DEFINE
+#endif


### PR DESCRIPTION
## Description

Due to the change in #13555, `RGBLIGHT_H_DUMMY_DEFINE` in rgblight.h is already no longer needed, so delete it.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
