### PR TITLE
[Keyboard] smallkeyboard fix of rgb matrix config

### DIFF
--- a/keyboards/smallkeyboard/smallkeyboard.c
+++ b/keyboards/smallkeyboard/smallkeyboard.c
@@ -1,35 +1,35 @@
 /* Copyright 2021 zhouqiong19840119
-  * 
-  * This program is free software: you can redistribute it and/or modify 
-  * it under the terms of the GNU General Public License as published by 
-  * the Free Software Foundation, either version 2 of the License, or 
-  * (at your option) any later version. 
-  * 
-  * This program is distributed in the hope that it will be useful, 
-  * but WITHOUT ANY WARRANTY; without even the implied warranty of 
-  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
-  * GNU General Public License for more details. 
-  * 
-  * You should have received a copy of the GNU General Public License 
-  * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
-  */ 
+  *
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 2 of the License, or
+  * (at your option) any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  */
 #include "smallkeyboard.h"
 
 #ifdef RGB_MATRIX_ENABLE
 
-const is31_led g_is31_leds[DRIVER_LED_TOTAL] = {
-/* Refer to IS31 manual for these locations
- *   driver
- *   |  R location
- *   |  |       G location
- *   |  |       |       B location
- *   |  |       |       | */
-	{0, C1_3,  C2_3,  C3_3},// BL1
-    {0, C1_4,  C2_4,  C3_4},// BL2
-    {0, C1_5,  C2_5,  C3_5},// BL3
-    {0, C1_11, C2_11, C3_11},// BL4
-    {0, C1_12, C2_12, C3_12},// BL5
-    {0, C1_13, C2_13, C3_13},// BL6
+const is31_led __flash g_is31_leds[DRIVER_LED_TOTAL] = {
+    /* Refer to IS31 manual for these locations
+     *   driver
+     *   |  R location
+     *   |  |       G location
+     *   |  |       |       B location
+     *   |  |       |       | */
+    {0, C1_3, C2_3, C3_3},     // BL1
+    {0, C1_4, C2_4, C3_4},     // BL2
+    {0, C1_5, C2_5, C3_5},     // BL3
+    {0, C1_11, C2_11, C3_11},  // BL4
+    {0, C1_12, C2_12, C3_12},  // BL5
+    {0, C1_13, C2_13, C3_13},  // BL6
 };
 
 led_config_t g_led_config = {
@@ -42,7 +42,7 @@ led_config_t g_led_config = {
         { 80, 16},{ 64, 32},{ 80, 32}
     },
     {
-        4, 4, 4, 
+        4, 4, 4,
         1, 1, 4
     }
 };


### PR DESCRIPTION
## Description

Didn't catch the lack of `__flash` in the rgb matrix config for the `smallkeyboard`

## Types of Changes

- [x] Bugfix
- [x] Keyboard (addition or update)

## Issues Fixed or Closed by This PR

* Tzarc CI

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
