### PR TITLE
Added RGBLIGHT_TIMEOUT implementation

### DIFF
--- a/docs/feature_rgblight.md
+++ b/docs/feature_rgblight.md
@@ -89,6 +89,7 @@ Your RGB lighting can be configured by placing these `#define`s in your `config.
 |`RGBLIGHT_SAT_STEP`        |`17`                        |The number of steps to increment the saturation by                                                                         |
 |`RGBLIGHT_VAL_STEP`        |`17`                        |The number of steps to increment the brightness by                                                                         |
 |`RGBLIGHT_LIMIT_VAL`       |`255`                       |The maximum brightness level                                                                                               |
+|`RGBLIGHT_TIMEOUT`         |`0`                         |The time in milliseconds after which the RGB lighting will be switched off if there is no keyboard activity (like a key press or encoder tick)                                                                                                                        |
 |`RGBLIGHT_SLEEP`           |*Not defined*               |If defined, the RGB lighting will be switched off when the host goes to sleep                                              |
 |`RGBLIGHT_SPLIT`           |*Not defined*               |If defined, synchronization functionality for split keyboards is added                                                     |
 |`RGBLIGHT_DISABLE_KEYCODES`|*Not defined*               |If defined, disables the ability to control RGB Light from the keycodes. You must use code functions to control the feature|

--- a/quantum/keyboard.c
+++ b/quantum/keyboard.c
@@ -451,9 +451,26 @@ MATRIX_LOOP_END:
     matrix_scan_perf_task();
 #endif
 
+    #ifdef ENCODER_ENABLE
+    encoders_changed = encoder_read();
+    if (encoders_changed) last_encoder_activity_trigger();
+#endif
+
 #if defined(RGBLIGHT_ENABLE)
     rgblight_task();
 #endif
+
+#ifdef RGBLIGHT_ENABLE
+     rgblight_task();
+#       ifdef RGBLIGHT_TIMEOUT
+        // Wake up rgblight if user is using those fabulous keys or spinning those encoders!
+#           ifdef ENCODER_ENABLE
+        if (matrix_changed || encoders_changed) rgblight_wakeup();
+#           else
+        if (matrix_changed) rgblight_wakeup();
+#           endif
+#       endif
+ #endif
 
 #ifdef LED_MATRIX_ENABLE
     led_matrix_task();
@@ -466,11 +483,6 @@ MATRIX_LOOP_END:
 #    if defined(BACKLIGHT_PIN) || defined(BACKLIGHT_PINS)
     backlight_task();
 #    endif
-#endif
-
-#ifdef ENCODER_ENABLE
-    encoders_changed = encoder_read();
-    if (encoders_changed) last_encoder_activity_trigger();
 #endif
 
 #ifdef QWIIC_ENABLE

--- a/quantum/keyboard.c
+++ b/quantum/keyboard.c
@@ -451,7 +451,7 @@ MATRIX_LOOP_END:
     matrix_scan_perf_task();
 #endif
 
-    #ifdef ENCODER_ENABLE
+#ifdef ENCODER_ENABLE
     encoders_changed = encoder_read();
     if (encoders_changed) last_encoder_activity_trigger();
 #endif
@@ -461,16 +461,16 @@ MATRIX_LOOP_END:
 #endif
 
 #ifdef RGBLIGHT_ENABLE
-     rgblight_task();
-#       ifdef RGBLIGHT_TIMEOUT
-        // Wake up rgblight if user is using those fabulous keys or spinning those encoders!
-#           ifdef ENCODER_ENABLE
-        if (matrix_changed || encoders_changed) rgblight_wakeup();
-#           else
-        if (matrix_changed) rgblight_wakeup();
-#           endif
-#       endif
- #endif
+    rgblight_task();
+#    ifdef RGBLIGHT_TIMEOUT
+    // Wake up rgblight if user is using those fabulous keys or spinning those encoders!
+#        ifdef ENCODER_ENABLE
+    if (matrix_changed || encoders_changed) rgblight_wakeup();
+#        else
+    if (matrix_changed) rgblight_wakeup();
+#        endif
+#    endif
+#endif
 
 #ifdef LED_MATRIX_ENABLE
     led_matrix_task();

--- a/quantum/rgblight/rgblight.c
+++ b/quantum/rgblight/rgblight.c
@@ -114,9 +114,9 @@ bool              is_rgblight_initialized = false;
 static bool is_suspended;
 static bool pre_suspend_enabled;
 
-    #if RGBLIGHT_TIMEOUT > 0
-    static uint32_t timeout_time;
-    #endif
+#    if RGBLIGHT_TIMEOUT > 0
+static uint32_t timeout_time;
+#    endif
 #endif
 
 #ifdef RGBLIGHT_USE_TIMER
@@ -250,9 +250,9 @@ void rgblight_init(void) {
         rgblight_mode_noeeprom(rgblight_config.mode);
     }
 
-    #if RGBLIGHT_TIMEOUT > 0
-        timeout_time = timer_read32() + RGBLIGHT_TIMEOUT;
-    #endif
+#if RGBLIGHT_TIMEOUT > 0
+    timeout_time = timer_read32() + RGBLIGHT_TIMEOUT;
+#endif
 
     is_rgblight_initialized = true;
 }
@@ -793,21 +793,20 @@ void rgblight_wakeup(void) {
         if (pre_suspend_enabled) {
             rgblight_enable_noeeprom();
         }
-#       ifdef RGBLIGHT_LAYERS_OVERRIDE_RGB_OFF
+#    ifdef RGBLIGHT_LAYERS_OVERRIDE_RGB_OFF
         // Need this or else the LEDs won't be set
         else if (rgblight_status.enabled_layer_mask != 0) {
             rgblight_set();
         }
-#       endif
+#    endif
 
         rgblight_timer_enable();
     }
 
-#   if RGBLIGHT_TIMEOUT > 0
+#    if RGBLIGHT_TIMEOUT > 0
     // Reset timeout timer
     timeout_time = timer_read32() + RGBLIGHT_TIMEOUT;
-#   endif
-
+#    endif
 }
 
 #endif
@@ -1064,9 +1063,9 @@ void rgblight_task(void) {
     rgblight_blink_layer_repeat_helper();
 #    endif
 
-#   if RGBLIGHT_TIMEOUT > 0
+#    if RGBLIGHT_TIMEOUT > 0
     if (timer_expired32(timer_read32(), timeout_time) && !is_suspended) rgblight_suspend();
-#   endif
+#    endif
 }
 
 #endif /* RGBLIGHT_USE_TIMER */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
<!--- Describe your changes in detail here. -->
Added the ability to define a timeout value for rgblight. Internally it reuses the existing wakeup/suspend functionality but now adds a timer check which runs in QMK's core task loop. If the timer expires then rgblight is suspended and it is woken up on the next keypress, encoder update or wake up call from the connected computer.

Also updated the rgblight documentation to reflect the new configuration variable introduced in this PR.

This PR replaces https://github.com/qmk/qmk_firmware/pull/14306 - I've closed it.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR
This PR will address all issues requesting similar features like this one - #12920

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
