### PR TITLE
[Keyboard] Fix missing return for oled task on Arabica37

### DIFF
--- a/keyboards/arabica37/keymaps/default/keymap.c
+++ b/keyboards/arabica37/keymaps/default/keymap.c
@@ -177,7 +177,6 @@ bool oled_task_user(void) {
     oled_write_P(led_state.num_lock ? PSTR("NUM ") : PSTR("    "), false);
     oled_write_P(led_state.caps_lock ? PSTR("CAP ") : PSTR("    "), false);
     oled_write_P(led_state.scroll_lock ? PSTR("SCR ") : PSTR("    "), false);
-    return false;
   }
 
 
@@ -196,5 +195,6 @@ bool oled_task_user(void) {
     } else {
         render_logo();  // Renders a static logo
     }
+    return false;
 }
 #endif


### PR DESCRIPTION
## Description

Arabica37's oled task function is a mess... Misplaced OLED return. 

## Types of Changes

- [x] Bugfix
- [x] Keyboard (addition or update)


## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
