### PR TITLE
Document examples on intercepting Mod-Tap

### DIFF
--- a/docs/mod_tap.md
+++ b/docs/mod_tap.md
@@ -65,7 +65,7 @@ It can also be mitigated by increasing [`TAP_CODE_DELAY`](config_options.md#beha
 
 Basic keycode limitation with Mod-Tap can be worked around by intercepting it in `process_record_user`. For example, shifted keycode `KC_DQUO` cannot be used with `MT()` because it is a 16-bit keycode alias of `LSFT(KC_QUOT)`. But the following custom code can be used to intercept the "tap" function to manually send `KC_DQUO`:
 ```c
-bool process_record_user(uint16_t const keycode, keyrecord_t *record) {
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     switch (keycode) {
         case LCTL_T(KC_DQUO):
             if (record->tap.count && record->event.pressed) {
@@ -85,7 +85,7 @@ bool process_record_user(uint16_t const keycode, keyrecord_t *record) {
 
 Likewise, the same custom code can also be used to intercept the hold function to send custom user key code. The following example uses `LT(0,<keycode>)`, current-layer Mod-Tap with no practical use, to create a copy-on-tap, paste-on-hold key:
 ```c
-bool process_record_user(uint16_t const keycode, keyrecord_t *record) {
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     switch (keycode) {
         case LT(0,KC_NO):
             if (record->tap.count && record->event.pressed) {

--- a/docs/mod_tap.md
+++ b/docs/mod_tap.md
@@ -65,7 +65,7 @@ It can also be mitigated by increasing [`TAP_CODE_DELAY`](config_options.md#beha
 
 ### Changing tap function
 
-Basic keycode limitation with Mod-Tap can be worked around by intercepting it in `process_record_user`. For example, shifted keycode `KC_DQUO` cannot be used with `MT()` because it is a 16-bit keycode alias of `LSFT(KC_QUOT)`. Modifier on `KC_DQUO` will be masked by `MT()`. But the following custom code can be used to intercept the "tap" function to manually send `KC_DQUO`:
+The basic keycode limitation with Mod-Tap can be worked around by intercepting it in `process_record_user`. For example, shifted keycode `KC_DQUO` cannot be used with `MT()` because it is a 16-bit keycode alias of `LSFT(KC_QUOT)`. Modifiers on `KC_DQUO` will be masked by `MT()`. But the following custom code can be used to intercept the "tap" function to manually send `KC_DQUO`:
 
 ```c
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {

--- a/docs/mod_tap.md
+++ b/docs/mod_tap.md
@@ -83,7 +83,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 
 ### Changing hold function
 
-Likewise, the same custom code can also be used to intercept the hold function to send custom user key code. The following example uses `LT(0, kc)`, a current-layer Mod-Tap with no practical use, to add cut, copy and paste function to X,C and V keys when they are held down:
+Likewise, the same custom code can also be used to intercept the hold function to send custom user key code. The following example uses `LT(0, kc)` (layer-tap key with no practical use because layer 0 is always active) to add cut, copy and paste function to X,C and V keys when they are held down:
 
 ```c
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
@@ -113,6 +113,8 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     return true;
 }
 ```
+
+Enabling `IGNORE_MOD_TAP_INTERRUPT` is recommended for Mod-Tap on alphanumeric keys to avoid hold function taking precendence when the next key is pressed quickly. See [Tap-Hold Configuration](tap_hold.md) for more details.
 
 ### Changing both tap and hold
 

--- a/docs/mod_tap.md
+++ b/docs/mod_tap.md
@@ -69,13 +69,10 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     switch (keycode) {
         case LCTL_T(KC_DQUO):
             if (record->tap.count && record->event.pressed) {
-                // Intercept tap function
-                tap_code16(KC_DQUO);
-                // Return false to ignore processing of tap function
-                return false;
+                tap_code16(KC_DQUO); // Send KC_DQUO on tap
+                return false;        // Return false to ignore further processing of key
             } else if (record->event.pressed) {
-                // Return true for normal processing of hold function
-                return true;
+                return true;         // Return true for normal processing of hold function 
             }
             break;
     }
@@ -89,11 +86,9 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     switch (keycode) {
         case LT(0,KC_NO):
             if (record->tap.count && record->event.pressed) {
-                // Intercept tap function to send Ctrl-C
-                tap_code16(C(KC_C));
+                tap_code16(C(KC_C)); // Intercept tap function to send Ctrl-C
             } else if (record->event.pressed) {
-                // Intercept hold function to send Ctrl-V
-                tap_code16(C(KC_V));
+                tap_code16(C(KC_V)); // Intercept hold function to send Ctrl-V
             }
             return false;
             break;

--- a/docs/mod_tap.md
+++ b/docs/mod_tap.md
@@ -74,8 +74,6 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             if (record->tap.count && record->event.pressed) {
                 tap_code16(KC_DQUO); // Send KC_DQUO on tap
                 return false;        // Return false to ignore further processing of key
-            } else if (record->event.pressed) {
-                return true;         // Return true for normal processing of hold function 
             }
             break;
     }

--- a/docs/mod_tap.md
+++ b/docs/mod_tap.md
@@ -80,7 +80,40 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 }
 ```
 
-Likewise, the same custom code can also be used to intercept the hold function to send custom user key code. The following example uses `LT(0, kc)`, a current-layer Mod-Tap with no practical use, as a copy-on-tap, paste-on-hold key:
+Likewise, the same custom code can also be used to intercept the hold function to send custom user key code. The following example uses `LT(0, kc)`, a current-layer Mod-Tap with no practical use, to add cut, copy and paste function to X,C and V keys when they are held down:
+```c
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    switch (keycode) {
+        case LT(0,KC_X):
+            if (record->tap.count && record->event.pressed) {
+                return true;         // Return true for normal processing of tap keycode
+            } else if (record->event.pressed) {
+                tap_code16(C(KC_X)); // Intercept hold function to send Ctrl-X
+            }
+            return false;
+            break;
+        case LT(0,KC_C):
+            if (record->tap.count && record->event.pressed) {
+                return true;         // Return true for normal processing of tap keycode
+            } else if (record->event.pressed) {
+                tap_code16(C(KC_C)); // Intercept hold function to send Ctrl-C
+            }
+            return false;
+            break;
+        case LT(0,KC_V):
+            if (record->tap.count && record->event.pressed) {
+                return true;         // Return true for normal processing of tap keycode
+            } else if (record->event.pressed) {
+                tap_code16(C(KC_V)); // Intercept hold function to send Ctrl-V
+            }
+            return false;
+            break;
+    }
+    return true;
+}
+```
+
+This last example creates a custom copy on tap, paste on hold key using `LT(0,KC_NO)`:
 ```c
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     switch (keycode) {

--- a/docs/mod_tap.md
+++ b/docs/mod_tap.md
@@ -104,7 +104,6 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
                 tap_code16(C(KC_C)); // Intercept hold function to send Ctrl-C
             }
             return false;
-            break;
         case LT(0,KC_V):
             if (record->tap.count && record->event.pressed) {
                 return true;         // Return true for normal processing of tap keycode

--- a/docs/mod_tap.md
+++ b/docs/mod_tap.md
@@ -91,7 +91,6 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
                 tap_code16(C(KC_X)); // Intercept hold function to send Ctrl-X
             }
             return false;
-            break;
         case LT(0,KC_C):
             if (record->tap.count && record->event.pressed) {
                 return true;         // Return true for normal processing of tap keycode

--- a/docs/mod_tap.md
+++ b/docs/mod_tap.md
@@ -82,8 +82,11 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     return true;
 }
 ```
+
 ### Changing hold function
+
 Likewise, the same custom code can also be used to intercept the hold function to send custom user key code. The following example uses `LT(0, kc)`, a current-layer Mod-Tap with no practical use, to add cut, copy and paste function to X,C and V keys when they are held down:
+
 ```c
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     switch (keycode) {

--- a/docs/mod_tap.md
+++ b/docs/mod_tap.md
@@ -113,7 +113,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 }
 ```
 ### Changing both tap and hold
-This last example creates a custom copy on tap, paste on hold key using `LT(0,KC_NO)`:
+This last example uses both tap and hold function of `LT()` to create a copy-on-tap, paste-on-hold key with `LT(0,KC_NO)`:
 ```c
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     switch (keycode) {

--- a/docs/mod_tap.md
+++ b/docs/mod_tap.md
@@ -80,7 +80,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 }
 ```
 
-Likewise, the same custom code can also be used to intercept the hold function to send custom user key code. The following example uses `LT(0,<keycode>)`, current-layer Mod-Tap with no practical use, to create a copy-on-tap, paste-on-hold key:
+Likewise, the same custom code can also be used to intercept the hold function to send custom user key code. The following example uses `LT(0, kc)`, a current-layer Mod-Tap with no practical use, as a copy-on-tap, paste-on-hold key:
 ```c
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     switch (keycode) {

--- a/docs/mod_tap.md
+++ b/docs/mod_tap.md
@@ -62,8 +62,11 @@ To fix this, open Remote Desktop Connection, click on "Show Options", open the t
 It can also be mitigated by increasing [`TAP_CODE_DELAY`](config_options.md#behaviors-that-can-be-configured).
 
 ## Intercepting Mod-Taps
+
 ### Changing tap function
+
 Basic keycode limitation with Mod-Tap can be worked around by intercepting it in `process_record_user`. For example, shifted keycode `KC_DQUO` cannot be used with `MT()` because it is a 16-bit keycode alias of `LSFT(KC_QUOT)`. But the following custom code can be used to intercept the "tap" function to manually send `KC_DQUO`:
+
 ```c
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     switch (keycode) {

--- a/docs/mod_tap.md
+++ b/docs/mod_tap.md
@@ -114,11 +114,11 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 }
 ```
 
-Enabling `IGNORE_MOD_TAP_INTERRUPT` is recommended for Mod-Tap on alphanumeric keys to avoid hold function taking precendence when the next key is pressed quickly. See [Ignore Mod Tap Interrupt](tap_hold.md#ignore-mod-tap-interrupt) for more details.
+Enabling `IGNORE_MOD_TAP_INTERRUPT` is recommended for using Mod-Tap on alphanumeric keys to avoid hold function taking precendence when the next key is pressed quickly. See [Ignore Mod Tap Interrupt](tap_hold.md#ignore-mod-tap-interrupt) for more details.
 
 ### Changing both tap and hold
 
-This last example uses both tap and hold function of `LT()` to create a copy-on-tap, paste-on-hold key with `LT(0,KC_NO)`:
+This last example implements custom tap and hold function with `LT(0,KC_NO)` to create a single copy-on-tap, paste-on-hold key:
 
 ```c
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {

--- a/docs/mod_tap.md
+++ b/docs/mod_tap.md
@@ -114,7 +114,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 }
 ```
 
-Enabling `IGNORE_MOD_TAP_INTERRUPT` is recommended for Mod-Tap on alphanumeric keys to avoid hold function taking precendence when the next key is pressed quickly. See [Tap-Hold Configuration](tap_hold.md) for more details.
+Enabling `IGNORE_MOD_TAP_INTERRUPT` is recommended for Mod-Tap on alphanumeric keys to avoid hold function taking precendence when the next key is pressed quickly. See [Ignore Mod Tap Interrupt](tap_hold.md#ignore-mod-tap-interrupt) for more details.
 
 ### Changing both tap and hold
 

--- a/docs/mod_tap.md
+++ b/docs/mod_tap.md
@@ -61,10 +61,10 @@ You may also run into issues when using Remote Desktop Connection on Windows. Be
 To fix this, open Remote Desktop Connection, click on "Show Options", open the the "Local Resources" tab, and in the keyboard section, change the drop down to "On this Computer". This will fix the issue, and allow the characters to work correctly.
 It can also be mitigated by increasing [`TAP_CODE_DELAY`](config_options.md#behaviors-that-can-be-configured).
 
-## Intercepting Mod-taps
+## Intercepting Mod-Taps
 
-Basic keycode limitation with mod-tap can be worked around by intercepting it in `process_record_user`. For example, shifted keycode `KC_DQUO` cannot be used with `MT()` because it is a 16-bit keycode alias of `LSFT(KC_QUOT)`. But the following custom code can be used to intercept the "tap" function to manually send `KC_DQUO`:
-```
+Basic keycode limitation with Mod-Tap can be worked around by intercepting it in `process_record_user`. For example, shifted keycode `KC_DQUO` cannot be used with `MT()` because it is a 16-bit keycode alias of `LSFT(KC_QUOT)`. But the following custom code can be used to intercept the "tap" function to manually send `KC_DQUO`:
+```c
 bool process_record_user(uint16_t const keycode, keyrecord_t *record) {
     switch (keycode) {
         case LCTL_T(KC_DQUO):
@@ -83,8 +83,8 @@ bool process_record_user(uint16_t const keycode, keyrecord_t *record) {
 }
 ```
 
-Likewise, the same custom code can also be used to intercept the hold function to send custom user key code. The following example uses `LT(0,<keycode>)`, a current-layer mod-tap with no practical use, to create a copy on tap, paste on hold key:
-```
+Likewise, the same custom code can also be used to intercept the hold function to send custom user key code. The following example uses `LT(0,<keycode>)`, current-layer Mod-Tap with no practical use, to create a copy-on-tap, paste-on-hold key:
+```c
 bool process_record_user(uint16_t const keycode, keyrecord_t *record) {
     switch (keycode) {
         case LT(0,KC_NO):

--- a/docs/mod_tap.md
+++ b/docs/mod_tap.md
@@ -62,7 +62,7 @@ To fix this, open Remote Desktop Connection, click on "Show Options", open the t
 It can also be mitigated by increasing [`TAP_CODE_DELAY`](config_options.md#behaviors-that-can-be-configured).
 
 ## Intercepting Mod-Taps
-
+### Changing tap function
 Basic keycode limitation with Mod-Tap can be worked around by intercepting it in `process_record_user`. For example, shifted keycode `KC_DQUO` cannot be used with `MT()` because it is a 16-bit keycode alias of `LSFT(KC_QUOT)`. But the following custom code can be used to intercept the "tap" function to manually send `KC_DQUO`:
 ```c
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
@@ -79,7 +79,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     return true;
 }
 ```
-
+### Changing hold function
 Likewise, the same custom code can also be used to intercept the hold function to send custom user key code. The following example uses `LT(0, kc)`, a current-layer Mod-Tap with no practical use, to add cut, copy and paste function to X,C and V keys when they are held down:
 ```c
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
@@ -112,7 +112,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     return true;
 }
 ```
-
+### Changing both tap and hold
 This last example creates a custom copy on tap, paste on hold key using `LT(0,KC_NO)`:
 ```c
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {

--- a/docs/mod_tap.md
+++ b/docs/mod_tap.md
@@ -117,8 +117,11 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     return true;
 }
 ```
+
 ### Changing both tap and hold
+
 This last example uses both tap and hold function of `LT()` to create a copy-on-tap, paste-on-hold key with `LT(0,KC_NO)`:
+
 ```c
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     switch (keycode) {

--- a/docs/mod_tap.md
+++ b/docs/mod_tap.md
@@ -65,7 +65,7 @@ It can also be mitigated by increasing [`TAP_CODE_DELAY`](config_options.md#beha
 
 ### Changing tap function
 
-Basic keycode limitation with Mod-Tap can be worked around by intercepting it in `process_record_user`. For example, shifted keycode `KC_DQUO` cannot be used with `MT()` because it is a 16-bit keycode alias of `LSFT(KC_QUOT)`. But the following custom code can be used to intercept the "tap" function to manually send `KC_DQUO`:
+Basic keycode limitation with Mod-Tap can be worked around by intercepting it in `process_record_user`. For example, shifted keycode `KC_DQUO` cannot be used with `MT()` because it is a 16-bit keycode alias of `LSFT(KC_QUOT)`. Modifier on `KC_DQUO` will be masked by `MT()`. But the following custom code can be used to intercept the "tap" function to manually send `KC_DQUO`:
 
 ```c
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
@@ -114,7 +114,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 }
 ```
 
-Enabling `IGNORE_MOD_TAP_INTERRUPT` is recommended for using Mod-Tap on alphanumeric keys to avoid hold function taking precendence when the next key is pressed quickly. See [Ignore Mod Tap Interrupt](tap_hold.md#ignore-mod-tap-interrupt) for more details.
+Enabling `IGNORE_MOD_TAP_INTERRUPT` is recommended when using Mod-Tap on alphanumeric keys to avoid hold function taking precendence when the next key is pressed quickly. See [Ignore Mod Tap Interrupt](tap_hold.md#ignore-mod-tap-interrupt) for more details.
 
 ### Changing both tap and hold
 

--- a/docs/mod_tap.md
+++ b/docs/mod_tap.md
@@ -111,7 +111,6 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
                 tap_code16(C(KC_V)); // Intercept hold function to send Ctrl-V
             }
             return false;
-            break;
     }
     return true;
 }

--- a/docs/mod_tap.md
+++ b/docs/mod_tap.md
@@ -130,7 +130,6 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
                 tap_code16(C(KC_V)); // Intercept hold function to send Ctrl-V
             }
             return false;
-            break;
     }
     return true;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Intercepting Mod-Tap to workaround caveats is a frequently asked question in Discord. Documented here are code examples of doing so.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

FAQ in QMK Discord

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
