### PR TITLE
Fix shell port bug in computation of QMK_FIRMWARE_DIR

### DIFF
--- a/util/qmk_install.sh
+++ b/util/qmk_install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-QMK_FIRMWARE_DIR=$(cd -P -- "$(dirname -- "$0")/.." && pwd -P)
+QMK_FIRMWARE_DIR=$(cd -P -- "$(dirname -- "$0")/.." >/dev/null && pwd -P)
 QMK_FIRMWARE_UTIL_DIR=$QMK_FIRMWARE_DIR/util
 if [ "$1" = "-y" ]; then
     SKIP_PROMPT='-y'


### PR DESCRIPTION
Previous code would fail if cd echoes the target directory to stdout,
which is pretty common.  Redirecting its output to /dev/null
solves the problem.

Sorry about the typo in the actual change comment, feel free to fix that.