### PR TITLE
[Keyboard] Fix keymaps for Ocean Gin v2

### DIFF
--- a/keyboards/ocean/gin_v2/keymaps/default/keymap.c
+++ b/keyboards/ocean/gin_v2/keymaps/default/keymap.c
@@ -14,8 +14,8 @@
  */
 #include QMK_KEYBOARD_H
 
+// clang-format off
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-  {
   [0] = LAYOUT(
     KC_P7, KC_P8, KC_P9,      KC_ESC, KC_Q, KC_W, KC_E, KC_R, KC_T, KC_Y, KC_U, KC_I, KC_O, KC_P, KC_MINS, KC_BSPC,
     KC_P4, KC_P5, KC_P6,      KC_TAB,  KC_A, KC_S, KC_D, KC_F, KC_G, KC_H, KC_J, KC_K, KC_L, KC_QUOT, KC_ENT,

--- a/keyboards/ocean/gin_v2/keymaps/via/keymap.c
+++ b/keyboards/ocean/gin_v2/keymaps/via/keymap.c
@@ -14,8 +14,8 @@
  */
 #include QMK_KEYBOARD_H
 
+// clang-format off
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-  {
   [0] = LAYOUT(
     KC_P7, KC_P8, KC_P9,      KC_ESC, KC_Q, KC_W, KC_E, KC_R, KC_T, KC_Y, KC_U, KC_I, KC_O, KC_P, KC_MINS, KC_BSPC,
     KC_P4, KC_P5, KC_P6,      KC_TAB,  KC_A, KC_S, KC_D, KC_F, KC_G, KC_H, KC_J, KC_K, KC_L, KC_QUOT, KC_ENT,


### PR DESCRIPTION

## Description

Has an extra `{` in the keymap array. Didn't catch. 

## Types of Changes

- [x] Bugfix
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)

## Issues Fixed or Closed by This PR

* Tzarc CI

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
