### PR TITLE
Make the `MAGIC_TOGGLE_GUI` keycode work

### DIFF
--- a/quantum/process_keycode/process_magic.c
+++ b/quantum/process_keycode/process_magic.c
@@ -43,6 +43,7 @@ bool process_magic(uint16_t keycode, keyrecord_t *record) {
         switch (keycode) {
             case MAGIC_SWAP_CONTROL_CAPSLOCK ... MAGIC_TOGGLE_ALT_GUI:
             case MAGIC_SWAP_LCTL_LGUI ... MAGIC_EE_HANDS_RIGHT:
+            case MAGIC_TOGGLE_GUI:
                 /* keymap config */
                 keymap_config.raw = eeconfig_read_keymap();
                 switch (keycode) {


### PR DESCRIPTION
## Description

`MAGIC_TOGGLE_GUI` was added to the inner switch statement in `process_magic()`, which handles individual keycodes, but was not added to the outer switch statement, where all contiguous ranges of magic keycodes are listed, therefore it did not actually work.

(Yes, the magic keycodes now occupy three separate ranges, with the last of them consisting of just `MAGIC_TOGGLE_GUI`.)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #14885

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
