### PR TITLE
keebzdotnet F-Me Configurator fixes and codebase touch-up

### DIFF
--- a/keyboards/keebzdotnet/fme/fme.h
+++ b/keyboards/keebzdotnet/fme/fme.h
@@ -20,7 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define ___ KC_NO
 
-#define LAYOUT( \
+#define LAYOUT_all( \
     k00, k13, k14, k12, k10,      \
     k11, k04, k02, k03,           \
     k22, k32, k21, k01            \

--- a/keyboards/keebzdotnet/fme/info.json
+++ b/keyboards/keebzdotnet/fme/info.json
@@ -1,0 +1,31 @@
+{
+    "keyboard_name": "FMe",
+    "url": "",
+    "maintainer": "keebzdotnet",
+    "height": 4,
+    "width": 5,
+    "layout_aliases": {
+        "LAYOUT": "LAYOUT_all"
+    },
+    "layouts": {
+        "LAYOUT_all": {
+            "layout": [
+                {"label":"k00", "x":0, "y":0},
+                {"label":"k13", "x":1, "y":0},
+                {"label":"k14", "x":2, "y":0},
+                {"label":"k12", "x":3, "y":0},
+                {"label":"k10", "x":4, "y":0},
+
+                {"label":"k11", "x":0.25, "y":1},
+                {"label":"k04", "x":1.25, "y":1},
+                {"label":"k02", "x":2.25, "y":1},
+                {"label":"k03", "x":3.25, "y":1, "w":1.75},
+
+                {"label":"k22", "x":0.25, "y":2, "w":2.75},
+                {"label":"k32", "x":3, "y":3},
+                {"label":"k21", "x":3, "y":2, "w":2},
+                {"label":"k01", "x":4, "y":3}
+            ]
+        }
+    }
+}

--- a/keyboards/keebzdotnet/fme/keymaps/default/keymap.c
+++ b/keyboards/keebzdotnet/fme/keymaps/default/keymap.c
@@ -17,13 +17,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include QMK_KEYBOARD_H
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    [0] = LAYOUT(
+    [0] = LAYOUT_all(
         KC_F,   KC_U,   KC_C,   KC_K, KC_BSPC,
         KC_Y,   KC_O,   KC_U,   MO(1),
         KC_SPC, KC_SPC, KC_SPC, KC_SPC
     ),
 
-    [1] = LAYOUT(
+    [1] = LAYOUT_all(
       RESET,   KC_TRNS, KC_TRNS, KC_TRNS, KC_DEL,
       KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
       KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS

--- a/keyboards/keebzdotnet/fme/keymaps/via/config.h
+++ b/keyboards/keebzdotnet/fme/keymaps/via/config.h
@@ -1,0 +1,19 @@
+/* Copyright 2021 QMK / James Young (@noroadsleft)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define DYNAMIC_KEYMAP_LAYER_COUNT 2

--- a/keyboards/keebzdotnet/fme/keymaps/via/keymap.c
+++ b/keyboards/keebzdotnet/fme/keymaps/via/keymap.c
@@ -17,13 +17,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include QMK_KEYBOARD_H
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    [0] = LAYOUT(
+    [0] = LAYOUT_all(
         KC_F,   KC_U,   KC_C,   KC_K, KC_BSPC,
         KC_Y,   KC_O,   KC_U,   MO(1),
         KC_SPC, KC_SPC, KC_SPC, KC_SPC
     ),
 
-    [1] = LAYOUT(
+    [1] = LAYOUT_all(
       RESET,   KC_TRNS, KC_TRNS, KC_TRNS, KC_DEL,
       KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
       KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS


### PR DESCRIPTION
## Description

* renames `LAYOUT` to `LAYOUT_all`
* adds `info.json` file
* override layer count on `via` keymap

![image](https://user-images.githubusercontent.com/18669334/130111766-fefe66c3-a068-4cc6-b5c5-6b0a2f615dd9.png)

cc @keebzdotnet (keyboard maintainer)

## Types of Changes

- [x] Bugfix
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)


## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
