### PR TITLE
Revert to old init order for host driver

### DIFF
--- a/quantum/main.c
+++ b/quantum/main.c
@@ -19,11 +19,21 @@
 void platform_setup(void);
 
 void protocol_setup(void);
-void protocol_init(void);
+void protocol_pre_init(void);
+void protocol_post_init(void);
 void protocol_pre_task(void);
 void protocol_post_task(void);
 
-// Bodge as refactoring vusb sucks....
+// Bodge as refactoring this area sucks....
+void protocol_init(void) __attribute__((weak));
+void protocol_init(void){
+    protocol_pre_init();
+
+    keyboard_init();
+
+    protocol_post_init();
+}
+
 void protocol_task(void) __attribute__((weak));
 void protocol_task(void) {
     protocol_pre_task();
@@ -44,7 +54,6 @@ int main(void) {
     keyboard_setup();
 
     protocol_init();
-    keyboard_init();
 
     /* Main loop */
     while (true) {

--- a/quantum/main.c
+++ b/quantum/main.c
@@ -26,7 +26,7 @@ void protocol_post_task(void);
 
 // Bodge as refactoring this area sucks....
 void protocol_init(void) __attribute__((weak));
-void protocol_init(void){
+void protocol_init(void) {
     protocol_pre_init();
 
     keyboard_init();

--- a/tmk_core/protocol/chibios/chibios.c
+++ b/tmk_core/protocol/chibios/chibios.c
@@ -140,7 +140,7 @@ void protocol_setup(void) {
     // chThdCreateStatic(waThread1, sizeof(waThread1), NORMALPRIO, Thread1, NULL);
 }
 
-void protocol_init(void) {
+void protocol_pre_init(void) {
     /* Init USB */
     usb_event_queue_init();
     init_usb_driver(&USB_DRIVER);
@@ -173,7 +173,9 @@ void protocol_init(void) {
     wait_ms(50);
 
     print("USB configured.\n");
+}
 
+void protocol_post_init(void) {
     host_set_driver(driver);
 }
 

--- a/tmk_core/protocol/chibios/chibios.c
+++ b/tmk_core/protocol/chibios/chibios.c
@@ -175,9 +175,7 @@ void protocol_pre_init(void) {
     print("USB configured.\n");
 }
 
-void protocol_post_init(void) {
-    host_set_driver(driver);
-}
+void protocol_post_init(void) { host_set_driver(driver); }
 
 void protocol_pre_task(void) {
     usb_event_queue_task();

--- a/tmk_core/protocol/lufa/lufa.c
+++ b/tmk_core/protocol/lufa/lufa.c
@@ -1072,7 +1072,7 @@ void protocol_setup(void) {
     usb_device_state_init();
 }
 
-void protocol_init(void) {
+void protocol_pre_init(void) {
     setup_usb();
     sei();
 
@@ -1094,7 +1094,9 @@ void protocol_init(void) {
 #else
     USB_USBTask();
 #endif
+}
 
+void protocol_post_init(void) {
     host_set_driver(&lufa_driver);
 }
 

--- a/tmk_core/protocol/lufa/lufa.c
+++ b/tmk_core/protocol/lufa/lufa.c
@@ -1096,9 +1096,7 @@ void protocol_pre_init(void) {
 #endif
 }
 
-void protocol_post_init(void) {
-    host_set_driver(&lufa_driver);
-}
+void protocol_post_init(void) { host_set_driver(&lufa_driver); }
 
 void protocol_pre_task(void) {
 #if !defined(NO_USB_STARTUP_CHECK)

--- a/tmk_core/protocol/vusb/protocol.c
+++ b/tmk_core/protocol/vusb/protocol.c
@@ -113,12 +113,13 @@ void protocol_setup(void) {
 #endif
 }
 
-void protocol_init(void) {
+void protocol_pre_init(void) {
     setup_usb();
     sei();
+}
 
+void protocol_post_init(void) {
     host_set_driver(vusb_driver());
-
     wait_ms(50);
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Partially reverts #14888 due to some form of condition between when keyboard_init is called and when the host driver is set. This was reproduced by spamming a key on startup, where it would then not recover and never output any keys.

This close to the code freeze, its not worth breaking a bunch of edge cases.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
