### PR TITLE
[Bug] Fix compile issues for boards with custom matrix

### DIFF
--- a/keyboards/bpiphany/pegasushoof/2015/matrix.c
+++ b/keyboards/bpiphany/pegasushoof/2015/matrix.c
@@ -33,6 +33,18 @@ static matrix_row_t matrix_debouncing[MATRIX_ROWS];
 static matrix_row_t read_cols(void);
 static void select_row(uint8_t col);
 
+// user-defined overridable functions
+
+__attribute__((weak)) void matrix_init_kb(void) { matrix_init_user(); }
+
+__attribute__((weak)) void matrix_scan_kb(void) { matrix_scan_user(); }
+
+__attribute__((weak)) void matrix_init_user(void) {}
+
+__attribute__((weak)) void matrix_scan_user(void) {}
+
+// helper functions
+
 inline uint8_t matrix_rows(void)
 {
   return MATRIX_ROWS;

--- a/keyboards/handwired/datahand/matrix.c
+++ b/keyboards/handwired/datahand/matrix.c
@@ -27,6 +27,17 @@ static matrix_row_t matrix[MATRIX_ROWS];
 static matrix_row_t read_cols(void);
 static void select_row(uint8_t row);
 
+// user-defined overridable functions
+
+__attribute__((weak)) void matrix_init_kb(void) { matrix_init_user(); }
+
+__attribute__((weak)) void matrix_scan_kb(void) { matrix_scan_user(); }
+
+__attribute__((weak)) void matrix_init_user(void) {}
+
+__attribute__((weak)) void matrix_scan_user(void) {}
+
+// helper functions
 void matrix_init(void) {
   /* See datahand.h for more detail on pins. */
 
@@ -48,7 +59,7 @@ void matrix_init(void) {
   /* Turn off the lock LEDs. */
   PORTF |= LED_CAPS_LOCK | LED_NUM_LOCK | LED_SCROLL_LOCK | LED_MOUSE_LOCK;
 
-  matrix_init_user();
+  matrix_init_quantum();
 }
 
 uint8_t matrix_scan(void) {
@@ -62,7 +73,7 @@ uint8_t matrix_scan(void) {
     matrix[row] = read_cols();
   }
 
-  matrix_scan_user();
+  matrix_scan_quantum();
 
   return 1;
 }

--- a/keyboards/keyboardio/model01/matrix.c
+++ b/keyboards/keyboardio/model01/matrix.c
@@ -25,6 +25,17 @@
 static matrix_row_t rows[MATRIX_ROWS];
 #define ROWS_PER_HAND (MATRIX_ROWS / 2)
 
+// user-defined overridable functions
+
+__attribute__((weak)) void matrix_init_kb(void) { matrix_init_user(); }
+
+__attribute__((weak)) void matrix_scan_kb(void) { matrix_scan_user(); }
+
+__attribute__((weak)) void matrix_init_user(void) {}
+
+__attribute__((weak)) void matrix_scan_user(void) {}
+
+// helper functions
 inline
 uint8_t matrix_rows(void) {
   return MATRIX_ROWS;

--- a/keyboards/matrix/noah/matrix.c
+++ b/keyboards/matrix/noah/matrix.c
@@ -26,6 +26,17 @@ static matrix_row_t matrix_debouncing[MATRIX_COLS];
 static bool debouncing = false;
 static uint16_t debouncing_time = 0;
 
+// user-defined overridable functions
+
+__attribute__((weak)) void matrix_init_kb(void) { matrix_init_user(); }
+
+__attribute__((weak)) void matrix_scan_kb(void) { matrix_scan_user(); }
+
+__attribute__((weak)) void matrix_init_user(void) {}
+
+__attribute__((weak)) void matrix_scan_user(void) {}
+
+// helper functions
 void matrix_init(void)
 {
     //debug_enable = true;

--- a/keyboards/ymdk/sp64/matrix.c
+++ b/keyboards/ymdk/sp64/matrix.c
@@ -38,6 +38,17 @@ static void matrix_select_row(uint8_t row);
 static uint8_t mcp23018_reset_loop = 0;
 #endif
 
+// user-defined overridable functions
+
+__attribute__((weak)) void matrix_init_kb(void) { matrix_init_user(); }
+
+__attribute__((weak)) void matrix_scan_kb(void) { matrix_scan_user(); }
+
+__attribute__((weak)) void matrix_init_user(void) {}
+
+__attribute__((weak)) void matrix_scan_user(void) {}
+
+// helper functions
 void matrix_init(void)
 {
   // all outputs for rows high


### PR DESCRIPTION
## Description

user functions were removed in #14312, but they weren't in the matrix.c for boards with full custom matrix.  So they are erroring out. 

## Types of Changes

- [x] Bugfix
- [ ] Keyboard (addition or update)

## Issues Fixed or Closed by This PR

* #14312 and tzarc CI

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
