### PR TITLE
Fix errors that have cropped up in develop

### DIFF
--- a/keyboards/frooastboard/config.h
+++ b/keyboards/frooastboard/config.h
@@ -19,9 +19,6 @@
 #include "config_common.h"
 
 /* USB Device descriptor parameter */
-#define VENDOR_ID       0x4642 /*F rooast B oards*/
-#define PRODUCT_ID      0x6F21 /*osu!*/
-#define DEVICE_VER      0x0001
 #define MANUFACTURER    frooastside
 #define PRODUCT         Frooastboard
 
@@ -29,19 +26,8 @@
 #define MATRIX_ROWS 2
 #define MATRIX_COLS 2
 
-/* key matrix pins */
-#define MATRIX_ROW_PINS { B0, B1 }
-#define MATRIX_COL_PINS { B2, B3 }
-#define UNUSED_PINS
-
 #define BOOTMAGIC_LITE_ROW 1
 #define BOOTMAGIC_LITE_COLUMN 1
-
-/* COL2ROW or ROW2COL */
-#define DIODE_DIRECTION COL2ROW
-
-/* Set 0 if debouncing isn't needed */
-#define DEBOUNCE 5
 
 #define RGB_DI_PIN B4
 #define RGBLED_NUM 8

--- a/keyboards/pistachio_pro/config.h
+++ b/keyboards/pistachio_pro/config.h
@@ -34,7 +34,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MATRIX_COLS 18
 
 #define MATRIX_ROW_PINS { D4, C6, D7, B3, B4, B5 }
-#define MATRIX_COL_PINS { E6, F0, F1, F4, F5, F6, F7, B6, D6, D5,}
+#define MATRIX_COL_PINS { E6, F0, F1, F4, F5, F6, F7, B6, D6 }
 #define UNUSED_PINS
 /* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
 #define DEBOUNCE 5


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

These keyboards were added to `master` recently. This brings our error count back to 0.

```
⚠ frooastboard: DEBOUNCE in config.h is overwriting debounce in info.json
⚠ frooastboard: DEVICE_VER in config.h is overwriting usb.device_ver in info.json
⚠ frooastboard: DIODE_DIRECTION in config.h is overwriting diode_direction in info.json
⚠ frooastboard: PRODUCT_ID in config.h is overwriting usb.pid in info.json
⚠ frooastboard: VENDOR_ID in config.h is overwriting usb.vid in info.json
⚠ frooastboard: Matrix pins are specified in both info.json and config.h, the config.h values win.
☒ pistachio_pro: MATRIX_COLS is inconsistent with the size of MATRIX_COL_PINS: 11 != 18
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bugfix
- [x] Keyboard (addition or update)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).