### PR TITLE
Ocean Sus Board: rename layout macro

### DIFF
--- a/keyboards/ocean/sus/info.json
+++ b/keyboards/ocean/sus/info.json
@@ -5,7 +5,7 @@
     "width": 3, 
     "height": 4, 
     "layouts": {
-        "LAYOUT_ortho_3x4": {
+        "LAYOUT_ortho_4x3": {
           "layout": [
             {"x":0, "y":0}, 
             {"x":1, "y":0},

--- a/keyboards/ocean/sus/keymaps/default/keymap.c
+++ b/keyboards/ocean/sus/keymaps/default/keymap.c
@@ -15,28 +15,28 @@
 #include QMK_KEYBOARD_H
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-  [0] = LAYOUT_ortho_3x4(
+  [0] = LAYOUT_ortho_4x3(
     KC_P7, KC_P8, KC_P9,
     KC_P4, KC_P5, KC_P6,
     KC_P1, KC_P2, KC_P3,
     KC_PENT, KC_P0, MO(1)
   ),
 
-  [1] = LAYOUT_ortho_3x4(
+  [1] = LAYOUT_ortho_4x3(
     KC_TRNS, KC_TRNS, KC_TRNS,
     KC_TRNS, KC_TRNS, KC_TRNS,
     KC_TRNS, KC_TRNS, KC_TRNS,
     KC_TRNS, KC_TRNS, KC_TRNS
   ),
 
-  [2] = LAYOUT_ortho_3x4(
+  [2] = LAYOUT_ortho_4x3(
     KC_TRNS, KC_TRNS, KC_TRNS,
     KC_TRNS, KC_TRNS, KC_TRNS,
     KC_TRNS, KC_TRNS, KC_TRNS,
     KC_TRNS, KC_TRNS, KC_TRNS
   ),
 
-  [3] = LAYOUT_ortho_3x4(
+  [3] = LAYOUT_ortho_4x3(
     KC_TRNS, KC_TRNS, KC_TRNS,
     KC_TRNS, KC_TRNS, KC_TRNS,
     KC_TRNS, KC_TRNS, KC_TRNS,

--- a/keyboards/ocean/sus/keymaps/via/keymap.c
+++ b/keyboards/ocean/sus/keymaps/via/keymap.c
@@ -15,28 +15,28 @@
 #include QMK_KEYBOARD_H
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-  [0] = LAYOUT_ortho_3x4(
+  [0] = LAYOUT_ortho_4x3(
     KC_P7, KC_P8, KC_P9,
     KC_P4, KC_P5, KC_P6,
     KC_P1, KC_P2, KC_P3,
     KC_PENT, KC_P0, MO(1)
   ),
 
-  [1] = LAYOUT_ortho_3x4(
+  [1] = LAYOUT_ortho_4x3(
     KC_TRNS, KC_TRNS, KC_TRNS,
     KC_TRNS, KC_TRNS, KC_TRNS,
     KC_TRNS, KC_TRNS, KC_TRNS,
     KC_TRNS, KC_TRNS, KC_TRNS
   ),
 
-  [2] = LAYOUT_ortho_3x4(
+  [2] = LAYOUT_ortho_4x3(
     KC_TRNS, KC_TRNS, KC_TRNS,
     KC_TRNS, KC_TRNS, KC_TRNS,
     KC_TRNS, KC_TRNS, KC_TRNS,
     KC_TRNS, KC_TRNS, KC_TRNS
   ),
 
-  [3] = LAYOUT_ortho_3x4(
+  [3] = LAYOUT_ortho_4x3(
     KC_TRNS, KC_TRNS, KC_TRNS,
     KC_TRNS, KC_TRNS, KC_TRNS,
     KC_TRNS, KC_TRNS, KC_TRNS,

--- a/keyboards/ocean/sus/sus.h
+++ b/keyboards/ocean/sus/sus.h
@@ -17,7 +17,7 @@
 
 #include "quantum.h"
 
-#define LAYOUT_ortho_3x4(\
+#define LAYOUT_ortho_4x3(\
   K00, K01, K02, \
   K10, K11, K12, \
   K20, K21, K22, \


### PR DESCRIPTION
## Description

- rename LAYOUT_ortho_3x4 to LAYOUT_ortho_4x3
  - ... because ortho layouts in QMK are named by \<rows\>x\<columns\> instead of \<columns\>x\<rows\>

cc @alabahuy (keyboard maintainer)

## Types of Changes

- [x] Enhancement/optimization
- [x] Keyboard (addition or update)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
