### PR TITLE
fix: Fix typo in documentation for one shot keys. ON_TOGG -> OS_TOGG

### DIFF
--- a/docs/one_shot_keys.md
+++ b/docs/one_shot_keys.md
@@ -19,7 +19,7 @@ You can control the behavior of one shot keys by defining these in `config.h`:
 * `OSL(layer)` - momentary switch to *layer*.
 * `OS_ON` - Turns on One Shot keys.
 * `OS_OFF` - Turns off One Shot keys. OSM act as regular mod keys, OSL act like `MO`.
-* `ON_TOGG` - Toggles the one shot key status.
+* `OS_TOGG` - Toggles the one shot key status.
 
 Sometimes, you want to activate a one-shot key as part of a macro or tap dance routine.  
 


### PR DESCRIPTION
Simple typo clean up in documentation that threw me for a loop at first.

## Description

Changed "ON_TOGG" to "OS_TOGG" in the documentation to match what's present in the codebase. There is no "ON_TOGG" anywhere else. 

## Types of Changes

- [ ] Core
- [ x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ x] Documentation