### PR TITLE
Fix pins, add VIA support for Stream Cheap 2x4

### DIFF
--- a/keyboards/handwired/stream_cheap/2x4/2x4.h
+++ b/keyboards/handwired/stream_cheap/2x4/2x4.h
@@ -3,8 +3,8 @@
 #include "quantum.h"
 
 #define LAYOUT_ortho_2x4(\
-	K00, K01, K02,K03, \
-	K04, K05, K06,K07  \
+	K00, K01, K02, K03, \
+	K04, K05, K06, K07  \
 ) \
   { \
     { K00,K01,K02,K03}, \

--- a/keyboards/handwired/stream_cheap/2x4/2x4.h
+++ b/keyboards/handwired/stream_cheap/2x4/2x4.h
@@ -3,8 +3,8 @@
 #include "quantum.h"
 
 #define LAYOUT_ortho_2x4(\
-	K00, K01, K02, K03, \
-	K04, K05, K06, K07  \
+    K00, K01, K02, K03, \
+    K04, K05, K06, K07  \
 ) \
   { \
     { K00,K01,K02,K03}, \

--- a/keyboards/handwired/stream_cheap/2x4/config.h
+++ b/keyboards/handwired/stream_cheap/2x4/config.h
@@ -7,8 +7,7 @@
 #define PRODUCT_ID      0x1214
 #define DEVICE_VER      0x0001
 #define MANUFACTURER    Stream Cheap
-#define PRODUCT         Stream Cheap 2x4
-#define DESCRIPTION     Stream Cheap 2x4
+#define PRODUCT         2x4
 
 /* key matrix size */
 #define MATRIX_ROWS 2

--- a/keyboards/handwired/stream_cheap/2x4/config.h
+++ b/keyboards/handwired/stream_cheap/2x4/config.h
@@ -3,19 +3,19 @@
 #include "config_common.h"
 
 /* USB Device descriptor parameter */
-#define VENDOR_ID       0xFEED
+#define VENDOR_ID       0x7363 // Stream Cheap
 #define PRODUCT_ID      0x1214
 #define DEVICE_VER      0x0001
-#define MANUFACTURER    Kyle Hart
+#define MANUFACTURER    Stream Cheap
 #define PRODUCT         Stream Cheap 2x4
+#define DESCRIPTION     Stream Cheap 2x4
 
 /* key matrix size */
 #define MATRIX_ROWS 2
 #define MATRIX_COLS 4
 
 /* define direct pins used */
-#define DIRECT_PINS { { B5,D7,C6,D1}, { B4,E6,D4,D0} }
-
+#define DIRECT_PINS { { D1,D0,D4,C6}, { D7,E6,B4,B5} }
 
 /* Set 0 if debouncing isn't needed */
 #define DEBOUNCE 5

--- a/keyboards/handwired/stream_cheap/2x4/keymaps/via/keymap.c
+++ b/keyboards/handwired/stream_cheap/2x4/keymaps/via/keymap.c
@@ -1,0 +1,28 @@
+#include QMK_KEYBOARD_H
+
+
+enum layers {
+  NORMAL_LAYER = 0,
+  SECOND_LAYER = 1,
+  THIRD_LAYER = 2,
+  FOURTH_LAYER = 3
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [NORMAL_LAYER] = LAYOUT_ortho_2x4(
+        KC_A,  KC_A, KC_A, TO(3),
+        KC_A, KC_A, KC_A, TO(1)
+    ),
+    [SECOND_LAYER] = LAYOUT_ortho_2x4(
+        KC_B,   KC_B, KC_B, TO(0),
+        KC_B, KC_B, KC_B, TO(2)
+    ),
+    [THIRD_LAYER] = LAYOUT_ortho_2x4(
+        KC_C,   KC_C, KC_C, TO(1),
+        KC_C, KC_C, KC_C, TO(3)
+    ),
+    [FOURTH_LAYER] = LAYOUT_ortho_2x4(
+        KC_D,   KC_D, KC_D, TO(2),
+        KC_D, KC_D, KC_D, TO(0)
+    )
+};

--- a/keyboards/handwired/stream_cheap/2x4/keymaps/via/keymap.c
+++ b/keyboards/handwired/stream_cheap/2x4/keymaps/via/keymap.c
@@ -1,28 +1,43 @@
+/* Copyright 2021 Matthias Liffers
+  *
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 2 of the License, or
+  * (at your option) any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  */
+
 #include QMK_KEYBOARD_H
 
-
 enum layers {
-  NORMAL_LAYER = 0,
-  SECOND_LAYER = 1,
-  THIRD_LAYER = 2,
-  FOURTH_LAYER = 3
+  NORMAL_LAYER,
+  SECOND_LAYER,
+  THIRD_LAYER,
+  FOURTH_LAYER
 };
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [NORMAL_LAYER] = LAYOUT_ortho_2x4(
-        KC_A,  KC_A, KC_A, TO(3),
+        KC_A, KC_A, KC_A, TO(3),
         KC_A, KC_A, KC_A, TO(1)
     ),
     [SECOND_LAYER] = LAYOUT_ortho_2x4(
-        KC_B,   KC_B, KC_B, TO(0),
+        KC_B, KC_B, KC_B, TO(0),
         KC_B, KC_B, KC_B, TO(2)
     ),
     [THIRD_LAYER] = LAYOUT_ortho_2x4(
-        KC_C,   KC_C, KC_C, TO(1),
+        KC_C, KC_C, KC_C, TO(1),
         KC_C, KC_C, KC_C, TO(3)
     ),
     [FOURTH_LAYER] = LAYOUT_ortho_2x4(
-        KC_D,   KC_D, KC_D, TO(2),
+        KC_D, KC_D, KC_D, TO(2),
         KC_D, KC_D, KC_D, TO(0)
     )
 };

--- a/keyboards/handwired/stream_cheap/2x4/keymaps/via/rules.mk
+++ b/keyboards/handwired/stream_cheap/2x4/keymaps/via/rules.mk
@@ -1,0 +1,10 @@
+VIA_ENABLE = yes
+# LTO: link time optimization makes the build take slightly longer
+# but makes the resulting .hex file smaller, which allows you to
+# fit more features into smaller MCUs:
+LTO_ENABLE = yes
+# Support for these features make the hex file larger, but we want 'em:
+MOUSEKEY_ENABLE = yes     # Allow mapping of mouse control keys
+EXTRAKEY_ENABLE = yes     # Allow audio & system control keys
+COMMAND_ENABLE = yes      # Commands for debug and configuration
+NKRO_ENABLE = yes         # Support USB N-key roll over.

--- a/keyboards/handwired/stream_cheap/2x4/keymaps/via/rules.mk
+++ b/keyboards/handwired/stream_cheap/2x4/keymaps/via/rules.mk
@@ -1,10 +1,1 @@
 VIA_ENABLE = yes
-# LTO: link time optimization makes the build take slightly longer
-# but makes the resulting .hex file smaller, which allows you to
-# fit more features into smaller MCUs:
-LTO_ENABLE = yes
-# Support for these features make the hex file larger, but we want 'em:
-MOUSEKEY_ENABLE = yes     # Allow mapping of mouse control keys
-EXTRAKEY_ENABLE = yes     # Allow audio & system control keys
-COMMAND_ENABLE = yes      # Commands for debug and configuration
-NKRO_ENABLE = yes         # Support USB N-key roll over.

--- a/keyboards/handwired/stream_cheap/2x4/rules.mk
+++ b/keyboards/handwired/stream_cheap/2x4/rules.mk
@@ -20,3 +20,4 @@ BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 BLUETOOTH_ENABLE = no       # Enable Bluetooth
 AUDIO_ENABLE = no           # Audio output
+VIA_ENABLE = yes			# VIA support

--- a/keyboards/handwired/stream_cheap/2x4/rules.mk
+++ b/keyboards/handwired/stream_cheap/2x4/rules.mk
@@ -20,4 +20,3 @@ BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 BLUETOOTH_ENABLE = no       # Enable Bluetooth
 AUDIO_ENABLE = no           # Audio output
-VIA_ENABLE = yes			# VIA support


### PR DESCRIPTION
## Description

Added VIA support for the Stream Cheap 2x4.

While doing this, I noticed that the existing pin definition for the Stream Cheap 2x4 seemed entirely arbitrary. I have fixed the pins so that they are in a logical order.

I did not touch the Stream Cheap 2x3 and 2x5 configurations as I do not have them to test on.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

Nil

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
