### PR TITLE
Move feature suspend logic out of platform specific code

### DIFF
--- a/tmk_core/common/avr/suspend.c
+++ b/tmk_core/common/avr/suspend.c
@@ -16,25 +16,6 @@
 #    include "vusb.h"
 #endif
 
-#ifdef BACKLIGHT_ENABLE
-#    include "backlight.h"
-#endif
-
-#ifdef AUDIO_ENABLE
-#    include "audio.h"
-#endif /* AUDIO_ENABLE */
-
-#if defined(RGBLIGHT_SLEEP) && defined(RGBLIGHT_ENABLE)
-#    include "rgblight.h"
-#endif
-
-#ifdef LED_MATRIX_ENABLE
-#    include "led_matrix.h"
-#endif
-#ifdef RGB_MATRIX_ENABLE
-#    include "rgb_matrix.h"
-#endif
-
 /** \brief Suspend idle
  *
  * FIXME: needs doc
@@ -49,17 +30,6 @@ void suspend_idle(uint8_t time) {
 }
 
 // TODO: This needs some cleanup
-
-/** \brief Run keyboard level Power down
- *
- * FIXME: needs doc
- */
-__attribute__((weak)) void suspend_power_down_user(void) {}
-/** \brief Run keyboard level Power down
- *
- * FIXME: needs doc
- */
-__attribute__((weak)) void suspend_power_down_kb(void) { suspend_power_down_user(); }
 
 #if !defined(NO_SUSPEND_POWER_DOWN) && defined(WDT_vect)
 
@@ -135,41 +105,9 @@ void suspend_power_down(void) {
     if (!vusb_suspended) return;
 #endif
 
-    suspend_power_down_kb();
+    suspend_power_down_quantum();
 
 #ifndef NO_SUSPEND_POWER_DOWN
-    // Turn off backlight
-#    ifdef BACKLIGHT_ENABLE
-    backlight_set(0);
-#    endif
-
-    // Turn off LED indicators
-    uint8_t leds_off = 0;
-#    if defined(BACKLIGHT_CAPS_LOCK) && defined(BACKLIGHT_ENABLE)
-    if (is_backlight_enabled()) {
-        // Don't try to turn off Caps Lock indicator as it is backlight and backlight is already off
-        leds_off |= (1 << USB_LED_CAPS_LOCK);
-    }
-#    endif
-    led_set(leds_off);
-
-    // Turn off audio
-#    ifdef AUDIO_ENABLE
-    stop_all_notes();
-#    endif
-
-    // Turn off underglow
-#    if defined(RGBLIGHT_SLEEP) && defined(RGBLIGHT_ENABLE)
-    rgblight_suspend();
-#    endif
-
-#    if defined(LED_MATRIX_ENABLE)
-    led_matrix_set_suspend_state(true);
-#    endif
-#    if defined(RGB_MATRIX_ENABLE)
-    rgb_matrix_set_suspend_state(true);
-#    endif
-
     // Enter sleep state if possible (ie, the MCU has a watchdog timeout interrupt)
 #    if defined(WDT_vect)
     power_down(WDTO_15MS);
@@ -189,18 +127,6 @@ bool                       suspend_wakeup_condition(void) {
     return false;
 }
 
-/** \brief run user level code immediately after wakeup
- *
- * FIXME: needs doc
- */
-__attribute__((weak)) void suspend_wakeup_init_user(void) {}
-
-/** \brief run keyboard level code immediately after wakeup
- *
- * FIXME: needs doc
- */
-__attribute__((weak)) void suspend_wakeup_init_kb(void) { suspend_wakeup_init_user(); }
-
 /** \brief run immediately after wakeup
  *
  * FIXME: needs doc
@@ -209,27 +135,7 @@ void suspend_wakeup_init(void) {
     // clear keyboard state
     clear_keyboard();
 
-    // Turn on backlight
-#ifdef BACKLIGHT_ENABLE
-    backlight_init();
-#endif
-
-    // Restore LED indicators
-    led_set(host_keyboard_leds());
-
-    // Wake up underglow
-#if defined(RGBLIGHT_SLEEP) && defined(RGBLIGHT_ENABLE)
-    rgblight_wakeup();
-#endif
-
-#if defined(LED_MATRIX_ENABLE)
-    led_matrix_set_suspend_state(false);
-#endif
-#if defined(RGB_MATRIX_ENABLE)
-    rgb_matrix_set_suspend_state(false);
-#endif
-
-    suspend_wakeup_init_kb();
+    suspend_wakeup_init_quantum();
 }
 
 #if !defined(NO_SUSPEND_POWER_DOWN) && defined(WDT_vect)

--- a/tmk_core/common/chibios/suspend.c
+++ b/tmk_core/common/chibios/suspend.c
@@ -12,25 +12,6 @@
 #include "led.h"
 #include "wait.h"
 
-#ifdef AUDIO_ENABLE
-#    include "audio.h"
-#endif /* AUDIO_ENABLE */
-
-#ifdef BACKLIGHT_ENABLE
-#    include "backlight.h"
-#endif
-
-#if defined(RGBLIGHT_SLEEP) && defined(RGBLIGHT_ENABLE)
-#    include "rgblight.h"
-#endif
-
-#ifdef LED_MATRIX_ENABLE
-#    include "led_matrix.h"
-#endif
-#ifdef RGB_MATRIX_ENABLE
-#    include "rgb_matrix.h"
-#endif
-
 /** \brief suspend idle
  *
  * FIXME: needs doc
@@ -40,61 +21,12 @@ void suspend_idle(uint8_t time) {
     wait_ms(time);
 }
 
-/** \brief Run keyboard level Power down
- *
- * FIXME: needs doc
- */
-__attribute__((weak)) void suspend_power_down_user(void) {}
-/** \brief Run keyboard level Power down
- *
- * FIXME: needs doc
- */
-__attribute__((weak)) void suspend_power_down_kb(void) { suspend_power_down_user(); }
-
 /** \brief suspend power down
  *
  * FIXME: needs doc
  */
 void suspend_power_down(void) {
-#ifdef BACKLIGHT_ENABLE
-    backlight_set(0);
-#endif
-
-#ifdef LED_MATRIX_ENABLE
-    led_matrix_task();
-#endif
-#ifdef RGB_MATRIX_ENABLE
-    rgb_matrix_task();
-#endif
-
-    // Turn off LED indicators
-    uint8_t leds_off = 0;
-#if defined(BACKLIGHT_CAPS_LOCK) && defined(BACKLIGHT_ENABLE)
-    if (is_backlight_enabled()) {
-        // Don't try to turn off Caps Lock indicator as it is backlight and backlight is already off
-        leds_off |= (1 << USB_LED_CAPS_LOCK);
-    }
-#endif
-    led_set(leds_off);
-
-    // TODO: figure out what to power down and how
-    // shouldn't power down TPM/FTM if we want a breathing LED
-    // also shouldn't power down USB
-#if defined(RGBLIGHT_SLEEP) && defined(RGBLIGHT_ENABLE)
-    rgblight_suspend();
-#endif
-
-#if defined(LED_MATRIX_ENABLE)
-    led_matrix_set_suspend_state(true);
-#endif
-#if defined(RGB_MATRIX_ENABLE)
-    rgb_matrix_set_suspend_state(true);
-#endif
-#ifdef AUDIO_ENABLE
-    stop_all_notes();
-#endif /* AUDIO_ENABLE */
-
-    suspend_power_down_kb();
+    suspend_power_down_quantum();
     // on AVR, this enables the watchdog for 15ms (max), and goes to
     // SLEEP_MODE_PWR_DOWN
 
@@ -151,19 +83,6 @@ void suspend_wakeup_init(void) {
     host_system_send(0);
     host_consumer_send(0);
 #endif /* EXTRAKEY_ENABLE */
-#ifdef BACKLIGHT_ENABLE
-    backlight_init();
-#endif /* BACKLIGHT_ENABLE */
-    led_set(host_keyboard_leds());
-#if defined(RGBLIGHT_SLEEP) && defined(RGBLIGHT_ENABLE)
-    rgblight_wakeup();
-#endif
 
-#if defined(LED_MATRIX_ENABLE)
-    led_matrix_set_suspend_state(false);
-#endif
-#if defined(RGB_MATRIX_ENABLE)
-    rgb_matrix_set_suspend_state(false);
-#endif
-    suspend_wakeup_init_kb();
+    suspend_wakeup_init_quantum();
 }

--- a/tmk_core/common/suspend.h
+++ b/tmk_core/common/suspend.h
@@ -10,8 +10,10 @@ void suspend_wakeup_init(void);
 
 void suspend_wakeup_init_user(void);
 void suspend_wakeup_init_kb(void);
+void suspend_wakeup_init_quantum(void);
 void suspend_power_down_user(void);
 void suspend_power_down_kb(void);
+void suspend_power_down_quantum(void);
 
 #ifndef USB_SUSPEND_WAKEUP_DELAY
 #    define USB_SUSPEND_WAKEUP_DELAY 0


### PR DESCRIPTION
## Description

While looking to add OLED suspend support, noticed that a LOT of feature suspend code is duplicated in `tmk_core/common/(platform)/suspend.c`.  

Moves out that code into quantum.c to be a common location for easier management.

And added oled/st7565 suspend support, too. 

I'm not sure I like dumping it in quantum.c, but ...

## Types of Changes

- [x] Core
- [x] Enhancement/optimization


## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
