### PR TITLE
Changed VENDOR_ID and PRODUCT_ID to no longer be identical to the Acheron (Driftmechanics) Austin 

### DIFF
--- a/keyboards/boston/config.h
+++ b/keyboards/boston/config.h
@@ -17,8 +17,8 @@
 #pragma once
 
 /* USB Device descriptor parameter */
-#define VENDOR_ID 0xAC11
-#define PRODUCT_ID 0x4175
+#define VENDOR_ID 0xAC12
+#define PRODUCT_ID 0x4176
 #define DEVICE_VER 0x0001
 #define MANUFACTURER Pylon
 #define PRODUCT Boston


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The original IDs (0xAC11 for Vendor ID and 0x4175 for Product ID) was identical to the Acheron (Driftmechanics) Austin, which was causing it to be mistakenly recognized as an Austin when VIA was open, even though Boston does not currently support VIA.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
