### PR TITLE
[Keyboard] Fix default keymap for GMMK Pro Iso

### DIFF
--- a/keyboards/gmmk/pro/iso/keymaps/default/keymap.c
+++ b/keyboards/gmmk/pro/iso/keymaps/default/keymap.c
@@ -69,4 +69,4 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
     }
     return true;
 }
-#endif ENCODER_ENABLE
+#endif


### PR DESCRIPTION
## Description

Fix encoder define in default keymap

## Types of Changes

- [x] Bugfix
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
