### PR TITLE
Remove GCC version check from song list inclusion

### DIFF
--- a/quantum/audio/song_list.h
+++ b/quantum/audio/song_list.h
@@ -20,11 +20,9 @@
 
 #include "musical_notes.h"
 
-#if __GNUC__ > 5  // don't use for older gcc compilers since check isn't supported.
-#    if __has_include("user_song_list.h")
-#        include "user_song_list.h"
-#    endif  // if file exists
-#endif      // __GNUC__
+#if __has_include("user_song_list.h")
+#    include "user_song_list.h"
+#endif  // if file exists
 
 #define NO_SOUND
 


### PR DESCRIPTION
## Description

This appears to not be an issue with avr-gcc 5.  May have been fixed with the binaries, not sure. 

But appears to be safe to remove. 

## Types of Changes

- [x] Core
- [x] Enhancement/optimization

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
