### PR TITLE
[Keyboard] Fix double comment in config files

### DIFF
--- a/keyboards/metamechs/timberwolf/config.h
+++ b/keyboards/metamechs/timberwolf/config.h
@@ -96,7 +96,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define FORCE_NKRO
 
 /*
-/*
  * Feature disable options
  *  These options are also useful to firmware size reduction.
  */

--- a/keyboards/mint60/config.h
+++ b/keyboards/mint60/config.h
@@ -95,7 +95,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 //#define FORCE_NKRO
 
-/*
 /* ws2812 RGB LED */
 #define RGB_DI_PIN D3
 
@@ -124,4 +123,3 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define NO_ACTION_ONESHOT
 //#define NO_ACTION_MACRO
 //#define NO_ACTION_FUNCTION
-

--- a/keyboards/miuni32/config.h
+++ b/keyboards/miuni32/config.h
@@ -87,7 +87,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define FORCE_NKRO
 
 /*
-/*
  * Feature disable options
  *  These options are also useful to firmware size reduction.
  */

--- a/keyboards/snampad/config.h
+++ b/keyboards/snampad/config.h
@@ -118,7 +118,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define FORCE_NKRO
 
 /*
-/*
  * Feature disable options
  *  These options are also useful to firmware size reduction.
  */


### PR DESCRIPTION

## Description

gcc doesn't like double comment....

```
Compiling: quantum/action_macro.c                                                                  In file included from <command-line>:0:0:
./keyboards/metamechs/timberwolf/config.h:99:1: error: "/*" within comment [-Werror=comment]
 /*
 ^
cc1: all warnings being treated as errors
 [ERRORS]
 | 
 | 
 | 
gmake[1]: *** [tmk_core/rules.mk:443: .build/obj_metamechs_timberwolf_default/quantum/action_macro.o] Error 1
```

## Types of Changes

- [x] Bugfix
- [x] Keyboard (addition or update)

## Issues Fixed or Closed by This PR

* Tzarc CI

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
