### PR TITLE
Fix type of Tap Dance max index variable

### DIFF
--- a/quantum/process_keycode/process_tap_dance.c
+++ b/quantum/process_keycode/process_tap_dance.c
@@ -20,7 +20,7 @@ uint8_t get_oneshot_mods(void);
 #endif
 
 static uint16_t last_td;
-static int8_t   highest_td = -1;
+static int16_t  highest_td = -1;
 
 void qk_tap_dance_pair_on_each_tap(qk_tap_dance_state_t *state, void *user_data) {
     qk_tap_dance_pair_t *pair = (qk_tap_dance_pair_t *)user_data;


### PR DESCRIPTION
## Description

Tap dance uses a int8_t to track the max tap dance index.  This limits it to 128 dances, but has a range of 256. 

Ran into this on ZSA's fork, and a keymap with heavy tapdance usage. 

## Types of Changes

- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* ZSA

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
