### PR TITLE
Reimplements WPM feature to be smaller & precise

### DIFF
--- a/docs/feature_wpm.md
+++ b/docs/feature_wpm.md
@@ -13,7 +13,7 @@ For split keyboards using soft serial, the computed WPM score will be available 
 | Define                       | Default       | Description                                                                              |
 |------------------------------|---------------|------------------------------------------------------------------------------------------|
 | `WPM_ESTIMATED_WORD_SIZE`    | `5`           | This is the value used when estimating average word size (for regression and normal use) |
-| `WPM_ALLOW_COUNT_REGRESSOIN` | _Not defined_ | If defined allows the WPM to be decreased when hitting Delete or Backspace               |
+| `WPM_ALLOW_COUNT_REGRESSION` | _Not defined_ | If defined allows the WPM to be decreased when hitting Delete or Backspace               |
 | `WPM_UNFILTERED`             | _Not defined_ | If undefined (the default), WPM values will be smoothed to avoid sudden changes in value |
 | `WPM_SAMPLE_SECONDS`         | `5`           | This defines how many seconds of typing to average, when calculating WPM                 |
 | `WPM_SAMPLE_PERIODS`         | `50`          | This defines how many sampling periods to use when calculating WPM                       |

--- a/docs/feature_wpm.md
+++ b/docs/feature_wpm.md
@@ -10,11 +10,23 @@ For split keyboards using soft serial, the computed WPM score will be available 
 
 ## Configuration
 
-|Define                       |Default       | Description                                                                              |
-|-----------------------------|--------------|------------------------------------------------------------------------------------------|
-|`WPM_SMOOTHING`              |`0.0487`      | Sets the smoothing to about 40 keystrokes                                                |
-|`WPM_ESTIMATED_WORD_SIZE`    |`5`           | This is the value used when estimating average word size (for regression and normal use) |
-|`WPM_ALLOW_COUNT_REGRESSOIN` |_Not defined_ | If defined allows the WPM to be decreased when hitting Delete or Backspace               |
+| Define                       | Default       | Description                                                                              |
+|------------------------------|---------------|------------------------------------------------------------------------------------------|
+| `WPM_ESTIMATED_WORD_SIZE`    | `5`           | This is the value used when estimating average word size (for regression and normal use) |
+| `WPM_ALLOW_COUNT_REGRESSOIN` | _Not defined_ | If defined allows the WPM to be decreased when hitting Delete or Backspace               |
+| `WPM_UNFILTERED`             | _Not defined_ | If undefined (the default), WPM values will be smoothed to avoid sudden changes in value |
+| `WPM_SAMPLE_SECONDS`         | `5`           | This defines how many seconds of typing to average, when calculating WPM                 |
+| `WPM_SAMPLE_PERIODS`         | `50`          | This defines how many sampling periods to use when calculating WPM                       |
+| `WPM_LAUNCH_CONTROL`         | _Not defined_ | If defined, WPM values will be calculated using partial buffers when typing begins       |
+
+'WPM_UNFILTERED' is potentially useful if you're filtering data in some other way (and also because it reduces the code required for the WPM feature), or if reducing measurement latency to a minimum is important for you.
+
+Increasing 'WPM_SAMPLE_SECONDS' will give more smoothly changing WPM values at the expense of slightly more latency to the WPM calculation.
+
+Increasing 'WPM_SAMPLE_PERIODS' will improve the smoothness at which WPM decays once typing stops, at a cost of approximately this many bytes of firmware space.
+
+If 'WPM_LAUNCH_CONTROL' is defined, whenever WPM drops to zero, the next time typing begins WPM will be calculated based only on the time since that typing began, instead of the whole period of time specified by WPM_SAMPLE_SECONDS.  This results in reaching an accurate WPM value much faster, even when filtering is enabled and a large WPM_SAMPLE_SECONDS value is specified.
+
 ## Public Functions
 
 |Function                  |Description                                       |

--- a/quantum/wpm.c
+++ b/quantum/wpm.c
@@ -107,9 +107,12 @@ void update_wpm(uint16_t keycode) {
 }
 
 void decay_wpm(void) {
-    uint32_t presses = period_presses[0];
+    int32_t presses = period_presses[0];
     for (int i = 1; i <= periods; i++) {
         presses += period_presses[i];
+    }
+    if (presses < 0) {
+        presses = 0;
     }
     int32_t  elapsed  = timer_elapsed32(wpm_timer);
     uint32_t duration = (((periods)*PERIOD_DURATION) + elapsed);

--- a/quantum/wpm.c
+++ b/quantum/wpm.c
@@ -21,13 +21,37 @@
 
 // WPM Stuff
 static uint8_t  current_wpm = 0;
-static uint16_t wpm_timer   = 0;
+static uint32_t wpm_timer   = 0;
+#ifndef WPM_UNFILTERED
+static uint32_t smoothing_timer = 0;
+#endif
 
-// This smoothing is 40 keystrokes
-static const float wpm_smoothing = WPM_SMOOTHING;
+/* The WPM calculation works by specifying a certain number of 'periods' inside
+ * a ring buffer, and we count the number of keypresses which occur in each of
+ * those periods.  Then to calculate WPM, we add up all of the keypresses in
+ * the whole ring buffer, divide by the number of keypresses in a 'word', and
+ * then adjust for how much time is captured by our ring buffer.  Right now
+ * the ring buffer is hardcoded below to be six half-second periods, accounting
+ * for a total WPM sampling period of up to three seconds of typing.
+ *
+ * Whenever our WPM drops to absolute zero due to no typing occurring within
+ * any contiguous three seconds, we reset and start measuring fresh,
+ * which lets our WPM immediately reach the correct value even before a full
+ * three second sampling buffer has been filled.
+ */
+#define MAX_PERIODS (WPM_SAMPLE_PERIODS)
+#define PERIOD_DURATION (1000 * WPM_SAMPLE_SECONDS / MAX_PERIODS)
+#define LATENCY (100)
+static int8_t  period_presses[MAX_PERIODS] = {0};
+static uint8_t current_period              = 0;
+static uint8_t periods                     = 1;
 
-void set_current_wpm(uint8_t new_wpm) { current_wpm = new_wpm; }
+#if !defined(WPM_UNFILTERED)
+static uint8_t prev_wpm = 0;
+static uint8_t next_wpm = 0;
+#endif
 
+void    set_current_wpm(uint8_t new_wpm) { current_wpm = new_wpm; }
 uint8_t get_current_wpm(void) { return current_wpm; }
 
 bool wpm_keycode(uint16_t keycode) { return wpm_keycode_kb(keycode); }
@@ -68,33 +92,62 @@ __attribute__((weak)) uint8_t wpm_regress_count(uint16_t keycode) {
 }
 #endif
 
+// Outside 'raw' mode we smooth results over time.
+
 void update_wpm(uint16_t keycode) {
     if (wpm_keycode(keycode)) {
-        if (wpm_timer > 0) {
-            uint16_t latest_wpm = 60000 / timer_elapsed(wpm_timer) / WPM_ESTIMATED_WORD_SIZE;
-            if (latest_wpm > UINT8_MAX) {
-                latest_wpm = UINT8_MAX;
-            }
-            current_wpm += ceilf((latest_wpm - current_wpm) * wpm_smoothing);
-        }
-        wpm_timer = timer_read();
+        period_presses[current_period]++;
     }
 #ifdef WPM_ALLOW_COUNT_REGRESSION
     uint8_t regress = wpm_regress_count(keycode);
     if (regress) {
-        if (current_wpm < regress) {
-            current_wpm = 0;
-        } else {
-            current_wpm -= regress;
-        }
-        wpm_timer = timer_read();
+        period_presses[current_period]--;
     }
 #endif
 }
 
 void decay_wpm(void) {
-    if (timer_elapsed(wpm_timer) > 1000) {
-        current_wpm += (-current_wpm) * wpm_smoothing;
-        wpm_timer = timer_read();
+    uint32_t presses = period_presses[0];
+    for (int i = 1; i <= periods; i++) {
+        presses += period_presses[i];
     }
+    int32_t  elapsed  = timer_elapsed32(wpm_timer);
+    uint32_t duration = (((periods)*PERIOD_DURATION) + elapsed);
+    uint32_t wpm_now  = (60000 * presses) / (duration * WPM_ESTIMATED_WORD_SIZE);
+    wpm_now           = (wpm_now > 240) ? 240 : wpm_now;
+
+    if (elapsed > PERIOD_DURATION) {
+        current_period                 = (current_period + 1) % MAX_PERIODS;
+        period_presses[current_period] = 0;
+        periods                        = (periods < MAX_PERIODS - 1) ? periods + 1 : MAX_PERIODS - 1;
+        elapsed                        = 0;
+        /* if (wpm_timer == 0) { */
+        wpm_timer = timer_read32();
+        /* } else { */
+        /*     wpm_timer += PERIOD_DURATION; */
+        /* } */
+    }
+    if (presses < 2)  // don't guess high WPM based on a single keypress.
+        wpm_now = 0;
+
+#if defined WPM_LAUNCH_CONTROL
+    if (presses == 0) {
+        current_period = 0;
+        periods        = 0;
+        wpm_now        = 0;
+    }
+#endif  // WPM_LAUNCH_CONTROL
+
+#ifndef WPM_UNFILTERED
+    int32_t latency = timer_elapsed32(smoothing_timer);
+    if (latency > LATENCY) {
+        smoothing_timer = timer_read32();
+        prev_wpm        = current_wpm;
+        next_wpm        = wpm_now;
+    }
+
+    current_wpm = prev_wpm + (latency * ((int)next_wpm - (int)prev_wpm) / LATENCY);
+#else
+    current_wpm = wpm_now;
+#endif
 }

--- a/quantum/wpm.h
+++ b/quantum/wpm.h
@@ -22,8 +22,11 @@
 #ifndef WPM_ESTIMATED_WORD_SIZE
 #    define WPM_ESTIMATED_WORD_SIZE 5
 #endif
-#ifndef WPM_SMOOTHING
-#    define WPM_SMOOTHING 0.0487
+#ifndef WPM_SAMPLE_SECONDS
+#    define WPM_SAMPLE_SECONDS 5
+#endif
+#ifndef WPM_SAMPLE_PERIODS
+#    define WPM_SAMPLE_PERIODS 50
 #endif
 
 bool wpm_keycode(uint16_t keycode);


### PR DESCRIPTION
Changes the WPM feature to provide a correct WPM value instead of only a rough estimate.

This change is similar to the one in [this PR](https://github.com/qmk/qmk_firmware/pull/13359), which I hadn't known about at the time I made this change locally.  It's worth checking that one out for comparison to this one!

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The original WPM feature worked by measuring the time between two keypresses, estimating a WPM value from that delay between keypresses, and then interpolating a rolling average "WPM" value by 4.87% of the difference between the current average and the new calculation (which we're told is equivalent to averaging over 40 keypresses).  If no keys are pressed, then after one second the rolling average would be reduced by 4.87%.

There were some problems with this original calculation;  if you were typing at 100wpm and then entirely stopped typing, it took the original implementation approximately 45 seconds for your WPM value to drop back to 0, because it was only dropping by less than 5% per second.

This new implementation instead uses a ring buffer.  We define 6 "periods" within this buffer, each representing half a second of time.  We track the number of keys pressed during each period, with a timer telling us when to move from one period to the next within the ring buffer, and then we can simply count the number of keys pressed and how long has passed and calculate WPM exactly, without any of the mathematical complexity of the original implementation.   

When `WPM_ALLOW_COUNT_REGRESSION` is defined, we count keys like backspace as "negative" keys.  I'm not sure that this is the right behaviour;  most real-world WPM calculations work by counting each mistakenly pressed key as a full negative word and ignoring backspaces entirely.  However, since we can't actually detect "errors" the way that normal WPM tests do, the implementation in this PR just gives backspace presses a similar impact to what they had in the original feature.  (that part of the functionality was less important to me personally, so I figured I'd make it mirror the general impact of the old behaviour as much as I could)

Since we're no longer doing a "smoothing" calculation at all, but instead are actually calculating WPM correctly over an actual period of time, we no longer need the `WPM_SMOOTHING` #define, and it has been removed both from the code and from the documentation.

This change saves 998 bytes in the firmware, in my tests, compared against the previous implementation, and maintains all the same external interfaces as the original implementation, so it should just work for everything that was already using the WPM feature;  they'll just  get more accurate WPM numbers now than they did before.

## Discussion Points:

- Should the number of measurement periods and/or their duration be exposed to make them configurable in different keymaps?

It'd take a small amount of extra space to store more sampling periods, or the sampling period could be made longer without adding extra periods just by moving those #define values (`MAX_PERIODS` and `PERIOD_DURATION`) from wpm.c to wpm.h, with changed names to make it more obvious that they're part of the WPM feature. I didn't do that in the initial PR because I felt like the 3-second measurement period was a pretty good starting point and I'm not sure whether anyone really wants their keyboard storing WPM data for much longer than that, so maybe best to keep configuration options and documentation as light as possible.  

But I'm very interested in feedback here and could absolutely amend this PR with those configuration options if anybody feels that they might be useful to somebody!


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [X] Core
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [X] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
