### PR TITLE
Backport F_CPU/F_USB hack from system76

### DIFF
--- a/tmk_core/protocol/lufa/lufa.c
+++ b/tmk_core/protocol/lufa/lufa.c
@@ -1015,8 +1015,13 @@ static void setup_mcu(void) {
     MCUSR &= ~_BV(WDRF);
     wdt_disable();
 
-    /* Disable clock division */
+// HACK for boards running at 3.3V and crystal at 16 MHz like the system76
+#if (F_CPU == 8000000 && F_USB == 16000000)
+    /* Divide clock by 2 */
+    clock_prescale_set(clock_div_2);
+#else /* Disable clock division */
     clock_prescale_set(clock_div_1);
+#endif
 }
 
 /** \brief Setup USB

--- a/tmk_core/protocol/lufa/lufa.c
+++ b/tmk_core/protocol/lufa/lufa.c
@@ -1015,7 +1015,7 @@ static void setup_mcu(void) {
     MCUSR &= ~_BV(WDRF);
     wdt_disable();
 
-// HACK for boards running at 3.3V and crystal at 16 MHz like the system76
+// For boards running at 3.3V and crystal at 16 MHz
 #if (F_CPU == 8000000 && F_USB == 16000000)
     /* Divide clock by 2 */
     clock_prescale_set(clock_div_2);


### PR DESCRIPTION
## Description

Adds support for boards running at 3.3V and crystal at 16 MHz (like the system76), or a [modded teensy](https://www.pjrc.com/teensy/3volt.html). 

There are a few boards that are doing this in the repo, doing this manually. 

## Types of Changes

- [x] Core
- [x] Enhancement/optimization

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
