### PR TITLE
Add ifndef to WS2812 timing constraints

### DIFF
--- a/docs/feature_rgblight.md
+++ b/docs/feature_rgblight.md
@@ -559,6 +559,23 @@ In addition to setting the Clipping Range, you can use `RGBLIGHT_LED_MAP` togeth
 ```
 <img src="https://user-images.githubusercontent.com/2170248/55743747-119e4c00-5a6e-11e9-91e5-013203ffae8a.JPG" alt="clip mapped" width="70%"/>
 
+## Adjusting bit timings
+
+The WS2812 LED communication topology depends on a serialized timed window, lasting typically 1250ns in total, where a bit is interpreted as either 0 or 1 depending on for how much time the ``RGB_DI`` pin voltage is kept high and how much time it is kept low. The WS2812 datasheet specifies quantities defined as ``T0H``, ``T0L``, ``T1H``, ``T1L`` (respectively, typically 350ns, 900ns, 900ns and 350ns); a bit is interpreted as zero if the voltage on the control pin is held high for ``T0H`` and then ``T0L``, and the bit is interpreted as one if the voltage is held high for ``T1H`` and then low for ``T1L``. Additionally, there is also a RESET time parameter whereby an LED color is reset if the voltage control pin is kept low for more than that parameter; in WS2812 that amount is 6000 nanoseconds.
+
+The WS2812 "bit-banged" ChibiOS driver does just that, in a simple way. It defines these values and governs the ``RGB_DI`` pin according to these times. There are, however, other LED parts that work in a communication topology similar to this but with different timing parameters; such is the case, for instance, of the SK6812. In order to better support such LEDs whilst keeping the WS2812 driver applicable, QMK allows you to tune these parameters through the definition macros:
+
+| Macro               |Default              |
+|---------------------|---------------------|
+|`WS2812_TIMING       |`1250`               |
+|`WS2812_T0H`         |`350`                |
+|`WS2812_T0L`         |`900`                |
+|`WS2812_T1H`         |`900`                |
+|`WS2812_T1L`         |`350`                |
+|`WS2812_RES`         |`6000`               |
+
+It must be noted, however, that this tuning is not available for PWM and SPI drivers -- so if you intend to use this be aware it will only work with the "bit-banged" driver which is knowingly slower and can possibly throttle the microcontroller if too many LEDs are used.
+
 ## Hardware Modification
 
 If your keyboard lacks onboard underglow LEDs, you may often be able to solder on an RGB LED strip yourself. You will need to find an unused pin to wire to the data pin of your LED strip. Some keyboards may break out unused pins from the MCU to make soldering easier. The other two pins, VCC and GND, must also be connected to the appropriate power pins.

--- a/docs/feature_rgblight.md
+++ b/docs/feature_rgblight.md
@@ -559,22 +559,22 @@ In addition to setting the Clipping Range, you can use `RGBLIGHT_LED_MAP` togeth
 ```
 <img src="https://user-images.githubusercontent.com/2170248/55743747-119e4c00-5a6e-11e9-91e5-013203ffae8a.JPG" alt="clip mapped" width="70%"/>
 
-## Adjusting bit timings
+## Adjusting bit timings (ChibiOS)
 
-The WS2812 LED communication topology depends on a serialized timed window, lasting typically 1250ns in total, where a bit is interpreted as either 0 or 1 depending on for how much time the ``RGB_DI`` pin voltage is kept high and how much time it is kept low. The WS2812 datasheet specifies quantities defined as ``T0H``, ``T0L``, ``T1H``, ``T1L`` (respectively, typically 350ns, 900ns, 900ns and 350ns); a bit is interpreted as zero if the voltage on the control pin is held high for ``T0H`` and then ``T0L``, and the bit is interpreted as one if the voltage is held high for ``T1H`` and then low for ``T1L``. Additionally, there is also a RESET time parameter whereby an LED color is reset if the voltage control pin is kept low for more than that parameter; in WS2812 that amount is 6000 nanoseconds.
+The WS2812 LED communication topology depends on a serialized timed window, lasting typically 1250ns in total, where a bit is interpreted as either 0 or 1 depending on for how much time the `RGB_DI` pin voltage is kept high and how much time it is kept low. The WS2812 datasheet specifies quantities defined as `T0H`, `T0L`, `T1H`, `T1L` (respectively, typically 350ns, 900ns, 900ns and 350ns); a bit is interpreted as zero if the voltage on the control pin is held high for `T0H` and then `T0L`, and the bit is interpreted as one if the voltage is held high for `T1H` and then low for `T1L`. Additionally, there is also a RESET time parameter whereby an LED color is reset if the voltage control pin is kept low for more than that parameter; in WS2812 that amount is 6000 nanoseconds.
 
-The WS2812 "bit-banged" ChibiOS driver does just that, in a simple way. It defines these values and governs the ``RGB_DI`` pin according to these times. There are, however, other LED parts that work in a communication topology similar to this but with different timing parameters; such is the case, for instance, of the SK6812. In order to better support such LEDs whilst keeping the WS2812 driver applicable, QMK allows you to tune these parameters through the definition macros:
+The WS2812 "bit-banged" ChibiOS driver does just that, in a simple way. It defines these values and governs the `RGB_DI` pin according to these times. There are, however, other LED parts that work in a communication topology similar to this but with different timing parameters; such is the case, for instance, of the SK6812. In order to better support such LEDs whilst keeping the WS2812 driver applicable, QMK allows you to tune these parameters through the definition macros:
 
-| Macro               |Default              |
-|---------------------|---------------------|
-|`WS2812_TIMING       |`1250`               |
-|`WS2812_T0H`         |`350`                |
-|`WS2812_T0L`         |`900`                |
-|`WS2812_T1H`         |`900`                |
-|`WS2812_T1L`         |`350`                |
-|`WS2812_RES`         |`6000`               |
+| Macro               |Default                                     |
+|---------------------|--------------------------------------------|
+|`WS2812_TIMING       |`1250`                                      |
+|`WS2812_T0H`         |`350`                                       |
+|`WS2812_T0L`         |`WS2812_TIMING - WS2812_T0H`                |
+|`WS2812_T1H`         |`900`                                       |
+|`WS2812_T1L`         |`WS2812_TIMING - WS2812_T1L`                |
+|`WS2812_RES`         |`6000`                                      |
 
-It must be noted, however, that this tuning is not available for PWM and SPI drivers -- so if you intend to use this be aware it will only work with the "bit-banged" driver which is knowingly slower and can possibly throttle the microcontroller if too many LEDs are used.
+It must be noted, however, that this tuning is only available for the ARM family of microprocessors (since it's ChibiOS-dependente) and only available for PWM and SPI drivers -- so if you intend to use this be aware it will only work with the "bit-banged" driver which is knowingly slower and can possibly throttle the microcontroller if too many LEDs are used.
 
 ## Hardware Modification
 

--- a/docs/feature_rgblight.md
+++ b/docs/feature_rgblight.md
@@ -559,23 +559,6 @@ In addition to setting the Clipping Range, you can use `RGBLIGHT_LED_MAP` togeth
 ```
 <img src="https://user-images.githubusercontent.com/2170248/55743747-119e4c00-5a6e-11e9-91e5-013203ffae8a.JPG" alt="clip mapped" width="70%"/>
 
-## Adjusting bit timings (ChibiOS)
-
-The WS2812 LED communication topology depends on a serialized timed window, lasting typically 1250ns in total, where a bit is interpreted as either 0 or 1 depending on for how much time the `RGB_DI` pin voltage is kept high and how much time it is kept low. The WS2812 datasheet specifies quantities defined as `T0H`, `T0L`, `T1H`, `T1L` (respectively, typically 350ns, 900ns, 900ns and 350ns); a bit is interpreted as zero if the voltage on the control pin is held high for `T0H` and then `T0L`, and the bit is interpreted as one if the voltage is held high for `T1H` and then low for `T1L`. Additionally, there is also a RESET time parameter whereby an LED color is reset if the voltage control pin is kept low for more than that parameter; in WS2812 that amount is 6000 nanoseconds.
-
-The WS2812 "bit-banged" ChibiOS driver does just that, in a simple way. It defines these values and governs the `RGB_DI` pin according to these times. There are, however, other LED parts that work in a communication topology similar to this but with different timing parameters; such is the case, for instance, of the SK6812. In order to better support such LEDs whilst keeping the WS2812 driver applicable, QMK allows you to tune these parameters through the definition macros:
-
-| Macro               |Default                                     |
-|---------------------|--------------------------------------------|
-|`WS2812_TIMING       |`1250`                                      |
-|`WS2812_T0H`         |`350`                                       |
-|`WS2812_T0L`         |`WS2812_TIMING - WS2812_T0H`                |
-|`WS2812_T1H`         |`900`                                       |
-|`WS2812_T1L`         |`WS2812_TIMING - WS2812_T1L`                |
-|`WS2812_RES`         |`6000`                                      |
-
-It must be noted, however, that this tuning is only available for the ARM family of microprocessors (since it's ChibiOS-dependente) and only available for PWM and SPI drivers -- so if you intend to use this be aware it will only work with the "bit-banged" driver which is knowingly slower and can possibly throttle the microcontroller if too many LEDs are used.
-
 ## Hardware Modification
 
 If your keyboard lacks onboard underglow LEDs, you may often be able to solder on an RGB LED strip yourself. You will need to find an unused pin to wire to the data pin of your LED strip. Some keyboards may break out unused pins from the MCU to make soldering easier. The other two pins, VCC and GND, must also be connected to the appropriate power pins.

--- a/docs/ws2812_driver.md
+++ b/docs/ws2812_driver.md
@@ -62,6 +62,23 @@ Configure the hardware via your config.h:
 #define WS2812_TIMEOUT 100 // default: 100
 ```
 
+##### Adjusting bit timings (ChibiOS only)
+
+The WS2812 LED communication topology depends on a serialized timed window, lasting typically 1250ns in total, where a bit is interpreted as either 0 or 1 depending on for how much time the `RGB_DI` pin voltage is kept high and how much time it is kept low. The WS2812 datasheet specifies quantities defined as `T0H`, `T0L`, `T1H`, `T1L` (respectively, typically 350ns, 900ns, 900ns and 350ns); a bit is interpreted as zero if the voltage on the control pin is held high for `T0H` and then `T0L`, and the bit is interpreted as one if the voltage is held high for `T1H` and then low for `T1L`. Additionally, there is also a RESET time parameter whereby an LED color is reset if the voltage control pin is kept low for more than that parameter; in WS2812 that amount is 6000 nanoseconds.
+
+The WS2812 "bit-banged" ChibiOS driver does just that, in a simple way. It defines these values and governs the `RGB_DI` pin according to these times. There are, however, other LED parts that work in a communication topology similar to this but with different timing parameters; such is the case, for instance, of the SK6812. In order to better support such LEDs whilst keeping the WS2812 driver applicable, QMK allows you to tune these parameters through the definition macros:
+
+| Macro               |Default                                     |
+|---------------------|--------------------------------------------|
+|`WS2812_TIMING       |`1250`                                      |
+|`WS2812_T0H`         |`350`                                       |
+|`WS2812_T0L`         |`WS2812_TIMING - WS2812_T0H`                |
+|`WS2812_T1H`         |`900`                                       |
+|`WS2812_T1L`         |`WS2812_TIMING - WS2812_T1L`                |
+|`WS2812_RES`         |`6000`                                      |
+
+It must be noted, however, that this tuning is only available for the ARM family of microprocessors (since it's ChibiOS-dependent) and not available for PWM and SPI drivers -- so if you intend to use this be aware it will only work with the "bit-banged" driver which is knowingly slower and can possibly throttle the microcontroller if too many LEDs are used.
+
 ### SPI
 Targeting STM32 boards where WS2812 support is offloaded to an SPI hardware device. The advantage is that the use of DMA offloads processing of the WS2812 protocol from the MCU. `RGB_DI_PIN` for this driver is the configured SPI MOSI pin. Due to the nature of repurposing SPI to drive the LEDs, the other SPI pins, MISO and SCK, **must** remain unused. To configure it, add this to your rules.mk:
 
@@ -156,21 +173,3 @@ Note: This only applies to STM32 boards.
 ```c
 #define WS2812_EXTERNAL_PULLUP
 ```
-## Adjusting bit timings (ChibiOS only)
-
-The WS2812 LED communication topology depends on a serialized timed window, lasting typically 1250ns in total, where a bit is interpreted as either 0 or 1 depending on for how much time the `RGB_DI` pin voltage is kept high and how much time it is kept low. The WS2812 datasheet specifies quantities defined as `T0H`, `T0L`, `T1H`, `T1L` (respectively, typically 350ns, 900ns, 900ns and 350ns); a bit is interpreted as zero if the voltage on the control pin is held high for `T0H` and then `T0L`, and the bit is interpreted as one if the voltage is held high for `T1H` and then low for `T1L`. Additionally, there is also a RESET time parameter whereby an LED color is reset if the voltage control pin is kept low for more than that parameter; in WS2812 that amount is 6000 nanoseconds.
-
-The WS2812 "bit-banged" ChibiOS driver does just that, in a simple way. It defines these values and governs the `RGB_DI` pin according to these times. There are, however, other LED parts that work in a communication topology similar to this but with different timing parameters; such is the case, for instance, of the SK6812. In order to better support such LEDs whilst keeping the WS2812 driver applicable, QMK allows you to tune these parameters through the definition macros:
-
-| Macro               |Default                                     |
-|---------------------|--------------------------------------------|
-|`WS2812_TIMING       |`1250`                                      |
-|`WS2812_T0H`         |`350`                                       |
-|`WS2812_T0L`         |`WS2812_TIMING - WS2812_T0H`                |
-|`WS2812_T1H`         |`900`                                       |
-|`WS2812_T1L`         |`WS2812_TIMING - WS2812_T1L`                |
-|`WS2812_RES`         |`6000`                                      |
-
-It must be noted, however, that this tuning is only available for the ARM family of microprocessors (since it's ChibiOS-dependente) and only available for PWM and SPI drivers -- so if you intend to use this be aware it will only work with the "bit-banged" driver which is knowingly slower and can possibly throttle the microcontroller if too many LEDs are used.
-
-

--- a/docs/ws2812_driver.md
+++ b/docs/ws2812_driver.md
@@ -156,3 +156,21 @@ Note: This only applies to STM32 boards.
 ```c
 #define WS2812_EXTERNAL_PULLUP
 ```
+## Adjusting bit timings (ChibiOS only)
+
+The WS2812 LED communication topology depends on a serialized timed window, lasting typically 1250ns in total, where a bit is interpreted as either 0 or 1 depending on for how much time the `RGB_DI` pin voltage is kept high and how much time it is kept low. The WS2812 datasheet specifies quantities defined as `T0H`, `T0L`, `T1H`, `T1L` (respectively, typically 350ns, 900ns, 900ns and 350ns); a bit is interpreted as zero if the voltage on the control pin is held high for `T0H` and then `T0L`, and the bit is interpreted as one if the voltage is held high for `T1H` and then low for `T1L`. Additionally, there is also a RESET time parameter whereby an LED color is reset if the voltage control pin is kept low for more than that parameter; in WS2812 that amount is 6000 nanoseconds.
+
+The WS2812 "bit-banged" ChibiOS driver does just that, in a simple way. It defines these values and governs the `RGB_DI` pin according to these times. There are, however, other LED parts that work in a communication topology similar to this but with different timing parameters; such is the case, for instance, of the SK6812. In order to better support such LEDs whilst keeping the WS2812 driver applicable, QMK allows you to tune these parameters through the definition macros:
+
+| Macro               |Default                                     |
+|---------------------|--------------------------------------------|
+|`WS2812_TIMING       |`1250`                                      |
+|`WS2812_T0H`         |`350`                                       |
+|`WS2812_T0L`         |`WS2812_TIMING - WS2812_T0H`                |
+|`WS2812_T1H`         |`900`                                       |
+|`WS2812_T1L`         |`WS2812_TIMING - WS2812_T1L`                |
+|`WS2812_RES`         |`6000`                                      |
+
+It must be noted, however, that this tuning is only available for the ARM family of microprocessors (since it's ChibiOS-dependente) and only available for PWM and SPI drivers -- so if you intend to use this be aware it will only work with the "bit-banged" driver which is knowingly slower and can possibly throttle the microcontroller if too many LEDs are used.
+
+

--- a/platforms/chibios/drivers/ws2812.c
+++ b/platforms/chibios/drivers/ws2812.c
@@ -60,13 +60,15 @@ However, there are certain "WS2812"-like LEDs, like the SK6812s, which work in a
 #    define WS2812_T0H 350  // Width of a 0 bit in ns
 #endif
 
-#ifndef T0L
+#ifndef WS2812_T0L
 #    define WS2812_T0L (WS2812_TIMING - T0H)  // Width of a 0 bit in ns
 #endif
 
 // The reset gap can be 6000 ns, but depending on the LED strip it may have to be increased
 // to values like 600000 ns. If it is too small, the pixels will show nothing most of the time.
-#define WS2812_RES (1000 * WS2812_TRST_US)  // Width of the low gap between bits to cause a frame to latch
+#ifndef WS2812_RES
+#	define WS2812_RES (1000 * WS2812_TRST_US)  // Width of the low gap between bits to cause a frame to latch
+#endif
 
 void sendByte(uint8_t byte) {
     // WS2812 protocol wants most significant bits first

--- a/platforms/chibios/drivers/ws2812.c
+++ b/platforms/chibios/drivers/ws2812.c
@@ -67,7 +67,7 @@ However, there are certain "WS2812"-like LEDs, like the SK6812s, which work in a
 // The reset gap can be 6000 ns, but depending on the LED strip it may have to be increased
 // to values like 600000 ns. If it is too small, the pixels will show nothing most of the time.
 #ifndef WS2812_RES
-#	define WS2812_RES (1000 * WS2812_TRST_US)  // Width of the low gap between bits to cause a frame to latch
+#    define WS2812_RES (1000 * WS2812_TRST_US)  // Width of the low gap between bits to cause a frame to latch
 #endif
 
 void sendByte(uint8_t byte) {

--- a/platforms/chibios/drivers/ws2812.c
+++ b/platforms/chibios/drivers/ws2812.c
@@ -41,7 +41,7 @@
     } while (0)
 
 /* The WS2812 datasheets define T1H 900ns, T0H 350ns, T1L 350ns, T0L 900ns. Hence, by default, these are chosen to be conservative and avoid problems rather than for maximum throughput; in the code, this is done by default using a WS2812_TIMING parameter that accounts for the whole window (1250ns) and defining T1H and T0H; T1L and T0L are obtained by subtracting their low counterparts from the window.
-However, there are certain "WS2812"-like LEDs, like the SK6812s, which work in a similar communication topology but use different timings for the window and the T1L, T1H, T0L and T0H. This means that, albeit the same driver being applicable, the timings must be adapted. The following defines are dons such that the adjustment of these timings can be done in the keyboard's config.h; if nothing is said, the defines default to the WS2812 ones.
+However, there are certain "WS2812"-like LEDs, like the SK6812s, which work in a similar communication topology but use different timings for the window and the T1L, T1H, T0L and T0H. This means that, albeit the same driver being applicable, the timings must be adapted. The following defines are done such that the adjustment of these timings can be done in the keyboard's config.h; if nothing is said, the defines default to the WS2812 ones.
 */
 
 #ifndef WS2812_TIMING

--- a/platforms/chibios/drivers/ws2812.c
+++ b/platforms/chibios/drivers/ws2812.c
@@ -40,28 +40,33 @@
         }                                           \
     } while (0)
 
-// These are the timing constraints taken mostly from the WS2812 datasheets
-// These are chosen to be conservative and avoid problems rather than for maximum throughput
+/* The WS2812 datasheets define T1H 900ns, T0H 350ns, T1L 350ns, T0L 900ns. Hence, by default, these are chosen to be conservative and avoid problems rather than for maximum throughput; in the code, this is done by default using a WS2812_TIMING parameter that accounts for the whole window (1250ns) and defining T1H and T0H; T1L and T0L are obtained by subtracting their low counterparts from the window.
+However, there are certain "WS2812"-like LEDs, like the SK6812s, which work in a similar communication topology but use different timings for the window and the T1L, T1H, T0L and T0H. This means that, albeit the same driver being applicable, the timings must be adapted. The following defines are dons such that the adjustment of these timings can be done in the keyboard's config.h; if nothing is said, the defines default to the WS2812 ones.
+*/
 
-#ifndef T1H
-#    define T1H 900  // Width of a 1 bit in ns
+#ifndef WS2812_TIMING
+#    define WS2812_TIMING 1250
 #endif
 
-#ifndef T1L
-#    define T1L (1250 - T1H)  // Width of a 1 bit in ns
+#ifndef WS2812_T1H
+#    define WS2812_T1H 900  // Width of a 1 bit in ns
 #endif
 
-#ifndef T0H
-#    define T0H 350  // Width of a 0 bit in ns
+#ifndef WS2812_T1L
+#    define WS2812_T1L (WS2812_TIMING - T1H)  // Width of a 1 bit in ns
+#endif
+
+#ifndef WS2812_T0H
+#    define WS2812_T0H 350  // Width of a 0 bit in ns
 #endif
 
 #ifndef T0L
-#    define T0L (1250 - T0H)  // Width of a 0 bit in ns
+#    define WS2812_T0L (WS2812_TIMING - T0H)  // Width of a 0 bit in ns
 #endif
 
 // The reset gap can be 6000 ns, but depending on the LED strip it may have to be increased
 // to values like 600000 ns. If it is too small, the pixels will show nothing most of the time.
-#define RES (1000 * WS2812_TRST_US)  // Width of the low gap between bits to cause a frame to latch
+#define WS2812_RES (1000 * WS2812_TRST_US)  // Width of the low gap between bits to cause a frame to latch
 
 void sendByte(uint8_t byte) {
     // WS2812 protocol wants most significant bits first
@@ -71,15 +76,15 @@ void sendByte(uint8_t byte) {
         if (is_one) {
             // 1
             writePinHigh(RGB_DI_PIN);
-            wait_ns(T1H);
+            wait_ns(WS2812_T1H);
             writePinLow(RGB_DI_PIN);
-            wait_ns(T1L);
+            wait_ns(WS2812_T1L);
         } else {
             // 0
             writePinHigh(RGB_DI_PIN);
-            wait_ns(T0H);
+            wait_ns(WS2812_T0H);
             writePinLow(RGB_DI_PIN);
-            wait_ns(T0L);
+            wait_ns(WS2812_T0L);
         }
     }
 }
@@ -118,7 +123,7 @@ void ws2812_setleds(LED_TYPE *ledarray, uint16_t leds) {
 #endif
     }
 
-    wait_ns(RES);
+    wait_ns(WS2812_RES);
 
     chSysUnlock();
 }

--- a/platforms/chibios/drivers/ws2812.c
+++ b/platforms/chibios/drivers/ws2812.c
@@ -53,7 +53,7 @@ However, there are certain "WS2812"-like LEDs, like the SK6812s, which work in a
 #endif
 
 #ifndef WS2812_T1L
-#    define WS2812_T1L (WS2812_TIMING - T1H)  // Width of a 1 bit in ns
+#    define WS2812_T1L (WS2812_TIMING - WS2812_T1H)  // Width of a 1 bit in ns
 #endif
 
 #ifndef WS2812_T0H
@@ -61,7 +61,7 @@ However, there are certain "WS2812"-like LEDs, like the SK6812s, which work in a
 #endif
 
 #ifndef WS2812_T0L
-#    define WS2812_T0L (WS2812_TIMING - T0H)  // Width of a 0 bit in ns
+#    define WS2812_T0L (WS2812_TIMING - WS2812_T0H)  // Width of a 0 bit in ns
 #endif
 
 // The reset gap can be 6000 ns, but depending on the LED strip it may have to be increased

--- a/platforms/chibios/drivers/ws2812.c
+++ b/platforms/chibios/drivers/ws2812.c
@@ -43,11 +43,21 @@
 // These are the timing constraints taken mostly from the WS2812 datasheets
 // These are chosen to be conservative and avoid problems rather than for maximum throughput
 
+#ifndef T1H
 #define T1H 900           // Width of a 1 bit in ns
-#define T1L (1250 - T1H)  // Width of a 1 bit in ns
+#endif
 
+#ifndef T1L
+#define T1L (1250 - T1H)  // Width of a 1 bit in ns
+#endif
+
+#ifndef T0H
 #define T0H 350           // Width of a 0 bit in ns
+#endif
+
+#ifndef T0L
 #define T0L (1250 - T0H)  // Width of a 0 bit in ns
+#endif
 
 // The reset gap can be 6000 ns, but depending on the LED strip it may have to be increased
 // to values like 600000 ns. If it is too small, the pixels will show nothing most of the time.

--- a/platforms/chibios/drivers/ws2812.c
+++ b/platforms/chibios/drivers/ws2812.c
@@ -44,7 +44,7 @@
 // These are chosen to be conservative and avoid problems rather than for maximum throughput
 
 #ifndef T1H
-#    define T1H 900           // Width of a 1 bit in ns
+#    define T1H 900  // Width of a 1 bit in ns
 #endif
 
 #ifndef T1L
@@ -52,7 +52,7 @@
 #endif
 
 #ifndef T0H
-#    define T0H 350           // Width of a 0 bit in ns
+#    define T0H 350  // Width of a 0 bit in ns
 #endif
 
 #ifndef T0L

--- a/platforms/chibios/drivers/ws2812.c
+++ b/platforms/chibios/drivers/ws2812.c
@@ -44,19 +44,19 @@
 // These are chosen to be conservative and avoid problems rather than for maximum throughput
 
 #ifndef T1H
-#define T1H 900           // Width of a 1 bit in ns
+#    define T1H 900           // Width of a 1 bit in ns
 #endif
 
 #ifndef T1L
-#define T1L (1250 - T1H)  // Width of a 1 bit in ns
+#    define T1L (1250 - T1H)  // Width of a 1 bit in ns
 #endif
 
 #ifndef T0H
-#define T0H 350           // Width of a 0 bit in ns
+#    define T0H 350           // Width of a 0 bit in ns
 #endif
 
 #ifndef T0L
-#define T0L (1250 - T0H)  // Width of a 0 bit in ns
+#    define T0L (1250 - T0H)  // Width of a 0 bit in ns
 #endif
 
 // The reset gap can be 6000 ns, but depending on the LED strip it may have to be increased


### PR DESCRIPTION
## Description

Due to the way that the PrimeKB Meridian PCB was assembled (LEDs not to spec), this change is needed in order to properly use the LEDs.

Note that this change alone does not fix the LEDs. A follow-up PR with changes to the keyboard firmware will fully solve the issue.

## Types of Changes

- [x] Core
- [x] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/qmk/qmk_firmware/issues/11755

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
