### PR TITLE
[keymap][docs] correct a wrong statement

### DIFF
--- a/keyboards/splitkb/kyria/keymaps/default/readme.md
+++ b/keyboards/splitkb/kyria/keymaps/default/readme.md
@@ -71,7 +71,7 @@ First thing to notice is the presence of blank keys. To fill in the blank keys a
 
 The base layer is starting to form but there remains some flaws. One glaring issue is the position of Control. Control is a very commonly used function but the key on which it sits right now is way too tucked in under the hand to be able to press it comfortably with either the thumb or the pinky from resting position. In fact, installing a rotary encoder there is a common move among Kyria users and I guarantee you that activating Control by holding down a rotary encoder does not spark joy. Instead, let's employ a popular trick that involves remapping the current Caps Lock key, which is positioned at a comfortable position on the keyboard, to Control. 
 
-We can go further though; a variant of this trick makes the Control key produce Escape when tapped. This is called a “modtap”. There is no use to tapping Control by itself without chording it with another key and there is no use to holding down the Esc key so why not combine the two into a single key?
+We can go further though; a variant of this trick makes the Control key produce Escape when tapped. This is called a “modtap”. There is no use to tapping Control by itself without chording it with another key (except for very special use cases like PhpStorm's "Run Anything" tool, which you can access via Nav or Function layer) and there is no use to holding down the Esc key so why not combine the two into a single key?
 
 All of this leaves us with three blank keys.
 


### PR DESCRIPTION
## Description

Wrong statement: _There is no use to tapping Control by itself without chording it with another key_
Correct statement: There are some uncommon use cases. Ctrl can be used on its own for PhpStorm's [Run Anything](https://www.jetbrains.com/help/idea/running-anything.html) popup.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* (not filed)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] ~~My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)~~
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] ~~My change requires a change to the documentation.~~
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] ~~I have added tests to cover my changes.~~
- [ ] ~~I have tested the changes and verified that they work and don't break anything (as well as I can manage).~~
