### PR TITLE
Add support to persist MD LED framework settings

### DIFF
--- a/keyboards/massdrop/alt/config.h
+++ b/keyboards/massdrop/alt/config.h
@@ -43,6 +43,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* Temporary solution for matrix delay */
 #define IGNORE_ATOMIC_BLOCK
 
+/* Avoid out-of-bounds errors when SmartEEPROM is not enabled */
+#define EEPROM_SIZE 1024
+
 /* MCU Port name definitions */
 #define PA 0
 #define PB 1

--- a/keyboards/massdrop/alt/keymaps/default_md/keymap.c
+++ b/keyboards/massdrop/alt/keymaps/default_md/keymap.c
@@ -62,6 +62,14 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     static uint8_t scroll_effect = 0;
 
     switch (keycode) {
+        case L_BRI ... U_T_AGCR:
+            if (record->event.pressed) {
+                md_led_changed();
+            }
+            break;
+    }
+
+    switch (keycode) {
         case L_BRI:
             if (record->event.pressed) {
                 if (LED_GCR_STEP > LED_GCR_MAX - gcr_desired) gcr_desired = LED_GCR_MAX;

--- a/keyboards/massdrop/ctrl/config.h
+++ b/keyboards/massdrop/ctrl/config.h
@@ -42,6 +42,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* Temporary solution for matrix delay */
 #define IGNORE_ATOMIC_BLOCK
 
+/* Avoid out-of-bounds errors when SmartEEPROM is not enabled */
+#define EEPROM_SIZE 1024
+
 /* MCU Port name definitions */
 #define PA 0
 #define PB 1

--- a/keyboards/massdrop/ctrl/keymaps/default_md/keymap.c
+++ b/keyboards/massdrop/ctrl/keymaps/default_md/keymap.c
@@ -65,6 +65,14 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     static uint8_t scroll_effect = 0;
 
     switch (keycode) {
+        case L_BRI ... U_T_AGCR:
+            if (record->event.pressed) {
+                md_led_changed();
+            }
+            break;
+    }
+
+    switch (keycode) {
         case L_BRI:
             if (record->event.pressed) {
                 if (LED_GCR_STEP > LED_GCR_MAX - gcr_desired) gcr_desired = LED_GCR_MAX;

--- a/tmk_core/protocol/arm_atsam/md_rgb_matrix.c
+++ b/tmk_core/protocol/arm_atsam/md_rgb_matrix.c
@@ -35,7 +35,7 @@ EECONFIG_DEBOUNCE_HELPER(md_led, EECONFIG_MD_LED, md_led_config);
 void eeconfig_update_md_led_default(void) {
     md_led_config.ver = MD_LED_CONFIG_VERSION;
 
-    gcr_desired               = 0;
+    gcr_desired               = LED_GCR_MAX;
     led_animation_orientation = 0;
     led_animation_direction   = 0;
     led_animation_breathing   = 0;

--- a/tmk_core/protocol/arm_atsam/md_rgb_matrix.c
+++ b/tmk_core/protocol/arm_atsam/md_rgb_matrix.c
@@ -15,6 +15,10 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#define FLUSH_TIMEOUT 5000
+#define EECONFIG_MD_LED ((uint8_t *)(EECONFIG_SIZE + 64))
+#define MD_LED_CONFIG_VERSION 1
+
 #ifdef RGB_MATRIX_ENABLE
 #    include "arm_atsam_protocol.h"
 #    include "led.h"
@@ -23,8 +27,45 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    include <math.h>
 
 #    ifdef USE_MASSDROP_CONFIGURATOR
+// TODO?: wire these up to keymap.c
+md_led_config_t md_led_config = {0};
+
+EECONFIG_DEBOUNCE_HELPER(md_led, EECONFIG_MD_LED, md_led_config);
+
+void eeconfig_update_md_led_default(void) {
+    md_led_config.ver = MD_LED_CONFIG_VERSION;
+
+    gcr_desired               = 0;
+    led_animation_orientation = 0;
+    led_animation_direction   = 0;
+    led_animation_breathing   = 0;
+    led_animation_id          = 0;
+    led_animation_speed       = 4.0f;
+    led_lighting_mode         = LED_MODE_NORMAL;
+    led_enabled               = 1;
+    led_animation_breathe_cur = BREATHE_MIN_STEP;
+    breathe_dir               = 1;
+    led_animation_circular    = 0;
+    led_edge_brightness       = 1.0f;
+    led_ratio_brightness      = 1.0f;
+    led_edge_mode             = LED_EDGE_MODE_ALL;
+
+    eeconfig_flush_md_led(true);
+}
+
+void md_led_changed(void) {
+    eeconfig_flag_md_led(true);
+}
+
+//todo: use real task rather than this bodge
+void housekeeping_task_kb(void) {
+    eeconfig_flush_md_led_task(FLUSH_TIMEOUT);
+}
+
 __attribute__((weak)) led_instruction_t led_instructions[] = {{.end = 1}};
 static void                             md_rgb_matrix_config_override(int i);
+#    else
+uint8_t gcr_desired;
 #    endif  // USE_MASSDROP_CONFIGURATOR
 
 void SERCOM1_0_Handler(void) {
@@ -56,7 +97,6 @@ issi3733_driver_t issidrv[ISSI3733_DRIVER_COUNT];
 issi3733_led_t led_map[ISSI3733_LED_COUNT] = ISSI3733_LED_MAP;
 RGB            led_buffer[ISSI3733_LED_COUNT];
 
-uint8_t gcr_desired;
 uint8_t gcr_actual;
 uint8_t gcr_actual_last;
 #    ifdef USE_MASSDROP_CONFIGURATOR
@@ -218,6 +258,13 @@ static void led_set_all(uint8_t r, uint8_t g, uint8_t b) {
 static void init(void) {
     DBGC(DC_LED_MATRIX_INIT_BEGIN);
 
+#    ifdef USE_MASSDROP_CONFIGURATOR
+    eeconfig_init_md_led();
+    if (md_led_config.ver != MD_LED_CONFIG_VERSION) {
+        eeconfig_update_md_led_default();
+    }
+#endif
+
     issi3733_prepare_arrays();
 
     md_rgb_matrix_prepare();
@@ -330,21 +377,6 @@ const rgb_matrix_driver_t rgb_matrix_driver = {.init = init, .flush = flush, .se
 
 #    ifdef USE_MASSDROP_CONFIGURATOR
 // Ported from Massdrop QMK GitHub Repo
-
-// TODO?: wire these up to keymap.c
-uint8_t led_animation_orientation = 0;
-uint8_t led_animation_direction   = 0;
-uint8_t led_animation_breathing   = 0;
-uint8_t led_animation_id          = 0;
-float   led_animation_speed       = 4.0f;
-uint8_t led_lighting_mode         = LED_MODE_NORMAL;
-uint8_t led_enabled               = 1;
-uint8_t led_animation_breathe_cur = BREATHE_MIN_STEP;
-uint8_t breathe_dir               = 1;
-uint8_t led_animation_circular    = 0;
-float   led_edge_brightness       = 1.0f;
-float   led_ratio_brightness      = 1.0f;
-uint8_t led_edge_mode             = LED_EDGE_MODE_ALL;
 
 static void led_run_pattern(led_setup_t* f, float* ro, float* go, float* bo, float pos) {
     float po;

--- a/tmk_core/protocol/arm_atsam/md_rgb_matrix.c
+++ b/tmk_core/protocol/arm_atsam/md_rgb_matrix.c
@@ -16,7 +16,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #define FLUSH_TIMEOUT 5000
-#define EECONFIG_MD_LED ((uint8_t *)(EECONFIG_SIZE + 64))
+#define EECONFIG_MD_LED ((uint8_t*)(EECONFIG_SIZE + 64))
 #define MD_LED_CONFIG_VERSION 1
 
 #ifdef RGB_MATRIX_ENABLE
@@ -53,14 +53,10 @@ void eeconfig_update_md_led_default(void) {
     eeconfig_flush_md_led(true);
 }
 
-void md_led_changed(void) {
-    eeconfig_flag_md_led(true);
-}
+void md_led_changed(void) { eeconfig_flag_md_led(true); }
 
-//todo: use real task rather than this bodge
-void housekeeping_task_kb(void) {
-    eeconfig_flush_md_led_task(FLUSH_TIMEOUT);
-}
+// todo: use real task rather than this bodge
+void housekeeping_task_kb(void) { eeconfig_flush_md_led_task(FLUSH_TIMEOUT); }
 
 __attribute__((weak)) led_instruction_t led_instructions[] = {{.end = 1}};
 static void                             md_rgb_matrix_config_override(int i);
@@ -263,7 +259,7 @@ static void init(void) {
     if (md_led_config.ver != MD_LED_CONFIG_VERSION) {
         eeconfig_update_md_led_default();
     }
-#endif
+#    endif
 
     issi3733_prepare_arrays();
 

--- a/tmk_core/protocol/arm_atsam/md_rgb_matrix.h
+++ b/tmk_core/protocol/arm_atsam/md_rgb_matrix.h
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define _LED_MATRIX_H_
 
 #include "quantum.h"
+#include "eeprom.h"
 
 // From keyboard
 #include "config_led.h"
@@ -79,7 +80,6 @@ typedef struct issi3733_led_s {
 
 extern issi3733_driver_t issidrv[ISSI3733_DRIVER_COUNT];
 
-extern uint8_t gcr_desired;
 extern uint8_t gcr_breathe;
 extern uint8_t gcr_actual;
 extern uint8_t gcr_actual_last;
@@ -140,19 +140,43 @@ typedef struct led_instruction_s {
 
 extern led_instruction_t led_instructions[];
 
-extern uint8_t led_animation_breathing;
-extern uint8_t led_animation_id;
-extern float   led_animation_speed;
-extern uint8_t led_lighting_mode;
-extern uint8_t led_enabled;
-extern uint8_t led_animation_breathe_cur;
-extern uint8_t led_animation_direction;
-extern uint8_t breathe_dir;
-extern uint8_t led_animation_orientation;
-extern uint8_t led_animation_circular;
-extern float   led_edge_brightness;
-extern float   led_ratio_brightness;
-extern uint8_t led_edge_mode;
+typedef struct led_config_s {
+    uint8_t ver; // assumed to be zero on eeprom reset
+
+    uint8_t desired_gcr;
+    uint8_t animation_breathing;
+    uint8_t animation_id;
+    float   animation_speed;
+    uint8_t lighting_mode;
+    uint8_t enabled;
+    uint8_t animation_breathe_cur;
+    uint8_t animation_direction;
+    uint8_t animation_breathe_dir;
+    uint8_t animation_orientation;
+    uint8_t animation_circular;
+    float   edge_brightness;
+    float   ratio_brightness;
+    uint8_t edge_mode;
+} md_led_config_t;
+
+extern md_led_config_t md_led_config;
+
+void md_led_changed(void);
+
+#    define gcr_desired md_led_config.desired_gcr
+#    define led_animation_breathing md_led_config.animation_breathing
+#    define led_animation_id md_led_config.animation_id
+#    define led_animation_speed md_led_config.animation_speed
+#    define led_lighting_mode md_led_config.lighting_mode
+#    define led_enabled md_led_config.enabled
+#    define led_animation_breathe_cur md_led_config.animation_breathe_cur
+#    define led_animation_direction md_led_config.animation_direction
+#    define breathe_dir md_led_config.animation_breathe_dir
+#    define led_animation_orientation md_led_config.animation_orientation
+#    define led_animation_circular md_led_config.animation_circular
+#    define led_edge_brightness md_led_config.edge_brightness
+#    define led_ratio_brightness md_led_config.ratio_brightness
+#    define led_edge_mode md_led_config.edge_mode
 
 #    define LED_MODE_NORMAL 0  // Must be 0
 #    define LED_MODE_KEYS_ONLY 1
@@ -173,7 +197,8 @@ extern uint8_t led_edge_mode;
 #    define LED_IS_EDGE(scan) (scan >= LED_EDGE_MIN_SCAN)        // Return true if an LED's scan value indicates an edge LED
 #    define LED_IS_EDGE_ALT(scan) (scan == LED_EDGE_ALT_MODE)    // Return true if an LED's scan value indicates an alternate edge mode LED
 #    define LED_IS_INDICATOR(scan) (scan == LED_INDICATOR_SCAN)  // Return true if an LED's scan value indicates it is a dedicated Indicator
-
+#else
+extern uint8_t gcr_desired;
 #endif  // USE_MASSDROP_CONFIGURATOR
 
 #endif  //_LED_MATRIX_H_

--- a/tmk_core/protocol/arm_atsam/md_rgb_matrix.h
+++ b/tmk_core/protocol/arm_atsam/md_rgb_matrix.h
@@ -141,7 +141,7 @@ typedef struct led_instruction_s {
 extern led_instruction_t led_instructions[];
 
 typedef struct led_config_s {
-    uint8_t ver; // assumed to be zero on eeprom reset
+    uint8_t ver;  // assumed to be zero on eeprom reset
 
     uint8_t desired_gcr;
     uint8_t animation_breathing;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
This gets the ALT/CTRL feature compatible with the massdrop/qmk_firmware fork.

Future iterations will move away from the bespoke LED framework and to core RGB Matrix.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
