### PR TITLE
Update documentation because GPIO functions are no longer in quantum.h

### DIFF
--- a/docs/internals_gpio_control.md
+++ b/docs/internals_gpio_control.md
@@ -4,7 +4,7 @@ QMK has a GPIO control abstraction layer which is microcontroller agnostic. This
 
 ## Functions :id=functions
 
-The following functions can provide basic control of GPIOs and are found in `tmk_core/common/avr/gpio.h`, `tmk_core/common/chibios/gpio.h`, and `tmk_core/common/arm_atsam/gpio.h`.
+The following functions provide basic control of GPIOs and are found in `tmk_core/common/<platform>/gpio.h`.
 
 |Function                |Description                                       | Old AVR Examples                                | Old ChibiOS/ARM Examples                        |
 |------------------------|--------------------------------------------------|-------------------------------------------------|-------------------------------------------------|


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
They are defined in platform specific tmk headers.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
