### PR TITLE
Add Encoder Matrix support

### DIFF
--- a/quantum/encoder.c
+++ b/quantum/encoder.c
@@ -38,8 +38,8 @@
 static pin_t encoder_row_pins[] = ENCODER_ROW_PINS;
 static pin_t encoder_col_pins[] = ENCODER_COL_PINS;
 
-static encoder_pin_pair_t PROGMEM encoders_pad_a[] = ENCODERS_PAD_A;
-static encoder_pin_pair_t PROGMEM encoders_pad_b[] = ENCODERS_PAD_B;
+static const encoder_pin_pair_t PROGMEM encoders_pad_a[] = ENCODERS_PAD_A;
+static const encoder_pin_pair_t PROGMEM encoders_pad_b[] = ENCODERS_PAD_B;
 /* max 32 cols for now */
 static uint32_t encoder_matrix[ENCODER_ROWS];
 

--- a/quantum/encoder.c
+++ b/quantum/encoder.c
@@ -110,8 +110,12 @@ void encoder_init(void) {
 #endif
 
 #ifdef ENCODER_MATRIX
-    for (size_t i = 0; i < ENCODER_ROWS; ++i) setPinInputHigh_atomic(encoder_row_pins[i]);
-    for (size_t i = 0; i < ENCODER_COLS; ++i) setPinInputHigh_atomic(encoder_col_pins[i]);
+    for (size_t i = 0; i < ENCODER_ROWS; ++i) {
+        setPinInputHigh_atomic(encoder_row_pins[i]);
+    }
+    for (size_t i = 0; i < ENCODER_COLS; ++i) {
+        setPinInputHigh_atomic(encoder_col_pins[i]);
+    }
 #else
     for (int i = 0; i < NUMBER_OF_ENCODERS; i++) {
         setPinInputHigh(encoders_pad_a[i]);
@@ -163,7 +167,7 @@ static bool encoder_update(uint8_t index, uint8_t state) {
 #ifdef ENCODER_MATRIX
 static void encoder_matrix_read_row(size_t row) {
     setPinOutput_writeLow(encoder_row_pins[row]);
-    matrix_io_delay();
+    matrix_output_select_delay();
 
     uint32_t line = 0;
     for (size_t col = 0; col < ENCODER_COLS; ++col) {
@@ -172,7 +176,7 @@ static void encoder_matrix_read_row(size_t row) {
     }
 
     setPinInputHigh_atomic(encoder_row_pins[row]);
-    matrix_io_delay();
+    matrix_output_select_delay();
 
     encoder_matrix[row] = line;
 }

--- a/quantum/encoder.h
+++ b/quantum/encoder.h
@@ -29,3 +29,10 @@ bool encoder_update_user(uint8_t index, bool clockwise);
 void encoder_state_raw(uint8_t* slave_state);
 void encoder_update_raw(uint8_t* slave_state);
 #endif
+
+#ifdef ENCODER_MATRIX
+typedef struct {
+    uint8_t row;
+    uint8_t col;
+} encoder_pin_pair_t;
+#endif


### PR DESCRIPTION

## Description

Add support for using encoders in a matrix, rather than connecting directly to GPIO pins. 

## Types of Changes

- [x] Core
- [x] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

* Closes #7209

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
