### PR TITLE
[Bug] Revert backlight pins on function call

### DIFF
--- a/quantum/backlight/backlight_avr.c
+++ b/quantum/backlight/backlight_avr.c
@@ -222,7 +222,7 @@ ISR(TIMERx_OVF_vect) {
     // takes many computation cycles).
     // so better not turn them on while the counter TOP is very low.
     if (OCRxx > ICRx / 250 + 5) {
-        FOR_EACH_LED(backlight_on(backlight_pin);)
+        backlight_pins_on();
     }
 }
 


### PR DESCRIPTION
## Description

Reverts the change to turn the pins on, as it's erroring out, and backlight_common properly handles it. 

## Types of Changes

- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* Tzarc CI

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
