### PR TITLE
Restore layout count validation

### DIFF
--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -341,39 +341,6 @@ def _extract_rules_mk(info_data):
     return info_data
 
 
-def _merge_layouts(info_data, new_info_data):
-    """Merge new_info_data into info_data in an intelligent way.
-    """
-    for layout_name, layout_json in new_info_data['layouts'].items():
-        if layout_name in info_data['layouts']:
-            # Pull in layouts we have a macro for
-            if len(info_data['layouts'][layout_name]['layout']) != len(layout_json['layout']):
-                msg = '%s: %s: Number of elements in info.json does not match! info.json:%s != %s:%s'
-                _log_error(info_data, msg % (info_data['keyboard_folder'], layout_name, len(layout_json['layout']), layout_name, len(info_data['layouts'][layout_name]['layout'])))
-            else:
-                for i, key in enumerate(info_data['layouts'][layout_name]['layout']):
-                    key.update(layout_json['layout'][i])
-        else:
-            # Pull in layouts that have matrix data
-            missing_matrix = False
-            for key in layout_json.get('layout', {}):
-                if 'matrix' not in key:
-                    missing_matrix = True
-
-            if not missing_matrix:
-                if layout_name in info_data['layouts']:
-                    # Update an existing layout with new data
-                    for i, key in enumerate(info_data['layouts'][layout_name]['layout']):
-                        key.update(layout_json['layout'][i])
-
-                else:
-                    # Copy in the new layout wholesale
-                    layout_json['c_macro'] = False
-                    info_data['layouts'][layout_name] = layout_json
-
-    return info_data
-
-
 def _search_keyboard_h(path):
     current_path = Path('keyboards/')
     aliases = {}
@@ -511,8 +478,12 @@ def merge_info_jsons(keyboard, info_data):
                 layout_name = info_data['layout_aliases'][layout_name]
 
             if layout_name in info_data['layouts']:
-                for new_key, existing_key in zip(layout['layout'], info_data['layouts'][layout_name]['layout']):
-                    existing_key.update(new_key)
+                if len(info_data['layouts'][layout_name]['layout']) != len(layout['layout']):
+                    msg = '%s: %s: Number of elements in info.json does not match! info.json:%s != %s:%s'
+                    _log_error(info_data, msg % (info_data['keyboard_folder'], layout_name, len(layout['layout']), layout_name, len(info_data['layouts'][layout_name]['layout'])))
+                else:
+                    for new_key, existing_key in zip(layout['layout'], info_data['layouts'][layout_name]['layout']):
+                        existing_key.update(new_key)
             else:
                 layout['c_macro'] = False
                 info_data['layouts'][layout_name] = layout


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
The call to `_merge_layouts` was replaced at some point and is no longer called. The downside is this now allows bad `info.json` files to slip through.

![image](https://user-images.githubusercontent.com/16520359/129983680-788380b0-40cf-4d35-9e67-fd1887e1f318.png)
Note the extra random keys on the right.

This restores the previous behaviour producing the following error:
```console
 ☒ cest73/tkm: cest73/tkm: LAYOUT_all: Number of elements in info.json does not match! info.json:105 != LAYOUT_all:110
```

If the new rendering behaviour is desired, then it might be worth still printing out the error. (And maybe a follow up PR to make the rendering put the extra matrix positions not miles to the right).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* <https://discord.com/channels/440868230475677696/440875445911683084/877671832529027182>

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
