### PR TITLE
[Keyboard] Disable Console on Keebio Quefrency

### DIFF
--- a/keyboards/keebio/quefrency/keymaps/via/rules.mk
+++ b/keyboards/keebio/quefrency/keymaps/via/rules.mk
@@ -1,3 +1,2 @@
 VIA_ENABLE = yes
-CONSOLE_ENABLE = yes
 LTO_ENABLE = yes

--- a/keyboards/keebio/quefrency/rev2/config.h
+++ b/keyboards/keebio/quefrency/rev2/config.h
@@ -51,11 +51,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* serial.c configuration for split keyboard */
 #define SOFT_SERIAL_PIN D0
 
-/* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
-#define LOCKING_SUPPORT_ENABLE
-/* Locking resynchronize hack */
-#define LOCKING_RESYNC_ENABLE
-
 /* ws2812 RGB LED */
 #define RGB_DI_PIN E6
 #define RGBLIGHT_ANIMATIONS

--- a/keyboards/keebio/quefrency/rev3/config.h
+++ b/keyboards/keebio/quefrency/rev3/config.h
@@ -51,11 +51,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* serial.c configuration for split keyboard */
 #define SOFT_SERIAL_PIN D0
 
-/* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
-#define LOCKING_SUPPORT_ENABLE
-/* Locking resynchronize hack */
-#define LOCKING_RESYNC_ENABLE
-
 /* ws2812 RGB LED */
 #define RGB_DI_PIN E6
 #define RGBLIGHT_ANIMATIONS


### PR DESCRIPTION
## Description

Console was enabled by default on VIA keymap. Not needed here, so lets disabled.
Also remove lock key syncing support because ... it saves a bit more. 

## Types of Changes

- [x] Bugfix
- [x] Keyboard (addition or update)

## Issues Fixed or Closed by This PR

* Tzarc CI

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
