### PR TITLE
Update the documentation to call steno_set_mode inside eeconfig_init_user

### DIFF
--- a/docs/feature_stenography.md
+++ b/docs/feature_stenography.md
@@ -40,8 +40,8 @@ MOUSEKEY_ENABLE = no
 In your keymap create a new layer for Plover. You will need to include `keymap_steno.h`. See `planck/keymaps/steno/keymap.c` for an example. Remember to create a key to switch to the layer as well as a key for exiting the layer. If you would like to switch modes on the fly you can use the keycodes `QK_STENO_BOLT` and `QK_STENO_GEMINI`. If you only want to use one of the protocols you may set it up in your initialization function:
 
 ```c
-void matrix_init_user() {
-  steno_set_mode(STENO_MODE_GEMINI); // or STENO_MODE_BOLT
+void eeconfig_init_user() {
+    steno_set_mode(STENO_MODE_GEMINI); // or STENO_MODE_BOLT
 }
 ```
 

--- a/docs/ja/feature_stenography.md
+++ b/docs/ja/feature_stenography.md
@@ -45,8 +45,8 @@ MOUSEKEY_ENABLE = no
 キーマップで Plover 用の新しいレイヤーを作成します。`keymap_steno.h` をインクルードする必要があります。例については `planck/keymaps/steno/keymap.c` を見てください。レイヤーに切り替えるためのキーとレイヤーから抜けるためのキーを作成することを忘れないでください。その場でモードを切り替えたい場合は、キーコード `QK_STENO_BOLT` および `QK_STENO_GEMINI` を使うことができます。プロトコルのうちの1つのみを使う場合は、初期化関数の中でそれをセットアップすることができます:
 
 ```c
-void matrix_init_user() {
-  steno_set_mode(STENO_MODE_GEMINI); // あるいは STENO_MODE_BOLT
+void eeconfig_init_user() {
+    steno_set_mode(STENO_MODE_GEMINI); // あるいは STENO_MODE_BOLT
 }
 ```
 


### PR DESCRIPTION
## Description

As mentioned in https://github.com/qmk/qmk_firmware/pull/15133#discussion_r749754206, `eeconfig_init_user()` is a better place than `matrix_init_user()` to call `steno_set_mode()`.

## Types of Changes

- [x] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).