### PR TITLE
Add bootloader size

### DIFF
--- a/keyboards/dztech/dz60rgb/v2_1/rules.mk
+++ b/keyboards/dztech/dz60rgb/v2_1/rules.mk
@@ -3,6 +3,7 @@ MCU = atmega32u4
 
 # Bootloader selection
 BOOTLOADER = lufa-ms
+BOOTLOADER_SIZE = 6144
 
 # Build Options
 #   change yes to no to disable

--- a/keyboards/dztech/dz65rgb/v3/rules.mk
+++ b/keyboards/dztech/dz65rgb/v3/rules.mk
@@ -3,6 +3,7 @@ MCU = atmega32u4
 
 # Bootloader selection
 BOOTLOADER = lufa-ms
+BOOTLOADER_SIZE = 6144
 
 # Build Options
 #   change yes to no to disable


### PR DESCRIPTION
Bootloader size needs to be 6144 to allow QMK to jump to the correct location with bootmagic

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/qmk/qmk_firmware/issues/13283

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
