### PR TITLE
Unify behaviour of wait on AVR

### DIFF
--- a/tmk_core/common/avr/_wait.h
+++ b/tmk_core/common/avr/_wait.h
@@ -17,8 +17,26 @@
 
 #include <util/delay.h>
 
-#define wait_ms(ms) _delay_ms(ms)
-#define wait_us(us) _delay_us(us)
+#define wait_ms(ms)                             \
+    do {                                        \
+        if (__builtin_constant_p(ms)) {         \
+            _delay_ms(ms);                      \
+        } else {                                \
+            for (uint16_t i = ms; i > 0; i--) { \
+                _delay_ms(1);                   \
+            }                                   \
+        }                                       \
+    } while (0)
+#define wait_us(us)                             \
+    do {                                        \
+        if (__builtin_constant_p(us)) {         \
+            _delay_us(us);                      \
+        } else {                                \
+            for (uint16_t i = us; i > 0; i--) { \
+                _delay_us(1);                   \
+            }                                   \
+        }                                       \
+    } while (0)
 
 /* The AVR series GPIOs have a one clock read delay for changes in the digital input signal.
  * But here's more margin to make it two clocks. */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
`wait_ms`/`wait_us` on AVR cannot handle dynamic values like the ChibiOS abstraction can.

This leads to code that bleeds implementation details outside of tmk_core. For example;
```c
#if defined(__AVR__)
        for (uint16_t i = delay; i > 0; i--) {
            wait_ms(1);
        }
#else
        wait_ms(delay);
#endif
```

Hopefully the `__builtin_constant_p` magic should catch a lot of the existing cases, limited testing shows the same firmware sizes.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
