### PR TITLE
Lenient doctor

### DIFF
--- a/lib/python/qmk/cli/doctor/check.py
+++ b/lib/python/qmk/cli/doctor/check.py
@@ -159,6 +159,6 @@ def check_git_repo():
     This is a decent enough indicator that the qmk_firmware directory is a
     proper Git repository, rather than a .zip download from GitHub.
     """
-    dot_git_dir = QMK_FIRMWARE / '.git'
+    dot_git = QMK_FIRMWARE / '.git'
 
-    return CheckStatus.OK if dot_git_dir.is_dir() else CheckStatus.WARNING
+    return CheckStatus.OK if dot_git.exists() else CheckStatus.WARNING

--- a/lib/python/qmk/cli/doctor/linux.py
+++ b/lib/python/qmk/cli/doctor/linux.py
@@ -41,7 +41,12 @@ def check_udev_rules():
     """Make sure the udev rules look good.
     """
     rc = CheckStatus.OK
-    udev_dir = Path("/etc/udev/rules.d/")
+    udev_dirs = [
+        Path("/usr/lib/udev/rules.d/"),
+        Path("/usr/local/lib/udev/rules.d/"),
+        Path("/run/udev/rules.d/"),
+        Path("/etc/udev/rules.d/"),
+    ]
     desired_rules = {
         'atmel-dfu': {
             _udev_rule("03eb", "2fef"),  # ATmega16U2
@@ -90,8 +95,8 @@ def check_udev_rules():
         'tmk': {_deprecated_udev_rule("feed")}
     }
 
-    if udev_dir.exists():
-        udev_rules = [rule_file for rule_file in udev_dir.glob('*.rules')]
+    if any(udev_dir.exists() for udev_dir in udev_dirs):
+        udev_rules = [rule_file for udev_dir in udev_dirs for rule_file in udev_dir.glob('*.rules')]
         current_rules = set()
 
         # Collect all rules from the config files
@@ -117,7 +122,8 @@ def check_udev_rules():
                     cli.log.warning("{fg_yellow}Missing or outdated udev rules for '%s' boards. Run 'sudo cp %s/util/udev/50-qmk.rules /etc/udev/rules.d/'.", bootloader, QMK_FIRMWARE)
 
     else:
-        cli.log.warning("{fg_yellow}'%s' does not exist. Skipping udev rule checking...", udev_dir)
+        cli.log.warning("{fg_yellow}Can't find udev rules, skipping udev rule checking...")
+        cli.log.debug("Checked directories: %s", ', '.join(str(udev_dir) for udev_dir in udev_dirs))
 
     return rc
 


### PR DESCRIPTION
## Description

`qmk doctor` is a bit too strict on a couple of issues, which can lead to false-positive warnings:

1) To determine if the `qmk_firmware` home is a git repository, the `doctor` checks, if `${QMK_FIRMWARE}/.git` is a directory. However, if `qmk_firmware` is a git submodule, then `.git` will be a file instead of a directory. This PR relaxes the requirement, allowing `.git` to be a file.

2) When checking for the installed `udev` rules, the `doctor` searches only in `/etc/udev/rules.d/*.rules`. According to `man udev`, this isn't the only directory, where `udev` rules can be located:

    ```
    RULES FILES
           The udev rules are read from the files located in the system rules directories /usr/lib/udev/rules.d
           and /usr/local/lib/udev/rules.d, the volatile runtime directory /run/udev/rules.d and the local
           administration directory /etc/udev/rules.d.
    ```

    In particular, the official `arch`/`manjaro` `qmk` package places the udev rules into `/usr/lib/udev/rules.d/50-qmk.rules`, leading to a false positive. This PR makes the `doctor` also search for `udev` rules in `/usr/lib/udev/rules.d/`, `/usr/local/lib/udev/rules.d/` and `/run/udev/rules.d/`.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
