### PR TITLE
[Keyboard] Fix compilation size issues for Canary 60 RGB

### DIFF
--- a/keyboards/canary/canary60rgb/v1/rules.mk
+++ b/keyboards/canary/canary60rgb/v1/rules.mk
@@ -21,3 +21,5 @@ RGBLIGHT_ENABLE = yes          # Enable keyboard RGB underglow
 AUDIO_ENABLE = no              # Audio output
 RGB_MATRIX_ENABLE = yes        # Use RGB matrix
 RGB_MATRIX_DRIVER = IS31FL3733
+
+LTO_ENABLE = yes


### PR DESCRIPTION
## Description

Compiles over limit due to too many features.  Enables LTO.

## Types of Changes

- [x] Bugfix
- [x] Keyboard (addition or update)

## Issues Fixed or Closed by This PR

* Tzarc CI

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
