### PR TITLE
Update USB Device strings for VIA identification

### DIFF
--- a/keyboards/handwired/3dp660/config.h
+++ b/keyboards/handwired/3dp660/config.h
@@ -19,11 +19,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "config_common.h"
 /* USB Device descriptor parameter */
-#define VENDOR_ID       0xFEED
-#define PRODUCT_ID      0x6075
+#define VENDOR_ID       0x676F // "go" - gooberpsycho
+#define PRODUCT_ID      0x3660 // "3" "660"
 #define DEVICE_VER      0x0001
-#define MANUFACTURER    Handwired
-#define PRODUCT         3dp660
+#define MANUFACTURER    gooberpsycho
+#define PRODUCT         3dp660 Handwired
 
 #define TAPPING_TERM 400
 

--- a/keyboards/rpiguy9907/southpaw66/config.h
+++ b/keyboards/rpiguy9907/southpaw66/config.h
@@ -18,8 +18,8 @@
 
 #include "config_common.h"
 /* USB Device descriptor parameter */
-#define VENDOR_ID       0xFEED
-#define PRODUCT_ID      0x6077
+#define VENDOR_ID       0x9907 // "9907" - rpiguy9907
+#define PRODUCT_ID      0x5366 // "S" "66"
 #define DEVICE_VER      0x0001
 #define MANUFACTURER    rpiguy9907
 #define PRODUCT         Southpaw66

--- a/keyboards/yatara/drink_me/config.h
+++ b/keyboards/yatara/drink_me/config.h
@@ -19,7 +19,7 @@
 #include "config_common.h"
 
 /* USB Device descriptor parameter */
-#define VENDOR_ID       0xFEED
+#define VENDOR_ID       0x5961 // "Ya" - Yatara
 #define PRODUCT_ID      0x1470
 #define DEVICE_VER      0x0001
 #define MANUFACTURER    Yatara


### PR DESCRIPTION
## Description

@sigprof found some keyboards in the VIA repo that use `0xFEED` for the Vendor ID, in violation of VIA's own policies.

A follow-up of sorts to #13961, this PR updates the other three keyboards sigprof flagged to use non-`0xFEED` Vendor IDs, two of which gain updated Product IDs as well.

CC:

* @gooberpsycho (maintainer of `handwired/3dp660` and `rpiguy9907/southpaw66`)
* @yatara-cc (maintainer of `yatara/drink_me`)


## Types of Changes

- [x] Enhancement/optimization
- [x] Keyboard (addition or update)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
