### PR TITLE
added keymap fronti90 with rgb layers

### DIFF
--- a/keyboards/senselessclay/ck65/keymaps/fronti90/config.h
+++ b/keyboards/senselessclay/ck65/keymaps/fronti90/config.h
@@ -1,0 +1,3 @@
+#include "../../config.h"
+#define RGBLIGHT_LAYERS
+#define RGBLIGHT_LAYERS_RETAIN_VAL

--- a/keyboards/senselessclay/ck65/keymaps/fronti90/keymap.c
+++ b/keyboards/senselessclay/ck65/keymaps/fronti90/keymap.c
@@ -1,0 +1,92 @@
+/* Copyright 2020 Hadi Iskandarani
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include QMK_KEYBOARD_H
+#include "rgblight.h"
+#include "eeconfig.h"
+
+#define DEFAULT_LAYER 0
+#define GAMING_LAYER 1
+#define FN_LAYER 2
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [DEFAULT_LAYER] = LAYOUT(
+    /*Base*/
+      KC_ESC, KC_1, KC_2, KC_3, KC_4, KC_5, KC_6, KC_7, KC_8, KC_9, KC_0, KC_MINS, KC_EQL, KC_BSPC, KC_HOME, 
+      KC_TAB, KC_Q, KC_W, KC_E, KC_R, KC_T, KC_Y, KC_U, KC_I, KC_O, KC_P, KC_LBRC, KC_RBRC, KC_ENT, KC_END,
+      MO(2), KC_A, KC_S, KC_D, KC_F, KC_G, KC_H, KC_J, KC_K, KC_L, KC_SCLN, KC_QUOT, KC_NUHS, KC_DEL,
+      KC_LSFT, KC_NUBS, KC_Z, KC_X, KC_C, KC_V, KC_B, KC_N, KC_M, KC_COMM, KC_DOT, KC_SLSH, KC_RSFT, KC_UP, KC_NLCK,
+      KC_LCTL, KC_LGUI, KC_LALT, KC_SPC, KC_RALT, KC_RGUI, MO(2), KC_LEFT, KC_DOWN, KC_RIGHT),
+    [GAMING_LAYER] = LAYOUT(
+      KC_GRV, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+      KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+      KC_ESC, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+      KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+      KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS),
+    [FN_LAYER] = LAYOUT(
+      KC_TRNS, KC_F1, KC_F2, KC_F3, KC_F4, KC_F5, KC_F6, KC_F7, KC_F8, KC_F9, KC_F10, KC_F11, KC_F12, KC_TRNS, KC_PGUP,
+      KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_PGDN,
+      KC_CAPS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_LEFT, KC_UP, KC_DOWN, KC_RGHT, KC_TRNS, KC_TRNS, KC_TRNS, KC_PSCR,
+      KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_VOLU, KC_INS,
+      KC_TRNS, KC_TRNS, KC_TRNS, KC_MPLY, MAGIC_TOGGLE_NKRO, TG(1), KC_TRNS, KC_MPRV, KC_VOLD, KC_MNXT),
+};
+
+const rgblight_segment_t PROGMEM my_0_layer[] = RGBLIGHT_LAYER_SEGMENTS(
+  {0, 1, HSV_RED}
+);
+
+const rgblight_segment_t PROGMEM my_1_layer[] = RGBLIGHT_LAYER_SEGMENTS(
+  {0, 15, HSV_RED}
+);
+const rgblight_segment_t PROGMEM my_2_layer[] = RGBLIGHT_LAYER_SEGMENTS(
+  {1, 4, HSV_PURPLE},
+	{7, 4, HSV_PURPLE}
+);
+
+const rgblight_segment_t PROGMEM my_caps_layer[] = RGBLIGHT_LAYER_SEGMENTS(
+  {0, 1, HSV_RED},
+	{5, 1, HSV_RED},
+	{6, 1, HSV_RED},
+	{11, 1, HSV_RED}
+);
+	
+// Now define the array of layers. Later layers take precedence
+const rgblight_segment_t* const PROGMEM my_layers[] = RGBLIGHT_LAYERS_LIST(
+  my_0_layer,
+	my_1_layer,
+  my_2_layer,
+	my_caps_layer
+);
+
+void keyboard_post_init_user(void) {
+  // Enable the LED layers
+  rgblight_enable_noeeprom(); // enables Rgb, without saving settings
+  rgblight_sethsv_noeeprom(252, 3, 3); // sets the color to red without saving
+  rgblight_mode_noeeprom(RGBLIGHT_MODE_STATIC_GRADIENT + 6);
+  rgblight_layers = my_layers;
+	layer_state_set_user(layer_state);
+};
+
+layer_state_t layer_state_set_user(layer_state_t state) {
+  rgblight_set_layer_state(0, layer_state_cmp(state, 0));
+	rgblight_set_layer_state(1, layer_state_cmp(state, 1));
+  rgblight_set_layer_state(2, layer_state_cmp(state, 2));
+  return state;
+};
+
+bool led_update_user(led_t led_state) {
+  rgblight_set_layer_state(3, led_state.caps_lock);
+  return true;
+};

--- a/keyboards/senselessclay/ck65/keymaps/fronti90/rules.mk
+++ b/keyboards/senselessclay/ck65/keymaps/fronti90/rules.mk
@@ -1,0 +1,1 @@
+VIA_ENABLE = yes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Added the "fronti90" keymap which enables rgb layers support to display the current layer on the top row leds

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [X] Keymap/layout/userspace (addition or update)

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
