### PR TITLE
Fix wait_us overflow in matrix for dactyl based boards

### DIFF
--- a/keyboards/handwired/dactyl/matrix.c
+++ b/keyboards/handwired/dactyl/matrix.c
@@ -130,7 +130,7 @@ void matrix_init(void)
 void init_expander(void) {
     if (! i2c_initialized) {
         i2c_init();
-        wait_us(1000000);
+        wait_ms(1000);
     }
 
     if (! expander_input_pin_mask) {

--- a/keyboards/handwired/pterodactyl/matrix.c
+++ b/keyboards/handwired/pterodactyl/matrix.c
@@ -143,7 +143,7 @@ void matrix_init(void)
 void init_expander(void) {
     if (! i2c_initialized) {
         i2c_init();
-        wait_us(1000000);
+        wait_ms(1000);
     }
 
     if (! expander_input_pin_mask) {


### PR DESCRIPTION
## Description

Change `wait_us(1000000)` to `wait_ms(1000)` in dactyl and pterodactyl keyboards to prevent overflowing of uint16.

## Types of Changes

- [x] Bugfix
- [x] Keyboard (addition or update)

## Issues Fixed or Closed by This PR

* Tzarc CI

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
