### PR TITLE
[Keymap] Fix link error for helix/rev3_5rows:five_rows

### DIFF
--- a/keyboards/helix/rev3_5rows/keymaps/five_rows/oled_display.c
+++ b/keyboards/helix/rev3_5rows/keymaps/five_rows/oled_display.c
@@ -25,6 +25,10 @@
 #include <string.h>
 #include "layer_number.h"
 
+char *sprints(char *buf, char *src);
+char *sprintd(char *buf, char *leadstr, int data);
+char *sprint2d(char *buf, char *leadstr, int data);
+
 extern int current_default_layer;
 
 void init_helix_oled(void) {
@@ -63,55 +67,6 @@ void matrix_update(struct CharacterMatrix *dest,
     }
 }
 #    endif
-
-static char *sprint_decimal(char *buf, int data) {
-    if (data > 9) {
-        buf = sprint_decimal(buf, data/10);
-    }
-    *buf++ = "0123456789"[data%10];
-    *buf = '\0';
-    return buf;
-}
-
-static char *sprint_hex(char *buf, uint32_t data) {
-    if (data > 0xf) {
-        buf = sprint_hex(buf, data/0x10);
-    }
-    *buf++ = "0123456789abcdef"[data & 0xf];
-    *buf = '\0';
-    return buf;
-}
-
-char *sprints(char *buf, char *src) {
-    while (*src) {
-        *buf++ = *src++;
-    }
-    *buf = '\0';
-    return buf;
-}
-
-char *sprintx(char *buf, char *leadstr, uint32_t data) {
-    buf = sprints(buf, leadstr);
-    buf = sprint_hex(buf, data);
-    return buf;
-}
-
-char *sprintd(char *buf, char *leadstr, int data) {
-    buf = sprints(buf, leadstr);
-    buf = sprint_decimal(buf, data);
-    return buf;
-}
-
-char *sprint2d(char *buf, char *leadstr, int data) {
-    buf = sprints(buf, leadstr);
-    if (data > 99) {
-        return sprint_decimal(buf, data);
-    }
-    if (data < 10) {
-        *buf++ = ' ';
-    }
-    return sprint_decimal(buf, data);
-}
 
 #    ifdef SSD1306OLED
 static void render_logo(struct CharacterMatrix *matrix) {


### PR DESCRIPTION
## Description

This is a tentative quick fix.
I was adding the same functions for both #14426 and #14427 and they were in conflict.


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
