### PR TITLE
Fix suspend issues on ergodox_ez.

### DIFF
--- a/keyboards/ergodox_ez/matrix.c
+++ b/keyboards/ergodox_ez/matrix.c
@@ -70,7 +70,7 @@ void matrix_init_custom(void) {
 // Reads and stores a row, returning
 // whether a change occurred.
 static inline bool store_raw_matrix_row(uint8_t index) {
-    matrix_row_t temp = read_cols(index);
+    matrix_row_t temp = 0x3F & read_cols(index);
     if (raw_matrix[index] != temp) {
         raw_matrix[index] = temp;
         return true;


### PR DESCRIPTION
Since read_cols() in ergodox_ez/matrix.c always returns numbers with two highest bits set,
and suspend_wakeup_condiiton() checks whether they are 0, ergodox_ez
wakes the system immediately after suspend. This very tiny PR fixes that.

Please note that while I have verified that the PR works and doesn't break anything to the extent of my knowledge, I do not know if it's the best place to put the bit mask. Well, at least it identifies the cause of the issue and fixes it *somehow*.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* possibly #15108 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
