### PR TITLE
[Keymap] Adding 'super alt' keymap for Wuque ikki68 Aurora

### DIFF
--- a/keyboards/wuque/ikki68_aurora/keymaps/ewersp/README.md
+++ b/keyboards/wuque/ikki68_aurora/keymaps/ewersp/README.md
@@ -1,0 +1,36 @@
+## Greetings, Traveler!
+
+This layout is for the [Wuque ikki68 Aurora](https://shop.wuquestudio.com/pages/ikki68-aurora) and is primarily meant for Windows.
+
+The keymap is similar to the default keymap for the Aurora, but it overloads the left alt key to behave like an additional 'Fn' key while keeping the standard functionality of the alt key intact.
+
+### For Example
+```
+LeftAlt + 1...N         -> F1...FN
+LeftAlt + L/R Arrows    -> Home/End
+LeftAlt + Home          -> End
+LeftAlt + Backspace     -> Delete
+LeftAlt + Esc           -> Backtick (`)
+LeftAlt + Shift + Esc   -> Tilde (~)
+LeftAlt + LeftShift + 4 -> Alt+F4
+```
+
+The novel part of this keymap is that it **preserves the default functionality** of the left alt key, so ```'alt + tab', 'ctrl + alt + del', 'alt + f4'```, etc. all work as expected without having to use timers.
+
+Everything also works with other modifier keys, so ```'alt + L/R' and 'alt + shift + L/R'``` work great for text manipulation to select lines.
+
+This **super alt** keymap will feel very familiar for anyone **coming from macOS** since the Windows alt key is in the same position as CMD on macOS keyboards.
+
+And finally, the original alt key functionality can be toggled at any time by pressing ```'Fn + period'``` so for example if a game requires use of the left alt, you can easily turn it off.
+
+### Compiling/Flashing
+1) After installing QMK MSYS, open the QMK MSYS terminal
+2) Type ```qmk compile -kb wuque/ikki68_aurora -km ewersp``` to test compilation
+3) Type ```qmk flash -kb wuque/ikki68_aurora -km ewersp``` to start flashing
+4) Press ```Fn+Page Up``` to put your keyboard into bootloader mode
+    - Note: After installing the keymap, to enter bootloader mode again press and hold ```Fn+B``` for half a second
+5) Wait for the ```Validating... Success``` message to appear and you're done!
+
+If you have any questions, feel free to reach out to me at: ewersp [at] gmail [dot] com.
+
+Enjoy! **<3**

--- a/keyboards/wuque/ikki68_aurora/keymaps/ewersp/README.md
+++ b/keyboards/wuque/ikki68_aurora/keymaps/ewersp/README.md
@@ -23,6 +23,9 @@ This **super alt** keymap will feel very familiar for anyone **coming from macOS
 
 And finally, the original alt key functionality can be toggled at any time by pressing ```'Fn + period'``` so for example if a game requires use of the left alt, you can easily turn it off.
 
+### Toggle LED Modes
+You can also cycle though multiple LED modes (underglow, logo, all, none) by pressing ```'Fn + x'``` (the default ikki68 Aurora keymap only supports all or none). The last value set is persisted in EEPROM.
+
 ### Compiling/Flashing
 1) After installing QMK MSYS, open the QMK MSYS terminal
 2) Type ```qmk compile -kb wuque/ikki68_aurora -km ewersp``` to test compilation
@@ -30,6 +33,7 @@ And finally, the original alt key functionality can be toggled at any time by pr
 4) Press ```Fn+Page Up``` to put your keyboard into bootloader mode
     - Note: After installing the keymap, to enter bootloader mode again press and hold ```Fn+B``` for half a second
 5) Wait for the ```Validating... Success``` message to appear and you're done!
+    - Note: If it gets stuck on ```Bootloader not found. Trying again every 0.5s...``` you may need to run QMK Toolbox to install/update drivers
 
 If you have any questions, feel free to reach out to me at: ewersp [at] gmail [dot] com.
 

--- a/keyboards/wuque/ikki68_aurora/keymaps/ewersp/config.h
+++ b/keyboards/wuque/ikki68_aurora/keymaps/ewersp/config.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#define FORCE_NKRO

--- a/keyboards/wuque/ikki68_aurora/keymaps/ewersp/config.h
+++ b/keyboards/wuque/ikki68_aurora/keymaps/ewersp/config.h
@@ -1,3 +1,19 @@
+/* Copyright 2021 Paul Ewers
+ * 
+ * This program is free software: you can redistribute it and/or modify 
+ * it under the terms of the GNU General Public License as published by 
+ * the Free Software Foundation, either version 2 of the License, or 
+ * (at your option) any later version. 
+ * 
+ * This program is distributed in the hope that it will be useful, 
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+ * GNU General Public License for more details. 
+ * 
+ * You should have received a copy of the GNU General Public License 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ */
+
 #pragma once
 
 #define FORCE_NKRO

--- a/keyboards/wuque/ikki68_aurora/keymaps/ewersp/keymap.c
+++ b/keyboards/wuque/ikki68_aurora/keymaps/ewersp/keymap.c
@@ -25,6 +25,7 @@ enum alt_keycodes {
 enum alt_layers {
     DEF = 0,
     ALT,
+    MAC,
     FUNC,
     SUPR
 };
@@ -63,11 +64,18 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,             _______,
         _______, _______, KC_LALT,          _______,          _______,          _______,          _______, _______, _______,             _______, _______, _______
     ),
+    [MAC] = LAYOUT_all(
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,    _______, _______,
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,             _______, _______,
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          _______,
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,             _______,
+        _______, KC_LALT, KC_LGUI,          _______,          _______,          _______,          KC_RGUI, _______, KC_RALT,             _______, _______, _______
+    ),
     [FUNC] = LAYOUT_all(
         KC_GRV,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  _______, _______,    KC_END,  KC_VOLU,
-        _______, RGB_HUD, RGB_VAI, RGB_HUI, RGB_SAI, RGB_M_P, _______, _______, _______, KC_PAUS, KC_PSCR, _______, _______, _______,             KC_MUTE, KC_VOLD,
-        _______, RGB_RMOD,RGB_VAD, RGB_MOD, RGB_SAD, RGB_M_B, _______, _______, _______, _______, _______, _______,          _______,
-        _______, _______, RGB_TOG, LED_TOG, _______, EEP_RST, RESET,   _______, _______, _______, TG(ALT), _______, _______, _______,             KC_PGUP,
+        _______, RGB_HUD, RGB_VAI, RGB_HUI, RGB_SAI, RGB_M_P, _______, _______, _______, KC_BRIU, KC_PAUS, KC_PSCR, _______, _______,             KC_MUTE, KC_VOLD,
+        _______, RGB_RMOD,RGB_VAD, RGB_MOD, RGB_SAD, RGB_M_B, _______, _______, _______, KC_BRID, _______, _______,          _______,
+        _______, _______, RGB_TOG, LED_TOG, _______, EEP_RST, RESET,   _______, _______, TG(MAC), TG(ALT), _______, _______, _______,             KC_PGUP,
         _______, _______, KC_LALT,          _______,          _______,          _______,          _______, _______, _______,             KC_HOME, KC_PGDN, KC_END
     ),
     [SUPR] = LAYOUT_all(
@@ -147,6 +155,8 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         case KC_DEL:
         case KC_UP:
         case KC_DOWN:
+        case KC_ENT:
+        case KC_SPC:
         case MO(FUNC):
             if (super_alt_layer_active && record->event.pressed) {
                 // Only activate the alt modifier for the first key press

--- a/keyboards/wuque/ikki68_aurora/keymaps/ewersp/keymap.c
+++ b/keyboards/wuque/ikki68_aurora/keymaps/ewersp/keymap.c
@@ -1,0 +1,129 @@
+#include QMK_KEYBOARD_H
+
+enum alt_keycodes {
+    ALT_DEL = SAFE_RANGE // Added to map left alt + backspace to delete
+};
+
+// Friendly layer names
+enum alt_layers {
+    DEF = 0,
+    ALT,
+    FUNC,
+    SUPR
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [DEF] = LAYOUT_all(
+        KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_BSPC,    KC_HOME, KC_PGUP,
+        KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS,             KC_DEL,  KC_PGDN,
+        KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,          KC_ENT,
+        KC_LSFT, KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT, KC_RSFT,             KC_UP,
+        KC_LCTL, KC_LGUI, MO(SUPR),         KC_SPC,           KC_SPC,           KC_SPC,           KC_RALT, MO(FUNC),KC_RCTL,             KC_LEFT, KC_DOWN, KC_RGHT
+    ),
+    [ALT] = LAYOUT_all(
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,    _______, _______,
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,             _______, _______,
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          _______,
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,             _______,
+        _______, _______, KC_LALT,          _______,          _______,          _______,          _______, _______, _______,             _______, _______, _______
+    ),
+    [FUNC] = LAYOUT_all(
+        KC_GRV,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  _______, _______,    KC_END,  KC_VOLU,
+        _______, RGB_SPD, RGB_VAI, RGB_SPI, RGB_HUI, RGB_SAI, RGB_M_P, _______, _______, KC_PAUS, KC_PSCR, _______, _______, _______,             KC_MUTE, KC_VOLD,
+        _______, RGB_RMOD,RGB_VAD, RGB_MOD, RGB_HUD, RGB_SAD, RGB_M_B, _______, _______, _______, _______, _______,          _______,
+        _______, _______, RGB_TOG, _______, _______, EEP_RST, RESET,   _______, _______, _______, TG(ALT), _______, _______, _______,             KC_PGUP,
+        _______, _______, KC_LALT,          _______,          _______,          _______,          _______, _______, _______,             KC_HOME, KC_PGDN, KC_END
+    ),
+    [SUPR] = LAYOUT_all(
+        KC_GRV,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  ALT_DEL, ALT_DEL,    KC_END,  _______,
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,             _______, _______,
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          _______,
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,             _______,
+        _______, _______, _______,          _______,          _______,          _______,          _______, _______, _______,             KC_HOME, _______, KC_END
+    )
+};
+
+// If the super alt layer is the active layer
+bool super_alt_layer_active = false;
+
+// If we need to unregister alt when leaving the super alt layer
+bool need_to_unregister_alt = false;
+
+// This runs code every time that the layers get changed
+layer_state_t layer_state_set_user(layer_state_t state) {
+    switch (get_highest_layer(state)) {
+        case DEF:
+            // When returning to the default layer, check if we need to unregister the left alt key
+            if (super_alt_layer_active && need_to_unregister_alt) {
+                unregister_code(KC_LALT);
+            }
+
+            super_alt_layer_active = false;
+            need_to_unregister_alt = false;
+            break;
+        case SUPR:
+            super_alt_layer_active = true;
+            break;
+    }
+    return state;
+}
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    static uint32_t key_timer;
+
+    switch (keycode) {
+        // These are the keys we want to 'fall though' and behave as usual when pressed with the alt modifier
+        case KC_A ... KC_Z:
+        case KC_TAB:
+        case KC_DEL:
+        case KC_UP:
+        case KC_DOWN:
+        case MO(FUNC):
+            if (super_alt_layer_active && record->event.pressed) {
+                // Only activate the alt modifier for the first key press
+                if ((get_mods() & MOD_BIT(KC_LALT)) == false) {
+                    register_code(KC_LALT);
+                    need_to_unregister_alt = true;
+                }
+            }
+            // We still want to process the keycode normally
+            return true;
+        case KC_F4:
+            // Map alt+shift+4 to alt+f4
+            if (super_alt_layer_active && (get_mods() & MOD_BIT(KC_LSHIFT))) {
+                if (record->event.pressed) {
+                    register_code(KC_LALT);
+                } else {
+                    unregister_code(KC_LALT);
+                }
+            }
+            return true;
+        case ALT_DEL:
+            if (record->event.pressed) {
+                register_code(KC_DEL);
+            } else {
+                unregister_code(KC_DEL);
+            }
+            return false;
+        case RESET:
+            if (record->event.pressed) {
+                key_timer = timer_read32();
+            } else {
+                if (timer_elapsed32(key_timer) >= 500) {
+                    reset_keyboard();
+                }
+            }
+            return false;
+        case EEP_RST:
+            if (record->event.pressed) {
+                key_timer = timer_read32();
+            } else {
+                if (timer_elapsed32(key_timer) >= 500) {
+                    eeconfig_init();
+                }
+            }
+            return false;
+        default:
+            return true; // Process all other keycodes normally
+    }
+}

--- a/keyboards/wuque/ikki68_aurora/keymaps/ewersp/keymap.c
+++ b/keyboards/wuque/ikki68_aurora/keymaps/ewersp/keymap.c
@@ -1,3 +1,19 @@
+/* Copyright 2021 Paul Ewers
+ * 
+ * This program is free software: you can redistribute it and/or modify 
+ * it under the terms of the GNU General Public License as published by 
+ * the Free Software Foundation, either version 2 of the License, or 
+ * (at your option) any later version. 
+ * 
+ * This program is distributed in the hope that it will be useful, 
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+ * GNU General Public License for more details. 
+ * 
+ * You should have received a copy of the GNU General Public License 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ */
+
 #include QMK_KEYBOARD_H
 
 enum alt_keycodes {

--- a/keyboards/wuque/ikki68_aurora/keymaps/ewersp/rules.mk
+++ b/keyboards/wuque/ikki68_aurora/keymaps/ewersp/rules.mk
@@ -1,0 +1,1 @@
+LTO_ENABLE = yes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Added a personal keymap for the Wuque ikki68 Aurora (this keymap is based off of another of my personal keymaps for the Drop ALT).

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
