### PR TITLE
Short term bodge for PRODUCT warning

### DIFF
--- a/data/mappings/info_config.json
+++ b/data/mappings/info_config.json
@@ -68,7 +68,7 @@
     "RGBLIGHT_SLEEP": {"info_key": "rgblight.sleep", "value_type": "bool"},
     "RGBLIGHT_SPLIT": {"info_key": "rgblight.split", "value_type": "bool"},
     "RGBW": {"info_key": "rgblight.rgbw", "value_type": "bool"},
-    "PRODUCT": {"info_key": "keyboard_name"},
+    "PRODUCT": {"info_key": "keyboard_name", "warn_duplicate": false},
     "PRODUCT_ID": {"info_key": "usb.pid", "value_type": "hex"},
     "VENDOR_ID": {"info_key": "usb.vid", "value_type": "hex"},
     "QMK_ESC_OUTPUT": {"info_key": "qmk_lufa_bootloader.esc_output"},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
With code freeze looming, virtually every keyboard is spitting out the following warning
```
make zvecr/zv48:default:flash
QMK Firmware 0.14.31
⚠ zvecr/zv48/f401: PRODUCT in config.h is overwriting keyboard_name in info.json
Making zvecr/zv48/f401 with keymap default and target flash

⚠ zvecr/zv48/f401: PRODUCT in config.h is overwriting keyboard_name in info.json
arm-none-eabi-gcc (Arch Repository) 11.2.0
```

While maybe a better experience while porting new keyboards, this is just going to cause issues for the majority. (Just look at how many questions get raised about the arm size warning)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
