### PR TITLE
Durgod: Increase scan rate by using wait_us timer

### DIFF
--- a/keyboards/durgod/boards/DURGOD_STM32_F070/chconf.h
+++ b/keyboards/durgod/boards/DURGOD_STM32_F070/chconf.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#define CH_CFG_ST_FREQUENCY 10000
+#define CH_CFG_ST_FREQUENCY 1000
 
 #define CH_CFG_ST_TIMEDELTA 0
 

--- a/keyboards/durgod/boards/DURGOD_STM32_F070/mcuconf.h
+++ b/keyboards/durgod/boards/DURGOD_STM32_F070/mcuconf.h
@@ -85,7 +85,7 @@
  */
 #define STM32_GPT_USE_TIM1                  FALSE
 #define STM32_GPT_USE_TIM2                  FALSE
-#define STM32_GPT_USE_TIM3                  FALSE
+#define STM32_GPT_USE_TIM3                  TRUE
 #define STM32_GPT_USE_TIM14                 FALSE
 #define STM32_GPT_TIM1_IRQ_PRIORITY         2
 #define STM32_GPT_TIM2_IRQ_PRIORITY         2

--- a/keyboards/durgod/dgk6x/config.h
+++ b/keyboards/durgod/dgk6x/config.h
@@ -22,6 +22,9 @@
 #define VENDOR_ID       0xD60D
 #define MANUFACTURER    Hoksi Technology
 
+#define USB_POLLING_INTERVAL_MS 1
+#define WAIT_US_TIMER           GPTD3
+
 /* COL2ROW, ROW2COL*/
 #define DIODE_DIRECTION ROW2COL
 

--- a/keyboards/durgod/dgk6x/halconf.h
+++ b/keyboards/durgod/dgk6x/halconf.h
@@ -19,4 +19,7 @@
 #ifdef RGB_MATRIX_ENABLE
 #define HAL_USE_I2C TRUE
 #endif
+
+#define HAL_USE_GPT TRUE
+
 #include_next <halconf.h>

--- a/keyboards/durgod/k3x0/config.h
+++ b/keyboards/durgod/k3x0/config.h
@@ -23,6 +23,9 @@
 #define VENDOR_ID       0xD60D
 #define MANUFACTURER    Hoksi Technology
 
+#define USB_POLLING_INTERVAL_MS 1
+#define WAIT_US_TIMER           GPTD3
+
 /* key matrix size (rows in specific keyboard variant) */
 #define MATRIX_COLS 16
 

--- a/keyboards/durgod/k3x0/halconf.h
+++ b/keyboards/durgod/k3x0/halconf.h
@@ -19,4 +19,6 @@
 #define HAL_USE_PAL                 TRUE
 #define PAL_USE_CALLBACKS           TRUE
 
+#define HAL_USE_GPT                 TRUE
+
 #include_next <halconf.h>


### PR DESCRIPTION
## Description

Increase scan rate on Durgod keyboards by using the wait_us timer.

Lower the tick rate from 10kHz to 1kHz (otherwise all the extra interrupts reduce the achievable scan rate).
Enable the WAIT_US_TIMER using GPT timer 3.
Observed scan rate on the K320 is increased from 625Hz to 2090-2120Hz.

@J-Sully, @dkjer can you test this on the `dgk6x` keyboards? They use the same board definition so I had to enable it for those keyboards otherwise their scan rate would go down with the lower tick rate.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
