### PR TITLE
[Core] Add ENCODER_DETECT_OVER_SPEED into quantum/encoder.c

### DIFF
--- a/quantum/encoder.h
+++ b/quantum/encoder.h
@@ -29,3 +29,8 @@ bool encoder_update_user(uint8_t index, bool clockwise);
 void encoder_state_raw(uint8_t* slave_state);
 void encoder_update_raw(uint8_t* slave_state);
 #endif
+
+#ifdef ENCODER_DETECT_OVER_SPEED
+/* The number of times the rotation speed has exceeded the sampling speed. */
+int get_encoder_over_count(void);
+#endif


### PR DESCRIPTION
## Description

This is diagnostic feature for detect encoder sample overflow.

You can check if the encoder scan speed is fast enough by writing the following keymap level code.

```c
bool encoder_update_user(uint8_t index, bool clockwise) {
#ifdef ENCODER_DETECT_OVER_SPEED
    int enc_over = get_encoder_over_count();
    for (; enc_over > 0; enc_over--) {
        tap_code(KC_MINUS);
    }
#endif

    if (index == 0) { /* Left side encoder */
        if (clockwise) {
            tap_code(KC_A);
        } else {
            tap_code(KC_B);
        }
    } else if (index == 1) { /* Right side encoder */
        if (clockwise) {
            tap_code(KC_C);
        } else {
            tap_code(KC_D);
        }
    }
    return true;
}
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
