### PR TITLE
Fix docs markup

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,10 +8,10 @@ QMK (*Quantum Mechanical Keyboard*) is an open source community centered around 
 
 <div class="flex-container">
 
-?> **Basic** [QMK Configurator](newbs_building_firmware_configurator.md) <br>
+- **Basic** [QMK Configurator](newbs_building_firmware_configurator.md) <br>
 User friendly graphical interfaces, no programming knowledge required.
 
-?> **Advanced** [Use The Source](newbs.md) <br> 
+- **Advanced** [Use The Source](newbs.md) <br> 
 More powerful, but harder to use.
 
 </div>


### PR DESCRIPTION
Some markup is not rendering correctly:

![image](https://user-images.githubusercontent.com/3461018/139769306-d19488ac-870d-4e9b-b2f9-cbb83b6d166d.png)

This PR fixes it using Markdown. 