### PR TITLE
[Bug] Fix IS31fl3741 driver to accept 1 or 2 addresses

### DIFF
--- a/drivers/led/issi/is31fl3741.c
+++ b/drivers/led/issi/is31fl3741.c
@@ -73,7 +73,7 @@ uint8_t g_twi_transfer_buffer[20] = {0xFF};
 // buffers and the transfers in IS31FL3741_write_pwm_buffer() but it's
 // probably not worth the extra complexity.
 uint8_t g_pwm_buffer[DRIVER_COUNT][ISSI_MAX_LEDS];
-bool    g_pwm_buffer_update_required                      = false;
+bool    g_pwm_buffer_update_required[DRIVER_COUNT]        = {false};
 bool    g_scaling_registers_update_required[DRIVER_COUNT] = {false};
 
 uint8_t g_scaling_registers[DRIVER_COUNT][ISSI_MAX_LEDS];
@@ -172,7 +172,7 @@ void IS31FL3741_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
         g_pwm_buffer[led.driver][led.r] = red;
         g_pwm_buffer[led.driver][led.g] = green;
         g_pwm_buffer[led.driver][led.b] = blue;
-        g_pwm_buffer_update_required    = true;
+        g_pwm_buffer_update_required[led.driver] = true;
     }
 }
 
@@ -206,12 +206,12 @@ void IS31FL3741_set_led_control_register(uint8_t index, bool red, bool green, bo
     g_scaling_registers_update_required[led.driver] = true;
 }
 
-void IS31FL3741_update_pwm_buffers(uint8_t addr1, uint8_t addr2) {
-    if (g_pwm_buffer_update_required) {
-        IS31FL3741_write_pwm_buffer(addr1, g_pwm_buffer[0]);
+void IS31FL3741_update_pwm_buffers(uint8_t addr, uint8_t index) {
+    if (g_pwm_buffer_update_required[index]) {
+        IS31FL3741_write_pwm_buffer(addr, g_pwm_buffer[index]);
     }
 
-    g_pwm_buffer_update_required = false;
+    g_pwm_buffer_update_required[index] = false;
 }
 
 void IS31FL3741_set_pwm_buffer(const is31_led *pled, uint8_t red, uint8_t green, uint8_t blue) {
@@ -219,7 +219,7 @@ void IS31FL3741_set_pwm_buffer(const is31_led *pled, uint8_t red, uint8_t green,
     g_pwm_buffer[pled->driver][pled->g] = green;
     g_pwm_buffer[pled->driver][pled->b] = blue;
 
-    g_pwm_buffer_update_required = true;
+    g_pwm_buffer_update_required[pled->driver] = true;
 }
 
 void IS31FL3741_update_led_control_registers(uint8_t addr, uint8_t index) {

--- a/drivers/led/issi/is31fl3741.c
+++ b/drivers/led/issi/is31fl3741.c
@@ -169,9 +169,9 @@ void IS31FL3741_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
     if (index >= 0 && index < DRIVER_LED_TOTAL) {
         is31_led led = g_is31_leds[index];
 
-        g_pwm_buffer[led.driver][led.r] = red;
-        g_pwm_buffer[led.driver][led.g] = green;
-        g_pwm_buffer[led.driver][led.b] = blue;
+        g_pwm_buffer[led.driver][led.r]          = red;
+        g_pwm_buffer[led.driver][led.g]          = green;
+        g_pwm_buffer[led.driver][led.b]          = blue;
         g_pwm_buffer_update_required[led.driver] = true;
     }
 }

--- a/drivers/led/issi/is31fl3741.h
+++ b/drivers/led/issi/is31fl3741.h
@@ -45,8 +45,8 @@ void IS31FL3741_set_led_control_register(uint8_t index, bool red, bool green, bo
 // (eg. from a timer interrupt).
 // Call this while idle (in between matrix scans).
 // If the buffer is dirty, it will update the driver with the buffer.
-void IS31FL3741_update_pwm_buffers(uint8_t addr1, uint8_t addr2);
-void IS31FL3741_update_led_control_registers(uint8_t addr1, uint8_t addr2);
+void IS31FL3741_update_pwm_buffers(uint8_t addr, uint8_t index);
+void IS31FL3741_update_led_control_registers(uint8_t addr, uint8_t index);
 void IS31FL3741_set_scaling_registers(const is31_led *pled, uint8_t red, uint8_t green, uint8_t blue);
 
 void IS31FL3741_set_pwm_buffer(const is31_led *pled, uint8_t red, uint8_t green, uint8_t blue);

--- a/keyboards/kbdfans/boop65/rgb/config.h
+++ b/keyboards/kbdfans/boop65/rgb/config.h
@@ -52,12 +52,11 @@
 #    define RGB_MATRIX_MAXIMUM_BRIGHTNESS 200 // limits maximum brightness of LEDs to 200 out of 255. If not defined maximum brightness is set to 255
 #    define RGB_MATRIX_STARTUP_VAL RGB_MATRIX_MAXIMUM_BRIGHTNESS // Sets the default brightness value, if none has been set
 #    define RGB_MATRIX_STARTUP_MODE RGB_MATRIX_CYCLE_ALL
-#    define DRIVER_ADDR_1                 0b0110000
-#    define DRIVER_ADDR_2                 0b0110000
-#    define DRIVER_COUNT                  1
-#    define DRIVER_1_LED_TOTAL            83
-#    define DRIVER_LED_TOTAL              DRIVER_1_LED_TOTAL
-#    define DRIVER_INDICATOR_LED_TOTAL    0
+#    define DRIVER_ADDR_1 0b0110000
+#    define DRIVER_COUNT 1
+#    define DRIVER_1_LED_TOTAL 83
+#    define DRIVER_LED_TOTAL DRIVER_1_LED_TOTAL
+#    define DRIVER_INDICATOR_LED_TOTAL 0
 #endif
 
 #define VIA_EEPROM_LAYOUT_OPTIONS_SIZE 2

--- a/quantum/rgb_matrix/rgb_matrix_drivers.c
+++ b/quantum/rgb_matrix/rgb_matrix_drivers.c
@@ -175,7 +175,7 @@ const rgb_matrix_driver_t rgb_matrix_driver = {
 static void flush(void) {
     IS31FL3741_update_pwm_buffers(DRIVER_ADDR_1, 0);
 #        if defined(DRIVER_ADDR_2) && (DRIVER_ADDR_2 != DRIVER_ADDR_1)  // provides backward compatibility
-    IS31FL3741_update_pwm_buffers(DRIVER_ADDR_1, 1);
+    IS31FL3741_update_pwm_buffers(DRIVER_ADDR_2, 1);
 #        endif
 }
 

--- a/quantum/rgb_matrix/rgb_matrix_drivers.c
+++ b/quantum/rgb_matrix/rgb_matrix_drivers.c
@@ -172,7 +172,12 @@ const rgb_matrix_driver_t rgb_matrix_driver = {
     .set_color_all = IS31FL3737_set_color_all,
 };
 #    else
-static void flush(void) { IS31FL3741_update_pwm_buffers(DRIVER_ADDR_1, DRIVER_ADDR_2); }
+static void flush(void) {
+    IS31FL3741_update_pwm_buffers(DRIVER_ADDR_1, 0);
+#        if defined(DRIVER_ADDR_2) && (DRIVER_ADDR_2 != DRIVER_ADDR_1)  // provides backward compatibility
+    IS31FL3741_update_pwm_buffers(DRIVER_ADDR_1, 1);
+#        endif
+}
 
 const rgb_matrix_driver_t rgb_matrix_driver = {
     .init = init,


### PR DESCRIPTION
## Description

This fixes the IS31fl3741 driver so that it will accept just a single address without failing to compile. 

Also reverts the change to the boop65 board to get it compiling. 


## Types of Changes

- [x] Core
- [x] Bugfix
- [x] Keyboard (addition or update)

## Issues Fixed or Closed by This PR

* Also closes #14443 

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
