### PR TITLE
Improvements to handling of disconnected split keyboards.

### DIFF
--- a/quantum/matrix.c
+++ b/quantum/matrix.c
@@ -288,10 +288,8 @@ void matrix_init(void) {
     matrix_init_pins();
 
     // initialize matrix state: all keys off
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        raw_matrix[i] = 0;
-        matrix[i]     = 0;
-    }
+    memset(matrix, 0, sizeof(matrix));
+    memset(raw_matrix, 0, sizeof(raw_matrix));
 
     debounce_init(ROWS_PER_HAND);
 
@@ -314,19 +312,11 @@ bool matrix_post_scan(void) {
     if (is_keyboard_master()) {
         matrix_row_t slave_matrix[ROWS_PER_HAND] = {0};
         if (transport_master_if_connected(matrix + thisHand, slave_matrix)) {
-            for (int i = 0; i < ROWS_PER_HAND; ++i) {
-                if (matrix[thatHand + i] != slave_matrix[i]) {
-                    matrix[thatHand + i] = slave_matrix[i];
-                    changed              = true;
-                }
-            }
+            changed = memcmp(matrix + thatHand, slave_matrix, sizeof(slave_matrix)) != 0;
+            if (changed) memcpy(matrix + thatHand, slave_matrix, sizeof(slave_matrix));
         } else {
             // reset other half if disconnected
-            for (int i = 0; i < ROWS_PER_HAND; ++i) {
-                matrix[thatHand + i] = 0;
-                slave_matrix[i]      = 0;
-            }
-
+            memset(matrix + thatHand, 0, sizeof(slave_matrix));
             changed = true;
         }
 

--- a/quantum/matrix.c
+++ b/quantum/matrix.c
@@ -310,8 +310,8 @@ __attribute__((weak)) bool transport_master_if_connected(matrix_row_t master_mat
 bool matrix_post_scan(void) {
     bool changed = false;
     if (is_keyboard_master()) {
-        static bool  last_connected = false;
-        matrix_row_t slave_matrix[ROWS_PER_HAND];
+        static bool  last_connected              = false;
+        matrix_row_t slave_matrix[ROWS_PER_HAND] = {0};
         if (transport_master_if_connected(matrix + thisHand, slave_matrix)) {
             changed = memcmp(matrix + thatHand, slave_matrix, sizeof(slave_matrix)) != 0;
 


### PR DESCRIPTION
## Description

Continuing from #13523.

First, a slight cleanup of how the slave matrix is copied to the master matrix. Now using `memcmp`, `memcpy` and `memset`, as suggested by @KarlK90 in comments in the above mentioned PR.

Secondly, fixes an issue with `matrix_post_scan` signalling a matrix change on every scan cycle while disconnected, causing issues with (at least) OLED timeouts.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
