### PR TITLE
Allow AVR Bootloader size to be configurable

### DIFF
--- a/bootloader.mk
+++ b/bootloader.mk
@@ -42,10 +42,10 @@ ifeq ($(strip $(BOOTLOADER)), atmel-dfu)
     OPT_DEFS += -DBOOTLOADER_ATMEL_DFU
     OPT_DEFS += -DBOOTLOADER_DFU
     ifneq (,$(filter $(MCU), at90usb162 atmega16u2 atmega32u2 atmega16u4 atmega32u4 at90usb646 at90usb647))
-        BOOTLOADER_SIZE ?= 4096
+        BOOTLOADER_SIZE = 4096
     endif
     ifneq (,$(filter $(MCU), at90usb1286 at90usb1287))
-        BOOTLOADER_SIZE ?= 8192
+        BOOTLOADER_SIZE = 8192
     endif
 endif
 ifeq ($(strip $(BOOTLOADER)), lufa-dfu)


### PR DESCRIPTION
## Description

As the title says.  Allows the AVR bootloader sizes to be configurable, as some controllers can support it.  See referenced PR. 

## Types of Changes

- [x] Core
- [x] Enhancement/optimization

## Issues Fixed or Closed by This PR

* closes #13547

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
