### PR TITLE
cKeys theDora Refactor

### DIFF
--- a/keyboards/ckeys/thedora/info.json
+++ b/keyboards/ckeys/thedora/info.json
@@ -3,32 +3,32 @@
   "url": "https://ckeys.org/slides/exboard",
   "maintainer": "brandenbyers",
   "layouts": {
-    "LAYOUT_ortho_4x5": {
+    "LAYOUT": {
       "layout": [
         {"label":"k00", "x":1, "y":0},
         {"label":"k01", "x":2, "y":0},
         {"label":"k02", "x":3, "y":0},
         {"label":"k03", "x":4, "y":0},
         {"label":"k04", "x":5, "y":0},
+
+        {"label":"k10", "x":1, "y":1},
+        {"label":"k11", "x":2, "y":1},
+        {"label":"k12", "x":3, "y":1},
+        {"label":"k13", "x":4, "y":1},
+        {"label":"k14", "x":5, "y":1},
+
+        {"label":"k20", "x":1, "y":2},
+        {"label":"k21", "x":2, "y":2},
+        {"label":"k22", "x":3, "y":2},
+        {"label":"k23", "x":4, "y":2},
+        {"label":"k24", "x":5, "y":2},
+
         {"label":"k05 (Rotary Push)", "x":0, "y":3},
-
-        {"label":"k06", "x":1, "y":1},
-        {"label":"k07", "x":2, "y":1},
-        {"label":"k08", "x":3, "y":1},
-        {"label":"k09", "x":4, "y":1},
-        {"label":"k10", "x":5, "y":1},
-
-        {"label":"k11", "x":1, "y":2},
-        {"label":"k12", "x":2, "y":2},
-        {"label":"k13", "x":3, "y":2},
-        {"label":"k14", "x":4, "y":2},
-        {"label":"k15", "x":5, "y":2},
-
-        {"label":"k16", "x":1, "y":3},
-        {"label":"k17", "x":2, "y":3},
-        {"label":"k18", "x":3, "y":3},
-        {"label":"k19", "x":4, "y":3},
-        {"label":"k20", "x":5, "y":3}
+        {"label":"k30", "x":1, "y":3},
+        {"label":"k31", "x":2, "y":3},
+        {"label":"k32", "x":3, "y":3},
+        {"label":"k33", "x":4, "y":3},
+        {"label":"k34", "x":5, "y":3}
       ]
     }
   }

--- a/keyboards/ckeys/thedora/keymaps/default/config.h
+++ b/keyboards/ckeys/thedora/keymaps/default/config.h
@@ -1,3 +1,0 @@
-#pragma once
-
-// Add overrides here

--- a/keyboards/ckeys/thedora/keymaps/default/keymap.c
+++ b/keyboards/ckeys/thedora/keymaps/default/keymap.c
@@ -29,10 +29,10 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 // └─────────┴─────────┴─────────┴─────────┴─────────┴─────────┘
 
   [_BASE] = LAYOUT(
-    KC_KP_7, KC_KP_8,   KC_KP_9,     KC_PSLS, MO(_ADMIN), MU_TOG,
-    KC_KP_4, KC_KP_5,   KC_KP_6,     KC_PAST, TG(_MOUSE),
-    KC_KP_1, KC_KP_2,   KC_KP_3,     KC_PMNS, TG(_MIDI),
-    KC_KP_0, KC_KP_DOT, KC_KP_EQUAL, KC_PPLS, MO(_MUSIC)
+             KC_KP_7, KC_KP_8,   KC_KP_9,     KC_PSLS, MO(_ADMIN),
+             KC_KP_4, KC_KP_5,   KC_KP_6,     KC_PAST, TG(_MOUSE),
+             KC_KP_1, KC_KP_2,   KC_KP_3,     KC_PMNS, TG(_MIDI),
+     MU_TOG, KC_KP_0, KC_KP_DOT, KC_KP_EQUAL, KC_PPLS, MO(_MUSIC)
   ),
 
 // MUSIC LAYER
@@ -55,10 +55,10 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  //└─────────┴─────────┴─────────┴─────────┴─────────┴─────────┘
 
   [_MUSIC] = LAYOUT(
-    _______, _______, _______, _______, _______, _______,
-    _______, _______, _______, _______, _______,
-    _______, _______, _______, _______, MU_MOD,
-    KC_LCTL, KC_LALT, _______, KC_LGUI, _______
+             _______, _______, _______, _______, _______,
+             _______, _______, _______, _______, _______,
+             _______, _______, _______, _______, MU_MOD,
+    _______, KC_LCTL, KC_LALT, _______, KC_LGUI, _______
   ),
 
 // MIDI LAYER
@@ -81,10 +81,10 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 // └─────────┴─────────┴─────────┴─────────┴─────────┴─────────┘
 
   [_MIDI] = LAYOUT(
-    MI_Ds_3, MI_E_3,  MI_F_3, MI_Fs_3, MI_G_3, _______,
-    MI_As_2, MI_B_2,  MI_C_3, MI_Cs_3, MI_D_3,
-    MI_F_2,  MI_Fs_2, MI_G_2, MI_Gs_2, TG(_MIDI),
-    MI_C_2,  MI_Cs_2, MI_D_2, MI_Ds_2, MI_E_2
+             MI_Ds_3, MI_E_3,  MI_F_3, MI_Fs_3, MI_G_3,
+             MI_As_2, MI_B_2,  MI_C_3, MI_Cs_3, MI_D_3,
+             MI_F_2,  MI_Fs_2, MI_G_2, MI_Gs_2, TG(_MIDI),
+    _______, MI_C_2,  MI_Cs_2, MI_D_2, MI_Ds_2, MI_E_2
   ),
 
 // MOUSE LAYER
@@ -107,10 +107,10 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 // └─────────┴─────────┴─────────┴─────────┴─────────┴─────────┘
 
   [_MOUSE] = LAYOUT(
-    KC_MS_BTN5, _______,       KC_MS_WH_UP,   _______,        _______,    _______,
-    _______,    KC_MS_BTN1,    KC_MS_UP,      KC_MS_BTN2,     TG(_MOUSE),
-    KC_MS_BTN4, KC_MS_LEFT,    KC_MS_DOWN,    KC_MS_RIGHT,    _______,
-    KC_MS_BTN3, KC_MS_WH_LEFT, KC_MS_WH_DOWN, KC_MS_WH_RIGHT, _______
+             KC_MS_BTN5, _______,       KC_MS_WH_UP,   _______,        _______,
+             _______,    KC_MS_BTN1,    KC_MS_UP,      KC_MS_BTN2,     TG(_MOUSE),
+             KC_MS_BTN4, KC_MS_LEFT,    KC_MS_DOWN,    KC_MS_RIGHT,    _______,
+    _______, KC_MS_BTN3, KC_MS_WH_LEFT, KC_MS_WH_DOWN, KC_MS_WH_RIGHT, _______
   ),
 
 // ADMIN LAYER
@@ -133,10 +133,10 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 // └─────────┴─────────┴─────────┴─────────┴─────────┴─────────┘
 
   [_ADMIN] = LAYOUT(
-    RESET,   _______, _______, _______, TG(_ADMIN), _______,
-    _______, _______, _______, _______, _______,
-    _______, _______, _______, _______, _______,
-    _______, _______, _______, _______, _______
+             RESET,   _______, _______, _______, TG(_ADMIN),
+             _______, _______, _______, _______, _______,
+             _______, _______, _______, _______, _______,
+    _______, _______, _______, _______, _______, _______
   ),
 };
 

--- a/keyboards/ckeys/thedora/keymaps/default/keymap.c
+++ b/keyboards/ckeys/thedora/keymaps/default/keymap.c
@@ -1,156 +1,172 @@
+/* Copyright 2019 Branden Byers (@brandenbyers)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include QMK_KEYBOARD_H
 
 enum layers {
-  _BASE,                // base layer
-  _MUSIC,               // music mode
-  _MIDI,                // midi mode
-  _MOUSE,               // mouse keys
-  _ADMIN                // admin duties
+    _BASE,   // base layer
+    _MUSIC,  // music mode
+    _MIDI,   // midi mode
+    _MOUSE,  // mouse keys
+    _ADMIN   // admin duties
 };
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
-//           ┌─────────┬─────────┬─────────┬─────────┬─────────┐
-//           │         │         │         │         │         │
-//           │    7    │    8    │    9    │    /    │  ADMIN  │
-//  ROTORY   │         │         │         │         │         │
-//  RIGHT:   ├─────────┼─────────┼─────────┼─────────┼─────────┤
-//  VOL UP   │         │         │         │         │         │
-//           │    4    │    5    │    6    │    *    │  MOUSE  │
-//  ROTORY   │         │         │         │         │         │
-//  LEFT:    ├─────────┼─────────┼─────────┼─────────┼─────────┤
-//  VOL DOWN │         │         │         │         │         │
-//           │    1    │    2    │    3    │    -    │  MIDI   │
-//           │         │         │         │         │         │
-// ┌─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
-// │  TOGGLE │         │         │         │         │         │
-// │  MUSIC  │    0    │    .    │    =    │    +    │  MUSIC  │
-// │         │         │         │         │         │         │
-// └─────────┴─────────┴─────────┴─────────┴─────────┴─────────┘
+    //           ┌─────────┬─────────┬─────────┬─────────┬─────────┐
+    //           │         │         │         │         │         │
+    //           │    7    │    8    │    9    │    /    │  ADMIN  │
+    //  ROTARY   │         │         │         │         │         │
+    //  RIGHT:   ├─────────┼─────────┼─────────┼─────────┼─────────┤
+    //  PAGE DOWN│         │         │         │         │         │
+    //           │    4    │    5    │    6    │    *    │  MOUSE  │
+    //  ROTARY   │         │         │         │         │         │
+    //  LEFT:    ├─────────┼─────────┼─────────┼─────────┼─────────┤
+    //  PAGE UP  │         │         │         │         │         │
+    //           │    1    │    2    │    3    │    -    │  MIDI   │
+    //           │         │         │         │         │         │
+    // ┌─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
+    // │  TOGGLE │         │         │         │         │         │
+    // │  MUSIC  │    0    │    .    │    =    │    +    │  MUSIC  │
+    // │         │         │         │         │         │         │
+    // └─────────┴─────────┴─────────┴─────────┴─────────┴─────────┘
 
-  [_BASE] = LAYOUT(
-             KC_KP_7, KC_KP_8,   KC_KP_9,     KC_PSLS, MO(_ADMIN),
-             KC_KP_4, KC_KP_5,   KC_KP_6,     KC_PAST, TG(_MOUSE),
-             KC_KP_1, KC_KP_2,   KC_KP_3,     KC_PMNS, TG(_MIDI),
-     MU_TOG, KC_KP_0, KC_KP_DOT, KC_KP_EQUAL, KC_PPLS, MO(_MUSIC)
-  ),
+    [_BASE] = LAYOUT(
+                KC_P7,    KC_P8  , KC_P9  , KC_PSLS, MO(_ADMIN),
+                KC_P4,    KC_P5  , KC_P6  , KC_PAST, TG(_MOUSE),
+                KC_P1,    KC_P2  , KC_P3  , KC_PMNS, TG(_MIDI),
+        MU_TOG, KC_P0,    KC_PDOT, KC_PEQL, KC_PPLS, MO(_MUSIC)
+    ),
 
-// MUSIC LAYER
- //          ┌─────────┬─────────┬─────────┬─────────┬─────────┐
- //          │         │         │         │         │         │
- //          │         │         │         │         │         │
- // ROTORY   │         │         │         │         │         │
- // RIGHT:   ├─────────┼─────────┼─────────┼─────────┼─────────┤
- // PAGE UP  │         │         │         │         │         │
- //          │         │         │         │         │         │
- // ROTORY   │         │         │         │         │         │
- // LEFT:    ├─────────┼─────────┼─────────┼─────────┼─────────┤
- // PAGE DOWN│         │         │         │         │         │
- //          │         │         │         │  MODE   │         │
- //          │         │         │         │         │         │
- //┌─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
- //│         │         │         │         │         │         │
- //│         │ RECORD  │  STOP   │         │  PLAY   │         │
- //│         │         │         │         │         │         │
- //└─────────┴─────────┴─────────┴─────────┴─────────┴─────────┘
+    // MUSIC LAYER
+    //           ┌─────────┬─────────┬─────────┬─────────┬─────────┐
+    //           │         │         │         │         │         │
+    //           │         │         │         │         │         │
+    //  ROTARY   │         │         │         │         │         │
+    //  RIGHT:   ├─────────┼─────────┼─────────┼─────────┼─────────┤
+    //  PAGE DOWN│         │         │         │         │         │
+    //           │         │         │         │         │         │
+    //  ROTARY   │         │         │         │         │         │
+    //  LEFT:    ├─────────┼─────────┼─────────┼─────────┼─────────┤
+    //  PAGE UP  │         │         │         │         │         │
+    //           │         │         │         │  MODE   │         │
+    //           │         │         │         │         │         │
+    // ┌─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
+    // │         │         │         │         │         │         │
+    // │         │ RECORD  │  STOP   │         │  PLAY   │         │
+    // │         │         │         │         │         │         │
+    // └─────────┴─────────┴─────────┴─────────┴─────────┴─────────┘
 
-  [_MUSIC] = LAYOUT(
-             _______, _______, _______, _______, _______,
-             _______, _______, _______, _______, _______,
-             _______, _______, _______, _______, MU_MOD,
-    _______, KC_LCTL, KC_LALT, _______, KC_LGUI, _______
-  ),
+    [_MUSIC] = LAYOUT(
+                 _______, _______, _______, _______, _______,
+                 _______, _______, _______, _______, _______,
+                 _______, _______, _______, _______, MU_MOD,
+        _______, KC_LCTL, KC_LALT, _______, KC_LGUI, _______
+    ),
 
-// MIDI LAYER
-//           ┌─────────┬─────────┬─────────┬─────────┬─────────┐
-//           │         │         │         │         │         │
-//           │   D♯    │    E    │    F    │   F♯    │    G    │
-//  ROTORY   │         │         │         │         │         │
-//  RIGHT:   ├─────────┼─────────┼─────────┼─────────┼─────────┤
-//  PAGE UP  │         │         │         │         │         │
-//           │   A♯    │    B    │    C    │   C♯    │    D    │
-//  ROTORY   │         │         │         │         │         │
-//  LEFT:    ├─────────┼─────────┼─────────┼─────────┼─────────┤
-//  PAGE DOWN│         │         │         │         │         │
-//           │    F    │   F♯    │    G    │   G♯    │    A    │
-//           │         │         │         │         │         │
-// ┌─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
-// │         │         │         │         │         │         │
-// │         │    C    │   C♯    │    D    │   D♯    │    E    │
-// │         │         │         │         │         │         │
-// └─────────┴─────────┴─────────┴─────────┴─────────┴─────────┘
+    // MIDI LAYER
+    //           ┌─────────┬─────────┬─────────┬─────────┬─────────┐
+    //           │         │         │         │         │         │
+    //           │   D♯    │    E    │    F    │   F♯    │    G    │
+    //  ROTARY   │         │         │         │         │         │
+    //  RIGHT:   ├─────────┼─────────┼─────────┼─────────┼─────────┤
+    //  PAGE DOWN│         │         │         │         │         │
+    //           │   A♯    │    B    │    C    │   C♯    │    D    │
+    //  ROTARY   │         │         │         │         │         │
+    //  LEFT:    ├─────────┼─────────┼─────────┼─────────┼─────────┤
+    //  PAGE UP  │         │         │         │         │         │
+    //           │    F    │   F♯    │    G    │   G♯    │    A    │
+    //           │         │         │         │         │         │
+    // ┌─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
+    // │         │         │         │         │         │         │
+    // │         │    C    │   C♯    │    D    │   D♯    │    E    │
+    // │         │         │         │         │         │         │
+    // └─────────┴─────────┴─────────┴─────────┴─────────┴─────────┘
 
-  [_MIDI] = LAYOUT(
-             MI_Ds_3, MI_E_3,  MI_F_3, MI_Fs_3, MI_G_3,
-             MI_As_2, MI_B_2,  MI_C_3, MI_Cs_3, MI_D_3,
-             MI_F_2,  MI_Fs_2, MI_G_2, MI_Gs_2, TG(_MIDI),
-    _______, MI_C_2,  MI_Cs_2, MI_D_2, MI_Ds_2, MI_E_2
-  ),
+    [_MIDI] = LAYOUT(
+                 MI_Ds_3, MI_E_3,  MI_F_3,  MI_Fs_3, MI_G_3,
+                 MI_As_2, MI_B_2,  MI_C_3,  MI_Cs_3, MI_D_3,
+                 MI_F_2,  MI_Fs_2, MI_G_2,  MI_Gs_2, TG(_MIDI),
+        _______, MI_C_2,  MI_Cs_2, MI_D_2,  MI_Ds_2, MI_E_2
+    ),
 
-// MOUSE LAYER
-//           ┌─────────┬─────────┬─────────┬─────────┬─────────┐
-//           │         │         │         │         │         │
-//           │  BTN 5  │         │  WHEEL  │         │         │
-//  ROTORY   │         │         │   UP    │         │         │
-//  RIGHT:   ├─────────┼─────────┼─────────┼─────────┼─────────┤
-//  PAGE DOWN│         │         │         │         │         │
-//           │         │  LEFT   │  MOUSE  │  RIGHT  │         │
-//  ROTORY   │         │  CLICK  │   UP    │  CLICK  │         │
-//  LEFT:    ├─────────┼─────────┼─────────┼─────────┼─────────┤
-//  PAGE UP  │         │         │         │         │         │
-//           │  BTN 4  │  MOUSE  │  MOUSE  │  MOUSE  │         │
-//           │         │  LEFT   │  DOWN   │  RIGHT  │         │
-// ┌─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
-// │         │         │         │         │         │         │
-// │         │  BTN 3  │  WHEEL  │  WHEEL  │  WHEEL  │         │
-// │         │         │  LEFT   │  DOWN   │  RIGHT  │         │
-// └─────────┴─────────┴─────────┴─────────┴─────────┴─────────┘
+    // MOUSE LAYER
+    //           ┌─────────┬─────────┬─────────┬─────────┬─────────┐
+    //           │         │         │         │         │         │
+    //           │  BTN 5  │         │  WHEEL  │         │         │
+    //  ROTARY   │         │         │   UP    │         │         │
+    //  RIGHT:   ├─────────┼─────────┼─────────┼─────────┼─────────┤
+    //  PAGE DOWN│         │         │         │         │         │
+    //           │         │  LEFT   │  MOUSE  │  RIGHT  │         │
+    //  ROTARY   │         │  CLICK  │   UP    │  CLICK  │         │
+    //  LEFT:    ├─────────┼─────────┼─────────┼─────────┼─────────┤
+    //  PAGE UP  │         │         │         │         │         │
+    //           │  BTN 4  │  MOUSE  │  MOUSE  │  MOUSE  │         │
+    //           │         │  LEFT   │  DOWN   │  RIGHT  │         │
+    // ┌─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
+    // │         │         │         │         │         │         │
+    // │         │  BTN 3  │  WHEEL  │  WHEEL  │  WHEEL  │         │
+    // │         │         │  LEFT   │  DOWN   │  RIGHT  │         │
+    // └─────────┴─────────┴─────────┴─────────┴─────────┴─────────┘
 
-  [_MOUSE] = LAYOUT(
-             KC_MS_BTN5, _______,       KC_MS_WH_UP,   _______,        _______,
-             _______,    KC_MS_BTN1,    KC_MS_UP,      KC_MS_BTN2,     TG(_MOUSE),
-             KC_MS_BTN4, KC_MS_LEFT,    KC_MS_DOWN,    KC_MS_RIGHT,    _______,
-    _______, KC_MS_BTN3, KC_MS_WH_LEFT, KC_MS_WH_DOWN, KC_MS_WH_RIGHT, _______
-  ),
+    [_MOUSE] = LAYOUT(
+                 KC_BTN5, _______, KC_WH_U, _______, _______,
+                 _______, KC_BTN1, KC_MS_U, KC_BTN2, TG(_MOUSE),
+                 KC_BTN4, KC_MS_L, KC_MS_D, KC_MS_R, _______,
+        _______, KC_BTN3, KC_WH_L, KC_WH_D, KC_WH_R, _______
+    ),
 
-// ADMIN LAYER
-//           ┌─────────┬─────────┬─────────┬─────────┬─────────┐
-//           │         │         │         │         │         │
-//           │  RESET  │         │         │         │         │
-//  ROTORY   │         │         │         │         │         │
-//  RIGHT:   ├─────────┼─────────┼─────────┼─────────┼─────────┤
-//  PAGE UP  │         │         │         │         │         │
-//           │    4    │    5    │    6    │    *    │         │
-//  ROTORY   │         │         │         │         │         │
-//  LEFT:    ├─────────┼─────────┼─────────┼─────────┼─────────┤
-//  PAGE DOWN│         │         │         │         │         │
-//           │    1    │    2    │    3    │         │         │
-//           │         │         │         │         │         │
-// ┌─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
-// │         │         │         │         │         │         │
-// │         │    0    │    .    │    =    │         │         │
-// │         │         │         │         │         │         │
-// └─────────┴─────────┴─────────┴─────────┴─────────┴─────────┘
+    // ADMIN LAYER
+    //           ┌─────────┬─────────┬─────────┬─────────┬─────────┐
+    //           │         │         │         │         │         │
+    //           │  RESET  │         │         │         │         │
+    //  ROTARY   │         │         │         │         │         │
+    //  RIGHT:   ├─────────┼─────────┼─────────┼─────────┼─────────┤
+    //  PAGE DOWN│         │         │         │         │         │
+    //           │    4    │    5    │    6    │    *    │         │
+    //  ROTARY   │         │         │         │         │         │
+    //  LEFT:    ├─────────┼─────────┼─────────┼─────────┼─────────┤
+    //  PAGE UP  │         │         │         │         │         │
+    //           │    1    │    2    │    3    │         │         │
+    //           │         │         │         │         │         │
+    // ┌─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
+    // │         │         │         │         │         │         │
+    // │         │    0    │    .    │    =    │         │         │
+    // │         │         │         │         │         │         │
+    // └─────────┴─────────┴─────────┴─────────┴─────────┴─────────┘
 
-  [_ADMIN] = LAYOUT(
-             RESET,   _______, _______, _______, TG(_ADMIN),
-             _______, _______, _______, _______, _______,
-             _______, _______, _______, _______, _______,
-    _______, _______, _______, _______, _______, _______
-  ),
+    [_ADMIN] = LAYOUT(
+                 RESET,   _______, _______, _______, TG(_ADMIN),
+                 _______, _______, _______, _______, _______,
+                 _______, _______, _______, _______, _______,
+        _______, _______, _______, _______, _______, _______
+    ),
 };
 
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
-  return true;
+    return true;
 };
 
 bool encoder_update_user(uint8_t index, bool clockwise) {
-  if (index == 0) { /* First encoder */
-    if (clockwise) {
-      tap_code(KC_PGDN);
-    } else {
-      tap_code(KC_PGUP);
+    if (index == 0) { /* First encoder */
+        if (clockwise) {
+            tap_code(KC_PGDN);
+        } else {
+            tap_code(KC_PGUP);
+        }
     }
-  }
     return true;
 }

--- a/keyboards/ckeys/thedora/keymaps/default/readme.md
+++ b/keyboards/ckeys/thedora/keymaps/default/readme.md
@@ -1,1 +1,0 @@
-# The default keymap for the cKeys Handwire 101 4x4 keyboard.

--- a/keyboards/ckeys/thedora/readme.md
+++ b/keyboards/ckeys/thedora/readme.md
@@ -4,9 +4,9 @@
 
 A 4x5 keyboard with rotary encoder, QWIIC connector, and header pinouts for easy access to all pins on the Proton C. This keyboard was built for QMK exploration big and small. What will you discover next?
 
-Keyboard Maintainer: [brandenbyers](https://github.com/brandenbyers)  
-Hardware Supported: theDora  
-Hardware Availability: [cKeys.org](https://ckeys.org)
+* Keyboard Maintainer: [brandenbyers](https://github.com/brandenbyers)
+* Hardware Supported: theDora
+* Hardware Availability: [cKeys.org](https://ckeys.org)
 
 Make example for this keyboard (after setting up your build environment):
 

--- a/keyboards/ckeys/thedora/rules.mk
+++ b/keyboards/ckeys/thedora/rules.mk
@@ -6,17 +6,20 @@ BOARD = QMK_PROTON_C
 BOOTLOADER = stm32-dfu
 
 # Build Options
-#   comment out to disable the options.
+#   change yes to no to disable
 #
-BACKLIGHT_ENABLE = no
 BOOTMAGIC_ENABLE = lite     # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = yes # Mouse keys
-EXTRAKEY_ENABLE = yes # Audio control and System control
-CONSOLE_ENABLE = no  # Console for debug
-COMMAND_ENABLE = no    # Commands for debug and configuration
-#SLEEP_LED_ENABLE = yes  # Breathing sleep LED during USB suspend
-NKRO_ENABLE = yes     # USB Nkey Rollover
-AUDIO_ENABLE = yes
+MOUSEKEY_ENABLE = yes       # Mouse keys
+EXTRAKEY_ENABLE = yes       # Audio control and System control
+CONSOLE_ENABLE = no         # Console for debug
+COMMAND_ENABLE = no         # Commands for debug and configuration
+# Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
+SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
+# if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+NKRO_ENABLE = yes           # USB Nkey Rollover
+BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
+RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
+AUDIO_ENABLE = yes          # Audio output
+
 MIDI_ENABLE = yes           # MIDI support
-RGBLIGHT_ENABLE = no
 ENCODER_ENABLE = yes

--- a/keyboards/ckeys/thedora/thedora.c
+++ b/keyboards/ckeys/thedora/thedora.c
@@ -1,3 +1,19 @@
+/* Copyright 2019 Branden Byers (@brandenbyers)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "thedora.h"
 
 bool encoder_update_kb(uint8_t index, bool clockwise) {

--- a/keyboards/ckeys/thedora/thedora.c
+++ b/keyboards/ckeys/thedora/thedora.c
@@ -1,1 +1,15 @@
 #include "thedora.h"
+
+bool encoder_update_kb(uint8_t index, bool clockwise) {
+    if (!encoder_update_user(index, clockwise)) {
+        return false;
+    }
+    if (index == 0) {
+        if (clockwise) {
+            tap_code(KC_PGDN);
+        } else {
+            tap_code(KC_PGUP);
+        }
+    }
+    return true;
+}

--- a/keyboards/ckeys/thedora/thedora.h
+++ b/keyboards/ckeys/thedora/thedora.h
@@ -1,3 +1,19 @@
+/* Copyright 2019 Branden Byers (@brandenbyers)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include "quantum.h"

--- a/keyboards/ckeys/thedora/thedora.h
+++ b/keyboards/ckeys/thedora/thedora.h
@@ -2,20 +2,20 @@
 
 #include "quantum.h"
 
+#define XXX KC_NO
+
 // This a shortcut to help you visually see your layout.
-// The following is an example using the Planck MIT layout
-// The first section contains all of the arguements
+// The first section contains all of the arguments
 // The second converts the arguments into a two-dimensional array
 #define LAYOUT( \
-    k00, k01, k02, k03, k04, k05, \
-    k06, k07, k08, k09, k10, \
-    k11, k12, k13, k14, k15, \
-    k16, k17, k18, k19, k20 \
+         k00, k01, k02, k03, k04, \
+         k10, k11, k12, k13, k14, \
+         k20, k21, k22, k23, k24, \
+    k05, k30, k31, k32, k33, k34  \
 ) \
 { \
-    { k00, k01, k02, k03, k04, k05, }, \
-    { k06, k07, k08, k09, k10 },       \
-    { k11, k12, k13, k14, k15 },       \
-    { k16, k17, k18, k19, k20 }        \
+    { k00, k01, k02, k03, k04, k05 }, \
+    { k10, k11, k12, k13, k14, XXX }, \
+    { k20, k21, k22, k23, k24, XXX }, \
+    { k30, k31, k32, k33, k34, XXX }  \
 }
-


### PR DESCRIPTION
## Description

* rearranges the layout macro to resemble the assembled board
* switches `thedora.h`/`info.json` to use QMK's 3-character notation for matrix position identifiers (`k<row><column>`)
* fixes a broken layout macro reference in `info.json`
* convert default keymap to use four-space indent
* remove `config.h` and `readme.md` from default keymap (they were effectively blank)
* add `encoder_update_kb()` to `thedora.c` (adds encoder functionality to firmware compiled through QMK Configurator)
* adds license headers
* minor touch-up on keyboard readme
* update `rules.mk` to conform to QMK's template

cc @brandenbyers (keyboard maintainer)

## Types of Changes

- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
