### PR TITLE
steal_this_keyboard: fix info.json macro reference

### DIFF
--- a/keyboards/steal_this_keyboard/info.json
+++ b/keyboards/steal_this_keyboard/info.json
@@ -3,7 +3,7 @@
     "url": "https://github.com/obosob/steal_this_keyboard",
     "maintainer": "@obosob",
     "layouts": {
-        "LAYOUT": {
+        "LAYOUT_split_3x5_2": {
             "layout": [
                 {"x": 0, "y": 0.93},
                 {"x": 1, "y": 0.31},


### PR DESCRIPTION
## Description

- change `LAYOUT` to `LAYOUT_split_3x5_2`
  Source code uses `LAYOUT_split_3x5_2`

cc @obosob (keyboard maintainer)

## Types of Changes

- [x] Enhancement/optimization
- [x] Keyboard (addition or update)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
