### PR TITLE
Fix Mouse Shared EP functionality

### DIFF
--- a/common_features.mk
+++ b/common_features.mk
@@ -117,13 +117,13 @@ endif
 
 ifeq ($(strip $(MOUSEKEY_ENABLE)), yes)
     OPT_DEFS += -DMOUSEKEY_ENABLE
-    OPT_DEFS += -DMOUSE_ENABLE
+    MOUSE_ENABLE := yes
     SRC += $(QUANTUM_DIR)/mousekey.c
 endif
 
 ifeq ($(strip $(POINTING_DEVICE_ENABLE)), yes)
     OPT_DEFS += -DPOINTING_DEVICE_ENABLE
-    OPT_DEFS += -DMOUSE_ENABLE
+    MOUSE_ENABLE := yes
     SRC += $(QUANTUM_DIR)/pointing_device.c
 endif
 

--- a/tmk_core/common.mk
+++ b/tmk_core/common.mk
@@ -25,7 +25,8 @@ ifeq ($(strip $(KEYBOARD_SHARED_EP)), yes)
     MOUSE_SHARED_EP = yes
 endif
 
-ifeq ($(strip $(MOUSEKEY_ENABLE)), yes)
+ifeq ($(strip $(MOUSE_ENABLE)), yes)
+    OPT_DEFS += -DMOUSE_ENABLE
     ifeq ($(strip $(MOUSE_SHARED_EP)), yes)
         TMK_COMMON_DEFS += -DMOUSE_SHARED_EP
         SHARED_EP_ENABLE = yes


### PR DESCRIPTION
Specifically, if you enable the shared endpoint for mouse reports (or keyboard, which force enables it for mouse), and you don't have mousekeys enabled, it does not properly enable shared mouse EP for pointing device (which uses mouse reports).   This cause it to error out in compiling.  This fixes up some of the logic to ensure that all use cases are supported, and consolidates some of the code.

Honestly, I'm surprised that I didn't run into this before.  But ... wasn't running a blackpill before, so wasn't as much of a concern. 

## Types of Changes

- [x] Core
- [x] Bugfix
- [x] Enhancement/optimization

## Issues Fixed or Closed by This PR

* Compilation error when MOUSE_SHARED_EP or KEYBOARD_SHARED_EP are enabled, and POINTING_DEVICE_ENABLE is set, but mousekeys are not turned on. 

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
