### PR TITLE
Remove Arduino-style `analogRead()`

### DIFF
--- a/platforms/avr/drivers/analog.c
+++ b/platforms/avr/drivers/analog.c
@@ -23,29 +23,6 @@ static uint8_t aref = ADC_REF_POWER;
 
 void analogReference(uint8_t mode) { aref = mode & (_BV(REFS1) | _BV(REFS0)); }
 
-// Arduino compatible pin input
-int16_t analogRead(uint8_t pin) {
-#if defined(__AVR_ATmega32U4__)
-    // clang-format off
-    static const uint8_t PROGMEM pin_to_mux[] = {
-        //A0    A1    A2    A3    A4    A5
-        //F7    F6    F5    F4    F1    F0
-        0x07, 0x06, 0x05, 0x04, 0x01, 0x00,
-        //A6    A7    A8    A9   A10   A11
-        //D4    D7    B4    B5    B6    D6
-        0x20, 0x22, 0x23, 0x24, 0x25, 0x21
-    };
-    // clang-format on
-    if (pin >= 12) return 0;
-    return adc_read(pgm_read_byte(pin_to_mux + pin));
-#elif defined(__AVR_AT90USB646__) || defined(__AVR_AT90USB647__) || defined(__AVR_AT90USB1286__) || defined(__AVR_AT90USB1287__) || defined(__AVR_ATmega328P__) || defined(__AVR_ATmega328__)
-    if (pin >= 8) return 0;
-    return adc_read(pin);
-#else
-    return 0;
-#endif
-}
-
 int16_t analogReadPin(pin_t pin) { return adc_read(pinToMux(pin)); }
 
 uint8_t pinToMux(pin_t pin) {

--- a/platforms/avr/drivers/analog.h
+++ b/platforms/avr/drivers/analog.h
@@ -23,7 +23,6 @@
 extern "C" {
 #endif
 void    analogReference(uint8_t mode);
-int16_t analogRead(uint8_t pin);
 
 int16_t analogReadPin(pin_t pin);
 uint8_t pinToMux(pin_t pin);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This was deprecated a few cycles ago, in favour of `analogReadPin()` which takes a QMK-style pin. There are no more usages in the repo.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
