### PR TITLE
Add fix for brew upgrade

### DIFF
--- a/util/install/macos.sh
+++ b/util/install/macos.sh
@@ -9,7 +9,7 @@ _qmk_install_prepare() {
         return 1
     fi
 
-    brew update && brew upgrade --ignore-pinned
+    brew update && brew upgrade --formula --ignore-pinned
 }
 
 _qmk_install() {


### PR DESCRIPTION
This will improve usability of install scripts on systems that does not like to be updated. Adding `--formula` to `brew upgrade` will omit upgrading casks. This is an intermediate solution since there is no reason to upgrade all packages on a system for something installed with a package manager. That aside this solves an issue specifically on where upgrading casks breaks virtual box docker-machine setup for hackintosh.

If there are any packages or dependencies that needs upgrading it will
prompt the user and he/she/they/ze can consent to the upgrade or
continue without at own risk.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #12794
## Checklist

- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
