### PR TITLE
Update newbs_getting_started.md

### DIFF
--- a/docs/newbs_getting_started.md
+++ b/docs/newbs_getting_started.md
@@ -66,6 +66,8 @@ You will need to install Homebrew. Follow the instructions on https://brew.sh.
 
 Install the QMK CLI by running:
 
+    brew tap osx-cross/arm
+    brew tap osx-cross/avr
     brew install qmk/qmk/qmk
 
 ### ** Linux/WSL **


### PR DESCRIPTION
Currently, following the instructions above gives "Warning: No available formula with the name "osx-cross/arm/arm-gcc-bin@8". on a new Mac install, because these casks need to be tapped first.

## Description

Documentation update to help new Mac users.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ X ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ X ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
