### PR TITLE
Update endgame keymap to work with suspend changes

### DIFF
--- a/keyboards/massdrop/ctrl/keymaps/endgame/keymap.c
+++ b/keyboards/massdrop/ctrl/keymaps/endgame/keymap.c
@@ -373,7 +373,7 @@ void set_layer_color(int layer) {
 }
 
 void rgb_matrix_indicators_user(void) {
-    if (g_suspend_state || disable_layer_color ||
+    if (disable_layer_color ||
         rgb_matrix_get_flags() == LED_FLAG_NONE ||
         rgb_matrix_get_flags() == LED_FLAG_UNDERGLOW) {
             return;

--- a/keyboards/massdrop/ctrl/keymaps/endgame/keymap.h
+++ b/keyboards/massdrop/ctrl/keymaps/endgame/keymap.h
@@ -33,7 +33,6 @@
 #define RGB_TIME_OUT_MIN 10
 #define RGB_TIME_OUT_STEP 10
 
-extern bool g_suspend_state;
 extern rgb_config_t rgb_matrix_config;
 bool disable_layer_color;
 


### PR DESCRIPTION
## Description

Updates the Massdrop CTRL keyboard endgame keymap to work after the changes to USB suspend in #12697

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #13782

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
