### PR TITLE
simple define to disable auto shift at startupAUTO_SHIFT_DISABLED_AT_STARTUP

### DIFF
--- a/quantum/process_keycode/process_auto_shift.c
+++ b/quantum/process_keycode/process_auto_shift.c
@@ -21,6 +21,12 @@
 
 #    include "process_auto_shift.h"
 
+#ifndef AUTO_SHIFT_DISABLED_AT_STARTUP
+#   define AUTO_SHIFT_STARTUP_STATE true    /* enabled */
+#else
+#   define AUTO_SHIFT_STARTUP_STATE false   /* disabled */
+#endif
+
 static uint16_t autoshift_time    = 0;
 static uint16_t autoshift_timeout = AUTO_SHIFT_TIMEOUT;
 static uint16_t autoshift_lastkey = KC_NO;
@@ -34,7 +40,7 @@ static struct {
     bool in_progress : 1;
     // Whether the auto-shifted keypress has been registered.
     bool holding_shift : 1;
-} autoshift_flags = {true, false, false, false};
+} autoshift_flags = {AUTO_SHIFT_STARTUP_STATE, false, false, false};
 
 /** \brief Record the press of an autoshiftable key
  *


### PR DESCRIPTION
simple define to disable auto shift at startup AUTO_SHIFT_DISABLED_AT_STARTUP

## Description

Simple define to change the auto shift initial state.
The current auto shift initial state is always on, with this #define we will be able to
make it disabled at startup.

#define AUTO_SHIFT_DISABLED_AT_STARTUP

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [X] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
