### PR TITLE
[Keyboard] Fix Planck EZ's nested macro layout warning

### DIFF
--- a/keyboards/planck/ez/ez.h
+++ b/keyboards/planck/ez/ez.h
@@ -23,6 +23,7 @@
 #    include "glow.h"
 #endif
 
+// clang-format off
 #define LAYOUT_planck_1x2uC( \
     k00, k01, k02, k03, k04, k05, k06, k07, k08, k09, k0a, k0b, \
     k10, k11, k12, k13, k14, k15, k16, k17, k18, k19, k1a, k1b, \
@@ -41,17 +42,23 @@
 }
 
 #define LAYOUT_ortho_4x12( \
-    k00, k01, k02, k03, k04, k05, k06,   k07, k08, k09, k0a, k0b, \
-    k10, k11, k12, k13, k14, k15, k16,   k17, k18, k19, k1a, k1b, \
-    k20, k21, k22, k23, k24, k25, k26,   k27, k28, k29, k2a, k2b, \
-    k30, k31, k32, k33, k34, k35, KC_NO, k37, k38, k39, k3a, k3b  \
-) \
-LAYOUT_planck_1x2uC( \
     k00, k01, k02, k03, k04, k05, k06, k07, k08, k09, k0a, k0b, \
     k10, k11, k12, k13, k14, k15, k16, k17, k18, k19, k1a, k1b, \
     k20, k21, k22, k23, k24, k25, k26, k27, k28, k29, k2a, k2b, \
-    k30, k31, k32, k33, k34,    k35,   k37, k38, k39, k3a, k3b  \
-)
+    k30, k31, k32, k33, k34, k35, k36, k37, k38, k39, k3a, k3b  \
+) \
+{ \
+    { k00, k01, k02, k03, k04, k05   }, \
+    { k10, k11, k12, k13, k14, k15   }, \
+    { k20, k21, k22, k23, k24, k25   }, \
+    { k30, k31, k32, k3a, k3b, KC_NO }, \
+    { k06, k07, k08, k09, k0a, k0b   }, \
+    { k16, k17, k18, k19, k1a, k1b   }, \
+    { k26, k27, k28, k29, k2a, k2b   }, \
+    { k37, k38, k39, k33, k34, k35   } \
+}
+
+// clang-format on
 
 #define LAYOUT_planck_mit LAYOUT_planck_1x2uC
 #define LAYOUT_planck_grid LAYOUT_ortho_4x12


### PR DESCRIPTION
## Description

Fix the nested layout macro

## Types of Changes

- [x] Enhancement/optimization
- [x] Keyboard (addition or update)

## Issues Fixed or Closed by This PR

* #14042 

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
