### PR TITLE
[Keyboard] Move Moonlander off 'Proton C' board

### DIFF
--- a/keyboards/moonlander/halconf.h
+++ b/keyboards/moonlander/halconf.h
@@ -1,0 +1,22 @@
+/* Copyright 2021 QMK
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#define HAL_USE_I2C TRUE
+#define HAL_USE_GPT TRUE
+#define HAL_USE_DAC TRUE
+
+#include_next <halconf.h>

--- a/keyboards/moonlander/mcuconf.h
+++ b/keyboards/moonlander/mcuconf.h
@@ -1,0 +1,39 @@
+/* Copyright 2021 QMK
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include_next "mcuconf.h"
+
+// for i2c expander, and ISSI
+#undef STM32_I2C_USE_I2C1
+#define STM32_I2C_USE_I2C1 TRUE
+
+// for future hardwar
+#undef STM32_I2C_USE_I2C2
+#define STM32_I2C_USE_I2C2 TRUE
+
+// for audio
+#undef STM32_DAC_USE_DAC1_CH1
+#define STM32_DAC_USE_DAC1_CH1 TRUE
+#undef STM32_DAC_USE_DAC1_CH2
+#define STM32_DAC_USE_DAC1_CH2 TRUE
+#undef STM32_GPT_USE_TIM6
+#define STM32_GPT_USE_TIM6 TRUE
+#undef STM32_GPT_USE_TIM7
+#define STM32_GPT_USE_TIM7 TRUE
+#undef STM32_GPT_USE_TIM8
+#define STM32_GPT_USE_TIM8 TRUE

--- a/keyboards/moonlander/rules.mk
+++ b/keyboards/moonlander/rules.mk
@@ -1,6 +1,5 @@
 # MCU name
 MCU = STM32F303
-BOARD = QMK_PROTON_C
 
 # Bootloader selection
 BOOTLOADER = stm32-dfu
@@ -8,7 +7,7 @@ BOOTLOADER = stm32-dfu
 # Build Options
 #   change yes to no to disable
 #
-BOOTMAGIC_ENABLE = lite     # Enable Bootmagic Lite
+BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
 MOUSEKEY_ENABLE = yes       # Mouse keys
 EXTRAKEY_ENABLE = yes       # Audio control and System control
 CONSOLE_ENABLE = yes        # Console for debug


### PR DESCRIPTION

## Description

The Moonlander does not use a Proton C, and shouldn't use the configuration from it. 

This removes the board type, and manually specifies the hardware config, properly.  No functionality change has occurred. 

## Types of Changes

- [x] Bugfix
- [x] Keyboard (addition or update)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
