### PR TITLE
Remove keyboard-level `COMBO_ENABLE` rules

### DIFF
--- a/keyboards/handwired/aek64/config.h
+++ b/keyboards/handwired/aek64/config.h
@@ -49,8 +49,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* Enable double tab */
 #define TAPPING_TERM 175
 
-#define COMBO_COUNT 1
-
 #define BACKLIGHT_PIN B7
 #define BACKLIGHT_BREATHING
 #define BACKLIGHT_LEVELS 5

--- a/keyboards/handwired/aek64/keymaps/4sstylz/config.h
+++ b/keyboards/handwired/aek64/keymaps/4sstylz/config.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#define COMBO_COUNT 1

--- a/keyboards/handwired/aek64/keymaps/4sstylz/rules.mk
+++ b/keyboards/handwired/aek64/keymaps/4sstylz/rules.mk
@@ -1,0 +1,1 @@
+COMBO_ENABLE = yes

--- a/keyboards/handwired/aek64/rules.mk
+++ b/keyboards/handwired/aek64/rules.mk
@@ -15,6 +15,5 @@ COMMAND_ENABLE   = yes # Commands for debug and configuration
 SLEEP_LED_ENABLE = no  # Breathing sleep LED during USB suspend
 NKRO_ENABLE      = no  # USB Nkey Rollover - not yet supported in LUFA
 UNICODE_ENABLE   = yes # Enable support for arrow keys icon on the second layer.
-COMBO_ENABLE     = yes # Enable combo for special function when using multiple keys at once.
 NKRO_ENABLE      = yes
 BACKLIGHT_ENABLE = yes

--- a/keyboards/maxr1998/phoebe/rules.mk
+++ b/keyboards/maxr1998/phoebe/rules.mk
@@ -13,7 +13,6 @@ MOUSEKEY_ENABLE = no       # Mouse keys
 EXTRAKEY_ENABLE = no       # Audio control and System control
 CONSOLE_ENABLE = yes       # Console for debug
 COMMAND_ENABLE = no        # Commands for debug and configuration
-COMBO_ENABLE = no          # Key combo feature
 NKRO_ENABLE = yes          # Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
 BACKLIGHT_ENABLE = no      # Enable keyboard backlight functionality
 AUDIO_ENABLE = no          # Audio output

--- a/keyboards/uranuma/rules.mk
+++ b/keyboards/uranuma/rules.mk
@@ -21,5 +21,4 @@ RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 UNICODE_ENABLE = no         # Unicode
 AUDIO_ENABLE = no           # Audio output
 
-#COMBO_ENABLE = yes
 #SRC +=  .nicola.c \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Combos currently cannot be enabled at keyboard level, as it requires custom code that the Configurator doesn't generate.

@4sStylZ this lightly touches your AEK64 keymap.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
