### PR TITLE
Fix pmw3360 code to only output debug info if mouse debugging is enabled

### DIFF
--- a/drivers/sensors/pmw3360.c
+++ b/drivers/sensors/pmw3360.c
@@ -213,12 +213,14 @@ report_pmw_t pmw_read_burst(void) {
 
     spi_stop();
 
-    print_byte(data.motion);
-    print_byte(data.dx);
-    print_byte(data.mdx);
-    print_byte(data.dy);
-    print_byte(data.mdy);
-    dprintf("\n");
+    if (debug_mouse) {
+        print_byte(data.motion);
+        print_byte(data.dx);
+        print_byte(data.mdx);
+        print_byte(data.dy);
+        print_byte(data.mdy);
+        dprintf("\n");
+    }
 
     data.isMotion    = (data.motion & 0x80) != 0;
     data.isOnSurface = (data.motion & 0x08) == 0;


### PR DESCRIPTION
## Description

Debugging is good, but should only be reported *when* requested.  This changes it so tha the pmw3360 sensor code only outputs debugging info if `debug_mouse` is set to true. 

## Types of Changes

- [x] Core
- [x] Bugfix


## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
