### PR TITLE
[Keyboard] Enable LTO by default on BastardKB Scylla

### DIFF
--- a/keyboards/bastardkb/scylla/rules.mk
+++ b/keyboards/bastardkb/scylla/rules.mk
@@ -23,3 +23,4 @@ RGB_MATRIX_DRIVER = WS2812  # RGB matrix driver support
 BLUETOOTH_ENABLE = no       # Enable Bluetooth
 AUDIO_ENABLE = no           # Audio output
 SPLIT_KEYBOARD = yes
+LTO_ENABLE = yes


### PR DESCRIPTION
To reduce it's size so it will compile

## Types of Changes

- [x] Enhancement/optimization
- [x] Keyboard (addition or update)


## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
