### PR TITLE
txuu: rename LAYOUT to LAYOUT_65_ansi_blocker_split_bs

### DIFF
--- a/keyboards/txuu/info.json
+++ b/keyboards/txuu/info.json
@@ -3,8 +3,11 @@
     "maintainer": "matthewdias", 
     "width": 16, 
     "height": 5, 
+    "layout_aliases": {
+        "LAYOUT": "LAYOUT_65_ansi_blocker_split_bs"
+    },
     "layouts": {
-        "LAYOUT": {
+        "LAYOUT_65_ansi_blocker_split_bs": {
             "layout": [
                 {"label":"0,0", "x":0, "y":0},
                 {"label":"0,1", "x":1, "y":0},

--- a/keyboards/txuu/txuu.h
+++ b/keyboards/txuu/txuu.h
@@ -21,7 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define XXX KC_NO
 
-#define LAYOUT( \
+#define LAYOUT_65_ansi_blocker_split_bs( \
     K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C, K0D, K0E, K0F, \
     K10, K11, K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, K1C,      K1E, K1F, \
     K20, K21, K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B,      K2D,      K2F, \


### PR DESCRIPTION
## Description

Renames the layout macro to be more conformant to the rest of QMK.

cc @matthewdias (keyboard maintainer)

## Types of Changes

- [x] Enhancement/optimization
- [x] Keyboard (addition or update)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
