### PR TITLE
Remove legacy Makefile functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,6 @@ BUILD_DIR := $(ROOT_DIR)/.build
 TEST_DIR := $(BUILD_DIR)/test
 ERROR_FILE := $(BUILD_DIR)/error_occurred
 
-MAKEFILE_INCLUDED=yes
-
 # Helper function to process the newt element of a space separated path
 # It works a bit like the traditional functional head tail
 # so the CURRENT_PATH_ELEMENT will become the new head
@@ -93,31 +91,8 @@ distclean: clean
 	rm -f *.bin *.hex *.uf2
 	echo 'done.'
 
-#Compatibility with the old make variables, anything you specify directly on the command line
-# always overrides the detected folders
-ifdef keyboard
-    KEYBOARD := $(keyboard)
-endif
-ifdef keymap
-    KEYMAP := $(keymap)
-endif
 
-# Uncomment these for debugging
-# $(info Keyboard: $(KEYBOARD))
-# $(info Keymap: $(KEYMAP))
-
-
-# Set the default goal depending on where we are running make from
-# this handles the case where you run make without any arguments
 .DEFAULT_GOAL := all:all
-ifneq ($(KEYMAP),)
-    .DEFAULT_GOAL := $(KEYBOARD):$(KEYMAP)
-else ifneq ($(KEYBOARD),)
-     # Inside a keyboard folder, build all keymaps for all subprojects
-     # Note that this is different from the old behaviour, which would
-     # build only the default keymap of the default keyboard
-    .DEFAULT_GOAL := $(KEYBOARD):all
-endif
 
 
 # Compare the start of the RULE variable with the first argument($1)
@@ -241,10 +216,6 @@ define PARSE_RULE
     else ifeq ($$(call TRY_TO_MATCH_RULE_FROM_LIST,$$(shell util/list_keyboards.sh | sort -u)),true)
         KEYBOARD_RULE=$$(MATCHED_ITEM)
         $$(eval $$(call PARSE_KEYBOARD,$$(MATCHED_ITEM)))
-    # Otherwise use the KEYBOARD variable, which is determined either by
-    # the current directory you run make from, or passed in as an argument
-    else ifneq ($$(KEYBOARD),)
-        $$(eval $$(call PARSE_KEYBOARD,$$(KEYBOARD)))
     else
         $$(info make: *** No rule to make target '$1'. Stop.)
         $$(info |)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Given the direction of the cli (and its execution of `build_keyboard.mk` directly), its unlikely the `make KEYBOARD=...` logic is going to be required.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
