### PR TITLE
Migrate STM32_EEPROM_ENABLE to use EEPROM_DRIVER

### DIFF
--- a/common_features.mk
+++ b/common_features.mk
@@ -157,20 +157,26 @@ else
       # Automatically provided by avr-libc, nothing required
     else ifeq ($(PLATFORM),CHIBIOS)
       ifeq ($(MCU_SERIES), STM32F3xx)
+        OPT_DEFS += -DEEPROM_DRIVER
+        COMMON_VPATH += $(DRIVER_PATH)/eeprom
+        SRC += eeprom_driver.c
         SRC += $(PLATFORM_COMMON_DIR)/eeprom_stm32.c
         SRC += $(PLATFORM_COMMON_DIR)/flash_stm32.c
         OPT_DEFS += -DEEPROM_EMU_STM32F303xC
-        OPT_DEFS += -DSTM32_EEPROM_ENABLE
       else ifeq ($(MCU_SERIES), STM32F1xx)
+        OPT_DEFS += -DEEPROM_DRIVER
+        COMMON_VPATH += $(DRIVER_PATH)/eeprom
+        SRC += eeprom_driver.c
         SRC += $(PLATFORM_COMMON_DIR)/eeprom_stm32.c
         SRC += $(PLATFORM_COMMON_DIR)/flash_stm32.c
         OPT_DEFS += -DEEPROM_EMU_STM32F103xB
-        OPT_DEFS += -DSTM32_EEPROM_ENABLE
       else ifeq ($(MCU_SERIES)_$(MCU_LDSCRIPT), STM32F0xx_STM32F072xB)
+        OPT_DEFS += -DEEPROM_DRIVER
+        COMMON_VPATH += $(DRIVER_PATH)/eeprom
+        SRC += eeprom_driver.c
         SRC += $(PLATFORM_COMMON_DIR)/eeprom_stm32.c
         SRC += $(PLATFORM_COMMON_DIR)/flash_stm32.c
         OPT_DEFS += -DEEPROM_EMU_STM32F072xB
-        OPT_DEFS += -DSTM32_EEPROM_ENABLE
       else ifeq ($(MCU_SERIES)_$(MCU_LDSCRIPT), STM32F0xx_STM32F042x6)
 
         # Stack sizes: Since this chip has limited RAM capacity, the stack area needs to be reduced.
@@ -178,10 +184,12 @@ else
         USE_PROCESS_STACKSIZE = 0x600
         USE_EXCEPTIONS_STACKSIZE = 0x300
 
+        OPT_DEFS += -DEEPROM_DRIVER
+        COMMON_VPATH += $(DRIVER_PATH)/eeprom
+        SRC += eeprom_driver.c
         SRC += $(PLATFORM_COMMON_DIR)/eeprom_stm32.c
         SRC += $(PLATFORM_COMMON_DIR)/flash_stm32.c
         OPT_DEFS += -DEEPROM_EMU_STM32F042x6
-        OPT_DEFS += -DSTM32_EEPROM_ENABLE
       else ifneq ($(filter $(MCU_SERIES),STM32L0xx STM32L1xx),)
         OPT_DEFS += -DEEPROM_DRIVER
         COMMON_VPATH += $(DRIVER_PATH)/eeprom

--- a/keyboards/mxss/rgblight.c
+++ b/keyboards/mxss/rgblight.c
@@ -23,10 +23,6 @@
 #ifdef EEPROM_ENABLE
 #    include "eeprom.h"
 #endif
-#ifdef STM32_EEPROM_ENABLE
-#    include <hal.h>
-#    include "eeprom_stm32.h"
-#endif
 #include "wait.h"
 #include "progmem.h"
 #include "timer.h"

--- a/quantum/eeconfig.c
+++ b/quantum/eeconfig.c
@@ -4,11 +4,6 @@
 #include "eeconfig.h"
 #include "action_layer.h"
 
-#ifdef STM32_EEPROM_ENABLE
-#    include <hal.h>
-#    include "eeprom_stm32.h"
-#endif
-
 #if defined(EEPROM_DRIVER)
 #    include "eeprom_driver.h"
 #endif
@@ -43,9 +38,6 @@ __attribute__((weak)) void eeconfig_init_kb(void) {
  * FIXME: needs doc
  */
 void eeconfig_init_quantum(void) {
-#ifdef STM32_EEPROM_ENABLE
-    EEPROM_Erase();
-#endif
 #if defined(EEPROM_DRIVER)
     eeprom_driver_erase();
 #endif
@@ -111,9 +103,6 @@ void eeconfig_enable(void) { eeprom_update_word(EECONFIG_MAGIC, EECONFIG_MAGIC_N
  * FIXME: needs doc
  */
 void eeconfig_disable(void) {
-#ifdef STM32_EEPROM_ENABLE
-    EEPROM_Erase();
-#endif
 #if defined(EEPROM_DRIVER)
     eeprom_driver_erase();
 #endif

--- a/quantum/keyboard.c
+++ b/quantum/keyboard.c
@@ -97,9 +97,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifdef DIP_SWITCH_ENABLE
 #    include "dip_switch.h"
 #endif
-#ifdef STM32_EEPROM_ENABLE
-#    include "eeprom_stm32.h"
-#endif
 #ifdef EEPROM_DRIVER
 #    include "eeprom_driver.h"
 #endif
@@ -246,9 +243,6 @@ void keyboard_setup(void) {
     disable_jtag();
 #endif
     print_set_sendchar(sendchar);
-#ifdef STM32_EEPROM_ENABLE
-    EEPROM_Init();
-#endif
 #ifdef EEPROM_DRIVER
     eeprom_driver_init();
 #endif

--- a/tmk_core/common/chibios/eeprom_stm32.c
+++ b/tmk_core/common/chibios/eeprom_stm32.c
@@ -622,13 +622,9 @@ uint16_t EEPROM_ReadDataWord(uint16_t Address) {
 /*****************************************************************************
  *  Bind to eeprom_driver.c
  *******************************************************************************/
-void eeprom_driver_init(void) {
-    EEPROM_Init();
-}
+void eeprom_driver_init(void) { EEPROM_Init(); }
 
-void eeprom_driver_erase(void) {
-    EEPROM_Erase();
-}
+void eeprom_driver_erase(void) { EEPROM_Erase(); }
 
 void eeprom_read_block(void *buf, const void *addr, size_t len) {
     const uint8_t *src  = (const uint8_t *)addr;

--- a/tmk_core/common/chibios/eeprom_stm32.c
+++ b/tmk_core/common/chibios/eeprom_stm32.c
@@ -620,48 +620,15 @@ uint16_t EEPROM_ReadDataWord(uint16_t Address) {
 }
 
 /*****************************************************************************
- *  Wrap library in AVR style functions.
+ *  Bind to eeprom_driver.c
  *******************************************************************************/
-uint8_t eeprom_read_byte(const uint8_t *Address) { return EEPROM_ReadDataByte((const uintptr_t)Address); }
-
-void eeprom_write_byte(uint8_t *Address, uint8_t Value) { EEPROM_WriteDataByte((uintptr_t)Address, Value); }
-
-void eeprom_update_byte(uint8_t *Address, uint8_t Value) { EEPROM_WriteDataByte((uintptr_t)Address, Value); }
-
-uint16_t eeprom_read_word(const uint16_t *Address) { return EEPROM_ReadDataWord((const uintptr_t)Address); }
-
-void eeprom_write_word(uint16_t *Address, uint16_t Value) { EEPROM_WriteDataWord((uintptr_t)Address, Value); }
-
-void eeprom_update_word(uint16_t *Address, uint16_t Value) { EEPROM_WriteDataWord((uintptr_t)Address, Value); }
-
-uint32_t eeprom_read_dword(const uint32_t *Address) {
-    const uint16_t p = (const uintptr_t)Address;
-    /* Check word alignment */
-    if (p % 2) {
-        /* Not aligned */
-        return (uint32_t)EEPROM_ReadDataByte(p) | (uint32_t)(EEPROM_ReadDataWord(p + 1) << 8) | (uint32_t)(EEPROM_ReadDataByte(p + 3) << 24);
-    } else {
-        /* Aligned */
-        return EEPROM_ReadDataWord(p) | (EEPROM_ReadDataWord(p + 2) << 16);
-    }
+void eeprom_driver_init(void) {
+    EEPROM_Init();
 }
 
-void eeprom_write_dword(uint32_t *Address, uint32_t Value) {
-    uint16_t p = (const uintptr_t)Address;
-    /* Check word alignment */
-    if (p % 2) {
-        /* Not aligned */
-        EEPROM_WriteDataByte(p, (uint8_t)Value);
-        EEPROM_WriteDataWord(p + 1, (uint16_t)(Value >> 8));
-        EEPROM_WriteDataByte(p + 3, (uint8_t)(Value >> 24));
-    } else {
-        /* Aligned */
-        EEPROM_WriteDataWord(p, (uint16_t)Value);
-        EEPROM_WriteDataWord(p + 2, (uint16_t)(Value >> 16));
-    }
+void eeprom_driver_erase(void) {
+    EEPROM_Erase();
 }
-
-void eeprom_update_dword(uint32_t *Address, uint32_t Value) { eeprom_write_dword(Address, Value); }
 
 void eeprom_read_block(void *buf, const void *addr, size_t len) {
     const uint8_t *src  = (const uint8_t *)addr;
@@ -670,14 +637,14 @@ void eeprom_read_block(void *buf, const void *addr, size_t len) {
     /* Check word alignment */
     if (len && (uintptr_t)src % 2) {
         /* Read the unaligned first byte */
-        *dest++ = eeprom_read_byte(src++);
+        *dest++ = EEPROM_ReadDataByte((const uintptr_t)src++);
         --len;
     }
 
     uint16_t value;
     bool     aligned = ((uintptr_t)dest % 2 == 0);
     while (len > 1) {
-        value = eeprom_read_word((uint16_t *)src);
+        value = EEPROM_ReadDataWord((const uintptr_t)((uint16_t *)src));
         if (aligned) {
             *(uint16_t *)dest = value;
             dest += 2;
@@ -689,7 +656,7 @@ void eeprom_read_block(void *buf, const void *addr, size_t len) {
         len -= 2;
     }
     if (len) {
-        *dest = eeprom_read_byte(src);
+        *dest = EEPROM_ReadDataByte((const uintptr_t)src);
     }
 }
 
@@ -700,7 +667,7 @@ void eeprom_write_block(const void *buf, void *addr, size_t len) {
     /* Check word alignment */
     if (len && (uintptr_t)dest % 2) {
         /* Write the unaligned first byte */
-        eeprom_write_byte(dest++, *src++);
+        EEPROM_WriteDataByte((uintptr_t)dest++, *src++);
         --len;
     }
 
@@ -712,15 +679,13 @@ void eeprom_write_block(const void *buf, void *addr, size_t len) {
         } else {
             value = *(uint8_t *)src | (*(uint8_t *)(src + 1) << 8);
         }
-        eeprom_write_word((uint16_t *)dest, value);
+        EEPROM_WriteDataWord((uintptr_t)((uint16_t *)dest), value);
         dest += 2;
         src += 2;
         len -= 2;
     }
 
     if (len) {
-        eeprom_write_byte(dest, *src);
+        EEPROM_WriteDataByte((uintptr_t)dest, *src);
     }
 }
-
-void eeprom_update_block(const void *buf, void *addr, size_t len) { eeprom_write_block(buf, addr, len); }

--- a/tmk_core/common/test/rules.mk
+++ b/tmk_core/common/test/rules.mk
@@ -16,6 +16,7 @@ eeprom_stm32_tiny_INC := $(eeprom_stm32_INC)
 eeprom_stm32_large_INC := $(eeprom_stm32_INC)
 
 eeprom_stm32_SRC := \
+	$(TOP_DIR)/drivers/eeprom/eeprom_driver.c \
 	$(TMK_PATH)/common/test/eeprom_stm32_tests.cpp \
 	$(TMK_PATH)/common/test/flash_stm32_mock.c \
 	$(TMK_PATH)/common/chibios/eeprom_stm32.c


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Avoids `STM32_EEPROM_ENABLE` becoming a template when adding new MCU support, while also making the API a little more uniform.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
