### PR TITLE
endgame mac + fixing endgame - massdrop/ctrl 

### DIFF
--- a/keyboards/massdrop/ctrl/keymaps/endgame/config_led.c
+++ b/keyboards/massdrop/ctrl/keymaps/endgame/config_led.c
@@ -75,7 +75,7 @@ led_config_t g_led_config = { {
 #ifdef USB_LED_INDICATOR_ENABLE
 void rgb_matrix_indicators_kb(void)
 {
-  md_rgb_matrix_indicators();
+  md_rgb_matrix_indicators_advanced(0, ISSI3733_LED_COUNT);
 }
 #endif // USB_LED_INDICATOR_ENABLE
 

--- a/keyboards/massdrop/ctrl/keymaps/endgame_mac/README.md
+++ b/keyboards/massdrop/ctrl/keymaps/endgame_mac/README.md
@@ -1,0 +1,83 @@
+# Massdrop Ctrl Endgame
+
+This keymap is here to show some love to the MD Ctrl.
+
+## Layers
+
+### Typing Layer
+
+![Typing Layer](https://imgur.com/QUIU2SL.png)
+
+### Function Layer
+
+![Function Layer](https://imgur.com/4q4ld4X.png)
+
+### Mouse Layer
+
+![Mouse Layer](https://imgur.com/xXVFyEE.png)
+
+### Git Layer
+
+![Git Layer](https://imgur.com/WMMM0zz.png)
+
+## Features
+
+These are the features currently supported by this keymap:
+
+### RGB Time Out
+
+This allows setting a dynamic timeout for RGB to turn off. The following is supported:
+
+1. Restores on the first click of any key.
+2. Restores to its previous state before timeout. i.e. if it was edge only before timeout it will restore to edge only, same for all modes.
+3. Doesn't interfere with RGB modes. You can set keyboard to All, Edge Only or Off and timeout will not interfere with these modes.
+4. The time before RGB is turned off is dynamically adjustable using keycodes ROUT_VI to increase, ROUT_VD to decrease. They have a 10 second steps by default. Minimum value 10 seconds by default and maximum is 10 minutes.
+5. Can be toggled on or off dyncamically with the ROUT_TG keycode.
+6. Can be put in fast mode using ROUT_FM, for movie watching purposes. Default value is 3 seconds. Note that fast mode disabled ROUT_VD and ROUT_VI so to use them again you have to toggle fast mode off with ROUT_FM. It doesn't impact ROUT_TG and ROUT_TG will remember if fast mode was enabled when toggled back on, so it doesn't disable fast mode on its own, only ROUT_FM can disable or enable fast mode.
+
+### Tapdance Keys
+
+Not really a feature. I just want to document what tapdance keys this keymap has because there will be many of them.
+
+1. LGUI is used for both LGUI and toggle mouse layer for double tap.
+2. LCTRL sends LCTRL for single tap and LCTRL+LALT+T for double tap, which opens terminal in most environments.
+
+## Future Work
+
+By the time this is project has accomplished its original primary objectives, the following features will be available for the ctrl:
+
+1. Automatic RGB timeout with all the options you would need. **DONE**
+2. Macro and Shortcut layers for at least the following: Git **DONE**, IntelliJ, VIM **WIP**, Yakuake, KDE, Firefox, Slack, Discord. All using default program configuration. [This list may and probably will get longer]
+3. Custom LED configs that offer all the RGB layouts I deem useful or having a unique feature, look or feel. **DONE**
+4. Increased Dynamic Macro slots, because two simply isn't enough. This particular one falls outside Ctrl config and into QMK core modification. However, it is on the list of features I would like this keyboard to have and is a **TOP PRIORITY** for me. It won't be easy, but I will figure it out.
+5. Porting from the Drop, Inc. way of doing things to the QMK way of doing things, wherever possible. Full QMK support of this keyboard is the goal, not that it's possible, but I'd like to get as close as it gets. **WIP**
+6. An easier way to configure LED than both the QMK way and the Drop way. I'm thinking of a graphical LED config like Drop configurator that offers the advanced LED config features QMK offers. This may or may not get done depending on whether or not I get sick of QMK LED config at any point. If it does get done, it may or may not be added to QMK Configurator.
+7. Better documentation of the MD Ctrl specifications, features, etc. This will be included here in the form of C and doxygen comments. The bigger portion will be included in QMK docs if and where possible. **WIP**
+
+Additions:
+
+8. Implement Raw HID. **WIP**
+
+This list will most probably either expand or have some items removed if they're deemed not worthy, probably both. Nothing will be removed because it can't be done though, I am a firm believer in You Can Do It. Anything modified in this list will be clearly marked, for posterity.
+
+## Motivation
+
+I bought this keyboard because I believed and still believe that it offers the greatest possible value for money for any TKL fan. It was very disappointing to me after receiving it to see that this keyboard didn't get the love it should have in QMK, from either Drop, Inc. or users.
+Granted, this is a TKL RGB board which means it is hated by every single enthusiast in the community. That doesn't mean it shouldn't be getting love form its users, or most importantly its maker.
+
+Drop, Inc. have for some reason decided that they want to work on their own QMK stack. A stupid decision to say the least. Although having made this decision, they did very little actual work on this keyboard and have offered very little support and almost no time working on the firmware. To my knowledge, no one is currently working on it in a truly active fashion. A small handful of people work on the software and even then, they seem to think that their own way of doing things is better than the way chosen by the thousands in the community who have worked on QMK. Their QMK fork for the keyboard is abandoned for months. Updates are few and far between and it seems this keyboard has been forgotten in the annals of 2018 by both its maker and its users.
+
+To their credit, at least they decided to abandon their idiotic RGB setup and have opted after taking their sweet time to use QMK RGB and they did make some much needed changes to mdloader. That being said, Drop, Inc. still don't show love to this keyboard and whether or not they are actually able is questionable.
+
+So the aim of this work, starting with this Keymap, is to make the Massdrop Ctrl a true QMK keyboard instead of the marketing spiel "QMK Supported". As much as it can be made so of course within the bounds of what can be done with information openly available about the keyboard.
+
+I am not of the opinion that a mechanical keyboard is inherently superior. I am of the opinion that a mechanical keyboard is a tool that boosts productivity, enjoyment and efficiency, if it fails at that then it is no longer superior. Programmability is a huge part of that and I can no longer use any keyboard that doesn't have a level of programmability less than  QMK offers.
+
+I will personally do my best for this keyboard for no reason other than it will likely be my main keyboard for years to come.
+
+## Credits
+
+RGB timeout functionality was originally inspired by the code in this [gist](https://gist.github.com/algernon/9182469e21894192017f2bb5d478c7df).
+LED config code was mostly transferred from [matthewrobo keymap](https://github.com/qmk/qmk_firmware/tree/master/keyboards/massdrop/ctrl/keymaps/matthewrobo).
+
+Rest of the information about RGB matrix, scan matrix, and whatever information I have used was made publicly available by many other awesome members of the community.

--- a/keyboards/massdrop/ctrl/keymaps/endgame_mac/config.h
+++ b/keyboards/massdrop/ctrl/keymaps/endgame_mac/config.h
@@ -1,0 +1,116 @@
+#pragma once
+
+
+#define MODS_SHIFT  (get_mods() & MOD_MASK_SHIFT)
+#define MODS_CTRL   (get_mods() & MOD_MASK_CTRL)
+#define MODS_ALT    (get_mods() & MOD_MASK_ALT)
+
+// #define IS_COMMAND() (get_mods() == MOD_MASK_SHIFT)      // Key combination that allows the use of magic commands (useful for debugging)
+
+// #define NO_DEBUG                    // Disable debugging
+// #define NO_PRINT                    // Disable printing/debugging using hid_listen
+// #define NO_ACTION_LAYER             // Disable layers
+// #define NO_ACTION_TAPPING           // Disable tap dance and other tapping features
+// #define NO_ACTION_ONESHOT           // Disable one-shot modifiers
+// #define NO_ACTION_MACRO             // Disable old style macro handling: MACRO() & action_get_macro
+#define TERMINAL_HELP
+#define MOUSEKEY_INTERVAL 20
+#define MOUSEKEY_DELAY 0
+#define MOUSEKEY_TIME_TO_MAX 60
+#define MOUSEKEY_MAX_SPEED 10
+#define MOUSEKEY_WHEEL_DELAY 0
+#define FORCE_NKRO                  // NKRO by default requires to be turned on, this forces it on during keyboard startup regardless of EEPROM setting. NKRO can still be turned off but will be turned on again if the keyboard reboots.
+// #define QMK_KEYS_PER_SCAN 4         // Allows sending more than one key per scan. By default, only one key event gets sent via process_record() per scan. This has little impact on most typing, but if you're doing a lot of chords, or your scan rate is slow to begin with, you can have some delay in processing key events. Each press and release is a separate event. For a keyboard with 1ms or so scan times, even a very fast typist isn't going to produce the 500 keystrokes a second needed to actually get more than a few ms of delay from this. But if you're doing chording on something with 3-4ms scan times? You probably want this.
+// #define STRICT_LAYER_RELEASE        // Force a key release to be evaluated using the current layer stack instead of remembering which layer it came from (used for advanced cases)
+// #define LOCKING_SUPPORT_ENABLE      // Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap
+// #define LOCKING_RESYNC_ENABLE       // Tries to keep switch state consistent with keyboard LED state
+#define TAPPING_TERM 200            // How long before a tap becomes a hold, if set above 500, a key tapped during the tapping term will turn it into a hold too
+// #define TAPPING_TERM_PER_KEY        // Enables handling for per key TAPPING_TERM settings
+// #define RETRO_TAPPING               // Tap anyway, even after TAPPING_TERM, if there was no other key interruption between press and release
+#define TAPPING_TOGGLE 2            // How many taps before triggering the toggle
+// #define PERMISSIVE_HOLD             // Makes tap and hold keys trigger the hold if another key is pressed before releasing, even if it hasn't hit the TAPPING_TERM. See Permissive Hold for details
+// #define IGNORE_MOD_TAP_INTERRUPT    // Makes it possible to do rolling combos (zx) with keys that convert to other keys on hold, by enforcing the TAPPING_TERM for both keys. See Mod tap interrupt for details
+// #define TAPPING_FORCE_HOLD          // Makes it possible to use a dual role key as modifier shortly after having been tapped. See Hold after tap. Breaks any Tap Toggle functionality (TT or the One Shot Tap Toggle)
+// #define LEADER_TIMEOUT 300          // How long before the leader key times out. If you're having issues finishing the sequence before it times out, you may need to increase the timeout setting. Or you may want to enable the LEADER_PER_KEY_TIMING option, which resets the timeout after each key is tapped.
+// #define LEADER_PER_KEY_TIMING       // Sets the timer for leader key chords to run on each key press rather than overall
+// #define LEADER_KEY_STRICT_KEY_PROCESSING    // Disables keycode filtering for Mod-Tap and Layer-Tap keycodes. Eg, if you enable this, you would need to specify MT(MOD_CTL, KC_A) if you want to use KC_A.
+// #define ONESHOT_TIMEOUT 300         // How long before oneshot times out
+// #define ONESHOT_TAP_TOGGLE 2        // How many taps before oneshot toggle is triggered
+// #define COMBO_COUNT 2               // Set this to the number of combos that you're using in the Combo feature.
+// #define COMBO_TERM 200              // How long for the Combo keys to be detected. Defaults to TAPPING_TERM if not defined.
+// #define TAP_CODE_DELAY 100          // Sets the delay between register_code and unregister_code, if you're having issues with it registering properly (common on VUSB boards). The value is in milliseconds.
+// #define TAP_HOLD_CAPS_DELAY 80      // Sets the delay for Tap Hold keys (LT, MT) when using KC_CAPSLOCK keycode, as this has some special handling on MacOS.  The value is in milliseconds, and defaults to 80 ms if not defined. For macOS, you may want to set this to 200 or higher.
+
+#define RGB_MATRIX_FRAMEBUFFER_EFFECTS
+#define RGB_MATRIX_KEYPRESSES         // reacts to keypresses
+// #define RGB_MATRIX_KEYRELEASES        // reacts to keyreleases (instead of keypresses)
+#define RGB_MATRIX_STARTUP_MODE RGB_MATRIX_TYPING_HEATMAP // Sets the default mode, if none has been set
+// #define RGBLIGHT_HUE_STEP 12        // Units to step when in/decreasing hue
+// #define RGBLIGHT_SAT_STEP 25        // Units to step when in/decreasing saturation
+// #define RGBLIGHT_VAL_STEP 12        // Units to step when in/decreasing value (brightness)
+// #define RGB_DISABLE_AFTER_TIMEOUT 0   // number of ticks to wait until disabling effects
+// #define RGB_DISABLE_WHEN_USB_SUSPENDED false // turn off effects when suspended
+// #define RGB_MATRIX_LED_PROCESS_LIMIT (DRIVER_LED_TOTAL + 4) / 5 // limits the number of LEDs to process in an animation per task run (increases keyboard responsiveness)
+// #define RGB_MATRIX_LED_FLUSH_LIMIT 16 // limits in milliseconds how frequently an animation will update the LEDs. 16 (16ms) is equivalent to limiting to 60fps (increases keyboard responsiveness)
+// #define RGBLIGHT_ANIMATIONS             // Run RGB animations
+// #define RGBLIGHT_ANIMATIONS             // Enable all additional animation modes.
+// #define RGBLIGHT_EFFECT_ALTERNATING     // Enable alternating animation mode.
+// #define RGBLIGHT_EFFECT_BREATHING       // Enable breathing animation mode.
+// #define RGBLIGHT_EFFECT_CHRISTMAS       // Enable christmas animation mode.
+// #define RGBLIGHT_EFFECT_KNIGHT          // Enable knight animation mode.
+// #define RGBLIGHT_EFFECT_RAINBOW_MOOD    // Enable rainbow mood animation mode.
+// #define RGBLIGHT_EFFECT_RAINBOW_SWIRL   // Enable rainbow swirl animation mode.
+// #define RGBLIGHT_EFFECT_RGB_TEST        // Enable RGB test animation mode.
+// #define RGBLIGHT_EFFECT_SNAKE           // Enable snake animation mode.
+// #define RGBLIGHT_EFFECT_STATIC_GRADIENT // Enable static gradient mode.
+
+// #define RGBLIGHT_EFFECT_BREATHE_CENTER              // If defined, used to calculate the curve for the breathing animation. Valid values are 1.0 to 2.7
+// #define RGBLIGHT_EFFECT_BREATHE_MAX 255             // The maximum brightness for the breathing mode. Valid values are 1 to 255
+// #define RGBLIGHT_EFFECT_CHRISTMAS_INTERVAL 1000     // How long to wait between light changes for the "Christmas" animation, in milliseconds
+// #define RGBLIGHT_EFFECT_CHRISTMAS_STEP 2            // The number of LEDs to group the red/green colors by for the "Christmas" animation
+// #define RGBLIGHT_EFFECT_KNIGHT_LED_NUM RGBLED_NUM   // The number of LEDs to have the "Knight" animation travel
+// #define RGBLIGHT_EFFECT_KNIGHT_LENGTH 3             // The number of LEDs to light up for the "Knight" animation
+// #define RGBLIGHT_EFFECT_KNIGHT_OFFSET 0             // The number of LEDs to start the "Knight" animation from the start of the strip by
+// #define RGBLIGHT_RAINBOW_SWIRL_RANGE 255            // Range adjustment for the rainbow swirl effect to get different swirls
+// #define RGBLIGHT_EFFECT_SNAKE_LENGTH 4              // The number of LEDs to light up for the "Snake" animation
+
+// This list in in the correct mode order. Next mode is the following line, previous mode is previous line. Loops around.
+#define DISABLE_RGB_MATRIX_SOLID_COLOR                   // Static single hue, no speed support
+#define DISABLE_RGB_MATRIX_ALPHAS_MODS                   // Static dual hue, speed is hue for secondary hue
+#define DISABLE_RGB_MATRIX_GRADIENT_UP_DOWN              // Static gradient top to bottom, speed controls how much gradient changes
+#define DISABLE_RGB_MATRIX_BREATHING                     // Single hue brightness cycling animation
+#define DISABLE_RGB_MATRIX_BAND_SAT                      // Single hue band fading saturation scrolling left to right
+#define DISABLE_RGB_MATRIX_BAND_VAL                      // Single hue band fading brightness scrolling left to right
+#define DISABLE_RGB_MATRIX_BAND_PINWHEEL_SAT             // Single hue 3 blade spinning pinwheel fades saturation
+#define DISABLE_RGB_MATRIX_BAND_PINWHEEL_VAL             // Single hue 3 blade spinning pinwheel fades brightness
+#define DISABLE_RGB_MATRIX_BAND_SPIRAL_SAT               // Single hue spinning spiral fades saturation
+#define DISABLE_RGB_MATRIX_BAND_SPIRAL_VAL               // Single hue spinning spiral fades brightness
+#define DISABLE_RGB_MATRIX_CYCLE_ALL                     // Full keyboard solid hue cycling through full gradient
+#define DISABLE_RGB_MATRIX_CYCLE_LEFT_RIGHT              // Full gradient scrolling left to right
+#define DISABLE_RGB_MATRIX_CYCLE_UP_DOWN                 // Full gradient scrolling top to bottom
+#define DISABLE_RGB_MATRIX_CYCLE_OUT_IN                  // Full gradient scrolling out to in
+#define DISABLE_RGB_MATRIX_CYCLE_OUT_IN_DUAL             // Full dual gradients scrolling out to in
+#define DISABLE_RGB_MATRIX_RAINBOW_MOVING_CHEVRON        // Full gradent Chevron shapped scrolling left to right
+#define DISABLE_RGB_MATRIX_CYCLE_PINWHEEL                // Full gradient spinning pinwheel around center of keyboard
+#define DISABLE_RGB_MATRIX_CYCLE_SPIRAL                  // Full gradient spinning spiral around center of keyboard
+#define DISABLE_RGB_MATRIX_DUAL_BEACON                   // Full gradient spinning around center of keyboard
+#define DISABLE_RGB_MATRIX_RAINBOW_BEACON                // Full tighter gradient spinning around center of keyboard
+#define DISABLE_RGB_MATRIX_RAINBOW_PINWHEELS             // Full dual gradients spinning two halfs of keyboard
+#define DISABLE_RGB_MATRIX_RAINDROPS                     // Randomly changes a single key's hue
+#define DISABLE_RGB_MATRIX_JELLYBEAN_RAINDROPS           // Randomly changes a single key's hue and saturation
+// =================================================== Requires RGB_MATRIX_FRAMEBUFFER_EFFECTS =============================================================
+// #define DISABLE_RGB_MATRIX_TYPING_HEATMAP                // How hot is your WPM!
+#define DISABLE_RGB_MATRIX_DIGITAL_RAIN                  // That famous computer simulation
+// =================================================== RGB_MATRIX_KEYPRESSES OR RGB_MATRIX_KEYRELEASES =====================================================
+ #define DISABLE_RGB_MATRIX_SOLID_REACTIVE                // Static single hue, pulses keys hit to shifted hue then fades to current hue
+#define DISABLE_RGB_MATRIX_SOLID_REACTIVE_SIMPLE         // Pulses keys hit to hue & value then fades value out
+ #define DISABLE_RGB_MATRIX_SOLID_REACTIVE_WIDE           // Hue & value pulse near a single key hit then fades value out
+ #define DISABLE_RGB_MATRIX_SOLID_REACTIVE_MULTIWIDE      // Hue & value pulse near multiple key hits then fades value out
+ #define DISABLE_RGB_MATRIX_SOLID_REACTIVE_CROSS          // Hue & value pulse the same column and row of a single key hit then fades value out
+ #define DISABLE_RGB_MATRIX_SOLID_REACTIVE_MULTICROSS     // Hue & value pulse the same column and row of multiple key hits then fades value out
+ #define DISABLE_RGB_MATRIX_SOLID_REACTIVE_NEXUS          // Hue & value pulse away on the same column and row of a single key hit then fades value out
+ #define DISABLE_RGB_MATRIX_SOLID_REACTIVE_MULTINEXUS     // Hue & value pulse away on the same column and row of multiple key hits then fades value out
+#define DISABLE_RGB_MATRIX_SPLASH                        // Full gradient & value pulse away from a single key hit then fades value out
+#define DISABLE_RGB_MATRIX_MULTISPLASH                   // Full gradient & value pulse away from multiple key hits then fades value out
+#define DISABLE_RGB_MATRIX_SOLID_SPLASH                  // Hue & value pulse away from a single key hit then fades value out
+#define DISABLE_RGB_MATRIX_SOLID_MULTISPLASH             // Hue & value pulse away from multiple key hits then fades value out

--- a/keyboards/massdrop/ctrl/keymaps/endgame_mac/config.h
+++ b/keyboards/massdrop/ctrl/keymaps/endgame_mac/config.h
@@ -1,3 +1,7 @@
+// Copyright 2021 Randall Shutt (@rshutt)
+
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 #pragma once
 
 

--- a/keyboards/massdrop/ctrl/keymaps/endgame_mac/config.h
+++ b/keyboards/massdrop/ctrl/keymaps/endgame_mac/config.h
@@ -1,5 +1,4 @@
 // Copyright 2021 Randall Shutt (@rshutt)
-
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #pragma once

--- a/keyboards/massdrop/ctrl/keymaps/endgame_mac/config_led.c
+++ b/keyboards/massdrop/ctrl/keymaps/endgame_mac/config_led.c
@@ -1,0 +1,82 @@
+#ifdef RGB_MATRIX_ENABLE
+#include "ctrl.h"
+
+#include "md_rgb_matrix.h"
+#include "rgb_matrix.h"
+#include "config_led.h"
+
+led_config_t g_led_config = { {
+    {   0,   1,   2,   3,   4,   5,   6,   7 },
+    {  16,  17,  18,  19,  20,  21,  22,  23 },
+    {  33,  34,  35,  36,  37,  38,  39,  40 },
+    {  50,  51,  52,  53,  54,  55,  56,  57 },
+    {  63,  64,  65,  66,  67,  68,  69,  70 },
+    {  76,  77,  78,  79,  80,  81,  82,  83 },
+    {   8,   9,  10,  11,  12,  13,  14,  15 },
+    {  24,  25,  26,  27,  28,  29,  30,  31 },
+    {  41,  42,  43,  44,  45,  46,  47,  48 },
+    {  58,  59,  60,  61,  62,  75,  49,  32 },
+    {  71,  72,  73,  74,  84,  85,  86, NO_LED }
+}, {
+  // KC_ESC, KC_F1, KC_F2, KC_F3, KC_F4, KC_F5, KC_F6, KC_F7, KC_F8, KC_F9, KC_F10, KC_F11, KC_F12, KC_PSCR, KC_SLCK, KC_PAUS
+    {   7,   5 }, {  31,   5 }, {  43,   5 }, {  55,   5 }, {  67,   5 }, {  85,   5 }, {  97,   5 }, { 109,   5 },
+    { 121,   5 }, { 139,   5 }, { 151,   5 }, { 163,   5 }, { 175,   5 }, { 193,   5 }, { 205,   5 }, { 217,   5 },
+  // KC_GRV, KC_1, KC_2, KC_3, KC_4, KC_5, KC_6, KC_7, KC_8, KC_9, KC_0, KC_MINS, KC_EQL, KC_BSPC, KC_INS, KC_HOME, KC_PGUP
+    {   7,  20 }, {  19,  20 }, {  31,  20 }, {  43,  20 }, {  55,  20 }, {  67,  20 }, {  79,  20 }, {  91,  20 },
+    { 103,  20 }, { 115,  20 }, { 127,  20 }, { 139,  20 }, { 151,  20 }, { 169,  20 }, { 193,  20 }, { 205,  20 },
+    { 217,  20 },
+  // KC_TAB, KC_Q, KC_W, KC_E, KC_R, KC_T, KC_Y, KC_U, KC_I, KC_O, KC_P, KC_LBRC, KC_RBRC, KC_BSLS, KC_DEL, KC_END, KC_PGDN
+    {  10,  30 }, {  25,  30 }, {  37,  30 }, {  49,  30 }, {  61,  30 }, {  73,  30 }, {  85,  30 }, {  97,  30 },
+    { 109,  30 }, { 121,  30 }, { 133,  30 }, { 145,  30 }, { 157,  30 }, { 172,  30 }, { 193,  30 }, { 205,  30 },
+    { 217,  30 },
+  // KC_CAPS, KC_A, KC_S, KC_D, KC_F, KC_G, KC_H, KC_J, KC_K, KC_L, KC_SCLN, KC_QUOT, KC_ENT
+    {  11,  39 }, {  28,  39 }, {  40,  39 }, {  52,  39 }, {  64,  39 }, {  76,  39 }, {  88,  39 }, { 100,  39 },
+    { 112,  39 }, { 124,  39 }, { 136,  39 }, { 148,  39 }, { 168,  39 },
+  // KC_LSFT, KC_Z, KC_X, KC_C, KC_V, KC_B, KC_N, KC_M, KC_COMM, KC_DOT, KC_SLSH, KC_RSFT, KC_UP
+    {  14,  49 }, {  34,  49 }, {  46,  49 }, {  58,  49 }, {  70,  49 }, {  82,  49 }, {  94,  49 }, { 106,  49 },
+    { 118,  49 }, { 130,  49 }, { 142,  49 }, { 165,  49 }, { 205,  49 },
+  // KC_LCTL, KC_LGUI, KC_LALT, KC_SPC, KC_RALT, MO(1), KC_APP, KC_RCTL, KC_LEFT, KC_DOWN, KC_RGHT
+    {   8,  59 }, {  23,  59 }, {  38,  59 }, {  83,  59 }, { 129,  59 }, { 144,  59 }, { 159,  59 }, { 174,  59 },
+    { 193,  59 }, { 205,  59 }, { 217,  59 },
+  // Underglow / Border
+    { 224,  64 }, { 204,  64 }, { 186,  64 }, { 167,  64 }, { 149,  64 }, { 130,  64 }, { 112,  64 }, {  94,  64 },
+    {  75,  64 }, {  57,  64 }, {  38,  64 }, {  20,  64 }, {   0,  64 }, {   0,  47 }, {   0,  32 }, {   0,  17 },
+    {   0,   0 }, {  20,   0 }, {  38,   0 }, {  57,   0 }, {  75,   0 }, {  94,   0 }, { 112,   0 }, { 130,   0 },
+    { 149,   0 }, { 167,   0 }, { 186,   0 }, { 204,   0 }, { 224,   0 }, { 224,  17 }, { 224,  32 }, { 224,  47 }
+}, {
+  // KC_ESC, KC_F1, KC_F2, KC_F3, KC_F4, KC_F5, KC_F6, KC_F7, KC_F8, KC_F9, KC_F10, KC_F11, KC_F12, KC_PSCR, KC_SLCK, KC_PAUS
+    1, 4, 4, 4, 4, 1, 1, 1,
+    1, 4, 4, 4, 4, 1, 1, 1,
+  // KC_GRV, KC_1, KC_2, KC_3, KC_4, KC_5, KC_6, KC_7, KC_8, KC_9, KC_0, KC_MINS, KC_EQL, KC_BSPC, KC_INS, KC_HOME, KC_PGUP
+    4, 4, 4, 4, 4, 4, 4, 4,
+    4, 4, 4, 4, 4, 1, 1, 1,
+    1,
+  // KC_TAB, KC_Q, KC_W, KC_E, KC_R, KC_T, KC_Y, KC_U, KC_I, KC_O, KC_P, KC_LBRC, KC_RBRC, KC_BSLS, KC_DEL, KC_END, KC_PGDN
+    1, 4, 4, 4, 4, 4, 4, 4,
+    4, 4, 4, 4, 4, 4, 1, 1,
+    1,
+  // KC_CAPS, KC_A, KC_S, KC_D, KC_F, KC_G, KC_H, KC_J, KC_K, KC_L, KC_SCLN, KC_QUOT, KC_ENT
+    1, 4, 4, 4, 4, 4, 4, 4,
+    4, 4, 4, 4, 1,
+  // KC_LSFT, KC_Z, KC_X, KC_C, KC_V, KC_B, KC_N, KC_M, KC_COMM, KC_DOT, KC_SLSH, KC_RSFT, KC_UP
+    1, 4, 4, 4, 4, 4, 4, 4,
+    4, 4, 4, 1, 1,
+  // KC_LCTL, KC_LGUI, KC_LALT, KC_SPC, KC_RALT, MO(1), KC_APP, KC_RCTL, KC_LEFT, KC_DOWN, KC_RGHT
+    1, 1, 1, 4, 1, 1, 1, 1,
+    1, 1, 1,
+  // Underglow / Border
+    2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2
+} };
+
+
+#ifdef USB_LED_INDICATOR_ENABLE
+void rgb_matrix_indicators_kb(void)
+{
+  md_rgb_matrix_indicators_advanced(0, ISSI3733_LED_COUNT);
+}
+#endif // USB_LED_INDICATOR_ENABLE
+
+#endif

--- a/keyboards/massdrop/ctrl/keymaps/endgame_mac/config_led.c
+++ b/keyboards/massdrop/ctrl/keymaps/endgame_mac/config_led.c
@@ -1,3 +1,7 @@
+// Copyright 2021 Randall Shutt (@rshutt)
+
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 #ifdef RGB_MATRIX_ENABLE
 #include "ctrl.h"
 

--- a/keyboards/massdrop/ctrl/keymaps/endgame_mac/config_led.c
+++ b/keyboards/massdrop/ctrl/keymaps/endgame_mac/config_led.c
@@ -1,5 +1,4 @@
 // Copyright 2021 Randall Shutt (@rshutt)
-
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #ifdef RGB_MATRIX_ENABLE

--- a/keyboards/massdrop/ctrl/keymaps/endgame_mac/keymap.c
+++ b/keyboards/massdrop/ctrl/keymaps/endgame_mac/keymap.c
@@ -1,5 +1,6 @@
 // Copyright 2021 Randall Shutt (@rshutt)
 // SPDX-License-Identifier: GPL-2.0-or-later
+
 #include "keymap.h"
 
 static uint16_t idle_timer;             // Idle LED timeout timer

--- a/keyboards/massdrop/ctrl/keymaps/endgame_mac/keymap.c
+++ b/keyboards/massdrop/ctrl/keymaps/endgame_mac/keymap.c
@@ -1,0 +1,395 @@
+#include "keymap.h"
+
+static uint16_t idle_timer;             // Idle LED timeout timer
+static uint8_t idle_second_counter;     // Idle LED seconds counter, counts seconds not milliseconds
+static uint8_t key_event_counter;       // This counter is used to check if any keys are being held
+
+static const char * sendstring_commands[] = {
+    "git init ",
+    "git clone ",
+    "git config --global ",
+    "git add ",
+    "git diff ",
+    "git reset ",
+    "git rebase ",
+    "git branch -b \"",
+    "git checkout ",
+    "git merge ",
+    "git remote add ",
+    "git fetch ",
+    "git pull ",
+    "git push ",
+    "git commit ",
+    "git status ",
+    "git log ",
+};
+
+//Associate our tap dance key with its functionality
+qk_tap_dance_action_t tap_dance_actions[] = {
+    [TD_LGUI_ML] = ACTION_TAP_DANCE_LAYER_TOGGLE(KC_LGUI, _ML),
+    [TD_RGUI_ML] = ACTION_TAP_DANCE_LAYER_TOGGLE(KC_RGUI, _ML),
+    [TD_APP_YL] = ACTION_TAP_DANCE_LAYER_TOGGLE(KC_APP, _YL),
+    [TD_CTRL_TERM] = ACTION_TAP_DANCE_DOUBLE(KC_LCTRL, LCA(KC_T)),
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    /*
+    [DEFAULT] = LAYOUT(
+        KC_ESC,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,           KC_PSCR, KC_SLCK, KC_PAUS,
+        KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_INS,  KC_HOME, KC_PGUP,
+        KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS, KC_DEL,  KC_END,  KC_PGDN,
+        KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_ENT,
+        KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT,                            KC_UP,
+        KC_LCTL, KC_LGUI, KC_LALT,                   KC_SPC,                             KC_RALT, MO(1),   KC_APP,  KC_RCTL,          KC_LEFT, KC_DOWN, KC_RGHT
+    ),
+    */
+    [_KL] = LAYOUT(
+        KC_ESC,            KC_F1,          KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,        KC_F12,           KC_PSCR, KC_SLCK, KC_PAUS,
+        KC_GRV,            KC_1,           KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS,       KC_EQL,  KC_BSPC, KC_INS,  KC_HOME, KC_PGUP,
+        KC_TAB,            KC_Q,           KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC,       KC_RBRC, KC_BSLS, KC_DEL,  KC_END,  KC_PGDN,
+        KC_CAPS,           KC_A,           KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,       KC_ENT,
+        KC_LSFT,           KC_Z,           KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_SFTENT,                                KC_UP,
+        TD(TD_CTRL_TERM),   KC_LALT,    TD(TD_LGUI_ML),                  KC_SPC,                             TD(TD_RGUI_ML), TT(_FL), KC_RALT, KC_RCTL,          KC_LEFT, KC_DOWN, KC_RGHT
+    ),
+    [_FL] = LAYOUT(
+        _______, DM_PLY1, DM_PLY2, _______,  _______, DM_REC1, DM_REC2, _______,  _______,  DM_RSTP, _______, KC_WAKE, KC_SLEP,          KC_MUTE, TERM_ON, TERM_OFF,
+        _______, _______, TG(_ML), TG(_GL),  TG(_VL), TG(_YL), _______, _______,  _______,  ROUT_FM, ROUT_TG, ROUT_VD, ROUT_VI, _______, KC_MSTP, KC_MPLY, KC_VOLU,
+        RGB_M_P, RGB_SPD, RGB_VAI, RGB_SPI,  RGB_HUI, RGB_SAI, _______, U_T_AUTO, U_T_AGCR, _______, _______, _______, _______, _______, KC_MPRV, KC_MNXT, KC_VOLD,
+        _______, RGB_RMOD,RGB_VAD, RGB_MOD,  RGB_HUD, RGB_SAD, _______, _______,  _______,  _______, _______, _______, _______,
+        _______, RGB_TOG, _______, COPY_ALL, _______, MD_BOOT, NK_TOGG, _______,  _______,  _______, _______, _______,                            KC_BRIU,
+        _______, _______, _______,                    _______,                              _______, TG(_FL), TD(TD_APP_YL), _______,          _______, KC_BRID, _______
+    ),
+    [_ML] = LAYOUT(
+        _______, KC_ACL0, KC_ACL1, KC_ACL2, _______, _______, _______, _______, _______, _______, _______, _______, _______,          _______, _______, _______,
+        _______, KC_BTN4, KC_BTN3, KC_BTN5, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+        _______, KC_BTN1, KC_MS_U, KC_BTN2, KC_WH_U, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+        _______, KC_MS_L, KC_MS_D, KC_MS_R, KC_WH_D, _______, _______, _______, _______, _______, _______, _______, _______,
+        _______, _______, _______, SEL_CPY, _______, _______, _______, _______, _______, _______, _______, _______,                            KC_MS_U,
+        _______, TG(_ML), _______,                   _______,                            _______, TG(_ML), _______, _______,          KC_MS_L, KC_MS_D, KC_MS_R
+    ),
+    [_GL] = LAYOUT(
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          _______, _______, _______,
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+        _______, _______, _______, _______, G_REMTE, G_RESET, G_REBAS, _______, G_INIT,  _______, G_PULL,  G_PUSH,  _______, _______, _______, _______, _______,
+        _______, G_ADD,   G_STAT,  G_DIFF,  G_FETCH, _______, _______, _______, _______, G_LOG,   _______, _______, _______,
+        _______, G_CONF,  G_CHECK, G_CLONE, G_COMM,  G_BRANH, _______, G_MERGE, _______, _______, _______, _______,                            _______,
+        _______, _______, _______,                   _______,                            _______, TG(_GL), _______, _______,          _______, _______, _______
+    ),
+    // This layout doesn't have custom keycodes for now, just custom LED config
+    [_VL] = LAYOUT(
+        KC_ESC,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,  KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,    KC_F12,           KC_PSCR, KC_SLCK, KC_PAUS,
+        KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,   KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS,   KC_EQL,  KC_BSPC, KC_INS,  KC_HOME, KC_PGUP,
+        KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,   KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC,   KC_RBRC, KC_BSLS, KC_DEL,  KC_END,  KC_PGDN,
+        KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,   KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,   KC_ENT,
+        KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,   KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_SFTENT,                            KC_UP,
+        KC_LCTL, KC_LGUI, KC_LALT,                   KC_SPC,                            KC_RALT, TG(_VL), KC_APP,    KC_RCTL,          KC_LEFT, KC_DOWN, KC_RGHT
+    ),
+    // Works with https://github.com/ash0x0/config/blob/master/yakuake.shortcuts
+    [_YL] = LAYOUT(
+        KC_ESC, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO,   KC_NO,  KC_NO,   KC_NO, KC_NO,            KC_NO,   KC_NO,   KC_NO,
+        KC_GRV, KC_1,  KC_2,  KC_3,  KC_4,  KC_5,  KC_6,  KC_7,  KC_8,    KC_9,   KC_0,    KC_NO, KC_NO,   KC_NO,   KC_NO,   KC_HOME, KC_PGUP,
+        KC_NO,  KC_Q,  KC_NO, KC_E,  KC_NO, KC_T,  KC_NO, KC_NO, KC_I,    KC_NO,  KC_P,    KC_NO, KC_RBRC, KC_BSLS, KC_NO,   KC_END,  KC_PGDN,
+        KC_NO,  KC_A,  KC_NO, KC_D,  KC_NO, KC_G,  KC_NO, KC_J,  KC_K,    KC_L,   KC_SCLN, KC_NO, KC_NO,
+        KC_NO,  KC_Z,  KC_X,  KC_NO, KC_NO, KC_NO, KC_NO, KC_M,  KC_COMM, KC_DOT, KC_NO,   KC_NO,                            KC_UP,
+        KC_NO,  KC_NO, KC_NO,               KC_NO,                        KC_NO,  TG(_YL), KC_NO, KC_NO,            KC_LEFT, KC_DOWN, KC_RGHT
+    ),
+    /*
+    [X] = LAYOUT(
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          _______, _______, _______,
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+        _______, _______, _______, _______, _______, _______, TG_NKRO, _______, _______, _______, _______, _______,                            _______,
+        _______, _______, _______,                   _______,                            _______, _______, _______, _______,          _______, _______, _______
+    ),
+    [RGB] = LAYOUT(
+        ESC: 0,   F1: 1,    F2: 2,    F3: 3,    F4: 4,    F5: 5,    F6: 6,    F7: 7,    F8: 8,    F9: 9,    F10: 10,  F11: 11,  F12: 12,            PSCR: 13, SLCK: 14, PAUS: 15,
+        GRV: 16,  1: 17,    2: 18,    3: 19,    4: 20,    5: 21,    6: 22,    7: 23,    8: 24,    9: 25,    0: 26,    MINS: 27, EQL: 28,  BSPC: 29, INS: 30,  HOME: 31, PGUP: 32,
+        TAB: 33,  Q: 34,    W: 35,    E: 36,    R: 37,    T: 38,    Y: 39,    U: 40,    I: 41,    O: 42,    P: 43,    LBRC: 44, RBRC: 45, BSLS: 46, DEL: 47,  END: 48,  PGDN: 49,
+        CAPS: 50, A: 51,    S: 52,    D: 53,    F: 54,    G: 55,    H: 56,    J: 57,    K: 58,    L: 59,    SCLN: 60, QUOT: 61, ENT: 62,
+        LSFT: 63, Z: 64,    X: 65,    C: 66,    V: 67,    B: 68,    N: 69,    M: 70,    COMM: 71, DOT: 72,  SLSH: 73, RSFT: 74,                               UP: 75,
+        LCTL: 76, LGUI: 77, LALT: 78,                   SPC: 79,                                  RALT: 80, Fn: 81,   APP: 82,  RCTL: 83,           LEFT: 84, DOWN: 85, RGHT: 86
+    ),
+	[MATRIX] = LAYOUT(
+	    0,       1,       2,       3,       4,       5,       6,       7,       8,       9,       10,      11,      12,                 13,      14,      15,
+	    16,      17,      18,      19,      20,      21,      22,      23,      24,      25,      26,      27,      28,      29,        30,      31,      32,
+	    33,      34,      35,      36,      37,      38,      39,      40,      41,      42,      43,      44,      45,      46,        47,      48,      49,
+	    50,      51,      52,      53,      54,      55,      56,      57,      58,      59,      60,      61,      62,
+	    63,      64,      65,      66,      67,      68,      69,      70,      71,      72,      73,      74,                                   75,
+	    76,      77,      78,                        79,                                 80,      81,      82,      83,                 84,      85,      86
+	),
+    */
+};
+
+#ifdef _______
+#undef _______
+#define _______ {0, 0, 0}
+
+const uint8_t PROGMEM ledmap[][DRIVER_LED_TOTAL][3] = {
+    [_FL] = {
+        _______, CORAL,   CORAL,   _______, _______, CORAL,   CORAL,   _______, _______, CORAL,   _______, YELLOW,  YELLOW,           TEAL,    GOLD,   GOLD,
+        _______, _______, PINK,    PINK,    PINK,    PINK,    _______, _______, _______, GREEN,   GREEN,   GREEN,   GREEN,   _______, TEAL,    TEAL,   TEAL,
+        ORANGE,  ORANGE,  ORANGE,  ORANGE,  ORANGE,  ORANGE,  _______, AZURE,   AZURE,   _______, _______, _______, _______, _______, TEAL,    TEAL,   TEAL,
+        _______, ORANGE,  ORANGE,  ORANGE,  ORANGE,  ORANGE,  _______, _______, _______, _______, _______, _______, _______,
+        _______, ORANGE,  _______, CORAL,   _______, AZURE,   AZURE,   _______, _______, _______, _______, AZURE,                              SPRING,
+        _______, _______, _______,                   _______,                            _______, PINK,    _______, AZURE,            _______, SPRING, _______
+    },
+    [_ML] = {
+        _______, GOLD,    GOLD,    GOLD,   _______, _______, _______, _______, _______, _______, _______, _______, _______,          _______, _______, _______,
+        _______, MAGENT,  MAGENT,  MAGENT, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+        _______, MAGENT,  GOLD,    MAGENT, GOLD,    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+        _______, GOLD,    GOLD,    GOLD,   GOLD,    _______, _______, _______, _______, _______, _______, _______, _______,
+        _______, _______, _______, CORAL,  _______, _______, _______, _______, _______, _______, _______, _______,                            GOLD,
+        _______, PINK,    _______,                  _______,                                     _______, PINK,    _______, _______, GOLD,    GOLD,    GOLD
+    },
+    [_GL] = {
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          _______, _______, _______,
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+        _______, _______, _______, _______, BLUE,    AZURE,   AZURE,   _______, CYAN,    _______, TURQ,    PURPLE,  _______, _______, _______, _______, _______,
+        _______, CORAL,   GREEN,   GREEN,   TURQ,    _______, _______, _______, _______, GREEN,   _______, _______, _______,
+        _______, CYAN,    CHART,   TURQ,    ORANGE,  CHART,   _______, CHART,   _______, _______, _______, _______,                            _______,
+        _______, _______, _______,                   _______,                            _______, PINK,    _______, _______,          _______, _______, _______
+    },
+    [_VL] = {
+        PURPLE,  _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          _______, _______, _______,
+        _______, _______, _______, TURQ,    _______, _______, _______, _______, TURQ,    _______, _______, _______, _______, _______, _______, _______, _______,
+        _______, AZURE,   AZURE,   AZURE,   PURPLE,  _______, BLUE,    PURPLE,  PURPLE,  PURPLE,  BLUE,    _______, _______, _______, _______, _______, _______,
+        _______, PURPLE,  _______, BLUE,    _______, GOLD,    GOLDEN,  GOLDEN,  GOLDEN,  GOLDEN,  _______, _______, _______,
+        _______, _______, BLUE,    BLUE,    _______, _______, TURQ,    _______, _______, _______, TURQ,    _______,                            _______,
+        _______, _______, _______,                   _______,                            _______, PINK,    _______, _______,          _______, _______, _______
+    },
+    [_YL] = {
+        RED,     _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          _______, _______, _______,
+        CHART,   BLUE,    BLUE,    BLUE,    BLUE,    BLUE,    BLUE,    BLUE,    BLUE,    BLUE,    BLUE,    _______, _______, _______, _______, PURPLE,  PURPLE,
+        _______, RED,     _______, BLUE,    _______, GOLD,    _______, _______, GREEN,   _______, MAGENT,  _______, GOLD,    GOLD,    _______, PURPLE,  PURPLE,
+        _______, BLUE,    _______, BLUE,    _______, MAGENT,  _______, GREEN,   GREEN,   GREEN,   MAGENT,  _______, _______,
+        _______, ORANGE,  ORANGE,  _______, _______, _______, _______, RED,     MAGENT,  MAGENT,  _______, _______,                            GREEN,
+        _______, _______, _______,                   _______,                   _______, PINK,    _______, _______,                   BLUE,    GREEN,   BLUE
+    },
+};
+
+#undef _______
+#define _______ KC_TRNS
+#endif
+
+// Runs just one time when the keyboard initializes.
+void matrix_init_user(void) {
+    // Enable or disable debugging
+    debug_enable=true;
+    debug_matrix=true;
+    debug_keyboard=true;
+    debug_mouse=true;
+
+    idle_second_counter = 0;                            // Counter for number of seconds keyboard has been idle.
+    key_event_counter = 0;                              // Counter to determine if keys are being held, neutral at 0.
+    rgb_time_out_seconds = RGB_DEFAULT_TIME_OUT;        // RGB timeout initialized to its default configure in keymap.h
+    rgb_time_out_enable = false;                        // Disable RGB timeout by default. Enable using toggle key.
+    rgb_time_out_user_value = false;                    // Has to have the same initial value as rgb_time_out_enable.
+    rgb_enabled_flag = true;                            // Initially, keyboard RGB is enabled. Change to false config.h initializes RGB disabled.
+    rgb_time_out_fast_mode_enabled = false;             // RGB timeout fast mode disabled initially.
+    rgb_time_out_saved_flag = rgb_matrix_get_flags();   // Save RGB matrix state for when keyboard comes back from ide.
+};
+
+void keyboard_post_init_user(void) {
+    rgb_matrix_enable();
+}
+
+// Runs constantly in the background, in a loop.
+void matrix_scan_user(void) {
+    if(rgb_time_out_enable && rgb_enabled_flag) {
+        // If the key event counter is not zero then some key was pressed down but not released, thus reset the timeout counter.
+        if (key_event_counter) {
+            idle_second_counter = 0;
+        } else if (timer_elapsed(idle_timer) > MILLISECONDS_IN_SECOND) {
+            idle_second_counter++;
+            idle_timer = timer_read();
+        }
+
+        if (idle_second_counter >= rgb_time_out_seconds) {
+            rgb_time_out_saved_flag = rgb_matrix_get_flags();
+            rgb_matrix_set_flags(LED_FLAG_NONE);
+            rgb_matrix_disable_noeeprom();
+            rgb_enabled_flag = false;
+            idle_second_counter = 0;
+        }
+    }
+};
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    static uint32_t key_timer;
+
+    // Increment key event counter for every press and decrement for every release.
+    if (record->event.pressed) {
+        key_event_counter++;
+    } else {
+        key_event_counter--;
+    }
+
+    if (rgb_time_out_enable) {
+        idle_timer = timer_read();
+        // Reset the seconds counter. Without this, something like press> leave x seconds> press, would be x seconds on the effective counter not 0 as it should.
+        idle_second_counter = 0;
+        if (!rgb_enabled_flag) {
+            rgb_matrix_enable_noeeprom();
+            rgb_matrix_set_flags(rgb_time_out_saved_flag);
+            rgb_enabled_flag = true;
+        }
+    }
+
+    switch (keycode) {
+        case U_T_AUTO:
+            if (record->event.pressed && MODS_SHIFT && MODS_CTRL) {
+                TOGGLE_FLAG_AND_PRINT(usb_extra_manual, "USB extra port manual mode");
+            }
+            return false;
+        case U_T_AGCR:
+            if (record->event.pressed && MODS_SHIFT && MODS_CTRL) {
+                TOGGLE_FLAG_AND_PRINT(usb_gcr_auto, "USB GCR auto mode");
+            }
+            return false;
+        case MD_BOOT:
+            if (record->event.pressed) {
+                key_timer = timer_read32();
+            } else {
+                if (timer_elapsed32(key_timer) >= 500) {
+                    reset_keyboard();
+                }
+            }
+            return false;
+    }
+
+    if (record->event.pressed) {
+        // The Yakuake config uses LGUI+Ctrl+Shift+<keycode>. KC_NO used for undesired key, all mapped ones get mods.
+        if (get_highest_layer(layer_state) == _YL && keycode != TG(_YL)) {
+            tap_code16(C(G(S(keycode))));
+            return false;
+        }
+        switch (keycode) {
+            case DBG_TOG:
+                TOGGLE_FLAG_AND_PRINT(debug_enable, "Debug mode");
+                return false;
+            case DBG_MTRX:
+                TOGGLE_FLAG_AND_PRINT(debug_matrix, "Debug matrix");
+                return false;
+            case DBG_KBD:
+                TOGGLE_FLAG_AND_PRINT(debug_keyboard, "Debug keyboard");
+                return false;
+            case DBG_MOU:
+                TOGGLE_FLAG_AND_PRINT(debug_mouse, "Debug mouse");
+                return false;
+            case RGB_TOG:
+                rgb_time_out_enable = rgb_time_out_user_value;
+                switch (rgb_matrix_get_flags()) {
+                    case LED_FLAG_ALL: {
+                        rgb_matrix_set_flags(LED_FLAG_KEYLIGHT | LED_FLAG_MODIFIER);
+                        rgb_matrix_set_color_all(0, 0, 0);
+                    }
+                    break;
+                    case LED_FLAG_KEYLIGHT | LED_FLAG_MODIFIER: {
+                        rgb_matrix_set_flags(LED_FLAG_UNDERGLOW);
+                        rgb_matrix_set_color_all(0, 0, 0);
+                    }
+                    break;
+                    case LED_FLAG_UNDERGLOW: {
+                        // This line is for LED idle timer. It disables the toggle so you can turn off LED completely if you like
+                        rgb_time_out_enable = false;
+                        rgb_matrix_set_flags(LED_FLAG_NONE);
+                        rgb_matrix_disable_noeeprom();
+                    }
+                    break;
+                    default: {
+                        rgb_matrix_set_flags(LED_FLAG_ALL);
+                        rgb_matrix_enable_noeeprom();
+                    }
+                    break;
+                }
+                return false;
+            // ======================================================== CUSTOM KEYCOADS BELOW ========================================================
+            case COPY_ALL:
+                // Selects all and text and copy
+                SEND_STRING(SS_LCTRL("ac"));
+                return false;
+            case SEL_CPY:
+                // Select word under cursor and copy. Double mouse click then ctrl+c
+                tap_code16(KC_BTN1);
+                tap_code16(KC_BTN1);
+                tap_code16(C(KC_C));
+                return false;
+            case ROUT_TG:
+                // Toggle idle LED timeout on or off
+                rgb_time_out_enable = !rgb_time_out_enable;
+                rgb_time_out_user_value = rgb_time_out_enable;
+                return false;
+            case ROUT_VI:
+                // Increase idle LED timeout value in seconds
+                // Only increase if current value is lower than RGB_TIME_OUT_MAX. Don't care what value the result will be
+                // Modity RGB_TIME_OUT_STEP for bigger or smaller increments
+                if (!rgb_time_out_fast_mode_enabled && rgb_time_out_seconds <= RGB_TIME_OUT_MAX) {
+                    rgb_time_out_seconds += RGB_TIME_OUT_STEP;
+                }
+                return false;
+            case ROUT_VD:
+                // Decrease idle LED timeout value in seconds
+                // Only decrease if current value is higher than minimum value and the result is larger than zero
+                // Modity RGB_TIME_OUT_STEP for bigger or smaller decrements
+                if (!rgb_time_out_fast_mode_enabled && rgb_time_out_seconds > RGB_TIME_OUT_MIN) {
+                    rgb_time_out_seconds -= RGB_TIME_OUT_STEP;
+                }
+                return false;
+            case ROUT_FM:
+                if (rgb_time_out_fast_mode_enabled) {
+                    rgb_time_out_seconds = rgb_time_out_saved_seconds;
+                } else {
+                    rgb_time_out_saved_seconds = rgb_time_out_seconds;
+                    rgb_time_out_seconds = RGB_FAST_MODE_TIME_OUT;
+                }
+                rgb_time_out_fast_mode_enabled = !rgb_time_out_fast_mode_enabled;
+                return false;
+            case G_INIT ... G_LOG:
+                send_string_with_delay(sendstring_commands[keycode - G_INIT], 5);
+                return false;
+        }
+    }
+    return true;
+}
+
+void set_layer_color(int layer) {
+    if (layer == 0) { return; }
+    for (int i = 0; i < DRIVER_LED_TOTAL; i++) {
+        HSV hsv = {
+            .h = pgm_read_byte(&ledmap[layer][i][0]),
+            .s = pgm_read_byte(&ledmap[layer][i][1]),
+            .v = pgm_read_byte(&ledmap[layer][i][2]),
+        };
+        if (hsv.h || hsv.s || hsv.v) {
+            RGB rgb = hsv_to_rgb(hsv);
+            float f = (float)rgb_matrix_config.hsv.v / UINT8_MAX;
+            rgb_matrix_set_color(i, f * rgb.r, f * rgb.g, f * rgb.b);
+        } else if (layer != 1) {
+            // Only deactivate non-defined key LEDs at layers other than FN. Because at FN we have RGB adjustments and need to see them live.
+            // If the values are all false then it's a transparent key and deactivate LED at this layer
+            rgb_matrix_set_color(i, 0, 0, 0);
+        }
+    }
+}
+
+void rgb_matrix_indicators_user(void) {
+    if (disable_layer_color ||
+        rgb_matrix_get_flags() == LED_FLAG_NONE ||
+        rgb_matrix_get_flags() == LED_FLAG_UNDERGLOW) {
+            return;
+        }
+    set_layer_color(get_highest_layer(layer_state));
+}
+
+/* This is a test function for Raw HID, which is currently not implemented for this keyboard */
+/**
+void raw_hid_receive(uint8_t *data, uint8_t length) {
+    uint8_t response[RAW_EPSIZE];
+    memset(response+1, 'C', 1);
+    memset(response+2, 'T', 1);
+    memset(response+3, 'R', 1);
+    memset(response+4, 'L', 1);
+    raw_hid_send(data, length);
+}
+*/

--- a/keyboards/massdrop/ctrl/keymaps/endgame_mac/keymap.c
+++ b/keyboards/massdrop/ctrl/keymaps/endgame_mac/keymap.c
@@ -1,3 +1,6 @@
+// Copyright 2021 Randall Shutt (@rshutt)
+
+// SPDX-License-Identifier: GPL-2.0-or-later
 #include "keymap.h"
 
 static uint16_t idle_timer;             // Idle LED timeout timer

--- a/keyboards/massdrop/ctrl/keymaps/endgame_mac/keymap.c
+++ b/keyboards/massdrop/ctrl/keymaps/endgame_mac/keymap.c
@@ -1,5 +1,4 @@
 // Copyright 2021 Randall Shutt (@rshutt)
-
 // SPDX-License-Identifier: GPL-2.0-or-later
 #include "keymap.h"
 

--- a/keyboards/massdrop/ctrl/keymaps/endgame_mac/keymap.h
+++ b/keyboards/massdrop/ctrl/keymaps/endgame_mac/keymap.h
@@ -1,5 +1,4 @@
 // Copyright 2021 Randall Shutt (@rshutt)
-
 // SPDX-License-Identifier: GPL-2.0-or-later
 #include QMK_KEYBOARD_H
 

--- a/keyboards/massdrop/ctrl/keymaps/endgame_mac/keymap.h
+++ b/keyboards/massdrop/ctrl/keymaps/endgame_mac/keymap.h
@@ -1,5 +1,6 @@
 // Copyright 2021 Randall Shutt (@rshutt)
 // SPDX-License-Identifier: GPL-2.0-or-later
+
 #include QMK_KEYBOARD_H
 
 #include <print.h>

--- a/keyboards/massdrop/ctrl/keymaps/endgame_mac/keymap.h
+++ b/keyboards/massdrop/ctrl/keymaps/endgame_mac/keymap.h
@@ -1,0 +1,100 @@
+#include QMK_KEYBOARD_H
+
+#include <print.h>
+#include <string.h>
+// HID has not yet been implemented for this keyboard
+// #include "raw_hid.h"
+
+#define MILLISECONDS_IN_SECOND 1000
+
+// These are just to make it neater to use builtin HSV values in the keymap
+#define RED {HSV_RED}
+#define CORAL {HSV_CORAL}
+#define ORANGE {HSV_ORANGE}
+#define GOLDEN {HSV_GOLDENROD}
+#define GOLD {HSV_GOLD}
+#define YELLOW {HSV_YELLOW}
+#define CHART {HSV_CHARTREUSE}
+#define GREEN {HSV_GREEN}
+#define SPRING {HSV_SPRINGGREEN}
+#define TURQ {HSV_TURQUOISE}
+#define TEAL {HSV_TEAL}
+#define CYAN {HSV_CYAN}
+#define AZURE {HSV_AZURE}
+#define BLUE {HSV_BLUE}
+#define PURPLE {HSV_PURPLE}
+#define MAGENT {HSV_MAGENTA}
+#define PINK {HSV_PINK}
+
+//========================================================== CONFIGURABLE DEFAULTS ==========================================================
+#define RGB_DEFAULT_TIME_OUT 30
+#define RGB_FAST_MODE_TIME_OUT 3
+#define RGB_TIME_OUT_MAX 600
+#define RGB_TIME_OUT_MIN 10
+#define RGB_TIME_OUT_STEP 10
+
+extern rgb_config_t rgb_matrix_config;
+bool disable_layer_color;
+
+bool rgb_enabled_flag;                  // Current LED state flag. If false then LED is off.
+bool rgb_time_out_enable;               // Idle LED toggle enable. If false then LED will not turn off after idle timeout.
+bool rgb_time_out_fast_mode_enabled;    // Enable flag for RGB timeout fast mode
+bool rgb_time_out_user_value;           // This holds the toggle value set by user with ROUT_TG. It's necessary as RGB_TOG changes timeout enable.
+uint16_t rgb_time_out_seconds;          // Idle LED timeout value, in seconds not milliseconds
+uint16_t rgb_time_out_saved_seconds;    // The saved user config for RGB timeout period
+led_flags_t rgb_time_out_saved_flag;    // Store LED flag before timeout so it can be restored when LED is turned on again.
+
+enum layout_names {
+    _KL=0,       // Keys Layout: The main keyboard layout that has all the characters
+    _FL,         // Function Layout: The function key activated layout with default functions and some added ones
+    _ML,         // Mouse Layout: Mouse Keys and mouse movement
+    _GL,         // GIT Layout: GIT shortcuts and macros
+    _VL,         // VIM Layout: VIM shorcuts and macros
+    _YL,         // Yakuake Layout: Yakuake drop-down terminal shortcuts and macros
+    _EL,         // KDE Layout: Shortcuts for KDE desktop using default KDE shortcuts settings
+};
+
+enum tapdance_keycodes {
+    TD_LGUI_ML = 0,     // Tap dance key to switch to mouse layer _ML
+    TD_RGUI_ML = 0,     // Tap dance key to switch to mouse layer _ML
+    TD_APP_YL,
+    TD_CTRL_TERM,       // Tap dance key to open terminal on LCTRL double press
+};
+
+enum ctrl_keycodes {
+    U_T_AUTO = SAFE_RANGE, // USB Extra Port Toggle Auto Detect / Always Active
+    U_T_AGCR,              // USB Toggle Automatic GCR control
+    DBG_TOG,               // DEBUG Toggle On / Off
+    DBG_MTRX,              // DEBUG Toggle Matrix Prints
+    DBG_KBD,               // DEBUG Toggle Keyboard Prints
+    DBG_MOU,               // DEBUG Toggle Mouse Prints
+    MD_BOOT,               // Restart into bootloader after hold timeout
+    SEL_CPY,               // Select Copy. Select the word cursor is pointed at and copy, using double mouse click and ctrl+c
+    ROUT_TG,               // Timeout Toggle. Toggle idle LED time out on or off
+    ROUT_VI,               // Timeout Value Increase. Increase idle time out before LED disabled
+    ROUT_VD,               // Timeout Value Decrease. Decrease idle time out before LED disabled
+    ROUT_FM,               // RGB timeout fast mode toggle
+    COPY_ALL,              // Copy all text using ctrl(a+c)
+    TERMINAL,              // CTRL+ALT+T
+};
+
+enum string_macro_keycodes {
+    // The start of this enum should always be equal to end of ctrl_keycodes + 1
+    G_INIT = TERMINAL + 1, // git init
+    G_CLONE,               // git clone
+    G_CONF,                // git config --global
+    G_ADD,                 // git add
+    G_DIFF,                // git diff
+    G_RESET,               // git reset
+    G_REBAS,               // git rebase
+    G_BRANH,               // git branch
+    G_CHECK,               // git checkout
+    G_MERGE,               // git merge
+    G_REMTE,               // git remote add
+    G_FETCH,               // git fetch
+    G_PULL,                // git pull
+    G_PUSH,                // git push
+    G_COMM,                // git commit
+    G_STAT,                // git status
+    G_LOG,                 // git log
+};

--- a/keyboards/massdrop/ctrl/keymaps/endgame_mac/keymap.h
+++ b/keyboards/massdrop/ctrl/keymaps/endgame_mac/keymap.h
@@ -1,3 +1,6 @@
+// Copyright 2021 Randall Shutt (@rshutt)
+
+// SPDX-License-Identifier: GPL-2.0-or-later
 #include QMK_KEYBOARD_H
 
 #include <print.h>

--- a/keyboards/massdrop/ctrl/keymaps/endgame_mac/rules.mk
+++ b/keyboards/massdrop/ctrl/keymaps/endgame_mac/rules.mk
@@ -1,0 +1,16 @@
+# RGBLIGHT_ENABLE = no				# Not for MD boards. This is here in case you forget.
+COMMAND_ENABLE = yes				# Commands for debug and configuration
+# BOOTMAGIC_ENABLE = full			# Virtual DIP switch configuration
+# BOOTMAGIC_ENABLE = lite
+# AUTO_SHIFT_ENABLE = yes      	# Auto Shift
+NKRO_ENABLE = yes           	# USB Nkey Rollover
+DYNAMIC_MACRO_ENABLE = yes		# Dynamic macro recording and play
+MOUSEKEY_ENABLE = yes			# Enable mouse control keycodes. Increases firmware size.
+TAP_DANCE_ENABLE = yes			# Enable tap dance keys
+CONSOLE_ENABLE = yes			# Enable debugging console. Increases firmware size.
+SRC += config_led.c				# Used to add files to the compilation/linking list.
+TERMINAL_ENABLE = yes
+EXTRAKEY_ENABLE = yes			# Audio control and System control
+# RAW_ENABLE = yes				# Raw HID has not yet been implemented for this keyboard
+# COMBO_ENABLE					# Key combo feature
+# LEADER_ENABLE					# Enable leader key chording

--- a/keyboards/massdrop/ctrl/keymaps/endgame_mac/rules.mk
+++ b/keyboards/massdrop/ctrl/keymaps/endgame_mac/rules.mk
@@ -1,7 +1,7 @@
 # RGBLIGHT_ENABLE = no				# Not for MD boards. This is here in case you forget.
 COMMAND_ENABLE = yes				# Commands for debug and configuration
 # BOOTMAGIC_ENABLE = full			# Virtual DIP switch configuration
-BOOTMAGIC_ENABLE = lite
+BOOTMAGIC_ENABLE = yes
 # AUTO_SHIFT_ENABLE = yes      	# Auto Shift
 NKRO_ENABLE = yes           	# USB Nkey Rollover
 DYNAMIC_MACRO_ENABLE = yes		# Dynamic macro recording and play

--- a/keyboards/massdrop/ctrl/keymaps/endgame_mac/rules.mk
+++ b/keyboards/massdrop/ctrl/keymaps/endgame_mac/rules.mk
@@ -1,7 +1,7 @@
 # RGBLIGHT_ENABLE = no				# Not for MD boards. This is here in case you forget.
 COMMAND_ENABLE = yes				# Commands for debug and configuration
 # BOOTMAGIC_ENABLE = full			# Virtual DIP switch configuration
-# BOOTMAGIC_ENABLE = lite
+BOOTMAGIC_ENABLE = lite
 # AUTO_SHIFT_ENABLE = yes      	# Auto Shift
 NKRO_ENABLE = yes           	# USB Nkey Rollover
 DYNAMIC_MACRO_ENABLE = yes		# Dynamic macro recording and play


### PR DESCRIPTION
## Description

This pr both adds an `endgame_mac` keymap and fixes the `endgame` keymap. 

Changes introduced in #12097 (4b96d5876eb01dfd8063949a2e5cb4b70e01786d) actually broke the endgame keymap as the function `md_rgb_matrix_indicators` was replaced with `md_rgb_matrix_indicators_advanced`.  The former had no args and the latter took a `led_min` and `led_max` integer argument.  Turns out, min = 0 and max = ISSI3733_LED_COUNT

Furthermore, with the endgame_mac keymap, I changed some of the matrix effects and set the default to be something I liked :). As expected, the endgame_mac keymap takes into account the swapped cmd and alt keys!

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ X ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ X ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Not sure what issues are fixed.  I didn't bother to create an issue

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ X ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ X ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
