### PR TITLE
[Core] Fix copypasta issue with pmw3360 sensor config

### DIFF
--- a/drivers/sensors/pmw3360.h
+++ b/drivers/sensors/pmw3360.h
@@ -40,7 +40,7 @@
 #    ifdef __AVR__
 #        define PMW3360_SPI_DIVISOR (F_CPU / PMW3360_CLOCK_SPEED)
 #    else
-#        define EXTERNAL_EEPROM_SPI_CLOCK_DIVISOR 64
+#        define PMW3360_SPI_DIVISOR 64
 #    endif
 #endif
 


### PR DESCRIPTION
## Description

Wrong define used for ARM config on pmw3360 sensor.  whoops. 

## Types of Changes

- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* Tzarc CI

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
