### PR TITLE
compiledb: query include paths from gcc directly.

### DIFF
--- a/lib/python/qmk/cli/generate/compilation_database.py
+++ b/lib/python/qmk/cli/generate/compilation_database.py
@@ -1,7 +1,6 @@
 """Creates a compilation database for the given keyboard build.
 """
 
-import itertools
 import json
 import os
 import re

--- a/lib/python/qmk/cli/generate/compilation_database.py
+++ b/lib/python/qmk/cli/generate/compilation_database.py
@@ -65,7 +65,8 @@ def parse_make_n(f: Iterator[str]) -> List[Dict[str, str]]:
                 # we have a hit!
                 this_cmd = m.group(1)
                 args = shlex.split(this_cmd)
-                args += ['-I%s' % s for s in system_libs(args[0])]
+                for s in system_libs(args[0]):
+                    args += ['-isystem', '%s' % s]
                 new_cmd = ' '.join(shlex.quote(s) for s in args if s != '-mno-thumb-interwork')
                 records.append({"directory": str(QMK_FIRMWARE.resolve()), "command": new_cmd, "file": this_file})
                 state = 'start'

--- a/lib/python/qmk/cli/generate/compilation_database.py
+++ b/lib/python/qmk/cli/generate/compilation_database.py
@@ -27,7 +27,7 @@ def system_libs(binary: str) -> List[Path]:
 
     # Actually query xxxxxx-gcc to find its include paths.
     if binary.endswith("gcc") or binary.endswith("g++"):
-        result = cli.run([binary, '-E', '-Wp,-v',  '-'], capture_output=True, check=True, input='\n')
+        result = cli.run([binary, '-E', '-Wp,-v', '-'], capture_output=True, check=True, input='\n')
         paths = []
         for line in result.stderr.splitlines():
             if line.startswith(" "):

--- a/lib/python/qmk/cli/generate/compilation_database.py
+++ b/lib/python/qmk/cli/generate/compilation_database.py
@@ -24,6 +24,16 @@ def system_libs(binary: str) -> List[Path]:
     """
     cli.log.debug("searching for system library directory for binary: %s", binary)
     bin_path = shutil.which(binary)
+
+    # Actually query xxxxxx-gcc to find its include paths.
+    if binary.endswith("gcc") or binary.endswith("g++"):
+        result = cli.run([binary, '-E', '-Wp,-v',  '-'], capture_output=True, check=True, input='\n')
+        paths = []
+        for line in result.stderr.splitlines():
+            if line.startswith(" "):
+                paths.append(Path(line.strip()).resolve())
+        return paths
+
     return list(Path(bin_path).resolve().parent.parent.glob("*/include")) if bin_path else []
 
 


### PR DESCRIPTION
## Description

Modifies the logic of the compiledb generator to actually request from gcc the list of include directories it's going to use.
The original logic was injecting mingw32 directories for me -- this correctly handles the generation based on the toolchain in question.

Tested on both AVR and ARM.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
