### PR TITLE
[Keyboard] Reduce compile size for melgeek mach80

### DIFF
--- a/keyboards/melgeek/mach80/keymaps/via/rules.mk
+++ b/keyboards/melgeek/mach80/keymaps/via/rules.mk
@@ -1,2 +1,1 @@
 VIA_ENABLE = yes
-LTO_ENABLE = yes

--- a/keyboards/melgeek/mach80/rev1/rules.mk
+++ b/keyboards/melgeek/mach80/rev1/rules.mk
@@ -21,4 +21,6 @@ RGBLIGHT_ENABLE = no           # Enable keyboard RGB underglow
 RGB_MATRIX_ENABLE = yes        # Use RGB matrix
 RGB_MATRIX_DRIVER = IS31FL3741
 
+LTO_ENABLE = yes
+
 LAYOUTS = tkl_ansi


### PR DESCRIPTION

## Description

Moves LTO from via keymap to keyboard config. 
Compiles fine on master, only has issues on develop. Yay feature creep.

## Types of Changes

- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)

## Issues Fixed or Closed by This PR

* Tzarc CI

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
