### PR TITLE
kb_elmo/elmopad: fix macro reference in info.json

### DIFF
--- a/keyboards/kb_elmo/elmopad/info.json
+++ b/keyboards/kb_elmo/elmopad/info.json
@@ -3,7 +3,7 @@
     "url": "https://github.com/kb-elmo/numpad",
     "maintainer": "kb-elmo",
     "layouts": {
-        "LAYOUT": {
+        "LAYOUT_numpad_6x4": {
             "layout": [
                 {"x":0, "y":0}, 
                 {"x":1, "y":0}, 


### PR DESCRIPTION
## Description

Fixes
![image](https://user-images.githubusercontent.com/18669334/141654011-b7c13ae0-c068-41c5-8561-3ff7d6a5684b.png)

cc @kb-elmo (keyboard maintainer)

## Types of Changes

- [x] Enhancement/optimization
- [x] Keyboard (addition or update)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
