### PR TITLE
Orthocode update default keymap, and fix encoder function for keymaps built in configurator

### DIFF
--- a/keyboards/orthocode/info.json
+++ b/keyboards/orthocode/info.json
@@ -5,9 +5,9 @@
     "layouts": {
         "LAYOUT": {
             "layout": [
-                {"label":"Rotary", "x":0.5, "y":0},
+                {"label":"Mute", "x":0.5, "y":0},
 
-                {"label":"Game", "x":0.5, "y":1},
+                {"label":"RGB Tog", "x":0.5, "y":1},
                 {"label":"Esc", "x":1.75, "y":1},
                 {"label":"1", "x":3, "y":1},
                 {"label":"2", "x":4, "y":1},
@@ -23,7 +23,7 @@
                 {"label":"+", "x":16.5, "y":1},
                 {"label":"Home", "x":17.5, "y":1},
 
-                {"label":"M1", "x":0.25, "y":2},
+                {"label":"RGB Mode", "x":0.25, "y":2},
                 {"label":"Tab", "x":1.5, "y":2, "w":1.5},
                 {"label":"Q", "x":3, "y":2},
                 {"label":"W", "x":4, "y":2},
@@ -39,8 +39,8 @@
                 {"label":"Delete", "x":17, "y":2},
                 {"label":"End", "x":18, "y":2},
 
-                {"label":"M2", "x":0, "y":3},
-                {"label":"Ctrl", "x":1.25, "y":3, "w":1.75},
+                {"label":"RGB RMode", "x":0, "y":3},
+                {"label":"Caps", "x":1.25, "y":3, "w":1.75},
                 {"label":"A", "x":3, "y":3},
                 {"label":"S", "x":4, "y":3},
                 {"label":"D", "x":5, "y":3},
@@ -54,7 +54,7 @@
                 {"label":"\"", "x":15.5, "y":3},
                 {"label":"Enter", "x":16.5, "y":3, "w":2.25},
 
-                {"label":"Layer", "x":0.75, "y":4, "w":2.25},
+                {"label":"Shift", "x":0.75, "y":4, "w":2.25},
                 {"label":"Z", "x":3, "y":4},
                 {"label":"X", "x":4, "y":4},
                 {"label":"C", "x":5, "y":4},

--- a/keyboards/orthocode/keymaps/default/keymap.c
+++ b/keyboards/orthocode/keymaps/default/keymap.c
@@ -66,14 +66,3 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 };
 
 
-#ifdef ENCODER_ENABLE
-bool encoder_update_user(uint8_t index, bool clockwise) {
-    // Volume control
-    if (clockwise) {
-        tap_code(KC_VOLU);
-    } else {
-        tap_code(KC_VOLD);
-    }
-    return true;
-}
-#endif

--- a/keyboards/orthocode/keymaps/default/keymap.c
+++ b/keyboards/orthocode/keymaps/default/keymap.c
@@ -17,43 +17,36 @@
 
 enum custom_keycodes {
   QWERTY = SAFE_RANGE,
-  SHIFTSPACE,
-  ILIKEFROG
 };
-
-#define KC_SHSP SHIFTSPACE
-#define KC_FROG ILIKEFROG
-
-
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [0] = LAYOUT(
      /* Rotary                                                                                                                                  */
         KC__MUTE,
      /*           esc      1        2        3        4        5        6        7        8        9        0        -        =        home     */
-        TG(2),    KC_GESC, KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_HOME,
+        RGB_TOG,    KC_GESC, KC_1,    KC_2,    KC_3,  KC_4,    KC_5,    KC_6,    KC_7,   KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_HOME,
      /*           tab      Q        W        E        R        T        Y        U        I        O        P        \        delete   end      */
-        RGB_TOG,  KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_BSLS, KC_DEL,  KC_END,
+        RGB_MOD,    KC_TAB,  KC_Q,    KC_W,    KC_E,  KC_R,    KC_T,    KC_Y,    KC_U,   KC_I,    KC_O,    KC_P,    KC_BSLS, KC_DEL,  KC_END,
      /*           caps     A        S        D        F        G        H        J        K        L        ;        '        enter             */
-        RGB_MOD,  KC_LCTL, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_ENT,
+        RGB_RMOD,   KC_CAPS, KC_A,    KC_S,    KC_D,  KC_F,    KC_G,    KC_H,    KC_J,   KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_ENT,
      /*           shift    Z        X        C        V        B        N        M        ,        .        /                 up                */
-                  KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH,          KC_UP,
+                  KC_LSFT,   KC_Z,    KC_X,    KC_C,  KC_V,    KC_B,    KC_N,    KC_M,   KC_COMM, KC_DOT,  KC_SLSH,          KC_UP,
      /*           ctrl     win      alt      fn       th1      th2      th3      th4      fn       alt      ctrl     left     down     right    */
-                  KC_LCTL, KC_LGUI, KC_LALT, MO(1),   KC_RSFT, KC_ENT,  KC_BSPC, KC_SHSP, MO(1),   KC_RALT, KC_RCTL, KC_LEFT, KC_DOWN, KC_RGHT
+                  KC_LCTL, KC_LGUI, KC_LALT, MO(1),  KC_RSFT, KC_ENT,  KC_BSPC, KC_SPC, MO(1),   KC_RALT, KC_RCTL, KC_LEFT, KC_DOWN, KC_RIGHT
     ),
     [1] = LAYOUT(
      /* Rotary                                                                                                                                                  */
-        KC_TRNS,
-     /*          esc      1        2        3        4        5        6        7             8              9              0        -        =        home     */
-        TG(3),   KC_GRV,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,        KC_F8,         KC_F9,         KC_F10,  KC_F11,  KC_F12,  KC_TRNS,
-     /*          tab      Q        W        E        R        T        Y        U             I              O              P        \        delete   end      */
-        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, RESET,   KC_TRNS, KC_TRNS, KC_TRNS,      LSFT(KC_LBRC), LSFT(KC_RBRC), KC_TRNS, KC_TRNS, KC_PAUS, KC_TRNS,
-     /*          caps     A        S        D        F        G        H        J             K              L              ;        '        enter             */
-        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,      KC_LBRC,       KC_RBRC,       KC_TRNS, KC_TRNS, KC_TRNS,
-     /*          shift    Z        X        C        V        B        N        M             ,              .              /                 up                */
-                 KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_EQL,  LSFT(KC_EQL), LSFT(KC_9),    LSFT(KC_0),    KC_TRNS,          KC_VOLU,
-     /*          ctrl     win      alt      fn       th1      th2      th3      th4           fn             alt            ctrl     left     down     right    */
-                 KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_MINS,      KC_TRNS,       KC_TRNS,       KC_TRNS, KC_TRNS, KC_VOLD, KC_TRNS
+        TG(2),
+     /*          esc      1        2        3        4       5       6        7            8          9           0        -         =     home  */
+      KC_TRNS, KC_GRV,  KC_F1,   KC_F2,   KC_F3,   KC_F4,  KC_F5,  KC_F6,   KC_F7,       KC_F8,      KC_F9,      KC_F10,  KC_F11,   KC_F12,  KC_TRNS,
+     /*          tab      Q       W        E        R        T       Y        U             I           O          P         \      delete     end */
+      RGB_HUI, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, RESET,  KC_TRNS,KC_TRNS, KC_TRNS, LSFT(KC_LBRC), LSFT(KC_RBRC), KC_TRNS, KC_TRNS,  KC_PAUS, KC_TRNS,
+     /*          caps      A       S        D        F        G      H         J            K          L         ;        '        enter    */
+      RGB_HUD, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,KC_TRNS,KC_TRNS, KC_TRNS,     KC_LBRC,    KC_RBRC, KC_TRNS, KC_TRNS,  KC_TRNS,
+     /*         shift      Z         X        C       V       B       N       M             ,           .          /                       up      */
+              KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,KC_TRNS,KC_TRNS, LSFT(KC_EQL), LSFT(KC_9), LSFT(KC_0), KC_TRNS,             KC_VOLU,
+     /*         ctrl     win      alt        fn     th1      th2     th3      th4          fn         alt       ctrl      left     down     right*/
+              KC_TRNS, KC_TRNS, KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,  KC_TRNS,  KC_TRNS,   KC_TRNS,  KC_TRNS,   KC_TRNS, KC_VOLD,  KC_TRNS
     ),
     [2] = LAYOUT(
      /* Rotary                                                                                                                                 */
@@ -69,106 +62,17 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
      /*          ctrl     win      alt      fn       th1      th2      th3      th4      fn       alt      ctrl     left     down     right    */
                  KC_TRNS, KC_NO,   KC_TRNS, KC_TRNS, KC_SPC,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS
 
-    ),
-    [3] = LAYOUT(
-     /* Rotary                                                                                                                                 */
-        KC_FROG,
-     /*          esc      1        2        3        4        5        6        7        8        9        0        -        =        home     */
-        TG(3),   KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG,
-     /*          tab      Q        W        E        R        T        Y        U        I        O        P        \        delete   end      */
-        KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG,
-     /*          caps     A        S        D        F        G        H        J        K        L        ;        '        enter             */
-        KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG,
-     /*          shift    Z        X        C        V        B        N        M        ,        .        /                 up                */
-                 KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG,          KC_FROG,
-     /*          ctrl     win      alt      fn       th1      th2      th3      th4      fn       alt      ctrl     left     down     right    */
-                 KC_FROG, KC_FROG, KC_FROG, MO(1),   KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG, KC_FROG
     )
 };
-
-
-
-
-bool process_record_user(uint16_t keycode, keyrecord_t *record) {
-    static bool shiftspace_mods = false;
-    static int frogchar = 0;
-    switch (keycode) {
-    case SHIFTSPACE:
-        if (record->event.pressed) {
-            if(get_mods() & MOD_BIT(KC_RSFT)) {
-                register_code(KC_MINS);
-                shiftspace_mods = true;
-            }
-            else {
-                register_code(KC_SPC);
-            }
-        } else {
-            if (shiftspace_mods) {
-                unregister_code(KC_MINS);
-                shiftspace_mods = false;
-            } else {
-                unregister_code(KC_SPC);
-            }
-        }
-        return false;
-        break;
-    case ILIKEFROG:
-        if (record->event.pressed) {
-            switch (frogchar)
-            {
-            case 0:
-                SEND_STRING("I");
-                break;
-            case 1:
-                SEND_STRING(" ");
-                break;
-            case 2:
-                SEND_STRING("L");
-                break;
-            case 3:
-                SEND_STRING("i");
-                break;
-            case 4:
-                SEND_STRING("k");
-                break;
-            case 5:
-                SEND_STRING("e");
-                break;
-            case 6:
-                SEND_STRING(" ");
-                break;
-            case 7:
-                SEND_STRING("F");
-                break;
-            case 8:
-                SEND_STRING("r");
-                break;
-            case 9:
-                SEND_STRING("o");
-                break;
-            case 10:
-                SEND_STRING("g");
-                break;
-            case 11:
-                SEND_STRING(" ");
-                break;
-            }
-            frogchar = (frogchar + 1) % 12;
-        }
-        break;
-    }
-    return true;
-
-}
 
 
 #ifdef ENCODER_ENABLE
 bool encoder_update_user(uint8_t index, bool clockwise) {
     // Volume control
     if (clockwise) {
-        tap_code(KC_VOLD);
-    } else {
         tap_code(KC_VOLU);
+    } else {
+        tap_code(KC_VOLD);
     }
     return true;
 }

--- a/keyboards/orthocode/orthocode.c
+++ b/keyboards/orthocode/orthocode.c
@@ -17,6 +17,7 @@
 
 #ifdef ENCODER_ENABLE
 bool encoder_update_kb(uint8_t index, bool clockwise) {
+    if (!encoder_update_user(index, clockwise)) { return false; }
     // Volume control
     if (clockwise) {
         tap_code(KC_VOLU);

--- a/keyboards/orthocode/orthocode.c
+++ b/keyboards/orthocode/orthocode.c
@@ -14,3 +14,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "orthocode.h"
+
+#ifdef ENCODER_ENABLE
+bool encoder_update_kb(uint8_t index, bool clockwise) {
+    // Volume control
+    if (clockwise) {
+        tap_code(KC_VOLU);
+    } else {
+        tap_code(KC_VOLD);
+    }
+    return true;
+}
+#endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Updating the default keymap to match the one shipped on the boards.
Moving the encoder function definition to orthocode.c so it works by default for those using the online qmk configurator

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
