### PR TITLE
[Keyboard] Helix use `post_rules.mk`

### DIFF
--- a/keyboards/helix/pico/keymaps/biacco/rules.mk
+++ b/keyboards/helix/pico/keymaps/biacco/rules.mk
@@ -18,7 +18,3 @@ LTO_ENABLE = no  # if firmware size over limit, try this option
 # LED_UNDERGLOW_ENABLE = no   # LED underglow (Enable WS2812 RGB underlight.)
 LED_ANIMATIONS = no           # LED animations
 # IOS_DEVICE_ENABLE = no      # connect to IOS device (iPad,iPhone)
-
-# convert Helix-specific options (that represent combinations of standard options)
-#   into QMK standard options.
-include $(strip $(KEYBOARD_LOCAL_FEATURES_MK))

--- a/keyboards/helix/pico/keymaps/default/rules.mk
+++ b/keyboards/helix/pico/keymaps/default/rules.mk
@@ -18,7 +18,3 @@ LTO_ENABLE = no  # if firmware size over limit, try this option
 # LED_UNDERGLOW_ENABLE = no   # LED underglow (Enable WS2812 RGB underlight.)
 # LED_ANIMATIONS = yes        # LED animations
 # IOS_DEVICE_ENABLE = no      # connect to IOS device (iPad,iPhone)
-
-# convert Helix-specific options (that represent combinations of standard options)
-#   into QMK standard options.
-include $(strip $(KEYBOARD_LOCAL_FEATURES_MK))

--- a/keyboards/helix/pico/keymaps/mtei/rules.mk
+++ b/keyboards/helix/pico/keymaps/mtei/rules.mk
@@ -18,7 +18,3 @@ LTO_ENABLE = no  # if firmware size over limit, try this option
 # LED_UNDERGLOW_ENABLE = no   # LED underglow (Enable WS2812 RGB underlight.)
 # LED_ANIMATIONS = yes        # LED animations
 # IOS_DEVICE_ENABLE = no      # connect to IOS device (iPad,iPhone)
-
-# convert Helix-specific options (that represent combinations of standard options)
-#   into QMK standard options.
-include $(strip $(KEYBOARD_LOCAL_FEATURES_MK))

--- a/keyboards/helix/pico/post_rules.mk
+++ b/keyboards/helix/pico/post_rules.mk
@@ -1,11 +1,9 @@
 #
-#  local_features.mk contains post-processing rules for the Helix keyboard.
+#  post_rules.mk contains post-processing rules for the Helix keyboard.
 #
 #   Post-processing rules convert keyboard-specific shortcuts (that represent
 #   combinations of standard options) into QMK standard options.
 #
-
-KEYBOARD_LOCAL_FEATURES_MK :=
 
 define HELIX_CUSTOMISE_MSG
   $(info Helix Spacific Build Options)

--- a/keyboards/helix/pico/rules.mk
+++ b/keyboards/helix/pico/rules.mk
@@ -1,5 +1,3 @@
-KEYBOARD_LOCAL_FEATURES_MK := $(dir $(lastword $(MAKEFILE_LIST)))local_features.mk
-
 # Helix Spacific Build Options default values
 OLED_ENABLE = no            # OLED_ENABLE
 LOCAL_GLCDFONT = no         # use each keymaps "helixfont.h" insted of "common/glcdfont.c"

--- a/keyboards/helix/rev2/keymaps/default/rules.mk
+++ b/keyboards/helix/rev2/keymaps/default/rules.mk
@@ -29,7 +29,3 @@ OLED_SELECT = core
 ifeq ($(strip $(OLED_ENABLE)), yes)
     SRC += oled_display.c
 endif
-
-# convert Helix-specific options (that represent combinations of standard options)
-#   into QMK standard options.
-include $(strip $(KEYBOARD_LOCAL_FEATURES_MK))

--- a/keyboards/helix/rev2/keymaps/five_rows/rules.mk
+++ b/keyboards/helix/rev2/keymaps/five_rows/rules.mk
@@ -95,7 +95,3 @@ endif
 ifeq ($(strip $(OLED_ENABLE)), yes)
     SRC += oled_display.c
 endif
-
-# convert Helix-specific options (that represent combinations of standard options)
-#   into QMK standard options.
-include $(strip $(KEYBOARD_LOCAL_FEATURES_MK))

--- a/keyboards/helix/rev2/keymaps/five_rows_jis/rules.mk
+++ b/keyboards/helix/rev2/keymaps/five_rows_jis/rules.mk
@@ -17,7 +17,3 @@ HELIX_ROWS = 5              # Helix Rows is 4 or 5
 # LED_UNDERGLOW_ENABLE = no   # LED underglow (Enable WS2812 RGB underlight.)
 # LED_ANIMATIONS = yes        # LED animations
 # IOS_DEVICE_ENABLE = no      # connect to IOS device (iPad,iPhone)
-
-# convert Helix-specific options (that represent combinations of standard options)
-#   into QMK standard options.
-include $(strip $(KEYBOARD_LOCAL_FEATURES_MK))

--- a/keyboards/helix/rev2/keymaps/fraanrosi/rules.mk
+++ b/keyboards/helix/rev2/keymaps/fraanrosi/rules.mk
@@ -22,7 +22,3 @@ LED_ANIMATIONS = yes        # LED animations
 
 LED_BACK_ENABLE = no
 LED_UNDERGLOW_ENABLE = yes
-
-# convert Helix-specific options (that represent combinations of standard options)
-#   into QMK standard options.
-include $(strip $(KEYBOARD_LOCAL_FEATURES_MK))

--- a/keyboards/helix/rev2/keymaps/froggy/rules.mk
+++ b/keyboards/helix/rev2/keymaps/froggy/rules.mk
@@ -17,7 +17,3 @@ LED_BACK_ENABLE = yes       # LED backlight (Enable WS2812 RGB underlight.)
 LED_UNDERGLOW_ENABLE = no   # LED underglow (Enable WS2812 RGB underlight.)
 LED_ANIMATIONS = yes        # LED animations
 # IOS_DEVICE_ENABLE = no      # connect to IOS device (iPad,iPhone)
-
-# convert Helix-specific options (that represent combinations of standard options)
-#   into QMK standard options.
-include $(strip $(KEYBOARD_LOCAL_FEATURES_MK))

--- a/keyboards/helix/rev2/keymaps/froggy_106/rules.mk
+++ b/keyboards/helix/rev2/keymaps/froggy_106/rules.mk
@@ -17,7 +17,3 @@ LED_BACK_ENABLE = yes       # LED backlight (Enable WS2812 RGB underlight.)
 LED_UNDERGLOW_ENABLE = no   # LED underglow (Enable WS2812 RGB underlight.)
 LED_ANIMATIONS = yes        # LED animations
 # IOS_DEVICE_ENABLE = no      # connect to IOS device (iPad,iPhone)
-
-# convert Helix-specific options (that represent combinations of standard options)
-#   into QMK standard options.
-include $(strip $(KEYBOARD_LOCAL_FEATURES_MK))

--- a/keyboards/helix/rev2/keymaps/led_test/rules.mk
+++ b/keyboards/helix/rev2/keymaps/led_test/rules.mk
@@ -23,7 +23,3 @@ ifeq ($(strip $(OLED_ENABLE)), yes)
     SRC += oled_display.c
 endif
 SRC += led_test_init.c
-
-# convert Helix-specific options (that represent combinations of standard options)
-#   into QMK standard options.
-include $(strip $(KEYBOARD_LOCAL_FEATURES_MK))

--- a/keyboards/helix/rev2/keymaps/yshrsmz/rules.mk
+++ b/keyboards/helix/rev2/keymaps/yshrsmz/rules.mk
@@ -17,7 +17,3 @@ OLED_ENABLE = yes            # OLED_ENABLE
 # LED_UNDERGLOW_ENABLE = no   # LED underglow (Enable WS2812 RGB underlight.)
 LED_ANIMATIONS = no        # LED animations
 # IOS_DEVICE_ENABLE = no      # connect to IOS device (iPad,iPhone)
-
-# convert Helix-specific options (that represent combinations of standard options)
-#   into QMK standard options.
-include $(strip $(KEYBOARD_LOCAL_FEATURES_MK))

--- a/keyboards/helix/rev2/post_rules.mk
+++ b/keyboards/helix/rev2/post_rules.mk
@@ -1,0 +1,3 @@
+ifneq ($(strip $(KEYBOARD_LOCAL_FEATURES_MK)),)
+  include $(strip $(KEYBOARD_LOCAL_FEATURES_MK))
+endif


### PR DESCRIPTION
## Description

Helix/pico and Helix/rev2 change to use `post_rules.mk`.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
