### PR TITLE
docs/cli_commands: fix typo

### DIFF
--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -109,7 +109,7 @@ qmk config [-ro] [config_token1] [config_token2] [...] [config_tokenN]
 
 ## `qmk console`
 
-This command lets you connect to keyboard consoles to get debugging messages. It only works if your keyboard firmware has been compiled with `CONSOLE_ENABLED=yes`.
+This command lets you connect to keyboard consoles to get debugging messages. It only works if your keyboard firmware has been compiled with `CONSOLE_ENABLE=yes`.
 
 **Usage**:
 


### PR DESCRIPTION
Fairly certain it's `CONSOLE_ENABLE` everywhere else in the docs:
- https://github.com/qmk/qmk_firmware/blame/master/docs/faq_debug.md#L7
- https://github.com/qmk/qmk_firmware/blame/master/docs/faq_misc.md#L113
- https://github.com/qmk/qmk_firmware/blame/master/docs/config_options.md#L368
- https://github.com/qmk/qmk_firmware/blame/master/docs/getting_started_make_guide.md#L68