### PR TITLE
Enable de-ghosting for RGB matrix on the IS31L3733

### DIFF
--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -21,6 +21,8 @@ You can use between 1 and 4 IS31FL3731 IC's. Do not specify `DRIVER_ADDR_<N>` de
 |----------|-------------|---------|
 | `ISSI_TIMEOUT` | (Optional) How long to wait for i2c messages, in milliseconds | 100 |
 | `ISSI_PERSISTENCE` | (Optional) Retry failed messages this many times | 0 |
+| `ISSI_SWPULLUP` | (Optional) Set the value of the SWx lines built-in de-ghosting resistors | PUR_0R (Disabled) |
+| `ISSI_CSPULLUP` | (Optional) Set the value of the CSx lines built-in de-ghosting resistors | PUR_0R (Disabled) |
 | `DRIVER_COUNT` | (Required) How many RGB driver IC's are present | |
 | `DRIVER_LED_TOTAL` | (Required) How many RGB lights are present across all drivers | |
 | `DRIVER_ADDR_1` | (Required) Address for the first RGB driver | |

--- a/drivers/led/issi/is31fl3733.c
+++ b/drivers/led/issi/is31fl3733.c
@@ -56,6 +56,14 @@
 #    define ISSI_PERSISTENCE 0
 #endif
 
+#ifndef ISSI_SWPULLUP
+#	define ISSI_SWPULLUP PUR_0R
+#endif
+
+#ifndef ISSI_CSPULLUP
+#	define ISSI_CSPULLUP PUR_0R
+#endif
+
 // Transfer buffer for TWITransmitData()
 uint8_t g_twi_transfer_buffer[20];
 
@@ -154,6 +162,10 @@ void IS31FL3733_init(uint8_t addr, uint8_t sync) {
 
     // Select PG3
     IS31FL3733_write_register(addr, ISSI_COMMANDREGISTER, ISSI_PAGE_FUNCTION);
+    // Set de-ghost pull-up resistors (SWx)
+    IS31FL3733_write_register(addr, ISSI_REG_SWPULLUP, ISSI_SWPULLUP);
+    // Set de-ghost pull-down resistors (CSx)
+	IS31FL3733_write_register(addr, ISSI_REG_CSPULLUP, ISSI_CSPULLUP);
     // Set global current to maximum.
     IS31FL3733_write_register(addr, ISSI_REG_GLOBALCURRENT, 0xFF);
     // Disable software shutdown.

--- a/drivers/led/issi/is31fl3733.c
+++ b/drivers/led/issi/is31fl3733.c
@@ -1,6 +1,7 @@
 /* Copyright 2017 Jason Williams
  * Copyright 2018 Jack Humbert
  * Copyright 2018 Yiancar
+ * Copyright 2021 Doni Crosby
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/drivers/led/issi/is31fl3733.c
+++ b/drivers/led/issi/is31fl3733.c
@@ -58,11 +58,11 @@
 #endif
 
 #ifndef ISSI_SWPULLUP
-#	define ISSI_SWPULLUP PUR_0R
+#    define ISSI_SWPULLUP PUR_0R
 #endif
 
 #ifndef ISSI_CSPULLUP
-#	define ISSI_CSPULLUP PUR_0R
+#    define ISSI_CSPULLUP PUR_0R
 #endif
 
 // Transfer buffer for TWITransmitData()
@@ -166,7 +166,7 @@ void IS31FL3733_init(uint8_t addr, uint8_t sync) {
     // Set de-ghost pull-up resistors (SWx)
     IS31FL3733_write_register(addr, ISSI_REG_SWPULLUP, ISSI_SWPULLUP);
     // Set de-ghost pull-down resistors (CSx)
-	IS31FL3733_write_register(addr, ISSI_REG_CSPULLUP, ISSI_CSPULLUP);
+    IS31FL3733_write_register(addr, ISSI_REG_CSPULLUP, ISSI_CSPULLUP);
     // Set global current to maximum.
     IS31FL3733_write_register(addr, ISSI_REG_GLOBALCURRENT, 0xFF);
     // Disable software shutdown.

--- a/drivers/led/issi/is31fl3733.h
+++ b/drivers/led/issi/is31fl3733.h
@@ -1,6 +1,7 @@
 /* Copyright 2017 Jason Williams
  * Copyright 2018 Jack Humbert
  * Copyright 2018 Yiancar
+ * Copyright 2021 Doni Crosby
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/drivers/led/issi/is31fl3733.h
+++ b/drivers/led/issi/is31fl3733.h
@@ -48,7 +48,6 @@ void IS31FL3733_update_pwm_buffers(uint8_t addr, uint8_t index);
 void IS31FL3733_update_led_control_registers(uint8_t addr, uint8_t index);
 
 #define PUR_0R 0x00 // No PUR resistor
-#define PUR_05KR 0x01 // 0.5k Ohm resistor in t_NOL
 #define PUR_05KR 0x02 // 0.5k Ohm resistor in t_NOL
 #define PUR_3KR 0x03 // 3.0k Ohm resistor on all the time
 #define PUR_4KR 0x04 // 4.0k Ohm resistor on all the time

--- a/drivers/led/issi/is31fl3733.h
+++ b/drivers/led/issi/is31fl3733.h
@@ -47,6 +47,15 @@ void IS31FL3733_set_led_control_register(uint8_t index, bool red, bool green, bo
 void IS31FL3733_update_pwm_buffers(uint8_t addr, uint8_t index);
 void IS31FL3733_update_led_control_registers(uint8_t addr, uint8_t index);
 
+#define PUR_0R 0x00 // No PUR resistor
+#define PUR_05KR 0x01 // 0.5k Ohm resistor in t_NOL
+#define PUR_05KR 0x02 // 0.5k Ohm resistor in t_NOL
+#define PUR_3KR 0x03 // 3.0k Ohm resistor on all the time
+#define PUR_4KR 0x04 // 4.0k Ohm resistor on all the time
+#define PUR_8KR 0x05 // 8.0k Ohm resistor on all the time
+#define PUR_16KR 0x06 // 16k Ohm resistor on all the time
+#define PUR_32KR 0x07 // 32k Ohm resistor in t_NOL
+
 #define A_1 0x00
 #define A_2 0x01
 #define A_3 0x02

--- a/drivers/led/issi/is31fl3733.h
+++ b/drivers/led/issi/is31fl3733.h
@@ -48,13 +48,13 @@ void IS31FL3733_set_led_control_register(uint8_t index, bool red, bool green, bo
 void IS31FL3733_update_pwm_buffers(uint8_t addr, uint8_t index);
 void IS31FL3733_update_led_control_registers(uint8_t addr, uint8_t index);
 
-#define PUR_0R 0x00 // No PUR resistor
-#define PUR_05KR 0x02 // 0.5k Ohm resistor in t_NOL
-#define PUR_3KR 0x03 // 3.0k Ohm resistor on all the time
-#define PUR_4KR 0x04 // 4.0k Ohm resistor on all the time
-#define PUR_8KR 0x05 // 8.0k Ohm resistor on all the time
-#define PUR_16KR 0x06 // 16k Ohm resistor on all the time
-#define PUR_32KR 0x07 // 32k Ohm resistor in t_NOL
+#define PUR_0R 0x00    // No PUR resistor
+#define PUR_05KR 0x02  // 0.5k Ohm resistor in t_NOL
+#define PUR_3KR 0x03   // 3.0k Ohm resistor on all the time
+#define PUR_4KR 0x04   // 4.0k Ohm resistor on all the time
+#define PUR_8KR 0x05   // 8.0k Ohm resistor on all the time
+#define PUR_16KR 0x06  // 16k Ohm resistor on all the time
+#define PUR_32KR 0x07  // 32k Ohm resistor in t_NOL
 
 #define A_1 0x00
 #define A_2 0x01


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Currently RGB matrixes for the IS31L3733 have ghosting issues with the LEDs. Any LEDs used as indicators or just plain off in the matrix glow faintly which isn't ideal. I have added a option to be set in a keyboards `config.h` that allows for makers and users to enable the on-chip resistors for all of the drivers on the board so that this ghosting is eliminated. 

I have set the default value to allow for ghosting (0 ohm resistor) so as to stay backwards compatible and not cause power issues with older boards. 

The datasheet recommends enabling the 32k ohm resistor as it is only on during the blanking time so there shouldn't be any dimming with the LEDs when they are on. If you want me to set that as the default (would make sense that you _wouldn't_ want ghosting on the matrix) I can do that as well.
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
