### PR TITLE
Add i2c defaults for Convert to Proton C

### DIFF
--- a/platforms/chibios/boards/QMK_PROTON_C/configs/config.h
+++ b/platforms/chibios/boards/QMK_PROTON_C/configs/config.h
@@ -19,9 +19,11 @@
 #    define EARLY_INIT_PERFORM_BOOTLOADER_JUMP TRUE
 #endif
 
-#ifndef I2C1_SDA_PIN
-#    define I2C1_SDA_PIN D1
-#endif
-#ifndef I2C1_SCL_PIN
-#    define I2C1_SCL_PIN D0
+#ifdef CONVERT_TO_PROTON_C
+#    ifndef I2C1_SDA_PIN
+#        define I2C1_SDA_PIN D1
+#    endif
+#    ifndef I2C1_SCL_PIN
+#        define I2C1_SCL_PIN D0
+#    endif
 #endif

--- a/platforms/chibios/boards/QMK_PROTON_C/configs/config.h
+++ b/platforms/chibios/boards/QMK_PROTON_C/configs/config.h
@@ -18,3 +18,10 @@
 #ifndef EARLY_INIT_PERFORM_BOOTLOADER_JUMP
 #    define EARLY_INIT_PERFORM_BOOTLOADER_JUMP TRUE
 #endif
+
+#ifndef I2C1_SDA_PIN
+#    define I2C1_SDA_PIN D1
+#endif
+#ifndef I2C1_SCL_PIN
+#    define I2C1_SCL_PIN D0
+#endif


### PR DESCRIPTION
## Description

I2C config was updated for ChibiOS, and it breaks the CTPC compatibility.

This adds a default define that is override-able, but should work with the rest of the default config. 

I'm not sure this is the best way to handle this, though. 

## Types of Changes

- [x] Core
- [x] Enhancement/optimization


## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
