### PR TITLE
Add uint to char functions

### DIFF
--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -572,8 +572,13 @@ __attribute__((weak)) void suspend_wakeup_init_quantum(void) {
 #endif
     suspend_wakeup_init_kb();
 
-// Useful string manipulation code
-static const char *get_numeric_str(char *buf, size_t buf_len, uint32_t curr_num, char curr_pad) {
+/** \brief converts unsigned integers into char arrays
+ *
+ * Takes an unsigned integer, and uses a static conversion buffer to convert that value into a
+ * char array
+ */
+
+const char *get_numeric_str(char *buf, size_t buf_len, uint32_t curr_num, char curr_pad) {
     buf[buf_len-1] = '\0';
     for(size_t i = 0; i < buf_len-1; ++i) {
         char c = '0' + curr_num % 10;

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -576,6 +576,8 @@ __attribute__((weak)) void suspend_wakeup_init_quantum(void) {
  *
  * Takes an unsigned integer, and uses a static conversion buffer to convert that value into a
  * char array
+ * NOTE: Subsequent invocations will reuse the same static buffer and overwrite the previous
+ *       contents. Use the result immediately, instead of caching it.
  */
 
 const char *get_numeric_str(char *buf, size_t buf_len, uint32_t curr_num, char curr_pad) {

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -571,6 +571,7 @@ __attribute__((weak)) void suspend_wakeup_init_quantum(void) {
     rgb_matrix_set_suspend_state(false);
 #endif
     suspend_wakeup_init_kb();
+}
 
 /** \brief converts unsigned integers into char arrays
  *
@@ -579,10 +580,10 @@ __attribute__((weak)) void suspend_wakeup_init_quantum(void) {
  */
 
 const char *get_numeric_str(char *buf, size_t buf_len, uint32_t curr_num, char curr_pad) {
-    buf[buf_len-1] = '\0';
-    for(size_t i = 0; i < buf_len-1; ++i) {
-        char c = '0' + curr_num % 10;
-        buf[buf_len-2-i] = (c == '0' && i == 0) ? '0' : (curr_num > 0 ? c : curr_pad);
+    buf[buf_len - 1] = '\0';
+    for (size_t i = 0; i < buf_len - 1; ++i) {
+        char c               = '0' + curr_num % 10;
+        buf[buf_len - 2 - i] = (c == '0' && i == 0) ? '0' : (curr_num > 0 ? c : curr_pad);
         curr_num /= 10;
     }
     return buf;
@@ -597,10 +598,12 @@ const char *get_numeric_str(char *buf, size_t buf_len, uint32_t curr_num, char c
  *       contents. Use the result immediately, instead of caching it.
  */
 const char *get_u8_str(uint8_t curr_num, char curr_pad) {
-    static char buf[4] = {0};
+    static char    buf[4]   = {0};
     static uint8_t last_num = 0xFF;
-    static char last_pad = '\0';
-    if (last_num == curr_num && last_pad == curr_pad) { return buf; }
+    static char    last_pad = '\0';
+    if (last_num == curr_num && last_pad == curr_pad) {
+        return buf;
+    }
     last_num = curr_num;
     last_pad = curr_pad;
     return get_numeric_str(buf, sizeof(buf), curr_num, curr_pad);
@@ -615,10 +618,12 @@ const char *get_u8_str(uint8_t curr_num, char curr_pad) {
  *       contents. Use the result immediately, instead of caching it.
  */
 const char *get_u16_str(uint16_t curr_num, char curr_pad) {
-    static char buf[6] = {0};
+    static char     buf[6]   = {0};
     static uint16_t last_num = 0xFF;
-    static char last_pad = '\0';
-    if (last_num == curr_num && last_pad == curr_pad) { return buf; }
+    static char     last_pad = '\0';
+    if (last_num == curr_num && last_pad == curr_pad) {
+        return buf;
+    }
     last_num = curr_num;
     last_pad = curr_pad;
     return get_numeric_str(buf, sizeof(buf), curr_num, curr_pad);

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -573,7 +573,6 @@ __attribute__((weak)) void suspend_wakeup_init_quantum(void) {
     suspend_wakeup_init_kb();
 
 // Useful string manipulation code
-
 const char *get_u8_str(uint8_t curr_num, char curr_pad) {
     static char    buf[4]   = {0};
     static uint8_t last_num = 0xFF;

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -575,33 +575,36 @@ __attribute__((weak)) void suspend_wakeup_init_quantum(void) {
 // Useful string manipulation code
 
 const char *get_u8_str(uint8_t curr_num, char curr_pad) {
-    static char buf[4] = {0};
+    static char    buf[4]   = {0};
     static uint8_t last_num = 0xFF;
-    static char last_pad = '\0';
-    if (last_num == curr_num && last_pad == curr_pad) { return buf; }
+    static char    last_pad = '\0';
+    if (last_num == curr_num && last_pad == curr_pad) {
+        return buf;
+    }
     last_num = curr_num;
     last_pad = curr_pad;
-    buf[3] = '\0';
-    buf[2] = '0' + curr_num % 10;
-    buf[1] = (curr_num /= 10) % 10 ? '0' + (curr_num) % 10 : (curr_num / 10) % 10 ? '0' : curr_pad;
-    buf[0] = curr_num / 10 ? '0' + curr_num / 10 : curr_pad;
+    buf[3]   = '\0';
+    buf[2]   = '0' + curr_num % 10;
+    buf[1]   = (curr_num /= 10) % 10 ? '0' + (curr_num) % 10 : (curr_num / 10) % 10 ? '0' : curr_pad;
+    buf[0]   = curr_num / 10 ? '0' + curr_num / 10 : curr_pad;
     return buf;
 }
 
-
 const char *get_u16_str(uint16_t curr_num, char curr_pad) {
-    static char buf[6] = {0};
+    static char     buf[6]   = {0};
     static uint16_t last_num = 0xFF;
-    static char last_pad = '\0';
-    if (last_num == curr_num && last_pad == curr_pad) { return buf; }
+    static char     last_pad = '\0';
+    if (last_num == curr_num && last_pad == curr_pad) {
+        return buf;
+    }
     last_num = curr_num;
     last_pad = curr_pad;
-    buf[5] = '\0';
-    buf[4] = '0' + curr_num % 10;
-    buf[3] = (curr_num /= 10) % 10 ? '0' + (curr_num) % 10 : (curr_num / 10) % 10 ? '0' : curr_pad;
-    buf[2] = (curr_num /= 10) % 10 ? '0' + (curr_num) % 10 : (curr_num / 10) % 10 ? '0' : curr_pad;
-    buf[1] = (curr_num /= 10) % 10 ? '0' + (curr_num) % 10 : (curr_num / 10) % 10 ? '0' : curr_pad;
-    buf[0] = curr_num / 10 ? '0' + curr_num / 10 : curr_pad;
+    buf[5]   = '\0';
+    buf[4]   = '0' + curr_num % 10;
+    buf[3]   = (curr_num /= 10) % 10 ? '0' + (curr_num) % 10 : (curr_num / 10) % 10 ? '0' : curr_pad;
+    buf[2]   = (curr_num /= 10) % 10 ? '0' + (curr_num) % 10 : (curr_num / 10) % 10 ? '0' : curr_pad;
+    buf[1]   = (curr_num /= 10) % 10 ? '0' + (curr_num) % 10 : (curr_num / 10) % 10 ? '0' : curr_pad;
+    buf[0]   = curr_num / 10 ? '0' + curr_num / 10 : curr_pad;
 
     return buf;
 }

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -571,4 +571,37 @@ __attribute__((weak)) void suspend_wakeup_init_quantum(void) {
     rgb_matrix_set_suspend_state(false);
 #endif
     suspend_wakeup_init_kb();
+
+// Useful string manipulation code
+
+const char *get_u8_str(uint8_t curr_num, char curr_pad) {
+    static char buf[4] = {0};
+    static uint8_t last_num = 0xFF;
+    static char last_pad = '\0';
+    if (last_num == curr_num && last_pad == curr_pad) { return buf; }
+    last_num = curr_num;
+    last_pad = curr_pad;
+    buf[3] = '\0';
+    buf[2] = '0' + curr_num % 10;
+    buf[1] = (curr_num /= 10) % 10 ? '0' + (curr_num) % 10 : (curr_num / 10) % 10 ? '0' : curr_pad;
+    buf[0] = curr_num / 10 ? '0' + curr_num / 10 : curr_pad;
+    return buf;
+}
+
+
+const char *get_u16_str(uint16_t curr_num, char curr_pad) {
+    static char buf[6] = {0};
+    static uint16_t last_num = 0xFF;
+    static char last_pad = '\0';
+    if (last_num == curr_num && last_pad == curr_pad) { return buf; }
+    last_num = curr_num;
+    last_pad = curr_pad;
+    buf[5] = '\0';
+    buf[4] = '0' + curr_num % 10;
+    buf[3] = (curr_num /= 10) % 10 ? '0' + (curr_num) % 10 : (curr_num / 10) % 10 ? '0' : curr_pad;
+    buf[2] = (curr_num /= 10) % 10 ? '0' + (curr_num) % 10 : (curr_num / 10) % 10 ? '0' : curr_pad;
+    buf[1] = (curr_num /= 10) % 10 ? '0' + (curr_num) % 10 : (curr_num / 10) % 10 ? '0' : curr_pad;
+    buf[0] = curr_num / 10 ? '0' + curr_num / 10 : curr_pad;
+
+    return buf;
 }

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -573,37 +573,32 @@ __attribute__((weak)) void suspend_wakeup_init_quantum(void) {
     suspend_wakeup_init_kb();
 
 // Useful string manipulation code
-const char *get_u8_str(uint8_t curr_num, char curr_pad) {
-    static char    buf[4]   = {0};
-    static uint8_t last_num = 0xFF;
-    static char    last_pad = '\0';
-    if (last_num == curr_num && last_pad == curr_pad) {
-        return buf;
+static const char *get_numeric_str(char *buf, size_t buf_len, uint32_t curr_num, char curr_pad) {
+    buf[buf_len-1] = '\0';
+    for(size_t i = 0; i < buf_len-1; ++i) {
+        char c = '0' + curr_num % 10;
+        buf[buf_len-2-i] = (c == '0' && i == 0) ? '0' : (curr_num > 0 ? c : curr_pad);
+        curr_num /= 10;
     }
-    last_num = curr_num;
-    last_pad = curr_pad;
-    buf[3]   = '\0';
-    buf[2]   = '0' + curr_num % 10;
-    buf[1]   = (curr_num /= 10) % 10 ? '0' + (curr_num) % 10 : (curr_num / 10) % 10 ? '0' : curr_pad;
-    buf[0]   = curr_num / 10 ? '0' + curr_num / 10 : curr_pad;
     return buf;
 }
 
-const char *get_u16_str(uint16_t curr_num, char curr_pad) {
-    static char     buf[6]   = {0};
-    static uint16_t last_num = 0xFF;
-    static char     last_pad = '\0';
-    if (last_num == curr_num && last_pad == curr_pad) {
-        return buf;
-    }
+const char *get_u8_str(uint16_t curr_num, char curr_pad) {
+    static char buf[4] = {0};
+    static uint8_t last_num = 0xFF;
+    static char last_pad = '\0';
+    if (last_num == curr_num && last_pad == curr_pad) { return buf; }
     last_num = curr_num;
     last_pad = curr_pad;
-    buf[5]   = '\0';
-    buf[4]   = '0' + curr_num % 10;
-    buf[3]   = (curr_num /= 10) % 10 ? '0' + (curr_num) % 10 : (curr_num / 10) % 10 ? '0' : curr_pad;
-    buf[2]   = (curr_num /= 10) % 10 ? '0' + (curr_num) % 10 : (curr_num / 10) % 10 ? '0' : curr_pad;
-    buf[1]   = (curr_num /= 10) % 10 ? '0' + (curr_num) % 10 : (curr_num / 10) % 10 ? '0' : curr_pad;
-    buf[0]   = curr_num / 10 ? '0' + curr_num / 10 : curr_pad;
+    return get_numeric_str(buf, sizeof(buf), curr_num, curr_pad);
+}
 
-    return buf;
+const char *get_u16_str(uint16_t curr_num, char curr_pad) {
+    static char buf[6] = {0};
+    static uint16_t last_num = 0xFF;
+    static char last_pad = '\0';
+    if (last_num == curr_num && last_pad == curr_pad) { return buf; }
+    last_num = curr_num;
+    last_pad = curr_pad;
+    return get_numeric_str(buf, sizeof(buf), curr_num, curr_pad);
 }

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -574,10 +574,8 @@ __attribute__((weak)) void suspend_wakeup_init_quantum(void) {
 
 /** \brief converts unsigned integers into char arrays
  *
- * Takes an unsigned integer, and uses a static conversion buffer to convert that value into a
- * char array
- * NOTE: Subsequent invocations will reuse the same static buffer and overwrite the previous
- *       contents. Use the result immediately, instead of caching it.
+ * Takes an unsigned integer and converts that value into an equivalent char array
+ * A padding character may be specified, ' ' for leading spaces, '0' for leading zeros.
  */
 
 const char *get_numeric_str(char *buf, size_t buf_len, uint32_t curr_num, char curr_pad) {
@@ -590,7 +588,15 @@ const char *get_numeric_str(char *buf, size_t buf_len, uint32_t curr_num, char c
     return buf;
 }
 
-const char *get_u8_str(uint16_t curr_num, char curr_pad) {
+/** \brief converts uint8_t into char array
+ *
+ * Takes an uint8_t, and uses an internal static buffer to render that value into a char array
+ * A padding character may be specified, ' ' for leading spaces, '0' for leading zeros.
+ *
+ * NOTE: Subsequent invocations will reuse the same static buffer and overwrite the previous
+ *       contents. Use the result immediately, instead of caching it.
+ */
+const char *get_u8_str(uint8_t curr_num, char curr_pad) {
     static char buf[4] = {0};
     static uint8_t last_num = 0xFF;
     static char last_pad = '\0';
@@ -600,6 +606,14 @@ const char *get_u8_str(uint16_t curr_num, char curr_pad) {
     return get_numeric_str(buf, sizeof(buf), curr_num, curr_pad);
 }
 
+/** \brief converts uint16_t into char array
+ *
+ * Takes an uint16_t, and uses an internal static buffer to render that value into a char array
+ * A padding character may be specified, ' ' for leading spaces, '0' for leading zeros.
+ *
+ * NOTE: Subsequent invocations will reuse the same static buffer and overwrite the previous
+ *       contents. Use the result immediately, instead of caching it.
+ */
 const char *get_u16_str(uint16_t curr_num, char curr_pad) {
     static char buf[6] = {0};
     static uint16_t last_num = 0xFF;

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -245,3 +245,6 @@ void led_set_user(uint8_t usb_led);
 void led_set_kb(uint8_t usb_led);
 bool led_update_user(led_t led_state);
 bool led_update_kb(led_t led_state);
+
+const char *get_u8_str(uint8_t curr_num, char curr_pad);
+const char *get_u16_str(uint16_t curr_num, char curr_pad);

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -246,5 +246,6 @@ void led_set_kb(uint8_t usb_led);
 bool led_update_user(led_t led_state);
 bool led_update_kb(led_t led_state);
 
+const char *get_numeric_str(char *buf, size_t buf_len, uint32_t curr_num, char curr_pad);
 const char *get_u8_str(uint8_t curr_num, char curr_pad);
 const char *get_u16_str(uint16_t curr_num, char curr_pad);


### PR DESCRIPTION
## Description

Adds functions to convert an unsigned int to a char array.  Useful for OLEDs and displays, especially on AVR, as things like sprintf take up ~1.5kB of firmware space. 

And instead of continually adding the same block of code, add a function into core to do this. 

## Types of Changes

- [x] Core
- [x] Enhancement/optimization
- [ ] Documentation


## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
