### PR TITLE
Add gaming toggle layer & layer colors to r-pufky keymap.

### DIFF
--- a/keyboards/massdrop/ctrl/keymaps/r-pufky/config.h
+++ b/keyboards/massdrop/ctrl/keymaps/r-pufky/config.h
@@ -24,3 +24,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGB_MATRIX_STARTUP_MODE RGB_MATRIX_SOLID_COLOR
 #define RGB_MATRIX_STARTUP_VAL 100
 #define HSV_BACKLIGHT_COLOR HSV_BLUE
+#define HSV_GAME_COLOR      170, 255, 192 // darker blue
+#define HSV_CONTROL_COLOR   0,   255, 192 // darker red

--- a/keyboards/massdrop/ctrl/keymaps/r-pufky/keymap.c
+++ b/keyboards/massdrop/ctrl/keymaps/r-pufky/keymap.c
@@ -16,6 +16,9 @@
 
 #include QMK_KEYBOARD_H
 
+#define BASE 0
+#define GAME 1
+#define CTRL 2
 #define MODS_SHIFT  (get_mods() & MOD_MASK_SHIFT)
 #define MODS_CTRL   (get_mods() & MOD_MASK_CTRL)
 #define MODS_ALT    (get_mods() & MOD_MASK_ALT)
@@ -43,33 +46,59 @@ enum ctrl_keycodes {
 };
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    [0] = LAYOUT(
-        KC_ESC,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,             KC_PSCR, KC_SLCK, KC_PAUS,
-        KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC,   KC_INS,  KC_HOME, KC_PGUP,
-        KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS,   KC_DEL,  KC_END,  KC_PGDN,
-        KC_LCTL, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_ENT,
-        KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT,                              KC_UP,
-        KC_NLCK, KC_LGUI, KC_LALT,                   KC_SPC,                             KC_RALT, MO(1),   KC_F24,  KC_RCTL,            KC_LEFT, KC_DOWN, KC_RGHT
+    [BASE] = LAYOUT(
+        KC_ESC,  KC_F1,    KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,   KC_F11,   KC_F12,            KC_PSCR, KC_SLCK, KC_PAUS,
+        KC_GRV,  KC_1,     KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,     KC_MINS,  KC_EQL,   KC_BSPC, KC_INS,  KC_HOME, KC_PGUP,
+        KC_TAB,  KC_Q,     KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,     KC_LBRC,  KC_RBRC,  KC_BSLS, KC_DEL,  KC_END,  KC_PGDN,
+        KC_LCTL, KC_A,     KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN,  KC_QUOT,  KC_ENT,
+        KC_LSFT, KC_Z,     KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH,  KC_RSFT,                              KC_UP,
+        KC_NLCK, KC_LGUI,  KC_LALT,                   KC_SPC,                             KC_RALT, MO(CTRL), KC_F24,   KC_RCTL,           KC_LEFT, KC_DOWN, KC_RGHT
     ),
-    [1] = LAYOUT(
-        KC_EJCT, KC_F13,  KC_F14,  KC_F15,  KC_F16,  KC_F17,  KC_F18,  KC_F19,  KC_F20,  KC_F21,  KC_F22,  KC_F23,  KC_F24,             KC_MUTE, _______, _______,
-        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,   KC_MPLY, KC_MSTP, KC_VOLU,
-        _______, RGB_SPD, RGB_VAI, RGB_SPI, RGB_HUI, RGB_SAI, _______, _______, _______, _______, _______, _______, _______, _______,   KC_MPRV, KC_MNXT, KC_VOLD,
-        KC_CAPS, RGB_RMOD,RGB_VAD, RGB_MOD, RGB_HUD, RGB_SAD, _______, _______, _______, _______, _______, _______, _______,
-        _______, RGB_TOG, _______, _______, _______, MD_BOOT, NK_TOGG, _______, _______, _______, _______, _______,                              KC_BRIU,
-        _______, _______, _______,                   _______,                            _______, _______, _______, _______,            KC_MRWD, KC_BRID, KC_MFFD
+    [GAME] = LAYOUT(
+        KC_ESC,  KC_F1,    KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,   KC_F11,   KC_F12,            KC_PSCR, KC_SLCK, KC_PAUS,
+        KC_GRV,  KC_1,     KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,     KC_MINS,  KC_EQL,   KC_BSPC, KC_INS,  KC_HOME, KC_PGUP,
+        KC_TAB,  KC_Q,     KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,     KC_LBRC,  KC_RBRC,  KC_BSLS, KC_DEL,  KC_END,  KC_PGDN,
+        KC_LCTL, KC_A,     KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN,  KC_QUOT,  KC_ENT,
+        KC_LSFT, KC_Z,     KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH,  KC_RSFT,                              KC_UP,
+        KC_HOME, KC_END,   KC_LALT,                   KC_SPC,                             KC_RALT, MO(CTRL), KC_F24,   KC_RCTL,           KC_LEFT, KC_DOWN, KC_RGHT
+    ),
+    [CTRL] = LAYOUT(
+        KC_EJCT, KC_F13,   KC_F14,  KC_F15,  KC_F16,  KC_F17,  KC_F18,  KC_F19,  KC_F20,  KC_F21,  KC_F22,   KC_F23,   KC_F24,            KC_MUTE, _______, _______,
+        _______, _______,  _______, _______, _______, _______, _______, _______, _______, _______, _______,  _______,  _______,  _______, KC_MPLY, KC_MSTP, KC_VOLU,
+        _______, RGB_SPD,  RGB_VAI, RGB_SPI, RGB_HUI, RGB_SAI, _______, _______, _______, _______, _______,  TO(BASE), TO(GAME), _______, KC_MPRV, KC_MNXT, KC_VOLD,
+        KC_CAPS, RGB_RMOD, RGB_VAD, RGB_MOD, RGB_HUD, RGB_SAD, _______, _______, _______, _______, _______,  _______,  _______,
+        _______, RGB_TOG,  _______, _______, _______, MD_BOOT, NK_TOGG, _______, _______, _______, _______,  _______,                              KC_BRIU,
+        _______, _______,  _______,                   _______,                            _______, _______,  _______,  _______,           KC_MRWD, KC_BRID, KC_MFFD
     ),
 };
 
 // Init keyboard static color with underglow off.
 void matrix_init_user(void) {
-  rgblight_sethsv(HSV_BACKLIGHT_COLOR);
-  rgb_matrix_set_flags(LED_FLAG_KEYLIGHT | LED_FLAG_MODIFIER | LED_FLAG_INDICATOR);
+    rgblight_sethsv(HSV_BACKLIGHT_COLOR);
+    rgb_matrix_set_flags(LED_FLAG_KEYLIGHT | LED_FLAG_MODIFIER | LED_FLAG_INDICATOR);
 };
 
 // Runs constantly in the background, in a loop.
 void matrix_scan_user(void) {
 };
+
+// Set backlight color based on active layer
+layer_state_t layer_state_set_user(layer_state_t state) {
+    switch (get_highest_layer(state)) {
+        case GAME: {
+           rgblight_sethsv_noeeprom(HSV_GAME_COLOR);
+           break;
+        }
+        case CTRL: {
+            rgblight_sethsv_noeeprom(HSV_CONTROL_COLOR);
+            break;
+        }
+        default:
+            rgblight_sethsv_noeeprom(HSV_BACKLIGHT_COLOR);
+            break;
+    }
+    return state;
+}
 
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     static uint32_t key_timer;
@@ -116,28 +145,28 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             return false;
         case RGB_TOG:
             if (record->event.pressed) {
-              switch (rgb_matrix_get_flags()) {
-                case LED_FLAG_ALL: {
-                    rgb_matrix_set_flags(LED_FLAG_KEYLIGHT | LED_FLAG_MODIFIER | LED_FLAG_INDICATOR);
-                    rgb_matrix_set_color_all(RGB_OFF);
-                  }
-                  break;
-                case (LED_FLAG_KEYLIGHT | LED_FLAG_MODIFIER | LED_FLAG_INDICATOR): {
-                    rgb_matrix_set_flags(LED_FLAG_UNDERGLOW);
-                    rgb_matrix_set_color_all(RGB_OFF);
-                  }
-                  break;
-                case LED_FLAG_UNDERGLOW: {
-                    rgb_matrix_set_flags(LED_FLAG_NONE);
-                    rgb_matrix_disable_noeeprom();
-                  }
-                  break;
-                default: {
-                    rgb_matrix_set_flags(LED_FLAG_ALL);
-                    rgb_matrix_enable_noeeprom();
-                  }
-                  break;
-              }
+                switch (rgb_matrix_get_flags()) {
+                    case LED_FLAG_ALL: {
+                        rgb_matrix_set_flags(LED_FLAG_KEYLIGHT | LED_FLAG_MODIFIER | LED_FLAG_INDICATOR);
+                        rgb_matrix_set_color_all(RGB_OFF);
+                    }
+                    break;
+                    case (LED_FLAG_KEYLIGHT | LED_FLAG_MODIFIER | LED_FLAG_INDICATOR): {
+                        rgb_matrix_set_flags(LED_FLAG_UNDERGLOW);
+                        rgb_matrix_set_color_all(RGB_OFF);
+                    }
+                    break;
+                    case LED_FLAG_UNDERGLOW: {
+                        rgb_matrix_set_flags(LED_FLAG_NONE);
+                        rgb_matrix_disable_noeeprom();
+                    }
+                    break;
+                    default: {
+                        rgb_matrix_set_flags(LED_FLAG_ALL);
+                        rgb_matrix_enable_noeeprom();
+                    }
+                    break;
+                }
             }
             return false;
         default:

--- a/keyboards/massdrop/ctrl/keymaps/r-pufky/readme.md
+++ b/keyboards/massdrop/ctrl/keymaps/r-pufky/readme.md
@@ -1,6 +1,7 @@
 # Massdrop Ctrl r-pufky
 
-Gaming QOL improvments; enabling useful keys for left hand & in-game overlay usage.
+Gaming QOL improvments; enabling useful keys for left hand & in-game overlay
+usage.
 
 ## Layers
 
@@ -8,21 +9,36 @@ Gaming QOL improvments; enabling useful keys for left hand & in-game overlay usa
 
 ![Typing Layer](https://i.imgur.com/qEBaupV.png)
 
-Layer optimized to enable useful keys for gaming without changing typing state, as well as specific
-in-game overlay keys.
+Layer optimized to enable useful keys for typing and casual gaming without
+changing typing state, as well as specific in-game overlay keys.
 
 * Left Ctrl: Easier control key usage without always setting capslock.
-* Num Lock: Unique non visible character key for additional left-hand input options in game.
-* Fn: Enable layer 1, temporal.
-* F24: Unique non-visible F24 key; no windows function. Map to in-game overlays.
- 
-### Function Layer
+* Num Lock: Unique non visible character key for additional left-hand input
+    options in game.
+* Fn: Enable Control layer, temporal.
+* F24: Non-visible F24 key; no windows function. Map to in-game overlays.
 
-![Function Layer](https://i.imgur.com/2qGNwVQ.png)
+### Gaming Layer
+
+![Gaming Layer](https://i.imgur.com/q4wGbFQ.png)
+
+Replaces super key with additional non-printing inputs.
+
+* Home: Non visible character key for additional input options in game.
+* End: Non visible character key for additional input options in game.
+* Left Ctrl: Easier control key usage without always setting capslock.
+* Fn: Enable Control layer, temporal.
+* F24: Non-visible F24 key; no windows function. Map to in-game overlays.
+ 
+### Control Layer
+
+![Function Layer](https://i.imgur.com/7Nalcyp.png)
 
 * Purple: Media keys. Note CD Eject on Escape, and OSX Prev/Next on Arrows.
-* Blue: Keyboard adminstration. Toggle NKRO (N Key Rollover) and enable bootloader.
+* Blue: Keyboard adminstration. Toggle NKRO (N Key Rollover) and enable
+    bootloader.
 * Orange: RGB Controls.
+* Green: Toggle gaming layer.
 * Capslock: Now requires the use of the function key.
 * F13-F24: Extended function keys.
 * Bright+/-: Monitor Brightness.


### PR DESCRIPTION
Update massdrop/ctrl:r-pufky with gaming layer, LED color change based on state.

## Description

* Added gaming layer
* Added `layer_state_set_user` to set backlight color based on current state
* Defined custom red, blue colors in `config.h`
* Update documentation with new image links and button mapping
* Corrected whitespace issues

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [X] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* None.

## Checklist

- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
