### PR TITLE
[Keymap] Fix missing return for oled task in drashna userspace

### DIFF
--- a/users/drashna/oled_stuff.c
+++ b/users/drashna/oled_stuff.c
@@ -427,7 +427,7 @@ bool oled_task_user(void) {
     if (is_keyboard_master()) {
         if (timer_elapsed32(oled_timer) > 30000) {
             oled_off();
-            return;
+            return false;
         } else {
             oled_on();
         }


### PR DESCRIPTION
## Description

Fix missing return time in oled task for drashna's oled stuff

## Types of Changes

- [x] Bugfix
- [x] Keymap/layout/userspace (addition or update)


## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
