### PR TITLE
i2c_master: Add support for reading/writing to 16-bit registers

### DIFF
--- a/docs/i2c_driver.md
+++ b/docs/i2c_driver.md
@@ -190,7 +190,7 @@ Receive multiple bytes from the selected SPI device.
 
 ### `i2c_status_t i2c_writeReg(uint8_t devaddr, uint8_t regaddr, uint8_t* data, uint16_t length, uint16_t timeout)`
 
-Writes to a register on the I2C device.
+Writes to an 8-bit register on the I2C device.
 
 #### Arguments
 
@@ -211,15 +211,59 @@ Writes to a register on the I2C device.
 
 ---
 
+### `i2c_status_t i2c_writeReg16(uint8_t devaddr, uint16_t regaddr, uint8_t* data, uint16_t length, uint16_t timeout)`
+
+Writes to a 16-bit register on the I2C device.
+
+#### Arguments
+
+ - `uint8_t devaddr`  
+   The 7-bit I2C address of the device.
+ - `uint16_t regaddr`  
+   The register address to write to.
+ - `uint8_t *data`  
+   A pointer to the data to transmit.
+ - `uint16_t length`  
+ The number of bytes to write. Take care not to overrun the length of `data`.
+ - `uint16_t timeout`  
+   The time in milliseconds to wait for a response from the target device.
+
+#### Return Value
+
+`I2C_STATUS_TIMEOUT` if the timeout period elapses, `I2C_STATUS_ERROR` if some other error occurs, otherwise `I2C_STATUS_SUCCESS`.
+
+---
+
 ### `i2c_status_t i2c_readReg(uint8_t devaddr, uint8_t regaddr, uint8_t* data, uint16_t length, uint16_t timeout)`
 
-Reads from a register on the I2C device.
+Reads from an 8-bit register on the I2C device.
 
 #### Arguments
 
  - `uint8_t devaddr`  
    The 7-bit I2C address of the device.
  - `uint8_t regaddr`  
+   The register address to read from.
+ - `uint16_t length`  
+ The number of bytes to read. Take care not to overrun the length of `data`.
+ - `uint16_t timeout`  
+   The time in milliseconds to wait for a response from the target device.
+
+#### Return Value
+
+`I2C_STATUS_TIMEOUT` if the timeout period elapses, `I2C_STATUS_ERROR` if some other error occurs, otherwise `I2C_STATUS_SUCCESS`.
+
+---
+
+### `i2c_status_t i2c_readReg16(uint8_t devaddr, uint16_t regaddr, uint8_t* data, uint16_t length, uint16_t timeout)`
+
+Reads from a 16-bit register on the I2C device.
+
+#### Arguments
+
+ - `uint8_t devaddr`  
+   The 7-bit I2C address of the device.
+ - `uint16_t regaddr`  
    The register address to read from.
  - `uint16_t length`  
  The number of bytes to read. Take care not to overrun the length of `data`.

--- a/platforms/avr/drivers/i2c_master.c
+++ b/platforms/avr/drivers/i2c_master.c
@@ -202,6 +202,22 @@ i2c_status_t i2c_writeReg(uint8_t devaddr, uint8_t regaddr, const uint8_t* data,
     return status;
 }
 
+i2c_status_t i2c_writeReg16(uint8_t devaddr, uint16_t regaddr, const uint8_t* data, uint16_t length, uint16_t timeout) {
+    i2c_status_t status = i2c_start(devaddr | 0x00, timeout);
+    if (status >= 0) {
+        i2c_write(regaddr >> 8, timeout);
+        status = i2c_write(regaddr & 0xFF, timeout);
+
+        for (uint16_t i = 0; i < length && status >= 0; i++) {
+            status = i2c_write(data[i], timeout);
+        }
+    }
+
+    i2c_stop();
+
+    return status;
+}
+
 i2c_status_t i2c_readReg(uint8_t devaddr, uint8_t regaddr, uint8_t* data, uint16_t length, uint16_t timeout) {
     i2c_status_t status = i2c_start(devaddr, timeout);
     if (status < 0) {
@@ -209,6 +225,43 @@ i2c_status_t i2c_readReg(uint8_t devaddr, uint8_t regaddr, uint8_t* data, uint16
     }
 
     status = i2c_write(regaddr, timeout);
+    if (status < 0) {
+        goto error;
+    }
+
+    status = i2c_start(devaddr | 0x01, timeout);
+
+    for (uint16_t i = 0; i < (length - 1) && status >= 0; i++) {
+        status = i2c_read_ack(timeout);
+        if (status >= 0) {
+            data[i] = status;
+        }
+    }
+
+    if (status >= 0) {
+        status = i2c_read_nack(timeout);
+        if (status >= 0) {
+            data[(length - 1)] = status;
+        }
+    }
+
+error:
+    i2c_stop();
+
+    return (status < 0) ? status : I2C_STATUS_SUCCESS;
+}
+
+i2c_status_t i2c_readReg16(uint8_t devaddr, uint16_t regaddr, uint8_t* data, uint16_t length, uint16_t timeout) {
+    i2c_status_t status = i2c_start(devaddr, timeout);
+    if (status < 0) {
+        goto error;
+    }
+
+    status = i2c_write(regaddr >> 8, timeout);
+    if (status < 0) {
+        goto error;
+    }
+    status = i2c_write(regaddr & 0xFF, timeout);
     if (status < 0) {
         goto error;
     }

--- a/platforms/avr/drivers/i2c_master.h
+++ b/platforms/avr/drivers/i2c_master.h
@@ -39,5 +39,7 @@ int16_t      i2c_read_nack(uint16_t timeout);
 i2c_status_t i2c_transmit(uint8_t address, const uint8_t* data, uint16_t length, uint16_t timeout);
 i2c_status_t i2c_receive(uint8_t address, uint8_t* data, uint16_t length, uint16_t timeout);
 i2c_status_t i2c_writeReg(uint8_t devaddr, uint8_t regaddr, const uint8_t* data, uint16_t length, uint16_t timeout);
+i2c_status_t i2c_writeReg16(uint8_t devaddr, uint16_t regaddr, const uint8_t* data, uint16_t length, uint16_t timeout);
 i2c_status_t i2c_readReg(uint8_t devaddr, uint8_t regaddr, uint8_t* data, uint16_t length, uint16_t timeout);
+i2c_status_t i2c_readReg16(uint8_t devaddr, uint16_t regaddr, uint8_t* data, uint16_t length, uint16_t timeout);
 void         i2c_stop(void);

--- a/platforms/chibios/drivers/i2c_master.c
+++ b/platforms/chibios/drivers/i2c_master.c
@@ -111,10 +111,32 @@ i2c_status_t i2c_writeReg(uint8_t devaddr, uint8_t regaddr, const uint8_t* data,
     return chibios_to_qmk(&status);
 }
 
+i2c_status_t i2c_writeReg16(uint8_t devaddr, uint16_t regaddr, const uint8_t* data, uint16_t length, uint16_t timeout) {
+    i2c_address = devaddr;
+    i2cStart(&I2C_DRIVER, &i2cconfig);
+
+    uint8_t complete_packet[length + 2];
+    for (uint8_t i = 0; i < length; i++) {
+        complete_packet[i + 2] = data[i];
+    }
+    complete_packet[0] = regaddr >> 8;
+    complete_packet[1] = regaddr & 0xFF;
+
+    msg_t status = i2cMasterTransmitTimeout(&I2C_DRIVER, (i2c_address >> 1), complete_packet, length + 2, 0, 0, TIME_MS2I(timeout));
+    return chibios_to_qmk(&status);
+}
+
 i2c_status_t i2c_readReg(uint8_t devaddr, uint8_t regaddr, uint8_t* data, uint16_t length, uint16_t timeout) {
     i2c_address = devaddr;
     i2cStart(&I2C_DRIVER, &i2cconfig);
     msg_t status = i2cMasterTransmitTimeout(&I2C_DRIVER, (i2c_address >> 1), &regaddr, 1, data, length, TIME_MS2I(timeout));
+    return chibios_to_qmk(&status);
+}
+
+i2c_status_t i2c_readReg16(uint8_t devaddr, uint16_t regaddr, uint8_t* data, uint16_t length, uint16_t timeout) {
+    i2c_address = devaddr;
+    i2cStart(&I2C_DRIVER, &i2cconfig);
+    msg_t status = i2cMasterTransmitTimeout(&I2C_DRIVER, (i2c_address >> 1), &regaddr, 2, data, length, TIME_MS2I(timeout));
     return chibios_to_qmk(&status);
 }
 

--- a/platforms/chibios/drivers/i2c_master.h
+++ b/platforms/chibios/drivers/i2c_master.h
@@ -109,5 +109,7 @@ i2c_status_t i2c_start(uint8_t address);
 i2c_status_t i2c_transmit(uint8_t address, const uint8_t* data, uint16_t length, uint16_t timeout);
 i2c_status_t i2c_receive(uint8_t address, uint8_t* data, uint16_t length, uint16_t timeout);
 i2c_status_t i2c_writeReg(uint8_t devaddr, uint8_t regaddr, const uint8_t* data, uint16_t length, uint16_t timeout);
+i2c_status_t i2c_writeReg16(uint8_t devaddr, uint16_t regaddr, const uint8_t* data, uint16_t length, uint16_t timeout);
 i2c_status_t i2c_readReg(uint8_t devaddr, uint8_t regaddr, uint8_t* data, uint16_t length, uint16_t timeout);
+i2c_status_t i2c_readReg16(uint8_t devaddr, uint16_t regaddr, uint8_t* data, uint16_t length, uint16_t timeout);
 void         i2c_stop(void);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I2C itself has no concept of registers, but for devices that do specify the first two bytes of a given transaction as the "register address", this should provide an easier to use interface than splitting the address up manually into the `regaddr` parameter and the first actual data byte.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
