### PR TITLE
[Keyboard] Switch Draculad to using WPM char hack

### DIFF
--- a/keyboards/draculad/keymaps/default/keymap.c
+++ b/keyboards/draculad/keymaps/default/keymap.c
@@ -17,7 +17,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include QMK_KEYBOARD_H
 
-
 enum layer_number {
   _BASE,
   _NUM,
@@ -25,9 +24,6 @@ enum layer_number {
   _MUS,
   _ADJ
 };
-
-
-char wpm_as_str[8];
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [_BASE] =  LAYOUT(
@@ -155,14 +151,20 @@ static void render_logo(void) {
 }
 
 static void render_status(void) {
-  oled_write_P(PSTR("This is\n~~~~~~~~~\nDracu\nLad\n~~~~~~~~~\nv1.0\n~~~~~~~~~\n"), false);
-  sprintf(wpm_as_str, "WPM %03d", get_current_wpm());
-  oled_write(wpm_as_str,false);
-  led_t led_state = host_keyboard_led_state();
-  oled_write_P(PSTR("\nCaps: "), false);
-  oled_write_P(led_state.caps_lock ? PSTR("on ") : PSTR("off"), false);
-  oled_write_P(PSTR("\n"),false);
-  switch (get_highest_layer(layer_state)) {
+    oled_write_P(PSTR("This is\n~~~~~~~~~\nDracu\nLad\n~~~~~~~~~\nv1.0\n~~~~~~~~~\n"), false);
+    uint8_t n = get_current_wpm();
+    char    wpm_counter[4];
+    wpm_counter[3] = '\0';
+    wpm_counter[2] = '0' + n % 10;
+    wpm_counter[1] = (n /= 10) % 10 ? '0' + (n) % 10 : (n / 10) % 10 ? '0' : ' ';
+    wpm_counter[0] = n / 10 ? '0' + n / 10 : ' ';
+    oled_write_P(PSTR("WPM:"), false);
+    oled_write(wpm_counter, false);
+    led_t led_state = host_keyboard_led_state();
+    oled_write_P(PSTR("\nCaps: "), false);
+    oled_write_P(led_state.caps_lock ? PSTR("on ") : PSTR("off"), false);
+    oled_write_P(PSTR("\n"), false);
+    switch (get_highest_layer(layer_state)) {
         case _BASE:
             oled_write_P(PSTR("Base   "), false);
             break;

--- a/keyboards/draculad/keymaps/pimoroni/keymap.c
+++ b/keyboards/draculad/keymaps/pimoroni/keymap.c
@@ -38,9 +38,6 @@ enum custom_keycodes {
   BALL_MCL,//middle click
 };
 
-
-char wpm_as_str[8];
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [_BASE] =  LAYOUT(
         KC_Q,         KC_W,    KC_E,    KC_R,    KC_T,                                         KC_Y,            KC_U,             KC_I,    KC_O,    KC_P,
@@ -168,14 +165,20 @@ static void render_logo(void) {
 }
 
 static void render_status(void) {
-  oled_write_P(PSTR("This is\n~~~~~~~~~\nDracu\nLad\n~~~~~~~~~\nv1.0\n~~~~~~~~~\n"), false);
-  sprintf(wpm_as_str, "WPM %03d", get_current_wpm());
-  oled_write(wpm_as_str,false);
-  led_t led_state = host_keyboard_led_state();
-  oled_write_P(PSTR("\nCaps: "), false);
-  oled_write_P(led_state.caps_lock ? PSTR("on ") : PSTR("off"), false);
-  oled_write_P(PSTR("\n"),false);
-  switch (get_highest_layer(layer_state)) {
+    oled_write_P(PSTR("This is\n~~~~~~~~~\nDracu\nLad\n~~~~~~~~~\nv1.0\n~~~~~~~~~\n"), false);
+    uint8_t n = get_current_wpm();
+    char    wpm_counter[4];
+    wpm_counter[3] = '\0';
+    wpm_counter[2] = '0' + n % 10;
+    wpm_counter[1] = (n /= 10) % 10 ? '0' + (n) % 10 : (n / 10) % 10 ? '0' : ' ';
+    wpm_counter[0] = n / 10 ? '0' + n / 10 : ' ';
+    oled_write_P(PSTR("WPM:"), false);
+    oled_write(wpm_counter, false);
+    led_t led_state = host_keyboard_led_state();
+    oled_write_P(PSTR("\nCaps: "), false);
+    oled_write_P(led_state.caps_lock ? PSTR("on ") : PSTR("off"), false);
+    oled_write_P(PSTR("\n"), false);
+    switch (get_highest_layer(layer_state)) {
         case _BASE:
             oled_write_P(PSTR("Base   "), false);
             break;


### PR DESCRIPTION
## Description

It's compiling over size.  This removes the use of sprintf, and reduces the compiled size.

## Types of Changes

- [x] Bugfix
- [x] Keyboard (addition or update)

## Issues Fixed or Closed by This PR

* CI

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
