### PR TITLE
[Keyboard] Fix compile issues for Tractyl Manuform

### DIFF
--- a/keyboards/handwired/tractyl_manuform/4x6_right/config.h
+++ b/keyboards/handwired/tractyl_manuform/4x6_right/config.h
@@ -87,8 +87,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define NO_ACTION_MACRO
 #define NO_ACTION_FUNCTION
 
-#define SERIAL_USE_MULTI_TRANSACTION
-#define SPLIT_TRANSACTION_IDS_KB RPC_ID_STATE_SYNC, RPC_ID_SLAVE_STATE
-
 /* PMW3360 Settings */
 #define PMW3360_CS_PIN           B0

--- a/keyboards/handwired/tractyl_manuform/4x6_right/keymaps/drashna/keymap.c
+++ b/keyboards/handwired/tractyl_manuform/4x6_right/keymaps/drashna/keymap.c
@@ -122,7 +122,7 @@ static uint16_t mouse_debounce_timer  = 0;
 static uint8_t  mouse_keycode_tracker = 0;
 bool            tap_toggling          = false;
 
-void process_mouse_user(report_mouse_t* mouse_report, int16_t x, int16_t y) {
+void process_mouse_user(report_mouse_t* mouse_report, int8_t x, int8_t y) {
     if ((x || y) && timer_elapsed(mouse_timer) > 125) {
         mouse_timer = timer_read();
         if (!layer_state_is(_MOUSE) && !(layer_state_is(_GAMEPAD) || layer_state_is(_DIABLO)) && timer_elapsed(mouse_debounce_timer) > 125) {

--- a/keyboards/handwired/tractyl_manuform/5x6_right/config.h
+++ b/keyboards/handwired/tractyl_manuform/5x6_right/config.h
@@ -51,8 +51,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define NO_ACTION_MACRO
 #define NO_ACTION_FUNCTION
 
-#define SERIAL_USE_MULTI_TRANSACTION
-#define SPLIT_TRANSACTION_IDS_KB RPC_ID_KB_CONFIG_SYNC, RPC_ID_POINTER_STATE_SYNC
-
 /* PMW3360 Settings */
 #define PMW3360_CS_PIN           B0

--- a/keyboards/handwired/tractyl_manuform/config.h
+++ b/keyboards/handwired/tractyl_manuform/config.h
@@ -41,3 +41,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define NO_ACTION_ONESHOT
 #define NO_ACTION_MACRO
 #define NO_ACTION_FUNCTION
+
+#define SPLIT_TRANSACTION_IDS_KB RPC_ID_KB_CONFIG_SYNC, RPC_ID_POINTER_STATE_SYNC


### PR DESCRIPTION
## Description

Fix a couple of compile issues with keyboard. 
* wrong type in `process_record_mouse`
* Move config defines to root keyboard config

There is an issue with the pmw3360 code, but I figured that was better as a separate PR. 

## Types of Changes

- [x] Bugfix
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)

## Issues Fixed or Closed by This PR

* Tzarc CI

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
