### PR TITLE
Add custom keymap 'j4ckofalltrades' for sofle/rev1

### DIFF
--- a/keyboards/sofle/keymaps/j4ckofalltrades/encoder.c
+++ b/keyboards/sofle/keymaps/j4ckofalltrades/encoder.c
@@ -1,0 +1,37 @@
+/* Copyright 2021 Jordan Duabe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifdef ENCODER_ENABLE
+#    include QMK_KEYBOARD_H
+
+bool encoder_update_user(uint8_t index, bool clockwise) {
+    if (index == 0) {
+        if (clockwise) {
+            tap_code_delay(KC_VOLU, 10);
+        } else {
+            tap_code_delay(KC_VOLD, 10);
+        }
+    } else if (index == 1) {
+        if (clockwise) {
+            tap_code(KC_PGDOWN);
+        } else {
+            tap_code(KC_PGUP);
+        }
+    }
+    return true;
+}
+
+#endif

--- a/keyboards/sofle/keymaps/j4ckofalltrades/keymap.c
+++ b/keyboards/sofle/keymaps/j4ckofalltrades/keymap.c
@@ -1,0 +1,85 @@
+/* Copyright 2021 Jordan Duabe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+/*
+ * QWERTY
+ * ,-----------------------------------------.                    ,-----------------------------------------.
+ * |  `   |   1  |   2  |   3  |   4  |   5  |                    |   6  |   7  |   8  |   9  |   0  |  `   |
+ * |------+------+------+------+------+------|                    |------+------+------+------+------+------|
+ * | Tab  |   Q  |   W  |   E  |   R  |   T  |                    |   Y  |   U  |   I  |   O  |   P  | Bspc |
+ * |------+------+------+------+------+------|                    |------+------+------+------+------+------|
+ * | Esc  |   A  |   S  |   D  |   F  |   G  |-------.    ,-------|   H  |   J  |   K  |   L  |   ;  |  '   |
+ * |------+------+------+------+------+------| TO(2) |    | TO(1) |------+------+------+------+------+------|
+ * |LShift|   Z  |   X  |   C  |   V  |   B  |-------|    |-------|   N  |   M  |   ,  |   .  |   /  |RShift|
+ * `-----------------------------------------/       /     \      \-----------------------------------------'
+ *            | LGUI | LAlt | LCTR |LOWER | /Enter  /       \Space \  |RAISE | RCTR | RAlt | RGUI |
+ *            |      |      |      |      |/       /         \      \ |      |      |      |      |
+ *            `----------------------------------'            '------''---------------------------'
+ */
+
+[0] = LAYOUT(
+  KC_GRV,               KC_1,    KC_2,    KC_3,     KC_4,  KC_5,                   KC_6,    KC_7,    KC_8,     KC_9,    KC_0,    KC_GRV,
+  KC_TAB,               KC_Q,    KC_W,    KC_E,     KC_R,  KC_T,                   KC_Y,    KC_U,    KC_I,     KC_O,    KC_P,    KC_BSPC,
+  MT(MOD_LCTL, KC_ESC), KC_A,    KC_S,    KC_D,     KC_F,  KC_G,                   KC_H,    KC_J,    KC_K,     KC_L,    KC_SCLN, KC_QUOT,
+  KC_LSFT,              KC_Z,    KC_X,    KC_C,     KC_V,  KC_B, TO(2),     TO(1), KC_N,    KC_M,    KC_COMM,  KC_DOT,  KC_SLSH, KC_RSFT,
+                        KC_LGUI, KC_LALT, KC_LCTRL, MO(2), KC_ENT,                 KC_SPC,  MO(1),   KC_RCTRL, KC_RALT, KC_RGUI
+),
+/* RAISE
+ * ,-----------------------------------------.                    ,-----------------------------------------.
+ * |      |  F1  |  F2  |  F3  |  F4  |  F5  |                    |  F6  |  F7  |  F8  |  F9  | F10  | F11  |
+ * |------+------+------+------+------+------|                    |------+------+------+------+------+------|
+ * | Tab  |   1  |   2  |   3  |   4  |   5  |                    |   6  |   7  |   8  |   9  |   0  | F12  |
+ * |------+------+------+------+------+------|                    |------+------+------+------+------+------|
+ * | Esc  |   !  |   @  |   #  |   $  |   %  |-------.    ,-------|   ^  |   &  |   *  |   (  |   )  |   |  |
+ * |------+------+------+------+------+------| TO(2) |    | TO(1) |------+------+------+------+------+------|
+ * |LShift|  =   |  -   |  +   |   {  |   }  |-------|    |-------|   [  |   ]  |   ;  |   :  |   \  | Shift|
+ * `-----------------------------------------/       /     \      \-----------------------------------------'
+ *            | LGUI | LAlt | LCTR |LOWER | /Enter  /       \Space \  |RAISE | RCTR | RAlt | RGUI |
+ *            |      |      |      |      |/       /         \      \ |      |      |      |      |
+ *            `----------------------------------'            '------''---------------------------'
+ */
+[1] = LAYOUT(
+  _______, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,                         KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,
+  _______, KC_1,    KC_2,    KC_3,    KC_4,    KC_5,                          KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_F12,
+  _______, KC_EXLM, KC_AT,   KC_HASH, KC_DLR,  KC_PERC,                       KC_CIRC, KC_AMPR, KC_ASTR, KC_LPRN, KC_RPRN, KC_PIPE,
+  _______, KC_EQL,  KC_MINS, KC_PLUS, KC_LCBR, KC_RCBR, _______,     _______, KC_LBRC, KC_RBRC, KC_SCLN, KC_COLN, KC_BSLS, _______,
+                    _______, _______, _______, _______, _______,     _______, _______, _______, _______, _______
+),
+/* LOWER
+ * ,----------------------------------------.                    ,-----------------------------------------.
+ * |      | Pscr | Slck |Pause |      |      |                    |      |      |      |      |      |      |
+ * |------+------+------+------+------+------|                    |------+------+------+------+------+------|
+ * | Tab  | Ins  | Home | PgUp |      |      |                    |      |      |      |       |     |      |
+ * |------+------+------+------+------+------|                    |------+------+------+------+------+------|
+ * | Esc  | Del  | End  | PgDn |      |      |-------.    ,-------| Left | Down | Up   | Right |     |      |
+ * |------+------+------+------+------+------| TO(2) |    | TO(1) |------+------+------+------+------+------|
+ * |Shift | Undo |  Cut | Copy | Paste|      |-------|    |-------|      |      |      |       |     |      |
+ * `-----------------------------------------/       /     \      \-----------------------------------------'
+ *            | LGUI | LAlt | LCTR |LOWER | /Enter  /       \Space \  |RAISE | RCTR | RAlt | RGUI |
+ *            |      |      |      |      |/       /         \      \ |      |      |      |      |
+ *            `----------------------------------'            '------''---------------------------'
+ */
+[2] = LAYOUT(
+  _______, KC_PSCR, KC_SLCK, KC_PAUSE, _______,  _______,                       _______, _______, _______, _______,  _______, _______,
+  _______, KC_INS,  KC_HOME, KC_PGUP,  XXXXXXX,  XXXXXXX,                       _______, _______, _______, _______,  _______, _______,
+  _______, KC_DEL,  KC_END,  KC_PGDN,  XXXXXXX,  XXXXXXX,                       KC_LEFT, KC_DOWN, KC_UP,   KC_RIGHT, XXXXXXX, XXXXXXX,
+  _______, KC_UNDO, KC_CUT,  KC_COPY,  KC_PASTE, XXXXXXX, _______,     _______, XXXXXXX, _______, XXXXXXX, _______,  XXXXXXX, _______,
+                      _______, _______, _______, _______, _______,     _______, _______, _______, _______, _______
+)
+};

--- a/keyboards/sofle/keymaps/j4ckofalltrades/oled.c
+++ b/keyboards/sofle/keymaps/j4ckofalltrades/oled.c
@@ -1,0 +1,76 @@
+/* Copyright 2021 Jordan Duabe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifdef OLED_ENABLE
+#    include QMK_KEYBOARD_H
+
+static void render_logo(void) {
+    static const char PROGMEM qmk_logo[] = {
+        0x80,0x81,0x82,0x83,0x84,0x85,0x86,0x87,0x88,0x89,0x8a,0x8b,0x8c,0x8d,0x8e,0x8f,0x90,0x91,0x92,0x93,0x94,
+        0xa0,0xa1,0xa2,0xa3,0xa4,0xa5,0xa6,0xa7,0xa8,0xa9,0xaa,0xab,0xac,0xad,0xae,0xaf,0xb0,0xb1,0xb2,0xb3,0xb4,
+        0xc0,0xc1,0xc2,0xc3,0xc4,0xc5,0xc6,0xc7,0xc8,0xc9,0xca,0xcb,0xcc,0xcd,0xce,0xcf,0xd0,0xd1,0xd2,0xd3,0xd4,0
+    };
+
+    oled_write_P(qmk_logo, false);
+}
+
+static void print_status_narrow(void) {
+    oled_write_P(PSTR("Sofle"), false);
+    oled_write_P(PSTR("\n\n\n"), false);
+    // Print current mode
+    switch (get_highest_layer(layer_state)) {
+        case 0:
+            oled_write_ln_P(PSTR("Qwrt"), false);
+            break;
+        default:
+            oled_write_P(PSTR("Mod\n"), false);
+            break;
+    }
+    oled_write_P(PSTR("\n\n"), false);
+    // Print current layer
+    oled_write_ln_P(PSTR("LAYER"), false);
+    switch (get_highest_layer(layer_state)) {
+        case 0:
+            oled_write_P(PSTR("Base\n"), false);
+            break;
+        case 1:
+            oled_write_P(PSTR("Raise"), false);
+            break;
+        case 2:
+            oled_write_P(PSTR("Lower"), false);
+            break;
+        default:
+            oled_write_ln_P(PSTR("Undef"), false);
+    }
+    oled_write_P(PSTR("\n\n"), false);
+}
+
+oled_rotation_t oled_init_user(oled_rotation_t rotation) {
+    if (is_keyboard_master()) {
+        return OLED_ROTATION_270;
+    }
+    return rotation;
+}
+
+void oled_task_user(void) {
+    if (is_keyboard_master()) {
+        print_status_narrow();
+    } else {
+        render_logo();
+    }
+}
+
+#endif

--- a/keyboards/sofle/keymaps/j4ckofalltrades/readme.md
+++ b/keyboards/sofle/keymaps/j4ckofalltrades/readme.md
@@ -1,0 +1,19 @@
+![SofleKeyboard custom keymap](https://raw.githubusercontent.com/j4ckofalltrades/keebs/master/sofle/assets/soflekeyboard.png)
+
+# Via-compatible custom keymap for Sofle
+
+Modified version of default Via-compatible keymap with focus on adding a standard navigation cluster layer plus some
+Vim-inspired features e.g. soft escape (Esc when held, Ctrl when tapped), using 'h', 'j', 'k', 'l' as arrow keys.
+
+## Layout
+
+View in [Keyboard Layout Editor](http://www.keyboard-layout-editor.com/#/gists/a1f6519e723ad81ca151741b53a28b80)
+
+## Features
+
+- Via support
+- Mode for soft escape (`Esc` when tapped, `Ctrl` when held) 
+- Vim-style navigation (`h` `j` `k` `l` as arrow keys)
+- Mode for standard navigation cluster
+- Toggling between layers when encoders are pressed
+- Left encoder controls `VOLUP`/`VOLDOWN`. Right encoder `PGUP`/`PGDN`.

--- a/keyboards/sofle/keymaps/j4ckofalltrades/rules.mk
+++ b/keyboards/sofle/keymaps/j4ckofalltrades/rules.mk
@@ -1,0 +1,6 @@
+CONSOLE_ENABLE = no
+EXTRAKEY_ENABLE = yes
+VIA_ENABLE = yes
+LTO_ENABLE = yes
+
+SRC += oled.c encoder.c


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
    
Modified version of default Via-compatible keymap with focus on adding a standard navigation cluster layer
plus some Vim-inspired features e.g. soft escape (Esc when held, Ctrl when tapped), using 'h', 'j', 'k', 'l' as arrow keys.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
