### PR TITLE
keyhive sofle rgb: fix configuration.

### DIFF
--- a/keyboards/sofle/keyhive/config.h
+++ b/keyboards/sofle/keyhive/config.h
@@ -22,10 +22,10 @@
 // USB Device descriptor parameter
 
 #define VENDOR_ID    0xFC32
-#define PRODUCT_ID   0x1287
-#define DEVICE_VER   0x0002
+#define PRODUCT_ID   0x0287
+#define DEVICE_VER   0x0001
 #define MANUFACTURER Keyhive
-#define PRODUCT      Sofle  // VIA version for this PCB is incorrect for the bottom row
+#define PRODUCT      Sofle
 
 // Key matrix size
 // Rows are doubled-up. Added extra column for rotary encoder VIA mapping.

--- a/keyboards/sofle/keyhive/readme.md
+++ b/keyboards/sofle/keyhive/readme.md
@@ -45,18 +45,20 @@ Build guide: [Keyhive Sofle RGB build guide](https://github.com/keyhive/build_gu
 
 ## Using with VIA
 
--   After flashing, in VIA make sure to Import Keymap, which is "sofle VIA keymap.json". This will alow VIA to recognize the updated layout and custom functions. VIA will not auto-recognize the keyboard with this firmware because of the necessary customization.
--   Go to Save+Load to Load Saved Layout. You can import my own layout "sofle VIA layout.json" or just use the Keymap tab to assign your own keys. Having another keyboard connected can be handy for doing this step.
--   It is a good idea to Save Current Layout after you decide on your mapping.
-
-
 Make example for this keyboard (after setting up your build environment):
 
-    make sofle/keyhive:default
+    make sofle/keyhive:via
 
 Flashing example for this keyboard:
+```sh
+# for pro micro-based builds
+qmk flash -kb sofle/keyhive -km via -bl avrdude-split-left
+qmk flash -kb sofle/keyhive -km via -bl avrdude-split-right
 
-    make sofle/keyhive:default:flash
+# for Elite C or dfu bootloader builds
+qmk flash -kb sofle/keyhive -km via -bl dfu-split-left
+qmk flash -kb sofle/keyhive -km via -bl dfu-split-right
+```
 
 Press reset button on he keyboard when asked.
 


### PR DESCRIPTION

## Description

* Change PRODUCT_ID and DEVICE_VER to match sofle/rev1.
* Update readme.md to use qmk and via keymap.

Note: With this change, the keyhive PRODUCT_ID and DEVICE_VER match that of sofle/rev1. Strictly speaking, this is incorrect for a couple reasons (it's a different product, and the v1/v2 keyboards are slightly different). It is, however, what the keyhive fork does. It also corrects the via issues mentioned in the readme.

I'll probably look into updating via as well. If I do that, I'll create a follow-up PR here. Until then, I believe these changes are an improvement to the current sofle/keyhive support.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [X] Keymap/layout/userspace (addition or update)
- [X] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
