### PR TITLE
Fix right half of Nyquist in 4x12 mode having row shifted up by one

### DIFF
--- a/keyboards/keebio/nyquist/rev3/rev3.h
+++ b/keyboards/keebio/nyquist/rev3/rev3.h
@@ -42,10 +42,12 @@
 		{ L10, L11, L12, L13, L14, L15 }, \
 		{ L20, L21, L22, L23, L24, L25 }, \
 		{ L30, L31, L32, L33, L34, L35 }, \
+		{ KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO }, \
 		{ R00, R01, R02, R03, R04, R05 }, \
 		{ R10, R11, R12, R13, R14, R15 }, \
 		{ R20, R21, R22, R23, R24, R25 }, \
-		{ R30, R31, R32, R33, R34, R35 } \
+		{ R30, R31, R32, R33, R34, R35 }, \
+		{ KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO } \
 	}
 
 #define LAYOUT_ortho_5x12 LAYOUT


### PR DESCRIPTION
## Description

Fix right half of Nyquist in 4x12 mode having row shifted up by one, due to missing KC_NO filler line on 5th row.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
