### PR TITLE
CLI/Docs: Fix the format commands' name

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -31,12 +31,12 @@ jobs:
         output: ' '
         fileOutput: ' '
 
-    - name: Run qmk cformat and qmk pyformat
+    - name: Run qmk format-c and qmk format-python
       shell: 'bash {0}'
       run: |
-        qmk cformat --core-only -n $(< ~/files.txt)
-        cformat_exit=$?
-        qmk pyformat -n
-        pyformat_exit=$?
+        qmk format-c --core-only -n $(< ~/files.txt)
+        format_c_exit=$?
+        qmk format-python -n
+        format_python_exit=$?
 
-        exit $((cformat_exit + pyformat_exit))
+        exit $((format_c_exit + format_python_exit))

--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -314,7 +314,18 @@ qmk clean [-a]
 
 # Developer Commands
 
-## `qmk cformat`
+## `qmk format-text`
+
+This command formats text files to have proper line endings. 
+
+Every text file in the repository needs to have Unix (LF) line ending.
+If you are working on **Windows**, you must ensure that line endings are corrected in order to get your PRs merged.
+
+```
+qmk format-text
+```
+
+## `qmk format-c`
 
 This command formats C code using clang-format. 
 
@@ -325,25 +336,25 @@ Run it with `-a` to format all core code, or pass filenames on the command line 
 **Usage for specified files**:
 
 ```
-qmk cformat [file1] [file2] [...] [fileN]
+qmk format-c [file1] [file2] [...] [fileN]
 ```
 
 **Usage for all core files**:
 
 ```
-qmk cformat -a
+qmk format-c -a
 ```
 
 **Usage for only changed files against origin/master**:
 
 ```
-qmk cformat
+qmk format-c
 ```
 
 **Usage for only changed files against branch_name**:
 
 ```
-qmk cformat -b branch_name
+qmk format-c -b branch_name
 ```
 
 ## `qmk docs`
@@ -398,14 +409,14 @@ $ qmk kle2json -f kle.txt -f
 Ψ Wrote out to info.json
 ```
 
-## `qmk pyformat`
+## `qmk format-python`
 
 This command formats python code in `qmk_firmware`.
 
 **Usage**:
 
 ```
-qmk pyformat
+qmk format-python
 ```
 
 ## `qmk pytest`

--- a/docs/cli_development.md
+++ b/docs/cli_development.md
@@ -188,7 +188,7 @@ cli.log.info('Reading from %s and writing to %s', cli.args.filename, cli.args.ou
 
 # Testing, and Linting, and Formatting (oh my!)
 
-We use nose2, flake8, and yapf to test, lint, and format code. You can use the `pytest` and `pyformat` subcommands to run these tests:
+We use nose2, flake8, and yapf to test, lint, and format code. You can use the `pytest` and `format-py` subcommands to run these tests:
 
 ### Testing and Linting
 
@@ -196,7 +196,7 @@ We use nose2, flake8, and yapf to test, lint, and format code. You can use the `
 
 ### Formatting
 
-    qmk pyformat
+    qmk format-py
 
 ## Formatting Details
 

--- a/docs/de/cli.md
+++ b/docs/de/cli.md
@@ -88,14 +88,14 @@ qmk compile <configuratorExport.json>
 qmk compile -kb <keyboard_name> -km <keymap_name>
 ```
 
-## `qmk cformat`
+## `qmk format-c`
 
 Dieser Befehl formatiert C-Code im clang-Format. Benutze ihn ohne Argumente, um den core-Code zu formatieren, oder benutze Namen von Dateien in der CLI, um den Befehl auf bestimmte Dateien anzuwenden.
 
 **Anwendung**:
 
 ```
-qmk cformat [file1] [file2] [...] [fileN]
+qmk format-c [file1] [file2] [...] [fileN]
 ```
 
 ## `qmk config`
@@ -148,14 +148,14 @@ Dieser Befehl erstellt eine neue Keymap basierend auf einer existierenden Standa
 qmk new-keymap [-kb KEYBOARD] [-km KEYMAP]
 ```
 
-## `qmk pyformat`
+## `qmk format-py`
 
 Dieser Befehl formatiert Python-Code in `qmk_firmware`.
 
 **Anwendung**:
 
 ```
-qmk pyformat
+qmk format-py
 ```
 
 ## `qmk pytest`

--- a/docs/fr-fr/cli.md
+++ b/docs/fr-fr/cli.md
@@ -85,14 +85,14 @@ qmk compile <configuratorExport.json>
 qmk compile -kb <keyboard_name> -km <keymap_name>
 ```
 
-## `qmk cformat`
+## `qmk format-c`
 
 Cette commande formatte le code C en utilisant clang-format. Lancez-la sans arguments pour formatter tout le code core, ou passez les noms de fichiers à la ligne de commande pour la lancer sur des fichiers spécifiques.
 
 **Utilisation**:
 
 ```
-qmk cformat [file1] [file2] [...] [fileN]
+qmk format-c [file1] [file2] [...] [fileN]
 ```
 
 ## `qmk config`
@@ -125,14 +125,14 @@ Cette commande crée une nouvelle keymap basée sur une keymap par défaut d'un 
 qmk new-keymap [-kb KEYBOARD] [-km KEYMAP]
 ```
 
-## `qmk pyformat`
+## `qmk format-py`
 
 Cette commande formate le code python dans `qmk_firmware`.
 
 **Utilisation**:
 
 ```
-qmk pyformat
+qmk format-py
 ```
 
 ## `qmk pytest`

--- a/docs/ja/cli_commands.md
+++ b/docs/ja/cli_commands.md
@@ -211,7 +211,7 @@ qmk new-keymap [-kb KEYBOARD] [-km KEYMAP]
 
 # 開発者用コマンド
 
-## `qmk cformat`
+## `qmk format-c`
 
 このコマンドは clang-format を使って C コードを整形します。
 
@@ -222,25 +222,25 @@ qmk new-keymap [-kb KEYBOARD] [-km KEYMAP]
 **指定したファイルに対する使い方**:
 
 ```
-qmk cformat [file1] [file2] [...] [fileN]
+qmk format-c [file1] [file2] [...] [fileN]
 ```
 
 **全てのコアファイルに対する使い方**:
 
 ```
-qmk cformat -a
+qmk format-c -a
 ```
 
 **origin/master で変更されたファイルのみに対する使い方**:
 
 ```
-qmk cformat
+qmk format-c
 ```
 
 **branch_name で変更されたファイルのみに対する使い方**:
 
 ```
-qmk cformat -b branch_name
+qmk format-c -b branch_name
 ```
 
 ## `qmk docs`
@@ -275,14 +275,14 @@ $ qmk kle2json -f kle.txt -f
 Ψ Wrote out to info.json
 ```
 
-## `qmk pyformat`
+## `qmk format-py`
 
 このコマンドは `qmk_firmware` 内の python コードを整形します。
 
 **使用法**:
 
 ```
-qmk pyformat
+qmk format-py
 ```
 
 ## `qmk pytest`

--- a/docs/ja/cli_development.md
+++ b/docs/ja/cli_development.md
@@ -192,7 +192,7 @@ cli.log.info('Reading from %s and writing to %s', cli.args.filename, cli.args.ou
 
 # テスト、リントおよびフォーマット
 
-nose2、flake8 および yapf を使ってコードをテスト、リントおよびフォーマットします。これらのテストを実行するために `pytest` と `pyformat` サブコマンドを使うことができます。
+nose2、flake8 および yapf を使ってコードをテスト、リントおよびフォーマットします。これらのテストを実行するために `pytest` と `format-py` サブコマンドを使うことができます。
 
 ### テストとリント
 
@@ -200,7 +200,7 @@ nose2、flake8 および yapf を使ってコードをテスト、リントお�
 
 ### フォーマット
 
-    qmk pyformat
+    qmk format-py
 
 ## フォーマットの詳細
 

--- a/lib/python/qmk/cli/format/c.py
+++ b/lib/python/qmk/cli/format/c.py
@@ -127,7 +127,7 @@ def format_c(cli):
 
     # Sanity check
     if not files:
-        cli.log.error('No changed files detected. Use "qmk cformat -a" to format all core files')
+        cli.log.error('No changed files detected. Use "qmk format-c -a" to format all core files')
         return False
 
     # Run clang-format on the files we've found

--- a/lib/python/qmk/tests/test_cli_commands.py
+++ b/lib/python/qmk/tests/test_cli_commands.py
@@ -31,13 +31,13 @@ def check_returncode(result, expected=[0]):
     assert result.returncode in expected
 
 
-def test_cformat():
-    result = check_subcommand('cformat', '-n', 'quantum/matrix.c')
+def test_format_c():
+    result = check_subcommand('format-c', '-n', 'quantum/matrix.c')
     check_returncode(result)
 
 
-def test_cformat_all():
-    result = check_subcommand('cformat', '-n', '-a')
+def test_format_c_all():
+    result = check_subcommand('format-c', '-n', '-a')
     check_returncode(result, [0, 1])
 
 
@@ -80,8 +80,8 @@ def test_hello():
     assert 'Hello,' in result.stdout
 
 
-def test_pyformat():
-    result = check_subcommand('pyformat', '--dry-run')
+def test_format_python():
+    result = check_subcommand('format-python', '--dry-run')
     check_returncode(result)
     assert 'Python code in `bin/qmk` and `lib/python` is correctly formatted.' in result.stdout
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

PR #13296 changed the name of the `cformat` and `pyformat` commands to
`format-c` and `format-py` respectively. This PR updates the documentation
and some parts of the CLI to use the new names.
Also add documentation for the new `format-text` subcommand, introduced
in the same PR.
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
