### PR TITLE
fix short circuit in led_update_bk

### DIFF
--- a/keyboards/keebio/quefrency/rev3/rev3.c
+++ b/keyboards/keebio/quefrency/rev3/rev3.c
@@ -24,7 +24,7 @@ void matrix_init_kb(void) {
 
 bool led_update_kb(led_t led_state) {
     // Only update if left half
-    if (isLeftHand && led_update_user(led_state)) {
+    if (led_update_user(led_state) && isLeftHand) {
         writePin(CAPS_LOCK_LED_PIN, !led_state.caps_lock);
     }
     return true;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Fix a short circuit evaluation issue in quefrency/rev3/rev3.c that causes the user function led_update_user() to never run when the right side of the board is connected. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 13750

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
