### PR TITLE
[Bug] Fix RGB/LED Matrix Suspend code

### DIFF
--- a/quantum/led_matrix/led_matrix.c
+++ b/quantum/led_matrix/led_matrix.c
@@ -459,8 +459,9 @@ void led_matrix_init(void) {
 
 void led_matrix_set_suspend_state(bool state) {
 #ifdef LED_DISABLE_WHEN_USB_SUSPENDED
-    if (state && is_keyboard_master()) {
-        led_matrix_set_value_all(0);  // turn off all LEDs when suspending
+    if (state && !suspend_state && is_keyboard_master()) {  // only run if turning off, and only once
+        led_task_effect(0);                                 // turn off all LEDs when suspending
+        led_task_flush(0);                                  // and actually flash led state to LEDs
     }
     suspend_state = state;
 #endif

--- a/quantum/rgb_matrix/rgb_matrix.c
+++ b/quantum/rgb_matrix/rgb_matrix.c
@@ -501,8 +501,9 @@ void rgb_matrix_init(void) {
 
 void rgb_matrix_set_suspend_state(bool state) {
 #ifdef RGB_DISABLE_WHEN_USB_SUSPENDED
-    if (state) {
-        rgb_matrix_set_color_all(0, 0, 0);  // turn off all LEDs when suspending
+    if (state && !suspend_state) {  // only run if turning off, and only once
+        rgb_task_render(0);         // turn off all LEDs when suspending
+        rgb_task_flush(0);          // and actually flash led state to LEDs
     }
     suspend_state = state;
 #endif


### PR DESCRIPTION
## Description

Since RGB Matrix's task was moved from `matrix_scan` to `keyboard_task`, the suspend functionally  was broken.  This is because the LED array is never flushed to the LEDs, since the keyboard task loops while suspended, and never hits the rgb matrix task. 

This fixes the suspend `set_suspend_state` function by forcing an update to the LEDs (using the "none" effect, which renders the LEDs off), and then forcibly flushes the data to the LEDs, so that they actually turn off. This happens as part of the suspend loop, and should only be called the first cycle.

## Types of Changes

- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* https://discord.com/channels/440868230475677696/867530715192885269/878113349957713960
  * Contains the actual issue and a bit more technical detail

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
