### PR TITLE
Give a hint to adjust F_CPU in the rules.mk template

### DIFF
--- a/data/templates/avr/rules.mk
+++ b/data/templates/avr/rules.mk
@@ -1,5 +1,7 @@
 # MCU name
 MCU = atmega32u4
+# Uncomment if using 3.3 V Pro Micro running at 8 MHz
+#F_CPU = 8000000
 
 # Bootloader selection
 BOOTLOADER = atmel-dfu


### PR DESCRIPTION
## Description

By default F_CPU is set to 16000000 which makes all timings (especially USB and UART) twice too slow on 3.3 V/8 MHz Pro Micro boards. As hard as they try hosts are unable to establish communication with such boards and messages like below can be found in the Linux kernel log.

Such hint in the rules.mk may spare novice QMK hackers a day or two of debugging and keep them interested in the project.

```
[2459329.123362] usb 1-1: USB disconnect, device number 125
[2459329.429298] usb 1-1: new full-speed USB device number 126 using xhci_hcd
[2459329.557275] usb 1-1: device descriptor read/64, error -71
[2459329.793224] usb 1-1: device descriptor read/64, error -71
[2459330.029221] usb 1-1: new full-speed USB device number 127 using xhci_hcd
[2459330.161235] usb 1-1: device descriptor read/64, error -71
[2459330.397242] usb 1-1: device descriptor read/64, error -71
[2459330.505304] usb usb1-port1: attempt power cycle
[2459330.917187] usb 1-1: new full-speed USB device number 2 using xhci_hcd
[2459330.917336] usb 1-1: Device not responding to setup address.
[2459331.125341] usb 1-1: Device not responding to setup address.
[2459331.333195] usb 1-1: device not accepting address 2, error -71
[2459331.461230] usb 1-1: new full-speed USB device number 3 using xhci_hcd
[2459331.461394] usb 1-1: Device not responding to setup address.
[2459331.669333] usb 1-1: Device not responding to setup address.
[2459331.877162] usb 1-1: device not accepting address 3, error -71
[2459331.877209] usb usb1-port1: unable to enumerate USB device
```


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
