### PR TITLE
Improved settings for Cradio default keymap

### DIFF
--- a/keyboards/cradio/keymaps/default/config.h
+++ b/keyboards/cradio/keymaps/default/config.h
@@ -1,0 +1,40 @@
+/* Copyright 2018-2021
+ * ENDO Katsuhiro <ka2hiro@curlybracket.co.jp>
+ * David Philip Barr <@davidphilipbarr>
+ * Pierre Chevalier <pierrechevalier83@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// Defaults for usable home row mods
+#define TAPPING_TERM 230
+#define PERMISSIVE_HOLD
+#define IGNORE_MOD_TAP_INTERRUPT
+
+// Improved mouse key defaults
+// Delay between pressing a key and cursor movement
+#define MOUSEKEY_DELAY 16
+// Time between cursor movements in milliseconds
+#define MOUSEKEY_INTERVAL 16
+// Step size for acceleration
+#define MOUSEKEY_MOVE_DELTA 9
+#define MOUSEKEY_MAX_SPEED 12
+#define MOUSEKEY_TIME_TO_MAX 70
+#define MOUSEKEY_WHEEL_DELAY 16
+#define MOUSEKEY_WHEEL_INTERVAL 30
+#define MOUSEKEY_WHEEL_MAX_SPEED 10
+#define MOUSEKEY_WHEEL_TIME_TO_MAX 95
+

--- a/keyboards/cradio/keymaps/default/config.h
+++ b/keyboards/cradio/keymaps/default/config.h
@@ -21,7 +21,6 @@
 
 // Defaults for usable home row mods
 #define TAPPING_TERM 230
-#define PERMISSIVE_HOLD
 #define IGNORE_MOD_TAP_INTERRUPT
 
 // Improved mouse key defaults


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Default keymap included home row mod taps and mouse keys. These `config.h` settings are good defaults for both features to be usable.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
