### PR TITLE
Fix command feature if mousekey is enabled and using 3-speed setting

### DIFF
--- a/quantum/command.c
+++ b/quantum/command.c
@@ -39,7 +39,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    include "backlight.h"
 #endif
 
-#if defined(MOUSEKEY_ENABLE) && !defined(MK_3_SPEED)
+#if defined(MOUSEKEY_ENABLE)
 #    include "mousekey.h"
 #endif
 
@@ -53,7 +53,7 @@ static void print_version(void);
 static void print_status(void);
 static bool command_console(uint8_t code);
 static void command_console_help(void);
-#if defined(MOUSEKEY_ENABLE) && !defined(MK_3_SPEED)
+#if defined(MOUSEKEY_ENABLE)
 static bool mousekey_console(uint8_t code);
 #endif
 
@@ -73,7 +73,7 @@ bool command_proc(uint8_t code) {
             else
                 return (command_console_extra(code) || command_console(code));
             break;
-#if defined(MOUSEKEY_ENABLE) && !defined(MK_3_SPEED)
+#if defined(MOUSEKEY_ENABLE)
         case MOUSEKEY:
             mousekey_console(code);
             break;


### PR DESCRIPTION
## Description

Fixes compilation issue with command and mousekeys is enabled, and the mousekeys 3 speed setting define was enabled.

## Types of Changes

- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* Closes #14621
* 
## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
