### PR TITLE
`qmk docs`: Add flag to open in browser

### DIFF
--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -349,11 +349,12 @@ qmk cformat -b branch_name
 ## `qmk docs`
 
 This command starts a local HTTP server which you can use for browsing or improving the docs. Default port is 8936.
+Use the `-b`/`--browser` flag to automatically open the local webserver in your default browser.
 
 **Usage**:
 
 ```
-qmk docs [-p PORT]
+qmk docs [-b] [-p PORT]
 ```
 
 ## `qmk generate-docs`

--- a/lib/python/qmk/cli/docs.py
+++ b/lib/python/qmk/cli/docs.py
@@ -2,11 +2,13 @@
 """
 import http.server
 import os
+import webbrowser
 
 from milc import cli
 
 
 @cli.argument('-p', '--port', default=8936, type=int, help='Port number to use.')
+@cli.argument('-b', '--browser', action='store_true', help='Open the docs in the default browser.')
 @cli.subcommand('Run a local webserver for QMK documentation.', hidden=False if cli.config.user.developer else True)
 def docs(cli):
     """Spin up a local HTTPServer instance for the QMK docs.
@@ -14,8 +16,11 @@ def docs(cli):
     os.chdir('docs')
 
     with http.server.HTTPServer(('', cli.config.docs.port), http.server.SimpleHTTPRequestHandler) as httpd:
-        cli.log.info("Serving QMK docs at http://localhost:%d/", cli.config.docs.port)
+        cli.log.info(f"Serving QMK docs at http://localhost:{cli.config.docs.port}/")
         cli.log.info("Press Control+C to exit.")
+
+        if cli.config.docs.browser:
+            webbrowser.open(f'http://localhost:{cli.config.docs.port}')
 
         try:
             httpd.serve_forever()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Last time I tried this in MSYS2 it didn't work, it seems to now 🤷

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
