### PR TITLE
Remove commented out BLUETOOTH_ENABLE rules

### DIFF
--- a/keyboards/atreus62/rules.mk
+++ b/keyboards/atreus62/rules.mk
@@ -23,7 +23,6 @@ COMMAND_ENABLE = yes        # Commands for debug and configuration
 NKRO_ENABLE = no            # Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
 #BACKLIGHT_ENABLE = no      # Enable keyboard backlight functionality
 UNICODE_ENABLE = yes         # Unicode
-#BLUETOOTH_ENABLE = yes       # Enable Bluetooth with the Adafruit EZ-Key HID
 
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
 SLEEP_LED_ENABLE = no    # Breathing sleep LED during USB suspend

--- a/keyboards/bantam44/rules.mk
+++ b/keyboards/bantam44/rules.mk
@@ -25,4 +25,3 @@ COMMAND_ENABLE = yes    # Commands for debug and configuration
 # BACKLIGHT_ENABLE = yes  # Enable keyboard backlight functionality
 MIDI_ENABLE = no              # MIDI support
 # UNICODE_ENABLE = YES 		# Unicode
-# BLUETOOTH_ENABLE = yes # Enable Bluetooth with the Adafruit EZ-Key HID

--- a/keyboards/chimera_ergo/rules.mk
+++ b/keyboards/chimera_ergo/rules.mk
@@ -26,7 +26,6 @@ NKRO_ENABLE = yes		# USB Nkey Rollover - not yet supported in LUFA
 # BACKLIGHT_ENABLE = yes  # Enable keyboard backlight functionality
 MIDI_ENABLE = no              # MIDI support
 UNICODE_ENABLE = YES 		# Unicode
-# BLUETOOTH_ENABLE = yes # Enable Bluetooth with the Adafruit EZ-Key HID
 
 # # project specific files
 SRC += matrix.c serial_uart.c

--- a/keyboards/chimera_ls/rules.mk
+++ b/keyboards/chimera_ls/rules.mk
@@ -26,7 +26,6 @@ NKRO_ENABLE = yes		# USB Nkey Rollover - not yet supported in LUFA
 # BACKLIGHT_ENABLE = yes  # Enable keyboard backlight functionality
 MIDI_ENABLE = no              # MIDI support
 UNICODE_ENABLE = YES 		# Unicode
-# BLUETOOTH_ENABLE = yes # Enable Bluetooth with the Adafruit EZ-Key HID
 
 # project specific files
 SRC += matrix.c serial_uart.c

--- a/keyboards/chimera_ortho/rules.mk
+++ b/keyboards/chimera_ortho/rules.mk
@@ -26,7 +26,6 @@ NKRO_ENABLE = yes		# USB Nkey Rollover - not yet supported in LUFA
 # BACKLIGHT_ENABLE = yes  # Enable keyboard backlight functionality
 MIDI_ENABLE = no              # MIDI support
 UNICODE_ENABLE = YES 		# Unicode
-# BLUETOOTH_ENABLE = yes # Enable Bluetooth with the Adafruit EZ-Key HID
 
 # project specific files
 SRC += matrix.c serial_uart.c

--- a/keyboards/comet46/rules.mk
+++ b/keyboards/comet46/rules.mk
@@ -26,7 +26,6 @@ NKRO_ENABLE = yes		# USB Nkey Rollover - not yet supported in LUFA
 # BACKLIGHT_ENABLE = yes  # Enable keyboard backlight functionality
 MIDI_ENABLE = no              # MIDI support
 UNICODE_ENABLE = YES 		# Unicode
-# BLUETOOTH_ENABLE = yes # Enable Bluetooth with the Adafruit EZ-Key HID
 
 # project specific files
 SRC += matrix.c \

--- a/keyboards/dichotomy/rules.mk
+++ b/keyboards/dichotomy/rules.mk
@@ -27,7 +27,6 @@ NKRO_ENABLE = yes		# USB Nkey Rollover - not yet supported in LUFA
 # BACKLIGHT_ENABLE = yes  # Enable keyboard backlight functionality
 MIDI_ENABLE = no              # MIDI support
 UNICODE_ENABLE = YES 		# Unicode
-# BLUETOOTH_ENABLE = yes # Enable Bluetooth with the Adafruit EZ-Key HID
 
 # # project specific files
 SRC += matrix.c serial_uart.c

--- a/keyboards/gh60/revc/rules.mk
+++ b/keyboards/gh60/revc/rules.mk
@@ -26,6 +26,5 @@ NKRO_ENABLE = yes			# USB Nkey Rollover - if this doesn't work, see here: https:
 # BACKLIGHT_ENABLE = yes	# Enable keyboard backlight functionality
 MIDI_ENABLE = no              # MIDI support
 # UNICODE_ENABLE = YES		# Unicode
-# BLUETOOTH_ENABLE = yes	# Enable Bluetooth with the Adafruit EZ-Key HID
 
 LAYOUTS = 60_ansi 60_iso 60_ansi_split_bs_rshift 60_tsangan_hhkb

--- a/keyboards/handwired/retro_refit/rules.mk
+++ b/keyboards/handwired/retro_refit/rules.mk
@@ -26,4 +26,3 @@ NKRO_ENABLE = yes			# USB Nkey Rollover - if this doesn't work, see here: https:
 # BACKLIGHT_ENABLE = yes	# Enable keyboard backlight functionality
 MIDI_ENABLE = no              # MIDI support
 # UNICODE_ENABLE = YES		# Unicode
-# BLUETOOTH_ENABLE = yes	# Enable Bluetooth with the Adafruit EZ-Key HID

--- a/keyboards/hhkb/ansi/rules.mk
+++ b/keyboards/hhkb/ansi/rules.mk
@@ -26,7 +26,6 @@ CUSTOM_MATRIX = yes    # Custom matrix file for the HHKB
 # BACKLIGHT_ENABLE = yes  # Enable keyboard backlight functionality
 MIDI_ENABLE = no              # MIDI support
 # UNICODE_ENABLE = yes    # Unicode
-# BLUETOOTH_ENABLE = yes  # Enable Bluetooth with the Adafruit EZ-Key HID
 
 
 # HHKB_RN42_ENABLE = yes  # Enable support for hasu's BT alt controller -- code borrowed from tmk source tree.

--- a/keyboards/hhkb/jp/rules.mk
+++ b/keyboards/hhkb/jp/rules.mk
@@ -26,7 +26,6 @@ CUSTOM_MATRIX = yes    # Custom matrix file for the HHKB
 # BACKLIGHT_ENABLE = yes  # Enable keyboard backlight functionality
 MIDI_ENABLE = no              # MIDI support
 # UNICODE_ENABLE = yes    # Unicode
-# BLUETOOTH_ENABLE = yes  # Enable Bluetooth with the Adafruit EZ-Key HID
 
 
 # HHKB_RN42_ENABLE = yes  # Enable support for hasu's BT alt controller -- code borrowed from tmk source tree.

--- a/keyboards/honeycomb/rules.mk
+++ b/keyboards/honeycomb/rules.mk
@@ -27,7 +27,6 @@ NKRO_ENABLE = yes		# USB Nkey Rollover - not yet supported in LUFA
 # BACKLIGHT_ENABLE = yes  # Enable keyboard backlight functionality
 MIDI_ENABLE = no              # MIDI support
 UNICODE_ENABLE = YES 		# Unicode
-# BLUETOOTH_ENABLE = yes # Enable Bluetooth with the Adafruit EZ-Key HID
 
 # # project specific files
 SRC += matrix.c serial_uart.c

--- a/keyboards/jd40/rules.mk
+++ b/keyboards/jd40/rules.mk
@@ -26,5 +26,4 @@ NKRO_ENABLE = yes			# USB Nkey Rollover - if this doesn't work, see here: https:
 # BACKLIGHT_ENABLE = yes	# Enable keyboard backlight functionality
 MIDI_ENABLE = no              # MIDI support
 # UNICODE_ENABLE = YES		# Unicode
-# BLUETOOTH_ENABLE = yes	# Enable Bluetooth with the Adafruit EZ-Key HID
 RGBLIGHT_ENABLE = yes          # Enable RGB Underglow

--- a/keyboards/mitosis/rules.mk
+++ b/keyboards/mitosis/rules.mk
@@ -26,7 +26,6 @@ NKRO_ENABLE = yes		# USB Nkey Rollover - not yet supported in LUFA
 # BACKLIGHT_ENABLE = yes  # Enable keyboard backlight functionality
 MIDI_ENABLE = no              # MIDI support
 UNICODE_ENABLE = yes 		# Unicode
-# BLUETOOTH_ENABLE = yes # Enable Bluetooth with the Adafruit EZ-Key HID
 
 # # project specific files
 SRC += matrix.c serial_uart.c

--- a/keyboards/numatreus/rules.mk
+++ b/keyboards/numatreus/rules.mk
@@ -22,7 +22,6 @@ COMMAND_ENABLE = no        # Commands for debug and configuration
 NKRO_ENABLE = yes            # Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
 #BACKLIGHT_ENABLE = no      # Enable keyboard backlight functionality
 UNICODE_ENABLE = yes         # Unicode
-#BLUETOOTH_ENABLE = yes       # Enable Bluetooth with the Adafruit EZ-Key HID
 #TAP_DANCE_ENABLE = yes
 RGBLIGHT_ENABLE = no
 LED_ANIMATIONS = no

--- a/keyboards/ok60/rules.mk
+++ b/keyboards/ok60/rules.mk
@@ -25,6 +25,5 @@ BACKLIGHT_ENABLE = yes	# Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = yes  # Enable the RGB backlight
 MIDI_ENABLE = no              # MIDI support
 # UNICODE_ENABLE = YES		# Unicode
-# BLUETOOTH_ENABLE = yes	# Enable Bluetooth with the Adafruit EZ-Key HID
 
 LAYOUTS = 60_ansi 60_iso 60_hhkb

--- a/keyboards/redox_w/rules.mk
+++ b/keyboards/redox_w/rules.mk
@@ -26,7 +26,6 @@ NKRO_ENABLE = yes		# USB Nkey Rollover - not yet supported in LUFA
 # BACKLIGHT_ENABLE = yes  # Enable keyboard backlight functionality
 MIDI_ENABLE = no              # MIDI support
 UNICODE_ENABLE = YES 		# Unicode
-# BLUETOOTH_ENABLE = yes # Enable Bluetooth with the Adafruit EZ-Key HID
 
 # # project specific files
 SRC += matrix.c serial_uart.c


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Starting cleanup of Bluetooth config system. `BLUETOOTH_ENABLE` will be removed from all keyboard `rules.mk`s and defaultish keymaps where it is `no`.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
