### PR TITLE
Fixup Audio startup and add to documents

### DIFF
--- a/docs/feature_audio.md
+++ b/docs/feature_audio.md
@@ -169,29 +169,29 @@ The available keycodes for audio are:
 
 ## Audio Config
 
-| Settings                        | Default              | Description                                                              |
-|---------------------------------|----------------------|--------------------------------------------------------------------------|
-|`AUDIO_PIN`                      | *Not defined*        |Configures the pin that the Solenoid is connected to.                     |
-|`AUDIO_PIN_ALT`                  | *Not defined*        |Configures the default dwell time for the solenoid.                       |
-|`AUDIO_PIN_ALT_AS_NEGATIVE`      | *Not defined*        |Sets the lower limit for the dwell.                                       |
-|`AUDIO_INIT_DELAY`               | *Not defined*        |Enables delay during startup song to accomidate for USB startup issues    |
-|`AUDIO_ENABLE_TONE_MULTIPLEXING` | *Not defined*        |Enables time splicing/multiplexing to create multiple tones simutaneously |
-|`STARTUP_SONG`                   | `STARTUP_SOUND`      |Plays when the keyboard starts up (audio.c)                               |
-|`GOODBYE_SONG`                   | `GOODBYE_SOUND`      |Plays when you press the RESET key (quantum.c)                            |
-|`AG_NORM_SONG`                   | `AG_NORM_SOUND`      |Plays when you press AG_NORM (process_magic.c)                            |
-|`AG_SWAP_SONG`                   | `AG_SWAP_SOUND`      |Plays when you press AG_SWAP (process_magic.c)                            |
-|`CG_NORM_SONG`                   | `AG_NORM_SOUND`      |Plays when you press CG_NORM (process_magic.c)                            |
-|`CG_SWAP_SONG`                   | `AG_SWAP_SOUND`      |Plays when you press CG_SWAP (process_magic.c)                            |
-|`MUSIC_ON_SONG`                  | `MUSIC_ON_SOUND`     |Plays when music mode is activated (process_music.c)                      |
-|`MUSIC_OFF_SONG`                 | `MUSIC_OFF_SOUND`    |Plays when music mode is deactivated (process_music.c)                    |
-|`MIDI_ON_SONG`                   | `MUSIC_ON_SOUND`     |Plays when midi mode is activated (process_music.c)                       |
-|`MIDI_OFF_SONG`                  | `MUSIC_OFF_SOUND`    |Plays when midi mode is deactivated (process_music.c)                     |
-|`CHROMATIC_SONG`                 | `CHROMATIC_SOUND`    |Plays when the chromatic music mode is selected (process_music.c)         |
-|`GUITAR_SONG`                    | `GUITAR_SOUND`       |Plays when the guitar music mode is selected (process_music.c)            |
-|`VIOLIN_SONG`                    | `VIOLIN_SOUND`       |Plays when the violin music mode is selected (process_music.c)            |
-|`MAJOR_SONG`                     | `MAJOR_SOUND`        |Plays when the major music mode is selected (process_music.c)             |
+| Settings                        | Default              | Description                                                                   |
+|---------------------------------|----------------------|-------------------------------------------------------------------------------|
+|`AUDIO_PIN`                      | *Not defined*        |Configures the pin that the speaker is connected to.                           |
+|`AUDIO_PIN_ALT`                  | *Not defined*        |Configures the pin for a second speaker or second pin connected to one speaker.|
+|`AUDIO_PIN_ALT_AS_NEGATIVE`      | *Not defined*        |Enables support for one speaker connected to two pins.                         |
+|`AUDIO_INIT_DELAY`               | *Not defined*        |Enables delay during startup song to accomidate for USB startup issues.        |
+|`AUDIO_ENABLE_TONE_MULTIPLEXING` | *Not defined*        |Enables time splicing/multiplexing to create multiple tones simutaneously.     |
+|`STARTUP_SONG`                   | `STARTUP_SOUND`      |Plays when the keyboard starts up (audio.c)                                    |
+|`GOODBYE_SONG`                   | `GOODBYE_SOUND`      |Plays when you press the RESET key (quantum.c)                                 |
+|`AG_NORM_SONG`                   | `AG_NORM_SOUND`      |Plays when you press AG_NORM (process_magic.c)                                 |
+|`AG_SWAP_SONG`                   | `AG_SWAP_SOUND`      |Plays when you press AG_SWAP (process_magic.c)                                 |
+|`CG_NORM_SONG`                   | `AG_NORM_SOUND`      |Plays when you press CG_NORM (process_magic.c)                                 |
+|`CG_SWAP_SONG`                   | `AG_SWAP_SOUND`      |Plays when you press CG_SWAP (process_magic.c)                                 |
+|`MUSIC_ON_SONG`                  | `MUSIC_ON_SOUND`     |Plays when music mode is activated (process_music.c)                           |
+|`MUSIC_OFF_SONG`                 | `MUSIC_OFF_SOUND`    |Plays when music mode is deactivated (process_music.c)                         |
+|`MIDI_ON_SONG`                   | `MUSIC_ON_SOUND`     |Plays when midi mode is activated (process_music.c)                            |
+|`MIDI_OFF_SONG`                  | `MUSIC_OFF_SOUND`    |Plays when midi mode is deactivated (process_music.c)                          |
+|`CHROMATIC_SONG`                 | `CHROMATIC_SOUND`    |Plays when the chromatic music mode is selected (process_music.c)              |
+|`GUITAR_SONG`                    | `GUITAR_SOUND`       |Plays when the guitar music mode is selected (process_music.c)                 |
+|`VIOLIN_SONG`                    | `VIOLIN_SOUND`       |Plays when the violin music mode is selected (process_music.c)                 |
+|`MAJOR_SONG`                     | `MAJOR_SOUND`        |Plays when the major music mode is selected (process_music.c)                  |
 |`DEFAULT_LAYER_SONGS`            | *Not defined*        |Plays song when switched default layers with [`set_single_persistent_default_layer(layer)`](ref_functions.md#setting-the-persistent-default-layer)(quantum.c)       |
-|`SENDSTRING_BELL`                | *Not defined*        |Plays chime when the "enter" ("\a") character is sent (send_string.c)     |
+|`SENDSTRING_BELL`                | *Not defined*        |Plays chime when the "enter" ("\a") character is sent (send_string.c)          |
 
 ## Tempo
 the 'speed' at which SONGs are played is dictated by the set Tempo, which is measured in beats-per-minute. Note lengths are defined relative to that.

--- a/docs/feature_audio.md
+++ b/docs/feature_audio.md
@@ -167,6 +167,32 @@ The available keycodes for audio are:
 
 !> These keycodes turn all of the audio functionality on and off.  Turning it off means that audio feedback, audio clicky, music mode, etc. are disabled, completely.
 
+## Audio Config
+
+| Settings                        | Default              | Description                                                              |
+|---------------------------------|----------------------|--------------------------------------------------------------------------|
+|`AUDIO_PIN`                      | *Not defined*        |Configures the pin that the Solenoid is connected to.                     |
+|`AUDIO_PIN_ALT`                  | *Not defined*        |Configures the default dwell time for the solenoid.                       |
+|`AUDIO_PIN_ALT_AS_NEGATIVE`      | *Not defined*        |Sets the lower limit for the dwell.                                       |
+|`AUDIO_INIT_DELAY`               | *Not defined*        |Enables delay during startup song to accomidate for USB startup issues    |
+|`AUDIO_ENABLE_TONE_MULTIPLEXING` | *Not defined*        |Enables time splicing/multiplexing to create multiple tones simutaneously |
+|`STARTUP_SONG`                   | `STARTUP_SOUND`      |Plays when the keyboard starts up (audio.c)                               |
+|`GOODBYE_SONG`                   | `GOODBYE_SOUND`      |Plays when you press the RESET key (quantum.c)                            |
+|`AG_NORM_SONG`                   | `AG_NORM_SOUND`      |Plays when you press AG_NORM (process_magic.c)                            |
+|`AG_SWAP_SONG`                   | `AG_SWAP_SOUND`      |Plays when you press AG_SWAP (process_magic.c)                            |
+|`CG_NORM_SONG`                   | `AG_NORM_SOUND`      |Plays when you press CG_NORM (process_magic.c)                            |
+|`CG_SWAP_SONG`                   | `AG_SWAP_SOUND`      |Plays when you press CG_SWAP (process_magic.c)                            |
+|`MUSIC_ON_SONG`                  | `MUSIC_ON_SOUND`     |Plays when music mode is activated (process_music.c)                      |
+|`MUSIC_OFF_SONG`                 | `MUSIC_OFF_SOUND`    |Plays when music mode is deactivated (process_music.c)                    |
+|`MIDI_ON_SONG`                   | `MUSIC_ON_SOUND`     |Plays when midi mode is activated (process_music.c)                       |
+|`MIDI_OFF_SONG`                  | `MUSIC_OFF_SOUND`    |Plays when midi mode is deactivated (process_music.c)                     |
+|`CHROMATIC_SONG`                 | `CHROMATIC_SOUND`    |Plays when the chromatic music mode is selected (process_music.c)         |
+|`GUITAR_SONG`                    | `GUITAR_SOUND`       |Plays when the guitar music mode is selected (process_music.c)            |
+|`VIOLIN_SONG`                    | `VIOLIN_SOUND`       |Plays when the violin music mode is selected (process_music.c)            |
+|`MAJOR_SONG`                     | `MAJOR_SOUND`        |Plays when the major music mode is selected (process_music.c)             |
+|`DEFAULT_LAYER_SONGS`            | *Not defined*        |Plays song when switched default layers with [`set_single_persistent_default_layer(layer)`](ref_functions.md#setting-the-persistent-default-layer)(quantum.c)       |
+|`SENDSTRING_BELL`                | *Not defined*        |Plays chime when the "enter" ("\a") character is sent (send_string.c)     |
+
 ## Tempo
 the 'speed' at which SONGs are played is dictated by the set Tempo, which is measured in beats-per-minute. Note lengths are defined relative to that.
 The initial/default tempo is set to 120 bpm, but can be configured by setting `TEMPO_DEFAULT` in `config.c`.

--- a/quantum/audio/audio.c
+++ b/quantum/audio/audio.c
@@ -139,6 +139,9 @@ void audio_init() {
         audio_initialized = true;
     }
     stop_all_notes();
+#ifndef AUDIO_INIT_DELAY
+    audio_startup();
+#endif
 }
 
 void audio_startup(void) {

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -398,7 +398,7 @@ void matrix_init_quantum() {
 }
 
 void matrix_scan_quantum() {
-#if defined(AUDIO_ENABLE)
+#if defined(AUDIO_ENABLE) && defined(AUDIO_INIT_DELAY)
     // There are some tasks that need to be run a little bit
     // after keyboard startup, or else they will not work correctly
     // because of interaction with the USB device state, which


### PR DESCRIPTION
## Description

#11553 changed the location that the audio startup code was called (eg the code that plays the startup chime), due to issues with timing issues with the suspend code for the board and the audio. 

Unfortunately, this can cause the startup sound to simply not play at all, or to play a note or two, but nothing else.  	Reverting the change fixes the issue, but then potentially re-introduces the previous issue. 

This adds a define that allows for users to choose between which situation, until a better fix can be found.

## Types of Changes

- [x] Core
- [x] Bugfix
- [x] Enhancement/optimization
- [x] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
