### PR TITLE
Hex 4b LED Layer Indicater

### DIFF
--- a/keyboards/mechlovin/hex4b/keymaps/nazzer/keymap.c
+++ b/keyboards/mechlovin/hex4b/keymaps/nazzer/keymap.c
@@ -1,0 +1,98 @@
+/* Copyright 2020 Team Mechlovin
+ * Copyright 2021 Nazerim
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [0] = LAYOUT_split_bs(
+        KC_ESC,  KC_F1,   KC_F2,   KC_F3,   KC_F4,            KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_F13,
+        KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_SPC,  KC_HOME,
+        KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS, KC_PGUP,
+        KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_ENT,           KC_PGDN,
+        KC_LSFT,          KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_LSFT, KC_UP,   KC_END,
+        KC_LCTL, KC_LGUI, KC_LALT,                            KC_SPC,                                      MO(1),   KC_RCTL, KC_LEFT, KC_DOWN, KC_RGHT
+    ),
+    [1] = LAYOUT_split_bs(
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,          KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,          KC_TRNS,
+        KC_TRNS,          KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+        KC_TRNS, KC_TRNS, KC_TRNS,                            KC_TRNS,                                     KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS
+    ),
+    [2] = LAYOUT_split_bs(
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,          KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,          KC_TRNS,
+        KC_TRNS,          KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+        KC_TRNS, KC_TRNS, KC_TRNS,                            KC_TRNS,                                     KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS
+    ),
+    [3] = LAYOUT_split_bs(
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,          KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,          KC_TRNS,
+        KC_TRNS,          KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+        KC_TRNS, KC_TRNS, KC_TRNS,                            KC_TRNS,                                     KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS
+    ),
+
+};
+
+bool led_update_user(led_t led_state) {
+	
+	// Toggle CAPS_LOCK LED normally
+	
+#    if LED_PIN_ON_STATE == 0
+        // invert the whole thing to avoid having to conditionally !led_state.x later
+        led_state.raw = ~led_state.raw;
+#    endif
+#    ifdef LED_CAPS_LOCK_PIN
+        writePin(LED_CAPS_LOCK_PIN, led_state.caps_lock);
+#    endif
+
+	// Don't call led_update_kb
+    return false;
+}
+
+layer_state_t layer_state_set_user(layer_state_t state) {
+	
+	uint8_t layer = biton32(state);
+	
+#if defined(LED_NUM_LOCK_PIN) && defined(LED_SCROLL_LOCK_PIN)
+    switch (layer) {
+        case 0:
+			writePin(LED_SCROLL_LOCK_PIN, !LED_PIN_ON_STATE); 
+			writePin(LED_NUM_LOCK_PIN, !LED_PIN_ON_STATE); 
+            break;
+        case 1:
+			writePin(LED_SCROLL_LOCK_PIN, LED_PIN_ON_STATE); 
+			writePin(LED_NUM_LOCK_PIN, !LED_PIN_ON_STATE); 
+            break;
+        case 2:
+			writePin(LED_SCROLL_LOCK_PIN, !LED_PIN_ON_STATE); 
+			writePin(LED_NUM_LOCK_PIN, LED_PIN_ON_STATE); 
+            break;
+        case 3:
+			writePin(LED_SCROLL_LOCK_PIN, LED_PIN_ON_STATE); 
+			writePin(LED_NUM_LOCK_PIN, LED_PIN_ON_STATE); 
+            break;
+    }
+#endif
+
+	return state;												
+
+}

--- a/keyboards/mechlovin/hex4b/keymaps/nazzer/reame.md
+++ b/keyboards/mechlovin/hex4b/keymaps/nazzer/reame.md
@@ -1,0 +1,15 @@
+# Nazzer's Hex 4b - Layers on Scroll Lock and Num Lock LED
+
+Repurposed the Scroll Lock and Num Lock LED's as Hex 4b does not have a NUM pad and default layout does not map Scroll Lock
+- Top LED shows CAPS lock status
+- Layer indicators:
+- Layer 0: bottom LED off, middle LED off
+- Layer 1: bottom LED on , middle LED off
+- Layer 2: bottom LED off, middle LED on
+- Layer 3: bottom LED on , middle LED on
+
+## Changelog
+
+### 15/11/2021 - 0.0.1
+
+- Initial release

--- a/keyboards/mechlovin/hex4b/keymaps/nazzer/rules.mk
+++ b/keyboards/mechlovin/hex4b/keymaps/nazzer/rules.mk
@@ -1,0 +1,1 @@
+VIA_ENABLE = yes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Hex 4b VIA Keymap to use scroll lock and num lock LED's to indicate active layer (0,1,2,3)

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Repurposed the Scroll Lock and Num Lock LED's as Hex 4b does not have a NUM pad and default layout does not map Scroll Lock

- Top LED shows CAPS lock status
- Layer indicators:
- Layer 0: bottom LED off, middle LED off
- Layer 1: bottom LED on , middle LED off
- Layer 2: bottom LED off, middle LED on
- Layer 3: bottom LED on , middle LED on

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
