### PR TITLE
`qmk docs`: Run `docsify serve` if available

### DIFF
--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -373,6 +373,8 @@ qmk format-c -b branch_name
 This command starts a local HTTP server which you can use for browsing or improving the docs. Default port is 8936.
 Use the `-b`/`--browser` flag to automatically open the local webserver in your default browser.
 
+This command runs `docsify serve` if `docsify-cli` is installed (which provides live reload), otherwise Python's builtin HTTP server module will be used.
+
 **Usage**:
 
 ```

--- a/lib/python/qmk/cli/docs.py
+++ b/lib/python/qmk/cli/docs.py
@@ -2,6 +2,7 @@
 """
 import http.server
 import os
+import shutil
 import webbrowser
 
 from milc import cli
@@ -11,20 +12,33 @@ from milc import cli
 @cli.argument('-b', '--browser', action='store_true', help='Open the docs in the default browser.')
 @cli.subcommand('Run a local webserver for QMK documentation.', hidden=False if cli.config.user.developer else True)
 def docs(cli):
-    """Spin up a local HTTPServer instance for the QMK docs.
+    """Spin up a local HTTP server for the QMK docs.
     """
     os.chdir('docs')
 
-    with http.server.HTTPServer(('', cli.config.docs.port), http.server.SimpleHTTPRequestHandler) as httpd:
-        cli.log.info(f"Serving QMK docs at http://localhost:{cli.config.docs.port}/")
+    # If docsify-cli is installed, run that instead so we get live reload
+    if shutil.which('docsify'):
+        command = ['docsify', 'serve', '--port', f'{cli.config.docs.port}', '--open' if cli.config.docs.browser else '']
+
+        cli.log.info(f"Running {{fg_cyan}}{str.join(' ', command)}{{fg_reset}}")
         cli.log.info("Press Control+C to exit.")
 
-        if cli.config.docs.browser:
-            webbrowser.open(f'http://localhost:{cli.config.docs.port}')
-
         try:
-            httpd.serve_forever()
+            cli.run(command, capture_output=False)
         except KeyboardInterrupt:
             cli.log.info("Stopping HTTP server...")
-        finally:
-            httpd.shutdown()
+    else:
+        # Fall back to Python HTTPServer
+        with http.server.HTTPServer(('', cli.config.docs.port), http.server.SimpleHTTPRequestHandler) as httpd:
+            cli.log.info(f"Serving QMK docs at http://localhost:{cli.config.docs.port}/")
+            cli.log.info("Press Control+C to exit.")
+
+            if cli.config.docs.browser:
+                webbrowser.open(f'http://localhost:{cli.config.docs.port}')
+
+            try:
+                httpd.serve_forever()
+            except KeyboardInterrupt:
+                cli.log.info("Stopping HTTP server...")
+            finally:
+                httpd.shutdown()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

If `docsify-cli` is installed through NPM, `qmk docs` can run that instead, and you get live reload. Falls back to the current behaviour of starting a Python HTTPServer.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
