### PR TITLE
barracuda: update info.json layout macro reference

### DIFF
--- a/keyboards/barracuda/info.json
+++ b/keyboards/barracuda/info.json
@@ -5,7 +5,7 @@
     "width": 14,
     "height": 3,
     "layouts": {
-        "LAYOUT": {
+        "LAYOUT_ortho_3x11": {
             "layout": [
                 {"x": 0, "y": 0},
                 {"x": 1, "y": 0},

--- a/keyboards/barracuda/rules.mk
+++ b/keyboards/barracuda/rules.mk
@@ -20,5 +20,3 @@ BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 BLUETOOTH_ENABLE = no       # Enable Bluetooth
 AUDIO_ENABLE = no           # Audio output
-
-LAYOUTS = ortho_3x11


### PR DESCRIPTION
## Description

- change LAYOUT to LAYOUT_ortho_3x11

https://github.com/qmk/qmk_firmware/blob/2b097d670a9fa458b8d059f824a0cbbd5b6c6659/keyboards/barracuda/barracuda.h#L30 vs. https://github.com/qmk/qmk_firmware/blob/2b097d670a9fa458b8d059f824a0cbbd5b6c6659/keyboards/barracuda/info.json#L8
cc @knaruo (keyboard maintainer)

## Types of Changes

- [x] Enhancement/optimization
- [x] Keyboard (addition or update)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
