### PR TITLE
Simplify add_key_byte() when USB_6KRO_ENABLE isn't defined

### DIFF
--- a/tmk_core/common/report.c
+++ b/tmk_core/common/report.c
@@ -143,19 +143,10 @@ void add_key_byte(report_keyboard_t* keyboard_report, uint8_t code) {
     cb_tail                        = RO_INC(cb_tail);
     cb_count++;
 #else
-    int8_t i     = 0;
-    int8_t empty = -1;
-    for (; i < KEYBOARD_REPORT_KEYS; i++) {
-        if (keyboard_report->keys[i] == code) {
+    for (uint8_t i = 0; i < KEYBOARD_REPORT_KEYS && keyboard_report->keys[i] != code; i++) {
+        if (keyboard_report->keys[i] == 0) {
+            keyboard_report->keys[i] = code;
             break;
-        }
-        if (empty == -1 && keyboard_report->keys[i] == 0) {
-            empty = i;
-        }
-    }
-    if (i == KEYBOARD_REPORT_KEYS) {
-        if (empty != -1) {
-            keyboard_report->keys[empty] = code;
         }
     }
 #endif


### PR DESCRIPTION
## Description

_Note: this is my first PR for QMK, so please don't hesitate to tell me if anything needs changes._

Just like the title says, this PR simplifies `add_key_byte()` when `USB_6KRO_ENABLE` isn't defined.
This saves 10 firmware bytes on AVR (tested with GCC 8.4.0 on macOS with LTO enabled), and probably a few stack bytes and CPU cycles too (although I don't understand AVR ASM well enough to make sure of that).
I've been using this code on my boards for a few days without any issues.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

None.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
