### PR TITLE
[CI] Ignore deleted files when formatting codebase

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -36,9 +36,10 @@ jobs:
     - name: Run qmk formatters
       shell: 'bash {0}'
       run: |
-        qmk format-c --core-only $(< ~/files.txt)
-        qmk format-python $(< ~/files.txt)
-        qmk format-text $(< ~/files.txt)
+        cat ~/files_added.txt ~/files_modified.txt > ~/files_changed.txt
+        qmk format-c --core-only $(< ~/files_changed.txt)
+        qmk format-python $(< ~/files_changed.txt)
+        qmk format-text $(< ~/files_changed.txt)
 
     - name: Fail when formatting required
       run: |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
PR Formatting workflows are sometimes hitting the following error,
```
Run qmk format-c --core-only $(< ~/files.txt)
  qmk format-c --core-only $(< ~/files.txt)
  qmk format-python $(< ~/files.txt)
  qmk format-text $(< ~/files.txt)
  shell: bash {0}
No such file or directory
☒ Error formatting C code!
```

From https://github.com/trilom/file-changes-action,
> The names all new, updated, and removed files

This PR changes the workflow to only include added+changed files.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
