### PR TITLE
[Keyboard] Symmetric70_proto use `post_rules.mk`

### DIFF
--- a/keyboards/handwired/symmetric70_proto/post_rules.mk
+++ b/keyboards/handwired/symmetric70_proto/post_rules.mk
@@ -1,0 +1,2 @@
+KEYBOARD_LOCAL_FEATURES_MK := $(dir $(lastword $(MAKEFILE_LIST)))local_features.mk
+include $(strip $(KEYBOARD_LOCAL_FEATURES_MK))

--- a/keyboards/handwired/symmetric70_proto/promicro/fast/rules.mk
+++ b/keyboards/handwired/symmetric70_proto/promicro/fast/rules.mk
@@ -1,6 +1,3 @@
 CUSTOM_MATRIX = yes
 SRC += matrix_common.c
 SRC += matrix_fast/matrix.c
-
-KEYBOARD_LOCAL_FEATURES_MK := $(dir $(lastword $(MAKEFILE_LIST)))../../local_features.mk
-include $(KEYBOARD_LOCAL_FEATURES_MK)

--- a/keyboards/handwired/symmetric70_proto/promicro/normal/rules.mk
+++ b/keyboards/handwired/symmetric70_proto/promicro/normal/rules.mk
@@ -1,6 +1,3 @@
 CUSTOM_MATRIX = yes
 SRC += matrix_common.c
 SRC += matrix_debug/matrix.c
-
-KEYBOARD_LOCAL_FEATURES_MK := $(dir $(lastword $(MAKEFILE_LIST)))../../local_features.mk
-include $(KEYBOARD_LOCAL_FEATURES_MK)

--- a/keyboards/handwired/symmetric70_proto/proton_c/fast/rules.mk
+++ b/keyboards/handwired/symmetric70_proto/proton_c/fast/rules.mk
@@ -1,6 +1,3 @@
 CUSTOM_MATRIX = yes
 SRC += matrix_common.c
 SRC += matrix_fast/matrix.c
-
-KEYBOARD_LOCAL_FEATURES_MK := $(dir $(lastword $(MAKEFILE_LIST)))../../local_features.mk
-include $(KEYBOARD_LOCAL_FEATURES_MK)

--- a/keyboards/handwired/symmetric70_proto/proton_c/normal/rules.mk
+++ b/keyboards/handwired/symmetric70_proto/proton_c/normal/rules.mk
@@ -1,6 +1,3 @@
 CUSTOM_MATRIX = yes
 SRC += matrix_common.c
 SRC += matrix_debug/matrix.c
-
-KEYBOARD_LOCAL_FEATURES_MK := $(dir $(lastword $(MAKEFILE_LIST)))../../local_features.mk
-include $(KEYBOARD_LOCAL_FEATURES_MK)


### PR DESCRIPTION
## Description

handwired/symmetric70_proto change to use post_rules.mk.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
