### PR TITLE
[Core] Add encoder_set_resolution function

### DIFF
--- a/docs/feature_encoders.md
+++ b/docs/feature_encoders.md
@@ -110,7 +110,7 @@ Here rotating Encoder 0 `B1 B2` and Encoder 1 `B1 B3` could be interpreted as ro
 
 ## Change Resolution
 
-You can change the resolution(s) of encoder(s) by `encoder_set_resolution` function while using your keyboard.
+You can set / get the resolution(s) of encoder(s) by `encoder_set_resolution` /  `encoder_get_resolution` function while using your keyboard.
 The resolution, i.e. the number of pulses/counts per each detent varies depending on the encoder model. You should set the appropriate constant value to `ENCODER_RESOLUTION` if you know the specification of the encoder to be used, but this function is useful if you are distributing pre-assembled PCBs with pre-programmed firmware and you don't know what kind of encoders the users will use.
 
 For example, by assigning this function to a custom keycode,  its users can freely choose the resolution. 
@@ -118,5 +118,6 @@ In most cases, a suitable resolution value is 4, which is the default for QMK, o
 
 ```c
 void encoder_set_resolution(uint8_t index, uint8_t resolution);
+uint8_t encoder_get_resolutioin(uint8_t index);
     // index : use 0 if one encoder only available
 ```

--- a/docs/feature_encoders.md
+++ b/docs/feature_encoders.md
@@ -107,3 +107,16 @@ You could even support three encoders using only three pins (one per encoder) ho
 #define ENCODERS_PAD_B { B2, B3, B3 }
 ```
 Here rotating Encoder 0 `B1 B2` and Encoder 1 `B1 B3` could be interpreted as rotating Encoder 2 `B2 B3` or `B3 B2` depending on the timing. This may still be a useful configuration depending on your use case 
+
+## Change Resolution
+
+You can change the resolution(s) of encoder(s) by `encoder_set_resolution` function while using your keyboard.
+The resolution, i.e. the number of pulses/counts per each detent varies depending on the encoder model. You should set the appropriate constant value to `ENCODER_RESOLUTION` if you know the specification of the encoder to be used, but this function is useful if you are distributing pre-assembled PCBs with pre-programmed firmware and you don't know what kind of encoders the users will use.
+
+For example, by assigning this function to a custom keycode,  its users can freely choose the resolution. 
+In most cases, a suitable resolution value is 4, which is the default for QMK, or 2 for some Alps encoders.
+
+```c
+void encoder_set_resolution(uint8_t index, uint8_t resolution);
+    // index : use 0 if one encoder only available
+```

--- a/quantum/encoder.c
+++ b/quantum/encoder.c
@@ -108,7 +108,7 @@ uint8_t encoder_get_resolution(uint8_t index) {
 #ifdef ENCODER_RESOLUTIONS
     return encoder_resolutions[index];
 #else
-    return resolution;
+    return encoder_resolution;
 #endif
 }
 

--- a/quantum/encoder.c
+++ b/quantum/encoder.c
@@ -104,6 +104,14 @@ void encoder_set_resolution(uint8_t index, uint8_t resolution) {
 #endif
 }
 
+uint8_t encoder_get_resolution(uint8_t index) {
+#ifdef ENCODER_RESOLUTIONS
+    return encoder_resolutions[index];
+#else
+    return resolution;
+#endif
+}
+
 static bool encoder_update(uint8_t index, uint8_t state) {
     bool    changed = false;
     uint8_t i       = index;

--- a/quantum/encoder.c
+++ b/quantum/encoder.c
@@ -36,6 +36,8 @@ static pin_t encoders_pad_a[] = ENCODERS_PAD_A;
 static pin_t encoders_pad_b[] = ENCODERS_PAD_B;
 #ifdef ENCODER_RESOLUTIONS
 static uint8_t encoder_resolutions[] = ENCODER_RESOLUTIONS;
+#else
+static uint8_t encoder_resolution = ENCODER_RESOLUTION;
 #endif
 
 #ifndef ENCODER_DIRECTION_FLIP
@@ -94,6 +96,14 @@ void encoder_init(void) {
 #endif
 }
 
+void encoder_set_resolution(uint8_t index, uint8_t resolution) {
+#ifdef ENCODER_RESOLUTIONS
+    encoder_resolutions[index] = resolution;
+#else
+    encoder_resolution = resolution;
+#endif
+}
+
 static bool encoder_update(uint8_t index, uint8_t state) {
     bool    changed = false;
     uint8_t i       = index;
@@ -101,7 +111,7 @@ static bool encoder_update(uint8_t index, uint8_t state) {
 #ifdef ENCODER_RESOLUTIONS
     uint8_t resolution = encoder_resolutions[i];
 #else
-    uint8_t resolution = ENCODER_RESOLUTION;
+    uint8_t resolution = encoder_resolution;
 #endif
 
 #ifdef SPLIT_KEYBOARD

--- a/quantum/encoder.h
+++ b/quantum/encoder.h
@@ -31,3 +31,4 @@ void encoder_update_raw(uint8_t* slave_state);
 #endif
 
 void encoder_set_resolution(uint8_t index, uint8_t resolution);
+uint8_t encoder_get_resolution(uint8_t index);

--- a/quantum/encoder.h
+++ b/quantum/encoder.h
@@ -29,3 +29,5 @@ bool encoder_update_user(uint8_t index, bool clockwise);
 void encoder_state_raw(uint8_t* slave_state);
 void encoder_update_raw(uint8_t* slave_state);
 #endif
+
+void encoder_set_resolution(uint8_t index, uint8_t resolution);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Currently, the resolution of the encoder is set by the ENCODER_RESOLUTION constant, which is fixed at build.
This function allows the user to change the resolution of the encoder by keypress or other means.
Very simple.

<!--- Describe your changes in detail here. -->
```
encoder_set_resolution(uint8_t index, uint8_t resolution);
```
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
