### PR TITLE
Remove BLUETOOTH_ENABLE from keyboard-level rules.mk (2021-09-22)

### DIFF
--- a/keyboards/canary/canary60rgb/v1/rules.mk
+++ b/keyboards/canary/canary60rgb/v1/rules.mk
@@ -18,7 +18,6 @@ SLEEP_LED_ENABLE = no          # Breathing sleep LED during USB suspend
 NKRO_ENABLE = yes              # USB Nkey Rollover
 BACKLIGHT_ENABLE = no          # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no           # Enable keyboard RGB underglow
-BLUETOOTH_ENABLE = no          # Enable Bluetooth
 AUDIO_ENABLE = no              # Audio output
 RGB_MATRIX_ENABLE = yes        # Use RGB matrix
 RGB_MATRIX_DRIVER = IS31FL3733

--- a/keyboards/handwired/slash/rules.mk
+++ b/keyboards/handwired/slash/rules.mk
@@ -22,6 +22,6 @@ NKRO_ENABLE = no            # USB Nkey Rollover
 BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 UNICODE_ENABLE = no         # Unicode
-#BLUETOOTH_ENABLE = Yes # Enable Bluetooth with the Adafruit EZ-Key HID
+BLUETOOTH_ENABLE = no       # Enable Bluetooth
 BLUETOOTH = AdafruitBLE
 AUDIO_ENABLE = no           # Audio output

--- a/keyboards/handwired/slash/rules.mk
+++ b/keyboards/handwired/slash/rules.mk
@@ -22,6 +22,5 @@ NKRO_ENABLE = no            # USB Nkey Rollover
 BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 UNICODE_ENABLE = no         # Unicode
-BLUETOOTH_ENABLE = no       # Enable Bluetooth
 BLUETOOTH = AdafruitBLE
 AUDIO_ENABLE = no           # Audio output

--- a/keyboards/kiwikeebs/macro_v2/rules.mk
+++ b/keyboards/kiwikeebs/macro_v2/rules.mk
@@ -16,6 +16,5 @@ SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
 NKRO_ENABLE = yes            # USB Nkey Rollover
 BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-BLUETOOTH_ENABLE = no       # Enable Bluetooth
 AUDIO_ENABLE = no           # Audio output
 ENCODER_ENABLE = yes

--- a/keyboards/kprepublic/bm43hsrgb/rules.mk
+++ b/keyboards/kprepublic/bm43hsrgb/rules.mk
@@ -18,7 +18,6 @@ SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
 NKRO_ENABLE = no            # USB Nkey Rollover
 BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = yes       # Enable keyboard RGB underglow
-BLUETOOTH_ENABLE = no       # Enable Bluetooth
 AUDIO_ENABLE = no           # Audio output
 
 KEY_LOCK_ENABLE = no        # Enable KC_LOCK support

--- a/keyboards/mode/m65s/rules.mk
+++ b/keyboards/mode/m65s/rules.mk
@@ -15,7 +15,6 @@ SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
 NKRO_ENABLE = no           # USB Nkey Rollover
 BACKLIGHT_ENABLE = no      # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-BLUETOOTH_ENABLE = no       # Enable Bluetooth
 AUDIO_ENABLE = no           # Audio output
 EEPROM_DRIVER = i2c
 # Enter lower-power sleep mode when on the ChibiOS idle thread

--- a/keyboards/mokey/mokey63/rules.mk
+++ b/keyboards/mokey/mokey63/rules.mk
@@ -18,6 +18,4 @@ SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
 NKRO_ENABLE = no            # USB Nkey Rollover
 BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-BLUETOOTH_ENABLE = no       # Enable Bluetooth
 AUDIO_ENABLE = no           # Audio output
-

--- a/keyboards/nix_studio/oxalys80/rules.mk
+++ b/keyboards/nix_studio/oxalys80/rules.mk
@@ -18,7 +18,6 @@ SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
 NKRO_ENABLE = no            # USB Nkey Rollover
 BACKLIGHT_ENABLE = yes      # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = yes       # Enable RGB underglow
-BLUETOOTH_ENABLE = no       # Enable Bluetooth
 AUDIO_ENABLE = no           # Audio output
 LTO_ENABLE = yes
 


### PR DESCRIPTION
## Description

Except where `BLUETOOTH_ENABLE` is `yes` or `BLUETOOTH` is set - those few will eventually (in develop) be changed to eg.

```makefile
BLUETOOTH_ENABLE = yes
BLUETOOTH_DRIVER = AdafruitBLE|RN42
```

## Types of Changes

- [x] Enhancement/optimization
- [x] Keyboard (addition or update)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
