### PR TITLE
Allow for higher USB Polling rate on ATSAM boards

### DIFF
--- a/tmk_core/protocol/arm_atsam/usb/udi_device_conf.h
+++ b/tmk_core/protocol/arm_atsam/usb/udi_device_conf.h
@@ -23,6 +23,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "compiler.h"
 #include "usb_protocol_hid.h"
 
+#ifndef USB_POLLING_INTERVAL_MS
+#    define USB_POLLING_INTERVAL_MS 10
+#endif
+
 #ifdef VIRTSER_ENABLE
 // because CDC uses IAD (interface association descriptor
 // per USB Interface Association Descriptor Device Class Code and Use Model 7/23/2003 Rev 1.0)
@@ -118,7 +122,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define UDI_HID_KBD_EP_IN KEYBOARD_IN_EPNUM
 #define NEXT_IN_EPNUM_1 (KEYBOARD_IN_EPNUM + 1)
 #define UDI_HID_KBD_EP_SIZE KEYBOARD_EPSIZE
-#define KBD_POLLING_INTERVAL 10
+#define KBD_POLLING_INTERVAL USB_POLLING_INTERVAL_MS
 #ifndef UDI_HID_KBD_STRING_ID
 #    define UDI_HID_KBD_STRING_ID 0
 #endif
@@ -128,7 +132,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    define NEXT_IN_EPNUM_2 (MOUSE_IN_EPNUM + 1)
 #    define UDI_HID_MOU_EP_IN MOUSE_IN_EPNUM
 #    define UDI_HID_MOU_EP_SIZE MOUSE_EPSIZE
-#    define MOU_POLLING_INTERVAL 10
+#    define MOU_POLLING_INTERVAL USB_POLLING_INTERVAL_MS
 #    ifndef UDI_HID_MOU_STRING_ID
 #        define UDI_HID_MOU_STRING_ID 0
 #    endif
@@ -141,7 +145,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    define UDI_HID_EXK_EP_IN EXTRAKEY_IN_EPNUM
 #    define NEXT_IN_EPNUM_3 (EXTRAKEY_IN_EPNUM + 1)
 #    define UDI_HID_EXK_EP_SIZE EXTRAKEY_EPSIZE
-#    define EXTRAKEY_POLLING_INTERVAL 10
+#    define EXTRAKEY_POLLING_INTERVAL USB_POLLING_INTERVAL_MS
 #    ifndef UDI_HID_EXK_STRING_ID
 #        define UDI_HID_EXK_STRING_ID 0
 #    endif


### PR DESCRIPTION
## Description

Enables the `USB_POLLING_INTERVAL_MS` define to be respected for ATSAM boards.

## Types of Changes


- [x] Core
- [x] Enhancement/optimization


## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
