### PR TITLE
Light up WASD on layer 2 activation for gmmk/pro/ansi/jonavin

### DIFF
--- a/keyboards/gmmk/pro/ansi/keymaps/jonavin/keymap.c
+++ b/keyboards/gmmk/pro/ansi/keymaps/jonavin/keymap.c
@@ -272,6 +272,9 @@ void matrix_scan_user(void) {
             for (uint8_t i=0; i<ARRAYSIZE(LED_LIST_NUMPAD); i++) {
                 rgb_matrix_set_color(LED_LIST_NUMPAD[i], RGB_MAGENTA);
             }
+            for (uint8_t i=0; i<ARRAYSIZE(LED_LIST_WASD); i++) {
+                rgb_matrix_set_color(LED_LIST_WASD[i], RGB_MAGENTA);
+            }
             rgb_matrix_set_color(LED_R4, RGB_MAGENTA);
             rgb_matrix_set_color(LED_R5, RGB_MAGENTA);
             rgb_matrix_set_color(LED_R6, RGB_MAGENTA);

--- a/keyboards/gmmk/pro/ansi/keymaps/jonavin/readme.md
+++ b/keyboards/gmmk/pro/ansi/keymaps/jonavin/readme.md
@@ -22,12 +22,12 @@
         - indicators in FN layer using RGB in FN and number rows to show the timeout in minutes
     - LED address location map as enum definition
     - LED group lists for arrows, numpad, F row, num row, left and right side LEDs
-    - default startuo in single mode with default colour 
+    - default startuo in single mode with default colour
     - Capslock, Scroll Lock, and Num Lock (not set) indicator on left side LED
     - Layer indicator on right side LED
     - Fn key light up red when Fn layer activate
     - Win Key light up red when Win Lock mode enabled
-    - Layer 2 activation lights up Numpad area
+    - Layer 2 activation lights up Numpad and WASD area
 
 ## All layers diagram
 Default layer


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Layer 2 activation now lights up WASD area as well since they're mapped to arrow keys


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
