### PR TITLE
Fix API generation failure caused by GRS-70EC

### DIFF
--- a/keyboards/sekigon/grs_70ec/config.h
+++ b/keyboards/sekigon/grs_70ec/config.h
@@ -45,7 +45,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
 #define MATRIX_ROW_PINS { C6, D7, E6, B4, B5 }
-#define MATRIX_COL_PINS { S2, S1, S0, S3, S5, S7, S6, S4 }
+#define MATRIX_COL_CHANNELS { 2, 1, 0, 3, 5, 7, 6, 4 }
 #define UNUSED_PINS
 #define DISCHARGE_PIN B1
 #define ANALOG_PORT F6

--- a/keyboards/sekigon/grs_70ec/ec_switch_matrix.c
+++ b/keyboards/sekigon/grs_70ec/ec_switch_matrix.c
@@ -20,19 +20,9 @@
 #include "analog.h"
 #include "print.h"
 
-// sensing channel definitions
-#define S0 0
-#define S1 1
-#define S2 2
-#define S3 3
-#define S4 4
-#define S5 5
-#define S6 6
-#define S7 7
-
 // pin connections
 const uint8_t row_pins[]     = MATRIX_ROW_PINS;
-const uint8_t col_channels[] = MATRIX_COL_PINS;
+const uint8_t col_channels[] = MATRIX_COL_CHANNELS;
 const uint8_t mux_sel_pins[] = MUX_SEL_PINS;
 
 _Static_assert(sizeof(mux_sel_pins) == 3, "invalid MUX_SEL_PINS");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

@sekigon-gonnoc

https://github.com/qmk/qmk_firmware/runs/3126472278
```
ValueError: Invalid pin: S2
Error: Process completed with exit code 255.
```

`qmk generate-api` on develop is a little more forgiving (at least it catches the error):
```
☒ Invalid API data: sekigon/grs_70ec: matrix_pins.cols.0: 'S2' is not valid under any of the given schemas
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
