### PR TITLE
Set USB max power consumption of kint* controllers to 100mA

### DIFF
--- a/keyboards/kinesis/kint2pp/config.h
+++ b/keyboards/kinesis/kint2pp/config.h
@@ -44,3 +44,7 @@
 // Reduce input latency by lowering the USB polling interval
 // from its 10ms default to the 1ms minimum that USB 1.x (Full Speed) allows:
 #define USB_POLLING_INTERVAL_MS 1
+
+// The Teensy 2++ consumes about 60 mA of current at its full speed of 16 MHz as
+// per https://www.pjrc.com/teensy/low_power.html
+#define USB_MAX_POWER_CONSUMPTION 100

--- a/keyboards/kinesis/kint36/config.h
+++ b/keyboards/kinesis/kint36/config.h
@@ -63,6 +63,10 @@
 // from its 10ms default to the 1ms minimum that USB 1.x (Full Speed) allows:
 #define USB_POLLING_INTERVAL_MS 1
 
+// The Teensy 3.6 consumes about 80 mA of current at its full speed of 180 MHz:
+// https://forum.pjrc.com/threads/47256-What-is-the-power-consumption-of-the-Teensy-3-6
+#define USB_MAX_POWER_CONSUMPTION 100
+
 #define LED_PIN_ON_STATE 0
 #define LED_NUM_LOCK_PIN A14
 #define LED_CAPS_LOCK_PIN C7

--- a/keyboards/kinesis/kint41/config.h
+++ b/keyboards/kinesis/kint41/config.h
@@ -90,6 +90,10 @@
 // from its 10ms default to the 125μs minimum that USB 2.x (High Speed) allows:
 #define USB_POLLING_INTERVAL_MS 1
 
+// The Teensy 4.1 consumes about 100 mA of current at its full speed of 600 MHz
+// as per https://www.pjrc.com/store/teensy41.html
+#define USB_MAX_POWER_CONSUMPTION 100
+
 /* We use the i.MX RT1060 high-speed GPIOs (GPIO6-9) which are connected to the
  * AHB bus (AHB_CLK_ROOT), which runs at the same speed as the ARM Core Clock,
  * i.e. 600 MHz. See MIMXRT1062, page 949, 12.1 Chip-specific GPIO information.


### PR DESCRIPTION
All generations of Teensy microcontrollers stay below (or at) the 100mA mark.

This makes the controllers work in tight power budgets, e.g. when connected to a
USB hub.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
