### PR TITLE
fix rgb_matrix flicker on split keyboards caused by RGB_DISABLE_TIMEOUT

### DIFF
--- a/quantum/rgb_matrix/rgb_matrix.c
+++ b/quantum/rgb_matrix/rgb_matrix.c
@@ -291,12 +291,8 @@ static void rgb_task_timers(void) {
 
     // Update double buffer timers
 #if RGB_DISABLE_TIMEOUT > 0
-    if (rgb_anykey_timer < UINT32_MAX) {
-        if (UINT32_MAX - deltaTime < rgb_anykey_timer) {
-            rgb_anykey_timer = UINT32_MAX;
-        } else {
-            rgb_anykey_timer += deltaTime;
-        }
+    if (rgb_anykey_timer + deltaTime <= UINT32_MAX) {
+        rgb_anykey_timer += deltaTime;
     }
 #endif  // RGB_DISABLE_TIMEOUT > 0
 


### PR DESCRIPTION
## Description

Workaround for a bug which causes the slave side of a split keyboard (crkbd in my case) to randomly turn the rgb matrix on and off after every keypress when RGB_DISABLE_TIMEOUT is set. (had values like 300000 and 450000 for 5 or 7.5 minutes timeout)

I think the root of this bug has is in `sync_timer.c` where https://github.com/qmk/qmk_firmware/blob/6e8eb2cf542d38332ef460d4f88eed281aed9188/tmk_core/common/sync_timer.c#L36
can produce a negative value and the result in 
https://github.com/qmk/qmk_firmware/blob/6e8eb2cf542d38332ef460d4f88eed281aed9188/tmk_core/common/sync_timer.c#L46
can still be negative, which then results in a range underflow of the `uint32_t` result and therefore will be a very large number.

So as a result the code in `rgb_matrix.c` will eventually go into the if case in line 295 and 296 and make the slave side think the timeout is reached.

I assume the flicker occurs because the calculation oscillate around 0 and sometimes is negative and sometimes positive.

**This is just a workaround** and only works 99% of the time - some short random flickers still occur.
My C skills and microcontroller knowledge are very rusted/limited so I currently wasn't able to figure out a real solution to fix the root of this problem

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR
There is no issue right now for this

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
