### PR TITLE
contra, fractal: Remove wrongly copypasted pin E6 manipulation code

### DIFF
--- a/keyboards/contra/keymaps/default/keymap.c
+++ b/keyboards/contra/keymaps/default/keymap.c
@@ -222,10 +222,8 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         #ifdef BACKLIGHT_ENABLE
           backlight_step();
         #endif
-        PORTE &= ~(1<<6);
       } else {
         unregister_code(KC_RSFT);
-        PORTE |= (1<<6);
       }
       return false;
       break;

--- a/keyboards/fractal/keymaps/default/keymap.c
+++ b/keyboards/fractal/keymaps/default/keymap.c
@@ -213,10 +213,8 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             #ifdef BACKLIGHT_ENABLE
               backlight_step();
             #endif
-            PORTE &= ~(1<<6);
           } else {
             unregister_code(KC_RSFT);
-            PORTE |= (1<<6);
           }
           return false;
           break;


### PR DESCRIPTION
## Description

Apparently the default keymaps for `contra` and `fractal` were derived from some `planck` keymap which contained code to control the status LED in the implementation of the `BACKLIT` custom keycode.  Unfortunately, the code to control the LED manipulated the `E6` pin directly, and it was copied without changes, but the `contra` and `fractal` boards use the `E6` pin in the matrix, therefore pressing the key mapped to `BACKLIT` resulted in phantom keypresses for all keys in the corresponding column.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Problem with `contra` reported in Discord `#help-hardware`: https://discord.com/channels/440868230475677696/867530303261114398/898086779649941524

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
