### PR TITLE
Add BOOTMAGIC_ENABLE=both which combines lite and full mode

### DIFF
--- a/common_features.mk
+++ b/common_features.mk
@@ -466,10 +466,13 @@ ifeq ($(strip $(VELOCIKEY_ENABLE)), yes)
     SRC += $(QUANTUM_DIR)/velocikey.c
 endif
 
+BOOTMAGIC_ENABLE ?= no
 ifeq ($(strip $(VIA_ENABLE)), yes)
     DYNAMIC_KEYMAP_ENABLE := yes
     RAW_ENABLE := yes
+  ifneq ($(strip $(BOOTMAGIC_ENABLE)), both)
     BOOTMAGIC_ENABLE := lite
+  endif
     SRC += $(QUANTUM_DIR)/via.c
     OPT_DEFS += -DVIA_ENABLE
 endif
@@ -484,13 +487,15 @@ ifeq ($(strip $(DIP_SWITCH_ENABLE)), yes)
     SRC += $(QUANTUM_DIR)/dip_switch.c
 endif
 
-VALID_MAGIC_TYPES := yes full lite
-BOOTMAGIC_ENABLE ?= no
+VALID_MAGIC_TYPES := yes full lite both
 ifneq ($(strip $(BOOTMAGIC_ENABLE)), no)
   ifeq ($(filter $(BOOTMAGIC_ENABLE),$(VALID_MAGIC_TYPES)),)
     $(error BOOTMAGIC_ENABLE="$(BOOTMAGIC_ENABLE)" is not a valid type of magic)
   endif
-  ifneq ($(strip $(BOOTMAGIC_ENABLE)), full)
+  ifeq ($(strip $(BOOTMAGIC_ENABLE)), both)
+      OPT_DEFS += -DBOOTMAGIC_LITE -DBOOTMAGIC_ENABLE
+      QUANTUM_SRC += $(QUANTUM_DIR)/bootmagic/bootmagic_full.c $(QUANTUM_DIR)/bootmagic/bootmagic_lite.c
+  else ifneq ($(strip $(BOOTMAGIC_ENABLE)), full)
       OPT_DEFS += -DBOOTMAGIC_LITE
       QUANTUM_SRC += $(QUANTUM_DIR)/bootmagic/bootmagic_lite.c
   else

--- a/docs/feature_bootmagic.md
+++ b/docs/feature_bootmagic.md
@@ -14,12 +14,19 @@ On some keyboards Bootmagic is disabled by default. If this is the case, it must
 BOOTMAGIC_ENABLE = full
 ```
 
-?> You may see `yes` being used in place of `full`, and this is okay. However, `yes` is deprecated, and ideally `full` (or `lite`) should be used instead.
-
 Additionally, you can use [Bootmagic Lite](#bootmagic-lite) (a scaled down, very basic version of Bootmagic) by adding the following to your `rules.mk` file:
 
 ```make
 BOOTMAGIC_ENABLE = lite
+```
+
+?> You may see `yes` being used in place of `lite`, and this is okay. However, `yes` is deprecated, and ideally `full` or `lite` should be used instead.
+
+
+You can enable both `full` and `lite` mode by adding the following to your `rules.mk` file:
+
+```make
+BOOTMAGIC_ENABLE = both
 ```
 
 ## Hotkeys

--- a/quantum/bootmagic/bootmagic.h
+++ b/quantum/bootmagic/bootmagic.h
@@ -17,8 +17,7 @@
 
 #if defined(BOOTMAGIC_ENABLE)
 #    include "bootmagic_full.h"
-#elif defined(BOOTMAGIC_LITE)
+#endif
+#if defined(BOOTMAGIC_LITE)
 #    include "bootmagic_lite.h"
 #endif
-
-void bootmagic(void);

--- a/quantum/bootmagic/bootmagic_full.c
+++ b/quantum/bootmagic/bootmagic_full.c
@@ -53,7 +53,7 @@ static bool bootmagic_scan_keycode(uint8_t keycode) {
     return scan_keycode(keycode);
 }
 
-void bootmagic(void) {
+void bootmagic_full(void) {
     /* do scans in case of bounce */
     print("bootmagic scan: ... ");
     uint8_t scan = 100;

--- a/quantum/bootmagic/bootmagic_full.h
+++ b/quantum/bootmagic/bootmagic_full.h
@@ -113,3 +113,5 @@
 #ifndef BOOTMAGIC_KEY_DEFAULT_LAYER_7
 #    define BOOTMAGIC_KEY_DEFAULT_LAYER_7 KC_7
 #endif
+
+void bootmagic_full(void);

--- a/quantum/bootmagic/bootmagic_lite.c
+++ b/quantum/bootmagic/bootmagic_lite.c
@@ -62,5 +62,3 @@ __attribute__((weak)) void bootmagic_lite(void) {
         bootloader_jump();
     }
 }
-
-void bootmagic(void) { bootmagic_lite(); }

--- a/quantum/bootmagic/magic.c
+++ b/quantum/bootmagic/magic.c
@@ -43,7 +43,12 @@ void magic(void) {
     debug_config.raw  = eeconfig_read_debug();
     keymap_config.raw = eeconfig_read_keymap();
 
-    bootmagic();
+#if defined(BOOTMAGIC_LITE)
+    bootmagic_lite();
+#endif
+#if defined(BOOTMAGIC_ENABLE)
+    bootmagic_full();
+#endif
 
     /* read here just incase bootmagic process changed its value */
     layer_state_t default_layer = (layer_state_t)eeconfig_read_default_layer();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

Add BOOTMAGIC_ENABLE = both which combines lite and full mode

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Currently BOOTMAGIC_ENABLE can either be 'lite' ('yes') or 'full'.  VIA currently forces 'lite' mode when enabled, presumably to have a method for clearing eeprom and entering bootloader mode that isn't reliant on a particular set of keys being available on layer 0 (which VIA may change). 

This change allows for both 'full' mode and 'lite' mode to be enabled at the same time.  VIA still defaults to enabling 'lite' mode, but will allow for 'both' mode if bootmagic 'full' functionally is also desired.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
