### PR TITLE
Move LTO logic from common.mk

### DIFF
--- a/keyboards/hub20/config.h
+++ b/keyboards/hub20/config.h
@@ -108,7 +108,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define LOCKING_RESYNC_ENABLE
 
 /* disable these deprecated features by default */
-#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-  #define NO_ACTION_MACRO
-  #define NO_ACTION_FUNCTION
-#endif
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION

--- a/keyboards/latin17rgb/config.h
+++ b/keyboards/latin17rgb/config.h
@@ -49,10 +49,8 @@
 #define DEBOUNCE 3
 
 /* disable these deprecated features by default */
-//#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-//#    define NO_ACTION_MACRO
-//#    define NO_ACTION_FUNCTION
-//#endif
+//#define NO_ACTION_MACRO
+//#define NO_ACTION_FUNCTION
 
 #ifdef RGB_MATRIX_ENABLE
 #    define RGB_DISABLE_AFTER_TIMEOUT 0 // number of ticks to wait until disabling effects

--- a/keyboards/latin6rgb/config.h
+++ b/keyboards/latin6rgb/config.h
@@ -50,10 +50,8 @@
 #define DEBOUNCE 3
 
 /* disable these deprecated features by default */
-//#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-//#    define NO_ACTION_MACRO
-//#    define NO_ACTION_FUNCTION
-//#endif
+//#define NO_ACTION_MACRO
+//#define NO_ACTION_FUNCTION
 
 #ifdef RGB_MATRIX_ENABLE
 #    define RGB_DISABLE_AFTER_TIMEOUT 0 // number of ticks to wait until disabling effects

--- a/keyboards/smallkeyboard/config.h
+++ b/keyboards/smallkeyboard/config.h
@@ -50,10 +50,8 @@
 #define DEBOUNCE 3
 
 /* disable these deprecated features by default */
-//#ifndef LINK_TIME_OPTIMIZATION_ENABLE
-//#    define NO_ACTION_MACRO
-//#    define NO_ACTION_FUNCTION
-//#endif
+//#define NO_ACTION_MACRO
+//#define NO_ACTION_FUNCTION
 
 #ifdef RGB_MATRIX_ENABLE
 #    define RGB_DISABLE_AFTER_TIMEOUT 0 // number of ticks to wait until disabling effects

--- a/keyboards/thevankeyboards/minivan/keymaps/josjoha/config.h
+++ b/keyboards/thevankeyboards/minivan/keymaps/josjoha/config.h
@@ -24,7 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // place overrides here
 
 // Some defines meant to decrease the firmware size. The firmware is otherwise over the maximum (atmega32u4)
-//# ifndef LINK_TIME_OPTIMIZATION_ENABLE
+//# ifndef LTO_ENABLE
      //Disable old style macro handling: MACRO() & action_get_macro
 //#     define NO_ACTION_MACRO // This saves 320 bytes
       //disable calling of action_function() from the fn_actions array (deprecated)
@@ -40,7 +40,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
 // Attempts to reduce firmware size:
-    //#define LINK_TIME_OPTIMIZATION_ENABLE // Did not decrease firmware size when tested on 26 Jan 2020 
+    //#define LTO_ENABLE // Did not decrease firmware size when tested on 26 Jan 2020 
     //#define NO_DEBUG //disable debugging (already defined)
     //#define NO_PRINT JJdisable printing/debugging using hid_listen (already defined)
     //#define NO_ACTION_LAYER //disable layers (obviously need layers)

--- a/tmk_core/common.mk
+++ b/tmk_core/common.mk
@@ -100,18 +100,6 @@ ifeq ($(strip $(SHARED_EP_ENABLE)), yes)
     TMK_COMMON_DEFS += -DSHARED_EP_ENABLE
 endif
 
-ifeq ($(strip $(LTO_ENABLE)), yes)
-    ifeq ($(PLATFORM),CHIBIOS)
-        $(info Enabling LTO on ChibiOS-targeting boards is known to have a high likelihood of failure.)
-        $(info If unsure, set LTO_ENABLE = no.)
-    endif
-    EXTRAFLAGS += -flto
-    TMK_COMMON_DEFS += -DLTO_ENABLE
-    TMK_COMMON_DEFS += -DLINK_TIME_OPTIMIZATON_ENABLE
-else ifdef LINK_TIME_OPTIMIZATION_ENABLE
-    $(error The LINK_TIME_OPTIMIZATION_ENABLE flag has been renamed to LTO_ENABLE.)
-endif
-
 # Search Path
 VPATH += $(TMK_PATH)/$(COMMON_DIR)
 VPATH += $(TMK_PATH)/$(PLATFORM_COMMON_DIR)

--- a/tmk_core/rules.mk
+++ b/tmk_core/rules.mk
@@ -82,6 +82,15 @@ endif
 #  -Wall...:     warning level
 #  -Wa,...:      tell GCC to pass this to the assembler.
 #    -adhlns...: create assembler listing
+ifeq ($(strip $(LTO_ENABLE)), yes)
+    ifeq ($(PLATFORM),CHIBIOS)
+        $(info Enabling LTO on ChibiOS-targeting boards is known to have a high likelihood of failure.)
+        $(info If unsure, set LTO_ENABLE = no.)
+    endif
+    CDEFS += -flto
+    CDEFS += -DLTO_ENABLE
+endif
+
 DEBUG_ENABLE ?= yes
 ifeq ($(strip $(SKIP_DEBUG_INFO)),yes)
   DEBUG_ENABLE=no


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
#13918 plans to remove/replace `tmk_core/common.mk`, so this PR moves the LTO logic to a "better" location (as well as removing the legacy warning).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
