### PR TITLE
Stratos: fix layout macro reference in info.json

### DIFF
--- a/keyboards/stratos/info.json
+++ b/keyboards/stratos/info.json
@@ -272,7 +272,7 @@
                 {"x":13.5, "y":4, "w":1.5}
             ]
         },
-        "LAYOUT_60_ansi_tsangan_hhkb": {
+        "LAYOUT_60_tsangan_hhkb": {
             "layout": [
                 {"x":0, "y":0},
                 {"x":1, "y":0},


### PR DESCRIPTION
## Description

- change LAYOUT_60_ansi_tsangan_hhkb to LAYOUT_60_tsangan_hhkb

https://github.com/qmk/qmk_firmware/blob/5a0985aa4a10ae15d3c3eb49a0394b10a62160ae/keyboards/stratos/stratos.h#L79 vs. https://github.com/qmk/qmk_firmware/blob/5a0985aa4a10ae15d3c3eb49a0394b10a62160ae/keyboards/stratos/info.json#L275

cc @kb-elmo (keyboard maintainer)

## Types of Changes

- [x] Enhancement/optimization
- [x] Keyboard (addition or update)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
