### PR TITLE
Added clarification on send_unicode_string()

### DIFF
--- a/docs/feature_unicode.md
+++ b/docs/feature_unicode.md
@@ -230,6 +230,12 @@ send_unicode_string("(ノಠ痊ಠ)ノ彡┻━┻");
 
 Example uses include sending Unicode strings when a key is pressed, as described in [Macros](feature_macros.md).
 
+This function requires Unicode to be enabled in your `rules.mk` and an [input mode](https://beta.docs.qmk.fm/using-qmk/software-features/feature_unicode#2.-input-modes-id-input-modes) to be selected:
+
+```make
+UNICODE_ENABLE = yes
+```
+
 ### `send_unicode_hex_string()` (Deprecated)
 
 Similar to `send_unicode_string()`, but the characters are represented by their Unicode code points, written in hexadecimal and separated by spaces. For example, the table flip above would be achieved with:


### PR DESCRIPTION
## Description

From the docs it wasn't super clear that using `send_unicode_string()` also requires the appropriate options to be enabled in `rules.mk` and `config.h` so I added a short clarification.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* Unclear documentation on the `send_unicode_string()` function

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
