### PR TITLE
[Keyboard] Fix matrix_output_unselect_delay for handwired/xealousbrown

### DIFF
--- a/keyboards/handwired/xealousbrown/matrix.c
+++ b/keyboards/handwired/xealousbrown/matrix.c
@@ -100,7 +100,7 @@ uint8_t matrix_scan_custom(matrix_row_t current_matrix[]) {
     // Set row, read cols
     for (uint8_t current_row = 0; current_row < MATRIX_ROWS; current_row++) {
         select_row(current_row);
-        matrix_output_select_delay();
+        matrix_output_unselect_delay(current_row, changed);
 
         matrix_row_t cols = read_cols();
         changed |= (current_matrix[current_row] != cols);
@@ -108,9 +108,8 @@ uint8_t matrix_scan_custom(matrix_row_t current_matrix[]) {
 
         unselect_rows();
         //this internally calls matrix_io_delay()
-        matrix_output_unselect_delay();
+        matrix_output_unselect_delay(current_row, changed);
     }
 
     return changed;
 }
-


### PR DESCRIPTION
## Description

Fix `matrix_output_unselect_delay` function call on develop

## Types of Changes

- [x] Keyboard (addition or update)

## Issues Fixed or Closed by This PR

* CI

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
