### PR TITLE
Zinc: Clean up LTO rules

### DIFF
--- a/keyboards/zinc/keymaps/default/rules.mk
+++ b/keyboards/zinc/keymaps/default/rules.mk
@@ -14,6 +14,7 @@ AUDIO_ENABLE = no           # Audio output
 UNICODE_ENABLE = no         # Unicode
 RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight.  Do not enable this with audio at the same time.
 SWAP_HANDS_ENABLE = no        # Enable one-hand typing
+LTO_ENABLE = no             # if firmware size over limit, try this option
 
 define ZINC_CUSTOMISE_MSG
   $(info Zinc customize)
@@ -35,7 +36,6 @@ RGB_MATRIX = no             # RGB LED Matrix
 RGB_MATRIX_SPLIT_RIGHT = no # RGB Matrix for RIGHT Hand
 LED_ANIMATIONS = yes        # LED animations
 IOS_DEVICE_ENABLE = no      # connect to IOS device (iPad,iPhone)
-Link_Time_Optimization = no # if firmware size over limit, try this option
 
 ####  LED_BACK_ENABLE and LED_UNDERGLOW_ENABLE.
 ####    Do not enable these with audio at the same time.
@@ -119,10 +119,6 @@ endif
 
 ifeq ($(strip $(RGB_MATRIX_SPLIT_RIGHT)), yes)
     OPT_DEFS += -DRGB_MATRIX_SPLIT_RIGHT
-endif
-
-ifeq ($(strip $(Link_Time_Optimization)),yes)
-  EXTRAFLAGS += -flto -DUSE_Link_Time_Optimization
 endif
 
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE

--- a/keyboards/zinc/keymaps/ginjake/rules.mk
+++ b/keyboards/zinc/keymaps/ginjake/rules.mk
@@ -15,6 +15,7 @@ UNICODE_ENABLE = no         # Unicode
 BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
 RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight.  Do not enable this with audio at the same time.
 SWAP_HANDS_ENABLE = no        # Enable one-hand typing
+LTO_ENABLE = no             # if firmware size over limit, try this option
 
 define ZINC_CUSTOMISE_MSG
   $(info Zinc customize)
@@ -33,7 +34,6 @@ LED_BOTH_ENABLE = no        # LED backlight and underglow
 LED_RGB_CONT = no           # LED continuous backlight or/and underglow between left Zinc and right Zinc
 LED_ANIMATIONS = yes        # LED animations
 IOS_DEVICE_ENABLE = no      # connect to IOS device (iPad,iPhone)
-Link_Time_Optimization = no # if firmware size over limit, try this option
 
 ####  LED_BACK_ENABLE and LED_UNDERGLOW_ENABLE.
 ####    Do not enable these with audio at the same time.
@@ -102,10 +102,6 @@ ifeq ($(strip $(LED_ANIMATIONS)), yes)
 # OPT_DEFS += -DRGBLIGHT_ANIMATIONS
   OPT_DEFS += -DLED_ANIMATIONS
 
-endif
-
-ifeq ($(strip $(Link_Time_Optimization)),yes)
-  EXTRAFLAGS += -flto -DUSE_Link_Time_Optimization
 endif
 
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE

--- a/keyboards/zinc/keymaps/monks/rules.mk
+++ b/keyboards/zinc/keymaps/monks/rules.mk
@@ -15,6 +15,7 @@ UNICODE_ENABLE = no         # Unicode
 BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
 RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight.  Do not enable this with audio at the same time.
 SWAP_HANDS_ENABLE = no        # Enable one-hand typing
+LTO_ENABLE = no             # if firmware size over limit, try this option
 
 define ZINC_CUSTOMISE_MSG
   $(info Zinc customize)
@@ -33,7 +34,6 @@ LED_BOTH_ENABLE = no        # LED backlight and underglow
 LED_RGB_CONT = no           # LED continuous backlight or/and underglow between left Zinc and right Zinc
 LED_ANIMATIONS = yes        # LED animations
 IOS_DEVICE_ENABLE = no      # connect to IOS device (iPad,iPhone)
-Link_Time_Optimization = no # if firmware size over limit, try this option
 
 ####  LED_BACK_ENABLE and LED_UNDERGLOW_ENABLE.
 ####    Do not enable these with audio at the same time.
@@ -102,10 +102,6 @@ ifeq ($(strip $(LED_ANIMATIONS)), yes)
 # OPT_DEFS += -DRGBLIGHT_ANIMATIONS
   OPT_DEFS += -DLED_ANIMATIONS
 
-endif
-
-ifeq ($(strip $(Link_Time_Optimization)),yes)
-  EXTRAFLAGS += -flto -DUSE_Link_Time_Optimization
 endif
 
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE

--- a/keyboards/zinc/keymaps/toshi0383/rules.mk
+++ b/keyboards/zinc/keymaps/toshi0383/rules.mk
@@ -15,6 +15,7 @@ UNICODE_ENABLE = no         # Unicode
 BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
 RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight.  Do not enable this with audio at the same time.
 SWAP_HANDS_ENABLE = no      # Enable one-hand typing
+LTO_ENABLE = no             # if firmware size over limit, try this option
 
 define ZINC_CUSTOMISE_MSG
   $(info Zinc customize)
@@ -36,7 +37,6 @@ RGB_MATRIX = no             # RGB LED Matrix
 RGB_MATRIX_SPLIT_RIGHT = no # RGB Matrix for RIGHT Hand
 LED_ANIMATIONS = yes        # LED animations
 IOS_DEVICE_ENABLE = no      # connect to IOS device (iPad,iPhone)
-Link_Time_Optimization = no # if firmware size over limit, try this option
 
 ####  LED_BACK_ENABLE and LED_UNDERGLOW_ENABLE.
 ####    Do not enable these with audio at the same time.
@@ -120,10 +120,6 @@ endif
 
 ifeq ($(strip $(RGB_MATRIX_SPLIT_RIGHT)), yes)
     OPT_DEFS += -DRGB_MATRIX_SPLIT_RIGHT
-endif
-
-ifeq ($(strip $(Link_Time_Optimization)),yes)
-  EXTRAFLAGS += -flto -DUSE_Link_Time_Optimization
 endif
 
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Removing the `Link_Time_Optimization` rule in favour of the core `LTO_ENABLE` rule.

@ginjake @monksoffunk @toshi0383

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
