### PR TITLE
Fix OLED timeout on satisfaction75 after migration from QWIIC

### DIFF
--- a/keyboards/cannonkeys/satisfaction75/config.h
+++ b/keyboards/cannonkeys/satisfaction75/config.h
@@ -74,6 +74,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // configure oled driver for the 128x32 oled
 #define OLED_UPDATE_INTERVAL 66 // ~15fps
 
+// OLED_TIMEOUT is incompatible with the OLED_OFF mode
+#define OLED_TIMEOUT 0
+
+// OLED timeout reimplemented in the keyboard-specific code
+#define CUSTOM_OLED_TIMEOUT 60000
+
 // Custom config starts after VIA's EEPROM usage,
 // dynamic keymaps start after this.
 // Custom config Usage:

--- a/keyboards/cannonkeys/satisfaction75/satisfaction75.h
+++ b/keyboards/cannonkeys/satisfaction75/satisfaction75.h
@@ -72,6 +72,9 @@ extern uint8_t layer;
 
 // OLED Behavior
 extern uint8_t oled_mode;
+extern bool oled_repaint_requested;
+extern bool oled_wakeup_requested;
+extern uint32_t oled_sleep_timer;
 
 // Encoder Behavior
 extern uint8_t encoder_value;
@@ -106,6 +109,10 @@ uint16_t retrieve_custom_encoder_config(uint8_t encoder_idx, uint8_t behavior);
 void set_custom_encoder_config(uint8_t encoder_idx, uint8_t behavior, uint16_t new_code);
 
 void update_time_config(int8_t increment);
+
+void oled_request_wakeup(void);
+void oled_request_repaint(void);
+bool oled_task_needs_to_repaint(void);
 
 void backlight_init_ports(void);
 void backlight_set(uint8_t level);

--- a/keyboards/cannonkeys/satisfaction75/satisfaction_oled.c
+++ b/keyboards/cannonkeys/satisfaction75/satisfaction_oled.c
@@ -8,7 +8,7 @@ void draw_clock(void);
 __attribute__((weak)) oled_rotation_t oled_init_user(oled_rotation_t rotation) { return OLED_ROTATION_0; }
 
 __attribute__((weak)) void oled_task_user(void) {
-    if (!is_oled_on()) {
+    if (!oled_task_needs_to_repaint()) {
         return;
     }
     oled_clear();
@@ -25,6 +25,70 @@ __attribute__((weak)) void oled_task_user(void) {
             draw_clock();
             break;
     }
+}
+
+// Request a repaint of the OLED image without resetting the OLED sleep timer.
+// Used for things like clock updates that should not keep the OLED turned on
+// if there is no other activity.
+void oled_request_repaint(void) {
+    if (is_oled_on()) {
+        oled_repaint_requested = true;
+    }
+}
+
+// Request a repaint of the OLED image and reset the OLED sleep timer.
+// Needs to be called after any activity that should keep the OLED turned on.
+void oled_request_wakeup(void) {
+    oled_wakeup_requested = true;
+}
+
+// Check whether oled_task_user() needs to repaint the OLED image.  This
+// function should be called at the start of oled_task_user(); it also handles
+// the OLED sleep timer and the OLED_OFF mode.
+bool oled_task_needs_to_repaint(void) {
+    // In the OLED_OFF mode the OLED is kept turned off; any wakeup requests
+    // are ignored.
+    if ((oled_mode == OLED_OFF) && !clock_set_mode) {
+        oled_wakeup_requested = false;
+        oled_repaint_requested = false;
+        oled_off();
+        return false;
+    }
+
+    // If OLED wakeup was requested, reset the sleep timer and do a repaint.
+    if (oled_wakeup_requested) {
+        oled_wakeup_requested = false;
+        oled_repaint_requested = false;
+        oled_sleep_timer = timer_read32() + CUSTOM_OLED_TIMEOUT;
+        oled_on();
+        return true;
+    }
+
+    // If OLED repaint was requested, just do a repaint without touching the
+    // sleep timer.
+    if (oled_repaint_requested) {
+        oled_repaint_requested = false;
+        return true;
+    }
+
+    // If the OLED is currently off, skip the repaint (which would turn the
+    // OLED on if the image is changed in any way).
+    if (!is_oled_on()) {
+        return false;
+    }
+
+    // If the sleep timer has expired while the OLED was on, turn the OLED off.
+    if (timer_expired32(timer_read32(), oled_sleep_timer)) {
+        oled_off();
+        return false;
+    }
+
+    // Always perform a repaint if the OLED is currently on.  (This can
+    // potentially be optimized to avoid unneeded repaints if all possible
+    // state changes are covered by oled_request_repaint() or
+    // oled_request_wakeup(), but then any missed calls to these functions
+    // would result in displaying a stale image.)
+    return true;
 }
 
 


### PR DESCRIPTION
## Description

When the `cannonkeys/satisfaction75` code was migrated from QWIIC drivers to the common OLED API in #14747, the OLED idle timeout feature got broken (the OLED display was always turned on, unless the custom `OLED_OFF` mode was selected). Restore the OLED idle timeout functionality.

Normally the OLED idle timeout handling is performed by the common OLED code (`OLED_TIMEOUT` defaults to 60000, so the display gets turned off after 60 seconds without any key or encoder actions). However, the custom `OLED_OFF` mode implemented on `cannonkeys/satisfaction75` is incompatible with the `OLED_TIMEOUT` feature (the `OLED_TIMEOUT` code assumes that any key or encoder action should turn the OLED display on, and does not provide any way to disable that behavior).  To keep the `OLED_OFF` mode functioning as before while still having a working OLED idle timeout, a custom implementation of the OLED idle timeout code is added (somewhat similar to what the old QWIIC code had).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Broken OLED display timeout on `cannonkeys/satisfaction75` after #14747

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
