### PR TITLE
[CLI] Add qmk-hid bootloader detection support to `qmk console`

### DIFF
--- a/lib/python/qmk/cli/console.py
+++ b/lib/python/qmk/cli/console.py
@@ -51,7 +51,8 @@ KNOWN_BOOTLOADERS = {
     ('2A03', '0036'): 'caterina: Arduino Leonardo',
     ('2A03', '0037'): 'caterina: Arduino Micro',
     ('314B', '0106'): 'apm32-dfu: APM32 DFU ISP Mode',
-    ('03EB', '2067'): 'qmk-hid: HID Bootloader'
+    ('03EB', '2067'): 'qmk-hid: HID Bootloader',
+    ('03EB', '2045'): 'lufa-ms: LUFA Mass Storage Bootloader'
 }
 
 

--- a/lib/python/qmk/cli/console.py
+++ b/lib/python/qmk/cli/console.py
@@ -51,7 +51,8 @@ KNOWN_BOOTLOADERS = {
     ('239A', '000E'): 'caterina: Adafruit ItsyBitsy 32U4 5v',
     ('2A03', '0036'): 'caterina: Arduino Leonardo',
     ('2A03', '0037'): 'caterina: Arduino Micro',
-    ('314B', '0106'): 'apm32-dfu: APM32 DFU ISP Mode'
+    ('314B', '0106'): 'apm32-dfu: APM32 DFU ISP Mode',
+    ('03EB', '2067'): 'qmk-hid: HID Bootloader'
 }
 
 

--- a/lib/python/qmk/cli/console.py
+++ b/lib/python/qmk/cli/console.py
@@ -48,7 +48,6 @@ KNOWN_BOOTLOADERS = {
     ('239A', '000C'): 'caterina: Adafruit Feather 32U4',
     ('239A', '000D'): 'caterina: Adafruit ItsyBitsy 32U4 3v',
     ('239A', '000E'): 'caterina: Adafruit ItsyBitsy 32U4 5v',
-    ('239A', '000E'): 'caterina: Adafruit ItsyBitsy 32U4 5v',
     ('2A03', '0036'): 'caterina: Arduino Leonardo',
     ('2A03', '0037'): 'caterina: Arduino Micro',
     ('314B', '0106'): 'apm32-dfu: APM32 DFU ISP Mode',

--- a/lib/python/qmk/cli/doctor/linux.py
+++ b/lib/python/qmk/cli/doctor/linux.py
@@ -82,6 +82,10 @@ def check_udev_rules():
             # dog hunter AG
             _udev_rule("2a03", "0036", 'ENV{ID_MM_DEVICE_IGNORE}="1"'),  # Leonardo
             _udev_rule("2a03", "0037", 'ENV{ID_MM_DEVICE_IGNORE}="1"')  # Micro
+        },
+        'hid-bootloader': {
+            _udev_rule("03eb", "2067"),  # QMK HID
+            _udev_rule("16c0", "0478")  # PJRC halfkay
         }
     }
 

--- a/util/udev/50-qmk.rules
+++ b/util/udev/50-qmk.rules
@@ -63,3 +63,9 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="2a03", ATTRS{idProduct}=="0037", TAG+="uacc
 
 # hid_listen
 KERNEL=="hidraw*", MODE="0660", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"
+
+# hid bootloaders
+## QMK HID
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2076", TAG+="uaccess"
+## PJRC's HalfKay
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="0483", TAG+="uaccess"

--- a/util/udev/50-qmk.rules
+++ b/util/udev/50-qmk.rules
@@ -68,4 +68,4 @@ KERNEL=="hidraw*", MODE="0660", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"
 ## QMK HID
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2076", TAG+="uaccess"
 ## PJRC's HalfKay
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="0483", TAG+="uaccess"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="0478", TAG+="uaccess"

--- a/util/udev/50-qmk.rules
+++ b/util/udev/50-qmk.rules
@@ -66,6 +66,6 @@ KERNEL=="hidraw*", MODE="0660", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"
 
 # hid bootloaders
 ## QMK HID
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2076", TAG+="uaccess"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2067", TAG+="uaccess"
 ## PJRC's HalfKay
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="0478", TAG+="uaccess"


### PR DESCRIPTION
## Description

Like the title says.

## Types of Changes

- [x] Core
- [x] Enhancement/optimization

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
