### PR TITLE
add wait to unicode for win

### DIFF
--- a/quantum/process_keycode/process_unicode_common.c
+++ b/quantum/process_keycode/process_unicode_common.c
@@ -100,6 +100,7 @@ __attribute__((weak)) void unicode_input_start(void) {
             break;
         case UC_WIN:
             register_code(KC_LALT);
+            wait_ms(UNICODE_TYPE_DELAY);
             tap_code(KC_PPLS);
             break;
         case UC_WINC:


### PR DESCRIPTION
## Description

In order to use UC_WIN with remote sessions, a wait has to be inserted before sending KC_PPLS.

Fixes #15062

## Types of Changes

- [X] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
