### PR TITLE
`OLED_TIMEOUT 0` and `OLED_DISABLE_TIMEOUT` should behave the same

### DIFF
--- a/quantum/keyboard.c
+++ b/quantum/keyboard.c
@@ -479,7 +479,7 @@ MATRIX_LOOP_END:
 
 #ifdef OLED_ENABLE
     oled_task();
-#    ifndef OLED_DISABLE_TIMEOUT
+#    if OLED_TIMEOUT > 0
     // Wake up oled if user is using those fabulous keys or spinning those encoders!
 #        ifdef ENCODER_ENABLE
     if (matrix_changed || encoders_changed) oled_on();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

While implementing a custom timeout rule I stumbled upon the fact that `OLED_TIMEOUT 0` and `OLED_DISABLE_TIMEOUT` are not equivalent.
As far as I can tell this should be the case tho, at least [oled_driver.h#L150](https://github.com/qmk/qmk_firmware/blob/master/drivers/oled/oled_driver.h#L150) indicates so. Feel free to close this pr if I am misunderstanding something here.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
