### PR TITLE
Fix Rocketboard-16 QMK Configurator Implementation

### DIFF
--- a/keyboards/rocketboard_16/info.json
+++ b/keyboards/rocketboard_16/info.json
@@ -2,6 +2,9 @@
     "keyboard_name": "Rocketboard-16",
     "url": "",
     "maintainer": "fl3tching101",
+    "layout_aliases": {
+        "LAYOUT_default": "LAYOUT"
+    },
     "layouts": {
         "LAYOUT": {
             "layout": [

--- a/keyboards/rocketboard_16/keymaps/default/keymap.c
+++ b/keyboards/rocketboard_16/keymaps/default/keymap.c
@@ -34,18 +34,18 @@ enum custom_keycodes {
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [_BASE] = LAYOUT(
-        RGB_MODE_FORWARD,                KC_NUMLOCK,
-        KC_KP_7, KC_KP_8, KC_KP_9,       KC_DELETE,
-        KC_KP_4, KC_KP_5, KC_KP_6,       KC_END,
-        KC_KP_1, KC_KP_2, KC_KP_3,       KC_F13,
-        KC_KP_0, MO(1),   KC_KP_DOT,     KC_KP_ENTER
+        RGB_MOD,                   KC_NLCK,
+        KC_P7,   KC_P8,   KC_P9,   KC_DEL,
+        KC_P4,   KC_P5,   KC_P6,   KC_END,
+        KC_P1,   KC_P2,   KC_P3,   KC_F13,
+        KC_P0,   MO(1),   KC_PDOT, KC_PENT
     ),
     [_SPEC] = LAYOUT(
-        RGB_MODE_REVERSE,               KC_AUDIO_MUTE,
-        KC_NO,   KC_NO,   KC_NO,         KC_EXAM,
-        KC_NO,   KC_NO,   KC_NO,         KC_NO,
-        RESET,   RGB_TOG, RGB_SPI,       RGB_SPD,
-        KC_NO,   _______, KC_NO,         KC_NO
+        RGB_RMOD,                   KC_MUTE,
+        KC_NO,    KC_NO,   KC_NO,   KC_EXAM,
+        KC_NO,    KC_NO,   KC_NO,   KC_NO,
+        RESET,    RGB_TOG, RGB_SPI, RGB_SPD,
+        KC_NO,    _______, KC_NO,   KC_NO
     )
 };
 

--- a/keyboards/rocketboard_16/keymaps/default/keymap.c
+++ b/keyboards/rocketboard_16/keymaps/default/keymap.c
@@ -33,14 +33,14 @@ enum custom_keycodes {
 
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    [_BASE] = LAYOUT_default(
+    [_BASE] = LAYOUT(
         RGB_MODE_FORWARD,                KC_NUMLOCK,
         KC_KP_7, KC_KP_8, KC_KP_9,       KC_DELETE,
         KC_KP_4, KC_KP_5, KC_KP_6,       KC_END,
         KC_KP_1, KC_KP_2, KC_KP_3,       KC_F13,
         KC_KP_0, MO(1),   KC_KP_DOT,     KC_KP_ENTER
     ),
-    [_SPEC] = LAYOUT_default(
+    [_SPEC] = LAYOUT(
         RGB_MODE_REVERSE,               KC_AUDIO_MUTE,
         KC_NO,   KC_NO,   KC_NO,         KC_EXAM,
         KC_NO,   KC_NO,   KC_NO,         KC_NO,

--- a/keyboards/rocketboard_16/keymaps/via/keymap.c
+++ b/keyboards/rocketboard_16/keymaps/via/keymap.c
@@ -34,18 +34,18 @@ enum custom_keycodes {
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [_BASE] = LAYOUT(
-        RGB_MODE_FORWARD,                KC_NUMLOCK,
-        KC_KP_7, KC_KP_8, KC_KP_9,       KC_DELETE,
-        KC_KP_4, KC_KP_5, KC_KP_6,       KC_END,
-        KC_KP_1, KC_KP_2, KC_KP_3,       KC_F13,
-        KC_KP_0, MO(1),   KC_KP_DOT,     KC_KP_ENTER
+        RGB_MOD,                   KC_NLCK,
+        KC_P7,   KC_P8,   KC_P9,   KC_DEL,
+        KC_P4,   KC_P5,   KC_P6,   KC_END,
+        KC_P1,   KC_P2,   KC_P3,   KC_F13,
+        KC_P0,   MO(1),   KC_PDOT, KC_PENT
     ),
     [_SPEC] = LAYOUT(
-        RGB_MODE_REVERSE,               KC_AUDIO_MUTE,
-        KC_NO,   KC_NO,   KC_NO,         KC_EXAM,
-        KC_NO,   KC_NO,   KC_NO,         KC_NO,
-        RESET,   RGB_TOG, RGB_SPI,       RGB_SPD,
-        KC_NO,   _______, KC_NO,         KC_NO
+        RGB_RMOD,                   KC_MUTE,
+        KC_NO,    KC_NO,   KC_NO,   KC_EXAM,
+        KC_NO,    KC_NO,   KC_NO,   KC_NO,
+        RESET,    RGB_TOG, RGB_SPI, RGB_SPD,
+        KC_NO,    _______, KC_NO,   KC_NO
     )
 };
 

--- a/keyboards/rocketboard_16/keymaps/via/keymap.c
+++ b/keyboards/rocketboard_16/keymaps/via/keymap.c
@@ -33,14 +33,14 @@ enum custom_keycodes {
 
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    [_BASE] = LAYOUT_default(
+    [_BASE] = LAYOUT(
         RGB_MODE_FORWARD,                KC_NUMLOCK,
         KC_KP_7, KC_KP_8, KC_KP_9,       KC_DELETE,
         KC_KP_4, KC_KP_5, KC_KP_6,       KC_END,
         KC_KP_1, KC_KP_2, KC_KP_3,       KC_F13,
         KC_KP_0, MO(1),   KC_KP_DOT,     KC_KP_ENTER
     ),
-    [_SPEC] = LAYOUT_default(
+    [_SPEC] = LAYOUT(
         RGB_MODE_REVERSE,               KC_AUDIO_MUTE,
         KC_NO,   KC_NO,   KC_NO,         KC_EXAM,
         KC_NO,   KC_NO,   KC_NO,         KC_NO,

--- a/keyboards/rocketboard_16/rocketboard_16.h
+++ b/keyboards/rocketboard_16/rocketboard_16.h
@@ -4,7 +4,7 @@
 
 #define KNO KC_NO
 
-#define LAYOUT_default( \
+#define LAYOUT( \
   K00,           K01, \
   K02, K03, K04, K05, \
   K06, K07, K08, K09, \


### PR DESCRIPTION
## Description

`info.json` was referencing a layout macro that did not exist. Instead of fixing the reference, I renamed the layout macro in source per QMK guidelines because there's only one physical layout supported.

![image](https://user-images.githubusercontent.com/18669334/139910298-2ee8e640-5137-4522-8d95-be48889c5342.png)

cc @fl3tching101 (keyboard maintainer)

## Types of Changes

- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
