### PR TITLE
[Core] RISC-V toolchain and picolibc fixes

### DIFF
--- a/platforms/chibios/platform.mk
+++ b/platforms/chibios/platform.mk
@@ -346,8 +346,8 @@ ifeq ($(strip $(MCU)), risc-v)
         endif
     endif
 
-    # Default to compiling with picolibc for RISC-V targets if available,
-    # which is available by default on current (bullseye) debian based systems.
+    # Default to compiling with picolibc for RISC-V targets if available, which
+    # is available by default on distributions based on Debian 11+.
     ifeq ($(shell $(TOOLCHAIN)gcc --specs=picolibc.specs -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
         # Toolchain specific Compiler flags
         # Note that we still link with our own linker script

--- a/platforms/chibios/platform.mk
+++ b/platforms/chibios/platform.mk
@@ -316,7 +316,7 @@ endif
 #
 
 # Use defined stack sizes of the main thread in linker scripts
-LDSYMBOLS =--defsym=__process_stack_size__=$(USE_PROCESS_STACKSIZE),--defsym=__main_stack_size__=$(USE_EXCEPTIONS_STACKSIZE)
+SHARED_LDSYMBOLS = -Wl,--defsym=__process_stack_size__=$(USE_PROCESS_STACKSIZE),--defsym=__main_stack_size__=$(USE_EXCEPTIONS_STACKSIZE)
 
 # Shared Compiler flags for all toolchains
 SHARED_CFLAGS = -fomit-frame-pointer \
@@ -327,7 +327,6 @@ SHARED_CFLAGS = -fomit-frame-pointer \
 
 # Shared Linker flags for all toolchains
 SHARED_LDFLAGS = -T $(LDSCRIPT) \
-                 -Wl,$(LDSYMBOLS) \
                  -Wl,--gc-sections \
                  -nostartfiles
 
@@ -349,10 +348,14 @@ ifeq ($(strip $(MCU)), risc-v)
     # Default to compiling with picolibc for RISC-V targets if available, which
     # is available by default on distributions based on Debian 11+.
     ifeq ($(shell $(TOOLCHAIN)gcc --specs=picolibc.specs -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
-        # Toolchain specific Compiler flags
-        # Note that we still link with our own linker script
-        # by providing it via the -T flag above.
+        # Toolchain specific Compiler flags Note that we still link with our own
+        # linker script by providing it via the -T flag in SHARED_LDFLAGS.
         TOOLCHAIN_CFLAGS = --specs=picolibc.specs
+
+        # picolibc internally uses __heap_start and __heap_end instead of the
+        # defacto chibios linker script standard __heap_base__ and __heap_end__
+        # therefore we introduce these symbols as an alias.
+        TOOLCHAIN_LDSYMBOLS = -Wl,--defsym=__heap_start=__heap_base__,--defsym=__heap_end=__heap_end__
 
         # Tell QMK that we are compiling with picolibc.
         OPT_DEFS += -DUSE_PICOLIBC
@@ -404,7 +407,7 @@ CFLAGS   += $(SHARED_CFLAGS) $(TOOLCHAIN_CFLAGS)
 CXXFLAGS += $(CFLAGS) $(SHARED_CXXFLAGS) $(TOOLCHAIN_CXXFLAGS) -fno-rtti
 
 # Linker flags
-LDFLAGS  += $(SHARED_LDFLAGS) $(TOOLCHAIN_LDFLAGS) $(MCUFLAGS)
+LDFLAGS  += $(SHARED_LDFLAGS) $(SHARED_LDSYMBOLS) $(TOOLCHAIN_LDFLAGS) $(TOOLCHAIN_LDSYMBOLS) $(MCUFLAGS)
 
 # Tell QMK that we are hosting it on ChibiOS.
 OPT_DEFS += -DPROTOCOL_CHIBIOS

--- a/platforms/chibios/syscall-fallbacks.c
+++ b/platforms/chibios/syscall-fallbacks.c
@@ -22,6 +22,7 @@
  * the _reent struct has to be defined. */
 #if defined(USE_PICOLIBC)
 struct _reent;
+struct timeval;
 #endif
 
 #pragma GCC diagnostic ignored "-Wmissing-prototypes"

--- a/util/install/debian.sh
+++ b/util/install/debian.sh
@@ -11,12 +11,18 @@ _qmk_install_prepare() {
 _qmk_install() {
     echo "Installing dependencies"
 
-    sudo apt-get -yq install \
+    sudo apt-get --quiet --yes install \
         build-essential clang-format diffutils gcc git unzip wget zip \
         python3-pip binutils-avr gcc-avr avr-libc binutils-arm-none-eabi \
         gcc-arm-none-eabi libnewlib-arm-none-eabi avrdude dfu-programmer \
-        dfu-util teensy-loader-cli libhidapi-hidraw0 libusb-dev \
-        picolibc-riscv64-unknown-elf gcc-riscv64-unknown-elf binutils-riscv64-unknown-elf
+        dfu-util teensy-loader-cli libhidapi-hidraw0 libusb-dev
 
-    python3 -m pip install --user -r $QMK_FIRMWARE_DIR/requirements.txt
+    # RISC-V toolchains with picolibc support are only available for distributions based on Debian 11+.
+    if sudo apt-get install --simulate --quiet --yes picolibc-riscv64-unknown-elf gcc-riscv64-unknown-elf binutils-riscv64-unknown-elf > /dev/null 2>&1; then
+        sudo apt-get --quiet --yes install picolibc-riscv64-unknown-elf \
+            gcc-riscv64-unknown-elf \
+            binutils-riscv64-unknown-elf
+    fi
+
+    python3 -m pip install --user -r "$QMK_FIRMWARE_DIR"/requirements.txt
 }


### PR DESCRIPTION
## Description

This PR contains multiple fixes for the upcoming develop to master merge. 

1. Debian and Distributions based on it ship the needed RISC-V toolchain beginning with Debian 11+ and Ubuntu 21.04+. Therefore the qmk install script checks if the needed dependencies are available.
2. QMK CLI setup: RISC-V toolchains are not widely available at the moment and the naming is not unified. The main userbase of QMK are AVR and ARM mcus therefore RISC-V should not be treated as a hard requirement. Therefore a missing toolchain produces no error but merely a warning.
3. picolibc usage with heap allocation: picolibc internally uses `__heap_start` and `__heap_end` instead of the defacto chibios linker script standard `__heap_base__` and `__heap_end__` therefore we introduce these symbols as an alias. Usually all memory used within QMK is statically allocated, but some algorithms make usage of `malloc` and friends. Also the `timeval` struct is not defined by picolibc for syscalls, therefore it is declared as a stub.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
