### PR TITLE
gcc10 LTO - Only specify adhlns assembler options at link time

### DIFF
--- a/tmk_core/rules.mk
+++ b/tmk_core/rules.mk
@@ -215,12 +215,8 @@ LDFLAGS += $(EXTRALDFLAGS)
 #             files -- see avr-libc docs [FIXME: not yet described there]
 #  -listing-cont-lines: Sets the maximum number of continuation lines of hex
 #       dump that will be displayed for a given single line of source input.
-GCC_VERSION := $(shell gcc --version 2>/dev/null)
-ifneq ($(findstring clang, ${GCC_VERSION}),)
-  ADHLNS_ENABLE := no
-endif
 
-ADHLNS_ENABLE ?= yes
+ADHLNS_ENABLE ?= no
 ifeq ($(ADHLNS_ENABLE),yes)
   # Avoid "Options to '-Xassembler' do not match" - only specify assembler options at LTO link time
   ifeq ($(strip $(LTO_ENABLE)), yes)

--- a/tmk_core/rules.mk
+++ b/tmk_core/rules.mk
@@ -81,7 +81,6 @@ endif
 #  -f...:        tuning, see GCC manual and avr-libc documentation
 #  -Wall...:     warning level
 #  -Wa,...:      tell GCC to pass this to the assembler.
-#    -adhlns...: create assembler listing
 ifeq ($(strip $(LTO_ENABLE)), yes)
     ifeq ($(PLATFORM),CHIBIOS)
         $(info Enabling LTO on ChibiOS-targeting boards is known to have a high likelihood of failure.)
@@ -117,10 +116,6 @@ endif
 #CFLAGS += -Wundef
 #CFLAGS += -Wunreachable-code
 #CFLAGS += -Wsign-compare
-GCC_VERSION := $(shell gcc --version 2>/dev/null)
-ifeq ($(findstring clang, ${GCC_VERSION}),)
-CFLAGS += -Wa,-adhlns=$(@:%.o=%.lst)
-endif
 CFLAGS += $(CSTANDARD)
 
 # This fixes lots of keyboards linking errors but SHOULDN'T BE A FINAL SOLUTION
@@ -133,7 +128,6 @@ CFLAGS += -fcommon
 #  -f...:        tuning, see GCC manual and avr-libc documentation
 #  -Wall...:     warning level
 #  -Wa,...:      tell GCC to pass this to the assembler.
-#    -adhlns...: create assembler listing
 ifeq ($(strip $(DEBUG_ENABLE)),yes)
   CXXFLAGS += -g$(DEBUG)
 endif
@@ -152,28 +146,10 @@ endif
 #CXXFLAGS += -Wstrict-prototypes
 #CXXFLAGS += -Wunreachable-code
 #CXXFLAGS += -Wsign-compare
-ifeq ($(findstring clang, ${GCC_VERSION}),)
-CXXFLAGS += -Wa,-adhlns=$(@:%.o=%.lst)
-endif
 #CXXFLAGS += $(CSTANDARD)
 
 #---------------- Assembler Options ----------------
-#  -Wa,...:   tell GCC to pass this to the assembler.
-#  -adhlns:   create listing
-#  -gstabs:   have the assembler create line number information; note that
-#             for use in COFF files, additional information about filenames
-#             and function names needs to be present in the assembler source
-#             files -- see avr-libc docs [FIXME: not yet described there]
-#  -listing-cont-lines: Sets the maximum number of continuation lines of hex
-#       dump that will be displayed for a given single line of source input.
 ASFLAGS += $(ADEFS)
-ifeq ($(findstring clang, ${GCC_VERSION}),)
-ifeq ($(strip $(DEBUG_ENABLE)),yes)
-  ASFLAGS += -Wa,-adhlns=$(@:%.o=%.lst),-gstabs,--listing-cont-lines=100
-else
-  ASFLAGS += -Wa,-adhlns=$(@:%.o=%.lst),--listing-cont-lines=100
-endif
-endif
 ifeq ($(VERBOSE_AS_CMD),yes)
 	ASFLAGS += -v
 endif
@@ -229,6 +205,36 @@ LDFLAGS += $(PRINTF_LIB) $(SCANF_LIB) $(MATH_LIB)
 #LDFLAGS += -T linker_script.x
 # You can give EXTRALDFLAGS at 'make' command line.
 LDFLAGS += $(EXTRALDFLAGS)
+
+#---------------- Assembler Listings ----------------
+#  -Wa,...:   tell GCC to pass this to the assembler.
+#  -adhlns:   create listing
+#  -gstabs:   have the assembler create line number information; note that
+#             for use in COFF files, additional information about filenames
+#             and function names needs to be present in the assembler source
+#             files -- see avr-libc docs [FIXME: not yet described there]
+#  -listing-cont-lines: Sets the maximum number of continuation lines of hex
+#       dump that will be displayed for a given single line of source input.
+GCC_VERSION := $(shell gcc --version 2>/dev/null)
+ifneq ($(findstring clang, ${GCC_VERSION}),)
+  ADHLNS_ENABLE := no
+endif
+
+ADHLNS_ENABLE ?= yes
+ifeq ($(ADHLNS_ENABLE),yes)
+  # Avoid "Options to '-Xassembler' do not match" - only specify assembler options at LTO link time
+  ifeq ($(strip $(LTO_ENABLE)), yes)
+    LDFLAGS += -Wa,-adhlns=$(BUILD_DIR)/$(TARGET).lst
+  else
+    CFLAGS += -Wa,-adhlns=$(@:%.o=%.lst)
+    CXXFLAGS += -Wa,-adhlns=$(@:%.o=%.lst)
+    ifeq ($(strip $(DEBUG_ENABLE)),yes)
+      ASFLAGS = -Wa,-adhlns=$(@:%.o=%.lst),-gstabs,--listing-cont-lines=100
+    else
+      ASFLAGS = -Wa,-adhlns=$(@:%.o=%.lst),--listing-cont-lines=100
+    endif
+  endif
+endif
 
 # Define programs and commands.
 SHELL = sh


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Resolves the long standing issue of,
```
Making lets_split/sockets with keymap default                                                          [WARNINGS]
 | 
 | lto-wrapper: warning: Options to Xassembler do not match: -adhlns=.build/obj_lets_split_sockets_default/keyboards/lets_split/lets_split.lst, -adhlns=.build/obj_lets_split_sockets_default/keyboards/lets_split/sockets/sockets.lst, dropping all -Xassembler and -Wa options.
 |
````

447ec8f - Do the vast majority of users actually care about these files? Seems like it should be opt-in (which also removes an additional clang check).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
