### PR TITLE
Fix bandominedoni via keymap compilation

### DIFF
--- a/keyboards/bandominedoni/config.h
+++ b/keyboards/bandominedoni/config.h
@@ -197,6 +197,7 @@
 #            define ENABLE_RGB_MATRIX_SOLID_MULTISPLASH
 
 #        endif
+#            define ENABLE_RGB_MATRIX_SOLID_REACTIVE
 // #define ENABLE_RGB_MATRIX_SPLASH
 // #define ENABLE_RGB_MATRIX_SOLID_SPLASH
 #    endif  // AUDIO_ENABLE


### PR DESCRIPTION
## Description

Add missing mode for via keymap. verified that via keymap compiles. (826 bytes free)

## Types of Changes

- [x] Bugfix
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)

## Issues Fixed or Closed by This PR

* Tzarc CI

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
