### PR TITLE
[Keyboard] fix compile error `make helix/rev2/sc:all`

### DIFF
--- a/keyboards/helix/rev2/local_features.mk
+++ b/keyboards/helix/rev2/local_features.mk
@@ -164,14 +164,25 @@ ifeq ($(strip $(OLED_ENABLE)), yes)
            OPT_DEFS += -DOLED_FONT_H=\"common/glcdfont.c\"
         endif
     else
-        OLED_ENABLE = no # disable OLED in TOP/common_features.mk
-        OLED_LOCAL_ENABLE = yes
-        SRC += local_drivers/i2c.c
-        SRC += local_drivers/ssd1306.c
-        KEYBOARD_PATHS += $(HELIX_TOP_DIR)/local_drivers
-        OPT_DEFS += -DOLED_LOCAL_ENABLE
-        ifeq ($(strip $(LOCAL_GLCDFONT)), yes)
-            OPT_DEFS += -DLOCAL_GLCDFONT
+        ifeq ($(strip $(SPLIT_KEYBOARD)), yes)
+            $(info Helix/rev2: The following combinations are not supported.)
+            $(info - SPLIT_KEYBOARD = $(SPLIT_KEYBOARD)) # yes
+            $(info - OLED_ENABLE    = $(OLED_ENABLE))    # yes
+            $(info - OLED_SELECT    = $(OLED_SELECT))    # local
+            $(info Force : OLED_ENABLE = no)
+            $(info .)
+            OLED_ENABLE = no
+        endif
+        ifeq ($(strip $(OLED_ENABLE)), yes)
+            OLED_ENABLE = no # disable OLED in TOP/common_features.mk
+            OLED_LOCAL_ENABLE = yes
+            SRC += local_drivers/i2c.c
+            SRC += local_drivers/ssd1306.c
+            KEYBOARD_PATHS += $(HELIX_TOP_DIR)/local_drivers
+            OPT_DEFS += -DOLED_LOCAL_ENABLE
+            ifeq ($(strip $(LOCAL_GLCDFONT)), yes)
+                OPT_DEFS += -DLOCAL_GLCDFONT
+            endif
         endif
     endif
 endif


### PR DESCRIPTION
## Description

Some keymaps on the Helix keyboard have not yet been migrated to the standard OLED driver. Therefore, running `make helix/rev2/sc:all` will result in a compilation error on some keymaps.

The following changes are tentatively made to avoid compilation errors.

```diff
diff --git a/keyboards/helix/rev2/local_features.mk b/keyboards/helix/rev2/local_features.mk
index 47e8c6a83e..8c3ac9c3c1 100644
--- a/keyboards/helix/rev2/local_features.mk
+++ b/keyboards/helix/rev2/local_features.mk
@@ -164,6 +164,16 @@ ifeq ($(strip $(OLED_ENABLE)), yes)
            OPT_DEFS += -DOLED_FONT_H=\"common/glcdfont.c\"
         endif
     else
+        ifeq ($(strip $(SPLIT_KEYBOARD)), yes)
+            $(info Helix/rev2: The following combinations are not supported.)
+            $(info - SPLIT_KEYBOARD = $(SPLIT_KEYBOARD)) # yes
+            $(info - OLED_ENABLE    = $(OLED_ENABLE))    # yes
+            $(info - OLED_SELECT    = $(OLED_SELECT))    # local
+            $(info Force : OLED_ENABLE = no)
+            $(info .)
+            OLED_ENABLE = no
+        endif
+        ifeq ($(strip $(OLED_ENABLE)), yes)
             OLED_ENABLE = no # disable OLED in TOP/common_features.mk
             OLED_LOCAL_ENABLE = yes
             SRC += local_drivers/i2c.c
@@ -174,6 +184,7 @@ ifeq ($(strip $(OLED_ENABLE)), yes)
                 OPT_DEFS += -DLOCAL_GLCDFONT
             endif
         endif
+    endif
 endif
 
 ifneq ($(strip $(SHOW_HELIX_OPTIONS)),)
```

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
