### PR TITLE
[Keymap] fix helix:fraanrosi compile error caused by #13677.

### DIFF
--- a/keyboards/helix/rev2/keymaps/fraanrosi/config.h
+++ b/keyboards/helix/rev2/keymaps/fraanrosi/config.h
@@ -25,7 +25,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // If you need more program area, try select and reduce rgblight modes to use.
 
-#define RGBLIGHT_ANIMATIONS
+#ifndef LED_ANIMATIONS
+#    define LED_ANIMATIONS
+#endif
 
 // Selection of RGBLIGHT MODE to use.
 #if defined(LED_ANIMATIONS)
@@ -38,6 +40,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
    #define RGBLIGHT_EFFECT_STATIC_GRADIENT
    #define RGBLIGHT_EFFECT_RGB_TEST
    #define RGBLIGHT_EFFECT_ALTERNATING
+   #define RGBLIGHT_EFFECT_TWINKLE
 #endif
 
 #undef RGBLIGHT_HUE_STEP


### PR DESCRIPTION
## Description

I'm against using RGBLIGHT_ANIMATIONS because this happens.
See also #8688.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
