### PR TITLE
Update config.h to add a value to RGB_DISABLE_WHEN_USB_SUSPENDED

### DIFF
--- a/keyboards/kbdfans/kbd67/mkiirgb/v3/config.h
+++ b/keyboards/kbdfans/kbd67/mkiirgb/v3/config.h
@@ -42,7 +42,7 @@
 #define NO_ACTION_FUNCTION
 #ifdef RGB_MATRIX_ENABLE
 #define RGB_DISABLE_AFTER_TIMEOUT 0 // number of ticks to wait until disabling effects
-#define RGB_DISABLE_WHEN_USB_SUSPENDED // turn off effects when suspended
+#define RGB_DISABLE_WHEN_USB_SUSPENDED true // turn off effects when suspended
 #define USB_SUSPEND_WAKEUP_DELAY 5000
 #define RGB_MATRIX_KEYPRESSES
 #define DISABLE_RGB_MATRIX_GRADIENT_UP_DOWN	


### PR DESCRIPTION

## Description

QMK Configurator does not compile - needs a value on RGB_DISABLE_WHEN_USB_SUSPENDED

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR 

n/a

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
