### PR TITLE
Fix ifdefs for OLED split sync code

### DIFF
--- a/keyboards/splitkb/kyria/rev1/config.h
+++ b/keyboards/splitkb/kyria/rev1/config.h
@@ -71,6 +71,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #ifdef OLED_DRIVER_ENABLE
 #    define OLED_DISPLAY_128X64
+#    define SPLIT_OLED_ENABLE
 #endif
 
 /* RGB matrix support */

--- a/quantum/split_common/transaction_id_define.h
+++ b/quantum/split_common/transaction_id_define.h
@@ -70,9 +70,9 @@ enum serial_transaction_id {
     PUT_WPM,
 #endif  // defined(WPM_ENABLE) && defined(SPLIT_WPM_ENABLE)
 
-#if defined(OLED_ENABLE) && defined(SPLIT_OLED_ENABLE)
+#if defined(OLED_DRIVER_ENABLE) && defined(SPLIT_OLED_ENABLE)
     PUT_OLED,
-#endif  // defined(WPM_ENABLE) && defined(SPLIT_OLED_ENABLE)
+#endif  // defined(OLED_DRIVER_ENABLE) && defined(SPLIT_OLED_ENABLE)
 
 #if defined(ST7565_ENABLE) && defined(SPLIT_ST7565_ENABLE)
     PUT_ST7565,

--- a/quantum/split_common/transactions.c
+++ b/quantum/split_common/transactions.c
@@ -522,7 +522,7 @@ static void wpm_handlers_slave(matrix_row_t master_matrix[], matrix_row_t slave_
 ////////////////////////////////////////////////////
 // OLED
 
-#if defined(OLED_ENABLE) && defined(SPLIT_OLED_ENABLE)
+#if defined(OLED_DRIVER_ENABLE) && defined(SPLIT_OLED_ENABLE)
 
 static bool oled_handlers_master(matrix_row_t master_matrix[], matrix_row_t slave_matrix[]) {
     static uint32_t last_update        = 0;
@@ -542,7 +542,7 @@ static void oled_handlers_slave(matrix_row_t master_matrix[], matrix_row_t slave
 #    define TRANSACTIONS_OLED_SLAVE()       TRANSACTION_HANDLER_SLAVE(oled_handlers)
 #    define TRANSACTIONS_OLED_REGISTRATIONS [PUT_OLED] = trans_initiator2target_initializer(current_oled_state),
 
-#else  // defined(OLED_ENABLE) && defined(SPLIT_OLED_ENABLE)
+#else  // defined(OLED_DRIVER_ENABLE) && defined(SPLIT_OLED_ENABLE)
 
 #    define TRANSACTIONS_OLED_MASTER()
 #    define TRANSACTIONS_OLED_SLAVE()

--- a/quantum/split_common/transport.h
+++ b/quantum/split_common/transport.h
@@ -165,9 +165,9 @@ typedef struct _split_shared_memory_t {
     uint8_t current_wpm;
 #endif  // defined(WPM_ENABLE) && defined(SPLIT_WPM_ENABLE)
 
-#if defined(OLED_ENABLE) && defined(SPLIT_OLED_ENABLE)
+#if defined(OLED_DRIVER_ENABLE) && defined(SPLIT_OLED_ENABLE)
     uint8_t current_oled_state;
-#endif  // defined(OLED_ENABLE) && defined(SPLIT_OLED_ENABLE)
+#endif  // defined(OLED_DRIVER_ENABLE) && defined(SPLIT_OLED_ENABLE)
 
 #if defined(ST7565_ENABLE) && defined(SPLIT_ST7565_ENABLE)
     uint8_t current_st7565_state;


### PR DESCRIPTION
## Description

Was using the wrong defines ...

Plus side, verified that even if the timeouts are different, it still works, and doesn't cause flickering or other weird behavior. 

## Types of Changes

- [x] Core
- [x] Bugfix


## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
