### PR TITLE
[Keyboard] Fix Boop65 rgb compile issues

### DIFF
--- a/keyboards/kbdfans/boop65/rgb/config.h
+++ b/keyboards/kbdfans/boop65/rgb/config.h
@@ -52,11 +52,12 @@
 #    define RGB_MATRIX_MAXIMUM_BRIGHTNESS 200 // limits maximum brightness of LEDs to 200 out of 255. If not defined maximum brightness is set to 255
 #    define RGB_MATRIX_STARTUP_VAL RGB_MATRIX_MAXIMUM_BRIGHTNESS // Sets the default brightness value, if none has been set
 #    define RGB_MATRIX_STARTUP_MODE RGB_MATRIX_CYCLE_ALL
-#    define DRIVER_ADDR_1 0b0110000
-#    define DRIVER_COUNT 1
-#    define DRIVER_1_LED_TOTAL 83
-#    define DRIVER_LED_TOTAL DRIVER_1_LED_TOTAL
-#    define DRIVER_INDICATOR_LED_TOTAL 0
+#    define DRIVER_ADDR_1                 0b0110000
+#    define DRIVER_ADDR_2                 0b0110000
+#    define DRIVER_COUNT                  1
+#    define DRIVER_1_LED_TOTAL            83
+#    define DRIVER_LED_TOTAL              DRIVER_1_LED_TOTAL
+#    define DRIVER_INDICATOR_LED_TOTAL    0
 #endif
 
 #define VIA_EEPROM_LAYOUT_OPTIONS_SIZE 2


### PR DESCRIPTION

## Description

`IS31FL3741` requires 2 addresses to be defined. 

## Types of Changes

- [x] Bugfix
- [x] Keyboard (addition or update)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
