### PR TITLE
Updated settings.json file to fit VSC's docs

### DIFF
--- a/docs/other_vscode.md
+++ b/docs/other_vscode.md
@@ -65,14 +65,17 @@ Now, we will set up the MSYS2 window to show up in VSCode as the integrated term
 
    ```json
    {
-        "terminal.integrated.shell.windows": "C:\\msys64\\usr\\bin\\bash.exe",
-        "terminal.integrated.env.windows": {
-            "MSYSTEM": "MINGW64",
-            "CHERE_INVOKING": "1"
+        "terminal.integrated.profiles.windows": {
+            "QMK_MSYS": {
+                "path": "C:/QMK_MSYS/usr/bin/bash.exe",
+                "env": {
+                    "MSYSTEM": "MINGW64",
+                    "CHERE_INVOKING": "1"
+                },
+                "args": ["--login"]
+            }
         },
-        "terminal.integrated.shellArgs.windows": [
-            "--login"
-        ],
+
         "terminal.integrated.cursorStyle": "line"
     }
     ```


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This change fixes the warning caused by deprecated way of configuring terminal profiles.

The warning caused by old settings.json is the following:
```
This is deprecated, the new recommended way to configure your default shell is by creating a terminal profile in `#terminal.integrated.profiles.windows#` and setting its profile name as the default in `#terminal.integrated.defaultProfile.windows#`. This will currently take priority over the new profiles settings but that will change in the future.
```

Refer to the link below for more information:
https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* Warning caused by deprecated way of setting terminal profile.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
