### PR TITLE
40percentclub/nein: update info.json layout macro reference

### DIFF
--- a/keyboards/40percentclub/nein/info.json
+++ b/keyboards/40percentclub/nein/info.json
@@ -5,7 +5,7 @@
   "width": 3,
   "height": 3,
   "layouts": {
-    "LAYOUT": {
+    "LAYOUT_ortho_3x3": {
       "layout": [
         {"x":0, "y":0},
         {"x":1, "y":0},


### PR DESCRIPTION
## Description

Changes `LAYOUT` to `LAYOUT_ortho_3x3` in `info.json`.

Fixes:

https://github.com/qmk/qmk_firmware/blob/a73e0a7b1308825ffd2fff18ff385add09f31c03/keyboards/40percentclub/nein/nein.h#L28 vs. https://github.com/qmk/qmk_firmware/blob/a73e0a7b1308825ffd2fff18ff385add09f31c03/keyboards/40percentclub/nein/info.json#L8


## Types of Changes

- [x] Enhancement/optimization
- [x] Keyboard (addition or update)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
