### PR TITLE
Add option to use numpad for digits entry for unicode mode UC_WIN

### DIFF
--- a/quantum/process_keycode/process_unicode_common.c
+++ b/quantum/process_keycode/process_unicode_common.c
@@ -179,6 +179,8 @@ static void send_nibble_wrapper(uint8_t digit) {
     send_nibble(digit);
 }
 
+// clang-format on
+
 void register_hex(uint16_t hex) {
     for (int i = 3; i >= 0; i--) {
         uint8_t digit = ((hex >> (i * 4)) & 0xF);

--- a/quantum/process_keycode/process_unicode_common.c
+++ b/quantum/process_keycode/process_unicode_common.c
@@ -178,7 +178,6 @@ __attribute__((weak)) void unicode_input_cancel(void) {
 }
 
 static void send_nibble_wrapper(uint8_t digit) {
-#ifdef UNICODE_UC_WIN_USE_NUMPAD_IF_POSSIBLE
     if (unicode_config.input_mode == UC_WIN) {
         uint8_t kc = digit < 10
                    ? KC_KP_1 + (10 + digit - 1) % 10
@@ -186,7 +185,6 @@ static void send_nibble_wrapper(uint8_t digit) {
         tap_code(kc);
         return;
     }
-#endif
     send_nibble(digit);
 }
 

--- a/quantum/process_keycode/process_unicode_common.c
+++ b/quantum/process_keycode/process_unicode_common.c
@@ -81,10 +81,7 @@ void cycle_unicode_input_mode(int8_t offset) {
 void persist_unicode_input_mode(void) { eeprom_update_byte(EECONFIG_UNICODEMODE, unicode_config.input_mode); }
 
 __attribute__((weak)) void unicode_input_start(void) {
-    unicode_saved_caps_lock = host_keyboard_led_state().caps_lock;
-#ifdef UNICODE_UC_WIN_USE_NUMPAD_IF_POSSIBLE
-    unicode_saved_num_lock = host_keyboard_led_state().num_lock;
-#endif
+    unicode_saved_num_lock  = host_keyboard_led_state().num_lock;
 
     // Note the order matters here!
     // Need to do this before we mess around with the mods, or else

--- a/quantum/process_keycode/process_unicode_common.c
+++ b/quantum/process_keycode/process_unicode_common.c
@@ -166,6 +166,8 @@ __attribute__((weak)) void unicode_input_cancel(void) {
     set_mods(unicode_saved_mods);  // Reregister previously set mods
 }
 
+// clang-format off
+
 static void send_nibble_wrapper(uint8_t digit) {
     if (unicode_config.input_mode == UC_WIN) {
         uint8_t kc = digit < 10

--- a/quantum/process_keycode/process_unicode_common.c
+++ b/quantum/process_keycode/process_unicode_common.c
@@ -163,11 +163,9 @@ __attribute__((weak)) void unicode_input_cancel(void) {
             break;
         case UC_WIN:
             unregister_code(KC_LALT);
-#ifdef UNICODE_UC_WIN_USE_NUMPAD_IF_POSSIBLE
             if (!unicode_saved_num_lock) {
                 tap_code(KC_NUMLOCK);
             }
-#endif
             break;
     }
 

--- a/quantum/process_keycode/process_unicode_common.c
+++ b/quantum/process_keycode/process_unicode_common.c
@@ -79,6 +79,7 @@ void cycle_unicode_input_mode(int8_t offset) {
 void persist_unicode_input_mode(void) { eeprom_update_byte(EECONFIG_UNICODEMODE, unicode_config.input_mode); }
 
 __attribute__((weak)) void unicode_input_start(void) {
+    unicode_saved_caps_lock = host_keyboard_led_state().caps_lock;
     unicode_saved_num_lock  = host_keyboard_led_state().num_lock;
 
     // Note the order matters here!

--- a/quantum/process_keycode/process_unicode_common.c
+++ b/quantum/process_keycode/process_unicode_common.c
@@ -22,9 +22,7 @@
 unicode_config_t unicode_config;
 uint8_t          unicode_saved_mods;
 bool             unicode_saved_caps_lock;
-#ifdef UNICODE_UC_WIN_USE_NUMPAD_IF_POSSIBLE
 bool             unicode_saved_num_lock;
-#endif
 
 #if UNICODE_SELECTED_MODES != -1
 static uint8_t selected[]     = {UNICODE_SELECTED_MODES};

--- a/quantum/process_keycode/process_unicode_common.c
+++ b/quantum/process_keycode/process_unicode_common.c
@@ -102,12 +102,10 @@ __attribute__((weak)) void unicode_input_start(void) {
             tap_code16(UNICODE_KEY_LNX);
             break;
         case UC_WIN:
-#ifdef UNICODE_UC_WIN_USE_NUMPAD_IF_POSSIBLE
             // For increased reliability, use numpad keys for inputting digits
             if (!unicode_saved_num_lock) {
                 tap_code(KC_NUMLOCK);
             }
-#endif
             register_code(KC_LALT);
             tap_code(KC_KP_PLUS);
             break;

--- a/quantum/process_keycode/process_unicode_common.c
+++ b/quantum/process_keycode/process_unicode_common.c
@@ -133,11 +133,9 @@ __attribute__((weak)) void unicode_input_finish(void) {
             break;
         case UC_WIN:
             unregister_code(KC_LALT);
-#ifdef UNICODE_UC_WIN_USE_NUMPAD_IF_POSSIBLE
             if (!unicode_saved_num_lock) {
                 tap_code(KC_NUMLOCK);
             }
-#endif
             break;
         case UC_WINC:
             tap_code(KC_ENTER);

--- a/quantum/process_keycode/process_unicode_common.c
+++ b/quantum/process_keycode/process_unicode_common.c
@@ -92,7 +92,7 @@ __attribute__((weak)) void unicode_input_start(void) {
     // UNICODE_KEY_LNX (which is usually Ctrl-Shift-U) might not work
     // correctly in the shifted case.
     if (unicode_config.input_mode == UC_LNX && unicode_saved_caps_lock) {
-        tap_code(KC_CAPS);
+        tap_code(KC_CAPSLOCK);
     }
 
     unicode_saved_mods = get_mods();  // Save current mods
@@ -112,7 +112,7 @@ __attribute__((weak)) void unicode_input_start(void) {
             }
 #endif
             register_code(KC_LALT);
-            tap_code(KC_PPLS);
+            tap_code(KC_KP_PLUS);
             break;
         case UC_WINC:
             tap_code(UNICODE_KEY_WINC);
@@ -129,9 +129,9 @@ __attribute__((weak)) void unicode_input_finish(void) {
             unregister_code(UNICODE_KEY_MAC);
             break;
         case UC_LNX:
-            tap_code(KC_SPC);
+            tap_code(KC_SPACE);
             if (unicode_saved_caps_lock) {
-                tap_code(KC_CAPS);
+                tap_code(KC_CAPSLOCK);
             }
             break;
         case UC_WIN:
@@ -157,13 +157,13 @@ __attribute__((weak)) void unicode_input_cancel(void) {
             unregister_code(UNICODE_KEY_MAC);
             break;
         case UC_LNX:
-            tap_code(KC_ESC);
+            tap_code(KC_ESCAPE);
             if (unicode_saved_caps_lock) {
-                tap_code(KC_CAPS);
+                tap_code(KC_CAPSLOCK);
             }
             break;
         case UC_WINC:
-            tap_code(KC_ESC);
+            tap_code(KC_ESCAPE);
             break;
         case UC_WIN:
             unregister_code(KC_LALT);


### PR DESCRIPTION
Adds an option `UNICODE_UC_WIN_USE_NUMPAD_IF_POSSIBLE` to use the numpad for entering digits 0-9 of a hexadecimal unicode codepoint for unicode mode `UC_WIN`, improving reliability of this unicode mode on Windows.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

On Windows, if using the `UC_WIN` unicode mode, reliability of the alt entry succeeding is improved by using the numpad for entering the 0-9 digits of a hex code under numlock. This is because fewer apps hook alt+numpad digits for custom shortcuts. Of course this method of unicode entry still has issues if e.g. apps use menu mnemonics, though if they are disabled in for example VSCode the alt method becomes reliable if using the numpad instead of regular number keys.

The downside of this method is that numlock is required, thus entering a unicode character this way would make the numlock led flash (if it was off), which is one reason I used a preprocessor setting to not switch this on by default.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
