### PR TITLE
[develop] Speed up pimoroni driver.

### DIFF
--- a/drivers/sensors/pimoroni_trackball.c
+++ b/drivers/sensors/pimoroni_trackball.c
@@ -55,7 +55,7 @@ static int16_t        h_offset  = 0;
 static int16_t        v_offset  = 0;
 static uint16_t       precision = 128;
 
-float trackball_get_precision(void) { return (float)(precision >> 7); }
+float trackball_get_precision(void) { return ((float)precision / 128); }
 void  trackball_set_precision(float floatprecision) { precision = (floatprecision * 128); }
 bool  trackball_is_scrolling(void) { return scrolling; }
 void  trackball_set_scrolling(bool scroll) { scrolling = scroll; }

--- a/drivers/sensors/pimoroni_trackball.c
+++ b/drivers/sensors/pimoroni_trackball.c
@@ -18,6 +18,16 @@
 #include "i2c_master.h"
 #include "print.h"
 
+#ifndef TRACKBALL_ADDRESS
+#    define TRACKBALL_ADDRESS 0x0A
+#endif
+#ifndef TRACKBALL_INTERVAL_MS
+#    define TRACKBALL_INTERVAL_MS 8
+#endif
+#ifndef TRACKBALL_DEBOUNCE_ONCLICK
+#    define TRACKBALL_DEBOUNCE_ONCLICK 5
+#endif
+
 #define TRACKBALL_TIMEOUT 100
 #define TRACKBALL_REG_LED_RED 0x00
 #define TRACKBALL_REG_LED_GRN 0x01
@@ -27,6 +37,14 @@
 #define TRACKBALL_REG_RIGHT 0x05
 #define TRACKBALL_REG_UP 0x06
 #define TRACKBALL_REG_DOWN 0x07
+
+typedef struct pimoroni_data {
+    uint8_t left;
+    uint8_t right;
+    uint8_t up;
+    uint8_t down;
+    uint8_t click;
+} pimoroni_data;
 
 static pimoroni_data  current_pimoroni_data;
 static report_mouse_t mouse_report;

--- a/drivers/sensors/pimoroni_trackball.h
+++ b/drivers/sensors/pimoroni_trackball.h
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+#pragma once
 
 #include "quantum.h"
 #include "pointing_device.h"

--- a/drivers/sensors/pimoroni_trackball.h
+++ b/drivers/sensors/pimoroni_trackball.h
@@ -1,4 +1,5 @@
 /* Copyright 2020 Christopher Courtney, aka Drashna Jael're  (@drashna) <drashna@live.com>
+ * Copyright 2021 Dasky (@daskygit)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,16 +15,27 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#pragma once
-
 #include "quantum.h"
 #include "pointing_device.h"
 
 #ifndef TRACKBALL_ADDRESS
 #    define TRACKBALL_ADDRESS 0x0A
 #endif
-#define TRACKBALL_WRITE ((TRACKBALL_ADDRESS << 1) | I2C_WRITE)
-#define TRACKBALL_READ (TRACKBALL_ADDRESS << 1)
+
+#ifndef TRACKBALL_INTERVAL_MS
+#    define TRACKBALL_INTERVAL_MS 8
+#endif
+
+#ifndef TRACKBALL_DEBOUNCE_ONCLICK
+#    define TRACKBALL_DEBOUNCE_ONCLICK 5
+#endif
+typedef struct pimoroni_data {
+    uint8_t left;
+    uint8_t right;
+    uint8_t up;
+    uint8_t down;
+    uint8_t click;
+} pimoroni_data;
 
 void trackball_set_rgbw(uint8_t red, uint8_t green, uint8_t blue, uint8_t white);
 void trackball_check_click(bool pressed, report_mouse_t *mouse);

--- a/drivers/sensors/pimoroni_trackball.h
+++ b/drivers/sensors/pimoroni_trackball.h
@@ -19,28 +19,8 @@
 #include "quantum.h"
 #include "pointing_device.h"
 
-#ifndef TRACKBALL_ADDRESS
-#    define TRACKBALL_ADDRESS 0x0A
-#endif
-
-#ifndef TRACKBALL_INTERVAL_MS
-#    define TRACKBALL_INTERVAL_MS 8
-#endif
-
-#ifndef TRACKBALL_DEBOUNCE_ONCLICK
-#    define TRACKBALL_DEBOUNCE_ONCLICK 5
-#endif
-typedef struct pimoroni_data {
-    uint8_t left;
-    uint8_t right;
-    uint8_t up;
-    uint8_t down;
-    uint8_t click;
-} pimoroni_data;
-
 void trackball_set_rgbw(uint8_t red, uint8_t green, uint8_t blue, uint8_t white);
 void trackball_check_click(bool pressed, report_mouse_t *mouse);
-void trackball_register_button(bool pressed, enum mouse_buttons button);
 
 float trackball_get_precision(void);
 void  trackball_set_precision(float precision);

--- a/drivers/sensors/pimoroni_trackball.h
+++ b/drivers/sensors/pimoroni_trackball.h
@@ -19,10 +19,19 @@
 #include "quantum.h"
 #include "pointing_device.h"
 
-void trackball_set_rgbw(uint8_t red, uint8_t green, uint8_t blue, uint8_t white);
-void trackball_check_click(bool pressed, report_mouse_t *mouse);
+typedef struct pimoroni_data {
+    uint8_t left;
+    uint8_t right;
+    uint8_t up;
+    uint8_t down;
+    uint8_t click;
+} pimoroni_data;
 
-float trackball_get_precision(void);
-void  trackball_set_precision(float precision);
-bool  trackball_is_scrolling(void);
-void  trackball_set_scrolling(bool scroll);
+void    trackball_set_rgbw(uint8_t red, uint8_t green, uint8_t blue, uint8_t white);
+void    trackball_click(bool pressed, report_mouse_t* mouse);
+int16_t trackball_get_offsets(uint8_t negative_dir, uint8_t positive_dir, uint8_t scale);
+void    trackball_adapt_values(int8_t* mouse, int16_t* offset);
+float   trackball_get_precision(void);
+void    trackball_set_precision(float precision);
+bool    trackball_is_scrolling(void);
+void    trackball_set_scrolling(bool scroll);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This should function almost the same as the old driver. I've avoided the costly floating point calculation in the main loop and implemented throttling. The major difference being the x, y directions are swapped vs the original. (I was following the python library). This can be corrected with a couple of defines.

I don't have prior experience with the trackball on the old driver so some feedback on how it compares would be great. The throttling can be adjusted using the `TRACKBALL_INTERVAL_MS` define, it defaults to 8 (125hz). So likely worth playing with lower values on faster usb polling rates.

The mouse control feels pretty similar to the old driver but with the speed increase being so large it may outweigh the slight difference in feel. I've included a little log of the scan rate while spinning the trackball quickly.

Old driver scan rate: 
```QMK:Onekey Pro Micro:1: matrix scan frequency: 2277
QMK:Onekey Pro Micro:1: matrix scan frequency: 2278
QMK:Onekey Pro Micro:1: matrix scan frequency: 1885
QMK:Onekey Pro Micro:1: matrix scan frequency: 379
QMK:Onekey Pro Micro:1: matrix scan frequency: 682
QMK:Onekey Pro Micro:1: matrix scan frequency: 176
QMK:Onekey Pro Micro:1: matrix scan frequency: 909
QMK:Onekey Pro Micro:1: matrix scan frequency: 158
QMK:Onekey Pro Micro:1: matrix scan frequency: 145
QMK:Onekey Pro Micro:1: matrix scan frequency: 1150
QMK:Onekey Pro Micro:1: matrix scan frequency: 146
QMK:Onekey Pro Micro:1: matrix scan frequency: 486
QMK:Onekey Pro Micro:1: matrix scan frequency: 1698
QMK:Onekey Pro Micro:1: matrix scan frequency: 1690
QMK:Onekey Pro Micro:1: matrix scan frequency: 1370
```

New driver (TRACKBALL_INTERVAL_MS 8) scan rate:
```
QMK:Onekey Pro Micro:1: matrix scan frequency: 9917
QMK:Onekey Pro Micro:1: matrix scan frequency: 9917
QMK:Onekey Pro Micro:1: matrix scan frequency: 9914
QMK:Onekey Pro Micro:1: matrix scan frequency: 9911
QMK:Onekey Pro Micro:1: matrix scan frequency: 9907
QMK:Onekey Pro Micro:1: matrix scan frequency: 9904
QMK:Onekey Pro Micro:1: matrix scan frequency: 9903
QMK:Onekey Pro Micro:1: matrix scan frequency: 9907
QMK:Onekey Pro Micro:1: matrix scan frequency: 9929
QMK:Onekey Pro Micro:1: matrix scan frequency: 9928
QMK:Onekey Pro Micro:1: matrix scan frequency: 9928
QMK:Onekey Pro Micro:1: matrix scan frequency: 9925
QMK:Onekey Pro Micro:1: matrix scan frequency: 9929
```

New driver (TRACKBALL_INTERVAL_MS 1) scan rate:
```
QMK:Onekey Pro Micro:1: matrix scan frequency: 8718
QMK:Onekey Pro Micro:1: matrix scan frequency: 8715
QMK:Onekey Pro Micro:1: matrix scan frequency: 7594
QMK:Onekey Pro Micro:1: matrix scan frequency: 4741
QMK:Onekey Pro Micro:1: matrix scan frequency: 5420
QMK:Onekey Pro Micro:1: matrix scan frequency: 5134
QMK:Onekey Pro Micro:1: matrix scan frequency: 4672
QMK:Onekey Pro Micro:1: matrix scan frequency: 5234
QMK:Onekey Pro Micro:1: matrix scan frequency: 7436
QMK:Onekey Pro Micro:1: matrix scan frequency: 6029
QMK:Onekey Pro Micro:1: matrix scan frequency: 7984
QMK:Onekey Pro Micro:1: matrix scan frequency: 7974
QMK:Onekey Pro Micro:1: matrix scan frequency: 8045
```

I've tested on a promicro and bluepill, the performance benefit exists for both. I wonder if some basic documentation is in order explaining some of the defines with an example on how to implement it.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Enhancement/optimization
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
