### PR TITLE
Allow for removal of hysteresis on 4x encoders

### DIFF
--- a/docs/feature_encoders.md
+++ b/docs/feature_encoders.md
@@ -38,6 +38,12 @@ It can also be defined per-encoder, by instead defining:
 #define ENCODER_RESOLUTIONS { 4, 2 }
 ```
 
+For 4× encoders you also can assign default position if encoder skips pulses when it changes direction. For example, if your encoder send high level on both pins by default, define this:
+
+```c
+#define ENCODER_DEFAULT_POS 0x3
+```
+
 ## Split Keyboards
 
 If you are using different pinouts for the encoders on each half of a split keyboard, you can define the pinout (and optionally, resolutions) for the right half like this:

--- a/quantum/encoder.c
+++ b/quantum/encoder.c
@@ -119,6 +119,11 @@ static bool encoder_update(uint8_t index, uint8_t state) {
         encoder_update_kb(index, ENCODER_CLOCKWISE);
     }
     encoder_pulses[i] %= resolution;
+#ifdef ENCODER_DEFAULT_POS
+    if ((state & 0x3) == ENCODER_DEFAULT_POS) {
+        encoder_pulses[i] = 0;
+    }
+#endif
     return changed;
 }
 


### PR DESCRIPTION
Sometimes, controller skips encoder pulses and when it returns to default position, the encoder_pulses variable isn't equals 0. And when I turn encoder in opposite direciton, it skips first click becase of encoder_pulses crosses zero. To prevent this, I add the ENCODER_DEFAULT_POS constant, and reset encoder_pulses into 0 when the state variable equals ENCODER_DEFAULT_POS.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
