### PR TITLE
[Keyboard] Fix default keymap for quark squared keyboard

### DIFF
--- a/keyboards/checkerboards/quark_squared/keymaps/default/keymap.c
+++ b/keyboards/checkerboards/quark_squared/keymaps/default/keymap.c
@@ -33,7 +33,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
      * | PRINT   |  OS   |  Alt  |  Layer  |    Space & Layer     |   [     |   ]    |    CAPS   |
      * `-----------------------------------------------------------------------------------------'
      */
-    [0] = LAYOUT_ortho_2x225u2u(
+    [0] = LAYOUT_ortho_2x225u(
       KC_TAB,        KC_Q,    KC_W,    KC_F,     KC_P,    KC_G,    KC_J,    KC_L,    KC_U,    KC_Y,    KC_SCLN, KC_BSPC,
       CTL_T(KC_ESC), KC_A,    KC_R,    KC_S,     KC_T,    KC_D,    KC_H,    KC_N,    KC_E,    KC_I,    KC_O,    KC_QUOT,
       KC_LSFT,       KC_Z,    KC_X,    KC_C,     KC_V,    KC_B,    KC_K,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_ENT,


### PR DESCRIPTION

## Description

First layer was named wrong.

## Types of Changes

- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)


## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
