### PR TITLE
Fix errors with `matrix_output_unselect_delay` function calls

### DIFF
--- a/keyboards/handwired/symmetric70_proto/matrix_debug/matrix.c
+++ b/keyboards/handwired/symmetric70_proto/matrix_debug/matrix.c
@@ -32,7 +32,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    define MATRIX_DEBUG_DELAY_END()
 #    define MATRIX_DEBUG_GAP()
 #else
-#    define MATRIX_DEBUG_GAP()  asm volatile("nop \n nop":::"memory")
+#    define MATRIX_DEBUG_GAP() asm volatile("nop \n nop" ::: "memory")
 #endif
 
 #ifndef MATRIX_IO_DELAY_ALWAYS
@@ -44,16 +44,16 @@ static pin_t direct_pins[MATRIX_ROWS][MATRIX_COLS] = DIRECT_PINS;
 #elif (DIODE_DIRECTION == ROW2COL) || (DIODE_DIRECTION == COL2ROW)
 static const pin_t row_pins[MATRIX_ROWS] = MATRIX_ROW_PINS;
 static const pin_t col_pins[MATRIX_COLS] = MATRIX_COL_PINS;
-#  ifdef MATRIX_MUL_SELECT
-static const pin_t col_sel[MATRIX_COLS] = MATRIX_MUL_SEL;
-#  endif
+#    ifdef MATRIX_MUL_SELECT
+static const pin_t col_sel[MATRIX_COLS]  = MATRIX_MUL_SEL;
+#    endif
 #endif
 
 #ifdef MATRIX_IO_DELAY_PORTS
-static const pin_t delay_ports[] = { MATRIX_IO_DELAY_PORTS };
-static const port_data_t delay_masks[] = { MATRIX_IO_DELAY_MASKS };
+static const pin_t       delay_ports[] = {MATRIX_IO_DELAY_PORTS};
+static const port_data_t delay_masks[] = {MATRIX_IO_DELAY_MASKS};
 #    ifdef MATRIX_IO_DELAY_MULSEL
-static const uint8_t delay_sel[] = { MATRIX_IO_DELAY_MULSEL };
+static const uint8_t delay_sel[] = {MATRIX_IO_DELAY_MULSEL};
 #    endif
 #endif
 
@@ -120,10 +120,10 @@ static void unselect_rows(void) {
 }
 
 static void init_pins(void) {
-#ifdef MATRIX_MUL_SELECT
+#        ifdef MATRIX_MUL_SELECT
     setPinOutput(MATRIX_MUL_SELECT);
     writePinLow(MATRIX_MUL_SELECT);
-#endif
+#        endif
     unselect_rows();
     for (uint8_t x = 0; x < MATRIX_COLS; x++) {
         setPinInputHigh_atomic(col_pins[x]);
@@ -141,10 +141,10 @@ static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
     // For each col...
     for (uint8_t col_index = 0; col_index < MATRIX_COLS; col_index++) {
         // Select the col pin to read (active low)
-#ifdef MATRIX_MUL_SELECT
-        writePin(MATRIX_MUL_SELECT,col_sel[col_index]);
+#        ifdef MATRIX_MUL_SELECT
+        writePin(MATRIX_MUL_SELECT, col_sel[col_index]);
         waitInputPinDelay();
-#endif
+#        endif
         uint8_t pin_state = readPin(col_pins[col_index]);
 
         // Populate the matrix row with the state of the col pin
@@ -153,37 +153,38 @@ static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
 
     // Unselect row
     unselect_row(current_row);
-#ifdef MATRIX_IO_DELAY_PORTS
+#        ifdef MATRIX_IO_DELAY_PORTS
     if (current_row_value) {  // wait for col signal to go HIGH
         bool is_pressed;
         do {
             MATRIX_DEBUG_DELAY_START();
             is_pressed = false;
-            for (uint8_t i = 0; i < sizeof(delay_ports)/sizeof(pin_t); i++ ) {
-#    ifdef MATRIX_IO_DELAY_MULSEL
+            for (uint8_t i = 0; i < sizeof(delay_ports) / sizeof(pin_t); i++) {
+#            ifdef MATRIX_IO_DELAY_MULSEL
                 writePin(MATRIX_MUL_SELECT, delay_sel[i]);
                 waitInputPinDelay();
-#    endif
-                is_pressed |= ( (readPort(delay_ports[i]) & delay_masks[i]) != delay_masks[i] );
+#            endif
+                is_pressed |= ((readPort(delay_ports[i]) & delay_masks[i]) != delay_masks[i]);
             }
             MATRIX_DEBUG_DELAY_END();
         } while (is_pressed);
     }
-#endif
-#ifdef MATRIX_IO_DELAY_ADAPTIVE
+#        endif
+#        ifdef MATRIX_IO_DELAY_ADAPTIVE
     if (current_row_value) {  // wait for col signal to go HIGH
         for (uint8_t col_index = 0; col_index < MATRIX_COLS; col_index++) {
             MATRIX_DEBUG_DELAY_START();
-#ifdef MATRIX_MUL_SELECT
-            writePin(MATRIX_MUL_SELECT,col_sel[col_index]);
+#            ifdef MATRIX_MUL_SELECT
+            writePin(MATRIX_MUL_SELECT, col_sel[col_index]);
             waitInputPinDelay();
-#endif
-            while (readPin(col_pins[col_index]) == 0) {}
+#            endif
+            while (readPin(col_pins[col_index]) == 0) {
+            }
             MATRIX_DEBUG_DELAY_END();
         }
     }
-#endif
-#ifdef MATRIX_IO_DELAY_ADAPTIVE2
+#        endif
+#        ifdef MATRIX_IO_DELAY_ADAPTIVE2
     if (current_row_value) {  // wait for col signal to go HIGH
         pin_t state;
         do {
@@ -192,19 +193,19 @@ static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
             for (uint8_t col_index = 0; col_index < MATRIX_COLS; col_index++) {
                 MATRIX_DEBUG_DELAY_END();
                 MATRIX_DEBUG_DELAY_START();
-#ifdef MATRIX_MUL_SELECT
-                writePin(MATRIX_MUL_SELECT,col_sel[col_index]);
+#            ifdef MATRIX_MUL_SELECT
+                writePin(MATRIX_MUL_SELECT, col_sel[col_index]);
                 waitInputPinDelay();
-#endif
+#            endif
                 state |= (readPin(col_pins[col_index]) == 0);
             }
             MATRIX_DEBUG_DELAY_END();
         } while (state);
     }
-#endif
+#        endif
     if (MATRIX_IO_DELAY_ALWAYS || current_row + 1 < MATRIX_ROWS) {
         MATRIX_DEBUG_DELAY_START();
-        matrix_output_unselect_delay();  // wait for col signal to go HIGH
+        matrix_output_unselect_delay(current_row, current_row_value != 0);
         MATRIX_DEBUG_DELAY_END();
     }
 
@@ -267,7 +268,7 @@ static bool read_rows_on_col(matrix_row_t current_matrix[], uint8_t current_col)
     // Unselect col
     unselect_col(current_col);
     if (MATRIX_IO_DELAY_ALWAYS || current_col + 1 < MATRIX_COLS) {
-        matrix_output_unselect_delay();  // wait for col signal to go HIGH
+        matrix_output_unselect_delay(current_row, current_row_value != 0);
     }
 
     return matrix_changed;
@@ -311,11 +312,13 @@ uint8_t matrix_scan(void) {
         changed |= read_rows_on_col(raw_matrix, current_col);
     }
 #endif
-    MATRIX_DEBUG_SCAN_END(); MATRIX_DEBUG_GAP();
+    MATRIX_DEBUG_SCAN_END();
+    MATRIX_DEBUG_GAP();
 
     MATRIX_DEBUG_SCAN_START();
     debounce(raw_matrix, matrix, MATRIX_ROWS, changed);
-    MATRIX_DEBUG_SCAN_END(); MATRIX_DEBUG_GAP();
+    MATRIX_DEBUG_SCAN_END();
+    MATRIX_DEBUG_GAP();
 
     MATRIX_DEBUG_SCAN_START();
     matrix_scan_quantum();

--- a/keyboards/handwired/symmetric70_proto/proton_c/proton_c.c
+++ b/keyboards/handwired/symmetric70_proto/proton_c/proton_c.c
@@ -4,9 +4,9 @@
 /* In tmk_core/common/wait.h, the implementation for PROTOCOL_CHIBIOS
  * calls 'chThdSleepMicroseconds(1)' when 'wait_us(0)'.
  * However, 'wait_us(0)' should do nothing. */
-void matrix_output_unselect_delay(void) {
-#   if !defined(MATRIX_IO_DELAY) || MATRIX_IO_DELAY > 0
+void matrix_output_unselect_delay(uint8_t line, bool key_pressed) {
+#    if !defined(MATRIX_IO_DELAY) || MATRIX_IO_DELAY > 0
     matrix_io_delay();
-#   endif
+#    endif
 }
 #endif

--- a/keyboards/kinesis/kint41/kint41.c
+++ b/keyboards/kinesis/kint41/kint41.c
@@ -32,21 +32,21 @@ void matrix_init_kb(void) {
 // ChibiOS enables the cycle counter in chcore_v7m.c:
 // https://github.com/ChibiOS/ChibiOS/blob/b63023915c304092acb9f33bbab40f3ec07a7f0e/os/common/ports/ARMCMx/chcore_v7m.c#L263
 static void delay_inline(const uint32_t cycles) {
-  const uint32_t start = DWT->CYCCNT;
-  while ((DWT->CYCCNT - start) < cycles) {
-    // busy-loop until time has passed
-  }
+    const uint32_t start = DWT->CYCCNT;
+    while ((DWT->CYCCNT - start) < cycles) {
+        // busy-loop until time has passed
+    }
 }
 
-void matrix_output_unselect_delay(void) {
-  // Use the cycle counter to do precise timing in microseconds. The ChibiOS
-  // thread sleep functions only allow sleep durations starting at 1 tick, which
-  // is 100μs in our configuration.
+void matrix_output_unselect_delay(uint8_t line, bool key_pressed) {
+    // Use the cycle counter to do precise timing in microseconds. The ChibiOS
+    // thread sleep functions only allow sleep durations starting at 1 tick, which
+    // is 100μs in our configuration.
 
-  // Empirically: e.g. 5μs is not enough, will result in keys that don’t work
-  // and ghost key presses. 10μs seems to work well.
+    // Empirically: e.g. 5μs is not enough, will result in keys that don’t work
+    // and ghost key presses. 10μs seems to work well.
 
-  // 600 cycles at 0.6 cycles/ns == 1μs
-  const uint32_t cycles_per_us = 600;
-  delay_inline(10 * cycles_per_us);
+    // 600 cycles at 0.6 cycles/ns == 1μs
+    const uint32_t cycles_per_us = 600;
+    delay_inline(10 * cycles_per_us);
 }

--- a/keyboards/rgbkb/mun/matrix.c
+++ b/keyboards/rgbkb/mun/matrix.c
@@ -19,7 +19,7 @@
 #include "transactions.h"
 
 #define ERROR_DISCONNECT_COUNT 5
-#define ROWS_PER_HAND (MATRIX_ROWS / 2)
+#define ROWS_PER_HAND          (MATRIX_ROWS / 2)
 
 static const pin_t row_pins[ROWS_PER_HAND] = MATRIX_ROW_PINS;
 static const pin_t col_pins[MATRIX_COLS]   = MATRIX_COL_PINS;
@@ -141,7 +141,7 @@ uint8_t matrix_scan(void) {
 
         /* Drive row pin high again. */
         ATOMIC_BLOCK_FORCEON { writePinHigh(row_pins[row_idx]); }
-        matrix_output_unselect_delay();
+        matrix_output_unselect_delay(row_idx, row_pins[row_idx] != 0);
     }
 
     if (memcmp(raw_matrix, current_matrix, sizeof(current_matrix)) != 0) {

--- a/keyboards/rgbkb/mun/mun.c
+++ b/keyboards/rgbkb/mun/mun.c
@@ -12,22 +12,20 @@
 #include "common_oled.h"
 #include <transactions.h>
 
-void keyboard_post_init_kb(void)
-{
+void keyboard_post_init_kb(void) {
     touch_encoder_init();
     transaction_register_rpc(TOUCH_ENCODER_SYNC, touch_encoder_slave_sync);
     transaction_register_rpc(RGB_MENU_SYNC, rgb_menu_slave_sync);
     keyboard_post_init_user();
 }
 
-void housekeeping_task_kb(void)
-{
+void housekeeping_task_kb(void) {
     touch_encoder_update(TOUCH_ENCODER_SYNC);
     rgb_menu_update(RGB_MENU_SYNC);
 }
 
 #if defined(BUSY_WAIT)
-void matrix_output_unselect_delay(void) {
+void matrix_output_unselect_delay(uint8_t line, bool key_pressed) {
     for (int32_t i = 0; i < BUSY_WAIT_INSTRUCTIONS; i++) {
         __asm__ volatile("nop" ::: "memory");
     }


### PR DESCRIPTION
## Description

Fir the function call for boards using `matrix_output_unselect_delay`.

## Types of Changes

- [x] Bugfix
- [x] Keyboard (addition or update)

## Issues Fixed or Closed by This PR

* Compilation issues 

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
