### PR TITLE
[Core] Don't send keyboard reports that propagate no changes to the host 

### DIFF
--- a/quantum/action_util.c
+++ b/quantum/action_util.c
@@ -21,6 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "action_layer.h"
 #include "timer.h"
 #include "keycode_config.h"
+#include <string.h>
 
 extern keymap_config_t keymap_config;
 
@@ -247,7 +248,13 @@ void send_keyboard_report(void) {
     keyboard_report->mods |= weak_override_mods;
 #endif
 
-    host_keyboard_send(keyboard_report);
+    static report_keyboard_t last_report;
+
+    /* Only send the report if there are changes to propagate to the host. */
+    if (memcmp(keyboard_report, &last_report, sizeof(report_keyboard_t)) != 0) {
+        memcpy(&last_report, keyboard_report, sizeof(report_keyboard_t));
+        host_keyboard_send(keyboard_report);
+    }
 }
 
 /** \brief Get mods

--- a/tests/auto_shift/test_auto_shift.cpp
+++ b/tests/auto_shift/test_auto_shift.cpp
@@ -42,7 +42,6 @@ TEST_F(AutoShift, key_release_before_timeout) {
     /* Release regular key */
     EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_A)));
     EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport()));
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport()));
     regular_key.release();
     run_one_scan_loop();
     testing::Mock::VerifyAndClearExpectations(&driver);
@@ -64,8 +63,6 @@ TEST_F(AutoShift, key_release_after_timeout) {
     /* Release regular key */
     EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_LSFT, KC_A)));
     EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_LSFT)));
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport()));
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport()));
     EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport()));
     regular_key.release();
     run_one_scan_loop();

--- a/tests/basic/test_action_layer.cpp
+++ b/tests/basic/test_action_layer.cpp
@@ -131,14 +131,12 @@ TEST_F(ActionLayer, MomentaryLayerDoesNothing) {
     set_keymap({layer_key});
 
     /* Press and release MO, nothing should happen. */
-    /* TODO: QMK currently sends an empty report even if nothing needs to be reported to the host! */
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport())).Times(1);
+    EXPECT_CALL(driver, send_keyboard_mock(_)).Times(0);
     layer_key.press();
     run_one_scan_loop();
     testing::Mock::VerifyAndClearExpectations(&driver);
 
-    /* TODO: QMK currently sends an empty report even if nothing needs to be reported to the host! */
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport())).Times(1);
+    EXPECT_CALL(driver, send_keyboard_mock(_)).Times(0);
     layer_key.release();
     run_one_scan_loop();
     testing::Mock::VerifyAndClearExpectations(&driver);
@@ -153,8 +151,7 @@ TEST_F(ActionLayer, MomentaryLayerWithKeypress) {
     set_keymap({layer_key, regular_key, KeymapKey{1, 1, 0, KC_B}});
 
     /* Press MO. */
-    /* TODO: QMK currently sends an empty report even if nothing needs to be reported to the host! */
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport())).Times(1);
+    EXPECT_CALL(driver, send_keyboard_mock(_)).Times(0);
     layer_key.press();
     run_one_scan_loop();
     EXPECT_TRUE(layer_state_is(1));
@@ -175,8 +172,7 @@ TEST_F(ActionLayer, MomentaryLayerWithKeypress) {
     testing::Mock::VerifyAndClearExpectations(&driver);
 
     /* Release MO */
-    /* TODO: QMK currently sends an empty report even if nothing needs to be reported to the host! */
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport())).Times(1);
+    EXPECT_CALL(driver, send_keyboard_mock(_)).Times(0);
     layer_key.release();
     run_one_scan_loop();
     EXPECT_TRUE(layer_state_is(0));
@@ -199,8 +195,7 @@ TEST_F(ActionLayer, ToggleLayerDoesNothing) {
     testing::Mock::VerifyAndClearExpectations(&driver);
 
     /* Release TG. */
-    /* TODO: QMK currently sends an empty report even if nothing needs to be reported to the host! */
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport())).Times(1);
+    EXPECT_CALL(driver, send_keyboard_mock(_)).Times(0);
     layer_key.release();
     run_one_scan_loop();
     EXPECT_TRUE(layer_state_is(1));
@@ -223,8 +218,7 @@ TEST_F(ActionLayer, ToggleLayerUpAndDown) {
     EXPECT_TRUE(layer_state_is(1));
     testing::Mock::VerifyAndClearExpectations(&driver);
 
-    /* TODO: QMK currently sends an empty report even if nothing needs to be reported to the host! */
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport())).Times(1);
+    EXPECT_CALL(driver, send_keyboard_mock(_)).Times(0);
     toggle_layer_1_on_layer_0.release();
     run_one_scan_loop();
     EXPECT_TRUE(layer_state_is(1));
@@ -237,8 +231,7 @@ TEST_F(ActionLayer, ToggleLayerUpAndDown) {
     EXPECT_TRUE(layer_state_is(0));
     testing::Mock::VerifyAndClearExpectations(&driver);
 
-    /* TODO: QMK currently sends an empty report even if nothing needs to be reported to the host! */
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport())).Times(1);
+    EXPECT_CALL(driver, send_keyboard_mock(_)).Times(0);
     toggle_layer_0_on_layer_1.release();
     run_one_scan_loop();
     EXPECT_TRUE(layer_state_is(0));
@@ -254,14 +247,13 @@ TEST_F(ActionLayer, LayerTapToggleDoesNothing) {
     set_keymap({layer_key});
 
     /* Press and release TT. */
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport())).Times(0);
+    EXPECT_CALL(driver, send_keyboard_mock(_)).Times(0);
     layer_key.press();
     run_one_scan_loop();
     EXPECT_TRUE(layer_state_is(1));
     testing::Mock::VerifyAndClearExpectations(&driver);
 
-    /* TODO: QMK currently sends an empty report even if nothing needs to be reported to the host! */
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport())).Times(2);
+    EXPECT_CALL(driver, send_keyboard_mock(_)).Times(0);
     layer_key.release();
     run_one_scan_loop();
     EXPECT_TRUE(layer_state_is(0));
@@ -279,7 +271,6 @@ TEST_F(ActionLayer, LayerTapToggleWithKeypress) {
     set_keymap({layer_key, regular_key, KeymapKey{1, 1, 0, KC_B}});
 
     /* Press TT. */
-    /* TODO: QMK currently sends an empty report even if nothing needs to be reported to the host! */
     EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport())).Times(0);
     layer_key.press();
     run_one_scan_loop();
@@ -298,8 +289,7 @@ TEST_F(ActionLayer, LayerTapToggleWithKeypress) {
     EXPECT_TRUE(layer_state_is(1));
     testing::Mock::VerifyAndClearExpectations(&driver);
 
-    /* TODO: QMK currently sends an empty report even if nothing needs to be reported to the host! */
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport())).Times(1);
+    EXPECT_CALL(driver, send_keyboard_mock(_)).Times(0);
     layer_key.release();
     run_one_scan_loop();
     EXPECT_TRUE(layer_state_is(0));
@@ -317,8 +307,7 @@ TEST_F(ActionLayer, LayerTapToggleWithToggleWithKeypress) {
     set_keymap({layer_key, regular_key, KeymapKey{1, 1, 0, KC_B}});
 
     /* Tap TT five times . */
-    /* TODO: QMK currently sends an empty report even if nothing needs to be reported to the host! */
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport())).Times(9);
+    EXPECT_CALL(driver, send_keyboard_mock(_)).Times(0);
 
     layer_key.press();
     run_one_scan_loop();

--- a/tests/basic/test_keypress.cpp
+++ b/tests/basic/test_keypress.cpp
@@ -85,7 +85,7 @@ TEST_F(KeyPress, CorrectKeysAreReportedWhenTwoKeysArePressed) {
 TEST_F(KeyPress, LeftShiftIsReportedCorrectly) {
     TestDriver driver;
     auto       key_a    = KeymapKey(0, 0, 0, KC_A);
-    auto       key_lsft = KeymapKey(0, 3, 0, KC_LSFT);
+    auto       key_lsft = KeymapKey(0, 3, 0, KC_LEFT_SHIFT);
 
     set_keymap({key_a, key_lsft});
 
@@ -110,8 +110,8 @@ TEST_F(KeyPress, LeftShiftIsReportedCorrectly) {
 
 TEST_F(KeyPress, PressLeftShiftAndControl) {
     TestDriver driver;
-    auto       key_lsft  = KeymapKey(0, 3, 0, KC_LSFT);
-    auto       key_lctrl = KeymapKey(0, 5, 0, KC_LCTRL);
+    auto       key_lsft  = KeymapKey(0, 3, 0, KC_LEFT_SHIFT);
+    auto       key_lctrl = KeymapKey(0, 5, 0, KC_LEFT_CTRL);
 
     set_keymap({key_lctrl, key_lsft});
 
@@ -138,8 +138,8 @@ TEST_F(KeyPress, PressLeftShiftAndControl) {
 
 TEST_F(KeyPress, LeftAndRightShiftCanBePressedAtTheSameTime) {
     TestDriver driver;
-    auto       key_lsft = KeymapKey(0, 3, 0, KC_LSFT);
-    auto       key_rsft = KeymapKey(0, 4, 0, KC_RSFT);
+    auto       key_lsft = KeymapKey(0, 3, 0, KC_LEFT_SHIFT);
+    auto       key_rsft = KeymapKey(0, 4, 0, KC_RIGHT_SHIFT);
 
     set_keymap({key_rsft, key_lsft});
 
@@ -175,12 +175,12 @@ TEST_F(KeyPress, RightShiftLeftControlAndCharWithTheSameKey) {
     // The underlying cause is that we use only one bit to represent the right hand
     // modifiers.
     combo_key.press();
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_RSFT, KC_RCTRL)));
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_RSFT, KC_RCTRL, KC_O)));
+    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_RIGHT_SHIFT, KC_RIGHT_CTRL)));
+    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_RIGHT_SHIFT, KC_RIGHT_CTRL, KC_O)));
     keyboard_task();
 
     combo_key.release();
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_RSFT, KC_RCTRL)));
+    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_RIGHT_SHIFT, KC_RIGHT_CTRL)));
     EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport()));
     keyboard_task();
 }
@@ -189,18 +189,18 @@ TEST_F(KeyPress, PressPlusEqualReleaseBeforePress) {
     TestDriver driver;
     InSequence s;
     auto       key_plus = KeymapKey(0, 1, 1, KC_PLUS);
-    auto       key_eql  = KeymapKey(0, 0, 1, KC_EQL);
+    auto       key_eql  = KeymapKey(0, 0, 1, KC_EQUAL);
 
     set_keymap({key_plus, key_eql});
 
     key_plus.press();
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_LSFT)));
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_LSFT, KC_EQL)));
+    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_LEFT_SHIFT)));
+    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_LEFT_SHIFT, KC_EQUAL)));
     run_one_scan_loop();
     testing::Mock::VerifyAndClearExpectations(&driver);
 
     key_plus.release();
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_LSFT)));
+    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_LEFT_SHIFT)));
     EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport()));
     run_one_scan_loop();
     testing::Mock::VerifyAndClearExpectations(&driver);
@@ -220,13 +220,13 @@ TEST_F(KeyPress, PressPlusEqualDontReleaseBeforePress) {
     TestDriver driver;
     InSequence s;
     auto       key_plus = KeymapKey(0, 1, 1, KC_PLUS);
-    auto       key_eql  = KeymapKey(0, 0, 1, KC_EQL);
+    auto       key_eql  = KeymapKey(0, 0, 1, KC_EQUAL);
 
     set_keymap({key_plus, key_eql});
 
     key_plus.press();
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_LSFT)));
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_LSFT, KC_EQL)));
+    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_LEFT_SHIFT)));
+    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_LEFT_SHIFT, KC_EQUAL)));
     run_one_scan_loop();
     testing::Mock::VerifyAndClearExpectations(&driver);
 
@@ -237,14 +237,13 @@ TEST_F(KeyPress, PressPlusEqualDontReleaseBeforePress) {
     testing::Mock::VerifyAndClearExpectations(&driver);
 
     key_plus.release();
-    // BUG: Should really still return KC_EQL, but this is fine too
-    // It's also called twice for some reason
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport())).Times(2);
+    // BUG: Should really still return KC_EQUAL, but this is fine too
+    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport())).Times(1);
     run_one_scan_loop();
     testing::Mock::VerifyAndClearExpectations(&driver);
 
     key_eql.release();
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport()));
+    EXPECT_CALL(driver, send_keyboard_mock(_)).Times(0);
     run_one_scan_loop();
     testing::Mock::VerifyAndClearExpectations(&driver);
 }
@@ -253,12 +252,12 @@ TEST_F(KeyPress, PressEqualPlusReleaseBeforePress) {
     TestDriver driver;
     InSequence s;
     auto       key_plus = KeymapKey(0, 1, 1, KC_PLUS);
-    auto       key_eql  = KeymapKey(0, 0, 1, KC_EQL);
+    auto       key_eql  = KeymapKey(0, 0, 1, KC_EQUAL);
 
     set_keymap({key_plus, key_eql});
 
     key_eql.press();
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_EQL)));
+    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_EQUAL)));
     run_one_scan_loop();
     testing::Mock::VerifyAndClearExpectations(&driver);
 
@@ -268,13 +267,13 @@ TEST_F(KeyPress, PressEqualPlusReleaseBeforePress) {
     testing::Mock::VerifyAndClearExpectations(&driver);
 
     key_plus.press();
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_LSFT)));
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_LSFT, KC_EQL)));
+    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_LEFT_SHIFT)));
+    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_LEFT_SHIFT, KC_EQUAL)));
     run_one_scan_loop();
     testing::Mock::VerifyAndClearExpectations(&driver);
 
     key_plus.release();
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_LSFT)));
+    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_LEFT_SHIFT)));
     EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport()));
     run_one_scan_loop();
     testing::Mock::VerifyAndClearExpectations(&driver);
@@ -284,12 +283,12 @@ TEST_F(KeyPress, PressEqualPlusDontReleaseBeforePress) {
     TestDriver driver;
     InSequence s;
     auto       key_plus = KeymapKey(0, 1, 1, KC_PLUS);
-    auto       key_eql  = KeymapKey(0, 0, 1, KC_EQL);
+    auto       key_eql  = KeymapKey(0, 0, 1, KC_EQUAL);
 
     set_keymap({key_plus, key_eql});
 
     key_eql.press();
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_EQL)));
+    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_EQUAL)));
     run_one_scan_loop();
     testing::Mock::VerifyAndClearExpectations(&driver);
 
@@ -309,8 +308,6 @@ TEST_F(KeyPress, PressEqualPlusDontReleaseBeforePress) {
     testing::Mock::VerifyAndClearExpectations(&driver);
 
     key_plus.release();
-    // This report is not needed
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_LEFT_SHIFT)));
     EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport()));
     run_one_scan_loop();
     testing::Mock::VerifyAndClearExpectations(&driver);

--- a/tests/basic/test_one_shot_keys.cpp
+++ b/tests/basic/test_one_shot_keys.cpp
@@ -175,22 +175,20 @@ TEST_F(OneShot, OSLWithAdditionalKeypress) {
     testing::Mock::VerifyAndClearExpectations(&driver);
 
     /* Release OSL key */
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport())).Times(2);
+    EXPECT_CALL(driver, send_keyboard_mock(_)).Times(0);
     osl_key.release();
     run_one_scan_loop();
     testing::Mock::VerifyAndClearExpectations(&driver);
 
     /* Press regular key */
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport()));
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(regular_key.report_code))).Times(2);
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport()));
+    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(regular_key.report_code))).Times(1);
     EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport()));
     regular_key.press();
     run_one_scan_loop();
     testing::Mock::VerifyAndClearExpectations(&driver);
 
     /* Release regular key */
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport()));
+    EXPECT_CALL(driver, send_keyboard_mock(_)).Times(0);
     regular_key.release();
     run_one_scan_loop();
     testing::Mock::VerifyAndClearExpectations(&driver);

--- a/tests/tap_hold_configurations/permissive_hold/test_tap_hold.cpp
+++ b/tests/tap_hold_configurations/permissive_hold/test_tap_hold.cpp
@@ -117,7 +117,6 @@ TEST_F(PermissiveHold, tap_regular_key_while_layer_tap_key_is_held) {
     testing::Mock::VerifyAndClearExpectations(&driver);
 
     /* Release regular key */
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport()));
     EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(layer_key.report_code)));
     EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport()));
     regular_key.release();
@@ -125,7 +124,7 @@ TEST_F(PermissiveHold, tap_regular_key_while_layer_tap_key_is_held) {
     testing::Mock::VerifyAndClearExpectations(&driver);
 
     /* Release layer-tap-hold key */
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport()));
+    EXPECT_CALL(driver, send_keyboard_mock(_)).Times(0);
     layer_tap_hold_key.release();
     run_one_scan_loop();
     testing::Mock::VerifyAndClearExpectations(&driver);

--- a/tests/tap_hold_configurations/permissive_hold_ignore_mod_tap_interrupt/test_tap_hold.cpp
+++ b/tests/tap_hold_configurations/permissive_hold_ignore_mod_tap_interrupt/test_tap_hold.cpp
@@ -119,7 +119,6 @@ TEST_F(PermissiveHold_IgnoreModTapInterrupt, tap_regular_key_while_layer_tap_key
     testing::Mock::VerifyAndClearExpectations(&driver);
 
     /* Release regular key */
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport()));
     EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_B)));
     EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport()));
     regular_key.release();
@@ -127,7 +126,7 @@ TEST_F(PermissiveHold_IgnoreModTapInterrupt, tap_regular_key_while_layer_tap_key
     testing::Mock::VerifyAndClearExpectations(&driver);
 
     /* Release layer-tap-hold key */
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport()));
+    EXPECT_CALL(driver, send_keyboard_mock(_)).Times(0);
     layer_tap_hold_key.release();
     run_one_scan_loop();
     testing::Mock::VerifyAndClearExpectations(&driver);

--- a/tests/tap_hold_configurations/tapping_force_hold/test_action_layer.cpp
+++ b/tests/tap_hold_configurations/tapping_force_hold/test_action_layer.cpp
@@ -31,9 +31,8 @@ TEST_F(ActionLayer, LayerTapToggleWithToggleWithKeypress) {
     set_keymap({layer_key, regular_key, KeymapKey{1, 1, 0, KC_B}});
 
     /* Tap TT five times . */
-    /* TODO: QMK currently sends an empty report even if nothing needs to be reported to the host! */
     /* TODO: Tapping Force Hold breaks TT */
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport())).Times(10);
+    EXPECT_CALL(driver, send_keyboard_mock(_)).Times(0);
 
     layer_key.press();
     run_one_scan_loop();

--- a/tests/tap_hold_configurations/tapping_force_hold/test_tap_hold.cpp
+++ b/tests/tap_hold_configurations/tapping_force_hold/test_tap_hold.cpp
@@ -60,7 +60,6 @@ TEST_F(TappingForceHold, tap_regular_key_while_mod_tap_key_is_held) {
     testing::Mock::VerifyAndClearExpectations(&driver);
 
     /* Idle for tapping term of mod tap hold key. */
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_LSFT)));
     EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_LSFT, KC_A)));
     EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_LSFT)));
     EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport()));
@@ -101,7 +100,6 @@ TEST_F(TappingForceHold, tap_mod_tap_key_while_mod_tap_key_is_held) {
     testing::Mock::VerifyAndClearExpectations(&driver);
 
     /* Idle for tapping term of first mod tap hold key. */
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_LSFT)));
     EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_LSFT, KC_A)));
     EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_LSFT)));
     EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport()));

--- a/tests/test_common/test_fixture.cpp
+++ b/tests/test_common/test_fixture.cpp
@@ -48,7 +48,6 @@ void TestFixture::SetUpTestCase() {
     eeconfig_update_debug(debug_config.raw);
 
     TestDriver driver;
-    EXPECT_CALL(driver, send_keyboard_mock(_));
     keyboard_init();
 
     test_logger.info() << "TestFixture setup-up end." << std::endl;
@@ -61,8 +60,6 @@ TestFixture::TestFixture() { m_this = this; }
 TestFixture::~TestFixture() {
     test_logger.info() << "TestFixture clean-up start." << std::endl;
     TestDriver driver;
-
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport())).Times(2);
 
     /* Reset keyboard state. */
     clear_all_keys();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

As the title suggest, with this change only keyboard reports that propagate changes to the host get send at all. This PR builds on to of #13789 so the change set is obviously a bit larger than necessary. Only ab2e2b2 and 5c9fb10 contain the necessary changes.
Note that the method used is a bit brute force as it doesn't fix the logic bugs under the hood.


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
