### PR TITLE
Fix dc01/left so that it doesn't throw a warning

### DIFF
--- a/keyboards/dc01/left/config.h
+++ b/keyboards/dc01/left/config.h
@@ -42,7 +42,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
 */
 #define MATRIX_ROW_PINS { B6, B5, B4, D7, D6 }
-#define MATRIX_COL_PINS { F4, F1, F0, F7, F6, F5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
+#define MATRIX_COL_PINS { F4, F1, F0, F7, F6, F5, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN }
 #define UNUSED_PINS
 
 #define F_SCL 350000UL

--- a/keyboards/dc01/left/config.h
+++ b/keyboards/dc01/left/config.h
@@ -42,7 +42,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
 */
 #define MATRIX_ROW_PINS { B6, B5, B4, D7, D6 }
-#define MATRIX_COL_PINS { F4, F1, F0, F7, F6, F5 }
+#define MATRIX_COL_PINS { F4, F1, F0, F7, F6, F5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
 #define UNUSED_PINS
 
 #define F_SCL 350000UL

--- a/keyboards/dc01/left/matrix.c
+++ b/keyboards/dc01/left/matrix.c
@@ -26,6 +26,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "wait.h"
 #include "print.h"
 #include "debug.h"
+#include "gpio.h"
 #include "util.h"
 #include "matrix.h"
 #include "timer.h"

--- a/keyboards/dc01/left/matrix.c
+++ b/keyboards/dc01/left/matrix.c
@@ -71,7 +71,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #if (DIODE_DIRECTION == ROW2COL) || (DIODE_DIRECTION == COL2ROW)
 static const uint8_t row_pins[MATRIX_ROWS] = MATRIX_ROW_PINS;
-static const uint8_t col_pins[MATRIX_COLS_SCANNED] = MATRIX_COL_PINS;
+static const uint8_t col_pins[MATRIX_COLS] = MATRIX_COL_PINS;
 #endif
 
 /* matrix state(1:on, 0:off) */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Fixes this error:

    ☒ dc01/left: MATRIX_COLS is inconsistent with the size of MATRIX_COL_PINS: 6 != 21

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Keyboard (addition or update)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
