### PR TITLE
Bugfix for Joystick and JSON schema

### DIFF
--- a/common_features.mk
+++ b/common_features.mk
@@ -698,19 +698,23 @@ ifeq ($(strip $(AUTO_SHIFT_ENABLE)), yes)
 endif
 
 JOYSTICK_ENABLE ?= no
-ifneq ($(strip $(JOYSTICK_ENABLE)), no)
+VALID_JOYSTICK_TYPES := analog digital
+JOYSTICK_DRIVER ?= analog
+ifeq ($(strip $(JOYSTICK_ENABLE)), yes)
+    ifeq ($(filter $(JOYSTICK_DRIVER),$(VALID_JOYSTICK_TYPES)),)
+        $(error "$(JOYSTICK_DRIVER)" is not a valid joystick driver)
+    endif
     OPT_DEFS += -DJOYSTICK_ENABLE
     SRC += $(QUANTUM_DIR)/process_keycode/process_joystick.c
     SRC += $(QUANTUM_DIR)/joystick.c
-endif
 
-ifeq ($(strip $(JOYSTICK_ENABLE)), analog)
-    OPT_DEFS += -DANALOG_JOYSTICK_ENABLE
-    SRC += analog.c
-endif
-
-ifeq ($(strip $(JOYSTICK_ENABLE)), digital)
-    OPT_DEFS += -DDIGITAL_JOYSTICK_ENABLE
+    ifeq ($(strip $(JOYSTICK_DRIVER)), analog)
+        OPT_DEFS += -DANALOG_JOYSTICK_ENABLE
+        SRC += analog.c
+    endif
+    ifeq ($(strip $(JOYSTICK_DRIVER)), digital)
+        OPT_DEFS += -DDIGITAL_JOYSTICK_ENABLE
+    endif
 endif
 
 DIGITIZER_ENABLE ?= no

--- a/docs/feature_joystick.md
+++ b/docs/feature_joystick.md
@@ -2,8 +2,6 @@
 
 The keyboard can be made to be recognized as a joystick HID device by the operating system.
 
-This is enabled by adding `JOYSTICK_ENABLE` to `rules.mk`. You can set this value to `analog`, `digital`, or `no`.
-
 !> Joystick support is not currently available on V-USB devices.
 
 The joystick feature provides two services:
@@ -18,7 +16,8 @@ or send gamepad reports based on values computed by the keyboard.
 To use analog input you must first enable it in `rules.mk`:
 
 ```makefile
-JOYSTICK_ENABLE = analog
+JOYSTICK_ENABLE = yes
+JOYSTICK_DRIVER = analog # or 'digital'
 ```
 
 An analog device such as a potentiometer found on a gamepad's analog axes is based on a [voltage divider](https://en.wikipedia.org/wiki/Voltage_divider).

--- a/keyboards/handwired/onekey/keymaps/joystick/rules.mk
+++ b/keyboards/handwired/onekey/keymaps/joystick/rules.mk
@@ -1,1 +1,1 @@
-JOYSTICK_ENABLE = analog
+JOYSTICK_ENABLE = yes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

If `JOYSTICK_ENABLE = analog` is set at keyboard level, things like `qmk info` will complain about it:
```
☒ Invalid API data: handwired/onekey/promicro: features.joystick: 'analog' is not of type 'boolean'
```
So it has been split up into `_ENABLE` and `_DRIVER` settings, defaulting to `analog`. The documentation has been updated to reflect the new usage.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
