### PR TITLE
[Core] Add NanoBoot support

### DIFF
--- a/bootloader.mk
+++ b/bootloader.mk
@@ -107,6 +107,13 @@ lufa_warning: $(FIRMWARE_FORMAT)
 	$(info It is extremely prone to bricking, and is only included to support existing boards.)
 	$(info @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@)
 endif
+ifeq ($(strip $(BOOTLOADER)), nanoboot)
+    OPT_DEFS += -DBOOTLOADER_NANOBOOT
+    OPT_DEFS += -DBOOTLOADER_HID
+    ifneq (,$(filter $(MCU), atmega16u4 atmega32u4))
+        BOOTLOADER_SIZE = 512
+    endif
+endif
 ifdef BOOTLOADER_SIZE
     OPT_DEFS += -DBOOTLOADER_SIZE=$(strip $(BOOTLOADER_SIZE))
 endif

--- a/data/schemas/keyboard.jsonschema
+++ b/data/schemas/keyboard.jsonschema
@@ -56,7 +56,7 @@
         },
         "bootloader": {
             "type": "string",
-            "enum": ["atmel-dfu", "bootloadHID", "caterina", "halfkay", "kiibohd", "lufa-dfu", "lufa-ms", "micronucleus", "qmk-dfu", "qmk-hid", "stm32-dfu", "stm32duino", "unknown", "USBasp", "tinyuf2"],
+            "enum": ["atmel-dfu", "bootloadHID", "caterina", "halfkay", "kiibohd", "lufa-dfu", "lufa-ms", "micronucleus", "qmk-dfu", "qmk-hid", "stm32-dfu", "stm32duino", "unknown", "USBasp", "tinyuf2", "nanoboot"],
         },
         "bootloader_instructions": {
             "type": "string",

--- a/docs/flashing.md
+++ b/docs/flashing.md
@@ -217,6 +217,35 @@ Flashing sequence:
 
 * `:qmk-hid`: Checks every 5 seconds until a DFU device is available, and then flashes the firmware.
 
+### nanoBoot
+
+NanoBoot is a USB HID based bootloader for the ATmega##u4 family of devices, designed to fit in 256 words (512 bytes).  It's based on the LUFA/QMK HID Bootloader but is incredibly streamlined, and sized optimized. 
+
+To ensure compatibility with the NanoBoot bootloader, make sure this block is present in your `rules.mk`:
+
+```make
+# Bootloader selection
+BOOTLOADER = nanoboot
+```
+
+Compatible flashers:
+
+* TBD
+  * Currently, you need to either use the [Python script](https://github.com/qmk/lufa/tree/master/Bootloaders/HID/HostLoaderApp_python), or compile [`hid_bootloader_cli`](https://github.com/qmk/lufa/tree/master/Bootloaders/HID/HostLoaderApp), from the LUFA repo. Homebrew may (will) have support for this directly (via `brew install qmk/qmk/hid_bootloader_cli`).
+
+Flashing sequence:
+
+1. Enter the bootloader using any of the following methods:
+    * Press the `RESET` keycode
+    * Press the `RESET` button on the PCB if available
+    * short RST to GND quickly
+2. Wait for the OS to detect the device
+3. Flash a .hex file
+4. Reset the device into application mode (may be done automatically)
+
+### `make` Targets
+
+* `:nanoboot`: Checks every 5 seconds until a DFU device is available, and then flashes the firmware.
 ## STM32/APM32 DFU
 
 All STM32 and APM32 MCUs, except for F103 (see the [STM32duino section](#stm32duino)) come preloaded with a factory bootloader that cannot be modified nor deleted.

--- a/docs/hardware_avr.md
+++ b/docs/hardware_avr.md
@@ -177,6 +177,24 @@ BOOTLOADER = atmel-dfu
 BOOTLOADER = caterina
 ```
 
+#### QMK DFU Bootloader Example
+
+```make
+BOOTLOADER = qmk-dfu
+```
+
+#### QMK HID Bootloader Example
+
+```make
+BOOTLOADER = qmk-hid
+```
+
+#### nanoBoot Bootloader Example
+
+```make
+BOOTLOADER = nanoboot
+```
+
 ### Build Options
 
 There are a number of features that can be turned on or off in `rules.mk`. See the [Config Options](config_options.md#feature-options) page for a detailed list and description.

--- a/platforms/avr/flash.mk
+++ b/platforms/avr/flash.mk
@@ -159,6 +159,9 @@ endef
 hid_bootloader: $(BUILD_DIR)/$(TARGET).hex check-size cpfirmware
 	$(call EXEC_HID_LUFA)
 
+nanoboot: $(BUILD_DIR)/$(TARGET).hex check-size cpfirmware
+	$(call EXEC_HID_LUFA)
+
 flash:  $(BUILD_DIR)/$(TARGET).hex check-size cpfirmware
 ifneq ($(strip $(PROGRAM_CMD)),)
 	$(UNSYNC_OUTPUT_CMD) && $(PROGRAM_CMD)
@@ -173,6 +176,8 @@ else ifeq ($(strip $(BOOTLOADER)), USBasp)
 else ifeq ($(strip $(BOOTLOADER)), bootloadHID)
 	$(UNSYNC_OUTPUT_CMD) && $(call EXEC_BOOTLOADHID)
 else ifeq ($(strip $(BOOTLOADER)), qmk-hid)
+	$(UNSYNC_OUTPUT_CMD) && $(call EXEC_HID_LUFA)
+else ifeq ($(strip $(BOOTLOADER)), nanoboot)
 	$(UNSYNC_OUTPUT_CMD) && $(call EXEC_HID_LUFA)
 else
 	$(PRINT_OK); $(SILENT) || printf "$(MSG_FLASH_BOOTLOADER)"

--- a/tmk_core/common/avr/bootloader.c
+++ b/tmk_core/common/avr/bootloader.c
@@ -245,6 +245,44 @@ __attribute__((weak)) void bootloader_jump(void) {
 #    endif
                    [bootaddrme] "M"((((FLASH_SIZE - BOOTLOADER_SIZE) >> 1) >> 8) & 0xff), [bootaddrlo] "M"((((FLASH_SIZE - BOOTLOADER_SIZE) >> 1) >> 0) & 0xff));
 
+#elif defined(BOOTLOADER_NANOBOOT)
+    /* nanoBoot sets up 2 registers (r2,r3), copies then clears the MCUSR register,
+    disables the watchdog timer and then checks the EXTRF. It'll only continue in the
+    bootloader if the flag is set, otherwise it'll boot the application (jmp 0) when
+    using the reset vector (0x7E00). This code jumps past the reset vector straight into
+    the bootloader skipping the EXTRF check, so prior setup is required. */
+    cli();
+    UDCON  = 1;
+    USBCON = (1 << FRZCLK);  // disable USB
+    UCSR1B = 0;
+    _delay_ms(1000);  // delay seemed to help but issue not limited to hid_listen
+    EIMSK  = 0;
+    PCICR  = 0;
+    SPCR   = 0;
+    ACSR   = 0;
+    EECR   = 0;
+    ADCSRA = 0;
+    TIMSK0 = 0;
+    TIMSK1 = 0;
+    TIMSK3 = 0;
+    TIMSK4 = 0;
+    UCSR1B = 0;
+    TWCR   = 0;
+    DDRB   = 0;
+    DDRC   = 0;
+    DDRD   = 0;
+    DDRE   = 0;
+    DDRF   = 0;
+    TWCR   = 0;
+    PORTB  = 0;
+    PORTC  = 0;
+    PORTD  = 0;
+    PORTE  = 0;
+    PORTF  = 0;
+    asm volatile("clr r2");      // clear register (rZERO in bootloader)
+    asm volatile("clr r3");      // clear register (rONE in bootloader)
+    asm volatile("inc r3");      // increment register
+    asm volatile("jmp 0x7e6a");  // jump to bootloader skipping some setup and extrf check.
 #else  // Assume remaining boards are DFU, even if the flag isn't set
 
 #    if !(defined(__AVR_ATmega32A__) || defined(__AVR_ATmega328P__) || defined(__AVR_ATmega328__) || defined(__AVR_ATtiny85__))  // no USB - maybe BOOTLOADER_BOOTLOADHID instead though?


### PR DESCRIPTION

## Description

Adds support for flashing via the nanoBoot bootloader. 

## Types of Changes

- [x] Core
- [x] New feature
- [x] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
