### PR TITLE
Partially reinstate CI formatting process

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -19,7 +19,9 @@ jobs:
     container: qmkfm/qmk_cli
 
     steps:
-    - uses: rlespinasse/github-slug-action@v3.x
+    - name: Install dependencies
+      run: |
+        apt-get update && apt-get install -y dos2unix
 
     - uses: actions/checkout@v2
       with:
@@ -31,12 +33,17 @@ jobs:
         output: ' '
         fileOutput: ' '
 
-    - name: Run qmk format-c and qmk format-python
+    - name: Run qmk formatters
       shell: 'bash {0}'
       run: |
-        qmk format-c --core-only -n $(< ~/files.txt)
-        format_c_exit=$?
-        qmk format-python -n
-        format_python_exit=$?
+        qmk format-c --core-only $(< ~/files.txt)
+        qmk format-python
+        qmk format-text $(< ~/files.txt)
+        git diff
 
-        exit $((format_c_exit + format_python_exit))
+    - name: Fail when formatting required
+      run: |
+        for file in $(git diff --name-only); do
+          echo "::error file=${file}::::File Requires Formatting"
+        done
+        test -n "$(git status  --porcelain)" && exit 1

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -46,4 +46,4 @@ jobs:
         for file in $(git diff --name-only); do
           echo "::error file=${file}::::File Requires Formatting"
         done
-        test -n "$(git status  --porcelain)" && exit 1
+        test -n "$(git diff --name-only)" && exit 1

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -46,4 +46,4 @@ jobs:
         for file in $(git diff --name-only); do
           echo "::error file=${file}::::File Requires Formatting"
         done
-        test -n "$(git diff --name-only)" && exit 1
+        test -z "$(git diff --name-only)"

--- a/lib/python/qmk/cli/format/text.py
+++ b/lib/python/qmk/cli/format/text.py
@@ -1,27 +1,57 @@
 """Ensure text files have the proper line endings.
 """
-from subprocess import CalledProcessError
+from itertools import islice
+from subprocess import DEVNULL
 
 from milc import cli
 
+from qmk.path import normpath
 
+
+def _get_chunks(it, size):
+    """Break down a collection into smaller parts
+    """
+    it = iter(it)
+    return iter(lambda: tuple(islice(it, size)), ())
+
+
+def dos2unix_run(files):
+    """Spawn multiple dos2unix subprocess avoiding too long commands on formatting everything
+    """
+    for chunk in _get_chunks(files, 10):
+        dos2unix = cli.run(['dos2unix', *chunk])
+
+        if dos2unix.returncode:
+            return False
+
+
+@cli.argument('-b', '--base-branch', default='origin/master', help='Branch to compare to diffs to.')
+@cli.argument('-a', '--all-files', arg_only=True, action='store_true', help='Format all files.')
+@cli.argument('files', nargs='*', arg_only=True, type=normpath, help='Filename(s) to format.')
 @cli.subcommand("Ensure text files have the proper line endings.", hidden=True)
 def format_text(cli):
     """Ensure text files have the proper line endings.
     """
-    try:
-        file_list_cmd = cli.run(['git', 'ls-files', '-z'], check=True)
-    except CalledProcessError as e:
-        cli.log.error('Could not get file list: %s', e)
-        exit(1)
-    except Exception as e:
-        cli.log.error('Unhandled exception: %s: %s', e.__class__.__name__, e)
-        cli.log.exception(e)
-        exit(1)
+    # Find the list of files to format
+    if cli.args.files:
+        files = list(cli.args.files)
 
-    dos2unix = cli.run(['xargs', '-0', 'dos2unix'], stdin=None, input=file_list_cmd.stdout)
+        if cli.args.all_files:
+            cli.log.warning('Filenames passed with -a, only formatting: %s', ','.join(map(str, files)))
 
-    if dos2unix.returncode != 0:
-        print(dos2unix.stderr)
+    elif cli.args.all_files:
+        git_ls_cmd = ['git', 'ls-files']
+        git_ls = cli.run(git_ls_cmd, stdin=DEVNULL)
+        files = list(filter(None, git_ls.stdout.split('\n')))
 
-    return dos2unix.returncode
+    else:
+        git_diff_cmd = ['git', 'diff', '--name-only', cli.args.base_branch]
+        git_diff = cli.run(git_diff_cmd, stdin=DEVNULL)
+        files = list(filter(None, git_diff.stdout.split('\n')))
+
+    # Sanity check
+    if not files:
+        cli.log.error('No changed files detected. Use "qmk format-text -a" to format all files')
+        return False
+
+    return dos2unix_run(files)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Puts back the dos2unix check, however keyboard PRs will need further work.

QOL improvement to flag which files are failing, rather than it be hidden in the log
![image](https://user-images.githubusercontent.com/16520359/141700691-f1750db0-87b1-49f8-8dd0-fda276fd8d02.png)
(further iteration on the problem would be required to get accurate line numbers, error content, etc)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
