### PR TITLE
Update "make format" message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -262,8 +262,10 @@ define PARSE_RULE
         $$(info | Examples:)
         $$(info |     keyboards/dz60, keyboards/dz60/keymaps/default)
         $$(info |       -> make dz60:default)
+        $$(info |       -> qmk compile -kb dz60 -km default)
         $$(info |     keyboards/planck/rev6, keyboards/planck/keymaps/default)
         $$(info |       -> make planck/rev6:default:flash)
+        $$(info |       -> qmk flash -kb planck/rev6 -km default)
         $$(info |)
     endif
 endef

--- a/Makefile
+++ b/Makefile
@@ -252,11 +252,18 @@ define PARSE_RULE
     else
         $$(info make: *** No rule to make target '$1'. Stop.)
         $$(info |)
-        $$(info |  QMK's make format recently changed to use folder locations and colons:)
-        $$(info |     make project_folder:keymap[:target])
-        $$(info |  Examples:)
-        $$(info |     make dz60:default)
-        $$(info |     make planck/rev6:default:flash)
+        $$(info | QMK's make format is:)
+        $$(info |     make keyboard_folder:keymap_folder[:target])
+        $$(info |)
+        $$(info | Where `keyboard_folder` is the path to the keyboard relative to)
+        $$(info | `qmk_firmware/keyboards/`, and `keymap_folder` is the name of the)
+        $$(info | keymap folder under that board's `keymaps/` directory.)
+        $$(info |)
+        $$(info | Examples:)
+        $$(info |     keyboards/dz60, keyboards/dz60/keymaps/default)
+        $$(info |       -> make dz60:default)
+        $$(info |     keyboards/planck/rev6, keyboards/planck/keymaps/default)
+        $$(info |       -> make planck/rev6:default:flash)
         $$(info |)
     endif
 endef


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Hopefully this is a bit clearer.

```
$ make a:b       
make: *** No rule to make target 'a:b'. Stop.
|
| QMK's make format is:
|     make keyboard_folder:keymap_folder[:target]
|
| Where `keyboard_folder` is the path to the keyboard relative to
| `qmk_firmware/keyboards/`, and `keymap_folder` is the name of the
| keymap folder under that board's `keymaps/` directory.
|
| Examples:
|     keyboards/dz60, keyboards/dz60/keymaps/default
|       -> make dz60:default
|       -> qmk compile -kb dz60 -km default
|     keyboards/planck/rev6, keyboards/planck/keymaps/default
|       -> make planck/rev6:default:flash
|       -> qmk flash -kb planck/rev6 -km default
|
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
