### PR TITLE
Fix 'format-c --core-only' matching keyboard level folders

### DIFF
--- a/lib/python/qmk/cli/format/c.py
+++ b/lib/python/qmk/cli/format/c.py
@@ -74,7 +74,7 @@ def filter_files(files, core_only=False):
             # The following statement checks each file to see if the file path is
             # - in the core directories
             # - not in the ignored directories
-            if not any(i in str(file) for i in core_dirs) or any(i in str(file) for i in ignored):
+            if not any(str(file).startswith(i) for i in core_dirs) or any(str(file).startswith(i) for i in ignored):
                 files[index] = None
                 cli.log.debug("Skipping non-core file %s, as '--core-only' is used.", file)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Found during the recent develop merge, <https://github.com/qmk/qmk_firmware/runs/4342852367?check_suite_focus=true>

Was incorrectly finding `drivers` within `keyboards/helix/local_drivers/i2c.h`

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
