### PR TITLE
Add Keyboardio Atreus 2 Bootloader to udev rules

### DIFF
--- a/util/udev/50-qmk.rules
+++ b/util/udev/50-qmk.rules
@@ -33,6 +33,9 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="05dc", TAG+="uacc
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="6124", TAG+="uaccess", ENV{ID_MM_DEVICE_IGNORE}="1"
 
 # Caterina (Pro Micro)
+## pid.codes shared PID
+### Keyboardio Atreus 2 Bootloader
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="2302", TAG+="uaccess", ENV{ID_MM_DEVICE_IGNORE}="1"
 ## Spark Fun Electronics
 ### Pro Micro 3V3/8MHz
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b4f", ATTRS{idProduct}=="9203", TAG+="uaccess", ENV{ID_MM_DEVICE_IGNORE}="1"


### PR DESCRIPTION
## Description

The Keyboardio Atreus 2 Bootloader is a clone of the Caterina bootloader with different USB VID:PID values (`1209:2302`):

  https://github.com/keyboardio/Atreus2-Bootloader

Add the appropriate udev rule for that bootloader.

Verified in Discord: https://discord.com/channels/440868230475677696/867530222407778344/911701982891360286

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Keyboardio Atreus 2 board not flashable from Linux

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
