### PR TITLE
Enables I2C for OLKB rev*_drop boards

### DIFF
--- a/keyboards/planck/rev6_drop/halconf.h
+++ b/keyboards/planck/rev6_drop/halconf.h
@@ -18,5 +18,6 @@
 #define HAL_USE_PWM TRUE
 #define HAL_USE_GPT TRUE
 #define HAL_USE_DAC TRUE
+#define HAL_USE_I2C TRUE
 
 #include_next <halconf.h>

--- a/keyboards/planck/rev6_drop/matrix.c
+++ b/keyboards/planck/rev6_drop/matrix.c
@@ -43,7 +43,7 @@ __attribute__((weak)) void matrix_init_kb(void) { matrix_init_user(); }
 __attribute__((weak)) void matrix_scan_kb(void) { matrix_scan_user(); }
 
 void matrix_init(void) {
-    printf("matrix init\n");
+    dprintf("matrix init\n");
     // debug_matrix = true;
 
     // actual matrix setup
@@ -151,16 +151,16 @@ bool matrix_is_on(uint8_t row, uint8_t col) { return (matrix[row] & (1 << col));
 matrix_row_t matrix_get_row(uint8_t row) { return matrix[row]; }
 
 void matrix_print(void) {
-    printf("\nr/c 01234567\n");
+    dprintf("\nr/c 01234567\n");
     for (uint8_t row = 0; row < MATRIX_ROWS; row++) {
-        printf("%X0: ", row);
+        dprintf("%X0: ", row);
         matrix_row_t data = matrix_get_row(row);
         for (int col = 0; col < MATRIX_COLS; col++) {
             if (data & (1 << col))
-                printf("1");
+                dprintf("1");
             else
-                printf("0");
+                dprintf("0");
         }
-        printf("\n");
+        dprintf("\n");
     }
 }

--- a/keyboards/planck/rev6_drop/mcuconf.h
+++ b/keyboards/planck/rev6_drop/mcuconf.h
@@ -37,3 +37,8 @@
 // TIM2 to TIM3.
 #undef STM32_ST_USE_TIMER
 #define STM32_ST_USE_TIMER 3
+
+// enable i2c 
+#undef STM32_I2C_USE_I2C1
+#define STM32_I2C_USE_I2C1                  TRUE
+

--- a/keyboards/preonic/rev3_drop/halconf.h
+++ b/keyboards/preonic/rev3_drop/halconf.h
@@ -18,5 +18,6 @@
 #define HAL_USE_PWM TRUE
 #define HAL_USE_GPT TRUE
 #define HAL_USE_DAC TRUE
+#define HAL_USE_I2C TRUE
 
 #include_next <halconf.h>

--- a/keyboards/preonic/rev3_drop/matrix.c
+++ b/keyboards/preonic/rev3_drop/matrix.c
@@ -43,7 +43,7 @@ __attribute__((weak)) void matrix_init_kb(void) { matrix_init_user(); }
 __attribute__((weak)) void matrix_scan_kb(void) { matrix_scan_user(); }
 
 void matrix_init(void) {
-    printf("matrix init\n");
+    dprintf("matrix init\n");
     // debug_matrix = true;
 
     // actual matrix setup
@@ -153,16 +153,16 @@ bool matrix_is_on(uint8_t row, uint8_t col) { return (matrix[row] & (1 << col));
 matrix_row_t matrix_get_row(uint8_t row) { return matrix[row]; }
 
 void matrix_print(void) {
-    printf("\nr/c 01234567\n");
+    dprintf("\nr/c 01234567\n");
     for (uint8_t row = 0; row < MATRIX_ROWS; row++) {
-        printf("%X0: ", row);
+        dprintf("%X0: ", row);
         matrix_row_t data = matrix_get_row(row);
         for (int col = 0; col < MATRIX_COLS; col++) {
             if (data & (1 << col))
-                printf("1");
+                dprintf("1");
             else
-                printf("0");
+                dprintf("0");
         }
-        printf("\n");
+        dprintf("\n");
     }
 }

--- a/keyboards/preonic/rev3_drop/mcuconf.h
+++ b/keyboards/preonic/rev3_drop/mcuconf.h
@@ -37,3 +37,7 @@
 // TIM2 to TIM3.
 #undef STM32_ST_USE_TIMER
 #define STM32_ST_USE_TIMER 3
+
+// enable i2c 
+#undef STM32_I2C_USE_I2C1
+#define STM32_I2C_USE_I2C1                  TRUE


### PR DESCRIPTION
## Description

Builds on #14510, adding the Chibios options to enable I2C (like the normal `rev*` boards), with the help of @Cipulot testing out the Preonic version on hardware.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Reports by @Cipulot on Discord

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
