### PR TITLE
Fix broken layout rendering in `qmk info` by '\n'

### DIFF
--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -103,7 +103,7 @@ def info_json(keyboard):
     for layout_name, layout_json in layouts.items():
         for key in layout_json['layout']:
             if '\n' in key['label']:
-                key['label'] = key['label'].replace('\n', '')
+                key['label'] = key['label'].split('\n')[0]
 
     return info_data
 

--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -99,6 +99,12 @@ def info_json(keyboard):
     # Check that the reported matrix size is consistent with the actual matrix size
     _check_matrix(info_data)
 
+    # Remove newline characters from layout labels
+    for layout_name, layout_json in layouts.items():
+        for key in layout_json['layout']:
+            if '\n' in key['label']:
+                key['label'] = key['label'].replace('\n', '')
+
     return info_data
 
 


### PR DESCRIPTION
## Description
JSON generator is looking for newline characters inside labels in layouts and removes them

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

[#99 from qmk/qmk_cli](https://github.com/qmk/qmk_cli/issues/99)