### PR TITLE
Apply `TAP_CODE_DELAY` to Tap Dance key sequences

### DIFF
--- a/quantum/action.c
+++ b/quantum/action.c
@@ -57,12 +57,6 @@ __attribute__((weak)) bool get_retro_tapping(uint16_t keycode, keyrecord_t *reco
 
 __attribute__((weak)) bool pre_process_record_quantum(keyrecord_t *record) { return true; }
 
-#ifndef TAP_CODE_DELAY
-#    define TAP_CODE_DELAY 0
-#endif
-#ifndef TAP_HOLD_CAPS_DELAY
-#    define TAP_HOLD_CAPS_DELAY 80
-#endif
 /** \brief Called to execute an action.
  *
  * FIXME: Needs documentation.

--- a/quantum/action.h
+++ b/quantum/action.h
@@ -38,6 +38,13 @@ extern "C" {
 #    endif
 #endif
 
+#ifndef TAP_CODE_DELAY
+#    define TAP_CODE_DELAY 0
+#endif
+#ifndef TAP_HOLD_CAPS_DELAY
+#    define TAP_HOLD_CAPS_DELAY 80
+#endif
+
 /* tapping count and state */
 typedef struct {
     bool    interrupted : 1;

--- a/quantum/process_keycode/process_tap_dance.c
+++ b/quantum/process_keycode/process_tap_dance.c
@@ -44,6 +44,7 @@ void qk_tap_dance_pair_finished(qk_tap_dance_state_t *state, void *user_data) {
 void qk_tap_dance_pair_reset(qk_tap_dance_state_t *state, void *user_data) {
     qk_tap_dance_pair_t *pair = (qk_tap_dance_pair_t *)user_data;
 
+    wait_ms(TAP_CODE_DELAY);
     if (state->count == 1) {
         unregister_code16(pair->kc1);
     } else if (state->count == 2) {
@@ -74,6 +75,7 @@ void qk_tap_dance_dual_role_reset(qk_tap_dance_state_t *state, void *user_data) 
     qk_tap_dance_dual_role_t *pair = (qk_tap_dance_dual_role_t *)user_data;
 
     if (state->count == 1) {
+        wait_ms(TAP_CODE_DELAY);
         unregister_code16(pair->kc);
     }
 }


### PR DESCRIPTION
## Description

This adds a wait before the `unregister_code16` in tap dances, so that it respects the tap code delay for media key compatibility. 

Also, this moves the tap code delay defines to action.h, so that they're picked up most everywhere, rather than just in action.c, in case they're not actually defined.


## Types of Changes

- [x] Core
- [x] Bugfix
- [x] Enhancement/optimization

## Issues Fixed or Closed by This PR

* Fixes #5262  and https://discord.com/channels/440868230475677696/869812721552601088/886583370795065354

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
