### PR TITLE
[Bug] Fix timer include in override_wiring.c

### DIFF
--- a/tmk_core/protocol/usb_hid/override_wiring.c
+++ b/tmk_core/protocol/usb_hid/override_wiring.c
@@ -3,7 +3,7 @@
  */
 #define __DELAY_BACKWARD_COMPATIBLE__
 #include <util/delay.h>
-#include "common/timer.h"
+#include "timer.h"
 
 
 unsigned long millis(void)

--- a/tmk_core/protocol/usb_hid/override_wiring.c
+++ b/tmk_core/protocol/usb_hid/override_wiring.c
@@ -3,7 +3,7 @@
  */
 #define __DELAY_BACKWARD_COMPATIBLE__
 #include <util/delay.h>
-#include "timer.h"
+#include "platforms/timer.h"
 
 
 unsigned long millis(void)


### PR DESCRIPTION
## Description

Fix timer include.

## Types of Changes

- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* Tzarc CI

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
