### PR TITLE
IS31FL3733 driver for LED Matrix

### DIFF
--- a/drivers/led/issi/is31fl3733-simple.c
+++ b/drivers/led/issi/is31fl3733-simple.c
@@ -1,0 +1,248 @@
+/* Copyright 2017 Jason Williams
+ * Copyright 2018 Jack Humbert
+ * Copyright 2018 Yiancar
+ * Copyright 2021 Doni Crosby
+ * Copyright 2021 Leo Deng
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "is31fl3733-simple.h"
+#include "i2c_master.h"
+#include "wait.h"
+
+// This is a 7-bit address, that gets left-shifted and bit 0
+// set to 0 for write, 1 for read (as per I2C protocol)
+// The address will vary depending on your wiring:
+// 00 <-> GND
+// 01 <-> SCL
+// 10 <-> SDA
+// 11 <-> VCC
+// ADDR1 represents A1:A0 of the 7-bit address.
+// ADDR2 represents A3:A2 of the 7-bit address.
+// The result is: 0b101(ADDR2)(ADDR1)
+#define ISSI_ADDR_DEFAULT 0x50
+
+#define ISSI_COMMANDREGISTER 0xFD
+#define ISSI_COMMANDREGISTER_WRITELOCK 0xFE
+#define ISSI_INTERRUPTMASKREGISTER 0xF0
+#define ISSI_INTERRUPTSTATUSREGISTER 0xF1
+
+#define ISSI_PAGE_LEDCONTROL 0x00  // PG0
+#define ISSI_PAGE_PWM 0x01         // PG1
+#define ISSI_PAGE_AUTOBREATH 0x02  // PG2
+#define ISSI_PAGE_FUNCTION 0x03    // PG3
+
+#define ISSI_REG_CONFIGURATION 0x00  // PG3
+#define ISSI_REG_GLOBALCURRENT 0x01  // PG3
+#define ISSI_REG_RESET 0x11          // PG3
+#define ISSI_REG_SWPULLUP 0x0F       // PG3
+#define ISSI_REG_CSPULLUP 0x10       // PG3
+
+#ifndef ISSI_TIMEOUT
+#    define ISSI_TIMEOUT 100
+#endif
+
+#ifndef ISSI_PERSISTENCE
+#    define ISSI_PERSISTENCE 0
+#endif
+
+#ifndef ISSI_PWM_FREQUENCY
+#    define ISSI_PWM_FREQUENCY 0b000  // PFS - IS31FL3733B only
+#endif
+
+#ifndef ISSI_SWPULLUP
+#    define ISSI_SWPULLUP PUR_0R
+#endif
+
+#ifndef ISSI_CSPULLUP
+#    define ISSI_CSPULLUP PUR_0R
+#endif
+
+// Transfer buffer for TWITransmitData()
+uint8_t g_twi_transfer_buffer[20];
+
+// These buffers match the IS31FL3733 PWM registers.
+// The control buffers match the PG0 LED On/Off registers.
+// Storing them like this is optimal for I2C transfers to the registers.
+// We could optimize this and take out the unused registers from these
+// buffers and the transfers in IS31FL3733_write_pwm_buffer() but it's
+// probably not worth the extra complexity.
+uint8_t g_pwm_buffer[LED_DRIVER_COUNT][192];
+bool    g_pwm_buffer_update_required[LED_DRIVER_COUNT] = {false};
+
+/* There's probably a better way to init this... */
+#if LED_DRIVER_COUNT == 1
+uint8_t g_led_control_registers[LED_DRIVER_COUNT][24] = {{0}};
+#elif LED_DRIVER_COUNT == 2
+uint8_t g_led_control_registers[LED_DRIVER_COUNT][24] = {{0}, {0}};
+#elif LED_DRIVER_COUNT == 3
+uint8_t g_led_control_registers[LED_DRIVER_COUNT][24] = {{0}, {0}, {0}};
+#elif LED_DRIVER_COUNT == 4
+uint8_t g_led_control_registers[LED_DRIVER_COUNT][24] = {{0}, {0}, {0}, {0}};
+#endif
+bool g_led_control_registers_update_required[LED_DRIVER_COUNT] = {false};
+
+bool IS31FL3733_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
+    // If the transaction fails function returns false.
+    g_twi_transfer_buffer[0] = reg;
+    g_twi_transfer_buffer[1] = data;
+
+#if ISSI_PERSISTENCE > 0
+    for (uint8_t i = 0; i < ISSI_PERSISTENCE; i++) {
+        if (i2c_transmit(addr << 1, g_twi_transfer_buffer, 2, ISSI_TIMEOUT) != 0) {
+            return false;
+        }
+    }
+#else
+    if (i2c_transmit(addr << 1, g_twi_transfer_buffer, 2, ISSI_TIMEOUT) != 0) {
+        return false;
+    }
+#endif
+    return true;
+}
+
+bool IS31FL3733_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
+    // Assumes PG1 is already selected.
+    // If any of the transactions fails function returns false.
+    // Transmit PWM registers in 12 transfers of 16 bytes.
+    // g_twi_transfer_buffer[] is 20 bytes
+
+    // Iterate over the pwm_buffer contents at 16 byte intervals.
+    for (int i = 0; i < 192; i += 16) {
+        g_twi_transfer_buffer[0] = i;
+        // Copy the data from i to i+15.
+        // Device will auto-increment register for data after the first byte
+        // Thus this sets registers 0x00-0x0F, 0x10-0x1F, etc. in one transfer.
+        for (int j = 0; j < 16; j++) {
+            g_twi_transfer_buffer[1 + j] = pwm_buffer[i + j];
+        }
+
+#if ISSI_PERSISTENCE > 0
+        for (uint8_t i = 0; i < ISSI_PERSISTENCE; i++) {
+            if (i2c_transmit(addr << 1, g_twi_transfer_buffer, 17, ISSI_TIMEOUT) != 0) {
+                return false;
+            }
+        }
+#else
+        if (i2c_transmit(addr << 1, g_twi_transfer_buffer, 17, ISSI_TIMEOUT) != 0) {
+            return false;
+        }
+#endif
+    }
+    return true;
+}
+
+void IS31FL3733_init(uint8_t addr, uint8_t sync) {
+    // In order to avoid the LEDs being driven with garbage data
+    // in the LED driver's PWM registers, shutdown is enabled last.
+    // Set up the mode and other settings, clear the PWM registers,
+    // then disable software shutdown.
+    // Sync is passed so set it according to the datasheet.
+
+    // Unlock the command register.
+    IS31FL3733_write_register(addr, ISSI_COMMANDREGISTER_WRITELOCK, 0xC5);
+
+    // Select PG0
+    IS31FL3733_write_register(addr, ISSI_COMMANDREGISTER, ISSI_PAGE_LEDCONTROL);
+    // Turn off all LEDs.
+    for (int i = 0x00; i <= 0x17; i++) {
+        IS31FL3733_write_register(addr, i, 0x00);
+    }
+
+    // Unlock the command register.
+    IS31FL3733_write_register(addr, ISSI_COMMANDREGISTER_WRITELOCK, 0xC5);
+
+    // Select PG1
+    IS31FL3733_write_register(addr, ISSI_COMMANDREGISTER, ISSI_PAGE_PWM);
+    // Set PWM on all LEDs to 0
+    // No need to setup Breath registers to PWM as that is the default.
+    for (int i = 0x00; i <= 0xBF; i++) {
+        IS31FL3733_write_register(addr, i, 0x00);
+    }
+
+    // Unlock the command register.
+    IS31FL3733_write_register(addr, ISSI_COMMANDREGISTER_WRITELOCK, 0xC5);
+
+    // Select PG3
+    IS31FL3733_write_register(addr, ISSI_COMMANDREGISTER, ISSI_PAGE_FUNCTION);
+    // Set de-ghost pull-up resistors (SWx)
+    IS31FL3733_write_register(addr, ISSI_REG_SWPULLUP, ISSI_SWPULLUP);
+    // Set de-ghost pull-down resistors (CSx)
+    IS31FL3733_write_register(addr, ISSI_REG_CSPULLUP, ISSI_CSPULLUP);
+    // Set global current to maximum.
+    IS31FL3733_write_register(addr, ISSI_REG_GLOBALCURRENT, 0xFF);
+    // Disable software shutdown.
+    IS31FL3733_write_register(addr, ISSI_REG_CONFIGURATION, ((sync & 0b11) << 6) | ((ISSI_PWM_FREQUENCY & 0b111) << 3) | 0x01);
+
+    // Wait 10ms to ensure the device has woken up.
+    wait_ms(10);
+}
+
+void IS31FL3733_set_value(int index, uint8_t value) {
+    if (index >= 0 && index < DRIVER_LED_TOTAL) {
+        is31_led led = g_is31_leds[index];
+
+        g_pwm_buffer[led.driver][led.v]          = value;
+        g_pwm_buffer_update_required[led.driver] = true;
+    }
+}
+
+void IS31FL3733_set_value_all(uint8_t value) {
+    for (int i = 0; i < DRIVER_LED_TOTAL; i++) {
+        IS31FL3733_set_value(i, value);
+    }
+}
+
+void IS31FL3733_set_led_control_register(uint8_t index, bool value) {
+    is31_led led = g_is31_leds[index];
+
+    uint8_t control_register = led.v / 8;
+    uint8_t bit_value        = led.v % 8;
+
+    if (value) {
+        g_led_control_registers[led.driver][control_register] |= (1 << bit_value);
+    } else {
+        g_led_control_registers[led.driver][control_register] &= ~(1 << bit_value);
+    }
+
+    g_led_control_registers_update_required[led.driver] = true;
+}
+
+void IS31FL3733_update_pwm_buffers(uint8_t addr, uint8_t index) {
+    if (g_pwm_buffer_update_required[index]) {
+        // Firstly we need to unlock the command register and select PG1.
+        IS31FL3733_write_register(addr, ISSI_COMMANDREGISTER_WRITELOCK, 0xC5);
+        IS31FL3733_write_register(addr, ISSI_COMMANDREGISTER, ISSI_PAGE_PWM);
+
+        // If any of the transactions fail we risk writing dirty PG0,
+        // refresh page 0 just in case.
+        if (!IS31FL3733_write_pwm_buffer(addr, g_pwm_buffer[index])) {
+            g_led_control_registers_update_required[index] = true;
+        }
+        g_pwm_buffer_update_required[index] = false;
+    }
+}
+
+void IS31FL3733_update_led_control_registers(uint8_t addr, uint8_t index) {
+    if (g_led_control_registers_update_required[index]) {
+        // Firstly we need to unlock the command register and select PG0
+        IS31FL3733_write_register(addr, ISSI_COMMANDREGISTER_WRITELOCK, 0xC5);
+        IS31FL3733_write_register(addr, ISSI_COMMANDREGISTER, ISSI_PAGE_LEDCONTROL);
+        for (int i = 0; i < 24; i++) {
+            IS31FL3733_write_register(addr, i, g_led_control_registers[index][i]);
+        }
+        g_led_control_registers_update_required[index] = false;
+    }
+}

--- a/drivers/led/issi/is31fl3733-simple.h
+++ b/drivers/led/issi/is31fl3733-simple.h
@@ -1,0 +1,260 @@
+/* Copyright 2017 Jason Williams
+ * Copyright 2018 Jack Humbert
+ * Copyright 2018 Yiancar
+ * Copyright 2021 Doni Crosby
+ * Copyright 2021 Leo Deng
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "progmem.h"
+
+typedef struct is31_led {
+    uint8_t driver : 2;
+    uint8_t v;
+} __attribute__((packed)) is31_led;
+
+extern const is31_led __flash g_is31_leds[DRIVER_LED_TOTAL];
+
+void IS31FL3733_init(uint8_t addr, uint8_t sync);
+bool IS31FL3733_write_register(uint8_t addr, uint8_t reg, uint8_t data);
+bool IS31FL3733_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer);
+
+void IS31FL3733_set_value(int index, uint8_t value);
+void IS31FL3733_set_value_all(uint8_t value);
+
+void IS31FL3733_set_led_control_register(uint8_t index, bool value);
+
+// This should not be called from an interrupt
+// (eg. from a timer interrupt).
+// Call this while idle (in between matrix scans).
+// If the buffer is dirty, it will update the driver with the buffer.
+void IS31FL3733_update_pwm_buffers(uint8_t addr, uint8_t index);
+void IS31FL3733_update_led_control_registers(uint8_t addr, uint8_t index);
+
+#define PUR_0R 0x00    // No PUR resistor
+#define PUR_05KR 0x02  // 0.5k Ohm resistor in t_NOL
+#define PUR_3KR 0x03   // 3.0k Ohm resistor on all the time
+#define PUR_4KR 0x04   // 4.0k Ohm resistor on all the time
+#define PUR_8KR 0x05   // 8.0k Ohm resistor on all the time
+#define PUR_16KR 0x06  // 16k Ohm resistor on all the time
+#define PUR_32KR 0x07  // 32k Ohm resistor in t_NOL
+
+#define A_1 0x00
+#define A_2 0x01
+#define A_3 0x02
+#define A_4 0x03
+#define A_5 0x04
+#define A_6 0x05
+#define A_7 0x06
+#define A_8 0x07
+#define A_9 0x08
+#define A_10 0x09
+#define A_11 0x0A
+#define A_12 0x0B
+#define A_13 0x0C
+#define A_14 0x0D
+#define A_15 0x0E
+#define A_16 0x0F
+
+#define B_1 0x10
+#define B_2 0x11
+#define B_3 0x12
+#define B_4 0x13
+#define B_5 0x14
+#define B_6 0x15
+#define B_7 0x16
+#define B_8 0x17
+#define B_9 0x18
+#define B_10 0x19
+#define B_11 0x1A
+#define B_12 0x1B
+#define B_13 0x1C
+#define B_14 0x1D
+#define B_15 0x1E
+#define B_16 0x1F
+
+#define C_1 0x20
+#define C_2 0x21
+#define C_3 0x22
+#define C_4 0x23
+#define C_5 0x24
+#define C_6 0x25
+#define C_7 0x26
+#define C_8 0x27
+#define C_9 0x28
+#define C_10 0x29
+#define C_11 0x2A
+#define C_12 0x2B
+#define C_13 0x2C
+#define C_14 0x2D
+#define C_15 0x2E
+#define C_16 0x2F
+
+#define D_1 0x30
+#define D_2 0x31
+#define D_3 0x32
+#define D_4 0x33
+#define D_5 0x34
+#define D_6 0x35
+#define D_7 0x36
+#define D_8 0x37
+#define D_9 0x38
+#define D_10 0x39
+#define D_11 0x3A
+#define D_12 0x3B
+#define D_13 0x3C
+#define D_14 0x3D
+#define D_15 0x3E
+#define D_16 0x3F
+
+#define E_1 0x40
+#define E_2 0x41
+#define E_3 0x42
+#define E_4 0x43
+#define E_5 0x44
+#define E_6 0x45
+#define E_7 0x46
+#define E_8 0x47
+#define E_9 0x48
+#define E_10 0x49
+#define E_11 0x4A
+#define E_12 0x4B
+#define E_13 0x4C
+#define E_14 0x4D
+#define E_15 0x4E
+#define E_16 0x4F
+
+#define F_1 0x50
+#define F_2 0x51
+#define F_3 0x52
+#define F_4 0x53
+#define F_5 0x54
+#define F_6 0x55
+#define F_7 0x56
+#define F_8 0x57
+#define F_9 0x58
+#define F_10 0x59
+#define F_11 0x5A
+#define F_12 0x5B
+#define F_13 0x5C
+#define F_14 0x5D
+#define F_15 0x5E
+#define F_16 0x5F
+
+#define G_1 0x60
+#define G_2 0x61
+#define G_3 0x62
+#define G_4 0x63
+#define G_5 0x64
+#define G_6 0x65
+#define G_7 0x66
+#define G_8 0x67
+#define G_9 0x68
+#define G_10 0x69
+#define G_11 0x6A
+#define G_12 0x6B
+#define G_13 0x6C
+#define G_14 0x6D
+#define G_15 0x6E
+#define G_16 0x6F
+
+#define H_1 0x70
+#define H_2 0x71
+#define H_3 0x72
+#define H_4 0x73
+#define H_5 0x74
+#define H_6 0x75
+#define H_7 0x76
+#define H_8 0x77
+#define H_9 0x78
+#define H_10 0x79
+#define H_11 0x7A
+#define H_12 0x7B
+#define H_13 0x7C
+#define H_14 0x7D
+#define H_15 0x7E
+#define H_16 0x7F
+
+#define I_1 0x80
+#define I_2 0x81
+#define I_3 0x82
+#define I_4 0x83
+#define I_5 0x84
+#define I_6 0x85
+#define I_7 0x86
+#define I_8 0x87
+#define I_9 0x88
+#define I_10 0x89
+#define I_11 0x8A
+#define I_12 0x8B
+#define I_13 0x8C
+#define I_14 0x8D
+#define I_15 0x8E
+#define I_16 0x8F
+
+#define J_1 0x90
+#define J_2 0x91
+#define J_3 0x92
+#define J_4 0x93
+#define J_5 0x94
+#define J_6 0x95
+#define J_7 0x96
+#define J_8 0x97
+#define J_9 0x98
+#define J_10 0x99
+#define J_11 0x9A
+#define J_12 0x9B
+#define J_13 0x9C
+#define J_14 0x9D
+#define J_15 0x9E
+#define J_16 0x9F
+
+#define K_1 0xA0
+#define K_2 0xA1
+#define K_3 0xA2
+#define K_4 0xA3
+#define K_5 0xA4
+#define K_6 0xA5
+#define K_7 0xA6
+#define K_8 0xA7
+#define K_9 0xA8
+#define K_10 0xA9
+#define K_11 0xAA
+#define K_12 0xAB
+#define K_13 0xAC
+#define K_14 0xAD
+#define K_15 0xAE
+#define K_16 0xAF
+
+#define L_1 0xB0
+#define L_2 0xB1
+#define L_3 0xB2
+#define L_4 0xB3
+#define L_5 0xB4
+#define L_6 0xB5
+#define L_7 0xB6
+#define L_8 0xB7
+#define L_9 0xB8
+#define L_10 0xB9
+#define L_11 0xBA
+#define L_12 0xBB
+#define L_13 0xBC
+#define L_14 0xBD
+#define L_15 0xBE
+#define L_16 0xBF

--- a/quantum/led_matrix/led_matrix.h
+++ b/quantum/led_matrix/led_matrix.h
@@ -2,6 +2,7 @@
  * Copyright 2017 Jack Humbert
  * Copyright 2018 Yiancar
  * Copyright 2019 Clueboard
+ * Copyright 2021 Leo Deng
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -27,6 +28,9 @@
 
 #ifdef IS31FL3731
 #    include "is31fl3731-simple.h"
+#endif
+#ifdef IS31FL3733
+#    include "is31fl3733-simple.h"
 #endif
 
 #ifndef LED_MATRIX_LED_FLUSH_LIMIT


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

After reading source code of LED matrix, I noticed that the [work for supporting IS31FL3733 has partially done](https://github.com/qmk/qmk_firmware/blob/master/quantum/led_matrix/led_matrix_drivers.c). But I've no idea why it wasn't finished since then.

I port an IS31FL3733 driver for LED matrix, almost the same way as how IS31FL3731 was ported. Simply add following lines in `rules.mk` to use it:

```
LED_MATRIX_ENABLE = yes
LED_MATRIX_DRIVER = IS31FL3733
```

The documentation needs to be updated accordingly, could be highly similar to IS31FL3731 section though.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
