### PR TITLE
Ensure that the directory for sys.executable is in the user's path

### DIFF
--- a/lib/python/qmk/cli/__init__.py
+++ b/lib/python/qmk/cli/__init__.py
@@ -181,8 +181,14 @@ if int(milc_version[0]) < 2 and int(milc_version[1]) < 4:
     print(f'Your MILC library is too old! Please upgrade: python3 -m pip install -U -r {str(requirements)}')
     exit(127)
 
+# Make sure we can run binaries in the same directory as our Python interpreter
+python_dir = os.path.dirname(sys.executable)
+
+if python_dir not in os.environ['PATH'].split(':'):
+    os.environ['PATH'] = ":".join((python_dir, os.environ['PATH']))
+
 # Check to make sure we have all our dependencies
-msg_install = 'Please run `python3 -m pip install -r %s` to install required python dependencies.'
+msg_install = f'Please run `{sys.executable} -m pip install -r %s` to install required python dependencies.'
 args = sys.argv[1:]
 while args and args[0][0] == '-':
     del args[0]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

When the user is using `qmk` inside a virtualenv that has not been activated the directory that `sys.executable` is in (which usually contains other tools we need like `flake8` and `nose2`) may not be in the user's search path. This happens with our Debian/Ubuntu/Fedora packages, for example.

This PR ensures that the user's path will include the directory containing `sys.executable`.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
