### PR TITLE
Update LUFA to newest (18-07-2021) and add QMK-HID Bootloader support

### DIFF
--- a/bootloader.mk
+++ b/bootloader.mk
@@ -26,6 +26,7 @@
 #     atmel-dfu   Atmel factory DFU
 #     lufa-dfu    LUFA DFU
 #     qmk-dfu     QMK DFU (LUFA + blinkenlight)
+#     qmk-hid     QMK HID (LUFA + blinkenlight)
 #     bootloadHID HIDBootFlash compatible (ATmega32A)
 #     USBasp      USBaspLoader (ATmega328P)
 # ARM:

--- a/bootloader.mk
+++ b/bootloader.mk
@@ -70,12 +70,7 @@ endif
 ifeq ($(strip $(BOOTLOADER)), qmk-hid)
     OPT_DEFS += -DBOOTLOADER_QMK_HID
     OPT_DEFS += -DBOOTLOADER_HID
-    ifneq (,$(filter $(MCU), at90usb162 atmega16u2 atmega32u2 atmega16u4 atmega32u4 at90usb646 at90usb647))
-        BOOTLOADER_SIZE = 2048
-    endif
-    ifneq (,$(filter $(MCU), at90usb1286 at90usb1287))
-        BOOTLOADER_SIZE = 4096
-    endif
+    BOOTLOADER_SIZE = 4096
 endif
 ifeq ($(strip $(BOOTLOADER)), halfkay)
     OPT_DEFS += -DBOOTLOADER_HALFKAY

--- a/bootloader.mk
+++ b/bootloader.mk
@@ -67,6 +67,16 @@ ifeq ($(strip $(BOOTLOADER)), qmk-dfu)
         BOOTLOADER_SIZE = 8192
     endif
 endif
+ifeq ($(strip $(BOOTLOADER)), qmk-hid)
+    OPT_DEFS += -DBOOTLOADER_QMK_HID
+    OPT_DEFS += -DBOOTLOADER_HID
+    ifneq (,$(filter $(MCU), at90usb162 atmega16u2 atmega32u2 atmega16u4 atmega32u4 at90usb646 at90usb647))
+        BOOTLOADER_SIZE = 2048
+    endif
+    ifneq (,$(filter $(MCU), at90usb1286 at90usb1287))
+        BOOTLOADER_SIZE = 4096
+    endif
+endif
 ifeq ($(strip $(BOOTLOADER)), halfkay)
     OPT_DEFS += -DBOOTLOADER_HALFKAY
     ifeq ($(strip $(MCU)), atmega32u4)

--- a/data/schemas/keyboard.jsonschema
+++ b/data/schemas/keyboard.jsonschema
@@ -22,7 +22,7 @@
         },
         "bootloader": {
             "type": "string",
-            "enum": ["atmel-dfu", "bootloadHID", "caterina", "halfkay", "kiibohd", "lufa-dfu", "lufa-ms", "micronucleus", "qmk-dfu", "stm32-dfu", "stm32duino", "unknown", "USBasp", "tinyuf2"]
+            "enum": ["atmel-dfu", "bootloadHID", "caterina", "halfkay", "kiibohd", "lufa-dfu", "lufa-ms", "micronucleus", "qmk-dfu", "qmk-hid", "stm32-dfu", "stm32duino", "unknown", "USBasp", "tinyuf2"]
         },
         "diode_direction": {
             "type": "string",

--- a/docs/driver_installation_zadig.md
+++ b/docs/driver_installation_zadig.md
@@ -75,3 +75,4 @@ The device name here is the name that appears in Zadig, and may not be what the 
 |`stm32-dfu`  |STM32 BOOTLOADER              |`0483:DF11`   |WinUSB |
 |`kiibohd`    |Kiibohd DFU Bootloader        |`1C11:B007`   |WinUSB |
 |`stm32duino` |Maple 003                     |`1EAF:0003`   |WinUSB |
+|`qmk-hid`    |(keyboard name) Bootloader    |`03EB:2067`   |HidUsb |

--- a/docs/flashing.md
+++ b/docs/flashing.md
@@ -174,7 +174,17 @@ Flashing sequence:
 
 ### QMK HID
 
-QMK maintains [a fork of the LUFA HID bootloader](https://github.com/qmk/lufa/tree/master/Bootloaders/HID), which uses a USB HID Endpoint for flashing in the way that the PJRC's Teensy Loader flasher and Halfkay bootloader work. Additionally, it performs a simple matrix scan for exiting the bootloader and returning to the application, as well as flashing an LED/making a ticking noise with a speaker when things are happening. To enable these features, add the following defines to your `config.h`:
+QMK maintains [a fork of the LUFA HID bootloader](https://github.com/qmk/lufa/tree/master/Bootloaders/HID), which uses a USB HID Endpoint for flashing in the way that the PJRC's Teensy Loader flasher and Halfkay bootloader work. Additionally, it performs a simple matrix scan for exiting the bootloader and returning to the application, as well as flashing an LED/making a ticking noise with a speaker when things are happening. 
+
+
+To ensure compatibility with the QMK HID bootloader, make sure this block is present in your `rules.mk`:
+
+```make
+# Bootloader selection
+BOOTLOADER = qmk-hid
+```
+
+To enable the additional features, add the following defines to your `config.h`:
 
 ```c
 #define QMK_ESC_OUTPUT F1  // COL pin if COL2ROW
@@ -183,13 +193,32 @@ QMK maintains [a fork of the LUFA HID bootloader](https://github.com/qmk/lufa/tr
 //#define QMK_LED E6
 //#define QMK_SPEAKER C6
 ```
+
 Currently we do not recommend making `QMK_ESC` the same key as the one designated for [Bootmagic Lite](feature_bootmagic.md#bootmagic-lite), as holding it down will cause the MCU to loop back and forth between entering and exiting the bootloader.
 
 The manufacturer and product strings are automatically pulled from `config.h`, with " Bootloader" appended to the product string.
 
 To generate this bootloader, use the `bootloader` target, eg. `make planck/rev4:default:bootloader`. To generate a production-ready .hex file (combining QMK and the bootloader), use the `production` target, eg. `make planck/rev4:default:production`.
 
-!> Currently, you need to either use the [python script](https://github.com/qmk/lufa/tree/master/Bootloaders/HID/HostLoaderApp_python) in the lufa repo, or compile the [`hid_bootloader_cli`](https://github.com/qmk/lufa/tree/master/Bootloaders/HID/HostLoaderApp) from the LUFA repo.   Homebrew may (will) have support for this directly (via `brew install qmk/qmk/hid_bootloader_cli`)
+
+Compatible flashers:
+
+* TBD
+  * Currently, you need to either use the [python script](https://github.com/qmk/lufa/tree/master/Bootloaders/HID/HostLoaderApp_python) in the lufa repo, or compile the [`hid_bootloader_cli`](https://github.com/qmk/lufa/tree/master/Bootloaders/HID/HostLoaderApp) from the LUFA repo.   Homebrew may (will) have support for this directly (via `brew install qmk/qmk/hid_bootloader_cli`)
+
+Flashing sequence:
+
+1. Enter the bootloader using any of the following methods (you only have 7 seconds to flash once it enters):
+    * Press the `RESET` keycode
+    * Press the `RESET` button on the Teensy or PCB if available
+    * short RST to GND quickly
+2. Wait for the OS to detect the device
+3. Flash a .hex file
+4. Reset the device into application mode (may be done automatically)
+
+### `make` Targets
+
+* `:qmk-hid`: Checks every 5 seconds until a DFU device is available, and then flashes the firmware.
 
 ## STM32/APM32 DFU
 

--- a/docs/flashing.md
+++ b/docs/flashing.md
@@ -171,11 +171,9 @@ Flashing sequence:
 3. Flash a .hex file
 4. Reset the device into application mode (may be done automatically)
 
-
 ### QMK HID
 
-QMK maintains [a fork of the LUFA HID bootloader](https://github.com/qmk/lufa/tree/master/Bootloaders/HID), which uses a USB HID Endpoint for flashing in the way that the PJRC's Teensy Loader flasher and Halfkay bootloader work. Additionally, it performs a simple matrix scan for exiting the bootloader and returning to the application, as well as flashing an LED/making a ticking noise with a speaker when things are happening. 
-
+QMK maintains [a fork of the LUFA HID bootloader](https://github.com/qmk/lufa/tree/master/Bootloaders/HID), which uses a USB HID Endpoint for flashing in the way that the PJRC's Teensy Loader flasher and HalfKay bootloader work. Additionally, it performs a simple matrix scan for exiting the bootloader and returning to the application, as well as flashing an LED/making a ticking noise with a speaker when things are happening.
 
 To ensure compatibility with the QMK HID bootloader, make sure this block is present in your `rules.mk`:
 
@@ -200,17 +198,16 @@ The manufacturer and product strings are automatically pulled from `config.h`, w
 
 To generate this bootloader, use the `bootloader` target, eg. `make planck/rev4:default:bootloader`. To generate a production-ready .hex file (combining QMK and the bootloader), use the `production` target, eg. `make planck/rev4:default:production`.
 
-
 Compatible flashers:
 
 * TBD
-  * Currently, you need to either use the [python script](https://github.com/qmk/lufa/tree/master/Bootloaders/HID/HostLoaderApp_python) in the lufa repo, or compile the [`hid_bootloader_cli`](https://github.com/qmk/lufa/tree/master/Bootloaders/HID/HostLoaderApp) from the LUFA repo.   Homebrew may (will) have support for this directly (via `brew install qmk/qmk/hid_bootloader_cli`)
+  * Currently, you need to either use the [Python script](https://github.com/qmk/lufa/tree/master/Bootloaders/HID/HostLoaderApp_python), or compile [`hid_bootloader_cli`](https://github.com/qmk/lufa/tree/master/Bootloaders/HID/HostLoaderApp), from the LUFA repo. Homebrew may (will) have support for this directly (via `brew install qmk/qmk/hid_bootloader_cli`).
 
 Flashing sequence:
 
-1. Enter the bootloader using any of the following methods (you only have 7 seconds to flash once it enters):
+1. Enter the bootloader using any of the following methods:
     * Press the `RESET` keycode
-    * Press the `RESET` button on the Teensy or PCB if available
+    * Press the `RESET` button on the PCB if available
     * short RST to GND quickly
 2. Wait for the OS to detect the device
 3. Flash a .hex file

--- a/docs/flashing.md
+++ b/docs/flashing.md
@@ -171,6 +171,26 @@ Flashing sequence:
 3. Flash a .hex file
 4. Reset the device into application mode (may be done automatically)
 
+
+### QMK HID
+
+QMK maintains [a fork of the LUFA HID bootloader](https://github.com/qmk/lufa/tree/master/Bootloaders/HID), which uses a USB HID Endpoint for flashing in the way that the PJRC's Teensy Loader flasher and Halfkay bootloader work. Additionally, it performs a simple matrix scan for exiting the bootloader and returning to the application, as well as flashing an LED/making a ticking noise with a speaker when things are happening. To enable these features, add the following defines to your `config.h`:
+
+```c
+#define QMK_ESC_OUTPUT F1  // COL pin if COL2ROW
+#define QMK_ESC_INPUT  D5  // ROW pin if COL2ROW
+// Optional:
+//#define QMK_LED E6
+//#define QMK_SPEAKER C6
+```
+Currently we do not recommend making `QMK_ESC` the same key as the one designated for [Bootmagic Lite](feature_bootmagic.md#bootmagic-lite), as holding it down will cause the MCU to loop back and forth between entering and exiting the bootloader.
+
+The manufacturer and product strings are automatically pulled from `config.h`, with " Bootloader" appended to the product string.
+
+To generate this bootloader, use the `bootloader` target, eg. `make planck/rev4:default:bootloader`. To generate a production-ready .hex file (combining QMK and the bootloader), use the `production` target, eg. `make planck/rev4:default:production`.
+
+!> Currently, you need to either use the [python script](https://github.com/qmk/lufa/tree/master/Bootloaders/HID/HostLoaderApp_python) in the lufa repo, or compile the [`hid_bootloader_cli`](https://github.com/qmk/lufa/tree/master/Bootloaders/HID/HostLoaderApp) from the LUFA repo.   Homebrew may (will) have support for this directly (via `brew install qmk/qmk/hid_bootloader_cli`)
+
 ## STM32/APM32 DFU
 
 All STM32 and APM32 MCUs, except for F103 (see the [STM32duino section](#stm32duino)) come preloaded with a factory bootloader that cannot be modified nor deleted.

--- a/tmk_core/avr.mk
+++ b/tmk_core/avr.mk
@@ -296,9 +296,7 @@ extcoff: $(BUILD_DIR)/$(TARGET).elf
 	$(COFFCONVERT) -O coff-ext-avr $< $(BUILD_DIR)/$(TARGET).cof
 
 bootloader:
-ifneq ($(strip $(BOOTLOADER)), qmk-dfu)
-	$(error Please set BOOTLOADER = qmk-dfu first!)
-endif
+ifeq ($(strip $(BOOTLOADER)), qmk-dfu)
 	make -C lib/lufa/Bootloaders/DFU/ clean
 	$(QMK_BIN) generate-dfu-header --quiet --keyboard $(KEYBOARD) --output lib/lufa/Bootloaders/DFU/Keyboard.h
 	$(eval MAX_SIZE=$(shell n=`$(CC) -E -mmcu=$(MCU) -D__ASSEMBLER__ $(CFLAGS) $(OPT_DEFS) tmk_core/common/avr/bootloader_size.c 2> /dev/null | sed -ne 's/\r//;/^#/n;/^AVR_SIZE:/,$${s/^AVR_SIZE: //;p;}'` && echo $$(($$n)) || echo 0))
@@ -308,6 +306,19 @@ endif
 	make -C lib/lufa/Bootloaders/DFU/ MCU=$(MCU) ARCH=$(ARCH) F_CPU=$(F_CPU) FLASH_SIZE_KB=$(FLASH_SIZE_KB) BOOT_SECTION_SIZE_KB=$(BOOT_SECTION_SIZE_KB)
 	printf "BootloaderDFU.hex copied to $(TARGET)_bootloader.hex\n"
 	cp lib/lufa/Bootloaders/DFU/BootloaderDFU.hex $(TARGET)_bootloader.hex
+else ifeq ($(strip $(BOOTLOADER)), qmk-hid)
+	make -C lib/lufa/Bootloaders/HID/ clean
+	$(QMK_BIN) generate-dfu-header --quiet --keyboard $(KEYBOARD) --output lib/lufa/Bootloaders/HID/Keyboard.h
+	$(eval MAX_SIZE=$(shell n=`$(CC) -E -mmcu=$(MCU) -D__ASSEMBLER__ $(CFLAGS) $(OPT_DEFS) tmk_core/common/avr/bootloader_size.c 2> /dev/null | sed -ne 's/\r//;/^#/n;/^AVR_SIZE:/,$${s/^AVR_SIZE: //;p;}'` && echo $$(($$n)) || echo 0))
+	$(eval PROGRAM_SIZE_KB=$(shell n=`expr $(MAX_SIZE) / 1024` && echo $$(($$n)) || echo 0))
+	$(eval BOOT_SECTION_SIZE_KB=$(shell n=`expr  $(BOOTLOADER_SIZE) / 1024` && echo $$(($$n)) || echo 0))
+	$(eval FLASH_SIZE_KB=$(shell n=`expr $(PROGRAM_SIZE_KB) + $(BOOT_SECTION_SIZE_KB)` && echo $$(($$n)) || echo 0))
+	make -C lib/lufa/Bootloaders/HID/ MCU=$(MCU) ARCH=$(ARCH) F_CPU=$(F_CPU) FLASH_SIZE_KB=$(FLASH_SIZE_KB) BOOT_SECTION_SIZE_KB=$(BOOT_SECTION_SIZE_KB)
+	printf "BootloaderHID.hex copied to $(TARGET)_bootloader.hex\n"
+	cp lib/lufa/Bootloaders/HID/BootloaderHID.hex $(TARGET)_bootloader.hex
+else
+	$(error Please set BOOTLOADER to "qmk-dfu" or "qmk-hid" first!)
+endif
 
 production: $(BUILD_DIR)/$(TARGET).hex bootloader cpfirmware
 	@cat $(BUILD_DIR)/$(TARGET).hex | awk '/^:00000001FF/ == 0' > $(TARGET)_production.hex

--- a/tmk_core/avr.mk
+++ b/tmk_core/avr.mk
@@ -237,7 +237,6 @@ endef
 bootloadHID: $(BUILD_DIR)/$(TARGET).hex check-size cpfirmware
 	$(call EXEC_BOOTLOADHID)
 
-
 HID_BOOTLOADER_CLI ?= hid_bootloader_cli
 
 define EXEC_HID_LUFA
@@ -304,8 +303,6 @@ coff: $(BUILD_DIR)/$(TARGET).elf
 extcoff: $(BUILD_DIR)/$(TARGET).elf
 	@$(SECHO) $(MSG_EXTENDED_COFF) $(BUILD_DIR)/$(TARGET).cof
 	$(COFFCONVERT) -O coff-ext-avr $< $(BUILD_DIR)/$(TARGET).cof
-
-
 
 ifeq ($(strip $(BOOTLOADER)), qmk-dfu)
 QMK_BOOTLOADER_TYPE = DFU

--- a/tmk_core/avr.mk
+++ b/tmk_core/avr.mk
@@ -237,6 +237,16 @@ endef
 bootloadHID: $(BUILD_DIR)/$(TARGET).hex check-size cpfirmware
 	$(call EXEC_BOOTLOADHID)
 
+
+HID_BOOTLOADER_CLI ?= hid_bootloader_cli
+
+define EXEC_HID_LUFA
+	$(HID_BOOTLOADER_CLI) -mmcu=$(MCU) -w -v $(BUILD_DIR)/$(TARGET).hex
+endef
+
+hid_bootloader: $(BUILD_DIR)/$(TARGET).hex check-size cpfirmware
+	$(call EXEC_HID_LUFA)
+
 # Convert hex to bin.
 bin: $(BUILD_DIR)/$(TARGET).hex
 	$(OBJCOPY) -Iihex -Obinary $(BUILD_DIR)/$(TARGET).hex $(BUILD_DIR)/$(TARGET).bin
@@ -337,6 +347,8 @@ else ifeq ($(strip $(BOOTLOADER)), USBasp)
 	$(call EXEC_USBASP)
 else ifeq ($(strip $(BOOTLOADER)), bootloadHID)
 	$(call EXEC_BOOTLOADHID)
+else ifeq ($(strip $(BOOTLOADER)), qmk-hid)
+	$(call EXEC_HID_LUFA)
 else
 	$(PRINT_OK); $(SILENT) || printf "$(MSG_FLASH_BOOTLOADER)"
 endif


### PR DESCRIPTION
## Description

Like the title says. 
Updates LUFA to the latest version, as well as adds support for generating the lufa HID bootloader, as well as flashing it.

## Types of Changes

- [x] Core
- [x] New feature
- [x] Enhancement/optimization
- [ ] Documentation


## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
