### PR TITLE
Revamp the ergodox french_hacker layout

### DIFF
--- a/layouts/community/ergodox/french_hacker/keymap.c
+++ b/layouts/community/ergodox/french_hacker/keymap.c
@@ -7,82 +7,64 @@
 #define BASE 0 // default Colemak Mod-DH layer
 #define SYMB 1 // symbols
 #define MDIA 2 // media keys
-#define ACC 3 // accented characters
-
-#define QCOPY 0 // Qubes OS VM to VM copy
-#define QPASTE 1 // Qubes OS VM to VM paste
-#define M_ACIRC 2 // â
-#define M_ECIRC 3 // ê
-#define M_ICIRC 4 // î
-#define M_OCIRC 5 // ô
-#define M_UCIRC 6 // û
-#define M_YCIRC 7 // ŷ
-#define M_AUMLT 8 // ä
-#define M_EUMLT 9 // ë
-#define M_IUMLT 10 // ï
-#define M_OUMLT 11 // ö
-#define M_UUMLT 12 // ü
-#define M_YUMLT 13 // ÿ
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 /* Keymap 0: Base Colemak Mod-DH layer
  *
  * ,--------------------------------------------------.           ,--------------------------------------------------.
- * | Esc    |   1  |   2  |   3  |   4  |   5  |      |           |      |   6  |   7  |   8  |   9  |   0  |        |
+ * | Esc    | & _1 | é _2 | " _3 | ' _4 | ( _5 |      |           |      | - _6 | è _7 | _ _8 | ç _9 | à _0 |        |
  * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
- * |        |   Q  |   W  |   F  |   P  |   B  | TO(0)|           |TO(2) |   J  |   L  |   U  |   Y  |   ;  |        |
+ * |        |   Q  |   W  |   F  |   P  |   B  | TO(0)|           |TO(2) |   J  |   L  |   U  |   Y  |   ;  | Ins    |
  * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
  * | Tab    |   A  |   R  |   S  |   T  |   G  |------|           |------|   M  |   N  |   E  |   I  |   O  | Bcksp  |
- * |--------+------+------+------+------+------| TO(1)|           |OSL(3)|------+------+------+------+------+--------|
+ * |--------+------+------+------+------+------| TO(1)|           | MEH  |------+------+------+------+------+--------|
  * | LShift |   Z  |   X  |   C  |   D  |   V  |      |           |      |   K  |   H  |   ,  |   .  |   :  | Rshift |
  * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
- *   | Ins  | Caps | Left | Right| MO(2)|                                       | MO(2)| Down |  Up  | PgDn | PgUp  |
+ *   |  ù   |      | Left | Right| MO(2)|                                       | MO(2)| Down |  Up  | PgDn | PgUp  |
  *   `----------------------------------'                                       `----------------------------------'
  *                                        ,-------------.       ,-------------.
- *                                        |QCopy | Ralt |       | Ralt |QPaste|
- *                                 ,------|------|------|       |------+------+------.
- *                                 |      |      | Home |       | End  |      |      |
- *                                 | Space| Ctrl |------|       |------| Ctrl |Enter |
- *                                 |      |      | LAlt |       | LAlt |      |      |
- *                                 `--------------------'       `--------------------'
+ *                                        |      | Ralt |       | Ralt |      |
+ *                                ,-------|------|------|       |------+------+------.
+ *                                |       |      | Home |       | End  |      |       |
+ *                                | Space | Ctrl |------|       |------| Ctrl | Enter |
+ *                                |       |      | LAlt |       | LAlt |      |       |
+ *                                `---------------------'       `---------------------'
  */
-  // If it accepts an argument (i.e, is a function), it doesn't need KC_.
-// Otherwise, it needs KC_*
 [BASE] = LAYOUT_ergodox(  // layer 0 : default
         // left hand
-        KC_ESC,         KC_1,         KC_2,   KC_3,   KC_4,   KC_5,   KC_TRNS,
-        KC_TRNS,        FR_Q,         FR_W,   KC_F,   KC_P,   KC_B,   TO(BASE),
-        KC_TAB,         FR_A,         KC_R,   KC_S,   KC_T,   KC_G,
-        KC_LSFT,        FR_Z,         KC_X,   KC_C,   KC_D,   KC_V,   TO(SYMB),
-        KC_INS,         KC_CAPS,      KC_LEFT,KC_RIGHT, MO(SYMB),
-                                               M(QCOPY),          KC_RALT,
+        KC_ESC,         KC_1,         KC_2,       KC_3,        KC_4,    KC_5,   KC_NO,
+        KC_NO,          FR_Q,         FR_W,       KC_F,        KC_P,    KC_B,   TO(BASE),
+        KC_TAB,         FR_A,         KC_R,       KC_S,        KC_T,    KC_G,
+        KC_LSFT,        FR_Z,         KC_X,       KC_C,        KC_D,    KC_V,   TO(SYMB),
+        FR_UGRV,        KC_NO,        KC_LEFT,    KC_RIGHT,    MO(SYMB),
+                                               KC_NO,             KC_RALT,
                                                                   KC_HOME,
                                                KC_SPC,KC_LCTRL,   KC_LALT,
         // right hand
-        KC_TRNS,     KC_6,    KC_7,   KC_8,     KC_9,    KC_0,             KC_TRNS,
-        TO(MDIA),    KC_J,    KC_L,   KC_U,     KC_Y,    FR_SCLN,          KC_TRNS,
-                     FR_M,    KC_N,   KC_E,     KC_I,    KC_O,             KC_BSPC,
-        OSL(ACC),    KC_K,    KC_H,   FR_COMM,  FR_DOT,  FR_COLN,          KC_RSFT,
-        MO(SYMB),    KC_DOWN, KC_UP,  KC_PGDN,  KC_PGUP,
+        KC_NO,        KC_6,    KC_7,       KC_8,             KC_9,      KC_0,             KC_NO,
+        TO(MDIA),     KC_J,    KC_L,       KC_U,             KC_Y,      FR_SCLN,          KC_INS,
+                      FR_M,    KC_N,       KC_E,             KC_I,      KC_O,             KC_BSPC,
+        OSM(MOD_MEH), KC_K,    KC_H,       FR_COMM,          FR_DOT,    FR_COLN,          KC_RSFT,
+                               MO(SYMB),   KC_DOWN, KC_UP,   KC_PGDN,   KC_PGUP,
 
-        KC_RALT,        M(QPASTE),
+        KC_RALT,        KC_NO,
         KC_END,
         KC_LALT,KC_RCTL, KC_ENT
                   ),
 
 
 /* Keymap 1: Symbol Layer
- * // TODO missing: ¤
+ *
  * ,--------------------------------------------------.           ,--------------------------------------------------.
  * |Version |  F1  |  F2  |  F3  |  F4  |  F5  |      |           |      |  F6  |  F7  |  F8  |  F9  |  F10 |   F11  |
  * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
- * |        |   §  |   <  |   {  |   \  |   ~  |      |           |      |   %  |   @  |   }  |  >   |  µ   |   F12  |
+ * |        |   §  |   <  |   {  |   \  |   ~  |      |           |      |   %  |   @  |   }  |  >   |   ¨  |   F12  |
  * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
  * |        |   '  |   =  |   -  |   (  |   +  |------|           |------|   *  |   )  |   _  |  /   |   "  |        |
  * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
  * |        |   `  |   ?  |   #  |   [  |   |  |      |           |      |   &  |   ]  |   $  |   !  |   ^  |        |
  * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
- *   |   €  |   £  |   $  |      |      |                                       |      |      |      |   ß  |      |
+ *   |   €  |   £  |   ¤  |  ²   |      |                                       |      |   °  |  µ   |   ß  |      |
  *   `----------------------------------'                                       `----------------------------------'
  *                                        ,-------------.       ,-------------.
  *                                        |      |      |       |      |      |
@@ -95,20 +77,20 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 // SYMBOLS
 [SYMB] = LAYOUT_ergodox(
        // left hand
-       M(0),   KC_F1,  KC_F2,  KC_F3,  KC_F4,  KC_F5,  KC_TRNS,
-       KC_TRNS,FR_SECT,FR_LABK,  FR_LCBR,FR_BSLS,FR_TILD,KC_TRNS,
-       KC_TRNS,FR_QUOT,FR_EQL, FR_MINS,FR_LPRN,FR_PLUS,
-       KC_TRNS,FR_GRV,FR_QUES,FR_HASH,FR_LBRC,FR_PIPE,KC_TRNS,
-          FR_EURO,FR_PND,FR_DLR,KC_TRNS,KC_TRNS,
+       M(0),       KC_F1,     KC_F2,      KC_F3,      KC_F4,       KC_F5,      KC_TRNS,
+       KC_TRNS,    FR_SECT,   FR_LABK,    FR_LCBR,    FR_BSLS,     FR_TILD,    KC_TRNS,
+       KC_TRNS,    FR_QUOT,   FR_EQL,     FR_MINS,    FR_LPRN,     FR_PLUS,
+       KC_TRNS,    FR_GRV,    FR_QUES,    FR_HASH,    FR_LBRC,     FR_PIPE,    KC_TRNS,
+          FR_EURO, FR_PND,    FR_CURR,    FR_SUP2,    KC_TRNS,
                                        KC_TRNS,KC_TRNS,
                                                KC_TRNS,
                                KC_TRNS,KC_TRNS,KC_TRNS,
        // right hand
-       KC_TRNS, KC_F6,   KC_F7,  KC_F8,   KC_F9,   KC_F10,  KC_F11,
-       KC_TRNS, FR_PERC, FR_AT,  FR_RCBR, FR_RABK, FR_MICR, KC_F12,
-                FR_ASTR,   FR_RPRN, FR_UNDS, FR_SLSH, FR_DQUO, KC_TRNS,
-       KC_TRNS, FR_AMPR, FR_RBRC, FR_DLR,  FR_EXLM,  FR_CIRC, KC_TRNS,
-                         KC_TRNS, KC_TRNS, KC_TRNS,  ALGR(KC_S),  KC_TRNS,
+       KC_TRNS,    KC_F6,      KC_F7,      KC_F8,      KC_F9,      KC_F10,     KC_F11,
+       KC_TRNS,    FR_PERC,    FR_AT,      FR_RCBR,    FR_RABK,    FR_DIAE,    KC_F12,
+                   FR_ASTR,    FR_RPRN,    FR_UNDS,    FR_SLSH,    FR_DQUO,    KC_TRNS,
+       KC_TRNS,    FR_AMPR,    FR_RBRC,    FR_DLR,     FR_EXLM,    FR_CIRC,    KC_TRNS,
+                               KC_TRNS,    FR_DEG,     FR_MICR,    ALGR(KC_S), KC_TRNS,
        KC_TRNS, KC_TRNS,
        KC_TRNS,
        KC_TRNS, KC_TRNS, KC_TRNS
@@ -154,178 +136,6 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
        KC_TRNS,
        KC_TRNS, KC_TRNS, KC_WBAK
 ),
-
-/* Keymap 3: accented characters
- *
- * ,--------------------------------------------------.           ,--------------------------------------------------.
- * |        |      |      |      |      |      |      |           |      |      |      |      |      |      |        |
- * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
- * |        |      |  à   |  â   |  ä   |      |      |           |      |      |      |  î   |  ï   |      |        |
- * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
- * |        |  é   |  è   |  ê   |  ë   |      |------|           |------|      |      |  ô   |  ö   |      |        |
- * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
- * |        |      |  ù   |  û   |  ü   |      |      |           |      |      |      |  ŷ   |  ÿ   |      |        |
- * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
- *   |      |      |      |      |      |                                       |      |      |      |      |      |
- *   `----------------------------------'                                       `----------------------------------'
- *                                        ,-------------.       ,-------------.
- *                                        |      |      |       |      |      |
- *                                 ,------|------|------|       |------+------+------.
- *                                 |      |      |      |       |      |      |      |
- *                                 |      |      |------|       |------|      |      |
- *                                 |      |      |      |       |      |      |      |
- *                                 `--------------------'       `--------------------'
- */
-// ACCENTED CHARACTERS
-[ACC] = LAYOUT_ergodox(
-       KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,     KC_TRNS,    KC_TRNS, KC_TRNS,
-
-       KC_TRNS, KC_TRNS, FR_AGRV, M(M_ACIRC),  M(M_AUMLT), KC_TRNS, KC_TRNS,
-       KC_TRNS, FR_EACU, FR_EGRV, M(M_ECIRC),  M(M_EUMLT), KC_TRNS,
-       KC_TRNS, KC_TRNS, FR_UGRV, M(M_UCIRC),  M(M_UUMLT), KC_TRNS, KC_TRNS,
-       KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,     KC_TRNS,
-                                               KC_TRNS, KC_TRNS,
-                                                    KC_TRNS,
-                                  KC_TRNS, KC_TRNS, KC_TRNS,
-       // right hand
-       KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
-       KC_TRNS,  KC_TRNS, KC_TRNS, M(M_ICIRC), M(M_IUMLT), KC_TRNS, KC_TRNS,
-                 KC_TRNS, KC_TRNS, M(M_OCIRC), M(M_OUMLT), KC_TRNS, KC_TRNS,
-       KC_TRNS,  KC_TRNS, KC_TRNS, M(M_YCIRC), M(M_YUMLT), KC_TRNS, KC_TRNS,
-                          KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
-       KC_TRNS, KC_TRNS,
-       KC_TRNS,
-       KC_TRNS, KC_TRNS, KC_TRNS
-),
-};
-
-const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
-{
-  // MACRODOWN only works in this function
-  switch(id) {
-  case QCOPY:
-    if (record->event.pressed) {
-      return MACRO(I(255),
-                   D(LCTRL),
-                   T(C),
-                   D(LSFT),
-                   T(C),
-                   U(LCTRL),
-                   U(LSFT),
-                   END);
-    }
-    break;
-  case QPASTE:
-    if (record->event.pressed) {
-      return MACRO(I(255),
-                   D(LCTRL),
-                   D(LSFT),
-                   T(V),
-                   U(LCTRL),
-                   T(INS),
-                   U(LSFT),
-                   END);
-    }
-    break;
-  case M_ACIRC:
-    if (record->event.pressed) {
-      return MACRO(T(LBRC), // FR_CIRC
-                   T(Q), // FR_A
-                   END);
-    }
-    break;
-  case M_ECIRC:
-    if (record->event.pressed) {
-      return MACRO(T(LBRC), // FR_CIRC
-                   T(E),
-                   END);
-    }
-    break;
-  case M_UCIRC:
-    if (record->event.pressed) {
-      return MACRO(T(LBRC), // FR_CIRC
-                   T(U),
-                   END);
-    }
-    break;
-  case M_ICIRC:
-    if (record->event.pressed) {
-      return MACRO(T(LBRC), // FR_CIRC
-                   T(I),
-                   END);
-    }
-    break;
-  case M_OCIRC:
-    if (record->event.pressed) {
-      return MACRO(T(LBRC), // FR_CIRC
-                   T(O),
-                   END);
-    }
-    break;
-  case M_YCIRC:
-    if (record->event.pressed) {
-      return MACRO(T(LBRC), // FR_CIRC
-                   T(Y),
-                   END);
-    }
-    break;
-  case M_AUMLT:
-    if (record->event.pressed) {
-      return MACRO(D(LSFT),
-                   T(LBRC),
-                   U(LSFT),
-                   T(Q),
-                   END);
-    }
-    break;
-  case M_EUMLT:
-    if (record->event.pressed) {
-      return MACRO(D(LSFT),
-                   T(LBRC),
-                   U(LSFT),
-                   T(E),
-                   END);
-    }
-    break;
-  case M_UUMLT:
-    if (record->event.pressed) {
-      return MACRO(D(LSFT),
-                   T(LBRC),
-                   U(LSFT),
-                   T(U),
-                   END);
-    }
-    break;
-  case M_IUMLT:
-    if (record->event.pressed) {
-      return MACRO(D(LSFT),
-                   T(LBRC),
-                   U(LSFT),
-                   T(I),
-                   END);
-    }
-    break;
-  case M_OUMLT:
-    if (record->event.pressed) {
-      return MACRO(D(LSFT),
-                   T(LBRC),
-                   U(LSFT),
-                   T(O),
-                   END);
-    }
-    break;
-  case M_YUMLT:
-    if (record->event.pressed) {
-      return MACRO(D(LSFT),
-                   T(LBRC),
-                   U(LSFT),
-                   T(Y),
-                   END);
-    }
-    break;
-
-  }
-  return MACRO_NONE;
 };
 
 // Runs just one time when the keyboard initializes.
@@ -349,9 +159,6 @@ void matrix_scan_user(void) {
       break;
     case MDIA:
       ergodox_right_led_2_on();
-      break;
-    case ACC:
-      ergodox_right_led_3_on();
       break;
     default:
       // none

--- a/layouts/community/ergodox/french_hacker/readme.md
+++ b/layouts/community/ergodox/french_hacker/readme.md
@@ -1,30 +1,27 @@
 # French hacker layout
 
-## Introduction
-
 [Colemak Mod-DH](https://colemakmods.github.io/mod-dh/) layout for
 users keeping an `azerty` layout configuration on their OS.
 
+## Introduction
+
 This keymap is for users keeping their operating systems configured with
-`azerty` - for typing passwords or in their native languages - but who
-wants a Colemak Mod-DH layout on their mechanical.
+`azerty` - for typing passwords in their native languages, or for their laptop
+keyboard - but who wants a Colemak Mod-DH layout on their mechanical keyboard.
 
 The symbols layers was done after analysing various programming
 languages sources codes and should be close to optimal for typing
-confort.
+confort, see the link at the end of the README.
 
-Special macros for [Qubes OS](https://www.qubes-os.org/) are included.
+The design is done to minimize the usage of the pinky fingers and reduces stress
+on the hands, thus Alt and Ctrl keys are accessible for both hands.
 
-There is an accented characters layer for infrequent typing of french
-accents.
+## Flashing the firmware
 
-Special macros for [Qubes OS](https://www.qubes-os.org/) are included.
-
-## Build
-
-    cd keyboards/ergodox
-    make french_hacker
+```
+qmk flash -kb ergodox_ez -km french_hacker
+```
 
 ## Design explanations
 
-See my [blog post](http://dialectical-computing.de/blog/blog/2017/01/29/a-better-coder-layout-for-the-ergodox-ez-keyboard/).
+See my [blog post](http://www.dialectical-computing.de/blog/blog/2017/01/29/a-better-coder-layout-for-the-ergodox-ez-keyboard/).


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Provides a revamp of my original ergodox french_hacker layout.

- Remove specific QubesOS shortcuts
- Remove clunky accented letters layers
- Add missing azerty symbols
- Add Meh key

All accented characters are now accessible either with dead accent keys or with
directly with on the traditional azerty top row

I have kept the media layer, even if I don't use it, as it may ease forking/hacking on the layout  for follow programmers.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
