### PR TITLE
[Keyboard] Fix missing return for oled task on Lefty

### DIFF
--- a/keyboards/lefty/lefty.c
+++ b/keyboards/lefty/lefty.c
@@ -42,5 +42,6 @@ bool oled_task_kb(void) {
             oled_write_ln_P(PSTR("Undefined"), false);
     }
 
+    return true;
 }
 #endif


### PR DESCRIPTION
## Description

Somehow, I missed this? 

`oled_task_kb` doesn't return a value.

## Types of Changes

- [x] Bugfix
- [x] Keyboard (addition or update)


## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
