### PR TITLE
Fixing I2C init issue and RGB default status.

### DIFF
--- a/keyboards/mechwild/obe/config.h
+++ b/keyboards/mechwild/obe/config.h
@@ -62,7 +62,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define LED_CAPS_LOCK_PIN B9
 
 /* RGB settings, uncomment this define to enable RGB */
-//#define RGB_DI_PIN A0
+#define RGB_DI_PIN A0
 #ifdef RGB_DI_PIN
 #    define RGBLED_NUM 10
 #    define RGBLIGHT_HUE_STEP 8

--- a/keyboards/mechwild/obe/obe.c
+++ b/keyboards/mechwild/obe/obe.c
@@ -16,6 +16,12 @@
 
 #include "obe.h"
 
+void board_init(void) {
+    // B9 is configured as I2C1_SDA in the board file; that function must be
+    // disabled before using B7 as I2C1_SDA.
+    setPinInputHigh(B9);
+}
+
 #ifdef ENCODER_ENABLE
 bool encoder_update_kb(uint8_t index, bool clockwise) {
     if (!encoder_update_user(index, clockwise)) { return false; }

--- a/keyboards/mechwild/obe/rules.mk
+++ b/keyboards/mechwild/obe/rules.mk
@@ -11,7 +11,7 @@ SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
 # if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
 NKRO_ENABLE = no            # USB Nkey Rollover
 BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
+RGBLIGHT_ENABLE = yes        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
 ENCODER_ENABLE = yes        # Encoder Enabled
 


### PR DESCRIPTION
Changing RGB default to on so it plays well with VIA's QMK lighting section and adding the B9 init workaround to obe.c so the I2C EEPROM will initialize correctly since we are using B9 for caps lock indicator.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* I2C failed to init correctly because of the B9 usage as caps lock indicator. Additionally, RGB is now defaulted to on as the lighting tab in VIA freezes if it is off and it is selected in the VIA GUI.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
