### PR TITLE
Fix bit loss in cie_lightness() when doing division to resolve #15331

### DIFF
--- a/quantum/backlight/backlight_avr.c
+++ b/quantum/backlight/backlight_avr.c
@@ -238,7 +238,7 @@ static uint16_t cie_lightness(uint16_t v) {
     } else {
         // In the next two lines values are bit-shifted. This is to avoid loosing decimals in integer math.
         uint32_t y   = (((uint32_t)v + (uint32_t)ICRx / 6) << 5) / ((uint32_t)ICRx / 6 + ICRx);  // If above 8%, add ~16% of max, and normalize with (max + ~16% max)
-        uint32_t out = (y * y * y * ICRx) >> 15;                             // Cube it and undo the bit-shifting. (which is now three times as much due to the cubing)
+        uint32_t out = (y * y * y * ICRx) >> 15;                                                 // Cube it and undo the bit-shifting. (which is now three times as much due to the cubing)
 
         if (out > ICRx)  // Avoid overflows
         {

--- a/quantum/backlight/backlight_avr.c
+++ b/quantum/backlight/backlight_avr.c
@@ -232,12 +232,12 @@ ISR(TIMERx_OVF_vect) {
 
 // See http://jared.geek.nz/2013/feb/linear-led-pwm
 static uint16_t cie_lightness(uint16_t v) {
-    if (v <= (unsigned long)ICRx / 12)  // If the value is less than or equal to ~8% of max
+    if (v <= (uint32_t)ICRx / 12)  // If the value is less than or equal to ~8% of max
     {
         return v / 9;  // Same as dividing by 900%
     } else {
         // In the next two lines values are bit-shifted. This is to avoid loosing decimals in integer math.
-        uint32_t y   = (((uint32_t)v + (unsigned long)ICRx / 6) << 5) / ((unsigned long)ICRx / 6 + ICRx);  // If above 8%, add ~16% of max, and normalize with (max + ~16% max)
+        uint32_t y   = (((uint32_t)v + (uint32_t)ICRx / 6) << 5) / ((uint32_t)ICRx / 6 + ICRx);  // If above 8%, add ~16% of max, and normalize with (max + ~16% max)
         uint32_t out = (y * y * y * ICRx) >> 15;                             // Cube it and undo the bit-shifting. (which is now three times as much due to the cubing)
 
         if (out > ICRx)  // Avoid overflows

--- a/quantum/backlight/backlight_avr.c
+++ b/quantum/backlight/backlight_avr.c
@@ -232,19 +232,19 @@ ISR(TIMERx_OVF_vect) {
 
 // See http://jared.geek.nz/2013/feb/linear-led-pwm
 static uint16_t cie_lightness(uint16_t v) {
-    if (v <= ICRx / 12)  // If the value is less than or equal to ~8% of max
+    if (v <= (unsigned long)ICRx / 12)  // If the value is less than or equal to ~8% of max
     {
         return v / 9;  // Same as dividing by 900%
     } else {
         // In the next two lines values are bit-shifted. This is to avoid loosing decimals in integer math.
-        uint32_t y   = (((uint32_t)v + ICRx / 6) << 5) / (ICRx / 6 + ICRx);  // If above 8%, add ~16% of max, and normalize with (max + ~16% max)
+        uint32_t y   = (((uint32_t)v + (unsigned long)ICRx / 6) << 5) / ((unsigned long)ICRx / 6 + ICRx);  // If above 8%, add ~16% of max, and normalize with (max + ~16% max)
         uint32_t out = (y * y * y * ICRx) >> 15;                             // Cube it and undo the bit-shifting. (which is now three times as much due to the cubing)
 
         if (out > ICRx)  // Avoid overflows
         {
             out = ICRx;
         }
-        return out;
+        return (uint16_t)out;
     }
 }
 


### PR DESCRIPTION
## Description

Bit loss during division breaks static backlight levels.

@Duckle29 since you authored the PR that made these changes can you confirm this doesn't break what you were trying to accomplish?

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #15331

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
