### PR TITLE
0xCB Static: fix `qmk info` and Configurator issues

### DIFF
--- a/keyboards/0xcb/static/info.json
+++ b/keyboards/0xcb/static/info.json
@@ -4,8 +4,11 @@
   "maintainer": "Conor-Burns",
   "width": 12,
   "height": 5,
+  "layout_aliases": {
+    "LAYOUT": "LAYOUT_all"
+  },
   "layouts": {
-    "LAYOUT": {
+    "LAYOUT_all": {
       "layout": [
           {"x":11, "y":0},
           {"x":0, "y":1},

--- a/keyboards/0xcb/static/keymaps/default/keymap.c
+++ b/keyboards/0xcb/static/keymaps/default/keymap.c
@@ -23,28 +23,28 @@ enum layer_names {
   _FN4
 };
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-[_HOME] = LAYOUT(
+[_HOME] = LAYOUT_all(
                                                                                                        KC_MPLY,
     KC_GESC, KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_BSPC,
     KC_TAB,  KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,             KC_ENT,
     KC_LSPO,          KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_RSPC,
     KC_LCTL, KC_LGUI, KC_LALT, KC_SPC,           KC_SPC,                    KC_SPC,  KC_RALT, MO(1),   MO(2)
 ),
-[_FN2] = LAYOUT(
+[_FN2] = LAYOUT_all(
                                                                                                        RESET,
     KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,
     KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,           _______,
     _______,          _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
     _______, _______, _______, _______,          _______,                   _______, _______, _______, _______
 ),
-[_FN3] = LAYOUT(
+[_FN3] = LAYOUT_all(
                                                                                                        EEP_RST,
     _______, _______, _______, _______, _______, _______, _______, _______, _______, KC_LBRC, KC_RBRC, KC_BSLS,
     _______, _______, _______, _______, _______, _______, _______, _______, KC_SCLN, KC_QUOT,          _______,
     _______,          _______, _______, _______, _______, _______, _______, _______, _______, _______, KC_SLSH,
     _______, _______, _______, _______,          _______,                   _______, _______, _______, _______
 ),
-[_FN4] = LAYOUT(
+[_FN4] = LAYOUT_all(
                                                                                                        _______,
     _______, KC_MUTE, KC_VOLD, KC_VOLU, KC_MPRV, KC_MNXT, KC_MSTP, KC_INS,  KC_HOME, KC_DEL,  KC_END,  _______,
     _______, _______, KC_BRID, KC_BRIU, _______, _______, _______, KC_PGUP, KC_UP,   KC_PGDN,          _______,

--- a/keyboards/0xcb/static/keymaps/via/keymap.c
+++ b/keyboards/0xcb/static/keymaps/via/keymap.c
@@ -23,28 +23,28 @@ enum layer_names {
   _FN4
 };
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-[_HOME] = LAYOUT(
+[_HOME] = LAYOUT_all(
                                                                                                        KC_MPLY,
     KC_GESC, KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_BSPC,
     KC_TAB,  KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,             KC_ENT,
     KC_LSPO,          KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_RSPC,
     KC_LCTL, KC_LGUI, KC_LALT, KC_SPC,           KC_SPC,                    KC_SPC,  KC_RALT, MO(1),   MO(2)
 ),
-[_FN2] = LAYOUT(
+[_FN2] = LAYOUT_all(
                                                                                                        RESET,
     KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,
     KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,           _______,
     _______,          _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
     _______, _______, _______, _______,          _______,                   _______, _______, _______, _______
 ),
-[_FN3] = LAYOUT(
+[_FN3] = LAYOUT_all(
                                                                                                        EEP_RST,
     _______, _______, _______, _______, _______, _______, _______, _______, _______, KC_LBRC, KC_RBRC, KC_BSLS,
     _______, _______, _______, _______, _______, _______, _______, _______, KC_SCLN, KC_QUOT,          _______,
     _______,          _______, _______, _______, _______, _______, _______, _______, _______, _______, KC_SLSH,
     _______, _______, _______, _______,          _______,                   _______, _______, _______, _______
 ),
-[_FN4] = LAYOUT(
+[_FN4] = LAYOUT_all(
                                                                                                        _______,
     _______, KC_MUTE, KC_VOLD, KC_VOLU, KC_MPRV, KC_MNXT, KC_MSTP, KC_INS,  KC_HOME, KC_DEL,  KC_END,  _______,
     _______, _______, KC_BRID, KC_BRIU, _______, _______, _______, KC_PGUP, KC_UP,   KC_PGDN,          _______,

--- a/keyboards/0xcb/static/static.h
+++ b/keyboards/0xcb/static/static.h
@@ -28,21 +28,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 // clang-format off
- #define LAYOUT( \
-                                                            K15, \
-     K00, K10, K01, K11, K02, K12, K03, K13, K04, K14, K05, K35, \
-     K20, K30, K21, K31, K22, K32, K23, K33, K24, K34,      K25, \
-     K40,      K41, K51, K42, K52, K43, K53, K44, K54, K45, K55, \
-     K60, K70, K61, K71,      K72,           K64, K74, K65, K75  \
- ) \
- { \
-     { K00,   K01,   K02,   K03,   K04,   K05 }, \
-     { K10,   K11,   K12,   K13,   K14,   K15 }, \
-     { K20,   K21,   K22,   K23,   K24,   K25 }, \
-     { K30,   K31,   K32,   K33,   K34,   K35 }, \
-     { K40,   K41,   K42,   K43,   K44,   K45 }, \
-     { KC_NO, K51,   K52,   K53,   K54,   K55 }, \
-     { K60,   K61,   KC_NO, KC_NO, K64,   K65 }, \
-     { K70,   K71,   K72,   KC_NO, K74,   K75 }, \
- }
+#define LAYOUT( \
+                                                           K15, \
+    K00, K10, K01, K11, K02, K12, K03, K13, K04, K14, K05, K35, \
+    K20, K30, K21, K31, K22, K32, K23, K33, K24, K34,      K25, \
+    K40,      K41, K51, K42, K52, K43, K53, K44, K54, K45, K55, \
+    K60, K70, K61, K71,      K72,           K64, K74, K65, K75  \
+) \
+{ \
+    { K00,   K01,   K02,   K03,   K04,   K05 }, \
+    { K10,   K11,   K12,   K13,   K14,   K15 }, \
+    { K20,   K21,   K22,   K23,   K24,   K25 }, \
+    { K30,   K31,   K32,   K33,   K34,   K35 }, \
+    { K40,   K41,   K42,   K43,   K44,   K45 }, \
+    { KC_NO, K51,   K52,   K53,   K54,   K55 }, \
+    { K60,   K61,   KC_NO, KC_NO, K64,   K65 }, \
+    { K70,   K71,   K72,   KC_NO, K74,   K75 }, \
+}
 // clang-format on

--- a/keyboards/0xcb/static/static.h
+++ b/keyboards/0xcb/static/static.h
@@ -28,7 +28,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 // clang-format off
-#define LAYOUT( \
+#define LAYOUT_all( \
                                                            K15, \
     K00, K10, K01, K11, K02, K12, K03, K13, K04, K14, K05, K35, \
     K20, K30, K21, K31, K22, K32, K23, K33, K24, K34,      K25, \

--- a/keyboards/0xcb/static/static.h
+++ b/keyboards/0xcb/static/static.h
@@ -45,4 +45,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     { K60,   K61,   KC_NO, KC_NO, K64,   K65 }, \
     { K70,   K71,   K72,   KC_NO, K74,   K75 }, \
 }
+
+#define LAYOUT_bigbar( \
+                                                           K15, \
+    K00, K10, K01, K11, K02, K12, K03, K13, K04, K14, K05, K35, \
+    K20, K30, K21, K31, K22, K32, K23, K33, K24, K34,      K25, \
+    K40,      K41, K51, K42, K52, K43, K53, K44, K54, K45, K55, \
+    K60, K70, K61,                K72,                K65, K75  \
+) \
+{ \
+    { K00,   K01,   K02,   K03,   K04,   K05 }, \
+    { K10,   K11,   K12,   K13,   K14,   K15 }, \
+    { K20,   K21,   K22,   K23,   K24,   K25 }, \
+    { K30,   K31,   K32,   K33,   K34,   K35 }, \
+    { K40,   K41,   K42,   K43,   K44,   K45 }, \
+    { KC_NO, K51,   K52,   K53,   K54,   K55 }, \
+    { K60,   K61,   KC_NO, KC_NO, KC_NO, K65 }, \
+    { K70,   KC_NO, K72,   KC_NO, KC_NO, K75 }, \
+}
 // clang-format on


### PR DESCRIPTION
## Description

- `qmk info` can't retrieve the matrix data for the layout macro if there is white space before the `#define`.
- add macro for `LAYOUT_bigbar`
- rename `LAYOUT` to `LAYOUT_all` per QMK guidelines

cc @conor-burns (keyboard maintainer)

## Types of Changes

- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
