### PR TITLE
[Keyboard] Move Planck EZ off 'Proton C' board

### DIFF
--- a/keyboards/planck/ez/halconf.h
+++ b/keyboards/planck/ez/halconf.h
@@ -1,0 +1,23 @@
+/* Copyright 2021 QMK
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#define HAL_USE_I2C TRUE
+#define HAL_USE_GPT TRUE
+#define HAL_USE_DAC TRUE
+#define HAL_USE_PWM TRUE
+
+#include_next <halconf.h>

--- a/keyboards/planck/ez/mcuconf.h
+++ b/keyboards/planck/ez/mcuconf.h
@@ -1,0 +1,41 @@
+/* Copyright 2021 QMK
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include_next "mcuconf.h"
+
+// for i2c expander, and ISSI
+#undef STM32_I2C_USE_I2C1
+#define STM32_I2C_USE_I2C1 TRUE
+
+// for indicator LEDs
+#undef STM32_PWM_USE_TIM3
+#define STM32_PWM_USE_TIM3 TRUE
+#undef STM32_PWM_USE_TIM4
+#define STM32_PWM_USE_TIM4 TRUE
+
+// for audio
+#undef STM32_DAC_USE_DAC1_CH1
+#define STM32_DAC_USE_DAC1_CH1 TRUE
+#undef STM32_DAC_USE_DAC1_CH2
+#define STM32_DAC_USE_DAC1_CH2 TRUE
+#undef STM32_GPT_USE_TIM6
+#define STM32_GPT_USE_TIM6 TRUE
+#undef STM32_GPT_USE_TIM7
+#define STM32_GPT_USE_TIM7 TRUE
+#undef STM32_GPT_USE_TIM8
+#define STM32_GPT_USE_TIM8 TRUE

--- a/keyboards/planck/ez/rules.mk
+++ b/keyboards/planck/ez/rules.mk
@@ -1,6 +1,5 @@
 # MCU name
 MCU = STM32F303
-BOARD = QMK_PROTON_C
 
 # Bootloader selection
 BOOTLOADER = stm32-dfu
@@ -9,23 +8,25 @@ BOOTLOADER = stm32-dfu
 #   change to "no" to disable the options, or define them in the Makefile in
 #   the appropriate keymap folder that will get included automatically
 #
-BOOTMAGIC_ENABLE = lite     # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = yes      # Mouse keys
+BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
+MOUSEKEY_ENABLE = yes       # Mouse keys
 EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = yes         # Console for debug
+CONSOLE_ENABLE = yes        # Console for debug
 COMMAND_ENABLE = yes       # Commands for debug and configuration
-NKRO_ENABLE = yes            # Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+NKRO_ENABLE = yes           # Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
 BACKLIGHT_ENABLE = no      # Enable keyboard backlight functionality
-AUDIO_ENABLE = yes           # Audio output on port C6
-UNICODE_ENABLE = no         # Unicode
+AUDIO_ENABLE = yes          # Audio output
 RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight.
 
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
 SLEEP_LED_ENABLE = no    # Breathing sleep LED during USB suspend
-#SLEEP_LED_ENABLE = yes  # Breathing sleep LED during USB suspend
 
 ENCODER_ENABLE = yes
 RGB_MATRIX_DRIVER = IS31FL3737
 
 LAYOUTS = ortho_4x12 planck_mit
 LAYOUTS_HAS_RGB = no
+
+RGB_MATRIX_SUPPORTED = yes
+RGBLIGHT_SUPPORTED = no
+BAKCLIGHT_SUPPORTED = no


### PR DESCRIPTION
## Description

Moves the Planck Z off of the Proton C board config, and onto the STM32F303 board definitions, since this doesn't actually use a proton C.

Functionality is not changed. 

## Types of Changes

- [x] Bugfix
- [x] Keyboard (addition or update)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
