### PR TITLE
[Keyboard] Fix IS31FL3741 driver flushin for Xelus pachi rgb

### DIFF
--- a/keyboards/xelus/pachi/rgb/rgb.c
+++ b/keyboards/xelus/pachi/rgb/rgb.c
@@ -228,7 +228,11 @@ static void init(void) {
     IS31FL3741_update_led_control_registers(DRIVER_ADDR_1, 0);
 }
 
-static void flush(void) { IS31FL3741_update_pwm_buffers(DRIVER_ADDR_1, DRIVER_ADDR_2); }
+static void flush(void) {
+    IS31FL3741_update_pwm_buffers(DRIVER_ADDR_1, 0);
+    // Just for reference. Only first driver is used? 
+    // IS31FL3741_update_pwm_buffers(DRIVER_ADDR_2, 1);
+}
 
 const rgb_matrix_driver_t rgb_matrix_driver = {
     .init = init,


### PR DESCRIPTION

## Description

Changes to 3741 driver broke compilation.  This should fix it.


## Types of Changes

- [x] Bugfix
- [x] Keyboard (addition or update)

## Issues Fixed or Closed by This PR

* Tzarc CI

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
