### PR TITLE
add keyboard dyz40

### DIFF
--- a/keyboards/dyz/dyz40/config.h
+++ b/keyboards/dyz/dyz40/config.h
@@ -30,31 +30,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MATRIX_ROWS 4
 #define MATRIX_COLS 13
 
-/*
- * Keyboard Matrix Assignments
- *
- * Change this to how you wired your keyboard
- * COLS: AVR pins used for columns, left to right
- * ROWS: AVR pins used for rows, top to bottom
- * DIODE_DIRECTION: COL2ROW = COL = Anode (+), ROW = Cathode (-, marked on diode)
- *                  ROW2COL = ROW = Anode (+), COL = Cathode (-, marked on diode)
- *
-*/
-#define MATRIX_ROW_PINS { B0, B1, B3, B2 }
-#define MATRIX_COL_PINS { E6, F0, F1, F4, F5, F6, F7, C7, C6, B6, B5, B4, D7 }
-#define UNUSED_PINS
-
-/* COL2ROW, ROW2COL*/
-#define DIODE_DIRECTION COL2ROW
-
-#define RGB_DI_PIN B7
-#define RGBLED_NUM 13
-#define RGBLIGHT_EFFECT_BREATHING
-#define RGBLIGHT_EFFECT_RAINBOW_MOOD
-#define RGBLIGHT_EFFECT_RAINBOW_SWIRL
-#define RGBLIGHT_EFFECT_SNAKE
-#define RGBLIGHT_EFFECT_KNIGHT
-#define RGBLIGHT_EFFECT_RGB_TEST
 
 /* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
 #define DEBOUNCE 5

--- a/keyboards/dyz/dyz40/config.h
+++ b/keyboards/dyz/dyz40/config.h
@@ -1,0 +1,70 @@
+/*
+Copyright 2021 dayatz
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "config_common.h"
+
+/* USB Device descriptor parameter */
+#define VENDOR_ID       0xD772
+#define PRODUCT_ID      0x000B
+#define DEVICE_VER      0x0001
+#define MANUFACTURER    dyz
+#define PRODUCT         dyz40
+
+/* key matrix size */
+#define MATRIX_ROWS 4
+#define MATRIX_COLS 13
+
+/*
+ * Keyboard Matrix Assignments
+ *
+ * Change this to how you wired your keyboard
+ * COLS: AVR pins used for columns, left to right
+ * ROWS: AVR pins used for rows, top to bottom
+ * DIODE_DIRECTION: COL2ROW = COL = Anode (+), ROW = Cathode (-, marked on diode)
+ *                  ROW2COL = ROW = Anode (+), COL = Cathode (-, marked on diode)
+ *
+*/
+#define MATRIX_ROW_PINS { B0, B1, B3, B2 }
+#define MATRIX_COL_PINS { E6, F0, F1, F4, F5, F6, F7, C7, C6, B6, B5, B4, D7 }
+#define UNUSED_PINS
+
+/* COL2ROW, ROW2COL*/
+#define DIODE_DIRECTION COL2ROW
+
+#define RGB_DI_PIN B7
+#define RGBLED_NUM 13
+#define RGBLIGHT_EFFECT_BREATHING
+#define RGBLIGHT_EFFECT_RAINBOW_MOOD
+#define RGBLIGHT_EFFECT_RAINBOW_SWIRL
+#define RGBLIGHT_EFFECT_SNAKE
+#define RGBLIGHT_EFFECT_KNIGHT
+#define RGBLIGHT_EFFECT_RGB_TEST
+
+/* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
+#define DEBOUNCE 5
+
+/* Bootmagic Lite key configuration */
+#define BOOTMAGIC_LITE_ROW 0
+#define BOOTMAGIC_LITE_COLUMN 0
+
+#define TAP_CODE_DELAY 10 // Need this delay for some keys like VOLD/VOLU to work
+#define ENCODERS_PAD_A { D1 }
+#define ENCODERS_PAD_B { D0 }
+
+#define DYNAMIC_KEYMAP_LAYER_COUNT 3

--- a/keyboards/dyz/dyz40/config.h
+++ b/keyboards/dyz/dyz40/config.h
@@ -20,9 +20,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "config_common.h"
 
 /* USB Device descriptor parameter */
-#define VENDOR_ID       0xD772
-#define PRODUCT_ID      0x000B
-#define DEVICE_VER      0x0001
 #define MANUFACTURER    dyz
 #define PRODUCT         dyz40
 

--- a/keyboards/dyz/dyz40/dyz40.c
+++ b/keyboards/dyz/dyz40/dyz40.c
@@ -1,0 +1,16 @@
+/* Copyright 2021 dayatz
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "dyz40.h"

--- a/keyboards/dyz/dyz40/dyz40.h
+++ b/keyboards/dyz/dyz40/dyz40.h
@@ -1,0 +1,31 @@
+/* Copyright 2021 dayatz
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "quantum.h"
+#define _X_ KC_NO
+
+#define LAYOUT_all( \
+	K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C, \
+    K10, K11, K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, \
+    K20, K21, K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B, \
+    K30, K31, K32, K33,           K36, K37,           K3A, K3B, K3C \
+) { \
+	{ K00,  K01,  K02,  K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C }, \
+	{ K10,  K11,  K12,  K13, K14, K15, K16, K17, K18, K19, K1A, K1B, _X_ }, \
+	{ K20,  K21,  K22,  K23, K24, K25, K26, K27, K28, K29, K2A, K2B, _X_ }, \
+	{ K30,  K31,  K32,  K33, _X_, _X_, K36, K37, _X_, _X_, K3A, K3B, K3C } \
+}

--- a/keyboards/dyz/dyz40/info.json
+++ b/keyboards/dyz/dyz40/info.json
@@ -2,8 +2,6 @@
     "keyboard_name": "dyz40",
     "url": "https://github.com/dayatz/mechanical-keyboards/tree/master/dyz40",
     "maintainer": "dayatz",
-    "width": 15,
-    "height": 5,
     "diode_direction": "COL2ROW",
     "matrix_pins": {
         "cols": ["E6", "F0", "F1", "F4", "F5", "F6", "F7", "C7", "C6", "B6", "B5", "B4", "D7"],

--- a/keyboards/dyz/dyz40/info.json
+++ b/keyboards/dyz/dyz40/info.json
@@ -1,0 +1,32 @@
+{
+    "keyboard_name": "dyz40",
+    "url": "https://github.com/dayatz/mechanical-keyboards/tree/master/dyz40",
+    "maintainer": "dayatz",
+    "width": 15,
+    "height": 5,
+    "diode_direction": "COL2ROW",
+    "matrix_pins": {
+        "cols": ["E6", "F0", "F1", "F4", "F5", "F6", "F7", "C7", "C6", "B6", "B5", "B4", "D7"],
+        "rows": ["B0", "B1", "B3", "B2"]
+    },
+    "rgblight": {
+        "led_count": 13,
+        "pin": "B7",
+        "hue_steps": 10,
+        "saturation_steps": 10,
+        "brightness_steps": 10,
+        "animations": {
+            "all": true
+        }
+    },
+    "usb": {
+        "vid": "0xD772",
+        "pid": "0x000B",
+        "device_ver": "0x0001"
+    },
+    "layouts": {
+        "LAYOUT": {
+            "layout": [{"label":"Esc", "x":0, "y":0}, {"label":"Q", "x":1, "y":0}, {"label":"W", "x":2, "y":0}, {"label":"E", "x":3, "y":0}, {"label":"R", "x":4, "y":0}, {"label":"T", "x":5, "y":0}, {"label":"Y", "x":6, "y":0}, {"label":"U", "x":7, "y":0}, {"label":"I", "x":8, "y":0}, {"label":"O", "x":9, "y":0}, {"label":"P", "x":10, "y":0}, {"label":"{", "x":11, "y":0}, {"label":"}", "x":12, "y":0}, {"label":"Tab", "x":0, "y":1, "w":1.25}, {"label":"A", "x":1.25, "y":1}, {"label":"S", "x":2.25, "y":1}, {"label":"D", "x":3.25, "y":1}, {"label":"F", "x":4.25, "y":1}, {"label":"G", "x":5.25, "y":1}, {"label":"H", "x":6.25, "y":1}, {"label":"J", "x":7.25, "y":1}, {"label":"K", "x":8.25, "y":1}, {"label":"L", "x":9.25, "y":1}, {"label":"", "x":10.25, "y":1}, {"label":"Enter", "x":11.25, "y":1, "w":1.75}, {"label":"Shift", "x":0, "y":2, "w":1.75}, {"label":"Z", "x":1.75, "y":2}, {"label":"X", "x":2.75, "y":2}, {"label":"C", "x":3.75, "y":2}, {"label":"V", "x":4.75, "y":2}, {"label":"B", "x":5.75, "y":2}, {"label":"N", "x":6.75, "y":2}, {"label":"M", "x":7.75, "y":2}, {"label":"", "x":8.75, "y":2}, {"label":"", "x":9.75, "y":2}, {"label":"", "x":10.75, "y":2}, {"label":"Shift", "x":11.75, "y":2, "w":1.25}, {"label":"Ctrl", "x":0, "y":3, "w":1.5}, {"label":"Win", "x":1.5, "y":3}, {"label":"Alt", "x":2.5, "y":3, "w":1.5}, {"label":"Space", "x":4, "y":3, "w":2.75}, {"label":"Fn", "x":6.75, "y":3, "w":2.25}, {"label":"Alt", "x":9, "y":3, "w":1.5}, {"label":"Win", "x":10.5, "y":3}, {"label":"Ctrl", "x":11.5, "y":3, "w":1.5}]
+        }
+    }
+}

--- a/keyboards/dyz/dyz40/keymaps/default/keymap.c
+++ b/keyboards/dyz/dyz40/keymaps/default/keymap.c
@@ -1,0 +1,43 @@
+/* Copyright 2021 dayatz
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include QMK_KEYBOARD_H
+
+enum layer_names {
+    _BASE,
+    _FN,
+    _FN2
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  [_BASE] = LAYOUT_all( /* Base */
+    KC_ESC,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,  KC_Y, KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC,
+    KC_TAB,  KC_A,    KC_S,    KC_D,    KC_F,    KC_G,  KC_H, KC_J,    KC_K,    KC_L,    KC_QUOT,       KC_ENT,
+    KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,  KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH,        KC_RSFT,
+    KC_LCTL, KC_LWIN, KC_LALT,                   KC_SPC,         MO(_FN), MO(_FN2), KC_RALT,  KC_RWIN, KC_SCLN
+  ),
+  [_FN] = LAYOUT_all(
+    KC_CAPS, KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,   KC_9, KC_0,    KC_MINS, KC_EQL,
+    _______, _______, _______,    _______,    _______,    _______,    _______,    _______,    _______,    _______, _______, _______,
+    _______, _______, _______,    _______,    _______,    _______,    _______,    _______,    _______, _______,  _______, _______,
+    _______, _______, _______, _______, _______, _______, _______, _______, _______
+  ),
+  [_FN2] = LAYOUT_all(
+    KC_GRV,  KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,   KC_F9, KC_F10,    KC_F11, KC_F12,
+    _______, _______,    _______,    _______,    _______,    _______,    _______,    _______,    _______,    _______,    _______, _______,
+    _______, _______,    _______,    _______,    _______,    _______,    _______,    _______, _______,   _______,          _______, _______,
+    _______, _______, _______, _______, _______, _______, _______, _______, _______
+  )
+};

--- a/keyboards/dyz/dyz40/keymaps/via/keymap.c
+++ b/keyboards/dyz/dyz40/keymaps/via/keymap.c
@@ -1,0 +1,43 @@
+/* Copyright 2021 dayatz
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include QMK_KEYBOARD_H
+
+enum layer_names {
+    _BASE,
+    _FN,
+    _FN2
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  [_BASE] = LAYOUT_all( /* Base */
+    KC_ESC,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,  KC_Y, KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC,
+    KC_TAB,  KC_A,    KC_S,    KC_D,    KC_F,    KC_G,  KC_H, KC_J,    KC_K,    KC_L,    KC_QUOT,       KC_ENT,
+    KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,  KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH,        KC_RSFT,
+    KC_LCTL, KC_LWIN, KC_LALT,                   KC_SPC,         MO(_FN), MO(_FN2), KC_RALT,  KC_RWIN, KC_SCLN
+  ),
+  [_FN] = LAYOUT_all(
+    KC_CAPS, KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,   KC_9, KC_0,    KC_MINS, KC_EQL,
+    _______, _______, _______,    _______,    _______,    _______,    _______,    _______,    _______,    _______, _______, _______,
+    _______, _______, _______,    _______,    _______,    _______,    _______,    _______,    _______, _______,  _______, _______,
+    _______, _______, _______, _______, _______, _______, _______, _______, _______
+  ),
+  [_FN2] = LAYOUT_all(
+    KC_GRV,  KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,   KC_F9, KC_F10,    KC_F11, KC_F12,
+    _______, _______,    _______,    _______,    _______,    _______,    _______,    _______,    _______,    _______,    _______, _______,
+    _______, _______,    _______,    _______,    _______,    _______,    _______,    _______, _______,   _______,          _______, _______,
+    _______, _______, _______, _______, _______, _______, _______, _______, _______
+  )
+};

--- a/keyboards/dyz/dyz40/keymaps/via/rules.mk
+++ b/keyboards/dyz/dyz40/keymaps/via/rules.mk
@@ -1,0 +1,1 @@
+VIA_ENABLE = yes

--- a/keyboards/dyz/dyz40/readme.md
+++ b/keyboards/dyz/dyz40/readme.md
@@ -1,0 +1,18 @@
+# dyz40
+
+40% 13u hotswap with multiple layouts for bottom row
+![pcb](https://i.imgur.com/XFYzF94.jpg)
+
+-   Keyboard Maintainer: [dayatz](https://github.com/dayatz)
+-   Hardware Supported: ATMega32u4
+-   Hardware Availability: Local Indonesia GB.
+
+Make example for this keyboard (after setting up your build environment):
+
+    make dyz/dyz40:default
+
+Flashing example for this keyboard:
+
+    make dyz/dyz40:default:flash
+
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).

--- a/keyboards/dyz/dyz40/readme.md
+++ b/keyboards/dyz/dyz40/readme.md
@@ -1,7 +1,8 @@
 # dyz40
 
+![pcb](https://i.imgur.com/XFYzF94h.jpg)
+
 40% 13u hotswap with multiple layouts for bottom row
-![pcb](https://i.imgur.com/XFYzF94.jpg)
 
 -   Keyboard Maintainer: [dayatz](https://github.com/dayatz)
 -   Hardware Supported: ATMega32u4

--- a/keyboards/dyz/dyz40/readme.md
+++ b/keyboards/dyz/dyz40/readme.md
@@ -17,3 +17,11 @@ Flashing example for this keyboard:
     make dyz/dyz40:default:flash
 
 See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
+
+## Bootloader
+
+Enter the bootloader in 3 ways:
+
+-   **Bootmagic reset**: Hold the `Esc` key while plugging in the USB cable
+-   **Physical reset button**: Briefly short the pins under the Enter key
+-   **Keycode in layout**: Press the key mapped to `RESET` if it is available

--- a/keyboards/dyz/dyz40/rules.mk
+++ b/keyboards/dyz/dyz40/rules.mk
@@ -1,0 +1,22 @@
+# MCU name
+MCU = atmega32u4
+
+# Bootloader selection
+BOOTLOADER = atmel-dfu
+
+# Build Options
+#   change yes to no to disable
+#
+BOOTMAGIC_ENABLE = lite     # Enable Bootmagic Lite
+MOUSEKEY_ENABLE = no        # Mouse keys
+EXTRAKEY_ENABLE = yes       # Audio control and System control
+CONSOLE_ENABLE = no         # Console for debug
+COMMAND_ENABLE = no         # Commands for debug and configuration
+# Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
+SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
+# if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+NKRO_ENABLE = yes           # USB Nkey Rollover
+BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
+RGBLIGHT_ENABLE = yes       # Enable keyboard RGB underglow
+AUDIO_ENABLE = no           # Audio output
+ENCODER_ENABLE = yes

--- a/keyboards/dyz/dyz40/rules.mk
+++ b/keyboards/dyz/dyz40/rules.mk
@@ -7,7 +7,7 @@ BOOTLOADER = atmel-dfu
 # Build Options
 #   change yes to no to disable
 #
-BOOTMAGIC_ENABLE = lite     # Enable Bootmagic Lite
+BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
 MOUSEKEY_ENABLE = no        # Mouse keys
 EXTRAKEY_ENABLE = yes       # Audio control and System control
 CONSOLE_ENABLE = no         # Console for debug


### PR DESCRIPTION
# dyz40

40% 13u hotswap with multiple layouts for bottom row
![pcb](https://i.imgur.com/XFYzF94.jpg)

* Keyboard Maintainer: [dayatz](https://github.com/dayatz)
* Hardware Supported: dyz40, ATMega32u4
* Hardware Availability: Local Indonesia GB.

Make example for this keyboard (after setting up your build environment):

    make dyz/dyz40:default

Flashing example for this keyboard:

    make dyz/dyz40:default:flash

See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
