### PR TITLE
preonic/rev3_drop: Fix old custom matrix code

### DIFF
--- a/keyboards/preonic/rev3_drop/matrix.c
+++ b/keyboards/preonic/rev3_drop/matrix.c
@@ -24,13 +24,15 @@
 #include "debug.h"
 #include "matrix.h"
 
+typedef uint16_t matrix_col_t;
+
 /*
  *     col: { B11, B10, B2, B1, A7, B0 }
  *     row: { A10, A9, A8, B15, C13, C14, C15, A2 }
  */
 /* matrix state(1:on, 0:off) */
 static matrix_row_t matrix[MATRIX_ROWS];
-static matrix_row_t matrix_debouncing[MATRIX_COLS];
+static matrix_col_t matrix_debouncing[MATRIX_COLS];
 static bool         debouncing      = false;
 static uint16_t     debouncing_time = 0;
 
@@ -66,7 +68,7 @@ void matrix_init(void) {
     palSetPadMode(GPIOA, 6, PAL_MODE_INPUT_PULLDOWN);
 
     memset(matrix, 0, MATRIX_ROWS * sizeof(matrix_row_t));
-    memset(matrix_debouncing, 0, MATRIX_COLS * sizeof(matrix_row_t));
+    memset(matrix_debouncing, 0, MATRIX_COLS * sizeof(matrix_col_t));
 
     matrix_init_quantum();
 }
@@ -74,7 +76,7 @@ void matrix_init(void) {
 uint8_t matrix_scan(void) {
     // actual matrix
     for (int col = 0; col < MATRIX_COLS; col++) {
-        matrix_row_t data = 0;
+        matrix_col_t data = 0;
 
         // strobe col { B11, B10, B2, B1, A7, B0 }
         switch (col) {


### PR DESCRIPTION
## Description

Fix nonfunctional bottom row for `preonic/rev3_drop` without doing any major changes to the code.

The old custom matrix code for Preonic rev3 was relying on the `matrix_col_t` type, because the code actually reads the row pins and assembles the state for whole columns, and then transposes the matrix in the custom debouncing code.  Restore that type (which is no longer defined by the core QMK code) to make the custom matrix code work properly (when `matrix_row_t` was used instead of `matrix_col_t`, the state of two electrical rows was lost, and those electrical rows corresponded to the bottom physical row, which did not work).

Tested using a development board with STM32F303CCT6 due to lack of the real Preonic board; unfortunately, that development board does not have a proper breakout for the B2 pin, which is used for one of the columns, but the rest of the matrix was found to be partially broken before the fix and completely working after the fix.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Non-working bottom row on Preonic rev3 boards flashed with the `preonic/rev3_drop` firmware, reported by multiple people.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
