### PR TITLE
[Core] Enable emulated eeprom when using F401xE.

### DIFF
--- a/common_features.mk
+++ b/common_features.mk
@@ -174,7 +174,7 @@ else
         SRC += $(PLATFORM_COMMON_DIR)/eeprom_stm32.c
         SRC += $(PLATFORM_COMMON_DIR)/flash_stm32.c
         OPT_DEFS += -DEEPROM_EMU_STM32F072xB
-      else ifneq ($(filter $(MCU_SERIES)_$(MCU_LDSCRIPT),STM32F4xx_STM32F401xC STM32F4xx_STM32F411xE STM32F4xx_STM32F405xG),)
+      else ifneq ($(filter $(MCU_SERIES)_$(MCU_LDSCRIPT),STM32F4xx_STM32F401xC STM32F4xx_STM32F401xE STM32F4xx_STM32F411xE STM32F4xx_STM32F405xG),)
         OPT_DEFS += -DEEPROM_DRIVER
         COMMON_VPATH += $(DRIVER_PATH)/eeprom
         SRC += eeprom_driver.c

--- a/platforms/chibios/boards/common/ld/STM32F401xE.ld
+++ b/platforms/chibios/boards/common/ld/STM32F401xE.ld
@@ -1,0 +1,85 @@
+/*
+    ChibiOS - Copyright (C) 2006..2018 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/*
+ * STM32F401xE memory setup.
+ */
+MEMORY
+{
+    flash0 (rx) : org = 0x08000000, len = 16k        /* Sector 0    - Init code as ROM bootloader assumes application starts here */
+    flash1 (rx) : org = 0x08004000, len = 16k        /* Sector 1    - Emulated eeprom */
+    flash2 (rx) : org = 0x08008000, len = 512k - 32k /* Sector 2..7 - Rest of firmware */
+    flash3 (rx) : org = 0x00000000, len = 0
+    flash4 (rx) : org = 0x00000000, len = 0
+    flash5 (rx) : org = 0x00000000, len = 0
+    flash6 (rx) : org = 0x00000000, len = 0
+    flash7 (rx) : org = 0x00000000, len = 0
+    ram0   (wx) : org = 0x20000000, len = 96k
+    ram1   (wx) : org = 0x00000000, len = 0
+    ram2   (wx) : org = 0x00000000, len = 0
+    ram3   (wx) : org = 0x00000000, len = 0
+    ram4   (wx) : org = 0x00000000, len = 0
+    ram5   (wx) : org = 0x00000000, len = 0
+    ram6   (wx) : org = 0x00000000, len = 0
+    ram7   (wx) : org = 0x00000000, len = 0
+}
+
+/* For each data/text section two region are defined, a virtual region
+   and a load region (_LMA suffix).*/
+
+/* Flash region to be used for exception vectors.*/
+REGION_ALIAS("VECTORS_FLASH", flash0);
+REGION_ALIAS("VECTORS_FLASH_LMA", flash0);
+
+/* Flash region to be used for constructors and destructors.*/
+REGION_ALIAS("XTORS_FLASH", flash2);
+REGION_ALIAS("XTORS_FLASH_LMA", flash2);
+
+/* Flash region to be used for code text.*/
+REGION_ALIAS("TEXT_FLASH", flash2);
+REGION_ALIAS("TEXT_FLASH_LMA", flash2);
+
+/* Flash region to be used for read only data.*/
+REGION_ALIAS("RODATA_FLASH", flash2);
+REGION_ALIAS("RODATA_FLASH_LMA", flash2);
+
+/* Flash region to be used for various.*/
+REGION_ALIAS("VARIOUS_FLASH", flash2);
+REGION_ALIAS("VARIOUS_FLASH_LMA", flash2);
+
+/* Flash region to be used for RAM(n) initialization data.*/
+REGION_ALIAS("RAM_INIT_FLASH_LMA", flash2);
+
+/* RAM region to be used for Main stack. This stack accommodates the processing
+   of all exceptions and interrupts.*/
+REGION_ALIAS("MAIN_STACK_RAM", ram0);
+
+/* RAM region to be used for the process stack. This is the stack used by
+   the main() function.*/
+REGION_ALIAS("PROCESS_STACK_RAM", ram0);
+
+/* RAM region to be used for data segment.*/
+REGION_ALIAS("DATA_RAM", ram0);
+REGION_ALIAS("DATA_RAM_LMA", flash2);
+
+/* RAM region to be used for BSS segment.*/
+REGION_ALIAS("BSS_RAM", ram0);
+
+/* RAM region to be used for the default heap.*/
+REGION_ALIAS("HEAP_RAM", ram0);
+
+/* Generic rules inclusion.*/
+INCLUDE rules.ld

--- a/tmk_core/common/chibios/eeprom_stm32_defs.h
+++ b/tmk_core/common/chibios/eeprom_stm32_defs.h
@@ -32,7 +32,7 @@
 #        ifndef FEE_PAGE_COUNT
 #            define FEE_PAGE_COUNT 4  // How many pages are used
 #        endif
-#    elif defined(STM32F401xC) || defined(STM32F405xG) || defined(STM32F411xE)
+#    elif defined(STM32F401xC) || defined(STM32F401xE) || defined(STM32F405xG) || defined(STM32F411xE)
 #        ifndef FEE_PAGE_SIZE
 #            define FEE_PAGE_SIZE 0x4000  // Page size = 16KByte
 #        endif
@@ -49,7 +49,7 @@
 #        define FEE_MCU_FLASH_SIZE 128  // Size in Kb
 #    elif defined(STM32F303xC) || defined(STM32F401xC)
 #        define FEE_MCU_FLASH_SIZE 256  // Size in Kb
-#    elif defined(STM32F103xE) || defined(STM32F411xE)
+#    elif defined(STM32F103xE) || defined(STM32F401xE) || defined(STM32F411xE)
 #        define FEE_MCU_FLASH_SIZE 512  // Size in Kb
 #    elif defined(STM32F405xG)
 #        define FEE_MCU_FLASH_SIZE 1024  // Size in Kb
@@ -58,7 +58,7 @@
 
 /* Start of the emulated eeprom */
 #if !defined(FEE_PAGE_BASE_ADDRESS)
-#    if defined(STM32F401xC) || defined(STM32F405xG) || defined(STM32F411xE)
+#    if defined(STM32F401xC) || defined(STM32F401xE) || defined(STM32F405xG) || defined(STM32F411xE)
 #        ifndef FEE_PAGE_BASE_ADDRESS
 #            define FEE_PAGE_BASE_ADDRESS 0x08004000  // bodge to force 2nd 16k page
 #        endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

Not really much to change, I added the defined checks for `STM32F401xE` so it should work correctly if using the NUCLEO F401RE as a base. 

I tested using the existing blackpill f401 platform by undefining `STM32F401xC`, defining `STM32F401xE` in my board.h and setting `MCU_LDSCRIPT = STM32F401xE` in my rules.mk.

ldflags.txt in .build shows the correct ldscript being used `--script=./platforms/chibios/boards/common/ld/STM32F401xE.ld`

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
