### PR TITLE
maxr1998/pulse4k: use layout macros in keymaps

### DIFF
--- a/keyboards/maxr1998/pulse4k/keymaps/default/keymap.c
+++ b/keyboards/maxr1998/pulse4k/keymaps/default/keymap.c
@@ -24,8 +24,8 @@ enum layers {
 const uint16_t PROGMEM led_adjust_combo[] = {KC_LEFT, KC_RGHT, COMBO_END};
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    [DEFAULT] = {
-        { KC_END,  KC_UP,   KC_MUTE },
-        { KC_LEFT, KC_DOWN, KC_RGHT }
-    }
+    [DEFAULT] = LAYOUT(
+        KC_END,  KC_UP,   KC_MUTE,
+        KC_LEFT, KC_DOWN, KC_RGHT
+    )
 };

--- a/keyboards/maxr1998/pulse4k/keymaps/maxr1998/keymap.c
+++ b/keyboards/maxr1998/pulse4k/keymaps/maxr1998/keymap.c
@@ -24,10 +24,10 @@ enum layers {
 const uint16_t PROGMEM led_adjust_combo[] = {KC_F22, KC_F24, COMBO_END};
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    [DEFAULT] = {
-        { KC_F20, KC_F21, KC_MUTE },
-        { KC_F22, KC_F23, KC_F24  }
-    }
+    [DEFAULT] = LAYOUT(
+        KC_F20,  KC_F21,  KC_MUTE,
+        KC_F22,  KC_F23,  KC_F24
+    )
 };
 
 void encoder_one_update(bool clockwise) {


### PR DESCRIPTION
## Description

The board has a layout macro that isn't currently used by its keymaps.

cc @Maxr1998 (keyboard maintainer) – This PR also edits your personal keymap, but none of the behaviour is changed.

## Types of Changes

- [x] Enhancement/optimization
- [x] Keymap/layout/userspace (addition or update)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
