### PR TITLE
Meridian LED update

### DIFF
--- a/keyboards/primekb/meridian/ktr1010/config.h
+++ b/keyboards/primekb/meridian/ktr1010/config.h
@@ -1,0 +1,51 @@
+/*
+Copyright 2020 Holten Campbell
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+/* USB Device descriptor parameter */
+#define VENDOR_ID       0x5052
+#define PRODUCT_ID      0x004D
+#define DEVICE_VER      0x0001
+#define MANUFACTURER    Prime Keyboards
+#define PRODUCT         Meridian
+
+/* key matrix size */
+#define MATRIX_ROWS 5
+#define MATRIX_COLS 14
+
+#define MATRIX_COL_PINS { B11, B10, B2, B1, B0, A7, B9, B8, B7, B6, B5, B4, B3, A15 }
+#define MATRIX_ROW_PINS { A6, A5, A4, A3, A2 }
+#define DIODE_DIRECTION COL2ROW
+
+#define RGB_DI_PIN B15
+#define RGBLED_NUM 3
+// Special timing definitions for KTR101
+#define WS2812_TIMING 1200
+#define WS2812_T0H 300
+#define WS2812_T1H 900
+#define WS2812_T0L 900
+#define WS2812_T1L 300
+#define WS2812_RES_US 100
+
+/* Set 0 if debouncing isn't needed */
+#define DEBOUNCE    5
+
+/* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
+#define LOCKING_SUPPORT_ENABLE
+/* Locking resynchronize hack */
+#define LOCKING_RESYNC_ENABLE

--- a/keyboards/primekb/meridian/ktr1010/config.h
+++ b/keyboards/primekb/meridian/ktr1010/config.h
@@ -35,11 +35,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGB_DI_PIN B15
 #define RGBLED_NUM 3
 // Special timing definitions for KTR101
-#define WS2812_TIMING 1200
-#define WS2812_T0H 300
-#define WS2812_T1H 900
-#define WS2812_T0L 900
-#define WS2812_T1L 300
+#define WS2812_TIMING 1325
+#define WS2812_T0H 350
+#define WS2812_T1H 975
+#define WS2812_T0L 975
+#define WS2812_T1L 350
 #define WS2812_RES_US 100
 
 /* Set 0 if debouncing isn't needed */

--- a/keyboards/primekb/meridian/ktr1010/rules.mk
+++ b/keyboards/primekb/meridian/ktr1010/rules.mk
@@ -1,0 +1,1 @@
+WS2812_DRIVER = bitbang

--- a/keyboards/primekb/meridian/readme.md
+++ b/keyboards/primekb/meridian/readme.md
@@ -11,13 +11,13 @@
 
 The DFU state in the bootloader can be accessed in 3 ways:
 
-* **Bootmagic reset**: Hold down the key at (0,0) in the matrix (usually the top left key or Escape) and plug in the keyboard
+* **Bootmagic reset**: hold down the key at (0,0) in the matrix (usually Escape) and plug in the keyboard
 * **Physical reset button**: press the button on the front of the PCB
-* **Keycode in layout**: Press the key mapped to `RESET` if it is available (Escape key on layer 1 in the default layout)
+* **Keycode in layout**: press the key mapped to `RESET` if it is available (Escape key on layer 1 in the default layout).
 
 ### Compile firmware
 
-The Meridian PCB was delivered in two variants, equal in design but using different RGB LED models: one using WS2812 and another using KTR1010 LEDs. Both cam be compiled using
+The Meridian PCB was delivered in two variants, equal in design but using different RGB LED models: one using WS2812 and another using KTR1010 LEDs. Both can be compiled using
 
     make primekb/meridian/ws1812:default
     make primekb/meridian/ktr1010:default

--- a/keyboards/primekb/meridian/readme.md
+++ b/keyboards/primekb/meridian/readme.md
@@ -11,8 +11,8 @@
 
 The DFU state in the bootloader can be accessed in 3 ways:
 
-* **Bootmagic reset**: hold down the key at (0,0) in the matrix (usually Escape) and plug in the keyboard
-* **Physical reset button**: press the button on the front of the PCB
+* **Bootmagic reset**: hold down the key at (0,0) in the matrix (usually Escape) and plug in the keyboard; or
+* **Physical reset button**: press the button on the bottom of the PCB; or
 * **Keycode in layout**: press the key mapped to `RESET` if it is available (Escape key on layer 1 in the default layout).
 
 ### Compile firmware

--- a/keyboards/primekb/meridian/readme.md
+++ b/keyboards/primekb/meridian/readme.md
@@ -5,8 +5,28 @@
 * Keyboard Maintainer: [Holten Campbell](https://github.com/holtenc)
 * Hardware Supported: STM32F072CBT6
 
-Make example for this keyboard (after setting up your build environment):
+## Compiling firmware and flashing
 
-    make primekb/meridian:default
+### Enter bootloader
+
+The DFU state in the bootloader can be accessed in 3 ways:
+
+* **Bootmagic reset**: Hold down the key at (0,0) in the matrix (usually the top left key or Escape) and plug in the keyboard
+* **Physical reset button**: press the button on the front of the PCB
+* **Keycode in layout**: Press the key mapped to `RESET` if it is available (Escape key on layer 1 in the default layout)
+
+### Compile firmware
+
+The Meridian PCB was delivered in two variants, equal in design but using different RGB LED models: one using WS2812 and another using KTR1010 LEDs. Both cam be compiled using
+
+    make primekb/meridian/ws1812:default
+    make primekb/meridian/ktr1010:default
+
+After compiling, enter bootloader in the PCB and flash the firmware using `dfu-util` or QMK Toolbox. For direct compile-and-flashing, put the PCB in DFU state and use
+
+    make primekb/meridian/ws1812:default:flash
+    make primekb/meridian/ktr1010:default:flash
+
+VIA-supported firmwares are also available.
 
 See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).

--- a/keyboards/primekb/meridian/rules.mk
+++ b/keyboards/primekb/meridian/rules.mk
@@ -7,7 +7,7 @@ BOOTLOADER = stm32-dfu
 # Build Options
 #   change yes to no to disable
 #
-BOOTMAGIC_ENABLE = lite     # Enable Bootmagic Lite
+BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
 MOUSEKEY_ENABLE = yes       # Mouse keys
 EXTRAKEY_ENABLE = yes       # Audio control and System control
 CONSOLE_ENABLE = yes        # Console for debug
@@ -19,7 +19,6 @@ NKRO_ENABLE = yes           # USB Nkey Rollover
 BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = yes       # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
-WS2812_DRIVER = spi
 
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/primekb/meridian/rules.mk
+++ b/keyboards/primekb/meridian/rules.mk
@@ -7,7 +7,7 @@ BOOTLOADER = stm32-dfu
 # Build Options
 #   change yes to no to disable
 #
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
+BOOTMAGIC_ENABLE = lite     # Enable Bootmagic Lite
 MOUSEKEY_ENABLE = yes       # Mouse keys
 EXTRAKEY_ENABLE = yes       # Audio control and System control
 CONSOLE_ENABLE = yes        # Console for debug

--- a/keyboards/primekb/meridian/ws2812/config.h
+++ b/keyboards/primekb/meridian/ws2812/config.h
@@ -1,0 +1,48 @@
+/*
+Copyright 2020 Holten Campbell
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+/* USB Device descriptor parameter */
+#define VENDOR_ID       0x5052
+#define PRODUCT_ID      0x004D
+#define DEVICE_VER      0x0001
+#define MANUFACTURER    Prime Keyboards
+#define PRODUCT         Meridian
+
+/* key matrix size */
+#define MATRIX_ROWS 5
+#define MATRIX_COLS 14
+
+#define MATRIX_COL_PINS { B11, B10, B2, B1, B0, A7, B9, B8, B7, B6, B5, B4, B3, A15 }
+#define MATRIX_ROW_PINS { A6, A5, A4, A3, A2 }
+#define DIODE_DIRECTION COL2ROW
+
+#define RGB_DI_PIN B15
+#define RGBLED_NUM 3
+#define WS2812_SPI SPID2
+#define WS2812_SPI_MOSI_PAL_MODE 0
+#define WS2812_SPI_SCK_PAL_MODE 0
+#define WS2812_SPI_SCK_PIN B13
+
+/* Set 0 if debouncing isn't needed */
+#define DEBOUNCE    5
+
+/* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
+#define LOCKING_SUPPORT_ENABLE
+/* Locking resynchronize hack */
+#define LOCKING_RESYNC_ENABLE

--- a/keyboards/primekb/meridian/ws2812/rules.mk
+++ b/keyboards/primekb/meridian/ws2812/rules.mk
@@ -1,0 +1,1 @@
+WS2812_DRIVER = spi


### PR DESCRIPTION
The Meridian PCB suffered a logistics/communication issue and some units were shipped with KTR1010 LEDs which are wildly out of timing when compared to the default WS2812 LEDs. In this regard, this firmware update makes use of the recent "ajustable timing parameters" recently merged into master from these PRs:

https://github.com/qmk/qmk_firmware/pull/14678
https://github.com/qmk/qmk_firmware/pull/15298
https://github.com/qmk/qmk_firmware/pull/15299

The updated firmware has two options, `ws2812` and `ktr1010` which compiling and flashing are explained in the readme.

Firmware-wise the difference between these options is that while the `ws2812` option uses the common SPI driver with default timings, the `ktr1010` options uses the bit-banged driver with the adjusted timing parameters. The PCB suffers no noticeable problems stemming from the bit-bang usage since it has only three RGB LEDs used for indicators.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

Not exactly fixed or closed but this PR fulfills the initial intent of the PR lineage mentioned in the description: officially supporting the Meridian KTR1010 PCBs.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
