### PR TITLE
quantum: led: split out led_update_ports() for customization of led behaviour

### DIFF
--- a/docs/feature_led_indicators.md
+++ b/docs/feature_led_indicators.md
@@ -101,6 +101,13 @@ The `host_keyboard_led_state()` function will report the LED state returned from
 bool caps = host_keyboard_led_state().caps_lock;
 ```
 
+## `led_update_ports()`
+
+This function writes the LED state to the actual hardware. Call it manually
+from your `led_update_*()` callbacks to modify the handling of the standard
+keyboard LEDs.
+For example when repurposing a standard LED indicator as layer indicator.
+
 ## Setting Physical LED State
 
 Some keyboard implementations provide convenient methods for setting the state of the physical LEDs.

--- a/quantum/led.c
+++ b/quantum/led.c
@@ -92,6 +92,14 @@ __attribute__((weak)) bool led_update_user(led_t led_state) {
 __attribute__((weak)) bool led_update_kb(led_t led_state) {
     bool res = led_update_user(led_state);
     if (res) {
+        led_update_ports(led_state);
+    }
+    return res;
+}
+
+/** \brief Write LED state to hardware
+ */
+void led_update_ports(led_t led_state) {
 #if defined(LED_NUM_LOCK_PIN) || defined(LED_CAPS_LOCK_PIN) || defined(LED_SCROLL_LOCK_PIN) || defined(LED_COMPOSE_PIN) || defined(LED_KANA_PIN)
 #    if LED_PIN_ON_STATE == 0
         // invert the whole thing to avoid having to conditionally !led_state.x later
@@ -114,8 +122,6 @@ __attribute__((weak)) bool led_update_kb(led_t led_state) {
         writePin(LED_KANA_PIN, led_state.kana);
 #    endif
 #endif
-    }
-    return res;
 }
 
 /** \brief Initialise any LED related hardware and/or state

--- a/quantum/led.c
+++ b/quantum/led.c
@@ -99,7 +99,7 @@ __attribute__((weak)) bool led_update_kb(led_t led_state) {
 
 /** \brief Write LED state to hardware
  */
-void led_update_ports(led_t led_state) {
+__attribute__((weak)) void led_update_ports(led_t led_state) {
 #if LED_PIN_ON_STATE == 0
     // invert the whole thing to avoid having to conditionally !led_state.x later
     led_state.raw = ~led_state.raw;

--- a/quantum/led.c
+++ b/quantum/led.c
@@ -100,27 +100,25 @@ __attribute__((weak)) bool led_update_kb(led_t led_state) {
 /** \brief Write LED state to hardware
  */
 void led_update_ports(led_t led_state) {
-#if defined(LED_NUM_LOCK_PIN) || defined(LED_CAPS_LOCK_PIN) || defined(LED_SCROLL_LOCK_PIN) || defined(LED_COMPOSE_PIN) || defined(LED_KANA_PIN)
-#    if LED_PIN_ON_STATE == 0
-        // invert the whole thing to avoid having to conditionally !led_state.x later
-        led_state.raw = ~led_state.raw;
-#    endif
+#if LED_PIN_ON_STATE == 0
+    // invert the whole thing to avoid having to conditionally !led_state.x later
+    led_state.raw = ~led_state.raw;
+#endif
 
-#    ifdef LED_NUM_LOCK_PIN
-        writePin(LED_NUM_LOCK_PIN, led_state.num_lock);
-#    endif
-#    ifdef LED_CAPS_LOCK_PIN
-        writePin(LED_CAPS_LOCK_PIN, led_state.caps_lock);
-#    endif
-#    ifdef LED_SCROLL_LOCK_PIN
-        writePin(LED_SCROLL_LOCK_PIN, led_state.scroll_lock);
-#    endif
-#    ifdef LED_COMPOSE_PIN
-        writePin(LED_COMPOSE_PIN, led_state.compose);
-#    endif
-#    ifdef LED_KANA_PIN
-        writePin(LED_KANA_PIN, led_state.kana);
-#    endif
+#ifdef LED_NUM_LOCK_PIN
+    writePin(LED_NUM_LOCK_PIN, led_state.num_lock);
+#endif
+#ifdef LED_CAPS_LOCK_PIN
+    writePin(LED_CAPS_LOCK_PIN, led_state.caps_lock);
+#endif
+#ifdef LED_SCROLL_LOCK_PIN
+    writePin(LED_SCROLL_LOCK_PIN, led_state.scroll_lock);
+#endif
+#ifdef LED_COMPOSE_PIN
+    writePin(LED_COMPOSE_PIN, led_state.compose);
+#endif
+#ifdef LED_KANA_PIN
+    writePin(LED_KANA_PIN, led_state.kana);
 #endif
 }
 

--- a/quantum/led.h
+++ b/quantum/led.h
@@ -60,6 +60,7 @@ void led_set_user(uint8_t usb_led);
 void led_set_kb(uint8_t usb_led);
 bool led_update_user(led_t led_state);
 bool led_update_kb(led_t led_state);
+void led_update_ports(led_t led_state);
 
 uint32_t last_led_activity_time(void);    // Timestamp of the LED activity
 uint32_t last_led_activity_elapsed(void); // Number of milliseconds since the last LED activity


### PR DESCRIPTION
Allow implementors of led_update_user() to modify the current led_state
but still use the default functionality of led_update_kb().
This can be used to reuse one of the standard LEDs for a different
usecase without having to reimplement led_update_kb().

Fixes #13272

This is still missing updates to the docs and keymaps.
Will do those after a first round of feedback.

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* #13272

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
