### PR TITLE
[Keymap] Update Helix:five_rows OLED code

### DIFF
--- a/keyboards/helix/rev2/keymaps/five_rows/config.h
+++ b/keyboards/helix/rev2/keymaps/five_rows/config.h
@@ -29,7 +29,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
    see tmk_core/common/action_tapping.c */
 
 #undef OLED_UPDATE_INTERVAL
-#define OLED_UPDATE_INTERVAL 50
+#ifdef DEBUG_MATRIX_SCAN_RATE
+#    define OLED_UPDATE_INTERVAL 500
+#else
+#    define OLED_UPDATE_INTERVAL 50
+#endif
 
 // place overrides here
 

--- a/keyboards/helix/rev2/keymaps/five_rows/matrix_output_unselect_delay.c
+++ b/keyboards/helix/rev2/keymaps/five_rows/matrix_output_unselect_delay.c
@@ -1,0 +1,15 @@
+#include QMK_KEYBOARD_H
+
+void matrix_output_unselect_delay(uint8_t line, bool key_pressed) {
+     /* If none of the keys are pressed,
+      *  there is no need to wait for time for the next line. */
+     if (key_pressed) {
+#    ifdef MATRIX_IO_DELAY
+#        if MATRIX_IO_DELAY > 0
+         wait_us(MATRIX_IO_DELAY);
+#        endif
+#    else
+         wait_us(30);
+#    endif
+     }
+}

--- a/keyboards/helix/rev2/keymaps/five_rows/matrix_output_unselect_delay.c
+++ b/keyboards/helix/rev2/keymaps/five_rows/matrix_output_unselect_delay.c
@@ -1,3 +1,19 @@
+/* Copyright 2021 mtei
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include QMK_KEYBOARD_H
 
 void matrix_output_unselect_delay(uint8_t line, bool key_pressed) {

--- a/keyboards/helix/rev2/keymaps/five_rows/oled_display.c
+++ b/keyboards/helix/rev2/keymaps/five_rows/oled_display.c
@@ -221,12 +221,13 @@ void render_status(void) {
             }
         }
     }
+    oled_write_P(PSTR("\n"), false);
 
     // Host Keyboard LED Status
-    oled_write_P(PSTR("\n"), false);
-    oled_write_P((host_keyboard_leds() & (1<<USB_LED_NUM_LOCK)) ? PSTR("NUMLOCK  ") : PSTR("         "), false);
-    oled_write_P((host_keyboard_leds() & (1<<USB_LED_CAPS_LOCK)) ? PSTR("CAPS  ") : PSTR("      "), false);
-    oled_write_P((host_keyboard_leds() & (1<<USB_LED_SCROLL_LOCK)) ? PSTR("SCLK  ") : PSTR("      "), false);
+    led_t led_state = host_keyboard_led_state();
+    oled_write_P(led_state.num_lock ? PSTR("NUMLOCK  ") : PSTR("         "), false);
+    oled_write_P(led_state.caps_lock ? PSTR("CAPS  ") : PSTR("      "), false);
+    oled_write_P(led_state.scroll_lock ? PSTR("SCLK  ") : PSTR("      "), false);
 }
 
 #    ifdef SSD1306OLED

--- a/keyboards/helix/rev2/keymaps/five_rows/oled_display.c
+++ b/keyboards/helix/rev2/keymaps/five_rows/oled_display.c
@@ -125,21 +125,35 @@ static void render_logo(void) {
         0xc0,0xc1,0xc2,0xc3,0xc4,0xc5,0xc6,0xc7,0xc8,0xc9,0xca,0xcb,0xcc,0xcd,0xce,0xcf,0xd0,0xd1,0xd2,0xd3,0xd4,
         0};
     oled_write_P(helix_logo, false);
-#    ifdef RGBLIGHT_ENABLE
     char buf[30];
     char *bufp;
+#    ifdef RGBLIGHT_ENABLE
     if (RGBLIGHT_MODES > 1 && rgblight_is_enabled()) {
         bufp = sprint2d(buf, " LED ", rgblight_get_mode());
+#        ifdef DEBUG_MATRIX_SCAN_RATE
+        bufp = sprintd(bufp, "  scan:", get_matrix_scan_rate());
+#        else
         bufp = sprintd(bufp, ": ", rgblight_get_hue()/RGBLIGHT_HUE_STEP);
         bufp = sprintd(bufp, ",", rgblight_get_sat()/RGBLIGHT_SAT_STEP);
         bufp = sprintd(bufp, ",", rgblight_get_val()/RGBLIGHT_VAL_STEP);
         bufp = sprints(bufp, " ");
+#        endif
         oled_write(buf, false);
 #        ifndef SSD1306OLED
     } else {
+#        ifdef DEBUG_MATRIX_SCAN_RATE
+        bufp = sprintd(buf, "  scan:", get_matrix_scan_rate());
+        oled_write(buf, false);
+#        endif
         oled_write_P( PSTR("\n"), false);
 #        endif
     }
+#    else
+#        ifdef DEBUG_MATRIX_SCAN_RATE
+    bufp = sprintd(buf, " scan:", get_matrix_scan_rate());
+    bufp = sprints(bufp, " ");
+    oled_write(buf, false);
+#        endif
 #    endif
 }
 
@@ -192,6 +206,11 @@ void render_status(void) {
     int name_num;
     uint32_t lstate;
     oled_write_P(layer_names[current_default_layer], false);
+#    ifdef DEBUG_MATRIX_SCAN_RATE
+    char buf[16];
+    sprintd(buf, " scan:", get_matrix_scan_rate());
+    oled_write(buf, false);
+#    endif
     oled_write_P(PSTR("\n"), false);
     for (lstate = layer_state, name_num = 0;
          lstate && name_num < sizeof(layer_names)/sizeof(char *);

--- a/keyboards/helix/rev2/keymaps/five_rows/rules.mk
+++ b/keyboards/helix/rev2/keymaps/five_rows/rules.mk
@@ -27,7 +27,7 @@ HELIX_ROWS = 5              # Helix Rows is 4 or 5
 
 ifneq ($(strip $(HELIX)),)
   define KEYMAP_OPTION_PARSE
-    # parse  'dispoff', 'consloe', 'na', 'ani', 'mini-ani'
+    # parse  'dispoff', 'consloe', 'na', 'ani', 'mini-ani', 'scan-api'
     $(if $(SHOW_PARCE),$(info parse -$1-))  #debug
     ifeq ($(strip $1),dispoff)
         OLED_ENABLE = no
@@ -71,6 +71,11 @@ ifneq ($(strip $(HELIX)),)
     endif
     ifneq ($(filter nolto no-lto no_lto,$(strip $1)),)
         LTO_ENABLE = no
+    endif
+    ifeq ($(strip $1),scan-api)
+        # use DEBUG_MATRIX_SCAN_RATE
+        # see docs/newbs_testing_debugging.md
+        DEBUG_MATRIX_SCAN_RATE_ENABLE = api
     endif
   endef # end of KEYMAP_OPTION_PARSE
 

--- a/keyboards/helix/rev2/keymaps/five_rows/rules.mk
+++ b/keyboards/helix/rev2/keymaps/five_rows/rules.mk
@@ -25,9 +25,11 @@ HELIX_ROWS = 5              # Helix Rows is 4 or 5
 # LED_ANIMATIONS = yes        # LED animations
 # IOS_DEVICE_ENABLE = no      # connect to IOS device (iPad,iPhone)
 
+CUSTOM_DELAY = yes
+
 ifneq ($(strip $(HELIX)),)
   define KEYMAP_OPTION_PARSE
-    # parse  'dispoff', 'consloe', 'na', 'ani', 'mini-ani', 'scan-api'
+    # parse  'dispoff', 'consloe', 'na', 'ani', 'mini-ani', 'scan-api',
     $(if $(SHOW_PARCE),$(info parse -$1-))  #debug
     ifeq ($(strip $1),dispoff)
         OLED_ENABLE = no
@@ -99,6 +101,10 @@ endif
 
 ifeq ($(strip $(OLED_ENABLE)), yes)
     SRC += oled_display.c
+endif
+
+ifeq ($(strip $(CUSTOM_DELAY)),yes)
+    SRC += matrix_output_unselect_delay.c
 endif
 
 # convert Helix-specific options (that represent combinations of standard options)

--- a/keyboards/helix/rev3_5rows/keymaps/five_rows/config.h
+++ b/keyboards/helix/rev3_5rows/keymaps/five_rows/config.h
@@ -29,7 +29,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
    see tmk_core/common/action_tapping.c */
 
 #undef OLED_UPDATE_INTERVAL
-#define OLED_UPDATE_INTERVAL 50
+#ifdef DEBUG_MATRIX_SCAN_RATE
+#    define OLED_UPDATE_INTERVAL 500
+#else
+#    define OLED_UPDATE_INTERVAL 50
+#endif
 
 // place overrides here
 

--- a/keyboards/helix/rev3_5rows/keymaps/five_rows/matrix_output_unselect_delay.c
+++ b/keyboards/helix/rev3_5rows/keymaps/five_rows/matrix_output_unselect_delay.c
@@ -1,0 +1,15 @@
+#include QMK_KEYBOARD_H
+
+void matrix_output_unselect_delay(uint8_t line, bool key_pressed) {
+     /* If none of the keys are pressed,
+      *  there is no need to wait for time for the next line. */
+     if (key_pressed) {
+#    ifdef MATRIX_IO_DELAY
+#        if MATRIX_IO_DELAY > 0
+         wait_us(MATRIX_IO_DELAY);
+#        endif
+#    else
+         wait_us(30);
+#    endif
+     }
+}

--- a/keyboards/helix/rev3_5rows/keymaps/five_rows/matrix_output_unselect_delay.c
+++ b/keyboards/helix/rev3_5rows/keymaps/five_rows/matrix_output_unselect_delay.c
@@ -1,3 +1,19 @@
+/* Copyright 2021 mtei
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include QMK_KEYBOARD_H
 
 void matrix_output_unselect_delay(uint8_t line, bool key_pressed) {

--- a/keyboards/helix/rev3_5rows/keymaps/five_rows/oled_display.c
+++ b/keyboards/helix/rev3_5rows/keymaps/five_rows/oled_display.c
@@ -221,12 +221,13 @@ void render_status(void) {
             }
         }
     }
+    oled_write_P(PSTR("\n"), false);
 
     // Host Keyboard LED Status
-    oled_write_P(PSTR("\n"), false);
-    oled_write_P((host_keyboard_leds() & (1<<USB_LED_NUM_LOCK)) ? PSTR("NUMLOCK  ") : PSTR("         "), false);
-    oled_write_P((host_keyboard_leds() & (1<<USB_LED_CAPS_LOCK)) ? PSTR("CAPS  ") : PSTR("      "), false);
-    oled_write_P((host_keyboard_leds() & (1<<USB_LED_SCROLL_LOCK)) ? PSTR("SCLK  ") : PSTR("      "), false);
+    led_t led_state = host_keyboard_led_state();
+    oled_write_P(led_state.num_lock ? PSTR("NUMLOCK  ") : PSTR("         "), false);
+    oled_write_P(led_state.caps_lock ? PSTR("CAPS  ") : PSTR("      "), false);
+    oled_write_P(led_state.scroll_lock ? PSTR("SCLK  ") : PSTR("      "), false);
 }
 
 #    ifdef SSD1306OLED

--- a/keyboards/helix/rev3_5rows/keymaps/five_rows/oled_display.c
+++ b/keyboards/helix/rev3_5rows/keymaps/five_rows/oled_display.c
@@ -125,21 +125,35 @@ static void render_logo(void) {
         0xc0,0xc1,0xc2,0xc3,0xc4,0xc5,0xc6,0xc7,0xc8,0xc9,0xca,0xcb,0xcc,0xcd,0xce,0xcf,0xd0,0xd1,0xd2,0xd3,0xd4,
         0};
     oled_write_P(helix_logo, false);
-#    ifdef RGBLIGHT_ENABLE
     char buf[30];
     char *bufp;
+#    ifdef RGBLIGHT_ENABLE
     if (RGBLIGHT_MODES > 1 && rgblight_is_enabled()) {
         bufp = sprint2d(buf, " LED ", rgblight_get_mode());
+#        ifdef DEBUG_MATRIX_SCAN_RATE
+        bufp = sprintd(bufp, "  scan:", get_matrix_scan_rate());
+#        else
         bufp = sprintd(bufp, ": ", rgblight_get_hue()/RGBLIGHT_HUE_STEP);
         bufp = sprintd(bufp, ",", rgblight_get_sat()/RGBLIGHT_SAT_STEP);
         bufp = sprintd(bufp, ",", rgblight_get_val()/RGBLIGHT_VAL_STEP);
         bufp = sprints(bufp, " ");
+#        endif
         oled_write(buf, false);
 #        ifndef SSD1306OLED
     } else {
+#        ifdef DEBUG_MATRIX_SCAN_RATE
+        bufp = sprintd(buf, "  scan:", get_matrix_scan_rate());
+        oled_write(buf, false);
+#        endif
         oled_write_P( PSTR("\n"), false);
 #        endif
     }
+#    else
+#        ifdef DEBUG_MATRIX_SCAN_RATE
+    bufp = sprintd(buf, " scan:", get_matrix_scan_rate());
+    bufp = sprints(bufp, " ");
+    oled_write(buf, false);
+#        endif
 #    endif
 }
 
@@ -192,6 +206,11 @@ void render_status(void) {
     int name_num;
     uint32_t lstate;
     oled_write_P(layer_names[current_default_layer], false);
+#    ifdef DEBUG_MATRIX_SCAN_RATE
+    char buf[16];
+    sprintd(buf, " scan:", get_matrix_scan_rate());
+    oled_write(buf, false);
+#    endif
     oled_write_P(PSTR("\n"), false);
     for (lstate = layer_state, name_num = 0;
          lstate && name_num < sizeof(layer_names)/sizeof(char *);

--- a/keyboards/helix/rev3_5rows/keymaps/five_rows/rules.mk
+++ b/keyboards/helix/rev3_5rows/keymaps/five_rows/rules.mk
@@ -16,7 +16,7 @@ LED_ANIMATIONS = yes
 
 ifneq ($(strip $(HELIX)),)
   define KEYMAP_OPTION_PARSE
-    # parse 'dispoff', 'consle', 'back', 'oled', 'no-ani', 'mini-ani', 'lto', 'no-lto', 'no-enc', 'scan'
+    # parse 'dispoff', 'consle', 'back', 'oled', 'no-ani', 'mini-ani', 'lto', 'no-lto', 'no-enc', 'scan', 'scan-api'
     $(if $(SHOW_PARCE),$(info parse .$1.))  #debug
     ifeq ($(strip $1),dispoff)
         OLED_ENABLE = no
@@ -62,6 +62,11 @@ ifneq ($(strip $(HELIX)),)
         # use DEBUG_MATRIX_SCAN_RATE
         # see docs/newbs_testing_debugging.md
         DEBUG_MATRIX_SCAN_RATE_ENABLE = yes
+    endif
+    ifeq ($(strip $1),scan-api)
+        # use DEBUG_MATRIX_SCAN_RATE
+        # see docs/newbs_testing_debugging.md
+        DEBUG_MATRIX_SCAN_RATE_ENABLE = api
     endif
   endef # end of KEYMAP_OPTION_PARSE
 

--- a/keyboards/helix/rev3_5rows/keymaps/five_rows/rules.mk
+++ b/keyboards/helix/rev3_5rows/keymaps/five_rows/rules.mk
@@ -14,6 +14,8 @@ ENCODER_ENABLE = no
 LTO_ENABLE = no  # if firmware size over limit, try this option
 LED_ANIMATIONS = yes
 
+CUSTOM_DELAY = yes
+
 ifneq ($(strip $(HELIX)),)
   define KEYMAP_OPTION_PARSE
     # parse 'dispoff', 'consle', 'back', 'oled', 'no-ani', 'mini-ani', 'lto', 'no-lto', 'no-enc', 'scan', 'scan-api'
@@ -83,6 +85,10 @@ endif
 ifeq ($(strip $(LED_ANIMATIONS)), mini)
     OPT_DEFS += -DLED_ANIMATIONS
     OPT_DEFS += -DLED_ANIMATIONS_LEVEL=1
+endif
+
+ifeq ($(strip $(CUSTOM_DELAY)),yes)
+    SRC += matrix_output_unselect_delay.c
 endif
 
 ifeq ($(strip $(DEBUG_CONFIG)), yes)


### PR DESCRIPTION
## Description

Update helix rev2 and rev3 keymap 'five_rows'.

*  Stop using snprintf() in keymaps/five_rows/oled_display.c.
    The binary size becomes 1350 bytes smaller.
* add matrix scan rate display to OLED.
* add matrix_output_unselect_delay.c.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
