### PR TITLE
Add support for ISSI drivers on both sides of a split keyboard

### DIFF
--- a/docs/feature_led_matrix.md
+++ b/docs/feature_led_matrix.md
@@ -49,6 +49,8 @@ Here is an example using 2 drivers.
 
 !> Note the parentheses, this is so when `LED_DRIVER_LED_TOTAL` is used in code and expanded, the values are added together before any additional math is applied to them. As an example, `rand() % (LED_DRIVER_1_LED_TOTAL + LED_DRIVER_2_LED_TOTAL)` will give very different results than `rand() % LED_DRIVER_1_LED_TOTAL + LED_DRIVER_2_LED_TOTAL`.
 
+For split keyboards using LED_MATRIX_SPLIT with an LED driver, you can either have the same driver address or different driver addresses. If using different addresses, use `DRIVER_ADDR_1` for one and `DRIVER_2_LED_TOTAL` for the other one. Then, in `g_is31_leds`, fill out the correct driver index (0 or 1). If using one address, use `DRIVER_ADDR_1` for both, and use index 0 for `g_is31_leds`.
+
 Define these arrays listing all the LEDs in your `<keyboard>.c`:
 
 ```c
@@ -219,7 +221,7 @@ static bool my_cool_effect(effect_params_t* params) {
   for (uint8_t i = led_min; i < led_max; i++) {
     led_matrix_set_value(i, 0xFF);
   }
-  return led_max < DRIVER_LED_TOTAL;
+  return led_matrix_check_finished_leds(led_max);
 }
 
 // e.g: A more complex effect, relying on external methods and state, with
@@ -234,7 +236,7 @@ static bool my_cool_effect2_complex_run(effect_params_t* params) {
     led_matrix_set_value(i, some_global_state++);
   }
 
-  return led_max < DRIVER_LED_TOTAL;
+  return led_matrix_check_finished_leds(led_max);
 }
 static bool my_cool_effect2(effect_params_t* params) {
   if (params->init) my_cool_effect2_complex_init(params);

--- a/docs/feature_led_matrix.md
+++ b/docs/feature_led_matrix.md
@@ -49,7 +49,7 @@ Here is an example using 2 drivers.
 
 !> Note the parentheses, this is so when `LED_DRIVER_LED_TOTAL` is used in code and expanded, the values are added together before any additional math is applied to them. As an example, `rand() % (LED_DRIVER_1_LED_TOTAL + LED_DRIVER_2_LED_TOTAL)` will give very different results than `rand() % LED_DRIVER_1_LED_TOTAL + LED_DRIVER_2_LED_TOTAL`.
 
-For split keyboards using LED_MATRIX_SPLIT with an LED driver, you can either have the same driver address or different driver addresses. If using different addresses, use `DRIVER_ADDR_1` for one and `DRIVER_2_LED_TOTAL` for the other one. Then, in `g_is31_leds`, fill out the correct driver index (0 or 1). If using one address, use `DRIVER_ADDR_1` for both, and use index 0 for `g_is31_leds`.
+For split keyboards using `LED_MATRIX_SPLIT` with an LED driver, you can either have the same driver address or different driver addresses. If using different addresses, use `DRIVER_ADDR_1` for one and `DRIVER_ADDR_2` for the other one. Then, in `g_is31_leds`, fill out the correct driver index (0 or 1). If using one address, use `DRIVER_ADDR_1` for both, and use index 0 for `g_is31_leds`.
 
 Define these arrays listing all the LEDs in your `<keyboard>.c`:
 
@@ -235,7 +235,6 @@ static bool my_cool_effect2_complex_run(effect_params_t* params) {
   for (uint8_t i = led_min; i < led_max; i++) {
     led_matrix_set_value(i, some_global_state++);
   }
-
   return led_matrix_check_finished_leds(led_max);
 }
 static bool my_cool_effect2(effect_params_t* params) {

--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -49,7 +49,7 @@ Here is an example using 2 drivers.
 
 !> Note the parentheses, this is so when `DRIVER_LED_TOTAL` is used in code and expanded, the values are added together before any additional math is applied to them. As an example, `rand() % (DRIVER_1_LED_TOTAL + DRIVER_2_LED_TOTAL)` will give very different results than `rand() % DRIVER_1_LED_TOTAL + DRIVER_2_LED_TOTAL`.
 
-For split keyboards using RGB_MATRIX_SPLIT with an LED driver, you can either have the same driver address or different driver addresses. If using different addresses, use `DRIVER_ADDR_1` for one and `DRIVER_2_LED_TOTAL` for the other one. Then, in `g_is31_leds`, fill out the correct driver index (0 or 1). If using one address, use `DRIVER_ADDR_1` for both, and use index 0 for `g_is31_leds`.
+For split keyboards using `RGB_MATRIX_SPLIT` with an LED driver, you can either have the same driver address or different driver addresses. If using different addresses, use `DRIVER_ADDR_1` for one and `DRIVER_ADDR_2` for the other one. Then, in `g_is31_leds`, fill out the correct driver index (0 or 1). If using one address, use `DRIVER_ADDR_1` for both, and use index 0 for `g_is31_leds`.
 
 Define these arrays listing all the LEDs in your `<keyboard>.c`:
 

--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -49,6 +49,8 @@ Here is an example using 2 drivers.
 
 !> Note the parentheses, this is so when `DRIVER_LED_TOTAL` is used in code and expanded, the values are added together before any additional math is applied to them. As an example, `rand() % (DRIVER_1_LED_TOTAL + DRIVER_2_LED_TOTAL)` will give very different results than `rand() % DRIVER_1_LED_TOTAL + DRIVER_2_LED_TOTAL`.
 
+For split keyboards using RGB_MATRIX_SPLIT with an LED driver, you can either have the same driver address or different driver addresses. If using different addresses, use `DRIVER_ADDR_1` for one and `DRIVER_2_LED_TOTAL` for the other one. Then, in `g_is31_leds`, fill out the correct driver index (0 or 1). If using one address, use `DRIVER_ADDR_1` for both, and use index 0 for `g_is31_leds`.
+
 Define these arrays listing all the LEDs in your `<keyboard>.c`:
 
 ```c

--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -537,7 +537,7 @@ static bool my_cool_effect(effect_params_t* params) {
   for (uint8_t i = led_min; i < led_max; i++) {
     rgb_matrix_set_color(i, 0xff, 0xff, 0x00);
   }
-  return led_max < DRIVER_LED_TOTAL;
+  RGB_MATRIX_FINISHED_ALL_LEDS
 }
 
 // e.g: A more complex effect, relying on external methods and state, with
@@ -551,8 +551,7 @@ static bool my_cool_effect2_complex_run(effect_params_t* params) {
   for (uint8_t i = led_min; i < led_max; i++) {
     rgb_matrix_set_color(i, 0xff, some_global_state++, 0xff);
   }
-
-  return led_max < DRIVER_LED_TOTAL;
+  RGB_MATRIX_FINISHED_ALL_LEDS
 }
 static bool my_cool_effect2(effect_params_t* params) {
   if (params->init) my_cool_effect2_complex_init(params);

--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -537,7 +537,7 @@ static bool my_cool_effect(effect_params_t* params) {
   for (uint8_t i = led_min; i < led_max; i++) {
     rgb_matrix_set_color(i, 0xff, 0xff, 0x00);
   }
-  RGB_MATRIX_FINISHED_ALL_LEDS
+  return rgb_matrix_check_finished_leds(led_max);
 }
 
 // e.g: A more complex effect, relying on external methods and state, with
@@ -551,7 +551,7 @@ static bool my_cool_effect2_complex_run(effect_params_t* params) {
   for (uint8_t i = led_min; i < led_max; i++) {
     rgb_matrix_set_color(i, 0xff, some_global_state++, 0xff);
   }
-  RGB_MATRIX_FINISHED_ALL_LEDS
+  return rgb_matrix_check_finished_leds(led_max);
 }
 static bool my_cool_effect2(effect_params_t* params) {
   if (params->init) my_cool_effect2_complex_init(params);

--- a/keyboards/bandominedoni/rgb_matrix_user.inc
+++ b/keyboards/bandominedoni/rgb_matrix_user.inc
@@ -9,8 +9,8 @@ bool my_party_rocks(effect_params_t* params) {
     RGB rgb = rgb_matrix_hsv_to_rgb(hsv);
     // rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
     rgb_matrix_set_color_all(rgb.r, rgb.g, rgb.b);
-    return led_max < DRIVER_LED_TOTAL;
+    return rgb_matrix_check_finished_leds(led_max);
 }
 
-#    endif      // RGB_MATRIX_CUSTOM_EFFECT_IMPLS
-#endif          // RGB_MATRIX_KEYREACTIVE_ENABLED
+#    endif  // RGB_MATRIX_CUSTOM_EFFECT_IMPLS
+#endif      // RGB_MATRIX_KEYREACTIVE_ENABLED

--- a/keyboards/percent/canoe_gen2/rgb_matrix_kb.inc
+++ b/keyboards/percent/canoe_gen2/rgb_matrix_kb.inc
@@ -25,13 +25,13 @@ static bool indicator_static(effect_params_t* params) {
     HSV hsv = rgb_matrix_config.hsv;
     RGB rgb = hsv_to_rgb(hsv);
     RGB_MATRIX_USE_LIMITS(led_min, led_max);
-    for (uint8_t i = led_min ; i < 74; i++) {
+    for (uint8_t i = led_min; i < 74; i++) {
         rgb_matrix_set_color(i, 0x00, 0x00, 0x00);
     }
-    for (uint8_t i = 74 ; i < led_max; i++) {
+    for (uint8_t i = 74; i < led_max; i++) {
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
     }
-    return led_max < DRIVER_LED_TOTAL;
+    return rgb_matrix_check_finished_leds(led_max);
 }
 
 bool effect_runner_indicator(effect_params_t* params, i_f effect_func) {
@@ -47,7 +47,7 @@ bool effect_runner_indicator(effect_params_t* params, i_f effect_func) {
             rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
         }
     }
-    return led_max < DRIVER_LED_TOTAL;
+    return rgb_matrix_check_finished_leds(led_max);
 }
 
 static HSV indicator_gradient_math(HSV hsv, uint8_t i, uint8_t time) {
@@ -64,4 +64,4 @@ static HSV indicator_cycle_all_math(HSV hsv, uint8_t i, uint8_t time) {
 
 bool indicator_cycle_all(effect_params_t* params) { return effect_runner_indicator(params, &indicator_cycle_all_math); }
 
-#endif // RGB_MATRIX_CUSTOM_EFFECT_IMPLS
+#endif  // RGB_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/keyboards/yushakobo/quick17/rgb_matrix_kb.inc
+++ b/keyboards/yushakobo/quick17/rgb_matrix_kb.inc
@@ -111,7 +111,7 @@ static bool quick17_rgbm_effect (effect_params_t* params) {
             led_color_set(i, rgb_keymaps[_CONTROL][i]);
         }
     }
-    return led_max < DRIVER_LED_TOTAL;
+    return rgb_matrix_check_finished_leds(led_max);
 }
 
 #endif

--- a/quantum/led_matrix/animations/alpha_mods_anim.h
+++ b/quantum/led_matrix/animations/alpha_mods_anim.h
@@ -17,7 +17,7 @@ bool ALPHAS_MODS(effect_params_t* params) {
             led_matrix_set_value(i, val1);
         }
     }
-    return led_max < DRIVER_LED_TOTAL;
+    return led_matrix_check_finished_leds(led_max);
 }
 
 #    endif  // LED_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/quantum/led_matrix/animations/breathing_anim.h
+++ b/quantum/led_matrix/animations/breathing_anim.h
@@ -12,7 +12,7 @@ bool BREATHING(effect_params_t* params) {
         LED_MATRIX_TEST_LED_FLAGS();
         led_matrix_set_value(i, val);
     }
-    return led_max < DRIVER_LED_TOTAL;
+    return led_matrix_check_finished_leds(led_max);
 }
 
 #    endif  // LED_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/quantum/led_matrix/animations/runners/effect_runner_dx_dy.h
+++ b/quantum/led_matrix/animations/runners/effect_runner_dx_dy.h
@@ -12,5 +12,5 @@ bool effect_runner_dx_dy(effect_params_t* params, dx_dy_f effect_func) {
         int16_t dy = g_led_config.point[i].y - k_led_matrix_center.y;
         led_matrix_set_value(i, effect_func(led_matrix_eeconfig.val, dx, dy, time));
     }
-    return led_max < DRIVER_LED_TOTAL;
+    return led_matrix_check_finished_leds(led_max);
 }

--- a/quantum/led_matrix/animations/runners/effect_runner_dx_dy_dist.h
+++ b/quantum/led_matrix/animations/runners/effect_runner_dx_dy_dist.h
@@ -13,5 +13,5 @@ bool effect_runner_dx_dy_dist(effect_params_t* params, dx_dy_dist_f effect_func)
         uint8_t dist = sqrt16(dx * dx + dy * dy);
         led_matrix_set_value(i, effect_func(led_matrix_eeconfig.val, dx, dy, dist, time));
     }
-    return led_max < DRIVER_LED_TOTAL;
+    return led_matrix_check_finished_leds(led_max);
 }

--- a/quantum/led_matrix/animations/runners/effect_runner_i.h
+++ b/quantum/led_matrix/animations/runners/effect_runner_i.h
@@ -10,5 +10,5 @@ bool effect_runner_i(effect_params_t* params, i_f effect_func) {
         LED_MATRIX_TEST_LED_FLAGS();
         led_matrix_set_value(i, effect_func(led_matrix_eeconfig.val, i, time));
     }
-    return led_max < DRIVER_LED_TOTAL;
+    return led_matrix_check_finished_leds(led_max);
 }

--- a/quantum/led_matrix/animations/runners/effect_runner_reactive.h
+++ b/quantum/led_matrix/animations/runners/effect_runner_reactive.h
@@ -22,7 +22,7 @@ bool effect_runner_reactive(effect_params_t* params, reactive_f effect_func) {
         uint16_t offset = scale16by8(tick, led_matrix_eeconfig.speed);
         led_matrix_set_value(i, effect_func(led_matrix_eeconfig.val, offset));
     }
-    return led_max < DRIVER_LED_TOTAL;
+    return led_matrix_check_finished_leds(led_max);
 }
 
 #endif  // LED_MATRIX_KEYREACTIVE_ENABLED

--- a/quantum/led_matrix/animations/runners/effect_runner_reactive_splash.h
+++ b/quantum/led_matrix/animations/runners/effect_runner_reactive_splash.h
@@ -20,7 +20,7 @@ bool effect_runner_reactive_splash(uint8_t start, effect_params_t* params, react
         }
         led_matrix_set_value(i, scale8(val, led_matrix_eeconfig.val));
     }
-    return led_max < DRIVER_LED_TOTAL;
+    return led_matrix_check_finished_leds(led_max);
 }
 
 #endif  // LED_MATRIX_KEYREACTIVE_ENABLED

--- a/quantum/led_matrix/animations/runners/effect_runner_sin_cos_i.h
+++ b/quantum/led_matrix/animations/runners/effect_runner_sin_cos_i.h
@@ -12,5 +12,5 @@ bool effect_runner_sin_cos_i(effect_params_t* params, sin_cos_i_f effect_func) {
         LED_MATRIX_TEST_LED_FLAGS();
         led_matrix_set_value(i, effect_func(led_matrix_eeconfig.val, cos_value, sin_value, i, time));
     }
-    return led_max < DRIVER_LED_TOTAL;
+    return led_matrix_check_finished_leds(led_max);
 }

--- a/quantum/led_matrix/animations/solid_anim.h
+++ b/quantum/led_matrix/animations/solid_anim.h
@@ -9,7 +9,7 @@ bool SOLID(effect_params_t* params) {
         LED_MATRIX_TEST_LED_FLAGS();
         led_matrix_set_value(i, val);
     }
-    return led_max < DRIVER_LED_TOTAL;
+    return led_matrix_check_finished_leds(led_max);
 }
 
 #endif  // LED_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/quantum/led_matrix/led_matrix.c
+++ b/quantum/led_matrix/led_matrix.c
@@ -165,20 +165,10 @@ uint8_t led_matrix_map_row_column_to_led(uint8_t row, uint8_t column, uint8_t *l
 void led_matrix_update_pwm_buffers(void) { led_matrix_driver.flush(); }
 
 void led_matrix_set_value(int index, uint8_t value) {
-#if defined(LED_MATRIX_ENABLE) && defined(LED_MATRIX_SPLIT)
-    if (!is_keyboard_left() && index >= k_led_matrix_split[0])
-#    ifdef USE_CIE1931_CURVE
-        led_matrix_driver.set_value(index - k_led_matrix_split[0], pgm_read_byte(&CIE1931_CURVE[value]));
-#    else
-        led_matrix_driver.set_value(index - k_led_matrix_split[0], value);
-#    endif
-    else if (is_keyboard_left() && index < k_led_matrix_split[0])
-#endif
 #ifdef USE_CIE1931_CURVE
-        led_matrix_driver.set_value(index, pgm_read_byte(&CIE1931_CURVE[value]));
-#else
-    led_matrix_driver.set_value(index, value);
+    value = pgm_read_byte(&CIE1931_CURVE[value]);
 #endif
+    led_matrix_driver.set_value(index, value);
 }
 
 void led_matrix_set_value_all(uint8_t value) {

--- a/quantum/led_matrix/led_matrix.h
+++ b/quantum/led_matrix/led_matrix.h
@@ -38,14 +38,33 @@
 #endif
 
 #if defined(LED_MATRIX_LED_PROCESS_LIMIT) && LED_MATRIX_LED_PROCESS_LIMIT > 0 && LED_MATRIX_LED_PROCESS_LIMIT < DRIVER_LED_TOTAL
-#    define LED_MATRIX_USE_LIMITS(min, max)                        \
-        uint8_t min = LED_MATRIX_LED_PROCESS_LIMIT * params->iter; \
-        uint8_t max = min + LED_MATRIX_LED_PROCESS_LIMIT;          \
-        if (max > DRIVER_LED_TOTAL) max = DRIVER_LED_TOTAL;
+#    if defined(LED_MATRIX_SPLIT)
+#        define LED_MATRIX_USE_LIMITS(min, max)
+uint8_t min = LED_MATRIX_LED_PROCESS_LIMIT * params->iter;
+uint8_t max = min + LED_MATRIX_LED_PROCESS_LIMIT;
+if (max > DRIVER_LED_TOTAL) max = DRIVER_LED_TOTAL;
+uint8_t k_led_matrix_split[2] = LED_MATRIX_SPLIT;
+if (is_keyboard_left() && (max > k_led_matrix_split[0])) max = k_led_matrix_split[0];
+if (!(is_keyboard_left()) && (min < k_led_matrix_split[0])) min = k_led_matrix_split[0];
+#    else
+#        define LED_MATRIX_USE_LIMITS(min, max)                        \
+            uint8_t min = LED_MATRIX_LED_PROCESS_LIMIT * params->iter; \
+            uint8_t max = min + LED_MATRIX_LED_PROCESS_LIMIT;          \
+            if (max > DRIVER_LED_TOTAL) max = DRIVER_LED_TOTAL;
+#    endif
 #else
-#    define LED_MATRIX_USE_LIMITS(min, max) \
-        uint8_t min = 0;                    \
-        uint8_t max = DRIVER_LED_TOTAL;
+#    if defined(LED_MATRIX_SPLIT)
+#        define LED_MATRIX_USE_LIMITS(min, max)                                                   \
+            uint8_t       min                   = 0;                                              \
+            uint8_t       max                   = DRIVER_LED_TOTAL;                               \
+            const uint8_t k_led_matrix_split[2] = LED_MATRIX_SPLIT;                               \
+            if (is_keyboard_left() && (max > k_led_matrix_split[0])) max = k_led_matrix_split[0]; \
+            if (!(is_keyboard_left()) && (min < k_led_matrix_split[0])) min = k_led_matrix_split[0];
+#    else
+#        define LED_MATRIX_USE_LIMITS(min, max) \
+            uint8_t min = 0;                    \
+            uint8_t max = DRIVER_LED_TOTAL;
+#    endif
 #endif
 
 #define LED_MATRIX_TEST_LED_FLAGS() \
@@ -146,6 +165,18 @@ typedef struct {
     /* Flush any buffered changes to the hardware. */
     void (*flush)(void);
 } led_matrix_driver_t;
+
+inline bool led_matrix_check_finished_leds(uint8_t led_idx) {
+#if defined(LED_MATRIX_SPLIT)
+    if (is_keyboard_left()) {
+        uint8_t k_led_matrix_split[2] = LED_MATRIX_SPLIT;
+        return led_idx < k_led_matrix_split[0];
+    } else
+        return led_idx < DRIVER_LED_TOTAL;
+#else
+    return led_idx < DRIVER_LED_TOTAL;
+#endif
+}
 
 extern const led_matrix_driver_t led_matrix_driver;
 

--- a/quantum/led_matrix/led_matrix.h
+++ b/quantum/led_matrix/led_matrix.h
@@ -135,6 +135,15 @@ void        led_matrix_decrease_speed_noeeprom(void);
 led_flags_t led_matrix_get_flags(void);
 void        led_matrix_set_flags(led_flags_t flags);
 
+inline bool led_matrix_finished_all_leds(uint8_t last_led_idx) {
+    #if defined(RGB_MATRIX_SPLIT)
+        if (is_keyboard_left()) return led_max < k_rgb_matrix_split[0];
+        else return led_max < DRIVER_LED_TOTAL;
+    #else
+        return led_max < DRIVER_LED_TOTAL;
+    #endif
+}
+
 typedef struct {
     /* Perform any initialisation required for the other driver functions to work. */
     void (*init)(void);

--- a/quantum/led_matrix/led_matrix.h
+++ b/quantum/led_matrix/led_matrix.h
@@ -135,7 +135,6 @@ void        led_matrix_decrease_speed_noeeprom(void);
 led_flags_t led_matrix_get_flags(void);
 void        led_matrix_set_flags(led_flags_t flags);
 
-
 typedef struct {
     /* Perform any initialisation required for the other driver functions to work. */
     void (*init)(void);

--- a/quantum/led_matrix/led_matrix.h
+++ b/quantum/led_matrix/led_matrix.h
@@ -135,14 +135,6 @@ void        led_matrix_decrease_speed_noeeprom(void);
 led_flags_t led_matrix_get_flags(void);
 void        led_matrix_set_flags(led_flags_t flags);
 
-inline bool led_matrix_finished_all_leds(uint8_t last_led_idx) {
-    #if defined(RGB_MATRIX_SPLIT)
-        if (is_keyboard_left()) return led_max < k_rgb_matrix_split[0];
-        else return led_max < DRIVER_LED_TOTAL;
-    #else
-        return led_max < DRIVER_LED_TOTAL;
-    #endif
-}
 
 typedef struct {
     /* Perform any initialisation required for the other driver functions to work. */

--- a/quantum/led_matrix/led_matrix.h
+++ b/quantum/led_matrix/led_matrix.h
@@ -166,7 +166,7 @@ typedef struct {
     void (*flush)(void);
 } led_matrix_driver_t;
 
-inline bool led_matrix_check_finished_leds(uint8_t led_idx) {
+static inline bool led_matrix_check_finished_leds(uint8_t led_idx) {
 #if defined(LED_MATRIX_SPLIT)
     if (is_keyboard_left()) {
         uint8_t k_led_matrix_split[2] = LED_MATRIX_SPLIT;

--- a/quantum/rgb_matrix/animations/alpha_mods_anim.h
+++ b/quantum/rgb_matrix/animations/alpha_mods_anim.h
@@ -19,7 +19,7 @@ bool ALPHAS_MODS(effect_params_t* params) {
             rgb_matrix_set_color(i, rgb1.r, rgb1.g, rgb1.b);
         }
     }
-    RGB_MATRIX_FINISHED_ALL_LEDS
+    return rgb_matrix_check_finished_leds(led_max);
 }
 
 #    endif  // RGB_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/quantum/rgb_matrix/animations/alpha_mods_anim.h
+++ b/quantum/rgb_matrix/animations/alpha_mods_anim.h
@@ -19,7 +19,7 @@ bool ALPHAS_MODS(effect_params_t* params) {
             rgb_matrix_set_color(i, rgb1.r, rgb1.g, rgb1.b);
         }
     }
-    return led_max < DRIVER_LED_TOTAL;
+    RGB_MATRIX_FINISHED_ALL_LEDS
 }
 
 #    endif  // RGB_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/quantum/rgb_matrix/animations/breathing_anim.h
+++ b/quantum/rgb_matrix/animations/breathing_anim.h
@@ -13,7 +13,7 @@ bool BREATHING(effect_params_t* params) {
         RGB_MATRIX_TEST_LED_FLAGS();
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
     }
-    return led_max < DRIVER_LED_TOTAL;
+    RGB_MATRIX_FINISHED_ALL_LEDS
 }
 
 #    endif  // RGB_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/quantum/rgb_matrix/animations/breathing_anim.h
+++ b/quantum/rgb_matrix/animations/breathing_anim.h
@@ -13,7 +13,7 @@ bool BREATHING(effect_params_t* params) {
         RGB_MATRIX_TEST_LED_FLAGS();
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
     }
-    RGB_MATRIX_FINISHED_ALL_LEDS
+    return rgb_matrix_check_finished_leds(led_max);
 }
 
 #    endif  // RGB_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/quantum/rgb_matrix/animations/gradient_left_right_anim.h
+++ b/quantum/rgb_matrix/animations/gradient_left_right_anim.h
@@ -15,7 +15,7 @@ bool GRADIENT_LEFT_RIGHT(effect_params_t* params) {
         RGB rgb = rgb_matrix_hsv_to_rgb(hsv);
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
     }
-    return led_max < DRIVER_LED_TOTAL;
+    RGB_MATRIX_FINISHED_ALL_LEDS
 }
 
 #    endif  // RGB_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/quantum/rgb_matrix/animations/gradient_left_right_anim.h
+++ b/quantum/rgb_matrix/animations/gradient_left_right_anim.h
@@ -15,7 +15,7 @@ bool GRADIENT_LEFT_RIGHT(effect_params_t* params) {
         RGB rgb = rgb_matrix_hsv_to_rgb(hsv);
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
     }
-    RGB_MATRIX_FINISHED_ALL_LEDS
+    return rgb_matrix_check_finished_leds(led_max);
 }
 
 #    endif  // RGB_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/quantum/rgb_matrix/animations/gradient_up_down_anim.h
+++ b/quantum/rgb_matrix/animations/gradient_up_down_anim.h
@@ -15,7 +15,7 @@ bool GRADIENT_UP_DOWN(effect_params_t* params) {
         RGB rgb = rgb_matrix_hsv_to_rgb(hsv);
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
     }
-    RGB_MATRIX_FINISHED_ALL_LEDS
+    return rgb_matrix_check_finished_leds(led_max);
 }
 
 #    endif  // RGB_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/quantum/rgb_matrix/animations/gradient_up_down_anim.h
+++ b/quantum/rgb_matrix/animations/gradient_up_down_anim.h
@@ -15,7 +15,7 @@ bool GRADIENT_UP_DOWN(effect_params_t* params) {
         RGB rgb = rgb_matrix_hsv_to_rgb(hsv);
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
     }
-    return led_max < DRIVER_LED_TOTAL;
+    RGB_MATRIX_FINISHED_ALL_LEDS
 }
 
 #    endif  // RGB_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/quantum/rgb_matrix/animations/hue_breathing_anim.h
+++ b/quantum/rgb_matrix/animations/hue_breathing_anim.h
@@ -15,7 +15,7 @@ bool HUE_BREATHING(effect_params_t* params) {
         RGB_MATRIX_TEST_LED_FLAGS();
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
     }
-    RGB_MATRIX_FINISHED_ALL_LEDS
+    return rgb_matrix_check_finished_leds(led_max);
 }
 
 #    endif  // RGB_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/quantum/rgb_matrix/animations/hue_breathing_anim.h
+++ b/quantum/rgb_matrix/animations/hue_breathing_anim.h
@@ -15,7 +15,7 @@ bool HUE_BREATHING(effect_params_t* params) {
         RGB_MATRIX_TEST_LED_FLAGS();
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
     }
-    return led_max < DRIVER_LED_TOTAL;
+    RGB_MATRIX_FINISHED_ALL_LEDS
 }
 
 #    endif  // RGB_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/quantum/rgb_matrix/animations/jellybean_raindrops_anim.h
+++ b/quantum/rgb_matrix/animations/jellybean_raindrops_anim.h
@@ -22,7 +22,7 @@ bool JELLYBEAN_RAINDROPS(effect_params_t* params) {
     for (int i = led_min; i < led_max; i++) {
         jellybean_raindrops_set_color(i, params);
     }
-    RGB_MATRIX_FINISHED_ALL_LEDS
+    return rgb_matrix_check_finished_leds(led_max);
 }
 
 #    endif  // RGB_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/quantum/rgb_matrix/animations/jellybean_raindrops_anim.h
+++ b/quantum/rgb_matrix/animations/jellybean_raindrops_anim.h
@@ -22,7 +22,7 @@ bool JELLYBEAN_RAINDROPS(effect_params_t* params) {
     for (int i = led_min; i < led_max; i++) {
         jellybean_raindrops_set_color(i, params);
     }
-    return led_max < DRIVER_LED_TOTAL;
+    RGB_MATRIX_FINISHED_ALL_LEDS
 }
 
 #    endif  // RGB_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/quantum/rgb_matrix/animations/raindrops_anim.h
+++ b/quantum/rgb_matrix/animations/raindrops_anim.h
@@ -32,7 +32,7 @@ bool RAINDROPS(effect_params_t* params) {
     for (int i = led_min; i < led_max; i++) {
         raindrops_set_color(i, params);
     }
-    RGB_MATRIX_FINISHED_ALL_LEDS
+    return rgb_matrix_check_finished_leds(led_max);
 }
 
 #    endif  // RGB_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/quantum/rgb_matrix/animations/raindrops_anim.h
+++ b/quantum/rgb_matrix/animations/raindrops_anim.h
@@ -32,7 +32,7 @@ bool RAINDROPS(effect_params_t* params) {
     for (int i = led_min; i < led_max; i++) {
         raindrops_set_color(i, params);
     }
-    return led_max < DRIVER_LED_TOTAL;
+    RGB_MATRIX_FINISHED_ALL_LEDS
 }
 
 #    endif  // RGB_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/quantum/rgb_matrix/animations/runners/effect_runner_dx_dy.h
+++ b/quantum/rgb_matrix/animations/runners/effect_runner_dx_dy.h
@@ -13,5 +13,10 @@ bool effect_runner_dx_dy(effect_params_t* params, dx_dy_f effect_func) {
         RGB     rgb = rgb_matrix_hsv_to_rgb(effect_func(rgb_matrix_config.hsv, dx, dy, time));
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
     }
-    return led_max < DRIVER_LED_TOTAL;
+    #if defined(RGB_MATRIX_SPLIT)
+        if (is_keyboard_left()) return led_max < k_rgb_matrix_split[0];
+        else return led_max < DRIVER_LED_TOTAL;
+    #else
+        return led_max < DRIVER_LED_TOTAL;
+    #endif
 }

--- a/quantum/rgb_matrix/animations/runners/effect_runner_dx_dy.h
+++ b/quantum/rgb_matrix/animations/runners/effect_runner_dx_dy.h
@@ -13,5 +13,5 @@ bool effect_runner_dx_dy(effect_params_t* params, dx_dy_f effect_func) {
         RGB     rgb = rgb_matrix_hsv_to_rgb(effect_func(rgb_matrix_config.hsv, dx, dy, time));
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
     }
-    RGB_MATRIX_FINISHED_ALL_LEDS
+    return rgb_matrix_check_finished_leds(led_max);
 }

--- a/quantum/rgb_matrix/animations/runners/effect_runner_dx_dy.h
+++ b/quantum/rgb_matrix/animations/runners/effect_runner_dx_dy.h
@@ -13,5 +13,5 @@ bool effect_runner_dx_dy(effect_params_t* params, dx_dy_f effect_func) {
         RGB     rgb = rgb_matrix_hsv_to_rgb(effect_func(rgb_matrix_config.hsv, dx, dy, time));
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
     }
-    return rgb_matrix_finished_all_leds(led_max);
+    RGB_MATRIX_FINISHED_ALL_LEDS
 }

--- a/quantum/rgb_matrix/animations/runners/effect_runner_dx_dy.h
+++ b/quantum/rgb_matrix/animations/runners/effect_runner_dx_dy.h
@@ -13,10 +13,5 @@ bool effect_runner_dx_dy(effect_params_t* params, dx_dy_f effect_func) {
         RGB     rgb = rgb_matrix_hsv_to_rgb(effect_func(rgb_matrix_config.hsv, dx, dy, time));
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
     }
-    #if defined(RGB_MATRIX_SPLIT)
-        if (is_keyboard_left()) return led_max < k_rgb_matrix_split[0];
-        else return led_max < DRIVER_LED_TOTAL;
-    #else
-        return led_max < DRIVER_LED_TOTAL;
-    #endif
+    return rgb_matrix_finished_all_leds(led_max);
 }

--- a/quantum/rgb_matrix/animations/runners/effect_runner_dx_dy_dist.h
+++ b/quantum/rgb_matrix/animations/runners/effect_runner_dx_dy_dist.h
@@ -14,5 +14,5 @@ bool effect_runner_dx_dy_dist(effect_params_t* params, dx_dy_dist_f effect_func)
         RGB     rgb  = rgb_matrix_hsv_to_rgb(effect_func(rgb_matrix_config.hsv, dx, dy, dist, time));
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
     }
-    RGB_MATRIX_FINISHED_ALL_LEDS
+    return rgb_matrix_check_finished_leds(led_max);
 }

--- a/quantum/rgb_matrix/animations/runners/effect_runner_dx_dy_dist.h
+++ b/quantum/rgb_matrix/animations/runners/effect_runner_dx_dy_dist.h
@@ -14,10 +14,5 @@ bool effect_runner_dx_dy_dist(effect_params_t* params, dx_dy_dist_f effect_func)
         RGB     rgb  = rgb_matrix_hsv_to_rgb(effect_func(rgb_matrix_config.hsv, dx, dy, dist, time));
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
     }
-    #if defined(RGB_MATRIX_SPLIT)
-        if (is_keyboard_left()) return led_max < k_rgb_matrix_split[0];
-        else return led_max < DRIVER_LED_TOTAL;
-    #else
-        return led_max < DRIVER_LED_TOTAL;
-    #endif
+    RGB_MATRIX_FINISHED_ALL_LEDS
 }

--- a/quantum/rgb_matrix/animations/runners/effect_runner_dx_dy_dist.h
+++ b/quantum/rgb_matrix/animations/runners/effect_runner_dx_dy_dist.h
@@ -14,5 +14,10 @@ bool effect_runner_dx_dy_dist(effect_params_t* params, dx_dy_dist_f effect_func)
         RGB     rgb  = rgb_matrix_hsv_to_rgb(effect_func(rgb_matrix_config.hsv, dx, dy, dist, time));
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
     }
-    return led_max < DRIVER_LED_TOTAL;
+    #if defined(RGB_MATRIX_SPLIT)
+        if (is_keyboard_left()) return led_max < k_rgb_matrix_split[0];
+        else return led_max < DRIVER_LED_TOTAL;
+    #else
+        return led_max < DRIVER_LED_TOTAL;
+    #endif
 }

--- a/quantum/rgb_matrix/animations/runners/effect_runner_i.h
+++ b/quantum/rgb_matrix/animations/runners/effect_runner_i.h
@@ -11,10 +11,5 @@ bool effect_runner_i(effect_params_t* params, i_f effect_func) {
         RGB rgb = rgb_matrix_hsv_to_rgb(effect_func(rgb_matrix_config.hsv, i, time));
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
     }
-    #if defined(RGB_MATRIX_SPLIT)
-        if (is_keyboard_left()) return led_max < k_rgb_matrix_split[0];
-        else return led_max < DRIVER_LED_TOTAL;
-    #else
-        return led_max < DRIVER_LED_TOTAL;
-    #endif
+    RGB_MATRIX_FINISHED_ALL_LEDS
 }

--- a/quantum/rgb_matrix/animations/runners/effect_runner_i.h
+++ b/quantum/rgb_matrix/animations/runners/effect_runner_i.h
@@ -11,5 +11,5 @@ bool effect_runner_i(effect_params_t* params, i_f effect_func) {
         RGB rgb = rgb_matrix_hsv_to_rgb(effect_func(rgb_matrix_config.hsv, i, time));
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
     }
-    RGB_MATRIX_FINISHED_ALL_LEDS
+    return rgb_matrix_check_finished_leds(led_max);
 }

--- a/quantum/rgb_matrix/animations/runners/effect_runner_i.h
+++ b/quantum/rgb_matrix/animations/runners/effect_runner_i.h
@@ -11,5 +11,10 @@ bool effect_runner_i(effect_params_t* params, i_f effect_func) {
         RGB rgb = rgb_matrix_hsv_to_rgb(effect_func(rgb_matrix_config.hsv, i, time));
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
     }
-    return led_max < DRIVER_LED_TOTAL;
+    #if defined(RGB_MATRIX_SPLIT)
+        if (is_keyboard_left()) return led_max < k_rgb_matrix_split[0];
+        else return led_max < DRIVER_LED_TOTAL;
+    #else
+        return led_max < DRIVER_LED_TOTAL;
+    #endif
 }

--- a/quantum/rgb_matrix/animations/runners/effect_runner_reactive.h
+++ b/quantum/rgb_matrix/animations/runners/effect_runner_reactive.h
@@ -24,7 +24,7 @@ bool effect_runner_reactive(effect_params_t* params, reactive_f effect_func) {
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
 
     }
-    RGB_MATRIX_FINISHED_ALL_LEDS
+    return rgb_matrix_check_finished_leds(led_max);
 }
 
 #endif  // RGB_MATRIX_KEYREACTIVE_ENABLED

--- a/quantum/rgb_matrix/animations/runners/effect_runner_reactive.h
+++ b/quantum/rgb_matrix/animations/runners/effect_runner_reactive.h
@@ -24,12 +24,7 @@ bool effect_runner_reactive(effect_params_t* params, reactive_f effect_func) {
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
 
     }
-    #if defined(RGB_MATRIX_SPLIT)
-        if (is_keyboard_left()) return led_max < k_rgb_matrix_split[0];
-        else return led_max < DRIVER_LED_TOTAL;
-    #else
-        return led_max < DRIVER_LED_TOTAL;
-    #endif
+    RGB_MATRIX_FINISHED_ALL_LEDS
 }
 
 #endif  // RGB_MATRIX_KEYREACTIVE_ENABLED

--- a/quantum/rgb_matrix/animations/runners/effect_runner_reactive.h
+++ b/quantum/rgb_matrix/animations/runners/effect_runner_reactive.h
@@ -22,8 +22,14 @@ bool effect_runner_reactive(effect_params_t* params, reactive_f effect_func) {
         uint16_t offset = scale16by8(tick, qadd8(rgb_matrix_config.speed, 1));
         RGB      rgb    = rgb_matrix_hsv_to_rgb(effect_func(rgb_matrix_config.hsv, offset));
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
+
     }
-    return led_max < DRIVER_LED_TOTAL;
+    #if defined(RGB_MATRIX_SPLIT)
+        if (is_keyboard_left()) return led_max < k_rgb_matrix_split[0];
+        else return led_max < DRIVER_LED_TOTAL;
+    #else
+        return led_max < DRIVER_LED_TOTAL;
+    #endif
 }
 
 #endif  // RGB_MATRIX_KEYREACTIVE_ENABLED

--- a/quantum/rgb_matrix/animations/runners/effect_runner_reactive.h
+++ b/quantum/rgb_matrix/animations/runners/effect_runner_reactive.h
@@ -22,7 +22,6 @@ bool effect_runner_reactive(effect_params_t* params, reactive_f effect_func) {
         uint16_t offset = scale16by8(tick, qadd8(rgb_matrix_config.speed, 1));
         RGB      rgb    = rgb_matrix_hsv_to_rgb(effect_func(rgb_matrix_config.hsv, offset));
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
-
     }
     return rgb_matrix_check_finished_leds(led_max);
 }

--- a/quantum/rgb_matrix/animations/runners/effect_runner_reactive_splash.h
+++ b/quantum/rgb_matrix/animations/runners/effect_runner_reactive_splash.h
@@ -23,12 +23,7 @@ bool effect_runner_reactive_splash(uint8_t start, effect_params_t* params, react
         RGB rgb = rgb_matrix_hsv_to_rgb(hsv);
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
     }
-    #if defined(RGB_MATRIX_SPLIT)
-        if (is_keyboard_left()) return led_max < k_rgb_matrix_split[0];
-        else return led_max < DRIVER_LED_TOTAL;
-    #else
-        return led_max < DRIVER_LED_TOTAL;
-    #endif
+    RGB_MATRIX_FINISHED_ALL_LEDS
 }
 
 #endif  // RGB_MATRIX_KEYREACTIVE_ENABLED

--- a/quantum/rgb_matrix/animations/runners/effect_runner_reactive_splash.h
+++ b/quantum/rgb_matrix/animations/runners/effect_runner_reactive_splash.h
@@ -23,7 +23,7 @@ bool effect_runner_reactive_splash(uint8_t start, effect_params_t* params, react
         RGB rgb = rgb_matrix_hsv_to_rgb(hsv);
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
     }
-    RGB_MATRIX_FINISHED_ALL_LEDS
+    return rgb_matrix_check_finished_leds(led_max);
 }
 
 #endif  // RGB_MATRIX_KEYREACTIVE_ENABLED

--- a/quantum/rgb_matrix/animations/runners/effect_runner_reactive_splash.h
+++ b/quantum/rgb_matrix/animations/runners/effect_runner_reactive_splash.h
@@ -23,7 +23,12 @@ bool effect_runner_reactive_splash(uint8_t start, effect_params_t* params, react
         RGB rgb = rgb_matrix_hsv_to_rgb(hsv);
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
     }
-    return led_max < DRIVER_LED_TOTAL;
+    #if defined(RGB_MATRIX_SPLIT)
+        if (is_keyboard_left()) return led_max < k_rgb_matrix_split[0];
+        else return led_max < DRIVER_LED_TOTAL;
+    #else
+        return led_max < DRIVER_LED_TOTAL;
+    #endif
 }
 
 #endif  // RGB_MATRIX_KEYREACTIVE_ENABLED

--- a/quantum/rgb_matrix/animations/runners/effect_runner_sin_cos_i.h
+++ b/quantum/rgb_matrix/animations/runners/effect_runner_sin_cos_i.h
@@ -13,5 +13,5 @@ bool effect_runner_sin_cos_i(effect_params_t* params, sin_cos_i_f effect_func) {
         RGB rgb = rgb_matrix_hsv_to_rgb(effect_func(rgb_matrix_config.hsv, cos_value, sin_value, i, time));
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
     }
-    RGB_MATRIX_FINISHED_ALL_LEDS
+    return rgb_matrix_check_finished_leds(led_max);
 }

--- a/quantum/rgb_matrix/animations/runners/effect_runner_sin_cos_i.h
+++ b/quantum/rgb_matrix/animations/runners/effect_runner_sin_cos_i.h
@@ -13,10 +13,5 @@ bool effect_runner_sin_cos_i(effect_params_t* params, sin_cos_i_f effect_func) {
         RGB rgb = rgb_matrix_hsv_to_rgb(effect_func(rgb_matrix_config.hsv, cos_value, sin_value, i, time));
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
     }
-    #if defined(RGB_MATRIX_SPLIT)
-        if (is_keyboard_left()) return led_max < k_rgb_matrix_split[0];
-        else return led_max < DRIVER_LED_TOTAL;
-    #else
-        return led_max < DRIVER_LED_TOTAL;
-    #endif
+    RGB_MATRIX_FINISHED_ALL_LEDS
 }

--- a/quantum/rgb_matrix/animations/runners/effect_runner_sin_cos_i.h
+++ b/quantum/rgb_matrix/animations/runners/effect_runner_sin_cos_i.h
@@ -13,5 +13,10 @@ bool effect_runner_sin_cos_i(effect_params_t* params, sin_cos_i_f effect_func) {
         RGB rgb = rgb_matrix_hsv_to_rgb(effect_func(rgb_matrix_config.hsv, cos_value, sin_value, i, time));
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
     }
-    return led_max < DRIVER_LED_TOTAL;
+    #if defined(RGB_MATRIX_SPLIT)
+        if (is_keyboard_left()) return led_max < k_rgb_matrix_split[0];
+        else return led_max < DRIVER_LED_TOTAL;
+    #else
+        return led_max < DRIVER_LED_TOTAL;
+    #endif
 }

--- a/quantum/rgb_matrix/animations/solid_color_anim.h
+++ b/quantum/rgb_matrix/animations/solid_color_anim.h
@@ -9,7 +9,7 @@ bool SOLID_COLOR(effect_params_t* params) {
         RGB_MATRIX_TEST_LED_FLAGS();
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
     }
-    RGB_MATRIX_FINISHED_ALL_LEDS
+    return rgb_matrix_check_finished_leds(led_max);
 }
 
 #endif  // RGB_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/quantum/rgb_matrix/animations/solid_color_anim.h
+++ b/quantum/rgb_matrix/animations/solid_color_anim.h
@@ -9,7 +9,7 @@ bool SOLID_COLOR(effect_params_t* params) {
         RGB_MATRIX_TEST_LED_FLAGS();
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
     }
-    return led_max < DRIVER_LED_TOTAL;
+    RGB_MATRIX_FINISHED_ALL_LEDS
 }
 
 #endif  // RGB_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/quantum/rgb_matrix/rgb_matrix.c
+++ b/quantum/rgb_matrix/rgb_matrix.c
@@ -188,13 +188,7 @@ uint8_t rgb_matrix_map_row_column_to_led(uint8_t row, uint8_t column, uint8_t *l
 void rgb_matrix_update_pwm_buffers(void) { rgb_matrix_driver.flush(); }
 
 void rgb_matrix_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
-// #if defined(RGB_MATRIX_ENABLE) && defined(RGB_MATRIX_SPLIT) && RGB_MATRIX_DRIVER == WS2812
-//     if (!is_keyboard_left() && index >= k_rgb_matrix_split[0])
-//         rgb_matrix_driver.set_color(index - k_rgb_matrix_split[0], red, green, blue);
-//     else if (is_keyboard_left() && index < k_rgb_matrix_split[0])
-// #endif
-        rgb_matrix_driver.set_color(index, red, green, blue);
-
+    rgb_matrix_driver.set_color(index, red, green, blue);
 }
 
 void rgb_matrix_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {

--- a/quantum/rgb_matrix/rgb_matrix.c
+++ b/quantum/rgb_matrix/rgb_matrix.c
@@ -187,9 +187,7 @@ uint8_t rgb_matrix_map_row_column_to_led(uint8_t row, uint8_t column, uint8_t *l
 
 void rgb_matrix_update_pwm_buffers(void) { rgb_matrix_driver.flush(); }
 
-void rgb_matrix_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
-    rgb_matrix_driver.set_color(index, red, green, blue);
-}
+void rgb_matrix_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) { rgb_matrix_driver.set_color(index, red, green, blue); }
 
 void rgb_matrix_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {
 #if defined(RGB_MATRIX_ENABLE) && defined(RGB_MATRIX_SPLIT)

--- a/quantum/rgb_matrix/rgb_matrix.c
+++ b/quantum/rgb_matrix/rgb_matrix.c
@@ -188,12 +188,13 @@ uint8_t rgb_matrix_map_row_column_to_led(uint8_t row, uint8_t column, uint8_t *l
 void rgb_matrix_update_pwm_buffers(void) { rgb_matrix_driver.flush(); }
 
 void rgb_matrix_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
-#if defined(RGB_MATRIX_ENABLE) && defined(RGB_MATRIX_SPLIT)
-    if (!is_keyboard_left() && index >= k_rgb_matrix_split[0])
-        rgb_matrix_driver.set_color(index - k_rgb_matrix_split[0], red, green, blue);
-    else if (is_keyboard_left() && index < k_rgb_matrix_split[0])
-#endif
+// #if defined(RGB_MATRIX_ENABLE) && defined(RGB_MATRIX_SPLIT) && RGB_MATRIX_DRIVER == WS2812
+//     if (!is_keyboard_left() && index >= k_rgb_matrix_split[0])
+//         rgb_matrix_driver.set_color(index - k_rgb_matrix_split[0], red, green, blue);
+//     else if (is_keyboard_left() && index < k_rgb_matrix_split[0])
+// #endif
         rgb_matrix_driver.set_color(index, red, green, blue);
+
 }
 
 void rgb_matrix_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {

--- a/quantum/rgb_matrix/rgb_matrix.h
+++ b/quantum/rgb_matrix/rgb_matrix.h
@@ -235,14 +235,16 @@ typedef struct {
     void (*flush)(void);
 } rgb_matrix_driver_t;
 
-inline bool rgb_matrix_finished_all_leds(uint8_t last_led_idx) {
-    #if defined(RGB_MATRIX_SPLIT)
-        if (is_keyboard_left()) return last_led_idx < k_rgb_matrix_split[0];
-        else return last_led_idx < DRIVER_LED_TOTAL;
-    #else
-        return last_led_idx < DRIVER_LED_TOTAL;
-    #endif
-}
+
+#if defined(RGB_MATRIX_SPLIT)
+#define RGB_MATRIX_FINISHED_ALL_LEDS \
+    if (is_keyboard_left()) return led_max < k_rgb_matrix_split[0]; \
+    else return led_max < DRIVER_LED_TOTAL;
+#else
+#define RGB_MATRIX_FINISHED_ALL_LEDS \
+    return led_max < DRIVER_LED_TOTAL;
+
+#endif
 
 extern const rgb_matrix_driver_t rgb_matrix_driver;
 

--- a/quantum/rgb_matrix/rgb_matrix.h
+++ b/quantum/rgb_matrix/rgb_matrix.h
@@ -236,9 +236,10 @@ typedef struct {
 
 inline bool rgb_matrix_check_finished_leds(uint8_t led_idx) {
 #if defined(RGB_MATRIX_SPLIT)
-    if (is_keyboard_left())
+    if (is_keyboard_left()){
         uint8_t k_rgb_matrix_split[2] = RGB_MATRIX_SPLIT; 
         return led_idx < k_rgb_matrix_split[0];
+    }
     else
         return led_idx < DRIVER_LED_TOTAL;
 #else

--- a/quantum/rgb_matrix/rgb_matrix.h
+++ b/quantum/rgb_matrix/rgb_matrix.h
@@ -233,20 +233,17 @@ typedef struct {
     void (*flush)(void);
 } rgb_matrix_driver_t;
 
-
 inline bool rgb_matrix_check_finished_leds(uint8_t led_idx) {
 #if defined(RGB_MATRIX_SPLIT)
-    if (is_keyboard_left()){
-        uint8_t k_rgb_matrix_split[2] = RGB_MATRIX_SPLIT; 
+    if (is_keyboard_left()) {
+        uint8_t k_rgb_matrix_split[2] = RGB_MATRIX_SPLIT;
         return led_idx < k_rgb_matrix_split[0];
-    }
-    else
+    } else
         return led_idx < DRIVER_LED_TOTAL;
 #else
     return led_idx < DRIVER_LED_TOTAL;
 #endif
 }
-
 
 extern const rgb_matrix_driver_t rgb_matrix_driver;
 

--- a/quantum/rgb_matrix/rgb_matrix.h
+++ b/quantum/rgb_matrix/rgb_matrix.h
@@ -233,7 +233,7 @@ typedef struct {
     void (*flush)(void);
 } rgb_matrix_driver_t;
 
-inline bool rgb_matrix_check_finished_leds(uint8_t led_idx) {
+static inline bool rgb_matrix_check_finished_leds(uint8_t led_idx) {
 #if defined(RGB_MATRIX_SPLIT)
     if (is_keyboard_left()) {
         uint8_t k_rgb_matrix_split[2] = RGB_MATRIX_SPLIT;

--- a/quantum/rgb_matrix/rgb_matrix.h
+++ b/quantum/rgb_matrix/rgb_matrix.h
@@ -54,8 +54,6 @@
                 uint8_t max = min + RGB_MATRIX_LED_PROCESS_LIMIT;          \
                 if (max > DRIVER_LED_TOTAL) max = DRIVER_LED_TOTAL;  \
                 uint8_t k_rgb_matrix_split[2] = RGB_MATRIX_SPLIT; \
-                k_rgb_matrix_split[1] += 1; \
-                k_rgb_matrix_split[1] -= 1; \
                 if (is_keyboard_left() && (max > k_rgb_matrix_split[0])) max = k_rgb_matrix_split[0] ; \
                 if( !(is_keyboard_left()) && (min < k_rgb_matrix_split[0])) min = k_rgb_matrix_split[0]; 
     #else

--- a/quantum/rgb_matrix/rgb_matrix.h
+++ b/quantum/rgb_matrix/rgb_matrix.h
@@ -48,14 +48,35 @@
 #endif
 
 #if defined(RGB_MATRIX_LED_PROCESS_LIMIT) && RGB_MATRIX_LED_PROCESS_LIMIT > 0 && RGB_MATRIX_LED_PROCESS_LIMIT < DRIVER_LED_TOTAL
-#    define RGB_MATRIX_USE_LIMITS(min, max)                        \
-        uint8_t min = RGB_MATRIX_LED_PROCESS_LIMIT * params->iter; \
-        uint8_t max = min + RGB_MATRIX_LED_PROCESS_LIMIT;          \
-        if (max > DRIVER_LED_TOTAL) max = DRIVER_LED_TOTAL;
+    #if defined(RGB_MATRIX_SPLIT)
+        #    define RGB_MATRIX_USE_LIMITS(min, max)                        \
+                uint8_t min = RGB_MATRIX_LED_PROCESS_LIMIT * params->iter; \
+                uint8_t max = min + RGB_MATRIX_LED_PROCESS_LIMIT;          \
+                if (max > DRIVER_LED_TOTAL) max = DRIVER_LED_TOTAL;  \
+                uint8_t k_rgb_matrix_split[2] = RGB_MATRIX_SPLIT; \
+                k_rgb_matrix_split[1] += 1; \
+                k_rgb_matrix_split[1] -= 1; \
+                if (is_keyboard_left() && (max > k_rgb_matrix_split[0])) max = k_rgb_matrix_split[0] ; \
+                if( !(is_keyboard_left()) && (min < k_rgb_matrix_split[0])) min = k_rgb_matrix_split[0]; 
+    #else
+        #    define RGB_MATRIX_USE_LIMITS(min, max)                        \
+                uint8_t min = RGB_MATRIX_LED_PROCESS_LIMIT * params->iter; \
+                uint8_t max = min + RGB_MATRIX_LED_PROCESS_LIMIT;          \
+                if (max > DRIVER_LED_TOTAL) max = DRIVER_LED_TOTAL;
+    #endif
 #else
-#    define RGB_MATRIX_USE_LIMITS(min, max) \
-        uint8_t min = 0;                    \
-        uint8_t max = DRIVER_LED_TOTAL;
+    #if defined(RGB_MATRIX_SPLIT)
+        #    define RGB_MATRIX_USE_LIMITS(min, max) \
+                uint8_t min = 0;                    \
+                uint8_t max = DRIVER_LED_TOTAL; \
+                const uint8_t k_rgb_matrix_split[2] = RGB_MATRIX_SPLIT; \
+                if (is_keyboard_left() && (max > k_rgb_matrix_split[0])) max = k_rgb_matrix_split[0]; \
+                if( !(is_keyboard_left()) && (min < k_rgb_matrix_split[0])) min = k_rgb_matrix_split[0];
+    #else
+        #    define RGB_MATRIX_USE_LIMITS(min, max) \
+                uint8_t min = 0;                    \
+                uint8_t max = DRIVER_LED_TOTAL;
+    #endif
 #endif
 
 #define RGB_MATRIX_INDICATOR_SET_COLOR(i, r, g, b) \

--- a/quantum/rgb_matrix/rgb_matrix.h
+++ b/quantum/rgb_matrix/rgb_matrix.h
@@ -235,6 +235,15 @@ typedef struct {
     void (*flush)(void);
 } rgb_matrix_driver_t;
 
+inline bool rgb_matrix_finished_all_leds(uint8_t last_led_idx) {
+    #if defined(RGB_MATRIX_SPLIT)
+        if (is_keyboard_left()) return last_led_idx < k_rgb_matrix_split[0];
+        else return last_led_idx < DRIVER_LED_TOTAL;
+    #else
+        return last_led_idx < DRIVER_LED_TOTAL;
+    #endif
+}
+
 extern const rgb_matrix_driver_t rgb_matrix_driver;
 
 extern rgb_config_t rgb_matrix_config;

--- a/quantum/rgb_matrix/rgb_matrix.h
+++ b/quantum/rgb_matrix/rgb_matrix.h
@@ -48,33 +48,33 @@
 #endif
 
 #if defined(RGB_MATRIX_LED_PROCESS_LIMIT) && RGB_MATRIX_LED_PROCESS_LIMIT > 0 && RGB_MATRIX_LED_PROCESS_LIMIT < DRIVER_LED_TOTAL
-    #if defined(RGB_MATRIX_SPLIT)
-        #    define RGB_MATRIX_USE_LIMITS(min, max)                        \
-                uint8_t min = RGB_MATRIX_LED_PROCESS_LIMIT * params->iter; \
-                uint8_t max = min + RGB_MATRIX_LED_PROCESS_LIMIT;          \
-                if (max > DRIVER_LED_TOTAL) max = DRIVER_LED_TOTAL;  \
-                uint8_t k_rgb_matrix_split[2] = RGB_MATRIX_SPLIT; \
-                if (is_keyboard_left() && (max > k_rgb_matrix_split[0])) max = k_rgb_matrix_split[0] ; \
-                if( !(is_keyboard_left()) && (min < k_rgb_matrix_split[0])) min = k_rgb_matrix_split[0]; 
-    #else
-        #    define RGB_MATRIX_USE_LIMITS(min, max)                        \
-                uint8_t min = RGB_MATRIX_LED_PROCESS_LIMIT * params->iter; \
-                uint8_t max = min + RGB_MATRIX_LED_PROCESS_LIMIT;          \
-                if (max > DRIVER_LED_TOTAL) max = DRIVER_LED_TOTAL;
-    #endif
+#    if defined(RGB_MATRIX_SPLIT)
+#        define RGB_MATRIX_USE_LIMITS(min, max)                                                   \
+            uint8_t min = RGB_MATRIX_LED_PROCESS_LIMIT * params->iter;                            \
+            uint8_t max = min + RGB_MATRIX_LED_PROCESS_LIMIT;                                     \
+            if (max > DRIVER_LED_TOTAL) max = DRIVER_LED_TOTAL;                                   \
+            uint8_t k_rgb_matrix_split[2] = RGB_MATRIX_SPLIT;                                     \
+            if (is_keyboard_left() && (max > k_rgb_matrix_split[0])) max = k_rgb_matrix_split[0]; \
+            if (!(is_keyboard_left()) && (min < k_rgb_matrix_split[0])) min = k_rgb_matrix_split[0];
+#    else
+#        define RGB_MATRIX_USE_LIMITS(min, max)                        \
+            uint8_t min = RGB_MATRIX_LED_PROCESS_LIMIT * params->iter; \
+            uint8_t max = min + RGB_MATRIX_LED_PROCESS_LIMIT;          \
+            if (max > DRIVER_LED_TOTAL) max = DRIVER_LED_TOTAL;
+#    endif
 #else
-    #if defined(RGB_MATRIX_SPLIT)
-        #    define RGB_MATRIX_USE_LIMITS(min, max) \
-                uint8_t min = 0;                    \
-                uint8_t max = DRIVER_LED_TOTAL; \
-                const uint8_t k_rgb_matrix_split[2] = RGB_MATRIX_SPLIT; \
-                if (is_keyboard_left() && (max > k_rgb_matrix_split[0])) max = k_rgb_matrix_split[0]; \
-                if( !(is_keyboard_left()) && (min < k_rgb_matrix_split[0])) min = k_rgb_matrix_split[0];
-    #else
-        #    define RGB_MATRIX_USE_LIMITS(min, max) \
-                uint8_t min = 0;                    \
-                uint8_t max = DRIVER_LED_TOTAL;
-    #endif
+#    if defined(RGB_MATRIX_SPLIT)
+#        define RGB_MATRIX_USE_LIMITS(min, max)                                                   \
+            uint8_t       min                   = 0;                                              \
+            uint8_t       max                   = DRIVER_LED_TOTAL;                               \
+            const uint8_t k_rgb_matrix_split[2] = RGB_MATRIX_SPLIT;                               \
+            if (is_keyboard_left() && (max > k_rgb_matrix_split[0])) max = k_rgb_matrix_split[0]; \
+            if (!(is_keyboard_left()) && (min < k_rgb_matrix_split[0])) min = k_rgb_matrix_split[0];
+#    else
+#        define RGB_MATRIX_USE_LIMITS(min, max) \
+            uint8_t min = 0;                    \
+            uint8_t max = DRIVER_LED_TOTAL;
+#    endif
 #endif
 
 #define RGB_MATRIX_INDICATOR_SET_COLOR(i, r, g, b) \
@@ -233,14 +233,14 @@ typedef struct {
     void (*flush)(void);
 } rgb_matrix_driver_t;
 
-
 #if defined(RGB_MATRIX_SPLIT)
-#define RGB_MATRIX_FINISHED_ALL_LEDS \
-    if (is_keyboard_left()) return led_max < k_rgb_matrix_split[0]; \
-    else return led_max < DRIVER_LED_TOTAL;
+#    define RGB_MATRIX_FINISHED_ALL_LEDS            \
+        if (is_keyboard_left())                     \
+            return led_max < k_rgb_matrix_split[0]; \
+        else                                        \
+            return led_max < DRIVER_LED_TOTAL;
 #else
-#define RGB_MATRIX_FINISHED_ALL_LEDS \
-    return led_max < DRIVER_LED_TOTAL;
+#    define RGB_MATRIX_FINISHED_ALL_LEDS return led_max < DRIVER_LED_TOTAL;
 
 #endif
 

--- a/quantum/rgb_matrix/rgb_matrix.h
+++ b/quantum/rgb_matrix/rgb_matrix.h
@@ -233,16 +233,19 @@ typedef struct {
     void (*flush)(void);
 } rgb_matrix_driver_t;
 
-#if defined(RGB_MATRIX_SPLIT)
-#    define RGB_MATRIX_FINISHED_ALL_LEDS            \
-        if (is_keyboard_left())                     \
-            return led_max < k_rgb_matrix_split[0]; \
-        else                                        \
-            return led_max < DRIVER_LED_TOTAL;
-#else
-#    define RGB_MATRIX_FINISHED_ALL_LEDS return led_max < DRIVER_LED_TOTAL;
 
+inline bool rgb_matrix_check_finished_leds(uint8_t led_idx) {
+#if defined(RGB_MATRIX_SPLIT)
+    if (is_keyboard_left())
+        uint8_t k_rgb_matrix_split[2] = RGB_MATRIX_SPLIT; 
+        return led_idx < k_rgb_matrix_split[0];
+    else
+        return led_idx < DRIVER_LED_TOTAL;
+#else
+    return led_idx < DRIVER_LED_TOTAL;
 #endif
+}
+
 
 extern const rgb_matrix_driver_t rgb_matrix_driver;
 

--- a/quantum/rgb_matrix/rgb_matrix_drivers.c
+++ b/quantum/rgb_matrix/rgb_matrix_drivers.c
@@ -229,6 +229,14 @@ static void flush(void) {
 
 // Set an led in the buffer to a color
 static inline void setled(int i, uint8_t r, uint8_t g, uint8_t b) {
+    #if defined(RGB_MATRIX_ENABLE) && defined(RGB_MATRIX_SPLIT)
+        if (!is_keyboard_left() && index >= k_rgb_matrix_split[0]){
+            i -= k_rgb_matrix_split[0];
+        }
+        else if (is_keyboard_left() && index >= k_rgb_matrix_split[0])
+            return
+    #endif
+
     rgb_matrix_ws2812_array[i].r = r;
     rgb_matrix_ws2812_array[i].g = g;
     rgb_matrix_ws2812_array[i].b = b;

--- a/quantum/rgb_matrix/rgb_matrix_drivers.c
+++ b/quantum/rgb_matrix/rgb_matrix_drivers.c
@@ -229,14 +229,13 @@ static void flush(void) {
 
 // Set an led in the buffer to a color
 static inline void setled(int i, uint8_t r, uint8_t g, uint8_t b) {
-    #if defined(RGB_MATRIX_ENABLE) && defined(RGB_MATRIX_SPLIT)
-        const uint8_t k_rgb_matrix_split[2] = RGB_MATRIX_SPLIT;
-        if (!is_keyboard_left() && (i >= k_rgb_matrix_split[0])){
-            i -= k_rgb_matrix_split[0];
-        }
-        else if (is_keyboard_left() && (i >= k_rgb_matrix_split[0]))
-            return;
-    #endif
+#    if defined(RGB_MATRIX_ENABLE) && defined(RGB_MATRIX_SPLIT)
+    const uint8_t k_rgb_matrix_split[2] = RGB_MATRIX_SPLIT;
+    if (!is_keyboard_left() && (i >= k_rgb_matrix_split[0])) {
+        i -= k_rgb_matrix_split[0];
+    } else if (is_keyboard_left() && (i >= k_rgb_matrix_split[0]))
+        return;
+#    endif
 
     rgb_matrix_ws2812_array[i].r = r;
     rgb_matrix_ws2812_array[i].g = g;

--- a/quantum/rgb_matrix/rgb_matrix_drivers.c
+++ b/quantum/rgb_matrix/rgb_matrix_drivers.c
@@ -230,11 +230,12 @@ static void flush(void) {
 // Set an led in the buffer to a color
 static inline void setled(int i, uint8_t r, uint8_t g, uint8_t b) {
     #if defined(RGB_MATRIX_ENABLE) && defined(RGB_MATRIX_SPLIT)
-        if (!is_keyboard_left() && index >= k_rgb_matrix_split[0]){
+        const uint8_t k_rgb_matrix_split[2] = RGB_MATRIX_SPLIT;
+        if (!is_keyboard_left() && (i >= k_rgb_matrix_split[0])){
             i -= k_rgb_matrix_split[0];
         }
-        else if (is_keyboard_left() && index >= k_rgb_matrix_split[0])
-            return
+        else if (is_keyboard_left() && (i >= k_rgb_matrix_split[0]))
+            return;
     #endif
 
     rgb_matrix_ws2812_array[i].r = r;


### PR DESCRIPTION
When a split keyboard has a driver (such as the IS31FL3733) on each side of the split, this diff allows for full RGB animation support on both sides.

## Description

Gotchas. This touches the "rgb_matrix" code and not the "led_matrix" code. 
I tested this on my own split keyboard with a driver per side.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
