### PR TITLE
Make sequencer keycodes static (#11156)

### DIFF
--- a/docs/feature_sequencer.md
+++ b/docs/feature_sequencer.md
@@ -40,20 +40,20 @@ While the tempo defines the absolute speed at which the sequencer goes through t
 
 ## Keycodes
 
-|Keycode  |Description                                        |
-|-------  |-----------                                        |
-|`SQ_ON`  |Start the step sequencer                           |
-|`SQ_OFF` |Stop the step sequencer                            |
-|`SQ_TOG` |Toggle the step sequencer playback                 |
-|`SQ_SALL`|Enable all the steps                               |
-|`SQ_SCLR`|Disable all the steps                              |
-|`SQ_S(n)`|Toggle the step `n`                                |
-|`SQ_TMPD`|Decrease the tempo                                 |
-|`SQ_TMPU`|Increase the tempo                                 |
-|`SQ_R(n)`|Set the resolution to n                            |
-|`SQ_RESD`|Change to the slower resolution                    |
-|`SQ_RESU`|Change to the faster resolution                    |
-|`SQ_T(n)`|Set `n` as the only active track or deactivate all |
+|Keycode   |Description                                        |
+|-------   |-----------                                        |
+|`SQ_ON`   |Start the step sequencer                           |
+|`SQ_OFF`  |Stop the step sequencer                            |
+|`SQ_TOG`  |Toggle the step sequencer playback                 |
+|`SQ_SALL` |Enable all the steps                               |
+|`SQ_SCLR` |Disable all the steps                              |
+|`SQ_STEP` |Toggle a sequencer step                            |
+|`SQ_TMPD` |Decrease the tempo                                 |
+|`SQ_TMPU` |Increase the tempo                                 |
+|`SQ_RES`  |Modify the sequencer resolution                    |
+|`SQ_RESD` |Change to the slower resolution                    |
+|`SQ_RESU` |Change to the faster resolution                    |
+|`SQ_TRACK`|Activate a single track or deactivate all          |
 
 ## Functions
 

--- a/quantum/process_keycode/process_sequencer.c
+++ b/quantum/process_keycode/process_sequencer.c
@@ -34,9 +34,6 @@ bool process_sequencer(uint16_t keycode, keyrecord_t *record) {
             case SQ_TMPU:
                 sequencer_increase_tempo();
                 return false;
-            case SEQUENCER_RESOLUTION_MIN ... SEQUENCER_RESOLUTION_MAX:
-                sequencer_set_resolution(keycode - SEQUENCER_RESOLUTION_MIN);
-                return false;
             case SQ_RESD:
                 sequencer_decrease_resolution();
                 return false;
@@ -48,12 +45,6 @@ bool process_sequencer(uint16_t keycode, keyrecord_t *record) {
                 return false;
             case SQ_SCLR:
                 sequencer_set_all_steps_off();
-                return false;
-            case SEQUENCER_STEP_MIN ... SEQUENCER_STEP_MAX:
-                sequencer_toggle_step(keycode - SEQUENCER_STEP_MIN);
-                return false;
-            case SEQUENCER_TRACK_MIN ... SEQUENCER_TRACK_MAX:
-                sequencer_toggle_single_active_track(keycode - SEQUENCER_TRACK_MIN);
                 return false;
         }
     }

--- a/quantum/process_keycode/process_sequencer.c
+++ b/quantum/process_keycode/process_sequencer.c
@@ -1,4 +1,4 @@
-/* Copyright 2020 Rodolphe Belouin
+/* Copyright 2020-2021 Rodolphe Belouin
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/quantum/process_keycode/process_sequencer.h
+++ b/quantum/process_keycode/process_sequencer.h
@@ -1,4 +1,4 @@
-/* Copyright 2020 Rodolphe Belouin
+/* Copyright 2020-2021 Rodolphe Belouin
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -16,8 +16,6 @@
 
 #pragma once
 
-#include "sequencer.h"
-
 // Fillers to make layering more clear
 #define _______ KC_TRNS
 #define XXXXXXX KC_NO
@@ -495,18 +493,9 @@ enum quantum_keycodes {
     SQ_SALL,  // 5D35
     SQ_SCLR,  // 5D36
 
-    SEQUENCER_STEP_MIN,  // 5D37
-    SEQUENCER_STEP_MAX = SEQUENCER_STEP_MIN + SEQUENCER_STEPS,
-
-    SEQUENCER_RESOLUTION_MIN,
-    SEQUENCER_RESOLUTION_MAX = SEQUENCER_RESOLUTION_MIN + SEQUENCER_RESOLUTIONS,
-
-    SEQUENCER_TRACK_MIN,
-    SEQUENCER_TRACK_MAX = SEQUENCER_TRACK_MIN + SEQUENCER_TRACKS,
-
-#define SQ_S(n) (n < SEQUENCER_STEPS ? SEQUENCER_STEP_MIN + n : KC_NO)
-#define SQ_R(n) (n < SEQUENCER_RESOLUTIONS ? SEQUENCER_RESOLUTION_MIN + n : KC_NO)
-#define SQ_T(n) (n < SEQUENCER_TRACKS ? SEQUENCER_TRACK_MIN + n : KC_NO)
+    SQ_RES,
+    SQ_STEP,
+    SQ_TRACK,
 
     // One Shot
     ONESHOT_ENABLE,

--- a/quantum/sequencer/sequencer.c
+++ b/quantum/sequencer/sequencer.c
@@ -1,4 +1,4 @@
-/* Copyright 2020 Rodolphe Belouin
+/* Copyright 2020-2021 Rodolphe Belouin
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/quantum/sequencer/sequencer.h
+++ b/quantum/sequencer/sequencer.h
@@ -19,6 +19,7 @@
 #include <stdbool.h>
 #include "debug.h"
 #include "timer.h"
+#include "sequencer_keycodes.h"
 
 // Maximum number of steps: 256
 #ifndef SEQUENCER_STEPS

--- a/quantum/sequencer/sequencer.h
+++ b/quantum/sequencer/sequencer.h
@@ -1,4 +1,4 @@
-/* Copyright 2020 Rodolphe Belouin
+/* Copyright 2020-2021 Rodolphe Belouin
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/quantum/sequencer/sequencer_keycodes.h
+++ b/quantum/sequencer/sequencer_keycodes.h
@@ -1,0 +1,43 @@
+/* Copyright 2021 Rodolphe Belouin
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define SQ_R(n) ((n << 16) + SQ_RES)
+#define SQ_S(n) ((n << 16) + SQ_STEP)
+#define SQ_T(n) ((n << 16) + SQ_TRACK)
+
+// clang-format off
+#define sequencer_get_keycodes_48( \
+    k00, k01, k02, k03, k04, k05, k06, k07, k08, k09, k10, k11, \
+    k12, k13, k14, k15, k16, k17, k18, k19, k20, k21, k22, k23, \
+    k24, k25, k26, k27, k28, k29, k30, k31, k32, k33, k34, k35, \
+    k36, k37, k38, k39, k40, k41, k42, k43, k44, k45, k46, k47) \
+    (k00 & 0xFFFF), (k01 & 0xFFFF), (k02 & 0xFFFF), (k03 & 0xFFFF), (k04 & 0xFFFF), (k05 & 0xFFFF), (k06 & 0xFFFF), (k07 & 0xFFFF), (k08 & 0xFFFF), (k09 & 0xFFFF), (k10 & 0xFFFF), (k11 & 0xFFFF), \
+    (k12 & 0xFFFF), (k13 & 0xFFFF), (k14 & 0xFFFF), (k15 & 0xFFFF), (k16 & 0xFFFF), (k17 & 0xFFFF), (k18 & 0xFFFF), (k19 & 0xFFFF), (k20 & 0xFFFF), (k21 & 0xFFFF), (k22 & 0xFFFF), (k23 & 0xFFFF), \
+    (k24 & 0xFFFF), (k25 & 0xFFFF), (k26 & 0xFFFF), (k27 & 0xFFFF), (k28 & 0xFFFF), (k29 & 0xFFFF), (k30 & 0xFFFF), (k31 & 0xFFFF), (k32 & 0xFFFF), (k33 & 0xFFFF), (k34 & 0xFFFF), (k35 & 0xFFFF), \
+    (k36 & 0xFFFF), (k37 & 0xFFFF), (k38 & 0xFFFF), (k39 & 0xFFFF), (k40 & 0xFFFF), (k41 & 0xFFFF), (k42 & 0xFFFF), (k43 & 0xFFFF), (k44 & 0xFFFF), (k45 & 0xFFFF), (k46 & 0xFFFF), (k47 & 0xFFFF)
+
+#define sequencer_get_indices_48( \
+    k00, k01, k02, k03, k04, k05, k06, k07, k08, k09, k10, k11, \
+    k12, k13, k14, k15, k16, k17, k18, k19, k20, k21, k22, k23, \
+    k24, k25, k26, k27, k28, k29, k30, k31, k32, k33, k34, k35, \
+    k36, k37, k38, k39, k40, k41, k42, k43, k44, k45, k46, k47) \
+    (k00 >> 16), (k01 >> 16), (k02 >> 16), (k03 >> 16), (k04 >> 16), (k05 >> 16), (k06 >> 16), (k07 >> 16), (k08 >> 16), (k09 >> 16), (k10 >> 16), (k11 >> 16), \
+    (k12 >> 16), (k13 >> 16), (k14 >> 16), (k15 >> 16), (k16 >> 16), (k17 >> 16), (k18 >> 16), (k19 >> 16), (k20 >> 16), (k21 >> 16), (k22 >> 16), (k23 >> 16), \
+    (k24 >> 16), (k25 >> 16), (k26 >> 16), (k27 >> 16), (k28 >> 16), (k29 >> 16), (k30 >> 16), (k31 >> 16), (k32 >> 16), (k33 >> 16), (k34 >> 16), (k35 >> 16), \
+    (k36 >> 16), (k37 >> 16), (k38 >> 16), (k39 >> 16), (k40 >> 16), (k41 >> 16), (k42 >> 16), (k43 >> 16), (k44 >> 16), (k45 >> 16), (k46 >> 16), (k47 >> 16)
+// clang-format on

--- a/quantum/sequencer/tests/midi_mock.c
+++ b/quantum/sequencer/tests/midi_mock.c
@@ -1,4 +1,4 @@
-/* Copyright 2020 Rodolphe Belouin
+/* Copyright 2020-2021 Rodolphe Belouin
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/quantum/sequencer/tests/midi_mock.h
+++ b/quantum/sequencer/tests/midi_mock.h
@@ -1,4 +1,4 @@
-/* Copyright 2020 Rodolphe Belouin
+/* Copyright 2020-2021 Rodolphe Belouin
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/quantum/sequencer/tests/sequencer_tests.cpp
+++ b/quantum/sequencer/tests/sequencer_tests.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Rodolphe Belouin
+/* Copyright 2020-2021 Rodolphe Belouin
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This pull request is an attempt to rewrite the `sequencer` feature in a way that makes the QMK framework compatible with VIA (as suggested by @fauxpark in #11156).

Instead of assigning one keycode to each possible resolution, step, and track; it lets the user create a layout where each entry is a `uint32_t` combining a `uint16_t` keycode and a `uint16_t` index. This keeps the keycode enumeration simple and static, while keeping the possibility for end users to declare a rich sequencer layout.

You can see these changes in action on my personal branch: https://github.com/rbelouin/qmk_firmware/blob/rbelouin/keyboards/planck/keymaps/rbelouin/keymap.c#L27-L31

So far, I’ve only created the `sequencer_get_keycodes_48` and `sequencer_get_indices_48` macros to satisfy my needs with my Planck EZ. I’m curious to know your opinion on whether this is the right way to go, and whether I should decline these macros for other keyboards too (and if there’s a way to automate this somehow).

I can probably add some tests to cover the macro, if you believe this is useful.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* #11156

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
