### PR TITLE
[Keyboard] Quick hack to fix Astro65 board

### DIFF
--- a/keyboards/handwired/swiftrax/astro65/config.h
+++ b/keyboards/handwired/swiftrax/astro65/config.h
@@ -26,13 +26,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MANUFACTURER    Swiftrax
 #define PRODUCT         Astro65
 /* key matrix size */
-#define MATRIX_ROWS 5
-#define MATRIX_COLS 15
+#define MATRIX_ROWS     5
+#define MATRIX_COLS     16
 
 // ROWS: Top to bottom, COLS: Left to right
 
-#define MATRIX_ROW_PINS { B0, B3, F7, B1, B2 }
-#define MATRIX_COL_PINS { E6, D5, C7, C6, B6, B5, B4, D7, D6, D4, F0, F1, F4, F5, F6 }
+#define MATRIX_ROW_PINS \
+    { B0, B3, F7, B1, B2 }
+#define MATRIX_COL_PINS \
+    { E6, D5, C7, C6, B6, B5, B4, D7, D6, D4, F0, F1, F4, F5, F6, NO_PIN }
 
 /* COL2ROW or ROW2COL */
 #define DIODE_DIRECTION COL2ROW

--- a/keyboards/handwired/swiftrax/astro65/config.h
+++ b/keyboards/handwired/swiftrax/astro65/config.h
@@ -34,7 +34,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MATRIX_ROW_PINS \
     { B0, B3, F7, B1, B2 }
 #define MATRIX_COL_PINS \
-    { E6, D5, C7, C6, B6, B5, B4, D7, D6, D4, F0, F1, F4, F5, F6, NO_PIN }
+    { E6, D5, D3, D4, D6, D7, B4, B5, B6, C6, C7, F6, F5, F4, F1, F0 }
 
 /* COL2ROW or ROW2COL */
 #define DIODE_DIRECTION COL2ROW


### PR DESCRIPTION
## Description

Fix column num, and add `NO_PIN` until it can be properly fixed.

## Types of Changes

- [x] Bugfix
- [x] Keyboard (addition or update)

## Issues Fixed or Closed by This PR

* Fix CI compiler

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
